### PR TITLE
feat(ssm): seedable SendCommand/GetCommandInvocation outcomes (#345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- SSM: seedable `SendCommand` / `GetCommandInvocation` outcomes (#345). Substrate
+  still does not execute the shell command (that is workload-internal and out of
+  scope), but a test can now seed the **observable result** — `Status`, stdout,
+  stderr, and `ResponseCode` (exit code) — that `GetCommandInvocation` returns,
+  instead of always getting `Success` with empty output. New control-plane
+  endpoints `POST` / `DELETE /v1/ssm/command-invocation` seed by document name
+  (default `*` wildcard) with an optional command-parameter substring match
+  (`paramMatch`), following the Athena/SageMaker/Bedrock seed pattern. Unseeded
+  commands keep the nominal `Success`/empty result. `GetCommandInvocation` now
+  also returns `ResponseCode`.
+
 ## [v0.73.0] - 2026-07-20
 
 ### Fixed

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -255,6 +255,9 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/sagemaker/training-job-status", s.handleSageMakerSeedTrainingJobStatus)
 	r.Delete("/v1/sagemaker/training-job-status", s.handleSageMakerClearTrainingJobStatus)
 
+	r.Post("/v1/ssm/command-invocation", s.handleSSMSeedCommandInvocation)
+	r.Delete("/v1/ssm/command-invocation", s.handleSSMClearCommandInvocation)
+
 	// Bedrock Runtime control-plane endpoints.
 	r.Post("/v1/bedrock-runtime/responses", s.handleBedrockRuntimeSeedResponse)
 	r.Delete("/v1/bedrock-runtime/responses", s.handleBedrockRuntimeClearResponses)

--- a/emulator/ssm_control.go
+++ b/emulator/ssm_control.go
@@ -1,0 +1,138 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ssmCtrlNamespace is the state namespace for SSM control-plane (seed) data.
+const ssmCtrlNamespace = "ssm-ctrl"
+
+// ssmSeededInvocation is a seeded Run Command outcome. Substrate never executes
+// the command; a seed lets a test set the observable result that
+// GetCommandInvocation returns, keyed by document name (with an optional
+// command-parameter substring match) or the "*" wildcard.
+type ssmSeededInvocation struct {
+	// DocumentName the seed applies to, or "*" for any document.
+	DocumentName string `json:"documentName"`
+
+	// ParamMatch, if set, requires the SendCommand parameters to contain this
+	// substring (matched against the flattened Parameters values) — lets a test
+	// distinguish, e.g., "systemctl status spored" from other RunShellScript calls.
+	ParamMatch string `json:"paramMatch"`
+
+	// Status is the resolved invocation status ("Success", "Failed", ...).
+	Status string `json:"status"`
+
+	// Stdout / Stderr are the resolved StandardOutputContent / StandardErrorContent.
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+
+	// ExitCode is the resolved ResponseCode.
+	ExitCode int `json:"exitCode"`
+}
+
+// ssmCtrlKey returns the state key for a seeded invocation. Document-scoped seeds
+// use "invocation:{doc}"; the wildcard uses "invocation:*".
+func ssmCtrlKey(documentName string) string {
+	if documentName == "" {
+		documentName = "*"
+	}
+	return "invocation:" + documentName
+}
+
+// resolveSeededInvocation returns the seeded outcome for a command, if any,
+// matching by exact document name first then the "*" wildcard, and honoring an
+// optional ParamMatch substring against the flattened parameter values. It
+// returns (nil, nil) when no seed applies, so callers fall back to the nominal
+// Success/empty result.
+func (p *SSMPlugin) resolveSeededInvocation(documentName string, params map[string][]string) (*ssmSeededInvocation, error) {
+	goCtx := context.Background()
+	flat := flattenSSMParams(params)
+	for _, key := range []string{ssmCtrlKey(documentName), ssmCtrlKey("*")} {
+		data, err := p.state.Get(goCtx, ssmCtrlNamespace, key)
+		if err != nil {
+			return nil, fmt.Errorf("ssm resolveSeededInvocation get: %w", err)
+		}
+		if data == nil {
+			continue
+		}
+		var seed ssmSeededInvocation
+		if err := json.Unmarshal(data, &seed); err != nil {
+			return nil, fmt.Errorf("ssm resolveSeededInvocation unmarshal: %w", err)
+		}
+		if seed.ParamMatch != "" && !strings.Contains(flat, seed.ParamMatch) {
+			continue
+		}
+		return &seed, nil
+	}
+	return nil, nil //nolint:nilnil // (nil, nil) = "no seed applies", handled by caller.
+}
+
+// flattenSSMParams joins all SendCommand parameter values into a single string
+// for substring matching.
+func flattenSSMParams(params map[string][]string) string {
+	var b strings.Builder
+	for _, vals := range params {
+		for _, v := range vals {
+			b.WriteString(v)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// handleSSMSeedCommandInvocation handles POST /v1/ssm/command-invocation. It
+// seeds the outcome GetCommandInvocation returns for commands matching the given
+// document name (default "*") and optional parameter substring. Substrate does
+// not execute the command; this sets the observable result.
+// Body: {"documentName","paramMatch","status","stdout","stderr","exitCode"}.
+func (s *Server) handleSSMSeedCommandInvocation(w http.ResponseWriter, r *http.Request) {
+	var seed ssmSeededInvocation
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.Status == "" {
+		http.Error(w, `{"error":"status is required"}`, http.StatusBadRequest)
+		return
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), ssmCtrlNamespace, ssmCtrlKey(seed.DocumentName), data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true, "documentName": ssmCtrlKey(seed.DocumentName)})
+}
+
+// handleSSMClearCommandInvocation handles DELETE /v1/ssm/command-invocation.
+// With ?documentName=... it removes that seed; without it removes all.
+func (s *Server) handleSSMClearCommandInvocation(w http.ResponseWriter, r *http.Request) {
+	if doc := r.URL.Query().Get("documentName"); doc != "" {
+		if err := s.state.Delete(r.Context(), ssmCtrlNamespace, ssmCtrlKey(doc)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), ssmCtrlNamespace, "invocation:")
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), ssmCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}

--- a/emulator/ssm_plugin.go
+++ b/emulator/ssm_plugin.go
@@ -827,6 +827,9 @@ type SSMCommandInvocation struct {
 	// StandardErrorContent is the captured stderr.
 	StandardErrorContent string `json:"StandardErrorContent"`
 
+	// ResponseCode is the shell exit code of the command (0 on Success).
+	ResponseCode int `json:"ResponseCode"`
+
 	// DocumentName is the SSM document that was executed.
 	DocumentName string `json:"DocumentName"`
 }
@@ -864,14 +867,33 @@ func (p *SSMPlugin) sendCommand(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		return nil, fmt.Errorf("ssm sendCommand state.Put: %w", err)
 	}
 
-	// Create per-instance invocation records immediately (Success in test mode).
+	// Resolve any seeded outcome (substrate does not execute the command; a seed
+	// sets the observable result). Unseeded → nominal Success/empty (#345).
+	status, stdout, stderr, exitCode := "Success", "", "", 0
+	seed, seedErr := p.resolveSeededInvocation(input.DocumentName, input.Parameters)
+	if seedErr != nil {
+		return nil, seedErr
+	}
+	if seed != nil {
+		status, stdout, stderr, exitCode = seed.Status, seed.Stdout, seed.Stderr, seed.ExitCode
+	}
+	// The command status reflects the resolved invocation outcome.
+	if status != "Success" {
+		cmd.Status = status
+		if data, mErr := json.Marshal(cmd); mErr == nil {
+			_ = p.state.Put(goCtx, ssmNamespace, ssmCommandKey(ctx.AccountID, ctx.Region, commandID), data)
+		}
+	}
+
+	// Create per-instance invocation records with the resolved outcome.
 	for _, instID := range input.InstanceIDs {
 		inv := SSMCommandInvocation{
 			CommandID:             commandID,
 			InstanceID:            instID,
-			Status:                "Success",
-			StandardOutputContent: "",
-			StandardErrorContent:  "",
+			Status:                status,
+			StandardOutputContent: stdout,
+			StandardErrorContent:  stderr,
+			ResponseCode:          exitCode,
 			DocumentName:          input.DocumentName,
 		}
 		invData, _ := json.Marshal(inv)
@@ -924,6 +946,7 @@ func (p *SSMPlugin) getCommandInvocation(ctx *RequestContext, req *AWSRequest) (
 		"Status":                inv.Status,
 		"StandardOutputContent": inv.StandardOutputContent,
 		"StandardErrorContent":  inv.StandardErrorContent,
+		"ResponseCode":          inv.ResponseCode,
 		"DocumentName":          inv.DocumentName,
 	})
 }

