### PR TITLE
docs: add publishing the GitHub Release to the release procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `CLAUDE.md`'s release procedure now includes publishing the GitHub Release. The
+  step was absent, so v0.84.0 and v0.85.0 were tagged and their tags pushed with no
+  Release entry behind them — the tag alone does not create one, and v0.83.0 was
+  the last version to appear on the releases page. Both have since been published
+  retroactively against their existing signed tags. The step records the house
+  style for the notes and requires `--verify-tag`, because `gh release create`
+  otherwise tags the current branch tip when the named tag is missing, which would
+  produce an unsigned tag at whatever commit happened to be checked out — the one
+  way this step could damage a release rather than merely omit one. Deferred issues
+  are also now explicitly moved to the next milestone rather than closed with the
+  release.
+
 ## [v0.85.0] - 2026-08-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,13 +113,31 @@ These enforce the rules below server-side — do not attempt to bypass them.
    verification for every consumer (see `SECURITY.md`, #296). Fix any release
    mistake by cutting a new patch version, never by re-tagging. The tag ruleset
    will reject a move or delete regardless.
-4. Close the issues the release resolves. A `(#N)` reference in a commit or PR
+4. Publish a GitHub Release against the tag — the tag alone does not create one,
+   and v0.84.0/v0.85.0 shipped without one because this step was unwritten:
+   `gh release create vX.Y.Z --verify-tag --latest --title vX.Y.Z --notes-file <file>`.
+   Always pass `--verify-tag`, so the command fails rather than creating a tag if
+   the tag is missing — `gh release create` will otherwise tag the current branch
+   tip, producing an unsigned tag at whatever commit happens to be checked out.
+   Create releases in ascending version order, and pass `--latest` on the newest.
+   Notes follow the house style: a prose lede naming the release's theme, the
+   CHANGELOG entries condensed one bullet per issue (**not** verbatim — the
+   CHANGELOG carries the full reasoning and the release links to it), a
+   `## Provenance` section when any error code comes from observed behaviour
+   rather than the API model, and a `## Compatibility` section stating what a
+   consumer must know before upgrading. Close with the CHANGELOG anchor and the
+   compare link. A release body is editable after publication (`gh release edit`),
+   unlike the tag it points at.
+5. Close the issues the release resolves. A `(#N)` reference in a commit or PR
    **title** only links — it does not auto-close. Use a `Closes #N` / `Fixes #N`
    keyword in the PR **body** (or the merged commit message body), or close the
    issue manually. Only close an issue when every acceptance-criteria checkbox
    is met; if a release ships part of an issue, comment with what shipped vs.
    what remains and leave it open.
-5. Close the release's milestone once all its issues are closed.
+6. Close the release's milestone once all its issues are closed. Issues
+   deliberately deferred out of the release must be **moved to the next
+   milestone**, not closed — comment on each saying why it moved and whether
+   anything in the shipped release changed its analysis.
 
 ## AWS service emulation
 


### PR DESCRIPTION
## Problem

The documented release procedure went from pushing the signed tag (step 3)
straight to closing issues (step 4), with nothing in between about publishing a
GitHub Release.

A pushed tag does not create a Release. So v0.84.0 and v0.85.0 were both cut
correctly — signed tags at the right commits, CHANGELOG sections in place — and
neither appeared on the releases page. `gh release list` showed **v0.83.0 as
Latest** with two newer versions tagged and invisible.

That is a real consumer-facing gap, not a cosmetic one: the releases page is where
someone looks to find out what changed, and anything watching releases rather than
tags saw nothing ship.

## Fix

Both releases have been published retroactively against their existing signed
tags (v0.84.0 → `b3d1caa`, v0.85.0 → `c37de24`, the latter marked Latest). No tag
was moved, re-cut, or created.

This PR adds the missing step so it does not happen again.

### The `--verify-tag` requirement is the load-bearing part

Without `--verify-tag`, `gh release create` **creates the tag** when the named one
is absent — at the current branch tip, unsigned. That turns a forgotten step into
a damaged release: an unsigned tag at whatever commit happened to be checked out,
which is precisely the "tag as a side effect" the procedure's opening sentence
already forbids. The flag makes the command fail instead.

The step also records:

- **Ascending order, `--latest` on the newest** — creating them newest-first
  leaves the older one marked Latest.
- **The notes house style** — a prose lede naming the theme, one condensed bullet
  per issue rather than the CHANGELOG verbatim, a `## Provenance` section when an
  error code comes from observed behaviour rather than the API model, and a
  `## Compatibility` section. This is what v0.82.0 and v0.83.0 already do; it was
  just never written down.
- **That a release body is editable after publication**, unlike the tag — worth
  knowing, since it means the notes are the one part of a release that can be
  corrected in place.

### One more procedural gap, in step 6

Deferred issues must **move to the next milestone**, not be closed with the
release. v0.85.0 hit this: the milestone could not be closed while #411, #455 and
#456 sat open on it, and closing them would have been wrong — they were deliberate
scope decisions, not completed work. They were moved to a new v0.86.0 milestone
with a comment each explaining why, which is now the documented behaviour.

## Verification

`make docs-versions` passes (`scripts/check-doc-versions.sh` does not scan
`CLAUDE.md`, but ran it to confirm nothing else regressed). Documentation-only —
no Go source touched, so the build, lint and test surface is unchanged.

Notably this could not have been caught by CI: there is no guard asserting that a
pushed `v*` tag has a Release behind it. Worth considering separately, but it is a
workflow addition rather than a docs fix and does not belong here.
