### PR TITLE
fix(sqs): store and return message attributes (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   this rather than implying a doc citation.
 
 ### Fixed
+- SQS: message attributes are now stored on send and returned on receive (#461). #454
+  parsed them in order to measure them against `MaximumMessageSize` and then discarded
+  them: `SQSMessage.MessageAttributes` existed and was never populated, and
+  `ReceiveMessage` had no attribute handling at all. A consumer routing on an attribute
+  — a `messageType` discriminator, a trace ID, a tenant key — saw every message fall to
+  its default branch, with no error to explain why, because the attribute was simply
+  not there. `SendMessage`, `SendMessageBatch` and `ReceiveMessage` all carry them now,
+  under both the query and JSON protocols.
+
+  **Attributes are returned only for the names a receive asks for.** Returning them
+  unconditionally is the trap here, and it fails in the permissive direction: a consumer
+  whose production caller never sets `MessageAttributeNames` would pass against
+  substrate and then read nothing from real SQS. All the documented selector forms work
+  — `All` and `.*` for everything, a bare name for one, and the `prefix.*` form the
+  guide documents as "all message attributes starting with a prefix, for example
+  `bar.*`". A named attribute the message does not carry is absent rather than an error,
+  matching AWS.
+
+  `MD5OfMessageAttributes` is returned on `SendMessage`, on each `SendMessageBatch`
+  result entry, and on each received message, computed with the algorithm published in
+  the developer guide under "Calculating the MD5 message digest for message attributes".
+  Two details of it are load-bearing and a reimplementation gets both wrong by default:
+  **a binary value is hashed raw, not base64** — the same raw-versus-encoded distinction
+  #454 already drew for measurement, except here there is a hash to settle it, since
+  base64 yields `5ff413c9dc7bd18abea88ca05643f902` where AWS yields
+  `049075255ebc53fb95f7f9f3cedf3c50` for the same input — and **a custom data-type
+  suffix is hashed in full**, so `Number.java.lang.Long` is the whole string rather than
+  its `Number` base type.
+
+  The implementation is pinned against **three real-AWS digests**, which is what makes
+  #461's "verified against a known-good digest" criterion satisfiable with no network
+  access: the vectors ship in the test file with their provenance, and each fails on a
+  different mistake — the minimal single-attribute case, the custom-suffix case, and the
+  raw-binary case.
+
+  The field is **omitted entirely** for a message with no attributes rather than
+  reported as the MD5 of zero bytes, matching observed behaviour. A digest of nothing is
+  a value a caller could compare against and "successfully" verify, which is worse than
+  no value at all.
+
+  On a receive the digest covers **what is being returned**, not what was sent, so a
+  request naming a subset gets that subset's digest — the digest exists to let a caller
+  checksum the attributes in hand, and replaying the send-time value would fail that
+  check for a request that legitimately succeeded. A deduplicated FIFO send likewise
+  reports the digest of that request's attributes rather than the stored original's.
+  Attributes are emitted in name order; real SQS promises no order, but a Go map
+  iterates randomly, and two identical requests must not produce different responses.
+
+  Not enforced, and deliberately so for now: the documented maximum of 10 attributes per
+  message, and the attribute-name character rules (no `AWS.`/`Amazon.` prefix, no
+  leading, trailing or sequential periods). Both are newly reachable and tracked
+  separately; a 10-attribute message is accepted, pinned as the boundary it is.
 - EC2: `RunInstances` now merges a named launch template with the request field by
   field, instead of consulting the template only when the request omitted `ImageId`
   (#453). The entire template block was gated on the AMI being absent, so a request

--- a/docs/services.md
+++ b/docs/services.md
@@ -795,9 +795,9 @@ Lambda invocations: $0.0000002 per request.
 | SetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteQueue | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | ListQueues | |
-| SendMessage | Returns MessageId; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; enforces [`MaximumMessageSize`](#message-size-enforcement) |
-| SendMessageBatch | Enforces both the [per-message and batch-total size limits](#message-size-enforcement) |
-| ReceiveMessage | Supports MaxNumberOfMessages, WaitTimeSeconds; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
+| SendMessage | Returns MessageId; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; enforces [`MaximumMessageSize`](#message-size-enforcement); stores [message attributes](#message-attributes) and returns `MD5OfMessageAttributes` |
+| SendMessageBatch | Enforces both the [per-message and batch-total size limits](#message-size-enforcement); stores [message attributes](#message-attributes) per entry |
+| ReceiveMessage | Supports MaxNumberOfMessages, WaitTimeSeconds; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; returns [message attributes](#message-attributes) for the names requested |
 | DeleteMessage | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteMessageBatch | |
 | ChangeMessageVisibility | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
@@ -922,8 +922,8 @@ per-component breakdown is the one AWS's own Extended Client Library uses to dec
 whether a payload needs offloading to S3. Message *system* attributes are excluded,
 per the `SendMessage` reference.
 
-Attributes are parsed for measurement only; substrate does not yet store them or
-return them from `ReceiveMessage` (tracked separately).
+Attributes are also stored and returned — see [Message
+attributes](#message-attributes).
 
 `SendMessageBatch` enforces two limits, both 1 MiB, as the reference states: "the
 maximum allowed individual message size and the maximum total payload size (the sum of
@@ -957,6 +957,68 @@ a doc citation — captured SDK errors carrying `code: 'InvalidParameterValue'` 
 HTTP 400, and `BatchRequestTooLong: Batch requests cannot be longer than N bytes. You
 have sent M bytes.` The same strings appear in independent reimplementations, which
 corroborates them as transcribed AWS text.
+
+### Message attributes
+
+User-defined message attributes are stored on send and returned on receive, for both
+`SendMessage` and `SendMessageBatch`, under both protocols. A consumer routing on an
+attribute — a `messageType` discriminator, a trace ID, a tenant key — reads back what
+it sent.
+
+**Attributes are returned only when the receive asks for them.** This is the part that
+is easy to get wrong in the permissive direction: a consumer whose production caller
+never sets `MessageAttributeNames` would pass a test against an emulator that
+volunteered them, then read none from real SQS.
+
+| `MessageAttributeName` | Returned |
+|---|---|
+| omitted | nothing |
+| `All` | every attribute |
+| `.*` | every attribute |
+| `messageType` | that attribute, if the message carries it |
+| `trace.*` | every attribute whose name starts with `trace.` |
+
+A named attribute the message does not carry is simply absent, not an error — the
+selector says what to return, not that it must exist. The query protocol numbers the
+selectors `MessageAttributeName.1`, `.2`, …; the JSON protocol sends a
+`MessageAttributeNames` array.
+
+`MD5OfMessageAttributes` is returned on `SendMessage`, on each `SendMessageBatch`
+result entry, and on each received message. It is computed with the algorithm published
+in the developer guide under "Calculating the MD5 message digest for message
+attributes": sort by name, then per attribute append a 4-byte big-endian length and the
+UTF-8 name, the same for the data type, one transport byte (`1` for String and Number,
+`2` for Binary), then the value's length and bytes.
+
+Two details of that algorithm are load-bearing, and substrate's implementation is
+pinned against three real-AWS digests that fail if either is wrong:
+
+- **A binary value is hashed raw, not base64.** Base64 is the wire form, so hashing
+  what travels is the natural mistake; it produces `5ff413c9dc7bd18abea88ca05643f902`
+  where AWS produces `049075255ebc53fb95f7f9f3cedf3c50` for the same input. This is
+  the same raw-versus-encoded distinction [message size
+  enforcement](#message-size-enforcement) makes, now with a hash to settle it.
+- **A custom data-type suffix is included in full.** `Number.java.lang.Long` hashes as
+  the whole 21-byte string, not as its `Number` base type.
+
+`MD5OfMessageAttributes` is **omitted entirely** from a response for a message with no
+attributes, rather than reported as the MD5 of zero bytes. A digest of nothing is a
+value a caller could compare against and "successfully" verify, which is worse than no
+value at all.
+
+On a receive, the digest covers **what is being returned**, not what was sent: a
+request naming a subset gets that subset's digest, since the digest exists so a caller
+can checksum the attributes in hand. Attributes come back in name order, which real SQS
+does not promise but determinism here does.
+
+A deduplicated FIFO send reports the digest of *that request's* attributes rather than
+the stored original's, for the same reason: the digest is a checksum of what the caller
+sent.
+
+Two limits are **not** enforced (tracked separately): the documented maximum of 10
+attributes per message, and the attribute-name character rules (no `AWS.` or `Amazon.`
+prefix, no leading, trailing or sequential periods). A 10-attribute message is accepted,
+which is the boundary rather than a rejection.
 
 ### QueueNameExists
 

--- a/emulator/sqs_messageattributes.go
+++ b/emulator/sqs_messageattributes.go
@@ -1,0 +1,244 @@
+package emulator
+
+import (
+	"crypto/md5" // #nosec G501 -- AWS specifies MD5 for this digest; it is not a security control.
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SQS transport types for the message-attribute MD5 digest, from the developer
+// guide's "Calculating the MD5 digest" procedure: a single byte distinguishing a
+// string-shaped value from a binary one.
+const (
+	sqsAttrTransportString = 1
+	sqsAttrTransportBinary = 2
+)
+
+// sqsMD5OfMessageAttributes returns the MD5OfMessageAttributes digest AWS computes
+// for a message's user-defined attributes, or "" when there are none.
+//
+// The algorithm is the one published in the SQS developer guide under "Calculating
+// the MD5 message digest for message attributes": sort the attributes by name, then
+// for each one append the name's UTF-8 length as a 4-byte big-endian integer followed
+// by the name, the data type's length and the data type, a single transport-type byte
+// (1 for String and Number, 2 for Binary), and the value's length followed by the
+// value bytes. MD5 the result.
+//
+// Two details are load-bearing, and a reimplementation gets both wrong by default:
+//
+//   - A binary value is hashed **raw**, not base64-encoded. This is the same
+//     raw-versus-encoded distinction [sqsMessageSize] already makes for measurement,
+//     and here there is a hash to prove which one AWS means: vector 3 in
+//     sqs_messageattributes_test.go digests to 049075255ebc53fb95f7f9f3cedf3c50 from
+//     raw bytes and 5ff413c9dc7bd18abea88ca05643f902 from base64.
+//   - The full data type is hashed, custom suffix included, so
+//     "Number.java.lang.Long" is 21 bytes rather than the 6 of its "Number" base.
+//     The guide states that a custom type is appended to the base type with a period,
+//     and vector 2 does not reproduce without it.
+//
+// Sorting is by byte order rather than by any locale collation — the guide's wording
+// is "sorted by name", and Go's [sort.Strings] is byte order, which is what makes
+// the captured digests reproduce.
+//
+// The empty case returns "" rather than the MD5 of zero bytes, because AWS omits
+// MD5OfMessageAttributes from a response for a message with no attributes rather than
+// reporting a digest of nothing. Callers use "" as the signal to leave the field out.
+//
+// MD5 is not a security control here: it is a wire-format value AWS specifies, and
+// substrate must produce the same bytes real SQS does in order for a consumer's
+// integrity check to pass.
+func sqsMD5OfMessageAttributes(attrs map[string]SQSMessageAttribute) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	h := md5.New() // #nosec G401 -- see the doc comment: AWS specifies MD5 for this digest.
+	for _, name := range names {
+		attr := attrs[name]
+		sqsAttrWriteField(h, []byte(name))
+		sqsAttrWriteField(h, []byte(attr.DataType))
+		// A Binary attribute is identified by its declared data type, not by which
+		// value field happens to be populated. Keying off BinaryValue instead would
+		// hash a Binary attribute with an empty value as a string and silently
+		// produce a digest real SQS never emits.
+		if sqsAttrIsBinary(attr.DataType) {
+			_, _ = h.Write([]byte{sqsAttrTransportBinary})
+			sqsAttrWriteField(h, attr.BinaryValue)
+		} else {
+			_, _ = h.Write([]byte{sqsAttrTransportString})
+			sqsAttrWriteField(h, []byte(attr.StringValue))
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// sqsAttrIsBinary reports whether a data type is the Binary family.
+//
+// The match is on the base type before any custom suffix, since "Binary.gzip" is a
+// documented custom binary type and transports as binary.
+func sqsAttrIsBinary(dataType string) bool {
+	base, _, _ := strings.Cut(dataType, ".")
+	return base == "Binary"
+}
+
+// sqsAttrWriteField appends one length-prefixed field to the digest input: a 4-byte
+// big-endian length followed by the bytes themselves.
+//
+// [hash.Hash] never returns an error from Write, which is why the results are
+// discarded here rather than plumbed out: its contract states that Write, via the
+// embedded io.Writer interface, adds more data to the running hash and never returns
+// an error.
+func sqsAttrWriteField(h interface{ Write([]byte) (int, error) }, b []byte) {
+	var length [4]byte
+	binary.BigEndian.PutUint32(length[:], uint32(len(b)))
+	_, _ = h.Write(length[:])
+	_, _ = h.Write(b)
+}
+
+// sqsRequestedAttributeNames returns the MessageAttributeName selectors a
+// ReceiveMessage request carried.
+//
+// The wire forms differ by protocol and both are flattened lists: the query protocol
+// sends MessageAttributeName.N numbered from 1, and the JSON protocol sends a
+// MessageAttributeNames array. The model member is MessageAttributeNames
+// (AttributeNameList), which is why the query name is singular and the JSON one
+// plural.
+func sqsRequestedAttributeNames(req *AWSRequest) []string {
+	if sqsIsJSONProtocol(req) {
+		var input struct {
+			MessageAttributeNames []string `json:"MessageAttributeNames"`
+		}
+		// A body that does not parse yields no selectors, which is the same outcome
+		// as a request that named none: attributes are withheld rather than
+		// returned by accident.
+		_ = json.Unmarshal(req.Body, &input)
+		return input.MessageAttributeNames
+	}
+	var names []string
+	for i := 1; ; i++ {
+		name, ok := req.Params[fmt.Sprintf("MessageAttributeName.%d", i)]
+		if !ok {
+			break
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+// sqsSelectMessageAttributes returns the subset of a message's attributes a
+// ReceiveMessage request asked for, or nil when it asked for none.
+//
+// Attributes are returned **only when requested**, which is the part of this that is
+// easy to get wrong in the permissive direction. The ReceiveMessage reference is
+// explicit: "MessageAttributeNames — The name of the message attribute" and
+// attributes are not returned unless named. A consumer whose test passes because
+// substrate volunteered an attribute their production caller never requests has a
+// test that will not survive contact with real SQS.
+//
+// The documented selectors:
+//
+//   - "All" or ".*" — every attribute. The reference gives both spellings.
+//   - "Name" — that attribute, if the message has it.
+//   - "Prefix.*" — every attribute whose name starts with "Prefix.". The reference
+//     documents this form: "You can also use all message attributes starting with a
+//     prefix, for example bar.*".
+//
+// A named attribute the message does not carry is simply absent from the result
+// rather than an error, matching AWS: the selector describes what to return, not an
+// assertion that it exists.
+func sqsSelectMessageAttributes(attrs map[string]SQSMessageAttribute, requested []string) map[string]SQSMessageAttribute {
+	if len(attrs) == 0 || len(requested) == 0 {
+		return nil
+	}
+
+	selected := make(map[string]SQSMessageAttribute)
+	for _, want := range requested {
+		if want == "All" || want == ".*" {
+			for name, attr := range attrs {
+				selected[name] = attr
+			}
+			continue
+		}
+		if prefix, ok := strings.CutSuffix(want, ".*"); ok {
+			for name, attr := range attrs {
+				if strings.HasPrefix(name, prefix+".") {
+					selected[name] = attr
+				}
+			}
+			continue
+		}
+		if attr, ok := attrs[want]; ok {
+			selected[want] = attr
+		}
+	}
+	if len(selected) == 0 {
+		return nil
+	}
+	return selected
+}
+
+// sqsMessageAttributeXML is one attribute in a ReceiveMessage XML response.
+//
+// The element name is MessageAttribute rather than the model's MessageAttributes
+// member name, because the shape carries locationName "MessageAttribute" and is
+// flattened — so real SDKs parse a repeated MessageAttribute element, not a wrapper.
+type sqsMessageAttributeXML struct {
+	Name  string                      `xml:"Name"`
+	Value sqsMessageAttributeValueXML `xml:"Value"`
+}
+
+// sqsMessageAttributeValueXML is an attribute's value in a ReceiveMessage XML
+// response.
+//
+// BinaryValue is a string rather than []byte because the wire form is base64 and
+// encoding/xml would otherwise emit the raw bytes; encoding/json base64s a []byte for
+// free, which is why only the XML path needs the explicit conversion.
+type sqsMessageAttributeValueXML struct {
+	DataType    string `xml:"DataType"`
+	StringValue string `xml:"StringValue,omitempty"`
+	BinaryValue string `xml:"BinaryValue,omitempty"`
+}
+
+// sqsMessageAttributesXML renders a message's attributes for an XML response,
+// ordered by name.
+//
+// The ordering is deliberate rather than incidental. Real SQS does not promise an
+// order, but a Go map iterates randomly, so emitting in map order would make one
+// substrate response differ from the next for identical input — which is the one
+// property this emulator exists to provide. Sorting by name matches the order the
+// digest is computed in.
+func sqsMessageAttributesXML(attrs map[string]SQSMessageAttribute) []sqsMessageAttributeXML {
+	if len(attrs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	out := make([]sqsMessageAttributeXML, 0, len(names))
+	for _, name := range names {
+		attr := attrs[name]
+		value := sqsMessageAttributeValueXML{
+			DataType:    attr.DataType,
+			StringValue: attr.StringValue,
+		}
+		if len(attr.BinaryValue) > 0 {
+			value.BinaryValue = base64.StdEncoding.EncodeToString(attr.BinaryValue)
+		}
+		out = append(out, sqsMessageAttributeXML{Name: name, Value: value})
+	}
+	return out
+}

--- a/emulator/sqs_messageattributes_test.go
+++ b/emulator/sqs_messageattributes_test.go
@@ -1,0 +1,703 @@
+package emulator_test
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// receivedAttrXML is one message attribute in a ReceiveMessage XML response.
+type receivedAttrXML struct {
+	Name  string `xml:"Name"`
+	Value struct {
+		DataType    string `xml:"DataType"`
+		StringValue string `xml:"StringValue"`
+		BinaryValue string `xml:"BinaryValue"`
+	} `xml:"Value"`
+}
+
+// receivedMessageXML is one message in a ReceiveMessage XML response, carrying the
+// fields #461 is about.
+type receivedMessageXML struct {
+	MessageID              string            `xml:"MessageId"`
+	Body                   string            `xml:"Body"`
+	MD5OfBody              string            `xml:"MD5OfBody"`
+	MD5OfMessageAttributes string            `xml:"MD5OfMessageAttributes"`
+	MessageAttribute       []receivedAttrXML `xml:"MessageAttribute"`
+}
+
+// receivedAttr is a message attribute as a test observes it, normalized across the
+// two protocols so an assertion can be written once. A binary value is held in its
+// base64 wire form, which is what both protocols carry.
+type receivedAttr struct {
+	dataType    string
+	stringValue string
+	binaryValue string
+}
+
+// receivedMessage is a received message normalized across protocols.
+type receivedMessage struct {
+	messageID              string
+	body                   string
+	md5OfMessageAttributes string
+	attributes             map[string]receivedAttr
+}
+
+// receiveMessages calls ReceiveMessage under either protocol, optionally naming
+// MessageAttributeName selectors, and returns the messages in a protocol-independent
+// shape.
+//
+// A nil selector list sends no MessageAttributeName at all, which is the case that
+// distinguishes "return nothing" from "return everything" — the whole point of the
+// selection rule.
+func receiveMessages(t *testing.T, srv *emulator.Server, queueURL string,
+	attrNames []string, jsonProto bool,
+) []receivedMessage {
+	t.Helper()
+	if jsonProto {
+		in := map[string]interface{}{"QueueUrl": queueURL, "MaxNumberOfMessages": 10}
+		if attrNames != nil {
+			in["MessageAttributeNames"] = attrNames
+		}
+		resp := sqsJSONRequest(t, srv, "ReceiveMessage", in)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body := readJSONBody(t, resp)
+
+		raw, _ := body["Messages"].([]interface{})
+		out := make([]receivedMessage, 0, len(raw))
+		for _, item := range raw {
+			m, ok := item.(map[string]interface{})
+			require.True(t, ok, "message is not an object: %v", item)
+			msg := receivedMessage{}
+			msg.messageID, _ = m["MessageId"].(string)
+			msg.body, _ = m["Body"].(string)
+			msg.md5OfMessageAttributes, _ = m["MD5OfMessageAttributes"].(string)
+			if attrs, present := m["MessageAttributes"].(map[string]interface{}); present {
+				msg.attributes = make(map[string]receivedAttr, len(attrs))
+				for name, v := range attrs {
+					av, isObj := v.(map[string]interface{})
+					require.True(t, isObj, "attribute %q is not an object", name)
+					got := receivedAttr{}
+					got.dataType, _ = av["DataType"].(string)
+					got.stringValue, _ = av["StringValue"].(string)
+					// A []byte field marshals to base64 in JSON, so the value
+					// arrives in the same wire form the XML path emits.
+					got.binaryValue, _ = av["BinaryValue"].(string)
+					msg.attributes[name] = got
+				}
+			}
+			out = append(out, msg)
+		}
+		return out
+	}
+
+	params := map[string]string{
+		"Action":              "ReceiveMessage",
+		"QueueUrl":            queueURL,
+		"MaxNumberOfMessages": "10",
+	}
+	for i, name := range attrNames {
+		params["MessageAttributeName."+strconv.Itoa(i+1)] = name
+	}
+	resp := sqsRequest(t, srv, params)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var parsed struct {
+		Result struct {
+			Message []receivedMessageXML `xml:"Message"`
+		} `xml:"ReceiveMessageResult"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(readBody(t, resp)), &parsed))
+
+	out := make([]receivedMessage, 0, len(parsed.Result.Message))
+	for _, m := range parsed.Result.Message {
+		msg := receivedMessage{
+			messageID:              m.MessageID,
+			body:                   m.Body,
+			md5OfMessageAttributes: m.MD5OfMessageAttributes,
+		}
+		if len(m.MessageAttribute) > 0 {
+			msg.attributes = make(map[string]receivedAttr, len(m.MessageAttribute))
+			for _, a := range m.MessageAttribute {
+				msg.attributes[a.Name] = receivedAttr{
+					dataType:    a.Value.DataType,
+					stringValue: a.Value.StringValue,
+					binaryValue: a.Value.BinaryValue,
+				}
+			}
+		}
+		out = append(out, msg)
+	}
+	return out
+}
+
+// sendMessageAttrDigest sends a message with attributes and returns the
+// MD5OfMessageAttributes from the send response, plus whether the field was present
+// at all. The presence flag is what distinguishes an omitted field from an empty one,
+// which is the assertion the no-attribute case needs.
+func sendMessageAttrDigest(t *testing.T, srv *emulator.Server, queueURL, body string,
+	attrs []sqsMessageAttr, jsonProto bool,
+) (string, bool) {
+	t.Helper()
+	if jsonProto {
+		in := map[string]interface{}{"QueueUrl": queueURL, "MessageBody": body}
+		if len(attrs) > 0 {
+			in["MessageAttributes"] = jsonAttrMap(attrs)
+		}
+		resp := sqsJSONRequest(t, srv, "SendMessage", in)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		got := readJSONBody(t, resp)
+		v, ok := got["MD5OfMessageAttributes"].(string)
+		return v, ok
+	}
+
+	params := map[string]string{"Action": "SendMessage", "QueueUrl": queueURL, "MessageBody": body}
+	for i, a := range attrs {
+		base := "MessageAttribute." + strconv.Itoa(i+1) + "."
+		params[base+"Name"] = a.name
+		params[base+"Value.DataType"] = a.dataType
+		if a.stringValue != "" {
+			params[base+"Value.StringValue"] = a.stringValue
+		}
+		if a.binaryValue != nil {
+			params[base+"Value.BinaryValue"] = base64.StdEncoding.EncodeToString(a.binaryValue)
+		}
+	}
+	resp := sqsRequest(t, srv, params)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var parsed struct {
+		Result struct {
+			MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes"`
+		} `xml:"SendMessageResult"`
+	}
+	raw := readBody(t, resp)
+	require.NoError(t, xml.Unmarshal([]byte(raw), &parsed))
+	// `omitempty` on the field means an absent element and an empty one are
+	// indistinguishable once unmarshaled, so presence is read from the document.
+	return parsed.Result.MD5OfMessageAttributes, strings.Contains(raw, "<MD5OfMessageAttributes>")
+}
+
+// jsonAttrMap renders attributes in the JSON protocol's MessageAttributes shape.
+func jsonAttrMap(attrs []sqsMessageAttr) map[string]interface{} {
+	m := make(map[string]interface{}, len(attrs))
+	for _, a := range attrs {
+		v := map[string]interface{}{"DataType": a.dataType}
+		if a.stringValue != "" {
+			v["StringValue"] = a.stringValue
+		}
+		if a.binaryValue != nil {
+			v["BinaryValue"] = a.binaryValue
+		}
+		m[a.name] = v
+	}
+	return m
+}
+
+// createAttrQueue creates a default queue and returns its URL.
+func createAttrQueue(t *testing.T, srv *emulator.Server, name string) string {
+	t.Helper()
+	status, code := createQueueWithAttrs(t, srv, name, nil, false)
+	require.Equal(t, http.StatusOK, status, "create failed: %s", code)
+	return "http://sqs.us-east-1.localhost/000000000000/" + name
+}
+
+// TestSQS_MessageAttributes_KnownGoodDigests is #461's "verified against a known-good
+// digest" criterion, met without network access.
+//
+// The three vectors are real-AWS MD5OfMessageAttributes values captured in moto's
+// test suite (tests/test_sqs/test_sqs.py, test_message_send_with_attributes), which
+// asserts them against responses recorded from the live service. Each was reproduced
+// from the documented algorithm — sort by name; 4-byte big-endian length plus UTF-8
+// name; the same for the data type; one transport byte (1 for String and Number, 2
+// for Binary); then the value's length and bytes — before any of this code was
+// written, which is what makes them a check on the implementation rather than a
+// transcription of it.
+//
+// They are not interchangeable. Vector 1 is the minimal single-attribute case.
+// Vector 2 pins that a custom data-type suffix is hashed in full: it does not
+// reproduce if "Number.java.lang.Long" is truncated to its "Number" base type.
+// Vector 3 pins that a binary value is hashed raw — the base64 form of the same
+// input digests to 5ff413c9dc7bd18abea88ca05643f902 instead, which is the mistake a
+// reimplementation makes by default because base64 is what travels on the wire.
+func TestSQS_MessageAttributes_KnownGoodDigests(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createAttrQueue(t, srv, "digest-vectors")
+
+	tests := []struct {
+		name  string
+		attrs []sqsMessageAttr
+		want  string
+	}{
+		{
+			name: "single Number attribute",
+			attrs: []sqsMessageAttr{
+				{name: "SOME_Valid.attribute-Name", dataType: "Number", stringValue: "1493147359900"},
+			},
+			want: "36655e7e9d7c0e8479fa3f3f42247ae7",
+		},
+		{
+			name: "three attributes including a custom Number suffix",
+			attrs: []sqsMessageAttr{
+				{name: "id", dataType: "String", stringValue: "2018fc74-4f77-1a5a-1be0-c2d037d5052b"},
+				{name: "contentType", dataType: "String", stringValue: "application/json"},
+				{name: "timestamp", dataType: "Number.java.lang.Long", stringValue: "1602845432024"},
+			},
+			want: "b12289320bb6e494b18b645ef562b4a9",
+		},
+		{
+			name: "binary attribute hashes raw bytes",
+			attrs: []sqsMessageAttr{
+				{name: "id", dataType: "String", stringValue: "453ae55e-f03b-21a6-a4b1-70c2e2e8fe71"},
+				{name: "mybin", dataType: "Binary", binaryValue: []byte("kekchebukek")},
+				{name: "timestamp", dataType: "Number.java.lang.Long", stringValue: "1603134247654"},
+				{name: "contentType", dataType: "String", stringValue: "application/json"},
+			},
+			want: "049075255ebc53fb95f7f9f3cedf3c50",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bothProtocols(t, func(t *testing.T, jsonProto bool) {
+				got, present := sendMessageAttrDigest(t, srv, queueURL, "derp", tt.attrs, jsonProto)
+				assert.True(t, present, "MD5OfMessageAttributes should be present")
+				assert.Equal(t, tt.want, got)
+			})
+		})
+	}
+}
+
+// TestSQS_MessageAttributes_BinaryIsIdentifiedByDataType pins that the digest's
+// transport byte is chosen from the declared data type, not from which value field
+// happens to be populated.
+//
+// The two rules agree on every attribute with a value, and diverge only on a Binary
+// attribute whose value is empty: keyed off the data type it transports as binary
+// (byte 2), keyed off the value it would fall through to the string branch (byte 1)
+// and digest to something real SQS never emits.
+//
+// There is no real-AWS digest to compare against here: the SendMessage reference
+// states that an attribute's "name, type, and value must not be empty or null", so
+// real SQS rejects this request outright, and substrate not enforcing that rule yet is
+// what makes the case reachable at all. So the expected value is computed from the
+// published algorithm rather than captured — 4-byte length and "payload", 4-byte
+// length and "Binary", transport byte 2, then a 4-byte zero length and no value bytes.
+// Byte 1 in that position yields e275a101bd238d68e457c2f49e1ad0e7, which is what an
+// implementation keyed off the value field produces.
+func TestSQS_MessageAttributes_BinaryIsIdentifiedByDataType(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createAttrQueue(t, srv, "attr-empty-binary")
+
+	got, present := sendMessageAttrDigest(t, srv, queueURL, "body",
+		[]sqsMessageAttr{{name: "payload", dataType: "Binary"}}, false)
+	require.True(t, present)
+	assert.Equal(t, "6f8879e6be14e9d1c45ef3e9631b86c9", got,
+		"an empty Binary attribute must still transport as binary")
+
+	// A custom binary type transports the same way, since "Binary.gzip" is a
+	// documented custom type in the Binary family.
+	gzipped, present := sendMessageAttrDigest(t, srv, queueURL, "body",
+		[]sqsMessageAttr{{name: "payload", dataType: "Binary.gzip",
+			binaryValue: []byte{0x1f, 0x8b}}}, false)
+	require.True(t, present)
+	assert.NotEmpty(t, gzipped)
+}
+
+// TestSQS_MessageAttributes_DigestIsOrderIndependent pins that the digest depends on
+// the attribute names, not on the order they were sent in.
+//
+// The algorithm sorts by name, so two requests carrying the same attributes in
+// different orders must produce the same digest — and a Go map's random iteration
+// order means an implementation that skipped the sort would produce a *different*
+// digest on different runs of the same test, which is precisely the nondeterminism
+// this emulator exists to avoid.
+func TestSQS_MessageAttributes_DigestIsOrderIndependent(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createAttrQueue(t, srv, "digest-order")
+
+	forward := []sqsMessageAttr{
+		{name: "alpha", dataType: "String", stringValue: "1"},
+		{name: "beta", dataType: "String", stringValue: "2"},
+		{name: "gamma", dataType: "String", stringValue: "3"},
+	}
+	reversed := []sqsMessageAttr{forward[2], forward[1], forward[0]}
+
+	first, _ := sendMessageAttrDigest(t, srv, queueURL, "body", forward, false)
+	second, _ := sendMessageAttrDigest(t, srv, queueURL, "body", reversed, false)
+	assert.Equal(t, first, second, "digest must not depend on send order")
+	assert.NotEmpty(t, first)
+}
+
+// TestSQS_MessageAttributes_OmittedWhenNoneSent pins that MD5OfMessageAttributes is
+// absent from a send with no attributes, rather than reported as the digest of zero
+// bytes.
+//
+// Real SQS omits the field entirely — moto's suite asserts `"MD5OfMessageAttributes"
+// not in msg` for a bare send, against recorded live behavior. A digest of nothing
+// (d41d8cd98f00b204e9800998ecf8427e) would be a value a caller could compare against
+// and "successfully" verify, so reporting it is worse than reporting nothing.
+func TestSQS_MessageAttributes_OmittedWhenNoneSent(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "digest-absent")
+
+		got, present := sendMessageAttrDigest(t, srv, queueURL, "derp", nil, jsonProto)
+		assert.False(t, present, "MD5OfMessageAttributes should be omitted, got %q", got)
+		assert.Empty(t, got)
+	})
+}
+
+// TestSQS_MessageAttributes_RoundTrip is the core of #461: attributes were parsed for
+// size measurement (#454) but never stored, so ReceiveMessage returned none of them.
+// A consumer routing on an attribute — a messageType discriminator, a trace ID, a
+// tenant key — saw every message fall to its default branch, with no error to explain
+// why.
+//
+// All four value shapes round-trip: String, Number, a custom-suffixed Number, and
+// Binary. The binary case is the one that can go wrong invisibly, since it must come
+// back base64-encoded on the wire and decode to the exact bytes that were sent.
+func TestSQS_MessageAttributes_RoundTrip(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "attr-roundtrip")
+
+		binary := []byte{0x00, 0x01, 0xfe, 0xff, 0x42}
+		attrs := []sqsMessageAttr{
+			{name: "messageType", dataType: "String", stringValue: "OrderPlaced"},
+			{name: "retries", dataType: "Number", stringValue: "3"},
+			{name: "timestamp", dataType: "Number.java.lang.Long", stringValue: "1602845432024"},
+			{name: "payload", dataType: "Binary", binaryValue: binary},
+		}
+
+		status, code := sendMessageWithAttrs(t, srv, queueURL, "order-42", attrs, jsonProto)
+		require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+
+		msgs := receiveMessages(t, srv, queueURL, []string{"All"}, jsonProto)
+		require.Len(t, msgs, 1)
+		require.Len(t, msgs[0].attributes, 4)
+
+		assert.Equal(t, receivedAttr{dataType: "String", stringValue: "OrderPlaced"},
+			msgs[0].attributes["messageType"])
+		assert.Equal(t, receivedAttr{dataType: "Number", stringValue: "3"},
+			msgs[0].attributes["retries"])
+		assert.Equal(t, receivedAttr{dataType: "Number.java.lang.Long", stringValue: "1602845432024"},
+			msgs[0].attributes["timestamp"])
+
+		got := msgs[0].attributes["payload"]
+		assert.Equal(t, "Binary", got.dataType)
+		decoded, err := base64.StdEncoding.DecodeString(got.binaryValue)
+		require.NoError(t, err, "BinaryValue should be base64 on the wire")
+		assert.Equal(t, binary, decoded, "binary value must survive byte-identical")
+	})
+}
+
+// TestSQS_MessageAttributes_ReturnedOnlyWhenRequested pins the four documented
+// selection outcomes.
+//
+// Returning attributes unconditionally is the trap a naive fix falls into, and it is
+// an infidelity in the permissive direction: a consumer whose production caller never
+// sets MessageAttributeNames would pass a test against substrate and then read no
+// attributes from AWS. The selector forms come from the ReceiveMessage reference —
+// "All" and ".*" for everything, a name for one, and a "prefix.*" form the guide
+// documents as "all message attributes starting with a prefix, for example bar.*".
+func TestSQS_MessageAttributes_ReturnedOnlyWhenRequested(t *testing.T) {
+	attrs := []sqsMessageAttr{
+		{name: "alpha", dataType: "String", stringValue: "a"},
+		{name: "beta", dataType: "String", stringValue: "b"},
+		{name: "trace.id", dataType: "String", stringValue: "t"},
+		{name: "trace.span", dataType: "String", stringValue: "s"},
+	}
+
+	tests := []struct {
+		name      string
+		requested []string
+		want      []string
+	}{
+		{name: "omitted returns none", requested: nil, want: nil},
+		{name: "All returns every attribute", requested: []string{"All"},
+			want: []string{"alpha", "beta", "trace.id", "trace.span"}},
+		{name: "dot-star returns every attribute", requested: []string{".*"},
+			want: []string{"alpha", "beta", "trace.id", "trace.span"}},
+		{name: "a named subset returns only those", requested: []string{"alpha", "beta"},
+			want: []string{"alpha", "beta"}},
+		{name: "a single name returns one", requested: []string{"beta"}, want: []string{"beta"}},
+		{name: "a prefix selector returns its family", requested: []string{"trace.*"},
+			want: []string{"trace.id", "trace.span"}},
+		{name: "an unmatched name returns none", requested: []string{"nosuchattr"}, want: nil},
+		{name: "a mix of matched and unmatched returns the matched", requested: []string{"alpha", "nosuchattr"},
+			want: []string{"alpha"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bothProtocols(t, func(t *testing.T, jsonProto bool) {
+				srv, _ := newSQSTestServer(t)
+				queueURL := createAttrQueue(t, srv, "attr-select")
+
+				status, code := sendMessageWithAttrs(t, srv, queueURL, "body", attrs, jsonProto)
+				require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+
+				msgs := receiveMessages(t, srv, queueURL, tt.requested, jsonProto)
+				require.Len(t, msgs, 1)
+
+				names := make([]string, 0, len(msgs[0].attributes))
+				for name := range msgs[0].attributes {
+					names = append(names, name)
+				}
+				sort.Strings(names)
+				assert.Equal(t, tt.want, nilIfEmpty(names))
+			})
+		})
+	}
+}
+
+// nilIfEmpty normalizes an empty slice to nil, so a test can express "no attributes"
+// once rather than distinguishing a nil map from an empty one at every call site.
+func nilIfEmpty(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	return s
+}
+
+// TestSQS_MessageAttributes_ReceiveDigestCoversTheReturnedSubset pins that
+// MD5OfMessageAttributes on a receive is the digest of what is being returned, not a
+// replay of the send-time value.
+//
+// The digest exists so a caller can checksum the attributes in hand. A request naming
+// a subset that got the full send-time digest would fail that check every time — and
+// fail it in the confusing direction, since the data is correct and only the checksum
+// disagrees.
+func TestSQS_MessageAttributes_ReceiveDigestCoversTheReturnedSubset(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, tc := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "attr-subset-digest")
+
+		// The full set is vector 2, so the send-time digest is a known constant and
+		// the subset digest is demonstrably not it.
+		attrs := []sqsMessageAttr{
+			{name: "id", dataType: "String", stringValue: "2018fc74-4f77-1a5a-1be0-c2d037d5052b"},
+			{name: "contentType", dataType: "String", stringValue: "application/json"},
+			{name: "timestamp", dataType: "Number.java.lang.Long", stringValue: "1602845432024"},
+		}
+		const fullDigest = "b12289320bb6e494b18b645ef562b4a9"
+
+		sent, present := sendMessageAttrDigest(t, srv, queueURL, "derp", attrs, jsonProto)
+		require.True(t, present)
+		require.Equal(t, fullDigest, sent)
+
+		// Each receive here inspects the same message, so the simulated clock is moved
+		// past the 30-second visibility timeout between them. Without that the second
+		// and third calls would return nothing and the assertions below would pass
+		// vacuously on an empty list.
+		redeliver := func() { tc.SetTime(tc.Now().Add(31 * time.Second)) }
+
+		// Receiving everything reproduces the send-time digest.
+		all := receiveMessages(t, srv, queueURL, []string{"All"}, jsonProto)
+		require.Len(t, all, 1)
+		assert.Equal(t, fullDigest, all[0].md5OfMessageAttributes)
+
+		// A single-attribute subset must digest to that attribute alone. Asserting it
+		// is not the full digest is the part that catches a replayed send-time value.
+		redeliver()
+		subset := receiveMessages(t, srv, queueURL, []string{"contentType"}, jsonProto)
+		require.Len(t, subset, 1)
+		require.Len(t, subset[0].attributes, 1)
+		assert.NotEqual(t, fullDigest, subset[0].md5OfMessageAttributes,
+			"a subset must not report the full set's digest")
+		assert.NotEmpty(t, subset[0].md5OfMessageAttributes)
+
+		// And a receive that asked for nothing carries no digest at all, since there
+		// is nothing for a caller to checksum.
+		redeliver()
+		none := receiveMessages(t, srv, queueURL, nil, jsonProto)
+		require.Len(t, none, 1)
+		assert.Empty(t, none[0].md5OfMessageAttributes)
+	})
+}
+
+// TestSQS_MessageAttributes_BatchRoundTrip pins that SendMessageBatch stores and
+// digests per-entry attributes.
+//
+// The batch path parsed attributes only to measure them (#454) and constructed its
+// messages without them, in both protocols. Each entry's digest must cover that
+// entry's own attributes — a batch reporting one shared digest, or the first entry's,
+// would break a caller checksumming per entry.
+func TestSQS_MessageAttributes_BatchRoundTrip(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "attr-batch")
+
+		entries := []sqsBatchEntry{
+			{id: "e1", body: "first", attrs: []sqsMessageAttr{
+				{name: "messageType", dataType: "String", stringValue: "Alpha"},
+			}},
+			{id: "e2", body: "second", attrs: []sqsMessageAttr{
+				{name: "messageType", dataType: "String", stringValue: "Beta"},
+				{name: "retries", dataType: "Number", stringValue: "7"},
+			}},
+			{id: "e3", body: "third"},
+		}
+		status, code := sendMessageBatch(t, srv, queueURL, entries, jsonProto)
+		require.Equal(t, http.StatusOK, status, "batch failed: %s", code)
+
+		msgs := receiveMessages(t, srv, queueURL, []string{"All"}, jsonProto)
+		require.Len(t, msgs, 3)
+
+		byBody := make(map[string]receivedMessage, len(msgs))
+		for _, m := range msgs {
+			byBody[m.body] = m
+		}
+
+		require.Contains(t, byBody, "first")
+		assert.Equal(t, receivedAttr{dataType: "String", stringValue: "Alpha"},
+			byBody["first"].attributes["messageType"])
+
+		require.Contains(t, byBody, "second")
+		assert.Len(t, byBody["second"].attributes, 2)
+		assert.Equal(t, receivedAttr{dataType: "String", stringValue: "Beta"},
+			byBody["second"].attributes["messageType"])
+		assert.Equal(t, receivedAttr{dataType: "Number", stringValue: "7"},
+			byBody["second"].attributes["retries"])
+
+		// The entry that carried none has none, and no digest — the per-entry
+		// omission rule, not just the per-message one.
+		require.Contains(t, byBody, "third")
+		assert.Empty(t, byBody["third"].attributes)
+		assert.Empty(t, byBody["third"].md5OfMessageAttributes)
+
+		// Each entry's digest differs, because each covers its own attributes.
+		assert.NotEqual(t, byBody["first"].md5OfMessageAttributes,
+			byBody["second"].md5OfMessageAttributes)
+	})
+}
+
+// TestSQS_MessageAttributes_SurviveRedelivery pins that attributes are stored on the
+// message rather than held for the first receive.
+//
+// A message whose visibility timeout lapses is redelivered, and a consumer's retry
+// path reads the same attributes the first delivery carried. Attributes that vanished
+// on redelivery would make the retry take a different branch than the original
+// attempt — the kind of divergence that only shows up under failure, which is when it
+// is least welcome.
+func TestSQS_MessageAttributes_SurviveRedelivery(t *testing.T) {
+	srv, tc := newSQSTestServer(t)
+	queueURL := createAttrQueue(t, srv, "attr-redelivery")
+
+	attrs := []sqsMessageAttr{
+		{name: "messageType", dataType: "String", stringValue: "OrderPlaced"},
+	}
+	status, code := sendMessageWithAttrs(t, srv, queueURL, "order-42", attrs, false)
+	require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+
+	first := receiveMessages(t, srv, queueURL, []string{"All"}, false)
+	require.Len(t, first, 1)
+	require.Equal(t, "OrderPlaced", first[0].attributes["messageType"].stringValue)
+
+	// Let the default 30-second visibility timeout lapse on the simulated clock.
+	tc.SetTime(tc.Now().Add(31 * time.Second))
+
+	second := receiveMessages(t, srv, queueURL, []string{"All"}, false)
+	require.Len(t, second, 1)
+	assert.Equal(t, first[0].messageID, second[0].messageID)
+	assert.Equal(t, "OrderPlaced", second[0].attributes["messageType"].stringValue)
+	assert.Equal(t, first[0].md5OfMessageAttributes, second[0].md5OfMessageAttributes)
+}
+
+// TestSQS_MessageAttributes_TenAttributesAccepted pins AWS's documented per-message
+// maximum as the boundary it is, not as a rejection.
+//
+// The reference states a message "can have up to 10 metadata attributes", and
+// substrate does not enforce the count — so this asserts the legal case works rather
+// than asserting an error substrate does not raise. Enforcing the maximum is tracked
+// separately; pinning the boundary here is what makes that change visible when it
+// lands, instead of silently turning a passing test into a failing one.
+func TestSQS_MessageAttributes_TenAttributesAccepted(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "attr-ten")
+
+		attrs := make([]sqsMessageAttr, 0, 10)
+		for i := 0; i < 10; i++ {
+			attrs = append(attrs, sqsMessageAttr{
+				name:        "attr" + strconv.Itoa(i),
+				dataType:    "String",
+				stringValue: "v" + strconv.Itoa(i),
+			})
+		}
+
+		status, code := sendMessageWithAttrs(t, srv, queueURL, "body", attrs, jsonProto)
+		require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+
+		msgs := receiveMessages(t, srv, queueURL, []string{"All"}, jsonProto)
+		require.Len(t, msgs, 1)
+		assert.Len(t, msgs[0].attributes, 10)
+	})
+}
+
+// TestSQS_MessageAttributes_FifoDedupReportsThisRequestsDigest pins that a
+// deduplicated FIFO send reports the digest of the attributes *this* request carried,
+// not the original message's.
+//
+// The digest is a checksum of what the caller sent, so a caller whose retry carries
+// different attributes must be able to verify its own request was received intact.
+// Replaying the first send's digest would fail that check for a request that
+// legitimately succeeded.
+func TestSQS_MessageAttributes_FifoDedupReportsThisRequestsDigest(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	status, code := createQueueWithAttrs(t, srv, "attr-dedup.fifo",
+		map[string]string{"FifoQueue": "true"}, false)
+	require.Equal(t, http.StatusOK, status, "create failed: %s", code)
+	queueURL := "http://sqs.us-east-1.localhost/000000000000/attr-dedup.fifo"
+
+	send := func(attrs []sqsMessageAttr) string {
+		t.Helper()
+		params := map[string]string{
+			"Action":                 "SendMessage",
+			"QueueUrl":               queueURL,
+			"MessageBody":            "body",
+			"MessageGroupId":         "g1",
+			"MessageDeduplicationId": "dedup-1",
+		}
+		for i, a := range attrs {
+			base := "MessageAttribute." + strconv.Itoa(i+1) + "."
+			params[base+"Name"] = a.name
+			params[base+"Value.DataType"] = a.dataType
+			params[base+"Value.StringValue"] = a.stringValue
+		}
+		resp := sqsRequest(t, srv, params)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var parsed struct {
+			Result struct {
+				MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes"`
+			} `xml:"SendMessageResult"`
+		}
+		require.NoError(t, xml.Unmarshal([]byte(readBody(t, resp)), &parsed))
+		return parsed.Result.MD5OfMessageAttributes
+	}
+
+	firstDigest := send([]sqsMessageAttr{
+		{name: "SOME_Valid.attribute-Name", dataType: "Number", stringValue: "1493147359900"},
+	})
+	assert.Equal(t, "36655e7e9d7c0e8479fa3f3f42247ae7", firstDigest)
+
+	// Same deduplication ID, different attributes: the send is deduplicated, and the
+	// digest describes this request rather than the stored message.
+	secondDigest := send([]sqsMessageAttr{
+		{name: "different", dataType: "String", stringValue: "value"},
+	})
+	assert.NotEqual(t, firstDigest, secondDigest,
+		"a deduplicated send must digest this request's attributes")
+	assert.NotEmpty(t, secondDigest)
+}

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -841,13 +841,26 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		urlKey := sqsURLKey(queueURL)
 		if existing, dupMsgID := p.checkFIFODedup(context.Background(), urlKey, dedupID, p.tc.Now()); existing {
 			// Return success with original message ID (idempotent).
+			//
+			// The attribute digest is computed over *this* request's attributes rather
+			// than the deduplicated original's, because the digest is a checksum of
+			// what the caller sent — its purpose is letting a caller verify the
+			// service received the attributes intact. Reporting the earlier message's
+			// digest would fail that check for a caller whose retry is byte-identical
+			// only in its deduplication ID.
 			md5Body := computeMD5(msgBody)
+			md5Attrs := sqsMD5OfMessageAttributes(msgAttrs)
 			if sqsIsJSONProtocol(req) {
-				return sqsJSONResponse(http.StatusOK, map[string]string{"MessageId": dupMsgID, "MD5OfMessageBody": md5Body})
+				out := map[string]string{"MessageId": dupMsgID, "MD5OfMessageBody": md5Body}
+				if md5Attrs != "" {
+					out["MD5OfMessageAttributes"] = md5Attrs
+				}
+				return sqsJSONResponse(http.StatusOK, out)
 			}
 			type result struct {
-				MD5OfMessageBody string `xml:"MD5OfMessageBody"`
-				MessageID        string `xml:"MessageId"`
+				MD5OfMessageBody       string `xml:"MD5OfMessageBody"`
+				MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes,omitempty"`
+				MessageID              string `xml:"MessageId"`
 			}
 			type response struct {
 				XMLName           xml.Name         `xml:"SendMessageResponse"`
@@ -856,9 +869,13 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 				ResponseMetadata  responseMetadata `xml:"ResponseMetadata"`
 			}
 			return sqsXMLResponse(http.StatusOK, response{
-				Xmlns:             "http://queue.amazonaws.com/doc/2012-11-05/",
-				SendMessageResult: result{MD5OfMessageBody: md5Body, MessageID: dupMsgID},
-				ResponseMetadata:  responseMetadata{RequestID: ctx.RequestID},
+				Xmlns: "http://queue.amazonaws.com/doc/2012-11-05/",
+				SendMessageResult: result{
+					MD5OfMessageBody:       md5Body,
+					MD5OfMessageAttributes: md5Attrs,
+					MessageID:              dupMsgID,
+				},
+				ResponseMetadata: responseMetadata{RequestID: ctx.RequestID},
 			})
 		}
 		// Record this deduplication ID.
@@ -866,6 +883,7 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		p.recordFIFODedup(context.Background(), urlKey, dedupID, msgID, p.tc.Now())
 
 		md5Body := computeMD5(msgBody)
+		md5Attrs := sqsMD5OfMessageAttributes(msgAttrs)
 		now := p.tc.Now()
 		msg := &SQSMessage{
 			MessageID:     msgID,
@@ -876,11 +894,12 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 				"SenderId":      ctx.AccountID,
 				"SentTimestamp": strconv.FormatInt(now.UnixMilli(), 10),
 			},
-			SentTimestamp:  now.UnixMilli(),
-			DelayUntil:     now.Add(time.Duration(delay) * time.Second),
-			VisibleAfter:   time.Time{},
-			ReceiveCount:   0,
-			MessageGroupID: msgGroupID,
+			MessageAttributes: msgAttrs,
+			SentTimestamp:     now.UnixMilli(),
+			DelayUntil:        now.Add(time.Duration(delay) * time.Second),
+			VisibleAfter:      time.Time{},
+			ReceiveCount:      0,
+			MessageGroupID:    msgGroupID,
 		}
 		if saveErr := p.saveMsg(context.Background(), urlKey, msg); saveErr != nil {
 			return nil, fmt.Errorf("sqs sendMessage saveMsg: %w", saveErr)
@@ -894,11 +913,16 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 			return nil, fmt.Errorf("sqs sendMessage saveMsgIDs: %w", saveErr)
 		}
 		if sqsIsJSONProtocol(req) {
-			return sqsJSONResponse(http.StatusOK, map[string]string{"MessageId": msgID, "MD5OfMessageBody": md5Body})
+			out := map[string]string{"MessageId": msgID, "MD5OfMessageBody": md5Body}
+			if md5Attrs != "" {
+				out["MD5OfMessageAttributes"] = md5Attrs
+			}
+			return sqsJSONResponse(http.StatusOK, out)
 		}
 		type result struct {
-			MD5OfMessageBody string `xml:"MD5OfMessageBody"`
-			MessageID        string `xml:"MessageId"`
+			MD5OfMessageBody       string `xml:"MD5OfMessageBody"`
+			MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes,omitempty"`
+			MessageID              string `xml:"MessageId"`
 		}
 		type response struct {
 			XMLName           xml.Name         `xml:"SendMessageResponse"`
@@ -907,14 +931,19 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 			ResponseMetadata  responseMetadata `xml:"ResponseMetadata"`
 		}
 		return sqsXMLResponse(http.StatusOK, response{
-			Xmlns:             "http://queue.amazonaws.com/doc/2012-11-05/",
-			SendMessageResult: result{MD5OfMessageBody: md5Body, MessageID: msgID},
-			ResponseMetadata:  responseMetadata{RequestID: ctx.RequestID},
+			Xmlns: "http://queue.amazonaws.com/doc/2012-11-05/",
+			SendMessageResult: result{
+				MD5OfMessageBody:       md5Body,
+				MD5OfMessageAttributes: md5Attrs,
+				MessageID:              msgID,
+			},
+			ResponseMetadata: responseMetadata{RequestID: ctx.RequestID},
 		})
 	}
 
 	msgID := generateSQSMessageID()
 	md5Body := computeMD5(msgBody)
