### PR TITLE
feat(s3): verify the x-amz-checksum-* family (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Not emulated, deliberately: the `409 ConditionalRequestConflict` and the
     concurrent-delete `404` that real S3 can return, both of which are races against
     wall-clock timing rather than states a deterministic emulator can reach.
+- S3 storage classes, `InvalidObjectState`, and `CopyObject` metadata directives
+  (#398). `x-amz-storage-class` had been discarded on every write and reported
+  nowhere, so a consumer implementing lifecycle transitions could not observe the
+  one thing a transition changes — and the classes whose objects real S3 refuses to
+  serve looked exactly like the ones it serves instantly.
+  - **Recorded and reported.** `PutObject`, `CopyObject` and
+    `CreateMultipartUpload` accept `x-amz-storage-class`, defaulting to `STANDARD`
+    when absent. All thirteen documented values are accepted, including the
+    Outposts, Snow, Express One Zone and FSx tiers — rejecting a value real S3
+    takes is the same class of defect as accepting one it rejects. Anything else is
+    `400 InvalidStorageClass`, raised before the write, so a rejected class leaves
+    no object behind. The class is reported as `x-amz-storage-class` on
+    `GetObject`/`HeadObject` — **omitted for `STANDARD`**, per the response-header
+    reference — and as `<StorageClass>` in `ListObjects`, `ListObjectsV2`,
+    `ListObjectVersions` and `ListMultipartUploads`, where unlike the header it is
+    emitted for every class including `STANDARD`. A `<DeleteMarker>` carries none,
+    matching S3's response shape. A class set at `CreateMultipartUpload` survives
+    to the object `CompleteMultipartUpload` assembles.
+  - **Archived objects are unreadable.** `GetObject` of a `GLACIER` or
+    `DEEP_ARCHIVE` object is `403 InvalidObjectState`, as is a `CopyObject` naming
+    one as its source. The check precedes the `Range` step, so a ranged read of an
+    archived object is the same `403` rather than a `206`. `GLACIER_IR` reads
+    normally: it is the instant-retrieval tier, and conflating it with the archival
+    classes would make a consumer's restore path fire where real S3 never would.
+  - **`HeadObject` of an archived object is `200`, not `403`** — a deliberate
+    departure from the issue as filed. The `HeadObject` reference documents no
+    `InvalidObjectState` and states that "even if the object is stored in S3
+    Glacier, all object metadata is still available", which is what makes `HEAD`
+    the way a consumer discovers that a `GET` needs a restore first. `GetObject`'s
+    reference does list the error. Emulating a `403` on `HEAD` would have made a
+    test pass against substrate and fail against AWS.
+  - **`CopyObject` metadata directives.** `x-amz-metadata-directive` and
+    `x-amz-tagging-directive` are both honored, both defaulting to `COPY`, and an
+    unrecognized value on either is `400 InvalidArgument` rather than a silent fall
+    back to the default. Under `COPY` the destination takes the source's
+    `Content-Type`, `Content-Encoding`, user metadata and tags, and headers
+    restated on the request are ignored; under `REPLACE` it takes only what the
+    request supplies and drops the rest. `Content-Encoding` had previously been
+    dropped on every copy regardless of directive, so a copy of a gzipped object
+    produced one a client would hand to the application still compressed.
+  - **The storage class is never inherited from the source**, per "if the
+    `x-amz-storage-class` header is not used, the copied object will be stored in
+    the `STANDARD` Storage Class by default" — so an unqualified copy of a
+    `STANDARD_IA` object yields a `STANDARD` one. This is what makes an in-place
+    `CopyObject` with a new class the tier-transition mechanism, and also the trap:
+    a transition using `REPLACE` must restate the metadata it means to keep.
+  - `RestoreObject`, the `x-amz-restore` header and Intelligent-Tiering archive
+    access tiers are not implemented, so an archived object stays unreadable for
+    the run; restoring is modeled by copying to a non-archival class.
 
 ### Fixed
 - S3 multipart operations now return S3's documented `NoSuchUpload` and
@@ -103,11 +152,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alone — it had to issue a GET and download the body to find out.
 - S3 `GetObject` and `HeadObject` now advertise `Accept-Ranges: bytes`, as real
   S3 does on both (#396).
+- S3 `CopyObject` no longer discards the source object's `Content-Encoding` and
+  object tags (#398). Both are user-controlled metadata that a default (`COPY`)
+  copy preserves on real S3, so a copy of a gzipped object produced one whose body
+  a client would hand to the application still compressed, and a copy silently lost
+  the tags any cost-allocation or lifecycle rule keyed on. The destination's
+  metadata map is also no longer aliased to the source's, so retagging one object
+  no longer mutates the other.
 
 ### Changed
 - The S3 error-response builder can now carry error-specific child elements and
   response headers (#396), which the `InvalidRange` body needs and which
-  `EntityTooSmall` (#400) now uses and `StorageClass` (#398) will need. Its
+  `EntityTooSmall` (#400) and the `CopyObject` directive errors (#398) now use. Its
   `extras ...string` parameter had been an unused stub with no call sites; it is
   replaced by an explicit `s3Error` options struct, and `s3DeleteMarkerResponse`
   now shares the same builder instead of re-declaring its own XML type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `RestoreObject`, the `x-amz-restore` header and Intelligent-Tiering archive
     access tiers are not implemented, so an archived object stays unreadable for
     the run; restoring is modeled by copying to a non-archival class.
+- S3 additional checksums: the `x-amz-checksum-*` family is now computed and
+  **verified** on `PutObject`, `UploadPart`, `CopyObject` and
+  `CompleteMultipartUpload` (#399). Checksum headers were previously ignored
+  altogether, which inverts the guarantee they exist to provide: a consumer
+  computing a checksum client-side and sending it to have S3 reject corrupt data
+  got a `200` whether the value matched the body or not, so a test asserting "a
+  corrupted upload is rejected" passed against substrate and would have passed
+  against a version of the consumer that computed the checksum wrong.
+  - **A mismatch is `400 BadDigest` and nothing is written.** The object does not
+    appear at the key — neither its metadata nor its body — and a rejected write
+    over an existing object leaves the original bytes, ETag and checksum intact
+    rather than truncating them. A rejected `UploadPart` stores no part, so a
+    later `CompleteMultipartUpload` cannot pick up a part that failed its
+    checksum. The error body names the algorithm alongside both the supplied and
+    the computed value, so a failing test says which value was wrong.
+  - **Seven algorithms are verified**: `CRC32`, `CRC32C`, `CRC64NVME`, `SHA1`,
+    `SHA256`, `SHA512` and `MD5`. `CRC-64/NVME` is built from the bit-reversed
+    catalog polynomial and pinned by a test against the published check value, so
+    a transcription error surfaces as a failing assertion rather than as a
+    plausible-looking wrong digest that agrees with itself.
+  - **`XXHASH64`, `XXHASH3` and `XXHASH128` are `501 NotImplemented`**, not
+    silently accepted. Substrate has no implementation to check a caller's value
+    against, and storing an unverified checksum is the precise defect this change
+    removes — it would make a test pass on data real S3 would have rejected. A
+    name outside all ten documented algorithms is `400 InvalidRequest`.
+  - **Trailing checksums are read.** `decodeAWSChunked` previously discarded
+    everything after the `aws-chunked` completion chunk, which is exactly where
+    every AWS SDK puts the checksum of a streamed upload — so header-only
+    verification would have silently never fired for any real SDK write. Trailers
+    are now parsed and honored when `x-amz-trailer` declares them; a trailer whose
+    name differs from what was declared, or a declared trailer that never arrives,
+    is `400 MalformedTrailerError`.
+  - **Reading a checksum back requires `x-amz-checksum-mode: ENABLED`** on
+    `GetObject` or `HeadObject`. Without it neither the `x-amz-checksum-*` header
+    nor `x-amz-checksum-type` is present, so the absence is observable. A ranged
+    `GET` returns the whole object's checksum, not the range's.
+  - **Multipart checksums distinguish `COMPOSITE` from `FULL_OBJECT`.**
+    `CreateMultipartUpload` takes `x-amz-checksum-algorithm` and an optional
+    `x-amz-checksum-type`, echoing both back; an absent type defaults to
+    `COMPOSITE`, except for `CRC64NVME`, which has no composite form and defaults
+    to `FULL_OBJECT`. An unsupported algorithm/type pairing is rejected at
+    *creation*, before any part is uploaded, rather than after a consumer has paid
+    to upload every part. `CompleteMultipartUpload` returns the value as an XML
+    element (`<ChecksumSHA256>`, `<ChecksumType>`), not a header, and verifies a
+    whole-object checksum supplied on the request itself. A `FULL_OBJECT` multipart
+    checksum equals what a single-part `PutObject` of the same bytes produces —
+    the invariant a consumer whose two write paths disagree needs a test to catch.
+  - **`CopyObject` recomputes** as a direct full-object checksum of the copied
+    bytes, under the source's algorithm unless the copy names a new one. Copying a
+    `COMPOSITE` multipart object therefore changes both the value and the type
+    even though the data is identical, matching S3.
+  - **One deliberate divergence:** real S3 attaches a default `CRC64NVME` checksum
+    to every object uploaded without one, so a checksum-mode `GET` always returns
+    something. Substrate records none. Synthesizing one would make a consumer's
+    round-trip assertion pass whether or not their writer actually sends a
+    checksum, which is the failure this work exists to expose; an absent checksum
+    in substrate means "your writer sent none".
 
 ### Fixed
 - S3 multipart operations now return S3's documented `NoSuchUpload` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ETags are compared ignoring surrounding quotes, hex case, and whitespace, since
   clients differ on whether they echo back the quotes S3 sends and a false
   `InvalidPart` would send a consumer hunting a data bug that does not exist.
+- S3 conditional requests: `If-Match`, `If-None-Match`, `If-Modified-Since` and
+  `If-Unmodified-Since` (#397). All four were previously ignored, which is the worst
+  possible outcome for the pattern they exist to serve: a consumer using
+  `If-None-Match: *` to claim a lock, elect a leader, or refuse to clobber a
+  checkpoint got a `200` every time, so its lost-race branch was unreachable and its
+  tests passed while proving the opposite of the intended invariant.
+  - **Writes.** `PutObject`, `CopyObject` and `CompleteMultipartUpload` evaluate
+    `If-None-Match` and `If-Match` against the current version of the destination
+    key. `If-None-Match: *` is `412 PreconditionFailed` when the key exists;
+    `If-Match` is `412` on an ETag mismatch and `404 NoSuchKey` when the key is
+    absent — not a `412`, since there is no ETag to compare. A delete marker counts
+    as absent for both, per the conditional-writes reference. An `If-None-Match`
+    value other than `*` is rejected rather than ignored, so a header sent to
+    prevent an overwrite can never silently permit one.
+    A rejected write is a no-op: the stored object is byte-identical afterwards, and
+    a rejected `CompleteMultipartUpload` leaves its upload open to be aborted.
+  - **Exactly one winner.** N concurrent `If-None-Match: *` PUTs to one key produce
+    exactly one `200` and N-1 `412`s, as do N concurrent `If-Match` PUTs asserting
+    the same ETag. `StateManager` has no compare-and-swap and `MemoryStateManager`
+    is last-write-wins, so this required a per-key mutex held across the existence
+    check and the write; without it 23 of 32 concurrent writers won. The guarantee
+    is **process-local** — airtight for substrate's single-process topology, but it
+    would not hold across two emulator processes sharing one state backend, and that
+    limit is documented rather than papered over.
+  - **Reads.** `GetObject` and `HeadObject` evaluate all four preconditions
+    *before* the `Range` step, so a failed precondition is reported rather than a
+    partial response served from an entity the caller did not ask for. A matching
+    `If-None-Match` is `304 Not Modified` with no body and the `ETag` echoed; a
+    failed `If-Match` or `If-Unmodified-Since` is `412`. Both combination rules
+    from the `GetObject` reference are implemented: `If-Match` true with
+    `If-Unmodified-Since` false is `200`, and `If-None-Match` false with
+    `If-Modified-Since` true is `304`.
+  - **Copies.** `CopyObject` additionally honors the four `x-amz-copy-source-if-*`
+    headers, which gate reading the source rather than overwriting the destination;
+    both sets may appear on one request and both are checked before anything is
+    written. A failed copy-source condition is always `412`, including where the
+    equivalent GET would be `304`.
+  - ETag comparison ignores quoting, `W/` prefixes, hex case and whitespace, and a
+    comma-separated list matches if any member does. An unparseable date makes its
+    condition inapplicable rather than failed (per RFC 9110), so a client with a
+    broken date formatter never sees a spurious `412`; all three date formats RFC
+    9110 requires a recipient to accept are parsed. An empty header value is a
+    condition that cannot be met, distinct from an absent header.
+  - Not emulated, deliberately: the `409 ConditionalRequestConflict` and the
+    concurrent-delete `404` that real S3 can return, both of which are races against
+    wall-clock timing rather than states a deterministic emulator can reach.
 
 ### Fixed
 - S3 multipart operations now return S3's documented `NoSuchUpload` and

--- a/docs/services.md
+++ b/docs/services.md
@@ -186,16 +186,16 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers |
-| GetObject | Supports Range header — see [Ranged reads](#ranged-reads) |
-| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads) |
+| PutObject | Supports Content-Type, metadata headers; conditional writes — see [Conditional requests](#conditional-requests) |
+| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests) |
+| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests) |
 | DeleteObject | Fires S3 notifications if configured |
-| CopyObject | |
+| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests) |
 | ListObjects | |
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken |
 | CreateMultipartUpload | |
 | UploadPart | |
-| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation) |
+| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests) |
 | AbortMultipartUpload | |
 | ListMultipartUploads | |
 | GetBucketPolicy | |
@@ -242,6 +242,87 @@ Every range against a zero-byte object is unsatisfiable. A `416` body carries
 without a second round trip. Ranges compose with `versionId`.
 
 Retrieving a specific part by `?partNumber=N` is not implemented.
+
+### Conditional requests
+
+#### Conditional writes
+
+`PutObject`, `CopyObject` and `CompleteMultipartUpload` honor `If-None-Match` and
+`If-Match`, evaluated against the current version of the destination key:
+
+| Header | Destination state | Result |
+|---|---|---|
+| `If-None-Match: *` | Key absent | `200` — the write proceeds |
+| `If-None-Match: *` | Key present | `412 PreconditionFailed` |
+| `If-None-Match: *` | Current version is a delete marker | `200` — a delete marker is not an object |
+| `If-None-Match: <anything but *>` | Any | `412 PreconditionFailed` — S3 expects only `*` on a write |
+| `If-Match: "<etag>"` | ETag matches | `200` — the write proceeds |
+| `If-Match: "<etag>"` | ETag differs | `412 PreconditionFailed` |
+| `If-Match: "<etag>"` | Key absent, or the current version is a delete marker | `404 NoSuchKey` |
+
+A rejected conditional write is a no-op: the stored object is byte-identical
+afterwards — body, ETag, size, `Content-Type` and user metadata all unchanged — and
+a rejected `CompleteMultipartUpload` additionally leaves its upload open to be
+retried or aborted.
+
+**Concurrency.** N concurrent `If-None-Match: *` writes to one key yield exactly one
+`200` and N-1 `412`s; the same holds for N concurrent `If-Match` writes asserting
+the same ETag, which is the compare-and-swap primitive optimistic locking needs.
+This guarantee is **process-local**. Substrate implements it with a per-key mutex
+held across the existence check and the write, because `StateManager` exposes no
+compare-and-swap; it therefore holds for any number of goroutines or HTTP clients
+against one emulator process, but would not hold across two emulator processes
+sharing one state backend.
+
+Two outcomes real S3 documents are deliberately not emulated: the `409
+ConditionalRequestConflict` returned when a concurrent operation interferes, and the
+`404` returned when a concurrent delete lands mid-write. Both are races against
+wall-clock timing rather than states a deterministic emulator can reach, so
+substrate resolves every conditional write to one of the rows above. A consumer
+that must exercise its 409 handler needs a fault-injection tier, not this one.
+
+#### Conditional reads
+
+`GetObject` and `HeadObject` honor all four RFC 9110 preconditions. They are
+evaluated **before** the `Range` header, so a failed precondition is reported rather
+than a partial response served:
+
+| Header | Evaluation | Result |
+|---|---|---|
+| `If-None-Match` | Matches the object's ETag (or is `*`) | `304 Not Modified`, no body, `ETag` echoed |
+| `If-None-Match` | Does not match | `200` |
+| `If-Match` | Matches (or is `*`) | `200` |
+| `If-Match` | Does not match | `412 PreconditionFailed` |
+| `If-Modified-Since` | Object not modified since the date | `304 Not Modified` |
+| `If-Unmodified-Since` | Object modified since the date | `412 PreconditionFailed` |
+
+Two combination rules from the `GetObject` reference are implemented, both of which
+stop a coarse date condition from overriding an exact entity assertion:
+
+- `If-Match` true **and** `If-Unmodified-Since` false → `200`, not `412`.
+- `If-None-Match` false **and** `If-Modified-Since` true → `304`, not `200`.
+
+A precondition against an absent key is still `404 NoSuchKey` — there is no ETag to
+compare. An unparseable date makes its condition inapplicable rather than failed
+(per RFC 9110), so a malformed date never produces a spurious `412`. The three date
+formats RFC 9110 requires a recipient to accept are all parsed. An empty header
+value is a condition that cannot be met, distinct from an absent header.
+
+ETag comparison ignores surrounding quotes, `W/` weak-validator prefixes, hex case
+and whitespace, and a comma-separated list matches if any member does. Header names
+are matched case-insensitively.
+
+#### Conditional copies
+
+`CopyObject` carries two independent sets: the unprefixed headers above gate
+overwriting the destination, while `x-amz-copy-source-if-match`,
+`x-amz-copy-source-if-none-match`, `x-amz-copy-source-if-modified-since` and
+`x-amz-copy-source-if-unmodified-since` gate reading the source. Both are evaluated
+before anything is written, so a rejected copy leaves the destination untouched.
+
+Every failed copy-source condition is a `412`, including the case where the
+equivalent `GetObject` would be a `304`: there is no cached entity for a
+server-side copy to revalidate against.
 
 ### Multipart upload validation
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -186,18 +186,18 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers; conditional writes — see [Conditional requests](#conditional-requests) |
-| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests) |
-| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests) |
+| PutObject | Supports Content-Type, metadata headers; `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests) |
+| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes) |
+| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes) |
 | DeleteObject | Fires S3 notifications if configured |
-| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests) |
-| ListObjects | |
-| ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken |
-| CreateMultipartUpload | |
+| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects) |
+| ListObjects | Emits `<StorageClass>` per object |
+| ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
+| CreateMultipartUpload | Accepts `x-amz-storage-class`, applied to the assembled object |
 | UploadPart | |
 | CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests) |
 | AbortMultipartUpload | |
-| ListMultipartUploads | |
+| ListMultipartUploads | Emits `<StorageClass>` per in-progress upload |
 | GetBucketPolicy | |
 | PutBucketPolicy | |
 | DeleteBucketPolicy | |
@@ -213,6 +213,96 @@ STS operations are free.
 | PutObjectTagging | |
 | GetObjectTagging | |
 | DeleteObjectTagging | |
+
+### Storage classes
+
+`PutObject`, `CopyObject` and `CreateMultipartUpload` accept `x-amz-storage-class`
+and record it on the object. An absent header means `STANDARD`, S3's documented
+default for a newly created object. All thirteen documented values are accepted:
+
+```
+STANDARD  REDUCED_REDUNDANCY  STANDARD_IA  ONEZONE_IA  INTELLIGENT_TIERING
+GLACIER  DEEP_ARCHIVE  OUTPOSTS  GLACIER_IR  SNOW  EXPRESS_ONEZONE
+FSX_OPENZFS  FSX_ONTAP
+```
+
+Any other value — including a lowercase or whitespace-padded one — is `400
+InvalidStorageClass`, rejected before anything is written, so the key does not
+appear. The classes reachable only through Outposts, Snow, Express One Zone and the
+FSx-backed tiers are accepted but carry no distinct behaviour beyond being recorded.
+
+How the class is reported back differs between the header and the XML, which is easy
+to get wrong in both directions:
+
+| Surface | STANDARD | Every other class |
+|---|---|---|
+| `x-amz-storage-class` response header on `GetObject`/`HeadObject` | **Omitted** | Present |
+| `<StorageClass>` in `ListObjects`, `ListObjectsV2`, `ListObjectVersions`, `ListMultipartUploads` | `STANDARD` | The class |
+
+An absent header therefore means `STANDARD`, not "unknown". A `<DeleteMarker>` entry
+in `ListObjectVersions` carries no `<StorageClass>`, matching S3's response shape.
+
+**Archived objects.** A `GetObject` of a `GLACIER` or `DEEP_ARCHIVE` object is `403
+InvalidObjectState` with the message `The action is not valid for the object's
+storage class`, and so is a `CopyObject` that names one as its source — S3 requires
+a restore first. The check precedes the `Range` step, so a ranged read of an
+archived object is the same `403`, not a `206`.
+
+`GLACIER_IR` is **not** archival. It is the instant-retrieval tier and reads
+normally; so do `STANDARD_IA`, `ONEZONE_IA` and `INTELLIGENT_TIERING`.
+
+`HeadObject` of an archived object is a **`200`**, not a `403`. The `HeadObject`
+reference documents no `InvalidObjectState` and states that "even if the object is
+stored in S3 Glacier, all object metadata is still available" — which is what makes
+`HEAD` the way a consumer discovers that a `GET` would need a restore first. A test
+asserting `403` on `HEAD` is asserting behaviour real S3 does not have.
+
+`RestoreObject` and the `x-amz-restore` response header are not implemented, so an
+archived object stays unreadable for the lifetime of the emulator run. Restoring is
+modeled by copying the object to a non-archival class.
+
+Intelligent-Tiering archive access tiers are not modeled, so the `InvalidObjectState`
+variant carrying `<StorageClass>` and `<AccessTier>` children is never returned.
+
+### Copying objects
+
+`CopyObject`'s metadata behaviour is governed by two independent directives, both
+defaulting to `COPY` when absent. An unrecognized value on either is `400
+InvalidArgument` rather than a silent fall back to the default — a typo that quietly
+preserved metadata is the kind of false success this emulator exists to surface.
+
+| `x-amz-metadata-directive` | Destination `Content-Type`, `Content-Encoding`, `x-amz-meta-*` |
+|---|---|
+| `COPY` (default) | Taken from the **source**; headers restated on the request are ignored |
+| `REPLACE` | Taken from the **request**; anything not restated is dropped |
+
+`COPY` preserving `Content-Encoding` is the documented behaviour: "when you copy an
+object, user-controlled system metadata and user-defined metadata are also copied",
+and `Content-Type`, `Content-Encoding`, `Content-Disposition` and `Cache-Control` are
+all user-controlled. Only `x-amz-website-redirect-location` is documented as not
+copied, and substrate does not model it.
+
+The loss case is `REPLACE`: "you must explicitly specify all of the user-configurable
+metadata present on the source object in your request, even if you are changing only
+one of the metadata values". A `REPLACE` that omits `Content-Encoding` drops it, and
+`Content-Type` falls back to `application/octet-stream`.
+
+`x-amz-tagging-directive` works the same way for the tag-set: `COPY` (the default)
+carries the source's tags, `REPLACE` takes them from `x-amz-tagging` as URL query
+parameters (`stage=prod&owner=alice`), defaulting to an empty tag-set when that
+header is absent.
+
+**Storage class is never inherited.** "If the `x-amz-storage-class` header is not
+used, the copied object will be stored in the `STANDARD` Storage Class by default" —
+so an unqualified copy of a `STANDARD_IA` object yields a `STANDARD` one. This is
+what makes an in-place `CopyObject` onto an object's own key with a new
+`x-amz-storage-class` the tier-transition mechanism, and it is also the trap: a
+transition that means to change only the class must restate the metadata it wants to
+keep if it uses `REPLACE`.
+
+Every request-derived value — storage class, both directives, both precondition sets
+— is resolved before the first write, so a rejected copy leaves the destination
+untouched.
 
 ### Ranged reads
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -186,16 +186,16 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers; `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests) |
-| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes) |
-| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes) |
+| PutObject | Supports Content-Type, metadata headers; `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums) |
+| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
+| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
 | DeleteObject | Fires S3 notifications if configured |
-| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects) |
+| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums) |
 | ListObjects | Emits `<StorageClass>` per object |
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
-| CreateMultipartUpload | Accepts `x-amz-storage-class`, applied to the assembled object |
-| UploadPart | |
-| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests) |
+| CreateMultipartUpload | Accepts `x-amz-storage-class`, applied to the assembled object; `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums) |
+| UploadPart | Verifies the part checksum, including a trailing one — see [Additional checksums](#additional-checksums) |
+| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums) |
 | AbortMultipartUpload | |
 | ListMultipartUploads | Emits `<StorageClass>` per in-progress upload |
 | GetBucketPolicy | |
