### PR TITLE
feat(s3): seedable spore.host task-completion outcomes (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- S3: seedable spore.host `spawn task run` task-completion outcomes (#360). A GET
+  of `tasks/<task_id>/completion.json` against a bucket now resolves a seedable,
+  clock-aware completion record — `task_id`, `exit_code`, `state`
+  (`completed`/`failed`), `started_at`, `ended_at` — matching
+  `taskproto.CompletionRecord`. New control-plane endpoints `POST` / `DELETE
+  /v1/spawn/task-completion` seed by task id (`DELETE ?taskId=...` clears one,
+  no query clears all). Before a seed's `ended_at` (on the simulated clock) the
+  GET returns `NoSuchKey` ("still running"); at/after it the record is served —
+  so a consumer's real poll loop is exercised deterministically. Absent a seed, a
+  matching key resolves to the nominal `exit_code:0 / completed` success record;
+  a real staged object at the key (the interim `aws s3 cp` path) always wins, and
+  a GET of any non-`tasks/*/completion.json` key stays a normal 404. Substrate
+  does not execute the task — this is the seedable completion observation only,
+  mirroring the SSM (#345) / SageMaker / Bedrock seed pattern.
+
 ## [v0.74.0] - 2026-07-22
 
 ### Security

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -550,6 +550,14 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 		return nil, fmt.Errorf("get object metadata: %w", err)
 	}
 	if data == nil {
+		// No real object at this key: a GET of tasks/<task_id>/completion.json may
+		// be a seedable spore.host task-completion observation (#360). A real
+		// staged object always wins, so this only runs when the key is absent.
+		if versionID == "" {
+			if resp, handled := p.resolveTaskCompletion(ctx, bucket, key); handled {
+				return resp, nil
+			}
+		}
 		return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound), nil
 	}
 

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -258,6 +258,10 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/ssm/command-invocation", s.handleSSMSeedCommandInvocation)
 	r.Delete("/v1/ssm/command-invocation", s.handleSSMClearCommandInvocation)
 
+	// spore.host spawn task-completion control-plane endpoints (#360).
+	r.Post("/v1/spawn/task-completion", s.handleSpawnSeedTaskCompletion)
+	r.Delete("/v1/spawn/task-completion", s.handleSpawnClearTaskCompletion)
+
 	// Bedrock Runtime control-plane endpoints.
 	r.Post("/v1/bedrock-runtime/responses", s.handleBedrockRuntimeSeedResponse)
 	r.Delete("/v1/bedrock-runtime/responses", s.handleBedrockRuntimeClearResponses)

--- a/emulator/spawn_control.go
+++ b/emulator/spawn_control.go
@@ -1,0 +1,175 @@
+package emulator
+
+import (
+	"context"
+	"crypto/md5" //nolint:gosec // S3 ETags are MD5 by definition, not a security use.
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// spawnCtrlNamespace is the state namespace for spore.host spawn control-plane
+// (seed) data.
+const spawnCtrlNamespace = "spawn-ctrl"
+
+// spawnTaskCompletion is a seeded spore.host `spawn task run` completion record.
+// Substrate never executes the task; a seed lets a test set the observable
+// completion outcome that a GET of tasks/<task_id>/completion.json returns,
+// gated on the simulated clock. It mirrors taskproto.CompletionRecord's wire
+// form (see #360). The minimal five fields below are what the spawn CLI's
+// fetchCompletion reads; cost_estimate/logs/retry_class are omitempty on the
+// consumer side and are not modeled here.
+type spawnTaskCompletion struct {
+	// TaskID is the spawn task identifier (the middle segment of the object key).
+	TaskID string `json:"task_id"`
+
+	// ExitCode is the task's exit code (0 for the nominal success path).
+	ExitCode int `json:"exit_code"`
+
+	// State is the terminal task state: "completed" or "failed".
+	State string `json:"state"`
+
+	// StartedAt / EndedAt are RFC3339 timestamps. A poll before EndedAt (on the
+	// simulated clock) observes the record as not-yet-present (404 NoSuchKey);
+	// at or after EndedAt it is served.
+	StartedAt string `json:"started_at"`
+	EndedAt   string `json:"ended_at"`
+}
+
+// spawnCompletionKey returns the state key for a seeded task-completion record.
+func spawnCompletionKey(taskID string) string {
+	return "completion:" + taskID
+}
+
+// taskCompletionID returns the task id embedded in a completion-record object
+// key of the form "tasks/<task_id>/completion.json", and true when the key
+// matches that shape. Any other key returns ("", false) so a bare GET of a
+// non-existent key stays a normal 404.
+func taskCompletionID(key string) (string, bool) {
+	const prefix = "tasks/"
+	const suffix = "/completion.json"
+	if !strings.HasPrefix(key, prefix) || !strings.HasSuffix(key, suffix) {
+		return "", false
+	}
+	id := strings.TrimSuffix(strings.TrimPrefix(key, prefix), suffix)
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+// resolveTaskCompletion serves a spore.host task-completion record for a GET of
+// tasks/<task_id>/completion.json when no real object exists at the key. It
+// returns (resp, true) when it handled the request — either a synthesized 200
+// carrying the completion JSON, or a 404 NoSuchKey when a seeded record's
+// EndedAt has not yet been reached on the simulated clock ("still running").
+// It returns (nil, false) when the key is not a completion-record key, so the
+// caller falls through to its normal NoSuchKey response.
+//
+// Absent a seed, a matching key resolves to the nominal success record
+// (exit_code 0, state "completed") so the happy path needs no seeding, matching
+// the seeding philosophy. Substrate does not run the task; this is the seedable
+// completion observation only.
+func (p *S3Plugin) resolveTaskCompletion(ctx context.Context, _ string, key string) (*AWSResponse, bool) {
+	taskID, ok := taskCompletionID(key)
+	if !ok {
+		return nil, false
+	}
+
+	data, err := p.state.Get(ctx, spawnCtrlNamespace, spawnCompletionKey(taskID))
+	if err != nil {
+		return nil, false
+	}
+
+	var rec spawnTaskCompletion
+	if data == nil {
+		// No seed: nominal success path.
+		now := p.tc.Now().UTC().Format(time.RFC3339)
+		rec = spawnTaskCompletion{TaskID: taskID, ExitCode: 0, State: "completed", StartedAt: now, EndedAt: now}
+	} else {
+		if err := json.Unmarshal(data, &rec); err != nil {
+			return nil, false
+		}
+		rec.TaskID = taskID
+		if rec.State == "" {
+			rec.State = "completed"
+		}
+		// Clock gate: before EndedAt the record is not yet present.
+		if ended, perr := time.Parse(time.RFC3339, rec.EndedAt); perr == nil {
+			if p.tc.Now().Before(ended) {
+				return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound), true
+			}
+		}
+	}
+
+	body, err := json.Marshal(rec)
+	if err != nil {
+		return nil, false
+	}
+	hash := md5.Sum(body) //nolint:gosec // S3 ETags are MD5 by definition.
+	headers := map[string]string{
+		"Content-Type":   "application/json",
+		"ETag":           fmt.Sprintf("%q", fmt.Sprintf("%x", hash)),
+		"Last-Modified":  p.tc.Now().UTC().Format(http.TimeFormat),
+		"Content-Length": strconv.Itoa(len(body)),
+	}
+	return &AWSResponse{StatusCode: http.StatusOK, Headers: headers, Body: body}, true
+}
+
+// handleSpawnSeedTaskCompletion handles POST /v1/spawn/task-completion. It seeds
+// the completion record a GET of tasks/<task_id>/completion.json returns, gated
+// on EndedAt over the simulated clock. Substrate does not execute the task; this
+// sets the observable completion outcome.
+// Body: {"task_id","exit_code","state","started_at","ended_at"}.
+func (s *Server) handleSpawnSeedTaskCompletion(w http.ResponseWriter, r *http.Request) {
+	var rec spawnTaskCompletion
+	if err := json.NewDecoder(r.Body).Decode(&rec); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if rec.TaskID == "" {
+		http.Error(w, `{"error":"task_id is required"}`, http.StatusBadRequest)
+		return
+	}
+	if rec.State == "" {
+		rec.State = "completed"
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), spawnCtrlNamespace, spawnCompletionKey(rec.TaskID), data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true, "taskId": rec.TaskID})
+}
+
+// handleSpawnClearTaskCompletion handles DELETE /v1/spawn/task-completion.
+// With ?taskId=... it removes that seed; without it removes all.
+func (s *Server) handleSpawnClearTaskCompletion(w http.ResponseWriter, r *http.Request) {
+	if id := r.URL.Query().Get("taskId"); id != "" {
+		if err := s.state.Delete(r.Context(), spawnCtrlNamespace, spawnCompletionKey(id)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), spawnCtrlNamespace, "completion:")
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), spawnCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}

