### PR TITLE
chore(release): v0.80.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.80.0] - 2026-07-31
+
+A fidelity release driven by two downstream consumers (`parsl-ephemeral-aws` and
+`objectfs`), who filed ten issues sharing one defect: **substrate returned success,
+or a confident wrong answer, where real AWS signals failure.** That makes a
+consumer's error branch unreachable, so their suite reports green while verifying
+nothing — worse than an incomplete emulator, and directly against this project's
+premise that a red test is a real signal.
+
+Ranged and conditional S3 reads, checksum verification, storage classes, symbolic
+error codes across five services, EC2 `Invalid*.NotFound`, Lambda invoke metadata,
+and a new `pricing` plugin. Closes #391, #392, #393, #396, #397, #398, #399, #400,
+#401 and #403.
+
 ### Added
 - New `pricing` plugin emulating the AWS Price List Query API — `GetProducts`,
   `DescribeServices` and `GetAttributeValues` — over `api.pricing.{region}` and
@@ -2436,7 +2450,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.76.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.80.0...HEAD
+[v0.80.0]: https://github.com/scttfrdmn/substrate/compare/v0.76.0...v0.80.0
 [v0.76.0]: https://github.com/scttfrdmn/substrate/compare/v0.75.0...v0.76.0
 [v0.75.0]: https://github.com/scttfrdmn/substrate/compare/v0.74.0...v0.75.0
 [v0.74.0]: https://github.com/scttfrdmn/substrate/compare/v0.73.0...v0.74.0


### PR DESCRIPTION
Step 1 of the documented release process: promote `## [Unreleased]` to
`## [v0.80.0] - 2026-07-31` and add the comparison link. Changelog only — no code
changes.

Once this merges, the tag gets cut on the merge commit per `CLAUDE.md`:
`git tag -s v0.80.0 -m "v0.80.0"` then push.

## Version choice

`v0.80.0`, matching the milestone whose issues this ships. Latest existing tag is
`v0.76.0`, so this is strictly greater, as required.

Note the gap: **v0.77.0, v0.78.0 and v0.79.0 are skipped as tags.** The v0.79.0 and
v0.80.0 milestones both have zero open issues and their work is interleaved
throughout this one changelog section, so splitting it into three retroactive tags
would mean inventing boundaries the commits don't have. v0.77.0 still has 5 open
issues (#371, #380, #387, #388, #389 — #387/#388 are PR #390, still conflicting),
so it genuinely hasn't shipped. Skipping minor versions is legal under semver;
milestones can be reconciled separately.

## What ships

Ten issues from two downstream consumers — `parsl-ephemeral-aws` and `objectfs` —
sharing one defect: substrate returned success, or a confident wrong answer, where
real AWS signals failure. That leaves a consumer's error branch unreachable, so
their suite reports green while verifying nothing.

Closes #391, #392, #393, #396, #397, #398, #399, #400, #401, #403.

- **S3 reads/writes**: ranged `GetObject`/`HeadObject` (206/`Content-Range`/416),
  conditional request headers, multipart `Complete` validation, storage classes and
  `CopyObject` metadata directives, and `x-amz-checksum-*` verification across
  seven algorithms with `BadDigest` on mismatch.
- **Error fidelity**: symbolic `Code` values serialized in each service's own wire
  protocol, EC2 `Invalid*.NotFound`/`Malformed` for explicit resource IDs, and
  Lambda omitting `FunctionError`/`LogResult` unless applicable.
- **New `pricing` plugin**: Price List Query API over a real offer corpus.
- Plus the `x/text` CVE-2026-56852 bump and the `test/e2e` tidy fix.

## Verification

`## [Unreleased]` is now empty with all four subsections (Added / Fixed / Changed /
Security) and 24 bullets moved intact under the new heading — matching the shape of
the v0.76.0 release commit. `scripts/check-doc-versions.sh` passes.
