### PR TITLE
docs: articulate AI-infra fit and how Substrate compares

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,54 @@ AI generates infrastructure code → ??? → Deploy to AWS → $$$
                              This is where you find out
 ```
 
-LocalStack and container-backed emulators run real workloads, so behaviour
-depends on wall-clock timing, scheduling, and network — failure and edge-case
-paths are hard to trigger and rarely reproduce. Substrate trades workload-internal
-fidelity for **determinism**: it makes the API surface accurate and every outcome
-seedable, so the rare paths your retry/poll/wait logic exists to handle become
-first-class, instant, and repeatable.
+AI generates infrastructure code *at volume*, inside generate → test → fix loops.
+That changes what a test harness has to do — and it's where most AWS emulators
+fall down.
 
-## Why Substrate
+## Why Substrate for AI-generated infrastructure
+
+A generate-and-verify loop has needs a human-paced workflow doesn't have:
+
+- **Determinism, because flakes mislead the loop.** A non-deterministic failure is
+  a *false signal an agent acts on* — wasting fix cycles chasing timing noise.
+  Substrate records every request as an immutable event over a simulated clock, so
+  a failing run is real and replays identically. No retry-until-green.
+- **Free, fast, offline, so you can run it on every generation.** No real account,
+  no provisioning latency, no spend, no blast radius. Suitable for tight inner
+  loops and CI on every candidate the model produces.
+- **Cost visibility as a machine-gradeable guardrail.** An AI has no instinct for
+  bill shock. Substrate prices each operation, so you get a projected dollar figure
+  *before* deploy — and can gate on it: `betty.Deploy(ctx, tmpl, Intent{MaxCost: 1.0})`
+  fails the run if generated infra would blow a budget.
+- **Seedable failure paths, to verify the error handling the code claims to have.**
+  Generated code is full of retry/poll/wait logic for capacity errors, throttling,
+  and terminal states. Substrate lets you seed exactly those outcomes on demand, so
+  the unhappy paths are actually exercised — not just assumed.
+
+## How it compares
+
+Substrate is a **different tier** from container emulators and real accounts, not a
+drop-in replacement. It trades workload-execution fidelity for determinism,
+replayability, and cost insight — the fast inner-loop tier.
+
+| | **Substrate** | LocalStack | moto | Real AWS |
+|---|:---:|:---:|:---:|:---:|
+| Deterministic replay | ✅ | ❌ | partial | ❌ |
+| Time-travel debugging | ✅ | ❌ | ❌ | ❌ |
+| Cost visibility before deploy | ✅ | ❌ | ❌ | after the bill |
+| Seedable failure / capacity / timing paths | ✅ | partial | partial | ❌ |
+| Runs your actual workload code | ❌ *(by design)* | ✅ | ❌ | ✅ |
+| Language-agnostic (any SDK/CLI over HTTP) | ✅ | ✅ | Python-first | ✅ |
+| No account · offline · free | ✅ | ✅ | ✅ | ❌ |
+
+The one ❌ is deliberate: Substrate models **what is observable through an AWS API
+call**, not what software inside a resource does (see
+[Scope & Philosophy](docs/scope.md)). If you need to execute your Lambda's code or
+boot a real container, reach for LocalStack or a real account; if you need to test
+*how your infrastructure code drives and reacts to the AWS API* — fast,
+deterministically, and on every AI-generated candidate — that's Substrate.
+
+## Core capabilities
 
 ### 1. Deterministic reproducibility
 

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -74,3 +74,41 @@ The same testing need is reachable three ways, with very different trade-offs:
 The deliberate cost is fidelity to workload internals, which is out of scope:
 Substrate is the fast, deterministic tier for exercising how code *drives and
 reacts to* the AWS API — not for validating what runs inside a resource.
+
+## How it compares
+
+Substrate is a **different tier** from container emulators and real accounts, not
+a drop-in replacement for them. It trades workload-execution fidelity for
+determinism, replayability, and cost insight.
+
+| | **Substrate** | LocalStack | moto | Real AWS |
+|---|:---:|:---:|:---:|:---:|
+| Deterministic replay | ✅ | ❌ | partial | ❌ |
+| Time-travel debugging | ✅ | ❌ | ❌ | ❌ |
+| Cost visibility before deploy | ✅ | ❌ | ❌ | after the bill |
+| Seedable failure / capacity / timing paths | ✅ | partial | partial | ❌ |
+| Runs your actual workload code | ❌ *(by design)* | ✅ | ❌ | ✅ |
+| Language-agnostic (any SDK/CLI over HTTP) | ✅ | ✅ | Python-first | ✅ |
+| No account · offline · free | ✅ | ✅ | ✅ | ❌ |
+
+The single ❌ is the scope boundary above, by design. If you need to **execute**
+your Lambda's code or boot a real container, reach for LocalStack or a real
+account. If you need to test **how your infrastructure code drives and reacts to
+the AWS API** — fast, deterministically, and on every change — that is exactly
+what Substrate is for.
+
+### Why this fits AI-generated infrastructure
+
+AI generates infrastructure code at volume, inside generate → test → fix loops,
+and those loops need what this tier provides:
+
+- **Determinism**, because a flaky failure is a false signal an agent acts on —
+  wasting fix cycles chasing timing noise rather than real bugs.
+- **Free, fast, and offline**, so verification can run on *every* generated
+  candidate without a real account, provisioning latency, or spend.
+- **Cost visibility as a machine-gradeable guardrail** — `Intent{MaxCost}` lets a
+  deploy fail when generated infra would blow a budget, a check an AI has no
+  instinct for.
+- **Seedable failure paths**, so the retry/poll/wait logic generated code claims
+  to have is actually exercised against capacity errors, throttling, and terminal
+  states — not merely assumed.


### PR DESCRIPTION
Makes two arguments the README previously only asserted — explicit, grounded, and honest. Added to **both** the README and the docs **Scope & Philosophy** page.

## 1. Why it suits AI-generated infrastructure
AI generates IaC *at volume* inside generate → test → fix loops, which need:
- **Determinism** — a flaky failure is a false signal an agent acts on, wasting fix cycles.
- **Free / fast / offline** — runnable on every generated candidate, no account/spend/latency.
- **Cost as a machine-gradeable guardrail** — `Intent{MaxCost}` fails a deploy that would blow a budget (an AI has no bill-shock instinct).
- **Seedable failure paths** — actually exercise the retry/poll/wait logic generated code claims to have.

## 2. How it compares
An **honest trade-off** table vs LocalStack / moto / Real AWS that *includes where Substrate is weaker* — it doesn't run your workload code, **by design**. Framed as "a different tier," not "better than," consistent with the scope boundary. The one deliberate ❌ links to Scope & Philosophy.

Replaces the old throwaway "LocalStack hides bugs" line. Renamed the differentiators heading `Why Substrate` → `Core capabilities` so the new subsection owns the "why."

Docs build clean (strict link check passes). Deploys to Pages on merge.