### PR TITLE
feat(ec2): reject reserved aws: tag keys on tag-on-create (#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Reserved `aws:` tag keys are now rejected on every tag-on-create path** (#468).
+  #452 closed this for `CreateTags` and `DeleteTags` but deliberately left it off
+  tag-on-create, so a key real EC2 refuses was still accepted whenever it arrived
+  through a `TagSpecification` — on `RunInstances`, `CreateFleet`, `CreateImage` or
+  `CreateNatGateway`. A consumer's error branch for the rejection stayed unreachable
+  on exactly the path where the rejection is best evidenced: both real-AWS captures
+  behind the message are of `RunInstances` tag-on-create.
+
+  The rejection happens **before the resource is created**. A refused `RunInstances`
+  launches no instance, a refused `CreateImage` leaves behind neither the AMI nor its
+  backing snapshot, and a refused `CreateNatGateway` creates no gateway — per the
+  tagging documentation, "If tags cannot be applied during resource creation, we roll
+  back the resource creation process. This ensures that resources are either created
+  with tags or not created at all."
+
+  Substrate stamps `aws:ec2:fleet-id` on every fleet instance (#443), which is itself
+  a reserved key on a checked path — the reason the check was previously left off it.
+  That tag is now exempt **structurally rather than by a flag**: `CreateFleet` parses
+  and checks the caller's tags exactly as `RunInstances` does, and the fleet-ID tag is
+  appended afterwards, on an internal launch entry point taking already-parsed tags
+  that no request can address. A validation-skipping flag would have made the
+  outcome depend on internal state a consumer cannot observe, which is the opposite of
+  the deterministic-replay property. So a caller naming `aws:` anything in a
+  `CreateFleet` request is now rejected — instance- and fleet-scoped alike — while the
+  fleet's own stamp still lands, alongside the caller's legal tags.
+
+  The match remains **case-sensitive**, so `AWS:foo` is still an ordinary user tag.
+  Note that #472's SQS attribute prefix rule is case-*insensitive*; the two services
+  document different rules and the checks are deliberately not shared.
 - **EC2 launch templates are now versioned** (#456).
   `CreateLaunchTemplateVersion`, `ModifyLaunchTemplate`,
   `DescribeLaunchTemplateVersions` and `DeleteLaunchTemplateVersions` were all
@@ -86,6 +115,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   way this step could damage a release rather than merely omit one. Deferred issues
   are also now explicitly moved to the next milestone rather than closed with the
   release.
+- `CreateImage` now honours its `TagSpecification.N` `ResourceType` (#468). The
+  reference gives two scopes — `image` tags the AMI, `snapshot` tags the snapshots
+  created of the attached volumes — but substrate read `TagSpecification.1`'s tags
+  whatever they were scoped to, so a request tagging only its snapshots put those tags
+  on the AMI. Snapshot-scoped tags now land on the backing snapshot substrate
+  materializes, where `DescribeSnapshots` reports them. A caller asserting on
+  `DescribeImages` for tags that were actually snapshot-scoped will see them move,
+  which is where real EC2 has them.
 
 ## [v0.85.0] - 2026-08-02
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -1559,8 +1559,9 @@ A caller cannot delete this tag — see
 
 ### Reserved tag keys
 
-`CreateTags` and `DeleteTags` reject any tag whose key begins with `aws:`, the
-prefix EC2 reserves for its own use:
+Every path that assigns a tag rejects any key beginning with `aws:`, the prefix EC2
+reserves for its own use — `CreateTags`, `DeleteTags`, and tag-on-create through
+`RunInstances`, `CreateFleet`, `CreateImage` and `CreateNatGateway`:
 
 ```
 InvalidParameterValue: Tag keys starting with 'aws:' are reserved for internal use
@@ -1575,21 +1576,61 @@ The match is **case-sensitive**. AWS documents tag keys and values as
 case-sensitive, so `AWS:foo` and `Aws:foo` are ordinary user tags and are accepted;
 only the lowercase `aws:` prefix is reserved.
 
-Two caveats about the scope of this rule:
+On a tag-on-create path the rejection happens **before the resource is created**, so
+a refused `RunInstances` launches no instance, a refused `CreateImage` leaves behind
+neither the AMI nor its backing snapshot, and a refused `CreateNatGateway` creates no
+gateway. This follows the tagging documentation directly: "If tags cannot be applied
+during resource creation, we roll back the resource creation process. This ensures
+that resources are either created with tags or not created at all."
 
-- Provenance: the `CreateTags` API reference has an empty Errors section, so neither
-  the code nor the message above is derivable from the API model. Both come from
-  observed real-AWS responses. The `DeleteTags` rejection is a step weaker still —
-  substrate found no captured `DeleteTags` error and inherits the wording from the
-  `CreateTags` capture. What the tagging documentation does state plainly is the
-  outcome: such a tag "can't be edited or deleted" by a caller.
-- `RunInstances` tag-on-create is **not** covered. Real EC2 rejects a reserved key
-  there too, but substrate stamps [`aws:ec2:fleet-id`](#finding-a-fleets-instances)
-  through exactly that path, so restricting it would reject substrate's own fleet
-  tagging.
+Provenance: the `CreateTags` API reference has an empty Errors section, so neither
+the code nor the message above is derivable from the API model. Both come from
+observed real-AWS responses — and both captures are in fact of `RunInstances`
+tag-on-create, so that path has the strongest claim to this wording. The
+`DeleteTags` rejection is a step weaker — substrate found no captured `DeleteTags`
+error and inherits the wording from the same capture. What the tagging documentation
+does state plainly is the outcome: such a tag "can't be edited or deleted" by a
+caller.
 
-The 50-tag-per-resource limit is not modelled at all, so the companion rule that
-reserved tags are exempt from it has nothing to exempt them from yet.
+#### How substrate's own fleet tag is exempt
+
+Substrate stamps [`aws:ec2:fleet-id`](#finding-a-fleets-instances) on every fleet
+instance, which is a reserved key on a tag-on-create path — the reason this check
+was previously left off that path entirely.
+
+It is exempt structurally rather than by a flag. `CreateFleet` parses the caller's
+`TagSpecification.N` tags and checks them exactly as `RunInstances` does; the
+fleet-ID tag is appended to the resulting value *after* that check, on an internal
+launch entry point that takes already-parsed tags. There is no param a request could
+set to reach it. A validation-skipping flag would have made the outcome depend on
+internal state a consumer cannot observe, which is the opposite of the
+deterministic-replay property substrate exists for.
+
+So a caller naming `aws:` anything in a `CreateFleet` request is rejected —
+instance- and fleet-scoped alike — while the fleet's own stamp is still applied, and
+both coexist with the caller's legal tags on the same instance.
+
+Two limits of the current scope, stated rather than implied:
+
+- Only tags scoped to a resource substrate models are checked. A
+  `TagSpecification` naming `volume` or `network-interface` on `RunInstances` is
+  skipped, because substrate does not tag those resources at all; real EC2 would
+  reject a reserved key there too.
+- The 50-tag-per-resource limit is not modelled, so the companion rule that
+  reserved tags are exempt from it has nothing to exempt them from yet.
+
+#### Tag scoping on `CreateImage`
+
+`CreateImage` accepts two tag scopes, and substrate now honours the distinction:
+`ResourceType=image` tags the AMI, and `ResourceType=snapshot` tags the backing
+snapshot substrate materializes for the AMI's root device. Per the reference, "the
+same tag is applied to all of the snapshots that are created."
+
+This is a behaviour change. `CreateImage` previously read `TagSpecification.1`'s tags
+whatever they were scoped to, so a request that tagged only its snapshots put those
+tags on the AMI instead. A caller asserting on `DescribeImages` tags that were
+actually snapshot-scoped will now see them on `DescribeSnapshots`, which is where
+real EC2 puts them.
 
 ### Seeding EC2 Fleet partial fulfillment
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -517,6 +517,12 @@ func addRequestTags(condCtx map[string]string, req *AWSRequest) {
 
 	case "ec2":
 		// EC2 tags arrive as query params: TagSpecification.1.Tag.N.Key / .Value
+		//
+		// This walk is deliberately not ec2LaunchTagsForResource: it collects every
+		// tag in the request regardless of which resource the specification is scoped
+		// to, because a policy condition on aws:RequestTag is about what the request
+		// asked for, not about what state a handler ends up writing. Filtering by
+		// resourceType here would silently narrow policy evaluation (#468).
 		for i := 1; ; i++ {
 			prefix := fmt.Sprintf("TagSpecification.%d.Tag.", i)
 			found := false

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -275,8 +275,17 @@ func (p *EC2Plugin) createFleet(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 	wantPerPool := distributeAcrossPools(total, len(pools))
 	gotPerPool := distributeAcrossPools(fulfill, len(pools))
 
-	instanceTags := passthroughFleetTagSpecs(req.Params, "instance")
-	fleetTags := fleetTagsFor(req.Params, "fleet")
+	// The fleet's own instance-scoped tags are the caller's, so they are checked here
+	// exactly as RunInstances checks its own. Only the fleet-ID tag substrate adds
+	// afterwards is exempt, and it is exempt by never being part of a request (#468).
+	instanceTags := ec2LaunchTagsForResource(req.Params, "instance")
+	if awsErr := ec2CheckReservedTagKeys(instanceTags); awsErr != nil {
+		return nil, awsErr
+	}
+	fleetTags := ec2LaunchTagsForResource(req.Params, "fleet")
+	if awsErr := ec2CheckReservedTagKeys(fleetTags); awsErr != nil {
+		return nil, awsErr
+	}
 
 	fleet := EC2Fleet{
 		FleetID:                   generateFleetID(),
@@ -433,7 +442,7 @@ func (p *EC2Plugin) launchFleetPool(
 	reqCtx *RequestContext,
 	pool fleetPool,
 	count int,
-	instanceTags map[string]string,
+	instanceTags []EC2Tag,
 	fleetID string,
 ) ([]string, error) {
 	params := map[string]string{
@@ -467,19 +476,25 @@ func (p *EC2Plugin) launchFleetPool(
 	if pool.override.PlacementGroupName != "" {
 		params["Placement.GroupName"] = pool.override.PlacementGroupName
 	}
-	for k, v := range instanceTags {
-		params[k] = v
-	}
-	for k, v := range fleetIDTagSpec(instanceTags, fleetID) {
-		params[k] = v
+	// The caller's tags travel as already-parsed values rather than as re-emitted
+	// TagSpecification.N params, so the fleet-ID tag can be appended without hunting
+	// for a free index — and, more to the point, without riding the request-tag path
+	// that now rejects reserved keys. See [EC2Plugin.runInstances] for why that split
+	// is structural rather than a bypass flag (#468).
+	tags := instanceTags
+	if fleetID != "" {
+		tags = append(append([]EC2Tag{}, instanceTags...), EC2Tag{
+			Key:   ec2FleetIDTagKey,
+			Value: fleetID,
+		})
 	}
 
-	resp, err := p.runInstances(reqCtx, &AWSRequest{
+	resp, err := p.runInstancesWithTags(reqCtx, &AWSRequest{
 		Service:   "ec2",
 		Operation: "RunInstances",
 		Params:    params,
 		Headers:   map[string]string{},
-	})
+	}, tags)
 	if err != nil {
 		return nil, err
 	}
@@ -557,36 +572,6 @@ func parseFleetOverride(params map[string]string, prefix string) (EC2FleetOverri
 	return ov, present
 }
 
-// passthroughFleetTagSpecs extracts TagSpecification.N entries for resourceType
-// and re-emits them as RunInstances TagSpecification params, so launch-time tags
-// declared on a fleet land on its instances (callers find fleet instances with
-// DescribeInstances tag filters).
-func passthroughFleetTagSpecs(params map[string]string, resourceType string) map[string]string {
-	out := map[string]string{}
-	idx := 0
-	for n := 1; ; n++ {
-		rt, ok := params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
-		if !ok || rt == "" {
-			break
-		}
-		if rt != resourceType {
-			continue
-		}
-		idx++
-		for m := 1; ; m++ {
-			key, keyOK := params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", n, m)]
-			if !keyOK || key == "" {
-				break
-			}
-			out[fmt.Sprintf("TagSpecification.%d.ResourceType", idx)] = resourceType
-			out[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", idx, m)] = key
-			out[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", idx, m)] =
-				params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", n, m)]
-		}
-	}
-	return out
-}
-
 // ec2FleetIDTagKey is the reserved tag EC2 stamps on every instance a fleet
 // launches, naming the fleet that created it.
 //
@@ -602,64 +587,17 @@ func passthroughFleetTagSpecs(params map[string]string, resourceType string) map
 //
 // The "aws:" prefix is reserved: per the EC2 tagging documentation such a tag
 // cannot be edited or deleted by a caller and does not count against the 50-tag
-// per-resource limit. CreateTags and DeleteTags now enforce the first rule (#452);
-// the second has nothing to exempt from yet, since substrate does not model the
-// 50-tag limit at all. Substrate stamps this tag by building RunInstances
-// TagSpecification params, which is a separate parse from CreateTags and is
-// deliberately left unrestricted — restricting it would reject substrate's own
-// fleet tagging.
-const ec2FleetIDTagKey = "aws:ec2:fleet-id"
-
-// fleetIDTagSpec returns the RunInstances TagSpecification params that stamp
-// ec2FleetIDTagKey on a pool's instances.
+// per-resource limit. CreateTags and DeleteTags enforce the first rule (#452), and
+// every tag-on-create path now enforces it too (#468).
 //
-// The index is chosen past whatever passthroughFleetTagSpecs already emitted:
-// that function renumbers its output from 1, so reusing an occupied index would
-// silently overwrite a caller's own launch-time tag. existing is the map it
-// returned; an empty fleetID yields no params, so a caller that somehow has no
-// fleet ID launches unchanged rather than stamping an empty tag.
-func fleetIDTagSpec(existing map[string]string, fleetID string) map[string]string {
-	if fleetID == "" {
-		return nil
-	}
-	idx := 1
-	for {
-		if _, taken := existing[fmt.Sprintf("TagSpecification.%d.ResourceType", idx)]; !taken {
-			break
-		}
-		idx++
-	}
-	return map[string]string{
-		fmt.Sprintf("TagSpecification.%d.ResourceType", idx): "instance",
-		fmt.Sprintf("TagSpecification.%d.Tag.1.Key", idx):    ec2FleetIDTagKey,
-		fmt.Sprintf("TagSpecification.%d.Tag.1.Value", idx):  fleetID,
-	}
-}
-
-// fleetTagsFor collects TagSpecification.N tags for resourceType as EC2Tags.
-func fleetTagsFor(params map[string]string, resourceType string) []EC2Tag {
-	var tags []EC2Tag
-	for n := 1; ; n++ {
-		rt, ok := params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
-		if !ok || rt == "" {
-			break
-		}
-		if rt != resourceType {
-			continue
-		}
-		for m := 1; ; m++ {
-			key, keyOK := params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", n, m)]
-			if !keyOK || key == "" {
-				break
-			}
-			tags = append(tags, EC2Tag{
-				Key:   key,
-				Value: params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", n, m)],
-			})
-		}
-	}
-	return tags
-}
+// Substrate stamps this tag without tripping its own check because
+// [EC2Plugin.launchFleetPool] appends it to the already-parsed, already-checked tag
+// slice it hands [EC2Plugin.runInstancesWithTags] — it never becomes a
+// TagSpecification.N param, and so is never part of anything a caller could send.
+// That is deliberately a structural exemption rather than a validation-skipping flag:
+// a flag would make the check's outcome depend on internal state a consumer cannot
+// see, whereas this way the checked path is simply the only path a request can reach.
+const ec2FleetIDTagKey = "aws:ec2:fleet-id"
 
 // fleetDefaultErrorMessage returns the message AWS pairs with a fleet error code.
 func fleetDefaultErrorMessage(code string) string {

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -241,7 +241,38 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 
 // --- Instance operations ---
 
+// runInstances handles a caller's RunInstances request: it parses the request's
+// instance-scoped TagSpecification.N tags, rejects any reserved key among them, and
+// delegates to [EC2Plugin.runInstancesWithTags].
+//
+// The parse-and-check is split from the launch so that substrate's own internal
+// launches — the fleet path, which stamps [ec2FleetIDTagKey] — can supply a reserved
+// tag without going through this check, while a caller's request cannot. The
+// distinction is structural rather than a bypass flag: a request reaches only this
+// function, and extraTags is not addressable from a param map. #468 rules out a flag
+// explicitly, and rightly — an internal "skip validation" switch would make behavior
+// depend on state a consumer cannot observe, the opposite of the deterministic-replay
+// property this emulator exists for.
 func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	launchTags := ec2LaunchTagsForResource(req.Params, "instance")
+	if awsErr := ec2CheckReservedTagKeys(launchTags); awsErr != nil {
+		return nil, awsErr
+	}
+	return p.runInstancesWithTags(reqCtx, req, launchTags)
+}
+
+// runInstancesWithTags launches instances carrying tags, which the caller has already
+// parsed and, if they came from a request, checked.
+//
+// tags is the complete tag set for the new instances: [EC2Plugin.runInstances] passes
+// the request's checked TagSpecification.N tags, and the fleet path passes those plus
+// its own fleet-ID tag. See [EC2Plugin.runInstances] for why the check lives with the
+// parse rather than here.
+func (p *EC2Plugin) runInstancesWithTags(
+	reqCtx *RequestContext,
+	req *AWSRequest,
+	tags []EC2Tag,
+) (*AWSResponse, error) {
 	imageID := req.Params["ImageId"]
 	// The call-level instance type is kept verbatim, with no default applied yet: a
 	// launch template may supply one, and the default can only be resolved once the
@@ -444,28 +475,6 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		}
 	}
 
-	// Extract tags for instances from TagSpecification.N (ResourceType=instance).
-	var launchTags []EC2Tag
-	for n := 1; ; n++ {
-		rt := req.Params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
-		if rt == "" {
-			break
-		}
-		if rt != "instance" {
-			continue
-		}
-		for m := 1; ; m++ {
-			key := req.Params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", n, m)]
-			if key == "" {
-				break
-			}
-			launchTags = append(launchTags, EC2Tag{
-				Key:   key,
-				Value: req.Params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", n, m)],
-			})
-		}
-	}
-
 	reservationID := generateReservationID()
 	now := p.tc.Now().UTC().Format(time.RFC3339)
 	var instances []EC2Instance
@@ -486,7 +495,7 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 			KeyName:            keyName,
 			IamInstanceProfile: iamInstanceProfile,
 			UserData:           userData,
-			Tags:               launchTags,
+			Tags:               tags,
 		}
 
 		// Look up VPCID from subnet and decide whether to assign a public IP.
@@ -2839,14 +2848,22 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 		return nil, &AWSError{Code: "InvalidParameterValue", Message: "InstanceId and Name are required", HTTPStatus: http.StatusBadRequest}
 	}
 
-	// Parse TagSpecifications (TagSpecification.1.Tag.N.Key / Value).
-	var tags []EC2Tag
-	for i := 1; ; i++ {
-		key := req.Params[fmt.Sprintf("TagSpecification.1.Tag.%d.Key", i)]
-		if key == "" {
-			break
-		}
-		tags = append(tags, EC2Tag{Key: key, Value: req.Params[fmt.Sprintf("TagSpecification.1.Tag.%d.Value", i)]})
+	// CreateImage can tag the AMI, the snapshots it creates, or both: "To tag the AMI,
+	// the value for ResourceType must be image. To tag the snapshots […] the value for
+	// ResourceType must be snapshot. The same tag is applied to all of the snapshots
+	// that are created." Both are parsed through the shared parser, so ResourceType is
+	// honored rather than ignored — this path previously read TagSpecification.1's tags
+	// regardless of what resource they were scoped to, which put snapshot-scoped tags
+	// on the AMI (#468).
+	tags := ec2LaunchTagsForResource(req.Params, "image")
+	snapshotTags := ec2LaunchTagsForResource(req.Params, "snapshot")
+	// Checked before the snapshot and image are written, so a rejected request creates
+	// neither. See [ec2CheckReservedTagKeys] for the rollback rule this follows.
+	if awsErr := ec2CheckReservedTagKeys(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckReservedTagKeys(snapshotTags); awsErr != nil {
+		return nil, awsErr
 	}
 
 	// Materialize a backing EBS snapshot for the AMI's root device, so that
@@ -2859,6 +2876,7 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 		State:       "completed",
 		StartTime:   p.tc.Now().UTC().Format(time.RFC3339),
 		Description: "Created by CreateImage for " + name,
+		Tags:        snapshotTags,
 		AccountID:   reqCtx.AccountID,
 		Region:      reqCtx.Region,
 	}
@@ -3594,25 +3612,9 @@ func (p *EC2Plugin) createNatGateway(reqCtx *RequestContext, req *AWSRequest) (*
 		}
 	}
 
-	// Extract tags from TagSpecification.N.
-	for n := 1; ; n++ {
-		rt := req.Params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
-		if rt == "" {
-			break
-		}
-		if rt != "natgateway" {
-			continue
-		}
-		for m := 1; ; m++ {
-			key := req.Params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", n, m)]
-			if key == "" {
-				break
-			}
-			gw.Tags = append(gw.Tags, EC2Tag{
-				Key:   key,
-				Value: req.Params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", n, m)],
-			})
-		}
+	gw.Tags = ec2LaunchTagsForResource(req.Params, "natgateway")
+	if awsErr := ec2CheckReservedTagKeys(gw.Tags); awsErr != nil {
+		return nil, awsErr
 	}
 
 	data, marshalErr := json.Marshal(gw)

--- a/emulator/ec2_tags.go
+++ b/emulator/ec2_tags.go
@@ -1,6 +1,7 @@
 package emulator
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 )
@@ -34,16 +35,64 @@ func ec2ReservedTagKeyError() *AWSError {
 	}
 }
 
+// ec2LaunchTagsForResource collects the TagSpecification.N tags scoped to
+// resourceType, in the request's Tag.N order.
+//
+// This is the single parser for tag-on-create across every EC2 operation that
+// accepts TagSpecification.N — RunInstances, CreateFleet, CreateImage and
+// CreateNatGateway. It exists as one function because it is what every
+// tag-on-create path must be checked at: four separate copies of this loop had
+// drifted apart, and only the RunInstances one was reachable by
+// [ec2CheckReservedTagKeys] (#468).
+//
+// A specification whose ResourceType names a different resource is skipped rather
+// than ending the walk, so TagSpecification.1=volume followed by
+// TagSpecification.2=instance still yields the instance's tags. An absent or empty
+// ResourceType ends it, which is how the query protocol terminates an indexed list.
+//
+// Note that authz.go builds aws:RequestTag condition keys from the same params with
+// its own walk, deliberately: it evaluates a policy against the request rather than
+// producing resource state, and the two must not share a filter on resourceType.
+func ec2LaunchTagsForResource(params map[string]string, resourceType string) []EC2Tag {
+	var tags []EC2Tag
+	for n := 1; ; n++ {
+		rt, ok := params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
+		if !ok || rt == "" {
+			break
+		}
+		if rt != resourceType {
+			continue
+		}
+		for m := 1; ; m++ {
+			key, keyOK := params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", n, m)]
+			if !keyOK || key == "" {
+				break
+			}
+			tags = append(tags, EC2Tag{
+				Key:   key,
+				Value: params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", n, m)],
+			})
+		}
+	}
+	return tags
+}
+
 // ec2CheckReservedTagKeys returns an error if any tag uses a reserved key, or nil.
 //
-// The tags are checked in slice order — extractEC2Tags preserves the request's Tag.N
-// numbering — so the request that is rejected is decided identically on every run. A
-// map would make it iteration-order dependent, which is the opposite of what this
-// emulator is for.
+// The tags are checked in slice order — extractEC2Tags and
+// [ec2LaunchTagsForResource] both preserve the request's Tag.N numbering — so the
+// request that is rejected is decided identically on every run. A map would make it
+// iteration-order dependent, which is the opposite of what this emulator is for.
 //
 // Callers must check before applying anything. CreateTags accepts up to 1000 resource
 // IDs, and rejecting partway through the loop would leave the earlier resources tagged
 // and the rest not, a state real EC2 never produces.
+//
+// On a tag-on-create path the same rule means checking before the resource is created
+// at all. The tagging documentation is explicit — "If tags cannot be applied during
+// resource creation, we roll back the resource creation process. This ensures that
+// resources are either created with tags or not created at all" — so a rejected
+// request must leave nothing behind.
 func ec2CheckReservedTagKeys(tags []EC2Tag) *AWSError {
 	for _, t := range tags {
 		if strings.HasPrefix(t.Key, ec2ReservedTagPrefix) {

--- a/emulator/ec2_tags_test.go
+++ b/emulator/ec2_tags_test.go
@@ -206,15 +206,16 @@ func TestEC2_DeleteTags_OrdinaryKeyStillWorks(t *testing.T) {
 	}
 }
 
-// TestEC2_ReservedTagCheck_DoesNotBreakFleetTagging is the gate on #452 having
-// landed in the right code path.
+// TestEC2_ReservedTagCheck_DoesNotBreakFleetTagging is the gate on the reserved-key
+// check having landed in the right code path.
 //
-// Substrate stamps aws:ec2:fleet-id (#443) by building RunInstances
-// TagSpecification params, which runInstances parses itself rather than routing
-// through CreateTags. Putting the reserved-prefix check in that parse would reject
-// substrate's own fleet tagging and silently undo #443 — for an "instant" fleet
-// this tag is the only route from a fleet back to its instances, so the failure
-// would surface as a fully-running fleet reporting as empty.
+// Substrate stamps aws:ec2:fleet-id (#443) on every fleet instance. #468 extended the
+// reserved-prefix check to every tag-on-create path, including the one fleets launch
+// through, so the stamp now travels as an already-parsed tag appended after the check
+// rather than as a TagSpecification param subject to it. If that split is ever
+// collapsed the check rejects substrate's own tagging and silently undoes #443 — for
+// an "instant" fleet this tag is the only route from a fleet back to its instances, so
+// the failure surfaces as a fully-running fleet reporting as empty.
 func TestEC2_ReservedTagCheck_DoesNotBreakFleetTagging(t *testing.T) {
 	ts := newEC2TestServer(t)
 	ltID := newFleetLaunchTemplate(t, ts, "reserved-tag-fleet")
@@ -245,4 +246,373 @@ func TestEC2_ReservedTagCheck_DoesNotBreakFleetTagging(t *testing.T) {
 	}, &desc)
 	assert.Len(t, desc.Instances, 2,
 		"filtering on %s must still find the fleet's instances", fleetIDTagKey)
+}
+
+// ec2TagTestSubnet creates a VPC and a subnet in it, returning the subnet ID — the
+// setup CreateNatGateway needs before it can be asked to tag anything.
+func ec2TagTestSubnet(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	var vpc struct {
+		VPCID string `xml:"vpc>vpcId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":    "CreateVpc",
+		"CidrBlock": "10.9.0.0/16",
+	}, &vpc)
+	require.NotEmpty(t, vpc.VPCID)
+
+	var subnet struct {
+		SubnetID string `xml:"subnet>subnetId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":    "CreateSubnet",
+		"VpcId":     vpc.VPCID,
+		"CidrBlock": "10.9.1.0/24",
+	}, &subnet)
+	require.NotEmpty(t, subnet.SubnetID)
+	return subnet.SubnetID
+}
+
+// ec2InstanceCount returns how many instances DescribeInstances reports in total,
+// which is how the tag-on-create tests assert that a rejected launch created nothing.
+func ec2InstanceCount(t *testing.T, ts *httptest.Server) int {
+	t.Helper()
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeInstances"}, &desc)
+	return len(desc.Instances)
+}
+
+// TestEC2_RunInstances_RejectsReservedTagKeys covers #468: #452 closed the reserved
+// "aws:" prefix on CreateTags and DeleteTags but not on tag-on-create, so the same key
+// real EC2 refuses was accepted whenever it arrived through a TagSpecification.
+//
+// Both captures behind ec2ReservedTagMessage are of RunInstances tag-on-create, so
+// this path has stronger provenance for the message than the one #452 shipped it on.
+func TestEC2_RunInstances_RejectsReservedTagKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		tagKey   string
+		accepted bool
+	}{
+		{name: "reserved prefix", tagKey: "aws:foo"},
+		{name: "the fleet-id key itself", tagKey: fleetIDTagKey},
+		{name: "prefix alone", tagKey: "aws:"},
+		// Tag keys are case-sensitive per the EC2 tagging documentation, so these are
+		// ordinary user tags. A case-folded check would trade #452's infidelity for a
+		// new one in the other direction — and the SQS attribute prefix in #472 is
+		// case-INsensitive, so the two rules must not be unified.
+		{name: "uppercase is an ordinary tag", tagKey: "AWS:foo", accepted: true},
+		{name: "mixed case is an ordinary tag", tagKey: "Aws:foo", accepted: true},
+		{name: "no colon is an ordinary tag", tagKey: "awsfoo", accepted: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			params := map[string]string{
+				"Action":                          "RunInstances",
+				"ImageId":                         "ami-0reserved00000001",
+				"MinCount":                        "1",
+				"MaxCount":                        "1",
+				"TagSpecification.1.ResourceType": "instance",
+				"TagSpecification.1.Tag.1.Key":    tc.tagKey,
+				"TagSpecification.1.Tag.1.Value":  "v",
+			}
+
+			if tc.accepted {
+				ids := ec2RunInstanceIDs(t, ts, params)
+				require.Len(t, ids, 1)
+				value, ok := ec2InstanceTagValue(t, ts, ids[0], tc.tagKey)
+				assert.True(t, ok, "%s should have been applied", tc.tagKey)
+				assert.Equal(t, "v", value)
+				return
+			}
+
+			status, code, message := ec2ErrorDetail(t, ts, params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Equal(t, ec2ReservedTagMessage, message)
+			assert.Zero(t, ec2InstanceCount(t, ts),
+				"a rejected launch must not create an instance")
+		})
+	}
+}
+
+// TestEC2_RunInstances_ReservedTagRejectionCreatesNothing pins the rollback rule: "If
+// tags cannot be applied during resource creation, we roll back the resource creation
+// process. This ensures that resources are either created with tags or not created at
+// all."
+//
+// This is the assertion that fails if the check ever moves after the per-instance
+// state.Put, which would leave instances behind that real EC2 never creates. MaxCount
+// is 3 so a partial application is visible as a count rather than only as a tag.
+func TestEC2_RunInstances_ReservedTagRejectionCreatesNothing(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	// One legal tag alongside one reserved key: the request is refused whole, so the
+	// legal tag is not applied to anything either.
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                          "RunInstances",
+		"ImageId":                         "ami-0rollback00000001",
+		"MinCount":                        "3",
+		"MaxCount":                        "3",
+		"TagSpecification.1.ResourceType": "instance",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+		"TagSpecification.1.Tag.2.Key":    "aws:internal",
+		"TagSpecification.1.Tag.2.Value":  "x",
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValue", code)
+	assert.Zero(t, ec2InstanceCount(t, ts), "no instance may survive the rejection")
+
+	// A second specification carrying the reserved key still fails the request, even
+	// though the first specification is legal — the check sees every instance-scoped
+	// tag, not just the first block's.
+	status, code, _ = ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                          "RunInstances",
+		"ImageId":                         "ami-0rollback00000002",
+		"MinCount":                        "1",
+		"MaxCount":                        "1",
+		"TagSpecification.1.ResourceType": "instance",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+		"TagSpecification.2.ResourceType": "instance",
+		"TagSpecification.2.Tag.1.Key":    "aws:internal",
+		"TagSpecification.2.Tag.1.Value":  "x",
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValue", code)
+	assert.Zero(t, ec2InstanceCount(t, ts))
+
+	// A volume-scoped reserved key does not fail an instance launch: substrate models
+	// instance tags on this path, and a specification for a resource it does not tag is
+	// skipped rather than checked. Stated as a deliberate limit, not an oversight.
+	ids := ec2RunInstanceIDs(t, ts, map[string]string{
+		"Action":                          "RunInstances",
+		"ImageId":                         "ami-0rollback00000003",
+		"MinCount":                        "1",
+		"MaxCount":                        "1",
+		"TagSpecification.1.ResourceType": "volume",
+		"TagSpecification.1.Tag.1.Key":    "aws:volume",
+		"TagSpecification.1.Tag.1.Value":  "x",
+	})
+	assert.Len(t, ids, 1)
+}
+
+// TestEC2_CreateImage_RejectsReservedTagKeys covers CreateImage's two tag scopes.
+//
+// Per the reference, ResourceType=image tags the AMI while ResourceType=snapshot tags
+// "the snapshots that are created of the root volume and of other Amazon EBS volumes
+// that are attached to the instance", so a reserved key is refused on either.
+func TestEC2_CreateImage_RejectsReservedTagKeys(t *testing.T) {
+	for _, resourceType := range []string{"image", "snapshot"} {
+		t.Run(resourceType, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			instID := ec2TagTestInstance(t, ts)
+
+			status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+				"Action":                          "CreateImage",
+				"InstanceId":                      instID,
+				"Name":                            "reserved-tag-ami",
+				"TagSpecification.1.ResourceType": resourceType,
+				"TagSpecification.1.Tag.1.Key":    "aws:foo",
+				"TagSpecification.1.Tag.1.Value":  "v",
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Equal(t, ec2ReservedTagMessage, message)
+
+			// Neither the AMI nor its backing snapshot may exist.
+			var images struct {
+				Images []struct {
+					ImageID string `xml:"imageId"`
+				} `xml:"imagesSet>item"`
+			}
+			ec2FleetXML(t, ts, map[string]string{"Action": "DescribeImages"}, &images)
+			assert.Empty(t, images.Images, "a rejected CreateImage must not create an AMI")
+
+			var snaps struct {
+				Snapshots []struct {
+					SnapshotID string `xml:"snapshotId"`
+				} `xml:"snapshotSet>item"`
+			}
+			ec2FleetXML(t, ts, map[string]string{"Action": "DescribeSnapshots"}, &snaps)
+			assert.Empty(t, snaps.Snapshots,
+				"a rejected CreateImage must not leave its backing snapshot behind")
+		})
+	}
+}
+
+// TestEC2_CreateImage_HonorsTagResourceType pins the fidelity gain that came with
+// routing CreateImage through the shared parser: snapshot-scoped tags land on the
+// snapshot and image-scoped tags on the AMI. This path previously read
+// TagSpecification.1's tags whatever they were scoped to, so a request tagging only
+// its snapshots put those tags on the AMI instead.
+func TestEC2_CreateImage_HonorsTagResourceType(t *testing.T) {
+	ts := newEC2TestServer(t)
+	instID := ec2TagTestInstance(t, ts)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                          "CreateImage",
+		"InstanceId":                      instID,
+		"Name":                            "scoped-tag-ami",
+		"TagSpecification.1.ResourceType": "image",
+		"TagSpecification.1.Tag.1.Key":    "Scope",
+		"TagSpecification.1.Tag.1.Value":  "ami",
+		"TagSpecification.2.ResourceType": "snapshot",
+		"TagSpecification.2.Tag.1.Key":    "Scope",
+		"TagSpecification.2.Tag.1.Value":  "snap",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close() //nolint:errcheck
+
+	var images struct {
+		Images []struct {
+			ImageID string `xml:"imageId"`
+			Tags    []struct {
+				Key   string `xml:"key"`
+				Value string `xml:"value"`
+			} `xml:"tagSet>item"`
+		} `xml:"imagesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeImages"}, &images)
+	require.Len(t, images.Images, 1)
+	require.Len(t, images.Images[0].Tags, 1, "only the image-scoped tag belongs on the AMI")
+	assert.Equal(t, "Scope", images.Images[0].Tags[0].Key)
+	assert.Equal(t, "ami", images.Images[0].Tags[0].Value)
+
+	var snaps struct {
+		Snapshots []struct {
+			SnapshotID string `xml:"snapshotId"`
+			Tags       []struct {
+				Key   string `xml:"key"`
+				Value string `xml:"value"`
+			} `xml:"tagSet>item"`
+		} `xml:"snapshotSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeSnapshots"}, &snaps)
+	require.Len(t, snaps.Snapshots, 1)
+	require.Len(t, snaps.Snapshots[0].Tags, 1,
+		"only the snapshot-scoped tag belongs on the snapshot")
+	assert.Equal(t, "snap", snaps.Snapshots[0].Tags[0].Value)
+}
+
+// TestEC2_CreateNatGateway_RejectsReservedTagKeys covers the third tag-on-create path.
+func TestEC2_CreateNatGateway_RejectsReservedTagKeys(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetID := ec2TagTestSubnet(t, ts)
+
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                          "CreateNatGateway",
+		"SubnetId":                        subnetID,
+		"ConnectivityType":                "private",
+		"TagSpecification.1.ResourceType": "natgateway",
+		"TagSpecification.1.Tag.1.Key":    "aws:foo",
+		"TagSpecification.1.Tag.1.Value":  "v",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+	assert.Equal(t, ec2ReservedTagMessage, message)
+
+	var gws struct {
+		Gateways []struct {
+			NatGatewayID string `xml:"natGatewayId"`
+		} `xml:"natGatewaySet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeNatGateways"}, &gws)
+	assert.Empty(t, gws.Gateways, "a rejected CreateNatGateway must not create a gateway")
+
+	// An ordinary key on the same path still works, so the check is a filter rather
+	// than a blanket refusal.
+	var created struct {
+		NatGatewayID string `xml:"natGateway>natGatewayId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":                          "CreateNatGateway",
+		"SubnetId":                        subnetID,
+		"ConnectivityType":                "private",
+		"TagSpecification.1.ResourceType": "natgateway",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	}, &created)
+	assert.NotEmpty(t, created.NatGatewayID)
+}
+
+// TestEC2_CreateFleet_RejectsCallersReservedTagKeys is the other half of the fleet
+// gate: substrate's own aws:ec2:fleet-id stamp is exempt because it never rides the
+// request path, but a *caller's* reserved key in the same fleet request is not.
+//
+// Without this the structural split would have opened a hole — a consumer could reach
+// the unchecked path by asking a fleet to apply the tag for them.
+func TestEC2_CreateFleet_RejectsCallersReservedTagKeys(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+	}{
+		{name: "instance-scoped", resourceType: "instance"},
+		{name: "fleet-scoped", resourceType: "fleet"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			ltID := newFleetLaunchTemplate(t, ts, "fleet-reserved-"+tc.resourceType)
+
+			status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+				"Action": "CreateFleet",
+				"Type":   "instant",
+				"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+				"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+				"TagSpecification.1.ResourceType":                                      tc.resourceType,
+				"TagSpecification.1.Tag.1.Key":                                         "aws:mine",
+				"TagSpecification.1.Tag.1.Value":                                       "v",
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Equal(t, ec2ReservedTagMessage, message)
+			assert.Zero(t, ec2InstanceCount(t, ts),
+				"a rejected fleet must not launch instances")
+		})
+	}
+}
+
+// TestEC2_CreateFleet_CallerTagsAndFleetIDTagCoexist pins that the split kept both
+// halves working at once: the caller's legal launch tags reach the instances *and* the
+// fleet-ID stamp is still applied alongside them.
+//
+// Under the old mechanism the stamp was written into a free TagSpecification.N index,
+// so an off-by-one in that index hunt would silently overwrite a caller's tag. There
+// is no index to get wrong now, and this test is what would catch it returning.
+func TestEC2_CreateFleet_CallerTagsAndFleetIDTagCoexist(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-tags-coexist")
+
+	var fleet createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+		"TagSpecification.1.ResourceType":                                      "instance",
+		"TagSpecification.1.Tag.1.Key":                                         "Env",
+		"TagSpecification.1.Tag.1.Value":                                       "prod",
+		"TagSpecification.1.Tag.2.Key":                                         "Team",
+		"TagSpecification.1.Tag.2.Value":                                       "infra",
+	}, &fleet)
+	require.Len(t, fleet.instanceIDs(), 2)
+
+	for _, id := range fleet.instanceIDs() {
+		env, ok := ec2InstanceTagValue(t, ts, id, "Env")
+		assert.True(t, ok, "instance %s lost the caller's Env tag", id)
+		assert.Equal(t, "prod", env)
+
+		team, ok := ec2InstanceTagValue(t, ts, id, "Team")
+		assert.True(t, ok, "instance %s lost the caller's Team tag", id)
+		assert.Equal(t, "infra", team)
+
+		fleetID, ok := ec2InstanceTagValue(t, ts, id, fleetIDTagKey)
+		assert.True(t, ok, "instance %s lost its %s tag", id, fleetIDTagKey)
+		assert.Equal(t, fleet.FleetID, fleetID)
+	}
 }


### PR DESCRIPTION
## What

Reserved `aws:` tag keys are now rejected on every tag-on-create path —
`RunInstances`, `CreateFleet`, `CreateImage` and `CreateNatGateway` — not just
on `CreateTags`/`DeleteTags`.

## Why

#452 closed this for `CreateTags` and `DeleteTags` but deliberately left
tag-on-create alone, because substrate stamps `aws:ec2:fleet-id` (#443) through
that same path and restricting it would have rejected substrate's own fleet
tagging. So a key real EC2 refuses was still accepted through any
`TagSpecification`, leaving a consumer's error branch unreachable on precisely
the path the message has the best evidence for: **both real-AWS captures behind
`Tag keys starting with 'aws:' are reserved for internal use` are of
`RunInstances` tag-on-create**, not `CreateTags`.

## The routing problem, and why not a flag

`#468` rules out an internal bypass flag, and the reason holds: a
skip-validation switch makes the check's outcome depend on state a consumer
cannot observe, which is the opposite of the deterministic-replay property
substrate exists for.

Instead the parse is split from the launch. `runInstances` parses the request's
`TagSpecification.N` tags, checks them, and delegates to
`runInstancesWithTags(reqCtx, req, tags)`. `CreateFleet` parses and checks the
caller's tags the same way, then appends the fleet-ID tag to the resulting
slice. **There is no param a request could set to reach that append** — the
exemption is structural, not conditional.

Two tests pin both halves: a caller naming `aws:mine` in a `CreateFleet`
request is rejected (instance- *and* fleet-scoped), and the fleet's own stamp
still lands alongside the caller's legal `Env`/`Team` tags on the same
instance.

## Rollback

The check runs before `generateReservationID()` and the per-instance
`state.Put`, so nothing is created:

> If tags cannot be applied during resource creation, we roll back the resource
> creation process. This ensures that resources are either created with tags or
> not created at all.

A refused `RunInstances` launches no instance, a refused `CreateImage` leaves
behind neither the AMI nor its backing snapshot, and a refused
`CreateNatGateway` creates no gateway.

## Deletions

`passthroughFleetTagSpecs` and `fleetIDTagSpec` are both gone. With tags
travelling as values there is no free `TagSpecification.N` index to hunt for —
that index hunt was the subtlest function in the fleet tag path, and an
off-by-one in it would have silently overwritten a caller's own tag. Four
drifted copies of the `TagSpecification.N` loop collapse into one
`ec2LaunchTagsForResource`.

## One deviation from the plan: a fourth copy, and a behaviour change

The plan named three `TagSpecification.N` parsers besides `runInstances`. There
were **four** — `passthroughFleetTagSpecs` was a fifth copy of the loop that
re-emitted params rather than returning tags.

Folding `createImage` onto the shared parser is also a **behaviour change**,
which the plan did not anticipate: `createImage` hardcoded
`TagSpecification.1.Tag.%d` and ignored `ResourceType` entirely. Checked against
the reference before changing it — `ResourceType` is load-bearing there
(`image` and `snapshot` are both valid, and "If you specify other values for
`ResourceType`, the request fails"), and `EC2Snapshot` already carries `Tags`
that `DescribeSnapshots` emits. So honouring it is a fidelity gain: a request
tagging only its snapshots previously put those tags on the AMI. Called out in
`### Changed` and in `docs/services.md`, since a caller asserting on
`DescribeImages` for snapshot-scoped tags will see them move.

`authz.go:519`'s walk over the same params is deliberately left alone, now with
a comment saying why: it builds `aws:RequestTag` condition keys, where
filtering by `resourceType` would silently narrow policy evaluation.

## Verification

From the repo root: `gofmt -l .` clean, `go build ./...`, `go vet ./...`,
`golangci-lint run ./...` → **0 issues**, `make test` (race) all packages ok,
`make docs-reference docs-reference-check docs-versions` pass,
`go test -C test/e2e ./...` ok. The whole pre-existing EC2 and fleet suite
passes unchanged.

**Mutation-tested, four mutants, all killed:**

| Mutation | Killed by |
|---|---|
| drop the check from `runInstances` | `RejectsReservedTagKeys` (3 subtests), `ReservedTagRejectionCreatesNothing` |
| move the check *after* the launch | same — and via the rollback assertion specifically (`Should be zero, but was 3`), which is the ordering gate |
| route the fleet stamp back through the checked path | the **entire fleet suite** (9 tests) — the #443 regression the split prevents |
| stop honouring `ResourceType` in the shared parser | `CreateFleet_TagPropagation`, `FleetIDTagCoexistsWithCallerTags`, `ReservedTagRejectionCreatesNothing`, `CreateImage_HonorsTagResourceType` |

Closes #468
