### PR TITLE
feat(docs): generate service reference from the plugin registry (#364)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,20 @@ jobs:
       - name: Run E2E tests
         run: cd test/e2e && go test -v -race ./...
 
+  docs-reference:
+    name: Service Reference Drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check docs/services.md is in sync with the plugin registry
+        run: make docs-reference-check
+
   benchmark:
     name: Benchmarks
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Service reference is now generated from the plugin registry (#364).
+  `cmd/gen-service-reference` (invoked via `go generate ./...` or
+  `make docs-reference`) rewrites the coverage matrix in `docs/services.md`
+  between marker comments, listing every registered plugin so the documented
+  count can no longer drift from the implementation (this is the root cause of
+  the 63-vs-37 contradiction fixed in #363). A `make docs-reference-check` CI job
+  fails the build if the matrix is stale or a newly registered plugin has no
+  documentation metadata. Hand-written per-service operation/CFN/cost detail is
+  preserved untouched.
 - `TestServer` now exposes accessors for the underlying components —
   `Store() *EventStore`, `StateManager()`, `TimeController()`, and `Registry()`
   — and `StartTestServer` enables the in-memory event store by default, so cost

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-substrate build-substratelocal test lint coverage clean tidy vet bench e2e docker-build compose-up compose-down compose-logs python-test python-lint python-build vuln scan-fs scan-image scan-iac sast security
+.PHONY: build build-substrate build-substratelocal test lint coverage clean tidy vet bench e2e docker-build compose-up compose-down compose-logs python-test python-lint python-build vuln scan-fs scan-image scan-iac sast security docs-reference docs-reference-check
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-X main.version=$(VERSION) -X github.com/scttfrdmn/substrate/emulator.Version=$(VERSION)"
@@ -42,6 +42,12 @@ coverage: ## Generate coverage report
 tidy: ## Tidy and verify go modules
 	go mod tidy
 	go mod verify
+
+docs-reference: ## Regenerate docs/services.md from the plugin registry
+	go run ./cmd/gen-service-reference
+
+docs-reference-check: ## Fail if docs/services.md is out of date with the registry
+	go run ./cmd/gen-service-reference -check
 
 bench: ## Run benchmarks
 	go test -bench=. -benchmem -benchtime=5s ./...

--- a/cmd/gen-service-reference/main.go
+++ b/cmd/gen-service-reference/main.go
@@ -1,0 +1,220 @@
+// Command gen-service-reference keeps the coverage matrix in docs/services.md in
+// sync with the live plugin registry so the documented service count and plugin
+// list can never drift from the implementation (see issue #364).
+//
+// It boots the default plugin registry, enumerates the registered plugins, and
+// renders a Markdown coverage table between the marker comments
+//
+//	<!-- BEGIN GENERATED COVERAGE MATRIX -->
+//	<!-- END GENERATED COVERAGE MATRIX -->
+//
+// in docs/services.md. Everything outside the markers — including the
+// hand-written per-service operation, CloudFormation, and cost detail — is left
+// untouched. Per-plugin display names and protocols come from the maintained
+// metadata map below; the tool fails if a registered plugin has no metadata
+// entry (or an entry names a plugin that is not registered), which is what a CI
+// drift check enforces.
+//
+// Usage:
+//
+//	go run ./cmd/gen-service-reference -out docs/services.md          # rewrite the matrix
+//	go run ./cmd/gen-service-reference -out docs/services.md -check    # exit non-zero if out of date
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"time"
+
+	emu "github.com/scttfrdmn/substrate/emulator"
+)
+
+const (
+	beginMarker = "<!-- BEGIN GENERATED COVERAGE MATRIX -->"
+	endMarker   = "<!-- END GENERATED COVERAGE MATRIX -->"
+)
+
+// pluginMeta is the maintained per-plugin documentation metadata.
+type pluginMeta struct {
+	// Display is the human-facing AWS service name.
+	Display string
+	// Protocol is the wire protocol the plugin speaks.
+	Protocol string
+}
+
+// meta maps each registered plugin name to its documentation metadata. Adding a
+// plugin to the registry without a matching entry here fails generation (and CI).
+var meta = map[string]pluginMeta{
+	"acm":                  {"ACM", "Query"},
+	"apigateway":           {"API Gateway (REST)", "REST/JSON"},
+	"apigatewayv2":         {"API Gateway (HTTP)", "REST/JSON"},
+	"appsync":              {"AppSync", "REST/JSON"},
+	"athena":               {"Athena", "JSON"},
+	"backup":               {"Backup", "REST/JSON"},
+	"batch":                {"Batch", "REST/JSON"},
+	"bedrock-runtime":      {"Bedrock Runtime", "REST/JSON"},
+	"budgets":              {"Budgets", "JSON"},
+	"ce":                   {"Cost Explorer", "JSON"},
+	"cloudfront":           {"CloudFront", "REST/XML"},
+	"cloudtrail":           {"CloudTrail", "JSON"},
+	"codebuild":            {"CodeBuild", "JSON"},
+	"codedeploy":           {"CodeDeploy", "JSON"},
+	"codepipeline":         {"CodePipeline", "JSON"},
+	"cognito-identity":     {"Cognito Identity", "JSON"},
+	"cognito-idp":          {"Cognito Identity Provider", "JSON"},
+	"dynamodb":             {"DynamoDB", "JSON"},
+	"ec2":                  {"EC2 / VPC", "Query"},
+	"ecr":                  {"ECR", "JSON"},
+	"ecs":                  {"ECS", "JSON"},
+	"efs":                  {"EFS", "REST/JSON"},
+	"elasticache":          {"ElastiCache", "Query"},
+	"elasticloadbalancing": {"ELBv2", "Query"},
+	"emrserverless":        {"EMR Serverless", "REST/JSON"},
+	"eventbridge":          {"EventBridge", "JSON"},
+	"execute-api":          {"API Gateway (execute-api)", "REST/JSON"},
+	"firehose":             {"Kinesis Data Firehose", "JSON"},
+	"fsx":                  {"FSx", "JSON"},
+	"glue":                 {"Glue", "JSON"},
+	"health":               {"Health", "JSON"},
+	"iam":                  {"IAM", "Query"},
+	"kinesis":              {"Kinesis Data Streams", "JSON"},
+	"kms":                  {"KMS", "JSON"},
+	"lambda":               {"Lambda", "REST/JSON"},
+	"logs":                 {"CloudWatch Logs", "JSON"},
+	"monitoring":           {"CloudWatch", "Query"},
+	"msk":                  {"MSK", "REST/JSON"},
+	"omics":                {"HealthOmics", "REST/JSON"},
+	"opensearch":           {"OpenSearch", "REST/JSON"},
+	"organizations":        {"Organizations", "JSON"},
+	"quicksight":           {"QuickSight", "REST/JSON"},
+	"ram":                  {"RAM", "JSON"},
+	"rds":                  {"RDS", "Query"},
+	"redshift":             {"Redshift", "Query"},
+	"redshift-data":        {"Redshift Data API", "JSON"},
+	"route53":              {"Route 53", "REST/XML"},
+	"s3":                   {"S3", "REST/XML"},
+	"sagemaker":            {"SageMaker", "JSON"},
+	"scheduler":            {"EventBridge Scheduler", "REST/JSON"},
+	"secretsmanager":       {"Secrets Manager", "JSON"},
+	"servicequotas":        {"Service Quotas", "JSON"},
+	"sesv2":                {"SES v2", "REST/JSON"},
+	"sns":                  {"SNS", "Query"},
+	"sqs":                  {"SQS", "JSON"},
+	"ssm":                  {"SSM", "JSON"},
+	"sso":                  {"SSO / Identity Store", "REST/JSON"},
+	"states":               {"Step Functions", "JSON"},
+	"sts":                  {"STS", "Query"},
+	"tagging":              {"Resource Groups Tagging", "JSON"},
+	"timestream":           {"Timestream", "JSON"},
+	"transfer":             {"Transfer Family", "JSON"},
+	"wafv2":                {"WAFv2", "JSON"},
+}
+
+func main() {
+	check := flag.Bool("check", false, "exit non-zero if the file is out of date instead of writing it")
+	out := flag.String("out", "docs/services.md", "path to the services reference file")
+	flag.Parse()
+
+	names, err := registeredPlugins()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gen-service-reference:", err)
+		os.Exit(1)
+	}
+
+	existing, err := os.ReadFile(*out)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gen-service-reference: read %s: %v\n", *out, err)
+		os.Exit(1)
+	}
+
+	updated, err := replaceMatrix(existing, names)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gen-service-reference:", err)
+		os.Exit(1)
+	}
+
+	if *check {
+		if !bytes.Equal(existing, updated) {
+			fmt.Fprintf(os.Stderr, "gen-service-reference: %s coverage matrix is out of date; run `make docs-reference` and commit the result\n", *out)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if bytes.Equal(existing, updated) {
+		fmt.Printf("%s already up to date (%d plugins)\n", *out, len(names))
+		return
+	}
+	if err := os.WriteFile(*out, updated, 0o644); err != nil { //nolint:gosec // docs file, world-readable is fine.
+		fmt.Fprintln(os.Stderr, "gen-service-reference:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("updated %s (%d plugins)\n", *out, len(names))
+}
+
+// registeredPlugins boots the default registry and returns the sorted plugin
+// names, verifying that metadata is complete in both directions.
+func registeredPlugins() ([]string, error) {
+	reg := emu.NewPluginRegistry()
+	state := emu.NewMemoryStateManager()
+	tc := emu.NewTimeController(time.Unix(0, 0).UTC())
+	logger := emu.NewDefaultLogger(slog.LevelError, false)
+	store := emu.NewEventStore(emu.EventStoreConfig{Enabled: false})
+
+	if err := emu.RegisterDefaultPlugins(context.Background(), reg, state, tc, logger, store, nil); err != nil {
+		return nil, fmt.Errorf("register default plugins: %w", err)
+	}
+	names := reg.Names()
+
+	registered := make(map[string]bool, len(names))
+	for _, n := range names {
+		registered[n] = true
+		if _, ok := meta[n]; !ok {
+			return nil, fmt.Errorf("plugin %q is registered but has no metadata entry in cmd/gen-service-reference/main.go; add one", n)
+		}
+	}
+	for n := range meta {
+		if !registered[n] {
+			return nil, fmt.Errorf("metadata entry %q does not correspond to a registered plugin; remove it from cmd/gen-service-reference/main.go", n)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// replaceMatrix swaps the content between the begin/end markers in doc for a
+// freshly rendered coverage matrix, leaving everything else untouched.
+func replaceMatrix(doc []byte, names []string) ([]byte, error) {
+	begin := bytes.Index(doc, []byte(beginMarker))
+	end := bytes.Index(doc, []byte(endMarker))
+	if begin < 0 || end < 0 || end < begin {
+		return nil, fmt.Errorf("could not find %q ... %q markers in the document", beginMarker, endMarker)
+	}
+
+	var matrix bytes.Buffer
+	fmt.Fprintln(&matrix, beginMarker)
+	fmt.Fprintf(&matrix, "Substrate ships **%d built-in service plugins**. This section is generated\n", len(names))
+	fmt.Fprintln(&matrix, "from the plugin registry (`make docs-reference`), so the count and plugin list")
+	fmt.Fprintln(&matrix, "cannot drift from the implementation. The live count is also available from the")
+	fmt.Fprintln(&matrix, "`/ready` endpoint (`curl http://localhost:4566/ready`). Per-service operation,")
+	fmt.Fprintln(&matrix, "CloudFormation, and cost detail follows below the matrix.")
+	fmt.Fprintln(&matrix)
+	fmt.Fprintln(&matrix, "| # | Service | Plugin name | Protocol |")
+	fmt.Fprintln(&matrix, "|---|---------|-------------|----------|")
+	for i, n := range names {
+		m := meta[n]
+		fmt.Fprintf(&matrix, "| %d | %s | `%s` | %s |\n", i+1, m.Display, n, m.Protocol)
+	}
+	fmt.Fprint(&matrix, endMarker)
+
+	var result bytes.Buffer
+	result.Write(doc[:begin])
+	result.Write(matrix.Bytes())
+	result.Write(doc[end+len(endMarker):])
+	return result.Bytes(), nil
+}

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,58 +1,88 @@
 # Service Reference
 
-Substrate ships **63 built-in service plugins**. The matrix below currently
-documents the operation lists, Betty CloudFormation resource types, and pricing
-notes for a subset of them; the remaining plugins are registered and functional
-but not yet detailed here.
-
-> **Note:** this page is being migrated to generation directly from the plugin
-> registry so the count and per-operation detail can never drift from the
-> implementation again (see
-> [#364](https://github.com/scttfrdmn/substrate/issues/364)). Until then, the
-> authoritative live count is the `/ready` endpoint
-> (`curl http://localhost:4566/ready` → `{"status":"ready","plugins":63}`).
-
 ## Coverage matrix
 
-| # | Service | Plugin | Protocol | CFN Support |
-|---|---------|--------|----------|-------------|
-| 1 | IAM | IAMPlugin | Query | Yes |
-| 2 | STS | STSPlugin | Query | — |
-| 3 | Lambda | LambdaPlugin | REST/JSON | Yes |
-| 4 | SQS | SQSPlugin | Query | Yes |
-| 5 | DynamoDB | DynamoDBPlugin | JSON | Yes |
-| 6 | EC2 | EC2Plugin | Query | Yes |
-| 7 | S3 | S3Plugin | REST/XML | Yes |
-| 8 | ELB v2 | ELBPlugin | Query | Yes |
-| 9 | Route 53 | Route53Plugin | REST/XML | Yes |
-| 10 | Resource Groups Tagging | TaggingPlugin | JSON | — |
-| 11 | SNS | SNSPlugin | Query | Yes |
-| 12 | Secrets Manager | SecretsManagerPlugin | JSON | Yes |
-| 13 | SSM Parameter Store | SSMPlugin | JSON | Yes |
-| 14 | KMS | KMSPlugin | JSON | Yes |
-| 15 | CloudWatch Logs | CloudWatchLogsPlugin | JSON | Yes |
-| 16 | EventBridge | EventBridgePlugin | JSON | Yes |
-| 17 | CloudWatch | CloudWatchPlugin | Query | Yes |
-| 18 | ACM | ACMPlugin | JSON | Yes |
-| 19 | API Gateway (REST) | APIGatewayPlugin | REST/JSON | Yes |
-| 20 | API Gateway v2 (HTTP) | APIGatewayV2Plugin | REST/JSON | Yes |
-| 21 | Step Functions | StepFunctionsPlugin | JSON | Yes |
-| 22 | ECR | ECRPlugin | JSON | Yes |
-| 23 | ECS | ECSPlugin | JSON | Yes |
-| 24 | Cognito User Pools | CognitoIDPPlugin | JSON | Yes |
-| 25 | Cognito Identity | CognitoIdentityPlugin | JSON | Yes |
-| 26 | Kinesis Data Streams | KinesisPlugin | JSON | Yes |
-| 27 | CloudFront | CloudFrontPlugin | REST/XML | Yes |
-| 28 | RDS | RDSPlugin | Query | Yes |
-| 29 | ElastiCache | ElastiCachePlugin | Query | Yes |
-| 30 | EFS | EFSPlugin | REST/JSON | Yes |
-| 31 | Glue | GluePlugin | JSON | Yes |
-| 32 | Cost Explorer | CEPlugin | JSON | — |
-| 33 | Budgets | BudgetsPlugin | JSON | Yes |
-| 34 | Health | HealthPlugin | JSON | — |
-| 35 | Organizations | OrganizationsPlugin | JSON | — |
-| 36 | SES v2 | SESv2Plugin | REST/JSON | Yes |
-| 37 | Kinesis Data Firehose | FirehosePlugin | JSON | Yes |
+<!-- BEGIN GENERATED COVERAGE MATRIX -->
+Substrate ships **63 built-in service plugins**. This section is generated
+from the plugin registry (`make docs-reference`), so the count and plugin list
+cannot drift from the implementation. The live count is also available from the
+`/ready` endpoint (`curl http://localhost:4566/ready`). Per-service operation,
+CloudFormation, and cost detail follows below the matrix.
+
+| # | Service | Plugin name | Protocol |
+|---|---------|-------------|----------|
+| 1 | ACM | `acm` | Query |
+| 2 | API Gateway (REST) | `apigateway` | REST/JSON |
+| 3 | API Gateway (HTTP) | `apigatewayv2` | REST/JSON |
+| 4 | AppSync | `appsync` | REST/JSON |
+| 5 | Athena | `athena` | JSON |
+| 6 | Backup | `backup` | REST/JSON |
+| 7 | Batch | `batch` | REST/JSON |
+| 8 | Bedrock Runtime | `bedrock-runtime` | REST/JSON |
+| 9 | Budgets | `budgets` | JSON |
+| 10 | Cost Explorer | `ce` | JSON |
+| 11 | CloudFront | `cloudfront` | REST/XML |
+| 12 | CloudTrail | `cloudtrail` | JSON |
+| 13 | CodeBuild | `codebuild` | JSON |
+| 14 | CodeDeploy | `codedeploy` | JSON |
+| 15 | CodePipeline | `codepipeline` | JSON |
+| 16 | Cognito Identity | `cognito-identity` | JSON |
+| 17 | Cognito Identity Provider | `cognito-idp` | JSON |
+| 18 | DynamoDB | `dynamodb` | JSON |
+| 19 | EC2 / VPC | `ec2` | Query |
+| 20 | ECR | `ecr` | JSON |
+| 21 | ECS | `ecs` | JSON |
+| 22 | EFS | `efs` | REST/JSON |
+| 23 | ElastiCache | `elasticache` | Query |
+| 24 | ELBv2 | `elasticloadbalancing` | Query |
+| 25 | EMR Serverless | `emrserverless` | REST/JSON |
+| 26 | EventBridge | `eventbridge` | JSON |
+| 27 | API Gateway (execute-api) | `execute-api` | REST/JSON |
+| 28 | Kinesis Data Firehose | `firehose` | JSON |
+| 29 | FSx | `fsx` | JSON |
+| 30 | Glue | `glue` | JSON |
+| 31 | Health | `health` | JSON |
+| 32 | IAM | `iam` | Query |
+| 33 | Kinesis Data Streams | `kinesis` | JSON |
+| 34 | KMS | `kms` | JSON |
+| 35 | Lambda | `lambda` | REST/JSON |
+| 36 | CloudWatch Logs | `logs` | JSON |
+| 37 | CloudWatch | `monitoring` | Query |
+| 38 | MSK | `msk` | REST/JSON |
+| 39 | HealthOmics | `omics` | REST/JSON |
+| 40 | OpenSearch | `opensearch` | REST/JSON |
+| 41 | Organizations | `organizations` | JSON |
+| 42 | QuickSight | `quicksight` | REST/JSON |
+| 43 | RAM | `ram` | JSON |
+| 44 | RDS | `rds` | Query |
+| 45 | Redshift | `redshift` | Query |
+| 46 | Redshift Data API | `redshift-data` | JSON |
+| 47 | Route 53 | `route53` | REST/XML |
+| 48 | S3 | `s3` | REST/XML |
+| 49 | SageMaker | `sagemaker` | JSON |
+| 50 | EventBridge Scheduler | `scheduler` | REST/JSON |
+| 51 | Secrets Manager | `secretsmanager` | JSON |
+| 52 | Service Quotas | `servicequotas` | JSON |
+| 53 | SES v2 | `sesv2` | REST/JSON |
+| 54 | SNS | `sns` | Query |
+| 55 | SQS | `sqs` | JSON |
+| 56 | SSM | `ssm` | JSON |
+| 57 | SSO / Identity Store | `sso` | REST/JSON |
+| 58 | Step Functions | `states` | JSON |
+| 59 | STS | `sts` | Query |
+| 60 | Resource Groups Tagging | `tagging` | JSON |
+| 61 | Timestream | `timestream` | JSON |
+| 62 | Transfer Family | `transfer` | JSON |
+| 63 | WAFv2 | `wafv2` | JSON |
+<!-- END GENERATED COVERAGE MATRIX -->
+
+---
+
+The per-service sections below carry hand-written operation lists, Betty
+CloudFormation resource types, and cost notes for the most heavily used plugins.
+They are maintained by hand and cover a subset of the plugins in the matrix
+above; the remaining plugins are registered and functional but not yet detailed
+here.
 
 ---
 

--- a/emulator/plugins.go
+++ b/emulator/plugins.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+//go:generate go run ../cmd/gen-service-reference -out ../docs/services.md
+
 // RegisterDefaultPlugins initializes and registers all built-in service plugins
 // into registry. This function is called by both the server binary and
 // [StartTestServer] so the same plugin set is always available.
@@ -13,6 +15,8 @@ import (
 // test helpers that do not need cost-derived data in the Cost Explorer plugin).
 // cfg is optional; pass nil to disable all Docker-backed features (Lambda
 // Docker execution, RDS container engine).
+// Adding a plugin here also requires a metadata entry in cmd/gen-service-reference
+// (enforced by `make docs-reference-check` in CI).
 func RegisterDefaultPlugins(
 	ctx context.Context,
 	registry *PluginRegistry,


### PR DESCRIPTION
Second PR of the v0.76.0 documentation-reliability milestone. Root-cause fix for the drift behind #363.

## What
`cmd/gen-service-reference` boots the default plugin registry and rewrites the coverage matrix in `docs/services.md` **between marker comments** — listing all **63** registered plugins with their wire protocol. Everything outside the markers (the hand-written per-service operation / CloudFormation / cost detail) is left untouched.

## Why this design
- The old table was hand-maintained and had drifted to 37 while the registry has 63. Generation makes the count and plugin list impossible to drift.
- I deliberately scoped the generated columns to what's **machine-truthful** (name + protocol). CFN support and per-operation detail live in the hand-written sections below the matrix — I did **not** destroy that content or replace it with guesses (per the count-and-list scope agreed for this issue; full per-operation generation remains a tracked follow-up).

## Guardrails
- Per-plugin metadata lives in a map the generator **enforces is complete in both directions** — a registered plugin with no entry, or an entry naming no plugin, fails generation.
- `//go:generate` directive on `RegisterDefaultPlugins`; `make docs-reference` / `make docs-reference-check`.
- New CI job **Service Reference Drift** runs `make docs-reference-check` on every PR.

## Verification
`go generate` is idempotent; the drift guard **fails** when a plugin lacks metadata (tested); build + lint + full test suite clean.

Closes #364. Part of v0.76.0.