### PR TITLE
feat(s3): verify the x-amz-checksum-* family (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `RestoreObject`, the `x-amz-restore` header and Intelligent-Tiering archive
     access tiers are not implemented, so an archived object stays unreadable for
     the run; restoring is modeled by copying to a non-archival class.
+- S3 additional checksums: the `x-amz-checksum-*` family is now computed and
+  **verified** on `PutObject`, `UploadPart`, `CopyObject` and
+  `CompleteMultipartUpload` (#399). Checksum headers were previously ignored
+  altogether, which inverts the guarantee they exist to provide: a consumer
+  computing a checksum client-side and sending it to have S3 reject corrupt data
+  got a `200` whether the value matched the body or not, so a test asserting "a
+  corrupted upload is rejected" passed against substrate and would have passed
+  against a version of the consumer that computed the checksum wrong.
+  - **A mismatch is `400 BadDigest` and nothing is written.** The object does not
+    appear at the key — neither its metadata nor its body — and a rejected write
+    over an existing object leaves the original bytes, ETag and checksum intact
+    rather than truncating them. A rejected `UploadPart` stores no part, so a
+    later `CompleteMultipartUpload` cannot pick up a part that failed its
+    checksum. The error body names the algorithm alongside both the supplied and
+    the computed value, so a failing test says which value was wrong.
+  - **Seven algorithms are verified**: `CRC32`, `CRC32C`, `CRC64NVME`, `SHA1`,
+    `SHA256`, `SHA512` and `MD5`. `CRC-64/NVME` is built from the bit-reversed
+    catalog polynomial and pinned by a test against the published check value, so
+    a transcription error surfaces as a failing assertion rather than as a
+    plausible-looking wrong digest that agrees with itself.
+  - **`XXHASH64`, `XXHASH3` and `XXHASH128` are `501 NotImplemented`**, not
+    silently accepted. Substrate has no implementation to check a caller's value
+    against, and storing an unverified checksum is the precise defect this change
+    removes — it would make a test pass on data real S3 would have rejected. A
+    name outside all ten documented algorithms is `400 InvalidRequest`.
+  - **Trailing checksums are read.** `decodeAWSChunked` previously discarded
+    everything after the `aws-chunked` completion chunk, which is exactly where
+    every AWS SDK puts the checksum of a streamed upload — so header-only
+    verification would have silently never fired for any real SDK write. Trailers
+    are now parsed and honored when `x-amz-trailer` declares them; a trailer whose
+    name differs from what was declared, or a declared trailer that never arrives,
+    is `400 MalformedTrailerError`.
+  - **Reading a checksum back requires `x-amz-checksum-mode: ENABLED`** on
+    `GetObject` or `HeadObject`. Without it neither the `x-amz-checksum-*` header
+    nor `x-amz-checksum-type` is present, so the absence is observable. A ranged
+    `GET` returns the whole object's checksum, not the range's.
+  - **Multipart checksums distinguish `COMPOSITE` from `FULL_OBJECT`.**
+    `CreateMultipartUpload` takes `x-amz-checksum-algorithm` and an optional
+    `x-amz-checksum-type`, echoing both back; an absent type defaults to
+    `COMPOSITE`, except for `CRC64NVME`, which has no composite form and defaults
+    to `FULL_OBJECT`. An unsupported algorithm/type pairing is rejected at
+    *creation*, before any part is uploaded, rather than after a consumer has paid
+    to upload every part. `CompleteMultipartUpload` returns the value as an XML
+    element (`<ChecksumSHA256>`, `<ChecksumType>`), not a header, and verifies a
+    whole-object checksum supplied on the request itself. A `FULL_OBJECT` multipart
+    checksum equals what a single-part `PutObject` of the same bytes produces —
+    the invariant a consumer whose two write paths disagree needs a test to catch.
+  - **`CopyObject` recomputes** as a direct full-object checksum of the copied
+    bytes, under the source's algorithm unless the copy names a new one. Copying a
+    `COMPOSITE` multipart object therefore changes both the value and the type
+    even though the data is identical, matching S3.
+  - **One deliberate divergence:** real S3 attaches a default `CRC64NVME` checksum
+    to every object uploaded without one, so a checksum-mode `GET` always returns
+    something. Substrate records none. Synthesizing one would make a consumer's
+    round-trip assertion pass whether or not their writer actually sends a
+    checksum, which is the failure this work exists to expose; an absent checksum
+    in substrate means "your writer sent none".
 
 ### Fixed
 - EC2 `Describe*` calls that name a resource ID explicitly now raise

--- a/docs/services.md
+++ b/docs/services.md
@@ -187,16 +187,16 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers; `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests) |
-| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes) |
-| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes) |
+| PutObject | Supports Content-Type, metadata headers; `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums) |
+| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
+| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
 | DeleteObject | Fires S3 notifications if configured |
-| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects) |
+| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums) |
 | ListObjects | Emits `<StorageClass>` per object |
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
-| CreateMultipartUpload | Accepts `x-amz-storage-class`, applied to the assembled object |
-| UploadPart | |
-| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests) |
+| CreateMultipartUpload | Accepts `x-amz-storage-class`, applied to the assembled object; `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums) |
+| UploadPart | Verifies the part checksum, including a trailing one — see [Additional checksums](#additional-checksums) |
+| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums) |
 | AbortMultipartUpload | |
 | ListMultipartUploads | Emits `<StorageClass>` per in-progress upload |
 | GetBucketPolicy | |
@@ -454,6 +454,94 @@ The `EntityTooSmall` body identifies the offending part:
   <PartNumber>1</PartNumber>
 </Error>
 ```
+
+### Additional checksums
+
+`PutObject`, `UploadPart`, `CopyObject`, `CreateMultipartUpload` and
+`CompleteMultipartUpload` honor the `x-amz-checksum-*` family, and **verify** any
+value the caller supplies. A wrong value is `400 BadDigest` and nothing is written —
+the object does not appear at the key, and a rejected `UploadPart` leaves no part for
+a later Complete to pick up.
+
+All ten documented algorithms are recognized. Seven are computed and verified:
+
+| Algorithm | Header | `FULL_OBJECT` | `COMPOSITE` |
+|---|---|---|---|
+| `CRC32` | `x-amz-checksum-crc32` | yes | yes |
+| `CRC32C` | `x-amz-checksum-crc32c` | yes | yes |
+| `CRC64NVME` | `x-amz-checksum-crc64nvme` | yes | **no** |
+| `SHA1` | `x-amz-checksum-sha1` | no | yes |
+| `SHA256` | `x-amz-checksum-sha256` | no | yes |
+| `SHA512` | `x-amz-checksum-sha512` | no | yes |
+| `MD5` | `x-amz-checksum-md5` | no | yes |
+
+`XXHASH64`, `XXHASH3` and `XXHASH128` are recognized but answered with `501
+NotImplemented`, because substrate has no implementation to check a supplied value
+against. That is deliberate: storing a checksum nobody verified would make a
+consumer's test pass on data real S3 would have rejected, which is the failure this
+section exists to prevent. An algorithm name outside all ten is `400 InvalidRequest`.
+
+Three request shapes are honored on a write:
+
+| Request | Behavior |
+|---|---|
+| `x-amz-checksum-<alg>: <base64>` | Verified against the body; mismatch is `400 BadDigest` |
+| `x-amz-sdk-checksum-algorithm: <NAME>` alone | Substrate computes and records the digest |
+| Both, naming different algorithms | `400 BadDigest` |
+| Two different `x-amz-checksum-*` headers | `400 InvalidRequest`, "Multiple checksum Types are not allowed" |
+| A base64 value of the wrong width for the algorithm | `400 InvalidRequest`, distinct from `BadDigest` |
+
+**Trailing checksums are read.** When the body is `aws-chunked` and `x-amz-trailer`
+names a checksum header, the value is taken from the trailer that follows the
+completion chunk — which is where every AWS SDK puts the checksum of a streamed
+upload. A trailer whose name differs from what `x-amz-trailer` declared is `400
+MalformedTrailerError`; so is a declared trailer that never arrives.
+
+**Reading a checksum back** requires `x-amz-checksum-mode: ENABLED` on `GetObject` or
+`HeadObject`. Without it the response carries no `x-amz-checksum-*` header and no
+`x-amz-checksum-type`, so the absence is observable. A ranged `GET` returns the
+whole object's checksum, not the range's.
+
+**Multipart.** `CreateMultipartUpload` takes `x-amz-checksum-algorithm` (not the
+`x-amz-sdk-` form) and an optional `x-amz-checksum-type`, echoing both back. An
+absent type defaults to `COMPOSITE`, except for `CRC64NVME`, which has no composite
+form and defaults to `FULL_OBJECT`. An unsupported algorithm/type pairing is `400
+InvalidRequest` at **creation**, before any part is uploaded. A part supplying a
+checksum under a different algorithm than the upload's is `400 InvalidRequest`.
+
+`CompleteMultipartUpload` returns the object checksum as an XML **element**, not a
+header:
+
+```xml
+<CompleteMultipartUploadResult>
+  <Location>/bucket/key</Location>
+  <Bucket>bucket</Bucket>
+  <Key>key</Key>
+  <ETag>"b6d81b360a5672d80c27430f39153e2c-2"</ETag>
+  <ChecksumCRC32>Zm9vYmFy-2</ChecksumCRC32>
+  <ChecksumType>COMPOSITE</ChecksumType>
+</CompleteMultipartUploadResult>
+```
+
+A `COMPOSITE` value is the digest of the concatenated raw part digests with a
+`-<part count>` suffix; a `FULL_OBJECT` value is the digest of every byte of the
+assembled object, with no suffix. For the same bytes the two differ, which is the
+point of distinguishing them. A `FULL_OBJECT` multipart checksum equals what a
+single-part `PutObject` of the same bytes produces — a property a test can assert.
+Complete also verifies a whole-object checksum supplied on the request itself, and
+rejects an `x-amz-checksum-type` that disagrees with the upload's.
+
+**`CopyObject` recomputes.** The destination's checksum is always a direct
+full-object checksum of the copied bytes, under the source's algorithm unless the
+copy names a new one. Copying a `COMPOSITE` multipart object therefore changes both
+the value and the type even though the data is identical, matching S3.
+
+**One deliberate divergence.** Real S3 attaches a default `CRC64NVME` checksum to
+every object uploaded without one, so a checksum-mode `GET` always returns something.
+Substrate records **no** checksum in that case. Synthesizing one would make a
+round-trip assertion pass whether or not the consumer's writer actually sends a
+checksum — the exact defect this support was added to expose. An absent checksum in
+substrate means "your writer sent none".
 
 ### Betty CFN resource types
 

