### PR TITLE
feat(s3): honor the Range header on GetObject and HeadObject (#396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- S3 `GetObject` and `HeadObject` honor a single-range `Range` header (#396),
+  returning `206 Partial Content` with `Content-Range` and a `Content-Length`
+  equal to the range served. `docs/services.md` had claimed "Supports Range
+  header" since the operation was first documented, but the header was never
+  read — a consumer whose every read is a ranged GET (a FUSE filesystem, a
+  columnar reader seeking within a Parquet footer) silently received whole
+  objects, so no test of its read path was verifying anything.
+  Range composes with `versionId`, and the synthesized spore.host
+  task-completion record is rangeable like any other object.
+  The edge cases are the substance of the fix, because S3 does not report an
+  error for most bad ranges: a range extending past the end of the object is
+  clamped rather than rejected, and a malformed range, a multi-range request, or
+  a unit other than `bytes` is *ignored* — the whole object is served with 200.
+  Only a range starting at or beyond the object's end is a `416 InvalidRange`,
+  whose body carries `<ActualObjectSize>` and `<RangeRequested>` alongside the
+  `Content-Range: bytes */<size>` header so a caller can correct the request
+  without a second round trip. Every range against a zero-byte object is
+  unsatisfiable. Retrieving a part by `?partNumber=N` remains unimplemented.
+
+### Fixed
+- S3 `HeadObject` now reports `x-amz-version-id` (#396). `GetObject` always did,
+  so a caller could not learn which version it had just described from a HEAD
+  alone — it had to issue a GET and download the body to find out.
+- S3 `GetObject` and `HeadObject` now advertise `Accept-Ranges: bytes`, as real
+  S3 does on both (#396).
+
+### Changed
+- The S3 error-response builder can now carry error-specific child elements and
+  response headers (#396), which the `InvalidRange` body needs and which
+  `MinSizeAllowed`/`ProposedSize` (#400) and `StorageClass` (#398) will need. Its
+  `extras ...string` parameter had been an unused stub with no call sites; it is
+  replaced by an explicit `s3Error` options struct, and `s3DeleteMarkerResponse`
+  now shares the same builder instead of re-declaring its own XML type.
+- The GET/HEAD object response headers are built in one place, and
+  `resolveTaskCompletion` returns the object and body it synthesized rather than
+  a finished response (#396). The header block had been duplicated three times
+  and had already drifted — the missing `x-amz-version-id` above was a
+  consequence — and the early return meant a synthesized completion record
+  bypassed the shared response path entirely.
+
 ### Security
 - Bumped the indirect dependency `golang.org/x/text` from v0.38.0 to v0.39.0 in
   both the root and `test/e2e` modules to clear CVE-2026-56852 (#394), a HIGH

--- a/docs/services.md
+++ b/docs/services.md
@@ -187,8 +187,8 @@ STS operations are free.
 | DeleteBucket | |
 | ListBuckets | |
 | PutObject | Supports Content-Type, metadata headers |
-| GetObject | Supports Range header |
-| HeadObject | |
+| GetObject | Supports Range header — see [Ranged reads](#ranged-reads) |
+| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads) |
 | DeleteObject | Fires S3 notifications if configured |
 | CopyObject | |
 | ListObjects | |
@@ -213,6 +213,35 @@ STS operations are free.
 | PutObjectTagging | |
 | GetObjectTagging | |
 | DeleteObjectTagging | |
+
+### Ranged reads
+
+`GetObject` and `HeadObject` honor a single-range `Range` header, returning `206
+Partial Content` with `Content-Range` and a `Content-Length` equal to the range
+served. Both advertise `Accept-Ranges: bytes`. `HeadObject` returns the same
+status and headers with no body.
+
+The edge cases matter more than the happy path, because S3 does **not** report an
+error for most bad ranges — a caller cannot use a 416 to detect a malformed
+request:
+
+| `Range` (1000-byte object) | Result |
+|---|---|
+| `bytes=0-99` | `206`, `Content-Range: bytes 0-99/1000` |
+| `bytes=900-` | `206`, `bytes 900-999/1000` |
+| `bytes=-100` | `206`, `bytes 900-999/1000` (suffix range) |
+| `bytes=0-99999` | `206`, **clamped** to `bytes 0-999/1000` — past EOF is not an error |
+| `bytes=1000-1099` | `416 InvalidRange` with `Content-Range: bytes */1000` |
+| `bytes=-0` | `416 InvalidRange` — a zero-length suffix is unsatisfiable |
+| `bytes=abc`, `bytes=500-100` | `200` with the whole object — malformed ranges are ignored |
+| `bytes=0-99,200-299` | `200` with the whole object — S3 serves only one range per GET |
+| `items=0-99` | `200` with the whole object — units other than `bytes` are ignored |
+
+Every range against a zero-byte object is unsatisfiable. A `416` body carries
+`<ActualObjectSize>` and `<RangeRequested>` so a caller can correct the request
+without a second round trip. Ranges compose with `versionId`.
+
+Retrieving a specific part by `?partNumber=N` is not implemented.
 
 ### Betty CFN resource types
 

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -549,63 +549,66 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 	if err != nil {
 		return nil, fmt.Errorf("get object metadata: %w", err)
 	}
+
+	var obj S3Object
+	var body []byte
 	if data == nil {
 		// No real object at this key: a GET of tasks/<task_id>/completion.json may
 		// be a seedable spore.host task-completion observation (#360). A real
 		// staged object always wins, so this only runs when the key is absent.
+		var handled bool
 		if versionID == "" {
-			if resp, handled := p.resolveTaskCompletion(ctx, bucket, key); handled {
-				return resp, nil
-			}
+			obj, body, handled = p.resolveTaskCompletion(ctx, key)
 		}
-		return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound), nil
-	}
+		if !handled {
+			return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound), nil
+		}
+	} else {
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return nil, fmt.Errorf("unmarshal object metadata: %w", err)
+		}
 
-	var obj S3Object
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, fmt.Errorf("unmarshal object metadata: %w", err)
-	}
+		if obj.IsDeleteMarker {
+			// A GET targeting a delete marker directly (explicit versionId) is a 405
+			// MethodNotAllowed in S3; a GET of a key whose current version is a delete
+			// marker is a 404 NoSuchKey. Both carry x-amz-delete-marker: true.
+			return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
+		}
 
-	if obj.IsDeleteMarker {
-		// A GET targeting a delete marker directly (explicit versionId) is a 405
-		// MethodNotAllowed in S3; a GET of a key whose current version is a delete
-		// marker is a 404 NoSuchKey. Both carry x-amz-delete-marker: true.
-		return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
-	}
-
-	// Directory-marker objects (key ends with "/") are never written to the
-	// afero filesystem; their body is always empty.
-	var body []byte
-	if !strings.HasSuffix(key, "/") {
-		// Try versioned fs path first, then fallback to main path.
-		var readErr error
-		body, readErr = afero.ReadFile(p.fs, fsPath)
-		if readErr != nil {
-			// Fall back to main path for objects written before versioning was enabled.
-			body, readErr = afero.ReadFile(p.fs, "/"+bucket+"/"+key)
+		// Directory-marker objects (key ends with "/") are never written to the
+		// afero filesystem; their body is always empty.
+		if !strings.HasSuffix(key, "/") {
+			// Try versioned fs path first, then fallback to main path.
+			var readErr error
+			body, readErr = afero.ReadFile(p.fs, fsPath)
 			if readErr != nil {
-				return nil, fmt.Errorf("read object body: %w", readErr)
+				// Fall back to main path for objects written before versioning was enabled.
+				body, readErr = afero.ReadFile(p.fs, "/"+bucket+"/"+key)
+				if readErr != nil {
+					return nil, fmt.Errorf("read object body: %w", readErr)
+				}
 			}
 		}
 	}
 
-	headers := map[string]string{
-		"Content-Type":   obj.ContentType,
-		"ETag":           obj.ETag,
-		"Last-Modified":  obj.LastModified.UTC().Format(http.TimeFormat),
-		"Content-Length": strconv.FormatInt(obj.Size, 10),
+	headers := objectResponseHeaders(&obj)
+
+	rangeHeader := headerValueFold(req.Headers, "Range")
+	spec := parseByteRange(rangeHeader, obj.Size)
+	if spec.Unsatisfiable {
+		return s3InvalidRangeResponse(rangeHeader, obj.Size), nil
 	}
-	if obj.ContentEncoding != "" {
-		headers["Content-Encoding"] = obj.ContentEncoding
-	}
-	if obj.VersionID != "" {
-		headers["x-amz-version-id"] = obj.VersionID
-	}
-	for k, v := range obj.UserMetadata {
-		headers["X-Amz-Meta-"+k] = v
+	status := applyByteRange(spec, obj.Size, headers)
+	if spec.Satisfiable {
+		// Clamp against the body actually read: getObject's fallback path can
+		// return a body shorter than the recorded Size, which would otherwise
+		// panic here.
+		end := min(spec.End+1, int64(len(body)))
+		start := min(spec.Start, end)
+		body = body[start:end]
 	}
 
-	return &AWSResponse{StatusCode: http.StatusOK, Headers: headers, Body: body}, nil
+	return &AWSResponse{StatusCode: status, Headers: headers, Body: body}, nil
 }
 
 // headObject handles HEAD /<bucket>/<key>.
@@ -637,20 +640,17 @@ func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key st
 		return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
 	}
 
-	headers := map[string]string{
-		"Content-Type":   obj.ContentType,
-		"ETag":           obj.ETag,
-		"Last-Modified":  obj.LastModified.UTC().Format(http.TimeFormat),
-		"Content-Length": strconv.FormatInt(obj.Size, 10),
-	}
-	if obj.ContentEncoding != "" {
-		headers["Content-Encoding"] = obj.ContentEncoding
-	}
-	for k, v := range obj.UserMetadata {
-		headers["X-Amz-Meta-"+k] = v
-	}
+	headers := objectResponseHeaders(&obj)
 
-	return &AWSResponse{StatusCode: http.StatusOK, Headers: headers}, nil
+	// HEAD honors Range exactly as GET does, minus the body.
+	rangeHeader := headerValueFold(req.Headers, "Range")
+	spec := parseByteRange(rangeHeader, obj.Size)
+	if spec.Unsatisfiable {
+		return s3InvalidRangeResponse(rangeHeader, obj.Size), nil
+	}
+	status := applyByteRange(spec, obj.Size, headers)
+
+	return &AWSResponse{StatusCode: status, Headers: headers}, nil
 }
 
 // deleteObject handles DELETE /<bucket>/<key>.
@@ -1645,21 +1645,93 @@ func s3XMLResponse(status int, v any) (*AWSResponse, error) {
 	}, nil
 }
 
-// s3ErrorResponse builds an S3-style XML error [AWSResponse].
-// extras is currently unused and reserved for future extension.
-func s3ErrorResponse(code, message string, status int, extras ...string) *AWSResponse {
-	_ = extras // reserved
-	type errorXML struct {
-		XMLName   xml.Name `xml:"Error"`
-		Code      string   `xml:"Code"`
-		Message   string   `xml:"Message"`
-		RequestID string   `xml:"RequestId"`
+// objectResponseHeaders builds the response headers common to GetObject and
+// HeadObject. Content-Length is the object's recorded size; a ranged read
+// overwrites it with the length of the range actually served.
+func objectResponseHeaders(obj *S3Object) map[string]string {
+	headers := map[string]string{
+		"Content-Type":   obj.ContentType,
+		"ETag":           obj.ETag,
+		"Last-Modified":  obj.LastModified.UTC().Format(http.TimeFormat),
+		"Content-Length": strconv.FormatInt(obj.Size, 10),
+		"Accept-Ranges":  "bytes",
 	}
-	e := errorXML{Code: code, Message: message, RequestID: "SUBSTRATE"}
-	body, _ := xml.Marshal(e)
+	if obj.ContentEncoding != "" {
+		headers["Content-Encoding"] = obj.ContentEncoding
+	}
+	if obj.VersionID != "" {
+		headers["x-amz-version-id"] = obj.VersionID
+	}
+	for k, v := range obj.UserMetadata {
+		headers["X-Amz-Meta-"+k] = v
+	}
+	return headers
+}
+
+// s3ErrorDetail is one error-specific child element of an S3 <Error> document,
+// such as the <ActualObjectSize> that accompanies an InvalidRange.
+type s3ErrorDetail struct {
+	Name  string
+	Value string
+}
+
+// s3Error describes an S3 XML error response. Code, Message and Status are
+// required; Details adds error-specific child elements and Headers adds response
+// headers beyond the XML content type.
+type s3Error struct {
+	Code    string
+	Message string
+	Status  int
+	Details []s3ErrorDetail
+	Headers map[string]string
+}
+
+// s3ErrorDetailXML carries one dynamically named child element. encoding/xml
+// resolves an element's name from the XMLName field's value ahead of the parent
+// struct field's tag, which is what lets each entry emit a different name.
+type s3ErrorDetailXML struct {
+	XMLName xml.Name
+	Value   string `xml:",chardata"`
+}
+
+// s3ErrorXML is the wire form of an S3 <Error> document.
+type s3ErrorXML struct {
+	XMLName   xml.Name           `xml:"Error"`
+	Code      string             `xml:"Code"`
+	Message   string             `xml:"Message"`
+	RequestID string             `xml:"RequestId"`
+	Details   []s3ErrorDetailXML `xml:",any"`
+}
+
+// s3ErrorResponse builds an S3-style XML error [AWSResponse].
+func s3ErrorResponse(code, message string, status int) *AWSResponse {
+	return s3ErrorResponseWith(s3Error{Code: code, Message: message, Status: status})
+}
+
+// s3ErrorResponseWith builds an S3-style XML error [AWSResponse], including any
+// error-specific child elements and response headers described by e. Details
+// with an empty Name are skipped.
+func s3ErrorResponseWith(e s3Error) *AWSResponse {
+	doc := s3ErrorXML{Code: e.Code, Message: e.Message, RequestID: "SUBSTRATE"}
+	for _, d := range e.Details {
+		if d.Name == "" {
+			continue
+		}
+		doc.Details = append(doc.Details, s3ErrorDetailXML{
+			XMLName: xml.Name{Local: d.Name},
+			Value:   d.Value,
+		})
+	}
+
+	headers := map[string]string{"Content-Type": "text/xml; charset=UTF-8"}
+	for k, v := range e.Headers {
+		headers[k] = v
+	}
+
+	body, _ := xml.Marshal(doc)
 	return &AWSResponse{
-		StatusCode: status,
-		Headers:    map[string]string{"Content-Type": "text/xml; charset=UTF-8"},
+		StatusCode: e.Status,
+		Headers:    headers,
 		Body:       append([]byte(xml.Header), body...),
 	}
 }
@@ -1671,10 +1743,7 @@ func s3ErrorResponse(code, message string, status int, extras ...string) *AWSRes
 // carry the x-amz-delete-marker: true header so SDKs can distinguish a deleted
 // object from a never-existed key.
 func s3DeleteMarkerResponse(versionRequested bool, markerVersionID string) *AWSResponse {
-	headers := map[string]string{
-		"Content-Type":        "text/xml; charset=UTF-8",
-		"x-amz-delete-marker": "true",
-	}
+	headers := map[string]string{"x-amz-delete-marker": "true"}
 	if markerVersionID != "" {
 		headers["x-amz-version-id"] = markerVersionID
 	}
@@ -1686,18 +1755,7 @@ func s3DeleteMarkerResponse(versionRequested bool, markerVersionID string) *AWSR
 		headers["Allow"] = "DELETE"
 	}
 
-	type errorXML struct {
-		XMLName   xml.Name `xml:"Error"`
-		Code      string   `xml:"Code"`
-		Message   string   `xml:"Message"`
-		RequestID string   `xml:"RequestId"`
-	}
-	body, _ := xml.Marshal(errorXML{Code: code, Message: message, RequestID: "SUBSTRATE"})
-	return &AWSResponse{
-		StatusCode: status,
-		Headers:    headers,
-		Body:       append([]byte(xml.Header), body...),
-	}
+	return s3ErrorResponseWith(s3Error{Code: code, Message: message, Status: status, Headers: headers})
 }
 
 // --- Bucket policy operations ----------------------------------------------

--- a/emulator/s3_range.go
+++ b/emulator/s3_range.go
@@ -1,0 +1,135 @@
+package emulator
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// byteRangeSpec is the resolved outcome of parsing a Range request header
+// against a known object size. Three outcomes must be distinguishable, because
+// they produce three different responses:
+//
+//   - the zero value: no usable range. Either the header was absent, malformed,
+//     used a non-bytes unit, or asked for multiple ranges. S3 ignores all of
+//     these and serves the whole object with 200.
+//   - Satisfiable: serve Start..End inclusive with 206.
+//   - Unsatisfiable: the range lies wholly outside the object. 416 InvalidRange.
+type byteRangeSpec struct {
+	// Satisfiable reports that Start and End describe a range to serve.
+	Satisfiable bool
+	// Unsatisfiable reports that the range cannot be met and 416 is required.
+	Unsatisfiable bool
+	// Start and End are inclusive byte offsets, valid only when Satisfiable.
+	Start int64
+	End   int64
+}
+
+// parseByteRange resolves a Range request header against an object of total
+// bytes, following RFC 9110 section 14 as the S3 GetObject reference specifies.
+//
+// A range that runs past the end of the object is clamped rather than rejected,
+// and a malformed or multi-range header is ignored rather than rejected — both
+// match S3, and both mean a caller cannot rely on a 416 to detect a bad request.
+// Only a range starting at or beyond the object's end is unsatisfiable. Every
+// range against a zero-byte object is unsatisfiable.
+func parseByteRange(header string, total int64) byteRangeSpec {
+	spec, ok := strings.CutPrefix(strings.ToLower(strings.TrimSpace(header)), "bytes=")
+	if !ok {
+		// Absent, or a unit other than bytes: ignore.
+		return byteRangeSpec{}
+	}
+	if strings.Contains(spec, ",") {
+		// "Amazon S3 doesn't support retrieving multiple ranges of data per
+		// GET request" — the header is ignored, not an error.
+		return byteRangeSpec{}
+	}
+
+	first, last, ok := strings.Cut(spec, "-")
+	if !ok {
+		return byteRangeSpec{}
+	}
+	first, last = strings.TrimSpace(first), strings.TrimSpace(last)
+
+	switch {
+	case first == "":
+		// Suffix range: the final N bytes. A zero suffix-length is
+		// unsatisfiable per RFC 9110, as is any suffix of an empty object.
+		suffix, err := strconv.ParseInt(last, 10, 64)
+		if err != nil || suffix < 0 {
+			return byteRangeSpec{}
+		}
+		if suffix == 0 || total == 0 {
+			return byteRangeSpec{Unsatisfiable: true}
+		}
+		start := total - suffix
+		if start < 0 {
+			start = 0
+		}
+		return byteRangeSpec{Satisfiable: true, Start: start, End: total - 1}
+
+	case last == "":
+		// Open-ended range: from Start to the end of the object.
+		start, err := strconv.ParseInt(first, 10, 64)
+		if err != nil || start < 0 {
+			return byteRangeSpec{}
+		}
+		if start >= total {
+			return byteRangeSpec{Unsatisfiable: true}
+		}
+		return byteRangeSpec{Satisfiable: true, Start: start, End: total - 1}
+
+	default:
+		start, serr := strconv.ParseInt(first, 10, 64)
+		end, eerr := strconv.ParseInt(last, 10, 64)
+		if serr != nil || eerr != nil || start < 0 || end < 0 || end < start {
+			// A last-byte-pos below first-byte-pos makes the spec invalid,
+			// which RFC 9110 says to ignore rather than reject.
+			return byteRangeSpec{}
+		}
+		if start >= total {
+			return byteRangeSpec{Unsatisfiable: true}
+		}
+		if end >= total {
+			end = total - 1 // Clamp past EOF; not an error.
+		}
+		return byteRangeSpec{Satisfiable: true, Start: start, End: end}
+	}
+}
+
+// applyByteRange sets the range response headers on a satisfiable spec and
+// returns the status code to serve: 206 for a range, 200 otherwise.
+//
+// Content-Length is overwritten with the length of the range, which is required
+// rather than cosmetic: [Server.writeResponse] only defaults Content-Length when
+// a plugin supplied none, and [objectResponseHeaders] always supplies the full
+// object size. Leaving it would desynchronize every SDK client.
+func applyByteRange(spec byteRangeSpec, total int64, headers map[string]string) int {
+	if !spec.Satisfiable {
+		return http.StatusOK
+	}
+	length := spec.End - spec.Start + 1
+	headers["Content-Range"] = fmt.Sprintf("bytes %d-%d/%d", spec.Start, spec.End, total)
+	headers["Content-Length"] = strconv.FormatInt(length, 10)
+	return http.StatusPartialContent
+}
+
+// s3InvalidRangeResponse builds the 416 InvalidRange response for a range that
+// cannot be satisfied, carrying the object's actual size both as the
+// Content-Range header RFC 9110 requires and as the <ActualObjectSize> element
+// S3 includes, so a caller can correct the request without a second round trip.
+func s3InvalidRangeResponse(rangeHeader string, total int64) *AWSResponse {
+	return s3ErrorResponseWith(s3Error{
+		Code:    "InvalidRange",
+		Message: "The requested range cannot be satisfied.",
+		Status:  http.StatusRequestedRangeNotSatisfiable,
+		Details: []s3ErrorDetail{
+			{Name: "RangeRequested", Value: rangeHeader},
+			{Name: "ActualObjectSize", Value: strconv.FormatInt(total, 10)},
+		},
+		Headers: map[string]string{
+			"Content-Range": fmt.Sprintf("bytes */%d", total),
+		},
+	})
+}

--- a/emulator/s3_range_test.go
+++ b/emulator/s3_range_test.go
@@ -1,0 +1,323 @@
+package emulator_test
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// rangeFixture creates a bucket holding one 1000-byte object whose bytes are
+// distinguishable by position, so a served range can be checked for content and
+// not merely length.
+func rangeFixture(t *testing.T) (*emulator.Server, []byte) {
+	t.Helper()
+	srv, _ := newS3TestServer(t)
+
+	body := make([]byte, 1000)
+	for i := range body {
+		body[i] = byte('a' + i%26)
+	}
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/ranged", nil, nil).Code, "create bucket")
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/ranged/obj.bin", body, nil).Code, "put object")
+
+	return srv, body
+}
+
+func TestS3_GetObject_Range(t *testing.T) {
+	tests := []struct {
+		name        string
+		rangeHeader string
+		wantStatus  int
+		wantRange   string // expected Content-Range, "" when none
+		wantStart   int64  // body slice bounds, used when wantStatus is 200 or 206
+		wantEnd     int64  // exclusive
+	}{
+		{
+			name:        "prefix range",
+			rangeHeader: "bytes=0-99", wantStatus: http.StatusPartialContent,
+			wantRange: "bytes 0-99/1000", wantStart: 0, wantEnd: 100,
+		},
+		{
+			name:        "open ended range to EOF",
+			rangeHeader: "bytes=900-", wantStatus: http.StatusPartialContent,
+			wantRange: "bytes 900-999/1000", wantStart: 900, wantEnd: 1000,
+		},
+		{
+			name:        "suffix range",
+			rangeHeader: "bytes=-100", wantStatus: http.StatusPartialContent,
+			wantRange: "bytes 900-999/1000", wantStart: 900, wantEnd: 1000,
+		},
+		{
+			name:        "range past EOF is clamped not rejected",
+			rangeHeader: "bytes=0-99999", wantStatus: http.StatusPartialContent,
+			wantRange: "bytes 0-999/1000", wantStart: 0, wantEnd: 1000,
+		},
+		{
+			name:        "single byte",
+			rangeHeader: "bytes=0-0", wantStatus: http.StatusPartialContent,
+			wantRange: "bytes 0-0/1000", wantStart: 0, wantEnd: 1,
+		},
+		{
+			name:        "whole object as an explicit range is still 206",
+			rangeHeader: "bytes=0-999", wantStatus: http.StatusPartialContent,
+			wantRange: "bytes 0-999/1000", wantStart: 0, wantEnd: 1000,
+		},
+		{
+			name:        "suffix longer than the object clamps to the whole object",
+			rangeHeader: "bytes=-5000", wantStatus: http.StatusPartialContent,
+			wantRange: "bytes 0-999/1000", wantStart: 0, wantEnd: 1000,
+		},
+		{
+			name:        "start beyond EOF is unsatisfiable",
+			rangeHeader: "bytes=1000-1099", wantStatus: http.StatusRequestedRangeNotSatisfiable,
+		},
+		{
+			name:        "start exactly at EOF is unsatisfiable",
+			rangeHeader: "bytes=1000-", wantStatus: http.StatusRequestedRangeNotSatisfiable,
+		},
+		{
+			name:        "zero-length suffix is unsatisfiable",
+			rangeHeader: "bytes=-0", wantStatus: http.StatusRequestedRangeNotSatisfiable,
+		},
+		{
+			name:        "unparseable range is ignored",
+			rangeHeader: "bytes=abc", wantStatus: http.StatusOK, wantStart: 0, wantEnd: 1000,
+		},
+		{
+			name:        "multiple ranges are ignored: S3 serves the whole object",
+			rangeHeader: "bytes=0-99,200-299", wantStatus: http.StatusOK, wantStart: 0, wantEnd: 1000,
+		},
+		{
+			name:        "non-bytes unit is ignored",
+			rangeHeader: "items=0-99", wantStatus: http.StatusOK, wantStart: 0, wantEnd: 1000,
+		},
+		{
+			name:        "end before start is ignored",
+			rangeHeader: "bytes=500-100", wantStatus: http.StatusOK, wantStart: 0, wantEnd: 1000,
+		},
+		{
+			name:        "absent header serves the whole object",
+			rangeHeader: "", wantStatus: http.StatusOK, wantStart: 0, wantEnd: 1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, full := rangeFixture(t)
+
+			var headers map[string]string
+			if tt.rangeHeader != "" {
+				headers = map[string]string{"Range": tt.rangeHeader}
+			}
+			w := s3Request(t, srv, http.MethodGet, "/ranged/obj.bin", nil, headers)
+
+			require.Equal(t, tt.wantStatus, w.Code)
+
+			if tt.wantStatus == http.StatusRequestedRangeNotSatisfiable {
+				// RFC 9110 requires the unsatisfied-range form here.
+				assert.Equal(t, "bytes */1000", w.Header().Get("Content-Range"))
+				return
+			}
+			assert.Equal(t, tt.wantRange, w.Header().Get("Content-Range"))
+
+			assert.Equal(t, full[tt.wantStart:tt.wantEnd], w.Body.Bytes(),
+				"served bytes must be exactly the requested range")
+
+			// The desync guard: writeResponse only defaults Content-Length when
+			// the plugin supplied none, and the object header block always
+			// supplies the full size. A 206 that forgets to overwrite it sends a
+			// short body under a full-object length and hangs SDK clients.
+			assert.Equal(t, strconv.Itoa(w.Body.Len()), w.Header().Get("Content-Length"),
+				"Content-Length must match the bytes actually written")
+		})
+	}
+}
+
+func TestS3_GetObject_Range_AcceptRangesAndMetadataMatchFullGet(t *testing.T) {
+	srv, _ := rangeFixture(t)
+
+	full := s3Request(t, srv, http.MethodGet, "/ranged/obj.bin", nil, nil)
+	require.Equal(t, http.StatusOK, full.Code)
+	assert.Equal(t, "bytes", full.Header().Get("Accept-Ranges"),
+		"S3 advertises range support on an unranged GET too")
+
+	part := s3Request(t, srv, http.MethodGet, "/ranged/obj.bin", nil, map[string]string{"Range": "bytes=10-19"})
+	require.Equal(t, http.StatusPartialContent, part.Code)
+
+	// A ranged read describes the same object, so its identity headers must be
+	// byte-identical to the full read's.
+	for _, h := range []string{"ETag", "Last-Modified", "Content-Type", "Accept-Ranges"} {
+		assert.Equal(t, full.Header().Get(h), part.Header().Get(h), "header %s", h)
+	}
+}
+
+func TestS3_GetObject_Range_InvalidRangeBody(t *testing.T) {
+	srv, _ := rangeFixture(t)
+
+	w := s3Request(t, srv, http.MethodGet, "/ranged/obj.bin", nil, map[string]string{"Range": "bytes=2000-2099"})
+	require.Equal(t, http.StatusRequestedRangeNotSatisfiable, w.Code)
+
+	assert.Equal(t, "bytes */1000", w.Header().Get("Content-Range"),
+		"RFC 9110 requires the actual length on a 416")
+
+	body := w.Body.String()
+	assert.Contains(t, body, "<Code>InvalidRange</Code>")
+	assert.Contains(t, body, "<ActualObjectSize>1000</ActualObjectSize>")
+	assert.Contains(t, body, "<RangeRequested>bytes=2000-2099</RangeRequested>")
+}
+
+func TestS3_GetObject_Range_ZeroByteObject(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/empty", nil, nil).Code)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/empty/zero.bin", []byte{}, nil).Code)
+
+	// Any range against an empty object is unsatisfiable — there is no byte 0.
+	for _, rh := range []string{"bytes=0-0", "bytes=0-", "bytes=-1"} {
+		t.Run(rh, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodGet, "/empty/zero.bin", nil, map[string]string{"Range": rh})
+			require.Equal(t, http.StatusRequestedRangeNotSatisfiable, w.Code)
+			assert.Equal(t, "bytes */0", w.Header().Get("Content-Range"))
+		})
+	}
+
+	// Without a Range header an empty object is a normal 200.
+	w := s3Request(t, srv, http.MethodGet, "/empty/zero.bin", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 0, w.Body.Len())
+}
+
+func TestS3_HeadObject_Range(t *testing.T) {
+	srv, _ := rangeFixture(t)
+
+	w := s3Request(t, srv, http.MethodHead, "/ranged/obj.bin", nil, map[string]string{"Range": "bytes=100-199"})
+	require.Equal(t, http.StatusPartialContent, w.Code, "HEAD honors Range like GET")
+	assert.Equal(t, "bytes 100-199/1000", w.Header().Get("Content-Range"))
+	assert.Equal(t, "100", w.Header().Get("Content-Length"),
+		"Content-Length reports the range length even with no body")
+	assert.Equal(t, 0, w.Body.Len(), "HEAD never carries a body")
+
+	unsat := s3Request(t, srv, http.MethodHead, "/ranged/obj.bin", nil, map[string]string{"Range": "bytes=5000-"})
+	require.Equal(t, http.StatusRequestedRangeNotSatisfiable, unsat.Code)
+	assert.Equal(t, "bytes */1000", unsat.Header().Get("Content-Range"))
+}
+
+func TestS3_HeadObject_EmitsVersionID(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/hver", nil, nil).Code)
+	versioning := `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+		`<Status>Enabled</Status></VersioningConfiguration>`
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/hver?versioning", []byte(versioning),
+			map[string]string{"Content-Type": "application/xml"}).Code)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/hver/k.txt", []byte("v1"), nil).Code)
+
+	g := s3Request(t, srv, http.MethodGet, "/hver/k.txt", nil, nil)
+	require.Equal(t, http.StatusOK, g.Code)
+	vid := g.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, vid, "GET reports the version id")
+
+	h := s3Request(t, srv, http.MethodHead, "/hver/k.txt", nil, nil)
+	require.Equal(t, http.StatusOK, h.Code)
+	assert.Equal(t, vid, h.Header().Get("x-amz-version-id"),
+		"HEAD must report the same version id as GET")
+}
+
+func TestS3_GetObject_Range_WithVersionID(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/rver", nil, nil).Code)
+	versioning := `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+		`<Status>Enabled</Status></VersioningConfiguration>`
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/rver?versioning", []byte(versioning),
+			map[string]string{"Content-Type": "application/xml"}).Code)
+
+	first := s3Request(t, srv, http.MethodPut, "/rver/k.txt", []byte("AAAABBBBCCCC"), nil)
+	require.Equal(t, http.StatusOK, first.Code)
+	v1 := first.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, v1)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/rver/k.txt", []byte("ZZZZZZZZZZZZZZZZ"), nil).Code)
+
+	// A range must apply to the named version, not the current one.
+	w := s3Request(t, srv, http.MethodGet, "/rver/k.txt?versionId="+v1, nil,
+		map[string]string{"Range": "bytes=4-7"})
+	require.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, "BBBB", w.Body.String())
+	assert.Equal(t, "bytes 4-7/12", w.Header().Get("Content-Range"))
+	assert.Equal(t, v1, w.Header().Get("x-amz-version-id"))
+	assert.Equal(t, strconv.Itoa(w.Body.Len()), w.Header().Get("Content-Length"))
+}
+
+func TestS3_GetObject_Range_HeaderCaseInsensitive(t *testing.T) {
+	srv, _ := rangeFixture(t)
+
+	// Plugins receive canonicalized header keys through the parser, but tests and
+	// alternate transports may not canonicalize, so the lookup must fold case.
+	for _, name := range []string{"Range", "range", "RANGE"} {
+		t.Run(name, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodGet, "/ranged/obj.bin", nil, map[string]string{name: "bytes=0-9"})
+			require.Equal(t, http.StatusPartialContent, w.Code)
+			assert.Equal(t, "bytes 0-9/1000", w.Header().Get("Content-Range"))
+		})
+	}
+}
+
+func TestS3_GetObject_Range_TaskCompletionRecord(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/results", nil, nil).Code)
+
+	// The synthesized spore.host completion record now flows through the same
+	// response path as a stored object, so it is rangeable too (#360, #396).
+	full := s3Request(t, srv, http.MethodGet, "/results/tasks/task-r/completion.json", nil, nil)
+	require.Equal(t, http.StatusOK, full.Code)
+	require.Contains(t, full.Body.String(), `"state":"completed"`)
+	assert.Equal(t, "bytes", full.Header().Get("Accept-Ranges"))
+
+	w := s3Request(t, srv, http.MethodGet, "/results/tasks/task-r/completion.json", nil,
+		map[string]string{"Range": "bytes=0-3"})
+	require.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, full.Body.String()[:4], w.Body.String())
+	assert.Equal(t, strconv.Itoa(full.Body.Len()),
+		strings.SplitN(w.Header().Get("Content-Range"), "/", 2)[1],
+		"the /total in Content-Range is the whole record's length")
+}
+
+func TestS3_ErrorResponse_DetailElements(t *testing.T) {
+	srv, _ := rangeFixture(t)
+
+	// The dynamic detail elements rely on encoding/xml resolving an element name
+	// from the XMLName field's value ahead of the parent field's tag. Assert the
+	// exact bytes, since a change in that precedence would silently rename them.
+	w := s3Request(t, srv, http.MethodGet, "/ranged/obj.bin", nil, map[string]string{"Range": "bytes=4096-"})
+	require.Equal(t, http.StatusRequestedRangeNotSatisfiable, w.Code)
+
+	assert.Equal(t,
+		`<?xml version="1.0" encoding="UTF-8"?>`+"\n"+
+			`<Error><Code>InvalidRange</Code>`+
+			`<Message>The requested range cannot be satisfied.</Message>`+
+			`<RequestId>SUBSTRATE</RequestId>`+
+			`<RangeRequested>bytes=4096-</RangeRequested>`+
+			`<ActualObjectSize>1000</ActualObjectSize></Error>`,
+		w.Body.String())
+}
+
+func TestS3_ErrorResponse_NoDetailsIsUnchanged(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+
+	// An error with no detail elements must serialize exactly as before the
+	// builder gained the Details field — 61 call sites depend on this shape.
+	w := s3Request(t, srv, http.MethodGet, "/nosuchbucket/nosuchkey", nil, nil)
+	require.Equal(t, http.StatusNotFound, w.Code)
+	assert.NotContains(t, w.Body.String(), "<Details>")
+	assert.Contains(t, w.Body.String(), "<RequestId>SUBSTRATE</RequestId></Error>")
+}

