### PR TITLE
feat(pricing): emulate the Price List Query API over a real offer corpus (#401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InvalidPart` would send a consumer hunting a data bug that does not exist.
 
 ### Fixed
+- The region parsed from a request's `Host` header is now validated against the
+  shape of a region code, and `api.<service>.<region>` hosts are understood
+  (#403). `api.pricing.us-east-1.amazonaws.com` had yielded `pricing` — the
+  second label of a three-label host, returned by the `<service>.<region>`
+  assumption the parser fell through to. The deeper problem was that the
+  function failed *open*: any host layout it did not recognize still produced a
+  confident answer, so a caller could not distinguish a service name
+  masquerading as a region from a real one. An unrecognized layout now yields
+  no region, which routes the request through the fallbacks that already
+  existed — the SigV4 credential scope, then the default region.
 - S3 multipart operations now return S3's documented `NoSuchUpload` and
   `MalformedXML` message text rather than abbreviated paraphrases (#400).
 - S3 `HeadObject` now reports `x-amz-version-id` (#396). `GetObject` always did,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- New `pricing` plugin emulating the AWS Price List Query API — `GetProducts`,
+  `DescribeServices` and `GetAttributeValues` — over `api.pricing.{region}` and
+  `X-Amz-Target: AWSPriceListService.{Op}` (#401). This is the *server* side of
+  pricing, for consumers that query AWS rates at runtime; it is the inverse of
+  Substrate's existing cost-tracking provider, which consumes the public offer
+  index to price simulated usage.
+  The offer corpus is seven Amazon S3 SKUs copied verbatim from the live
+  `AmazonS3/current/us-east-1` offer file, kept small on purpose: each SKU
+  reproduces a response shape callers get wrong. `PriceList` elements are JSON
+  documents encoded as *strings*, not objects. `pricePerUnit`, `beginRange` and
+  `endRange` are strings with trailing zeros, never numbers. `productFamily` is
+  absent from most products — 315 of the 381 in the real file omit it — so a
+  filter on it misses the majority of SKUs, while `usagetype` reaches every one.
+  `TimedStorage-ByteHrs` carries three `priceDimensions`, the last with
+  `"endRange": "Inf"`, so a parser reading only the first reports the
+  first-50 TB rate as the only rate.
+  Two of those shapes are the reporter's own bugs, now reproducible: their static
+  table had `Requests-Tier1` 10× low (it is `"0.0000050000"` per request — $0.005
+  per 1,000, with `unit: Requests`, so dividing by 1,000 again is a 1,000× error),
+  and filtering `productFamily=Storage` with `volumeType="Glacier Deep Archive"`
+  returns *only* `TimedStorage-GDA-Staging` at $0.021/GB-Mo — 21× the $0.00099
+  archive rate. No `TimedStorage-GDA-ByteHrs` SKU exists in the S3 offer file at
+  all, so that filter cannot return the rate a caller expects; the nearest
+  $0.00099 SKU is Intelligent-Tiering's `TimedStorage-INT-DAA-ByteHrs`.
+  `Filter.Type` supports the full documented enum — `TERM_MATCH`, `EQUALS`,
+  `CONTAINS`, `ANY_OF`, `NONE_OF` — not just `TERM_MATCH`. `MaxResults` bounds are
+  per-operation (1–100 for `GetProducts`/`DescribeServices`, 1–**10000** for
+  `GetAttributeValues`), out-of-range values are `InvalidParameterException`
+  rather than a silent clamp, and an unknown `ServiceCode` is `NotFoundException`
+  rather than an empty `PriceList` that would read as "AWS has no such price".
+- Price List failures are seedable via `POST`/`DELETE
+  /v1/pricing/query-failures`, keyed by operation or the `"*"` wildcard (#401).
+  Pricing is the kind of dependency whose failure should degrade a caller rather
+  than stop it, and that property is only testable if the failure can be produced
+  on demand — otherwise the fallback branch is unreachable and a green suite says
+  nothing about it. The seed endpoint rejects any code outside the seven the Price
+  List API documents, because a typo'd code would seed an error no SDK catch
+  branch matches: the fallback path would go untested while the seed appeared to
+  work.
 - S3 `GetObject` and `HeadObject` honor a single-range `Range` header (#396),
   returning `206 Partial Content` with `Content-Range` and a `Content-Length`
   equal to the range served. `docs/services.md` had claimed "Supports Range
@@ -60,6 +99,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   masquerading as a region from a real one. An unrecognized layout now yields
   no region, which routes the request through the fallbacks that already
   existed — the SigV4 credential scope, then the default region.
+- The *service* parsed from a `Host` header now handles the `api.<service>.<region>`
+  layout too (#401). `api.pricing.us-east-1.amazonaws.com` had resolved to a
+  service literally named `api`, so the request could not route to any plugin; the
+  same was true of `api.ecr.*` and `api.sagemaker.*`, which had been reachable
+  only via their `X-Amz-Target` namespace.
 - S3 multipart operations now return S3's documented `NoSuchUpload` and
   `MalformedXML` message text rather than abbreviated paraphrases (#400).
 - S3 `HeadObject` now reports `x-amz-version-id` (#396). `GetObject` always did,

--- a/cmd/gen-service-reference/main.go
+++ b/cmd/gen-service-reference/main.go
@@ -91,6 +91,7 @@ var meta = map[string]pluginMeta{
 	"omics":                {"HealthOmics", "REST/JSON"},
 	"opensearch":           {"OpenSearch", "REST/JSON"},
 	"organizations":        {"Organizations", "JSON"},
+	"pricing":              {"Price List Query API", "JSON"},
 	"quicksight":           {"QuickSight", "REST/JSON"},
 	"ram":                  {"RAM", "JSON"},
 	"rds":                  {"RDS", "Query"},

--- a/docs/services.md
+++ b/docs/services.md
@@ -54,7 +54,7 @@ CloudFormation, and cost detail follows below the matrix.
 | 41 | Organizations | `organizations` | JSON |
 | 42 | Price List Query API | `pricing` | JSON |
 | 43 | QuickSight | `quicksight` | REST/JSON |
-| 44 | RAM | `ram` | JSON |
+| 44 | RAM | `ram` | REST/JSON |
 | 45 | RDS | `rds` | Query |
 | 46 | Redshift | `redshift` | Query |
 | 47 | Redshift Data API | `redshift-data` | JSON |

--- a/docs/services.md
+++ b/docs/services.md
@@ -3,7 +3,7 @@
 ## Coverage matrix
 
 <!-- BEGIN GENERATED COVERAGE MATRIX -->
-Substrate ships **63 built-in service plugins**. This section is generated
+Substrate ships **64 built-in service plugins**. This section is generated
 from the plugin registry (`make docs-reference`), so the count and plugin list
 cannot drift from the implementation. The live count is also available from the
 `/ready` endpoint (`curl http://localhost:4566/ready`). Per-service operation,
@@ -52,28 +52,29 @@ CloudFormation, and cost detail follows below the matrix.
 | 39 | HealthOmics | `omics` | REST/JSON |
 | 40 | OpenSearch | `opensearch` | REST/JSON |
 | 41 | Organizations | `organizations` | JSON |
-| 42 | QuickSight | `quicksight` | REST/JSON |
-| 43 | RAM | `ram` | JSON |
-| 44 | RDS | `rds` | Query |
-| 45 | Redshift | `redshift` | Query |
-| 46 | Redshift Data API | `redshift-data` | JSON |
-| 47 | Route 53 | `route53` | REST/XML |
-| 48 | S3 | `s3` | REST/XML |
-| 49 | SageMaker | `sagemaker` | JSON |
-| 50 | EventBridge Scheduler | `scheduler` | REST/JSON |
-| 51 | Secrets Manager | `secretsmanager` | JSON |
-| 52 | Service Quotas | `servicequotas` | JSON |
-| 53 | SES v2 | `sesv2` | REST/JSON |
-| 54 | SNS | `sns` | Query |
-| 55 | SQS | `sqs` | JSON |
-| 56 | SSM | `ssm` | JSON |
-| 57 | SSO / Identity Store | `sso` | REST/JSON |
-| 58 | Step Functions | `states` | JSON |
-| 59 | STS | `sts` | Query |
-| 60 | Resource Groups Tagging | `tagging` | JSON |
-| 61 | Timestream | `timestream` | JSON |
-| 62 | Transfer Family | `transfer` | JSON |
-| 63 | WAFv2 | `wafv2` | JSON |
+| 42 | Price List Query API | `pricing` | JSON |
+| 43 | QuickSight | `quicksight` | REST/JSON |
+| 44 | RAM | `ram` | JSON |
+| 45 | RDS | `rds` | Query |
+| 46 | Redshift | `redshift` | Query |
+| 47 | Redshift Data API | `redshift-data` | JSON |
+| 48 | Route 53 | `route53` | REST/XML |
+| 49 | S3 | `s3` | REST/XML |
+| 50 | SageMaker | `sagemaker` | JSON |
+| 51 | EventBridge Scheduler | `scheduler` | REST/JSON |
+| 52 | Secrets Manager | `secretsmanager` | JSON |
+| 53 | Service Quotas | `servicequotas` | JSON |
+| 54 | SES v2 | `sesv2` | REST/JSON |
+| 55 | SNS | `sns` | Query |
+| 56 | SQS | `sqs` | JSON |
+| 57 | SSM | `ssm` | JSON |
+| 58 | SSO / Identity Store | `sso` | REST/JSON |
+| 59 | Step Functions | `states` | JSON |
+| 60 | STS | `sts` | Query |
+| 61 | Resource Groups Tagging | `tagging` | JSON |
+| 62 | Timestream | `timestream` | JSON |
+| 63 | Transfer Family | `transfer` | JSON |
+| 64 | WAFv2 | `wafv2` | JSON |
 <!-- END GENERATED COVERAGE MATRIX -->
 
 ---
@@ -1283,6 +1284,121 @@ allow infrastructure code that calls the Health API to run without errors.
 ### Cost
 
 Health API calls are free.
+
+---
+
+## Price List Query API
+
+**Endpoints:** `api.pricing.us-east-1.amazonaws.com`,
+`api.pricing.ap-south-1.amazonaws.com`, `api.pricing.eu-central-1.amazonaws.com`
+**Protocol:** JSON (`X-Amz-Target: AWSPriceListService.{Op}`)
+
+This is the *server* side of pricing — for code that queries AWS rates at
+runtime. It is the inverse of Substrate's own cost-tracking pricing provider,
+which consumes the public offer index to cost simulated usage (the
+`/v1/pricing/refresh`, `/v1/pricing/lookup`, `/v1/pricing/discounts` and
+`/v1/pricing/credits` control endpoints, and the `substrate pricing` command).
+
+The offer corpus is seven Amazon S3 SKUs copied verbatim from the live
+`AmazonS3/current/us-east-1/index.json` offer file (version `20260728131000`).
+It is small on purpose: each SKU exists to reproduce a response shape that
+callers get wrong, so a consumer's parser is tested against real awkwardness
+rather than a tidied-up fixture.
+
+### Supported operations
+
+| Operation | Notes |
+|-----------|-------|
+| GetProducts | `ServiceCode` required; `Filters` 0–50; `MaxResults` 1–100 |
+| DescribeServices | All fields optional; `MaxResults` 1–100 |
+| GetAttributeValues | `AttributeName` **and** `ServiceCode` required; `MaxResults` 1–**10000** |
+
+`FormatVersion` accepts only `aws_v1`, the sole documented value. Pagination
+uses an opaque `NextToken`; a token that does not decode, or that points past the
+end of the result set, is an `InvalidNextTokenException`.
+
+`Filter.Type` supports the full documented enum — `TERM_MATCH`, `EQUALS`,
+`CONTAINS`, `ANY_OF`, `NONE_OF` — not just `TERM_MATCH`. `ANY_OF` and `NONE_OF`
+take a comma-separated `Value`. Filters are conjunctive, and a filter naming a
+field a product does not carry never matches it, including `NONE_OF`.
+
+### Response shapes worth knowing about
+
+These are the traps the corpus deliberately preserves. Each is verified against
+the live offer file.
+
+- **`PriceList` elements are JSON documents encoded as strings**, not objects.
+  Decoding requires a second unmarshal per element.
+- **`pricePerUnit` values are strings** with trailing zeros (`"0.0230000000"`),
+  never numbers. So are `beginRange` and `endRange`.
+- **`productFamily` is absent from most products** — 315 of the 381 in the real
+  S3 offer file omit it. A filter on `productFamily` therefore misses the
+  majority of SKUs. `usagetype` is the attribute that is reliably present and
+  1:1 with a SKU.
+- **`TimedStorage-ByteHrs` carries three `priceDimensions`**, the last with
+  `"endRange": "Inf"`. Reading only the first reports the first-50 TB rate as if
+  it were the only rate.
+- **`Requests-Tier1` is `"0.0000050000"` per request**, and its `unit` is
+  `Requests` — that is $0.005 per 1,000. Dividing by 1,000 again is a 1,000×
+  error.
+- **Filtering `productFamily=Storage` with `volumeType="Glacier Deep Archive"`
+  returns only `TimedStorage-GDA-Staging` at $0.021/GB-Mo** — the staging rate,
+  21× the $0.00099 archive rate. No `TimedStorage-GDA-ByteHrs` SKU exists in the
+  S3 offer file at all, so that filter cannot return the rate a caller expects;
+  the nearest $0.00099 SKU is Intelligent-Tiering's
+  `TimedStorage-INT-DAA-ByteHrs`.
+
+An unknown `ServiceCode` is a `NotFoundException` rather than an empty
+`PriceList`. Substrate's corpus is far smaller than AWS's catalog, and a loud
+error is better than an empty result that reads as "AWS has no such price".
+
+### Endpoint regions — a deliberate divergence
+
+AWS hosts the Price List Query API in exactly three regions: `us-east-1`,
+`ap-south-1` and `eu-central-1`. There is no `api.pricing.eu-west-1.amazonaws.com`
+to resolve.
+
+Substrate serves every region from one endpoint, so it cannot reproduce a name
+that fails to resolve. Instead, a request signed for any other region is rejected
+with **`SubstrateInvalidPricingEndpoint`** (HTTP 400). The code is deliberately
+not an AWS code — this is Substrate reporting a condition AWS surfaces at the
+transport layer, and naming it as such is better than silently pricing a request
+against an endpoint that does not exist.
+
+### Seeding failures
+
+Pricing is the kind of dependency whose failure should degrade a caller, not stop
+it. That property is only testable if the failure can be produced on demand:
+
+```bash
+# Fail one operation.
+curl -X POST http://localhost:4566/v1/pricing/query-failures \
+  -d '{"operation":"GetProducts","code":"ThrottlingException","message":"Rate exceeded"}'
+
+# Fail every operation (wildcard).
+curl -X POST http://localhost:4566/v1/pricing/query-failures \
+  -d '{"code":"InternalErrorException"}'
+
+# Clear one, or all.
+curl -X DELETE 'http://localhost:4566/v1/pricing/query-failures?operation=GetProducts'
+curl -X DELETE http://localhost:4566/v1/pricing/query-failures
+```
+
+An operation-specific seed takes precedence over the wildcard. `statusCode`
+defaults to the status the Price List API documents for the code — 400 for every
+documented code except `InternalErrorException`, which is 500 — and may be
+overridden explicitly.
+
+`code` must be one of the seven codes the Price List API documents:
+`AccessDeniedException`, `ExpiredNextTokenException`, `InvalidNextTokenException`,
+`InvalidParameterException`, `NotFoundException`, `ThrottlingException`,
+`InternalErrorException`. Anything else is rejected with a 400, because a typo'd
+code would seed an error no SDK catch branch matches — the fallback path would go
+untested while the seed itself appeared to work.
+
+### Cost
+
+Price List API calls are free.
 
 ---
 

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -34,6 +34,9 @@ func NormalizeS3VirtualHostForTest(host, urlPath string) (bucket, normPath strin
 	return normalizeS3VirtualHost(host, urlPath)
 }
 
+// ExtractRegionFromHostForTest wraps extractRegionFromHost for external tests.
+func ExtractRegionFromHostForTest(host string) string { return extractRegionFromHost(host) }
+
 // ExtractAccessKeyFromAuthForTest wraps extractAccessKeyFromAuth for external tests.
 func ExtractAccessKeyFromAuthForTest(authHeader string) string {
 	return extractAccessKeyFromAuth(authHeader)

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -408,6 +408,10 @@ func extractRegion(host, authHeader string) string {
 // extractRegionFromHost parses the region segment from a Host header value
 // such as "s3.us-west-2.amazonaws.com" or
 // "mybucket.s3.us-east-1.amazonaws.com" (virtual-hosted S3).
+//
+// Every candidate is checked against the shape of a region code before being
+// returned, so an unrecognized host layout yields "" rather than a service name
+// masquerading as a region; see regionCandidate.
 func extractRegionFromHost(host string) string {
 	// Strip port if present.
 	if colon := strings.LastIndexByte(host, ':'); colon > 0 {
@@ -426,7 +430,7 @@ func extractRegionFromHost(host string) string {
 	for i, p := range parts {
 		if p == "s3" {
 			if i+1 < len(parts) {
-				return parts[i+1]
+				return regionCandidate(parts[i+1])
 			}
 			return "" // s3 at the end → global, no region
 		}
@@ -434,14 +438,77 @@ func extractRegionFromHost(host string) string {
 
 	// execute-api runtime: "{apiId}.execute-api.{region}".
 	if len(parts) >= 3 && parts[1] == "execute-api" {
-		return parts[2]
+		return regionCandidate(parts[2])
+	}
+
+	// "api.<service>.<region>": the layout the Price List Query API and other
+	// services that front their endpoint with a literal "api" label use, e.g.
+	// "api.pricing.us-east-1.amazonaws.com". Without this the region is read
+	// from the wrong label (#403).
+	if len(parts) >= 3 && parts[0] == "api" {
+		return regionCandidate(parts[2])
 	}
 
 	// Non-S3: "<service>.<region>" or just "<service>".
 	if len(parts) < 2 {
 		return ""
 	}
-	return parts[1]
+	return regionCandidate(parts[1])
+}
+
+// regionCandidate returns s when it has the shape of an AWS region code, and ""
+// otherwise.
+//
+// This is what makes extractRegionFromHost fail closed. Without it, a host
+// layout the parser does not recognize still produced an answer — whichever
+// label happened to sit in the position a region usually occupies, which is
+// typically a service name — and a caller had no way to tell that apart from a
+// real region. Returning "" instead routes the request through the fallbacks
+// extractRegion already has: the SigV4 credential scope, then defaultRegion.
+//
+// The shape is a two-letter geography, one or two lowercase words, and a
+// trailing ordinal: "us-east-1", "ap-southeast-4", "il-central-1",
+// "cn-northwest-1", and the four-segment partition forms "us-gov-west-1" and
+// "us-iso-east-1". Verified against the region table in the AWS General
+// Reference (docs.aws.amazon.com/general/latest/gr/rande.html).
+func regionCandidate(s string) string {
+	segs := strings.Split(s, "-")
+	if len(segs) < 3 || len(segs) > 4 {
+		return ""
+	}
+	// Geography: exactly two lowercase letters — us, ap, eu, af, me, sa, ca,
+	// il, mx, cn.
+	if len(segs[0]) != 2 || !isLowerAlpha(segs[0]) {
+		return ""
+	}
+	// Compass and partition words: east, southeast, central, gov, iso.
+	for _, seg := range segs[1 : len(segs)-1] {
+		if seg == "" || !isLowerAlpha(seg) {
+			return ""
+		}
+	}
+	// Trailing ordinal: digits only.
+	last := segs[len(segs)-1]
+	if last == "" {
+		return ""
+	}
+	for _, c := range last {
+		if c < '0' || c > '9' {
+			return ""
+		}
+	}
+	return s
+}
+
+// isLowerAlpha reports whether s consists only of the ASCII letters a-z. An
+// empty string satisfies it vacuously; callers that care reject "" themselves.
+func isLowerAlpha(s string) bool {
+	for _, c := range s {
+		if c < 'a' || c > 'z' {
+			return false
+		}
+	}
+	return true
 }
 
 // normalizeS3VirtualHost detects an S3 virtual-hosted-style request

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -245,6 +245,10 @@ var targetServiceAliases = map[string]string{
 	// "RedshiftData_20191217" → strip version → "RedshiftData" → lowercase → "redshiftdata".
 	// Both aws-sdk-go-v2 and boto3 use this X-Amz-Target namespace for the Data API.
 	"redshiftdata": "redshift-data",
+	// "AWSPriceListService" → no strip → "awspricelistservice" → "pricing".
+	// Both aws-sdk-go-v2 and boto3 use X-Amz-Target: AWSPriceListService.{Op}
+	// for the Price List Query API, whose SigV4 signing name is "pricing".
+	"awspricelistservice": "pricing",
 }
 
 // extractServiceFromTarget parses an X-Amz-Target value such as
@@ -304,6 +308,15 @@ func extractServiceFromHost(host string) string {
 	// API Gateway runtime endpoint: {apiId}.execute-api.{region}
 	if strings.Contains(host, ".execute-api.") {
 		return "execute-api"
+	}
+
+	// "api.<service>.<region>": several services front their endpoint with a
+	// literal "api" label — the Price List Query API
+	// (api.pricing.us-east-1.amazonaws.com), ECR (api.ecr.*), SageMaker
+	// (api.sagemaker.*). Taking the first label would route all of them to a
+	// service named "api" (#401).
+	if rest, ok := strings.CutPrefix(host, "api."); ok && rest != "" {
+		host = rest
 	}
 
 	// "<service>.<region>" or just "<service>".

--- a/emulator/parser_test.go
+++ b/emulator/parser_test.go
@@ -190,6 +190,103 @@ func TestParseAWSRequest_Region(t *testing.T) {
 	}
 }
 
+// TestExtractRegionFromHost covers every host layout the parser recognizes, plus
+// the layouts it must refuse to guess at.
+//
+// The refusals are the point of #403. The function used to fall through to a
+// "<service>.<region>" assumption and return the second label of whatever it was
+// given, so "api.pricing.us-east-1.amazonaws.com" yielded "pricing" — a service
+// name presented as a region, indistinguishable to the caller from a real one.
+func TestExtractRegionFromHost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		// The reported bug: "api.<service>.<region>".
+		{"api-prefixed pricing host", "api.pricing.us-east-1.amazonaws.com", "us-east-1"},
+		{"api-prefixed pricing ap-south-1", "api.pricing.ap-south-1.amazonaws.com", "ap-south-1"},
+
+		// Region shapes that must all be accepted. Codes taken from the region
+		// table in the AWS General Reference.
+		{"four-segment gov partition", "ec2.us-gov-west-1.amazonaws.com", "us-gov-west-1"},
+		{"long compass word", "ec2.ap-southeast-4.amazonaws.com", "ap-southeast-4"},
+		{"il geography", "ec2.il-central-1.amazonaws.com", "il-central-1"},
+		{"mx geography", "ec2.mx-central-1.amazonaws.com", "mx-central-1"},
+		{"cn geography", "ec2.cn-northwest-1.amazonaws.com", "cn-northwest-1"},
+
+		// Pre-existing layouts, which must keep parsing as they did.
+		{"path-style s3 regional", "s3.us-west-2.amazonaws.com", "us-west-2"},
+		{"virtual-hosted s3 regional", "mybucket.s3.us-east-1.amazonaws.com", "us-east-1"},
+		{"dotted bucket virtual-hosted", "my.bucket.s3.us-west-2.amazonaws.com", "us-west-2"},
+		{"execute-api runtime", "abc123.execute-api.us-east-1.amazonaws.com", "us-east-1"},
+		{"plain service regional", "dynamodb.ap-southeast-1.amazonaws.com", "ap-southeast-1"},
+		{"regional host with port", "dynamodb.eu-west-1.amazonaws.com:443", "eu-west-1"},
+
+		// Hosts that carry the region in the second label for reasons of their own
+		// rather than by the "<service>.<region>" convention. The shape check
+		// passes them through, which is the right answer.
+		{"elb dns name", "my-lb-1234.us-east-1.elb.amazonaws.com", "us-east-1"},
+		{"opensearch domain", "my-domain.us-east-1.es.amazonaws.com", "us-east-1"},
+
+		// Layouts with no region to find: the function must yield "" so the
+		// caller falls back rather than acting on a guess.
+		{"global s3", "s3.amazonaws.com", ""},
+		{"bare service host", "iam.amazonaws.com", ""},
+		{"virtual-hosted s3 global", "mybucket.s3.amazonaws.com", ""},
+		{"api-prefixed global host", "api.pricing.amazonaws.com", ""},
+		{"not an aws host", "localhost:4566", ""},
+		{"empty host", "", ""},
+
+		// Near-misses on the region shape, each failing a different check.
+		{"two segments only", "svc.us-east.amazonaws.com", ""},
+		{"five segments", "svc.us-gov-iso-east-1.amazonaws.com", ""},
+		{"three-letter geography", "svc.usa-east-1.amazonaws.com", ""},
+		{"non-numeric ordinal", "svc.us-east-one.amazonaws.com", ""},
+		{"digits in compass word", "svc.us-e4st-1.amazonaws.com", ""},
+		{"uppercase region", "svc.US-EAST-1.amazonaws.com", ""},
+		{"trailing hyphen", "svc.us-east-.amazonaws.com", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, emulator.ExtractRegionFromHostForTest(tt.host))
+		})
+	}
+}
+
+// TestExtractRegion_APIPrefixedHost asserts the fix reaches the RequestContext a
+// plugin actually sees, not just the helper. A pricing client signs for
+// us-east-1, so the SigV4 fallback would mask a parser that still returned
+// "pricing" — this sends no Authorization header so the host is the only signal.
+func TestExtractRegion_APIPrefixedHost(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "http://localhost/", nil)
+	r.Host = "api.pricing.us-east-1.amazonaws.com"
+
+	_, reqCtx, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1", reqCtx.Region)
+}
+
+// TestExtractRegion_UnparseableHostFallsBackToAuth is the payoff of failing
+// closed: because the host no longer yields a bogus region, the SigV4 credential
+// scope — which is authoritative — gets its turn.
+func TestExtractRegion_UnparseableHostFallsBackToAuth(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "http://localhost/", nil)
+	r.Host = "api.pricing.amazonaws.com"
+	r.Header.Set("Authorization",
+		"AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/ap-south-1/pricing/aws4_request, "+
+			"SignedHeaders=host, Signature=abc")
+
+	_, reqCtx, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	assert.Equal(t, "ap-south-1", reqCtx.Region)
+}
+
 func TestParseAWSRequest_Account(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/emulator/parser_test.go
+++ b/emulator/parser_test.go
@@ -287,6 +287,58 @@ func TestExtractRegion_UnparseableHostFallsBackToAuth(t *testing.T) {
 	assert.Equal(t, "ap-south-1", reqCtx.Region)
 }
 
+// TestExtractService_APIPrefixedHost covers the service half of the same host
+// layout (#401). Taking the first label of "api.pricing.us-east-1" yielded a
+// service literally named "api", which routes to no plugin at all — so these
+// endpoints were reachable only via their X-Amz-Target namespace. No
+// Authorization header is sent, because the credential scope also names the
+// service and would mask a parser that still returned "api".
+func TestExtractService_APIPrefixedHost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{"pricing regional", "api.pricing.us-east-1.amazonaws.com", "pricing"},
+		{"pricing global", "api.pricing.amazonaws.com", "pricing"},
+		// Two other services that front their endpoint with a literal "api"
+		// label, both previously reachable only by X-Amz-Target.
+		{"ecr regional", "api.ecr.us-west-2.amazonaws.com", "ecr"},
+		{"sagemaker regional", "api.sagemaker.eu-west-1.amazonaws.com", "sagemaker"},
+		// A service whose own name merely begins with "api" must not be
+		// truncated: the prefix stripped is the label "api.", not the letters.
+		{"apigateway is not api-prefixed", "apigateway.us-east-1.amazonaws.com", "apigateway"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodPost, "http://localhost/", nil)
+			r.Host = tt.host
+
+			req, _, err := emulator.ParseAWSRequest(r)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, req.Service)
+		})
+	}
+}
+
+// TestExtractService_PriceListTarget pins the X-Amz-Target namespace both
+// aws-sdk-go-v2 and boto3 use for the Price List Query API. Its SigV4 signing
+// name is "pricing", which is the plugin's own name, so the alias is what closes
+// the gap between the two spellings.
+func TestExtractService_PriceListTarget(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest(http.MethodPost, "http://localhost/", nil)
+	r.Host = "localhost:4566"
+	r.Header.Set("X-Amz-Target", "AWSPriceListService.GetProducts")
+
+	req, _, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	assert.Equal(t, "pricing", req.Service)
+	assert.Equal(t, "GetProducts", req.Operation)
+}
+
 func TestParseAWSRequest_Account(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/emulator/plugins.go
+++ b/emulator/plugins.go
@@ -420,6 +420,15 @@ func RegisterDefaultPlugins(
 	}
 	registry.Register(healthPlugin)
 
+	priceListPlugin := &PriceListPlugin{}
+	if err := priceListPlugin.Initialize(ctx, PluginConfig{
+		State:  state,
+		Logger: logger,
+	}); err != nil {
+		return fmt.Errorf("initialize pricing plugin: %w", err)
+	}
+	registry.Register(priceListPlugin)
+
 	orgsPlugin := &OrganizationsPlugin{}
 	if err := orgsPlugin.Initialize(ctx, PluginConfig{
 		State:   state,

--- a/emulator/pricing_offer_fixture.go
+++ b/emulator/pricing_offer_fixture.go
@@ -1,0 +1,347 @@
+package emulator
+
+// This file holds the offer corpus the Price List Query API serves (#401).
+//
+// Every SKU, attribute value, rate code, offer-term code and price string below
+// is copied from the live AWS offer file
+// https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonS3/current/us-east-1/index.json
+// (version 20260728131000, publicationDate 2026-07-28T13:10:00Z). Nothing here is
+// invented, because the point of the corpus is to reproduce the shapes that
+// surprise a caller — and a tidied-up fixture would let a consumer's code pass
+// its tests and then misbehave against the real API. The specific traps, each
+// verified in that file:
+//
+//   - PriceList elements are JSON *documents encoded as strings*, not objects.
+//   - pricePerUnit values are strings with trailing zeros ("0.0230000000"), not
+//     numbers.
+//   - productFamily is absent from most products — 315 of the 381 in the real S3
+//     offer file omit it — so a caller that filters on it will miss most SKUs.
+//     usagetype is the attribute that is reliably present and 1:1.
+//   - TimedStorage-ByteHrs carries three priceDimensions, the last with
+//     "endRange": "Inf". A parser that takes the first dimension silently reports
+//     the 50 TB tier rate as if it were the only one.
+//   - Filtering productFamily=Storage with volumeType="Glacier Deep Archive"
+//     returns *only* TimedStorage-GDA-Staging at $0.021/GB-Mo — the staging rate,
+//     21x the $0.00099 archive rate. There is no GDA-ByteHrs SKU in the S3 offer
+//     file at all, so this filter cannot return the rate a caller expects; the
+//     nearest $0.00099 SKU is Intelligent-Tiering's TimedStorage-INT-DAA-ByteHrs.
+//
+// See docs/services.md for the served operations and the seed endpoints.
+
+// pricingFormatVersion is the only FormatVersion the Price List API defines.
+const pricingFormatVersion = "aws_v1"
+
+// pricingOfferVersion and pricingOfferPublicationDate identify the offer file
+// revision the corpus below was taken from. They are embedded in each PriceList
+// document exactly as the real API emits them.
+const (
+	pricingOfferVersion         = "20260728131000"
+	pricingOfferPublicationDate = "2026-07-28T13:10:00Z"
+)
+
+// pricingOfferTermCode is the on-demand offer-term code. AWS uses the same
+// literal for every on-demand term across every service.
+const pricingOfferTermCode = "JRTCKXETXF"
+
+// pricingPriceDimension is one rate within an offer term. A tiered SKU has
+// several, distinguished by BeginRange/EndRange.
+type pricingPriceDimension struct {
+	// RateCode is "<sku>.<offerTermCode>.<dimensionCode>".
+	RateCode string `json:"rateCode"`
+
+	// Description is AWS's own human-readable rate text, kept verbatim because
+	// some callers parse the dollar figure out of it.
+	Description string `json:"description"`
+
+	// BeginRange and EndRange bound the tier. EndRange is the literal string
+	// "Inf" on the final tier, not a number and not null.
+	BeginRange string `json:"beginRange"`
+	EndRange   string `json:"endRange"`
+
+	// Unit is the billing unit, e.g. "GB-Mo" or "Requests".
+	Unit string `json:"unit"`
+
+	// PricePerUnit maps a currency code to the rate as a *string*, e.g.
+	// "0.0230000000". AWS never emits it as a number.
+	PricePerUnit map[string]string `json:"pricePerUnit"`
+
+	// AppliesTo is present but empty on every on-demand dimension AWS emits.
+	AppliesTo []string `json:"appliesTo"`
+}
+
+// pricingTerm is one offer term for a SKU.
+type pricingTerm struct {
+	SKU             string                           `json:"sku"`
+	OfferTermCode   string                           `json:"offerTermCode"`
+	EffectiveDate   string                           `json:"effectiveDate"`
+	PriceDimensions map[string]pricingPriceDimension `json:"priceDimensions"`
+	TermAttributes  map[string]string                `json:"termAttributes"`
+}
+
+// pricingProduct is the product half of a PriceList document.
+type pricingProduct struct {
+	SKU string `json:"sku"`
+
+	// ProductFamily is omitted when the product has none, which is the common
+	// case rather than the exception. omitempty is what reproduces that.
+	ProductFamily string `json:"productFamily,omitempty"`
+
+	Attributes map[string]string `json:"attributes"`
+}
+
+// pricingOfferDoc is one element of a GetProducts PriceList — the structure that
+// gets marshaled and then embedded in the response as a *string*.
+type pricingOfferDoc struct {
+	Product         pricingProduct                    `json:"product"`
+	ServiceCode     string                            `json:"serviceCode"`
+	Terms           map[string]map[string]pricingTerm `json:"terms"`
+	Version         string                            `json:"version"`
+	PublicationDate string                            `json:"publicationDate"`
+}
+
+// pricingCorpusEntry is a SKU in substrate's offer corpus, before assembly into
+// a pricingOfferDoc.
+type pricingCorpusEntry struct {
+	sku           string
+	serviceCode   string
+	productFamily string
+	attributes    map[string]string
+	effectiveDate string
+	dimensions    []pricingPriceDimension
+}
+
+// pricingServiceCodeS3 is the Price List service code for Amazon S3. It is not
+// the same string as substrate's own "s3" service name.
+const pricingServiceCodeS3 = "AmazonS3"
+
+// pricingCorpus is the seven-SKU offer corpus substrate serves. It is
+// deliberately small: each entry exists to exhibit a specific shape a caller
+// must handle, and the set is ordered so that iteration is stable.
+//
+//nolint:gochecknoglobals // Immutable reference data, read-only after init.
+var pricingCorpus = []pricingCorpusEntry{
+	{
+		// Tiered storage: three dimensions, final EndRange "Inf". A caller that
+		// reads only the first reports the 50 TB rate for a 600 TB bucket.
+		sku:           "WP9ANXZGBYYSGJEA",
+		serviceCode:   pricingServiceCodeS3,
+		productFamily: "Storage",
+		attributes: map[string]string{
+			"availability": "99.99%", "durability": "99.999999999%",
+			"location": "US East (N. Virginia)", "locationType": "AWS Region",
+			"operation": "", "regionCode": "us-east-1",
+			"servicecode": pricingServiceCodeS3, "servicename": "Amazon Simple Storage Service",
+			"storageClass": "General Purpose", "usagetype": "TimedStorage-ByteHrs",
+			"volumeType": "Standard",
+		},
+		effectiveDate: "2026-07-01T00:00:00Z",
+		dimensions: []pricingPriceDimension{
+			{
+				RateCode:    "WP9ANXZGBYYSGJEA.JRTCKXETXF.PGHJ3S3EYE",
+				Description: "$0.023 per GB - first 50 TB / month of storage used",
+				BeginRange:  "0", EndRange: "51200", Unit: "GB-Mo",
+				PricePerUnit: map[string]string{"USD": "0.0230000000"}, AppliesTo: []string{},
+			},
+			{
+				RateCode:    "WP9ANXZGBYYSGJEA.JRTCKXETXF.D42MF2PVJS",
+				Description: "$0.022 per GB - next 450 TB / month of storage used",
+				BeginRange:  "51200", EndRange: "512000", Unit: "GB-Mo",
+				PricePerUnit: map[string]string{"USD": "0.0220000000"}, AppliesTo: []string{},
+			},
+			{
+				RateCode:    "WP9ANXZGBYYSGJEA.JRTCKXETXF.PXJDJ3YRG3",
+				Description: "$0.021 per GB - storage used / month over 500 TB",
+				BeginRange:  "512000", EndRange: "Inf", Unit: "GB-Mo",
+				PricePerUnit: map[string]string{"USD": "0.0210000000"}, AppliesTo: []string{},
+			},
+		},
+	},
+	{
+		// The rate the reporter's static table had 10x low: $0.005 per 1,000 is
+		// $0.000005 per request, and the unit is "Requests" — per-request, not
+		// per-thousand. Reading the figure out of the description instead of the
+		// pricePerUnit is how a 1000x error gets made.
+		sku:           "E9YHNFENF4XQBZR6",
+		serviceCode:   pricingServiceCodeS3,
+		productFamily: "API Request",
+		attributes: map[string]string{
+			"group": "S3-API-Tier1", "groupDescription": "PUT/COPY/POST or LIST requests",
+			"location": "US East (N. Virginia)", "locationType": "AWS Region",
+			"operation": "", "regionCode": "us-east-1",
+			"servicecode": pricingServiceCodeS3, "servicename": "Amazon Simple Storage Service",
+			"usagetype": "Requests-Tier1",
+		},
+		effectiveDate: "2026-07-01T00:00:00Z",
+		dimensions: []pricingPriceDimension{{
+			RateCode:    "E9YHNFENF4XQBZR6.JRTCKXETXF.6YS6EN2CT7",
+			Description: "$0.005 per 1,000 PUT, COPY, POST, or LIST requests",
+			BeginRange:  "0", EndRange: "Inf", Unit: "Requests",
+			PricePerUnit: map[string]string{"USD": "0.0000050000"}, AppliesTo: []string{},
+		}},
+	},
+	{
+		// GET requests are quoted per 10,000, not per 1,000 — the denominator
+		// changes between Tier1 and Tier2 while the unit stays "Requests".
+		sku:           "ZWQ6Q48CRJXX4FXE",
+		serviceCode:   pricingServiceCodeS3,
+		productFamily: "API Request",
+		attributes: map[string]string{
+			"group": "S3-API-Tier2", "groupDescription": "GET and all other requests",
+			"location": "US East (N. Virginia)", "locationType": "AWS Region",
+			"operation": "", "regionCode": "us-east-1",
+			"servicecode": pricingServiceCodeS3, "servicename": "Amazon Simple Storage Service",
+			"usagetype": "Requests-Tier2",
+		},
+		effectiveDate: "2026-07-01T00:00:00Z",
+		dimensions: []pricingPriceDimension{{
+			RateCode:    "ZWQ6Q48CRJXX4FXE.JRTCKXETXF.6YS6EN2CT7",
+			Description: "$0.004 per 10,000 GET and all other requests",
+			BeginRange:  "0", EndRange: "Inf", Unit: "Requests",
+			PricePerUnit: map[string]string{"USD": "0.0000004000"}, AppliesTo: []string{},
+		}},
+	},
+	{
+		// The Deep Archive decoy. This is the *only* SKU in the real S3 offer
+		// file matching productFamily=Storage + volumeType="Glacier Deep
+		// Archive", and it prices staging storage at $0.021 — 21x the $0.00099 a
+		// caller filtering that way is looking for.
+		sku:           "EXB3YJ6YV5CRH4JN",
+		serviceCode:   pricingServiceCodeS3,
+		productFamily: "Storage",
+		attributes: map[string]string{
+			"availability": "99.99%", "durability": "99.999999999%",
+			"location": "US East (N. Virginia)", "locationType": "AWS Region",
+			"operation": "", "regionCode": "us-east-1",
+			"servicecode": pricingServiceCodeS3, "servicename": "Amazon Simple Storage Service",
+			"storageClass": "Archive", "usagetype": "TimedStorage-GDA-Staging",
+			"volumeType": "Glacier Deep Archive",
+		},
+		effectiveDate: "2026-07-01T00:00:00Z",
+		dimensions: []pricingPriceDimension{{
+			RateCode:    "EXB3YJ6YV5CRH4JN.JRTCKXETXF.6YS6EN2CT7",
+			Description: "$0.021 per GB-Month of storage used in GlacierStagingStorage",
+			BeginRange:  "0", EndRange: "Inf", Unit: "GB-Mo",
+			PricePerUnit: map[string]string{"USD": "0.0210000000"}, AppliesTo: []string{},
+		}},
+	},
+	{
+		// The $0.00099 rate, which lives under Intelligent-Tiering rather than
+		// under any Glacier Deep Archive SKU. Included so a filter aiming for
+		// $0.00099 can be tested for reaching the right SKU, not just the right
+		// number.
+		sku:           "82TFRVR9729PGTNP",
+		serviceCode:   pricingServiceCodeS3,
+		productFamily: "Storage",
+		attributes: map[string]string{
+			"availability": "N/A", "durability": "N/A",
+			"location": "US East (N. Virginia)", "locationType": "AWS Region",
+			"operation": "", "regionCode": "us-east-1",
+			"servicecode": pricingServiceCodeS3, "servicename": "Amazon Simple Storage Service",
+			"storageClass": "Intelligent-Tiering", "usagetype": "TimedStorage-INT-DAA-ByteHrs",
+			"volumeType": "IntelligentTieringDeepArchiveAccess",
+		},
+		effectiveDate: "2026-07-01T00:00:00Z",
+		dimensions: []pricingPriceDimension{{
+			RateCode: "82TFRVR9729PGTNP.JRTCKXETXF.6YS6EN2CT7",
+			Description: "$0.00099 per Gigabyte Month for TimedStorage-INT-DAA-ByteHrs:" +
+				"IntelligentTieringDAAStorage in US East (N. Virginia)",
+			BeginRange: "0", EndRange: "Inf", Unit: "GB-Mo",
+			PricePerUnit: map[string]string{"USD": "0.0009900000"}, AppliesTo: []string{},
+		}},
+	},
+	{
+		// Standard-IA, so that a storageClass filter has more than one candidate
+		// and a test can prove it selected rather than took the only match.
+		sku:           "379GYJUQ5WFBUYGM",
+		serviceCode:   pricingServiceCodeS3,
+		productFamily: "Storage",
+		attributes: map[string]string{
+			"availability": "99.9%", "durability": "99.999999999%",
+			"location": "US East (N. Virginia)", "locationType": "AWS Region",
+			"operation": "", "regionCode": "us-east-1",
+			"servicecode": pricingServiceCodeS3, "servicename": "Amazon Simple Storage Service",
+			"storageClass": "Infrequent Access", "usagetype": "TimedStorage-SIA-ByteHrs",
+			"volumeType": "Standard - Infrequent Access",
+		},
+		effectiveDate: "2026-07-01T00:00:00Z",
+		dimensions: []pricingPriceDimension{{
+			RateCode:    "379GYJUQ5WFBUYGM.JRTCKXETXF.6YS6EN2CT7",
+			Description: "$0.0125 per GB-Month of storage used in Standard-Infrequent Access",
+			BeginRange:  "0", EndRange: "Inf", Unit: "GB-Mo",
+			PricePerUnit: map[string]string{"USD": "0.0125000000"}, AppliesTo: []string{},
+		}},
+	},
+	{
+		// productFamily absent, which is the majority case in the real file. Note
+		// it still has a usagetype, so a caller keying on usagetype finds it and
+		// a caller filtering on productFamily does not.
+		sku:         "WDAC2WRXVNRSNQS6",
+		serviceCode: pricingServiceCodeS3,
+		attributes: map[string]string{
+			"group": "S3-API-GDA-Tier2", "groupDescription": "GET and all other requests to GDA",
+			"location": "US East (N. Virginia)", "locationType": "AWS Region",
+			"operation": "", "regionCode": "us-east-1",
+			"servicecode": pricingServiceCodeS3, "servicename": "Amazon Simple Storage Service",
+			"usagetype": "Requests-GDA-Tier2",
+		},
+		effectiveDate: "2026-07-01T00:00:00Z",
+		dimensions: []pricingPriceDimension{{
+			RateCode:    "WDAC2WRXVNRSNQS6.JRTCKXETXF.6YS6EN2CT7",
+			Description: "$0.004 per 10,000 GET and all other requests from Glacier",
+			BeginRange:  "0", EndRange: "Inf", Unit: "Requests",
+			PricePerUnit: map[string]string{"USD": "0.0000004000"}, AppliesTo: []string{},
+		}},
+	},
+}
+
+// offerDoc assembles the entry into the document shape GetProducts serializes.
+func (e pricingCorpusEntry) offerDoc() pricingOfferDoc {
+	termKey := e.sku + "." + pricingOfferTermCode
+	dims := make(map[string]pricingPriceDimension, len(e.dimensions))
+	for _, d := range e.dimensions {
+		dims[d.RateCode] = d
+	}
+	return pricingOfferDoc{
+		Product: pricingProduct{
+			SKU:           e.sku,
+			ProductFamily: e.productFamily,
+			Attributes:    e.attributes,
+		},
+		ServiceCode: e.serviceCode,
+		Terms: map[string]map[string]pricingTerm{
+			"OnDemand": {termKey: {
+				SKU:             e.sku,
+				OfferTermCode:   pricingOfferTermCode,
+				EffectiveDate:   e.effectiveDate,
+				PriceDimensions: dims,
+				TermAttributes:  map[string]string{},
+			}},
+		},
+		Version:         pricingOfferVersion,
+		PublicationDate: pricingOfferPublicationDate,
+	}
+}
+
+// pricingServiceAttributes lists the attribute names DescribeServices reports
+// for a service code. Every name is one that actually appears in the offer
+// corpus, so a caller can move from DescribeServices to GetAttributeValues to a
+// GetProducts filter without hitting an attribute that yields nothing.
+//
+//nolint:gochecknoglobals // Immutable reference data, read-only after init.
+var pricingServiceAttributes = map[string][]string{
+	pricingServiceCodeS3: {
+		"availability",
+		"durability",
+		"group",
+		"groupDescription",
+		"location",
+		"locationType",
+		"operation",
+		"regionCode",
+		"servicecode",
+		"servicename",
+		"storageClass",
+		"usagetype",
+		"volumeType",
+	},
+}

--- a/emulator/pricing_plugin.go
+++ b/emulator/pricing_plugin.go
@@ -1,0 +1,698 @@
+package emulator
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// pricingNamespace is the service name used by PriceListPlugin. It is the SigV4
+// signing name of the Price List Query API, so a request routed by credential
+// scope lands here without an alias.
+const pricingNamespace = "pricing"
+
+// pricingCtrlNamespace is the state namespace holding seeded Price List
+// failures. It is distinct from the pricingNamespace the plugin serves from so
+// that clearing seeds can never touch the offer corpus.
+const pricingCtrlNamespace = "pricing-ctrl"
+
+// pricingEndpointRegions are the regions in which AWS hosts a Price List Query
+// API endpoint. Every other region has no such endpoint at all — there is no
+// api.pricing.eu-west-1.amazonaws.com to resolve.
+//
+// Substrate rejects a request signed for any other region with
+// [pricingErrCodeInvalidRegion]. That is a deliberate divergence from AWS, which
+// fails DNS resolution at the transport layer long before a request is sent:
+// substrate serves every region from one endpoint and so cannot reproduce a name
+// that does not resolve. Returning a legible API error is the closest available
+// signal, and is far better than pricing a request substrate was never asked to
+// price. See docs/services.md.
+//
+//nolint:gochecknoglobals // Immutable reference data, read-only after init.
+var pricingEndpointRegions = map[string]bool{
+	"us-east-1":    true,
+	"ap-south-1":   true,
+	"eu-central-1": true,
+}
+
+// Price List error codes. Every one below is from the AWS Price List Query API
+// reference; all map to HTTP 400 except InternalErrorException, which is 500.
+const (
+	pricingErrAccessDenied     = "AccessDeniedException"
+	pricingErrExpiredNextToken = "ExpiredNextTokenException"
+	pricingErrInvalidNextToken = "InvalidNextTokenException"
+	pricingErrInvalidParameter = "InvalidParameterException"
+	pricingErrNotFound         = "NotFoundException"
+	pricingErrThrottling       = "ThrottlingException"
+	pricingErrInternalError    = "InternalErrorException"
+
+	// pricingErrCodeInvalidRegion is substrate's own code for a request signed
+	// for a region with no Price List endpoint. It is not an AWS code, and is
+	// named so that it cannot be mistaken for one.
+	pricingErrCodeInvalidRegion = "SubstrateInvalidPricingEndpoint"
+)
+
+// pricingSeedableErrorCodes is the set of error codes a Price List failure may
+// be seeded with.
+//
+// The seed endpoint rejects anything else. A typo'd code would otherwise produce
+// an error whose Code no consumer's catch branch matches, so their fallback path
+// would go untested while the seed appeared to work — the same silent-green
+// failure this plugin exists to make impossible.
+//
+//nolint:gochecknoglobals // Immutable reference data, read-only after init.
+var pricingSeedableErrorCodes = map[string]bool{
+	pricingErrAccessDenied:     true,
+	pricingErrExpiredNextToken: true,
+	pricingErrInvalidNextToken: true,
+	pricingErrInvalidParameter: true,
+	pricingErrNotFound:         true,
+	pricingErrThrottling:       true,
+	pricingErrInternalError:    true,
+}
+
+// pricingSeedableCodeList returns the sorted seedable error codes, for use in
+// the seed endpoint's rejection message.
+func pricingSeedableCodeList() []string {
+	codes := make([]string, 0, len(pricingSeedableErrorCodes))
+	for c := range pricingSeedableErrorCodes {
+		codes = append(codes, c)
+	}
+	sort.Strings(codes)
+	return codes
+}
+
+// Documented MaxResults bounds. GetProducts and DescribeServices cap at 100;
+// GetAttributeValues at 10000. The maximum doubles as the default so that an
+// omitted MaxResults returns as much as one page can hold.
+const (
+	pricingMaxResultsProducts   = 100
+	pricingMaxResultsServices   = 100
+	pricingMaxResultsAttributes = 10000
+)
+
+// pricingMaxFilters is the documented cap on GetProducts Filters.
+const pricingMaxFilters = 50
+
+// pricingMaxFilterFieldLen is the documented length cap on a filter's Field and
+// Value, and on FormatVersion's own cap of 32.
+const (
+	pricingMaxFilterFieldLen = 1024
+	pricingMaxFormatVerLen   = 32
+)
+
+// Filter types the Price List API defines. TERM_MATCH is the only one most
+// callers use, but a filter naming any other value is valid and must not be
+// treated as an error.
+const (
+	pricingFilterTermMatch = "TERM_MATCH"
+	pricingFilterEquals    = "EQUALS"
+	pricingFilterContains  = "CONTAINS"
+	pricingFilterAnyOf     = "ANY_OF"
+	pricingFilterNoneOf    = "NONE_OF"
+)
+
+// pricingFilter is one GetProducts filter. All three members are required.
+type pricingFilter struct {
+	Type  string `json:"Type"`
+	Field string `json:"Field"`
+	Value string `json:"Value"`
+}
+
+// PriceListPlugin emulates the AWS Price List Query API — GetProducts,
+// DescribeServices and GetAttributeValues — over a small offer corpus copied
+// verbatim from the live AWS S3 offer file (see pricing_offer_fixture.go).
+//
+// It is the inverse of [AWSPricingProvider], which consumes the public offer
+// index to cost substrate's own simulated usage. This plugin is the server side:
+// it lets a consumer that queries pricing at runtime test that path without
+// network access.
+//
+// Failures are seedable via POST /v1/pricing/query-failures, so a consumer can
+// prove the property they actually care about — that pricing degrading does not
+// take the I/O path down with it.
+type PriceListPlugin struct {
+	state  StateManager
+	logger Logger
+}
+
+// Name returns the service name "pricing".
+func (p *PriceListPlugin) Name() string { return pricingNamespace }
+
+// Initialize configures the PriceListPlugin with the provided configuration.
+func (p *PriceListPlugin) Initialize(_ context.Context, cfg PluginConfig) error {
+	p.state = cfg.State
+	p.logger = cfg.Logger
+	return nil
+}
+
+// Shutdown is a no-op for PriceListPlugin.
+func (p *PriceListPlugin) Shutdown(_ context.Context) error { return nil }
+
+// HandleRequest dispatches a Price List JSON-target request to the appropriate
+// handler. A seeded failure for the operation (or the "*" wildcard) preempts the
+// handler, and a request signed for a region with no Price List endpoint is
+// rejected before either.
+func (p *PriceListPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	if err := p.checkEndpointRegion(ctx); err != nil {
+		return nil, err
+	}
+	if err := p.seededFailure(req.Operation); err != nil {
+		return nil, err
+	}
+	switch req.Operation {
+	case "GetProducts":
+		return p.getProducts(req)
+	case "DescribeServices":
+		return p.describeServices(req)
+	case "GetAttributeValues":
+		return p.getAttributeValues(req)
+	default:
+		return nil, pricingError(pricingErrInvalidParameter,
+			"PriceListPlugin: unsupported operation "+req.Operation)
+	}
+}
+
+// checkEndpointRegion rejects a request signed for a region in which AWS hosts
+// no Price List endpoint. See [pricingEndpointRegions] for why this diverges
+// from AWS deliberately.
+func (p *PriceListPlugin) checkEndpointRegion(ctx *RequestContext) error {
+	if ctx == nil || ctx.Region == "" || pricingEndpointRegions[ctx.Region] {
+		return nil
+	}
+	valid := make([]string, 0, len(pricingEndpointRegions))
+	for r := range pricingEndpointRegions {
+		valid = append(valid, r)
+	}
+	sort.Strings(valid)
+	return &AWSError{
+		Code: pricingErrCodeInvalidRegion,
+		Message: fmt.Sprintf(
+			"the Price List Query API has no endpoint in %s; sign for one of %s. "+
+				"Real AWS fails to resolve api.pricing.%s.amazonaws.com; substrate "+
+				"reports it as this error instead",
+			ctx.Region, strings.Join(valid, ", "), ctx.Region),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// pricingSeededFailureKey is the state key holding the seeded failure for an
+// operation, or for the "*" wildcard.
+func pricingSeededFailureKey(operation string) string { return "failure:" + operation }
+
+// pricingSeededFailure is the stored shape of a seeded failure.
+type pricingSeededFailure struct {
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	StatusCode int    `json:"statusCode"`
+}
+
+// seededFailure returns the seeded error for operation, preferring an
+// operation-specific seed over the "*" wildcard, or nil when none is seeded.
+func (p *PriceListPlugin) seededFailure(operation string) error {
+	if p.state == nil {
+		return nil
+	}
+	for _, key := range []string{pricingSeededFailureKey(operation), pricingSeededFailureKey("*")} {
+		data, err := p.state.Get(context.Background(), pricingCtrlNamespace, key)
+		if err != nil || data == nil {
+			continue
+		}
+		var seed pricingSeededFailure
+		if json.Unmarshal(data, &seed) != nil {
+			continue
+		}
+		status := seed.StatusCode
+		if status == 0 {
+			status = pricingErrorStatus(seed.Code)
+		}
+		return &AWSError{Code: seed.Code, Message: seed.Message, HTTPStatus: status}
+	}
+	return nil
+}
+
+// pricingErrorStatus maps a Price List error code to its HTTP status. Every
+// documented code is 400 except InternalErrorException.
+func pricingErrorStatus(code string) int {
+	if code == pricingErrInternalError {
+		return http.StatusInternalServerError
+	}
+	return http.StatusBadRequest
+}
+
+// pricingError builds an AWSError with the HTTP status the Price List API
+// documents for code.
+func pricingError(code, message string) *AWSError {
+	return &AWSError{Code: code, Message: message, HTTPStatus: pricingErrorStatus(code)}
+}
+
+// pricingJSONResponse marshals v as JSON with the Content-Type the Price List
+// API uses.
+func pricingJSONResponse(v any) (*AWSResponse, error) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("pricing: marshal response: %w", err)
+	}
+	return &AWSResponse{
+		StatusCode: http.StatusOK,
+		Headers:    map[string]string{"Content-Type": "application/x-amz-json-1.1"},
+		Body:       body,
+	}, nil
+}
+
+// getProducts serves GetProducts. ServiceCode is required; Filters select over
+// productFamily and the product's attributes.
+func (p *PriceListPlugin) getProducts(req *AWSRequest) (*AWSResponse, error) {
+	var input struct {
+		ServiceCode   string          `json:"ServiceCode"`
+		Filters       []pricingFilter `json:"Filters"`
+		FormatVersion string          `json:"FormatVersion"`
+		NextToken     string          `json:"NextToken"`
+		MaxResults    *int            `json:"MaxResults"`
+	}
+	if err := pricingDecode(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if input.ServiceCode == "" {
+		return nil, pricingError(pricingErrInvalidParameter, "ServiceCode is required")
+	}
+	if err := pricingValidateFormatVersion(input.FormatVersion); err != nil {
+		return nil, err
+	}
+	if err := pricingValidateFilters(input.Filters); err != nil {
+		return nil, err
+	}
+	limit, err := pricingLimit(input.MaxResults, pricingMaxResultsProducts)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := pricingEntriesFor(input.ServiceCode)
+	if err != nil {
+		return nil, err
+	}
+
+	matched := make([]pricingCorpusEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.matchesAll(input.Filters) {
+			matched = append(matched, e)
+		}
+	}
+
+	page, next, err := pricingPage(len(matched), input.NextToken, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// PriceList elements are JSON documents encoded as strings, not objects.
+	// Marshaling each document and storing the result as a string is what
+	// reproduces that; json.Marshal of the outer []string escapes it.
+	priceList := make([]string, 0, page.end-page.start)
+	for _, e := range matched[page.start:page.end] {
+		doc, marshalErr := json.Marshal(e.offerDoc())
+		if marshalErr != nil {
+			return nil, fmt.Errorf("pricing: marshal offer document for %s: %w", e.sku, marshalErr)
+		}
+		priceList = append(priceList, string(doc))
+	}
+
+	out := map[string]interface{}{
+		"FormatVersion": pricingFormatVersion,
+		"PriceList":     priceList,
+	}
+	if next != "" {
+		out["NextToken"] = next
+	}
+	return pricingJSONResponse(out)
+}
+
+// describeServices serves DescribeServices. Every field is optional; with no
+// ServiceCode it lists every service in the corpus.
+func (p *PriceListPlugin) describeServices(req *AWSRequest) (*AWSResponse, error) {
+	var input struct {
+		ServiceCode   string `json:"ServiceCode"`
+		FormatVersion string `json:"FormatVersion"`
+		NextToken     string `json:"NextToken"`
+		MaxResults    *int   `json:"MaxResults"`
+	}
+	if err := pricingDecode(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := pricingValidateFormatVersion(input.FormatVersion); err != nil {
+		return nil, err
+	}
+	limit, err := pricingLimit(input.MaxResults, pricingMaxResultsServices)
+	if err != nil {
+		return nil, err
+	}
+
+	codes := pricingServiceCodes()
+	if input.ServiceCode != "" {
+		if _, ok := pricingServiceAttributes[input.ServiceCode]; !ok {
+			return nil, pricingError(pricingErrInvalidParameter,
+				"unknown ServiceCode "+input.ServiceCode)
+		}
+		codes = []string{input.ServiceCode}
+	}
+
+	page, next, err := pricingPage(len(codes), input.NextToken, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	services := make([]map[string]interface{}, 0, page.end-page.start)
+	for _, code := range codes[page.start:page.end] {
+		services = append(services, map[string]interface{}{
+			"ServiceCode":    code,
+			"AttributeNames": pricingServiceAttributes[code],
+		})
+	}
+
+	out := map[string]interface{}{
+		"FormatVersion": pricingFormatVersion,
+		"Services":      services,
+	}
+	if next != "" {
+		out["NextToken"] = next
+	}
+	return pricingJSONResponse(out)
+}
+
+// getAttributeValues serves GetAttributeValues. Both AttributeName and
+// ServiceCode are required, and the values returned are exactly those the corpus
+// carries — so a value from here always matches at least one product.
+func (p *PriceListPlugin) getAttributeValues(req *AWSRequest) (*AWSResponse, error) {
+	var input struct {
+		ServiceCode   string `json:"ServiceCode"`
+		AttributeName string `json:"AttributeName"`
+		NextToken     string `json:"NextToken"`
+		MaxResults    *int   `json:"MaxResults"`
+	}
+	if err := pricingDecode(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if input.ServiceCode == "" {
+		return nil, pricingError(pricingErrInvalidParameter, "ServiceCode is required")
+	}
+	if input.AttributeName == "" {
+		return nil, pricingError(pricingErrInvalidParameter, "AttributeName is required")
+	}
+	limit, err := pricingLimit(input.MaxResults, pricingMaxResultsAttributes)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := pricingEntriesFor(input.ServiceCode)
+	if err != nil {
+		return nil, err
+	}
+	if !pricingHasAttribute(input.ServiceCode, input.AttributeName) {
+		return nil, pricingError(pricingErrInvalidParameter,
+			"unknown AttributeName "+input.AttributeName+" for service "+input.ServiceCode)
+	}
+
+	seen := make(map[string]bool)
+	var values []string
+	for _, e := range entries {
+		v, ok := e.attribute(input.AttributeName)
+		// An attribute that is present but empty — "operation" is "" on every S3
+		// product in the offer file — is reported as the empty value rather than
+		// skipped, so that every value returned here matches at least one product
+		// when fed back to a GetProducts filter. Absent is different from empty
+		// and is skipped.
+		if !ok || seen[v] {
+			continue
+		}
+		seen[v] = true
+		values = append(values, v)
+	}
+	sort.Strings(values)
+
+	page, next, err := pricingPage(len(values), input.NextToken, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]map[string]string, 0, page.end-page.start)
+	for _, v := range values[page.start:page.end] {
+		out = append(out, map[string]string{"Value": v})
+	}
+
+	resp := map[string]interface{}{"AttributeValues": out}
+	if next != "" {
+		resp["NextToken"] = next
+	}
+	return pricingJSONResponse(resp)
+}
+
+// pricingDecode unmarshals a Price List request body. An empty body is treated
+// as an empty object, since DescribeServices takes no required members.
+func pricingDecode(body []byte, v any) error {
+	if len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, v); err != nil {
+		return pricingError(pricingErrInvalidParameter, "malformed request body: "+err.Error())
+	}
+	return nil
+}
+
+// pricingValidateFormatVersion rejects a FormatVersion other than "aws_v1". An
+// empty value means "unspecified" and is accepted.
+func pricingValidateFormatVersion(v string) error {
+	if v == "" || v == pricingFormatVersion {
+		return nil
+	}
+	if len(v) > pricingMaxFormatVerLen {
+		return pricingError(pricingErrInvalidParameter,
+			fmt.Sprintf("FormatVersion must be at most %d characters", pricingMaxFormatVerLen))
+	}
+	return pricingError(pricingErrInvalidParameter,
+		"unsupported FormatVersion "+v+"; the only valid value is "+pricingFormatVersion)
+}
+
+// pricingValidateFilters enforces the documented Filters constraints: at most 50
+// filters, each with all three members set, Field and Value at most 1024
+// characters, and Type one of the five documented values.
+func pricingValidateFilters(filters []pricingFilter) error {
+	if len(filters) > pricingMaxFilters {
+		return pricingError(pricingErrInvalidParameter,
+			fmt.Sprintf("at most %d filters are allowed, got %d", pricingMaxFilters, len(filters)))
+	}
+	for i, f := range filters {
+		switch f.Type {
+		case pricingFilterTermMatch, pricingFilterEquals, pricingFilterContains,
+			pricingFilterAnyOf, pricingFilterNoneOf:
+		case "":
+			return pricingError(pricingErrInvalidParameter,
+				fmt.Sprintf("Filters[%d].Type is required", i))
+		default:
+			return pricingError(pricingErrInvalidParameter,
+				fmt.Sprintf("Filters[%d].Type %q is not a valid filter type", i, f.Type))
+		}
+		if f.Field == "" {
+			return pricingError(pricingErrInvalidParameter,
+				fmt.Sprintf("Filters[%d].Field is required", i))
+		}
+		if f.Value == "" {
+			return pricingError(pricingErrInvalidParameter,
+				fmt.Sprintf("Filters[%d].Value is required", i))
+		}
+		if len(f.Field) > pricingMaxFilterFieldLen || len(f.Value) > pricingMaxFilterFieldLen {
+			return pricingError(pricingErrInvalidParameter,
+				fmt.Sprintf("Filters[%d].Field and Value must be at most %d characters",
+					i, pricingMaxFilterFieldLen))
+		}
+	}
+	return nil
+}
+
+// pricingLimit resolves MaxResults against its documented bound. A nil pointer
+// means the caller omitted it, which defaults to the maximum; an explicit value
+// outside 1..max is an InvalidParameterException rather than a silent clamp,
+// because clamping would hide a caller's mistake.
+func pricingLimit(maxResults *int, max int) (int, error) {
+	if maxResults == nil {
+		return max, nil
+	}
+	if *maxResults < 1 || *maxResults > max {
+		return 0, pricingError(pricingErrInvalidParameter,
+			fmt.Sprintf("MaxResults must be between 1 and %d, got %d", max, *maxResults))
+	}
+	return *maxResults, nil
+}
+
+// pricingEntriesFor returns the corpus entries for a service code.
+//
+// An unknown service code is a NotFoundException. Substrate's corpus is far
+// smaller than AWS's catalog, so a caller asking for a real service substrate
+// does not carry gets a loud error rather than an empty PriceList that reads as
+// "AWS has no such price". A false alarm is visible; a false empty is not.
+func pricingEntriesFor(serviceCode string) ([]pricingCorpusEntry, error) {
+	if _, ok := pricingServiceAttributes[serviceCode]; !ok {
+		return nil, pricingError(pricingErrNotFound,
+			"no offer data for ServiceCode "+serviceCode+
+				"; substrate's corpus covers "+strings.Join(pricingServiceCodes(), ", "))
+	}
+	out := make([]pricingCorpusEntry, 0, len(pricingCorpus))
+	for _, e := range pricingCorpus {
+		if e.serviceCode == serviceCode {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+// pricingServiceCodes returns the sorted service codes the corpus covers.
+func pricingServiceCodes() []string {
+	codes := make([]string, 0, len(pricingServiceAttributes))
+	for code := range pricingServiceAttributes {
+		codes = append(codes, code)
+	}
+	sort.Strings(codes)
+	return codes
+}
+
+// pricingHasAttribute reports whether serviceCode declares name as one of its
+// attributes.
+func pricingHasAttribute(serviceCode, name string) bool {
+	for _, a := range pricingServiceAttributes[serviceCode] {
+		if a == name {
+			return true
+		}
+	}
+	return false
+}
+
+// pricingProductFamilyField is the one filterable field that is a sibling of the
+// attribute map rather than a member of it.
+const pricingProductFamilyField = "productFamily"
+
+// attribute returns the value of the named field, which may be the product's
+// productFamily or any of its attributes. Matching is exact: the offer file's
+// own names are what a caller must use, and accepting near-misses would let a
+// filter that AWS rejects appear to work here.
+func (e pricingCorpusEntry) attribute(field string) (string, bool) {
+	if field == pricingProductFamilyField {
+		// A product with no family reports absent, not empty — which is what
+		// makes a productFamily filter miss most of the corpus, exactly as it
+		// does against the real offer file.
+		return e.productFamily, e.productFamily != ""
+	}
+	v, ok := e.attributes[field]
+	return v, ok
+}
+
+// matchesAll reports whether the entry satisfies every filter. Filters are
+// conjunctive, and a filter naming a field the product does not carry never
+// matches — including NONE_OF, since AWS filters over products that have the
+// field rather than over those that lack it.
+func (e pricingCorpusEntry) matchesAll(filters []pricingFilter) bool {
+	for _, f := range filters {
+		v, ok := e.attribute(f.Field)
+		if !ok {
+			return false
+		}
+		if !pricingFilterMatches(f, v) {
+			return false
+		}
+	}
+	return true
+}
+
+// pricingFilterMatches applies one filter to one attribute value. ANY_OF and
+// NONE_OF take a comma-separated Value.
+func pricingFilterMatches(f pricingFilter, value string) bool {
+	switch f.Type {
+	case pricingFilterTermMatch, pricingFilterEquals:
+		return value == f.Value
+	case pricingFilterContains:
+		return strings.Contains(value, f.Value)
+	case pricingFilterAnyOf:
+		return pricingInCommaList(f.Value, value)
+	case pricingFilterNoneOf:
+		return !pricingInCommaList(f.Value, value)
+	default:
+		// Unreachable: pricingValidateFilters rejects any other type.
+		return false
+	}
+}
+
+// pricingInCommaList reports whether value equals one of the comma-separated
+// entries in list. Entries are trimmed, since AWS accepts "a, b" as two values.
+func pricingInCommaList(list, value string) bool {
+	for _, part := range strings.Split(list, ",") {
+		if strings.TrimSpace(part) == value {
+			return true
+		}
+	}
+	return false
+}
+
+// pricingPageBounds is the half-open slice range one page covers.
+type pricingPageBounds struct {
+	start int
+	end   int
+}
+
+// pricingPage resolves a NextToken and page size into slice bounds plus the
+// token for the following page, which is "" on the last page.
+//
+// The token is an opaque base64 offset. A token that does not decode, or that
+// names an offset past the end of the result set, is an InvalidNextTokenException
+// — the error the API documents for exactly that case, and one a caller cannot
+// otherwise reach.
+func pricingPage(total int, token string, limit int) (pricingPageBounds, string, error) {
+	start := 0
+	if token != "" {
+		off, err := pricingDecodeToken(token)
+		if err != nil {
+			return pricingPageBounds{}, "", err
+		}
+		if off > total {
+			return pricingPageBounds{}, "", pricingError(pricingErrInvalidNextToken,
+				"NextToken refers to an offset past the end of the result set")
+		}
+		start = off
+	}
+	end := start + limit
+	if end > total {
+		end = total
+	}
+	next := ""
+	if end < total {
+		next = pricingEncodeToken(end)
+	}
+	return pricingPageBounds{start: start, end: end}, next, nil
+}
+
+// pricingTokenPrefix marks a substrate pagination token. It is part of the
+// encoded payload so that a token minted elsewhere fails to decode rather than
+// being read as an offset.
+const pricingTokenPrefix = "substrate-pricing:"
+
+// pricingEncodeToken encodes a result offset as an opaque token.
+func pricingEncodeToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(pricingTokenPrefix + strconv.Itoa(offset)))
+}
+
+// pricingDecodeToken recovers the offset from a token minted by
+// pricingEncodeToken.
+func pricingDecodeToken(token string) (int, error) {
+	raw, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0, pricingError(pricingErrInvalidNextToken, "NextToken is not a valid token")
+	}
+	s, ok := strings.CutPrefix(string(raw), pricingTokenPrefix)
+	if !ok {
+		return 0, pricingError(pricingErrInvalidNextToken, "NextToken is not a valid token")
+	}
+	offset, convErr := strconv.Atoi(s)
+	if convErr != nil || offset < 0 {
+		return 0, pricingError(pricingErrInvalidNextToken, "NextToken is not a valid token")
+	}
+	return offset, nil
+}

--- a/emulator/pricing_plugin_test.go
+++ b/emulator/pricing_plugin_test.go
@@ -1,0 +1,1265 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The Price List Query API is how a consumer that prices its own usage at
+// runtime discovers rates. #401 was filed because substrate did not emulate it at
+// all, so such a consumer could only be tested against a hand-maintained static
+// table — and the reporter's table was already 10x wrong on Requests-Tier1 and
+// 21x wrong on Deep Archive. These tests assert the shapes that made those errors
+// possible, not just that a request succeeds.
+
+// newPricingTestServer builds a server with PriceListPlugin registered.
+func newPricingTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Now())
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.PriceListPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:  state,
+		Logger: logger,
+	}); err != nil {
+		t.Fatalf("initialize pricing plugin: %v", err)
+	}
+	registry.Register(p)
+
+	cfg := emulator.DefaultConfig()
+	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// pricingCall issues a Price List request against host
+// api.pricing.<region>.amazonaws.com — the real endpoint layout, so these tests
+// also exercise the routing added for #401/#403 rather than a shortcut path.
+func pricingCall(t *testing.T, ts *httptest.Server, region, op string, in any) *http.Response {
+	t.Helper()
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal %s input: %v", op, err)
+	}
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("build %s request: %v", op, err)
+	}
+	req.Host = "api.pricing." + region + ".amazonaws.com"
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "AWSPriceListService."+op)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do %s request: %v", op, err)
+	}
+	return resp
+}
+
+// pricingJSON reads a response body into a generic map.
+func pricingJSON(t *testing.T, r *http.Response) map[string]any {
+	t.Helper()
+	defer r.Body.Close() //nolint:errcheck
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read pricing body: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal pricing body %q: %v", raw, err)
+	}
+	return out
+}
+
+// pricingGetProducts is the common happy-path call: GetProducts for AmazonS3
+// with the given filters, asserting 200.
+func pricingGetProducts(t *testing.T, ts *httptest.Server, filters []map[string]string) map[string]any {
+	t.Helper()
+	in := map[string]any{"ServiceCode": "AmazonS3", "FormatVersion": "aws_v1"}
+	if filters != nil {
+		in["Filters"] = filters
+	}
+	resp := pricingCall(t, ts, "us-east-1", "GetProducts", in)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GetProducts status = %d, want 200 (body %s)", resp.StatusCode,
+			mustReadAll(t, resp))
+	}
+	return pricingJSON(t, resp)
+}
+
+func mustReadAll(t *testing.T, r *http.Response) string {
+	t.Helper()
+	defer r.Body.Close() //nolint:errcheck
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return string(b)
+}
+
+// priceListDocs decodes the PriceList field, asserting each element is a JSON
+// document encoded as a *string* rather than an object. That encoding is the
+// single most common thing callers get wrong, so it is asserted structurally
+// here rather than assumed.
+func priceListDocs(t *testing.T, out map[string]any) []map[string]any {
+	t.Helper()
+	raw, ok := out["PriceList"]
+	if !ok {
+		t.Fatalf("response has no PriceList: %v", out)
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("PriceList is %T, want []any", raw)
+	}
+	docs := make([]map[string]any, 0, len(list))
+	for i, el := range list {
+		s, isStr := el.(string)
+		if !isStr {
+			t.Fatalf("PriceList[%d] is %T, want string: AWS encodes each offer "+
+				"document as a JSON string, not an object", i, el)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal([]byte(s), &doc); err != nil {
+			t.Fatalf("PriceList[%d] is not valid JSON: %v", i, err)
+		}
+		docs = append(docs, doc)
+	}
+	return docs
+}
+
+// docBySKU indexes decoded offer documents by SKU.
+func docBySKU(t *testing.T, docs []map[string]any) map[string]map[string]any {
+	t.Helper()
+	byS := make(map[string]map[string]any, len(docs))
+	for _, d := range docs {
+		prod, ok := d["product"].(map[string]any)
+		if !ok {
+			t.Fatalf("offer document has no product object: %v", d)
+		}
+		sku, ok := prod["sku"].(string)
+		if !ok {
+			t.Fatalf("product has no sku: %v", prod)
+		}
+		byS[sku] = d
+	}
+	return byS
+}
+
+// dimensions returns the OnDemand priceDimensions of an offer document.
+func dimensions(t *testing.T, doc map[string]any) map[string]any {
+	t.Helper()
+	terms, ok := doc["terms"].(map[string]any)
+	if !ok {
+		t.Fatalf("offer document has no terms: %v", doc)
+	}
+	onDemand, ok := terms["OnDemand"].(map[string]any)
+	if !ok {
+		t.Fatalf("terms has no OnDemand: %v", terms)
+	}
+	for _, term := range onDemand {
+		tm, isMap := term.(map[string]any)
+		if !isMap {
+			continue
+		}
+		dims, isDims := tm["priceDimensions"].(map[string]any)
+		if isDims {
+			return dims
+		}
+	}
+	t.Fatalf("OnDemand term has no priceDimensions: %v", onDemand)
+	return nil
+}
+
+func TestPricingGetProducts_ReturnsWholeCorpus(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	out := pricingGetProducts(t, ts, nil)
+	if got := out["FormatVersion"]; got != "aws_v1" {
+		t.Errorf("FormatVersion = %v, want aws_v1", got)
+	}
+	docs := priceListDocs(t, out)
+	if len(docs) != 7 {
+		t.Fatalf("got %d products, want the whole 7-SKU corpus", len(docs))
+	}
+	// A single page covers the corpus, so no NextToken should be offered.
+	if _, ok := out["NextToken"]; ok {
+		t.Errorf("unpaginated response carries a NextToken: %v", out["NextToken"])
+	}
+}
+
+// TestPricingGetProducts_PriceStringsAreStrings pins the encoding that makes a
+// naive float unmarshal fail: pricePerUnit values are strings with trailing
+// zeros, and so is every range bound.
+func TestPricingGetProducts_PriceStringsAreStrings(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	docs := priceListDocs(t, pricingGetProducts(t, ts, nil))
+	for _, doc := range docs {
+		for rateCode, raw := range dimensions(t, doc) {
+			dim, ok := raw.(map[string]any)
+			if !ok {
+				t.Fatalf("%s: dimension is %T, want object", rateCode, raw)
+			}
+			ppu, ok := dim["pricePerUnit"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s: pricePerUnit is %T, want object", rateCode, dim["pricePerUnit"])
+			}
+			usd, ok := ppu["USD"]
+			if !ok {
+				t.Fatalf("%s: pricePerUnit has no USD", rateCode)
+			}
+			if _, isStr := usd.(string); !isStr {
+				t.Errorf("%s: pricePerUnit.USD is %T, want string — AWS never "+
+					"emits a bare number here", rateCode, usd)
+			}
+			for _, field := range []string{"beginRange", "endRange"} {
+				if _, isStr := dim[field].(string); !isStr {
+					t.Errorf("%s: %s is %T, want string", rateCode, field, dim[field])
+				}
+			}
+		}
+	}
+}
+
+// TestPricingGetProducts_RequestsTier1Rate is the rate the reporter's static
+// table had 10x low. $0.005 per 1,000 requests is 0.000005 per request, and the
+// unit is "Requests" — so a caller must not divide by 1000 again.
+func TestPricingGetProducts_RequestsTier1Rate(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	out := pricingGetProducts(t, ts, []map[string]string{
+		{"Type": "TERM_MATCH", "Field": "usagetype", "Value": "Requests-Tier1"},
+	})
+	docs := priceListDocs(t, out)
+	if len(docs) != 1 {
+		t.Fatalf("got %d products for usagetype=Requests-Tier1, want 1", len(docs))
+	}
+	dims := dimensions(t, docs[0])
+	if len(dims) != 1 {
+		t.Fatalf("got %d price dimensions, want 1", len(dims))
+	}
+	for _, raw := range dims {
+		dim, _ := raw.(map[string]any)
+		ppu, _ := dim["pricePerUnit"].(map[string]any)
+		if got := ppu["USD"]; got != "0.0000050000" {
+			t.Errorf("Requests-Tier1 USD = %v, want 0.0000050000 ($0.005 per 1,000)", got)
+		}
+		if got := dim["unit"]; got != "Requests" {
+			t.Errorf("unit = %v, want Requests (per-request, not per-thousand)", got)
+		}
+	}
+}
+
+// TestPricingGetProducts_TieredStorageHasEveryDimension guards the trap where a
+// parser takes the first priceDimension and reports the 50 TB tier rate as the
+// only rate. All three tiers must be present, and the last endRange must be the
+// literal string "Inf".
+func TestPricingGetProducts_TieredStorageHasEveryDimension(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	out := pricingGetProducts(t, ts, []map[string]string{
+		{"Type": "TERM_MATCH", "Field": "usagetype", "Value": "TimedStorage-ByteHrs"},
+	})
+	docs := priceListDocs(t, out)
+	if len(docs) != 1 {
+		t.Fatalf("got %d products for TimedStorage-ByteHrs, want 1", len(docs))
+	}
+	dims := dimensions(t, docs[0])
+	if len(dims) != 3 {
+		t.Fatalf("got %d price dimensions, want 3 (50 TB / 450 TB / beyond)", len(dims))
+	}
+
+	// Index by beginRange so the assertion does not depend on map ordering.
+	byBegin := make(map[string]map[string]any, len(dims))
+	for _, raw := range dims {
+		dim, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("dimension is %T, want object", raw)
+		}
+		begin, _ := dim["beginRange"].(string)
+		byBegin[begin] = dim
+	}
+
+	for _, want := range []struct {
+		begin, end, usd string
+	}{
+		{"0", "51200", "0.0230000000"},
+		{"51200", "512000", "0.0220000000"},
+		{"512000", "Inf", "0.0210000000"},
+	} {
+		dim, ok := byBegin[want.begin]
+		if !ok {
+			t.Errorf("no dimension with beginRange %s", want.begin)
+			continue
+		}
+		if got := dim["endRange"]; got != want.end {
+			t.Errorf("beginRange %s: endRange = %v, want %s", want.begin, got, want.end)
+		}
+		ppu, _ := dim["pricePerUnit"].(map[string]any)
+		if got := ppu["USD"]; got != want.usd {
+			t.Errorf("beginRange %s: USD = %v, want %s", want.begin, got, want.usd)
+		}
+	}
+}
+
+// TestPricingGetProducts_DeepArchiveFilterReturnsOnlyStaging encodes the trap
+// verified against the live offer file: filtering productFamily=Storage with
+// volumeType="Glacier Deep Archive" returns *only* the staging SKU at $0.021 —
+// 21x the $0.00099 archive rate a caller is looking for. There is no
+// TimedStorage-GDA-ByteHrs SKU in the S3 offer file to return instead.
+func TestPricingGetProducts_DeepArchiveFilterReturnsOnlyStaging(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	out := pricingGetProducts(t, ts, []map[string]string{
+		{"Type": "TERM_MATCH", "Field": "productFamily", "Value": "Storage"},
+		{"Type": "TERM_MATCH", "Field": "volumeType", "Value": "Glacier Deep Archive"},
+	})
+	docs := priceListDocs(t, out)
+	if len(docs) != 1 {
+		t.Fatalf("got %d products, want exactly 1 (the staging decoy)", len(docs))
+	}
+	bySKU := docBySKU(t, docs)
+	doc, ok := bySKU["EXB3YJ6YV5CRH4JN"]
+	if !ok {
+		t.Fatalf("want SKU EXB3YJ6YV5CRH4JN (TimedStorage-GDA-Staging), got %v", bySKU)
+	}
+	for _, raw := range dimensions(t, doc) {
+		dim, _ := raw.(map[string]any)
+		ppu, _ := dim["pricePerUnit"].(map[string]any)
+		if got := ppu["USD"]; got != "0.0210000000" {
+			t.Errorf("GDA-Staging USD = %v, want 0.0210000000 — the staging rate, "+
+				"not the archive rate", got)
+		}
+	}
+
+	// The $0.00099 rate exists, but under Intelligent-Tiering, so a caller cannot
+	// reach it by filtering for Deep Archive.
+	daa := priceListDocs(t, pricingGetProducts(t, ts, []map[string]string{
+		{"Type": "TERM_MATCH", "Field": "usagetype", "Value": "TimedStorage-INT-DAA-ByteHrs"},
+	}))
+	if len(daa) != 1 {
+		t.Fatalf("got %d products for TimedStorage-INT-DAA-ByteHrs, want 1", len(daa))
+	}
+	for _, raw := range dimensions(t, daa[0]) {
+		dim, _ := raw.(map[string]any)
+		ppu, _ := dim["pricePerUnit"].(map[string]any)
+		if got := ppu["USD"]; got != "0.0009900000" {
+			t.Errorf("INT-DAA USD = %v, want 0.0009900000", got)
+		}
+	}
+}
+
+// TestPricingGetProducts_ProductFamilyOftenAbsent pins the majority case: most
+// products carry no productFamily at all, so filtering on it misses them, while
+// usagetype reaches every one.
+func TestPricingGetProducts_ProductFamilyOftenAbsent(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	docs := priceListDocs(t, pricingGetProducts(t, ts, nil))
+	withFamily := 0
+	for _, doc := range docs {
+		prod, _ := doc["product"].(map[string]any)
+		if _, ok := prod["productFamily"]; ok {
+			withFamily++
+		}
+		if _, ok := prod["attributes"].(map[string]any)["usagetype"]; !ok {
+			sku := prod["sku"]
+			t.Errorf("product %v has no usagetype; usagetype must be present on "+
+				"every product since it is the only reliable key", sku)
+		}
+	}
+	if withFamily == len(docs) {
+		t.Error("every product carries a productFamily; the corpus must include " +
+			"family-less products, which are the majority in the real offer file")
+	}
+
+	// The concrete consequence: a productFamily filter cannot see the family-less
+	// SKU, but a usagetype filter can.
+	byFamily := priceListDocs(t, pricingGetProducts(t, ts, []map[string]string{
+		{"Type": "TERM_MATCH", "Field": "productFamily", "Value": "API Request"},
+	}))
+	byUsage := priceListDocs(t, pricingGetProducts(t, ts, []map[string]string{
+		{"Type": "TERM_MATCH", "Field": "usagetype", "Value": "Requests-GDA-Tier2"},
+	}))
+	if len(byUsage) != 1 {
+		t.Fatalf("usagetype=Requests-GDA-Tier2 returned %d products, want 1", len(byUsage))
+	}
+	for _, doc := range byFamily {
+		prod, _ := doc["product"].(map[string]any)
+		if prod["sku"] == "WDAC2WRXVNRSNQS6" {
+			t.Error("the family-less SKU was returned by a productFamily filter; " +
+				"an absent productFamily must not match")
+		}
+	}
+}
+
+func TestPricingGetProducts_FilterTypes(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	tests := []struct {
+		name    string
+		filters []map[string]string
+		wantN   int
+	}{
+		{
+			name: "EQUALS behaves as TERM_MATCH",
+			filters: []map[string]string{
+				{"Type": "EQUALS", "Field": "usagetype", "Value": "Requests-Tier1"},
+			},
+			wantN: 1,
+		},
+		{
+			name: "CONTAINS matches a substring",
+			filters: []map[string]string{
+				{"Type": "CONTAINS", "Field": "usagetype", "Value": "TimedStorage"},
+			},
+			wantN: 4,
+		},
+		{
+			name: "ANY_OF takes a comma-separated list",
+			filters: []map[string]string{
+				{"Type": "ANY_OF", "Field": "usagetype", "Value": "Requests-Tier1,Requests-Tier2"},
+			},
+			wantN: 2,
+		},
+		{
+			name: "NONE_OF excludes listed values",
+			filters: []map[string]string{
+				{"Type": "NONE_OF", "Field": "storageClass", "Value": "General Purpose,Archive"},
+			},
+			// Only the four products carrying storageClass are candidates at all;
+			// NONE_OF filters within them, it does not select products lacking the
+			// field.
+			wantN: 2,
+		},
+		{
+			name: "conjunctive filters narrow",
+			filters: []map[string]string{
+				{"Type": "TERM_MATCH", "Field": "productFamily", "Value": "Storage"},
+				{"Type": "TERM_MATCH", "Field": "storageClass", "Value": "Infrequent Access"},
+			},
+			wantN: 1,
+		},
+		{
+			name: "unknown field matches nothing",
+			filters: []map[string]string{
+				{"Type": "TERM_MATCH", "Field": "instanceType", "Value": "m5.large"},
+			},
+			wantN: 0,
+		},
+		{
+			name: "unmatched value matches nothing",
+			filters: []map[string]string{
+				{"Type": "TERM_MATCH", "Field": "usagetype", "Value": "NoSuchUsageType"},
+			},
+			wantN: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			docs := priceListDocs(t, pricingGetProducts(t, ts, tt.filters))
+			if len(docs) != tt.wantN {
+				skus := make([]string, 0, len(docs))
+				for s := range docBySKU(t, docs) {
+					skus = append(skus, s)
+				}
+				t.Errorf("got %d products, want %d (SKUs %v)", len(docs), tt.wantN, skus)
+			}
+		})
+	}
+}
+
+// TestPricingGetProducts_Pagination walks the corpus a page at a time and
+// asserts the pages partition it exactly — no duplicates, no gaps, and no
+// NextToken on the final page.
+func TestPricingGetProducts_Pagination(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	seen := make(map[string]int)
+	token := ""
+	pages := 0
+	for {
+		in := map[string]any{"ServiceCode": "AmazonS3", "MaxResults": 3}
+		if token != "" {
+			in["NextToken"] = token
+		}
+		resp := pricingCall(t, ts, "us-east-1", "GetProducts", in)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("page %d status = %d, want 200 (body %s)", pages,
+				resp.StatusCode, mustReadAll(t, resp))
+		}
+		out := pricingJSON(t, resp)
+		for sku := range docBySKU(t, priceListDocs(t, out)) {
+			seen[sku]++
+		}
+		pages++
+		next, ok := out["NextToken"].(string)
+		if !ok || next == "" {
+			break
+		}
+		token = next
+		if pages > 10 {
+			t.Fatal("pagination did not terminate within 10 pages")
+		}
+	}
+	if pages != 3 {
+		t.Errorf("walked %d pages of 3 over a 7-SKU corpus, want 3", pages)
+	}
+	if len(seen) != 7 {
+		t.Errorf("saw %d distinct SKUs across all pages, want 7", len(seen))
+	}
+	for sku, n := range seen {
+		if n != 1 {
+			t.Errorf("SKU %s appeared on %d pages, want 1", sku, n)
+		}
+	}
+}
+
+func TestPricingGetProducts_InvalidNextToken(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{"not base64", "!!!not-base64!!!"},
+		{"base64 but not a substrate token", "aGVsbG8gd29ybGQ="},
+		{"offset past the end", "c3Vic3RyYXRlLXByaWNpbmc6OTk5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resp := pricingCall(t, ts, "us-east-1", "GetProducts", map[string]any{
+				"ServiceCode": "AmazonS3",
+				"NextToken":   tt.token,
+			})
+			assertPricingError(t, resp, http.StatusBadRequest, "InvalidNextTokenException")
+		})
+	}
+}
+
+// assertPricingError checks an error response's status and Code. The Code is
+// what an SDK matches on to pick an except/catch branch, so a wrong code makes
+// the branch unreachable even when the status is right.
+func assertPricingError(t *testing.T, resp *http.Response, wantStatus int, wantCode string) {
+	t.Helper()
+	body := mustReadAll(t, resp)
+	if resp.StatusCode != wantStatus {
+		t.Errorf("status = %d, want %d (body %s)", resp.StatusCode, wantStatus, body)
+	}
+	var out struct {
+		Code    string `json:"Code"`
+		Message string `json:"Message"`
+	}
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("error body is not JSON: %v (body %s)", err, body)
+	}
+	if out.Code != wantCode {
+		t.Errorf("Code = %q, want %q (message %q)", out.Code, wantCode, out.Message)
+	}
+	if out.Message == "" {
+		t.Error("error carries an empty Message")
+	}
+}
+
+func TestPricingGetProducts_ValidationErrors(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	manyFilters := make([]map[string]string, 51)
+	for i := range manyFilters {
+		manyFilters[i] = map[string]string{
+			"Type": "TERM_MATCH", "Field": "usagetype", "Value": "Requests-Tier1",
+		}
+	}
+
+	tests := []struct {
+		name  string
+		input map[string]any
+		code  string
+	}{
+		{
+			name:  "ServiceCode required",
+			input: map[string]any{},
+			code:  "InvalidParameterException",
+		},
+		{
+			name:  "unknown ServiceCode is NotFound",
+			input: map[string]any{"ServiceCode": "AmazonNoSuchService"},
+			code:  "NotFoundException",
+		},
+		{
+			name:  "FormatVersion must be aws_v1",
+			input: map[string]any{"ServiceCode": "AmazonS3", "FormatVersion": "aws_v2"},
+			code:  "InvalidParameterException",
+		},
+		{
+			name:  "MaxResults below 1",
+			input: map[string]any{"ServiceCode": "AmazonS3", "MaxResults": 0},
+			code:  "InvalidParameterException",
+		},
+		{
+			name:  "MaxResults above 100",
+			input: map[string]any{"ServiceCode": "AmazonS3", "MaxResults": 101},
+			code:  "InvalidParameterException",
+		},
+		{
+			name:  "more than 50 filters",
+			input: map[string]any{"ServiceCode": "AmazonS3", "Filters": manyFilters},
+			code:  "InvalidParameterException",
+		},
+		{
+			name: "filter Type is required",
+			input: map[string]any{"ServiceCode": "AmazonS3", "Filters": []map[string]string{
+				{"Field": "usagetype", "Value": "Requests-Tier1"},
+			}},
+			code: "InvalidParameterException",
+		},
+		{
+			name: "filter Type must be a known value",
+			input: map[string]any{"ServiceCode": "AmazonS3", "Filters": []map[string]string{
+				{"Type": "REGEX_MATCH", "Field": "usagetype", "Value": "Requests.*"},
+			}},
+			code: "InvalidParameterException",
+		},
+		{
+			name: "filter Field is required",
+			input: map[string]any{"ServiceCode": "AmazonS3", "Filters": []map[string]string{
+				{"Type": "TERM_MATCH", "Value": "Requests-Tier1"},
+			}},
+			code: "InvalidParameterException",
+		},
+		{
+			name: "filter Value is required",
+			input: map[string]any{"ServiceCode": "AmazonS3", "Filters": []map[string]string{
+				{"Type": "TERM_MATCH", "Field": "usagetype"},
+			}},
+			code: "InvalidParameterException",
+		},
+		{
+			name: "filter Field over 1024 characters",
+			input: map[string]any{"ServiceCode": "AmazonS3", "Filters": []map[string]string{
+				{"Type": "TERM_MATCH", "Field": strings.Repeat("a", 1025), "Value": "x"},
+			}},
+			code: "InvalidParameterException",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resp := pricingCall(t, ts, "us-east-1", "GetProducts", tt.input)
+			assertPricingError(t, resp, http.StatusBadRequest, tt.code)
+		})
+	}
+}
+
+// TestPricingGetProducts_MalformedBody: a body that is not JSON must be an
+// InvalidParameterException, not a 500.
+func TestPricingGetProducts_MalformedBody(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader("{not json"))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Host = "api.pricing.us-east-1.amazonaws.com"
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "AWSPriceListService.GetProducts")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	assertPricingError(t, resp, http.StatusBadRequest, "InvalidParameterException")
+}
+
+func TestPricingDescribeServices(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	resp := pricingCall(t, ts, "us-east-1", "DescribeServices", map[string]any{})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, mustReadAll(t, resp))
+	}
+	out := pricingJSON(t, resp)
+	if got := out["FormatVersion"]; got != "aws_v1" {
+		t.Errorf("FormatVersion = %v, want aws_v1", got)
+	}
+	services, ok := out["Services"].([]any)
+	if !ok || len(services) == 0 {
+		t.Fatalf("Services = %v, want a non-empty list", out["Services"])
+	}
+	svc, ok := services[0].(map[string]any)
+	if !ok {
+		t.Fatalf("Services[0] is %T, want object", services[0])
+	}
+	if got := svc["ServiceCode"]; got != "AmazonS3" {
+		t.Errorf("ServiceCode = %v, want AmazonS3", got)
+	}
+	names, ok := svc["AttributeNames"].([]any)
+	if !ok || len(names) == 0 {
+		t.Fatalf("AttributeNames = %v, want a non-empty list", svc["AttributeNames"])
+	}
+	// Every attribute DescribeServices advertises must be usable as a filter
+	// field, otherwise a caller following the documented discovery path
+	// (DescribeServices → GetAttributeValues → GetProducts) hits a dead end.
+	for _, raw := range names {
+		name, isStr := raw.(string)
+		if !isStr {
+			t.Fatalf("AttributeNames element is %T, want string", raw)
+		}
+		vals := pricingCall(t, ts, "us-east-1", "GetAttributeValues", map[string]any{
+			"ServiceCode": "AmazonS3", "AttributeName": name,
+		})
+		if vals.StatusCode != http.StatusOK {
+			t.Errorf("GetAttributeValues(%s) status = %d, want 200 (body %s)",
+				name, vals.StatusCode, mustReadAll(t, vals))
+			continue
+		}
+		_ = mustReadAll(t, vals)
+	}
+}
+
+// TestPricingDescribeServices_SingleServiceCode: naming a ServiceCode narrows the
+// list to that one service rather than being ignored.
+func TestPricingDescribeServices_SingleServiceCode(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	resp := pricingCall(t, ts, "us-east-1", "DescribeServices", map[string]any{
+		"ServiceCode": "AmazonS3",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, mustReadAll(t, resp))
+	}
+	out := pricingJSON(t, resp)
+	services, ok := out["Services"].([]any)
+	if !ok || len(services) != 1 {
+		t.Fatalf("Services = %v, want exactly one entry", out["Services"])
+	}
+}
+
+// TestPricingPaginationAcrossOperations: DescribeServices and
+// GetAttributeValues paginate on the same token scheme as GetProducts, and each
+// stops offering a token on its final page.
+func TestPricingPaginationAcrossOperations(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	t.Run("DescribeServices single page has no token", func(t *testing.T) {
+		t.Parallel()
+		resp := pricingCall(t, ts, "us-east-1", "DescribeServices", map[string]any{
+			"MaxResults": 100,
+		})
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, mustReadAll(t, resp))
+		}
+		out := pricingJSON(t, resp)
+		if _, ok := out["NextToken"]; ok {
+			t.Errorf("single-page DescribeServices offered a NextToken: %v", out["NextToken"])
+		}
+	})
+
+	t.Run("GetAttributeValues paginates", func(t *testing.T) {
+		t.Parallel()
+		seen := make(map[string]int)
+		token := ""
+		pages := 0
+		for {
+			in := map[string]any{
+				"ServiceCode": "AmazonS3", "AttributeName": "usagetype", "MaxResults": 3,
+			}
+			if token != "" {
+				in["NextToken"] = token
+			}
+			resp := pricingCall(t, ts, "us-east-1", "GetAttributeValues", in)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("page %d status = %d, want 200 (body %s)", pages,
+					resp.StatusCode, mustReadAll(t, resp))
+			}
+			out := pricingJSON(t, resp)
+			values, ok := out["AttributeValues"].([]any)
+			if !ok {
+				t.Fatalf("AttributeValues = %v, want a list", out["AttributeValues"])
+			}
+			for _, raw := range values {
+				el, _ := raw.(map[string]any)
+				v, _ := el["Value"].(string)
+				seen[v]++
+			}
+			pages++
+			next, hasNext := out["NextToken"].(string)
+			if !hasNext || next == "" {
+				break
+			}
+			token = next
+			if pages > 10 {
+				t.Fatal("pagination did not terminate within 10 pages")
+			}
+		}
+		if len(seen) != 7 {
+			t.Errorf("saw %d distinct usagetype values, want 7", len(seen))
+		}
+		for v, n := range seen {
+			if n != 1 {
+				t.Errorf("value %q appeared on %d pages, want 1", v, n)
+			}
+		}
+	})
+
+	t.Run("bad token is rejected by every operation", func(t *testing.T) {
+		t.Parallel()
+		for _, op := range []string{"DescribeServices", "GetAttributeValues"} {
+			resp := pricingCall(t, ts, "us-east-1", op, map[string]any{
+				"ServiceCode": "AmazonS3", "AttributeName": "usagetype",
+				"NextToken": "!!!not-base64!!!",
+			})
+			assertPricingError(t, resp, http.StatusBadRequest, "InvalidNextTokenException")
+		}
+	})
+}
+
+// TestPricingFormatVersionTooLong covers the documented 32-character cap, which
+// is a distinct rejection from "not aws_v1".
+func TestPricingFormatVersionTooLong(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	resp := pricingCall(t, ts, "us-east-1", "GetProducts", map[string]any{
+		"ServiceCode":   "AmazonS3",
+		"FormatVersion": strings.Repeat("v", 33),
+	})
+	assertPricingError(t, resp, http.StatusBadRequest, "InvalidParameterException")
+}
+
+// TestPricingShutdown: the plugin holds no resources, so Shutdown must be a
+// clean no-op rather than an error a caller has to special-case.
+func TestPricingShutdown(t *testing.T) {
+	t.Parallel()
+	p := &emulator.PriceListPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:  emulator.NewMemoryStateManager(),
+		Logger: emulator.NewDefaultLogger(0, false),
+	}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if err := p.Shutdown(t.Context()); err != nil { //nolint:contextcheck
+		t.Errorf("Shutdown: %v", err)
+	}
+}
+
+func TestPricingDescribeServices_UnknownServiceCode(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	resp := pricingCall(t, ts, "us-east-1", "DescribeServices", map[string]any{
+		"ServiceCode": "AmazonNoSuchService",
+	})
+	assertPricingError(t, resp, http.StatusBadRequest, "InvalidParameterException")
+}
+
+func TestPricingGetAttributeValues(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	resp := pricingCall(t, ts, "us-east-1", "GetAttributeValues", map[string]any{
+		"ServiceCode": "AmazonS3", "AttributeName": "usagetype",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, mustReadAll(t, resp))
+	}
+	out := pricingJSON(t, resp)
+	values, ok := out["AttributeValues"].([]any)
+	if !ok {
+		t.Fatalf("AttributeValues = %v, want a list", out["AttributeValues"])
+	}
+	if len(values) != 7 {
+		t.Fatalf("got %d usagetype values, want 7 (one per SKU)", len(values))
+	}
+	// Every returned value must select at least one product. A value that
+	// matches nothing would send a caller looking for a bug in their filter.
+	for _, raw := range values {
+		el, isMap := raw.(map[string]any)
+		if !isMap {
+			t.Fatalf("AttributeValues element is %T, want object", raw)
+		}
+		v, isStr := el["Value"].(string)
+		if !isStr {
+			t.Fatalf("AttributeValues element has no string Value: %v", el)
+		}
+		docs := priceListDocs(t, pricingGetProducts(t, ts, []map[string]string{
+			{"Type": "TERM_MATCH", "Field": "usagetype", "Value": v},
+		}))
+		if len(docs) == 0 {
+			t.Errorf("usagetype %q was advertised but matches no product", v)
+		}
+	}
+}
+
+func TestPricingGetAttributeValues_Errors(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	tests := []struct {
+		name  string
+		input map[string]any
+		code  string
+	}{
+		{
+			name:  "ServiceCode required",
+			input: map[string]any{"AttributeName": "usagetype"},
+			code:  "InvalidParameterException",
+		},
+		{
+			name:  "AttributeName required",
+			input: map[string]any{"ServiceCode": "AmazonS3"},
+			code:  "InvalidParameterException",
+		},
+		{
+			name:  "unknown ServiceCode is NotFound",
+			input: map[string]any{"ServiceCode": "AmazonNope", "AttributeName": "usagetype"},
+			code:  "NotFoundException",
+		},
+		{
+			name:  "unknown AttributeName",
+			input: map[string]any{"ServiceCode": "AmazonS3", "AttributeName": "instanceType"},
+			code:  "InvalidParameterException",
+		},
+		{
+			name: "MaxResults above 10000",
+			input: map[string]any{
+				"ServiceCode": "AmazonS3", "AttributeName": "usagetype", "MaxResults": 10001,
+			},
+			code: "InvalidParameterException",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resp := pricingCall(t, ts, "us-east-1", "GetAttributeValues", tt.input)
+			assertPricingError(t, resp, http.StatusBadRequest, tt.code)
+		})
+	}
+}
+
+// TestPricingGetAttributeValues_MaxResultsIs10000 pins the bound that differs
+// from the other two operations: GetAttributeValues caps at 10000, not 100, so a
+// caller passing 500 must not be rejected.
+func TestPricingGetAttributeValues_MaxResultsIs10000(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	resp := pricingCall(t, ts, "us-east-1", "GetAttributeValues", map[string]any{
+		"ServiceCode": "AmazonS3", "AttributeName": "usagetype", "MaxResults": 500,
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("MaxResults=500 status = %d, want 200 (body %s)",
+			resp.StatusCode, mustReadAll(t, resp))
+	}
+	_ = mustReadAll(t, resp)
+}
+
+// TestPricingEndpointRegions covers the deliberate divergence: AWS hosts the
+// Price List API in exactly three regions, and substrate rejects a request
+// signed for any other rather than answering it.
+func TestPricingEndpointRegions(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	for _, region := range []string{"us-east-1", "ap-south-1", "eu-central-1"} {
+		t.Run("endpoint region "+region, func(t *testing.T) {
+			t.Parallel()
+			resp := pricingCall(t, ts, region, "GetProducts", map[string]any{
+				"ServiceCode": "AmazonS3",
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("%s status = %d, want 200 (body %s)", region,
+					resp.StatusCode, mustReadAll(t, resp))
+				return
+			}
+			_ = mustReadAll(t, resp)
+		})
+	}
+
+	for _, region := range []string{"us-west-2", "eu-west-1"} {
+		t.Run("non-endpoint region "+region, func(t *testing.T) {
+			t.Parallel()
+			resp := pricingCall(t, ts, region, "GetProducts", map[string]any{
+				"ServiceCode": "AmazonS3",
+			})
+			assertPricingError(t, resp, http.StatusBadRequest,
+				"SubstrateInvalidPricingEndpoint")
+		})
+	}
+}
+
+func TestPricingUnsupportedOperation(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	resp := pricingCall(t, ts, "us-east-1", "GetPriceListFileUrl", map[string]any{})
+	assertPricingError(t, resp, http.StatusBadRequest, "InvalidParameterException")
+}
+
+// TestPricingSeededFailure is the point of the seed endpoint: it lets a consumer
+// prove that pricing degrading does not take their I/O path down. Without it,
+// the fallback branch is unreachable and a green suite says nothing about it.
+func TestPricingSeededFailure(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	// Nominal first, so the failure below is demonstrably caused by the seed.
+	if docs := priceListDocs(t, pricingGetProducts(t, ts, nil)); len(docs) != 7 {
+		t.Fatalf("pre-seed GetProducts returned %d products, want 7", len(docs))
+	}
+
+	seedPricingFailure(t, ts, map[string]any{
+		"operation": "GetProducts",
+		"code":      "ThrottlingException",
+		"message":   "Rate exceeded",
+	})
+
+	resp := pricingCall(t, ts, "us-east-1", "GetProducts", map[string]any{
+		"ServiceCode": "AmazonS3",
+	})
+	assertPricingError(t, resp, http.StatusBadRequest, "ThrottlingException")
+
+	// The seed is scoped to GetProducts, so the other operations still work —
+	// which is what lets a test isolate one failing call.
+	other := pricingCall(t, ts, "us-east-1", "DescribeServices", map[string]any{})
+	if other.StatusCode != http.StatusOK {
+		t.Errorf("DescribeServices status = %d under a GetProducts-scoped seed, want 200",
+			other.StatusCode)
+	}
+	_ = mustReadAll(t, other)
+
+	clearPricingFailures(t, ts, "")
+	if docs := priceListDocs(t, pricingGetProducts(t, ts, nil)); len(docs) != 7 {
+		t.Error("GetProducts did not recover after the seed was cleared")
+	}
+}
+
+func TestPricingSeededFailure_Wildcard(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	seedPricingFailure(t, ts, map[string]any{"code": "InternalErrorException"})
+
+	// InternalErrorException is the one documented code that is 500, not 400.
+	for _, op := range []string{"GetProducts", "DescribeServices", "GetAttributeValues"} {
+		resp := pricingCall(t, ts, "us-east-1", op, map[string]any{
+			"ServiceCode": "AmazonS3", "AttributeName": "usagetype",
+		})
+		assertPricingError(t, resp, http.StatusInternalServerError, "InternalErrorException")
+	}
+
+	// A per-operation seed takes precedence over the wildcard.
+	seedPricingFailure(t, ts, map[string]any{
+		"operation": "GetProducts", "code": "AccessDeniedException",
+	})
+	resp := pricingCall(t, ts, "us-east-1", "GetProducts", map[string]any{
+		"ServiceCode": "AmazonS3",
+	})
+	assertPricingError(t, resp, http.StatusBadRequest, "AccessDeniedException")
+
+	// Clearing just that operation leaves the wildcard in force.
+	clearPricingFailures(t, ts, "GetProducts")
+	resp = pricingCall(t, ts, "us-east-1", "GetProducts", map[string]any{
+		"ServiceCode": "AmazonS3",
+	})
+	assertPricingError(t, resp, http.StatusInternalServerError, "InternalErrorException")
+}
+
+// TestPricingSeedFailure_RejectsBadCode: the seed endpoint validates the code
+// against the documented set. A typo'd code would otherwise seed an error no
+// consumer's catch branch matches, so their fallback path would go untested while
+// the seed itself appeared to work.
+func TestPricingSeedFailure_RejectsBadCode(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	tests := []struct {
+		name string
+		seed map[string]any
+	}{
+		{"code omitted", map[string]any{"operation": "GetProducts"}},
+		{"typo in a real code", map[string]any{"code": "ThrotlingException"}},
+		{"not a Price List code", map[string]any{"code": "NoSuchBucket"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body, err := json.Marshal(tt.seed)
+			if err != nil {
+				t.Fatalf("marshal seed: %v", err)
+			}
+			resp, err := http.Post(ts.URL+"/v1/pricing/query-failures", //nolint:noctx
+				"application/json", bytes.NewReader(body))
+			if err != nil {
+				t.Fatalf("post seed: %v", err)
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 (body %s)", resp.StatusCode,
+					mustReadAll(t, resp))
+				return
+			}
+			_ = mustReadAll(t, resp)
+		})
+	}
+}
+
+// TestPricingSeedFailure_AcceptsEveryDocumentedCode makes sure the validation
+// above did not narrow the seedable set: every code the Price List API documents
+// must still be seedable, with the status AWS gives it.
+func TestPricingSeedFailure_AcceptsEveryDocumentedCode(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		code   string
+		status int
+	}{
+		{"AccessDeniedException", http.StatusBadRequest},
+		{"ExpiredNextTokenException", http.StatusBadRequest},
+		{"InvalidNextTokenException", http.StatusBadRequest},
+		{"InvalidParameterException", http.StatusBadRequest},
+		{"NotFoundException", http.StatusBadRequest},
+		{"ThrottlingException", http.StatusBadRequest},
+		{"InternalErrorException", http.StatusInternalServerError},
+	} {
+		t.Run(tt.code, func(t *testing.T) {
+			t.Parallel()
+			ts := newPricingTestServer(t)
+			seedPricingFailure(t, ts, map[string]any{"code": tt.code})
+			resp := pricingCall(t, ts, "us-east-1", "GetProducts", map[string]any{
+				"ServiceCode": "AmazonS3",
+			})
+			assertPricingError(t, resp, tt.status, tt.code)
+		})
+	}
+}
+
+// TestPricingSeedFailure_StatusCodeOverride: an explicit statusCode wins over the
+// documented default, so a consumer can reproduce a gateway or proxy returning an
+// unexpected status for a known code.
+func TestPricingSeedFailure_StatusCodeOverride(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	seedPricingFailure(t, ts, map[string]any{
+		"code": "ThrottlingException", "statusCode": http.StatusTooManyRequests,
+	})
+	resp := pricingCall(t, ts, "us-east-1", "GetProducts", map[string]any{
+		"ServiceCode": "AmazonS3",
+	})
+	assertPricingError(t, resp, http.StatusTooManyRequests, "ThrottlingException")
+}
+
+func seedPricingFailure(t *testing.T, ts *httptest.Server, seed map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(seed)
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	resp, err := http.Post(ts.URL+"/v1/pricing/query-failures", //nolint:noctx
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post seed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed status = %d, want 200 (body %s)", resp.StatusCode, mustReadAll(t, resp))
+	}
+	_ = mustReadAll(t, resp)
+}
+
+func clearPricingFailures(t *testing.T, ts *httptest.Server, operation string) {
+	t.Helper()
+	url := ts.URL + "/v1/pricing/query-failures"
+	if operation != "" {
+		url += "?operation=" + operation
+	}
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("build clear request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do clear request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("clear status = %d, want 200 (body %s)", resp.StatusCode, mustReadAll(t, resp))
+	}
+	_ = mustReadAll(t, resp)
+}
+
+// TestPricingRoutesFromHostAndTarget proves both routing signals reach the
+// plugin independently: the X-Amz-Target namespace AWSPriceListService, and the
+// api.pricing.<region> host layout. A request carrying only one of them must
+// still land here (#401).
+func TestPricingRoutesFromHostAndTarget(t *testing.T) {
+	t.Parallel()
+	ts := newPricingTestServer(t)
+
+	tests := []struct {
+		name   string
+		host   string
+		target string
+	}{
+		{"target only", "localhost", "AWSPriceListService.DescribeServices"},
+		{"host only", "api.pricing.us-east-1.amazonaws.com", ""},
+		{"both", "api.pricing.us-east-1.amazonaws.com", "AWSPriceListService.DescribeServices"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader("{}"))
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+			req.Host = tt.host
+			req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+			if tt.target != "" {
+				req.Header.Set("X-Amz-Target", tt.target)
+			} else {
+				// Without a target the operation comes from the Action parameter,
+				// which is how a host-routed request names its operation.
+				req.URL.RawQuery = "Action=DescribeServices"
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("do request: %v", err)
+			}
+			body := mustReadAll(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200 — the request did not route to the "+
+					"pricing plugin (body %s)", resp.StatusCode, body)
+			}
+			if !strings.Contains(body, "AmazonS3") {
+				t.Errorf("DescribeServices body does not mention AmazonS3: %s", body)
+			}
+		})
+	}
+}

