### PR TITLE
feat(ec2): RegisterImage with explicit BDM snapshot-id for shared snapshots (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- EC2: `RegisterImage` now registers an AMI that can point its root device at an
+  existing EBS snapshot via `BlockDeviceMapping.N.Ebs.SnapshotId` (#328, follow-up
+  to #322). Unlike `CreateImage` (which always materializes a fresh snapshot, as
+  in real AWS), `RegisterImage` lets multiple AMIs *share* one snapshot, so the
+  `DescribeImages` `block-device-mapping.snapshot-id` filter returns every AMI
+  referencing it — enabling the "retain a shared snapshot" path to be tested
+  end-to-end. (The filter itself already returned all matches; the gap was that
+  distinct `CreateImage` calls never produced a shared snapshot to find.)
+
 ## [v0.69.0] - 2026-06-09
 
 ### Added

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -144,6 +144,8 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	// AMI operations
 	case "CreateImage":
 		return p.createImage(ctx, req)
+	case "RegisterImage":
+		return p.registerImage(ctx, req)
 	case "DescribeImages":
 		return p.describeImages(ctx, req)
 	case "DeregisterImage":
@@ -2477,6 +2479,58 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 
 	type response struct {
 		XMLName xml.Name `xml:"CreateImageResponse"`
+		XMLNS   string   `xml:"xmlns,attr"`
+		ImageID string   `xml:"imageId"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:   "http://ec2.amazonaws.com/doc/2016-11-15/",
+		ImageID: imageID,
+	})
+}
+
+// registerImage registers an AMI, optionally pointing its root device at an
+// existing EBS snapshot supplied via BlockDeviceMapping.N.Ebs.SnapshotId. Unlike
+// CreateImage (which always materializes a fresh snapshot), RegisterImage lets a
+// caller register multiple AMIs that *share* one snapshot — the AWS-faithful way
+// to model snapshot sharing, so retain-shared-snapshot logic is testable (#328).
+func (p *EC2Plugin) registerImage(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	name := req.Params["Name"]
+	if name == "" {
+		return nil, &AWSError{Code: "InvalidParameterValue", Message: "Name is required", HTTPStatus: http.StatusBadRequest}
+	}
+
+	// Find the first block device mapping that names an EBS snapshot. EC2 sends
+	// these as BlockDeviceMapping.N.Ebs.SnapshotId (1-indexed); scan a bounded
+	// range so a sparse index doesn't cause an early stop.
+	snapshotID := ""
+	for i := 1; i <= 32; i++ {
+		if v := req.Params[fmt.Sprintf("BlockDeviceMapping.%d.Ebs.SnapshotId", i)]; v != "" {
+			snapshotID = v
+			break
+		}
+	}
+
+	imageID := generateImageID()
+	img := EC2Image{
+		ImageID:      imageID,
+		Name:         name,
+		Description:  req.Params["Description"],
+		State:        "available",
+		CreationDate: p.tc.Now().UTC().Format(time.RFC3339),
+		SnapshotID:   snapshotID,
+		AccountID:    reqCtx.AccountID,
+		Region:       reqCtx.Region,
+	}
+	data, err := json.Marshal(img)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 registerImage marshal: %w", err)
+	}
+	if err := p.state.Put(context.Background(), ec2Namespace, ec2ImageStateKey(reqCtx.AccountID, reqCtx.Region, imageID), data); err != nil {
+		return nil, fmt.Errorf("ec2 registerImage put: %w", err)
+	}
+
+	type response struct {
+		XMLName xml.Name `xml:"RegisterImageResponse"`
 		XMLNS   string   `xml:"xmlns,attr"`
 		ImageID string   `xml:"imageId"`
 	}

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -3501,3 +3501,90 @@ func TestEC2_CreateImage_SnapshotsAndFilter(t *testing.T) {
 	assert.Contains(t, after, snapA, "unrelated snapshot retained")
 	assert.NotContains(t, after, snapB, "deleted snapshot gone")
 }
+
+// TestEC2_RegisterImage_SharedSnapshot is a regression test for #328: an AMI
+// registered (via RegisterImage) against an existing snapshot shares it with the
+// AMI that created it, and the block-device-mapping.snapshot-id filter returns
+// ALL AMIs referencing that snapshot — enabling shared-snapshot retain testing.
+func TestEC2_RegisterImage_SharedSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	run := ec2Request(t, ts, map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-base",
+		"InstanceType": "t3.micro", "MinCount": "1", "MaxCount": "1",
+	})
+	var runResult struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(run.Body).Decode(&runResult))
+	run.Body.Close() //nolint:errcheck
+	instanceID := runResult.Instances[0].InstanceID
+
+	// AMI A: CreateImage materializes snap-X.
+	cre := ec2Request(t, ts, map[string]string{
+		"Action": "CreateImage", "InstanceId": instanceID, "Name": "ami-a",
+	})
+	var creRes struct {
+		ImageID string `xml:"imageId"`
+	}
+	require.NoError(t, xml.NewDecoder(cre.Body).Decode(&creRes))
+	cre.Body.Close() //nolint:errcheck
+	amiA := creRes.ImageID
+
+	// Discover snap-X from AMI A's block device mapping.
+	desc := ec2Request(t, ts, map[string]string{"Action": "DescribeImages", "ImageId.1": amiA})
+	var dRes struct {
+		Images []struct {
+			BDM []struct {
+				EBS struct {
+					SnapshotID string `xml:"snapshotId"`
+				} `xml:"ebs"`
+			} `xml:"blockDeviceMapping>item"`
+		} `xml:"imagesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(desc.Body).Decode(&dRes))
+	desc.Body.Close() //nolint:errcheck
+	require.Len(t, dRes.Images, 1)
+	require.NotEmpty(t, dRes.Images[0].BDM)
+	snapX := dRes.Images[0].BDM[0].EBS.SnapshotID
+	require.NotEmpty(t, snapX)
+
+	// AMI B: RegisterImage pointing at the SAME snapshot.
+	reg := ec2Request(t, ts, map[string]string{
+		"Action": "RegisterImage", "Name": "ami-b",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": snapX,
+	})
+	require.Equal(t, http.StatusOK, reg.StatusCode)
+	var regRes struct {
+		ImageID string `xml:"imageId"`
+	}
+	require.NoError(t, xml.NewDecoder(reg.Body).Decode(&regRes))
+	reg.Body.Close() //nolint:errcheck
+	amiB := regRes.ImageID
+	require.NotEmpty(t, amiB)
+	require.NotEqual(t, amiA, amiB)
+
+	// The snapshot-id filter must now return BOTH AMIs.
+	f := ec2Request(t, ts, map[string]string{
+		"Action":        "DescribeImages",
+		"Filter.1.Name": "block-device-mapping.snapshot-id", "Filter.1.Value.1": snapX,
+	})
+	var fRes struct {
+		Images []struct {
+			ImageID string `xml:"imageId"`
+		} `xml:"imagesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(f.Body).Decode(&fRes))
+	f.Body.Close() //nolint:errcheck
+	got := map[string]bool{}
+	for _, im := range fRes.Images {
+		got[im.ImageID] = true
+	}
+	assert.Len(t, fRes.Images, 2, "both AMIs sharing the snapshot must match the filter")
+	assert.True(t, got[amiA], "ami-a should match")
+	assert.True(t, got[amiB], "ami-b should match")
+}


### PR DESCRIPTION
Follow-up to #322. Enables the "retain a snapshot shared by multiple AMIs" path in spore.host/spawn's `DeleteAMI` to be tested end-to-end.

## Diagnosis
The issue reported the `block-device-mapping.snapshot-id` filter returning only one AMI for a shared snapshot. Reproduced empirically — and the **filter was already correct** (it returns all matching AMIs, no early break). The real gap: two `CreateImage` calls from the same instance produce **different** snapshots (each gets a fresh `snap-id`, matching real AWS), so a shared snapshot never existed to be found.

## Fix
Add **`RegisterImage`** honoring `BlockDeviceMapping.N.Ebs.SnapshotId`, so a caller can register an AMI pointing at an *existing* snapshot — the AWS-faithful way to share a snapshot across AMIs (vs. `CreateImage`, which always materializes a new one). `DescribeImages` filtered by that snapshot then returns every referencing AMI.

## Verification
`TestEC2_RegisterImage_SharedSnapshot`: CreateImage A → snap-X; RegisterImage B on snap-X; filter by snap-X returns **both** A and B. `make test` (race) + `make lint` clean. Param shapes (`BlockDeviceMapping.N.Ebs.SnapshotId`, `RegisterImageResponse`) verified against the EC2 API reference.

Closes #328