--- a/emulator/spawn_control_test.go
+++ b/emulator/spawn_control_test.go
@@ -1,0 +1,148 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// spawnSeedCompletion posts a seeded task-completion record to the control endpoint.
+func spawnSeedCompletion(t *testing.T, srv *emulator.Server, body map[string]any) {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	w := s3Request(t, srv, http.MethodPost, "/v1/spawn/task-completion", b, nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestSpawn_TaskCompletion_NominalSuccess(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	s3Request(t, srv, http.MethodPut, "/results", nil, nil)
+
+	// No seed: a matching completion key resolves to the nominal success record.
+	w := s3Request(t, srv, http.MethodGet, "/results/tasks/task-1/completion.json", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rec))
+	assert.Equal(t, "task-1", rec["task_id"])
+	assert.Equal(t, float64(0), rec["exit_code"])
+	assert.Equal(t, "completed", rec["state"])
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+}
+
+func TestSpawn_TaskCompletion_SeededFailure(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	s3Request(t, srv, http.MethodPut, "/results", nil, nil)
+
+	// ended_at is in the past relative to the fixed test clock (2026-01-01 12:00),
+	// so the record is immediately observable.
+	spawnSeedCompletion(t, srv, map[string]any{
+		"task_id":    "task-fail",
+		"exit_code":  4,
+		"state":      "failed",
+		"started_at": "2026-01-01T11:00:00Z",
+		"ended_at":   "2026-01-01T11:05:00Z",
+	})
+
+	w := s3Request(t, srv, http.MethodGet, "/results/tasks/task-fail/completion.json", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rec))
+	assert.Equal(t, float64(4), rec["exit_code"])
+	assert.Equal(t, "failed", rec["state"])
+	assert.Equal(t, "2026-01-01T11:05:00Z", rec["ended_at"])
+}
+
+func TestSpawn_TaskCompletion_ClockGate(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	s3Request(t, srv, http.MethodPut, "/results", nil, nil)
+
+	// ended_at is far in the future relative to the fixed test clock, so a poll
+	// observes the record as not-yet-present ("still running").
+	spawnSeedCompletion(t, srv, map[string]any{
+		"task_id":    "task-slow",
+		"exit_code":  0,
+		"state":      "completed",
+		"started_at": "2026-01-01T11:59:00Z",
+		"ended_at":   "2030-01-01T00:00:00Z",
+	})
+
+	w := s3Request(t, srv, http.MethodGet, "/results/tasks/task-slow/completion.json", nil, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "NoSuchKey")
+}
+
+func TestSpawn_TaskCompletion_RealObjectWins(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	s3Request(t, srv, http.MethodPut, "/results", nil, nil)
+
+	// A real staged object at the completion key (the interim `aws s3 cp` path)
+	// is served verbatim, not overridden by the seed resolver.
+	staged := `{"task_id":"task-staged","exit_code":7,"state":"failed","started_at":"x","ended_at":"y"}`
+	pw := s3Request(t, srv, http.MethodPut, "/results/tasks/task-staged/completion.json", []byte(staged), nil)
+	require.Equal(t, http.StatusOK, pw.Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/results/tasks/task-staged/completion.json", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, staged, w.Body.String())
+}
+
+func TestSpawn_TaskCompletion_NonMatchingKeyStays404(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	s3Request(t, srv, http.MethodPut, "/results", nil, nil)
+
+	// A bare GET of a non-existent, non-completion key must still 404 — the
+	// resolver only synthesizes for the tasks/*/completion.json shape.
+	for _, key := range []string{
+		"/results/tasks/task-1/other.json",
+		"/results/some/other/object.txt",
+		"/results/tasks//completion.json",
+	} {
+		w := s3Request(t, srv, http.MethodGet, key, nil, nil)
+		assert.Equal(t, http.StatusNotFound, w.Code, key)
+		assert.Contains(t, w.Body.String(), "NoSuchKey", key)
+	}
+}
+
+func TestSpawn_TaskCompletion_SeedAndClear(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	s3Request(t, srv, http.MethodPut, "/results", nil, nil)
+
+	spawnSeedCompletion(t, srv, map[string]any{
+		"task_id": "task-c", "exit_code": 2, "state": "failed",
+		"started_at": "2026-01-01T11:00:00Z", "ended_at": "2026-01-01T11:01:00Z",
+	})
+
+	// Seeded outcome is observed.
+	w := s3Request(t, srv, http.MethodGet, "/results/tasks/task-c/completion.json", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rec))
+	assert.Equal(t, float64(2), rec["exit_code"])
+
+	// Targeted clear removes the seed; the key falls back to the nominal success.
+	dw := s3Request(t, srv, http.MethodDelete, "/v1/spawn/task-completion?taskId=task-c", nil, nil)
+	require.Equal(t, http.StatusOK, dw.Code)
+
+	w2 := s3Request(t, srv, http.MethodGet, "/results/tasks/task-c/completion.json", nil, nil)
+	require.Equal(t, http.StatusOK, w2.Code)
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &rec))
+	assert.Equal(t, float64(0), rec["exit_code"])
+	assert.Equal(t, "completed", rec["state"])
+
+	// Missing task_id on seed is a 400.
+	bw := s3Request(t, srv, http.MethodPost, "/v1/spawn/task-completion", []byte(`{"exit_code":1}`), nil)
+	assert.Equal(t, http.StatusBadRequest, bw.Code)
+
+	// Clear-all also succeeds.
+	spawnSeedCompletion(t, srv, map[string]any{"task_id": "task-d", "state": "completed", "ended_at": "2026-01-01T11:00:00Z"})
+	caw := s3Request(t, srv, http.MethodDelete, "/v1/spawn/task-completion", nil, nil)
+	assert.Equal(t, http.StatusOK, caw.Code)
+}

