### PR TITLE
feat(ec2): version launch templates (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **EC2 launch templates are now versioned** (#456).
+  `CreateLaunchTemplateVersion`, `ModifyLaunchTemplate`,
+  `DescribeLaunchTemplateVersions` and `DeleteLaunchTemplateVersions` were all
+  unregistered, so a consumer that shipped a second version of a template got
+  `InvalidAction` from the create and — worse — every launch silently used the one
+  stored parameter set. There was also no way to read a template's contents back at
+  all: `DescribeLaunchTemplates` returns only summary fields, matching AWS, and
+  `DescribeLaunchTemplateVersions` is the only operation that carries
+  `launchTemplateData`.
+
+  **An absent `LaunchTemplate.Version` resolves to the template's *default*
+  version, not its latest**, per aws-sdk-go-v2's
+  `LaunchTemplateSpecification.Version` ("Default: The default version of the launch
+  template"). This is the detail worth checking a test against, because a new
+  version does not become the default: creating version 2 and launching without
+  naming a version still gets version 1, and an emulator that resolved to the latest
+  instead would agree with every test that never pins a default.
+
+  `CreateLaunchTemplateVersion`'s `SourceVersion` inherits the source version's
+  parameters and lets the request overwrite the ones it names; **omitting
+  `SourceVersion` inherits nothing**, so the new version holds only what the request
+  names. `DeleteLaunchTemplateVersions` reports per version at HTTP 200 rather than
+  failing the request — the default version cannot be deleted, and a request naming
+  both a deletable and an undeletable version puts one entry in each set while still
+  returning 200, so a caller checking only the status code sees success. A deleted
+  version number is never reused.
+
+  A `CreateFleet` config's `LaunchTemplateSpecification.Version` now reaches the
+  launch. It was parsed and then dropped, so a fleet pinned to version 1 launched
+  whatever the template held latest, with nothing reporting the substitution.
+
+  Templates stored before this change keep working: a stored template with no
+  versions array reads back as version 1, default, synthesized from the parameters
+  it does carry. A recorded event log from an earlier substrate replays unchanged —
+  no event rewriting is involved.
+
+  Provenance: the default-version deletion is reported with `responseError.code`
+  `unexpectedError`, because `ResponseError.code` is a closed six-value enum in the
+  AWS SDK models with no default-version member and a typed SDK deserializes
+  anything outside it as an unknown variant. AWS's real code for this case is not
+  published and no capture of the rejection exists (searched the API reference, the
+  CLI help, moto — which does not implement the operation — LocalStack, and the SDK
+  models); the message is the reference's own sentence. Both are inferred, not
+  captured.
 - `make tag-releases-check` (`scripts/check-tag-releases.sh`) fails if a published
   `vX.Y.Z` tag has no GitHub Release behind it, run daily by the new `Release Audit`
   workflow. Pushing a tag does not create a Release and nothing asserted otherwise,

--- a/docs/services.md
+++ b/docs/services.md
@@ -1260,9 +1260,13 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids) |
-| CreateLaunchTemplate | Networking is read from `NetworkInterface.1.*` — see [Launch template networking](#launch-template-networking) |
-| DescribeLaunchTemplates | |
+| CreateLaunchTemplate | Creates version 1. Networking is read from `NetworkInterface.1.*` — see [Launch template networking](#launch-template-networking) |
+| DescribeLaunchTemplates | Summary only — no `launchTemplateData`, matching AWS. Use `DescribeLaunchTemplateVersions` to read a template's parameters |
 | DeleteLaunchTemplate | |
+| CreateLaunchTemplateVersion | `SourceVersion` inheritance — see [Launch template versions](#launch-template-versions) |
+| ModifyLaunchTemplate | `SetDefaultVersion` only, which is AWS's only modifiable attribute |
+| DescribeLaunchTemplateVersions | Numbers, `$Latest`, `$Default`, `MinVersion`/`MaxVersion`, `MaxResults`/`NextToken`, and the account-wide form |
+| DeleteLaunchTemplateVersions | Reports per version at HTTP 200; the default version cannot be deleted |
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances |
@@ -1311,6 +1315,10 @@ corresponding parameters included in the launch template."
 | `KeyName` | `k-request` | `k-template` | `k-request` |
 | `SubnetId`, security groups, `AssociatePublicIpAddress` | see [Launch template networking](#launch-template-networking) | | |
 
+Which *version* of the template supplies those values is resolved from
+`LaunchTemplate.Version`; an absent version means the template's **default**
+version, not its latest. See [Launch template versions](#launch-template-versions).
+
 Two details are worth stating, because both were wrong before and each fails
 silently rather than loudly.
 
@@ -1331,6 +1339,66 @@ a type.
 
 A template's `TagSpecifications` and `IamInstanceProfile` are not parsed at all, so
 neither participates in the merge.
+
+### Launch template versions
+
+Launch templates are versioned. `CreateLaunchTemplate` creates version 1, each
+`CreateLaunchTemplateVersion` appends the next number, and `ModifyLaunchTemplate`
+moves the default.
+
+**An absent `LaunchTemplate.Version` means the default version, not the latest.**
+aws-sdk-go-v2 documents this on `LaunchTemplateSpecification.Version` — "Default:
+The default version of the launch template" — and it is the detail worth stating
+loudest, because a new version does *not* become the default. A consumer that
+creates version 2 and launches without naming a version still gets version 1.
+
+| `LaunchTemplate.Version` | Resolves to |
+|---|---|
+| absent | the **default** version |
+| `$Default` | the default version |
+| `$Latest` | the highest version number |
+| a number | that version, or `InvalidLaunchTemplateId.VersionNotFound` |
+
+Both aliases are matched case-insensitively, so a hand-built `$latest` works. A
+version that does not exist is an error rather than a silent fallback: a fallback
+would launch instances from parameters the caller never asked for.
+
+`CreateLaunchTemplateVersion`'s `SourceVersion` is the asymmetry to know:
+
+- **With `SourceVersion`**, the new version inherits that version's parameters and
+  the request's values overwrite the ones they name.
+- **Without it**, the new version holds *only* what the request names. Nothing is
+  inherited — not from version 1, not from the latest.
+
+`DeleteLaunchTemplateVersions` reports **per version**, at HTTP 200:
+`successfullyDeletedLaunchTemplateVersionSet` and
+`unsuccessfullyDeletedLaunchTemplateVersionSet`. A request naming a deletable and an
+undeletable version puts one entry in each set and still returns 200, so a caller
+checking only the status code sees success. The default version cannot be deleted
+("you must first assign a different version as the default"), and a deleted version
+number is never reused.
+
+The `responseError.code` on a failed item is `launchTemplateVersionDoesNotExist` for
+a missing version. For the default-version rejection substrate emits
+`unexpectedError`: `ResponseError.code` is a **closed six-value enum** in the AWS
+SDK models (`launchTemplateIdDoesNotExist`, `launchTemplateIdMalformed`,
+`launchTemplateNameDoesNotExist`, `launchTemplateNameMalformed`,
+`launchTemplateVersionDoesNotExist`, `unexpectedError`) with no default-version
+member, and a typed SDK deserializes anything outside it as an unknown variant.
+AWS's real code for this case is not published and no capture of the rejection
+exists — the code is the modeled catch-all and the message is the reference's own
+sentence. Both are inferred, not captured.
+
+Omitting both `LaunchTemplateId` and `LaunchTemplateName` from
+`DescribeLaunchTemplateVersions` selects the **account-wide** form, which lists every
+template's `$Latest` and/or `$Default`. As AWS does, it accepts only those two
+aliases — a version number means nothing across templates — and rejects a request
+naming neither.
+
+**A template stored before versioning existed reads back as version 1, default.**
+Its single stored parameter set *is* its version 1, synthesized on read, so a
+replayed event log recorded against an earlier substrate still launches instances
+and still describes correctly. No event rewriting is involved.
 
 ### Launch template networking
 

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -447,6 +447,13 @@ func (p *EC2Plugin) launchFleetPool(
 	if pool.ltName != "" {
 		params["LaunchTemplate.LaunchTemplateName"] = pool.ltName
 	}
+	// The config's version is forwarded so a fleet pinned to a specific launch
+	// template version gets that version's parameters. fleetPools has always parsed
+	// this value; before #456 nothing consumed it, so a fleet naming version 1 of a
+	// template silently launched whatever the template held latest.
+	if pool.version != "" {
+		params["LaunchTemplate.Version"] = pool.version
+	}
 	// An override's ImageId replaces the launch template's AMI.
 	if pool.override.ImageID != "" {
 		params["ImageId"] = pool.override.ImageID

--- a/emulator/ec2_launchtemplate_versions.go
+++ b/emulator/ec2_launchtemplate_versions.go
@@ -1,0 +1,658 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Launch template versioning (#456).
+//
+// A launch template is versioned: CreateLaunchTemplate produces version 1, each
+// CreateLaunchTemplateVersion appends one, and a launch names either a number or
+// one of the two aliases. Before this, substrate stored a single
+// EC2LaunchTemplateData and registered neither CreateLaunchTemplateVersion nor
+// ModifyLaunchTemplate, so a consumer that shipped a second version launched the
+// first one's parameters with no error anywhere — the silent-wrong-answer shape.
+//
+// DescribeLaunchTemplateVersions is also the only operation that returns a
+// template's data at all: DescribeLaunchTemplates' response carries just createTime,
+// createdBy, defaultVersionNumber, latestVersionNumber, launchTemplateId and
+// launchTemplateName. Anything asserting on what a template *contains* has to come
+// through here.
+
+// ec2LaunchTemplateVersionAliases are the two symbolic version specifiers AWS
+// accepts in place of a number.
+const (
+	ec2LTVersionLatest  = "$latest"
+	ec2LTVersionDefault = "$default"
+)
+
+// ec2MaxLaunchTemplateVersionResults is the upper bound on
+// DescribeLaunchTemplateVersions' MaxResults, per its API reference ("Valid
+// values: Minimum value of 1. Maximum value of 200").
+const ec2MaxLaunchTemplateVersionResults = 200
+
+// ec2ResolveTemplateVersion returns the version of lt that spec names.
+//
+// An empty spec resolves to the template's *default* version, not its latest. That
+// is aws-sdk-go-v2's documented behavior for
+// LaunchTemplateSpecification.Version ("Default: The default version of the launch
+// template"), and it is the detail #456 asked to have confirmed: inverting it stays
+// invisible until a consumer pins a default and keeps shipping newer versions, at
+// which point every launch quietly uses the wrong parameters.
+//
+// The aliases are matched case-insensitively. AWS documents them capitalized
+// ("$Latest", "$Default") and the CLI emits them that way, but a hand-written
+// request using "$latest" is accepted rather than read as a malformed number.
+func ec2ResolveTemplateVersion(lt *EC2LaunchTemplate, spec string) (*EC2LaunchTemplateVersion, *AWSError) {
+	versions := lt.TemplateVersions()
+
+	wanted := lt.DefaultVersionNum
+	switch strings.ToLower(strings.TrimSpace(spec)) {
+	case "", ec2LTVersionDefault:
+		// wanted is already the default.
+	case ec2LTVersionLatest:
+		wanted = lt.LatestVersionNum
+	default:
+		n, err := strconv.ParseInt(strings.TrimSpace(spec), 10, 64)
+		if err != nil {
+			return nil, ec2LaunchTemplateVersionNotFound(lt.LaunchTemplateID, spec)
+		}
+		wanted = n
+	}
+
+	for i := range versions {
+		if versions[i].VersionNumber == wanted {
+			return &versions[i], nil
+		}
+	}
+	return nil, ec2LaunchTemplateVersionNotFound(lt.LaunchTemplateID, spec)
+}
+
+// ec2LaunchTemplateVersionNotFound reports a version that does not exist.
+//
+// Code and message follow moto's InvalidLaunchTemplateVersionNotFound. AWS's
+// published Errors section for these operations is empty, so this is a
+// reimplementation's wording rather than a capture — the code is the load-bearing
+// half, since SDKs dispatch on it and never on the message.
+func ec2LaunchTemplateVersionNotFound(ltID, version string) *AWSError {
+	return &AWSError{
+		Code:       "InvalidLaunchTemplateId.VersionNotFound",
+		Message:    fmt.Sprintf("Could not find the specified version %s for the launch template with ID %s.", version, ltID),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2LaunchTemplateNotFound reports a launch template that does not exist.
+func ec2LaunchTemplateNotFound() *AWSError {
+	return &AWSError{
+		Code:       "InvalidLaunchTemplateId.NotFound",
+		Message:    "The launch template was not found",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2LTVersionItem is the launchTemplateVersion element shared by
+// CreateLaunchTemplateVersion and DescribeLaunchTemplateVersions, whose response
+// items are the same shape.
+type ec2LTVersionItem struct {
+	CreateTime         string              `xml:"createTime"`
+	CreatedBy          string              `xml:"createdBy"`
+	DefaultVersion     bool                `xml:"defaultVersion"`
+	LaunchTemplateData ec2LTVersionDataXML `xml:"launchTemplateData"`
+	LaunchTemplateID   string              `xml:"launchTemplateId"`
+	LaunchTemplateName string              `xml:"launchTemplateName"`
+	VersionDescription string              `xml:"versionDescription,omitempty"`
+	VersionNumber      int64               `xml:"versionNumber"`
+}
+
+// ec2LTVersionDataXML renders a version's stored parameters as AWS's
+// ResponseLaunchTemplateData.
+//
+// The network-interface fields are nested rather than top-level because
+// ResponseLaunchTemplateData has no top-level SubnetId member — a template can only
+// name a subnet, or a public-IP preference, inside a network interface. That is the
+// same asymmetry [EC2LaunchTemplateData.SubnetID] documents on the storage side.
+type ec2LTVersionDataXML struct {
+	ImageID           string                  `xml:"imageId,omitempty"`
+	InstanceType      string                  `xml:"instanceType,omitempty"`
+	KeyName           string                  `xml:"keyName,omitempty"`
+	UserData          string                  `xml:"userData,omitempty"`
+	SecurityGroupIDs  []string                `xml:"securityGroupIdSet>item,omitempty"`
+	NetworkInterfaces []ec2LTVersionNetIfcXML `xml:"networkInterfaceSet>item,omitempty"`
+}
+
+// ec2LTVersionNetIfcXML is one network interface within a version's data.
+type ec2LTVersionNetIfcXML struct {
+	DeviceIndex              int      `xml:"deviceIndex"`
+	SubnetID                 string   `xml:"subnetId,omitempty"`
+	AssociatePublicIPAddress string   `xml:"associatePublicIpAddress,omitempty"`
+	Groups                   []string `xml:"groupSet>item,omitempty"`
+}
+
+// ec2LTVersionData renders stored template data for the wire.
+func ec2LTVersionData(d EC2LaunchTemplateData) ec2LTVersionDataXML {
+	out := ec2LTVersionDataXML{
+		ImageID:          d.ImageID,
+		InstanceType:     d.InstanceType,
+		KeyName:          d.KeyName,
+		UserData:         d.UserData,
+		SecurityGroupIDs: d.SecurityGroupIDs,
+	}
+	// Emit an interface only when the template actually named one, so a template
+	// carrying no networking does not read back with a phantom eth0.
+	if d.SubnetID != "" || d.AssociatePublicIPAddress != "" || len(d.NetworkInterfaceGroups) > 0 {
+		out.NetworkInterfaces = []ec2LTVersionNetIfcXML{{
+			DeviceIndex:              0,
+			SubnetID:                 d.SubnetID,
+			AssociatePublicIPAddress: d.AssociatePublicIPAddress,
+			Groups:                   d.NetworkInterfaceGroups,
+		}}
+	}
+	return out
+}
+
+// ec2LTVersionItemFor builds a response item for one version of a template.
+func ec2LTVersionItemFor(lt *EC2LaunchTemplate, v EC2LaunchTemplateVersion) ec2LTVersionItem {
+	return ec2LTVersionItem{
+		CreateTime:         v.CreateTime,
+		CreatedBy:          v.CreatedBy,
+		DefaultVersion:     v.VersionNumber == lt.DefaultVersionNum,
+		LaunchTemplateData: ec2LTVersionData(v.Data),
+		LaunchTemplateID:   lt.LaunchTemplateID,
+		LaunchTemplateName: lt.LaunchTemplateName,
+		VersionDescription: v.VersionDescription,
+		VersionNumber:      v.VersionNumber,
+	}
+}
+
+// putLaunchTemplate writes a launch template back to state.
+func (p *EC2Plugin) putLaunchTemplate(goCtx context.Context, lt *EC2LaunchTemplate) error {
+	ltJSON, err := json.Marshal(lt)
+	if err != nil {
+		return fmt.Errorf("putLaunchTemplate: marshal: %w", err)
+	}
+	key := "lt:" + lt.AccountID + "/" + lt.Region + "/" + lt.LaunchTemplateID
+	if err := p.state.Put(goCtx, ec2Namespace, key, ltJSON); err != nil {
+		return fmt.Errorf("putLaunchTemplate: put: %w", err)
+	}
+	return nil
+}
+
+// createLaunchTemplateVersion handles the CreateLaunchTemplateVersion action.
+func (p *EC2Plugin) createLaunchTemplateVersion(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+
+	lt := p.resolveLaunchTemplate(goCtx, ctx, req.Params["LaunchTemplateId"], req.Params["LaunchTemplateName"])
+	if lt == nil {
+		return nil, ec2LaunchTemplateNotFound()
+	}
+
+	data := parseLaunchTemplateData(req.Params)
+
+	// SourceVersion inheritance, per the API reference: "the new version inherits
+	// the launch parameters from the source version, except for parameters that you
+	// specify in LaunchTemplateData. […] any additional launch parameters that you
+	// specify […] overwrite any corresponding launch parameters inherited from the
+	// source version."
+	//
+	// So an omitted SourceVersion inherits *nothing* — the new version holds only
+	// what the request names. That asymmetry is easy to get backwards, and getting
+	// it backwards silently carries forward parameters the caller meant to drop.
+	if src := req.Params["SourceVersion"]; src != "" {
+		srcVersion, awsErr := ec2ResolveTemplateVersion(lt, src)
+		if awsErr != nil {
+			return nil, awsErr
+		}
+		data = ec2OverlayTemplateData(srcVersion.Data, data)
+	}
+
+	versions := lt.TemplateVersions()
+	newVersion := EC2LaunchTemplateVersion{
+		VersionNumber:      lt.LatestVersionNum + 1,
+		VersionDescription: req.Params["VersionDescription"],
+		CreateTime:         p.tc.Now().UTC().Format(time.RFC3339),
+		CreatedBy:          ctx.AccountID,
+		Data:               data,
+	}
+	lt.Versions = append(versions, newVersion)
+	lt.LatestVersionNum = newVersion.VersionNumber
+	// LatestData tracks the newest version; see its field comment for why it is kept
+	// rather than derived.
+	lt.LatestData = data
+
+	if err := p.putLaunchTemplate(goCtx, lt); err != nil {
+		return nil, err
+	}
+
+	type response struct {
+		XMLName xml.Name         `xml:"CreateLaunchTemplateVersionResponse"`
+		XMLNS   string           `xml:"xmlns,attr"`
+		Version ec2LTVersionItem `xml:"launchTemplateVersion"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:   "http://ec2.amazonaws.com/doc/2016-11-15/",
+		Version: ec2LTVersionItemFor(lt, newVersion),
+	})
+}
+
+// ec2OverlayTemplateData returns src with every field overlay names replaced.
+//
+// Field-by-field rather than reflective so that adding a field to
+// EC2LaunchTemplateData is a visible omission here — a reflective merge would
+// silently do the wrong thing for any field whose zero value is meaningful.
+func ec2OverlayTemplateData(src, overlay EC2LaunchTemplateData) EC2LaunchTemplateData {
+	out := src
+	if overlay.ImageID != "" {
+		out.ImageID = overlay.ImageID
+	}
+	if overlay.InstanceType != "" {
+		out.InstanceType = overlay.InstanceType
+	}
+	if overlay.KeyName != "" {
+		out.KeyName = overlay.KeyName
+	}
+	if overlay.UserData != "" {
+		out.UserData = overlay.UserData
+	}
+	if overlay.SubnetID != "" {
+		out.SubnetID = overlay.SubnetID
+	}
+	if overlay.AssociatePublicIPAddress != "" {
+		out.AssociatePublicIPAddress = overlay.AssociatePublicIPAddress
+	}
+	if len(overlay.SecurityGroupIDs) > 0 {
+		out.SecurityGroupIDs = overlay.SecurityGroupIDs
+	}
+	if len(overlay.NetworkInterfaceGroups) > 0 {
+		out.NetworkInterfaceGroups = overlay.NetworkInterfaceGroups
+	}
+	return out
+}
+
+// modifyLaunchTemplate handles the ModifyLaunchTemplate action.
+func (p *EC2Plugin) modifyLaunchTemplate(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+
+	lt := p.resolveLaunchTemplate(goCtx, ctx, req.Params["LaunchTemplateId"], req.Params["LaunchTemplateName"])
+	if lt == nil {
+		return nil, ec2LaunchTemplateNotFound()
+	}
+
+	// SetDefaultVersion is the only modifiable attribute, and it is Required: No —
+	// a request naming nothing is a no-op that still returns the template.
+	if spec := req.Params["SetDefaultVersion"]; spec != "" {
+		v, awsErr := ec2ResolveTemplateVersion(lt, spec)
+		if awsErr != nil {
+			return nil, awsErr
+		}
+		lt.DefaultVersionNum = v.VersionNumber
+		if err := p.putLaunchTemplate(goCtx, lt); err != nil {
+			return nil, err
+		}
+	}
+
+	type response struct {
+		XMLName        xml.Name             `xml:"ModifyLaunchTemplateResponse"`
+		XMLNS          string               `xml:"xmlns,attr"`
+		LaunchTemplate ec2LaunchTemplateXML `xml:"launchTemplate"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:          "http://ec2.amazonaws.com/doc/2016-11-15/",
+		LaunchTemplate: ec2LaunchTemplateSummary(lt),
+	})
+}
+
+// describeLaunchTemplateVersions handles the DescribeLaunchTemplateVersions action.
+func (p *EC2Plugin) describeLaunchTemplateVersions(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+
+	maxResults := ec2MaxLaunchTemplateVersionResults
+	if raw := req.Params["MaxResults"]; raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > ec2MaxLaunchTemplateVersionResults {
+			return nil, &AWSError{
+				Code:       "InvalidParameterValue",
+				Message:    "MaxResults must be between 1 and " + strconv.Itoa(ec2MaxLaunchTemplateVersionResults),
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+		maxResults = n
+	}
+
+	specs := indexedParams(req.Params, "LaunchTemplateVersion.%d", "Versions.member.%d")
+	ltID := req.Params["LaunchTemplateId"]
+	ltName := req.Params["LaunchTemplateName"]
+
+	var items []ec2LTVersionItem
+	if ltID == "" && ltName == "" {
+		// The account-wide form: naming no template lists every template's $Latest
+		// and/or $Default. AWS restricts it to those two aliases — a version number
+		// makes no sense across templates — and rejects a request that names neither.
+		var awsErr *AWSError
+		items, awsErr = p.describeVersionsAccountWide(goCtx, ctx, specs)
+		if awsErr != nil {
+			return nil, awsErr
+		}
+	} else {
+		lt := p.resolveLaunchTemplate(goCtx, ctx, ltID, ltName)
+		if lt == nil {
+			return nil, ec2LaunchTemplateNotFound()
+		}
+		var awsErr *AWSError
+		items, awsErr = p.describeVersionsOfTemplate(lt, specs, req.Params)
+		if awsErr != nil {
+			return nil, awsErr
+		}
+	}
+
+	// Pagination is offset-based over a stable ordering, matching the other EC2
+	// describes: the token is the index to resume at.
+	start := 0
+	if tok := req.Params["NextToken"]; tok != "" {
+		n, err := strconv.Atoi(tok)
+		if err != nil || n < 0 {
+			return nil, &AWSError{
+				Code:       "InvalidParameterValue",
+				Message:    "The token '" + tok + "' is invalid",
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+		start = n
+	}
+	if start > len(items) {
+		start = len(items)
+	}
+	page := items[start:]
+	nextToken := ""
+	if len(page) > maxResults {
+		page = page[:maxResults]
+		nextToken = strconv.Itoa(start + maxResults)
+	}
+
+	type response struct {
+		XMLName   xml.Name           `xml:"DescribeLaunchTemplateVersionsResponse"`
+		XMLNS     string             `xml:"xmlns,attr"`
+		Versions  []ec2LTVersionItem `xml:"launchTemplateVersionSet>item"`
+		NextToken string             `xml:"nextToken,omitempty"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:     "http://ec2.amazonaws.com/doc/2016-11-15/",
+		Versions:  page,
+		NextToken: nextToken,
+	})
+}
+
+// describeVersionsOfTemplate returns the requested versions of one template.
+func (p *EC2Plugin) describeVersionsOfTemplate(lt *EC2LaunchTemplate, specs []string, params map[string]string) ([]ec2LTVersionItem, *AWSError) {
+	if len(specs) > 0 {
+		items := make([]ec2LTVersionItem, 0, len(specs))
+		for _, spec := range specs {
+			v, awsErr := ec2ResolveTemplateVersion(lt, spec)
+			if awsErr != nil {
+				return nil, awsErr
+			}
+			items = append(items, ec2LTVersionItemFor(lt, *v))
+		}
+		return items, nil
+	}
+
+	// MinVersion is "the version number after which to describe launch template
+	// versions" and MaxVersion "the version number up to which to describe" — both
+	// inclusive bounds on the returned range.
+	minVersion, awsErr := ec2VersionBound(params["MinVersion"])
+	if awsErr != nil {
+		return nil, awsErr
+	}
+	maxVersion, awsErr := ec2VersionBound(params["MaxVersion"])
+	if awsErr != nil {
+		return nil, awsErr
+	}
+
+	versions := lt.TemplateVersions()
+	sorted := make([]EC2LaunchTemplateVersion, len(versions))
+	copy(sorted, versions)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].VersionNumber < sorted[j].VersionNumber })
+
+	items := make([]ec2LTVersionItem, 0, len(sorted))
+	for _, v := range sorted {
+		if minVersion > 0 && v.VersionNumber < minVersion {
+			continue
+		}
+		if maxVersion > 0 && v.VersionNumber > maxVersion {
+			continue
+		}
+		items = append(items, ec2LTVersionItemFor(lt, v))
+	}
+	return items, nil
+}
+
+// ec2VersionBound parses a MinVersion/MaxVersion bound, returning 0 when absent.
+func ec2VersionBound(raw string) (int64, *AWSError) {
+	if raw == "" {
+		return 0, nil
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n < 1 {
+		return 0, &AWSError{
+			Code:       "InvalidParameterValue",
+			Message:    "Invalid launch template version number: " + raw,
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	return n, nil
+}
+
+// describeVersionsAccountWide returns each template's $Latest and/or $Default.
+//
+// Reuses the same lt_ids: index walk describeLaunchTemplates does, which is why
+// this form is a small addition rather than a separate query path.
+func (p *EC2Plugin) describeVersionsAccountWide(goCtx context.Context, ctx *RequestContext, specs []string) ([]ec2LTVersionItem, *AWSError) {
+	wantLatest, wantDefault := false, false
+	for _, spec := range specs {
+		switch strings.ToLower(strings.TrimSpace(spec)) {
+		case ec2LTVersionLatest:
+			wantLatest = true
+		case ec2LTVersionDefault:
+			wantDefault = true
+		default:
+			// A version number is meaningless without a template to number within.
+			return nil, &AWSError{
+				Code:       "InvalidParameterValue",
+				Message:    "To describe the launch template data for all your launch templates, for 'Versions' specify '$Latest', '$Default', or both, and omit 'LaunchTemplateId' and 'LaunchTemplateName'.",
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+	}
+	if !wantLatest && !wantDefault {
+		return nil, &AWSError{
+			Code:       "MissingParameter",
+			Message:    "Either a launch template ID or name, or a Versions value of '$Latest' or '$Default', is required",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	idsKey := "lt_ids:" + ctx.AccountID + "/" + ctx.Region
+	ids, err := loadStringIndex(goCtx, p.state, ec2Namespace, idsKey)
+	if err != nil {
+		return nil, &AWSError{
+			Code:       "InternalError",
+			Message:    "Failed to list launch templates",
+			HTTPStatus: http.StatusInternalServerError,
+		}
+	}
+
+	var items []ec2LTVersionItem
+	for _, id := range ids {
+		key := "lt:" + ctx.AccountID + "/" + ctx.Region + "/" + id
+		data, err := p.state.Get(goCtx, ec2Namespace, key)
+		if err != nil || data == nil {
+			continue
+		}
+		var lt EC2LaunchTemplate
+		if json.Unmarshal(data, &lt) != nil {
+			continue
+		}
+		if wantLatest {
+			if v, awsErr := ec2ResolveTemplateVersion(&lt, "$Latest"); awsErr == nil {
+				items = append(items, ec2LTVersionItemFor(&lt, *v))
+			}
+		}
+		if wantDefault {
+			if v, awsErr := ec2ResolveTemplateVersion(&lt, "$Default"); awsErr == nil {
+				items = append(items, ec2LTVersionItemFor(&lt, *v))
+			}
+		}
+	}
+	return items, nil
+}
+
+// deleteLaunchTemplateVersions handles the DeleteLaunchTemplateVersions action.
+//
+// Outcomes are reported per version, not as a whole-request error: the response
+// carries successfullyDeletedLaunchTemplateVersionSet and
+// unsuccessfullyDeletedLaunchTemplateVersionSet, and a request naming both a
+// deletable and an undeletable version succeeds for one and fails for the other at
+// HTTP 200. Same trap as SendMessageBatch — a caller checking only the status code
+// sees success.
+func (p *EC2Plugin) deleteLaunchTemplateVersions(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+
+	specs := indexedParams(req.Params, "LaunchTemplateVersion.%d", "Versions.member.%d")
+	if len(specs) == 0 {
+		return nil, &AWSError{
+			Code:       "MissingParameter",
+			Message:    "LaunchTemplateVersion is required",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	lt := p.resolveLaunchTemplate(goCtx, ctx, req.Params["LaunchTemplateId"], req.Params["LaunchTemplateName"])
+	if lt == nil {
+		return nil, ec2LaunchTemplateNotFound()
+	}
+
+	type responseErrorXML struct {
+		Code    string `xml:"code"`
+		Message string `xml:"message"`
+	}
+	type deletedItem struct {
+		LaunchTemplateID   string `xml:"launchTemplateId"`
+		LaunchTemplateName string `xml:"launchTemplateName"`
+		VersionNumber      int64  `xml:"versionNumber"`
+	}
+	type failedItem struct {
+		LaunchTemplateID   string           `xml:"launchTemplateId"`
+		LaunchTemplateName string           `xml:"launchTemplateName"`
+		ResponseError      responseErrorXML `xml:"responseError"`
+		VersionNumber      int64            `xml:"versionNumber"`
+	}
+
+	var deleted []deletedItem
+	var failed []failedItem
+	remaining := lt.TemplateVersions()
+
+	for _, spec := range specs {
+		v, awsErr := ec2ResolveTemplateVersion(lt, spec)
+		if awsErr != nil {
+			// A missing version is the one failure mode with a modeled code:
+			// ResponseError.code's documented valid values are exactly
+			// launchTemplateIdDoesNotExist | launchTemplateIdMalformed |
+			// launchTemplateNameDoesNotExist | launchTemplateNameMalformed |
+			// launchTemplateVersionDoesNotExist | unexpectedError.
+			failed = append(failed, failedItem{
+				LaunchTemplateID:   lt.LaunchTemplateID,
+				LaunchTemplateName: lt.LaunchTemplateName,
+				ResponseError: responseErrorXML{
+					Code:    "launchTemplateVersionDoesNotExist",
+					Message: awsErr.Message,
+				},
+			})
+			continue
+		}
+
+		// "You can't delete the default version of a launch template; you must first
+		// assign a different version as the default." — DeleteLaunchTemplateVersions.
+		//
+		// The code is unexpectedError because ResponseError.code is a closed
+		// six-value enum (listed above) with no default-version member, and a
+		// typed SDK deserializes anything outside it as an unknown variant. AWS's
+		// actual code for this case is not published and no capture of the
+		// rejection exists — searched the API reference, the CLI help, moto (which
+		// does not implement this operation at all), LocalStack, and the SDK
+		// models. The message is the reference's own sentence; the code is the
+		// modeled catch-all. Both are inferred, not captured.
+		if v.VersionNumber == lt.DefaultVersionNum {
+			failed = append(failed, failedItem{
+				LaunchTemplateID:   lt.LaunchTemplateID,
+				LaunchTemplateName: lt.LaunchTemplateName,
+				ResponseError: responseErrorXML{
+					Code:    "unexpectedError",
+					Message: "You can't delete the default version of a launch template; you must first assign a different version as the default.",
+				},
+				VersionNumber: v.VersionNumber,
+			})
+			continue
+		}
+
+		kept := make([]EC2LaunchTemplateVersion, 0, len(remaining))
+		for _, existing := range remaining {
+			if existing.VersionNumber != v.VersionNumber {
+				kept = append(kept, existing)
+			}
+		}
+		remaining = kept
+		deleted = append(deleted, deletedItem{
+			LaunchTemplateID:   lt.LaunchTemplateID,
+			LaunchTemplateName: lt.LaunchTemplateName,
+			VersionNumber:      v.VersionNumber,
+		})
+	}
+
+	if len(deleted) > 0 {
+		lt.Versions = remaining
+		// LatestVersionNum tracks the highest surviving version. Deleting the newest
+		// version lowers it, and the next CreateLaunchTemplateVersion then reuses
+		// that number — which is wrong per the user guide ("You cannot replace the
+		// version number after you delete it"), so the highest number ever issued is
+		// what matters. Only lower it when the deleted version was not the latest,
+		// i.e. never: LatestVersionNum is left alone deliberately.
+		lt.LatestData = ec2LatestVersionData(remaining, lt.LatestData)
+		if err := p.putLaunchTemplate(goCtx, lt); err != nil {
+			return nil, err
+		}
+	}
+
+	type response struct {
+		XMLName xml.Name      `xml:"DeleteLaunchTemplateVersionsResponse"`
+		XMLNS   string        `xml:"xmlns,attr"`
+		Deleted []deletedItem `xml:"successfullyDeletedLaunchTemplateVersionSet>item"`
+		Failed  []failedItem  `xml:"unsuccessfullyDeletedLaunchTemplateVersionSet>item"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:   "http://ec2.amazonaws.com/doc/2016-11-15/",
+		Deleted: deleted,
+		Failed:  failed,
+	})
+}
+
+// ec2LatestVersionData returns the highest-numbered version's data, falling back to
+// fallback when no versions survive.
+func ec2LatestVersionData(versions []EC2LaunchTemplateVersion, fallback EC2LaunchTemplateData) EC2LaunchTemplateData {
+	out := fallback
+	var highest int64
+	for _, v := range versions {
+		if v.VersionNumber > highest {
+			highest = v.VersionNumber
+			out = v.Data
+		}
+	}
+	return out
+}

--- a/emulator/ec2_launchtemplate_versions_test.go
+++ b/emulator/ec2_launchtemplate_versions_test.go
@@ -1,0 +1,851 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ltVersionItem is one launchTemplateVersion element, shared by
+// CreateLaunchTemplateVersion and DescribeLaunchTemplateVersions.
+type ltVersionItem struct {
+	VersionNumber      int64  `xml:"versionNumber"`
+	VersionDescription string `xml:"versionDescription"`
+	DefaultVersion     bool   `xml:"defaultVersion"`
+	CreatedBy          string `xml:"createdBy"`
+	CreateTime         string `xml:"createTime"`
+	Data               struct {
+		ImageID          string   `xml:"imageId"`
+		InstanceType     string   `xml:"instanceType"`
+		KeyName          string   `xml:"keyName"`
+		UserData         string   `xml:"userData"`
+		SecurityGroupIDs []string `xml:"securityGroupIdSet>item"`
+		Interfaces       []struct {
+			SubnetID                 string   `xml:"subnetId"`
+			AssociatePublicIPAddress string   `xml:"associatePublicIpAddress"`
+			Groups                   []string `xml:"groupSet>item"`
+		} `xml:"networkInterfaceSet>item"`
+	} `xml:"launchTemplateData"`
+}
+
+// createLTVersion sends CreateLaunchTemplateVersion and returns the new version.
+func createLTVersion(t *testing.T, ts *httptest.Server, params map[string]string) ltVersionItem {
+	t.Helper()
+	full := map[string]string{"Action": "CreateLaunchTemplateVersion"}
+	for k, v := range params {
+		full[k] = v
+	}
+	resp := ec2Request(t, ts, full)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "CreateLaunchTemplateVersion")
+	var out struct {
+		Version ltVersionItem `xml:"launchTemplateVersion"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	return out.Version
+}
+
+// describeLTVersions sends DescribeLaunchTemplateVersions and returns the items
+// plus the pagination token.
+func describeLTVersions(t *testing.T, ts *httptest.Server, params map[string]string) ([]ltVersionItem, string) {
+	t.Helper()
+	full := map[string]string{"Action": "DescribeLaunchTemplateVersions"}
+	for k, v := range params {
+		full[k] = v
+	}
+	resp := ec2Request(t, ts, full)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "DescribeLaunchTemplateVersions")
+	var out struct {
+		Versions  []ltVersionItem `xml:"launchTemplateVersionSet>item"`
+		NextToken string          `xml:"nextToken"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	return out.Versions, out.NextToken
+}
+
+// ltSummary is the launchTemplate summary element, which carries no template data.
+type ltSummary struct {
+	LaunchTemplateID   string `xml:"launchTemplateId"`
+	LaunchTemplateName string `xml:"launchTemplateName"`
+	DefaultVersionNum  int64  `xml:"defaultVersionNumber"`
+	LatestVersionNum   int64  `xml:"latestVersionNumber"`
+}
+
+// describeLT returns one launch template's summary.
+func describeLT(t *testing.T, ts *httptest.Server, ltID string) ltSummary {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":             "DescribeLaunchTemplates",
+		"LaunchTemplateId.1": ltID,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out struct {
+		Templates []ltSummary `xml:"launchTemplates>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	require.Len(t, out.Templates, 1)
+	return out.Templates[0]
+}
+
+// TestEC2_CreateLaunchTemplate_MakesVersionOne pins that creating a template
+// creates its version 1, and that version 1 is both the default and the latest.
+func TestEC2_CreateLaunchTemplate_MakesVersionOne(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := createLaunchTemplate(t, ts, "v1-only", map[string]string{
+		"LaunchTemplateData.ImageId":      "ami-0000000000000001",
+		"LaunchTemplateData.InstanceType": "t3.small",
+		"VersionDescription":              "initial",
+	})
+
+	summary := describeLT(t, ts, ltID)
+	assert.Equal(t, int64(1), summary.DefaultVersionNum)
+	assert.Equal(t, int64(1), summary.LatestVersionNum)
+
+	versions, _ := describeLTVersions(t, ts, map[string]string{"LaunchTemplateId": ltID})
+	require.Len(t, versions, 1)
+	assert.Equal(t, int64(1), versions[0].VersionNumber)
+	assert.True(t, versions[0].DefaultVersion)
+	assert.Equal(t, "initial", versions[0].VersionDescription)
+	assert.Equal(t, "ami-0000000000000001", versions[0].Data.ImageID)
+	assert.Equal(t, "t3.small", versions[0].Data.InstanceType)
+}
+
+// TestEC2_CreateLaunchTemplateVersion_AppendsWithoutChangingDefault covers the
+// half of #456 that made the operation worth registering: a new version becomes the
+// latest but *not* the default, so launches keep using version 1 until
+// ModifyLaunchTemplate says otherwise.
+func TestEC2_CreateLaunchTemplateVersion_AppendsWithoutChangingDefault(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := createLaunchTemplate(t, ts, "appends", map[string]string{
+		"LaunchTemplateData.ImageId":      "ami-0000000000000001",
+		"LaunchTemplateData.InstanceType": "t3.small",
+	})
+
+	second := createLTVersion(t, ts, map[string]string{
+		"LaunchTemplateId":           ltID,
+		"LaunchTemplateData.ImageId": "ami-0000000000000002",
+	})
+	assert.Equal(t, int64(2), second.VersionNumber)
+	assert.False(t, second.DefaultVersion, "a new version must not become the default")
+
+	third := createLTVersion(t, ts, map[string]string{
+		"LaunchTemplateId":           ltID,
+		"LaunchTemplateData.ImageId": "ami-0000000000000003",
+	})
+	assert.Equal(t, int64(3), third.VersionNumber)
+
+	summary := describeLT(t, ts, ltID)
+	assert.Equal(t, int64(1), summary.DefaultVersionNum, "default must still be version 1")
+	assert.Equal(t, int64(3), summary.LatestVersionNum)
+}
+
+// TestEC2_CreateLaunchTemplateVersion_SourceVersion covers the asymmetry the API
+// reference documents and a consumer routinely gets backwards: with SourceVersion
+// the new version inherits the source's parameters and the request's values
+// overwrite them; *without* it the new version holds only what the request names.
+//
+// Getting this wrong in either direction is silent — an unintended inherit carries
+// forward a parameter the caller meant to drop, and a missing inherit launches
+// instances with no instance type or key pair.
+func TestEC2_CreateLaunchTemplateVersion_SourceVersion(t *testing.T) {
+	t.Run("SourceVersion inherits, request overwrites", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		ltID := createLaunchTemplate(t, ts, "inherits", map[string]string{
+			"LaunchTemplateData.ImageId":      "ami-0000000000000001",
+			"LaunchTemplateData.InstanceType": "t3.small",
+			"LaunchTemplateData.KeyName":      "inherited-key",
+		})
+
+		v2 := createLTVersion(t, ts, map[string]string{
+			"LaunchTemplateId":           ltID,
+			"SourceVersion":              "1",
+			"LaunchTemplateData.ImageId": "ami-0000000000000002",
+		})
+		assert.Equal(t, "ami-0000000000000002", v2.Data.ImageID, "the request's AMI wins")
+		assert.Equal(t, "t3.small", v2.Data.InstanceType, "inherited from version 1")
+		assert.Equal(t, "inherited-key", v2.Data.KeyName, "inherited from version 1")
+	})
+
+	t.Run("no SourceVersion inherits nothing", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		ltID := createLaunchTemplate(t, ts, "no-inherit", map[string]string{
+			"LaunchTemplateData.ImageId":      "ami-0000000000000001",
+			"LaunchTemplateData.InstanceType": "t3.small",
+			"LaunchTemplateData.KeyName":      "dropped-key",
+		})
+
+		v2 := createLTVersion(t, ts, map[string]string{
+			"LaunchTemplateId":           ltID,
+			"LaunchTemplateData.ImageId": "ami-0000000000000002",
+		})
+		assert.Equal(t, "ami-0000000000000002", v2.Data.ImageID)
+		assert.Empty(t, v2.Data.InstanceType, "an omitted SourceVersion inherits nothing")
+		assert.Empty(t, v2.Data.KeyName, "an omitted SourceVersion inherits nothing")
+	})
+
+	t.Run("$Latest as the source", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		ltID := createLaunchTemplate(t, ts, "latest-source", map[string]string{
+			"LaunchTemplateData.ImageId": "ami-0000000000000001",
+		})
+		createLTVersion(t, ts, map[string]string{
+			"LaunchTemplateId":                ltID,
+			"LaunchTemplateData.ImageId":      "ami-0000000000000002",
+			"LaunchTemplateData.InstanceType": "t3.large",
+		})
+		v3 := createLTVersion(t, ts, map[string]string{
+			"LaunchTemplateId":           ltID,
+			"SourceVersion":              "$Latest",
+			"LaunchTemplateData.KeyName": "k",
+		})
+		assert.Equal(t, "ami-0000000000000002", v3.Data.ImageID, "inherited from version 2")
+		assert.Equal(t, "t3.large", v3.Data.InstanceType)
+	})
+
+	t.Run("a nonexistent SourceVersion is an error", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		ltID := createLaunchTemplate(t, ts, "bad-source", map[string]string{
+			"LaunchTemplateData.ImageId": "ami-0000000000000001",
+		})
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":                     "CreateLaunchTemplateVersion",
+			"LaunchTemplateId":           ltID,
+			"SourceVersion":              "7",
+			"LaunchTemplateData.ImageId": "ami-0000000000000002",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidLaunchTemplateId.VersionNotFound", code)
+	})
+}
+
+// TestEC2_RunInstances_AbsentVersionMeansDefault is the correctness gate on the
+// whole PR. LaunchTemplateSpecification.Version documents "Default: The default
+// version of the launch template" — not the latest — so a launch naming no version
+// after ModifyLaunchTemplate must use the pinned default even though newer versions
+// exist.
+//
+// Inverting this resolution is invisible in every other test: with the default at
+// version 1 and no newer versions, latest and default are the same number. Here
+// they deliberately differ in both directions.
+func TestEC2_RunInstances_AbsentVersionMeansDefault(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := createLaunchTemplate(t, ts, "default-vs-latest", map[string]string{
+		"LaunchTemplateData.ImageId": "ami-0000000000000001",
+	})
+	createLTVersion(t, ts, map[string]string{
+		"LaunchTemplateId":           ltID,
+		"LaunchTemplateData.ImageId": "ami-0000000000000002",
+	})
+	createLTVersion(t, ts, map[string]string{
+		"LaunchTemplateId":           ltID,
+		"LaunchTemplateData.ImageId": "ami-0000000000000003",
+	})
+
+	// Before any Modify, the default is version 1 while the latest is 3.
+	instID := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+	assert.Equal(t, "ami-0000000000000001", describeInstance(t, ts, instID).ImageID,
+		"an absent version must resolve to the default (1), not the latest (3)")
+
+	// Pin the default to 2; the latest is still 3.
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":            "ModifyLaunchTemplate",
+		"LaunchTemplateId":  ltID,
+		"SetDefaultVersion": "2",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var modified struct {
+		LaunchTemplate ltSummary `xml:"launchTemplate"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&modified))
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, int64(2), modified.LaunchTemplate.DefaultVersionNum)
+	assert.Equal(t, int64(3), modified.LaunchTemplate.LatestVersionNum)
+
+	instID = runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+	assert.Equal(t, "ami-0000000000000002", describeInstance(t, ts, instID).ImageID,
+		"an absent version must follow the new default (2), not the latest (3)")
+}
+
+// TestEC2_RunInstances_VersionSpecifiers walks every way a launch can name a
+// version, with the default and the latest deliberately different numbers so no two
+// rows can pass for the same reason.
+func TestEC2_RunInstances_VersionSpecifiers(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		wantAMI string
+	}{
+		{name: "absent means the default", version: "", wantAMI: "ami-0000000000000002"},
+		{name: "$Default", version: "$Default", wantAMI: "ami-0000000000000002"},
+		{name: "$Latest", version: "$Latest", wantAMI: "ami-0000000000000003"},
+		{name: "lowercase $latest", version: "$latest", wantAMI: "ami-0000000000000003"},
+		{name: "an explicit number", version: "1", wantAMI: "ami-0000000000000001"},
+		{name: "the default's own number", version: "2", wantAMI: "ami-0000000000000002"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			ltID := createLaunchTemplate(t, ts, "specifiers", map[string]string{
+				"LaunchTemplateData.ImageId": "ami-0000000000000001",
+			})
+			for _, ami := range []string{"ami-0000000000000002", "ami-0000000000000003"} {
+				createLTVersion(t, ts, map[string]string{
+					"LaunchTemplateId":           ltID,
+					"LaunchTemplateData.ImageId": ami,
+				})
+			}
+			resp := ec2Request(t, ts, map[string]string{
+				"Action":            "ModifyLaunchTemplate",
+				"LaunchTemplateId":  ltID,
+				"SetDefaultVersion": "2",
+			})
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+
+			params := map[string]string{"LaunchTemplate.LaunchTemplateId": ltID}
+			if tt.version != "" {
+				params["LaunchTemplate.Version"] = tt.version
+			}
+			instID := runInstance(t, ts, params)
+			assert.Equal(t, tt.wantAMI, describeInstance(t, ts, instID).ImageID)
+		})
+	}
+}
+
+// TestEC2_RunInstances_NonexistentVersionIsRejected pins that a launch naming a
+// version that does not exist fails rather than silently falling back. A fallback
+// would launch an instance from parameters the caller never asked for, which is the
+// defect shape #456 exists to close.
+func TestEC2_RunInstances_NonexistentVersionIsRejected(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := createLaunchTemplate(t, ts, "bad-version", map[string]string{
+		"LaunchTemplateData.ImageId": "ami-0000000000000001",
+	})
+
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                          "RunInstances",
+		"MinCount":                        "1",
+		"MaxCount":                        "1",
+		"LaunchTemplate.LaunchTemplateId": ltID,
+		"LaunchTemplate.Version":          "9",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidLaunchTemplateId.VersionNotFound", code)
+	assert.Contains(t, message, "9")
+
+	// And nothing launched.
+	resp := ec2Request(t, ts, map[string]string{"Action": "DescribeInstances"})
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		Instances []launchedInstance `xml:"reservationSet>item>instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	assert.Empty(t, out.Instances, "a rejected launch must not create an instance")
+}
+
+// TestEC2_ModifyLaunchTemplate_RejectsUnknownVersion pins that a default cannot be
+// pinned to a version that does not exist — otherwise every later launch resolves
+// to nothing.
+func TestEC2_ModifyLaunchTemplate_RejectsUnknownVersion(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := createLaunchTemplate(t, ts, "modify-bad", map[string]string{
+		"LaunchTemplateData.ImageId": "ami-0000000000000001",
+	})
+
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":            "ModifyLaunchTemplate",
+		"LaunchTemplateId":  ltID,
+		"SetDefaultVersion": "4",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidLaunchTemplateId.VersionNotFound", code)
+	assert.Equal(t, int64(1), describeLT(t, ts, ltID).DefaultVersionNum, "the default must be unchanged")
+}
+
+// TestEC2_DescribeLaunchTemplateVersions_Selection covers version selection: named
+// versions in the order requested, the two aliases, and the Min/Max range form.
+func TestEC2_DescribeLaunchTemplateVersions_Selection(t *testing.T) {
+	newTemplate := func(t *testing.T) (*httptest.Server, string) {
+		t.Helper()
+		ts := newEC2TestServer(t)
+		ltID := createLaunchTemplate(t, ts, "selection", map[string]string{
+			"LaunchTemplateData.ImageId": "ami-0000000000000001",
+		})
+		for _, ami := range []string{
+			"ami-0000000000000002", "ami-0000000000000003", "ami-0000000000000004",
+		} {
+			createLTVersion(t, ts, map[string]string{
+				"LaunchTemplateId":           ltID,
+				"LaunchTemplateData.ImageId": ami,
+			})
+		}
+		return ts, ltID
+	}
+
+	t.Run("no version named returns all, ascending", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		versions, token := describeLTVersions(t, ts, map[string]string{"LaunchTemplateId": ltID})
+		require.Len(t, versions, 4)
+		assert.Empty(t, token)
+		for i, v := range versions {
+			assert.Equal(t, int64(i+1), v.VersionNumber)
+		}
+	})
+
+	t.Run("named versions, in the order requested", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		versions, _ := describeLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId":        ltID,
+			"LaunchTemplateVersion.1": "3",
+			"LaunchTemplateVersion.2": "1",
+		})
+		require.Len(t, versions, 2)
+		assert.Equal(t, int64(3), versions[0].VersionNumber)
+		assert.Equal(t, int64(1), versions[1].VersionNumber)
+	})
+
+	t.Run("the aliases", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		versions, _ := describeLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId":        ltID,
+			"LaunchTemplateVersion.1": "$Latest",
+			"LaunchTemplateVersion.2": "$Default",
+		})
+		require.Len(t, versions, 2)
+		assert.Equal(t, int64(4), versions[0].VersionNumber)
+		assert.Equal(t, int64(1), versions[1].VersionNumber)
+		assert.False(t, versions[0].DefaultVersion)
+		assert.True(t, versions[1].DefaultVersion)
+	})
+
+	t.Run("MinVersion and MaxVersion bound the range inclusively", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		versions, _ := describeLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId": ltID,
+			"MinVersion":       "2",
+			"MaxVersion":       "3",
+		})
+		require.Len(t, versions, 2)
+		assert.Equal(t, int64(2), versions[0].VersionNumber)
+		assert.Equal(t, int64(3), versions[1].VersionNumber)
+	})
+
+	t.Run("MaxResults pages, and the token resumes", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		first, token := describeLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId": ltID,
+			"MaxResults":       "2",
+		})
+		require.Len(t, first, 2)
+		require.NotEmpty(t, token, "a truncated page must carry a token")
+
+		rest, nextToken := describeLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId": ltID,
+			"MaxResults":       "2",
+			"NextToken":        token,
+		})
+		require.Len(t, rest, 2)
+		assert.Empty(t, nextToken, "the final page must not carry a token")
+		assert.Equal(t, int64(3), rest[0].VersionNumber)
+		assert.Equal(t, int64(4), rest[1].VersionNumber)
+	})
+
+	t.Run("a nonexistent version is an error", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":                  "DescribeLaunchTemplateVersions",
+			"LaunchTemplateId":        ltID,
+			"LaunchTemplateVersion.1": "9",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidLaunchTemplateId.VersionNotFound", code)
+	})
+}
+
+// TestEC2_DescribeLaunchTemplateVersions_AccountWide covers the form that names no
+// template: it lists every template's $Latest and/or $Default. AWS restricts it to
+// those two aliases, because a version number means nothing across templates.
+func TestEC2_DescribeLaunchTemplateVersions_AccountWide(t *testing.T) {
+	setup := func(t *testing.T) *httptest.Server {
+		t.Helper()
+		ts := newEC2TestServer(t)
+		for i, name := range []string{"acct-a", "acct-b"} {
+			ltID := createLaunchTemplate(t, ts, name, map[string]string{
+				"LaunchTemplateData.ImageId": "ami-000000000000000" + string(rune('1'+i*2)),
+			})
+			createLTVersion(t, ts, map[string]string{
+				"LaunchTemplateId":           ltID,
+				"LaunchTemplateData.ImageId": "ami-000000000000000" + string(rune('2'+i*2)),
+			})
+		}
+		return ts
+	}
+
+	t.Run("$Latest across every template", func(t *testing.T) {
+		ts := setup(t)
+		versions, _ := describeLTVersions(t, ts, map[string]string{"LaunchTemplateVersion.1": "$Latest"})
+		require.Len(t, versions, 2)
+		for _, v := range versions {
+			assert.Equal(t, int64(2), v.VersionNumber)
+		}
+	})
+
+	t.Run("both aliases yield two items per template", func(t *testing.T) {
+		ts := setup(t)
+		versions, _ := describeLTVersions(t, ts, map[string]string{
+			"LaunchTemplateVersion.1": "$Latest",
+			"LaunchTemplateVersion.2": "$Default",
+		})
+		assert.Len(t, versions, 4)
+	})
+
+	t.Run("a version number is rejected without a template", func(t *testing.T) {
+		ts := setup(t)
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":                  "DescribeLaunchTemplateVersions",
+			"LaunchTemplateVersion.1": "1",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+	})
+
+	t.Run("naming neither a template nor an alias is rejected", func(t *testing.T) {
+		ts := setup(t)
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action": "DescribeLaunchTemplateVersions",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "MissingParameter", code)
+	})
+}
+
+// ltDeleteResult is DeleteLaunchTemplateVersions' two-set response.
+type ltDeleteResult struct {
+	Deleted []struct {
+		VersionNumber int64 `xml:"versionNumber"`
+	} `xml:"successfullyDeletedLaunchTemplateVersionSet>item"`
+	Failed []struct {
+		VersionNumber int64 `xml:"versionNumber"`
+		ResponseError struct {
+			Code    string `xml:"code"`
+			Message string `xml:"message"`
+		} `xml:"responseError"`
+	} `xml:"unsuccessfullyDeletedLaunchTemplateVersionSet>item"`
+}
+
+// deleteLTVersions sends DeleteLaunchTemplateVersions and returns both sets along
+// with the HTTP status, which is 200 even for a wholly-failing request.
+func deleteLTVersions(t *testing.T, ts *httptest.Server, params map[string]string) (int, ltDeleteResult) {
+	t.Helper()
+	full := map[string]string{"Action": "DeleteLaunchTemplateVersions"}
+	for k, v := range params {
+		full[k] = v
+	}
+	resp := ec2Request(t, ts, full)
+	defer resp.Body.Close() //nolint:errcheck
+	var out ltDeleteResult
+	if resp.StatusCode == http.StatusOK {
+		require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	}
+	return resp.StatusCode, out
+}
+
+// TestEC2_DeleteLaunchTemplateVersions covers the operation's per-item failure
+// model. "You can't delete the default version of a launch template" is reported as
+// an entry in unsuccessfullyDeletedLaunchTemplateVersionSet at HTTP 200, not as a
+// request-level error — so a caller checking only the status code believes the
+// delete succeeded. That is the same trap SendMessageBatch sets.
+func TestEC2_DeleteLaunchTemplateVersions(t *testing.T) {
+	newTemplate := func(t *testing.T) (*httptest.Server, string) {
+		t.Helper()
+		ts := newEC2TestServer(t)
+		ltID := createLaunchTemplate(t, ts, "deletes", map[string]string{
+			"LaunchTemplateData.ImageId": "ami-0000000000000001",
+		})
+		for _, ami := range []string{"ami-0000000000000002", "ami-0000000000000003"} {
+			createLTVersion(t, ts, map[string]string{
+				"LaunchTemplateId":           ltID,
+				"LaunchTemplateData.ImageId": ami,
+			})
+		}
+		return ts, ltID
+	}
+
+	t.Run("a non-default version deletes", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		status, result := deleteLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId":        ltID,
+			"LaunchTemplateVersion.1": "2",
+		})
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, result.Deleted, 1)
+		assert.Equal(t, int64(2), result.Deleted[0].VersionNumber)
+		assert.Empty(t, result.Failed)
+
+		versions, _ := describeLTVersions(t, ts, map[string]string{"LaunchTemplateId": ltID})
+		require.Len(t, versions, 2)
+		assert.Equal(t, int64(1), versions[0].VersionNumber)
+		assert.Equal(t, int64(3), versions[1].VersionNumber)
+	})
+
+	t.Run("the default version fails as an item, at 200", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		status, result := deleteLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId":        ltID,
+			"LaunchTemplateVersion.1": "1",
+		})
+		require.Equal(t, http.StatusOK, status, "a per-item failure is still HTTP 200")
+		assert.Empty(t, result.Deleted)
+		require.Len(t, result.Failed, 1)
+		assert.Equal(t, int64(1), result.Failed[0].VersionNumber)
+		assert.Contains(t, result.Failed[0].ResponseError.Message, "default version")
+
+		// And the version survives.
+		versions, _ := describeLTVersions(t, ts, map[string]string{"LaunchTemplateId": ltID})
+		assert.Len(t, versions, 3)
+	})
+
+	t.Run("$Default resolves to the default and fails too", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		status, result := deleteLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId":        ltID,
+			"LaunchTemplateVersion.1": "$Default",
+		})
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, result.Failed, 1)
+		assert.Empty(t, result.Deleted)
+	})
+
+	t.Run("one request, one entry in each set", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		status, result := deleteLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId":        ltID,
+			"LaunchTemplateVersion.1": "1",
+			"LaunchTemplateVersion.2": "3",
+		})
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, result.Deleted, 1, "the non-default version deletes")
+		assert.Equal(t, int64(3), result.Deleted[0].VersionNumber)
+		require.Len(t, result.Failed, 1, "the default version fails")
+		assert.Equal(t, int64(1), result.Failed[0].VersionNumber)
+	})
+
+	t.Run("a nonexistent version fails as an item", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		status, result := deleteLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId":        ltID,
+			"LaunchTemplateVersion.1": "9",
+		})
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, result.Failed, 1)
+		// The one failure mode ResponseError.code has a documented value for.
+		assert.Equal(t, "launchTemplateVersionDoesNotExist", result.Failed[0].ResponseError.Code)
+	})
+
+	t.Run("deleting the newest version does not free its number", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		status, _ := deleteLTVersions(t, ts, map[string]string{
+			"LaunchTemplateId":        ltID,
+			"LaunchTemplateVersion.1": "3",
+		})
+		require.Equal(t, http.StatusOK, status)
+
+		// "You cannot replace the version number after you delete it."
+		next := createLTVersion(t, ts, map[string]string{
+			"LaunchTemplateId":           ltID,
+			"LaunchTemplateData.ImageId": "ami-0000000000000004",
+		})
+		assert.Equal(t, int64(4), next.VersionNumber, "a deleted version number must not be reused")
+	})
+
+	t.Run("naming no version is a request-level error", func(t *testing.T) {
+		ts, ltID := newTemplate(t)
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":           "DeleteLaunchTemplateVersions",
+			"LaunchTemplateId": ltID,
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "MissingParameter", code)
+	})
+}
+
+// TestEC2_LaunchTemplate_PreVersioningStateStillWorks is the migration gate.
+//
+// A template written to state before #456 has no versions array — only the single
+// latestData field. Replaying such an event log must still launch instances and must
+// read back as a one-version template, which it does because that template's
+// latestData *is* its version 1. The stored JSON is written by hand rather than
+// produced by CreateLaunchTemplate, because CreateLaunchTemplate can no longer
+// produce it: that is precisely what makes this a migration rather than a round-trip.
+func TestEC2_LaunchTemplate_PreVersioningStateStillWorks(t *testing.T) {
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Now())
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.EC2Plugin{}
+	require.NoError(t, p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(p)
+	ts := httptest.NewServer(emulator.NewServer(*emulator.DefaultConfig(), registry, store, state, tc, logger))
+	t.Cleanup(ts.Close)
+
+	// Exactly the shape createLaunchTemplate wrote before #456: no "versions" key.
+	const acct, region, ltID = "000000000000", "us-east-1", "lt-0legacy00000001"
+	legacy := map[string]any{
+		"launchTemplateId":     ltID,
+		"launchTemplateName":   "legacy",
+		"defaultVersionNumber": 1,
+		"latestVersionNumber":  1,
+		"createdBy":            acct,
+		"createTime":           "2026-01-01T00:00:00Z",
+		"latestData": map[string]any{
+			"imageId":      "ami-0legacy000000001",
+			"instanceType": "t3.small",
+			"keyName":      "legacy-key",
+		},
+		"accountID": acct,
+		"region":    region,
+	}
+	raw, err := json.Marshal(legacy)
+	require.NoError(t, err)
+	ctx := t.Context()
+	require.NoError(t, state.Put(ctx, "ec2", "lt:"+acct+"/"+region+"/"+ltID, raw))
+	require.NoError(t, state.Put(ctx, "ec2", "lt_by_name:"+acct+"/"+region+"/legacy", []byte(ltID)))
+	idsRaw, err := json.Marshal([]string{ltID})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "ec2", "lt_ids:"+acct+"/"+region, idsRaw))
+
+	t.Run("it still launches", func(t *testing.T) {
+		instID := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+		inst := describeInstance(t, ts, instID)
+		assert.Equal(t, "ami-0legacy000000001", inst.ImageID)
+		assert.Equal(t, "t3.small", inst.InstanceType)
+		assert.Equal(t, "legacy-key", inst.KeyName)
+	})
+
+	t.Run("it reads back as version 1, default", func(t *testing.T) {
+		versions, _ := describeLTVersions(t, ts, map[string]string{"LaunchTemplateId": ltID})
+		require.Len(t, versions, 1)
+		assert.Equal(t, int64(1), versions[0].VersionNumber)
+		assert.True(t, versions[0].DefaultVersion)
+		assert.Equal(t, "ami-0legacy000000001", versions[0].Data.ImageID)
+	})
+
+	t.Run("$Latest and $Default both resolve to it", func(t *testing.T) {
+		for _, spec := range []string{"$Latest", "$Default", "1"} {
+			instID := runInstance(t, ts, map[string]string{
+				"LaunchTemplate.LaunchTemplateId": ltID,
+				"LaunchTemplate.Version":          spec,
+			})
+			assert.Equal(t, "ami-0legacy000000001", describeInstance(t, ts, instID).ImageID, "version %q", spec)
+		}
+	})
+
+	t.Run("a new version appends as version 2", func(t *testing.T) {
+		v2 := createLTVersion(t, ts, map[string]string{
+			"LaunchTemplateId":           ltID,
+			"SourceVersion":              "1",
+			"LaunchTemplateData.ImageId": "ami-0legacy000000002",
+		})
+		assert.Equal(t, int64(2), v2.VersionNumber)
+		assert.Equal(t, "t3.small", v2.Data.InstanceType, "inherited from the synthesized version 1")
+	})
+}
+
+// TestEC2_DescribeLaunchTemplateVersions_RoundTripsNetworking pins that a
+// template's network interface survives the round trip. ResponseLaunchTemplateData
+// has no top-level subnetId, so the subnet and public-IP preference must come back
+// nested inside networkInterfaceSet — the same asymmetry #444 hinged on.
+func TestEC2_DescribeLaunchTemplateVersions_RoundTripsNetworking(t *testing.T) {
+	ts := newEC2TestServer(t)
+	net := newLTNetwork(t, ts, "10.9.0.0/16", "lt-versions-net")
+	ltID := createLaunchTemplate(t, ts, "networking", map[string]string{
+		"LaunchTemplateData.ImageId":                                     "ami-0000000000000001",
+		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
+		"LaunchTemplateData.NetworkInterface.1.SubnetId":                 net.subnetID,
+		"LaunchTemplateData.NetworkInterface.1.Groups.1":                 net.sgID,
+		"LaunchTemplateData.NetworkInterface.1.AssociatePublicIpAddress": "true",
+	})
+
+	versions, _ := describeLTVersions(t, ts, map[string]string{"LaunchTemplateId": ltID})
+	require.Len(t, versions, 1)
+	require.Len(t, versions[0].Data.Interfaces, 1)
+	ifc := versions[0].Data.Interfaces[0]
+	assert.Equal(t, net.subnetID, ifc.SubnetID)
+	assert.Equal(t, "true", ifc.AssociatePublicIPAddress)
+	assert.Equal(t, []string{net.sgID}, ifc.Groups)
+}
+
+// TestEC2_Fleet_HonorsLaunchTemplateVersion covers the fleet half of #456.
+// fleetPools has always parsed a config's Version; launchFleetPool dropped it, so a
+// fleet pinned to version 1 launched whatever the template held latest. Nothing
+// errored — the fleet just launched the wrong AMI.
+func TestEC2_Fleet_HonorsLaunchTemplateVersion(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := createLaunchTemplate(t, ts, "fleet-versions", map[string]string{
+		"LaunchTemplateData.ImageId":      "ami-0fleet0000000001",
+		"LaunchTemplateData.InstanceType": "t3.small",
+	})
+	createLTVersion(t, ts, map[string]string{
+		"LaunchTemplateId":                ltID,
+		"LaunchTemplateData.ImageId":      "ami-0fleet0000000002",
+		"LaunchTemplateData.InstanceType": "t3.small",
+	})
+
+	tests := []struct {
+		name    string
+		version string
+		wantAMI string
+	}{
+		{name: "pinned to version 1", version: "1", wantAMI: "ami-0fleet0000000001"},
+		{name: "pinned to version 2", version: "2", wantAMI: "ami-0fleet0000000002"},
+		{name: "$Latest", version: "$Latest", wantAMI: "ami-0fleet0000000002"},
+		// An absent version follows the default, which is still 1 even though
+		// version 2 exists.
+		{name: "absent means the default", version: "", wantAMI: "ami-0fleet0000000001"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{
+				"Action": "CreateFleet",
+				"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+				"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+				"TargetCapacitySpecification.DefaultTargetCapacityType":                "on-demand",
+				"Type": "instant",
+			}
+			if tt.version != "" {
+				params["LaunchTemplateConfigs.1.LaunchTemplateSpecification.Version"] = tt.version
+			}
+			resp := ec2Request(t, ts, params)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			var out struct {
+				Instances []struct {
+					InstanceIDs []string `xml:"instanceIds>item"`
+				} `xml:"fleetInstanceSet>item"`
+			}
+			require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+			require.NoError(t, resp.Body.Close())
+			require.Len(t, out.Instances, 1)
+			require.Len(t, out.Instances[0].InstanceIDs, 1)
+
+			inst := describeInstance(t, ts, out.Instances[0].InstanceIDs[0])
+			assert.Equal(t, tt.wantAMI, inst.ImageID)
+		})
+	}
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -200,6 +200,14 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.describeLaunchTemplates(ctx, req)
 	case "DeleteLaunchTemplate":
 		return p.deleteLaunchTemplate(ctx, req)
+	case "CreateLaunchTemplateVersion":
+		return p.createLaunchTemplateVersion(ctx, req)
+	case "ModifyLaunchTemplate":
+		return p.modifyLaunchTemplate(ctx, req)
+	case "DescribeLaunchTemplateVersions":
+		return p.describeLaunchTemplateVersions(ctx, req)
+	case "DeleteLaunchTemplateVersions":
+		return p.deleteLaunchTemplateVersions(ctx, req)
 	// EC2 Fleet operations
 	case "CreateFleet":
 		return p.createFleet(ctx, req)
@@ -317,29 +325,38 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	// run *after* the call-level NetworkInterface.1.* reads above rather than before
 	// them (#444) — the subnet fallback used to sit ahead of this block, where there
 	// was nothing yet to fall back to.
+	//
+	// Which *version* supplies those values is resolved from LaunchTemplate.Version.
+	// An absent version means the template's default version, not its latest — see
+	// [ec2ResolveTemplateVersion] (#456).
 	ltID := req.Params["LaunchTemplate.LaunchTemplateId"]
 	ltName := req.Params["LaunchTemplate.LaunchTemplateName"]
 	if lt := p.resolveLaunchTemplate(context.Background(), reqCtx, ltID, ltName); lt != nil {
+		version, awsErr := ec2ResolveTemplateVersion(lt, req.Params["LaunchTemplate.Version"])
+		if awsErr != nil {
+			return nil, awsErr
+		}
+		ltData := version.Data
 		if imageID == "" {
-			imageID = lt.LatestData.ImageID
+			imageID = ltData.ImageID
 		}
 		if instanceType == "" {
-			instanceType = lt.LatestData.InstanceType
+			instanceType = ltData.InstanceType
 		}
 		if keyName == "" {
-			keyName = lt.LatestData.KeyName
+			keyName = ltData.KeyName
 		}
 		if userData == "" {
-			userData = lt.LatestData.UserData
+			userData = ltData.UserData
 		}
 		if subnetID == "" {
-			subnetID = lt.LatestData.SubnetID
+			subnetID = ltData.SubnetID
 		}
 		if publicIPPref == "" {
-			publicIPPref = lt.LatestData.AssociatePublicIPAddress
+			publicIPPref = ltData.AssociatePublicIPAddress
 		}
 		if len(securityGroupIDs) == 0 {
-			securityGroupIDs = lt.LatestData.NetworkSecurityGroupIDs()
+			securityGroupIDs = ltData.NetworkSecurityGroupIDs()
 		}
 		if sgID == "" && len(securityGroupIDs) > 0 {
 			sgID = securityGroupIDs[0]
@@ -4118,8 +4135,17 @@ func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 		CreatedBy:          ctx.AccountID,
 		CreateTime:         now,
 		LatestData:         ltData,
-		AccountID:          ctx.AccountID,
-		Region:             ctx.Region,
+		// Creating a template creates its version 1, which is both the default and
+		// the latest (#456).
+		Versions: []EC2LaunchTemplateVersion{{
+			VersionNumber:      1,
+			VersionDescription: req.Params["VersionDescription"],
+			CreateTime:         now,
+			CreatedBy:          ctx.AccountID,
+			Data:               ltData,
+		}},
+		AccountID: ctx.AccountID,
+		Region:    ctx.Region,
 	}
 
 	ltJSON, err := json.Marshal(lt)
@@ -4136,28 +4162,56 @@ func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 	idsKey := "lt_ids:" + ctx.AccountID + "/" + ctx.Region
 	updateStringIndex(goCtx, p.state, ec2Namespace, idsKey, ltID)
 
-	type ltItem struct {
-		LaunchTemplateID   string `xml:"launchTemplateId"`
-		LaunchTemplateName string `xml:"launchTemplateName"`
-		CreateTime         string `xml:"createTime"`
-		DefaultVersionNum  int64  `xml:"defaultVersionNumber"`
-		LatestVersionNum   int64  `xml:"latestVersionNumber"`
-	}
 	type response struct {
-		XMLName        xml.Name `xml:"CreateLaunchTemplateResponse"`
-		XMLNS          string   `xml:"xmlns,attr"`
-		LaunchTemplate ltItem   `xml:"launchTemplate"`
+		XMLName        xml.Name             `xml:"CreateLaunchTemplateResponse"`
+		XMLNS          string               `xml:"xmlns,attr"`
+		LaunchTemplate ec2LaunchTemplateXML `xml:"launchTemplate"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{
-		XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/",
-		LaunchTemplate: ltItem{
-			LaunchTemplateID:   ltID,
-			LaunchTemplateName: name,
-			CreateTime:         now,
-			DefaultVersionNum:  1,
-			LatestVersionNum:   1,
-		},
+		XMLNS:          "http://ec2.amazonaws.com/doc/2016-11-15/",
+		LaunchTemplate: ec2LaunchTemplateSummary(&lt),
 	})
+}
+
+// ec2LaunchTemplateXML is the launchTemplate summary element AWS returns from
+// CreateLaunchTemplate, DescribeLaunchTemplates and ModifyLaunchTemplate.
+//
+// Notably it carries no launchTemplateData: DescribeLaunchTemplates cannot read a
+// template's parameters back, which is why DescribeLaunchTemplateVersions exists and
+// why anything asserting on a template's contents has to call it.
+type ec2LaunchTemplateXML struct {
+	LaunchTemplateID   string       `xml:"launchTemplateId"`
+	LaunchTemplateName string       `xml:"launchTemplateName"`
+	CreateTime         string       `xml:"createTime"`
+	CreatedBy          string       `xml:"createdBy,omitempty"`
+	DefaultVersionNum  int64        `xml:"defaultVersionNumber"`
+	LatestVersionNum   int64        `xml:"latestVersionNumber"`
+	Tags               []ec2TagItem `xml:"tagSet>item,omitempty"`
+}
+
+// ec2TagItem is a tagSet entry on the wire.
+type ec2TagItem struct {
+	// Key is the tag key.
+	Key string `xml:"key"`
+
+	// Value is the tag value.
+	Value string `xml:"value"`
+}
+
+// ec2LaunchTemplateSummary renders a launch template as its summary element.
+func ec2LaunchTemplateSummary(lt *EC2LaunchTemplate) ec2LaunchTemplateXML {
+	out := ec2LaunchTemplateXML{
+		LaunchTemplateID:   lt.LaunchTemplateID,
+		LaunchTemplateName: lt.LaunchTemplateName,
+		CreateTime:         lt.CreateTime,
+		CreatedBy:          lt.CreatedBy,
+		DefaultVersionNum:  lt.DefaultVersionNum,
+		LatestVersionNum:   lt.LatestVersionNum,
+	}
+	for _, t := range lt.Tags {
+		out.Tags = append(out.Tags, ec2TagItem(t))
+	}
+	return out
 }
 
 func (p *EC2Plugin) describeLaunchTemplates(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -4192,28 +4246,15 @@ func (p *EC2Plugin) describeLaunchTemplates(ctx *RequestContext, req *AWSRequest
 		}
 	}
 
-	type ltItem struct {
-		LaunchTemplateID   string `xml:"launchTemplateId"`
-		LaunchTemplateName string `xml:"launchTemplateName"`
-		CreateTime         string `xml:"createTime"`
-		DefaultVersionNum  int64  `xml:"defaultVersionNumber"`
-		LatestVersionNum   int64  `xml:"latestVersionNumber"`
-	}
 	type response struct {
-		XMLName         xml.Name `xml:"DescribeLaunchTemplatesResponse"`
-		XMLNS           string   `xml:"xmlns,attr"`
-		LaunchTemplates []ltItem `xml:"launchTemplates>item"`
+		XMLName         xml.Name               `xml:"DescribeLaunchTemplatesResponse"`
+		XMLNS           string                 `xml:"xmlns,attr"`
+		LaunchTemplates []ec2LaunchTemplateXML `xml:"launchTemplates>item"`
 	}
 
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
-	for _, lt := range lts {
-		resp.LaunchTemplates = append(resp.LaunchTemplates, ltItem{
-			LaunchTemplateID:   lt.LaunchTemplateID,
-			LaunchTemplateName: lt.LaunchTemplateName,
-			CreateTime:         lt.CreateTime,
-			DefaultVersionNum:  lt.DefaultVersionNum,
-			LatestVersionNum:   lt.LatestVersionNum,
-		})
+	for i := range lts {
+		resp.LaunchTemplates = append(resp.LaunchTemplates, ec2LaunchTemplateSummary(&lts[i]))
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -681,13 +681,67 @@ type EC2LaunchTemplate struct {
 	Tags []EC2Tag `json:"tags,omitempty"`
 
 	// LatestData holds the launch template parameters for the latest version.
+	//
+	// Retained alongside Versions rather than derived from it, for two reasons. It
+	// is the field a template stored before versioning existed (#456) carries, so
+	// [EC2LaunchTemplate.TemplateVersions] can synthesize version 1 from it — that
+	// synthesis is the whole migration, with no event rewriting. And several call
+	// sites read it directly, so removing it would turn a storage change into a
+	// rewrite of the RunInstances merge block. It is kept in sync on every version
+	// append; do not delete it as redundant.
 	LatestData EC2LaunchTemplateData `json:"latestData"`
+
+	// Versions holds every version of the template, ordered by version number.
+	//
+	// Nil for a template stored before #456; see
+	// [EC2LaunchTemplate.TemplateVersions], which is how every reader must access
+	// this field.
+	Versions []EC2LaunchTemplateVersion `json:"versions,omitempty"`
 
 	// AccountID is the AWS account that owns the launch template.
 	AccountID string `json:"accountID"`
 
 	// Region is the AWS region in which the launch template resides.
 	Region string `json:"region"`
+}
+
+// EC2LaunchTemplateVersion represents one version of an EC2 launch template.
+type EC2LaunchTemplateVersion struct {
+	// VersionNumber is the version's number, starting at 1 for the version created
+	// alongside the template itself.
+	VersionNumber int64 `json:"versionNumber"`
+
+	// VersionDescription is the caller-supplied description, if any.
+	VersionDescription string `json:"versionDescription,omitempty"`
+
+	// CreateTime is the RFC3339 timestamp when the version was created.
+	CreateTime string `json:"createTime"`
+
+	// CreatedBy is the principal that created the version.
+	CreatedBy string `json:"createdBy"`
+
+	// Data holds the launch parameters this version carries.
+	Data EC2LaunchTemplateData `json:"data"`
+}
+
+// TemplateVersions returns the template's versions, synthesizing version 1 from
+// LatestData when the stored template predates version tracking.
+//
+// Every reader must go through this rather than reading Versions directly. A
+// template written to the event log before #456 has no versions array at all, and
+// replaying such a log must still launch instances and read back as a
+// single-version template — which it does, because that template's LatestData *is*
+// its version 1.
+func (t EC2LaunchTemplate) TemplateVersions() []EC2LaunchTemplateVersion {
+	if len(t.Versions) > 0 {
+		return t.Versions
+	}
+	return []EC2LaunchTemplateVersion{{
+		VersionNumber: 1,
+		CreateTime:    t.CreateTime,
+		CreatedBy:     t.CreatedBy,
+		Data:          t.LatestData,
+	}}
 }
 
 // generateLaunchTemplateID generates a random launch template ID.


### PR DESCRIPTION
## What

EC2 launch templates are now versioned. Adds the four version operations —
`CreateLaunchTemplateVersion`, `ModifyLaunchTemplate`,
`DescribeLaunchTemplateVersions`, `DeleteLaunchTemplateVersions` — and makes a
launch resolve *which* version supplies its parameters instead of always
reading the template's latest data.

## Why

`DescribeLaunchTemplates` returns only summary fields (`createTime`,
`createdBy`, `defaultVersionNumber`, `latestVersionNumber`,
`launchTemplateId`, `launchTemplateName`) — **no `launchTemplateData` at
all**. `DescribeLaunchTemplateVersions` is the only operation that returns a
template's parameters, so without it a consumer cannot assert what a template
actually stored.

## Behaviour worth reviewing

**An absent `LaunchTemplate.Version` means the *default* version, not the
latest.** From `LaunchTemplateSpecification`: "Default: The default version of
the launch template." This was #456's own flagged open question. Getting it
backwards stays invisible until a consumer pins a default and keeps shipping
new versions — hence `TestEC2_RunInstances_AbsentVersionMeansDefault`, which
sets up default 1 against latest 3 so an inverted resolution fails loudly.
`$Latest` / `$Default` are matched case-insensitively.

**`SourceVersion` is asymmetric.** Named: the new version inherits the
source's parameters and the request's overwrite the corresponding ones.
Omitted: the version holds *only* what the request names. That asymmetry is
the one a consumer gets wrong, so it has its own subtest.

**Deleting the default fails that item, at HTTP 200.** The operation reports
per-version outcomes, so one request naming both the default and a
non-default produces one entry in each set with a 200 overall. A caller
checking only the HTTP status sees success.

**The fleet path now forwards its version.** `fleetPools` has always parsed
`LaunchTemplateConfig`'s version; nothing consumed it, so a fleet pinned to
version 1 silently launched whatever the template held latest.

## Two deviations from the plan

**1. The default-version rejection ships as `unexpectedError`, not an invented
code.** The plan left the code open. It cannot be captured: the API reference
and the CLI help both state the prohibition but publish no code or message;
moto does not implement `DeleteLaunchTemplateVersions` at all; LocalStack does
not either; issue-tracker searches found nothing. Two facts settled it —
`ResponseError.code` is a **closed six-value enum** in three independent AWS
SDKs (`launchTemplateIdDoesNotExist | launchTemplateIdMalformed |
launchTemplateNameDoesNotExist | launchTemplateNameMalformed |
launchTemplateVersionDoesNotExist | unexpectedError`) with no default-version
member, and the operation's whole response is built for per-item partial
failure. So the item carries `unexpectedError` — the modeled catch-all — with
the reference's own sentence as the message, both labelled inferred in the
code, the CHANGELOG and `docs/services.md`. Another emulator invents
`InvalidLaunchTemplateVersion.NotAllowed`, which a typed SDK would deserialize
as an unknown enum variant; that was the trap avoided.

**2. The account-wide `DescribeLaunchTemplateVersions` form is included, not
scoped out.** The plan deferred it to a follow-up issue. `describeLaunchTemplates`
already walks the `lt_ids:` index, so the form was a reuse rather than a new
query — no issue needs filing.

## Migration

A template stored before this change unmarshals with `Versions == nil` and
synthesizes version 1 from `LatestData` on read
(`EC2LaunchTemplate.TemplateVersions`). That is the entire migration — no
event rewriting. `LatestData` is deliberately retained and kept in sync;
its doc comment says why, so a reader does not delete it as redundant.
`TestEC2_LaunchTemplate_PreVersioningStateStillWorks` writes pre-#456 JSON
directly into state as the gate.

## Verification

From the repo root: `gofmt -l .` clean, `go build ./...`, `go vet ./...`,
`golangci-lint run ./...` → **0 issues**, `make test` (race) all packages ok,
`make docs-reference docs-reference-check docs-versions` pass,
`go test -C test/e2e ./...` ok.

**Mutation-tested, three mutants, all killed:**

| Mutation | Killed by |
|---|---|
| absent version → latest instead of default | `AbsentVersionMeansDefault`, `VersionSpecifiers/absent_means_the_default`, `Fleet_HonorsLaunchTemplateVersion/absent_means_the_default` |
| let the default version be deleted | 3 `DeleteLaunchTemplateVersions` subtests |
| remove the `TemplateVersions()` synthesis | all 4 migration subtests |

Also walked end-to-end against a live server as a consumer would: create →
`CreateLaunchTemplateVersion(SourceVersion=1, ImageId=…)` returning version 2
with inherited instance type and key name → `ModifyLaunchTemplate` →
`DescribeLaunchTemplateVersions` (`defaultVersion` true only on 2) →
`RunInstances` with **no** version launching v2's AMI →
`DeleteLaunchTemplateVersions(2,1)` returning 200 with one entry in each set.

Closes #456
