### PR TITLE
feat(ec2): cluster placement group actions (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- EC2: cluster placement group actions (#344). `CreatePlacementGroup` (accepts
+  `GroupName` + `Strategy`, defaults `cluster`; duplicate name →
+  `InvalidPlacementGroup.Duplicate`), `DescribePlacementGroups` (with `GroupName.N`
+  filter, `State=available`), and `DeletePlacementGroup` (unknown name →
+  `InvalidPlacementGroup.Unknown`). `RunInstances` now validates a
+  `Placement.GroupName` against known groups (unknown → `InvalidPlacementGroup.Unknown`),
+  so a create → poll(available) → launch ordering (e.g. spawn's per-AZ MPI launch)
+  is testable end-to-end.
+
 ## [v0.72.0] - 2026-07-20
 
 ### Added

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -150,6 +150,13 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.describeImages(ctx, req)
 	case "DeregisterImage":
 		return p.deregisterImage(ctx, req)
+	// Placement group operations
+	case "CreatePlacementGroup":
+		return p.createPlacementGroup(ctx, req)
+	case "DescribePlacementGroups":
+		return p.describePlacementGroups(ctx, req)
+	case "DeletePlacementGroup":
+		return p.deletePlacementGroup(ctx, req)
 	// Availability Zone operations
 	case "DescribeAvailabilityZones":
 		return p.describeAvailabilityZones(ctx, req)
@@ -245,6 +252,15 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	sgID := req.Params["SecurityGroupId.1"]
 	if sgID == "" {
 		sgID = req.Params["SecurityGroupIds.1"]
+	}
+
+	// If a placement group is named, it must exist — mirrors AWS so a
+	// create → poll(available) → launch ordering is testable (#344).
+	if pgName := req.Params["Placement.GroupName"]; pgName != "" {
+		pgKey := ec2PlacementGroupStateKey(reqCtx.AccountID, reqCtx.Region, pgName)
+		if data, _ := p.state.Get(context.Background(), ec2Namespace, pgKey); data == nil {
+			return nil, &AWSError{Code: "InvalidPlacementGroup.Unknown", Message: "The placement group '" + pgName + "' is unknown.", HTTPStatus: http.StatusBadRequest}
+		}
 	}
 
 	// Networking can be specified either at the top level (above) or nested in a
@@ -2728,6 +2744,119 @@ func (p *EC2Plugin) describeAvailabilityZones(reqCtx *RequestContext, _ *AWSRequ
 		})
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
+}
+
+// createPlacementGroup creates an EC2 placement group (#344). A repeat create of
+// an existing name returns InvalidPlacementGroup.Duplicate.
+func (p *EC2Plugin) createPlacementGroup(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	name := req.Params["GroupName"]
+	if name == "" {
+		return nil, &AWSError{Code: "MissingParameter", Message: "GroupName is required", HTTPStatus: http.StatusBadRequest}
+	}
+	strategy := req.Params["Strategy"]
+	if strategy == "" {
+		strategy = "cluster"
+	}
+
+	key := ec2PlacementGroupStateKey(reqCtx.AccountID, reqCtx.Region, name)
+	if existing, _ := p.state.Get(context.Background(), ec2Namespace, key); existing != nil {
+		return nil, &AWSError{Code: "InvalidPlacementGroup.Duplicate", Message: "The placement group '" + name + "' already exists.", HTTPStatus: http.StatusBadRequest}
+	}
+
+	pg := EC2PlacementGroup{
+		GroupName: name,
+		GroupID:   generatePlacementGroupID(),
+		Strategy:  strategy,
+		State:     "available",
+		AccountID: reqCtx.AccountID,
+		Region:    reqCtx.Region,
+	}
+	data, err := json.Marshal(pg)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 createPlacementGroup marshal: %w", err)
+	}
+	if err := p.state.Put(context.Background(), ec2Namespace, key, data); err != nil {
+		return nil, fmt.Errorf("ec2 createPlacementGroup put: %w", err)
+	}
+
+	type pgItem struct {
+		GroupName string `xml:"groupName"`
+		GroupID   string `xml:"groupId"`
+		Strategy  string `xml:"strategy"`
+		State     string `xml:"state"`
+	}
+	type response struct {
+		XMLName        xml.Name `xml:"CreatePlacementGroupResponse"`
+		XMLNS          string   `xml:"xmlns,attr"`
+		PlacementGroup pgItem   `xml:"placementGroup"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:          "http://ec2.amazonaws.com/doc/2016-11-15/",
+		PlacementGroup: pgItem{GroupName: pg.GroupName, GroupID: pg.GroupID, Strategy: pg.Strategy, State: pg.State},
+	})
+}
+
+// describePlacementGroups lists placement groups, optionally filtered by
+// GroupName.N parameters (#344).
+func (p *EC2Plugin) describePlacementGroups(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	names := extractIndexedParams(req.Params, "GroupName")
+	allKeys, err := p.state.List(context.Background(), ec2Namespace,
+		"placement_group:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+	if err != nil {
+		return nil, fmt.Errorf("ec2 describePlacementGroups list: %w", err)
+	}
+
+	type pgItem struct {
+		GroupName string `xml:"groupName"`
+		GroupID   string `xml:"groupId"`
+		Strategy  string `xml:"strategy"`
+		State     string `xml:"state"`
+	}
+	type response struct {
+		XMLName xml.Name `xml:"DescribePlacementGroupsResponse"`
+		XMLNS   string   `xml:"xmlns,attr"`
+		Groups  []pgItem `xml:"placementGroupSet>item"`
+	}
+
+	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
+	for _, k := range allKeys {
+		data, getErr := p.state.Get(context.Background(), ec2Namespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var pg EC2PlacementGroup
+		if json.Unmarshal(data, &pg) != nil {
+			continue
+		}
+		if len(names) > 0 && !containsStr(names, pg.GroupName) {
+			continue
+		}
+		resp.Groups = append(resp.Groups, pgItem{GroupName: pg.GroupName, GroupID: pg.GroupID, Strategy: pg.Strategy, State: pg.State})
+	}
+	return ec2XMLResponse(http.StatusOK, resp)
+}
+
+// deletePlacementGroup removes a placement group by name (#344). Deleting an
+// unknown group returns InvalidPlacementGroup.Unknown.
+func (p *EC2Plugin) deletePlacementGroup(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	name := req.Params["GroupName"]
+	if name == "" {
+		return nil, &AWSError{Code: "MissingParameter", Message: "GroupName is required", HTTPStatus: http.StatusBadRequest}
+	}
+	key := ec2PlacementGroupStateKey(reqCtx.AccountID, reqCtx.Region, name)
+	data, _ := p.state.Get(context.Background(), ec2Namespace, key)
+	if data == nil {
+		return nil, &AWSError{Code: "InvalidPlacementGroup.Unknown", Message: "The placement group '" + name + "' is unknown.", HTTPStatus: http.StatusBadRequest}
+	}
+	if err := p.state.Delete(context.Background(), ec2Namespace, key); err != nil {
+		return nil, fmt.Errorf("ec2 deletePlacementGroup delete: %w", err)
+	}
+	type response struct {
+		XMLName xml.Name `xml:"DeletePlacementGroupResponse"`
+		XMLNS   string   `xml:"xmlns,attr"`
+		Return  bool     `xml:"return"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
 }
 
 // azRegionAbbrev returns a short abbreviation for a region name used in zone IDs

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -3723,3 +3723,82 @@ func TestSSM_DescribeInstanceInformation_RequiresProfile(t *testing.T) {
 	_, deadPresent := seen[deadID]
 	assert.False(t, deadPresent, "instance with no profile can never register (dead path)")
 }
