### PR TITLE
docs: restructure site + date comparison + clarify non-AI use (#370)

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -6,8 +6,8 @@
     { "pattern": "^https?://.*\\.s3\\.amazonaws\\.com" }
   ],
   "replacementPatterns": [
-    { "comment": "VitePress absolute routes (/foo) map to the sibling foo.md in docs/; links are resolved relative to the source file's directory. The VitePress build validates routing itself.",
-      "pattern": "^/([a-z][a-z0-9-]*)$", "replacement": "$1.md" }
+    { "comment": "VitePress absolute routes (/foo, /foo#anchor) map to the sibling foo.md in docs/; the fragment is dropped so the checker verifies the target file. The VitePress build validates routing and anchors itself.",
+      "pattern": "^/([a-z][a-z0-9-]*)(#[a-z0-9-]+)?$", "replacement": "$1.md" }
   ],
   "httpHeaders": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Docs site organised around **Learn / Start / Test / Reference / Contributing**
+  (#370); dated the LocalStack/moto/AWS comparison tables ("as of early 2026") so
+  they read as positioning rather than a current audit; clarified that Substrate
+  is equally useful for human-written and AI-generated IaC; updated the homepage
+  "use it" section to include the pytest plugin (three ways). Also fixed the
+  doc-version scanner (#365) to skip `node_modules`/VitePress build artifacts.
+
 ### Added
 - Runnable "journey" examples for the core differentiators, exercised in CI via
   the `test/e2e` module (#367): seeded throttling → SDK retry, record & replay,

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Substrate is a **different tier** from container emulators and real accounts, no
 drop-in replacement. It trades workload-execution fidelity for determinism,
 replayability, and cost insight — the fast inner-loop tier.
 
+_Comparison reflects these projects as of early 2026; LocalStack and moto evolve —
+treat it as positioning, not a current feature-by-feature audit._
+
 | | **Substrate** | LocalStack | moto | Real AWS |
 |---|:---:|:---:|:---:|:---:|
 | Deterministic replay | ✅ | ❌ | partial | ❌ |

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -59,7 +59,7 @@ export default defineConfig({
 
     sidebar: [
       {
-        text: 'Introduction',
+        text: 'Learn',
         collapsed: false,
         items: [
           { text: 'What is Substrate?', link: '/' },
@@ -67,11 +67,17 @@ export default defineConfig({
         ],
       },
       {
-        text: 'Using Substrate',
+        text: 'Start',
         collapsed: false,
         items: [
           { text: 'Getting Started', link: '/getting-started' },
           { text: 'Endpoint Configuration', link: '/endpoint-configuration' },
+        ],
+      },
+      {
+        text: 'Test',
+        collapsed: false,
+        items: [
           { text: 'Testing Guide', link: '/testing-guide' },
         ],
       },

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ boundary is what makes every run reproducible: API observations can be recorded
 as events and replayed identically, whereas a real workload's timing, scheduling,
 and I/O cannot. See [Scope & Philosophy](/scope) for the full reasoning.
 
-## Use it two ways
+## Use it three ways
 
 - **As a server** — run `substrate`, point any AWS SDK/CLI at
   `http://localhost:4566`. This is how most consumers use it.
@@ -49,6 +49,13 @@ and I/O cannot. See [Scope & Philosophy](/scope) for the full reasoning.
 - **As a Go test harness** — `import "github.com/scttfrdmn/substrate/emulator"`,
   spin up an in-process server or deploy a CloudFormation template directly.
   See the [Testing Guide](/testing-guide).
+- **As a pytest plugin** — `pip install pytest-substrate` for a server fixture
+  with per-test state reset and boto3 pre-wired. See
+  [Getting Started](/getting-started#first-python-test-pytest).
+
+Substrate is equally at home testing human-written and AI-generated
+infrastructure — the reproducibility, offline speed, and cost visibility matter
+either way.
 
 Substrate ships **63 built-in service plugins** — see the
 [Service Reference](/services).

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -81,6 +81,10 @@ Substrate is a **different tier** from container emulators and real accounts, no
 a drop-in replacement for them. It trades workload-execution fidelity for
 determinism, replayability, and cost insight.
 
+> The comparison below reflects these projects as of early 2026; LocalStack and
+> moto evolve, so treat it as a positioning guide rather than a current
+> feature-by-feature audit.
+
 | | **Substrate** | LocalStack | moto | Real AWS |
 |---|:---:|:---:|:---:|:---:|
 | Deterministic replay | ✅ | ❌ | partial | ❌ |

--- a/scripts/check-doc-versions.sh
+++ b/scripts/check-doc-versions.sh
@@ -8,9 +8,16 @@
 # URLs, blob/tree URLs, the CHANGELOG, and module-path references.
 set -euo pipefail
 
-# Files to scan: README plus all Markdown under docs/, excluding the changelog.
+# Files to scan: README plus all Markdown under docs/, excluding the changelog
+# and build artifacts (node_modules, VitePress output).
 mapfile -t files < <(
-  { echo "README.md"; find docs -name '*.md'; } | sort -u
+  {
+    echo "README.md"
+    find docs -name '*.md' \
+      -not -path '*/node_modules/*' \
+      -not -path '*/.vitepress/dist/*' \
+      -not -path '*/.vitepress/cache/*'
+  } | sort -u
 )
 
 status=0


### PR DESCRIPTION
Eighth PR of v0.76.0.

- **Learn / Start / Test / Reference / Contributing** sidebar — reorganised around the review's four user intentions (plus Contributing). This relabels and regroups existing pages rather than splitting them, delivering the navigation intent without destabilising content on a single-maintainer site.
- **Dated comparison tables** — the LocalStack/moto/AWS tables in README and `scope.md` now say "as of early 2026" and read as positioning, not a current feature-by-feature audit.
- **Non-AI clarification** — homepage and README now state Substrate is equally useful for human-written and AI-generated IaC.
- **Homepage 'use it' → three ways** — adds the pytest plugin alongside server + Go harness.
- **Scanner fix** — the #365 doc-version scanner now skips `node_modules`/VitePress build artifacts (only surfaced when a local docs build is present; CI was unaffected).

Docs build clean; links + version scan pass.

Closes #370. Part of v0.76.0.