### PR TITLE
fix(s3): do not persist aws-chunked as an object's Content-Encoding (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- S3: `PutObject` and `CreateMultipartUpload` no longer record the `aws-chunked`
+  transfer encoding as the object's `Content-Encoding` (#428). A SigV4 streaming
+  upload — what every AWS SDK sends for a body it does not buffer — arrives with
+  `Content-Encoding: aws-chunked`; substrate decoded the chunk framing but stored
+  that token verbatim, so `GetObject`/`HeadObject` reported the object as
+  `aws-chunked`-encoded when the stored bytes were plain. A consumer that
+  dispatches decompression on `Content-Encoding` was handed a name that is not a
+  content codec, for content needing no decoding — and against real AWS the
+  header is absent entirely, so nothing revealed the difference until a
+  round-trip failed. A genuine codec sent alongside it (`aws-chunked, gzip`, as
+  an SDK streaming a compressed body sends) is kept, in order: dropping the
+  header wholesale would lose the codec that *is* applied, which is the #406
+  failure. Both write paths now resolve the header through one helper, so they
+  cannot drift apart on it again the way #406 did.
+
 ## [v0.82.0] - 2026-08-01
 
 EC2 Fleet support, four CloudFormation resource types that silently deployed

--- a/docs/services.md
+++ b/docs/services.md
@@ -191,14 +191,14 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers; `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums) |
+| PutObject | Supports Content-Type, metadata headers; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums) |
 | GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
 | HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
 | DeleteObject | Fires S3 notifications if configured |
 | CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums) |
 | ListObjects | Emits `<StorageClass>` per object |
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
-| CreateMultipartUpload | Accepts `x-amz-storage-class`, applied to the assembled object; `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums) |
+| CreateMultipartUpload | Accepts `x-amz-storage-class`, applied to the assembled object; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums) |
 | UploadPart | Verifies the part checksum, including a trailing one — see [Additional checksums](#additional-checksums) |
 | CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums) |
 | AbortMultipartUpload | |
@@ -269,6 +269,36 @@ modeled by copying the object to a non-archival class.
 Intelligent-Tiering archive access tiers are not modeled, so the `InvalidObjectState`
 variant carrying `<StorageClass>` and `<AccessTier>` children is never returned.
 