--- a/emulator/s3_checksum.go
+++ b/emulator/s3_checksum.go
@@ -1,0 +1,700 @@
+package emulator
+
+import (
+	"crypto/md5"  //nolint:gosec // nosemgrep // MD5 is one of the checksum algorithms S3 offers; it is not used here as a security primitive.
+	"crypto/sha1" //nolint:gosec // nosemgrep // SHA-1 is one of the checksum algorithms S3 offers; it is not used here as a security primitive.
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/xml"
+	"hash"
+	"hash/crc32"
+	"hash/crc64"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// S3 checksum types, as reported in x-amz-checksum-type. A single-part PutObject
+// is always FULL_OBJECT: "Checksums of objects that are uploaded in a single part
+// (using PutObject) are treated as full object checksums".
+const (
+	// S3ChecksumTypeFullObject is a checksum computed over every byte of the
+	// object, "covering all data from the first byte of the first part to the last
+	// byte of the last part".
+	S3ChecksumTypeFullObject = "FULL_OBJECT"
+
+	// S3ChecksumTypeComposite is a checksum computed over the concatenated
+	// part-level digests of a multipart upload, suffixed with "-<part count>".
+	S3ChecksumTypeComposite = "COMPOSITE"
+)
+
+// crc64NVMEPolynomial is the CRC-64/NVME generator polynomial in the bit-reversed
+// (reflected) form that [crc64.MakeTable] expects.
+//
+// The catalog lists CRC-64/NVME as poly=0xad93d23594c93659 with refin/refout
+// true; hash/crc64 takes the reversed polynomial, which is bits.Reverse64 of that
+// value. Verified against the catalog check value: the CRC of "123456789" under
+// this table is 0xae8b14860a799888.
+const crc64NVMEPolynomial = 0x9a6c9329ac4bc9b5
+
+// crc64NVMETable is the CRC-64/NVME table, built once. [crc64.MakeTable] allocates
+// and fills 256 entries per call, and every checksummed request would otherwise
+// rebuild it.
+var crc64NVMETable = sync.OnceValue(func() *crc64.Table {
+	return crc64.MakeTable(crc64NVMEPolynomial)
+})
+
+// s3ChecksumAlgorithm describes one algorithm in the x-amz-checksum-* family.
+type s3ChecksumAlgorithm struct {
+	// Name is the algorithm as it appears in x-amz-checksum-algorithm and
+	// x-amz-sdk-checksum-algorithm, e.g. "CRC32C".
+	Name string
+
+	// New returns a fresh hash for this algorithm. Nil means substrate cannot
+	// compute the digest; see [s3ChecksumAlgorithms].
+	New func() hash.Hash
+
+	// FullObject reports whether the algorithm supports the FULL_OBJECT checksum
+	// type in a multipart upload. "Full object checksums in multipart uploads are
+	// only available for CRC-based checksums because they can linearize into a
+	// full object checksum."
+	FullObject bool
+
+	// Composite reports whether the algorithm supports the COMPOSITE checksum type.
+	// CRC-64/NVME is the sole algorithm that does not.
+	Composite bool
+}
+
+// s3ChecksumHeaderPrefix is the common prefix of every per-algorithm checksum
+// header.
+const s3ChecksumHeaderPrefix = "x-amz-checksum-"
+
+// s3ChecksumAlgorithms is the set of checksum algorithms S3 documents, in the
+// order the API reference lists them.
+//
+// Ten algorithms are accepted, because rejecting one real S3 takes would make a
+// consumer's working code fail against substrate. Only seven can be *verified*
+// here: XXHASH64, XXHASH3 and XXHASH128 have a nil New, because substrate has no
+// implementation of them to check a caller's value against. Those three are
+// answered with 501 NotImplemented rather than silently stored — accepting a
+// checksum substrate cannot verify is the exact defect #399 exists to remove, and
+// is worse than not offering the algorithm, since it makes a test pass while the
+// real service would have caught the corruption.
+//
+// The full-object/composite columns are the documented multipart support matrix.
+var s3ChecksumAlgorithms = []s3ChecksumAlgorithm{
+	{Name: "CRC32", New: func() hash.Hash { return crc32.NewIEEE() }, FullObject: true, Composite: true},
+	{Name: "CRC32C", New: func() hash.Hash { return crc32.New(crc32.MakeTable(crc32.Castagnoli)) }, FullObject: true, Composite: true},
+	{Name: "CRC64NVME", New: func() hash.Hash { return crc64.New(crc64NVMETable()) }, FullObject: true, Composite: false},
+	{Name: "SHA1", New: func() hash.Hash { return sha1.New() }, Composite: true}, //nolint:gosec // nosemgrep
+	{Name: "SHA256", New: sha256.New, Composite: true},
+	{Name: "SHA512", New: sha512.New, Composite: true},
+	{Name: "MD5", New: md5.New, Composite: true}, //nolint:gosec // nosemgrep
+	{Name: "XXHASH64", Composite: true},
+	{Name: "XXHASH3", Composite: true},
+	{Name: "XXHASH128", Composite: true},
+}
+
+// s3ChecksumByName resolves an algorithm by its documented name, case-insensitively.
+func s3ChecksumByName(name string) (s3ChecksumAlgorithm, bool) {
+	for _, alg := range s3ChecksumAlgorithms {
+		if strings.EqualFold(alg.Name, name) {
+			return alg, true
+		}
+	}
+	return s3ChecksumAlgorithm{}, false
+}
+
+// s3ChecksumHeaderOf returns the per-algorithm header name for alg.
+func s3ChecksumHeaderOf(name string) string {
+	return s3ChecksumHeaderPrefix + strings.ToLower(name)
+}
+
+// s3ChecksumDigest returns the base64-encoded big-endian digest of body under alg.
+// "The value field in the trailer chunk includes a base64 encoding of the
+// big-endian checksum value" — hash.Sum already yields big-endian bytes.
+func s3ChecksumDigest(alg s3ChecksumAlgorithm, body []byte) string {
+	return base64.StdEncoding.EncodeToString(s3ChecksumRawDigest(alg, body))
+}
+
+// s3ChecksumRawDigest returns the unencoded digest of body under alg. Composite
+// checksums hash the concatenation of these raw digests, so they need the bytes
+// rather than their base64 form.
+func s3ChecksumRawDigest(alg s3ChecksumAlgorithm, body []byte) []byte {
+	h := alg.New()
+	h.Write(body)
+	return h.Sum(nil)
+}
+
+// s3Checksum is the checksum recorded for an object or part.
+type s3Checksum struct {
+	// Algorithm is the documented algorithm name, e.g. "SHA256". Empty when the
+	// object carries no checksum.
+	Algorithm string `json:"algorithm,omitempty"`
+
+	// Value is the base64-encoded digest, with a "-<part count>" suffix when Type
+	// is COMPOSITE.
+	Value string `json:"value,omitempty"`
+
+	// Type is FULL_OBJECT or COMPOSITE.
+	Type string `json:"type,omitempty"`
+}
+
+// present reports whether a checksum was recorded.
+func (c s3Checksum) present() bool {
+	return c.Algorithm != "" && c.Value != ""
+}
+
+// s3ChecksumNotImplemented is the response for an algorithm S3 supports but
+// substrate cannot compute.
+//
+// This is deliberately an error rather than an unverified success. A caller that
+// gets a 501 learns immediately that substrate will not check this algorithm; one
+// that gets a 200 learns nothing, and ships a test that passes on a checksum
+// nobody validated.
+func s3ChecksumNotImplemented(name string) *AWSResponse {
+	return s3ErrorResponseWith(s3Error{
+		Code: "NotImplemented",
+		Message: "The " + name + " checksum algorithm is not implemented by substrate. " +
+			"Substrate rejects it rather than storing a value it cannot verify. " +
+			"Use CRC32, CRC32C, CRC64NVME, SHA1, SHA256, SHA512 or MD5.",
+		Status:  http.StatusNotImplemented,
+		Details: []s3ErrorDetail{{Name: "ChecksumAlgorithm", Value: name}},
+	})
+}
+
+// s3BadDigestMessage is the message S3 pairs with a BadDigest code.
+const s3BadDigestMessage = "The Content-MD5 or checksum value that you specified did not match what the server received."
+
+// s3BadDigestResponse builds the 400 BadDigest served when a supplied checksum
+// does not match the digest of the received body.
+//
+// "If the checksum value calculated by S3 matches your provided value, the request
+// is accepted. If the values don't match, the request is rejected." The supplied
+// and computed values are surfaced as detail elements so a failing test says which
+// value was wrong rather than only that something was.
+func s3BadDigestResponse(alg, supplied, computed string) *AWSResponse {
+	return s3ErrorResponseWith(s3Error{
+		Code:    "BadDigest",
+		Message: s3BadDigestMessage,
+		Status:  http.StatusBadRequest,
+		Details: []s3ErrorDetail{
+			{Name: "ChecksumAlgorithm", Value: alg},
+			{Name: "ClientComputedChecksum", Value: supplied},
+			{Name: "S3ComputedChecksum", Value: computed},
+		},
+	})
+}
+
+// resolveChecksum determines the checksum to record for a body written by
+// PutObject or UploadPart, verifying any value the caller supplied.
+//
+// Three request shapes are honored, per the PutObject reference:
+//
+//   - A per-algorithm header (x-amz-checksum-sha256: <base64>) supplies a
+//     precomputed value. It is verified against the body; a mismatch is 400
+//     BadDigest and nothing is written.
+//   - x-amz-sdk-checksum-algorithm: <NAME> names an algorithm without a value, so
+//     substrate computes and stores the digest. "When you send this header, there
+//     must be a corresponding x-amz-checksum-<algorithm> or x-amz-trailer header
+//     sent. Otherwise, Amazon S3 fails the request with the HTTP status code 400
+//     Bad Request."
+//   - Neither: no checksum is recorded. Real S3 attaches a default CRC-64/NVME
+//     checksum in this case, but substrate does not — see the note below.
+//
+// Both headers together must agree: "If the individual checksum value you provide
+// through x-amz-checksum-<algorithm> doesn't match the checksum algorithm you set
+// through x-amz-sdk-checksum-algorithm, Amazon S3 fails the request with a
+// BadDigest error."
+//
+// The default-checksum divergence is deliberate. S3 now attaches CRC-64/NVME to
+// every object uploaded without a checksum, so a GetObject with checksum-mode
+// ENABLED returns a value even for an object written with no checksum headers at
+// all. Substrate does not synthesize that, because doing so would make the
+// round-trip assertion in every consumer's test pass whether or not their upload
+// path actually sends a checksum — which is the failure mode this issue was filed
+// about. An absent checksum here means "your writer sent none".
+//
+// A non-nil *AWSResponse is the error to return; the caller must not write.
+func resolveChecksum(headers map[string]string, body []byte) (s3Checksum, *AWSResponse) {
+	named, resp := requestedChecksumAlgorithm(headers)
+	if resp != nil {
+		return s3Checksum{}, resp
+	}
+
+	supplied, alg, resp := suppliedChecksum(headers)
+	if resp != nil {
+		return s3Checksum{}, resp
+	}
+
+	switch {
+	case supplied != "":
+		// Both headers present must name the same algorithm.
+		if named != "" && !strings.EqualFold(named, alg.Name) {
+			return s3Checksum{}, s3ErrorResponseWith(s3Error{
+				Code:    "BadDigest",
+				Message: s3BadDigestMessage,
+				Status:  http.StatusBadRequest,
+				Details: []s3ErrorDetail{
+					{Name: "ChecksumAlgorithm", Value: alg.Name},
+					{Name: "SDKChecksumAlgorithm", Value: named},
+				},
+			})
+		}
+		computed := s3ChecksumDigest(alg, body)
+		if supplied != computed {
+			return s3Checksum{}, s3BadDigestResponse(alg.Name, supplied, computed)
+		}
+		return s3Checksum{Algorithm: alg.Name, Value: computed, Type: S3ChecksumTypeFullObject}, nil
+
+	case named != "":
+		// The algorithm was named with no value and no trailer to carry one.
+		sdkAlg, ok := s3ChecksumByName(named)
+		if !ok {
+			return s3Checksum{}, s3InvalidChecksumAlgorithmResponse(named)
+		}
+		if sdkAlg.New == nil {
+			return s3Checksum{}, s3ChecksumNotImplemented(sdkAlg.Name)
+		}
+		return s3Checksum{
+			Algorithm: sdkAlg.Name,
+			Value:     s3ChecksumDigest(sdkAlg, body),
+			Type:      S3ChecksumTypeFullObject,
+		}, nil
+
+	default:
+		return s3Checksum{}, nil
+	}
+}
+
+// requestedChecksumAlgorithm reads x-amz-sdk-checksum-algorithm, returning the
+// name it holds. An empty name means the header was absent.
+//
+// The value is not resolved to an algorithm here: whether it must be one substrate
+// can compute depends on whether a value accompanies it, which only
+// [resolveChecksum] knows.
+func requestedChecksumAlgorithm(headers map[string]string) (string, *AWSResponse) {
+	name, ok := headerLookupFold(headers, "x-amz-sdk-checksum-algorithm")
+	if !ok {
+		return "", nil
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", s3InvalidChecksumAlgorithmResponse(name)
+	}
+	if _, known := s3ChecksumByName(name); !known {
+		return "", s3InvalidChecksumAlgorithmResponse(name)
+	}
+	return name, nil
+}
+
+// suppliedChecksum finds the x-amz-checksum-<algorithm> header on a request and
+// returns its base64 value alongside the algorithm it names.
+//
+// An empty value with a non-nil error response means the request named an
+// algorithm substrate cannot verify, or named more than one.
+func suppliedChecksum(headers map[string]string) (string, s3ChecksumAlgorithm, *AWSResponse) {
+	var found s3ChecksumAlgorithm
+	var value string
+
+	for _, alg := range s3ChecksumAlgorithms {
+		v, ok := headerLookupFold(headers, s3ChecksumHeaderOf(alg.Name))
+		if !ok {
+			continue
+		}
+		if found.Name != "" {
+			// "Expecting a single x-amz-checksum- header. Multiple checksum Types
+			// are not allowed."
+			return "", s3ChecksumAlgorithm{}, s3ErrorResponseWith(s3Error{
+				Code:    "InvalidRequest",
+				Message: "Expecting a single x-amz-checksum- header. Multiple checksum Types are not allowed.",
+				Status:  http.StatusBadRequest,
+			})
+		}
+		found, value = alg, v
+	}
+
+	if found.Name == "" {
+		return "", s3ChecksumAlgorithm{}, nil
+	}
+	if found.New == nil {
+		return "", s3ChecksumAlgorithm{}, s3ChecksumNotImplemented(found.Name)
+	}
+	if !validBase64Checksum(value, found) {
+		return "", s3ChecksumAlgorithm{}, s3ErrorResponseWith(s3Error{
+			Code:    "InvalidRequest",
+			Message: "Value for " + s3ChecksumHeaderOf(found.Name) + " header is invalid.",
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{{Name: "ChecksumAlgorithm", Value: found.Name}},
+		})
+	}
+	return value, found, nil
+}
+
+// validBase64Checksum reports whether value is a base64 digest of the width alg
+// produces. A well-formed but wrong-length value is a malformed request rather
+// than a digest mismatch, so it is separated from BadDigest.
+func validBase64Checksum(value string, alg s3ChecksumAlgorithm) bool {
+	raw, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return false
+	}
+	return len(raw) == alg.New().Size()
+}
+
+// s3InvalidChecksumAlgorithmResponse is the 400 served for an algorithm name
+// outside the documented set.
+func s3InvalidChecksumAlgorithmResponse(name string) *AWSResponse {
+	return s3ErrorResponseWith(s3Error{
+		Code:    "InvalidRequest",
+		Message: "Checksum algorithm provided is unsupported. Please try again with any of the valid types: [CRC32, CRC32C, CRC64NVME, SHA1, SHA256, SHA512, MD5, XXHASH64, XXHASH3, XXHASH128]",
+		Status:  http.StatusBadRequest,
+		Details: []s3ErrorDetail{{Name: "ChecksumAlgorithm", Value: name}},
+	})
+}
+
+// resolveChecksumMode reads x-amz-checksum-mode and reports whether the caller
+// asked for the stored checksum to be returned.
+//
+// "To retrieve the checksum, this mode must be enabled." The only documented value
+// is ENABLED; anything else is treated as not enabled, matching S3, which returns
+// no checksum rather than an error for an unrecognized mode.
+func resolveChecksumMode(headers map[string]string) bool {
+	return strings.EqualFold(headerValueFold(headers, "x-amz-checksum-mode"), "ENABLED")
+}
+
+// s3ChecksumXML carries one dynamically named checksum element, such as the
+// <ChecksumSHA256> of a CompleteMultipartUploadResult. It works the same way
+// [s3ErrorDetailXML] does: encoding/xml takes the element name from the XMLName
+// field's value ahead of the parent field's tag.
+type s3ChecksumXML struct {
+	XMLName xml.Name
+	Value   string `xml:",chardata"`
+}
+
+// checksumXMLElements renders a checksum as the <Checksum<ALGORITHM>> element
+// CompleteMultipartUpload returns in its result body, or nil when there is none.
+//
+// The element name is the algorithm in the API's own casing — <ChecksumCRC64NVME>,
+// <ChecksumSHA256> — which is why it is taken from the algorithm table rather than
+// derived from the lowercased header name.
+func checksumXMLElements(c s3Checksum) []s3ChecksumXML {
+	if !c.present() {
+		return nil
+	}
+	return []s3ChecksumXML{{
+		XMLName: xml.Name{Local: "Checksum" + c.Algorithm},
+		Value:   c.Value,
+	}}
+}
+
+// applyChecksumHeaders adds the stored checksum and its type to a GetObject or
+// HeadObject response, when the object has one and the request enabled
+// checksum-mode. It is a no-op otherwise, which is what makes the absence of the
+// header on a plain GET observable.
+func applyChecksumHeaders(headers map[string]string, c s3Checksum, enabled bool) {
+	if !enabled || !c.present() {
+		return
+	}
+	headers[s3ChecksumHeaderOf(c.Algorithm)] = c.Value
+	if c.Type != "" {
+		headers["x-amz-checksum-type"] = c.Type
+	}
+}
+
+// resolveUploadChecksum determines the checksum configuration for a multipart
+// upload from a CreateMultipartUpload request.
+//
+// CreateMultipartUpload names the algorithm in x-amz-checksum-algorithm — not the
+// x-amz-sdk-checksum-algorithm form PutObject uses — and optionally the type in
+// x-amz-checksum-type. An absent type defaults to COMPOSITE for every algorithm
+// that supports it, since "if you're using a multipart upload to upload your
+// object, then you must specify the composite checksum type"; CRC-64/NVME, which
+// supports no composite form, defaults to FULL_OBJECT instead.
+//
+// The requested combination is validated against the documented support matrix, so
+// an upload that could never complete against real S3 is rejected here, at
+// creation, rather than after every part has been uploaded.
+func resolveUploadChecksum(headers map[string]string) (algorithm, checksumType string, resp *AWSResponse) {
+	name, ok := headerLookupFold(headers, "x-amz-checksum-algorithm")
+	requestedType := headerValueFold(headers, "x-amz-checksum-type")
+
+	if !ok || strings.TrimSpace(name) == "" {
+		if requestedType != "" {
+			// A type with no algorithm has nothing to apply to.
+			return "", "", s3ErrorResponseWith(s3Error{
+				Code:    "InvalidRequest",
+				Message: "x-amz-checksum-type cannot be used without x-amz-checksum-algorithm.",
+				Status:  http.StatusBadRequest,
+			})
+		}
+		return "", "", nil
+	}
+
+	alg, known := s3ChecksumByName(name)
+	if !known {
+		return "", "", s3InvalidChecksumAlgorithmResponse(name)
+	}
+	if alg.New == nil {
+		return "", "", s3ChecksumNotImplemented(alg.Name)
+	}
+
+	switch {
+	case requestedType == "":
+		if alg.Composite {
+			checksumType = S3ChecksumTypeComposite
+		} else {
+			checksumType = S3ChecksumTypeFullObject
+		}
+	case strings.EqualFold(requestedType, S3ChecksumTypeComposite):
+		checksumType = S3ChecksumTypeComposite
+	case strings.EqualFold(requestedType, S3ChecksumTypeFullObject):
+		checksumType = S3ChecksumTypeFullObject
+	default:
+		return "", "", s3ErrorResponseWith(s3Error{
+			Code:    "InvalidRequest",
+			Message: "Checksum type provided is unsupported. Please try again with any of the valid types: [COMPOSITE, FULL_OBJECT]",
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{{Name: "ChecksumType", Value: requestedType}},
+		})
+	}
+
+	if resp := checkChecksumTypeSupported(alg, checksumType); resp != nil {
+		return "", "", resp
+	}
+	return alg.Name, checksumType, nil
+}
+
+// checkChecksumTypeSupported rejects an algorithm/type pairing the documented
+// support matrix does not allow, such as a FULL_OBJECT SHA-256.
+func checkChecksumTypeSupported(alg s3ChecksumAlgorithm, checksumType string) *AWSResponse {
+	supported := alg.Composite
+	if checksumType == S3ChecksumTypeFullObject {
+		supported = alg.FullObject
+	}
+	if supported {
+		return nil
+	}
+	return s3ErrorResponseWith(s3Error{
+		Code: "InvalidRequest",
+		Message: "The " + checksumType + " checksum type is not supported for the " + alg.Name +
+			" checksum algorithm.",
+		Status: http.StatusBadRequest,
+		Details: []s3ErrorDetail{
+			{Name: "ChecksumAlgorithm", Value: alg.Name},
+			{Name: "ChecksumType", Value: checksumType},
+		},
+	})
+}
+
+// resolveCopyChecksumAlgorithm determines the algorithm a CopyObject destination
+// should be checksummed under.
+//
+// "You can copy the object and specify whether you want to use the existing
+// checksum algorithm or a new one. If you don't specify an algorithm, S3 uses the
+// existing algorithm." An unchecksummed source with no algorithm named yields no
+// checksum here, rather than the CRC-64/NVME real S3 would default to — the same
+// deliberate divergence [resolveChecksum] documents, for the same reason.
+//
+// CopyObject names the algorithm in x-amz-checksum-algorithm, as
+// CreateMultipartUpload does; there is no body for the caller to have precomputed a
+// value over, so no per-algorithm value header is honored.
+func resolveCopyChecksumAlgorithm(headers map[string]string, src *S3Object) (string, *AWSResponse) {
+	name, ok := headerLookupFold(headers, "x-amz-checksum-algorithm")
+	if !ok || strings.TrimSpace(name) == "" {
+		return src.Checksum.Algorithm, nil
+	}
+	alg, known := s3ChecksumByName(name)
+	if !known {
+		return "", s3InvalidChecksumAlgorithmResponse(name)
+	}
+	if alg.New == nil {
+		return "", s3ChecksumNotImplemented(alg.Name)
+	}
+	return alg.Name, nil
+}
+
+// copyChecksum computes the destination checksum of a CopyObject under algorithm,
+// which is always a full-object checksum of the copied bytes.
+func copyChecksum(algorithm string, body []byte) s3Checksum {
+	if algorithm == "" {
+		return s3Checksum{}
+	}
+	alg, known := s3ChecksumByName(algorithm)
+	if !known || alg.New == nil {
+		// Unreachable: resolveCopyChecksumAlgorithm rejects both cases. Returning
+		// no checksum rather than panicking keeps a stored object whose algorithm
+		// substrate no longer computes readable.
+		return s3Checksum{}
+	}
+	return s3Checksum{
+		Algorithm: alg.Name,
+		Value:     s3ChecksumDigest(alg, body),
+		Type:      S3ChecksumTypeFullObject,
+	}
+}
+
+// resolvePartChecksum determines the checksum to record for one uploaded part.
+//
+// A part's algorithm is fixed by the upload: uploadAlgorithm is what
+// CreateMultipartUpload recorded. A part that supplies a value under a *different*
+// algorithm is rejected, mirroring the trailer rule — "if a request contains
+// x-amz-trailer: x-amz-checksum-crc32 and the trailer chunk has the header name
+// x-amz-checksum-sha1, the request fails" — because a part digest computed under
+// another algorithm cannot contribute to the object's checksum.
+//
+// When the upload has an algorithm and the part supplies no value, the digest is
+// computed here. That is what lets substrate assemble the object checksum on
+// Complete regardless of whether the caller sent per-part values.
+func resolvePartChecksum(headers map[string]string, body []byte, uploadAlgorithm string) (s3Checksum, *AWSResponse) {
+	supplied, alg, resp := suppliedChecksum(headers)
+	if resp != nil {
+		return s3Checksum{}, resp
+	}
+	named, resp := requestedChecksumAlgorithm(headers)
+	if resp != nil {
+		return s3Checksum{}, resp
+	}
+
+	// Reconcile the algorithm the part names against the upload's.
+	partAlgorithm := alg.Name
+	if partAlgorithm == "" {
+		partAlgorithm = named
+	}
+	if partAlgorithm != "" && uploadAlgorithm != "" && !strings.EqualFold(partAlgorithm, uploadAlgorithm) {
+		return s3Checksum{}, s3ErrorResponseWith(s3Error{
+			Code: "InvalidRequest",
+			Message: "Checksum algorithm " + partAlgorithm + " does not match the " + uploadAlgorithm +
+				" algorithm specified for this multipart upload.",
+			Status: http.StatusBadRequest,
+			Details: []s3ErrorDetail{
+				{Name: "ChecksumAlgorithm", Value: partAlgorithm},
+				{Name: "UploadChecksumAlgorithm", Value: uploadAlgorithm},
+			},
+		})
+	}
+
+	effective := uploadAlgorithm
+	if effective == "" {
+		effective = partAlgorithm
+	}
+	if effective == "" {
+		return s3Checksum{}, nil
+	}
+
+	effAlg, known := s3ChecksumByName(effective)
+	if !known {
+		return s3Checksum{}, s3InvalidChecksumAlgorithmResponse(effective)
+	}
+	if effAlg.New == nil {
+		return s3Checksum{}, s3ChecksumNotImplemented(effAlg.Name)
+	}
+
+	computed := s3ChecksumDigest(effAlg, body)
+	if supplied != "" && supplied != computed {
+		return s3Checksum{}, s3BadDigestResponse(effAlg.Name, supplied, computed)
+	}
+	// A part checksum is a checksum of that part's bytes in full, so its type is
+	// FULL_OBJECT relative to the part. The object-level type is decided on
+	// Complete, from the upload's configuration.
+	return s3Checksum{Algorithm: effAlg.Name, Value: computed, Type: S3ChecksumTypeFullObject}, nil
+}
+
+// assembleObjectChecksum computes the object-level checksum of a completed
+// multipart upload from the assembled body and the individual part bodies.
+//
+// The two checksum types are computed differently, and the difference is the whole
+// point of distinguishing them:
+//
+//   - COMPOSITE hashes the concatenation of the raw part digests and appends
+//     "-<part count>", exactly as substrate already derives the multipart ETag:
+//     "this approach aggregates the part-level checksums (from the first part to
+//     the last) to produce a single, combined checksum for the complete object."
+//   - FULL_OBJECT hashes every byte of the assembled object, "covering all data
+//     from the first byte of the first part to the last byte of the last part",
+//     and carries no suffix.
+//
+// A caller whose single-part and multipart writers hash different byte streams gets
+// two different values here, which is the class of bug the reporter of #399 hit.
+func assembleObjectChecksum(algorithm, checksumType string, combined []byte, partBodies [][]byte) (s3Checksum, *AWSResponse) {
+	if algorithm == "" {
+		return s3Checksum{}, nil
+	}
+	alg, known := s3ChecksumByName(algorithm)
+	if !known {
+		return s3Checksum{}, s3InvalidChecksumAlgorithmResponse(algorithm)
+	}
+	if alg.New == nil {
+		return s3Checksum{}, s3ChecksumNotImplemented(alg.Name)
+	}
+	if resp := checkChecksumTypeSupported(alg, checksumType); resp != nil {
+		return s3Checksum{}, resp
+	}
+
+	if checksumType == S3ChecksumTypeFullObject {
+		return s3Checksum{
+			Algorithm: alg.Name,
+			Value:     s3ChecksumDigest(alg, combined),
+			Type:      S3ChecksumTypeFullObject,
+		}, nil
+	}
+
+	var digests []byte
+	for _, part := range partBodies {
+		digests = append(digests, s3ChecksumRawDigest(alg, part)...)
+	}
+	return s3Checksum{
+		Algorithm: alg.Name,
+		Value:     s3ChecksumDigest(alg, digests) + "-" + strconv.Itoa(len(partBodies)),
+		Type:      S3ChecksumTypeComposite,
+	}, nil
+}
+
+// verifyCompleteChecksum checks a checksum supplied on CompleteMultipartUpload
+// against the one substrate assembled.
+//
+// Complete accepts a full-object checksum for the whole upload: "You can provide
+// the checksum of the whole object in the CompleteMultipartUpload request... If the
+// two values don't match, S3 fails the request with a BadDigest error." A supplied
+// x-amz-checksum-type that disagrees with what CreateMultipartUpload specified is
+// also a BadDigest, since the value was computed under different rules.
+func verifyCompleteChecksum(headers map[string]string, assembled s3Checksum) *AWSResponse {
+	if requested := headerValueFold(headers, "x-amz-checksum-type"); requested != "" {
+		if !strings.EqualFold(requested, assembled.Type) {
+			return s3ErrorResponseWith(s3Error{
+				Code:    "BadDigest",
+				Message: s3BadDigestMessage,
+				Status:  http.StatusBadRequest,
+				Details: []s3ErrorDetail{
+					{Name: "ChecksumType", Value: requested},
+					{Name: "UploadChecksumType", Value: assembled.Type},
+				},
+			})
+		}
+	}
+
+	supplied, alg, resp := suppliedChecksum(headers)
+	if resp != nil {
+		return resp
+	}
+	if supplied == "" {
+		return nil
+	}
+	if assembled.Algorithm != "" && !strings.EqualFold(alg.Name, assembled.Algorithm) {
+		return s3ErrorResponseWith(s3Error{
+			Code: "InvalidRequest",
+			Message: "Checksum algorithm " + alg.Name + " does not match the " + assembled.Algorithm +
+				" algorithm specified for this multipart upload.",
+			Status: http.StatusBadRequest,
+			Details: []s3ErrorDetail{
+				{Name: "ChecksumAlgorithm", Value: alg.Name},
+				{Name: "UploadChecksumAlgorithm", Value: assembled.Algorithm},
+			},
+		})
+	}
+	if supplied != assembled.Value {
+		return s3BadDigestResponse(alg.Name, supplied, assembled.Value)
+	}
+	return nil
+}