@@ -453,6 +453,94 @@ The `EntityTooSmall` body identifies the offending part:
   <PartNumber>1</PartNumber>
 </Error>
 ```
+
+### Additional checksums
+
+`PutObject`, `UploadPart`, `CopyObject`, `CreateMultipartUpload` and
+`CompleteMultipartUpload` honor the `x-amz-checksum-*` family, and **verify** any
+value the caller supplies. A wrong value is `400 BadDigest` and nothing is written —
+the object does not appear at the key, and a rejected `UploadPart` leaves no part for
+a later Complete to pick up.
+
+All ten documented algorithms are recognized. Seven are computed and verified:
+
+| Algorithm | Header | `FULL_OBJECT` | `COMPOSITE` |
+|---|---|---|---|
+| `CRC32` | `x-amz-checksum-crc32` | yes | yes |
+| `CRC32C` | `x-amz-checksum-crc32c` | yes | yes |
+| `CRC64NVME` | `x-amz-checksum-crc64nvme` | yes | **no** |
+| `SHA1` | `x-amz-checksum-sha1` | no | yes |
+| `SHA256` | `x-amz-checksum-sha256` | no | yes |
+| `SHA512` | `x-amz-checksum-sha512` | no | yes |
+| `MD5` | `x-amz-checksum-md5` | no | yes |
+
+`XXHASH64`, `XXHASH3` and `XXHASH128` are recognized but answered with `501
+NotImplemented`, because substrate has no implementation to check a supplied value
+against. That is deliberate: storing a checksum nobody verified would make a
+consumer's test pass on data real S3 would have rejected, which is the failure this
+section exists to prevent. An algorithm name outside all ten is `400 InvalidRequest`.
+
+Three request shapes are honored on a write:
+
+| Request | Behavior |
+|---|---|
+| `x-amz-checksum-<alg>: <base64>` | Verified against the body; mismatch is `400 BadDigest` |
+| `x-amz-sdk-checksum-algorithm: <NAME>` alone | Substrate computes and records the digest |
+| Both, naming different algorithms | `400 BadDigest` |
+| Two different `x-amz-checksum-*` headers | `400 InvalidRequest`, "Multiple checksum Types are not allowed" |
+| A base64 value of the wrong width for the algorithm | `400 InvalidRequest`, distinct from `BadDigest` |
+
+**Trailing checksums are read.** When the body is `aws-chunked` and `x-amz-trailer`
+names a checksum header, the value is taken from the trailer that follows the
+completion chunk — which is where every AWS SDK puts the checksum of a streamed
+upload. A trailer whose name differs from what `x-amz-trailer` declared is `400
+MalformedTrailerError`; so is a declared trailer that never arrives.
+
+**Reading a checksum back** requires `x-amz-checksum-mode: ENABLED` on `GetObject` or
+`HeadObject`. Without it the response carries no `x-amz-checksum-*` header and no
+`x-amz-checksum-type`, so the absence is observable. A ranged `GET` returns the
+whole object's checksum, not the range's.
+
+**Multipart.** `CreateMultipartUpload` takes `x-amz-checksum-algorithm` (not the
+`x-amz-sdk-` form) and an optional `x-amz-checksum-type`, echoing both back. An
+absent type defaults to `COMPOSITE`, except for `CRC64NVME`, which has no composite
+form and defaults to `FULL_OBJECT`. An unsupported algorithm/type pairing is `400
+InvalidRequest` at **creation**, before any part is uploaded. A part supplying a
+checksum under a different algorithm than the upload's is `400 InvalidRequest`.
+
+`CompleteMultipartUpload` returns the object checksum as an XML **element**, not a
+header:
+
+```xml
+<CompleteMultipartUploadResult>
+  <Location>/bucket/key</Location>
+  <Bucket>bucket</Bucket>
+  <Key>key</Key>
+  <ETag>"b6d81b360a5672d80c27430f39153e2c-2"</ETag>
+  <ChecksumCRC32>Zm9vYmFy-2</ChecksumCRC32>
+  <ChecksumType>COMPOSITE</ChecksumType>
+</CompleteMultipartUploadResult>
+```
+
+A `COMPOSITE` value is the digest of the concatenated raw part digests with a
+`-<part count>` suffix; a `FULL_OBJECT` value is the digest of every byte of the
+assembled object, with no suffix. For the same bytes the two differ, which is the
+point of distinguishing them. A `FULL_OBJECT` multipart checksum equals what a
+single-part `PutObject` of the same bytes produces — a property a test can assert.
+Complete also verifies a whole-object checksum supplied on the request itself, and
+rejects an `x-amz-checksum-type` that disagrees with the upload's.
+
+**`CopyObject` recomputes.** The destination's checksum is always a direct
+full-object checksum of the copied bytes, under the source's algorithm unless the
+copy names a new one. Copying a `COMPOSITE` multipart object therefore changes both
+the value and the type even though the data is identical, matching S3.
+
+**One deliberate divergence.** Real S3 attaches a default `CRC64NVME` checksum to
+every object uploaded without one, so a checksum-mode `GET` always returns something.
+Substrate records **no** checksum in that case. Synthesizing one would make a
+round-trip assertion pass whether or not the consumer's writer actually sends a
+checksum — the exact defect this support was added to expose. An absent checksum in
+substrate means "your writer sent none".
 
 ### Betty CFN resource types
 

--- a/emulator/s3_checksum.go
+++ b/emulator/s3_checksum.go
@@ -1,0 +1,700 @@
+package emulator
+
+import (
+	"crypto/md5"  //nolint:gosec // nosemgrep // MD5 is one of the checksum algorithms S3 offers; it is not used here as a security primitive.
+	"crypto/sha1" //nolint:gosec // nosemgrep // SHA-1 is one of the checksum algorithms S3 offers; it is not used here as a security primitive.
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/xml"
+	"hash"
+	"hash/crc32"
+	"hash/crc64"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// S3 checksum types, as reported in x-amz-checksum-type. A single-part PutObject
+// is always FULL_OBJECT: "Checksums of objects that are uploaded in a single part
+// (using PutObject) are treated as full object checksums".
+const (
+	// S3ChecksumTypeFullObject is a checksum computed over every byte of the
+	// object, "covering all data from the first byte of the first part to the last
+	// byte of the last part".
+	S3ChecksumTypeFullObject = "FULL_OBJECT"
+
+	// S3ChecksumTypeComposite is a checksum computed over the concatenated
+	// part-level digests of a multipart upload, suffixed with "-<part count>".
+	S3ChecksumTypeComposite = "COMPOSITE"
+)
+
+// crc64NVMEPolynomial is the CRC-64/NVME generator polynomial in the bit-reversed
+// (reflected) form that [crc64.MakeTable] expects.
+//
+// The catalog lists CRC-64/NVME as poly=0xad93d23594c93659 with refin/refout
+// true; hash/crc64 takes the reversed polynomial, which is bits.Reverse64 of that
+// value. Verified against the catalog check value: the CRC of "123456789" under
+// this table is 0xae8b14860a799888.
+const crc64NVMEPolynomial = 0x9a6c9329ac4bc9b5
+
+// crc64NVMETable is the CRC-64/NVME table, built once. [crc64.MakeTable] allocates
+// and fills 256 entries per call, and every checksummed request would otherwise
+// rebuild it.
+var crc64NVMETable = sync.OnceValue(func() *crc64.Table {
+	return crc64.MakeTable(crc64NVMEPolynomial)
+})
+
+// s3ChecksumAlgorithm describes one algorithm in the x-amz-checksum-* family.
+type s3ChecksumAlgorithm struct {
+	// Name is the algorithm as it appears in x-amz-checksum-algorithm and
+	// x-amz-sdk-checksum-algorithm, e.g. "CRC32C".
+	Name string
+
+	// New returns a fresh hash for this algorithm. Nil means substrate cannot
+	// compute the digest; see [s3ChecksumAlgorithms].
+	New func() hash.Hash
+
+	// FullObject reports whether the algorithm supports the FULL_OBJECT checksum
+	// type in a multipart upload. "Full object checksums in multipart uploads are
+	// only available for CRC-based checksums because they can linearize into a
+	// full object checksum."
+	FullObject bool
+
+	// Composite reports whether the algorithm supports the COMPOSITE checksum type.
+	// CRC-64/NVME is the sole algorithm that does not.
+	Composite bool
+}
+
+// s3ChecksumHeaderPrefix is the common prefix of every per-algorithm checksum
+// header.
+const s3ChecksumHeaderPrefix = "x-amz-checksum-"
+
+// s3ChecksumAlgorithms is the set of checksum algorithms S3 documents, in the
+// order the API reference lists them.
+//
+// Ten algorithms are accepted, because rejecting one real S3 takes would make a
+// consumer's working code fail against substrate. Only seven can be *verified*
+// here: XXHASH64, XXHASH3 and XXHASH128 have a nil New, because substrate has no
+// implementation of them to check a caller's value against. Those three are
+// answered with 501 NotImplemented rather than silently stored — accepting a
+// checksum substrate cannot verify is the exact defect #399 exists to remove, and
+// is worse than not offering the algorithm, since it makes a test pass while the
+// real service would have caught the corruption.
+//
+// The full-object/composite columns are the documented multipart support matrix.
+var s3ChecksumAlgorithms = []s3ChecksumAlgorithm{
+	{Name: "CRC32", New: func() hash.Hash { return crc32.NewIEEE() }, FullObject: true, Composite: true},
+	{Name: "CRC32C", New: func() hash.Hash { return crc32.New(crc32.MakeTable(crc32.Castagnoli)) }, FullObject: true, Composite: true},
+	{Name: "CRC64NVME", New: func() hash.Hash { return crc64.New(crc64NVMETable()) }, FullObject: true, Composite: false},
+	{Name: "SHA1", New: func() hash.Hash { return sha1.New() }, Composite: true}, //nolint:gosec // nosemgrep
+	{Name: "SHA256", New: sha256.New, Composite: true},
+	{Name: "SHA512", New: sha512.New, Composite: true},
+	{Name: "MD5", New: md5.New, Composite: true}, //nolint:gosec // nosemgrep
+	{Name: "XXHASH64", Composite: true},
+	{Name: "XXHASH3", Composite: true},
+	{Name: "XXHASH128", Composite: true},
+}
+
+// s3ChecksumByName resolves an algorithm by its documented name, case-insensitively.
+func s3ChecksumByName(name string) (s3ChecksumAlgorithm, bool) {
+	for _, alg := range s3ChecksumAlgorithms {
+		if strings.EqualFold(alg.Name, name) {
+			return alg, true
+		}
+	}
+	return s3ChecksumAlgorithm{}, false
+}
+
+// s3ChecksumHeaderOf returns the per-algorithm header name for alg.
+func s3ChecksumHeaderOf(name string) string {
+	return s3ChecksumHeaderPrefix + strings.ToLower(name)
+}
+
+// s3ChecksumDigest returns the base64-encoded big-endian digest of body under alg.
+// "The value field in the trailer chunk includes a base64 encoding of the
+// big-endian checksum value" — hash.Sum already yields big-endian bytes.
+func s3ChecksumDigest(alg s3ChecksumAlgorithm, body []byte) string {
+	return base64.StdEncoding.EncodeToString(s3ChecksumRawDigest(alg, body))
+}
+
+// s3ChecksumRawDigest returns the unencoded digest of body under alg. Composite
+// checksums hash the concatenation of these raw digests, so they need the bytes
+// rather than their base64 form.
+func s3ChecksumRawDigest(alg s3ChecksumAlgorithm, body []byte) []byte {
+	h := alg.New()
+	h.Write(body)
+	return h.Sum(nil)
+}
+
+// s3Checksum is the checksum recorded for an object or part.
+type s3Checksum struct {
+	// Algorithm is the documented algorithm name, e.g. "SHA256". Empty when the
+	// object carries no checksum.
+	Algorithm string `json:"algorithm,omitempty"`
+
+	// Value is the base64-encoded digest, with a "-<part count>" suffix when Type
+	// is COMPOSITE.
+	Value string `json:"value,omitempty"`
+
+	// Type is FULL_OBJECT or COMPOSITE.
+	Type string `json:"type,omitempty"`
+}
+
+// present reports whether a checksum was recorded.
+func (c s3Checksum) present() bool {
+	return c.Algorithm != "" && c.Value != ""
+}
+
+// s3ChecksumNotImplemented is the response for an algorithm S3 supports but
+// substrate cannot compute.
+//
+// This is deliberately an error rather than an unverified success. A caller that
+// gets a 501 learns immediately that substrate will not check this algorithm; one
+// that gets a 200 learns nothing, and ships a test that passes on a checksum
+// nobody validated.
+func s3ChecksumNotImplemented(name string) *AWSResponse {
+	return s3ErrorResponseWith(s3Error{
+		Code: "NotImplemented",
+		Message: "The " + name + " checksum algorithm is not implemented by substrate. " +
+			"Substrate rejects it rather than storing a value it cannot verify. " +
+			"Use CRC32, CRC32C, CRC64NVME, SHA1, SHA256, SHA512 or MD5.",
+		Status:  http.StatusNotImplemented,
+		Details: []s3ErrorDetail{{Name: "ChecksumAlgorithm", Value: name}},
+	})
+}
+
+// s3BadDigestMessage is the message S3 pairs with a BadDigest code.
+const s3BadDigestMessage = "The Content-MD5 or checksum value that you specified did not match what the server received."
+
+// s3BadDigestResponse builds the 400 BadDigest served when a supplied checksum
+// does not match the digest of the received body.
+//
+// "If the checksum value calculated by S3 matches your provided value, the request
+// is accepted. If the values don't match, the request is rejected." The supplied
+// and computed values are surfaced as detail elements so a failing test says which
+// value was wrong rather than only that something was.
+func s3BadDigestResponse(alg, supplied, computed string) *AWSResponse {
+	return s3ErrorResponseWith(s3Error{
+		Code:    "BadDigest",
+		Message: s3BadDigestMessage,
+		Status:  http.StatusBadRequest,
+		Details: []s3ErrorDetail{
+			{Name: "ChecksumAlgorithm", Value: alg},
+			{Name: "ClientComputedChecksum", Value: supplied},
+			{Name: "S3ComputedChecksum", Value: computed},
+		},
+	})
+}
+
+// resolveChecksum determines the checksum to record for a body written by
+// PutObject or UploadPart, verifying any value the caller supplied.
+//
+// Three request shapes are honored, per the PutObject reference:
+//
+//   - A per-algorithm header (x-amz-checksum-sha256: <base64>) supplies a
+//     precomputed value. It is verified against the body; a mismatch is 400
+//     BadDigest and nothing is written.
+//   - x-amz-sdk-checksum-algorithm: <NAME> names an algorithm without a value, so
+//     substrate computes and stores the digest. "When you send this header, there
+//     must be a corresponding x-amz-checksum-<algorithm> or x-amz-trailer header
+//     sent. Otherwise, Amazon S3 fails the request with the HTTP status code 400
+//     Bad Request."
+//   - Neither: no checksum is recorded. Real S3 attaches a default CRC-64/NVME
+//     checksum in this case, but substrate does not — see the note below.
+//
+// Both headers together must agree: "If the individual checksum value you provide
+// through x-amz-checksum-<algorithm> doesn't match the checksum algorithm you set
+// through x-amz-sdk-checksum-algorithm, Amazon S3 fails the request with a
+// BadDigest error."
+//
+// The default-checksum divergence is deliberate. S3 now attaches CRC-64/NVME to
+// every object uploaded without a checksum, so a GetObject with checksum-mode
+// ENABLED returns a value even for an object written with no checksum headers at
+// all. Substrate does not synthesize that, because doing so would make the
+// round-trip assertion in every consumer's test pass whether or not their upload
+// path actually sends a checksum — which is the failure mode this issue was filed
+// about. An absent checksum here means "your writer sent none".
+//
+// A non-nil *AWSResponse is the error to return; the caller must not write.
+func resolveChecksum(headers map[string]string, body []byte) (s3Checksum, *AWSResponse) {
+	named, resp := requestedChecksumAlgorithm(headers)
+	if resp != nil {
+		return s3Checksum{}, resp
+	}
+
+	supplied, alg, resp := suppliedChecksum(headers)
+	if resp != nil {
+		return s3Checksum{}, resp
+	}
+
+	switch {
+	case supplied != "":
+		// Both headers present must name the same algorithm.
+		if named != "" && !strings.EqualFold(named, alg.Name) {
+			return s3Checksum{}, s3ErrorResponseWith(s3Error{
+				Code:    "BadDigest",
+				Message: s3BadDigestMessage,
+				Status:  http.StatusBadRequest,
+				Details: []s3ErrorDetail{
+					{Name: "ChecksumAlgorithm", Value: alg.Name},
+					{Name: "SDKChecksumAlgorithm", Value: named},
+				},
+			})
+		}
+		computed := s3ChecksumDigest(alg, body)
+		if supplied != computed {
+			return s3Checksum{}, s3BadDigestResponse(alg.Name, supplied, computed)
+		}
+		return s3Checksum{Algorithm: alg.Name, Value: computed, Type: S3ChecksumTypeFullObject}, nil
+
+	case named != "":
+		// The algorithm was named with no value and no trailer to carry one.
+		sdkAlg, ok := s3ChecksumByName(named)
+		if !ok {
+			return s3Checksum{}, s3InvalidChecksumAlgorithmResponse(named)
+		}
+		if sdkAlg.New == nil {
+			return s3Checksum{}, s3ChecksumNotImplemented(sdkAlg.Name)
+		}
+		return s3Checksum{
+			Algorithm: sdkAlg.Name,
+			Value:     s3ChecksumDigest(sdkAlg, body),
+			Type:      S3ChecksumTypeFullObject,
+		}, nil
+
+	default:
+		return s3Checksum{}, nil
+	}
+}
+
+// requestedChecksumAlgorithm reads x-amz-sdk-checksum-algorithm, returning the
+// name it holds. An empty name means the header was absent.
+//
+// The value is not resolved to an algorithm here: whether it must be one substrate
+// can compute depends on whether a value accompanies it, which only
+// [resolveChecksum] knows.
+func requestedChecksumAlgorithm(headers map[string]string) (string, *AWSResponse) {
+	name, ok := headerLookupFold(headers, "x-amz-sdk-checksum-algorithm")
+	if !ok {
+		return "", nil
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", s3InvalidChecksumAlgorithmResponse(name)
+	}
+	if _, known := s3ChecksumByName(name); !known {
+		return "", s3InvalidChecksumAlgorithmResponse(name)
+	}
+	return name, nil
+}
+
+// suppliedChecksum finds the x-amz-checksum-<algorithm> header on a request and
+// returns its base64 value alongside the algorithm it names.
+//
+// An empty value with a non-nil error response means the request named an
+// algorithm substrate cannot verify, or named more than one.
+func suppliedChecksum(headers map[string]string) (string, s3ChecksumAlgorithm, *AWSResponse) {
+	var found s3ChecksumAlgorithm
+	var value string
+
+	for _, alg := range s3ChecksumAlgorithms {
+		v, ok := headerLookupFold(headers, s3ChecksumHeaderOf(alg.Name))
+		if !ok {
+			continue
+		}
+		if found.Name != "" {
+			// "Expecting a single x-amz-checksum- header. Multiple checksum Types
+			// are not allowed."
+			return "", s3ChecksumAlgorithm{}, s3ErrorResponseWith(s3Error{
+				Code:    "InvalidRequest",
+				Message: "Expecting a single x-amz-checksum- header. Multiple checksum Types are not allowed.",
+				Status:  http.StatusBadRequest,
+			})
+		}
+		found, value = alg, v
+	}
+
+	if found.Name == "" {
+		return "", s3ChecksumAlgorithm{}, nil
+	}
+	if found.New == nil {
+		return "", s3ChecksumAlgorithm{}, s3ChecksumNotImplemented(found.Name)
+	}
+	if !validBase64Checksum(value, found) {
+		return "", s3ChecksumAlgorithm{}, s3ErrorResponseWith(s3Error{
+			Code:    "InvalidRequest",
+			Message: "Value for " + s3ChecksumHeaderOf(found.Name) + " header is invalid.",
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{{Name: "ChecksumAlgorithm", Value: found.Name}},
+		})
+	}
+	return value, found, nil
+}
+
+// validBase64Checksum reports whether value is a base64 digest of the width alg
+// produces. A well-formed but wrong-length value is a malformed request rather
+// than a digest mismatch, so it is separated from BadDigest.
+func validBase64Checksum(value string, alg s3ChecksumAlgorithm) bool {
+	raw, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return false
+	}
+	return len(raw) == alg.New().Size()
+}
+
+// s3InvalidChecksumAlgorithmResponse is the 400 served for an algorithm name
+// outside the documented set.
+func s3InvalidChecksumAlgorithmResponse(name string) *AWSResponse {
+	return s3ErrorResponseWith(s3Error{
+		Code:    "InvalidRequest",
+		Message: "Checksum algorithm provided is unsupported. Please try again with any of the valid types: [CRC32, CRC32C, CRC64NVME, SHA1, SHA256, SHA512, MD5, XXHASH64, XXHASH3, XXHASH128]",
+		Status:  http.StatusBadRequest,
+		Details: []s3ErrorDetail{{Name: "ChecksumAlgorithm", Value: name}},
+	})
+}
+
+// resolveChecksumMode reads x-amz-checksum-mode and reports whether the caller
+// asked for the stored checksum to be returned.
+//
+// "To retrieve the checksum, this mode must be enabled." The only documented value
+// is ENABLED; anything else is treated as not enabled, matching S3, which returns
+// no checksum rather than an error for an unrecognized mode.
+func resolveChecksumMode(headers map[string]string) bool {
+	return strings.EqualFold(headerValueFold(headers, "x-amz-checksum-mode"), "ENABLED")
+}
+
+// s3ChecksumXML carries one dynamically named checksum element, such as the
+// <ChecksumSHA256> of a CompleteMultipartUploadResult. It works the same way
+// [s3ErrorDetailXML] does: encoding/xml takes the element name from the XMLName
+// field's value ahead of the parent field's tag.
+type s3ChecksumXML struct {
+	XMLName xml.Name
+	Value   string `xml:",chardata"`
+}
+
+// checksumXMLElements renders a checksum as the <Checksum<ALGORITHM>> element
+// CompleteMultipartUpload returns in its result body, or nil when there is none.
+//
+// The element name is the algorithm in the API's own casing — <ChecksumCRC64NVME>,
+// <ChecksumSHA256> — which is why it is taken from the algorithm table rather than
+// derived from the lowercased header name.
+func checksumXMLElements(c s3Checksum) []s3ChecksumXML {
+	if !c.present() {
+		return nil
+	}
+	return []s3ChecksumXML{{
+		XMLName: xml.Name{Local: "Checksum" + c.Algorithm},
+		Value:   c.Value,
+	}}
+}
+
+// applyChecksumHeaders adds the stored checksum and its type to a GetObject or
+// HeadObject response, when the object has one and the request enabled
+// checksum-mode. It is a no-op otherwise, which is what makes the absence of the
+// header on a plain GET observable.
+func applyChecksumHeaders(headers map[string]string, c s3Checksum, enabled bool) {
+	if !enabled || !c.present() {
+		return
+	}
+	headers[s3ChecksumHeaderOf(c.Algorithm)] = c.Value
+	if c.Type != "" {
+		headers["x-amz-checksum-type"] = c.Type
+	}
+}
+
+// resolveUploadChecksum determines the checksum configuration for a multipart
+// upload from a CreateMultipartUpload request.
+//
+// CreateMultipartUpload names the algorithm in x-amz-checksum-algorithm — not the
+// x-amz-sdk-checksum-algorithm form PutObject uses — and optionally the type in
+// x-amz-checksum-type. An absent type defaults to COMPOSITE for every algorithm
+// that supports it, since "if you're using a multipart upload to upload your
+// object, then you must specify the composite checksum type"; CRC-64/NVME, which
+// supports no composite form, defaults to FULL_OBJECT instead.
+//
+// The requested combination is validated against the documented support matrix, so
+// an upload that could never complete against real S3 is rejected here, at
+// creation, rather than after every part has been uploaded.
+func resolveUploadChecksum(headers map[string]string) (algorithm, checksumType string, resp *AWSResponse) {
+	name, ok := headerLookupFold(headers, "x-amz-checksum-algorithm")
+	requestedType := headerValueFold(headers, "x-amz-checksum-type")
+
+	if !ok || strings.TrimSpace(name) == "" {
+		if requestedType != "" {
+			// A type with no algorithm has nothing to apply to.
+			return "", "", s3ErrorResponseWith(s3Error{
+				Code:    "InvalidRequest",
+				Message: "x-amz-checksum-type cannot be used without x-amz-checksum-algorithm.",
+				Status:  http.StatusBadRequest,
+			})
+		}
+		return "", "", nil
+	}
+
+	alg, known := s3ChecksumByName(name)
+	if !known {
+		return "", "", s3InvalidChecksumAlgorithmResponse(name)
+	}
+	if alg.New == nil {
+		return "", "", s3ChecksumNotImplemented(alg.Name)
+	}
+
+	switch {
+	case requestedType == "":
+		if alg.Composite {
+			checksumType = S3ChecksumTypeComposite
+		} else {
+			checksumType = S3ChecksumTypeFullObject
+		}
+	case strings.EqualFold(requestedType, S3ChecksumTypeComposite):
+		checksumType = S3ChecksumTypeComposite
+	case strings.EqualFold(requestedType, S3ChecksumTypeFullObject):
+		checksumType = S3ChecksumTypeFullObject
+	default:
+		return "", "", s3ErrorResponseWith(s3Error{
+			Code:    "InvalidRequest",
+			Message: "Checksum type provided is unsupported. Please try again with any of the valid types: [COMPOSITE, FULL_OBJECT]",
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{{Name: "ChecksumType", Value: requestedType}},
+		})
+	}
+
+	if resp := checkChecksumTypeSupported(alg, checksumType); resp != nil {
+		return "", "", resp
+	}
+	return alg.Name, checksumType, nil
+}
+
+// checkChecksumTypeSupported rejects an algorithm/type pairing the documented
+// support matrix does not allow, such as a FULL_OBJECT SHA-256.
+func checkChecksumTypeSupported(alg s3ChecksumAlgorithm, checksumType string) *AWSResponse {
+	supported := alg.Composite
+	if checksumType == S3ChecksumTypeFullObject {
+		supported = alg.FullObject
+	}
+	if supported {
+		return nil
+	}
+	return s3ErrorResponseWith(s3Error{
+		Code: "InvalidRequest",
+		Message: "The " + checksumType + " checksum type is not supported for the " + alg.Name +
+			" checksum algorithm.",
+		Status: http.StatusBadRequest,
+		Details: []s3ErrorDetail{
+			{Name: "ChecksumAlgorithm", Value: alg.Name},
+			{Name: "ChecksumType", Value: checksumType},
+		},
+	})
+}
+
+// resolveCopyChecksumAlgorithm determines the algorithm a CopyObject destination
+// should be checksummed under.
+//
+// "You can copy the object and specify whether you want to use the existing
+// checksum algorithm or a new one. If you don't specify an algorithm, S3 uses the
+// existing algorithm." An unchecksummed source with no algorithm named yields no
+// checksum here, rather than the CRC-64/NVME real S3 would default to — the same
+// deliberate divergence [resolveChecksum] documents, for the same reason.
+//
+// CopyObject names the algorithm in x-amz-checksum-algorithm, as
+// CreateMultipartUpload does; there is no body for the caller to have precomputed a
+// value over, so no per-algorithm value header is honored.
+func resolveCopyChecksumAlgorithm(headers map[string]string, src *S3Object) (string, *AWSResponse) {
+	name, ok := headerLookupFold(headers, "x-amz-checksum-algorithm")
+	if !ok || strings.TrimSpace(name) == "" {
+		return src.Checksum.Algorithm, nil
+	}
+	alg, known := s3ChecksumByName(name)
+	if !known {
+		return "", s3InvalidChecksumAlgorithmResponse(name)
+	}
+	if alg.New == nil {
+		return "", s3ChecksumNotImplemented(alg.Name)
+	}
+	return alg.Name, nil
+}
+
+// copyChecksum computes the destination checksum of a CopyObject under algorithm,
+// which is always a full-object checksum of the copied bytes.
+func copyChecksum(algorithm string, body []byte) s3Checksum {
+	if algorithm == "" {
+		return s3Checksum{}
+	}
+	alg, known := s3ChecksumByName(algorithm)
+	if !known || alg.New == nil {
+		// Unreachable: resolveCopyChecksumAlgorithm rejects both cases. Returning
+		// no checksum rather than panicking keeps a stored object whose algorithm
+		// substrate no longer computes readable.
+		return s3Checksum{}
+	}
+	return s3Checksum{
+		Algorithm: alg.Name,
+		Value:     s3ChecksumDigest(alg, body),
+		Type:      S3ChecksumTypeFullObject,
+	}
+}
+
+// resolvePartChecksum determines the checksum to record for one uploaded part.
+//
+// A part's algorithm is fixed by the upload: uploadAlgorithm is what
+// CreateMultipartUpload recorded. A part that supplies a value under a *different*
+// algorithm is rejected, mirroring the trailer rule — "if a request contains
+// x-amz-trailer: x-amz-checksum-crc32 and the trailer chunk has the header name
+// x-amz-checksum-sha1, the request fails" — because a part digest computed under
+// another algorithm cannot contribute to the object's checksum.
+//
+// When the upload has an algorithm and the part supplies no value, the digest is
+// computed here. That is what lets substrate assemble the object checksum on
+// Complete regardless of whether the caller sent per-part values.
+func resolvePartChecksum(headers map[string]string, body []byte, uploadAlgorithm string) (s3Checksum, *AWSResponse) {
+	supplied, alg, resp := suppliedChecksum(headers)
+	if resp != nil {
+		return s3Checksum{}, resp
+	}
+	named, resp := requestedChecksumAlgorithm(headers)
+	if resp != nil {
+		return s3Checksum{}, resp
+	}
+
+	// Reconcile the algorithm the part names against the upload's.
+	partAlgorithm := alg.Name
+	if partAlgorithm == "" {
+		partAlgorithm = named
+	}
+	if partAlgorithm != "" && uploadAlgorithm != "" && !strings.EqualFold(partAlgorithm, uploadAlgorithm) {
+		return s3Checksum{}, s3ErrorResponseWith(s3Error{
+			Code: "InvalidRequest",
+			Message: "Checksum algorithm " + partAlgorithm + " does not match the " + uploadAlgorithm +
+				" algorithm specified for this multipart upload.",
+			Status: http.StatusBadRequest,
+			Details: []s3ErrorDetail{
+				{Name: "ChecksumAlgorithm", Value: partAlgorithm},
+				{Name: "UploadChecksumAlgorithm", Value: uploadAlgorithm},
+			},
+		})
+	}
+
+	effective := uploadAlgorithm
+	if effective == "" {
+		effective = partAlgorithm
+	}
+	if effective == "" {
+		return s3Checksum{}, nil
+	}
+
+	effAlg, known := s3ChecksumByName(effective)
+	if !known {
+		return s3Checksum{}, s3InvalidChecksumAlgorithmResponse(effective)
+	}
+	if effAlg.New == nil {
+		return s3Checksum{}, s3ChecksumNotImplemented(effAlg.Name)
+	}
+
+	computed := s3ChecksumDigest(effAlg, body)
+	if supplied != "" && supplied != computed {
+		return s3Checksum{}, s3BadDigestResponse(effAlg.Name, supplied, computed)
+	}
+	// A part checksum is a checksum of that part's bytes in full, so its type is
+	// FULL_OBJECT relative to the part. The object-level type is decided on
+	// Complete, from the upload's configuration.
+	return s3Checksum{Algorithm: effAlg.Name, Value: computed, Type: S3ChecksumTypeFullObject}, nil
+}
+
+// assembleObjectChecksum computes the object-level checksum of a completed
+// multipart upload from the assembled body and the individual part bodies.
+//
+// The two checksum types are computed differently, and the difference is the whole
+// point of distinguishing them:
+//
+//   - COMPOSITE hashes the concatenation of the raw part digests and appends
+//     "-<part count>", exactly as substrate already derives the multipart ETag:
+//     "this approach aggregates the part-level checksums (from the first part to
+//     the last) to produce a single, combined checksum for the complete object."
+//   - FULL_OBJECT hashes every byte of the assembled object, "covering all data
+//     from the first byte of the first part to the last byte of the last part",
+//     and carries no suffix.
+//
+// A caller whose single-part and multipart writers hash different byte streams gets
+// two different values here, which is the class of bug the reporter of #399 hit.
+func assembleObjectChecksum(algorithm, checksumType string, combined []byte, partBodies [][]byte) (s3Checksum, *AWSResponse) {
+	if algorithm == "" {
+		return s3Checksum{}, nil
+	}
+	alg, known := s3ChecksumByName(algorithm)
+	if !known {
+		return s3Checksum{}, s3InvalidChecksumAlgorithmResponse(algorithm)
+	}
+	if alg.New == nil {
+		return s3Checksum{}, s3ChecksumNotImplemented(alg.Name)
+	}
+	if resp := checkChecksumTypeSupported(alg, checksumType); resp != nil {
+		return s3Checksum{}, resp
+	}
+
+	if checksumType == S3ChecksumTypeFullObject {
+		return s3Checksum{
+			Algorithm: alg.Name,
+			Value:     s3ChecksumDigest(alg, combined),
+			Type:      S3ChecksumTypeFullObject,
+		}, nil
+	}
+
+	var digests []byte
+	for _, part := range partBodies {
+		digests = append(digests, s3ChecksumRawDigest(alg, part)...)
+	}
+	return s3Checksum{
+		Algorithm: alg.Name,
+		Value:     s3ChecksumDigest(alg, digests) + "-" + strconv.Itoa(len(partBodies)),
+		Type:      S3ChecksumTypeComposite,
+	}, nil
+}
+
+// verifyCompleteChecksum checks a checksum supplied on CompleteMultipartUpload
+// against the one substrate assembled.
+//
+// Complete accepts a full-object checksum for the whole upload: "You can provide
+// the checksum of the whole object in the CompleteMultipartUpload request... If the
+// two values don't match, S3 fails the request with a BadDigest error." A supplied
+// x-amz-checksum-type that disagrees with what CreateMultipartUpload specified is
+// also a BadDigest, since the value was computed under different rules.
+func verifyCompleteChecksum(headers map[string]string, assembled s3Checksum) *AWSResponse {
+	if requested := headerValueFold(headers, "x-amz-checksum-type"); requested != "" {
+		if !strings.EqualFold(requested, assembled.Type) {
+			return s3ErrorResponseWith(s3Error{
+				Code:    "BadDigest",
+				Message: s3BadDigestMessage,
+				Status:  http.StatusBadRequest,
+				Details: []s3ErrorDetail{
+					{Name: "ChecksumType", Value: requested},
+					{Name: "UploadChecksumType", Value: assembled.Type},
+				},
+			})
+		}
+	}
+
+	supplied, alg, resp := suppliedChecksum(headers)
+	if resp != nil {
+		return resp
+	}
+	if supplied == "" {
+		return nil
+	}
+	if assembled.Algorithm != "" && !strings.EqualFold(alg.Name, assembled.Algorithm) {
+		return s3ErrorResponseWith(s3Error{
+			Code: "InvalidRequest",
+			Message: "Checksum algorithm " + alg.Name + " does not match the " + assembled.Algorithm +
+				" algorithm specified for this multipart upload.",
+			Status: http.StatusBadRequest,
+			Details: []s3ErrorDetail{
+				{Name: "ChecksumAlgorithm", Value: alg.Name},
+				{Name: "UploadChecksumAlgorithm", Value: assembled.Algorithm},
+			},
+		})
+	}
+	if supplied != assembled.Value {
+		return s3BadDigestResponse(alg.Name, supplied, assembled.Value)
+	}
+	return nil
+}

--- a/emulator/s3_checksum_test.go
+++ b/emulator/s3_checksum_test.go
@@ -1,0 +1,1214 @@
+package emulator_test
+
+import (
+	"bytes"
+	"crypto/md5" //nolint:gosec // MD5 is one of the checksum algorithms under test.
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"hash/crc64"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// checksumAlgorithms enumerates the algorithms substrate verifies, paired with an
+// independent implementation of each.
+//
+// The hash constructors here are deliberately declared in the test rather than
+// reached for from the emulator package: a test that computes its expected value by
+// calling the same code under test would pass even if that code hashed the wrong
+// algorithm. These are wired straight to the stdlib.
+var checksumAlgorithms = []struct {
+	Name       string
+	Header     string
+	New        func() hash.Hash
+	FullObject bool // supports FULL_OBJECT in a multipart upload
+	Composite  bool // supports COMPOSITE in a multipart upload
+}{
+	{Name: "CRC32", Header: "x-amz-checksum-crc32", New: func() hash.Hash { return crc32.NewIEEE() }, FullObject: true, Composite: true},
+	{Name: "CRC32C", Header: "x-amz-checksum-crc32c", New: func() hash.Hash { return crc32.New(crc32.MakeTable(crc32.Castagnoli)) }, FullObject: true, Composite: true},
+	{Name: "CRC64NVME", Header: "x-amz-checksum-crc64nvme", New: newCRC64NVME, FullObject: true},
+	{Name: "SHA1", Header: "x-amz-checksum-sha1", New: sha1.New, Composite: true},
+	{Name: "SHA256", Header: "x-amz-checksum-sha256", New: sha256.New, Composite: true},
+	{Name: "SHA512", Header: "x-amz-checksum-sha512", New: sha512.New, Composite: true},
+	{Name: "MD5", Header: "x-amz-checksum-md5", New: md5.New, Composite: true},
+}
+
+// newCRC64NVME builds a CRC-64/NVME hash from the reversed generator polynomial.
+// TestS3Checksum_CRC64NVMEPolynomial pins this against the published check value,
+// so a wrong polynomial here fails loudly rather than agreeing with a wrong one in
+// the emulator.
+func newCRC64NVME() hash.Hash {
+	return crc64.New(crc64.MakeTable(0x9a6c9329ac4bc9b5))
+}
+
+// digestFor returns the base64 digest of body under the named algorithm.
+func digestFor(t *testing.T, name string, body []byte) string {
+	t.Helper()
+	for _, alg := range checksumAlgorithms {
+		if alg.Name == name {
+			h := alg.New()
+			h.Write(body)
+			return base64.StdEncoding.EncodeToString(h.Sum(nil))
+		}
+	}
+	t.Fatalf("no test implementation for algorithm %q", name)
+	return ""
+}
+
+// corruptDigest returns a valid base64 digest of the right width for alg that is
+// not the digest of body — a wrong checksum, as distinct from a malformed one.
+func corruptDigest(t *testing.T, name string, body []byte) string {
+	t.Helper()
+	return digestFor(t, name, append([]byte("not-"), body...))
+}
+
+// putBucket creates a bucket, failing the test if it cannot.
+func putBucket(t *testing.T, srv *emulator.Server, bucket string) {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "create bucket")
+}
+
+// TestS3Checksum_CRC64NVMEPolynomial pins the CRC-64/NVME table against the
+// published catalog check value, so a transcription error in the polynomial is
+// caught here rather than showing up as a plausible-looking wrong digest.
+func TestS3Checksum_CRC64NVMEPolynomial(t *testing.T) {
+	h := newCRC64NVME()
+	h.Write([]byte("123456789"))
+	assert.Equal(t, "ae8b14860a799888", fmt.Sprintf("%x", h.Sum(nil)),
+		"CRC-64/NVME check value for the string 123456789")
+}
+
+// TestS3Checksum_PutObject_RoundTrip covers, per algorithm, the two halves of the
+// acceptance criterion: a supplied checksum is echoed on PUT and comes back on GET
+// and HEAD under checksum-mode ENABLED, and is absent from both without it.
+func TestS3Checksum_PutObject_RoundTrip(t *testing.T) {
+	body := []byte("substrate checksum round trip")
+
+	for _, alg := range checksumAlgorithms {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			want := digestFor(t, alg.Name, body)
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				alg.Header: want,
+			})
+			require.Equal(t, http.StatusOK, w.Code, "PUT body: %s", w.Body.String())
+			assert.Equal(t, want, w.Header().Get(alg.Header), "PutObject echoes the checksum")
+			assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"),
+				"a single-part PUT is always a full-object checksum")
+
+			// GET with the mode enabled returns it.
+			w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+			assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+			assert.Equal(t, body, w.Body.Bytes())
+
+			// GET without it does not.
+			w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, nil)
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Empty(t, w.Header().Get(alg.Header),
+				"checksum must be absent without x-amz-checksum-mode: ENABLED")
+			assert.Empty(t, w.Header().Get("x-amz-checksum-type"))
+
+			// HEAD honors the mode identically.
+			w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+
+			w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Empty(t, w.Header().Get(alg.Header))
+		})
+	}
+}
+
+// TestS3Checksum_PutObject_BadDigest is the behavior the issue most wanted: a
+// wrong checksum is a 400 BadDigest, and the object is not written.
+func TestS3Checksum_PutObject_BadDigest(t *testing.T) {
+	body := []byte("payload that will be rejected")
+
+	for _, alg := range checksumAlgorithms {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, fs := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/rejected", body, map[string]string{
+				alg.Header: corruptDigest(t, alg.Name, body),
+			})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+			assert.Contains(t, w.Body.String(), "<ChecksumAlgorithm>"+alg.Name+"</ChecksumAlgorithm>")
+
+			// The object must not exist: neither its metadata nor its body.
+			w = s3Request(t, srv, http.MethodHead, "/cks/rejected", nil, nil)
+			assert.Equal(t, http.StatusNotFound, w.Code, "rejected object must not be readable")
+
+			exists, err := afero.Exists(fs, "/cks/rejected")
+			require.NoError(t, err)
+			assert.False(t, exists, "rejected object body must not be on the filesystem")
+		})
+	}
+}
+
+// TestS3Checksum_PutObject_BadDigestDoesNotOverwrite asserts the stronger property:
+// a rejected PUT over an existing object leaves the original bytes and checksum
+// intact, rather than truncating or partially replacing them.
+func TestS3Checksum_PutObject_BadDigestDoesNotOverwrite(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	original := []byte("the original contents")
+	originalDigest := digestFor(t, "SHA256", original)
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", original, map[string]string{
+		"x-amz-checksum-sha256": originalDigest,
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	originalETag := w.Header().Get("ETag")
+
+	replacement := []byte("a replacement that fails its checksum")
+	w = s3Request(t, srv, http.MethodPut, "/cks/obj", replacement, map[string]string{
+		"x-amz-checksum-sha256": corruptDigest(t, "SHA256", replacement),
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, original, w.Body.Bytes(), "body must be unchanged")
+	assert.Equal(t, originalETag, w.Header().Get("ETag"), "ETag must be unchanged")
+	assert.Equal(t, originalDigest, w.Header().Get("x-amz-checksum-sha256"),
+		"stored checksum must be unchanged")
+}
+
+// TestS3Checksum_SDKChecksumAlgorithm covers the second write shape: the caller
+// names an algorithm and substrate computes the digest.
+func TestS3Checksum_SDKChecksumAlgorithm(t *testing.T) {
+	body := []byte("service-computed digest")
+
+	for _, alg := range checksumAlgorithms {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				"x-amz-sdk-checksum-algorithm": alg.Name,
+			})
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, digestFor(t, alg.Name, body), w.Header().Get(alg.Header))
+
+			w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, digestFor(t, alg.Name, body), w.Header().Get(alg.Header))
+		})
+	}
+}
+
+// TestS3Checksum_NoChecksumHeaders asserts that an object written with no checksum
+// headers records none.
+//
+// This is a deliberate divergence from current S3, which attaches a default
+// CRC-64/NVME checksum to every upload. Synthesizing one here would make a
+// consumer's "the checksum came back" assertion pass whether or not their writer
+// sends a checksum at all — the precise failure #399 was filed about.
+func TestS3Checksum_NoChecksumHeaders(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/plain", []byte("no checksum"), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	for _, alg := range checksumAlgorithms {
+		assert.Empty(t, w.Header().Get(alg.Header))
+	}
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/plain", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("x-amz-checksum-crc64nvme"),
+		"substrate does not synthesize a default checksum")
+	assert.Empty(t, w.Header().Get("x-amz-checksum-type"))
+}
+
+// TestS3Checksum_ChecksumModeValues checks the gate itself: only ENABLED opens it,
+// and an unrecognized value is not an error.
+func TestS3Checksum_ChecksumModeValues(t *testing.T) {
+	body := []byte("mode gating")
+	want := digestFor(t, "SHA256", body)
+
+	tests := []struct {
+		name    string
+		mode    string
+		present bool
+	}{
+		{name: "enabled", mode: "ENABLED", present: true},
+		{name: "lowercase enabled", mode: "enabled", present: true},
+		{name: "mixed case enabled", mode: "Enabled", present: true},
+		{name: "absent", mode: "", present: false},
+		{name: "disabled", mode: "DISABLED", present: false},
+		{name: "unrecognized", mode: "sometimes", present: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				"x-amz-checksum-sha256": want,
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+
+			headers := map[string]string{}
+			if tc.mode != "" {
+				headers["x-amz-checksum-mode"] = tc.mode
+			}
+			w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, headers)
+			// An unrecognized mode is never an error; it just returns no checksum.
+			require.Equal(t, http.StatusOK, w.Code)
+			if tc.present {
+				assert.Equal(t, want, w.Header().Get("x-amz-checksum-sha256"))
+			} else {
+				assert.Empty(t, w.Header().Get("x-amz-checksum-sha256"))
+			}
+		})
+	}
+}
+
+// TestS3Checksum_PutObject_MalformedValue distinguishes a malformed checksum from a
+// wrong one: a value that is not base64, or is the wrong width for its algorithm,
+// is an InvalidRequest rather than a BadDigest.
+func TestS3Checksum_PutObject_MalformedValue(t *testing.T) {
+	body := []byte("malformed checksum values")
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "not base64", value: "!!!not-base64!!!"},
+		{name: "too short", value: base64.StdEncoding.EncodeToString([]byte("short"))},
+		{name: "too long", value: base64.StdEncoding.EncodeToString(make([]byte, 64))},
+		{name: "empty", value: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				"x-amz-checksum-sha256": tc.value,
+			})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+
+			w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+			assert.Equal(t, http.StatusNotFound, w.Code, "object must not be written")
+		})
+	}
+}
+
+// TestS3Checksum_PutObject_AlgorithmDisagreement covers the documented BadDigest
+// case where the two write headers name different algorithms: "if the individual
+// checksum value you provide through x-amz-checksum-<algorithm> doesn't match the
+// checksum algorithm you set through x-amz-sdk-checksum-algorithm, Amazon S3 fails
+// the request with a BadDigest error".
+func TestS3Checksum_PutObject_AlgorithmDisagreement(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("disagreeing algorithms")
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+		"x-amz-checksum-sha256":        digestFor(t, "SHA256", body),
+		"x-amz-sdk-checksum-algorithm": "CRC32",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+
+	w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestS3Checksum_PutObject_AlgorithmAgreement is the converse: the same algorithm
+// named in both headers is accepted.
+func TestS3Checksum_PutObject_AlgorithmAgreement(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("agreeing algorithms")
+	want := digestFor(t, "SHA256", body)
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+		"x-amz-checksum-sha256":        want,
+		"x-amz-sdk-checksum-algorithm": "sha256", // case-insensitive
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, want, w.Header().Get("x-amz-checksum-sha256"))
+}
+
+// TestS3Checksum_PutObject_MultipleChecksumHeaders asserts that two different
+// per-algorithm headers on one request is an InvalidRequest, not a silent pick.
+func TestS3Checksum_PutObject_MultipleChecksumHeaders(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("two checksums")
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", body),
+		"x-amz-checksum-crc32":  digestFor(t, "CRC32", body),
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+	assert.Contains(t, w.Body.String(), "Multiple checksum Types are not allowed")
+}
+
+// TestS3Checksum_UnsupportedAlgorithms asserts that the three algorithms substrate
+// cannot compute are refused with 501 rather than accepted unverified.
+//
+// This is the property that keeps substrate from being worse than no mock at all
+// for these algorithms: a caller learns immediately, instead of shipping a test
+// that passes on a checksum nothing ever checked.
+func TestS3Checksum_UnsupportedAlgorithms(t *testing.T) {
+	body := []byte("xxhash family")
+
+	for _, alg := range []struct{ Name, Header string }{
+		{"XXHASH64", "x-amz-checksum-xxhash64"},
+		{"XXHASH3", "x-amz-checksum-xxhash3"},
+		{"XXHASH128", "x-amz-checksum-xxhash128"},
+	} {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			// Supplied as a value...
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				alg.Header: base64.StdEncoding.EncodeToString([]byte("00000000")),
+			})
+			assert.Equal(t, http.StatusNotImplemented, w.Code)
+			assert.Contains(t, w.Body.String(), "<Code>NotImplemented</Code>")
+			assert.Contains(t, w.Body.String(), "<ChecksumAlgorithm>"+alg.Name+"</ChecksumAlgorithm>")
+
+			// ...and named for the service to compute.
+			w = s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				"x-amz-sdk-checksum-algorithm": alg.Name,
+			})
+			assert.Equal(t, http.StatusNotImplemented, w.Code)
+
+			w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+			assert.Equal(t, http.StatusNotFound, w.Code, "object must not be written")
+		})
+	}
+}
+
+// TestS3Checksum_UnknownAlgorithm asserts an algorithm outside the documented set
+// is an InvalidRequest.
+func TestS3Checksum_UnknownAlgorithm(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", []byte("x"), map[string]string{
+		"x-amz-sdk-checksum-algorithm": "SHA3",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+	assert.Contains(t, w.Body.String(), "<ChecksumAlgorithm>SHA3</ChecksumAlgorithm>")
+}
+
+// TestS3Checksum_EmptyBody asserts a zero-byte object gets the digest of the empty
+// string, not an absent checksum.
+func TestS3Checksum_EmptyBody(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	want := digestFor(t, "CRC32", nil)
+	require.Equal(t, "AAAAAA==", want, "CRC32 of the empty string")
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/empty", []byte{}, map[string]string{
+		"x-amz-checksum-crc32": want,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/empty", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, want, w.Header().Get("x-amz-checksum-crc32"))
+}
+
+// TestS3Checksum_RangedGetReturnsObjectChecksum documents how a checksum composes
+// with a ranged read: the header is the whole object's checksum, so it must not be
+// mistaken for a checksum of the bytes actually served.
+func TestS3Checksum_RangedGetReturnsObjectChecksum(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("0123456789abcdefghij")
+	want := digestFor(t, "SHA256", body)
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+		"x-amz-checksum-sha256": want,
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+		"Range":               "bytes=0-3",
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, []byte("0123"), w.Body.Bytes())
+	assert.Equal(t, want, w.Header().Get("x-amz-checksum-sha256"),
+		"the checksum is the full object's, not the range's")
+}
+
+// TestS3Checksum_Versioning asserts each version keeps its own checksum.
+func TestS3Checksum_Versioning(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPut, "/cks?versioning", []byte(
+		`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	first := []byte("version one")
+	w = s3Request(t, srv, http.MethodPut, "/cks/obj", first, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", first),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	v1 := w.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, v1)
+
+	second := []byte("version two, which differs")
+	w = s3Request(t, srv, http.MethodPut, "/cks/obj", second, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", second),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/obj?versionId="+v1, nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "SHA256", first), w.Header().Get("x-amz-checksum-sha256"),
+		"the old version keeps its own checksum")
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "SHA256", second), w.Header().Get("x-amz-checksum-sha256"))
+}
+
+// --- aws-chunked trailing checksums ---
+
+// awsChunkedBody frames body as a single aws-chunked object chunk followed by a
+// completion chunk and a trailer, in the format the S3 user guide documents:
+//
+//	x-amz-checksum-<alg>:<base64>\n\r\n\r\n
+func awsChunkedBody(body []byte, trailerName, trailerValue string) []byte {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%x\r\n", len(body))
+	b.Write(body)
+	b.WriteString("\r\n0\r\n")
+	if trailerName != "" {
+		fmt.Fprintf(&b, "%s:%s\n\r\n", trailerName, trailerValue)
+	}
+	b.WriteString("\r\n")
+	return []byte(b.String())
+}
+
+// awsChunkedHeaders builds the header set that marks a body as aws-chunked with a
+// trailing checksum.
+func awsChunkedHeaders(decodedLen int, trailerName string) map[string]string {
+	h := map[string]string{
+		"Content-Encoding":             "aws-chunked",
+		"x-amz-content-sha256":         "STREAMING-UNSIGNED-PAYLOAD-TRAILER",
+		"x-amz-decoded-content-length": fmt.Sprintf("%d", decodedLen),
+	}
+	if trailerName != "" {
+		h["x-amz-trailer"] = trailerName
+	}
+	return h
+}
+
+// TestS3Checksum_TrailingChecksum_Accepted asserts that a checksum arriving in an
+// aws-chunked trailer is verified, not discarded.
+//
+// This is the path every real SDK upload takes when given a ChecksumAlgorithm, so a
+// decoder that dropped trailers would make checksum verification silently
+// unreachable in exactly the case consumers care about.
+func TestS3Checksum_TrailingChecksum_Accepted(t *testing.T) {
+	body := []byte("streamed with a trailing checksum")
+
+	for _, alg := range checksumAlgorithms {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			want := digestFor(t, alg.Name, body)
+			framed := awsChunkedBody(body, alg.Header, want)
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/streamed", framed,
+				awsChunkedHeaders(len(body), alg.Header))
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+
+			// The stored body must be the decoded content, not the framing.
+			w = s3Request(t, srv, http.MethodGet, "/cks/streamed", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, body, w.Body.Bytes())
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+		})
+	}
+}
+
+// TestS3Checksum_TrailingChecksum_BadDigest asserts a wrong trailing checksum is
+// rejected and writes nothing — the same guarantee as the header form.
+func TestS3Checksum_TrailingChecksum_BadDigest(t *testing.T) {
+	srv, fs := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("streamed but corrupt")
+	framed := awsChunkedBody(body, "x-amz-checksum-crc32", corruptDigest(t, "CRC32", body))
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/streamed", framed,
+		awsChunkedHeaders(len(body), "x-amz-checksum-crc32"))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+
+	exists, err := afero.Exists(fs, "/cks/streamed")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+// TestS3Checksum_TrailingChecksum_SignedFraming asserts the trailer is still found
+// when the chunks carry SigV4 signatures and a trailer signature line follows.
+func TestS3Checksum_TrailingChecksum_SignedFraming(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("signed chunks with a trailing checksum")
+	want := digestFor(t, "CRC32C", body)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%x;chunk-signature=%s\r\n", len(body), strings.Repeat("a", 64))
+	b.Write(body)
+	fmt.Fprintf(&b, "\r\n0;chunk-signature=%s\r\n", strings.Repeat("b", 64))
+	fmt.Fprintf(&b, "x-amz-checksum-crc32c:%s\n\r\n", want)
+	fmt.Fprintf(&b, "%s\r\n\r\n", strings.Repeat("c", 64)) // trailer signature
+
+	headers := awsChunkedHeaders(len(body), "x-amz-checksum-crc32c")
+	headers["x-amz-content-sha256"] = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER"
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/signed", []byte(b.String()), headers)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, want, w.Header().Get("x-amz-checksum-crc32c"))
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/signed", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, body, w.Body.Bytes())
+}
+
+// TestS3Checksum_TrailingChecksum_NameMismatch asserts the documented rule that the
+// trailer's header name must match what x-amz-trailer declared: "if a request
+// contains x-amz-trailer: x-amz-checksum-crc32 and the trailer chunk has the header
+// name x-amz-checksum-sha1, the request fails".
+func TestS3Checksum_TrailingChecksum_NameMismatch(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("mismatched trailer name")
+	framed := awsChunkedBody(body, "x-amz-checksum-sha1", digestFor(t, "SHA1", body))
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", framed,
+		awsChunkedHeaders(len(body), "x-amz-checksum-crc32"))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>MalformedTrailerError</Code>")
+
+	w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestS3Checksum_NonChunkedBodyUnaffected guards the decoder's no-op path: a plain
+// body whose content happens to resemble chunk framing must be stored verbatim.
+func TestS3Checksum_NonChunkedBodyUnaffected(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("5\r\nhello\r\n0\r\n\r\n")
+	want := digestFor(t, "SHA256", body)
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/plain", body, map[string]string{
+		"x-amz-checksum-sha256": want,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/plain", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, body, w.Body.Bytes())
+}
+
+// --- multipart ---
+
+// uploadIDOf extracts the UploadId from an InitiateMultipartUploadResult body.
+func uploadIDOf(t *testing.T, body string) string {
+	t.Helper()
+	var res struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &res))
+	require.NotEmpty(t, res.UploadID)
+	return res.UploadID
+}
+
+// multipartPartBodies is a two-part fixture. The parts differ in content so that a
+// composite checksum computed over the wrong concatenation cannot coincidentally
+// match, and they differ in length so that a digest taken over the wrong slice
+// boundary cannot either.
+//
+// The first part is exactly the minimum part size: anything smaller is rejected by
+// CompleteMultipartUpload with EntityTooSmall (#400) before checksum assembly runs.
+func multipartPartBodies() [][]byte {
+	return [][]byte{
+		bytes.Repeat([]byte("a"), s3MinPartSize),
+		bytes.Repeat([]byte("b"), 32),
+	}
+}
+
+// compositeChecksum computes the expected COMPOSITE object checksum independently:
+// the digest of the concatenated raw part digests, suffixed with the part count.
+func compositeChecksum(t *testing.T, name string, parts [][]byte) string {
+	t.Helper()
+	var alg struct {
+		New func() hash.Hash
+	}
+	for _, a := range checksumAlgorithms {
+		if a.Name == name {
+			alg.New = a.New
+		}
+	}
+	require.NotNil(t, alg.New, "no test implementation for %q", name)
+
+	var digests []byte
+	for _, part := range parts {
+		h := alg.New()
+		h.Write(part)
+		digests = append(digests, h.Sum(nil)...)
+	}
+	outer := alg.New()
+	outer.Write(digests)
+	return fmt.Sprintf("%s-%d", base64.StdEncoding.EncodeToString(outer.Sum(nil)), len(parts))
+}
+
+// TestS3Checksum_Multipart_Composite is the acceptance criterion's multipart case:
+// a COMPOSITE upload's object checksum is base64(digest-of-concatenated-part-digests)
+// with the "-N" suffix, returned as an XML element in the Complete result and as a
+// header on a subsequent GET.
+func TestS3Checksum_Multipart_Composite(t *testing.T) {
+	parts := multipartPartBodies()
+
+	for _, alg := range checksumAlgorithms {
+		if !alg.Composite {
+			continue
+		}
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+				"x-amz-checksum-algorithm": alg.Name,
+			})
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, alg.Name, w.Header().Get("x-amz-checksum-algorithm"))
+			assert.Equal(t, "COMPOSITE", w.Header().Get("x-amz-checksum-type"),
+				"an absent x-amz-checksum-type defaults to COMPOSITE")
+			uploadID := uploadIDOf(t, w.Body.String())
+
+			var etags []string
+			for i, part := range parts {
+				num := i + 1
+				w = s3Request(t, srv, http.MethodPut,
+					fmt.Sprintf("/cks/big?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+				require.Equal(t, http.StatusOK, w.Code, "upload part %d: %s", num, w.Body.String())
+				assert.Equal(t, digestFor(t, alg.Name, part), w.Header().Get(alg.Header),
+					"UploadPart echoes the part checksum")
+				etags = append(etags, w.Header().Get("ETag"))
+			}
+
+			want := compositeChecksum(t, alg.Name, parts)
+
+			w = s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+				completeBody(etags...), nil)
+			require.Equal(t, http.StatusOK, w.Code, "complete: %s", w.Body.String())
+			assert.Contains(t, w.Body.String(), "<Checksum"+alg.Name+">"+want+"</Checksum"+alg.Name+">",
+				"Complete returns the checksum as an XML element, not a header")
+			assert.Contains(t, w.Body.String(), "<ChecksumType>COMPOSITE</ChecksumType>")
+
+			// The "-N" suffix form is the property the reporter asked for explicitly.
+			assert.True(t, strings.HasSuffix(want, "-2"), "fixture sanity: two parts")
+
+			w = s3Request(t, srv, http.MethodGet, "/cks/big", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+			assert.Equal(t, "COMPOSITE", w.Header().Get("x-amz-checksum-type"))
+		})
+	}
+}
+
+// TestS3Checksum_Multipart_FullObject asserts a FULL_OBJECT multipart checksum is
+// the digest of every byte of the assembled object, with no "-N" suffix — and that
+// it equals what a single-part PUT of the same bytes would produce.
+//
+// That equality is the invariant the reporter's second bug violated: a single-part
+// and a multipart writer must agree on the checksum of identical content.
+func TestS3Checksum_Multipart_FullObject(t *testing.T) {
+	parts := multipartPartBodies()
+	var combined []byte
+	for _, p := range parts {
+		combined = append(combined, p...)
+	}
+
+	for _, alg := range checksumAlgorithms {
+		if !alg.FullObject {
+			continue
+		}
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+				"x-amz-checksum-algorithm": alg.Name,
+				"x-amz-checksum-type":      "FULL_OBJECT",
+			})
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+			uploadID := uploadIDOf(t, w.Body.String())
+
+			var etags []string
+			for i, part := range parts {
+				num := i + 1
+				w = s3Request(t, srv, http.MethodPut,
+					fmt.Sprintf("/cks/big?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+				require.Equal(t, http.StatusOK, w.Code)
+				etags = append(etags, w.Header().Get("ETag"))
+			}
+
+			want := digestFor(t, alg.Name, combined)
+
+			w = s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+				completeBody(etags...), nil)
+			require.Equal(t, http.StatusOK, w.Code, "complete: %s", w.Body.String())
+			assert.Contains(t, w.Body.String(), "<Checksum"+alg.Name+">"+want+"</Checksum"+alg.Name+">")
+			assert.Contains(t, w.Body.String(), "<ChecksumType>FULL_OBJECT</ChecksumType>")
+			assert.NotContains(t, want, "-", "a full-object checksum carries no part-count suffix")
+
+			// A single-part PUT of identical bytes must produce an identical value.
+			w = s3Request(t, srv, http.MethodPut, "/cks/single", combined, map[string]string{
+				"x-amz-sdk-checksum-algorithm": alg.Name,
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, want, w.Header().Get(alg.Header),
+				"single-part and full-object multipart checksums of the same bytes must agree")
+		})
+	}
+}
+
+// TestS3Checksum_Multipart_CompositeDiffersFromFullObject pins the distinction the
+// two types exist to express: for the same bytes they are different values, so a
+// consumer that mixes them up gets a mismatch rather than an accidental pass.
+func TestS3Checksum_Multipart_CompositeDiffersFromFullObject(t *testing.T) {
+	parts := multipartPartBodies()
+	var combined []byte
+	for _, p := range parts {
+		combined = append(combined, p...)
+	}
+
+	composite := compositeChecksum(t, "CRC32", parts)
+	fullObject := digestFor(t, "CRC32", combined)
+	assert.NotEqual(t, composite, fullObject,
+		"COMPOSITE and FULL_OBJECT are computed differently and must not coincide")
+}
+
+// TestS3Checksum_Multipart_UnsupportedType asserts the documented support matrix is
+// enforced at CreateMultipartUpload — before any part is uploaded, since an upload
+// that could never complete against real S3 should fail at creation.
+func TestS3Checksum_Multipart_UnsupportedType(t *testing.T) {
+	tests := []struct {
+		name      string
+		algorithm string
+		cksType   string
+	}{
+		{name: "SHA256 full object", algorithm: "SHA256", cksType: "FULL_OBJECT"},
+		{name: "SHA1 full object", algorithm: "SHA1", cksType: "FULL_OBJECT"},
+		{name: "SHA512 full object", algorithm: "SHA512", cksType: "FULL_OBJECT"},
+		{name: "MD5 full object", algorithm: "MD5", cksType: "FULL_OBJECT"},
+		{name: "CRC64NVME composite", algorithm: "CRC64NVME", cksType: "COMPOSITE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+				"x-amz-checksum-algorithm": tc.algorithm,
+				"x-amz-checksum-type":      tc.cksType,
+			})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+			assert.Contains(t, w.Body.String(), "<ChecksumAlgorithm>"+tc.algorithm+"</ChecksumAlgorithm>")
+			assert.Contains(t, w.Body.String(), "<ChecksumType>"+tc.cksType+"</ChecksumType>")
+		})
+	}
+}
+
+// TestS3Checksum_Multipart_CRC64NVMEDefaultsToFullObject covers the one algorithm
+// with no composite form: an absent x-amz-checksum-type must default to FULL_OBJECT
+// rather than to the COMPOSITE every other algorithm gets.
+func TestS3Checksum_Multipart_CRC64NVMEDefaultsToFullObject(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "CRC64NVME",
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+}
+
+// TestS3Checksum_Multipart_PartAlgorithmMismatch asserts a part supplying a
+// checksum under a different algorithm than the upload's is rejected — its digest
+// could not contribute to the object's checksum.
+func TestS3Checksum_Multipart_PartAlgorithmMismatch(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "SHA256",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	uploadID := uploadIDOf(t, w.Body.String())
+
+	part := []byte("a part checksummed the wrong way")
+	w = s3Request(t, srv, http.MethodPut, "/cks/big?partNumber=1&uploadId="+uploadID, part,
+		map[string]string{"x-amz-checksum-crc32": digestFor(t, "CRC32", part)})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+	assert.Contains(t, w.Body.String(), "<UploadChecksumAlgorithm>SHA256</UploadChecksumAlgorithm>")
+}
+
+// TestS3Checksum_Multipart_PartBadDigest asserts a part whose supplied checksum is
+// wrong is rejected and not stored, so a later Complete cannot pick it up.
+func TestS3Checksum_Multipart_PartBadDigest(t *testing.T) {
+	srv, fs := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "SHA256",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	uploadID := uploadIDOf(t, w.Body.String())
+
+	part := []byte("a corrupt part")
+	w = s3Request(t, srv, http.MethodPut, "/cks/big?partNumber=1&uploadId="+uploadID, part,
+		map[string]string{"x-amz-checksum-sha256": corruptDigest(t, "SHA256", part)})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+
+	exists, err := afero.Exists(fs, fmt.Sprintf("/.multipart/%s/1", uploadID))
+	require.NoError(t, err)
+	assert.False(t, exists, "rejected part must not be stored")
+}
+
+// TestS3Checksum_Multipart_CompleteFullObjectVerified asserts Complete verifies a
+// full-object checksum the caller supplies for the whole upload, and rejects a
+// wrong one without writing the object.
+func TestS3Checksum_Multipart_CompleteFullObjectVerified(t *testing.T) {
+	parts := multipartPartBodies()
+	var combined []byte
+	for _, p := range parts {
+		combined = append(combined, p...)
+	}
+
+	startUpload := func(t *testing.T, srv *emulator.Server) (string, []string) {
+		t.Helper()
+		w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+			"x-amz-checksum-algorithm": "CRC32",
+			"x-amz-checksum-type":      "FULL_OBJECT",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+		uploadID := uploadIDOf(t, w.Body.String())
+
+		var etags []string
+		for i, part := range parts {
+			num := i + 1
+			w = s3Request(t, srv, http.MethodPut,
+				fmt.Sprintf("/cks/big?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+			require.Equal(t, http.StatusOK, w.Code)
+			etags = append(etags, w.Header().Get("ETag"))
+		}
+		return uploadID, etags
+	}
+
+	t.Run("correct value accepted", func(t *testing.T) {
+		srv, _ := newS3TestServer(t)
+		putBucket(t, srv, "cks")
+		uploadID, etags := startUpload(t, srv)
+
+		w := s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+			completeBody(etags...), map[string]string{
+				"x-amz-checksum-crc32": digestFor(t, "CRC32", combined),
+			})
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	})
+
+	t.Run("wrong value rejected", func(t *testing.T) {
+		srv, _ := newS3TestServer(t)
+		putBucket(t, srv, "cks")
+		uploadID, etags := startUpload(t, srv)
+
+		w := s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+			completeBody(etags...), map[string]string{
+				"x-amz-checksum-crc32": corruptDigest(t, "CRC32", combined),
+			})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+
+		w = s3Request(t, srv, http.MethodHead, "/cks/big", nil, nil)
+		assert.Equal(t, http.StatusNotFound, w.Code, "object must not be written")
+	})
+
+	t.Run("disagreeing type rejected", func(t *testing.T) {
+		srv, _ := newS3TestServer(t)
+		putBucket(t, srv, "cks")
+		uploadID, etags := startUpload(t, srv)
+
+		w := s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+			completeBody(etags...), map[string]string{
+				"x-amz-checksum-type": "COMPOSITE",
+			})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+		assert.Contains(t, w.Body.String(), "<UploadChecksumType>FULL_OBJECT</UploadChecksumType>")
+	})
+}
+
+// TestS3Checksum_Multipart_NoAlgorithm asserts an upload created without a checksum
+// algorithm completes without one, and reports no checksum elements.
+func TestS3Checksum_Multipart_NoAlgorithm(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("x-amz-checksum-algorithm"))
+	assert.Empty(t, w.Header().Get("x-amz-checksum-type"))
+	uploadID := uploadIDOf(t, w.Body.String())
+
+	var etags []string
+	for i, part := range multipartPartBodies() {
+		num := i + 1
+		w = s3Request(t, srv, http.MethodPut,
+			fmt.Sprintf("/cks/big?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, w.Header().Get("x-amz-checksum-sha256"))
+		etags = append(etags, w.Header().Get("ETag"))
+	}
+
+	w = s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID, completeBody(etags...), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, w.Body.String(), "<ChecksumType>")
+	assert.NotContains(t, w.Body.String(), "<ChecksumCRC64NVME>")
+}
+
+// TestS3Checksum_Multipart_TypeWithoutAlgorithm asserts a checksum type with no
+// algorithm to apply to is an InvalidRequest.
+func TestS3Checksum_Multipart_TypeWithoutAlgorithm(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-type": "FULL_OBJECT",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+}
+
+// TestS3Checksum_Multipart_InvalidType asserts a type outside the documented pair
+// is an InvalidRequest.
+func TestS3Checksum_Multipart_InvalidType(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "CRC32",
+		"x-amz-checksum-type":      "PARTIAL",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+	assert.Contains(t, w.Body.String(), "<ChecksumType>PARTIAL</ChecksumType>")
+}
+
+// --- CopyObject ---
+
+// TestS3Checksum_CopyObject_RecomputesFullObject asserts a copy carries the source's
+// algorithm but recomputes the value as a direct full-object checksum: "with a copy
+// command, the checksum of the object is a direct checksum of the full object. If
+// the object was originally uploaded using a multipart upload, the checksum value
+// changes even though the data doesn't".
+func TestS3Checksum_CopyObject_RecomputesFullObject(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("copied with its checksum")
+	w := s3Request(t, srv, http.MethodPut, "/cks/src", body, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", body),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst", nil, map[string]string{
+		"x-amz-copy-source": "/cks/src",
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "SHA256", body), w.Header().Get("x-amz-checksum-sha256"),
+		"the source's algorithm is kept when none is named")
+	assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+}
+
+// TestS3Checksum_CopyObject_NewAlgorithm asserts a copy can switch algorithms:
+// "you can copy the object and specify whether you want to use the existing
+// checksum algorithm or a new one".
+func TestS3Checksum_CopyObject_NewAlgorithm(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("re-checksummed on copy")
+	w := s3Request(t, srv, http.MethodPut, "/cks/src", body, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", body),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst", nil, map[string]string{
+		"x-amz-copy-source":        "/cks/src",
+		"x-amz-checksum-algorithm": "CRC32C",
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "CRC32C", body), w.Header().Get("x-amz-checksum-crc32c"))
+	assert.Empty(t, w.Header().Get("x-amz-checksum-sha256"), "the old algorithm is replaced")
+}
+
+// TestS3Checksum_CopyObject_CompositeBecomesFullObject asserts the documented
+// consequence for a multipart source: copying it changes the checksum value and its
+// type, even though the bytes are identical.
+func TestS3Checksum_CopyObject_CompositeBecomesFullObject(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	parts := multipartPartBodies()
+	var combined []byte
+	for _, p := range parts {
+		combined = append(combined, p...)
+	}
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/src?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "CRC32",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	uploadID := uploadIDOf(t, w.Body.String())
+
+	var etags []string
+	for i, part := range parts {
+		num := i + 1
+		w = s3Request(t, srv, http.MethodPut,
+			fmt.Sprintf("/cks/src?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+		etags = append(etags, w.Header().Get("ETag"))
+	}
+	w = s3Request(t, srv, http.MethodPost, "/cks/src?uploadId="+uploadID, completeBody(etags...), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	composite := compositeChecksum(t, "CRC32", parts)
+
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst", nil, map[string]string{
+		"x-amz-copy-source": "/cks/src",
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "CRC32", combined), w.Header().Get("x-amz-checksum-crc32"))
+	assert.NotEqual(t, composite, w.Header().Get("x-amz-checksum-crc32"),
+		"the value changes even though the data does not")
+	assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+}
+
+// TestS3Checksum_CopyObject_UnchecksummedSource asserts a source with no checksum
+// yields a destination with none, unless the copy names an algorithm.
+func TestS3Checksum_CopyObject_UnchecksummedSource(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("no checksum on the source")
+	w := s3Request(t, srv, http.MethodPut, "/cks/src", body, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst", nil, map[string]string{
+		"x-amz-copy-source": "/cks/src",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("x-amz-checksum-type"))
+
+	// Naming an algorithm on the copy adds one.
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst2", nil, map[string]string{
+		"x-amz-copy-source":        "/cks/src",
+		"x-amz-checksum-algorithm": "SHA1",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst2", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "SHA1", body), w.Header().Get("x-amz-checksum-sha1"))
+}

--- a/emulator/s3_conditional.go
+++ b/emulator/s3_conditional.go
@@ -1,0 +1,234 @@
+package emulator
+
+import (
+	"hash/fnv"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// s3KeyLockStripes is the number of mutexes in [S3Plugin]'s per-key stripe set.
+// A power of two well above the concurrency any test drives, so distinct keys
+// almost never contend.
+const s3KeyLockStripes = 64
+
+// s3KeyMutex is a striped mutex set serializing writes per object key.
+//
+// It exists because [StateManager] offers no compare-and-swap: Get/Put/Delete/List
+// only, and [MemoryStateManager] is last-write-wins. A conditional write that
+// checked existence and then called Put would leave a window in which every one of
+// N concurrent `If-None-Match: *` PUTs observes the key as absent and all succeed —
+// precisely inverting the exactly-one-winner property such a write is used for.
+// Holding a per-key lock across check→Put closes that window.
+//
+// The guarantee this provides is deliberately bounded: it is *process-local*. It is
+// airtight for substrate's single-process topology, which is how tests use it, and
+// it would not hold across two emulator processes sharing one state backend. That
+// boundary is a property of the state layer, not of this lock.
+type s3KeyMutex struct {
+	stripes [s3KeyLockStripes]sync.Mutex
+}
+
+// lock acquires the stripe guarding bucket/key and returns its unlock function.
+func (m *s3KeyMutex) lock(bucket, key string) func() {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(bucket))
+	_, _ = h.Write([]byte{'/'})
+	_, _ = h.Write([]byte(key))
+	mu := &m.stripes[h.Sum32()%s3KeyLockStripes]
+	mu.Lock()
+	return mu.Unlock
+}
+
+// s3PreconditionFailedMessage is the message S3 pairs with PreconditionFailed.
+const s3PreconditionFailedMessage = "At least one of the pre-conditions you specified did not hold"
+
+// s3ConditionalHeaders holds the RFC 7232 precondition headers of a request,
+// already resolved case-insensitively.
+//
+// The distinction between an absent header and an empty one matters: an absent
+// header imposes no condition, whereas an empty value is a condition that cannot
+// be met. present tracks which of the four were sent at all.
+type s3ConditionalHeaders struct {
+	IfMatch           string
+	IfNoneMatch       string
+	IfModifiedSince   string
+	IfUnmodifiedSince string
+
+	hasIfMatch           bool
+	hasIfNoneMatch       bool
+	hasIfModifiedSince   bool
+	hasIfUnmodifiedSince bool
+}
+
+// readConditionalHeaders extracts the four read preconditions from a request.
+func readConditionalHeaders(headers map[string]string) s3ConditionalHeaders {
+	c := s3ConditionalHeaders{}
+	c.IfMatch, c.hasIfMatch = headerLookupFold(headers, "If-Match")
+	c.IfNoneMatch, c.hasIfNoneMatch = headerLookupFold(headers, "If-None-Match")
+	c.IfModifiedSince, c.hasIfModifiedSince = headerLookupFold(headers, "If-Modified-Since")
+	c.IfUnmodifiedSince, c.hasIfUnmodifiedSince = headerLookupFold(headers, "If-Unmodified-Since")
+	return c
+}
+
+// copySourceConditionalHeaders extracts CopyObject's source preconditions, which
+// are the same four conditions under x-amz-copy-source-* names. They gate reading
+// the source, whereas the unprefixed headers gate overwriting the destination, so a
+// single CopyObject request can carry both sets.
+func copySourceConditionalHeaders(headers map[string]string) s3ConditionalHeaders {
+	c := s3ConditionalHeaders{}
+	c.IfMatch, c.hasIfMatch = headerLookupFold(headers, "x-amz-copy-source-if-match")
+	c.IfNoneMatch, c.hasIfNoneMatch = headerLookupFold(headers, "x-amz-copy-source-if-none-match")
+	c.IfModifiedSince, c.hasIfModifiedSince = headerLookupFold(headers, "x-amz-copy-source-if-modified-since")
+	c.IfUnmodifiedSince, c.hasIfUnmodifiedSince = headerLookupFold(headers, "x-amz-copy-source-if-unmodified-since")
+	return c
+}
+
+// any reports whether the request carried any precondition at all, letting a
+// caller skip the whole evaluation on the common unconditional path.
+func (c s3ConditionalHeaders) any() bool {
+	return c.hasIfMatch || c.hasIfNoneMatch || c.hasIfModifiedSince || c.hasIfUnmodifiedSince
+}
+
+// headerLookupFold returns the value of the named header and whether it was
+// present, matching the name case-insensitively. It exists alongside
+// [headerValueFold] because a precondition header sent with an empty value is a
+// condition that fails, not an absent condition.
+func headerLookupFold(headers map[string]string, name string) (string, bool) {
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// evaluateReadPreconditions applies the GetObject/HeadObject preconditions to an
+// object that has already been found, returning the error response to serve or nil
+// to proceed.
+//
+// The two combination rules are S3's own, and both exist to stop a
+// cache-validation header from overriding an explicit ETag assertion:
+//
+//   - If-Match true and If-Unmodified-Since false → 200, not 412. The caller
+//     named the exact entity it wanted and got it; a coarser timestamp condition
+//     does not override that.
+//   - If-None-Match false and If-Modified-Since true → 304, not 200. The caller
+//     already holds this entity, so there is nothing to send regardless of dates.
+//
+// A precondition on an absent object is not evaluated at all — the caller's
+// NoSuchKey comes first, since there is no ETag to compare against.
+func evaluateReadPreconditions(c s3ConditionalHeaders, obj *S3Object) *AWSResponse {
+	if !c.any() {
+		return nil
+	}
+
+	// If-Match / If-None-Match are evaluated first: an explicit entity assertion
+	// outranks the date conditions, per the two rules above.
+	if c.hasIfNoneMatch && s3ETagMatches(c.IfNoneMatch, obj.ETag) {
+		// The caller holds this entity. 304 carries no body and no explanation.
+		return &AWSResponse{StatusCode: http.StatusNotModified, Headers: map[string]string{"ETag": obj.ETag}}
+	}
+	if c.hasIfMatch && !s3ETagMatches(c.IfMatch, obj.ETag) {
+		return s3PreconditionFailedResponse()
+	}
+
+	// If-None-Match evaluated false and did not return above; If-Modified-Since is
+	// then redundant with it, so S3 skips it. Likewise a satisfied If-Match
+	// suppresses If-Unmodified-Since.
+	if c.hasIfModifiedSince && !c.hasIfNoneMatch {
+		if since, ok := parseHTTPDate(c.IfModifiedSince); ok && !obj.LastModified.After(since) {
+			return &AWSResponse{StatusCode: http.StatusNotModified, Headers: map[string]string{"ETag": obj.ETag}}
+		}
+	}
+	if c.hasIfUnmodifiedSince && !c.hasIfMatch {
+		if since, ok := parseHTTPDate(c.IfUnmodifiedSince); ok && obj.LastModified.After(since) {
+			return s3PreconditionFailedResponse()
+		}
+	}
+
+	return nil
+}
+
+// evaluateWritePreconditions applies the PutObject/CopyObject/Complete conditional
+// write preconditions against the current state of the destination key, returning
+// the error response to serve or nil to proceed.
+//
+// current is the destination object, or nil when the key is absent. A delete
+// marker counts as absent: S3 documents both headers as evaluating against the
+// current version, and "if the current object version is a delete marker" the
+// If-None-Match write succeeds and the If-Match write is a 404.
+//
+// Unlike a read, an absent key is not an early NoSuchKey — its absence is exactly
+// what If-None-Match asserts.
+func evaluateWritePreconditions(c s3ConditionalHeaders, current *S3Object) *AWSResponse {
+	exists := current != nil && !current.IsDeleteMarker
+
+	if c.hasIfNoneMatch {
+		// "The If-None-Match header expects the * (asterisk) value." Any other
+		// value is not a supported form on a write; treat it as unmet rather than
+		// silently allowing the overwrite it was sent to prevent.
+		if strings.TrimSpace(c.IfNoneMatch) != "*" || exists {
+			return s3PreconditionFailedResponse()
+		}
+	}
+
+	if c.hasIfMatch {
+		if !exists {
+			// "If there's no current object version with the same name, or if the
+			// current object version is a delete marker, the operation fails with
+			// a 404 Not Found error."
+			return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound)
+		}
+		if !s3ETagMatches(c.IfMatch, current.ETag) {
+			return s3PreconditionFailedResponse()
+		}
+	}
+
+	return nil
+}
+
+// s3PreconditionFailedResponse builds the 412 PreconditionFailed response. The
+// code string is what an SDK matches on to distinguish a lost race from a real
+// failure, so it must be exact.
+func s3PreconditionFailedResponse() *AWSResponse {
+	return s3ErrorResponse("PreconditionFailed", s3PreconditionFailedMessage, http.StatusPreconditionFailed)
+}
+
+// s3ETagMatches reports whether an If-Match or If-None-Match header value matches
+// an object's ETag. "*" matches any existing entity. A comma-separated list
+// matches if any member does, per RFC 7232 — S3 restricts the write form of
+// If-None-Match to "*", but the read form accepts a list.
+//
+// Comparison ignores quoting, weak-validator prefixes and hex case, since clients
+// differ on whether they echo back the quotes S3 sends.
+func s3ETagMatches(header, etag string) bool {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return false
+	}
+	if header == "*" {
+		return true
+	}
+	for _, candidate := range strings.Split(header, ",") {
+		if s3ETagsEqual(candidate, etag) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseHTTPDate parses an If-Modified-Since / If-Unmodified-Since value, accepting
+// the three formats RFC 9110 requires a recipient to handle. An unparseable date
+// makes the condition inapplicable rather than failed, which is what RFC 9110
+// specifies and what keeps a malformed date from turning into a spurious 412.
+func parseHTTPDate(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	for _, layout := range []string{http.TimeFormat, time.RFC850, time.ANSIC} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}

--- a/emulator/s3_conditional_test.go
+++ b/emulator/s3_conditional_test.go
@@ -1,0 +1,1050 @@
+package emulator_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// condFixture creates a bucket and returns the server. The bucket is empty; each
+// test PUTs whatever it needs, so no test inherits another's object state.
+func condFixture(t *testing.T, bucket string) *emulator.Server {
+	t.Helper()
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code, "create bucket")
+	return srv
+}
+
+// putCondObject PUTs an object unconditionally and returns its ETag.
+func putCondObject(t *testing.T, srv *emulator.Server, bucket, key, body string) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte(body), nil)
+	require.Equal(t, http.StatusOK, w.Code, "seed PUT: %s", w.Body)
+	etag := w.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+	return etag
+}
+
+// getCondBody returns an object's body, requiring the GET to succeed.
+func getCondBody(t *testing.T, srv *emulator.Server, bucket, key string) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"/"+key, nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	return w.Body.String()
+}
+
+// TestS3_ConditionalWrite is the acceptance table for #397's write rows: the five
+// PutObject outcomes S3 documents for If-None-Match and If-Match.
+//
+// Every case asserts the stored body afterwards, not just the status code. A 412
+// that still overwrote the object would satisfy a status-only assertion while
+// destroying exactly the data the header was sent to protect.
+func TestS3_ConditionalWrite(t *testing.T) {
+	const (
+		bucket   = "cond-write"
+		existing = "original"
+		attempt  = "overwrite"
+	)
+
+	tests := []struct {
+		name string
+		// seed is written first; "" leaves the key absent.
+		seed string
+		// header returns the precondition header, given the seeded object's ETag
+		// ("" when nothing was seeded).
+		header     func(etag string) map[string]string
+		wantStatus int
+		wantCode   string
+		// wantBody is the body expected after the attempt. "" means the key must
+		// still not exist.
+		wantBody string
+	}{
+		{
+			name: "If-None-Match star, key absent",
+			seed: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   attempt,
+		},
+		{
+			name: "If-None-Match star, key present",
+			seed: existing,
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+			wantBody:   existing,
+		},
+		{
+			name: "If-Match matching etag",
+			seed: existing,
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-Match": etag}
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   attempt,
+		},
+		{
+			name: "If-Match differing etag",
+			seed: existing,
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+			wantBody:   existing,
+		},
+		{
+			// "If there's no current object version with the same name … the
+			// operation fails with a 404 Not Found error." Not a 412: there is
+			// nothing to compare the ETag against.
+			name: "If-Match, key absent",
+			seed: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NoSuchKey",
+			wantBody:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, bucket)
+
+			var etag string
+			if tt.seed != "" {
+				etag = putCondObject(t, srv, bucket, "obj.txt", tt.seed)
+			}
+
+			w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/obj.txt",
+				[]byte(attempt), tt.header(etag))
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+			if tt.wantCode != "" {
+				assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+			}
+
+			gw := s3Request(t, srv, http.MethodGet, "/"+bucket+"/obj.txt", nil, nil)
+			if tt.wantBody == "" {
+				assert.Equal(t, http.StatusNotFound, gw.Code,
+					"a rejected conditional write must not create the object")
+				return
+			}
+			require.Equal(t, http.StatusOK, gw.Code)
+			assert.Equal(t, tt.wantBody, gw.Body.String(),
+				"stored body after a %d", tt.wantStatus)
+		})
+	}
+}
+
+// TestS3_ConditionalWrite_412LeavesObjectByteIdentical is the assertion the issue
+// names explicitly. It is stronger than the table's body check: every observable
+// field of the object — ETag, size, Last-Modified, user metadata — must survive the
+// rejected write untouched, since a consumer that retries on 412 will compare them.
+func TestS3_ConditionalWrite_412LeavesObjectByteIdentical(t *testing.T) {
+	srv := condFixture(t, "cond-identical")
+
+	seedHeaders := map[string]string{
+		"Content-Type":      "text/plain",
+		"x-amz-meta-origin": "seed",
+	}
+	pw := s3Request(t, srv, http.MethodPut, "/cond-identical/obj.txt",
+		[]byte("original contents"), seedHeaders)
+	require.Equal(t, http.StatusOK, pw.Code)
+
+	before := s3Request(t, srv, http.MethodGet, "/cond-identical/obj.txt", nil, nil)
+	require.Equal(t, http.StatusOK, before.Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/cond-identical/obj.txt",
+		[]byte("a completely different body of another length"), map[string]string{
+			"If-None-Match":     "*",
+			"Content-Type":      "application/json",
+			"x-amz-meta-origin": "clobber",
+		})
+	require.Equal(t, http.StatusPreconditionFailed, w.Code)
+
+	after := s3Request(t, srv, http.MethodGet, "/cond-identical/obj.txt", nil, nil)
+	require.Equal(t, http.StatusOK, after.Code)
+
+	assert.Equal(t, before.Body.String(), after.Body.String(), "body")
+	for _, h := range []string{
+		"ETag", "Content-Length", "Content-Type", "Last-Modified", "X-Amz-Meta-Origin",
+	} {
+		assert.Equal(t, before.Header().Get(h), after.Header().Get(h), "header %s", h)
+	}
+	assert.Equal(t, "seed", after.Header().Get("X-Amz-Meta-Origin"),
+		"the rejected write's metadata must not have been applied")
+}
+
+// TestS3_ConditionalWrite_ExactlyOneWinner is the concurrency assertion from the
+// issue: N parallel `If-None-Match: *` PUTs of distinct bodies must produce exactly
+// one 200 and N-1 412s, and the object must hold the winner's body.
+//
+// This is the property [emulator.StateManager] cannot provide on its own — it has
+// no compare-and-swap, and MemoryStateManager is last-write-wins — so without the
+// plugin's per-key lock held across check→Put every writer would observe the key as
+// absent and all N would succeed. Run under -race.
+func TestS3_ConditionalWrite_ExactlyOneWinner(t *testing.T) {
+	const writers = 32
+
+	srv := condFixture(t, "cond-race")
+
+	type outcome struct {
+		status int
+		body   string
+	}
+	results := make([]outcome, writers)
+
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+
+	for i := range writers {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			body := fmt.Sprintf("writer-%02d", i)
+			start.Wait() // release all writers at once to maximize overlap
+			w := s3Request(t, srv, http.MethodPut, "/cond-race/obj.txt",
+				[]byte(body), map[string]string{"If-None-Match": "*"})
+			results[i] = outcome{status: w.Code, body: body}
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	var winners []string
+	for _, r := range results {
+		switch r.status {
+		case http.StatusOK:
+			winners = append(winners, r.body)
+		case http.StatusPreconditionFailed:
+		default:
+			t.Errorf("unexpected status %d from a concurrent conditional PUT", r.status)
+		}
+	}
+
+	require.Len(t, winners, 1,
+		"exactly one of %d concurrent If-None-Match: * PUTs may succeed", writers)
+	assert.Equal(t, winners[0], getCondBody(t, srv, "cond-race", "obj.txt"),
+		"the stored object must be the winner's body")
+}
+
+// TestS3_ConditionalWrite_IfMatchExactlyOneWinner is the compare-and-swap form of
+// the same race: every writer asserts the ETag it read, so only the first may land.
+// A consumer implementing optimistic locking depends on precisely this.
+func TestS3_ConditionalWrite_IfMatchExactlyOneWinner(t *testing.T) {
+	const writers = 32
+
+	srv := condFixture(t, "cond-cas")
+	etag := putCondObject(t, srv, "cond-cas", "obj.txt", "generation-0")
+
+	statuses := make([]int, writers)
+
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+
+	for i := range writers {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			w := s3Request(t, srv, http.MethodPut, "/cond-cas/obj.txt",
+				[]byte(fmt.Sprintf("generation-1-by-%02d", i)),
+				map[string]string{"If-Match": etag})
+			statuses[i] = w.Code
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	ok := 0
+	for _, s := range statuses {
+		switch s {
+		case http.StatusOK:
+			ok++
+		case http.StatusPreconditionFailed:
+		default:
+			t.Errorf("unexpected status %d from a concurrent If-Match PUT", s)
+		}
+	}
+	assert.Equal(t, 1, ok, "exactly one If-Match writer may win the ETag it read")
+}
+
+// TestS3_ConditionalWrite_DeleteMarkerCountsAsAbsent covers the versioned rule:
+// "if the current object version is a delete marker, the write operation succeeds"
+// for If-None-Match, and fails with 404 for If-Match. A delete marker is not an
+// object, so a key that once held data behaves as a free key again.
+func TestS3_ConditionalWrite_DeleteMarkerCountsAsAbsent(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "If-None-Match star succeeds",
+			header:     map[string]string{"If-None-Match": "*"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "If-Match is a 404",
+			header:     map[string]string{"If-Match": `"00000000000000000000000000000000"`},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NoSuchKey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, "cond-marker")
+			require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+				"/cond-marker?versioning",
+				[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`),
+				map[string]string{"Content-Type": "application/xml"}).Code)
+
+			putCondObject(t, srv, "cond-marker", "obj.txt", "v1")
+			require.Equal(t, http.StatusNoContent,
+				s3Request(t, srv, http.MethodDelete, "/cond-marker/obj.txt", nil, nil).Code,
+				"delete must insert a delete marker")
+
+			w := s3Request(t, srv, http.MethodPut, "/cond-marker/obj.txt",
+				[]byte("v2"), tt.header)
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+			if tt.wantCode != "" {
+				assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+			}
+		})
+	}
+}
+
+// TestS3_ConditionalWrite_IfNoneMatchNonStar asserts that a non-"*" If-None-Match
+// on a write is rejected rather than ignored. S3 documents the header as expecting
+// "*"; treating an unsupported value as "no condition" would let a header sent to
+// prevent an overwrite silently permit one, which is the failure mode this whole
+// issue is about.
+func TestS3_ConditionalWrite_IfNoneMatchNonStar(t *testing.T) {
+	srv := condFixture(t, "cond-nonstar")
+	etag := putCondObject(t, srv, "cond-nonstar", "obj.txt", "original")
+
+	for _, value := range []string{etag, `"00000000000000000000000000000000"`, ""} {
+		t.Run("value="+value, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodPut, "/cond-nonstar/obj.txt",
+				[]byte("overwrite"), map[string]string{"If-None-Match": value})
+			assert.Equal(t, http.StatusPreconditionFailed, w.Code, "body: %s", w.Body)
+			assert.Equal(t, "original", getCondBody(t, srv, "cond-nonstar", "obj.txt"))
+		})
+	}
+}
+
+// TestS3_ConditionalRead is the acceptance table for #397's read rows, run against
+// both GET and HEAD since S3 evaluates preconditions identically for the two.
+func TestS3_ConditionalRead(t *testing.T) {
+	const bucket = "cond-read"
+
+	tests := []struct {
+		name       string
+		header     func(etag string) map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name: "If-None-Match matching etag",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-None-Match": etag}
+			},
+			wantStatus: http.StatusNotModified,
+		},
+		{
+			name: "If-None-Match star on an existing object",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusNotModified,
+		},
+		{
+			name: "If-None-Match differing etag",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Match differing etag",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name: "If-Match matching etag",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-Match": etag}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Match star on an existing object",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": "*"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			// The object's Last-Modified is the pinned test clock, well after 1990.
+			name: "If-Modified-Since in the past",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Modified-Since": "Mon, 01 Jan 1990 00:00:00 GMT"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Modified-Since in the future",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Modified-Since": "Fri, 01 Jan 2100 00:00:00 GMT"}
+			},
+			wantStatus: http.StatusNotModified,
+		},
+		{
+			name: "If-Unmodified-Since in the future",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Unmodified-Since": "Fri, 01 Jan 2100 00:00:00 GMT"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Unmodified-Since in the past",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Unmodified-Since": "Mon, 01 Jan 1990 00:00:00 GMT"}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			// RFC 9110: an unparseable date makes the condition inapplicable, not
+			// failed. A spurious 412 here would break a client with a broken clock
+			// formatter in a way that looks like a server bug.
+			name: "unparseable date is ignored",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Unmodified-Since": "not a date at all"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			// An empty value is a condition that cannot be met, distinct from an
+			// absent header. Treating it as absent would serve the object to a
+			// client whose ETag-building code produced nothing.
+			name: "empty If-Match",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": ""}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name: "empty If-None-Match",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": ""}
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					srv := condFixture(t, bucket)
+					etag := putCondObject(t, srv, bucket, "obj.txt", "contents")
+
+					w := s3Request(t, srv, method, "/"+bucket+"/obj.txt", nil, tt.header(etag))
+					require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+					switch tt.wantStatus {
+					case http.StatusNotModified:
+						// 304 carries no body and must echo the ETag so a client can
+						// confirm which entity it was told it already holds.
+						assert.Zero(t, w.Body.Len(), "304 must carry no body")
+						assert.Equal(t, etag, w.Header().Get("ETag"))
+					case http.StatusPreconditionFailed:
+						assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+					case http.StatusOK:
+						assert.Equal(t, etag, w.Header().Get("ETag"))
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestS3_ConditionalRead_CombinationRules covers the two combinations S3 documents
+// explicitly, both of which exist to stop a coarse date condition from overriding an
+// exact entity assertion. Getting either backwards silently inverts a cache
+// revalidation, so they are asserted directly rather than inferred from the table.
+func TestS3_ConditionalRead_CombinationRules(t *testing.T) {
+	const (
+		past   = "Mon, 01 Jan 1990 00:00:00 GMT"
+		future = "Fri, 01 Jan 2100 00:00:00 GMT"
+	)
+
+	tests := []struct {
+		name       string
+		header     func(etag string) map[string]string
+		wantStatus int
+		reason     string
+	}{
+		{
+			// "If-Match condition evaluates to true, and If-Unmodified-Since
+			// condition evaluates to false; then, S3 returns 200 OK and the data
+			// requested."
+			name: "If-Match true and If-Unmodified-Since false is 200",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-Match": etag, "If-Unmodified-Since": past}
+			},
+			wantStatus: http.StatusOK,
+			reason:     "an exact ETag match outranks a failing If-Unmodified-Since",
+		},
+		{
+			// "If-None-Match condition evaluates to false, and If-Modified-Since
+			// condition evaluates to true; then, S3 returns 304 Not Modified."
+			name: "If-None-Match false and If-Modified-Since true is 304",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-None-Match": etag, "If-Modified-Since": past}
+			},
+			wantStatus: http.StatusNotModified,
+			reason:     "the caller already holds this entity regardless of dates",
+		},
+		{
+			name: "If-Match false still fails despite a satisfied If-Unmodified-Since",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"If-Match":            `"00000000000000000000000000000000"`,
+					"If-Unmodified-Since": future,
+				}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			reason:     "a failed ETag assertion is not rescued by a date condition",
+		},
+		{
+			name: "If-None-Match true suppresses If-Modified-Since",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"If-None-Match":     `"00000000000000000000000000000000"`,
+					"If-Modified-Since": future,
+				}
+			},
+			wantStatus: http.StatusOK,
+			reason:     "the caller does not hold this entity, so it must be sent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, "cond-combo")
+			etag := putCondObject(t, srv, "cond-combo", "obj.txt", "contents")
+
+			w := s3Request(t, srv, http.MethodGet, "/cond-combo/obj.txt", nil, tt.header(etag))
+			assert.Equal(t, tt.wantStatus, w.Code, "%s (body: %s)", tt.reason, w.Body)
+		})
+	}
+}
+
+// TestS3_ConditionalRead_PrecedesRange asserts the ordering that made #397 depend on
+// #396: a failed precondition supersedes a Range, so a 412 or 304 is returned rather
+// than a 206 of a stale entity. A client that got a partial body here would splice
+// bytes from the wrong generation of the object into its cache.
+func TestS3_ConditionalRead_PrecedesRange(t *testing.T) {
+	srv := condFixture(t, "cond-range")
+	etag := putCondObject(t, srv, "cond-range", "obj.txt", strings.Repeat("x", 1000))
+
+	t.Run("failed If-Match beats a valid range", func(t *testing.T) {
+		w := s3Request(t, srv, http.MethodGet, "/cond-range/obj.txt", nil, map[string]string{
+			"If-Match": `"00000000000000000000000000000000"`,
+			"Range":    "bytes=0-99",
+		})
+		require.Equal(t, http.StatusPreconditionFailed, w.Code)
+		assert.Empty(t, w.Header().Get("Content-Range"), "no partial response may be described")
+	})
+
+	t.Run("If-None-Match match beats a valid range", func(t *testing.T) {
+		w := s3Request(t, srv, http.MethodGet, "/cond-range/obj.txt", nil, map[string]string{
+			"If-None-Match": etag,
+			"Range":         "bytes=0-99",
+		})
+		require.Equal(t, http.StatusNotModified, w.Code)
+		assert.Zero(t, w.Body.Len())
+	})
+
+	t.Run("failed If-Match beats an unsatisfiable range", func(t *testing.T) {
+		// Both conditions would produce an error; the precondition is reported.
+		w := s3Request(t, srv, http.MethodGet, "/cond-range/obj.txt", nil, map[string]string{
+			"If-Match": `"00000000000000000000000000000000"`,
+			"Range":    "bytes=5000-5099",
+		})
+		require.Equal(t, http.StatusPreconditionFailed, w.Code)
+		assert.Equal(t, "PreconditionFailed", parseS3Error(t, w.Body.Bytes()).Code)
+	})
+
+	t.Run("satisfied precondition still serves the range", func(t *testing.T) {
+		w := s3Request(t, srv, http.MethodGet, "/cond-range/obj.txt", nil, map[string]string{
+			"If-Match": etag,
+			"Range":    "bytes=0-99",
+		})
+		require.Equal(t, http.StatusPartialContent, w.Code)
+		assert.Equal(t, "bytes 0-99/1000", w.Header().Get("Content-Range"))
+		assert.Equal(t, 100, w.Body.Len())
+	})
+}
+
+// TestS3_ConditionalRead_AbsentKeyIsNoSuchKey asserts a precondition does not turn a
+// missing object into a 412 or 304: there is no ETag to compare, so the caller's
+// real problem is the missing key.
+func TestS3_ConditionalRead_AbsentKeyIsNoSuchKey(t *testing.T) {
+	srv := condFixture(t, "cond-absent")
+
+	tests := []struct {
+		name   string
+		header map[string]string
+	}{
+		{name: "If-Match", header: map[string]string{"If-Match": `"00000000000000000000000000000000"`}},
+		{name: "If-None-Match", header: map[string]string{"If-None-Match": "*"}},
+		{
+			name:   "If-Modified-Since",
+			header: map[string]string{"If-Modified-Since": "Mon, 01 Jan 1990 00:00:00 GMT"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodGet, "/cond-absent/missing.txt", nil, tt.header)
+			require.Equal(t, http.StatusNotFound, w.Code)
+			assert.Equal(t, "NoSuchKey", parseS3Error(t, w.Body.Bytes()).Code)
+		})
+	}
+}
+
+// TestS3_ConditionalRead_ETagFormsAndLists asserts the ETag comparison is
+// quoting-, case- and list-insensitive on reads. Clients differ on whether they
+// echo back the quotes S3 sent, and RFC 7232 allows a list of validators.
+func TestS3_ConditionalRead_ETagFormsAndLists(t *testing.T) {
+	srv := condFixture(t, "cond-etag")
+	etag := putCondObject(t, srv, "cond-etag", "obj.txt", "contents")
+	bare := strings.Trim(etag, `"`)
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "as returned", value: etag},
+		{name: "unquoted", value: bare},
+		{name: "uppercase hex", value: strings.ToUpper(etag)},
+		{name: "weak validator", value: `W/` + etag},
+		{name: "list, first member", value: etag + `,"00000000000000000000000000000000"`},
+		{name: "list, later member", value: `"00000000000000000000000000000000", ` + etag},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A matching If-None-Match is a 304; the same value as If-Match is a 200.
+			// Asserting both proves the value was recognized as a match, rather than
+			// having produced the right status for the wrong reason.
+			nm := s3Request(t, srv, http.MethodGet, "/cond-etag/obj.txt", nil,
+				map[string]string{"If-None-Match": tt.value})
+			assert.Equal(t, http.StatusNotModified, nm.Code, "If-None-Match: %s", tt.value)
+
+			m := s3Request(t, srv, http.MethodGet, "/cond-etag/obj.txt", nil,
+				map[string]string{"If-Match": tt.value})
+			assert.Equal(t, http.StatusOK, m.Code, "If-Match: %s (body: %s)", tt.value, m.Body)
+		})
+	}
+}
+
+// TestS3_ConditionalRead_DateFormats asserts the three date formats RFC 9110
+// requires a recipient to accept. An SDK sending RFC 850 must not get a spurious
+// 200 where a 304 was correct — that would defeat its cache silently.
+func TestS3_ConditionalRead_DateFormats(t *testing.T) {
+	srv := condFixture(t, "cond-dates")
+	putCondObject(t, srv, "cond-dates", "obj.txt", "contents")
+
+	// All three are after the pinned test clock of 2026-01-01, so If-Modified-Since
+	// evaluates false and each must yield a 304. RFC 850's two-digit year cannot
+	// express 2100, hence 2027 for that row.
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "IMF-fixdate", value: "Fri, 01 Jan 2100 00:00:00 GMT"},
+		{name: "RFC 850", value: "Friday, 01-Jan-27 00:00:00 GMT"},
+		{name: "ANSI C asctime", value: "Fri Jan  1 00:00:00 2100"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodGet, "/cond-dates/obj.txt", nil,
+				map[string]string{"If-Modified-Since": tt.value})
+			assert.Equal(t, http.StatusNotModified, w.Code, "value %q: %s", tt.value, w.Body)
+		})
+	}
+}
+
+// TestS3_ConditionalRead_HeaderCaseInsensitive asserts the headers are matched
+// case-insensitively. Tests elsewhere construct AWSRequest literals directly and so
+// bypass net/http's canonicalization; a plugin reading req.Headers["If-Match"] would
+// pass those and still miss a real client sending "if-match".
+func TestS3_ConditionalRead_HeaderCaseInsensitive(t *testing.T) {
+	srv := condFixture(t, "cond-case")
+	etag := putCondObject(t, srv, "cond-case", "obj.txt", "contents")
+
+	for _, name := range []string{"if-none-match", "IF-NONE-MATCH", "If-None-Match"} {
+		t.Run(name, func(t *testing.T) {
+			w := s3Request(t, srv, http.MethodGet, "/cond-case/obj.txt", nil,
+				map[string]string{name: etag})
+			assert.Equal(t, http.StatusNotModified, w.Code)
+		})
+	}
+}
+
+// TestS3_ConditionalCopy_Destination asserts CopyObject honors the destination
+// preconditions, which is what makes a copy usable as an atomic publish step.
+func TestS3_ConditionalCopy_Destination(t *testing.T) {
+	tests := []struct {
+		name string
+		// seedDest is written at the destination first; "" leaves it absent.
+		seedDest   string
+		header     func(destETag string) map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:     "If-None-Match star, destination absent",
+			seedDest: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:     "If-None-Match star, destination present",
+			seedDest: "existing",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name:     "If-Match on the destination etag",
+			seedDest: "existing",
+			header: func(destETag string) map[string]string {
+				return map[string]string{"If-Match": destETag}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:     "If-Match differing from the destination etag",
+			seedDest: "existing",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, "cond-copy")
+			putCondObject(t, srv, "cond-copy", "src.txt", "source payload")
+
+			var destETag string
+			if tt.seedDest != "" {
+				destETag = putCondObject(t, srv, "cond-copy", "dst.txt", tt.seedDest)
+			}
+
+			headers := tt.header(destETag)
+			headers["X-Amz-Copy-Source"] = "/cond-copy/src.txt"
+			w := s3Request(t, srv, http.MethodPut, "/cond-copy/dst.txt", nil, headers)
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+			if tt.wantStatus == http.StatusOK {
+				assert.Equal(t, "source payload", getCondBody(t, srv, "cond-copy", "dst.txt"))
+				return
+			}
+			assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+			if tt.seedDest != "" {
+				assert.Equal(t, tt.seedDest, getCondBody(t, srv, "cond-copy", "dst.txt"),
+					"a rejected copy must leave the destination untouched")
+			}
+		})
+	}
+}
+
+// TestS3_ConditionalCopy_Source asserts the x-amz-copy-source-if-* family, which
+// gates reading the source rather than overwriting the destination. Every failure is
+// a 412: CopyObject documents no 304, because there is no cached entity for a
+// server-side copy to revalidate against.
+func TestS3_ConditionalCopy_Source(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     func(srcETag string) map[string]string
+		wantStatus int
+	}{
+		{
+			name: "copy-source-if-match matching",
+			header: func(etag string) map[string]string {
+				return map[string]string{"x-amz-copy-source-if-match": etag}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "copy-source-if-match differing",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-match": `"00000000000000000000000000000000"`,
+				}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+		},
+		{
+			name: "copy-source-if-none-match differing",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-none-match": `"00000000000000000000000000000000"`,
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			// The equivalent GET would be a 304. A copy is a 412.
+			name: "copy-source-if-none-match matching",
+			header: func(etag string) map[string]string {
+				return map[string]string{"x-amz-copy-source-if-none-match": etag}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+		},
+		{
+			name: "copy-source-if-unmodified-since in the future",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-unmodified-since": "Fri, 01 Jan 2100 00:00:00 GMT",
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "copy-source-if-unmodified-since in the past",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-unmodified-since": "Mon, 01 Jan 1990 00:00:00 GMT",
+				}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+		},
+		{
+			name: "copy-source-if-modified-since in the past",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-modified-since": "Mon, 01 Jan 1990 00:00:00 GMT",
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "copy-source-if-modified-since in the future",
+			header: func(string) map[string]string {
+				return map[string]string{
+					"x-amz-copy-source-if-modified-since": "Fri, 01 Jan 2100 00:00:00 GMT",
+				}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := condFixture(t, "cond-copysrc")
+			srcETag := putCondObject(t, srv, "cond-copysrc", "src.txt", "source payload")
+
+			headers := tt.header(srcETag)
+			headers["X-Amz-Copy-Source"] = "/cond-copysrc/src.txt"
+			w := s3Request(t, srv, http.MethodPut, "/cond-copysrc/dst.txt", nil, headers)
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+			if tt.wantStatus == http.StatusOK {
+				assert.Equal(t, "source payload", getCondBody(t, srv, "cond-copysrc", "dst.txt"))
+				return
+			}
+			assert.Equal(t, "PreconditionFailed", parseS3Error(t, w.Body.Bytes()).Code)
+			assert.Equal(t, http.StatusNotFound,
+				s3Request(t, srv, http.MethodHead, "/cond-copysrc/dst.txt", nil, nil).Code,
+				"a rejected copy must not create the destination")
+		})
+	}
+}
+
+// TestS3_ConditionalCopy_SourceAndDestinationBoth asserts both families can be sent
+// on one request, and that the source is evaluated even when the destination
+// condition would pass.
+func TestS3_ConditionalCopy_SourceAndDestinationBoth(t *testing.T) {
+	srv := condFixture(t, "cond-copyboth")
+	srcETag := putCondObject(t, srv, "cond-copyboth", "src.txt", "source payload")
+
+	w := s3Request(t, srv, http.MethodPut, "/cond-copyboth/dst.txt", nil, map[string]string{
+		"X-Amz-Copy-Source":          "/cond-copyboth/src.txt",
+		"x-amz-copy-source-if-match": `"00000000000000000000000000000000"`,
+		"If-None-Match":              "*", // would pass: the destination is absent
+	})
+	require.Equal(t, http.StatusPreconditionFailed, w.Code, "body: %s", w.Body)
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodHead, "/cond-copyboth/dst.txt", nil, nil).Code)
+
+	ok := s3Request(t, srv, http.MethodPut, "/cond-copyboth/dst.txt", nil, map[string]string{
+		"X-Amz-Copy-Source":          "/cond-copyboth/src.txt",
+		"x-amz-copy-source-if-match": srcETag,
+		"If-None-Match":              "*",
+	})
+	require.Equal(t, http.StatusOK, ok.Code, "body: %s", ok.Body)
+	assert.Equal(t, "source payload", getCondBody(t, srv, "cond-copyboth", "dst.txt"))
+}
+
+// TestS3_ConditionalCompleteMultipartUpload asserts Complete honors the same
+// conditional write headers as PutObject, per the conditional-writes documentation
+// listing it alongside PutObject and CopyObject. A rejected Complete must leave the
+// upload open, so a caller can abort it after losing the race.
+func TestS3_ConditionalCompleteMultipartUpload(t *testing.T) {
+	tests := []struct {
+		name string
+		// seed is written at the key before Complete; "" leaves it absent.
+		seed       string
+		header     func(seedETag string) map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name: "If-None-Match star, key absent",
+			seed: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-None-Match star, key written mid-upload",
+			seed: "raced in by another writer",
+			header: func(string) map[string]string {
+				return map[string]string{"If-None-Match": "*"}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name: "If-Match matching",
+			seed: "existing",
+			header: func(etag string) map[string]string {
+				return map[string]string{"If-Match": etag}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "If-Match differing",
+			seed: "existing",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusPreconditionFailed,
+			wantCode:   "PreconditionFailed",
+		},
+		{
+			name: "If-Match, key absent",
+			seed: "",
+			header: func(string) map[string]string {
+				return map[string]string{"If-Match": `"00000000000000000000000000000000"`}
+			},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NoSuchKey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, uploadID := multipartFixture(t, "cond-mpu", "obj.bin")
+			partETag := uploadPart(t, srv, "cond-mpu", "obj.bin", uploadID, 1, []byte("assembled"))
+
+			var seedETag string
+			if tt.seed != "" {
+				seedETag = putCondObject(t, srv, "cond-mpu", "obj.bin", tt.seed)
+			}
+
+			w := s3Request(t, srv, http.MethodPost, "/cond-mpu/obj.bin?uploadId="+uploadID,
+				completeBody(partETag), tt.header(seedETag))
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body)
+
+			if tt.wantStatus == http.StatusOK {
+				assert.Equal(t, "assembled", getCondBody(t, srv, "cond-mpu", "obj.bin"))
+				assert.Empty(t, openUploadIDs(t, srv, "cond-mpu"),
+					"a successful Complete closes the upload")
+				return
+			}
+
+			assert.Equal(t, tt.wantCode, parseS3Error(t, w.Body.Bytes()).Code)
+			assert.Equal(t, []string{uploadID}, openUploadIDs(t, srv, "cond-mpu"),
+				"a rejected Complete must leave the upload open to be aborted")
+			if tt.seed != "" {
+				assert.Equal(t, tt.seed, getCondBody(t, srv, "cond-mpu", "obj.bin"),
+					"a rejected Complete must not overwrite the raced-in object")
+			}
+		})
+	}
+}
+
+// TestS3_ConditionalCompleteMultipartUpload_MalformedBeatsPrecondition asserts a
+// malformed parts list is reported as malformed even when the precondition would
+// also fail. A caller that saw PreconditionFailed here would retry the upload
+// forever instead of fixing its request.
+func TestS3_ConditionalCompleteMultipartUpload_MalformedBeatsPrecondition(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "cond-mpu-xml", "obj.bin")
+	uploadPart(t, srv, "cond-mpu-xml", "obj.bin", uploadID, 1, []byte("assembled"))
+	putCondObject(t, srv, "cond-mpu-xml", "obj.bin", "already here")
+
+	w := s3Request(t, srv, http.MethodPost, "/cond-mpu-xml/obj.bin?uploadId="+uploadID,
+		[]byte(`<CompleteMultipartUpload></CompleteMultipartUpload>`),
+		map[string]string{"If-None-Match": "*"})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "MalformedXML", parseS3Error(t, w.Body.Bytes()).Code)
+}
+
+// TestS3_ConditionalWrite_UnconditionalPathUnaffected is the regression guard: an
+// ordinary PUT/GET carrying no precondition must be untouched by all of the above.
+func TestS3_ConditionalWrite_UnconditionalPathUnaffected(t *testing.T) {
+	srv := condFixture(t, "cond-plain")
+
+	first := putCondObject(t, srv, "cond-plain", "obj.txt", "first")
+	second := putCondObject(t, srv, "cond-plain", "obj.txt", "second")
+	assert.NotEqual(t, first, second, "an unconditional PUT still overwrites")
+	assert.Equal(t, "second", getCondBody(t, srv, "cond-plain", "obj.txt"))
+
+	w := s3Request(t, srv, http.MethodGet, "/cond-plain/obj.txt", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, second, w.Header().Get("ETag"))
+	// Last-Modified is the pinned clock, proving the object was really rewritten
+	// rather than served from the first generation.
+	assert.NotEmpty(t, w.Header().Get("Last-Modified"))
+	_, parseErr := time.Parse(http.TimeFormat, w.Header().Get("Last-Modified"))
+	assert.NoError(t, parseErr, "Last-Modified must be an HTTP date")
+}

