### PR TITLE
fix(ec2): carry a launch template's network interface to the launch (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- EC2: a launch template's network interface is no longer discarded, so a template
+  that names a subnet, security groups or a public-IP preference is honored on
+  launch (#444). `CreateLaunchTemplate` accepted
+  `LaunchTemplateData.NetworkInterface.1.*` and stored none of it, so an instance
+  launched from such a template landed in a substrate-chosen subnet — a wrong
+  answer returned confidently, with a 200 and a plausible-looking instance.
+
+  This hit exactly the templates configured the way AWS requires: AWS's
+  `RequestLaunchTemplateData` has **no top-level `SubnetId`** member, so a network
+  interface is the only place a template can name a subnet, and the only place
+  `AssociatePublicIpAddress` exists at all. It also produced a confusing
+  asymmetry, since a `CreateFleet` override's subnet *was* honored while the same
+  subnet named in the template was not.
+
+  Precedence follows AWS: a value named in the request wins over the template's,
+  and a fleet override wins over both (it reaches `RunInstances` as a
+  request-level value). `AssociatePublicIpAddress` is stored as a string because
+  three states are observable — absent (use the subnet default), `true` (force one
+  even on a non-default subnet) and `false` (suppress one). The interface's group
+  list is read from `SecurityGroupId.N`, which is what real SDKs send (the AWS
+  model gives the `Groups` member the `locationName` `SecurityGroupId`), with
+  `Groups.N` accepted as a secondary spelling. Only interface index 1 is modeled,
+  matching `RunInstances`.
+
 ### Added
 - EC2: `CreateFleet` stamps the reserved `aws:ec2:fleet-id` tag on every instance
   it launches, so a fleet's instances are reachable with a `DescribeInstances`

--- a/docs/services.md
+++ b/docs/services.md
@@ -943,7 +943,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids) |
-| CreateLaunchTemplate | |
+| CreateLaunchTemplate | Networking is read from `NetworkInterface.1.*` — see [Launch template networking](#launch-template-networking) |
 | DescribeLaunchTemplates | |
 | DeleteLaunchTemplate | |
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
@@ -972,6 +972,43 @@ Note that `ImageId` is an optional `*string` in the typed SDKs, so
 service rather than being caught client-side. That is the shape this check exists
 for. The AMI value itself is not format-validated — substrate accepts any
 non-empty string, so fixtures like `ami-test` work.
+
+### Launch template networking
+
+A launch template's subnet, security groups and public-IP preference are read from
+its **first network interface**:
+
+```
+LaunchTemplateData.NetworkInterface.1.SubnetId
+LaunchTemplateData.NetworkInterface.1.SecurityGroupId.N
+LaunchTemplateData.NetworkInterface.1.AssociatePublicIpAddress
+```
+
+That is not a stylistic choice. AWS's `RequestLaunchTemplateData` has **no
+top-level `SubnetId` member** — a network interface is the only place a template
+can name a subnet, and the only place `AssociatePublicIpAddress` exists at all. So
+a template configured the way AWS requires is precisely the one whose networking
+substrate used to discard.
+
+Note the group parameter name: the AWS model calls that member `Groups` but gives
+it the `locationName` `SecurityGroupId`, so real SDKs send `SecurityGroupId.N`.
+Substrate accepts `Groups.N` as well, for hand-built requests.
+
+Precedence when the same value is available from several sources, matching AWS:
+
+| Source | Wins over |
+|---|---|
+| The request itself — `SubnetId`, or `NetworkInterface.1.SubnetId` | everything below |
+| A `CreateFleet` override's `SubnetId` | the template (it reaches `RunInstances` as a request-level value) |
+| The launch template's network interface | the default VPC |
+| The auto-created default VPC | — |
+
+`AssociatePublicIpAddress` is three-valued, and only a non-default subnet without
+`MapPublicIPOnLaunch` distinguishes them: **absent** uses the subnet's own
+behavior, **`true`** forces a public IP anyway, and **`false`** suppresses one.
+
+Only interface index **1** is modeled, on both `RunInstances` and launch templates.
+A template declaring a second interface loses it silently.
 
 ### MinCount and MaxCount
 

--- a/emulator/ec2_launchtemplate_test.go
+++ b/emulator/ec2_launchtemplate_test.go
@@ -1,0 +1,432 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ltNetwork is the networking a launch-template test asks for and then asserts
+// landed on the instance.
+type ltNetwork struct {
+	vpcID    string
+	subnetID string
+	sgID     string
+}
+
+// newLTNetwork creates a non-default VPC, subnet and security group. Non-default
+// is what makes the assertions meaningful: a default subnet assigns a public IP
+// and resolves a security group on its own, so a dropped template value would
+// still produce a plausible-looking instance.
+func newLTNetwork(t *testing.T, ts *httptest.Server, cidr, name string) ltNetwork {
+	t.Helper()
+	vpcID := createVPC(t, ts, cidr)
+	return ltNetwork{
+		vpcID:    vpcID,
+		subnetID: createSubnet(t, ts, vpcID, cidr[:len(cidr)-6]+"1.0/24"),
+		sgID:     createSecurityGroup(t, ts, vpcID, name),
+	}
+}
+
+// createLaunchTemplate creates a launch template from the given
+// LaunchTemplateData.* params and returns its ID.
+func createLaunchTemplate(t *testing.T, ts *httptest.Server, name string, data map[string]string) string {
+	t.Helper()
+	params := map[string]string{
+		"Action":             "CreateLaunchTemplate",
+		"LaunchTemplateName": name,
+	}
+	for k, v := range data {
+		params[k] = v
+	}
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CreateLaunchTemplate: status = %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		LaunchTemplateID string `xml:"launchTemplate>launchTemplateId"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode CreateLaunchTemplate: %v", err)
+	}
+	if out.LaunchTemplateID == "" {
+		t.Fatal("CreateLaunchTemplate returned no launchTemplateId")
+	}
+	return out.LaunchTemplateID
+}
+
+// launchedInstance is the instance state a launch-template test inspects.
+type launchedInstance struct {
+	InstanceID      string `xml:"instanceId"`
+	SubnetID        string `xml:"subnetId"`
+	VpcID           string `xml:"vpcId"`
+	PublicIPAddress string `xml:"publicIpAddress"`
+	Groups          []struct {
+		GroupID   string `xml:"groupId"`
+		GroupName string `xml:"groupName"`
+	} `xml:"groupSet>item"`
+}
+
+// describeInstance runs DescribeInstances for one instance ID.
+func describeInstance(t *testing.T, ts *httptest.Server, id string) launchedInstance {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{"Action": "DescribeInstances", "InstanceId.1": id})
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		Instances []launchedInstance `xml:"reservationSet>item>instancesSet>item"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode DescribeInstances: %v", err)
+	}
+	if len(out.Instances) != 1 {
+		t.Fatalf("DescribeInstances returned %d instances, want 1", len(out.Instances))
+	}
+	return out.Instances[0]
+}
+
+// runInstance sends RunInstances with the given params and returns the launched
+// instance ID.
+func runInstance(t *testing.T, ts *httptest.Server, params map[string]string) string {
+	t.Helper()
+	full := map[string]string{"Action": "RunInstances", "MinCount": "1", "MaxCount": "1"}
+	for k, v := range params {
+		full[k] = v
+	}
+	resp := ec2Request(t, ts, full)
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("RunInstances: status = %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode RunInstances: %v", err)
+	}
+	if len(out.Instances) != 1 {
+		t.Fatalf("RunInstances launched %d instances, want 1", len(out.Instances))
+	}
+	return out.Instances[0].InstanceID
+}
+
+// TestEC2_LaunchTemplate_SubnetSources walks the four ways a subnet can reach a
+// launch, which is #444's own reproduction table. Cases A and D were the bug: a
+// template's NetworkInterface was parsed and discarded, so an instance landed in
+// a substrate-chosen subnet instead. B and C already worked and are regression
+// guards here — the fix reorders the resolution, which is exactly the kind of
+// change that breaks the paths that were already correct.
+func TestEC2_LaunchTemplate_SubnetSources(t *testing.T) {
+	t.Run("A: template network interface, via RunInstances", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		net := newLTNetwork(t, ts, "10.1.0.0/16", "lt-case-a")
+		ltID := createLaunchTemplate(t, ts, "case-a", map[string]string{
+			"LaunchTemplateData.ImageId":                        "ami-0case00000000001",
+			"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
+			"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
+		})
+
+		id := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+		if got := describeInstance(t, ts, id); got.SubnetID != net.subnetID {
+			t.Errorf("subnetId = %q, want %q from the template's network interface",
+				got.SubnetID, net.subnetID)
+		}
+	})
+
+	t.Run("B: call-level SubnetId", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		net := newLTNetwork(t, ts, "10.2.0.0/16", "lt-case-b")
+		ltID := createLaunchTemplate(t, ts, "case-b", map[string]string{
+			"LaunchTemplateData.ImageId": "ami-0case00000000002",
+		})
+
+		id := runInstance(t, ts, map[string]string{
+			"LaunchTemplate.LaunchTemplateId": ltID,
+			"SubnetId":                        net.subnetID,
+		})
+		if got := describeInstance(t, ts, id); got.SubnetID != net.subnetID {
+			t.Errorf("subnetId = %q, want %q from the call", got.SubnetID, net.subnetID)
+		}
+	})
+
+	t.Run("C: CreateFleet override", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		net := newLTNetwork(t, ts, "10.3.0.0/16", "lt-case-c")
+		ltID := createLaunchTemplate(t, ts, "case-c", map[string]string{
+			"LaunchTemplateData.ImageId": "ami-0case00000000003",
+		})
+
+		var fleet createFleetResp
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CreateFleet",
+			"Type":   "instant",
+			"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+			"LaunchTemplateConfigs.1.Overrides.1.SubnetId":                         net.subnetID,
+			"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+		}, &fleet)
+
+		ids := fleet.instanceIDs()
+		if len(ids) != 1 {
+			t.Fatalf("fleet launched %d instances, want 1", len(ids))
+		}
+		if got := describeInstance(t, ts, ids[0]); got.SubnetID != net.subnetID {
+			t.Errorf("subnetId = %q, want %q from the fleet override", got.SubnetID, net.subnetID)
+		}
+	})
+
+	t.Run("D: template network interface, via CreateFleet with no override", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		net := newLTNetwork(t, ts, "10.4.0.0/16", "lt-case-d")
+		ltID := createLaunchTemplate(t, ts, "case-d", map[string]string{
+			"LaunchTemplateData.ImageId":                        "ami-0case00000000004",
+			"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
+			"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
+		})
+
+		var fleet createFleetResp
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CreateFleet",
+			"Type":   "instant",
+			"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+			"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+		}, &fleet)
+
+		ids := fleet.instanceIDs()
+		if len(ids) != 1 {
+			t.Fatalf("fleet launched %d instances, want 1", len(ids))
+		}
+		if got := describeInstance(t, ts, ids[0]); got.SubnetID != net.subnetID {
+			t.Errorf("subnetId = %q, want %q from the template's network interface",
+				got.SubnetID, net.subnetID)
+		}
+	})
+}
+
+// TestEC2_LaunchTemplate_SubnetPrecedence pins AWS's ordering: a value named in
+// the request wins over the template's, and a fleet override wins over both.
+// Without an explicit assertion the fix could satisfy the four cases above while
+// letting a template silently override an explicit request.
+func TestEC2_LaunchTemplate_SubnetPrecedence(t *testing.T) {
+	ts := newEC2TestServer(t)
+	templateNet := newLTNetwork(t, ts, "10.5.0.0/16", "lt-prec-template")
+	callNet := newLTNetwork(t, ts, "10.6.0.0/16", "lt-prec-call")
+	overrideNet := newLTNetwork(t, ts, "10.7.0.0/16", "lt-prec-override")
+
+	ltID := createLaunchTemplate(t, ts, "precedence", map[string]string{
+		"LaunchTemplateData.ImageId":                        "ami-0prec00000000001",
+		"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
+		"LaunchTemplateData.NetworkInterface.1.SubnetId":    templateNet.subnetID,
+	})
+
+	t.Run("call beats template", func(t *testing.T) {
+		id := runInstance(t, ts, map[string]string{
+			"LaunchTemplate.LaunchTemplateId": ltID,
+			"SubnetId":                        callNet.subnetID,
+		})
+		if got := describeInstance(t, ts, id); got.SubnetID != callNet.subnetID {
+			t.Errorf("subnetId = %q, want the call's %q, not the template's %q",
+				got.SubnetID, callNet.subnetID, templateNet.subnetID)
+		}
+	})
+
+	t.Run("nested call network interface beats template", func(t *testing.T) {
+		id := runInstance(t, ts, map[string]string{
+			"LaunchTemplate.LaunchTemplateId": ltID,
+			"NetworkInterface.1.DeviceIndex":  "0",
+			"NetworkInterface.1.SubnetId":     callNet.subnetID,
+		})
+		if got := describeInstance(t, ts, id); got.SubnetID != callNet.subnetID {
+			t.Errorf("subnetId = %q, want the call's %q, not the template's %q",
+				got.SubnetID, callNet.subnetID, templateNet.subnetID)
+		}
+	})
+
+	t.Run("fleet override beats template", func(t *testing.T) {
+		var fleet createFleetResp
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CreateFleet",
+			"Type":   "instant",
+			"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+			"LaunchTemplateConfigs.1.Overrides.1.SubnetId":                         overrideNet.subnetID,
+			"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+		}, &fleet)
+
+		ids := fleet.instanceIDs()
+		if len(ids) != 1 {
+			t.Fatalf("fleet launched %d instances, want 1", len(ids))
+		}
+		if got := describeInstance(t, ts, ids[0]); got.SubnetID != overrideNet.subnetID {
+			t.Errorf("subnetId = %q, want the override's %q, not the template's %q",
+				got.SubnetID, overrideNet.subnetID, templateNet.subnetID)
+		}
+	})
+}
+
+// TestEC2_LaunchTemplate_SecurityGroups covers both spellings of the network
+// interface's group list. Real SDKs send SecurityGroupId.N — the AWS model gives
+// that member the locationName "SecurityGroupId" — while #444 suggested Groups.N;
+// substrate accepts either, so a hand-built request works too.
+//
+// The group is asserted through RunInstances' own cross-VPC validation rather than
+// a read of the instance: a group that does not belong to the subnet's VPC is
+// rejected with InvalidGroup.NotFound, which can only happen if the template's
+// list was actually read. Instances do not yet echo a groupSet at all — that is
+// the other half of #444, and its tests assert the template's groups directly.
+func TestEC2_LaunchTemplate_SecurityGroups(t *testing.T) {
+	tests := []struct {
+		name  string
+		param string
+	}{
+		{name: "SecurityGroupId.N (what SDKs send)", param: "LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1"},
+		{name: "Groups.N (hand-built form)", param: "LaunchTemplateData.NetworkInterface.1.Groups.1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			net := newLTNetwork(t, ts, "10.8.0.0/16", "lt-sg")
+			other := newLTNetwork(t, ts, "10.11.0.0/16", "lt-sg-other")
+
+			// A group from the template's own VPC launches.
+			sameVPC := createLaunchTemplate(t, ts, "sg-same-"+tt.param, map[string]string{
+				"LaunchTemplateData.ImageId":                        "ami-0sg000000000001",
+				"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
+				"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
+				tt.param: net.sgID,
+			})
+			id := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": sameVPC})
+			if got := describeInstance(t, ts, id); got.SubnetID != net.subnetID {
+				t.Errorf("subnetId = %q, want %q", got.SubnetID, net.subnetID)
+			}
+
+			// A group from a different VPC than the template's subnet must be
+			// rejected — which proves the list was read rather than ignored.
+			crossVPC := createLaunchTemplate(t, ts, "sg-cross-"+tt.param, map[string]string{
+				"LaunchTemplateData.ImageId":                        "ami-0sg000000000002",
+				"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
+				"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
+				tt.param: other.sgID,
+			})
+			status, code := ec2ErrorCode(t, ts, map[string]string{
+				"Action":                          "RunInstances",
+				"MinCount":                        "1",
+				"MaxCount":                        "1",
+				"LaunchTemplate.LaunchTemplateId": crossVPC,
+			})
+			if status != http.StatusBadRequest || code != "InvalidGroup.NotFound" {
+				t.Errorf("cross-VPC group: status/code = %d/%q, want 400/InvalidGroup.NotFound — "+
+					"the template's group list was not read", status, code)
+			}
+		})
+	}
+}
+
+// TestEC2_LaunchTemplate_AssociatePublicIPAddress is why the stored preference is
+// a string rather than a bool: absent, "true" and "false" are three distinct
+// observations, and only a non-default subnet without MapPublicIPOnLaunch can
+// tell them apart.
+func TestEC2_LaunchTemplate_AssociatePublicIPAddress(t *testing.T) {
+	tests := []struct {
+		name          string
+		preference    string
+		wantPublicIP  bool
+		wantPublicWhy string
+	}{
+		{
+			name:          "true forces a public IP on a non-default subnet",
+			preference:    "true",
+			wantPublicIP:  true,
+			wantPublicWhy: "the template requested one",
+		},
+		{
+			name:          "absent uses the subnet default",
+			preference:    "",
+			wantPublicIP:  false,
+			wantPublicWhy: "the subnet is non-default and does not map public IPs",
+		},
+		{
+			name:          "false suppresses one",
+			preference:    "false",
+			wantPublicIP:  false,
+			wantPublicWhy: "the template declined one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			net := newLTNetwork(t, ts, "10.9.0.0/16", "lt-public-ip")
+			data := map[string]string{
+				"LaunchTemplateData.ImageId":                        "ami-0pub00000000001",
+				"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
+				"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
+			}
+			if tt.preference != "" {
+				data["LaunchTemplateData.NetworkInterface.1.AssociatePublicIpAddress"] = tt.preference
+			}
+			ltID := createLaunchTemplate(t, ts, "public-ip", data)
+
+			id := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+			got := describeInstance(t, ts, id)
+			if hasPublicIP := got.PublicIPAddress != ""; hasPublicIP != tt.wantPublicIP {
+				t.Errorf("publicIpAddress = %q, want present = %v (%s)",
+					got.PublicIPAddress, tt.wantPublicIP, tt.wantPublicWhy)
+			}
+		})
+	}
+}
+
+// TestEC2_LaunchTemplate_NoNetworkInterface pins that a template without a
+// network interface still falls through to the auto-created default VPC, which is
+// how every launch-template test that predates #444 worked.
+func TestEC2_LaunchTemplate_NoNetworkInterface(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := createLaunchTemplate(t, ts, "no-ni", map[string]string{
+		"LaunchTemplateData.ImageId":      "ami-0noni0000000001",
+		"LaunchTemplateData.InstanceType": "t3.small",
+	})
+
+	id := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+	got := describeInstance(t, ts, id)
+	if got.SubnetID == "" {
+		t.Error("subnetId is empty; want the auto-created default subnet")
+	}
+	if got.VpcID == "" {
+		t.Error("vpcId is empty; want the auto-created default VPC")
+	}
+	// A default subnet assigns a public IP, which is what distinguishes this
+	// fall-through from the non-default subnets the tests above use.
+	if got.PublicIPAddress == "" {
+		t.Error("publicIpAddress is empty; the default subnet should assign one")
+	}
+}
+
+// TestEC2_LaunchTemplate_DescribeEchoesNetworking pins that the stored template
+// round-trips: DescribeLaunchTemplates is how a consumer confirms what it
+// created, so a template whose networking is parsed but never persisted would
+// still read back wrong.
+func TestEC2_LaunchTemplate_DescribeEchoesNetworking(t *testing.T) {
+	ts := newEC2TestServer(t)
+	net := newLTNetwork(t, ts, "10.10.0.0/16", "lt-echo")
+	ltID := createLaunchTemplate(t, ts, "echo", map[string]string{
+		"LaunchTemplateData.ImageId":                                     "ami-0echo0000000001",
+		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
+		"LaunchTemplateData.NetworkInterface.1.SubnetId":                 net.subnetID,
+		"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1":        net.sgID,
+		"LaunchTemplateData.NetworkInterface.1.AssociatePublicIpAddress": "true",
+	})
+
+	// Launching twice from the same template must be stable — the second launch
+	// reads the template back out of state rather than from the create request.
+	for i := range 2 {
+		id := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+		got := describeInstance(t, ts, id)
+		if got.SubnetID != net.subnetID {
+			t.Errorf("launch %d: subnetId = %q, want %q", i+1, got.SubnetID, net.subnetID)
+		}
+		if got.PublicIPAddress == "" {
+			t.Errorf("launch %d: no public IP, want one from the template", i+1)
+		}
+	}
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -285,10 +285,27 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		subnetID = req.Params["NetworkInterface.1.SubnetId"]
 	}
 	// AssociatePublicIpAddress=true forces a public IP even on a non-default
