### PR TITLE
chore(release): v0.68.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.68.3] - 2026-06-09
+
 ### Fixed
 - S3: `PutObject` (and `UploadPart`) now decode SigV4 streaming (`aws-chunked`)
   request bodies before storing them, instead of persisting the raw encoded
@@ -1839,7 +1841,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.68.2...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.68.3...HEAD
+[v0.68.3]: https://github.com/scttfrdmn/substrate/compare/v0.68.2...v0.68.3
 [v0.68.2]: https://github.com/scttfrdmn/substrate/compare/v0.68.1...v0.68.2
 [v0.68.1]: https://github.com/scttfrdmn/substrate/compare/v0.68.0...v0.68.1
 [v0.68.0]: https://github.com/scttfrdmn/substrate/compare/v0.66.1...v0.68.0


### PR DESCRIPTION
Patch release cutting **v0.68.3** for the S3 aws-chunked decoding fix (#321): `PutObject`/`UploadPart` now decode SigV4 streaming bodies instead of storing raw chunk framing. Changelog-only; the fix merged via #323. After merge, the merge commit is tagged `v0.68.3` (signed) and released, per the protected flow.