### PR TITLE
docs: rewrite README — clearer what/why, HTTP-first flow, current facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,27 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/scttfrdmn/substrate)](https://goreportcard.com/report/github.com/scttfrdmn/substrate)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-Substrate is an event-sourced AWS emulator that validates AI-generated
-CloudFormation, CDK, and Terraform before you deploy to AWS.
+## What is Substrate?
+
+Substrate is an **event-sourced AWS emulator** for testing the infrastructure
+code that drives AWS — CloudFormation, CDK, Terraform, and any SDK or CLI call —
+**deterministically, offline, and with cost visibility**, before you deploy to a
+real account.
+
+It models **what is observable through an AWS API call** — request/response
+shapes, resource state and how it transitions over a simulated clock, error
+codes, and seedable outcomes — *not* what software inside a resource does. It
+never runs your user-data, your Lambda code, an inference, or a training job;
+those are recorded as intent with a **seedable** result. That boundary is what
+makes every run reproducible: API observations can be recorded as events and
+replayed identically, whereas a real workload's timing, scheduling, and I/O
+cannot.
+
+**Use it two ways:**
+- **As a server** — run `substrate`, point any AWS SDK/CLI at `http://localhost:4566`.
+  This is how most consumers use it.
+- **As a Go test harness** — `import ".../emulator"`, spin up an in-process server
+  or deploy a CloudFormation template directly, no HTTP needed.
 
 ## The Problem
 
@@ -18,15 +37,20 @@ AI generates infrastructure code → ??? → Deploy to AWS → $$$
                              This is where you find out
 ```
 
-LocalStack hides bugs (no quotas, no realistic consistency, no cost tracking).
-Substrate catches them.
+LocalStack and container-backed emulators run real workloads, so behaviour
+depends on wall-clock timing, scheduling, and network — failure and edge-case
+paths are hard to trigger and rarely reproduce. Substrate trades workload-internal
+fidelity for **determinism**: it makes the API surface accurate and every outcome
+seedable, so the rare paths your retry/poll/wait logic exists to handle become
+first-class, instant, and repeatable.
 
-## Three Killer Features
+## Why Substrate
 
-### 1. Deterministic Reproducibility
+### 1. Deterministic reproducibility
 
-Every AWS request is an immutable event. Same inputs + same seed = same outputs,
-every time.
+Every AWS request is an immutable event over a simulated clock. Same inputs +
+same seed = same outputs, every time — no flakes, and a failing run replays
+identically for debugging.
 
 ```go
 session, _ := engine.StartRecording(ctx, "test-lambda-timeout")
@@ -39,18 +63,19 @@ for range 1000 {
 }
 ```
 
-### 2. Time-Travel Debugging
+### 2. Time-travel debugging
 
-Step backward through request history and inspect service state at any point.
+Step backward through recorded request history and inspect service state at any
+point — see exactly where a sequence of API calls diverged from what you expected.
 
 ```go
 replay := engine.Replay(ctx, "failing-test")
-engine.JumpToEvent(ctx, 87)       // jump to failure
-engine.StepBackward(ctx)          // step back
-state, _ := engine.InspectState(ctx, "iam") // see what broke
+engine.JumpToEvent(ctx, 87)                  // jump to the failure
+engine.StepBackward(ctx)                      // step back
+state, _ := engine.InspectState(ctx, "iam")   // see what broke
 ```
 
-### 3. Cost Visibility Before Deploy
+### 3. Cost visibility before deploy
 
 Real AWS pricing tracked per operation. Know your monthly bill before it arrives.
 
@@ -63,7 +88,18 @@ Total: $1,247.50/month
 WARNING: High S3 PUT rate — consider batching (save ~99%)
 ```
 
-## Getting Started
+### 4. Seedable outcomes (API-surface scope)
+
+Determinism doesn't mean every test sees the same result. Substrate defaults to
+the nominal success path; a test **seeds** an alternate outcome — an
+`InsufficientInstanceCapacity` on launch, a training job that comes back `Failed`
+with a `CapacityError`, a specific query result — and the plugin returns it at
+request time, fully reproducibly. The failure, capacity, and timing paths that
+are rare or impossible to trigger against real AWS become trivial to test.
+
+## Quick Start (server)
+
+The primary way to use Substrate is as a drop-in AWS endpoint.
 
 ### Install
 
@@ -71,106 +107,73 @@ WARNING: High S3 PUT rate — consider batching (save ~99%)
 go install github.com/scttfrdmn/substrate/cmd/substrate@latest
 ```
 
-Or build from source:
+Or build from source / run with Docker:
 
 ```bash
-git clone https://github.com/scttfrdmn/substrate
-cd substrate
+git clone https://github.com/scttfrdmn/substrate && cd substrate
 make build          # produces ./bin/substrate
-```
 
-Or run with Docker:
-
-```bash
 docker run -p 4566:4566 ghcr.io/scttfrdmn/substrate:latest
 ```
 
-### Start the server
+### Run the server
 
 ```bash
 substrate server
 # Listening on :4566
 ```
 
-Configuration via `substrate.yaml` or environment variables (see `substrate.yaml.example`).
+Configuration via `substrate.yaml` or environment variables (see
+[`substrate.yaml.example`](substrate.yaml.example)).
 
-### Use in Go tests (recommended)
+### Point your AWS client at it
 
-The fastest way to test Go code against Substrate is `StartTestServer`, which
-spins up an in-process server on a random port and registers a `t.Cleanup` to
-shut it down automatically:
-
-```go
-func TestMyInfra(t *testing.T) {
-    ts := substrate.StartTestServer(t)
-    defer ts.Close()
-
-    cfg, _ := config.LoadDefaultConfig(context.Background(),
-        config.WithRegion("us-east-1"),
-        config.WithBaseEndpoint(ts.URL),
-        config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
-    )
-    // Use cfg with any AWS SDK v2 client...
-}
-```
-
-### Configure your AWS SDK
-
-#### AWS CLI
+<details open>
+<summary><strong>AWS CLI</strong></summary>
 
 ```bash
 aws iam create-user --user-name alice \
-    --endpoint-url http://localhost:4566 \
-    --region us-east-1 \
-    --no-sign-request
+    --endpoint-url http://localhost:4566 --region us-east-1 --no-sign-request
 ```
 
-Or set permanently in `~/.aws/config`:
+Or set a profile in `~/.aws/config`:
 
 ```ini
 [profile substrate]
 region = us-east-1
 endpoint_url = http://localhost:4566
 ```
+</details>
 
-Then:
-```bash
-aws --profile substrate iam list-users
-```
-
-#### Go SDK v2
+<details>
+<summary><strong>Go SDK v2</strong></summary>
 
 ```go
-import (
-    "github.com/aws/aws-sdk-go-v2/config"
-    "github.com/aws/aws-sdk-go-v2/service/iam"
-)
-
 cfg, _ := config.LoadDefaultConfig(context.TODO(),
     config.WithRegion("us-east-1"),
     config.WithBaseEndpoint("http://localhost:4566"),
-    config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-        "test", "test", "",
-    )),
+    config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
 )
 client := iam.NewFromConfig(cfg)
 ```
+</details>
 
-#### Python (boto3)
+<details>
+<summary><strong>Python (boto3)</strong></summary>
 
 ```python
 import boto3
 
 client = boto3.client(
-    "iam",
-    region_name="us-east-1",
+    "iam", region_name="us-east-1",
     endpoint_url="http://localhost:4566",
-    aws_access_key_id="test",
-    aws_secret_access_key="test",
+    aws_access_key_id="test", aws_secret_access_key="test",
 )
 ```
+</details>
 
-#### Node.js (AWS SDK v3)
+<details>
+<summary><strong>Node.js (AWS SDK v3)</strong></summary>
 
 ```javascript
 import { IAMClient } from "@aws-sdk/client-iam";
