### PR TITLE
docs(security): void v0.67.0 advisory + document repo protection rulesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Repository protection rulesets + `v0.67.0` void advisory**: Added GitHub
+  rulesets enforcing the release contract server-side — `refs/tags/v*` tags are
+  immutable (no move/update/delete) and `main` requires changes via pull request
+  (no direct or force pushes), with no bypass actors. Documented `v0.67.0` as a
+  void, out-of-order tag (points to an ancestor of `v0.66.0`/`v0.66.1`; created
+  by a stray manual tag, not the release process; no GitHub release). It is left
+  in place per the tag-immutability rule and **not** re-pointed; the version
+  number is burned and the next minor release is **v0.68.0**. Consumers must use
+  `v0.66.1` or later. See `SECURITY.md`.
+
 ## [v0.66.1] - 2026-06-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,14 +87,29 @@ Use **Added / Changed / Deprecated / Removed / Fixed / Security** sections.
 
 ## Releasing
 
-1. Move `## [Unreleased]` entries to a new `## [vX.Y.Z] - YYYY-MM-DD` section.
+**A release tag is cut only by the steps below, never as a side effect of
+merging a feature.** Merging a PR must not create or push a tag. A version tag is
+created only after its `## [vX.Y.Z]` CHANGELOG section exists, and its version
+must be strictly greater than the latest existing tag (`git tag --sort=-v:refname
+| head -1`) — never an ancestor commit or an out-of-order number. (A stray
+out-of-order tag, `v0.67.0`, was created this way once; it is burned and
+documented as void in `SECURITY.md`. The next minor release is **v0.68.0**.)
+
+`main` is protected by a GitHub ruleset: all changes land via PR (no direct
+pushes), and a separate ruleset makes `refs/tags/v*` immutable (no move/delete).
+These enforce the rules below server-side — do not attempt to bypass them.
+
+1. Move `## [Unreleased]` entries to a new `## [vX.Y.Z] - YYYY-MM-DD` section
+   (via a PR — `main` cannot be pushed to directly).
 2. Add the comparison link at the bottom of `CHANGELOG.md`.
-3. Tag: `git tag -s vX.Y.Z -m "vX.Y.Z"` then `git push origin vX.Y.Z`.
+3. After the changelog PR merges, tag the merge commit:
+   `git tag -s vX.Y.Z -m "vX.Y.Z"` then `git push origin vX.Y.Z`.
    **Never move or re-cut a published tag.** Go's checksum database
    (`sum.golang.org`) permanently records a tag's hash on first fetch; moving the
    tag changes the content but not the recorded hash, which breaks `go.sum`
    verification for every consumer (see `SECURITY.md`, #296). Fix any release
-   mistake by cutting a new patch version, never by re-tagging.
+   mistake by cutting a new patch version, never by re-tagging. The tag ruleset
+   will reject a move or delete regardless.
 4. Close the issues the release resolves. A `(#N)` reference in a commit or PR
    **title** only links — it does not auto-close. Use a `Closes #N` / `Fixes #N`
    keyword in the PR **body** (or the merged commit message body), or close the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,8 +51,50 @@ tags are an isolated incident, not an ongoing compromise.
   tag can set `GOFLAGS=-insecure` or `GONOSUMCHECK`/`GONOSUMDB` — but the correct
   fix is to move off the poisoned versions.
 
-### Prevention
+## Out-of-order tag advisory
+
+### Void tag: v0.67.0 — do not use; skipped in versioning
+
+`v0.67.0` was tagged out of order: it points at commit `d4a93f2` (the #303
+NetworkInterface/SSM change), which is an **ancestor** of `v0.66.0` and
+`v0.66.1`. As a result the tag's content is *older* than — and a strict subset
+of — the `v0.66.x` releases: it predates the CFN drift-detection work (#290),
+the scope/philosophy documentation, the `DescribeInstances` filter fix (#305),
+and the Go 1.26.4 security toolchain bump. It was created by a stray manual
+`git tag` during the #303 merge, not by the documented release process, and has
+**no GitHub release and no CHANGELOG entry**.
+
+It is **not poisoned** (the content was never mutated; its hash matches the
+transparency log), but it is misleading and must not be depended on:
+
+```
+github.com/scttfrdmn/substrate v0.67.0 h1:p8nwUALuzlN6XDCKfCIQImgY28V17zqgZLi4MKjlPJ8=
+github.com/scttfrdmn/substrate v0.67.0/go.mod h1:0l7emfinozw6VVLToCq2EeEm1iuMJurSws+gHkfEu6Y=
+```
+
+### Resolution
+
+- **Consumers:** do not use `v0.67.0`. Use `v0.66.1` or later. A consumer that
+  accidentally pinned `v0.67.0` should `go get github.com/scttfrdmn/substrate@latest`.
+- The tag is **left in place** (per the immutability rule — `sum.golang.org` has
+  already recorded it and deleting it would break anyone who fetched it). It is
+  **not** re-pointed.
+- **The version number 0.67.0 is burned.** The next minor release skips it and
+  is `v0.68.0`.
+
+## Prevention
 
 Published git tags are immutable by contract. The release process
 (`CLAUDE.md` → Releasing) creates a signed tag and never moves it; any mistake
 in a release is corrected by cutting a new patch version, never by re-tagging.
+
+This is now enforced server-side by GitHub repository rulesets, not just by
+convention:
+
+- **Tag ruleset** on `refs/tags/v*`: blocks tag *deletion*, *update*, and
+  *non-fast-forward* — a published version tag cannot be moved or removed by
+  anyone (including admins and automation).
+- **Branch ruleset** on `main`: requires changes to land via pull request and
+  blocks direct pushes, force-pushes, and branch deletion, with no bypass
+  actors. This prevents unreviewed direct commits and stray tags-on-merge of the
+  kind that produced `v0.67.0`.


### PR DESCRIPTION
Addresses the stray `v0.67.0` tag and hardens the repo against recurrence.

## Background
Another session shipped #303 and **manually tagged `v0.67.0`** out of order — it points to commit `d4a93f2`, an *ancestor* of `v0.66.0`/`v0.66.1`, so its content is older than the current release. It has no GitHub release and no changelog entry. The repo is public, so `sum.golang.org` has already recorded the tag (`h1:p8nwUALuzlN6XDC...`) — meaning per the project's tag-immutability rule it **must not** be deleted or re-pointed.

## Fix (this PR — docs)
- **`SECURITY.md`**: new "Out-of-order tag advisory" — `v0.67.0` is void (left in place, not re-cut); version 0.67.0 is **burned**; next minor release is **v0.68.0**; consumers use `v0.66.1`+. Expanded "Prevention" with the rulesets below.
- **`CLAUDE.md` → Releasing**: tags are cut only via the documented flow (never as a side effect of merging), must be strictly greater than the latest tag and have a matching `## [vX.Y.Z]` changelog section. Notes that `main` is PR-only and `v*` tags are immutable via rulesets.
- **`CHANGELOG.md`**: Unreleased Security entry.

## Protection (already applied server-side, not in this diff)
- **Tag ruleset** on `refs/tags/v*`: blocks deletion / update / non-fast-forward → published version tags are immutable.
- **Branch ruleset** on `main`: requires PR (0 approvals), blocks direct/force push and deletion, **0 bypass actors** (applies to admins and agents too).

This PR is itself the first exercise of the new `main` protection — it could not have been pushed directly.

No code change.