--- a/emulator/s3_copy_metadata.go
+++ b/emulator/s3_copy_metadata.go
@@ -1,0 +1,144 @@
+package emulator
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// s3DirectiveCopy and s3DirectiveReplace are the two values S3 accepts in
+// x-amz-metadata-directive and x-amz-tagging-directive. COPY is the default for
+// both when the header is absent.
+const (
+	s3DirectiveCopy    = "COPY"
+	s3DirectiveReplace = "REPLACE"
+)
+
+// s3CopyMetadata is the metadata a CopyObject should record on its destination,
+// already resolved against the request's x-amz-metadata-directive.
+type s3CopyMetadata struct {
+	ContentType     string
+	ContentEncoding string
+	UserMetadata    map[string]string
+}
+
+// resolveDirective returns the COPY/REPLACE value of a directive header, or the
+// error response to serve when the value is neither.
+//
+// An absent header means COPY: "if this header isn't specified, COPY is the default
+// behavior". An unrecognized value is rejected rather than silently treated as the
+// default, because a typo'd directive that quietly preserved metadata is exactly the
+// kind of false success this emulator exists to catch. The code is S3's generic
+// 400 for a bad header value; the message wording is substrate's.
+func resolveDirective(headers map[string]string, name string) (string, *AWSResponse) {
+	value := headerValueFold(headers, name)
+	switch {
+	case value == "":
+		return s3DirectiveCopy, nil
+	case strings.EqualFold(value, s3DirectiveCopy):
+		return s3DirectiveCopy, nil
+	case strings.EqualFold(value, s3DirectiveReplace):
+		return s3DirectiveReplace, nil
+	}
+	return "", s3ErrorResponseWith(s3Error{
+		Code:    "InvalidArgument",
+		Message: "Unknown " + name + ". The directive must be COPY or REPLACE.",
+		Status:  http.StatusBadRequest,
+		Details: []s3ErrorDetail{
+			{Name: "ArgumentName", Value: name},
+			{Name: "ArgumentValue", Value: value},
+		},
+	})
+}
+
+// resolveCopyMetadata returns the metadata a CopyObject records on its destination,
+// or the error response to serve when x-amz-metadata-directive is malformed.
+//
+// Under COPY — the default — the source's user-controlled system metadata carries
+// over along with its user-defined metadata: "when you copy an object,
+// user-controlled system metadata and user-defined metadata are also copied", and
+// Content-Type, Content-Encoding, Content-Disposition and Cache-Control are all
+// user-controlled. Only x-amz-website-redirect-location is documented as not copied,
+// and substrate does not model it.
+//
+// Under REPLACE nothing carries over. The request must restate everything it wants
+// kept: "you must explicitly specify all of the user-configurable metadata present
+// on the source object in your request, even if you are changing only one of the
+// metadata values". This is the asymmetry a consumer's in-place CopyObject tier
+// transition trips over — a REPLACE that omits Content-Encoding loses it.
+func resolveCopyMetadata(headers map[string]string, src *S3Object) (s3CopyMetadata, *AWSResponse) {
+	directive, errResp := resolveDirective(headers, "x-amz-metadata-directive")
+	if errResp != nil {
+		return s3CopyMetadata{}, errResp
+	}
+
+	if directive == s3DirectiveCopy {
+		return s3CopyMetadata{
+			ContentType:     src.ContentType,
+			ContentEncoding: src.ContentEncoding,
+			UserMetadata:    copyStringMap(src.UserMetadata),
+		}, nil
+	}
+
+	contentType := headerValueFold(headers, "Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	return s3CopyMetadata{
+		ContentType:     contentType,
+		ContentEncoding: headerValueFold(headers, "Content-Encoding"),
+		UserMetadata:    extractUserMetadata(headers),
+	}, nil
+}
+
+// resolveCopyTags returns the tag-set a CopyObject records on its destination, or
+// the error response to serve when x-amz-tagging-directive is malformed.
+//
+// COPY is the default here too, so an ordinary copy carries the source's tags:
+// "if you choose COPY for the x-amz-tagging-directive, you don't need to set the
+// x-amz-tagging header, because the tag-set will be copied from the source object
+// directly". Under REPLACE the tag-set comes from x-amz-tagging, which S3 documents
+// as URL query-parameter encoded and defaulting to empty.
+func resolveCopyTags(headers map[string]string, src *S3Object) (map[string]string, *AWSResponse) {
+	directive, errResp := resolveDirective(headers, "x-amz-tagging-directive")
+	if errResp != nil {
+		return nil, errResp
+	}
+
+	if directive == s3DirectiveCopy {
+		return copyStringMap(src.Tags), nil
+	}
+
+	tagging := headerValueFold(headers, "x-amz-tagging")
+	if tagging == "" {
+		return nil, nil
+	}
+	values, parseErr := url.ParseQuery(tagging)
+	if parseErr != nil {
+		return nil, s3ErrorResponseWith(s3Error{
+			Code:    "InvalidArgument",
+			Message: "The tag-set must be encoded as URL query parameters.",
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{{Name: "ArgumentName", Value: "x-amz-tagging"}},
+		})
+	}
+	tags := make(map[string]string, len(values))
+	for k := range values {
+		tags[k] = values.Get(k)
+	}
+	return tags, nil
+}
+
+// copyStringMap returns an independent copy of m, or nil when m is empty. The copy
+// keeps a destination object's metadata from aliasing the source's, so a later
+// PutObjectTagging on one does not mutate the other.
+func copyStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -45,6 +45,7 @@ type S3Plugin struct {
 	fs         afero.Fs
 	registry   *PluginRegistry // nil = notifications disabled
 	versionSeq int64           // monotonic counter for unique version IDs
+	keyLocks   s3KeyMutex      // serializes conditional writes per object key
 }
 
 // Name returns the service name "s3".
