### PR TITLE
fix(ec2): raise Invalid*.NotFound/Malformed for explicit resource IDs (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InvalidPart` would send a consumer hunting a data bug that does not exist.
 
 ### Fixed
+- EC2 `Describe*` calls that name a resource ID explicitly now raise
+  `Invalid<Type>.NotFound` when the ID resolves to nothing, and
+  `Invalid<Type>.Malformed` when it is syntactically invalid, instead of
+  returning `200` with an empty list (#391). Covers `DescribeInstances`,
+  `DescribeInstanceStatus`, `DescribeVpcs`, `DescribeSubnets`,
+  `DescribeSecurityGroups`, `DescribeInternetGateways`, `DescribeRouteTables`,
+  `DescribeSnapshots`, `DescribeAddresses` and `DescribeNatGateways`, plus the
+  mutating operations that took an ID and silently succeeded on a missing one:
+  `TerminateInstances`, `StopInstances`, `StartInstances`, `DeleteVpc`,
+  `DeleteSubnet`, `DeleteSecurityGroup`, `DeleteInternetGateway` and
+  `DeleteRouteTable`.
+  This is the "absent vs. filtered" distinction: `DescribeVpcs()` with no
+  arguments legitimately returns `[]`, but naming a VPC ID is an assertion that
+  the ID exists and EC2 answers it with an error. A consumer whose entire
+  network-precondition check is a `try/except ClientError` on
+  `InvalidVpcID.NotFound` had that branch made unreachable — the call succeeded,
+  the guard was skipped, and a test asserting "a deleted VPC is reported clearly"
+  passed while verifying nothing. Status-polling loops reading
+  `Reservations[0]["Instances"][0]` got an `IndexError` in place of the
+  `InvalidInstanceID.NotFound` they handle.
+  AWS's casing is inconsistent across these codes and SDK callers match the
+  literal string, so each pair is spelled out verbatim from the EC2 error
+  reference rather than derived: `InvalidVpcID.NotFound` but
+  `InvalidGroupId.Malformed`; `InvalidGroup.NotFound` with no `Id` at all;
+  `InvalidSnapshot.NotFound` beside `InvalidSnapshotID.Malformed`. EC2 publishes
+  no `Malformed` variant for allocation IDs or NAT gateway IDs, so a malformed ID
+  for those surfaces as the `NotFound` code.
+  Three orderings match EC2 and are covered by tests: syntax is validated before
+  any lookup, so a request naming both a malformed and an absent ID reports
+  `Malformed`; one present plus one absent ID fails the whole call rather than
+  returning the partial set; and an ID excluded by a `Filter` rather than by
+  absence still counts as resolved, so an existing ID plus a non-matching filter
+  returns 200 and an empty set. ID syntax deliberately does not check length —
+  substrate's generators emit 16 hex characters where AWS emits 8 or 17, and AWS
+  still accepts the legacy 8-character form for several resources.
 - S3 multipart operations now return S3's documented `NoSuchUpload` and
   `MalformedXML` message text rather than abbreviated paraphrases (#400).
 - S3 `HeadObject` now reports `x-amz-version-id` (#396). `GetObject` always did,

--- a/docs/services.md
+++ b/docs/services.md
@@ -414,28 +414,76 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | Operation | Notes |
 |-----------|-------|
 | RunInstances | Auto-creates default VPC (172.31.0.0/16) |
-| DescribeInstances | |
-| TerminateInstances | |
-| StopInstances | |
-| StartInstances | |
-| DescribeInstanceStatus | |
+| DescribeInstances | [Explicit resource IDs](#explicit-resource-ids) |
+| TerminateInstances | [Explicit resource IDs](#explicit-resource-ids) |
+| StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
+| StartInstances | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeInstanceStatus | [Explicit resource IDs](#explicit-resource-ids) |
 | CreateVpc | |
-| DescribeVpcs | |
-| DeleteVpc | |
+| DescribeVpcs | [Explicit resource IDs](#explicit-resource-ids) |
+| DeleteVpc | [Explicit resource IDs](#explicit-resource-ids) |
 | CreateSubnet | |
-| DescribeSubnets | |
-| DeleteSubnet | |
+| DescribeSubnets | [Explicit resource IDs](#explicit-resource-ids) |
+| DeleteSubnet | [Explicit resource IDs](#explicit-resource-ids) |
 | CreateSecurityGroup | |
-| DescribeSecurityGroups | |
-| DeleteSecurityGroup | |
+| DescribeSecurityGroups | [Explicit resource IDs](#explicit-resource-ids) |
+| DeleteSecurityGroup | [Explicit resource IDs](#explicit-resource-ids) |
 | AuthorizeSecurityGroupIngress | |
 | AuthorizeSecurityGroupEgress | |
 | CreateInternetGateway | |
 | AttachInternetGateway | |
+| DescribeInternetGateways | [Explicit resource IDs](#explicit-resource-ids) |
+| DeleteInternetGateway | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeAvailabilityZones | |
 | DescribeRegions | |
 | CreateRouteTable | |
 | AssociateRouteTable | |
+| DescribeRouteTables | [Explicit resource IDs](#explicit-resource-ids) |
+| DeleteRouteTable | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids) |
+
+### Explicit resource IDs
+
+Naming a resource ID explicitly is an assertion that the ID exists, and EC2
+answers it with an error rather than an empty result. `DescribeVpcs()` with no
+arguments legitimately returns `[]`; `DescribeVpcs(VpcIds=["vpc-…"])` where that
+VPC is absent fails.
+
+- An ID that resolves to nothing → `Invalid<Type>.NotFound`, HTTP 400.
+- A syntactically invalid ID → `Invalid<Type>.Malformed`, HTTP 400. Syntax is
+  checked before existence, so a request naming both a malformed and an absent ID
+  reports `Malformed`.
+- One present plus one absent ID fails the whole call — EC2 does not return the
+  partial set.
+- An ID excluded by a `Filter` rather than by absence still counts as resolved:
+  an existing ID plus a non-matching filter returns 200 and an empty set.
+- No explicit IDs → every resource matches, and an empty account returns 200 and
+  an empty set.
+
+AWS's casing is inconsistent across these codes and SDK callers match the literal
+string, so substrate mirrors each pair exactly:
+
+| Resource | NotFound | Malformed |
+|----------|----------|-----------|
+| Instance | `InvalidInstanceID.NotFound` | `InvalidInstanceID.Malformed` |
+| VPC | `InvalidVpcID.NotFound` | `InvalidVpcID.Malformed` |
+| Subnet | `InvalidSubnetID.NotFound` | `InvalidSubnetID.Malformed` |
+| Security group | `InvalidGroup.NotFound` | `InvalidGroupId.Malformed` |
+| Internet gateway | `InvalidInternetGatewayID.NotFound` | `InvalidInternetGatewayId.Malformed` |
+| Route table | `InvalidRouteTableID.NotFound` | `InvalidRouteTableId.Malformed` |
+| Snapshot | `InvalidSnapshot.NotFound` | `InvalidSnapshotID.Malformed` |
+| Elastic IP allocation | `InvalidAllocationID.NotFound` | — |
+| NAT gateway | `InvalidNatGatewayID.NotFound` | — |
+
+EC2 publishes no `Malformed` variant for allocation IDs or NAT gateway IDs; a
+malformed ID for those surfaces as the `NotFound` code.
+
+An ID is well formed when it has the resource's prefix followed by at least one
+lowercase hex digit. Length is deliberately not checked: substrate's generators
+emit 16 hex characters where AWS emits 8 or 17, and AWS itself still accepts the
+legacy 8-character form for several resources.
 
 ### Betty CFN resource types
 

--- a/emulator/ec2_notfound_test.go
+++ b/emulator/ec2_notfound_test.go
@@ -1,0 +1,463 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ec2ErrorCode sends params and returns the HTTP status plus the Error/Code from
+// the EC2 query-protocol error document.
+func ec2ErrorCode(t *testing.T, ts *httptest.Server, params map[string]string) (int, string) {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var doc struct {
+		XMLName xml.Name `xml:"ErrorResponse"`
+		Error   struct {
+			Code    string `xml:"Code"`
+			Message string `xml:"Message"`
+		} `xml:"Error"`
+	}
+	if xml.Unmarshal(body, &doc) != nil {
+		return resp.StatusCode, ""
+	}
+	return resp.StatusCode, doc.Error.Code
+}
+
+// TestEC2_DescribeByExplicitID_NotFound covers #391: naming a resource ID
+// explicitly on a Describe* call asserts the ID exists, so a well-formed ID that
+// resolves to nothing must fail with the resource's Invalid*.NotFound code
+// rather than returning 200 with an empty set. A consumer's error branch is
+// otherwise unreachable and its test passes while verifying nothing.
+//
+// Codes and their inconsistent casing come from the EC2 error reference:
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
+func TestEC2_DescribeByExplicitID_NotFound(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		params map[string]string
+		code   string
+	}{
+		{
+			name:   "instances",
+			params: map[string]string{"Action": "DescribeInstances", "InstanceId.1": "i-0000000000000dead"},
+			code:   "InvalidInstanceID.NotFound",
+		},
+		{
+			name:   "instance status",
+			params: map[string]string{"Action": "DescribeInstanceStatus", "InstanceId.1": "i-0000000000000dead"},
+			code:   "InvalidInstanceID.NotFound",
+		},
+		{
+			name:   "vpcs",
+			params: map[string]string{"Action": "DescribeVpcs", "VpcId.1": "vpc-0000000000000dead"},
+			code:   "InvalidVpcID.NotFound",
+		},
+		{
+			name:   "subnets",
+			params: map[string]string{"Action": "DescribeSubnets", "SubnetId.1": "subnet-0000000000000dead"},
+			code:   "InvalidSubnetID.NotFound",
+		},
+		{
+			name:   "security groups",
+			params: map[string]string{"Action": "DescribeSecurityGroups", "GroupId.1": "sg-0000000000000dead"},
+			code:   "InvalidGroup.NotFound",
+		},
+		{
+			name:   "internet gateways",
+			params: map[string]string{"Action": "DescribeInternetGateways", "InternetGatewayId.1": "igw-0000000000000dead"},
+			code:   "InvalidInternetGatewayID.NotFound",
+		},
+		{
+			name:   "route tables",
+			params: map[string]string{"Action": "DescribeRouteTables", "RouteTableId.1": "rtb-0000000000000dead"},
+			code:   "InvalidRouteTableID.NotFound",
+		},
+		{
+			name:   "snapshots",
+			params: map[string]string{"Action": "DescribeSnapshots", "SnapshotId.1": "snap-0000000000000dead"},
+			code:   "InvalidSnapshot.NotFound",
+		},
+		{
+			name:   "addresses",
+			params: map[string]string{"Action": "DescribeAddresses", "AllocationId.1": "eipalloc-0000000000000dead"},
+			code:   "InvalidAllocationID.NotFound",
+		},
+		{
+			name:   "nat gateways",
+			params: map[string]string{"Action": "DescribeNatGateways", "NatGatewayId.1": "nat-0000000000000dead"},
+			code:   "InvalidNatGatewayID.NotFound",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			status, code := ec2ErrorCode(t, ts, tt.params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tt.code, code)
+		})
+	}
+}
+
+// TestEC2_DescribeByExplicitID_Malformed covers the second half of #391: a
+// syntactically invalid ID is rejected before any lookup, with the resource's
+// Malformed code. AWS spells several of these differently from the matching
+// NotFound code (InvalidGroupId.Malformed vs InvalidGroup.NotFound), and SDK
+// callers match the literal string, so each is asserted individually.
+func TestEC2_DescribeByExplicitID_Malformed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		params map[string]string
+		code   string
+	}{
+		{
+			name:   "instance wrong prefix",
+			params: map[string]string{"Action": "DescribeInstances", "InstanceId.1": "not-an-id"},
+			code:   "InvalidInstanceID.Malformed",
+		},
+		{
+			name:   "vpc wrong prefix",
+			params: map[string]string{"Action": "DescribeVpcs", "VpcId.1": "not-an-id"},
+			code:   "InvalidVpcID.Malformed",
+		},
+		{
+			name:   "vpc non-hex suffix",
+			params: map[string]string{"Action": "DescribeVpcs", "VpcId.1": "vpc-zzzz"},
+			code:   "InvalidVpcID.Malformed",
+		},
+		{
+			name:   "vpc empty suffix",
+			params: map[string]string{"Action": "DescribeVpcs", "VpcId.1": "vpc-"},
+			code:   "InvalidVpcID.Malformed",
+		},
+		{
+			name:   "subnet wrong prefix",
+			params: map[string]string{"Action": "DescribeSubnets", "SubnetId.1": "not-an-id"},
+			code:   "InvalidSubnetID.Malformed",
+		},
+		{
+			// AWS lowercases the "d" here but not in InvalidGroup.NotFound.
+			name:   "security group wrong prefix",
+			params: map[string]string{"Action": "DescribeSecurityGroups", "GroupId.1": "not-an-id"},
+			code:   "InvalidGroupId.Malformed",
+		},
+		{
+			name:   "internet gateway wrong prefix",
+			params: map[string]string{"Action": "DescribeInternetGateways", "InternetGatewayId.1": "not-an-id"},
+			code:   "InvalidInternetGatewayId.Malformed",
+		},
+		{
+			name:   "route table wrong prefix",
+			params: map[string]string{"Action": "DescribeRouteTables", "RouteTableId.1": "not-an-id"},
+			code:   "InvalidRouteTableId.Malformed",
+		},
+		{
+			name:   "snapshot wrong prefix",
+			params: map[string]string{"Action": "DescribeSnapshots", "SnapshotId.1": "not-an-id"},
+			code:   "InvalidSnapshotID.Malformed",
+		},
+		{
+			// EC2 publishes no InvalidAllocationID.Malformed, so a malformed
+			// allocation ID surfaces as NotFound.
+			name:   "allocation wrong prefix falls back to NotFound",
+			params: map[string]string{"Action": "DescribeAddresses", "AllocationId.1": "not-an-id"},
+			code:   "InvalidAllocationID.NotFound",
+		},
+		{
+			// Likewise for NAT gateways.
+			name:   "nat gateway wrong prefix falls back to NotFound",
+			params: map[string]string{"Action": "DescribeNatGateways", "NatGatewayId.1": "not-an-id"},
+			code:   "InvalidNatGatewayID.NotFound",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			status, code := ec2ErrorCode(t, ts, tt.params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tt.code, code)
+		})
+	}
+}
+
+// TestEC2_MalformedBeatsNotFound asserts syntax is checked before existence: a
+// request naming both a malformed and an absent ID reports Malformed, matching
+// EC2's ordering.
+func TestEC2_MalformedBeatsNotFound(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	status, code := ec2ErrorCode(t, ts, map[string]string{
+		"Action":   "DescribeVpcs",
+		"VpcId.1":  "vpc-0000000000000dead",
+		"VpcId.2":  "bogus",
+		"MaxItems": "10",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidVpcID.Malformed", code)
+}
+
+// TestEC2_DescribeWithNoIDs_ReturnsEmpty guards the "absent vs. filtered"
+// distinction #391 turns on: with no explicit ID, an empty account legitimately
+// describes to 200 and an empty set. Only an explicit ID is an existence
+// assertion.
+func TestEC2_DescribeWithNoIDs_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	for _, action := range []string{
+		"DescribeInstances", "DescribeInstanceStatus", "DescribeVpcs", "DescribeSubnets",
+		"DescribeSecurityGroups", "DescribeInternetGateways", "DescribeRouteTables",
+		"DescribeSnapshots", "DescribeAddresses", "DescribeNatGateways",
+	} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			resp := ec2Request(t, ts, map[string]string{"Action": action})
+			defer resp.Body.Close() //nolint:errcheck
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}
+
+// TestEC2_DescribeExistingID_Succeeds asserts the happy path still works: an ID
+// that was just created resolves, and mixing it with an absent ID fails the
+// whole call — EC2 does not return the partial set.
+func TestEC2_DescribeExistingID_Succeeds(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.0.0.0/16"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close() //nolint:errcheck
+	vpcID := ec2ExtractXML(string(body), "vpcId")
+	require.NotEmpty(t, vpcID)
+
+	// The created ID resolves.
+	ok := ec2Request(t, ts, map[string]string{"Action": "DescribeVpcs", "VpcId.1": vpcID})
+	defer ok.Body.Close() //nolint:errcheck
+	assert.Equal(t, http.StatusOK, ok.StatusCode)
+
+	// One present + one absent ID fails the whole call, naming the absent one.
+	status, code := ec2ErrorCode(t, ts, map[string]string{
+		"Action":  "DescribeVpcs",
+		"VpcId.1": vpcID,
+		"VpcId.2": "vpc-0000000000000dead",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidVpcID.NotFound", code)
+}
+
+// TestEC2_DescribeIDWithNonMatchingFilter_ReturnsEmpty asserts an ID excluded by
+// a filter rather than by absence still counts as resolved: EC2 answers an
+// existing ID plus a non-matching filter with an empty set, not NotFound.
+func TestEC2_DescribeIDWithNonMatchingFilter_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.0.0.0/16"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close() //nolint:errcheck
+	vpcID := ec2ExtractXML(string(body), "vpcId")
+	require.NotEmpty(t, vpcID)
+
+	rtb := ec2Request(t, ts, map[string]string{"Action": "CreateRouteTable", "VpcId": vpcID})
+	require.Equal(t, http.StatusOK, rtb.StatusCode)
+	rtbBody, err := io.ReadAll(rtb.Body)
+	require.NoError(t, err)
+	rtb.Body.Close() //nolint:errcheck
+	rtbID := ec2ExtractXML(string(rtbBody), "routeTableId")
+	require.NotEmpty(t, rtbID)
+
+	desc := ec2Request(t, ts, map[string]string{
+		"Action":           "DescribeRouteTables",
+		"RouteTableId.1":   rtbID,
+		"Filter.1.Name":    "vpc-id",
+		"Filter.1.Value.1": "vpc-0000000000000000",
+	})
+	defer desc.Body.Close() //nolint:errcheck
+	assert.Equal(t, http.StatusOK, desc.StatusCode)
+	descBody, err := io.ReadAll(desc.Body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(descBody), rtbID)
+}
+
+// TestEC2_MutateMissingID_NotFound covers the mutating counterparts: naming an
+// absent ID on a Terminate/Stop/Start or a Delete* is the same existence
+// assertion, and silently returning success hides a caller's mistake.
+func TestEC2_MutateMissingID_NotFound(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		params map[string]string
+		code   string
+	}{
+		{
+			name:   "terminate",
+			params: map[string]string{"Action": "TerminateInstances", "InstanceId.1": "i-0000000000000dead"},
+			code:   "InvalidInstanceID.NotFound",
+		},
+		{
+			name:   "stop",
+			params: map[string]string{"Action": "StopInstances", "InstanceId.1": "i-0000000000000dead"},
+			code:   "InvalidInstanceID.NotFound",
+		},
+		{
+			name:   "start",
+			params: map[string]string{"Action": "StartInstances", "InstanceId.1": "i-0000000000000dead"},
+			code:   "InvalidInstanceID.NotFound",
+		},
+		{
+			name:   "terminate malformed",
+			params: map[string]string{"Action": "TerminateInstances", "InstanceId.1": "bogus"},
+			code:   "InvalidInstanceID.Malformed",
+		},
+		{
+			name:   "delete vpc",
+			params: map[string]string{"Action": "DeleteVpc", "VpcId": "vpc-0000000000000dead"},
+			code:   "InvalidVpcID.NotFound",
+		},
+		{
+			name:   "delete subnet",
+			params: map[string]string{"Action": "DeleteSubnet", "SubnetId": "subnet-0000000000000dead"},
+			code:   "InvalidSubnetID.NotFound",
+		},
+		{
+			name:   "delete security group",
+			params: map[string]string{"Action": "DeleteSecurityGroup", "GroupId": "sg-0000000000000dead"},
+			code:   "InvalidGroup.NotFound",
+		},
+		{
+			name:   "delete internet gateway",
+			params: map[string]string{"Action": "DeleteInternetGateway", "InternetGatewayId": "igw-0000000000000dead"},
+			code:   "InvalidInternetGatewayID.NotFound",
+		},
+		{
+			name:   "delete route table",
+			params: map[string]string{"Action": "DeleteRouteTable", "RouteTableId": "rtb-0000000000000dead"},
+			code:   "InvalidRouteTableID.NotFound",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			status, code := ec2ErrorCode(t, ts, tt.params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tt.code, code)
+		})
+	}
+}
+
+// TestEC2_MutateWithoutID_MissingParameter asserts an omitted resource ID is
+// reported as MissingParameter rather than being read as an empty-string ID and
+// falling through to the Malformed path, which would name a parameter the caller
+// never sent.
+func TestEC2_MutateWithoutID_MissingParameter(t *testing.T) {
+	t.Parallel()
+	for _, action := range []string{
+		"DeleteSubnet", "DeleteSecurityGroup", "DeleteInternetGateway", "DeleteRouteTable",
+	} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			status, code := ec2ErrorCode(t, ts, map[string]string{"Action": action})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "MissingParameter", code)
+		})
+	}
+}
+
+// TestEC2_DuplicateRequestedID_Resolves asserts the same ID named twice resolves
+// once rather than leaving a second copy permanently unmatched, which would turn
+// a legitimate request into a spurious NotFound.
+func TestEC2_DuplicateRequestedID_Resolves(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.0.0.0/16"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close() //nolint:errcheck
+	vpcID := ec2ExtractXML(string(body), "vpcId")
+	require.NotEmpty(t, vpcID)
+
+	desc := ec2Request(t, ts, map[string]string{
+		"Action":  "DescribeVpcs",
+		"VpcId.1": vpcID,
+		"VpcId.2": vpcID,
+	})
+	defer desc.Body.Close() //nolint:errcheck
+	assert.Equal(t, http.StatusOK, desc.StatusCode)
+}
+
+// TestEC2_SubstrateMintedIDsAreWellFormed guards a self-inflicted regression:
+// substrate's generators emit 16 hex characters where AWS emits 8 or 17, so a
+// Malformed check that pinned the length would reject substrate's own IDs. Every
+// ID a create returns must describe back cleanly.
+func TestEC2_SubstrateMintedIDsAreWellFormed(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	create := func(params map[string]string, tag string) string {
+		t.Helper()
+		resp := ec2Request(t, ts, params)
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		id := ec2ExtractXML(string(body), tag)
+		require.NotEmpty(t, id, "no <%s> in %s response", tag, params["Action"])
+		return id
+	}
+
+	vpcID := create(map[string]string{"Action": "CreateVpc", "CidrBlock": "10.0.0.0/16"}, "vpcId")
+	subnetID := create(map[string]string{
+		"Action": "CreateSubnet", "VpcId": vpcID, "CidrBlock": "10.0.1.0/24",
+	}, "subnetId")
+	sgID := create(map[string]string{
+		"Action": "CreateSecurityGroup", "GroupName": "g", "GroupDescription": "d", "VpcId": vpcID,
+	}, "groupId")
+	igwID := create(map[string]string{"Action": "CreateInternetGateway"}, "internetGatewayId")
+	rtbID := create(map[string]string{"Action": "CreateRouteTable", "VpcId": vpcID}, "routeTableId")
+	instanceID := create(map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-12345678", "InstanceType": "t3.micro",
+		"MinCount": "1", "MaxCount": "1",
+	}, "instanceId")
+	allocID := create(map[string]string{"Action": "AllocateAddress", "Domain": "vpc"}, "allocationId")
+	natID := create(map[string]string{
+		"Action": "CreateNatGateway", "SubnetId": subnetID, "AllocationId": allocID,
+	}, "natGatewayId")
+
+	for _, tc := range []struct{ action, param, id string }{
+		{"DescribeVpcs", "VpcId.1", vpcID},
+		{"DescribeSubnets", "SubnetId.1", subnetID},
+		{"DescribeSecurityGroups", "GroupId.1", sgID},
+		{"DescribeInternetGateways", "InternetGatewayId.1", igwID},
+		{"DescribeRouteTables", "RouteTableId.1", rtbID},
+		{"DescribeInstances", "InstanceId.1", instanceID},
+		{"DescribeInstanceStatus", "InstanceId.1", instanceID},
+		{"DescribeAddresses", "AllocationId.1", allocID},
+		{"DescribeNatGateways", "NatGatewayId.1", natID},
+	} {
+		t.Run(tc.action, func(t *testing.T) {
+			resp := ec2Request(t, ts, map[string]string{"Action": tc.action, tc.param: tc.id})
+			defer resp.Body.Close() //nolint:errcheck
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "id %q rejected", tc.id)
+		})
+	}
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -580,7 +580,10 @@ func ec2InstanceMatchesFilter(inst EC2Instance, name string, values []string) bo
 }
 
 func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	ids := extractIndexedParams(req.Params, "InstanceId")
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "InstanceId"), ec2InstanceIDKind)
+	if err := ids.validate(); err != nil {
+		return nil, err
+	}
 	filters := extractEC2Filters(req.Params)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "instance:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
@@ -640,7 +643,7 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 			continue
 		}
 		// Filter by IDs.
-		if len(ids) > 0 && !containsStr(ids, inst.InstanceID) {
+		if !ids.match(inst.InstanceID) {
 			continue
 		}
 		// Apply all DescribeInstances filters, AND-combined.
@@ -686,6 +689,10 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		resMap[inst.ReservationID].Instances = append(resMap[inst.ReservationID].Instances, item)
 	}
 
+	if err := ids.unresolved(); err != nil {
+		return nil, err
+	}
+
 	for _, res := range resMap {
 		resp.Reservations = append(resp.Reservations, *res)
 	}
@@ -715,12 +722,15 @@ func (p *EC2Plugin) terminateInstances(reqCtx *RequestContext, req *AWSRequest) 
 	for _, id := range ids {
 		key := "instance:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + id
 		data, err := p.state.Get(context.Background(), ec2Namespace, key)
-		if err != nil || data == nil {
-			continue
+		if err != nil {
+			return nil, fmt.Errorf("ec2 terminateInstances get: %w", err)
+		}
+		if lookupErr := ec2RequireResource(ec2InstanceIDKind, id, data != nil); lookupErr != nil {
+			return nil, lookupErr
 		}
 		var inst EC2Instance
-		if json.Unmarshal(data, &inst) != nil {
-			continue
+		if err := json.Unmarshal(data, &inst); err != nil {
+			return nil, fmt.Errorf("ec2 terminateInstances unmarshal: %w", err)
 		}
 		prev := inst.State
 		inst.State = EC2InstanceState{Code: 48, Name: "terminated"}
@@ -760,12 +770,15 @@ func (p *EC2Plugin) stopInstances(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	for _, id := range ids {
 		key := "instance:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + id
 		data, err := p.state.Get(context.Background(), ec2Namespace, key)
-		if err != nil || data == nil {
-			continue
+		if err != nil {
+			return nil, fmt.Errorf("ec2 stopInstances get: %w", err)
+		}
+		if lookupErr := ec2RequireResource(ec2InstanceIDKind, id, data != nil); lookupErr != nil {
+			return nil, lookupErr
 		}
 		var inst EC2Instance
-		if json.Unmarshal(data, &inst) != nil {
-			continue
+		if err := json.Unmarshal(data, &inst); err != nil {
+			return nil, fmt.Errorf("ec2 stopInstances unmarshal: %w", err)
 		}
 		prev := inst.State
 		inst.State = EC2InstanceState{Code: 80, Name: "stopped"}
@@ -803,12 +816,15 @@ func (p *EC2Plugin) startInstances(reqCtx *RequestContext, req *AWSRequest) (*AW
 	for _, id := range ids {
 		key := "instance:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + id
 		data, err := p.state.Get(context.Background(), ec2Namespace, key)
-		if err != nil || data == nil {
-			continue
+		if err != nil {
+			return nil, fmt.Errorf("ec2 startInstances get: %w", err)
+		}
+		if lookupErr := ec2RequireResource(ec2InstanceIDKind, id, data != nil); lookupErr != nil {
+			return nil, lookupErr
 		}
 		var inst EC2Instance
-		if json.Unmarshal(data, &inst) != nil {
-			continue
+		if err := json.Unmarshal(data, &inst); err != nil {
+			return nil, fmt.Errorf("ec2 startInstances unmarshal: %w", err)
 		}
 		prev := inst.State
 		inst.State = EC2InstanceState{Code: 16, Name: "running"}
@@ -825,7 +841,10 @@ func (p *EC2Plugin) startInstances(reqCtx *RequestContext, req *AWSRequest) (*AW
 }
 
 func (p *EC2Plugin) describeInstanceStatus(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	ids := extractIndexedParams(req.Params, "InstanceId")
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "InstanceId"), ec2InstanceIDKind)
+	if err := ids.validate(); err != nil {
+		return nil, err
+	}
 	type statusItem struct {
 		InstanceID    string `xml:"instanceId"`
 		InstanceState struct {
@@ -853,13 +872,16 @@ func (p *EC2Plugin) describeInstanceStatus(reqCtx *RequestContext, req *AWSReque
 		if json.Unmarshal(data, &inst) != nil {
 			continue
 		}
-		if len(ids) > 0 && !containsStr(ids, inst.InstanceID) {
+		if !ids.match(inst.InstanceID) {
 			continue
 		}
 		si := statusItem{InstanceID: inst.InstanceID}
 		si.InstanceState.Code = inst.State.Code
 		si.InstanceState.Name = inst.State.Name
 		resp.Items = append(resp.Items, si)
+	}
+	if err := ids.unresolved(); err != nil {
+		return nil, err
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -915,7 +937,10 @@ func (p *EC2Plugin) createVPC(reqCtx *RequestContext, req *AWSRequest) (*AWSResp
 }
 
 func (p *EC2Plugin) describeVPCs(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	ids := extractIndexedParams(req.Params, "VpcId")
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "VpcId"), ec2VPCIDKind)
+	if err := ids.validate(); err != nil {
+		return nil, err
+	}
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "vpc:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeVpcs: %w", err)
@@ -941,10 +966,13 @@ func (p *EC2Plugin) describeVPCs(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		if json.Unmarshal(data, &vpc) != nil {
 			continue
 		}
-		if len(ids) > 0 && !containsStr(ids, vpc.VPCID) {
+		if !ids.match(vpc.VPCID) {
 			continue
 		}
 		resp.Vpcs = append(resp.Vpcs, vpcItem{VpcID: vpc.VPCID, CIDRBlock: vpc.CIDRBlock, IsDefault: vpc.IsDefault, State: vpc.State})
+	}
+	if err := ids.unresolved(); err != nil {
+		return nil, err
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -955,6 +983,13 @@ func (p *EC2Plugin) deleteVPC(reqCtx *RequestContext, req *AWSRequest) (*AWSResp
 		return nil, &AWSError{Code: "InvalidParameterValue", Message: "VpcId is required", HTTPStatus: http.StatusBadRequest}
 	}
 	key := "vpc:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + vpcID
+	existing, err := p.state.Get(context.Background(), ec2Namespace, key)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 deleteVpc get: %w", err)
+	}
+	if lookupErr := ec2RequireResource(ec2VPCIDKind, vpcID, existing != nil); lookupErr != nil {
+		return nil, lookupErr
+	}
 	if err := p.state.Delete(context.Background(), ec2Namespace, key); err != nil {
 		return nil, fmt.Errorf("ec2 deleteVpc: %w", err)
 	}
@@ -1013,7 +1048,10 @@ func (p *EC2Plugin) createSubnet(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 }
 
 func (p *EC2Plugin) describeSubnets(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	ids := extractIndexedParams(req.Params, "SubnetId")
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "SubnetId"), ec2SubnetIDKind)
+	if err := ids.validate(); err != nil {
+		return nil, err
+	}
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "subnet:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeSubnets: %w", err)
@@ -1041,7 +1079,7 @@ func (p *EC2Plugin) describeSubnets(reqCtx *RequestContext, req *AWSRequest) (*A
 		if json.Unmarshal(data, &subnet) != nil {
 			continue
 		}
-		if len(ids) > 0 && !containsStr(ids, subnet.SubnetID) {
+		if !ids.match(subnet.SubnetID) {
 			continue
 		}
 		resp.Subnets = append(resp.Subnets, subnetItem{
@@ -1053,13 +1091,28 @@ func (p *EC2Plugin) describeSubnets(reqCtx *RequestContext, req *AWSRequest) (*A
 			MapPublicIPOnLaunch: subnet.MapPublicIPOnLaunch,
 		})
 	}
+	if err := ids.unresolved(); err != nil {
+		return nil, err
+	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
 
 func (p *EC2Plugin) deleteSubnet(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	subnetID := req.Params["SubnetId"]
+	if subnetID == "" {
+		return nil, ec2MissingParameter("SubnetId")
+	}
 	key := "subnet:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + subnetID
-	_ = p.state.Delete(context.Background(), ec2Namespace, key)
+	existing, err := p.state.Get(context.Background(), ec2Namespace, key)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 deleteSubnet get: %w", err)
+	}
+	if lookupErr := ec2RequireResource(ec2SubnetIDKind, subnetID, existing != nil); lookupErr != nil {
+		return nil, lookupErr
+	}
+	if err := p.state.Delete(context.Background(), ec2Namespace, key); err != nil {
+		return nil, fmt.Errorf("ec2 deleteSubnet: %w", err)
+	}
 	type response struct {
 		XMLName xml.Name `xml:"DeleteSubnetResponse"`
 		XMLNS   string   `xml:"xmlns,attr"`
@@ -1103,7 +1156,10 @@ func (p *EC2Plugin) createSecurityGroup(reqCtx *RequestContext, req *AWSRequest)
 }
 
 func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	ids := extractIndexedParams(req.Params, "GroupId")
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "GroupId"), ec2SecurityGroupIDKind)
+	if err := ids.validate(); err != nil {
+		return nil, err
+	}
 	filters := extractEC2Filters(req.Params)
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "sg:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
@@ -1141,7 +1197,7 @@ func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSReque
 		if json.Unmarshal(data, &sg) != nil {
 			continue
 		}
-		if len(ids) > 0 && !containsStr(ids, sg.GroupID) {
+		if !ids.match(sg.GroupID) {
 			continue
 		}
 		if vals, ok := filters["group-name"]; ok && len(vals) > 0 && !containsStr(vals, sg.GroupName) {
@@ -1170,13 +1226,28 @@ func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSReque
 		}
 		resp.Groups = append(resp.Groups, item)
 	}
+	if err := ids.unresolved(); err != nil {
+		return nil, err
+	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
 
 func (p *EC2Plugin) deleteSecurityGroup(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	sgID := req.Params["GroupId"]
+	if sgID == "" {
+		return nil, ec2MissingParameter("GroupId")
+	}
 	key := "sg:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + sgID
-	_ = p.state.Delete(context.Background(), ec2Namespace, key)
+	existing, err := p.state.Get(context.Background(), ec2Namespace, key)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 deleteSecurityGroup get: %w", err)
+	}
+	if lookupErr := ec2RequireResource(ec2SecurityGroupIDKind, sgID, existing != nil); lookupErr != nil {
+		return nil, lookupErr
+	}
+	if err := p.state.Delete(context.Background(), ec2Namespace, key); err != nil {
+		return nil, fmt.Errorf("ec2 deleteSecurityGroup: %w", err)
+	}
 	type response struct {
 		XMLName xml.Name `xml:"DeleteSecurityGroupResponse"`
 		XMLNS   string   `xml:"xmlns,attr"`
@@ -1304,7 +1375,10 @@ func (p *EC2Plugin) createInternetGateway(reqCtx *RequestContext, _ *AWSRequest)
 }
 
 func (p *EC2Plugin) describeInternetGateways(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	ids := extractIndexedParams(req.Params, "InternetGatewayId")
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "InternetGatewayId"), ec2InternetGatewayIDKind)
+	if err := ids.validate(); err != nil {
+		return nil, err
+	}
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "igw:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeInternetGateways: %w", err)
@@ -1327,10 +1401,13 @@ func (p *EC2Plugin) describeInternetGateways(reqCtx *RequestContext, req *AWSReq
 		if json.Unmarshal(data, &igw) != nil {
 			continue
 		}
-		if len(ids) > 0 && !containsStr(ids, igw.InternetGatewayID) {
+		if !ids.match(igw.InternetGatewayID) {
 			continue
 		}
 		resp.IGWs = append(resp.IGWs, igwItem{igw.InternetGatewayID})
+	}
+	if err := ids.unresolved(); err != nil {
+		return nil, err
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -1389,8 +1466,20 @@ func (p *EC2Plugin) detachInternetGateway(reqCtx *RequestContext, req *AWSReques
 
 func (p *EC2Plugin) deleteInternetGateway(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	igwID := req.Params["InternetGatewayId"]
+	if igwID == "" {
+		return nil, ec2MissingParameter("InternetGatewayId")
+	}
 	key := "igw:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + igwID
-	_ = p.state.Delete(context.Background(), ec2Namespace, key)
+	existing, err := p.state.Get(context.Background(), ec2Namespace, key)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 deleteInternetGateway get: %w", err)
+	}
+	if lookupErr := ec2RequireResource(ec2InternetGatewayIDKind, igwID, existing != nil); lookupErr != nil {
+		return nil, lookupErr
+	}
+	if err := p.state.Delete(context.Background(), ec2Namespace, key); err != nil {
+		return nil, fmt.Errorf("ec2 deleteInternetGateway: %w", err)
+	}
 	type response struct {
 		XMLName xml.Name `xml:"DeleteInternetGatewayResponse"`
 		XMLNS   string   `xml:"xmlns,attr"`
@@ -1459,7 +1548,10 @@ func routeTableHasSubnet(rtb EC2RouteTable, subnetIDs []string) bool {
 }
 
 func (p *EC2Plugin) describeRouteTables(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	ids := extractIndexedParams(req.Params, "RouteTableId")
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "RouteTableId"), ec2RouteTableIDKind)
+	if err := ids.validate(); err != nil {
+		return nil, err
+	}
 	filters := extractEC2Filters(req.Params)
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "rtb:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
@@ -1496,7 +1588,7 @@ func (p *EC2Plugin) describeRouteTables(reqCtx *RequestContext, req *AWSRequest)
 		if json.Unmarshal(data, &rtb) != nil {
 			continue
 		}
-		if len(ids) > 0 && !containsStr(ids, rtb.RouteTableID) {
+		if !ids.match(rtb.RouteTableID) {
 			continue
 		}
 		if vals, ok := filters["vpc-id"]; ok && !containsStr(vals, rtb.VPCID) {
@@ -1516,6 +1608,9 @@ func (p *EC2Plugin) describeRouteTables(reqCtx *RequestContext, req *AWSRequest)
 			item.Associations = append(item.Associations, assocItem{AssociationID: a.AssociationID, SubnetID: a.SubnetID, Main: a.Main}) //nolint:staticcheck // XML tags differ from JSON tags.
 		}
 		resp.RouteTables = append(resp.RouteTables, item)
+	}
+	if err := ids.unresolved(); err != nil {
+		return nil, err
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -1761,8 +1856,20 @@ func (p *EC2Plugin) deleteRoute(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 
 func (p *EC2Plugin) deleteRouteTable(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	rtbID := req.Params["RouteTableId"]
+	if rtbID == "" {
+		return nil, ec2MissingParameter("RouteTableId")
+	}
 	key := "rtb:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + rtbID
-	_ = p.state.Delete(context.Background(), ec2Namespace, key)
+	existing, err := p.state.Get(context.Background(), ec2Namespace, key)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 deleteRouteTable get: %w", err)
+	}
+	if lookupErr := ec2RequireResource(ec2RouteTableIDKind, rtbID, existing != nil); lookupErr != nil {
+		return nil, lookupErr
+	}
+	if err := p.state.Delete(context.Background(), ec2Namespace, key); err != nil {
+		return nil, fmt.Errorf("ec2 deleteRouteTable: %w", err)
+	}
 	type response struct {
 		XMLName xml.Name `xml:"DeleteRouteTableResponse"`
 		XMLNS   string   `xml:"xmlns,attr"`
@@ -3116,7 +3223,10 @@ func (p *EC2Plugin) releaseAddress(reqCtx *RequestContext, req *AWSRequest) (*AW
 }
 
 func (p *EC2Plugin) describeAddresses(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	filterIDs := extractIndexedParams(req.Params, "AllocationId")
+	filterIDs := newEC2IDFilter(extractIndexedParams(req.Params, "AllocationId"), ec2AllocationIDKind)
+	if err := filterIDs.validate(); err != nil {
+		return nil, err
+	}
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "eip:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeAddresses list: %w", err)
@@ -3145,7 +3255,7 @@ func (p *EC2Plugin) describeAddresses(reqCtx *RequestContext, req *AWSRequest) (
 		if json.Unmarshal(data, &eip) != nil {
 			continue
 		}
-		if len(filterIDs) > 0 && !containsStr(filterIDs, eip.AllocationID) {
+		if !filterIDs.match(eip.AllocationID) {
 			continue
 		}
 		resp.Addresses = append(resp.Addresses, addressItem{
@@ -3157,6 +3267,9 @@ func (p *EC2Plugin) describeAddresses(reqCtx *RequestContext, req *AWSRequest) (
 			PrivateIPAddress:   eip.PrivateIPAddress,
 			Domain:             eip.Domain,
 		})
+	}
+	if err := filterIDs.unresolved(); err != nil {
+		return nil, err
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -3287,7 +3400,10 @@ func (p *EC2Plugin) createNatGateway(reqCtx *RequestContext, req *AWSRequest) (*
 }
 
 func (p *EC2Plugin) describeNatGateways(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	filterIDs := extractIndexedParams(req.Params, "NatGatewayId")
+	filterIDs := newEC2IDFilter(extractIndexedParams(req.Params, "NatGatewayId"), ec2NatGatewayIDKind)
+	if err := filterIDs.validate(); err != nil {
+		return nil, err
+	}
 	filters := extractEC2Filters(req.Params)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "nat:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
@@ -3324,7 +3440,7 @@ func (p *EC2Plugin) describeNatGateways(reqCtx *RequestContext, req *AWSRequest)
 		if json.Unmarshal(data, &gw) != nil {
 			continue
 		}
-		if len(filterIDs) > 0 && !containsStr(filterIDs, gw.NatGatewayID) {
+		if !filterIDs.match(gw.NatGatewayID) {
 			continue
 		}
 		// Apply filters.
@@ -3347,6 +3463,9 @@ func (p *EC2Plugin) describeNatGateways(reqCtx *RequestContext, req *AWSRequest)
 				PrivateIP:    gw.PrivateIP,
 			}},
 		})
+	}
+	if err := filterIDs.unresolved(); err != nil {
+		return nil, err
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -4251,7 +4370,10 @@ func (p *EC2Plugin) deleteSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AW
 // describeSnapshots lists EBS snapshots owned by the account, honoring an
 // optional list of SnapshotId.N parameters and the snapshot-id Filter.
 func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	ids := extractIndexedParams(req.Params, "SnapshotId")
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "SnapshotId"), ec2SnapshotIDKind)
+	if err := ids.validate(); err != nil {
+		return nil, err
+	}
 	filters := extractEC2Filters(req.Params)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace,
@@ -4291,7 +4413,7 @@ func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (
 		if json.Unmarshal(data, &snap) != nil {
 			continue
 		}
-		if len(ids) > 0 && !containsStr(ids, snap.SnapshotID) {
+		if !ids.match(snap.SnapshotID) {
 			continue
 		}
 		if vals, ok := filters["snapshot-id"]; ok && !containsStr(vals, snap.SnapshotID) {
@@ -4311,6 +4433,9 @@ func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (
 			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck
 		}
 		resp.Snapshots = append(resp.Snapshots, item)
+	}
+	if err := ids.unresolved(); err != nil {
+		return nil, err
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }

--- a/emulator/ec2_resourceid.go
+++ b/emulator/ec2_resourceid.go
@@ -1,0 +1,218 @@
+package emulator
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ec2IDKind describes one EC2 resource-ID family: its wire prefix and the two
+// error codes real EC2 raises when a caller names an ID explicitly and the ID is
+// either syntactically wrong or absent (#391).
+//
+// AWS's casing is inconsistent across these codes — `InvalidVpcID.NotFound` but
+// `InvalidGroupId.Malformed`, `InvalidSnapshot.NotFound` but
+// `InvalidSnapshotID.Malformed` — and SDK callers match on the literal string,
+// so each pair is spelled out verbatim from the EC2 error reference rather than
+// derived from a template.
+type ec2IDKind struct {
+	// Prefix is the ID's literal wire prefix, including the hyphen ("vpc-").
+	Prefix string
+	// NotFound is the error code for a well-formed ID that names nothing.
+	NotFound string
+	// Malformed is the error code for a syntactically invalid ID. It is empty
+	// for the resources where EC2 publishes no Malformed variant, in which case
+	// a malformed ID is reported as NotFound.
+	Malformed string
+	// Noun names the resource in an error message ("VPC", "subnet").
+	Noun string
+}
+
+// EC2 resource-ID kinds, with error codes taken verbatim from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html.
+var (
+	ec2InstanceIDKind = ec2IDKind{
+		Prefix: "i-", NotFound: "InvalidInstanceID.NotFound",
+		Malformed: "InvalidInstanceID.Malformed", Noun: "instance",
+	}
+	ec2VPCIDKind = ec2IDKind{
+		Prefix: "vpc-", NotFound: "InvalidVpcID.NotFound",
+		Malformed: "InvalidVpcID.Malformed", Noun: "VPC",
+	}
+	ec2SubnetIDKind = ec2IDKind{
+		Prefix: "subnet-", NotFound: "InvalidSubnetID.NotFound",
+		Malformed: "InvalidSubnetID.Malformed", Noun: "subnet",
+	}
+	ec2SecurityGroupIDKind = ec2IDKind{
+		Prefix: "sg-", NotFound: "InvalidGroup.NotFound",
+		Malformed: "InvalidGroupId.Malformed", Noun: "security group",
+	}
+	ec2InternetGatewayIDKind = ec2IDKind{
+		Prefix: "igw-", NotFound: "InvalidInternetGatewayID.NotFound",
+		Malformed: "InvalidInternetGatewayId.Malformed", Noun: "internet gateway",
+	}
+	ec2RouteTableIDKind = ec2IDKind{
+		Prefix: "rtb-", NotFound: "InvalidRouteTableID.NotFound",
+		Malformed: "InvalidRouteTableId.Malformed", Noun: "route table",
+	}
+	ec2SnapshotIDKind = ec2IDKind{
+		Prefix: "snap-", NotFound: "InvalidSnapshot.NotFound",
+		Malformed: "InvalidSnapshotID.Malformed", Noun: "snapshot",
+	}
+	// EC2 publishes no InvalidAllocationID.Malformed; a malformed allocation ID
+	// comes back as InvalidAllocationID.NotFound.
+	ec2AllocationIDKind = ec2IDKind{
+		Prefix: "eipalloc-", NotFound: "InvalidAllocationID.NotFound", Noun: "allocation ID",
+	}
+	// Likewise EC2 publishes no InvalidNatGatewayID.Malformed.
+	ec2NatGatewayIDKind = ec2IDKind{
+		Prefix: "nat-", NotFound: "InvalidNatGatewayID.NotFound", Noun: "NAT gateway",
+	}
+)
+
+// wellFormed reports whether id has the kind's prefix followed by a non-empty
+// run of lowercase hex digits.
+//
+// Substrate's generators emit 16 hex characters where AWS emits 8 or 17, so the
+// length is deliberately not checked: a substrate-minted ID must stay valid, and
+// AWS itself accepts both the legacy 8-character and the current 17-character
+// form for several resources.
+func (k ec2IDKind) wellFormed(id string) bool {
+	suffix, ok := strings.CutPrefix(id, k.Prefix)
+	if !ok || suffix == "" {
+		return false
+	}
+	for i := 0; i < len(suffix); i++ {
+		c := suffix[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// malformedError returns the AWSError for a syntactically invalid id, falling
+// back to the NotFound code for kinds with no published Malformed variant.
+func (k ec2IDKind) malformedError(id string) *AWSError {
+	if k.Malformed == "" {
+		return k.notFoundError(id)
+	}
+	return &AWSError{
+		Code:       k.Malformed,
+		Message:    "Invalid id: \"" + id + "\"",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// notFoundError returns the AWSError for a well-formed id that names nothing.
+func (k ec2IDKind) notFoundError(id string) *AWSError {
+	return &AWSError{
+		Code:       k.NotFound,
+		Message:    "The " + k.Noun + " ID '" + id + "' does not exist",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2IDFilter decides which stored resources a Describe* call should return when
+// the caller named IDs explicitly, and reports the ones that did not resolve.
+//
+// Real EC2 treats an explicit ID list as an assertion that every ID exists: a
+// missing one fails the whole call with Invalid*.NotFound rather than being
+// silently dropped from the result set (#391). An empty list means "describe
+// everything" and matches unconditionally.
+//
+// Usage inside a Describe* loop:
+//
+//	ids := newEC2IDFilter(extractIndexedParams(req.Params, "VpcId"), ec2VPCIDKind)
+//	if err := ids.validate(); err != nil {
+//	    return nil, err
+//	}
+//	... for each stored vpc: if !ids.match(vpc.VPCID) { continue }
+//	if err := ids.unresolved(); err != nil {
+//	    return nil, err
+//	}
+type ec2IDFilter struct {
+	kind ec2IDKind
+	// want holds each requested ID mapped to whether it has been matched.
+	want map[string]bool
+	// order preserves request order so the reported ID is deterministic.
+	order []string
+}
+
+// newEC2IDFilter builds a filter over the IDs a request named explicitly.
+func newEC2IDFilter(ids []string, kind ec2IDKind) *ec2IDFilter {
+	f := &ec2IDFilter{kind: kind, want: make(map[string]bool, len(ids))}
+	for _, id := range ids {
+		if _, seen := f.want[id]; seen {
+			continue
+		}
+		f.want[id] = false
+		f.order = append(f.order, id)
+	}
+	return f
+}
+
+// validate rejects any syntactically invalid requested ID with the kind's
+// Malformed code. It must be called before the describe loop, because real EC2
+// validates ID syntax before it looks anything up.
+func (f *ec2IDFilter) validate() error {
+	for _, id := range f.order {
+		if !f.kind.wellFormed(id) {
+			return f.kind.malformedError(id)
+		}
+	}
+	return nil
+}
+
+// match reports whether id belongs in the response, recording that it resolved.
+// With no explicit IDs requested, every resource matches.
+func (f *ec2IDFilter) match(id string) bool {
+	if len(f.want) == 0 {
+		return true
+	}
+	if _, ok := f.want[id]; !ok {
+		return false
+	}
+	f.want[id] = true
+	return true
+}
+
+// unresolved returns the kind's NotFound error for the first requested ID that
+// match never saw, or nil if every requested ID resolved. Call it after the
+// describe loop.
+//
+// A resource that a filter (rather than the ID list) excluded still counts as
+// resolved, matching EC2: a Describe* with both an ID and a non-matching filter
+// returns an empty set, not NotFound.
+func (f *ec2IDFilter) unresolved() error {
+	for _, id := range f.order {
+		if !f.want[id] {
+			return f.kind.notFoundError(id)
+		}
+	}
+	return nil
+}
+
+// ec2RequireResource returns the kind's Malformed or NotFound error for an ID a
+// mutating operation named that substrate holds no state for. found reports
+// whether the lookup succeeded.
+func ec2RequireResource(kind ec2IDKind, id string, found bool) error {
+	switch {
+	case !kind.wellFormed(id):
+		return kind.malformedError(id)
+	case !found:
+		return kind.notFoundError(id)
+	default:
+		return nil
+	}
+}
+
+// ec2MissingParameter returns the error EC2 raises for a required-but-absent
+// request parameter.
+func ec2MissingParameter(name string) error {
+	return &AWSError{
+		Code:       "MissingParameter",
+		Message:    fmt.Sprintf("The request must contain the parameter %s", name),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}


### PR DESCRIPTION
Closes #391

## The defect

Naming a resource ID explicitly on a `Describe*` call is an assertion that the ID
exists, and EC2 answers it with an error when it does not. Substrate instead
filtered the ID out and returned `200` with an empty set:

```go
if len(ids) > 0 && !containsStr(ids, vpc.VpcID) {
    continue
}
```

So a consumer's `InvalidVpcID.NotFound` branch was unreachable and its test
passed while verifying nothing — the failure mode `CLAUDE.md` calls out as worse
than an incomplete emulator. The mutating counterparts were worse still:
`TerminateInstances` swallowed the lookup and `DeleteVpc` ran `_ = p.state.Delete(...)`,
both reporting success for IDs that were never there.

This is *not* about empty results in general. `DescribeVpcs()` with no arguments
legitimately returns an empty set — that distinction ("absent vs. filtered") is
pinned by `TestEC2_DescribeWithNoIDs_ReturnsEmpty`.

## What changed

New `emulator/ec2_resourceid.go` holds the mechanism: an `ec2IDKind` per resource
carrying its wire prefix and its two error codes, plus an `ec2IDFilter` with a
`newEC2IDFilter` → `validate()` → `match()` → `unresolved()` contract, and
`ec2RequireResource` for single-ID mutators.

Ten describes now use it — `DescribeInstances`, `DescribeInstanceStatus`,
`DescribeVpcs`, `DescribeSubnets`, `DescribeSecurityGroups`,
`DescribeInternetGateways`, `DescribeRouteTables`, `DescribeSnapshots`,
`DescribeAddresses`, `DescribeNatGateways` — as do eight mutators
(`Terminate`/`Stop`/`StartInstances`, `DeleteVpc`/`Subnet`/`SecurityGroup`/`InternetGateway`/`RouteTable`).
The five deletes are now Get-then-check-then-Delete, with the `Delete` error
wrapped rather than discarded.

## Error codes

Every code is mirrored verbatim from the [EC2 error reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html)
rather than from memory, because SDK callers match the literal string and AWS is
inconsistent about casing:

| Resource | NotFound | Malformed |
|---|---|---|
| `i-` | `InvalidInstanceID.NotFound` | `InvalidInstanceID.Malformed` |
| `vpc-` | `InvalidVpcID.NotFound` | `InvalidVpcID.Malformed` |
| `subnet-` | `InvalidSubnetID.NotFound` | `InvalidSubnetID.Malformed` |
| `sg-` | `InvalidGroup.NotFound` | `InvalidGroupId.Malformed` |
| `igw-` | `InvalidInternetGatewayID.NotFound` | `InvalidInternetGatewayId.Malformed` |
| `rtb-` | `InvalidRouteTableID.NotFound` | `InvalidRouteTableId.Malformed` |
| `snap-` | `InvalidSnapshot.NotFound` | `InvalidSnapshotID.Malformed` |
| `eipalloc-` | `InvalidAllocationID.NotFound` | *(none published)* |
| `nat-` | `InvalidNatGatewayID.NotFound` | *(none published)* |

`eipalloc-` and `nat-` have no published `Malformed` variant, so a malformed ID
of those kinds falls back to `NotFound`.

## Three orderings, each pinned by a test

- **Malformed precedes NotFound.** Syntax is validated before any lookup, matching EC2 (`TestEC2_MalformedBeatsNotFound`).
- **An omitted ID is `MissingParameter`**, not an empty-string `Malformed` that would name a parameter the caller never sent (`TestEC2_MutateWithoutID_MissingParameter`).
- **An ID excluded by a filter still counts as resolved** — `200` with an empty set, not `NotFound` (`TestEC2_DescribeIDWithNonMatchingFilter_ReturnsEmpty`).

Also deliberate: one present + one absent ID fails the whole call, since EC2 does
not return the partial set.

## The length trap

The `Malformed` check validates prefix and hex-ness but **not** length.
Substrate's generators emit 16 hex characters (`randomHex(8)`) where AWS emits 8
or 17, so a length check would have rejected substrate's own minted IDs.
`TestEC2_SubstrateMintedIDsAreWellFormed` creates a VPC, subnet, SG, IGW, route
table, instance, EIP and NAT gateway, then describes each by the ID its create
returned — a standing guard against that regression.

## Out of scope

`DescribeVolumes` (`InvalidVolume.NotFound`), `DescribeImages` (`InvalidAMIID.*`),
`DescribeLaunchTemplates` and `DescribeKeyPairs` want the same treatment but are
different code families; worth a follow-up issue. `DeleteSnapshot` is left as-is —
its comment documents idempotent delete-on-missing as intentional and an existing
test asserts it.

## Verification

`emulator/ec2_notfound_test.go` adds 9 table-driven tests (all `t.Parallel()`),
reusing the existing `newEC2TestServer`/`ec2Request` harness.

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `make test` (race) — pass
- `test/e2e` — pass
- `make docs-reference-check` — pass
- `make scan-fs` (Trivy) — clean
- Coverage on `ec2_resourceid.go` — 100% on all 9 functions

`docs/services.md` gains an **Explicit resource IDs** section documenting the six
semantics and the full code table, and links it from 17 operation rows.