--- a/emulator/spawn_control_test.go
+++ b/emulator/spawn_control_test.go
@@ -60,6 +60,22 @@ func TestSpawn_TaskCompletion_SeededFailure(t *testing.T) {
 	assert.Equal(t, "2026-01-01T11:05:00Z", rec["ended_at"])
 }
 
+func TestSpawn_TaskCompletion_SeedNoEndedAt(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	s3Request(t, srv, http.MethodPut, "/results", nil, nil)
+
+	// A seed without ended_at (unparseable) is served immediately, and an empty
+	// state defaults to "completed".
+	spawnSeedCompletion(t, srv, map[string]any{"task_id": "task-now", "exit_code": 1})
+
+	w := s3Request(t, srv, http.MethodGet, "/results/tasks/task-now/completion.json", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var rec map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &rec))
+	assert.Equal(t, float64(1), rec["exit_code"])
+	assert.Equal(t, "completed", rec["state"])
+}
+
 func TestSpawn_TaskCompletion_ClockGate(t *testing.T) {
 	srv, _ := newS3TestServer(t)
 	s3Request(t, srv, http.MethodPut, "/results", nil, nil)
@@ -140,6 +156,10 @@ func TestSpawn_TaskCompletion_SeedAndClear(t *testing.T) {
 	// Missing task_id on seed is a 400.
 	bw := s3Request(t, srv, http.MethodPost, "/v1/spawn/task-completion", []byte(`{"exit_code":1}`), nil)
 	assert.Equal(t, http.StatusBadRequest, bw.Code)
+
+	// Malformed JSON body on seed is a 400.
+	mw := s3Request(t, srv, http.MethodPost, "/v1/spawn/task-completion", []byte(`{not json`), nil)
+	assert.Equal(t, http.StatusBadRequest, mw.Code)
 
 	// Clear-all also succeeds.
 	spawnSeedCompletion(t, srv, map[string]any{"task_id": "task-d", "state": "completed", "ended_at": "2026-01-01T11:00:00Z"})


### PR DESCRIPTION
Implements #360 — a seedable, clock-aware completion signal for spore.host `spawn task run`, so the workflow adapters (nf-spawn, miniwdl-spawn, cwl-spawn, snakemake-executor-plugin-spawn, airflow-spawn, pegasus-spawn) can run engine-composition CI against Substrate with only the completion outcome seeded.

## What
A GET of `tasks/<task_id>/completion.json` against a bucket resolves a seedable completion record — `task_id`, `exit_code`, `state` (`completed`/`failed`), `started_at`, `ended_at` — matching `taskproto.CompletionRecord`.

New control-plane endpoints, mirroring `/v1/ssm/command-invocation` (#345):
- `POST /v1/spawn/task-completion` — `{task_id, exit_code, state, started_at, ended_at}`
- `DELETE /v1/spawn/task-completion?taskId=...` (one) / no query (all)

## Behaviour
- **Clock gate:** before a seed's `ended_at` (on the simulated clock via `TimeController`) the GET returns `NoSuchKey` ("still running"); at/after, the record is served — so a consumer's real poll loop is exercised deterministically.
- **Nominal path:** no seed + a matching `tasks/*/completion.json` key → `exit_code:0 / completed` (per the seeding philosophy).
- **Real object wins:** a staged object at the key (the interim `aws s3 cp` path) is served verbatim — the resolver only runs when the key is genuinely absent.
- **No over-reach:** any non-`tasks/*/completion.json` key stays a normal 404 — this never turns a bare miss into a fake success.

Per the [#360 discussion](https://github.com/scttfrdmn/substrate/issues/360): `completion.json` is the only object the spawn CLI's `fetchCompletion()` reads (`.exitcode` is unread, so not synthesized); `state ∈ {completed, failed}`.

## Scope
Substrate does not execute the task — this is the seedable completion **observation** only, exactly the category of #345 / SageMaker / Bedrock seeds. In-scope per `docs/scope.md`.

## Tests
`emulator/spawn_control_test.go`: nominal success, seeded failure, clock-gate (future `ended_at` → NoSuchKey), real-object-wins, non-matching-key-stays-404, seed+targeted-clear+clear-all+missing-`task_id`-400. Full race suite + lint clean.

Closes #360.
