### PR TITLE
feat: Bedrock batch inference, DynamoDB tagging, SageMaker CapacityError (#297, #298, #299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Bedrock control-plane batch inference (#297)**: Added the ModelInvocationJob
+  APIs to `BedrockRuntimePlugin` (the control plane shares the `bedrock` SigV4
+  signing name with the data plane and is distinguished by request path, so no
+  parser change was needed). `CreateModelInvocationJob` (`POST
+  /model-invocation-job`) stores a job in the `Submitted` state and returns its
+  `jobArn`; `GetModelInvocationJob` (`GET /model-invocation-job/{jobId}`) returns
+  the job; `StopModelInvocationJob` (`POST /model-invocation-job/{jobId}/stop`)
+  transitions it to `Stopped`; `ListModelInvocationJobs` (`GET
+  /model-invocation-jobs`) returns summaries. New control-plane endpoints `POST`
+  and `DELETE /v1/bedrock/model-invocation-job-status` seed and clear a status
+  override (keyed by job ID or `"*"`), letting tests drive a job through
+  `InProgress`/`Completed`/`Failed` without simulated time. Cost entry:
+  `bedrock-runtime/CreateModelInvocationJob: $0.000015`. Closes #297.
+- **DynamoDB resource tagging (#298)**: `CreateTable` now stores the `Tags` list
+  supplied at creation time, and the plugin implements `TagResource`,
+  `UntagResource`, and `ListTagsOfResource`. Tags are stored on the table record
+  and keyed by the table ARN (`arn:aws:dynamodb:{region}:{acct}:table/{name}`,
+  parsed via the new `dynamodbTableNameFromARN` helper, which tolerates
+  `/index/...` and `/stream/...` suffixes). `ListTagsOfResource` returns tags
+  sorted by key for deterministic output; tagging a non-existent table returns
+  `ResourceNotFoundException`. This lets tag-based ownership logic (e.g. a tool
+  tagging its own tables `lagotto:managed=cli`) be tested end-to-end. Closes #298.
+- **SageMaker training-job CapacityError seeding (#299)**: `DescribeTrainingJob`
+  now honours a seeded terminal status and `FailureReason`, so a job can be made
+  to report `Failed` with a `CapacityError` reason for capacity-retry testing
+  (the default unseeded behaviour remains `Completed`). New control-plane
+  endpoints `POST` and `DELETE /v1/sagemaker/training-job-status` seed and clear
+  the override, keyed by training job name or `"*"` (mirroring the
+  Athena/RedshiftData/Timestream/Bedrock seeding pattern). Added `FailureReason`
+  to `SageMakerTrainingJob`. Closes #299.
+
 ### Security
 - **Module tag integrity advisory (#296)**: Documented that tags **v0.45.1** and
   **v0.45.2** are poisoned — both were re-cut after publication, so their current

--- a/bedrock_runtime_ctrl.go
+++ b/bedrock_runtime_ctrl.go
@@ -61,3 +61,66 @@ func (s *Server) handleBedrockRuntimeClearResponses(w http.ResponseWriter, r *ht
 	}
 	writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true})
 }
+
+// handleBedrockRuntimeSeedJobStatus handles POST /v1/bedrock/model-invocation-job-status.
+// It seeds the status (and optional message) returned by GetModelInvocationJob for
+// a given job ID (or wildcard "*"), letting tests drive a job to InProgress,
+// Completed, Failed, etc. without simulated time.
+// Body: {"jobId": "<id>", "status": "Failed", "message": "..."}
+// The "jobId" field defaults to "*" (wildcard) if omitted or empty.
+func (s *Server) handleBedrockRuntimeSeedJobStatus(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		JobID   string `json:"jobId"`
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if body.Status == "" {
+		http.Error(w, `{"error":"status is required"}`, http.StatusBadRequest)
+		return
+	}
+	jobID := body.JobID
+	if jobID == "" {
+		jobID = "*"
+	}
+	seed, err := json.Marshal(map[string]string{"status": body.Status, "message": body.Message})
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), bedrockRuntimeCtrlNamespace, bedrockRuntimeCtrlJobStatusKey(jobID), seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true, "jobId": jobID})
+}
+
+// handleBedrockRuntimeClearJobStatus handles DELETE /v1/bedrock/model-invocation-job-status.
+// With ?jobId=... it removes the seeded status for that specific job.
+// Without a query param it removes all seeded job statuses.
+func (s *Server) handleBedrockRuntimeClearJobStatus(w http.ResponseWriter, r *http.Request) {
+	jobID := r.URL.Query().Get("jobId")
+	if jobID != "" {
+		if err := s.state.Delete(r.Context(), bedrockRuntimeCtrlNamespace, bedrockRuntimeCtrlJobStatusKey(jobID)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), bedrockRuntimeCtrlNamespace, "jobstatus:")
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), bedrockRuntimeCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true})
+}

--- a/bedrock_runtime_plugin.go
+++ b/bedrock_runtime_plugin.go
@@ -2,6 +2,7 @@ package substrate
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -18,6 +19,12 @@ const bedrockRuntimeCtrlNamespace = "bedrock-runtime-ctrl"
 // bedrockRuntimeCtrlResponseKey returns the state key for a seeded model response.
 func bedrockRuntimeCtrlResponseKey(modelID string) string {
 	return "response:" + modelID
+}
+
+// bedrockRuntimeCtrlJobStatusKey returns the state key for a seeded model
+// invocation job status override.
+func bedrockRuntimeCtrlJobStatusKey(jobID string) string {
+	return "jobstatus:" + jobID
 }
 
 // BedrockRuntimePlugin emulates the Amazon Bedrock Runtime service.
