### PR TITLE
fix(ec2): apply all DescribeInstances filters, not just Filter.1 (#305)

### DIFF
--- a/ec2_describefilters_test.go
+++ b/ec2_describefilters_test.go
@@ -1,0 +1,130 @@
+package substrate_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// describeQuery issues DescribeInstances with the given params and returns the
+// set of instance IDs in the response.
+func describeQuery(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DescribeInstances: expected 200, got %d", resp.StatusCode)
+	}
+	var desc struct {
+		Reservations []struct {
+			Instances []struct {
+				InstanceID string `xml:"instanceId"`
+			} `xml:"instancesSet>item"`
+		} `xml:"reservationSet>item"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&desc); err != nil {
+		t.Fatalf("decode DescribeInstances: %v", err)
+	}
+	resp.Body.Close() //nolint:errcheck
+	var ids []string
+	for _, r := range desc.Reservations {
+		for _, i := range r.Instances {
+			ids = append(ids, i.InstanceID)
+		}
+	}
+	return ids
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEC2_DescribeInstances_MultiFilter is the regression for substrate #305:
+// DescribeInstances must apply EVERY Filter.N (AND-combined), not just
+// Filter.1, and must honor tag: filters. Real callers (e.g. spawn list
+// --state running) lead with a tag filter and put instance-state-name second,
+// so reading only Filter.1 silently dropped the state filter and let
+// terminated instances leak into a running-only query.
+func TestEC2_DescribeInstances_MultiFilter(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	// Launch one instance tagged spawn:managed=true.
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                          "RunInstances",
+		"ImageId":                         "ami-12345678",
+		"InstanceType":                    "t3.small",
+		"MinCount":                        "1",
+		"MaxCount":                        "1",
+		"TagSpecification.1.ResourceType": "instance",
+		"TagSpecification.1.Tag.1.Key":    "spawn:managed",
+		"TagSpecification.1.Tag.1.Value":  "true",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("RunInstances: expected 200, got %d", resp.StatusCode)
+	}
+	var run struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&run); err != nil {
+		t.Fatalf("decode RunInstances: %v", err)
+	}
+	resp.Body.Close() //nolint:errcheck
+	if len(run.Instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(run.Instances))
+	}
+	id := run.Instances[0].InstanceID
+
+	// Filter as spawn does: tag filter FIRST, state filter SECOND.
+	runningFilter := map[string]string{
+		"Action":           "DescribeInstances",
+		"Filter.1.Name":    "tag:spawn:managed",
+		"Filter.1.Value.1": "true",
+		"Filter.2.Name":    "instance-state-name",
+		"Filter.2.Value.1": "running",
+	}
+
+	// Before terminate: the running instance must be returned.
+	if ids := describeQuery(t, ts, runningFilter); !contains(ids, id) {
+		t.Fatalf("running instance %s not returned by [tag, state=running] filter; got %v", id, ids)
+	}
+
+	// Terminate it.
+	term := ec2Request(t, ts, map[string]string{"Action": "TerminateInstances", "InstanceId.1": id})
+	if term.StatusCode != http.StatusOK {
+		t.Fatalf("TerminateInstances: expected 200, got %d", term.StatusCode)
+	}
+	term.Body.Close() //nolint:errcheck
+
+	// After terminate: the SAME [tag, state=running] filter must NOT return it.
+	if ids := describeQuery(t, ts, runningFilter); contains(ids, id) {
+		t.Errorf("#305: terminated instance %s still returned by state=running filter; got %v", id, ids)
+	}
+
+	// A state=terminated filter (state first this time) must return it,
+	// proving filter order is irrelevant.
+	terminatedFilter := map[string]string{
+		"Action":           "DescribeInstances",
+		"Filter.1.Name":    "instance-state-name",
+		"Filter.1.Value.1": "terminated",
+	}
+	if ids := describeQuery(t, ts, terminatedFilter); !contains(ids, id) {
+		t.Errorf("terminated instance %s not returned by state=terminated filter; got %v", id, ids)
+	}
+
+	// A tag filter that doesn't match must exclude it.
+	noMatch := map[string]string{
+		"Action":           "DescribeInstances",
+		"Filter.1.Name":    "tag:spawn:managed",
+		"Filter.1.Value.1": "false",
+	}
+	if ids := describeQuery(t, ts, noMatch); contains(ids, id) {
+		t.Errorf("instance %s returned by non-matching tag filter; got %v", id, ids)
+	}
+}

--- a/ec2_plugin.go
+++ b/ec2_plugin.go
@@ -494,8 +494,7 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 
 func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := extractIndexedParams(req.Params, "InstanceId")
-	filterNames := extractIndexedParams(req.Params, "Filter.1.Value")
-	filterKey := req.Params["Filter.1.Name"]
+	filters := extractEC2Filters(req.Params)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "instance:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
@@ -552,8 +551,8 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		if len(ids) > 0 && !containsStr(ids, inst.InstanceID) {
 			continue
 		}
-		// Filter by state name.
-		if filterKey == "instance-state-name" && len(filterNames) > 0 && !containsStr(filterNames, inst.State.Name) {
+		// Filter by the request's Filter.N.* parameters (AND-combined).
+		if !matchesEC2InstanceFilters(&inst, filters) {
 			continue
 		}
 
@@ -2316,6 +2315,68 @@ func extractEC2Filters(params map[string]string) map[string][]string {
 		}
 	}
 	return filters
+}
+
+// matchesEC2InstanceFilters reports whether inst satisfies every filter in
+// filters (AND-combined; within a single filter the allowed values are OR'd,
+// matching EC2 semantics). Supported keys cover what real callers use; an
+// unrecognized key matches nothing (safer than silently ignoring it, which is
+// what caused terminated instances to leak through a running-only query).
+func matchesEC2InstanceFilters(inst *EC2Instance, filters map[string][]string) bool {
+	for name, vals := range filters {
+		if len(vals) == 0 {
+			continue
+		}
+		var got string
+		switch {
+		case name == "instance-state-name":
+			got = inst.State.Name
+		case name == "instance-id":
+			got = inst.InstanceID
+		case name == "instance-type":
+			got = inst.InstanceType
+		case name == "vpc-id":
+			got = inst.VPCID
+		case name == "subnet-id":
+			got = inst.SubnetID
+		case name == "key-name":
+			got = inst.KeyName
+		case name == "image-id":
+			got = inst.ImageID
+		case name == "tag-key":
+			matched := false
+			for _, t := range inst.Tags {
+				if containsStr(vals, t.Key) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false
+			}
+			continue
+		case strings.HasPrefix(name, "tag:"):
+			key := strings.TrimPrefix(name, "tag:")
+			matched := false
+			for _, t := range inst.Tags {
+				if t.Key == key && containsStr(vals, t.Value) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false
+			}
+			continue
+		default:
+			// Unknown filter key: match nothing.
+			return false
+		}
+		if !containsStr(vals, got) {
+			return false
+		}
+	}
+	return true
 }
 
 // containsStr reports whether s is in the slice.


### PR DESCRIPTION
## What

`describeInstances` only read `Filter.1.Name`/`Filter.1.Value.*` and only handled the `instance-state-name` key — `Filter.2+` and `tag:*` filters were silently dropped. Real callers (e.g. `spawn list --state running`) lead with a `tag:spawn:managed` filter and put `instance-state-name` second, so the state filter never applied and **terminated instances leaked into a running-only query**.

## Fix

- Parse all filters via the existing `extractEC2Filters` helper.
- New `matchesEC2InstanceFilters` AND-combines every `Filter.N` (values within a filter OR'd, per EC2 semantics).
- Supported keys: `instance-state-name`, `instance-id`, `instance-type`, `vpc-id`, `subnet-id`, `key-name`, `image-id`, `tag-key`, `tag:<key>`. Unknown keys match nothing (safer than silently passing).

## Test

`TestEC2_DescribeInstances_MultiFilter` launches + terminates an instance and asserts a `[tag:spawn:managed=true, instance-state-name=running]` filter returns it before terminate and excludes it after — and that order is irrelevant. Verified the test FAILS on the old single-filter code with the exact #305 symptom and passes on the fix. Full suite + `go vet` green.

Fixes #305