### PR TITLE
fix(s3): resolve task completions on HeadObject so HEAD matches GET (#457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- S3: `HeadObject` now resolves a synthesized task-completion record, so `HEAD` and
+  `GET` agree about whether the key exists (#457). `getObject` consulted the
+  completion resolver when no real object was staged at
+  `tasks/<task_id>/completion.json`; `headObject` did not, and answered `NoSuchKey`
+  for a key `GET` served with a 200 and a full body. Real S3 never contradicts itself
+  that way.
+
+  The practical consequence was that `aws s3 cp` could not read a synthesized record
+  at all — the CLI HEADs before it GETs, so it failed on the 404 and never reached
+  the working GET. That is the exact command spawn prints for users. An SDK
+  `HeadObject` existence poll broke in the worse direction: absence reads as "still
+  running", so a wait loop spun forever rather than failing visibly.
+
+  `HeadObject` now reports the same `Content-Length`, `ETag`, `Content-Type` and
+  `Last-Modified` a `GET` of the same key returns, and the `ended_at` clock gate that
+  makes a not-yet-complete record absent applies identically to both verbs — so a HEAD
+  before the simulated completion time is still the `404` a poll loop depends on. A
+  real staged object still wins, and a read naming an explicit `versionId` still does
+  not resolve, since a synthesized record has no version history.
+
+  `ListObjectsV2` deliberately continues not to enumerate synthesized records, and
+  that asymmetry is now recorded in `docs/services.md` rather than left to be
+  rediscovered: a keyed read works because the caller names the task, whereas a list
+  is unkeyed and substrate cannot enumerate the task IDs a consumer might ask about.
+  The task-completion resolver and its seeding endpoints are documented there for the
+  first time.
 - S3: `DELETE /bucket?publicAccessBlock` no longer destroys the bucket (#446). The
   `?publicAccessBlock` subresource was unrouted on all three verbs, and because it is
   addressed as a bare query key on the bucket itself, each request fell through to the

--- a/docs/services.md
+++ b/docs/services.md
@@ -192,8 +192,8 @@ STS operations are free.
 | DeleteBucket | |
 | ListBuckets | |
 | PutObject | Supports Content-Type, metadata headers; `Cache-Control`, `Content-Disposition`, `Content-Language`, `Expires` — see [Object system metadata](#object-system-metadata); `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums) |
-| GetObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
-| HeadObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums) |
+| GetObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); synthesizes a seedable task-completion record — see [Task-completion records](#task-completion-records) |
+| HeadObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); resolves a synthesized task-completion record exactly as `GetObject` does — see [Task-completion records](#task-completion-records) |
 | DeleteObject | Fires S3 notifications if configured |
 | CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums) |
 | ListObjects | Emits `<StorageClass>` per object |
@@ -641,6 +641,52 @@ Substrate records **no** checksum in that case. Synthesizing one would make a
 round-trip assertion pass whether or not the consumer's writer actually sends a
 checksum — the exact defect this support was added to expose. An absent checksum in
 substrate means "your writer sent none".
+
+### Task-completion records
+
+A read of `tasks/<task_id>/completion.json` on any bucket resolves to a synthesized
+spore.host task-completion record when no real object exists at that key. Substrate
+does not run the task — this is the seedable completion *observation* only, so a
+consumer's poll-until-done loop can be exercised instantly and reproducibly.
+
+Absent a seed the key resolves to the nominal success record, so the happy path needs
+no setup:
+
+```console
+$ aws s3api get-object --bucket results --key tasks/t1/completion.json /dev/stdout
+{"task_id":"t1","exit_code":0,"state":"completed","started_at":"…","ended_at":"…"}
+```
+
+Seed an alternate outcome — a non-zero exit, a `failed` state, or a completion time in
+the simulated future:
+
+```
+POST   /v1/spawn/task-completion   {"task_id","exit_code","state","started_at","ended_at"}
+DELETE /v1/spawn/task-completion?taskId=<id>   (or with no query, clear all)
+```
+
+**`ended_at` gates presence on the simulated clock.** Before that time the record
+reads as absent — `404 NoSuchKey` — which is the "still running" observation a poll
+loop needs in order to loop at all. After it, the record is served.
+
+**`HeadObject` resolves the record exactly as `GetObject` does**, reporting the same
+`Content-Length`, `ETag`, `Content-Type` and `Last-Modified`, and honoring the same
+clock gate. This matters because `aws s3 cp` and `aws s3 sync` HEAD before they GET,
+so a HEAD that 404'd made the record unreadable through the CLI even though the GET
+worked; an SDK `HeadObject` existence poll had the same problem in the worse
+direction, since absence reads as "still running" and the loop never terminates.
+
+**A real object always wins.** Staging an actual object at the completion key serves
+it verbatim; the resolver only runs when the key is absent. A read naming an explicit
+`versionId` never resolves either, since a synthesized record has no version history.
+Both reads and the resolver's response path are otherwise ordinary, so ranged and
+conditional reads apply to a synthesized record as to any other object.
+
+**`ListObjectsV2` deliberately does not enumerate synthesized records.** A keyed read
+works because the caller names the task, so the resolver has something to answer
+about. A list is unkeyed, and substrate cannot enumerate the set of task IDs a
+consumer might ask about — a list that invented entries would be a wrong answer, not a
+more complete one. This asymmetry is a decision, not an oversight.
 
 ### Block Public Access
 

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -730,18 +730,35 @@ func (p *S3Plugin) headObject(_ *RequestContext, req *AWSRequest, bucket, key st
 	if err != nil {
 		return nil, fmt.Errorf("get object metadata: %w", err)
 	}
-	if data == nil {
-		return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound), nil
-	}
 
 	var obj S3Object
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, fmt.Errorf("unmarshal object metadata: %w", err)
-	}
+	if data == nil {
+		// Mirror getObject: no real object at this key, so a HEAD of
+		// tasks/<task_id>/completion.json may be a seedable spore.host
+		// task-completion observation (#360). HEAD has to consult the same resolver
+		// GET does, because HEAD and GET disagreeing about whether a key exists is
+		// something real S3 never does — and `aws s3 cp` HEADs before it GETs, so a
+		// HEAD-only 404 made a synthesized record unreadable through the CLI (#457).
+		//
+		// The body is discarded: the resolver returns a fully-populated S3Object, so
+		// Content-Length, ETag and Content-Type below match what GET reports, and the
+		// clock gate that makes a not-yet-complete record absent applies identically.
+		var handled bool
+		if versionID == "" {
+			obj, _, handled = p.resolveTaskCompletion(ctx, key)
+		}
+		if !handled {
+			return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound), nil
+		}
+	} else {
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return nil, fmt.Errorf("unmarshal object metadata: %w", err)
+		}
 
