### PR TITLE
feat(sqs): enforce MaximumMessageSize on SendMessage (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- SQS: `SendMessage` and `SendMessageBatch` now enforce `MaximumMessageSize` (#454).
+  No length check existed anywhere in the send path — against the queue's attribute or
+  against any constant — so a body of any size was accepted and delivered. Real SQS
+  rejects an oversized message, which meant a consumer's too-large-payload branch
+  (chunk, compress, spill to S3) was unreachable and any test of it passed while
+  verifying nothing. This is the enforcement half of #439, which deliberately
+  corrected only the reported default.
+
+  `SendMessage` fails with `InvalidParameterValue`, HTTP 400, and a message naming the
+  limit that applied. The limit is the queue's **effective** `MaximumMessageSize`,
+  resolved through the 1 MiB default when the attribute is unset and read via the same
+  call `GetQueueAttributes` uses — so the number a caller reads back is by construction
+  the number enforced. A queue created with an explicit smaller value enforces that
+  value. The boundary is inclusive: a message of exactly the limit is accepted, since
+  AWS's "must be shorter than N bytes" wording describes N as the maximum size.
+
+  **Message attributes count toward the measured size**, as AWS measures it: the body
+  plus each attribute's name, data type and value, with a binary value counted at its
+  raw decoded length. The developer guide states that "all components of a message
+  attribute are included in the 1 MiB message size restriction", and the per-component
+  breakdown is the one AWS's own Extended Client Library uses to decide whether a
+  payload needs offloading to S3. Measuring the body alone would be wrong in the
+  direction that matters — a caller packing most of the budget into metadata is over
+  the limit in AWS and under it here, so the payload shape that motivates a chunking
+  branch is precisely the one substrate would have accepted. Attributes are parsed for
+  measurement only; storing and returning them is tracked separately (#461).
+
+  `SendMessageBatch` enforces both documented limits: `BatchRequestTooLong` when the
+  combined payload exceeds 1 MiB, and `InvalidParameterValue` when a single entry
+  exceeds the queue's per-message limit. Because the two limits are equal on a default
+  queue, a batch carrying one oversized entry breaches the total as well — and real AWS
+  reports `BatchRequestTooLong` for that case rather than the per-message error, so the
+  total is checked first. The queue attribute is a per-message cap and does not lower
+  the request payload cap, so ten legal 1 KiB entries on a 1 KiB queue are accepted.
+
+  A rejected send or batch enqueues nothing, rather than a prefix of the batch that a
+  retry would then duplicate. On a FIFO queue the check runs before the deduplication
+  ID is recorded, so a corrected retry reusing the same `MessageDeduplicationId` is
+  delivered instead of being swallowed as a duplicate — which would have been a worse
+  failure than the original, because it looks like success.
+
+  **Provenance, stated plainly:** the per-message error code is not derivable from the
+  API model. `SendMessage` declares no oversized-message error at all, its
+  `InvalidMessageContents` is documented as a character-set error, and
+  `BatchRequestTooLong` is declared only on `SendMessageBatch`. The code and both
+  message wordings come from observed real-AWS responses — captured SDK errors carrying
+  `code: 'InvalidParameterValue'` with HTTP 400, and `BatchRequestTooLong: Batch
+  requests cannot be longer than N bytes. You have sent M bytes.` — corroborated by
+  independent reimplementations emitting the same strings. `docs/services.md` records
+  this rather than implying a doc citation.
+
 ### Fixed
 - S3: `HeadObject` now resolves a synthesized task-completion record, so `HEAD` and
   `GET` agree about whether the key exists (#457). `getObject` consulted the

--- a/docs/services.md
+++ b/docs/services.md
@@ -795,8 +795,8 @@ Lambda invocations: $0.0000002 per request.
 | SetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteQueue | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | ListQueues | |
-| SendMessage | Returns MessageId; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; does **not** enforce [`MaximumMessageSize`](#queue-attribute-defaults) |
-| SendMessageBatch | |
+| SendMessage | Returns MessageId; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; enforces [`MaximumMessageSize`](#message-size-enforcement) |
+| SendMessageBatch | Enforces both the [per-message and batch-total size limits](#message-size-enforcement) |
 | ReceiveMessage | Supports MaxNumberOfMessages, WaitTimeSeconds; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteMessage | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteMessageBatch | |
@@ -891,14 +891,72 @@ along with everything else.
 what substrate reported until #439. An explicitly requested value is always honored
 — 256 KiB is still a legal size.
 
-**Substrate does not enforce `MaximumMessageSize` on `SendMessage`.** No length
-check exists against the attribute or any constant, so an oversized body is
-accepted rather than rejected. A consumer's too-large-payload branch is therefore
-not reachable here; enforcement is tracked separately.
-
 These defaults also decide what counts as a
 [`QueueNameExists`](#queuenameexists) conflict, since an existing queue's unset
 attributes are resolved through them before comparing.
+
+### Message size enforcement
+
+`SendMessage` rejects a message larger than the queue's **effective**
+`MaximumMessageSize` with `InvalidParameterValue`, HTTP 400:
+
+```
+One or more parameters are invalid. Reason: Message must be shorter than 1048576 bytes.
+```
+
+"Effective" means resolved through the [default](#queue-attribute-defaults) when the
+attribute is unset, so a queue created with no attributes enforces 1 MiB. The limit is
+read through the same default `GetQueueAttributes` reports, so the number a caller
+reads back is by construction the number that is enforced. The limit named in the
+message is the one that actually applied — a queue configured at 1 KiB says 1024.
+
+The boundary is **inclusive**: a message of exactly the limit is accepted. AWS's
+wording is "must be shorter than N bytes", but N is the documented maximum *size*, so
+the largest legal message is N bytes.
+
+**Message attributes count toward the size.** The measured total is the body plus, for
+every attribute, its name, its data type, and its value — a binary value counted as
+its raw (decoded) byte length. The developer guide is explicit that "all components of
+a message attribute are included in the 1 MiB message size restriction", and the
+per-component breakdown is the one AWS's own Extended Client Library uses to decide
+whether a payload needs offloading to S3. Message *system* attributes are excluded,
+per the `SendMessage` reference.
+
+Attributes are parsed for measurement only; substrate does not yet store them or
+return them from `ReceiveMessage` (tracked separately).
+
+`SendMessageBatch` enforces two limits, both 1 MiB, as the reference states: "the
+maximum allowed individual message size and the maximum total payload size (the sum of
+the individual lengths of all of the batched messages) are both 1 MiB".
+
+| Condition | Error |
+|---|---|
+| Combined payload of all entries over 1 MiB | `BatchRequestTooLong` |
+| One entry over the queue's per-message limit | `InvalidParameterValue` |
+
+Because the two limits are equal on a default queue, a batch carrying a single
+oversized entry breaches the total as well — and real AWS reports
+`BatchRequestTooLong` for that case, not the per-message error, so the total is checked
+first. The queue's `MaximumMessageSize` is a *per-message* cap and does not lower the
+request payload cap: ten legal 1 KiB entries on a queue configured at 1 KiB are
+accepted.
+
+A rejected send or batch enqueues **nothing** — a partially applied batch would leave a
+retry to re-send the entries that already landed. On a FIFO queue the size check runs
+before the deduplication ID is recorded, so a corrected retry reusing the same
+`MessageDeduplicationId` is delivered rather than swallowed as a duplicate.
+
+An unparseable or non-positive `MaximumMessageSize` falls back to the default rather
+than to zero, which would make the queue reject every message including an empty one.
+
+**Provenance.** `SendMessage` declares no oversized-message error in the API model:
+its `InvalidMessageContents` is documented as a character-set error, and
+`BatchRequestTooLong` is declared only on `SendMessageBatch`. The per-message code and
+both message wordings therefore come from **observed real-AWS responses** rather than
+a doc citation — captured SDK errors carrying `code: 'InvalidParameterValue'` with
+HTTP 400, and `BatchRequestTooLong: Batch requests cannot be longer than N bytes. You
+have sent M bytes.` The same strings appear in independent reimplementations, which
+corroborates them as transcribed AWS text.
 
 ### QueueNameExists
 

--- a/emulator/sqs_createqueue.go
+++ b/emulator/sqs_createqueue.go
@@ -11,9 +11,10 @@ import "sort"
 // report one number while a re-create request naming that same number was rejected as
 // a conflict.
 //
-// Substrate does not enforce this limit on SendMessage; no length check exists against
-// it or any other constant. That absence is deliberate here — enforcement is a new
-// error path with its own scope, tracked separately from correcting the default.
+// SendMessage and SendMessageBatch enforce it, resolved through this default when the
+// attribute is unset (#454) — see [sqsEffectiveMaximumMessageSize], which reads it via
+// the same getAttrOrDefault call the read path uses so the reported and enforced
+// numbers cannot diverge.
 const sqsDefaultMaximumMessageSize = "1048576"
 
 // sqsAttributeDefaults are the values GetQueueAttributes reports for a queue that

--- a/emulator/sqs_createqueue_test.go
+++ b/emulator/sqs_createqueue_test.go
@@ -549,8 +549,9 @@ func sqsQueueAttribute(t *testing.T, srv *emulator.Server, name, attr string, js
 // historical limit. A consumer sizing a payload against what substrate reported was
 // working from a number a real queue would not give it.
 //
-// Note that substrate does not enforce this on SendMessage — no length check exists
-// against the attribute or any constant. This corrects the reported default only.
+// This covers the reported default only. Enforcement of it on SendMessage came later
+// (#454) and is covered by TestSQS_SendMessage_EffectiveLimitResolvesThroughDefault,
+// which asserts the enforced limit is the value this test pins.
 func TestSQS_CreateQueue_MaximumMessageSizeDefault(t *testing.T) {
 	bothProtocols(t, func(t *testing.T, jsonProto bool) {
 		t.Run("a bare queue reports 1 MiB", func(t *testing.T) {

--- a/emulator/sqs_messagesize.go
+++ b/emulator/sqs_messagesize.go
@@ -1,0 +1,209 @@
+package emulator
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// sqsEffectiveMaximumMessageSize returns the byte limit a queue observably enforces,
+// resolved through [sqsDefaultMaximumMessageSize] when the attribute is unset.
+//
+// It reads through the same default the read path does rather than holding a second
+// copy, so the number GetQueueAttributes reports is by construction the number
+// SendMessage enforces. A divergence here would be its own confident wrong answer: a
+// consumer that sizes its payloads from the reported attribute would have them
+// rejected anyway.
+//
+// A malformed attribute value falls back to the default rather than to zero. Zero
+// would reject every message including an empty one, turning an unparseable
+// attribute into a queue that accepts nothing — CreateQueue is where an invalid
+// value belongs, not every subsequent send.
+func sqsEffectiveMaximumMessageSize(q *SQSQueue) int {
+	v := getAttrOrDefault(q.Attributes, "MaximumMessageSize", sqsDefaultMaximumMessageSize)
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		n, _ = strconv.Atoi(sqsDefaultMaximumMessageSize)
+	}
+	return n
+}
+
+// sqsMessageSize returns the byte size AWS measures a message at: the body plus
+// every component of every message attribute.
+//
+// The developer guide is explicit that attributes count — "All components of a
+// message attribute are included in the 1 MiB message size restriction" — and the
+// per-component breakdown is AWS's own, from the size calculation the Amazon SQS
+// Extended Client Library uses to decide whether a payload needs offloading to S3
+// (`getMsgAttributesSize`): the name, the data type, and the value, each as UTF-8
+// bytes, with a binary value counted as its raw byte length.
+//
+// Measuring the body alone would be the wrong boundary in the direction that
+// matters: a caller who packs 900 KiB of metadata beside a 200 KiB body is over the
+// limit in AWS and under it here, so the very payload shape that motivates a
+// chunking branch is the one substrate would accept.
+//
+// Message *system* attributes are deliberately excluded — the SendMessage reference
+// states "The size of a message system attribute doesn't count towards the total
+// size of a message." Substrate does not model them today; the exclusion is recorded
+// here so that adding them does not silently add them to the total.
+func sqsMessageSize(body string, attrs map[string]SQSMessageAttribute) int {
+	size := len(body)
+	for name, attr := range attrs {
+		size += len(name) + len(attr.DataType) + len(attr.StringValue) + len(attr.BinaryValue)
+	}
+	return size
+}
+
+// sqsQueryMessageAttributes collects the message attributes carried under a
+// query-protocol parameter prefix, for measurement by [sqsMessageSize].
+//
+// The wire form is the SendMessage reference's own example:
+// MessageAttribute.N.Name, MessageAttribute.N.Value.DataType and
+// MessageAttribute.N.Value.StringValue, numbered from 1. The prefix argument is what
+// lets SendMessageBatch reuse this for its per-entry
+// SendMessageBatchRequestEntry.N.MessageAttribute.M.* nesting. Note this is not SNS's
+// MessageAttributes.entry.N.* shape; the two services differ and
+// [parseSNSMessageAttributes] is deliberately separate.
+//
+// A BinaryValue arrives base64-encoded, and AWS counts a binary attribute as its raw
+// byte length, so it is decoded before measurement. Undecodable input is measured as
+// the bytes actually sent rather than dropped to zero — a request substrate cannot
+// decode is still a request whose size a caller can observe being rejected.
+//
+// Attributes are collected for measurement only; substrate does not yet store or
+// return them on ReceiveMessage (#461). Returning nil for a request carrying none
+// keeps that the common, allocation-free path.
+func sqsQueryMessageAttributes(params map[string]string, prefix string) map[string]SQSMessageAttribute {
+	var attrs map[string]SQSMessageAttribute
+	for i := 1; ; i++ {
+		base := fmt.Sprintf("%sMessageAttribute.%d.", prefix, i)
+		name, ok := params[base+"Name"]
+		if !ok {
+			break
+		}
+		attr := SQSMessageAttribute{
+			DataType:    params[base+"Value.DataType"],
+			StringValue: params[base+"Value.StringValue"],
+		}
+		if raw := params[base+"Value.BinaryValue"]; raw != "" {
+			decoded, err := base64.StdEncoding.DecodeString(raw)
+			if err != nil {
+				decoded = []byte(raw)
+			}
+			attr.BinaryValue = decoded
+		}
+		if attrs == nil {
+			attrs = make(map[string]SQSMessageAttribute)
+		}
+		attrs[name] = attr
+	}
+	return attrs
+}
+
+// sqsMessageTooLong returns the error SendMessage raises for a message exceeding the
+// queue's effective MaximumMessageSize.
+//
+// The code is InvalidParameterValue, HTTP 400. It is not derivable from the API
+// model: the SendMessage reference lists no oversized-message error at all, its
+// InvalidMessageContents is documented as a character-set error ("The message
+// contains characters outside the allowed set"), and BatchRequestTooLong is declared
+// only on SendMessageBatch. The provenance is therefore an observed real-AWS
+// response rather than a doc citation, and is recorded as such: a captured SDK error
+// from real SQS carries `code: 'InvalidParameterValue'`, statusCode 400, and the
+// message reproduced below (artilleryio/artillery#3463, whose 262144 reflects the
+// queue's limit at the time). The same wording is what moto emits, which corroborates
+// it as transcribed AWS text rather than one project's invention.
+//
+// The limit is interpolated rather than fixed because the message is the only place a
+// caller learns which limit applied — a queue with an explicit 1 KiB attribute
+// rejects at 1 KiB, and reporting 1 MiB there would send them looking for a bug in
+// their own sizing.
+func sqsMessageTooLong(limit int) *AWSError {
+	return &AWSError{
+		Code: "InvalidParameterValue",
+		Message: fmt.Sprintf("One or more parameters are invalid. Reason: Message must be shorter than %d bytes.",
+			limit),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// sqsMaxBatchPayloadSize is the combined payload limit for one SendMessageBatch
+// request: 1 MiB, per the reference's "the maximum total payload size (the sum of the
+// individual lengths of all of the batched messages)".
+//
+// It is derived from [sqsDefaultMaximumMessageSize] rather than written as a second
+// literal, because AWS states the two limits are the same number ("are both 1 MiB")
+// and a divergence would be silent. They are nonetheless distinct *limits*: a queue's
+// MaximumMessageSize attribute is documented as a per-message cap, so lowering it does
+// not lower the request payload cap. That is what keeps both checks reachable — a
+// queue with a 1 KiB attribute rejects a 2 KiB entry as too long while a batch of ten
+// legal 1 KiB entries stays under the 1 MiB request cap, which is the behavior a
+// per-message reading of the attribute requires.
+var sqsMaxBatchPayloadSize = func() int {
+	n, err := strconv.Atoi(sqsDefaultMaximumMessageSize)
+	if err != nil {
+		// Unreachable: the constant is a literal decimal. Checked rather than
+		// discarded so that editing it to something unparseable fails loudly at the
+		// first batch send instead of silently capping batches at zero bytes.
+		panic("sqsDefaultMaximumMessageSize is not an integer: " + err.Error())
+	}
+	return n
+}()
+
+// sqsCheckBatchSizes validates a SendMessageBatch's entry sizes, returning the error
+// AWS raises or nil.
+//
+// The combined total is checked first, which is not an arbitrary ordering: because the
+// per-message and total limits are equal on a default queue, a batch carrying one
+// oversized entry breaches the total too, and real AWS reports BatchRequestTooLong for
+// that case rather than the per-message error (aws/aws-sdk-go-v2#3026). Checking
+// per-entry first would report a different code than AWS does for the single most
+// common batch mistake.
+//
+// An oversized entry fails the whole request rather than landing in the response's
+// Failed list. The batch reference warns that a caller "should check for batch errors
+// even when the call returns an HTTP status code of 200" precisely because per-entry
+// failures are easy to miss — so for a condition AWS is observed to report as a
+// request-level 400, reporting it the same way is both faithful and the version a
+// consumer cannot overlook.
+func sqsCheckBatchSizes(perMessageLimit int, sizes []int) *AWSError {
+	total := 0
+	for _, n := range sizes {
+		total += n
+	}
+	if total > sqsMaxBatchPayloadSize {
+		return sqsBatchRequestTooLong(sqsMaxBatchPayloadSize, total)
+	}
+	for _, n := range sizes {
+		if n > perMessageLimit {
+			return sqsMessageTooLong(perMessageLimit)
+		}
+	}
+	return nil
+}
+
+// sqsBatchRequestTooLong returns the error SendMessageBatch raises when the batch's
+// combined payload exceeds the limit.
+//
+// SendMessageBatch declares this one in the API model — "The length of all the
+// messages put together is more than the limit" — and the reference states that "The
+// maximum allowed individual message size and the maximum total payload size (the sum
+// of the individual lengths of all of the batched messages) are both 1 MiB". So the
+// two limits are equal, which has a consequence worth stating: a batch containing one
+// oversized entry breaches the total as well, and real AWS reports
+// BatchRequestTooLong for it rather than the per-message error. A captured real-AWS
+// response shows exactly that shape (aws/aws-sdk-go-v2#3026), including the
+// "You have sent N bytes" clause reproduced here.
+//
+// The message wording is not published in the reference; it comes from that observed
+// response, corroborated by moto emitting the same text.
+func sqsBatchRequestTooLong(limit, sent int) *AWSError {
+	return &AWSError{
+		Code: "BatchRequestTooLong",
+		Message: fmt.Sprintf("Batch requests cannot be longer than %d bytes. You have sent %d bytes.",
+			limit, sent),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/emulator/sqs_messagesize_test.go
+++ b/emulator/sqs_messagesize_test.go
@@ -1,0 +1,605 @@
+package emulator_test
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// sqsMessageAttr is one message attribute in a send request, in the form each
+// protocol needs it.
+type sqsMessageAttr struct {
+	name        string
+	dataType    string
+	stringValue string
+	binaryValue []byte
+}
+
+// sendMessageWithAttrs sends a message under either protocol and returns the status
+// and error code, so a size rejection can be asserted on the code rather than merely
+// on failure.
+func sendMessageWithAttrs(t *testing.T, srv *emulator.Server, queueURL, body string,
+	attrs []sqsMessageAttr, jsonProto bool,
+) (int, string) {
+	t.Helper()
+	if jsonProto {
+		in := map[string]interface{}{"QueueUrl": queueURL, "MessageBody": body}
+		if len(attrs) > 0 {
+			m := make(map[string]interface{}, len(attrs))
+			for _, a := range attrs {
+				v := map[string]interface{}{"DataType": a.dataType}
+				if a.stringValue != "" {
+					v["StringValue"] = a.stringValue
+				}
+				if a.binaryValue != nil {
+					// encoding/json marshals []byte as base64, which is the wire form,
+					// so the emulator's []byte field round-trips without help here.
+					v["BinaryValue"] = a.binaryValue
+				}
+				m[a.name] = v
+			}
+			in["MessageAttributes"] = m
+		}
+		return sqsErrorCode(t, sqsJSONRequest(t, srv, "SendMessage", in))
+	}
+
+	params := map[string]string{"Action": "SendMessage", "QueueUrl": queueURL, "MessageBody": body}
+	for i, a := range attrs {
+		base := "MessageAttribute." + strconv.Itoa(i+1) + "."
+		params[base+"Name"] = a.name
+		params[base+"Value.DataType"] = a.dataType
+		if a.stringValue != "" {
+			params[base+"Value.StringValue"] = a.stringValue
+		}
+		if a.binaryValue != nil {
+			params[base+"Value.BinaryValue"] = base64.StdEncoding.EncodeToString(a.binaryValue)
+		}
+	}
+	return sqsErrorCode(t, sqsRequest(t, srv, params))
+}
+
+// sendMessage sends a body with no attributes.
+func sendMessage(t *testing.T, srv *emulator.Server, queueURL, body string, jsonProto bool) (int, string) {
+	t.Helper()
+	return sendMessageWithAttrs(t, srv, queueURL, body, nil, jsonProto)
+}
+
+// sqsBatchEntry is one SendMessageBatch entry.
+type sqsBatchEntry struct {
+	id    string
+	body  string
+	attrs []sqsMessageAttr
+}
+
+// sendMessageBatch sends a batch under either protocol.
+func sendMessageBatch(t *testing.T, srv *emulator.Server, queueURL string,
+	entries []sqsBatchEntry, jsonProto bool,
+) (int, string) {
+	t.Helper()
+	if jsonProto {
+		list := make([]map[string]interface{}, 0, len(entries))
+		for _, e := range entries {
+			entry := map[string]interface{}{"Id": e.id, "MessageBody": e.body}
+			if len(e.attrs) > 0 {
+				m := make(map[string]interface{}, len(e.attrs))
+				for _, a := range e.attrs {
+					m[a.name] = map[string]interface{}{
+						"DataType": a.dataType, "StringValue": a.stringValue,
+					}
+				}
+				entry["MessageAttributes"] = m
+			}
+			list = append(list, entry)
+		}
+		return sqsErrorCode(t, sqsJSONRequest(t, srv, "SendMessageBatch",
+			map[string]interface{}{"QueueUrl": queueURL, "Entries": list}))
+	}
+
+	params := map[string]string{"Action": "SendMessageBatch", "QueueUrl": queueURL}
+	for i, e := range entries {
+		base := "SendMessageBatchRequestEntry." + strconv.Itoa(i+1) + "."
+		params[base+"Id"] = e.id
+		params[base+"MessageBody"] = e.body
+		for j, a := range e.attrs {
+			ab := base + "MessageAttribute." + strconv.Itoa(j+1) + "."
+			params[ab+"Name"] = a.name
+			params[ab+"Value.DataType"] = a.dataType
+			params[ab+"Value.StringValue"] = a.stringValue
+		}
+	}
+	return sqsErrorCode(t, sqsRequest(t, srv, params))
+}
+
+// sqsQueueDepth counts the messages a queue will deliver, by receiving up to max and
+// returning how many came back. Used to assert that a rejected send enqueued nothing
+// — a 400 that still stored the message would leave the queue in a state real AWS
+// never produces, and asserting only on the status code would not notice.
+func sqsQueueDepth(t *testing.T, srv *emulator.Server, queueURL string) int {
+	t.Helper()
+	resp := sqsRequest(t, srv, map[string]string{
+		"Action":              "ReceiveMessage",
+		"QueueUrl":            queueURL,
+		"MaxNumberOfMessages": "10",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return strings.Count(readBody(t, resp), "<MessageId>")
+}
+
+// createSizedQueue creates a queue with an explicit MaximumMessageSize and returns
+// its URL.
+func createSizedQueue(t *testing.T, srv *emulator.Server, name, maxSize string) string {
+	t.Helper()
+	status, code := createQueueWithAttrs(t, srv, name,
+		map[string]string{"MaximumMessageSize": maxSize}, false)
+	require.Equal(t, http.StatusOK, status, "create failed: %s", code)
+	return "http://sqs.us-east-1.localhost/000000000000/" + name
+}
+
+// TestSQS_SendMessage_EnforcesMaximumMessageSize is #454. No length check existed
+// anywhere in the send path, so a body of any size was accepted and delivered. Real
+// SQS rejects one over the queue's MaximumMessageSize with InvalidParameterValue,
+// HTTP 400 — which made a consumer's too-large-payload branch (chunk, compress, spill
+// to S3) unreachable, and any test of it green while verifying nothing.
+//
+// The error code is not derivable from the API model: SendMessage declares no
+// oversized-message error, its InvalidMessageContents is a character-set error, and
+// BatchRequestTooLong is declared only on SendMessageBatch. The code asserted here is
+// the one a captured real-AWS SDK error carries.
+func TestSQS_SendMessage_EnforcesMaximumMessageSize(t *testing.T) {
+	const limit = 4096
+
+	tests := []struct {
+		name     string
+		bodyLen  int
+		wantCode string
+	}{
+		{
+			// The inclusive boundary. AWS's wording is "must be shorter than N bytes",
+			// but N is the documented maximum *size*, so exactly N is legal — an
+			// exclusive reading would reject the largest legal message and send a
+			// consumer chunking a payload that needs no chunking.
+			name:    "exactly at the limit is accepted",
+			bodyLen: limit,
+		},
+		{
+			name:     "one byte over is rejected",
+			bodyLen:  limit + 1,
+			wantCode: "InvalidParameterValue",
+		},
+		{
+			name:    "one byte under is accepted",
+			bodyLen: limit - 1,
+		},
+		{
+			name:     "far over is rejected",
+			bodyLen:  limit * 4,
+			wantCode: "InvalidParameterValue",
+		},
+		{
+			// A body of "" is legal here even though AWS documents a one-character
+			// minimum: that is a separate validation from the size cap, and folding it
+			// in would make this change reject sends #454 says nothing about.
+			name:    "empty body is not a size failure",
+			bodyLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bothProtocols(t, func(t *testing.T, jsonProto bool) {
+				srv, _ := newSQSTestServer(t)
+				queueURL := createSizedQueue(t, srv, "sized-q", strconv.Itoa(limit))
+
+				status, code := sendMessage(t, srv, queueURL, strings.Repeat("x", tt.bodyLen), jsonProto)
+
+				if tt.wantCode == "" {
+					assert.Equal(t, http.StatusOK, status)
+					assert.Empty(t, code)
+					assert.Equal(t, 1, sqsQueueDepth(t, srv, queueURL), "an accepted message is enqueued")
+					return
+				}
+
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, tt.wantCode, code)
+				assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL),
+					"a rejected message must not be enqueued")
+			})
+		})
+	}
+}
+
+// TestSQS_SendMessage_EffectiveLimitResolvesThroughDefault pins that the enforced
+// limit is the *effective* one: a queue created without the attribute enforces the
+// 1 MiB default (#439), not no limit at all and not a second hardcoded copy.
+//
+// Reading through the same default the read path uses is what keeps the number
+// GetQueueAttributes reports identical to the number SendMessage enforces. A consumer
+// that sizes payloads from the reported attribute would otherwise have them rejected
+// anyway.
+func TestSQS_SendMessage_EffectiveLimitResolvesThroughDefault(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createSQSQueue(t, srv, "bare-q")
+
+		reported := sqsQueueAttribute(t, srv, "bare-q", "MaximumMessageSize", jsonProto)
+		require.Equal(t, "1048576", reported, "the #439 default")
+		limit, err := strconv.Atoi(reported)
+		require.NoError(t, err)
+
+		status, code := sendMessage(t, srv, queueURL, strings.Repeat("x", limit), jsonProto)
+		assert.Equal(t, http.StatusOK, status, "exactly the reported limit must be accepted")
+		assert.Empty(t, code)
+
+		status, code = sendMessage(t, srv, queueURL, strings.Repeat("x", limit+1), jsonProto)
+		assert.Equal(t, http.StatusBadRequest, status,
+			"a bare queue enforces the default rather than no limit")
+		assert.Equal(t, "InvalidParameterValue", code)
+	})
+}
+
+// TestSQS_SendMessage_ExplicitSmallerLimitIsEnforced covers the case that separates
+// enforcing the queue's attribute from enforcing a constant: a body legal under the
+// 1 MiB default must still be rejected by a queue configured smaller. A constant-based
+// check passes every other test in this file and fails this one.
+func TestSQS_SendMessage_ExplicitSmallerLimitIsEnforced(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		small := createSizedQueue(t, srv, "small-q", "1024")
+		big := createSQSQueue(t, srv, "big-q")
+
+		body := strings.Repeat("x", 2048) // legal at 1 MiB, over the 1 KiB attribute
+
+		status, code := sendMessage(t, srv, small, body, jsonProto)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+
+		status, code = sendMessage(t, srv, big, body, jsonProto)
+		assert.Equal(t, http.StatusOK, status, "the same body is legal on a default queue")
+		assert.Empty(t, code)
+	})
+}
+
+// TestSQS_SendMessage_ErrorMessageNamesTheLimit pins that the message interpolates the
+// limit that actually applied. It is the only place a caller learns which limit they
+// hit, and reporting 1 MiB for a queue that rejected at 1 KiB would send them looking
+// for a bug in their own sizing.
+func TestSQS_SendMessage_ErrorMessageNamesTheLimit(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createSizedQueue(t, srv, "msg-q", "1024")
+
+	resp := sqsRequest(t, srv, map[string]string{
+		"Action": "SendMessage", "QueueUrl": queueURL,
+		"MessageBody": strings.Repeat("x", 2048),
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := readBody(t, resp)
+
+	assert.Contains(t, body, "Message must be shorter than 1024 bytes",
+		"the observed real-AWS wording, naming the queue's own limit")
+	assert.NotContains(t, body, "1048576", "the default must not be reported for a 1 KiB queue")
+}
+
+// TestSQS_SendMessage_AttributesCountTowardTheLimit is the acceptance criterion that
+// size is measured the way AWS measures it. The developer guide is explicit: "All
+// components of a message attribute are included in the 1 MiB message size
+// restriction", and the per-component breakdown — name, data type, and value — is the
+// one AWS's own Extended Client Library uses to decide whether a payload needs
+// offloading to S3.
+//
+// Measuring the body alone is wrong in the direction that matters: a caller packing
+// most of the budget into metadata is over the limit in AWS and under it here, so the
+// payload shape that motivates a chunking branch is the one substrate would accept.
+func TestSQS_SendMessage_AttributesCountTowardTheLimit(t *testing.T) {
+	const limit = 1024
+
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		t.Run("a body under the limit plus attributes over it is rejected", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSizedQueue(t, srv, "attr-q", strconv.Itoa(limit))
+
+			// The body alone fits comfortably; body + attribute does not.
+			status, code := sendMessageWithAttrs(t, srv, queueURL, strings.Repeat("x", 600),
+				[]sqsMessageAttr{{name: "meta", dataType: "String", stringValue: strings.Repeat("y", 600)}},
+				jsonProto)
+
+			assert.Equal(t, http.StatusBadRequest, status,
+				"attributes count toward the total, so this is over the limit")
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL))
+		})
+
+		t.Run("body plus attributes exactly at the limit is accepted", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSizedQueue(t, srv, "attr-exact-q", strconv.Itoa(limit))
+
+			// name(4) + dataType(6) + value = the attribute's contribution, so the
+			// body takes the remainder. Computed rather than written as a literal so
+			// the arithmetic is visible: this is the inclusive boundary *with*
+			// attributes, which is where an off-by-one in the size formula shows up.
+			const attrName, attrType = "meta", "String"
+			attrValue := strings.Repeat("y", 100)
+			attrSize := len(attrName) + len(attrType) + len(attrValue)
+			body := strings.Repeat("x", limit-attrSize)
+
+			status, code := sendMessageWithAttrs(t, srv, queueURL, body,
+				[]sqsMessageAttr{{name: attrName, dataType: attrType, stringValue: attrValue}},
+				jsonProto)
+
+			assert.Equal(t, http.StatusOK, status, "exactly at the limit is legal: %s", code)
+			assert.Empty(t, code)
+
+			// One more body byte crosses it, which proves the boundary above was the
+			// real edge rather than merely somewhere under it.
+			status, code = sendMessageWithAttrs(t, srv, queueURL, body+"x",
+				[]sqsMessageAttr{{name: attrName, dataType: attrType, stringValue: attrValue}},
+				jsonProto)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+		})
+
+		t.Run("multiple attributes accumulate", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSizedQueue(t, srv, "attr-multi-q", strconv.Itoa(limit))
+
+			// Each attribute alone leaves room — 400 bytes of a 1024 limit — but three
+			// together do not. A formula that measured only the first, or that stopped
+			// at the first index, would accept this.
+			attrs := []sqsMessageAttr{
+				{name: "a1", dataType: "String", stringValue: strings.Repeat("y", 400)},
+				{name: "a2", dataType: "String", stringValue: strings.Repeat("y", 400)},
+				{name: "a3", dataType: "String", stringValue: strings.Repeat("y", 400)},
+			}
+			for _, a := range attrs {
+				require.Less(t, len(a.name)+len(a.dataType)+len(a.stringValue), limit,
+					"each attribute alone must fit, or this proves nothing about accumulation")
+			}
+
+			status, code := sendMessageWithAttrs(t, srv, queueURL, "small", attrs, jsonProto)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+		})
+	})
+}
+
+// TestSQS_SendMessage_BinaryAttributeCountsRawBytes pins that a binary attribute is
+// measured as its decoded length, per AWS's size calculation
+// ("binaryVal.asByteArray().length"), not as its base64 transport encoding — which is
+// ~33% larger and would reject messages AWS accepts.
+func TestSQS_SendMessage_BinaryAttributeCountsRawBytes(t *testing.T) {
+	const limit = 1024
+
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createSizedQueue(t, srv, "bin-q", strconv.Itoa(limit))
+
+		// 780 raw bytes encode to 1040 base64 characters, so the two readings
+		// straddle the 1024 limit: legal measured raw, over it measured encoded.
+		const attrName, attrType, body = "blob", "Binary", "small"
+		overhead := len(attrName) + len(attrType) + len(body)
+		raw := make([]byte, 780)
+		for i := range raw {
+			raw[i] = byte(i % 251)
+		}
+
+		// Both bounds are asserted, because either one alone leaves the test unable to
+		// fail for the right reason: without the first it might pass by being small
+		// enough either way, and without the second the encoded reading would not
+		// actually cross the limit.
+		require.LessOrEqual(t, len(raw)+overhead, limit,
+			"measured raw, this message must be legal")
+		require.Greater(t, len(base64.StdEncoding.EncodeToString(raw))+overhead, limit,
+			"measured base64-encoded, it must exceed the limit — otherwise the two readings agree")
+
+		status, code := sendMessageWithAttrs(t, srv, queueURL, body,
+			[]sqsMessageAttr{{name: attrName, dataType: attrType, binaryValue: raw}}, jsonProto)
+
+		assert.Equal(t, http.StatusOK, status, "raw bytes are what count: %s", code)
+		assert.Empty(t, code)
+	})
+}
+
+// TestSQS_SendMessage_FifoQueueEnforcesBeforeDedup covers the ordering the size check
+// deliberately takes: ahead of the FIFO branch.
+//
+// A FIFO send that recorded its deduplication ID and *then* failed would poison the
+// dedup window — the corrected retry, carrying the same MessageDeduplicationId with a
+// smaller body, would be swallowed as a duplicate and silently never delivered. That
+// is a worse failure than the one being fixed, because it looks like success.
+func TestSQS_SendMessage_FifoQueueEnforcesBeforeDedup(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	status, code := createQueueWithAttrs(t, srv, "size-q.fifo", map[string]string{
+		"FifoQueue": "true", "MaximumMessageSize": "1024",
+	}, false)
+	require.Equal(t, http.StatusOK, status, code)
+	queueURL := "http://sqs.us-east-1.localhost/000000000000/size-q.fifo"
+
+	send := func(body string) (int, string) {
+		return sqsErrorCode(t, sqsRequest(t, srv, map[string]string{
+			"Action": "SendMessage", "QueueUrl": queueURL,
+			"MessageBody": body, "MessageGroupId": "g1", "MessageDeduplicationId": "d1",
+		}))
+	}
+
+	status, code = send(strings.Repeat("x", 2048))
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValue", code)
+
+	// The retry reuses the dedup ID, as a real client would after fixing the payload.
+	status, code = send("ok")
+	assert.Equal(t, http.StatusOK, status, code)
+	assert.Equal(t, 1, sqsQueueDepth(t, srv, queueURL),
+		"the rejected send must not have consumed the deduplication ID")
+}
+
+// TestSQS_SendMessageBatch_EnforcesSizes covers the batch limits. AWS states that "the
+// maximum allowed individual message size and the maximum total payload size (the sum
+// of the individual lengths of all of the batched messages) are both 1 MiB", so both
+// apply and both are covered here.
+//
+// The codes differ by which limit is breached, and the ordering matters: because the
+// two limits are equal on a default queue, a single oversized entry breaches the total
+// as well, and real AWS reports BatchRequestTooLong for that case rather than the
+// per-message error.
+func TestSQS_SendMessageBatch_EnforcesSizes(t *testing.T) {
+	t.Run("batch total over the cap is BatchRequestTooLong", func(t *testing.T) {
+		bothProtocols(t, func(t *testing.T, jsonProto bool) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSQSQueue(t, srv, "batch-total-q")
+
+			// Ten entries, each legal on its own at 1 MiB, summing to over 1 MiB. This
+			// is the case a per-message-only check accepts.
+			entries := make([]sqsBatchEntry, 0, 10)
+			for i := 1; i <= 10; i++ {
+				entries = append(entries, sqsBatchEntry{
+					id:   "e" + strconv.Itoa(i),
+					body: strings.Repeat("x", 200_000),
+				})
+			}
+
+			status, code := sendMessageBatch(t, srv, queueURL, entries, jsonProto)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "BatchRequestTooLong", code)
+			assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL),
+				"a rejected batch must enqueue nothing, not a prefix of its entries")
+		})
+	})
+
+	t.Run("one oversized entry on a default queue is BatchRequestTooLong", func(t *testing.T) {
+		bothProtocols(t, func(t *testing.T, jsonProto bool) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSQSQueue(t, srv, "batch-one-big-q")
+
+			status, code := sendMessageBatch(t, srv, queueURL, []sqsBatchEntry{
+				{id: "small", body: "ok"},
+				{id: "big", body: strings.Repeat("x", 1_048_577)},
+			}, jsonProto)
+
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "BatchRequestTooLong", code,
+				"the equal limits mean the total is breached too, and AWS reports this code")
+			assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL))
+		})
+	})
+
+	t.Run("per-entry limit from the queue attribute", func(t *testing.T) {
+		bothProtocols(t, func(t *testing.T, jsonProto bool) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSizedQueue(t, srv, "batch-per-entry-q", "1024")
+
+			// Well under the 1 MiB request cap, so only the per-message limit can
+			// reject this. That is what makes both checks independently reachable.
+			status, code := sendMessageBatch(t, srv, queueURL, []sqsBatchEntry{
+				{id: "ok", body: "small"},
+				{id: "over", body: strings.Repeat("x", 2048)},
+			}, jsonProto)
+
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL))
+		})
+	})
+
+	t.Run("a small queue attribute does not lower the request cap", func(t *testing.T) {
+		bothProtocols(t, func(t *testing.T, jsonProto bool) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSizedQueue(t, srv, "batch-small-attr-q", "1024")
+
+			// Ten entries at 1 KiB each: every entry is exactly at the per-message
+			// limit and the total is ~10 KiB, far under the 1 MiB request cap. AWS
+			// documents MaximumMessageSize as a per-message attribute, so this must be
+			// accepted — a batch check that compared the *total* against the queue
+			// attribute would reject it.
+			entries := make([]sqsBatchEntry, 0, 10)
+			for i := 1; i <= 10; i++ {
+				entries = append(entries, sqsBatchEntry{
+					id:   "e" + strconv.Itoa(i),
+					body: strings.Repeat("x", 1024),
+				})
+			}
+
+			status, code := sendMessageBatch(t, srv, queueURL, entries, jsonProto)
+			assert.Equal(t, http.StatusOK, status, code)
+			assert.Empty(t, code)
+			assert.Equal(t, 10, sqsQueueDepth(t, srv, queueURL))
+		})
+	})
+
+	t.Run("entry attributes count toward its size", func(t *testing.T) {
+		bothProtocols(t, func(t *testing.T, jsonProto bool) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSizedQueue(t, srv, "batch-attr-q", "1024")
+
+			status, code := sendMessageBatch(t, srv, queueURL, []sqsBatchEntry{
+				{id: "ok", body: "small"},
+				{
+					id:   "over",
+					body: strings.Repeat("x", 600),
+					attrs: []sqsMessageAttr{
+						{name: "meta", dataType: "String", stringValue: strings.Repeat("y", 600)},
+					},
+				},
+			}, jsonProto)
+
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+		})
+	})
+
+	t.Run("a legal batch still succeeds", func(t *testing.T) {
+		bothProtocols(t, func(t *testing.T, jsonProto bool) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSQSQueue(t, srv, "batch-ok-q")
+
+			status, code := sendMessageBatch(t, srv, queueURL, []sqsBatchEntry{
+				{id: "a", body: "one"},
+				{id: "b", body: "two", attrs: []sqsMessageAttr{
+					{name: "k", dataType: "String", stringValue: "v"},
+				}},
+			}, jsonProto)
+
+			assert.Equal(t, http.StatusOK, status, code)
+			assert.Empty(t, code)
+			assert.Equal(t, 2, sqsQueueDepth(t, srv, queueURL),
+				"adding the size check must not drop legal entries")
+		})
+	})
+}
+
+// TestSQS_SendMessage_MalformedAttributeFallsBackToDefault pins that an unparseable
+// MaximumMessageSize resolves to the default rather than to zero. Zero would reject
+// every message including an empty one, turning a bad attribute value into a queue
+// that accepts nothing — CreateQueue is where an invalid value belongs, not every
+// subsequent send.
+//
+// The attribute is written through SetQueueAttributes because CreateQueue is the
+// validating path; this reaches the state a corrupted or hand-seeded queue would be in.
+func TestSQS_SendMessage_MalformedAttributeFallsBackToDefault(t *testing.T) {
+	for _, bad := range []string{"not-a-number", "0", "-1", ""} {
+		t.Run("value "+strconv.Quote(bad), func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createSQSQueue(t, srv, "bad-attr-q")
+
+			resp := sqsRequest(t, srv, map[string]string{
+				"Action": "SetQueueAttributes", "QueueUrl": queueURL,
+				"Attribute.1.Name": "MaximumMessageSize", "Attribute.1.Value": bad,
+			})
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			status, code := sendMessage(t, srv, queueURL, "a modest body", false)
+			assert.Equal(t, http.StatusOK, status, "a bad attribute must not reject everything: %s", code)
+			assert.Equal(t, 1, sqsQueueDepth(t, srv, queueURL))
+
+			// The default still applies, so enforcement is not simply switched off.
+			status, code = sendMessage(t, srv, queueURL, strings.Repeat("x", 1_048_577), false)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+		})
+	}
+}

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -777,12 +777,14 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 
 	// Extract parameters supporting both protocols.
 	var msgBody, delayStr, msgGroupID, dedupIDParam string