@@ -452,6 +453,24 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
+	// Conditional writes must not race: the existence check and the write below have
+	// to be one atomic step, or N concurrent If-None-Match: * PUTs would all
+	// observe the key as absent and all succeed. See [s3KeyMutex].
+	if cond := readConditionalHeaders(req.Headers); cond.any() {
+		unlock := p.keyLocks.lock(bucket, key)
+		defer unlock()
+
+		current, condErr := p.loadCurrentObject(ctx, bucket, key)
+		if condErr != nil {
+			return nil, condErr
+		}
+		if resp := evaluateWritePreconditions(cond, current); resp != nil {
+			// Nothing has been written yet, so an unmet precondition leaves the
+			// stored object byte-identical.
+			return resp, nil
+		}
+	}
+
 	body := decodeAWSChunked(req.Headers, req.Body)
 	hash := md5.Sum(body) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x"`, hash)
@@ -601,6 +620,13 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 		}
 	}
 
+	// Preconditions are evaluated before the range step: a 412 or 304 supersedes
+	// any range, and RFC 9110 requires a failed precondition to be reported rather
+	// than a partial response served.
+	if resp := evaluateReadPreconditions(readConditionalHeaders(req.Headers), &obj); resp != nil {
+		return resp, nil
+	}
+
 	headers := objectResponseHeaders(&obj)
 
 	rangeHeader := headerValueFold(req.Headers, "Range")