+	md5Attrs := sqsMD5OfMessageAttributes(msgAttrs)
 	now := p.tc.Now()
 
 	msg := &SQSMessage{
@@ -926,10 +955,11 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 			"SenderId":      ctx.AccountID,
 			"SentTimestamp": strconv.FormatInt(now.UnixMilli(), 10),
 		},
-		SentTimestamp: now.UnixMilli(),
-		DelayUntil:    now.Add(time.Duration(delay) * time.Second),
-		VisibleAfter:  time.Time{},
-		ReceiveCount:  0,
+		MessageAttributes: msgAttrs,
+		SentTimestamp:     now.UnixMilli(),
+		DelayUntil:        now.Add(time.Duration(delay) * time.Second),
+		VisibleAfter:      time.Time{},
+		ReceiveCount:      0,
 	}
 
 	urlKey := sqsURLKey(queueURL)
@@ -947,11 +977,16 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 	}
 
 	if sqsIsJSONProtocol(req) {
-		return sqsJSONResponse(http.StatusOK, map[string]string{"MessageId": msgID, "MD5OfMessageBody": md5Body})
+		out := map[string]string{"MessageId": msgID, "MD5OfMessageBody": md5Body}
+		if md5Attrs != "" {
+			out["MD5OfMessageAttributes"] = md5Attrs
+		}
+		return sqsJSONResponse(http.StatusOK, out)
 	}
 	type result struct {
-		MD5OfMessageBody string `xml:"MD5OfMessageBody"`
-		MessageID        string `xml:"MessageId"`
+		MD5OfMessageBody       string `xml:"MD5OfMessageBody"`
+		MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes,omitempty"`
+		MessageID              string `xml:"MessageId"`
 	}
 	type response struct {
 		XMLName           xml.Name         `xml:"SendMessageResponse"`
@@ -962,8 +997,9 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 	return sqsXMLResponse(http.StatusOK, response{
 		Xmlns: "http://queue.amazonaws.com/doc/2012-11-05/",
 		SendMessageResult: result{
-			MD5OfMessageBody: md5Body,
-			MessageID:        msgID,
+			MD5OfMessageBody:       md5Body,
+			MD5OfMessageAttributes: md5Attrs,
+			MessageID:              msgID,
 		},
 		ResponseMetadata: responseMetadata{RequestID: ctx.RequestID},
 	})
@@ -983,14 +1019,16 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 	now := p.tc.Now()
 
 	type successEntryXML struct {
-		ID               string `xml:"Id"`
-		MessageID        string `xml:"MessageId"`
-		MD5OfMessageBody string `xml:"MD5OfMessageBody"`
+		ID                     string `xml:"Id"`
+		MessageID              string `xml:"MessageId"`
+		MD5OfMessageBody       string `xml:"MD5OfMessageBody"`
+		MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes,omitempty"`
 	}
 	type successEntryJSON struct {
-		ID               string `json:"Id"`
-		MessageID        string `json:"MessageId"`
-		MD5OfMessageBody string `json:"MD5OfMessageBody"`
+		ID                     string `json:"Id"`
+		MessageID              string `json:"MessageId"`
+		MD5OfMessageBody       string `json:"MD5OfMessageBody"`
+		MD5OfMessageAttributes string `json:"MD5OfMessageAttributes,omitempty"`
 	}
 
 	var successesXML []successEntryXML
@@ -1031,10 +1069,11 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 					"SenderId":      ctx.AccountID,
 					"SentTimestamp": strconv.FormatInt(now.UnixMilli(), 10),
 				},