--- a/emulator/s3_checksum_test.go
+++ b/emulator/s3_checksum_test.go
@@ -1,0 +1,1214 @@
+package emulator_test
+
+import (
+	"bytes"
+	"crypto/md5" //nolint:gosec // MD5 is one of the checksum algorithms under test.
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"hash/crc64"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// checksumAlgorithms enumerates the algorithms substrate verifies, paired with an
+// independent implementation of each.
+//
+// The hash constructors here are deliberately declared in the test rather than
+// reached for from the emulator package: a test that computes its expected value by
+// calling the same code under test would pass even if that code hashed the wrong
+// algorithm. These are wired straight to the stdlib.
+var checksumAlgorithms = []struct {
+	Name       string
+	Header     string
+	New        func() hash.Hash
+	FullObject bool // supports FULL_OBJECT in a multipart upload
+	Composite  bool // supports COMPOSITE in a multipart upload
+}{
+	{Name: "CRC32", Header: "x-amz-checksum-crc32", New: func() hash.Hash { return crc32.NewIEEE() }, FullObject: true, Composite: true},
+	{Name: "CRC32C", Header: "x-amz-checksum-crc32c", New: func() hash.Hash { return crc32.New(crc32.MakeTable(crc32.Castagnoli)) }, FullObject: true, Composite: true},
+	{Name: "CRC64NVME", Header: "x-amz-checksum-crc64nvme", New: newCRC64NVME, FullObject: true},
+	{Name: "SHA1", Header: "x-amz-checksum-sha1", New: sha1.New, Composite: true},
+	{Name: "SHA256", Header: "x-amz-checksum-sha256", New: sha256.New, Composite: true},
+	{Name: "SHA512", Header: "x-amz-checksum-sha512", New: sha512.New, Composite: true},
+	{Name: "MD5", Header: "x-amz-checksum-md5", New: md5.New, Composite: true},
+}
+
+// newCRC64NVME builds a CRC-64/NVME hash from the reversed generator polynomial.
+// TestS3Checksum_CRC64NVMEPolynomial pins this against the published check value,
+// so a wrong polynomial here fails loudly rather than agreeing with a wrong one in
+// the emulator.
+func newCRC64NVME() hash.Hash {
+	return crc64.New(crc64.MakeTable(0x9a6c9329ac4bc9b5))
+}
+
+// digestFor returns the base64 digest of body under the named algorithm.
+func digestFor(t *testing.T, name string, body []byte) string {
+	t.Helper()
+	for _, alg := range checksumAlgorithms {
+		if alg.Name == name {
+			h := alg.New()
+			h.Write(body)
+			return base64.StdEncoding.EncodeToString(h.Sum(nil))
+		}
+	}
+	t.Fatalf("no test implementation for algorithm %q", name)
+	return ""
+}
+
+// corruptDigest returns a valid base64 digest of the right width for alg that is
+// not the digest of body — a wrong checksum, as distinct from a malformed one.
+func corruptDigest(t *testing.T, name string, body []byte) string {
+	t.Helper()
+	return digestFor(t, name, append([]byte("not-"), body...))
+}
+
+// putBucket creates a bucket, failing the test if it cannot.
+func putBucket(t *testing.T, srv *emulator.Server, bucket string) {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "create bucket")
+}
+
+// TestS3Checksum_CRC64NVMEPolynomial pins the CRC-64/NVME table against the
+// published catalog check value, so a transcription error in the polynomial is
+// caught here rather than showing up as a plausible-looking wrong digest.
+func TestS3Checksum_CRC64NVMEPolynomial(t *testing.T) {
+	h := newCRC64NVME()
+	h.Write([]byte("123456789"))
+	assert.Equal(t, "ae8b14860a799888", fmt.Sprintf("%x", h.Sum(nil)),
+		"CRC-64/NVME check value for the string 123456789")
+}
+
+// TestS3Checksum_PutObject_RoundTrip covers, per algorithm, the two halves of the
+// acceptance criterion: a supplied checksum is echoed on PUT and comes back on GET
+// and HEAD under checksum-mode ENABLED, and is absent from both without it.
+func TestS3Checksum_PutObject_RoundTrip(t *testing.T) {
+	body := []byte("substrate checksum round trip")
+
+	for _, alg := range checksumAlgorithms {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			want := digestFor(t, alg.Name, body)
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				alg.Header: want,
+			})
+			require.Equal(t, http.StatusOK, w.Code, "PUT body: %s", w.Body.String())
+			assert.Equal(t, want, w.Header().Get(alg.Header), "PutObject echoes the checksum")
+			assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"),
+				"a single-part PUT is always a full-object checksum")
+
+			// GET with the mode enabled returns it.
+			w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+			assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+			assert.Equal(t, body, w.Body.Bytes())
+
+			// GET without it does not.
+			w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, nil)
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Empty(t, w.Header().Get(alg.Header),
+				"checksum must be absent without x-amz-checksum-mode: ENABLED")
+			assert.Empty(t, w.Header().Get("x-amz-checksum-type"))
+
+			// HEAD honors the mode identically.
+			w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+
+			w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Empty(t, w.Header().Get(alg.Header))
+		})
+	}
+}
+
+// TestS3Checksum_PutObject_BadDigest is the behavior the issue most wanted: a
+// wrong checksum is a 400 BadDigest, and the object is not written.
+func TestS3Checksum_PutObject_BadDigest(t *testing.T) {
+	body := []byte("payload that will be rejected")
+
+	for _, alg := range checksumAlgorithms {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, fs := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/rejected", body, map[string]string{
+				alg.Header: corruptDigest(t, alg.Name, body),
+			})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+			assert.Contains(t, w.Body.String(), "<ChecksumAlgorithm>"+alg.Name+"</ChecksumAlgorithm>")
+
+			// The object must not exist: neither its metadata nor its body.
+			w = s3Request(t, srv, http.MethodHead, "/cks/rejected", nil, nil)
+			assert.Equal(t, http.StatusNotFound, w.Code, "rejected object must not be readable")
+
+			exists, err := afero.Exists(fs, "/cks/rejected")
+			require.NoError(t, err)
+			assert.False(t, exists, "rejected object body must not be on the filesystem")
+		})
+	}
+}
+
+// TestS3Checksum_PutObject_BadDigestDoesNotOverwrite asserts the stronger property:
+// a rejected PUT over an existing object leaves the original bytes and checksum
+// intact, rather than truncating or partially replacing them.
+func TestS3Checksum_PutObject_BadDigestDoesNotOverwrite(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	original := []byte("the original contents")
+	originalDigest := digestFor(t, "SHA256", original)
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", original, map[string]string{
+		"x-amz-checksum-sha256": originalDigest,
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	originalETag := w.Header().Get("ETag")
+
+	replacement := []byte("a replacement that fails its checksum")
+	w = s3Request(t, srv, http.MethodPut, "/cks/obj", replacement, map[string]string{
+		"x-amz-checksum-sha256": corruptDigest(t, "SHA256", replacement),
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, original, w.Body.Bytes(), "body must be unchanged")
+	assert.Equal(t, originalETag, w.Header().Get("ETag"), "ETag must be unchanged")
+	assert.Equal(t, originalDigest, w.Header().Get("x-amz-checksum-sha256"),
+		"stored checksum must be unchanged")
+}
+
+// TestS3Checksum_SDKChecksumAlgorithm covers the second write shape: the caller
+// names an algorithm and substrate computes the digest.
+func TestS3Checksum_SDKChecksumAlgorithm(t *testing.T) {
+	body := []byte("service-computed digest")
+
+	for _, alg := range checksumAlgorithms {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				"x-amz-sdk-checksum-algorithm": alg.Name,
+			})
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, digestFor(t, alg.Name, body), w.Header().Get(alg.Header))
+
+			w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, digestFor(t, alg.Name, body), w.Header().Get(alg.Header))
+		})
+	}
+}
+
+// TestS3Checksum_NoChecksumHeaders asserts that an object written with no checksum
+// headers records none.
+//
+// This is a deliberate divergence from current S3, which attaches a default
+// CRC-64/NVME checksum to every upload. Synthesizing one here would make a
+// consumer's "the checksum came back" assertion pass whether or not their writer
+// sends a checksum at all — the precise failure #399 was filed about.
+func TestS3Checksum_NoChecksumHeaders(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/plain", []byte("no checksum"), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	for _, alg := range checksumAlgorithms {
+		assert.Empty(t, w.Header().Get(alg.Header))
+	}
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/plain", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("x-amz-checksum-crc64nvme"),
+		"substrate does not synthesize a default checksum")
+	assert.Empty(t, w.Header().Get("x-amz-checksum-type"))
+}
+
+// TestS3Checksum_ChecksumModeValues checks the gate itself: only ENABLED opens it,
+// and an unrecognized value is not an error.
+func TestS3Checksum_ChecksumModeValues(t *testing.T) {
+	body := []byte("mode gating")
+	want := digestFor(t, "SHA256", body)
+
+	tests := []struct {
+		name    string
+		mode    string
+		present bool
+	}{
+		{name: "enabled", mode: "ENABLED", present: true},
+		{name: "lowercase enabled", mode: "enabled", present: true},
+		{name: "mixed case enabled", mode: "Enabled", present: true},
+		{name: "absent", mode: "", present: false},
+		{name: "disabled", mode: "DISABLED", present: false},
+		{name: "unrecognized", mode: "sometimes", present: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				"x-amz-checksum-sha256": want,
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+
+			headers := map[string]string{}
+			if tc.mode != "" {
+				headers["x-amz-checksum-mode"] = tc.mode
+			}
+			w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, headers)
+			// An unrecognized mode is never an error; it just returns no checksum.
+			require.Equal(t, http.StatusOK, w.Code)
+			if tc.present {
+				assert.Equal(t, want, w.Header().Get("x-amz-checksum-sha256"))
+			} else {
+				assert.Empty(t, w.Header().Get("x-amz-checksum-sha256"))
+			}
+		})
+	}
+}
+
+// TestS3Checksum_PutObject_MalformedValue distinguishes a malformed checksum from a
+// wrong one: a value that is not base64, or is the wrong width for its algorithm,
+// is an InvalidRequest rather than a BadDigest.
+func TestS3Checksum_PutObject_MalformedValue(t *testing.T) {
+	body := []byte("malformed checksum values")
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "not base64", value: "!!!not-base64!!!"},
+		{name: "too short", value: base64.StdEncoding.EncodeToString([]byte("short"))},
+		{name: "too long", value: base64.StdEncoding.EncodeToString(make([]byte, 64))},
+		{name: "empty", value: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				"x-amz-checksum-sha256": tc.value,
+			})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+
+			w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+			assert.Equal(t, http.StatusNotFound, w.Code, "object must not be written")
+		})
+	}
+}
+
+// TestS3Checksum_PutObject_AlgorithmDisagreement covers the documented BadDigest
+// case where the two write headers name different algorithms: "if the individual
+// checksum value you provide through x-amz-checksum-<algorithm> doesn't match the
+// checksum algorithm you set through x-amz-sdk-checksum-algorithm, Amazon S3 fails
+// the request with a BadDigest error".
+func TestS3Checksum_PutObject_AlgorithmDisagreement(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("disagreeing algorithms")
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+		"x-amz-checksum-sha256":        digestFor(t, "SHA256", body),
+		"x-amz-sdk-checksum-algorithm": "CRC32",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+
+	w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestS3Checksum_PutObject_AlgorithmAgreement is the converse: the same algorithm
+// named in both headers is accepted.
+func TestS3Checksum_PutObject_AlgorithmAgreement(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("agreeing algorithms")
+	want := digestFor(t, "SHA256", body)
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+		"x-amz-checksum-sha256":        want,
+		"x-amz-sdk-checksum-algorithm": "sha256", // case-insensitive
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, want, w.Header().Get("x-amz-checksum-sha256"))
+}
+
+// TestS3Checksum_PutObject_MultipleChecksumHeaders asserts that two different
+// per-algorithm headers on one request is an InvalidRequest, not a silent pick.
+func TestS3Checksum_PutObject_MultipleChecksumHeaders(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("two checksums")
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", body),
+		"x-amz-checksum-crc32":  digestFor(t, "CRC32", body),
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+	assert.Contains(t, w.Body.String(), "Multiple checksum Types are not allowed")
+}
+
+// TestS3Checksum_UnsupportedAlgorithms asserts that the three algorithms substrate
+// cannot compute are refused with 501 rather than accepted unverified.
+//
+// This is the property that keeps substrate from being worse than no mock at all
+// for these algorithms: a caller learns immediately, instead of shipping a test
+// that passes on a checksum nothing ever checked.
+func TestS3Checksum_UnsupportedAlgorithms(t *testing.T) {
+	body := []byte("xxhash family")
+
+	for _, alg := range []struct{ Name, Header string }{
+		{"XXHASH64", "x-amz-checksum-xxhash64"},
+		{"XXHASH3", "x-amz-checksum-xxhash3"},
+		{"XXHASH128", "x-amz-checksum-xxhash128"},
+	} {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			// Supplied as a value...
+			w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				alg.Header: base64.StdEncoding.EncodeToString([]byte("00000000")),
+			})
+			assert.Equal(t, http.StatusNotImplemented, w.Code)
+			assert.Contains(t, w.Body.String(), "<Code>NotImplemented</Code>")
+			assert.Contains(t, w.Body.String(), "<ChecksumAlgorithm>"+alg.Name+"</ChecksumAlgorithm>")
+
+			// ...and named for the service to compute.
+			w = s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+				"x-amz-sdk-checksum-algorithm": alg.Name,
+			})
+			assert.Equal(t, http.StatusNotImplemented, w.Code)
+
+			w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+			assert.Equal(t, http.StatusNotFound, w.Code, "object must not be written")
+		})
+	}
+}
+
+// TestS3Checksum_UnknownAlgorithm asserts an algorithm outside the documented set
+// is an InvalidRequest.
+func TestS3Checksum_UnknownAlgorithm(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", []byte("x"), map[string]string{
+		"x-amz-sdk-checksum-algorithm": "SHA3",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+	assert.Contains(t, w.Body.String(), "<ChecksumAlgorithm>SHA3</ChecksumAlgorithm>")
+}
+
+// TestS3Checksum_EmptyBody asserts a zero-byte object gets the digest of the empty
+// string, not an absent checksum.
+func TestS3Checksum_EmptyBody(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	want := digestFor(t, "CRC32", nil)
+	require.Equal(t, "AAAAAA==", want, "CRC32 of the empty string")
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/empty", []byte{}, map[string]string{
+		"x-amz-checksum-crc32": want,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/empty", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, want, w.Header().Get("x-amz-checksum-crc32"))
+}
+
+// TestS3Checksum_RangedGetReturnsObjectChecksum documents how a checksum composes
+// with a ranged read: the header is the whole object's checksum, so it must not be
+// mistaken for a checksum of the bytes actually served.
+func TestS3Checksum_RangedGetReturnsObjectChecksum(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("0123456789abcdefghij")
+	want := digestFor(t, "SHA256", body)
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", body, map[string]string{
+		"x-amz-checksum-sha256": want,
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+		"Range":               "bytes=0-3",
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, []byte("0123"), w.Body.Bytes())
+	assert.Equal(t, want, w.Header().Get("x-amz-checksum-sha256"),
+		"the checksum is the full object's, not the range's")
+}
+
+// TestS3Checksum_Versioning asserts each version keeps its own checksum.
+func TestS3Checksum_Versioning(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPut, "/cks?versioning", []byte(
+		`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	first := []byte("version one")
+	w = s3Request(t, srv, http.MethodPut, "/cks/obj", first, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", first),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	v1 := w.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, v1)
+
+	second := []byte("version two, which differs")
+	w = s3Request(t, srv, http.MethodPut, "/cks/obj", second, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", second),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/obj?versionId="+v1, nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "SHA256", first), w.Header().Get("x-amz-checksum-sha256"),
+		"the old version keeps its own checksum")
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/obj", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "SHA256", second), w.Header().Get("x-amz-checksum-sha256"))
+}
+
+// --- aws-chunked trailing checksums ---
+
+// awsChunkedBody frames body as a single aws-chunked object chunk followed by a
+// completion chunk and a trailer, in the format the S3 user guide documents:
+//
+//	x-amz-checksum-<alg>:<base64>\n\r\n\r\n
+func awsChunkedBody(body []byte, trailerName, trailerValue string) []byte {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%x\r\n", len(body))
+	b.Write(body)
+	b.WriteString("\r\n0\r\n")
+	if trailerName != "" {
+		fmt.Fprintf(&b, "%s:%s\n\r\n", trailerName, trailerValue)
+	}
+	b.WriteString("\r\n")
+	return []byte(b.String())
+}
+
+// awsChunkedHeaders builds the header set that marks a body as aws-chunked with a
+// trailing checksum.
+func awsChunkedHeaders(decodedLen int, trailerName string) map[string]string {
+	h := map[string]string{
+		"Content-Encoding":             "aws-chunked",
+		"x-amz-content-sha256":         "STREAMING-UNSIGNED-PAYLOAD-TRAILER",
+		"x-amz-decoded-content-length": fmt.Sprintf("%d", decodedLen),
+	}
+	if trailerName != "" {
+		h["x-amz-trailer"] = trailerName
+	}
+	return h
+}
+
+// TestS3Checksum_TrailingChecksum_Accepted asserts that a checksum arriving in an
+// aws-chunked trailer is verified, not discarded.
+//
+// This is the path every real SDK upload takes when given a ChecksumAlgorithm, so a
+// decoder that dropped trailers would make checksum verification silently
+// unreachable in exactly the case consumers care about.
+func TestS3Checksum_TrailingChecksum_Accepted(t *testing.T) {
+	body := []byte("streamed with a trailing checksum")
+
+	for _, alg := range checksumAlgorithms {
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			want := digestFor(t, alg.Name, body)
+			framed := awsChunkedBody(body, alg.Header, want)
+
+			w := s3Request(t, srv, http.MethodPut, "/cks/streamed", framed,
+				awsChunkedHeaders(len(body), alg.Header))
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+
+			// The stored body must be the decoded content, not the framing.
+			w = s3Request(t, srv, http.MethodGet, "/cks/streamed", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, body, w.Body.Bytes())
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+		})
+	}
+}
+
+// TestS3Checksum_TrailingChecksum_BadDigest asserts a wrong trailing checksum is
+// rejected and writes nothing — the same guarantee as the header form.
+func TestS3Checksum_TrailingChecksum_BadDigest(t *testing.T) {
+	srv, fs := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("streamed but corrupt")
+	framed := awsChunkedBody(body, "x-amz-checksum-crc32", corruptDigest(t, "CRC32", body))
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/streamed", framed,
+		awsChunkedHeaders(len(body), "x-amz-checksum-crc32"))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+
+	exists, err := afero.Exists(fs, "/cks/streamed")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+// TestS3Checksum_TrailingChecksum_SignedFraming asserts the trailer is still found
+// when the chunks carry SigV4 signatures and a trailer signature line follows.
+func TestS3Checksum_TrailingChecksum_SignedFraming(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("signed chunks with a trailing checksum")
+	want := digestFor(t, "CRC32C", body)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%x;chunk-signature=%s\r\n", len(body), strings.Repeat("a", 64))
+	b.Write(body)
+	fmt.Fprintf(&b, "\r\n0;chunk-signature=%s\r\n", strings.Repeat("b", 64))
+	fmt.Fprintf(&b, "x-amz-checksum-crc32c:%s\n\r\n", want)
+	fmt.Fprintf(&b, "%s\r\n\r\n", strings.Repeat("c", 64)) // trailer signature
+
+	headers := awsChunkedHeaders(len(body), "x-amz-checksum-crc32c")
+	headers["x-amz-content-sha256"] = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER"
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/signed", []byte(b.String()), headers)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, want, w.Header().Get("x-amz-checksum-crc32c"))
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/signed", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, body, w.Body.Bytes())
+}
+
+// TestS3Checksum_TrailingChecksum_NameMismatch asserts the documented rule that the
+// trailer's header name must match what x-amz-trailer declared: "if a request
+// contains x-amz-trailer: x-amz-checksum-crc32 and the trailer chunk has the header
+// name x-amz-checksum-sha1, the request fails".
+func TestS3Checksum_TrailingChecksum_NameMismatch(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("mismatched trailer name")
+	framed := awsChunkedBody(body, "x-amz-checksum-sha1", digestFor(t, "SHA1", body))
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/obj", framed,
+		awsChunkedHeaders(len(body), "x-amz-checksum-crc32"))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>MalformedTrailerError</Code>")
+
+	w = s3Request(t, srv, http.MethodHead, "/cks/obj", nil, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestS3Checksum_NonChunkedBodyUnaffected guards the decoder's no-op path: a plain
+// body whose content happens to resemble chunk framing must be stored verbatim.
+func TestS3Checksum_NonChunkedBodyUnaffected(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("5\r\nhello\r\n0\r\n\r\n")
+	want := digestFor(t, "SHA256", body)
+
+	w := s3Request(t, srv, http.MethodPut, "/cks/plain", body, map[string]string{
+		"x-amz-checksum-sha256": want,
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/plain", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, body, w.Body.Bytes())
+}
+
+// --- multipart ---
+
+// uploadIDOf extracts the UploadId from an InitiateMultipartUploadResult body.
+func uploadIDOf(t *testing.T, body string) string {
+	t.Helper()
+	var res struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &res))
+	require.NotEmpty(t, res.UploadID)
+	return res.UploadID
+}
+
+// multipartPartBodies is a two-part fixture. The parts differ in content so that a
+// composite checksum computed over the wrong concatenation cannot coincidentally
+// match, and they differ in length so that a digest taken over the wrong slice
+// boundary cannot either.
+//
+// The first part is exactly the minimum part size: anything smaller is rejected by
+// CompleteMultipartUpload with EntityTooSmall (#400) before checksum assembly runs.
+func multipartPartBodies() [][]byte {
+	return [][]byte{
+		bytes.Repeat([]byte("a"), s3MinPartSize),
+		bytes.Repeat([]byte("b"), 32),
+	}
+}
+
+// compositeChecksum computes the expected COMPOSITE object checksum independently:
+// the digest of the concatenated raw part digests, suffixed with the part count.
+func compositeChecksum(t *testing.T, name string, parts [][]byte) string {
+	t.Helper()
+	var alg struct {
+		New func() hash.Hash
+	}
+	for _, a := range checksumAlgorithms {
+		if a.Name == name {
+			alg.New = a.New
+		}
+	}
+	require.NotNil(t, alg.New, "no test implementation for %q", name)
+
+	var digests []byte
+	for _, part := range parts {
+		h := alg.New()
+		h.Write(part)
+		digests = append(digests, h.Sum(nil)...)
+	}
+	outer := alg.New()
+	outer.Write(digests)
+	return fmt.Sprintf("%s-%d", base64.StdEncoding.EncodeToString(outer.Sum(nil)), len(parts))
+}
+
+// TestS3Checksum_Multipart_Composite is the acceptance criterion's multipart case:
+// a COMPOSITE upload's object checksum is base64(digest-of-concatenated-part-digests)
+// with the "-N" suffix, returned as an XML element in the Complete result and as a
+// header on a subsequent GET.
+func TestS3Checksum_Multipart_Composite(t *testing.T) {
+	parts := multipartPartBodies()
+
+	for _, alg := range checksumAlgorithms {
+		if !alg.Composite {
+			continue
+		}
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+				"x-amz-checksum-algorithm": alg.Name,
+			})
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, alg.Name, w.Header().Get("x-amz-checksum-algorithm"))
+			assert.Equal(t, "COMPOSITE", w.Header().Get("x-amz-checksum-type"),
+				"an absent x-amz-checksum-type defaults to COMPOSITE")
+			uploadID := uploadIDOf(t, w.Body.String())
+
+			var etags []string
+			for i, part := range parts {
+				num := i + 1
+				w = s3Request(t, srv, http.MethodPut,
+					fmt.Sprintf("/cks/big?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+				require.Equal(t, http.StatusOK, w.Code, "upload part %d: %s", num, w.Body.String())
+				assert.Equal(t, digestFor(t, alg.Name, part), w.Header().Get(alg.Header),
+					"UploadPart echoes the part checksum")
+				etags = append(etags, w.Header().Get("ETag"))
+			}
+
+			want := compositeChecksum(t, alg.Name, parts)
+
+			w = s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+				completeBody(etags...), nil)
+			require.Equal(t, http.StatusOK, w.Code, "complete: %s", w.Body.String())
+			assert.Contains(t, w.Body.String(), "<Checksum"+alg.Name+">"+want+"</Checksum"+alg.Name+">",
+				"Complete returns the checksum as an XML element, not a header")
+			assert.Contains(t, w.Body.String(), "<ChecksumType>COMPOSITE</ChecksumType>")
+
+			// The "-N" suffix form is the property the reporter asked for explicitly.
+			assert.True(t, strings.HasSuffix(want, "-2"), "fixture sanity: two parts")
+
+			w = s3Request(t, srv, http.MethodGet, "/cks/big", nil, map[string]string{
+				"x-amz-checksum-mode": "ENABLED",
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, want, w.Header().Get(alg.Header))
+			assert.Equal(t, "COMPOSITE", w.Header().Get("x-amz-checksum-type"))
+		})
+	}
+}
+
+// TestS3Checksum_Multipart_FullObject asserts a FULL_OBJECT multipart checksum is
+// the digest of every byte of the assembled object, with no "-N" suffix — and that
+// it equals what a single-part PUT of the same bytes would produce.
+//
+// That equality is the invariant the reporter's second bug violated: a single-part
+// and a multipart writer must agree on the checksum of identical content.
+func TestS3Checksum_Multipart_FullObject(t *testing.T) {
+	parts := multipartPartBodies()
+	var combined []byte
+	for _, p := range parts {
+		combined = append(combined, p...)
+	}
+
+	for _, alg := range checksumAlgorithms {
+		if !alg.FullObject {
+			continue
+		}
+		t.Run(alg.Name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+				"x-amz-checksum-algorithm": alg.Name,
+				"x-amz-checksum-type":      "FULL_OBJECT",
+			})
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+			uploadID := uploadIDOf(t, w.Body.String())
+
+			var etags []string
+			for i, part := range parts {
+				num := i + 1
+				w = s3Request(t, srv, http.MethodPut,
+					fmt.Sprintf("/cks/big?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+				require.Equal(t, http.StatusOK, w.Code)
+				etags = append(etags, w.Header().Get("ETag"))
+			}
+
+			want := digestFor(t, alg.Name, combined)
+
+			w = s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+				completeBody(etags...), nil)
+			require.Equal(t, http.StatusOK, w.Code, "complete: %s", w.Body.String())
+			assert.Contains(t, w.Body.String(), "<Checksum"+alg.Name+">"+want+"</Checksum"+alg.Name+">")
+			assert.Contains(t, w.Body.String(), "<ChecksumType>FULL_OBJECT</ChecksumType>")
+			assert.NotContains(t, want, "-", "a full-object checksum carries no part-count suffix")
+
+			// A single-part PUT of identical bytes must produce an identical value.
+			w = s3Request(t, srv, http.MethodPut, "/cks/single", combined, map[string]string{
+				"x-amz-sdk-checksum-algorithm": alg.Name,
+			})
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, want, w.Header().Get(alg.Header),
+				"single-part and full-object multipart checksums of the same bytes must agree")
+		})
+	}
+}
+
+// TestS3Checksum_Multipart_CompositeDiffersFromFullObject pins the distinction the
+// two types exist to express: for the same bytes they are different values, so a
+// consumer that mixes them up gets a mismatch rather than an accidental pass.
+func TestS3Checksum_Multipart_CompositeDiffersFromFullObject(t *testing.T) {
+	parts := multipartPartBodies()
+	var combined []byte
+	for _, p := range parts {
+		combined = append(combined, p...)
+	}
+
+	composite := compositeChecksum(t, "CRC32", parts)
+	fullObject := digestFor(t, "CRC32", combined)
+	assert.NotEqual(t, composite, fullObject,
+		"COMPOSITE and FULL_OBJECT are computed differently and must not coincide")
+}
+
+// TestS3Checksum_Multipart_UnsupportedType asserts the documented support matrix is
+// enforced at CreateMultipartUpload — before any part is uploaded, since an upload
+// that could never complete against real S3 should fail at creation.
+func TestS3Checksum_Multipart_UnsupportedType(t *testing.T) {
+	tests := []struct {
+		name      string
+		algorithm string
+		cksType   string
+	}{
+		{name: "SHA256 full object", algorithm: "SHA256", cksType: "FULL_OBJECT"},
+		{name: "SHA1 full object", algorithm: "SHA1", cksType: "FULL_OBJECT"},
+		{name: "SHA512 full object", algorithm: "SHA512", cksType: "FULL_OBJECT"},
+		{name: "MD5 full object", algorithm: "MD5", cksType: "FULL_OBJECT"},
+		{name: "CRC64NVME composite", algorithm: "CRC64NVME", cksType: "COMPOSITE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			putBucket(t, srv, "cks")
+
+			w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+				"x-amz-checksum-algorithm": tc.algorithm,
+				"x-amz-checksum-type":      tc.cksType,
+			})
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+			assert.Contains(t, w.Body.String(), "<ChecksumAlgorithm>"+tc.algorithm+"</ChecksumAlgorithm>")
+			assert.Contains(t, w.Body.String(), "<ChecksumType>"+tc.cksType+"</ChecksumType>")
+		})
+	}
+}
+
+// TestS3Checksum_Multipart_CRC64NVMEDefaultsToFullObject covers the one algorithm
+// with no composite form: an absent x-amz-checksum-type must default to FULL_OBJECT
+// rather than to the COMPOSITE every other algorithm gets.
+func TestS3Checksum_Multipart_CRC64NVMEDefaultsToFullObject(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "CRC64NVME",
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+}
+
+// TestS3Checksum_Multipart_PartAlgorithmMismatch asserts a part supplying a
+// checksum under a different algorithm than the upload's is rejected — its digest
+// could not contribute to the object's checksum.
+func TestS3Checksum_Multipart_PartAlgorithmMismatch(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "SHA256",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	uploadID := uploadIDOf(t, w.Body.String())
+
+	part := []byte("a part checksummed the wrong way")
+	w = s3Request(t, srv, http.MethodPut, "/cks/big?partNumber=1&uploadId="+uploadID, part,
+		map[string]string{"x-amz-checksum-crc32": digestFor(t, "CRC32", part)})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+	assert.Contains(t, w.Body.String(), "<UploadChecksumAlgorithm>SHA256</UploadChecksumAlgorithm>")
+}
+
+// TestS3Checksum_Multipart_PartBadDigest asserts a part whose supplied checksum is
+// wrong is rejected and not stored, so a later Complete cannot pick it up.
+func TestS3Checksum_Multipart_PartBadDigest(t *testing.T) {
+	srv, fs := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "SHA256",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	uploadID := uploadIDOf(t, w.Body.String())
+
+	part := []byte("a corrupt part")
+	w = s3Request(t, srv, http.MethodPut, "/cks/big?partNumber=1&uploadId="+uploadID, part,
+		map[string]string{"x-amz-checksum-sha256": corruptDigest(t, "SHA256", part)})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+
+	exists, err := afero.Exists(fs, fmt.Sprintf("/.multipart/%s/1", uploadID))
+	require.NoError(t, err)
+	assert.False(t, exists, "rejected part must not be stored")
+}
+
+// TestS3Checksum_Multipart_CompleteFullObjectVerified asserts Complete verifies a
+// full-object checksum the caller supplies for the whole upload, and rejects a
+// wrong one without writing the object.
+func TestS3Checksum_Multipart_CompleteFullObjectVerified(t *testing.T) {
+	parts := multipartPartBodies()
+	var combined []byte
+	for _, p := range parts {
+		combined = append(combined, p...)
+	}
+
+	startUpload := func(t *testing.T, srv *emulator.Server) (string, []string) {
+		t.Helper()
+		w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+			"x-amz-checksum-algorithm": "CRC32",
+			"x-amz-checksum-type":      "FULL_OBJECT",
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+		uploadID := uploadIDOf(t, w.Body.String())
+
+		var etags []string
+		for i, part := range parts {
+			num := i + 1
+			w = s3Request(t, srv, http.MethodPut,
+				fmt.Sprintf("/cks/big?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+			require.Equal(t, http.StatusOK, w.Code)
+			etags = append(etags, w.Header().Get("ETag"))
+		}
+		return uploadID, etags
+	}
+
+	t.Run("correct value accepted", func(t *testing.T) {
+		srv, _ := newS3TestServer(t)
+		putBucket(t, srv, "cks")
+		uploadID, etags := startUpload(t, srv)
+
+		w := s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+			completeBody(etags...), map[string]string{
+				"x-amz-checksum-crc32": digestFor(t, "CRC32", combined),
+			})
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	})
+
+	t.Run("wrong value rejected", func(t *testing.T) {
+		srv, _ := newS3TestServer(t)
+		putBucket(t, srv, "cks")
+		uploadID, etags := startUpload(t, srv)
+
+		w := s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+			completeBody(etags...), map[string]string{
+				"x-amz-checksum-crc32": corruptDigest(t, "CRC32", combined),
+			})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+
+		w = s3Request(t, srv, http.MethodHead, "/cks/big", nil, nil)
+		assert.Equal(t, http.StatusNotFound, w.Code, "object must not be written")
+	})
+
+	t.Run("disagreeing type rejected", func(t *testing.T) {
+		srv, _ := newS3TestServer(t)
+		putBucket(t, srv, "cks")
+		uploadID, etags := startUpload(t, srv)
+
+		w := s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID,
+			completeBody(etags...), map[string]string{
+				"x-amz-checksum-type": "COMPOSITE",
+			})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "<Code>BadDigest</Code>")
+		assert.Contains(t, w.Body.String(), "<UploadChecksumType>FULL_OBJECT</UploadChecksumType>")
+	})
+}
+
+// TestS3Checksum_Multipart_NoAlgorithm asserts an upload created without a checksum
+// algorithm completes without one, and reports no checksum elements.
+func TestS3Checksum_Multipart_NoAlgorithm(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("x-amz-checksum-algorithm"))
+	assert.Empty(t, w.Header().Get("x-amz-checksum-type"))
+	uploadID := uploadIDOf(t, w.Body.String())
+
+	var etags []string
+	for i, part := range multipartPartBodies() {
+		num := i + 1
+		w = s3Request(t, srv, http.MethodPut,
+			fmt.Sprintf("/cks/big?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, w.Header().Get("x-amz-checksum-sha256"))
+		etags = append(etags, w.Header().Get("ETag"))
+	}
+
+	w = s3Request(t, srv, http.MethodPost, "/cks/big?uploadId="+uploadID, completeBody(etags...), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, w.Body.String(), "<ChecksumType>")
+	assert.NotContains(t, w.Body.String(), "<ChecksumCRC64NVME>")
+}
+
+// TestS3Checksum_Multipart_TypeWithoutAlgorithm asserts a checksum type with no
+// algorithm to apply to is an InvalidRequest.
+func TestS3Checksum_Multipart_TypeWithoutAlgorithm(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-type": "FULL_OBJECT",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+}
+
+// TestS3Checksum_Multipart_InvalidType asserts a type outside the documented pair
+// is an InvalidRequest.
+func TestS3Checksum_Multipart_InvalidType(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/big?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "CRC32",
+		"x-amz-checksum-type":      "PARTIAL",
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "<Code>InvalidRequest</Code>")
+	assert.Contains(t, w.Body.String(), "<ChecksumType>PARTIAL</ChecksumType>")
+}
+
+// --- CopyObject ---
+
+// TestS3Checksum_CopyObject_RecomputesFullObject asserts a copy carries the source's
+// algorithm but recomputes the value as a direct full-object checksum: "with a copy
+// command, the checksum of the object is a direct checksum of the full object. If
+// the object was originally uploaded using a multipart upload, the checksum value
+// changes even though the data doesn't".
+func TestS3Checksum_CopyObject_RecomputesFullObject(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("copied with its checksum")
+	w := s3Request(t, srv, http.MethodPut, "/cks/src", body, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", body),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst", nil, map[string]string{
+		"x-amz-copy-source": "/cks/src",
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "SHA256", body), w.Header().Get("x-amz-checksum-sha256"),
+		"the source's algorithm is kept when none is named")
+	assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+}
+
+// TestS3Checksum_CopyObject_NewAlgorithm asserts a copy can switch algorithms:
+// "you can copy the object and specify whether you want to use the existing
+// checksum algorithm or a new one".
+func TestS3Checksum_CopyObject_NewAlgorithm(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("re-checksummed on copy")
+	w := s3Request(t, srv, http.MethodPut, "/cks/src", body, map[string]string{
+		"x-amz-checksum-sha256": digestFor(t, "SHA256", body),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst", nil, map[string]string{
+		"x-amz-copy-source":        "/cks/src",
+		"x-amz-checksum-algorithm": "CRC32C",
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "CRC32C", body), w.Header().Get("x-amz-checksum-crc32c"))
+	assert.Empty(t, w.Header().Get("x-amz-checksum-sha256"), "the old algorithm is replaced")
+}
+
+// TestS3Checksum_CopyObject_CompositeBecomesFullObject asserts the documented
+// consequence for a multipart source: copying it changes the checksum value and its
+// type, even though the bytes are identical.
+func TestS3Checksum_CopyObject_CompositeBecomesFullObject(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	parts := multipartPartBodies()
+	var combined []byte
+	for _, p := range parts {
+		combined = append(combined, p...)
+	}
+
+	w := s3Request(t, srv, http.MethodPost, "/cks/src?uploads", nil, map[string]string{
+		"x-amz-checksum-algorithm": "CRC32",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	uploadID := uploadIDOf(t, w.Body.String())
+
+	var etags []string
+	for i, part := range parts {
+		num := i + 1
+		w = s3Request(t, srv, http.MethodPut,
+			fmt.Sprintf("/cks/src?partNumber=%d&uploadId=%s", num, uploadID), part, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+		etags = append(etags, w.Header().Get("ETag"))
+	}
+	w = s3Request(t, srv, http.MethodPost, "/cks/src?uploadId="+uploadID, completeBody(etags...), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	composite := compositeChecksum(t, "CRC32", parts)
+
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst", nil, map[string]string{
+		"x-amz-copy-source": "/cks/src",
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "CRC32", combined), w.Header().Get("x-amz-checksum-crc32"))
+	assert.NotEqual(t, composite, w.Header().Get("x-amz-checksum-crc32"),
+		"the value changes even though the data does not")
+	assert.Equal(t, "FULL_OBJECT", w.Header().Get("x-amz-checksum-type"))
+}
+
+// TestS3Checksum_CopyObject_UnchecksummedSource asserts a source with no checksum
+// yields a destination with none, unless the copy names an algorithm.
+func TestS3Checksum_CopyObject_UnchecksummedSource(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	putBucket(t, srv, "cks")
+
+	body := []byte("no checksum on the source")
+	w := s3Request(t, srv, http.MethodPut, "/cks/src", body, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst", nil, map[string]string{
+		"x-amz-copy-source": "/cks/src",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("x-amz-checksum-type"))
+
+	// Naming an algorithm on the copy adds one.
+	w = s3Request(t, srv, http.MethodPut, "/cks/dst2", nil, map[string]string{
+		"x-amz-copy-source":        "/cks/src",
+		"x-amz-checksum-algorithm": "SHA1",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = s3Request(t, srv, http.MethodGet, "/cks/dst2", nil, map[string]string{
+		"x-amz-checksum-mode": "ENABLED",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, digestFor(t, "SHA1", body), w.Header().Get("x-amz-checksum-sha1"))
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -478,9 +478,21 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		}
 	}
 
-	body := decodeAWSChunked(req.Headers, req.Body)
+	body, trailers := decodeAWSChunkedWithTrailers(req.Headers, req.Body)
 	hash := md5.Sum(body) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x"`, hash)
+
+	// The checksum is verified against the decoded body, and before the write
+	// below: a BadDigest must leave the stored object untouched, which is what lets
+	// a consumer assert that a corrupt upload changed nothing.
+	checksumHeaders, trailerErr := checksumHeadersWithTrailers(req.Headers, trailers)
+	if trailerErr != nil {
+		return trailerErr, nil
+	}
+	checksum, cksErr := resolveChecksum(checksumHeaders, body)
+	if cksErr != nil {
+		return cksErr, nil
+	}
 
 	// Directory-marker objects (key ends with "/") must not be written to the
 	// afero filesystem: filepath.Clean inside MemMapFs would strip the trailing
@@ -511,11 +523,15 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		ContentEncoding: req.Headers["Content-Encoding"],
 		Size:            int64(len(body)),
 		StorageClass:    storageClass,
+		Checksum:        checksum,
 		LastModified:    p.tc.Now(),
 		UserMetadata:    userMeta,
 	}
 
 	respHeaders := map[string]string{"ETag": etag}
