### PR TITLE
feat(ec2,ssm): NetworkInterface.N.* on RunInstances + managed-AMI SSM resolution

### DIFF
--- a/ec2_networkinterface_test.go
+++ b/ec2_networkinterface_test.go
@@ -1,0 +1,137 @@
+package substrate_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestEC2_RunInstances_NetworkInterface verifies that RunInstances reads the
+// subnet, security group, and AssociatePublicIpAddress from a nested
+// NetworkInterface.1.* spec (the form the AWS SDK uses when a public-IP
+// preference is set) — not just the top-level params. Tools like spawn always
+// nest these, so without this the caller's networking is silently dropped.
+func TestEC2_RunInstances_NetworkInterface(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	// Create a non-default VPC + subnet + SG so we can prove the nested fields
+	// are honored (a default subnet would assign a public IP regardless).
+	vpcID := createVPC(t, ts, "10.1.0.0/16")
+	subnetID := createSubnet(t, ts, vpcID, "10.1.1.0/24")
+	sgID := createSecurityGroup(t, ts, vpcID, "ni-sg")
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":       "RunInstances",
+		"ImageId":      "ami-12345678",
+		"InstanceType": "t3.small",
+		"MinCount":     "1",
+		"MaxCount":     "1",
+		// Networking specified ONLY in the nested NetworkInterface form.
+		"NetworkInterface.1.DeviceIndex":              "0",
+		"NetworkInterface.1.SubnetId":                 subnetID,
+		"NetworkInterface.1.SecurityGroupId.1":        sgID,
+		"NetworkInterface.1.AssociatePublicIpAddress": "true",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("RunInstances: expected 200, got %d", resp.StatusCode)
+	}
+	var run struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&run); err != nil {
+		t.Fatalf("decode RunInstances: %v", err)
+	}
+	resp.Body.Close() //nolint:errcheck
+	if len(run.Instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(run.Instances))
+	}
+	id := run.Instances[0].InstanceID
+
+	// Describe and confirm the nested subnet was used AND a public IP was
+	// assigned because AssociatePublicIpAddress=true (the subnet is non-default).
+	d := ec2Request(t, ts, map[string]string{"Action": "DescribeInstances", "InstanceId.1": id})
+	var desc struct {
+		Reservations []struct {
+			Instances []struct {
+				SubnetID        string `xml:"subnetId"`
+				PublicIPAddress string `xml:"publicIpAddress"`
+			} `xml:"instancesSet>item"`
+		} `xml:"reservationSet>item"`
+	}
+	if err := xml.NewDecoder(d.Body).Decode(&desc); err != nil {
+		t.Fatalf("decode DescribeInstances: %v", err)
+	}
+	d.Body.Close() //nolint:errcheck
+
+	if len(desc.Reservations) != 1 || len(desc.Reservations[0].Instances) != 1 {
+		t.Fatalf("expected 1 reservation/instance, got %+v", desc)
+	}
+	got := desc.Reservations[0].Instances[0]
+	if got.SubnetID != subnetID {
+		t.Errorf("subnet from NetworkInterface.1.SubnetId not honored: got %q want %q", got.SubnetID, subnetID)
+	}
+	if got.PublicIPAddress == "" {
+		t.Errorf("AssociatePublicIpAddress=true did not assign a public IP on a non-default subnet")
+	}
+}
+
+// --- small helpers (EC2 query protocol) ---
+
+func createVPC(t *testing.T, ts *httptest.Server, cidr string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": cidr})
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		VPC struct {
+			VPCID string `xml:"vpcId"`
+		} `xml:"vpc"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode CreateVpc: %v", err)
+	}
+	if out.VPC.VPCID == "" {
+		t.Fatal("CreateVpc returned empty vpcId")
+	}
+	return out.VPC.VPCID
+}
+
+func createSubnet(t *testing.T, ts *httptest.Server, vpcID, cidr string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "CreateSubnet", "VpcId": vpcID, "CidrBlock": cidr,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		Subnet struct {
+			SubnetID string `xml:"subnetId"`
+		} `xml:"subnet"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode CreateSubnet: %v", err)
+	}
+	if out.Subnet.SubnetID == "" {
+		t.Fatal("CreateSubnet returned empty subnetId")
+	}
+	return out.Subnet.SubnetID
+}
+
+func createSecurityGroup(t *testing.T, ts *httptest.Server, vpcID, name string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "CreateSecurityGroup", "VpcId": vpcID, "GroupName": name, "GroupDescription": name,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		GroupID string `xml:"groupId"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode CreateSecurityGroup: %v", err)
+	}
+	if out.GroupID == "" {
+		t.Fatal("CreateSecurityGroup returned empty groupId")
+	}
+	return out.GroupID
+}

--- a/ec2_plugin.go
+++ b/ec2_plugin.go
@@ -231,11 +231,29 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	}
 
 	keyName := req.Params["KeyName"]
+	iamInstanceProfile := req.Params["IamInstanceProfile.Name"]
+	if iamInstanceProfile == "" {
+		iamInstanceProfile = req.Params["IamInstanceProfile.Arn"]
+	}
+	userData := req.Params["UserData"]
+
 	subnetID := req.Params["SubnetId"]
 	sgID := req.Params["SecurityGroupId.1"]
 	if sgID == "" {
 		sgID = req.Params["SecurityGroupIds.1"]
 	}
+
+	// Networking can be specified either at the top level (above) or nested in a
+	// NetworkInterface spec (NetworkInterface.1.*). The AWS SDK puts SubnetId,
+	// security groups, and AssociatePublicIpAddress inside the network interface
+	// whenever a public-IP preference is set — which spawn always does. Fall back
+	// to the nested form so that subnet/SG/public-IP aren't silently dropped.
+	if subnetID == "" {
+		subnetID = req.Params["NetworkInterface.1.SubnetId"]
+	}
+	// AssociatePublicIpAddress=true forces a public IP even on a non-default
+	// subnet; "" means "use the subnet default".
+	associatePublicIP := strings.EqualFold(req.Params["NetworkInterface.1.AssociatePublicIpAddress"], "true")
 
 	// Resolve launch template parameters when no ImageId is provided directly.
 	if imageID == "" {
@@ -277,7 +295,8 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		}
 	}
 
-	// Collect all specified security group IDs.
+	// Collect all specified security group IDs, from top-level params or the
+	// nested NetworkInterface.1.* form (SecurityGroupId.M or Groups.M).
 	var securityGroupIDs []string
 	for n := 1; ; n++ {
 		id := req.Params[fmt.Sprintf("SecurityGroupId.%d", n)]
@@ -288,6 +307,18 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 			break
 		}
 		securityGroupIDs = append(securityGroupIDs, id)
+	}
+	if len(securityGroupIDs) == 0 {
+		for n := 1; ; n++ {
+			id := req.Params[fmt.Sprintf("NetworkInterface.1.SecurityGroupId.%d", n)]
+			if id == "" {
+				id = req.Params[fmt.Sprintf("NetworkInterface.1.Groups.%d", n)]
+			}
+			if id == "" {
+				break
+			}
+			securityGroupIDs = append(securityGroupIDs, id)
+		}
 	}
 	if len(securityGroupIDs) == 0 && sgID != "" {
 		securityGroupIDs = []string{sgID}
@@ -355,19 +386,21 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 
 	for i := 0; i < maxCount; i++ {
 		inst := EC2Instance{
-			InstanceID:       generateEC2InstanceID(),
-			ReservationID:    reservationID,
-			ImageID:          imageID,
-			InstanceType:     instanceType,
-			State:            EC2InstanceState{Code: 16, Name: "running"},
-			SubnetID:         subnetID,
-			PrivateIPAddress: fmt.Sprintf("172.31.%d.%d", i+1, i+10),
-			SecurityGroupIDs: filterEmpty(securityGroupIDs),
-			LaunchTime:       now,
-			AccountID:        reqCtx.AccountID,
-			Region:           reqCtx.Region,
-			KeyName:          keyName,
-			Tags:             launchTags,
+			InstanceID:         generateEC2InstanceID(),
+			ReservationID:      reservationID,
+			ImageID:            imageID,
+			InstanceType:       instanceType,
+			State:              EC2InstanceState{Code: 16, Name: "running"},
+			SubnetID:           subnetID,
+			PrivateIPAddress:   fmt.Sprintf("172.31.%d.%d", i+1, i+10),
+			SecurityGroupIDs:   filterEmpty(securityGroupIDs),
+			LaunchTime:         now,
+			AccountID:          reqCtx.AccountID,
+			Region:             reqCtx.Region,
+			KeyName:            keyName,
+			IamInstanceProfile: iamInstanceProfile,
+			UserData:           userData,
+			Tags:               launchTags,
 		}
 
 		// Look up VPCID from subnet and decide whether to assign a public IP.
@@ -378,8 +411,10 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 				inst.VPCID = subnet.VPCID
 				// Always set private DNS name.
 				inst.PrivateDNSName = ec2PrivateDNSName(inst.PrivateIPAddress, reqCtx.Region)
-				// Assign public IP for default subnets or subnets with MapPublicIPOnLaunch.
-				if subnet.IsDefault || subnet.MapPublicIPOnLaunch {
+				// Assign public IP for default subnets, subnets with
+				// MapPublicIPOnLaunch, or when the launch explicitly requested
+				// AssociatePublicIpAddress=true (the spawn #308 behavior).
+				if subnet.IsDefault || subnet.MapPublicIPOnLaunch || associatePublicIP {
 					inst.PublicIPAddress = generatePublicIP(inst.InstanceID)
 					inst.PublicDNSName = ec2PublicDNSName(inst.PublicIPAddress, reqCtx.Region)
 				}

--- a/ec2_types.go
+++ b/ec2_types.go
@@ -86,6 +86,14 @@ type EC2Instance struct {
 
 	// KeyName is the name of the key pair used to launch the instance.
 	KeyName string `json:"key_name,omitempty"`
+
+	// IamInstanceProfile is the ARN or name of the IAM instance profile attached
+	// at launch (echoed back so callers can verify it was applied).
+	IamInstanceProfile string `json:"iam_instance_profile,omitempty"`
+
+	// UserData is the base64-encoded user-data supplied at launch (stored so
+	// callers can verify it was accepted; not executed).
+	UserData string `json:"user_data,omitempty"`
 }
 
 // EC2KeyPair represents an EC2 key pair (public/private key used for SSH access).

--- a/ssm_managed_ami_test.go
+++ b/ssm_managed_ami_test.go
@@ -1,0 +1,49 @@
+package substrate_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSSMPlugin_ManagedAMIParameter verifies that GetParameter resolves the
+// AWS-managed public AMI parameters under /aws/service/* (which are not
+// user-created) to a deterministic synthetic AMI id, rather than 404. Tools
+// like spawn auto-detect their AMI via these parameters.
+func TestSSMPlugin_ManagedAMIParameter(t *testing.T) {
+	srv := newSSMTestServer(t)
+
+	const name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+
+	resp := ssmRequest(t, srv, "GetParameter", map[string]interface{}{"Name": name})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body := readSSMBody(t, resp)
+	param, ok := body["Parameter"].(map[string]interface{})
+	require.True(t, ok)
+
+	val, _ := param["Value"].(string)
+	assert.True(t, strings.HasPrefix(val, "ami-"), "managed AMI param should resolve to an ami- value, got %q", val)
+	assert.Equal(t, name, param["Name"])
+
+	// Deterministic: a second lookup returns the same value.
+	resp2 := ssmRequest(t, srv, "GetParameter", map[string]interface{}{"Name": name})
+	body2 := readSSMBody(t, resp2)
+	param2, _ := body2["Parameter"].(map[string]interface{})
+	assert.Equal(t, val, param2["Value"], "managed AMI resolution should be stable across calls")
+
+	// A user-created param still wins over the synthetic resolver.
+	ssmRequest(t, srv, "PutParameter", map[string]interface{}{
+		"Name": "/aws/service/custom-override", "Value": "explicit", "Type": "String",
+	})
+	resp3 := ssmRequest(t, srv, "GetParameter", map[string]interface{}{"Name": "/aws/service/custom-override"})
+	body3 := readSSMBody(t, resp3)
+	param3, _ := body3["Parameter"].(map[string]interface{})
+	assert.Equal(t, "explicit", param3["Value"])
+
+	// A non-managed, non-existent param still 404s.
+	resp4 := ssmRequest(t, srv, "GetParameter", map[string]interface{}{"Name": "/not/aws/service/missing"})
+	assert.Equal(t, http.StatusNotFound, resp4.StatusCode)
+}

--- a/ssm_plugin.go
+++ b/ssm_plugin.go
@@ -3,7 +3,9 @@ package substrate
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -245,6 +247,13 @@ func (p *SSMPlugin) getParameter(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return nil, err
 	}
 	if param == nil {
+		// AWS publishes managed public parameters under /aws/service/* (e.g. the
+		// latest-AMI parameters that tools resolve to discover an AMI). They're
+		// not user-created, so synthesize a deterministic value rather than 404.
+		if mp := resolveManagedParameter(name, ctx.Region); mp != nil {
+			out := map[string]interface{}{"Parameter": mp}
+			return ssmJSONResponse(http.StatusOK, out)
+		}
 		return nil, &AWSError{
 			Code:       "ParameterNotFound",
 			Message:    fmt.Sprintf("Parameter %q not found", name),
@@ -263,6 +272,37 @@ func (p *SSMPlugin) getParameter(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		},
 	}
 	return ssmJSONResponse(http.StatusOK, out)
+}
+
+// resolveManagedParameter returns a synthetic value for AWS-managed public
+// parameters under /aws/service/* that callers expect to exist without creating
+// them — primarily the latest-AMI parameters
+// (/aws/service/ami-amazon-linux-latest/*, /aws/service/ami-windows-latest/*,
+// /aws/service/canonical/ubuntu/*, /aws/service/ecs/optimized-ami/*). The AMI id
+// is deterministic per (name, region) so repeated lookups are stable. Returns
+// nil for non-managed names.
+func resolveManagedParameter(name, region string) map[string]interface{} {
+	if !strings.HasPrefix(name, "/aws/service/") {
+		return nil
+	}
+	isAMI := strings.Contains(name, "ami-") ||
+		strings.Contains(name, "/optimized-ami/") ||
+		strings.Contains(name, "/ubuntu/") ||
+		strings.Contains(name, "-latest")
+	if !isAMI {
+		return nil
+	}
+	// Deterministic 17-hex-char AMI id derived from name+region.
+	sum := sha256.Sum256([]byte(region + ":" + name))
+	amiID := "ami-" + hex.EncodeToString(sum[:])[:17]
+	return map[string]interface{}{
+		"Name":             name,
+		"Type":             "String",
+		"Value":            amiID,
+		"Version":          int64(1),
+		"ARN":              fmt.Sprintf("arn:aws:ssm:%s::parameter%s", region, name),
+		"LastModifiedDate": int64(0),
+	}
 }
 
 func (p *SSMPlugin) getParameters(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {


### PR DESCRIPTION
Two fidelity fixes that let the AWS SDK v2's standard instance-launch shape work end-to-end against substrate (needed to drive real CLIs like spawn against the emulator).

## EC2 RunInstances — honor nested NetworkInterface.1.*
The SDK puts SubnetId, security groups, and AssociatePublicIpAddress **inside** a NetworkInterface spec whenever a public-IP preference is set (which tools like spawn always do). `runInstances` only read top-level `SubnetId`/`SecurityGroupId.1`, so the caller's subnet/SG were silently dropped and public-IP assignment was accidental.
- Fall back to `NetworkInterface.1.SubnetId`, `NetworkInterface.1.SecurityGroupId.M`/`Groups.M`, `NetworkInterface.1.AssociatePublicIpAddress`.
- `AssociatePublicIpAddress=true` now forces a public IP even on a non-default subnet.
- Also store + echo `IamInstanceProfile` and `UserData` (previously dropped) so callers can verify them.

## SSM GetParameter — resolve managed /aws/service/* AMI params
AWS publishes managed public parameters (e.g. `/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64`) that aren't user-created; tools resolve them to discover an AMI. `getParameter` 404'd them. Now synthesizes a deterministic `ami-...` for the managed AMI namespace; user-created params still win; non-managed missing params still 404.

## Tests
- `TestEC2_RunInstances_NetworkInterface`: nested subnet honored + public IP assigned on a non-default subnet via AssociatePublicIpAddress.
- `TestSSMPlugin_ManagedAMIParameter`: managed-AMI resolves to ami-, stable across calls, user-override wins, non-managed still 404.
- Full existing suite green; vet clean.

Context: spore-host/spawn deep integration test suite (Tier 0 drives the real spawn binary against substrate). Related earlier substrate asks: #298, #299.