### PR TITLE
feat(ec2): CreateFleet with seedable partial fulfillment; wire four CFN resource types (#387, #388, #389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- EC2 Fleet: `CreateFleet`, `DescribeFleets`, and `DeleteFleets` (#387).
+  Instances launch through the same `RunInstances` path as a direct launch, so
+  they are visible to `DescribeInstances` with subnet/security-group validation,
+  placement groups, and launch-time tag propagation intact.
+  `LaunchTemplateConfigs[]` × `Overrides[]` are flattened into ordered capacity
+  pools (sorted by `Priority` under a `prioritized` allocation strategy) and
+  fulfilled round-robin, so `fleetInstanceSet` carries one item per pool each
+  with a *list* of instance IDs. An `instant` fleet returns instances and errors
+  synchronously; `request`/`maintain` fleets return only the fleet ID, matching
+  AWS. `DescribeFleets` returns an `instant` fleet only when its ID is named
+  explicitly; `DeleteFleets` terminates the fleet's instances when
+  `TerminateInstances=true` or the fleet is `instant`.
+- Seedable EC2 Fleet partial fulfillment via
+  `POST`/`DELETE /v1/ec2/fleet-shortfall`, keyed by launch-template ID/name or
+  `"*"` (#387). A fleet that asks for 12 and receives 8 still returns a fleet ID
+  and echoes the *request* in `TotalTargetCapacity`, so this path — rare and
+  hard to trigger against real AWS — is where callers most often go wrong;
+  seeding makes it instant and reproducible. The unfulfilled capacity is
+  reported per pool in `errorSet` with a configurable error code and lifecycle.
+- Source and destination security groups in security-group rules
+  (`IpPermissions.N.Groups.M.GroupId`), rendered by `DescribeSecurityGroups` as
+  `groups>item` (#388). A rule whose source is another security group — the
+  self-referencing rule in particular — has no CIDR at all and previously could
+  not be represented.
+- CloudFormation wiring for four resource types whose API handlers already
+  existed but which fell through to `deployGenericStub`, so a stack deployed
+  "successfully" while the resource was never created (#388):
+  `AWS::EC2::LaunchTemplate` (Ref is the real `lt-…` ID, usable by
+  `CreateFleet`), `AWS::IAM::InstanceProfile` (creates the profile and attaches
+  each entry in `Roles`), and the standalone `AWS::EC2::SecurityGroupIngress` /
+  `AWS::EC2::SecurityGroupEgress` rules, which resolve
+  `SourceSecurityGroupId`/`DestinationSecurityGroupId` through `Ref`/`GetAtt` so
+  self- and mutually-referencing groups work.
+
+### Changed
+- `AWS::EC2::SecurityGroup` now authorizes the rules declared inline in its
+  `SecurityGroupIngress`/`SecurityGroupEgress` properties (#388). They were
+  parsed but never applied, so `DescribeSecurityGroups` reported a group with no
+  rules regardless of how the template was written.
+- `AWS::EC2::Instance` passes through `IamInstanceProfile`, `KeyName`, and
+  `SecurityGroupIds` (#388) — the profile reference is only resolvable now that
+  `AWS::IAM::InstanceProfile` creates a real profile.
+- `AuthorizeSecurityGroup{Ingress,Egress}` parse every `IpPermissions.N` entry
+  and all of each entry's `IpRanges.M`, rather than only the first rule and
+  first CIDR (#388). `RevokeSecurityGroup{Ingress,Egress}` match on source as
+  well as protocol and ports, so revoking a CIDR rule no longer removes a
+  source-group rule on the same port.
+- The generic-stub warning now reports whether the unhandled type's service
+  plugin is loaded (#388). It previously read as "substrate doesn't model this",
+  which is misleading when the API actions exist and only the wiring is missing.
+
+### Fixed
+- Package documentation no longer states a plugin count or per-plugin operation
+  count (#389). `emulator/doc.go` claimed 39 plugins and 23 S3 operations while
+  the registry had 63 and `s3_plugin.go` 53 — the counts that #364 made
+  generated elsewhere had drifted here. It now points at the generated
+  `docs/services.md` instead of repeating a number that can drift.
+- `CLAUDE.md`'s key-files table pointed at four paths that moved to `emulator/`
+  in the #310 reorg (#389). The stale next-release pin flagged in the same issue
+  was already removed in v0.81.0.
+
 ## [v0.81.0] - 2026-08-01
 
 A fidelity release driven by three consumer-filed issues (`objectfs`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,10 @@ service before writing code or tests.
 
 | File | Purpose |
 |------|---------|
-| `doc.go` | Package documentation |
-| `types.go` | Core types (AWSRequest, StateManager, Logger, …) |
-| `eventstore.go` | Immutable event log |
-| `replay.go` | Replay engine and time-travel debugging |
+| `emulator/doc.go` | Package documentation |
+| `emulator/types.go` | Core types (AWSRequest, StateManager, Logger, …) |
+| `emulator/eventstore.go` | Immutable event log |
+| `emulator/replay.go` | Replay engine and time-travel debugging |
+| `emulator/plugins.go` | `RegisterDefaultPlugins` — the plugin registry |
+| `docs/services.md` | Generated service reference (`make docs-reference`) |
 | `cmd/substrate/main.go` | CLI entry point |

--- a/docs/services.md
+++ b/docs/services.md
@@ -139,6 +139,9 @@ here.
 | TagRole | |
 | UntagRole | |
 | ListRoleTags | |
+| CreateInstanceProfile | |
+| GetInstanceProfile | |
+| AddRoleToInstanceProfile | |
 
 ### Betty CFN resource types
 
@@ -147,6 +150,7 @@ here.
 | AWS::IAM::Role | RoleName | Supports AssumeRolePolicyDocument, ManagedPolicyArns |
 | AWS::IAM::Policy | PolicyName | |
 | AWS::IAM::User | UserName | |
+| AWS::IAM::InstanceProfile | InstanceProfileName | Attaches each entry in `Roles`; resolvable by an `AWS::EC2::Instance`'s `IamInstanceProfile` |
 | AWS::IAM::Group | GroupName | |
 
 ### Cost
@@ -779,8 +783,10 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | CreateSecurityGroup | |
 | DescribeSecurityGroups | [Explicit resource IDs](#explicit-resource-ids) |
 | DeleteSecurityGroup | [Explicit resource IDs](#explicit-resource-ids) |
-| AuthorizeSecurityGroupIngress | |
-| AuthorizeSecurityGroupEgress | |
+| AuthorizeSecurityGroupIngress | Supports source security groups (`IpPermissions.N.Groups.M.GroupId`), including self-referencing rules |
+| AuthorizeSecurityGroupEgress | Supports destination security groups |
+| RevokeSecurityGroupIngress | Matches on protocol, ports, **and** source |
+| RevokeSecurityGroupEgress | |
 | CreateInternetGateway | |
 | AttachInternetGateway | |
 | DescribeInternetGateways | [Explicit resource IDs](#explicit-resource-ids) |
@@ -794,6 +800,12 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids) |
+| CreateLaunchTemplate | |
+| DescribeLaunchTemplates | |
+| DeleteLaunchTemplate | |
+| CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`. Partial fulfillment is seedable — see below |
+| DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS |
+| DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances |
 
 ### RunInstances requires a resolvable AMI
 
@@ -859,15 +871,41 @@ lowercase hex digit. Length is deliberately not checked: substrate's generators
 emit 16 hex characters where AWS emits 8 or 17, and AWS itself still accepts the
 legacy 8-character form for several resources.
 
+### Seeding EC2 Fleet partial fulfillment
+
+`CreateFleet` fulfills its whole `TotalTargetCapacity` by default. Partial
+fulfillment — the case callers most often get wrong, since a fleet that asks for
+12 and receives 8 still returns a fleet ID and echoes the *request* in
+`TotalTargetCapacity` — is reachable by seeding a shortfall:
+
+```bash
+# Fulfill 8 instances and report the remainder as a capacity failure.
+curl -X POST http://localhost:4566/v1/ec2/fleet-shortfall \
+  -d '{"launchTemplate":"lt-0abc123","fulfill":8,
+       "errorCode":"InsufficientInstanceCapacity","lifecycle":"spot"}'
+
+# Clear one seed, or all of them.
+curl -X DELETE 'http://localhost:4566/v1/ec2/fleet-shortfall?launchTemplate=lt-0abc123'
+curl -X DELETE http://localhost:4566/v1/ec2/fleet-shortfall
+```
+
+`launchTemplate` matches a launch template ID or name, or `*` (the default) for
+any. The shortfall is spread across the request's capacity pools, so `errorSet`
+reports one item per pool that came up short, and `DescribeFleets` reports the
+result in `fulfilledCapacity`.
+
 ### Betty CFN resource types
 
 | Type | Ref | Notes |
 |------|-----|-------|
 | AWS::EC2::VPC | VpcId | |
 | AWS::EC2::Subnet | SubnetId | |
-| AWS::EC2::SecurityGroup | GroupId | |
-| AWS::EC2::Instance | InstanceId | |
+| AWS::EC2::SecurityGroup | GroupId | Inline `SecurityGroupIngress`/`SecurityGroupEgress` rules are authorized |
+| AWS::EC2::SecurityGroupIngress | GroupId | Standalone rule; resolves `SourceSecurityGroupId` through `Ref`/`GetAtt`, so self- and mutually-referencing groups work |
+| AWS::EC2::SecurityGroupEgress | GroupId | Standalone rule; supports `DestinationSecurityGroupId` |
+| AWS::EC2::Instance | InstanceId | Passes through `IamInstanceProfile`, `KeyName`, and `SecurityGroupIds` |
 | AWS::EC2::InternetGateway | InternetGatewayId | |
+| AWS::EC2::LaunchTemplate | LaunchTemplateId | Ref is the real `lt-…` ID, usable by `CreateFleet` |
 
 ### Cost
 

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -214,16 +214,22 @@ type CFNDriftDetectionStatus struct {
 // typePriority determines deployment order for CloudFormation resources.
 // Lower numbers deploy first.
 var typePriority = map[string]int{
-	"AWS::IAM::Policy":                            0,
-	"AWS::IAM::Role":                              1,
-	"AWS::EC2::VPC":                               1,
-	"AWS::Route53::HostedZone":                    1,
-	"AWS::KMS::Key":                               1,
-	"AWS::DynamoDB::Table":                        2,
-	"AWS::S3::Bucket":                             2,
-	"AWS::EC2::Subnet":                            2,
-	"AWS::EC2::SecurityGroup":                     2,
-	"AWS::EC2::InternetGateway":                   2,
+	"AWS::IAM::Policy":          0,
+	"AWS::IAM::Role":            1,
+	"AWS::EC2::VPC":             1,
+	"AWS::Route53::HostedZone":  1,
+	"AWS::KMS::Key":             1,
+	"AWS::DynamoDB::Table":      2,
+	"AWS::S3::Bucket":           2,
+	"AWS::EC2::Subnet":          2,
+	"AWS::EC2::SecurityGroup":   2,
+	"AWS::EC2::InternetGateway": 2,
+	"AWS::IAM::InstanceProfile": 2,
+	"AWS::EC2::LaunchTemplate":  3,
+	// Standalone security-group rules must follow every group they reference, so
+	// a self-referencing or mutually-referencing pair resolves (#388).
+	"AWS::EC2::SecurityGroupIngress":              3,
+	"AWS::EC2::SecurityGroupEgress":               3,
 	"AWS::KMS::Alias":                             2,
 	"AWS::KMS::ReplicaKey":                        2,
 	"AWS::SecretsManager::Secret":                 2,
@@ -1490,10 +1496,24 @@ func (d *StackDeployer) deployResource(
 		return d.deployTransferServer(ctx, logicalID, res.Properties, streamID, cctx)
 	case "AWS::Athena::WorkGroup":
 		return d.deployAthenaWorkGroup(ctx, logicalID, res.Properties, streamID, cctx)
+	// v0.77.0 — resource types whose API handlers already existed but which fell
+	// through to the generic stub (#388).
+	case "AWS::EC2::LaunchTemplate":
+		return d.deployEC2LaunchTemplate(ctx, logicalID, res.Properties, streamID, cctx)
+	case "AWS::IAM::InstanceProfile":
+		return d.deployIAMInstanceProfile(ctx, logicalID, res.Properties, streamID, cctx)
+	case "AWS::EC2::SecurityGroupIngress":
+		return d.deployEC2SecurityGroupIngress(ctx, logicalID, res.Properties, streamID, cctx)
+	case "AWS::EC2::SecurityGroupEgress":
+		return d.deployEC2SecurityGroupEgress(ctx, logicalID, res.Properties, streamID, cctx)
 	default:
 		d.logger.Warn("unknown CloudFormation resource type; using generic stub",
 			"logical_id", logicalID,
 			"type", res.Type,
+			// A loaded plugin means the API handler may exist and the type merely
+			// needs wiring, which is a different problem from an unsupported
+			// service (#388).
+			"service_plugin_loaded", d.servicePluginLoaded(res.Type),
 		)
 		return d.deployGenericStub(ctx, logicalID, res.Type, res.Properties, cctx)
 	}
@@ -1943,10 +1963,23 @@ func (d *StackDeployer) deployEC2SecurityGroup(
 	resp, cost, routeErr := d.dispatch(ctx, req, streamID)
 	dr := DeployedResource{LogicalID: logicalID, Type: "AWS::EC2::SecurityGroup"}
 	if routeErr != nil {
+		// A failed resource is recorded on the DeployedResource, not returned — a
+		// returned error aborts the whole stack.
 		dr.Error = routeErr.Error()
-	} else if resp != nil {
+		return dr, cost, nil //nolint:nilerr
+	}
+	if resp != nil {
 		dr.PhysicalID = extractXMLField(resp.Body, "groupId")
 		dr.ARN = dr.PhysicalID
+	}
+	// Apply the rules declared inline on the group. Without this the group is
+	// created with no rules at all (#388).
+	if dr.PhysicalID != "" {
+		ruleCost, ruleErr := d.authorizeInlineSGRules(ctx, dr.PhysicalID, props, streamID, cctx)
+		cost += ruleCost
+		if ruleErr != "" {
+			dr.Error = ruleErr
+		}
 	}
 	return dr, cost, nil
 }
@@ -2014,18 +2047,30 @@ func (d *StackDeployer) deployEC2Instance(
 	imageID := resolveStringProp(props, "ImageId", "ami-00000000", cctx)
 	instanceType := resolveStringProp(props, "InstanceType", "t3.micro", cctx)
 	subnetID := resolveStringProp(props, "SubnetId", "", cctx)
+	params := map[string]string{
+		"Action":       "RunInstances",
+		"ImageId":      imageID,
+		"InstanceType": instanceType,
+		"MinCount":     "1",
+		"MaxCount":     "1",
+		"SubnetId":     subnetID,
+	}
+	// An instance profile reference is only resolvable now that
+	// AWS::IAM::InstanceProfile creates a real profile (#388).
+	if profile := resolveStringProp(props, "IamInstanceProfile", "", cctx); profile != "" {
+		params["IamInstanceProfile.Name"] = profile
+	}
+	if keyName := resolveStringProp(props, "KeyName", "", cctx); keyName != "" {
+		params["KeyName"] = keyName
+	}
+	for i, sg := range resolveStringList(props["SecurityGroupIds"], cctx) {
+		params[fmt.Sprintf("SecurityGroupId.%d", i+1)] = sg
+	}
 	req := &AWSRequest{
 		Service:   "ec2",
 		Operation: "RunInstances",
-		Params: map[string]string{
-			"Action":       "RunInstances",
-			"ImageId":      imageID,
-			"InstanceType": instanceType,
-			"MinCount":     "1",
-			"MaxCount":     "1",
-			"SubnetId":     subnetID,
-		},
-		Headers: map[string]string{},
+		Params:    params,
+		Headers:   map[string]string{},
 	}
 	resp, cost, routeErr := d.dispatch(ctx, req, streamID)
 	dr := DeployedResource{LogicalID: logicalID, Type: "AWS::EC2::Instance"}

--- a/emulator/betty_cfn_v77_plugins.go
+++ b/emulator/betty_cfn_v77_plugins.go
@@ -1,0 +1,367 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// This file wires CloudFormation resource types whose EC2/IAM API handlers
+// already existed but which fell through to deployGenericStub, so a stack that
+// declared them deployed "successfully" while the resource was never created
+// (#388). Each handler dispatches the real API action, so the deployed resource
+// is observable through the corresponding Describe call.
+
+// deployEC2LaunchTemplate creates an EC2 launch template for the given CFN
+// resource. Its Ref is the launch template ID, which is what
+// AWS::AutoScaling::AutoScalingGroup and CreateFleet consume — a stub's
+// synthesized ARN is not a usable launch template reference.
+func (d *StackDeployer) deployEC2LaunchTemplate(
+	ctx context.Context,
+	logicalID string,
+	props map[string]interface{},
+	streamID string,
+	cctx *cfnContext,
+) (DeployedResource, float64, error) {
+	name := resolveStringProp(props, "LaunchTemplateName", logicalID, cctx)
+
+	params := map[string]string{
+		"Action":             "CreateLaunchTemplate",
+		"LaunchTemplateName": name,
+	}
+	if data, ok := props["LaunchTemplateData"].(map[string]interface{}); ok {
+		for cfnKey, param := range map[string]string{
+			"ImageId":      "LaunchTemplateData.ImageId",
+			"InstanceType": "LaunchTemplateData.InstanceType",
+			"KeyName":      "LaunchTemplateData.KeyName",
+			"UserData":     "LaunchTemplateData.UserData",
+		} {
+			if v := resolveStringProp(data, cfnKey, "", cctx); v != "" {
+				params[param] = v
+			}
+		}
+		for i, sg := range resolveStringList(data["SecurityGroupIds"], cctx) {
+			params[fmt.Sprintf("LaunchTemplateData.SecurityGroupId.%d", i+1)] = sg
+		}
+	}
+
+	resp, cost, routeErr := d.dispatch(ctx, &AWSRequest{
+		Service:   "ec2",
+		Operation: "CreateLaunchTemplate",
+		Params:    params,
+		Headers:   map[string]string{},
+	}, streamID)
+
+	dr := DeployedResource{LogicalID: logicalID, Type: "AWS::EC2::LaunchTemplate"}
+	if routeErr != nil {
+		// Recorded on the resource, not returned — a returned error aborts the stack.
+		dr.Error = routeErr.Error()
+		return dr, cost, nil //nolint:nilerr
+	}
+	if resp != nil {
+		dr.PhysicalID = extractXMLField(resp.Body, "launchTemplateId")
+		dr.ARN = fmt.Sprintf("arn:aws:ec2:%s:%s:launch-template/%s", cctx.region, cctx.accountID, dr.PhysicalID)
+	}
+	return dr, cost, nil
+}
+
+// deployIAMInstanceProfile creates an IAM instance profile for the given CFN
+// resource and attaches the roles listed in Roles. An EC2 instance that
+// references a stubbed profile is launched without one, which silently changes
+// its permissions.
+func (d *StackDeployer) deployIAMInstanceProfile(
+	ctx context.Context,
+	logicalID string,
+	props map[string]interface{},
+	streamID string,
+	cctx *cfnContext,
+) (DeployedResource, float64, error) {
+	name := resolveStringProp(props, "InstanceProfileName", logicalID, cctx)
+	path := resolveStringProp(props, "Path", "/", cctx)
+
+	bodyBytes, err := json.Marshal(map[string]string{
+		"InstanceProfileName": name,
+		"Path":                path,
+	})
+	if err != nil {
+		return DeployedResource{}, 0, fmt.Errorf("marshal instance profile body: %w", err)
+	}
+
+	resp, cost, routeErr := d.dispatch(ctx, &AWSRequest{
+		Service:   "iam",
+		Operation: "CreateInstanceProfile",
+		Body:      bodyBytes,
+		Headers:   map[string]string{},
+		Params:    map[string]string{},
+	}, streamID)
+
+	dr := DeployedResource{LogicalID: logicalID, Type: "AWS::IAM::InstanceProfile", PhysicalID: name}
+	if routeErr != nil {
+		// Recorded on the resource, not returned — a returned error aborts the stack.
+		dr.Error = routeErr.Error()
+		return dr, cost, nil //nolint:nilerr
+	}
+	if resp != nil {
+		var result struct {
+			ARN string `xml:"CreateInstanceProfileResult>InstanceProfile>Arn"`
+		}
+		if xmlErr := xmlUnmarshalIAM(resp.Body, &result); xmlErr == nil {
+			dr.ARN = result.ARN
+		}
+	}
+
+	// Attach each role. CFN allows only one, but the list form is what templates use.
+	totalCost := cost
+	for _, roleName := range resolveStringList(props["Roles"], cctx) {
+		roleBody, marshalErr := json.Marshal(map[string]string{
+			"InstanceProfileName": name,
+			"RoleName":            roleName,
+		})
+		if marshalErr != nil {
+			return dr, totalCost, fmt.Errorf("marshal add-role body: %w", marshalErr)
+		}
+		_, addCost, addErr := d.dispatch(ctx, &AWSRequest{
+			Service:   "iam",
+			Operation: "AddRoleToInstanceProfile",
+			Body:      roleBody,
+			Headers:   map[string]string{},
+			Params:    map[string]string{},
+		}, streamID)
+		totalCost += addCost
+		if addErr != nil && dr.Error == "" {
+			dr.Error = addErr.Error()
+		}
+	}
+	return dr, totalCost, nil
+}
+
+// deployEC2SecurityGroupIngress authorizes a standalone
+// AWS::EC2::SecurityGroupIngress rule. The standalone form exists precisely for
+// the rules the inline form cannot express — a self-referencing rule, or a pair
+// of groups referencing each other — so stubbing it silently drops exactly the
+// rules a template author had to reach for it to write.
+func (d *StackDeployer) deployEC2SecurityGroupIngress(
+	ctx context.Context,
+	logicalID string,
+	props map[string]interface{},
+	streamID string,
+	cctx *cfnContext,
+) (DeployedResource, float64, error) {
+	return d.deploySGRule(ctx, logicalID, "AWS::EC2::SecurityGroupIngress",
+		"AuthorizeSecurityGroupIngress", props, streamID, cctx)
+}
+
+// deployEC2SecurityGroupEgress authorizes a standalone
+// AWS::EC2::SecurityGroupEgress rule.
+func (d *StackDeployer) deployEC2SecurityGroupEgress(
+	ctx context.Context,
+	logicalID string,
+	props map[string]interface{},
+	streamID string,
+	cctx *cfnContext,
+) (DeployedResource, float64, error) {
+	return d.deploySGRule(ctx, logicalID, "AWS::EC2::SecurityGroupEgress",
+		"AuthorizeSecurityGroupEgress", props, streamID, cctx)
+}
+
+// deploySGRule authorizes one standalone security-group rule via action.
+func (d *StackDeployer) deploySGRule(
+	ctx context.Context,
+	logicalID, resourceType, action string,
+	props map[string]interface{},
+	streamID string,
+	cctx *cfnContext,
+) (DeployedResource, float64, error) {
+	groupID := resolveStringProp(props, "GroupId", "", cctx)
+	if groupID == "" {
+		// GroupName is accepted for default-VPC groups.
+		groupID = resolveStringProp(props, "GroupName", "", cctx)
+	}
+
+	params := map[string]string{"Action": action, "GroupId": groupID}
+	for k, v := range sgRuleParams(props, "IpPermissions.1.", cctx) {
+		params[k] = v
+	}
+
+	_, cost, routeErr := d.dispatch(ctx, &AWSRequest{
+		Service:   "ec2",
+		Operation: action,
+		Params:    params,
+		Headers:   map[string]string{},
+	}, streamID)
+
+	dr := DeployedResource{
+		LogicalID: logicalID,
+		Type:      resourceType,
+		// AWS assigns an opaque sgr- physical ID; the group is the useful handle.
+		PhysicalID: groupID,
+		ARN:        groupID,
+	}
+	if routeErr != nil {
+		dr.Error = routeErr.Error()
+	}
+	return dr, cost, nil
+}
+
+// sgRuleParams translates one CFN security-group rule's properties into EC2
+// query parameters under prefix. It handles both CIDR sources and
+// security-group sources (SourceSecurityGroupId / DestinationSecurityGroupId),
+// the latter being what a self-referencing rule needs.
+func sgRuleParams(props map[string]interface{}, prefix string, cctx *cfnContext) map[string]string {
+	params := map[string]string{}
+	if proto := resolveStringProp(props, "IpProtocol", "", cctx); proto != "" {
+		params[prefix+"IpProtocol"] = proto
+	}
+	if from := resolveStringProp(props, "FromPort", "", cctx); from != "" {
+		params[prefix+"FromPort"] = from
+	}
+	if to := resolveStringProp(props, "ToPort", "", cctx); to != "" {
+		params[prefix+"ToPort"] = to
+	}
+	if cidr := resolveStringProp(props, "CidrIp", "", cctx); cidr != "" {
+		params[prefix+"IpRanges.1.CidrIp"] = cidr
+	}
+	// CidrIpv6 has no IPv6-specific storage yet; record it as a range so the rule
+	// is not silently dropped.
+	if cidr6 := resolveStringProp(props, "CidrIpv6", "", cctx); cidr6 != "" {
+		params[prefix+"IpRanges.1.CidrIp"] = cidr6
+	}
+
+	// A source/destination security group. GroupId takes precedence over
+	// GroupName, matching AWS.
+	srcID := resolveStringProp(props, "SourceSecurityGroupId", "", cctx)
+	if srcID == "" {
+		srcID = resolveStringProp(props, "DestinationSecurityGroupId", "", cctx)
+	}
+	srcName := resolveStringProp(props, "SourceSecurityGroupName", "", cctx)
+	if srcID != "" || srcName != "" {
+		if srcID != "" {
+			params[prefix+"Groups.1.GroupId"] = srcID
+		} else {
+			params[prefix+"Groups.1.GroupName"] = srcName
+		}
+		if owner := resolveStringProp(props, "SourceSecurityGroupOwnerId", "", cctx); owner != "" {
+			params[prefix+"Groups.1.UserId"] = owner
+		}
+	}
+	if desc := resolveStringProp(props, "Description", "", cctx); desc != "" && (srcID != "" || srcName != "") {
+		params[prefix+"Groups.1.Description"] = desc
+	}
+	return params
+}
+
+// authorizeInlineSGRules authorizes the SecurityGroupIngress and
+// SecurityGroupEgress rules declared inline on an AWS::EC2::SecurityGroup. These
+// were previously parsed as part of the resource's properties but never
+// applied, so DescribeSecurityGroups reported a group with no rules (#388).
+func (d *StackDeployer) authorizeInlineSGRules(
+	ctx context.Context,
+	groupID string,
+	props map[string]interface{},
+	streamID string,
+	cctx *cfnContext,
+) (float64, string) {
+	var totalCost float64
+	var firstErr string
+
+	for _, spec := range []struct {
+		propKey string
+		action  string
+	}{
+		{"SecurityGroupIngress", "AuthorizeSecurityGroupIngress"},
+		{"SecurityGroupEgress", "AuthorizeSecurityGroupEgress"},
+	} {
+		rules, ok := props[spec.propKey].([]interface{})
+		if !ok {
+			continue
+		}
+		params := map[string]string{"Action": spec.action, "GroupId": groupID}
+		count := 0
+		for _, raw := range rules {
+			rule, isMap := raw.(map[string]interface{})
+			if !isMap {
+				continue
+			}
+			count++
+			prefix := "IpPermissions." + strconv.Itoa(count) + "."
+			for k, v := range sgRuleParams(rule, prefix, cctx) {
+				params[k] = v
+			}
+		}
+		if count == 0 {
+			continue
+		}
+		_, cost, routeErr := d.dispatch(ctx, &AWSRequest{
+			Service:   "ec2",
+			Operation: spec.action,
+			Params:    params,
+			Headers:   map[string]string{},
+		}, streamID)
+		totalCost += cost
+		if routeErr != nil && firstErr == "" {
+			firstErr = routeErr.Error()
+		}
+	}
+	return totalCost, firstErr
+}
+
+// cfnTypeServiceOverrides maps CFN service segments whose lower-cased form is
+// not the substrate plugin name.
+var cfnTypeServiceOverrides = map[string]string{
+	"elasticloadbalancingv2": "elbv2",
+	"certificatemanager":     "acm",
+	"opensearchservice":      "opensearch",
+	"servicediscovery":       "servicediscovery",
+	"elasticache":            "elasticache",
+	"applicationautoscaling": "application-autoscaling",
+	"secretsmanager":         "secretsmanager",
+	"stepfunctions":          "states",
+	"serverless":             "lambda",
+}
+
+// servicePluginLoaded reports whether a plugin for the CFN resource type's
+// service is registered. A generic stub for a type whose plugin *is* loaded
+// usually means the type needs wiring rather than that the service is
+// unsupported, which is the distinction the stub warning should surface (#388).
+func (d *StackDeployer) servicePluginLoaded(resType string) bool {
+	parts := strings.SplitN(resType, "::", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	service := strings.ToLower(parts[1])
+	if override, ok := cfnTypeServiceOverrides[service]; ok {
+		service = override
+	}
+	for _, name := range d.registry.Names() {
+		if name == service {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveStringList resolves a CFN list-valued property to a string slice,
+// resolving each element through Ref/Fn::GetAtt. A single scalar is treated as a
+// one-element list, which is what templates that omit the YAML list syntax
+// produce.
+func resolveStringList(v interface{}, cctx *cfnContext) []string {
+	switch val := v.(type) {
+	case nil:
+		return nil
+	case []interface{}:
+		out := make([]string, 0, len(val))
+		for _, item := range val {
+			if s := resolveValue(item, cctx); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		if s := resolveValue(v, cctx); s != "" {
+			return []string{s}
+		}
+		return nil
+	}
+}

--- a/emulator/betty_cfn_v77_test.go
+++ b/emulator/betty_cfn_v77_test.go
@@ -1,0 +1,441 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// newEC2IAMTestDeployer creates a StackDeployer with the EC2 and IAM plugins and
+// returns the registry, so a test can observe deployed resources through the
+// same API a consumer would call.
+func newEC2IAMTestDeployer(t *testing.T) (*emulator.StackDeployer, *emulator.PluginRegistry) {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+
+	ec2Plugin := &emulator.EC2Plugin{}
+	require.NoError(t, ec2Plugin.Initialize(context.Background(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(ec2Plugin)
+
+	iamPlugin := &emulator.IAMPlugin{}
+	require.NoError(t, iamPlugin.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+	}))
+	registry.Register(iamPlugin)
+
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs), registry
+}
+
+// routeQuery sends a request through the registry and returns the XML response
+// body. The IAM plugin reads its input from a JSON body rather than Params, so
+// params are marshaled for that service.
+func routeQuery(t *testing.T, registry *emulator.PluginRegistry, service string, params map[string]string) string {
+	t.Helper()
+	req := &emulator.AWSRequest{
+		Service:   service,
+		Operation: params["Action"],
+		Params:    params,
+		Headers:   map[string]string{},
+	}
+	if service == "iam" {
+		body, err := json.Marshal(params)
+		require.NoError(t, err)
+		req.Body = body
+	}
+	resp, err := registry.RouteRequest(&emulator.RequestContext{
+		RequestID: "test-request",
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		Timestamp: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+	}, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return string(resp.Body)
+}
+
+// findResource returns the deployed resource with the given logical ID.
+func findResource(t *testing.T, result *emulator.DeployResult, logicalID string) emulator.DeployedResource {
+	t.Helper()
+	for _, r := range result.Resources {
+		if r.LogicalID == logicalID {
+			return r
+		}
+	}
+	t.Fatalf("resource %s not found in %+v", logicalID, result.Resources)
+	return emulator.DeployedResource{}
+}
+
+// TestCFN_EC2LaunchTemplate verifies a launch template declared in a template is
+// afterwards visible to DescribeLaunchTemplates, rather than being stubbed (#388).
+func TestCFN_EC2LaunchTemplate(t *testing.T) {
+	d, registry := newEC2IAMTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"ComputeLT": {
+				"Type": "AWS::EC2::LaunchTemplate",
+				"Properties": {
+					"LaunchTemplateName": "compute-nodes",
+					"LaunchTemplateData": {
+						"ImageId": "ami-0abc1234",
+						"InstanceType": "c5.4xlarge",
+						"KeyName": "cluster-key"
+					}
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "lt-stack", nil)
+	require.NoError(t, err)
+
+	lt := findResource(t, result, "ComputeLT")
+	assert.Empty(t, lt.Error)
+	// The Ref must be the launch template ID, which is what CreateFleet and
+	// AutoScaling consume; a stub would return the logical ID.
+	assert.Regexp(t, `^lt-[0-9a-f]+$`, lt.PhysicalID)
+	assert.Contains(t, lt.ARN, "launch-template/"+lt.PhysicalID)
+
+	body := routeQuery(t, registry, "ec2", map[string]string{"Action": "DescribeLaunchTemplates"})
+	assert.Contains(t, body, lt.PhysicalID)
+	assert.Contains(t, body, "compute-nodes")
+}
+
+// TestCFN_IAMInstanceProfile verifies an instance profile is created and its
+// roles attached, and that an instance referencing it resolves (#388).
+func TestCFN_IAMInstanceProfile(t *testing.T) {
+	d, registry := newEC2IAMTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"NodeRole": {
+				"Type": "AWS::IAM::Role",
+				"Properties": {
+					"RoleName": "compute-node-role",
+					"AssumeRolePolicyDocument": {
+						"Version": "2012-10-17",
+						"Statement": [{
+							"Effect": "Allow",
+							"Principal": {"Service": "ec2.amazonaws.com"},
+							"Action": "sts:AssumeRole"
+						}]
+					}
+				}
+			},
+			"NodeProfile": {
+				"Type": "AWS::IAM::InstanceProfile",
+				"Properties": {
+					"InstanceProfileName": "compute-node-profile",
+					"Roles": [{"Ref": "NodeRole"}]
+				}
+			},
+			"Node": {
+				"Type": "AWS::EC2::Instance",
+				"Properties": {
+					"ImageId": "ami-0abc1234",
+					"InstanceType": "c5.large",
+					"IamInstanceProfile": {"Ref": "NodeProfile"}
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "profile-stack", nil)
+	require.NoError(t, err)
+
+	profile := findResource(t, result, "NodeProfile")
+	assert.Empty(t, profile.Error)
+	assert.Equal(t, "compute-node-profile", profile.PhysicalID)
+	assert.Contains(t, profile.ARN, "instance-profile/compute-node-profile")
+
+	// GetInstanceProfile must find it, and the role must be attached.
+	body := routeQuery(t, registry, "iam", map[string]string{
+		"Action":              "GetInstanceProfile",
+		"InstanceProfileName": "compute-node-profile",
+	})
+	assert.Contains(t, body, "compute-node-profile")
+	assert.Contains(t, body, "compute-node-role")
+
+	// The instance's profile reference resolves to the real profile.
+	node := findResource(t, result, "Node")
+	assert.Empty(t, node.Error)
+	instances := routeQuery(t, registry, "ec2", map[string]string{"Action": "DescribeInstances"})
+	assert.Contains(t, instances, node.PhysicalID)
+	assert.Contains(t, instances, "instance-profile/compute-node-profile")
+}
+
+// TestCFN_SecurityGroupIngress_SelfReferencing verifies the standalone rule
+// resource, which is the only way to express a self-referencing group. This is
+// the case #388 calls sharpest: a test asserting "my template opens port 6818
+// within the compute security group" could pass deploy and still not observe the
+// rule.
+func TestCFN_SecurityGroupIngress_SelfReferencing(t *testing.T) {
+	d, registry := newEC2IAMTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"ComputeSG": {
+				"Type": "AWS::EC2::SecurityGroup",
+				"Properties": {
+					"GroupDescription": "Slurm compute nodes",
+					"VpcId": "vpc-01234567"
+				}
+			},
+			"SlurmdIngress": {
+				"Type": "AWS::EC2::SecurityGroupIngress",
+				"Properties": {
+					"GroupId": {"Ref": "ComputeSG"},
+					"IpProtocol": "tcp",
+					"FromPort": 6818,
+					"ToPort": 6818,
+					"SourceSecurityGroupId": {"Ref": "ComputeSG"},
+					"Description": "slurmd within the cluster"
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "self-ref-stack", nil)
+	require.NoError(t, err)
+
+	sg := findResource(t, result, "ComputeSG")
+	require.NotEmpty(t, sg.PhysicalID)
+	ingress := findResource(t, result, "SlurmdIngress")
+	assert.Empty(t, ingress.Error)
+	assert.Equal(t, sg.PhysicalID, ingress.PhysicalID)
+
+	body := routeQuery(t, registry, "ec2", map[string]string{
+		"Action":    "DescribeSecurityGroups",
+		"GroupId.1": sg.PhysicalID,
+	})
+	assert.Contains(t, body, "<fromPort>6818</fromPort>")
+	assert.Contains(t, body, "<toPort>6818</toPort>")
+	// The rule's source is the group itself, so it renders as a group pair with no
+	// CIDR — a shape IPRanges alone cannot express.
+	assert.Contains(t, body, "<groups>")
+	assert.Contains(t, body, "<groupId>"+sg.PhysicalID+"</groupId>")
+	assert.Contains(t, body, "slurmd within the cluster")
+}
+
+// TestCFN_SecurityGroup_InlineRules verifies inline SecurityGroupIngress and
+// SecurityGroupEgress properties are authorized, so both spellings behave the
+// same (#388).
+func TestCFN_SecurityGroup_InlineRules(t *testing.T) {
+	d, registry := newEC2IAMTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"HeadSG": {
+				"Type": "AWS::EC2::SecurityGroup",
+				"Properties": {
+					"GroupDescription": "Head node",
+					"VpcId": "vpc-01234567",
+					"SecurityGroupIngress": [
+						{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "CidrIp": "10.0.0.0/8"},
+						{"IpProtocol": "tcp", "FromPort": 6817, "ToPort": 6817, "CidrIp": "10.1.0.0/16"}
+					],
+					"SecurityGroupEgress": [
+						{"IpProtocol": "-1", "CidrIp": "0.0.0.0/0"}
+					]
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "inline-rules-stack", nil)
+	require.NoError(t, err)
+
+	sg := findResource(t, result, "HeadSG")
+	assert.Empty(t, sg.Error)
+	require.NotEmpty(t, sg.PhysicalID)
+
+	body := routeQuery(t, registry, "ec2", map[string]string{
+		"Action":    "DescribeSecurityGroups",
+		"GroupId.1": sg.PhysicalID,
+	})
+	// Both ingress rules are present, not just the first.
+	assert.Contains(t, body, "<cidrIp>10.0.0.0/8</cidrIp>")
+	assert.Contains(t, body, "<cidrIp>10.1.0.0/16</cidrIp>")
+	assert.Contains(t, body, "<fromPort>22</fromPort>")
+	assert.Contains(t, body, "<fromPort>6817</fromPort>")
+	assert.Contains(t, body, "<ipPermissionsEgress>")
+	assert.Contains(t, body, "<cidrIp>0.0.0.0/0</cidrIp>")
+}
+
+// TestCFN_SecurityGroupEgress_Standalone verifies the standalone egress rule
+// resource, including a destination security group.
+func TestCFN_SecurityGroupEgress_Standalone(t *testing.T) {
+	d, registry := newEC2IAMTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"AppSG": {
+				"Type": "AWS::EC2::SecurityGroup",
+				"Properties": {"GroupDescription": "App", "VpcId": "vpc-01234567"}
+			},
+			"DBSG": {
+				"Type": "AWS::EC2::SecurityGroup",
+				"Properties": {"GroupDescription": "DB", "VpcId": "vpc-01234567"}
+			},
+			"AppToDB": {
+				"Type": "AWS::EC2::SecurityGroupEgress",
+				"Properties": {
+					"GroupId": {"Ref": "AppSG"},
+					"IpProtocol": "tcp",
+					"FromPort": 5432,
+					"ToPort": 5432,
+					"DestinationSecurityGroupId": {"Ref": "DBSG"}
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "egress-stack", nil)
+	require.NoError(t, err)
+
+	appSG := findResource(t, result, "AppSG")
+	dbSG := findResource(t, result, "DBSG")
+	rule := findResource(t, result, "AppToDB")
+	assert.Empty(t, rule.Error)
+
+	body := routeQuery(t, registry, "ec2", map[string]string{
+		"Action":    "DescribeSecurityGroups",
+		"GroupId.1": appSG.PhysicalID,
+	})
+	assert.Contains(t, body, "<ipPermissionsEgress>")
+	assert.Contains(t, body, "<fromPort>5432</fromPort>")
+	assert.Contains(t, body, "<groupId>"+dbSG.PhysicalID+"</groupId>")
+}
+
+// TestCFN_SecurityGroupIngress_MutualReference verifies two groups that
+// reference each other both resolve, which requires the standalone rules to
+// deploy after every group.
+func TestCFN_SecurityGroupIngress_MutualReference(t *testing.T) {
+	d, registry := newEC2IAMTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"AToB": {
+				"Type": "AWS::EC2::SecurityGroupIngress",
+				"Properties": {
+					"GroupId": {"Ref": "GroupA"},
+					"IpProtocol": "tcp", "FromPort": 80, "ToPort": 80,
+					"SourceSecurityGroupId": {"Ref": "GroupB"}
+				}
+			},
+			"BToA": {
+				"Type": "AWS::EC2::SecurityGroupIngress",
+				"Properties": {
+					"GroupId": {"Ref": "GroupB"},
+					"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443,
+					"SourceSecurityGroupId": {"Ref": "GroupA"}
+				}
+			},
+			"GroupA": {
+				"Type": "AWS::EC2::SecurityGroup",
+				"Properties": {"GroupDescription": "A", "VpcId": "vpc-01234567"}
+			},
+			"GroupB": {
+				"Type": "AWS::EC2::SecurityGroup",
+				"Properties": {"GroupDescription": "B", "VpcId": "vpc-01234567"}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "mutual-stack", nil)
+	require.NoError(t, err)
+
+	groupA := findResource(t, result, "GroupA")
+	groupB := findResource(t, result, "GroupB")
+	require.NotEmpty(t, groupA.PhysicalID)
+	require.NotEmpty(t, groupB.PhysicalID)
+	assert.Empty(t, findResource(t, result, "AToB").Error)
+	assert.Empty(t, findResource(t, result, "BToA").Error)
+
+	bodyA := routeQuery(t, registry, "ec2", map[string]string{
+		"Action": "DescribeSecurityGroups", "GroupId.1": groupA.PhysicalID,
+	})
+	assert.Contains(t, bodyA, "<groupId>"+groupB.PhysicalID+"</groupId>",
+		"GroupA's ingress should name GroupB as its source")
+
+	bodyB := routeQuery(t, registry, "ec2", map[string]string{
+		"Action": "DescribeSecurityGroups", "GroupId.1": groupB.PhysicalID,
+	})
+	assert.Contains(t, bodyB, "<groupId>"+groupA.PhysicalID+"</groupId>",
+		"GroupB's ingress should name GroupA as its source")
+}
+
+// TestCFN_LaunchTemplateFeedsCreateFleet verifies the two halves of this sprint
+// compose: a launch template deployed from a template can be used by CreateFleet
+// (#387, #388). A stubbed launch template's physical ID is not a usable
+// reference, so this only works with the real wiring.
+func TestCFN_LaunchTemplateFeedsCreateFleet(t *testing.T) {
+	d, registry := newEC2IAMTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"FleetLT": {
+				"Type": "AWS::EC2::LaunchTemplate",
+				"Properties": {
+					"LaunchTemplateName": "fleet-nodes",
+					"LaunchTemplateData": {"ImageId": "ami-0abc1234", "InstanceType": "c5.large"}
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "lt-fleet-stack", nil)
+	require.NoError(t, err)
+	lt := findResource(t, result, "FleetLT")
+	require.NotEmpty(t, lt.PhysicalID)
+
+	body := routeQuery(t, registry, "ec2", map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": lt.PhysicalID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+	})
+	assert.Contains(t, body, "<fleetId>fleet-")
+	assert.Contains(t, body, "<instanceIds>")
+}
+
+// TestCFN_GenericStubReportsPluginLoaded verifies an unhandled type whose service
+// plugin is loaded is distinguishable from an unmodelled service (#388).
+func TestCFN_GenericStubReportsPluginLoaded(t *testing.T) {
+	d, _ := newEC2IAMTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"ENI": {
+				"Type": "AWS::EC2::NetworkInterface",
+				"Properties": {"SubnetId": "subnet-01234567"}
+			},
+			"Widget": {
+				"Type": "AWS::SomeNewService::Widget",
+				"Properties": {"Name": "w"}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "stub-stack", nil)
+	require.NoError(t, err)
+
+	// Both still deploy as stubs; the difference is only in the warning, which
+	// carries service_plugin_loaded. Assert the stub behavior is unchanged.
+	eni := findResource(t, result, "ENI")
+	assert.Equal(t, "ENI", eni.PhysicalID)
+	assert.Contains(t, eni.ARN, "arn:aws:ec2:")
+	widget := findResource(t, result, "Widget")
+	assert.Equal(t, "Widget", widget.PhysicalID)
+	assert.Contains(t, widget.ARN, "somenewservice")
+}

--- a/emulator/doc.go
+++ b/emulator/doc.go
@@ -108,11 +108,14 @@
 // Service emulation is provided by [Plugin] implementations registered with
 // a [PluginRegistry]. State is persisted via the [StateManager] interface.
 //
-// Substrate ships 39 built-in service plugins registered by
+// Substrate ships a large set of built-in service plugins registered by
 // [RegisterDefaultPlugins], covering S3, Lambda, DynamoDB, EC2, IAM, SQS,
-// SNS, SES, Kinesis, Firehose, AppSync, Service Quotas, and many more. [S3Plugin]
-// alone supports 23 REST+XML operations including multipart uploads,
-// versioning, and lifecycle configuration. The [BettyClient]
+// SNS, SES, Kinesis, Firehose, AppSync, Service Quotas, and many more.
+// [S3Plugin] alone supports REST+XML operations including multipart uploads,
+// versioning, and lifecycle configuration. For the authoritative per-service
+// operation list and plugin count, see docs/services.md, which is generated
+// from the plugin registry by cmd/gen-service-reference — counts are
+// deliberately not repeated here so they cannot drift. The [BettyClient]
 // integrates CloudFormation deployment ([StackDeployer]), recording,
 // [ValidateRecording], and [DebugSession] time-travel into a single
 // high-level API for AI-generated infrastructure validation.

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -1,0 +1,915 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// EC2FleetOverride is one launch-template override in an EC2 Fleet request: an
+// (instance type, subnet) pool the fleet may draw capacity from.
+type EC2FleetOverride struct {
+	// InstanceType is the instance type for this pool.
+	InstanceType string `json:"instanceType,omitempty"`
+
+	// SubnetID is the subnet the pool launches into.
+	SubnetID string `json:"subnetId,omitempty"`
+
+	// AvailabilityZone is the AZ for this pool, when specified instead of a subnet.
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+
+	// ImageID overrides the launch template's AMI. Supported only for instant fleets.
+	ImageID string `json:"imageId,omitempty"`
+
+	// MaxPrice is the maximum Spot price per unit hour for this pool.
+	MaxPrice string `json:"maxPrice,omitempty"`
+
+	// Priority orders the pool when the allocation strategy is "prioritized";
+	// lower numbers are launched first.
+	Priority float64 `json:"priority,omitempty"`
+
+	// WeightedCapacity is the number of units this instance type provides. It is
+	// echoed back but does not scale the instance count — see [EC2Plugin.createFleet].
+	WeightedCapacity float64 `json:"weightedCapacity,omitempty"`
+
+	// PlacementGroupName constrains this pool to a placement group.
+	PlacementGroupName string `json:"placementGroupName,omitempty"`
+}
+
+// EC2FleetLaunchTemplateConfig pairs a launch template with the overrides that
+// replace values in it.
+type EC2FleetLaunchTemplateConfig struct {
+	// LaunchTemplateID is the referenced launch template's ID.
+	LaunchTemplateID string `json:"launchTemplateId,omitempty"`
+
+	// LaunchTemplateName is the referenced launch template's name.
+	LaunchTemplateName string `json:"launchTemplateName,omitempty"`
+
+	// Version is the launch template version ("$Latest", "$Default", or a number).
+	Version string `json:"version,omitempty"`
+
+	// Overrides holds the per-pool overrides for this launch template.
+	Overrides []EC2FleetOverride `json:"overrides,omitempty"`
+}
+
+// EC2FleetInstanceGroup records the instances launched from a single pool. The
+// IDs are grouped per pool because that is how CreateFleet reports them:
+// fleetInstanceSet contains one item per pool, each carrying a *list* of
+// instance IDs (#387).
+type EC2FleetInstanceGroup struct {
+	// InstanceIDs are the instances launched from this pool.
+	InstanceIDs []string `json:"instanceIds"`
+
+	// InstanceType is the instance type the pool launched.
+	InstanceType string `json:"instanceType,omitempty"`
+
+	// Lifecycle is "spot" or "on-demand".
+	Lifecycle string `json:"lifecycle,omitempty"`
+
+	// LaunchTemplateID and LaunchTemplateName identify the pool's launch template.
+	LaunchTemplateID   string `json:"launchTemplateId,omitempty"`
+	LaunchTemplateName string `json:"launchTemplateName,omitempty"`
+
+	// Override is the override that produced this pool.
+	Override EC2FleetOverride `json:"override"`
+}
+
+// EC2FleetError records capacity a fleet could not fulfill, mirroring one
+// CreateFleetError item.
+type EC2FleetError struct {
+	// ErrorCode is the reason the launch failed, e.g. "InsufficientInstanceCapacity".
+	ErrorCode string `json:"errorCode"`
+
+	// ErrorMessage describes the failure.
+	ErrorMessage string `json:"errorMessage"`
+
+	// Lifecycle is "spot" or "on-demand".
+	Lifecycle string `json:"lifecycle,omitempty"`
+
+	// LaunchTemplateID and LaunchTemplateName identify the pool that failed.
+	LaunchTemplateID   string `json:"launchTemplateId,omitempty"`
+	LaunchTemplateName string `json:"launchTemplateName,omitempty"`
+
+	// Override is the override describing the pool that failed.
+	Override EC2FleetOverride `json:"override"`
+}
+
+// EC2Fleet represents an EC2 Fleet request and the outcome of fulfilling it.
+type EC2Fleet struct {
+	// FleetID is the unique identifier (e.g. "fleet-12a34b56-...").
+	FleetID string `json:"fleetId"`
+
+	// FleetState is the fleet's state ("active", "deleted_terminating", ...).
+	FleetState string `json:"fleetState"`
+
+	// ActivityStatus is the fulfillment progress. For instant fleets this is
+	// always "fulfilled" once requests are placed, even on a partial fulfillment.
+	ActivityStatus string `json:"activityStatus"`
+
+	// Type is the fleet type: "instant", "request", or "maintain".
+	Type string `json:"type"`
+
+	// TotalTargetCapacity is the requested capacity — what was asked for, not
+	// what was delivered. Callers routinely mistake this for the result.
+	TotalTargetCapacity int `json:"totalTargetCapacity"`
+
+	// OnDemandTargetCapacity and SpotTargetCapacity are the per-lifecycle requests.
+	OnDemandTargetCapacity int `json:"onDemandTargetCapacity"`
+	SpotTargetCapacity     int `json:"spotTargetCapacity"`
+
+	// DefaultTargetCapacityType is "on-demand" or "spot".
+	DefaultTargetCapacityType string `json:"defaultTargetCapacityType"`
+
+	// FulfilledCapacity is the number of instances actually launched.
+	FulfilledCapacity int `json:"fulfilledCapacity"`
+
+	// LaunchTemplateConfigs is the request's launch-template/override matrix.
+	LaunchTemplateConfigs []EC2FleetLaunchTemplateConfig `json:"launchTemplateConfigs,omitempty"`
+
+	// Instances groups the launched instances by pool.
+	Instances []EC2FleetInstanceGroup `json:"instances,omitempty"`
+
+	// Errors describes capacity the fleet could not fulfill.
+	Errors []EC2FleetError `json:"errors,omitempty"`
+
+	// Tags holds the fleet's own tags (ResourceType=fleet).
+	Tags []EC2Tag `json:"tags,omitempty"`
+
+	// ClientToken is the caller-supplied idempotency token.
+	ClientToken string `json:"clientToken,omitempty"`
+
+	// CreateTime is the RFC3339 creation timestamp.
+	CreateTime string `json:"createTime"`
+
+	// AccountID and Region locate the fleet.
+	AccountID string `json:"accountId"`
+	Region    string `json:"region"`
+}
+
+// generateFleetID generates an EC2 Fleet ID in the AWS format, "fleet-"
+// followed by a UUID-shaped hex string.
+func generateFleetID() string {
+	return fmt.Sprintf("fleet-%s-%s-%s-%s-%s",
+		randomHex(4), randomHex(2), randomHex(2), randomHex(2), randomHex(6))
+}
+
+// ec2FleetStateKey returns the state key for a fleet.
+func ec2FleetStateKey(accountID, region, fleetID string) string {
+	return "fleet:" + accountID + "/" + region + "/" + fleetID
+}
+
+// createFleet handles CreateFleet.
+//
+// The emulated fulfillment model is deliberately simple and fully deterministic:
+// the launch-template/override matrix defines an ordered list of capacity pools
+// (sorted by Priority when the allocation strategy is "prioritized"), and the
+// fulfilled instances are distributed round-robin across those pools. Grouping
+// by pool is what makes fleetInstanceSet contain one item per pool, each with a
+// *list* of instance IDs — the shape callers most often flatten incorrectly.
+//
+// By default a fleet fulfills its entire TotalTargetCapacity. A seeded shortfall
+// (POST /v1/ec2/fleet-shortfall) makes the fleet fulfill fewer instances and
+// report the remainder in errorSet, which is how a test exercises the partial
+// fulfillment path that is rare and hard to trigger against real AWS (#387).
+//
+// Instances are created through runInstances, so everything that path
+// establishes — subnet/security-group validation, placement-group existence,
+// public IP assignment, launch-time tag propagation, and visibility to
+// DescribeInstances — applies to fleet instances too.
+//
+// TargetCapacityUnitType and WeightedCapacity are recorded and echoed but do not
+// scale the instance count: capacity is counted in instances, which is the
+// default "units" behavior.
+func (p *EC2Plugin) createFleet(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+
+	fleetType := req.Params["Type"]
+	if fleetType == "" {
+		fleetType = "maintain" // AWS default.
+	}
+	switch fleetType {
+	case "instant", "request", "maintain":
+	default:
+		return nil, &AWSError{
+			Code:       "InvalidParameterValue",
+			Message:    "Invalid fleet type: " + fleetType,
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	total, err := strconv.Atoi(req.Params["TargetCapacitySpecification.TotalTargetCapacity"])
+	if err != nil || total < 0 {
+		return nil, &AWSError{
+			Code:       "MissingParameter",
+			Message:    "TargetCapacitySpecification.TotalTargetCapacity is required",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	onDemand, _ := strconv.Atoi(req.Params["TargetCapacitySpecification.OnDemandTargetCapacity"])
+	spot, _ := strconv.Atoi(req.Params["TargetCapacitySpecification.SpotTargetCapacity"])
+	defaultType := req.Params["TargetCapacitySpecification.DefaultTargetCapacityType"]
+	if defaultType == "" {
+		defaultType = "on-demand" // AWS default.
+	}
+
+	configs := parseFleetLaunchTemplateConfigs(req.Params)
+	if len(configs) == 0 {
+		return nil, &AWSError{
+			Code:       "MissingParameter",
+			Message:    "LaunchTemplateConfigs is required",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	// Every referenced launch template must exist, mirroring AWS — so a
+	// create-template → create-fleet ordering error is observable.
+	for _, cfg := range configs {
+		if lt := p.resolveLaunchTemplate(goCtx, reqCtx, cfg.LaunchTemplateID, cfg.LaunchTemplateName); lt == nil {
+			if cfg.LaunchTemplateID != "" {
+				return nil, &AWSError{
+					Code:       "InvalidLaunchTemplateId.NotFound",
+					Message:    "Launch template " + cfg.LaunchTemplateID + " does not exist",
+					HTTPStatus: http.StatusBadRequest,
+				}
+			}
+			return nil, &AWSError{
+				Code:       "InvalidLaunchTemplateName.NotFoundException",
+				Message:    "Launch template with name '" + cfg.LaunchTemplateName + "' does not exist",
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+	}
+
+	pools := fleetPools(configs, fleetAllocationStrategy(req.Params, defaultType))
+
+	// Resolve a seeded shortfall against the first config's template.
+	fulfill := total
+	shortfallCode := "InsufficientInstanceCapacity"
+	shortfallMsg := ""
+	shortfallLifecycle := ""
+	seed, err := p.resolveFleetShortfall(configs[0].LaunchTemplateID, configs[0].LaunchTemplateName)
+	if err != nil {
+		return nil, err
+	}
+	if seed != nil {
+		fulfill = min(seed.Fulfill, total)
+		if seed.ErrorCode != "" {
+			shortfallCode = seed.ErrorCode
+		}
+		shortfallMsg = seed.ErrorMessage
+		shortfallLifecycle = seed.Lifecycle
+	}
+	if shortfallMsg == "" {
+		shortfallMsg = fleetDefaultErrorMessage(shortfallCode)
+	}
+	if shortfallLifecycle == "" {
+		shortfallLifecycle = defaultType
+	}
+
+	// Requested and fulfilled counts per pool, distributed round-robin.
+	wantPerPool := distributeAcrossPools(total, len(pools))
+	gotPerPool := distributeAcrossPools(fulfill, len(pools))
+
+	instanceTags := passthroughFleetTagSpecs(req.Params, "instance")
+	fleetTags := fleetTagsFor(req.Params, "fleet")
+
+	fleet := EC2Fleet{
+		FleetID:                   generateFleetID(),
+		FleetState:                "active",
+		Type:                      fleetType,
+		TotalTargetCapacity:       total,
+		OnDemandTargetCapacity:    onDemand,
+		SpotTargetCapacity:        spot,
+		DefaultTargetCapacityType: defaultType,
+		LaunchTemplateConfigs:     configs,
+		Tags:                      fleetTags,
+		ClientToken:               req.Params["ClientToken"],
+		CreateTime:                p.tc.Now().UTC().Format(time.RFC3339),
+		AccountID:                 reqCtx.AccountID,
+		Region:                    reqCtx.Region,
+	}
+	// For instant fleets AWS reports "fulfilled" once all requests are placed,
+	// regardless of whether target capacity was actually met.
+	if fleetType == "instant" {
+		fleet.ActivityStatus = "fulfilled"
+	} else {
+		fleet.ActivityStatus = "pending_fulfillment"
+	}
+
+	for i, pool := range pools {
+		lifecycle := defaultType
+		if pool.override.MaxPrice != "" {
+			lifecycle = "spot"
+		}
+
+		if gotPerPool[i] > 0 {
+			ids, launchErr := p.launchFleetPool(reqCtx, pool, gotPerPool[i], instanceTags)
+			if launchErr != nil {
+				return nil, launchErr
+			}
+			fleet.Instances = append(fleet.Instances, EC2FleetInstanceGroup{
+				InstanceIDs:        ids,
+				InstanceType:       pool.instanceType(),
+				Lifecycle:          lifecycle,
+				LaunchTemplateID:   pool.ltID,
+				LaunchTemplateName: pool.ltName,
+				Override:           pool.override,
+			})
+			fleet.FulfilledCapacity += len(ids)
+		}
+
+		// Any pool that received less than its share reports the shortfall.
+		if gotPerPool[i] < wantPerPool[i] {
+			errLifecycle := shortfallLifecycle
+			if pool.override.MaxPrice != "" {
+				errLifecycle = "spot"
+			}
+			fleet.Errors = append(fleet.Errors, EC2FleetError{
+				ErrorCode:          shortfallCode,
+				ErrorMessage:       shortfallMsg,
+				Lifecycle:          errLifecycle,
+				LaunchTemplateID:   pool.ltID,
+				LaunchTemplateName: pool.ltName,
+				Override:           pool.override,
+			})
+		}
+	}
+
+	data, err := json.Marshal(fleet)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 createFleet marshal: %w", err)
+	}
+	key := ec2FleetStateKey(reqCtx.AccountID, reqCtx.Region, fleet.FleetID)
+	if err := p.state.Put(goCtx, ec2Namespace, key, data); err != nil {
+		return nil, fmt.Errorf("ec2 createFleet state.Put: %w", err)
+	}
+
+	return p.createFleetResponse(&fleet)
+}
+
+// fleetPool is one resolved capacity pool: a launch template plus one override.
+type fleetPool struct {
+	ltID     string
+	ltName   string
+	version  string
+	override EC2FleetOverride
+}
+
+// instanceType returns the pool's overridden instance type, which may be empty
+// when the launch template's own type should apply.
+func (f fleetPool) instanceType() string { return f.override.InstanceType }
+
+// fleetPools flattens launch-template configs into an ordered pool list. With
+// the "prioritized" allocation strategy the pools are sorted by Priority
+// (lowest first, AWS's highest-priority-first rule); otherwise request order is
+// preserved. A config with no overrides contributes a single pool that launches
+// straight from the launch template.
+func fleetPools(configs []EC2FleetLaunchTemplateConfig, strategy string) []fleetPool {
+	var pools []fleetPool
+	for _, cfg := range configs {
+		if len(cfg.Overrides) == 0 {
+			pools = append(pools, fleetPool{ltID: cfg.LaunchTemplateID, ltName: cfg.LaunchTemplateName, version: cfg.Version})
+			continue
+		}
+		for _, ov := range cfg.Overrides {
+			pools = append(pools, fleetPool{
+				ltID:     cfg.LaunchTemplateID,
+				ltName:   cfg.LaunchTemplateName,
+				version:  cfg.Version,
+				override: ov,
+			})
+		}
+	}
+	if strategy == "prioritized" || strategy == "capacity-optimized-prioritized" {
+		sort.SliceStable(pools, func(i, j int) bool {
+			return pools[i].override.Priority < pools[j].override.Priority
+		})
+	}
+	return pools
+}
+
+// fleetAllocationStrategy returns the allocation strategy that orders the pools,
+// reading the Spot or On-Demand options according to the default capacity type.
+func fleetAllocationStrategy(params map[string]string, defaultType string) string {
+	if defaultType == "spot" {
+		if s := params["SpotOptions.AllocationStrategy"]; s != "" {
+			return s
+		}
+		return ""
+	}
+	return params["OnDemandOptions.AllocationStrategy"]
+}
+
+// distributeAcrossPools splits n items across pools round-robin, so earlier
+// pools take the remainder. Returns a per-pool count slice.
+func distributeAcrossPools(n, pools int) []int {
+	out := make([]int, pools)
+	if pools == 0 || n <= 0 {
+		return out
+	}
+	base, rem := n/pools, n%pools
+	for i := range out {
+		out[i] = base
+		if i < rem {
+			out[i]++
+		}
+	}
+	return out
+}
+
+// launchFleetPool launches count instances for one pool by dispatching through
+// runInstances, and returns the resulting instance IDs. Going through
+// runInstances (rather than writing instance state directly) is what makes fleet
+// instances indistinguishable from directly-launched ones to DescribeInstances.
+func (p *EC2Plugin) launchFleetPool(
+	reqCtx *RequestContext,
+	pool fleetPool,
+	count int,
+	instanceTags map[string]string,
+) ([]string, error) {
+	params := map[string]string{
+		"Action":   "RunInstances",
+		"MinCount": strconv.Itoa(count),
+		"MaxCount": strconv.Itoa(count),
+	}
+	if pool.ltID != "" {
+		params["LaunchTemplate.LaunchTemplateId"] = pool.ltID
+	}
+	if pool.ltName != "" {
+		params["LaunchTemplate.LaunchTemplateName"] = pool.ltName
+	}
+	// An override's ImageId replaces the launch template's AMI.
+	if pool.override.ImageID != "" {
+		params["ImageId"] = pool.override.ImageID
+	}
+	if pool.override.InstanceType != "" {
+		params["InstanceType"] = pool.override.InstanceType
+	}
+	if pool.override.SubnetID != "" {
+		params["SubnetId"] = pool.override.SubnetID
+	}
+	if pool.override.PlacementGroupName != "" {
+		params["Placement.GroupName"] = pool.override.PlacementGroupName
+	}
+	for k, v := range instanceTags {
+		params[k] = v
+	}
+
+	resp, err := p.runInstances(reqCtx, &AWSRequest{
+		Service:   "ec2",
+		Operation: "RunInstances",
+		Params:    params,
+		Headers:   map[string]string{},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	if err := xml.Unmarshal(resp.Body, &parsed); err != nil {
+		return nil, fmt.Errorf("ec2 launchFleetPool parse RunInstances response: %w", err)
+	}
+	ids := make([]string, 0, len(parsed.Instances))
+	for _, inst := range parsed.Instances {
+		ids = append(ids, inst.InstanceID)
+	}
+	return ids, nil
+}
+
+// parseFleetLaunchTemplateConfigs parses LaunchTemplateConfigs.N and their
+// nested Overrides.M from the flattened query parameters.
+func parseFleetLaunchTemplateConfigs(params map[string]string) []EC2FleetLaunchTemplateConfig {
+	var configs []EC2FleetLaunchTemplateConfig
+	for n := 1; ; n++ {
+		prefix := fmt.Sprintf("LaunchTemplateConfigs.%d.", n)
+		spec := prefix + "LaunchTemplateSpecification."
+		ltID := params[spec+"LaunchTemplateId"]
+		ltName := params[spec+"LaunchTemplateName"]
+		version := params[spec+"Version"]
+
+		cfg := EC2FleetLaunchTemplateConfig{
+			LaunchTemplateID:   ltID,
+			LaunchTemplateName: ltName,
+			Version:            version,
+		}
+		for m := 1; ; m++ {
+			ovPrefix := fmt.Sprintf("%sOverrides.%d.", prefix, m)
+			ov, ok := parseFleetOverride(params, ovPrefix)
+			if !ok {
+				break
+			}
+			cfg.Overrides = append(cfg.Overrides, ov)
+		}
+		if ltID == "" && ltName == "" && len(cfg.Overrides) == 0 {
+			break
+		}
+		configs = append(configs, cfg)
+	}
+	return configs
+}
+
+// parseFleetOverride parses a single Overrides.M entry. The bool reports whether
+// any field was present, which terminates the caller's index scan.
+func parseFleetOverride(params map[string]string, prefix string) (EC2FleetOverride, bool) {
+	ov := EC2FleetOverride{
+		InstanceType:       params[prefix+"InstanceType"],
+		SubnetID:           params[prefix+"SubnetId"],
+		AvailabilityZone:   params[prefix+"AvailabilityZone"],
+		ImageID:            params[prefix+"ImageId"],
+		MaxPrice:           params[prefix+"MaxPrice"],
+		PlacementGroupName: params[prefix+"Placement.GroupName"],
+	}
+	priority, hasPriority := params[prefix+"Priority"]
+	if hasPriority {
+		ov.Priority, _ = strconv.ParseFloat(priority, 64)
+	}
+	weight, hasWeight := params[prefix+"WeightedCapacity"]
+	if hasWeight {
+		ov.WeightedCapacity, _ = strconv.ParseFloat(weight, 64)
+	}
+
+	present := ov.InstanceType != "" || ov.SubnetID != "" || ov.AvailabilityZone != "" ||
+		ov.ImageID != "" || ov.MaxPrice != "" || ov.PlacementGroupName != "" ||
+		hasPriority || hasWeight
+	return ov, present
+}
+
+// passthroughFleetTagSpecs extracts TagSpecification.N entries for resourceType
+// and re-emits them as RunInstances TagSpecification params, so launch-time tags
+// declared on a fleet land on its instances (callers find fleet instances with
+// DescribeInstances tag filters).
+func passthroughFleetTagSpecs(params map[string]string, resourceType string) map[string]string {
+	out := map[string]string{}
+	idx := 0
+	for n := 1; ; n++ {
+		rt, ok := params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
+		if !ok || rt == "" {
+			break
+		}
+		if rt != resourceType {
+			continue
+		}
+		idx++
+		for m := 1; ; m++ {
+			key, keyOK := params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", n, m)]
+			if !keyOK || key == "" {
+				break
+			}
+			out[fmt.Sprintf("TagSpecification.%d.ResourceType", idx)] = resourceType
+			out[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", idx, m)] = key
+			out[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", idx, m)] =
+				params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", n, m)]
+		}
+	}
+	return out
+}
+
+// fleetTagsFor collects TagSpecification.N tags for resourceType as EC2Tags.
+func fleetTagsFor(params map[string]string, resourceType string) []EC2Tag {
+	var tags []EC2Tag
+	for n := 1; ; n++ {
+		rt, ok := params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
+		if !ok || rt == "" {
+			break
+		}
+		if rt != resourceType {
+			continue
+		}
+		for m := 1; ; m++ {
+			key, keyOK := params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", n, m)]
+			if !keyOK || key == "" {
+				break
+			}
+			tags = append(tags, EC2Tag{
+				Key:   key,
+				Value: params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", n, m)],
+			})
+		}
+	}
+	return tags
+}
+
+// fleetDefaultErrorMessage returns the message AWS pairs with a fleet error code.
+func fleetDefaultErrorMessage(code string) string {
+	switch code {
+	case "InsufficientInstanceCapacity":
+		return "There is no Spot capacity available that matches your request."
+	case "InsufficientFreeAddressesInSubnet":
+		return "The specified subnet does not have enough free addresses to satisfy the request."
+	case "UnfulfillableCapacity":
+		return "Unable to fulfill capacity due to your request configuration."
+	default:
+		return "The fleet could not launch the requested capacity."
+	}
+}
+
+// fleetOverrideXML is the XML rendering of a launch template override.
+type fleetOverrideXML struct {
+	InstanceType     string  `xml:"instanceType,omitempty"`
+	SubnetID         string  `xml:"subnetId,omitempty"`
+	AvailabilityZone string  `xml:"availabilityZone,omitempty"`
+	ImageID          string  `xml:"imageId,omitempty"`
+	MaxPrice         string  `xml:"maxPrice,omitempty"`
+	Priority         float64 `xml:"priority,omitempty"`
+	WeightedCapacity float64 `xml:"weightedCapacity,omitempty"`
+	Placement        *struct {
+		GroupName string `xml:"groupName,omitempty"`
+	} `xml:"placement,omitempty"`
+}
+
+// fleetLTSpecXML is the XML rendering of a fleet launch template specification.
+type fleetLTSpecXML struct {
+	LaunchTemplateID   string `xml:"launchTemplateId,omitempty"`
+	LaunchTemplateName string `xml:"launchTemplateName,omitempty"`
+	Version            string `xml:"version,omitempty"`
+}
+
+// fleetLTAndOverridesXML is the XML rendering of LaunchTemplateAndOverridesResponse.
+type fleetLTAndOverridesXML struct {
+	LaunchTemplateSpecification fleetLTSpecXML   `xml:"launchTemplateSpecification"`
+	Overrides                   fleetOverrideXML `xml:"overrides"`
+}
+
+// fleetLTAndOverrides renders the launch template plus override for a pool.
+func fleetLTAndOverrides(ltID, ltName, version string, ov EC2FleetOverride) fleetLTAndOverridesXML {
+	out := fleetLTAndOverridesXML{
+		LaunchTemplateSpecification: fleetLTSpecXML{
+			LaunchTemplateID:   ltID,
+			LaunchTemplateName: ltName,
+			Version:            version,
+		},
+		Overrides: fleetOverrideXML{
+			InstanceType:     ov.InstanceType,
+			SubnetID:         ov.SubnetID,
+			AvailabilityZone: ov.AvailabilityZone,
+			ImageID:          ov.ImageID,
+			MaxPrice:         ov.MaxPrice,
+			Priority:         ov.Priority,
+			WeightedCapacity: ov.WeightedCapacity,
+		},
+	}
+	if ov.PlacementGroupName != "" {
+		out.Overrides.Placement = &struct {
+			GroupName string `xml:"groupName,omitempty"`
+		}{GroupName: ov.PlacementGroupName}
+	}
+	return out
+}
+
+// createFleetResponse renders the CreateFleet response. For non-instant fleets
+// AWS returns only the fleet ID: instances and errors are reported
+// asynchronously, so a caller that reads Instances from a "request"/"maintain"
+// fleet legitimately sees nothing.
+func (p *EC2Plugin) createFleetResponse(fleet *EC2Fleet) (*AWSResponse, error) {
+	type instanceItem struct {
+		LaunchTemplateAndOverrides fleetLTAndOverridesXML `xml:"launchTemplateAndOverrides"`
+		Lifecycle                  string                 `xml:"lifecycle,omitempty"`
+		InstanceIDs                []string               `xml:"instanceIds>item"`
+		InstanceType               string                 `xml:"instanceType,omitempty"`
+	}
+	type errorItem struct {
+		LaunchTemplateAndOverrides fleetLTAndOverridesXML `xml:"launchTemplateAndOverrides"`
+		Lifecycle                  string                 `xml:"lifecycle,omitempty"`
+		ErrorCode                  string                 `xml:"errorCode"`
+		ErrorMessage               string                 `xml:"errorMessage"`
+	}
+	type response struct {
+		XMLName   xml.Name       `xml:"CreateFleetResponse"`
+		XMLNS     string         `xml:"xmlns,attr"`
+		FleetID   string         `xml:"fleetId"`
+		Instances []instanceItem `xml:"fleetInstanceSet>item,omitempty"`
+		Errors    []errorItem    `xml:"errorSet>item,omitempty"`
+	}
+
+	resp := response{
+		XMLNS:   "http://ec2.amazonaws.com/doc/2016-11-15/",
+		FleetID: fleet.FleetID,
+	}
+	// fleetInstanceSet and errorSet are populated only for instant fleets.
+	if fleet.Type == "instant" {
+		for _, g := range fleet.Instances {
+			resp.Instances = append(resp.Instances, instanceItem{
+				LaunchTemplateAndOverrides: fleetLTAndOverrides(g.LaunchTemplateID, g.LaunchTemplateName, "", g.Override),
+				Lifecycle:                  g.Lifecycle,
+				InstanceIDs:                g.InstanceIDs,
+				InstanceType:               g.InstanceType,
+			})
+		}
+		for _, e := range fleet.Errors {
+			resp.Errors = append(resp.Errors, errorItem{
+				LaunchTemplateAndOverrides: fleetLTAndOverrides(e.LaunchTemplateID, e.LaunchTemplateName, "", e.Override),
+				Lifecycle:                  e.Lifecycle,
+				ErrorCode:                  e.ErrorCode,
+				ErrorMessage:               e.ErrorMessage,
+			})
+		}
+	}
+	return ec2XMLResponse(http.StatusOK, resp)
+}
+
+// describeFleets handles DescribeFleets. Mirroring AWS, an instant fleet appears
+// only when its ID is named explicitly.
+func (p *EC2Plugin) describeFleets(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	ids := extractIndexedParams(req.Params, "FleetId")
+	filters := extractEC2Filters(req.Params)
+
+	keys, err := p.state.List(goCtx, ec2Namespace, "fleet:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+	if err != nil {
+		return nil, fmt.Errorf("ec2 describeFleets: %w", err)
+	}
+
+	type targetCapacityXML struct {
+		TotalTargetCapacity       int    `xml:"totalTargetCapacity"`
+		OnDemandTargetCapacity    int    `xml:"onDemandTargetCapacity"`
+		SpotTargetCapacity        int    `xml:"spotTargetCapacity"`
+		DefaultTargetCapacityType string `xml:"defaultTargetCapacityType,omitempty"`
+	}
+	type tagItem struct {
+		Key   string `xml:"key"`
+		Value string `xml:"value"`
+	}
+	type fleetItem struct {
+		FleetID                     string             `xml:"fleetId"`
+		FleetState                  string             `xml:"fleetState"`
+		ActivityStatus              string             `xml:"activityStatus,omitempty"`
+		Type                        string             `xml:"type"`
+		CreateTime                  string             `xml:"createTime"`
+		FulfilledCapacity           int                `xml:"fulfilledCapacity"`
+		FulfilledOnDemandCapacity   int                `xml:"fulfilledOnDemandCapacity"`
+		TargetCapacitySpecification targetCapacityXML  `xml:"targetCapacitySpecification"`
+		ClientToken                 string             `xml:"clientToken,omitempty"`
+		Tags                        []tagItem          `xml:"tagSet>item,omitempty"`
+		Errors                      []fleetDescribeErr `xml:"errorSet>item,omitempty"`
+	}
+	type response struct {
+		XMLName xml.Name    `xml:"DescribeFleetsResponse"`
+		XMLNS   string      `xml:"xmlns,attr"`
+		Fleets  []fleetItem `xml:"fleetSet>item"`
+	}
+
+	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
+	for _, k := range keys {
+		data, getErr := p.state.Get(goCtx, ec2Namespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var fleet EC2Fleet
+		if json.Unmarshal(data, &fleet) != nil {
+			continue
+		}
+		if len(ids) > 0 && !containsStr(ids, fleet.FleetID) {
+			continue
+		}
+		// An instant fleet is only returned when named explicitly.
+		if len(ids) == 0 && fleet.Type == "instant" {
+			continue
+		}
+		if vals, ok := filters["fleet-state"]; ok && !containsStr(vals, fleet.FleetState) {
+			continue
+		}
+		if vals, ok := filters["type"]; ok && !containsStr(vals, fleet.Type) {
+			continue
+		}
+		if vals, ok := filters["activity-status"]; ok && !containsStr(vals, fleet.ActivityStatus) {
+			continue
+		}
+
+		item := fleetItem{
+			FleetID:           fleet.FleetID,
+			FleetState:        fleet.FleetState,
+			ActivityStatus:    fleet.ActivityStatus,
+			Type:              fleet.Type,
+			CreateTime:        fleet.CreateTime,
+			FulfilledCapacity: fleet.FulfilledCapacity,
+			ClientToken:       fleet.ClientToken,
+			TargetCapacitySpecification: targetCapacityXML{
+				TotalTargetCapacity:       fleet.TotalTargetCapacity,
+				OnDemandTargetCapacity:    fleet.OnDemandTargetCapacity,
+				SpotTargetCapacity:        fleet.SpotTargetCapacity,
+				DefaultTargetCapacityType: fleet.DefaultTargetCapacityType,
+			},
+		}
+		if fleet.DefaultTargetCapacityType != "spot" {
+			item.FulfilledOnDemandCapacity = fleet.FulfilledCapacity
+		}
+		for _, t := range fleet.Tags {
+			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck // XML tags differ from EC2Tag's JSON tags.
+		}
+		for _, e := range fleet.Errors {
+			item.Errors = append(item.Errors, fleetDescribeErr{
+				LaunchTemplateAndOverrides: fleetLTAndOverrides(e.LaunchTemplateID, e.LaunchTemplateName, "", e.Override),
+				Lifecycle:                  e.Lifecycle,
+				ErrorCode:                  e.ErrorCode,
+				ErrorMessage:               e.ErrorMessage,
+			})
+		}
+		resp.Fleets = append(resp.Fleets, item)
+	}
+	return ec2XMLResponse(http.StatusOK, resp)
+}
+
+// fleetDescribeErr is the errorSet item rendered by DescribeFleets.
+type fleetDescribeErr struct {
+	LaunchTemplateAndOverrides fleetLTAndOverridesXML `xml:"launchTemplateAndOverrides"`
+	Lifecycle                  string                 `xml:"lifecycle,omitempty"`
+	ErrorCode                  string                 `xml:"errorCode"`
+	ErrorMessage               string                 `xml:"errorMessage"`
+}
+
+// deleteFleets handles DeleteFleets. TerminateInstances is required by AWS; when
+// set (and always for instant fleets, which cannot outlive their instances) the
+// fleet's instances are terminated through the normal TerminateInstances path.
+func (p *EC2Plugin) deleteFleets(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	ids := extractIndexedParams(req.Params, "FleetId")
+	if len(ids) == 0 {
+		return nil, &AWSError{Code: "MissingParameter", Message: "FleetId is required", HTTPStatus: http.StatusBadRequest}
+	}
+	terminate := req.Params["TerminateInstances"] == "true"
+
+	type successItem struct {
+		CurrentFleetState  string `xml:"currentFleetState"`
+		PreviousFleetState string `xml:"previousFleetState"`
+		FleetID            string `xml:"fleetId"`
+	}
+	type errorItem struct {
+		FleetID string `xml:"fleetId"`
+		Error   struct {
+			Code    string `xml:"code"`
+			Message string `xml:"message"`
+		} `xml:"error"`
+	}
+	type response struct {
+		XMLName      xml.Name      `xml:"DeleteFleetsResponse"`
+		XMLNS        string        `xml:"xmlns,attr"`
+		Successful   []successItem `xml:"successfulFleetDeletionSet>item,omitempty"`
+		Unsuccessful []errorItem   `xml:"unsuccessfulFleetDeletionSet>item,omitempty"`
+	}
+	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
+
+	for _, id := range ids {
+		key := ec2FleetStateKey(reqCtx.AccountID, reqCtx.Region, id)
+		data, err := p.state.Get(goCtx, ec2Namespace, key)
+		if err != nil || data == nil {
+			item := errorItem{FleetID: id}
+			item.Error.Code = "fleetIdDoesNotExist"
+			item.Error.Message = "The fleet ID " + id + " does not exist"
+			resp.Unsuccessful = append(resp.Unsuccessful, item)
+			continue
+		}
+		var fleet EC2Fleet
+		if err := json.Unmarshal(data, &fleet); err != nil {
+			return nil, fmt.Errorf("ec2 deleteFleets unmarshal: %w", err)
+		}
+
+		previous := fleet.FleetState
+		// An instant fleet always terminates its instances on delete.
+		if terminate || fleet.Type == "instant" {
+			var all []string
+			for _, g := range fleet.Instances {
+				all = append(all, g.InstanceIDs...)
+			}
+			if len(all) > 0 {
+				params := map[string]string{"Action": "TerminateInstances"}
+				for i, iid := range all {
+					params[fmt.Sprintf("InstanceId.%d", i+1)] = iid
+				}
+				if _, err := p.terminateInstances(reqCtx, &AWSRequest{
+					Service:   "ec2",
+					Operation: "TerminateInstances",
+					Params:    params,
+					Headers:   map[string]string{},
+				}); err != nil {
+					return nil, err
+				}
+			}
+			fleet.FleetState = "deleted_terminating"
+		} else {
+			fleet.FleetState = "deleted_running"
+		}
+
+		updated, err := json.Marshal(fleet)
+		if err != nil {
+			return nil, fmt.Errorf("ec2 deleteFleets marshal: %w", err)
+		}
+		if err := p.state.Put(goCtx, ec2Namespace, key, updated); err != nil {
+			return nil, fmt.Errorf("ec2 deleteFleets state.Put: %w", err)
+		}
+		resp.Successful = append(resp.Successful, successItem{
+			CurrentFleetState:  fleet.FleetState,
+			PreviousFleetState: previous,
+			FleetID:            id,
+		})
+	}
+	return ec2XMLResponse(http.StatusOK, resp)
+}

--- a/emulator/ec2_fleet_control.go
+++ b/emulator/ec2_fleet_control.go
@@ -1,0 +1,139 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ec2FleetCtrlNamespace is the state namespace for EC2 Fleet control-plane
+// (seed) data.
+const ec2FleetCtrlNamespace = "ec2-fleet-ctrl"
+
+// ec2FleetShortfall is a seeded CreateFleet fulfillment outcome. Substrate never
+// runs a real capacity broker; a seed lets a test set how much of the requested
+// target capacity a fleet actually fulfills and which error the shortfall reports,
+// keyed by launch-template name/ID or the "*" wildcard.
+//
+// Partial fulfillment is the observation callers most often get wrong — an
+// instant fleet that asks for 12 and receives 8 still looks like a successful
+// call, and TotalTargetCapacity echoes the request, not the result. Seeding it
+// makes that path instant and reproducible (#387).
+type ec2FleetShortfall struct {
+	// LaunchTemplate is the launch-template name or ID the seed applies to, or
+	// "*" for any template.
+	LaunchTemplate string `json:"launchTemplate"`
+
+	// Fulfill is the number of instances the fleet actually launches. It is
+	// clamped to the requested TotalTargetCapacity. Zero means fulfill nothing,
+	// so the fleet returns only errors.
+	Fulfill int `json:"fulfill"`
+
+	// ErrorCode is the code reported for the unfulfilled capacity, e.g.
+	// "InsufficientInstanceCapacity" or "InsufficientFreeAddressesInSubnet".
+	// Defaults to "InsufficientInstanceCapacity" when empty.
+	ErrorCode string `json:"errorCode"`
+
+	// ErrorMessage is the human-readable message for the shortfall. A default
+	// derived from ErrorCode is used when empty.
+	ErrorMessage string `json:"errorMessage"`
+
+	// Lifecycle is the lifecycle reported for the unfulfilled capacity
+	// ("spot" or "on-demand"). Defaults to the fleet's default target capacity
+	// type when empty.
+	Lifecycle string `json:"lifecycle"`
+}
+
+// ec2FleetCtrlKey returns the state key for a seeded shortfall. Template-scoped
+// seeds use "shortfall:{template}"; the wildcard uses "shortfall:*".
+func ec2FleetCtrlKey(launchTemplate string) string {
+	if launchTemplate == "" {
+		launchTemplate = "*"
+	}
+	return "shortfall:" + launchTemplate
+}
+
+// resolveFleetShortfall returns the seeded shortfall for a fleet request, if any,
+// matching by exact launch-template ID, then name, then the "*" wildcard. It
+// returns (nil, nil) when no seed applies, so callers fall back to fulfilling the
+// full requested capacity.
+func (p *EC2Plugin) resolveFleetShortfall(ltID, ltName string) (*ec2FleetShortfall, error) {
+	goCtx := context.Background()
+	candidates := make([]string, 0, 3)
+	if ltID != "" {
+		candidates = append(candidates, ec2FleetCtrlKey(ltID))
+	}
+	if ltName != "" {
+		candidates = append(candidates, ec2FleetCtrlKey(ltName))
+	}
+	candidates = append(candidates, ec2FleetCtrlKey("*"))
+
+	for _, key := range candidates {
+		data, err := p.state.Get(goCtx, ec2FleetCtrlNamespace, key)
+		if err != nil {
+			return nil, fmt.Errorf("ec2 resolveFleetShortfall get: %w", err)
+		}
+		if data == nil {
+			continue
+		}
+		var seed ec2FleetShortfall
+		if err := json.Unmarshal(data, &seed); err != nil {
+			return nil, fmt.Errorf("ec2 resolveFleetShortfall unmarshal: %w", err)
+		}
+		return &seed, nil
+	}
+	return nil, nil //nolint:nilnil // (nil, nil) = "no seed applies", handled by caller.
+}
+
+// handleEC2SeedFleetShortfall handles POST /v1/ec2/fleet-shortfall. It seeds how
+// much of a CreateFleet request's target capacity is fulfilled and which error
+// the shortfall reports, for fleets matching the given launch template (default
+// "*"). Substrate does not model real capacity; this sets the observable result.
+// Body: {"launchTemplate","fulfill","errorCode","errorMessage","lifecycle"}.
+func (s *Server) handleEC2SeedFleetShortfall(w http.ResponseWriter, r *http.Request) {
+	var seed ec2FleetShortfall
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.Fulfill < 0 {
+		http.Error(w, `{"error":"fulfill must be >= 0"}`, http.StatusBadRequest)
+		return
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), ec2FleetCtrlNamespace, ec2FleetCtrlKey(seed.LaunchTemplate), data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true, "launchTemplate": ec2FleetCtrlKey(seed.LaunchTemplate)})
+}
+
+// handleEC2ClearFleetShortfall handles DELETE /v1/ec2/fleet-shortfall. With
+// ?launchTemplate=... it removes that seed; without it removes all.
+func (s *Server) handleEC2ClearFleetShortfall(w http.ResponseWriter, r *http.Request) {
+	if lt := r.URL.Query().Get("launchTemplate"); lt != "" {
+		if err := s.state.Delete(r.Context(), ec2FleetCtrlNamespace, ec2FleetCtrlKey(lt)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), ec2FleetCtrlNamespace, "shortfall:")
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), ec2FleetCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}

--- a/emulator/ec2_fleet_test.go
+++ b/emulator/ec2_fleet_test.go
@@ -1,0 +1,779 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fleetInstanceItem mirrors a CreateFleet fleetInstanceSet item. instanceIds is a
+// list per pool, which is the shape callers most often flatten incorrectly.
+type fleetInstanceItem struct {
+	InstanceIDs  []string `xml:"instanceIds>item"`
+	InstanceType string   `xml:"instanceType"`
+	Lifecycle    string   `xml:"lifecycle"`
+	LT           struct {
+		Spec struct {
+			LaunchTemplateID   string `xml:"launchTemplateId"`
+			LaunchTemplateName string `xml:"launchTemplateName"`
+		} `xml:"launchTemplateSpecification"`
+		Overrides struct {
+			InstanceType string `xml:"instanceType"`
+			SubnetID     string `xml:"subnetId"`
+			MaxPrice     string `xml:"maxPrice"`
+			Priority     string `xml:"priority"`
+		} `xml:"overrides"`
+	} `xml:"launchTemplateAndOverrides"`
+}
+
+// fleetErrorItem mirrors a CreateFleet errorSet item.
+type fleetErrorItem struct {
+	ErrorCode    string `xml:"errorCode"`
+	ErrorMessage string `xml:"errorMessage"`
+	Lifecycle    string `xml:"lifecycle"`
+	LT           struct {
+		Overrides struct {
+			InstanceType string `xml:"instanceType"`
+		} `xml:"overrides"`
+	} `xml:"launchTemplateAndOverrides"`
+}
+
+// createFleetResp mirrors the CreateFleet response.
+type createFleetResp struct {
+	FleetID   string              `xml:"fleetId"`
+	Instances []fleetInstanceItem `xml:"fleetInstanceSet>item"`
+	Errors    []fleetErrorItem    `xml:"errorSet>item"`
+}
+
+// describeFleetsResp mirrors the DescribeFleets response.
+type describeFleetsResp struct {
+	Fleets []struct {
+		FleetID           string `xml:"fleetId"`
+		FleetState        string `xml:"fleetState"`
+		ActivityStatus    string `xml:"activityStatus"`
+		Type              string `xml:"type"`
+		FulfilledCapacity int    `xml:"fulfilledCapacity"`
+		TargetCapacity    struct {
+			TotalTargetCapacity       int    `xml:"totalTargetCapacity"`
+			DefaultTargetCapacityType string `xml:"defaultTargetCapacityType"`
+		} `xml:"targetCapacitySpecification"`
+		Tags []struct {
+			Key   string `xml:"key"`
+			Value string `xml:"value"`
+		} `xml:"tagSet>item"`
+		Errors []fleetErrorItem `xml:"errorSet>item"`
+	} `xml:"fleetSet>item"`
+}
+
+// ec2FleetXML sends an EC2 request and unmarshals the XML body into v, failing
+// the test on a non-200 status.
+func ec2FleetXML(t *testing.T, ts *httptest.Server, params map[string]string, v any) {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, body)
+	}
+	if v != nil {
+		if err := xml.Unmarshal(body, v); err != nil {
+			t.Fatalf("unmarshal %s: %v", body, err)
+		}
+	}
+}
+
+// newFleetLaunchTemplate creates a launch template and returns its ID.
+func newFleetLaunchTemplate(t *testing.T, ts *httptest.Server, name string) string {
+	t.Helper()
+	var lt struct {
+		LaunchTemplateID string `xml:"launchTemplate>launchTemplateId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":                          "CreateLaunchTemplate",
+		"LaunchTemplateName":              name,
+		"LaunchTemplateData.ImageId":      "ami-0fleet0000000001",
+		"LaunchTemplateData.InstanceType": "t3.micro",
+	}, &lt)
+	if lt.LaunchTemplateID == "" {
+		t.Fatal("CreateLaunchTemplate returned no launchTemplateId")
+	}
+	return lt.LaunchTemplateID
+}
+
+func TestEC2_CreateFleet_InstantFullFulfillment(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-full")
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.Version":          "1",
+		"LaunchTemplateConfigs.1.Overrides.1.InstanceType":                     "c5.large",
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "3",
+		"TargetCapacitySpecification.DefaultTargetCapacityType":                "on-demand",
+	}, &got)
+
+	if !strings.HasPrefix(got.FleetID, "fleet-") {
+		t.Errorf("fleetId = %q, want fleet- prefix", got.FleetID)
+	}
+	if len(got.Instances) != 1 {
+		t.Fatalf("fleetInstanceSet items = %d, want 1", len(got.Instances))
+	}
+	inst := got.Instances[0]
+	if len(inst.InstanceIDs) != 3 {
+		t.Errorf("instanceIds = %v, want 3 entries", inst.InstanceIDs)
+	}
+	if inst.InstanceType != "c5.large" {
+		t.Errorf("instanceType = %q, want c5.large", inst.InstanceType)
+	}
+	if inst.Lifecycle != "on-demand" {
+		t.Errorf("lifecycle = %q, want on-demand", inst.Lifecycle)
+	}
+	if inst.LT.Spec.LaunchTemplateID != ltID {
+		t.Errorf("launchTemplateId = %q, want %q", inst.LT.Spec.LaunchTemplateID, ltID)
+	}
+	if inst.LT.Overrides.InstanceType != "c5.large" {
+		t.Errorf("overrides.instanceType = %q, want c5.large", inst.LT.Overrides.InstanceType)
+	}
+	if len(got.Errors) != 0 {
+		t.Errorf("errorSet = %+v, want empty on full fulfillment", got.Errors)
+	}
+
+	// The launched instances must be visible to DescribeInstances, which is the
+	// whole point of routing through runInstances.
+	var desc struct {
+		Instances []struct {
+			InstanceID   string `xml:"instanceId"`
+			InstanceType string `xml:"instanceType"`
+			State        string `xml:"instanceState>name"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeInstances"}, &desc)
+	seen := map[string]bool{}
+	for _, d := range desc.Instances {
+		seen[d.InstanceID] = true
+		if d.InstanceType != "c5.large" {
+			t.Errorf("DescribeInstances instanceType = %q, want c5.large", d.InstanceType)
+		}
+		if d.State != "running" {
+			t.Errorf("DescribeInstances state = %q, want running", d.State)
+		}
+	}
+	for _, id := range inst.InstanceIDs {
+		if !seen[id] {
+			t.Errorf("fleet instance %s not visible to DescribeInstances", id)
+		}
+	}
+}
+
+func TestEC2_CreateFleet_SeededPartialFulfillment(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-partial")
+
+	seedFleetShortfall(t, ts, `{
+		"launchTemplate": "`+ltID+`",
+		"fulfill": 8,
+		"errorCode": "InsufficientInstanceCapacity",
+		"errorMessage": "no capacity",
+		"lifecycle": "spot"
+	}`)
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"LaunchTemplateConfigs.1.Overrides.1.InstanceType":                     "c5.large",
+		"LaunchTemplateConfigs.1.Overrides.2.InstanceType":                     "c5.xlarge",
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "12",
+		"TargetCapacitySpecification.DefaultTargetCapacityType":                "on-demand",
+	}, &got)
+
+	// 8 of 12 fulfilled, 4 short: round-robin gives each pool 6 wanted / 4 got.
+	total := 0
+	for _, g := range got.Instances {
+		total += len(g.InstanceIDs)
+	}
+	if total != 8 {
+		t.Errorf("fulfilled instances = %d, want 8", total)
+	}
+	if len(got.Instances) != 2 {
+		t.Fatalf("fleetInstanceSet items = %d, want 2 (one per pool)", len(got.Instances))
+	}
+	if len(got.Errors) != 2 {
+		t.Fatalf("errorSet items = %d, want 2 (both pools short)", len(got.Errors))
+	}
+	for _, e := range got.Errors {
+		if e.ErrorCode != "InsufficientInstanceCapacity" {
+			t.Errorf("errorCode = %q, want InsufficientInstanceCapacity", e.ErrorCode)
+		}
+		if e.ErrorMessage != "no capacity" {
+			t.Errorf("errorMessage = %q, want seeded message", e.ErrorMessage)
+		}
+		if e.Lifecycle != "spot" {
+			t.Errorf("lifecycle = %q, want seeded spot", e.Lifecycle)
+		}
+	}
+
+	// The fleet must report the request in TotalTargetCapacity and the result in
+	// FulfilledCapacity — conflating the two is the caller bug this models.
+	var desc describeFleetsResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":    "DescribeFleets",
+		"FleetId.1": got.FleetID,
+	}, &desc)
+	if len(desc.Fleets) != 1 {
+		t.Fatalf("fleetSet items = %d, want 1", len(desc.Fleets))
+	}
+	f := desc.Fleets[0]
+	if f.TargetCapacity.TotalTargetCapacity != 12 {
+		t.Errorf("totalTargetCapacity = %d, want 12 (the request)", f.TargetCapacity.TotalTargetCapacity)
+	}
+	if f.FulfilledCapacity != 8 {
+		t.Errorf("fulfilledCapacity = %d, want 8 (the result)", f.FulfilledCapacity)
+	}
+	if f.ActivityStatus != "fulfilled" {
+		t.Errorf("activityStatus = %q, want fulfilled (instant fleets report fulfilled even when short)", f.ActivityStatus)
+	}
+	if len(f.Errors) != 2 {
+		t.Errorf("DescribeFleets errorSet items = %d, want 2", len(f.Errors))
+	}
+}
+
+func TestEC2_CreateFleet_SeededZeroFulfillment(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-zero")
+
+	// Wildcard seed with an alternate error code.
+	seedFleetShortfall(t, ts, `{"fulfill": 0, "errorCode": "InsufficientFreeAddressesInSubnet"}`)
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+	}, &got)
+
+	if len(got.Instances) != 0 {
+		t.Errorf("fleetInstanceSet = %+v, want empty when nothing is fulfilled", got.Instances)
+	}
+	if len(got.Errors) != 1 {
+		t.Fatalf("errorSet items = %d, want 1", len(got.Errors))
+	}
+	if got.Errors[0].ErrorCode != "InsufficientFreeAddressesInSubnet" {
+		t.Errorf("errorCode = %q, want InsufficientFreeAddressesInSubnet", got.Errors[0].ErrorCode)
+	}
+	if got.Errors[0].ErrorMessage == "" {
+		t.Error("errorMessage is empty; a default should be derived from the code")
+	}
+	// A zero-fulfillment fleet still returns a fleet ID, so a caller that only
+	// checks for an error sees success.
+	if got.FleetID == "" {
+		t.Error("fleetId is empty; CreateFleet succeeds even when it launches nothing")
+	}
+
+	// Clearing the seed restores full fulfillment.
+	clearFleetShortfall(t, ts, "")
+	var after createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+	}, &after)
+	if len(after.Instances) != 1 || len(after.Instances[0].InstanceIDs) != 2 {
+		t.Errorf("after clearing seed, instances = %+v, want one pool of 2", after.Instances)
+	}
+	if len(after.Errors) != 0 {
+		t.Errorf("after clearing seed, errorSet = %+v, want empty", after.Errors)
+	}
+}
+
+func TestEC2_CreateFleet_NonInstantDefersInstances(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-maintain")
+
+	for _, fleetType := range []string{"request", "maintain"} {
+		t.Run(fleetType, func(t *testing.T) {
+			var got createFleetResp
+			ec2FleetXML(t, ts, map[string]string{
+				"Action": "CreateFleet",
+				"Type":   fleetType,
+				"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+				"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+			}, &got)
+
+			if got.FleetID == "" {
+				t.Fatal("fleetId is empty")
+			}
+			// AWS reports instances asynchronously for request/maintain fleets, so
+			// a caller reading Instances here legitimately sees nothing.
+			if len(got.Instances) != 0 {
+				t.Errorf("fleetInstanceSet = %+v, want empty for a %s fleet", got.Instances, fleetType)
+			}
+			if len(got.Errors) != 0 {
+				t.Errorf("errorSet = %+v, want empty for a %s fleet", got.Errors, fleetType)
+			}
+
+			// The fleet is still discoverable, and its capacity was launched.
+			var desc describeFleetsResp
+			ec2FleetXML(t, ts, map[string]string{"Action": "DescribeFleets", "FleetId.1": got.FleetID}, &desc)
+			if len(desc.Fleets) != 1 {
+				t.Fatalf("fleetSet items = %d, want 1", len(desc.Fleets))
+			}
+			if desc.Fleets[0].Type != fleetType {
+				t.Errorf("type = %q, want %q", desc.Fleets[0].Type, fleetType)
+			}
+			if desc.Fleets[0].FulfilledCapacity != 2 {
+				t.Errorf("fulfilledCapacity = %d, want 2", desc.Fleets[0].FulfilledCapacity)
+			}
+		})
+	}
+}
+
+func TestEC2_CreateFleet_PrioritizedPoolOrdering(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-prioritized")
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":                             "CreateFleet",
+		"Type":                               "instant",
+		"OnDemandOptions.AllocationStrategy": "prioritized",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"LaunchTemplateConfigs.1.Overrides.1.InstanceType":                     "c5.large",
+		"LaunchTemplateConfigs.1.Overrides.1.Priority":                         "2",
+		"LaunchTemplateConfigs.1.Overrides.2.InstanceType":                     "m5.large",
+		"LaunchTemplateConfigs.1.Overrides.2.Priority":                         "1",
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "3",
+	}, &got)
+
+	if len(got.Instances) != 2 {
+		t.Fatalf("fleetInstanceSet items = %d, want 2", len(got.Instances))
+	}
+	// Priority 1 is highest, so m5.large sorts first and takes the remainder.
+	if got.Instances[0].InstanceType != "m5.large" {
+		t.Errorf("first pool instanceType = %q, want m5.large (priority 1)", got.Instances[0].InstanceType)
+	}
+	if len(got.Instances[0].InstanceIDs) != 2 {
+		t.Errorf("highest-priority pool got %d instances, want 2", len(got.Instances[0].InstanceIDs))
+	}
+	if len(got.Instances[1].InstanceIDs) != 1 {
+		t.Errorf("second pool got %d instances, want 1", len(got.Instances[1].InstanceIDs))
+	}
+}
+
+func TestEC2_CreateFleet_SpotLifecycleFromMaxPrice(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-spot")
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"LaunchTemplateConfigs.1.Overrides.1.InstanceType":                     "c5.large",
+		"LaunchTemplateConfigs.1.Overrides.1.MaxPrice":                         "0.05",
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+		"TargetCapacitySpecification.SpotTargetCapacity":                       "1",
+		"TargetCapacitySpecification.DefaultTargetCapacityType":                "spot",
+	}, &got)
+
+	if len(got.Instances) != 1 {
+		t.Fatalf("fleetInstanceSet items = %d, want 1", len(got.Instances))
+	}
+	if got.Instances[0].Lifecycle != "spot" {
+		t.Errorf("lifecycle = %q, want spot", got.Instances[0].Lifecycle)
+	}
+	if got.Instances[0].LT.Overrides.MaxPrice != "0.05" {
+		t.Errorf("overrides.maxPrice = %q, want 0.05", got.Instances[0].LT.Overrides.MaxPrice)
+	}
+}
+
+func TestEC2_CreateFleet_TagPropagation(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-tags")
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+		"TagSpecification.1.ResourceType":                                      "fleet",
+		"TagSpecification.1.Tag.1.Key":                                         "Owner",
+		"TagSpecification.1.Tag.1.Value":                                       "research",
+		"TagSpecification.2.ResourceType":                                      "instance",
+		"TagSpecification.2.Tag.1.Key":                                         "Name",
+		"TagSpecification.2.Tag.1.Value":                                       "worker",
+	}, &got)
+
+	// Instance tags must land on the launched instances.
+	var desc struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+			Tags       []struct {
+				Key   string `xml:"key"`
+				Value string `xml:"value"`
+			} `xml:"tagSet>item"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeInstances"}, &desc)
+	if len(desc.Instances) != 1 {
+		t.Fatalf("DescribeInstances returned %d instances, want 1", len(desc.Instances))
+	}
+	found := false
+	for _, tag := range desc.Instances[0].Tags {
+		if tag.Key == "Name" && tag.Value == "worker" {
+			found = true
+		}
+		if tag.Key == "Owner" {
+			t.Error("fleet-scoped tag leaked onto the instance")
+		}
+	}
+	if !found {
+		t.Errorf("instance tags = %+v, want Name=worker propagated from the fleet", desc.Instances[0].Tags)
+	}
+
+	// Fleet tags must land on the fleet.
+	var fleets describeFleetsResp
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeFleets", "FleetId.1": got.FleetID}, &fleets)
+	if len(fleets.Fleets) != 1 {
+		t.Fatalf("fleetSet items = %d, want 1", len(fleets.Fleets))
+	}
+	if len(fleets.Fleets[0].Tags) != 1 || fleets.Fleets[0].Tags[0].Key != "Owner" {
+		t.Errorf("fleet tags = %+v, want only Owner=research", fleets.Fleets[0].Tags)
+	}
+}
+
+func TestEC2_CreateFleet_Errors(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-errors")
+
+	tests := []struct {
+		name     string
+		params   map[string]string
+		wantCode string
+	}{
+		{
+			name: "missing target capacity",
+			params: map[string]string{
+				"Action": "CreateFleet",
+				"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+			},
+			wantCode: "MissingParameter",
+		},
+		{
+			name: "missing launch template configs",
+			params: map[string]string{
+				"Action": "CreateFleet",
+				"TargetCapacitySpecification.TotalTargetCapacity": "1",
+			},
+			wantCode: "MissingParameter",
+		},
+		{
+			name: "unknown launch template id",
+			params: map[string]string{
+				"Action": "CreateFleet",
+				"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": "lt-doesnotexist",
+				"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+			},
+			wantCode: "InvalidLaunchTemplateId.NotFound",
+		},
+		{
+			name: "unknown launch template name",
+			params: map[string]string{
+				"Action": "CreateFleet",
+				"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateName": "nope",
+				"TargetCapacitySpecification.TotalTargetCapacity":                        "1",
+			},
+			wantCode: "InvalidLaunchTemplateName.NotFoundException",
+		},
+		{
+			name: "invalid fleet type",
+			params: map[string]string{
+				"Action": "CreateFleet",
+				"Type":   "bogus",
+				"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+				"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+			},
+			wantCode: "InvalidParameterValue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := ec2Request(t, ts, tt.params)
+			defer func() { _ = resp.Body.Close() }()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400; body = %s", resp.StatusCode, body)
+			}
+			if !strings.Contains(string(body), tt.wantCode) {
+				t.Errorf("body = %s, want error code %s", body, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestEC2_DescribeFleets_InstantRequiresExplicitID(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-visibility")
+
+	var instant createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+	}, &instant)
+
+	var maintain createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "maintain",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+	}, &maintain)
+
+	// Unfiltered DescribeFleets omits instant fleets, matching AWS.
+	var all describeFleetsResp
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeFleets"}, &all)
+	ids := map[string]bool{}
+	for _, f := range all.Fleets {
+		ids[f.FleetID] = true
+	}
+	if ids[instant.FleetID] {
+		t.Error("unfiltered DescribeFleets returned an instant fleet; AWS requires an explicit fleet ID")
+	}
+	if !ids[maintain.FleetID] {
+		t.Error("unfiltered DescribeFleets omitted the maintain fleet")
+	}
+
+	// Naming the instant fleet returns it.
+	var named describeFleetsResp
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeFleets", "FleetId.1": instant.FleetID}, &named)
+	if len(named.Fleets) != 1 || named.Fleets[0].FleetID != instant.FleetID {
+		t.Errorf("DescribeFleets with explicit id returned %+v, want the instant fleet", named.Fleets)
+	}
+
+	// Filters apply.
+	var filtered describeFleetsResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "DescribeFleets",
+		"Filter.1.Name":    "type",
+		"Filter.1.Value.1": "maintain",
+	}, &filtered)
+	if len(filtered.Fleets) != 1 || filtered.Fleets[0].Type != "maintain" {
+		t.Errorf("type filter returned %+v, want only the maintain fleet", filtered.Fleets)
+	}
+
+	var noMatch describeFleetsResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "DescribeFleets",
+		"Filter.1.Name":    "fleet-state",
+		"Filter.1.Value.1": "deleted",
+	}, &noMatch)
+	if len(noMatch.Fleets) != 0 {
+		t.Errorf("fleet-state=deleted returned %+v, want none", noMatch.Fleets)
+	}
+}
+
+func TestEC2_DeleteFleets(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-delete")
+
+	var fleet createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "maintain",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+	}, &fleet)
+
+	var del struct {
+		Successful []struct {
+			FleetID            string `xml:"fleetId"`
+			CurrentFleetState  string `xml:"currentFleetState"`
+			PreviousFleetState string `xml:"previousFleetState"`
+		} `xml:"successfulFleetDeletionSet>item"`
+		Unsuccessful []struct {
+			FleetID string `xml:"fleetId"`
+			Code    string `xml:"error>code"`
+		} `xml:"unsuccessfulFleetDeletionSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":             "DeleteFleets",
+		"FleetId.1":          fleet.FleetID,
+		"FleetId.2":          "fleet-missing",
+		"TerminateInstances": "true",
+	}, &del)
+
+	if len(del.Successful) != 1 || del.Successful[0].FleetID != fleet.FleetID {
+		t.Fatalf("successfulFleetDeletionSet = %+v, want the created fleet", del.Successful)
+	}
+	if del.Successful[0].PreviousFleetState != "active" {
+		t.Errorf("previousFleetState = %q, want active", del.Successful[0].PreviousFleetState)
+	}
+	if del.Successful[0].CurrentFleetState != "deleted_terminating" {
+		t.Errorf("currentFleetState = %q, want deleted_terminating", del.Successful[0].CurrentFleetState)
+	}
+	if len(del.Unsuccessful) != 1 || del.Unsuccessful[0].Code != "fleetIdDoesNotExist" {
+		t.Errorf("unsuccessfulFleetDeletionSet = %+v, want fleetIdDoesNotExist", del.Unsuccessful)
+	}
+
+	// TerminateInstances=true must actually terminate the fleet's instances.
+	var desc struct {
+		Instances []struct {
+			State string `xml:"instanceState>name"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeInstances"}, &desc)
+	for i, d := range desc.Instances {
+		if d.State != "terminated" && d.State != "shutting-down" {
+			t.Errorf("instance %d state = %q, want terminated after DeleteFleets", i, d.State)
+		}
+	}
+
+	// The fleet's recorded state reflects the deletion.
+	var after describeFleetsResp
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeFleets", "FleetId.1": fleet.FleetID}, &after)
+	if len(after.Fleets) != 1 || after.Fleets[0].FleetState != "deleted_terminating" {
+		t.Errorf("DescribeFleets after delete = %+v, want fleetState deleted_terminating", after.Fleets)
+	}
+}
+
+func TestEC2_DeleteFleets_WithoutTerminate(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-keep-instances")
+
+	var fleet createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "maintain",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+	}, &fleet)
+
+	var del struct {
+		Successful []struct {
+			CurrentFleetState string `xml:"currentFleetState"`
+		} `xml:"successfulFleetDeletionSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":             "DeleteFleets",
+		"FleetId.1":          fleet.FleetID,
+		"TerminateInstances": "false",
+	}, &del)
+
+	if len(del.Successful) != 1 || del.Successful[0].CurrentFleetState != "deleted_running" {
+		t.Fatalf("successfulFleetDeletionSet = %+v, want deleted_running", del.Successful)
+	}
+
+	// Instances outlive the fleet when TerminateInstances is false.
+	var desc struct {
+		Instances []struct {
+			State string `xml:"instanceState>name"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeInstances"}, &desc)
+	if len(desc.Instances) != 1 || desc.Instances[0].State != "running" {
+		t.Errorf("instances = %+v, want one still running", desc.Instances)
+	}
+}
+
+func TestEC2_DeleteFleets_MissingFleetID(t *testing.T) {
+	ts := newEC2TestServer(t)
+	resp := ec2Request(t, ts, map[string]string{"Action": "DeleteFleets"})
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "MissingParameter") {
+		t.Errorf("body = %s, want MissingParameter", body)
+	}
+}
+
+// seedFleetShortfall POSTs a fleet shortfall seed to the control plane.
+func seedFleetShortfall(t *testing.T, ts *httptest.Server, body string) {
+	t.Helper()
+	resp, err := http.Post(ts.URL+"/v1/ec2/fleet-shortfall", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("seed fleet shortfall: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		got, _ := io.ReadAll(resp.Body)
+		t.Fatalf("seed fleet shortfall status = %d: %s", resp.StatusCode, got)
+	}
+}
+
+// clearFleetShortfall DELETEs a fleet shortfall seed; an empty launchTemplate
+// clears all seeds.
+func clearFleetShortfall(t *testing.T, ts *httptest.Server, launchTemplate string) {
+	t.Helper()
+	u := ts.URL + "/v1/ec2/fleet-shortfall"
+	if launchTemplate != "" {
+		u += "?launchTemplate=" + launchTemplate
+	}
+	req, err := http.NewRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		t.Fatalf("build clear request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("clear fleet shortfall: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		got, _ := io.ReadAll(resp.Body)
+		t.Fatalf("clear fleet shortfall status = %d: %s", resp.StatusCode, got)
+	}
+}
+
+func TestEC2_SeedFleetShortfall_Validation(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{name: "valid", body: `{"fulfill":1}`, wantStatus: http.StatusOK},
+		{name: "negative fulfill", body: `{"fulfill":-1}`, wantStatus: http.StatusBadRequest},
+		{name: "malformed json", body: `{`, wantStatus: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := http.Post(ts.URL+"/v1/ec2/fleet-shortfall", "application/json", strings.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+		})
+	}
+
+	// Template-scoped clear leaves the wildcard seed alone.
+	seedFleetShortfall(t, ts, `{"launchTemplate":"lt-scoped","fulfill":0}`)
+	clearFleetShortfall(t, ts, "lt-scoped")
+	clearFleetShortfall(t, ts, "")
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -200,6 +200,13 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.describeLaunchTemplates(ctx, req)
 	case "DeleteLaunchTemplate":
 		return p.deleteLaunchTemplate(ctx, req)
+	// EC2 Fleet operations
+	case "CreateFleet":
+		return p.createFleet(ctx, req)
+	case "DescribeFleets":
+		return p.describeFleets(ctx, req)
+	case "DeleteFleets":
+		return p.deleteFleets(ctx, req)
 	// EBS volume operations
 	case "CreateVolume":
 		return p.createVolume(ctx, req)
@@ -1179,11 +1186,18 @@ func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSReque
 	type ipRangeItem struct {
 		CidrIP string `xml:"cidrIp"` //nolint:revive
 	}
+	type groupPairItem struct {
+		UserID      string `xml:"userId,omitempty"`
+		GroupID     string `xml:"groupId,omitempty"`
+		GroupName   string `xml:"groupName,omitempty"`
+		Description string `xml:"description,omitempty"`
+	}
 	type permItem struct {
-		IPProtocol string        `xml:"ipProtocol"` //nolint:revive
-		FromPort   int           `xml:"fromPort"`
-		ToPort     int           `xml:"toPort"`
-		IPRanges   []ipRangeItem `xml:"ipRanges>item"` //nolint:revive
+		IPProtocol string          `xml:"ipProtocol"` //nolint:revive
+		FromPort   int             `xml:"fromPort"`
+		ToPort     int             `xml:"toPort"`
+		IPRanges   []ipRangeItem   `xml:"ipRanges>item"` //nolint:revive
+		Groups     []groupPairItem `xml:"groups>item,omitempty"`
 	}
 	type sgItem struct {
 		GroupID        string     `xml:"groupId"`
@@ -1220,20 +1234,27 @@ func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSReque
 		if vals, ok := filters["group-id"]; ok && len(vals) > 0 && !containsStr(vals, sg.GroupID) {
 			continue
 		}
+		renderPerm := func(rule EC2IPPermission) permItem {
+			pi := permItem{IPProtocol: rule.IPProtocol, FromPort: rule.FromPort, ToPort: rule.ToPort}
+			for _, cidr := range rule.IPRanges {
+				pi.IPRanges = append(pi.IPRanges, ipRangeItem{CidrIP: cidr})
+			}
+			for _, pair := range rule.UserIDGroupPairs {
+				pi.Groups = append(pi.Groups, groupPairItem{
+					UserID:      pair.UserID,
+					GroupID:     pair.GroupID,
+					GroupName:   pair.GroupName,
+					Description: pair.Description,
+				})
+			}
+			return pi
+		}
 		item := sgItem{GroupID: sg.GroupID, GroupName: sg.GroupName, Description: sg.Description, VpcID: sg.VPCID}
 		for _, rule := range sg.IngressRules {
-			pi := permItem{IPProtocol: rule.IPProtocol, FromPort: rule.FromPort, ToPort: rule.ToPort}
-			for _, cidr := range rule.IPRanges {
-				pi.IPRanges = append(pi.IPRanges, ipRangeItem{CidrIP: cidr})
-			}
-			item.IPPermissions = append(item.IPPermissions, pi)
+			item.IPPermissions = append(item.IPPermissions, renderPerm(rule))
 		}
 		for _, rule := range sg.EgressRules {
-			pi := permItem{IPProtocol: rule.IPProtocol, FromPort: rule.FromPort, ToPort: rule.ToPort}
-			for _, cidr := range rule.IPRanges {
-				pi.IPRanges = append(pi.IPRanges, ipRangeItem{CidrIP: cidr})
-			}
-			item.IPPermissionsE = append(item.IPPermissionsE, pi)
+			item.IPPermissionsE = append(item.IPPermissionsE, renderPerm(rule))
 		}
 		resp.Groups = append(resp.Groups, item)
 	}
@@ -1295,44 +1316,28 @@ func (p *EC2Plugin) modifySGRules(reqCtx *RequestContext, req *AWSRequest, direc
 		return nil, fmt.Errorf("ec2 modifySGRules unmarshal: %w", unmarshalErr)
 	}
 
-	// Parse permission from params (simplified: IpPermissions.1.*)
-	proto := req.Params["IpPermissions.1.IpProtocol"]
-	if proto == "" {
-		proto = req.Params["IpProtocol"]
-	}
-	fromPort, _ := strconv.Atoi(req.Params["IpPermissions.1.FromPort"])
-	if fromPort == 0 {
-		fromPort, _ = strconv.Atoi(req.Params["FromPort"])
-	}
-	toPort, _ := strconv.Atoi(req.Params["IpPermissions.1.ToPort"])
-	if toPort == 0 {
-		toPort, _ = strconv.Atoi(req.Params["ToPort"])
-	}
-	cidrRange := req.Params["IpPermissions.1.IpRanges.1.CidrIp"]
-	if cidrRange == "" {
-		cidrRange = req.Params["CidrIp"]
-	}
-
-	perm := EC2IPPermission{
-		IPProtocol: proto,
-		FromPort:   fromPort,
-		ToPort:     toPort,
-	}
-	if cidrRange != "" {
-		perm.IPRanges = []string{cidrRange}
-	}
-
-	if direction == "ingress" {
-		if add {
-			sg.IngressRules = append(sg.IngressRules, perm)
-		} else {
-			sg.IngressRules = removePerm(sg.IngressRules, perm)
+	perms := parseSGPermissions(req.Params, reqCtx.AccountID)
+	if len(perms) == 0 {
+		return nil, &AWSError{
+			Code:       "MissingParameter",
+			Message:    "No permissions specified",
+			HTTPStatus: http.StatusBadRequest,
 		}
-	} else {
-		if add {
-			sg.EgressRules = append(sg.EgressRules, perm)
+	}
+
+	for _, perm := range perms {
+		if direction == "ingress" {
+			if add {
+				sg.IngressRules = append(sg.IngressRules, perm)
+			} else {
+				sg.IngressRules = removePerm(sg.IngressRules, perm)
+			}
 		} else {
-			sg.EgressRules = removePerm(sg.EgressRules, perm)
+			if add {
+				sg.EgressRules = append(sg.EgressRules, perm)
+			} else {
+				sg.EgressRules = removePerm(sg.EgressRules, perm)
+			}
 		}
 	}
 
@@ -2559,13 +2564,130 @@ func filterEmpty(slice []string) []string {
 }
 
 // removePerm removes the first matching permission from the slice.
+// removePerm removes the first permission matching target's protocol, port
+// range, and source. The source must match too: a CIDR rule and a
+// source-security-group rule on the same port are distinct rules, so revoking
+// one must not remove the other.
 func removePerm(perms []EC2IPPermission, target EC2IPPermission) []EC2IPPermission {
 	for i, p := range perms {
-		if p.IPProtocol == target.IPProtocol && p.FromPort == target.FromPort && p.ToPort == target.ToPort {
-			return append(perms[:i], perms[i+1:]...)
+		if p.IPProtocol != target.IPProtocol || p.FromPort != target.FromPort || p.ToPort != target.ToPort {
+			continue
 		}
+		if !sgSourcesMatch(p, target) {
+			continue
+		}
+		return append(perms[:i], perms[i+1:]...)
 	}
 	return perms
+}
+
+// sgSourcesMatch reports whether two permissions have the same source, comparing
+// CIDR ranges and referenced security groups. A target that names no source at
+// all matches any source, preserving the pre-existing revoke-by-ports behavior.
+func sgSourcesMatch(a, target EC2IPPermission) bool {
+	if len(target.IPRanges) == 0 && len(target.UserIDGroupPairs) == 0 {
+		return true
+	}
+	for _, cidr := range target.IPRanges {
+		if containsStr(a.IPRanges, cidr) {
+			return true
+		}
+	}
+	for _, pair := range target.UserIDGroupPairs {
+		for _, existing := range a.UserIDGroupPairs {
+			if pair.GroupID != "" && existing.GroupID == pair.GroupID {
+				return true
+			}
+			if pair.GroupID == "" && pair.GroupName != "" && existing.GroupName == pair.GroupName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parseSGPermissions parses security-group rules from the EC2 query protocol,
+// handling both the flattened IpPermissions.N form and the legacy top-level
+// IpProtocol/FromPort/ToPort/CidrIp/SourceSecurityGroupName form.
+//
+// Each permission may carry several IpRanges.M and Groups.M entries. The Groups
+// entries are what make a source-security-group rule — including a
+// self-referencing rule, where a group allows traffic from itself — expressible;
+// such a rule has no CIDR at all (#388).
+func parseSGPermissions(params map[string]string, accountID string) []EC2IPPermission {
+	var perms []EC2IPPermission
+	for n := 1; ; n++ {
+		prefix := fmt.Sprintf("IpPermissions.%d.", n)
+		perm, ok := parseSGPermission(params, prefix, accountID)
+		if !ok {
+			break
+		}
+		perms = append(perms, perm)
+	}
+	if len(perms) > 0 {
+		return perms
+	}
+
+	// Legacy top-level form.
+	perm := EC2IPPermission{IPProtocol: params["IpProtocol"]}
+	perm.FromPort, _ = strconv.Atoi(params["FromPort"])
+	perm.ToPort, _ = strconv.Atoi(params["ToPort"])
+	if cidr := params["CidrIp"]; cidr != "" {
+		perm.IPRanges = []string{cidr}
+	}
+	if name := params["SourceSecurityGroupName"]; name != "" {
+		perm.UserIDGroupPairs = append(perm.UserIDGroupPairs, EC2UserIDGroupPair{
+			GroupName: name,
+			UserID:    sgOwnerOrDefault(params["SourceSecurityGroupOwnerId"], accountID),
+		})
+	}
+	if perm.IPProtocol == "" && len(perm.IPRanges) == 0 && len(perm.UserIDGroupPairs) == 0 {
+		return nil
+	}
+	return []EC2IPPermission{perm}
+}
+
+// parseSGPermission parses a single IpPermissions.N entry. The bool reports
+// whether the entry was present.
+func parseSGPermission(params map[string]string, prefix, accountID string) (EC2IPPermission, bool) {
+	proto, hasProto := params[prefix+"IpProtocol"]
+	perm := EC2IPPermission{IPProtocol: proto}
+	perm.FromPort, _ = strconv.Atoi(params[prefix+"FromPort"])
+	perm.ToPort, _ = strconv.Atoi(params[prefix+"ToPort"])
+
+	for m := 1; ; m++ {
+		cidr, ok := params[fmt.Sprintf("%sIpRanges.%d.CidrIp", prefix, m)]
+		if !ok || cidr == "" {
+			break
+		}
+		perm.IPRanges = append(perm.IPRanges, cidr)
+	}
+	for m := 1; ; m++ {
+		groupPrefix := fmt.Sprintf("%sGroups.%d.", prefix, m)
+		groupID := params[groupPrefix+"GroupId"]
+		groupName := params[groupPrefix+"GroupName"]
+		if groupID == "" && groupName == "" {
+			break
+		}
+		perm.UserIDGroupPairs = append(perm.UserIDGroupPairs, EC2UserIDGroupPair{
+			GroupID:     groupID,
+			GroupName:   groupName,
+			UserID:      sgOwnerOrDefault(params[groupPrefix+"UserId"], accountID),
+			Description: params[groupPrefix+"Description"],
+		})
+	}
+
+	present := hasProto || len(perm.IPRanges) > 0 || len(perm.UserIDGroupPairs) > 0
+	return perm, present
+}
+
+// sgOwnerOrDefault returns owner, or accountID when owner is empty — AWS fills
+// in the requesting account for a same-account group reference.
+func sgOwnerOrDefault(owner, accountID string) string {
+	if owner != "" {
+		return owner
+	}
+	return accountID
 }
 
 // --- AMI operations ----------------------------------------------------------

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -199,6 +199,29 @@ type EC2IPPermission struct {
 
 	// IPRanges holds the IPv4 CIDR ranges for this permission.
 	IPRanges []string `json:"ip_ranges,omitempty"`
+
+	// UserIDGroupPairs holds the source/destination security groups for this
+	// permission. A rule whose source is another security group (including the
+	// group itself) has no CIDR at all, so it cannot be represented by IPRanges
+	// alone (#388).
+	UserIDGroupPairs []EC2UserIDGroupPair `json:"user_id_group_pairs,omitempty"`
+}
+
+// EC2UserIDGroupPair identifies a security group referenced as the source or
+// destination of a rule.
+type EC2UserIDGroupPair struct {
+	// GroupID is the referenced security group's ID.
+	GroupID string `json:"group_id"`
+
+	// GroupName is the referenced security group's name, used for EC2-Classic
+	// style and default-VPC references.
+	GroupName string `json:"group_name,omitempty"`
+
+	// UserID is the AWS account that owns the referenced group.
+	UserID string `json:"user_id,omitempty"`
+
+	// Description is the optional rule description.
+	Description string `json:"description,omitempty"`
 }
 
 // EC2SecurityGroup represents a VPC security group.

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -265,6 +265,10 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/sqs/consistency", s.handleSQSSeedConsistency)
 	r.Delete("/v1/sqs/consistency", s.handleSQSClearConsistency)
 
+	// EC2 Fleet partial-fulfillment control-plane endpoints (#387).
+	r.Post("/v1/ec2/fleet-shortfall", s.handleEC2SeedFleetShortfall)
+	r.Delete("/v1/ec2/fleet-shortfall", s.handleEC2ClearFleetShortfall)
+
 	// spore.host spawn task-completion control-plane endpoints (#360).
 	r.Post("/v1/spawn/task-completion", s.handleSpawnSeedTaskCompletion)
 	r.Delete("/v1/spawn/task-completion", s.handleSpawnClearTaskCompletion)


### PR DESCRIPTION
Sprint covering #387, #388, and #389.

## #387 — EC2 `CreateFleet`

Adds `CreateFleet`, `DescribeFleets`, `DeleteFleets`.

Instances launch through the same `runInstances` path as a direct launch, so they are visible to `DescribeInstances` with subnet/security-group validation, placement-group checks, and launch-time tag propagation intact.

`LaunchTemplateConfigs[]` × `Overrides[]` flatten into ordered capacity pools (sorted by `Priority` under a `prioritized` allocation strategy) and are fulfilled round-robin, so `fleetInstanceSet` carries **one item per pool, each with a list of instance IDs** — the shape the issue flags as the classic caller bug. An `instant` fleet returns instances and errors synchronously; `request`/`maintain` return only the fleet ID, matching AWS.

**Partial fulfillment is seedable** — the valuable part:

```bash
curl -X POST localhost:4566/v1/ec2/fleet-shortfall \
  -d '{"launchTemplate":"lt-0abc123","fulfill":8,
       "errorCode":"InsufficientInstanceCapacity","lifecycle":"spot"}'
```

A fleet that asks for 12 and receives 8 still returns a fleet ID and echoes the *request* in `TotalTargetCapacity`, never the result — which is exactly why callers get it wrong, and it is rare and hard to trigger against real AWS. The shortfall is spread across pools, so `errorSet` reports one item per short pool, and `DescribeFleets` reports the truth in `fulfilledCapacity`. Seeds are keyed by launch-template ID/name or `\"*\"`, following the established pattern (`ssm_control.go`).

## #388 — four CFN types fell to the generic stub

The handlers existed; the wiring didn't, so a stack deployed "successfully" while the resource was never created.

| Type | Now dispatches | Ref |
|---|---|---|
| `AWS::EC2::LaunchTemplate` | `CreateLaunchTemplate` | real `lt-…` ID, usable by `CreateFleet` |
| `AWS::IAM::InstanceProfile` | `CreateInstanceProfile` + `AddRoleToInstanceProfile` per `Roles` entry | profile name |
| `AWS::EC2::SecurityGroupIngress` | `AuthorizeSecurityGroupIngress` | group ID |
| `AWS::EC2::SecurityGroupEgress` | `AuthorizeSecurityGroupEgress` | group ID |

`AWS::EC2::SecurityGroup` now also authorizes its **inline** `SecurityGroupIngress`/`SecurityGroupEgress` rules. Previously *neither* spelling produced rules, so `DescribeSecurityGroups` reported an empty group however the template was written — the case the issue calls sharpest.

That needed a type change the issue didn't anticipate: `EC2IPPermission` had no way to express a rule whose source is another security group, and a self-referencing rule has no CIDR at all. Added `UserIDGroupPairs`, parsing of `IpPermissions.N.Groups.M.GroupId`, and `groups>item` rendering. While in the parser: it now reads **every** `IpPermissions.N` entry and all of each entry's `IpRanges.M` (it previously read only the first of each), and revoke matches on source as well as protocol/ports, so revoking a CIDR rule no longer removes a source-group rule on the same port.

`AWS::EC2::Instance` passes through `IamInstanceProfile`, `KeyName`, and `SecurityGroupIds` — the profile reference is only resolvable now that the profile is real.

The generic-stub warning reports `service_plugin_loaded`, the issue's suggested cheap improvement; it previously read as "substrate doesn't model this", misleading when only the wiring is missing.

`AWS::EC2::NetworkInterface` is left stubbed — it needs a `CreateNetworkInterface` handler first, which the issue notes belongs in its own issue.

## #389 — doc drift

`emulator/doc.go` claimed 39 plugins and 23 S3 operations; the registry has 63 and `s3_plugin.go` 53. The counts #364 made generated had drifted here, so `doc.go` now points at the generated `docs/services.md` rather than repeating a number that can drift. `CLAUDE.md`'s key-files table pointed at four paths that moved to `emulator/` in the #310 reorg. (The stale next-release pin flagged in the same issue was already removed while cutting v0.81.0, so this PR no longer claims it.)

## Verification

All wire shapes checked against the AWS API reference per CLAUDE.md, which caught two things worth noting:
- The XML elements are `fleetId`/`fleetInstanceSet`/`errorSet`, **not** the boto3-facing `Instances`/`Errors` named in #387.
- Source-SG ingress uses `IpPermissions.N.Groups.M.GroupId`.

23 new fleet subtests + 7 new CFN tests, covering full/partial/zero fulfillment, pool prioritization, spot lifecycle, tag propagation, error cases, instant-fleet visibility rules, delete with and without `TerminateInstances`, self-referencing and mutually-referencing security groups, and launch-template → `CreateFleet` composition.

`make test` (race), `test/e2e`, `go vet`, `golangci-lint run ./...` (0 issues), and `make docs-reference-check` all green.

Closes #387
Closes #388
Closes #389
