### PR TITLE
chore(release): v0.73.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.73.0] - 2026-07-20
+
 ### Fixed
 - EC2: `RunInstances` now returns the instance `tagSet` for launch-time tags
   applied via `TagSpecifications` (#351), matching real EC2. Previously the tags
@@ -1935,7 +1937,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.72.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.73.0...HEAD
+[v0.73.0]: https://github.com/scttfrdmn/substrate/compare/v0.72.0...v0.73.0
 [v0.72.0]: https://github.com/scttfrdmn/substrate/compare/v0.71.0...v0.72.0
 [v0.71.0]: https://github.com/scttfrdmn/substrate/compare/v0.70.0...v0.71.0
 [v0.70.0]: https://github.com/scttfrdmn/substrate/compare/v0.69.0...v0.70.0


### PR DESCRIPTION
Minor release cutting **v0.73.0**: EC2 cluster **placement group** actions (#344) and the **RunInstances `tagSet`** fix (#351). Changelog-only; both merged. After merge, the merge commit is tagged `v0.73.0` (signed) and released, per the protected flow.