### PR TITLE
feat: property-level CFN drift MODIFIED for all drift-checkable types (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **CloudFormation drift detection — property-level `MODIFIED` for all
+  drift-checkable types (#290)**: Extended `cfnDriftComparators` with comparators
+  for DynamoDB (`BillingMode`, `ProvisionedThroughput` read/write capacity),
+  Lambda (`Runtime`, `Handler`, `Timeout`, `MemorySize`), IAM Role
+  (`AssumeRolePolicyDocument` via the new order-insensitive `policyDocumentsEqual`
+  helper, plus `Description`/`Path`), SQS (queue attributes —
+  `VisibilityTimeout`, `MessageRetentionPeriod`, `DelaySeconds`,
+  `ReceiveMessageWaitTimeSeconds`, `MaximumMessageSize`), and SNS (`DisplayName`).
+  To make SQS/SNS comparable, `deploySQSQueue` and `deploySNSTopic` now forward
+  declared properties, and SNS `CreateTopic` persists an initial `DisplayName`.
+  Comparison is **template-declared-only**: a property is checked solely when the
+  template explicitly declares it, so deploy-applied defaults never produce false
+  drift (the S3 versioning comparator was aligned to the same rule). This
+  completes #290. Also fixed latent state-key bugs in the existing SQS, SNS, and
+  Lambda existence drift-checkers (spurious region component / ARN-vs-name) and a
+  pre-existing bug where `deployLambdaFunction` sent `Timeout`/`MemorySize` as
+  strings, causing `CreateFunction` to reject the request. Closes #290.
 - **CloudFormation drift detection — MODIFIED + describe operations (#290)**:
   `DetectStackDrift` now reports `MODIFIED` (in addition to `IN_SYNC`/`DELETED`/
   `NOT_CHECKED`) via a new `cfnDriftComparators` map that performs property-level
@@ -24,8 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DETECTION_IN_PROGRESS → DETECTION_COMPLETE` lifecycle, with the in-progress
   record persisted before synchronous detection runs). New types
   `CFNPropertyDiff` and `CFNDriftDetectionStatus`; `CFNResourceDriftEntry` gained
-  `PropertyDifferences`. Partially addresses #290 (property-level `MODIFIED`
-  remains existence-only for non-S3-versioning resource types; #290 stays open).
+  `PropertyDifferences`. (Broadened to all drift-checkable types in the entry
+  above.)
 - **VPC route table completion (#293)**: Added `ReplaceRoute` (repoints an
   existing route's target; returns `InvalidRoute.NotFound` for an unknown
   destination) and `ReplaceRouteTableAssociation` (repoints a subnet association

--- a/betty_cfn.go
+++ b/betty_cfn.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -948,16 +949,19 @@ var cfnDriftCheckers = map[string]func(d *StackDeployer, ctx context.Context, ac
 		data, _ := d.state.Get(ctx, "dynamodb", "table:"+acct+"/"+physicalID)
 		return data != nil
 	},
-	"AWS::SQS::Queue": func(d *StackDeployer, ctx context.Context, acct, region, physicalID string) bool {
-		data, _ := d.state.Get(ctx, "sqs", "queue:"+acct+"/"+region+"/"+physicalID)
+	"AWS::SQS::Queue": func(d *StackDeployer, ctx context.Context, acct, _, physicalID string) bool {
+		// SQS state key is account/queue-name (no region component).
+		data, _ := d.state.Get(ctx, "sqs", "queue:"+acct+"/"+physicalID)
 		return data != nil
 	},
 	"AWS::SNS::Topic": func(d *StackDeployer, ctx context.Context, acct, region, physicalID string) bool {
-		data, _ := d.state.Get(ctx, "sns", "topic:"+acct+"/"+region+"/"+physicalID)
+		// PhysicalID is the topic ARN; the SNS state key is name-based.
+		data, _ := d.state.Get(ctx, "sns", "topic:"+acct+"/"+region+"/"+snsTopicNameFromPhysicalID(physicalID))
 		return data != nil
 	},
-	"AWS::Lambda::Function": func(d *StackDeployer, ctx context.Context, acct, region, physicalID string) bool {
-		data, _ := d.state.Get(ctx, "lambda", "function:"+acct+"/"+region+"/"+physicalID)
+	"AWS::Lambda::Function": func(d *StackDeployer, ctx context.Context, _, _, physicalID string) bool {
+		// Lambda state key is the bare function name (no account/region).
+		data, _ := d.state.Get(ctx, "lambda", "function:"+physicalID)
 		return data != nil
 	},
 	"AWS::IAM::Role": func(d *StackDeployer, ctx context.Context, _, _, physicalID string) bool {
@@ -979,52 +983,277 @@ var cfnDriftCheckers = map[string]func(d *StackDeployer, ctx context.Context, ac
 // paths do not store template-comparable properties. New comparators can be
 // added here as the underlying plugins persist more properties.
 var cfnDriftComparators = map[string]func(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff{
-	"AWS::S3::Bucket": compareS3BucketDrift,
+	"AWS::S3::Bucket":       compareS3BucketDrift,
+	"AWS::DynamoDB::Table":  compareDynamoDBTableDrift,
+	"AWS::Lambda::Function": compareLambdaFunctionDrift,
+	"AWS::IAM::Role":        compareIAMRoleDrift,
+	"AWS::SQS::Queue":       compareSQSQueueDrift,
+	"AWS::SNS::Topic":       compareSNSTopicDrift,
+}
+
+// cfnDriftResourceProps re-parses the stack template and returns the declared
+// Properties map plus a resolution context for the given deployed resource.
+// It returns (nil, nil, false) when the template cannot be parsed or the
+// resource is absent, so callers can simply skip drift comparison.
+func cfnDriftResourceProps(stack *CFNStackState, dr DeployedResource) (map[string]interface{}, *cfnContext, bool) {
+	tmpl, err := parseCFNTemplate(stack.TemplateBody)
+	if err != nil {
+		return nil, nil, false
+	}
+	res, ok := tmpl.Resources[dr.LogicalID]
+	if !ok {
+		return nil, nil, false
+	}
+	cctx := buildCFNContext(tmpl, stack.Parameters, defaultRegion, testAccountID, stack.StackName)
+	evaluateConditions(tmpl, cctx)
+	return res.Properties, cctx, true
+}
+
+// driftDiff builds a NOT_EQUAL property difference for a property the template
+// explicitly declares whose live value diverges from the expected value.
+func driftDiff(path, expected, actual string) CFNPropertyDiff {
+	return CFNPropertyDiff{
+		PropertyPath:   path,
+		ExpectedValue:  expected,
+		ActualValue:    actual,
+		DifferenceType: "NOT_EQUAL",
+	}
 }
 
 // compareS3BucketDrift compares a deployed S3 bucket's VersioningConfiguration
 // against its live state, reporting a property difference if they diverge.
 func compareS3BucketDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
-	// Derive the expected versioning status from the template definition,
-	// resolving any intrinsics/params exactly as at deploy time.
-	tmpl, err := parseCFNTemplate(stack.TemplateBody)
-	if err != nil {
-		return nil
-	}
-	res, ok := tmpl.Resources[dr.LogicalID]
+	props, cctx, ok := cfnDriftResourceProps(stack, dr)
 	if !ok {
 		return nil
 	}
-	cctx := buildCFNContext(tmpl, stack.Parameters, defaultRegion, testAccountID, stack.StackName)
-	evaluateConditions(tmpl, cctx)
-
-	expected := ""
-	if vc, ok := res.Properties["VersioningConfiguration"].(map[string]interface{}); ok {
-		expected = resolveValue(vc["Status"], cctx)
+	// Template-declared-only: compare versioning solely when the template
+	// declares VersioningConfiguration.
+	vc, ok := props["VersioningConfiguration"].(map[string]interface{})
+	if !ok {
+		return nil
 	}
+	expected := resolveValue(vc["Status"], cctx)
 
 	// Actual versioning status is stored verbatim under bucket_versioning:{name}.
 	actual := ""
 	if data, _ := d.state.Get(ctx, "s3", "bucket_versioning:"+dr.PhysicalID); data != nil {
 		actual = string(data)
 	}
-
 	if expected == actual {
 		return nil
 	}
-	diffType := "NOT_EQUAL"
-	switch {
-	case expected == "":
-		diffType = "ADD" // present live, absent in template
-	case actual == "":
-		diffType = "REMOVE" // defined in template, absent live
+	return []CFNPropertyDiff{driftDiff("/VersioningConfiguration/Status", expected, actual)}
+}
+
+// compareDynamoDBTableDrift compares a deployed DynamoDB table's declared
+// BillingMode and provisioned throughput against live state.
+func compareDynamoDBTableDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
+	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	if !ok {
+		return nil
 	}
-	return []CFNPropertyDiff{{
-		PropertyPath:   "/VersioningConfiguration/Status",
-		ExpectedValue:  expected,
-		ActualValue:    actual,
-		DifferenceType: diffType,
-	}}
+	data, _ := d.state.Get(ctx, "dynamodb", "table:"+testAccountID+"/"+dr.PhysicalID)
+	if data == nil {
+		return nil
+	}
+	var tbl DynamoDBTable
+	if json.Unmarshal(data, &tbl) != nil {
+		return nil
+	}
+
+	var diffs []CFNPropertyDiff
+	if _, declared := props["BillingMode"]; declared {
+		expected := resolveStringProp(props, "BillingMode", "", cctx)
+		if expected != "" && expected != tbl.BillingModeSummary.BillingMode {
+			diffs = append(diffs, driftDiff("/BillingMode", expected, tbl.BillingModeSummary.BillingMode))
+		}
+	}
+	if pt, declared := props["ProvisionedThroughput"].(map[string]interface{}); declared {
+		if expRead := resolveValue(pt["ReadCapacityUnits"], cctx); expRead != "" {
+			actRead := strconv.FormatInt(tbl.ProvisionedThroughput.ReadCapacityUnits, 10)
+			if expRead != actRead {
+				diffs = append(diffs, driftDiff("/ProvisionedThroughput/ReadCapacityUnits", expRead, actRead))
+			}
+		}
+		if expWrite := resolveValue(pt["WriteCapacityUnits"], cctx); expWrite != "" {
+			actWrite := strconv.FormatInt(tbl.ProvisionedThroughput.WriteCapacityUnits, 10)
+			if expWrite != actWrite {
+				diffs = append(diffs, driftDiff("/ProvisionedThroughput/WriteCapacityUnits", expWrite, actWrite))
+			}
+		}
+	}
+	return diffs
+}
+
+// compareLambdaFunctionDrift compares a deployed Lambda function's declared
+// configuration properties against live state.
+func compareLambdaFunctionDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
+	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	if !ok {
+		return nil
+	}
+	data, _ := d.state.Get(ctx, "lambda", "function:"+dr.PhysicalID)
+	if data == nil {
+		return nil
+	}
+	var fn LambdaFunction
+	if json.Unmarshal(data, &fn) != nil {
+		return nil
+	}
+
+	var diffs []CFNPropertyDiff
+	if _, declared := props["Runtime"]; declared {
+		if exp := resolveStringProp(props, "Runtime", "", cctx); exp != "" && exp != fn.Runtime {
+			diffs = append(diffs, driftDiff("/Runtime", exp, fn.Runtime))
+		}
+	}
+	if _, declared := props["Handler"]; declared {
+		if exp := resolveStringProp(props, "Handler", "", cctx); exp != "" && exp != fn.Handler {
+			diffs = append(diffs, driftDiff("/Handler", exp, fn.Handler))
+		}
+	}
+	if _, declared := props["Timeout"]; declared {
+		if exp := resolveValue(props["Timeout"], cctx); exp != "" {
+			if act := strconv.Itoa(fn.Timeout); exp != act {
+				diffs = append(diffs, driftDiff("/Timeout", exp, act))
+			}
+		}
+	}
+	if _, declared := props["MemorySize"]; declared {
+		if exp := resolveValue(props["MemorySize"], cctx); exp != "" {
+			if act := strconv.Itoa(fn.MemorySize); exp != act {
+				diffs = append(diffs, driftDiff("/MemorySize", exp, act))
+			}
+		}
+	}
+	return diffs
+}
+
+// compareIAMRoleDrift compares a deployed IAM role's declared Description, Path,
+// and AssumeRolePolicyDocument against live state. The trust policy is compared
+// order-independently via policyDocumentsEqual.
+func compareIAMRoleDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
+	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	if !ok {
+		return nil
+	}
+	data, _ := d.state.Get(ctx, "iam", "role:"+dr.PhysicalID)
+	if data == nil {
+		return nil
+	}
+	var role IAMRole
+	if json.Unmarshal(data, &role) != nil {
+		return nil
+	}
+
+	var diffs []CFNPropertyDiff
+	if _, declared := props["Description"]; declared {
+		if exp := resolveStringProp(props, "Description", "", cctx); exp != role.Description {
+			diffs = append(diffs, driftDiff("/Description", exp, role.Description))
+		}
+	}
+	if _, declared := props["Path"]; declared {
+		if exp := resolveStringProp(props, "Path", "", cctx); exp != "" && exp != role.Path {
+			diffs = append(diffs, driftDiff("/Path", exp, role.Path))
+		}
+	}
+	if raw, declared := props["AssumeRolePolicyDocument"]; declared {
+		var expected PolicyDocument
+		// The template value is a JSON object (or string); unmarshal it the same
+		// way the IAM CreateRole handler stores the live document.
+		if err := json.Unmarshal([]byte(marshalToJSON(raw)), &expected); err == nil {
+			if !policyDocumentsEqual(expected, role.AssumeRolePolicyDocument) {
+				diffs = append(diffs, driftDiff(
+					"/AssumeRolePolicyDocument",
+					marshalToJSON(expected),
+					marshalToJSON(role.AssumeRolePolicyDocument),
+				))
+			}
+		}
+	}
+	return diffs
+}
+
+// sqsDriftAttributes are the SQS queue CloudFormation properties whose names map
+// 1:1 to SQS queue attributes; deploySQSQueue forwards declared ones and
+// compareSQSQueueDrift checks them.
+var sqsDriftAttributes = []string{
+	"VisibilityTimeout",
+	"MessageRetentionPeriod",
+	"DelaySeconds",
+	"ReceiveMessageWaitTimeSeconds",
+	"MaximumMessageSize",
+}
+
+// compareSQSQueueDrift compares a deployed SQS queue's declared attribute
+// properties against the live queue attributes.
+func compareSQSQueueDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
+	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	if !ok {
+		return nil
+	}
+	data, _ := d.state.Get(ctx, "sqs", "queue:"+testAccountID+"/"+dr.PhysicalID)
+	if data == nil {
+		return nil
+	}
+	var q SQSQueue
+	if json.Unmarshal(data, &q) != nil {
+		return nil
+	}
+
+	var diffs []CFNPropertyDiff
+	for _, name := range sqsDriftAttributes {
+		if _, declared := props[name]; !declared {
+			continue
+		}
+		exp := resolveValue(props[name], cctx)
+		if exp == "" {
+			continue
+		}
+		if act := q.Attributes[name]; exp != act {
+			diffs = append(diffs, driftDiff("/"+name, exp, act))
+		}
+	}
+	return diffs
+}
+
+// snsTopicNameFromPhysicalID returns the topic name from an SNS topic physical
+// ID, which is the topic ARN (arn:aws:sns:{region}:{acct}:{name}). A bare name
+// is returned unchanged.
+func snsTopicNameFromPhysicalID(physicalID string) string {
+	if idx := strings.LastIndexByte(physicalID, ':'); idx >= 0 {
+		return physicalID[idx+1:]
+	}
+	return physicalID
+}
+
+// compareSNSTopicDrift compares a deployed SNS topic's declared DisplayName
+// against live state.
+func compareSNSTopicDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
+	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	if !ok {
+		return nil
+	}
+	if _, declared := props["DisplayName"]; !declared {
+		return nil
+	}
+	name := snsTopicNameFromPhysicalID(dr.PhysicalID)
+	data, _ := d.state.Get(ctx, "sns", "topic:"+testAccountID+"/"+defaultRegion+"/"+name)
+	if data == nil {
+		return nil
+	}
+	var topic SNSTopic
+	if json.Unmarshal(data, &topic) != nil {
+		return nil
+	}
+
+	exp := resolveValue(props["DisplayName"], cctx)
+	act := topic.Attributes["DisplayName"]
+	if exp == act {
+		return nil
+	}
+	return []CFNPropertyDiff{driftDiff("/DisplayName", exp, act)}
 }
 
 // deployResource dispatches a single CFN resource to the correct deploy helper.
@@ -1435,11 +1664,18 @@ func (d *StackDeployer) deployLambdaFunction(
 		"Handler":      resolveStringProp(props, "Handler", "index.handler", cctx),
 		"Description":  resolveStringProp(props, "Description", "", cctx),
 	}
+	// Timeout and MemorySize are numeric in the Lambda API; convert the resolved
+	// string so the JSON body unmarshals into the int fields (CreateFunction
+	// rejects string values otherwise).
 	if timeout := resolveStringProp(props, "Timeout", "", cctx); timeout != "" {
-		body["Timeout"] = timeout
+		if n, convErr := strconv.Atoi(timeout); convErr == nil {
+			body["Timeout"] = n
+		}
 	}
 	if memory := resolveStringProp(props, "MemorySize", "", cctx); memory != "" {
-		body["MemorySize"] = memory
+		if n, convErr := strconv.Atoi(memory); convErr == nil {
+			body["MemorySize"] = n
+		}
 	}
 
 	bodyBytes, err := json.Marshal(body)
@@ -1487,15 +1723,30 @@ func (d *StackDeployer) deploySQSQueue(
 ) (DeployedResource, float64, error) {
 	queueName := resolveStringProp(props, "QueueName", logicalID, cctx)
 
+	params := map[string]string{
+		"Action":    "CreateQueue",
+		"QueueName": queueName,
+	}
+	// Forward declared queue attributes so they round-trip into SQSQueue.Attributes
+	// (CreateQueue persists them via parseSQSAttributes) and become drift-checkable.
+	attrIdx := 0
+	for _, name := range sqsDriftAttributes {
+		if _, declared := props[name]; !declared {
+			continue
+		}
+		if v := resolveValue(props[name], cctx); v != "" {
+			attrIdx++
+			params[fmt.Sprintf("Attribute.%d.Name", attrIdx)] = name
+			params[fmt.Sprintf("Attribute.%d.Value", attrIdx)] = v
+		}
+	}
+
 	req := &AWSRequest{
 		Service:   "sqs",
 		Operation: "CreateQueue",
 		Body:      nil,
 		Headers:   map[string]string{},
-		Params: map[string]string{
-			"Action":    "CreateQueue",
-			"QueueName": queueName,
-		},
+		Params:    params,
 	}
 
 	resp, cost, routeErr := d.dispatch(ctx, req, streamID)
@@ -2250,17 +2501,26 @@ func (d *StackDeployer) deploySNSTopic(
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
 	topicName := resolveStringProp(props, "TopicName", logicalID, cctx)
+	params := map[string]string{
+		"Action": "CreateTopic",
+		"Name":   topicName,
+	}
+	// Forward DisplayName when declared so it round-trips and is drift-checkable.
+	if _, declared := props["DisplayName"]; declared {
+		if dn := resolveValue(props["DisplayName"], cctx); dn != "" {
+			params["DisplayName"] = dn
+		}
+	}
 	req := &AWSRequest{
 		Service:   "sns",
 		Operation: "CreateTopic",
 		Body:      nil,
 		Headers:   map[string]string{},
-		Params: map[string]string{
-			"Action": "CreateTopic",
-			"Name":   topicName,
-		},
+		Params:    params,
 	}
 	resp, cost, routeErr := d.dispatch(ctx, req, streamID)
+	// PhysicalID is the topic ARN (CloudFormation Ref on an SNS topic returns its
+	// ARN); the drift checker/comparator derive the topic name from it.
 	dr := DeployedResource{LogicalID: logicalID, Type: "AWS::SNS::Topic", PhysicalID: topicName}
 	if routeErr != nil {
 		dr.Error = routeErr.Error()

--- a/betty_cfn_test.go
+++ b/betty_cfn_test.go
@@ -2176,6 +2176,24 @@ func newTestDeployerWithState(t *testing.T) (*substrate.StackDeployer, *substrat
 	}))
 	registry.Register(snsPlugin)
 
+	dynamoPlugin := &substrate.DynamoDBPlugin{}
+	require.NoError(t, dynamoPlugin.Initialize(context.Background(), substrate.PluginConfig{
+		State: state, Logger: logger, Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(dynamoPlugin)
+
+	lambdaPlugin := &substrate.LambdaPlugin{}
+	require.NoError(t, lambdaPlugin.Initialize(context.Background(), substrate.PluginConfig{
+		State: state, Logger: logger, Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(lambdaPlugin)
+
+	sqsPlugin := &substrate.SQSPlugin{}
+	require.NoError(t, sqsPlugin.Initialize(context.Background(), substrate.PluginConfig{
+		State: state, Logger: logger, Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(sqsPlugin)
+
 	return substrate.NewStackDeployer(registry, store, state, tc, logger, costs), state
 }
 
@@ -2415,4 +2433,254 @@ func TestCFN_StartStackDriftDetection_UnknownStack(t *testing.T) {
 	d, _ := newTestDeployerWithState(t)
 	_, err := d.StartStackDriftDetection(context.Background(), "no-such-stack")
 	require.Error(t, err)
+}
+
+// TestCFN_DriftDetection_DynamoDB_Modified verifies MODIFIED drift on a DynamoDB
+// table's provisioned throughput changed outside CloudFormation.
+func TestCFN_DriftDetection_DynamoDB_Modified(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+
+	tmpl := `{"Resources": {"T": {"Type": "AWS::DynamoDB::Table", "Properties": {
+		"TableName": "drift-ddb",
+		"AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
+		"KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
+		"BillingMode": "PROVISIONED",
+		"ProvisionedThroughput": {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5}
+	}}}}`
+	_, err := d.Deploy(context.Background(), tmpl, "drift-ddb-stack", nil)
+	require.NoError(t, err)
+
+	// In sync immediately after deploy.
+	result, err := d.DetectStackDrift(context.Background(), "drift-ddb-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "IN_SYNC", result.DriftStatus)
+
+	// Mutate read capacity directly in state (bypassing CloudFormation).
+	raw, err := state.Get(context.Background(), "dynamodb", "table:123456789012/drift-ddb")
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	var tbl map[string]any
+	require.NoError(t, json.Unmarshal(raw, &tbl))
+	pt := tbl["ProvisionedThroughput"].(map[string]any)
+	pt["ReadCapacityUnits"] = 99
+	mutated, _ := json.Marshal(tbl)
+	require.NoError(t, state.Put(context.Background(), "dynamodb", "table:123456789012/drift-ddb", mutated))
+
+	result, err = d.DetectStackDrift(context.Background(), "drift-ddb-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "DRIFTED", result.DriftStatus)
+	require.Len(t, result.ResourceDrifts, 1)
+	entry := result.ResourceDrifts[0]
+	assert.Equal(t, "MODIFIED", entry.DriftStatus)
+	require.Len(t, entry.PropertyDifferences, 1)
+	assert.Equal(t, "/ProvisionedThroughput/ReadCapacityUnits", entry.PropertyDifferences[0].PropertyPath)
+	assert.Equal(t, "5", entry.PropertyDifferences[0].ExpectedValue)
+	assert.Equal(t, "99", entry.PropertyDifferences[0].ActualValue)
+}
+
+// TestCFN_DriftDetection_Lambda_Modified verifies MODIFIED drift on a Lambda
+// function's Timeout changed outside CloudFormation.
+func TestCFN_DriftDetection_Lambda_Modified(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+
+	tmpl := `{"Resources": {"F": {"Type": "AWS::Lambda::Function", "Properties": {
+		"FunctionName": "drift-fn", "Runtime": "python3.12", "Handler": "index.handler",
+		"Role": "arn:aws:iam::123456789012:role/r", "Timeout": 30, "MemorySize": 256
+	}}}}`
+	_, err := d.Deploy(context.Background(), tmpl, "drift-fn-stack", nil)
+	require.NoError(t, err)
+
+	result, err := d.DetectStackDrift(context.Background(), "drift-fn-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "IN_SYNC", result.DriftStatus)
+
+	// Change Timeout directly in state.
+	key := "function:drift-fn"
+	raw, err := state.Get(context.Background(), "lambda", key)
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	var fn map[string]any
+	require.NoError(t, json.Unmarshal(raw, &fn))
+	fn["Timeout"] = 60
+	mutated, _ := json.Marshal(fn)
+	require.NoError(t, state.Put(context.Background(), "lambda", key, mutated))
+
+	result, err = d.DetectStackDrift(context.Background(), "drift-fn-stack")
+	require.NoError(t, err)
+	require.Len(t, result.ResourceDrifts, 1)
+	entry := result.ResourceDrifts[0]
+	assert.Equal(t, "MODIFIED", entry.DriftStatus)
+	require.Len(t, entry.PropertyDifferences, 1)
+	assert.Equal(t, "/Timeout", entry.PropertyDifferences[0].PropertyPath)
+	assert.Equal(t, "30", entry.PropertyDifferences[0].ExpectedValue)
+	assert.Equal(t, "60", entry.PropertyDifferences[0].ActualValue)
+}
+
+// TestCFN_DriftDetection_SQS_Modified verifies MODIFIED drift on a queue's
+// VisibilityTimeout changed outside CloudFormation, and that an undeclared
+// property does not produce drift (template-declared-only rule).
+func TestCFN_DriftDetection_SQS_Modified(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+
+	tmpl := `{"Resources": {"Q": {"Type": "AWS::SQS::Queue", "Properties": {
+		"QueueName": "drift-q", "VisibilityTimeout": 45
+	}}}}`
+	_, err := d.Deploy(context.Background(), tmpl, "drift-q-stack", nil)
+	require.NoError(t, err)
+
+	result, err := d.DetectStackDrift(context.Background(), "drift-q-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "IN_SYNC", result.DriftStatus)
+
+	// Change VisibilityTimeout directly in state.
+	key := "queue:123456789012/drift-q"
+	raw, err := state.Get(context.Background(), "sqs", key)
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	var q map[string]any
+	require.NoError(t, json.Unmarshal(raw, &q))
+	attrs, _ := q["Attributes"].(map[string]any)
+	if attrs == nil {
+		attrs = map[string]any{}
+	}
+	attrs["VisibilityTimeout"] = "90"
+	q["Attributes"] = attrs
+	mutated, _ := json.Marshal(q)
+	require.NoError(t, state.Put(context.Background(), "sqs", key, mutated))
+
+	result, err = d.DetectStackDrift(context.Background(), "drift-q-stack")
+	require.NoError(t, err)
+	require.Len(t, result.ResourceDrifts, 1)
+	entry := result.ResourceDrifts[0]
+	assert.Equal(t, "MODIFIED", entry.DriftStatus)
+	require.Len(t, entry.PropertyDifferences, 1)
+	assert.Equal(t, "/VisibilityTimeout", entry.PropertyDifferences[0].PropertyPath)
+	assert.Equal(t, "45", entry.PropertyDifferences[0].ExpectedValue)
+	assert.Equal(t, "90", entry.PropertyDifferences[0].ActualValue)
+}
+
+// TestCFN_DriftDetection_SNS_Modified verifies MODIFIED drift on a topic's
+// DisplayName changed outside CloudFormation (and that the existence checker
+// works now that the physical ID is the ARN).
+func TestCFN_DriftDetection_SNS_Modified(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+
+	tmpl := `{"Resources": {"Tp": {"Type": "AWS::SNS::Topic", "Properties": {
+		"TopicName": "drift-topic", "DisplayName": "My Topic"
+	}}}}`
+	_, err := d.Deploy(context.Background(), tmpl, "drift-topic-stack", nil)
+	require.NoError(t, err)
+
+	// Existence checker + comparator both in sync after deploy.
+	result, err := d.DetectStackDrift(context.Background(), "drift-topic-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "IN_SYNC", result.DriftStatus)
+	require.Len(t, result.ResourceDrifts, 1)
+	assert.Equal(t, "IN_SYNC", result.ResourceDrifts[0].DriftStatus)
+
+	// Change DisplayName directly in state.
+	key := "topic:123456789012/us-east-1/drift-topic"
+	raw, err := state.Get(context.Background(), "sns", key)
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	var topic map[string]any
+	require.NoError(t, json.Unmarshal(raw, &topic))
+	topic["Attributes"] = map[string]any{"DisplayName": "Renamed"}
+	mutated, _ := json.Marshal(topic)
+	require.NoError(t, state.Put(context.Background(), "sns", key, mutated))
+
+	result, err = d.DetectStackDrift(context.Background(), "drift-topic-stack")
+	require.NoError(t, err)
+	require.Len(t, result.ResourceDrifts, 1)
+	entry := result.ResourceDrifts[0]
+	assert.Equal(t, "MODIFIED", entry.DriftStatus)
+	require.Len(t, entry.PropertyDifferences, 1)
+	assert.Equal(t, "/DisplayName", entry.PropertyDifferences[0].PropertyPath)
+	assert.Equal(t, "My Topic", entry.PropertyDifferences[0].ExpectedValue)
+	assert.Equal(t, "Renamed", entry.PropertyDifferences[0].ActualValue)
+}
+
+// TestCFN_DriftDetection_IAMRole_PolicyReorderInSync verifies an IAM role whose
+// trust-policy statements are reordered (but semantically identical) does NOT
+// report drift, and that a genuine Description change does.
+func TestCFN_DriftDetection_IAMRole_Modified(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+
+	tmpl := `{"Resources": {"R": {"Type": "AWS::IAM::Role", "Properties": {
+		"RoleName": "drift-role", "Description": "original",
+		"AssumeRolePolicyDocument": {"Version": "2012-10-17", "Statement": [
+			{"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole"},
+			{"Effect": "Allow", "Principal": {"Service": "lambda.amazonaws.com"}, "Action": "sts:AssumeRole"}
+		]}
+	}}}}`
+	_, err := d.Deploy(context.Background(), tmpl, "drift-role-stack", nil)
+	require.NoError(t, err)
+
+	// In sync after deploy.
+	result, err := d.DetectStackDrift(context.Background(), "drift-role-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "IN_SYNC", result.DriftStatus)
+
+	// Reorder the stored trust-policy statements (semantically identical) and
+	// confirm this does NOT register as drift.
+	key := "role:drift-role"
+	raw, err := state.Get(context.Background(), "iam", key)
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	var role map[string]any
+	require.NoError(t, json.Unmarshal(raw, &role))
+	doc := role["AssumeRolePolicyDocument"].(map[string]any)
+	stmts := doc["Statement"].([]any)
+	stmts[0], stmts[1] = stmts[1], stmts[0]
+	doc["Statement"] = stmts
+	reordered, _ := json.Marshal(role)
+	require.NoError(t, state.Put(context.Background(), "iam", key, reordered))
+
+	result, err = d.DetectStackDrift(context.Background(), "drift-role-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "IN_SYNC", result.DriftStatus, "reordered-but-equal trust policy must not drift")
+
+	// Now change Description → genuine drift.
+	raw, err = state.Get(context.Background(), "iam", key)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, &role))
+	role["Description"] = "changed"
+	mutated, _ := json.Marshal(role)
+	require.NoError(t, state.Put(context.Background(), "iam", key, mutated))
+
+	result, err = d.DetectStackDrift(context.Background(), "drift-role-stack")
+	require.NoError(t, err)
+	require.Len(t, result.ResourceDrifts, 1)
+	entry := result.ResourceDrifts[0]
+	assert.Equal(t, "MODIFIED", entry.DriftStatus)
+	require.Len(t, entry.PropertyDifferences, 1)
+	assert.Equal(t, "/Description", entry.PropertyDifferences[0].PropertyPath)
+	assert.Equal(t, "original", entry.PropertyDifferences[0].ExpectedValue)
+	assert.Equal(t, "changed", entry.PropertyDifferences[0].ActualValue)
+}
+
+// TestCFN_DriftDetection_DeclaredOnly verifies that a property NOT declared in
+// the template does not produce drift even when live state diverges.
+func TestCFN_DriftDetection_DeclaredOnly(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+
+	// Template omits VisibilityTimeout entirely.
+	tmpl := `{"Resources": {"Q": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "declq"}}}}`
+	_, err := d.Deploy(context.Background(), tmpl, "declq-stack", nil)
+	require.NoError(t, err)
+
+	// Set a VisibilityTimeout directly in state — not declared, so not drift.
+	key := "queue:123456789012/declq"
+	raw, err := state.Get(context.Background(), "sqs", key)
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	var q map[string]any
+	require.NoError(t, json.Unmarshal(raw, &q))
+	q["Attributes"] = map[string]any{"VisibilityTimeout": "120"}
+	mutated, _ := json.Marshal(q)
+	require.NoError(t, state.Put(context.Background(), "sqs", key, mutated))
+
+	result, err := d.DetectStackDrift(context.Background(), "declq-stack")
+	require.NoError(t, err)
+	assert.Equal(t, "IN_SYNC", result.DriftStatus, "undeclared property must not produce drift")
 }

--- a/iam_policy_compare.go
+++ b/iam_policy_compare.go
@@ -1,0 +1,47 @@
+package substrate
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// policyDocumentsEqual reports whether two IAM policy documents are semantically
+// equivalent, independent of statement order. The Version must match and the set
+// of statements must be equal as multisets. Each statement is canonicalized by
+// marshaling to JSON (StringOrSlice and PolicyPrincipal already normalize
+// single-value vs. array forms on unmarshal, so equivalent statements produce
+// identical JSON), then the per-statement JSON strings are sorted before
+// comparison so statement ordering does not produce false drift.
+func policyDocumentsEqual(a, b PolicyDocument) bool {
+	if a.Version != b.Version {
+		return false
+	}
+	sa := canonicalStatements(a.Statement)
+	sb := canonicalStatements(b.Statement)
+	if len(sa) != len(sb) {
+		return false
+	}
+	for i := range sa {
+		if sa[i] != sb[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// canonicalStatements marshals each statement to JSON and returns the sorted
+// slice of JSON strings, giving an order-independent canonical form.
+func canonicalStatements(stmts []PolicyStatement) []string {
+	out := make([]string, 0, len(stmts))
+	for i := range stmts {
+		b, err := json.Marshal(stmts[i])
+		if err != nil {
+			// Fall back to a best-effort string so unequal inputs stay unequal.
+			out = append(out, "")
+			continue
+		}
+		out = append(out, string(b))
+	}
+	sort.Strings(out)
+	return out
+}

--- a/sns_plugin.go
+++ b/sns_plugin.go
@@ -247,6 +247,11 @@ func (p *SNSPlugin) createTopic(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		AccountID: ctx.AccountID,
 		Region:    ctx.Region,
 	}
+	// CreateTopic accepts initial attributes in real AWS; persist DisplayName so
+	// it round-trips and is drift-checkable.
+	if dn := req.Params["DisplayName"]; dn != "" {
+		topic.Attributes = map[string]string{"DisplayName": dn}
+	}
 	if err := p.saveTopic(goCtx, topic); err != nil {
 		return nil, fmt.Errorf("sns createTopic saveTopic: %w", err)
 	}


### PR DESCRIPTION
Completes #290 — faithful property-level `MODIFIED` drift detection across all six drift-checkable CloudFormation resource types (S3 versioning shipped earlier; this adds the rest).

## New comparators (`cfnDriftComparators`)
| Type | Properties compared |
|------|--------------------|
| DynamoDB::Table | `BillingMode`, `ProvisionedThroughput.{Read,Write}CapacityUnits` |
| Lambda::Function | `Runtime`, `Handler`, `Timeout`, `MemorySize` |
| IAM::Role | `AssumeRolePolicyDocument` (order-insensitive), `Description`, `Path` |
| SQS::Queue | `VisibilityTimeout`, `MessageRetentionPeriod`, `DelaySeconds`, `ReceiveMessageWaitTimeSeconds`, `MaximumMessageSize` |
| SNS::Topic | `DisplayName` |

## Design
- **Template-declared-only comparison**: a property is checked only when the template explicitly declares it, so deploy-applied defaults (e.g. DynamoDB `BillingMode`→PROVISIONED) never produce false drift. The existing S3 versioning comparator was aligned to this rule (it previously emitted an `ADD` diff when the template omitted versioning).
- All comparators reuse the existing `compareS3BucketDrift` pattern via a shared `cfnDriftResourceProps` helper (re-parse template → resolve intrinsics/params → read live state).
- New `policyDocumentsEqual` (`iam_policy_compare.go`) compares trust policies independent of statement order (canonical per-statement JSON, sorted), so a reordered-but-equivalent policy does not register as drift.
- To make SQS/SNS comparable (their deploy paths were name-only), `deploySQSQueue`/`deploySNSTopic` now forward declared properties, and SNS `CreateTopic` persists an initial `DisplayName` (AWS-faithful).

## Latent bugs fixed en route
- SQS, SNS, and Lambda **existence** drift-checkers used wrong state keys (spurious `/region/` component; SNS used the ARN where the key is name-based) — so those checkers were silently broken.
- `deployLambdaFunction` sent `Timeout`/`MemorySize` as **strings**, which `CreateFunction` (int fields) rejected with "invalid request body" — CFN Lambda with these properties never deployed. Now converted to int.

## Tests
One `MODIFIED` case per type (mutate live state outside CFN → assert MODIFIED + PropertyDifferences), plus a reordered-trust-policy IN_SYNC case (no false positive) and a declared-only IN_SYNC case (undeclared property diverging in state → not drift). Test harness extended to register DynamoDB/Lambda/SQS.

`make test` (race) + `make lint` clean; main-pkg coverage steady at ~79.5%. AWS property names/shapes verified against the CloudFormation resource references.

Closes #290