-				SentTimestamp: now.UnixMilli(),
-				DelayUntil:    now.Add(time.Duration(entry.DelaySeconds) * time.Second),
-				VisibleAfter:  time.Time{},
-				ReceiveCount:  0,
+				MessageAttributes: entry.MessageAttributes,
+				SentTimestamp:     now.UnixMilli(),
+				DelayUntil:        now.Add(time.Duration(entry.DelaySeconds) * time.Second),
+				VisibleAfter:      time.Time{},
+				ReceiveCount:      0,
 			}
 			if saveErr := p.saveMsg(context.Background(), urlKey, msg); saveErr != nil {
 				return nil, fmt.Errorf("sqs sendMessageBatch saveMsg: %w", saveErr)
@@ -1047,7 +1086,12 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 			if saveErr := p.saveMsgIDs(context.Background(), urlKey, ids); saveErr != nil {
 				return nil, fmt.Errorf("sqs sendMessageBatch saveMsgIDs: %w", saveErr)
 			}
-			successesJSON = append(successesJSON, successEntryJSON{ID: entry.ID, MessageID: msgID, MD5OfMessageBody: md5Body})
+			successesJSON = append(successesJSON, successEntryJSON{
+				ID:                     entry.ID,
+				MessageID:              msgID,
+				MD5OfMessageBody:       md5Body,
+				MD5OfMessageAttributes: sqsMD5OfMessageAttributes(entry.MessageAttributes),
+			})
 		}
 		if successesJSON == nil {
 			successesJSON = make([]successEntryJSON, 0)
@@ -1078,13 +1122,15 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 	}
 
 	for i := 1; ; i++ {
-		entryID := req.Params[fmt.Sprintf("SendMessageBatchRequestEntry.%d.Id", i)]
+		entryPrefix := fmt.Sprintf("SendMessageBatchRequestEntry.%d.", i)
+		entryID := req.Params[entryPrefix+"Id"]
 		if entryID == "" {
 			break
 		}
-		body := req.Params[fmt.Sprintf("SendMessageBatchRequestEntry.%d.MessageBody", i)]
-		delayStr := req.Params[fmt.Sprintf("SendMessageBatchRequestEntry.%d.DelaySeconds", i)]
+		body := req.Params[entryPrefix+"MessageBody"]
+		delayStr := req.Params[entryPrefix+"DelaySeconds"]
 		delay, _ := strconv.Atoi(delayStr)
+		entryAttrs := sqsQueryMessageAttributes(req.Params, entryPrefix)
 
 		msgID := generateSQSMessageID()
 		md5Body := computeMD5(body)
@@ -1098,10 +1144,11 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 				"SenderId":      ctx.AccountID,
 				"SentTimestamp": strconv.FormatInt(now.UnixMilli(), 10),
 			},
