### PR TITLE
docs: fix package doc comments to say 'Package emulator' after reorg

### DIFF
--- a/emulator/coverage_test.go
+++ b/emulator/coverage_test.go
@@ -1,4 +1,4 @@
-// Package substrate_test contains additional tests for coverage of helper
+// Package emulator_test contains additional tests for coverage of helper
 // functions, snapshot operations, and replay navigation.
 package emulator_test
 

--- a/emulator/doc.go
+++ b/emulator/doc.go
@@ -1,4 +1,4 @@
-// Package substrate provides an event-sourced AWS emulation layer for
+// Package emulator provides an event-sourced AWS emulation layer for
 // deterministic testing of AI-generated infrastructure code.
 //
 // # Overview

--- a/emulator/doc_plugins.go
+++ b/emulator/doc_plugins.go
@@ -1,4 +1,4 @@
-// Package substrate — plugin developer guide.
+// Package emulator — plugin developer guide.
 //
 // # Building a Substrate Plugin
 //

--- a/emulator/sns_types.go
+++ b/emulator/sns_types.go
@@ -1,4 +1,4 @@
-// Package substrate contains SNS type definitions for the AWS SNS emulator.
+// Package emulator contains SNS type definitions for the AWS SNS emulator.
 package emulator
 
 import "fmt"

--- a/emulator/v030_coverage_test.go
+++ b/emulator/v030_coverage_test.go
@@ -1,4 +1,4 @@
-// Package substrate_test contains coverage tests for v0.30.0 new features.
+// Package emulator_test contains coverage tests for v0.30.0 new features.
 package emulator_test
 
 import (


### PR DESCRIPTION
Loose end from the `emulator/` reorg (#310): the package clause was renamed `substrate` → `emulator`, but five files' leading doc comments still said `// Package substrate` / `// Package substrate_test` — a name mismatch Go/gopls flags.

Updates the comment lines in `doc.go`, `doc_plugins.go`, `sns_types.go`, `coverage_test.go`, `v030_coverage_test.go`. 'Substrate' as the product name in prose is left as-is. Doc-comment only — no code or behaviour change; build/vet/lint clean. No CHANGELOG entry (no user-facing effect).