### PR TITLE
feat(s3): record storage classes and honor CopyObject metadata directives (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Not emulated, deliberately: the `409 ConditionalRequestConflict` and the
     concurrent-delete `404` that real S3 can return, both of which are races against
     wall-clock timing rather than states a deterministic emulator can reach.
+- S3 storage classes, `InvalidObjectState`, and `CopyObject` metadata directives
+  (#398). `x-amz-storage-class` had been discarded on every write and reported
+  nowhere, so a consumer implementing lifecycle transitions could not observe the
+  one thing a transition changes — and the classes whose objects real S3 refuses to
+  serve looked exactly like the ones it serves instantly.
+  - **Recorded and reported.** `PutObject`, `CopyObject` and
+    `CreateMultipartUpload` accept `x-amz-storage-class`, defaulting to `STANDARD`
+    when absent. All thirteen documented values are accepted, including the
+    Outposts, Snow, Express One Zone and FSx tiers — rejecting a value real S3
+    takes is the same class of defect as accepting one it rejects. Anything else is
+    `400 InvalidStorageClass`, raised before the write, so a rejected class leaves
+    no object behind. The class is reported as `x-amz-storage-class` on
+    `GetObject`/`HeadObject` — **omitted for `STANDARD`**, per the response-header
+    reference — and as `<StorageClass>` in `ListObjects`, `ListObjectsV2`,
+    `ListObjectVersions` and `ListMultipartUploads`, where unlike the header it is
+    emitted for every class including `STANDARD`. A `<DeleteMarker>` carries none,
+    matching S3's response shape. A class set at `CreateMultipartUpload` survives
+    to the object `CompleteMultipartUpload` assembles.
+  - **Archived objects are unreadable.** `GetObject` of a `GLACIER` or
+    `DEEP_ARCHIVE` object is `403 InvalidObjectState`, as is a `CopyObject` naming
+    one as its source. The check precedes the `Range` step, so a ranged read of an
+    archived object is the same `403` rather than a `206`. `GLACIER_IR` reads
+    normally: it is the instant-retrieval tier, and conflating it with the archival
+    classes would make a consumer's restore path fire where real S3 never would.
+  - **`HeadObject` of an archived object is `200`, not `403`** — a deliberate
+    departure from the issue as filed. The `HeadObject` reference documents no
+    `InvalidObjectState` and states that "even if the object is stored in S3
+    Glacier, all object metadata is still available", which is what makes `HEAD`
+    the way a consumer discovers that a `GET` needs a restore first. `GetObject`'s
+    reference does list the error. Emulating a `403` on `HEAD` would have made a
+    test pass against substrate and fail against AWS.
+  - **`CopyObject` metadata directives.** `x-amz-metadata-directive` and
+    `x-amz-tagging-directive` are both honored, both defaulting to `COPY`, and an
+    unrecognized value on either is `400 InvalidArgument` rather than a silent fall
+    back to the default. Under `COPY` the destination takes the source's
+    `Content-Type`, `Content-Encoding`, user metadata and tags, and headers
+    restated on the request are ignored; under `REPLACE` it takes only what the
+    request supplies and drops the rest. `Content-Encoding` had previously been
+    dropped on every copy regardless of directive, so a copy of a gzipped object
+    produced one a client would hand to the application still compressed.
+  - **The storage class is never inherited from the source**, per "if the
+    `x-amz-storage-class` header is not used, the copied object will be stored in
+    the `STANDARD` Storage Class by default" — so an unqualified copy of a
+    `STANDARD_IA` object yields a `STANDARD` one. This is what makes an in-place
+    `CopyObject` with a new class the tier-transition mechanism, and also the trap:
+    a transition using `REPLACE` must restate the metadata it means to keep.
+  - `RestoreObject`, the `x-amz-restore` header and Intelligent-Tiering archive
+    access tiers are not implemented, so an archived object stays unreadable for
+    the run; restoring is modeled by copying to a non-archival class.
 
 ### Fixed
 - EC2 `Describe*` calls that name a resource ID explicitly now raise
@@ -138,11 +187,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alone — it had to issue a GET and download the body to find out.
 - S3 `GetObject` and `HeadObject` now advertise `Accept-Ranges: bytes`, as real
   S3 does on both (#396).
+- S3 `CopyObject` no longer discards the source object's `Content-Encoding` and
+  object tags (#398). Both are user-controlled metadata that a default (`COPY`)
+  copy preserves on real S3, so a copy of a gzipped object produced one whose body
+  a client would hand to the application still compressed, and a copy silently lost
+  the tags any cost-allocation or lifecycle rule keyed on. The destination's
+  metadata map is also no longer aliased to the source's, so retagging one object
+  no longer mutates the other.
 
 ### Changed
 - The S3 error-response builder can now carry error-specific child elements and
   response headers (#396), which the `InvalidRange` body needs and which
-  `EntityTooSmall` (#400) now uses and `StorageClass` (#398) will need. Its
+  `EntityTooSmall` (#400) and the `CopyObject` directive errors (#398) now use. Its
   `extras ...string` parameter had been an unused stub with no call sites; it is
   replaced by an explicit `s3Error` options struct, and `s3DeleteMarkerResponse`
   now shares the same builder instead of re-declaring its own XML type.

--- a/docs/services.md
+++ b/docs/services.md
@@ -186,18 +186,18 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers; conditional writes — see [Conditional requests](#conditional-requests) |
-| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests) |
-| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests) |
+| PutObject | Supports Content-Type, metadata headers; `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests) |
+| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes) |
+| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes) |
 | DeleteObject | Fires S3 notifications if configured |
-| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests) |
-| ListObjects | |
-| ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken |
-| CreateMultipartUpload | |
+| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects) |
+| ListObjects | Emits `<StorageClass>` per object |
+| ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
+| CreateMultipartUpload | Accepts `x-amz-storage-class`, applied to the assembled object |
 | UploadPart | |
 | CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests) |
 | AbortMultipartUpload | |
-| ListMultipartUploads | |
+| ListMultipartUploads | Emits `<StorageClass>` per in-progress upload |
 | GetBucketPolicy | |
 | PutBucketPolicy | |
 | DeleteBucketPolicy | |
@@ -213,6 +213,96 @@ STS operations are free.
 | PutObjectTagging | |
 | GetObjectTagging | |
 | DeleteObjectTagging | |
+
+### Storage classes
+
+`PutObject`, `CopyObject` and `CreateMultipartUpload` accept `x-amz-storage-class`
+and record it on the object. An absent header means `STANDARD`, S3's documented
+default for a newly created object. All thirteen documented values are accepted:
+
+```
+STANDARD  REDUCED_REDUNDANCY  STANDARD_IA  ONEZONE_IA  INTELLIGENT_TIERING
+GLACIER  DEEP_ARCHIVE  OUTPOSTS  GLACIER_IR  SNOW  EXPRESS_ONEZONE
+FSX_OPENZFS  FSX_ONTAP
+```
+
+Any other value — including a lowercase or whitespace-padded one — is `400
+InvalidStorageClass`, rejected before anything is written, so the key does not
+appear. The classes reachable only through Outposts, Snow, Express One Zone and the
+FSx-backed tiers are accepted but carry no distinct behaviour beyond being recorded.
+
+How the class is reported back differs between the header and the XML, which is easy
+to get wrong in both directions:
+
+| Surface | STANDARD | Every other class |
+|---|---|---|
+| `x-amz-storage-class` response header on `GetObject`/`HeadObject` | **Omitted** | Present |
+| `<StorageClass>` in `ListObjects`, `ListObjectsV2`, `ListObjectVersions`, `ListMultipartUploads` | `STANDARD` | The class |
+
+An absent header therefore means `STANDARD`, not "unknown". A `<DeleteMarker>` entry
+in `ListObjectVersions` carries no `<StorageClass>`, matching S3's response shape.
+
+**Archived objects.** A `GetObject` of a `GLACIER` or `DEEP_ARCHIVE` object is `403
+InvalidObjectState` with the message `The action is not valid for the object's
+storage class`, and so is a `CopyObject` that names one as its source — S3 requires
+a restore first. The check precedes the `Range` step, so a ranged read of an
+archived object is the same `403`, not a `206`.
+
+`GLACIER_IR` is **not** archival. It is the instant-retrieval tier and reads
+normally; so do `STANDARD_IA`, `ONEZONE_IA` and `INTELLIGENT_TIERING`.
+
+`HeadObject` of an archived object is a **`200`**, not a `403`. The `HeadObject`
+reference documents no `InvalidObjectState` and states that "even if the object is
+stored in S3 Glacier, all object metadata is still available" — which is what makes
+`HEAD` the way a consumer discovers that a `GET` would need a restore first. A test
+asserting `403` on `HEAD` is asserting behaviour real S3 does not have.
+
+`RestoreObject` and the `x-amz-restore` response header are not implemented, so an
+archived object stays unreadable for the lifetime of the emulator run. Restoring is
+modeled by copying the object to a non-archival class.
+
+Intelligent-Tiering archive access tiers are not modeled, so the `InvalidObjectState`
+variant carrying `<StorageClass>` and `<AccessTier>` children is never returned.
+
+### Copying objects
+
+`CopyObject`'s metadata behaviour is governed by two independent directives, both
+defaulting to `COPY` when absent. An unrecognized value on either is `400
+InvalidArgument` rather than a silent fall back to the default — a typo that quietly
+preserved metadata is the kind of false success this emulator exists to surface.
+
+| `x-amz-metadata-directive` | Destination `Content-Type`, `Content-Encoding`, `x-amz-meta-*` |
+|---|---|
+| `COPY` (default) | Taken from the **source**; headers restated on the request are ignored |
+| `REPLACE` | Taken from the **request**; anything not restated is dropped |
+
+`COPY` preserving `Content-Encoding` is the documented behaviour: "when you copy an
+object, user-controlled system metadata and user-defined metadata are also copied",
+and `Content-Type`, `Content-Encoding`, `Content-Disposition` and `Cache-Control` are
+all user-controlled. Only `x-amz-website-redirect-location` is documented as not
+copied, and substrate does not model it.
+
+The loss case is `REPLACE`: "you must explicitly specify all of the user-configurable
+metadata present on the source object in your request, even if you are changing only
+one of the metadata values". A `REPLACE` that omits `Content-Encoding` drops it, and
+`Content-Type` falls back to `application/octet-stream`.
+
+`x-amz-tagging-directive` works the same way for the tag-set: `COPY` (the default)
+carries the source's tags, `REPLACE` takes them from `x-amz-tagging` as URL query
+parameters (`stage=prod&owner=alice`), defaulting to an empty tag-set when that
+header is absent.
+
+**Storage class is never inherited.** "If the `x-amz-storage-class` header is not
+used, the copied object will be stored in the `STANDARD` Storage Class by default" —
+so an unqualified copy of a `STANDARD_IA` object yields a `STANDARD` one. This is
+what makes an in-place `CopyObject` onto an object's own key with a new
+`x-amz-storage-class` the tier-transition mechanism, and it is also the trap: a
+transition that means to change only the class must restate the metadata it wants to
+keep if it uses `REPLACE`.
+
+Every request-derived value — storage class, both directives, both precondition sets
+— is resolved before the first write, so a rejected copy leaves the destination
+untouched.
 
 ### Ranged reads
 

--- a/emulator/s3_copy_metadata.go
+++ b/emulator/s3_copy_metadata.go
@@ -1,0 +1,144 @@
+package emulator
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// s3DirectiveCopy and s3DirectiveReplace are the two values S3 accepts in
+// x-amz-metadata-directive and x-amz-tagging-directive. COPY is the default for
+// both when the header is absent.
+const (
+	s3DirectiveCopy    = "COPY"
+	s3DirectiveReplace = "REPLACE"
+)
+
+// s3CopyMetadata is the metadata a CopyObject should record on its destination,
+// already resolved against the request's x-amz-metadata-directive.
+type s3CopyMetadata struct {
+	ContentType     string
+	ContentEncoding string
+	UserMetadata    map[string]string
+}
+
+// resolveDirective returns the COPY/REPLACE value of a directive header, or the
+// error response to serve when the value is neither.
+//
+// An absent header means COPY: "if this header isn't specified, COPY is the default
+// behavior". An unrecognized value is rejected rather than silently treated as the
+// default, because a typo'd directive that quietly preserved metadata is exactly the
+// kind of false success this emulator exists to catch. The code is S3's generic
+// 400 for a bad header value; the message wording is substrate's.
+func resolveDirective(headers map[string]string, name string) (string, *AWSResponse) {
+	value := headerValueFold(headers, name)
+	switch {
+	case value == "":
+		return s3DirectiveCopy, nil
+	case strings.EqualFold(value, s3DirectiveCopy):
+		return s3DirectiveCopy, nil
+	case strings.EqualFold(value, s3DirectiveReplace):
+		return s3DirectiveReplace, nil
+	}
+	return "", s3ErrorResponseWith(s3Error{
+		Code:    "InvalidArgument",
+		Message: "Unknown " + name + ". The directive must be COPY or REPLACE.",
+		Status:  http.StatusBadRequest,
+		Details: []s3ErrorDetail{
+			{Name: "ArgumentName", Value: name},
+			{Name: "ArgumentValue", Value: value},
+		},
+	})
+}
+
+// resolveCopyMetadata returns the metadata a CopyObject records on its destination,
+// or the error response to serve when x-amz-metadata-directive is malformed.
+//
+// Under COPY — the default — the source's user-controlled system metadata carries
+// over along with its user-defined metadata: "when you copy an object,
+// user-controlled system metadata and user-defined metadata are also copied", and
+// Content-Type, Content-Encoding, Content-Disposition and Cache-Control are all
+// user-controlled. Only x-amz-website-redirect-location is documented as not copied,
+// and substrate does not model it.
+//
+// Under REPLACE nothing carries over. The request must restate everything it wants
+// kept: "you must explicitly specify all of the user-configurable metadata present
+// on the source object in your request, even if you are changing only one of the
+// metadata values". This is the asymmetry a consumer's in-place CopyObject tier
+// transition trips over — a REPLACE that omits Content-Encoding loses it.
+func resolveCopyMetadata(headers map[string]string, src *S3Object) (s3CopyMetadata, *AWSResponse) {
+	directive, errResp := resolveDirective(headers, "x-amz-metadata-directive")
+	if errResp != nil {
+		return s3CopyMetadata{}, errResp
+	}
+
+	if directive == s3DirectiveCopy {
+		return s3CopyMetadata{
+			ContentType:     src.ContentType,
+			ContentEncoding: src.ContentEncoding,
+			UserMetadata:    copyStringMap(src.UserMetadata),
+		}, nil
+	}
+
+	contentType := headerValueFold(headers, "Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	return s3CopyMetadata{
+		ContentType:     contentType,
+		ContentEncoding: headerValueFold(headers, "Content-Encoding"),
+		UserMetadata:    extractUserMetadata(headers),
+	}, nil
+}
+
+// resolveCopyTags returns the tag-set a CopyObject records on its destination, or
+// the error response to serve when x-amz-tagging-directive is malformed.
+//
+// COPY is the default here too, so an ordinary copy carries the source's tags:
+// "if you choose COPY for the x-amz-tagging-directive, you don't need to set the
+// x-amz-tagging header, because the tag-set will be copied from the source object
+// directly". Under REPLACE the tag-set comes from x-amz-tagging, which S3 documents
+// as URL query-parameter encoded and defaulting to empty.
+func resolveCopyTags(headers map[string]string, src *S3Object) (map[string]string, *AWSResponse) {
+	directive, errResp := resolveDirective(headers, "x-amz-tagging-directive")
+	if errResp != nil {
+		return nil, errResp
+	}
+
+	if directive == s3DirectiveCopy {
+		return copyStringMap(src.Tags), nil
+	}
+
+	tagging := headerValueFold(headers, "x-amz-tagging")
+	if tagging == "" {
+		return nil, nil
+	}
+	values, parseErr := url.ParseQuery(tagging)
+	if parseErr != nil {
+		return nil, s3ErrorResponseWith(s3Error{
+			Code:    "InvalidArgument",
+			Message: "The tag-set must be encoded as URL query parameters.",
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{{Name: "ArgumentName", Value: "x-amz-tagging"}},
+		})
+	}
+	tags := make(map[string]string, len(values))
+	for k := range values {
+		tags[k] = values.Get(k)
+	}
+	return tags, nil
+}
+
+// copyStringMap returns an independent copy of m, or nil when m is empty. The copy
+// keeps a destination object's metadata from aliasing the source's, so a later
+// PutObjectTagging on one does not mutate the other.
+func copyStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -453,6 +453,13 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
+	// Validated before anything is written, so a rejected storage class leaves no
+	// partial object behind.
+	storageClass, scErr := resolveStorageClass(req.Headers)
+	if scErr != nil {
+		return scErr, nil
+	}
+
 	// Conditional writes must not race: the existence check and the write below have
 	// to be one atomic step, or N concurrent If-None-Match: * PUTs would all
 	// observe the key as absent and all succeed. See [s3KeyMutex].
@@ -503,6 +510,7 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		ContentType:     contentType,
 		ContentEncoding: req.Headers["Content-Encoding"],
 		Size:            int64(len(body)),
+		StorageClass:    storageClass,
 		LastModified:    p.tc.Now(),
 		UserMetadata:    userMeta,
 	}
@@ -620,6 +628,12 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 		}
 	}
 
+	// An archived object has no readable body, so its storage class is checked
+	// before the preconditions that would compare against one.
+	if resp := evaluateStorageClassRead(&obj); resp != nil {
+		return resp, nil
+	}
+
 	// Preconditions are evaluated before the range step: a 412 or 304 supersedes
 	// any range, and RFC 9110 requires a failed precondition to be reported rather
 	// than a partial response served.
@@ -676,7 +690,10 @@ func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key st
 		return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
 	}
 
-	// HEAD evaluates preconditions exactly as GET does.
+	// HEAD evaluates preconditions exactly as GET does. It deliberately does *not*
+	// check the storage class the way getObject does: HeadObject documents no
+	// InvalidObjectState, because "even if the object is stored in S3 Glacier, all
+	// object metadata is still available". See [evaluateStorageClassRead].
 	if resp := evaluateReadPreconditions(readConditionalHeaders(req.Headers), &obj); resp != nil {
 		return resp, nil
 	}
@@ -902,6 +919,29 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
+	// An archived source must be restored before it can be copied: "if the source
+	// object is in the S3 Glacier Flexible Retrieval or S3 Glacier Deep Archive
+	// storage class, you must restore a copy of this object before you can use it as
+	// a source object for the copy operation."
+	if resp := evaluateStorageClassRead(&srcObj); resp != nil {
+		return resp, nil
+	}
+
+	// Every request-derived value is resolved before the first write, so a malformed
+	// directive or storage class leaves the destination untouched.
+	dstStorageClass, scErr := resolveStorageClass(req.Headers)
+	if scErr != nil {
+		return scErr, nil
+	}
+	meta, metaErr := resolveCopyMetadata(req.Headers, &srcObj)
+	if metaErr != nil {
+		return metaErr, nil
+	}
+	tags, tagErr := resolveCopyTags(req.Headers, &srcObj)
+	if tagErr != nil {
+		return tagErr, nil
+	}
+
 	// Source preconditions gate whether the copy may read; destination
 	// preconditions gate whether it may overwrite. Both are checked before any
 	// write, so a rejected copy leaves the destination untouched.
@@ -945,13 +985,19 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	newETag := fmt.Sprintf(`"%x"`, hash)
 
 	dstObj := S3Object{
-		Bucket:       dstBucket,
-		Key:          dstKey,
-		ETag:         newETag,
-		ContentType:  srcObj.ContentType,
-		Size:         srcObj.Size,
+		Bucket:          dstBucket,
+		Key:             dstKey,
+		ETag:            newETag,
+		ContentType:     meta.ContentType,
+		ContentEncoding: meta.ContentEncoding,
+		Size:            srcObj.Size,
+		// The copy's class comes from the request, never from the source: "if the
+		// x-amz-storage-class header is not used, the copied object will be stored in
+		// the STANDARD Storage Class by default."
+		StorageClass: dstStorageClass,
 		LastModified: now,
-		UserMetadata: srcObj.UserMetadata,
+		UserMetadata: meta.UserMetadata,
+		Tags:         tags,
 	}
 
 	dstMeta, err := json.Marshal(dstObj)
@@ -1181,6 +1227,13 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
+	// The storage class is supplied here, at creation, not on Complete — so it is
+	// validated here and carried on the upload until the object is assembled.
+	storageClass, scErr := resolveStorageClass(req.Headers)
+	if scErr != nil {
+		return scErr, nil
+	}
+
 	uploadID := generateUploadID()
 
 	contentType := req.Headers["Content-Type"]
@@ -1193,6 +1246,7 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		Bucket:       bucket,
 		Key:          key,
 		ContentType:  contentType,
+		StorageClass: storageClass,
 		Initiated:    p.tc.Now(),
 		UserMetadata: extractUserMetadata(req.Headers),
 	}
@@ -1400,6 +1454,7 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		ETag:         etag,
 		ContentType:  upload.ContentType,
 		Size:         int64(len(combined)),
+		StorageClass: upload.StorageClass,
 		LastModified: p.tc.Now(),
 		UserMetadata: upload.UserMetadata,
 	}
@@ -1572,9 +1627,10 @@ func (p *S3Plugin) listMultipartUploads(_ *RequestContext, _ *AWSRequest, bucket
 	}
 
 	type uploadEntry struct {
-		Key       string `xml:"Key"`
-		UploadId  string `xml:"UploadId"` //nolint:revive // matches AWS XML field name
-		Initiated string `xml:"Initiated"`
+		Key          string `xml:"Key"`
+		UploadId     string `xml:"UploadId"` //nolint:revive // matches AWS XML field name
+		StorageClass string `xml:"StorageClass"`
+		Initiated    string `xml:"Initiated"`
 	}
 	type listMultipartUploadsResult struct {
 		XMLName xml.Name      `xml:"ListMultipartUploadsResult"`
@@ -1596,10 +1652,15 @@ func (p *S3Plugin) listMultipartUploads(_ *RequestContext, _ *AWSRequest, bucket
 		if upload.Bucket != bucket {
 			continue
 		}
+		storageClass := upload.StorageClass
+		if storageClass == "" {
+			storageClass = S3StorageClassStandard
+		}
 		result.Uploads = append(result.Uploads, uploadEntry{
-			Key:       upload.Key,
-			UploadId:  upload.UploadID,
-			Initiated: upload.Initiated.UTC().Format(time.RFC3339),
+			Key:          upload.Key,
+			UploadId:     upload.UploadID,
+			StorageClass: storageClass,
+			Initiated:    upload.Initiated.UTC().Format(time.RFC3339),
 		})
 	}
 
@@ -1633,6 +1694,7 @@ type objectEntryItem struct {
 	LastModified string `xml:"LastModified"`
 	ETag         string `xml:"ETag"`
 	Size         int64  `xml:"Size"`
+	StorageClass string `xml:"StorageClass"`
 }
 
 // loadObjectEntry loads and returns the XML entry for a single object.
@@ -1657,6 +1719,9 @@ func (p *S3Plugin) loadObjectEntry(ctx context.Context, bucket, key string) (*ob
 		LastModified: obj.LastModified.UTC().Format(time.RFC3339),
 		ETag:         obj.ETag,
 		Size:         obj.Size,
+		// Unlike the x-amz-storage-class response header, <StorageClass> is emitted
+		// for every listed object, STANDARD included.
+		StorageClass: storageClassOf(&obj),
 	}, nil
 }
 
@@ -1869,6 +1934,11 @@ func objectResponseHeaders(obj *S3Object) map[string]string {
 	}
 	if obj.VersionID != "" {
 		headers["x-amz-version-id"] = obj.VersionID
+	}
+	// "Amazon S3 returns this header for all objects except for S3 Standard storage
+	// class objects" — so an absent header means STANDARD, not unknown.
+	if sc := storageClassOf(obj); sc != S3StorageClassStandard {
+		headers["x-amz-storage-class"] = sc
 	}
 	for k, v := range obj.UserMetadata {
 		headers["X-Amz-Meta-"+k] = v
@@ -2792,6 +2862,7 @@ func (p *S3Plugin) listObjectVersions(_ *RequestContext, req *AWSRequest, bucket
 				LastModified: obj.LastModified.UTC().Format(time.RFC3339Nano),
 				ETag:         obj.ETag,
 				Size:         obj.Size,
+				StorageClass: storageClassOf(&obj),
 			})
 			continue
 		}
@@ -2821,6 +2892,7 @@ func (p *S3Plugin) listObjectVersions(_ *RequestContext, req *AWSRequest, bucket
 					LastModified: obj.LastModified.UTC().Format(time.RFC3339Nano),
 					ETag:         obj.ETag,
 					Size:         obj.Size,
+					StorageClass: storageClassOf(&obj),
 				})
 			}
 		}

--- a/emulator/s3_storage_class.go
+++ b/emulator/s3_storage_class.go
@@ -1,0 +1,89 @@
+package emulator
+
+import (
+	"net/http"
+)
+
+// S3StorageClassStandard is the storage class S3 assigns to an object written
+// without an x-amz-storage-class header. It is also the one class S3 omits from
+// the x-amz-storage-class response header on GetObject and HeadObject.
+const S3StorageClassStandard = "STANDARD"
+
+// s3StorageClasses is the set of values S3 accepts in x-amz-storage-class.
+//
+// It is the full documented enumeration, including the classes reachable only
+// through S3 on Outposts, Snow, Express One Zone and the FSx-backed tiers. Those
+// are not modeled as distinct behavior here, but accepting them keeps substrate
+// from rejecting a value real S3 would take — an emulator that returns an error
+// where AWS succeeds is the same class of defect as one that succeeds where AWS
+// errors.
+var s3StorageClasses = map[string]bool{
+	S3StorageClassStandard: true,
+	"REDUCED_REDUNDANCY":   true,
+	"STANDARD_IA":          true,
+	"ONEZONE_IA":           true,
+	"INTELLIGENT_TIERING":  true,
+	"GLACIER":              true,
+	"DEEP_ARCHIVE":         true,
+	"OUTPOSTS":             true,
+	"GLACIER_IR":           true,
+	"SNOW":                 true,
+	"EXPRESS_ONEZONE":      true,
+	"FSX_OPENZFS":          true,
+	"FSX_ONTAP":            true,
+}
+
+// s3ArchiveStorageClasses is the set of storage classes whose objects are not
+// directly readable: a GetObject against one fails until the object is restored.
+//
+// GLACIER_IR is deliberately absent. It is the instant-retrieval tier and reads
+// like any other class; treating it as archival is a plausible-looking mistake
+// that would make a consumer's restore path fire where real S3 never would.
+var s3ArchiveStorageClasses = map[string]bool{
+	"GLACIER":      true,
+	"DEEP_ARCHIVE": true,
+}
+
+// resolveStorageClass returns the storage class a write should record, given the
+// request's x-amz-storage-class header, along with the error response to serve
+// when the value is not one S3 accepts.
+//
+// An absent or empty header yields STANDARD, which is S3's documented default for
+// a newly created object. This is applied to CopyObject too: the copy's class comes
+// from the request, and is *not* inherited from the source — "if the
+// x-amz-storage-class header is not used, the copied object will be stored in the
+// STANDARD Storage Class by default".
+func resolveStorageClass(headers map[string]string) (string, *AWSResponse) {
+	value := headerValueFold(headers, "x-amz-storage-class")
+	if value == "" {
+		return S3StorageClassStandard, nil
+	}
+	if !s3StorageClasses[value] {
+		return "", s3ErrorResponse("InvalidStorageClass", "The storage class you specified is not valid.", http.StatusBadRequest)
+	}
+	return value, nil
+}
+
+// storageClassOf returns an object's storage class, treating the empty string as
+// STANDARD so that objects written before the field existed read back correctly.
+func storageClassOf(obj *S3Object) string {
+	if obj.StorageClass == "" {
+		return S3StorageClassStandard
+	}
+	return obj.StorageClass
+}
+
+// evaluateStorageClassRead returns the error response to serve when an object's
+// storage class makes its body unavailable, or nil when the read may proceed.
+//
+// Only GetObject uses this. HeadObject deliberately does not: "Even if the object
+// is stored in S3 Glacier, all object metadata is still available", and the
+// HeadObject reference lists no error but NoSuchKey. A HEAD of an archived object
+// is a 200 — which is what makes HEAD the way a consumer discovers that a GET
+// would need a restore first.
+func evaluateStorageClassRead(obj *S3Object) *AWSResponse {
+	if !s3ArchiveStorageClasses[storageClassOf(obj)] {
+		return nil
+	}
+	return s3ErrorResponse("InvalidObjectState", "The action is not valid for the object's storage class", http.StatusForbidden)
+}

--- a/emulator/s3_storage_class_test.go
+++ b/emulator/s3_storage_class_test.go
@@ -1,0 +1,692 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// storageClassFixture creates a bucket and returns the server.
+func storageClassFixture(t *testing.T, bucket string) *emulator.Server {
+	t.Helper()
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code, "create bucket")
+	return srv
+}
+
+// listedStorageClass returns the <StorageClass> ListObjectsV2 reports for a key.
+func listedStorageClass(t *testing.T, srv *emulator.Server, bucket, key string) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?list-type=2", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "list objects v2")
+
+	var result struct {
+		Contents []struct {
+			Key          string `xml:"Key"`
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"Contents"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+
+	for _, c := range result.Contents {
+		if c.Key == key {
+			return c.StorageClass
+		}
+	}
+	t.Fatalf("key %q absent from ListObjectsV2: %s", key, w.Body.String())
+	return ""
+}
+
+// TestS3_StorageClass_RoundTrip covers every storage class S3 documents: the value
+// PutObject records must come back on HEAD and in ListObjectsV2, and the
+// x-amz-storage-class response header must be omitted for STANDARD only.
+func TestS3_StorageClass_RoundTrip(t *testing.T) {
+	// The full documented enumeration, so a valid value is never rejected.
+	classes := []string{
+		"STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA",
+		"INTELLIGENT_TIERING", "GLACIER", "DEEP_ARCHIVE", "OUTPOSTS",
+		"GLACIER_IR", "SNOW", "EXPRESS_ONEZONE", "FSX_OPENZFS", "FSX_ONTAP",
+	}
+
+	for _, class := range classes {
+		t.Run(class, func(t *testing.T) {
+			srv := storageClassFixture(t, "sc-bucket")
+			key := "obj-" + class
+
+			pw := s3Request(t, srv, http.MethodPut, "/sc-bucket/"+key, []byte("payload"),
+				map[string]string{"x-amz-storage-class": class})
+			require.Equal(t, http.StatusOK, pw.Code, "put with storage class %s", class)
+
+			// HEAD reports the class even for the archival tiers: object metadata
+			// stays available regardless of where the body lives.
+			hw := s3Request(t, srv, http.MethodHead, "/sc-bucket/"+key, nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code, "head %s", class)
+
+			if class == "STANDARD" {
+				assert.Empty(t, hw.Header().Get("x-amz-storage-class"),
+					"S3 returns x-amz-storage-class for all objects except STANDARD")
+			} else {
+				assert.Equal(t, class, hw.Header().Get("x-amz-storage-class"))
+			}
+
+			// Unlike the header, the XML element is emitted for every class.
+			assert.Equal(t, class, listedStorageClass(t, srv, "sc-bucket", key))
+		})
+	}
+}
+
+// TestS3_StorageClass_DefaultsToStandard asserts a write with no
+// x-amz-storage-class records STANDARD, not the empty string.
+func TestS3_StorageClass_DefaultsToStandard(t *testing.T) {
+	srv := storageClassFixture(t, "sc-default")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-default/plain", []byte("body"), nil).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sc-default/plain", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Empty(t, hw.Header().Get("x-amz-storage-class"))
+
+	assert.Equal(t, "STANDARD", listedStorageClass(t, srv, "sc-default", "plain"),
+		"an absent header means STANDARD, and the list element is never blank")
+}
+
+// TestS3_StorageClass_Invalid asserts an unrecognized class is a 400
+// InvalidStorageClass, and that the rejected write leaves nothing behind.
+func TestS3_StorageClass_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"unknown", "TURBO_FROZEN"},
+		{"lowercase", "standard"},
+		{"typo", "GLACIER_INSTANT"},
+		{"whitespace", " STANDARD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := storageClassFixture(t, "sc-invalid")
+
+			w := s3Request(t, srv, http.MethodPut, "/sc-invalid/obj", []byte("body"),
+				map[string]string{"x-amz-storage-class": tt.value})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+
+			body := parseS3Error(t, w.Body.Bytes())
+			assert.Equal(t, "InvalidStorageClass", body.Code)
+			assert.Equal(t, "The storage class you specified is not valid.", body.Message)
+
+			// Validation runs before any write, so the key must not exist.
+			assert.Equal(t, http.StatusNotFound,
+				s3Request(t, srv, http.MethodHead, "/sc-invalid/obj", nil, nil).Code,
+				"a rejected storage class must not create the object")
+		})
+	}
+}
+
+// TestS3_StorageClass_ArchivedGetIsInvalidObjectState covers the read gate: the two
+// archival classes fail a GET until restored, and GLACIER_IR — instant retrieval —
+// does not. Conflating the two is the mistake this test exists to catch.
+func TestS3_StorageClass_ArchivedGetIsInvalidObjectState(t *testing.T) {
+	tests := []struct {
+		class      string
+		wantStatus int
+	}{
+		{"GLACIER", http.StatusForbidden},
+		{"DEEP_ARCHIVE", http.StatusForbidden},
+		{"GLACIER_IR", http.StatusOK},
+		{"STANDARD", http.StatusOK},
+		{"STANDARD_IA", http.StatusOK},
+		{"INTELLIGENT_TIERING", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.class, func(t *testing.T) {
+			srv := storageClassFixture(t, "sc-archive")
+			key := "obj-" + tt.class
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sc-archive/"+key, []byte("payload"),
+					map[string]string{"x-amz-storage-class": tt.class}).Code)
+
+			gw := s3Request(t, srv, http.MethodGet, "/sc-archive/"+key, nil, nil)
+			assert.Equal(t, tt.wantStatus, gw.Code)
+
+			if tt.wantStatus == http.StatusForbidden {
+				body := parseS3Error(t, gw.Body.Bytes())
+				assert.Equal(t, "InvalidObjectState", body.Code)
+				assert.Equal(t, "The action is not valid for the object's storage class", body.Message)
+			} else {
+				assert.Equal(t, "payload", gw.Body.String())
+			}
+		})
+	}
+}
+
+// TestS3_StorageClass_ArchivedHeadSucceeds pins the deliberate asymmetry: HeadObject
+// documents no InvalidObjectState, because "even if the object is stored in S3
+// Glacier, all object metadata is still available". HEAD is therefore how a consumer
+// discovers that a GET needs a restore first.
+func TestS3_StorageClass_ArchivedHeadSucceeds(t *testing.T) {
+	for _, class := range []string{"GLACIER", "DEEP_ARCHIVE"} {
+		t.Run(class, func(t *testing.T) {
+			srv := storageClassFixture(t, "sc-head")
+			key := "obj-" + class
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sc-head/"+key, []byte("payload"),
+					map[string]string{"x-amz-storage-class": class}).Code)
+
+			hw := s3Request(t, srv, http.MethodHead, "/sc-head/"+key, nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code, "HEAD of an archived object is a 200")
+			assert.Equal(t, class, hw.Header().Get("x-amz-storage-class"))
+			assert.Equal(t, "7", hw.Header().Get("Content-Length"),
+				"metadata, including the size, stays available")
+		})
+	}
+}
+
+// TestS3_StorageClass_ArchivedRangedGet asserts the archival gate precedes the range
+// step: an archived object has no readable bytes, so a ranged GET is the same 403 as
+// an unranged one rather than a 206.
+func TestS3_StorageClass_ArchivedRangedGet(t *testing.T) {
+	srv := storageClassFixture(t, "sc-range")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-range/frozen", []byte("0123456789"),
+			map[string]string{"x-amz-storage-class": "GLACIER"}).Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/sc-range/frozen", nil,
+		map[string]string{"Range": "bytes=0-3"})
+	require.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "InvalidObjectState", parseS3Error(t, w.Body.Bytes()).Code)
+}
+
+// TestS3_StorageClass_MultipartCarriesClass asserts the class supplied at
+// CreateMultipartUpload survives to the assembled object — the header is accepted
+// there, not on CompleteMultipartUpload.
+func TestS3_StorageClass_MultipartCarriesClass(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-mpu", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/sc-mpu/big?uploads", nil,
+		map[string]string{"x-amz-storage-class": "STANDARD_IA"})
+	require.Equal(t, http.StatusOK, iw.Code)
+
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	// ListMultipartUploads reports the in-progress upload's class.
+	lw := s3Request(t, srv, http.MethodGet, "/sc-mpu?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, lw.Code)
+	var lr struct {
+		Uploads []struct {
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"Upload"`
+	}
+	require.NoError(t, xml.Unmarshal(lw.Body.Bytes(), &lr))
+	require.Len(t, lr.Uploads, 1)
+	assert.Equal(t, "STANDARD_IA", lr.Uploads[0].StorageClass)
+
+	etag := uploadPart(t, srv, "sc-mpu", "big", ir.UploadID, 1, []byte("single part is exempt from the 5 MB floor"))
+	cw := s3Request(t, srv, http.MethodPost, "/sc-mpu/big?uploadId="+ir.UploadID,
+		completeBody(etag), nil)
+	require.Equal(t, http.StatusOK, cw.Code, "complete multipart upload")
+
+	hw := s3Request(t, srv, http.MethodHead, "/sc-mpu/big", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "STANDARD_IA", hw.Header().Get("x-amz-storage-class"))
+}
+
+// TestS3_StorageClass_MultipartInvalidClass asserts CreateMultipartUpload validates
+// the class up front rather than failing at Complete, after parts have been paid for.
+func TestS3_StorageClass_MultipartInvalidClass(t *testing.T) {
+	srv := storageClassFixture(t, "sc-mpu-bad")
+
+	w := s3Request(t, srv, http.MethodPost, "/sc-mpu-bad/big?uploads", nil,
+		map[string]string{"x-amz-storage-class": "NOPE"})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "InvalidStorageClass", parseS3Error(t, w.Body.Bytes()).Code)
+}
+
+// TestS3_StorageClass_ListObjectVersions asserts each <Version> carries a
+// <StorageClass>, while a <DeleteMarker> does not — matching the response shape S3
+// documents.
+func TestS3_StorageClass_ListObjectVersions(t *testing.T) {
+	srv := storageClassFixture(t, "sc-versions")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-versions?versioning",
+			[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil).Code)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-versions/obj", []byte("v1"),
+			map[string]string{"x-amz-storage-class": "STANDARD_IA"}).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-versions/obj", []byte("v2"),
+			map[string]string{"x-amz-storage-class": "GLACIER_IR"}).Code)
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/sc-versions/obj", nil, nil).Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/sc-versions?versions", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var result struct {
+		Versions []struct {
+			VersionID    string `xml:"VersionId"`
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"Version"`
+		DeleteMarkers []struct {
+			VersionID string `xml:"VersionId"`
+			// Decoded only to assert it is never emitted: the DeleteMarkerEntry
+			// shape S3 documents has no StorageClass child.
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"DeleteMarker"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+
+	require.Len(t, result.Versions, 2)
+	classes := []string{result.Versions[0].StorageClass, result.Versions[1].StorageClass}
+	assert.ElementsMatch(t, []string{"STANDARD_IA", "GLACIER_IR"}, classes,
+		"each version reports the class it was written with")
+
+	require.Len(t, result.DeleteMarkers, 1)
+	assert.Empty(t, result.DeleteMarkers[0].StorageClass,
+		"a <DeleteMarker> carries no <StorageClass>")
+}
+
+// TestS3_StorageClass_ListObjectsV1 asserts ListObjects v1 emits <StorageClass> too,
+// since both list operations share one entry type.
+func TestS3_StorageClass_ListObjectsV1(t *testing.T) {
+	srv := storageClassFixture(t, "sc-v1")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sc-v1/obj", []byte("body"),
+			map[string]string{"x-amz-storage-class": "ONEZONE_IA"}).Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/sc-v1", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var result struct {
+		Contents []struct {
+			Key          string `xml:"Key"`
+			StorageClass string `xml:"StorageClass"`
+		} `xml:"Contents"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+	require.Len(t, result.Contents, 1)
+	assert.Equal(t, "ONEZONE_IA", result.Contents[0].StorageClass)
+}
+
+// --- CopyObject storage class ---
+
+// TestS3_CopyObject_StorageClass asserts the copy's class comes from the request and
+// is never inherited from the source: "if the x-amz-storage-class header is not used,
+// the copied object will be stored in the STANDARD Storage Class by default".
+func TestS3_CopyObject_StorageClass(t *testing.T) {
+	tests := []struct {
+		name        string
+		sourceClass string
+		copyHeader  string
+		wantClass   string
+	}{
+		{"unqualified copy resets to STANDARD", "STANDARD_IA", "", "STANDARD"},
+		{"explicit class is recorded", "STANDARD", "GLACIER_IR", "GLACIER_IR"},
+		{"in-place transition to archival", "STANDARD", "GLACIER", "GLACIER"},
+		{"transition away from archival", "GLACIER_IR", "STANDARD", "STANDARD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := storageClassFixture(t, "cp-sc")
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-sc/src", []byte("payload"),
+					map[string]string{"x-amz-storage-class": tt.sourceClass}).Code)
+
+			headers := map[string]string{"X-Amz-Copy-Source": "/cp-sc/src"}
+			if tt.copyHeader != "" {
+				headers["x-amz-storage-class"] = tt.copyHeader
+			}
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-sc/dst", nil, headers).Code, "copy")
+
+			hw := s3Request(t, srv, http.MethodHead, "/cp-sc/dst", nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code)
+			assert.Equal(t, tt.wantClass, listedStorageClass(t, srv, "cp-sc", "dst"))
+		})
+	}
+}
+
+// TestS3_CopyObject_InPlaceTransition covers the tier-transition pattern directly: a
+// CopyObject onto the object's own key changes its class, and the archival target is
+// then unreadable by GET while still readable by HEAD.
+func TestS3_CopyObject_InPlaceTransition(t *testing.T) {
+	srv := storageClassFixture(t, "cp-inplace")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/cp-inplace/obj", []byte("payload"), nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodGet, "/cp-inplace/obj", nil, nil).Code)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/cp-inplace/obj", nil, map[string]string{
+			"X-Amz-Copy-Source":   "/cp-inplace/obj",
+			"x-amz-storage-class": "DEEP_ARCHIVE",
+		}).Code, "in-place transition")
+
+	gw := s3Request(t, srv, http.MethodGet, "/cp-inplace/obj", nil, nil)
+	require.Equal(t, http.StatusForbidden, gw.Code, "the transitioned object is no longer readable")
+	assert.Equal(t, "InvalidObjectState", parseS3Error(t, gw.Body.Bytes()).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/cp-inplace/obj", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "DEEP_ARCHIVE", hw.Header().Get("x-amz-storage-class"))
+}
+
+// TestS3_CopyObject_ArchivedSource asserts an archived source must be restored before
+// it can be copied — the class gate applies to the read side of a copy too.
+func TestS3_CopyObject_ArchivedSource(t *testing.T) {
+	srv := storageClassFixture(t, "cp-frozen")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/cp-frozen/src", []byte("payload"),
+			map[string]string{"x-amz-storage-class": "GLACIER"}).Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/cp-frozen/dst", nil, map[string]string{
+		"X-Amz-Copy-Source":   "/cp-frozen/src",
+		"x-amz-storage-class": "STANDARD",
+	})
+	require.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "InvalidObjectState", parseS3Error(t, w.Body.Bytes()).Code)
+
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodHead, "/cp-frozen/dst", nil, nil).Code,
+		"a rejected copy must leave no destination object")
+}
+
+// TestS3_CopyObject_InvalidStorageClass asserts a bad class on a copy is rejected
+// before the destination is written.
+func TestS3_CopyObject_InvalidStorageClass(t *testing.T) {
+	srv := storageClassFixture(t, "cp-bad")
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/cp-bad/src", []byte("payload"), nil).Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/cp-bad/dst", nil, map[string]string{
+		"X-Amz-Copy-Source":   "/cp-bad/src",
+		"x-amz-storage-class": "ICEBOX",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "InvalidStorageClass", parseS3Error(t, w.Body.Bytes()).Code)
+
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodHead, "/cp-bad/dst", nil, nil).Code)
+}
+
+// --- CopyObject metadata directive ---
+
+// TestS3_CopyObject_MetadataDirectiveCopy asserts the documented COPY behavior:
+// "when you copy an object, user-controlled system metadata and user-defined metadata
+// are also copied", and Content-Encoding is user-controlled. A COPY therefore
+// preserves it, and headers restated on the request are *ignored* — only REPLACE
+// reads them.
+func TestS3_CopyObject_MetadataDirectiveCopy(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive string
+	}{
+		{"default (no directive header)", ""},
+		{"explicit COPY", "COPY"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := storageClassFixture(t, "cp-meta")
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-meta/src", []byte("payload"),
+					map[string]string{
+						"Content-Type":     "text/plain",
+						"Content-Encoding": "gzip",
+						"x-amz-meta-owner": "alice",
+					}).Code)
+
+			headers := map[string]string{"X-Amz-Copy-Source": "/cp-meta/src"}
+			if tt.directive != "" {
+				headers["x-amz-metadata-directive"] = tt.directive
+			}
+			// Restated headers a COPY must ignore.
+			headers["Content-Type"] = "application/json"
+			headers["x-amz-meta-owner"] = "bob"
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-meta/dst", nil, headers).Code)
+
+			hw := s3Request(t, srv, http.MethodHead, "/cp-meta/dst", nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code)
+			assert.Equal(t, "gzip", hw.Header().Get("Content-Encoding"),
+				"COPY preserves Content-Encoding")
+			assert.Equal(t, "text/plain", hw.Header().Get("Content-Type"),
+				"COPY takes the source's Content-Type, not the request's")
+			assert.Equal(t, "alice", hw.Header().Get("X-Amz-Meta-Owner"),
+				"COPY takes the source's user metadata, not the request's")
+		})
+	}
+}
+
+// TestS3_CopyObject_MetadataDirectiveReplace asserts REPLACE drops everything the
+// request does not restate: "you must explicitly specify all of the user-configurable
+// metadata present on the source object in your request, even if you are changing
+// only one of the metadata values." This is the asymmetry an in-place tier transition
+// trips over — a REPLACE that omits Content-Encoding loses it.
+func TestS3_CopyObject_MetadataDirectiveReplace(t *testing.T) {
+	t.Run("omitted metadata is dropped", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-repl")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-repl/src", []byte("payload"),
+				map[string]string{
+					"Content-Type":     "text/plain",
+					"Content-Encoding": "gzip",
+					"x-amz-meta-owner": "alice",
+				}).Code)
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-repl/dst", nil, map[string]string{
+				"X-Amz-Copy-Source":        "/cp-repl/src",
+				"x-amz-metadata-directive": "REPLACE",
+			}).Code)
+
+		hw := s3Request(t, srv, http.MethodHead, "/cp-repl/dst", nil, nil)
+		require.Equal(t, http.StatusOK, hw.Code)
+		assert.Empty(t, hw.Header().Get("Content-Encoding"),
+			"REPLACE drops a Content-Encoding the request did not restate")
+		assert.Equal(t, "application/octet-stream", hw.Header().Get("Content-Type"),
+			"REPLACE falls back to the default Content-Type")
+		assert.Empty(t, hw.Header().Get("X-Amz-Meta-Owner"),
+			"REPLACE drops user metadata the request did not restate")
+	})
+
+	t.Run("restated metadata is kept", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-repl2")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-repl2/src", []byte("payload"),
+				map[string]string{
+					"Content-Type":     "text/plain",
+					"Content-Encoding": "gzip",
+					"x-amz-meta-owner": "alice",
+				}).Code)
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-repl2/dst", nil, map[string]string{
+				"X-Amz-Copy-Source":        "/cp-repl2/src",
+				"x-amz-metadata-directive": "REPLACE",
+				"Content-Type":             "application/json",
+				"Content-Encoding":         "br",
+				"x-amz-meta-owner":         "bob",
+			}).Code)
+
+		hw := s3Request(t, srv, http.MethodHead, "/cp-repl2/dst", nil, nil)
+		require.Equal(t, http.StatusOK, hw.Code)
+		assert.Equal(t, "br", hw.Header().Get("Content-Encoding"))
+		assert.Equal(t, "application/json", hw.Header().Get("Content-Type"))
+		assert.Equal(t, "bob", hw.Header().Get("X-Amz-Meta-Owner"))
+	})
+}
+
+// TestS3_CopyObject_MetadataDirectiveInvalid asserts an unrecognized directive is
+// rejected rather than silently defaulting to COPY. A typo that quietly preserved
+// metadata is exactly the false success this emulator exists to surface.
+func TestS3_CopyObject_MetadataDirectiveInvalid(t *testing.T) {
+	for _, header := range []string{"x-amz-metadata-directive", "x-amz-tagging-directive"} {
+		t.Run(header, func(t *testing.T) {
+			srv := storageClassFixture(t, "cp-dir")
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/cp-dir/src", []byte("payload"), nil).Code)
+
+			w := s3Request(t, srv, http.MethodPut, "/cp-dir/dst", nil, map[string]string{
+				"X-Amz-Copy-Source": "/cp-dir/src",
+				header:              "MERGE",
+			})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+
+			body := parseS3Error(t, w.Body.Bytes())
+			assert.Equal(t, "InvalidArgument", body.Code)
+			assert.Contains(t, body.Message, header)
+
+			assert.Equal(t, http.StatusNotFound,
+				s3Request(t, srv, http.MethodHead, "/cp-dir/dst", nil, nil).Code)
+		})
+	}
+}
+
+// TestS3_CopyObject_TaggingDirective asserts the tag-set follows its own directive:
+// COPY (the default) carries the source's tags, REPLACE takes them from the
+// URL-query-encoded x-amz-tagging header.
+func TestS3_CopyObject_TaggingDirective(t *testing.T) {
+	putSourceTags := func(t *testing.T, srv *emulator.Server, bucket string) {
+		t.Helper()
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/"+bucket+"/src?tagging",
+				[]byte(`<Tagging><TagSet><Tag><Key>team</Key><Value>infra</Value></Tag></TagSet></Tagging>`),
+				nil).Code)
+	}
+
+	getTags := func(t *testing.T, srv *emulator.Server, bucket, key string) map[string]string {
+		t.Helper()
+		w := s3Request(t, srv, http.MethodGet, "/"+bucket+"/"+key+"?tagging", nil, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var result struct {
+			Tags []struct {
+				Key   string `xml:"Key"`
+				Value string `xml:"Value"`
+			} `xml:"TagSet>Tag"`
+		}
+		require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+
+		tags := make(map[string]string, len(result.Tags))
+		for _, tag := range result.Tags {
+			tags[tag.Key] = tag.Value
+		}
+		return tags
+	}
+
+	t.Run("COPY carries the source tag-set", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag/src", []byte("payload"), nil).Code)
+		putSourceTags(t, srv, "cp-tag")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag/dst", nil, map[string]string{
+				"X-Amz-Copy-Source": "/cp-tag/src",
+			}).Code)
+
+		assert.Equal(t, map[string]string{"team": "infra"}, getTags(t, srv, "cp-tag", "dst"))
+	})
+
+	t.Run("REPLACE takes the request tag-set", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag2")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag2/src", []byte("payload"), nil).Code)
+		putSourceTags(t, srv, "cp-tag2")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag2/dst", nil, map[string]string{
+				"X-Amz-Copy-Source":       "/cp-tag2/src",
+				"x-amz-tagging-directive": "REPLACE",
+				"x-amz-tagging":           "stage=prod&owner=alice",
+			}).Code)
+
+		assert.Equal(t, map[string]string{"stage": "prod", "owner": "alice"},
+			getTags(t, srv, "cp-tag2", "dst"))
+	})
+
+	t.Run("REPLACE with no tagging header clears the tag-set", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag3")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag3/src", []byte("payload"), nil).Code)
+		putSourceTags(t, srv, "cp-tag3")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag3/dst", nil, map[string]string{
+				"X-Amz-Copy-Source":       "/cp-tag3/src",
+				"x-amz-tagging-directive": "REPLACE",
+			}).Code)
+
+		assert.Empty(t, getTags(t, srv, "cp-tag3", "dst"),
+			`the default value of x-amz-tagging is the empty value`)
+	})
+
+	t.Run("REPLACE with an unparseable tagging header is rejected", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag-bad")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag-bad/src", []byte("payload"), nil).Code)
+
+		// %zz is not valid percent-encoding, so the tag-set cannot be decoded.
+		w := s3Request(t, srv, http.MethodPut, "/cp-tag-bad/dst", nil, map[string]string{
+			"X-Amz-Copy-Source":       "/cp-tag-bad/src",
+			"x-amz-tagging-directive": "REPLACE",
+			"x-amz-tagging":           "stage=%zz",
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "InvalidArgument", parseS3Error(t, w.Body.Bytes()).Code)
+
+		assert.Equal(t, http.StatusNotFound,
+			s3Request(t, srv, http.MethodHead, "/cp-tag-bad/dst", nil, nil).Code)
+	})
+
+	t.Run("copied tags do not alias the source", func(t *testing.T) {
+		srv := storageClassFixture(t, "cp-tag4")
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag4/src", []byte("payload"), nil).Code)
+		putSourceTags(t, srv, "cp-tag4")
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag4/dst", nil, map[string]string{
+				"X-Amz-Copy-Source": "/cp-tag4/src",
+			}).Code)
+
+		// Retagging the destination must not disturb the source.
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/cp-tag4/dst?tagging",
+				[]byte(`<Tagging><TagSet><Tag><Key>team</Key><Value>data</Value></Tag></TagSet></Tagging>`),
+				nil).Code)
+
+		assert.Equal(t, map[string]string{"team": "infra"}, getTags(t, srv, "cp-tag4", "src"))
+		assert.Equal(t, map[string]string{"team": "data"}, getTags(t, srv, "cp-tag4", "dst"))
+	})
+}

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -43,6 +43,10 @@ type S3Object struct {
 	// Size is the byte length of the object body.
 	Size int64 `json:"size"`
 
+	// StorageClass is the S3 storage class of the object, set via the
+	// x-amz-storage-class header on write. Empty is equivalent to STANDARD.
+	StorageClass string `json:"storage_class,omitempty"`
+
 	// LastModified is the time of the most recent write.
 	LastModified time.Time `json:"last_modified"`
 
@@ -88,6 +92,9 @@ type S3ObjectVersion struct {
 
 	// Size is the byte length of the object body.
 	Size int64 `xml:"Size"`
+
+	// StorageClass is the S3 storage class of this version.
+	StorageClass string `xml:"StorageClass"`
 }
 
 // S3DeleteMarker holds metadata for one delete marker in a ListObjectVersions
@@ -131,6 +138,10 @@ type S3MultipartUpload struct {
 
 	// ContentType is the MIME type supplied at upload creation.
 	ContentType string `json:"content_type"`
+
+	// StorageClass is the storage class supplied at upload creation, applied to
+	// the object CompleteMultipartUpload assembles. Empty means STANDARD.
+	StorageClass string `json:"storage_class,omitempty"`
 
 	// Initiated is the time the multipart upload was created.
 	Initiated time.Time `json:"initiated"`


### PR DESCRIPTION
Closes #398

Reopens #409, which GitHub closed when its base branch (`feat/397-s3-conditional-requests`, the #397 work now merged as #408) was deleted on merge. A closed PR cannot be retargeted, so this is the same commit rebased onto `main`. The rebase was clean — #397's content is already in `main` via the squash — and the diff here is #398 only.

## What changed

**Storage classes are recorded and reported.** `PutObject`, `CopyObject` and `CreateMultipartUpload` accept `x-amz-storage-class`, defaulting to `STANDARD` when absent. All thirteen documented values are accepted; anything else — including a lowercase or whitespace-padded value — is `400 InvalidStorageClass`, raised before the write so a rejected class leaves no object behind. A class set at `CreateMultipartUpload` survives to the object `CompleteMultipartUpload` assembles.

The two report surfaces differ, and both directions are easy to get wrong:

| Surface | `STANDARD` | Every other class |
|---|---|---|
| `x-amz-storage-class` response header on GET/HEAD | **Omitted** | Present |
| `<StorageClass>` in `ListObjects`, `ListObjectsV2`, `ListObjectVersions`, `ListMultipartUploads` | `STANDARD` | The class |

A `<DeleteMarker>` carries none, matching S3's response shape.

**Archived objects are unreadable.** `GetObject` of a `GLACIER` or `DEEP_ARCHIVE` object is `403 InvalidObjectState`, as is a `CopyObject` naming one as its source. The check precedes the `Range` step, so a ranged read of an archived object is the same `403` rather than a `206`. `GLACIER_IR` reads normally.

**`CopyObject` metadata directives.** `x-amz-metadata-directive` and `x-amz-tagging-directive` are both honored, both defaulting to `COPY`. Under `COPY` the destination takes the source's `Content-Type`, `Content-Encoding`, user metadata and tags; under `REPLACE` only what the request restates. An unrecognized directive value is `400 InvalidArgument` rather than a silent fall back to the default. The destination's storage class comes from the request, never the source.

Two pre-existing `copyObject` bugs fall out of this: it had dropped the source's `Content-Encoding` and object tags on every copy, and it aliased the destination's metadata maps to the source's, so retagging one object mutated the other.

## Three deviations from the issue text

Each is a case where the AWS reference contradicts the issue, so implementing the issue as written would have made a test pass here and fail against AWS. Full quotes are in the issue comment.

1. **`COPY` preserves `Content-Encoding`; the issue has it inverted.** The issue asks for a test asserting `Content-Encoding` is *dropped* under `COPY`. The API reference says `COPY` means "you can preserve all metadata (the default)" and names only `x-amz-website-redirect-location` as not copied; the User Guide confirms `Content-Encoding` is user-controlled metadata that a copy carries. The real-world loss the issue describes is reachable — via `REPLACE`, which drops anything the request does not restate. Both directions are tested.

2. **`HeadObject` of an archived object is `200`, not `403`.** `API_HeadObject.html` lists only `NoSuchKey` under Errors and states "even if the object is stored in S3 Glacier, all object metadata is still available". `GetObject`'s reference does list `InvalidObjectState`. `HEAD` succeeding is what lets a consumer discover that a `GET` needs a restore first, so the asymmetry is load-bearing, not an omission.

3. **A copy does not inherit the source's class.** "If the `x-amz-storage-class` header is not used, the copied object will be stored in the `STANDARD` Storage Class by default" — so an unqualified copy of a `STANDARD_IA` object yields a `STANDARD` one.

Also accepted beyond the issue's list: `OUTPOSTS`, `SNOW`, `FSX_OPENZFS`, `FSX_ONTAP`. Rejecting a value real S3 takes is the same class of defect as accepting one it rejects.

## Not implemented

`RestoreObject`, the `x-amz-restore` response header, and Intelligent-Tiering archive access tiers (so the `InvalidObjectState` variant carrying `<StorageClass>`/`<AccessTier>` never appears). The issue notes `InvalidObjectState` alone unblocks the reporter. Restoring is modeled by copying to a non-archival class.

## Verification

`make test` (race), `golangci-lint run ./...` (0 issues), `make e2e`, `make docs-reference-check` all pass. Coverage on the new files: `resolveStorageClass`, `storageClassOf`, `evaluateStorageClassRead`, `resolveDirective`, `resolveCopyMetadata`, `copyStringMap` at 100%, `resolveCopyTags` at 93%.

New `emulator/s3_storage_class_test.go` covers: a round-trip per storage class asserting the header and the XML element; the `STANDARD` default; `InvalidStorageClass` across four bad forms with the key asserted absent afterwards; the `403` gate with `GLACIER_IR`/`STANDARD_IA`/`INTELLIGENT_TIERING` asserted to read normally; `HEAD` returning `200` on both archival classes; the ranged-read-of-archived case; multipart class carry-through and up-front validation; `<StorageClass>` in v1 and v2 listings and in `ListObjectVersions` with a `<DeleteMarker>` asserted to have none; the four `CopyObject` storage-class transitions; the in-place transition end to end; both directives in both modes including the alias check; and the malformed-directive and malformed-`x-amz-tagging` rejections.

`docs/services.md` gains **Storage classes** and **Copying objects** sections; `CHANGELOG.md` is updated under `## [Unreleased]`.

