### PR TITLE
feat: complete VPC route tables (#293), advance CFN drift detection (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CloudFormation drift detection — MODIFIED + describe operations (#290)**:
+  `DetectStackDrift` now reports `MODIFIED` (in addition to `IN_SYNC`/`DELETED`/
+  `NOT_CHECKED`) via a new `cfnDriftComparators` map that performs property-level
+  comparison of live state against the template (re-parsed and intrinsic/param-
+  resolved at drift-check time). The S3 `VersioningConfiguration` comparator is
+  implemented end-to-end (deploy a bucket with versioning, change it outside
+  CloudFormation, and drift reports `MODIFIED` with a `PropertyDifferences`
+  entry). Property-level drift is bounded by what each plugin persists, so the
+  other drift-checkable types (DynamoDB/SQS/SNS/Lambda/IAM) remain existence-only
+  for now; the comparator map makes adding more types straightforward. Added
+  `StackDeployer.DescribeStackResourceDrifts(stackName, statusFilters)` (returns
+  per-resource entries, optionally filtered by drift status) and
+  `StartStackDriftDetection` / `DescribeStackDriftDetectionStatus` (the
+  `DETECTION_IN_PROGRESS → DETECTION_COMPLETE` lifecycle, with the in-progress
+  record persisted before synchronous detection runs). New types
+  `CFNPropertyDiff` and `CFNDriftDetectionStatus`; `CFNResourceDriftEntry` gained
+  `PropertyDifferences`. Partially addresses #290 (property-level `MODIFIED`
+  remains existence-only for non-S3-versioning resource types; #290 stays open).
+- **VPC route table completion (#293)**: Added `ReplaceRoute` (repoints an
+  existing route's target; returns `InvalidRoute.NotFound` for an unknown
+  destination) and `ReplaceRouteTableAssociation` (repoints a subnet association
+  to a different route table, returning a fresh `newAssociationId`; returns
+  `InvalidAssociationID.NotFound` for an unknown association). `DescribeRouteTables`
+  now honours the `vpc-id`, `association.subnet-id`, and `association.route-table-id`
+  filters (via the existing `extractEC2Filters` helper), not just `RouteTableId`.
+  `ensureDefaultVPC` now creates and attaches a default internet gateway and adds
+  a `0.0.0.0/0 → igw-…` route to the default VPC's main route table (previously
+  only the local route was present, despite the code comment). Closes #293.
+
 ### Security
 - **Module tag integrity advisory (#296)**: Documented that tags **v0.45.1** and
   **v0.45.2** are poisoned — both were re-cut after publication, so their current

--- a/betty_cfn.go
+++ b/betty_cfn.go
@@ -162,8 +162,52 @@ type CFNResourceDriftEntry struct {
 	// PhysicalID is the actual resource identifier.
 	PhysicalID string `json:"PhysicalResourceId"`
 
-	// DriftStatus is "IN_SYNC", "DELETED", or "NOT_CHECKED".
+	// DriftStatus is "IN_SYNC", "MODIFIED", "DELETED", or "NOT_CHECKED".
 	DriftStatus string `json:"StackResourceDriftStatus"`
+
+	// PropertyDifferences lists per-property differences when DriftStatus is
+	// "MODIFIED". It is empty for all other statuses.
+	PropertyDifferences []CFNPropertyDiff `json:"PropertyDifferences,omitempty"`
+}
+
+// CFNPropertyDiff describes a single property-level difference between the
+// expected (template) and actual (live) value of a drifted resource.
+type CFNPropertyDiff struct {
+	// PropertyPath is the JSON-path-like path to the differing property.
+	PropertyPath string `json:"PropertyPath"`
+
+	// ExpectedValue is the value defined by the template.
+	ExpectedValue string `json:"ExpectedValue"`
+
+	// ActualValue is the value found in live service state.
+	ActualValue string `json:"ActualValue"`
+
+	// DifferenceType is "ADD", "REMOVE", or "NOT_EQUAL".
+	DifferenceType string `json:"DifferenceType"`
+}
+
+// CFNDriftDetectionStatus holds the status of an asynchronous drift-detection
+// operation started by [StackDeployer.StartStackDriftDetection].
+type CFNDriftDetectionStatus struct {
+	// StackDriftDetectionID is the ID returned by StartStackDriftDetection.
+	StackDriftDetectionID string `json:"StackDriftDetectionId"`
+
+	// StackName identifies the stack the detection ran against.
+	StackName string `json:"StackId"`
+
+	// DetectionStatus is "DETECTION_IN_PROGRESS", "DETECTION_COMPLETE", or
+	// "DETECTION_FAILED".
+	DetectionStatus string `json:"DetectionStatus"`
+
+	// StackDriftStatus is "DRIFTED", "IN_SYNC", or "NOT_CHECKED" once detection
+	// completes.
+	StackDriftStatus string `json:"StackDriftStatus"`
+
+	// DriftedStackResourceCount is the number of drifted resources.
+	DriftedStackResourceCount int `json:"DriftedStackResourceCount"`
+
+	// Timestamp is when the detection record was last updated.
+	Timestamp time.Time `json:"Timestamp"`
 }
 
 // typePriority determines deployment order for CloudFormation resources.
@@ -684,11 +728,21 @@ func (d *StackDeployer) DetectStackDrift(ctx context.Context, stackName string) 
 		checker, ok := cfnDriftCheckers[dr.Type]
 		if ok {
 			exists := checker(d, ctx, testAccountID, defaultRegion, dr.PhysicalID)
-			if exists {
-				entry.DriftStatus = "IN_SYNC"
-			} else {
+			switch {
+			case !exists:
 				entry.DriftStatus = "DELETED"
 				result.DriftedCount++
+			default:
+				entry.DriftStatus = "IN_SYNC"
+				// For resource types with a property comparator, check whether
+				// the live resource has drifted from its template definition.
+				if cmp, hasCmp := cfnDriftComparators[dr.Type]; hasCmp {
+					if diffs := cmp(ctx, d, &stack, dr); len(diffs) > 0 {
+						entry.DriftStatus = "MODIFIED"
+						entry.PropertyDifferences = diffs
+						result.DriftedCount++
+					}
+				}
 			}
 		}
 
@@ -700,6 +754,105 @@ func (d *StackDeployer) DetectStackDrift(ctx context.Context, stackName string) 
 	}
 
 	return result, nil
+}
+
+// DescribeStackResourceDrifts returns the per-resource drift entries for a
+// stack, optionally filtered to the given drift statuses (e.g. {"MODIFIED"}).
+// An empty statusFilters returns all entries. Drift is recomputed on each call.
+func (d *StackDeployer) DescribeStackResourceDrifts(ctx context.Context, stackName string, statusFilters []string) ([]CFNResourceDriftEntry, error) {
+	result, err := d.DetectStackDrift(ctx, stackName)
+	if err != nil {
+		return nil, err
+	}
+	if len(statusFilters) == 0 {
+		return result.ResourceDrifts, nil
+	}
+	filtered := make([]CFNResourceDriftEntry, 0, len(result.ResourceDrifts))
+	for _, e := range result.ResourceDrifts {
+		for _, s := range statusFilters {
+			if e.DriftStatus == s {
+				filtered = append(filtered, e)
+				break
+			}
+		}
+	}
+	return filtered, nil
+}
+
+// StartStackDriftDetection begins a drift-detection operation and returns its
+// detection ID. The operation runs synchronously, but the IN_PROGRESS record is
+// persisted before detection runs so a concurrent
+// [StackDeployer.DescribeStackDriftDetectionStatus] read can observe it.
+func (d *StackDeployer) StartStackDriftDetection(ctx context.Context, stackName string) (string, error) {
+	if d.state == nil {
+		return "", fmt.Errorf("cfn StartStackDriftDetection: state manager required")
+	}
+	if data, err := d.state.Get(ctx, cfnNamespace, "stack:"+stackName); err != nil || data == nil {
+		return "", fmt.Errorf("cfn StartStackDriftDetection: stack %q not found", stackName)
+	}
+
+	detectionID := generateRequestID()
+	// Persist the in-progress record before running detection.
+	inProgress := &CFNDriftDetectionStatus{
+		StackDriftDetectionID: detectionID,
+		StackName:             stackName,
+		DetectionStatus:       "DETECTION_IN_PROGRESS",
+		Timestamp:             d.tc.Now(),
+	}
+	if err := d.saveDriftDetection(ctx, inProgress); err != nil {
+		return "", err
+	}
+
+	result, err := d.DetectStackDrift(ctx, stackName)
+	if err != nil {
+		failed := &CFNDriftDetectionStatus{
+			StackDriftDetectionID: detectionID,
+			StackName:             stackName,
+			DetectionStatus:       "DETECTION_FAILED",
+			Timestamp:             d.tc.Now(),
+		}
+		_ = d.saveDriftDetection(ctx, failed)
+		return detectionID, err
+	}
+
+	complete := &CFNDriftDetectionStatus{
+		StackDriftDetectionID:     detectionID,
+		StackName:                 stackName,
+		DetectionStatus:           "DETECTION_COMPLETE",
+		StackDriftStatus:          result.DriftStatus,
+		DriftedStackResourceCount: result.DriftedCount,
+		Timestamp:                 d.tc.Now(),
+	}
+	if err := d.saveDriftDetection(ctx, complete); err != nil {
+		return "", err
+	}
+	return detectionID, nil
+}
+
+// DescribeStackDriftDetectionStatus returns the status of a previously started
+// drift-detection operation.
+func (d *StackDeployer) DescribeStackDriftDetectionStatus(ctx context.Context, detectionID string) (*CFNDriftDetectionStatus, error) {
+	data, err := d.state.Get(ctx, cfnNamespace, "drift_detection:"+detectionID)
+	if err != nil || data == nil {
+		return nil, fmt.Errorf("cfn DescribeStackDriftDetectionStatus: detection %q not found", detectionID)
+	}
+	var status CFNDriftDetectionStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil, fmt.Errorf("cfn DescribeStackDriftDetectionStatus: unmarshal: %w", err)
+	}
+	return &status, nil
+}
+
+// saveDriftDetection persists a drift-detection status record.
+func (d *StackDeployer) saveDriftDetection(ctx context.Context, status *CFNDriftDetectionStatus) error {
+	data, err := json.Marshal(status)
+	if err != nil {
+		return fmt.Errorf("cfn saveDriftDetection: marshal: %w", err)
+	}
+	if err := d.state.Put(ctx, cfnNamespace, "drift_detection:"+status.StackDriftDetectionID, data); err != nil {
+		return fmt.Errorf("cfn saveDriftDetection: put: %w", err)
+	}
+	return nil
 }
 
 func (d *StackDeployer) loadChangeSetNames(ctx context.Context, stackName string) ([]string, error) {
@@ -811,6 +964,67 @@ var cfnDriftCheckers = map[string]func(d *StackDeployer, ctx context.Context, ac
 		data, _ := d.state.Get(ctx, "iam", "role:"+physicalID)
 		return data != nil
 	},
+}
+
+// cfnDriftComparators holds optional property-level drift comparators, keyed by
+// CloudFormation resource type. A comparator runs only after the existence
+// check passes; it returns the property differences between the template
+// (expected) and live service state (actual), or nil/empty when in sync.
+//
+// Property-level drift is only as faithful as the properties a service plugin
+// actually persists in its own state. Today the sole comparator covers
+// S3 VersioningConfiguration, which is both pushed by the deploy path and
+// independently readable from S3 state; other drift-checkable resource types
+// (DynamoDB/SQS/SNS/Lambda/IAM) remain existence-only because their deploy
+// paths do not store template-comparable properties. New comparators can be
+// added here as the underlying plugins persist more properties.
+var cfnDriftComparators = map[string]func(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff{
+	"AWS::S3::Bucket": compareS3BucketDrift,
+}
+
+// compareS3BucketDrift compares a deployed S3 bucket's VersioningConfiguration
+// against its live state, reporting a property difference if they diverge.
+func compareS3BucketDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
+	// Derive the expected versioning status from the template definition,
+	// resolving any intrinsics/params exactly as at deploy time.
+	tmpl, err := parseCFNTemplate(stack.TemplateBody)
+	if err != nil {
+		return nil
+	}
+	res, ok := tmpl.Resources[dr.LogicalID]
+	if !ok {
+		return nil
+	}
+	cctx := buildCFNContext(tmpl, stack.Parameters, defaultRegion, testAccountID, stack.StackName)
+	evaluateConditions(tmpl, cctx)
+
+	expected := ""
+	if vc, ok := res.Properties["VersioningConfiguration"].(map[string]interface{}); ok {
+		expected = resolveValue(vc["Status"], cctx)
+	}
+
+	// Actual versioning status is stored verbatim under bucket_versioning:{name}.
+	actual := ""
+	if data, _ := d.state.Get(ctx, "s3", "bucket_versioning:"+dr.PhysicalID); data != nil {
+		actual = string(data)
+	}
+
+	if expected == actual {
+		return nil
+	}
+	diffType := "NOT_EQUAL"
+	switch {
+	case expected == "":
+		diffType = "ADD" // present live, absent in template
+	case actual == "":
+		diffType = "REMOVE" // defined in template, absent live
+	}
+	return []CFNPropertyDiff{{
+		PropertyPath:   "/VersioningConfiguration/Status",
+		ExpectedValue:  expected,
+		ActualValue:    actual,
+		DifferenceType: diffType,
+	}}
 }
 
 // deployResource dispatches a single CFN resource to the correct deploy helper.