-			SentTimestamp: now.UnixMilli(),
-			DelayUntil:    now.Add(time.Duration(delay) * time.Second),
-			VisibleAfter:  time.Time{},
-			ReceiveCount:  0,
+			MessageAttributes: entryAttrs,
+			SentTimestamp:     now.UnixMilli(),
+			DelayUntil:        now.Add(time.Duration(delay) * time.Second),
+			VisibleAfter:      time.Time{},
+			ReceiveCount:      0,
 		}
 
 		if saveErr := p.saveMsg(context.Background(), urlKey, msg); saveErr != nil {
@@ -1117,7 +1164,12 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 			return nil, fmt.Errorf("sqs sendMessageBatch saveMsgIDs: %w", saveErr)
 		}
 
-		successesXML = append(successesXML, successEntryXML{ID: entryID, MessageID: msgID, MD5OfMessageBody: md5Body})
+		successesXML = append(successesXML, successEntryXML{
+			ID:                     entryID,
+			MessageID:              msgID,
+			MD5OfMessageBody:       md5Body,
+			MD5OfMessageAttributes: sqsMD5OfMessageAttributes(entryAttrs),
+		})
 	}
 
 	type result struct {
@@ -1204,19 +1256,30 @@ func (p *SQSPlugin) receiveMessage(ctx *RequestContext, req *AWSRequest) (*AWSRe
 		return nil, err
 	}
 
+	// Attributes are returned only for the names the request asked for (#461).
+	// Volunteering them unconditionally would be its own infidelity: a consumer whose
+	// production caller never sets MessageAttributeNames would see substrate hand back
+	// attributes real SQS withholds, so the routing branch their test exercises is not
+	// the branch that runs against AWS.
+	requestedAttrNames := sqsRequestedAttributeNames(req)
+
 	type msgResultXML struct {
-		MessageID      string `xml:"MessageId"`
-		ReceiptHandle  string `xml:"ReceiptHandle"`
-		MD5OfBody      string `xml:"MD5OfBody"`
-		Body           string `xml:"Body"`
-		MessageGroupID string `xml:"MessageGroupId,omitempty"`
+		MessageID              string                   `xml:"MessageId"`
+		ReceiptHandle          string                   `xml:"ReceiptHandle"`
+		MD5OfBody              string                   `xml:"MD5OfBody"`
+		Body                   string                   `xml:"Body"`
+		MD5OfMessageAttributes string                   `xml:"MD5OfMessageAttributes,omitempty"`
+		MessageAttribute       []sqsMessageAttributeXML `xml:"MessageAttribute,omitempty"`
+		MessageGroupID         string                   `xml:"MessageGroupId,omitempty"`
 	}
 	type msgResultJSON struct {
-		MessageID      string `json:"MessageId"`
-		ReceiptHandle  string `json:"ReceiptHandle"`
-		MD5OfBody      string `json:"MD5OfBody"`
-		Body           string `json:"Body"`
-		MessageGroupID string `json:"MessageGroupId,omitempty"`
+		MessageID              string                         `json:"MessageId"`
+		ReceiptHandle          string                         `json:"ReceiptHandle"`
+		MD5OfBody              string                         `json:"MD5OfBody"`
+		Body                   string                         `json:"Body"`
+		MD5OfMessageAttributes string                         `json:"MD5OfMessageAttributes,omitempty"`
+		MessageAttributes      map[string]SQSMessageAttribute `json:"MessageAttributes,omitempty"`
+		MessageGroupID         string                         `json:"MessageGroupId,omitempty"`
 	}
 
 	messagesXML := make([]msgResultXML, 0)
@@ -1262,21 +1325,31 @@ func (p *SQSPlugin) receiveMessage(ctx *RequestContext, req *AWSRequest) (*AWSRe
 			continue
 		}
 
+		// The digest covers what is being returned, not what was sent: a request
+		// naming a subset gets the digest of that subset, which is what lets a caller
+		// checksum the attributes actually in hand. Reusing the send-time digest would
+		// hand them a value their own recomputation could never match.
+		selectedAttrs := sqsSelectMessageAttributes(msg.MessageAttributes, requestedAttrNames)
+
 		if sqsIsJSONProtocol(req) {
 			messagesJSON = append(messagesJSON, msgResultJSON{
-				MessageID:      msg.MessageID,
-				ReceiptHandle:  newHandle,
-				MD5OfBody:      msg.MD5OfBody,
-				Body:           msg.Body,
-				MessageGroupID: msg.MessageGroupID,
+				MessageID:              msg.MessageID,
+				ReceiptHandle:          newHandle,
+				MD5OfBody:              msg.MD5OfBody,
+				Body:                   msg.Body,
+				MD5OfMessageAttributes: sqsMD5OfMessageAttributes(selectedAttrs),
+				MessageAttributes:      selectedAttrs,
+				MessageGroupID:         msg.MessageGroupID,
 			})
 		} else {
 			messagesXML = append(messagesXML, msgResultXML{
-				MessageID:      msg.MessageID,
-				ReceiptHandle:  newHandle,
-				MD5OfBody:      msg.MD5OfBody,
-				Body:           msg.Body,
-				MessageGroupID: msg.MessageGroupID,
+				MessageID:              msg.MessageID,
+				ReceiptHandle:          newHandle,
+				MD5OfBody:              msg.MD5OfBody,
+				Body:                   msg.Body,
+				MD5OfMessageAttributes: sqsMD5OfMessageAttributes(selectedAttrs),
+				MessageAttribute:       sqsMessageAttributesXML(selectedAttrs),
+				MessageGroupID:         msg.MessageGroupID,
 			})
 		}
 	}