+	// PutObject echoes the checksum unconditionally — checksum-mode gates the read
+	// path, not the write. A single-part PUT is always a full-object checksum.
+	applyChecksumHeaders(respHeaders, checksum, true)
 
 	// If versioning is enabled, generate a version ID and store the versioned copy.
 	versioningStatus := p.getBucketVersioningStatus(ctx, bucket)
@@ -651,6 +667,7 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 	}
 
 	headers := objectResponseHeaders(&obj)
+	applyChecksumHeaders(headers, obj.Checksum, resolveChecksumMode(req.Headers))
 
 	rangeHeader := headerValueFold(req.Headers, "Range")
 	spec := parseByteRange(rangeHeader, obj.Size)
@@ -715,6 +732,7 @@ func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key st
 	}
 
 	headers := objectResponseHeaders(&obj)
+	applyChecksumHeaders(headers, obj.Checksum, resolveChecksumMode(req.Headers))
 
 	// HEAD honors Range exactly as GET does, minus the body.
 	rangeHeader := headerValueFold(req.Headers, "Range")
@@ -957,6 +975,10 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	if tagErr != nil {
 		return tagErr, nil
 	}
+	copyChecksumAlgorithm, cksErr := resolveCopyChecksumAlgorithm(req.Headers, &srcObj)
+	if cksErr != nil {
+		return cksErr, nil
+	}
 
 	// Source preconditions gate whether the copy may read; destination
 	// preconditions gate whether it may overwrite. Both are checked before any
