### PR TITLE
feat(s3): honor conditional request headers on reads and writes (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ETags are compared ignoring surrounding quotes, hex case, and whitespace, since
   clients differ on whether they echo back the quotes S3 sends and a false
   `InvalidPart` would send a consumer hunting a data bug that does not exist.
+- S3 conditional requests: `If-Match`, `If-None-Match`, `If-Modified-Since` and
+  `If-Unmodified-Since` (#397). All four were previously ignored, which is the worst
+  possible outcome for the pattern they exist to serve: a consumer using
+  `If-None-Match: *` to claim a lock, elect a leader, or refuse to clobber a
+  checkpoint got a `200` every time, so its lost-race branch was unreachable and its
+  tests passed while proving the opposite of the intended invariant.
+  - **Writes.** `PutObject`, `CopyObject` and `CompleteMultipartUpload` evaluate
+    `If-None-Match` and `If-Match` against the current version of the destination
+    key. `If-None-Match: *` is `412 PreconditionFailed` when the key exists;
+    `If-Match` is `412` on an ETag mismatch and `404 NoSuchKey` when the key is
+    absent — not a `412`, since there is no ETag to compare. A delete marker counts
+    as absent for both, per the conditional-writes reference. An `If-None-Match`
+    value other than `*` is rejected rather than ignored, so a header sent to
+    prevent an overwrite can never silently permit one.
+    A rejected write is a no-op: the stored object is byte-identical afterwards, and
+    a rejected `CompleteMultipartUpload` leaves its upload open to be aborted.
+  - **Exactly one winner.** N concurrent `If-None-Match: *` PUTs to one key produce
+    exactly one `200` and N-1 `412`s, as do N concurrent `If-Match` PUTs asserting
+    the same ETag. `StateManager` has no compare-and-swap and `MemoryStateManager`
+    is last-write-wins, so this required a per-key mutex held across the existence
+    check and the write; without it 23 of 32 concurrent writers won. The guarantee
+    is **process-local** — airtight for substrate's single-process topology, but it
+    would not hold across two emulator processes sharing one state backend, and that
+    limit is documented rather than papered over.
+  - **Reads.** `GetObject` and `HeadObject` evaluate all four preconditions
+    *before* the `Range` step, so a failed precondition is reported rather than a
+    partial response served from an entity the caller did not ask for. A matching
+    `If-None-Match` is `304 Not Modified` with no body and the `ETag` echoed; a
+    failed `If-Match` or `If-Unmodified-Since` is `412`. Both combination rules
+    from the `GetObject` reference are implemented: `If-Match` true with
+    `If-Unmodified-Since` false is `200`, and `If-None-Match` false with
+    `If-Modified-Since` true is `304`.
+  - **Copies.** `CopyObject` additionally honors the four `x-amz-copy-source-if-*`
+    headers, which gate reading the source rather than overwriting the destination;
+    both sets may appear on one request and both are checked before anything is
+    written. A failed copy-source condition is always `412`, including where the
+    equivalent GET would be `304`.
+  - ETag comparison ignores quoting, `W/` prefixes, hex case and whitespace, and a
+    comma-separated list matches if any member does. An unparseable date makes its
+    condition inapplicable rather than failed (per RFC 9110), so a client with a
+    broken date formatter never sees a spurious `412`; all three date formats RFC
+    9110 requires a recipient to accept are parsed. An empty header value is a
+    condition that cannot be met, distinct from an absent header.
+  - Not emulated, deliberately: the `409 ConditionalRequestConflict` and the
+    concurrent-delete `404` that real S3 can return, both of which are races against
+    wall-clock timing rather than states a deterministic emulator can reach.
 
 ### Fixed
 - S3 multipart operations now return S3's documented `NoSuchUpload` and

--- a/docs/services.md
+++ b/docs/services.md
@@ -186,16 +186,16 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers |
-| GetObject | Supports Range header — see [Ranged reads](#ranged-reads) |
-| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads) |
+| PutObject | Supports Content-Type, metadata headers; conditional writes — see [Conditional requests](#conditional-requests) |
+| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests) |
+| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests) |
 | DeleteObject | Fires S3 notifications if configured |
-| CopyObject | |
+| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests) |
 | ListObjects | |
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken |
 | CreateMultipartUpload | |
 | UploadPart | |
-| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation) |
+| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests) |
 | AbortMultipartUpload | |
 | ListMultipartUploads | |
 | GetBucketPolicy | |
@@ -242,6 +242,87 @@ Every range against a zero-byte object is unsatisfiable. A `416` body carries
 without a second round trip. Ranges compose with `versionId`.
 
 Retrieving a specific part by `?partNumber=N` is not implemented.
+
+### Conditional requests
+
+#### Conditional writes
+
+`PutObject`, `CopyObject` and `CompleteMultipartUpload` honor `If-None-Match` and
+`If-Match`, evaluated against the current version of the destination key:
+
+| Header | Destination state | Result |
+|---|---|---|
+| `If-None-Match: *` | Key absent | `200` — the write proceeds |
+| `If-None-Match: *` | Key present | `412 PreconditionFailed` |
+| `If-None-Match: *` | Current version is a delete marker | `200` — a delete marker is not an object |
+| `If-None-Match: <anything but *>` | Any | `412 PreconditionFailed` — S3 expects only `*` on a write |
+| `If-Match: "<etag>"` | ETag matches | `200` — the write proceeds |
+| `If-Match: "<etag>"` | ETag differs | `412 PreconditionFailed` |
+| `If-Match: "<etag>"` | Key absent, or the current version is a delete marker | `404 NoSuchKey` |
+
+A rejected conditional write is a no-op: the stored object is byte-identical
+afterwards — body, ETag, size, `Content-Type` and user metadata all unchanged — and
+a rejected `CompleteMultipartUpload` additionally leaves its upload open to be
+retried or aborted.
+
+**Concurrency.** N concurrent `If-None-Match: *` writes to one key yield exactly one
+`200` and N-1 `412`s; the same holds for N concurrent `If-Match` writes asserting
+the same ETag, which is the compare-and-swap primitive optimistic locking needs.
+This guarantee is **process-local**. Substrate implements it with a per-key mutex
+held across the existence check and the write, because `StateManager` exposes no
+compare-and-swap; it therefore holds for any number of goroutines or HTTP clients
+against one emulator process, but would not hold across two emulator processes
+sharing one state backend.
+
+Two outcomes real S3 documents are deliberately not emulated: the `409
+ConditionalRequestConflict` returned when a concurrent operation interferes, and the
+`404` returned when a concurrent delete lands mid-write. Both are races against
+wall-clock timing rather than states a deterministic emulator can reach, so
+substrate resolves every conditional write to one of the rows above. A consumer
+that must exercise its 409 handler needs a fault-injection tier, not this one.
+
+#### Conditional reads
+
+`GetObject` and `HeadObject` honor all four RFC 9110 preconditions. They are
+evaluated **before** the `Range` header, so a failed precondition is reported rather
+than a partial response served:
+
+| Header | Evaluation | Result |
+|---|---|---|
+| `If-None-Match` | Matches the object's ETag (or is `*`) | `304 Not Modified`, no body, `ETag` echoed |
+| `If-None-Match` | Does not match | `200` |
+| `If-Match` | Matches (or is `*`) | `200` |
+| `If-Match` | Does not match | `412 PreconditionFailed` |
+| `If-Modified-Since` | Object not modified since the date | `304 Not Modified` |
+| `If-Unmodified-Since` | Object modified since the date | `412 PreconditionFailed` |
+
+Two combination rules from the `GetObject` reference are implemented, both of which
+stop a coarse date condition from overriding an exact entity assertion:
+
+- `If-Match` true **and** `If-Unmodified-Since` false → `200`, not `412`.
+- `If-None-Match` false **and** `If-Modified-Since` true → `304`, not `200`.
+
+A precondition against an absent key is still `404 NoSuchKey` — there is no ETag to
+compare. An unparseable date makes its condition inapplicable rather than failed
+(per RFC 9110), so a malformed date never produces a spurious `412`. The three date
+formats RFC 9110 requires a recipient to accept are all parsed. An empty header
+value is a condition that cannot be met, distinct from an absent header.
+
+ETag comparison ignores surrounding quotes, `W/` weak-validator prefixes, hex case
+and whitespace, and a comma-separated list matches if any member does. Header names
+are matched case-insensitively.
+
+#### Conditional copies
+
+`CopyObject` carries two independent sets: the unprefixed headers above gate
+overwriting the destination, while `x-amz-copy-source-if-match`,
+`x-amz-copy-source-if-none-match`, `x-amz-copy-source-if-modified-since` and
+`x-amz-copy-source-if-unmodified-since` gate reading the source. Both are evaluated
+before anything is written, so a rejected copy leaves the destination untouched.
+
+Every failed copy-source condition is a `412`, including the case where the
+equivalent `GetObject` would be a `304`: there is no cached entity for a
+server-side copy to revalidate against.
 
 ### Multipart upload validation
 