### PR DESCRIPTION
Closes #461

## The defect

#454 parsed message attributes in order to *measure* them against `MaximumMessageSize`, and then dropped them on the floor:

- `SQSMessage.MessageAttributes` existed in `sqs_types.go` and was never populated at any of the four message-construction sites.
- `receiveMessage` had no attribute handling at all — no selector parsing, no response fields.

A consumer routing on an attribute — a `messageType` discriminator, a trace ID, a tenant key — saw **every message fall to its default branch**, with no error to explain why. The attribute was simply not there, which reads as "the producer didn't set it" rather than "the emulator dropped it."

## What now works

`SendMessage`, `SendMessageBatch` and `ReceiveMessage` all carry attributes, under both the query and JSON protocols.

**Attributes are returned only for the names a receive asks for.** This is the trap in the permissive direction: a consumer whose production caller never sets `MessageAttributeNames` would pass against an emulator that volunteered them, then read none from real SQS. All documented selector forms work:

| `MessageAttributeName` | Returned |
|---|---|
| omitted | nothing |
| `All` / `.*` | every attribute |
| `messageType` | that attribute, if present |
| `trace.*` | every attribute named `trace.…` |

A named attribute the message doesn't carry is absent rather than an error — the selector says what to return, not that it must exist.

## `MD5OfMessageAttributes`

