### PR TITLE
feat(server): opt-in CORS for browser SDK clients (#346); bump Go to 1.26.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CORS support for browser-based AWS SDK clients (#346). The HTTP server can now
+  emit `Access-Control-Allow-*` headers and answer `OPTIONS` preflight requests,
+  so a page served from another origin (e.g. a Vite dev server) can drive the
+  emulator. Off by default; enable via `server.cors.enabled` (with optional
+  `server.cors.allowed_origins`, default reflect-any `*`). Exposes
+  `x-amzn-RequestId` / `x-amz-request-id` / `x-amzn-ErrorType` / `x-amz-id-2` so
+  the SDK can read request IDs and (seeded) error types from the browser.
+
 ### Security
+- Bumped the Go toolchain to **go1.26.5** (`go.mod`, `test/e2e/go.mod`) to clear
+  a call-reachable `crypto/tls` standard-library advisory (GO-2026-5856); CI
+  reads the toolchain from `go.mod`, so `govulncheck` passes again.
 - Bumped `golang.org/x/net` v0.52.0 → v0.56.0 (with `x/sys`, `x/text`) in both the
   root and `test/e2e` modules to clear Trivy-flagged advisories (CVE-2026-27136,
   -33814, -39821, -42502). The dependency is indirect and the CVEs are not

--- a/emulator/config.go
+++ b/emulator/config.go
@@ -128,6 +128,21 @@ type ServerConfig struct {
 
 	// ReadyPath is the HTTP path for the readiness endpoint. Defaults to "/ready".
 	ReadyPath string `mapstructure:"ready_path"`
+
+	// CORS configures cross-origin resource sharing for browser-based clients.
+	CORS CORSConfig `mapstructure:"cors"`
+}
+
+// CORSConfig configures CORS headers and preflight handling. It is off by
+// default (non-browser use needs no CORS); enable it to let browser-based AWS
+// SDK clients (served from another origin) reach the emulator.
+type CORSConfig struct {
+	// Enabled turns on the CORS middleware and OPTIONS preflight handling.
+	Enabled bool `mapstructure:"enabled"`
+
+	// AllowedOrigins is the list of permitted origins. Empty (with Enabled) means
+	// reflect any origin ("*") — reasonable for a local dev emulator.
+	AllowedOrigins []string `mapstructure:"allowed_origins"`
 }
 
 // EventStoreCfg is the YAML-friendly configuration for the event store.

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/cors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -200,6 +201,25 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *Server) buildRouter() *chi.Mux {
 	r := chi.NewRouter()
 	r.Use(middleware.Recoverer)
+
+	// CORS for browser-based AWS SDK clients (opt-in). The AWS SDK issues a
+	// preflight OPTIONS before non-simple requests and sends many x-amz-*/
+	// amz-sdk-* headers; reflect them and expose the request-id/error-type
+	// headers the SDK reads. Off by default — non-browser callers need no CORS.
+	if s.config.Server.CORS.Enabled {
+		origins := s.config.Server.CORS.AllowedOrigins
+		if len(origins) == 0 {
+			origins = []string{"*"}
+		}
+		r.Use(cors.Handler(cors.Options{
+			AllowedOrigins:   origins,
+			AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"},
+			AllowedHeaders:   []string{"*"},
+			ExposedHeaders:   []string{"x-amzn-RequestId", "x-amz-request-id", "x-amzn-ErrorType", "x-amz-id-2"},
+			AllowCredentials: false,
+			MaxAge:           300,
+		}))
+	}
 
 	healthPath := s.config.Server.HealthPath
 	if healthPath == "" {

--- a/emulator/server_test.go
+++ b/emulator/server_test.go
@@ -507,3 +507,60 @@ func TestServer_EmailsEndpoint(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp3.Body).Decode(&result3))
 	assert.Equal(t, 1, result3.Count)
 }
