### PR TITLE
feat(ec2): reject reserved aws:-prefixed tag keys (#452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- EC2: `CreateTags` and `DeleteTags` now reject tag keys using the reserved `aws:`
+  prefix (#452). Substrate accepted them, so a consumer could tag a resource in a way
+  real EC2 refuses — and a test asserting that refusal passed against substrate while
+  the same call failed against AWS. The rejection is `InvalidParameterValue`, HTTP 400,
+  `Tag keys starting with 'aws:' are reserved for internal use`.
+
+  The whole request is refused before any resource is modified, so a request mixing a
+  legal tag with a reserved one leaves every resource it named untouched. `CreateTags`
+  accepts up to 1000 resource IDs, and rejecting partway through the apply loop would
+  leave a prefix of them tagged — a state real EC2 never produces, and a worse outcome
+  than either accepting or refusing cleanly.
+
+  **The match is case-sensitive**, which corrects the assumption #452 was filed with.
+  AWS documents tag keys and values as case-sensitive, and every observed rejection
+  quotes the lowercase form, so `AWS:foo` and `Aws:foo` are ordinary user tags and are
+  accepted. A case-folded check would have traded this infidelity for a new one in the
+  opposite direction.
+
+  **Provenance, stated plainly:** the `CreateTags` reference's Errors section is empty,
+  so neither the code nor the message is derivable from the API model. Both come from
+  observed real-AWS responses — two independent captures giving byte-identical text,
+  one recording `Service: AmazonEC2; Status Code: 400; Error Code:
+  InvalidParameterValue`. Both captures are of `RunInstances` tag-on-create rather than
+  `CreateTags`; the message is evidently shared across the tagging paths, but substrate
+  has not observed it on `CreateTags` directly. The `DeleteTags` rejection rests on
+  weaker evidence still: no captured `DeleteTags` error was found, so its code and
+  message are inherited from the `CreateTags` capture. What the tagging documentation
+  does state unambiguously is the outcome — such a tag "can't be edited or deleted" by
+  a caller — and a `DeleteTags` that returned success while leaving the tag in place
+  would be its own infidelity, so refusing is the closer of the two available
+  behaviors. `docs/services.md` records all of this rather than implying a doc
+  citation.
+
+  Two parts of AWS's rule are deliberately **not** covered. `RunInstances`
+  tag-on-create is unrestricted: real EC2 rejects a reserved key there too, but
+  substrate stamps `aws:ec2:fleet-id` (#443) by building `RunInstances`
+  `TagSpecification` params, so restricting that path would reject substrate's own
+  fleet tagging and silently undo the only route from an `instant` fleet back to its
+  instances. A regression test pins that a fleet still stamps and still filters on the
+  tag. And the companion rule that reserved tags do not count against the 50-tag
+  per-resource limit is vacuous here, because substrate does not model that limit at
+  all — `TagLimitExceeded` never fires. Both gaps are tracked separately.
 - SQS: `SendMessage` and `SendMessageBatch` now enforce `MaximumMessageSize` (#454).
   No length check existed anywhere in the send path — against the queue's attribute or
   against any constant — so a body of any size was accepted and delivered. Real SQS

--- a/docs/services.md
+++ b/docs/services.md
@@ -1124,6 +1124,8 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances |
+| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) |
+| DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) |
 
 ### RunInstances requires a resolvable AMI
 
@@ -1301,10 +1303,43 @@ documented API contract: it appears in neither the EC2 API reference nor the fle
 tagging and describe pages. It is applied to every fleet type, and — unlike a
 caller's own `TagSpecification` entries — it is not scoped by `ResourceType`.
 
-Note that substrate does not yet enforce the two rules AWS attaches to the
-reserved `aws:` prefix: such a tag cannot be edited or deleted by a caller, and
-does not count against the 50-tag limit. `CreateTags` currently accepts an
-`aws:`-prefixed key that real EC2 would reject with `InvalidParameterValue`.
+A caller cannot delete this tag — see
+[reserved tag keys](#reserved-tag-keys) — which matches the rule AWS attaches to the
+`aws:` prefix.
+
+### Reserved tag keys
+
+`CreateTags` and `DeleteTags` reject any tag whose key begins with `aws:`, the
+prefix EC2 reserves for its own use:
+
+```
+InvalidParameterValue: Tag keys starting with 'aws:' are reserved for internal use
+```
+
+The status is `400`. The whole request is refused before any resource is modified,
+so a request that mixes a legal tag with a reserved one leaves every resource it
+named untouched — `CreateTags` accepts up to 1000 resource IDs, and a partial
+application is a state real EC2 never produces.
+
+The match is **case-sensitive**. AWS documents tag keys and values as
+case-sensitive, so `AWS:foo` and `Aws:foo` are ordinary user tags and are accepted;
+only the lowercase `aws:` prefix is reserved.
+
+Two caveats about the scope of this rule:
+
+- Provenance: the `CreateTags` API reference has an empty Errors section, so neither
+  the code nor the message above is derivable from the API model. Both come from
+  observed real-AWS responses. The `DeleteTags` rejection is a step weaker still —
+  substrate found no captured `DeleteTags` error and inherits the wording from the
+  `CreateTags` capture. What the tagging documentation does state plainly is the
+  outcome: such a tag "can't be edited or deleted" by a caller.
+- `RunInstances` tag-on-create is **not** covered. Real EC2 rejects a reserved key
+  there too, but substrate stamps [`aws:ec2:fleet-id`](#finding-a-fleets-instances)
+  through exactly that path, so restricting it would reject substrate's own fleet
+  tagging.
+
+The 50-tag-per-resource limit is not modelled at all, so the companion rule that
+reserved tags are exempt from it has nothing to exempt them from yet.
 
 ### Seeding EC2 Fleet partial fulfillment
 

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -595,7 +595,12 @@ func passthroughFleetTagSpecs(params map[string]string, resourceType string) map
 //
 // The "aws:" prefix is reserved: per the EC2 tagging documentation such a tag
 // cannot be edited or deleted by a caller and does not count against the 50-tag
-// per-resource limit. Substrate does not yet enforce either rule on CreateTags.
+// per-resource limit. CreateTags and DeleteTags now enforce the first rule (#452);
+// the second has nothing to exempt from yet, since substrate does not model the
+// 50-tag limit at all. Substrate stamps this tag by building RunInstances
+// TagSpecification params, which is a separate parse from CreateTags and is
+// deliberately left unrestricted — restricting it would reject substrate's own
+// fleet tagging.
 const ec2FleetIDTagKey = "aws:ec2:fleet-id"
 
 // fleetIDTagSpec returns the RunInstances TagSpecification params that stamp

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -1962,9 +1962,18 @@ func (p *EC2Plugin) rebootInstances(_ *RequestContext, _ *AWSRequest) (*AWSRespo
 }
 
 // createTags handles CreateTags — applies key-value tags to one or more EC2 resources.
+//
+// Keys using the reserved "aws:" prefix are rejected before anything is applied, so a
+// mixed request leaves every named resource untouched (#452). Note that this covers
+// CreateTags only: RunInstances tag-on-create parses its TagSpecification.N params
+// separately, and substrate's own fleet tagging stamps aws:ec2:fleet-id through that
+// path — see [ec2FleetIDTagKey].
 func (p *EC2Plugin) createTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	resourceIDs := extractIndexedParams(req.Params, "ResourceId")
 	tags := extractEC2Tags(req.Params)
+	if err := ec2CheckReservedTagKeys(tags); err != nil {
+		return nil, err
+	}
 	for _, id := range resourceIDs {
 		if err := p.applyTagsToResource(reqCtx, id, tags, false); err != nil {
 			return nil, err
@@ -1979,9 +1988,20 @@ func (p *EC2Plugin) createTags(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 }
 
 // deleteTags handles DeleteTags — removes tags from one or more EC2 resources.
+//
+// Reserved "aws:" keys are rejected here too (#452). The evidence for this is weaker
+// than for CreateTags: substrate found no captured real-AWS DeleteTags rejection, so
+// the code and message are inherited from the CreateTags capture rather than separately
+// observed. The tagging documentation is unambiguous about the outcome — such a tag
+// "can't be edited or deleted" by a caller — and a DeleteTags that returned success
+// while leaving the tag in place would be its own infidelity, so rejecting is the
+// closer of the two available behaviors.
 func (p *EC2Plugin) deleteTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	resourceIDs := extractIndexedParams(req.Params, "ResourceId")
 	tags := extractEC2Tags(req.Params)
+	if err := ec2CheckReservedTagKeys(tags); err != nil {
+		return nil, err
+	}
 	for _, id := range resourceIDs {
 		if err := p.applyTagsToResource(reqCtx, id, tags, true); err != nil {
 			return nil, err

--- a/emulator/ec2_tags.go
+++ b/emulator/ec2_tags.go
@@ -1,0 +1,54 @@
+package emulator
+
+import (
+	"net/http"
+	"strings"
+)
+
+// ec2ReservedTagPrefix is the tag-key prefix EC2 reserves for its own use. A caller
+// cannot create, edit, or delete a tag whose key begins with it.
+//
+// The match is case-sensitive, and deliberately so: the EC2 tagging documentation
+// states that "tag keys and values are case-sensitive", and every observed rejection
+// quotes the lowercase form. A case-folded check would reject "AWS:foo", which real
+// EC2 accepts as an ordinary user tag — trading one infidelity for another.
+//
+// Source note: the CreateTags reference's Errors section is empty, so neither the
+// error code nor its message is derivable from the API model. Both come from observed
+// real-AWS responses — two independent captures giving byte-identical text, one of
+// which records "Service: AmazonEC2; Status Code: 400; Error Code:
+// InvalidParameterValue". Both captures are of RunInstances tag-on-create rather than
+// CreateTags; the message is evidently shared across the tagging paths, but substrate
+// has not observed it on CreateTags directly.
+const ec2ReservedTagPrefix = "aws:"
+
+// ec2ReservedTagKeyError returns the error EC2 raises for a reserved tag key.
+//
+// The observed message does not name the offending key, so neither does this. See
+// [ec2ReservedTagPrefix] for where the code, status, and wording come from.
+func ec2ReservedTagKeyError() *AWSError {
+	return &AWSError{
+		Code:       "InvalidParameterValue",
+		Message:    "Tag keys starting with 'aws:' are reserved for internal use",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2CheckReservedTagKeys returns an error if any tag uses a reserved key, or nil.
+//
+// The tags are checked in slice order — extractEC2Tags preserves the request's Tag.N
+// numbering — so the request that is rejected is decided identically on every run. A
+// map would make it iteration-order dependent, which is the opposite of what this
+// emulator is for.
+//
+// Callers must check before applying anything. CreateTags accepts up to 1000 resource
+// IDs, and rejecting partway through the loop would leave the earlier resources tagged
+// and the rest not, a state real EC2 never produces.
+func ec2CheckReservedTagKeys(tags []EC2Tag) *AWSError {
+	for _, t := range tags {
+		if strings.HasPrefix(t.Key, ec2ReservedTagPrefix) {
+			return ec2ReservedTagKeyError()
+		}
+	}
+	return nil
+}

--- a/emulator/ec2_tags_test.go
+++ b/emulator/ec2_tags_test.go
@@ -1,0 +1,248 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ec2ReservedTagMessage is the wording real EC2 uses for a reserved tag key,
+// pinned here so it cannot drift silently. See ec2ReservedTagPrefix's doc comment
+// for its provenance: the CreateTags reference has an empty Errors section, so the
+// string comes from observed real-AWS responses rather than the API model.
+const ec2ReservedTagMessage = "Tag keys starting with 'aws:' are reserved for internal use"
+
+// ec2TagTestInstance launches one instance and returns its ID.
+func ec2TagTestInstance(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	ids := ec2RunInstanceIDs(t, ts, map[string]string{
+		"Action":   "RunInstances",
+		"ImageId":  "ami-0tagtest00000001",
+		"MinCount": "1",
+		"MaxCount": "1",
+	})
+	require.Len(t, ids, 1)
+	return ids[0]
+}
+
+// ec2InstanceTagValue returns the value of key on instID as DescribeInstances
+// reports it, and whether the tag was present at all — an absent tag and an empty
+// value are different observations, and the difference is what these tests turn on.
+func ec2InstanceTagValue(t *testing.T, ts *httptest.Server, instID, key string) (string, bool) {
+	t.Helper()
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":       "DescribeInstances",
+		"InstanceId.1": instID,
+	}, &desc)
+	require.Len(t, desc.Instances, 1, "DescribeInstances should return %s", instID)
+	return desc.instanceTag(0, key)
+}
+
+// TestEC2_CreateTags_RejectsReservedPrefix covers #452: substrate accepted tag keys
+// using the "aws:" prefix that real EC2 reserves for itself, so a consumer's
+// error branch for that rejection was unreachable and a test asserting it passed
+// against substrate while the same code failed against AWS.
+//
+// The accepted cases are as much the point as the rejected ones. EC2 documents tag
+// keys as case-sensitive, so "AWS:foo" is an ordinary user tag — a case-folded
+// check would trade this infidelity for a new one in the other direction.
+func TestEC2_CreateTags_RejectsReservedPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        string
+		wantReject bool
+	}{
+		{name: "lowercase reserved prefix", key: "aws:cloudformation:stack-name", wantReject: true},
+		{name: "reserved prefix with empty suffix", key: "aws:", wantReject: true},
+		{name: "the tag substrate stamps on fleet instances", key: "aws:ec2:fleet-id", wantReject: true},
+		// Case-sensitivity: EC2 tag keys are case-sensitive, so none of these is
+		// the reserved prefix and all three are legal user tags.
+		{name: "uppercase is not the reserved prefix", key: "AWS:foo"},
+		{name: "mixed case is not the reserved prefix", key: "Aws:foo"},
+		// Near-misses on the delimiter.
+		{name: "hyphen rather than colon", key: "aws-foo"},
+		{name: "no delimiter at all", key: "awsfoo"},
+		{name: "aws not at the start", key: "my-aws:foo"},
+		{name: "an ordinary key", key: "Name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			instID := ec2TagTestInstance(t, ts)
+
+			status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+				"Action":       "CreateTags",
+				"ResourceId.1": instID,
+				"Tag.1.Key":    tt.key,
+				"Tag.1.Value":  "v",
+			})
+
+			if !tt.wantReject {
+				require.Equal(t, http.StatusOK, status, "key %q should be accepted", tt.key)
+				value, ok := ec2InstanceTagValue(t, ts, instID, tt.key)
+				assert.True(t, ok, "tag %q should have been applied", tt.key)
+				assert.Equal(t, "v", value)
+				return
+			}
+
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Equal(t, ec2ReservedTagMessage, message)
+
+			_, ok := ec2InstanceTagValue(t, ts, instID, tt.key)
+			assert.False(t, ok, "rejected tag %q must not have been applied", tt.key)
+		})
+	}
+}
+
+// TestEC2_CreateTags_RejectionIsAllOrNothing pins the reason the check runs before
+// the first resource is touched rather than inside the apply loop. CreateTags
+// accepts up to 1000 resource IDs; rejecting partway through would leave the
+// earlier resources tagged and the rest not, a state real EC2 never produces.
+//
+// Both dimensions are asserted at once: the legal tag in the same request is not
+// applied either, and neither of the two named resources is modified.
+func TestEC2_CreateTags_RejectionIsAllOrNothing(t *testing.T) {
+	ts := newEC2TestServer(t)
+	first := ec2TagTestInstance(t, ts)
+	second := ec2TagTestInstance(t, ts)
+
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": first,
+		"ResourceId.2": second,
+		// A legal tag ahead of the reserved one, so a mid-loop implementation
+		// would have already written it by the time it noticed.
+		"Tag.1.Key":   "Name",
+		"Tag.1.Value": "legal",
+		"Tag.2.Key":   "aws:reserved",
+		"Tag.2.Value": "v",
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValue", code)
+
+	for _, id := range []string{first, second} {
+		if _, ok := ec2InstanceTagValue(t, ts, id, "Name"); ok {
+			t.Errorf("instance %s has the legal tag from a rejected request", id)
+		}
+		if _, ok := ec2InstanceTagValue(t, ts, id, "aws:reserved"); ok {
+			t.Errorf("instance %s has the reserved tag from a rejected request", id)
+		}
+	}
+}
+
+// TestEC2_DeleteTags_RejectsReservedPrefix covers the DeleteTags half of #452.
+//
+// The evidence here is weaker than for CreateTags and deliberately so: substrate
+// found no captured real-AWS DeleteTags rejection, so the code and message are
+// inherited from the CreateTags capture. What the documentation does state
+// unambiguously is the outcome — a reserved tag "can't be edited or deleted" — and
+// the test asserts that outcome: the tag survives the call.
+func TestEC2_DeleteTags_RejectsReservedPrefix(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	// The tag has to exist to prove deletion was refused rather than a no-op, and
+	// CreateTags now refuses to make one — so use the path that legitimately
+	// stamps a reserved tag: a fleet launch.
+	ltID := newFleetLaunchTemplate(t, ts, "delete-reserved-tag")
+	var fleet createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+	}, &fleet)
+	ids := fleet.instanceIDs()
+	require.Len(t, ids, 1)
+	instID := ids[0]
+
+	before, ok := ec2InstanceTagValue(t, ts, instID, fleetIDTagKey)
+	require.True(t, ok, "fleet instance should carry %s", fleetIDTagKey)
+
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":       "DeleteTags",
+		"ResourceId.1": instID,
+		"Tag.1.Key":    fleetIDTagKey,
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+	assert.Equal(t, ec2ReservedTagMessage, message)
+
+	after, ok := ec2InstanceTagValue(t, ts, instID, fleetIDTagKey)
+	assert.True(t, ok, "reserved tag must survive a refused DeleteTags")
+	assert.Equal(t, before, after)
+}
+
+// TestEC2_DeleteTags_OrdinaryKeyStillWorks is the regression guard on the check
+// above: an ordinary tag must still be deletable.
+func TestEC2_DeleteTags_OrdinaryKeyStillWorks(t *testing.T) {
+	ts := newEC2TestServer(t)
+	instID := ec2TagTestInstance(t, ts)
+
+	status, _, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": instID,
+		"Tag.1.Key":    "Name",
+		"Tag.1.Value":  "keep-me",
+	})
+	require.Equal(t, http.StatusOK, status)
+	_, ok := ec2InstanceTagValue(t, ts, instID, "Name")
+	require.True(t, ok)
+
+	status, _, _ = ec2ErrorDetail(t, ts, map[string]string{
+		"Action":       "DeleteTags",
+		"ResourceId.1": instID,
+		"Tag.1.Key":    "Name",
+	})
+	require.Equal(t, http.StatusOK, status)
+
+	if _, ok := ec2InstanceTagValue(t, ts, instID, "Name"); ok {
+		t.Error("Name tag should have been deleted")
+	}
+}
+
+// TestEC2_ReservedTagCheck_DoesNotBreakFleetTagging is the gate on #452 having
+// landed in the right code path.
+//
+// Substrate stamps aws:ec2:fleet-id (#443) by building RunInstances
+// TagSpecification params, which runInstances parses itself rather than routing
+// through CreateTags. Putting the reserved-prefix check in that parse would reject
+// substrate's own fleet tagging and silently undo #443 — for an "instant" fleet
+// this tag is the only route from a fleet back to its instances, so the failure
+// would surface as a fully-running fleet reporting as empty.
+func TestEC2_ReservedTagCheck_DoesNotBreakFleetTagging(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "reserved-tag-fleet")
+
+	var fleet createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+	}, &fleet)
+	require.NotEmpty(t, fleet.FleetID)
+	require.Len(t, fleet.instanceIDs(), 2, "fleet should still launch its instances")
+
+	// Every instance still carries the tag...
+	for _, id := range fleet.instanceIDs() {
+		value, ok := ec2InstanceTagValue(t, ts, id, fleetIDTagKey)
+		assert.True(t, ok, "instance %s lost its %s tag", id, fleetIDTagKey)
+		assert.Equal(t, fleet.FleetID, value)
+	}
+
+	// ...and the lookup the tag exists for still works.
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "DescribeInstances",
+		"Filter.1.Name":    "tag:" + fleetIDTagKey,
+		"Filter.1.Value.1": fleet.FleetID,
+	}, &desc)
+	assert.Len(t, desc.Instances, 2,
+		"filtering on %s must still find the fleet's instances", fleetIDTagKey)
+}


