### PR TITLE
chore(release): v0.75.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.75.0] - 2026-07-26
+
 ### Added
 - S3: seedable spore.host `spawn task run` task-completion outcomes (#360). A GET
   of `tasks/<task_id>/completion.json` against a bucket now resolves a seedable,
@@ -1974,7 +1976,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.74.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.75.0...HEAD
+[v0.75.0]: https://github.com/scttfrdmn/substrate/compare/v0.74.0...v0.75.0
 [v0.74.0]: https://github.com/scttfrdmn/substrate/compare/v0.73.0...v0.74.0
 [v0.73.0]: https://github.com/scttfrdmn/substrate/compare/v0.72.0...v0.73.0
 [v0.72.0]: https://github.com/scttfrdmn/substrate/compare/v0.71.0...v0.72.0


### PR DESCRIPTION
Cuts **v0.75.0**. Promotes the Unreleased section:

- **Added** — S3 seedable spore.host `spawn task run` task-completion outcomes (#360)

Changelog-only; comparison links updated. Tag cut after merge per release flow.