@@ -648,6 +674,11 @@ func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key st
 	if obj.IsDeleteMarker {
 		// Mirror getObject: 405 when a version is named, 404 otherwise.
 		return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
+	}
+
+	// HEAD evaluates preconditions exactly as GET does.
+	if resp := evaluateReadPreconditions(readConditionalHeaders(req.Headers), &obj); resp != nil {
+		return resp, nil
 	}
 
 	headers := objectResponseHeaders(&obj)
@@ -869,6 +900,31 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	}
 	if dstBucketData == nil {
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
+	}
+
+	// Source preconditions gate whether the copy may read; destination
+	// preconditions gate whether it may overwrite. Both are checked before any
+	// write, so a rejected copy leaves the destination untouched.
+	//
+	// A failed copy-source condition is always a 412, even in the case where the
+	// equivalent GET would be a 304: CopyObject documents PreconditionFailed as its
+	// only conditional outcome, since there is no cached entity for a server-side
+	// copy to revalidate against.
+	if evaluateReadPreconditions(copySourceConditionalHeaders(req.Headers), &srcObj) != nil {
+		return s3PreconditionFailedResponse(), nil
+	}
+
+	if cond := readConditionalHeaders(req.Headers); cond.any() {
+		unlock := p.keyLocks.lock(dstBucket, dstKey)
+		defer unlock()
+
+		current, condErr := p.loadCurrentObject(ctx, dstBucket, dstKey)
+		if condErr != nil {
+			return nil, condErr
+		}
+		if resp := evaluateWritePreconditions(cond, current); resp != nil {
+			return resp, nil
+		}
 	}
 
 	srcBody, readErr := afero.ReadFile(p.fs, "/"+srcBucket+"/"+srcKey)