### PR DESCRIPTION
Closes #452

## Problem

`CreateTags` and `DeleteTags` accepted tag keys using the `aws:` prefix that real EC2 reserves for its own use. A consumer could tag a resource in a way AWS refuses, so a test asserting that refusal passed against substrate while the same call failed against AWS — the recurring shape on this tracker.

## What changed

New `emulator/ec2_tags.go` holds the rule and its provenance in one place. Both operations now reject with:

```
InvalidParameterValue: Tag keys starting with 'aws:' are reserved for internal use
```

HTTP 400. The check runs **before the first `applyTagsToResource` call**, so the whole request is refused atomically — a request mixing a legal tag with a reserved one leaves every resource it named untouched. `CreateTags` accepts up to 1000 resource IDs, and rejecting partway through the loop would leave a prefix tagged, a state real EC2 never produces.

### The match is case-sensitive — this corrects the issue

#452 asks to confirm whether the prefix match is case-insensitive. It is not: the EC2 tag-restrictions page documents tag keys and values as case-sensitive, and every observed rejection quotes the lowercase `'aws:'`. `AWS:foo` and `Aws:foo` are ordinary user tags and are accepted. A case-folded check would have traded this infidelity for a new one in the opposite direction.

## Provenance, stated plainly

The `CreateTags` reference's **Errors section is empty**, so neither the code nor the message is derivable from the API model. Both come from observed real-AWS responses — two independent captures giving byte-identical text (jcjorel/ec2-spot-converter#13; dtan4/terraforming#343, which records `Status Code: 400; Error Code: InvalidParameterValue`). Both captures are of `RunInstances` tag-on-create rather than `CreateTags`; the message is evidently shared, but substrate has not observed it on `CreateTags` directly.