+### Content-Encoding and aws-chunked
+
+`PutObject` and `CreateMultipartUpload` record `Content-Encoding` on the object and
+`GetObject`/`HeadObject` echo it back. **The `aws-chunked` token is stripped before
+the value is recorded**, on both write paths:
+
+| Request `Content-Encoding` | Recorded, and returned on a read |
+|---|---|
+| `gzip` | `gzip` |
+| absent | absent — no header on the response |
+| `aws-chunked` | absent |
+| `aws-chunked, gzip` | `gzip` |
+| `gzip, aws-chunked` | `gzip` |
+
+`aws-chunked` is a *transfer* encoding: it describes the chunk-signature framing a
+SigV4 streaming upload arrived in, which substrate decodes before storing the body
+(see [Additional checksums](#additional-checksums) for the trailer that framing
+carries). The bytes at rest are plain, and the API reference defines
+`Content-Encoding` as "what content encodings have been applied to the object and
+thus what decoding mechanisms must be applied" — so persisting `aws-chunked` would
+hand a consumer a codec name for content that needs no decoding. `PutObject` does
+not document it as persisted metadata, and `CreateMultipartUpload` scopes that value
+to directory buckets.
+
+A genuine codec alongside it is kept, in order, because an SDK streaming a
+compressed body sends both tokens and dropping the header wholesale would lose the
+codec that *is* applied to the stored object.
+
+The header name is matched case-insensitively on both paths.
+
 ### Copying objects
 
 `CopyObject`'s metadata behaviour is governed by two independent directives, both
@@ -291,6 +321,10 @@ The loss case is `REPLACE`: "you must explicitly specify all of the user-configu
 metadata present on the source object in your request, even if you are changing only
 one of the metadata values". A `REPLACE` that omits `Content-Encoding` drops it, and
 `Content-Type` falls back to `application/octet-stream`.
+
+`CopyObject` applies no `aws-chunked` filtering of its own and does not need to:
+under `COPY` it inherits the source object's already-filtered value, and a copy
+request carries no body, so no SDK sends a transfer encoding on it.
 
 `x-amz-tagging-directive` works the same way for the tag-set: `COPY` (the default)
 carries the source's tags, `REPLACE` takes them from `x-amz-tagging` as URL query
@@ -470,7 +504,7 @@ is assembled:
 | Supplied at Create | Applied to the assembled object |
 |---|---|
 | `Content-Type` | yes (defaults to `application/octet-stream`) |
-| `Content-Encoding` | yes |
+| `Content-Encoding` | yes, less any `aws-chunked` token — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked) |
 | `x-amz-storage-class` | yes (empty means `STANDARD`) |
 | `x-amz-checksum-algorithm` | yes — see [Additional checksums](#additional-checksums) |
 | `x-amz-meta-*` | yes |

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -36,6 +36,14 @@ func NormalizeS3VirtualHostForTest(host, urlPath string) (bucket, normPath strin
 	return normalizeS3VirtualHost(host, urlPath)
 }
 
+// S3PersistedContentEncodingForTest wraps s3PersistedContentEncoding for external
+// tests. Header casing cannot be varied through the HTTP test helpers — net/http
+// canonicalizes on the way in — so the case-insensitive resolution is only
+// observable from here.
+func S3PersistedContentEncodingForTest(headers map[string]string) string {
+	return s3PersistedContentEncoding(headers)
+}
+
 // ExtractRegionFromHostForTest wraps extractRegionFromHost for external tests.
 func ExtractRegionFromHostForTest(host string) string { return extractRegionFromHost(host) }
 

--- a/emulator/s3_multipart_test.go
+++ b/emulator/s3_multipart_test.go
@@ -401,16 +401,26 @@ func TestS3_CompleteMultipartUpload_WrongBucketOrKey(t *testing.T) {
 // net/http, which canonicalizes on the way in, so a lowercase-header case would
 // assert nothing about the plugin. createMultipartUpload resolves the header
 // case-insensitively for the benefit of in-process callers that build an
-// AWSRequest directly.
+// AWSRequest directly; TestS3PersistedContentEncoding_HeaderCasing covers that
+// directly.
+//
+// The aws-chunked rows pin #428 on this path too. Both write paths share
+// s3PersistedContentEncoding precisely so they cannot disagree about this header
+// again — which is what #406 was — so both are asserted rather than trusting the
+// shared call.
 func TestS3_Multipart_ContentEncoding(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		encoding string
+		name string
+		sent string // Content-Encoding on CreateMultipartUpload; "" means absent.
+		want string // Content-Encoding on the assembled object; "" means not emitted.
 	}{
-		{"gzip", "gzip"},
-		{"zstd", "zstd"},
-		{"brotli", "br"},
-		{"absent", ""},
+		{"gzip", "gzip", "gzip"},
+		{"zstd", "zstd", "zstd"},
+		{"brotli", "br", "br"},
+		{"absent", "", ""},
+		{"aws-chunked alone dropped", "aws-chunked", ""},
+		{"aws-chunked before codec", "aws-chunked, gzip", "gzip"},
+		{"aws-chunked after codec", "gzip, aws-chunked", "gzip"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			srv, _ := newS3TestServer(t)
@@ -421,8 +431,8 @@ func TestS3_Multipart_ContentEncoding(t *testing.T) {
 			// encoding was not, and that asymmetry is what made the bug look like an
 			// application fault rather than an emulator gap.
 			headers := map[string]string{"x-amz-meta-original-size": "999"}
-			if tc.encoding != "" {
-				headers["Content-Encoding"] = tc.encoding
+			if tc.sent != "" {
+				headers["Content-Encoding"] = tc.sent
 			}
 			iw := s3Request(t, srv, http.MethodPost, "/mpu-enc/big?uploads", nil, headers)
 			require.Equal(t, http.StatusOK, iw.Code, "initiate multipart upload")
@@ -447,7 +457,7 @@ func TestS3_Multipart_ContentEncoding(t *testing.T) {
 			for _, method := range []string{http.MethodHead, http.MethodGet} {
 				w := s3Request(t, srv, method, "/mpu-enc/big", nil, nil)
 				require.Equal(t, http.StatusOK, w.Code, method)
-				assert.Equal(t, tc.encoding, w.Header().Get("Content-Encoding"),
+				assert.Equal(t, tc.want, w.Header().Get("Content-Encoding"),
 					"%s Content-Encoding", method)
 				assert.Equal(t, "999", w.Header().Get("X-Amz-Meta-Original-Size"),
 					"%s user metadata must survive alongside the encoding", method)

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -520,7 +520,7 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		Key:             key,
 		ETag:            etag,
 		ContentType:     contentType,
-		ContentEncoding: req.Headers["Content-Encoding"],
+		ContentEncoding: s3PersistedContentEncoding(req.Headers),
 		Size:            int64(len(body)),
 		StorageClass:    storageClass,
 		Checksum:        checksum,
@@ -1303,7 +1303,7 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		Bucket:            bucket,
 		Key:               key,
 		ContentType:       contentType,
-		ContentEncoding:   headerValueFold(req.Headers, "Content-Encoding"),
+		ContentEncoding:   s3PersistedContentEncoding(req.Headers),
 		StorageClass:      storageClass,
 		ChecksumAlgorithm: checksumAlgorithm,
 		ChecksumType:      checksumType,
@@ -1867,12 +1867,17 @@ func headerValueFold(headers map[string]string, name string) string {
 	return ""
 }
 
+// s3AWSChunkedEncoding is the Content-Encoding token the AWS SDKs use to mark a
+// SigV4 streaming request body. It is lowercase so it can be compared against a
+// lowercased header value directly.
+const s3AWSChunkedEncoding = "aws-chunked"
+
 // isAWSChunked reports whether the request body is SigV4 streaming (aws-chunked)
 // encoded, per its headers. The AWS SDKs signal this with Content-Encoding
 // aws-chunked and/or an x-amz-content-sha256 of STREAMING-*, alongside
 // x-amz-decoded-content-length giving the true payload size.
 func isAWSChunked(headers map[string]string) bool {
-	if strings.Contains(strings.ToLower(headerValueFold(headers, "Content-Encoding")), "aws-chunked") {
+	if strings.Contains(strings.ToLower(headerValueFold(headers, "Content-Encoding")), s3AWSChunkedEncoding) {
 		return true
 	}
 	if strings.HasPrefix(headerValueFold(headers, "X-Amz-Content-Sha256"), "STREAMING-") {
@@ -1880,6 +1885,45 @@ func isAWSChunked(headers map[string]string) bool {
 	}
 	// A decoded-content-length header is only sent for aws-chunked bodies.
 	return headerValueFold(headers, "X-Amz-Decoded-Content-Length") != ""
+}
+
+// s3PersistedContentEncoding returns the Content-Encoding to record on an object,
+// resolved case-insensitively from the request headers with any aws-chunked token
+// removed.
+//
+// aws-chunked is a transfer encoding, not a content encoding: it describes the
+// chunk-signature framing the body arrived in, which substrate has already stripped
+// by the time an object is written (see [decodeAWSChunked]). AWS documents
+// Content-Encoding as "what content encodings have been applied to the object and
+// thus what decoding mechanisms must be applied" — the object at rest is plain
+// bytes, so persisting aws-chunked would hand a consumer a codec name for content
+// that is not encoded (#428). PutObject's reference never lists aws-chunked as
+// persisted metadata, and CreateMultipartUpload scopes that value to directory
+// buckets.
+//
+// SDKs may send it alongside a genuine codec ("aws-chunked, gzip" when a compressed
+// body is streamed), so the remaining codecs are kept in order. A value with nothing
+// to strip is returned verbatim, spacing included.
+//
+// Both write paths that capture the header — putObject and createMultipartUpload —
+// use this, deliberately: the two having drifted apart on this exact header is what
+// #406 was. CopyObject is not a caller. Its COPY branch inherits the source
+// object's already-filtered value, and its REPLACE branch takes headers from a
+// request that carries no body, so no SDK sends a transfer encoding there.
+func s3PersistedContentEncoding(headers map[string]string) string {
+	value := headerValueFold(headers, "Content-Encoding")
+	if !strings.Contains(strings.ToLower(value), s3AWSChunkedEncoding) {
+		return value
+	}
+	kept := make([]string, 0, 2)
+	for _, token := range strings.Split(value, ",") {
+		token = strings.TrimSpace(token)
+		if token == "" || strings.EqualFold(token, s3AWSChunkedEncoding) {
+			continue
+		}
+		kept = append(kept, token)
+	}
+	return strings.Join(kept, ", ")
 }
 
 // decodeAWSChunked decodes a SigV4 streaming (aws-chunked) request body into the

--- a/emulator/s3_plugin_test.go
+++ b/emulator/s3_plugin_test.go
@@ -921,9 +921,23 @@ func TestS3_GetHeadObject_DeleteMarker(t *testing.T) {
 	assert.Contains(t, getVer.Body.String(), "MethodNotAllowed")
 }
 
+// awsChunkedSignedBody wraps payload in single-chunk aws-chunked framing with
+// per-chunk signatures:
+// "<hexlen>;chunk-signature=...\r\n<data>\r\n0;chunk-signature=...\r\n\r\n".
+//
+// awsChunkedBody in s3_checksum_test.go frames the unsigned, trailer-carrying
+// variant; both wire shapes are real, and this is the one a SigV4 SDK upload sends.
+func awsChunkedSignedBody(payload string) []byte {
+	return []byte(fmt.Sprintf("%x;chunk-signature=%s\r\n%s\r\n0;chunk-signature=%s\r\n\r\n",
+		len(payload), strings.Repeat("a", 64), payload, strings.Repeat("b", 64)))
+}
+
 // TestS3_PutObject_AWSChunked is a regression test for #321: a SigV4 streaming
 // (aws-chunked) PutObject body must be decoded before storage, not stored raw
 // with its chunk-signature framing. The AWS SDK .NET sends bodies this way.
+//
+// It also pins the other half of that decode (#428): having stripped the framing,
+// the object must not go on advertising the transfer encoding that carried it.
 func TestS3_PutObject_AWSChunked(t *testing.T) {
 	t.Parallel()
 	srv, _ := newS3TestServer(t)
@@ -931,9 +945,7 @@ func TestS3_PutObject_AWSChunked(t *testing.T) {
 	s3Request(t, srv, http.MethodPut, "/chunk-bucket", nil, nil)
 
 	payload := "hello world"
-	// Single-chunk aws-chunked body: "<hexlen>;chunk-signature=...\r\n<data>\r\n0;chunk-signature=...\r\n\r\n"
-	chunked := fmt.Sprintf("%x;chunk-signature=%s\r\n%s\r\n0;chunk-signature=%s\r\n\r\n",
-		len(payload), strings.Repeat("a", 64), payload, strings.Repeat("b", 64))
+	chunked := awsChunkedSignedBody(payload)
 
 	hdrs := map[string]string{
 		"Content-Type":                 "text/plain",
@@ -941,7 +953,7 @@ func TestS3_PutObject_AWSChunked(t *testing.T) {
 		"X-Amz-Content-Sha256":         "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
 		"X-Amz-Decoded-Content-Length": strconv.Itoa(len(payload)),
 	}
-	put := s3Request(t, srv, http.MethodPut, "/chunk-bucket/key", []byte(chunked), hdrs)
+	put := s3Request(t, srv, http.MethodPut, "/chunk-bucket/key", chunked, hdrs)
 	require.Equal(t, http.StatusOK, put.Code)
 
 	// GetObject must return the decoded payload, not the chunk framing.
@@ -951,11 +963,96 @@ func TestS3_PutObject_AWSChunked(t *testing.T) {
 	assert.NotContains(t, get.Body.String(), "chunk-signature")
 	assert.Equal(t, strconv.Itoa(len(payload)), get.Header().Get("Content-Length"))
 
+	// The body is plaintext at rest, so nothing may claim it is encoded. A consumer
+	// that dispatches decompression on Content-Encoding would otherwise be handed
+	// "aws-chunked" — not a content codec — for bytes needing no decoding at all.
+	head := s3Request(t, srv, http.MethodHead, "/chunk-bucket/key", nil, nil)
+	require.Equal(t, http.StatusOK, head.Code)
+	assert.Empty(t, get.Header().Get("Content-Encoding"), "GET Content-Encoding")
+	assert.Empty(t, head.Header().Get("Content-Encoding"), "HEAD Content-Encoding")
+
 	// A normal (non-chunked) PutObject is unaffected — body stored verbatim.
 	s3Request(t, srv, http.MethodPut, "/chunk-bucket/plain", []byte("raw bytes"),
 		map[string]string{"Content-Type": "text/plain"})
 	plain := s3Request(t, srv, http.MethodGet, "/chunk-bucket/plain", nil, nil)
 	assert.Equal(t, "raw bytes", plain.Body.String())
+}
+
+// TestS3_PutObject_PersistedContentEncoding asserts which Content-Encoding a
+// PutObject records: aws-chunked is dropped as a transfer encoding, any genuine
+// codec beside it is kept (#428).
+//
+// SDKs streaming a compressed body send both tokens, so dropping the header
+// wholesale would lose the codec — the #406 failure — while keeping it whole
+// reports a codec that was never applied to the stored bytes. Both are asserted
+// on HEAD and GET, the two reads a consumer dispatches decompression from.
+func TestS3_PutObject_PersistedContentEncoding(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		sent string // Content-Encoding on the request; "" means absent.
+		want string // Content-Encoding on the stored object; "" means not emitted.
+	}{
+		{"plain codec kept", "gzip", "gzip"},
+		{"absent stays absent", "", ""},
+		{"aws-chunked alone dropped", "aws-chunked", ""},
+		{"aws-chunked before codec", "aws-chunked, gzip", "gzip"},
+		{"aws-chunked after codec", "gzip, aws-chunked", "gzip"},
+		{"aws-chunked unspaced list", "aws-chunked,zstd", "zstd"},
+		{"aws-chunked mixed case", "AWS-Chunked, br", "br"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/pce", nil, nil).Code, "create bucket")
+
+			payload := "compressible payload"
+			hdrs := map[string]string{"Content-Type": "application/octet-stream"}
+			body := []byte(payload)
+			if tc.sent != "" {
+				hdrs["Content-Encoding"] = tc.sent
+			}
+			// A request naming aws-chunked really is chunk-framed, so the body has to
+			// match or the decode under test would be fed the wrong bytes.
+			if strings.Contains(strings.ToLower(tc.sent), "aws-chunked") {
+				body = awsChunkedSignedBody(payload)
+				hdrs["X-Amz-Content-Sha256"] = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
+				hdrs["X-Amz-Decoded-Content-Length"] = strconv.Itoa(len(payload))
+			}
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/pce/obj", body, hdrs).Code, "put object")
+
+			for _, method := range []string{http.MethodHead, http.MethodGet} {
+				w := s3Request(t, srv, method, "/pce/obj", nil, nil)
+				require.Equal(t, http.StatusOK, w.Code, method)
+				assert.Equal(t, tc.want, w.Header().Get("Content-Encoding"),
+					"%s Content-Encoding", method)
+			}
+		})
+	}
+}
+
+// TestS3PersistedContentEncoding_HeaderCasing asserts the header name itself is
+// matched case-insensitively.
+//
+// This cannot be driven through s3Request: net/http canonicalizes header names on
+// the way in, so a lowercase key never reaches the plugin from an HTTP test and an
+// apparent test of it would assert nothing. It matters because substrate builds
+// AWSRequest values in-process too (see betty_cfn.go), where no canonicalization
+// has happened.
+func TestS3PersistedContentEncoding_HeaderCasing(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"Content-Encoding", "content-encoding", "CONTENT-ENCODING"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := emulator.S3PersistedContentEncodingForTest(map[string]string{
+				name: "aws-chunked, gzip",
+			})
+			assert.Equal(t, "gzip", got)
+		})
+	}
 }
 
 func TestS3_ListObjectsV2_Delimiter(t *testing.T) {

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -39,7 +39,8 @@ type S3Object struct {
 	// ContentEncoding is the encoding of the object body (e.g. "gzip"), set via
 	// the Content-Encoding header on PutObject or on CreateMultipartUpload —
 	// Complete accepts no metadata headers, so a multipart object's encoding is
-	// carried on the upload record from creation.
+	// carried on the upload record from creation. The aws-chunked transfer
+	// encoding is never recorded here; see [s3PersistedContentEncoding].
 	ContentEncoding string `json:"content_encoding,omitempty"`
 
 	// Size is the byte length of the object body.
@@ -149,7 +150,8 @@ type S3MultipartUpload struct {
 	// ContentEncoding is the Content-Encoding supplied at upload creation (e.g.
 	// "gzip"), applied to the object CompleteMultipartUpload assembles. Create is
 	// the only place it can be supplied: Complete accepts no object-metadata
-	// headers, so an encoding not carried here is lost for good.
+	// headers, so an encoding not carried here is lost for good. The aws-chunked
+	// transfer encoding is never recorded here; see [s3PersistedContentEncoding].
 	ContentEncoding string `json:"content_encoding,omitempty"`
 
 	// StorageClass is the storage class supplied at upload creation, applied to


### PR DESCRIPTION
A SigV4 streaming upload — what every AWS SDK sends for a body it does not buffer — arrives with `Content-Encoding: aws-chunked`. `putObject` stored that value verbatim, so `GetObject`/`HeadObject` reported the object as `aws-chunked`-encoded for bytes substrate had already dechunked.

`aws-chunked` is a *transfer* encoding — it describes the chunk-signature framing the body arrived in, not how the stored object is encoded. AWS defines `Content-Encoding` as "what content encodings have been applied to the object and thus what decoding mechanisms must be applied"; PutObject's reference never lists `aws-chunked` as persisted metadata, and CreateMultipartUpload scopes that value to directory buckets. So a consumer dispatching decompression on the header was handed a name that is not a content codec, for content needing no decoding — and real AWS omits the header entirely, so nothing revealed the difference until a round-trip failed.

## The fix

Both write paths now resolve the header through one `s3PersistedContentEncoding` helper:

| Request `Content-Encoding` | Recorded |
|---|---|
| `gzip` | `gzip` |
| absent | absent |
| `aws-chunked` | absent |
| `aws-chunked, gzip` | `gzip` |
| `gzip, aws-chunked` | `gzip` |
| `AWS-Chunked, br` | `br` |

The shared-helper shape is the point, not incidental. `putObject` and `createMultipartUpload` having drifted apart on this exact header is what #406 was; filtering in only one of them would set up the same bug again. A genuine codec sent alongside (`aws-chunked, gzip`, as an SDK streaming a compressed body sends) is kept in order — dropping the header wholesale would lose the codec that *is* applied, which is #406's failure from the other side.

`CopyObject` is deliberately not a caller: its `COPY` branch inherits the source object's already-filtered value, and a copy request carries no body, so no SDK sends a transfer encoding on it. Recorded in the helper's doc comment and in `docs/services.md` so it does not read as an oversight.

## Tests

`TestS3_PutObject_AWSChunked` now asserts the persisted value on both HEAD and GET — closing the gap that let this survive, since it sent the header but checked only `Content-Length`. New table tests cover both write paths across all the rows above.

Header-name casing is asserted through an `export_test.go` wrapper rather than an HTTP request: `net/http` canonicalizes header names on the way in, so a lowercase key never reaches the plugin from an HTTP test and an apparent test of it would assert nothing. It matters because substrate builds `AWSRequest` values in-process too (`betty_cfn.go`).

**Verified by reverting the filter**: every `aws-chunked` row fails, and the plain-codec and absent rows still pass.

## Verification

`gofmt` · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` (0 issues) · `make test` (race) · `test/e2e` · `make docs-reference-check docs-versions` — all clean.

## AWS references consulted

- [PutObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html) — `aws-chunked` appears nowhere in the request-header documentation.
- [CreateMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html) — "For directory buckets, only the `aws-chunked` value is supported in this header field", i.e. scoped to directory buckets, which substrate does not model.

Closes #428