### PR TITLE
chore(release): v0.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.83.0] - 2026-08-01
+
 ### Added
 - S3: `Cache-Control`, `Content-Disposition`, `Content-Language` and `Expires`
   persist on an object and are returned on every read (#430). `S3Object` had no
@@ -2724,7 +2726,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.82.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.83.0...HEAD
+[v0.83.0]: https://github.com/scttfrdmn/substrate/compare/v0.82.0...v0.83.0
 [v0.82.0]: https://github.com/scttfrdmn/substrate/compare/v0.81.0...v0.82.0
 [v0.81.0]: https://github.com/scttfrdmn/substrate/compare/v0.80.0...v0.81.0
 [v0.80.0]: https://github.com/scttfrdmn/substrate/compare/v0.76.0...v0.80.0


### PR DESCRIPTION
Cuts **v0.83.0**. Changelog-only — no code changes; every fix in it is already on `main`.

## What's in the release

Four consumer-filed fidelity issues, all sharing one shape: **substrate returned success, or a confident wrong answer, where real AWS signals failure** — so the consumer's error branch was unreachable and their suite reported green while verifying nothing.

| Issue | Change |
|---|---|
| #428 | S3 no longer records the `aws-chunked` transfer encoding as an object's `Content-Encoding` |
| #429 | SQS `CreateQueue` raises `QueueNameExists` on an attribute conflict; `QueueDeletedRecently` is seedable |
| #430 | S3 persists `Cache-Control`, `Content-Disposition`, `Content-Language` and `Expires` |
| #431 | EC2 `RunInstances` validates `MinCount`/`MaxCount` instead of silently clamping them |

## Why minor, not patch

Two of the four **add** observable surface — the SQS `deletedRecentlyMisses` seed and an S3 metadata family that previously had no fields at all — so this is not purely corrective.

Absence still defaults everywhere it did before: the new seed counter defaults to 0, and an omitted `MinCount`/`MaxCount` still means one instance. Unseeded behaviour is unchanged.

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race), `test/e2e`, `make docs-reference-check docs-versions` — all green on the merged `main` this branches from, and the doc/version checks re-run after the changelog edit.

Per `CLAUDE.md`, the `v0.83.0` tag is created **only after this merges**, against the merge commit — never as a side effect of it.