### PR TITLE
fix(ec2,ssm): echo IamInstanceProfile; gate SSM PingStatus on a profile (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- EC2: `DescribeInstances` now echoes the `IamInstanceProfile` set at launch
+  (#331). `RunInstances` already accepted and stored it, but the describe response
+  dropped it; the response now includes `iamInstanceProfile` with `arn` and `id`
+  so callers can read back the profile they attached.
+
+### Changed
+- SSM: `DescribeInstanceInformation` now lists a running instance only if it has
+  an IAM instance profile attached (#331). Previously every running instance
+  reported `PingStatus=Online` regardless of preconditions; in real AWS, SSM
+  registration requires a profile granting `ssm:UpdateInstanceInformation`, and an
+  instance with no profile never registers. This lets callers distinguish a "dead"
+  instance (no profile → can never register) from an SSM-managed one. Eligibility
+  is based on profile presence (substrate does not model profile→policy attachment).
+
 ## [v0.70.0] - 2026-06-09
 
 ### Added

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -570,20 +570,25 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		Key   string `xml:"key"`
 		Value string `xml:"value"`
 	}
+	type iamProfileItem struct {
+		ARN string `xml:"arn"`
+		ID  string `xml:"id"`
+	}
 	type ec2InstanceItem struct {
-		InstanceID       string       `xml:"instanceId"`
-		ImageID          string       `xml:"imageId"`
-		InstanceType     string       `xml:"instanceType"`
-		LaunchTime       string       `xml:"launchTime"`
-		PrivateIPAddress string       `xml:"privateIpAddress"`
-		PublicIPAddress  string       `xml:"publicIpAddress,omitempty"`
-		PublicDNSName    string       `xml:"dnsName,omitempty"`
-		PrivateDNSName   string       `xml:"privateDnsName,omitempty"`
-		SubnetID         string       `xml:"subnetId"`
-		VpcID            string       `xml:"vpcId"`
-		KeyName          string       `xml:"keyName,omitempty"`
-		State            ec2StateItem `xml:"instanceState"`
-		Tags             []tagItem    `xml:"tagSet>item"`
+		InstanceID         string          `xml:"instanceId"`
+		ImageID            string          `xml:"imageId"`
+		InstanceType       string          `xml:"instanceType"`
+		LaunchTime         string          `xml:"launchTime"`
+		PrivateIPAddress   string          `xml:"privateIpAddress"`
+		PublicIPAddress    string          `xml:"publicIpAddress,omitempty"`
+		PublicDNSName      string          `xml:"dnsName,omitempty"`
+		PrivateDNSName     string          `xml:"privateDnsName,omitempty"`
+		SubnetID           string          `xml:"subnetId"`
+		VpcID              string          `xml:"vpcId"`
+		KeyName            string          `xml:"keyName,omitempty"`
+		IamInstanceProfile *iamProfileItem `xml:"iamInstanceProfile,omitempty"`
+		State              ec2StateItem    `xml:"instanceState"`
+		Tags               []tagItem       `xml:"tagSet>item"`
 	}
 	type reservationItem struct {
 		ReservationID string            `xml:"reservationId"`
@@ -632,6 +637,16 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		}
 		item.State.Code = inst.State.Code
 		item.State.Name = inst.State.Name
+		// Echo the IAM instance profile set at launch (#331). The stored value is
+		// the name or ARN supplied; surface it as the ARN and derive an id so a
+		// caller can read back the profile it attached.
+		if inst.IamInstanceProfile != "" {
+			arn := inst.IamInstanceProfile
+			if !strings.HasPrefix(arn, "arn:") {
+				arn = "arn:aws:iam::" + reqCtx.AccountID + ":instance-profile/" + inst.IamInstanceProfile
+			}
+			item.IamInstanceProfile = &iamProfileItem{ARN: arn, ID: "AIPA" + randomHex(8)}
+		}
 		for _, t := range inst.Tags {
 			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck
 		}

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -1,6 +1,8 @@
 package emulator_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"io"
 	"net/http"
@@ -3587,4 +3589,137 @@ func TestEC2_RegisterImage_SharedSnapshot(t *testing.T) {
 	assert.Len(t, fRes.Images, 2, "both AMIs sharing the snapshot must match the filter")
 	assert.True(t, got[amiA], "ami-a should match")
 	assert.True(t, got[amiB], "ami-b should match")
+}
+
+// newEC2SSMTestServer starts a server with both EC2 and SSM plugins sharing
+// state, for end-to-end RunInstances → DescribeInstanceInformation tests (#331).
+func newEC2SSMTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Now())
+	logger := emulator.NewDefaultLogger(0, false)
+
+	ec2p := &emulator.EC2Plugin{}
+	require.NoError(t, ec2p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State: state, Logger: logger, Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(ec2p)
+
+	ssmp := &emulator.SSMPlugin{}
+	require.NoError(t, ssmp.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State: state, Logger: logger, Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(ssmp)
+
+	cfg := emulator.DefaultConfig()
+	ts := httptest.NewServer(emulator.NewServer(*cfg, registry, store, state, tc, logger))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// runInstanceWithProfile launches one instance, optionally with an IAM instance
+// profile name, and returns its instance id.
+func runInstanceWithProfile(t *testing.T, ts *httptest.Server, profile string) string {
+	t.Helper()
+	params := map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-base",
+		"InstanceType": "m7i.xlarge", "MinCount": "1", "MaxCount": "1",
+	}
+	if profile != "" {
+		params["IamInstanceProfile.Name"] = profile
+	}
+	r := ec2Request(t, ts, params)
+	var res struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(r.Body).Decode(&res))
+	r.Body.Close() //nolint:errcheck
+	require.NotEmpty(t, res.Instances)
+	return res.Instances[0].InstanceID
+}
+
+// TestEC2_DescribeInstances_EchoesIamInstanceProfile is a regression test for
+// #331 gap #2: an instance launched with an IAM instance profile reports it back
+// in DescribeInstances; one launched without reports none.
+func TestEC2_DescribeInstances_EchoesIamInstanceProfile(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	withID := runInstanceWithProfile(t, ts, "spawn-spored-profile")
+	withoutID := runInstanceWithProfile(t, ts, "")
+
+	describe := func(id string) (string, bool) {
+		r := ec2Request(t, ts, map[string]string{"Action": "DescribeInstances", "InstanceId.1": id})
+		var res struct {
+			Instances []struct {
+				IamInstanceProfile *struct {
+					ARN string `xml:"arn"`
+					ID  string `xml:"id"`
+				} `xml:"iamInstanceProfile"`
+			} `xml:"reservationSet>item>instancesSet>item"`
+		}
+		require.NoError(t, xml.NewDecoder(r.Body).Decode(&res))
+		r.Body.Close() //nolint:errcheck
+		require.Len(t, res.Instances, 1)
+		if res.Instances[0].IamInstanceProfile == nil {
+			return "", false
+		}
+		return res.Instances[0].IamInstanceProfile.ARN, true
+	}
+
+	arn, present := describe(withID)
+	assert.True(t, present, "instance launched with a profile must echo it")
+	assert.Contains(t, arn, "instance-profile/spawn-spored-profile")
+
+	_, present = describe(withoutID)
+	assert.False(t, present, "instance with no profile must not report one")
+}
+
+// ssmRequestTo posts an SSM JSON request to an httptest server and returns the
+// response body bytes.
+func ssmRequestTo(t *testing.T, ts *httptest.Server, operation string, body any) []byte {
+	t.Helper()
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/", bytes.NewReader(data))
+	require.NoError(t, err)
+	req.Host = "ssm.us-east-1.amazonaws.com"
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "AmazonSSM."+operation)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	out, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return out
+}
+
+// TestSSM_DescribeInstanceInformation_RequiresProfile is a regression test for
+// #331 gap #1: only an instance with an IAM instance profile registers with SSM
+// (PingStatus Online); one without never appears, modeling the dead path.
+func TestSSM_DescribeInstanceInformation_RequiresProfile(t *testing.T) {
+	t.Parallel()
+	ts := newEC2SSMTestServer(t)
+	managedID := runInstanceWithProfile(t, ts, "spawn-spored-profile")
+	deadID := runInstanceWithProfile(t, ts, "")
+
+	r := ssmRequestTo(t, ts, "DescribeInstanceInformation", map[string]any{})
+	var out struct {
+		InstanceInformationList []struct {
+			InstanceID string `json:"InstanceId"`
+			PingStatus string `json:"PingStatus"`
+		} `json:"InstanceInformationList"`
+	}
+	require.NoError(t, json.Unmarshal(r, &out))
+
+	seen := map[string]string{}
+	for _, i := range out.InstanceInformationList {
+		seen[i.InstanceID] = i.PingStatus
+	}
+	assert.Equal(t, "Online", seen[managedID], "profile-bearing instance is SSM-managed")
+	_, deadPresent := seen[deadID]
+	assert.False(t, deadPresent, "instance with no profile can never register (dead path)")
 }

