### PR TITLE
chore(release): v0.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.72.0] - 2026-07-20
+
 ### Added
 - CORS support for browser-based AWS SDK clients (#346). The HTTP server can now
   emit `Access-Control-Allow-*` headers and answer `OPTIONS` preflight requests,
@@ -1915,7 +1917,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.71.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.72.0...HEAD
+[v0.72.0]: https://github.com/scttfrdmn/substrate/compare/v0.71.0...v0.72.0
 [v0.71.0]: https://github.com/scttfrdmn/substrate/compare/v0.70.0...v0.71.0
 [v0.70.0]: https://github.com/scttfrdmn/substrate/compare/v0.69.0...v0.70.0
 [v0.69.0]: https://github.com/scttfrdmn/substrate/compare/v0.68.3...v0.69.0


### PR DESCRIPTION
Minor release cutting **v0.72.0**. Highlights: opt-in **CORS** for browser AWS SDK clients (#346), **Go 1.26.5** toolchain (clears crypto/tls GO-2026-5856), golang.org/x/net bump, trivy-action pin, and Dependabot enablement. Changelog-only; all features already merged. After merge, the merge commit is tagged `v0.72.0` (signed) and released, per the protected flow.