@@ -1289,6 +1345,28 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		return errResp, nil
 	}
 
+	// Complete is a WRITE, so it honors the same conditional headers as PutObject —
+	// evaluated against the destination key, not against the in-progress upload.
+	// "Conditional writes do not consider any in-progress multipart uploads requests
+	// since those are not yet fully written objects": another writer landing on this
+	// key mid-upload is exactly what makes this Complete fail.
+	//
+	// Checked after the parts list, so a malformed request is reported as malformed
+	// rather than as a lost race, and held under the key lock through the write below.
+	if cond := readConditionalHeaders(req.Headers); cond.any() {
+		unlock := p.keyLocks.lock(bucket, key)
+		defer unlock()
+
+		current, condErr := p.loadCurrentObject(ctx, bucket, key)
+		if condErr != nil {
+			return nil, condErr
+		}
+		if resp := evaluateWritePreconditions(cond, current); resp != nil {
+			// The upload stays open: a caller that lost the race can abort it.
+			return resp, nil
+		}
+	}
+
 	// Concatenate parts and compute multi-part ETag.
 	var combined []byte
 	var partMD5s []byte
@@ -1580,6 +1658,25 @@ func (p *S3Plugin) loadObjectEntry(ctx context.Context, bucket, key string) (*ob
 		ETag:         obj.ETag,
 		Size:         obj.Size,
 	}, nil
+}
+
+// loadCurrentObject returns the current version of an object, or nil when the key
+// has never been written. A delete marker is returned rather than treated as
+// absent: the caller decides what absence means, and conditional writes
+// distinguish "never existed" from "deleted" differently than reads do.
+func (p *S3Plugin) loadCurrentObject(ctx context.Context, bucket, key string) (*S3Object, error) {
+	data, err := p.state.Get(ctx, s3Namespace, "object:"+bucket+"/"+key)
+	if err != nil {
+		return nil, fmt.Errorf("get current object %s/%s: %w", bucket, key, err)
+	}
+	if data == nil {
+		return nil, nil
+	}
+	var obj S3Object
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, fmt.Errorf("unmarshal current object %s/%s: %w", bucket, key, err)
+	}
+	return &obj, nil
 }
 
 // headerValueFold returns the value of the named header, case-insensitively

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -478,9 +478,21 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		}
 	}
 
-	body := decodeAWSChunked(req.Headers, req.Body)
+	body, trailers := decodeAWSChunkedWithTrailers(req.Headers, req.Body)
 	hash := md5.Sum(body) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x"`, hash)
+
+	// The checksum is verified against the decoded body, and before the write
+	// below: a BadDigest must leave the stored object untouched, which is what lets
+	// a consumer assert that a corrupt upload changed nothing.
+	checksumHeaders, trailerErr := checksumHeadersWithTrailers(req.Headers, trailers)
+	if trailerErr != nil {
+		return trailerErr, nil
+	}
+	checksum, cksErr := resolveChecksum(checksumHeaders, body)
+	if cksErr != nil {
+		return cksErr, nil
+	}
 
 	// Directory-marker objects (key ends with "/") must not be written to the
 	// afero filesystem: filepath.Clean inside MemMapFs would strip the trailing
@@ -511,11 +523,15 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		ContentEncoding: req.Headers["Content-Encoding"],
 		Size:            int64(len(body)),
 		StorageClass:    storageClass,
+		Checksum:        checksum,
 		LastModified:    p.tc.Now(),
 		UserMetadata:    userMeta,
 	}
 
 	respHeaders := map[string]string{"ETag": etag}
+	// PutObject echoes the checksum unconditionally — checksum-mode gates the read
+	// path, not the write. A single-part PUT is always a full-object checksum.
+	applyChecksumHeaders(respHeaders, checksum, true)
 
 	// If versioning is enabled, generate a version ID and store the versioned copy.
 	versioningStatus := p.getBucketVersioningStatus(ctx, bucket)
@@ -642,6 +658,7 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 	}
 
 	headers := objectResponseHeaders(&obj)
+	applyChecksumHeaders(headers, obj.Checksum, resolveChecksumMode(req.Headers))
 
 	rangeHeader := headerValueFold(req.Headers, "Range")
 	spec := parseByteRange(rangeHeader, obj.Size)
@@ -699,6 +716,7 @@ func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key st
 	}
 
 	headers := objectResponseHeaders(&obj)
+	applyChecksumHeaders(headers, obj.Checksum, resolveChecksumMode(req.Headers))
 
 	// HEAD honors Range exactly as GET does, minus the body.
 	rangeHeader := headerValueFold(req.Headers, "Range")
@@ -941,6 +959,10 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	if tagErr != nil {
 		return tagErr, nil
 	}
+	copyChecksumAlgorithm, cksErr := resolveCopyChecksumAlgorithm(req.Headers, &srcObj)
+	if cksErr != nil {
+		return cksErr, nil
+	}
 
 	// Source preconditions gate whether the copy may read; destination
 	// preconditions gate whether it may overwrite. Both are checked before any
@@ -984,6 +1006,13 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	hash := md5.Sum(srcBody) //nolint:gosec // nosemgrep
 	newETag := fmt.Sprintf(`"%x"`, hash)
 
+	// "With a copy command, the checksum of the object is a direct checksum of the
+	// full object. If the object was originally uploaded using a multipart upload,
+	// the checksum value changes even though the data doesn't." So the copy's
+	// checksum is recomputed over the whole body, never carried across — a composite
+	// source yields a full-object destination.
+	dstChecksum := copyChecksum(copyChecksumAlgorithm, srcBody)
+
 	dstObj := S3Object{
 		Bucket:          dstBucket,
 		Key:             dstKey,
@@ -995,6 +1024,7 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 		// x-amz-storage-class header is not used, the copied object will be stored in
 		// the STANDARD Storage Class by default."
 		StorageClass: dstStorageClass,
+		Checksum:     dstChecksum,
 		LastModified: now,
 		UserMetadata: meta.UserMetadata,
 		Tags:         tags,
@@ -1234,6 +1264,13 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		return scErr, nil
 	}
 
+	// The checksum algorithm and type are fixed here too, and validated against the
+	// documented support matrix now rather than after every part has been uploaded.
+	checksumAlgorithm, checksumType, cksErr := resolveUploadChecksum(req.Headers)
+	if cksErr != nil {
+		return cksErr, nil
+	}
+
 	uploadID := generateUploadID()
 
 	contentType := req.Headers["Content-Type"]
@@ -1242,13 +1279,15 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 	}
 
 	upload := S3MultipartUpload{
-		UploadID:     uploadID,
-		Bucket:       bucket,
-		Key:          key,
-		ContentType:  contentType,
-		StorageClass: storageClass,
-		Initiated:    p.tc.Now(),
-		UserMetadata: extractUserMetadata(req.Headers),
+		UploadID:          uploadID,
+		Bucket:            bucket,
+		Key:               key,
+		ContentType:       contentType,
+		StorageClass:      storageClass,
+		ChecksumAlgorithm: checksumAlgorithm,
+		ChecksumType:      checksumType,
+		Initiated:         p.tc.Now(),
+		UserMetadata:      extractUserMetadata(req.Headers),
 	}
 
 	data, err := json.Marshal(upload)
@@ -1265,11 +1304,21 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		Key      string   `xml:"Key"`
 		UploadId string   `xml:"UploadId"` //nolint:revive // matches AWS XML field name
 	}
-	return s3XMLResponse(http.StatusOK, initiateMultipartUploadResult{
+	resp, err := s3XMLResponse(http.StatusOK, initiateMultipartUploadResult{
 		Bucket:   bucket,
 		Key:      key,
 		UploadId: uploadID,
 	})
+	if err != nil {
+		return nil, err
+	}
+	// Both are echoed as response headers, so a caller can confirm the type it got
+	// is the type it asked for before uploading a single part.
+	if checksumAlgorithm != "" {
+		resp.Headers["x-amz-checksum-algorithm"] = checksumAlgorithm
+		resp.Headers["x-amz-checksum-type"] = checksumType
+	}
+	return resp, nil
 }
 
 // uploadPart handles PUT /<bucket>/<key>?partNumber=N&uploadId=ID.
@@ -1300,9 +1349,20 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
 	}
 
-	body := decodeAWSChunked(req.Headers, req.Body)
+	body, trailers := decodeAWSChunkedWithTrailers(req.Headers, req.Body)
 	hash := md5.Sum(body) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x"`, hash)
+
+	// Verified before the part is written, so a BadDigest part is not left on disk
+	// for a later Complete to pick up.
+	checksumHeaders, trailerErr := checksumHeadersWithTrailers(req.Headers, trailers)
+	if trailerErr != nil {
+		return trailerErr, nil
+	}
+	checksum, cksErr := resolvePartChecksum(checksumHeaders, body, upload.ChecksumAlgorithm)
+	if cksErr != nil {
+		return cksErr, nil
+	}
 
 	partPath := fmt.Sprintf("/.multipart/%s/%d", uploadID, partNum)
 	if mkdirErr := p.fs.MkdirAll(filepath.Dir(partPath), 0o755); mkdirErr != nil {
@@ -1316,6 +1376,7 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		PartNumber:   partNum,
 		ETag:         etag,
 		Size:         int64(len(body)),
+		Checksum:     checksum,
 		LastModified: p.tc.Now(),
 	}
 	partData, err := json.Marshal(part)
@@ -1326,9 +1387,16 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		return nil, fmt.Errorf("save part metadata: %w", err)
 	}
 
+	respHeaders := map[string]string{"ETag": etag}
+	// UploadPart echoes the part's checksum so the caller can carry it into the
+	// <Part> entries of its Complete request, as the SDKs do.
+	if checksum.present() {
+		respHeaders[s3ChecksumHeaderOf(checksum.Algorithm)] = checksum.Value
+	}
+
 	return &AWSResponse{
 		StatusCode: http.StatusOK,
-		Headers:    map[string]string{"ETag": etag},
+		Headers:    respHeaders,
 	}, nil
 }
 
@@ -1424,6 +1492,7 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 	// Concatenate parts and compute multi-part ETag.
 	var combined []byte
 	var partMD5s []byte
+	partBodies := make([][]byte, 0, len(parts))
 
 	for _, part := range parts {
 		partPath := fmt.Sprintf("/.multipart/%s/%d", uploadID, part.PartNumber)
@@ -1432,6 +1501,7 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 			return nil, fmt.Errorf("read part %d body: %w", part.PartNumber, readErr)
 		}
 		combined = append(combined, partBody...)
+		partBodies = append(partBodies, partBody)
 		h := md5.Sum(partBody) //nolint:gosec // nosemgrep
 		partMD5s = append(partMD5s, h[:]...)
 	}
@@ -1439,6 +1509,18 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 	numParts := len(parts)
 	combinedHash := md5.Sum(partMD5s) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x-%d"`, combinedHash, numParts)
+
+	// The object checksum is derived the same way the ETag above is — from the part
+	// digests for a COMPOSITE upload, or from every byte for a FULL_OBJECT one — and
+	// any value the caller supplied is verified against it before anything is
+	// written.
+	checksum, cksErr := assembleObjectChecksum(upload.ChecksumAlgorithm, upload.ChecksumType, combined, partBodies)
+	if cksErr != nil {
+		return cksErr, nil
+	}
+	if resp := verifyCompleteChecksum(req.Headers, checksum); resp != nil {
+		return resp, nil
+	}
 
 	filePath := "/" + bucket + "/" + key
 	if mkdirErr := p.fs.MkdirAll(filepath.Dir(filePath), 0o755); mkdirErr != nil {
@@ -1455,6 +1537,7 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		ContentType:  upload.ContentType,
 		Size:         int64(len(combined)),
 		StorageClass: upload.StorageClass,
+		Checksum:     checksum,
 		LastModified: p.tc.Now(),
 		UserMetadata: upload.UserMetadata,
 	}
