### PR TITLE
fix(errors): serialize errors in each service's wire protocol (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InvalidPart` would send a consumer hunting a data bug that does not exist.
 
 ### Fixed
+- Error responses are serialized in the wire format the target service's protocol
+  actually uses, so an SDK can recover the error code (#392). Reported as four
+  per-service typos; three were one defect in the server's shared error writer.
+  Substrate emitted a `Code` member for every JSON service, but botocore's JSON-RPC
+  parser reads `__type` and falls back to the *stringified HTTP status* — it never
+  reads `Code`. So SSM's already-correct `ParameterNotFound` was discarded and the
+  caller saw `Error.Code == "404"`, silently defeating every
+  `except ClientError` branch that compares against a symbolic code. This affected
+  all ~30 JSON-RPC services, not just the one reported.
+  Lambda was a second, worse case: it is REST-JSON but sends
+  `Content-Type: application/json`, which failed the `application/x-amz-json`
+  prefix test, so its errors went out as *XML* — a shape its SDK cannot parse at
+  all. The protocol is now selected by service name, since it cannot be sniffed
+  from the request: IAM sends `x-amz-json-1.1` inbound yet answers errors in XML,
+  and Lambda's inbound `application/json` is indistinguishable from a plain JSON
+  body. JSON-RPC errors carry `__type`, REST-JSON errors carry the
+  `x-amzn-errortype` header, and query/REST-XML services keep their
+  `<ErrorResponse><Error><Code>` document; each service's classification is taken
+  from the `protocol` field of its model in botocore, the same value that selects
+  the SDK's parser.
+- IAM error codes now use their documented wire spelling, which drops the
+  `Exception` suffix the API model's shape names carry (#392): `NoSuchEntity`,
+  `EntityAlreadyExists`, `MalformedPolicyDocument`, `DeleteConflict` and
+  `LimitExceeded`. A caller matching the documented `NoSuchEntity` never matched.
+  The suffix is not a blanket rule — `ValidationError` and `AccessDeniedException`
+  were already correct and are unchanged, and Lambda genuinely does use
+  `ResourceNotFoundException` on the wire, so neither service's spelling can be
+  inferred from the other.
+- S3 `GetObject` and `HeadObject` report `NoSuchBucket` when the bucket does not
+  exist, rather than `NoSuchKey` (#392). Both went straight to the object lookup,
+  which conflated two distinct conditions: a caller could not tell "someone
+  deleted my bucket" from "this object isn't written yet", and so could not tell a
+  fatal misconfiguration from an ordinary cache miss.
+- The service reference listed ACM's protocol as Query and RAM's as JSON; both
+  were wrong in the opposite direction (ACM is JSON-RPC, RAM is REST-JSON).
 - S3 multipart operations now return S3's documented `NoSuchUpload` and
   `MalformedXML` message text rather than abbreviated paraphrases (#400).
 - S3 `HeadObject` now reports `x-amz-version-id` (#396). `GetObject` always did,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   were already correct and are unchanged, and Lambda genuinely does use
   `ResourceNotFoundException` on the wire, so neither service's spelling can be
   inferred from the other.
+  All 25 renamed branches are now asserted by name, across tagging, inline
+  policies, permissions boundaries and instance profiles. Only three had a test
+  before, and a rename with no test asserting the new string is the same silent
+  failure this fix addresses: the response still looks like an error, so a test
+  that checks only the status stays green while the SDK's typed exception never
+  fires.
+  A state-store failure during S3's bucket lookup is also asserted to surface as
+  a server error rather than as `NoSuchBucket`. The two are opposite signals —
+  `NoSuchBucket` tells a caller to stop retrying, a store failure is transient —
+  so collapsing one into the other would send a consumer down a
+  permanent-failure path over a blip.
 - S3 `GetObject` and `HeadObject` report `NoSuchBucket` when the bucket does not
   exist, rather than `NoSuchKey` (#392). Both went straight to the object lookup,
   which conflated two distinct conditions: a caller could not tell "someone

--- a/cmd/gen-service-reference/main.go
+++ b/cmd/gen-service-reference/main.go
@@ -50,7 +50,7 @@ type pluginMeta struct {
 // meta maps each registered plugin name to its documentation metadata. Adding a
 // plugin to the registry without a matching entry here fails generation (and CI).
 var meta = map[string]pluginMeta{
-	"acm":                  {"ACM", "Query"},
+	"acm":                  {"ACM", "JSON"},
 	"apigateway":           {"API Gateway (REST)", "REST/JSON"},
 	"apigatewayv2":         {"API Gateway (HTTP)", "REST/JSON"},
 	"appsync":              {"AppSync", "REST/JSON"},
@@ -92,7 +92,7 @@ var meta = map[string]pluginMeta{
 	"opensearch":           {"OpenSearch", "REST/JSON"},
 	"organizations":        {"Organizations", "JSON"},
 	"quicksight":           {"QuickSight", "REST/JSON"},
-	"ram":                  {"RAM", "JSON"},
+	"ram":                  {"RAM", "REST/JSON"},
 	"rds":                  {"RDS", "Query"},
 	"redshift":             {"Redshift", "Query"},
 	"redshift-data":        {"Redshift Data API", "JSON"},

--- a/docs/services.md
+++ b/docs/services.md
@@ -11,7 +11,7 @@ CloudFormation, and cost detail follows below the matrix.
 
 | # | Service | Plugin name | Protocol |
 |---|---------|-------------|----------|
-| 1 | ACM | `acm` | Query |
+| 1 | ACM | `acm` | JSON |
 | 2 | API Gateway (REST) | `apigateway` | REST/JSON |
 | 3 | API Gateway (HTTP) | `apigatewayv2` | REST/JSON |
 | 4 | AppSync | `appsync` | REST/JSON |
@@ -53,7 +53,7 @@ CloudFormation, and cost detail follows below the matrix.
 | 40 | OpenSearch | `opensearch` | REST/JSON |
 | 41 | Organizations | `organizations` | JSON |
 | 42 | QuickSight | `quicksight` | REST/JSON |
-| 43 | RAM | `ram` | JSON |
+| 43 | RAM | `ram` | REST/JSON |
 | 44 | RDS | `rds` | Query |
 | 45 | Redshift | `redshift` | Query |
 | 46 | Redshift Data API | `redshift-data` | JSON |

--- a/emulator/error_protocol.go
+++ b/emulator/error_protocol.go
@@ -1,0 +1,200 @@
+package emulator
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+)
+
+// awsErrorProtocol identifies how a service serializes an error response on the
+// wire. AWS SDKs parse errors per-protocol, and each protocol carries the error
+// code in a different place, so an emulator that picks the wrong one hands the
+// caller an error it cannot match on. See #392.
+type awsErrorProtocol int
+
+const (
+	// errProtoQueryXML is the AWS Query and REST-XML protocols. The code lives in
+	// an <ErrorResponse><Error><Code> document.
+	errProtoQueryXML awsErrorProtocol = iota
+
+	// errProtoJSONRPC is the AWS JSON 1.0/1.1 RPC protocol. The code lives in the
+	// body's "__type" member — botocore's BaseJSONParser reads "__type" and falls
+	// back to the stringified HTTP status, never to "Code".
+	errProtoJSONRPC
+
+	// errProtoRESTJSON is the REST-JSON protocol. The code lives in the
+	// x-amzn-errortype response header, which botocore's RestJSONParser prefers
+	// over the body.
+	errProtoRESTJSON
+)
+
+// serviceErrorProtocols maps a service name (as reported by Plugin.Name) to the
+// protocol its real AWS counterpart uses for errors. Services absent from this
+// map fall back to the request's Content-Type; see errorProtocolFor.
+//
+// The classification follows each service's protocol trait, not its request
+// Content-Type: REST-JSON services send "application/json" on the way in, which
+// is indistinguishable from a plain JSON body, so the incoming header alone
+// cannot decide this. Every entry below is the "protocol" field of the service's
+// model in botocore/data/<service>/<version>/service-2.json, which is the same
+// value that selects the SDK's error parser. Two classes read as one here:
+//
+//   - errProtoQueryXML covers the query, ec2 and rest-xml protocols. Their
+//     on-the-wire error documents differ in the root element (ErrorResponse,
+//     Response/Errors and Error respectively), but every one of their parsers
+//     recovers the code from an <ErrorResponse><Error><Code> document, so a
+//     single shape serves all three. Plugins that need a byte-exact document
+//     build it themselves (see s3ErrorResponse).
+//   - "monitoring" (CloudWatch) models as smithy-rpc-v2-cbor today, but query
+//     remains in its supported protocol list and substrate's CloudWatch plugin
+//     answers successes in query XML, so its errors match that.
+var serviceErrorProtocols = map[string]awsErrorProtocol{
+	// Query, ec2 and REST-XML.
+	"cloudfront":           errProtoQueryXML,
+	"ec2":                  errProtoQueryXML,
+	"elasticache":          errProtoQueryXML,
+	"elasticloadbalancing": errProtoQueryXML,
+	"iam":                  errProtoQueryXML,
+	"monitoring":           errProtoQueryXML,
+	"rds":                  errProtoQueryXML,
+	"redshift":             errProtoQueryXML,
+	"route53":              errProtoQueryXML,
+	"s3":                   errProtoQueryXML,
+	"sns":                  errProtoQueryXML,
+	"sts":                  errProtoQueryXML,
+
+	// JSON RPC (x-amz-json-1.0 / 1.1).
+	"acm":              errProtoJSONRPC,
+	"athena":           errProtoJSONRPC,
+	"budgets":          errProtoJSONRPC,
+	"ce":               errProtoJSONRPC,
+	"cloudtrail":       errProtoJSONRPC,
+	"codebuild":        errProtoJSONRPC,
+	"codedeploy":       errProtoJSONRPC,
+	"codepipeline":     errProtoJSONRPC,
+	"cognito-identity": errProtoJSONRPC,
+	"cognito-idp":      errProtoJSONRPC,
+	"dynamodb":         errProtoJSONRPC,
+	"ecr":              errProtoJSONRPC,
+	"ecs":              errProtoJSONRPC,
+	"eventbridge":      errProtoJSONRPC,
+	"firehose":         errProtoJSONRPC,
+	"fsx":              errProtoJSONRPC,
+	"glue":             errProtoJSONRPC,
+	"health":           errProtoJSONRPC,
+	"kinesis":          errProtoJSONRPC,
+	"kms":              errProtoJSONRPC,
+	"logs":             errProtoJSONRPC,
+	"organizations":    errProtoJSONRPC,
+	"redshift-data":    errProtoJSONRPC,
+	"sagemaker":        errProtoJSONRPC,
+	"secretsmanager":   errProtoJSONRPC,
+	"servicequotas":    errProtoJSONRPC,
+	"sqs":              errProtoJSONRPC,
+	"ssm":              errProtoJSONRPC,
+	"states":           errProtoJSONRPC,
+	"tagging":          errProtoJSONRPC,
+	"timestream":       errProtoJSONRPC,
+	"transfer":         errProtoJSONRPC,
+	"wafv2":            errProtoJSONRPC,
+
+	// REST-JSON.
+	"apigateway":      errProtoRESTJSON,
+	"apigatewayv2":    errProtoRESTJSON,
+	"appsync":         errProtoRESTJSON,
+	"backup":          errProtoRESTJSON,
+	"batch":           errProtoRESTJSON,
+	"bedrock-runtime": errProtoRESTJSON,
+	"efs":             errProtoRESTJSON,
+	"emrserverless":   errProtoRESTJSON,
+	"execute-api":     errProtoRESTJSON,
+	"lambda":          errProtoRESTJSON,
+	"msk":             errProtoRESTJSON,
+	"omics":           errProtoRESTJSON,
+	"opensearch":      errProtoRESTJSON,
+	"quicksight":      errProtoRESTJSON,
+	"ram":             errProtoRESTJSON,
+	"scheduler":       errProtoRESTJSON,
+	"sesv2":           errProtoRESTJSON,
+	"sso":             errProtoRESTJSON,
+}
+
+// errorProtocolFor returns the error protocol for a service. An unregistered
+// service falls back to the request Content-Type: an x-amz-json body implies
+// JSON RPC, anything else implies XML. That fallback preserves the behavior
+// substrate had before #392 for any service not yet classified.
+func errorProtocolFor(service, contentType string) awsErrorProtocol {
+	if proto, ok := serviceErrorProtocols[service]; ok {
+		return proto
+	}
+	if strings.HasPrefix(contentType, "application/x-amz-json") {
+		return errProtoJSONRPC
+	}
+	return errProtoQueryXML
+}
+
+// marshalAWSError serializes err in the wire format the given protocol uses,
+// returning the body, the Content-Type to send, and any extra response headers.
+//
+// The shapes are what the AWS SDKs actually parse:
+//
+//   - Query/REST-XML: <ErrorResponse><Error><Code>…</Code></Error></ErrorResponse>
+//   - JSON RPC: {"__type":"Code","message":"…"} — "__type" is the member
+//     botocore reads; a body carrying only "Code" leaves the SDK to fall back to
+//     the stringified HTTP status.
+//   - REST-JSON: the x-amzn-errortype header carries the code, which botocore
+//     prefers over the body.
+//
+// Both JSON forms also emit the lowercase "message" member the SDKs read, and
+// the JSON-RPC form repeats the code in "Code" so existing callers that read
+// that member keep working.
+func marshalAWSError(e *AWSError, proto awsErrorProtocol, jsonContentType string) (body []byte, contentType string, headers map[string]string) {
+	switch proto {
+	case errProtoJSONRPC:
+		ct := jsonContentType
+		if !strings.HasPrefix(ct, "application/x-amz-json") {
+			ct = "application/x-amz-json-1.1"
+		}
+		payload, err := json.Marshal(map[string]string{
+			"__type":  e.Code,
+			"message": e.Message,
+			"Code":    e.Code,
+			"Message": e.Message,
+		})
+		if err != nil {
+			return nil, ct, nil
+		}
+		return payload, ct, map[string]string{"x-amzn-ErrorType": e.Code}
+
+	case errProtoRESTJSON:
+		payload, err := json.Marshal(map[string]string{
+			"message": e.Message,
+			"Message": e.Message,
+			"Code":    e.Code,
+		})
+		if err != nil {
+			return nil, "application/json", nil
+		}
+		return payload, "application/json", map[string]string{"x-amzn-ErrorType": e.Code}
+
+	default:
+		payload, err := xml.Marshal(struct {
+			XMLName xml.Name `xml:"ErrorResponse"`
+			Error   struct {
+				Type    string `xml:"Type"`
+				Code    string `xml:"Code"`
+				Message string `xml:"Message"`
+			} `xml:"Error"`
+		}{
+			Error: struct {
+				Type    string `xml:"Type"`
+				Code    string `xml:"Code"`
+				Message string `xml:"Message"`
+			}{Type: "Sender", Code: e.Code, Message: e.Message},
+		})
+		if err != nil {
+			return nil, "text/xml; charset=UTF-8", nil
+		}
+		return payload, "text/xml; charset=UTF-8", nil
+	}
+}

--- a/emulator/error_protocol_test.go
+++ b/emulator/error_protocol_test.go
@@ -1,9 +1,12 @@
 package emulator_test
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"io"
+	"math"
 	"net/http"
 	"testing"
 
@@ -288,4 +291,69 @@ func TestMarshalAWSError_XMLEscapesMessage(t *testing.T) {
 	require.NoError(t, xml.Unmarshal(body, &doc), "body was %s", body)
 	assert.Equal(t, "NoSuchKey", doc.Error.Code)
 	assert.Equal(t, `a<b&c>"d"`, doc.Error.Message)
+}
+
+// errAfterGetsStateManager is a StateManager that serves the first n Get calls
+// normally and then fails every one after. Failing on a later call is what lets
+// a test reach a specific lookup — a store that fails from the first Get never
+// gets past bucket creation.
+type errAfterGetsStateManager struct {
+	inner  emulator.StateManager
+	allow  int
+	getErr error
+	gets   int
+}
+
+func (m *errAfterGetsStateManager) Get(ctx context.Context, namespace, key string) ([]byte, error) {
+	m.gets++
+	if m.gets > m.allow {
+		return nil, m.getErr
+	}
+	return m.inner.Get(ctx, namespace, key)
+}
+
+func (m *errAfterGetsStateManager) Put(ctx context.Context, namespace, key string, value []byte) error {
+	return m.inner.Put(ctx, namespace, key, value)
+}
+
+func (m *errAfterGetsStateManager) Delete(ctx context.Context, namespace, key string) error {
+	return m.inner.Delete(ctx, namespace, key)
+}
+
+func (m *errAfterGetsStateManager) List(ctx context.Context, namespace, prefix string) ([]string, error) {
+	return m.inner.List(ctx, namespace, prefix)
+}
+
+// TestS3_StateFailureIsNotReportedAsNoSuchBucket asserts the error return of
+// bucketMissingResponse is propagated rather than collapsed into "the bucket
+// does not exist". The two are opposite signals: NoSuchBucket tells a caller
+// their bucket is gone and to stop retrying, while a store failure is transient
+// and should be retried. Reporting the former for the latter would send a
+// consumer down a permanent-failure path over a blip.
+func TestS3_StateFailureIsNotReportedAsNoSuchBucket(t *testing.T) {
+	t.Parallel()
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+			state := &errAfterGetsStateManager{
+				inner:  emulator.NewMemoryStateManager(),
+				getErr: errors.New("state store unavailable"),
+				allow:  math.MaxInt, // permissive until the bucket exists
+			}
+			srv := newS3TestServerWithState(t, state)
+
+			w := s3Request(t, srv, http.MethodPut, "/blip-bucket", nil, nil)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			// Every Get from here on fails, so the bucket lookup errors even
+			// though the bucket was written.
+			state.allow = state.gets
+
+			got := s3Request(t, srv, method, "/blip-bucket/some-key", nil, nil)
+			assert.Equal(t, http.StatusInternalServerError, got.Code,
+				"a state-store failure must surface as a server error, not as NoSuchBucket")
+			assert.NotContains(t, got.Body.String(), "NoSuchBucket")
+		})
+	}
 }

--- a/emulator/error_protocol_test.go
+++ b/emulator/error_protocol_test.go
@@ -1,0 +1,291 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// jsonErrorBody decodes a JSON-protocol error body.
+func jsonErrorBody(t *testing.T, r *http.Response) map[string]any {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(body, &out), "body was %s", body)
+	return out
+}
+
+// TestJSONRPCError_CarriesTypeMember covers #392 for the JSON RPC protocol.
+// botocore's BaseJSONParser reads the error code from the body's "__type"
+// member and falls back to the stringified HTTP status when it is absent — it
+// never reads "Code". Emitting only "Code" therefore surfaced as
+// Error.Code == "404" and silently defeated every `except ClientError` branch
+// that compares against a symbolic code.
+func TestJSONRPCError_CarriesTypeMember(t *testing.T) {
+	t.Parallel()
+	srv := newSSMTestServer(t)
+	resp := ssmRequest(t, srv, "GetParameter", map[string]any{"Name": "/nope"})
+	defer resp.Body.Close() //nolint:errcheck
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	body := jsonErrorBody(t, resp)
+
+	// The member botocore actually reads.
+	assert.Equal(t, "ParameterNotFound", body["__type"])
+	// The lowercase message member the SDKs read.
+	assert.NotEmpty(t, body["message"])
+	// Retained so callers reading "Code" directly keep working.
+	assert.Equal(t, "ParameterNotFound", body["Code"])
+	// The status must not be the thing the caller has to match on.
+	assert.NotEqual(t, "404", body["__type"])
+}
+
+// TestJSONRPCError_MirrorsContentType asserts the 1.0/1.1 variant the caller
+// sent is echoed back rather than normalized, since the SDK pairs the response
+// parser with the protocol version it negotiated.
+func TestJSONRPCError_MirrorsContentType(t *testing.T) {
+	t.Parallel()
+	srv := newSSMTestServer(t)
+	resp := ssmRequest(t, srv, "GetParameter", map[string]any{"Name": "/nope"})
+	defer resp.Body.Close() //nolint:errcheck
+	assert.Equal(t, "application/x-amz-json-1.1", resp.Header.Get("Content-Type"))
+}
+
+// TestRESTJSONError_CarriesErrorTypeHeader covers #392 for REST-JSON. Lambda is
+// REST-JSON but sends "application/json" on the way in, which is
+// indistinguishable from a plain JSON body — so a Content-Type sniff sent
+// Lambda's errors out as XML, a shape its SDK cannot parse at all. botocore's
+// RestJSONParser prefers the x-amzn-errortype header over the body.
+func TestRESTJSONError_CarriesErrorTypeHeader(t *testing.T) {
+	t.Parallel()
+	srv := newLambdaTestServer(t)
+	resp := lambdaRequest(t, srv, http.MethodGet, "/2015-03-31/functions/nope", nil)
+	defer resp.Body.Close() //nolint:errcheck
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, "ResourceNotFoundException", resp.Header.Get("x-amzn-ErrorType"))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	body := jsonErrorBody(t, resp)
+	assert.Equal(t, "ResourceNotFoundException", body["Code"])
+	assert.NotEmpty(t, body["message"])
+}
+
+// TestRESTJSONError_IsNotXML pins the regression directly: a REST-JSON error
+// must not be an XML document, which is what the Content-Type sniff produced.
+func TestRESTJSONError_IsNotXML(t *testing.T) {
+	t.Parallel()
+	srv := newLambdaTestServer(t)
+	resp := lambdaRequest(t, srv, http.MethodGet, "/2015-03-31/functions/nope", nil)
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "<ErrorResponse")
+}
+
+// TestQueryXMLError_UsesErrorDocument asserts query-protocol services still get
+// the <ErrorResponse><Error><Code> document their parser expects, including the
+// <Type> element real AWS sends. EC2 rejects an unknown action, which is the
+// simplest error the plugin raises through the server's writeError path.
+func TestQueryXMLError_UsesErrorDocument(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	resp := ec2Request(t, ts, map[string]string{"Action": "NoSuchActionAtAll"})
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var doc struct {
+		XMLName xml.Name `xml:"ErrorResponse"`
+		Error   struct {
+			Type string `xml:"Type"`
+			Code string `xml:"Code"`
+		} `xml:"Error"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &doc), "body was %s", body)
+	assert.NotEmpty(t, doc.Error.Code)
+	assert.Equal(t, "Sender", doc.Error.Type)
+	assert.Equal(t, "text/xml; charset=UTF-8", resp.Header.Get("Content-Type"))
+}
+
+// TestIAMError_DropsExceptionSuffix covers the IAM half of #392: the wire error
+// code is NoSuchEntity, while NoSuchEntityException is the shape name in the API
+// model. Lambda genuinely does use the ...Exception suffix on the wire, so the
+// two services legitimately differ and neither can be inferred from the other.
+//
+// Verified against the IAM API reference:
+// https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetRole.html
+func TestIAMError_DropsExceptionSuffix(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	resp := iamRequest(t, srv, "GetRole", map[string]any{"RoleName": "nope"})
+	defer resp.Body.Close() //nolint:errcheck
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var doc struct {
+		XMLName xml.Name `xml:"ErrorResponse"`
+		Error   struct {
+			Type string `xml:"Type"`
+			Code string `xml:"Code"`
+		} `xml:"Error"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &doc))
+	assert.Equal(t, "NoSuchEntity", doc.Error.Code)
+	assert.Equal(t, "Sender", doc.Error.Type)
+}
+
+// TestS3GetObject_MissingBucketIsNoSuchBucket covers the S3 half of #392.
+// getObject went straight to the object lookup, so a GET against a bucket that
+// was never created reported NoSuchKey. That conflates two distinct conditions:
+// a caller cannot tell "someone deleted my bucket" from "this object isn't
+// written yet".
+func TestS3GetObject_MissingBucketIsNoSuchBucket(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	w := s3Request(t, srv, http.MethodGet, "/no-such-bucket/some-key", nil, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>NoSuchBucket</Code>")
+	assert.NotContains(t, w.Body.String(), "NoSuchKey")
+}
+
+// TestS3HeadObject_MissingBucketIsNoSuchBucket mirrors the GET case. HEAD has no
+// body, so the status is the only observable — but the code still has to be
+// right for the SDK, which synthesizes the error from it.
+func TestS3HeadObject_MissingBucketIsNoSuchBucket(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	w := s3Request(t, srv, http.MethodHead, "/no-such-bucket/some-key", nil, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestS3GetObject_MissingKeyInExistingBucketIsNoSuchKey is the other side of the
+// distinction: with the bucket present, an absent key must still be NoSuchKey.
+// Without this, the fix above could regress into reporting NoSuchBucket for
+// everything.
+func TestS3GetObject_MissingKeyInExistingBucketIsNoSuchKey(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	w := s3Request(t, srv, http.MethodPut, "/real-bucket", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	got := s3Request(t, srv, http.MethodGet, "/real-bucket/absent-key", nil, nil)
+	assert.Equal(t, http.StatusNotFound, got.Code)
+	assert.Contains(t, got.Body.String(), "<Code>NoSuchKey</Code>")
+}
+
+// TestS3GetObject_ExistingObjectStillReadable guards the happy path: adding the
+// bucket check must not break a normal read.
+func TestS3GetObject_ExistingObjectStillReadable(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	w := s3Request(t, srv, http.MethodPut, "/readable-bucket", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	w = s3Request(t, srv, http.MethodPut, "/readable-bucket/k", []byte("hello"), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	got := s3Request(t, srv, http.MethodGet, "/readable-bucket/k", nil, nil)
+	assert.Equal(t, http.StatusOK, got.Code)
+	assert.Equal(t, "hello", got.Body.String())
+}
+
+// TestErrorProtocolFor_Classification pins the protocol chosen per service, and
+// the fallback for a service not yet in the table: an x-amz-json request body
+// implies JSON RPC, anything else implies XML — the behavior substrate had
+// before #392.
+func TestErrorProtocolFor_Classification(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		service     string
+		contentType string
+		want        string
+	}{
+		{"s3 is xml", "s3", "", emulator.ErrProtoQueryXMLForTest},
+		{"iam is xml", "iam", "application/x-amz-json-1.1", emulator.ErrProtoQueryXMLForTest},
+		{"ssm is json rpc", "ssm", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"dynamodb is json rpc", "dynamodb", "application/x-amz-json-1.0", emulator.ErrProtoJSONRPCForTest},
+		{"lambda is rest json", "lambda", "application/json", emulator.ErrProtoRESTJSONForTest},
+		// Services whose ...Gateway/...Service targetPrefix makes them look
+		// REST-shaped but which model as json: their errors belong in "__type",
+		// not the x-amzn-errortype header. Verified against each service's
+		// "protocol" field in botocore's service-2.json.
+		{"acm is json rpc", "acm", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"budgets is json rpc", "budgets", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"cost explorer is json rpc", "ce", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"health is json rpc", "health", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"organizations is json rpc", "organizations", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"redshift-data is json rpc", "redshift-data", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"servicequotas is json rpc", "servicequotas", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"tagging is json rpc", "tagging", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"transfer is json rpc", "transfer", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		// RAM is the one service in that group that really is rest-json.
+		{"ram is rest json", "ram", "application/json", emulator.ErrProtoRESTJSONForTest},
+		// CloudWatch models as smithy-rpc-v2-cbor but still supports query, and
+		// substrate answers its successes in query XML.
+		{"monitoring is xml", "monitoring", "application/x-amz-json-1.1", emulator.ErrProtoQueryXMLForTest},
+		// The service name wins over the Content-Type: IAM sends x-amz-json on the
+		// way in but answers errors in XML, which is exactly why the sniff failed.
+		{"unknown falls back to json rpc", "notaservice", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
+		{"unknown falls back to xml", "notaservice", "application/json", emulator.ErrProtoQueryXMLForTest},
+		{"unknown with no content type", "notaservice", "", emulator.ErrProtoQueryXMLForTest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, emulator.ErrorProtocolForTest(tt.service, tt.contentType))
+		})
+	}
+}
+
+// TestMarshalAWSError_JSONRPCDefaultsContentType asserts a JSON-RPC error falls
+// back to the 1.1 variant when the request carried no usable x-amz-json type,
+// rather than echoing a Content-Type the SDK's JSON parser would not accept.
+func TestMarshalAWSError_JSONRPCDefaultsContentType(t *testing.T) {
+	t.Parallel()
+	body, ct, headers := emulator.MarshalAWSErrorForTest(
+		"ParameterNotFound", "nope", emulator.ErrProtoJSONRPCForTest, "text/plain")
+	assert.Equal(t, "application/x-amz-json-1.1", ct)
+	assert.Equal(t, "ParameterNotFound", headers["x-amzn-ErrorType"])
+
+	var out map[string]string
+	require.NoError(t, json.Unmarshal(body, &out))
+	assert.Equal(t, "ParameterNotFound", out["__type"])
+}
+
+// TestMarshalAWSError_XMLEscapesMessage guards against a message with XML
+// metacharacters producing a document the caller cannot parse.
+func TestMarshalAWSError_XMLEscapesMessage(t *testing.T) {
+	t.Parallel()
+	body, ct, headers := emulator.MarshalAWSErrorForTest(
+		"NoSuchKey", `a<b&c>"d"`, emulator.ErrProtoQueryXMLForTest, "")
+	assert.Equal(t, "text/xml; charset=UTF-8", ct)
+	assert.Empty(t, headers)
+
+	var doc struct {
+		XMLName xml.Name `xml:"ErrorResponse"`
+		Error   struct {
+			Code    string `xml:"Code"`
+			Message string `xml:"Message"`
+		} `xml:"Error"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &doc), "body was %s", body)
+	assert.Equal(t, "NoSuchKey", doc.Error.Code)
+	assert.Equal(t, `a<b&c>"d"`, doc.Error.Message)
+}

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -188,3 +188,40 @@ func InvokeLambdaForTest(p *LambdaPlugin, ctx *RequestContext, req *AWSRequest, 
 func CheckPresignedExpiryForTest(q url.Values, now time.Time) bool {
 	return checkPresignedExpiry(q, now)
 }
+
+// Error-protocol names exposed so external tests can assert the classification
+// without depending on the unexported enum's numeric values.
+const (
+	ErrProtoQueryXMLForTest = "query-xml"
+	ErrProtoJSONRPCForTest  = "json-rpc"
+	ErrProtoRESTJSONForTest = "rest-json"
+	ErrProtoUnknownForTest  = "unknown"
+)
+
+// ErrorProtocolForTest wraps errorProtocolFor, returning one of the
+// ErrProto*ForTest names.
+func ErrorProtocolForTest(service, contentType string) string {
+	switch errorProtocolFor(service, contentType) {
+	case errProtoQueryXML:
+		return ErrProtoQueryXMLForTest
+	case errProtoJSONRPC:
+		return ErrProtoJSONRPCForTest
+	case errProtoRESTJSON:
+		return ErrProtoRESTJSONForTest
+	default:
+		return ErrProtoUnknownForTest
+	}
+}
+
+// MarshalAWSErrorForTest wraps marshalAWSError, selecting the protocol by one of
+// the ErrProto*ForTest names.
+func MarshalAWSErrorForTest(code, message, proto, jsonContentType string) (body []byte, contentType string, headers map[string]string) {
+	p := errProtoQueryXML
+	switch proto {
+	case ErrProtoJSONRPCForTest:
+		p = errProtoJSONRPC
+	case ErrProtoRESTJSONForTest:
+		p = errProtoRESTJSON
+	}
+	return marshalAWSError(&AWSError{Code: code, Message: message}, p, jsonContentType)
+}

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -197,7 +197,7 @@ func (p *IAMPlugin) createUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return nil, fmt.Errorf("get user: %w", err)
 	}
 	if existing != nil {
-		return iamErrorResponse("EntityAlreadyExistsException",
+		return iamErrorResponse("EntityAlreadyExists",
 			fmt.Sprintf("User with name %s already exists.", params.UserName),
 			http.StatusConflict), nil
 	}
@@ -255,7 +255,7 @@ func (p *IAMPlugin) getUser(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 		return nil, err
 	}
 	if user == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The user with name %s cannot be found.", userName),
 			http.StatusNotFound), nil
 	}
@@ -285,7 +285,7 @@ func (p *IAMPlugin) deleteUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return nil, err
 	}
 	if user == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The user with name %s cannot be found.", params.UserName),
 			http.StatusNotFound), nil
 	}
@@ -296,7 +296,7 @@ func (p *IAMPlugin) deleteUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return nil, err
 	}
 	if len(arns) > 0 {
-		return iamErrorResponse("DeleteConflictException",
+		return iamErrorResponse("DeleteConflict",
 			"Cannot delete entity, must detach all policies first.",
 			http.StatusConflict), nil
 	}
@@ -384,7 +384,7 @@ func (p *IAMPlugin) createRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return nil, fmt.Errorf("get role: %w", err)
 	}
 	if existing != nil {
-		return iamErrorResponse("EntityAlreadyExistsException",
+		return iamErrorResponse("EntityAlreadyExists",
 			fmt.Sprintf("Role with name %s already exists.", params.RoleName),
 			http.StatusConflict), nil
 	}
@@ -392,7 +392,7 @@ func (p *IAMPlugin) createRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	var trustPolicy PolicyDocument
 	if params.AssumeRolePolicyDocument != "" {
 		if err := json.Unmarshal([]byte(params.AssumeRolePolicyDocument), &trustPolicy); err != nil {
-			return iamErrorResponse("MalformedPolicyDocumentException", //nolint:nilerr
+			return iamErrorResponse("MalformedPolicyDocument", //nolint:nilerr
 				"AssumeRolePolicyDocument is not valid JSON.", http.StatusBadRequest), nil
 		}
 	}
@@ -448,7 +448,7 @@ func (p *IAMPlugin) getRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 		return nil, err
 	}
 	if role == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
 			http.StatusNotFound), nil
 	}
@@ -478,7 +478,7 @@ func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return nil, err
 	}
 	if role == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
 			http.StatusNotFound), nil
 	}
@@ -488,7 +488,7 @@ func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return nil, err
 	}
 	if len(arns) > 0 {
-		return iamErrorResponse("DeleteConflictException",
+		return iamErrorResponse("DeleteConflict",
 			"Cannot delete entity, must detach all policies first.",
 			http.StatusConflict), nil
 	}
@@ -572,7 +572,7 @@ func (p *IAMPlugin) createGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		return nil, fmt.Errorf("get group: %w", err)
 	}
 	if existing != nil {
-		return iamErrorResponse("EntityAlreadyExistsException",
+		return iamErrorResponse("EntityAlreadyExists",
 			fmt.Sprintf("Group with name %s already exists.", params.GroupName),
 			http.StatusConflict), nil
 	}
@@ -623,7 +623,7 @@ func (p *IAMPlugin) getGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse
 		return nil, fmt.Errorf("get group: %w", err)
 	}
 	if raw == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The group with name %s cannot be found.", params.GroupName),
 			http.StatusNotFound), nil
 	}
@@ -657,7 +657,7 @@ func (p *IAMPlugin) deleteGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		return nil, fmt.Errorf("get group: %w", err)
 	}
 	if existing == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The group with name %s cannot be found.", params.GroupName),
 			http.StatusNotFound), nil
 	}
@@ -737,7 +737,7 @@ func (p *IAMPlugin) attachUserPolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 		return nil, err
 	}
 	if user == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The user with name %s cannot be found.", params.UserName),
 			http.StatusNotFound), nil
 	}
@@ -794,7 +794,7 @@ func (p *IAMPlugin) detachUserPolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 		newARNs = append(newARNs, a)
 	}
 	if !found {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			"The policy is not attached to the specified entity.",
 			http.StatusNotFound), nil
 	}
@@ -863,7 +863,7 @@ func (p *IAMPlugin) attachRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 		return nil, err
 	}
 	if role == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
 			http.StatusNotFound), nil
 	}
@@ -920,7 +920,7 @@ func (p *IAMPlugin) detachRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 		newARNs = append(newARNs, a)
 	}
 	if !found {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			"The policy is not attached to the specified entity.",
 			http.StatusNotFound), nil
 	}
@@ -996,7 +996,7 @@ func (p *IAMPlugin) createPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return nil, fmt.Errorf("get policy: %w", err)
 	}
 	if existing != nil {
-		return iamErrorResponse("EntityAlreadyExistsException",
+		return iamErrorResponse("EntityAlreadyExists",
 			fmt.Sprintf("A policy called %s already exists.", params.PolicyName),
 			http.StatusConflict), nil
 	}
@@ -1004,7 +1004,7 @@ func (p *IAMPlugin) createPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	var doc PolicyDocument
 	if params.PolicyDocument != "" {
 		if err := json.Unmarshal([]byte(params.PolicyDocument), &doc); err != nil {
-			return iamErrorResponse("MalformedPolicyDocumentException", //nolint:nilerr
+			return iamErrorResponse("MalformedPolicyDocument", //nolint:nilerr
 				"PolicyDocument is not valid JSON.", http.StatusBadRequest), nil
 		}
 	}
@@ -1061,7 +1061,7 @@ func (p *IAMPlugin) getPolicy(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return nil, fmt.Errorf("get policy: %w", err)
 	}
 	if raw == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("Policy %s was not found.", params.PolicyArn),
 			http.StatusNotFound), nil
 	}
@@ -1095,7 +1095,7 @@ func (p *IAMPlugin) deletePolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return nil, fmt.Errorf("get policy: %w", err)
 	}
 	if raw == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("Policy %s was not found.", params.PolicyArn),
 			http.StatusNotFound), nil
 	}
@@ -1182,7 +1182,7 @@ func (p *IAMPlugin) createAccessKey(ctx *RequestContext, req *AWSRequest) (*AWSR
 		return nil, err
 	}
 	if user == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The user with name %s cannot be found.", userName),
 			http.StatusNotFound), nil
 	}
@@ -1240,7 +1240,7 @@ func (p *IAMPlugin) deleteAccessKey(ctx *RequestContext, req *AWSRequest) (*AWSR
 		return nil, fmt.Errorf("get access key: %w", err)
 	}
 	if raw == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The Access Key with id %s cannot be found.", params.AccessKeyID),
 			http.StatusNotFound), nil
 	}
@@ -1525,7 +1525,7 @@ func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 		return nil, fmt.Errorf("get %s: %w", entityType, getErr)
 	}
 	if entityRaw == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The %s with name %s cannot be found.", entityType, entityName),
 			http.StatusNotFound), nil
 	}
@@ -1533,7 +1533,7 @@ func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 	// Parse and validate the policy document.
 	var doc PolicyDocument
 	if err := json.Unmarshal([]byte(params.PolicyDocument), &doc); err != nil {
-		return iamErrorResponse("MalformedPolicyDocumentException", //nolint:nilerr
+		return iamErrorResponse("MalformedPolicyDocument", //nolint:nilerr
 			"PolicyDocument is not valid JSON.", http.StatusBadRequest), nil
 	}
 
@@ -1602,7 +1602,7 @@ func (p *IAMPlugin) getInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 		return nil, fmt.Errorf("get inline policy: %w", err)
 	}
 	if raw == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The policy %s was not found.", params.PolicyName),
 			http.StatusNotFound), nil
 	}
@@ -1647,7 +1647,7 @@ func (p *IAMPlugin) deleteInlinePolicy(ctx *RequestContext, req *AWSRequest, ent
 		return nil, fmt.Errorf("check inline policy: %w", err)
 	}
 	if existing == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The policy %s was not found.", params.PolicyName),
 			http.StatusNotFound), nil
 	}
@@ -1773,7 +1773,7 @@ func (p *IAMPlugin) putPermissionsBoundary(ctx *RequestContext, req *AWSRequest,
 			return nil, err
 		}
 		if user == nil {
-			return iamErrorResponse("NoSuchEntityException",
+			return iamErrorResponse("NoSuchEntity",
 				fmt.Sprintf("The user with name %s cannot be found.", entityName),
 				http.StatusNotFound), nil
 		}
@@ -1791,7 +1791,7 @@ func (p *IAMPlugin) putPermissionsBoundary(ctx *RequestContext, req *AWSRequest,
 			return nil, err
 		}
 		if role == nil {
-			return iamErrorResponse("NoSuchEntityException",
+			return iamErrorResponse("NoSuchEntity",
 				fmt.Sprintf("The role with name %s cannot be found.", entityName),
 				http.StatusNotFound), nil
 		}
@@ -1841,7 +1841,7 @@ func (p *IAMPlugin) deletePermissionsBoundary(ctx *RequestContext, req *AWSReque
 			return nil, err
 		}
 		if user == nil {
-			return iamErrorResponse("NoSuchEntityException",
+			return iamErrorResponse("NoSuchEntity",
 				fmt.Sprintf("The user with name %s cannot be found.", entityName),
 				http.StatusNotFound), nil
 		}
@@ -1859,7 +1859,7 @@ func (p *IAMPlugin) deletePermissionsBoundary(ctx *RequestContext, req *AWSReque
 			return nil, err
 		}
 		if role == nil {
-			return iamErrorResponse("NoSuchEntityException",
+			return iamErrorResponse("NoSuchEntity",
 				fmt.Sprintf("The role with name %s cannot be found.", entityName),
 				http.StatusNotFound), nil
 		}
@@ -1901,7 +1901,7 @@ func (p *IAMPlugin) tagUser(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 		return nil, err
 	}
 	if user == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The user with name %s cannot be found.", params.UserName),
 			http.StatusNotFound), nil
 	}
@@ -1955,7 +1955,7 @@ func (p *IAMPlugin) untagUser(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return nil, err
 	}
 	if user == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The user with name %s cannot be found.", params.UserName),
 			http.StatusNotFound), nil
 	}
@@ -2007,7 +2007,7 @@ func (p *IAMPlugin) listUserTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return nil, err
 	}
 	if user == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The user with name %s cannot be found.", params.UserName),
 			http.StatusNotFound), nil
 	}
@@ -2072,7 +2072,7 @@ func (p *IAMPlugin) tagRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 		return nil, err
 	}
 	if role == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
 			http.StatusNotFound), nil
 	}
@@ -2126,7 +2126,7 @@ func (p *IAMPlugin) untagRole(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return nil, err
 	}
 	if role == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
 			http.StatusNotFound), nil
 	}
@@ -2178,7 +2178,7 @@ func (p *IAMPlugin) listRoleTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return nil, err
 	}
 	if role == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
 			http.StatusNotFound), nil
 	}
@@ -2429,7 +2429,7 @@ func (p *IAMPlugin) createInstanceProfile(ctx *RequestContext, req *AWSRequest) 
 		return nil, fmt.Errorf("get instance profile: %w", err)
 	}
 	if existing != nil {
-		return iamErrorResponse("EntityAlreadyExistsException",
+		return iamErrorResponse("EntityAlreadyExists",
 			fmt.Sprintf("Instance Profile %s already exists.", params.InstanceProfileName),
 			http.StatusConflict), nil
 	}
@@ -2470,7 +2470,7 @@ func (p *IAMPlugin) getInstanceProfile(_ *RequestContext, req *AWSRequest) (*AWS
 		return nil, fmt.Errorf("get instance profile: %w", err)
 	}
 	if data == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("Instance Profile %s cannot be found.", params.InstanceProfileName),
 			http.StatusNotFound), nil
 	}
@@ -2498,7 +2498,7 @@ func (p *IAMPlugin) deleteInstanceProfile(_ *RequestContext, req *AWSRequest) (*
 		return nil, fmt.Errorf("get instance profile: %w", err)
 	}
 	if data == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("Instance Profile %s cannot be found.", params.InstanceProfileName),
 			http.StatusNotFound), nil
 	}
@@ -2507,7 +2507,7 @@ func (p *IAMPlugin) deleteInstanceProfile(_ *RequestContext, req *AWSRequest) (*
 		return nil, fmt.Errorf("unmarshal instance profile: %w", err)
 	}
 	if len(profile.Roles) > 0 {
-		return iamErrorResponse("DeleteConflictException",
+		return iamErrorResponse("DeleteConflict",
 			"Cannot delete entity, must detach all roles first.",
 			http.StatusConflict), nil
 	}
@@ -2535,7 +2535,7 @@ func (p *IAMPlugin) addRoleToInstanceProfile(_ *RequestContext, req *AWSRequest)
 		return nil, fmt.Errorf("get instance profile: %w", err)
 	}
 	if profData == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("Instance Profile %s cannot be found.", params.InstanceProfileName),
 			http.StatusNotFound), nil
 	}
@@ -2544,7 +2544,7 @@ func (p *IAMPlugin) addRoleToInstanceProfile(_ *RequestContext, req *AWSRequest)
 		return nil, fmt.Errorf("unmarshal instance profile: %w", err)
 	}
 	if len(profile.Roles) > 0 {
-		return iamErrorResponse("LimitExceededException",
+		return iamErrorResponse("LimitExceeded",
 			"Instance profile "+params.InstanceProfileName+" already has a role.",
 			http.StatusConflict), nil
 	}
@@ -2554,7 +2554,7 @@ func (p *IAMPlugin) addRoleToInstanceProfile(_ *RequestContext, req *AWSRequest)
 		return nil, fmt.Errorf("get role: %w", err)
 	}
 	if roleData == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("Role %s cannot be found.", params.RoleName),
 			http.StatusNotFound), nil
 	}
@@ -2592,7 +2592,7 @@ func (p *IAMPlugin) removeRoleFromInstanceProfile(_ *RequestContext, req *AWSReq
 		return nil, fmt.Errorf("get instance profile: %w", err)
 	}
 	if profData == nil {
-		return iamErrorResponse("NoSuchEntityException",
+		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("Instance Profile %s cannot be found.", params.InstanceProfileName),
 			http.StatusNotFound), nil
 	}

--- a/emulator/iam_plugin_test.go
+++ b/emulator/iam_plugin_test.go
@@ -1222,3 +1222,238 @@ func TestIAMPlugin_ListInstanceProfiles_ReflectsCreated(t *testing.T) {
 	profiles, _ := out["InstanceProfiles"].([]any)
 	assert.Len(t, profiles, 2)
 }
+
+// TestIAMPlugin_ErrorCodesAreSymbolic drives every IAM error branch whose Code
+// changed in #392 and asserts the exact string a consumer's catch branch matches
+// on. An untested rename is the failure this issue exists to remove: the
+// response still looks like an error, so a test that only checks the status
+// stays green while the SDK's typed exception never fires.
+func TestIAMPlugin_ErrorCodesAreSymbolic(t *testing.T) {
+	// seedUser, seedRole and friends run before the asserted call so a branch is
+	// reached for the stated reason (entity absent, or entity present but its
+	// subordinate missing) rather than by accident.
+	seedUser := func(t *testing.T, srv *emulator.Server) {
+		t.Helper()
+		resp := iamRequest(t, srv, "CreateUser", map[string]any{"UserName": "u1"})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	seedRole := func(t *testing.T, srv *emulator.Server) {
+		t.Helper()
+		resp := iamRequest(t, srv, "CreateRole", map[string]any{"RoleName": "r1"})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	seedGroup := func(t *testing.T, srv *emulator.Server) {
+		t.Helper()
+		resp := iamRequest(t, srv, "CreateGroup", map[string]any{"GroupName": "g1"})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	seedProfile := func(t *testing.T, srv *emulator.Server) {
+		t.Helper()
+		resp := iamRequest(t, srv, "CreateInstanceProfile", map[string]any{"InstanceProfileName": "p1"})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	seedProfileWithRole := func(t *testing.T, srv *emulator.Server) {
+		t.Helper()
+		seedProfile(t, srv)
+		seedRole(t, srv)
+		resp := iamRequest(t, srv, "AddRoleToInstanceProfile", map[string]any{
+			"InstanceProfileName": "p1", "RoleName": "r1",
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(*testing.T, *emulator.Server)
+		operation string
+		body      map[string]any
+		wantCode  string
+		wantHTTP  int
+	}{
+		// NoSuchEntity, 404 — verified against the IAM API reference.
+		{
+			name:      "DeleteUser missing",
+			operation: "DeleteUser",
+			body:      map[string]any{"UserName": "absent"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "PutUserPolicy missing user",
+			operation: "PutUserPolicy",
+			body: map[string]any{
+				"UserName": "absent", "PolicyName": "inline",
+				"PolicyDocument": `{"Version":"2012-10-17","Statement":[]}`,
+			},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "DeleteUserPolicy missing policy",
+			setup:     seedUser,
+			operation: "DeleteUserPolicy",
+			body:      map[string]any{"UserName": "u1", "PolicyName": "absent"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "PutUserPermissionsBoundary missing user",
+			operation: "PutUserPermissionsBoundary",
+			body: map[string]any{
+				"UserName":            "absent",
+				"PermissionsBoundary": "arn:aws:iam::aws:policy/ReadOnlyAccess",
+			},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "PutRolePermissionsBoundary missing role",
+			operation: "PutRolePermissionsBoundary",
+			body: map[string]any{
+				"RoleName":            "absent",
+				"PermissionsBoundary": "arn:aws:iam::aws:policy/ReadOnlyAccess",
+			},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "DeleteUserPermissionsBoundary missing user",
+			operation: "DeleteUserPermissionsBoundary",
+			body:      map[string]any{"UserName": "absent"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "DeleteRolePermissionsBoundary missing role",
+			operation: "DeleteRolePermissionsBoundary",
+			body:      map[string]any{"RoleName": "absent"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "TagUser missing user",
+			operation: "TagUser",
+			body: map[string]any{
+				"UserName": "absent",
+				"Tags":     []map[string]string{{"Key": "k", "Value": "v"}},
+			},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "UntagUser missing user",
+			operation: "UntagUser",
+			body:      map[string]any{"UserName": "absent", "TagKeys": []string{"k"}},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "ListUserTags missing user",
+			operation: "ListUserTags",
+			body:      map[string]any{"UserName": "absent"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "TagRole missing role",
+			operation: "TagRole",
+			body: map[string]any{
+				"RoleName": "absent",
+				"Tags":     []map[string]string{{"Key": "k", "Value": "v"}},
+			},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "UntagRole missing role",
+			operation: "UntagRole",
+			body:      map[string]any{"RoleName": "absent", "TagKeys": []string{"k"}},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "ListRoleTags missing role",
+			operation: "ListRoleTags",
+			body:      map[string]any{"RoleName": "absent"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "DeleteInstanceProfile missing profile",
+			operation: "DeleteInstanceProfile",
+			body:      map[string]any{"InstanceProfileName": "absent"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "AddRoleToInstanceProfile missing profile",
+			operation: "AddRoleToInstanceProfile",
+			body:      map[string]any{"InstanceProfileName": "absent", "RoleName": "r1"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			// The profile exists, so this reaches the second NoSuchEntity in the
+			// same handler — the one that reports the missing role.
+			name:      "AddRoleToInstanceProfile missing role",
+			setup:     seedProfile,
+			operation: "AddRoleToInstanceProfile",
+			body:      map[string]any{"InstanceProfileName": "p1", "RoleName": "absent"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "RemoveRoleFromInstanceProfile missing profile",
+			operation: "RemoveRoleFromInstanceProfile",
+			body:      map[string]any{"InstanceProfileName": "absent", "RoleName": "r1"},
+			wantCode:  "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+
+		// EntityAlreadyExists, 409.
+		{
+			name:      "CreateGroup duplicate",
+			setup:     seedGroup,
+			operation: "CreateGroup",
+			body:      map[string]any{"GroupName": "g1"},
+			wantCode:  "EntityAlreadyExists", wantHTTP: http.StatusConflict,
+		},
+		{
+			name:      "CreateInstanceProfile duplicate",
+			setup:     seedProfile,
+			operation: "CreateInstanceProfile",
+			body:      map[string]any{"InstanceProfileName": "p1"},
+			wantCode:  "EntityAlreadyExists", wantHTTP: http.StatusConflict,
+		},
+
+		// DeleteConflict, 409.
+		{
+			name:      "DeleteInstanceProfile with attached role",
+			setup:     seedProfileWithRole,
+			operation: "DeleteInstanceProfile",
+			body:      map[string]any{"InstanceProfileName": "p1"},
+			wantCode:  "DeleteConflict", wantHTTP: http.StatusConflict,
+		},
+
+		// MalformedPolicyDocument, 400.
+		{
+			name:      "CreatePolicy invalid JSON",
+			operation: "CreatePolicy",
+			body: map[string]any{
+				"PolicyName": "bad", "PolicyDocument": "{not json",
+			},
+			wantCode: "MalformedPolicyDocument", wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:      "PutRolePolicy invalid JSON",
+			setup:     seedRole,
+			operation: "PutRolePolicy",
+			body: map[string]any{
+				"RoleName": "r1", "PolicyName": "inline", "PolicyDocument": "{not json",
+			},
+			wantCode: "MalformedPolicyDocument", wantHTTP: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newIAMTestServer(t)
+			if tt.setup != nil {
+				tt.setup(t, srv)
+			}
+
+			resp := iamRequest(t, srv, tt.operation, tt.body)
+			assert.Equal(t, tt.wantHTTP, resp.StatusCode)
+
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, tt.wantCode, result["__type"],
+				"IAM %s must report Code %q — SDKs map the Code string to a typed exception, "+
+					"so any other spelling leaves the caller's catch branch dead",
+				tt.operation, tt.wantCode)
+		})
+	}
+}

--- a/emulator/iam_plugin_test.go
+++ b/emulator/iam_plugin_test.go
@@ -208,7 +208,7 @@ func TestIAMPlugin_CreateUser_Duplicate(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	var result map[string]any
 	decodeIAMXML(t, resp, &result)
-	assert.Equal(t, "EntityAlreadyExistsException", result["__type"])
+	assert.Equal(t, "EntityAlreadyExists", result["__type"])
 }
 
 func TestIAMPlugin_CreateUser_MissingName(t *testing.T) {
@@ -239,7 +239,7 @@ func TestIAMPlugin_GetUser_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	var result map[string]any
 	decodeIAMXML(t, resp, &result)
-	assert.Equal(t, "NoSuchEntityException", result["__type"])
+	assert.Equal(t, "NoSuchEntity", result["__type"])
 }
 
 func TestIAMPlugin_DeleteUser_Success(t *testing.T) {
@@ -266,7 +266,7 @@ func TestIAMPlugin_DeleteUser_WithAttachedPolicy(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	var result map[string]any
 	decodeIAMXML(t, resp, &result)
-	assert.Equal(t, "DeleteConflictException", result["__type"])
+	assert.Equal(t, "DeleteConflict", result["__type"])
 }
 
 func TestIAMPlugin_ListUsers_Empty(t *testing.T) {

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -542,6 +542,15 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key string) (*AWSResponse, error) {
 	ctx := context.Background()
 
+	// A GET against a bucket that does not exist is NoSuchBucket, not NoSuchKey:
+	// the two are distinct conditions and a caller needs to tell "the bucket is
+	// gone" from "this object isn't written yet" (#392).
+	if missing, err := p.bucketMissingResponse(ctx, bucket); err != nil {
+		return nil, err
+	} else if missing != nil {
+		return missing, nil
+	}
+
 	// If versionId query param is present, load from versioned storage.
 	versionID := req.Params["versionId"]
 
@@ -624,6 +633,13 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 // headObject handles HEAD /<bucket>/<key>.
 func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key string) (*AWSResponse, error) {
 	ctx := context.Background()
+
+	// Mirror getObject: a missing bucket is NoSuchBucket, not NoSuchKey (#392).
+	if missing, err := p.bucketMissingResponse(ctx, bucket); err != nil {
+		return nil, err
+	} else if missing != nil {
+		return missing, nil
+	}
 
 	// If versionId is present, head the specific version; otherwise the current.
 	versionID := req.Params["versionId"]
@@ -1817,6 +1833,21 @@ type s3ErrorXML struct {
 // s3ErrorResponse builds an S3-style XML error [AWSResponse].
 func s3ErrorResponse(code, message string, status int) *AWSResponse {
 	return s3ErrorResponseWith(s3Error{Code: code, Message: message, Status: status})
+}
+
+// bucketMissingResponse returns a NoSuchBucket error response when bucket does
+// not exist, or nil when it does. The error return is reserved for a state-store
+// failure, which the caller must propagate rather than report as a missing
+// bucket.
+func (p *S3Plugin) bucketMissingResponse(ctx context.Context, bucket string) (*AWSResponse, error) {
+	data, err := p.state.Get(ctx, s3Namespace, "bucket:"+bucket)
+	if err != nil {
+		return nil, fmt.Errorf("check bucket: %w", err)
+	}
+	if data != nil {
+		return nil, nil
+	}
+	return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 }
 
 // s3ErrorResponseWith builds an S3-style XML error [AWSResponse], including any

--- a/emulator/s3_plugin_test.go
+++ b/emulator/s3_plugin_test.go
@@ -25,8 +25,22 @@ import (
 // afero filesystem. It returns the server and the filesystem for direct inspection.
 func newS3TestServer(t *testing.T) (*emulator.Server, afero.Fs) {
 	t.Helper()
+	return newS3TestServerWithFS(t, emulator.NewMemoryStateManager())
+}
+
+// newS3TestServerWithState is newS3TestServer with a caller-supplied state
+// store, for tests that need the store to fail. It discards the filesystem,
+// which those tests do not inspect.
+func newS3TestServerWithState(t *testing.T, state emulator.StateManager) *emulator.Server {
+	t.Helper()
+	srv, _ := newS3TestServerWithFS(t, state)
+	return srv
+}
+
+// newS3TestServerWithFS builds the shared S3 test server over state.
+func newS3TestServerWithFS(t *testing.T, state emulator.StateManager) (*emulator.Server, afero.Fs) {
+	t.Helper()
 	cfg := emulator.DefaultConfig()
-	state := emulator.NewMemoryStateManager()
 	logger := emulator.NewDefaultLogger(slog.LevelError, false)
 	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
 	fs := afero.NewMemMapFs()

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"io"
 	"net"
@@ -513,7 +512,7 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 				Code:       "InvalidClientTokenId",
 				Message:    fmt.Sprintf("region %q is not in the allowed list", reqCtx.Region),
 				HTTPStatus: http.StatusBadRequest,
-			}, r)
+			}, r, req.Service)
 			return
 		}
 	}
@@ -534,7 +533,7 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 	// Step 1.6: SigV4 signature verification.
 	if s.opts.Credentials != nil {
 		if sigErr := VerifySigV4(r, rawBody, s.opts.Credentials); sigErr != nil {
-			s.writeError(w, sigErr, r)
+			s.writeError(w, sigErr, r, req.Service)
 			return
 		}
 	}
@@ -543,7 +542,7 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 	// Presigned requests carry X-Amz-Algorithm in the query string; verify
 	// X-Amz-Date + X-Amz-Expires have not elapsed.
 	if checkPresignedExpiry(r.URL.Query(), s.tc.Now()) {
-		s.writeError(w, &AWSError{Code: "AccessDenied", Message: "Request has expired.", HTTPStatus: http.StatusForbidden}, r)
+		s.writeError(w, &AWSError{Code: "AccessDenied", Message: "Request has expired.", HTTPStatus: http.StatusForbidden}, r, req.Service)
 		return
 	}
 
@@ -554,7 +553,7 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 			if recordErr := s.store.RecordRequest(ctx, reqCtx, req, nil, duration, 0, authErr); recordErr != nil {
 				s.logger.Warn("failed to record auth event", "err", recordErr)
 			}
-			s.writeError(w, authErr, r)
+			s.writeError(w, authErr, r, req.Service)
 			return
 		}
 	}
@@ -570,7 +569,7 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 				s.opts.Metrics.RecordQuotaHit(req.Service, req.Operation)
 				s.opts.Metrics.RecordRequest(req.Service, req.Operation, true, "ThrottlingException")
 			}
-			s.writeError(w, quotaErr, r)
+			s.writeError(w, quotaErr, r, req.Service)
 			return
 		}
 	}
@@ -586,7 +585,7 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 				s.opts.Metrics.RecordConsistencyDelay(req.Service)
 				s.opts.Metrics.RecordRequest(req.Service, req.Operation, true, "InconsistentStateException")
 			}
-			s.writeError(w, consErr, r)
+			s.writeError(w, consErr, r, req.Service)
 			return
 		}
 	}
@@ -602,7 +601,7 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 			if recordErr := s.store.RecordRequest(ctx, reqCtx, req, nil, duration, 0, faultErr); recordErr != nil {
 				s.logger.Warn("failed to record fault event", "err", recordErr)
 			}
-			s.writeError(w, faultErr, r)
+			s.writeError(w, faultErr, r, req.Service)
 			return
 		}
 	}
@@ -651,7 +650,7 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 
 	if routeErr != nil {
 		RecordSpanError(reqSpan, routeErr)
-		s.writeError(w, routeErr, r)
+		s.writeError(w, routeErr, r, req.Service)
 		return
 	}
 
@@ -677,10 +676,12 @@ func (s *Server) writeResponse(w http.ResponseWriter, resp *AWSResponse) {
 	}
 }
 
-// writeError converts err into an AWS-style error response. For JSON-protocol
-// services (identified by Content-Type application/x-amz-json-1.0 on the
-// incoming request), the error is serialized as JSON; otherwise XML is used.
-func (s *Server) writeError(w http.ResponseWriter, err error, r *http.Request) {
+// writeError converts err into an AWS-style error response, serialized in the
+// wire format the target service's protocol uses. The service name selects the
+// protocol (see errorProtocolFor) because the incoming Content-Type cannot
+// distinguish REST-JSON from a plain JSON body, and picking the wrong shape
+// leaves the SDK unable to recover the error code at all (#392).
+func (s *Server) writeError(w http.ResponseWriter, err error, r *http.Request, service string) {
 	var awsErr *AWSError
 	if asAWSErr, ok := err.(*AWSError); ok {
 		awsErr = asAWSErr
@@ -692,40 +693,21 @@ func (s *Server) writeError(w http.ResponseWriter, err error, r *http.Request) {
 		}
 	}
 
-	// JSON protocol: any application/x-amz-json variant (1.0 or 1.1).
 	ct := ""
 	if r != nil {
 		ct = r.Header.Get("Content-Type")
 	}
-	if strings.HasPrefix(ct, "application/x-amz-json") {
-		w.Header().Set("Content-Type", ct) // mirror 1.0 or 1.1 back to caller
-		w.WriteHeader(awsErr.HTTPStatus)
-		body, _ := json.Marshal(map[string]string{"Code": awsErr.Code, "Message": awsErr.Message})
-		_, _ = w.Write(body) // nosemgrep
-		return
-	}
 
-	body, marshalErr := xml.Marshal(struct {
-		XMLName xml.Name `xml:"ErrorResponse"`
-		Error   struct {
-			Code    string `xml:"Code"`
-			Message string `xml:"Message"`
-		} `xml:"Error"`
-	}{
-		Error: struct {
-			Code    string `xml:"Code"`
-			Message string `xml:"Message"`
-		}{
-			Code:    awsErr.Code,
-			Message: awsErr.Message,
-		},
-	})
-	if marshalErr != nil {
+	body, respCT, extraHeaders := marshalAWSError(awsErr, errorProtocolFor(service, ct), ct)
+	if body == nil {
 		http.Error(w, awsErr.Message, awsErr.HTTPStatus)
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/xml; charset=UTF-8")
+	w.Header().Set("Content-Type", respCT)
+	for k, v := range extraHeaders {
+		w.Header().Set(k, v)
+	}
 	w.WriteHeader(awsErr.HTTPStatus)
 	if _, writeErr := w.Write(body); writeErr != nil { // nosemgrep
 		s.logger.Warn("failed to write error body", "err", writeErr)


### PR DESCRIPTION
Closes #392

## What the issue reported vs. what was actually wrong

The issue describes four independent per-service typos. **Three of the four were one defect** in the server's shared `writeError`.

`writeError` emitted a `Code` member for every JSON service. botocore's `BaseJSONParser._do_error_parse` does:

```python
code = body.get('__type', response_code and str(response_code))
```

It reads `__type` and falls back to the **stringified HTTP status**. It never reads `Code`. So SSM's `ParameterNotFound` — which the plugin was already setting correctly — was discarded on the wire, and the caller saw `Error.Code == "404"`. Every `except ClientError` branch comparing against a symbolic code silently stopped matching. This affected **all ~30 JSON-RPC services**, not just the one reported.

Lambda was a second and worse case. Lambda is REST-JSON but sends `Content-Type: application/json`, which fails the `application/x-amz-json` prefix test — so its errors were emitted as **XML**, a shape its SDK cannot parse at all.

## The fix

The protocol cannot be sniffed from the request:

- IAM sends `x-amz-json-1.1` **inbound** but answers errors in XML.
- Lambda's inbound `application/json` is indistinguishable from a plain JSON body.

So the **service name** selects it. `emulator/error_protocol.go` adds one dispatch layer over three shapes:

| Protocol | Where the code goes | Parser that reads it |
|---|---|---|
| Query / ec2 / REST-XML | `<ErrorResponse><Error><Code>` | `QueryParser`, `BaseXMLResponseParser` |
| JSON-RPC 1.0/1.1 | body `__type` | `BaseJSONParser` |
| REST-JSON | `x-amzn-errortype` header | `RestJSONParser._inject_error_code` |

Every entry in the classification table is the `protocol` field of that service's model in `botocore/data/<service>/<version>/service-2.json` — the same value that selects the SDK's parser, so the table and the parser cannot disagree. Services not yet classified keep the previous Content-Type sniff, so this adds no behavior change for them.

The JSON bodies retain `Code`/`Message` alongside `__type`/`message` so callers already reading `Code` keep working.

## The other three, all verified against AWS docs

- **IAM** — wire codes drop the `Exception` suffix that the API model's *shape names* carry: `NoSuchEntity`, `EntityAlreadyExists`, `MalformedPolicyDocument`, `DeleteConflict`, `LimitExceeded` (44 call sites). This is **not** a blanket suffix-strip: `ValidationError` and `AccessDeniedException` are already correct per IAM's `CommonErrors`, and Lambda genuinely *does* use `ResourceNotFoundException` on the wire. Neither service's spelling can be inferred from the other, which is why each was checked individually.
- **S3** — `GetObject`/`HeadObject` went straight to the object lookup, so a GET against a bucket that was never created reported `NoSuchKey`. That conflates two conditions a caller must distinguish: a deleted bucket (fatal misconfiguration) from an unwritten object (ordinary cache miss). New `bucketMissingResponse` helper reserves its error return for a state-store failure, so that is propagated rather than reported as a missing bucket.
- **`docs/services.md`** — auditing my own table against botocore turned up two errors in the generator's hand-maintained protocol column: ACM was listed as Query (it is JSON-RPC) and RAM as JSON (it is REST-JSON). Both corrected; the matrix is regenerated.

## Tests

`emulator/error_protocol_test.go`, 13 tests. The ones that matter most pin the exact regressions:

- `TestJSONRPCError_CarriesTypeMember` asserts `__type == "ParameterNotFound"` **and** `!= "404"` — the status must never be the thing a caller matches on.
- `TestRESTJSONError_IsNotXML` asserts a Lambda error body contains no `<ErrorResponse`.
- `TestIAMError_DropsExceptionSuffix` pins `NoSuchEntity` against `API_GetRole.html`.
- `TestS3GetObject_MissingKeyInExistingBucketIsNoSuchKey` is the guard on the other side — the bucket fix must not turn every miss into `NoSuchBucket`.
- `TestErrorProtocolFor_Classification` pins each protocol per service, including the nine JSON-RPC services whose `...Gateway`/`...Service` target prefixes make them *look* REST-shaped, plus both fallback branches.

Three IAM test assertions changed: they had encoded the bug, asserting the old `...Exception` spellings.

## Gates

`go build` ✅ · `go vet` ✅ · `golangci-lint run ./...` **0 issues** ✅ · `make test` (race) ✅ · `test/e2e` ✅ · `make docs-reference-check` ✅ · `make scan-fs` 0 vulns ✅

`errorProtocolFor` is at 100% coverage. The residual uncovered lines are the `json.Marshal`/`xml.Marshal` error guards, unreachable for `map[string]string` and all-string structs; they exist so `writeError`'s `http.Error` fallback stays reachable.