--- a/emulator/s3_conditional.go
+++ b/emulator/s3_conditional.go
@@ -1,0 +1,234 @@
+package emulator
+
+import (
+	"hash/fnv"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// s3KeyLockStripes is the number of mutexes in [S3Plugin]'s per-key stripe set.
+// A power of two well above the concurrency any test drives, so distinct keys
+// almost never contend.
+const s3KeyLockStripes = 64
+
+// s3KeyMutex is a striped mutex set serializing writes per object key.
+//
+// It exists because [StateManager] offers no compare-and-swap: Get/Put/Delete/List
+// only, and [MemoryStateManager] is last-write-wins. A conditional write that
+// checked existence and then called Put would leave a window in which every one of
+// N concurrent `If-None-Match: *` PUTs observes the key as absent and all succeed —
+// precisely inverting the exactly-one-winner property such a write is used for.
+// Holding a per-key lock across check→Put closes that window.
+//
+// The guarantee this provides is deliberately bounded: it is *process-local*. It is
+// airtight for substrate's single-process topology, which is how tests use it, and
+// it would not hold across two emulator processes sharing one state backend. That
+// boundary is a property of the state layer, not of this lock.
+type s3KeyMutex struct {
+	stripes [s3KeyLockStripes]sync.Mutex
+}
+
+// lock acquires the stripe guarding bucket/key and returns its unlock function.
+func (m *s3KeyMutex) lock(bucket, key string) func() {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(bucket))
+	_, _ = h.Write([]byte{'/'})
+	_, _ = h.Write([]byte(key))
+	mu := &m.stripes[h.Sum32()%s3KeyLockStripes]
+	mu.Lock()
+	return mu.Unlock
+}
+
+// s3PreconditionFailedMessage is the message S3 pairs with PreconditionFailed.
+const s3PreconditionFailedMessage = "At least one of the pre-conditions you specified did not hold"
+
+// s3ConditionalHeaders holds the RFC 7232 precondition headers of a request,
+// already resolved case-insensitively.
+//
+// The distinction between an absent header and an empty one matters: an absent
+// header imposes no condition, whereas an empty value is a condition that cannot
+// be met. present tracks which of the four were sent at all.
+type s3ConditionalHeaders struct {
+	IfMatch           string
+	IfNoneMatch       string
+	IfModifiedSince   string
+	IfUnmodifiedSince string
+
+	hasIfMatch           bool
+	hasIfNoneMatch       bool
+	hasIfModifiedSince   bool
+	hasIfUnmodifiedSince bool
+}
+
+// readConditionalHeaders extracts the four read preconditions from a request.
+func readConditionalHeaders(headers map[string]string) s3ConditionalHeaders {
+	c := s3ConditionalHeaders{}
+	c.IfMatch, c.hasIfMatch = headerLookupFold(headers, "If-Match")
+	c.IfNoneMatch, c.hasIfNoneMatch = headerLookupFold(headers, "If-None-Match")
+	c.IfModifiedSince, c.hasIfModifiedSince = headerLookupFold(headers, "If-Modified-Since")
+	c.IfUnmodifiedSince, c.hasIfUnmodifiedSince = headerLookupFold(headers, "If-Unmodified-Since")
+	return c
+}
+
+// copySourceConditionalHeaders extracts CopyObject's source preconditions, which
+// are the same four conditions under x-amz-copy-source-* names. They gate reading
+// the source, whereas the unprefixed headers gate overwriting the destination, so a
+// single CopyObject request can carry both sets.
+func copySourceConditionalHeaders(headers map[string]string) s3ConditionalHeaders {
+	c := s3ConditionalHeaders{}
+	c.IfMatch, c.hasIfMatch = headerLookupFold(headers, "x-amz-copy-source-if-match")
+	c.IfNoneMatch, c.hasIfNoneMatch = headerLookupFold(headers, "x-amz-copy-source-if-none-match")
+	c.IfModifiedSince, c.hasIfModifiedSince = headerLookupFold(headers, "x-amz-copy-source-if-modified-since")
+	c.IfUnmodifiedSince, c.hasIfUnmodifiedSince = headerLookupFold(headers, "x-amz-copy-source-if-unmodified-since")
+	return c
+}
+
+// any reports whether the request carried any precondition at all, letting a
+// caller skip the whole evaluation on the common unconditional path.
+func (c s3ConditionalHeaders) any() bool {
+	return c.hasIfMatch || c.hasIfNoneMatch || c.hasIfModifiedSince || c.hasIfUnmodifiedSince
+}
+
+// headerLookupFold returns the value of the named header and whether it was
+// present, matching the name case-insensitively. It exists alongside
+// [headerValueFold] because a precondition header sent with an empty value is a
+// condition that fails, not an absent condition.
+func headerLookupFold(headers map[string]string, name string) (string, bool) {
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// evaluateReadPreconditions applies the GetObject/HeadObject preconditions to an
+// object that has already been found, returning the error response to serve or nil
+// to proceed.
+//
+// The two combination rules are S3's own, and both exist to stop a
+// cache-validation header from overriding an explicit ETag assertion:
+//
+//   - If-Match true and If-Unmodified-Since false → 200, not 412. The caller
+//     named the exact entity it wanted and got it; a coarser timestamp condition
+//     does not override that.
+//   - If-None-Match false and If-Modified-Since true → 304, not 200. The caller
+//     already holds this entity, so there is nothing to send regardless of dates.
+//
+// A precondition on an absent object is not evaluated at all — the caller's
+// NoSuchKey comes first, since there is no ETag to compare against.
+func evaluateReadPreconditions(c s3ConditionalHeaders, obj *S3Object) *AWSResponse {
+	if !c.any() {
+		return nil
+	}
+
+	// If-Match / If-None-Match are evaluated first: an explicit entity assertion
+	// outranks the date conditions, per the two rules above.
+	if c.hasIfNoneMatch && s3ETagMatches(c.IfNoneMatch, obj.ETag) {
+		// The caller holds this entity. 304 carries no body and no explanation.
+		return &AWSResponse{StatusCode: http.StatusNotModified, Headers: map[string]string{"ETag": obj.ETag}}
+	}
+	if c.hasIfMatch && !s3ETagMatches(c.IfMatch, obj.ETag) {
+		return s3PreconditionFailedResponse()
+	}
+
+	// If-None-Match evaluated false and did not return above; If-Modified-Since is
+	// then redundant with it, so S3 skips it. Likewise a satisfied If-Match
+	// suppresses If-Unmodified-Since.
+	if c.hasIfModifiedSince && !c.hasIfNoneMatch {
+		if since, ok := parseHTTPDate(c.IfModifiedSince); ok && !obj.LastModified.After(since) {
+			return &AWSResponse{StatusCode: http.StatusNotModified, Headers: map[string]string{"ETag": obj.ETag}}
+		}
+	}
+	if c.hasIfUnmodifiedSince && !c.hasIfMatch {
+		if since, ok := parseHTTPDate(c.IfUnmodifiedSince); ok && obj.LastModified.After(since) {
+			return s3PreconditionFailedResponse()
+		}
+	}
+
+	return nil
+}
+
+// evaluateWritePreconditions applies the PutObject/CopyObject/Complete conditional
+// write preconditions against the current state of the destination key, returning
+// the error response to serve or nil to proceed.
+//
+// current is the destination object, or nil when the key is absent. A delete
+// marker counts as absent: S3 documents both headers as evaluating against the
+// current version, and "if the current object version is a delete marker" the
+// If-None-Match write succeeds and the If-Match write is a 404.
+//
+// Unlike a read, an absent key is not an early NoSuchKey — its absence is exactly
+// what If-None-Match asserts.
+func evaluateWritePreconditions(c s3ConditionalHeaders, current *S3Object) *AWSResponse {
+	exists := current != nil && !current.IsDeleteMarker
+
+	if c.hasIfNoneMatch {
+		// "The If-None-Match header expects the * (asterisk) value." Any other
+		// value is not a supported form on a write; treat it as unmet rather than
+		// silently allowing the overwrite it was sent to prevent.
+		if strings.TrimSpace(c.IfNoneMatch) != "*" || exists {
+			return s3PreconditionFailedResponse()
+		}
+	}
+
+	if c.hasIfMatch {
+		if !exists {
+			// "If there's no current object version with the same name, or if the
+			// current object version is a delete marker, the operation fails with
+			// a 404 Not Found error."
+			return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound)
+		}
+		if !s3ETagMatches(c.IfMatch, current.ETag) {
+			return s3PreconditionFailedResponse()
+		}
+	}
+
+	return nil
+}
+
+// s3PreconditionFailedResponse builds the 412 PreconditionFailed response. The
+// code string is what an SDK matches on to distinguish a lost race from a real
+// failure, so it must be exact.
+func s3PreconditionFailedResponse() *AWSResponse {
+	return s3ErrorResponse("PreconditionFailed", s3PreconditionFailedMessage, http.StatusPreconditionFailed)
+}
+
+// s3ETagMatches reports whether an If-Match or If-None-Match header value matches
+// an object's ETag. "*" matches any existing entity. A comma-separated list
+// matches if any member does, per RFC 7232 — S3 restricts the write form of
+// If-None-Match to "*", but the read form accepts a list.
+//
+// Comparison ignores quoting, weak-validator prefixes and hex case, since clients
+// differ on whether they echo back the quotes S3 sends.
+func s3ETagMatches(header, etag string) bool {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return false
+	}
+	if header == "*" {
+		return true
+	}
+	for _, candidate := range strings.Split(header, ",") {
+		if s3ETagsEqual(candidate, etag) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseHTTPDate parses an If-Modified-Since / If-Unmodified-Since value, accepting
+// the three formats RFC 9110 requires a recipient to handle. An unparseable date
+// makes the condition inapplicable rather than failed, which is what RFC 9110
+// specifies and what keeps a malformed date from turning into a spurious 412.
+func parseHTTPDate(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	for _, layout := range []string{http.TimeFormat, time.RFC850, time.ANSIC} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}

--- a/emulator/s3_conditional_test.go
+++ b/emulator/s3_conditional_test.go
@@ -1,0 +1,1050 @@
+package emulator_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// condFixture creates a bucket and returns the server. The bucket is empty; each
+// test PUTs whatever it needs, so no test inherits another's object state.
+func condFixture(t *testing.T, bucket string) *emulator.Server {
+	t.Helper()
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code, "create bucket")
+	return srv
+}
+
+// putCondObject PUTs an object unconditionally and returns its ETag.
+func putCondObject(t *testing.T, srv *emulator.Server, bucket, key, body string) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte(body), nil)
+	require.Equal(t, http.StatusOK, w.Code, "seed PUT: %s", w.Body)
+	etag := w.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+	return etag
+}
+
+// getCondBody returns an object's body, requiring the GET to succeed.
+func getCondBody(t *testing.T, srv *emulator.Server, bucket, key string) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"/"+key, nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	return w.Body.String()
+}
+
+// TestS3_ConditionalWrite is the acceptance table for #397's write rows: the five
+// PutObject outcomes S3 documents for If-None-Match and If-Match.
+//
+// Every case asserts the stored body afterwards, not just the status code. A 412
+// that still overwrote the object would satisfy a status-only assertion while
+// destroying exactly the data the header was sent to protect.
+func TestS3_ConditionalWrite(t *testing.T) {
+	const (
+		bucket   = "cond-write"
+		existing = "original"
+		attempt  = "overwrite"
+	)
+
+	tests := []struct {
+		name string
+		// seed is written first; "" leaves the key absent.
+		seed string
+		// header returns the precondition header, given the seeded object's ETag
+		// ("" when nothing was seeded).
+		header     func(etag string) map[string]string
+		wantStatus int
+		wantCode   string
+		// wantBody is the body expected after the attempt. "" means the key must
+		// still not exist.
+		wantBody string
+	}{
+		{
+			name: "If-None-Match star, key absent",
+			seed: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   attempt,
+		},
+		{
+			name: "If-None-Match star, key present",
+			seed: existing,
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+			wantBody:   existing,
+		},
+		{
+			name: "If-Match matching etag",
+			seed: existing,
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-Match": etag}
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   attempt,
+		},
+		{
+			name: "If-Match differing etag",
+			seed: existing,
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+			wantBody:   existing,
+		},
+		{
+			// "If there's no current object version with the same name … the
+			// operation fails with a 404 Not Found error." Not a 412: there is
+			// nothing to compare the ETag against.
+			name: "If-Match, key absent",
+			seed: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NoSuchKey",
+			wantBody:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, bucket)
+
+			var etag string
+			if tt.seed != "" {
+				etag = putCondObject(t, srv, bucket, "obj.txt", tt.seed)
+			}
+
+			w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/obj.txt",
+				[]byte(attempt), tt.header(etag))
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+			if tt.wantCode != "" {
+				assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+			}
+
+			gw := s3Request(t, srv, http.MethodGet, "/"+bucket+"/obj.txt", nil, nil)
+			if tt.wantBody == "" {
+				assert.Equal(t, http.StatusNotFound, gw.Code,
+					"a rejected conditional write must not create the object")
+				return
+			}
+			require.Equal(t, http.StatusOK, gw.Code)
+			assert.Equal(t, tt.wantBody, gw.Body.String(),
+				"stored body after a %d", tt.wantStatus)
+		})
+	}
+}
+
+// TestS3_ConditionalWrite_412LeavesObjectByteIdentical is the assertion the issue
+// names explicitly. It is stronger than the table's body check: every observable
+// field of the object — ETag, size, Last-Modified, user metadata — must survive the
+// rejected write untouched, since a consumer that retries on 412 will compare them.
+func TestS3_ConditionalWrite_412LeavesObjectByteIdentical(t *testing.T) {
+	srv := condFixture(t, "cond-identical")
+
+	seedHeaders := map[string]string{
+		"Content-Type":      "text/plain",
+		"x-amz-meta-origin": "seed",
+	}
+	pw := s3Request(t, srv, http.MethodPut, "/cond-identical/obj.txt",
+		[]byte("original contents"), seedHeaders)
+	require.Equal(t, http.StatusOK, pw.Code)
+
+	before := s3Request(t, srv, http.MethodGet, "/cond-identical/obj.txt", nil, nil)
+	require.Equal(t, http.StatusOK, before.Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/cond-identical/obj.txt",
+		[]byte("a completely different body of another length"), map[string]string{
+			"If-None-Match":     "*",
+			"Content-Type":      "application/json",
+			"x-amz-meta-origin": "clobber",
+		})
+	require.Equal(t, http.StatusPreconditionFailed, w.Code)
+
+	after := s3Request(t, srv, http.MethodGet, "/cond-identical/obj.txt", nil, nil)
+	require.Equal(t, http.StatusOK, after.Code)
+
+	assert.Equal(t, before.Body.String(), after.Body.String(), "body")
+	for _, h := range []string{
+		"ETag", "Content-Length", "Content-Type", "Last-Modified", "X-Amz-Meta-Origin",
+	} {
+		assert.Equal(t, before.Header().Get(h), after.Header().Get(h), "header %s", h)
+	}
+	assert.Equal(t, "seed", after.Header().Get("X-Amz-Meta-Origin"),
+		"the rejected write's metadata must not have been applied")
+}
+
+// TestS3_ConditionalWrite_ExactlyOneWinner is the concurrency assertion from the
+// issue: N parallel `If-None-Match: *` PUTs of distinct bodies must produce exactly
+// one 200 and N-1 412s, and the object must hold the winner's body.
+//
+// This is the property [emulator.StateManager] cannot provide on its own — it has
+// no compare-and-swap, and MemoryStateManager is last-write-wins — so without the
+// plugin's per-key lock held across check→Put every writer would observe the key as
+// absent and all N would succeed. Run under -race.
+func TestS3_ConditionalWrite_ExactlyOneWinner(t *testing.T) {
+	const writers = 32
+
+	srv := condFixture(t, "cond-race")
+
+	type outcome struct {
+		status int
+		body   string
+	}
+	results := make([]outcome, writers)
+
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+
+	for i := range writers {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			body := fmt.Sprintf("writer-%02d", i)
+			start.Wait() // release all writers at once to maximize overlap
+			w := s3Request(t, srv, http.MethodPut, "/cond-race/obj.txt",
+				[]byte(body), map[string]string{"If-None-Match": "*"})
+			results[i] = outcome{status: w.Code, body: body}
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	var winners []string
+	for _, r := range results {
+		switch r.status {
+		case http.StatusOK:
+			winners = append(winners, r.body)
+		case http.StatusPreconditionFailed:
+		default:
+			t.Errorf("unexpected status %d from a concurrent conditional PUT", r.status)
+		}
+	}
+
+	require.Len(t, winners, 1,
+		"exactly one of %d concurrent If-None-Match: * PUTs may succeed", writers)
+	assert.Equal(t, winners[0], getCondBody(t, srv, "cond-race", "obj.txt"),
+		"the stored object must be the winner's body")
+}
+
+// TestS3_ConditionalWrite_IfMatchExactlyOneWinner is the compare-and-swap form of
+// the same race: every writer asserts the ETag it read, so only the first may land.
+// A consumer implementing optimistic locking depends on precisely this.
+func TestS3_ConditionalWrite_IfMatchExactlyOneWinner(t *testing.T) {
+	const writers = 32
+
+	srv := condFixture(t, "cond-cas")
+	etag := putCondObject(t, srv, "cond-cas", "obj.txt", "generation-0")
+
+	statuses := make([]int, writers)
+
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+
+	for i := range writers {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			w := s3Request(t, srv, http.MethodPut, "/cond-cas/obj.txt",
+				[]byte(fmt.Sprintf("generation-1-by-%02d", i)),
+				map[string]string{"If-Match": etag})
+			statuses[i] = w.Code
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	ok := 0
+	for _, s := range statuses {
+		switch s {
+		case http.StatusOK:
+			ok++
+		case http.StatusPreconditionFailed:
+		default:
+			t.Errorf("unexpected status %d from a concurrent If-Match PUT", s)
+		}
+	}
+	assert.Equal(t, 1, ok, "exactly one If-Match writer may win the ETag it read")
+}
+
+// TestS3_ConditionalWrite_DeleteMarkerCountsAsAbsent covers the versioned rule:
+// "if the current object version is a delete marker, the write operation succeeds"
+// for If-None-Match, and fails with 404 for If-Match. A delete marker is not an
+// object, so a key that once held data behaves as a free key again.
+func TestS3_ConditionalWrite_DeleteMarkerCountsAsAbsent(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "If-None-Match star succeeds",
+			header:     map[string]string{"If-None-Match": "*"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "If-Match is a 404",
+			header:     map[string]string{"If-Match": `"00000000000000000000000000000000"`},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NoSuchKey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, "cond-marker")
+			require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+				"/cond-marker?versioning",
+				[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`),
+				map[string]string{"Content-Type": "application/xml"}).Code)
+
+			putCondObject(t, srv, "cond-marker", "obj.txt", "v1")
+			require.Equal(t, http.StatusNoContent,
+				s3Request(t, srv, http.MethodDelete, "/cond-marker/obj.txt", nil, nil).Code,
+				"delete must insert a delete marker")
+
+			w := s3Request(t, srv, http.MethodPut, "/cond-marker/obj.txt",
+				[]byte("v2"), tt.header)
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+			if tt.wantCode != "" {
+				assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+			}
+		})
+	}
+}
+
+// TestS3_ConditionalWrite_IfNoneMatchNonStar asserts that a non-"*" If-None-Match
+// on a write is rejected rather than ignored. S3 documents the header as expecting
+// "*"; treating an unsupported value as "no condition" would let a header sent to
+// prevent an overwrite silently permit one, which is the failure mode this whole
+// issue is about.
+func TestS3_ConditionalWrite_IfNoneMatchNonStar(t *testing.T) {
+	srv := condFixture(t, "cond-nonstar")
+	etag := putCondObject(t, srv, "cond-nonstar", "obj.txt", "original")
+
+	for _, value := range []string{etag, `"00000000000000000000000000000000"`, ""} {
+		t.Run("value="+value, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodPut, "/cond-nonstar/obj.txt",
+				[]byte("overwrite"), map[string]string{"If-None-Match": value})
+			assert.Equal(t, http.StatusPreconditionFailed, w.Code, "body: %s", w.Body)
+			assert.Equal(t, "original", getCondBody(t, srv, "cond-nonstar", "obj.txt"))
+		})
+	}
+}
+
+// TestS3_ConditionalRead is the acceptance table for #397's read rows, run against
+// both GET and HEAD since S3 evaluates preconditions identically for the two.
+func TestS3_ConditionalRead(t *testing.T) {
+	const bucket = "cond-read"
+
+	tests := []struct {
+		name       string
+		header     func(etag string) map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name: "If-None-Match matching etag",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-None-Match": etag}
+			},
+			wantStatus: http.StatusNotModified,
+		},
+		{
+			name: "If-None-Match star on an existing object",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusNotModified,
+		},
+		{
+			name: "If-None-Match differing etag",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Match differing etag",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name: "If-Match matching etag",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-Match": etag}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Match star on an existing object",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": "*"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			// The object's Last-Modified is the pinned test clock, well after 1990.
+			name: "If-Modified-Since in the past",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Modified-Since": "Mon, 01 Jan 1990 00:00:00 GMT"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Modified-Since in the future",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Modified-Since": "Fri, 01 Jan 2100 00:00:00 GMT"}
+			},
+			wantStatus: http.StatusNotModified,
+		},
+		{
+			name: "If-Unmodified-Since in the future",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Unmodified-Since": "Fri, 01 Jan 2100 00:00:00 GMT"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Unmodified-Since in the past",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Unmodified-Since": "Mon, 01 Jan 1990 00:00:00 GMT"}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			// RFC 9110: an unparseable date makes the condition inapplicable, not
+			// failed. A spurious 412 here would break a client with a broken clock
+			// formatter in a way that looks like a server bug.
+			name: "unparseable date is ignored",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Unmodified-Since": "not a date at all"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			// An empty value is a condition that cannot be met, distinct from an
+			// absent header. Treating it as absent would serve the object to a
+			// client whose ETag-building code produced nothing.
+			name: "empty If-Match",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": ""}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name: "empty If-None-Match",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": ""}
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					srv := condFixture(t, bucket)
+					etag := putCondObject(t, srv, bucket, "obj.txt", "contents")
+
+					w := s3Request(t, srv, method, "/"+bucket+"/obj.txt", nil, tt.header(etag))
+					require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+					switch tt.wantStatus {
+					case http.StatusNotModified:
+						// 304 carries no body and must echo the ETag so a client can
+						// confirm which entity it was told it already holds.
+						assert.Zero(t, w.Body.Len(), "304 must carry no body")
+						assert.Equal(t, etag, w.Header().Get("ETag"))
+					case http.StatusPreconditionFailed:
+						assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+					case http.StatusOK:
+						assert.Equal(t, etag, w.Header().Get("ETag"))
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestS3_ConditionalRead_CombinationRules covers the two combinations S3 documents
+// explicitly, both of which exist to stop a coarse date condition from overriding an
+// exact entity assertion. Getting either backwards silently inverts a cache
+// revalidation, so they are asserted directly rather than inferred from the table.
+func TestS3_ConditionalRead_CombinationRules(t *testing.T) {
+	const (
+		past   = "Mon, 01 Jan 1990 00:00:00 GMT"
+		future = "Fri, 01 Jan 2100 00:00:00 GMT"
+	)
+
+	tests := []struct {
+		name       string
+		header     func(etag string) map[string]string
+		wantStatus int
+		reason     string
+	}{
+		{
+			// "If-Match condition evaluates to true, and If-Unmodified-Since
+			// condition evaluates to false; then, S3 returns 200 OK and the data
+			// requested."
+			name: "If-Match true and If-Unmodified-Since false is 200",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-Match": etag, "If-Unmodified-Since": past}
+			},
+			wantStatus: http.StatusOK,
+			reason:     "an exact ETag match outranks a failing If-Unmodified-Since",
+		},
+		{
+			// "If-None-Match condition evaluates to false, and If-Modified-Since
+			// condition evaluates to true; then, S3 returns 304 Not Modified."
+			name: "If-None-Match false and If-Modified-Since true is 304",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-None-Match": etag, "If-Modified-Since": past}
+			},
+			wantStatus: http.StatusNotModified,
+			reason:     "the caller already holds this entity regardless of dates",
+		},
+		{
+			name: "If-Match false still fails despite a satisfied If-Unmodified-Since",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"If-Match":            `"00000000000000000000000000000000"`,
+					"If-Unmodified-Since": future,
+				}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			reason:     "a failed ETag assertion is not rescued by a date condition",
+		},
+		{
+			name: "If-None-Match true suppresses If-Modified-Since",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"If-None-Match":     `"00000000000000000000000000000000"`,
+					"If-Modified-Since": future,
+				}
+			},
+			wantStatus: http.StatusOK,
+			reason:     "the caller does not hold this entity, so it must be sent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, "cond-combo")
+			etag := putCondObject(t, srv, "cond-combo", "obj.txt", "contents")
+
+			w := s3Request(t, srv, http.MethodGet, "/cond-combo/obj.txt", nil, tt.header(etag))
+			assert.Equal(t, tt.wantStatus, w.Code, "%s (body: %s)", tt.reason, w.Body)
+		})
+	}
+}
+
+// TestS3_ConditionalRead_PrecedesRange asserts the ordering that made #397 depend on
+// #396: a failed precondition supersedes a Range, so a 412 or 304 is returned rather
+// than a 206 of a stale entity. A client that got a partial body here would splice
+// bytes from the wrong generation of the object into its cache.
+func TestS3_ConditionalRead_PrecedesRange(t *testing.T) {
+	srv := condFixture(t, "cond-range")
+	etag := putCondObject(t, srv, "cond-range", "obj.txt", strings.Repeat("x", 1000))
+
+	t.Run("failed If-Match beats a valid range", func(t *testing.T) {
+		w := s3Request(t, srv, http.MethodGet, "/cond-range/obj.txt", nil, map[string]string{
+			"If-Match": `"00000000000000000000000000000000"`,
+			"Range":    "bytes=0-99",
+		})
+		require.Equal(t, http.StatusPreconditionFailed, w.Code)
+		assert.Empty(t, w.Header().Get("Content-Range"), "no partial response may be described")
+	})
+
+	t.Run("If-None-Match match beats a valid range", func(t *testing.T) {
+		w := s3Request(t, srv, http.MethodGet, "/cond-range/obj.txt", nil, map[string]string{
+			"If-None-Match": etag,
+			"Range":         "bytes=0-99",
+		})
+		require.Equal(t, http.StatusNotModified, w.Code)
+		assert.Zero(t, w.Body.Len())
+	})
+
+	t.Run("failed If-Match beats an unsatisfiable range", func(t *testing.T) {
+		// Both conditions would produce an error; the precondition is reported.
+		w := s3Request(t, srv, http.MethodGet, "/cond-range/obj.txt", nil, map[string]string{
+			"If-Match": `"00000000000000000000000000000000"`,
+			"Range":    "bytes=5000-5099",
+		})
+		require.Equal(t, http.StatusPreconditionFailed, w.Code)
+		assert.Equal(t, "PreconditionFailed", parseS3Error(t, w.Body.Bytes()).Code)
+	})
+
+	t.Run("satisfied precondition still serves the range", func(t *testing.T) {
+		w := s3Request(t, srv, http.MethodGet, "/cond-range/obj.txt", nil, map[string]string{
+			"If-Match": etag,
+			"Range":    "bytes=0-99",
+		})
+		require.Equal(t, http.StatusPartialContent, w.Code)
+		assert.Equal(t, "bytes 0-99/1000", w.Header().Get("Content-Range"))
+		assert.Equal(t, 100, w.Body.Len())
+	})
+}
+
+// TestS3_ConditionalRead_AbsentKeyIsNoSuchKey asserts a precondition does not turn a
+// missing object into a 412 or 304: there is no ETag to compare, so the caller's
+// real problem is the missing key.
+func TestS3_ConditionalRead_AbsentKeyIsNoSuchKey(t *testing.T) {
+	srv := condFixture(t, "cond-absent")
+
+	tests := []struct {
+		name   string
+		header map[string]string
+	}{
+		{name: "If-Match", header: map[string]string{"If-Match": `"00000000000000000000000000000000"`}},
+		{name: "If-None-Match", header: map[string]string{"If-None-Match": "*"}},
+		{
+			name:   "If-Modified-Since",
+			header: map[string]string{"If-Modified-Since": "Mon, 01 Jan 1990 00:00:00 GMT"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodGet, "/cond-absent/missing.txt", nil, tt.header)
+			require.Equal(t, http.StatusNotFound, w.Code)
+			assert.Equal(t, "NoSuchKey", parseS3Error(t, w.Body.Bytes()).Code)
+		})
+	}
+}
+
+// TestS3_ConditionalRead_ETagFormsAndLists asserts the ETag comparison is
+// quoting-, case- and list-insensitive on reads. Clients differ on whether they
+// echo back the quotes S3 sent, and RFC 7232 allows a list of validators.
+func TestS3_ConditionalRead_ETagFormsAndLists(t *testing.T) {
+	srv := condFixture(t, "cond-etag")
+	etag := putCondObject(t, srv, "cond-etag", "obj.txt", "contents")
+	bare := strings.Trim(etag, `"`)
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "as returned", value: etag},
+		{name: "unquoted", value: bare},
+		{name: "uppercase hex", value: strings.ToUpper(etag)},
+		{name: "weak validator", value: `W/` + etag},
+		{name: "list, first member", value: etag + `,"00000000000000000000000000000000"`},
+		{name: "list, later member", value: `"00000000000000000000000000000000", ` + etag},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A matching If-None-Match is a 304; the same value as If-Match is a 200.
+			// Asserting both proves the value was recognized as a match, rather than
+			// having produced the right status for the wrong reason.
+			nm := s3Request(t, srv, http.MethodGet, "/cond-etag/obj.txt", nil,
+				map[string]string{"If-None-Match": tt.value})
+			assert.Equal(t, http.StatusNotModified, nm.Code, "If-None-Match: %s", tt.value)
+
+			m := s3Request(t, srv, http.MethodGet, "/cond-etag/obj.txt", nil,
+				map[string]string{"If-Match": tt.value})
+			assert.Equal(t, http.StatusOK, m.Code, "If-Match: %s (body: %s)", tt.value, m.Body)
+		})
+	}
+}
+
+// TestS3_ConditionalRead_DateFormats asserts the three date formats RFC 9110
+// requires a recipient to accept. An SDK sending RFC 850 must not get a spurious
+// 200 where a 304 was correct — that would defeat its cache silently.
+func TestS3_ConditionalRead_DateFormats(t *testing.T) {
+	srv := condFixture(t, "cond-dates")
+	putCondObject(t, srv, "cond-dates", "obj.txt", "contents")
+
+	// All three are after the pinned test clock of 2026-01-01, so If-Modified-Since
+	// evaluates false and each must yield a 304. RFC 850's two-digit year cannot
+	// express 2100, hence 2027 for that row.
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "IMF-fixdate", value: "Fri, 01 Jan 2100 00:00:00 GMT"},
+		{name: "RFC 850", value: "Friday, 01-Jan-27 00:00:00 GMT"},
+		{name: "ANSI C asctime", value: "Fri Jan  1 00:00:00 2100"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodGet, "/cond-dates/obj.txt", nil,
+				map[string]string{"If-Modified-Since": tt.value})
+			assert.Equal(t, http.StatusNotModified, w.Code, "value %q: %s", tt.value, w.Body)
+		})
+	}
+}
+
+// TestS3_ConditionalRead_HeaderCaseInsensitive asserts the headers are matched
+// case-insensitively. Tests elsewhere construct AWSRequest literals directly and so
+// bypass net/http's canonicalization; a plugin reading req.Headers["If-Match"] would
+// pass those and still miss a real client sending "if-match".
+func TestS3_ConditionalRead_HeaderCaseInsensitive(t *testing.T) {
+	srv := condFixture(t, "cond-case")
+	etag := putCondObject(t, srv, "cond-case", "obj.txt", "contents")
+
+	for _, name := range []string{"if-none-match", "IF-NONE-MATCH", "If-None-Match"} {
+		t.Run(name, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodGet, "/cond-case/obj.txt", nil,
+				map[string]string{name: etag})
+			assert.Equal(t, http.StatusNotModified, w.Code)
+		})
+	}
+}
+
+// TestS3_ConditionalCopy_Destination asserts CopyObject honors the destination
+// preconditions, which is what makes a copy usable as an atomic publish step.
+func TestS3_ConditionalCopy_Destination(t *testing.T) {
+	tests := []struct {
+		name string
+		// seedDest is written at the destination first; "" leaves it absent.
+		seedDest   string
+		header     func(destETag string) map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:     "If-None-Match star, destination absent",
+			seedDest: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:     "If-None-Match star, destination present",
+			seedDest: "existing",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name:     "If-Match on the destination etag",
+			seedDest: "existing",
+			header: func(destETag string) map[string]string {
+				return map[string]string{"If-Match": destETag}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:     "If-Match differing from the destination etag",
+			seedDest: "existing",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, "cond-copy")
+			putCondObject(t, srv, "cond-copy", "src.txt", "source payload")
+
+			var destETag string
+			if tt.seedDest != "" {
+				destETag = putCondObject(t, srv, "cond-copy", "dst.txt", tt.seedDest)
+			}
+
+			headers := tt.header(destETag)
+			headers["X-Amz-Copy-Source"] = "/cond-copy/src.txt"
+			w := s3Request(t, srv, http.MethodPut, "/cond-copy/dst.txt", nil, headers)
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+			if tt.wantStatus == http.StatusOK {
+				assert.Equal(t, "source payload", getCondBody(t, srv, "cond-copy", "dst.txt"))
+				return
+			}
+			assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+			if tt.seedDest != "" {
+				assert.Equal(t, tt.seedDest, getCondBody(t, srv, "cond-copy", "dst.txt"),
+					"a rejected copy must leave the destination untouched")
+			}
+		})
+	}
+}
+
+// TestS3_ConditionalCopy_Source asserts the x-amz-copy-source-if-* family, which
+// gates reading the source rather than overwriting the destination. Every failure is
+// a 412: CopyObject documents no 304, because there is no cached entity for a
+// server-side copy to revalidate against.
+func TestS3_ConditionalCopy_Source(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     func(srcETag string) map[string]string
+		wantStatus int
+	}{
+		{
+			name: "copy-source-if-match matching",
+			header: func(etag string) map[string]string {
+				return map[string]string{"x-amz-copy-source-if-match": etag}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "copy-source-if-match differing",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-match": `"00000000000000000000000000000000"`,
+				}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+		},
+		{
+			name: "copy-source-if-none-match differing",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-none-match": `"00000000000000000000000000000000"`,
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			// The equivalent GET would be a 304. A copy is a 412.
+			name: "copy-source-if-none-match matching",
+			header: func(etag string) map[string]string {
+				return map[string]string{"x-amz-copy-source-if-none-match": etag}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+		},
+		{
+			name: "copy-source-if-unmodified-since in the future",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-unmodified-since": "Fri, 01 Jan 2100 00:00:00 GMT",
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "copy-source-if-unmodified-since in the past",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-unmodified-since": "Mon, 01 Jan 1990 00:00:00 GMT",
+				}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+		},
+		{
+			name: "copy-source-if-modified-since in the past",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-modified-since": "Mon, 01 Jan 1990 00:00:00 GMT",
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "copy-source-if-modified-since in the future",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-modified-since": "Fri, 01 Jan 2100 00:00:00 GMT",
+				}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, "cond-copysrc")
+			srcETag := putCondObject(t, srv, "cond-copysrc", "src.txt", "source payload")
+
+			headers := tt.header(srcETag)
+			headers["X-Amz-Copy-Source"] = "/cond-copysrc/src.txt"
+			w := s3Request(t, srv, http.MethodPut, "/cond-copysrc/dst.txt", nil, headers)
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+			if tt.wantStatus == http.StatusOK {
+				assert.Equal(t, "source payload", getCondBody(t, srv, "cond-copysrc", "dst.txt"))
+				return
+			}
+			assert.Equal(t, "PreconditionFailed", parseS3Error(t, w.Body.Bytes()).Code)
+			assert.Equal(t, http.StatusNotFound,
+				s3Request(t, srv, http.MethodHead, "/cond-copysrc/dst.txt", nil, nil).Code,
+				"a rejected copy must not create the destination")
+		})
+	}
+}
+
+// TestS3_ConditionalCopy_SourceAndDestinationBoth asserts both families can be sent
+// on one request, and that the source is evaluated even when the destination
+// condition would pass.
+func TestS3_ConditionalCopy_SourceAndDestinationBoth(t *testing.T) {
+	srv := condFixture(t, "cond-copyboth")
+	srcETag := putCondObject(t, srv, "cond-copyboth", "src.txt", "source payload")
+
+	w := s3Request(t, srv, http.MethodPut, "/cond-copyboth/dst.txt", nil, map[string]string{
+		"X-Amz-Copy-Source":          "/cond-copyboth/src.txt",
+		"x-amz-copy-source-if-match": `"00000000000000000000000000000000"`,
+		"If-None-Match":              "*", // would pass: the destination is absent
+	})
+	require.Equal(t, http.StatusPreconditionFailed, w.Code, "body: %s", w.Body)
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodHead, "/cond-copyboth/dst.txt", nil, nil).Code)
+
+	ok := s3Request(t, srv, http.MethodPut, "/cond-copyboth/dst.txt", nil, map[string]string{
+		"X-Amz-Copy-Source":          "/cond-copyboth/src.txt",
+		"x-amz-copy-source-if-match": srcETag,
+		"If-None-Match":              "*",
+	})
+	require.Equal(t, http.StatusOK, ok.Code, "body: %s", ok.Body)
+	assert.Equal(t, "source payload", getCondBody(t, srv, "cond-copyboth", "dst.txt"))
+}
+
+// TestS3_ConditionalCompleteMultipartUpload asserts Complete honors the same
+// conditional write headers as PutObject, per the conditional-writes documentation
+// listing it alongside PutObject and CopyObject. A rejected Complete must leave the
+// upload open, so a caller can abort it after losing the race.
+func TestS3_ConditionalCompleteMultipartUpload(t *testing.T) {
+	tests := []struct {
+		name string
+		// seed is written at the key before Complete; "" leaves it absent.
+		seed       string
+		header     func(seedETag string) map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name: "If-None-Match star, key absent",
+			seed: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-None-Match star, key written mid-upload",
+			seed: "raced in by another writer",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name: "If-Match matching",
+			seed: "existing",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-Match": etag}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Match differing",
+			seed: "existing",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name: "If-Match, key absent",
+			seed: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NoSuchKey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, uploadID := multipartFixture(t, "cond-mpu", "obj.bin")
+			partETag := uploadPart(t, srv, "cond-mpu", "obj.bin", uploadID, 1, []byte("assembled"))
+
+			var seedETag string
+			if tt.seed != "" {
+				seedETag = putCondObject(t, srv, "cond-mpu", "obj.bin", tt.seed)
+			}
+
+			w := s3Request(t, srv, http.MethodPost, "/cond-mpu/obj.bin?uploadId="+uploadID,
+				completeBody(partETag), tt.header(seedETag))
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+			if tt.wantStatus == http.StatusOK {
+				assert.Equal(t, "assembled", getCondBody(t, srv, "cond-mpu", "obj.bin"))
+				assert.Empty(t, openUploadIDs(t, srv, "cond-mpu"),
+					"a successful Complete closes the upload")
+				return
+			}
+
+			assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+			assert.Equal(t, []string{uploadID}, openUploadIDs(t, srv, "cond-mpu"),
+				"a rejected Complete must leave the upload open to be aborted")
+			if tt.seed != "" {
+				assert.Equal(t, tt.seed, getCondBody(t, srv, "cond-mpu", "obj.bin"),
+					"a rejected Complete must not overwrite the raced-in object")
+			}
+		})
+	}
+}
+
+// TestS3_ConditionalCompleteMultipartUpload_MalformedBeatsPrecondition asserts a
+// malformed parts list is reported as malformed even when the precondition would
+// also fail. A caller that saw PreconditionFailed here would retry the upload
+// forever instead of fixing its request.
+func TestS3_ConditionalCompleteMultipartUpload_MalformedBeatsPrecondition(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "cond-mpu-xml", "obj.bin")
+	uploadPart(t, srv, "cond-mpu-xml", "obj.bin", uploadID, 1, []byte("assembled"))
+	putCondObject(t, srv, "cond-mpu-xml", "obj.bin", "already here")
+
+	w := s3Request(t, srv, http.MethodPost, "/cond-mpu-xml/obj.bin?uploadId="+uploadID,
+		[]byte(`<CompleteMultipartUpload></CompleteMultipartUpload>`),
+		map[string]string{"If-None-Match": "*"})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "MalformedXML", parseS3Error(t, w.Body.Bytes()).Code)
+}
+
+// TestS3_ConditionalWrite_UnconditionalPathUnaffected is the regression guard: an
+// ordinary PUT/GET carrying no precondition must be untouched by all of the above.
+func TestS3_ConditionalWrite_UnconditionalPathUnaffected(t *testing.T) {
+	srv := condFixture(t, "cond-plain")
+
+	first := putCondObject(t, srv, "cond-plain", "obj.txt", "first")
+	second := putCondObject(t, srv, "cond-plain", "obj.txt", "second")
+	assert.NotEqual(t, first, second, "an unconditional PUT still overwrites")
+	assert.Equal(t, "second", getCondBody(t, srv, "cond-plain", "obj.txt"))
+
+	w := s3Request(t, srv, http.MethodGet, "/cond-plain/obj.txt", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, second, w.Header().Get("ETag"))
+	// Last-Modified is the pinned clock, proving the object was really rewritten
+	// rather than served from the first generation.
+	assert.NotEmpty(t, w.Header().Get("Last-Modified"))
+	_, parseErr := time.Parse(http.TimeFormat, w.Header().Get("Last-Modified"))
+	assert.NoError(t, parseErr, "Last-Modified must be an HTTP date")
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -45,6 +45,7 @@ type S3Plugin struct {
 	fs         afero.Fs
 	registry   *PluginRegistry // nil = notifications disabled
 	versionSeq int64           // monotonic counter for unique version IDs
+	keyLocks   s3KeyMutex      // serializes conditional writes per object key
 }
 
 // Name returns the service name "s3".
@@ -452,6 +453,24 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
+	// Conditional writes must not race: the existence check and the write below have
+	// to be one atomic step, or N concurrent If-None-Match: * PUTs would all
+	// observe the key as absent and all succeed. See [s3KeyMutex].
+	if cond := readConditionalHeaders(req.Headers); cond.any() {
+		unlock := p.keyLocks.lock(bucket, key)
+		defer unlock()
+
+		current, condErr := p.loadCurrentObject(ctx, bucket, key)
+		if condErr != nil {
+			return nil, condErr
+		}
+		if resp := evaluateWritePreconditions(cond, current); resp != nil {
+			// Nothing has been written yet, so an unmet precondition leaves the
+			// stored object byte-identical.
+			return resp, nil
+		}
+	}
+
 	body := decodeAWSChunked(req.Headers, req.Body)
 	hash := md5.Sum(body) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x"`, hash)
@@ -601,6 +620,13 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 		}
 	}
 
