### PR TITLE
chore(release): v0.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.69.0] - 2026-06-09
+
 ### Added
 - EC2: `DescribeSnapshots` now lists EBS snapshots (returning `SnapshotId`,
   `VolumeSize`, `State`, `StartTime`, `Encrypted`), honoring `SnapshotId.N`
@@ -1853,7 +1855,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.68.3...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.69.0...HEAD
+[v0.69.0]: https://github.com/scttfrdmn/substrate/compare/v0.68.3...v0.69.0
 [v0.68.3]: https://github.com/scttfrdmn/substrate/compare/v0.68.2...v0.68.3
 [v0.68.2]: https://github.com/scttfrdmn/substrate/compare/v0.68.1...v0.68.2
 [v0.68.1]: https://github.com/scttfrdmn/substrate/compare/v0.68.0...v0.68.1


### PR DESCRIPTION
Minor release cutting **v0.69.0** for the EC2 snapshot feature (#322): `DescribeSnapshots`, `CreateImage` backing snapshots, and the `block-device-mapping.snapshot-id` filter on `DescribeImages`. Changelog-only; the feature merged via #325. After merge, the merge commit is tagged `v0.69.0` (signed) and released, per the protected flow.