### PR TITLE
chore(release): v0.70.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.70.0] - 2026-06-09
+
 ### Added
 - EC2: `RegisterImage` now registers an AMI that can point its root device at an
   existing EBS snapshot via `BlockDeviceMapping.N.Ebs.SnapshotId` (#328, follow-up
@@ -1865,7 +1867,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.69.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.70.0...HEAD
+[v0.70.0]: https://github.com/scttfrdmn/substrate/compare/v0.69.0...v0.70.0
 [v0.69.0]: https://github.com/scttfrdmn/substrate/compare/v0.68.3...v0.69.0
 [v0.68.3]: https://github.com/scttfrdmn/substrate/compare/v0.68.2...v0.68.3
 [v0.68.2]: https://github.com/scttfrdmn/substrate/compare/v0.68.1...v0.68.2


### PR DESCRIPTION
Minor release cutting **v0.70.0** for the EC2 `RegisterImage` feature (#328): register an AMI against an existing snapshot so multiple AMIs can share one, enabling shared-snapshot retain testing. Changelog-only; the feature merged via #329. After merge, the merge commit is tagged `v0.70.0` (signed) and released, per the protected flow.