@@ -181,121 +184,102 @@ const client = new IAMClient({
   credentials: { accessKeyId: "test", secretAccessKey: "test" },
 });
 ```
+</details>
 
-### Supported services
+## Use as a Go test harness
 
-| Service | Protocol | Key Operations | Betty CFN Types |
-|---------|----------|----------------|-----------------|
-| IAM | Query | CreateUser, CreateRole, CreatePolicy, AttachRolePolicy (25 ops) | AWS::IAM::Role, AWS::IAM::Policy |
-| STS | Query | GetCallerIdentity, AssumeRole, GetSessionToken | — |
-| S3 | REST/XML | CreateBucket, PutObject, GetObject, ListObjectsV2, multipart (16 ops) | AWS::S3::Bucket |
-| Lambda | REST/JSON | CreateFunction, InvokeFunction, UpdateFunctionCode (12 ops) | AWS::Lambda::Function |
-| SQS | Query | CreateQueue, SendMessage, ReceiveMessage, DeleteMessage (10 ops) | AWS::SQS::Queue |
-| DynamoDB | JSON | CreateTable, PutItem, GetItem, Query, Scan, UpdateItem (15 ops) | AWS::DynamoDB::Table |
-| EC2 | Query | RunInstances, DescribeInstances, CreateVpc, CreateSubnet (20 ops) | AWS::EC2::VPC, AWS::EC2::Instance |
-| ELB v2 | Query | CreateLoadBalancer, CreateTargetGroup, CreateListener (10 ops) | AWS::ElasticLoadBalancingV2::LoadBalancer |
-| Route 53 | REST/XML | CreateHostedZone, ChangeResourceRecordSets (6 ops) | AWS::Route53::HostedZone |
-| Resource Groups Tagging | JSON | GetResources, TagResources, UntagResources | — |
-| SNS | Query | CreateTopic, Publish, Subscribe, Unsubscribe (10 ops) | AWS::SNS::Topic |
-| Secrets Manager | JSON | CreateSecret, GetSecretValue, PutSecretValue (8 ops) | AWS::SecretsManager::Secret |
-| SSM Parameter Store | JSON | GetParameter, PutParameter, DeleteParameter (6 ops) | AWS::SSM::Parameter |
-| KMS | JSON | CreateKey, Encrypt, Decrypt, GenerateDataKey (8 ops) | AWS::KMS::Key |
-| CloudWatch Logs | JSON | CreateLogGroup, CreateLogStream, PutLogEvents (8 ops) | AWS::Logs::LogGroup |
-| EventBridge | JSON | PutEvents, CreateEventBus, PutRule (8 ops) | AWS::Events::Rule |
-| CloudWatch | Query | PutMetricAlarm, GetMetricStatistics, DescribeAlarms (6 ops) | AWS::CloudWatch::Alarm |
-| ACM | JSON | RequestCertificate, DescribeCertificate, DeleteCertificate (5 ops) | AWS::CertificateManager::Certificate |
-| API Gateway (REST) | REST/JSON | CreateRestApi, CreateResource, PutMethod, CreateDeployment (12 ops) | AWS::ApiGateway::RestApi |
-| API Gateway v2 (HTTP) | REST/JSON | CreateApi, CreateRoute, CreateIntegration, CreateStage (8 ops) | AWS::ApiGatewayV2::Api |
-| Step Functions | JSON | CreateStateMachine, StartExecution, DescribeExecution (6 ops) | AWS::StepFunctions::StateMachine |
-| ECR | JSON | CreateRepository, PutImage, GetAuthorizationToken (6 ops) | AWS::ECR::Repository |
-| ECS | JSON | CreateCluster, CreateService, RegisterTaskDefinition, RunTask (10 ops) | AWS::ECS::Cluster |
-| Cognito User Pools | JSON | CreateUserPool, AdminCreateUser, InitiateAuth (10 ops) | AWS::Cognito::UserPool |
-| Cognito Identity | JSON | CreateIdentityPool, GetCredentialsForIdentity (4 ops) | AWS::Cognito::IdentityPool |
-| Kinesis Data Streams | JSON | CreateStream, PutRecord, PutRecords, GetRecords (8 ops) | AWS::Kinesis::Stream |
-| CloudFront | REST/XML | CreateDistribution, GetDistribution, UpdateDistribution (6 ops) | AWS::CloudFront::Distribution |
-| RDS | Query | CreateDBInstance, CreateDBSnapshot, ModifyDBInstance (8 ops) | AWS::RDS::DBInstance |
-| ElastiCache | Query | CreateCacheCluster, CreateReplicationGroup (6 ops) | AWS::ElastiCache::CacheCluster |
-| EFS | REST/JSON | CreateFileSystem, CreateMountTarget, CreateAccessPoint (6 ops) | AWS::EFS::FileSystem |
-| Glue | JSON | CreateDatabase, CreateTable, CreateJob, StartJobRun (10 ops) | AWS::Glue::Database |
-| Cost Explorer | JSON | GetCostAndUsage, GetCostForecast | — |
-| Budgets | JSON | CreateBudget, DescribeBudget, UpdateBudget, DeleteBudget (6 ops) | AWS::Budgets::Budget |
-| Health | JSON | DescribeEvents, DescribeEventDetails (stub) | — |
-| Organizations | JSON | CreateOrganization, DescribeOrganization, CreateAccount (6 ops) | — |
-| SES v2 | REST/JSON | CreateEmailIdentity, SendEmail, GetEmailIdentity, ListEmailIdentities (5 ops) | AWS::SES::EmailIdentity |
-| Kinesis Data Firehose | JSON | CreateDeliveryStream, PutRecord, PutRecordBatch, ListDeliveryStreams (6 ops) | AWS::KinesisFirehose::DeliveryStream |
-
-### Known limitations
-
-- **Cross-service IAM enforcement**: IAM policies are evaluated for IAM and STS operations.
-  Per-operation enforcement for other services is planned.
-- **Persistence**: In-memory by default; SQLite persistence available via `EventStoreConfig{Backend: "sqlite"}`.
-- **Authentication**: SigV4 verification is opt-in (disabled by default for ease of testing).
-  Enable via `ServerOptions.VerifySignatures = true`.
-- **Partial operation coverage**: Each service emulates the most common operations.
-  See [docs/services.md](docs/services.md) for the full operation list.
-
----
-
-## Status
-
-| Milestone | Status |
-|-----------|--------|
-| v0.1.0 — v0.9.0 | Complete |
-| v0.10.0 — Lambda, SQS, S3 notifications | Complete |
-| v0.11.0 — DynamoDB | Complete |
-| v0.13.0 — EC2/VPC, fault injection, multi-region | Complete |
-| v0.15.0 — ELB v2, Route 53 | Complete |
-| v0.17.0 — Observability (metrics, tracing) | Complete |
-| v0.18.0 — CloudWatch Logs, EventBridge, CloudWatch Alarms | Complete |
-| v0.19.0–v0.23.0 — ACM, API Gateway, Step Functions, ECS, ECR, Cognito, Kinesis, CloudFront | Complete |
-| v0.25.0–v0.26.0 — RDS, ElastiCache, EFS, Glue | Complete |
-| v0.27.0 — Cost Explorer, Budgets, Health, Organizations | Complete |
-| [v0.28.0](https://github.com/scttfrdmn/substrate/milestone/28) — SES v2, Firehose, Documentation | In Progress |
-
-See [CHANGELOG.md](CHANGELOG.md) for full release history.
-
-## Documentation
-
-- [Getting Started](docs/getting-started.md) — install, first test, 15-minute tutorial
-- [Service Reference](docs/services.md) — all 37 plugins with operation lists
-- [Testing Guide](docs/testing-guide.md) — `StartTestServer`, recording/replay, cost assertions
-- [Endpoint Configuration](docs/endpoint-configuration.md) — SDK and tool configuration
-
-## Quick Start
-
-```bash
-go get github.com/scttfrdmn/substrate
-```
+For Go code, the fastest path is `StartTestServer`, which spins up an in-process
+server on a random port and registers a `t.Cleanup` to shut it down.
 
 ```go
