### PR TITLE
fix(ec2): RunInstances must reject invalid MinCount/MaxCount (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   header wholesale would lose the codec that *is* applied, which is the #406
   failure. Both write paths now resolve the header through one helper, so they
   cannot drift apart on it again the way #406 did.
+- EC2: `RunInstances` validates `MinCount` and `MaxCount` instead of silently
+  clamping them (#431). Both were parsed with `strconv.Atoi`'s error discarded and
+  anything `<= 0` raised to 1, so `MinCount=0` launched an instance where real EC2
+  fails the request, and a non-numeric value launched one too. That is worse than
+  a missing error: it is a confidently wrong answer, so a consumer asserting on
+  the launched count got a green run for a request AWS rejects. A count that is
+  present but unparseable or below 1, or a `MinCount` above `MaxCount`, is now
+  `InvalidParameterValue` / HTTP 400 with the parameter named in the message.
+  **Absence still defaults**, so nothing relying on today's behaviour changes: no
+  counts means one instance, and an absent `MaxCount` defaults to `MinCount`
+  rather than to 1 — a request asking for three no longer risks launching one.
+  Validating presence would catch an unreachable bug class, since both are
+  required members that fail client-side in every typed SDK; validating *values*
+  catches a reachable one, because the query protocol carries them as strings and
+  neither botocore nor `aws-sdk-go-v2` range-checks them.
 
 ## [v0.82.0] - 2026-08-01
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -802,7 +802,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 
 | Operation | Notes |
 |-----------|-------|
-| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami) |
+| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [validates MinCount/MaxCount](#mincount-and-maxcount) |
 | DescribeInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | TerminateInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
@@ -863,6 +863,42 @@ Note that `ImageId` is an optional `*string` in the typed SDKs, so
 service rather than being caught client-side. That is the shape this check exists
 for. The AMI value itself is not format-validated — substrate accepts any
 non-empty string, so fixtures like `ami-test` work.
+
+### MinCount and MaxCount
+
+A count that is **present but invalid** fails with `InvalidParameterValue`,
+HTTP 400. A count that is **absent** still defaults.
+
+| Request | Result |
+|---|---|
+| Neither given | 1 instance |
+| `MinCount=2` alone | 2 instances — an absent `MaxCount` defaults to `MinCount`, not to 1 |
+| `MaxCount=4` alone | 4 instances |
+| `MinCount=1&MaxCount=3` | 3 instances |
+| `MinCount=0`, or either count `< 1` | `Invalid value '0' for parameter minCount. It must be at least 1.` |
+| Either count unparseable | `Invalid value 'abc' for parameter minCount. It must be an integer.` |
+| `MinCount=3&MaxCount=1` | `Invalid value '1' for parameter maxCount. The maxCount must be equal to or greater than the minCount '3'.` |
+
+A successful launch always creates `MaxCount` instances. AWS "launches the largest
+possible number of instances above the specified minimum count", and substrate
+models no capacity ceiling, so the largest possible number is always the maximum
+asked for and `MinCount` can only ever be satisfied.
+
+Absence defaults rather than erroring even though AWS marks both **Required: Yes**,
+because in every typed SDK they are required members that fail client-side — so a
+consumer bug there cannot reach the wire, while requiring presence here would break
+hand-built form-encoded requests. A value that is present and invalid *is*
+reachable: the query protocol carries these as strings, and neither botocore's
+`ParamValidator` nor `aws-sdk-go-v2` range-checks them.
+
+The error code is the common-error `InvalidParameterValue` because the RunInstances
+reference documents no action-specific error for these. `MinCount > MaxCount` uses
+it too, rather than `InvalidParameterCombination` — that code is defined as
+"Parameters that must not be used together were used together", which cannot
+describe two parameters AWS documents as used together; the defect is the *value*.
+
+The upper bound is a per-account, per-instance-type quota substrate does not model,
+so it is not enforced: any count at or above 1 is accepted.
 
 ### Explicit resource IDs
 

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -239,13 +239,19 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if instanceType == "" {
 		instanceType = "t3.micro"
 	}
-	minCount, _ := strconv.Atoi(req.Params["MinCount"])
-	if minCount <= 0 {
-		minCount = 1
-	}
-	maxCount, _ := strconv.Atoi(req.Params["MaxCount"])
-	if maxCount <= 0 {
-		maxCount = minCount
+	// Absent counts still default; a count that is present and invalid is rejected
+	// rather than clamped, because clamping MinCount=0 up to 1 launched an instance
+	// where AWS fails the request (#431). See resolveInstanceCounts for why the
+	// codes are the common-error ones and why presence is not required.
+	//
+	// Only MaxCount reaches the launch loop. AWS "launches the largest possible
+	// number of instances above the specified minimum count", and substrate models
+	// no capacity ceiling, so the largest possible number is always MaxCount and
+	// MinCount can only ever be satisfied. It is still validated, and still sets
+	// MaxCount's default, which is all it can affect here.
+	_, maxCount, countErr := resolveInstanceCounts(req.Params)
+	if countErr != nil {
+		return nil, countErr
 	}
 
 	keyName := req.Params["KeyName"]

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -3983,3 +3983,208 @@ func TestEC2_RunInstances_MissingImageId(t *testing.T) {
 		})
 	}
 }