@@ -1000,6 +1022,13 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	hash := md5.Sum(srcBody) //nolint:gosec // nosemgrep
 	newETag := fmt.Sprintf(`"%x"`, hash)
 
+	// "With a copy command, the checksum of the object is a direct checksum of the
+	// full object. If the object was originally uploaded using a multipart upload,
+	// the checksum value changes even though the data doesn't." So the copy's
+	// checksum is recomputed over the whole body, never carried across — a composite
+	// source yields a full-object destination.
+	dstChecksum := copyChecksum(copyChecksumAlgorithm, srcBody)
+
 	dstObj := S3Object{
 		Bucket:          dstBucket,
 		Key:             dstKey,
@@ -1011,6 +1040,7 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 		// x-amz-storage-class header is not used, the copied object will be stored in
 		// the STANDARD Storage Class by default."
 		StorageClass: dstStorageClass,
+		Checksum:     dstChecksum,
 		LastModified: now,
 		UserMetadata: meta.UserMetadata,
 		Tags:         tags,
@@ -1250,6 +1280,13 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		return scErr, nil
 	}
 
+	// The checksum algorithm and type are fixed here too, and validated against the
+	// documented support matrix now rather than after every part has been uploaded.
+	checksumAlgorithm, checksumType, cksErr := resolveUploadChecksum(req.Headers)
+	if cksErr != nil {
+		return cksErr, nil
+	}
+
 	uploadID := generateUploadID()
 
 	contentType := req.Headers["Content-Type"]
