### PR TITLE
fix(s3): GetObject/HeadObject return 404/405 for delete markers (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- S3: `GetObject` and `HeadObject` now return the correct error for delete markers
+  instead of surfacing the marker (#318, follow-up to #316). A plain request whose
+  current version is a delete marker returns `404 NoSuchKey`; a request naming the
+  delete-marker version returns `405 MethodNotAllowed`. Both responses carry the
+  `x-amz-delete-marker: true` header so SDKs can distinguish a deleted object from a
+  never-existed key. `HeadObject` is now version-aware and no longer returns `200`
+  with marker metadata for a deleted key.
+
 ## [v0.68.1] - 2026-06-04
 
 ### Fixed

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -559,7 +559,10 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 	}
 
 	if obj.IsDeleteMarker {
-		return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound), nil
+		// A GET targeting a delete marker directly (explicit versionId) is a 405
+		// MethodNotAllowed in S3; a GET of a key whose current version is a delete
+		// marker is a 404 NoSuchKey. Both carry x-amz-delete-marker: true.
+		return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
 	}
 
 	// Directory-marker objects (key ends with "/") are never written to the
@@ -598,10 +601,17 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 }
 
 // headObject handles HEAD /<bucket>/<key>.
-func (p *S3Plugin) headObject(_ *RequestContext, _ *AWSRequest, bucket, key string) (*AWSResponse, error) {
+func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key string) (*AWSResponse, error) {
 	ctx := context.Background()
 
-	data, err := p.state.Get(ctx, s3Namespace, "object:"+bucket+"/"+key)
+	// If versionId is present, head the specific version; otherwise the current.
+	versionID := req.Params["versionId"]
+	stateKey := "object:" + bucket + "/" + key
+	if versionID != "" {
+		stateKey = "object_version:" + bucket + "/" + key + "/" + versionID
+	}
+
+	data, err := p.state.Get(ctx, s3Namespace, stateKey)
 	if err != nil {
 		return nil, fmt.Errorf("get object metadata: %w", err)
 	}
@@ -612,6 +622,11 @@ func (p *S3Plugin) headObject(_ *RequestContext, _ *AWSRequest, bucket, key stri
 	var obj S3Object
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return nil, fmt.Errorf("unmarshal object metadata: %w", err)
+	}
+
+	if obj.IsDeleteMarker {
+		// Mirror getObject: 405 when a version is named, 404 otherwise.
+		return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
 	}
 
 	headers := map[string]string{
@@ -1524,6 +1539,42 @@ func s3ErrorResponse(code, message string, status int, extras ...string) *AWSRes
 	return &AWSResponse{
 		StatusCode: status,
 		Headers:    map[string]string{"Content-Type": "text/xml; charset=UTF-8"},
+		Body:       append([]byte(xml.Header), body...),
+	}
+}
+
+// s3DeleteMarkerResponse builds the [AWSResponse] returned by GetObject/HeadObject
+// when the resolved object is a delete marker. Per the S3 API, a request that
+// names a specific version pointing at a delete marker gets 405 MethodNotAllowed;
+// a request for the (delete-marker) current version gets 404 NoSuchKey. Both
+// carry the x-amz-delete-marker: true header so SDKs can distinguish a deleted
+// object from a never-existed key.
+func s3DeleteMarkerResponse(versionRequested bool, markerVersionID string) *AWSResponse {
+	headers := map[string]string{
+		"Content-Type":        "text/xml; charset=UTF-8",
+		"x-amz-delete-marker": "true",
+	}
+	if markerVersionID != "" {
+		headers["x-amz-version-id"] = markerVersionID
+	}
+
+	code, message, status := "NoSuchKey", "The specified key does not exist.", http.StatusNotFound
+	if versionRequested {
+		// Naming the delete-marker version explicitly: not a retrievable object.
+		code, message, status = "MethodNotAllowed", "The specified method is not allowed against this resource.", http.StatusMethodNotAllowed
+		headers["Allow"] = "DELETE"
+	}
+
+	type errorXML struct {
+		XMLName   xml.Name `xml:"Error"`
+		Code      string   `xml:"Code"`
+		Message   string   `xml:"Message"`
+		RequestID string   `xml:"RequestId"`
+	}
+	body, _ := xml.Marshal(errorXML{Code: code, Message: message, RequestID: "SUBSTRATE"})
+	return &AWSResponse{
+		StatusCode: status,
+		Headers:    headers,
 		Body:       append([]byte(xml.Header), body...),
 	}
 }

--- a/emulator/s3_plugin_test.go
+++ b/emulator/s3_plugin_test.go
@@ -864,6 +864,46 @@ func TestS3_DeleteObjects_Versioned_HiddenFromList(t *testing.T) {
 	assert.Empty(t, listResult.Contents)
 }
 
+// TestS3_GetHeadObject_DeleteMarker is a regression test for #318: after a
+// delete marker is created on a versioned bucket, GetObject/HeadObject must not
+// surface the marker as content. A plain request returns 404 NoSuchKey with the
+// x-amz-delete-marker header; a request naming the marker version returns 405
+// MethodNotAllowed.
+func TestS3_GetHeadObject_DeleteMarker(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/dm-bucket", nil, nil)
+	s3Request(t, srv, http.MethodPut, "/dm-bucket?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+	s3Request(t, srv, http.MethodPut, "/dm-bucket/key", []byte("hello"), nil)
+
+	// Delete → inserts a delete marker; capture its version id.
+	del := s3Request(t, srv, http.MethodDelete, "/dm-bucket/key", nil, nil)
+	assert.Equal(t, http.StatusNoContent, del.Code)
+	assert.Equal(t, "true", del.Header().Get("x-amz-delete-marker"))
+	markerVID := del.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, markerVID)
+
+	// 1) Plain GET → 404 NoSuchKey + x-amz-delete-marker, not the object body.
+	get := s3Request(t, srv, http.MethodGet, "/dm-bucket/key", nil, nil)
+	assert.Equal(t, http.StatusNotFound, get.Code)
+	assert.Equal(t, "true", get.Header().Get("x-amz-delete-marker"))
+	assert.NotContains(t, get.Body.String(), "hello")
+	assert.Contains(t, get.Body.String(), "NoSuchKey")
+
+	// 2) Plain HEAD → 404 (previously returned 200 with marker metadata).
+	head := s3Request(t, srv, http.MethodHead, "/dm-bucket/key", nil, nil)
+	assert.Equal(t, http.StatusNotFound, head.Code)
+	assert.Equal(t, "true", head.Header().Get("x-amz-delete-marker"))
+
+	// 3) GET naming the delete-marker version → 405 MethodNotAllowed.
+	getVer := s3Request(t, srv, http.MethodGet, "/dm-bucket/key?versionId="+markerVID, nil, nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, getVer.Code)
+	assert.Equal(t, "true", getVer.Header().Get("x-amz-delete-marker"))
+	assert.Contains(t, getVer.Body.String(), "MethodNotAllowed")
+}
+
 func TestS3_ListObjectsV2_Delimiter(t *testing.T) {
 	t.Parallel()
 	srv, _ := newS3TestServer(t)


### PR DESCRIPTION
Follow-up to #316 (ListObjectsV2 delete-marker fix). Found via Fatou.jl integration tests.

## Problem
`getObject` already returned 404 for a delete-marker *current* version, but two gaps remained, and `headObject` had no delete-marker handling at all:
1. **`GET` naming the delete-marker version** returned `404 NoSuchKey`; per the S3 API it should be **`405 MethodNotAllowed`**.
2. **Neither path emitted `x-amz-delete-marker: true`**, so SDKs couldn't distinguish a deleted object from a never-existed key.
3. **`HeadObject` had no `IsDeleteMarker` check** (and ignored `versionId`) — `HEAD` on a deleted key returned `200` with marker metadata.

## Fix
New `s3DeleteMarkerResponse` helper centralizes AWS-accurate behaviour:
- delete-marker current version → `404 NoSuchKey` + `x-amz-delete-marker: true`
- request naming the marker version → `405 MethodNotAllowed` + `x-amz-delete-marker: true` + `Allow`

`getObject` uses it; `headObject` is now version-aware and applies the same check.

## Verification
New `TestS3_GetHeadObject_DeleteMarker` covers all three paths (plain GET 404+header, HEAD 404, versioned GET 405). `make lint` clean; full S3 suite green. AWS semantics verified against the S3 GetObject API reference.

Closes #318