-	// subnet; "" means "use the subnet default".
-	associatePublicIP := strings.EqualFold(req.Params["NetworkInterface.1.AssociatePublicIpAddress"], "true")
+	// subnet; "" means "use the subnet default". A launch template can also carry
+	// this preference, so the call-level value is kept as the raw string and only
+	// resolved to a bool once the template has had its chance to supply one.
+	publicIPPref := req.Params["NetworkInterface.1.AssociatePublicIpAddress"]
+
+	// Security groups named at call level, from either the top-level params or the
+	// nested NetworkInterface.1.* form (SecurityGroupId.M or Groups.M).
+	securityGroupIDs := indexedParams(req.Params, "SecurityGroupId.%d", "SecurityGroupIds.%d")
+	if len(securityGroupIDs) == 0 {
+		securityGroupIDs = indexedParams(req.Params,
+			"NetworkInterface.1.SecurityGroupId.%d", "NetworkInterface.1.Groups.%d")
+	}
 
 	// Resolve launch template parameters when no ImageId is provided directly.
+	//
+	// Every fallback below is guarded on the call-level value being absent, which is
+	// AWS's precedence: a value named in the request wins over the template's. The
+	// networking fallbacks in particular must run *after* the call-level
+	// NetworkInterface.1.* reads above rather than before them (#444) — the subnet
+	// fallback used to sit ahead of this block, where there was nothing yet to fall
+	// back to.
 	if imageID == "" {
 		ltID := req.Params["LaunchTemplate.LaunchTemplateId"]
 		ltName := req.Params["LaunchTemplate.LaunchTemplateName"]
@@ -300,11 +317,22 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 			if keyName == "" {
 				keyName = lt.LatestData.KeyName
 			}
-			if sgID == "" && len(lt.LatestData.SecurityGroupIDs) > 0 {
-				sgID = lt.LatestData.SecurityGroupIDs[0]
+			if subnetID == "" {
+				subnetID = lt.LatestData.SubnetID
+			}
+			if publicIPPref == "" {
+				publicIPPref = lt.LatestData.AssociatePublicIPAddress
+			}
+			if len(securityGroupIDs) == 0 {
+				securityGroupIDs = lt.LatestData.NetworkSecurityGroupIDs()
+			}
+			if sgID == "" && len(securityGroupIDs) > 0 {
+				sgID = securityGroupIDs[0]
 			}
 		}
 	}
