### PR TITLE
docs: contributor guide + compatibility/fidelity policy (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Contributor guide (`docs/contributing.md`) covering how to implement and test a
+  new service plugin — the scope test, the `Plugin` interface, state-key and
+  error conventions, the seedable control-plane pattern, registration + the
+  `gen-service-reference` metadata requirement, and the testing/coverage bar —
+  plus a Compatibility & Fidelity policy (`docs/fidelity.md`) defining the
+  Implemented/Partial/Fault-aware/Stateful/CFN/Pricing levels and how fidelity is
+  decided (#368). Both wired into the docs sidebar.
+
 ### Changed
 - Refreshed `SECURITY.md` (#369): private vulnerability reporting is now the
   documented preferred path (public issues only for already-public matters),

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -80,6 +80,14 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Service Reference', link: '/services' },
+          { text: 'Compatibility & Fidelity', link: '/fidelity' },
+        ],
+      },
+      {
+        text: 'Contributing',
+        collapsed: false,
+        items: [
+          { text: 'Adding a Service Plugin', link: '/contributing' },
         ],
       },
     ],

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,153 @@
+# Contributing a Service Plugin
+
+This guide walks through adding a new AWS service plugin to Substrate and the
+conventions your change must follow. It assumes you have read
+[Scope & Philosophy](/scope) — the scope test below is the first gate for any
+new behaviour.
+
+For general project rules (Go style, changelog, release process) see
+[`CLAUDE.md`](https://github.com/scttfrdmn/substrate/blob/main/CLAUDE.md). All
+non-trivial work starts with a
+[GitHub issue](https://github.com/scttfrdmn/substrate/issues) tied to a
+milestone.
+
+## Before you write code: the scope test
+
+Substrate models **what is observable through an AWS API call, not what software
+inside a resource does.** Before adding a behaviour, ask:
+
+> *Is this observable through an API call, or is it resource-internal?*
+
+- **In scope:** request/response shapes, error codes, resource state and its
+  transitions over the simulated clock, pagination, and **seedable** outcomes
+  (errors, capacity failures, terminal job states, specific result sets).
+- **Out of scope:** actually running the workload — executing user-data,
+  running a Lambda's code, performing an inference or training job. Capture such
+  inputs as recorded intent and expose a **seedable** completion signal instead.
+
+If a feature needs to model box-internals, it belongs in a different tool or test
+tier, not in Substrate.
+
+## Anatomy of a plugin
+
+A plugin implements the `Plugin` interface (`emulator/types.go`):
+
+```go
+type Plugin interface {
+    Name() string                                                    // AWS service name for routing, e.g. "s3"
+    Initialize(ctx context.Context, config PluginConfig) error       // wire up state, logger, time controller
+    HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error)
+    Shutdown(ctx context.Context) error
+}
+```
+
+A complete, runnable minimal plugin lives in
+[`examples/custom_plugin`](https://github.com/scttfrdmn/substrate/tree/main/examples/custom_plugin)
+— start there. The essentials:
+
+```go
+type WeatherPlugin struct {
+    state  emulator.StateManager
+    logger emulator.Logger
+}
+
+func (p *WeatherPlugin) Name() string { return "weather" }
+
+func (p *WeatherPlugin) Initialize(_ context.Context, cfg emulator.PluginConfig) error {
+    p.state = cfg.State
+    p.logger = cfg.Logger
+    return nil
+}
+
+func (p *WeatherPlugin) HandleRequest(_ *emulator.RequestContext, req *emulator.AWSRequest) (*emulator.AWSResponse, error) {
+    switch req.Operation {
+    case "GetWeather":
+        return p.handleGetWeather(req)
+    default:
+        return nil, &emulator.AWSError{
+            Code:       "UnsupportedOperation",
+            Message:    fmt.Sprintf("operation %q is not supported", req.Operation),
+            HTTPStatus: http.StatusBadRequest,
+        }
+    }
+}
+
+func (p *WeatherPlugin) Shutdown(_ context.Context) error { return nil }
+```
+
+If your plugin is time-dependent, pull the `*TimeController` from
+`cfg.Options["time_controller"]` in `Initialize` (see any built-in plugin such
+as `ssm_plugin.go`) and read the clock with `p.tc.Now()` — never `time.Now()`,
+which would break deterministic replay.
+
+## Conventions
+
+### Verify against the real AWS API
+
+Request/response shapes, error codes, pagination, and IAM condition keys must be
+checked against the **official AWS API reference** for the service — not built-in
+knowledge. This is a hard rule (`CLAUDE.md` → AWS service emulation).
+
+### State keys
+
+Persist state through `StateManager` under a namespace (usually the service
+name) with a stable, documented key shape, e.g. `object:{bucket}/{key}` for S3
+or `queue:{account}/{name}` for SQS. Keep keys consistent across the plugin's
+handlers so `ResetState` and replay behave predictably.
+
+### Errors
+
+Return `*AWSError` with the exact AWS `Code` and HTTP status for API-level
+errors. Wrap internal Go errors with context (`fmt.Errorf("...: %w", err)`) and
+never discard them.
+
+### Seedable outcomes (the deterministic-emulator pattern)
+
+A new operation defaults to its nominal success path. Alternate outcomes
+(errors, capacity failures, terminal states, specific result sets) are exposed
+as **seedable** values a test sets via a control-plane endpoint, read at request
+time — never as nondeterministic behaviour. Follow the established pattern:
+`POST`/`DELETE /v1/{service}/...` keyed by an ID or the `"*"` wildcard. See
+`ssm_control.go`, `spawn_control.go`, Athena/SageMaker/Bedrock seeds for
+worked examples, and register the routes in `server.go`'s `buildRouter`.
+
+### Registration + service reference
+
+Register the plugin in `RegisterDefaultPlugins` (`emulator/plugins.go`). Then add
+a metadata entry (display name + protocol) in
+[`cmd/gen-service-reference`](https://github.com/scttfrdmn/substrate/tree/main/cmd/gen-service-reference)
+and regenerate the reference:
+
+```bash
+make docs-reference
+```
+
+The `docs-reference-check` CI job **fails** if a registered plugin has no
+metadata entry, so this is not optional.
+
+## Testing
+
+- Tests live in `package emulator_test` (`emulator/{service}_plugin_test.go`),
+  are table-driven where practical, and must be race-safe.
+- No test may depend on network access, real AWS, or wall-clock time — drive time
+  through the `TimeController` / `TestServer.AdvanceTime`.
+- Use `StartTestServer(t)` for integration-style tests over HTTP; it registers
+  all plugins and cleans up automatically. See the [Testing Guide](/testing-guide).
+- Aim for **>80% coverage**. `make test` runs the race detector; `make coverage`
+  generates a report.
+- If your change diverges from real AWS behaviour in any way, document it (and
+  the reason) so reviewers can see it.
+
+## Checklist before opening a PR
+
+- [ ] There is a tracked issue for the work.
+- [ ] Behaviour passes the scope test (API-observable, not resource-internal).
+- [ ] Shapes/errors/pagination verified against the official AWS API docs.
+- [ ] Alternate outcomes are seedable via a control-plane endpoint, not random.
+- [ ] Plugin registered in `RegisterDefaultPlugins` **and** metadata added to
+      `cmd/gen-service-reference`; `make docs-reference` run.
+- [ ] Tests added (table-driven, race-safe, no wall-clock/network), coverage
+      maintained.
+- [ ] `make test` and `make lint` pass.
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]`.
+- [ ] Every exported symbol has a doc comment ending in a period.

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -1,0 +1,65 @@
+# Compatibility & Fidelity Policy
+
+This page defines what "supported" means for a service in Substrate, how much
+fidelity to expect, and how those decisions are made. It complements
+[Scope & Philosophy](/scope), which draws the hard boundary between API
+observations (in scope) and workload internals (out of scope).
+
+## How fidelity is decided
+
+Every modelled behaviour is verified against the **official AWS API reference**
+for the service — request/response shapes, error codes, pagination, and IAM
+condition keys — not against built-in assumptions. When Substrate's behaviour
+intentionally differs from real AWS, that divergence is documented alongside the
+behaviour and its rationale.
+
+The guiding question for any addition is the scope test:
+
+> *Is this observable through an API call, or is it resource-internal?*
+
+If it is resource-internal (running user code, performing an inference,
+bootstrapping a node), Substrate does not execute it; it captures the input as
+recorded intent and exposes a **seedable** completion signal instead.
+
+## Fidelity levels
+
+A given plugin/operation sits at one or more of these levels. They are
+descriptive, not a ranking — a serial service that never needs lifecycle
+transitions is not "worse" than a stateful one.
+
+| Level | Meaning |
+|-------|---------|
+| **Implemented** | The nominal success path is modelled: valid requests return AWS-shaped responses. |
+| **Partial** | A subset of the operation's parameters or response fields is modelled. Unmodelled fields are omitted rather than faked. |
+| **Fault-aware** | Alternate outcomes (errors, capacity/throttle failures, terminal states) can be **seeded** via a control-plane endpoint, so a caller's retry/poll/wait loop can be exercised deterministically. |
+| **Stateful** | Cross-request lifecycle is modelled — a resource transitions through states over the simulated clock (e.g. `pending → running`, `Pending → InProgress → Success`). |
+| **CFN-supported** | Betty models the relevant CloudFormation resource types for deploy/drift. |
+| **Pricing-supported** | Operations carry cost data, so cost summaries and budget gates work. |
+
+The per-service sections of the [Service Reference](/services) note which of
+these apply, and the generated coverage matrix lists every registered plugin.
+
+## What "not yet supported" means
+
+- **An operation absent from a plugin** returns an `UnsupportedOperation`-style
+  error, not a silent success. If you need it, open an issue.
+- **A plugin absent from the registry** means that service is not emulated yet.
+  The live plugin list is always available from the `/ready` endpoint.
+- **A field you don't see** in a response is not modelled; Substrate omits
+  unmodelled fields rather than returning fabricated values.
+
+## Stability
+
+- The HTTP wire contract and the `cmd/substrate` CLI are treated as stable
+  surfaces; breaking changes go through the changelog and semver.
+- The Go library (`package emulator`) is pre-1.0 and may evolve; pin a version
+  and consult the [changelog](https://github.com/scttfrdmn/substrate/blob/main/CHANGELOG.md).
+- New fidelity is added incrementally and driven by
+  [issues](https://github.com/scttfrdmn/substrate/issues). Requesting a specific
+  operation, field, or seedable outcome is the fastest way to get it modelled.
+
+## Requesting or improving fidelity
+
+Open an issue describing the operation and the observable behaviour you need
+(including any error/timing path). If you want to implement it yourself, see the
+[Contributing a Service Plugin](/contributing) guide.


### PR DESCRIPTION
Sixth PR of v0.76.0.

- **`docs/contributing.md`** — how to implement and test a new service plugin: the scope test as the first gate, the `Plugin` interface (grounded in the existing `examples/custom_plugin`), state-key/error conventions, the **seedable control-plane pattern**, registration + the `gen-service-reference` metadata requirement (enforced by CI from #364), the testing/coverage bar, and a pre-PR checklist.
- **`docs/fidelity.md`** — compatibility & fidelity policy: defines the **Implemented / Partial / Fault-aware / Stateful / CFN-supported / Pricing-supported** levels, how fidelity is decided (verify against official AWS docs; the scope test), and what "not yet supported" means (unmodelled fields omitted, not faked).
- Both wired into the VitePress sidebar (a new **Contributing** section + Fidelity under Reference).

Verified: docs build clean, links + version scan pass.

Closes #368. Part of v0.76.0.