### PR TITLE
ci+docs: run pytest-substrate in primary CI and surface Python onboarding (#366)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,41 @@ jobs:
       - name: Check docs/services.md is in sync with the plugin registry
         run: make docs-reference-check
 
+  python:
+    name: Python (pytest-substrate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build substrate binary
+        run: go build -o bin/substrate ./cmd/substrate
+
+      - name: Install pytest-substrate and tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff build
+          pip install -e ./python
+
+      - name: Lint (ruff)
+        run: ruff check python/src python/tests
+
+      - name: Test (pytest)
+        env:
+          SUBSTRATE_BINARY: ${{ github.workspace }}/bin/substrate
+        run: cd python && pytest tests/ -v
+
+      - name: Build wheel
+        run: cd python && python -m build --wheel --outdir dist/
+
   benchmark:
     name: Benchmarks
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Python `pytest-substrate` support is now exercised in primary CI and surfaced
+  in the docs (#366). A new CI job builds the binary and runs `ruff`, `pytest`,
+  and a wheel build for the `python/` package; Getting Started gained a "First
+  Python test" section and README lists pytest as a third usage mode. Added an
+  explicit `[tool.ruff]` config (line-length 120; E/F/I/SIM/BLE/UP) and cleared
+  the pre-existing lint findings it surfaced.
 - Service reference is now generated from the plugin registry (#364).
   `cmd/gen-service-reference` (invoked via `go generate ./...` or
   `make docs-reference`) rewrites the coverage matrix in `docs/services.md`

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ makes every run reproducible: API observations can be recorded as events and
 replayed identically, whereas a real workload's timing, scheduling, and I/O
 cannot.
 
-**Use it two ways:**
+**Use it three ways:**
 - **As a server** — run `substrate`, point any AWS SDK/CLI at `http://localhost:4566`.
   This is how most consumers use it.
 - **As a Go test harness** — `import ".../emulator"`, spin up an in-process server
   or deploy a CloudFormation template directly, no HTTP needed.
+- **As a pytest plugin** — `pip install` the `pytest-substrate` package (in
+  [`python/`](python/)) for a session-scoped server fixture with per-test state
+  reset and boto3 wired to the emulator automatically.
 
 ## The Problem
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -229,6 +229,41 @@ go test ./... -run TestCreateS3Bucket -v
 The test starts its own Substrate server, runs entirely in-process with no
 network access to real AWS, and shuts down automatically when the test finishes.
 
+> **Not using Go?** Substrate is language-agnostic — anything that speaks the AWS
+> wire protocol works. Point your SDK/CLI at `http://localhost:4566` (see
+> [Endpoint Configuration](endpoint-configuration.md) for boto3, Terraform, CDK,
+> and more), or for Python use the **`pytest-substrate`** plugin below.
+
+## First Python test (pytest)
+
+The [`pytest-substrate`](https://github.com/scttfrdmn/substrate/tree/main/python)
+package provides a session-scoped server fixture with per-test state reset and
+boto3 pre-wired to the emulator. Install it and the substrate binary:
+
+```bash
+pip install pytest-substrate  # or: pip install -e ./python from a checkout
+go install github.com/scttfrdmn/substrate/cmd/substrate@latest
+```
+
+Write `test_s3.py` — the `substrate` fixture resets state and sets the boto3
+endpoint/credentials environment variables for you:
+
+```python
+import boto3
+
+def test_create_bucket(substrate):
+    s3 = boto3.client("s3")  # already pointed at the emulator
+    s3.create_bucket(Bucket="my-test-bucket")
+    s3.put_object(Bucket="my-test-bucket", Key="hello.txt", Body=b"hi")
+
+    objects = s3.list_objects_v2(Bucket="my-test-bucket")
+    assert objects["KeyCount"] == 1
+```
+
+The plugin locates the binary via `SUBSTRATE_BINARY`, `~/src/substrate/bin/substrate`,
+or `substrate` on `PATH`. Use the `substrate_isolated` fixture instead for a fresh
+server per test.
+
 ## Reusing a server across subtests
 
 Create one `TestServer` and call `ts.ResetState(t)` between subtests to avoid

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,3 +22,12 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+# E/F (pyflakes+pycodestyle), I (isort), SIM (flake8-simplify),
+# BLE (blind-except), UP (pyupgrade). Keep the set explicit so CI is reproducible.
+select = ["E", "F", "I", "SIM", "BLE", "UP"]

--- a/python/src/pytest_substrate/server.py
+++ b/python/src/pytest_substrate/server.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import socket
 import subprocess
 import time
-import json
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -156,7 +156,7 @@ class SubstrateServer:
             try:
                 urllib.request.urlopen(f"{self.url}/health", timeout=1)  # nosemgrep
                 return
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - any startup error means "not ready yet"; keep polling
                 last_exc = exc
                 time.sleep(0.05)
         raise RuntimeError(

--- a/python/tests/test_plugin.py
+++ b/python/tests/test_plugin.py
@@ -9,7 +9,6 @@ import pytest
 
 from pytest_substrate.server import SubstrateServer
 
-
 # ---------------------------------------------------------------------------
 # Test that fixtures are registered as pytest plugins
 # ---------------------------------------------------------------------------
@@ -34,7 +33,7 @@ def test_plugin_registers_substrate_fixture(pytestconfig: pytest.Config) -> None
 # ---------------------------------------------------------------------------
 
 def test_substrateserver_importable() -> None:
-    from pytest_substrate import SubstrateServer as SS  # noqa: F401
+    from pytest_substrate import SubstrateServer as SS
     assert SS is SubstrateServer
 
 

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import subprocess
 import urllib.error
 from http.client import HTTPResponse
-from io import BytesIO
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pytest_substrate.server import SubstrateServer
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -52,17 +50,21 @@ class TestFindBinary:
     def test_falls_back_to_path(self, tmp_path: Path) -> None:
         import os
         os.environ.pop("SUBSTRATE_BINARY", None)
-        with patch("pathlib.Path.home", return_value=tmp_path):  # no candidate
-            with patch("shutil.which", return_value="/usr/local/bin/substrate"):
-                assert SubstrateServer._find_binary() == "/usr/local/bin/substrate"
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),  # no candidate
+            patch("shutil.which", return_value="/usr/local/bin/substrate"),
+        ):
+            assert SubstrateServer._find_binary() == "/usr/local/bin/substrate"
 
     def test_raises_when_not_found(self, tmp_path: Path) -> None:
         import os
         os.environ.pop("SUBSTRATE_BINARY", None)
-        with patch("pathlib.Path.home", return_value=tmp_path):
-            with patch("shutil.which", return_value=None):
-                with pytest.raises(RuntimeError, match="substrate binary not found"):
-                    SubstrateServer._find_binary()
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("shutil.which", return_value=None),
+            pytest.raises(RuntimeError, match="substrate binary not found"),
+        ):
+            SubstrateServer._find_binary()
 
 
 # ---------------------------------------------------------------------------
@@ -160,11 +162,9 @@ class TestWaitHealthy:
 
     def test_raises_after_timeout(self) -> None:
         server = SubstrateServer()
-        import time as time_mod
 
         # Simulate time advancing past the deadline after 2 checks.
         call_count = 0
-        original_monotonic = time_mod.monotonic
 
         def fake_monotonic():
             nonlocal call_count
@@ -175,11 +175,13 @@ class TestWaitHealthy:
                 return 0.0
             return 100.0
 
-        with patch("urllib.request.urlopen", side_effect=ConnectionRefusedError("nope")), \
-             patch("time.monotonic", side_effect=fake_monotonic), \
-             patch("time.sleep"):
-            with pytest.raises(RuntimeError, match="did not become healthy"):
-                server._wait_healthy(timeout=1.0)
+        with (
+            patch("urllib.request.urlopen", side_effect=ConnectionRefusedError("nope")),
+            patch("time.monotonic", side_effect=fake_monotonic),
+            patch("time.sleep"),
+            pytest.raises(RuntimeError, match="did not become healthy"),
+        ):
+            server._wait_healthy(timeout=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -199,16 +201,20 @@ class TestResetState:
 
     def test_raises_on_http_error(self) -> None:
         server = SubstrateServer()
-        with patch("urllib.request.urlopen",
-                   side_effect=urllib.error.HTTPError(
-                       url=f"{server.url}/v1/state/reset",
-                       code=500,
-                       msg="Internal Server Error",
-                       hdrs=None,  # type: ignore[arg-type]
-                       fp=None,    # type: ignore[arg-type]
-                   )):
-            with pytest.raises(RuntimeError, match="state reset failed"):
-                server.reset_state()
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=urllib.error.HTTPError(
+                    url=f"{server.url}/v1/state/reset",
+                    code=500,
+                    msg="Internal Server Error",
+                    hdrs=None,  # type: ignore[arg-type]
+                    fp=None,    # type: ignore[arg-type]
+                ),
+            ),
+            pytest.raises(RuntimeError, match="state reset failed"),
+        ):
+            server.reset_state()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Third PR of the v0.76.0 milestone. The `pytest-substrate` package (`python/`) was a real, functional package — session-scoped server fixture, per-test state reset, boto3 wiring — but **primary CI never ran it** and it was nearly invisible in the docs.

## CI
New **Python (pytest-substrate)** job: builds the substrate binary, installs the package, and runs `ruff` + `pytest` (32 tests) + a wheel build on every PR. A published package is now exercised by CI.

## Lint
Added an explicit `[tool.ruff]` config (line-length 120 — matching the code's actual style — with E/F/I/SIM/BLE/UP) and cleared the pre-existing findings it surfaced: import ordering, unused imports, nested `with` statements, and an intentional blind-except in the health-poll loop (kept, with a `# noqa: BLE001` explaining why). No behavior change.

## Docs
- Getting Started gains a **First Python test (pytest)** section with a runnable example and fixture explanation.
- README lists the pytest plugin as a **third usage mode**.
- A language-agnostic pointer sits under the Go example ("Not using Go?").

Verified locally: 32 pytest pass, ruff clean, wheel builds.

Closes #366. Part of v0.76.0.