-import "github.com/scttfrdmn/substrate"
+import "github.com/scttfrdmn/substrate/emulator"
 
-store    := substrate.NewEventStore(substrate.EventStoreConfig{Enabled: true, Backend: "memory"})
-state    := substrate.NewMemoryStateManager()
-tc       := substrate.NewTimeController(time.Now())
-registry := substrate.NewPluginRegistry()
+func TestMyInfra(t *testing.T) {
+    ts := emulator.StartTestServer(t)
 
-betty := substrate.NewBettyClient(registry, store, state, tc, logger)
+    cfg, _ := config.LoadDefaultConfig(context.Background(),
+        config.WithRegion("us-east-1"),
+        config.WithBaseEndpoint(ts.URL),
+        config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+    )
+    // Use cfg with any AWS SDK v2 client...
+}
+```
 
-// Deploy a CloudFormation template — all in-process, no HTTP server needed.
-result, _ := betty.Deploy(ctx, cfnTemplate, substrate.Intent{MaxCost: 1.0})
+Or deploy a CloudFormation template and validate it entirely in-process, no HTTP
+server required, via the **Betty** client:
 
-// Record and validate operations.
+```go
+import "github.com/scttfrdmn/substrate/emulator"
+
+store    := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
+state    := emulator.NewMemoryStateManager()
+tc       := emulator.NewTimeController(time.Now())
+registry := emulator.NewPluginRegistry()
+
+betty := emulator.NewBettyClient(registry, store, state, tc, logger)
+
+result, _ := betty.Deploy(ctx, cfnTemplate, emulator.Intent{MaxCost: 1.0})
+
 session, _ := betty.StartRecording(ctx, "my-test")
 // ... run operations against the emulator ...
 report, _ := betty.StopRecording(ctx, session)
 fmt.Printf("status=%s cost=$%.4f\n", report.PassFail, report.Cost.Total)
 ```
 
-See [`examples/betty_workflow/main.go`](examples/betty_workflow/main.go) for a complete runnable example.
+> The Go import path is `github.com/scttfrdmn/substrate/emulator`. Installing the
+> CLI (`.../cmd/substrate@latest`) is unaffected.
+
+See [`examples/betty_workflow/main.go`](examples/betty_workflow/main.go) for a
+complete runnable example.
+
+## Supported services
+
+Substrate ships **63 built-in service plugins** spanning compute, storage,
+networking, databases, messaging, analytics, ML, security, and management:
+
+- **Compute & containers** — EC2, Lambda, ECS, ECR, Batch, EKS-adjacent
+- **Storage & data** — S3, EFS, FSx, DynamoDB, RDS, Redshift, ElastiCache, Timestream
+- **Networking** — VPC/EC2, ELBv2, Route 53, CloudFront, API Gateway (REST & HTTP)
+- **Messaging & streaming** — SQS, SNS, EventBridge, Kinesis, Firehose, MSK
+- **ML & analytics** — SageMaker, Bedrock Runtime, Athena, Glue, EMR Serverless, OpenSearch, QuickSight, HealthOmics
+- **Security & identity** — IAM, STS, KMS, Secrets Manager, ACM, Cognito, SSO, WAFv2, RAM
+- **Management & cost** — CloudWatch (+ Logs), CloudTrail, Organizations, Budgets, Cost Explorer, Service Quotas, SSM, Health, the CodeSuite, Step Functions, Backup, Transfer
+
+Many integrate with **Betty** for CloudFormation deployment. See the
+[Service Reference](docs/services.md) for the authoritative, per-operation list.
+
+### Known limitations
+
+- **Cross-service IAM enforcement** — policies are evaluated for IAM and STS;
+  per-operation enforcement for other services is partial.
+- **Persistence** — in-memory by default; SQLite available via
+  `EventStoreConfig{Backend: "sqlite"}`.
+- **Authentication** — SigV4 verification is opt-in (off by default for testing
+  ease); enable with `ServerOptions.VerifySignatures = true`.
+- **Workload internals are out of scope by design** — Substrate models the API
+  surface, not what runs inside a resource (see *What is Substrate?*).
+
+## Status
+
+Current release: **v0.68.0**. See [Releases](https://github.com/scttfrdmn/substrate/releases)
+and [CHANGELOG.md](CHANGELOG.md) for full history.
+
+## Documentation
+
+- **[Getting Started](docs/getting-started.md)** — install, first test, 15-minute tutorial
+- **[Service Reference](docs/services.md)** — all 63 plugins with operation lists
+- **[Testing Guide](docs/testing-guide.md)** — `StartTestServer`, recording/replay, cost assertions
+- **[Endpoint Configuration](docs/endpoint-configuration.md)** — SDK and tool configuration
 
 ## Development
 
 ```bash