--- a/emulator/ssm_plugin_test.go
+++ b/emulator/ssm_plugin_test.go
@@ -261,3 +261,62 @@ func TestSSMPlugin_DescribeInstanceInformation(t *testing.T) {
 	list, _ := out["InstanceInformationList"].([]interface{})
 	assert.Empty(t, list)
 }
+
+// ssmSeedInvocation posts a seeded Run Command outcome to the control endpoint.
+func ssmSeedInvocation(t *testing.T, srv *emulator.Server, body map[string]any) {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/v1/ssm/command-invocation", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+}
+
+// TestSSM_SeededCommandInvocation is a regression test for #345: a seeded outcome
+// drives GetCommandInvocation's status/stdout/stderr/exit code (substrate does
+// not execute the command); an unseeded command keeps the nominal Success/empty.
+func TestSSM_SeededCommandInvocation(t *testing.T) {
+	srv := newSSMTestServer(t)
+
+	// Seed a Failed outcome for RunShellScript commands mentioning "spored".
+	ssmSeedInvocation(t, srv, map[string]any{
+		"documentName": "AWS-RunShellScript",
+		"paramMatch":   "systemctl status spored",
+		"status":       "Failed",
+		"stdout":       "",
+		"stderr":       "Unit spored.service could not be found.\n",
+		"exitCode":     4,
+	})
+
+	// Send a matching command.
+	sendResp := ssmRequest(t, srv, "SendCommand", map[string]any{
+		"DocumentName": "AWS-RunShellScript",
+		"InstanceIds":  []string{"i-abc123"},
+		"Parameters":   map[string][]string{"commands": {"systemctl status spored"}},
+	})
+	require.Equal(t, http.StatusOK, sendResp.StatusCode)
+	cmdID, _ := readSSMBody(t, sendResp)["Command"].(map[string]any)["CommandId"].(string)
+	require.NotEmpty(t, cmdID)
+
+	// GetCommandInvocation returns the seeded outcome.
+	getResp := ssmRequest(t, srv, "GetCommandInvocation", map[string]any{
+		"CommandId": cmdID, "InstanceId": "i-abc123",
+	})
+	got := readSSMBody(t, getResp)
+	assert.Equal(t, "Failed", got["Status"])
+	assert.Contains(t, got["StandardErrorContent"], "spored.service could not be found")
+	assert.Equal(t, float64(4), got["ResponseCode"])
+
+	// A non-matching command (different params) falls back to nominal Success.
+	send2 := ssmRequest(t, srv, "SendCommand", map[string]any{
+		"DocumentName": "AWS-RunShellScript",
+		"InstanceIds":  []string{"i-abc123"},
+		"Parameters":   map[string][]string{"commands": {"echo hello"}},
+	})
+	cmd2, _ := readSSMBody(t, send2)["Command"].(map[string]any)["CommandId"].(string)
+	get2 := ssmRequest(t, srv, "GetCommandInvocation", map[string]any{
+		"CommandId": cmd2, "InstanceId": "i-abc123",
+	})
+	assert.Equal(t, "Success", readSSMBody(t, get2)["Status"])
+}

--- a/emulator/ssm_plugin_test.go
+++ b/emulator/ssm_plugin_test.go
@@ -320,3 +320,48 @@ func TestSSM_SeededCommandInvocation(t *testing.T) {
 	})
 	assert.Equal(t, "Success", readSSMBody(t, get2)["Status"])
 }
