### PR TITLE
fix(sqs): raise QueueDoesNotExist, not the legacy NonExistentQueue (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- SQS now raises `QueueDoesNotExist` rather than the legacy
+  `AWS.SimpleQueueService.NonExistentQueue` for an operation naming a queue that
+  does not exist, across all 14 sites that produced it (#413). The code decides
+  whether a consumer can catch the error as a typed exception at all: botocore
+  derives the exception class from the resolved error code, so the legacy string
+  resolved to a bare `ClientError` and `except sqs.exceptions.QueueDoesNotExist`
+  never matched, while `aws-sdk-go-v2` dispatches on
+  `strings.EqualFold("QueueDoesNotExist", …)` and does not mention the dotted form
+  anywhere in its `sqs` module, so `errors.As(err, &types.QueueDoesNotExist{})`
+  never matched either. SQS is an `awsQueryCompatible` JSON service and the dotted
+  form is the query-compatibility alias AWS sends in an `x-amzn-query-error`
+  header, not in `__type`. Because `writeError` derives `x-amzn-ErrorType` from the
+  code, correcting the code fixes both SDKs with no additional plumbing. The 14
+  verbatim duplicates are now a single `sqsQueueDoesNotExist` helper, so future
+  queue operations inherit the right code.
 - `CreateMultipartUpload` now records `Content-Encoding` and
   `CompleteMultipartUpload` applies it to the assembled object, so `GetObject` and
   `HeadObject` report the codec a multipart object was uploaded with (#406).

--- a/docs/services.md
+++ b/docs/services.md
@@ -623,18 +623,39 @@ Lambda invocations: $0.0000002 per request.
 | Operation | Notes |
 |-----------|-------|
 | CreateQueue | Supports FifoQueue, VisibilityTimeout attributes |
-| GetQueueUrl | |
-| GetQueueAttributes | |
-| SetQueueAttributes | |
-| DeleteQueue | |
+| GetQueueUrl | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
+| GetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
+| SetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
+| DeleteQueue | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | ListQueues | |
-| SendMessage | Returns MessageId |
+| SendMessage | Returns MessageId; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | SendMessageBatch | |
-| ReceiveMessage | Supports MaxNumberOfMessages, WaitTimeSeconds |
-| DeleteMessage | |
+| ReceiveMessage | Supports MaxNumberOfMessages, WaitTimeSeconds; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
+| DeleteMessage | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteMessageBatch | |
-| ChangeMessageVisibility | |
-| PurgeQueue | |
+| ChangeMessageVisibility | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
+| PurgeQueue | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
+
+### QueueDoesNotExist
+
+Every operation that names a queue fails with `QueueDoesNotExist`, HTTP 400, when
+that queue is absent — not the legacy `AWS.SimpleQueueService.NonExistentQueue`.
+
+The distinction decides whether a consumer can catch the error as a typed
+exception. SQS is an `awsQueryCompatible` JSON service, and the dotted form is the
+query-compatibility alias AWS sends in an `x-amzn-query-error` header, not in
+`__type`:
+
+- **botocore** derives the exception class from the resolved error code, so the
+  legacy string resolves to a bare `ClientError` and
+  `except sqs.exceptions.QueueDoesNotExist` never matches.
+- **aws-sdk-go-v2** dispatches on `strings.EqualFold("QueueDoesNotExist", …)`; the
+  legacy string appears nowhere in the `sqs` module, so
+  `errors.As(err, &types.QueueDoesNotExist{})` never matched either.
+
+SQS errors are emitted as JSON regardless of the request protocol, since substrate
+resolves the error protocol per service and SQS is JSON-RPC. A query-protocol
+request therefore gets a JSON error document rather than the XML `<Error>` shape.
 
 ### Betty CFN resource types
 

--- a/emulator/sqs_errors.go
+++ b/emulator/sqs_errors.go
@@ -1,0 +1,33 @@
+package emulator
+
+import "net/http"
+
+// sqsQueueDoesNotExist returns the error SQS raises for an operation naming a
+// queue that does not exist.
+//
+// The code is QueueDoesNotExist, not the legacy
+// "AWS.SimpleQueueService.NonExistentQueue". The AWS GetQueueUrl and
+// GetQueueAttributes references document QueueDoesNotExist, and the legacy string
+// appears nowhere in the current API reference: SQS is an
+// awsQueryCompatible/JSON service, and the dotted form is the query-compatibility
+// alias AWS sends in an x-amzn-query-error header rather than in __type.
+//
+// The distinction decides whether a consumer can catch the error at all:
+//
+//   - botocore derives the exception class from the resolved error code, so
+//     __type: "AWS.SimpleQueueService.NonExistentQueue" resolves to a bare
+//     ClientError and `except sqs.exceptions.QueueDoesNotExist` never matches,
+//     while "QueueDoesNotExist" resolves to the modeled class.
+//   - aws-sdk-go-v2 dispatches on strings.EqualFold("QueueDoesNotExist",
+//     errorCode); the legacy string appears nowhere in the sqs module, so
+//     errors.As(&types.QueueDoesNotExist{}) never matched either.
+//
+// Because writeError derives x-amzn-ErrorType from Code, changing the code alone
+// corrects both SDKs with no additional plumbing.
+func sqsQueueDoesNotExist() *AWSError {
+	return &AWSError{
+		Code:       "QueueDoesNotExist",
+		Message:    "The specified queue does not exist",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -352,7 +352,7 @@ func (p *SQSPlugin) getQueueURL(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	if sqsIsJSONProtocol(req) {
@@ -381,7 +381,7 @@ func (p *SQSPlugin) getQueueAttributes(ctx *RequestContext, req *AWSRequest) (*A
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	// Build standard attributes.
@@ -437,7 +437,7 @@ func (p *SQSPlugin) setQueueAttributes(ctx *RequestContext, req *AWSRequest) (*A
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	var attrs map[string]string
@@ -483,7 +483,7 @@ func (p *SQSPlugin) deleteQueue(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	urlKey := sqsURLKey(queueURL)
@@ -587,7 +587,7 @@ func (p *SQSPlugin) tagQueue(ctx *RequestContext, req *AWSRequest) (*AWSResponse
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	if q.Tags == nil {
@@ -638,7 +638,7 @@ func (p *SQSPlugin) untagQueue(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	if sqsIsJSONProtocol(req) {
@@ -684,7 +684,7 @@ func (p *SQSPlugin) listQueueTags(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	type tagEntry struct {
@@ -731,7 +731,7 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	// Extract parameters supporting both protocols.
@@ -923,7 +923,7 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	urlKey := sqsURLKey(queueURL)
@@ -1057,7 +1057,7 @@ func (p *SQSPlugin) receiveMessage(ctx *RequestContext, req *AWSRequest) (*AWSRe
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	var maxNum int
@@ -1221,7 +1221,7 @@ func (p *SQSPlugin) deleteMessage(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	var receiptHandle string
@@ -1288,7 +1288,7 @@ func (p *SQSPlugin) deleteMessageBatch(ctx *RequestContext, req *AWSRequest) (*A
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	urlKey := sqsURLKey(queueURL)
@@ -1400,7 +1400,7 @@ func (p *SQSPlugin) changeMessageVisibility(ctx *RequestContext, req *AWSRequest
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	var receiptHandle string
@@ -1460,7 +1460,7 @@ func (p *SQSPlugin) purgeQueue(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return nil, err
 	}
 	if q == nil {
-		return nil, &AWSError{Code: "AWS.SimpleQueueService.NonExistentQueue", Message: "The specified queue does not exist", HTTPStatus: http.StatusBadRequest}
+		return nil, sqsQueueDoesNotExist()
 	}
 
 	urlKey := sqsURLKey(queueURL)

--- a/emulator/sqs_plugin_test.go
+++ b/emulator/sqs_plugin_test.go
@@ -905,6 +905,81 @@ func TestSQSPlugin_JSON_Error_NonExistentQueue(t *testing.T) {
 		"MessageBody": "test",
 	})
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// Assert the code, not just the status. Checking only StatusCode is why the
+	// wrong code survived: AWS documents QueueDoesNotExist, and the legacy
+	// "AWS.SimpleQueueService.NonExistentQueue" resolves to a bare ClientError in
+	// botocore while aws-sdk-go-v2 dispatches on EqualFold("QueueDoesNotExist",…)
+	// and never mentions the dotted form — so a consumer could not catch it as the
+	// modeled exception type at all (#413).
+	body := readJSONBody(t, resp)
+	assert.Equal(t, "QueueDoesNotExist", body["__type"])
+	assert.Equal(t, "QueueDoesNotExist", body["Code"])
+	assert.Equal(t, "The specified queue does not exist", body["message"])
+	assert.Equal(t, "QueueDoesNotExist", resp.Header.Get("X-Amzn-ErrorType"),
+		"writeError derives x-amzn-ErrorType from Code; SDKs read it in preference to the body")
+}
+
+// TestSQS_QueueDoesNotExist_AllOperations pins the not-exist code across every
+// operation that can raise it, under both protocols. The code was duplicated
+// verbatim at 14 sites before #413 and is now a single helper, so this is the
+// regression guard that any future queue operation inherits the right code — and
+// that no site was missed by the dedup.
+//
+// SQS errors are always JSON here regardless of request protocol:
+// errorProtocolFor consults the service map before the Content-Type, and sqs is
+// registered as errProtoJSONRPC. Both protocol rows therefore assert the same JSON
+// shape; that is deliberate, not an oversight.
+func TestSQS_QueueDoesNotExist_AllOperations(t *testing.T) {
+	const missingURL = "http://sqs.us-east-1.localhost/000000000000/no-such-queue"
+
+	// Each case names an operation and the minimum extra parameters it needs to
+	// reach the queue lookup.
+	tests := []struct {
+		op     string
+		params map[string]string
+	}{
+		{op: "GetQueueUrl", params: map[string]string{"QueueName": "no-such-queue"}},
+		{op: "GetQueueAttributes"},
+		{op: "SetQueueAttributes", params: map[string]string{"Attribute.1.Name": "VisibilityTimeout", "Attribute.1.Value": "60"}},
+		{op: "DeleteQueue"},
+		{op: "TagQueue", params: map[string]string{"Tag.1.Key": "k", "Tag.1.Value": "v"}},
+		{op: "UntagQueue", params: map[string]string{"TagKey.1": "k"}},
+		{op: "ListQueueTags"},
+		{op: "SendMessage", params: map[string]string{"MessageBody": "x"}},
+		{op: "ReceiveMessage"},
+		{op: "DeleteMessage", params: map[string]string{"ReceiptHandle": "rh"}},
+		{op: "ChangeMessageVisibility", params: map[string]string{"ReceiptHandle": "rh", "VisibilityTimeout": "30"}},
+		{op: "PurgeQueue"},
+	}
+
+	assertCode := func(t *testing.T, resp *http.Response) {
+		t.Helper()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		body := readJSONBody(t, resp)
+		assert.Equal(t, "QueueDoesNotExist", body["__type"])
+		assert.Equal(t, "QueueDoesNotExist", resp.Header.Get("X-Amzn-ErrorType"))
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.op+"/query", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			params := map[string]string{"Action": tt.op, "QueueUrl": missingURL}
+			for k, v := range tt.params {
+				params[k] = v
+			}
+			assertCode(t, sqsRequest(t, srv, params))
+		})
+
+		t.Run(tt.op+"/json", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			body := map[string]interface{}{"QueueUrl": missingURL}
+			for k, v := range tt.params {
+				body[k] = v
+			}
+			assertCode(t, sqsJSONRequest(t, srv, tt.op, body))
+		})
+	}
 }
 
 func TestSQSPlugin_CrossProtocol(t *testing.T) {


### PR DESCRIPTION
**Part A of #413.** The seedable consistency window follows in a separate PR; this
one deliberately does **not** close the issue.

## What

SQS returned `AWS.SimpleQueueService.NonExistentQueue` for an operation naming an
absent queue. AWS documents the error as **`QueueDoesNotExist`**, and the dotted
form appears nowhere in the current API reference: SQS is an `awsQueryCompatible`
JSON service, and that string is the query-compatibility alias AWS sends in an
`x-amzn-query-error` header — not in `__type`.

## Why this is in #413's scope rather than a follow-up

The code decides whether a consumer can catch the error as a typed exception *at
all*. Verified against both SDKs rather than assumed:

| SDK | Behaviour |
|---|---|
| **botocore** | Derives the exception class from the resolved error code. Running its real parser + `errorfactory`: the legacy string resolves to a bare **`ClientError`**, so `except sqs.exceptions.QueueDoesNotExist` never matches. `"QueueDoesNotExist"` resolves to the modeled class. |
| **aws-sdk-go-v2** | `deserializers.go` dispatches on `strings.EqualFold("QueueDoesNotExist", errorCode)`. The legacy string appears **nowhere** in the `sqs` module, so `errors.As(err, &types.QueueDoesNotExist{})` never matched either. |

So the retry loop #413 asks for could not be written idiomatically against
substrate regardless of the seed — shipping the seed on the current code would
reproduce the very defect the issue exists to fix, one layer down. This must land
first, since Part B's tests assert the code the seeded window returns.

## Wire shape: change the code, don't add the compat header

`writeError` already derives `x-amzn-ErrorType` from `Code`, so changing the code
alone corrects both SDKs with no new plumbing.

Adding `x-amzn-query-error` would need a cross-cutting change to the shared
`AWSError` type for one service's legacy alias, and would *still* leave
`Error["Code"]` reading the legacy string. Gating on `x-amzn-query-mode` is not
viable either: botocore always sends it for a query-compatible service, but it
appears nowhere in the Go SDK — gating would silently disable the header for every
Go caller, substrate's primary consumer language.

## Changes

The 14 byte-identical duplicates collapse into one `sqsQueueDoesNotExist` helper
(new `emulator/sqs_errors.go`), doc-commented with the AWS citation and the
SDK reasoning, so every future queue operation inherits the right code.

## Tests

`TestSQSPlugin_JSON_Error_NonExistentQueue` asserted **only `StatusCode`** — which
is precisely why the wrong code survived this long. It now asserts `__type`,
`Code`, `message` and the `x-amzn-ErrorType` header.

New `TestSQS_QueueDoesNotExist_AllOperations` covers all 12 operations that can
raise it, under both protocols — **24 subtests**, which is also the evidence the
dedup missed no site.

Verified the tests can fail: restoring the legacy code string fails both.

**No query-protocol XML assertion.** `errorProtocolFor` consults the service map
before the Content-Type and `sqs` is registered as `errProtoJSONRPC`, so SQS errors
are always JSON — an XML assertion would fail. Both protocol rows assert the same
JSON shape deliberately; whether that is itself a fidelity gap is noted on the
issue rather than changed here.

## Compatibility

The legacy string appears nowhere else in this repo (the only other match was a
test *function name*), nowhere in botocore's model, and nowhere in
`aws-sdk-go-v2/service/sqs`. The message text is only ever produced, never
asserted on.

## Verification

`gofmt` clean · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` (0
issues) · `make test` (race) · `make docs-reference-check` · `test/e2e` — all green.