### PR TITLE
fix(docker): stamp emulator.Version so images report their release (#402)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,26 @@ jobs:
           cache: true
 
       - name: Build binary
-        run: go build -ldflags "-X main.version=$(git describe --tags --always --dirty)" ./cmd/substrate
+        run: |
+          VERSION="$(git describe --tags --always --dirty)"
+          go build -ldflags "-X main.version=${VERSION} -X github.com/scttfrdmn/substrate/emulator.Version=${VERSION}" ./cmd/substrate
+
+  version-stamping:
+    name: Version Stamping
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # A -X flag naming a symbol that does not exist links cleanly and leaves the
+      # variable at its default, so a wrong path is invisible until someone curls
+      # /health on a released image (#402). Assert the observable outcome.
+      - name: Check the build stamps the version the server reports
+        run: make version-check
 
   e2e:
     name: E2E Tests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,3 +44,27 @@ jobs:
           build-args: VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # CI's version-stamping job checks the -ldflags paths against the source
+      # tree; this checks the wiring only a real image can exercise — that the
+      # VERSION build-arg above actually reaches the binary. Every released image
+      # reported "dev" for five releases because nothing asserted this (#402).
+      - name: Smoke-test the published image reports its version
+        run: |
+          set -euo pipefail
+          image=$(head -1 <<<"${{ steps.meta.outputs.tags }}")
+          echo "smoke-testing $image"
+          docker run -d --name substrate-smoke -p 4566:4566 "$image"
+          for _ in $(seq 1 40); do
+            curl -fsS http://127.0.0.1:4566/health >/dev/null 2>&1 && break
+            sleep 1
+          done
+          body=$(curl -fsS http://127.0.0.1:4566/health)
+          echo "GET /health -> $body"
+          got=$(jq -r .version <<<"$body")
+          if [ "$got" != "${{ github.ref_name }}" ]; then
+            echo "::error::image reports version \"$got\", expected \"${{ github.ref_name }}\" — the VERSION build-arg is not reaching emulator.Version"
+            docker logs substrate-smoke
+            exit 1
+          fi
+          docker rm -f substrate-smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AWS::EC2::SecurityGroupEgress` rules, which resolve
   `SourceSecurityGroupId`/`DestinationSecurityGroupId` through `Ref`/`GetAtt` so
   self- and mutually-referencing groups work.
+- `make version-check` (`scripts/check-version-stamping.sh`), run by CI, builds
+  with the Dockerfile's own `-ldflags` and asserts the running server reports
+  that version (#402). It also fails if the Dockerfile and Makefile stamp
+  different symbols, or if any `-X` names a symbol that does not exist. A silent
+  `-X` is invisible at build time, so the guard asserts the observable outcome
+  rather than the spelling of the flag.
+- The Docker release workflow smoke-tests the image it just pushed, asserting
+  `/health` reports the tag being released (#402) — the build-arg wiring that
+  only a real image can exercise.
 
 ### Changed
 - `AWS::EC2::SecurityGroup` now authorizes the rules declared inline in its
@@ -60,6 +69,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which is misleading when the API actions exist and only the wiring is missing.
 
 ### Fixed
+- Published container images report their release version from `/health` and
+  `/_localstack/{health,info}` instead of `"dev"` (#402). The Dockerfile stamped
+  `github.com/scttfrdmn/substrate.Version` — the root module path, which contains
+  no Go files — while the variable those endpoints serve is
+  `github.com/scttfrdmn/substrate/emulator.Version`. The linker silently ignores
+  `-X` against a symbol that does not exist, so the build succeeded with no
+  diagnostic and every image since the endpoint was added reported `"dev"`.
+  Consumers pinning an image tag for reproducible CI had no way to confirm at
+  runtime which build answered, so a silently-wrong tag or a stale cached image
+  went unnoticed. `substrate --version` was unaffected, which is why this
+  survived so long.
 - Package documentation no longer states a plugin count or per-plugin operation
   count (#389). `emulator/doc.go` claimed 39 plugins and 23 S3 operations while
   the registry had 63 and `s3_plugin.go` 53 — the counts that #364 made

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+# The emulator path segment is load-bearing: emulator.Version is what /health and
+# /_localstack/{health,info} serve. -X against a package with no Go files (the root
+# module path) is silently ignored by the linker, so a typo here fails at runtime,
+# not at build time (#402). Keep in sync with LDFLAGS in the Makefile.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build \
-    -ldflags "-X main.version=${VERSION} -X github.com/scttfrdmn/substrate.Version=${VERSION}" \
+    -ldflags "-X main.version=${VERSION} -X github.com/scttfrdmn/substrate/emulator.Version=${VERSION}" \
     -o /substrate ./cmd/substrate
 
 # Stage 2: runtime

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-substrate build-substratelocal test lint coverage clean tidy vet bench e2e docker-build compose-up compose-down compose-logs python-test python-lint python-build vuln scan-fs scan-image scan-iac sast security docs-reference docs-reference-check docs-versions
+.PHONY: build build-substrate build-substratelocal test lint coverage clean tidy vet bench e2e docker-build compose-up compose-down compose-logs python-test python-lint python-build vuln scan-fs scan-image scan-iac sast security docs-reference docs-reference-check docs-versions version-check
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-X main.version=$(VERSION) -X github.com/scttfrdmn/substrate/emulator.Version=$(VERSION)"
@@ -51,6 +51,9 @@ docs-reference-check: ## Fail if docs/services.md is out of date with the regist
 
 docs-versions: ## Fail if docs/README pin a stale version in prose
 	./scripts/check-doc-versions.sh
+
+version-check: ## Fail if the build's -ldflags do not reach the version the server reports
+	./scripts/check-version-stamping.sh
 
 bench: ## Run benchmarks
 	go test -bench=. -benchmem -benchtime=5s ./...

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ docker compose up -d
 
 # Verify — healthy after ~15 s while SQLite initialises
 curl http://localhost:4566/health
-# {"status":"ok"}
+# {"status":"ok","version":"v0.x.y"}
 ```
 
 Point any application at `http://localhost:4566`:
@@ -79,11 +79,17 @@ Start the server (binary or Docker), then confirm it's healthy:
 
 ```bash
 curl http://localhost:4566/health
-# {"status":"ok"}
+# {"status":"ok","version":"v0.x.y"}
 
 curl http://localhost:4566/ready
 # {"status":"ready","plugins":63}
 ```
+
+`version` reports the build that is actually answering, so a pinned image tag can
+be verified at runtime — useful in CI, where a stale cached image otherwise looks
+identical to a fresh pull. Builds from source without ldflags (a plain
+`go build ./cmd/substrate`) report `dev`; `make build` and the published images
+report the release version.
 
 ## First 5 minutes: AWS CLI
 

--- a/emulator/doc.go
+++ b/emulator/doc.go
@@ -130,5 +130,13 @@
 // See examples/custom_plugin/main.go for a minimal self-contained example.
 package emulator
 
-// Version is the Substrate release version, set at build time via ldflags.
+// Version is the Substrate release version, set at build time via ldflags. It is
+// what /health and /_localstack/{health,info} report, so any build recipe that
+// stamps a version must name this symbol exactly:
+//
+//	-X github.com/scttfrdmn/substrate/emulator.Version=vX.Y.Z
+//
+// The linker silently ignores -X against a symbol that does not exist, so a wrong
+// path leaves this at "dev" with no build error (#402). scripts/check-version-stamping.sh
+// guards the recipes against that.
 var Version = "dev"

--- a/scripts/check-version-stamping.sh
+++ b/scripts/check-version-stamping.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# check-version-stamping.sh — build the substrate binary with the exact -ldflags the
+# Dockerfile uses and assert the running server reports that version.
+#
+# `go build -X` against a symbol that does not exist — a wrong package path, a
+# renamed variable — is silently ignored by the linker: no warning, no non-zero
+# exit. The stamped variable simply keeps its "dev" default, and nothing notices
+# until someone curls /health on a released image. That is exactly what happened
+# in #402: the Dockerfile stamped `github.com/scttfrdmn/substrate.Version`, a
+# module path with no Go files, so every published image reported "dev" while the
+# Makefile-built binary reported the right version.
+#
+# So this asserts the observable outcome rather than the spelling of the flag: a
+# real build, a real server, a real HTTP response. A typo in any -X path fails
+# here instead of at the next release.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SENTINEL="v9.99.99-stamptest"
+status=0
+
+fail() {
+  echo "check-version-stamping: $*" >&2
+  status=1
+}
+
+# ---------------------------------------------------------------------------
+# 1. The Dockerfile and the Makefile must stamp the same symbols.
+#
+# They are separate recipes for the same binary, so they drift silently. The
+# Makefile is the reference: it is exercised by every local `make build`.
+# ---------------------------------------------------------------------------
+extract_x_paths() {
+  # Print each -X target (the part before '=') from stdin, one per line, sorted.
+  grep -oE -- '-X [^= ]+=' | sed -e 's/^-X //' -e 's/=$//' | sort -u
+}
+
+docker_ldflags=$(grep -oE -- '-ldflags "[^"]*"' Dockerfile || true)
+make_ldflags=$(grep -oE -- '-ldflags "[^"]*"' Makefile || true)
+
+if [[ -z "$docker_ldflags" ]]; then
+  fail "no -ldflags found in Dockerfile"
+fi
+if [[ -z "$make_ldflags" ]]; then
+  fail "no -ldflags found in Makefile"
+fi
+
+docker_paths=$(extract_x_paths <<<"$docker_ldflags")
+make_paths=$(extract_x_paths <<<"$make_ldflags")
+
+if [[ "$docker_paths" != "$make_paths" ]]; then
+  fail "Dockerfile and Makefile stamp different symbols:"
+  diff <(echo "$make_paths") <(echo "$docker_paths") \
+    --label Makefile --label Dockerfile -u >&2 || true
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Every stamped symbol must actually exist.
+#
+# Catches the #402 typo directly, and reports which flag is wrong — the runtime
+# check below proves something is broken, this says what.
+# ---------------------------------------------------------------------------
+while IFS= read -r target; do
+  [[ -z "$target" ]] && continue
+  pkg="${target%.*}"
+  sym="${target##*.}"
+  if [[ "$pkg" == "main" ]]; then
+    # `-X main.Sym` targets the main package of the build, which for every recipe
+    # here is ./cmd/substrate. -u because these are conventionally unexported.
+    if ! go doc -u ./cmd/substrate "$sym" >/dev/null 2>&1; then
+      fail "-X $target: no symbol $sym in ./cmd/substrate"
+    fi
+  elif ! go doc "$pkg" "$sym" >/dev/null 2>&1; then
+    fail "-X $target: no symbol $sym in package $pkg (a -X against a missing symbol is silently ignored)"
+  fi
+done <<<"$docker_paths"
+
+# ---------------------------------------------------------------------------
+# 3. Build with the Dockerfile's flags and assert the server reports the version.
+#
+# The spelling checks above can only catch mistakes we thought of; this catches
+# any reason the version fails to reach a caller.
+# ---------------------------------------------------------------------------
+tmpdir=$(mktemp -d)
+bin="$tmpdir/substrate"
+srv_pid=""
+# shellcheck disable=SC2329  # invoked by the trap below, not by name.
+cleanup() {
+  [[ -n "$srv_pid" ]] && kill "$srv_pid" 2>/dev/null
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+# Reuse the Dockerfile's flags verbatim, with the sentinel substituted for the
+# build arg. Rewriting them here would defeat the purpose.
+ldflags=${docker_ldflags#-ldflags \"}
+ldflags=${ldflags%\"}
+ldflags=${ldflags//\$\{VERSION\}/$SENTINEL}
+
+echo "check-version-stamping: building with -ldflags \"$ldflags\""
+go build -ldflags "$ldflags" -o "$bin" ./cmd/substrate
+
+# Bind an ephemeral port by trial: the server takes an --address and does not
+# report the port it chose, so :0 gives us nothing to connect to.
+port=""
+for candidate in $(seq 14566 14600); do
+  "$bin" server --address ":$candidate" >"$tmpdir/server.log" 2>&1 &
+  srv_pid=$!
+  for _ in $(seq 1 40); do
+    if curl -fsS "http://127.0.0.1:$candidate/health" >/dev/null 2>&1; then
+      port=$candidate
+      break
+    fi
+    kill -0 "$srv_pid" 2>/dev/null || break # died — port in use, try the next
+    sleep 0.25
+  done
+  [[ -n "$port" ]] && break
+  kill "$srv_pid" 2>/dev/null
+  wait "$srv_pid" 2>/dev/null
+  srv_pid=""
+done
+
+if [[ -z "$port" ]]; then
+  echo "check-version-stamping: server never became healthy; log follows" >&2
+  cat "$tmpdir/server.log" >&2
+  exit 1
+fi
+
+# `substrate --version` reads main.version; the endpoints read emulator.Version.
+# Assert both — #402 was invisible for five releases precisely because the CLI
+# was right while the endpoints were wrong.
+cli_version=$("$bin" --version)
+if [[ "$cli_version" != *"$SENTINEL"* ]]; then
+  fail "substrate --version reported \"$cli_version\", want it to contain $SENTINEL"
+fi
+
+for path in /health /_localstack/health /_localstack/info; do
+  body=$(curl -fsS "http://127.0.0.1:$port$path")
+  # Parse without jq: this runs on a bare `make` with no assumed tooling. The
+  # sentinel is distinctive, so a loose match is safe here.
+  got=$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]*"' <<<"$body" | grep -oE '[^"]*"$' | tr -d '"')
+  if [[ "$got" != "$SENTINEL" ]]; then
+    fail "GET $path reported version \"$got\", want \"$SENTINEL\" — the -X flag is not reaching the variable this endpoint serves"
+  fi
+done
+
+if [[ "$status" -ne 0 ]]; then
+  echo "" >&2
+  echo "A -X flag naming a symbol that does not exist links cleanly and leaves the" >&2
+  echo "variable at its default. See scripts/check-version-stamping.sh and #402." >&2
+else
+  echo "check-version-stamping: ok — version $SENTINEL reported by the CLI and all health endpoints"
+fi
+exit "$status"


### PR DESCRIPTION
Fixes #402, exactly as diagnosed in the issue: `Dockerfile` stamped the root module path, which has no Go files.

```diff
--- a/Dockerfile
-    -ldflags "-X main.version=${VERSION} -X github.com/scttfrdmn/substrate.Version=${VERSION}" \
+    -ldflags "-X main.version=${VERSION} -X github.com/scttfrdmn/substrate/emulator.Version=${VERSION}" \
```

## Why it was invisible

`go build -X` against a symbol that does not exist links cleanly — no warning, no non-zero exit. The variable keeps its default. And `substrate --version` reads `main.version`, which was always stamped correctly, so the binary looked fine; only the HTTP endpoints were wrong.

Reproduced from a real image build rather than by reading the flag:

```console
# pre-fix Dockerfile, VERSION=v9.99.99-imagetest
$ curl -s localhost:.../health
{"status":"ok","version":"dev"}
$ substrate --version
substrate version v9.99.99-imagetest      # ← correct, which is why nobody noticed

# post-fix
$ curl -s localhost:.../health
{"status":"ok","version":"v9.99.99-imagetest"}
```

## Guards

The one-line fix is trivial; keeping it fixed is the actual work, since the failure mode is a typo that compiles. Three layers, each catching what the others cannot:

**`scripts/check-version-stamping.sh`** — new, wired up as `make version-check` and a CI job. It builds with the **Dockerfile's own** `-ldflags` (extracted from the file, not restated) and asserts the running server reports that version over HTTP. Plus two cheaper checks that name the culprit: Dockerfile and Makefile must stamp the same symbols, and every `-X` target must resolve via `go doc`. The runtime assertion is the load-bearing one — the spelling checks only catch mistakes I thought of.

**`docker.yml`** — smoke-tests the image it just pushed against `github.ref_name`. This is the layer CI cannot reach: the `VERSION` build-arg wiring only exists in a real image build.

**`ci.yml`** — the build job omitted `emulator.Version` entirely. Cosmetic today (that binary isn't published) but it would have drifted from the Makefile the same way, and `make version-check` would now fail on it.

Verified the guard is load-bearing rather than decorative — reverting `Dockerfile` to the buggy path:

```
check-version-stamping: Dockerfile and Makefile stamp different symbols:
-github.com/scttfrdmn/substrate/emulator.Version
+github.com/scttfrdmn/substrate.Version
check-version-stamping: -X github.com/scttfrdmn/substrate.Version: no symbol Version in package …
check-version-stamping: GET /health reported version "dev", want "v9.99.99-stamptest" …
check-version-stamping: GET /_localstack/health reported version "dev" …
check-version-stamping: GET /_localstack/info reported version "dev" …
```

All three layers fire independently.

## Docs

`emulator/doc.go` — `Version`'s comment now gives the exact `-X` path and warns that a wrong one fails silently, since that comment is what someone writing a new build recipe will read.

`docs/getting-started.md` — the `/health` examples showed `{"status":"ok"}`, omitting the field this issue is about. They now show `version`, with a note that it identifies the build answering (the reporter's use case: verifying a pinned tag in CI) and that a plain `go build` reports `dev`.

## Not done

The issue's alternative suggestion — falling back to `runtime/debug.ReadBuildInfo()` so a VCS-stamped binary self-reports — is deliberately skipped. It would mask a broken `-X` rather than surface it, and the CI/release guards make the ldflags path reliable. Worth its own issue if you want `go install`-ed binaries to report a version.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race), `test/e2e`, `make docs-reference-check docs-versions version-check` — all clean. `shellcheck` clean on the new script, matching `check-doc-versions.sh`. Both workflow files re-parsed as YAML after editing. Image built and run both ways with podman, as shown above.

Closes #402