+
+// TestSSM_SeedCommandInvocation_WildcardAndClear covers the "*" wildcard seed,
+// the clear endpoints (targeted + all), and seed validation (#345).
+func TestSSM_SeedCommandInvocation_WildcardAndClear(t *testing.T) {
+	srv := newSSMTestServer(t)
+
+	postSeed := func(body map[string]any) int {
+		b, _ := json.Marshal(body)
+		r := httptest.NewRequest(http.MethodPost, "/v1/ssm/command-invocation", bytes.NewReader(b))
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, r)
+		return w.Result().StatusCode
+	}
+	del := func(query string) int {
+		r := httptest.NewRequest(http.MethodDelete, "/v1/ssm/command-invocation"+query, nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, r)
+		return w.Result().StatusCode
+	}
+	getStatus := func() string {
+		send := ssmRequest(t, srv, "SendCommand", map[string]any{
+			"DocumentName": "AWS-RunShellScript", "InstanceIds": []string{"i-1"},
+			"Parameters": map[string][]string{"commands": {"whoami"}},
+		})
+		id, _ := readSSMBody(t, send)["Command"].(map[string]any)["CommandId"].(string)
+		g := ssmRequest(t, srv, "GetCommandInvocation", map[string]any{"CommandId": id, "InstanceId": "i-1"})
+		return readSSMBody(t, g)["Status"].(string)
+	}
+
+	// Missing status → 400.
+	assert.Equal(t, http.StatusBadRequest, postSeed(map[string]any{"documentName": "*"}))
+
+	// Wildcard seed applies to any document.
+	assert.Equal(t, http.StatusOK, postSeed(map[string]any{"status": "Failed", "stderr": "boom"}))
+	assert.Equal(t, "Failed", getStatus())
+
+	// Targeted clear (by documentName) removes the wildcard seed → back to Success.
+	assert.Equal(t, http.StatusOK, del("?documentName=*"))
+	assert.Equal(t, "Success", getStatus())
+
+	// Re-seed, then clear-all (no query) → back to Success.
+	assert.Equal(t, http.StatusOK, postSeed(map[string]any{"status": "Failed"}))
+	assert.Equal(t, http.StatusOK, del(""))
+	assert.Equal(t, "Success", getStatus())
+}


