### PR TITLE
chore(release): v0.74.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.74.0] - 2026-07-22
+
 ### Security
 - Bumped `google.golang.org/grpc` v1.81.1 → v1.82.1 in both the root and
   `test/e2e` modules to clear a Trivy-flagged HIGH advisory (GHSA-hrxh-6v49-42gf,
@@ -1956,7 +1958,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.73.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.74.0...HEAD
+[v0.74.0]: https://github.com/scttfrdmn/substrate/compare/v0.73.0...v0.74.0
 [v0.73.0]: https://github.com/scttfrdmn/substrate/compare/v0.72.0...v0.73.0
 [v0.72.0]: https://github.com/scttfrdmn/substrate/compare/v0.71.0...v0.72.0
 [v0.71.0]: https://github.com/scttfrdmn/substrate/compare/v0.70.0...v0.71.0


### PR DESCRIPTION
Cuts **v0.74.0**. Promotes the Unreleased section:

- **Added** — SSM seedable `SendCommand`/`GetCommandInvocation` outcomes (#345)
- **Security** — `google.golang.org/grpc` → v1.82.1 (GHSA-hrxh-6v49-42gf, #358)

Changelog-only; comparison links updated. Tag cut after merge per release flow.