@@ -1473,18 +1556,24 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		_ = p.fs.Remove(fmt.Sprintf("/.multipart/%s/%d", uploadID, pr.PartNumber))
 	}
 
+	// Unlike every other checksum-bearing operation, Complete returns the checksum as
+	// XML elements in its result body rather than as response headers.
 	type completeMultipartUploadResult struct {
-		XMLName  xml.Name `xml:"CompleteMultipartUploadResult"`
-		Location string   `xml:"Location"`
-		Bucket   string   `xml:"Bucket"`
-		Key      string   `xml:"Key"`
-		ETag     string   `xml:"ETag"`
+		XMLName      xml.Name        `xml:"CompleteMultipartUploadResult"`
+		Location     string          `xml:"Location"`
+		Bucket       string          `xml:"Bucket"`
+		Key          string          `xml:"Key"`
+		ETag         string          `xml:"ETag"`
+		Checksum     []s3ChecksumXML `xml:",any"`
+		ChecksumType string          `xml:"ChecksumType,omitempty"`
 	}
 	return s3XMLResponse(http.StatusOK, completeMultipartUploadResult{
-		Location: "https://s3.amazonaws.com/" + bucket + "/" + key,
-		Bucket:   bucket,
-		Key:      key,
-		ETag:     etag,
+		Location:     "https://s3.amazonaws.com/" + bucket + "/" + key,
+		Bucket:       bucket,
+		Key:          key,
+		ETag:         etag,
+		Checksum:     checksumXMLElements(checksum),
+		ChecksumType: checksum.Type,
 	})
 }
 
@@ -1772,16 +1861,43 @@ func isAWSChunked(headers map[string]string) bool {
 }
 
 // decodeAWSChunked decodes a SigV4 streaming (aws-chunked) request body into the
-// raw object content, stripping the per-chunk "<hex-size>;chunk-signature=...\r\n"
-// framing and trailing checksum trailers. Non-chunked bodies (and anything that
-// fails to parse as aws-chunked) are returned unchanged, so this is a safe no-op
-// for CLI-style standard HTTP chunking, which net/http has already de-framed.
+// raw object content, discarding any trailers. Callers that need the trailing
+// checksum a real SDK appends must use [decodeAWSChunkedWithTrailers].
+func decodeAWSChunked(headers map[string]string, body []byte) []byte {
+	decoded, _ := decodeAWSChunkedWithTrailers(headers, body)
+	return decoded
+}
+
+// decodeAWSChunkedWithTrailers decodes a SigV4 streaming (aws-chunked) request body
+// into the raw object content, stripping the per-chunk
+// "<hex-size>;chunk-signature=...\r\n" framing, and returns the trailing headers
+// that followed the completion chunk. Non-chunked bodies (and anything that fails
+// to parse as aws-chunked) are returned unchanged with no trailers, so this is a
+// safe no-op for CLI-style standard HTTP chunking, which net/http has already
+// de-framed.
 //
 // Format per chunk: "<hex-len>[;chunk-signature=<sig>]\r\n<len bytes>\r\n",
-// terminated by a zero-length chunk optionally followed by trailer headers.
-func decodeAWSChunked(headers map[string]string, body []byte) []byte {
+// terminated by a zero-length completion chunk optionally followed by trailers.
+//
+// The trailers are where the AWS SDKs put the checksum of a streamed upload:
+// "if trailing checksums exist (where AWS SDKs append checksums to the encoded
+// request bodies), the x-amz-trailer header value includes the x-amz-checksum-
+// prefix and ends with the algorithm name". Discarding them, as this function's
+// predecessor did, would mean checksum verification silently never fired for any
+// real SDK upload — a mock that accepts every checksum, which is worse than one
+// that offers none.
+//
+// Trailer chunk format, per the S3 user guide:
+//
+//	x-amz-checksum-<lowercase-algorithm>:<base64-value>\n\r\n\r\n
+//
+// with a trailer signature line following the value when the payload is
+// SigV4-signed. Header names are returned lowercased; the trailing "\n" the guide
+// notes as optional ("the usage of the linefeed \n at the end of the checksum value
+// might vary across clients") is trimmed from the value.
+func decodeAWSChunkedWithTrailers(headers map[string]string, body []byte) ([]byte, map[string]string) {
 	if len(body) == 0 || !isAWSChunked(headers) {
-		return body
+		return body, nil
 	}
 
 	var out []byte
@@ -1791,7 +1907,7 @@ func decodeAWSChunked(headers map[string]string, body []byte) []byte {
 		nl := indexCRLF(rest)
 		if nl < 0 {
 			// No framing found — not actually aws-chunked; return original.
-			return body
+			return body, nil
 		}
 		sizeLine := string(rest[:nl])
 		advance := nl + crlfLen(rest, nl)
@@ -1803,14 +1919,14 @@ func decodeAWSChunked(headers map[string]string, body []byte) []byte {
 		}
 		size, err := strconv.ParseInt(strings.TrimSpace(hexPart), 16, 64)
 		if err != nil {
-			return body // malformed → fall back to raw
+			return body, nil // malformed → fall back to raw
 		}
 		rest = rest[advance:]
 		if size == 0 {
-			break // final chunk; trailers (if any) follow and are ignored
+			break // completion chunk; whatever follows is trailers
 		}
 		if int64(len(rest)) < size {
-			return body // truncated → fall back to raw
+			return body, nil // truncated → fall back to raw
 		}
 		out = append(out, rest[:size]...)
 		rest = rest[size:]
@@ -1826,7 +1942,83 @@ func decodeAWSChunked(headers map[string]string, body []byte) []byte {
 			out = out[:n]
 		}
 	}
-	return out
+	return out, parseChunkedTrailers(rest)
+}
+
+// parseChunkedTrailers reads the "<name>:<value>" lines that follow an aws-chunked
+// completion chunk, returning them keyed by lowercased name.
+//
+// Lines without a colon are skipped rather than treated as malformed: a
+// SigV4-signed request appends a bare trailer-signature line after the trailer, and
+// the body ends with a final CRLF. Returns nil when there is nothing to report, so
+// callers can distinguish "no trailers" from "an empty trailer".
+func parseChunkedTrailers(rest []byte) map[string]string {
+	var trailers map[string]string
+	for len(rest) > 0 {
+		nl := indexCRLF(rest)
+		var line string
+		if nl < 0 {
+			line, rest = string(rest), nil
+		} else {
+			line, rest = string(rest[:nl]), rest[nl+crlfLen(rest, nl):]
+		}
+
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			continue // blank line, or a trailer signature
+		}
+		name := strings.ToLower(strings.TrimSpace(line[:colon]))
+		if name == "" {
+			continue
+		}
+		if trailers == nil {
+			trailers = make(map[string]string)
+		}
+		// Trim the optional linefeed the guide documents at the end of the value.
+		trailers[name] = strings.Trim(strings.TrimSpace(line[colon+1:]), "\n")
+	}
+	return trailers
+}
+
+// checksumHeadersWithTrailers returns the header set to resolve a write's checksum
+// from: the request headers, plus any x-amz-checksum-* trailer the streamed body
+// carried.
+//
+// A trailer is only honored when the request's x-amz-trailer header named it:
+// "the header name field for an upload request must match the value passed into the
+// x-amz-trailer request header. For example, if a request contains
+// x-amz-trailer: x-amz-checksum-crc32 and the trailer chunk has the header name
+// x-amz-checksum-sha1, the request fails." A mismatch is reported so the caller
+// does not get a silent success on a checksum nothing agreed on.
+//
+// The returned map is a copy when a trailer applies, so the request's own headers
+// are never mutated.
+func checksumHeadersWithTrailers(headers, trailers map[string]string) (map[string]string, *AWSResponse) {
+	declared := strings.ToLower(strings.TrimSpace(headerValueFold(headers, "x-amz-trailer")))
+	if declared == "" {
+		return headers, nil
+	}
+	if !strings.HasPrefix(declared, s3ChecksumHeaderPrefix) {
+		// Some other trailer (not a checksum) — nothing to verify against.
+		return headers, nil
+	}
+
+	value, ok := trailers[declared]
+	if !ok {
+		return nil, s3ErrorResponseWith(s3Error{
+			Code:    "MalformedTrailerError",
+			Message: "The request contained trailing data that was not well-formed or did not conform to our published schema.",
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{{Name: "TrailerHeader", Value: declared}},
+		})
+	}
+
+	merged := make(map[string]string, len(headers)+1)
+	for k, v := range headers {
+		merged[k] = v
+	}
+	merged[declared] = value
+	return merged, nil
 }
 
 // indexCRLF returns the index of the first \r\n or \n in b, or -1 if neither.

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -453,6 +453,13 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
+	// Validated before anything is written, so a rejected storage class leaves no
+	// partial object behind.
+	storageClass, scErr := resolveStorageClass(req.Headers)
+	if scErr != nil {
+		return scErr, nil
+	}
+
 	// Conditional writes must not race: the existence check and the write below have
 	// to be one atomic step, or N concurrent If-None-Match: * PUTs would all
 	// observe the key as absent and all succeed. See [s3KeyMutex].
@@ -503,6 +510,7 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		ContentType:     contentType,
 		ContentEncoding: req.Headers["Content-Encoding"],
 		Size:            int64(len(body)),
+		StorageClass:    storageClass,
 		LastModified:    p.tc.Now(),
 		UserMetadata:    userMeta,
 	}
@@ -620,6 +628,12 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 		}
 	}
 
+	// An archived object has no readable body, so its storage class is checked
+	// before the preconditions that would compare against one.
+	if resp := evaluateStorageClassRead(&obj); resp != nil {
+		return resp, nil
+	}
+
 	// Preconditions are evaluated before the range step: a 412 or 304 supersedes
 	// any range, and RFC 9110 requires a failed precondition to be reported rather
 	// than a partial response served.
@@ -676,7 +690,10 @@ func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key st
 		return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
 	}
 
-	// HEAD evaluates preconditions exactly as GET does.
+	// HEAD evaluates preconditions exactly as GET does. It deliberately does *not*
+	// check the storage class the way getObject does: HeadObject documents no
+	// InvalidObjectState, because "even if the object is stored in S3 Glacier, all
+	// object metadata is still available". See [evaluateStorageClassRead].
 	if resp := evaluateReadPreconditions(readConditionalHeaders(req.Headers), &obj); resp != nil {
 		return resp, nil
 	}
@@ -902,6 +919,29 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
+	// An archived source must be restored before it can be copied: "if the source
+	// object is in the S3 Glacier Flexible Retrieval or S3 Glacier Deep Archive
+	// storage class, you must restore a copy of this object before you can use it as
+	// a source object for the copy operation."
+	if resp := evaluateStorageClassRead(&srcObj); resp != nil {
+		return resp, nil
+	}
+
+	// Every request-derived value is resolved before the first write, so a malformed
+	// directive or storage class leaves the destination untouched.
+	dstStorageClass, scErr := resolveStorageClass(req.Headers)
+	if scErr != nil {
+		return scErr, nil
+	}
+	meta, metaErr := resolveCopyMetadata(req.Headers, &srcObj)
+	if metaErr != nil {
+		return metaErr, nil
+	}
+	tags, tagErr := resolveCopyTags(req.Headers, &srcObj)
+	if tagErr != nil {
+		return tagErr, nil
+	}
+
 	// Source preconditions gate whether the copy may read; destination
 	// preconditions gate whether it may overwrite. Both are checked before any
 	// write, so a rejected copy leaves the destination untouched.
@@ -945,13 +985,19 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	newETag := fmt.Sprintf(`"%x"`, hash)
 
 	dstObj := S3Object{
-		Bucket:       dstBucket,
-		Key:          dstKey,
-		ETag:         newETag,
-		ContentType:  srcObj.ContentType,
-		Size:         srcObj.Size,
+		Bucket:          dstBucket,
+		Key:             dstKey,
+		ETag:            newETag,
+		ContentType:     meta.ContentType,
+		ContentEncoding: meta.ContentEncoding,
+		Size:            srcObj.Size,
+		// The copy's class comes from the request, never from the source: "if the
+		// x-amz-storage-class header is not used, the copied object will be stored in
+		// the STANDARD Storage Class by default."
+		StorageClass: dstStorageClass,
 		LastModified: now,
-		UserMetadata: srcObj.UserMetadata,
+		UserMetadata: meta.UserMetadata,
+		Tags:         tags,
 	}
 
 	dstMeta, err := json.Marshal(dstObj)
@@ -1181,6 +1227,13 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
+	// The storage class is supplied here, at creation, not on Complete — so it is
+	// validated here and carried on the upload until the object is assembled.
+	storageClass, scErr := resolveStorageClass(req.Headers)
+	if scErr != nil {
+		return scErr, nil
+	}
+
 	uploadID := generateUploadID()
 
 	contentType := req.Headers["Content-Type"]
@@ -1193,6 +1246,7 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		Bucket:       bucket,
 		Key:          key,
 		ContentType:  contentType,
+		StorageClass: storageClass,
 		Initiated:    p.tc.Now(),
 		UserMetadata: extractUserMetadata(req.Headers),
 	}
@@ -1400,6 +1454,7 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		ETag:         etag,
 		ContentType:  upload.ContentType,
 		Size:         int64(len(combined)),
+		StorageClass: upload.StorageClass,
 		LastModified: p.tc.Now(),
 		UserMetadata: upload.UserMetadata,
 	}
@@ -1572,9 +1627,10 @@ func (p *S3Plugin) listMultipartUploads(_ *RequestContext, _ *AWSRequest, bucket
 	}
 
 	type uploadEntry struct {
-		Key       string `xml:"Key"`
-		UploadId  string `xml:"UploadId"` //nolint:revive // matches AWS XML field name
-		Initiated string `xml:"Initiated"`
+		Key          string `xml:"Key"`
+		UploadId     string `xml:"UploadId"` //nolint:revive // matches AWS XML field name
+		StorageClass string `xml:"StorageClass"`
+		Initiated    string `xml:"Initiated"`
 	}
 	type listMultipartUploadsResult struct {
 		XMLName xml.Name      `xml:"ListMultipartUploadsResult"`
@@ -1596,10 +1652,15 @@ func (p *S3Plugin) listMultipartUploads(_ *RequestContext, _ *AWSRequest, bucket
 		if upload.Bucket != bucket {
 			continue
 		}
+		storageClass := upload.StorageClass
+		if storageClass == "" {
+			storageClass = S3StorageClassStandard
+		}
 		result.Uploads = append(result.Uploads, uploadEntry{
-			Key:       upload.Key,
-			UploadId:  upload.UploadID,
-			Initiated: upload.Initiated.UTC().Format(time.RFC3339),
+			Key:          upload.Key,
+			UploadId:     upload.UploadID,
+			StorageClass: storageClass,
+			Initiated:    upload.Initiated.UTC().Format(time.RFC3339),
 		})
 	}
 
@@ -1633,6 +1694,7 @@ type objectEntryItem struct {
 	LastModified string `xml:"LastModified"`
 	ETag         string `xml:"ETag"`
 	Size         int64  `xml:"Size"`
+	StorageClass string `xml:"StorageClass"`
 }
 
 // loadObjectEntry loads and returns the XML entry for a single object.
@@ -1657,6 +1719,9 @@ func (p *S3Plugin) loadObjectEntry(ctx context.Context, bucket, key string) (*ob
 		LastModified: obj.LastModified.UTC().Format(time.RFC3339),
 		ETag:         obj.ETag,
 		Size:         obj.Size,
+		// Unlike the x-amz-storage-class response header, <StorageClass> is emitted
+		// for every listed object, STANDARD included.
+		StorageClass: storageClassOf(&obj),
 	}, nil
 }
 
@@ -1869,6 +1934,11 @@ func objectResponseHeaders(obj *S3Object) map[string]string {
 	}
 	if obj.VersionID != "" {
 		headers["x-amz-version-id"] = obj.VersionID
+	}
+	// "Amazon S3 returns this header for all objects except for S3 Standard storage
+	// class objects" — so an absent header means STANDARD, not unknown.
+	if sc := storageClassOf(obj); sc != S3StorageClassStandard {
+		headers["x-amz-storage-class"] = sc
 	}
 	for k, v := range obj.UserMetadata {
 		headers["X-Amz-Meta-"+k] = v
@@ -2792,6 +2862,7 @@ func (p *S3Plugin) listObjectVersions(_ *RequestContext, req *AWSRequest, bucket
 				LastModified: obj.LastModified.UTC().Format(time.RFC3339Nano),
 				ETag:         obj.ETag,
 				Size:         obj.Size,
+				StorageClass: storageClassOf(&obj),
 			})
 			continue
 		}
@@ -2821,6 +2892,7 @@ func (p *S3Plugin) listObjectVersions(_ *RequestContext, req *AWSRequest, bucket
 					LastModified: obj.LastModified.UTC().Format(time.RFC3339Nano),
 					ETag:         obj.ETag,
 					Size:         obj.Size,
+					StorageClass: storageClassOf(&obj),
 				})
 			}
 		}

--- a/emulator/s3_storage_class.go
+++ b/emulator/s3_storage_class.go
@@ -1,0 +1,89 @@
+package emulator
+
+import (
+	"net/http"
+)
+
+// S3StorageClassStandard is the storage class S3 assigns to an object written
+// without an x-amz-storage-class header. It is also the one class S3 omits from
+// the x-amz-storage-class response header on GetObject and HeadObject.
+const S3StorageClassStandard = "STANDARD"
+
+// s3StorageClasses is the set of values S3 accepts in x-amz-storage-class.
+//
+// It is the full documented enumeration, including the classes reachable only
+// through S3 on Outposts, Snow, Express One Zone and the FSx-backed tiers. Those
+// are not modeled as distinct behavior here, but accepting them keeps substrate
+// from rejecting a value real S3 would take — an emulator that returns an error
+// where AWS succeeds is the same class of defect as one that succeeds where AWS
+// errors.
+var s3StorageClasses = map[string]bool{
+	S3StorageClassStandard: true,
+	"REDUCED_REDUNDANCY":   true,
+	"STANDARD_IA":          true,
+	"ONEZONE_IA":           true,
+	"INTELLIGENT_TIERING":  true,
+	"GLACIER":              true,
+	"DEEP_ARCHIVE":         true,
+	"OUTPOSTS":             true,
+	"GLACIER_IR":           true,
+	"SNOW":                 true,
+	"EXPRESS_ONEZONE":      true,
+	"FSX_OPENZFS":          true,
+	"FSX_ONTAP":            true,
+}
+
+// s3ArchiveStorageClasses is the set of storage classes whose objects are not
+// directly readable: a GetObject against one fails until the object is restored.
+//
+// GLACIER_IR is deliberately absent. It is the instant-retrieval tier and reads
+// like any other class; treating it as archival is a plausible-looking mistake
+// that would make a consumer's restore path fire where real S3 never would.
+var s3ArchiveStorageClasses = map[string]bool{
+	"GLACIER":      true,
+	"DEEP_ARCHIVE": true,
+}
+
+// resolveStorageClass returns the storage class a write should record, given the
+// request's x-amz-storage-class header, along with the error response to serve
+// when the value is not one S3 accepts.
+//
+// An absent or empty header yields STANDARD, which is S3's documented default for
+// a newly created object. This is applied to CopyObject too: the copy's class comes
+// from the request, and is *not* inherited from the source — "if the
+// x-amz-storage-class header is not used, the copied object will be stored in the
+// STANDARD Storage Class by default".
+func resolveStorageClass(headers map[string]string) (string, *AWSResponse) {
+	value := headerValueFold(headers, "x-amz-storage-class")
+	if value == "" {
+		return S3StorageClassStandard, nil
+	}
+	if !s3StorageClasses[value] {
+		return "", s3ErrorResponse("InvalidStorageClass", "The storage class you specified is not valid.", http.StatusBadRequest)
+	}
+	return value, nil
+}
+
+// storageClassOf returns an object's storage class, treating the empty string as
+// STANDARD so that objects written before the field existed read back correctly.
+func storageClassOf(obj *S3Object) string {
+	if obj.StorageClass == "" {
+		return S3StorageClassStandard
+	}
+	return obj.StorageClass
+}
+
+// evaluateStorageClassRead returns the error response to serve when an object's
+// storage class makes its body unavailable, or nil when the read may proceed.
+//
+// Only GetObject uses this. HeadObject deliberately does not: "Even if the object
+// is stored in S3 Glacier, all object metadata is still available", and the
+// HeadObject reference lists no error but NoSuchKey. A HEAD of an archived object
+// is a 200 — which is what makes HEAD the way a consumer discovers that a GET
+// would need a restore first.
+func evaluateStorageClassRead(obj *S3Object) *AWSResponse {
+	if !s3ArchiveStorageClasses[storageClassOf(obj)] {
+		return nil
+	}
+	return s3ErrorResponse("InvalidObjectState", "The action is not valid for the object's storage class", http.StatusForbidden)
+}

