### PR TITLE
feat(s3): persist Cache-Control, Content-Disposition, Content-Language, Expires (#430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- S3: `Cache-Control`, `Content-Disposition`, `Content-Language` and `Expires`
+  persist on an object and are returned on every read (#430). `S3Object` had no
+  fields for them at all, so substrate accepted the headers on write and silently
+  discarded them — a consumer asserting that an `attachment; filename=` download
+  name or a cache lifetime survives an upload got a green test verifying nothing,
+  because the write appeared to succeed. All three write paths record them now:
+  `PutObject`, `CreateMultipartUpload` → `CompleteMultipartUpload` (Complete
+  accepts no object-metadata headers, so the family is carried on the upload
+  record from creation), and `CopyObject` under the same
+  `x-amz-metadata-directive` that already governed `Content-Type` and
+  `Content-Encoding` — S3 documents no per-header variant, so a `REPLACE`
+  restating only `Content-Type` drops the rest. The four share one embedded
+  struct declaration used by both `S3Object` and `S3MultipartUpload`, so the two
+  write paths cannot drift apart on a member the way they did on
+  `Content-Encoding` in #406. An absent header stays **absent** on the response
+  rather than becoming empty, since an SDK distinguishing nil from `""` would
+  otherwise report the wrong one. `Expires` is stored as a string and never
+  parsed: real S3 returns what the caller sent, the Go SDK deprecates its
+  `time.Time` `Expires` in favour of the unparsed `ExpiresString`, and parsing
+  here would make a consumer's parse-failure branch unreachable.
 - SQS: `QueueDeletedRecently` is seedable on `CreateQueue` (#429). AWS requires a
   60-second wait after `DeleteQueue` before the same name can be reused, so a
   consumer's delete → recreate → retry loop has a documented error to handle;

--- a/docs/services.md
+++ b/docs/services.md
@@ -191,14 +191,14 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums) |
-| GetObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
-| HeadObject | Supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
+| PutObject | Supports Content-Type, metadata headers; `Cache-Control`, `Content-Disposition`, `Content-Language`, `Expires` — see [Object system metadata](#object-system-metadata); `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums) |
+| GetObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
+| HeadObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
 | DeleteObject | Fires S3 notifications if configured |
 | CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums) |
 | ListObjects | Emits `<StorageClass>` per object |
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
-| CreateMultipartUpload | Accepts `x-amz-storage-class`, applied to the assembled object; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums) |
+| CreateMultipartUpload | Accepts `x-amz-storage-class` and the [system-metadata family](#object-system-metadata), applied to the assembled object; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums) |
 | UploadPart | Verifies the part checksum, including a trailing one — see [Additional checksums](#additional-checksums) |
 | CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums) |
 | AbortMultipartUpload | |
@@ -299,6 +299,35 @@ codec that *is* applied to the stored object.
 
 The header name is matched case-insensitively on both paths.
 
+### Object system metadata
+
+`Cache-Control`, `Content-Disposition`, `Content-Language` and `Expires` are recorded
+on write and returned on every read, on all three write paths — `PutObject`,
+`CreateMultipartUpload` → `CompleteMultipartUpload`, and `CopyObject`. Substrate
+previously accepted them and discarded them, so a test asserting "the download
+filename survives an upload" passed while verifying nothing.
+
+They are stored verbatim and never interpreted: substrate does not evaluate a
+`Cache-Control` lifetime, parse a `Content-Disposition` filename, or apply an
+`Expires` date to anything. What is modeled is the observation — that a read reports
+what the write set.
+
+An absent header is **absent on the response, not empty**. `Cache-Control: ` and no
+`Cache-Control` are different observations, and an SDK distinguishing nil from `""`
+would otherwise report the wrong one.
+
+**`Expires` is a string, never a parsed date.** A malformed value round-trips
+unchanged rather than being normalized or dropped. Real S3 stores and returns what the
+caller sent, and the Go SDK's own `GetObject` output deprecates its `time.Time`
+`Expires` in favour of `ExpiresString` — "the unparsed value of the `Expires` field
+from the service response". Parsing here would be lower fidelity, and would make a
+consumer's parse-failure branch unreachable.
+
+`Content-Type`, `Content-Encoding` and the storage class are user-controlled system
+metadata too, but each has resolution rules of its own — a default of
+`application/octet-stream`, `aws-chunked` filtering, and a `STANDARD`-means-absent
+read rule — so they are documented in their own sections above.
+
 ### Copying objects
 
 `CopyObject`'s metadata behaviour is governed by two independent directives, both
@@ -306,7 +335,7 @@ defaulting to `COPY` when absent. An unrecognized value on either is `400
 InvalidArgument` rather than a silent fall back to the default — a typo that quietly
 preserved metadata is the kind of false success this emulator exists to surface.
 
-| `x-amz-metadata-directive` | Destination `Content-Type`, `Content-Encoding`, `x-amz-meta-*` |
+| `x-amz-metadata-directive` | Destination `Content-Type`, `Content-Encoding`, `Cache-Control`, `Content-Disposition`, `Content-Language`, `Expires`, `x-amz-meta-*` |
 |---|---|
 | `COPY` (default) | Taken from the **source**; headers restated on the request are ignored |
 | `REPLACE` | Taken from the **request**; anything not restated is dropped |
@@ -321,6 +350,11 @@ The loss case is `REPLACE`: "you must explicitly specify all of the user-configu
 metadata present on the source object in your request, even if you are changing only
 one of the metadata values". A `REPLACE` that omits `Content-Encoding` drops it, and
 `Content-Type` falls back to `application/octet-stream`.
+
+**The one directive governs the whole family.** S3 documents no per-header variant of
+`x-amz-metadata-directive`, so a `REPLACE` restating only `Content-Type` also drops
+the `Content-Disposition` download name and the `Cache-Control` lifetime the source
+carried. Each header is independently restatable, but each must actually be restated.
 
 `CopyObject` applies no `aws-chunked` filtering of its own and does not need to:
 under `COPY` it inherits the source object's already-filtered value, and a copy
@@ -505,14 +539,17 @@ is assembled:
 |---|---|
 | `Content-Type` | yes (defaults to `application/octet-stream`) |
 | `Content-Encoding` | yes, less any `aws-chunked` token — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked) |
+| `Cache-Control` | yes — see [Object system metadata](#object-system-metadata) |
+| `Content-Disposition` | yes |
+| `Content-Language` | yes |
+| `Expires` | yes, stored verbatim |
 | `x-amz-storage-class` | yes (empty means `STANDARD`) |
 | `x-amz-checksum-algorithm` | yes — see [Additional checksums](#additional-checksums) |
 | `x-amz-meta-*` | yes |
 
-`Cache-Control`, `Content-Disposition` and `Content-Language` are **not modeled** on
-either upload path: substrate records no field for them, so they are accepted and
-discarded rather than echoed on a later `GetObject`/`HeadObject`. A test asserting
-one of those survives a write will pass against real S3 and fail here.
+Setting one of these at `Complete` instead has no effect — the reference lists no
+object-metadata header there, so substrate ignores them rather than applying them
+late.
 
 ### Additional checksums
 

--- a/emulator/s3_copy_metadata.go
+++ b/emulator/s3_copy_metadata.go
@@ -20,6 +20,12 @@ type s3CopyMetadata struct {
 	ContentType     string
 	ContentEncoding string
 	UserMetadata    map[string]string
+
+	// System is the Cache-Control/Content-Disposition/Content-Language/Expires
+	// family, resolved under the same directive as the fields above. Embedding
+	// [S3SystemMetadata] here rather than restating its members means a header added
+	// to the family is carried by CopyObject without editing this file (#430).
+	System S3SystemMetadata
 }
 
 // resolveDirective returns the COPY/REPLACE value of a directive header, or the
@@ -66,6 +72,15 @@ func resolveDirective(headers map[string]string, name string) (string, *AWSRespo
 // on the source object in your request, even if you are changing only one of the
 // metadata values". This is the asymmetry a consumer's in-place CopyObject tier
 // transition trips over — a REPLACE that omits Content-Encoding loses it.
+//
+// Cache-Control, Content-Disposition, Content-Language and Expires follow exactly
+// the same rule, and deliberately share the one directive rather than getting
+// per-header treatment (#430). S3 documents a single x-amz-metadata-directive
+// governing "the metadata", with no per-header variant, and all four are
+// user-controlled system metadata by the same definition Content-Type and
+// Content-Encoding are. So a REPLACE that restates only Content-Type drops the
+// download name a consumer set — which is the failure this models, not an
+// implementation shortcut.
 func resolveCopyMetadata(headers map[string]string, src *S3Object) (s3CopyMetadata, *AWSResponse) {
 	directive, errResp := resolveDirective(headers, "x-amz-metadata-directive")
 	if errResp != nil {
@@ -77,6 +92,7 @@ func resolveCopyMetadata(headers map[string]string, src *S3Object) (s3CopyMetada
 			ContentType:     src.ContentType,
 			ContentEncoding: src.ContentEncoding,
 			UserMetadata:    copyStringMap(src.UserMetadata),
+			System:          src.S3SystemMetadata,
 		}, nil
 	}
 
@@ -88,6 +104,7 @@ func resolveCopyMetadata(headers map[string]string, src *S3Object) (s3CopyMetada
 		ContentType:     contentType,
 		ContentEncoding: headerValueFold(headers, "Content-Encoding"),
 		UserMetadata:    extractUserMetadata(headers),
+		System:          resolveSystemMetadata(headers),
 	}, nil
 }
 

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -516,16 +516,17 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 	}
 
 	obj := S3Object{
-		Bucket:          bucket,
-		Key:             key,
-		ETag:            etag,
-		ContentType:     contentType,
-		ContentEncoding: s3PersistedContentEncoding(req.Headers),
-		Size:            int64(len(body)),
-		StorageClass:    storageClass,
-		Checksum:        checksum,
-		LastModified:    p.tc.Now(),
-		UserMetadata:    userMeta,
+		Bucket:           bucket,
+		Key:              key,
+		ETag:             etag,
+		ContentType:      contentType,
+		ContentEncoding:  s3PersistedContentEncoding(req.Headers),
+		S3SystemMetadata: resolveSystemMetadata(req.Headers),
+		Size:             int64(len(body)),
+		StorageClass:     storageClass,
+		Checksum:         checksum,
+		LastModified:     p.tc.Now(),
+		UserMetadata:     userMeta,
 	}
 
 	respHeaders := map[string]string{"ETag": etag}
@@ -1030,12 +1031,13 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	dstChecksum := copyChecksum(copyChecksumAlgorithm, srcBody)
 
 	dstObj := S3Object{
-		Bucket:          dstBucket,
-		Key:             dstKey,
-		ETag:            newETag,
-		ContentType:     meta.ContentType,
-		ContentEncoding: meta.ContentEncoding,
-		Size:            srcObj.Size,
+		Bucket:           dstBucket,
+		Key:              dstKey,
+		ETag:             newETag,
+		ContentType:      meta.ContentType,
+		ContentEncoding:  meta.ContentEncoding,
+		S3SystemMetadata: meta.System,
+		Size:             srcObj.Size,
 		// The copy's class comes from the request, never from the source: "if the
 		// x-amz-storage-class header is not used, the copied object will be stored in
 		// the STANDARD Storage Class by default."
@@ -1304,6 +1306,7 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		Key:               key,
 		ContentType:       contentType,
 		ContentEncoding:   s3PersistedContentEncoding(req.Headers),
+		S3SystemMetadata:  resolveSystemMetadata(req.Headers),
 		StorageClass:      storageClass,
 		ChecksumAlgorithm: checksumAlgorithm,
 		ChecksumType:      checksumType,
@@ -1557,11 +1560,15 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		ETag:            etag,
 		ContentType:     upload.ContentType,
 		ContentEncoding: upload.ContentEncoding,
-		Size:            int64(len(combined)),
-		StorageClass:    upload.StorageClass,
-		Checksum:        checksum,
-		LastModified:    p.tc.Now(),
-		UserMetadata:    upload.UserMetadata,
+		// The whole metadata family crosses in one assignment, because both structs
+		// embed the same declaration. A header added to S3SystemMetadata is carried
+		// here without touching this line — which is the point of embedding it.
+		S3SystemMetadata: upload.S3SystemMetadata,
+		Size:             int64(len(combined)),
+		StorageClass:     upload.StorageClass,
+		Checksum:         checksum,
+		LastModified:     p.tc.Now(),
+		UserMetadata:     upload.UserMetadata,
 	}
 	objData, err := json.Marshal(obj)
 	if err != nil {
@@ -2190,6 +2197,10 @@ func objectResponseHeaders(obj *S3Object) map[string]string {
 	if obj.ContentEncoding != "" {
 		headers["Content-Encoding"] = obj.ContentEncoding
 	}
+	// Cache-Control, Content-Disposition, Content-Language and Expires, each emitted
+	// only when the object carries it: S3 returns no header for metadata that was
+	// never set, and an empty value is a different observation from an absent one.
+	obj.emit(headers)
 	if obj.VersionID != "" {
 		headers["x-amz-version-id"] = obj.VersionID
 	}

--- a/emulator/s3_system_metadata.go
+++ b/emulator/s3_system_metadata.go
@@ -1,0 +1,92 @@
+package emulator
+
+// S3SystemMetadata holds the user-controlled system-metadata headers S3 stores on
+// an object and returns on every read: Cache-Control, Content-Disposition,
+// Content-Language and Expires (#430).
+//
+// It is embedded in both [S3Object] and [S3MultipartUpload] rather than declared
+// twice, so the two write paths cannot disagree about which headers survive a
+// write. That divergence is exactly what #406 was — Content-Encoding was carried
+// through PutObject and dropped by the multipart path — and one shared declaration
+// makes the repeat structurally impossible: CompleteMultipartUpload copies the
+// whole struct in one assignment, so a header added here is carried by both paths
+// or by neither.
+//
+// The four are grouped because substrate treats them identically: recorded verbatim
+// from the request, echoed verbatim on a read, never interpreted. Content-Type,
+// Content-Encoding and the storage class are user-controlled system metadata too
+// but are deliberately *not* in this struct — each has resolution rules of its own
+// (a default of application/octet-stream, aws-chunked filtering, and a
+// STANDARD-means-absent read rule respectively), so folding them in would mean
+// special cases in every helper below.
+//
+// Values are stored as strings, Expires included. The Go SDK's own GetObject output
+// deprecates its time.Time Expires in favor of ExpiresString, described as "the
+// unparsed value of the Expires field from the service response" — S3 stores and
+// returns whatever the caller sent, so parsing it here would be lower fidelity, not
+// higher. A malformed date round-trips unchanged, which is what real S3 does and
+// what lets a consumer's parse-failure branch be tested at all.
+type S3SystemMetadata struct {
+	// CacheControl is the Cache-Control header recorded on write, echoed on read.
+	CacheControl string `json:"cache_control,omitempty"`
+
+	// ContentDisposition is the Content-Disposition header recorded on write,
+	// echoed on read — the "attachment; filename=…" download name.
+	ContentDisposition string `json:"content_disposition,omitempty"`
+
+	// ContentLanguage is the Content-Language header recorded on write, echoed on
+	// read.
+	ContentLanguage string `json:"content_language,omitempty"`
+
+	// Expires is the Expires header recorded on write, echoed on read, stored
+	// verbatim and never parsed as a date.
+	Expires string `json:"expires,omitempty"`
+}
+
+// s3MetadataField pairs a metadata header's wire name with the field holding it, so
+// capture, emission and copying all walk one list instead of repeating the family
+// member by member.
+type s3MetadataField struct {
+	header string
+	value  *string
+}
+
+// fields returns the header-to-field pairing in a fixed order. Adding a header to
+// this family means one new struct field and one new entry here; nothing else in the
+// emulator enumerates them.
+func (m *S3SystemMetadata) fields() []s3MetadataField {
+	return []s3MetadataField{
+		{header: "Cache-Control", value: &m.CacheControl},
+		{header: "Content-Disposition", value: &m.ContentDisposition},
+		{header: "Content-Language", value: &m.ContentLanguage},
+		{header: "Expires", value: &m.Expires},
+	}
+}
+
+// resolveSystemMetadata reads the metadata family from request headers.
+//
+// Headers are matched case-insensitively via [headerValueFold] rather than by direct
+// map access: an [AWSRequest] reaching a plugin has not always been through
+// net/http's header canonicalization, since substrate builds requests in-process too
+// (see betty_cfn.go), and RFC 9110 header names are case-insensitive regardless.
+//
+// An absent header yields the empty string, which [S3SystemMetadata.emit] omits from
+// the response — S3 returns no header for metadata that was never set, and an empty
+// Cache-Control on a read is a different observation from no Cache-Control at all.
+func resolveSystemMetadata(headers map[string]string) S3SystemMetadata {
+	var meta S3SystemMetadata
+	for _, f := range meta.fields() {
+		*f.value = headerValueFold(headers, f.header)
+	}
+	return meta
+}
+
+// emit adds every recorded metadata header to a response header map, skipping the
+// ones the object does not carry.
+func (m *S3SystemMetadata) emit(dst map[string]string) {
+	for _, f := range m.fields() {
+		if *f.value != "" {
+			dst[f.header] = *f.value
+		}
+	}
+}

--- a/emulator/s3_system_metadata_test.go
+++ b/emulator/s3_system_metadata_test.go
@@ -1,0 +1,511 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// s3SystemMetadataHeaders is the family under test (#430), with a distinguishable
+// value for each. Table-driving the header *name* is what keeps a test from passing
+// because one header happens to work — the family drifting apart on a single member
+// is what #406 was.
+var s3SystemMetadataHeaders = []struct {
+	header string
+	value  string
+}{
+	{"Cache-Control", "max-age=3600, public"},
+	{"Content-Disposition", `attachment; filename="report.pdf"`},
+	{"Content-Language", "en-GB"},
+	{"Expires", "Wed, 21 Oct 2026 07:28:00 GMT"},
+}
+
+// s3SystemMetadataAll returns every family header as a request-header map, so a
+// write can set the whole family in one call.
+func s3SystemMetadataAll() map[string]string {
+	headers := make(map[string]string, len(s3SystemMetadataHeaders))
+	for _, h := range s3SystemMetadataHeaders {
+		headers[h.header] = h.value
+	}
+	return headers
+}
+
+// assertSystemMetadata asserts the response carries every family header with the
+// value the write supplied.
+func assertSystemMetadata(t *testing.T, got http.Header, context string) {
+	t.Helper()
+	for _, h := range s3SystemMetadataHeaders {
+		assert.Equal(t, h.value, got.Get(h.header), "%s: %s", context, h.header)
+	}
+}
+
+// assertNoSystemMetadata asserts the response carries none of the family headers.
+// An object written without them must produce no header at all, not an empty one:
+// "Cache-Control: " and no Cache-Control are different observations, and an SDK
+// that distinguishes nil from "" would report the wrong one.
+func assertNoSystemMetadata(t *testing.T, got http.Header, context string) {
+	t.Helper()
+	for _, h := range s3SystemMetadataHeaders {
+		_, present := got[http.CanonicalHeaderKey(h.header)]
+		assert.False(t, present, "%s: %s must be absent, not empty", context, h.header)
+	}
+}
+
+// newS3PluginDirect returns an initialized S3 plugin with no server in front of it,
+// for the one test that must hand it non-canonical header names — Go canonicalizes
+// them on the ServeHTTP path, so a lowercase header sent through the server would
+// arrive canonical and prove nothing.
+func newS3PluginDirect(t *testing.T) *emulator.S3Plugin {
+	t.Helper()
+	p := &emulator.S3Plugin{}
+	require.NoError(t, p.Initialize(t.Context(), emulator.PluginConfig{
+		State:  emulator.NewMemoryStateManager(),
+		Logger: emulator.NewDefaultLogger(slog.LevelError, false),
+		Options: map[string]any{
+			"time_controller": emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)),
+			"filesystem":      afero.NewMemMapFs(),
+		},
+	}))
+	return p
+}
+
+// TestS3_SystemMetadata_PutObjectRoundTrip asserts the family persists through
+// PutObject and is returned by both GetObject and HeadObject. Substrate previously
+// accepted these headers and discarded them, so a consumer asserting "the download
+// filename survives an upload" passed while verifying nothing (#430).
+func TestS3_SystemMetadata_PutObjectRoundTrip(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta/doc", []byte("payload"), s3SystemMetadataAll()).Code)
+
+	gw := s3Request(t, srv, http.MethodGet, "/sysmeta/doc", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assertSystemMetadata(t, gw.Header(), "GetObject")
+
+	hw := s3Request(t, srv, http.MethodHead, "/sysmeta/doc", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assertSystemMetadata(t, hw.Header(), "HeadObject")
+}
+
+// TestS3_SystemMetadata_PutObjectPerHeader asserts each header survives on its own,
+// so the round-trip test cannot pass on one header's behalf. Setting one also pins
+// that it does not cause the others to be emitted.
+func TestS3_SystemMetadata_PutObjectPerHeader(t *testing.T) {
+	for _, h := range s3SystemMetadataHeaders {
+		t.Run(h.header, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sysmeta-one", nil, nil).Code)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sysmeta-one/obj", []byte("x"),
+					map[string]string{h.header: h.value}).Code)
+
+			hw := s3Request(t, srv, http.MethodHead, "/sysmeta-one/obj", nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code)
+			assert.Equal(t, h.value, hw.Header().Get(h.header))
+
+			for _, other := range s3SystemMetadataHeaders {
+				if other.header == h.header {
+					continue
+				}
+				_, present := hw.Header()[http.CanonicalHeaderKey(other.header)]
+				assert.False(t, present, "%s must stay absent", other.header)
+			}
+		})
+	}
+}
+
+// TestS3_SystemMetadata_AbsentHeadersNotEmitted asserts an object written without
+// the family produces no family headers on a read — the acceptance criterion that
+// absent headers are absent rather than empty.
+func TestS3_SystemMetadata_AbsentHeadersNotEmitted(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-bare", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-bare/obj", []byte("x"), nil).Code)
+
+	gw := s3Request(t, srv, http.MethodGet, "/sysmeta-bare/obj", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assertNoSystemMetadata(t, gw.Header(), "GetObject")
+
+	hw := s3Request(t, srv, http.MethodHead, "/sysmeta-bare/obj", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assertNoSystemMetadata(t, hw.Header(), "HeadObject")
+}
+
+// TestS3_SystemMetadata_ExpiresStoredVerbatim asserts Expires is never parsed as a
+// date: an unparseable value round-trips unchanged rather than being normalized or
+// dropped.
+//
+// This is the deliberate design decision on Expires the issue asked to record. S3
+// stores and returns what the caller sent; the Go SDK's own GetObject output
+// deprecates its time.Time Expires in favor of ExpiresString, "the unparsed value
+// of the Expires field from the service response". Parsing here would be lower
+// fidelity, and would make a consumer's parse-failure branch unreachable — the
+// vacuous-pass shape this whole issue is about.
+func TestS3_SystemMetadata_ExpiresStoredVerbatim(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"RFC 1123 as an SDK sends it", "Wed, 21 Oct 2026 07:28:00 GMT"},
+		{"non-GMT offset", "Wed, 21 Oct 2026 07:28:00 +0100"},
+		{"not a date at all", "tomorrow-ish"},
+		{"a max-age style value", "0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sysmeta-exp", nil, nil).Code)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sysmeta-exp/obj", []byte("x"),
+					map[string]string{"Expires": tt.value}).Code)
+
+			hw := s3Request(t, srv, http.MethodHead, "/sysmeta-exp/obj", nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code)
+			assert.Equal(t, tt.value, hw.Header().Get("Expires"),
+				"Expires must round-trip verbatim, never reformatted")
+		})
+	}
+}
+
+// TestS3_SystemMetadata_HeaderCaseInsensitive asserts the family is read
+// case-insensitively. An AWSRequest reaching a plugin has not always been through
+// net/http's canonicalization, since substrate builds requests in-process too.
+//
+// It goes through the plugin directly rather than s3Request for exactly that reason:
+// on the ServeHTTP path Go canonicalizes header names, so a lowercase header sent
+// through the server would arrive canonical and the test would prove nothing.
+func TestS3_SystemMetadata_HeaderCaseInsensitive(t *testing.T) {
+	p := newS3PluginDirect(t)
+	rctx := &emulator.RequestContext{AccountID: "000000000000", Region: "us-east-1"}
+
+	// Operation carries the HTTP verb on entry; the plugin resolves the semantic
+	// operation from it and the path, exactly as the server pipeline does.
+	_, err := p.HandleRequest(rctx, &emulator.AWSRequest{
+		Service: "s3", Operation: http.MethodPut, Path: "/case-bucket",
+		Headers: map[string]string{}, Params: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	_, err = p.HandleRequest(rctx, &emulator.AWSRequest{
+		Service:   "s3",
+		Operation: http.MethodPut,
+		Path:      "/case-bucket/obj",
+		Body:      []byte("x"),
+		Params:    map[string]string{},
+		Headers: map[string]string{
+			"cache-control":       "no-store",
+			"CONTENT-DISPOSITION": "inline",
+			"content-Language":    "fr",
+			"expires":             "0",
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := p.HandleRequest(rctx, &emulator.AWSRequest{
+		Service: "s3", Operation: http.MethodHead, Path: "/case-bucket/obj",
+		Headers: map[string]string{}, Params: map[string]string{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "no-store", resp.Headers["Cache-Control"])
+	assert.Equal(t, "inline", resp.Headers["Content-Disposition"])
+	assert.Equal(t, "fr", resp.Headers["Content-Language"])
+	assert.Equal(t, "0", resp.Headers["Expires"])
+}
+
+// TestS3_SystemMetadata_MultipartRoundTrip asserts the family supplied at
+// CreateMultipartUpload reaches the assembled object. Create is the only place it
+// can be supplied — CompleteMultipartUpload accepts no object-metadata headers — so
+// a value not carried on the upload record is lost for good, which is the #406
+// failure shape.
+func TestS3_SystemMetadata_MultipartRoundTrip(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-mpu", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/sysmeta-mpu/big?uploads", nil, s3SystemMetadataAll())
+	require.Equal(t, http.StatusOK, iw.Code)
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	etag := uploadPart(t, srv, "sysmeta-mpu", "big", ir.UploadID, 1, []byte("a single part is exempt from the floor"))
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPost, "/sysmeta-mpu/big?uploadId="+ir.UploadID,
+			completeBody(etag), nil).Code)
+
+	gw := s3Request(t, srv, http.MethodGet, "/sysmeta-mpu/big", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assertSystemMetadata(t, gw.Header(), "GetObject after Complete")
+
+	hw := s3Request(t, srv, http.MethodHead, "/sysmeta-mpu/big", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assertSystemMetadata(t, hw.Header(), "HeadObject after Complete")
+}
+
+// TestS3_SystemMetadata_MultipartCompleteHeadersIgnored asserts the family cannot be
+// supplied at Complete. Per the API reference, CompleteMultipartUpload takes only the
+// checksum family, x-amz-mp-object-size, request-payer, SSE-C and the conditional
+// headers — so a caller setting Cache-Control there gets no effect, and one set at
+// Create is not overridden by a differing value at Complete.
+func TestS3_SystemMetadata_MultipartCompleteHeadersIgnored(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-late", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/sysmeta-late/big?uploads", nil,
+		map[string]string{"Cache-Control": "max-age=60"})
+	require.Equal(t, http.StatusOK, iw.Code)
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	etag := uploadPart(t, srv, "sysmeta-late", "big", ir.UploadID, 1, []byte("body"))
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPost, "/sysmeta-late/big?uploadId="+ir.UploadID,
+			completeBody(etag), map[string]string{
+				"Cache-Control":       "no-store",
+				"Content-Disposition": "attachment",
+			}).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sysmeta-late/big", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "max-age=60", hw.Header().Get("Cache-Control"),
+		"Complete accepts no metadata headers; Create's value stands")
+	_, present := hw.Header()[http.CanonicalHeaderKey("Content-Disposition")]
+	assert.False(t, present, "a Content-Disposition set only at Complete is ignored")
+}
+
+// TestS3_SystemMetadata_MultipartAbsentNotEmitted asserts a multipart object created
+// without the family emits none of it, so the carry cannot smuggle in empty headers.
+func TestS3_SystemMetadata_MultipartAbsentNotEmitted(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-mpu-bare", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/sysmeta-mpu-bare/big?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, iw.Code)
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	etag := uploadPart(t, srv, "sysmeta-mpu-bare", "big", ir.UploadID, 1, []byte("body"))
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPost, "/sysmeta-mpu-bare/big?uploadId="+ir.UploadID,
+			completeBody(etag), nil).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sysmeta-mpu-bare/big", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assertNoSystemMetadata(t, hw.Header(), "HeadObject after bare Complete")
+}
+
+// TestS3_SystemMetadata_CopyObjectCopyDirective asserts COPY — the default —
+// preserves the family from the source and ignores headers restated on the request:
+// "when you copy an object, user-controlled system metadata and user-defined
+// metadata are also copied", and all four are user-controlled.
+func TestS3_SystemMetadata_CopyObjectCopyDirective(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive string
+	}{
+		{"default (no directive header)", ""},
+		{"explicit COPY", "COPY"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sysmeta-cp", nil, nil).Code)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sysmeta-cp/src", []byte("payload"),
+					s3SystemMetadataAll()).Code)
+
+			headers := map[string]string{"X-Amz-Copy-Source": "/sysmeta-cp/src"}
+			if tt.directive != "" {
+				headers["x-amz-metadata-directive"] = tt.directive
+			}
+			// Restated values a COPY must ignore.
+			headers["Cache-Control"] = "no-store"
+			headers["Content-Language"] = "de"
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sysmeta-cp/dst", nil, headers).Code)
+
+			hw := s3Request(t, srv, http.MethodHead, "/sysmeta-cp/dst", nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code)
+			assertSystemMetadata(t, hw.Header(), "COPY destination")
+		})
+	}
+}
+
+// TestS3_SystemMetadata_CopyObjectReplaceDirective asserts REPLACE drops what the
+// request does not restate and takes what it does. The single
+// x-amz-metadata-directive governs the whole family — S3 documents no per-header
+// variant — so a REPLACE restating only Content-Type loses the download name a
+// consumer set, which is the failure being modeled rather than a shortcut.
+func TestS3_SystemMetadata_CopyObjectReplaceDirective(t *testing.T) {
+	t.Run("omitted metadata is dropped", func(t *testing.T) {
+		srv, _ := newS3TestServer(t)
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/sysmeta-repl", nil, nil).Code)
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/sysmeta-repl/src", []byte("payload"),
+				s3SystemMetadataAll()).Code)
+
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/sysmeta-repl/dst", nil, map[string]string{
+				"X-Amz-Copy-Source":        "/sysmeta-repl/src",
+				"x-amz-metadata-directive": "REPLACE",
+				"Content-Type":             "text/plain",
+			}).Code)
+
+		hw := s3Request(t, srv, http.MethodHead, "/sysmeta-repl/dst", nil, nil)
+		require.Equal(t, http.StatusOK, hw.Code)
+		assertNoSystemMetadata(t, hw.Header(), "REPLACE destination")
+		assert.Equal(t, "text/plain", hw.Header().Get("Content-Type"),
+			"the one restated header is kept")
+	})
+
+	t.Run("restated metadata is kept", func(t *testing.T) {
+		srv, _ := newS3TestServer(t)
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/sysmeta-repl2", nil, nil).Code)
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/sysmeta-repl2/src", []byte("payload"),
+				map[string]string{"Cache-Control": "max-age=60"}).Code)
+
+		headers := s3SystemMetadataAll()
+		headers["X-Amz-Copy-Source"] = "/sysmeta-repl2/src"
+		headers["x-amz-metadata-directive"] = "REPLACE"
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/sysmeta-repl2/dst", nil, headers).Code)
+
+		hw := s3Request(t, srv, http.MethodHead, "/sysmeta-repl2/dst", nil, nil)
+		require.Equal(t, http.StatusOK, hw.Code)
+		assertSystemMetadata(t, hw.Header(), "REPLACE destination with everything restated")
+	})
+
+	t.Run("each header is independently replaceable", func(t *testing.T) {
+		for _, h := range s3SystemMetadataHeaders {
+			t.Run(h.header, func(t *testing.T) {
+				srv, _ := newS3TestServer(t)
+				require.Equal(t, http.StatusOK,
+					s3Request(t, srv, http.MethodPut, "/sysmeta-repl3", nil, nil).Code)
+				require.Equal(t, http.StatusOK,
+					s3Request(t, srv, http.MethodPut, "/sysmeta-repl3/src", []byte("payload"),
+						s3SystemMetadataAll()).Code)
+
+				require.Equal(t, http.StatusOK,
+					s3Request(t, srv, http.MethodPut, "/sysmeta-repl3/dst", nil, map[string]string{
+						"X-Amz-Copy-Source":        "/sysmeta-repl3/src",
+						"x-amz-metadata-directive": "REPLACE",
+						h.header:                   h.value,
+					}).Code)
+
+				hw := s3Request(t, srv, http.MethodHead, "/sysmeta-repl3/dst", nil, nil)
+				require.Equal(t, http.StatusOK, hw.Code)
+				assert.Equal(t, h.value, hw.Header().Get(h.header), "the restated header survives")
+				for _, other := range s3SystemMetadataHeaders {
+					if other.header == h.header {
+						continue
+					}
+					_, present := hw.Header()[http.CanonicalHeaderKey(other.header)]
+					assert.False(t, present, "%s was not restated and must be dropped", other.header)
+				}
+			})
+		}
+	})
+}
+
+// TestS3_SystemMetadata_CopyObjectDoesNotAliasSource asserts a COPY leaves the
+// destination's metadata independent of the source's, so overwriting one does not
+// change the other. S3SystemMetadata is a value type, which is what makes this hold
+// — unlike UserMetadata, which needs an explicit map copy.
+func TestS3_SystemMetadata_CopyObjectDoesNotAliasSource(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-alias", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-alias/src", []byte("payload"),
+			map[string]string{"Cache-Control": "max-age=60"}).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-alias/dst", nil, map[string]string{
+			"X-Amz-Copy-Source": "/sysmeta-alias/src",
+		}).Code)
+
+	// Overwrite the source with a different value.
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-alias/src", []byte("payload"),
+			map[string]string{"Cache-Control": "no-store"}).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sysmeta-alias/dst", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "max-age=60", hw.Header().Get("Cache-Control"),
+		"the copy keeps the value it was made from")
+}
+
+// TestS3_SystemMetadata_SurvivesVersioning asserts the family is recorded on a
+// versioned object and returned when that version is read by ID, since a versioned
+// PUT marshals the object a second time under its own key.
+func TestS3_SystemMetadata_SurvivesVersioning(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-ver", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-ver?versioning",
+			[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil).Code)
+
+	pw := s3Request(t, srv, http.MethodPut, "/sysmeta-ver/obj", []byte("v1"), s3SystemMetadataAll())
+	require.Equal(t, http.StatusOK, pw.Code)
+	versionID := pw.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, versionID)
+
+	// A second write with none of the family, so reading the first version by ID
+	// cannot be satisfied by the current object.
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-ver/obj", []byte("v2"), nil).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sysmeta-ver/obj?versionId="+versionID, nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assertSystemMetadata(t, hw.Header(), "HeadObject by versionId")
+
+	cw := s3Request(t, srv, http.MethodHead, "/sysmeta-ver/obj", nil, nil)
+	require.Equal(t, http.StatusOK, cw.Code)
+	assertNoSystemMetadata(t, cw.Header(), "current version, written without the family")
+}
+
+// TestS3_SystemMetadata_RangedReadCarriesHeaders asserts a 206 response carries the
+// family too. A ranged read builds its own Content-Length and Content-Range over the
+// common header set, so it is worth pinning that it does not lose the rest.
+func TestS3_SystemMetadata_RangedReadCarriesHeaders(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-range", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sysmeta-range/obj", []byte("0123456789"),
+			s3SystemMetadataAll()).Code)
+
+	gw := s3Request(t, srv, http.MethodGet, "/sysmeta-range/obj", nil,
+		map[string]string{"Range": "bytes=2-5"})
+	require.Equal(t, http.StatusPartialContent, gw.Code)
+	assertSystemMetadata(t, gw.Header(), "ranged GetObject")
+}

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -43,6 +43,12 @@ type S3Object struct {
 	// encoding is never recorded here; see [s3PersistedContentEncoding].
 	ContentEncoding string `json:"content_encoding,omitempty"`
 
+	// S3SystemMetadata carries Cache-Control, Content-Disposition,
+	// Content-Language and Expires. Embedded so it is declared once and shared
+	// with [S3MultipartUpload], which is what keeps the two write paths from
+	// drifting on the family.
+	S3SystemMetadata
+
 	// Size is the byte length of the object body.
 	Size int64 `json:"size"`
 
@@ -153,6 +159,14 @@ type S3MultipartUpload struct {
 	// headers, so an encoding not carried here is lost for good. The aws-chunked
 	// transfer encoding is never recorded here; see [s3PersistedContentEncoding].
 	ContentEncoding string `json:"content_encoding,omitempty"`
+
+	// S3SystemMetadata carries the Cache-Control, Content-Disposition,
+	// Content-Language and Expires headers supplied at upload creation, applied to
+	// the object CompleteMultipartUpload assembles. Create is the only place they
+	// can be supplied, for the reason ContentEncoding is. Embedded so the field set
+	// is literally the same declaration [S3Object] uses and Complete can carry the
+	// family across in one assignment.
+	S3SystemMetadata
 
 	// StorageClass is the storage class supplied at upload creation, applied to
 	// the object CompleteMultipartUpload assembles. Empty means STANDARD.


### PR DESCRIPTION
Closes #430

**Stacked on #440** (`fix/429-sqs-createqueue-errors`), which is itself stacked on #438 — all three touch `CHANGELOG.md`. Bases retarget automatically as each merges.

## The gap

`S3Object` had **no fields** for these at all. Substrate accepted the headers on write and silently discarded them, so `GetObject`/`HeadObject` never reported them. A consumer asserting that an `attachment; filename=` download name or a cache lifetime survives an upload got a green test verifying nothing — the write appeared to succeed. Real S3 persists all of them as object metadata and returns them on every read.

## One declaration, not four fields × five sites

The four live in one embedded struct, `S3SystemMetadata`, shared by `S3Object` and `S3MultipartUpload`. That is the structural point of the change rather than a style preference: **the two write paths drifting apart on a single header is exactly what #406 was.** With one declaration, `CompleteMultipartUpload` carries the family across in a single assignment, so a header added to the family is carried by both paths or by neither — the repeat becomes impossible rather than merely unlikely.

Capture, emission and copying all walk one header-to-field list, so adding a member is one struct field plus one list entry. Nothing else in the emulator enumerates them.

## The five sites

| Site | Behavior |
|---|---|
| `S3Object` / `S3MultipartUpload` | one embedded `S3SystemMetadata` |
| `objectResponseHeaders` | emits each, only when non-empty |
| `putObject` | captures via `resolveSystemMetadata` |
| `createMultipartUpload` → `completeMultipartUpload` | recorded on the upload, carried onto the object |
| `resolveCopyMetadata` | COPY/REPLACE under the existing directive |

## CopyObject: one directive governs the family

S3 documents a single `x-amz-metadata-directive` over "the metadata", with no per-header variant, and all four are user-controlled system metadata by the same definition `Content-Type` and `Content-Encoding` are. So a `REPLACE` restating only `Content-Type` **drops the download name a consumer set**. That is the failure being modeled, not an implementation shortcut, and it is documented as such — with a test asserting each header is independently restatable but must actually be restated.

`Complete` accepts no object-metadata headers (the reference lists only the checksum family, `x-amz-mp-object-size`, request-payer, SSE-C and the conditional headers), so `Create` is the only place the family can be supplied. A value set at `Complete` is ignored rather than applied late — pinned by test.

## Absent stays absent

An object written without a header produces **no header**, not an empty one. `Cache-Control: ` and no `Cache-Control` are different observations, and an SDK distinguishing nil from `""` would report the wrong one. Asserted on both read paths, on both write paths, and on the `REPLACE` drop.

## The `Expires` decision

**Stored as a string, never parsed.** Real S3 returns what the caller sent; the Go SDK's own `GetObject` output deprecates its `time.Time` `Expires` in favor of `ExpiresString` — "the unparsed value of the `Expires` field from the service response". Parsing here would be *lower* fidelity, and would make a consumer's parse-failure branch unreachable, which is the same vacuous-pass shape this issue is about. A malformed value round-trips unchanged; four value shapes are covered including `tomorrow-ish` and a non-GMT offset.

`Content-Type`, `Content-Encoding` and the storage class stay out of the struct deliberately — each has resolution rules of its own (a default of `application/octet-stream`, `aws-chunked` filtering, a `STANDARD`-means-absent read rule), so folding them in would mean special cases in every helper.

## Verified against the model, not from memory

botocore's S3 model confirms all four are `location: header` members of `PutObject`, `CreateMultipartUpload` and `CopyObject` inputs, and header members of the `GetObject`/`HeadObject` outputs — and that `CompleteMultipartUpload` has none of them on either side. `aws-sdk-go-v2/service/s3@v1.88.4` agrees on the wire names and on the `Expires`/`ExpiresString` split.

Headers are read with `headerValueFold`: an `AWSRequest` reaching a plugin has not always been through `net/http`'s canonicalization, since substrate builds requests in-process too (`betty_cfn.go`), and RFC 9110 header names are case-insensitive regardless. The case test drives the plugin **directly** for that reason — a lowercase header sent through `ServeHTTP` would arrive canonical and prove nothing.

## Tests

27 subtests in the new `emulator/s3_system_metadata_test.go`, table-driven over the header *name* so a test cannot pass on one header's behalf: PutObject round-trip on GET and HEAD, per-header isolation, absent-not-emitted, the four `Expires` shapes, case-insensitivity via the plugin directly, the multipart carry, Complete-headers-ignored, multipart absent, COPY (default and explicit), REPLACE (dropped / restated / per-header), no aliasing between source and copy, survival through a versioned read by `versionId`, and a ranged 206 carrying the family.

**Mutation-tested with six mutants**, each caught by the tests that should catch it:

| Mutant | Caught by |
|---|---|
| emission removed | nearly every test |
| multipart carry dropped (the #406 shape) | `MultipartRoundTrip`, `MultipartCompleteHeadersIgnored` |
| COPY branch drops the family | `CopyObjectCopyDirective`, `CopyObjectDoesNotAliasSource` |
| REPLACE branch inherits the source | `CopyObjectReplaceDirective` |
| empty values emitted as headers | the four absent-not-emitted assertions |
| case-sensitive header read | `HeaderCaseInsensitive` |

## Docs

New `### Object system metadata` section; the `### Copying objects` directive table and the multipart carry table both extended; the **"not modeled"** paragraph removed, which was the issue's last acceptance criterion. Four ops-table rows annotated. All internal anchors verified to resolve.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race), `test/e2e`, `make docs-reference-check docs-versions`.