### PR TITLE
feat(sqs): seedable create-then-lookup consistency window (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   next N misses rather than re-arming on `CreateQueue`, which would otherwise be
   ambiguous given that `CreateQueue` is idempotent, and would make the data path
   write control-plane state.
+  A state-store failure during the seed lookup propagates as an error rather than
+  collapsing into `QueueDoesNotExist`: the two are opposite signals, since a 400
+  tells a caller to stop retrying while a store failure is transient — and this
+  seed exists so that retry loops can be tested, so conflating them would undercut
+  the feature.
 
 ### Fixed
 - SQS now raises `QueueDoesNotExist` rather than the legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The SQS create-then-lookup eventual-consistency window is now seedable via
+  `POST`/`DELETE /v1/sqs/consistency`, keyed by queue name or the `"*"` wildcard
+  (#413). AWS documents that a caller "must wait at least one second after the queue
+  is created to be able to use the queue", so a real
+  `CreateQueue` → `GetQueueUrl` → retry loop can see `QueueDoesNotExist` for a queue
+  that exists. Substrate resolved a new queue instantly, which made that retry path
+  unreachable — the consumer could not exercise it offline at all, so their suite
+  reported green on a loop it never ran.
+  `GetQueueUrl` and `GetQueueAttributes` have independent counters, both defaulting
+  to 0, so unseeded behaviour is unchanged. The window is counted in **misses rather
+  than measured as a duration**: the simulated clock advances with wall time from
+  its baseline, so a duration seed would expire partway through a test and make
+  "still missing" assertions wall-clock dependent, which no test here may be. A miss
+  counter is exactly reproducible.
+  Two ordering rules make it usable from a harness: a miss is consumed only when the
+  queue actually exists, so seeding before `CreateQueue` does not silently burn
+  budget on lookups against a genuinely absent queue; and a seed counts down the
+  next N misses rather than re-arming on `CreateQueue`, which would otherwise be
+  ambiguous given that `CreateQueue` is idempotent, and would make the data path
+  write control-plane state.
+
 ### Fixed
 - SQS now raises `QueueDoesNotExist` rather than the legacy
   `AWS.SimpleQueueService.NonExistentQueue` for an operation naming a queue that

--- a/docs/services.md
+++ b/docs/services.md
@@ -623,8 +623,8 @@ Lambda invocations: $0.0000002 per request.
 | Operation | Notes |
 |-----------|-------|
 | CreateQueue | Supports FifoQueue, VisibilityTimeout attributes |
-| GetQueueUrl | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
-| GetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
+| GetQueueUrl | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; [seedable consistency window](#seeding-the-create-then-lookup-consistency-window) |
+| GetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; [seedable consistency window](#seeding-the-create-then-lookup-consistency-window) |
 | SetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteQueue | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | ListQueues | |
@@ -656,6 +656,55 @@ query-compatibility alias AWS sends in an `x-amzn-query-error` header, not in
 SQS errors are emitted as JSON regardless of the request protocol, since substrate
 resolves the error protocol per service and SQS is JSON-RPC. A query-protocol
 request therefore gets a JSON error document rather than the XML `<Error>` shape.
+
+### Seeding the create-then-lookup consistency window
+
+AWS documents that you "must wait at least one second after the queue is created
+to be able to use the queue", so a real `CreateQueue` → `GetQueueUrl` → retry loop
+can legitimately see `QueueDoesNotExist` for a queue that exists. Substrate
+resolves a new queue instantly, which makes that retry path unreachable and any
+test of it vacuous. Seeding is what makes the window observable:
+
+```bash
+# The next 2 GetQueueUrl calls on run-q report QueueDoesNotExist.
+curl -X POST http://localhost:4566/v1/sqs/consistency \
+  -d '{"queueName":"run-q","getUrlMisses":2}'
+
+# GetQueueAttributes has its own independent counter.
+curl -X POST http://localhost:4566/v1/sqs/consistency \
+  -d '{"queueName":"run-q","getAttributesMisses":1}'
+
+# Apply to any queue (wildcard).
+curl -X POST http://localhost:4566/v1/sqs/consistency -d '{"getUrlMisses":3}'
+
+# Clear one, or all.
+curl -X DELETE 'http://localhost:4566/v1/sqs/consistency?queueName=run-q'
+curl -X DELETE http://localhost:4566/v1/sqs/consistency
+```
+
+A name-scoped seed is consulted before the wildcard. When a name-scoped seed is
+exhausted the lookup falls through to the wildcard, so an empty named seed does not
+mask a wildcard that still has budget.
+
+**The window is counted in misses, not measured as a duration.** Substrate's
+simulated clock advances with wall time from its baseline, so a duration-based
+window would expire partway through a test and make "still missing" assertions
+wall-clock dependent — which no test here may be. A miss counter is exactly
+reproducible.
+
+Two ordering rules make the seed usable from a harness:
+
+- A miss is consumed **only when the queue actually exists**. Seeding before
+  `CreateQueue` is safe: lookups against the genuinely absent queue still fail, but
+  they do not spend the budget.
+- A seed counts down the next N misses and **does not re-arm on `CreateQueue`**.
+  `CreateQueue` is idempotent here (it returns the existing URL), so "after its
+  CreateQueue" would be ambiguous when create runs twice, and re-arming would mean
+  the data path writes control-plane state.
+
+Both counters default to 0, so an unseeded queue behaves exactly as before —
+instantly resolvable. Seeds live in the state store, so `POST /v1/state/reset`
+clears them along with everything else.
 
 ### Betty CFN resource types
 

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -2,6 +2,8 @@ package emulator
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -192,6 +194,36 @@ func InvokeLambdaForTest(p *LambdaPlugin, ctx *RequestContext, req *AWSRequest, 
 // instead of a real Docker container.
 func InvokePOSTForTest(e *LambdaExecutor, port int, payload []byte) (body []byte, functionError string, err error) {
 	return e.invokePOST(context.Background(), &containerHandle{port: port}, payload)
+}
+
+// SQSQueueNameFromURLForTest wraps sqsQueueNameFromURL for external tests.
+func SQSQueueNameFromURLForTest(queueURL string) string { return sqsQueueNameFromURL(queueURL) }
+
+// SQSSeedForTest writes an SQS consistency seed directly into state, bypassing
+// the control-plane handler. It lets a test arrange a seed behind a state manager
+// whose Put or Delete is rigged to fail.
+func SQSSeedForTest(state StateManager, queueName string, getURLMisses, getAttributesMisses int) error {
+	data, err := json.Marshal(sqsConsistencySeed{
+		QueueName:           queueName,
+		GetURLMisses:        getURLMisses,
+		GetAttributesMisses: getAttributesMisses,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal sqs seed: %w", err)
+	}
+	if err := state.Put(context.Background(), sqsCtrlNamespace, sqsCtrlKey(queueName), data); err != nil {
+		return fmt.Errorf("put sqs seed: %w", err)
+	}
+	return nil
+}
+
+// SQSPutRawSeedForTest stores raw bytes at a consistency seed's key, so a test
+// can exercise the unmarshal-failure path with a corrupt stored value.
+func SQSPutRawSeedForTest(state StateManager, queueName string, raw []byte) error {
+	if err := state.Put(context.Background(), sqsCtrlNamespace, sqsCtrlKey(queueName), raw); err != nil {
+		return fmt.Errorf("put raw sqs seed: %w", err)
+	}
+	return nil
 }
 
 // CheckPresignedExpiryForTest exposes checkPresignedExpiry for white-box tests.

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -261,6 +261,10 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/lambda/invoke-error", s.handleLambdaSeedInvokeError)
 	r.Delete("/v1/lambda/invoke-error", s.handleLambdaClearInvokeError)
 
+	// SQS control-plane endpoints (#413).
+	r.Post("/v1/sqs/consistency", s.handleSQSSeedConsistency)
+	r.Delete("/v1/sqs/consistency", s.handleSQSClearConsistency)
+
 	// spore.host spawn task-completion control-plane endpoints (#360).
 	r.Post("/v1/spawn/task-completion", s.handleSpawnSeedTaskCompletion)
 	r.Delete("/v1/spawn/task-completion", s.handleSpawnClearTaskCompletion)

--- a/emulator/sqs_consistency_test.go
+++ b/emulator/sqs_consistency_test.go
@@ -1,0 +1,386 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// seedSQSConsistency posts a seeded create→lookup consistency window to the
+// control plane.
+func seedSQSConsistency(t *testing.T, srv *emulator.Server, seed map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(seed)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/v1/sqs/consistency", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code, "seed failed: %s", w.Body.String())
+}
+
+// clearSQSConsistency deletes seeds via the control plane. An empty queueName
+// clears all of them.
+func clearSQSConsistency(t *testing.T, srv *emulator.Server, queueName string) {
+	t.Helper()
+	path := "/v1/sqs/consistency"
+	if queueName != "" {
+		path += "?queueName=" + queueName
+	}
+	r := httptest.NewRequest(http.MethodDelete, path, nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code, "clear failed: %s", w.Body.String())
+}
+
+// createSQSQueue creates a queue and returns its URL.
+func createSQSQueue(t *testing.T, srv *emulator.Server, name string) string {
+	t.Helper()
+	resp := sqsRequest(t, srv, map[string]string{"Action": "CreateQueue", "QueueName": name})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return "http://sqs.us-east-1.localhost/000000000000/" + name
+}
+
+// sqsErrorCode returns the response status and the error code from an SQS error
+// document. SQS errors are always JSON here — errorProtocolFor resolves the
+// protocol per service and sqs is JSON-RPC — so this reads __type for both
+// request protocols.
+func sqsErrorCode(t *testing.T, resp *http.Response) (int, string) {
+	t.Helper()
+	if resp.StatusCode == http.StatusOK {
+		resp.Body.Close() //nolint:errcheck
+		return resp.StatusCode, ""
+	}
+	body := readJSONBody(t, resp)
+	code, _ := body["__type"].(string)
+	return resp.StatusCode, code
+}
+
+// getQueueURL calls GetQueueUrl by name under the given protocol.
+func getQueueURL(t *testing.T, srv *emulator.Server, name string, jsonProto bool) (int, string) {
+	t.Helper()
+	if jsonProto {
+		return sqsErrorCode(t, sqsJSONRequest(t, srv, "GetQueueUrl", map[string]interface{}{"QueueName": name}))
+	}
+	return sqsErrorCode(t, sqsRequest(t, srv, map[string]string{"Action": "GetQueueUrl", "QueueName": name}))
+}
+
+// getQueueAttributes calls GetQueueAttributes by URL under the given protocol.
+func getQueueAttributes(t *testing.T, srv *emulator.Server, queueURL string, jsonProto bool) (int, string) {
+	t.Helper()
+	if jsonProto {
+		return sqsErrorCode(t, sqsJSONRequest(t, srv, "GetQueueAttributes", map[string]interface{}{"QueueUrl": queueURL}))
+	}
+	return sqsErrorCode(t, sqsRequest(t, srv, map[string]string{"Action": "GetQueueAttributes", "QueueUrl": queueURL}))
+}
+
+// bothProtocols runs fn for the query and JSON protocols. SQS is dual-protocol and
+// the reporter reaches it through an SDK, so a seed that worked under only one
+// would still leave their retry loop untestable.
+func bothProtocols(t *testing.T, fn func(t *testing.T, jsonProto bool)) {
+	t.Helper()
+	t.Run("query", func(t *testing.T) { fn(t, false) })
+	t.Run("json", func(t *testing.T) { fn(t, true) })
+}
+
+// TestSQS_GetQueueUrl_SeededConsistencyWindow is the core of #413. AWS documents
+// that a caller must wait at least a second after CreateQueue before the queue is
+// usable, so a create→lookup→retry loop can legitimately see QueueDoesNotExist for
+// a queue that exists. Substrate resolves instantly, which makes that retry path
+// unreachable and any test of it vacuous.
+func TestSQS_GetQueueUrl_SeededConsistencyWindow(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		createSQSQueue(t, srv, "run-q")
+		seedSQSConsistency(t, srv, map[string]any{"queueName": "run-q", "getUrlMisses": 2})
+
+		for i := 1; i <= 2; i++ {
+			status, code := getQueueURL(t, srv, "run-q", jsonProto)
+			assert.Equal(t, http.StatusBadRequest, status, "call %d must miss", i)
+			assert.Equal(t, "QueueDoesNotExist", code, "call %d", i)
+		}
+
+		// Budget exhausted: the queue resolves.
+		status, _ := getQueueURL(t, srv, "run-q", jsonProto)
+		assert.Equal(t, http.StatusOK, status, "call 3 must succeed once the window closes")
+
+		// And stays resolved — the seed counts down, it does not re-arm.
+		status, _ = getQueueURL(t, srv, "run-q", jsonProto)
+		assert.Equal(t, http.StatusOK, status)
+	})
+}
+
+// TestSQS_GetQueueAttributes_SeededConsistencyWindow covers the second operation.
+// AWS documents QueueDoesNotExist on both, and a consumer that polls attributes
+// rather than the URL needs the same window.
+func TestSQS_GetQueueAttributes_SeededConsistencyWindow(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createSQSQueue(t, srv, "attr-q")
+		seedSQSConsistency(t, srv, map[string]any{"queueName": "attr-q", "getAttributesMisses": 1})
+
+		status, code := getQueueAttributes(t, srv, queueURL, jsonProto)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "QueueDoesNotExist", code)
+
+		status, _ = getQueueAttributes(t, srv, queueURL, jsonProto)
+		assert.Equal(t, http.StatusOK, status)
+	})
+}
+
+// TestSQS_Consistency_CountersAreIndependent pins that seeding one operation does
+// not perturb the other, so a test can exercise one retry loop in isolation.
+func TestSQS_Consistency_CountersAreIndependent(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createSQSQueue(t, srv, "indep-q")
+	seedSQSConsistency(t, srv, map[string]any{"queueName": "indep-q", "getUrlMisses": 1})
+
+	// GetQueueAttributes was not seeded, so it resolves immediately...
+	status, _ := getQueueAttributes(t, srv, queueURL, false)
+	assert.Equal(t, http.StatusOK, status, "unseeded GetQueueAttributes must not consume the GetQueueUrl budget")
+
+	// ...and the GetQueueUrl budget is still intact.
+	status, code := getQueueURL(t, srv, "indep-q", false)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "QueueDoesNotExist", code)
+
+	status, _ = getQueueURL(t, srv, "indep-q", false)
+	assert.Equal(t, http.StatusOK, status)
+}
+
+// TestSQS_GetQueueUrl_UnseededIsInstant is the "unseeded behavior is unchanged"
+// criterion: without a seed, a queue is resolvable the moment it is created.
+func TestSQS_GetQueueUrl_UnseededIsInstant(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createSQSQueue(t, srv, "instant-q")
+
+		status, _ := getQueueURL(t, srv, "instant-q", jsonProto)
+		assert.Equal(t, http.StatusOK, status)
+
+		status, _ = getQueueAttributes(t, srv, queueURL, jsonProto)
+		assert.Equal(t, http.StatusOK, status)
+	})
+}
+
+// TestSQS_Consistency_AbsentQueueDoesNotConsumeMisses pins the ordering rule: a
+// miss is consumed only when the queue actually exists. Otherwise a seed set
+// before CreateQueue would be silently spent by the lookups that precede it, and
+// the retry assertion the seed exists for would pass without ever exercising the
+// window.
+func TestSQS_Consistency_AbsentQueueDoesNotConsumeMisses(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+
+	// Seed before the queue exists — the natural order for a harness setting up a
+	// create→lookup→retry test.
+	seedSQSConsistency(t, srv, map[string]any{"queueName": "later-q", "getUrlMisses": 1})
+
+	// Genuinely absent: fails, but must not spend the budget.
+	status, code := getQueueURL(t, srv, "later-q", false)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "QueueDoesNotExist", code)
+
+	createSQSQueue(t, srv, "later-q")
+
+	// Now the seeded window applies.
+	status, code = getQueueURL(t, srv, "later-q", false)
+	assert.Equal(t, http.StatusBadRequest, status, "the seeded miss must survive the absent-queue lookup")
+	assert.Equal(t, "QueueDoesNotExist", code)
+
+	status, _ = getQueueURL(t, srv, "later-q", false)
+	assert.Equal(t, http.StatusOK, status)
+}
+
+// TestSQS_Consistency_DoesNotRearmOnCreateQueue pins that a seed counts down the
+// next N misses rather than re-arming per create. createQueue is unconditionally
+// idempotent — it early-returns the existing URL — so "after its CreateQueue" is
+// ambiguous when create runs twice, and re-arming would make the data path write
+// control-plane state.
+func TestSQS_Consistency_DoesNotRearmOnCreateQueue(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	createSQSQueue(t, srv, "rearm-q")
+	seedSQSConsistency(t, srv, map[string]any{"queueName": "rearm-q", "getUrlMisses": 1})
+
+	status, _ := getQueueURL(t, srv, "rearm-q", false)
+	require.Equal(t, http.StatusBadRequest, status)
+
+	// A second CreateQueue must not restore the budget.
+	createSQSQueue(t, srv, "rearm-q")
+
+	status, _ = getQueueURL(t, srv, "rearm-q", false)
+	assert.Equal(t, http.StatusOK, status, "CreateQueue must not re-arm a spent seed")
+}
+
+// TestSQS_Consistency_Wildcard covers a seed with no queueName, which applies to
+// any queue — useful for a harness that wants every lookup in a suite to face the
+// window without naming each queue.
+func TestSQS_Consistency_Wildcard(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	createSQSQueue(t, srv, "wild-a")
+	createSQSQueue(t, srv, "wild-b")
+	seedSQSConsistency(t, srv, map[string]any{"getUrlMisses": 2})
+
+	// The budget is on the wildcard seed itself, so the two queues share it.
+	status, code := getQueueURL(t, srv, "wild-a", false)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "QueueDoesNotExist", code)
+
+	status, _ = getQueueURL(t, srv, "wild-b", false)
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	status, _ = getQueueURL(t, srv, "wild-a", false)
+	assert.Equal(t, http.StatusOK, status)
+}
+
+// TestSQS_Consistency_NameTakesPrecedenceOverWildcard pins the resolution order:
+// an exact name match is consulted before the wildcard.
+func TestSQS_Consistency_NameTakesPrecedenceOverWildcard(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	createSQSQueue(t, srv, "named-q")
+	createSQSQueue(t, srv, "other-q")
+	seedSQSConsistency(t, srv, map[string]any{"queueName": "named-q", "getUrlMisses": 1})
+	seedSQSConsistency(t, srv, map[string]any{"getUrlMisses": 1})
+
+	// named-q spends its own seed, leaving the wildcard budget untouched.
+	status, _ := getQueueURL(t, srv, "named-q", false)
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	// A second named-q lookup falls through to the wildcard, which still has one.
+	status, _ = getQueueURL(t, srv, "named-q", false)
+	assert.Equal(t, http.StatusBadRequest, status,
+		"an exhausted name-scoped seed must not mask a wildcard seed that still has budget")
+
+	status, _ = getQueueURL(t, srv, "named-q", false)
+	assert.Equal(t, http.StatusOK, status)
+
+	// The wildcard is now spent, so an unrelated queue is unaffected.
+	status, _ = getQueueURL(t, srv, "other-q", false)
+	assert.Equal(t, http.StatusOK, status)
+}
+
+// TestSQS_Consistency_Clear covers DELETE with and without ?queueName.
+func TestSQS_Consistency_Clear(t *testing.T) {
+	t.Run("by name", func(t *testing.T) {
+		srv, _ := newSQSTestServer(t)
+		createSQSQueue(t, srv, "clear-q")
+		seedSQSConsistency(t, srv, map[string]any{"queueName": "clear-q", "getUrlMisses": 5})
+		clearSQSConsistency(t, srv, "clear-q")
+
+		status, _ := getQueueURL(t, srv, "clear-q", false)
+		assert.Equal(t, http.StatusOK, status)
+	})
+
+	t.Run("all", func(t *testing.T) {
+		srv, _ := newSQSTestServer(t)
+		createSQSQueue(t, srv, "clear-a")
+		createSQSQueue(t, srv, "clear-b")
+		seedSQSConsistency(t, srv, map[string]any{"queueName": "clear-a", "getUrlMisses": 5})
+		seedSQSConsistency(t, srv, map[string]any{"queueName": "clear-b", "getUrlMisses": 5})
+		seedSQSConsistency(t, srv, map[string]any{"getUrlMisses": 5})
+		clearSQSConsistency(t, srv, "")
+
+		for _, name := range []string{"clear-a", "clear-b"} {
+			status, _ := getQueueURL(t, srv, name, false)
+			assert.Equal(t, http.StatusOK, status, name)
+		}
+	})
+}
+
+// TestSQS_Consistency_RejectsNegative covers control-plane validation. A negative
+// count would otherwise sit in the store forever answering "no misses left",
+// looking like a seed that silently did nothing.
+func TestSQS_Consistency_RejectsNegative(t *testing.T) {
+	tests := []struct {
+		name string
+		body map[string]any
+	}{
+		{"negative getUrlMisses", map[string]any{"queueName": "neg-q", "getUrlMisses": -1}},
+		{"negative getAttributesMisses", map[string]any{"queueName": "neg-q", "getAttributesMisses": -3}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			body, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			r := httptest.NewRequest(http.MethodPost, "/v1/sqs/consistency", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, r)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+// TestSQS_Consistency_ConcurrentGetQueueUrl is the test that fails without the
+// striped mutex in sqsQueueMutex. Consuming a miss is a read-modify-write and
+// StateManager has no compare-and-swap, so concurrent lookups could each read the
+// same count and each write count-1, consuming one miss where several were seeded.
+//
+// Run with -race. If this ever passes with the lock removed, it is not driving
+// enough concurrency — check that before trusting it.
+func TestSQS_Consistency_ConcurrentGetQueueUrl(t *testing.T) {
+	const n = 32
+
+	srv, _ := newSQSTestServer(t)
+	createSQSQueue(t, srv, "conc-q")
+	seedSQSConsistency(t, srv, map[string]any{"queueName": "conc-q", "getUrlMisses": n})
+
+	var (
+		mu       sync.Mutex
+		misses   int
+		start    = make(chan struct{})
+		wg       sync.WaitGroup
+		statuses = make([]int, n)
+	)
+	for i := range n {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start // maximize the overlap on the read-modify-write
+			resp := sqsRequest(t, srv, map[string]string{"Action": "GetQueueUrl", "QueueName": "conc-q"})
+			resp.Body.Close() //nolint:errcheck
+			statuses[idx] = resp.StatusCode
+			if resp.StatusCode == http.StatusBadRequest {
+				mu.Lock()
+				misses++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	// Exactly the seeded number of misses: no double-spend, and none lost.
+	assert.Equal(t, n, misses, "every seeded miss must be consumed exactly once")
+
+	// The budget is now spent, so the next lookup resolves.
+	status, _ := getQueueURL(t, srv, "conc-q", false)
+	assert.Equal(t, http.StatusOK, status)
+}
+
+// TestSQS_Consistency_ResetClearsSeeds pins that seeds live in the state store and
+// are therefore wiped by POST /v1/state/reset, which is what a harness expects
+// between test cases.
+func TestSQS_Consistency_ResetClearsSeeds(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	createSQSQueue(t, srv, "reset-q")
+	seedSQSConsistency(t, srv, map[string]any{"queueName": "reset-q", "getUrlMisses": 3})
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/state/reset", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code, "reset failed: %s", w.Body.String())
+
+	// The queue is gone too, so recreate it and confirm no window remains.
+	createSQSQueue(t, srv, "reset-q")
+	status, _ := getQueueURL(t, srv, "reset-q", false)
+	assert.Equal(t, http.StatusOK, status)
+}

--- a/emulator/sqs_consistency_test.go
+++ b/emulator/sqs_consistency_test.go
@@ -2,9 +2,13 @@ package emulator_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -383,4 +387,234 @@ func TestSQS_Consistency_ResetClearsSeeds(t *testing.T) {
 	createSQSQueue(t, srv, "reset-q")
 	status, _ := getQueueURL(t, srv, "reset-q", false)
 	assert.Equal(t, http.StatusOK, status)
+}
+
+// sqsFailAfterGetsState is a StateManager that serves the first allow Get calls
+// normally and fails every one after, mirroring errAfterGetsStateManager in
+// error_protocol_test.go. Failing from the first Get is useless here: the test
+// needs CreateQueue and the seed write to succeed so the failure lands on the
+// seed lookup specifically.
+type sqsFailAfterGetsState struct {
+	inner  emulator.StateManager
+	allow  int
+	getErr error
+
+	mu   sync.Mutex
+	gets int
+}
+
+func (m *sqsFailAfterGetsState) Get(ctx context.Context, namespace, key string) ([]byte, error) {
+	m.mu.Lock()
+	m.gets++
+	over := m.gets > m.allow
+	m.mu.Unlock()
+	if over {
+		return nil, m.getErr
+	}
+	return m.inner.Get(ctx, namespace, key)
+}
+
+func (m *sqsFailAfterGetsState) Put(ctx context.Context, namespace, key string, value []byte) error {
+	return m.inner.Put(ctx, namespace, key, value)
+}
+
+func (m *sqsFailAfterGetsState) Delete(ctx context.Context, namespace, key string) error {
+	return m.inner.Delete(ctx, namespace, key)
+}
+
+func (m *sqsFailAfterGetsState) List(ctx context.Context, namespace, prefix string) ([]string, error) {
+	return m.inner.List(ctx, namespace, prefix)
+}
+
+// sqsAlwaysFailState fails whichever single operation the test names, so the
+// control-plane handlers' error paths can be reached individually.
+type sqsAlwaysFailState struct {
+	emulator.StateManager
+	putErr    error
+	deleteErr error
+	listErr   error
+}
+
+func (m *sqsAlwaysFailState) Put(ctx context.Context, namespace, key string, value []byte) error {
+	if m.putErr != nil {
+		return m.putErr
+	}
+	return m.StateManager.Put(ctx, namespace, key, value)
+}
+
+func (m *sqsAlwaysFailState) Delete(ctx context.Context, namespace, key string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	return m.StateManager.Delete(ctx, namespace, key)
+}
+
+func (m *sqsAlwaysFailState) List(ctx context.Context, namespace, prefix string) ([]string, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.StateManager.List(ctx, namespace, prefix)
+}
+
+// TestSQS_Consistency_StateFailureIsNotQueueDoesNotExist asserts a store failure
+// during the seed lookup propagates rather than collapsing into
+// QueueDoesNotExist. The two are opposite signals: QueueDoesNotExist is a 400
+// telling a caller the queue is gone and to stop retrying, while a store failure
+// is transient and should be retried. Reporting the former for the latter would
+// send a consumer down a permanent-failure path over a blip — and this seed
+// exists precisely so consumers can test their retry loops, so getting the
+// distinction wrong here would undercut the feature.
+func TestSQS_Consistency_StateFailureIsNotQueueDoesNotExist(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(t *testing.T, srv *emulator.Server, queueURL string) (int, string)
+	}{
+		{"GetQueueUrl", func(t *testing.T, srv *emulator.Server, _ string) (int, string) {
+			return getQueueURL(t, srv, "fail-q", false)
+		}},
+		{"GetQueueAttributes", func(t *testing.T, srv *emulator.Server, queueURL string) (int, string) {
+			return getQueueAttributes(t, srv, queueURL, false)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &sqsFailAfterGetsState{
+				inner:  emulator.NewMemoryStateManager(),
+				getErr: errors.New("state store unavailable"),
+				allow:  math.MaxInt, // permissive through setup
+			}
+			srv, _ := newSQSTestServerWithState(t, state)
+			queueURL := createSQSQueue(t, srv, "fail-q")
+			seedSQSConsistency(t, srv, map[string]any{"queueName": "fail-q", "getUrlMisses": 1, "getAttributesMisses": 1})
+
+			// Let the queue lookup succeed, then fail the seed lookup that
+			// follows it.
+			state.mu.Lock()
+			state.allow = state.gets + 1
+			state.mu.Unlock()
+
+			status, code := tt.call(t, srv, queueURL)
+			assert.Equal(t, http.StatusInternalServerError, status,
+				"a store failure must not be reported as a 400")
+			assert.NotEqual(t, "QueueDoesNotExist", code,
+				"a store failure must not be indistinguishable from an absent queue")
+		})
+	}
+}
+
+// TestSQS_Consistency_ControlPlaneStateFailures covers the control plane's own
+// error paths. A seed that silently fails to persist is worse than no seed at
+// all: the harness proceeds believing the window is armed, the lookups all
+// succeed, and the retry assertion passes vacuously — the exact failure mode
+// #413 was filed about.
+func TestSQS_Consistency_ControlPlaneStateFailures(t *testing.T) {
+	boom := errors.New("state store unavailable")
+
+	tests := []struct {
+		name  string
+		state func() emulator.StateManager
+		req   func() *http.Request
+	}{
+		{
+			name: "seed put fails",
+			state: func() emulator.StateManager {
+				return &sqsAlwaysFailState{StateManager: emulator.NewMemoryStateManager(), putErr: boom}
+			},
+			req: func() *http.Request {
+				return httptest.NewRequest(http.MethodPost, "/v1/sqs/consistency",
+					strings.NewReader(`{"queueName":"put-q","getUrlMisses":1}`))
+			},
+		},
+		{
+			name: "clear one delete fails",
+			state: func() emulator.StateManager {
+				return &sqsAlwaysFailState{StateManager: emulator.NewMemoryStateManager(), deleteErr: boom}
+			},
+			req: func() *http.Request {
+				return httptest.NewRequest(http.MethodDelete, "/v1/sqs/consistency?queueName=del-q", nil)
+			},
+		},
+		{
+			name: "clear all list fails",
+			state: func() emulator.StateManager {
+				return &sqsAlwaysFailState{StateManager: emulator.NewMemoryStateManager(), listErr: boom}
+			},
+			req: func() *http.Request {
+				return httptest.NewRequest(http.MethodDelete, "/v1/sqs/consistency", nil)
+			},
+		},
+		{
+			name: "clear all delete fails",
+			state: func() emulator.StateManager {
+				return &sqsAlwaysFailState{StateManager: emulator.NewMemoryStateManager(), deleteErr: boom}
+			},
+			req: func() *http.Request {
+				return httptest.NewRequest(http.MethodDelete, "/v1/sqs/consistency", nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := tt.state()
+			srv, _ := newSQSTestServerWithState(t, state)
+
+			// "clear all delete fails" needs a seed present for List to return a
+			// key to delete, so write one behind the failing wrapper.
+			if tt.name == "clear all delete fails" {
+				require.NoError(t, emulator.SQSSeedForTest(state, "seeded-q", 1, 0))
+			}
+
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, tt.req())
+			assert.Equal(t, http.StatusInternalServerError, w.Code, "body was %s", w.Body.String())
+		})
+	}
+}
+
+// TestSQS_Consistency_MalformedSeedBody covers a body the control plane cannot
+// decode, which must be rejected rather than silently stored as a zero seed.
+func TestSQS_Consistency_MalformedSeedBody(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/sqs/consistency", strings.NewReader(`{"queueName":`))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestSQS_Consistency_CorruptStoredSeed covers a seed value in the store that is
+// not valid JSON. It must surface as an error rather than being read as "no
+// misses left", which would look like a seed that silently did nothing.
+func TestSQS_Consistency_CorruptStoredSeed(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	srv, _ := newSQSTestServerWithState(t, state)
+	createSQSQueue(t, srv, "corrupt-q")
+	require.NoError(t, emulator.SQSPutRawSeedForTest(state, "corrupt-q", []byte("{not json")))
+
+	status, code := getQueueURL(t, srv, "corrupt-q", false)
+	assert.Equal(t, http.StatusInternalServerError, status)
+	assert.NotEqual(t, "QueueDoesNotExist", code)
+}
+
+// TestSQS_QueueNameFromURL covers the derivation GetQueueAttributes depends on,
+// including the degenerate forms an operation can be handed.
+func TestSQS_QueueNameFromURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"standard", "http://sqs.us-east-1.localhost/000000000000/my-q", "my-q"},
+		{"trailing slash", "http://sqs.us-east-1.localhost/000000000000/my-q/", "my-q"},
+		{"bare name, no separator", "my-q", "my-q"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, emulator.SQSQueueNameFromURLForTest(tt.url))
+		})
+	}
 }