--- a/emulator/s3_storage_class_test.go
+++ b/emulator/s3_storage_class_test.go
@@ -1,0 +1,692 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// storageClassFixture creates a bucket and returns the server.
+func storageClassFixture(t *testing.T, bucket string) *emulator.Server {
+	t.Helper()
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code, "create bucket")
+	return srv
+}
+
+// listedStorageClass returns the <StorageClass> ListObjectsV2 reports for a key.
+func listedStorageClass(t *testing.T, srv *emulator.Server, bucket, key string) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?list-type=2", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "list objects v2")
+
+	var result struct {
+		Contents []struct {
+			Key          string `xml:"Key"`
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"Contents"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+
+	for _, c := range result.Contents {
+		if c.Key == key {
+			return c.StorageClass
+		}
+	}
+	t.Fatalf("key %q absent from ListObjectsV2: %s", key, w.Body.String())
+	return ""
+}
+
+// TestS3_StorageClass_RoundTrip covers every storage class S3 documents: the value
+// PutObject records must come back on HEAD and in ListObjectsV2, and the
+// x-amz-storage-class response header must be omitted for STANDARD only.
+func TestS3_StorageClass_RoundTrip(t *testing.T) {
+	// The full documented enumeration, so a valid value is never rejected.
+	classes := []string{
+		"STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA",
+		"INTELLIGENT_TIERING", "GLACIER", "DEEP_ARCHIVE", "OUTPOSTS",
+		"GLACIER_IR", "SNOW", "EXPRESS_ONEZONE", "FSX_OPENZFS", "FSX_ONTAP",
+	}
+
+	for _, class := range classes {
+		t.Run(class, func(t *testing.T) {
+			srv := storageClassFixture(t, "sc-bucket")
+			key := "obj-" + class
+
+			pw := s3Request(t, srv, http.MethodPut, "/sc-bucket/"+key, []byte("payload"),
+				map[string]string{"x-amz-storage-class": class})
+			require.Equal(t, http.StatusOK, pw.Code, "put with storage class %s", class)
+
+			// HEAD reports the class even for the archival tiers: object metadata
+			// stays available regardless of where the body lives.
+			hw := s3Request(t, srv, http.MethodHead, "/sc-bucket/"+key, nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code, "head %s", class)
+
+			if class == "STANDARD" {
+				assert.Empty(t, hw.Header().Get("x-amz-storage-class"),
+					"S3 returns x-amz-storage-class for all objects except STANDARD")
+			} else {
+				assert.Equal(t, class, hw.Header().Get("x-amz-storage-class"))
+			}
+
+			// Unlike the header, the XML element is emitted for every class.
+			assert.Equal(t, class, listedStorageClass(t, srv, "sc-bucket", key))
+		})
+	}
+}
+
+// TestS3_StorageClass_DefaultsToStandard asserts a write with no
+// x-amz-storage-class records STANDARD, not the empty string.
+func TestS3_StorageClass_DefaultsToStandard(t *testing.T) {
+	srv := storageClassFixture(t, "sc-default")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-default/plain", []byte("body"), nil).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sc-default/plain", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Empty(t, hw.Header().Get("x-amz-storage-class"))
+
+	assert.Equal(t, "STANDARD", listedStorageClass(t, srv, "sc-default", "plain"),
+		"an absent header means STANDARD, and the list element is never blank")
+}
+
+// TestS3_StorageClass_Invalid asserts an unrecognized class is a 400
+// InvalidStorageClass, and that the rejected write leaves nothing behind.
+func TestS3_StorageClass_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"unknown", "TURBO_FROZEN"},
+		{"lowercase", "standard"},
+		{"typo", "GLACIER_INSTANT"},
+		{"whitespace", " STANDARD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := storageClassFixture(t, "sc-invalid")
+
+			w := s3Request(t, srv, http.MethodPut, "/sc-invalid/obj", []byte("body"),
+				map[string]string{"x-amz-storage-class": tt.value})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+
+			body := parseS3Error(t, w.Body.Bytes())
+			assert.Equal(t, "InvalidStorageClass", body.Code)
+			assert.Equal(t, "The storage class you specified is not valid.", body.Message)
+
+			// Validation runs before any write, so the key must not exist.
+			assert.Equal(t, http.StatusNotFound,
+				s3Request(t, srv, http.MethodHead, "/sc-invalid/obj", nil, nil).Code,
+				"a rejected storage class must not create the object")
+		})
+	}
+}
+
+// TestS3_StorageClass_ArchivedGetIsInvalidObjectState covers the read gate: the two
+// archival classes fail a GET until restored, and GLACIER_IR — instant retrieval —
+// does not. Conflating the two is the mistake this test exists to catch.
+func TestS3_StorageClass_ArchivedGetIsInvalidObjectState(t *testing.T) {
+	tests := []struct {
+		class      string
+		wantStatus int
+	}{
+		{"GLACIER", http.StatusForbidden},
+		{"DEEP_ARCHIVE", http.StatusForbidden},
+		{"GLACIER_IR", http.StatusOK},
+		{"STANDARD", http.StatusOK},
+		{"STANDARD_IA", http.StatusOK},
+		{"INTELLIGENT_TIERING", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.class, func(t *testing.T) {
+			srv := storageClassFixture(t, "sc-archive")
+			key := "obj-" + tt.class
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sc-archive/"+key, []byte("payload"),
+					map[string]string{"x-amz-storage-class": tt.class}).Code)
+
+			gw := s3Request(t, srv, http.MethodGet, "/sc-archive/"+key, nil, nil)
+			assert.Equal(t, tt.wantStatus, gw.Code)
+
+			if tt.wantStatus == http.StatusForbidden {
+				body := parseS3Error(t, gw.Body.Bytes())
+				assert.Equal(t, "InvalidObjectState", body.Code)
+				assert.Equal(t, "The action is not valid for the object's storage class", body.Message)
+			} else {
+				assert.Equal(t, "payload", gw.Body.String())
+			}
+		})
+	}
+}
+
+// TestS3_StorageClass_ArchivedHeadSucceeds pins the deliberate asymmetry: HeadObject
+// documents no InvalidObjectState, because "even if the object is stored in S3
+// Glacier, all object metadata is still available". HEAD is therefore how a consumer
+// discovers that a GET needs a restore first.
+func TestS3_StorageClass_ArchivedHeadSucceeds(t *testing.T) {
+	for _, class := range []string{"GLACIER", "DEEP_ARCHIVE"} {
+		t.Run(class, func(t *testing.T) {
+			srv := storageClassFixture(t, "sc-head")
+			key := "obj-" + class
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sc-head/"+key, []byte("payload"),
+					map[string]string{"x-amz-storage-class": class}).Code)
+
+			hw := s3Request(t, srv, http.MethodHead, "/sc-head/"+key, nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code, "HEAD of an archived object is a 200")
+			assert.Equal(t, class, hw.Header().Get("x-amz-storage-class"))
+			assert.Equal(t, "7", hw.Header().Get("Content-Length"),
+				"metadata, including the size, stays available")
+		})
+	}
+}
+
+// TestS3_StorageClass_ArchivedRangedGet asserts the archival gate precedes the range
+// step: an archived object has no readable bytes, so a ranged GET is the same 403 as
+// an unranged one rather than a 206.
+func TestS3_StorageClass_ArchivedRangedGet(t *testing.T) {
+	srv := storageClassFixture(t, "sc-range")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-range/frozen", []byte("0123456789"),
+			map[string]string{"x-amz-storage-class": "GLACIER"}).Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/sc-range/frozen", nil,
+		map[string]string{"Range": "bytes=0-3"})
+	require.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "InvalidObjectState", parseS3Error(t, w.Body.Bytes()).Code)
+}
+
+// TestS3_StorageClass_MultipartCarriesClass asserts the class supplied at
+// CreateMultipartUpload survives to the assembled object — the header is accepted
+// there, not on CompleteMultipartUpload.
+func TestS3_StorageClass_MultipartCarriesClass(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-mpu", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/sc-mpu/big?uploads", nil,
+		map[string]string{"x-amz-storage-class": "STANDARD_IA"})
+	require.Equal(t, http.StatusOK, iw.Code)
+
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	// ListMultipartUploads reports the in-progress upload's class.
+	lw := s3Request(t, srv, http.MethodGet, "/sc-mpu?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, lw.Code)
+	var lr struct {
+		Uploads []struct {
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"Upload"`
+	}
+	require.NoError(t, xml.Unmarshal(lw.Body.Bytes(), &lr))
+	require.Len(t, lr.Uploads, 1)
+	assert.Equal(t, "STANDARD_IA", lr.Uploads[0].StorageClass)
+
+	etag := uploadPart(t, srv, "sc-mpu", "big", ir.UploadID, 1, []byte("single part is exempt from the 5 MB floor"))
+	cw := s3Request(t, srv, http.MethodPost, "/sc-mpu/big?uploadId="+ir.UploadID,
+		completeBody(etag), nil)
+	require.Equal(t, http.StatusOK, cw.Code, "complete multipart upload")
+
+	hw := s3Request(t, srv, http.MethodHead, "/sc-mpu/big", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "STANDARD_IA", hw.Header().Get("x-amz-storage-class"))
+}
+
+// TestS3_StorageClass_MultipartInvalidClass asserts CreateMultipartUpload validates
+// the class up front rather than failing at Complete, after parts have been paid for.
+func TestS3_StorageClass_MultipartInvalidClass(t *testing.T) {
+	srv := storageClassFixture(t, "sc-mpu-bad")
+
+	w := s3Request(t, srv, http.MethodPost, "/sc-mpu-bad/big?uploads", nil,
+		map[string]string{"x-amz-storage-class": "NOPE"})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "InvalidStorageClass", parseS3Error(t, w.Body.Bytes()).Code)
+}
+
+// TestS3_StorageClass_ListObjectVersions asserts each <Version> carries a
+// <StorageClass>, while a <DeleteMarker> does not — matching the response shape S3
+// documents.
+func TestS3_StorageClass_ListObjectVersions(t *testing.T) {
+	srv := storageClassFixture(t, "sc-versions")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-versions?versioning",
+			[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil).Code)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-versions/obj", []byte("v1"),
+			map[string]string{"x-amz-storage-class": "STANDARD_IA"}).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-versions/obj", []byte("v2"),
+			map[string]string{"x-amz-storage-class": "GLACIER_IR"}).Code)
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/sc-versions/obj", nil, nil).Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/sc-versions?versions", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var result struct {
+		Versions []struct {
+			VersionID    string `xml:"VersionId"`
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"Version"`
+		DeleteMarkers []struct {
+			VersionID string `xml:"VersionId"`
+			// Decoded only to assert it is never emitted: the DeleteMarkerEntry
+			// shape S3 documents has no StorageClass child.
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"DeleteMarker"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+
+	require.Len(t, result.Versions, 2)
+	classes := []string{result.Versions[0].StorageClass, result.Versions[1].StorageClass}
+	assert.ElementsMatch(t, []string{"STANDARD_IA", "GLACIER_IR"}, classes,
+		"each version reports the class it was written with")
+
+	require.Len(t, result.DeleteMarkers, 1)
+	assert.Empty(t, result.DeleteMarkers[0].StorageClass,
+		"a <DeleteMarker> carries no <StorageClass>")
+}
+
+// TestS3_StorageClass_ListObjectsV1 asserts ListObjects v1 emits <StorageClass> too,
+// since both list operations share one entry type.
+func TestS3_StorageClass_ListObjectsV1(t *testing.T) {
+	srv := storageClassFixture(t, "sc-v1")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-v1/obj", []byte("body"),
+			map[string]string{"x-amz-storage-class": "ONEZONE_IA"}).Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/sc-v1", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var result struct {
+		Contents []struct {
+			Key          string `xml:"Key"`
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"Contents"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+	require.Len(t, result.Contents, 1)
+	assert.Equal(t, "ONEZONE_IA", result.Contents[0].StorageClass)
+}
+
+// --- CopyObject storage class ---
+
+// TestS3_CopyObject_StorageClass asserts the copy's class comes from the request and
+// is never inherited from the source: "if the x-amz-storage-class header is not used,
+// the copied object will be stored in the STANDARD Storage Class by default".
+func TestS3_CopyObject_StorageClass(t *testing.T) {
+	tests := []struct {
+		name        string
+		sourceClass string
+		copyHeader  string
+		wantClass   string
+	}{
+		{"unqualified copy resets to STANDARD", "STANDARD_IA", "", "STANDARD"},
+		{"explicit class is recorded", "STANDARD", "GLACIER_IR", "GLACIER_IR"},
+		{"in-place transition to archival", "STANDARD", "GLACIER", "GLACIER"},
+		{"transition away from archival", "GLACIER_IR", "STANDARD", "STANDARD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := storageClassFixture(t, "cp-sc")
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-sc/src", []byte("payload"),
+					map[string]string{"x-amz-storage-class": tt.sourceClass}).Code)
+
+			headers := map[string]string{"X-Amz-Copy-Source": "/cp-sc/src"}
+			if tt.copyHeader != "" {
+				headers["x-amz-storage-class"] = tt.copyHeader
+			}
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-sc/dst", nil, headers).Code, "copy")
+
+			hw := s3Request(t, srv, http.MethodHead, "/cp-sc/dst", nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code)
+			assert.Equal(t, tt.wantClass, listedStorageClass(t, srv, "cp-sc", "dst"))
+		})
+	}
+}
+
+// TestS3_CopyObject_InPlaceTransition covers the tier-transition pattern directly: a
+// CopyObject onto the object's own key changes its class, and the archival target is
+// then unreadable by GET while still readable by HEAD.
+func TestS3_CopyObject_InPlaceTransition(t *testing.T) {
+	srv := storageClassFixture(t, "cp-inplace")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/cp-inplace/obj", []byte("payload"), nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodGet, "/cp-inplace/obj", nil, nil).Code)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/cp-inplace/obj", nil, map[string]string{
+			"X-Amz-Copy-Source":   "/cp-inplace/obj",
+			"x-amz-storage-class": "DEEP_ARCHIVE",
+		}).Code, "in-place transition")
+
+	gw := s3Request(t, srv, http.MethodGet, "/cp-inplace/obj", nil, nil)
+	require.Equal(t, http.StatusForbidden, gw.Code, "the transitioned object is no longer readable")
+	assert.Equal(t, "InvalidObjectState", parseS3Error(t, gw.Body.Bytes()).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/cp-inplace/obj", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "DEEP_ARCHIVE", hw.Header().Get("x-amz-storage-class"))
+}
+
+// TestS3_CopyObject_ArchivedSource asserts an archived source must be restored before
+// it can be copied — the class gate applies to the read side of a copy too.
+func TestS3_CopyObject_ArchivedSource(t *testing.T) {
+	srv := storageClassFixture(t, "cp-frozen")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/cp-frozen/src", []byte("payload"),
+			map[string]string{"x-amz-storage-class": "GLACIER"}).Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/cp-frozen/dst", nil, map[string]string{
+		"X-Amz-Copy-Source":   "/cp-frozen/src",
+		"x-amz-storage-class": "STANDARD",
+	})
+	require.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "InvalidObjectState", parseS3Error(t, w.Body.Bytes()).Code)
+
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodHead, "/cp-frozen/dst", nil, nil).Code,
+		"a rejected copy must leave no destination object")
+}
+
+// TestS3_CopyObject_InvalidStorageClass asserts a bad class on a copy is rejected
+// before the destination is written.
+func TestS3_CopyObject_InvalidStorageClass(t *testing.T) {
+	srv := storageClassFixture(t, "cp-bad")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/cp-bad/src", []byte("payload"), nil).Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/cp-bad/dst", nil, map[string]string{
+		"X-Amz-Copy-Source":   "/cp-bad/src",
+		"x-amz-storage-class": "ICEBOX",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "InvalidStorageClass", parseS3Error(t, w.Body.Bytes()).Code)
+
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodHead, "/cp-bad/dst", nil, nil).Code)
+}
+
+// --- CopyObject metadata directive ---
+
+// TestS3_CopyObject_MetadataDirectiveCopy asserts the documented COPY behavior:
+// "when you copy an object, user-controlled system metadata and user-defined metadata
+// are also copied", and Content-Encoding is user-controlled. A COPY therefore
+// preserves it, and headers restated on the request are *ignored* — only REPLACE
+// reads them.
+func TestS3_CopyObject_MetadataDirectiveCopy(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive string
+	}{
+		{"default (no directive header)", ""},
+		{"explicit COPY", "COPY"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := storageClassFixture(t, "cp-meta")
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-meta/src", []byte("payload"),
+					map[string]string{
+						"Content-Type":     "text/plain",
+						"Content-Encoding": "gzip",
+						"x-amz-meta-owner": "alice",
+					}).Code)
+
+			headers := map[string]string{"X-Amz-Copy-Source": "/cp-meta/src"}
+			if tt.directive != "" {
+				headers["x-amz-metadata-directive"] = tt.directive
+			}
+			// Restated headers a COPY must ignore.
+			headers["Content-Type"] = "application/json"
+			headers["x-amz-meta-owner"] = "bob"
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-meta/dst", nil, headers).Code)
+
+			hw := s3Request(t, srv, http.MethodHead, "/cp-meta/dst", nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code)
+			assert.Equal(t, "gzip", hw.Header().Get("Content-Encoding"),
+				"COPY preserves Content-Encoding")
+			assert.Equal(t, "text/plain", hw.Header().Get("Content-Type"),
+				"COPY takes the source's Content-Type, not the request's")
+			assert.Equal(t, "alice", hw.Header().Get("X-Amz-Meta-Owner"),
+				"COPY takes the source's user metadata, not the request's")
+		})
+	}
+}
+
+// TestS3_CopyObject_MetadataDirectiveReplace asserts REPLACE drops everything the
+// request does not restate: "you must explicitly specify all of the user-configurable
+// metadata present on the source object in your request, even if you are changing
+// only one of the metadata values." This is the asymmetry an in-place tier transition
+// trips over — a REPLACE that omits Content-Encoding loses it.
+func TestS3_CopyObject_MetadataDirectiveReplace(t *testing.T) {
+	t.Run("omitted metadata is dropped", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-repl")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-repl/src", []byte("payload"),
+				map[string]string{
+					"Content-Type":     "text/plain",
+					"Content-Encoding": "gzip",
+					"x-amz-meta-owner": "alice",
+				}).Code)
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-repl/dst", nil, map[string]string{
+				"X-Amz-Copy-Source":        "/cp-repl/src",
+				"x-amz-metadata-directive": "REPLACE",
+			}).Code)
+
+		hw := s3Request(t, srv, http.MethodHead, "/cp-repl/dst", nil, nil)
+		require.Equal(t, http.StatusOK, hw.Code)
+		assert.Empty(t, hw.Header().Get("Content-Encoding"),
+			"REPLACE drops a Content-Encoding the request did not restate")
+		assert.Equal(t, "application/octet-stream", hw.Header().Get("Content-Type"),
+			"REPLACE falls back to the default Content-Type")
+		assert.Empty(t, hw.Header().Get("X-Amz-Meta-Owner"),
+			"REPLACE drops user metadata the request did not restate")
+	})
+
+	t.Run("restated metadata is kept", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-repl2")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-repl2/src", []byte("payload"),
+				map[string]string{
+					"Content-Type":     "text/plain",
+					"Content-Encoding": "gzip",
+					"x-amz-meta-owner": "alice",
+				}).Code)
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-repl2/dst", nil, map[string]string{
+				"X-Amz-Copy-Source":        "/cp-repl2/src",
+				"x-amz-metadata-directive": "REPLACE",
+				"Content-Type":             "application/json",
+				"Content-Encoding":         "br",
+				"x-amz-meta-owner":         "bob",
+			}).Code)
+
+		hw := s3Request(t, srv, http.MethodHead, "/cp-repl2/dst", nil, nil)
+		require.Equal(t, http.StatusOK, hw.Code)
+		assert.Equal(t, "br", hw.Header().Get("Content-Encoding"))
+		assert.Equal(t, "application/json", hw.Header().Get("Content-Type"))
+		assert.Equal(t, "bob", hw.Header().Get("X-Amz-Meta-Owner"))
+	})
+}
+
+// TestS3_CopyObject_MetadataDirectiveInvalid asserts an unrecognized directive is
+// rejected rather than silently defaulting to COPY. A typo that quietly preserved
+// metadata is exactly the false success this emulator exists to surface.
+func TestS3_CopyObject_MetadataDirectiveInvalid(t *testing.T) {
+	for _, header := range []string{"x-amz-metadata-directive", "x-amz-tagging-directive"} {
+		t.Run(header, func(t *testing.T) {
+			srv := storageClassFixture(t, "cp-dir")
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-dir/src", []byte("payload"), nil).Code)
+
+			w := s3Request(t, srv, http.MethodPut, "/cp-dir/dst", nil, map[string]string{
+				"X-Amz-Copy-Source": "/cp-dir/src",
+				header:              "MERGE",
+			})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+
+			body := parseS3Error(t, w.Body.Bytes())
+			assert.Equal(t, "InvalidArgument", body.Code)
+			assert.Contains(t, body.Message, header)
+
+			assert.Equal(t, http.StatusNotFound,
+				s3Request(t, srv, http.MethodHead, "/cp-dir/dst", nil, nil).Code)
+		})
+	}
+}
+
+// TestS3_CopyObject_TaggingDirective asserts the tag-set follows its own directive:
+// COPY (the default) carries the source's tags, REPLACE takes them from the
+// URL-query-encoded x-amz-tagging header.
+func TestS3_CopyObject_TaggingDirective(t *testing.T) {
+	putSourceTags := func(t *testing.T, srv *emulator.Server, bucket string) {
+		t.Helper()
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/"+bucket+"/src?tagging",
+				[]byte(`<Tagging><TagSet><Tag><Key>team</Key><Value>infra</Value></Tag></TagSet></Tagging>`),
+				nil).Code)
+	}
+
+	getTags := func(t *testing.T, srv *emulator.Server, bucket, key string) map[string]string {
+		t.Helper()
+		w := s3Request(t, srv, http.MethodGet, "/"+bucket+"/"+key+"?tagging", nil, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var result struct {
+			Tags []struct {
+				Key   string `xml:"Key"`
+				Value string `xml:"Value"`
+			} `xml:"TagSet>Tag"`
+		}
+		require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+
+		tags := make(map[string]string, len(result.Tags))
+		for _, tag := range result.Tags {
+			tags[tag.Key] = tag.Value
+		}
+		return tags
+	}
+
+	t.Run("COPY carries the source tag-set", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag/src", []byte("payload"), nil).Code)
+		putSourceTags(t, srv, "cp-tag")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag/dst", nil, map[string]string{
+				"X-Amz-Copy-Source": "/cp-tag/src",
+			}).Code)
+
+		assert.Equal(t, map[string]string{"team": "infra"}, getTags(t, srv, "cp-tag", "dst"))
+	})
+
+	t.Run("REPLACE takes the request tag-set", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag2")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag2/src", []byte("payload"), nil).Code)
+		putSourceTags(t, srv, "cp-tag2")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag2/dst", nil, map[string]string{
+				"X-Amz-Copy-Source":       "/cp-tag2/src",
+				"x-amz-tagging-directive": "REPLACE",
+				"x-amz-tagging":           "stage=prod&owner=alice",
+			}).Code)
+
+		assert.Equal(t, map[string]string{"stage": "prod", "owner": "alice"},
+			getTags(t, srv, "cp-tag2", "dst"))
+	})
+
+	t.Run("REPLACE with no tagging header clears the tag-set", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag3")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag3/src", []byte("payload"), nil).Code)
+		putSourceTags(t, srv, "cp-tag3")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag3/dst", nil, map[string]string{
+				"X-Amz-Copy-Source":       "/cp-tag3/src",
+				"x-amz-tagging-directive": "REPLACE",
+			}).Code)
+
+		assert.Empty(t, getTags(t, srv, "cp-tag3", "dst"),
+			`the default value of x-amz-tagging is the empty value`)
+	})
+
+	t.Run("REPLACE with an unparseable tagging header is rejected", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag-bad")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag-bad/src", []byte("payload"), nil).Code)
+
+		// %zz is not valid percent-encoding, so the tag-set cannot be decoded.
+		w := s3Request(t, srv, http.MethodPut, "/cp-tag-bad/dst", nil, map[string]string{
+			"X-Amz-Copy-Source":       "/cp-tag-bad/src",
+			"x-amz-tagging-directive": "REPLACE",
+			"x-amz-tagging":           "stage=%zz",
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "InvalidArgument", parseS3Error(t, w.Body.Bytes()).Code)
+
+		assert.Equal(t, http.StatusNotFound,
+			s3Request(t, srv, http.MethodHead, "/cp-tag-bad/dst", nil, nil).Code)
+	})
+
+	t.Run("copied tags do not alias the source", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag4")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag4/src", []byte("payload"), nil).Code)
+		putSourceTags(t, srv, "cp-tag4")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag4/dst", nil, map[string]string{
+				"X-Amz-Copy-Source": "/cp-tag4/src",
+			}).Code)
+
+		// Retagging the destination must not disturb the source.
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag4/dst?tagging",
+				[]byte(`<Tagging><TagSet><Tag><Key>team</Key><Value>data</Value></Tag></TagSet></Tagging>`),
+				nil).Code)
+
+		assert.Equal(t, map[string]string{"team": "infra"}, getTags(t, srv, "cp-tag4", "src"))
+		assert.Equal(t, map[string]string{"team": "data"}, getTags(t, srv, "cp-tag4", "dst"))
+	})
+}

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -43,6 +43,10 @@ type S3Object struct {
 	// Size is the byte length of the object body.
 	Size int64 `json:"size"`
 
+	// StorageClass is the S3 storage class of the object, set via the
+	// x-amz-storage-class header on write. Empty is equivalent to STANDARD.
+	StorageClass string `json:"storage_class,omitempty"`
+
 	// LastModified is the time of the most recent write.
 	LastModified time.Time `json:"last_modified"`
 
@@ -88,6 +92,9 @@ type S3ObjectVersion struct {
 
 	// Size is the byte length of the object body.
 	Size int64 `xml:"Size"`
+
+	// StorageClass is the S3 storage class of this version.
+	StorageClass string `xml:"StorageClass"`
 }
 
 // S3DeleteMarker holds metadata for one delete marker in a ListObjectVersions
@@ -131,6 +138,10 @@ type S3MultipartUpload struct {
 
 	// ContentType is the MIME type supplied at upload creation.
 	ContentType string `json:"content_type"`
+
+	// StorageClass is the storage class supplied at upload creation, applied to
+	// the object CompleteMultipartUpload assembles. Empty means STANDARD.
+	StorageClass string `json:"storage_class,omitempty"`
 
 	// Initiated is the time the multipart upload was created.
 	Initiated time.Time `json:"initiated"`

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -47,6 +47,11 @@ type S3Object struct {
 	// x-amz-storage-class header on write. Empty is equivalent to STANDARD.
 	StorageClass string `json:"storage_class,omitempty"`
 
+	// Checksum is the additional checksum recorded for the object, from the
+	// x-amz-checksum-* family. Zero when the object was written without one;
+	// returned on GetObject/HeadObject only under x-amz-checksum-mode: ENABLED.
+	Checksum s3Checksum `json:"checksum,omitzero"`
+
 	// LastModified is the time of the most recent write.
 	LastModified time.Time `json:"last_modified"`
 
@@ -143,6 +148,15 @@ type S3MultipartUpload struct {
 	// the object CompleteMultipartUpload assembles. Empty means STANDARD.
 	StorageClass string `json:"storage_class,omitempty"`
 
+	// ChecksumAlgorithm is the algorithm named in x-amz-checksum-algorithm at
+	// upload creation, applied to every part and to the assembled object. Empty
+	// when the upload was created without one.
+	ChecksumAlgorithm string `json:"checksum_algorithm,omitempty"`
+
+	// ChecksumType is COMPOSITE or FULL_OBJECT, deciding how the part checksums
+	// combine into the object's. Empty when ChecksumAlgorithm is empty.
+	ChecksumType string `json:"checksum_type,omitempty"`
+
 	// Initiated is the time the multipart upload was created.
 	Initiated time.Time `json:"initiated"`
 
@@ -161,6 +175,10 @@ type S3Part struct {
 
 	// Size is the byte length of the part body.
 	Size int64 `json:"size"`
+
+	// Checksum is the additional checksum of this part's body, under the upload's
+	// algorithm. A COMPOSITE object checksum is derived from these.
+	Checksum s3Checksum `json:"checksum,omitzero"`
 
 	// LastModified is the time this part was uploaded.
 	LastModified time.Time `json:"last_modified"`


### PR DESCRIPTION
Closes #399.

Stacked on #409 (`feat/398-s3-storage-class`), which is stacked on #408. Review the last commit only; the base will retarget as the stack merges.

## Why

Checksum headers were **ignored altogether**, which inverts the guarantee they exist to provide. A consumer computing a checksum client-side so that S3 rejects corrupt data got a `200` whether the value matched the body or not — so a test asserting "a corrupted upload is rejected" passed against substrate, and would equally have passed against a writer that computed the checksum wrong. That is the failure mode this milestone is about: substrate returning success where real AWS returns an error, making the consumer's error branch unreachable.

## What

`PutObject`, `UploadPart`, `CopyObject` and `CompleteMultipartUpload` now compute and **verify** checksums.

**A mismatch is `400 BadDigest` and nothing is written.** The key does not appear (neither metadata nor body), a rejected write over an existing object leaves the original bytes and ETag intact rather than truncating them, and a rejected part is not stored for a later Complete to pick up. Every verification sits after the `aws-chunked` decode — it needs the decoded body — and *before* the corresponding write.

**Seven algorithms verified:** `CRC32`, `CRC32C`, `CRC64NVME`, `SHA1`, `SHA256`, `SHA512`, `MD5`. CRC-64/NVME is built from the bit-reversed catalog polynomial (`0x9a6c9329ac4bc9b5`) and pinned by a test against the published check value `0xae8b14860a799888`, so a transcription error fails loudly instead of producing a wrong digest that agrees with itself.

**`XXHASH64`/`XXHASH3`/`XXHASH128` are `501 NotImplemented`,** not silently accepted. Substrate has nothing to check a supplied value against, and storing an unverified checksum is the exact defect this PR removes — it would make a test pass on data real S3 would have rejected.

**Trailing checksums are read.** `decodeAWSChunked` discarded everything after the completion chunk, which is where every AWS SDK puts the checksum of a streamed upload — header-only verification would silently never have fired for a real SDK write. Trailers are now parsed and honored when `x-amz-trailer` declares them; a name mismatch, or a declared trailer that never arrives, is `400 MalformedTrailerError`.

**Multipart distinguishes `COMPOSITE` from `FULL_OBJECT`.** An unsupported algorithm/type pairing is rejected at `CreateMultipartUpload` — before any part is uploaded, rather than after a consumer has paid to upload all of them. An absent `x-amz-checksum-type` defaults to `COMPOSITE`, except `CRC64NVME`, which has no composite form and defaults to `FULL_OBJECT`. Complete returns the value as an XML **element** (`<ChecksumSHA256>`, `<ChecksumType>`), not a header, and verifies a whole-object checksum supplied on the request itself. A `FULL_OBJECT` multipart checksum equals what a single-part `PutObject` of the same bytes produces — the invariant a consumer whose two write paths disagree needs a test to catch.

**`CopyObject` recomputes** as a direct full-object checksum of the copied bytes, under the source's algorithm unless the copy names a new one. Copying a `COMPOSITE` multipart object changes both the value and the type though the data is identical, matching S3.

**Reading a checksum back requires `x-amz-checksum-mode: ENABLED`,** so its absence on a plain `GET` is observable. A ranged `GET` returns the whole object's checksum, not the range's.

## One deliberate divergence

Real S3 attaches a default `CRC64NVME` checksum to every object uploaded without one, so a checksum-mode `GET` always returns something. **Substrate records none.** Synthesizing one would make a consumer's round-trip assertion pass whether or not their writer actually sends a checksum — precisely the failure this work exists to expose. An absent checksum in substrate means "your writer sent none". Documented in the code, in the changelog, and in `docs/services.md`.

## Verification

`emulator/s3_checksum_test.go` (~1,000 lines, ~30 tests). The algorithm table and hash constructors are **re-declared in the test**, wired straight to the stdlib, so a test computing its expected value never calls the code under test — otherwise it would pass even if the emulator hashed the wrong algorithm.

- `go build ./...`, `go vet ./...`, `gofmt` clean
- `golangci-lint run ./...` — **0 issues**
- `make test` (race) — green
- `test/e2e` — green
- `make docs-reference-check`, `make docs-versions` — green
- `make scan-fs` — 0 vulnerabilities (`scan-iac` findings are pre-existing, in `deploy/k8s/`)

Every request/response shape, error code and the multipart support matrix were checked against the AWS S3 API reference and the "Checking object integrity" user guide, per `CLAUDE.md`.