### PR TITLE
chore(release): v0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.68.0] - 2026-06-02
+
+This release intentionally skips `v0.67.0` (a void, out-of-order tag — see below
+and `SECURITY.md`) and supersedes it as the highest semver tag, so that
+`go get github.com/scttfrdmn/substrate@latest` once again resolves to current
+code rather than the void tag. No source change versus `v0.66.1`; the entries
+below are the released set.
+
 ### Security
 - **Repository protection rulesets + `v0.67.0` void advisory**: Added GitHub
   rulesets enforcing the release contract server-side — `refs/tags/v*` tags are
@@ -1806,6 +1814,7 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.66.1...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.68.0...HEAD
+[v0.68.0]: https://github.com/scttfrdmn/substrate/compare/v0.66.1...v0.68.0
 [v0.66.1]: https://github.com/scttfrdmn/substrate/compare/v0.66.0...v0.66.1
 [v0.66.0]: https://github.com/scttfrdmn/substrate/compare/v0.65.0...v0.66.0


### PR DESCRIPTION
Cuts **v0.68.0** to reclaim `go get @latest`.

## Why
The Go module proxy resolves `@latest` to the **highest semver tag**, ignoring GitHub "release" status. Because the void out-of-order tag **v0.67.0** outranks v0.66.1, `go get github.com/scttfrdmn/substrate@latest` currently returns v0.67.0 (older, ancestor-commit content). Documentation alone can't fix that — a `@latest` consumer never reads SECURITY.md.

Publishing v0.68.0 makes it the highest semver tag, so `@latest` resolves to current code again. The void v0.67.0 tag stays in place (immutable) but is no longer served by default.

## What
Changelog-only: `[Unreleased]` → `## [v0.68.0]`, with a note explaining the skip of v0.67.0. **No source change versus v0.66.1** — the tree is what `main` is already at (all of v0.66.x's fixes plus the protection-ruleset advisory). The released set is the rulesets + `v0.67.0` void advisory entry.

After merge, the merge commit will be tagged `v0.68.0` (signed) per the protected release flow.

Skips v0.67.0 intentionally (burned). See `SECURITY.md`.