--- a/emulator/spawn_control.go
+++ b/emulator/spawn_control.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -61,27 +60,29 @@ func taskCompletionID(key string) (string, bool) {
 	return id, true
 }
 
-// resolveTaskCompletion serves a spore.host task-completion record for a GET of
-// tasks/<task_id>/completion.json when no real object exists at the key. It
-// returns (resp, true) when it handled the request — either a synthesized 200
-// carrying the completion JSON, or a 404 NoSuchKey when a seeded record's
-// EndedAt has not yet been reached on the simulated clock ("still running").
-// It returns (nil, false) when the key is not a completion-record key, so the
-// caller falls through to its normal NoSuchKey response.
+// resolveTaskCompletion synthesizes a spore.host task-completion record for a GET
+// of tasks/<task_id>/completion.json when no real object exists at the key. It
+// returns (obj, body, true) when it handled the request, letting the caller serve
+// the record through its normal object-response path — so conditional and ranged
+// reads apply to it as they do to any other object.
+//
+// It returns handled=false both when the key is not a completion-record key and
+// when a seeded record's EndedAt has not yet been reached on the simulated clock
+// ("still running"); in either case the caller's NoSuchKey response is correct.
 //
 // Absent a seed, a matching key resolves to the nominal success record
 // (exit_code 0, state "completed") so the happy path needs no seeding, matching
 // the seeding philosophy. Substrate does not run the task; this is the seedable
 // completion observation only.