+
+// ec2RunInstanceIDs sends a RunInstances request expected to succeed and returns
+// the instance IDs it launched, so a test can assert how many the counts asked for.
+func ec2RunInstanceIDs(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "RunInstances must succeed")
+
+	var doc struct {
+		XMLName   xml.Name `xml:"RunInstancesResponse"`
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&doc))
+
+	ids := make([]string, 0, len(doc.Instances))
+	for _, inst := range doc.Instances {
+		require.NotEmpty(t, inst.InstanceID)
+		ids = append(ids, inst.InstanceID)
+	}
+	return ids
+}
+
+// ec2DescribeInstanceIDs returns every instance ID DescribeInstances reports,
+// flattened across reservations, so a test can check what a launch actually created
+// rather than trusting the launch response alone.
+func ec2DescribeInstanceIDs(t *testing.T, ts *httptest.Server) []string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{"Action": "DescribeInstances"})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "DescribeInstances must succeed")
+
+	var doc struct {
+		XMLName      xml.Name `xml:"DescribeInstancesResponse"`
+		Reservations []struct {
+			Instances []struct {
+				InstanceID string `xml:"instanceId"`
+			} `xml:"instancesSet>item"`
+		} `xml:"reservationSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&doc))
+
+	var ids []string
+	for _, res := range doc.Reservations {
+		for _, inst := range res.Instances {
+			ids = append(ids, inst.InstanceID)
+		}
+	}
+	return ids
+}
+
+// TestEC2_RunInstances_InstanceCounts covers #431: MinCount and MaxCount were
+// parsed with the error discarded and anything <= 0 clamped up to 1, so MinCount=0
+// launched an instance where AWS fails the request. That is worse than a missing
+// error — it is a confidently wrong answer, and a consumer asserting on the launched
+// count got a green run for a request real EC2 rejects.
+//
+// The bug class is reachable from ordinary typed SDK code, which is why these are
+// validated where presence is not: the query protocol carries both as strings and
+// neither SDK range-checks them. botocore's ParamValidator accepts MinCount=0 and
+// MinCount=3/MaxCount=1 unchanged, and aws-sdk-go-v2's validateOpRunInstancesInput
+// checks only for nil.
+//
+// The codes and messages are asserted, not just the status. They were verified
+// against the RunInstances reference, which documents no action-specific error for
+// these and defers to the common errors — see resolveInstanceCounts for why that
+// resolves to InvalidParameterValue rather than the plausible-looking
+// InvalidParameterCombination, and #413 for why a plausible guess about an AWS
+// error code is not good enough to ship.
+func TestEC2_RunInstances_InstanceCounts(t *testing.T) {
+	t.Run("rejected", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			params      map[string]string
+			wantMessage string
+		}{
+			{
+				// The row the fix exists for: this used to clamp to 1 and launch.
+				name:        "MinCount zero",
+				params:      map[string]string{"MinCount": "0", "MaxCount": "1"},
+				wantMessage: "Invalid value '0' for parameter minCount. It must be at least 1.",
+			},
+			{
+				name:        "MaxCount zero",
+				params:      map[string]string{"MinCount": "1", "MaxCount": "0"},
+				wantMessage: "Invalid value '0' for parameter maxCount. It must be at least 1.",
+			},
+			{
+				name:        "MinCount negative",
+				params:      map[string]string{"MinCount": "-1", "MaxCount": "1"},
+				wantMessage: "Invalid value '-1' for parameter minCount. It must be at least 1.",
+			},
+			{
+				name:        "MaxCount negative",
+				params:      map[string]string{"MinCount": "1", "MaxCount": "-2"},
+				wantMessage: "Invalid value '-2' for parameter maxCount. It must be at least 1.",
+			},
+			{
+				name:        "MinCount not an integer",
+				params:      map[string]string{"MinCount": "abc", "MaxCount": "1"},
+				wantMessage: "Invalid value 'abc' for parameter minCount. It must be an integer.",
+			},
+			{
+				name:        "MaxCount not an integer",
+				params:      map[string]string{"MinCount": "1", "MaxCount": "2.5"},
+				wantMessage: "Invalid value '2.5' for parameter maxCount. It must be an integer.",
+			},
+			{
+				name:        "MinCount above MaxCount",
+				params:      map[string]string{"MinCount": "3", "MaxCount": "1"},
+				wantMessage: "Invalid value '1' for parameter maxCount. The maxCount must be equal to or greater than the minCount '3'.",
+			},
+			{
+				// MinCount is validated even though only MaxCount reaches the launch
+				// loop, so an out-of-range minimum cannot pass silently.
+				name:        "MinCount invalid with MaxCount absent",
+				params:      map[string]string{"MinCount": "0"},
+				wantMessage: "Invalid value '0' for parameter minCount. It must be at least 1.",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ts := newEC2TestServer(t)
+				params := map[string]string{"Action": "RunInstances", "ImageId": "ami-counts"}
+				for k, v := range tt.params {
+					params[k] = v
+				}
+
+				status, code, message := ec2ErrorDetail(t, ts, params)
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "InvalidParameterValue", code)
+				assert.Equal(t, tt.wantMessage, message)
+
+				// A rejected launch must create nothing: the failure a consumer sees
+				// has to mean no instance exists, or their cleanup path is wrong.
+				assert.Empty(t, ec2DescribeInstanceIDs(t, ts),
+					"a rejected RunInstances must not launch an instance")
+			})
+		}
+	})
+
+	t.Run("accepted", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			params map[string]string
+			want   int
+		}{
+			{
+				// The "absence still defaults" regression guard: nothing relying on
+				// today's behavior may break, and no SDK can omit these anyway.
+				name:   "both absent defaults to one",
+				params: map[string]string{},
+				want:   1,
+			},
+			{
+				name:   "both empty strings default to one",
+				params: map[string]string{"MinCount": "", "MaxCount": ""},
+				want:   1,
+			},
+			{
+				// An absent MaxCount defaults to MinCount, not to 1: a request asking
+				// for three must not silently launch one.
+				name:   "MaxCount absent defaults to MinCount",
+				params: map[string]string{"MinCount": "2"},
+				want:   2,
+			},
+			{
+				name:   "MinCount absent defaults to one",
+				params: map[string]string{"MaxCount": "4"},
+				want:   4,
+			},
+			{
+				// AWS "launches the largest possible number of instances above the
+				// specified minimum count"; substrate models no capacity ceiling, so
+				// that is always MaxCount.
+				name:   "range launches MaxCount",
+				params: map[string]string{"MinCount": "1", "MaxCount": "3"},
+				want:   3,
+			},
+			{
+				name:   "equal counts",
+				params: map[string]string{"MinCount": "2", "MaxCount": "2"},
+				want:   2,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ts := newEC2TestServer(t)
+				params := map[string]string{"Action": "RunInstances", "ImageId": "ami-counts"}
+				for k, v := range tt.params {
+					params[k] = v
+				}
+
+				ids := ec2RunInstanceIDs(t, ts, params)
+				assert.Len(t, ids, tt.want, "instances in the RunInstances response")
+				assert.Len(t, ec2DescribeInstanceIDs(t, ts), tt.want,
+					"DescribeInstances must agree with the launch response")
+			})
+		}
+	})
+}

--- a/emulator/ec2_runinstances_counts.go
+++ b/emulator/ec2_runinstances_counts.go
@@ -1,0 +1,108 @@
+package emulator
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// ec2DefaultInstanceCount is the instance count RunInstances assumes when neither
+// MinCount nor MaxCount is on the wire.
+//
+// Absence keeps defaulting rather than erroring, deliberately. AWS marks both as
+// "Required: Yes", but in every typed SDK they are required members that fail
+// client-side — MaxCount == nil is smithy.NewErrParamRequired("MaxCount") in
+// aws-sdk-go-v2's validateOpRunInstancesInput, and botocore rejects the missing
+// kwarg before serializing — so a consumer bug there cannot reach the wire.
+// Requiring presence here would validate an unreachable bug class while breaking
+// every hand-built form-encoded request, which substrate's own tests and
+// betty_cfn.go's CFN path are (#431, declined half of #412).
+const ec2DefaultInstanceCount = 1
+
+// resolveInstanceCounts returns the MinCount/MaxCount a RunInstances request asks
+// for, or the error EC2 raises when a value is present and invalid.
+//
+// A value that is present but invalid *is* reachable, which is why this validates
+// where presence does not: the query protocol carries these as strings, and neither
+// SDK checks their range. botocore's ParamValidator accepts MinCount=0 and
+// MinCount=3/MaxCount=1 unchanged, and aws-sdk-go-v2 checks only for nil — so both
+// reach the wire from ordinary typed code. Substrate previously took
+// `strconv.Atoi(...)` with the error discarded and clamped anything <= 0 up to 1, so
+// MinCount=0 launched an instance instead of failing: a silently wrong result rather
+// than a missing one.
+//
+// Error codes are the common-error entries, because the RunInstances reference
+// documents no action-specific error for these ("For information about the errors
+// that are common to all actions, see Common Error Types") and the EC2 error
+// reference lists nothing for instance counts either. InvalidParameterValue is
+// documented as "A value that you provided for a parameter isn't valid. Check the
+// parameter constraints and try again." (HTTP 400) — which is exactly an
+// out-of-range or unparseable count, given the documented constraint "Between 1 and
+// the quota for the specified instance type for your account for this Region".
+//
+// min > max uses the same code rather than InvalidParameterCombination, which the
+// same reference defines as "Parameters that must not be used together were used
+// together. Remove one of the conflicting parameters and try again." MinCount and
+// MaxCount are documented as used together, so nothing about that description fits;
+// the defect is the *value* of maxCount relative to minCount. The plausible guess
+// was InvalidParameterCombination, and #413 is why a plausible guess about an AWS
+// error code is not good enough to ship: SDK callers match the literal string.
+//
+// Messages name the parameters in the lowercase form EC2's value-error messages use
+// ("Invalid value 'x' for parameter minCount"), matching the reference's own
+// examples for this error family.
+func resolveInstanceCounts(params map[string]string) (minCount, maxCount int, err error) {
+	minCount, err = ec2InstanceCount(params, "MinCount", "minCount", ec2DefaultInstanceCount)
+	if err != nil {
+		return 0, 0, err
+	}
+	// An absent MaxCount defaults to MinCount rather than to 1: a request naming
+	// only MinCount=3 asks for three instances, and defaulting to 1 would silently
+	// cap it below the minimum the caller demanded.
+	maxCount, err = ec2InstanceCount(params, "MaxCount", "maxCount", minCount)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if minCount > maxCount {
+		return 0, 0, &AWSError{
+			Code: "InvalidParameterValue",
+			Message: fmt.Sprintf(
+				"Invalid value '%d' for parameter maxCount. The maxCount must be equal to or greater than the minCount '%d'.",
+				maxCount, minCount),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	return minCount, maxCount, nil
+}
+
+// ec2InstanceCount reads one instance-count parameter, returning def when it is
+// absent and an InvalidParameterValue error when it is present but unparseable or
+// below 1. wireName is the lowercase spelling used in the error message.
+func ec2InstanceCount(params map[string]string, param, wireName string, def int) (int, error) {
+	raw, ok := params[param]
+	if !ok || raw == "" {
+		return def, nil
+	}
+	n, convErr := strconv.Atoi(raw)
+	if convErr != nil {
+		return 0, ec2InvalidInstanceCount(raw, wireName, "It must be an integer.")
+	}
+	if n < 1 {
+		// The documented constraint is "Between 1 and the quota ...", so 0 is out of
+		// range, not a request for nothing. The upper bound is a per-account,
+		// per-instance-type quota substrate does not model, so it is not enforced.
+		return 0, ec2InvalidInstanceCount(raw, wireName, "It must be at least 1.")
+	}
+	return n, nil
+}
+
+// ec2InvalidInstanceCount builds the InvalidParameterValue error for a bad
+// instance-count value.
+func ec2InvalidInstanceCount(value, wireName, reason string) error {
+	return &AWSError{
+		Code:       "InvalidParameterValue",
+		Message:    fmt.Sprintf("Invalid value '%s' for parameter %s. %s", value, wireName, reason),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}


### PR DESCRIPTION
Closes #431

## The defect

`RunInstances` parsed both counts with `strconv.Atoi`'s error discarded and clamped anything `<= 0` up to 1:

```go
minCount, _ := strconv.Atoi(req.Params["MinCount"])
if minCount <= 0 { minCount = 1 }
```

So `MinCount=0` launched an instance where real EC2 fails the request, and `MinCount=abc` launched one too. That is worse than a missing error — it is a *confidently wrong answer*. A consumer asserting on the launched count got a green run for a request AWS rejects.

## What changed

New `emulator/ec2_runinstances_counts.go`. A count that is **present but invalid** now fails; a count that is **absent** still defaults.

| Request | Before | After |
|---|---|---|
| `MinCount=0` | 1 instance | 400 `InvalidParameterValue` |
| `MaxCount=0` | 1 instance | 400 |
| `MinCount=-1` | 1 instance | 400 |
| `MinCount=abc` | 1 instance | 400 |
| `MinCount=3&MaxCount=1` | 1 instance | 400 |
| Neither given | 1 instance | 1 instance (unchanged) |
| `MinCount=2` alone | **1 instance** | **2 instances** |
| `MinCount=1&MaxCount=3` | 3 instances | 3 instances (unchanged) |

The `MinCount=2` row is the one behavior change beyond the errors: an absent `MaxCount` defaults to `MinCount` rather than to 1, so a request asking for three no longer silently launches one.

## Why presence is not required

The declined half of #412 asked for a "quick pass for other required params". AWS marks both counts **Required: Yes**, but in every typed SDK they are required members that fail client-side — `MaxCount == nil` is `smithy.NewErrParamRequired("MaxCount")` in `aws-sdk-go-v2`'s `validateOpRunInstancesInput`, and botocore rejects the missing kwarg before serializing. A consumer bug there cannot reach the wire, so validating presence would catch an unreachable bug class while breaking every hand-built form-encoded request — which substrate's own tests and `betty_cfn.go`'s CFN path are.

Values are the opposite. Verified empirically: botocore's `ParamValidator` accepts `MinCount=0`, `MinCount=3/MaxCount=1` and `MinCount=-1` with zero validation errors, and `aws-sdk-go-v2` checks only for `nil`. Both reach the wire from ordinary typed code. That split is the whole justification for validating one and not the other.

## Error codes: verified, not guessed

Per CLAUDE.md, checked against the AWS reference — and the answer came out **different from the issue's own guess**:

- The RunInstances reference documents **no action-specific error** for these and defers to the common errors. The EC2 errors overview lists nothing for instance counts either.
- `InvalidParameterValue` is documented as "A value that you provided for a parameter isn't valid" (HTTP 400) — exactly an out-of-range or unparseable count, given the documented constraint "Between 1 and the quota for the specified instance type".
- `MinCount > MaxCount` uses the same code rather than the plausible-looking `InvalidParameterCombination`, which is defined as "Parameters that must not be used together were used together". That cannot describe two parameters AWS documents as used *together*; the defect is the **value** of `maxCount` relative to `minCount`.

#413 is why a plausible guess about an AWS error code is not good enough to ship — SDK callers match the literal string.

The upper bound is a per-account, per-instance-type quota substrate does not model, so it is not enforced.

## Only MaxCount reaches the launch loop

`resolveInstanceCounts` returns both, but `runInstances` discards `minCount`. AWS "launches the largest possible number of instances above the specified minimum count", and substrate models no capacity ceiling, so the largest possible number is always `MaxCount` and `MinCount` can only ever be satisfied. It is still validated, and still sets `MaxCount`'s default — which is all it can affect. The discard is commented as a decision rather than left as a silent drop.

## Tests

`TestEC2_RunInstances_InstanceCounts`, beside the #412 test, in two groups:

- **rejected** — 8 rows, each asserting status, code **and message**, plus that `DescribeInstances` reports nothing (a rejected launch must create nothing, or a consumer's cleanup path is wrong).
- **accepted** — 6 rows asserting the launched count on both the `RunInstances` response and `DescribeInstances`, including the two "absence still defaults" regression guards the issue asked for.

**Verified by mutation, not just by passing:**

- Restoring the old clamp → all 8 rejection rows fail, accepted rows still pass.
- Defaulting `MaxCount` to 1 instead of `MinCount` → the row pinning that fails.

## Blast radius

Zero. All 101 existing `RunInstances` test references use `MinCount=1`/`MaxCount=1` or omit both. `betty_cfn.go:2054-2055` passes `"1"`/`"1"`. `ec2_fleet.go:437-438` passes `count` for both but is guarded by `if gotPerPool[i] > 0`, so no zero can reach `runInstances` from the fleet path.

## Verification

`gofmt` · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` (0 issues) · `make test` (race) · `test/e2e` · `make docs-reference-check docs-versions` — all green.

Docs: new `### MinCount and MaxCount` section in `docs/services.md` with the behavior table and the code rationale; the `RunInstances` ops-table row cross-references it.