### PR TITLE
fix(s3): decode aws-chunked PutObject/UploadPart bodies (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- S3: `PutObject` (and `UploadPart`) now decode SigV4 streaming (`aws-chunked`)
+  request bodies before storing them, instead of persisting the raw encoded
+  stream with its `chunk-signature` framing (#321). Affected SDK clients that send
+  `Content-Encoding: aws-chunked` / `x-amz-content-sha256: STREAMING-*` (e.g. the
+  AWS SDK for .NET with `InputStream`); `GetObject` returned the chunk headers as
+  content. Detection is header-based and decoding is a safe no-op for non-chunked
+  bodies (the AWS CLI, which uses standard HTTP chunking, was already correct).
+
 ## [v0.68.2] - 2026-06-05
 
 ### Fixed

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -442,7 +442,7 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
-	body := req.Body
+	body := decodeAWSChunked(req.Headers, req.Body)
 	hash := md5.Sum(body) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x"`, hash)
 
@@ -1172,7 +1172,7 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		return s3ErrorResponse("NoSuchUpload", "The specified upload does not exist.", http.StatusNotFound), nil
 	}
 
-	body := req.Body
+	body := decodeAWSChunked(req.Headers, req.Body)
 	hash := md5.Sum(body) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x"`, hash)
 
@@ -1461,6 +1461,119 @@ func (p *S3Plugin) loadObjectEntry(ctx context.Context, bucket, key string) (*ob
 		ETag:         obj.ETag,
 		Size:         obj.Size,
 	}, nil
+}
+
+// headerValueFold returns the value of the named header, case-insensitively
+// (req.Headers preserves Go's canonical-MIME casing, but callers send varied
+// cases for x-amz-* headers).
+func headerValueFold(headers map[string]string, name string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return v
+		}
+	}
+	return ""
+}
+
+// isAWSChunked reports whether the request body is SigV4 streaming (aws-chunked)
+// encoded, per its headers. The AWS SDKs signal this with Content-Encoding
+// aws-chunked and/or an x-amz-content-sha256 of STREAMING-*, alongside
+// x-amz-decoded-content-length giving the true payload size.
+func isAWSChunked(headers map[string]string) bool {
+	if strings.Contains(strings.ToLower(headerValueFold(headers, "Content-Encoding")), "aws-chunked") {
+		return true
+	}
+	if strings.HasPrefix(headerValueFold(headers, "X-Amz-Content-Sha256"), "STREAMING-") {
+		return true
+	}
+	// A decoded-content-length header is only sent for aws-chunked bodies.
+	return headerValueFold(headers, "X-Amz-Decoded-Content-Length") != ""
+}
+
+// decodeAWSChunked decodes a SigV4 streaming (aws-chunked) request body into the
+// raw object content, stripping the per-chunk "<hex-size>;chunk-signature=...\r\n"
+// framing and trailing checksum trailers. Non-chunked bodies (and anything that
+// fails to parse as aws-chunked) are returned unchanged, so this is a safe no-op
+// for CLI-style standard HTTP chunking, which net/http has already de-framed.
+//
+// Format per chunk: "<hex-len>[;chunk-signature=<sig>]\r\n<len bytes>\r\n",
+// terminated by a zero-length chunk optionally followed by trailer headers.
+func decodeAWSChunked(headers map[string]string, body []byte) []byte {
+	if len(body) == 0 || !isAWSChunked(headers) {
+		return body
+	}
+
+	var out []byte
+	rest := body
+	for {
+		// Each chunk starts with a size line ending in \r\n (tolerate bare \n).
+		nl := indexCRLF(rest)
+		if nl < 0 {
+			// No framing found — not actually aws-chunked; return original.
+			return body
+		}
+		sizeLine := string(rest[:nl])
+		advance := nl + crlfLen(rest, nl)
+
+		// Size is the hex value before any ";chunk-signature=..." extension.
+		hexPart := sizeLine
+		if semi := strings.IndexByte(hexPart, ';'); semi >= 0 {
+			hexPart = hexPart[:semi]
+		}
+		size, err := strconv.ParseInt(strings.TrimSpace(hexPart), 16, 64)
+		if err != nil {
+			return body // malformed → fall back to raw
+		}
+		rest = rest[advance:]
+		if size == 0 {
+			break // final chunk; trailers (if any) follow and are ignored
+		}
+		if int64(len(rest)) < size {
+			return body // truncated → fall back to raw
+		}
+		out = append(out, rest[:size]...)
+		rest = rest[size:]
+		// Skip the trailing CRLF after the chunk payload, if present.
+		if n := crlfLen(rest, 0); n > 0 {
+			rest = rest[n:]
+		}
+	}
+
+	// Honor the declared decoded length when present (defensive bound).
+	if dcl := headerValueFold(headers, "X-Amz-Decoded-Content-Length"); dcl != "" {
+		if n, err := strconv.ParseInt(dcl, 10, 64); err == nil && n >= 0 && n <= int64(len(out)) {
+			out = out[:n]
+		}
+	}
+	return out
+}
+
+// indexCRLF returns the index of the first \r\n or \n in b, or -1 if neither.
+func indexCRLF(b []byte) int {
+	for i := 0; i < len(b); i++ {
+		if b[i] == '\n' {
+			if i > 0 && b[i-1] == '\r' {
+				return i - 1
+			}
+			return i
+		}
+	}
+	return -1
+}
+
+// crlfLen returns the length (1 or 2) of the line terminator at b[i], or 0 if
+// b[i] is not a line terminator.
+func crlfLen(b []byte, i int) int {
+	if i >= len(b) {
+		return 0
+	}
+	if b[i] == '\r' && i+1 < len(b) && b[i+1] == '\n' {
+		return 2
+	}
+	if b[i] == '\r' || b[i] == '\n' {
+		return 1
+	}
+	return 0
 }
 
 // extractUserMetadata extracts X-Amz-Meta-* headers into a map keyed by the