-make test      # run tests with race detector
+make test      # run tests with the race detector
 make lint      # golangci-lint
 make coverage  # coverage report
 make build     # build the substrate binary
+make e2e       # end-to-end tests
 ```
 
 Requirements: Go 1.26+, [golangci-lint](https://golangci-lint.run/).
@@ -303,8 +287,9 @@ Requirements: Go 1.26+, [golangci-lint](https://golangci-lint.run/).
 ## Contributing
 
 Issues and pull requests welcome. All work is tracked in
-[GitHub Issues](https://github.com/scttfrdmn/substrate/issues) and organised
-into [Milestones](https://github.com/scttfrdmn/substrate/milestones).
+[GitHub Issues](https://github.com/scttfrdmn/substrate/issues) and organised into
+[Milestones](https://github.com/scttfrdmn/substrate/milestones). `main` is
+protected — changes land via pull request.
 
 ## License
 


### PR DESCRIPTION
**Part B of 3** (reorg → README → docs site). Builds on the merged `emulator/` reorg (#310).

## What changed
- **New "What is Substrate?" opener** framing the defining idea: it models the *AWS API surface* (not workload internals), and *seeding* is what lets a deterministic emulator produce different outcomes. Pulled from the scope/philosophy framing in `doc.go`/`CLAUDE.md`.
- **Four differentiators** (was three): added *seedable outcomes / API-surface scope* alongside deterministic replay, time-travel, and cost visibility.
- **Reordered for the real reader flow**: what it is → the problem → why → **server quick-start first** (how every consumer actually uses it) → Go test harness. SDK config snippets (CLI/Go/boto3/Node) consolidated behind collapsible `<details>`.
- **Fixed staleness**: 37 → **63** services; "v0.28.0 in progress" → current **v0.68.0**; replaced the hand-maintained per-service table (which drifts) with a grouped summary + link to `docs/services.md` as source of truth; replaced the milestone table with a Releases/CHANGELOG link.
- **Updated code samples** to the post-reorg import path `github.com/scttfrdmn/substrate/emulator` and `emulator.X` symbols.

## Verification
All referenced `emulator.*` symbols confirmed to exist (`StartTestServer`, `NewBettyClient`, `NewEventStore`, `Intent`, …); all in-repo doc links resolve. No code changes.

Part C (VitePress docs site matching spore-host's look, deployed via GitHub Pages) follows as a separate PR.