-	if obj.IsDeleteMarker {
-		// Mirror getObject: 405 when a version is named, 404 otherwise.
-		return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
+		if obj.IsDeleteMarker {
+			// Mirror getObject: 405 when a version is named, 404 otherwise.
+			return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
+		}
 	}
 
 	// HEAD evaluates preconditions exactly as GET does. It deliberately does *not*

--- a/emulator/spawn_control_test.go
+++ b/emulator/spawn_control_test.go
@@ -3,6 +3,8 @@ package emulator_test
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,6 +127,191 @@ func TestSpawn_TaskCompletion_NonMatchingKeyStays404(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, w.Code, key)
 		assert.Contains(t, w.Body.String(), "NoSuchKey", key)
 	}
+}
+
+// spawnCompletionHeadGet issues a HEAD and a GET of the same completion key and
+// returns both recorders, so a test can assert the pair agrees rather than
+// asserting each in isolation. The disagreement in #457 was invisible to any test
+// that only exercised one verb.
+func spawnCompletionHeadGet(t *testing.T, srv *emulator.Server, path string) (head, get *httptest.ResponseRecorder) {
+	t.Helper()
+	return s3Request(t, srv, http.MethodHead, path, nil, nil),
+		s3Request(t, srv, http.MethodGet, path, nil, nil)
+}
+
+// TestSpawn_TaskCompletion_HeadMatchesGet is #457: getObject consulted the
+// completion resolver and headObject did not, so HEAD reported NoSuchKey for a key
+// GET served with a 200 body. Real S3 never disagrees with itself that way.
+//
+// The practical failure was that `aws s3 cp` — the command spawn prints for users —
+// could not read a synthesized record at all, because the CLI HEADs before it GETs
+// and never reached the working GET. An SDK HeadObject existence poll had the same
+// problem, and in the worse direction: absence reads as "still running", so the
+// loop never terminates rather than failing visibly.
+//
+// Every resolver behavior is asserted through both verbs together, since the whole
+// defect was one verb's view of the resolver drifting from the other's.
+func TestSpawn_TaskCompletion_HeadMatchesGet(t *testing.T) {
+	tests := []struct {
+		name     string
+		seed     map[string]any
+		stage    string
+		key      string
+		wantCode int
+	}{
+		{
+			name:     "nominal success, no seed",
+			key:      "task-h1",
+			wantCode: http.StatusOK,
+		},
+		{
+			name: "seeded failure",
+			seed: map[string]any{
+				"task_id": "task-h2", "exit_code": 9, "state": "failed",
+				"started_at": "2026-01-01T11:00:00Z", "ended_at": "2026-01-01T11:05:00Z",
+			},
+			key:      "task-h2",
+			wantCode: http.StatusOK,
+		},
+		{
+			// The clock gate has to gate both verbs identically: a HEAD before the
+			// simulated completion time is the "still running" observation a poll
+			// loop depends on, and a HEAD that answered 200 early would report a
+			// task complete that GET still reports as absent.
+			name: "clock-gated, not yet complete",
+			seed: map[string]any{
+				"task_id": "task-h3", "exit_code": 0, "state": "completed",
+				"started_at": "2026-01-01T11:59:00Z", "ended_at": "2030-01-01T00:00:00Z",
+			},
+			key:      "task-h3",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "real staged object wins",
+			stage:    `{"task_id":"task-h4","exit_code":7,"state":"failed","started_at":"x","ended_at":"y"}`,
+			key:      "task-h4",
+			wantCode: http.StatusOK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/results", nil, nil).Code)
+
+			if tt.seed != nil {
+				spawnSeedCompletion(t, srv, tt.seed)
+			}
+			path := "/results/tasks/" + tt.key + "/completion.json"
+			if tt.stage != "" {
+				require.Equal(t, http.StatusOK,
+					s3Request(t, srv, http.MethodPut, path, []byte(tt.stage), nil).Code)
+			}
+
+			head, get := spawnCompletionHeadGet(t, srv, path)
+
+			assert.Equal(t, tt.wantCode, get.Code, "GET: %s", get.Body.String())
+			assert.Equal(t, tt.wantCode, head.Code, "HEAD: %s", head.Body.String())
+			assert.Equal(t, get.Code, head.Code, "HEAD and GET disagree about the same key")
+
+			if tt.wantCode != http.StatusOK {
+				assert.Contains(t, head.Body.String(), "NoSuchKey")
+				return
+			}
+
+			// The metadata a HEAD exists to report has to describe the body a GET
+			// would actually return — a HEAD promising a different length or ETag is
+			// its own wrong answer, and Content-Length is what `aws s3 cp` sizes its
+			// download from.
+			assert.Empty(t, head.Body.String(), "HEAD returns no body")
+			for _, h := range []string{"Content-Length", "ETag", "Content-Type", "Last-Modified", "Accept-Ranges"} {
+				assert.Equal(t, get.Header().Get(h), head.Header().Get(h), h)
+			}
+			assert.Equal(t, strconv.Itoa(get.Body.Len()), head.Header().Get("Content-Length"),
+				"HEAD's Content-Length must match the bytes GET returns")
+		})
+	}
+}
+
+// TestSpawn_TaskCompletion_HeadNonMatchingKeyStays404 is the counterpart to
+// [TestSpawn_TaskCompletion_NonMatchingKeyStays404] for HEAD. Routing the resolver
+// into headObject must not make HEAD answer for keys the resolver does not own; a
+// HEAD of any absent key outside the tasks/*/completion.json shape is still
+// NoSuchKey.
+func TestSpawn_TaskCompletion_HeadNonMatchingKeyStays404(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/results", nil, nil).Code)
+
+	for _, key := range []string{
+		"/results/tasks/task-1/other.json",
+		"/results/some/other/object.txt",
+		"/results/tasks//completion.json",
+		"/results/tasks/task-1/completion.json.bak",
+	} {
+		w := s3Request(t, srv, http.MethodHead, key, nil, nil)
+		assert.Equal(t, http.StatusNotFound, w.Code, key)
+		assert.Contains(t, w.Body.String(), "NoSuchKey", key)
+	}
+}
+
+// TestSpawn_TaskCompletion_HeadVersionedIsNot404Synthesized pins that a HEAD naming
+// an explicit versionId does not reach the resolver, matching getObject: a
+// synthesized record has no version history, so answering for a named version would
+// invent one.
+func TestSpawn_TaskCompletion_HeadVersionedIsNot404Synthesized(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/results", nil, nil).Code)
+
+	const path = "/results/tasks/task-v/completion.json"
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodHead, path, nil, nil).Code)
+
+	for _, verb := range []string{http.MethodHead, http.MethodGet} {
+		w := s3Request(t, srv, verb, path+"?versionId=null", nil, nil)
+		assert.Equal(t, http.StatusNotFound, w.Code, verb)
+		assert.Contains(t, w.Body.String(), "NoSuchKey", verb)
+	}
+}
+
+// TestSpawn_TaskCompletion_HeadRange covers HEAD's Range handling on a synthesized
+// record. headObject honors Range as GET does, and now that it serves the resolver's
+// object the two must agree on both the satisfiable and unsatisfiable cases.
+func TestSpawn_TaskCompletion_HeadRange(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/results", nil, nil).Code)
+
+	const path = "/results/tasks/task-hr/completion.json"
+	full := s3Request(t, srv, http.MethodGet, path, nil, nil)
+	require.Equal(t, http.StatusOK, full.Code)
+
+	part := s3Request(t, srv, http.MethodHead, path, nil, map[string]string{"Range": "bytes=0-3"})
+	require.Equal(t, http.StatusPartialContent, part.Code)
+	assert.Equal(t, "4", part.Header().Get("Content-Length"))
+	assert.Equal(t, "bytes 0-3/"+strconv.Itoa(full.Body.Len()), part.Header().Get("Content-Range"))
+	assert.Empty(t, part.Body.String(), "HEAD returns no body even for a range")
+
+	bad := s3Request(t, srv, http.MethodHead, path, nil,
+		map[string]string{"Range": "bytes=" + strconv.Itoa(full.Body.Len()+10) + "-"})
+	assert.Equal(t, http.StatusRequestedRangeNotSatisfiable, bad.Code)
+}
+
+// TestSpawn_TaskCompletion_HeadPreconditions covers conditional HEADs against a
+// synthesized record. The resolver supplies a real ETag, so If-None-Match must
+// produce a 304 — which is what makes a cheap "has it changed?" poll work — and a
+// non-matching If-Match a 412.
+func TestSpawn_TaskCompletion_HeadPreconditions(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/results", nil, nil).Code)
+
+	const path = "/results/tasks/task-hp/completion.json"
+	first := s3Request(t, srv, http.MethodHead, path, nil, nil)
+	require.Equal(t, http.StatusOK, first.Code)
+	etag := first.Header().Get("ETag")
+	require.NotEmpty(t, etag, "the resolver must supply an ETag for conditionals to work")
+
+	same := s3Request(t, srv, http.MethodHead, path, nil, map[string]string{"If-None-Match": etag})
+	assert.Equal(t, http.StatusNotModified, same.Code)
+
+	mismatch := s3Request(t, srv, http.MethodHead, path, nil, map[string]string{"If-Match": `"deadbeef"`})
+	assert.Equal(t, http.StatusPreconditionFailed, mismatch.Code)
 }
 
 func TestSpawn_TaskCompletion_SeedAndClear(t *testing.T) {


### PR DESCRIPTION
Closes #457.

## The defect

`getObject` consults `resolveTaskCompletion` when no real object is staged at
`tasks/<task_id>/completion.json` (#360). `headObject` had no equivalent hook, so the
two verbs disagreed about whether the key exists — something real S3 never does.

Reproduced before fixing:

```
GET  /results/tasks/t1/completion.json  → 200, 120-byte body, ETag, Content-Type
HEAD /results/tasks/t1/completion.json  → 404 NoSuchKey
```

**`aws s3 cp` could not read a synthesized record at all.** The CLI HEADs before it
GETs, fails on the 404, and never reaches the working GET — and that is the exact
command spawn prints for users.

**An SDK `HeadObject` poll broke in the worse direction.** Absence reads as *still
running*, so a wait loop spins forever rather than failing visibly. That is the
inverse of the polarity this batch has mostly been closing: not success where AWS
fails, but absence where substrate's own GET reports presence.

## The fix

`headObject` calls the same resolver, discarding the body:

```go
if data == nil {
    var handled bool
    if versionID == "" {
        obj, _, handled = p.resolveTaskCompletion(ctx, key)
    }
    if !handled {
        return s3ErrorResponse("NoSuchKey", …, http.StatusNotFound), nil
    }
} else { … }
```

The resolver returns a fully-populated `S3Object`, so `Content-Length`, `ETag`,
`Content-Type` and `Last-Modified` match what `GET` reports with no new synthesis
logic. The `versionID == ""` guard and the real-object-wins precedence mirror
`getObject`, and the delete-marker branch moves into the `else` where it belongs — a
synthesized record cannot be a delete marker.

**The clock gate applies identically**, which the issue specifically asked to have
confirmed: a HEAD before the simulated `ended_at` is still the `404` that a poll loop
depends on to keep polling. Asserted directly, not assumed.

## Tests

Tests assert HEAD and GET **together** rather than either in isolation, since the
defect was precisely one verb's view of the resolver drifting from the other's — a
test exercising one verb could never have caught it.

`TestSpawn_TaskCompletion_HeadMatchesGet` runs the resolver's whole behavior matrix
through both verbs: nominal success, a seeded failure, the clock-gated
not-yet-complete case, and a real staged object. Each asserts the two status codes
agree, and on a 200 that every header a HEAD exists to report matches what GET
returns — including `Content-Length` against the actual byte count, which is what
`aws s3 cp` sizes its download from.

Plus HEAD-specific coverage: ranges (satisfiable and unsatisfiable), conditionals
(`If-None-Match` → 304, non-matching `If-Match` → 412, which is what makes a cheap
"has it changed?" poll work), non-matching keys still 404, and an explicit
`versionId` not resolving.

**Mutation-tested:**

| Mutation | Result |
|---|---|
| Revert the fix entirely | 4 tests fail |
| Drop the `versionID == ""` guard | the versioned case fails |
| Move delete-marker handling out of the `else` | existing `TestS3_GetHeadObject_DeleteMarker` fails |

## Docs

The task-completion resolver was **undocumented entirely** — no mention of the key
shape, the seeding endpoints, or the clock gate anywhere in `docs/`. Added a
`### Task-completion records` section covering all of it, plus the HEAD/GET agreement
contract.

It also records the reporter's point about `ListObjectsV2`: not enumerating
synthesized records is **correct and deliberate**, not an oversight. A keyed read
works because the caller names the task, so the resolver has something to answer
about; a list is unkeyed and substrate cannot enumerate the set of task IDs a
consumer might ask about, so a list that invented entries would be a wrong answer
rather than a more complete one.

## Not addressed here

The issue's closing note that `go install`ed builds report `"version":"dev"` on
`/health` is real but separate — it's #402's immutable-tag caveat applying to
`go install`, since the `-X` ldflag is only set by the release build. Left out of
scope deliberately rather than silently.

## Verification

`gofmt -l` · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` (0 issues) ·
`make test` (race) · `make docs-reference-check docs-versions` — all clean.