@@ -2457,7 +2570,7 @@ func (p *S3Plugin) putBucketLifecycleConfiguration(_ *RequestContext, req *AWSRe
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
-	body := req.Body
+	body := decodeAWSChunked(req.Headers, req.Body)
 	if len(body) == 0 {
 		body = []byte("<LifecycleConfiguration/>")
 	}

--- a/emulator/s3_plugin_test.go
+++ b/emulator/s3_plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -902,6 +903,43 @@ func TestS3_GetHeadObject_DeleteMarker(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, getVer.Code)
 	assert.Equal(t, "true", getVer.Header().Get("x-amz-delete-marker"))
 	assert.Contains(t, getVer.Body.String(), "MethodNotAllowed")
+}
+
+// TestS3_PutObject_AWSChunked is a regression test for #321: a SigV4 streaming
+// (aws-chunked) PutObject body must be decoded before storage, not stored raw
+// with its chunk-signature framing. The AWS SDK .NET sends bodies this way.
+func TestS3_PutObject_AWSChunked(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/chunk-bucket", nil, nil)
+
+	payload := "hello world"
+	// Single-chunk aws-chunked body: "<hexlen>;chunk-signature=...\r\n<data>\r\n0;chunk-signature=...\r\n\r\n"
+	chunked := fmt.Sprintf("%x;chunk-signature=%s\r\n%s\r\n0;chunk-signature=%s\r\n\r\n",
+		len(payload), strings.Repeat("a", 64), payload, strings.Repeat("b", 64))
+
+	hdrs := map[string]string{
+		"Content-Type":                 "text/plain",
+		"Content-Encoding":             "aws-chunked",
+		"X-Amz-Content-Sha256":         "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
+		"X-Amz-Decoded-Content-Length": strconv.Itoa(len(payload)),
+	}
+	put := s3Request(t, srv, http.MethodPut, "/chunk-bucket/key", []byte(chunked), hdrs)
+	require.Equal(t, http.StatusOK, put.Code)
+
+	// GetObject must return the decoded payload, not the chunk framing.
+	get := s3Request(t, srv, http.MethodGet, "/chunk-bucket/key", nil, nil)
+	require.Equal(t, http.StatusOK, get.Code)
+	assert.Equal(t, payload, get.Body.String())
+	assert.NotContains(t, get.Body.String(), "chunk-signature")
+	assert.Equal(t, strconv.Itoa(len(payload)), get.Header().Get("Content-Length"))
+
+	// A normal (non-chunked) PutObject is unaffected — body stored verbatim.
+	s3Request(t, srv, http.MethodPut, "/chunk-bucket/plain", []byte("raw bytes"),
+		map[string]string{"Content-Type": "text/plain"})
+	plain := s3Request(t, srv, http.MethodGet, "/chunk-bucket/plain", nil, nil)
+	assert.Equal(t, "raw bytes", plain.Body.String())
 }
 
 func TestS3_ListObjectsV2_Delimiter(t *testing.T) {


### PR DESCRIPTION
## Problem
SigV4 streaming (`aws-chunked`) uploads were stored **raw** — chunk-signature framing and all — so `GetObject` returned chunk headers instead of the payload:
```
B;chunk-signature=...\r\nhello world\r\n0;chunk-signature=...
```
The AWS SDK for .NET sends bodies this way (`PutObjectRequest.InputStream` → `Content-Encoding: aws-chunked`, `x-amz-decoded-content-length`). The AWS CLI was unaffected (standard HTTP chunking, already de-framed by `net/http`), which is why it went unnoticed.

## Fix
New `decodeAWSChunked` helper:
- **Detects** aws-chunked via `Content-Encoding: aws-chunked`, `x-amz-content-sha256: STREAMING-*`, or presence of `x-amz-decoded-content-length` (all matched case-insensitively).
- **Strips** the per-chunk `<hexlen>;chunk-signature=...\r\n<payload>\r\n` framing and trailing checksum trailers; bounds output by the declared decoded length.
- **Falls back** to the raw body if anything doesn't parse → safe no-op for non-chunked uploads.

Applied in `putObject`, `uploadPart`, and `putBucketLifecycleConfiguration`.

## Verification
`TestS3_PutObject_AWSChunked` asserts a chunked body round-trips to the decoded payload (no `chunk-signature` leakage, correct `Content-Length`) and that a normal upload is stored verbatim. `make test` (race) + `make lint` clean. Decoding semantics verified against the S3 SigV4 streaming (aws-chunked) spec.

Closes #321