### PR TITLE
chore(release): v0.81.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.81.0] - 2026-08-01
+
+A fidelity release driven by three consumer-filed issues (`objectfs`,
+`spore-host/spawn`) that share one defect with v0.80.0: **substrate returned
+success, or a confident wrong answer, where real AWS signals failure** — so the
+consumer's error branch was unreachable and their suite reported green while
+verifying nothing. Each was found the expensive way: one as a false
+`DATA_CORRUPTION` against correct application code, one as a bug that shipped and
+was caught only by a paid smoke test against real AWS, one as a retry path that
+could not be exercised offline at all.
+
 ### Added
 - The SQS create-then-lookup eventual-consistency window is now seedable via
   `POST`/`DELETE /v1/sqs/consistency`, keyed by queue name or the `"*"` wildcard
@@ -2528,7 +2539,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.80.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.81.0...HEAD
+[v0.81.0]: https://github.com/scttfrdmn/substrate/compare/v0.80.0...v0.81.0
 [v0.80.0]: https://github.com/scttfrdmn/substrate/compare/v0.76.0...v0.80.0
 [v0.76.0]: https://github.com/scttfrdmn/substrate/compare/v0.75.0...v0.76.0
 [v0.75.0]: https://github.com/scttfrdmn/substrate/compare/v0.74.0...v0.75.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,10 @@ created only after its `## [vX.Y.Z]` CHANGELOG section exists, and its version
 must be strictly greater than the latest existing tag (`git tag --sort=-v:refname
 | head -1`) — never an ancestor commit or an out-of-order number. (A stray
 out-of-order tag, `v0.67.0`, was created this way once; it is burned and
-documented as void in `SECURITY.md`. The next minor release is **v0.68.0**.)
+documented as void in `SECURITY.md`.) Derive the next version from the latest tag
+at release time rather than trusting a number written here — a pinned number goes
+stale silently, which is exactly what `scripts/check-doc-versions.sh` exists to
+catch in the docs.
 
 `main` is protected by a GitHub ruleset: all changes land via PR (no direct
 pushes), and a separate ruleset makes `refs/tags/v*` immutable (no move/delete).


### PR DESCRIPTION
Cuts **v0.81.0**. Moves the four `## [Unreleased]` entries into a dated
`## [v0.81.0]` section and adds the comparison link. No code changes.

Ships all three open issues on the v0.81.0 milestone — #406, #412, #413 — merged as
#424, #425, #426 and #427. All three were consumer-filed (`objectfs`,
`spore-host/spawn`) and share one defect class with v0.80.0: **substrate returned
success, or a confident wrong answer, where real AWS signals failure**, so the
consumer's error branch was unreachable and their suite reported green while
verifying nothing.

| Issue | Fix |
|---|---|
| #406 | `CreateMultipartUpload` now carries `Content-Encoding` to the assembled object — the two upload paths disagreed, so a compressed object above the multipart threshold round-tripped as uncompressed |
| #412 | `RunInstances` rejects a launch that resolves no AMI, checked *after* launch-template resolution |
| #413 | `QueueDoesNotExist` replaces the legacy error code (neither SDK dispatched on the old string), plus a seedable create-then-lookup consistency window |

One extra fix landed en route to #412: `parser.go` was promoting *every*
explicitly-empty query-protocol **body** parameter to the bare-key sentinel `"1"`,
because the bare-key set was derived from the URL query while being applied to
`r.Form` (query *and* body). The entire AWS Query protocol travels in the body, so
`ImageId=` arrived as `"1"` and `RunInstances` launched from an AMI named `1`. The
one-line #412 fix could not have caught it; writing the test row for the reporter's
actual wire shape did.

## Also in this PR

Corrects the Releasing section's `The next minor release is **v0.68.0**` in
`CLAUDE.md`. It was 13 versions stale and would have led a future release straight
into the out-of-order-tag mistake the same paragraph warns about. Replaced with an
instruction to derive the next version from the latest tag at release time, since a
pinned number goes stale silently — the exact failure
`scripts/check-doc-versions.sh` guards against in the docs.

## After this merges

Tag the merge commit per the documented steps: `git tag -s v0.81.0 -m "v0.81.0"`
then push the tag. Never as a side effect of a merge, and never re-cut once
published.