--- a/emulator/pricing_query_ctrl.go
+++ b/emulator/pricing_query_ctrl.go
@@ -1,0 +1,95 @@
+package emulator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// handlePricingSeedQueryFailure handles POST /v1/pricing/query-failures.
+// It seeds the error returned by a Price List Query API operation — GetProducts,
+// DescribeServices or GetAttributeValues — for a given operation name (or
+// wildcard "*").
+//
+// This is what makes "pricing degrades, I/O does not" a testable property rather
+// than an assumption: a consumer seeds a ThrottlingException here, drives their
+// code path, and asserts their reads still succeed with whatever fallback rate
+// they carry.
+//
+// Body: {"operation": "GetProducts", "code": "ThrottlingException",
+// "message": "...", "statusCode": 400}
+// The "operation" field defaults to "*" (wildcard) if omitted or empty, and
+// "statusCode" defaults to the status the Price List API documents for the code.
+func (s *Server) handlePricingSeedQueryFailure(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Operation  string `json:"operation"`
+		Code       string `json:"code"`
+		Message    string `json:"message"`
+		StatusCode int    `json:"statusCode"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if body.Code == "" {
+		http.Error(w, `{"error":"code is required"}`, http.StatusBadRequest)
+		return
+	}
+	if !pricingSeedableErrorCodes[body.Code] {
+		http.Error(w, fmt.Sprintf(`{"error":"unknown code %q; must be one of %s"}`,
+			body.Code, strings.Join(pricingSeedableCodeList(), ", ")), http.StatusBadRequest)
+		return
+	}
+	operation := body.Operation
+	if operation == "" {
+		operation = "*"
+	}
+	message := body.Message
+	if message == "" {
+		message = "seeded " + body.Code + " for " + operation
+	}
+	seed, err := json.Marshal(pricingSeededFailure{
+		Code:       body.Code,
+		Message:    message,
+		StatusCode: body.StatusCode,
+	})
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), pricingCtrlNamespace,
+		pricingSeededFailureKey(operation), seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true, "operation": operation})
+}
+
+// handlePricingClearQueryFailures handles DELETE /v1/pricing/query-failures.
+// With ?operation=... it removes the seeded failure for that specific operation.
+// Without a query param it removes all seeded Price List failures.
+func (s *Server) handlePricingClearQueryFailures(w http.ResponseWriter, r *http.Request) {
+	operation := r.URL.Query().Get("operation")
+	if operation != "" {
+		if err := s.state.Delete(r.Context(), pricingCtrlNamespace,
+			pricingSeededFailureKey(operation)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), pricingCtrlNamespace, "failure:")
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), pricingCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]interface{}{"ok": true})
+}

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -283,6 +283,8 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/pricing/credits", s.handlePricingAddCredit)
 	r.Get("/v1/pricing/credits", s.handlePricingListCredits)
 	r.Delete("/v1/pricing/credits/{id}", s.handlePricingRemoveCredit)
+	r.Post("/v1/pricing/query-failures", s.handlePricingSeedQueryFailure)
+	r.Delete("/v1/pricing/query-failures", s.handlePricingClearQueryFailures)
 
 	// Health control-plane endpoints.
 	r.Post("/v1/health/events", s.handleHealthSeedEvents)


### PR DESCRIPTION
Emulates the AWS Price List Query API — `GetProducts`, `DescribeServices`,
`GetAttributeValues` — so a consumer that queries AWS rates at runtime can test
that path without network access.

This is the *server* side of pricing. It is the inverse of substrate's existing
cost-tracking provider (`AWSPricingProvider`, `/v1/pricing/lookup`), which
consumes the public offer index to price substrate's own simulated usage.

Stacked on #417 (`fix/403-region-from-host`), which fixes the *region* half of
the same host layout. Both touch `parser.go`. Please merge #417 first.

## The corpus is real, on purpose

Seven Amazon S3 SKUs copied verbatim from the live
`AmazonS3/current/us-east-1/index.json` offer file (version `20260728131000`).
Every SKU, rate code, `pricePerUnit` string and attribute value was taken from
that file — nothing is invented, because the point of the fixture is to reproduce
the shapes that surprise a caller. A tidied-up corpus would let a consumer's
parser pass its tests and then misbehave against the real API.

Each entry earns its place by exhibiting one trap:

| Shape | Why it matters |
|---|---|
| `PriceList` elements are JSON documents encoded as **strings** | Decoding needs a second unmarshal per element |
| `pricePerUnit`/`beginRange`/`endRange` are **strings** (`"0.0230000000"`) | A `float64` field silently fails to unmarshal |
| `productFamily` **absent** from most products (315 of 381 in the real file) | A filter on it misses the majority of SKUs; `usagetype` is the reliable key |
| `TimedStorage-ByteHrs` has **three** `priceDimensions`, last `endRange: "Inf"` | Reading the first reports the 50 TB rate as the only rate |

## Two verified corrections to the issue

**`Requests-Tier1` is `"0.0000050000"` per request**, `unit: Requests` — that is
$0.005 per 1,000. The static table in the issue had `0.0005`, which is 10× low;
and because the unit is per-request, dividing by 1,000 again is a 1,000× error.

**The Deep Archive filter is worse than reported.** Filtering
`productFamily=Storage` + `volumeType="Glacier Deep Archive"` does not return a
decoy *alongside* the right SKU — in both regional slices of the live file it
returns **only** `TimedStorage-GDA-Staging` at `"0.0210000000"`, 21× the $0.00099
archive rate. There is no `TimedStorage-GDA-ByteHrs` SKU in the S3 offer file at
all, so that filter cannot return the rate a caller expects. The only $0.00099
rate in the file is Intelligent-Tiering's `TimedStorage-INT-DAA-ByteHrs`. Both
SKUs are in the corpus so a test can assert it reached the right one, not just the
right number.

**And the endpoint count: three, not two.** AWS lists `us-east-1`, `ap-south-1`
**and `eu-central-1`** (Frankfurt).

## Contract details, doc-verified

`Filter.Type` supports the full enum — `TERM_MATCH`, `EQUALS`, `CONTAINS`,
`ANY_OF`, `NONE_OF` — not just `TERM_MATCH`; `ANY_OF`/`NONE_OF` take a
comma-separated `Value`. `MaxResults` bounds differ per operation (1–100 for
`GetProducts`/`DescribeServices`, 1–**10000** for `GetAttributeValues`), and an
out-of-range value is `InvalidParameterException` rather than a silent clamp,
because clamping hides the caller's mistake. `FormatVersion` accepts only
`aws_v1`. Pagination uses an opaque `NextToken`; an undecodable token or one
pointing past the end is `InvalidNextTokenException` — an error a caller otherwise
cannot reach.

An unknown `ServiceCode` is `NotFoundException`, not an empty `PriceList`.
Substrate's corpus is far smaller than AWS's catalog, and an empty result would
read as "AWS has no such price". A false alarm is visible; a false empty is not.

## Seedable failure

`POST`/`DELETE /v1/pricing/query-failures`, keyed by operation or `"*"`. This is
the acceptance criterion about pricing degrading without taking I/O down: that
property is only testable if the failure can be produced on demand, otherwise the
fallback branch is unreachable and a green suite says nothing about it.

The endpoint rejects any code outside the seven the API documents. A typo'd code
(`ThrotlingException`) would seed an error no SDK catch branch matches — the
fallback path would go untested while the seed itself appeared to work, which is
precisely the failure mode this whole issue batch exists to kill.

## One deliberate divergence

AWS hosts this API in three regions and nowhere else; there is no
`api.pricing.eu-west-1.amazonaws.com` to resolve. Substrate serves every region
from one endpoint, so it cannot reproduce a name that fails to resolve. A request
signed for any other region is rejected with **`SubstrateInvalidPricingEndpoint`**
(400) — deliberately *not* an AWS code, so it cannot be mistaken for one, and
documented in `docs/services.md` as a divergence rather than presented as parity.
Answering such a request instead would mean pricing against an endpoint that does
not exist.

## Also: the service half of the `api.` host fix

#403/#417 fixed the *region* parsed from `api.pricing.us-east-1.amazonaws.com`.
The *service* had the same bug from the other end: the first label yielded a
service literally named `api`, so the request could not route to any plugin.
`api.ecr.*` and `api.sagemaker.*` were affected too — reachable until now only via
their `X-Amz-Target` namespace. `apigateway.*` is covered by a test to confirm the
stripped prefix is the label `api.`, not the letters.

## Verification

`go build`, `go vet`, `golangci-lint run ./...` **0 issues**, `make test` (race)
green, `test/e2e` green, `make docs-reference-check` passes,
`make scan-fs` 0 findings.

New tests assert the traps structurally rather than asserting a request
succeeded: `PriceList` elements are checked to be strings (with a failure message
explaining why), every `pricePerUnit` is checked to be a string, the tiered SKU is
checked to have all three dimensions indexed by `beginRange`, the Deep Archive
filter is checked to return only the staging SKU, and every value
`GetAttributeValues` advertises is fed back through a `GetProducts` filter to
prove it matches at least one product — so the documented discovery path cannot
dead-end.

Closes #401.