### PR TITLE
feat(ec2): enforce the 50-tag-per-resource limit (#469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The match remains **case-sensitive**, so `AWS:foo` is still an ordinary user tag.
   Note that #472's SQS attribute prefix rule is case-*insensitive*; the two services
   document different rules and the checks are deliberately not shared.
+- **The 50-tag-per-resource limit is now enforced** (#469).
+  Substrate accepted any number of tags, so a consumer that hit real EC2's ceiling had
+  no way to reach the `TagLimitExceeded` branch — and a test asserting the rejection
+  passed against substrate while the same code failed against AWS. `CreateTags` and
+  every tag-on-create path now refuse a resource that would carry more than 50 user
+  tags with `TagLimitExceeded`, HTTP 400, per the tagging documentation's "Maximum
+  number of tags per resource – 50".
+
+  Two rules make this less like arithmetic than it looks, and both are modelled.
+  **Tags with the `aws:` prefix do not count** ("Tags with the `aws:` prefix do not
+  count against your tags per resource limit"), which matters beyond pedantry: since
+  substrate stamps `aws:ec2:fleet-id` on every fleet instance (#443), a counter that
+  included reserved keys would refuse a fleet launch whose template names the full 50
+  user tags — a launch real EC2 accepts. A fleet instance therefore holds 51 tags
+  legally. And **overwriting an existing key at the limit succeeds**, because the count
+  is over the post-merge key *set* rather than the sum of both sides: changing `key7`'s
+  value on a 50-tag instance is accepted while adding a new `key51` is refused.
+  [getmoto/moto#8151](https://github.com/getmoto/moto/issues/8151) reports real AWS
+  permitting the first. This also closes the companion gap v0.85.0 recorded as vacuous:
+  the reserved-tag exemption now has a limit to be exempt from.
+
+  As with reserved keys, the whole request is refused before anything is modified — a
+  `CreateTags` naming one instance with room and one at the limit tags neither.
+
+  Provenance is split, and the weaker half is named. The **code** is a doc citation:
+  EC2's client-error table lists `TagLimitExceeded` as "You've reached the limit on the
+  number of tags that you can assign to the specified resource." The wire **message**
+  is published nowhere, so the wording comes from moto — a reimplementation, not a
+  capture. Stronger than #452's provenance on the code, weaker on the message; SDKs
+  dispatch on `Error.Code`, so the documented half is the one a consumer's error branch
+  turns on. The documented tag key/value *length* limits (128 and 256 Unicode
+  characters) remain unenforced and are tracked separately.
 - **EC2 launch templates are now versioned** (#456).
   `CreateLaunchTemplateVersion`, `ModifyLaunchTemplate`,
   `DescribeLaunchTemplateVersions` and `DeleteLaunchTemplateVersions` were all

--- a/docs/services.md
+++ b/docs/services.md
@@ -1610,14 +1610,56 @@ So a caller naming `aws:` anything in a `CreateFleet` request is rejected —
 instance- and fleet-scoped alike — while the fleet's own stamp is still applied, and
 both coexist with the caller's legal tags on the same instance.
 
-Two limits of the current scope, stated rather than implied:
+One limit of the current scope, stated rather than implied: only tags scoped to a
+resource substrate models are checked. A `TagSpecification` naming `volume` or
+`network-interface` on `RunInstances` is skipped, because substrate does not tag those
+resources at all; real EC2 would reject a reserved key there too.
 
-- Only tags scoped to a resource substrate models are checked. A
-  `TagSpecification` naming `volume` or `network-interface` on `RunInstances` is
-  skipped, because substrate does not tag those resources at all; real EC2 would
-  reject a reserved key there too.
-- The 50-tag-per-resource limit is not modelled, so the companion rule that
-  reserved tags are exempt from it has nothing to exempt them from yet.
+### The 50-tag-per-resource limit
+
+A resource carrying more than 50 user tags is refused, on `CreateTags` and on every
+tag-on-create path:
+
+```
+TagLimitExceeded: The maximum number of Tags for a resource has been reached.
+```
+
+The status is `400`. From the tagging documentation's restrictions: "Maximum number of
+tags per resource – 50".
+
+Two rules make this less arithmetic than it looks, and both are modelled.
+
+**Tags with the `aws:` prefix do not count.** The documentation says so directly:
+"Tags with the `aws:` prefix do not count against your tags per resource limit." This
+is load-bearing rather than pedantry, because substrate stamps
+[`aws:ec2:fleet-id`](#finding-a-fleets-instances) on every fleet instance — a counter
+that included reserved keys would refuse a fleet launch whose template names the full
+50 user tags, which real EC2 accepts. A fleet instance therefore holds 51 tags legally:
+50 of the caller's and one of substrate's.
+
+**Overwriting an existing key at the limit succeeds.** The count is over the
+*post-merge key set*, so a key already on the resource adds nothing. `CreateTags` on a
+50-tag instance changing the value of `key7` is accepted and the value changes; adding
+a new `key51` to the same instance is refused. Written as
+`len(existing) + len(incoming)` both would fail, and real AWS permits the first —
+[getmoto/moto#8151](https://github.com/getmoto/moto/issues/8151) reports exactly that
+case.
+
+As with reserved keys, the whole request is refused before anything is modified.
+`CreateTags` naming two instances — one with room, one at the limit — tags neither.
+A resource ID that names nothing is not counted against, because the apply step ignores
+it: checking it would refuse a request real EC2 accepts as a no-op.
+
+Provenance is split, and the weaker half is the message. The **code** is documented:
+EC2's client-error table lists `TagLimitExceeded` as "You've reached the limit on the
+number of tags that you can assign to the specified resource." The wire **message** is
+published nowhere, so the wording above is [moto](https://github.com/getmoto/moto)'s,
+from a reimplementation rather than a captured response. That is a weaker claim than the
+code's, and is a distinction worth stating: SDKs dispatch on `Error.Code`, so the code
+is the part a consumer's error branch turns on.
+
+Two documented restrictions substrate does **not** enforce: a tag key's maximum length
+of 128 Unicode characters, and a value's maximum of 256. Both are tracked separately.
 
 #### Tag scoping on `CreateImage`
 

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -282,8 +282,14 @@ func (p *EC2Plugin) createFleet(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 	if awsErr := ec2CheckReservedTagKeys(instanceTags); awsErr != nil {
 		return nil, awsErr
 	}
+	if awsErr := ec2CheckTagLimit(nil, instanceTags); awsErr != nil {
+		return nil, awsErr
+	}
 	fleetTags := ec2LaunchTagsForResource(req.Params, "fleet")
 	if awsErr := ec2CheckReservedTagKeys(fleetTags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, fleetTags); awsErr != nil {
 		return nil, awsErr
 	}
 
@@ -588,7 +594,10 @@ func parseFleetOverride(params map[string]string, prefix string) (EC2FleetOverri
 // The "aws:" prefix is reserved: per the EC2 tagging documentation such a tag
 // cannot be edited or deleted by a caller and does not count against the 50-tag
 // per-resource limit. CreateTags and DeleteTags enforce the first rule (#452), and
-// every tag-on-create path now enforces it too (#468).
+// every tag-on-create path now enforces it too (#468). The second rule is why
+// [ec2CheckTagLimit] excludes reserved keys from its count (#469): this tag is stamped
+// on every fleet instance, so counting it would reject a fleet instance carrying the
+// full 50 user tags, which real EC2 accepts.
 //
 // Substrate stamps this tag without tripping its own check because
 // [EC2Plugin.launchFleetPool] appends it to the already-parsed, already-checked tag

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -258,6 +258,13 @@ func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if awsErr := ec2CheckReservedTagKeys(launchTags); awsErr != nil {
 		return nil, awsErr
 	}
+	// A new instance starts with no tags, so the request's own tags are the whole count
+	// (#469). The fleet-ID tag substrate may add afterwards is reserved, and reserved
+	// keys are excluded from the count — so a fleet instance launched from a template
+	// carrying the full 50 user tags is still legal, exactly as on real EC2.
+	if awsErr := ec2CheckTagLimit(nil, launchTags); awsErr != nil {
+		return nil, awsErr
+	}
 	return p.runInstancesWithTags(reqCtx, req, launchTags)
 }
 
@@ -2010,15 +2017,31 @@ func (p *EC2Plugin) rebootInstances(_ *RequestContext, _ *AWSRequest) (*AWSRespo
 // createTags handles CreateTags — applies key-value tags to one or more EC2 resources.
 //
 // Keys using the reserved "aws:" prefix are rejected before anything is applied, so a
-// mixed request leaves every named resource untouched (#452). Note that this covers
-// CreateTags only: RunInstances tag-on-create parses its TagSpecification.N params
-// separately, and substrate's own fleet tagging stamps aws:ec2:fleet-id through that
-// path — see [ec2FleetIDTagKey].
+// mixed request leaves every named resource untouched (#452), and every resource named
+// is checked against the per-resource tag limit before any of them is modified (#469).
+// Both checks run over the whole request for the same reason: CreateTags accepts up to
+// 1000 resource IDs, and a rejection partway through the apply loop would leave a
+// partially-tagged state real EC2 never produces.
 func (p *EC2Plugin) createTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	resourceIDs := extractIndexedParams(req.Params, "ResourceId")
 	tags := extractEC2Tags(req.Params)
 	if err := ec2CheckReservedTagKeys(tags); err != nil {
 		return nil, err
+	}
+	for _, id := range resourceIDs {
+		existing, found, err := p.resourceTags(reqCtx, id)
+		if err != nil {
+			return nil, err
+		}
+		// An unknown or absent resource is ignored by the apply loop below, so there is
+		// nothing to count against — checking it would reject a request real EC2 accepts
+		// as a no-op.
+		if !found {
+			continue
+		}
+		if awsErr := ec2CheckTagLimit(existing, tags); awsErr != nil {
+			return nil, awsErr
+		}
 	}
 	for _, id := range resourceIDs {
 		if err := p.applyTagsToResource(reqCtx, id, tags, false); err != nil {
@@ -2103,30 +2126,69 @@ func (p *EC2Plugin) modifyInstanceAttribute(reqCtx *RequestContext, req *AWSRequ
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
 }
 
+// ec2TaggableStateKey returns the state key for a taggable resource ID, and whether
+// the ID's prefix names a resource type substrate can tag at all.
+//
+// Shared by [EC2Plugin.applyTagsToResource] and [EC2Plugin.resourceTags] so the tag
+// limit is counted against exactly the resources the apply step will modify: if the two
+// disagreed about which IDs resolve, CreateTags would either check a resource it does
+// not tag or tag one it did not check.
+func ec2TaggableStateKey(reqCtx *RequestContext, id string) (string, bool) {
+	scope := reqCtx.AccountID + "/" + reqCtx.Region
+	switch {
+	case strings.HasPrefix(id, "i-"):
+		return "instance:" + scope + "/" + id, true
+	case strings.HasPrefix(id, "vpc-"):
+		return "vpc:" + scope + "/" + id, true
+	case strings.HasPrefix(id, "subnet-"):
+		return "subnet:" + scope + "/" + id, true
+	case strings.HasPrefix(id, "sg-"):
+		return "sg:" + scope + "/" + id, true
+	case strings.HasPrefix(id, "igw-"):
+		return "igw:" + scope + "/" + id, true
+	case strings.HasPrefix(id, "rtb-"):
+		return "rtb:" + scope + "/" + id, true
+	case strings.HasPrefix(id, "eipalloc-"):
+		return "eip:" + scope + "/" + id, true
+	case strings.HasPrefix(id, "nat-"):
+		return "nat:" + scope + "/" + id, true
+	default:
+		return "", false
+	}
+}
+
+// resourceTags returns the tags currently on the resource named by id, and whether the
+// resource was found at all.
+//
+// A missing resource reports found=false rather than an error, matching
+// [EC2Plugin.applyTagsToResource]: CreateTags on an absent resource is a no-op in
+// substrate rather than a rejection, so the tag-limit check has nothing to count.
+func (p *EC2Plugin) resourceTags(reqCtx *RequestContext, id string) ([]EC2Tag, bool, error) {
+	stateKey, ok := ec2TaggableStateKey(reqCtx, id)
+	if !ok {
+		return nil, false, nil
+	}
+	data, err := p.state.Get(context.Background(), ec2Namespace, stateKey)
+	if err != nil || data == nil {
+		return nil, false, nil //nolint:nilerr // Absent resource — ignored, as by applyTagsToResource.
+	}
+	var resource map[string]json.RawMessage
+	if err := json.Unmarshal(data, &resource); err != nil {
+		return nil, false, fmt.Errorf("ec2 resourceTags unmarshal %s: %w", id, err)
+	}
+	var existing []EC2Tag
+	if raw, ok := resource["tags"]; ok {
+		_ = json.Unmarshal(raw, &existing)
+	}
+	return existing, true, nil
+}
+
 // applyTagsToResource loads the EC2 resource identified by id, merges or
 // removes the provided tags, and saves the updated resource back to state.
 // When remove is true, matching tag keys are deleted; otherwise tags are upserted.
 func (p *EC2Plugin) applyTagsToResource(reqCtx *RequestContext, id string, tags []EC2Tag, remove bool) error {
-	scope := reqCtx.AccountID + "/" + reqCtx.Region
-	var stateKey string
-	switch {
-	case strings.HasPrefix(id, "i-"):
-		stateKey = "instance:" + scope + "/" + id
-	case strings.HasPrefix(id, "vpc-"):
-		stateKey = "vpc:" + scope + "/" + id
-	case strings.HasPrefix(id, "subnet-"):
-		stateKey = "subnet:" + scope + "/" + id
-	case strings.HasPrefix(id, "sg-"):
-		stateKey = "sg:" + scope + "/" + id
-	case strings.HasPrefix(id, "igw-"):
-		stateKey = "igw:" + scope + "/" + id
-	case strings.HasPrefix(id, "rtb-"):
-		stateKey = "rtb:" + scope + "/" + id
-	case strings.HasPrefix(id, "eipalloc-"):
-		stateKey = "eip:" + scope + "/" + id
-	case strings.HasPrefix(id, "nat-"):
-		stateKey = "nat:" + scope + "/" + id
-	default:
+	stateKey, ok := ec2TaggableStateKey(reqCtx, id)
+	if !ok {
 		// Unknown resource type — silently ignore (matches AWS behavior).
 		return nil
 	}
@@ -2863,6 +2925,12 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 		return nil, awsErr
 	}
 	if awsErr := ec2CheckReservedTagKeys(snapshotTags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, snapshotTags); awsErr != nil {
 		return nil, awsErr
 	}
 
@@ -3614,6 +3682,9 @@ func (p *EC2Plugin) createNatGateway(reqCtx *RequestContext, req *AWSRequest) (*
 
 	gw.Tags = ec2LaunchTagsForResource(req.Params, "natgateway")
 	if awsErr := ec2CheckReservedTagKeys(gw.Tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, gw.Tags); awsErr != nil {
 		return nil, awsErr
 	}
 

--- a/emulator/ec2_tags.go
+++ b/emulator/ec2_tags.go
@@ -35,6 +35,66 @@ func ec2ReservedTagKeyError() *AWSError {
 	}
 }
 
+// ec2MaxTagsPerResource is the number of user tags EC2 allows on one resource.
+//
+// From the tagging documentation's restrictions: "Maximum number of tags per resource –
+// 50". Tags whose keys carry [ec2ReservedTagPrefix] are excluded from the count, per the
+// same list — "Tags with the aws: prefix do not count against your tags per resource
+// limit" — so a resource can hold 50 user tags plus any number of reserved ones.
+const ec2MaxTagsPerResource = 50
+
+// ec2TagLimitExceededError returns the error EC2 raises when a resource would exceed
+// [ec2MaxTagsPerResource].
+//
+// Provenance, which is split: the *code* is documented — EC2's client-error table lists
+// TagLimitExceeded as "You've reached the limit on the number of tags that you can
+// assign to the specified resource." The *message* is not published anywhere, so the
+// wording here is moto's, from a reimplementation rather than a captured response. That
+// is a weaker claim than the code's and is marked as such deliberately: SDKs dispatch on
+// Error.Code, so the code is the part a consumer's error branch turns on.
+func ec2TagLimitExceededError() *AWSError {
+	return &AWSError{
+		Code:       "TagLimitExceeded",
+		Message:    "The maximum number of Tags for a resource has been reached.",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2CheckTagLimit returns an error if merging incoming into existing would leave a
+// resource with more than [ec2MaxTagsPerResource] user tags, or nil.
+//
+// The count is over the **post-merge key set**, excluding reserved keys, which is what
+// gets both of the documented rules right in one expression:
+//
+//   - A key already on the resource adds nothing, so overwriting an existing tag on a
+//     resource already at the limit succeeds. Written as len(existing)+len(incoming) it
+//     would fail instead — real AWS permits it, and getmoto/moto#8151 reports exactly
+//     that case.
+//   - Reserved keys are excluded from both sides, so they neither count nor consume
+//     room. This is load-bearing rather than pedantry: substrate stamps
+//     [ec2FleetIDTagKey] on every fleet instance, so a counter that included it would
+//     reject a 50-tag launch template on a fleet instance that real EC2 accepts.
+//
+// Callers on a tag-on-create path must check before the resource is created; see
+// [ec2CheckReservedTagKeys] for the rollback rule both checks follow.
+func ec2CheckTagLimit(existing, incoming []EC2Tag) *AWSError {
+	keys := make(map[string]struct{}, len(existing)+len(incoming))
+	for _, t := range existing {
+		if !strings.HasPrefix(t.Key, ec2ReservedTagPrefix) {
+			keys[t.Key] = struct{}{}
+		}
+	}
+	for _, t := range incoming {
+		if !strings.HasPrefix(t.Key, ec2ReservedTagPrefix) {
+			keys[t.Key] = struct{}{}
+		}
+	}
+	if len(keys) > ec2MaxTagsPerResource {
+		return ec2TagLimitExceededError()
+	}
+	return nil
+}
+
 // ec2LaunchTagsForResource collects the TagSpecification.N tags scoped to
 // resourceType, in the request's Tag.N order.
 //

--- a/emulator/ec2_tags_test.go
+++ b/emulator/ec2_tags_test.go
@@ -1,6 +1,7 @@
 package emulator_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -615,4 +616,338 @@ func TestEC2_CreateFleet_CallerTagsAndFleetIDTagCoexist(t *testing.T) {
 		assert.True(t, ok, "instance %s lost its %s tag", id, fleetIDTagKey)
 		assert.Equal(t, fleet.FleetID, fleetID)
 	}
+}
+
+// ec2TagLimit is the number of user tags EC2 allows on one resource, restated here
+// because an external test package cannot see ec2MaxTagsPerResource. That is a feature:
+// the tests assert the documented number rather than whatever the constant happens to
+// hold, so editing the constant alone cannot make them pass.
+//
+// "Maximum number of tags per resource – 50", from the EC2 tagging documentation.
+const ec2TagLimit = 50
+
+// ec2TagLimitMessage is the wording substrate emits when a resource is at its tag
+// limit, pinned so it cannot drift silently.
+//
+// Provenance is split, and the weaker half is the message. The *code*
+// TagLimitExceeded is documented in EC2's client-error table ("You've reached the
+// limit on the number of tags that you can assign to the specified resource"); the
+// wire *message* is published nowhere, so this string is moto's rather than a
+// captured response.
+const ec2TagLimitMessage = "The maximum number of Tags for a resource has been reached."
+
+// ec2NumberedTags returns count tags named key1..keyN, for filling a resource up to
+// its limit.
+func ec2NumberedTags(prefix string, count int) map[string]string {
+	params := map[string]string{}
+	for i := 1; i <= count; i++ {
+		params[fmt.Sprintf("Tag.%d.Key", i)] = fmt.Sprintf("%s%d", prefix, i)
+		params[fmt.Sprintf("Tag.%d.Value", i)] = "v"
+	}
+	return params
+}
+
+// ec2CreateTags issues a CreateTags request adding the given tags to id and returns
+// the HTTP status, error code and message.
+func ec2CreateTags(t *testing.T, ts *httptest.Server, id string, tags map[string]string) (int, string, string) {
+	t.Helper()
+	params := map[string]string{"Action": "CreateTags", "ResourceId.1": id}
+	for k, v := range tags {
+		params[k] = v
+	}
+	return ec2ErrorDetail(t, ts, params)
+}
+
+// ec2InstanceTagCount returns how many tags DescribeInstances reports on instID.
+func ec2InstanceTagCount(t *testing.T, ts *httptest.Server, instID string) int {
+	t.Helper()
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":       "DescribeInstances",
+		"InstanceId.1": instID,
+	}, &desc)
+	require.Len(t, desc.Instances, 1)
+	return len(desc.Instances[0].Tags)
+}
+
+// TestEC2_CreateTags_EnforcesTagLimit covers #469: substrate accepted any number of
+// tags, so a consumer that hit real EC2's 50-tag ceiling had no way to test the
+// TagLimitExceeded branch — and, worse, a test asserting the rejection passed against
+// substrate while the same code failed against AWS.
+//
+// "Maximum number of tags per resource – 50", from the tagging documentation.
+func TestEC2_CreateTags_EnforcesTagLimit(t *testing.T) {
+	ts := newEC2TestServer(t)
+	instID := ec2TagTestInstance(t, ts)
+
+	// Exactly 50 is legal.
+	status, _, _ := ec2CreateTags(t, ts, instID, ec2NumberedTags("key", ec2TagLimit))
+	require.Equal(t, http.StatusOK, status, "50 tags must be accepted")
+	require.Equal(t, ec2TagLimit, ec2InstanceTagCount(t, ts, instID))
+
+	// The 51st is not.
+	status, code, message := ec2CreateTags(t, ts, instID, map[string]string{
+		"Tag.1.Key":   "one-too-many",
+		"Tag.1.Value": "v",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "TagLimitExceeded", code)
+	assert.Equal(t, ec2TagLimitMessage, message)
+	assert.Equal(t, ec2TagLimit, ec2InstanceTagCount(t, ts, instID),
+		"the rejected tag must not have been applied")
+}
+
+// TestEC2_CreateTags_OverwriteAtLimitSucceeds is the subtle half of the counting rule,
+// and the one a naive implementation gets wrong.
+//
+// The count is over the post-merge key *set*, so a key already present adds nothing
+// and overwriting it on a resource already at 50 succeeds. Written as
+// len(existing)+len(incoming) > 50 this would fail — real AWS permits it, as
+// getmoto/moto#8151 reports.
+func TestEC2_CreateTags_OverwriteAtLimitSucceeds(t *testing.T) {
+	ts := newEC2TestServer(t)
+	instID := ec2TagTestInstance(t, ts)
+
+	status, _, _ := ec2CreateTags(t, ts, instID, ec2NumberedTags("key", ec2TagLimit))
+	require.Equal(t, http.StatusOK, status)
+
+	tests := []struct {
+		name       string
+		tagKey     string
+		wantReject bool
+	}{
+		{name: "overwriting an existing key is allowed at the limit", tagKey: "key7"},
+		{name: "adding a new key is not", tagKey: "key51", wantReject: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code, _ := ec2CreateTags(t, ts, instID, map[string]string{
+				"Tag.1.Key":   tc.tagKey,
+				"Tag.1.Value": "changed",
+			})
+
+			if tc.wantReject {
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "TagLimitExceeded", code)
+				return
+			}
+
+			require.Equal(t, http.StatusOK, status)
+			value, ok := ec2InstanceTagValue(t, ts, instID, tc.tagKey)
+			assert.True(t, ok)
+			assert.Equal(t, "changed", value, "the overwrite must take effect")
+			assert.Equal(t, ec2TagLimit, ec2InstanceTagCount(t, ts, instID),
+				"an overwrite must not grow the tag count")
+		})
+	}
+}
+
+// TestEC2_CreateTags_LimitRejectionIsAllOrNothing pins that the limit is checked across
+// every resource the request names before any of them is modified, matching the
+// reserved-key check's ordering. CreateTags accepts up to 1000 IDs and a partial apply
+// is a state real EC2 never produces.
+func TestEC2_CreateTags_LimitRejectionIsAllOrNothing(t *testing.T) {
+	ts := newEC2TestServer(t)
+	roomy := ec2TagTestInstance(t, ts)
+	full := ec2TagTestInstance(t, ts)
+
+	// Only the second instance is at the limit.
+	status, _, _ := ec2CreateTags(t, ts, full, ec2NumberedTags("key", ec2TagLimit))
+	require.Equal(t, http.StatusOK, status)
+
+	params := map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": roomy,
+		"ResourceId.2": full,
+		"Tag.1.Key":    "pushes-over",
+		"Tag.1.Value":  "v",
+	}
+	status, code, _ := ec2ErrorDetail(t, ts, params)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "TagLimitExceeded", code)
+
+	// Neither resource is modified — including the one that had room.
+	_, ok := ec2InstanceTagValue(t, ts, roomy, "pushes-over")
+	assert.False(t, ok,
+		"the resource with room must not be tagged when another named resource is over")
+	assert.Equal(t, ec2TagLimit, ec2InstanceTagCount(t, ts, full))
+}
+
+// TestEC2_TagLimit_ExemptsReservedKeys is #469's own acceptance criterion, asserted on a
+// real fleet instance rather than a synthetic resource.
+//
+// "Tags with the aws: prefix do not count against your tags per resource limit." This is
+// load-bearing rather than pedantic: substrate stamps aws:ec2:fleet-id on every fleet
+// instance, so a counter that included reserved keys would reject a fleet instance
+// carrying 50 user tags — a launch real EC2 accepts.
+func TestEC2_TagLimit_ExemptsReservedKeys(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "tag-limit-exempt")
+
+	var fleet createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+	}, &fleet)
+	ids := fleet.instanceIDs()
+	require.Len(t, ids, 1)
+	instID := ids[0]
+
+	// The instance already carries the reserved fleet-ID tag...
+	_, ok := ec2InstanceTagValue(t, ts, instID, fleetIDTagKey)
+	require.True(t, ok, "fleet instance should carry %s", fleetIDTagKey)
+
+	// ...and can still take a full complement of 50 user tags on top of it.
+	status, _, _ := ec2CreateTags(t, ts, instID, ec2NumberedTags("user", ec2TagLimit))
+	require.Equal(t, http.StatusOK, status,
+		"a reserved tag must not consume room from the user tag limit")
+
+	// 50 user tags plus the reserved one: 51 tags on the resource, all legal.
+	assert.Equal(t, ec2TagLimit+1, ec2InstanceTagCount(t, ts, instID))
+
+	// The 51st *user* tag is still refused, so the exemption did not raise the ceiling.
+	status, code, _ := ec2CreateTags(t, ts, instID, map[string]string{
+		"Tag.1.Key":   "user51",
+		"Tag.1.Value": "v",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "TagLimitExceeded", code)
+}
+
+// TestEC2_TagOnCreate_EnforcesTagLimit covers the limit on the tag-on-create paths,
+// where a new resource's tag count is just the request's own.
+func TestEC2_TagOnCreate_EnforcesTagLimit(t *testing.T) {
+	// launchTagParams builds count instance-scoped launch tags.
+	launchTagParams := func(count int) map[string]string {
+		params := map[string]string{"TagSpecification.1.ResourceType": "instance"}
+		for i := 1; i <= count; i++ {
+			params[fmt.Sprintf("TagSpecification.1.Tag.%d.Key", i)] = fmt.Sprintf("key%d", i)
+			params[fmt.Sprintf("TagSpecification.1.Tag.%d.Value", i)] = "v"
+		}
+		return params
+	}
+
+	t.Run("50 launch tags are accepted", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		params := map[string]string{
+			"Action":   "RunInstances",
+			"ImageId":  "ami-0taglimit0000001",
+			"MinCount": "1",
+			"MaxCount": "1",
+		}
+		for k, v := range launchTagParams(ec2TagLimit) {
+			params[k] = v
+		}
+		ids := ec2RunInstanceIDs(t, ts, params)
+		require.Len(t, ids, 1)
+		assert.Equal(t, ec2TagLimit, ec2InstanceTagCount(t, ts, ids[0]))
+	})
+
+	t.Run("51 launch tags are rejected and nothing is created", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		params := map[string]string{
+			"Action":   "RunInstances",
+			"ImageId":  "ami-0taglimit0000002",
+			"MinCount": "1",
+			"MaxCount": "1",
+		}
+		for k, v := range launchTagParams(ec2TagLimit + 1) {
+			params[k] = v
+		}
+		status, code, message := ec2ErrorDetail(t, ts, params)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "TagLimitExceeded", code)
+		assert.Equal(t, ec2TagLimitMessage, message)
+		assert.Zero(t, ec2InstanceCount(t, ts),
+			"a launch rejected for the tag limit must not create an instance")
+	})
+
+	t.Run("51 tags on CreateNatGateway are rejected", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		subnetID := ec2TagTestSubnet(t, ts)
+		params := map[string]string{
+			"Action":                          "CreateNatGateway",
+			"SubnetId":                        subnetID,
+			"ConnectivityType":                "private",
+			"TagSpecification.1.ResourceType": "natgateway",
+		}
+		for i := 1; i <= ec2TagLimit+1; i++ {
+			params[fmt.Sprintf("TagSpecification.1.Tag.%d.Key", i)] = fmt.Sprintf("key%d", i)
+			params[fmt.Sprintf("TagSpecification.1.Tag.%d.Value", i)] = "v"
+		}
+		status, code, _ := ec2ErrorDetail(t, ts, params)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "TagLimitExceeded", code)
+
+		var gws struct {
+			Gateways []struct {
+				NatGatewayID string `xml:"natGatewayId"`
+			} `xml:"natGatewaySet>item"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "DescribeNatGateways"}, &gws)
+		assert.Empty(t, gws.Gateways)
+	})
+
+	t.Run("51 tags on CreateImage are rejected", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		instID := ec2TagTestInstance(t, ts)
+		params := map[string]string{
+			"Action":                          "CreateImage",
+			"InstanceId":                      instID,
+			"Name":                            "over-limit-ami",
+			"TagSpecification.1.ResourceType": "image",
+		}
+		for i := 1; i <= ec2TagLimit+1; i++ {
+			params[fmt.Sprintf("TagSpecification.1.Tag.%d.Key", i)] = fmt.Sprintf("key%d", i)
+			params[fmt.Sprintf("TagSpecification.1.Tag.%d.Value", i)] = "v"
+		}
+		status, code, _ := ec2ErrorDetail(t, ts, params)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "TagLimitExceeded", code)
+
+		var images struct {
+			Images []struct {
+				ImageID string `xml:"imageId"`
+			} `xml:"imagesSet>item"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "DescribeImages"}, &images)
+		assert.Empty(t, images.Images)
+	})
+}
+
+// TestEC2_Fleet_TagLimitWithStampedTag is the fleet half of the exemption: a fleet whose
+// caller names the full 50 instance tags still launches, because the fleet-ID tag
+// substrate adds on top is reserved and excluded from the count.
+//
+// Under a counter that included reserved keys this launch fails at 51 — the exact
+// failure #469 calls out, and one real EC2 does not produce.
+func TestEC2_Fleet_TagLimitWithStampedTag(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-tag-limit")
+
+	params := map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+		"TagSpecification.1.ResourceType":                                      "instance",
+	}
+	for i := 1; i <= ec2TagLimit; i++ {
+		params[fmt.Sprintf("TagSpecification.1.Tag.%d.Key", i)] = fmt.Sprintf("key%d", i)
+		params[fmt.Sprintf("TagSpecification.1.Tag.%d.Value", i)] = "v"
+	}
+
+	var fleet createFleetResp
+	ec2FleetXML(t, ts, params, &fleet)
+	ids := fleet.instanceIDs()
+	require.Len(t, ids, 1, "a fleet with 50 caller tags must still launch")
+
+	// 50 caller tags plus the reserved stamp.
+	assert.Equal(t, ec2TagLimit+1, ec2InstanceTagCount(t, ts, ids[0]))
+	fleetID, ok := ec2InstanceTagValue(t, ts, ids[0], fleetIDTagKey)
+	assert.True(t, ok, "the stamp must survive a fully-tagged launch")
+	assert.Equal(t, fleet.FleetID, fleetID)
 }

--- a/emulator/ec2_tags_test.go
+++ b/emulator/ec2_tags_test.go
@@ -959,7 +959,7 @@ func TestEC2_Fleet_TagLimitWithStampedTag(t *testing.T) {
 // The check and the apply step read the same state key through one function, so a
 // resource type the apply step tags but the check could not resolve would be tagged
 // past the limit. This table is what makes that impossible to introduce quietly: it
-// walks all eight ID prefixes substrate recognises.
+// walks all eight ID prefixes substrate recognizes.
 //
 // It asserts on the rejection rather than a tag read-back because, apart from
 // instances and NAT gateways, substrate's Describe operations for these resources do

--- a/emulator/ec2_tags_test.go
+++ b/emulator/ec2_tags_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -950,4 +951,161 @@ func TestEC2_Fleet_TagLimitWithStampedTag(t *testing.T) {
 	fleetID, ok := ec2InstanceTagValue(t, ts, ids[0], fleetIDTagKey)
 	assert.True(t, ok, "the stamp must survive a fully-tagged launch")
 	assert.Equal(t, fleet.FleetID, fleetID)
+}
+
+// TestEC2_CreateTags_TagLimitAppliesToEveryTaggableResource pins that the limit is
+// counted for every resource type substrate can tag, not just instances.
+//
+// The check and the apply step read the same state key through one function, so a
+// resource type the apply step tags but the check could not resolve would be tagged
+// past the limit. This table is what makes that impossible to introduce quietly: it
+// walks all eight ID prefixes substrate recognises.
+//
+// It asserts on the rejection rather than a tag read-back because, apart from
+// instances and NAT gateways, substrate's Describe operations for these resources do
+// not emit a tagSet at all — the rejection is the observation available.
+func TestEC2_CreateTags_TagLimitAppliesToEveryTaggableResource(t *testing.T) {
+	// eipAllocationID allocates an Elastic IP and returns its allocation ID.
+	eipAllocationID := func(t *testing.T, ts *httptest.Server) string {
+		t.Helper()
+		var addr struct {
+			AllocationID string `xml:"allocationId"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "AllocateAddress", "Domain": "vpc"}, &addr)
+		require.NotEmpty(t, addr.AllocationID)
+		return addr.AllocationID
+	}
+
+	// vpcID creates a VPC and returns its ID, for the resources that need a parent.
+	vpcID := func(t *testing.T, ts *httptest.Server) string {
+		t.Helper()
+		var vpc struct {
+			VPCID string `xml:"vpc>vpcId"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.7.0.0/16"}, &vpc)
+		require.NotEmpty(t, vpc.VPCID)
+		return vpc.VPCID
+	}
+
+	tests := []struct {
+		name   string
+		prefix string
+		create func(t *testing.T, ts *httptest.Server) string
+	}{
+		{name: "instance", prefix: "i-", create: ec2TagTestInstance},
+		{name: "subnet", prefix: "subnet-", create: ec2TagTestSubnet},
+		{name: "vpc", prefix: "vpc-", create: vpcID},
+		{name: "elastic ip", prefix: "eipalloc-", create: eipAllocationID},
+		{
+			name:   "security group",
+			prefix: "sg-",
+			create: func(t *testing.T, ts *httptest.Server) string {
+				t.Helper()
+				var sg struct {
+					GroupID string `xml:"groupId"`
+				}
+				ec2FleetXML(t, ts, map[string]string{
+					"Action":           "CreateSecurityGroup",
+					"GroupName":        "tag-limit-sg",
+					"GroupDescription": "tag limit",
+					"VpcId":            vpcID(t, ts),
+				}, &sg)
+				require.NotEmpty(t, sg.GroupID)
+				return sg.GroupID
+			},
+		},
+		{
+			name:   "internet gateway",
+			prefix: "igw-",
+			create: func(t *testing.T, ts *httptest.Server) string {
+				t.Helper()
+				var igw struct {
+					ID string `xml:"internetGateway>internetGatewayId"`
+				}
+				ec2FleetXML(t, ts, map[string]string{"Action": "CreateInternetGateway"}, &igw)
+				require.NotEmpty(t, igw.ID)
+				return igw.ID
+			},
+		},
+		{
+			name:   "route table",
+			prefix: "rtb-",
+			create: func(t *testing.T, ts *httptest.Server) string {
+				t.Helper()
+				var rtb struct {
+					ID string `xml:"routeTable>routeTableId"`
+				}
+				ec2FleetXML(t, ts, map[string]string{
+					"Action": "CreateRouteTable",
+					"VpcId":  vpcID(t, ts),
+				}, &rtb)
+				require.NotEmpty(t, rtb.ID)
+				return rtb.ID
+			},
+		},
+		{
+			name:   "nat gateway",
+			prefix: "nat-",
+			create: func(t *testing.T, ts *httptest.Server) string {
+				t.Helper()
+				var gw struct {
+					ID string `xml:"natGateway>natGatewayId"`
+				}
+				ec2FleetXML(t, ts, map[string]string{
+					"Action":           "CreateNatGateway",
+					"SubnetId":         ec2TagTestSubnet(t, ts),
+					"ConnectivityType": "private",
+				}, &gw)
+				require.NotEmpty(t, gw.ID)
+				return gw.ID
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			id := tc.create(t, ts)
+			require.True(t, strings.HasPrefix(id, tc.prefix),
+				"%s should have the %q prefix, got %s", tc.name, tc.prefix, id)
+
+			status, _, _ := ec2CreateTags(t, ts, id, ec2NumberedTags("key", ec2TagLimit))
+			require.Equal(t, http.StatusOK, status, "50 tags must be accepted on a %s", tc.name)
+
+			status, code, message := ec2CreateTags(t, ts, id, map[string]string{
+				"Tag.1.Key":   "one-too-many",
+				"Tag.1.Value": "v",
+			})
+			assert.Equal(t, http.StatusBadRequest, status, "the 51st tag on a %s", tc.name)
+			assert.Equal(t, "TagLimitExceeded", code)
+			assert.Equal(t, ec2TagLimitMessage, message)
+		})
+	}
+}
+
+// TestEC2_CreateTags_UncountedResourceIDs pins that an ID the apply step will not touch
+// is not counted against either.
+//
+// Substrate's CreateTags ignores an ID it cannot resolve rather than rejecting it, so
+// counting one would refuse a request real EC2 accepts as a no-op — turning a
+// silent-success infidelity into a spurious-rejection one. The two rows are the two
+// ways an ID goes unresolved: a prefix substrate does not tag, and a well-formed prefix
+// naming nothing.
+func TestEC2_CreateTags_UncountedResourceIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{name: "a prefix substrate does not tag", id: "ami-0notaggable000001"},
+		{name: "a taggable prefix naming nothing", id: "i-0doesnotexist00001"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			status, _, _ := ec2CreateTags(t, ts, tc.id, ec2NumberedTags("key", ec2TagLimit+1))
+			assert.Equal(t, http.StatusOK, status,
+				"an ID the apply step ignores must not be counted against")
+		})
+	}
 }