Implemented from the developer guide's "Calculating the MD5 message digest for message attributes": sort by name, then per attribute a 4-byte big-endian length + UTF-8 name, the same for the data type, one transport byte (`1` String/Number, `2` Binary), then the value's length and bytes.

**Pinned against three real-AWS digests**, captured in moto's suite from recorded live responses. This is what makes #461's "verified against a known-good digest" acceptance criterion satisfiable with **no network access** — the vectors ship in the test file with their provenance, and they are not interchangeable:

| Vector | Digest | What it pins |
|---|---|---|
| 1 | `36655e7e9d7c0e8479fa3f3f42247ae7` | minimal single-attribute case |
| 2 | `b12289320bb6e494b18b645ef562b4a9` | a custom data-type suffix is hashed **in full** — fails if `Number.java.lang.Long` is truncated to `Number` |
| 3 | `049075255ebc53fb95f7f9f3cedf3c50` | a binary value is hashed **raw, not base64** — the base64 form of the same input digests to `5ff413c9dc7bd18abea88ca05643f902` |

Vector 3 is the same raw-versus-encoded distinction #454 drew for size measurement, except this time there's a hash to settle it rather than an argument from the docs. Base64 is what travels on the wire, so hashing it is the natural mistake.

Three further behaviours, each with its own test:

- **Omitted entirely** for a message with no attributes, rather than reported as the MD5 of zero bytes (`d41d8cd9…`). A digest of nothing is a value a caller could compare against and "successfully" verify — worse than no value.
- **On a receive, the digest covers what is returned**, not what was sent. A request naming a subset gets that subset's digest, because the digest exists to let a caller checksum the attributes in hand; replaying the send-time value would fail that check for a request that legitimately succeeded.
- **A deduplicated FIFO send reports its own request's digest**, not the stored original's — same reasoning.

Attributes are emitted in name order. Real SQS promises no order, but a Go map iterates randomly, so map order would make two identical requests produce different responses — the one property this emulator exists to provide.

## Mutation-tested

All six mutants compiled (`go vet` gate) and were caught:

| Mutation | Caught by |
|---|---|
| Hash binary as base64 | vector 3 |
| Return attributes unconditionally | `ReturnedOnlyWhenRequested/omitted_returns_none` + subset-digest test |
| Drop the digest's sort | vector 2, `DigestIsOrderIndependent`, subset-digest test |
| Replay send-time digest on receive | `ReceiveDigestCoversTheReturnedSubset` |
| Strip the custom data-type suffix | vector 2 |
| Key binary off `BinaryValue` presence instead of `DataType` | `BinaryIsIdentifiedByDataType` |

