### PR TITLE
fix(ec2): RunInstances must reject a launch that resolves no AMI (#412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-
 - `CreateMultipartUpload` now records `Content-Encoding` and
   `CompleteMultipartUpload` applies it to the assembled object, so `GetObject` and
   `HeadObject` report the codec a multipart object was uploaded with (#406).
@@ -22,6 +21,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upload" passed vacuously. `Complete` accepts no object-metadata headers at all, so
   carrying the value on the upload record from creation is the only place it can come
   from.
+- `RunInstances` now rejects a launch that resolves no AMI, with
+  `MissingParameter` / "The request must contain the parameter ImageId", HTTP 400
+  (#412). It previously accepted an empty `ImageId` and launched an instance, so a
+  consumer's error branch was unreachable: the bug reported here shipped and was
+  caught only by a paid smoke test against real AWS. The check runs *after* launch
+  template resolution, because AWS documents `ImageId` as "Required: No" precisely
+  so that a template can supply it — a launch naming a template that carries an
+  AMI is still valid, and one that resolves to nothing is not. `ImageId` is an
+  optional `*string` in the typed SDKs, so `aws.String("")` serializes as absent
+  from the wire and reaches the service rather than failing client-side, which is
+  the shape that shipped the bug.
+- The request parser no longer coerces an explicitly-empty form-body parameter to
+  the bare-key sentinel `"1"` (#412). Bare keys such as `?uploads` and `?delete`
+  map to `"1"` so a caller can detect their presence, but the set of bare keys was
+  derived from the URL's raw query while the value was applied to `r.Form`, which
+  merges query *and* body — the entire AWS Query protocol (EC2, IAM, STS, SQS,
+  SNS, CloudWatch) travels in the body. So `ImageId=` did not arrive as empty; it
+  arrived as `"1"`, and `RunInstances` launched an instance from an AMI named `1`.
+  Any query-protocol parameter sent explicitly empty was affected the same way,
+  which also made emptiness unverifiable by the plugin above it. The query-string
+  case was already correct (#200); this is the body-side companion.
 
 ## [v0.80.0] - 2026-07-31
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -694,7 +694,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 
 | Operation | Notes |
 |-----------|-------|
-| RunInstances | Auto-creates default VPC (172.31.0.0/16) |
+| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami) |
 | DescribeInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | TerminateInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
@@ -724,6 +724,29 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids) |
+
+### RunInstances requires a resolvable AMI
+
+`RunInstances` must end up with an AMI from *some* source, or it fails with
+`MissingParameter` / "The request must contain the parameter ImageId", HTTP 400.
+
+AWS documents `ImageId` as **Required: No** only because a launch template may
+supply it, so substrate checks *after* template resolution rather than on the way
+in. Both of these are valid:
+
+- `ImageId` given directly.
+- `LaunchTemplate.LaunchTemplateId` (or `…Name`) naming a template whose data
+  carries an `ImageId`.
+
+The request fails when neither applies — including when the named template
+resolves but carries no AMI of its own, and when the template name does not exist
+at all.
+
+Note that `ImageId` is an optional `*string` in the typed SDKs, so
+`aws.String("")` serializes as **absent from the wire**: an empty AMI reaches the
+service rather than being caught client-side. That is the shape this check exists
+for. The AMI value itself is not format-validated — substrate accepts any
+non-empty string, so fixtures like `ami-test` work.
 
 ### Explicit resource IDs
 

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -293,6 +293,17 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		}
 	}
 
+	// An AMI must have resolved from *some* source by this point. AWS documents
+	// ImageId as "Required: No" only because a launch template may supply it, so
+	// the check belongs here rather than at the top: a launch that names a
+	// template carrying an AMI is valid, and one that resolves to nothing is not.
+	// Without this, an empty ImageId — how aws.String("") on an optional *string
+	// serializes, i.e. absent from the wire — launched successfully here and
+	// failed on real AWS (#412).
+	if imageID == "" {
+		return nil, ec2MissingParameter("ImageId")
+	}
+
 	// Auto-create default VPC/subnet if none specified.
 	if subnetID == "" {
 		vpc, subnet, err := p.ensureDefaultVPC(context.Background(), reqCtx)

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -3840,3 +3840,146 @@ func TestEC2_RunInstances_ReturnsTagSet(t *testing.T) {
 	assert.Equal(t, "echo-test", tags["Name"], "RunInstances response must echo launch-time tags")
 	assert.Equal(t, "true", tags["spawn:managed"])
 }
+
+// ec2ErrorDetail sends params and returns the HTTP status plus the Error/Code and
+// Error/Message from the EC2 query-protocol error document. It differs from
+// ec2ErrorCode in also returning the message, so a test can pin AWS's exact
+// wording and catch a silent drift in it.
+func ec2ErrorDetail(t *testing.T, ts *httptest.Server, params map[string]string) (int, string, string) {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var doc struct {
+		XMLName xml.Name `xml:"ErrorResponse"`
+		Error   struct {
+			Code    string `xml:"Code"`
+			Message string `xml:"Message"`
+		} `xml:"Error"`
+	}
+	if xml.Unmarshal(body, &doc) != nil {
+		return resp.StatusCode, "", ""
+	}
+	return resp.StatusCode, doc.Error.Code, doc.Error.Message
+}
+
+// TestEC2_RunInstances_MissingImageId covers #412: RunInstances never validated
+// that an AMI resolved, so a launch with no ImageId "succeeded" against substrate
+// and failed against real AWS. A consumer's error branch was unreachable, so the
+// bug shipped and was caught only by a paid smoke test.
+//
+// The check runs *after* launch-template resolution, which the table pins from
+// both directions: a template that carries an AMI still launches (200), and a
+// template that resolves but carries no AMI does not. AWS documents ImageId as
+// "Required: No" precisely because a template may supply it, so an up-front check
+// would be wrong — the rule is "no AMI resolved from any source".
+func TestEC2_RunInstances_MissingImageId(t *testing.T) {
+	// createTemplate returns the ID of a launch template whose data carries
+	// imageID (empty for a template with no AMI of its own).
+	createTemplate := func(t *testing.T, ts *httptest.Server, name, imageID string) string {
+		t.Helper()
+		resp := ec2Request(t, ts, map[string]string{
+			"Action":                     "CreateLaunchTemplate",
+			"LaunchTemplateName":         name,
+			"LaunchTemplateData.ImageId": imageID,
+		})
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusOK, resp.StatusCode, "create launch template")
+		var cr struct {
+			LaunchTemplate struct {
+				LaunchTemplateID string `xml:"launchTemplateId"`
+			} `xml:"launchTemplate"`
+		}
+		require.NoError(t, xml.NewDecoder(resp.Body).Decode(&cr))
+		require.NotEmpty(t, cr.LaunchTemplate.LaunchTemplateID)
+		return cr.LaunchTemplate.LaunchTemplateID
+	}
+
+	tests := []struct {
+		name string
+		// params builds the RunInstances params, given a fresh server so a case
+		// can create a launch template first.
+		params     func(t *testing.T, ts *httptest.Server) map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name: "no ImageId and no launch template",
+			params: func(*testing.T, *httptest.Server) map[string]string {
+				return map[string]string{"MinCount": "1", "MaxCount": "1"}
+			},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "MissingParameter",
+		},
+		{
+			// How aws.String("") on an optional *string reaches the wire, and the
+			// exact shape that shipped the spawn#70 bug.
+			name: "ImageId explicitly empty",
+			params: func(*testing.T, *httptest.Server) map[string]string {
+				return map[string]string{"MinCount": "1", "MaxCount": "1", "ImageId": ""}
+			},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "MissingParameter",
+		},
+		{
+			name: "launch template resolves but carries no ImageId",
+			params: func(t *testing.T, ts *httptest.Server) map[string]string {
+				ltID := createTemplate(t, ts, "no-ami-tmpl", "")
+				return map[string]string{
+					"MinCount": "1", "MaxCount": "1",
+					"LaunchTemplate.LaunchTemplateId": ltID,
+				}
+			},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "MissingParameter",
+		},
+		{
+			name: "launch template name that does not exist",
+			params: func(*testing.T, *httptest.Server) map[string]string {
+				return map[string]string{
+					"MinCount": "1", "MaxCount": "1",
+					"LaunchTemplate.LaunchTemplateName": "no-such-template",
+				}
+			},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "MissingParameter",
+		},
+		{
+			name: "explicit ImageId still launches",
+			params: func(*testing.T, *httptest.Server) map[string]string {
+				return map[string]string{"MinCount": "1", "MaxCount": "1", "ImageId": "ami-regression-guard"}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			// The reason the check sits after template resolution rather than at
+			// the top of runInstances.
+			name: "launch template supplies the ImageId",
+			params: func(t *testing.T, ts *httptest.Server) map[string]string {
+				ltID := createTemplate(t, ts, "ami-tmpl", "ami-from-template")
+				return map[string]string{
+					"MinCount": "1", "MaxCount": "1",
+					"LaunchTemplate.LaunchTemplateId": ltID,
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			params := tt.params(t, ts)
+			params["Action"] = "RunInstances"
+
+			status, code, message := ec2ErrorDetail(t, ts, params)
+			assert.Equal(t, tt.wantStatus, status)
+			assert.Equal(t, tt.wantCode, code)
+			if tt.wantCode != "" {
+				// Pin AWS's wording so it cannot silently drift.
+				assert.Equal(t, "The request must contain the parameter ImageId", message)
+			}
+		})
+	}
+}

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -34,21 +34,24 @@ func ParseAWSRequest(r *http.Request) (*AWSRequest, *RequestContext, error) {
 	}
 
 	// Build flat params map from query string and form values.
-	// Bare keys (e.g. ?uploads, ?versions) have no "=" in the raw query and
-	// are stored as "1" so callers can detect their presence with a map lookup.
-	// Keys with an explicit empty value (e.g. ?prefix=) must be preserved as ""
-	// to avoid corrupting parameters such as ListObjectsV2 Prefix.
+	// Bare keys (e.g. ?uploads, ?versions) have no "=" at all and are stored as
+	// "1" so callers can detect their presence with a map lookup. Keys with an
+	// explicit empty value (e.g. ?prefix=, or ImageId= in a query-protocol form
+	// body) must be preserved as "", so that a caller distinguishing "absent"
+	// from "present but empty" — and any required-parameter check — sees the
+	// truth rather than the sentinel.
 	params := make(map[string]string)
-	// Build a set of keys that appear with an explicit "=" in the raw query so
-	// we can distinguish them from true bare keys.
-	rawQuery := r.URL.RawQuery
-	explicitEmpty := make(map[string]bool)
-	for _, part := range strings.Split(rawQuery, "&") {
-		if idx := strings.IndexByte(part, '='); idx >= 0 {
-			key := part[:idx]
-			if val := part[idx+1:]; val == "" {
-				explicitEmpty[key] = true
-			}
+	// Only the URL's raw query can contain bare keys: r.Form merges the query
+	// string with the form body, and the sentinel must not be applied to a body
+	// parameter that was legitimately sent empty. Deriving the bare set from the
+	// query alone is why this is a positive test rather than the inverse: an
+	// "explicitly empty" set built from the query cannot say anything about body
+	// keys, so empty body parameters were silently promoted to "1" — an empty
+	// ImageId on RunInstances launched an instance from an AMI named "1" (#412).
+	bareKeys := make(map[string]bool)
+	for _, part := range strings.Split(r.URL.RawQuery, "&") {
+		if part != "" && !strings.Contains(part, "=") {
+			bareKeys[part] = true
 		}
 	}
 	if err := r.ParseForm(); err == nil {
@@ -57,7 +60,7 @@ func ParseAWSRequest(r *http.Request) (*AWSRequest, *RequestContext, error) {
 			if len(vs) > 0 {
 				v = vs[0]
 			}
-			if v == "" && !explicitEmpty[k] {
+			if v == "" && bareKeys[k] {
 				v = "1" // bare key (e.g. ?uploads, ?versions)
 			}
 			params[k] = v

--- a/emulator/parser_test.go
+++ b/emulator/parser_test.go
@@ -3,6 +3,7 @@ package emulator_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -405,6 +406,41 @@ func TestParseAWSRequest_BareQueryKey(t *testing.T) {
 	req, _, err := emulator.ParseAWSRequest(r)
 	require.NoError(t, err)
 	assert.Equal(t, "1", req.Params["uploads"])
+}
+
+func TestParseAWSRequest_EmptyValueFormBodyParam(t *testing.T) {
+	// The companion to TestParseAWSRequest_EmptyValueQueryParam (#200), for the
+	// form body rather than the query string — the gap that let #412 through.
+	// r.Form merges query and body, but the bare-key set can only be derived from
+	// the query, so a body parameter sent explicitly empty was promoted to the
+	// "1" sentinel. RunInstances then launched an instance from an AMI named "1"
+	// instead of rejecting the request, which is how an empty ImageId "succeeded"
+	// against substrate and failed against real AWS.
+	body := "Action=RunInstances&MinCount=1&MaxCount=1&ImageId=&KeyName="
+	r := httptest.NewRequest(http.MethodPost, "http://ec2.us-east-1.amazonaws.com/",
+		strings.NewReader(body))
+	r.Host = "ec2.us-east-1.amazonaws.com"
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	req, _, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	assert.Equal(t, "", req.Params["ImageId"], "empty form-body param must not become the bare-key sentinel")
+	assert.Equal(t, "", req.Params["KeyName"])
+	assert.Equal(t, "RunInstances", req.Params["Action"])
+	assert.Equal(t, "1", req.Params["MinCount"], "a value that is genuinely \"1\" must survive")
+}
+
+func TestParseAWSRequest_BareQueryKeyWithFormBody(t *testing.T) {
+	// A bare key in the query string must still map to "1" when a form body is
+	// also present — S3 POST operations (e.g. ?delete, ?uploads) rely on it, so
+	// restricting the sentinel to query-string keys must not break them.
+	r := httptest.NewRequest(http.MethodPost, "http://s3.amazonaws.com/mybucket?delete",
+		strings.NewReader("<Delete></Delete>"))
+	r.Host = "s3.amazonaws.com"
+
+	req, _, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	assert.Equal(t, "1", req.Params["delete"])
 }
 
 func TestParseAWSRequest_EmptyValueQueryParam(t *testing.T) {


### PR DESCRIPTION
## What

`RunInstances` never validated that an AMI resolved, so a launch with an empty
`ImageId` returned 200 here and failed against real AWS. It now fails with
`MissingParameter` / "The request must contain the parameter ImageId", HTTP 400.

The consumer's error branch was unreachable, so the bug shipped and was caught only
by a paid smoke test — exactly the failure mode this project exists to prevent.

## The check runs after launch-template resolution

That placement is the whole design decision. AWS documents `ImageId` as
**Required: No** *precisely because* a launch template may supply it, so an up-front
check would be wrong — it would reject a valid launch. At the post-resolution point
the check means "no AMI resolved from any source", which is the actual AWS rule.

The pre-existing `TestEC2Plugin_RunInstances_ViaLaunchTemplate` still passing is the
evidence the check sits in the right place; the new table pins it from both sides.

## A second, deeper defect

Writing the test surfaced a bug the one-line check could not see: the
`ImageId=""` row still returned **200**, launching an instance from
`<imageId>1</imageId>`.

`ParseAWSRequest` maps bare keys (`?uploads`, `?delete`) to the sentinel `"1"` so a
caller can detect their presence via a map lookup. But it derived the bare-key set
from `r.URL.RawQuery` while applying the sentinel to `r.Form` — which **merges the
query string with the form body**. The entire AWS Query protocol (EC2, IAM, STS,
SQS, SNS, CloudWatch) travels in the body, so `ImageId=` never arrived as empty; it
arrived as `"1"`.

Every query-protocol parameter sent explicitly empty was corrupted the same way,
which made emptiness structurally unverifiable by any plugin above the parser.

The fix inverts the test to a positive one: a key is bare only if it appears with no
`=` in the raw query. An "explicitly empty" set built from the query string cannot
say anything about body keys, which is why the original direction could not be made
correct. The query-string half of this was already fixed (#200); this is the
body-side companion.

## Tests

`TestEC2_RunInstances_MissingImageId` — 6 rows, asserting status, code **and**
message so AWS's wording cannot silently drift:

| Case | Expect |
|---|---|
| No `ImageId`, no launch template | 400 `MissingParameter` |
| `ImageId` explicitly empty | 400 — the shape that shipped the bug |
| Template resolves but carries no AMI | 400 |
| Template name does not exist | 400 |
| Explicit `ImageId` | 200 (regression guard) |
| Template supplies the AMI | 200 (pins the placement) |

`TestParseAWSRequest_EmptyValueFormBodyParam` and
`TestParseAWSRequest_BareQueryKeyWithFormBody` — direct parser regressions, beside
the existing #200 query-string pair. The second guards the risk in the parser
change: S3 POST operations rely on bare keys resolving to `"1"` when a body is
*also* present.

Verified both fixes are load-bearing: reverting the parser change alone makes two
rows fail; the full suite covers every S3 bare-key path.

## Blast radius

Every `"RunInstances"` occurrence across `authz_test.go`, `ce_plugin_test.go`,
`ec2_networkinterface_test.go`, `ec2_notfound_test.go`, `ec2_plugin_test.go` and
`server_test.go` supplies either `ImageId` or a launch template. The one exception
(`authz_test.go:572`) calls `auth.CheckAccess` directly and never reaches the
plugin. `betty_cfn.go` uses a non-empty `ami-00000000` default, so CFN deploys are
unaffected. The `"1"` sentinel is consumed only for S3 bare keys (`policy`, `acl`),
which arrive in the URL query string.

Scoped strictly to emptiness — **no `ami-` format validation**. There is no
`ec2ImageIDKind` today, ~12 existing tests use non-hex fixture IDs (`ami-base`,
`ami-test`, `ami-1`), and AWS still accepts legacy ID forms.

## Verification

`gofmt` clean · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` (0
issues) · `make test` (race) · `make docs-reference-check` · `test/e2e` — all green.

Closes #412