### PR TITLE
docs: articulate scope boundary, seeding, and why determinism/replay matter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Scope & philosophy documentation**: Documented substrate's defining scope
+  boundary — it models what is observable through an AWS API call (request/
+  response shapes, resource state and its transitions over the simulated clock,
+  and seedable outcomes), not what software inside a resource does. Articulated
+  that **seeding** is the mechanism that lets a deterministic emulator produce
+  different results (default nominal path; alternate error/capacity/terminal
+  outcomes seeded via control-plane endpoints and read at request time), and why
+  this determinism is preferable to container- or real-infrastructure-backed
+  approaches (reproducibility by construction, exact replay of failures, history
+  inspection — at the deliberate cost of workload-internal fidelity). Also
+  articulated *why* determinism and replay are useful capabilities (no flakes,
+  exact reproduction, time-travel inspection, testable rare paths, fast/free
+  runs, regression fixtures). Added as a "Scope" section in `CLAUDE.md` and a
+  fourth differentiator plus "What determinism and replay give you", "Seeding",
+  and "Why determinism" sections in `doc.go`.
+
 ## [v0.66.0] - 2026-06-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,56 @@
 Substrate — event-sourced AWS emulator for deterministic testing of
 AI-generated infrastructure code (CDK/CloudFormation/Terraform).
 
+## Scope (what substrate models — and what it does not)
+
+**Substrate models what is observable through an AWS API call, not what software
+inside a resource does.** A plugin's job is to make every API *observation* a
+caller can make accurate, seedable, and time-ordered — never to execute the
+workload behind the API.
+
+- In scope: request/response shapes, error codes, resource state and its
+  transitions over the simulated clock (e.g. an instance moving
+  `pending → running`, a job reporting `Failed` with a seeded reason, a command
+  invocation going `Pending → InProgress → Success`), and seedable outcomes that
+  let a consumer's poll/retry/wait loop be tested.
+- Out of scope: actually running the work — executing user-data or cloud-init,
+  running a Lambda's code, performing an inference, running a training job,
+  bootstrapping a node. Capture such inputs as recorded intent and expose a
+  **seedable** success/failure/completion signal; do not model the internal
+  semantics of the workload.
+
+This boundary is also *why* deterministic replay works: API observations can be
+recorded as events and replayed identically, whereas resource internals are
+nondeterministic (real time, scheduling, I/O). When a proposed feature would
+require modeling box-internals, it belongs in a different tool or test tier, not
+in substrate. Apply this test before adding behaviour: *is this observable
+through an API call, or is it resource-internal?*
+
+**Seeding is how a deterministic emulator produces different results.** A new
+operation defaults to its nominal success path; alternate outcomes (errors,
+capacity failures, terminal job states, specific result sets, time-ordered
+transitions) are exposed as **seedable** values that a plugin reads from a
+control-plane endpoint at request time — never as nondeterministic behaviour.
+This is what lets a test exercise the rare/slow/failure paths a consumer's
+retry/poll/wait loops exist to handle, instantly and reproducibly. Follow the
+established seed pattern (`POST`/`DELETE /v1/{service}/...`, keyed by an ID or
+`"*"` wildcard; see Bedrock job status, SageMaker training-job status, Athena/
+RedshiftData/Timestream results) when adding a new outcome.
+
+The payoff over container- or real-infrastructure-backed approaches is
+reproducibility by construction: same inputs (including seeds) → same outputs, a
+failing run replays exactly, and state is inspectable at any point in history —
+none of which survive real timing, scheduling, and network. The deliberate cost
+is workload-internal fidelity, which is out of scope per the boundary above.
+
+Why that reproducibility matters in practice: no test flakes (a red test is a
+real signal, not timing noise), exact reproduction of failures from recorded
+events (no heisenbugs), time-travel inspection of state at any point, instant and
+repeatable coverage of rare paths (capacity/throttle/terminal states via seeds),
+and fast, network-free, zero-spend runs suitable for validating IaC before it
+touches AWS. Recorded runs can be exported as standalone regression fixtures. See
+`doc.go` for the fuller articulation.
+
 ## Work tracking
 
 All tasks are GitHub Issues assigned to Milestones. Before starting any

--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@
 //
 // # Overview
 //
-// Substrate's three core differentiators:
+// Substrate's core differentiators:
 //
 //  1. Deterministic reproducibility: event sourcing + seeded RNG + time control
 //     means the same test inputs always produce the same outputs.
@@ -13,6 +13,75 @@
 //
 //  3. Cost visibility: real AWS pricing is tracked per operation so you know
 //     projected monthly costs before the bill arrives.