+
+// TestServer_CORS_Preflight verifies that, with CORS enabled, an OPTIONS
+// preflight from a browser origin gets the Access-Control-Allow-* headers and a
+// 2xx, and exposes the AWS request-id/error-type headers (#346).
+func TestServer_CORS_Preflight(t *testing.T) {
+	cfg := emulator.DefaultConfig()
+	cfg.Server.CORS.Enabled = true
+	// Explicit allowlist → exercises origin reflection (a "*" default returns "*").
+	cfg.Server.CORS.AllowedOrigins = []string{"http://localhost:5173"}
+	registry := emulator.NewPluginRegistry()
+	registry.Register(&serverPlugin{
+		serviceName: "sqs",
+		resp:        &emulator.AWSResponse{StatusCode: http.StatusOK, Body: []byte(`{}`)},
+	})
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Now())
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger)
+
+	// Preflight for an EC2 RunInstances-style call from a Vite dev origin.
+	r := httptest.NewRequest(http.MethodOptions, "/", nil)
+	r.Header.Set("Origin", "http://localhost:5173")
+	r.Header.Set("Access-Control-Request-Method", "POST")
+	r.Header.Set("Access-Control-Request-Headers", "authorization,x-amz-target,amz-sdk-invocation-id")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	assert.Less(t, w.Code, 300, "preflight should be a 2xx (no-content), got %d", w.Code)
+	assert.Equal(t, "http://localhost:5173", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, w.Header().Get("Access-Control-Allow-Methods"), "POST")
+
+	// On the ACTUAL (non-preflight) response, the SDK must be able to read the
+	// request-id / error-type headers — Expose-Headers is set here, not on OPTIONS.
+	r2 := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
+	r2.Header.Set("Origin", "http://localhost:5173")
+	r2.Header.Set("X-Amz-Target", "AmazonSQS.SendMessage")
+	w2 := httptest.NewRecorder()
+	srv.ServeHTTP(w2, r2)
+	assert.Equal(t, "http://localhost:5173", w2.Header().Get("Access-Control-Allow-Origin"))
+	expose := strings.ToLower(w2.Header().Get("Access-Control-Expose-Headers"))
+	assert.Contains(t, expose, "x-amzn-requestid")
+	assert.Contains(t, expose, "x-amzn-errortype")
+}
+
+// TestServer_CORS_DisabledByDefault verifies no CORS headers are emitted unless
+// explicitly enabled (non-browser callers are unaffected).
+func TestServer_CORS_DisabledByDefault(t *testing.T) {
+	srv := newTestServer(t)
+	r := httptest.NewRequest(http.MethodOptions, "/", nil)
+	r.Header.Set("Origin", "http://localhost:5173")
+	r.Header.Set("Access-Control-Request-Method", "POST")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"),
+		"CORS must be off by default")
+}

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,11 @@ module github.com/scttfrdmn/substrate
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/go-chi/chi/v5 v5.3.1
+	github.com/go-chi/cors v1.2.2
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
 github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
+github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
+github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/substrate.yaml.example
+++ b/substrate.yaml.example
@@ -13,6 +13,14 @@ server:
   health_path: "/health"
   # HTTP path for the readiness endpoint (lists registered plugins).
   ready_path: "/ready"
+  # CORS for browser-based AWS SDK clients (off by default). Enable to let a page
+  # served from another origin (e.g. a Vite dev server) reach the emulator.
+  cors:
+    enabled: false
+    # Permitted origins. Omit or leave empty (with enabled: true) to reflect any
+    # origin ("*") — reasonable for a local dev emulator.
+    allowed_origins:
+      - "http://localhost:5173"
 
 event_store:
   # Set to false to disable the event log (not recommended for testing use cases).

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/scttfrdmn/substrate/test/e2e
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1


### PR DESCRIPTION
Health + up-to-date pass for 2026-07-20, folding in #346.

## #346 — CORS for browser-based AWS SDK clients (Added)
The HTTP server had no CORS headers / `OPTIONS` handler, so browser SDK clients (served from another origin) couldn't reach it — every call failed at preflight. Adds opt-in CORS middleware (`github.com/go-chi/cors`) to `buildRouter`:
- gated on **`server.cors.enabled`** (off by default; non-browser callers unaffected)
- origin allowlist via `server.cors.allowed_origins` (default reflect-any `*`)
- `OPTIONS` preflight → 2xx; permits the AWS SDK's `x-amz-*` / `amz-sdk-*` / `authorization` / `content-type` headers
- **exposes** `x-amzn-RequestId` / `x-amz-request-id` / `x-amzn-ErrorType` / `x-amz-id-2` so the browser SDK can read request IDs and **seeded error types** (keeps failure-path testing usable from the browser)

Unblocks **spawn-ts** (browser-native port of spore.host spawn). Documented in `substrate.yaml.example`.

## Go toolchain → 1.26.5 (Security)
`govulncheck` started failing on **every** PR due to a new call-reachable `crypto/tls` stdlib advisory **GO-2026-5856** (fixed in go1.26.5). Bumped `toolchain` in both `go.mod` and `test/e2e/go.mod`; CI reads it from `go.mod`, so the check passes again. This also unblocks the open Dependabot PRs (#342/#343), which were red for the same reason.

## Verification
`make test` (race) + `make lint` clean on go1.26.5; `govulncheck ./...` → no vulnerabilities. New tests: `TestServer_CORS_Preflight` (origin reflection + exposed headers) and `TestServer_CORS_DisabledByDefault`. CORS semantics verified against the go-chi/cors and AWS SDK preflight behavior.

Closes #346