`DeleteTags` rests on weaker evidence still — no captured `DeleteTags` rejection was found, so its code and message are inherited. What the documentation does state unambiguously is the outcome: such a tag "can't be edited or deleted". A `DeleteTags` that returned success while leaving the tag in place would be its own infidelity, so refusing is the closer of the two available behaviours. The code comment, `docs/services.md`, and the changelog all say this rather than implying a doc citation.

## Two parts of AWS's rule deliberately not covered

- **`RunInstances` tag-on-create is unrestricted.** Real EC2 rejects a reserved key there too — that is where both captures come from — but substrate stamps `aws:ec2:fleet-id` (#443) by building `RunInstances` `TagSpecification` params, parsed by its own loop rather than routed through `createTags`. Restricting that path would reject substrate's own fleet tagging and silently undo the only route from an `instant` fleet back to its live instances. `TestEC2_ReservedTagCheck_DoesNotBreakFleetTagging` pins that a fleet still stamps the tag **and** that `DescribeInstances --filters tag:aws:ec2:fleet-id` still finds its instances.
- **The 50-tag limit is unmodelled**, so the companion rule that reserved tags are exempt from it has nothing to exempt them from. `TagLimitExceeded` never fires.

Both gaps get follow-up issues.

## Tests

`emulator/ec2_tags_test.go`, table-driven:

- Reserved key rejected with the exact code, status and message; the tag is not applied.
- **All-or-nothing**: two resource IDs, a legal tag ahead of a reserved one — neither resource ends up with either tag.
- `AWS:foo`, `Aws:foo`, `aws-foo`, `awsfoo`, `my-aws:foo` all accepted (case-sensitivity).
- Bare `aws:` with an empty suffix rejected.
- `DeleteTags` on a reserved key refused **and the tag survives** — using a fleet launch to create the tag, since `CreateTags` now refuses to.
- `DeleteTags` on an ordinary key still works.
- The fleet regression above.

`ec2FleetIDTagKey`'s doc comment, whose last sentence said substrate enforced neither rule, is updated to say which one it now enforces and why the other has nothing to exempt.

## Verification

From the repo root: `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race) green, `make docs-reference-check docs-versions` green, `test/e2e` green.

Mutation-tested — each mutant compiles (`go vet` gate) and the new tests catch it:

| Mutation | Caught by |
|---|---|
| prefix check made case-insensitive | the two case-sensitivity cases fail |
| check moved inside the apply loop | every reject case + all-or-nothing fail |
| check added to `runInstances`' `TagSpecification` parse | **8 fleet tests fail** — the wrong-path implementation is loud |