+	// Preconditions are evaluated before the range step: a 412 or 304 supersedes
+	// any range, and RFC 9110 requires a failed precondition to be reported rather
+	// than a partial response served.
+	if resp := evaluateReadPreconditions(readConditionalHeaders(req.Headers), &obj); resp != nil {
+		return resp, nil
+	}
+
 	headers := objectResponseHeaders(&obj)
 
 	rangeHeader := headerValueFold(req.Headers, "Range")
@@ -648,6 +674,11 @@ func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key st
 	if obj.IsDeleteMarker {
 		// Mirror getObject: 405 when a version is named, 404 otherwise.
 		return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
+	}
+
+	// HEAD evaluates preconditions exactly as GET does.
+	if resp := evaluateReadPreconditions(readConditionalHeaders(req.Headers), &obj); resp != nil {
+		return resp, nil
 	}
 
 	headers := objectResponseHeaders(&obj)
@@ -869,6 +900,31 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	}
 	if dstBucketData == nil {
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
+	}
+
+	// Source preconditions gate whether the copy may read; destination
+	// preconditions gate whether it may overwrite. Both are checked before any
+	// write, so a rejected copy leaves the destination untouched.
+	//
+	// A failed copy-source condition is always a 412, even in the case where the
+	// equivalent GET would be a 304: CopyObject documents PreconditionFailed as its
+	// only conditional outcome, since there is no cached entity for a server-side
+	// copy to revalidate against.
+	if evaluateReadPreconditions(copySourceConditionalHeaders(req.Headers), &srcObj) != nil {
+		return s3PreconditionFailedResponse(), nil
+	}
+
+	if cond := readConditionalHeaders(req.Headers); cond.any() {
+		unlock := p.keyLocks.lock(dstBucket, dstKey)
+		defer unlock()
+
+		current, condErr := p.loadCurrentObject(ctx, dstBucket, dstKey)
+		if condErr != nil {
+			return nil, condErr
+		}
+		if resp := evaluateWritePreconditions(cond, current); resp != nil {
+			return resp, nil
+		}
 	}
 
 	srcBody, readErr := afero.ReadFile(p.fs, "/"+srcBucket+"/"+srcKey)