### PR DESCRIPTION
Substrate accepted any number of tags on a resource, so a consumer that hit real EC2's
50-tag ceiling had no way to reach the `TagLimitExceeded` branch — and, worse, a test
asserting the rejection passed against substrate while the same code failed against AWS.

`CreateTags` and every tag-on-create path (`RunInstances`, `CreateFleet`, `CreateImage`,
`CreateNatGateway`) now refuse a resource that would carry more than 50 user tags:
`TagLimitExceeded`, HTTP 400. From the tagging documentation's restrictions: "Maximum
number of tags per resource – 50".

## The counting rule

Two documented rules make this less like arithmetic than it looks, and both fall out of
one expression — the count is over the **post-merge key set**, excluding reserved keys:

- **Tags with the `aws:` prefix do not count** ("Tags with the `aws:` prefix do not
  count against your tags per resource limit"). This is load-bearing rather than
  pedantry: substrate stamps `aws:ec2:fleet-id` on every fleet instance (#443), so a
  counter that included reserved keys would refuse a fleet launch whose template names
  the full 50 user tags — a launch real EC2 accepts. A fleet instance holds 51 tags
  legally.
- **Overwriting an existing key at the limit succeeds**, since a key already present
  adds nothing to the set. Written as `len(existing) + len(incoming)` it would fail
  instead, and real AWS permits it — [getmoto/moto#8151](https://github.com/getmoto/moto/issues/8151)
  reports exactly that case.

This also closes the companion gap v0.85.0 recorded as vacuous: the reserved-tag
exemption now has a limit to be exempt from.

## Ordering

As with reserved keys (#468), the whole request is refused before anything is modified —
a `CreateTags` naming one instance with room and one at the limit tags neither.
`CreateTags` accepts up to 1000 resource IDs and a partial apply is a state real EC2
never produces.

A resource ID that names nothing is **not** counted against, because the apply step
ignores it: checking it would refuse a request real EC2 accepts as a no-op.
`ec2TaggableStateKey` is factored out of `applyTagsToResource` so the limit is counted
against exactly the resources the apply step will modify, rather than the two drifting.

## Provenance — split, and the weaker half marked

The **code** is a doc citation, unlike #452's: EC2's client-error table lists
`TagLimitExceeded` as "You've reached the limit on the number of tags that you can
assign to the specified resource." The wire **message** is published nowhere, so the
wording is moto's — a reimplementation rather than a capture. SDKs dispatch on
`Error.Code`, so the documented half is the one a consumer's error branch turns on.
`docs/services.md` and the CHANGELOG both say which half is which.

Two documented restrictions still unenforced and tracked separately: a tag key's maximum
of 128 Unicode characters and a value's maximum of 256.

## Tests

Six new tests in `emulator/ec2_tags_test.go`:

- 50 tags accepted, the 51st rejected with the exact code, status and message.
- Overwriting `key7` on a 50-tag instance succeeds and the value changes; adding `key51`
  is refused — the two outcomes side by side in one table. The overwrite half fails
  under naive arithmetic.
- Two resource IDs, one with room and one at the limit → neither is tagged.
- The `aws:` exemption asserted on a **real fleet instance**: it carries
  `aws:ec2:fleet-id` and still takes 50 user tags (51 total), while the 51st *user* tag
  is still refused, so the exemption did not raise the ceiling.
- Tag-on-create: 50 launch tags accepted, 51 rejected with no instance created; 51 tags
  on `CreateNatGateway` and on `CreateImage` rejected with no resource left behind.
- A `CreateFleet` naming the full 50 instance tags still launches, and the stamp survives.

Four mutations confirmed to fail these tests, then restored:

| Mutation | Killed by |
|---|---|
| count `len(existing) + len(incoming)` | `OverwriteAtLimitSucceeds` |
| stop exempting `aws:` keys | `TagLimit_ExemptsReservedKeys` |
| interleave the check with the apply loop | `LimitRejectionIsAllOrNothing` |
| check the tag-on-create limit *after* the launch | `TagOnCreate_EnforcesTagLimit` (the rollback assertion) |

## Verification

From the repo root: `gofmt -l .`, `go build ./...`, `go vet ./...`,
`golangci-lint run ./...` (0 issues), `make test` (race), `make docs-reference
docs-reference-check docs-versions`, `go test -C test/e2e ./...` — all pass. The full
EC2 suite including the fleet tests is green, which is the #443 regression gate.

Closes #469