### PR TITLE
fix(ec2): report an instance's security groups as groupSet (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- EC2: `RunInstances` and `DescribeInstances` now report an instance's security
+  groups as `groupSet` (#444). The groups a launch named were parsed, validated
+  against the subnet's VPC and stored — and then absent from every read, so a
+  consumer that had just launched an instance with an explicit security group read
+  back an instance with no groups at all. Nothing errored; the fact was simply
+  missing, which reads as "this instance has no security groups" rather than
+  "substrate didn't report them".
+
+  Both responses emit `groupId` and `groupName`, matching AWS's `GroupIdentifier`,
+  for groups from any source: the request, the launch template's network interface,
+  or the default VPC's `default` group. `groupName` is **omitted** when the group
+  cannot be resolved — a group deleted after the launch keeps reporting its
+  `groupId`, since that is what the launch recorded, rather than being given an
+  invented name. The two response builders had each declared their own instance
+  item type, which is how a field could go missing from both; they now share the
+  group item, so they cannot disagree about its shape.
 - EC2: a launch template's network interface is no longer discarded, so a template
   that names a subnet, security groups or a public-IP preference is honored on
   launch (#444). `CreateLaunchTemplate` accepted

--- a/docs/services.md
+++ b/docs/services.md
@@ -911,8 +911,8 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 
 | Operation | Notes |
 |-----------|-------|
-| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [validates MinCount/MaxCount](#mincount-and-maxcount) |
-| DescribeInstances | [Explicit resource IDs](#explicit-resource-ids) |
+| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [validates MinCount/MaxCount](#mincount-and-maxcount); reports [`groupSet`](#security-groups-on-an-instance) |
+| DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance) |
 | TerminateInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StartInstances | [Explicit resource IDs](#explicit-resource-ids) |
@@ -1009,6 +1009,23 @@ behavior, **`true`** forces a public IP anyway, and **`false`** suppresses one.
 
 Only interface index **1** is modeled, on both `RunInstances` and launch templates.
 A template declaring a second interface loses it silently.
+
+### Security groups on an instance
+
+Both `RunInstances` and `DescribeInstances` report an instance's security groups as
+`groupSet>item`, with `groupId` and `groupName` — the same shape as AWS's
+`GroupIdentifier`. Groups appear in the order the launch resolved them, whichever
+source supplied them:
+
+- `SecurityGroupId.N` (or `SecurityGroupIds.N`) on the request, or the nested
+  `NetworkInterface.1.SecurityGroupId.N` / `NetworkInterface.1.Groups.N`.
+- The launch template's [network interface](#launch-template-networking).
+- The auto-created default VPC's `default` group, when the launch names none.
+
+`groupName` is **omitted when the group cannot be resolved** — for example after
+the group is deleted while the instance it was launched with still exists. The
+`groupId` is still reported, because that is what the launch actually recorded; a
+name is not invented to fill the field.
 
 ### MinCount and MaxCount
 

--- a/emulator/ec2_launchtemplate_test.go
+++ b/emulator/ec2_launchtemplate_test.go
@@ -270,11 +270,11 @@ func TestEC2_LaunchTemplate_SubnetPrecedence(t *testing.T) {
 // that member the locationName "SecurityGroupId" — while #444 suggested Groups.N;
 // substrate accepts either, so a hand-built request works too.
 //
-// The group is asserted through RunInstances' own cross-VPC validation rather than
-// a read of the instance: a group that does not belong to the subnet's VPC is
-// rejected with InvalidGroup.NotFound, which can only happen if the template's
-// list was actually read. Instances do not yet echo a groupSet at all — that is
-// the other half of #444, and its tests assert the template's groups directly.
+// Each spelling is asserted twice over: the group lands in the launched
+// instance's groupSet, and a group from a different VPC than the template's
+// subnet is rejected with InvalidGroup.NotFound. The rejection matters
+// independently — it can only happen if the list reached validation, so it holds
+// even if the groupSet emission were to regress.
 func TestEC2_LaunchTemplate_SecurityGroups(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -297,8 +297,12 @@ func TestEC2_LaunchTemplate_SecurityGroups(t *testing.T) {
 				tt.param: net.sgID,
 			})
 			id := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": sameVPC})
-			if got := describeInstance(t, ts, id); got.SubnetID != net.subnetID {
+			got := describeInstance(t, ts, id)
+			if got.SubnetID != net.subnetID {
 				t.Errorf("subnetId = %q, want %q", got.SubnetID, net.subnetID)
+			}
+			if len(got.Groups) != 1 || got.Groups[0].GroupID != net.sgID {
+				t.Errorf("groupSet = %+v, want the template's group %s", got.Groups, net.sgID)
 			}
 
 			// A group from a different VPC than the template's subnet must be
@@ -427,6 +431,9 @@ func TestEC2_LaunchTemplate_DescribeEchoesNetworking(t *testing.T) {
 		}
 		if got.PublicIPAddress == "" {
 			t.Errorf("launch %d: no public IP, want one from the template", i+1)
+		}
+		if len(got.Groups) != 1 || got.Groups[0].GroupID != net.sgID {
+			t.Errorf("launch %d: groupSet = %+v, want the template's group %s", i+1, got.Groups, net.sgID)
 		}
 	}
 }

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -488,6 +488,46 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	return p.runInstancesResponse(instances, reservationID, reqCtx)
 }
 
+// ec2GroupItem is one groupSet>item entry, mirroring AWS's GroupIdentifier.
+//
+// It is declared once at package level rather than inside each response builder
+// because RunInstances and DescribeInstances each declared their own instance item
+// type, and the family of fields they emit had already drifted — neither carried a
+// groupSet at all, so security groups accepted on a launch were invisible to every
+// read (#444). One shared type means the two responses cannot disagree about the
+// shape.
+type ec2GroupItem struct {
+	// GroupID is the security group's ID.
+	GroupID string `xml:"groupId"`
+
+	// GroupName is the group's name, omitted when it cannot be resolved.
+	GroupName string `xml:"groupName,omitempty"`
+}
+
+// ec2GroupItems builds the groupSet entries for an instance's security groups.
+//
+// A group whose stored record cannot be read contributes its ID with no name
+// rather than a fabricated one: a caller comparing groupName against what it
+// created would rather see the field absent than see a plausible wrong value.
+func (p *EC2Plugin) ec2GroupItems(reqCtx *RequestContext, groupIDs []string) []ec2GroupItem {
+	if len(groupIDs) == 0 {
+		return nil
+	}
+	items := make([]ec2GroupItem, 0, len(groupIDs))
+	for _, id := range groupIDs {
+		item := ec2GroupItem{GroupID: id}
+		key := "sg:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + id
+		if data, err := p.state.Get(context.Background(), ec2Namespace, key); err == nil && data != nil {
+			var sg EC2SecurityGroup
+			if json.Unmarshal(data, &sg) == nil {
+				item.GroupName = sg.GroupName
+			}
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
 func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID string, reqCtx *RequestContext) (*AWSResponse, error) {
 	type tagItem struct {
 		Key   string `xml:"key"`
@@ -509,7 +549,8 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 			Code int    `xml:"code"`
 			Name string `xml:"name"`
 		} `xml:"instanceState"`
-		Tags []tagItem `xml:"tagSet>item"`
+		Groups []ec2GroupItem `xml:"groupSet>item"`
+		Tags   []tagItem      `xml:"tagSet>item"`
 	}
 	type response struct {
 		XMLName       xml.Name          `xml:"RunInstancesResponse"`
@@ -540,6 +581,7 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 		}
 		item.State.Code = inst.State.Code
 		item.State.Name = inst.State.Name
+		item.Groups = p.ec2GroupItems(reqCtx, inst.SecurityGroupIDs)
 		// Echo launch-time tags (from TagSpecifications) — real EC2 populates
 		// tagSet in the RunInstances response, not just DescribeInstances (#351).
 		for _, t := range inst.Tags {
@@ -646,6 +688,7 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		KeyName            string          `xml:"keyName,omitempty"`
 		IamInstanceProfile *iamProfileItem `xml:"iamInstanceProfile,omitempty"`
 		State              ec2StateItem    `xml:"instanceState"`
+		Groups             []ec2GroupItem  `xml:"groupSet>item"`
 		Tags               []tagItem       `xml:"tagSet>item"`
 	}
 	type reservationItem struct {
@@ -695,6 +738,7 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		}
 		item.State.Code = inst.State.Code
 		item.State.Name = inst.State.Name
+		item.Groups = p.ec2GroupItems(reqCtx, inst.SecurityGroupIDs)
 		// Echo the IAM instance profile set at launch (#331). The stored value is
 		// the name or ARN supplied; surface it as the ARN and derive an id so a
 		// caller can read back the profile it attached.

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -4186,5 +4187,174 @@ func TestEC2_RunInstances_InstanceCounts(t *testing.T) {
 					"DescribeInstances must agree with the launch response")
 			})
 		}
+	})
+}
+
+// runInstancesLaunched sends RunInstances and decodes the launched instances.
+//
+// It decodes into launchedInstance, the same type the DescribeInstances helper
+// uses, because the point of these tests is that the two responses agree: a
+// groupSet in one and not the other is exactly the state #444 reported.
+func runInstancesLaunched(t *testing.T, ts *httptest.Server, params map[string]string) []launchedInstance {
+	t.Helper()
+	full := map[string]string{"Action": "RunInstances", "MinCount": "1", "MaxCount": "1"}
+	for k, v := range params {
+		full[k] = v
+	}
+	resp := ec2Request(t, ts, full)
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("RunInstances: status = %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		Instances []launchedInstance `xml:"instancesSet>item"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode RunInstances: %v", err)
+	}
+	return out.Instances
+}
+
+// instanceView is one instance as reported by one API call, so an assertion can
+// name which response disagreed.
+type instanceView struct {
+	from string
+	inst launchedInstance
+}
+
+// bothViews launches one instance and returns it as RunInstances reported it and
+// as a following DescribeInstances reports it. Both are always checked: one
+// populated and the other empty is the drift that produced #444's gap, since the
+// two builders declare their instance item type separately.
+func bothViews(t *testing.T, ts *httptest.Server, params map[string]string) []instanceView {
+	t.Helper()
+	launched := runInstancesLaunched(t, ts, params)
+	if len(launched) != 1 {
+		t.Fatalf("RunInstances launched %d instances, want 1", len(launched))
+	}
+	return []instanceView{
+		{from: "RunInstances", inst: launched[0]},
+		{from: "DescribeInstances", inst: describeInstance(t, ts, launched[0].InstanceID)},
+	}
+}
+
+// groupIDs lists the instance's reported security group IDs.
+func groupIDs(inst launchedInstance) []string {
+	ids := make([]string, 0, len(inst.Groups))
+	for _, g := range inst.Groups {
+		ids = append(ids, g.GroupID)
+	}
+	return ids
+}
+
+// wantGroups asserts the instance reports exactly these group IDs, and — when a
+// name is expected — that each carries it.
+func wantGroups(t *testing.T, v instanceView, ids []string, names ...string) {
+	t.Helper()
+	if got := groupIDs(v.inst); !slices.Equal(got, ids) {
+		t.Errorf("%s: groupSet ids = %v, want %v", v.from, got, ids)
+		return
+	}
+	for i, name := range names {
+		if v.inst.Groups[i].GroupName != name {
+			t.Errorf("%s: groups[%d].groupName = %q, want %q", v.from, i, v.inst.Groups[i].GroupName, name)
+		}
+	}
+}
+
+// TestEC2_Instances_GroupSet covers the second half of #444: security groups were
+// accepted on a launch and stored, but neither RunInstances nor DescribeInstances
+// emitted a groupSet, so a caller reading back the instance it had just launched
+// saw no groups at all. Nothing errored — the fact was simply missing, which reads
+// as "this instance has no security groups" rather than "substrate did not report
+// them".
+func TestEC2_Instances_GroupSet(t *testing.T) {
+	t.Run("call-level SecurityGroupId", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		net := newLTNetwork(t, ts, "10.20.0.0/16", "gs-call")
+
+		for _, v := range bothViews(t, ts, map[string]string{
+			"ImageId":           "ami-0gs000000000001",
+			"SubnetId":          net.subnetID,
+			"SecurityGroupId.1": net.sgID,
+		}) {
+			wantGroups(t, v, []string{net.sgID}, "gs-call")
+		}
+	})
+
+	t.Run("multiple groups keep their order", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		net := newLTNetwork(t, ts, "10.21.0.0/16", "gs-multi-a")
+		second := createSecurityGroup(t, ts, net.vpcID, "gs-multi-b")
+
+		for _, v := range bothViews(t, ts, map[string]string{
+			"ImageId":           "ami-0gs000000000002",
+			"SubnetId":          net.subnetID,
+			"SecurityGroupId.1": net.sgID,
+			"SecurityGroupId.2": second,
+		}) {
+			wantGroups(t, v, []string{net.sgID, second}, "gs-multi-a", "gs-multi-b")
+		}
+	})
+
+	t.Run("default VPC group is reported", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+
+		// No SubnetId and no group: the launch falls through to the auto-created
+		// default VPC and resolves its "default" group. That resolution happened
+		// before this fix too — it was simply invisible.
+		for _, v := range bothViews(t, ts, map[string]string{"ImageId": "ami-0gs000000000003"}) {
+			if len(v.inst.Groups) != 1 {
+				t.Fatalf("%s: groupSet has %d items, want the default VPC group", v.from, len(v.inst.Groups))
+			}
+			if v.inst.Groups[0].GroupID == "" {
+				t.Errorf("%s: groupId is empty", v.from)
+			}
+			if v.inst.Groups[0].GroupName != "default" {
+				t.Errorf("%s: groupName = %q, want %q", v.from, v.inst.Groups[0].GroupName, "default")
+			}
+		}
+	})
+
+	t.Run("launch template groups surface", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		net := newLTNetwork(t, ts, "10.22.0.0/16", "gs-template")
+		ltID := createLaunchTemplate(t, ts, "gs-template", map[string]string{
+			"LaunchTemplateData.ImageId":                              "ami-0gs000000000004",
+			"LaunchTemplateData.NetworkInterface.1.DeviceIndex":       "0",
+			"LaunchTemplateData.NetworkInterface.1.SubnetId":          net.subnetID,
+			"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1": net.sgID,
+		})
+
+		for _, v := range bothViews(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID}) {
+			wantGroups(t, v, []string{net.sgID}, "gs-template")
+		}
+	})
+
+	t.Run("groupName is omitted when the group is gone", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		net := newLTNetwork(t, ts, "10.23.0.0/16", "gs-deleted")
+
+		launched := runInstancesLaunched(t, ts, map[string]string{
+			"ImageId":           "ami-0gs000000000005",
+			"SubnetId":          net.subnetID,
+			"SecurityGroupId.1": net.sgID,
+		})
+		if len(launched) != 1 {
+			t.Fatalf("RunInstances launched %d instances, want 1", len(launched))
+		}
+
+		del := ec2Request(t, ts, map[string]string{"Action": "DeleteSecurityGroup", "GroupId": net.sgID})
+		defer del.Body.Close() //nolint:errcheck
+		if del.StatusCode != http.StatusOK {
+			t.Fatalf("DeleteSecurityGroup: status = %d, want 200", del.StatusCode)
+		}
+
+		// The ID the instance was launched with is still a fact; the name is no
+		// longer resolvable. Reporting the ID with no name is the honest answer —
+		// inventing a name would be the same class of confident-wrong-answer as
+		// omitting the groupSet entirely.
+		v := instanceView{from: "DescribeInstances", inst: describeInstance(t, ts, launched[0].InstanceID)}
+		wantGroups(t, v, []string{net.sgID}, "")
 	})
 }