@@ -1289,6 +1345,28 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		return errResp, nil
 	}
 
+	// Complete is a WRITE, so it honors the same conditional headers as PutObject —
+	// evaluated against the destination key, not against the in-progress upload.
+	// "Conditional writes do not consider any in-progress multipart uploads requests
+	// since those are not yet fully written objects": another writer landing on this
+	// key mid-upload is exactly what makes this Complete fail.
+	//
+	// Checked after the parts list, so a malformed request is reported as malformed
+	// rather than as a lost race, and held under the key lock through the write below.
+	if cond := readConditionalHeaders(req.Headers); cond.any() {
+		unlock := p.keyLocks.lock(bucket, key)
+		defer unlock()
+
+		current, condErr := p.loadCurrentObject(ctx, bucket, key)
+		if condErr != nil {
+			return nil, condErr
+		}
+		if resp := evaluateWritePreconditions(cond, current); resp != nil {
+			// The upload stays open: a caller that lost the race can abort it.
+			return resp, nil
+		}
+	}
+
 	// Concatenate parts and compute multi-part ETag.
 	var combined []byte
 	var partMD5s []byte
@@ -1580,6 +1658,25 @@ func (p *S3Plugin) loadObjectEntry(ctx context.Context, bucket, key string) (*ob
 		ETag:         obj.ETag,
 		Size:         obj.Size,
 	}, nil
