### PR TITLE
ci: assert every published version tag has a GitHub Release

### DIFF
--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -1,0 +1,45 @@
+name: Release Audit
+
+# Asserts that every published version tag has a GitHub Release behind it.
+#
+# Deliberately not part of CI. This checks repository state rather than the
+# contents of a change, so running it on pull_request would fail a contributor's
+# unrelated PR for a missing release they cannot publish — and a check that fails
+# for reasons the author cannot act on is one people learn to click past.
+#
+# The schedule is what actually catches the failure this exists for. A tag pushed
+# without a Release looks fine at push time (CLAUDE.md publishes the Release after
+# pushing the tag, so the script grants a grace window), and the omission only
+# becomes visible once that window closes. v0.84.0 and v0.85.0 went unnoticed for
+# a day for exactly this reason.
+on:
+  schedule:
+    # 06:00 UTC daily. Any missing Release surfaces within a day of its tag.
+    - cron: '0 6 * * *'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/check-tag-releases.sh'
+      - '.github/workflows/release-audit.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tag-releases:
+    name: Tags have Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Tags are required locally: the script reads each tag's commit date to
+          # decide whether a just-pushed tag is still inside its publish grace
+          # window. checkout's default shallow clone has no tags, which would make
+          # every fresh tag look like a missed release.
+          fetch-depth: 0
+
+      - name: Check every version tag has a GitHub Release
+        run: make tag-releases-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `make tag-releases-check` (`scripts/check-tag-releases.sh`) fails if a published
+  `vX.Y.Z` tag has no GitHub Release behind it, run daily by the new `Release Audit`
+  workflow. Pushing a tag does not create a Release and nothing asserted otherwise,
+  so v0.84.0 and v0.85.0 were both cut correctly and neither appeared on the
+  releases page — anything watching releases rather than tags saw nothing ship. The
+  previous commit documented the step; this asserts it, because a documented step is
+  one a human has to remember.
+
+  Two design points, both about not crying wolf. The check grants a **grace window**
+  after a tag's commit, because the documented procedure pushes the tag before
+  publishing the Release, so a tag legitimately has neither for as long as writing
+  the notes takes. And it is **not part of CI**: it audits repository state rather
+  than the contents of a change, so on `pull_request` it would fail a contributor's
+  unrelated PR for a missing release they cannot publish. The schedule is what
+  catches this class of omission anyway, since it is invisible at push time.
+
+  Tags below v0.68.0 are exempt — 77 of them predate the convention and auditing the
+  whole history would report a wall of unactionable failures. The floor's premise is
+  asserted rather than trusted: the tag just below it must still lack a Release,
+  which also guards the void `v0.67.0` (see `SECURITY.md`) against ever acquiring
+  one.
+
 ### Changed
 - `CLAUDE.md`'s release procedure now includes publishing the GitHub Release. The
   step was absent, so v0.84.0 and v0.85.0 were tagged and their tags pushed with no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,9 @@ These enforce the rules below server-side — do not attempt to bypass them.
    rather than the API model, and a `## Compatibility` section stating what a
    consumer must know before upgrading. Close with the CHANGELOG anchor and the
    compare link. A release body is editable after publication (`gh release edit`),
-   unlike the tag it points at.
+   unlike the tag it points at. `make tag-releases-check` asserts this step
+   happened; the `Release Audit` workflow runs it daily, so a forgotten Release
+   surfaces within a day rather than at the next release.
 5. Close the issues the release resolves. A `(#N)` reference in a commit or PR
    **title** only links — it does not auto-close. Use a `Closes #N` / `Fixes #N`
    keyword in the PR **body** (or the merged commit message body), or close the

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ docs-versions: ## Fail if docs/README pin a stale version in prose
 version-check: ## Fail if the build's -ldflags do not reach the version the server reports
 	./scripts/check-version-stamping.sh
 
+tag-releases-check: ## Fail if a published version tag has no GitHub Release behind it
+	./scripts/check-tag-releases.sh
+
 bench: ## Run benchmarks
 	go test -bench=. -benchmem -benchtime=5s ./...
 

