### PR TITLE
fix(parser): validate the region parsed from Host and handle api.* hosts (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InvalidPart` would send a consumer hunting a data bug that does not exist.
 
 ### Fixed
+- The region parsed from a request's `Host` header is now validated against the
+  shape of a region code, and `api.<service>.<region>` hosts are understood
+  (#403). `api.pricing.us-east-1.amazonaws.com` had yielded `pricing` — the
+  second label of a three-label host, returned by the `<service>.<region>`
+  assumption the parser fell through to. The deeper problem was that the
+  function failed *open*: any host layout it did not recognize still produced a
+  confident answer, so a caller could not distinguish a service name
+  masquerading as a region from a real one. An unrecognized layout now yields
+  no region, which routes the request through the fallbacks that already
+  existed — the SigV4 credential scope, then the default region.
 - S3 multipart operations now return S3's documented `NoSuchUpload` and
   `MalformedXML` message text rather than abbreviated paraphrases (#400).
 - S3 `HeadObject` now reports `x-amz-version-id` (#396). `GetObject` always did,

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -34,6 +34,9 @@ func NormalizeS3VirtualHostForTest(host, urlPath string) (bucket, normPath strin
 	return normalizeS3VirtualHost(host, urlPath)
 }
 
+// ExtractRegionFromHostForTest wraps extractRegionFromHost for external tests.
+func ExtractRegionFromHostForTest(host string) string { return extractRegionFromHost(host) }
+
 // ExtractAccessKeyFromAuthForTest wraps extractAccessKeyFromAuth for external tests.
 func ExtractAccessKeyFromAuthForTest(authHeader string) string {
 	return extractAccessKeyFromAuth(authHeader)

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -408,6 +408,10 @@ func extractRegion(host, authHeader string) string {
 // extractRegionFromHost parses the region segment from a Host header value
 // such as "s3.us-west-2.amazonaws.com" or
 // "mybucket.s3.us-east-1.amazonaws.com" (virtual-hosted S3).
+//
+// Every candidate is checked against the shape of a region code before being
+// returned, so an unrecognized host layout yields "" rather than a service name
+// masquerading as a region; see regionCandidate.
 func extractRegionFromHost(host string) string {
 	// Strip port if present.
 	if colon := strings.LastIndexByte(host, ':'); colon > 0 {
@@ -426,7 +430,7 @@ func extractRegionFromHost(host string) string {
 	for i, p := range parts {
 		if p == "s3" {
 			if i+1 < len(parts) {
-				return parts[i+1]
+				return regionCandidate(parts[i+1])
 			}
 			return "" // s3 at the end → global, no region
 		}
@@ -434,14 +438,77 @@ func extractRegionFromHost(host string) string {
 
 	// execute-api runtime: "{apiId}.execute-api.{region}".
 	if len(parts) >= 3 && parts[1] == "execute-api" {
-		return parts[2]
+		return regionCandidate(parts[2])
+	}
+
+	// "api.<service>.<region>": the layout the Price List Query API and other
+	// services that front their endpoint with a literal "api" label use, e.g.
+	// "api.pricing.us-east-1.amazonaws.com". Without this the region is read
+	// from the wrong label (#403).
+	if len(parts) >= 3 && parts[0] == "api" {
+		return regionCandidate(parts[2])
 	}
 
 	// Non-S3: "<service>.<region>" or just "<service>".
 	if len(parts) < 2 {
 		return ""
 	}
-	return parts[1]
+	return regionCandidate(parts[1])
+}
+
+// regionCandidate returns s when it has the shape of an AWS region code, and ""
+// otherwise.
+//
+// This is what makes extractRegionFromHost fail closed. Without it, a host
+// layout the parser does not recognize still produced an answer — whichever
+// label happened to sit in the position a region usually occupies, which is
+// typically a service name — and a caller had no way to tell that apart from a
+// real region. Returning "" instead routes the request through the fallbacks
+// extractRegion already has: the SigV4 credential scope, then defaultRegion.
+//
+// The shape is a two-letter geography, one or two lowercase words, and a
+// trailing ordinal: "us-east-1", "ap-southeast-4", "il-central-1",
+// "cn-northwest-1", and the four-segment partition forms "us-gov-west-1" and
+// "us-iso-east-1". Verified against the region table in the AWS General
+// Reference (docs.aws.amazon.com/general/latest/gr/rande.html).
+func regionCandidate(s string) string {
+	segs := strings.Split(s, "-")
+	if len(segs) < 3 || len(segs) > 4 {
+		return ""
+	}
+	// Geography: exactly two lowercase letters — us, ap, eu, af, me, sa, ca,
+	// il, mx, cn.
+	if len(segs[0]) != 2 || !isLowerAlpha(segs[0]) {
+		return ""
+	}
+	// Compass and partition words: east, southeast, central, gov, iso.
+	for _, seg := range segs[1 : len(segs)-1] {
+		if seg == "" || !isLowerAlpha(seg) {
+			return ""
+		}
+	}
+	// Trailing ordinal: digits only.
+	last := segs[len(segs)-1]
+	if last == "" {
+		return ""
+	}
+	for _, c := range last {
+		if c < '0' || c > '9' {
+			return ""
+		}
+	}
+	return s
+}
+
+// isLowerAlpha reports whether s consists only of the ASCII letters a-z. An
+// empty string satisfies it vacuously; callers that care reject "" themselves.
+func isLowerAlpha(s string) bool {
+	for _, c := range s {
+		if c < 'a' || c > 'z' {
+			return false
+		}
+	}
+	return true
 }
 
 // normalizeS3VirtualHost detects an S3 virtual-hosted-style request

--- a/emulator/parser_test.go
+++ b/emulator/parser_test.go
@@ -190,6 +190,103 @@ func TestParseAWSRequest_Region(t *testing.T) {
 	}
 }
 
+// TestExtractRegionFromHost covers every host layout the parser recognizes, plus
+// the layouts it must refuse to guess at.
+//
+// The refusals are the point of #403. The function used to fall through to a
+// "<service>.<region>" assumption and return the second label of whatever it was
+// given, so "api.pricing.us-east-1.amazonaws.com" yielded "pricing" — a service
+// name presented as a region, indistinguishable to the caller from a real one.
+func TestExtractRegionFromHost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		// The reported bug: "api.<service>.<region>".
+		{"api-prefixed pricing host", "api.pricing.us-east-1.amazonaws.com", "us-east-1"},
+		{"api-prefixed pricing ap-south-1", "api.pricing.ap-south-1.amazonaws.com", "ap-south-1"},
+
+		// Region shapes that must all be accepted. Codes taken from the region
+		// table in the AWS General Reference.
+		{"four-segment gov partition", "ec2.us-gov-west-1.amazonaws.com", "us-gov-west-1"},
+		{"long compass word", "ec2.ap-southeast-4.amazonaws.com", "ap-southeast-4"},
+		{"il geography", "ec2.il-central-1.amazonaws.com", "il-central-1"},
+		{"mx geography", "ec2.mx-central-1.amazonaws.com", "mx-central-1"},
+		{"cn geography", "ec2.cn-northwest-1.amazonaws.com", "cn-northwest-1"},
+
+		// Pre-existing layouts, which must keep parsing as they did.
+		{"path-style s3 regional", "s3.us-west-2.amazonaws.com", "us-west-2"},
+		{"virtual-hosted s3 regional", "mybucket.s3.us-east-1.amazonaws.com", "us-east-1"},
+		{"dotted bucket virtual-hosted", "my.bucket.s3.us-west-2.amazonaws.com", "us-west-2"},
+		{"execute-api runtime", "abc123.execute-api.us-east-1.amazonaws.com", "us-east-1"},
+		{"plain service regional", "dynamodb.ap-southeast-1.amazonaws.com", "ap-southeast-1"},
+		{"regional host with port", "dynamodb.eu-west-1.amazonaws.com:443", "eu-west-1"},
+
+		// Hosts that carry the region in the second label for reasons of their own
+		// rather than by the "<service>.<region>" convention. The shape check
+		// passes them through, which is the right answer.
+		{"elb dns name", "my-lb-1234.us-east-1.elb.amazonaws.com", "us-east-1"},
+		{"opensearch domain", "my-domain.us-east-1.es.amazonaws.com", "us-east-1"},
+
+		// Layouts with no region to find: the function must yield "" so the
+		// caller falls back rather than acting on a guess.
+		{"global s3", "s3.amazonaws.com", ""},
+		{"bare service host", "iam.amazonaws.com", ""},
+		{"virtual-hosted s3 global", "mybucket.s3.amazonaws.com", ""},
+		{"api-prefixed global host", "api.pricing.amazonaws.com", ""},
+		{"not an aws host", "localhost:4566", ""},
+		{"empty host", "", ""},
+
+		// Near-misses on the region shape, each failing a different check.
+		{"two segments only", "svc.us-east.amazonaws.com", ""},
+		{"five segments", "svc.us-gov-iso-east-1.amazonaws.com", ""},
+		{"three-letter geography", "svc.usa-east-1.amazonaws.com", ""},
+		{"non-numeric ordinal", "svc.us-east-one.amazonaws.com", ""},
+		{"digits in compass word", "svc.us-e4st-1.amazonaws.com", ""},
+		{"uppercase region", "svc.US-EAST-1.amazonaws.com", ""},
+		{"trailing hyphen", "svc.us-east-.amazonaws.com", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, emulator.ExtractRegionFromHostForTest(tt.host))
+		})
+	}
+}
+
+// TestExtractRegion_APIPrefixedHost asserts the fix reaches the RequestContext a
+// plugin actually sees, not just the helper. A pricing client signs for
+// us-east-1, so the SigV4 fallback would mask a parser that still returned
+// "pricing" — this sends no Authorization header so the host is the only signal.
+func TestExtractRegion_APIPrefixedHost(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "http://localhost/", nil)
+	r.Host = "api.pricing.us-east-1.amazonaws.com"
+
+	_, reqCtx, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1", reqCtx.Region)
+}
+
+// TestExtractRegion_UnparseableHostFallsBackToAuth is the payoff of failing
+// closed: because the host no longer yields a bogus region, the SigV4 credential
+// scope — which is authoritative — gets its turn.
+func TestExtractRegion_UnparseableHostFallsBackToAuth(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "http://localhost/", nil)
+	r.Host = "api.pricing.amazonaws.com"
+	r.Header.Set("Authorization",
+		"AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/ap-south-1/pricing/aws4_request, "+
+			"SignedHeaders=host, Signature=abc")
+
+	_, reqCtx, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	assert.Equal(t, "ap-south-1", reqCtx.Region)
+}
+
 func TestParseAWSRequest_Account(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Closes #403
Refs #401 — this is one of that issue's two acceptance criteria; the Price List `GetProducts` emulation is the other and stays on v0.80.0.

Branched off `main` and independent of the other open PRs, so it gets CI immediately.

## The bug

`extractRegionFromHost("api.pricing.us-east-1.amazonaws.com")` returned **`"pricing"`**. With `.amazonaws.com` stripped, `parts` is `[api, pricing, us-east-1]`: the `s3` loop doesn't fire, `parts[1]` isn't `execute-api`, so it fell through to the `<service>.<region>` assumption and returned `parts[1]` — the second label of a three-label host.

## The part worth more than the symptom

The reporter's second suggestion is the one that matters, so this PR leads with it. Handling the `api.` prefix fixes one host layout; the function **failing open** is the class of bug. It returned whichever label sat where a region usually sits, so a caller had no way to distinguish a parse failure from a real region — the wrong answer arrived looking exactly like a right one, which is the same shape of defect as the rest of this batch.

Every candidate is now checked against the shape of a region code before being returned:

- two-letter geography (`us`, `ap`, `il`, `mx`, `cn`, …)
- one or two lowercase words, which covers both `us-east-1` and the four-segment partition forms `us-gov-west-1` / `us-iso-east-1`
- a trailing numeric ordinal

A layout that doesn't match yields `""`, which routes the request through the fallbacks `extractRegion` already had (`parser.go:392-406`): the SigV4 credential scope, then `defaultRegion`. The credential scope is the more trustworthy signal anyway, so failing closed also means it now gets its turn — `TestExtractRegion_UnparseableHostFallsBackToAuth` pins that.

Hand-rolled rather than a regex: the `emulator` package uses `regexp` nowhere in non-test source, and this is four cheap checks on a hot path (every request parses its Host).

## Two hosts that look like regressions and aren't

`my-lb-1234.us-east-1.elb.amazonaws.com` and `my-domain.us-east-1.es.amazonaws.com` reach the `<service>.<region>` branch and keep returning `us-east-1`. That is correct — both genuinely carry the region in the second label, just not by the `<service>.<region>` convention — and the shape check passes it through. Called out because they read like collateral damage at a glance; there are table rows asserting each.

## Verified against

The region table in the [AWS General Reference](https://docs.aws.amazon.com/general/latest/gr/rande.html), which is where the accepted shapes come from: the longest ordinary code is `ap-southeast-7`, the two-word geographies are the GovCloud pair, and the two-letter geography holds across all 36 regions listed plus the China regions.

## Tests

`TestExtractRegionFromHost` is table-driven over 28 rows in three groups:

- **The fix**: both Pricing endpoints (`us-east-1`, `ap-south-1` — the only two the real Price List API has).
- **Shapes that must pass**: `us-gov-west-1`, `ap-southeast-4`, `il-central-1`, `mx-central-1`, `cn-northwest-1`, and every layout that already worked (path-style and virtual-hosted S3, a dotted bucket name, `execute-api`, plain `<service>.<region>`, and a host with a port).
- **Shapes that must fail**, one row per check so a regression names its own cause: two segments, five segments, a three-letter geography, a non-numeric ordinal, digits inside a compass word, an uppercase region, a trailing hyphen.

Plus two tests at the `ParseAWSRequest` boundary, since the helper being right doesn't prove the `RequestContext` a plugin sees is. `TestExtractRegion_APIPrefixedHost` deliberately sends **no** `Authorization` header — a real pricing client signs for `us-east-1`, so the SigV4 fallback would have masked a still-broken parser.

`extractRegionFromHost`, `regionCandidate`, `isLowerAlpha` and `extractRegion` are all at 100%.

## Gates

`go build` ✅ · `go vet` ✅ · `golangci-lint run ./...` **0 issues** ✅ · `make test` (race) ✅ · `test/e2e` ✅ · `make docs-reference-check` ✅ · `make scan-fs` 0 vulns ✅