+
+// TestEC2_PlacementGroups is a regression test for #344: the create → poll
+// (available) → launch-into → delete lifecycle for cluster placement groups,
+// including duplicate/unknown errors, as spawn's MPI launch path exercises.
+func TestEC2_PlacementGroups(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	// Create.
+	c := ec2Request(t, ts, map[string]string{
+		"Action": "CreatePlacementGroup", "GroupName": "mpi-pg", "Strategy": "cluster",
+	})
+	require.Equal(t, http.StatusOK, c.StatusCode)
+	var created struct {
+		PG struct {
+			GroupName string `xml:"groupName"`
+			GroupID   string `xml:"groupId"`
+			State     string `xml:"state"`
+		} `xml:"placementGroup"`
+	}
+	require.NoError(t, xml.NewDecoder(c.Body).Decode(&created))
+	c.Body.Close() //nolint:errcheck
+	assert.Equal(t, "mpi-pg", created.PG.GroupName)
+	assert.NotEmpty(t, created.PG.GroupID)
+	assert.Equal(t, "available", created.PG.State)
+
+	// Duplicate create → InvalidPlacementGroup.Duplicate (400).
+	dup := ec2Request(t, ts, map[string]string{"Action": "CreatePlacementGroup", "GroupName": "mpi-pg"})
+	assert.Equal(t, http.StatusBadRequest, dup.StatusCode)
+	dup.Body.Close() //nolint:errcheck
+
+	// Describe by name → available.
+	d := ec2Request(t, ts, map[string]string{"Action": "DescribePlacementGroups", "GroupName.1": "mpi-pg"})
+	var desc struct {
+		Groups []struct {
+			GroupName string `xml:"groupName"`
+			State     string `xml:"state"`
+		} `xml:"placementGroupSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(d.Body).Decode(&desc))
+	d.Body.Close() //nolint:errcheck
+	require.Len(t, desc.Groups, 1)
+	assert.Equal(t, "available", desc.Groups[0].State)
+
+	// RunInstances into the known group → success.
+	ok := ec2Request(t, ts, map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-base", "InstanceType": "c7i.xlarge",
+		"MinCount": "1", "MaxCount": "1", "Placement.GroupName": "mpi-pg",
+	})
+	assert.Equal(t, http.StatusOK, ok.StatusCode)
+	ok.Body.Close() //nolint:errcheck
+
+	// RunInstances into an unknown group → InvalidPlacementGroup.Unknown (400).
+	bad := ec2Request(t, ts, map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-base", "InstanceType": "c7i.xlarge",
+		"MinCount": "1", "MaxCount": "1", "Placement.GroupName": "does-not-exist",
+	})
+	assert.Equal(t, http.StatusBadRequest, bad.StatusCode)
+	bad.Body.Close() //nolint:errcheck
+
+	// Delete, then describe → gone; delete again → Unknown.
+	del := ec2Request(t, ts, map[string]string{"Action": "DeletePlacementGroup", "GroupName": "mpi-pg"})
+	assert.Equal(t, http.StatusOK, del.StatusCode)
+	del.Body.Close() //nolint:errcheck
+
+	d2 := ec2Request(t, ts, map[string]string{"Action": "DescribePlacementGroups"})
+	var desc2 struct {
+		Groups []struct {
+			GroupName string `xml:"groupName"`
+		} `xml:"placementGroupSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(d2.Body).Decode(&desc2))
+	d2.Body.Close() //nolint:errcheck
+	assert.Empty(t, desc2.Groups)
+
+	delAgain := ec2Request(t, ts, map[string]string{"Action": "DeletePlacementGroup", "GroupName": "mpi-pg"})
+	assert.Equal(t, http.StatusBadRequest, delAgain.StatusCode)
+	delAgain.Body.Close() //nolint:errcheck
+}

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -454,6 +454,42 @@ func ec2SnapshotStateKey(accountID, region, snapshotID string) string {
 	return "snapshot:" + accountID + "/" + region + "/" + snapshotID
 }
 
+// EC2PlacementGroup represents an Amazon EC2 placement group.
+type EC2PlacementGroup struct {
+	// GroupName is the user-supplied placement group name.
+	GroupName string `json:"group_name"`
+
+	// GroupID is the AWS-assigned identifier (e.g. "pg-0123456789abcdef0").
+	GroupID string `json:"group_id"`
+
+	// Strategy is the placement strategy: "cluster", "spread", or "partition".
+	Strategy string `json:"strategy"`
+
+	// State is the placement group state: always "available" in Substrate.
+	State string `json:"state"`
+
+	// Tags holds key-value metadata tags.
+	Tags []EC2Tag `json:"tags,omitempty"`
+
+	// AccountID is the AWS account that owns the placement group.
+	AccountID string `json:"account_id"`
+
+	// Region is the AWS region in which the placement group resides.
+	Region string `json:"region"`
+}
+
+// generatePlacementGroupID generates a random placement group ID in the format
+// "pg-" followed by 17 hex characters.
+func generatePlacementGroupID() string {
+	return "pg-" + randomHex(8)
+}
+
+// ec2PlacementGroupStateKey returns the state key for a placement group (keyed
+// by name, which is unique per account/region).
+func ec2PlacementGroupStateKey(accountID, region, groupName string) string {
+	return "placement_group:" + accountID + "/" + region + "/" + groupName
+}
+
 // EC2ElasticIP represents an Amazon EC2 Elastic IP address.
 type EC2ElasticIP struct {
 	// AllocationID is the unique identifier for the Elastic IP allocation.


### PR DESCRIPTION
Unblocks spawn's MPI/HPC launch path (per-AZ lazy cluster placement groups) against Substrate.

## Added
- **`CreatePlacementGroup`** — `GroupName` + `Strategy` (default `cluster`); repeat create → `InvalidPlacementGroup.Duplicate`.
- **`DescribePlacementGroups`** — `GroupName.N` filter; returns `State=available` (spawn polls for this before launching).
- **`DeletePlacementGroup`** — removes by name; unknown → `InvalidPlacementGroup.Unknown`.
- **`RunInstances`** — validates `Placement.GroupName` against known groups (unknown → `InvalidPlacementGroup.Unknown`), so the create → poll(available) → launch ordering is testable.

New `EC2PlacementGroup` type + `generatePlacementGroupID` / `ec2PlacementGroupStateKey` helpers.

## Verification
`TestEC2_PlacementGroups` covers the full lifecycle: create → duplicate error → describe(available) → launch-into → launch-into-unknown(error) → delete → describe(empty) → delete-again(error). `make test` (race) + `make lint` clean. AWS shapes (`placementGroupSet>item`, error codes, `Placement.GroupName`) verified against the EC2 API reference. All API-observable state — squarely in substrate's scope.

Closes #344