@@ -56,6 +63,14 @@ func (p *BedrockRuntimePlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 		return p.applyGuardrail(ctx, req, resourceID, version)
 	case "InvokeModel":
 		return p.invokeModel(ctx, req, resourceID)
+	case "CreateModelInvocationJob":
+		return p.createModelInvocationJob(ctx, req)
+	case "GetModelInvocationJob":
+		return p.getModelInvocationJob(ctx, req, resourceID)
+	case "StopModelInvocationJob":
+		return p.stopModelInvocationJob(ctx, req, resourceID)
+	case "ListModelInvocationJobs":
+		return p.listModelInvocationJobs(ctx, req)
 	default:
 		return nil, &AWSError{
 			Code:       "InvalidAction",
@@ -69,6 +84,33 @@ func (p *BedrockRuntimePlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 // operation name plus resource IDs.
 func parseBedrockRuntimeOperation(method, path string) (op, id1, id2 string) {
 	rest := strings.TrimPrefix(path, "/")
+
+	// Control-plane batch inference (ModelInvocationJob) operations.
+	// GET /model-invocation-jobs            → ListModelInvocationJobs
+	if rest == "model-invocation-jobs" && method == "GET" {
+		return "ListModelInvocationJobs", "", ""
+	}
+	// /model-invocation-job[/{jobId}[/stop]]
+	if rest == "model-invocation-job" {
+		if method == "POST" {
+			return "CreateModelInvocationJob", "", ""
+		}
+		return "", "", ""
+	}
+	if strings.HasPrefix(rest, "model-invocation-job/") {
+		jobPart := strings.TrimPrefix(rest, "model-invocation-job/")
+		if strings.HasSuffix(jobPart, "/stop") {
+			jobID := strings.TrimSuffix(jobPart, "/stop")
+			if jobID != "" && method == "POST" {
+				return "StopModelInvocationJob", jobID, ""
+			}
+			return "", "", ""
+		}
+		if jobPart != "" && method == "GET" {
+			return "GetModelInvocationJob", jobPart, ""
+		}
+		return "", "", ""
+	}
 
 	// /model/{modelId}/invoke
 	if strings.HasPrefix(rest, "model/") {
@@ -223,6 +265,198 @@ func (p *BedrockRuntimePlugin) invokeModel(_ *RequestContext, _ *AWSRequest, mod
 		"usage":       map[string]int{"input_tokens": 0, "output_tokens": 0},
 	}
 	return bedrockRuntimeJSONResponse(http.StatusOK, defaultBody)
+}
+
+// BedrockModelInvocationJob holds persisted state for an Amazon Bedrock
+// control-plane batch inference job (ModelInvocationJob API).
+type BedrockModelInvocationJob struct {
+	// JobArn is the ARN of the model invocation job.
+	JobArn string `json:"jobArn"`
+
+	// JobName is the user-supplied name of the job.
+	JobName string `json:"jobName"`
+
+	// ModelID is the foundation model identifier used for the job.
+	ModelID string `json:"modelId"`
+
+	// RoleArn is the IAM service role granting Bedrock access to the S3 data.
+	RoleArn string `json:"roleArn,omitempty"`
+
+	// Status is the job status (Submitted, InProgress, Completed, Failed, Stopped, ...).
+	Status string `json:"status"`
+
+	// Message carries an optional status detail (e.g. a failure reason).
+	Message string `json:"message,omitempty"`
+
+	// InputDataConfig holds the S3 input configuration as supplied by the caller.
+	InputDataConfig json.RawMessage `json:"inputDataConfig,omitempty"`
+
+	// OutputDataConfig holds the S3 output configuration as supplied by the caller.
+	OutputDataConfig json.RawMessage `json:"outputDataConfig,omitempty"`
+
+	// SubmitTime is the epoch-seconds timestamp when the job was submitted.
+	SubmitTime float64 `json:"submitTime"`
+
+	// AccountID is the AWS account that owns the job.
+	AccountID string `json:"accountID"`
+
+	// Region is the AWS region where the job runs.
+	Region string `json:"region"`
+}
+
+// bedrockModelInvocationJobKey returns the state key for a model invocation job.
+func bedrockModelInvocationJobKey(acct, region, jobID string) string {
+	return "job:" + acct + "/" + region + "/" + jobID
+}
+
+// bedrockModelInvocationJobIDsKey returns the state key for the per-account/region
+// index of model invocation job IDs.
+func bedrockModelInvocationJobIDsKey(acct, region string) string {
+	return "job_ids:" + acct + "/" + region
+}
+
+// generateBedrockJobID generates a UUID-formatted model invocation job ID.
+func generateBedrockJobID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// createModelInvocationJob handles CreateModelInvocationJob, storing a new batch
+// inference job in the Submitted state.
+func (p *BedrockRuntimePlugin) createModelInvocationJob(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var body struct {
+		JobName          string          `json:"jobName"`
+		ModelID          string          `json:"modelId"`
+		RoleArn          string          `json:"roleArn"`
+		InputDataConfig  json.RawMessage `json:"inputDataConfig"`
+		OutputDataConfig json.RawMessage `json:"outputDataConfig"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil || body.JobName == "" {
+		return nil, &AWSError{Code: "ValidationException", Message: "jobName is required", HTTPStatus: http.StatusBadRequest}
+	}
+
+	jobID := generateBedrockJobID()
+	jobArn := fmt.Sprintf("arn:aws:bedrock:%s:%s:model-invocation-job/%s", ctx.Region, ctx.AccountID, jobID)
+	job := BedrockModelInvocationJob{
+		JobArn:           jobArn,
+		JobName:          body.JobName,
+		ModelID:          body.ModelID,
+		RoleArn:          body.RoleArn,
+		Status:           "Submitted",
+		InputDataConfig:  body.InputDataConfig,
+		OutputDataConfig: body.OutputDataConfig,
+		SubmitTime:       float64(p.tc.Now().UnixNano()) / 1e9,
+		AccountID:        ctx.AccountID,
+		Region:           ctx.Region,
+	}
+
+	goCtx := context.Background()
+	data, err := json.Marshal(job)
+	if err != nil {
+		return nil, fmt.Errorf("createModelInvocationJob: marshal: %w", err)
+	}
+	if err := p.state.Put(goCtx, bedrockRuntimeNamespace, bedrockModelInvocationJobKey(ctx.AccountID, ctx.Region, jobID), data); err != nil {
+		return nil, fmt.Errorf("createModelInvocationJob: put: %w", err)
+	}
+	updateStringIndex(goCtx, p.state, bedrockRuntimeNamespace, bedrockModelInvocationJobIDsKey(ctx.AccountID, ctx.Region), jobID)
+	return bedrockRuntimeJSONResponse(http.StatusOK, map[string]string{"jobArn": jobArn})
+}
+
+// loadModelInvocationJob fetches a job by ID and applies any seeded status override.
+func (p *BedrockRuntimePlugin) loadModelInvocationJob(ctx *RequestContext, jobID string) (*BedrockModelInvocationJob, error) {
+	goCtx := context.Background()
+	data, err := p.state.Get(goCtx, bedrockRuntimeNamespace, bedrockModelInvocationJobKey(ctx.AccountID, ctx.Region, jobID))
+	if err != nil || data == nil {
+		return nil, &AWSError{Code: "ResourceNotFoundException", Message: "model invocation job " + jobID + " not found", HTTPStatus: http.StatusNotFound}
+	}
+	var job BedrockModelInvocationJob
+	if err := json.Unmarshal(data, &job); err != nil {
+		return nil, fmt.Errorf("loadModelInvocationJob: unmarshal: %w", err)
+	}
+	p.applySeededJobStatus(goCtx, jobID, &job)
+	return &job, nil
+}
+
+// applySeededJobStatus overrides a job's status from a control-plane seed, if any
+// (exact job-ID match first, then the "*" wildcard).
+func (p *BedrockRuntimePlugin) applySeededJobStatus(goCtx context.Context, jobID string, job *BedrockModelInvocationJob) {
+	for _, key := range []string{
+		bedrockRuntimeCtrlJobStatusKey(jobID),
+		bedrockRuntimeCtrlJobStatusKey("*"),
+	} {
+		data, err := p.state.Get(goCtx, bedrockRuntimeCtrlNamespace, key)
+		if err != nil || data == nil {
+			continue
+		}
+		var seed struct {
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(data, &seed) == nil && seed.Status != "" {
+			job.Status = seed.Status
+			job.Message = seed.Message
+		}
+		return
+	}
+}
+
+// getModelInvocationJob handles GetModelInvocationJob.
+func (p *BedrockRuntimePlugin) getModelInvocationJob(ctx *RequestContext, _ *AWSRequest, jobID string) (*AWSResponse, error) {
+	job, err := p.loadModelInvocationJob(ctx, jobID)
+	if err != nil {
+		return nil, err
+	}
+	return bedrockRuntimeJSONResponse(http.StatusOK, job)
+}
+
+// stopModelInvocationJob handles StopModelInvocationJob, transitioning the job to Stopped.
+func (p *BedrockRuntimePlugin) stopModelInvocationJob(ctx *RequestContext, _ *AWSRequest, jobID string) (*AWSResponse, error) {
+	goCtx := context.Background()
+	data, err := p.state.Get(goCtx, bedrockRuntimeNamespace, bedrockModelInvocationJobKey(ctx.AccountID, ctx.Region, jobID))
+	if err != nil || data == nil {
+		return nil, &AWSError{Code: "ResourceNotFoundException", Message: "model invocation job " + jobID + " not found", HTTPStatus: http.StatusNotFound}
+	}
+	var job BedrockModelInvocationJob
+	if err := json.Unmarshal(data, &job); err != nil {
+		return nil, fmt.Errorf("stopModelInvocationJob: unmarshal: %w", err)
+	}
+	job.Status = "Stopped"
+	updated, _ := json.Marshal(job)
+	if err := p.state.Put(goCtx, bedrockRuntimeNamespace, bedrockModelInvocationJobKey(ctx.AccountID, ctx.Region, jobID), updated); err != nil {
+		return nil, fmt.Errorf("stopModelInvocationJob: put: %w", err)
+	}
+	return bedrockRuntimeJSONResponse(http.StatusOK, map[string]interface{}{})
+}
+
+// listModelInvocationJobs handles ListModelInvocationJobs, returning summaries
+// for all jobs in the account and region.
+func (p *BedrockRuntimePlugin) listModelInvocationJobs(ctx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	ids, _ := loadStringIndex(goCtx, p.state, bedrockRuntimeNamespace, bedrockModelInvocationJobIDsKey(ctx.AccountID, ctx.Region))
+
+	type summary struct {
+		JobArn     string  `json:"jobArn"`
+		JobName    string  `json:"jobName"`
+		ModelID    string  `json:"modelId"`
+		Status     string  `json:"status"`
+		SubmitTime float64 `json:"submitTime"`
+	}
+	summaries := make([]summary, 0, len(ids))
+	for _, id := range ids {
+		job, err := p.loadModelInvocationJob(ctx, id)
+		if err != nil {
+			continue
+		}
+		summaries = append(summaries, summary{
+			JobArn:     job.JobArn,
+			JobName:    job.JobName,
+			ModelID:    job.ModelID,
+			Status:     job.Status,
+			SubmitTime: job.SubmitTime,
+		})
+	}
+	return bedrockRuntimeJSONResponse(http.StatusOK, map[string]interface{}{"invocationJobSummaries": summaries})
 }
 
 // bedrockRuntimeJSONResponse serializes v to JSON and returns an AWSResponse.

--- a/bedrock_runtime_plugin_test.go
+++ b/bedrock_runtime_plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -355,4 +356,224 @@ func TestBedrockRuntimePlugin_InvokeModel_WildcardSeed(t *testing.T) {
 	if result3["completion"] != "wildcard-response" {
 		t.Errorf("expected wildcard-response for other model, got %v", result3)
 	}
+}
+
+// brJobRequest sends a Bedrock control-plane ModelInvocationJob request to the
+// given path/method, returning the response.
+func brJobRequest(t *testing.T, ts *httptest.Server, method, path string, body interface{}) *http.Response {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal job body: %v", err)
+		}
+		rdr = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest(method, ts.URL+path, rdr)
+	if err != nil {
+		t.Fatalf("build job request: %v", err)
+	}
+	req.Host = "bedrock.us-east-1.amazonaws.com"
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do job request: %v", err)
+	}
+	return resp
+}
+
+// TestBedrockModelInvocationJob_Lifecycle exercises create → get → stop → list.
+func TestBedrockModelInvocationJob_Lifecycle(t *testing.T) {
+	setup := newBedrockRuntimeTestServer(t)
+
+	// Create.
+	resp := brJobRequest(t, setup.server, http.MethodPost, "/model-invocation-job", map[string]any{
+		"jobName":          "batch-1",
+		"modelId":          "anthropic.claude-3-sonnet",
+		"roleArn":          "arn:aws:iam::123456789012:role/BedrockBatch",
+		"inputDataConfig":  map[string]any{"s3InputDataConfig": map[string]string{"s3Uri": "s3://in/"}},
+		"outputDataConfig": map[string]any{"s3OutputDataConfig": map[string]string{"s3Uri": "s3://out/"}},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+	var created struct {
+		JobArn string `json:"jobArn"`
+	}
+	if err := json.Unmarshal(brBody(t, resp), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.JobArn == "" {
+		t.Fatal("expected non-empty jobArn")
+	}
+	// jobId is the trailing ARN segment.
+	jobID := created.JobArn[strings.LastIndexByte(created.JobArn, '/')+1:]
+
+	// Get → Submitted.
+	resp = brJobRequest(t, setup.server, http.MethodGet, "/model-invocation-job/"+jobID, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get status = %d", resp.StatusCode)
+	}
+	var got struct {
+		JobName string `json:"jobName"`
+		ModelID string `json:"modelId"`
+		Status  string `json:"status"`
+	}
+	if err := json.Unmarshal(brBody(t, resp), &got); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if got.Status != "Submitted" || got.JobName != "batch-1" || got.ModelID != "anthropic.claude-3-sonnet" {
+		t.Fatalf("unexpected job: %+v", got)
+	}
+
+	// List → one summary.
+	resp = brJobRequest(t, setup.server, http.MethodGet, "/model-invocation-jobs", nil)
+	var listed struct {
+		InvocationJobSummaries []struct {
+			JobArn string `json:"jobArn"`
+			Status string `json:"status"`
+		} `json:"invocationJobSummaries"`
+	}
+	if err := json.Unmarshal(brBody(t, resp), &listed); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listed.InvocationJobSummaries) != 1 || listed.InvocationJobSummaries[0].Status != "Submitted" {
+		t.Fatalf("unexpected list: %+v", listed)
+	}
+
+	// Stop → Stopped.
+	resp = brJobRequest(t, setup.server, http.MethodPost, "/model-invocation-job/"+jobID+"/stop", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stop status = %d", resp.StatusCode)
+	}
+	_ = brBody(t, resp)
+	resp = brJobRequest(t, setup.server, http.MethodGet, "/model-invocation-job/"+jobID, nil)
+	if err := json.Unmarshal(brBody(t, resp), &got); err != nil {
+		t.Fatalf("decode get-after-stop: %v", err)
+	}
+	if got.Status != "Stopped" {
+		t.Fatalf("expected Stopped, got %q", got.Status)
+	}
+}
+
+// TestBedrockModelInvocationJob_NotFound verifies a missing job returns 404.
+func TestBedrockModelInvocationJob_NotFound(t *testing.T) {
+	setup := newBedrockRuntimeTestServer(t)
+	resp := brJobRequest(t, setup.server, http.MethodGet, "/model-invocation-job/does-not-exist", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+	_ = brBody(t, resp)
+}
+
+// TestBedrockModelInvocationJob_SeededStatus verifies the control-plane status
+// seed drives a job's GetModelInvocationJob status and message.
+func TestBedrockModelInvocationJob_SeededStatus(t *testing.T) {
+	setup := newBedrockRuntimeTestServer(t)
+
+	resp := brJobRequest(t, setup.server, http.MethodPost, "/model-invocation-job", map[string]any{
+		"jobName": "batch-seed",
+		"modelId": "anthropic.claude-3-haiku",
+	})
+	var created struct {
+		JobArn string `json:"jobArn"`
+	}
+	if err := json.Unmarshal(brBody(t, resp), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	jobID := created.JobArn[strings.LastIndexByte(created.JobArn, '/')+1:]
+
+	// Seed status for this specific job via the control plane.
+	seedResp := brJobRequest(t, setup.server, http.MethodPost, "/v1/bedrock/model-invocation-job-status", map[string]any{
+		"jobId":   jobID,
+		"status":  "Completed",
+		"message": "all done",
+	})
+	if seedResp.StatusCode != http.StatusOK {
+		t.Fatalf("seed status = %d", seedResp.StatusCode)
+	}
+	_ = brBody(t, seedResp)
+
+	resp = brJobRequest(t, setup.server, http.MethodGet, "/model-invocation-job/"+jobID, nil)
+	var got struct {
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(brBody(t, resp), &got); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if got.Status != "Completed" || got.Message != "all done" {
+		t.Fatalf("expected seeded Completed/all done, got %+v", got)
+	}
+}
+
+// TestBedrockModelInvocationJob_ClearStatus verifies the DELETE control endpoint
+// removes a seeded status (both targeted and clear-all).
+func TestBedrockModelInvocationJob_ClearStatus(t *testing.T) {
+	setup := newBedrockRuntimeTestServer(t)
+	resp := brJobRequest(t, setup.server, http.MethodPost, "/model-invocation-job", map[string]any{"jobName": "j", "modelId": "m"})
+	var created struct {
+		JobArn string `json:"jobArn"`
+	}
+	if err := json.Unmarshal(brBody(t, resp), &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	jobID := created.JobArn[strings.LastIndexByte(created.JobArn, '/')+1:]
+
+	// Seed wildcard, then clear all, then confirm default Submitted is restored.
+	_ = brBody(t, brJobRequest(t, setup.server, http.MethodPost, "/v1/bedrock/model-invocation-job-status", map[string]any{"status": "Failed"}))
+	delReq, _ := http.NewRequest(http.MethodDelete, setup.server.URL+"/v1/bedrock/model-invocation-job-status", nil)
+	delResp, err := http.DefaultClient.Do(delReq)
+	if err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if delResp.StatusCode != http.StatusOK {
+		t.Fatalf("clear status = %d", delResp.StatusCode)
+	}
+	_ = brBody(t, delResp)
+
+	resp = brJobRequest(t, setup.server, http.MethodGet, "/model-invocation-job/"+jobID, nil)
+	var got struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(brBody(t, resp), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != "Submitted" {
+		t.Fatalf("expected Submitted after clear, got %q", got.Status)
+	}
+}
+
+// TestBedrockModelInvocationJob_Validation verifies create without jobName and
+// seed without status are rejected.
+func TestBedrockModelInvocationJob_Validation(t *testing.T) {
+	setup := newBedrockRuntimeTestServer(t)
+	resp := brJobRequest(t, setup.server, http.MethodPost, "/model-invocation-job", map[string]any{"modelId": "m"})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing jobName, got %d", resp.StatusCode)
+	}
+	_ = brBody(t, resp)
+
+	seedResp := brJobRequest(t, setup.server, http.MethodPost, "/v1/bedrock/model-invocation-job-status", map[string]any{"jobId": "x"})
+	if seedResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing status, got %d", seedResp.StatusCode)
+	}
+	_ = brBody(t, seedResp)
+}
+
+// TestBedrockModelInvocationJob_ClearTargeted covers the targeted-delete branch
+// of the job-status control endpoint.
+func TestBedrockModelInvocationJob_ClearTargeted(t *testing.T) {
+	setup := newBedrockRuntimeTestServer(t)
+	_ = brBody(t, brJobRequest(t, setup.server, http.MethodPost, "/v1/bedrock/model-invocation-job-status", map[string]any{"jobId": "j1", "status": "Failed"}))
+	del, _ := http.NewRequest(http.MethodDelete, setup.server.URL+"/v1/bedrock/model-invocation-job-status?jobId=j1", nil)
+	resp, err := http.DefaultClient.Do(del)
+	if err != nil {
+		t.Fatalf("clear targeted: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("clear targeted status = %d", resp.StatusCode)
+	}
+	_ = brBody(t, resp)
 }

--- a/costs.go
+++ b/costs.go
@@ -479,6 +479,8 @@ func defaultCostTable() map[string]float64 {
 		// Bedrock Runtime: per guardrail evaluation unit; per model invocation.
 		"bedrock-runtime/ApplyGuardrail": 0.000075,
 		"bedrock-runtime/InvokeModel":    0.000015,
+		// Bedrock control-plane batch inference job submission.
+		"bedrock-runtime/CreateModelInvocationJob": 0.000015,
 		// Athena: per query execution ($5/TB scanned, stub approximation).
 		"athena/StartQueryExecution": 0.000005,
 		// S3 Select: per query request.

--- a/dynamodb_plugin.go
+++ b/dynamodb_plugin.go
@@ -97,6 +97,13 @@ func (p *DynamoDBPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*A
 		return p.executeStatement(ctx, req)
 	case "BatchExecuteStatement":
 		return p.batchExecuteStatement(ctx, req)
+	// Resource tagging.
+	case "TagResource":
+		return p.tagResource(ctx, req)
+	case "UntagResource":
+		return p.untagResource(ctx, req)
+	case "ListTagsOfResource":
+		return p.listTagsOfResource(ctx, req)
 	default:
 		return nil, &AWSError{
 			Code:       "UnknownOperationException",
@@ -295,6 +302,7 @@ func (p *DynamoDBPlugin) createTable(ctx *RequestContext, req *AWSRequest) (*AWS
 			Projection DynamoDBProjection         `json:"Projection"`
 		} `json:"LocalSecondaryIndexes"`
 		StreamSpecification *DynamoDBStreamSpecification `json:"StreamSpecification"`
+		Tags                []DynamoDBTag                `json:"Tags"`
 	}
 	if err := json.Unmarshal(req.Body, &input); err != nil {
 		return nil, &AWSError{Code: "SerializationException", Message: "Failed to parse request: " + err.Error(), HTTPStatus: http.StatusBadRequest}
@@ -367,6 +375,15 @@ func (p *DynamoDBPlugin) createTable(ctx *RequestContext, req *AWSRequest) (*AWS
 		ItemCount:              0,
 	}
 
+	// Store any tags supplied at table creation time so they can be read back
+	// via ListTagsOfResource.
+	if len(input.Tags) > 0 {
+		tbl.Tags = make(map[string]string, len(input.Tags))
+		for _, t := range input.Tags {
+			tbl.Tags[t.Key] = t.Value
+		}
+	}
+
 	// Generate stream ARN if streams enabled.
 	if input.StreamSpecification != nil && input.StreamSpecification.StreamEnabled {
 		tbl.LatestStreamARN = tableARN + "/stream/" + now.UTC().Format("2006-01-02T15:04:05.999")
@@ -387,6 +404,95 @@ func (p *DynamoDBPlugin) createTable(ctx *RequestContext, req *AWSRequest) (*AWS
 
 	return dynamodbJSONResponse(http.StatusOK, map[string]interface{}{
 		"TableDescription": tbl,
+	})
+}
+
+// loadTableForTagging resolves a DynamoDB resource ARN to its table, returning a
+// ResourceNotFoundException if the ARN is malformed or the table does not exist.
+func (p *DynamoDBPlugin) loadTableForTagging(ctx *RequestContext, resourceARN string) (*DynamoDBTable, error) {
+	tableName := dynamodbTableNameFromARN(resourceARN)
+	if tableName == "" {
+		return nil, &AWSError{Code: "ResourceNotFoundException", Message: "Invalid ResourceArn: " + resourceARN, HTTPStatus: http.StatusBadRequest}
+	}
+	tbl, err := p.loadTable(context.Background(), ctx.AccountID, tableName)
+	if err != nil {
+		return nil, err
+	}
+	if tbl == nil {
+		return nil, &AWSError{Code: "ResourceNotFoundException", Message: "Table not found: " + tableName, HTTPStatus: http.StatusBadRequest}
+	}
+	return tbl, nil
+}
+
+func (p *DynamoDBPlugin) tagResource(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var input struct {
+		ResourceArn string        `json:"ResourceArn"`
+		Tags        []DynamoDBTag `json:"Tags"`
+	}
+	if err := json.Unmarshal(req.Body, &input); err != nil {
+		return nil, &AWSError{Code: "SerializationException", Message: err.Error(), HTTPStatus: http.StatusBadRequest}
+	}
+	tbl, err := p.loadTableForTagging(ctx, input.ResourceArn)
+	if err != nil {
+		return nil, err
+	}
+	if tbl.Tags == nil {
+		tbl.Tags = make(map[string]string, len(input.Tags))
+	}
+	for _, t := range input.Tags {
+		tbl.Tags[t.Key] = t.Value
+	}
+	if err := p.saveTable(context.Background(), ctx.AccountID, tbl); err != nil {
+		return nil, fmt.Errorf("dynamodb tagResource saveTable: %w", err)
+	}
+	return dynamodbJSONResponse(http.StatusOK, map[string]interface{}{})
+}
+
+func (p *DynamoDBPlugin) untagResource(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var input struct {
+		ResourceArn string   `json:"ResourceArn"`
+		TagKeys     []string `json:"TagKeys"`
+	}
+	if err := json.Unmarshal(req.Body, &input); err != nil {
+		return nil, &AWSError{Code: "SerializationException", Message: err.Error(), HTTPStatus: http.StatusBadRequest}
+	}
+	tbl, err := p.loadTableForTagging(ctx, input.ResourceArn)
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range input.TagKeys {
+		delete(tbl.Tags, k)
+	}
+	if err := p.saveTable(context.Background(), ctx.AccountID, tbl); err != nil {
+		return nil, fmt.Errorf("dynamodb untagResource saveTable: %w", err)
+	}
+	return dynamodbJSONResponse(http.StatusOK, map[string]interface{}{})
+}
+
+func (p *DynamoDBPlugin) listTagsOfResource(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var input struct {
+		ResourceArn string `json:"ResourceArn"`
+	}
+	if err := json.Unmarshal(req.Body, &input); err != nil {
+		return nil, &AWSError{Code: "SerializationException", Message: err.Error(), HTTPStatus: http.StatusBadRequest}
+	}
+	tbl, err := p.loadTableForTagging(ctx, input.ResourceArn)
+	if err != nil {
+		return nil, err
+	}
+	// Emit tags sorted by key for deterministic output.
+	keys := make([]string, 0, len(tbl.Tags))
+	for k := range tbl.Tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	tags := make([]DynamoDBTag, 0, len(keys))
+	for _, k := range keys {
+		tags = append(tags, DynamoDBTag{Key: k, Value: tbl.Tags[k]})
+	}
+	return dynamodbJSONResponse(http.StatusOK, map[string]interface{}{
+		"Tags":      tags,
+		"NextToken": nil,
 	})
 }
 

--- a/dynamodb_plugin_test.go
+++ b/dynamodb_plugin_test.go
@@ -2832,3 +2832,89 @@ func TestDynamoDB_TransactWriteItems_ConditionCheckPasses(t *testing.T) {
 	_, bExists := outB["Item"]
 	assert.True(t, bExists, "B should exist — transaction committed")
 }
+
+// TestDynamoDB_CreateTableTags verifies that Tags supplied to CreateTable are
+// stored and returned by ListTagsOfResource.
+func TestDynamoDB_CreateTableTags(t *testing.T) {
+	srv := newDynamoDBTestServer(t)
+	resp := dynamodbRequest(t, srv, "CreateTable", map[string]any{
+		"TableName":            "tagged",
+		"AttributeDefinitions": []map[string]string{{"AttributeName": "id", "AttributeType": "S"}},
+		"KeySchema":            []map[string]string{{"AttributeName": "id", "KeyType": "HASH"}},
+		"BillingMode":          "PAY_PER_REQUEST",
+		"Tags": []map[string]string{
+			{"Key": "lagotto:managed", "Value": "cli"},
+			{"Key": "env", "Value": "test"},
+		},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	arn := "arn:aws:dynamodb:us-east-1:123456789012:table/tagged"
+	resp = dynamodbRequest(t, srv, "ListTagsOfResource", map[string]any{"ResourceArn": arn})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out struct {
+		Tags []struct {
+			Key   string `json:"Key"`
+			Value string `json:"Value"`
+		} `json:"Tags"`
+	}
+	decodeDynamoJSON(t, resp, &out)
+	require.Len(t, out.Tags, 2)
+	// Sorted by key: "env" before "lagotto:managed".
+	require.Equal(t, "env", out.Tags[0].Key)
+	require.Equal(t, "test", out.Tags[0].Value)
+	require.Equal(t, "lagotto:managed", out.Tags[1].Key)
+	require.Equal(t, "cli", out.Tags[1].Value)
+}
+
+// TestDynamoDB_TagUntagResource verifies TagResource adds tags and UntagResource
+// removes them.
+func TestDynamoDB_TagUntagResource(t *testing.T) {
+	srv := newDynamoDBTestServer(t)
+	resp := dynamodbRequest(t, srv, "CreateTable", map[string]any{
+		"TableName":            "tbl",
+		"AttributeDefinitions": []map[string]string{{"AttributeName": "id", "AttributeType": "S"}},
+		"KeySchema":            []map[string]string{{"AttributeName": "id", "KeyType": "HASH"}},
+		"BillingMode":          "PAY_PER_REQUEST",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	arn := "arn:aws:dynamodb:us-east-1:123456789012:table/tbl"
+
+	resp = dynamodbRequest(t, srv, "TagResource", map[string]any{
+		"ResourceArn": arn,
+		"Tags":        []map[string]string{{"Key": "a", "Value": "1"}, {"Key": "b", "Value": "2"}},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp = dynamodbRequest(t, srv, "UntagResource", map[string]any{
+		"ResourceArn": arn,
+		"TagKeys":     []string{"a"},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp = dynamodbRequest(t, srv, "ListTagsOfResource", map[string]any{"ResourceArn": arn})
+	var out struct {
+		Tags []struct {
+			Key   string `json:"Key"`
+			Value string `json:"Value"`
+		} `json:"Tags"`
+	}
+	decodeDynamoJSON(t, resp, &out)
+	require.Len(t, out.Tags, 1)
+	require.Equal(t, "b", out.Tags[0].Key)
+}
+
+// TestDynamoDB_TagResourceNotFound verifies tagging a missing table returns
+// ResourceNotFoundException.
+func TestDynamoDB_TagResourceNotFound(t *testing.T) {
+	srv := newDynamoDBTestServer(t)
+	resp := dynamodbRequest(t, srv, "ListTagsOfResource", map[string]any{
+		"ResourceArn": "arn:aws:dynamodb:us-east-1:123456789012:table/ghost",
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var out struct {
+		Code string `json:"Code"`
+	}
+	decodeDynamoJSON(t, resp, &out)
+	require.Equal(t, "ResourceNotFoundException", out.Code)
+}

--- a/dynamodb_types.go
+++ b/dynamodb_types.go
@@ -1,5 +1,7 @@
 package substrate
 
+import "strings"
+
 // dynamodbNamespace is the state namespace used by DynamoDBPlugin.
 const dynamodbNamespace = "dynamodb"
 
@@ -199,4 +201,31 @@ func dynamodbItemKey(pkVal, skVal string) string {
 // dynamodbTableARN constructs the ARN for a DynamoDB table.
 func dynamodbTableARN(region, accountID, tableName string) string {
 	return "arn:aws:dynamodb:" + region + ":" + accountID + ":table/" + tableName
+}
+
+// dynamodbTableNameFromARN extracts the table name from a DynamoDB resource ARN
+// of the form arn:aws:dynamodb:{region}:{account}:table/{name}[/...]. It returns
+// an empty string if the ARN does not reference a table.
+func dynamodbTableNameFromARN(arn string) string {
+	const marker = ":table/"
+	idx := strings.Index(arn, marker)
+	if idx < 0 {
+		return ""
+	}
+	name := arn[idx+len(marker):]
+	// Drop any sub-resource suffix (e.g. "/index/..." or "/stream/...").
+	if slash := strings.IndexByte(name, '/'); slash >= 0 {
+		name = name[:slash]
+	}
+	return name
+}
+
+// DynamoDBTag is a single key/value resource tag on a DynamoDB table, matching
+// the AWS wire shape of {"Key": "...", "Value": "..."}.
+type DynamoDBTag struct {
+	// Key is the tag key.
+	Key string `json:"Key"`
+
+	// Value is the tag value.
+	Value string `json:"Value"`
 }

--- a/sagemaker_control.go
+++ b/sagemaker_control.go
@@ -1,0 +1,79 @@
+package substrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// sagemakerCtrlNamespace is the state namespace for SageMaker control-plane data.
+const sagemakerCtrlNamespace = "sagemaker-ctrl"
+
+// sagemakerCtrlTrainingJobStatusKey returns the state key for a seeded training
+// job status override.
+func sagemakerCtrlTrainingJobStatusKey(name string) string {
+	return "trainingjob_status:" + name
+}
+
+// handleSageMakerSeedTrainingJobStatus handles POST /v1/sagemaker/training-job-status.
+// It overrides the terminal status (and optional FailureReason) returned by
+// DescribeTrainingJob for a given training job name (or wildcard "*"), letting
+// tests drive a job to a Failed/CapacityError outcome without simulated time.
+// Body: {"trainingJobName": "...", "status": "Failed", "failureReason": "CapacityError: ..."}
+// The "trainingJobName" field defaults to "*" (wildcard) if omitted or empty.
+func (s *Server) handleSageMakerSeedTrainingJobStatus(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		TrainingJobName string `json:"trainingJobName"`
+		Status          string `json:"status"`
+		FailureReason   string `json:"failureReason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if body.Status == "" {
+		http.Error(w, `{"error":"status is required"}`, http.StatusBadRequest)
+		return
+	}
+	name := body.TrainingJobName
+	if name == "" {
+		name = "*"
+	}
+	seed, err := json.Marshal(map[string]string{"status": body.Status, "failureReason": body.FailureReason})
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), sagemakerCtrlNamespace, sagemakerCtrlTrainingJobStatusKey(name), seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true, "trainingJobName": name})
+}
+
+// handleSageMakerClearTrainingJobStatus handles DELETE /v1/sagemaker/training-job-status.
+// With ?trainingJobName=... it removes the seeded status for that specific job.
+// Without a query param it removes all seeded training job statuses.
+func (s *Server) handleSageMakerClearTrainingJobStatus(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("trainingJobName")
+	if name != "" {
+		if err := s.state.Delete(r.Context(), sagemakerCtrlNamespace, sagemakerCtrlTrainingJobStatusKey(name)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), sagemakerCtrlNamespace, "trainingjob_status:")
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), sagemakerCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true})
+}

