### PR TITLE
feat(ec2): stamp aws:ec2:fleet-id on fleet instances (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- EC2: `CreateFleet` stamps the reserved `aws:ec2:fleet-id` tag on every instance
+  it launches, so a fleet's instances are reachable with a `DescribeInstances`
+  `tag:aws:ec2:fleet-id` filter (#443). Without it there was no route from a fleet
+  ID back to its instances at all: `DescribeFleetInstances` rejects `instant`
+  fleets outright, and the `fleetInstanceSet` a fleet response echoes is a record
+  of what was launched rather than what is running — it never drops terminated
+  instances. A consumer enumerating an instant fleet therefore saw a
+  fully-provisioned fleet as empty, which reads as "the instances are gone" rather
+  than "substrate didn't record this". The tag survives alongside a caller's own
+  launch-time `TagSpecification` entries and is applied per capacity pool, so a
+  multi-pool fleet tags all of its instances.
+
+  Source note: this tag is documented in neither the EC2 API reference nor the
+  fleet tagging and describe pages. Substrate models it on observed real-AWS
+  behaviour reported by the parsl-aws-provider consumer, whose fleet-to-instance
+  lookup is built on it — not on a documented API contract. Substrate also does
+  not yet enforce the rules AWS attaches to the reserved `aws:` prefix
+  (`CreateTags` still accepts an `aws:`-prefixed key that real EC2 rejects); that
+  is tracked separately.
+
 ## [v0.83.0] - 2026-08-01
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -946,7 +946,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | CreateLaunchTemplate | |
 | DescribeLaunchTemplates | |
 | DeleteLaunchTemplate | |
-| CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`. Partial fulfillment is seedable — see below |
+| CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances |
 
@@ -1049,6 +1049,33 @@ An ID is well formed when it has the resource's prefix followed by at least one
 lowercase hex digit. Length is deliberately not checked: substrate's generators
 emit 16 hex characters where AWS emits 8 or 17, and AWS itself still accepts the
 legacy 8-character form for several resources.
+
+### Finding a fleet's instances
+
+Every instance `CreateFleet` launches is tagged `aws:ec2:fleet-id` with the fleet
+that created it, so the fleet's instances are reachable with an ordinary
+`DescribeInstances` tag filter:
+
+```bash
+aws ec2 describe-instances \
+  --filters "Name=tag:aws:ec2:fleet-id,Values=fleet-12a34b56-7890-1cde-2f34-abcdef567890"
+```
+
+For an `instant` fleet this is the only route from a fleet back to its live
+instances. `DescribeFleetInstances` rejects instant fleets outright, and the
+`fleetInstanceSet` in a `CreateFleet`/`DescribeFleets` response is a record of what
+was launched — it never drops instances that have since terminated. Without the tag
+a fully-running fleet is indistinguishable from an empty one.
+
+This tag is modelled from observed behaviour on real AWS rather than from a
+documented API contract: it appears in neither the EC2 API reference nor the fleet
+tagging and describe pages. It is applied to every fleet type, and — unlike a
+caller's own `TagSpecification` entries — it is not scoped by `ResourceType`.
+
+Note that substrate does not yet enforce the two rules AWS attaches to the
+reserved `aws:` prefix: such a tag cannot be edited or deleted by a caller, and
+does not count against the 50-tag limit. `CreateTags` currently accepts an
+`aws:`-prefixed key that real EC2 would reject with `InvalidParameterValue`.
 
 ### Seeding EC2 Fleet partial fulfillment
 

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -308,7 +308,7 @@ func (p *EC2Plugin) createFleet(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 		}
 
 		if gotPerPool[i] > 0 {
-			ids, launchErr := p.launchFleetPool(reqCtx, pool, gotPerPool[i], instanceTags)
+			ids, launchErr := p.launchFleetPool(reqCtx, pool, gotPerPool[i], instanceTags, fleet.FleetID)
 			if launchErr != nil {
 				return nil, launchErr
 			}
@@ -426,11 +426,15 @@ func distributeAcrossPools(n, pools int) []int {
 // runInstances, and returns the resulting instance IDs. Going through
 // runInstances (rather than writing instance state directly) is what makes fleet
 // instances indistinguishable from directly-launched ones to DescribeInstances.
+//
+// fleetID is stamped on every instance as [ec2FleetIDTagKey], which is what lets a
+// caller get from a fleet back to its instances at all (#443).
 func (p *EC2Plugin) launchFleetPool(
 	reqCtx *RequestContext,
 	pool fleetPool,
 	count int,
 	instanceTags map[string]string,
+	fleetID string,
 ) ([]string, error) {
 	params := map[string]string{
 		"Action":   "RunInstances",
@@ -457,6 +461,9 @@ func (p *EC2Plugin) launchFleetPool(
 		params["Placement.GroupName"] = pool.override.PlacementGroupName
 	}
 	for k, v := range instanceTags {
+		params[k] = v
+	}
+	for k, v := range fleetIDTagSpec(instanceTags, fleetID) {
 		params[k] = v
 	}
 
@@ -571,6 +578,50 @@ func passthroughFleetTagSpecs(params map[string]string, resourceType string) map
 		}
 	}
 	return out
+}
+
+// ec2FleetIDTagKey is the reserved tag EC2 stamps on every instance a fleet
+// launches, naming the fleet that created it.
+//
+// Source note: this tag is not described in the EC2 API reference or the fleet
+// tagging/describe pages — the authority is observed real-AWS behavior, reported
+// by the parsl-aws-provider consumer in #443, whose fleet-to-instance lookup is
+// built on it. Substrate models it because for an "instant" fleet it is the only
+// route from a fleet back to its live instances: DescribeFleetInstances rejects
+// instant fleets outright, and DescribeFleets' instance list never drops
+// terminated instances, so a fully-running fleet is indistinguishable from an
+// empty one without this tag. It is deliberately not gated on the fleet type,
+// since real EC2 applies it to every fleet.
+//
+// The "aws:" prefix is reserved: per the EC2 tagging documentation such a tag
+// cannot be edited or deleted by a caller and does not count against the 50-tag
+// per-resource limit. Substrate does not yet enforce either rule on CreateTags.
+const ec2FleetIDTagKey = "aws:ec2:fleet-id"
+
+// fleetIDTagSpec returns the RunInstances TagSpecification params that stamp
+// ec2FleetIDTagKey on a pool's instances.
+//
+// The index is chosen past whatever passthroughFleetTagSpecs already emitted:
+// that function renumbers its output from 1, so reusing an occupied index would
+// silently overwrite a caller's own launch-time tag. existing is the map it
+// returned; an empty fleetID yields no params, so a caller that somehow has no
+// fleet ID launches unchanged rather than stamping an empty tag.
+func fleetIDTagSpec(existing map[string]string, fleetID string) map[string]string {
+	if fleetID == "" {
+		return nil
+	}
+	idx := 1
+	for {
+		if _, taken := existing[fmt.Sprintf("TagSpecification.%d.ResourceType", idx)]; !taken {
+			break
+		}
+		idx++
+	}
+	return map[string]string{
+		fmt.Sprintf("TagSpecification.%d.ResourceType", idx): "instance",
+		fmt.Sprintf("TagSpecification.%d.Tag.1.Key", idx):    ec2FleetIDTagKey,
+		fmt.Sprintf("TagSpecification.%d.Tag.1.Value", idx):  fleetID,
+	}
 }
 
 // fleetTagsFor collects TagSpecification.N tags for resourceType as EC2Tags.

--- a/emulator/ec2_fleet_test.go
+++ b/emulator/ec2_fleet_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -776,4 +777,235 @@ func TestEC2_SeedFleetShortfall_Validation(t *testing.T) {
 	seedFleetShortfall(t, ts, `{"launchTemplate":"lt-scoped","fulfill":0}`)
 	clearFleetShortfall(t, ts, "lt-scoped")
 	clearFleetShortfall(t, ts, "")
+}
+
+// fleetIDTagKey is the reserved tag CreateFleet stamps on its instances (#443).
+const fleetIDTagKey = "aws:ec2:fleet-id"
+
+// describedInstances mirrors the DescribeInstances fields the fleet-id tag tests
+// assert on.
+type describedInstances struct {
+	Instances []struct {
+		InstanceID string `xml:"instanceId"`
+		Tags       []struct {
+			Key   string `xml:"key"`
+			Value string `xml:"value"`
+		} `xml:"tagSet>item"`
+	} `xml:"reservationSet>item>instancesSet>item"`
+}
+
+// instanceTag returns the value of key on the i-th described instance, and
+// whether it was present at all — an absent tag and an empty value are different
+// observations.
+func (d describedInstances) instanceTag(i int, key string) (string, bool) {
+	for _, tag := range d.Instances[i].Tags {
+		if tag.Key == key {
+			return tag.Value, true
+		}
+	}
+	return "", false
+}
+
+// instanceIDs flattens every instance ID across a CreateFleet response's pools.
+func (r createFleetResp) instanceIDs() []string {
+	var ids []string
+	for _, pool := range r.Instances {
+		ids = append(ids, pool.InstanceIDs...)
+	}
+	return ids
+}
+
+func TestEC2_CreateFleet_AppliesFleetIDTag(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-id-tag")
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+	}, &got)
+	if got.FleetID == "" {
+		t.Fatal("CreateFleet returned no fleetId")
+	}
+	if len(got.instanceIDs()) != 2 {
+		t.Fatalf("launched %d instances, want 2", len(got.instanceIDs()))
+	}
+
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeInstances"}, &desc)
+	if len(desc.Instances) != 2 {
+		t.Fatalf("DescribeInstances returned %d instances, want 2", len(desc.Instances))
+	}
+	for i := range desc.Instances {
+		value, ok := desc.instanceTag(i, fleetIDTagKey)
+		if !ok {
+			t.Errorf("instance %s has no %s tag; tags = %+v",
+				desc.Instances[i].InstanceID, fleetIDTagKey, desc.Instances[i].Tags)
+			continue
+		}
+		if value != got.FleetID {
+			t.Errorf("instance %s %s = %q, want %q",
+				desc.Instances[i].InstanceID, fleetIDTagKey, value, got.FleetID)
+		}
+	}
+}
+
+// TestEC2_CreateFleet_FleetIDTagIsFilterable is the assertion that actually
+// matters: the tag is only useful if DescribeInstances can filter on it. The key
+// contains colons, so this also pins that the tag:<key> filter cuts only its own
+// prefix rather than splitting on every colon.
+func TestEC2_CreateFleet_FleetIDTagIsFilterable(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-id-filter")
+
+	newFleet := func(capacity string) createFleetResp {
+		var got createFleetResp
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CreateFleet",
+			"Type":   "instant",
+			"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+			"TargetCapacitySpecification.TotalTargetCapacity":                      capacity,
+		}, &got)
+		return got
+	}
+
+	first := newFleet("2")
+	second := newFleet("1")
+	if first.FleetID == second.FleetID {
+		t.Fatalf("both fleets share id %q", first.FleetID)
+	}
+
+	// Each fleet's filter must return exactly its own instances, never the other's.
+	for _, fleet := range []createFleetResp{first, second} {
+		var desc describedInstances
+		ec2FleetXML(t, ts, map[string]string{
+			"Action":           "DescribeInstances",
+			"Filter.1.Name":    "tag:" + fleetIDTagKey,
+			"Filter.1.Value.1": fleet.FleetID,
+		}, &desc)
+
+		want := fleet.instanceIDs()
+		if len(desc.Instances) != len(want) {
+			t.Fatalf("filter on %s returned %d instances, want %d",
+				fleet.FleetID, len(desc.Instances), len(want))
+		}
+		for i := range desc.Instances {
+			if !slices.Contains(want, desc.Instances[i].InstanceID) {
+				t.Errorf("filter on %s returned %s, which belongs to another fleet",
+					fleet.FleetID, desc.Instances[i].InstanceID)
+			}
+		}
+	}
+}
+
+// TestEC2_CreateFleet_FleetIDTagCoexistsWithCallerTags guards the index
+// arithmetic in fleetIDTagSpec: the reserved tag is appended past the
+// passthrough tags, so reusing an occupied TagSpecification index would silently
+// overwrite a caller's own launch-time tag.
+func TestEC2_CreateFleet_FleetIDTagCoexistsWithCallerTags(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-id-coexist")
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+		"TagSpecification.1.ResourceType":                                      "instance",
+		"TagSpecification.1.Tag.1.Key":                                         "Name",
+		"TagSpecification.1.Tag.1.Value":                                       "worker",
+		"TagSpecification.1.Tag.2.Key":                                         "Project",
+		"TagSpecification.1.Tag.2.Value":                                       "parsl",
+		"TagSpecification.2.ResourceType":                                      "fleet",
+		"TagSpecification.2.Tag.1.Key":                                         "Owner",
+		"TagSpecification.2.Tag.1.Value":                                       "research",
+	}, &got)
+
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeInstances"}, &desc)
+	if len(desc.Instances) != 1 {
+		t.Fatalf("DescribeInstances returned %d instances, want 1", len(desc.Instances))
+	}
+
+	for key, want := range map[string]string{
+		"Name":        "worker",
+		"Project":     "parsl",
+		fleetIDTagKey: got.FleetID,
+	} {
+		value, ok := desc.instanceTag(0, key)
+		if !ok {
+			t.Errorf("instance is missing tag %q; tags = %+v", key, desc.Instances[0].Tags)
+			continue
+		}
+		if value != want {
+			t.Errorf("instance tag %q = %q, want %q", key, value, want)
+		}
+	}
+	if _, ok := desc.instanceTag(0, "Owner"); ok {
+		t.Error("fleet-scoped tag leaked onto the instance")
+	}
+}
+
+// TestEC2_CreateFleet_FleetIDTagAcrossPools pins that the tag is stamped per
+// pool, not once per fleet: launchFleetPool runs for each pool, so a fleet with
+// several overrides has several chances to drop it.
+func TestEC2_CreateFleet_FleetIDTagAcrossPools(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-id-pools")
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"LaunchTemplateConfigs.1.Overrides.1.InstanceType":                     "t3.small",
+		"LaunchTemplateConfigs.1.Overrides.2.InstanceType":                     "c5.large",
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+	}, &got)
+	if len(got.Instances) != 2 {
+		t.Fatalf("fleetInstanceSet items = %d, want 2 pools", len(got.Instances))
+	}
+
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "DescribeInstances",
+		"Filter.1.Name":    "tag:" + fleetIDTagKey,
+		"Filter.1.Value.1": got.FleetID,
+	}, &desc)
+	if len(desc.Instances) != 2 {
+		t.Errorf("filter returned %d instances, want 2 (one per pool)", len(desc.Instances))
+	}
+}
+
+// TestEC2_CreateFleet_FleetIDTagZeroCapacity covers the pool that launches
+// nothing: a fully-unfulfilled fleet must still succeed rather than erroring in
+// the tag path.
+func TestEC2_CreateFleet_FleetIDTagZeroCapacity(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-id-zero")
+	seedFleetShortfall(t, ts, `{"fulfill":0}`)
+
+	var got createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+	}, &got)
+	if len(got.instanceIDs()) != 0 {
+		t.Errorf("launched %v, want no instances", got.instanceIDs())
+	}
+
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "DescribeInstances",
+		"Filter.1.Name":    "tag:" + fleetIDTagKey,
+		"Filter.1.Value.1": got.FleetID,
+	}, &desc)
+	if len(desc.Instances) != 0 {
+		t.Errorf("filter returned %d instances, want 0", len(desc.Instances))
+	}
 }


### PR DESCRIPTION
## Problem

`CreateFleet` launched its instances through `runInstances` but never tagged them with the fleet that created them, so there was no route from a fleet ID back to its instances.

For an `instant` fleet that tag is the *only* route:

- `DescribeFleetInstances` rejects instant fleets outright.
- The `fleetInstanceSet` a fleet response echoes is a record of what was *launched*, not what is *running* — it never drops terminated instances.

So a consumer enumerating an instant fleet saw a fully-provisioned, running fleet as empty. That reads as "the instances are gone" rather than "substrate didn't record this", which is why the reporter debugged their own code first.

## Change

`fleetIDTagSpec` appends `aws:ec2:fleet-id` to the synthetic `RunInstances` params `launchFleetPool` already builds, at an index **past** whatever `passthroughFleetTagSpecs` emitted — that function renumbers its output from 1, and reusing an occupied `TagSpecification` index would silently overwrite a caller's own launch-time tag. It runs per pool, so a multi-pool fleet tags all of its instances.

## Source note

Stated plainly, because CLAUDE.md makes AWS docs authoritative: `aws:ec2:fleet-id` appears in **neither** the EC2 API reference **nor** the fleet tagging/describe/delete user-guide pages. The authority is observed real-AWS behavior reported by the [parsl-aws-provider](https://github.com/scttfrdmn/parsl-aws-provider) consumer, whose `get_ec2_fleet_instance_ids()` is built on it — not a documented API contract. That provenance is recorded in the code comment, `docs/services.md` and the changelog rather than implied away.

What *is* documented authoritatively, and noted in the docs: the `aws:` prefix is reserved, such a tag cannot be edited or deleted by a caller, and it does not count against the 50-tag limit.

## Deliberately out of scope

`CreateTags` still accepts an `aws:`-prefixed key that real EC2 rejects with `InvalidParameterValue`. That acceptance is *currently the workaround this change removes the need for*, so tightening it in the same release would break the reporter on upgrade with no overlap window. Filed as a follow-up.

## Tests

Five tests in `emulator/ec2_fleet_test.go`:

- the tag lands on every launched instance with the returned `FleetId`
- **`DescribeInstances --filters tag:aws:ec2:fleet-id` returns exactly one fleet's instances** — the assertion that actually matters, and it also pins that the colon-bearing key survives the filter's `tag:` prefix cut rather than being split on every colon
- caller `TagSpecification` tags survive alongside the reserved tag, and the fleet-scoped tag still does not leak (the regression the index arithmetic can break)
- multi-pool fleet tags instances from both pools
- a fully-unfulfilled fleet succeeds and returns no instances

Each was mutation-tested: with the fix removed, four of the five fail.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `make test` (race), `test/e2e`, `make docs-reference-check docs-versions` — all clean.

Closes #443