### PR DESCRIPTION
Addresses #345 **within substrate's scope boundary** — models the observable Run Command *result*, without executing the command.

## Scope note
#345's title says "execute the shell command." Substrate deliberately **does not** run workloads (executing user commands is workload-internal, non-deterministic, and would break replay — the container/data-plane tier we don't do). Instead this models what a caller *observes* via the API: `GetCommandInvocation`'s `Status` / stdout / stderr / `ResponseCode`. That's what a consumer's poll loop reads, and it stays fully deterministic.

## What's added
- **`POST` / `DELETE /v1/ssm/command-invocation`** — seed the outcome for commands matching a document name (default `*` wildcard) with an optional command-parameter substring (`paramMatch`), e.g. `{"documentName":"AWS-RunShellScript","paramMatch":"systemctl status spored","status":"Failed","stderr":"...","exitCode":4}`. Mirrors the Athena/SageMaker/Bedrock seed pattern.
- **`SendCommand`** resolves the seed at request time and bakes the outcome into the per-instance invocation records. **Unseeded → nominal `Success`/empty (unchanged)**, so existing behavior is preserved.
- **`GetCommandInvocation`** now also returns `ResponseCode` (exit code).

## Verification
`TestSSM_SeededCommandInvocation`: seed a `Failed`/stderr/exit-4 outcome for a matching command → `GetCommandInvocation` returns it; a non-matching command falls back to `Success`. `make test` (race) + `make lint` clean.

Closes #345