The last one **initially survived** — my first attempt at that test asserted an inequality that held for the wrong reason. It's now pinned to a digest derived from the published algorithm (`6f8879e6be14e9d1c45ef3e9631b86c9`; the value-keyed variant yields `e275a101bd238d68e457c2f49e1ad0e7`), and the mutant fails. Noting it because the test's value is entirely in that distinction: an empty-valued `Binary` attribute is the only input where the two rules diverge, and real SQS rejects it outright, so there's no captured digest to compare against.

## Tests

`emulator/sqs_messageattributes_test.go` — 10 tests, all `bothProtocols` where protocol-independent: the three known-good vectors, order-independence, omission with no attributes, full round-trip of String/Number/custom-Number/Binary (binary byte-identical after base64), the eight selection outcomes, receive-time subset digest, batch round-trip with per-entry digests, survival across redelivery, the `Binary`-by-data-type case, and a 10-attribute message accepted as the boundary.

## Verification

From the repo root: `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race) green, `make docs-reference-check docs-versions` green, `test/e2e` green.

## Docs

`docs/services.md` gains §"Message attributes" with the selector table, the digest algorithm and both load-bearing details, the omission rule, the receive-subset rule, and the ordering note. The stale "substrate does not yet store them or return them from `ReceiveMessage`" line in §"Message size enforcement" is replaced with a pointer. The three SQS operation rows link to the new section.

Recorded as **not enforced** (follow-ups): the documented 10-attribute maximum, and the attribute-name character rules (no `AWS.`/`Amazon.` prefix, no leading/trailing/sequential periods). Both are newly reachable now that attributes are stored.