### PR TITLE
fix(s3): ListObjectsV2 must not surface delete markers as live objects (#316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.68.1] - 2026-06-04
+
+### Fixed
+- S3: `ListObjectsV2` (and `ListObjects`) no longer surfaces delete markers as live objects on versioning-enabled buckets. `DeleteObjects` correctly inserted delete markers but `loadObjectEntry` did not filter them, causing `aws s3 ls` to show objects that `GetObject` correctly returned 404 for (#316).
+
 ## [v0.68.0] - 2026-06-02
 
 This release intentionally skips `v0.67.0` (a void, out-of-order tag — see below
@@ -1814,7 +1819,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.68.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.68.1...HEAD
+[v0.68.1]: https://github.com/scttfrdmn/substrate/compare/v0.68.0...v0.68.1
 [v0.68.0]: https://github.com/scttfrdmn/substrate/compare/v0.66.1...v0.68.0
 [v0.66.1]: https://github.com/scttfrdmn/substrate/compare/v0.66.0...v0.66.1
 [v0.66.0]: https://github.com/scttfrdmn/substrate/compare/v0.65.0...v0.66.0

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -1437,6 +1437,9 @@ func (p *S3Plugin) loadObjectEntry(ctx context.Context, bucket, key string) (*ob
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return nil, fmt.Errorf("unmarshal object %s/%s: %w", bucket, key, err)
 	}
+	if obj.IsDeleteMarker {
+		return nil, nil
+	}
 	return &objectEntryItem{
 		Key:          key,
 		LastModified: obj.LastModified.UTC().Format(time.RFC3339),

--- a/emulator/s3_plugin_test.go
+++ b/emulator/s3_plugin_test.go
@@ -829,6 +829,41 @@ func TestS3_DeleteObjects_Quiet(t *testing.T) {
 	assert.Empty(t, result.Deleted)
 }
 
+// TestS3_DeleteObjects_Versioned_HiddenFromList is a regression test for #316:
+// DeleteObjects on a versioned bucket inserts delete markers; ListObjectsV2
+// must not surface those markers as live objects.
+func TestS3_DeleteObjects_Versioned_HiddenFromList(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/ver-del-bucket", nil, nil)
+	s3Request(t, srv, http.MethodPut, "/ver-del-bucket?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+	s3Request(t, srv, http.MethodPut, "/ver-del-bucket/key1", []byte("a"), nil)
+	s3Request(t, srv, http.MethodPut, "/ver-del-bucket/key2", []byte("b"), nil)
+
+	deleteXML := []byte(`<Delete><Object><Key>key1</Key></Object><Object><Key>key2</Key></Object></Delete>`)
+	w := s3Request(t, srv, http.MethodPost, "/ver-del-bucket?delete", deleteXML,
+		map[string]string{"Content-Type": "application/xml"})
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// GetObject must return 404 (delete marker present).
+	assert.Equal(t, http.StatusNotFound, s3Request(t, srv, http.MethodGet, "/ver-del-bucket/key1", nil, nil).Code)
+
+	// ListObjectsV2 must show zero live objects — delete markers are not live objects.
+	w = s3Request(t, srv, http.MethodGet, "/ver-del-bucket?list-type=2", nil, nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var listResult struct {
+		KeyCount int `xml:"KeyCount"`
+		Contents []struct {
+			Key string `xml:"Key"`
+		} `xml:"Contents"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &listResult))
+	assert.Equal(t, 0, listResult.KeyCount, "delete markers must not appear in ListObjectsV2")
+	assert.Empty(t, listResult.Contents)
+}
+
 func TestS3_ListObjectsV2_Delimiter(t *testing.T) {
 	t.Parallel()
 	srv, _ := newS3TestServer(t)


### PR DESCRIPTION
## Summary

- `loadObjectEntry` (used by `ListObjectsV2` and `ListObjects`) did not filter entries where `IsDeleteMarker` is true
- On versioning-enabled buckets, `DeleteObjects` inserts delete markers rather than removing the state key; without the filter, `aws s3 ls` showed objects that `GetObject` correctly returned 404 for
- Added the same `IsDeleteMarker` guard that `getObject` already carries

## Changes

- `emulator/s3_plugin.go`: three-line fix in `loadObjectEntry` — return `nil, nil` when `obj.IsDeleteMarker` is true
- `emulator/s3_plugin_test.go`: regression test `TestS3_DeleteObjects_Versioned_HiddenFromList`
- `CHANGELOG.md`: move entry to `[v0.68.1]`

## Test plan

- [ ] `go test ./emulator/ -run TestS3_DeleteObjects_Versioned_HiddenFromList` — new regression test passes
- [ ] `go test ./emulator/ -run TestS3` — all existing S3 tests still pass
- [ ] `go test ./emulator/ -count=1` — full suite clean

Closes #316