### PR DESCRIPTION
Closes #444.

Second and final half of #444. [#448](https://github.com/scttfrdmn/substrate/pull/448) carried the launch-template network interface; this carries the `groupSet`, and is what makes the template's security groups observable at all.

## The defect

`RunInstances` accepted security groups, **validated** them against the subnet's VPC, and **stored** them on the instance (`inst.SecurityGroupIDs`) — then neither `RunInstances` nor `DescribeInstances` emitted them. A consumer that launched an instance with an explicit security group read back an instance with no groups.

Nothing errored. The 200 was correct, the instance was correct, and the fact was simply absent — which reads as "this instance has no security groups" rather than "substrate didn't report them", so the consumer debugs their own code first. Same shape as the rest of this batch: a missing fact, not a missing error.

## The fix

Both responses emit `groupSet>item` with `groupId` and `groupName`, matching AWS's `GroupIdentifier`, for groups from any source — the request, the launch template's network interface, or the default VPC's `default` group.

**`groupName` is omitted when the group cannot be resolved.** A group deleted after the launch keeps reporting its `groupId`, since that is what the launch actually recorded, rather than being handed an invented name. A fabricated name is the same class of confident-wrong-answer this batch exists to remove.

The two response builders had each declared their own instance item type, which is how a field could go missing from both at once. They now share `ec2GroupItem` and a single `ec2GroupItems` helper, so they cannot disagree about the shape.

## Tests

`TestEC2_Instances_GroupSet` asserts **both responses in every case** — one populated and the other empty is exactly the drift that produced the gap:

- a call-level `SecurityGroupId.1`, with its name resolved;
- multiple groups, in resolution order;
- the default VPC's `default` group, when the launch names none;
- template-supplied groups (reachable only because of #448);
- `groupName` absent after the group is deleted, with `groupId` still reported.

Two assertions removed from #448 for being ahead of the code are restored here.

Mutation-tested three ways: removing either emission fails that response's assertions independently; removing the name lookup fails only the four name assertions, leaving the deleted-group case green — so the ID and the name are separately covered.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `make test` (race), `test/e2e`, `make docs-reference-check docs-versions` — all clean, re-run after rebasing onto the merged #448.