### PR TITLE
fix(ec2): RunInstances response includes tagSet for launch-time tags (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- EC2: `RunInstances` now returns the instance `tagSet` for launch-time tags
+  applied via `TagSpecifications` (#351), matching real EC2. Previously the tags
+  were stored (and appeared in a later `DescribeInstances`) but omitted from the
+  `RunInstances` response, so SDK callers reading the returned instance's tags got
+  an empty set. (`StartInstances`/`StopInstances` responses correctly omit
+  `tagSet`, matching AWS — no change there.)
+
 ### Added
 - EC2: cluster placement group actions (#344). `CreatePlacementGroup` (accepts
   `GroupName` + `Strategy`, defaults `cluster`; duplicate name →

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -460,6 +460,10 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 }
 
 func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID string, reqCtx *RequestContext) (*AWSResponse, error) {
+	type tagItem struct {
+		Key   string `xml:"key"`
+		Value string `xml:"value"`
+	}
 	type ec2InstanceItem struct {
 		InstanceID       string `xml:"instanceId"`
 		ImageID          string `xml:"imageId"`
@@ -476,6 +480,7 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 			Code int    `xml:"code"`
 			Name string `xml:"name"`
 		} `xml:"instanceState"`
+		Tags []tagItem `xml:"tagSet>item"`
 	}
 	type response struct {
 		XMLName       xml.Name          `xml:"RunInstancesResponse"`
@@ -506,6 +511,11 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 		}
 		item.State.Code = inst.State.Code
 		item.State.Name = inst.State.Name
+		// Echo launch-time tags (from TagSpecifications) — real EC2 populates
+		// tagSet in the RunInstances response, not just DescribeInstances (#351).
+		for _, t := range inst.Tags {
+			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck // XML tags differ from EC2Tag's JSON tags.
+		}
 		resp.Instances = append(resp.Instances, item)
 	}
 

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -3802,3 +3802,41 @@ func TestEC2_PlacementGroups(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, delAgain.StatusCode)
 	delAgain.Body.Close() //nolint:errcheck
 }
+
+// TestEC2_RunInstances_ReturnsTagSet is a regression test for #351: launch-time
+// tags (TagSpecification, ResourceType=instance) must appear in the RunInstances
+// response tagSet, matching real EC2 — not only in a later DescribeInstances.
+func TestEC2_RunInstances_ReturnsTagSet(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	run := ec2Request(t, ts, map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-12345678", "InstanceType": "c6a.xlarge",
+		"MinCount": "1", "MaxCount": "1",
+		"TagSpecification.1.ResourceType": "instance",
+		"TagSpecification.1.Tag.1.Key":    "Name",
+		"TagSpecification.1.Tag.1.Value":  "echo-test",
+		"TagSpecification.1.Tag.2.Key":    "spawn:managed",
+		"TagSpecification.1.Tag.2.Value":  "true",
+	})
+	require.Equal(t, http.StatusOK, run.StatusCode)
+	var res struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+			Tags       []struct {
+				Key   string `xml:"key"`
+				Value string `xml:"value"`
+			} `xml:"tagSet>item"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(run.Body).Decode(&res))
+	run.Body.Close() //nolint:errcheck
+	require.Len(t, res.Instances, 1)
+
+	tags := map[string]string{}
+	for _, tg := range res.Instances[0].Tags {
+		tags[tg.Key] = tg.Value
+	}
+	assert.Equal(t, "echo-test", tags["Name"], "RunInstances response must echo launch-time tags")
+	assert.Equal(t, "true", tags["spawn:managed"])
+}


### PR DESCRIPTION
## Problem
`RunInstances` stored `TagSpecification` tags but its response item struct had **no `tagSet` field**, so SDK callers reading the returned instance's tags got an empty set — even though a later `DescribeInstances` rendered them fine. Real EC2 populates `tagSet` in the `RunInstances` response.

## Fix
Add `tagSet` to the `runInstancesResponse` item struct and populate from `inst.Tags`, mirroring the `DescribeInstances` renderer.

Per the reporter's note, I checked **`StartInstances`/`StopInstances`** too — they correctly return only `instanceId` + `currentState`/`previousState` (no `tagSet`), matching AWS, so no change there.

## Verification
`TestEC2_RunInstances_ReturnsTagSet` launches with two `TagSpecification` tags and asserts both appear in the `RunInstances` response `tagSet`. `make test` (race) + `make lint` clean. Found building **spawn-ts** (browser EC2 launcher using #346's CORS).

Closes #351