--- a/emulator/sqs_control.go
+++ b/emulator/sqs_control.go
@@ -1,0 +1,215 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// sqsCtrlNamespace is the state namespace for SQS control-plane (seed) data.
+const sqsCtrlNamespace = "sqs-ctrl"
+
+// sqsQueueLockStripes is the number of mutexes in [SQSPlugin]'s per-queue stripe
+// set. A power of two well above the concurrency any test drives, so distinct
+// queues almost never contend.
+const sqsQueueLockStripes = 64
+
+// sqsQueueMutex is a striped mutex set serializing seed consumption per queue.
+//
+// It deliberately mirrors [s3KeyMutex] rather than reusing it: that type's API is
+// two-part (bucket, key) and its documentation is written entirely in S3 terms, so
+// sharing would mean either changing a signature used at every S3
+// conditional-write call site or adding a joined-string API that reads worse at
+// both. Roughly twenty lines of FNV striping is the cheaper duplication; extract a
+// common type on the third caller.
+//
+// The hazard is the same one s3KeyMutex exists for. Consuming a seeded miss is a
+// read-modify-write, and [StateManager] offers no compare-and-swap — Get/Put/
+// Delete/List only, with [MemoryStateManager] last-write-wins. Two concurrent
+// lookups could both read misses=1 and both write 0, consuming one miss where two
+// were seeded, so a test asserting "exactly N calls fail" would flake. Holding a
+// per-queue lock across read→decrement→Put closes that window.
+//
+// The guarantee is bounded the same way, and for the same reason: it is
+// process-local. That is airtight for substrate's single-process topology and
+// would not hold across two emulator processes sharing one state backend.
+type sqsQueueMutex struct {
+	stripes [sqsQueueLockStripes]sync.Mutex
+}
+
+// lock acquires the stripe guarding a queue name and returns its unlock function.
+func (m *sqsQueueMutex) lock(queueName string) func() {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(queueName))
+	mu := &m.stripes[h.Sum32()%sqsQueueLockStripes]
+	mu.Lock()
+	return mu.Unlock
+}
+
+// sqsConsistencySeed is a seeded create→lookup eventual-consistency window. AWS
+// documents that a caller "must wait at least one second after the queue is
+// created to be able to use the queue", so a real create→lookup→retry loop can
+// observe QueueDoesNotExist for a queue that does exist. Substrate resolves a new
+// queue instantly, which makes that retry path unreachable and a consumer's test
+// of it vacuous; seeding is what makes the window observable.
+//
+// The window is counted in misses rather than measured as a duration on purpose.
+// [TimeController.Now] advances with wall time from its baseline, so a duration
+// seed would expire partway through a test and make "still missing" assertions
+// wall-clock dependent — which no test here may be. A miss counter is exactly
+// reproducible.
+//
+// Keyed by queue name or the "*" wildcard. The two counters are independent so a
+// test can seed one operation without perturbing the other; both default to 0, so
+// an unseeded queue behaves exactly as before.
+type sqsConsistencySeed struct {
+	// QueueName the seed applies to, or "*" for any queue.
+	QueueName string `json:"queueName"`
+
+	// GetURLMisses is the number of subsequent GetQueueUrl calls that report
+	// QueueDoesNotExist even though the queue exists.
+	GetURLMisses int `json:"getUrlMisses"`
+
+	// GetAttributesMisses is the same count for GetQueueAttributes.
+	GetAttributesMisses int `json:"getAttributesMisses"`
+}
+
+// sqsCtrlKey returns the state key for a consistency seed. Queue-scoped seeds use
+// "consistency:{name}"; the wildcard uses "consistency:*".
+func sqsCtrlKey(queueName string) string {
+	if queueName == "" {
+		queueName = "*"
+	}
+	return "consistency:" + queueName
+}
+
+// sqsCtrlKeyPrefix is the key prefix for every consistency seed, used to clear all.
+const sqsCtrlKeyPrefix = "consistency:"
+
+// sqsQueueNameFromURL returns the queue name from a queue URL — its last path
+// component. GetQueueAttributes identifies a queue by URL while seeds are keyed by
+// name, so the name has to be recovered here.
+func sqsQueueNameFromURL(queueURL string) string {
+	trimmed := strings.TrimRight(queueURL, "/")
+	if idx := strings.LastIndexByte(trimmed, '/'); idx >= 0 {
+		return trimmed[idx+1:]
+	}
+	return trimmed
+}
+
+// sqsConsistencyOp names which counter on a seed an operation consumes.
+type sqsConsistencyOp int
+
+const (
+	// sqsConsistencyGetURL selects the GetQueueUrl counter.
+	sqsConsistencyGetURL sqsConsistencyOp = iota
+
+	// sqsConsistencyGetAttributes selects the GetQueueAttributes counter.
+	sqsConsistencyGetAttributes
+)
+
+// consumeQueueMiss reports whether the current call should answer
+// QueueDoesNotExist for a queue that exists, decrementing the seeded budget when
+// it does. It matches the queue name exactly first, then the "*" wildcard, and
+// returns false when no seed applies so the caller takes the nominal path.
+//
+// Callers must consult this only *after* establishing that the queue exists. A
+// miss consumed on a genuinely absent queue would silently burn budget the test
+// meant to spend on the window, leaving the later retry assertion meaningless.
+func (p *SQSPlugin) consumeQueueMiss(queueName string, op sqsConsistencyOp) (bool, error) {
+	unlock := p.queueMu.lock(queueName)
+	defer unlock()
+
+	goCtx := context.Background()
+	for _, key := range []string{sqsCtrlKey(queueName), sqsCtrlKey("*")} {
+		data, err := p.state.Get(goCtx, sqsCtrlNamespace, key)
+		if err != nil {
+			return false, fmt.Errorf("sqs consumeQueueMiss get: %w", err)
+		}
+		if data == nil {
+			continue
+		}
+		var seed sqsConsistencySeed
+		if err := json.Unmarshal(data, &seed); err != nil {
+			return false, fmt.Errorf("sqs consumeQueueMiss unmarshal: %w", err)
+		}
+
+		counter := &seed.GetURLMisses
+		if op == sqsConsistencyGetAttributes {
+			counter = &seed.GetAttributesMisses
+		}
+		if *counter <= 0 {
+			// This seed exists but has nothing left for this operation. Fall
+			// through to the wildcard: an exhausted name-scoped seed must not mask
+			// a wildcard seed that still has budget.
+			continue
+		}
+
+		*counter--
+		updated, err := json.Marshal(seed)
+		if err != nil {
+			return false, fmt.Errorf("sqs consumeQueueMiss marshal: %w", err)
+		}
+		if err := p.state.Put(goCtx, sqsCtrlNamespace, key, updated); err != nil {
+			return false, fmt.Errorf("sqs consumeQueueMiss put: %w", err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// handleSQSSeedConsistency handles POST /v1/sqs/consistency. It seeds how many
+// subsequent lookups report QueueDoesNotExist for a queue that exists, modeling
+// the create→lookup window AWS documents. Body:
+// {"queueName","getUrlMisses","getAttributesMisses"}; an empty queueName seeds the
+// "*" wildcard.
+func (s *Server) handleSQSSeedConsistency(w http.ResponseWriter, r *http.Request) {
+	var seed sqsConsistencySeed
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.GetURLMisses < 0 || seed.GetAttributesMisses < 0 {
+		http.Error(w, `{"error":"getUrlMisses and getAttributesMisses must not be negative"}`, http.StatusBadRequest)
+		return
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), sqsCtrlNamespace, sqsCtrlKey(seed.QueueName), data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true, "queueName": sqsCtrlKey(seed.QueueName)})
+}
+
+// handleSQSClearConsistency handles DELETE /v1/sqs/consistency. With
+// ?queueName=... it removes that seed; without it removes all.
+func (s *Server) handleSQSClearConsistency(w http.ResponseWriter, r *http.Request) {
+	if name := r.URL.Query().Get("queueName"); name != "" {
+		if err := s.state.Delete(r.Context(), sqsCtrlNamespace, sqsCtrlKey(name)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), sqsCtrlNamespace, sqsCtrlKeyPrefix)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), sqsCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -26,6 +26,11 @@ type SQSPlugin struct {
 	state  StateManager
 	logger Logger
 	tc     *TimeController
+
+	// queueMu serializes consumption of a seeded consistency window per queue,
+	// since decrementing the miss counter is a read-modify-write and StateManager
+	// offers no compare-and-swap. See [sqsQueueMutex].
+	queueMu sqsQueueMutex
 }
 
 // Name returns the service name "sqs".
@@ -354,6 +359,14 @@ func (p *SQSPlugin) getQueueURL(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 	if q == nil {
 		return nil, sqsQueueDoesNotExist()
 	}
+	// The queue exists, so a seeded create→lookup window may still hide it (#413).
+	// Checked only after the existence test: consuming a miss for a genuinely
+	// absent queue would burn budget the test meant to spend on the window.
+	if miss, err := p.consumeQueueMiss(name, sqsConsistencyGetURL); err != nil {
+		return nil, err
+	} else if miss {
+		return nil, sqsQueueDoesNotExist()
+	}
 
 	if sqsIsJSONProtocol(req) {
 		return sqsJSONResponse(http.StatusOK, map[string]string{"QueueUrl": q.QueueURL})
@@ -381,6 +394,13 @@ func (p *SQSPlugin) getQueueAttributes(ctx *RequestContext, req *AWSRequest) (*A
 		return nil, err
 	}
 	if q == nil {
+		return nil, sqsQueueDoesNotExist()
+	}
+	// As in getQueueURL: only after the queue is known to exist. Seeds are keyed by
+	// name, so the name is recovered from the URL this operation identifies it by.
+	if miss, err := p.consumeQueueMiss(sqsQueueNameFromURL(queueURL), sqsConsistencyGetAttributes); err != nil {
+		return nil, err
+	} else if miss {
 		return nil, sqsQueueDoesNotExist()
 	}
 

--- a/emulator/sqs_plugin_test.go
+++ b/emulator/sqs_plugin_test.go
@@ -23,9 +23,15 @@ import (
 
 func newSQSTestServer(t *testing.T) (*emulator.Server, *emulator.TimeController) {
 	t.Helper()
+	return newSQSTestServerWithState(t, emulator.NewMemoryStateManager())
+}
+
+// newSQSTestServerWithState builds the SQS test server over a caller-supplied
+// state manager, so a test can substitute a store that fails.
+func newSQSTestServerWithState(t *testing.T, state emulator.StateManager) (*emulator.Server, *emulator.TimeController) {
+	t.Helper()
 	cfg := emulator.DefaultConfig()
 	registry := emulator.NewPluginRegistry()
-	state := emulator.NewMemoryStateManager()
 	logger := emulator.NewDefaultLogger(slog.LevelInfo, false)
 	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
 	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))


### PR DESCRIPTION
Part B of #413 — the seedable consistency window. Part A (#426) corrected the error
code these tests assert on and had to land first.

AWS documents that a caller "must wait at least one second after the queue is
created to be able to use the queue", so a real `CreateQueue` → `GetQueueUrl` →
retry loop can legitimately observe `QueueDoesNotExist` for a queue that exists.
Substrate resolved a new queue instantly, which made that retry path **unreachable**
— the consumer could not exercise it offline at all, so a suite asserting on it
passed without ever running the loop.

## The seed

```
POST   /v1/sqs/consistency   {"queueName":"run-q","getUrlMisses":2}
DELETE /v1/sqs/consistency?queueName=run-q     # or no query to clear all
```

Keyed by queue name or the `"*"` wildcard. `GetQueueUrl` and `GetQueueAttributes`
have **independent counters**, both defaulting to 0, so unseeded behavior is
unchanged. An exhausted name-scoped seed falls through to the wildcard, so an empty
named seed cannot mask a wildcard that still has budget.

End to end, matching how the reporter will use it:

```
POST /v1/sqs/consistency  {"queueName":"run-q","getUrlMisses":2}
CreateQueue run-q          → 200
GetQueueUrl run-q ×2       → 400 QueueDoesNotExist
GetQueueUrl run-q          → 200 + URL
```

## Counts, not durations

The issue explicitly offered "or a clock-duration form"; this is counted in misses
deliberately. `TimeController.Now` advances with **wall time** from its baseline —
it is not a frozen, manually-stepped clock — so a duration seed would expire partway
through a test and make "still missing" assertions wall-clock dependent, which
CLAUDE.md forbids outright. A miss counter is exactly reproducible.

`emulator/consistency.go` is not reusable here for that same reason plus three
others: it is evaluated in server middleware, returns HTTP 409
`InconsistentStateException` (a different error entirely), and its `primaryParam`
list has no `QueueName` candidate.

## Two ordering rules, each pinned by a test

- **A miss is consumed only after the queue is known to exist.** Seeding before
  `CreateQueue` is the natural harness order, and consuming budget on a genuinely
  absent queue would silently spend what the test meant to spend on the window.
- **A seed counts down the next N misses rather than re-arming on `CreateQueue`.**
  `createQueue` is unconditionally idempotent (it early-returns the existing URL),
  so "after its CreateQueue" is ambiguous when create runs twice, and re-arming
  would make the data path write control-plane state.

## Concurrency

Consuming a miss is a read-modify-write and `StateManager` offers no
compare-and-swap (`MemoryStateManager` is last-write-wins), so concurrent lookups
could each read `misses=1` and each write `0`, consuming one miss where several were
seeded — a test asserting "exactly N calls fail" would flake.

A striped per-queue mutex closes that window. `TestSQS_Consistency_ConcurrentGetQueueUrl`
drives 32 goroutines through one barrier and asserts exactly N misses; **it fails
3/3 runs with the lock removed** and passes `-count=3` with it restored.

`sqsQueueMutex` deliberately mirrors `s3KeyMutex` rather than generalizing it:
that type's `lock(bucket, key)` is two-part by design and its documentation is
written entirely in S3 terms, so sharing would mean changing a signature used at
every S3 conditional-write call site from inside a PR about SQS. Extract a common
type on the third caller — the doc comment says so.

## Why the seed goes through StateManager

`PluginConfig` carries only State, Logger and Options, so a plugin cannot reach
`ServerOptions` controllers. The side benefit is that `POST /v1/state/reset` wipes
seeds, which is what a harness expects between cases;
`TestSQS_Consistency_ResetClearsSeeds` pins it.

## Tests

New `emulator/sqs_consistency_test.go` — 11 tests, the protocol-sensitive ones run
under **both** query and JSON (SQS is dual-protocol and the reporter reaches it
through an SDK): the two window tests, counter independence, unseeded-is-instant,
absent-queue-does-not-consume, no-re-arm-on-create, wildcard,
name-over-wildcard precedence, clear (by name and all), negative-count rejection,
the concurrency test, and reset.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues),
`make test` (race), `cd test/e2e && go test ./...`, `make docs-reference-check`,
`make docs-versions` — all clean.

Closes #413.