+}
+
+// loadCurrentObject returns the current version of an object, or nil when the key
+// has never been written. A delete marker is returned rather than treated as
+// absent: the caller decides what absence means, and conditional writes
+// distinguish "never existed" from "deleted" differently than reads do.
+func (p *S3Plugin) loadCurrentObject(ctx context.Context, bucket, key string) (*S3Object, error) {
+	data, err := p.state.Get(ctx, s3Namespace, "object:"+bucket+"/"+key)
+	if err != nil {
+		return nil, fmt.Errorf("get current object %s/%s: %w", bucket, key, err)
+	}
+	if data == nil {
+		return nil, nil
+	}
+	var obj S3Object
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, fmt.Errorf("unmarshal current object %s/%s: %w", bucket, key, err)
+	}
+	return &obj, nil
 }
 
 // headerValueFold returns the value of the named header, case-insensitively


### PR DESCRIPTION
Closes #397.

S3's four RFC 9110 precondition headers were read by nothing. That is the worst possible failure mode for the pattern they exist to serve: a consumer using `If-None-Match: *` to claim a lock, elect a leader, or refuse to clobber a checkpoint received a `200` every time. Its lost-race branch was unreachable, and its test suite passed while demonstrating the exact opposite of the invariant it was written to protect.

## Writes

