### PR TITLE
feat(s3): validate the parts list on CompleteMultipartUpload (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Content-Range: bytes */<size>` header so a caller can correct the request
   without a second round trip. Every range against a zero-byte object is
   unsatisfiable. Retrieving a part by `?partNumber=N` remains unimplemented.
+- S3 `CompleteMultipartUpload` validates the parts list before assembling
+  anything (#400). A non-final part below S3's 5 MB minimum is now
+  `400 EntityTooSmall`, carrying the offending `<PartNumber>`, its `<ETag>`,
+  `<ProposedSize>` and `<MinSizeAllowed>`; a part that was never uploaded or whose
+  supplied `ETag` does not match the stored one is `400 InvalidPart`; a body naming
+  no parts is `400 MalformedXML` rather than `InvalidPart`; and an upload ID
+  presented against a different bucket or key is `404 NoSuchUpload`, matching the
+  guard `UploadPart` and `AbortMultipartUpload` already applied.
+  A consumer computing chunk sizes from a file size can land under 5 MB and have
+  every upload in that band fail at Complete on real S3 — after every part has
+  been uploaded and paid for. Substrate accepted those uploads, so the only thing
+  holding the size floor correct was a unit test asserting the consumer's own
+  arithmetic against itself.
+  Equally important is what a rejected Complete does *not* do: it writes no
+  object, and it leaves the upload open, so `ListMultipartUploads` still reports it
+  until `AbortMultipartUpload` ends it. "No orphan upload was left behind after a
+  failed Complete" is thereby a property a test can assert by observing the
+  emulator, rather than by asserting the consumer called Abort — orphaned parts
+  bill indefinitely.
+  ETags are compared ignoring surrounding quotes, hex case, and whitespace, since
+  clients differ on whether they echo back the quotes S3 sends and a false
+  `InvalidPart` would send a consumer hunting a data bug that does not exist.
 
 ### Fixed
+- S3 multipart operations now return S3's documented `NoSuchUpload` and
+  `MalformedXML` message text rather than abbreviated paraphrases (#400).
 - S3 `HeadObject` now reports `x-amz-version-id` (#396). `GetObject` always did,
   so a caller could not learn which version it had just described from a HEAD
   alone — it had to issue a GET and download the body to find out.
@@ -37,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The S3 error-response builder can now carry error-specific child elements and
   response headers (#396), which the `InvalidRange` body needs and which
-  `MinSizeAllowed`/`ProposedSize` (#400) and `StorageClass` (#398) will need. Its
+  `EntityTooSmall` (#400) now uses and `StorageClass` (#398) will need. Its
   `extras ...string` parameter had been an unused stub with no call sites; it is
   replaced by an explicit `s3Error` options struct, and `s3DeleteMarkerResponse`
   now shares the same builder instead of re-declaring its own XML type.

--- a/docs/services.md
+++ b/docs/services.md
@@ -195,7 +195,7 @@ STS operations are free.
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken |
 | CreateMultipartUpload | |
 | UploadPart | |
-| CompleteMultipartUpload | |
+| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation) |
 | AbortMultipartUpload | |
 | ListMultipartUploads | |
 | GetBucketPolicy | |
@@ -242,6 +242,46 @@ Every range against a zero-byte object is unsatisfiable. A `416` body carries
 without a second round trip. Ranges compose with `versionId`.
 
 Retrieving a specific part by `?partNumber=N` is not implemented.
+
+### Multipart upload validation
+
+`CompleteMultipartUpload` validates the parts list before assembling anything, so
+the failure paths a consumer's retry and cleanup code exists to handle are
+reachable:
+
+| Condition | Result |
+|---|---|
+| A part other than the highest-numbered one is under 5 MB (5,242,880 bytes) | `400 EntityTooSmall` |
+| A referenced part was never uploaded | `400 InvalidPart` |
+| A supplied `ETag` does not match the stored part | `400 InvalidPart` |
+| Part numbers not strictly ascending (including duplicates) | `400 InvalidPartOrder` |
+| No `Part` elements, or a body that does not parse | `400 MalformedXML` |
+| `uploadId` unknown, or already completed or aborted | `404 NoSuchUpload` |
+| `uploadId` valid but for a different bucket or key | `404 NoSuchUpload` |
+
+The final part may be any size, including zero, and a single-part upload is exempt
+from the minimum entirely. Supplied ETags are compared ignoring surrounding quotes,
+hex case, and whitespace, since clients differ on whether they echo back the quotes
+S3 sends.
+
+A rejected `CompleteMultipartUpload` writes nothing: no object appears at the key,
+and the upload stays open — `ListMultipartUploads` still reports it until
+`AbortMultipartUpload` (or a successful Complete) ends it. That makes "no orphan
+upload was left behind" a property a test can assert by observing the emulator.
+
+The `EntityTooSmall` body identifies the offending part:
+
+```xml
+<Error>
+  <Code>EntityTooSmall</Code>
+  <Message>Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.</Message>
+  <RequestId>SUBSTRATE</RequestId>
+  <ETag>b6d81b360a5672d80c27430f39153e2c</ETag>
+  <MinSizeAllowed>5242880</MinSizeAllowed>
+  <ProposedSize>1024</ProposedSize>
+  <PartNumber>1</PartNumber>
+</Error>
+```
 
 ### Betty CFN resource types
 

--- a/emulator/s3_multipart_test.go
+++ b/emulator/s3_multipart_test.go
@@ -1,0 +1,390 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// s3MinPartSize mirrors the plugin's non-final part minimum. It is duplicated
+// rather than exported because these tests must fail if the plugin's constant
+// drifts from S3's documented 5 MB, which a shared constant would hide.
+const s3MinPartSize = 5 * 1024 * 1024
+
+// completeBody builds a CompleteMultipartUpload request body naming parts 1..N in
+// order, with the supplied ETags.
+func completeBody(etags ...string) []byte {
+	var b strings.Builder
+	b.WriteString(`<CompleteMultipartUpload>`)
+	for i, etag := range etags {
+		fmt.Fprintf(&b, `<Part><PartNumber>%d</PartNumber><ETag>%s</ETag></Part>`, i+1, etag)
+	}
+	b.WriteString(`</CompleteMultipartUpload>`)
+	return []byte(b.String())
+}
+
+// multipartFixture creates a bucket and initiates a multipart upload in it,
+// returning the server and the upload ID.
+func multipartFixture(t *testing.T, bucket, key string) (*emulator.Server, string) {
+	t.Helper()
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code, "create bucket")
+
+	iw := s3Request(t, srv, http.MethodPost, "/"+bucket+"/"+key+"?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, iw.Code, "initiate multipart upload")
+
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+	require.NotEmpty(t, ir.UploadID)
+
+	return srv, ir.UploadID
+}
+
+// uploadPart uploads one part and returns the ETag the emulator assigned it.
+func uploadPart(t *testing.T, srv *emulator.Server, bucket, key, uploadID string, partNumber int, body []byte) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodPut,
+		fmt.Sprintf("/%s/%s?partNumber=%d&uploadId=%s", bucket, key, partNumber, uploadID),
+		body, nil)
+	require.Equal(t, http.StatusOK, w.Code, "upload part %d", partNumber)
+	etag := w.Header().Get("ETag")
+	require.NotEmpty(t, etag, "UploadPart must return an ETag")
+	return etag
+}
+
+// s3ErrorBody is the parsed form of an S3 <Error> document, including the
+// error-specific child elements EntityTooSmall carries.
+type s3ErrorBody struct {
+	Code           string `xml:"Code"`
+	Message        string `xml:"Message"`
+	ETag           string `xml:"ETag"`
+	MinSizeAllowed string `xml:"MinSizeAllowed"`
+	ProposedSize   string `xml:"ProposedSize"`
+	PartNumber     string `xml:"PartNumber"`
+}
+
+// parseS3Error decodes an S3 XML error response body.
+func parseS3Error(t *testing.T, raw []byte) s3ErrorBody {
+	t.Helper()
+	var e s3ErrorBody
+	require.NoError(t, xml.Unmarshal(raw, &e), "decode error body: %s", raw)
+	return e
+}
+
+// openUploadIDs returns the upload IDs ListMultipartUploads reports for a bucket.
+func openUploadIDs(t *testing.T, srv *emulator.Server, bucket string) []string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "list multipart uploads")
+
+	var result struct {
+		Uploads []struct {
+			UploadID string `xml:"UploadId"`
+		} `xml:"Upload"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+
+	ids := make([]string, 0, len(result.Uploads))
+	for _, u := range result.Uploads {
+		ids = append(ids, u.UploadID)
+	}
+	return ids
+}
+
+// TestS3_CompleteMultipartUpload_EntityTooSmall is the acceptance test for #400:
+// a non-final part below the 5 MB minimum must fail Complete rather than silently
+// assembling an object real S3 would have rejected.
+func TestS3_CompleteMultipartUpload_EntityTooSmall(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "mpu-small", "obj.bin")
+
+	small := bytes.Repeat([]byte("x"), 1024)
+	e1 := uploadPart(t, srv, "mpu-small", "obj.bin", uploadID, 1, small)
+	e2 := uploadPart(t, srv, "mpu-small", "obj.bin", uploadID, 2, []byte("tail"))
+
+	w := s3Request(t, srv, http.MethodPost,
+		"/mpu-small/obj.bin?uploadId="+uploadID, completeBody(e1, e2), nil)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	got := parseS3Error(t, w.Body.Bytes())
+	assert.Equal(t, "EntityTooSmall", got.Code)
+	assert.Contains(t, got.Message, "smaller than the minimum allowed object size")
+	assert.Equal(t, strconv.Itoa(s3MinPartSize), got.MinSizeAllowed)
+	assert.Equal(t, "1024", got.ProposedSize, "ProposedSize must be the offending part's size")
+	assert.Equal(t, "1", got.PartNumber, "PartNumber must identify the offending part")
+	assert.Equal(t, strings.Trim(e1, `"`), got.ETag, "ETag must be the offending part's, unquoted")
+
+	// No object may exist at the key: a rejected Complete assembles nothing.
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodHead, "/mpu-small/obj.bin", nil, nil).Code,
+		"failed Complete must not create the object")
+}
+
+// TestS3_CompleteMultipartUpload_SmallFinalPartSucceeds asserts the exemption that
+// makes the minimum usable: only non-final parts are constrained.
+func TestS3_CompleteMultipartUpload_SmallFinalPartSucceeds(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "mpu-tail", "obj.bin")
+
+	big := bytes.Repeat([]byte("a"), s3MinPartSize)
+	tail := bytes.Repeat([]byte("z"), 1024)
+	e1 := uploadPart(t, srv, "mpu-tail", "obj.bin", uploadID, 1, big)
+	e2 := uploadPart(t, srv, "mpu-tail", "obj.bin", uploadID, 2, tail)
+
+	w := s3Request(t, srv, http.MethodPost,
+		"/mpu-tail/obj.bin?uploadId="+uploadID, completeBody(e1, e2), nil)
+	require.Equal(t, http.StatusOK, w.Code, "1 KiB final part must be allowed: %s", w.Body)
+
+	gw := s3Request(t, srv, http.MethodGet, "/mpu-tail/obj.bin", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Equal(t, append(big, tail...), gw.Body.Bytes())
+}
+
+// TestS3_CompleteMultipartUpload_SinglePartAnySize asserts a single-part upload is
+// exempt from the minimum: it is nothing but its own final part.
+func TestS3_CompleteMultipartUpload_SinglePartAnySize(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{name: "tiny", body: []byte("hi")},
+		{name: "empty", body: []byte{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, uploadID := multipartFixture(t, "mpu-single", "obj.bin")
+			etag := uploadPart(t, srv, "mpu-single", "obj.bin", uploadID, 1, tt.body)
+
+			w := s3Request(t, srv, http.MethodPost,
+				"/mpu-single/obj.bin?uploadId="+uploadID, completeBody(etag), nil)
+			require.Equal(t, http.StatusOK, w.Code, "single part of any size must complete: %s", w.Body)
+
+			gw := s3Request(t, srv, http.MethodGet, "/mpu-single/obj.bin", nil, nil)
+			require.Equal(t, http.StatusOK, gw.Code)
+			assert.Equal(t, string(tt.body), gw.Body.String())
+		})
+	}
+}
+
+// TestS3_CompleteMultipartUpload_FailedCompleteLeavesUploadOpen is the property the
+// issue reporter actually needs: after a rejected Complete the upload is still
+// listed, so a consumer's cleanup path is observable through the API rather than
+// inferred from its own call log. Aborting it then clears the listing.
+func TestS3_CompleteMultipartUpload_FailedCompleteLeavesUploadOpen(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "mpu-orphan", "obj.bin")
+
+	e1 := uploadPart(t, srv, "mpu-orphan", "obj.bin", uploadID, 1, bytes.Repeat([]byte("x"), 1024))
+	e2 := uploadPart(t, srv, "mpu-orphan", "obj.bin", uploadID, 2, []byte("tail"))
+
+	require.Equal(t, []string{uploadID}, openUploadIDs(t, srv, "mpu-orphan"),
+		"upload must be listed before Complete")
+
+	cw := s3Request(t, srv, http.MethodPost,
+		"/mpu-orphan/obj.bin?uploadId="+uploadID, completeBody(e1, e2), nil)
+	require.Equal(t, http.StatusBadRequest, cw.Code)
+
+	assert.Equal(t, []string{uploadID}, openUploadIDs(t, srv, "mpu-orphan"),
+		"a rejected Complete must leave the upload open so it can be retried or aborted")
+
+	aw := s3Request(t, srv, http.MethodDelete, "/mpu-orphan/obj.bin?uploadId="+uploadID, nil, nil)
+	require.Equal(t, http.StatusNoContent, aw.Code)
+
+	assert.Empty(t, openUploadIDs(t, srv, "mpu-orphan"),
+		"Abort must remove the upload from the listing")
+}
+
+// TestS3_CompleteMultipartUpload_SuccessfulCompleteClosesUpload is the companion to
+// the failure case: a successful Complete also ends the upload.
+func TestS3_CompleteMultipartUpload_SuccessfulCompleteClosesUpload(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "mpu-closed", "obj.bin")
+	etag := uploadPart(t, srv, "mpu-closed", "obj.bin", uploadID, 1, []byte("payload"))
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPost,
+		"/mpu-closed/obj.bin?uploadId="+uploadID, completeBody(etag), nil).Code)
+
+	assert.Empty(t, openUploadIDs(t, srv, "mpu-closed"))
+
+	// A second Complete on the same upload ID is now NoSuchUpload, per the
+	// documented "might have been aborted or completed" case.
+	w := s3Request(t, srv, http.MethodPost,
+		"/mpu-closed/obj.bin?uploadId="+uploadID, completeBody(etag), nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "NoSuchUpload", parseS3Error(t, w.Body.Bytes()).Code)
+}
+
+// TestS3_CompleteMultipartUpload_InvalidPart covers the two conditions S3 reports
+// identically: a part that was never uploaded, and a part whose supplied ETag does
+// not match the stored one.
+func TestS3_CompleteMultipartUpload_InvalidPart(t *testing.T) {
+	tests := []struct {
+		name string
+		// body builds the Complete request from the ETag of the one uploaded part.
+		body func(etag string) []byte
+	}{
+		{
+			name: "part never uploaded",
+			body: func(etag string) []byte {
+				return []byte(`<CompleteMultipartUpload>` +
+					`<Part><PartNumber>1</PartNumber><ETag>` + etag + `</ETag></Part>` +
+					`<Part><PartNumber>7</PartNumber><ETag>"d41d8cd98f00b204e9800998ecf8427e"</ETag></Part>` +
+					`</CompleteMultipartUpload>`)
+			},
+		},
+		{
+			name: "etag does not match stored part",
+			body: func(string) []byte {
+				return completeBody(`"00000000000000000000000000000000"`)
+			},
+		},
+		{
+			name: "etag empty",
+			body: func(string) []byte { return completeBody("") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, uploadID := multipartFixture(t, "mpu-invalid", "obj.bin")
+			etag := uploadPart(t, srv, "mpu-invalid", "obj.bin", uploadID, 1,
+				bytes.Repeat([]byte("a"), s3MinPartSize))
+
+			w := s3Request(t, srv, http.MethodPost,
+				"/mpu-invalid/obj.bin?uploadId="+uploadID, tt.body(etag), nil)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+
+			got := parseS3Error(t, w.Body.Bytes())
+			assert.Equal(t, "InvalidPart", got.Code)
+			assert.Contains(t, got.Message, "could not be found")
+
+			assert.Equal(t, http.StatusNotFound,
+				s3Request(t, srv, http.MethodHead, "/mpu-invalid/obj.bin", nil, nil).Code,
+				"rejected Complete must not create the object")
+			assert.Equal(t, []string{uploadID}, openUploadIDs(t, srv, "mpu-invalid"),
+				"rejected Complete must leave the upload open")
+		})
+	}
+}
+
+// TestS3_CompleteMultipartUpload_ETagQuotingIgnored asserts that quoting and hex
+// case do not decide validity. Clients differ on whether they echo back the quotes
+// S3 sends, and a false InvalidPart over quoting would send a consumer hunting a
+// data bug that does not exist.
+func TestS3_CompleteMultipartUpload_ETagQuotingIgnored(t *testing.T) {
+	tests := []struct {
+		name string
+		form func(etag string) string
+	}{
+		{name: "as returned", form: func(e string) string { return e }},
+		{name: "unquoted", form: func(e string) string { return strings.Trim(e, `"`) }},
+		{name: "uppercase hex", form: strings.ToUpper},
+		{name: "surrounding whitespace", form: func(e string) string { return " " + e + " " }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, uploadID := multipartFixture(t, "mpu-etag", "obj.bin")
+			etag := uploadPart(t, srv, "mpu-etag", "obj.bin", uploadID, 1, []byte("payload"))
+
+			w := s3Request(t, srv, http.MethodPost,
+				"/mpu-etag/obj.bin?uploadId="+uploadID, completeBody(tt.form(etag)), nil)
+			assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body)
+		})
+	}
+}
+
+// TestS3_CompleteMultipartUpload_InvalidPartOrder asserts the parts list must be
+// ascending. An ordering bug in a consumer that assembles the list concurrently is
+// silent data corruption, so this must be an error rather than a sort.
+func TestS3_CompleteMultipartUpload_InvalidPartOrder(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "mpu-order", "obj.bin")
+
+	big := bytes.Repeat([]byte("a"), s3MinPartSize)
+	e1 := uploadPart(t, srv, "mpu-order", "obj.bin", uploadID, 1, big)
+	e2 := uploadPart(t, srv, "mpu-order", "obj.bin", uploadID, 2, []byte("tail"))
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "descending",
+			body: `<CompleteMultipartUpload>` +
+				`<Part><PartNumber>2</PartNumber><ETag>` + e2 + `</ETag></Part>` +
+				`<Part><PartNumber>1</PartNumber><ETag>` + e1 + `</ETag></Part>` +
+				`</CompleteMultipartUpload>`,
+		},
+		{
+			name: "duplicate part number",
+			body: `<CompleteMultipartUpload>` +
+				`<Part><PartNumber>1</PartNumber><ETag>` + e1 + `</ETag></Part>` +
+				`<Part><PartNumber>1</PartNumber><ETag>` + e1 + `</ETag></Part>` +
+				`</CompleteMultipartUpload>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodPost,
+				"/mpu-order/obj.bin?uploadId="+uploadID, []byte(tt.body), nil)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+
+			got := parseS3Error(t, w.Body.Bytes())
+			assert.Equal(t, "InvalidPartOrder", got.Code)
+			assert.Contains(t, got.Message, "ascending order")
+		})
+	}
+}
+
+// TestS3_CompleteMultipartUpload_MalformedXML asserts that a body carrying no
+// usable part list is a 400, whether it fails to parse or simply names no parts.
+func TestS3_CompleteMultipartUpload_MalformedXML(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{name: "not well-formed", body: []byte(`<CompleteMultipartUpload><Part>`)},
+		{name: "no parts", body: []byte(`<CompleteMultipartUpload></CompleteMultipartUpload>`)},
+		{name: "empty body", body: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, uploadID := multipartFixture(t, "mpu-xml", "obj.bin")
+			uploadPart(t, srv, "mpu-xml", "obj.bin", uploadID, 1, []byte("payload"))
+
+			w := s3Request(t, srv, http.MethodPost,
+				"/mpu-xml/obj.bin?uploadId="+uploadID, tt.body, nil)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Equal(t, "MalformedXML", parseS3Error(t, w.Body.Bytes()).Code)
+		})
+	}
+}
+
+// TestS3_CompleteMultipartUpload_WrongBucketOrKey asserts an upload ID is only
+// valid against the bucket and key it was created for, matching the guard uploadPart
+// and abortMultipartUpload already applied.
+func TestS3_CompleteMultipartUpload_WrongBucketOrKey(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "mpu-owner", "right.bin")
+	etag := uploadPart(t, srv, "mpu-owner", "right.bin", uploadID, 1, []byte("payload"))
+
+	w := s3Request(t, srv, http.MethodPost,
+		"/mpu-owner/wrong.bin?uploadId="+uploadID, completeBody(etag), nil)
+	require.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "NoSuchUpload", parseS3Error(t, w.Body.Bytes()).Code)
+
+	// The upload survives the mismatched request and still completes correctly.
+	assert.Equal(t, []string{uploadID}, openUploadIDs(t, srv, "mpu-owner"))
+	assert.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPost,
+		"/mpu-owner/right.bin?uploadId="+uploadID, completeBody(etag), nil).Code)
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -22,6 +22,16 @@ import (
 // s3Namespace is the state namespace used by S3Plugin.
 const s3Namespace = "s3"
 
+// Error messages S3 returns verbatim from more than one operation.
+const (
+	// s3NoSuchUploadMessage accompanies NoSuchUpload from every multipart operation.
+	s3NoSuchUploadMessage = "The specified multipart upload does not exist. The upload ID might be invalid, " +
+		"or the multipart upload might have been aborted or completed."
+
+	// s3MalformedXMLMessage accompanies MalformedXML.
+	s3MalformedXMLMessage = "The XML you provided was not well-formed or did not validate against our published schema."
+)
+
 // S3Plugin emulates the AWS Simple Storage Service (S3) REST API.
 // It handles CreateBucket, HeadBucket, DeleteBucket, ListBuckets,
 // PutObject, GetObject, HeadObject, DeleteObject, CopyObject,
@@ -759,7 +769,7 @@ func (p *S3Plugin) deleteObjects(reqCtx *RequestContext, req *AWSRequest, bucket
 	var deleteReq deleteRequest
 	if len(req.Body) > 0 {
 		if xmlErr := xml.Unmarshal(req.Body, &deleteReq); xmlErr != nil {
-			return s3ErrorResponse("MalformedXML", "The XML you provided was not well-formed.", http.StatusBadRequest), nil //nolint:nilerr
+			return s3ErrorResponse("MalformedXML", s3MalformedXMLMessage, http.StatusBadRequest), nil //nolint:nilerr
 		}
 	}
 
@@ -1169,7 +1179,7 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		return nil, fmt.Errorf("get upload metadata: %w", err)
 	}
 	if uploadData == nil {
-		return s3ErrorResponse("NoSuchUpload", "The specified upload does not exist.", http.StatusNotFound), nil
+		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
 	}
 
 	var upload S3MultipartUpload
@@ -1177,7 +1187,7 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		return nil, fmt.Errorf("unmarshal upload metadata: %w", err)
 	}
 	if upload.Bucket != bucket || upload.Key != key {
-		return s3ErrorResponse("NoSuchUpload", "The specified upload does not exist.", http.StatusNotFound), nil
+		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
 	}
 
 	body := decodeAWSChunked(req.Headers, req.Body)
@@ -1212,6 +1222,24 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 	}, nil
 }
 
+// s3MinPartSize is the minimum size in bytes of every part in a multipart upload
+// except the highest-numbered one. S3 rejects a Complete request whose non-final
+// parts are smaller with 400 EntityTooSmall — after the parts have already been
+// uploaded, which is why a consumer needs that failure path to be reachable.
+const s3MinPartSize = 5 * 1024 * 1024
+
+// s3CompletePart is one <Part> entry of a CompleteMultipartUpload request body.
+type s3CompletePart struct {
+	PartNumber int    `xml:"PartNumber"`
+	ETag       string `xml:"ETag"`
+}
+
+// s3CompleteMultipartUploadRequest is the body of a CompleteMultipartUpload
+// request: the caller's assertion of which parts make up the object.
+type s3CompleteMultipartUploadRequest struct {
+	Parts []s3CompletePart `xml:"Part"`
+}
+
 // completeMultipartUpload handles POST /<bucket>/<key>?uploadId=ID.
 func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, bucket, key string) (*AWSResponse, error) {
 	ctx := context.Background()
@@ -1223,62 +1251,60 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		return nil, fmt.Errorf("get upload metadata: %w", err)
 	}
 	if uploadData == nil {
-		return s3ErrorResponse("NoSuchUpload", "The specified upload does not exist.", http.StatusNotFound), nil
+		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
 	}
 
 	var upload S3MultipartUpload
 	if err := json.Unmarshal(uploadData, &upload); err != nil {
 		return nil, fmt.Errorf("unmarshal upload metadata: %w", err)
 	}
-
-	type partRef struct {
-		PartNumber int    `xml:"PartNumber"`
-		ETag       string `xml:"ETag"`
-	}
-	type completeReq struct {
-		Parts []partRef `xml:"Part"`
+	if upload.Bucket != bucket || upload.Key != key {
+		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
 	}
 
-	var cReq completeReq
+	var cReq s3CompleteMultipartUploadRequest
 	xmlErr := xml.Unmarshal(req.Body, &cReq)
 	if xmlErr != nil {
-		return s3ErrorResponse("MalformedXML", "The XML you provided was not well-formed.", http.StatusBadRequest), nil //nolint:nilerr // intentionally converted to S3 XML error response
+		return s3ErrorResponse("MalformedXML", s3MalformedXMLMessage, http.StatusBadRequest), nil //nolint:nilerr // intentionally converted to S3 XML error response
 	}
 	if len(cReq.Parts) == 0 {
-		return s3ErrorResponse("InvalidPart", "One or more of the specified parts could not be found.", http.StatusBadRequest), nil
+		// "If you do not supply a valid Part with your request, the service sends
+		// back an HTTP 400 response" — the body parsed, but not into a part list.
+		return s3ErrorResponse("MalformedXML", s3MalformedXMLMessage, http.StatusBadRequest), nil
 	}
 
 	for i := 1; i < len(cReq.Parts); i++ {
 		if cReq.Parts[i].PartNumber <= cReq.Parts[i-1].PartNumber {
-			return s3ErrorResponse("InvalidPartOrder", "The list of parts was not in ascending order.", http.StatusBadRequest), nil
+			return s3ErrorResponse("InvalidPartOrder",
+				"The list of parts was not in ascending order. The parts list must be specified in order by part number.",
+				http.StatusBadRequest), nil
 		}
+	}
+
+	parts, errResp, err := p.validateCompleteParts(ctx, uploadID, cReq.Parts)
+	if err != nil {
+		return nil, err
+	}
+	if errResp != nil {
+		return errResp, nil
 	}
 
 	// Concatenate parts and compute multi-part ETag.
 	var combined []byte
 	var partMD5s []byte
 
-	for _, pr := range cReq.Parts {
-		partKey := fmt.Sprintf("part:%s/%d", uploadID, pr.PartNumber)
-		partData, getErr := p.state.Get(ctx, s3Namespace, partKey)
-		if getErr != nil {
-			return nil, fmt.Errorf("get part %d metadata: %w", pr.PartNumber, getErr)
-		}
-		if partData == nil {
-			return s3ErrorResponse("InvalidPart", fmt.Sprintf("Part %d not found.", pr.PartNumber), http.StatusBadRequest), nil
-		}
-
-		partPath := fmt.Sprintf("/.multipart/%s/%d", uploadID, pr.PartNumber)
+	for _, part := range parts {
+		partPath := fmt.Sprintf("/.multipart/%s/%d", uploadID, part.PartNumber)
 		partBody, readErr := afero.ReadFile(p.fs, partPath)
 		if readErr != nil {
-			return nil, fmt.Errorf("read part %d body: %w", pr.PartNumber, readErr)
+			return nil, fmt.Errorf("read part %d body: %w", part.PartNumber, readErr)
 		}
 		combined = append(combined, partBody...)
 		h := md5.Sum(partBody) //nolint:gosec // nosemgrep
 		partMD5s = append(partMD5s, h[:]...)
 	}
 
-	numParts := len(cReq.Parts)
+	numParts := len(parts)
 	combinedHash := md5.Sum(partMD5s) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x-%d"`, combinedHash, numParts)
 
