### PR TITLE
fix(s3): route ?publicAccessBlock so DELETE stops deleting the bucket (#446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- S3: `DELETE /bucket?publicAccessBlock` no longer destroys the bucket (#446). The
+  `?publicAccessBlock` subresource was unrouted on all three verbs, and because it is
+  addressed as a bare query key on the bucket itself, each request fell through to the
+  bucket-level operation for its method — so a `DeletePublicAccessBlock` reached
+  `DeleteBucket` and deleted the bucket and its contents. On an empty bucket that
+  returned `204`, exactly as a successful `DeletePublicAccessBlock` does, so the caller
+  had no signal at all: the next operation on that bucket failed with `NoSuchBucket`
+  for no visible reason. On a non-empty bucket it returned `409 BucketNotEmpty`, naming
+  an operation the caller never issued.
+
+  The other two verbs were wrong in the same way. `PUT` fell through to `CreateBucket`
+  and answered `409 BucketAlreadyExists` — the shape SDKs and CloudFormation send
+  immediately after creating a bucket, so locking a bucket down failed on the
+  already-owned bucket it was meant to configure. `GET` fell through to `ListObjects`
+  and returned `200` with a `ListBucketResult` body, which an SDK parses into an empty
+  `PublicAccessBlockConfiguration` — reporting "public access is not blocked" for a
+  bucket whose settings substrate had never stored.
+
+  All three are now routed and modeled. `PutPublicAccessBlock` records the
+  configuration and replaces it wholesale; settings the body omits are reported back as
+  `false`, as S3 does. `GetPublicAccessBlock` returns `404
+  NoSuchPublicAccessBlockConfiguration` for a bucket with no configuration, which keeps
+  it distinguishable from the all-false configuration a consumer may have written on
+  purpose. `DeletePublicAccessBlock` returns `204`, is idempotent, and touches nothing
+  but the configuration.
+
+  Two deliberate limits, both documented in `docs/services.md`: substrate does not
+  apply S3's April 2023 default of enabling all four settings on a newly created
+  bucket, because that default comes from AWS-managed account state substrate does not
+  model and seeding it would make the `NoSuchPublicAccessBlockConfiguration` path
+  unreachable; and the settings are recorded but not enforced, so nothing yet rejects a
+  public ACL or bucket policy.
+
 ## [v0.84.0] - 2026-08-01
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -206,6 +206,9 @@ STS operations are free.
 | GetBucketPolicy | |
 | PutBucketPolicy | |
 | DeleteBucketPolicy | |
+| PutPublicAccessBlock | Records the configuration; a partial body reports omitted settings as `false` — see [Block Public Access](#block-public-access) |
+| GetPublicAccessBlock | `404 NoSuchPublicAccessBlockConfiguration` when the bucket has none — see [Block Public Access](#block-public-access) |
+| DeletePublicAccessBlock | Idempotent; removes only the configuration, never the bucket — see [Block Public Access](#block-public-access) |
 | GetBucketAcl | |
 | PutBucketAcl | |
 | GetObjectAcl | |
@@ -638,6 +641,49 @@ Substrate records **no** checksum in that case. Synthesizing one would make a
 round-trip assertion pass whether or not the consumer's writer actually sends a
 checksum — the exact defect this support was added to expose. An absent checksum in
 substrate means "your writer sent none".
+
+### Block Public Access
+
+The `?publicAccessBlock` subresource is addressed as a bare query key on the bucket,
+which is why it needs explicit routing: an unrouted `DELETE
+/bucket?publicAccessBlock` is indistinguishable from `DeleteBucket`.
+
+```
+PUT    /bucket?publicAccessBlock   → 200, empty body
+GET    /bucket?publicAccessBlock   → 200 + PublicAccessBlockConfiguration, or 404
+DELETE /bucket?publicAccessBlock   → 204
+```
+
+**All four settings are always reported.** `BlockPublicAcls`, `IgnorePublicAcls`,
+`BlockPublicPolicy` and `RestrictPublicBuckets` are each optional on the request, and
+every one a `PUT` omits is recorded — and reported back — as `false`, matching S3.
+`PutPublicAccessBlock` replaces the whole document rather than merging into it, so a
+second call naming fewer settings clears the rest.
+
+**An unconfigured bucket is a 404, not an all-false 200.** A bucket that has never
+been the subject of a `PutPublicAccessBlock` returns `404
+NoSuchPublicAccessBlockConfiguration`. The two states are deliberately
+distinguishable: an all-false configuration a consumer wrote on purpose is a `200`
+carrying four `false` elements. Reporting the unset case as all-false would tell a
+caller "public access is not blocked" where AWS says "nothing is configured".
+
+**Substrate does not apply S3's April 2023 default.** Real S3 enables all four
+settings on buckets newly created through the API, CLI, SDKs or CloudFormation. In
+substrate a new bucket has no configuration at all. That default is a property of
+AWS-managed account and organization state substrate does not model, and seeding
+every bucket with a configuration would make the `NoSuchPublicAccessBlockConfiguration`
+path — the branch a consumer's error handling exists for — unreachable through the
+public API. Call `PutPublicAccessBlock` to get a configured bucket, which is what the
+SDKs and CloudFormation both do.
+
+**`DeletePublicAccessBlock` is idempotent** and touches nothing but the
+configuration. Deleting one that was never written is a `204`, which is what a
+teardown path that deletes unconditionally relies on.
+
+**The settings are recorded, not enforced.** Nothing rejects a public ACL or a public
+bucket policy on a bucket with `BlockPublicAcls` or `BlockPublicPolicy` set. Those are
+the resource-internal consequences of the setting rather than the setting itself;
+enforcement is tracked separately.
 
 ### Betty CFN resource types
 

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -22,6 +22,9 @@ import (
 // s3Namespace is the state namespace used by S3Plugin.
 const s3Namespace = "s3"
 
+// s3XMLNamespace is the xmlns attribute S3 puts on its XML response bodies.
+const s3XMLNamespace = "http://s3.amazonaws.com/doc/2006-03-01/"
+
 // Error messages S3 returns verbatim from more than one operation.
 const (
 	// s3NoSuchUploadMessage accompanies NoSuchUpload from every multipart operation.
@@ -163,6 +166,12 @@ func (p *S3Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return p.getBucketLifecycleConfiguration(ctx, req, bucket)
 	case "DeleteBucketLifecycle":
 		return p.deleteBucketLifecycle(ctx, req, bucket)
+	case "PutPublicAccessBlock":
+		return p.putPublicAccessBlock(ctx, req, bucket)
+	case "GetPublicAccessBlock":
+		return p.getPublicAccessBlock(ctx, req, bucket)
+	case "DeletePublicAccessBlock":
+		return p.deletePublicAccessBlock(ctx, req, bucket)
 	case "SelectObjectContent":
 		return p.selectObjectContent(ctx, req, bucket, key)
 	default:
@@ -223,6 +232,9 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 			if _, ok := req.Params["lifecycle"]; ok {
 				return bucket, "", "PutBucketLifecycleConfiguration"
 			}
+			if _, ok := req.Params["publicAccessBlock"]; ok {
+				return bucket, "", "PutPublicAccessBlock"
+			}
 			return bucket, "", "CreateBucket"
 		case "HEAD":
 			return bucket, "", "HeadBucket"
@@ -235,6 +247,11 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 			}
 			if _, ok := req.Params["lifecycle"]; ok {
 				return bucket, "", "DeleteBucketLifecycle"
+			}
+			// Before the DeleteBucket fall-through: an unrouted ?publicAccessBlock
+			// reached it and destroyed the bucket (#446).
+			if _, ok := req.Params["publicAccessBlock"]; ok {
+				return bucket, "", "DeletePublicAccessBlock"
 			}
 			return bucket, "", "DeleteBucket"
 		case "GET":
@@ -261,6 +278,9 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 			}
 			if _, ok := req.Params["lifecycle"]; ok {
 				return bucket, "", "GetBucketLifecycleConfiguration"
+			}
+			if _, ok := req.Params["publicAccessBlock"]; ok {
+				return bucket, "", "GetPublicAccessBlock"
 			}
 			if req.Params["list-type"] == "2" {
 				return bucket, "", "ListObjectsV2"

--- a/emulator/s3_publicaccessblock.go
+++ b/emulator/s3_publicaccessblock.go
@@ -1,0 +1,144 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+)
+
+// s3PublicAccessBlockKey is the state key holding a bucket's Block Public Access
+// configuration.
+//
+// The configuration lives under its own key rather than as a field on [S3Bucket]
+// because "no configuration" and "a configuration with all four settings false"
+// are distinct observations: the first is 404
+// NoSuchPublicAccessBlockConfiguration, the second is a 200 carrying four
+// `false` elements. A field on the bucket record could not tell them apart
+// without a pointer, and a separate key makes DeletePublicAccessBlock a delete
+// rather than a partial rewrite of the bucket — which is what keeps it from
+// touching the bucket at all (#446).
+func s3PublicAccessBlockKey(bucket string) string {
+	return "bucket_public_access_block:" + bucket
+}
+
+// s3NoSuchPublicAccessBlockResponse is the 404 a bucket with no Block Public
+// Access configuration returns from GetPublicAccessBlock.
+//
+// The code is not in the S3 (2006-03-01) API model — only the s3control model
+// declares it, and the bucket-level GetPublicAccessBlock reference documents no
+// Errors section at all. It is nonetheless what real bucket-level S3 returns:
+// the s3control shape's own documentation describes the same condition, the AWS
+// provider for Terraform handles this exact code on bucket-level
+// GetPublicAccessBlock and DeletePublicAccessBlock
+// (internal/service/s3/errors.go), and it is what callers report seeing from
+// boto3's s3.get_public_access_block. Modeling the 404 is what makes a
+// consumer's "no block configured" branch reachable; a 200 with four `false`
+// values would report a configuration the bucket does not have.
+func s3NoSuchPublicAccessBlockResponse() *AWSResponse {
+	return s3ErrorResponse("NoSuchPublicAccessBlockConfiguration",
+		"The public access block configuration was not found.", http.StatusNotFound)
+}
+
+// putPublicAccessBlock handles PUT /<bucket>?publicAccessBlock.
+//
+// Substrate does not apply S3's April 2023 default of enabling all four settings
+// on a newly created bucket: a bucket that has never been the subject of a
+// PutPublicAccessBlock has no configuration, and GetPublicAccessBlock 404s. That
+// is deliberate. The default is a property of AWS-managed account and
+// organization state layered over the bucket, which substrate does not model, and
+// seeding every new bucket with a configuration would make the
+// NoSuchPublicAccessBlockConfiguration path — the one a consumer's error branch
+// exists for — unreachable through the public API. Consumers that need a
+// configured bucket call PutPublicAccessBlock, which is what the SDK and
+// CloudFormation both do.
+func (p *S3Plugin) putPublicAccessBlock(_ *RequestContext, req *AWSRequest, bucket string) (*AWSResponse, error) {
+	ctx := context.Background()
+
+	if missing, err := p.bucketMissingResponse(ctx, bucket); err != nil {
+		return nil, err
+	} else if missing != nil {
+		return missing, nil
+	}
+
+	// The four members are each `Required: No`, so a partial body is legal and
+	// every member it omits is recorded as false — which is how S3 reports them
+	// back. Unmarshalling into a zero value gets that for free.
+	//
+	// The body itself is `Required: Yes`, and an empty one lands here as
+	// MalformedXML rather than as a request to clear the settings — clearing is
+	// DeletePublicAccessBlock's job. No separate length check is needed: an empty
+	// body fails to unmarshal.
+	var cfg S3PublicAccessBlockConfiguration
+	if err := xml.Unmarshal(req.Body, &cfg); err != nil {
+		return s3ErrorResponse("MalformedXML", s3MalformedXMLMessage, http.StatusBadRequest), nil //nolint:nilerr // intentionally converted to an S3 XML error response
+	}
+
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal public access block: %w", err)
+	}
+	if err := p.state.Put(ctx, s3Namespace, s3PublicAccessBlockKey(bucket), raw); err != nil {
+		return nil, fmt.Errorf("put public access block: %w", err)
+	}
+
+	// 200 with an empty body, per the PutPublicAccessBlock reference — not the 204
+	// that PutBucketPolicy returns.
+	return &AWSResponse{StatusCode: http.StatusOK, Headers: map[string]string{}}, nil
+}
+
+// getPublicAccessBlock handles GET /<bucket>?publicAccessBlock.
+func (p *S3Plugin) getPublicAccessBlock(_ *RequestContext, _ *AWSRequest, bucket string) (*AWSResponse, error) {
+	ctx := context.Background()
+
+	if missing, err := p.bucketMissingResponse(ctx, bucket); err != nil {
+		return nil, err
+	} else if missing != nil {
+		return missing, nil
+	}
+
+	raw, err := p.state.Get(ctx, s3Namespace, s3PublicAccessBlockKey(bucket))
+	if err != nil {
+		return nil, fmt.Errorf("get public access block: %w", err)
+	}
+	if raw == nil {
+		return s3NoSuchPublicAccessBlockResponse(), nil
+	}
+
+	var cfg S3PublicAccessBlockConfiguration
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal public access block: %w", err)
+	}
+	cfg.Xmlns = s3XMLNamespace
+
+	return s3XMLResponse(http.StatusOK, cfg)
+}
+
+// deletePublicAccessBlock handles DELETE /<bucket>?publicAccessBlock.
+//
+// This is the operation that made #446 a data-loss defect rather than a fidelity
+// gap: unrouted, it fell through to DeleteBucket and destroyed the bucket. The
+// bucket is deliberately not touched here.
+//
+// Deleting a configuration that does not exist is a 204, not a 404. The
+// DeletePublicAccessBlock reference documents no errors, and its own
+// idempotence is what a consumer tearing down a bucket relies on — the AWS
+// provider for Terraform treats a NoSuchPublicAccessBlockConfiguration on delete
+// as success for that reason.
+func (p *S3Plugin) deletePublicAccessBlock(_ *RequestContext, _ *AWSRequest, bucket string) (*AWSResponse, error) {
+	ctx := context.Background()
+
+	if missing, err := p.bucketMissingResponse(ctx, bucket); err != nil {
+		return nil, err
+	} else if missing != nil {
+		return missing, nil
+	}
+
+	if err := p.state.Delete(ctx, s3Namespace, s3PublicAccessBlockKey(bucket)); err != nil {
+		return nil, fmt.Errorf("delete public access block: %w", err)
+	}
+
+	// 204, per the DELETE operation's declared responseCode.
+	return &AWSResponse{StatusCode: http.StatusNoContent, Headers: map[string]string{}}, nil
+}

--- a/emulator/s3_publicaccessblock.go
+++ b/emulator/s3_publicaccessblock.go
@@ -75,6 +75,9 @@ func (p *S3Plugin) putPublicAccessBlock(_ *RequestContext, req *AWSRequest, buck
 		return s3ErrorResponse("MalformedXML", s3MalformedXMLMessage, http.StatusBadRequest), nil //nolint:nilerr // intentionally converted to an S3 XML error response
 	}
 
+	// The error is unreachable for the current field set — four bools and two
+	// skipped members — but checked rather than discarded, so adding a field that
+	// can fail to marshal does not silently store nothing.
 	raw, err := json.Marshal(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("marshal public access block: %w", err)

--- a/emulator/s3_publicaccessblock_test.go
+++ b/emulator/s3_publicaccessblock_test.go
@@ -1,7 +1,9 @@
 package emulator_test
 
 import (
+	"context"
 	"encoding/xml"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -333,6 +335,167 @@ func TestS3_PublicAccessBlock_VirtualHostStyle(t *testing.T) {
 	del := s3VirtualHostRequest(t, srv, http.MethodDelete, bucket, "/?publicAccessBlock", nil, nil)
 	assert.Equal(t, http.StatusNoContent, del.Code)
 	assert.True(t, bucketExists(t, srv, bucket), "the bucket was destroyed")
+}
+
+// pabFaultState fails one named key's operations once armed, leaving every other
+// key working. It is armed after setup rather than from construction because
+// CreateBucket reads and writes the same `bucket:` key the fault targets — a store
+// that fails from the first call never gets a bucket to test against.
+//
+// [errAfterGetsStateManager] in error_protocol_test.go counts calls instead, which
+// suits a test that only needs "fail from here on". Targeting a key is what lets
+// these tests distinguish the bucket lookup from the configuration lookup, since a
+// single request does both.
+type pabFaultState struct {
+	inner   emulator.StateManager
+	key     string
+	err     error
+	armed   bool
+	onGet   bool
+	onPut   bool
+	onDelet bool
+}
+
+func (m *pabFaultState) fails(key string, op bool) bool {
+	return m.armed && op && key == m.key
+}
+
+func (m *pabFaultState) Get(ctx context.Context, namespace, key string) ([]byte, error) {
+	if m.fails(key, m.onGet) {
+		return nil, m.err
+	}
+	return m.inner.Get(ctx, namespace, key)
+}
+
+func (m *pabFaultState) Put(ctx context.Context, namespace, key string, value []byte) error {
+	if m.fails(key, m.onPut) {
+		return m.err
+	}
+	return m.inner.Put(ctx, namespace, key, value)
+}
+
+func (m *pabFaultState) Delete(ctx context.Context, namespace, key string) error {
+	if m.fails(key, m.onDelet) {
+		return m.err
+	}
+	return m.inner.Delete(ctx, namespace, key)
+}
+
+func (m *pabFaultState) List(ctx context.Context, namespace, prefix string) ([]string, error) {
+	return m.inner.List(ctx, namespace, prefix)
+}
+
+// TestS3_PublicAccessBlock_StateFailure asserts a store failure surfaces as a 500
+// rather than as one of this subresource's own 404s. The distinction matters
+// exactly as it does for [TestS3_StateFailureIsNotReportedAsNoSuchBucket]: a
+// NoSuchBucket or NoSuchPublicAccessBlockConfiguration tells a caller the answer is
+// settled and to stop retrying, while a store failure is transient. Reporting
+// "there is no configuration" for "I could not read the configuration" would send a
+// consumer down a permanent-failure path over a blip — and, for the DELETE case,
+// would report a successful teardown that did not happen.
+func TestS3_PublicAccessBlock_StateFailure(t *testing.T) {
+	const bucket = "pab-fault"
+
+	tests := []struct {
+		name    string
+		method  string
+		body    []byte
+		key     string
+		onGet   bool
+		onPut   bool
+		onDelet bool
+		seedCfg bool
+		notWant string
+	}{
+		{
+			name:    "PUT bucket lookup fails",
+			method:  http.MethodPut,
+			body:    []byte(pabAllTrue),
+			key:     "bucket:" + bucket,
+			onGet:   true,
+			notWant: "NoSuchBucket",
+		},
+		{
+			name:   "PUT store write fails",
+			method: http.MethodPut,
+			body:   []byte(pabAllTrue),
+			key:    "bucket_public_access_block:" + bucket,
+			onPut:  true,
+		},
+		{
+			name:    "GET bucket lookup fails",
+			method:  http.MethodGet,
+			key:     "bucket:" + bucket,
+			onGet:   true,
+			notWant: "NoSuchBucket",
+		},
+		{
+			name:    "GET configuration lookup fails",
+			method:  http.MethodGet,
+			key:     "bucket_public_access_block:" + bucket,
+			onGet:   true,
+			notWant: "NoSuchPublicAccessBlockConfiguration",
+		},
+		{
+			name:    "DELETE bucket lookup fails",
+			method:  http.MethodDelete,
+			key:     "bucket:" + bucket,
+			onGet:   true,
+			notWant: "NoSuchBucket",
+		},
+		{
+			name:    "DELETE store delete fails",
+			method:  http.MethodDelete,
+			key:     "bucket_public_access_block:" + bucket,
+			onDelet: true,
+			seedCfg: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &pabFaultState{
+				inner:   emulator.NewMemoryStateManager(),
+				key:     tt.key,
+				err:     errors.New("state store unavailable"),
+				onGet:   tt.onGet,
+				onPut:   tt.onPut,
+				onDelet: tt.onDelet,
+			}
+			srv := newS3TestServerWithState(t, state)
+			newPABBucket(t, srv, bucket)
+
+			if tt.seedCfg {
+				require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabAllTrue).Code)
+			}
+
+			state.armed = true
+
+			w := s3Request(t, srv, tt.method, "/"+bucket+"?publicAccessBlock", tt.body, nil)
+			assert.Equal(t, http.StatusInternalServerError, w.Code,
+				"a state-store failure must surface as a server error: %s", w.Body.String())
+			if tt.notWant != "" {
+				assert.NotContains(t, w.Body.String(), tt.notWant,
+					"a transient store failure was reported as a settled answer")
+			}
+		})
+	}
+}
+
+// TestS3_PublicAccessBlock_CorruptState covers a stored configuration that will not
+// decode. It is a 500 rather than the unset 404 for the same reason as above: a
+// configuration substrate cannot read is not a configuration the caller never
+// wrote.
+func TestS3_PublicAccessBlock_CorruptState(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	srv := newS3TestServerWithState(t, state)
+	bucket := newPABBucket(t, srv, "pab-corrupt")
+
+	require.NoError(t, state.Put(context.Background(), "s3",
+		"bucket_public_access_block:"+bucket, []byte("{not json")))
+
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?publicAccessBlock", nil, nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code, "body: %s", w.Body.String())
+	assert.NotContains(t, w.Body.String(), "NoSuchPublicAccessBlockConfiguration")
 }
 
 // TestS3_PublicAccessBlock_SiblingSubresourcesUnaffected is the regression guard

--- a/emulator/s3_publicaccessblock_test.go
+++ b/emulator/s3_publicaccessblock_test.go
@@ -1,0 +1,356 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// pabConfig is the PublicAccessBlockConfiguration a test writes and reads back.
+type pabConfig struct {
+	XMLName               xml.Name `xml:"PublicAccessBlockConfiguration"`
+	BlockPublicAcls       bool     `xml:"BlockPublicAcls"`
+	IgnorePublicAcls      bool     `xml:"IgnorePublicAcls"`
+	BlockPublicPolicy     bool     `xml:"BlockPublicPolicy"`
+	RestrictPublicBuckets bool     `xml:"RestrictPublicBuckets"`
+}
+
+// pabAllTrue is the body every SDK sends to lock a bucket down, and what
+// parsl-ephemeral-aws sends immediately after CreateBucket (#446).
+const pabAllTrue = `<?xml version="1.0" encoding="UTF-8"?>
+<PublicAccessBlockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <BlockPublicAcls>true</BlockPublicAcls>
+  <IgnorePublicAcls>true</IgnorePublicAcls>
+  <BlockPublicPolicy>true</BlockPublicPolicy>
+  <RestrictPublicBuckets>true</RestrictPublicBuckets>
+</PublicAccessBlockConfiguration>`
+
+// newPABBucket creates a bucket for a public-access-block test and returns its name.
+func newPABBucket(t *testing.T, srv *emulator.Server, name string) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodPut, "/"+name, nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "CreateBucket %s: %s", name, w.Body.String())
+	return name
+}
+
+// putPAB sends PutPublicAccessBlock and returns the recorder.
+func putPAB(t *testing.T, srv *emulator.Server, bucket, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	return s3Request(t, srv, http.MethodPut, "/"+bucket+"?publicAccessBlock", []byte(body), nil)
+}
+
+// getPAB reads a bucket's configuration back, requiring a 200.
+func getPAB(t *testing.T, srv *emulator.Server, bucket string) pabConfig {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?publicAccessBlock", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "GetPublicAccessBlock: %s", w.Body.String())
+
+	var cfg pabConfig
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &cfg), "decode config: %s", w.Body.String())
+	return cfg
+}
+
+// bucketExists reports whether ListBuckets still names the bucket. #446's whole
+// severity is that DELETE ?publicAccessBlock destroyed it, so the assertion has
+// to be made against the same surface the reporter used.
+func bucketExists(t *testing.T, srv *emulator.Server, bucket string) bool {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "ListBuckets: %s", w.Body.String())
+
+	var out struct {
+		Names []string `xml:"Buckets>Bucket>Name"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &out), "decode ListBuckets: %s", w.Body.String())
+
+	for _, n := range out.Names {
+		if n == bucket {
+			return true
+		}
+	}
+	return false
+}
+
+// TestS3_PublicAccessBlock_RoundTrip is the core of #446: the subresource was
+// unrouted, so nothing could be written and nothing could be read back.
+//
+// The GET assertion is what proves PUT was routed rather than merely accepted. A
+// PUT that reached CreateBucket also "succeeded" in the reporter's sense of not
+// crashing, so asserting the PUT's status alone would still pass against the bug
+// on a bucket that did not already exist.
+func TestS3_PublicAccessBlock_RoundTrip(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "pab-roundtrip")
+
+	resp := putPAB(t, srv, bucket, pabAllTrue)
+	// 200 with an empty body, per the PutPublicAccessBlock reference — the
+	// reporter saw 409 BucketAlreadyExists here, CreateBucket's answer.
+	assert.Equal(t, http.StatusOK, resp.Code, "body: %s", resp.Body.String())
+	assert.Empty(t, resp.Body.String(), "PutPublicAccessBlock returns no body")
+
+	assert.Equal(t, pabConfig{
+		XMLName:               xml.Name{Space: "http://s3.amazonaws.com/doc/2006-03-01/", Local: "PublicAccessBlockConfiguration"},
+		BlockPublicAcls:       true,
+		IgnorePublicAcls:      true,
+		BlockPublicPolicy:     true,
+		RestrictPublicBuckets: true,
+	}, getPAB(t, srv, bucket))
+}
+
+// TestS3_PublicAccessBlock_DeleteKeepsBucket is the regression guard for the
+// data-loss shape. Both the empty and the non-empty case are covered because the
+// fall-through produced two different wrong answers: a silent 204 that took the
+// bucket with it, and a 409 BucketNotEmpty naming an operation the caller never
+// issued.
+func TestS3_PublicAccessBlock_DeleteKeepsBucket(t *testing.T) {
+	tests := []struct {
+		name    string
+		bucket  string
+		withObj bool
+	}{
+		{
+			name:   "empty bucket survives (was: silently deleted)",
+			bucket: "pab-del-empty",
+		},
+		{
+			name:    "non-empty bucket survives (was: 409 BucketNotEmpty)",
+			bucket:  "pab-del-nonempty",
+			withObj: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			newPABBucket(t, srv, tt.bucket)
+
+			if tt.withObj {
+				w := s3Request(t, srv, http.MethodPut, "/"+tt.bucket+"/important.txt", []byte("payload"), nil)
+				require.Equal(t, http.StatusOK, w.Code, "PutObject: %s", w.Body.String())
+			}
+
+			require.Equal(t, http.StatusOK, putPAB(t, srv, tt.bucket, pabAllTrue).Code)
+
+			w := s3Request(t, srv, http.MethodDelete, "/"+tt.bucket+"?publicAccessBlock", nil, nil)
+			assert.Equal(t, http.StatusNoContent, w.Code, "DeletePublicAccessBlock: %s", w.Body.String())
+
+			assert.True(t, bucketExists(t, srv, tt.bucket),
+				"the bucket was destroyed by DELETE ?publicAccessBlock")
+
+			// The object has to survive too: reaching DeleteBucket on an empty
+			// bucket is the loss, but a bucket that still lists while its contents
+			// are gone would be the same defect one layer down.
+			if tt.withObj {
+				got := s3Request(t, srv, http.MethodGet, "/"+tt.bucket+"/important.txt", nil, nil)
+				assert.Equal(t, http.StatusOK, got.Code, "the object did not survive")
+				assert.Equal(t, "payload", got.Body.String())
+			}
+
+			// And the configuration itself is gone, which is what was asked for.
+			after := s3Request(t, srv, http.MethodGet, "/"+tt.bucket+"?publicAccessBlock", nil, nil)
+			assert.Equal(t, http.StatusNotFound, after.Code,
+				"the configuration outlived its DELETE")
+		})
+	}
+}
+
+// TestS3_PublicAccessBlock_GetUnset pins the 404. Before the fix GET fell through
+// to ListObjects and returned 200 with a ListBucketResult body, which the
+// reporter's SDK parsed into an empty configuration — a confident wrong answer
+// that reads as "public access is not blocked" rather than "nothing is
+// configured".
+//
+// A newly created bucket has no configuration: substrate does not apply S3's
+// April 2023 default of enabling all four settings, because that default comes
+// from AWS-managed account state substrate does not model, and seeding it would
+// make this 404 unreachable.
+func TestS3_PublicAccessBlock_GetUnset(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "pab-unset")
+
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?publicAccessBlock", nil, nil)
+	require.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "NoSuchPublicAccessBlockConfiguration", parseS3Error(t, w.Body.Bytes()).Code)
+}
+
+// TestS3_PublicAccessBlock_PartialBody covers the members being `Required: No`
+// individually. A body naming one setting must report the other three as false
+// rather than dropping them — S3 always returns all four elements.
+func TestS3_PublicAccessBlock_PartialBody(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "pab-partial")
+
+	require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, `<PublicAccessBlockConfiguration>
+  <BlockPublicPolicy>true</BlockPublicPolicy>
+</PublicAccessBlockConfiguration>`).Code)
+
+	got := getPAB(t, srv, bucket)
+	assert.True(t, got.BlockPublicPolicy, "the named setting was not recorded")
+	assert.False(t, got.BlockPublicAcls, "an omitted setting must read back as false")
+	assert.False(t, got.IgnorePublicAcls, "an omitted setting must read back as false")
+	assert.False(t, got.RestrictPublicBuckets, "an omitted setting must read back as false")
+}
+
+// TestS3_PublicAccessBlock_AllFalseIsNotUnset separates the two states a single
+// bool field could not distinguish: a configuration whose settings are all false
+// is a 200 carrying four false elements, not the 404 an unconfigured bucket gets.
+// A consumer relaxing a block writes exactly this body.
+func TestS3_PublicAccessBlock_AllFalseIsNotUnset(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "pab-all-false")
+
+	require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, `<PublicAccessBlockConfiguration>
+  <BlockPublicAcls>false</BlockPublicAcls>
+  <IgnorePublicAcls>false</IgnorePublicAcls>
+  <BlockPublicPolicy>false</BlockPublicPolicy>
+  <RestrictPublicBuckets>false</RestrictPublicBuckets>
+</PublicAccessBlockConfiguration>`).Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?publicAccessBlock", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code,
+		"an all-false configuration must be a 200, not the unset 404: %s", w.Body.String())
+
+	got := getPAB(t, srv, bucket)
+	assert.False(t, got.BlockPublicAcls)
+	assert.False(t, got.IgnorePublicAcls)
+	assert.False(t, got.BlockPublicPolicy)
+	assert.False(t, got.RestrictPublicBuckets)
+}
+
+// TestS3_PublicAccessBlock_Overwrite pins that PutPublicAccessBlock replaces the
+// configuration rather than merging into it — the operation "creates or modifies"
+// the whole document, so a second call naming fewer settings clears the rest.
+func TestS3_PublicAccessBlock_Overwrite(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "pab-overwrite")
+
+	require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabAllTrue).Code)
+	require.True(t, getPAB(t, srv, bucket).BlockPublicAcls)
+
+	require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, `<PublicAccessBlockConfiguration>
+  <IgnorePublicAcls>true</IgnorePublicAcls>
+</PublicAccessBlockConfiguration>`).Code)
+
+	got := getPAB(t, srv, bucket)
+	assert.True(t, got.IgnorePublicAcls)
+	assert.False(t, got.BlockPublicAcls, "PutPublicAccessBlock merged instead of replacing")
+	assert.False(t, got.BlockPublicPolicy, "PutPublicAccessBlock merged instead of replacing")
+	assert.False(t, got.RestrictPublicBuckets, "PutPublicAccessBlock merged instead of replacing")
+}
+
+// TestS3_PublicAccessBlock_DeleteIsIdempotent pins that deleting a configuration
+// that was never written is a 204. DeletePublicAccessBlock documents no errors,
+// and a teardown path that deletes unconditionally depends on it.
+func TestS3_PublicAccessBlock_DeleteIsIdempotent(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "pab-del-idempotent")
+
+	for i := range 2 {
+		w := s3Request(t, srv, http.MethodDelete, "/"+bucket+"?publicAccessBlock", nil, nil)
+		assert.Equal(t, http.StatusNoContent, w.Code, "delete %d: %s", i+1, w.Body.String())
+	}
+	assert.True(t, bucketExists(t, srv, bucket), "the bucket was destroyed")
+}
+
+// TestS3_PublicAccessBlock_NoSuchBucket covers all three verbs against a bucket
+// that does not exist. This is the assertion that would catch the routing being
+// half-applied: an unrouted PUT on a missing bucket would *create* it and return
+// 200, which is the most damaging form of the original bug.
+func TestS3_PublicAccessBlock_NoSuchBucket(t *testing.T) {
+	tests := []struct {
+		method string
+		body   []byte
+	}{
+		{method: http.MethodPut, body: []byte(pabAllTrue)},
+		{method: http.MethodGet},
+		{method: http.MethodDelete},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+
+			w := s3Request(t, srv, tt.method, "/pab-absent?publicAccessBlock", tt.body, nil)
+			require.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, "NoSuchBucket", parseS3Error(t, w.Body.Bytes()).Code)
+
+			assert.False(t, bucketExists(t, srv, "pab-absent"),
+				"the request created the bucket it named")
+		})
+	}
+}
+
+// TestS3_PublicAccessBlock_MalformedBody covers the two bad-body shapes. An empty
+// body is not a request to clear the settings — that is DeletePublicAccessBlock —
+// because the body is `Required: Yes`.
+func TestS3_PublicAccessBlock_MalformedBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{name: "empty body", body: nil},
+		{name: "not XML", body: []byte("{\"BlockPublicAcls\": true}")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			bucket := newPABBucket(t, srv, "pab-malformed")
+
+			w := s3Request(t, srv, http.MethodPut, "/"+bucket+"?publicAccessBlock", tt.body, nil)
+			require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, "MalformedXML", parseS3Error(t, w.Body.Bytes()).Code)
+
+			// A rejected body must leave the bucket unconfigured rather than
+			// half-written.
+			after := s3Request(t, srv, http.MethodGet, "/"+bucket+"?publicAccessBlock", nil, nil)
+			assert.Equal(t, http.StatusNotFound, after.Code, "a rejected PUT wrote a configuration")
+		})
+	}
+}
+
+// TestS3_PublicAccessBlock_VirtualHostStyle covers the addressing form SDKs
+// actually use. parseS3Operation resolves the bucket from the path or the Host
+// header before the subresource switch, so routing that works path-style could
+// still miss here.
+func TestS3_PublicAccessBlock_VirtualHostStyle(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "pab-vhost")
+
+	w := s3VirtualHostRequest(t, srv, http.MethodPut, bucket, "/?publicAccessBlock", []byte(pabAllTrue), nil)
+	require.Equal(t, http.StatusOK, w.Code, "PutPublicAccessBlock: %s", w.Body.String())
+
+	get := s3VirtualHostRequest(t, srv, http.MethodGet, bucket, "/?publicAccessBlock", nil, nil)
+	require.Equal(t, http.StatusOK, get.Code, "GetPublicAccessBlock: %s", get.Body.String())
+
+	var cfg pabConfig
+	require.NoError(t, xml.Unmarshal(get.Body.Bytes(), &cfg))
+	assert.True(t, cfg.BlockPublicAcls)
+
+	del := s3VirtualHostRequest(t, srv, http.MethodDelete, bucket, "/?publicAccessBlock", nil, nil)
+	assert.Equal(t, http.StatusNoContent, del.Code)
+	assert.True(t, bucketExists(t, srv, bucket), "the bucket was destroyed")
+}
+
+// TestS3_PublicAccessBlock_SiblingSubresourcesUnaffected is the regression guard
+// on the routing change itself. Three new checks were inserted ahead of the
+// CreateBucket, DeleteBucket and ListObjects fall-throughs, so the operations
+// that reach those fall-throughs legitimately have to keep working.
+func TestS3_PublicAccessBlock_SiblingSubresourcesUnaffected(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "pab-siblings")
+
+	// ListObjects still reaches the GET fall-through.
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket, nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "ListBucketResult")
+
+	// A configured public access block does not block DeleteBucket.
+	require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabAllTrue).Code)
+	del := s3Request(t, srv, http.MethodDelete, "/"+bucket, nil, nil)
+	require.Equal(t, http.StatusNoContent, del.Code, "DeleteBucket: %s", del.Body.String())
+	assert.False(t, bucketExists(t, srv, bucket), "DeleteBucket left the bucket behind")
+}

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -214,6 +214,41 @@ type S3BucketPolicy struct {
 	Policy string `json:"Policy"`
 }
 
+// S3PublicAccessBlockConfiguration is a bucket's Block Public Access settings,
+// the body of PutPublicAccessBlock and GetPublicAccessBlock (#446).
+//
+// The four members are each `Required: No` on PutPublicAccessBlock, so a caller
+// may name a subset. They are plain bools rather than pointers because S3 reports
+// an omitted member as `false` rather than omitting it from the GET response —
+// "absent" and "explicitly false" are the same observation, so a third state
+// would be one substrate could produce but real S3 never returns.
+//
+// Substrate records the configuration and reports it back; it does not enforce
+// it. Nothing here rejects a public ACL or a public bucket policy, because those
+// are the resource-internal consequences of the setting rather than the setting
+// itself — see the scope boundary in CLAUDE.md. Enforcement is tracked
+// separately (#458).
+type S3PublicAccessBlockConfiguration struct {
+	XMLName xml.Name `xml:"PublicAccessBlockConfiguration" json:"-"`
+
+	// Xmlns is echoed on the GET response to match S3's wire shape. It is
+	// ignored on input.
+	Xmlns string `xml:"xmlns,attr,omitempty" json:"-"`
+
+	// BlockPublicAcls rejects PutBucketAcl/PutObjectAcl calls carrying a public ACL.
+	BlockPublicAcls bool `xml:"BlockPublicAcls" json:"block_public_acls"`
+
+	// IgnorePublicAcls causes existing public ACLs to be disregarded.
+	IgnorePublicAcls bool `xml:"IgnorePublicAcls" json:"ignore_public_acls"`
+
+	// BlockPublicPolicy rejects a PutBucketPolicy that would allow public access.
+	BlockPublicPolicy bool `xml:"BlockPublicPolicy" json:"block_public_policy"`
+
+	// RestrictPublicBuckets limits a publicly-policied bucket to AWS service
+	// principals and authorized users in the owning account.
+	RestrictPublicBuckets bool `xml:"RestrictPublicBuckets" json:"restrict_public_buckets"`
+}
+
 // S3AccessControlList is the S3 access control list XML structure.
 type S3AccessControlList struct {
 	XMLName xml.Name  `xml:"AccessControlPolicy" json:"-"`


### PR DESCRIPTION
Closes #446.

## The defect

The `?publicAccessBlock` subresource was unrouted on all three verbs. It is addressed
as a bare query key on the bucket itself, so each request fell through to the
bucket-level operation for its method:

| Request | Reached | Consumer saw |
|---|---|---|
| `DELETE /bucket?publicAccessBlock` | `DeleteBucket` | `204` — and the bucket was gone |
| `PUT /bucket?publicAccessBlock` | `CreateBucket` | `409 BucketAlreadyExists` |
| `GET /bucket?publicAccessBlock` | `ListObjects` | `200` + a `ListBucketResult` body |

**The DELETE case is data loss with no signal.** On an empty bucket it returned `204` —
exactly what a successful `DeletePublicAccessBlock` returns — having destroyed the
bucket and its contents. The caller had nothing to go on: the next operation on that
bucket failed with `NoSuchBucket` for no visible reason. On a non-empty bucket it
returned `409 BucketNotEmpty`, naming an operation the caller never issued.

**PUT failed on exactly the shape SDKs send.** `PutPublicAccessBlock` immediately after
`CreateBucket` is what the AWS SDKs and CloudFormation both do, so hardening a bucket
failed on the already-owned bucket it was meant to configure.

**GET returned a confident wrong answer.** A `ListBucketResult` body parses into an
empty `PublicAccessBlockConfiguration`, so a consumer read "public access is not
blocked" for a bucket whose settings substrate had never stored.

One correction to the report, which assumed `GET` was routed and returning an empty
configuration: it was not routed at all. The empty configuration the reporter observed
was their SDK parsing `ListObjects`' XML.

## The fix

Each verb is routed **ahead of** its fall-through in `parseS3Operation`, and the three
operations are modeled in a new `emulator/s3_publicaccessblock.go`:

```
PUT    /bucket?publicAccessBlock  → 200, empty body
GET    /bucket?publicAccessBlock  → 200 + PublicAccessBlockConfiguration, or 404
DELETE /bucket?publicAccessBlock  → 204
```

- `PUT` replaces the document wholesale rather than merging. The four settings are each
  `Required: No`, and every one the body omits is recorded — and reported back — as
  `false`, matching S3.
- `GET` on a bucket with no configuration is `404
  NoSuchPublicAccessBlockConfiguration`, which keeps it distinguishable from the
  all-false configuration a consumer relaxing a block writes on purpose.
- `DELETE` is idempotent and touches nothing but the configuration.

The configuration lives under its own state key rather than as a field on `S3Bucket`.
That is what makes `DeletePublicAccessBlock` a delete rather than a partial rewrite of
the bucket record — so it is *structurally* incapable of touching the bucket, not
merely tested against doing so.

## On `NoSuchPublicAccessBlockConfiguration`

This was the one open question, and it is not answerable from the S3 API reference: the
code is absent from the S3 2006-03-01 model, and the bucket-level `GetPublicAccessBlock`
page has no Errors section at all. Rather than assume, it was corroborated from three
independent sources, recorded in the code comment:

- **terraform-provider-aws** handles this exact code in its *bucket-level*
  `internal/service/s3` package (not just `s3control`), on both `GetPublicAccessBlock`
  (→ NotFound) and `DeletePublicAccessBlock` (→ treated as success, which is why DELETE
  is idempotent here).
- **The s3control model's own shape documentation** describes the same condition.
- **boto/boto3 #3627** supplies the live message string verbatim: *"The public access
  block configuration was not found."*

## Two deliberate limits

Both are documented in `docs/services.md` rather than left to be discovered:

1. **Substrate does not apply S3's April 2023 default** of enabling all four settings on
   a newly created bucket. The blog post confirms that default applies to buckets created
   via the API, CLI, SDKs and CloudFormation — but it is a property of AWS-managed
   account and organization state substrate does not model, and seeding every new bucket
   with a configuration would make the `NoSuchPublicAccessBlockConfiguration` path — the
   branch a consumer's error handling exists for — unreachable through the public API.
2. **The settings are recorded, not enforced.** Nothing rejects a public ACL or bucket
   policy. Those are the resource-internal consequences of the setting rather than the
   setting itself, per the scope boundary in `CLAUDE.md`. Filed as #458, which also
   argues why `RestrictPublicBuckets` and `IgnorePublicAcls` should stay recorded-only
   until substrate models anonymous access evaluation.

## Tests

New `emulator/s3_publicaccessblock_test.go`, 11 tests:

- **`DeleteKeepsBucket`** — the regression guard, covering both of the reporter's
  reproductions: empty bucket (was silently deleted) and non-empty (was `409
  BucketNotEmpty`). Asserts the bucket still appears in `ListBuckets`, the object
  survives, and the configuration is gone.
- **`RoundTrip`** — `PUT` → `200` with an empty body, then `GET` returns what was
  written. The `GET` assertion is what proves `PUT` was *routed* rather than merely not
  crashing.
- **`GetUnset`** — `404 NoSuchPublicAccessBlockConfiguration`, and no `ListBucketResult`.
- **`AllFalseIsNotUnset`** — the two states stay distinguishable.
- **`PartialBody`** / **`Overwrite`** — omitted settings read back `false`; `PUT`
  replaces rather than merges.
- **`DeleteIsIdempotent`**, **`NoSuchBucket`** (all three verbs, and none of them creates
  the bucket it names), **`MalformedBody`**, **`VirtualHostStyle`**,
  **`SiblingSubresourcesUnaffected`** (`ListObjects` and `DeleteBucket` still reach the
  fall-throughs the new checks were inserted ahead of).

**Mutation-tested**, per the batch practice: each of the three routing sites removed, and
seven handler behaviours broken (GET-unset → all-false 200, PUT merging, both status
codes, DELETE not deleting, the bucket guard, the xmlns attr) — every one is caught by a
failing test. One mutation initially *passed*, revealing that the explicit
`len(req.Body) == 0` check was unreachable-by-test dead code, since `xml.Unmarshal`
already errors into the same `MalformedXML`; it was removed and the reasoning kept in the
comment.

## Verification

`gofmt -l` · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` (0 issues) ·
`make test` (race) · `cd test/e2e && go test ./...` · `make docs-reference-check
docs-versions` — all clean.