### PR TITLE
fix(s3): enforce BlockPublicAcls and BlockPublicPolicy (#458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   this rather than implying a doc citation.
 
 ### Fixed
+- S3: `BlockPublicAcls` and `BlockPublicPolicy` are now enforced rather than merely
+  recorded (#458). #446 made the four Block Public Access settings storable and
+  readable, and nothing acted on any of them — so a consumer whose test asserted "once
+  we lock the bucket down, a public ACL is refused" got a green test that verified
+  nothing, and the assertion would have to be written a second time before it ever ran
+  against AWS. A bucket with `BlockPublicAcls` set now refuses a public ACL on
+  `PutBucketAcl` and `PutObjectAcl`, and one with `BlockPublicPolicy` set refuses a
+  public policy on `PutBucketPolicy`, both with `403 AccessDenied` / `Access Denied`.
+
+  **A rejection stores nothing.** The check runs before the write, so the bucket or
+  object keeps the ACL or policy it already had — "existing policies and ACLs for
+  buckets and objects aren't modified". Deleting the configuration re-allows what it was
+  refusing, matching the documented reversibility. `PutObjectAcl` reads the *bucket's*
+  configuration: "Amazon S3 doesn't support block public access settings on a per-object
+  basis".
+
+  **A public policy is decided by assuming public and then disqualifying, not by
+  looking for `Principal: "*"`.** This is the substance of the change and it is stricter
+  than the wildcard check the obvious reading suggests. Per the user guide, S3 "begins by
+  assuming that the policy is public" and a statement qualifies as non-public only when
+  it grants access solely to *fixed* values — no `*`, no `?`, no `${...}` IAM policy
+  variable — through its `Principal` or through a `Condition` on one of the documented
+  keys (`aws:SourceIp`, `aws:SourceArn`, `aws:SourceVpc`, `aws:SourceVpce`,
+  `aws:SourceOwner`, `aws:SourceAccount`, `aws:userid`, `aws:PrincipalOrgID`,
+  `aws:PrincipalArn`, `aws:PrincipalAccount`, `s3:DataAccessPointArn`,
+  `s3:DataAccessPointAccount`). So `Principal: "*"` narrowed by `StringLike
+  aws:SourceVpc: "vpc-*"` **is public** — the narrowing value is itself a wildcard —
+  where the same statement with `StringEquals aws:SourceVpc: "vpc-91237329"` is not.
+  Only an `Allow` can make a policy public, and one surviving public statement makes the
+  whole policy public: the guide's own example, where a single public statement disables
+  an otherwise-legal cross-account grant.
+
+  The `aws:SourceIp` breadth rule is implemented too, including the exclusion that makes
+  it usable: a range "broader than `/8` for IPv4 and `/32` for IPv6 (excluding RFC1918
+  private ranges)" pins nothing, so a policy conditioned on `0.0.0.0/0` is public
+  despite containing no wildcard character, while `10.0.0.0/8` and a unique-local IPv6
+  prefix are not. So is the `s3:DataAccessPointArn` carve-out, where a wildcard
+  access-point name does not make a *bucket* policy public as long as the account ID is
+  fixed.
+
+  **A public ACL is one granting any permission to `AllUsers` or
+  `AuthenticatedUsers`** — matched on the grantee URI, with the permission not
+  inspected, so `WRITE_ACP` counts as much as `READ`. `AuthenticatedUsers` is every AWS
+  account rather than every account in yours, which is why it counts despite the name and
+  why it can only arrive through an XML body: the canned-ACL resolver never emits it.
+  All three documented forms are covered — the `x-amz-acl` canned header, an XML `Grant`
+  naming a public group, and an `x-amz-grant-*` header whose grantee list contains one.
+  The grant headers were previously unread anywhere in substrate and are parsed for this
+  check only; an ACL set through them is still not stored, which is a separate gap.
+
+  **Provenance:** none of `PutBucketAcl`, `PutObjectAcl` or `PutBucketPolicy` documents
+  an Errors section covering this, so the `AccessDenied` / `Access Denied` / `403` triple
+  comes from observed real-AWS behaviour rather than from the API model — a blocked
+  `PutBucketPolicy` surfaces through the CLI as `An error occurred (AccessDenied) when
+  calling the PutBucketPolicy operation: Access Denied`. The definitions of "public" are
+  quoted from the user guide's *Blocking public access → The meaning of "public"*.
+
+  Three things stay as they were, deliberately. `IgnorePublicAcls` and
+  `RestrictPublicBuckets` remain recorded-only: both govern how an incoming request is
+  evaluated against an ACL or policy already in place rather than which write is refused,
+  and substrate has no unauthenticated or cross-account request path to deny. `PutObject`
+  and `CreateBucket` with a public ACL are not refused, because neither handler reads
+  `x-amz-acl` at all — covering them means modelling ACL-on-create first. And a body that
+  parses as JSON but not as a policy document is not treated as public: `PutBucketPolicy`
+  already rejects non-JSON with `400 MalformedPolicy`, and the new check is not a second
+  validity check. An unconfigured bucket, and one whose four settings are all `false`,
+  behave exactly as they did before enforcement existed — the case that guards #446.
+
 - SQS: message attributes are now stored on send and returned on receive (#461). #454
   parsed them in order to measure them against `MaximumMessageSize` and then discarded
   them: `SQSMessage.MessageAttributes` existed and was never populated, and

--- a/docs/services.md
+++ b/docs/services.md
@@ -204,15 +204,15 @@ STS operations are free.
 | AbortMultipartUpload | |
 | ListMultipartUploads | Emits `<StorageClass>` per in-progress upload |
 | GetBucketPolicy | |
-| PutBucketPolicy | |
+| PutBucketPolicy | `403 AccessDenied` for a public policy when `BlockPublicPolicy` is set — see [Block Public Access](#block-public-access) |
 | DeleteBucketPolicy | |
-| PutPublicAccessBlock | Records the configuration; a partial body reports omitted settings as `false` — see [Block Public Access](#block-public-access) |
+| PutPublicAccessBlock | Records the configuration and enforces `BlockPublicAcls` / `BlockPublicPolicy`; a partial body reports omitted settings as `false` — see [Block Public Access](#block-public-access) |
 | GetPublicAccessBlock | `404 NoSuchPublicAccessBlockConfiguration` when the bucket has none — see [Block Public Access](#block-public-access) |
 | DeletePublicAccessBlock | Idempotent; removes only the configuration, never the bucket — see [Block Public Access](#block-public-access) |
 | GetBucketAcl | |
-| PutBucketAcl | |
+| PutBucketAcl | Accepts a canned `x-amz-acl` or an XML body; `403 AccessDenied` for a public ACL when `BlockPublicAcls` is set — see [Block Public Access](#block-public-access) |
 | GetObjectAcl | |
-| PutObjectAcl | |
+| PutObjectAcl | `403 AccessDenied` for a public ACL when the *bucket* has `BlockPublicAcls` set — see [Block Public Access](#block-public-access) |
 | GetBucketNotificationConfiguration | |
 | PutBucketNotificationConfiguration | Triggers Lambda/SQS on PutObject/DeleteObject |
 | PutBucketTagging | |
@@ -726,10 +726,90 @@ SDKs and CloudFormation both do.
 configuration. Deleting one that was never written is a `204`, which is what a
 teardown path that deletes unconditionally relies on.
 
-**The settings are recorded, not enforced.** Nothing rejects a public ACL or a public
-bucket policy on a bucket with `BlockPublicAcls` or `BlockPublicPolicy` set. Those are
-the resource-internal consequences of the setting rather than the setting itself;
-enforcement is tracked separately.
+**`BlockPublicAcls` and `BlockPublicPolicy` are enforced at request time.** A bucket
+carrying either setting refuses the call that would make it public:
+
+| Setting | Refuses | Response |
+|---------|---------|----------|
+| `BlockPublicAcls` | `PutBucketAcl`, `PutObjectAcl` with a public ACL | `403 AccessDenied` / `Access Denied` |
+| `BlockPublicPolicy` | `PutBucketPolicy` with a public policy | `403 AccessDenied` / `Access Denied` |
+
+A rejection stores nothing: the bucket or object keeps the ACL or policy it already
+had, matching "existing policies and ACLs for buckets and objects aren't modified".
+Deleting the configuration re-allows what it was refusing, per "removing a block
+public access setting causes a bucket or object with a public policy or ACL to again
+be publicly accessible". The configuration read for `PutObjectAcl` is the *bucket's* —
+"Amazon S3 doesn't support block public access settings on a per-object basis".
+
+Neither operation documents an Errors section covering this, so the `AccessDenied` /
+`Access Denied` / `403` triple comes from observed real-AWS behaviour rather than from
+the API model: a blocked `PutBucketPolicy` surfaces through the CLI as `An error
+occurred (AccessDenied) when calling the PutBucketPolicy operation: Access Denied`.
+
+**A public ACL is one that grants any permission to a predefined public group.**
+Substrate matches the grantee URI against
+`http://acs.amazonaws.com/groups/global/AllUsers` and
+`.../AuthenticatedUsers`, per "Amazon S3 considers a bucket or object ACL public if it
+grants any permissions to members of the predefined `AllUsers` or `AuthenticatedUsers`
+groups". `AuthenticatedUsers` is every AWS account, not every account in yours, which
+is why it counts despite the name. The permission itself is not inspected — `READ`,
+`WRITE`, `READ_ACP`, `WRITE_ACP` and `FULL_CONTROL` all count. All three ways a public
+ACL arrives are covered: the `x-amz-acl` canned header (`public-read`,
+`public-read-write`), an XML `Grant` naming a public group URI, and an
+`x-amz-grant-*` header whose grantee list contains one. The grant headers are read for
+this check only; substrate does not otherwise model them, so an ACL set through them
+is still not stored.
+
+**A public policy is decided by assuming public and then trying to disqualify —
+not by looking for `Principal: "*"`.** This is stronger than wildcard-detection and is
+the part a naive implementation gets backwards. Per "When evaluating a bucket policy,
+Amazon S3 begins by assuming that the policy is public. It then evaluates the policy to
+determine whether it qualifies as non-public", a statement is non-public only when it
+grants access solely to *fixed* values — no `*`, no `?`, no `${...}` IAM policy
+variable — either through its `Principal` or through a `Condition` on one of
+`aws:SourceIp`, `aws:SourceArn`, `aws:SourceVpc`, `aws:SourceVpce`, `aws:SourceOwner`,
+`aws:SourceAccount`, `aws:userid`, `aws:PrincipalOrgID`, `aws:PrincipalArn`,
+`aws:PrincipalAccount`, `s3:DataAccessPointArn` or `s3:DataAccessPointAccount`.
+
+The consequence, and AWS's own example:
+
+| Policy | Public? |
+|--------|---------|
+| `Principal: "*"`, no condition | yes |
+| `Principal: "*"` + `StringLike aws:SourceVpc: "vpc-*"` | **yes** — the narrowing value is itself a wildcard |
+| `Principal: "*"` + `StringEquals aws:SourceVpc: "vpc-91237329"` | no |
+| `Principal: {"AWS": "arn:aws:iam::123456789012:root"}` | no |
+| `Principal: {"AWS": "arn:aws:iam::123456789012:user/*"}` | yes |
+| `Principal: "*"` + `aws:SourceIp: "203.0.113.0/24"` | no |
+| `Principal: "*"` + `aws:SourceIp: "0.0.0.0/1"` | **yes** — broader than `/8` |
+| `Effect: Deny`, `Principal: "*"` | no |
+| A fixed cross-account grant **plus** one public statement | yes |
+
+Three further rules follow from the same page. Only an `Allow` can make a policy
+public. A single surviving public statement makes the *whole* policy public — the
+guide's worked example, where one public statement disables an otherwise-legal
+cross-account grant. And an `aws:SourceIp` range pins nothing when it is "broader than
+`/8` for IPv4 and `/32` for IPv6 (excluding RFC1918 private ranges)", so a bucket
+policy conditioned on `0.0.0.0/0` is public even though it contains no wildcard
+character; the RFC1918 exclusion is what keeps a unique-local IPv6 range from tripping
+the `/32` bound.
+
+A body that parses as JSON but not as a policy document is **not** treated as public.
+`PutBucketPolicy` already rejects a non-JSON body with `400 MalformedPolicy` before
+this check runs, and the public-access check is not a second validity check — a
+malformed-but-JSON document keeps whatever answer it had before enforcement existed.
+
+**`IgnorePublicAcls` and `RestrictPublicBuckets` remain recorded-only.** Both govern
+how an *incoming* request is evaluated against an existing ACL or policy rather than
+which write is refused, and substrate has no unauthenticated or cross-account request
+path to deny — every request it serves is already the bucket owner's. Substrate also
+does not model the guide's unsupported-action clause (S3 treats a statement granting an
+action S3 does not support as potentially public), which would need an authoritative
+list of every supported `s3:` action.
+
+**`PutObject` and `CreateBucket` with a public ACL are not yet refused.** Real
+`BlockPublicAcls` rejects those too, but neither handler reads `x-amz-acl` at all, so
+covering them means first modelling ACL-on-create. Tracked separately.
 
 ### Betty CFN resource types
 

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -2409,6 +2409,19 @@ func (p *S3Plugin) putBucketPolicy(_ *RequestContext, req *AWSRequest, bucket st
 			"Bucket policy must be valid JSON.", http.StatusBadRequest), nil
 	}
 
+	// BlockPublicPolicy "causes Amazon S3 to reject calls to PutBucketPolicy if the
+	// specified bucket policy allows public access" (#458). The check runs before the
+	// Put so a rejected policy is not stored: "Enabling this setting doesn't affect
+	// existing access point or bucket policies", which means the bucket keeps whatever
+	// policy it had.
+	blocked, err := p.s3BlocksPublicPolicy(ctx, bucket)
+	if err != nil {
+		return nil, err
+	}
+	if blocked && s3PolicyIsPublic(policyJSON) {
+		return s3AccessDeniedResponse(), nil
+	}
+
 	pol := S3BucketPolicy{Policy: string(policyJSON)}
 	raw, err := json.Marshal(pol)
 	if err != nil {
@@ -2495,6 +2508,16 @@ func (p *S3Plugin) putBucketACL(_ *RequestContext, req *AWSRequest, bucket strin
 		acl = s3CannedACL(req.Headers["X-Amz-Acl"], bucket)
 	}
 
+	// BlockPublicAcls rejects a PutBucketAcl carrying a public ACL, without
+	// modifying the ACL already in place (#458). The check runs after the ACL is
+	// resolved from whichever of the three forms the caller used, so a canned
+	// header, an XML grant and an x-amz-grant-* header are all covered.
+	if denied, err := p.s3PublicACLDenied(ctx, bucket, acl, req.Headers); err != nil {
+		return nil, err
+	} else if denied != nil {
+		return denied, nil
+	}
+
 	raw, err := json.Marshal(acl)
 	if err != nil {
 		return nil, fmt.Errorf("marshal bucket acl: %w", err)
@@ -2564,6 +2587,14 @@ func (p *S3Plugin) putObjectACL(_ *RequestContext, req *AWSRequest, bucket, key 
 		}
 	} else {
 		acl = s3CannedACL(req.Headers["X-Amz-Acl"], bucket)
+	}
+
+	// The configuration consulted is the *bucket's*: Block Public Access has no
+	// per-object setting (#458).
+	if denied, err := p.s3PublicACLDenied(ctx, bucket, acl, req.Headers); err != nil {
+		return nil, err
+	} else if denied != nil {
+		return denied, nil
 	}
 
 	raw, err := json.Marshal(acl)

--- a/emulator/s3_publicaccess.go
+++ b/emulator/s3_publicaccess.go
@@ -1,0 +1,458 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// S3 predefined group URIs. A grant to either one is what makes an ACL public:
+// "Amazon S3 considers a bucket or object ACL public if it grants any permissions
+// to members of the predefined AllUsers or AuthenticatedUsers groups" (S3 user
+// guide, Blocking public access → The meaning of "public" → ACLs).
+//
+// AuthenticatedUsers is every AWS account, not every account in yours, which is
+// why it counts as public despite the name.
+const (
+	s3GroupAllUsers           = "http://acs.amazonaws.com/groups/global/AllUsers"
+	s3GroupAuthenticatedUsers = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+)
+
+// s3AccessDeniedResponse is the rejection Block Public Access returns for a
+// request that would make a bucket or object public.
+//
+// Neither PutBucketAcl, PutObjectAcl nor PutBucketPolicy documents an Errors
+// section covering this, so the code and message come from observed real-AWS
+// behavior rather than from the API model: a blocked PutBucketPolicy surfaces
+// through the CLI as "An error occurred (AccessDenied) when calling the
+// PutBucketPolicy operation: Access Denied" — code AccessDenied, HTTP 403, and
+// the message string "Access Denied" that S3 uses for every authorization
+// failure. Substrate returns the same triple so a consumer matching on the code
+// takes the branch it would take against AWS.
+func s3AccessDeniedResponse() *AWSResponse {
+	return s3ErrorResponse("AccessDenied", "Access Denied", http.StatusForbidden)
+}
+
+// s3LoadPublicAccessBlock returns a bucket's Block Public Access configuration,
+// or nil when the bucket has none.
+//
+// A nil return must behave exactly as substrate did before enforcement existed:
+// an unconfigured bucket accepts a public ACL and a public policy, which is both
+// what real S3 does for a bucket outside an account-level or organization-level
+// setting and what keeps the #446 tests — written against the record-only
+// behavior — passing unchanged.
+func (p *S3Plugin) s3LoadPublicAccessBlock(ctx context.Context, bucket string) (*S3PublicAccessBlockConfiguration, error) {
+	raw, err := p.state.Get(ctx, s3Namespace, s3PublicAccessBlockKey(bucket))
+	if err != nil {
+		return nil, fmt.Errorf("get public access block: %w", err)
+	}
+	if raw == nil {
+		return nil, nil
+	}
+	var cfg S3PublicAccessBlockConfiguration
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal public access block: %w", err)
+	}
+	return &cfg, nil
+}
+
+// s3BlocksPublicACLs reports whether a bucket's configuration rejects a public
+// ACL, and s3BlocksPublicPolicy whether it rejects a public bucket policy.
+//
+// Both read the bucket's own configuration. Block Public Access has no
+// per-object setting — "Amazon S3 doesn't support block public access settings on
+// a per-object basis" — so PutObjectAcl consults the bucket that holds the
+// object.
+func (p *S3Plugin) s3BlocksPublicACLs(ctx context.Context, bucket string) (bool, error) {
+	cfg, err := p.s3LoadPublicAccessBlock(ctx, bucket)
+	if err != nil {
+		return false, err
+	}
+	return cfg != nil && cfg.BlockPublicAcls, nil
+}
+
+// s3BlocksPublicPolicy reports whether a bucket's configuration rejects a public
+// bucket policy. See [S3Plugin.s3BlocksPublicACLs].
+func (p *S3Plugin) s3BlocksPublicPolicy(ctx context.Context, bucket string) (bool, error) {
+	cfg, err := p.s3LoadPublicAccessBlock(ctx, bucket)
+	if err != nil {
+		return false, err
+	}
+	return cfg != nil && cfg.BlockPublicPolicy, nil
+}
+
+// s3PublicACLDenied returns the 403 to send when a bucket blocks public ACLs and
+// the request carries one, or nil when the request may proceed.
+//
+// The ACL and the headers are both examined because they are two of the three ways
+// a public grant arrives: acl is what PutBucketAcl/PutObjectAcl resolved from the
+// XML body or the x-amz-acl canned header, and headers still needs reading for
+// x-amz-grant-*, which substrate does not fold into the resolved ACL.
+//
+// The error return is reserved for a state-store failure, which the caller must
+// propagate rather than report as an authorization decision.
+func (p *S3Plugin) s3PublicACLDenied(ctx context.Context, bucket string, acl S3AccessControlList, headers map[string]string) (*AWSResponse, error) {
+	blocked, err := p.s3BlocksPublicACLs(ctx, bucket)
+	if err != nil {
+		return nil, err
+	}
+	if !blocked {
+		return nil, nil
+	}
+	if s3ACLIsPublic(acl) || s3GrantHeadersArePublic(headers) {
+		return s3AccessDeniedResponse(), nil
+	}
+	return nil, nil
+}
+
+// s3ACLIsPublic reports whether an ACL grants any permission to a predefined
+// public group.
+//
+// "Any permissions" is literal: READ, WRITE, READ_ACP, WRITE_ACP and
+// FULL_CONTROL all count, and the permission itself is not inspected. Matching is
+// on the grantee URI rather than on the Type attribute, because the URI is what
+// identifies the group and a request may set Type to "Group" for a grantee that
+// is not one of the two public ones.
+func s3ACLIsPublic(acl S3AccessControlList) bool {
+	for _, grant := range acl.Grants {
+		switch grant.Grantee.URI {
+		case s3GroupAllUsers, s3GroupAuthenticatedUsers:
+			return true
+		}
+	}
+	return false
+}
+
+// s3GrantHeaderNames are the x-amz-grant-* headers PutBucketAcl and PutObjectAcl
+// accept, each naming grantees for one permission.
+//
+// Substrate does not otherwise model these headers — an ACL set through them is
+// not stored, which is a separate gap. They are parsed here because a header
+// naming a public group URI is a public ACL expressed the third documented way,
+// and a Block Public Access check that ignored them would have a hole a consumer
+// could drive a public grant straight through.
+var s3GrantHeaderNames = []string{
+	"X-Amz-Grant-Read",
+	"X-Amz-Grant-Write",
+	"X-Amz-Grant-Read-Acp",
+	"X-Amz-Grant-Write-Acp",
+	"X-Amz-Grant-Full-Control",
+}
+
+// s3GrantHeadersArePublic reports whether any x-amz-grant-* header names a
+// predefined public group.
+//
+// The header value is a comma-separated list of grantees, each written as
+// type=value — for example `uri="http://acs.amazonaws.com/groups/global/AllUsers"`.
+// Values may be quoted, so quotes are trimmed before the comparison.
+func s3GrantHeadersArePublic(headers map[string]string) bool {
+	for _, name := range s3GrantHeaderNames {
+		value := headers[name]
+		if value == "" {
+			continue
+		}
+		for _, grantee := range strings.Split(value, ",") {
+			key, val, found := strings.Cut(strings.TrimSpace(grantee), "=")
+			if !found || !strings.EqualFold(strings.TrimSpace(key), "uri") {
+				continue
+			}
+			switch strings.Trim(strings.TrimSpace(val), `"`) {
+			case s3GroupAllUsers, s3GroupAuthenticatedUsers:
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// s3PolicyQualifyingConditionKeys are the condition keys that can qualify an
+// otherwise-public statement as non-public, from the S3 user guide's "The meaning
+// of 'public'" → Bucket policies list.
+//
+// aws:userid is on the list only "outside the pattern AROLEID:*", which
+// [s3ConditionValuePinsAccess] handles as part of the wildcard rule: a value
+// ending in ":*" contains a wildcard and therefore does not pin anything.
+//
+// The guide's first bullet is "An AWS principal, user, role, or service principal
+// (e.g. aws:PrincipalOrgID)", so the three keys that name a principal directly —
+// aws:PrincipalOrgID, aws:PrincipalArn and aws:PrincipalAccount — qualify on the
+// same footing as the explicitly-listed ones. Keys not named or exemplified by the
+// guide are deliberately absent: a key substrate accepted that S3 does not would
+// let a public policy through, which is the defect this check exists to close.
+//
+// Lookup is lowercased because IAM condition keys are case-insensitive.
+var s3PolicyQualifyingConditionKeys = map[string]bool{
+	"aws:sourceip":              true,
+	"aws:sourcearn":             true,
+	"aws:sourcevpc":             true,
+	"aws:sourcevpce":            true,
+	"aws:sourceowner":           true,
+	"aws:sourceaccount":         true,
+	"aws:userid":                true,
+	"aws:principalorgid":        true,
+	"aws:principalarn":          true,
+	"aws:principalaccount":      true,
+	"s3:dataaccesspointarn":     true,
+	"s3:dataaccesspointaccount": true,
+}
+
+// s3PolicyIsPublic reports whether a bucket policy grants public access, by
+// Block Public Access's own definition.
+//
+// The rule is inverted from the obvious one, and getting it backwards is the
+// trap: S3 does **not** look for a wildcard principal. "When evaluating a bucket
+// policy, Amazon S3 begins by assuming that the policy is public. It then
+// evaluates the policy to determine whether it qualifies as non-public. To be
+// considered non-public, a bucket policy must grant access only to fixed values
+// (values that don't contain a wildcard or an AWS Identity and Access Management
+// Policy Variable)" for a principal or one of the keys in
+// [s3PolicyQualifyingConditionKeys].
+//
+// The consequence a wildcard-detecting implementation gets wrong is the guide's
+// own worked example: `Principal: "*"` narrowed by
+// `StringLike aws:SourceVpc: "vpc-*"` **is public**, because the narrowing value
+// itself contains a wildcard. The same statement with
+// `StringEquals aws:SourceVpc: "vpc-91237329"` is not.
+//
+// A policy that does not parse as a policy document is not public. PutBucketPolicy
+// already rejects a non-JSON body with MalformedPolicy before this runs, and a body
+// that is JSON but not a policy document should not acquire a second rejection
+// reason here — substrate would be refusing something real S3 accepts or refuses
+// for an entirely different reason.
+//
+// Substrate does not model the guide's unsupported-action clause (S3 treats a
+// statement granting an action S3 does not support as potentially public). That
+// requires an authoritative list of every supported s3: action, which would go
+// stale silently.
+func s3PolicyIsPublic(policyJSON []byte) bool {
+	var doc PolicyDocument
+	if err := json.Unmarshal(policyJSON, &doc); err != nil {
+		return false
+	}
+	for i := range doc.Statement {
+		if s3StatementIsPublic(&doc.Statement[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// s3StatementIsPublic reports whether one statement makes a policy public.
+//
+// A single surviving public statement makes the whole policy public regardless of
+// what the others grant. That is the guide's worked example: a policy granting
+// CloudTrail access, a named second account access, and the public access
+// "qualifies as public because of the third statement", and S3 then disables the
+// cross-account grant too.
+func s3StatementIsPublic(stmt *PolicyStatement) bool {
+	// Only an Allow can grant public access; a Deny narrows. Effect is compared
+	// case-insensitively because IAM accepts "Allow" and "allow" alike.
+	if !strings.EqualFold(stmt.Effect, "Allow") {
+		return false
+	}
+
+	// A statement whose Principal names only fixed values is non-public on the
+	// principal alone and needs no condition.
+	if s3PrincipalIsFixed(stmt.Principal) {
+		return false
+	}
+
+	// Otherwise a condition must pin one of the documented keys to a fixed value.
+	for _, values := range stmt.Condition {
+		for key, vals := range values {
+			if !s3PolicyQualifyingConditionKeys[strings.ToLower(key)] {
+				continue
+			}
+			if s3ConditionPinsAccess(key, vals) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// s3PrincipalIsFixed reports whether a statement's Principal names only fixed
+// values.
+//
+// A nil Principal is treated as not fixed. A bucket policy is a resource policy
+// and Principal is required in one; a statement without one is malformed, and
+// assuming public for it is the direction that matches S3's assume-public start.
+func s3PrincipalIsFixed(principal *PolicyPrincipal) bool {
+	if principal == nil || principal.All {
+		return false
+	}
+	values := make([]string, 0, len(principal.AWS)+len(principal.Service)+len(principal.Federated))
+	values = append(values, principal.AWS...)
+	values = append(values, principal.Service...)
+	values = append(values, principal.Federated...)
+	if len(values) == 0 {
+		return false
+	}
+	for _, v := range values {
+		if !s3ValueIsFixed(v) {
+			return false
+		}
+	}
+	return true
+}
+
+// s3ConditionPinsAccess reports whether a condition key's values pin access to
+// fixed values.
+//
+// Every value must be fixed: a key set to both a fixed and a wildcard value still
+// admits the wildcard, so it pins nothing.
+//
+// Two keys carry documented departures from the plain fixed-value rule, and both
+// are handled here rather than in [s3ValueIsFixed] because they are properties of
+// the key, not of the string: aws:SourceIp adds a breadth test that a syntactically
+// fixed CIDR can still fail, and s3:DataAccessPointArn permits one wildcard that
+// does not make the policy public.
+func s3ConditionPinsAccess(key string, values []string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	if strings.EqualFold(key, "s3:DataAccessPointArn") {
+		return s3DataAccessPointARNsPinAccess(values)
+	}
+	for _, v := range values {
+		if !s3ValueIsFixed(v) {
+			return false
+		}
+	}
+	if strings.EqualFold(key, "aws:SourceIp") {
+		return s3SourceIPPinsAccess(values)
+	}
+	return true
+}
+
+// s3DataAccessPointARNsPinAccess reports whether every s3:DataAccessPointArn value
+// pins access.
+//
+// This key has an explicit carve-out from the wildcard rule, for bucket policies
+// only: "When used in a bucket policy, this value can contain a wildcard for the
+// access point name without rendering the policy public, as long as the account ID
+// is fixed. For example, allowing access to
+// arn:aws:s3:us-west-2:123456789012:accesspoint/* would permit access to any access
+// point associated with account 123456789012 in Region us-west-2, without rendering
+// the bucket policy public." The same statement in an *access point* policy would
+// render it public — substrate models bucket policies here, so the carve-out
+// applies.
+//
+// So the wildcard is allowed in the resource segment and nowhere else: every ARN
+// field up to and including the account ID must be fixed.
+func s3DataAccessPointARNsPinAccess(values []string) bool {
+	for _, v := range values {
+		// arn:partition:service:region:account-id:resource — six fields, and the
+		// resource is the only one permitted a wildcard.
+		fields := strings.SplitN(v, ":", 6)
+		if len(fields) != 6 {
+			// Not an ARN shape at all; fall back to the plain fixed-value rule.
+			if !s3ValueIsFixed(v) {
+				return false
+			}
+			continue
+		}
+		for _, field := range fields[:5] {
+			if strings.ContainsAny(field, "*?") || strings.Contains(field, "${") {
+				return false
+			}
+		}
+		if fields[4] == "" {
+			// An empty account ID pins nothing, wildcard or not.
+			return false
+		}
+	}
+	return true
+}
+
+// s3ValueIsFixed reports whether a policy value is fixed: no wildcard and no IAM
+// policy variable.
+//
+// The two wildcard characters IAM recognizes in a policy value are "*" and "?",
+// and a policy variable is written "${...}" — a value carrying any of them is not
+// fixed, per "values that don't contain a wildcard or an AWS Identity and Access
+// Management Policy Variable".
+func s3ValueIsFixed(value string) bool {
+	if value == "" {
+		return false
+	}
+	return !strings.ContainsAny(value, "*?") && !strings.Contains(value, "${")
+}
+
+// s3SourceIPPinsAccess reports whether every aws:SourceIp value is narrow enough
+// to count as fixed.
+//
+// A broad range pins nothing even though it contains no wildcard: "Bucket policies
+// that grant access conditioned on the aws:SourceIp condition key with very broad
+// IP ranges (for example, 0.0.0.0/1) are evaluated as 'public'. This includes
+// values broader than /8 for IPv4 and /32 for IPv6 (excluding RFC1918 private
+// ranges)."
+//
+// The prefix limits are read as inclusive: /8 is not "broader than /8", so an IPv4
+// /8 pins access and only /7 and above do not.
+//
+// The RFC1918 exclusion exists because a private range is never reachable from the
+// internet, so its breadth cannot make a bucket public. Under the inclusive reading
+// it cannot change an IPv4 answer — the broadest RFC1918 range is 10.0.0.0/8, which
+// the /8 bound already admits — but it is load-bearing for IPv6, where the
+// unique-local range is fc00::/7 and every prefix inside it is far broader than the
+// /32 bound. It is written for both families rather than IPv6 only so the rule in
+// the code is the rule in the guide.
+//
+// A value that is neither a prefix nor a bare address does not pin access. That is
+// the assume-public direction, and real S3 rejects a malformed aws:SourceIp value
+// outright.
+func s3SourceIPPinsAccess(values []string) bool {
+	for _, v := range values {
+		if !s3SourceIPValuePinsAccess(v) {
+			return false
+		}
+	}
+	return true
+}
+
+// s3SourceIPValuePinsAccess reports whether one aws:SourceIp value is narrow
+// enough to count as fixed. See [s3SourceIPPinsAccess].
+func s3SourceIPValuePinsAccess(value string) bool {
+	prefix, err := netip.ParsePrefix(value)
+	if err != nil {
+		// A bare address is a single host, the narrowest possible range.
+		addr, addrErr := netip.ParseAddr(value)
+		return addrErr == nil && addr.IsValid()
+	}
+	if s3PrefixIsPrivate(prefix) {
+		return true
+	}
+	if prefix.Addr().Is4() {
+		return prefix.Bits() >= 8
+	}
+	return prefix.Bits() >= 32
+}
+
+// s3RFC1918Prefixes are the private IPv4 ranges the breadth rule excludes.
+var s3RFC1918Prefixes = []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+
+// s3PrefixIsPrivate reports whether a prefix lies entirely within an RFC1918
+// private range.
+//
+// Containment is tested rather than equality, so 10.1.0.0/16 is private as well as
+// 10.0.0.0/8. [netip.Addr.IsPrivate] covers the IPv6 unique-local range too, which
+// is the same reasoning applied to the address family the /32 bound governs.
+func s3PrefixIsPrivate(prefix netip.Prefix) bool {
+	if prefix.Addr().Is6() {
+		return prefix.Addr().IsPrivate()
+	}
+	for _, p := range s3RFC1918Prefixes {
+		private, err := netip.ParsePrefix(p)
+		if err != nil {
+			continue
+		}
+		if private.Bits() <= prefix.Bits() && private.Contains(prefix.Addr()) {
+			return true
+		}
+	}
+	return false
+}

--- a/emulator/s3_publicaccess_test.go
+++ b/emulator/s3_publicaccess_test.go
@@ -1,0 +1,717 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// Public-group grantee URIs, spelled out here rather than imported so a change to
+// the constants in the package under test has to be reflected deliberately.
+const (
+	testGroupAllUsers           = "http://acs.amazonaws.com/groups/global/AllUsers"
+	testGroupAuthenticatedUsers = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+)
+
+// pabBlockACLsOnly and pabBlockPolicyOnly turn on exactly one of the two settings
+// substrate enforces, so a test proving one is enforced cannot pass because the
+// other happened to fire.
+const (
+	pabBlockACLsOnly = `<?xml version="1.0" encoding="UTF-8"?>
+<PublicAccessBlockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <BlockPublicAcls>true</BlockPublicAcls>
+</PublicAccessBlockConfiguration>`
+
+	pabBlockPolicyOnly = `<?xml version="1.0" encoding="UTF-8"?>
+<PublicAccessBlockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <BlockPublicPolicy>true</BlockPublicPolicy>
+</PublicAccessBlockConfiguration>`
+
+	// pabAllFalse is the configuration that exists but blocks nothing. It is the
+	// case that distinguishes "configured, all four false" from "unconfigured", and
+	// the gate on not having regressed the record-only behavior of #446.
+	pabAllFalse = `<?xml version="1.0" encoding="UTF-8"?>
+<PublicAccessBlockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <BlockPublicAcls>false</BlockPublicAcls>
+  <IgnorePublicAcls>false</IgnorePublicAcls>
+  <BlockPublicPolicy>false</BlockPublicPolicy>
+  <RestrictPublicBuckets>false</RestrictPublicBuckets>
+</PublicAccessBlockConfiguration>`
+)
+
+// aclXML builds an AccessControlPolicy body granting permission to a grantee URI,
+// which is how an ACL arrives when it is not one of the canned values.
+func aclXML(granteeURI, permission string) string {
+	if granteeURI == "" {
+		return `<?xml version="1.0" encoding="UTF-8"?>
+<AccessControlPolicy>
+  <Owner><ID>owner-id</ID><DisplayName>owner</DisplayName></Owner>
+  <AccessControlList>
+    <Grant>
+      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
+        <ID>owner-id</ID>
+      </Grantee>
+      <Permission>FULL_CONTROL</Permission>
+    </Grant>
+  </AccessControlList>
+</AccessControlPolicy>`
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<AccessControlPolicy>
+  <Owner><ID>owner-id</ID><DisplayName>owner</DisplayName></Owner>
+  <AccessControlList>
+    <Grant>
+      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser">
+        <ID>owner-id</ID>
+      </Grantee>
+      <Permission>FULL_CONTROL</Permission>
+    </Grant>
+    <Grant>
+      <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Group">
+        <URI>%s</URI>
+      </Grantee>
+      <Permission>%s</Permission>
+    </Grant>
+  </AccessControlList>
+</AccessControlPolicy>`, granteeURI, permission)
+}
+
+// policyJSON builds a one-statement bucket policy. condition is spliced in raw so
+// a test can express any condition block, including a malformed one.
+func policyJSON(effect, principal, condition string) string {
+	if condition == "" {
+		return fmt.Sprintf(`{"Version":"2012-10-17","Statement":[
+  {"Sid":"s","Effect":%q,"Principal":%s,"Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"}]}`,
+			effect, principal)
+	}
+	return fmt.Sprintf(`{"Version":"2012-10-17","Statement":[
+  {"Sid":"s","Effect":%q,"Principal":%s,"Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*",
+   "Condition":%s}]}`, effect, principal, condition)
+}
+
+// s3ErrorCode decodes the Code from an S3 XML error body.
+func s3ErrorCode(t *testing.T, body []byte) string {
+	t.Helper()
+	var out struct {
+		Code    string `xml:"Code"`
+		Message string `xml:"Message"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &out), "decode error body: %s", string(body))
+	return out.Code
+}
+
+// s3ErrorMessage decodes the Message from an S3 XML error body.
+func s3ErrorMessage(t *testing.T, body []byte) string {
+	t.Helper()
+	var out struct {
+		Message string `xml:"Message"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &out), "decode error body: %s", string(body))
+	return out.Message
+}
+
+// getBucketACLGrants reads a bucket's stored ACL back as grantee-URI/permission
+// pairs, which is the surface a "nothing was stored" assertion has to be made
+// against.
+func getBucketACLGrants(t *testing.T, srv *emulator.Server, bucket string) []string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?acl", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "GetBucketAcl: %s", w.Body.String())
+	return aclGrantPairs(t, w.Body.Bytes())
+}
+
+// getObjectACLGrants is getBucketACLGrants for an object.
+func getObjectACLGrants(t *testing.T, srv *emulator.Server, bucket, key string) []string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"/"+key+"?acl", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "GetObjectAcl: %s", w.Body.String())
+	return aclGrantPairs(t, w.Body.Bytes())
+}
+
+// aclGrantPairs renders an ACL response as "<grantee>/<permission>" strings.
+func aclGrantPairs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var out struct {
+		Grants []struct {
+			URI        string `xml:"Grantee>URI"`
+			ID         string `xml:"Grantee>ID"`
+			Permission string `xml:"Permission"`
+		} `xml:"AccessControlList>Grant"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &out), "decode acl: %s", string(body))
+	pairs := make([]string, 0, len(out.Grants))
+	for _, g := range out.Grants {
+		grantee := g.URI
+		if grantee == "" {
+			grantee = g.ID
+		}
+		pairs = append(pairs, grantee+"/"+g.Permission)
+	}
+	return pairs
+}
+
+// getBucketPolicyBody reads a bucket policy back, or "" when there is none.
+func getBucketPolicyBody(t *testing.T, srv *emulator.Server, bucket string) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?policy", nil, nil)
+	if w.Code == http.StatusNotFound {
+		return ""
+	}
+	require.Equal(t, http.StatusOK, w.Code, "GetBucketPolicy: %s", w.Body.String())
+	return w.Body.String()
+}
+
+// aclCase is one public-or-not ACL, expressed in whichever of the three forms
+// carries it.
+type aclCase struct {
+	name    string
+	body    string            // AccessControlPolicy XML, or "" to use headers
+	headers map[string]string // x-amz-acl or x-amz-grant-*
+	public  bool
+}
+
+// publicACLCases covers all three documented ways a public ACL arrives, plus the
+// non-public counterparts that must keep working on a fully blocked bucket.
+func publicACLCases() []aclCase {
+	return []aclCase{
+		{name: "canned public-read", headers: map[string]string{"x-amz-acl": "public-read"}, public: true},
+		{name: "canned public-read-write", headers: map[string]string{"x-amz-acl": "public-read-write"}, public: true},
+		{name: "xml grant to AllUsers", body: aclXML(testGroupAllUsers, "READ"), public: true},
+		{name: "xml grant to AuthenticatedUsers", body: aclXML(testGroupAuthenticatedUsers, "READ"), public: true},
+		{
+			// "any permissions" is literal: WRITE_ACP counts as much as READ.
+			name:   "xml WRITE_ACP grant to AllUsers",
+			body:   aclXML(testGroupAllUsers, "WRITE_ACP"),
+			public: true,
+		},
+		{
+			name:    "x-amz-grant-read naming AllUsers",
+			headers: map[string]string{"x-amz-grant-read": `uri="` + testGroupAllUsers + `"`},
+			public:  true,
+		},
+		{
+			name: "x-amz-grant-full-control naming AuthenticatedUsers unquoted",
+			headers: map[string]string{
+				"x-amz-grant-full-control": "uri=" + testGroupAuthenticatedUsers,
+			},
+			public: true,
+		},
+		{
+			// A grant list mixing a canonical user with a public group is public on
+			// the second grantee, so the parse cannot stop at the first.
+			name: "x-amz-grant-read list ending in AllUsers",
+			headers: map[string]string{
+				"x-amz-grant-read": `id="abc123", uri="` + testGroupAllUsers + `"`,
+			},
+			public: true,
+		},
+		{name: "canned private", headers: map[string]string{"x-amz-acl": "private"}, public: false},
+		{name: "owner-only xml", body: aclXML("", ""), public: false},
+		{
+			name:    "x-amz-grant-read naming a canonical user",
+			headers: map[string]string{"x-amz-grant-read": `id="abc123"`},
+			public:  false,
+		},
+		{
+			// A non-public group URI must not be mistaken for a public one.
+			name:   "xml grant to LogDelivery",
+			body:   aclXML("http://acs.amazonaws.com/groups/s3/LogDelivery", "WRITE"),
+			public: false,
+		},
+	}
+}
+
+// TestS3_BlockPublicAcls_PutBucketAcl asserts that a bucket with BlockPublicAcls
+// set refuses a public ACL and keeps the one it already had (#458).
+func TestS3_BlockPublicAcls_PutBucketAcl(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range publicACLCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+			bucket := newPABBucket(t, srv, "acl-bucket")
+			require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabBlockACLsOnly).Code)
+
+			before := getBucketACLGrants(t, srv, bucket)
+
+			w := s3Request(t, srv, http.MethodPut, "/"+bucket+"?acl", nilIfEmptyBody(tc.body), tc.headers)
+			if !tc.public {
+				require.Equal(t, http.StatusOK, w.Code, "PutBucketAcl should be accepted: %s", w.Body.String())
+				return
+			}
+
+			require.Equal(t, http.StatusForbidden, w.Code, "PutBucketAcl should be refused: %s", w.Body.String())
+			assert.Equal(t, "AccessDenied", s3ErrorCode(t, w.Body.Bytes()))
+			assert.Equal(t, "Access Denied", s3ErrorMessage(t, w.Body.Bytes()))
+
+			// "existing policies and ACLs for buckets and objects aren't modified" —
+			// a rejection must store nothing.
+			assert.Equal(t, before, getBucketACLGrants(t, srv, bucket),
+				"a refused PutBucketAcl must leave the existing ACL in place")
+		})
+	}
+}
+
+// TestS3_BlockPublicAcls_PutObjectAcl is the object-level counterpart. The
+// configuration read is the bucket's: Block Public Access has no per-object
+// setting.
+func TestS3_BlockPublicAcls_PutObjectAcl(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range publicACLCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+			bucket := newPABBucket(t, srv, "obj-acl-bucket")
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/"+bucket+"/k.txt", []byte("hi"), nil).Code)
+			require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabBlockACLsOnly).Code)
+
+			before := getObjectACLGrants(t, srv, bucket, "k.txt")
+
+			w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/k.txt?acl", nilIfEmptyBody(tc.body), tc.headers)
+			if !tc.public {
+				require.Equal(t, http.StatusOK, w.Code, "PutObjectAcl should be accepted: %s", w.Body.String())
+				return
+			}
+
+			require.Equal(t, http.StatusForbidden, w.Code, "PutObjectAcl should be refused: %s", w.Body.String())
+			assert.Equal(t, "AccessDenied", s3ErrorCode(t, w.Body.Bytes()))
+			assert.Equal(t, before, getObjectACLGrants(t, srv, bucket, "k.txt"),
+				"a refused PutObjectAcl must leave the existing ACL in place")
+		})
+	}
+}
+
+// TestS3_BlockPublicAcls_UnenforcedConfigurations is the gate on not having
+// regressed #446: with no configuration at all, or a configuration whose four
+// members are false, or one that sets only the other three settings, every public
+// ACL is accepted exactly as before enforcement existed.
+func TestS3_BlockPublicAcls_UnenforcedConfigurations(t *testing.T) {
+	t.Parallel()
+
+	configs := []struct {
+		name string
+		body string // "" means send no PutPublicAccessBlock at all
+	}{
+		{name: "no configuration", body: ""},
+		{name: "all four false", body: pabAllFalse},
+		{
+			// The three settings substrate records but does not enforce must not
+			// acquire enforcement by accident.
+			name: "only the other three settings",
+			body: `<?xml version="1.0" encoding="UTF-8"?>
+<PublicAccessBlockConfiguration>
+  <IgnorePublicAcls>true</IgnorePublicAcls>
+  <BlockPublicPolicy>true</BlockPublicPolicy>
+  <RestrictPublicBuckets>true</RestrictPublicBuckets>
+</PublicAccessBlockConfiguration>`,
+		},
+	}
+
+	for _, cfg := range configs {
+		for _, tc := range publicACLCases() {
+			if !tc.public {
+				continue
+			}
+			t.Run(cfg.name+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+				srv, _ := newS3TestServer(t)
+				bucket := newPABBucket(t, srv, "unblocked")
+				if cfg.body != "" {
+					require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, cfg.body).Code)
+				}
+
+				w := s3Request(t, srv, http.MethodPut, "/"+bucket+"?acl", nilIfEmptyBody(tc.body), tc.headers)
+				assert.Equal(t, http.StatusOK, w.Code,
+					"a public ACL must still be accepted: %s", w.Body.String())
+			})
+		}
+	}
+}
+
+// TestS3_BlockPublicAcls_DeleteReenablesPublicAcls covers the documented
+// reversibility: "removing a block public access setting causes a bucket or object
+// with a public policy or ACL to again be publicly accessible".
+func TestS3_BlockPublicAcls_DeleteReenablesPublicAcls(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "reversible")
+
+	require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabAllTrue).Code)
+	blocked := s3Request(t, srv, http.MethodPut, "/"+bucket+"?acl", nil,
+		map[string]string{"x-amz-acl": "public-read"})
+	require.Equal(t, http.StatusForbidden, blocked.Code, "%s", blocked.Body.String())
+
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/"+bucket+"?publicAccessBlock", nil, nil).Code)
+
+	allowed := s3Request(t, srv, http.MethodPut, "/"+bucket+"?acl", nil,
+		map[string]string{"x-amz-acl": "public-read"})
+	assert.Equal(t, http.StatusOK, allowed.Code,
+		"deleting the configuration must re-allow a public ACL: %s", allowed.Body.String())
+	assert.Contains(t, getBucketACLGrants(t, srv, bucket), testGroupAllUsers+"/READ")
+}
+
+// policyCase is one bucket policy and whether Block Public Access considers it
+// public.
+type policyCase struct {
+	name   string
+	policy string
+	public bool
+}
+
+// publicPolicyCases is the documented rule reduced to cases. Every entry marked
+// public exercises the assume-public-then-qualify direction rather than
+// wildcard-detection.
+func publicPolicyCases() []policyCase {
+	return []policyCase{
+		{
+			name:   "wildcard principal, no condition",
+			policy: policyJSON("Allow", `"*"`, ""),
+			public: true,
+		},
+		{
+			// The guide's own example, and the case a wildcard-detecting
+			// implementation gets wrong: the narrowing value is itself a wildcard.
+			name:   "wildcard principal narrowed by StringLike vpc-*",
+			policy: policyJSON("Allow", `"*"`, `{"StringLike":{"aws:SourceVpc":"vpc-*"}}`),
+			public: true,
+		},
+		{
+			name:   "wildcard principal pinned to a fixed vpc",
+			policy: policyJSON("Allow", `"*"`, `{"StringEquals":{"aws:SourceVpc":"vpc-91237329"}}`),
+			public: false,
+		},
+		{
+			name:   "fixed account principal",
+			policy: policyJSON("Allow", `{"AWS":"arn:aws:iam::123456789012:root"}`, ""),
+			public: false,
+		},
+		{
+			name:   "fixed service principal",
+			policy: policyJSON("Allow", `{"Service":"cloudtrail.amazonaws.com"}`, ""),
+			public: false,
+		},
+		{
+			name:   "wildcard principal pinned to a /24",
+			policy: policyJSON("Allow", `"*"`, `{"IpAddress":{"aws:SourceIp":"203.0.113.0/24"}}`),
+			public: false,
+		},
+		{
+			// Broader than /8, so public despite carrying no wildcard character.
+			name:   "wildcard principal pinned to 0.0.0.0/1",
+			policy: policyJSON("Allow", `"*"`, `{"IpAddress":{"aws:SourceIp":"0.0.0.0/1"}}`),
+			public: true,
+		},
+		{
+			name:   "wildcard principal pinned to 0.0.0.0/0",
+			policy: policyJSON("Allow", `"*"`, `{"IpAddress":{"aws:SourceIp":"0.0.0.0/0"}}`),
+			public: true,
+		},
+		{
+			// /8 is the documented bound, read as acceptable rather than "broader
+			// than /8".
+			name:   "wildcard principal pinned to a public /8",
+			policy: policyJSON("Allow", `"*"`, `{"IpAddress":{"aws:SourceIp":"203.0.0.0/8"}}`),
+			public: false,
+		},
+		{
+			// The RFC1918 exclusion: a private range is never internet-reachable, so
+			// its breadth cannot make the bucket public.
+			name:   "wildcard principal pinned to 10.0.0.0/8",
+			policy: policyJSON("Allow", `"*"`, `{"IpAddress":{"aws:SourceIp":"10.0.0.0/8"}}`),
+			public: false,
+		},
+		{
+			name:   "wildcard principal pinned to a single host",
+			policy: policyJSON("Allow", `"*"`, `{"IpAddress":{"aws:SourceIp":"203.0.113.7"}}`),
+			public: false,
+		},
+		{
+			// IPv6's bound is /32, so a /48 pins and a /16 does not.
+			name:   "wildcard principal pinned to an IPv6 /48",
+			policy: policyJSON("Allow", `"*"`, `{"IpAddress":{"aws:SourceIp":"2001:db8:1234::/48"}}`),
+			public: false,
+		},
+		{
+			name:   "wildcard principal pinned to an IPv6 /16",
+			policy: policyJSON("Allow", `"*"`, `{"IpAddress":{"aws:SourceIp":"2001::/16"}}`),
+			public: true,
+		},
+		{
+			// The RFC1918 exclusion, on the family where it changes the answer: a
+			// unique-local IPv6 range is broader than the /32 bound but is private, so
+			// its breadth cannot make the bucket public. (For IPv4 the exclusion is
+			// unobservable, since the broadest private range is 10.0.0.0/8 and the /8
+			// bound already admits it.)
+			name:   "wildcard principal pinned to an IPv6 unique-local /8",
+			policy: policyJSON("Allow", `"*"`, `{"IpAddress":{"aws:SourceIp":"fd00::/8"}}`),
+			public: false,
+		},
+		{
+			// One wildcard value in a list admits the wildcard, so the list pins
+			// nothing.
+			name:   "condition list mixing a fixed and a wildcard value",
+			policy: policyJSON("Allow", `"*"`, `{"StringLike":{"aws:SourceVpc":["vpc-91237329","vpc-*"]}}`),
+			public: true,
+		},
+		{
+			// A policy variable is not a fixed value, same as a wildcard.
+			name:   "condition pinned to a policy variable",
+			policy: policyJSON("Allow", `"*"`, `{"StringEquals":{"aws:SourceVpc":"${aws:PrincipalTag/vpc}"}}`),
+			public: true,
+		},
+		{
+			// A key that is not on the qualifying list cannot make a statement
+			// non-public however fixed its value.
+			name:   "condition on a non-qualifying key",
+			policy: policyJSON("Allow", `"*"`, `{"StringEquals":{"s3:prefix":"public/"}}`),
+			public: true,
+		},
+		{
+			name:   "deny to everyone",
+			policy: policyJSON("Deny", `"*"`, ""),
+			public: false,
+		},
+		{
+			name:   "wildcard inside a principal ARN",
+			policy: policyJSON("Allow", `{"AWS":"arn:aws:iam::123456789012:user/*"}`, ""),
+			public: true,
+		},
+		{
+			name:   "wildcard principal pinned by aws:PrincipalOrgID",
+			policy: policyJSON("Allow", `"*"`, `{"StringEquals":{"aws:PrincipalOrgID":"o-abc123"}}`),
+			public: false,
+		},
+		{
+			name:   "wildcard principal pinned by aws:SourceAccount",
+			policy: policyJSON("Allow", `"*"`, `{"StringEquals":{"aws:SourceAccount":"123456789012"}}`),
+			public: false,
+		},
+		{
+			// aws:userid qualifies "outside the pattern AROLEID:*", and the trailing
+			// wildcard is what puts this value inside it.
+			name:   "wildcard principal pinned by an AROLEID:* userid",
+			policy: policyJSON("Allow", `"*"`, `{"StringLike":{"aws:userid":"AROAEXAMPLEID:*"}}`),
+			public: true,
+		},
+		{
+			// The s3:DataAccessPointArn carve-out: a wildcard access-point name does
+			// not make a *bucket* policy public so long as the account is fixed.
+			name: "wildcard principal pinned by a wildcard access-point ARN",
+			policy: policyJSON("Allow", `"*"`,
+				`{"StringEquals":{"s3:DataAccessPointArn":"arn:aws:s3:us-west-2:123456789012:accesspoint/*"}}`),
+			public: false,
+		},
+		{
+			// …but a wildcard in the account field is not carved out.
+			name: "wildcard principal pinned by a wildcard-account access-point ARN",
+			policy: policyJSON("Allow", `"*"`,
+				`{"StringEquals":{"s3:DataAccessPointArn":"arn:aws:s3:us-west-2:*:accesspoint/ap"}}`),
+			public: true,
+		},
+		{
+			// A condition key is case-insensitive, so the qualifying-key lookup must
+			// be too.
+			name:   "qualifying key in a different case",
+			policy: policyJSON("Allow", `"*"`, `{"StringEquals":{"AWS:SourceVpc":"vpc-91237329"}}`),
+			public: false,
+		},
+		{
+			name: "fixed cross-account grant plus one public statement",
+			policy: `{"Version":"2012-10-17","Statement":[
+  {"Sid":"trail","Effect":"Allow","Principal":{"Service":"cloudtrail.amazonaws.com"},
+   "Action":"s3:PutObject","Resource":"arn:aws:s3:::b/*"},
+  {"Sid":"acct2","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::210987654321:root"},
+   "Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"},
+  {"Sid":"pub","Effect":"Allow","Principal":"*",
+   "Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"}]}`,
+			public: true,
+		},
+		{
+			// The same policy without the third statement is not public — the guide's
+			// "if you remove statement 3" half of the worked example.
+			name: "fixed cross-account grant alone",
+			policy: `{"Version":"2012-10-17","Statement":[
+  {"Sid":"trail","Effect":"Allow","Principal":{"Service":"cloudtrail.amazonaws.com"},
+   "Action":"s3:PutObject","Resource":"arn:aws:s3:::b/*"},
+  {"Sid":"acct2","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::210987654321:root"},
+   "Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"}]}`,
+			public: false,
+		},
+		{
+			// Effect is case-insensitive in IAM, so a lowercase "allow" must not slip
+			// a public statement past the check.
+			name:   "lowercase allow with a wildcard principal",
+			policy: policyJSON("allow", `"*"`, ""),
+			public: true,
+		},
+		{
+			// JSON that is not a policy document must not acquire a new rejection
+			// reason from this check. PutBucketPolicy's own MalformedPolicy check
+			// already governs the non-JSON case.
+			name:   "json object with no statements",
+			policy: `{"not":"a policy"}`,
+			public: false,
+		},
+		{
+			// A body that is a JSON object — so it clears PutBucketPolicy's
+			// MalformedPolicy check — but does not unmarshal as a policy document.
+			// Substrate accepted this before enforcement existed and must still, for
+			// the same reason: the new check is not a validity check.
+			name:   "json object whose Statement is not an array",
+			policy: `{"Version":"2012-10-17","Statement":"nope"}`,
+			public: false,
+		},
+		{
+			// A statement with no Principal at all. Principal is required in a
+			// resource policy, so this is malformed — and substrate does not validate
+			// that. Assuming public is the direction that matches S3's
+			// assume-public-then-qualify start; the alternative would let a caller
+			// bypass the block by omitting the field.
+			name: "allow statement with no principal",
+			policy: `{"Version":"2012-10-17","Statement":[
+  {"Sid":"s","Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"}]}`,
+			public: true,
+		},
+	}
+}
+
+// TestS3_BlockPublicPolicy_PutBucketPolicy asserts that a bucket with
+// BlockPublicPolicy set refuses a public policy and keeps the one it had (#458).
+func TestS3_BlockPublicPolicy_PutBucketPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range publicPolicyCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+			bucket := newPABBucket(t, srv, "policy-bucket")
+
+			// A pre-existing non-public policy makes the "nothing was stored"
+			// assertion meaningful: a rejection must leave this one readable.
+			prior := policyJSON("Allow", `{"AWS":"arn:aws:iam::123456789012:root"}`, "")
+			require.Equal(t, http.StatusNoContent,
+				s3Request(t, srv, http.MethodPut, "/"+bucket+"?policy", []byte(prior), nil).Code)
+			require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabBlockPolicyOnly).Code)
+
+			w := s3Request(t, srv, http.MethodPut, "/"+bucket+"?policy", []byte(tc.policy), nil)
+			if !tc.public {
+				require.Equal(t, http.StatusNoContent, w.Code,
+					"PutBucketPolicy should be accepted: %s", w.Body.String())
+				assert.JSONEq(t, tc.policy, getBucketPolicyBody(t, srv, bucket))
+				return
+			}
+
+			require.Equal(t, http.StatusForbidden, w.Code,
+				"PutBucketPolicy should be refused: %s", w.Body.String())
+			assert.Equal(t, "AccessDenied", s3ErrorCode(t, w.Body.Bytes()))
+			assert.Equal(t, "Access Denied", s3ErrorMessage(t, w.Body.Bytes()))
+			assert.JSONEq(t, prior, getBucketPolicyBody(t, srv, bucket),
+				"a refused PutBucketPolicy must leave the existing policy in place")
+		})
+	}
+}
+
+// TestS3_BlockPublicPolicy_UnenforcedConfigurations is the policy-side gate on
+// #446: unconfigured, all-false, and the other-three-settings configurations all
+// accept a public policy.
+func TestS3_BlockPublicPolicy_UnenforcedConfigurations(t *testing.T) {
+	t.Parallel()
+
+	configs := []struct {
+		name string
+		body string
+	}{
+		{name: "no configuration", body: ""},
+		{name: "all four false", body: pabAllFalse},
+		{name: "only BlockPublicAcls", body: pabBlockACLsOnly},
+	}
+
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+			bucket := newPABBucket(t, srv, "unblocked-policy")
+			if cfg.body != "" {
+				require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, cfg.body).Code)
+			}
+
+			public := policyJSON("Allow", `"*"`, "")
+			w := s3Request(t, srv, http.MethodPut, "/"+bucket+"?policy", []byte(public), nil)
+			require.Equal(t, http.StatusNoContent, w.Code,
+				"a public policy must still be accepted: %s", w.Body.String())
+			assert.JSONEq(t, public, getBucketPolicyBody(t, srv, bucket))
+		})
+	}
+}
+
+// TestS3_BlockPublicPolicy_MalformedStillMalformed asserts the new check did not
+// displace the existing MalformedPolicy rejections: a non-JSON body and an empty
+// one still fail the way they did, with 400 rather than the new 403.
+func TestS3_BlockPublicPolicy_MalformedStillMalformed(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "malformed-policy")
+	require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabAllTrue).Code)
+
+	notJSON := s3Request(t, srv, http.MethodPut, "/"+bucket+"?policy", []byte("not json"), nil)
+	assert.Equal(t, http.StatusBadRequest, notJSON.Code, "%s", notJSON.Body.String())
+	assert.Equal(t, "MalformedPolicy", s3ErrorCode(t, notJSON.Body.Bytes()))
+
+	empty := s3Request(t, srv, http.MethodPut, "/"+bucket+"?policy", nil, nil)
+	assert.Equal(t, http.StatusBadRequest, empty.Code, "%s", empty.Body.String())
+	assert.Equal(t, "MalformedPolicy", s3ErrorCode(t, empty.Body.Bytes()))
+}
+
+// TestS3_BlockPublicAccess_MissingBucket asserts the existence checks still run
+// first: a public ACL or policy on a bucket that does not exist is NoSuchBucket,
+// not the new AccessDenied.
+func TestS3_BlockPublicAccess_MissingBucket(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	acl := s3Request(t, srv, http.MethodPut, "/absent?acl", nil,
+		map[string]string{"x-amz-acl": "public-read"})
+	assert.Equal(t, http.StatusNotFound, acl.Code, "%s", acl.Body.String())
+	assert.Equal(t, "NoSuchBucket", s3ErrorCode(t, acl.Body.Bytes()))
+
+	policy := s3Request(t, srv, http.MethodPut, "/absent?policy",
+		[]byte(policyJSON("Allow", `"*"`, "")), nil)
+	assert.Equal(t, http.StatusNotFound, policy.Code, "%s", policy.Body.String())
+	assert.Equal(t, "NoSuchBucket", s3ErrorCode(t, policy.Body.Bytes()))
+}
+
+// TestS3_BlockPublicAccess_ConfigurationIsPerBucket asserts one bucket's
+// configuration does not govern another's, which a shared or mis-keyed lookup
+// would break.
+func TestS3_BlockPublicAccess_ConfigurationIsPerBucket(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	blocked := newPABBucket(t, srv, "locked-down")
+	open := newPABBucket(t, srv, "left-open")
+	require.Equal(t, http.StatusOK, putPAB(t, srv, blocked, pabAllTrue).Code)
+
+	headers := map[string]string{"x-amz-acl": "public-read"}
+	assert.Equal(t, http.StatusForbidden,
+		s3Request(t, srv, http.MethodPut, "/"+blocked+"?acl", nil, headers).Code)
+	assert.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+open+"?acl", nil, headers).Code)
+}
+
+// nilIfEmptyBody converts an empty body string to a nil slice, so a header-only
+// request sends no body at all — which is what makes the handler read x-amz-acl.
+func nilIfEmptyBody(body string) []byte {
+	if body == "" {
+		return nil
+	}
+	return []byte(body)
+}

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -223,11 +223,17 @@ type S3BucketPolicy struct {
 // "absent" and "explicitly false" are the same observation, so a third state
 // would be one substrate could produce but real S3 never returns.
 //
-// Substrate records the configuration and reports it back; it does not enforce
-// it. Nothing here rejects a public ACL or a public bucket policy, because those
-// are the resource-internal consequences of the setting rather than the setting
-// itself — see the scope boundary in CLAUDE.md. Enforcement is tracked
-// separately (#458).
+// Substrate enforces the two request-time settings: BlockPublicAcls refuses a
+// public ACL on PutBucketAcl/PutObjectAcl and BlockPublicPolicy refuses a public
+// bucket policy on PutBucketPolicy, both with 403 AccessDenied and without storing
+// anything (#458). See s3_publicaccess.go for the definitions of "public", which
+// are not the obvious ones.
+//
+// IgnorePublicAcls and RestrictPublicBuckets stay recorded-only. Both govern how an
+// incoming request is evaluated against an ACL or policy already in place rather
+// than which write is refused, and substrate has no unauthenticated or
+// cross-account request path to deny — every request it serves is already the
+// bucket owner's.
 type S3PublicAccessBlockConfiguration struct {
 	XMLName xml.Name `xml:"PublicAccessBlockConfiguration" json:"-"`
 


### PR DESCRIPTION
Closes #458

#446 made the four Block Public Access settings storable and readable, and nothing acted on any of them. A consumer asserting "once we lock the bucket down, a public ACL is refused" got a green test that verified nothing — the assertion would have to be written a second time before it ever ran against AWS.

## What changed

| Setting | Refuses | Response |
|---|---|---|
| `BlockPublicAcls` | `PutBucketAcl`, `PutObjectAcl` with a public ACL | `403 AccessDenied` / `Access Denied` |
| `BlockPublicPolicy` | `PutBucketPolicy` with a public policy | `403 AccessDenied` / `Access Denied` |

Both check **before** the write, so a rejection stores nothing and the resource keeps the ACL or policy it already had — "existing policies and ACLs for buckets and objects aren't modified". Deleting the configuration re-allows what it was refusing. `PutObjectAcl` reads the *bucket's* configuration: "Amazon S3 doesn't support block public access settings on a per-object basis".

## The policy rule is inverted from the obvious reading

This is the substance of the change. S3 does **not** look for a wildcard principal — it "begins by assuming that the policy is public. It then evaluates the policy to determine whether it qualifies as non-public", which happens only when access is granted solely to *fixed* values (no `*`, no `?`, no `${...}` policy variable) through the `Principal` or a `Condition` on one of the documented keys.

| Policy | Public? |
|---|---|
| `Principal: "*"`, no condition | yes |
| `Principal: "*"` + `StringLike aws:SourceVpc: "vpc-*"` | **yes** — the narrowing value is itself a wildcard |
| `Principal: "*"` + `StringEquals aws:SourceVpc: "vpc-91237329"` | no |
| `Principal: {"AWS": "arn:aws:iam::123456789012:root"}` | no |
| `Principal: {"AWS": "arn:aws:iam::123456789012:user/*"}` | yes |
| `Principal: "*"` + `aws:SourceIp: "203.0.113.0/24"` | no |
| `Principal: "*"` + `aws:SourceIp: "0.0.0.0/1"` | **yes** — broader than `/8`, no wildcard character in sight |
| `Effect: Deny`, `Principal: "*"` | no |
| A fixed cross-account grant **plus** one public statement | yes |

Also implemented: the `aws:SourceIp` breadth rule ("broader than `/8` for IPv4 and `/32` for IPv6, excluding RFC1918 private ranges") via `net/netip`, and the `s3:DataAccessPointArn` carve-out where a wildcard access-point name does not make a *bucket* policy public as long as the account ID is fixed. Only an `Allow` can make a policy public, and one surviving public statement makes the whole policy public — the guide's worked example, where a single public statement disables an otherwise-legal cross-account grant.

## Public ACLs

Any permission granted to `AllUsers` or `AuthenticatedUsers`, matched on the grantee URI, with the permission not inspected (`WRITE_ACP` counts as much as `READ`). `AuthenticatedUsers` is every AWS account rather than every account in yours, which is why it counts despite the name and why it can only arrive through an XML body — the canned-ACL resolver never emits it.

All three documented forms are covered: the `x-amz-acl` canned header, an XML `Grant` naming a public group, and an `x-amz-grant-*` header whose grantee list contains one. **The grant headers were previously unread anywhere in substrate**; they are parsed for this check only, so an ACL set through them is still not stored (separate gap).

## Provenance

None of `PutBucketAcl`, `PutObjectAcl` or `PutBucketPolicy` documents an Errors section covering this, so the `AccessDenied` / `Access Denied` / `403` triple comes from **observed real-AWS behavior**, not the API model — a blocked `PutBucketPolicy` surfaces through the CLI as `An error occurred (AccessDenied) when calling the PutBucketPolicy operation: Access Denied`. The definitions of "public" are quoted from the user guide's *Blocking public access → The meaning of "public"*, fetched and read rather than recalled.

## Deliberately not covered

- `IgnorePublicAcls` and `RestrictPublicBuckets` stay recorded-only. Both govern how an *incoming* request is evaluated against an ACL or policy already in place rather than which write is refused, and substrate has no unauthenticated or cross-account request path to deny — every request it serves is already the bucket owner's.
- `PutObject` and `CreateBucket` with a public ACL are not refused, because neither handler reads `x-amz-acl` at all. Covering them means modelling ACL-on-create first; follow-up to be filed.
- The guide's unsupported-action clause (S3 treats a statement granting an action S3 does not support as potentially public), which would need an authoritative list of every supported `s3:` action and would go stale silently.
- A body that parses as JSON but not as a policy document is **not** treated as public. `PutBucketPolicy` already rejects non-JSON with `400 MalformedPolicy`, and the new check is not a second validity check.

## Tests

`emulator/s3_publicaccess_test.go`, 88 subtests. The ACL cases run against both `PutBucketAcl` and `PutObjectAcl` from one table; the policy table has 30 rows.

The gate on not regressing #446: an unconfigured bucket, an all-false configuration, and one setting only the other three settings all accept every public ACL and a public policy exactly as before enforcement existed. Also asserted — nothing is stored on rejection (read back through `GetBucketAcl`/`GetBucketPolicy`), the existence checks still run first (`NoSuchBucket`, not the new `AccessDenied`), `MalformedPolicy` still fires at 400 rather than being displaced by the 403, deleting the configuration re-allows a public ACL, and one bucket's configuration does not govern another's.

## Mutation testing

24 mutants, all caught. Three survived the first pass and each pointed at a real gap:

| Mutant | Fix |
|---|---|
| RFC1918 exclusion dropped | No test could see it — under the inclusive `/8` reading the exclusion cannot change an **IPv4** answer, since the broadest private range is `10.0.0.0/8` and the bound already admits it. It is load-bearing for IPv6, where unique-local is `fc00::/7`. Added an `fd00::/8` case and rewrote the doc comment, which had claimed the IPv4 rationale. |
| Unparseable JSON treated as public | Only case was `{"not":"a policy"}`, which unmarshals fine into an empty `PolicyDocument`. Added `{"Version":..., "Statement":"nope"}` — a JSON object that clears `MalformedPolicy` but genuinely fails to unmarshal as a policy. |
| A nil `Principal` counts as fixed | Untested. Added an `Allow` statement with no `Principal`; it must be public, which is the assume-public direction and the alternative would let a caller bypass the block by omitting the field. |

## Verification

From the repo root: `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → 0 issues, `make test` (race) green, `make docs-reference-check docs-versions` green, `go test -C test/e2e ./...` ok.

The plan's consumer sequence, run end to end:

```
PutPublicAccessBlock(all true)
  → PutBucketAcl(public-read)         → 403 AccessDenied, ACL unchanged
  → PutBucketPolicy(Principal:*)      → 403 AccessDenied, no policy stored
  → PutBucketPolicy(fixed principal)  → 204, policy readable
```

Docs: `docs/services.md` §Block Public Access — the "settings are recorded, not enforced" paragraph is replaced with what is now enforced, the assume-public-then-qualify rule with the `vpc-*` example and the policy table, the ACL rule, and each of the four things above that stays uncovered with its reason. The `S3PublicAccessBlockConfiguration` doc comment, which stated the opposite, is updated too.