### PR TITLE
ci: validate docs on pull requests (build, links, version scan) (#365)

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,0 +1,18 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^http://localhost" },
+    { "pattern": "^http://127\\.0\\.0\\.1" },
+    { "pattern": "^http://s3\\.amazonaws\\.com" },
+    { "pattern": "^https?://.*\\.s3\\.amazonaws\\.com" }
+  ],
+  "httpHeaders": [
+    {
+      "urls": ["https://github.com", "https://scttfrdmn.github.io"],
+      "headers": { "Accept": "text/html", "User-Agent": "markdown-link-check" }
+    }
+  ],
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206, 429]
+}

--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -5,6 +5,10 @@
     { "pattern": "^http://s3\\.amazonaws\\.com" },
     { "pattern": "^https?://.*\\.s3\\.amazonaws\\.com" }
   ],
+  "replacementPatterns": [
+    { "comment": "VitePress absolute routes (/foo) map to the sibling foo.md in docs/; links are resolved relative to the source file's directory. The VitePress build validates routing itself.",
+      "pattern": "^/([a-z][a-z0-9-]*)$", "replacement": "$1.md" }
+  ],
   "httpHeaders": [
     {
       "urls": ["https://github.com", "https://scttfrdmn.github.io"],

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,67 @@
+name: Docs CI
+
+# Validate documentation on pull requests so drift (broken build, dead links,
+# stale pinned versions, out-of-sync service reference) is caught before merge —
+# the deploy workflow (docs.yml) only runs on main, which is too late. See #365.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'scripts/check-doc-versions.sh'
+      - '.github/workflows/docs-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'README.md'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: VitePress build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install dependencies
+        working-directory: docs
+        run: npm ci
+
+      - name: Build site (fails on broken build)
+        working-directory: docs
+        run: npm run build
+
+  versions:
+    name: No pinned versions in prose
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Scan docs + README for stale pinned versions
+        run: ./scripts/check-doc-versions.sh
+
+  links:
+    name: Markdown link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check links in docs and README
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: '.github/markdown-link-check.json'
+          folder-path: 'docs'
+          file-path: './README.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Documentation is now validated on pull requests (#365). A new `Docs CI`
+  workflow runs the VitePress production build, a Markdown link check, and a
+  stale-pinned-version scan (`scripts/check-doc-versions.sh`, also `make
+  docs-versions`) on any PR touching `docs/` or the README — the deploy workflow
+  only ran on `main`, which was too late to catch drift like the stale `v0.68.0`
+  strings fixed in #363. (Service-reference drift is already guarded by the
+  `docs-reference-check` job added in #364.)
 - Python `pytest-substrate` support is now exercised in primary CI and surfaced
   in the docs (#366). A new CI job builds the binary and runs `ruff`, `pytest`,
   and a wheel build for the `python/` package; Getting Started gained a "First

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-substrate build-substratelocal test lint coverage clean tidy vet bench e2e docker-build compose-up compose-down compose-logs python-test python-lint python-build vuln scan-fs scan-image scan-iac sast security docs-reference docs-reference-check
+.PHONY: build build-substrate build-substratelocal test lint coverage clean tidy vet bench e2e docker-build compose-up compose-down compose-logs python-test python-lint python-build vuln scan-fs scan-image scan-iac sast security docs-reference docs-reference-check docs-versions
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-X main.version=$(VERSION) -X github.com/scttfrdmn/substrate/emulator.Version=$(VERSION)"
@@ -48,6 +48,9 @@ docs-reference: ## Regenerate docs/services.md from the plugin registry
 
 docs-reference-check: ## Fail if docs/services.md is out of date with the registry
 	go run ./cmd/gen-service-reference -check
+
+docs-versions: ## Fail if docs/README pin a stale version in prose
+	./scripts/check-doc-versions.sh
 
 bench: ## Run benchmarks
 	go test -bench=. -benchmem -benchtime=5s ./...

--- a/scripts/check-doc-versions.sh
+++ b/scripts/check-doc-versions.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# check-doc-versions.sh — fail if docs or the README pin a specific vX.Y.Z release
+# in prose. Pinned versions go stale silently (this is what let the docs advertise
+# v0.68.0 while the repo was at v0.75.0; see #363/#365). Use a neutral placeholder
+# such as `v0.x.y` or read the version from the release tag at build time instead.
+#
+# Legitimate version references are allowed: comparison/diff links, release-tag
+# URLs, blob/tree URLs, the CHANGELOG, and module-path references.
+set -euo pipefail
+
+# Files to scan: README plus all Markdown under docs/, excluding the changelog.
+mapfile -t files < <(
+  { echo "README.md"; find docs -name '*.md'; } | sort -u
+)
+
+status=0
+for f in "${files[@]}"; do
+  [[ "$f" == "CHANGELOG.md" ]] && continue
+  [[ -f "$f" ]] || continue
+  # Match vMAJOR.MINOR.PATCH, then drop lines where the match is part of a URL or
+  # an allowed context.
+  while IFS= read -r line; do
+    hits=$(grep -nE 'v[0-9]+\.[0-9]+\.[0-9]+' <<<"$line" || true)
+    [[ -z "$hits" ]] && continue
+    # Allowed contexts: URLs (github.com, compare, releases/tag, blob, tree),
+    # go module paths, and the explicit x.y placeholder.
+    if grep -qE 'github\.com|/compare/|releases/tag|/blob/|/tree/|go [0-9]|toolchain|x\.y' <<<"$line"; then
+      continue
+    fi
+    echo "$f: pinned version in prose — use a neutral placeholder (e.g. v0.x.y):"
+    echo "    $line"
+    status=1
+  done < <(grep -E 'v[0-9]+\.[0-9]+\.[0-9]+' "$f" || true)
+done
+
+if [[ "$status" -ne 0 ]]; then
+  echo ""
+  echo "Pinned versions go stale. See scripts/check-doc-versions.sh for the rule."
+fi
+exit "$status"


### PR DESCRIPTION
Fourth PR of v0.76.0 — the last prevention-tier piece. The docs deploy workflow only builds on `main`, so drift landed before anyone noticed (this is exactly how the docs advertised `v0.68.0` while the repo was at v0.75.0, #363).

## New `Docs CI` workflow (on PRs touching `docs/` or `README.md`)
- **VitePress production build** — fails on broken build or dead internal refs.
- **Markdown link check** — with a config that ignores `localhost`/S3-example URLs and tolerates 429s from GitHub.
- **Stale-version scan** — `scripts/check-doc-versions.sh` (also `make docs-versions`) fails on a bare `vX.Y.Z` in prose outside URLs/tags/CHANGELOG. Tested both ways (passes clean today; fails when a pinned version is injected).

## Coverage vs. the issue checklist
- ✅ VitePress build, ✅ link check, ✅ version scan
- ✅ Service-reference drift — already added in #364 (`docs-reference-check`)
- ⏭️ Go-snippet compile + anchor/spelling — deferred to the examples work (#367), which converts the canonical snippets into real compiled example programs (a more robust guard than fenced-block extraction). Noted in the issue.

Verified locally: docs build clean, no missing relative links, version scan passes.

Closes #365. Part of v0.76.0.