+
+	associatePublicIP := strings.EqualFold(publicIPPref, "true")
 
 	// An AMI must have resolved from *some* source by this point. AWS documents
 	// ImageId as "Required: No" only because a launch template may supply it, so
@@ -339,31 +367,8 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		}
 	}
 
-	// Collect all specified security group IDs, from top-level params or the
-	// nested NetworkInterface.1.* form (SecurityGroupId.M or Groups.M).
-	var securityGroupIDs []string
-	for n := 1; ; n++ {
-		id := req.Params[fmt.Sprintf("SecurityGroupId.%d", n)]
-		if id == "" {
-			id = req.Params[fmt.Sprintf("SecurityGroupIds.%d", n)]
-		}
-		if id == "" {
-			break
-		}
-		securityGroupIDs = append(securityGroupIDs, id)
-	}
-	if len(securityGroupIDs) == 0 {
-		for n := 1; ; n++ {
-			id := req.Params[fmt.Sprintf("NetworkInterface.1.SecurityGroupId.%d", n)]
-			if id == "" {
-				id = req.Params[fmt.Sprintf("NetworkInterface.1.Groups.%d", n)]
-			}
-			if id == "" {
-				break
-			}
-			securityGroupIDs = append(securityGroupIDs, id)
-		}
-	}
+	// sgID may have been filled from the default VPC above, after the call-level and
+	// template lists were resolved.
 	if len(securityGroupIDs) == 0 && sgID != "" {
 		securityGroupIDs = []string{sgID}
 	}