`PutObject`, `CopyObject` and `CompleteMultipartUpload` — the three operations AWS lists as supporting conditional writes — now evaluate against the current version of the destination key:

| Header | Destination state | Result |
|---|---|---|
| `If-None-Match: *` | Key absent | `200` |
| `If-None-Match: *` | Key present | `412 PreconditionFailed` |
| `If-None-Match: *` | Current version is a delete marker | `200` |
| `If-None-Match: <not *>` | Any | `412` |
| `If-Match: "<etag>"` | Matches | `200` |
| `If-Match: "<etag>"` | Differs | `412` |
| `If-Match: "<etag>"` | Absent, or a delete marker | `404 NoSuchKey` |

Two judgment calls worth flagging:

- **`If-Match` on an absent key is `404`, not `412`.** Straight from the conditional-writes page: "If there's no current object version with the same name, or if the current object version is a delete marker, the operation fails with a `404 Not Found` error." There is no ETag to compare, so the caller's real problem is the missing key.
- **A non-`*` `If-None-Match` on a write is rejected, not ignored.** S3 documents the header as expecting `*`. Treating an unsupported value as "no condition" would let a header sent specifically to prevent an overwrite silently permit one — the failure mode this whole issue is about.

A rejected write is a no-op. `TestS3_ConditionalWrite_412LeavesObjectByteIdentical` asserts body, ETag, `Content-Length`, `Content-Type`, `Last-Modified` and user metadata are all unchanged afterwards, because a `412` that still overwrote the object would satisfy a status-only assertion while destroying exactly the data the header protects. A rejected `CompleteMultipartUpload` additionally leaves its upload open, so a caller that lost the race can still abort it.

