### PR TITLE
feat(ec2): DescribeSnapshots + CreateImage snapshots + BDM snapshot-id filter (#322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- EC2: `DescribeSnapshots` now lists EBS snapshots (returning `SnapshotId`,
+  `VolumeSize`, `State`, `StartTime`, `Encrypted`), honoring `SnapshotId.N`
+  parameters and the `snapshot-id` filter. `CreateImage` now materializes a
+  backing snapshot and records it on the AMI, and `DescribeImages` surfaces it in
+  the response `blockDeviceMapping` and honors the
+  `block-device-mapping.snapshot-id` (and `image-id`) filters. `DeleteSnapshot`
+  now removes the snapshot from state (was a no-op stub) so a subsequent
+  `DescribeSnapshots` reflects the deletion. Together these let snapshot-retention
+  logic — retain a snapshot shared by multiple AMIs, delete an unshared one — be
+  tested end-to-end (#322).
+
 ## [v0.68.3] - 2026-06-09
 
 ### Fixed

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -204,6 +204,8 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.detachVolume(ctx, req)
 	case "DeleteSnapshot":
 		return p.deleteSnapshot(ctx, req)
+	case "DescribeSnapshots":
+		return p.describeSnapshots(ctx, req)
 	default:
 		return nil, &AWSError{
 			Code:       "InvalidAction",
@@ -2431,6 +2433,27 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 		tags = append(tags, EC2Tag{Key: key, Value: req.Params[fmt.Sprintf("TagSpecification.1.Tag.%d.Value", i)]})
 	}
 
+	// Materialize a backing EBS snapshot for the AMI's root device, so that
+	// DescribeSnapshots and the block-device-mapping.snapshot-id filter on
+	// DescribeImages can model snapshot-retention logic (#322).
+	snapshotID := generateEBSSnapshotID()
+	snap := EC2Snapshot{
+		SnapshotID:  snapshotID,
+		VolumeSize:  8,
+		State:       "completed",
+		StartTime:   p.tc.Now().UTC().Format(time.RFC3339),
+		Description: "Created by CreateImage for " + name,
+		AccountID:   reqCtx.AccountID,
+		Region:      reqCtx.Region,
+	}
+	snapData, err := json.Marshal(snap)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 createImage snapshot marshal: %w", err)
+	}
+	if err := p.state.Put(context.Background(), ec2Namespace, ec2SnapshotStateKey(reqCtx.AccountID, reqCtx.Region, snapshotID), snapData); err != nil {
+		return nil, fmt.Errorf("ec2 createImage snapshot put: %w", err)
+	}
+
 	imageID := generateImageID()
 	img := EC2Image{
 		ImageID:      imageID,
@@ -2439,6 +2462,7 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 		InstanceID:   instanceID,
 		State:        "available",
 		CreationDate: p.tc.Now().UTC().Format(time.RFC3339),
+		SnapshotID:   snapshotID,
 		Tags:         tags,
 		AccountID:    reqCtx.AccountID,
 		Region:       reqCtx.Region,
@@ -2496,14 +2520,23 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 		Key   string `xml:"key"`
 		Value string `xml:"value"`
 	}
