### PR TITLE
docs(security): refresh SECURITY.md (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Refreshed `SECURITY.md` (#369): private vulnerability reporting is now the
+  documented preferred path (public issues only for already-public matters),
+  added acknowledgement/assessment/fix timelines, a supported-versions table with
+  evergreen "upgrade to the latest verified release" guidance, and a release
+  integrity/verification section (`git verify-tag`, checksum database). The
+  existing poisoned-tag (v0.45.1/v0.45.2) and void-tag (v0.67.0) advisories are
+  unchanged.
+
 ### Added
 - Documentation is now validated on pull requests (#365). A new `Docs CI`
   workflow runs the VitePress production build, a Markdown link check, and a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,60 @@
 
 ## Reporting a vulnerability
 
-Open a GitHub issue at https://github.com/scttfrdmn/substrate/issues, or for
-sensitive reports use GitHub's private vulnerability reporting
-("Report a vulnerability" on the Security tab).
+**Preferred:** use GitHub's private vulnerability reporting — the
+**"Report a vulnerability"** button on the repository's
+[Security tab](https://github.com/scttfrdmn/substrate/security). This keeps the
+report confidential until a fix is available.
+
+Only use a public [GitHub issue](https://github.com/scttfrdmn/substrate/issues)
+for security matters that are **already public** (e.g. a disclosed upstream CVE
+in a dependency). Do not open a public issue for an undisclosed vulnerability.
+
+### What to expect
+
+Substrate is a single-maintainer project, so these are good-faith targets rather
+than contractual guarantees:
+
+| Stage | Target |
+|-------|--------|
+| Acknowledgement of your report | within 3 business days |
+| Initial assessment (severity + whether it's in scope) | within 7 business days |
+| Fix or mitigation for a confirmed issue | released as a new patch version as soon as practical, prioritised by severity |
+
+Please allow a reasonable disclosure window before publicising a confirmed
+vulnerability. Credit is given to reporters who want it.
+
+## Supported versions
+
+Fixes are released as new patch versions on top of the latest release; there are
+no long-lived maintenance branches for older minors.
+
+| Version | Supported |
+|---------|-----------|
+| Latest release (see [Releases](https://github.com/scttfrdmn/substrate/releases)) | ✅ |
+| Any earlier version | ❌ — upgrade to the latest release |
+
+Always depend on the **latest verified release**. Because the module checksum
+database pins content on first fetch, the correct response to any release-integrity
+problem is to move forward to a newer version, never to re-fetch an old one (see
+the advisories below).
+
+## Release integrity and verification
+
+Release tags are **signed** and created only through the documented release
+process (`CLAUDE.md` → Releasing); they are never moved once published. To verify
+a release before depending on it:
+
+```bash
+# Verify the signed tag (requires the maintainer's public key in your keyring):
+git verify-tag vX.Y.Z
+
+# Or confirm the GitHub release is attached to the verified tag:
+gh release view vX.Y.Z
+```
+
+Module integrity is additionally enforced by Go's checksum database
+(`sum.golang.org`); a `go.sum` mismatch on fetch is a hard failure by design.
 
 ## Module tag integrity advisory
 


### PR DESCRIPTION
Fifth PR of v0.76.0. Implements the review's SECURITY.md recommendations while preserving the existing (good) tag-integrity advisories.

- **Private reporting first** — GitHub's private vulnerability reporting is now the documented preferred path; public issues are explicitly only for already-public matters.
- **Timelines** — acknowledgement (3 business days), initial assessment (7), fix (patch release prioritised by severity), framed as good-faith single-maintainer targets.
- **Supported versions** — a table with evergreen "upgrade to the latest verified release" guidance instead of naming an aging version.
- **Release integrity/verification** — how to `git verify-tag` / `gh release view`, plus the checksum-database guarantee, tying to the existing signed-tag practice.

The poisoned-tag (v0.45.1/.2) and void-tag (v0.67.0) advisories are untouched.

Closes #369. Part of v0.76.0.