--- a/betty_cfn_test.go
+++ b/betty_cfn_test.go
@@ -2328,3 +2328,91 @@ func TestCFN_DriftDetection_Deleted(t *testing.T) {
 	require.Len(t, result.ResourceDrifts, 1)
 	assert.Equal(t, "DELETED", result.ResourceDrifts[0].DriftStatus)
 }
+
+// TestCFN_DriftDetection_Modified verifies property-level MODIFIED drift for an
+// S3 bucket whose VersioningConfiguration is changed outside CloudFormation.
+func TestCFN_DriftDetection_Modified(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+
+	tmpl := `{"Resources": {"B": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "drift-mod-bucket", "VersioningConfiguration": {"Status": "Enabled"}}}}}`
+	_, err := d.Deploy(context.Background(), tmpl, "drift-mod-stack", nil)
+	require.NoError(t, err)
+
+	// Sanity: freshly deployed, versioning Enabled → IN_SYNC.
+	result, err := d.DetectStackDrift(context.Background(), "drift-mod-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "IN_SYNC", result.DriftStatus)
+
+	// Change versioning directly in state (bypassing CloudFormation).
+	require.NoError(t, state.Put(context.Background(), "s3", "bucket_versioning:drift-mod-bucket", []byte("Suspended")))
+
+	result, err = d.DetectStackDrift(context.Background(), "drift-mod-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "DRIFTED", result.DriftStatus)
+	assert.Equal(t, 1, result.DriftedCount)
+	require.Len(t, result.ResourceDrifts, 1)
+	entry := result.ResourceDrifts[0]
+	assert.Equal(t, "MODIFIED", entry.DriftStatus)
+	require.Len(t, entry.PropertyDifferences, 1)
+	assert.Equal(t, "/VersioningConfiguration/Status", entry.PropertyDifferences[0].PropertyPath)
+	assert.Equal(t, "Enabled", entry.PropertyDifferences[0].ExpectedValue)
+	assert.Equal(t, "Suspended", entry.PropertyDifferences[0].ActualValue)
+	assert.Equal(t, "NOT_EQUAL", entry.PropertyDifferences[0].DifferenceType)
+}
+
+// TestCFN_DescribeStackResourceDrifts_Filter verifies status filtering.
+func TestCFN_DescribeStackResourceDrifts_Filter(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+
+	tmpl := `{"Resources": {"B": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "drift-f-bucket", "VersioningConfiguration": {"Status": "Enabled"}}}}}`
+	_, err := d.Deploy(context.Background(), tmpl, "drift-f-stack", nil)
+	require.NoError(t, err)
+	require.NoError(t, state.Put(context.Background(), "s3", "bucket_versioning:drift-f-bucket", []byte("Suspended")))
+
+	// Filter to MODIFIED → one entry.
+	mod, err := d.DescribeStackResourceDrifts(context.Background(), "drift-f-stack", []string{"MODIFIED"})
+	require.NoError(t, err)
+	require.Len(t, mod, 1)
+	assert.Equal(t, "MODIFIED", mod[0].DriftStatus)
+
+	// Filter to DELETED → none.
+	del, err := d.DescribeStackResourceDrifts(context.Background(), "drift-f-stack", []string{"DELETED"})
+	require.NoError(t, err)
+	assert.Empty(t, del)
+
+	// No filter → all entries.
+	all, err := d.DescribeStackResourceDrifts(context.Background(), "drift-f-stack", nil)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+}
+
+// TestCFN_DriftDetectionStatus verifies the start/describe detection-status flow.
+func TestCFN_DriftDetectionStatus(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+
+	tmpl := `{"Resources": {"B": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "drift-s-bucket"}}}}`
+	_, err := d.Deploy(context.Background(), tmpl, "drift-s-stack", nil)
+	require.NoError(t, err)
+
+	id, err := d.StartStackDriftDetection(context.Background(), "drift-s-stack")
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+
+	status, err := d.DescribeStackDriftDetectionStatus(context.Background(), id)
+	require.NoError(t, err)
+	assert.Equal(t, "DETECTION_COMPLETE", status.DetectionStatus)
+	assert.Equal(t, "IN_SYNC", status.StackDriftStatus)
+	assert.Equal(t, 0, status.DriftedStackResourceCount)
+	assert.Equal(t, id, status.StackDriftDetectionID)
+
+	// Unknown detection ID → error.
+	_, err = d.DescribeStackDriftDetectionStatus(context.Background(), "nonexistent")
+	require.Error(t, err)
+}
+
+// TestCFN_StartStackDriftDetection_UnknownStack verifies an unknown stack errors.
+func TestCFN_StartStackDriftDetection_UnknownStack(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	_, err := d.StartStackDriftDetection(context.Background(), "no-such-stack")
+	require.Error(t, err)
+}

--- a/ec2_plugin.go
+++ b/ec2_plugin.go
@@ -113,8 +113,12 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.associateRouteTable(ctx, req)
 	case "DisassociateRouteTable":
 		return p.disassociateRouteTable(ctx, req)
+	case "ReplaceRouteTableAssociation":
+		return p.replaceRouteTableAssociation(ctx, req)
 	case "CreateRoute":
 		return p.createRoute(ctx, req)
+	case "ReplaceRoute":
+		return p.replaceRoute(ctx, req)
 	case "DeleteRoute":
 		return p.deleteRoute(ctx, req)
 	case "DeleteRouteTable":
@@ -753,7 +757,7 @@ func (p *EC2Plugin) createVPC(reqCtx *RequestContext, req *AWSRequest) (*AWSResp
 		return nil, err
 	}
 	// Create default route table for VPC.
-	if _, err := p.createRouteTableForVPC(reqCtx, vpcID, cidr, true); err != nil {
+	if _, err := p.createRouteTableForVPC(reqCtx, vpcID, cidr, true, ""); err != nil {
 		p.logger.Warn("ec2: failed to create default route table", "err", err)
 	}
 
@@ -1261,7 +1265,7 @@ func (p *EC2Plugin) deleteInternetGateway(reqCtx *RequestContext, req *AWSReques
 
 func (p *EC2Plugin) createRouteTable(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	vpcID := req.Params["VpcId"]
-	rtbID, err := p.createRouteTableForVPC(reqCtx, vpcID, "", false)
+	rtbID, err := p.createRouteTableForVPC(reqCtx, vpcID, "", false, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1277,7 +1281,7 @@ func (p *EC2Plugin) createRouteTable(reqCtx *RequestContext, req *AWSRequest) (*
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", RouteTable: rtbItem{rtbID, vpcID}})
 }
 
-func (p *EC2Plugin) createRouteTableForVPC(reqCtx *RequestContext, vpcID, localCIDR string, main bool) (string, error) {
+func (p *EC2Plugin) createRouteTableForVPC(reqCtx *RequestContext, vpcID, localCIDR string, main bool, igwID string) (string, error) {
 	rtbID := generateRTBID()
 	rtb := EC2RouteTable{
 		RouteTableID: rtbID,
@@ -1287,6 +1291,11 @@ func (p *EC2Plugin) createRouteTableForVPC(reqCtx *RequestContext, vpcID, localC
 	}
 	if localCIDR != "" {
 		rtb.Routes = []EC2Route{{DestinationCIDR: localCIDR, GatewayID: "local", State: "active"}}
+	}
+	// A default VPC's main route table carries a default route to its attached
+	// internet gateway, matching real AWS.
+	if igwID != "" {
+		rtb.Routes = append(rtb.Routes, EC2Route{DestinationCIDR: "0.0.0.0/0", GatewayID: igwID, State: "active"})
 	}
 	if main {
 		rtb.Associations = []EC2RTAssociation{{AssociationID: generateAssociationID(), Main: true}}
@@ -1302,8 +1311,20 @@ func (p *EC2Plugin) createRouteTableForVPC(reqCtx *RequestContext, vpcID, localC
 	return rtbID, nil
 }
 
+// routeTableHasSubnet reports whether the route table has an association with
+// any of the given subnet IDs.
+func routeTableHasSubnet(rtb EC2RouteTable, subnetIDs []string) bool {
+	for _, a := range rtb.Associations {
+		if a.SubnetID != "" && containsStr(subnetIDs, a.SubnetID) {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *EC2Plugin) describeRouteTables(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := extractIndexedParams(req.Params, "RouteTableId")
+	filters := extractEC2Filters(req.Params)
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "rtb:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeRouteTables: %w", err)
@@ -1340,6 +1361,15 @@ func (p *EC2Plugin) describeRouteTables(reqCtx *RequestContext, req *AWSRequest)
 			continue
 		}
 		if len(ids) > 0 && !containsStr(ids, rtb.RouteTableID) {
+			continue
+		}
+		if vals, ok := filters["vpc-id"]; ok && !containsStr(vals, rtb.VPCID) {
+			continue
+		}
+		if vals, ok := filters["association.route-table-id"]; ok && !containsStr(vals, rtb.RouteTableID) {
+			continue
+		}
+		if vals, ok := filters["association.subnet-id"]; ok && !routeTableHasSubnet(rtb, vals) {
 			continue
 		}
 		item := rtbItem{RouteTableID: rtb.RouteTableID, VpcID: rtb.VPCID}
@@ -1439,6 +1469,129 @@ func (p *EC2Plugin) createRoute(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 		Return  bool     `xml:"return"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
+}
+
+// routeTargetGateway returns the route target gateway ID from whichever EC2
+// route-target parameter the caller supplied (internet/NAT gateway, instance,
+// or network interface), normalised to the single GatewayID field Substrate
+// stores per route.
+func routeTargetGateway(params map[string]string) string {
+	for _, k := range []string{"GatewayId", "NatGatewayId", "InstanceId", "NetworkInterfaceId", "TransitGatewayId", "VpcPeeringConnectionId"} {
+		if v := params[k]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func (p *EC2Plugin) replaceRoute(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	rtbID := req.Params["RouteTableId"]
+	destCIDR := req.Params["DestinationCidrBlock"]
+	gwID := routeTargetGateway(req.Params)
+	key := "rtb:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + rtbID
+	data, err := p.state.Get(context.Background(), ec2Namespace, key)
+	if err != nil || data == nil {
+		return nil, &AWSError{Code: "InvalidRouteTableID.NotFound", Message: "Route table not found", HTTPStatus: http.StatusBadRequest}
+	}
+	var rtb EC2RouteTable
+	if unmarshalErr := json.Unmarshal(data, &rtb); unmarshalErr != nil {
+		return nil, fmt.Errorf("ec2 replaceRoute unmarshal: %w", unmarshalErr)
+	}
+	found := false
+	for i := range rtb.Routes {
+		if rtb.Routes[i].DestinationCIDR == destCIDR {
+			rtb.Routes[i].GatewayID = gwID
+			rtb.Routes[i].State = "active"
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, &AWSError{Code: "InvalidRoute.NotFound", Message: "no route with destination " + destCIDR, HTTPStatus: http.StatusBadRequest}
+	}
+	newData, _ := json.Marshal(rtb)
+	_ = p.state.Put(context.Background(), ec2Namespace, key, newData)
+	type response struct {
+		XMLName xml.Name `xml:"ReplaceRouteResponse"`
+		XMLNS   string   `xml:"xmlns,attr"`
+		Return  bool     `xml:"return"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
+}
+
+// replaceRouteTableAssociation repoints an existing subnet association to a
+// different route table, returning a new association ID (matching AWS, which
+// allocates a fresh rtbassoc-* on replacement).
+func (p *EC2Plugin) replaceRouteTableAssociation(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	assocID := req.Params["AssociationId"]
+	newRtbID := req.Params["RouteTableId"]
+
+	allKeys, err := p.state.List(context.Background(), ec2Namespace, "rtb:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+	if err != nil {
+		return nil, fmt.Errorf("ec2 replaceRouteTableAssociation list: %w", err)
+	}
+
+	// Locate and remove the existing association, capturing its subnet/main flag.
+	var moved EC2RTAssociation
+	found := false
+	for _, k := range allKeys {
+		data, getErr := p.state.Get(context.Background(), ec2Namespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var rtb EC2RouteTable
+		if json.Unmarshal(data, &rtb) != nil {
+			continue
+		}
+		newAssoc := rtb.Associations[:0]
+		for _, a := range rtb.Associations {
+			if a.AssociationID == assocID {
+				moved = a
+				found = true
+			} else {
+				newAssoc = append(newAssoc, a)
+			}
+		}
+		if found {
+			rtb.Associations = newAssoc
+			updated, _ := json.Marshal(rtb)
+			_ = p.state.Put(context.Background(), ec2Namespace, k, updated)
+			break
+		}
+	}
+	if !found {
+		return nil, &AWSError{Code: "InvalidAssociationID.NotFound", Message: "association " + assocID + " not found", HTTPStatus: http.StatusBadRequest}
+	}
+
+	// Attach a fresh association to the target route table.
+	newKey := "rtb:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + newRtbID
+	data, getErr := p.state.Get(context.Background(), ec2Namespace, newKey)
+	if getErr != nil || data == nil {
+		return nil, &AWSError{Code: "InvalidRouteTableID.NotFound", Message: "Route table not found", HTTPStatus: http.StatusBadRequest}
+	}
+	var target EC2RouteTable
+	if unmarshalErr := json.Unmarshal(data, &target); unmarshalErr != nil {
+		return nil, fmt.Errorf("ec2 replaceRouteTableAssociation unmarshal: %w", unmarshalErr)
+	}
+	newAssocID := generateAssociationID()
+	target.Associations = append(target.Associations, EC2RTAssociation{AssociationID: newAssocID, SubnetID: moved.SubnetID, Main: moved.Main})
+	newData, _ := json.Marshal(target)
+	_ = p.state.Put(context.Background(), ec2Namespace, newKey, newData)
+
+	type assocState struct {
+		State string `xml:"state"`
+	}
+	type response struct {
+		XMLName          xml.Name   `xml:"ReplaceRouteTableAssociationResponse"`
+		XMLNS            string     `xml:"xmlns,attr"`
+		NewAssociationID string     `xml:"newAssociationId"`
+		AssociationState assocState `xml:"associationState"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:            "http://ec2.amazonaws.com/doc/2016-11-15/",
+		NewAssociationID: newAssocID,
+		AssociationState: assocState{State: "associated"},
+	})
 }
 
 func (p *EC2Plugin) deleteRoute(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -1981,8 +2134,26 @@ func (p *EC2Plugin) ensureDefaultVPC(ctx context.Context, reqCtx *RequestContext
 	}
 	_ = p.appendToList(reqCtx.AccountID+"/"+reqCtx.Region, "sg_ids", sgID)
 
-	// Create main route table with local route + IGW route for default VPC.
-	if _, rtErr := p.createRouteTableForVPC(reqCtx, vpcID, "172.31.0.0/16", true); rtErr != nil {
+	// Create and attach a default internet gateway so the main route table can
+	// carry a 0.0.0.0/0 → igw route, matching a real default VPC.
+	igwID := generateIGWID()
+	igw := EC2InternetGateway{
+		InternetGatewayID: igwID,
+		Attachments:       []EC2IGWAttachment{{VPCID: vpcID, State: "available"}},
+		AccountID:         reqCtx.AccountID,
+		Region:            reqCtx.Region,
+	}
+	igwData, _ := json.Marshal(igw)
+	igwKey := "igw:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + igwID
+	if err := p.state.Put(ctx, ec2Namespace, igwKey, igwData); err != nil {
+		p.logger.Warn("ec2: failed to create default internet gateway", "err", err)
+		igwID = ""
+	} else {
+		_ = p.appendToList(reqCtx.AccountID+"/"+reqCtx.Region, "igw_ids", igwID)
+	}
+
+	// Create main route table with local route + default IGW route.
+	if _, rtErr := p.createRouteTableForVPC(reqCtx, vpcID, "172.31.0.0/16", true, igwID); rtErr != nil {
 		p.logger.Warn("ec2: failed to create default route table", "err", rtErr)
 	}
 

--- a/ec2_plugin_test.go
+++ b/ec2_plugin_test.go
@@ -3093,3 +3093,175 @@ func TestEC2_SecurityGroupAllowed(t *testing.T) {
 	assert.True(t, substrate.SecurityGroupAllowed(allRules, "tcp", 22, "1.2.3.4"))
 	assert.True(t, substrate.SecurityGroupAllowed(allRules, "udp", 53, "10.0.0.1"))
 }
+
+// TestEC2_ReplaceRoute verifies ReplaceRoute repoints an existing route to a new
+// gateway, and returns InvalidRoute.NotFound for an unknown destination.
+func TestEC2_ReplaceRoute(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	vpcResp := ec2Request(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.7.0.0/16"})
+	var vpcResult struct {
+		Vpc struct {
+			VpcID string `xml:"vpcId"`
+		} `xml:"vpc"`
+	}
+	_ = xml.NewDecoder(vpcResp.Body).Decode(&vpcResult)
+	vpcResp.Body.Close() //nolint:errcheck
+	vpcID := vpcResult.Vpc.VpcID
+
+	rtbResp := ec2Request(t, ts, map[string]string{"Action": "CreateRouteTable", "VpcId": vpcID})
+	var rtbResult struct {
+		RouteTable struct {
+			RouteTableID string `xml:"routeTableId"`
+		} `xml:"routeTable"`
+	}
+	_ = xml.NewDecoder(rtbResp.Body).Decode(&rtbResult)
+	rtbResp.Body.Close() //nolint:errcheck
+	rtbID := rtbResult.RouteTable.RouteTableID
+
+	// Create a route to igw-aaa, then replace its target with igw-bbb.
+	r := ec2Request(t, ts, map[string]string{
+		"Action": "CreateRoute", "RouteTableId": rtbID,
+		"DestinationCidrBlock": "0.0.0.0/0", "GatewayId": "igw-aaa",
+	})
+	r.Body.Close() //nolint:errcheck
+
+	repl := ec2Request(t, ts, map[string]string{
+		"Action": "ReplaceRoute", "RouteTableId": rtbID,
+		"DestinationCidrBlock": "0.0.0.0/0", "GatewayId": "igw-bbb",
+	})
+	assert.Equal(t, http.StatusOK, repl.StatusCode)
+	repl.Body.Close() //nolint:errcheck
+
+	desc := ec2Request(t, ts, map[string]string{"Action": "DescribeRouteTables", "RouteTableId.1": rtbID})
+	body := readBody(t, desc)
+	assert.Contains(t, body, "igw-bbb")
+	assert.NotContains(t, body, "igw-aaa")
+
+	// Replacing a non-existent route → InvalidRoute.NotFound.
+	bad := ec2Request(t, ts, map[string]string{
+		"Action": "ReplaceRoute", "RouteTableId": rtbID,
+		"DestinationCidrBlock": "192.168.0.0/16", "GatewayId": "igw-ccc",
+	})
+	assert.Equal(t, http.StatusBadRequest, bad.StatusCode)
+	bad.Body.Close() //nolint:errcheck
+}
+
+// TestEC2_ReplaceRouteTableAssociation verifies an association can be repointed
+// to a different route table, yielding a fresh association ID.
+func TestEC2_ReplaceRouteTableAssociation(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	vpcResp := ec2Request(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.8.0.0/16"})
+	var vpcResult struct {
+		Vpc struct {
+			VpcID string `xml:"vpcId"`
+		} `xml:"vpc"`
+	}
+	_ = xml.NewDecoder(vpcResp.Body).Decode(&vpcResult)
+	vpcResp.Body.Close() //nolint:errcheck
+	vpcID := vpcResult.Vpc.VpcID
+
+	subResp := ec2Request(t, ts, map[string]string{"Action": "CreateSubnet", "VpcId": vpcID, "CidrBlock": "10.8.1.0/24"})
+	var subResult struct {
+		Subnet struct {
+			SubnetID string `xml:"subnetId"`
+		} `xml:"subnet"`
+	}
+	_ = xml.NewDecoder(subResp.Body).Decode(&subResult)
+	subResp.Body.Close() //nolint:errcheck
+	subnetID := subResult.Subnet.SubnetID
+
+	mkRTB := func() string {
+		resp := ec2Request(t, ts, map[string]string{"Action": "CreateRouteTable", "VpcId": vpcID})
+		var res struct {
+			RouteTable struct {
+				RouteTableID string `xml:"routeTableId"`
+			} `xml:"routeTable"`
+		}
+		_ = xml.NewDecoder(resp.Body).Decode(&res)
+		resp.Body.Close() //nolint:errcheck
+		return res.RouteTable.RouteTableID
+	}
+	rtb1, rtb2 := mkRTB(), mkRTB()
+
+	assocResp := ec2Request(t, ts, map[string]string{"Action": "AssociateRouteTable", "RouteTableId": rtb1, "SubnetId": subnetID})
+	var assocResult struct {
+		AssociationID string `xml:"associationId"`
+	}
+	_ = xml.NewDecoder(assocResp.Body).Decode(&assocResult)
+	assocResp.Body.Close() //nolint:errcheck
+	oldAssoc := assocResult.AssociationID
+	assert.NotEmpty(t, oldAssoc)
+
+	replResp := ec2Request(t, ts, map[string]string{
+		"Action": "ReplaceRouteTableAssociation", "AssociationId": oldAssoc, "RouteTableId": rtb2,
+	})
+	assert.Equal(t, http.StatusOK, replResp.StatusCode)
+	var replResult struct {
+		NewAssociationID string `xml:"newAssociationId"`
+	}
+	_ = xml.NewDecoder(replResp.Body).Decode(&replResult)
+	replResp.Body.Close() //nolint:errcheck
+	assert.NotEmpty(t, replResult.NewAssociationID)
+	assert.NotEqual(t, oldAssoc, replResult.NewAssociationID)
+
+	// rtb2 now carries the association for the subnet; filter by subnet returns rtb2.
+	desc := ec2Request(t, ts, map[string]string{
+		"Action": "DescribeRouteTables", "Filter.1.Name": "association.subnet-id", "Filter.1.Value.1": subnetID,
+	})
+	body := readBody(t, desc)
+	assert.Contains(t, body, rtb2)
+	assert.NotContains(t, body, rtb1)
+
+	// Replacing an unknown association → InvalidAssociationID.NotFound.
+	bad := ec2Request(t, ts, map[string]string{
+		"Action": "ReplaceRouteTableAssociation", "AssociationId": "rtbassoc-ghost", "RouteTableId": rtb2,
+	})
+	assert.Equal(t, http.StatusBadRequest, bad.StatusCode)
+	bad.Body.Close() //nolint:errcheck
+}
+
+// TestEC2_DescribeRouteTables_VpcFilter verifies filtering by vpc-id.
+func TestEC2_DescribeRouteTables_VpcFilter(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	mkVPC := func(cidr string) string {
+		resp := ec2Request(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": cidr})
+		var res struct {
+			Vpc struct {
+				VpcID string `xml:"vpcId"`
+			} `xml:"vpc"`
+		}
+		_ = xml.NewDecoder(resp.Body).Decode(&res)
+		resp.Body.Close() //nolint:errcheck
+		return res.Vpc.VpcID
+	}
+	vpcA, vpcB := mkVPC("10.10.0.0/16"), mkVPC("10.11.0.0/16")
+
+	desc := ec2Request(t, ts, map[string]string{
+		"Action": "DescribeRouteTables", "Filter.1.Name": "vpc-id", "Filter.1.Value.1": vpcA,
+	})
+	body := readBody(t, desc)
+	assert.Contains(t, body, vpcA)
+	assert.NotContains(t, body, vpcB)
+}
+
+// TestEC2_DefaultVPC_IGWRoute verifies that triggering default-VPC creation
+// yields a main route table with a 0.0.0.0/0 → igw route.
+func TestEC2_DefaultVPC_IGWRoute(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	// RunInstances with no SubnetId triggers ensureDefaultVPC.
+	run := ec2Request(t, ts, map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-12345678", "InstanceType": "t3.micro",
+		"MinCount": "1", "MaxCount": "1",
+	})
+	assert.Equal(t, http.StatusOK, run.StatusCode)
+	run.Body.Close() //nolint:errcheck
+
+	desc := ec2Request(t, ts, map[string]string{"Action": "DescribeRouteTables"})
+	body := readBody(t, desc)
+	assert.Contains(t, body, "0.0.0.0/0")
+	assert.Contains(t, body, "igw-")
+}


### PR DESCRIPTION
## #293 — VPC route tables (COMPLETE → closes #293)
- **`ReplaceRoute`** and **`ReplaceRouteTableAssociation`** (the latter returns a fresh `newAssociationId`, matching AWS).
- **`DescribeRouteTables`** now honours `vpc-id`, `association.subnet-id`, and `association.route-table-id` filters (reusing `extractEC2Filters`), not just `RouteTableId`.
- **Default-VPC IGW route**: `ensureDefaultVPC` previously claimed (in a comment) to add an IGW route but created no internet gateway and only the local route. It now creates+attaches a default IGW and adds `0.0.0.0/0 → igw-…` to the main route table.

## #290 — CloudFormation drift detection (PARTIAL → #290 stays open)
- **MODIFIED detection** via a new `cfnDriftComparators` map. The comparator re-parses the stored template and resolves intrinsics/params at drift-check time, then compares against live plugin state. The **S3 `VersioningConfiguration`** comparator is implemented and tested end-to-end (deploy a versioned bucket, change it outside CloudFormation, drift reports `MODIFIED` with a `PropertyDifferences` entry).
- **`DescribeStackResourceDrifts`** (optional status filter) and **`StartStackDriftDetection` / `DescribeStackDriftDetectionStatus`** (`DETECTION_IN_PROGRESS → DETECTION_COMPLETE`).
- New types `CFNPropertyDiff`, `CFNDriftDetectionStatus`; `CFNResourceDriftEntry` gained `PropertyDifferences`; enum gained `MODIFIED`.

### Why #290 stays open
Faithful property-level `MODIFIED` is bounded by what each plugin persists. Of the six drift-checkable types, only S3 versioning qualifies today (deploy path sets the property *and* it is independently readable). DynamoDB/SQS/SNS/Lambda/IAM remain existence-only (`DELETED`/`IN_SYNC`) — broadening requires a larger cross-plugin change to persist comparable properties. The `cfnDriftComparators` map makes adding types straightforward later. **This PR advances #290 but does not fully satisfy its acceptance criteria, so it is left open** (per the project's partial-ship release rule).

## Notes
- `make test` (race) + `make lint` clean. AWS wire shapes verified against the official CloudFormation/EC2 API references.
- Independent of #300 (#297/#298/#299); branched from `main`.

Closes #293