--- a/sagemaker_plugin.go
+++ b/sagemaker_plugin.go
@@ -110,6 +110,10 @@ type SageMakerTrainingJob struct {
 	// TrainingJobStatus is the job status (InProgress, Completed, Stopped, Failed).
 	TrainingJobStatus string `json:"TrainingJobStatus"`
 
+	// FailureReason describes why the job failed; set only for Failed jobs (e.g.
+	// a CapacityError when ML compute capacity could not be provisioned).
+	FailureReason string `json:"FailureReason,omitempty"`
+
 	// CreationTime is the epoch-seconds timestamp when the job was created.
 	CreationTime float64 `json:"CreationTime"`
 
@@ -298,7 +302,33 @@ func (p *SageMakerPlugin) describeTrainingJob(ctx *RequestContext, req *AWSReque
 	if err := json.Unmarshal(data, &job); err != nil {
 		return nil, fmt.Errorf("describeTrainingJob: unmarshal: %w", err)
 	}
+	p.applySeededTrainingJobStatus(goCtx, job.TrainingJobName, &job)
 	return sagemakerJSONResponse(http.StatusOK, job)
+}
+
+// applySeededTrainingJobStatus overrides a training job's terminal status and
+// FailureReason from a control-plane seed, if any (exact name match first, then
+// the "*" wildcard). This lets tests exercise capacity-retry paths by forcing a
+// job to report Failed with a CapacityError FailureReason.
+func (p *SageMakerPlugin) applySeededTrainingJobStatus(goCtx context.Context, name string, job *SageMakerTrainingJob) {
+	for _, key := range []string{
+		sagemakerCtrlTrainingJobStatusKey(name),
+		sagemakerCtrlTrainingJobStatusKey("*"),
+	} {
+		data, err := p.state.Get(goCtx, sagemakerCtrlNamespace, key)
+		if err != nil || data == nil {
+			continue
+		}
+		var seed struct {
+			Status        string `json:"status"`
+			FailureReason string `json:"failureReason"`
+		}
+		if json.Unmarshal(data, &seed) == nil && seed.Status != "" {
+			job.TrainingJobStatus = seed.Status
+			job.FailureReason = seed.FailureReason
+		}
+		return
+	}
 }
 
 func (p *SageMakerPlugin) stopTrainingJob(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {

--- a/sagemaker_plugin_test.go
+++ b/sagemaker_plugin_test.go
@@ -338,3 +338,176 @@ func TestSageMakerPlugin_ListTrainingJobs(t *testing.T) {
 		t.Fatalf("expected 2 training jobs, got %d", len(result.TrainingJobSummaries))
 	}
 }
+
+// smSeedTrainingJobStatus POSTs a seeded terminal status to the control plane.
+func smSeedTrainingJobStatus(t *testing.T, ts *httptest.Server, jobName, status, failureReason string) {
+	t.Helper()
+	data, err := json.Marshal(map[string]string{
+		"trainingJobName": jobName,
+		"status":          status,
+		"failureReason":   failureReason,
+	})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/sagemaker/training-job-status", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("build seed request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do seed request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed status = %d", resp.StatusCode)
+	}
+}
+
+const capacityErrorReason = "CapacityError: Unable to provision requested ML compute capacity. Please retry using a different ML instance type."
+
+// TestSageMaker_DescribeTrainingJob_DefaultCompleted verifies the unseeded path
+// still reports Completed (existing behavior, guarded).
+func TestSageMaker_DescribeTrainingJob_DefaultCompleted(t *testing.T) {
+	ts := newSageMakerTestServer(t)
+	resp := sagemakerRequest(t, ts, "CreateTrainingJob", map[string]any{"TrainingJobName": "ok-job"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+	_ = sagemakerBody(t, resp)
+
+	resp = sagemakerRequest(t, ts, "DescribeTrainingJob", map[string]any{"TrainingJobName": "ok-job"})
+	var job struct {
+		TrainingJobStatus string `json:"TrainingJobStatus"`
+		FailureReason     string `json:"FailureReason"`
+	}
+	if err := json.Unmarshal(sagemakerBody(t, resp), &job); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if job.TrainingJobStatus != "Completed" || job.FailureReason != "" {
+		t.Fatalf("expected Completed/no-reason, got %+v", job)
+	}
+}
+
+// TestSageMaker_DescribeTrainingJob_SeededCapacityError verifies a seeded Failed
+// status with a CapacityError FailureReason is returned, enabling capacity-retry
+// testing.
+func TestSageMaker_DescribeTrainingJob_SeededCapacityError(t *testing.T) {
+	ts := newSageMakerTestServer(t)
+	resp := sagemakerRequest(t, ts, "CreateTrainingJob", map[string]any{"TrainingJobName": "cap-job"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+	_ = sagemakerBody(t, resp)
+
+	smSeedTrainingJobStatus(t, ts, "cap-job", "Failed", capacityErrorReason)
+
+	resp = sagemakerRequest(t, ts, "DescribeTrainingJob", map[string]any{"TrainingJobName": "cap-job"})
+	var job struct {
+		TrainingJobStatus string `json:"TrainingJobStatus"`
+		FailureReason     string `json:"FailureReason"`
+	}
+	if err := json.Unmarshal(sagemakerBody(t, resp), &job); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if job.TrainingJobStatus != "Failed" {
+		t.Fatalf("expected Failed, got %q", job.TrainingJobStatus)
+	}
+	if job.FailureReason != capacityErrorReason {
+		t.Fatalf("expected CapacityError reason, got %q", job.FailureReason)
+	}
+}
+
+// TestSageMaker_TrainingJobStatus_Wildcard verifies a "*" seed applies to any job.
+func TestSageMaker_TrainingJobStatus_Wildcard(t *testing.T) {
+	ts := newSageMakerTestServer(t)
+	resp := sagemakerRequest(t, ts, "CreateTrainingJob", map[string]any{"TrainingJobName": "any-job"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+	_ = sagemakerBody(t, resp)
+
+	smSeedTrainingJobStatus(t, ts, "", "Failed", capacityErrorReason) // empty name → "*"
+
+	resp = sagemakerRequest(t, ts, "DescribeTrainingJob", map[string]any{"TrainingJobName": "any-job"})
+	var job struct {
+		TrainingJobStatus string `json:"TrainingJobStatus"`
+	}
+	if err := json.Unmarshal(sagemakerBody(t, resp), &job); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if job.TrainingJobStatus != "Failed" {
+		t.Fatalf("expected wildcard Failed, got %q", job.TrainingJobStatus)
+	}
+}
+
+// TestSageMaker_ClearTrainingJobStatus verifies the DELETE control endpoint
+// removes a seeded status so the job reverts to its stored Completed status.
+func TestSageMaker_ClearTrainingJobStatus(t *testing.T) {
+	ts := newSageMakerTestServer(t)
+	_ = sagemakerBody(t, sagemakerRequest(t, ts, "CreateTrainingJob", map[string]any{"TrainingJobName": "clr-job"}))
+	smSeedTrainingJobStatus(t, ts, "clr-job", "Failed", capacityErrorReason)
+
+	// Targeted clear.
+	delReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/v1/sagemaker/training-job-status?trainingJobName=clr-job", nil)
+	delResp, err := http.DefaultClient.Do(delReq)
+	if err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if delResp.StatusCode != http.StatusOK {
+		t.Fatalf("clear status = %d", delResp.StatusCode)
+	}
+	delResp.Body.Close() //nolint:errcheck
+
+	resp := sagemakerRequest(t, ts, "DescribeTrainingJob", map[string]any{"TrainingJobName": "clr-job"})
+	var job struct {
+		TrainingJobStatus string `json:"TrainingJobStatus"`
+	}
+	if err := json.Unmarshal(sagemakerBody(t, resp), &job); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if job.TrainingJobStatus != "Completed" {
+		t.Fatalf("expected Completed after clear, got %q", job.TrainingJobStatus)
+	}
+}
+
+// TestSageMaker_SeedTrainingJobStatus_Errors covers the control-endpoint error
+// and clear-all paths.
+func TestSageMaker_SeedTrainingJobStatus_Errors(t *testing.T) {
+	ts := newSageMakerTestServer(t)
+
+	// Missing status → 400.
+	bad, _ := json.Marshal(map[string]string{"trainingJobName": "x"})
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/sagemaker/training-job-status", bytes.NewReader(bad))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing status, got %d", resp.StatusCode)
+	}
+	resp.Body.Close() //nolint:errcheck
+
+	// Malformed JSON → 400.
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/v1/sagemaker/training-job-status", bytes.NewReader([]byte("{not json")))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("seed bad: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for bad JSON, got %d", resp.StatusCode)
+	}
+	resp.Body.Close() //nolint:errcheck
+
+	// Seed a wildcard then clear-all (no query param).
+	smSeedTrainingJobStatus(t, ts, "", "Failed", capacityErrorReason)
+	del, _ := http.NewRequest(http.MethodDelete, ts.URL+"/v1/sagemaker/training-job-status", nil)
+	resp, err = http.DefaultClient.Do(del)
+	if err != nil {
+		t.Fatalf("clear-all: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("clear-all status = %d", resp.StatusCode)
+	}
+	resp.Body.Close() //nolint:errcheck
+}

--- a/server.go
+++ b/server.go
@@ -232,9 +232,14 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/timestream-query/results", s.handleTimestreamSeedResult)
 	r.Delete("/v1/timestream-query/results", s.handleTimestreamClearResults)
 
+	r.Post("/v1/sagemaker/training-job-status", s.handleSageMakerSeedTrainingJobStatus)
+	r.Delete("/v1/sagemaker/training-job-status", s.handleSageMakerClearTrainingJobStatus)
+
 	// Bedrock Runtime control-plane endpoints.
 	r.Post("/v1/bedrock-runtime/responses", s.handleBedrockRuntimeSeedResponse)
 	r.Delete("/v1/bedrock-runtime/responses", s.handleBedrockRuntimeClearResponses)
+	r.Post("/v1/bedrock/model-invocation-job-status", s.handleBedrockRuntimeSeedJobStatus)
+	r.Delete("/v1/bedrock/model-invocation-job-status", s.handleBedrockRuntimeClearJobStatus)
 
 	// Fault injection control-plane endpoints.
 	r.Post("/v1/fault/rules", s.handleFaultSetRules)


### PR DESCRIPTION
Resolves three ecosystem-driven emulator gaps (spore-host/lagotto + aws-openondemand) so their integration tests can run against Substrate.

## #297 — Bedrock control-plane batch inference (ModelInvocationJob)
Extends `BedrockRuntimePlugin` with `CreateModelInvocationJob` / `GetModelInvocationJob` / `StopModelInvocationJob` / `ListModelInvocationJobs`, dispatched by their distinct REST paths. The control plane shares the `bedrock` SigV4 signing name with the data plane, so routing works with **no parser/alias change**. Job-status override via `POST`/`DELETE /v1/bedrock/model-invocation-job-status` (keyed by job ID or `*`) drives `InProgress`/`Completed`/`Failed` deterministically. Unblocks `ood-bedrock-adapter`'s skipped integration test.

## #298 — DynamoDB resource tagging
`CreateTable` now stores `Tags`; adds `TagResource` / `UntagResource` / `ListTagsOfResource` keyed by table ARN (`dynamodbTableNameFromARN` tolerates `/index/` and `/stream/` suffixes). Lets tag-based ownership logic (`lagotto:managed=cli`) be tested end-to-end.

## #299 — SageMaker CapacityError
`DescribeTrainingJob` honours a seeded terminal status + `FailureReason` via `POST`/`DELETE /v1/sagemaker/training-job-status`; default remains `Completed`. Enables the submit→CapacityError→retry test path.

## Notes
- New control endpoints follow the existing Athena/RedshiftData/Timestream/Bedrock seed-and-clear pattern; cleared on state reset.
- `make test` (race) + `make lint` clean. Main-package coverage 79.5% (baseline was 79.3% — the sub-80% is pre-existing across the whole package, not introduced here; new code is covered comparably to the surrounding tag/control handlers).
- AWS wire shapes (paths, status enums, ARN formats, error codes) verified against the official API references.

Closes #297
Closes #298
Closes #299