@@ -1258,13 +1295,15 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 	}
 
 	upload := S3MultipartUpload{
-		UploadID:     uploadID,
-		Bucket:       bucket,
-		Key:          key,
-		ContentType:  contentType,
-		StorageClass: storageClass,
-		Initiated:    p.tc.Now(),
-		UserMetadata: extractUserMetadata(req.Headers),
+		UploadID:          uploadID,
+		Bucket:            bucket,
+		Key:               key,
+		ContentType:       contentType,
+		StorageClass:      storageClass,
+		ChecksumAlgorithm: checksumAlgorithm,
+		ChecksumType:      checksumType,
+		Initiated:         p.tc.Now(),
+		UserMetadata:      extractUserMetadata(req.Headers),
 	}
 
 	data, err := json.Marshal(upload)
@@ -1281,11 +1320,21 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		Key      string   `xml:"Key"`
 		UploadId string   `xml:"UploadId"` //nolint:revive // matches AWS XML field name
 	}
-	return s3XMLResponse(http.StatusOK, initiateMultipartUploadResult{
+	resp, err := s3XMLResponse(http.StatusOK, initiateMultipartUploadResult{
 		Bucket:   bucket,
 		Key:      key,
 		UploadId: uploadID,
 	})
+	if err != nil {
+		return nil, err
+	}
+	// Both are echoed as response headers, so a caller can confirm the type it got
+	// is the type it asked for before uploading a single part.
+	if checksumAlgorithm != "" {
+		resp.Headers["x-amz-checksum-algorithm"] = checksumAlgorithm
+		resp.Headers["x-amz-checksum-type"] = checksumType
+	}
+	return resp, nil
 }
 
 // uploadPart handles PUT /<bucket>/<key>?partNumber=N&uploadId=ID.
@@ -1316,9 +1365,20 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
 	}
 
