### PR TITLE
feat(sqs): QueueNameExists on attribute conflict, seedable QueueDeletedRecently (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- SQS: `QueueDeletedRecently` is seedable on `CreateQueue` (#429). AWS requires a
+  60-second wait after `DeleteQueue` before the same name can be reused, so a
+  consumer's delete → recreate → retry loop has a documented error to handle;
+  substrate keeps no memory of a delete, so that branch could never be exercised
+  offline. `POST /v1/sqs/consistency` now accepts `deletedRecentlyMisses`
+  alongside the existing lookup counters, keyed by queue name or the `"*"`
+  wildcard and cleared by the same `DELETE`. It is counted rather than timed for
+  the reason the lookup windows are: the real condition is a wall-clock window,
+  and a wall-clock window makes the assertion depend on how long the rest of the
+  test took. Unlike the lookup counters it applies only while the name is free —
+  `QueueDeletedRecently` describes a name too recently freed, so a create that
+  hits an existing queue is an idempotent success and does not spend the budget.
+  Unseeded behaviour is unchanged: the counter defaults to 0, so a recreate is
+  still instant.
+
 ### Fixed
+- SQS: `CreateQueue` returns `QueueNameExists` when a name is reused with
+  differing attribute values, instead of treating every repeat as idempotent
+  (#429). `createQueue` returned the existing queue's URL regardless of what the
+  request asked for, so two stacks or two test cases claiming one queue name with
+  different settings both "succeeded" and the second silently got the first one's
+  configuration — a confidently wrong answer, not a missing error, and the
+  consumer's error branch was unreachable. Only attributes **present in the
+  request** are compared, per the error's own definition ("only if the request
+  includes attributes whose values differ from those of the existing queue"); an
+  omitted attribute is no opinion, which is also what keeps a CloudFormation
+  re-deploy working, since a template forwards only the properties it declares.
+  An existing queue's unset attributes resolve through the values
+  `GetQueueAttributes` reports before comparing, so `VisibilityTimeout=30` against
+  a bare queue is not a conflict, and `FifoQueue=true` against a `.fifo` queue —
+  what every SDK and template sends — stays idempotent. The message names the
+  offending attribute, which AWS's own wording omits.
 - S3: `PutObject` and `CreateMultipartUpload` no longer record the `aws-chunked`
   transfer encoding as the object's `Content-Encoding` (#428). A SigV4 streaming
   upload — what every AWS SDK sends for a body it does not buffer — arrives with

--- a/docs/services.md
+++ b/docs/services.md
@@ -660,7 +660,7 @@ Lambda invocations: $0.0000002 per request.
 
 | Operation | Notes |
 |-----------|-------|
-| CreateQueue | Supports FifoQueue, VisibilityTimeout attributes |
+| CreateQueue | Supports FifoQueue, VisibilityTimeout attributes; [`QueueNameExists`](#queuenameexists) when a name is reused with differing attributes; [seedable `QueueDeletedRecently`](#seeding-queuedeletedrecently) |
 | GetQueueUrl | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; [seedable consistency window](#seeding-the-create-then-lookup-consistency-window) |
 | GetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; [seedable consistency window](#seeding-the-create-then-lookup-consistency-window) |
 | SetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
@@ -732,17 +732,89 @@ reproducible.
 
 Two ordering rules make the seed usable from a harness:
 
-- A miss is consumed **only when the queue actually exists**. Seeding before
+- A lookup miss is consumed **only when the queue actually exists**. Seeding before
   `CreateQueue` is safe: lookups against the genuinely absent queue still fail, but
-  they do not spend the budget.
+  they do not spend the budget. (`deletedRecentlyMisses` is the deliberate
+  exception — see [below](#seeding-queuedeletedrecently).)
 - A seed counts down the next N misses and **does not re-arm on `CreateQueue`**.
   `CreateQueue` is idempotent here (it returns the existing URL), so "after its
   CreateQueue" would be ambiguous when create runs twice, and re-arming would mean
   the data path writes control-plane state.
 
-Both counters default to 0, so an unseeded queue behaves exactly as before —
-instantly resolvable. Seeds live in the state store, so `POST /v1/state/reset`
-clears them along with everything else.
+All three counters — including [`deletedRecentlyMisses`](#seeding-queuedeletedrecently)
+— default to 0, so an unseeded queue behaves exactly as before: instantly
+resolvable. Seeds live in the state store, so `POST /v1/state/reset` clears them
+along with everything else.
+
+### QueueNameExists
+
+`CreateQueue` fails with `QueueNameExists`, HTTP 400, when the named queue already
+exists **with attribute values differing from the ones requested**. Same name with
+the same values stays idempotent and returns the existing URL, as AWS documents.
+
+This needs no seed: the condition is entirely determined by state, so it fires on the
+real mistake — two stacks or two test cases claiming one queue name with different
+settings — rather than only when a harness remembers to arm it.
+
+**Only attributes present in the request are compared.** An omitted attribute is
+treated as "no opinion", not as an assertion of its default. That reading comes from
+the error's own definition — "Amazon SQS returns this error only if the request
+includes attributes whose values differ from those of the existing queue" — which
+scopes the comparison to what the request includes. It is also what keeps
+CloudFormation re-deploys working, since a template forwards only the properties it
+declares.
+
+An existing queue's unset attributes are resolved through their defaults before
+comparing, so these are all idempotent:
+
+| First create | Re-create | Result |
+|---|---|---|
+| no attributes | no attributes | idempotent |
+| no attributes | `VisibilityTimeout=30` | idempotent — 30 is what the queue already reports |
+| `VisibilityTimeout=30` | no attributes | idempotent |
+| `VisibilityTimeout=45`, `DelaySeconds=5` | `VisibilityTimeout=45` | idempotent — subset |
+| `VisibilityTimeout=45` | `VisibilityTimeout=90` | `QueueNameExists` |
+| no attributes | `DelaySeconds=10` | `QueueNameExists` — effective value is 0 |
+| `orders.fifo`, no attributes | `FifoQueue=true` | idempotent — derived from the `.fifo` suffix |
+| `orders.fifo`, no attributes | `FifoQueue=false` | `QueueNameExists` |
+
+Comparison is **exact string equality** on resolved values, so `5` and `05` differ,
+and two semantically identical `Policy` documents differing in whitespace or key
+order read as a conflict. Any SDK or template re-sending its own serialization
+matches, which is the case that has to work; semantic JSON comparison is not
+attempted.
+
+The message carries AWS's documented wording plus the name of the offending
+attribute, which AWS's own text omits — without it the error is nearly
+undiagnosable for a caller holding a large attribute set. When several attributes
+differ, the alphabetically first is named, so the message is reproducible across
+runs.
+
+### Seeding QueueDeletedRecently
+
+AWS requires a **60-second wait after `DeleteQueue`** before a queue of the same name
+can be created, raising `QueueDeletedRecently`, HTTP 400, in the meantime. Substrate
+keeps no memory of a delete, so a consumer's delete → recreate → retry loop had no
+reachable error branch.
+
+```bash
+# The next 2 CreateQueue calls naming run-q report QueueDeletedRecently.
+curl -X POST http://localhost:4566/v1/sqs/consistency \
+  -d '{"queueName":"run-q","deletedRecentlyMisses":2}'
+```
+
+It shares the `/v1/sqs/consistency` endpoint, the name-over-wildcard precedence, and
+the `DELETE` clearing described above, and it is counted rather than timed for the
+same reason: the real condition is a wall-clock window, and a wall-clock window would
+make the assertion depend on how long the rest of the test took.
+
+Unlike the two lookup counters, this one applies **only while the name is free**.
+`QueueDeletedRecently` describes a name too recently freed, so an existing queue is
+the one case it cannot describe — a `CreateQueue` that hits an existing queue is an
+idempotent success and does not spend the budget. Substrate cannot know whether a
+name was "recently deleted", which is why the condition is seeded rather than
+inferred: a seeded name is refused on its next create whether or not a delete
+preceded it.
 
 ### Betty CFN resource types
 

--- a/emulator/sqs_control.go
+++ b/emulator/sqs_control.go
@@ -76,6 +76,22 @@ type sqsConsistencySeed struct {
 
 	// GetAttributesMisses is the same count for GetQueueAttributes.
 	GetAttributesMisses int `json:"getAttributesMisses"`
+
+	// DeletedRecentlyMisses is the number of subsequent CreateQueue calls that
+	// report QueueDeletedRecently rather than creating the queue (#429).
+	//
+	// It rides on this seed rather than on a separate endpoint because it is the
+	// same kind of value: a count of API observations that deviate from the nominal
+	// path for one queue, cleared by the same DELETE and the same state reset. AWS
+	// documents the real condition as a 60-second wall-clock window after
+	// DeleteQueue, which is a duration — and counted for exactly the reason the
+	// misses above are, since a wall-clock window would make the assertion depend
+	// on how long the rest of the test took.
+	//
+	// Unlike the lookup counters this one is *not* gated on the queue existing:
+	// QueueDeletedRecently is precisely the case where the queue is absent, so
+	// gating it on existence would make it unreachable.
+	DeletedRecentlyMisses int `json:"deletedRecentlyMisses"`
 }
 
 // sqsCtrlKey returns the state key for a consistency seed. Queue-scoped seeds use
@@ -110,16 +126,35 @@ const (
 
 	// sqsConsistencyGetAttributes selects the GetQueueAttributes counter.
 	sqsConsistencyGetAttributes
+
+	// sqsConsistencyDeletedRecently selects the CreateQueue QueueDeletedRecently
+	// counter.
+	sqsConsistencyDeletedRecently
 )
 
-// consumeQueueMiss reports whether the current call should answer
-// QueueDoesNotExist for a queue that exists, decrementing the seeded budget when
-// it does. It matches the queue name exactly first, then the "*" wildcard, and
-// returns false when no seed applies so the caller takes the nominal path.
+// counter returns a pointer to the seed field this operation consumes, so
+// consumeQueueMiss decrements the right one without duplicating the switch.
+func (op sqsConsistencyOp) counter(seed *sqsConsistencySeed) *int {
+	switch op {
+	case sqsConsistencyGetAttributes:
+		return &seed.GetAttributesMisses
+	case sqsConsistencyDeletedRecently:
+		return &seed.DeletedRecentlyMisses
+	default:
+		return &seed.GetURLMisses
+	}
+}
+
+// consumeQueueMiss reports whether the current call should take a seeded deviation
+// instead of its nominal path, decrementing the budget when it does. It matches the
+// queue name exactly first, then the "*" wildcard, and returns false when no seed
+// applies.
 //
-// Callers must consult this only *after* establishing that the queue exists. A
-// miss consumed on a genuinely absent queue would silently burn budget the test
-// meant to spend on the window, leaving the later retry assertion meaningless.
+// For the two lookup counters, callers must consult this only *after* establishing
+// that the queue exists. A miss consumed on a genuinely absent queue would silently
+// burn budget the test meant to spend on the window, leaving the later retry
+// assertion meaningless. [sqsConsistencyDeletedRecently] is the deliberate
+// exception — the queue is absent by definition in that case.
 func (p *SQSPlugin) consumeQueueMiss(queueName string, op sqsConsistencyOp) (bool, error) {
 	unlock := p.queueMu.lock(queueName)
 	defer unlock()
@@ -138,10 +173,7 @@ func (p *SQSPlugin) consumeQueueMiss(queueName string, op sqsConsistencyOp) (boo
 			return false, fmt.Errorf("sqs consumeQueueMiss unmarshal: %w", err)
 		}
 
-		counter := &seed.GetURLMisses
-		if op == sqsConsistencyGetAttributes {
-			counter = &seed.GetAttributesMisses
-		}
+		counter := op.counter(&seed)
 		if *counter <= 0 {
 			// This seed exists but has nothing left for this operation. Fall
 			// through to the wildcard: an exhausted name-scoped seed must not mask
@@ -164,17 +196,18 @@ func (p *SQSPlugin) consumeQueueMiss(queueName string, op sqsConsistencyOp) (boo
 
 // handleSQSSeedConsistency handles POST /v1/sqs/consistency. It seeds how many
 // subsequent lookups report QueueDoesNotExist for a queue that exists, modeling
-// the create→lookup window AWS documents. Body:
-// {"queueName","getUrlMisses","getAttributesMisses"}; an empty queueName seeds the
-// "*" wildcard.
+// the create→lookup window AWS documents, and how many CreateQueue calls report
+// QueueDeletedRecently. Body:
+// {"queueName","getUrlMisses","getAttributesMisses","deletedRecentlyMisses"}; an
+// empty queueName seeds the "*" wildcard.
 func (s *Server) handleSQSSeedConsistency(w http.ResponseWriter, r *http.Request) {
 	var seed sqsConsistencySeed
 	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
 		return
 	}
-	if seed.GetURLMisses < 0 || seed.GetAttributesMisses < 0 {
-		http.Error(w, `{"error":"getUrlMisses and getAttributesMisses must not be negative"}`, http.StatusBadRequest)
+	if seed.GetURLMisses < 0 || seed.GetAttributesMisses < 0 || seed.DeletedRecentlyMisses < 0 {
+		http.Error(w, `{"error":"miss counts must not be negative"}`, http.StatusBadRequest)
 		return
 	}
 	data, err := json.Marshal(seed)

--- a/emulator/sqs_createqueue.go
+++ b/emulator/sqs_createqueue.go
@@ -1,0 +1,106 @@
+package emulator
+
+import "sort"
+
+// sqsAttributeDefaults are the values GetQueueAttributes reports for a queue that
+// was created without naming them, used to resolve an existing queue's unset
+// attributes before comparing them against a CreateQueue request (#429).
+//
+// Resolving through defaults is what keeps a legitimate re-create idempotent. A
+// queue created with no attributes has an empty map, but its VisibilityTimeout is
+// observably 30 — GetQueueAttributes says so. A request naming VisibilityTimeout=30
+// therefore asks for exactly what the queue already has, and raising
+// QueueNameExists for it would reject a request AWS accepts. Comparing raw map
+// entries would do precisely that, because "30" is not absent.
+//
+// The values deliberately mirror getQueueAttributes' inline fallbacks rather than
+// the AWS reference, so the two cannot disagree about what a queue's effective
+// attributes are — a comparison that used different defaults than the read path
+// would reject requests matching what a caller had just read back. That does carry
+// one known staleness through: MaximumMessageSize is 262144 (256 KiB) here, while
+// the current CreateQueue reference documents 1,048,576 (1 MiB). Correcting it
+// changes GetQueueAttributes output, so it is tracked separately rather than
+// smuggled into this change.
+// TODO(#439): reconcile MaximumMessageSize with the documented 1 MiB default.
+var sqsAttributeDefaults = map[string]string{
+	"VisibilityTimeout":             "30",
+	"MaximumMessageSize":            "262144",
+	"MessageRetentionPeriod":        "345600",
+	"DelaySeconds":                  "0",
+	"ReceiveMessageWaitTimeSeconds": "0",
+}
+
+// sqsEffectiveAttribute returns the value a queue observably reports for an
+// attribute, and whether it has one at all.
+//
+// FifoQueue is resolved from the queue's own flag rather than its attribute map,
+// because substrate derives it from the ".fifo" name suffix and does not copy it
+// into Attributes. Without this, re-creating a FIFO queue with FifoQueue=true — the
+// request every SDK and CloudFormation template sends — would compare "true"
+// against an absent value and be rejected.
+func sqsEffectiveAttribute(q *SQSQueue, name string) (string, bool) {
+	if v, ok := q.Attributes[name]; ok {
+		return v, true
+	}
+	if name == "FifoQueue" {
+		if q.FifoQueue {
+			return "true", true
+		}
+		return "false", true
+	}
+	if v, ok := sqsAttributeDefaults[name]; ok {
+		return v, true
+	}
+	return "", false
+}
+
+// sqsConflictingAttribute returns the name of the first attribute whose requested
+// value differs from the existing queue's, or "" when the request asks for nothing
+// the queue does not already have.
+//
+// Only attributes **present in the request** are compared; one the request omits is
+// treated as "no opinion" rather than as an assertion of its default. That reading
+// comes from the error's own definition in the CreateQueue reference — "Amazon SQS
+// returns this error only if the request includes attributes whose values differ
+// from those of the existing queue" — which scopes the comparison to what the
+// request includes. The page's other statement, that providing "the exact same
+// names and values for all its attributes" returns the existing URL, gives a
+// sufficient condition for idempotency, not a necessary one, so it does not
+// contradict the narrower error definition.
+//
+// It is also the only reading that keeps substrate's own CloudFormation path
+// working: deploySQSQueue forwards only the properties a template declares, so a
+// stack that dropped a property between deploys would send a strict subset on
+// re-deploy and fail to update at all under the stricter reading.
+//
+// Comparison is exact string equality on the resolved values. That means Policy and
+// RedrivePolicy are compared as serialized text, not as JSON documents, so two
+// semantically identical policies differing in whitespace or key order read as a
+// conflict. Any SDK or template re-sending its own serialization matches, which is
+// the case that has to work; semantic JSON comparison is not attempted.
+//
+// The attributes are checked in sorted order so the attribute named in the error is
+// deterministic — a message that varied by map iteration order would make the
+// error itself irreproducible, which is the opposite of what this emulator is for.
+func sqsConflictingAttribute(q *SQSQueue, requested map[string]string) string {
+	names := make([]string, 0, len(requested))
+	for name := range requested {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		want := requested[name]
+		got, known := sqsEffectiveAttribute(q, name)
+		if !known {
+			// An attribute the queue has no value for at all — neither stored nor
+			// defaulted. The request is asking for something the queue does not
+			// have, so it differs.
+			return name
+		}
+		if want != got {
+			return name
+		}
+	}
+	return ""
+}

--- a/emulator/sqs_createqueue_test.go
+++ b/emulator/sqs_createqueue_test.go
@@ -1,0 +1,508 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// createQueueWithAttrs calls CreateQueue with attributes under the given protocol,
+// returning the status and the error code (empty on success).
+func createQueueWithAttrs(t *testing.T, srv *emulator.Server, name string, attrs map[string]string, jsonProto bool) (int, string) {
+	t.Helper()
+	if jsonProto {
+		body := map[string]interface{}{"QueueName": name}
+		if attrs != nil {
+			body["Attributes"] = attrs
+		}
+		return sqsErrorCode(t, sqsJSONRequest(t, srv, "CreateQueue", body))
+	}
+
+	params := map[string]string{"Action": "CreateQueue", "QueueName": name}
+	// The query protocol carries attributes as ordered Attribute.N.Name/Value
+	// pairs. Sorted so the wire form is reproducible across runs rather than
+	// varying with map iteration order.
+	names := make([]string, 0, len(attrs))
+	for k := range attrs {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	for i, k := range names {
+		idx := strconv.Itoa(i + 1)
+		params["Attribute."+idx+".Name"] = k
+		params["Attribute."+idx+".Value"] = attrs[k]
+	}
+	return sqsErrorCode(t, sqsRequest(t, srv, params))
+}
+
+// postSQSSeedRaw posts a raw seed body to the control plane and returns the status,
+// so a test can exercise validation the typed helper would not produce.
+func postSQSSeedRaw(t *testing.T, srv *emulator.Server, body string) int {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/v1/sqs/consistency", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Code
+}
+
+// TestSQS_CreateQueue_QueueNameExists is the deterministic half of #429. AWS raises
+// QueueNameExists when a name is reused with attribute values differing from the
+// existing queue's; substrate returned the existing URL regardless, so a consumer's
+// conflict handler was unreachable and any test of it passed vacuously.
+//
+// This half needs no seed because the condition is observable from state, which is
+// what makes it the more valuable one: it fires on the real mistake — two stacks or
+// two test cases claiming one queue name with different settings — rather than only
+// when a harness remembers to arm it.
+func TestSQS_CreateQueue_QueueNameExists(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+
+		status, _ := createQueueWithAttrs(t, srv, "conflict-q",
+			map[string]string{"VisibilityTimeout": "45"}, jsonProto)
+		require.Equal(t, http.StatusOK, status, "first create must succeed")
+
+		status, code := createQueueWithAttrs(t, srv, "conflict-q",
+			map[string]string{"VisibilityTimeout": "90"}, jsonProto)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "QueueNameExists", code)
+	})
+}
+
+// TestSQS_CreateQueue_IdempotentWhenAttributesMatch is the regression guard the
+// issue asks for by name. The existing behavior is correct for this case and must
+// stay that way: AWS documents that a request naming the same values returns the
+// existing URL, and substrate's own CloudFormation re-deploy path depends on it.
+func TestSQS_CreateQueue_IdempotentWhenAttributesMatch(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		tests := []struct {
+			name   string
+			first  map[string]string
+			second map[string]string
+		}{
+			{
+				name:   "no attributes either time",
+				first:  nil,
+				second: nil,
+			},
+			{
+				name:   "identical explicit attributes",
+				first:  map[string]string{"VisibilityTimeout": "45", "DelaySeconds": "5"},
+				second: map[string]string{"VisibilityTimeout": "45", "DelaySeconds": "5"},
+			},
+			{
+				// The re-create asks for what the queue observably has, even though
+				// its stored attribute map is empty. GetQueueAttributes reports
+				// VisibilityTimeout=30 for a queue created bare, so a request naming
+				// 30 asks for no change — comparing raw map entries would wrongly
+				// reject this.
+				name:   "explicit value equal to the default",
+				first:  nil,
+				second: map[string]string{"VisibilityTimeout": "30"},
+			},
+			{
+				// The reverse direction: created with the default named explicitly,
+				// re-created without naming it.
+				name:   "default omitted on the second call",
+				first:  map[string]string{"VisibilityTimeout": "30"},
+				second: nil,
+			},
+			{
+				// An omitted attribute is "no opinion", not an assertion of its
+				// default — so dropping one between calls is not a conflict. This is
+				// what keeps CFN working: deploySQSQueue forwards only declared
+				// properties, so a template that drops one sends a strict subset.
+				name:   "subset of the original attributes",
+				first:  map[string]string{"VisibilityTimeout": "45", "DelaySeconds": "5"},
+				second: map[string]string{"VisibilityTimeout": "45"},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				srv, _ := newSQSTestServer(t)
+
+				status, _ := createQueueWithAttrs(t, srv, "idem-q", tt.first, jsonProto)
+				require.Equal(t, http.StatusOK, status, "first create")
+
+				status, code := createQueueWithAttrs(t, srv, "idem-q", tt.second, jsonProto)
+				assert.Equal(t, http.StatusOK, status, "re-create must stay idempotent")
+				assert.Empty(t, code)
+			})
+		}
+	})
+}
+
+// TestSQS_CreateQueue_ConflictCases covers which differences count, the acceptance
+// criterion asking for that decision to be pinned rather than left implicit.
+func TestSQS_CreateQueue_ConflictCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		first        map[string]string
+		second       map[string]string
+		wantConflict bool
+	}{
+		{
+			name:         "value differs from an explicit original",
+			first:        map[string]string{"DelaySeconds": "5"},
+			second:       map[string]string{"DelaySeconds": "10"},
+			wantConflict: true,
+		},
+		{
+			// Created bare, re-created naming a non-default value: the queue's
+			// effective DelaySeconds is 0, so asking for 10 is a real change.
+			name:         "value differs from a defaulted original",
+			first:        nil,
+			second:       map[string]string{"DelaySeconds": "10"},
+			wantConflict: true,
+		},
+		{
+			// A second attribute the first call never set, whose requested value is
+			// not the default either.
+			name:         "new attribute with a non-default value",
+			first:        map[string]string{"VisibilityTimeout": "45"},
+			second:       map[string]string{"VisibilityTimeout": "45", "MessageRetentionPeriod": "60"},
+			wantConflict: true,
+		},
+		{
+			// An attribute substrate has no default for at all: the queue has no
+			// value, so any requested value differs.
+			name:         "attribute with no substrate default",
+			first:        nil,
+			second:       map[string]string{"KmsMasterKeyId": "alias/aws/sqs"},
+			wantConflict: true,
+		},
+		{
+			// Values are compared as strings, so an equivalent-but-differently-spelled
+			// number is a conflict. Documented rather than normalized: an SDK or
+			// template re-sending its own serialization always matches, which is the
+			// case that has to work.
+			name:         "numerically equal but textually different",
+			first:        map[string]string{"DelaySeconds": "5"},
+			second:       map[string]string{"DelaySeconds": "05"},
+			wantConflict: true,
+		},
+		{
+			// Policy is compared as text for the same reason.
+			name:         "policy differing only in whitespace",
+			first:        map[string]string{"Policy": `{"Version":"2012-10-17"}`},
+			second:       map[string]string{"Policy": `{ "Version": "2012-10-17" }`},
+			wantConflict: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+
+			status, _ := createQueueWithAttrs(t, srv, "cases-q", tt.first, false)
+			require.Equal(t, http.StatusOK, status, "first create")
+
+			status, code := createQueueWithAttrs(t, srv, "cases-q", tt.second, false)
+			if tt.wantConflict {
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "QueueNameExists", code)
+				return
+			}
+			assert.Equal(t, http.StatusOK, status)
+			assert.Empty(t, code)
+		})
+	}
+}
+
+// TestSQS_CreateQueue_FifoQueueAttributeIsNotAConflict pins that re-creating a FIFO
+// queue with FifoQueue=true — what every SDK and CloudFormation template sends —
+// stays idempotent. Substrate derives the flag from the ".fifo" suffix and never
+// copies it into the attribute map, so a naive comparison would see "true" against
+// an absent value and reject the most ordinary FIFO re-create there is.
+func TestSQS_CreateQueue_FifoQueueAttributeIsNotAConflict(t *testing.T) {
+	// The first create names no attributes, so nothing lands in the queue's map and
+	// the flag is derived from the suffix alone. That is the case the special-casing
+	// exists for: a create that *does* pass FifoQueue stores it, and would compare
+	// fine from the map without any of this.
+	t.Run("derived from the name suffix", func(t *testing.T) {
+		srv, _ := newSQSTestServer(t)
+		require.Equal(t, http.StatusOK, mustCreate(t, srv, "orders.fifo", nil), "first create")
+
+		status, code := createQueueWithAttrs(t, srv, "orders.fifo",
+			map[string]string{"FifoQueue": "true"}, false)
+		assert.Equal(t, http.StatusOK, status, "re-creating a FIFO queue must stay idempotent")
+		assert.Empty(t, code)
+
+		// Claiming a FIFO queue is standard is a genuine conflict, and one AWS calls
+		// out as impossible to change after creation.
+		status, code = createQueueWithAttrs(t, srv, "orders.fifo",
+			map[string]string{"FifoQueue": "false"}, false)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "QueueNameExists", code)
+	})
+
+	// The mirror image: a standard queue must not accept a FifoQueue=true claim,
+	// which needs the false branch of the same derivation.
+	t.Run("standard queue claimed as FIFO", func(t *testing.T) {
+		srv, _ := newSQSTestServer(t)
+		require.Equal(t, http.StatusOK, mustCreate(t, srv, "plain-q", nil), "first create")
+
+		status, code := createQueueWithAttrs(t, srv, "plain-q",
+			map[string]string{"FifoQueue": "false"}, false)
+		assert.Equal(t, http.StatusOK, status, "FifoQueue=false on a standard queue is no change")
+		assert.Empty(t, code)
+
+		status, code = createQueueWithAttrs(t, srv, "plain-q",
+			map[string]string{"FifoQueue": "true"}, false)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "QueueNameExists", code)
+	})
+
+	// And the ordinary SDK shape, where the attribute is passed both times.
+	t.Run("attribute passed on both creates", func(t *testing.T) {
+		srv, _ := newSQSTestServer(t)
+		require.Equal(t, http.StatusOK,
+			mustCreate(t, srv, "events.fifo", map[string]string{"FifoQueue": "true"}))
+
+		status, code := createQueueWithAttrs(t, srv, "events.fifo",
+			map[string]string{"FifoQueue": "true"}, false)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Empty(t, code)
+	})
+}
+
+// TestSQS_CreateQueue_ConflictNamesTheAttribute asserts the message identifies which
+// attribute differs. AWS's own text does not, and without it the error is nearly
+// undiagnosable for a caller holding a large attribute set — the documented prefix
+// is still present, so a consumer matching on either the code or that text is
+// unaffected.
+func TestSQS_CreateQueue_ConflictNamesTheAttribute(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+
+	status, _ := createQueueWithAttrs(t, srv, "named-conflict-q",
+		map[string]string{"VisibilityTimeout": "45", "DelaySeconds": "5"}, false)
+	require.Equal(t, http.StatusOK, status)
+
+	resp := sqsRequest(t, srv, map[string]string{
+		"Action": "CreateQueue", "QueueName": "named-conflict-q",
+		"Attribute.1.Name": "DelaySeconds", "Attribute.1.Value": "9",
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body := readJSONBody(t, resp)
+	assert.Equal(t, "QueueNameExists", body["__type"])
+	message, _ := body["message"].(string)
+	if message == "" {
+		message, _ = body["Message"].(string)
+	}
+	assert.Contains(t, message, "A queue with this name already exists",
+		"AWS's documented wording must survive")
+	assert.Contains(t, message, "DelaySeconds", "the offending attribute must be named")
+}
+
+// TestSQS_CreateQueue_ConflictIsDeterministic pins that the attribute named when
+// several differ is stable. A message that varied with map iteration order would be
+// irreproducible across runs, which is the opposite of what this emulator exists
+// for — a consumer asserting on it would see a flaky test.
+func TestSQS_CreateQueue_ConflictIsDeterministic(t *testing.T) {
+	const runs = 20
+	for range runs {
+		srv, _ := newSQSTestServer(t)
+		require.Equal(t, http.StatusOK, mustCreate(t, srv, "det-q", map[string]string{
+			"VisibilityTimeout": "45", "DelaySeconds": "5", "MessageRetentionPeriod": "600",
+		}))
+
+		resp := sqsRequest(t, srv, map[string]string{
+			"Action": "CreateQueue", "QueueName": "det-q",
+			"Attribute.1.Name": "VisibilityTimeout", "Attribute.1.Value": "99",
+			"Attribute.2.Name": "DelaySeconds", "Attribute.2.Value": "99",
+			"Attribute.3.Name": "MessageRetentionPeriod", "Attribute.3.Value": "99",
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		message, _ := readJSONBody(t, resp)["message"].(string)
+		// Sorted order, so the first differing attribute is always DelaySeconds.
+		assert.Contains(t, message, "DelaySeconds")
+	}
+}
+
+// mustCreate creates a queue with attributes and returns the status.
+func mustCreate(t *testing.T, srv *emulator.Server, name string, attrs map[string]string) int {
+	t.Helper()
+	status, _ := createQueueWithAttrs(t, srv, name, attrs, false)
+	return status
+}
+
+// TestSQS_CreateQueue_ConflictCreatesNothing asserts a rejected create leaves the
+// existing queue untouched. A consumer that catches QueueNameExists and inspects the
+// queue has to find the original settings, not a half-applied merge.
+func TestSQS_CreateQueue_ConflictCreatesNothing(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createSQSQueue(t, srv, "intact-q")
+
+	require.Equal(t, http.StatusOK, mustCreate(t, srv, "intact-q",
+		map[string]string{"VisibilityTimeout": "30"}))
+
+	status, code := createQueueWithAttrs(t, srv, "intact-q",
+		map[string]string{"VisibilityTimeout": "77"}, false)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "QueueNameExists", code)
+
+	resp := sqsRequest(t, srv, map[string]string{
+		"Action": "GetQueueAttributes", "QueueUrl": queueURL,
+		"AttributeName.1": "All",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := readBody(t, resp)
+	assert.Contains(t, body, "<Value>30</Value>", "the original attributes must survive")
+	assert.NotContains(t, body, "<Value>77</Value>", "a rejected create must not apply anything")
+}
+
+// TestSQS_CreateQueue_SeededQueueDeletedRecently is the seeded half of #429. AWS
+// requires a 60-second wait after DeleteQueue before the name can be reused, so a
+// consumer's delete→recreate→retry loop has a real error branch. Substrate keeps no
+// memory of a delete, which made that branch unreachable.
+//
+// The budget is counted rather than timed for the same reason #413's is:
+// TimeController.Now advances with wall time, so a duration window would expire
+// partway through a test and make the assertion depend on how long the rest of the
+// test took.
+func TestSQS_CreateQueue_SeededQueueDeletedRecently(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createSQSQueue(t, srv, "recreate-q")
+
+		resp := sqsRequest(t, srv, map[string]string{"Action": "DeleteQueue", "QueueUrl": queueURL})
+		resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusOK, resp.StatusCode, "delete queue")
+
+		seedSQSConsistency(t, srv, map[string]any{
+			"queueName": "recreate-q", "deletedRecentlyMisses": 2,
+		})
+
+		for i := 1; i <= 2; i++ {
+			status, code := createQueueWithAttrs(t, srv, "recreate-q", nil, jsonProto)
+			assert.Equal(t, http.StatusBadRequest, status, "create %d must be refused", i)
+			assert.Equal(t, "QueueDeletedRecently", code, "create %d", i)
+		}
+
+		// Budget exhausted: the name is reusable, and the queue really is created.
+		status, _ := createQueueWithAttrs(t, srv, "recreate-q", nil, jsonProto)
+		require.Equal(t, http.StatusOK, status, "create 3 must succeed once the window closes")
+
+		status, _ = getQueueURL(t, srv, "recreate-q", jsonProto)
+		assert.Equal(t, http.StatusOK, status, "the queue must exist after the successful create")
+	})
+}
+
+// TestSQS_CreateQueue_DeletedRecentlyDoesNotApplyToExistingQueue pins that the seed
+// only fires while the name is free. AWS raises QueueDeletedRecently for a name too
+// recently freed, so an existing queue is the one case it cannot describe — and
+// spending the budget on an idempotent re-create would leave the delete→recreate
+// assertion the seed exists for meaningless.
+func TestSQS_CreateQueue_DeletedRecentlyDoesNotApplyToExistingQueue(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createSQSQueue(t, srv, "live-q")
+	seedSQSConsistency(t, srv, map[string]any{"queueName": "live-q", "deletedRecentlyMisses": 1})
+
+	// The queue exists, so this is an idempotent hit and must not consume the seed.
+	status, code := createQueueWithAttrs(t, srv, "live-q", nil, false)
+	require.Equal(t, http.StatusOK, status, "an existing queue must not be refused")
+	require.Empty(t, code)
+
+	resp := sqsRequest(t, srv, map[string]string{"Action": "DeleteQueue", "QueueUrl": queueURL})
+	resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Now the name is free and the budget is still intact.
+	status, code = createQueueWithAttrs(t, srv, "live-q", nil, false)
+	assert.Equal(t, http.StatusBadRequest, status, "the seeded miss must have survived")
+	assert.Equal(t, "QueueDeletedRecently", code)
+}
+
+// TestSQS_CreateQueue_UnseededRecreateIsInstant is the "unseeded behavior unchanged"
+// criterion: without a seed, a deleted name is immediately reusable.
+func TestSQS_CreateQueue_UnseededRecreateIsInstant(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createSQSQueue(t, srv, "fast-q")
+
+		resp := sqsRequest(t, srv, map[string]string{"Action": "DeleteQueue", "QueueUrl": queueURL})
+		resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		status, code := createQueueWithAttrs(t, srv, "fast-q", nil, jsonProto)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Empty(t, code)
+	})
+}
+
+// TestSQS_CreateQueue_DeletedRecentlyCounterIsIndependent pins that the new counter
+// does not disturb #413's two, so a test can seed a recreate window without also
+// perturbing its lookups.
+func TestSQS_CreateQueue_DeletedRecentlyCounterIsIndependent(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	createSQSQueue(t, srv, "indep-create-q")
+	seedSQSConsistency(t, srv, map[string]any{
+		"queueName": "indep-create-q", "deletedRecentlyMisses": 1,
+	})
+
+	// The lookup counters were not seeded, so lookups resolve normally...
+	status, _ := getQueueURL(t, srv, "indep-create-q", false)
+	assert.Equal(t, http.StatusOK, status, "an unseeded lookup must not consume the create budget")
+
+	// ...and the create budget is still intact once the name is free.
+	queueURL := "http://sqs.us-east-1.localhost/000000000000/indep-create-q"
+	resp := sqsRequest(t, srv, map[string]string{"Action": "DeleteQueue", "QueueUrl": queueURL})
+	resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	status, code := createQueueWithAttrs(t, srv, "indep-create-q", nil, false)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "QueueDeletedRecently", code)
+}
+
+// TestSQS_CreateQueue_DeletedRecentlyWildcard covers a seed with no queueName, for a
+// harness that wants every recreate in a suite to face the window.
+func TestSQS_CreateQueue_DeletedRecentlyWildcard(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	seedSQSConsistency(t, srv, map[string]any{"deletedRecentlyMisses": 1})
+
+	// No queue of this name has ever existed, so the wildcard applies to a first
+	// create too — the emulator cannot know whether a name was "recently deleted",
+	// which is exactly why the condition is seeded rather than inferred.
+	status, code := createQueueWithAttrs(t, srv, "wild-create-q", nil, false)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "QueueDeletedRecently", code)
+
+	status, _ = createQueueWithAttrs(t, srv, "wild-create-q", nil, false)
+	assert.Equal(t, http.StatusOK, status, "the budget is spent, so the create proceeds")
+}
+
+// TestSQS_CreateQueue_RejectsNegativeDeletedRecently covers control-plane validation
+// on the new counter. A negative value would sit in the store answering "no misses
+// left" forever, looking like a seed that silently did nothing.
+func TestSQS_CreateQueue_RejectsNegativeDeletedRecently(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+
+	status := postSQSSeedRaw(t, srv, `{"queueName":"neg-q","deletedRecentlyMisses":-1}`)
+	assert.Equal(t, http.StatusBadRequest, status)
+}
+
+// TestSQS_CreateQueue_DeletedRecentlyStateFailure asserts a store failure during the
+// seed lookup propagates rather than collapsing into a successful create. Creating
+// the queue anyway would hide the fault and hand back a URL for a queue whose seed
+// state is unknown.
+func TestSQS_CreateQueue_DeletedRecentlyStateFailure(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	srv, _ := newSQSTestServerWithState(t, state)
+	require.NoError(t, emulator.SQSPutRawSeedForTest(state, "corrupt-create-q", []byte("{not json")))
+
+	status, code := createQueueWithAttrs(t, srv, "corrupt-create-q", nil, false)
+	assert.Equal(t, http.StatusInternalServerError, status)
+	assert.NotEqual(t, "QueueDeletedRecently", code)
+}