-func (p *S3Plugin) resolveTaskCompletion(ctx context.Context, _ string, key string) (*AWSResponse, bool) {
+func (p *S3Plugin) resolveTaskCompletion(ctx context.Context, key string) (S3Object, []byte, bool) {
 	taskID, ok := taskCompletionID(key)
 	if !ok {
-		return nil, false
+		return S3Object{}, nil, false
 	}
 
 	data, err := p.state.Get(ctx, spawnCtrlNamespace, spawnCompletionKey(taskID))
 	if err != nil {
-		return nil, false
+		return S3Object{}, nil, false
 	}
 
 	var rec spawnTaskCompletion
@@ -91,7 +92,7 @@ func (p *S3Plugin) resolveTaskCompletion(ctx context.Context, _ string, key stri
 		rec = spawnTaskCompletion{TaskID: taskID, ExitCode: 0, State: "completed", StartedAt: now, EndedAt: now}
 	} else {
 		if err := json.Unmarshal(data, &rec); err != nil {
-			return nil, false
+			return S3Object{}, nil, false
 		}
 		rec.TaskID = taskID
 		if rec.State == "" {
@@ -100,23 +101,23 @@ func (p *S3Plugin) resolveTaskCompletion(ctx context.Context, _ string, key stri
 		// Clock gate: before EndedAt the record is not yet present.
 		if ended, perr := time.Parse(time.RFC3339, rec.EndedAt); perr == nil {
 			if p.tc.Now().Before(ended) {
-				return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound), true
+				return S3Object{}, nil, false
 			}
 		}
 	}
 
 	body, err := json.Marshal(rec)
 	if err != nil {
-		return nil, false
+		return S3Object{}, nil, false
 	}
 	hash := md5.Sum(body) //nolint:gosec // S3 ETags are MD5 by definition.
-	headers := map[string]string{
-		"Content-Type":   "application/json",
-		"ETag":           fmt.Sprintf("%q", fmt.Sprintf("%x", hash)),
-		"Last-Modified":  p.tc.Now().UTC().Format(http.TimeFormat),
-		"Content-Length": strconv.Itoa(len(body)),
-	}
-	return &AWSResponse{StatusCode: http.StatusOK, Headers: headers, Body: body}, true
+	return S3Object{
+		Key:          key,
+		Size:         int64(len(body)),
+		ContentType:  "application/json",
+		ETag:         fmt.Sprintf("%q", fmt.Sprintf("%x", hash)),
+		LastModified: p.tc.Now().UTC(),
+	}, body, true
 }
 
 // handleSpawnSeedTaskCompletion handles POST /v1/spawn/task-completion. It seeds


### PR DESCRIPTION
Closes #396.

`docs/services.md` has claimed `| GetObject | Supports Range header |` since the
operation was first documented, but the header was never read — `Content-Range`,
`StatusPartialContent` and `InvalidRange` appeared nowhere in non-test source. A
consumer whose every read is a ranged GET (the reporter is building a FUSE
filesystem; a columnar reader seeking within a Parquet footer is the same shape)
silently received whole objects, so its read-path tests passed while verifying
nothing. That is the failure mode this repo exists to prevent, and the false doc
claim is what made it invisible.

## The edge cases are the substance

S3 does not report an error for most bad ranges, so a caller cannot use a 416 to
detect one. Verified against the AWS GetObject API reference and RFC 9110 §14
rather than from memory:

| `Range` (1000-byte object) | Result |
|---|---|
| `bytes=0-99` | `206`, `Content-Range: bytes 0-99/1000` |
| `bytes=900-` | `206`, `bytes 900-999/1000` |
| `bytes=-100` | `206`, `bytes 900-999/1000` (suffix) |
| `bytes=0-99999` | `206`, **clamped** to `bytes 0-999/1000` — past EOF is not an error |
| `bytes=1000-1099` | `416 InvalidRange` + `Content-Range: bytes */1000` |
| `bytes=-0` | `416` — a zero-length suffix is unsatisfiable |
| `bytes=abc`, `bytes=500-100` | `200`, whole object — malformed ranges are *ignored* |
| `bytes=0-99,200-299` | `200`, whole object — S3 serves one range per GET |
| `items=0-99` | `200`, whole object — non-`bytes` units ignored |

`byteRangeSpec` therefore carries three states rather than a
`(start, end, error)` triple, which cannot distinguish "ignore, serve 200" from
"416". HEAD honors Range identically, minus the body. Ranges compose with
`versionId`, and every range against a zero-byte object is unsatisfiable.

## Two supporting changes

**The error builder can now carry child elements and headers.** The
`InvalidRange` body needs `<ActualObjectSize>`/`<RangeRequested>`, and #400
(`MinSizeAllowed`) and #398 (`StorageClass`) will need the same. The existing
`extras ...string` parameter was an unused stub (`_ = extras`) with **zero** call
sites, so it is replaced by an `s3Error` options struct rather than given a
meaning — one flat variadic cannot express two independent variable-length things
without a magic sentinel. All 61 `s3ErrorResponse` call sites compile untouched,
and `s3DeleteMarkerResponse` now shares the builder instead of re-declaring its
own XML type. The dynamic element names rely on `encoding/xml` resolving a name
from the `XMLName` field's *value* ahead of the parent field's tag, so a test
asserts the exact XML bytes.

**The GET/HEAD header block was duplicated 3× and had already drifted.** It moves
to `objectResponseHeaders`, and `resolveTaskCompletion` returns the object and
body it synthesized rather than a finished response. Its clock-gate branch
returned a `NoSuchKey` byte-identical to `getObject`'s own, so that case collapses
into `handled=false`, and the synthesized completion record becomes rangeable like
any other object. Two behaviour changes fall out, logged under **Fixed**: HEAD now
reports `x-amz-version-id` (GET always did, so a caller had to download a body to
learn which version it had just described), and both now advertise
`Accept-Ranges: bytes`.

## The trap worth flagging in review

`Content-Length` is overwritten on a 206 rather than left to the server.
`server.writeResponse` only *defaults* Content-Length when the plugin supplied
none, and the object header block always supplies `obj.Size` — so a short body
would ship under a full-object length and hang SDK clients. A test asserts
`Content-Length` equals the bytes actually written on **every** 206.

The body slice is clamped against the body actually read, because `getObject`'s
fallback path can return fewer bytes than the recorded `Size`. That pre-existing
drift already made `Content-Length` lie; the clamp keeps it from panicking too,
rather than papering over it.

## Out of scope

Retrieving a part by `?partNumber=N` is unrouted today and needs per-part byte
boundaries persisted on `S3Object` — which `completeMultipartUpload` currently
deletes. Noted in the docs as unimplemented; separate issue if wanted.

## Verification

`go build`, `go vet`, `golangci-lint run ./...` (0 issues), `make test` (race),
`test/e2e`, and `make docs-reference-check` all pass locally. New
`emulator/s3_range_test.go` covers all 15 table rows above plus the
Content-Length desync guard, ETag/Last-Modified identity between 200 and 206,
range+versionId, zero-byte objects, HEAD+Range, case-folded header lookup, a
ranged read of a synthesized completion record, and exact-bytes assertions on the
new error XML.