+	type ebsBlockDevice struct {
+		SnapshotID string `xml:"snapshotId"`
+		VolumeSize int64  `xml:"volumeSize"`
+	}
+	type blockDeviceItem struct {
+		DeviceName string         `xml:"deviceName"`
+		EBS        ebsBlockDevice `xml:"ebs"`
+	}
 	type imageItem struct {
-		ImageID      string    `xml:"imageId"`
-		Name         string    `xml:"name"`
-		Description  string    `xml:"description,omitempty"`
-		State        string    `xml:"imageState"`
-		OwnerID      string    `xml:"imageOwnerId"`
-		CreationDate string    `xml:"creationDate,omitempty"`
-		Tags         []tagItem `xml:"tagSet>item"`
+		ImageID             string            `xml:"imageId"`
+		Name                string            `xml:"name"`
+		Description         string            `xml:"description,omitempty"`
+		State               string            `xml:"imageState"`
+		OwnerID             string            `xml:"imageOwnerId"`
+		CreationDate        string            `xml:"creationDate,omitempty"`
+		BlockDeviceMappings []blockDeviceItem `xml:"blockDeviceMapping>item,omitempty"`
+		Tags                []tagItem         `xml:"tagSet>item"`
 	}
 	type response struct {
 		XMLName xml.Name    `xml:"DescribeImagesResponse"`
@@ -2525,7 +2558,8 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 		// Apply filters.
 		skip := false
 		for _, f := range filters {
-			if strings.HasPrefix(f.name, "tag:") {
+			switch {
+			case strings.HasPrefix(f.name, "tag:"):
 				tagKey := f.name[4:]
 				found := false
 				for _, t := range img.Tags {
@@ -2536,8 +2570,18 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 				}
 				if !found {
 					skip = true
-					break
 				}
+			case f.name == "block-device-mapping.snapshot-id":
+				if img.SnapshotID == "" || !containsStr(f.values, img.SnapshotID) {
+					skip = true
+				}
+			case f.name == "image-id":
+				if !containsStr(f.values, img.ImageID) {
+					skip = true
+				}
+			}
+			if skip {
+				break
 			}
 		}
 		if skip {
@@ -2551,6 +2595,12 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 			State:        img.State,
 			OwnerID:      img.AccountID,
 			CreationDate: img.CreationDate,
+		}
+		if img.SnapshotID != "" {
+			item.BlockDeviceMappings = []blockDeviceItem{{
+				DeviceName: "/dev/sda1",
+				EBS:        ebsBlockDevice{SnapshotID: img.SnapshotID, VolumeSize: 8},
+			}}
 		}
 		for _, t := range img.Tags {
 			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck
@@ -3971,10 +4021,16 @@ func (p *EC2Plugin) detachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 // deleteSnapshot is a stub that accepts DeleteSnapshot requests without error.
 // Substratefs does not persist snapshots; the operation succeeds to allow
 // AMI deregistration cleanup workflows to proceed.
-func (p *EC2Plugin) deleteSnapshot(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *EC2Plugin) deleteSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	snapshotID := req.Params["SnapshotId"]
 	if snapshotID == "" {
 		return nil, &AWSError{Code: "InvalidParameterValue", Message: "SnapshotId is required", HTTPStatus: http.StatusBadRequest}
+	}
+	// Remove the snapshot from state so a subsequent DescribeSnapshots reflects
+	// the deletion (enables shared-snapshot retain-vs-delete testing). Delete is
+	// idempotent — a missing snapshot still returns success.
+	if err := p.state.Delete(context.Background(), ec2Namespace, ec2SnapshotStateKey(reqCtx.AccountID, reqCtx.Region, snapshotID)); err != nil {
+		return nil, fmt.Errorf("ec2 deleteSnapshot delete: %w", err)
 	}
 	type response struct {
 		XMLName xml.Name `xml:"DeleteSnapshotResponse"`
@@ -3982,4 +4038,71 @@ func (p *EC2Plugin) deleteSnapshot(_ *RequestContext, req *AWSRequest) (*AWSResp
 		Return  bool     `xml:"return"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
+}
+
+// describeSnapshots lists EBS snapshots owned by the account, honoring an
+// optional list of SnapshotId.N parameters and the snapshot-id Filter.
+func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	ids := extractIndexedParams(req.Params, "SnapshotId")
+	filters := extractEC2Filters(req.Params)
+
+	allKeys, err := p.state.List(context.Background(), ec2Namespace,
+		"snapshot:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+	if err != nil {
+		return nil, fmt.Errorf("ec2 describeSnapshots list: %w", err)
+	}
+
+	type tagItem struct {
+		Key   string `xml:"key"`
+		Value string `xml:"value"`
+	}
+	type snapshotItem struct {
+		SnapshotID  string    `xml:"snapshotId"`
+		VolumeID    string    `xml:"volumeId,omitempty"`
+		VolumeSize  int64     `xml:"volumeSize"`
+		State       string    `xml:"status"`
+		StartTime   string    `xml:"startTime"`
+		Encrypted   bool      `xml:"encrypted"`
+		Description string    `xml:"description,omitempty"`
+		OwnerID     string    `xml:"ownerId"`
+		Tags        []tagItem `xml:"tagSet>item"`
+	}
+	type response struct {
+		XMLName   xml.Name       `xml:"DescribeSnapshotsResponse"`
+		XMLNS     string         `xml:"xmlns,attr"`
+		Snapshots []snapshotItem `xml:"snapshotSet>item"`
+	}
+
+	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
+	for _, k := range allKeys {
+		data, getErr := p.state.Get(context.Background(), ec2Namespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var snap EC2Snapshot
+		if json.Unmarshal(data, &snap) != nil {
+			continue
+		}
+		if len(ids) > 0 && !containsStr(ids, snap.SnapshotID) {
+			continue
+		}
+		if vals, ok := filters["snapshot-id"]; ok && !containsStr(vals, snap.SnapshotID) {
+			continue
+		}
+		item := snapshotItem{
+			SnapshotID:  snap.SnapshotID,
+			VolumeID:    snap.VolumeID,
+			VolumeSize:  snap.VolumeSize,
+			State:       snap.State,
+			StartTime:   snap.StartTime,
+			Encrypted:   snap.Encrypted,
+			Description: snap.Description,
+			OwnerID:     snap.AccountID,
+		}
+		for _, t := range snap.Tags {
+			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck
+		}
+		resp.Snapshots = append(resp.Snapshots, item)
+	}
+	return ec2XMLResponse(http.StatusOK, resp)
 }

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -3378,3 +3378,126 @@ func TestEC2_DescribeInstances_FilterOrderIndependent(t *testing.T) {
 	}))
 	_ = id
 }
+
+// TestEC2_CreateImage_SnapshotsAndFilter is a regression test for #322: CreateImage
+// materializes a backing EBS snapshot that is then describable via DescribeSnapshots
+// and discoverable via the DescribeImages block-device-mapping.snapshot-id filter,
+// enabling shared-snapshot retain-vs-delete logic to be tested.
+func TestEC2_CreateImage_SnapshotsAndFilter(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	run := ec2Request(t, ts, map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-base",
+		"InstanceType": "t3.micro", "MinCount": "1", "MaxCount": "1",
+	})
+	var runResult struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(run.Body).Decode(&runResult))
+	run.Body.Close() //nolint:errcheck
+	require.NotEmpty(t, runResult.Instances)
+	instanceID := runResult.Instances[0].InstanceID
+
+	// createAMI creates an AMI from the instance and returns its image id.
+	createAMI := func(name string) string {
+		r := ec2Request(t, ts, map[string]string{
+			"Action": "CreateImage", "InstanceId": instanceID, "Name": name,
+		})
+		var res struct {
+			ImageID string `xml:"imageId"`
+		}
+		require.NoError(t, xml.NewDecoder(r.Body).Decode(&res))
+		r.Body.Close() //nolint:errcheck
+		require.NotEmpty(t, res.ImageID)
+		return res.ImageID
+	}
+	amiA := createAMI("ami-a")
+	amiB := createAMI("ami-b")
+
+	// describeImages returns (imageId -> snapshotId) for the given filters.
+	describeImages := func(params map[string]string) map[string]string {
+		params["Action"] = "DescribeImages"
+		r := ec2Request(t, ts, params)
+		var res struct {
+			Images []struct {
+				ImageID string `xml:"imageId"`
+				BDM     []struct {
+					EBS struct {
+						SnapshotID string `xml:"snapshotId"`
+					} `xml:"ebs"`
+				} `xml:"blockDeviceMapping>item"`
+			} `xml:"imagesSet>item"`
+		}
+		require.NoError(t, xml.NewDecoder(r.Body).Decode(&res))
+		r.Body.Close() //nolint:errcheck
+		out := map[string]string{}
+		for _, im := range res.Images {
+			snap := ""
+			if len(im.BDM) > 0 {
+				snap = im.BDM[0].EBS.SnapshotID
+			}
+			out[im.ImageID] = snap
+		}
+		return out
+	}
+
+	all := describeImages(map[string]string{})
+	require.Len(t, all, 2)
+	snapA, snapB := all[amiA], all[amiB]
+	require.NotEmpty(t, snapA)
+	require.NotEmpty(t, snapB)
+	require.NotEqual(t, snapA, snapB, "each AMI gets its own backing snapshot")
+
+	// DescribeSnapshots returns both snapshots with the documented detail.
+	descSnaps := func() map[string]struct {
+		Size  int64
+		State string
+	} {
+		r := ec2Request(t, ts, map[string]string{"Action": "DescribeSnapshots"})
+		var res struct {
+			Snapshots []struct {
+				SnapshotID string `xml:"snapshotId"`
+				VolumeSize int64  `xml:"volumeSize"`
+				State      string `xml:"status"`
+				StartTime  string `xml:"startTime"`
+			} `xml:"snapshotSet>item"`
+		}
+		require.NoError(t, xml.NewDecoder(r.Body).Decode(&res))
+		r.Body.Close() //nolint:errcheck
+		out := map[string]struct {
+			Size  int64
+			State string
+		}{}
+		for _, s := range res.Snapshots {
+			require.NotEmpty(t, s.StartTime)
+			out[s.SnapshotID] = struct {
+				Size  int64
+				State string
+			}{s.VolumeSize, s.State}
+		}
+		return out
+	}
+	snaps := descSnaps()
+	require.Contains(t, snaps, snapA)
+	require.Contains(t, snaps, snapB)
+	assert.Equal(t, "completed", snaps[snapA].State)
+	assert.Equal(t, int64(8), snaps[snapA].Size)
+
+	// DescribeImages filtered by snapshot-id finds only the owning AMI.
+	filtered := describeImages(map[string]string{
+		"Filter.1.Name": "block-device-mapping.snapshot-id", "Filter.1.Value.1": snapA,
+	})
+	require.Len(t, filtered, 1)
+	require.Contains(t, filtered, amiA)
+
+	// Deleting a snapshot removes it from DescribeSnapshots (retention path).
+	del := ec2Request(t, ts, map[string]string{"Action": "DeleteSnapshot", "SnapshotId": snapB})
+	assert.Equal(t, http.StatusOK, del.StatusCode)
+	del.Body.Close() //nolint:errcheck
+	after := descSnaps()
+	assert.Contains(t, after, snapA, "unrelated snapshot retained")
+	assert.NotContains(t, after, snapB, "deleted snapshot gone")
+}

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -390,6 +390,10 @@ type EC2Image struct {
 	// CreationDate is the RFC3339 timestamp when the AMI was registered.
 	CreationDate string `json:"creation_date,omitempty"`
 
+	// SnapshotID is the EBS snapshot backing the root device of this AMI, if any.
+	// CreateImage materializes one so snapshot-retention logic can be tested.
+	SnapshotID string `json:"snapshot_id,omitempty"`
+
 	// Tags holds key-value metadata tags.
 	Tags []EC2Tag `json:"tags,omitempty"`
 
@@ -400,10 +404,54 @@ type EC2Image struct {
 	Region string `json:"region"`
 }
 
+// EC2Snapshot represents an Amazon EBS snapshot.
+type EC2Snapshot struct {
+	// SnapshotID is the snapshot identifier (e.g. "snap-0123456789abcdef0").
+	SnapshotID string `json:"snapshot_id"`
+
+	// VolumeID is the source volume, if the snapshot was created from one.
+	VolumeID string `json:"volume_id,omitempty"`
+
+	// VolumeSize is the size of the volume, in GiB.
+	VolumeSize int64 `json:"volume_size"`
+
+	// State is the snapshot state: always "completed" in Substrate.
+	State string `json:"state"`
+
+	// StartTime is the RFC3339 timestamp when the snapshot was started.
+	StartTime string `json:"start_time"`
+
+	// Encrypted reports whether the snapshot is encrypted.
+	Encrypted bool `json:"encrypted"`
+
+	// Description is the optional snapshot description.
+	Description string `json:"description,omitempty"`
+
+	// Tags holds key-value metadata tags.
+	Tags []EC2Tag `json:"tags,omitempty"`
+
+	// AccountID is the AWS account that owns the snapshot.
+	AccountID string `json:"account_id"`
+
+	// Region is the AWS region in which the snapshot resides.
+	Region string `json:"region"`
+}
+
 // generateImageID generates a random AMI ID in the format "ami-" followed
 // by 17 hex characters.
 func generateImageID() string {
 	return "ami-" + randomHex(8)
+}
+
+// generateEBSSnapshotID generates a random EBS snapshot ID in the format "snap-"
+// followed by 17 hex characters.
+func generateEBSSnapshotID() string {
+	return "snap-" + randomHex(8)
+}
+
+// ec2SnapshotStateKey returns the state key for an EBS snapshot.
+func ec2SnapshotStateKey(accountID, region, snapshotID string) string {
+	return "snapshot:" + accountID + "/" + region + "/" + snapshotID
 }
 
 // EC2ElasticIP represents an Amazon EC2 Elastic IP address.


### PR DESCRIPTION
Enables testing AMI-deletion logic that **retains EBS snapshots shared by multiple AMIs** (spore.host/spawn's `DeleteAMI`), which couldn't be exercised against substrate before.

## Changes
- **`CreateImage`** materializes a backing `EC2Snapshot` and records its id on the AMI.
- **`DescribeSnapshots`** (new) lists snapshots with `SnapshotId` / `VolumeSize` / `State` / `StartTime` / `Encrypted`, honoring `SnapshotId.N` params and the `snapshot-id` filter.
- **`DescribeImages`** surfaces the backing snapshot in the response `blockDeviceMapping` and honors the **`block-device-mapping.snapshot-id`** filter (plus `image-id`) — reusing the existing `extractEC2Filters` helper.
- **`DeleteSnapshot`** now removes the snapshot from state (was a no-op stub), so a subsequent `DescribeSnapshots` reflects the deletion.

New `EC2Snapshot` type + `generateEBSSnapshotID` / `ec2SnapshotStateKey` helpers.

## Verification
`TestEC2_CreateImage_SnapshotsAndFilter` covers the full consumer scenario: two AMIs → distinct backing snapshots → DescribeSnapshots sees both → snapshot-id filter finds only the owning AMI → DeleteSnapshot removes the unshared one while the shared one is retained. `make test` (race) + `make lint` clean. AWS shapes (snapshot `status` element, `blockDeviceMapping>ebs>snapshotId`, filter names) verified against the EC2 API reference.

Closes #322