--- a/scripts/check-tag-releases.sh
+++ b/scripts/check-tag-releases.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# check-tag-releases.sh — fail if a published vX.Y.Z tag has no GitHub Release
+# behind it.
+#
+# Pushing a tag does not create a Release. Nothing asserted otherwise, so v0.84.0
+# and v0.85.0 were both cut correctly — signed tags at the right commits, CHANGELOG
+# sections in place — and neither appeared on the releases page: `gh release list`
+# showed v0.83.0 as Latest with two newer versions tagged and invisible. Anything
+# watching releases rather than tags saw nothing ship. Both were published
+# retroactively and the step is now documented in CLAUDE.md, but a documented step
+# is one a human has to remember, which is what this script replaces.
+#
+# The inverse direction is not checked. A Release without a tag cannot exist —
+# `gh release create` creates the tag when one is absent, which is exactly why
+# CLAUDE.md requires `--verify-tag`.
+#
+# Requires `gh` authenticated against the repo. Skips cleanly when unavailable, so
+# a contributor without a token is not blocked; CI always has one.
+set -euo pipefail
+
+# CLAUDE.md's procedure pushes the tag (step 3) and publishes the Release (step 4),
+# so a just-pushed tag legitimately has no Release for as long as writing the notes
+# takes. Without a grace window this check would fail whenever it ran inside that
+# gap — and a guard that cries wolf is one people learn to ignore, which is worse
+# than not having it. Two hours is far longer than publishing takes and far shorter
+# than a forgotten release goes unnoticed.
+GRACE_SECONDS=$((2 * 60 * 60))
+
+# Tags below this predate the release convention: 77 of them have no Release and
+# never will, so auditing the whole history would report a wall of unactionable
+# failures and train everyone to ignore this check. v0.68.0 is the floor because
+# every tag from it onward already has a Release — verified when this was written,
+# and asserted below so the claim cannot rot silently.
+#
+# v0.67.0 sits below the floor for an unrelated reason worth knowing: it is the
+# void out-of-order tag documented in SECURITY.md. It must never acquire a
+# Release, and the floor keeps this check from ever asking for one.
+FLOOR_MINOR=68
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "check-tag-releases: gh not installed — skipping."
+  exit 0
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "check-tag-releases: gh not authenticated — skipping."
+  exit 0
+fi
+
+# Tags are read from the remote rather than the local clone: a local checkout may
+# be missing tags (a shallow CI clone especially), and a tag that was never pushed
+# is not a published release and is none of this check's business.
+mapfile -t tags < <(
+  git ls-remote --tags origin 'refs/tags/v*' 2>/dev/null |
+    sed 's|.*refs/tags/||' |
+    grep -vE '\^\{\}$' |
+    grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+    sort -u
+)
+
+if [[ "${#tags[@]}" -eq 0 ]]; then
+  echo "check-tag-releases: no version tags found on origin — skipping."
+  exit 0
+fi
+
+mapfile -t releases < <(gh release list --limit 500 --json tagName --jq '.[].tagName' | sort -u)
+
+has_release() {
+  local needle="$1" r
+  for r in "${releases[@]}"; do
+    [[ "$r" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# above_floor reports whether a tag is at or above the floor, comparing major then
+# minor numerically. A string comparison would place v0.9.0 above v0.68.0.
+above_floor() {
+  local v="${1#v}" major minor rest
+  major="${v%%.*}"
+  rest="${v#*.}"
+  minor="${rest%%.*}"
+  [[ "$major" -gt 0 ]] && return 0
+  [[ "$minor" -ge "$FLOOR_MINOR" ]]
+}
+
+# within_grace reports whether a tag's commit is recent enough that its Release may
+# still be in progress. The commit date is used rather than the tag's own creation
+# time because an annotated tag's date is not exposed by ls-remote, and a release
+# tag points at a merge commit made minutes earlier — close enough for a window
+# measured in hours, and it fails safe: an old commit tagged today is reported
+# immediately rather than being granted a window it does not need.
+now=$(date +%s)
+within_grace() {
+  local tag="$1" ts
+  ts=$(git log -1 --format=%ct "refs/tags/$tag" 2>/dev/null) || return 1
+  [[ -n "$ts" ]] || return 1
+  (( now - ts < GRACE_SECONDS ))
+}
+
+missing=()
+pending=()
+legacy_missing=0
+checked=0
+for t in "${tags[@]}"; do
+  if above_floor "$t"; then
+    checked=$((checked + 1))
+    has_release "$t" && continue
+    if within_grace "$t"; then
+      pending+=("$t")
+    else
+      missing+=("$t")
+    fi
+  elif ! has_release "$t"; then
+    legacy_missing=$((legacy_missing + 1))
+  fi
+done
+
+for t in "${pending[@]}"; do
+  echo "check-tag-releases: ${t} has no Release yet, but was tagged within the grace window — not failing."
+done
+
+if [[ "${#missing[@]}" -gt 0 ]]; then
+  echo "Tags with no GitHub Release:"
+  for t in "${missing[@]}"; do
+    echo "    $t"
+  done
+  cat <<'EOF'
+
+A pushed tag does not create a Release, and consumers watching releases rather
+than tags see nothing ship. Publish against the existing tag:
+
+    gh release create vX.Y.Z --verify-tag --latest --title vX.Y.Z --notes-file <file>
+
+Always pass --verify-tag: without it, gh release create *creates* the tag at the
+current branch tip, unsigned, when the named tag is absent. See CLAUDE.md's
+release procedure for the notes house style.
+EOF
+  exit 1
+fi
+
+# The floor's own premise is asserted rather than trusted: the tag immediately below
+# it must still be one of the legacy tags with no Release. If v0.67.0 ever acquires
+# one, the floor was drawn in the wrong place — or, worse, someone published a
+# Release for the void tag SECURITY.md says never to use.
+#
+# An earlier version of this check compared legacy_missing against a hardcoded 77.
+# That was wrong in a way worth recording: the count depends on the full tag history
+# being present, so a shallow clone or a partial fetch failed the check for a reason
+# that had nothing to do with releases. This assertion tests the one fact the floor
+# actually rests on.
+if has_release "v0.$((FLOOR_MINOR - 1)).0"; then
+  echo "check-tag-releases: v0.$((FLOOR_MINOR - 1)).0 has a Release, so the v0.${FLOOR_MINOR}.0 floor is misplaced."
+  echo "If that tag is the void v0.67.0 (see SECURITY.md), the Release must be deleted;"
+  echo "otherwise lower FLOOR_MINOR in scripts/check-tag-releases.sh."
+  exit 1
+fi
+
+echo "check-tag-releases: all ${checked} version tags at or above v0.${FLOOR_MINOR}.0 have a Release (${legacy_missing} older tags exempt)."


### PR DESCRIPTION
## Why

The follow-up I flagged in #474. That PR documented publishing the GitHub Release;
nothing asserted it, and a documented step is one a human has to remember.

The failure it catches already happened twice. v0.84.0 and v0.85.0 were both cut
correctly — signed tags at the right commits, CHANGELOG sections in place — and
neither appeared on the releases page. `gh release list` showed **v0.83.0 as
Latest** with two newer versions tagged and invisible. Anything watching releases
rather than tags saw nothing ship, and it went unnoticed for a day.

## What

`scripts/check-tag-releases.sh` + `make tag-releases-check`, run daily by a new
`Release Audit` workflow.

### Two decisions about not crying wolf

**A grace window after the tag's commit.** CLAUDE.md pushes the tag (step 3) and
publishes the Release (step 4), so a tag legitimately has no Release for as long as
writing the notes takes. Without a window this fails inside every release's normal
gap, and a check that cries wolf is one people learn to click past — worse than not
having it. Two hours: far longer than publishing takes, far shorter than a
forgotten release goes unnoticed.

**Not part of CI.** It audits repository state rather than the contents of a
change, so on `pull_request` it would fail a contributor's unrelated PR for a
missing release *they cannot publish*. The schedule is also what actually catches
this class of bug: it is invisible at push time and only becomes real once the
window closes. Hence a separate workflow, on `schedule` +
`workflow_dispatch` + `push` limited to the paths that define the check itself.

### The v0.68.0 floor

77 tags predate the release convention. Auditing the whole history would report a
wall of unactionable failures on day one.

The floor's premise is **asserted rather than trusted**: the tag immediately below
it must still lack a Release. If `v0.67.0` ever acquires one, this fails — which is
a useful guard in its own right, since that is the void out-of-order tag
`SECURITY.md` says never to use.

An earlier draft compared `legacy_missing` against a hardcoded `77`. Recording why
that was wrong, since it is a tempting shape: the count depends on the full tag
history being present, so a shallow clone or partial fetch failed the check for a
reason that had nothing to do with releases. Replaced with the single fact the
floor actually rests on.

## Verification

Mutation-tested in both directions rather than just confirming it passes:

| Mutation | Result |
|---|---|
| Floor lowered to 60 | ✅ reports v0.60.0–v0.67.0 as missing, exit 1 |
| Fresh tag, no Release, inside window | ✅ reports as pending, exit 0 |
| Same tag backdated past the window | ✅ reports as missing, exit 1 |
| Floor placed above a tag that *has* a Release | ✅ misplaced-floor assertion fires |
| Local tag ref absent | ✅ fails safe — reports rather than silently skipping |
| `above_floor` on v0.7.0 / v0.9.0 / v1.0.0 | ✅ numeric, not string — v0.9.0 exempt, v1.0.0 checked |

The fresh-tag cases ran against a throwaway repo with a stubbed `gh`, so no real
release was touched.

Also: `shellcheck` clean; passes with token-only auth and an empty `GH_CONFIG_DIR`
(how CI runs it); `fetch-depth: 0` is set because the grace window reads tag commit
dates and checkout's default shallow clone has no tags — without it every fresh tag
would look like a missed release.

Full gates from the repo root: `gofmt -l .` clean, `go build ./...`, `go vet ./...`,
`golangci-lint run ./...` → **0 issues**, `make test` (race) green,
`make docs-reference-check docs-versions` green.

## Note

The current state is clean — 18 tags at or above the floor, all with Releases — so
this PR's own run passes. It is a guard against recurrence, not a fix for an
outstanding problem.