+//
+//  4. API-surface scope: substrate models what is observable through an AWS API
+//     call — request/response shapes, resource state and its transitions over
+//     the simulated clock, and seedable outcomes — not what software inside a
+//     resource does. It never executes the workload behind the API (user-data,
+//     Lambda code, an inference, a training job); such inputs are captured as
+//     recorded intent with a seedable result. This is also why replay is
+//     deterministic: API observations are recordable and replayable, whereas
+//     resource internals are not.
+//
+// # What determinism and replay give you
+//
+// Determinism and the event log are not ends in themselves; they unlock
+// capabilities that flaky, stateful test infrastructure cannot offer:
+//
+//   - No flakes: the same inputs always produce the same outputs, so a green
+//     test stays green and a red test is a real signal, not timing noise. CI
+//     does not retry-until-pass.
+//   - Exact reproduction: a failure replays identically from its recorded
+//     events, so "works on my machine" and heisenbugs disappear — you debug the
+//     exact run, not an approximation of it.
+//   - Time-travel inspection: step backward through request history and read
+//     resource state at any point, to see precisely where a sequence of API
+//     calls diverged from what was expected.
+//   - Testable rare paths: seeded outcomes make capacity failures, throttling,
+//     terminal job states, and slow transitions instant and repeatable, so the
+//     retry/poll/wait logic that only runs on the unhappy path is actually
+//     covered (see Seeding, below).
+//   - Fast and free: no network, no real account, no provisioning latency or
+//     spend — suitable for unit tests and tight inner loops, and for validating
+//     AI-generated infrastructure code before it ever touches AWS.
+//   - Regression fixtures: a recorded run can be replayed as a fixture and
+//     exported as a standalone test, turning a once-seen scenario into a
+//     permanent guard.
+//
+// # Seeding: determinism without sacrificing coverage
+//
+// Determinism does not mean every test sees the same result. Seeding is the
+// mechanism that lets a deterministic emulator produce different outcomes on
+// demand. By default an operation returns its nominal success path; a test seeds
+// an alternate outcome through a control-plane endpoint, and the plugin reads
+// that seed at request time. The same launch can therefore be made to return
+// InsufficientInstanceCapacity, a training job to come back Failed with a
+// CapacityError, or a query to return a specific result set — each chosen by the
+// test, each fully reproducible. Crucially, the failure, capacity, and timing
+// paths a consumer's retry/poll/wait loops exist to handle are exactly the paths
+// that are rare, slow, or impossible to trigger on demand against real AWS;
+// seeding makes them first-class, instant, and deterministic.
+//
+// # Why determinism (vs. containers or real infrastructure)
+//
+// The same property is reachable three ways, with very different trade-offs:
+//
+//   - Real AWS / LocalStack-with-containers run actual workloads, so behavior
+//     depends on wall-clock timing, process scheduling, network, and the live
+//     state of a remote account. Failure and edge-case paths are hard to trigger
+//     and rarely reproduce; a flake cannot be replayed.
+//   - Hand-written mocks are deterministic but bespoke per test, drift from the
+//     real API, and cannot model state transitions or be inspected over time.
+//
+// Substrate records every request as an immutable event over a simulated clock,
+// so a run is reproducible by construction: the same inputs (including seeds)
+// always yield the same outputs, a failing run replays exactly for debugging,
+// and you can step backward through history to inspect state at any point — none
+// of which a container-backed or real-infrastructure approach offers. The cost
+// is fidelity to workload internals, which is deliberately out of scope (see
+// differentiator 4): substrate is the fast, deterministic tier for exercising
+// how code drives and reacts to the AWS API, not for validating what runs inside
+// a resource.
 //
 // # Quick Start
 //


### PR DESCRIPTION
Docs-only. Codifies the design philosophy discussed — *why* substrate says no to certain things, not just what it does.

## What's documented
- **Scope boundary**: substrate models what is observable through an AWS API call (request/response shapes, resource state and its transitions over the simulated clock, seedable outcomes) — **not** what software inside a resource does (it never executes user-data, Lambda code, an inference, a training job). Captured as a one-line test for future features: *is this observable through an API call, or is it resource-internal?*
- **Seeding is what lets a deterministic emulator produce different results**: default = nominal success path; alternate outcomes (errors, capacity failures, terminal job states, timing) are seeded via control-plane endpoints and read at request time. This is what makes the rare/slow/failure paths a consumer's retry/poll/wait loops exist to handle testable, instant, and reproducible.
- **Why this determinism beats containers / real infrastructure**: reproducibility by construction (same inputs incl. seeds → same outputs), exact replay of failures, history inspection — none of which survive real timing/scheduling/network. Deliberate cost: workload-internal fidelity (out of scope).
- **Why determinism & replay are useful in practice**: no flakes, exact failure reproduction, time-travel inspection, testable rare paths, fast/free/network-free runs, exportable regression fixtures.

The through-line: the scope boundary and the deterministic-replay guarantee are the same line viewed from two sides — API observations are recordable/replayable; resource internals are not.

## Changes
- `CLAUDE.md`: new "Scope" section.
- `doc.go`: fourth differentiator (API-surface scope) + "What determinism and replay give you", "Seeding", and "Why determinism (vs. containers or real infrastructure)" sections.
- `CHANGELOG.md`: `[Unreleased]` entry.

No behaviour change; `go build` + `go vet` clean.