### PR TITLE
fix(ec2): merge a launch template with request-level parameters (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   this rather than implying a doc citation.
 
 ### Fixed
+- EC2: `RunInstances` now merges a named launch template with the request field by
+  field, instead of consulting the template only when the request omitted `ImageId`
+  (#453). The entire template block was gated on the AMI being absent, so a request
+  passing both an `ImageId` and a `LaunchTemplate` never read the template at all: its
+  `InstanceType`, `KeyName`, `UserData`, security groups and — since #444 — its subnet
+  and public-IP preference were all silently dropped. The launch still succeeded and
+  still returned an instance ID, so nothing in the response said anything was wrong;
+  the instance simply was not the one that was asked for. A consumer templating a
+  `c5.xlarge` in a private subnet and pinning the AMI per environment at the call —
+  which is why `ImageId` is passed alongside a template in the first place — got a
+  `t3.micro` in the default VPC and a green test.
+
+  The template is now resolved whenever one is named, and each field falls back to it
+  only when the request did not supply that field. AWS's `RunInstances` reference is
+  the specification: "Any additional parameters that you specify for the new instance
+  overwrite the corresponding parameters included in the launch template." The
+  `ImageId` check added by #412 still runs after resolution, so a template remains a
+  valid sole source of the AMI, and a template that carries none still fails with
+  `MissingParameter`.
+
+  The `UserData` fallback is new rather than restored: a template's user data was
+  parsed and stored but never applied to the launch. Note that no registered operation
+  reads it back — substrate does not implement `DescribeInstanceAttribute` — so the
+  merge is observable only in the recorded instance state, not through an API call.
+
+  Separately, an explicit `InstanceType=t3.micro` on the request is now honoured over a
+  template's type. The `t3.micro` default used to be applied *before* the template was
+  read, and the template fallback then tested for that literal value as a proxy for
+  "the request named no instance type" — so asking for `t3.micro` alongside a template
+  naming `m5.large` yielded `m5.large`, exactly inverting the documented precedence.
+  The default is now resolved last, after the template has had its chance, so it
+  applies only when neither side names a type. This bug was reachable before this
+  change and is far more reachable after it, which is why it is fixed here rather than
+  deferred.
+
+  A template's `TagSpecifications` and `IamInstanceProfile` are still not parsed, so
+  neither participates in the merge; the request wins those two by default rather than
+  by rule.
 - S3: `HeadObject` now resolves a synthesized task-completion record, so `HEAD` and
   `GET` agree about whether the key exists (#457). `getObject` consulted the
   completion resolver when no real object was staged at

--- a/docs/services.md
+++ b/docs/services.md
@@ -1086,7 +1086,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 
 | Operation | Notes |
 |-----------|-------|
-| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [validates MinCount/MaxCount](#mincount-and-maxcount); reports [`groupSet`](#security-groups-on-an-instance) |
+| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); reports [`groupSet`](#security-groups-on-an-instance) |
 | DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance) |
 | TerminateInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
@@ -1147,6 +1147,46 @@ Note that `ImageId` is an optional `*string` in the typed SDKs, so
 service rather than being caught client-side. That is the shape this check exists
 for. The AMI value itself is not format-validated — substrate accepts any
 non-empty string, so fixtures like `ami-test` work.
+
+### A launch template merges with the request, field by field
+
+Naming a launch template does not replace the request, and the request does not
+replace the template: the two are merged per field, with the request winning any
+field it names. AWS's `RunInstances` reference states the rule directly — "Any
+additional parameters that you specify for the new instance overwrite the
+corresponding parameters included in the launch template."
+
+| Field | Request | Template | Result |
+|---|---|---|---|
+| `ImageId` | `ami-request` | `ami-template` | `ami-request` |
+| `ImageId` | absent | `ami-template` | `ami-template` |
+| `InstanceType` | `m5.large` | `c5.xlarge` | `m5.large` |
+| `InstanceType` | `t3.micro` | `m5.large` | `t3.micro` |
+| `InstanceType` | absent | `m5.large` | `m5.large` |
+| `InstanceType` | absent | absent | `t3.micro` (substrate's default) |
+| `KeyName` | `k-request` | `k-template` | `k-request` |
+| `SubnetId`, security groups, `AssociatePublicIpAddress` | see [Launch template networking](#launch-template-networking) | | |
+
+Two details are worth stating, because both were wrong before and each fails
+silently rather than loudly.
+
+Substrate used to consult the template **only when the request omitted `ImageId`**.
+A request naming both an AMI and a template therefore ignored the template
+entirely — its instance type, key name, user data, subnet, security groups and
+public-IP preference were all dropped — and the launch still succeeded. The
+instance simply was not the one that was asked for, which is the hardest kind of
+infidelity to notice from a test that only checks that the call worked.
+
+The `t3.micro` default is now applied **last**, after the template has had its
+chance. It used to be applied first, and the template fallback then treated
+`t3.micro` as a proxy for "the request named no instance type" — so a request
+explicitly asking for `t3.micro` alongside a template naming something else got
+the template's type, exactly inverting the documented precedence. An explicit
+`t3.micro` is now honoured, and the default applies only when neither side names
+a type.
+
+A template's `TagSpecifications` and `IamInstanceProfile` are not parsed at all, so
+neither participates in the merge.
 
 ### Launch template networking
 

--- a/emulator/ec2_launchtemplate_test.go
+++ b/emulator/ec2_launchtemplate_test.go
@@ -60,6 +60,9 @@ func createLaunchTemplate(t *testing.T, ts *httptest.Server, name string, data m
 // launchedInstance is the instance state a launch-template test inspects.
 type launchedInstance struct {
 	InstanceID      string `xml:"instanceId"`
+	ImageID         string `xml:"imageId"`
+	InstanceType    string `xml:"instanceType"`
+	KeyName         string `xml:"keyName"`
 	SubnetID        string `xml:"subnetId"`
 	VpcID           string `xml:"vpcId"`
 	PublicIPAddress string `xml:"publicIpAddress"`
@@ -67,6 +70,15 @@ type launchedInstance struct {
 		GroupID   string `xml:"groupId"`
 		GroupName string `xml:"groupName"`
 	} `xml:"groupSet>item"`
+}
+
+// groupIDs flattens the instance's security group IDs.
+func (l launchedInstance) groupIDs() []string {
+	ids := make([]string, 0, len(l.Groups))
+	for _, g := range l.Groups {
+		ids = append(ids, g.GroupID)
+	}
+	return ids
 }
 
 // describeInstance runs DescribeInstances for one instance ID.
@@ -403,6 +415,249 @@ func TestEC2_LaunchTemplate_NoNetworkInterface(t *testing.T) {
 	// fall-through from the non-default subnets the tests above use.
 	if got.PublicIPAddress == "" {
 		t.Error("publicIpAddress is empty; the default subnet should assign one")
+	}
+}
+
+// TestEC2_LaunchTemplate_MergesWithRequestParams is #453's headline case: a
+// request that names both an ImageId and a launch template.
+//
+// runInstances gated its entire template block on imageID == "", so such a
+// request never read the template at all — its InstanceType, KeyName, subnet,
+// security groups and public-IP preference were silently dropped and the instance
+// landed in a substrate-chosen default VPC on a default instance type. The launch
+// succeeded, so nothing failed; the instance simply was not the one asked for.
+//
+// AWS's RunInstances reference states the rule this asserts: "Any additional
+// parameters that you specify for the new instance overwrite the corresponding
+// parameters included in the launch template." So the request's AMI wins *and*
+// every field it did not name comes from the template — one launch, all of it.
+func TestEC2_LaunchTemplate_MergesWithRequestParams(t *testing.T) {
+	ts := newEC2TestServer(t)
+	net := newLTNetwork(t, ts, "10.20.0.0/16", "lt-merge")
+	ltID := createLaunchTemplate(t, ts, "merge", map[string]string{
+		"LaunchTemplateData.ImageId":                                     "ami-0template000001",
+		"LaunchTemplateData.InstanceType":                                "c5.xlarge",
+		"LaunchTemplateData.KeyName":                                     "template-key",
+		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
+		"LaunchTemplateData.NetworkInterface.1.SubnetId":                 net.subnetID,
+		"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1":        net.sgID,
+		"LaunchTemplateData.NetworkInterface.1.AssociatePublicIpAddress": "true",
+	})
+
+	id := runInstance(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateId": ltID,
+		// The only field the request names. Before #453 its presence alone was
+		// enough to discard everything else above.
+		"ImageId": "ami-0request0000001",
+	})
+	got := describeInstance(t, ts, id)
+
+	if got.ImageID != "ami-0request0000001" {
+		t.Errorf("imageId = %q, want the request's AMI", got.ImageID)
+	}
+	if got.InstanceType != "c5.xlarge" {
+		t.Errorf("instanceType = %q, want the template's c5.xlarge", got.InstanceType)
+	}
+	if got.KeyName != "template-key" {
+		t.Errorf("keyName = %q, want the template's template-key", got.KeyName)
+	}
+	if got.SubnetID != net.subnetID {
+		t.Errorf("subnetId = %q, want the template's %q", got.SubnetID, net.subnetID)
+	}
+	if ids := got.groupIDs(); len(ids) != 1 || ids[0] != net.sgID {
+		t.Errorf("groupSet = %v, want the template's group %s", ids, net.sgID)
+	}
+	// The subnet is non-default and does not map public IPs, so a public IP can
+	// only have come from the template's preference.
+	if got.PublicIPAddress == "" {
+		t.Error("publicIpAddress is empty; want one from the template's preference")
+	}
+}
+
+// TestEC2_LaunchTemplate_FieldPrecedence walks each mergeable field three ways:
+// the request wins when it names a value, the template fills the gap when it does
+// not, and the built-in default applies when neither does.
+//
+// The InstanceType rows are the ones that matter most. The template fallback used
+// to test instanceType == "t3.micro" as a proxy for "the request named nothing",
+// because the default was applied before the template was read — so a request
+// explicitly asking for t3.micro was indistinguishable from one asking for
+// nothing, and the template overrode it. That inverts AWS's precedence on the one
+// value most likely to be spelled out in a cost-sensitive launch.
+func TestEC2_LaunchTemplate_FieldPrecedence(t *testing.T) {
+	tests := []struct {
+		name string
+		// templateData is merged into the launch template.
+		templateData map[string]string
+		// requestParams is merged into the RunInstances call.
+		requestParams map[string]string
+		check         func(t *testing.T, got launchedInstance)
+	}{
+		{
+			name:          "request InstanceType wins over the template's",
+			templateData:  map[string]string{"LaunchTemplateData.InstanceType": "c5.xlarge"},
+			requestParams: map[string]string{"InstanceType": "m5.large"},
+			check: func(t *testing.T, got launchedInstance) {
+				if got.InstanceType != "m5.large" {
+					t.Errorf("instanceType = %q, want m5.large", got.InstanceType)
+				}
+			},
+		},
+		{
+			// The sentinel bug, stated directly: t3.micro is also the default, so
+			// an implementation that compares against the default cannot tell this
+			// request from one that named no type at all.
+			name:          "an explicit t3.micro wins over the template's type",
+			templateData:  map[string]string{"LaunchTemplateData.InstanceType": "m5.large"},
+			requestParams: map[string]string{"InstanceType": "t3.micro"},
+			check: func(t *testing.T, got launchedInstance) {
+				if got.InstanceType != "t3.micro" {
+					t.Errorf("instanceType = %q, want the explicitly requested t3.micro", got.InstanceType)
+				}
+			},
+		},
+		{
+			name:          "the template fills an absent InstanceType",
+			templateData:  map[string]string{"LaunchTemplateData.InstanceType": "m5.large"},
+			requestParams: map[string]string{},
+			check: func(t *testing.T, got launchedInstance) {
+				if got.InstanceType != "m5.large" {
+					t.Errorf("instanceType = %q, want the template's m5.large", got.InstanceType)
+				}
+			},
+		},
+		{
+			name:          "neither names an InstanceType, so the default applies",
+			templateData:  map[string]string{},
+			requestParams: map[string]string{},
+			check: func(t *testing.T, got launchedInstance) {
+				if got.InstanceType != "t3.micro" {
+					t.Errorf("instanceType = %q, want the t3.micro default", got.InstanceType)
+				}
+			},
+		},
+		{
+			name:          "request KeyName wins over the template's",
+			templateData:  map[string]string{"LaunchTemplateData.KeyName": "template-key"},
+			requestParams: map[string]string{"KeyName": "request-key"},
+			check: func(t *testing.T, got launchedInstance) {
+				if got.KeyName != "request-key" {
+					t.Errorf("keyName = %q, want request-key", got.KeyName)
+				}
+			},
+		},
+		{
+			name:          "the template fills an absent KeyName",
+			templateData:  map[string]string{"LaunchTemplateData.KeyName": "template-key"},
+			requestParams: map[string]string{},
+			check: func(t *testing.T, got launchedInstance) {
+				if got.KeyName != "template-key" {
+					t.Errorf("keyName = %q, want the template's template-key", got.KeyName)
+				}
+			},
+		},
+		{
+			name:          "the template fills an absent ImageId",
+			templateData:  map[string]string{"LaunchTemplateData.ImageId": "ami-0template000002"},
+			requestParams: map[string]string{},
+			check: func(t *testing.T, got launchedInstance) {
+				if got.ImageID != "ami-0template000002" {
+					t.Errorf("imageId = %q, want the template's", got.ImageID)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+
+			// Every template carries an AMI so the #412 check is satisfied even in
+			// the cases whose request names one; a case asserting on the AMI
+			// overrides it explicitly.
+			data := map[string]string{"LaunchTemplateData.ImageId": "ami-0template000001"}
+			for k, v := range tt.templateData {
+				data[k] = v
+			}
+			ltID := createLaunchTemplate(t, ts, "precedence", data)
+
+			params := map[string]string{"LaunchTemplate.LaunchTemplateId": ltID}
+			for k, v := range tt.requestParams {
+				params[k] = v
+			}
+			tt.check(t, describeInstance(t, ts, runInstance(t, ts, params)))
+		})
+	}
+}
+
+// TestEC2_LaunchTemplate_NetworkingPrecedenceWithRequestImageID is the #444
+// networking precedence re-asserted for the case #453 opened up.
+//
+// Those fallbacks were previously unreachable whenever the request named an
+// ImageId, so their guards had never actually been exercised against a
+// call-level value. This runs both directions with an ImageId present: a
+// request-level subnet and security group win, and the template's public-IP
+// preference still fills a gap the request left.
+func TestEC2_LaunchTemplate_NetworkingPrecedenceWithRequestImageID(t *testing.T) {
+	ts := newEC2TestServer(t)
+	tmplNet := newLTNetwork(t, ts, "10.30.0.0/16", "lt-net-tmpl")
+	reqNet := newLTNetwork(t, ts, "10.31.0.0/16", "lt-net-req")
+
+	ltID := createLaunchTemplate(t, ts, "net-precedence", map[string]string{
+		"LaunchTemplateData.ImageId":                                     "ami-0template000003",
+		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
+		"LaunchTemplateData.NetworkInterface.1.SubnetId":                 tmplNet.subnetID,
+		"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1":        tmplNet.sgID,
+		"LaunchTemplateData.NetworkInterface.1.AssociatePublicIpAddress": "true",
+	})
+
+	got := describeInstance(t, ts, runInstance(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateId": ltID,
+		"ImageId":                         "ami-0request0000002",
+		"SubnetId":                        reqNet.subnetID,
+		"SecurityGroupId.1":               reqNet.sgID,
+	}))
+
+	if got.SubnetID != reqNet.subnetID {
+		t.Errorf("subnetId = %q, want the request's %q", got.SubnetID, reqNet.subnetID)
+	}
+	if ids := got.groupIDs(); len(ids) != 1 || ids[0] != reqNet.sgID {
+		t.Errorf("groupSet = %v, want only the request's group %s", ids, reqNet.sgID)
+	}
+	// The request named no public-IP preference, so the template's still applies —
+	// on a non-default subnet, which would otherwise assign none.
+	if got.PublicIPAddress == "" {
+		t.Error("publicIpAddress is empty; the template's preference should still fill the gap")
+	}
+}
+
+// TestEC2_LaunchTemplate_RequestFalseBeatsTemplateTrue pins the direction of the
+// public-IP preference that a bool cannot express.
+//
+// AssociatePublicIpAddress is carried as a three-state string ("" / "true" /
+// "false") precisely so an explicit false can override a template's true. With
+// the template now read even when the request names an ImageId, this is the case
+// where collapsing the states would visibly assign an unwanted public IP.
+func TestEC2_LaunchTemplate_RequestFalseBeatsTemplateTrue(t *testing.T) {
+	ts := newEC2TestServer(t)
+	net := newLTNetwork(t, ts, "10.40.0.0/16", "lt-public-false")
+	ltID := createLaunchTemplate(t, ts, "public-false", map[string]string{
+		"LaunchTemplateData.ImageId":                                     "ami-0template000004",
+		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
+		"LaunchTemplateData.NetworkInterface.1.SubnetId":                 net.subnetID,
+		"LaunchTemplateData.NetworkInterface.1.AssociatePublicIpAddress": "true",
+	})
+
+	got := describeInstance(t, ts, runInstance(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateId": ltID,
+		"ImageId":                         "ami-0request0000003",
+		"NetworkInterface.1.AssociatePublicIpAddress": "false",
+		"NetworkInterface.1.SubnetId":                 net.subnetID,
+	}))
+
+	if got.PublicIPAddress != "" {
+		t.Errorf("publicIpAddress = %q, want none: the request explicitly asked for false",
+			got.PublicIPAddress)
 	}
 }
 

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -235,10 +235,13 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 
 func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	imageID := req.Params["ImageId"]
+	// The call-level instance type is kept verbatim, with no default applied yet: a
+	// launch template may supply one, and the default can only be resolved once the
+	// template has had its chance. Defaulting here and then testing for the default
+	// value later cannot tell "absent" from "explicitly t3.micro" — which is how a
+	// caller naming t3.micro alongside a template naming something else used to get
+	// the template's type, exactly inverting AWS's precedence (#453).
 	instanceType := req.Params["InstanceType"]
-	if instanceType == "" {
-		instanceType = "t3.micro"
-	}
 	// Absent counts still default; a count that is present and invalid is rejected
 	// rather than clamped, because clamping MinCount=0 up to 1 launched an instance
 	// where AWS fails the request (#431). See resolveInstanceCounts for why the
@@ -298,38 +301,55 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 			"NetworkInterface.1.SecurityGroupId.%d", "NetworkInterface.1.Groups.%d")
 	}
 
-	// Resolve launch template parameters when no ImageId is provided directly.
+	// Merge a named launch template into the request, per field.
+	//
+	// The template is consulted whenever one is named, not only when the request
+	// omitted ImageId (#453). AWS's RunInstances reference states the rule plainly:
+	// "Any additional parameters that you specify for the new instance overwrite the
+	// corresponding parameters included in the launch template." A request carrying
+	// both an ImageId and a template therefore gets its own AMI *and* the template's
+	// instance type, key name, subnet, security groups and public-IP preference —
+	// where the old imageID == "" gate meant such a request never read the template
+	// at all and silently dropped every one of those values.
 	//
 	// Every fallback below is guarded on the call-level value being absent, which is
-	// AWS's precedence: a value named in the request wins over the template's. The
-	// networking fallbacks in particular must run *after* the call-level
-	// NetworkInterface.1.* reads above rather than before them (#444) — the subnet
-	// fallback used to sit ahead of this block, where there was nothing yet to fall
-	// back to.
-	if imageID == "" {
-		ltID := req.Params["LaunchTemplate.LaunchTemplateId"]
-		ltName := req.Params["LaunchTemplate.LaunchTemplateName"]
-		if lt := p.resolveLaunchTemplate(context.Background(), reqCtx, ltID, ltName); lt != nil {
+	// what implements that precedence. The networking fallbacks in particular must
+	// run *after* the call-level NetworkInterface.1.* reads above rather than before
+	// them (#444) — the subnet fallback used to sit ahead of this block, where there
+	// was nothing yet to fall back to.
+	ltID := req.Params["LaunchTemplate.LaunchTemplateId"]
+	ltName := req.Params["LaunchTemplate.LaunchTemplateName"]
+	if lt := p.resolveLaunchTemplate(context.Background(), reqCtx, ltID, ltName); lt != nil {
+		if imageID == "" {
 			imageID = lt.LatestData.ImageID
-			if instanceType == "t3.micro" && lt.LatestData.InstanceType != "" {
-				instanceType = lt.LatestData.InstanceType
-			}
-			if keyName == "" {
-				keyName = lt.LatestData.KeyName
-			}
-			if subnetID == "" {
-				subnetID = lt.LatestData.SubnetID
-			}
-			if publicIPPref == "" {
-				publicIPPref = lt.LatestData.AssociatePublicIPAddress
-			}
-			if len(securityGroupIDs) == 0 {
-				securityGroupIDs = lt.LatestData.NetworkSecurityGroupIDs()
-			}
-			if sgID == "" && len(securityGroupIDs) > 0 {
-				sgID = securityGroupIDs[0]
-			}
 		}
+		if instanceType == "" {
+			instanceType = lt.LatestData.InstanceType
+		}
+		if keyName == "" {
+			keyName = lt.LatestData.KeyName
+		}
+		if userData == "" {
+			userData = lt.LatestData.UserData
+		}
+		if subnetID == "" {
+			subnetID = lt.LatestData.SubnetID
+		}
+		if publicIPPref == "" {
+			publicIPPref = lt.LatestData.AssociatePublicIPAddress
+		}
+		if len(securityGroupIDs) == 0 {
+			securityGroupIDs = lt.LatestData.NetworkSecurityGroupIDs()
+		}
+		if sgID == "" && len(securityGroupIDs) > 0 {
+			sgID = securityGroupIDs[0]
+		}
+	}
+
+	// The instance-type default is resolved last, so it applies only when neither the
+	// request nor the template named one.
+	if instanceType == "" {
+		instanceType = "t3.micro"
 	}
 
 	associatePublicIP := strings.EqualFold(publicIPPref, "true")


### PR DESCRIPTION
Closes #453

## The defect

`runInstances` gated its **entire** launch-template block on `ImageId` being absent:

```go
if imageID == "" {
    // ... resolve template, read every field from it
}
```

So a request passing both an `ImageId` and a `LaunchTemplate` never read the template at all. Its `InstanceType`, `KeyName`, `UserData`, security groups and — since #444 — its subnet and public-IP preference were all silently dropped.

The launch still succeeded and still returned an instance ID, so nothing in the response said anything was wrong. The instance simply was not the one that was asked for. A consumer templating a `c5.xlarge` in a private subnet and pinning the AMI per environment at the call — which is *why* `ImageId` is passed alongside a template — got a `t3.micro` in the default VPC and a green test.

## The rule

AWS's `RunInstances` reference is the specification, for the `LaunchTemplate` parameter:

> Any additional parameters that you specify for the new instance **overwrite** the corresponding parameters included in the launch template.

Per field, request wins; the template fills what the request omitted. The template is now resolved whenever one is named, and each existing fallback stays guarded on the call-level value being absent.

The #412 `ImageId` / `MissingParameter` check still runs *after* resolution, so a template remains a valid sole source of the AMI, and a template carrying none still fails.

## Two things beyond the mechanical fix

**`UserData` is a new fallback, not a restored one.** A template's user data was parsed and stored but never applied to the launch. Note that no registered operation reads it back — substrate does not implement `DescribeInstanceAttribute` — so the merge is observable only in recorded instance state, not through an API call. That is stated in the CHANGELOG rather than claimed as tested.

**An explicit `InstanceType=t3.micro` is now honored over a template's type.** The default used to be applied *before* the template was read, and the template fallback then tested for that literal value as a proxy for "the request named no instance type":

```go
if instanceType == "t3.micro" && lt.LatestData.InstanceType != "" { ... }
```

A sentinel cannot tell "absent" from "explicitly `t3.micro`", so asking for `t3.micro` alongside a template naming `m5.large` yielded `m5.large` — exactly inverting the documented precedence. The default is now resolved **last**, after the template has had its chance, so it applies only when neither side names a type. This is the same three-state pattern `publicIPPref` already uses (#444). It was reachable before this change and far more reachable after it, which is why it is fixed here.

## Tests

Four new tests in `emulator/ec2_launchtemplate_test.go`:

- `TestEC2_LaunchTemplate_MergesWithRequestParams` — the headline case, the whole bug in one launch: request names `ImageId`, template carries `c5.xlarge` / key name / non-default subnet / SG / `AssociatePublicIpAddress=true`; asserts the request's AMI **and** all five template values on the same instance.
- `TestEC2_LaunchTemplate_FieldPrecedence` — 7 cases: request `InstanceType` wins; **explicit `t3.micro` wins over the template's `m5.large`** (the sentinel bug); template fills an absent type; neither → `t3.micro`; request `KeyName` wins; template fills an absent `KeyName`; template fills an absent `ImageId`.
- `TestEC2_LaunchTemplate_NetworkingPrecedenceWithRequestImageID` — with an `ImageId` present, request subnet + SG win while the template's public-IP preference still fills the gap.
- `TestEC2_LaunchTemplate_RequestFalseBeatsTemplateTrue` — explicit `false` beats template `true`; the three-state string's reason for existing.

The **entire existing launch-template suite passes unchanged** — 29 subtests, including every pre-existing #444 test (`SubnetSources` A–D, `SubnetPrecedence`, `SecurityGroups`, `AssociatePublicIPAddress`, `NoNetworkInterface`, `DescribeEchoesNetworking`) and the #412 `MissingImageId` tests. That is the evidence the reordering did not regress paths that already worked. The fleet suite matters here too: `launchFleetPool` sets a call-level `ImageId` whenever an override names one, so every such fleet launch now reads the template where it previously did not.

## Mutation-tested

Both mutants compiled (`go vet` gate) and were caught:

| Mutation | Result |
|---|---|
| Restore the `lt != nil && imageID == ""` gate | `MergesWithRequestParams` + `NetworkingPrecedenceWithRequestImageID` failed |
| Restore the `instanceType == "t3.micro"` sentinel | `FieldPrecedence/an_explicit_t3.micro_wins_over_the_template's_type` failed |

## Verification

From the repo root: `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race) green, `make docs-reference-check docs-versions` green, `test/e2e` green.

## Docs

`docs/services.md` gains a new §"A launch template merges with the request, field by field" with the per-field precedence table, the AWS quote, and both fixes stated including why each failed silently. The `RunInstances` coverage row links to it. Also recorded: a template's `TagSpecifications` and `IamInstanceProfile` are not parsed, so neither participates in the merge (follow-up to be filed).