### PR TITLE
fix(s3): carry Content-Encoding through multipart upload (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `CreateMultipartUpload` now records `Content-Encoding` and
+  `CompleteMultipartUpload` applies it to the assembled object, so `GetObject` and
+  `HeadObject` report the codec a multipart object was uploaded with (#406).
+  `PutObject` already did this, so the two upload paths disagreed about the same
+  object property, and an object compressed above the multipart threshold
+  round-tripped as uncompressed. That makes a *correct* application look broken — one
+  that dispatches decompression on `Content-Encoding` fails closed on a read it wrote
+  properly — and, symmetrically, an application that forgot to set the header on the
+  multipart path (a separate input struct from `PutObjectInput`) was indistinguishable
+  from one that set it, so any test asserting "the encoding survives a multipart
+  upload" passed vacuously. `Complete` accepts no object-metadata headers at all, so
+  carrying the value on the upload record from creation is the only place it can come
+  from.
+
 ## [v0.80.0] - 2026-07-31
 
 A fidelity release driven by two downstream consumers (`parsl-ephemeral-aws` and

--- a/docs/services.md
+++ b/docs/services.md
@@ -455,6 +455,27 @@ The `EntityTooSmall` body identifies the offending part:
 </Error>
 ```
 
+#### Metadata carried from CreateMultipartUpload
+
+`CompleteMultipartUpload` accepts no object-metadata headers — per the AWS API
+reference it takes only the checksum family, `x-amz-mp-object-size`, request-payer,
+SSE-C and the conditional headers. So anything describing the finished object must
+be supplied at `CreateMultipartUpload` and is carried on the upload until the object
+is assembled:
+
+| Supplied at Create | Applied to the assembled object |
+|---|---|
+| `Content-Type` | yes (defaults to `application/octet-stream`) |
+| `Content-Encoding` | yes |
+| `x-amz-storage-class` | yes (empty means `STANDARD`) |
+| `x-amz-checksum-algorithm` | yes — see [Additional checksums](#additional-checksums) |
+| `x-amz-meta-*` | yes |
+
+`Cache-Control`, `Content-Disposition` and `Content-Language` are **not modeled** on
+either upload path: substrate records no field for them, so they are accepted and
+discarded rather than echoed on a later `GetObject`/`HeadObject`. A test asserting
+one of those survives a write will pass against real S3 and fail here.
+
 ### Additional checksums
 
 `PutObject`, `UploadPart`, `CopyObject`, `CreateMultipartUpload` and

--- a/emulator/s3_multipart_test.go
+++ b/emulator/s3_multipart_test.go
@@ -388,3 +388,70 @@ func TestS3_CompleteMultipartUpload_WrongBucketOrKey(t *testing.T) {
 	assert.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPost,
 		"/mpu-owner/right.bin?uploadId="+uploadID, completeBody(etag), nil).Code)
 }
+
+// TestS3_Multipart_ContentEncoding asserts the Content-Encoding supplied at
+// CreateMultipartUpload survives to the assembled object on both GET and HEAD.
+//
+// The header is accepted at creation, not on Complete, so an encoding the upload
+// record does not carry is lost — which made a compressed object large enough to
+// cross the multipart threshold round-trip as uncompressed, and made an
+// application that never set the header indistinguishable from one that did (#406).
+//
+// Only the canonical header casing is exercised: s3Request goes through
+// net/http, which canonicalizes on the way in, so a lowercase-header case would
+// assert nothing about the plugin. createMultipartUpload resolves the header
+// case-insensitively for the benefit of in-process callers that build an
+// AWSRequest directly.
+func TestS3_Multipart_ContentEncoding(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		encoding string
+	}{
+		{"gzip", "gzip"},
+		{"zstd", "zstd"},
+		{"brotli", "br"},
+		{"absent", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/mpu-enc", nil, nil).Code, "create bucket")
+
+			// User metadata rides alongside: it was already carried through when the
+			// encoding was not, and that asymmetry is what made the bug look like an
+			// application fault rather than an emulator gap.
+			headers := map[string]string{"x-amz-meta-original-size": "999"}
+			if tc.encoding != "" {
+				headers["Content-Encoding"] = tc.encoding
+			}
+			iw := s3Request(t, srv, http.MethodPost, "/mpu-enc/big?uploads", nil, headers)
+			require.Equal(t, http.StatusOK, iw.Code, "initiate multipart upload")
+
+			var ir struct {
+				UploadID string `xml:"UploadId"`
+			}
+			require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+			// Two parts, so this exercises the assembly path a real compressed upload
+			// takes rather than the single-part shortcut.
+			body1 := bytes.Repeat([]byte("a"), s3MinPartSize)
+			body2 := []byte("tail")
+			etag1 := uploadPart(t, srv, "mpu-enc", "big", ir.UploadID, 1, body1)
+			etag2 := uploadPart(t, srv, "mpu-enc", "big", ir.UploadID, 2, body2)
+
+			cw := s3Request(t, srv, http.MethodPost, "/mpu-enc/big?uploadId="+ir.UploadID,
+				completeBody(etag1, etag2), nil)
+			require.Equal(t, http.StatusOK, cw.Code, "complete multipart upload")
+
+			// Both read paths must agree; the reporter saw an empty value on each.
+			for _, method := range []string{http.MethodHead, http.MethodGet} {
+				w := s3Request(t, srv, method, "/mpu-enc/big", nil, nil)
+				require.Equal(t, http.StatusOK, w.Code, method)
+				assert.Equal(t, tc.encoding, w.Header().Get("Content-Encoding"),
+					"%s Content-Encoding", method)
+				assert.Equal(t, "999", w.Header().Get("X-Amz-Meta-Original-Size"),
+					"%s user metadata must survive alongside the encoding", method)
+			}
+		})
+	}
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -1289,7 +1289,11 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 
 	uploadID := generateUploadID()
 
-	contentType := req.Headers["Content-Type"]
+	// Resolved case-insensitively, like every other header this function reads
+	// (cf. resolveStorageClass, resolveUploadChecksum): an AWSRequest reaching a
+	// plugin has not always been through net/http's canonicalization, since
+	// substrate builds requests in-process too (see betty_cfn.go).
+	contentType := headerValueFold(req.Headers, "Content-Type")
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
@@ -1299,6 +1303,7 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		Bucket:            bucket,
 		Key:               key,
 		ContentType:       contentType,
+		ContentEncoding:   headerValueFold(req.Headers, "Content-Encoding"),
 		StorageClass:      storageClass,
 		ChecksumAlgorithm: checksumAlgorithm,
 		ChecksumType:      checksumType,
@@ -1547,15 +1552,16 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 	}
 
 	obj := S3Object{
-		Bucket:       bucket,
-		Key:          key,
-		ETag:         etag,
-		ContentType:  upload.ContentType,
-		Size:         int64(len(combined)),
-		StorageClass: upload.StorageClass,
-		Checksum:     checksum,
-		LastModified: p.tc.Now(),
-		UserMetadata: upload.UserMetadata,
+		Bucket:          bucket,
+		Key:             key,
+		ETag:            etag,
+		ContentType:     upload.ContentType,
+		ContentEncoding: upload.ContentEncoding,
+		Size:            int64(len(combined)),
+		StorageClass:    upload.StorageClass,
+		Checksum:        checksum,
+		LastModified:    p.tc.Now(),
+		UserMetadata:    upload.UserMetadata,
 	}
 	objData, err := json.Marshal(obj)
 	if err != nil {

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -36,8 +36,10 @@ type S3Object struct {
 	// ContentType is the MIME type of the object body.
 	ContentType string `json:"content_type"`
 
-	// ContentEncoding is the encoding of the object body (e.g. "gzip"),
-	// set via the Content-Encoding header on PutObject.
+	// ContentEncoding is the encoding of the object body (e.g. "gzip"), set via
+	// the Content-Encoding header on PutObject or on CreateMultipartUpload —
+	// Complete accepts no metadata headers, so a multipart object's encoding is
+	// carried on the upload record from creation.
 	ContentEncoding string `json:"content_encoding,omitempty"`
 
 	// Size is the byte length of the object body.
@@ -143,6 +145,12 @@ type S3MultipartUpload struct {
 
 	// ContentType is the MIME type supplied at upload creation.
 	ContentType string `json:"content_type"`
+
+	// ContentEncoding is the Content-Encoding supplied at upload creation (e.g.
+	// "gzip"), applied to the object CompleteMultipartUpload assembles. Create is
+	// the only place it can be supplied: Complete accepts no object-metadata
+	// headers, so an encoding not carried here is lost for good.
+	ContentEncoding string `json:"content_encoding,omitempty"`
 
 	// StorageClass is the storage class supplied at upload creation, applied to
 	// the object CompleteMultipartUpload assembles. Empty means STANDARD.


### PR DESCRIPTION
## What

`CreateMultipartUpload` accepted `Content-Encoding` and discarded it, so an object
assembled from parts came back with no encoding header while the identical body
written through `PutObject` came back correctly. Two upload paths disagreed about
one object property.

`S3MultipartUpload` now records `ContentEncoding` at create time and
`CompleteMultipartUpload` applies it to the assembled object.

## Why the upload record is the only correct home

Per the [CompleteMultipartUpload reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html),
Complete accepts no object-metadata headers at all — only checksums,
`x-amz-mp-object-size`, request-payer, SSE-C and conditional headers. Create is the
sole place the codec can be supplied, so an encoding not carried on the upload
record is lost for good.

## Why it mattered

`objectfs` compresses above its multipart threshold and read the object back as
uncompressed, surfacing as a false `DATA_CORRUPTION` against application code that
was behaving correctly. The symmetric risk is worse: a test asserting the header is
*absent* passed vacuously.

## Header casing

Both header reads in `createMultipartUpload` now use `headerValueFold`, matching
`resolveStorageClass` and `resolveUploadChecksum` in the same function.

To be explicit about the evidence: **no S3 test builds an `AWSRequest` literal, so
`headerValueFold` is not needed to make any test pass.** It rests on protocol
correctness — RFC 9110 header names are case-insensitive, and substrate constructs
`AWSRequest` values in-process (`betty_cfn.go`) where `net/http` canonicalization
never runs. The adjacent `Content-Type` switch is a consistency change, not a bug
fix.

## Scope

- The value is stored **verbatim**. `putObject` persisting `aws-chunked` as a
  Content-Encoding is a real but separate defect, filed on its own so a shared
  helper can fix both write paths at once rather than conflating it with this
  parity fix.
- `Cache-Control` / `Content-Disposition` / `Content-Language` (raised as "worth
  checking" on the issue) have no `S3Object` fields at all, so they are a feature
  across 4 headers × 5 sites, not this three-line change. Documented as unmodeled;
  filed separately. The storage-class half of that same suggestion already works
  (#398).

## Tests

`TestS3_Multipart_ContentEncoding` — table over `gzip`, `zstd`, `br` and `""`
(absent ⇒ header not emitted), asserting on **both** HEAD and GET, and that
`x-amz-meta-*` survives alongside the encoding (metadata working while encoding
vanished is exactly what the reporter saw).

No lowercase-header case: `s3Request` goes through `ServeHTTP`, which canonicalizes,
so such a test would assert nothing. Rationale is in a code comment.

Verified the test can fail: removing `ContentEncoding: upload.ContentEncoding`
produces `-br / +` on the brotli row.

## Verification

`gofmt` clean · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` (0
issues) · `make test` (race) · `make docs-reference-check` · `test/e2e` — all green.

Closes #406