-	body := decodeAWSChunked(req.Headers, req.Body)
+	body, trailers := decodeAWSChunkedWithTrailers(req.Headers, req.Body)
 	hash := md5.Sum(body) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x"`, hash)
+
+	// Verified before the part is written, so a BadDigest part is not left on disk
+	// for a later Complete to pick up.
+	checksumHeaders, trailerErr := checksumHeadersWithTrailers(req.Headers, trailers)
+	if trailerErr != nil {
+		return trailerErr, nil
+	}
+	checksum, cksErr := resolvePartChecksum(checksumHeaders, body, upload.ChecksumAlgorithm)
+	if cksErr != nil {
+		return cksErr, nil
+	}
 
 	partPath := fmt.Sprintf("/.multipart/%s/%d", uploadID, partNum)
 	if mkdirErr := p.fs.MkdirAll(filepath.Dir(partPath), 0o755); mkdirErr != nil {
@@ -1332,6 +1392,7 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		PartNumber:   partNum,
 		ETag:         etag,
 		Size:         int64(len(body)),
+		Checksum:     checksum,
 		LastModified: p.tc.Now(),
 	}
 	partData, err := json.Marshal(part)
@@ -1342,9 +1403,16 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		return nil, fmt.Errorf("save part metadata: %w", err)
 	}
 
+	respHeaders := map[string]string{"ETag": etag}
+	// UploadPart echoes the part's checksum so the caller can carry it into the
+	// <Part> entries of its Complete request, as the SDKs do.
+	if checksum.present() {
+		respHeaders[s3ChecksumHeaderOf(checksum.Algorithm)] = checksum.Value
+	}
+
 	return &AWSResponse{
 		StatusCode: http.StatusOK,
-		Headers:    map[string]string{"ETag": etag},
+		Headers:    respHeaders,
 	}, nil
 }
 
@@ -1440,6 +1508,7 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 	// Concatenate parts and compute multi-part ETag.
 	var combined []byte
 	var partMD5s []byte
+	partBodies := make([][]byte, 0, len(parts))
 
 	for _, part := range parts {
 		partPath := fmt.Sprintf("/.multipart/%s/%d", uploadID, part.PartNumber)
@@ -1448,6 +1517,7 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 			return nil, fmt.Errorf("read part %d body: %w", part.PartNumber, readErr)
 		}
 		combined = append(combined, partBody...)
+		partBodies = append(partBodies, partBody)
 		h := md5.Sum(partBody) //nolint:gosec // nosemgrep
 		partMD5s = append(partMD5s, h[:]...)
 	}
@@ -1455,6 +1525,18 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 	numParts := len(parts)
 	combinedHash := md5.Sum(partMD5s) //nolint:gosec // nosemgrep
 	etag := fmt.Sprintf(`"%x-%d"`, combinedHash, numParts)
+
+	// The object checksum is derived the same way the ETag above is — from the part
+	// digests for a COMPOSITE upload, or from every byte for a FULL_OBJECT one — and
+	// any value the caller supplied is verified against it before anything is
+	// written.
+	checksum, cksErr := assembleObjectChecksum(upload.ChecksumAlgorithm, upload.ChecksumType, combined, partBodies)
+	if cksErr != nil {
+		return cksErr, nil
+	}
+	if resp := verifyCompleteChecksum(req.Headers, checksum); resp != nil {
+		return resp, nil
+	}
 
 	filePath := "/" + bucket + "/" + key
 	if mkdirErr := p.fs.MkdirAll(filepath.Dir(filePath), 0o755); mkdirErr != nil {
@@ -1471,6 +1553,7 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		ContentType:  upload.ContentType,
 		Size:         int64(len(combined)),
 		StorageClass: upload.StorageClass,
+		Checksum:     checksum,
 		LastModified: p.tc.Now(),
 		UserMetadata: upload.UserMetadata,
 	}