## Exactly one winner

N concurrent `If-None-Match: *` PUTs to one key produce exactly one `200` and N-1 `412`s. N concurrent `If-Match` PUTs asserting the same ETag do too — that is the compare-and-swap primitive optimistic locking needs.

`StateManager` exposes no compare-and-swap (Get/Put/Delete/List only) and `MemoryStateManager` is last-write-wins, so a check followed by a `Put` leaves a window in which every writer observes the key as absent. This needed a striped per-key mutex held across check→Put. I verified the test isn't vacuous by stubbing the lock out: **23 of 32 writers won**.

The guarantee is deliberately bounded and **process-local**. It is airtight for substrate's single-process topology, which is how tests use it, but it would not hold across two emulator processes sharing one state backend. That limit is stated in the type's doc comment, in `docs/services.md`, and in the CHANGELOG — the reporter asked to be told if substrate could not guarantee this rather than have it papered over, and this is the honest answer: yes within a process, no across processes.

## Reads

`GetObject` and `HeadObject` evaluate all four preconditions **before** the range step. That ordering is why #397 was sequenced after #396: RFC 9110 requires a failed precondition to be reported rather than a partial response served, and a client that got a `206` here would splice bytes from the wrong generation of the object into its cache.

Both combination rules from the `GetObject` reference are implemented, without special-casing, by evaluating `If-Modified-Since` only when `If-None-Match` was absent and `If-Unmodified-Since` only when `If-Match` was absent:

- `If-Match` true **and** `If-Unmodified-Since` false → `200`. The caller named the exact entity it wanted and got it.
- `If-None-Match` false **and** `If-Modified-Since` true → `304`. The caller already holds this entity, dates notwithstanding.

## Copies

`CopyObject` carries two independent sets. The unprefixed headers gate overwriting the destination; the four `x-amz-copy-source-if-*` headers gate reading the source. Both may appear on one request, and both are checked before anything is written.

Every failed copy-source condition is a `412`, including the case where the equivalent GET would be a `304` — `CopyObject` documents `PreconditionFailed` as its only conditional outcome, since there is no cached entity for a server-side copy to revalidate against.

## Deliberately not emulated

Real S3 can return `409 ConditionalRequestConflict` when a concurrent operation interferes, and `404` when a concurrent delete lands mid-write. Both are races against wall-clock timing rather than states a deterministic emulator can reach, so substrate resolves every conditional write to one of the documented rows. A consumer that must exercise its 409 handler needs a fault-injection tier, not this one. Noted in the docs so nobody mistakes silence for coverage.

`DeleteObject` `If-Match` is out of scope per the reporter.

## Verification

- **71 subtests** in the new `emulator/s3_conditional_test.go`, all green under `-race`. 100% statement coverage of `emulator/s3_conditional.go`.
- Covers: the issue's seven-row write/read table, the exactly-one-winner concurrency test in both `If-None-Match` and `If-Match` forms, the byte-identical-after-412 assertion, delete-marker-as-absent, precondition-precedes-range (including when both would error), ETag quoting/case/weak-validator/list forms, all three RFC 9110 date formats, unparseable and empty header values, case-insensitive header lookup, both `CopyObject` families together, and `CompleteMultipartUpload` including malformed-XML-beats-precondition.
- A regression guard asserts the unconditional path is untouched.
- `make test` (race), `golangci-lint run ./...` (0 issues), `test/e2e` (race), `make docs-reference-check` — all clean.

Every semantic was verified against the AWS conditional-writes, conditional-reads, `GetObject`, `PutObject`, `CopyObject` and `CompleteMultipartUpload` references, not from built-in knowledge.

One caveat: the `PreconditionFailed` message string ("At least one of the pre-conditions you specified did not hold") is the well-known S3 text, but the AWS error-responses page failed to fetch on every attempt across two sessions, so it is not doc-verified. The `Code` string — which is what an SDK actually matches on — is confirmed by the operation references.