--- a/emulator/ssm_plugin.go
+++ b/emulator/ssm_plugin.go
@@ -961,6 +961,14 @@ func (p *SSMPlugin) describeInstanceInformation(ctx *RequestContext, _ *AWSReque
 		if inst.State.Name != "running" {
 			continue
 		}
+		// SSM registration requires an attached IAM instance profile (which in
+		// real AWS grants ssm:UpdateInstanceInformation). An instance with no
+		// profile can never register, so it does not appear here — letting
+		// callers distinguish a "dead" instance (no profile) from one that is
+		// SSM-managed. (#331)
+		if inst.IamInstanceProfile == "" {
+			continue
+		}
 		infos = append(infos, instanceInfo{
 			InstanceID:      inst.InstanceID,
 			PingStatus:      "Online",


### PR DESCRIPTION
Two EC2/SSM fidelity gaps surfaced by spawn's warm-AMI SSM-readiness logic (spore-host/spawn#98, #181).

## Gap #2 — `DescribeInstances` dropped `IamInstanceProfile` (Fixed)
`RunInstances` accepted and stored the profile, but the describe response had no field for it. Now the response includes `iamInstanceProfile` with `arn` and `id`, so a caller can read back the profile it attached. (Bare names are surfaced as a synthesized `instance-profile/<name>` ARN.)

## Gap #1 — SSM `DescribeInstanceInformation` always reported `Online` (Changed)
Every running instance appeared with `PingStatus=Online` regardless of preconditions. In real AWS, SSM registration requires an IAM instance profile granting `ssm:UpdateInstanceInformation`, and an instance with no profile **never** registers. Now only running instances **with a profile** are listed — so callers can distinguish a *dead* instance (no profile → can never register) from an SSM-managed one.

Eligibility is **profile presence** (per the chosen approach): substrate doesn't model profile→policy attachment, and a missing profile is the actual dead-path signal the consumer tests. Time/agent-boot modeling is intentionally out of scope here.

## Verification
- `TestEC2_DescribeInstances_EchoesIamInstanceProfile` — with-profile echoes it, without-profile reports none.
- `TestSSM_DescribeInstanceInformation_RequiresProfile` — end-to-end via a combined EC2+SSM server: profile-bearing instance is `Online`, profile-less instance never appears (dead path).

`make test` (race) + `make lint` clean. AWS shapes (`iamInstanceProfile>arn/id`, the SSM registration precondition) verified against the EC2/SSM API references.

Closes #331