@@ -1329,6 +1355,91 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 	})
 }
 
+// validateCompleteParts resolves each part named in a CompleteMultipartUpload
+// request against the parts actually uploaded, and applies the two validations
+// that can only be made once the stored parts are known: the ETag must match, and
+// every part except the highest-numbered one must be at least [s3MinPartSize].
+//
+// It returns the resolved parts in request order on success. A non-nil
+// *AWSResponse is the S3 error to return; a non-nil error is an internal failure.
+// It writes nothing, so a rejected Complete leaves the upload open for the caller
+// to retry or abort — which is the observation a consumer testing its cleanup path
+// depends on.
+//
+// Existence and ETag are checked across all parts before any size check, because
+// the size of a part that was never uploaded is not a meaningful complaint.
+func (p *S3Plugin) validateCompleteParts(ctx context.Context, uploadID string, refs []s3CompletePart) ([]S3Part, *AWSResponse, error) {
+	if len(refs) == 0 {
+		// The caller rejects an empty list as MalformedXML before reaching here;
+		// this keeps the final-part exemption below from indexing an empty slice.
+		return nil, s3ErrorResponse("MalformedXML", s3MalformedXMLMessage, http.StatusBadRequest), nil
+	}
+
+	parts := make([]S3Part, 0, len(refs))
+	for _, ref := range refs {
+		partData, err := p.state.Get(ctx, s3Namespace, fmt.Sprintf("part:%s/%d", uploadID, ref.PartNumber))
+		if err != nil {
+			return nil, nil, fmt.Errorf("get part %d metadata: %w", ref.PartNumber, err)
+		}
+		if partData == nil {
+			return nil, s3InvalidPartResponse(), nil
+		}
+		var part S3Part
+		if err := json.Unmarshal(partData, &part); err != nil {
+			return nil, nil, fmt.Errorf("unmarshal part %d metadata: %w", ref.PartNumber, err)
+		}
+		if !s3ETagsEqual(ref.ETag, part.ETag) {
+			return nil, s3InvalidPartResponse(), nil
+		}
+		parts = append(parts, part)
+	}
+
+	// The parts list is already known to be in ascending order, so the final
+	// entry is the highest-numbered part and is exempt from the minimum — as is
+	// a single-part upload, which is nothing but its own final part.
+	for _, part := range parts[:len(parts)-1] {
+		if part.Size >= s3MinPartSize {
+			continue
+		}
+		return nil, s3ErrorResponseWith(s3Error{
+			Code:    "EntityTooSmall",
+			Message: "Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.",
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{
+				{Name: "ETag", Value: strings.Trim(part.ETag, `"`)},
+				{Name: "MinSizeAllowed", Value: strconv.Itoa(s3MinPartSize)},
+				{Name: "ProposedSize", Value: strconv.FormatInt(part.Size, 10)},
+				{Name: "PartNumber", Value: strconv.Itoa(part.PartNumber)},
+			},
+		}), nil
+	}
+
+	return parts, nil, nil
+}
+
+// s3InvalidPartResponse builds the 400 InvalidPart response shared by a part that
+// was never uploaded and a part whose supplied ETag does not match the stored
+// one. S3 does not distinguish the two cases, and neither does the message.
+func s3InvalidPartResponse() *AWSResponse {
+	return s3ErrorResponse("InvalidPart",
+		"One or more of the specified parts could not be found. The part might not have been uploaded, "+
+			"or the specified ETag might not have matched the uploaded part's ETag.",
+		http.StatusBadRequest)
+}
+
+// s3ETagsEqual reports whether a client-supplied part ETag matches a stored one,
+// ignoring differences in quoting and hex case. An ETag is an opaque token, but
+// clients vary in whether they echo back the surrounding quotes S3 sends, and
+// rejecting an otherwise-correct ETag over quoting would be a false InvalidPart.
+func s3ETagsEqual(supplied, stored string) bool {
+	normalize := func(s string) string {
+		s = strings.TrimSpace(s)
+		s = strings.TrimPrefix(s, "W/")
+		return strings.ToLower(strings.Trim(s, `"`))
+	}
+	return normalize(supplied) == normalize(stored)
+}
+
 // abortMultipartUpload handles DELETE /<bucket>/<key>?uploadId=ID.
 func (p *S3Plugin) abortMultipartUpload(_ *RequestContext, req *AWSRequest, bucket, key string) (*AWSResponse, error) {
 	ctx := context.Background()
@@ -1340,7 +1451,7 @@ func (p *S3Plugin) abortMultipartUpload(_ *RequestContext, req *AWSRequest, buck
 		return nil, fmt.Errorf("get upload metadata: %w", err)
 	}
 	if uploadData == nil {
-		return s3ErrorResponse("NoSuchUpload", "The specified upload does not exist.", http.StatusNotFound), nil
+		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
 	}
 
 	var upload S3MultipartUpload
@@ -1348,7 +1459,7 @@ func (p *S3Plugin) abortMultipartUpload(_ *RequestContext, req *AWSRequest, buck
 		return nil, fmt.Errorf("unmarshal upload metadata: %w", err)
 	}
 	if upload.Bucket != bucket || upload.Key != key {
-		return s3ErrorResponse("NoSuchUpload", "The specified upload does not exist.", http.StatusNotFound), nil
+		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
 	}
 
 	_ = p.state.Delete(ctx, s3Namespace, "multipart:"+uploadID)
@@ -2273,7 +2384,7 @@ type s3Tagging struct {
 func (p *S3Plugin) putBucketTagging(_ *RequestContext, req *AWSRequest, bucket string) (*AWSResponse, error) {
 	var tagging s3Tagging
 	if err := xml.Unmarshal(req.Body, &tagging); err != nil {
-		return s3ErrorResponse("MalformedXML", "The XML you provided was not well-formed.", http.StatusBadRequest), nil //nolint:nilerr // intentionally converted to S3 XML error response
+		return s3ErrorResponse("MalformedXML", s3MalformedXMLMessage, http.StatusBadRequest), nil //nolint:nilerr // intentionally converted to S3 XML error response
 	}
 	ctx := context.Background()
 	data, err := p.state.Get(ctx, s3Namespace, "bucket:"+bucket)
@@ -2339,7 +2450,7 @@ func (p *S3Plugin) deleteBucketTagging(_ *RequestContext, _ *AWSRequest, bucket 
 func (p *S3Plugin) putObjectTagging(_ *RequestContext, req *AWSRequest, bucket, key string) (*AWSResponse, error) {
 	var tagging s3Tagging
 	if err := xml.Unmarshal(req.Body, &tagging); err != nil {
-		return s3ErrorResponse("MalformedXML", "The XML you provided was not well-formed.", http.StatusBadRequest), nil //nolint:nilerr // intentionally converted to S3 XML error response
+		return s3ErrorResponse("MalformedXML", s3MalformedXMLMessage, http.StatusBadRequest), nil //nolint:nilerr // intentionally converted to S3 XML error response
 	}
 	ctx := context.Background()
 	stateKey := "object:" + bucket + "/" + key

--- a/emulator/s3_plugin_test.go
+++ b/emulator/s3_plugin_test.go
@@ -342,12 +342,18 @@ func TestS3_MultipartUpload_Complete(t *testing.T) {
 
 	uploadID := ir.UploadId
 
-	// Upload two parts.
-	for i, part := range [][]byte{[]byte("part one data"), []byte("part two data")} {
+	// Upload two parts. The first is non-final and so must reach the 5 MB
+	// minimum; the last may be any size.
+	first := bytes.Repeat([]byte("a"), s3MinPartSize)
+	second := []byte("part two data")
+	etags := make([]string, 0, 2)
+	for i, part := range [][]byte{first, second} {
 		uw := s3Request(t, srv, http.MethodPut,
 			fmt.Sprintf("/my-bucket/bigfile.bin?partNumber=%d&uploadId=%s", i+1, uploadID),
 			part, nil)
 		require.Equal(t, http.StatusOK, uw.Code)
+		etags = append(etags, uw.Header().Get("ETag"))
+		require.NotEmpty(t, etags[i], "UploadPart must return an ETag")
 	}
 
 	// List multipart uploads.
@@ -356,20 +362,16 @@ func TestS3_MultipartUpload_Complete(t *testing.T) {
 	assert.Contains(t, lw.Body.String(), uploadID)
 
 	// Complete.
-	completeBody := `<CompleteMultipartUpload>` +
-		`<Part><PartNumber>1</PartNumber><ETag>e1</ETag></Part>` +
-		`<Part><PartNumber>2</PartNumber><ETag>e2</ETag></Part>` +
-		`</CompleteMultipartUpload>`
 	cw := s3Request(t, srv, http.MethodPost,
 		"/my-bucket/bigfile.bin?uploadId="+uploadID,
-		[]byte(completeBody), nil)
+		completeBody(etags...), nil)
 	require.Equal(t, http.StatusOK, cw.Code)
 	assert.Contains(t, cw.Body.String(), "CompleteMultipartUploadResult")
 
 	// Verify assembled object is readable.
 	gw := s3Request(t, srv, http.MethodGet, "/my-bucket/bigfile.bin", nil, nil)
 	require.Equal(t, http.StatusOK, gw.Code)
-	assert.Equal(t, []byte("part one datapart two data"), gw.Body.Bytes())
+	assert.Equal(t, append(first, second...), gw.Body.Bytes())
 }
 
 func TestS3_MultipartUpload_Abort(t *testing.T) {
@@ -1126,10 +1128,9 @@ func TestS3_MultipartUpload_UserMetadata(t *testing.T) {
 	require.Equal(t, http.StatusOK, uw.Code)
 
 	// Complete the upload.
-	completeBody := `<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>e1</ETag></Part></CompleteMultipartUpload>`
 	cw := s3Request(t, srv, http.MethodPost,
 		"/meta-bucket/upload.bin?uploadId="+ir.UploadId,
-		[]byte(completeBody), nil)
+		completeBody(uw.Header().Get("ETag")), nil)
 	require.Equal(t, http.StatusOK, cw.Code)
 
 	// HEAD the object — metadata must be present.


### PR DESCRIPTION
Closes #400.

`completeMultipartUpload` assembled whatever parts it was handed. `EntityTooSmall` appeared nowhere in the repo, and the `ETag` in each `<Part>` was parsed into a struct field that was never read.

## What this changes

| Condition | Before | After |
|---|---|---|
| Non-final part under 5,242,880 bytes | `200` | `400 EntityTooSmall` |
| Part never uploaded | `400 InvalidPart` | unchanged |
| Supplied `ETag` ≠ stored part `ETag` | `200` | `400 InvalidPart` |
| Part numbers not strictly ascending | `400 InvalidPartOrder` | unchanged |
| No `Part` elements | `400 InvalidPart` | `400 MalformedXML` |
| `uploadId` valid but wrong bucket/key | `200`, object written under the wrong key | `404 NoSuchUpload` |

The last part is exempt from the minimum and may be zero bytes; a single-part upload is nothing but its own final part, so it is exempt too.

The `EntityTooSmall` body carries the offending `<PartNumber>`, its `<ETag>`, `<ProposedSize>` and `<MinSizeAllowed>` — the capability #396 added to the error builder, which is why this was sequenced after it.

## Why the failure path matters more than the validation

A consumer computing multipart chunk sizes from a file size can land under 5 MB and have every upload in that band fail at Complete on real S3 — after every part has been uploaded and paid for. Substrate accepted those uploads, so the only thing holding such a consumer’s size floor correct was a unit test asserting its own arithmetic against itself.

Just as important is what a rejected Complete does **not** do. It writes no object and leaves the upload open, so `ListMultipartUploads` still reports it until `AbortMultipartUpload` ends it. That makes *no orphan upload was left behind after a failed Complete* a property a test can assert by observing the emulator, rather than by asserting the consumer called Abort. Orphaned parts bill indefinitely, and the issue reporter is fixing exactly that leak.

## Details worth a second look

- **ETag comparison ignores quoting, hex case and whitespace.** An ETag is opaque, but clients differ on whether they echo back the quotes S3 sends, and a false `InvalidPart` over quoting would send a consumer hunting a data bug that does not exist. Covered by a 4-case table test.
- **Existence and ETag are checked across all parts before any size check** — the size of a part that was never uploaded is not a meaningful complaint.
- **Zero parts is `MalformedXML`, not `InvalidPart`.** Per the API reference: "If you do not supply a valid `Part` with your request, the service sends back an HTTP 400 response." The old `InvalidPart` was a 400 too, so this changes the code, not the status.
- **Error codes, messages and statuses are verbatim from the AWS CompleteMultipartUpload API reference**, which also replaced the abbreviated `NoSuchUpload` / `MalformedXML` paraphrases used across the plugin. No test asserted the old strings.
- `validateCompleteParts` returns `([]S3Part, *AWSResponse, error)`: the third value is an internal failure, the second is an S3 error to serve. It writes nothing.

## Test changes

`TestS3_MultipartUpload_Complete` completed two 13-byte parts with the made-up ETags `e1`/`e2`; it now uses a 5 MB first part and the ETags `UploadPart` actually returned, as a real client would. `TestS3_MultipartUpload_UserMetadata` likewise dropped its `e1`.

New `emulator/s3_multipart_test.go` covers the three acceptance criteria from the issue (1 KiB first part of two → `EntityTooSmall` **and** no object at the key; 1 KiB *final* part succeeds; the upload is still listed after the failed Complete and gone after Abort) plus the `InvalidPart`, `InvalidPartOrder`, `MalformedXML`, ETag-quoting, wrong-bucket/key, and complete-then-`NoSuchUpload` cases.

## Verification

`make test` (race), `golangci-lint run ./...` (0 issues), `go vet ./...`, `test/e2e`, `make docs-reference-check` — all green. `docs/services.md` gains a *Multipart upload validation* section with the condition table and the `EntityTooSmall` body.