### PR TITLE
fix(sqs): MaximumMessageSize default is 1 MiB, not 256 KiB (#439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model gives the `Groups` member the `locationName` `SecurityGroupId`), with
   `Groups.N` accepted as a secondary spelling. Only interface index 1 is modeled,
   matching `RunInstances`.
+- SQS: `GetQueueAttributes` reports the documented `MaximumMessageSize` default of
+  1,048,576 bytes (1 MiB) rather than 262,144 (256 KiB) (#439). 256 KiB is the
+  historical limit; the current CreateQueue reference documents 1 MiB as the
+  default, so a consumer sizing a payload against what substrate reported was
+  working from a number a real queue would not give it. An explicitly requested
+  value is still honored — 256 KiB remains a legal size, it is simply no longer the
+  default.
+
+  Both sites moved together and now share one constant: `GetQueueAttributes`'
+  inline fallback, and the defaults `CreateQueue`'s conflict check (#429) resolves
+  an existing queue's unset attributes through. They can no longer diverge, which
+  matters because a divergence would report one number and then reject a re-create
+  naming exactly that number as `QueueNameExists`.
+
+  Substrate still does **not** enforce `MaximumMessageSize` on `SendMessage` — no
+  length check exists against the attribute or any constant, so an oversized body is
+  accepted. That absence is deliberate here: enforcement is a new error path with
+  its own scope, and is tracked separately.
 
 ### Added
 - EC2: `CreateFleet` stamps the reserved `aws:ec2:fleet-id` tag on every instance

--- a/docs/services.md
+++ b/docs/services.md
@@ -699,11 +699,11 @@ Lambda invocations: $0.0000002 per request.
 |-----------|-------|
 | CreateQueue | Supports FifoQueue, VisibilityTimeout attributes; [`QueueNameExists`](#queuenameexists) when a name is reused with differing attributes; [seedable `QueueDeletedRecently`](#seeding-queuedeletedrecently) |
 | GetQueueUrl | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; [seedable consistency window](#seeding-the-create-then-lookup-consistency-window) |
-| GetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; [seedable consistency window](#seeding-the-create-then-lookup-consistency-window) |
+| GetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; [seedable consistency window](#seeding-the-create-then-lookup-consistency-window); [attribute defaults](#queue-attribute-defaults) |
 | SetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteQueue | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | ListQueues | |
-| SendMessage | Returns MessageId; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
+| SendMessage | Returns MessageId; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; does **not** enforce [`MaximumMessageSize`](#queue-attribute-defaults) |
 | SendMessageBatch | |
 | ReceiveMessage | Supports MaxNumberOfMessages, WaitTimeSeconds; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteMessage | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
@@ -782,6 +782,31 @@ All three counters — including [`deletedRecentlyMisses`](#seeding-queuedeleted
 — default to 0, so an unseeded queue behaves exactly as before: instantly
 resolvable. Seeds live in the state store, so `POST /v1/state/reset` clears them
 along with everything else.
+
+### Queue attribute defaults
+
+`GetQueueAttributes` reports these for a queue created without naming them:
+
+| Attribute | Default |
+|---|---|
+| `VisibilityTimeout` | `30` |
+| `MaximumMessageSize` | `1048576` — 1 MiB, per the CreateQueue reference |
+| `MessageRetentionPeriod` | `345600` |
+| `DelaySeconds` | `0` |
+| `ReceiveMessageWaitTimeSeconds` | `0` |
+
+`262144` (256 KiB) is the historical limit rather than the current default, and is
+what substrate reported until #439. An explicitly requested value is always honored
+— 256 KiB is still a legal size.
+
+**Substrate does not enforce `MaximumMessageSize` on `SendMessage`.** No length
+check exists against the attribute or any constant, so an oversized body is
+accepted rather than rejected. A consumer's too-large-payload branch is therefore
+not reachable here; enforcement is tracked separately.
+
+These defaults also decide what counts as a
+[`QueueNameExists`](#queuenameexists) conflict, since an existing queue's unset
+attributes are resolved through them before comparing.
 
 ### QueueNameExists
 

--- a/emulator/sqs_createqueue.go
+++ b/emulator/sqs_createqueue.go
@@ -2,6 +2,20 @@ package emulator
 
 import "sort"
 
+// sqsDefaultMaximumMessageSize is the MaximumMessageSize a queue reports when it was
+// created without naming one: 1,048,576 bytes (1 MiB), per the CreateQueue reference.
+//
+// 256 KiB was the historical limit and is what substrate reported until #439. It is a
+// named constant because the value must be identical in sqsAttributeDefaults and in
+// getQueueAttributes' inline fallback — a divergence would make GetQueueAttributes
+// report one number while a re-create request naming that same number was rejected as
+// a conflict.
+//
+// Substrate does not enforce this limit on SendMessage; no length check exists against
+// it or any other constant. That absence is deliberate here — enforcement is a new
+// error path with its own scope, tracked separately from correcting the default.
+const sqsDefaultMaximumMessageSize = "1048576"
+
 // sqsAttributeDefaults are the values GetQueueAttributes reports for a queue that
 // was created without naming them, used to resolve an existing queue's unset
 // attributes before comparing them against a CreateQueue request (#429).
@@ -16,15 +30,13 @@ import "sort"
 // The values deliberately mirror getQueueAttributes' inline fallbacks rather than
 // the AWS reference, so the two cannot disagree about what a queue's effective
 // attributes are — a comparison that used different defaults than the read path
-// would reject requests matching what a caller had just read back. That does carry
-// one known staleness through: MaximumMessageSize is 262144 (256 KiB) here, while
-// the current CreateQueue reference documents 1,048,576 (1 MiB). Correcting it
-// changes GetQueueAttributes output, so it is tracked separately rather than
-// smuggled into this change.
-// TODO(#439): reconcile MaximumMessageSize with the documented 1 MiB default.
+// would reject requests matching what a caller had just read back. Any change to a
+// default must therefore move both sites at once; MaximumMessageSize (#439) is the
+// worked example, and TestSQS_CreateQueue_MaximumMessageSizeDefault's idempotent
+// re-create case is what fails if only one moves.
 var sqsAttributeDefaults = map[string]string{
 	"VisibilityTimeout":             "30",
-	"MaximumMessageSize":            "262144",
+	"MaximumMessageSize":            sqsDefaultMaximumMessageSize,
 	"MessageRetentionPeriod":        "345600",
 	"DelaySeconds":                  "0",
 	"ReceiveMessageWaitTimeSeconds": "0",

--- a/emulator/sqs_createqueue_test.go
+++ b/emulator/sqs_createqueue_test.go
@@ -1,6 +1,7 @@
 package emulator_test
 
 import (
+	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -505,4 +506,89 @@ func TestSQS_CreateQueue_DeletedRecentlyStateFailure(t *testing.T) {
 	status, code := createQueueWithAttrs(t, srv, "corrupt-create-q", nil, false)
 	assert.Equal(t, http.StatusInternalServerError, status)
 	assert.NotEqual(t, "QueueDeletedRecently", code)
+}
+
+// sqsQueueAttribute reads one attribute from GetQueueAttributes under either
+// protocol, so a default can be asserted against the exact value rather than mere
+// presence.
+func sqsQueueAttribute(t *testing.T, srv *emulator.Server, name, attr string, jsonProto bool) string {
+	t.Helper()
+	queueURL := "http://sqs.us-east-1.localhost/000000000000/" + name
+	if jsonProto {
+		resp := sqsJSONRequest(t, srv, "GetQueueAttributes", map[string]interface{}{
+			"QueueUrl":       queueURL,
+			"AttributeNames": []string{"All"},
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		attrs, ok := readJSONBody(t, resp)["Attributes"].(map[string]interface{})
+		require.True(t, ok, "response carries an Attributes object")
+		v, _ := attrs[attr].(string)
+		return v
+	}
+
+	resp := sqsRequest(t, srv, map[string]string{"Action": "GetQueueAttributes", "QueueUrl": queueURL})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out struct {
+		Attributes []struct {
+			Name  string `xml:"Name"`
+			Value string `xml:"Value"`
+		} `xml:"GetQueueAttributesResult>Attribute"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(readBody(t, resp)), &out))
+	for _, a := range out.Attributes {
+		if a.Name == attr {
+			return a.Value
+		}
+	}
+	return ""
+}
+
+// TestSQS_CreateQueue_MaximumMessageSizeDefault is #439. GetQueueAttributes reported
+// 262144 (256 KiB) for a queue created without the attribute; the current CreateQueue
+// reference documents 1,048,576 bytes (1 MiB) as the default, and 256 KiB is the
+// historical limit. A consumer sizing a payload against what substrate reported was
+// working from a number a real queue would not give it.
+//
+// Note that substrate does not enforce this on SendMessage — no length check exists
+// against the attribute or any constant. This corrects the reported default only.
+func TestSQS_CreateQueue_MaximumMessageSizeDefault(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		t.Run("a bare queue reports 1 MiB", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			status, _ := createQueueWithAttrs(t, srv, "mms-default", nil, jsonProto)
+			require.Equal(t, http.StatusOK, status)
+
+			assert.Equal(t, "1048576", sqsQueueAttribute(t, srv, "mms-default", "MaximumMessageSize", jsonProto),
+				"the documented CreateQueue default")
+		})
+
+		t.Run("an explicit value is still honored", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			status, _ := createQueueWithAttrs(t, srv, "mms-explicit",
+				map[string]string{"MaximumMessageSize": "262144"}, jsonProto)
+			require.Equal(t, http.StatusOK, status)
+
+			// Correcting the default must not start overriding a caller's own value —
+			// 256 KiB is still a legal size, it is simply no longer the default.
+			assert.Equal(t, "262144", sqsQueueAttribute(t, srv, "mms-explicit", "MaximumMessageSize", jsonProto))
+		})
+
+		// This is the case that fails if only one of the two default sites moves.
+		// CreateQueue's conflict check (#429) resolves an existing queue's unset
+		// attributes through sqsAttributeDefaults, while GetQueueAttributes reads its
+		// own inline fallback. If they disagree, a request naming exactly the value a
+		// caller just read back is rejected as QueueNameExists.
+		t.Run("re-creating with the reported default stays idempotent", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			status, _ := createQueueWithAttrs(t, srv, "mms-idem", nil, jsonProto)
+			require.Equal(t, http.StatusOK, status)
+
+			reported := sqsQueueAttribute(t, srv, "mms-idem", "MaximumMessageSize", jsonProto)
+			status, code := createQueueWithAttrs(t, srv, "mms-idem",
+				map[string]string{"MaximumMessageSize": reported}, jsonProto)
+			assert.Equal(t, http.StatusOK, status,
+				"re-creating with the value GetQueueAttributes reported must be idempotent")
+			assert.Empty(t, code)
+		})
+	})
 }

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -431,7 +431,7 @@ func (p *SQSPlugin) getQueueAttributes(ctx *RequestContext, req *AWSRequest) (*A
 		"CreatedTimestamp":              strconv.FormatInt(q.CreatedTimestamp, 10),
 		"LastModifiedTimestamp":         strconv.FormatInt(q.LastModifiedTimestamp, 10),
 		"VisibilityTimeout":             getAttrOrDefault(q.Attributes, "VisibilityTimeout", "30"),
-		"MaximumMessageSize":            getAttrOrDefault(q.Attributes, "MaximumMessageSize", "262144"),
+		"MaximumMessageSize":            getAttrOrDefault(q.Attributes, "MaximumMessageSize", sqsDefaultMaximumMessageSize),
 		"MessageRetentionPeriod":        getAttrOrDefault(q.Attributes, "MessageRetentionPeriod", "345600"),
 		"DelaySeconds":                  getAttrOrDefault(q.Attributes, "DelaySeconds", "0"),
 		"ReceiveMessageWaitTimeSeconds": getAttrOrDefault(q.Attributes, "ReceiveMessageWaitTimeSeconds", "0"),


### PR DESCRIPTION
Closes #439.

## The defect

`GetQueueAttributes` reported `262144` (256 KiB) as `MaximumMessageSize` for a queue created without the attribute. That is the **historical limit**; the current [CreateQueue reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html) documents *"An integer from 1,024 bytes (1 KiB) to 1,048,576 bytes (1 MiB). **Default: 1,048,576 bytes (1 MiB)**"*.

A consumer sizing a payload against what substrate reported was working from a number a real queue would not give it. Filed while implementing #429, which left a `TODO(#439)` pointing here — now removed.

An explicitly requested value is still honored: 256 KiB remains a legal size, it is simply no longer the default.

## Both sites move together

The default exists twice, deliberately:

- `sqs_plugin.go` — `getQueueAttributes`' inline fallback (the read path).
- `sqs_createqueue.go` — `sqsAttributeDefaults`, which `CreateQueue`'s conflict check (#429) resolves an existing queue's unset attributes through before comparing.

They mirror each other so the two cannot disagree about a queue's effective attributes. A divergence would report one number and then reject a re-create naming *exactly that number* as `QueueNameExists` — rejecting a request matching what the caller had just read back.

They now share a named constant, `sqsDefaultMaximumMessageSize`, so divergence is structurally impossible rather than merely tested. The test covers it either way.

## `SendMessage` enforcement is still absent

No length check exists against the attribute or any constant, so an oversized body is accepted. Per the issue's own acceptance criteria this PR **documents that absence** rather than adding a limit: enforcement is a new error path with its own scope, and adding it alongside a default change would conflate two observable behaviours. Tracked separately.

## Tests

`TestSQS_CreateQueue_MaximumMessageSizeDefault`, under **both** the query and JSON protocols:

- a bare queue reports `1048576`, asserted as an exact value rather than mere presence (pins it against future drift, per the acceptance criteria);
- an explicit `262144` is still reported back unchanged;
- re-creating with the value `GetQueueAttributes` just reported stays idempotent.

That third case is the gate on both sites moving together. Mutation-tested by reverting only the read-path site: it fails with `QueueNameExists`, exactly the failure mode the coupling exists to prevent.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `make test` (race), `test/e2e`, `make docs-reference-check docs-versions` — all clean. `check-doc-versions.sh` caught a pinned version number in my first docs draft; the wording now refers to the issue instead.