--- a/emulator/sqs_errors.go
+++ b/emulator/sqs_errors.go
@@ -31,3 +31,60 @@ func sqsQueueDoesNotExist() *AWSError {
 		HTTPStatus: http.StatusBadRequest,
 	}
 }
+
+// sqsQueueNameExists returns the error CreateQueue raises when the named queue
+// already exists with attribute values differing from the ones requested.
+//
+// The code and message are the CreateQueue reference's own, verbatim: QueueNameExists
+// / "A queue with this name already exists. Amazon SQS returns this error only if
+// the request includes attributes whose values differ from those of the existing
+// queue." / HTTP 400. AWS publishes no separate runtime wording for it, so the
+// documented description is the most faithful message available — the same basis
+// [sqsQueueDoesNotExist] uses.
+//
+// Verified to be the string both SDKs dispatch on, because #413 proved a plausible
+// guess is not good enough here: botocore's SQS model declares the exception shape
+// QueueNameExists, and aws-sdk-go-v2 matches
+// strings.EqualFold("QueueNameExists", errorCode). Neither carries a legacy alias
+// for this one.
+//
+// The offending attribute is named in the message beyond AWS's text, because the
+// condition is otherwise near-undiagnosable: a consumer holding a 20-attribute
+// template learns only that *something* differs. That is additive — a caller
+// matching the code still matches, and one matching the documented prefix still
+// matches.
+func sqsQueueNameExists(attribute string) *AWSError {
+	msg := "A queue with this name already exists. Amazon SQS returns this error " +
+		"only if the request includes attributes whose values differ from those of " +
+		"the existing queue."
+	if attribute != "" {
+		msg += " The attribute " + attribute + " differs."
+	}
+	return &AWSError{
+		Code:       "QueueNameExists",
+		Message:    msg,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// sqsQueueDeletedRecently returns the error CreateQueue raises when a queue of the
+// same name was deleted too recently to be recreated.
+//
+// Code, message and status are the CreateQueue reference's, verbatim:
+// QueueDeletedRecently / "You must wait 60 seconds after deleting a queue before
+// you can create another queue with the same name." / HTTP 400. Both SDKs dispatch
+// on the plain code — botocore models the QueueDeletedRecently exception shape and
+// aws-sdk-go-v2 matches it with EqualFold — so no alias handling is needed.
+//
+// Substrate raises this only when seeded. The real condition is a 60-second
+// wall-clock window, and a duration-based window cannot be modeled here without
+// making assertions wall-clock dependent; see [sqsConsistencySeed] for why the
+// budget is counted instead.
+func sqsQueueDeletedRecently() *AWSError {
+	return &AWSError{
+		Code: "QueueDeletedRecently",
+		Message: "You must wait 60 seconds after deleting a queue before you can " +
+			"create another queue with the same name.",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -270,7 +270,28 @@ func (p *SQSPlugin) createQueue(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 	if err != nil {
 		return nil, err
 	}
+
+	// A seeded QueueDeletedRecently is checked before the existence branch, unlike
+	// the lookup windows, which require the queue to exist. AWS raises this only
+	// when the name is free but too recently freed, so the absent case is the only
+	// one where it can apply — the seed is consulted here, and only here, for that
+	// reason. It is unseeded by default, so nothing changes without a seed.
+	if existing == nil {
+		if miss, missErr := p.consumeQueueMiss(name, sqsConsistencyDeletedRecently); missErr != nil {
+			return nil, missErr
+		} else if miss {
+			return nil, sqsQueueDeletedRecently()
+		}
+	}
 	if existing != nil {
+		// Same name with differing attribute values is an error, not an idempotent
+		// hit (#429). AWS scopes this to "attributes whose values differ from those
+		// of the existing queue", so only what the request names is compared and the
+		// same-name-same-attributes case stays idempotent below.
+		if conflict := sqsConflictingAttribute(existing, attrs); conflict != "" {
+			return nil, sqsQueueNameExists(conflict)
+		}
+
 		// Idempotent — return existing URL.
 		if sqsIsJSONProtocol(req) {
 			return sqsJSONResponse(http.StatusOK, map[string]string{"QueueUrl": existing.QueueURL})


### PR DESCRIPTION
Closes #429

## The defect

`createQueue` was unconditionally idempotent — it returned the existing queue's URL regardless of what the request asked for. Two stacks or two test cases claiming one queue name with different settings both "succeeded", and the second silently inherited the first one's configuration. That is a confidently wrong answer rather than a missing error, and the consumer's error branch was unreachable. AWS documents two failures on `CreateQueue`; neither was modeled.

**Stacked on #438** (`fix/431-run-instances-counts`) — both touch `CHANGELOG.md` and `docs/services.md`. Base retargets to `main` automatically when #438 merges.

## `QueueNameExists` — state-determined, no seed

400 when a name is reused with **differing attribute values**; same name with the same values stays idempotent.

No seed, because the condition is entirely determined by state: it fires on the real mistake rather than only when a harness remembers to arm it.

### Which differences count

**Only attributes present in the request are compared.** An omitted attribute is "no opinion", not an assertion of its default.

The CreateQueue reference says two things that pull in different directions — that providing "the exact same names and values for all its attributes" returns the existing URL, and that the error fires "only if the request includes attributes whose values differ from those of the existing queue". I took the narrower reading: the first is a *sufficient* condition for idempotency, not a necessary one, so it does not contradict the error's own definition.

It is also the only reading that keeps substrate's own CFN path working. `deploySQSQueue` forwards only the properties a template declares, so a stack that dropped a property between deploys would send a strict subset on re-deploy and fail to update at all under the strict reading.

### Resolving through defaults

An existing queue's unset attributes resolve through the values `getQueueAttributes` reports before comparing. A queue created with no attributes has an empty map but observably reports `VisibilityTimeout=30`, so a request naming `VisibilityTimeout=30` asks for exactly what it already has — comparing raw map entries would reject a request AWS accepts.

`sqsAttributeDefaults` deliberately mirrors `getQueueAttributes`' inline fallbacks rather than the AWS reference, so the comparison and read paths cannot disagree about a queue's effective attributes. That carries one known staleness through: `MaximumMessageSize` is 262144 here where AWS documents 1 MiB. Filed as #439 rather than smuggled in, since correcting it changes `GetQueueAttributes` output.

### The FifoQueue trap

Substrate derives `FifoQueue` from the `.fifo` name suffix and never copies it into `Attributes`. A naive map comparison would compare `"true"` against an absent value and reject the most ordinary FIFO re-create there is — `FifoQueue=true`, what every SDK and CloudFormation template sends. Resolved from the queue's own flag instead, and pinned by test.

Attributes are checked in **sorted order**, so the attribute named in the message is deterministic; a message varying by map iteration order would make the error irreproducible.

The message carries AWS's documented wording plus the offending attribute name, which AWS's own text omits — without it the error is nearly undiagnosable for a caller holding a large attribute set.

## Seedable `QueueDeletedRecently`

AWS requires a 60-second wait after `DeleteQueue` before the same name can be reused. Substrate keeps no memory of a delete, so a consumer's delete → recreate → retry loop had no reachable error branch.

```bash
curl -X POST http://localhost:4566/v1/sqs/consistency \
  -d '{"queueName":"run-q","deletedRecentlyMisses":2}'
```

Rides on the existing `/v1/sqs/consistency` seed as a third counter: same endpoint, same name-over-wildcard precedence, same `DELETE`, same state reset. **Counted rather than timed** for the reason the lookup windows are — the real condition is a wall-clock window, and a wall-clock window would make the assertion depend on how long the rest of the test took.

Unlike the two lookup counters it is **not gated on the queue existing**, since `QueueDeletedRecently` is precisely the absent case — gating it on existence would make it unreachable. A create that hits an existing queue is an idempotent success and does not spend the budget. The counter defaults to 0, so an unseeded recreate is still instant.

## Both codes verified to dispatch

Applying the #413 lesson rather than assuming:

- **botocore** — the SQS model declares both exception shapes and lists them under `CreateQueue.errors`.
- **aws-sdk-go-v2** `service/sqs@v1.42.27` — `deserializers.go:619,622` matches both with `strings.EqualFold`.

Neither has a legacy alias, unlike `QueueDoesNotExist`.

## Blast radius

No existing test creates the same queue twice with attributes. The only re-create path is CFN (`UpdateStack` → `Deploy` → `deploySQSQueue`), which forwards only declared properties — hence the "no opinion" decision. All existing `TestSQS`/`TestCFN` tests pass unchanged.

## Tests

28 subtests in the new `emulator/sqs_createqueue_test.go`, covering both wire protocols: the conflict cases, the idempotent cases including explicit-value-equal-to-default and subset, the three FIFO branches, message content, determinism across 20 runs, that a conflict creates nothing, the seeded window, that it does not apply to an existing queue, counter independence, the wildcard, negative rejection, and the state-failure path.

**Mutation-tested.** Disabling the conflict check, the defaults resolution, and the `FifoQueue` derivation each fails the tests covering it. The FIFO case initially did *not* fail: the test passed `FifoQueue=true` on the first create, so the value landed in `Attributes` and the derivation branch was never reached. The test is now split so the derived and standard-queue branches are both exercised — a real coverage gap that green tests hid.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race), `test/e2e`, `make docs-reference-check docs-versions`. All internal `docs/services.md` anchors verified to resolve.