### PR TITLE
chore(release): v0.84.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.84.0] - 2026-08-01
+
 ### Fixed
 - EC2: `RunInstances` and `DescribeInstances` now report an instance's security
   groups as `groupSet` (#444). The groups a launch named were parsed, validated
@@ -2806,7 +2808,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.83.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.84.0...HEAD
+[v0.84.0]: https://github.com/scttfrdmn/substrate/compare/v0.83.0...v0.84.0
 [v0.83.0]: https://github.com/scttfrdmn/substrate/compare/v0.82.0...v0.83.0
 [v0.82.0]: https://github.com/scttfrdmn/substrate/compare/v0.81.0...v0.82.0
 [v0.81.0]: https://github.com/scttfrdmn/substrate/compare/v0.80.0...v0.81.0


### PR DESCRIPTION
Moves `## [Unreleased]` to `## [v0.84.0] - 2026-08-01` and adds the comparison link. No code changes.

`v0.84.0` derived from `git tag --sort=-v:refname | head -1` → `v0.83.0`, so it is strictly greater and in order.

## What ships

Three consumer-filed issues, two of them from a single [parsl-aws-provider](https://github.com/scttfrdmn/parsl-aws-provider) sweep against `0.82.0`. All one shape, and a new register for this batch: not a missing *error* but a missing *fact* — substrate accepted an input, discarded it, and a later read came back empty. That reads as "the resource is gone" rather than "substrate didn't record this", so the consumer debugs their own code first. In both EC2 cases they worked around it and left a comment in their tests explaining why.

| Issue | PR | What was wrong |
|---|---|---|
| #443 | #447 | `CreateFleet` applied no `aws:ec2:fleet-id` tag, so there was no route from a fleet ID back to its instances. For an `instant` fleet this is the *only* supported route — `DescribeFleetInstances` rejects them outright. A fully-provisioned fleet reported as empty. |
| #444 | #448 | `CreateLaunchTemplate` accepted `NetworkInterface.1.*` and stored none of it. AWS's `RequestLaunchTemplateData` has **no top-level `SubnetId`**, so this hit exactly the templates configured the way AWS requires. |
| #444 | #449 | Security groups were parsed, validated and stored — then absent from `RunInstances` and `DescribeInstances`. |
| #439 | #450 | `MaximumMessageSize` reported 256 KiB, the historical limit; the current CreateQueue reference documents 1 MiB as the default. |

## Notes

- **#443's provenance is recorded, not implied.** `aws:ec2:fleet-id` appears in neither the EC2 API model nor the fleet user-guide pages. Substrate models it on the reporter's observed real-AWS behaviour, and the code comment, the CHANGELOG and `docs/services.md` all say so rather than implying a doc citation.
- **`CreateTags` still accepts reserved `aws:`-prefixed keys**, which real EC2 rejects. Deliberately left for a later release: it is parsl-aws-provider's current workaround for #443, so tightening it in the same release that removes the need would break them with no overlap window.
- **`SendMessage` still does not enforce `MaximumMessageSize`**, documented as an absence rather than quietly added.

#411 remains open on this milestone and does not block the cut; it will move to v0.85.0.

Follow-ups from this batch are being filed separately.