@@ -2558,6 +2563,27 @@ func containsStr(slice []string, s string) bool {
 	return false
 }
 
+// indexedParams collects a 1-based indexed query-parameter list, stopping at the
+// first missing index. Each format is a fmt pattern taking the index; they are
+// tried in order per index, so a caller can accept several spellings of the same
+// list (e.g. AWS's SecurityGroupId.N alongside the SecurityGroupIds.N form some
+// hand-built requests use).
+func indexedParams(params map[string]string, formats ...string) []string {
+	var out []string
+	for n := 1; ; n++ {
+		var value string
+		for _, format := range formats {
+			if value = params[fmt.Sprintf(format, n)]; value != "" {
+				break
+			}
+		}
+		if value == "" {
+			return out
+		}
+		out = append(out, value)
+	}
+}
+
 // filterEmpty removes empty strings from slice.
 func filterEmpty(slice []string) []string {
 	var result []string
@@ -3941,6 +3967,42 @@ func (p *EC2Plugin) resolveLaunchTemplate(goCtx context.Context, ctx *RequestCon
 	return &lt
 }
 
+// parseLaunchTemplateData parses the LaunchTemplateData.* params of a
+// CreateLaunchTemplate request.
+//
+// Networking comes from the first network interface, because AWS's
+// RequestLaunchTemplateData has no top-level SubnetId member — a network interface
+// is the only place a template can name a subnet, and the only place
+// AssociatePublicIpAddress exists at all. Substrate previously accepted those
+// params and stored none of them, so an instance launched from a template
+// configured the way AWS requires landed in a substrate-chosen subnet (#444).
+//
+// Only interface index 1 is modeled, matching runInstances' own NetworkInterface.1
+// handling: a template declaring a second interface silently loses it.
+//
+// The interface's security groups are read from SecurityGroupId.N first, which is
+// what real SDKs send — the AWS model gives that member the locationName
+// "SecurityGroupId" — with Groups.N accepted as a secondary spelling for
+// hand-built requests, mirroring runInstances.
+func parseLaunchTemplateData(params map[string]string) EC2LaunchTemplateData {
+	const niPrefix = "LaunchTemplateData.NetworkInterface.1."
+
+	data := EC2LaunchTemplateData{
+		ImageID:                  params["LaunchTemplateData.ImageId"],
+		InstanceType:             params["LaunchTemplateData.InstanceType"],
+		KeyName:                  params["LaunchTemplateData.KeyName"],
+		UserData:                 params["LaunchTemplateData.UserData"],
+		SubnetID:                 params[niPrefix+"SubnetId"],
+		AssociatePublicIPAddress: params[niPrefix+"AssociatePublicIpAddress"],
+	}
+	if sg1 := params["LaunchTemplateData.SecurityGroupId.1"]; sg1 != "" {
+		data.SecurityGroupIDs = []string{sg1}
+	}
+	data.NetworkInterfaceGroups = indexedParams(params,
+		niPrefix+"SecurityGroupId.%d", niPrefix+"Groups.%d")
+	return data
+}
+
 func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	name := req.Params["LaunchTemplateName"]
 	if name == "" {
@@ -3962,18 +4024,7 @@ func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 	ltID := generateLaunchTemplateID()
 	now := p.tc.Now().UTC().Format(time.RFC3339)
 
-	// Parse launch template data params.
-	ltData := EC2LaunchTemplateData{
-		ImageID:      req.Params["LaunchTemplateData.ImageId"],
-		InstanceType: req.Params["LaunchTemplateData.InstanceType"],
-		KeyName:      req.Params["LaunchTemplateData.KeyName"],
-	}
-	if sg1 := req.Params["LaunchTemplateData.SecurityGroupId.1"]; sg1 != "" {
-		ltData.SecurityGroupIDs = []string{sg1}
-	}
-	if ud := req.Params["LaunchTemplateData.UserData"]; ud != "" {
-		ltData.UserData = ud
-	}
+	ltData := parseLaunchTemplateData(req.Params)
 
 	lt := EC2LaunchTemplate{
 		LaunchTemplateID:   ltID,

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -611,11 +611,50 @@ type EC2LaunchTemplateData struct {
 	// KeyName is the name of the key pair to use.
 	KeyName string `json:"keyName,omitempty"`
 
-	// SecurityGroupIDs is the list of security group IDs.
+	// SecurityGroupIDs is the list of security group IDs, from the template's
+	// top-level SecurityGroupId.N.
 	SecurityGroupIDs []string `json:"securityGroupIds,omitempty"`
 
 	// UserData is the base64-encoded user data script.
 	UserData string `json:"userData,omitempty"`
+
+	// SubnetID is the subnet named in the template's first network interface
+	// (LaunchTemplateData.NetworkInterface.1.SubnetId).
+	//
+	// This is not a mirror of RunInstances' top-level SubnetId: AWS's
+	// RequestLaunchTemplateData has no top-level SubnetId member at all, so a
+	// network interface is the only place a template can name a subnet — and the
+	// only place AssociatePublicIpAddress exists (#444).
+	SubnetID string `json:"subnetId,omitempty"`
+
+	// AssociatePublicIPAddress is the first network interface's public-IP
+	// preference, stored verbatim as a string rather than a bool because three
+	// states are observable: absent (use the subnet's own default), "true" (force
+	// a public IP even on a non-default subnet), and "false" (suppress one). A
+	// bool would collapse the first two.
+	AssociatePublicIPAddress string `json:"associatePublicIpAddress,omitempty"`
+
+	// NetworkInterfaceGroups is the security groups named in the template's first
+	// network interface, kept separate from SecurityGroupIDs so a template
+	// carrying both is not silently merged. AWS rejects that combination; see
+	// [EC2LaunchTemplateData.NetworkSecurityGroupIDs] for how substrate resolves
+	// which list applies.
+	NetworkInterfaceGroups []string `json:"networkInterfaceGroups,omitempty"`
+}
+
+// NetworkSecurityGroupIDs returns the security groups a launch from this template
+// should use: the top-level list when present, otherwise the first network
+// interface's.
+//
+// The precedence only matters for a template AWS would have rejected — it refuses
+// a template that sets both — so substrate prefers the top-level list rather than
+// erroring, which keeps a hand-built template working while still honoring the
+// interface-scoped form the SDK emits.
+func (d EC2LaunchTemplateData) NetworkSecurityGroupIDs() []string {
+	if len(d.SecurityGroupIDs) > 0 {
+		return d.SecurityGroupIDs
+	}
+	return d.NetworkInterfaceGroups
 }
 
 // EC2LaunchTemplate represents an Amazon EC2 launch template.


### PR DESCRIPTION
## Problem

`CreateLaunchTemplate` accepted `LaunchTemplateData.NetworkInterface.1.*` and stored **none** of it, so an instance launched from such a template landed in a substrate-chosen subnet — a wrong answer returned confidently, with a 200 and a plausible-looking instance rather than an error.

This hit exactly the templates configured **the way AWS requires**. Verified against the EC2 model: `RequestLaunchTemplateData` has **no top-level `SubnetId` member**, so a network interface is the only place a template can name a subnet, and the only place `AssociatePublicIpAddress` exists at all.

It also produced a confusing asymmetry — a `CreateFleet` override's subnet *was* honored while the same subnet named in the template was not, so the feature looked half-working rather than absent.

## The fix is an ordering change as much as a parsing one

The call-level `NetworkInterface.1.SubnetId` fallback ran **before** the launch template resolved, where there was nothing yet to fall back to. Template networking is now consulted after the template resolves and only when the call did not supply it:

| Source | Wins over |
|---|---|
| The request — `SubnetId` or `NetworkInterface.1.SubnetId` | everything below |
| A `CreateFleet` override's `SubnetId` | the template (it reaches `runInstances` as a request-level value) |
| The template's network interface | the default VPC |

`AssociatePublicIPAddress` is stored as a **string, not a bool**: absent ("use the subnet default"), `"true"` and `"false"` are three observable states, and a bool collapses the first two.

## Correction to the issue's suggested parameter name

#444 proposes parsing `.Groups.N`. The AWS model gives that member the `locationName` **`SecurityGroupId`**, so real SDKs send `SecurityGroupId.N` — that is the primary spelling here, with `Groups.N` accepted as a secondary form for hand-built requests (mirroring what `runInstances` already does).

## Deliberately out of scope

A call passing **both** an explicit `ImageId` and a launch template still ignores the template entirely, because the resolution block is gated on `imageID == ""`. Real AWS merges per field. That predates this change, affects `InstanceType`/`KeyName`/groups equally, and needs its own per-field precedence matrix. Filed as a follow-up.

## Tests

New `emulator/ec2_launchtemplate_test.go` (there was no launch-template test file), reproducing the issue's own four-case table:

| Case | Subnet from | Before | After |
|---|---|---|---|
| A | template NI, via `RunInstances` | ❌ | ✅ |
| B | call-level `SubnetId` | ✅ | ✅ (regression guard) |
| C | `CreateFleet` override | ✅ | ✅ (regression guard) |
| D | template NI, via `CreateFleet`, no override | ❌ | ✅ |

Plus explicit precedence assertions, both group spellings, the three-valued public-IP preference, the no-interface fall-through to the default VPC, and a launch-twice check that the template round-trips through state.

**Mutation-tested**: dropping the subnet fallback fails exactly A and D and leaves B and C green — the issue's table reproduced. Dropping the public-IP fallback fails only the `"true"` row.

The template's group list is asserted through `runInstances`' cross-VPC `InvalidGroup.NotFound` validation rather than a read of the instance, because **instances do not echo a `groupSet` at all yet** — that is the other half of #444 and lands in the next PR.

## Note on closing

**This PR does not close #444.** It ships the network-interface half; the `groupSet` half follows immediately, and that PR carries the `Closes`.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `make test` (race), `test/e2e`, `make docs-reference-check docs-versions` — all clean, re-run after rebasing onto the merged #443.

Refs #444