@@ -1489,18 +1572,24 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		_ = p.fs.Remove(fmt.Sprintf("/.multipart/%s/%d", uploadID, pr.PartNumber))
 	}
 
+	// Unlike every other checksum-bearing operation, Complete returns the checksum as
+	// XML elements in its result body rather than as response headers.
 	type completeMultipartUploadResult struct {
-		XMLName  xml.Name `xml:"CompleteMultipartUploadResult"`
-		Location string   `xml:"Location"`
-		Bucket   string   `xml:"Bucket"`
-		Key      string   `xml:"Key"`
-		ETag     string   `xml:"ETag"`
+		XMLName      xml.Name        `xml:"CompleteMultipartUploadResult"`
+		Location     string          `xml:"Location"`
+		Bucket       string          `xml:"Bucket"`
+		Key          string          `xml:"Key"`
+		ETag         string          `xml:"ETag"`
+		Checksum     []s3ChecksumXML `xml:",any"`
+		ChecksumType string          `xml:"ChecksumType,omitempty"`
 	}
 	return s3XMLResponse(http.StatusOK, completeMultipartUploadResult{
-		Location: "https://s3.amazonaws.com/" + bucket + "/" + key,
-		Bucket:   bucket,
-		Key:      key,
-		ETag:     etag,
+		Location:     "https://s3.amazonaws.com/" + bucket + "/" + key,
+		Bucket:       bucket,
+		Key:          key,
+		ETag:         etag,
+		Checksum:     checksumXMLElements(checksum),
+		ChecksumType: checksum.Type,
 	})
 }
 
@@ -1788,16 +1877,43 @@ func isAWSChunked(headers map[string]string) bool {
 }
 
 // decodeAWSChunked decodes a SigV4 streaming (aws-chunked) request body into the
-// raw object content, stripping the per-chunk "<hex-size>;chunk-signature=...\r\n"
-// framing and trailing checksum trailers. Non-chunked bodies (and anything that
-// fails to parse as aws-chunked) are returned unchanged, so this is a safe no-op
-// for CLI-style standard HTTP chunking, which net/http has already de-framed.
+// raw object content, discarding any trailers. Callers that need the trailing
+// checksum a real SDK appends must use [decodeAWSChunkedWithTrailers].
+func decodeAWSChunked(headers map[string]string, body []byte) []byte {
+	decoded, _ := decodeAWSChunkedWithTrailers(headers, body)
+	return decoded
+}
+
+// decodeAWSChunkedWithTrailers decodes a SigV4 streaming (aws-chunked) request body
+// into the raw object content, stripping the per-chunk
+// "<hex-size>;chunk-signature=...\r\n" framing, and returns the trailing headers
+// that followed the completion chunk. Non-chunked bodies (and anything that fails
+// to parse as aws-chunked) are returned unchanged with no trailers, so this is a
+// safe no-op for CLI-style standard HTTP chunking, which net/http has already
+// de-framed.
 //
 // Format per chunk: "<hex-len>[;chunk-signature=<sig>]\r\n<len bytes>\r\n",
-// terminated by a zero-length chunk optionally followed by trailer headers.
-func decodeAWSChunked(headers map[string]string, body []byte) []byte {
+// terminated by a zero-length completion chunk optionally followed by trailers.
+//
+// The trailers are where the AWS SDKs put the checksum of a streamed upload:
+// "if trailing checksums exist (where AWS SDKs append checksums to the encoded
+// request bodies), the x-amz-trailer header value includes the x-amz-checksum-
+// prefix and ends with the algorithm name". Discarding them, as this function's
+// predecessor did, would mean checksum verification silently never fired for any
+// real SDK upload — a mock that accepts every checksum, which is worse than one
+// that offers none.
+//
+// Trailer chunk format, per the S3 user guide:
+//
+//	x-amz-checksum-<lowercase-algorithm>:<base64-value>\n\r\n\r\n
+//
+// with a trailer signature line following the value when the payload is
+// SigV4-signed. Header names are returned lowercased; the trailing "\n" the guide
+// notes as optional ("the usage of the linefeed \n at the end of the checksum value
+// might vary across clients") is trimmed from the value.
+func decodeAWSChunkedWithTrailers(headers map[string]string, body []byte) ([]byte, map[string]string) {
 	if len(body) == 0 || !isAWSChunked(headers) {
-		return body
+		return body, nil
 	}
 
 	var out []byte
@@ -1807,7 +1923,7 @@ func decodeAWSChunked(headers map[string]string, body []byte) []byte {
 		nl := indexCRLF(rest)
 		if nl < 0 {
 			// No framing found — not actually aws-chunked; return original.
-			return body
+			return body, nil
 		}
 		sizeLine := string(rest[:nl])
 		advance := nl + crlfLen(rest, nl)
@@ -1819,14 +1935,14 @@ func decodeAWSChunked(headers map[string]string, body []byte) []byte {
 		}
 		size, err := strconv.ParseInt(strings.TrimSpace(hexPart), 16, 64)
 		if err != nil {
-			return body // malformed → fall back to raw
+			return body, nil // malformed → fall back to raw
 		}
 		rest = rest[advance:]
 		if size == 0 {
-			break // final chunk; trailers (if any) follow and are ignored
+			break // completion chunk; whatever follows is trailers
 		}
 		if int64(len(rest)) < size {
-			return body // truncated → fall back to raw
+			return body, nil // truncated → fall back to raw
 		}
 		out = append(out, rest[:size]...)
 		rest = rest[size:]
@@ -1842,7 +1958,83 @@ func decodeAWSChunked(headers map[string]string, body []byte) []byte {
 			out = out[:n]
 		}
 	}
-	return out
+	return out, parseChunkedTrailers(rest)
+}
+
+// parseChunkedTrailers reads the "<name>:<value>" lines that follow an aws-chunked
+// completion chunk, returning them keyed by lowercased name.
+//
+// Lines without a colon are skipped rather than treated as malformed: a
+// SigV4-signed request appends a bare trailer-signature line after the trailer, and
+// the body ends with a final CRLF. Returns nil when there is nothing to report, so
+// callers can distinguish "no trailers" from "an empty trailer".
+func parseChunkedTrailers(rest []byte) map[string]string {
+	var trailers map[string]string
+	for len(rest) > 0 {
+		nl := indexCRLF(rest)
+		var line string
+		if nl < 0 {
+			line, rest = string(rest), nil
+		} else {
+			line, rest = string(rest[:nl]), rest[nl+crlfLen(rest, nl):]
+		}
+
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			continue // blank line, or a trailer signature
+		}
+		name := strings.ToLower(strings.TrimSpace(line[:colon]))
+		if name == "" {
+			continue
+		}
+		if trailers == nil {
+			trailers = make(map[string]string)
+		}
+		// Trim the optional linefeed the guide documents at the end of the value.
+		trailers[name] = strings.Trim(strings.TrimSpace(line[colon+1:]), "\n")
+	}
+	return trailers
+}
+
+// checksumHeadersWithTrailers returns the header set to resolve a write's checksum
+// from: the request headers, plus any x-amz-checksum-* trailer the streamed body
+// carried.
+//
+// A trailer is only honored when the request's x-amz-trailer header named it:
+// "the header name field for an upload request must match the value passed into the
+// x-amz-trailer request header. For example, if a request contains
+// x-amz-trailer: x-amz-checksum-crc32 and the trailer chunk has the header name
+// x-amz-checksum-sha1, the request fails." A mismatch is reported so the caller
+// does not get a silent success on a checksum nothing agreed on.
+//
+// The returned map is a copy when a trailer applies, so the request's own headers
+// are never mutated.
+func checksumHeadersWithTrailers(headers, trailers map[string]string) (map[string]string, *AWSResponse) {
+	declared := strings.ToLower(strings.TrimSpace(headerValueFold(headers, "x-amz-trailer")))
+	if declared == "" {
+		return headers, nil
+	}
+	if !strings.HasPrefix(declared, s3ChecksumHeaderPrefix) {
+		// Some other trailer (not a checksum) — nothing to verify against.
+		return headers, nil
+	}
+
+	value, ok := trailers[declared]
+	if !ok {
+		return nil, s3ErrorResponseWith(s3Error{
+			Code:    "MalformedTrailerError",
+			Message: "The request contained trailing data that was not well-formed or did not conform to our published schema.",
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{{Name: "TrailerHeader", Value: declared}},
+		})
+	}
+
+	merged := make(map[string]string, len(headers)+1)
+	for k, v := range headers {
+		merged[k] = v
+	}
+	merged[declared] = value
+	return merged, nil
 }
 
 // indexCRLF returns the index of the first \r\n or \n in b, or -1 if neither.

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -47,6 +47,11 @@ type S3Object struct {
 	// x-amz-storage-class header on write. Empty is equivalent to STANDARD.
 	StorageClass string `json:"storage_class,omitempty"`
 
+	// Checksum is the additional checksum recorded for the object, from the
+	// x-amz-checksum-* family. Zero when the object was written without one;
+	// returned on GetObject/HeadObject only under x-amz-checksum-mode: ENABLED.
+	Checksum s3Checksum `json:"checksum,omitzero"`
+
 	// LastModified is the time of the most recent write.
 	LastModified time.Time `json:"last_modified"`
 
@@ -143,6 +148,15 @@ type S3MultipartUpload struct {
 	// the object CompleteMultipartUpload assembles. Empty means STANDARD.
 	StorageClass string `json:"storage_class,omitempty"`
 
+	// ChecksumAlgorithm is the algorithm named in x-amz-checksum-algorithm at
+	// upload creation, applied to every part and to the assembled object. Empty
+	// when the upload was created without one.
+	ChecksumAlgorithm string `json:"checksum_algorithm,omitempty"`
+
+	// ChecksumType is COMPOSITE or FULL_OBJECT, deciding how the part checksums
+	// combine into the object's. Empty when ChecksumAlgorithm is empty.
+	ChecksumType string `json:"checksum_type,omitempty"`
+
 	// Initiated is the time the multipart upload was created.
 	Initiated time.Time `json:"initiated"`
 
@@ -161,6 +175,10 @@ type S3Part struct {
 
 	// Size is the byte length of the part body.
 	Size int64 `json:"size"`
+
+	// Checksum is the additional checksum of this part's body, under the upload's
+	// algorithm. A COMPOSITE object checksum is derived from these.
+	Checksum s3Checksum `json:"checksum,omitzero"`
 
 	// LastModified is the time this part was uploaded.
 	LastModified time.Time `json:"last_modified"`


### PR DESCRIPTION
Implements the `x-amz-checksum-*` family with real verification. Closes #399.

Substrate previously ignored checksum headers entirely, which inverts the
guarantee they exist to provide: a consumer computing a checksum client-side and
sending it so S3 will reject corrupt data got a `200` whether the value matched
the body or not. A test asserting "a corrupted upload is rejected" therefore
passed against substrate — and would have passed against a consumer that computed
the checksum wrong.

## What changed

- **Verified on `PutObject`, `UploadPart`, `CopyObject`, `CompleteMultipartUpload`.**
  A mismatch is `400 BadDigest` and **nothing is written** — the key shows neither
  metadata nor body, and a rejected overwrite leaves the original bytes, ETag and
  checksum intact rather than truncating them. A rejected `UploadPart` stores no
  part, so `CompleteMultipartUpload` cannot later pick up a part that failed.
- **Seven algorithms**: `CRC32`, `CRC32C`, `CRC64NVME`, `SHA1`, `SHA256`,
  `SHA512`, `MD5`. `CRC-64/NVME` is built from the bit-reversed catalog polynomial
  and pinned against the published check value, so a transcription error fails a
  test instead of producing a plausible wrong digest that agrees with itself.
- **`XXHASH64`/`XXHASH3`/`XXHASH128` are `501 NotImplemented`**, not silently
  accepted — storing an unverified checksum is the exact defect this removes.
  An unknown name is `400 InvalidRequest`.
- **Trailing checksums are read.** `decodeAWSChunked` discarded everything after
  the `aws-chunked` completion chunk, which is where every AWS SDK puts the
  checksum of a streamed upload — so header-only verification would have silently
  never fired for a real SDK write. Trailers are parsed and honored when
  `x-amz-trailer` declares them; a mismatched or missing declared trailer is
  `400 MalformedTrailerError`.

## Note on provenance

This replaces #410, which was orphaned when its base branch was deleted while
squash-merging #408 (GitHub closes rather than retargets such a PR). The content
is the same commit rebased onto current `main` — a clean cherry-pick, no conflicts
— now based directly on `main` since #398 has landed via #419.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run` (0 issues), `go test -race ./...`,
the `test/e2e` module, and `make docs-reference-check` all pass on the pushed commit.