+	var msgAttrs map[string]SQSMessageAttribute
 	if sqsIsJSONProtocol(req) {
 		var input struct {
-			MessageBody            string `json:"MessageBody"`
-			DelaySeconds           int    `json:"DelaySeconds"`
-			MessageGroupID         string `json:"MessageGroupId"`
-			MessageDeduplicationID string `json:"MessageDeduplicationId"`
+			MessageBody            string                         `json:"MessageBody"`
+			DelaySeconds           int                            `json:"DelaySeconds"`
+			MessageGroupID         string                         `json:"MessageGroupId"`
+			MessageDeduplicationID string                         `json:"MessageDeduplicationId"`
+			MessageAttributes      map[string]SQSMessageAttribute `json:"MessageAttributes"`
 		}
 		_ = json.Unmarshal(req.Body, &input)
 		msgBody = input.MessageBody
@@ -791,11 +793,21 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		}
 		msgGroupID = input.MessageGroupID
 		dedupIDParam = input.MessageDeduplicationID
+		msgAttrs = input.MessageAttributes
 	} else {
 		msgBody = req.Params["MessageBody"]
 		delayStr = req.Params["DelaySeconds"]
 		msgGroupID = req.Params["MessageGroupId"]
 		dedupIDParam = req.Params["MessageDeduplicationId"]
+		msgAttrs = sqsQueryMessageAttributes(req.Params, "")
+	}
+
+	// Enforce MaximumMessageSize before anything else observable happens (#454).
+	// Ahead of the FIFO branch deliberately: both queue types enforce it, and a FIFO
+	// send that recorded a deduplication ID before failing would poison the dedup
+	// window for the corrected retry that follows.
+	if limit := sqsEffectiveMaximumMessageSize(q); sqsMessageSize(msgBody, msgAttrs) > limit {
+		return nil, sqsMessageTooLong(limit)
 	}
 
 	if delayStr == "" {
@@ -984,15 +996,29 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 	var successesXML []successEntryXML
 	var successesJSON []successEntryJSON
 
+	// The per-message limit is the queue's effective MaximumMessageSize; the batch
+	// total has its own cap. Both are checked before any entry is stored, so a
+	// rejected batch enqueues nothing — a partially-applied batch would leave a
+	// consumer's retry to re-send the entries that already landed (#454).
+	perMessageLimit := sqsEffectiveMaximumMessageSize(q)
+
 	if sqsIsJSONProtocol(req) {
 		var input struct {
 			Entries []struct {
-				ID           string `json:"Id"`
-				MessageBody  string `json:"MessageBody"`
-				DelaySeconds int    `json:"DelaySeconds"`
+				ID                string                         `json:"Id"`
+				MessageBody       string                         `json:"MessageBody"`
+				DelaySeconds      int                            `json:"DelaySeconds"`
+				MessageAttributes map[string]SQSMessageAttribute `json:"MessageAttributes"`
 			} `json:"Entries"`
 		}
 		_ = json.Unmarshal(req.Body, &input)
+		sizes := make([]int, 0, len(input.Entries))
+		for _, entry := range input.Entries {
+			sizes = append(sizes, sqsMessageSize(entry.MessageBody, entry.MessageAttributes))
+		}
+		if sizeErr := sqsCheckBatchSizes(perMessageLimit, sizes); sizeErr != nil {
+			return nil, sizeErr
+		}
 		for _, entry := range input.Entries {
 			msgID := generateSQSMessageID()
 			md5Body := computeMD5(entry.MessageBody)
@@ -1030,6 +1056,25 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 			"Successful": successesJSON,
 			"Failed":     []struct{}{},
 		})
+	}
+
+	// Size every entry before storing any, for the reason above. This walks the
+	// entries a second time rather than checking inside the storing loop, because a
+	// mid-loop rejection is exactly the partial application the check exists to
+	// prevent.
+	var querySizes []int
+	for i := 1; ; i++ {
+		entryPrefix := fmt.Sprintf("SendMessageBatchRequestEntry.%d.", i)
+		if req.Params[entryPrefix+"Id"] == "" {
+			break
+		}
+		querySizes = append(querySizes, sqsMessageSize(
+			req.Params[entryPrefix+"MessageBody"],
+			sqsQueryMessageAttributes(req.Params, entryPrefix),
+		))
+	}
+	if sizeErr := sqsCheckBatchSizes(perMessageLimit, querySizes); sizeErr != nil {
+		return nil, sizeErr
 	}
 
 	for i := 1; ; i++ {


### PR DESCRIPTION
Closes #454

`SendMessage` and `SendMessageBatch` accepted a body of any length. The call
returned a `MessageId`, the message was enqueued, and a consumer's
oversized-payload branch was unreachable — a suite testing that failure path
reported green while verifying nothing. #439 corrected the *reported*
`MaximumMessageSize` default to 1 MiB but deliberately left enforcement out of
scope; this closes it.

## What the reference actually says — and doesn't

The issue's first acceptance criterion was *"confirm the exact error code and
message against the current SendMessage API reference — do not assume."* Taken
literally, that turned up the finding worth leading with: **the reference
declares no oversized-message error at all.** `SendMessage`'s error list has no
entry for it, its `InvalidMessageContents` is documented as a *character-set*
error (not a length one), and `BatchRequestTooLong` is declared only on
`SendMessageBatch`.

So neither the code nor the wording is derivable from the API model. Provenance,
stated plainly rather than implied:

| | Code | HTTP | Wire message |
|---|---|---|---|
| Per-message | `InvalidParameterValue` | 400 | `One or more parameters are invalid. Reason: Message must be shorter than N bytes.` |
| Batch total | `BatchRequestTooLong` | 400 | `Batch requests cannot be longer than N bytes. You have sent M bytes.` |

Both come from real-AWS responses captured in consumer bug reports
(artilleryio/artillery#3463; aws/aws-sdk-go-v2#3026). Independent
reimplementations emit the same strings, which corroborates them as transcribed
AWS text rather than one project's invention. That is weaker than a doc citation
and the code comment, CHANGELOG and `docs/services.md` all say so.

## Semantics

- **Effective limit** — the queue's `MaximumMessageSize`, resolved through
  `sqsDefaultMaximumMessageSize` via the same `getAttrOrDefault` call the read
  path uses, so the number `GetQueueAttributes` reports and the number enforced
  cannot diverge. A malformed value falls back to the default, not to zero —
  zero would reject every message including an empty one.
- **Boundary is inclusive** — a message of exactly the limit is accepted;
  limit+1 is rejected.
- **Attributes count.** AWS: *"all components of a message attribute are
  included in the 1 MiB message size restriction."* Name + data type + value,
  each as UTF-8 bytes, with a binary value measured at its **raw** length rather
  than its base64 length. Message *system* attributes are excluded, per the same
  page. The issue listed this as an open question.
- **Two batch limits, and the order matters.** Each entry is checked against the
  queue's per-message cap; the combined payload against the request cap. The
  total is checked **first** — not arbitrary: the two limits are equal on a
  default queue, so a batch carrying one oversized entry breaches the total too,
  and real AWS reports `BatchRequestTooLong` for that case rather than the
  per-message error. Neither limit lowers the other: a queue with a 1 KiB
  `MaximumMessageSize` still accepts ten 1 KiB entries in one batch.
- **Nothing is enqueued on rejection.** Both protocol paths size every entry
  before storing any, so a retry does not re-send entries that already landed.
  The query path walks the entries twice for exactly this reason.
- **FIFO: size before dedup.** A rejected send that had already recorded a
  deduplication ID would poison the dedup window for the corrected retry,
  silently swallowing it — a worse failure than the one being fixed, because it
  looks like success.

## Tests

New `emulator/sqs_messagesize_test.go` (~490 lines), both wire protocols where
the behaviour differs by protocol. Notable cases: exactly-at-limit vs +1;
enforcement reading the queue attribute rather than a constant (a
constant-based check passes every other test in the file and fails this one);
the error naming the queue's limit and not the default; attributes accumulating
to breach; a binary value straddling the limit only when measured base64
(asserting both bounds); FIFO retry after rejection succeeding with the same
dedup ID; a 1 KiB queue still accepting a legal ten-entry batch; malformed
attribute values falling back.

**Mutation testing: 13/13 caught.** The ones that justified their existence —
batch total compared against the per-message limit; the two batch checks
reordered (which decides whether AWS's actual error code is reported); a binary
value measured base64-encoded; and the error message hardcoding the default
limit.

## Verification

All from the repo root: `gofmt -l` clean; `go build`/`go vet` OK;
`golangci-lint run ./...` **0 issues**; `make test` (race, `-count=1`) passing;
`make docs-reference-check docs-versions` passing; `test/e2e` passing. New file
at 93.8–100% per function.

## Deliberately out of scope

Message attributes are parsed for measurement only — substrate does not yet
store or return them on `ReceiveMessage`. Filed as #461 so the code comment's
reference points at something real.