### PR TITLE
fix: DescribeInstances multi-filter + tag: support (#305); bump Go toolchain to 1.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fourth differentiator plus "What determinism and replay give you", "Seeding",
   and "Why determinism" sections in `doc.go`.
 
+### Fixed
+- **`DescribeInstances` multi-filter and `tag:` support (#305)**: `describeInstances`
+  only read `Filter.1` and only honoured `instance-state-name`, so any second-or-later
+  filter and all `tag:` filters were silently dropped — returning instances the
+  caller had explicitly filtered out (e.g. a terminated instance for a
+  `running`-only query when a `tag:` filter came first). It now uses the shared
+  `extractEC2Filters` helper and AND-combines every filter via the new
+  `ec2InstanceMatchesFilters`. Supported keys: `instance-state-name`,
+  `instance-state-code`, `instance-id`, `instance-type`, `image-id`, `vpc-id`,
+  `subnet-id`, `key-name`, `tag:<key>`, and `tag-key`. Unknown filter keys match
+  nothing rather than passing silently. Closes #305.
+
+### Security
+- **Go toolchain bumped to 1.26.4 (`go.mod`, `test/e2e/go.mod`)**: pins the
+  patched standard library to clear call-reachable stdlib advisories flagged by
+  `govulncheck` — GO-2026-5039 (`net/textproto` header escaping, reachable via
+  `http.Server.Serve`) and GO-2026-5037 (`crypto/x509` hostname parsing). CI
+  reads the toolchain from `go.mod`, so the vulnerability check now passes with
+  zero call-reachable vulnerabilities.
+
 ## [v0.66.0] - 2026-06-02
 
 ### Added

--- a/ec2_plugin.go
+++ b/ec2_plugin.go
@@ -492,10 +492,66 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 	return ec2XMLResponse(http.StatusOK, resp)
 }
 
+// ec2InstanceMatchesFilters reports whether an instance satisfies every supplied
+// DescribeInstances filter (filters are AND-combined; each filter's values are
+// OR-combined). Supported keys cover the filters real callers use; an unknown
+// key matches nothing (returns false) rather than being silently ignored, so a
+// filtered query never returns resources the caller meant to exclude.
+func ec2InstanceMatchesFilters(inst EC2Instance, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2InstanceMatchesFilter(inst, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2InstanceMatchesFilter evaluates a single filter against an instance.
+func ec2InstanceMatchesFilter(inst EC2Instance, name string, values []string) bool {
+	// tag:<key> — instance has a tag with that key whose value is in values.
+	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
+		for _, t := range inst.Tags {
+			if t.Key == tagKey && containsStr(values, t.Value) {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch name {
+	case "instance-state-name":
+		return containsStr(values, inst.State.Name)
+	case "instance-state-code":
+		return containsStr(values, strconv.Itoa(inst.State.Code))
+	case "instance-id":
+		return containsStr(values, inst.InstanceID)
+	case "instance-type":
+		return containsStr(values, inst.InstanceType)
+	case "image-id":
+		return containsStr(values, inst.ImageID)
+	case "vpc-id":
+		return containsStr(values, inst.VPCID)
+	case "subnet-id":
+		return containsStr(values, inst.SubnetID)
+	case "key-name":
+		return containsStr(values, inst.KeyName)
+	case "tag-key":
+		// Instance has a tag with any of the requested keys (any value).
+		for _, t := range inst.Tags {
+			if containsStr(values, t.Key) {
+				return true
+			}
+		}
+		return false
+	default:
+		// Unknown filter key: match nothing rather than silently passing.
+		return false
+	}
+}
+
 func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := extractIndexedParams(req.Params, "InstanceId")
-	filterNames := extractIndexedParams(req.Params, "Filter.1.Value")
-	filterKey := req.Params["Filter.1.Name"]
+	filters := extractEC2Filters(req.Params)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "instance:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
@@ -552,8 +608,8 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		if len(ids) > 0 && !containsStr(ids, inst.InstanceID) {
 			continue
 		}
-		// Filter by state name.
-		if filterKey == "instance-state-name" && len(filterNames) > 0 && !containsStr(filterNames, inst.State.Name) {
+		// Apply all DescribeInstances filters, AND-combined.
+		if !ec2InstanceMatchesFilters(inst, filters) {
 			continue
 		}
 

--- a/ec2_plugin_test.go
+++ b/ec2_plugin_test.go
@@ -12,6 +12,7 @@ import (
 
 	substrate "github.com/scttfrdmn/substrate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newEC2TestServer builds a minimal Server with the EC2 plugin registered.
@@ -3264,4 +3265,116 @@ func TestEC2_DefaultVPC_IGWRoute(t *testing.T) {
 	body := readBody(t, desc)
 	assert.Contains(t, body, "0.0.0.0/0")
 	assert.Contains(t, body, "igw-")
+}
+
+// TestEC2_DescribeInstances_MultiFilter is the #305 regression: DescribeInstances
+// must parse every Filter.N (not just Filter.1), AND-combine them, and support
+// tag:/instance-state-name/instance-id filtering regardless of filter order.
+func TestEC2_DescribeInstances_MultiFilter(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	// Launch a tagged instance.
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-12345678", "InstanceType": "t3.micro",
+		"MinCount": "1", "MaxCount": "1",
+		"TagSpecification.1.ResourceType": "instance",
+		"TagSpecification.1.Tag.1.Key":    "spawn:managed",
+		"TagSpecification.1.Tag.1.Value":  "true",
+	})
+	var runResult struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&runResult))
+	resp.Body.Close() //nolint:errcheck
+	require.Len(t, runResult.Instances, 1)
+	id := runResult.Instances[0].InstanceID
+
+	// describeRunning issues the real-client filter order: tag first, state second.
+	describeRunning := func() []string {
+		r := ec2Request(t, ts, map[string]string{
+			"Action":           "DescribeInstances",
+			"Filter.1.Name":    "tag:spawn:managed",
+			"Filter.1.Value.1": "true",
+			"Filter.2.Name":    "instance-state-name",
+			"Filter.2.Value.1": "running",
+		})
+		var res struct {
+			Instances []struct {
+				InstanceID string `xml:"instanceId"`
+			} `xml:"reservationSet>item>instancesSet>item"`
+		}
+		require.NoError(t, xml.NewDecoder(r.Body).Decode(&res))
+		r.Body.Close() //nolint:errcheck
+		out := make([]string, 0, len(res.Instances))
+		for _, in := range res.Instances {
+			out = append(out, in.InstanceID)
+		}
+		return out
+	}
+
+	// Before terminate: the running, tagged instance is returned.
+	assert.Contains(t, describeRunning(), id, "running tagged instance should match both filters")
+
+	// Terminate it.
+	rt := ec2Request(t, ts, map[string]string{"Action": "TerminateInstances", "InstanceId.1": id})
+	rt.Body.Close() //nolint:errcheck
+
+	// After terminate: excluded by the instance-state-name=running filter
+	// (which is Filter.2 — the bug was that Filter.2 was never read).
+	assert.NotContains(t, describeRunning(), id, "terminated instance must be excluded by the state filter")
+}
+
+// TestEC2_DescribeInstances_FilterOrderIndependent verifies state filtering works
+// whether instance-state-name is Filter.1 or Filter.2.
+func TestEC2_DescribeInstances_FilterOrderIndependent(t *testing.T) {
+	ts := newEC2TestServer(t)
+	run := ec2Request(t, ts, map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-1", "InstanceType": "t3.micro",
+		"MinCount": "1", "MaxCount": "1",
+		"TagSpecification.1.ResourceType": "instance",
+		"TagSpecification.1.Tag.1.Key":    "k", "TagSpecification.1.Tag.1.Value": "v",
+	})
+	var rr struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(run.Body).Decode(&rr))
+	run.Body.Close() //nolint:errcheck
+	id := rr.Instances[0].InstanceID
+
+	count := func(params map[string]string) int {
+		params["Action"] = "DescribeInstances"
+		r := ec2Request(t, ts, params)
+		var res struct {
+			Instances []struct {
+				InstanceID string `xml:"instanceId"`
+			} `xml:"reservationSet>item>instancesSet>item"`
+		}
+		require.NoError(t, xml.NewDecoder(r.Body).Decode(&res))
+		r.Body.Close() //nolint:errcheck
+		return len(res.Instances)
+	}
+
+	// State filter first.
+	assert.Equal(t, 1, count(map[string]string{
+		"Filter.1.Name": "instance-state-name", "Filter.1.Value.1": "running",
+		"Filter.2.Name": "tag:k", "Filter.2.Value.1": "v",
+	}))
+	// State filter second.
+	assert.Equal(t, 1, count(map[string]string{
+		"Filter.1.Name": "tag:k", "Filter.1.Value.1": "v",
+		"Filter.2.Name": "instance-state-name", "Filter.2.Value.1": "running",
+	}))
+	// Non-matching tag value excludes it.
+	assert.Equal(t, 0, count(map[string]string{
+		"Filter.1.Name": "tag:k", "Filter.1.Value.1": "other",
+	}))
+	// Unknown filter key matches nothing (does not silently pass).
+	assert.Equal(t, 0, count(map[string]string{
+		"Filter.1.Name": "some-unknown-filter", "Filter.1.Value.1": "x",
+	}))
+	_ = id
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/scttfrdmn/substrate
 
 go 1.26
 
+toolchain go1.26.4
+
 require (
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/spf13/afero v1.15.0

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,6 +2,8 @@ module github.com/scttfrdmn/substrate/test/e2e
 
 go 1.26
 
+toolchain go1.26.4
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.5
 	github.com/aws/aws-sdk-go-v2/config v1.28.0


### PR DESCRIPTION
Two related correctness/security fixes.

## #305 — DescribeInstances filter bug (Fixed)
`describeInstances` only read `Filter.1` and only honoured `instance-state-name`, so any `Filter.2+` and all `tag:` filters were **silently dropped** — returning instances the caller had explicitly filtered out. Order-dependent: a `running`-only query led by a `tag:` filter would still return terminated instances. Found by spawn's Tier 0 CLI-against-substrate suite.

Fix: adopt the shared `extractEC2Filters` helper (the same one `describeRouteTables` adopted in #293) and AND-combine every filter via a new `ec2InstanceMatchesFilters`. Supported keys: `instance-state-name`, `instance-state-code`, `instance-id`, `instance-type`, `image-id`, `vpc-id`, `subnet-id`, `key-name`, `tag:<key>`, `tag-key`. **Unknown filter keys match nothing** rather than silently passing (the cardinal sin the issue calls out).

Tests: the exact acceptance scenario (launch+tag → describe with `[tag:spawn:managed=true, instance-state-name=running]` returns it, then terminate → same query excludes it), plus filter-order independence and the unknown-key case. Existing EC2 suite stays green.

Note: `availability-zone`/`placement.availability-zone` is **not** supported — `EC2Instance` has no AZ field today; it falls to the match-nothing path. Out of scope here; can be added with the field later.

## Go toolchain → 1.26.4 (Security)
The `Go Vulnerability Check` was failing on `main` (and on PR #304) due to call-reachable **stdlib** advisories — GO-2026-5039 (`net/textproto`, reachable via `http.Server.Serve`) and GO-2026-5037 (`crypto/x509`) — fixed in go1.26.4 while CI built with 1.26.3. Added `toolchain go1.26.4` to `go.mod` and `test/e2e/go.mod`; CI reads `go-version-file: go.mod`, so it now installs the patched toolchain. Verified locally: `govulncheck ./...` → **0 call-reachable vulnerabilities**.

`make test` (race) + `make lint` clean on 1.26.4.

Closes #305