### PR TITLE
fix(ec2): carry a launch template's tags and instance profile to the launch (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DescribeImages` for tags that were actually snapshot-scoped will see them move,
   which is where real EC2 has them.
 
+### Fixed
+- **A launch template's `TagSpecifications` and `IamInstanceProfile` now reach the
+  instance** (#471). Both were accepted by `CreateLaunchTemplate` and stored nowhere,
+  so a template that tagged its instances produced untagged ones and a template naming
+  a role produced an instance with none — with nothing failing to say so. The tag half
+  is the more damaging: `DescribeInstances --filters tag:Env,Values=prod` is how IaC
+  finds the resources it just created, and it simply returned nothing, so an assertion
+  on the tags the template asked for could not pass however the code was written.
+  Neither field could even be read back before this release, because
+  `DescribeLaunchTemplates` carries no `launchTemplateData`; #456's
+  `DescribeLaunchTemplateVersions` is what makes the round-trip assertable.
+
+  **Template tags replace rather than merge.** A request naming `Env=req` against a
+  template naming `Env=tmpl,Team=x` yields `Env=req` alone — `Team` is not inherited.
+  The reference gives no `TagSpecifications`-specific merge semantics, only the general
+  "Any additional parameters that you specify for the new instance overwrite the
+  corresponding parameters included in the launch template", and replacement is that
+  rule applied to the whole specification rather than a per-field citation.
+
+  **Substrate's own `aws:ec2:fleet-id` stamp does not count as the request naming
+  tags.** A fleet instance already carries that reserved key by the time the merge
+  runs, so the fallback tests for a non-reserved key rather than for an empty set. Had
+  it tested emptiness, a fleet launched from a tagging template would have silently
+  lost the template's tags — the very defect this entry closes, on the path #443 added.
+  It is the same reserved-key exclusion #469's counter uses.
+
+  **A template's tags are subject to both tag rules**, so a template is not a second
+  unrestricted tagging path: `TagSpecifications` naming an `aws:`-prefixed key or
+  exceeding the 50-tag limit is rejected at `CreateLaunchTemplate` and at
+  `CreateLaunchTemplateVersion` — the latter *after* any `SourceVersion` inheritance, so
+  an inherited violation is caught rather than propagated. The launch checks again,
+  deliberately and not redundantly: a template written straight into state by a replayed
+  event log can predate these checks, and that launch is the one that would otherwise
+  apply the key.
+
+  Two scope limits, stated rather than implied. Only the **instance** scope is stored: a
+  template may also scope tags to `volume`, `network-interface` or
+  `spot-instances-request`, none of which substrate models, so those specifications are
+  recorded nowhere rather than misapplied to the instance. And the profile is stored as
+  the single string the request supplied, so `DescribeLaunchTemplateVersions` echoes it
+  in whichever member it arrived in — `arn` for an `arn:`-prefixed value, `name`
+  otherwise. `DescribeInstances` still surfaces it as an ARN either way, because AWS's
+  instance response shape has no name member; synthesizing the missing member for a
+  *template* read-back would report the template as naming something the caller never
+  wrote.
+
 ## [v0.85.0] - 2026-08-02
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -1313,6 +1313,10 @@ corresponding parameters included in the launch template."
 | `InstanceType` | absent | `m5.large` | `m5.large` |
 | `InstanceType` | absent | absent | `t3.micro` (substrate's default) |
 | `KeyName` | `k-request` | `k-template` | `k-request` |
+| `TagSpecification` (instance-scoped) | `Env=req` | `Env=tmpl,Team=x` | `Env=req` alone — replace, not merge |
+| `TagSpecification` (instance-scoped) | absent | `Env=tmpl` | `Env=tmpl` |
+| `IamInstanceProfile` | `p-request` | `p-template` | `p-request` |
+| `IamInstanceProfile` | absent | `p-template` | `p-template` |
 | `SubnetId`, security groups, `AssociatePublicIpAddress` | see [Launch template networking](#launch-template-networking) | | |
 
 Which *version* of the template supplies those values is resolved from
@@ -1337,8 +1341,49 @@ the template's type, exactly inverting the documented precedence. An explicit
 `t3.micro` is now honoured, and the default applies only when neither side names
 a type.
 
-A template's `TagSpecifications` and `IamInstanceProfile` are not parsed at all, so
-neither participates in the merge.
+A template's `TagSpecifications` and `IamInstanceProfile` used to be accepted and
+stored nowhere, so a template that tagged its instances produced untagged ones and a
+template naming a role produced an instance with none — with nothing failing to say
+so. That is worse than a dropped `KeyName`, because a `tag:` filter is how IaC finds
+the resources it just created: `DescribeInstances --filters tag:Env,Values=prod`
+simply returned nothing, and a suite asserting on the tags it asked for had an
+assertion that could not pass.
+
+Both now participate in the merge, with two things worth stating:
+
+- **Tags replace rather than merge.** A request naming `Env=req` against a template
+  naming `Env=tmpl,Team=x` yields `Env=req` alone; `Team` is not inherited. The
+  reference gives no `TagSpecifications`-specific merge semantics, only the general
+  "overwrite the corresponding parameters" rule quoted above, and replacement is that
+  rule applied to the whole specification.
+- **Substrate's own `aws:ec2:fleet-id` stamp does not count as the request naming
+  tags.** A fleet instance already carries that reserved key by the time the merge
+  runs, so the fallback tests for a non-reserved key rather than for an empty set —
+  otherwise a fleet launched from a tagging template would silently lose the
+  template's tags. See [Reserved tag keys](#reserved-tag-keys).
+
+**Only the instance scope is modelled.** A template may also scope tags to `volume`,
+`network-interface` or `spot-instances-request`. Substrate models none of those
+resources, so those specifications are recorded nowhere rather than misapplied to the
+instance: they neither reach the launch nor read back from
+`DescribeLaunchTemplateVersions`. Note that a template's instance-scoped tags land on
+the *instance*, not on the template — the reference is explicit that "these tags are
+not applied to the launch template."
+
+A template's tags are subject to both tag rules, so a template is not a second
+unrestricted tagging path: a `TagSpecifications` naming an `aws:`-prefixed key or
+exceeding the 50-tag limit is rejected at `CreateLaunchTemplate` and at
+`CreateLaunchTemplateVersion` (after any `SourceVersion` inheritance, so an inherited
+violation is caught too). The launch checks again, because a template written
+straight into state by a replayed event log can predate those checks.
+
+The instance profile is stored as the single string the request supplied, matching
+the shape an instance holds, so it is echoed back from
+`DescribeLaunchTemplateVersions` in whichever member it arrived in — `arn` for an
+`arn:`-prefixed value and `name` otherwise. `DescribeInstances` surfaces it as an ARN
+either way, because AWS's instance response shape has no name member; for a
+*template* read-back, synthesizing the other member would report the template as
+naming something the caller never wrote.
 
 ### Launch template versions
 
@@ -1612,8 +1657,15 @@ both coexist with the caller's legal tags on the same instance.
 
 One limit of the current scope, stated rather than implied: only tags scoped to a
 resource substrate models are checked. A `TagSpecification` naming `volume` or
-`network-interface` on `RunInstances` is skipped, because substrate does not tag those
-resources at all; real EC2 would reject a reserved key there too.
+`network-interface` on `RunInstances`, or inside a launch template's
+`LaunchTemplateData`, is skipped, because substrate does not tag those resources at
+all; real EC2 would reject a reserved key there too.
+
+A launch template's own instance-scoped tags *are* checked, at
+`CreateLaunchTemplate` and `CreateLaunchTemplateVersion` as well as at every launch
+that names the template — so a template cannot serve as an unchecked second path to a
+reserved key. See
+[A launch template merges with the request, field by field](#a-launch-template-merges-with-the-request-field-by-field).
 
 ### The 50-tag-per-resource limit
 
@@ -1657,6 +1709,11 @@ published nowhere, so the wording above is [moto](https://github.com/getmoto/mot
 from a reimplementation rather than a captured response. That is a weaker claim than the
 code's, and is a distinction worth stating: SDKs dispatch on `Error.Code`, so the code
 is the part a consumer's error branch turns on.
+
+A launch template's instance-scoped tags are counted the same way, at
+`CreateLaunchTemplate` and `CreateLaunchTemplateVersion` as well as at every launch
+that names the template. Exactly 50 template tags launch; 51 are refused at template
+creation.
 
 Two documented restrictions substrate does **not** enforce: a tag key's maximum length
 of 128 Unicode characters, and a value's maximum of 256. Both are tracked separately.

--- a/emulator/ec2_launchtemplate_test.go
+++ b/emulator/ec2_launchtemplate_test.go
@@ -1,10 +1,17 @@
 package emulator_test
 
 import (
+	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ltNetwork is the networking a launch-template test asks for and then asserts
@@ -659,6 +666,549 @@ func TestEC2_LaunchTemplate_RequestFalseBeatsTemplateTrue(t *testing.T) {
 		t.Errorf("publicIpAddress = %q, want none: the request explicitly asked for false",
 			got.PublicIPAddress)
 	}
+}
+
+// ltTagParams returns the LaunchTemplateData.TagSpecification.N params that scope
+// tags to instances, in the request's key order.
+//
+// Note the singular member name: the *request* spells it TagSpecification.N while
+// the response spells it tagSpecificationSet. Getting that backwards silently
+// produces a template with no tags, which is exactly #471's defect.
+func ltTagParams(tags ...[2]string) map[string]string {
+	params := map[string]string{
+		"LaunchTemplateData.TagSpecification.1.ResourceType": "instance",
+	}
+	for i, tag := range tags {
+		params[fmt.Sprintf("LaunchTemplateData.TagSpecification.1.Tag.%d.Key", i+1)] = tag[0]
+		params[fmt.Sprintf("LaunchTemplateData.TagSpecification.1.Tag.%d.Value", i+1)] = tag[1]
+	}
+	return params
+}
+
+// instanceTagMap returns an instance's tags as DescribeInstances reports them.
+func instanceTagMap(t *testing.T, ts *httptest.Server, instID string) map[string]string {
+	t.Helper()
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":       "DescribeInstances",
+		"InstanceId.1": instID,
+	}, &desc)
+	require.Len(t, desc.Instances, 1)
+	tags := map[string]string{}
+	for _, tag := range desc.Instances[0].Tags {
+		tags[tag.Key] = tag.Value
+	}
+	return tags
+}
+
+// instanceIDsMatchingTag returns the instance IDs a DescribeInstances tag: filter
+// returns, which is the observation a consumer's IaC actually depends on.
+func instanceIDsMatchingTag(t *testing.T, ts *httptest.Server, key, value string) []string {
+	t.Helper()
+	var desc describedInstances
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "DescribeInstances",
+		"Filter.1.Name":    "tag:" + key,
+		"Filter.1.Value.1": value,
+	}, &desc)
+	ids := make([]string, 0, len(desc.Instances))
+	for _, inst := range desc.Instances {
+		ids = append(ids, inst.InstanceID)
+	}
+	return ids
+}
+
+// instanceProfileARN returns the iamInstanceProfile ARN DescribeInstances reports.
+func instanceProfileARN(t *testing.T, ts *httptest.Server, instID string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":       "DescribeInstances",
+		"InstanceId.1": instID,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		Instances []struct {
+			Profile struct {
+				ARN string `xml:"arn"`
+			} `xml:"iamInstanceProfile"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	require.Len(t, out.Instances, 1)
+	return out.Instances[0].Profile.ARN
+}
+
+// TestEC2_LaunchTemplate_RoundTripsTagsAndProfile covers the read-back half of
+// #471: both fields were accepted by CreateLaunchTemplate and stored nowhere, so a
+// template that tagged its instances and named a role read back as carrying neither.
+//
+// DescribeLaunchTemplateVersions is the only operation that can make this
+// assertion — DescribeLaunchTemplates' response has no launchTemplateData at all —
+// which is why #456 landed in the same release rather than this criterion being
+// weakened.
+func TestEC2_LaunchTemplate_RoundTripsTagsAndProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		// profileParam is the member the request uses; both are valid and AWS's
+		// LaunchTemplateIamInstanceProfileSpecificationRequest has exactly these two.
+		profileParam string
+		profile      string
+		wantARN      string
+		wantName     string
+	}{
+		{
+			name:         "Name form",
+			profileParam: "LaunchTemplateData.IamInstanceProfile.Name",
+			profile:      "tmpl-profile",
+			wantName:     "tmpl-profile",
+		},
+		{
+			name:         "Arn form",
+			profileParam: "LaunchTemplateData.IamInstanceProfile.Arn",
+			profile:      "arn:aws:iam::000000000000:instance-profile/tmpl-profile",
+			wantARN:      "arn:aws:iam::000000000000:instance-profile/tmpl-profile",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			data := map[string]string{
+				"LaunchTemplateData.ImageId": "ami-0roundtrip000001",
+				tt.profileParam:              tt.profile,
+			}
+			for k, v := range ltTagParams([2]string{"Env", "prod"}, [2]string{"Team", "core"}) {
+				data[k] = v
+			}
+			ltID := createLaunchTemplate(t, ts, "roundtrip-"+tt.name, data)
+
+			versions, _ := describeLTVersions(t, ts, map[string]string{"LaunchTemplateId": ltID})
+			require.Len(t, versions, 1)
+
+			// The profile is echoed in whichever member it arrived in. Synthesizing the
+			// other would report the template as naming something the caller never wrote.
+			assert.Equal(t, tt.wantARN, versions[0].Data.IamInstanceProfile.ARN)
+			assert.Equal(t, tt.wantName, versions[0].Data.IamInstanceProfile.Name)
+
+			require.Len(t, versions[0].Data.TagSpecifications, 1)
+			spec := versions[0].Data.TagSpecifications[0]
+			assert.Equal(t, "instance", spec.ResourceType)
+			require.Len(t, spec.Tags, 2)
+			// Request order is preserved, so the assertion is deterministic.
+			assert.Equal(t, "Env", spec.Tags[0].Key)
+			assert.Equal(t, "prod", spec.Tags[0].Value)
+			assert.Equal(t, "Team", spec.Tags[1].Key)
+			assert.Equal(t, "core", spec.Tags[1].Value)
+		})
+	}
+}
+
+// TestEC2_LaunchTemplate_TagsReachTheInstance is #471's headline case: an instance
+// launched from a tagging template came up untagged, so DescribeInstances reported
+// no tags and a tag: filter returned nothing — with no error to explain why.
+//
+// The filter is asserted as well as the tagSet, because the filter is the half a
+// consumer's IaC actually depends on: it is how a stack finds the instances it just
+// created, and it can fail even when the tagSet is right.
+func TestEC2_LaunchTemplate_TagsReachTheInstance(t *testing.T) {
+	ts := newEC2TestServer(t)
+	data := map[string]string{"LaunchTemplateData.ImageId": "ami-0tagsreach00001"}
+	for k, v := range ltTagParams([2]string{"Env", "prod"}, [2]string{"Team", "core"}) {
+		data[k] = v
+	}
+	ltID := createLaunchTemplate(t, ts, "tags-reach", data)
+
+	instID := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+
+	tags := instanceTagMap(t, ts, instID)
+	assert.Equal(t, "prod", tags["Env"])
+	assert.Equal(t, "core", tags["Team"])
+
+	assert.Equal(t, []string{instID}, instanceIDsMatchingTag(t, ts, "Env", "prod"),
+		"a tag: filter must find an instance tagged through its launch template")
+}
+
+// TestEC2_LaunchTemplate_ProfileReachesTheInstance pins the other dropped field.
+// A consumer asserting which role its instances carry had an assertion that could
+// not fail: the instance reported no profile at all.
+//
+// DescribeInstances reports the profile as an ARN — AWS's IamInstanceProfile
+// response shape has no name member — so a bare template name is surfaced as the
+// ARN it implies, matching what a call-level IamInstanceProfile.Name already did.
+func TestEC2_LaunchTemplate_ProfileReachesTheInstance(t *testing.T) {
+	const arn = "arn:aws:iam::000000000000:instance-profile/tmpl-profile"
+	tests := []struct {
+		name  string
+		param string
+		value string
+	}{
+		{
+			name:  "Name is surfaced as the ARN it implies",
+			param: "LaunchTemplateData.IamInstanceProfile.Name",
+			value: "tmpl-profile",
+		},
+		{
+			name:  "an ARN is surfaced verbatim",
+			param: "LaunchTemplateData.IamInstanceProfile.Arn",
+			value: arn,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			ltID := createLaunchTemplate(t, ts, "profile-"+tt.param, map[string]string{
+				"LaunchTemplateData.ImageId": "ami-0profile0000001",
+				tt.param:                     tt.value,
+			})
+			instID := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+			assert.Equal(t, arn, instanceProfileARN(t, ts, instID))
+		})
+	}
+}
+
+// TestEC2_LaunchTemplate_TagAndProfilePrecedence extends #453's matrix with the two
+// fields #471 adds, three ways each: the request wins, the template fills the gap,
+// and neither names one.
+//
+// Before this, the request's value won by *default* rather than by rule — the
+// template's was never parsed — which happens to match AWS's precedence for the
+// wrong reason. Parsing the fields without writing the fallback would invert it
+// silently, which is what this table exists to catch.
+//
+// The tags row that matters is the first: template tags **replace** rather than
+// merge. The reference gives no TagSpecifications-specific merge semantics, only the
+// general "overwrite the corresponding parameters" rule, so replacement is that rule
+// applied — a request naming Env=req does not also inherit the template's Team=x.
+func TestEC2_LaunchTemplate_TagAndProfilePrecedence(t *testing.T) {
+	const reqARN = "arn:aws:iam::000000000000:instance-profile/p-req"
+	const tmplARN = "arn:aws:iam::000000000000:instance-profile/p-tmpl"
+
+	tests := []struct {
+		name          string
+		templateData  map[string]string
+		requestParams map[string]string
+		wantTags      map[string]string
+		// wantAbsentTags are keys that must not be present at all, which is how the
+		// replace-not-merge rule is asserted.
+		wantAbsentTags []string
+		wantProfile    string
+	}{
+		{
+			name:         "request tags replace the template's, not merge with them",
+			templateData: ltTagParams([2]string{"Env", "tmpl"}, [2]string{"Team", "x"}),
+			requestParams: map[string]string{
+				"TagSpecification.1.ResourceType": "instance",
+				"TagSpecification.1.Tag.1.Key":    "Env",
+				"TagSpecification.1.Tag.1.Value":  "req",
+			},
+			wantTags:       map[string]string{"Env": "req"},
+			wantAbsentTags: []string{"Team"},
+		},
+		{
+			name:          "the template fills absent tags",
+			templateData:  ltTagParams([2]string{"Env", "tmpl"}),
+			requestParams: map[string]string{},
+			wantTags:      map[string]string{"Env": "tmpl"},
+		},
+		{
+			name:           "neither names tags",
+			templateData:   map[string]string{},
+			requestParams:  map[string]string{},
+			wantAbsentTags: []string{"Env", "Team"},
+		},
+		{
+			name:          "request IamInstanceProfile wins",
+			templateData:  map[string]string{"LaunchTemplateData.IamInstanceProfile.Name": "p-tmpl"},
+			requestParams: map[string]string{"IamInstanceProfile.Name": "p-req"},
+			wantProfile:   reqARN,
+		},
+		{
+			name:          "the template fills an absent IamInstanceProfile",
+			templateData:  map[string]string{"LaunchTemplateData.IamInstanceProfile.Name": "p-tmpl"},
+			requestParams: map[string]string{},
+			wantProfile:   tmplARN,
+		},
+		{
+			name:          "neither names an IamInstanceProfile",
+			templateData:  map[string]string{},
+			requestParams: map[string]string{},
+			wantProfile:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			data := map[string]string{"LaunchTemplateData.ImageId": "ami-0precedence0001"}
+			for k, v := range tt.templateData {
+				data[k] = v
+			}
+			ltID := createLaunchTemplate(t, ts, "tag-precedence", data)
+
+			params := map[string]string{"LaunchTemplate.LaunchTemplateId": ltID}
+			for k, v := range tt.requestParams {
+				params[k] = v
+			}
+			instID := runInstance(t, ts, params)
+
+			tags := instanceTagMap(t, ts, instID)
+			for key, want := range tt.wantTags {
+				assert.Equal(t, want, tags[key], "tag %q", key)
+			}
+			for _, key := range tt.wantAbsentTags {
+				assert.NotContains(t, tags, key, "tag %q must not be present", key)
+			}
+			assert.Equal(t, tt.wantProfile, instanceProfileARN(t, ts, instID))
+		})
+	}
+}
+
+// TestEC2_LaunchTemplate_TagsAreSubjectToTheTagRules is #471's own interaction
+// criterion: a template's tags must not become a second, unrestricted path for
+// reserved keys or for exceeding the 50-tag limit (#468, #469).
+//
+// The rejection happens at CreateLaunchTemplate, as it does on real EC2 — both
+// rules are on the key and the count, not on the operation.
+func TestEC2_LaunchTemplate_TagsAreSubjectToTheTagRules(t *testing.T) {
+	t.Run("a reserved key is rejected at template creation", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		params := map[string]string{
+			"Action":                     "CreateLaunchTemplate",
+			"LaunchTemplateName":         "reserved-tag",
+			"LaunchTemplateData.ImageId": "ami-0reserved00001",
+		}
+		for k, v := range ltTagParams([2]string{"Name", "ok"}, [2]string{"aws:foo", "v"}) {
+			params[k] = v
+		}
+		status, code, message := ec2ErrorDetail(t, ts, params)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Equal(t, ec2ReservedTagMessage, message)
+
+		// Nothing is created, so the name is still free.
+		_ = createLaunchTemplate(t, ts, "reserved-tag", map[string]string{
+			"LaunchTemplateData.ImageId": "ami-0reserved00002",
+		})
+	})
+
+	t.Run("SourceVersion inheritance does not outrank the new version's tags", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		v1 := map[string]string{"LaunchTemplateData.ImageId": "ami-0overlay00000001"}
+		for k, v := range ltTagParams([2]string{"Env", "one"}) {
+			v1[k] = v
+		}
+		v1["LaunchTemplateData.IamInstanceProfile.Name"] = "p-one"
+		ltID := createLaunchTemplate(t, ts, "overlay", v1)
+
+		v2 := map[string]string{
+			"LaunchTemplateId": ltID,
+			"SourceVersion":    "1",
+			"LaunchTemplateData.IamInstanceProfile.Name": "p-two",
+		}
+		for k, v := range ltTagParams([2]string{"Env", "two"}) {
+			v2[k] = v
+		}
+		got := createLTVersion(t, ts, v2)
+
+		// The overlay direction is what this asserts: the request overwrites the
+		// inherited value rather than the inherited value winning. Both fields are
+		// separate overlay arms, so each can be dropped independently.
+		require.Len(t, got.Data.TagSpecifications, 1)
+		require.Len(t, got.Data.TagSpecifications[0].Tags, 1)
+		assert.Equal(t, "two", got.Data.TagSpecifications[0].Tags[0].Value)
+		assert.Equal(t, "p-two", got.Data.IamInstanceProfile.Name)
+
+		// And the launch takes the new version's values, not version 1's.
+		instID := runInstance(t, ts, map[string]string{
+			"LaunchTemplate.LaunchTemplateId": ltID,
+			"LaunchTemplate.Version":          "2",
+		})
+		assert.Equal(t, "two", instanceTagMap(t, ts, instID)["Env"])
+		assert.Contains(t, instanceProfileARN(t, ts, instID), "instance-profile/p-two")
+	})
+
+	t.Run("a new version carrying a reserved key is rejected", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		ltID := createLaunchTemplate(t, ts, "reserved-version", map[string]string{
+			"LaunchTemplateData.ImageId": "ami-0reserved00003",
+		})
+		params := map[string]string{
+			"Action":                     "CreateLaunchTemplateVersion",
+			"LaunchTemplateId":           ltID,
+			"LaunchTemplateData.ImageId": "ami-0reserved00004",
+		}
+		for k, v := range ltTagParams([2]string{"aws:foo", "v"}) {
+			params[k] = v
+		}
+		status, code, _ := ec2ErrorDetail(t, ts, params)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Equal(t, int64(1), describeLT(t, ts, ltID).LatestVersionNum,
+			"the rejected version must not have been appended")
+	})
+
+	t.Run("more than the tag limit is rejected at template creation", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		tags := make([][2]string, 0, ec2TagLimit+1)
+		for i := 1; i <= ec2TagLimit+1; i++ {
+			tags = append(tags, [2]string{fmt.Sprintf("key%d", i), "v"})
+		}
+		params := map[string]string{
+			"Action":                     "CreateLaunchTemplate",
+			"LaunchTemplateName":         "too-many-tags",
+			"LaunchTemplateData.ImageId": "ami-0toomany000001",
+		}
+		for k, v := range ltTagParams(tags...) {
+			params[k] = v
+		}
+		status, code, message := ec2ErrorDetail(t, ts, params)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "TagLimitExceeded", code)
+		assert.Equal(t, ec2TagLimitMessage, message)
+	})
+
+	t.Run("exactly the tag limit launches", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		tags := make([][2]string, 0, ec2TagLimit)
+		for i := 1; i <= ec2TagLimit; i++ {
+			tags = append(tags, [2]string{fmt.Sprintf("key%d", i), "v"})
+		}
+		data := map[string]string{"LaunchTemplateData.ImageId": "ami-0atlimit0000001"}
+		for k, v := range ltTagParams(tags...) {
+			data[k] = v
+		}
+		ltID := createLaunchTemplate(t, ts, "at-limit", data)
+		instID := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+		assert.Len(t, instanceTagMap(t, ts, instID), ec2TagLimit)
+	})
+}
+
+// storeTemplateWithTags writes a launch template straight into state with the given
+// instance-scoped tags and returns a server reading it.
+//
+// Written by hand rather than created through the API, because CreateLaunchTemplate
+// can no longer produce these templates — that is exactly the point. A template
+// stored before the tag checks existed, or one arriving from a replayed event log,
+// can still carry a violation, and the launch is where it would otherwise be applied.
+func storeTemplateWithTags(t *testing.T, name, ltID string, tags []map[string]string) *httptest.Server {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Now())
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.EC2Plugin{}
+	require.NoError(t, p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(p)
+	ts := httptest.NewServer(emulator.NewServer(*emulator.DefaultConfig(), registry, store, state, tc, logger))
+	t.Cleanup(ts.Close)
+
+	const acct, region = "000000000000", "us-east-1"
+	raw, err := json.Marshal(map[string]any{
+		"launchTemplateId":     ltID,
+		"launchTemplateName":   name,
+		"defaultVersionNumber": 1,
+		"latestVersionNumber":  1,
+		"createdBy":            acct,
+		"createTime":           "2026-01-01T00:00:00Z",
+		"latestData": map[string]any{
+			"imageId":           "ami-0stored00000001",
+			"tagSpecifications": tags,
+		},
+		"accountID": acct,
+		"region":    region,
+	})
+	require.NoError(t, err)
+	ctx := t.Context()
+	require.NoError(t, state.Put(ctx, "ec2", "lt:"+acct+"/"+region+"/"+ltID, raw))
+	require.NoError(t, state.Put(ctx, "ec2", "lt_by_name:"+acct+"/"+region+"/"+name, []byte(ltID)))
+	return ts
+}
+
+// TestEC2_LaunchTemplate_StoredTagsAreCheckedAtLaunch is the other half of the
+// interaction. The creation-time checks cannot see a template that predates them, so
+// the launch checks again — both rules, not just the reserved-key one.
+func TestEC2_LaunchTemplate_StoredTagsAreCheckedAtLaunch(t *testing.T) {
+	tests := []struct {
+		name        string
+		ltID        string
+		tags        []map[string]string
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name:        "a reserved key",
+			ltID:        "lt-0stored000000001",
+			tags:        []map[string]string{{"key": "aws:foo", "value": "v"}},
+			wantCode:    "InvalidParameterValue",
+			wantMessage: ec2ReservedTagMessage,
+		},
+		{
+			name:        "more than the tag limit",
+			ltID:        "lt-0stored000000002",
+			tags:        storedNumberedTags(ec2TagLimit + 1),
+			wantCode:    "TagLimitExceeded",
+			wantMessage: ec2TagLimitMessage,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := storeTemplateWithTags(t, "stored-"+tt.wantCode, tt.ltID, tt.tags)
+			status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+				"Action":                          "RunInstances",
+				"MinCount":                        "1",
+				"MaxCount":                        "1",
+				"LaunchTemplate.LaunchTemplateId": tt.ltID,
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tt.wantCode, code)
+			assert.Equal(t, tt.wantMessage, message)
+		})
+	}
+}
+
+// storedNumberedTags builds count distinct user tags in the stored JSON's shape.
+func storedNumberedTags(count int) []map[string]string {
+	tags := make([]map[string]string, 0, count)
+	for i := 1; i <= count; i++ {
+		tags = append(tags, map[string]string{"key": fmt.Sprintf("key%d", i), "value": "v"})
+	}
+	return tags
+}
+
+// TestEC2_Fleet_TemplateTagsReachFleetInstances pins that a fleet launched from a
+// tagging template gets the template's tags *and* substrate's fleet stamp.
+//
+// This is why the fallback tests for a non-reserved tag rather than for an empty
+// slice: by the time a fleet launch reaches the merge, aws:ec2:fleet-id has already
+// been appended, so a plain len(tags) == 0 would read the stamp as "the caller named
+// tags" and drop the template's — losing exactly the tags #471 exists to deliver, on
+// exactly the path #443 added.
+func TestEC2_Fleet_TemplateTagsReachFleetInstances(t *testing.T) {
+	ts := newEC2TestServer(t)
+	data := map[string]string{"LaunchTemplateData.ImageId": "ami-0fleettags00001"}
+	for k, v := range ltTagParams([2]string{"Env", "prod"}) {
+		data[k] = v
+	}
+	ltID := createLaunchTemplate(t, ts, "fleet-tags", data)
+
+	var fleet createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+	}, &fleet)
+
+	ids := fleet.instanceIDs()
+	require.Len(t, ids, 1)
+	tags := instanceTagMap(t, ts, ids[0])
+	assert.Equal(t, "prod", tags["Env"], "the template's tag must survive the fleet stamp")
+	assert.Equal(t, fleet.FleetID, tags[fleetIDTagKey], "the fleet stamp must survive the template's tags")
 }
 
 // TestEC2_LaunchTemplate_DescribeEchoesNetworking pins that the stored template

--- a/emulator/ec2_launchtemplate_versions.go
+++ b/emulator/ec2_launchtemplate_versions.go
@@ -120,13 +120,20 @@ type ec2LTVersionItem struct {
 // ResponseLaunchTemplateData has no top-level SubnetId member — a template can only
 // name a subnet, or a public-IP preference, inside a network interface. That is the
 // same asymmetry [EC2LaunchTemplateData.SubnetID] documents on the storage side.
+//
+// Note that the tag member is named tagSpecificationSet on the way out and
+// TagSpecification.N on the way in: ResponseLaunchTemplateData and
+// RequestLaunchTemplateData spell it differently, so a round-trip test has to use
+// both names.
 type ec2LTVersionDataXML struct {
-	ImageID           string                  `xml:"imageId,omitempty"`
-	InstanceType      string                  `xml:"instanceType,omitempty"`
-	KeyName           string                  `xml:"keyName,omitempty"`
-	UserData          string                  `xml:"userData,omitempty"`
-	SecurityGroupIDs  []string                `xml:"securityGroupIdSet>item,omitempty"`
-	NetworkInterfaces []ec2LTVersionNetIfcXML `xml:"networkInterfaceSet>item,omitempty"`
+	IamInstanceProfile *ec2LTVersionProfileXML  `xml:"iamInstanceProfile,omitempty"`
+	ImageID            string                   `xml:"imageId,omitempty"`
+	InstanceType       string                   `xml:"instanceType,omitempty"`
+	KeyName            string                   `xml:"keyName,omitempty"`
+	UserData           string                   `xml:"userData,omitempty"`
+	SecurityGroupIDs   []string                 `xml:"securityGroupIdSet>item,omitempty"`
+	NetworkInterfaces  []ec2LTVersionNetIfcXML  `xml:"networkInterfaceSet>item,omitempty"`
+	TagSpecifications  []ec2LTVersionTagSpecXML `xml:"tagSpecificationSet>item,omitempty"`
 }
 
 // ec2LTVersionNetIfcXML is one network interface within a version's data.
@@ -137,6 +144,20 @@ type ec2LTVersionNetIfcXML struct {
 	Groups                   []string `xml:"groupSet>item,omitempty"`
 }
 
+// ec2LTVersionProfileXML is a version's LaunchTemplateIamInstanceProfileSpecification,
+// whose two members are arn and name.
+type ec2LTVersionProfileXML struct {
+	ARN  string `xml:"arn,omitempty"`
+	Name string `xml:"name,omitempty"`
+}
+
+// ec2LTVersionTagSpecXML is one LaunchTemplateTagSpecification: a resource type and
+// the tags scoped to it.
+type ec2LTVersionTagSpecXML struct {
+	ResourceType string       `xml:"resourceType"`
+	Tags         []ec2TagItem `xml:"tagSet>item"`
+}
+
 // ec2LTVersionData renders stored template data for the wire.
 func ec2LTVersionData(d EC2LaunchTemplateData) ec2LTVersionDataXML {
 	out := ec2LTVersionDataXML{
@@ -145,6 +166,27 @@ func ec2LTVersionData(d EC2LaunchTemplateData) ec2LTVersionDataXML {
 		KeyName:          d.KeyName,
 		UserData:         d.UserData,
 		SecurityGroupIDs: d.SecurityGroupIDs,
+	}
+	// The profile is stored as one string, so it is echoed back in whichever member
+	// it arrived in: an "arn:"-prefixed value is an arn and anything else is a name.
+	// Synthesizing the other member — as DescribeInstances does, where AWS's response
+	// shape requires an ARN — would report a template as naming something the caller
+	// never wrote.
+	if d.IamInstanceProfile != "" {
+		if strings.HasPrefix(d.IamInstanceProfile, "arn:") {
+			out.IamInstanceProfile = &ec2LTVersionProfileXML{ARN: d.IamInstanceProfile}
+		} else {
+			out.IamInstanceProfile = &ec2LTVersionProfileXML{Name: d.IamInstanceProfile}
+		}
+	}
+	// Only the instance scope is stored, so only the instance scope reads back; see
+	// [EC2LaunchTemplateData.TagSpecifications].
+	if len(d.TagSpecifications) > 0 {
+		spec := ec2LTVersionTagSpecXML{ResourceType: "instance"}
+		for _, t := range d.TagSpecifications {
+			spec.Tags = append(spec.Tags, ec2TagItem(t))
+		}
+		out.TagSpecifications = []ec2LTVersionTagSpecXML{spec}
 	}
 	// Emit an interface only when the template actually named one, so a template
 	// carrying no networking does not read back with a phantom eth0.
@@ -214,6 +256,13 @@ func (p *EC2Plugin) createLaunchTemplateVersion(ctx *RequestContext, req *AWSReq
 		data = ec2OverlayTemplateData(srcVersion.Data, data)
 	}
 
+	// Checked after the overlay so an inherited tag set is checked too — a source
+	// version predating this check can carry a reserved key that the new version
+	// would otherwise inherit silently (#471).
+	if awsErr := ec2CheckTemplateTags(data); awsErr != nil {
+		return nil, awsErr
+	}
+
 	versions := lt.TemplateVersions()
 	newVersion := EC2LaunchTemplateVersion{
 		VersionNumber:      lt.LatestVersionNum + 1,
@@ -273,6 +322,12 @@ func ec2OverlayTemplateData(src, overlay EC2LaunchTemplateData) EC2LaunchTemplat
 	}
 	if len(overlay.NetworkInterfaceGroups) > 0 {
 		out.NetworkInterfaceGroups = overlay.NetworkInterfaceGroups
+	}
+	if len(overlay.TagSpecifications) > 0 {
+		out.TagSpecifications = overlay.TagSpecifications
+	}
+	if overlay.IamInstanceProfile != "" {
+		out.IamInstanceProfile = overlay.IamInstanceProfile
 	}
 	return out
 }

--- a/emulator/ec2_launchtemplate_versions_test.go
+++ b/emulator/ec2_launchtemplate_versions_test.go
@@ -32,6 +32,19 @@ type ltVersionItem struct {
 			AssociatePublicIPAddress string   `xml:"associatePublicIpAddress"`
 			Groups                   []string `xml:"groupSet>item"`
 		} `xml:"networkInterfaceSet>item"`
+		IamInstanceProfile struct {
+			ARN  string `xml:"arn"`
+			Name string `xml:"name"`
+		} `xml:"iamInstanceProfile"`
+		// Note the name: the response member is tagSpecificationSet while the request
+		// member is TagSpecification.N, so a round-trip has to spell it both ways.
+		TagSpecifications []struct {
+			ResourceType string `xml:"resourceType"`
+			Tags         []struct {
+				Key   string `xml:"key"`
+				Value string `xml:"value"`
+			} `xml:"tagSet>item"`
+		} `xml:"tagSpecificationSet>item"`
 	} `xml:"launchTemplateData"`
 }
 

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -399,6 +399,34 @@ func (p *EC2Plugin) runInstancesWithTags(
 		if sgID == "" && len(securityGroupIDs) > 0 {
 			sgID = securityGroupIDs[0]
 		}
+		if iamInstanceProfile == "" {
+			iamInstanceProfile = ltData.IamInstanceProfile
+		}
+		// A template's tags fill the gap only when the caller named none, so they
+		// *replace* rather than merge: a request naming Env=req and a template naming
+		// Env=tmpl,Team=x yields Env=req alone. The reference gives no
+		// TagSpecifications-specific merge semantics, only the general rule quoted
+		// above, and this is that rule applied — not a per-field citation.
+		//
+		// Substrate's own fleet stamp does not count as the caller naming tags. It is
+		// a reserved key, and a fleet launched from a tagging template must still get
+		// the template's tags alongside the stamp, exactly as on real EC2 — the same
+		// exclusion that keeps the stamp out of the tag count (#469).
+		if !ec2HasUserTags(tags) {
+			// Tags arriving from a template are subject to both tag rules here as well
+			// as at CreateLaunchTemplate, so a template is not a second unrestricted
+			// path (#471). The check is not redundant: a template stored before those
+			// checks existed, or one written straight into state by a replayed event
+			// log, can still carry a reserved key or more than the limit, and this is
+			// the launch that would otherwise apply them.
+			if awsErr := ec2CheckReservedTagKeys(ltData.TagSpecifications); awsErr != nil {
+				return nil, awsErr
+			}
+			if awsErr := ec2CheckTagLimit(nil, ltData.TagSpecifications); awsErr != nil {
+				return nil, awsErr
+			}
+			tags = append(append([]EC2Tag{}, ltData.TagSpecifications...), tags...)
+		}
 	}
 
 	// The instance-type default is resolved last, so it applies only when neither the
@@ -4158,18 +4186,31 @@ func (p *EC2Plugin) resolveLaunchTemplate(goCtx context.Context, ctx *RequestCon
 // what real SDKs send — the AWS model gives that member the locationName
 // "SecurityGroupId" — with Groups.N accepted as a secondary spelling for
 // hand-built requests, mirroring runInstances.
+//
+// TagSpecification.N and IamInstanceProfile were likewise accepted and stored
+// nowhere, so a template that tagged its instances produced untagged ones and a
+// template naming a role produced an instance with none — with nothing failing to
+// say so, and a tag: filter simply returning nothing (#471).
 func parseLaunchTemplateData(params map[string]string) EC2LaunchTemplateData {
-	const niPrefix = "LaunchTemplateData.NetworkInterface.1."
+	const ltPrefix = "LaunchTemplateData."
+	const niPrefix = ltPrefix + "NetworkInterface.1."
 
 	data := EC2LaunchTemplateData{
-		ImageID:                  params["LaunchTemplateData.ImageId"],
-		InstanceType:             params["LaunchTemplateData.InstanceType"],
-		KeyName:                  params["LaunchTemplateData.KeyName"],
-		UserData:                 params["LaunchTemplateData.UserData"],
+		ImageID:                  params[ltPrefix+"ImageId"],
+		InstanceType:             params[ltPrefix+"InstanceType"],
+		KeyName:                  params[ltPrefix+"KeyName"],
+		UserData:                 params[ltPrefix+"UserData"],
 		SubnetID:                 params[niPrefix+"SubnetId"],
 		AssociatePublicIPAddress: params[niPrefix+"AssociatePublicIpAddress"],
+		TagSpecifications:        ec2TagSpecificationTags(params, ltPrefix, "instance"),
 	}
-	if sg1 := params["LaunchTemplateData.SecurityGroupId.1"]; sg1 != "" {
+	// Name before Arn, mirroring runInstances' own precedence for the call-level
+	// pair; see [EC2LaunchTemplateData.IamInstanceProfile].
+	data.IamInstanceProfile = params[ltPrefix+"IamInstanceProfile.Name"]
+	if data.IamInstanceProfile == "" {
+		data.IamInstanceProfile = params[ltPrefix+"IamInstanceProfile.Arn"]
+	}
+	if sg1 := params[ltPrefix+"SecurityGroupId.1"]; sg1 != "" {
 		data.SecurityGroupIDs = []string{sg1}
 	}
 	data.NetworkInterfaceGroups = indexedParams(params,
@@ -4199,6 +4240,9 @@ func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 	now := p.tc.Now().UTC().Format(time.RFC3339)
 
 	ltData := parseLaunchTemplateData(req.Params)
+	if awsErr := ec2CheckTemplateTags(ltData); awsErr != nil {
+		return nil, awsErr
+	}
 
 	lt := EC2LaunchTemplate{
 		LaunchTemplateID:   ltID,

--- a/emulator/ec2_tags.go
+++ b/emulator/ec2_tags.go
@@ -105,18 +105,29 @@ func ec2CheckTagLimit(existing, incoming []EC2Tag) *AWSError {
 // drifted apart, and only the RunInstances one was reachable by
 // [ec2CheckReservedTagKeys] (#468).
 //
-// A specification whose ResourceType names a different resource is skipped rather
-// than ending the walk, so TagSpecification.1=volume followed by
-// TagSpecification.2=instance still yields the instance's tags. An absent or empty
-// ResourceType ends it, which is how the query protocol terminates an indexed list.
-//
 // Note that authz.go builds aws:RequestTag condition keys from the same params with
 // its own walk, deliberately: it evaluates a policy against the request rather than
 // producing resource state, and the two must not share a filter on resourceType.
 func ec2LaunchTagsForResource(params map[string]string, resourceType string) []EC2Tag {
+	return ec2TagSpecificationTags(params, "", resourceType)
+}
+
+// ec2TagSpecificationTags collects the tags a TagSpecification.N list scopes to
+// resourceType, under an optional param-name prefix.
+//
+// prefix serves the nested form a launch template uses:
+// "LaunchTemplateData.TagSpecification.1.Tag.1.Key" is the same list one level in
+// (#471). It is a parameter rather than a fifth copy of this loop because the whole
+// point of [ec2LaunchTagsForResource] is that there is exactly one walk to check.
+//
+// A specification whose ResourceType names a different resource is skipped rather
+// than ending the walk, so TagSpecification.1=volume followed by
+// TagSpecification.2=instance still yields the instance's tags. An absent or empty
+// ResourceType ends it, which is how the query protocol terminates an indexed list.
+func ec2TagSpecificationTags(params map[string]string, prefix, resourceType string) []EC2Tag {
 	var tags []EC2Tag
 	for n := 1; ; n++ {
-		rt, ok := params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
+		rt, ok := params[fmt.Sprintf("%sTagSpecification.%d.ResourceType", prefix, n)]
 		if !ok || rt == "" {
 			break
 		}
@@ -124,17 +135,50 @@ func ec2LaunchTagsForResource(params map[string]string, resourceType string) []E
 			continue
 		}
 		for m := 1; ; m++ {
-			key, keyOK := params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Key", n, m)]
+			key, keyOK := params[fmt.Sprintf("%sTagSpecification.%d.Tag.%d.Key", prefix, n, m)]
 			if !keyOK || key == "" {
 				break
 			}
 			tags = append(tags, EC2Tag{
 				Key:   key,
-				Value: params[fmt.Sprintf("TagSpecification.%d.Tag.%d.Value", n, m)],
+				Value: params[fmt.Sprintf("%sTagSpecification.%d.Tag.%d.Value", prefix, n, m)],
 			})
 		}
 	}
 	return tags
+}
+
+// ec2CheckTemplateTags returns an error if a launch template's instance-scoped tags
+// break either tag rule, or nil.
+//
+// Run when a template or a version of one is created, so a template carrying a
+// reserved key or more than [ec2MaxTagsPerResource] is refused up front rather than
+// at every launch that names it. Real EC2 rejects at creation too: both rules are on
+// the key and the count, not on the operation.
+//
+// The launch path checks again, deliberately — see the fallback in
+// [EC2Plugin.runInstancesWithTags] for why a stored template can still carry one.
+func ec2CheckTemplateTags(d EC2LaunchTemplateData) *AWSError {
+	if awsErr := ec2CheckReservedTagKeys(d.TagSpecifications); awsErr != nil {
+		return awsErr
+	}
+	return ec2CheckTagLimit(nil, d.TagSpecifications)
+}
+
+// ec2HasUserTags reports whether tags holds any key that is not reserved.
+//
+// It is how the launch-template tag fallback decides whether the caller named tags
+// of their own (#471). A plain len(tags) == 0 would answer "yes" for every fleet
+// instance, because substrate has already appended [ec2FleetIDTagKey] by then — so a
+// fleet launched from a tagging template would silently lose the template's tags,
+// which is the very defect #471 exists to close.
+func ec2HasUserTags(tags []EC2Tag) bool {
+	for _, t := range tags {
+		if !strings.HasPrefix(t.Key, ec2ReservedTagPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // ec2CheckReservedTagKeys returns an error if any tag uses a reserved key, or nil.

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -640,6 +640,28 @@ type EC2LaunchTemplateData struct {
 	// [EC2LaunchTemplateData.NetworkSecurityGroupIDs] for how substrate resolves
 	// which list applies.
 	NetworkInterfaceGroups []string `json:"networkInterfaceGroups,omitempty"`
+
+	// TagSpecifications is the template's instance-scoped tag-on-create tags, from
+	// LaunchTemplateData.TagSpecification.N with ResourceType=instance.
+	//
+	// Instance-scoped only. A template may also scope tags to volume,
+	// network-interface or spot-instances-request; substrate models none of those
+	// resources, so those scopes are recorded nowhere rather than misapplied to the
+	// instance. Note that these tags land on the *instance*, not on the template
+	// itself — the reference is explicit: "These tags are not applied to the launch
+	// template."
+	TagSpecifications []EC2Tag `json:"tagSpecifications,omitempty"`
+
+	// IamInstanceProfile is the instance profile the template names, stored as
+	// whichever of Name or Arn the request supplied — the same single-string shape
+	// [EC2Instance.IamInstanceProfile] holds, so the merge is a plain fallback.
+	//
+	// Name is preferred when both are given, mirroring RunInstances' own
+	// precedence. AWS's LaunchTemplateIamInstanceProfileSpecificationRequest has
+	// exactly those two members and documents neither as authoritative over the
+	// other, so the choice is substrate's, made for consistency with the call-level
+	// path rather than from the reference.
+	IamInstanceProfile string `json:"iamInstanceProfile,omitempty"`
 }
 
 // NetworkSecurityGroupIDs returns the security groups a launch from this template


### PR DESCRIPTION
Closes #471

## The defect

A launch template's `TagSpecifications` and `IamInstanceProfile` were accepted by `CreateLaunchTemplate` and stored nowhere, so a template that tagged its instances produced untagged ones and a template naming a role produced an instance with none — with nothing failing to say so.

The tag half is the more damaging. `DescribeInstances --filters tag:Env,Values=prod` is how IaC finds the resources it just created, and it simply returned nothing, so an assertion on the tags the template asked for could not pass however it was written.

Neither field could even be **read back** before this release: `DescribeLaunchTemplates` carries no `launchTemplateData`, so #456's `DescribeLaunchTemplateVersions` is what makes the round-trip assertable. That is why #456 came into this milestone rather than #471's acceptance criterion being weakened.

## Behaviour

**Template tags replace rather than merge.** A request naming `Env=req` against a template naming `Env=tmpl,Team=x` yields `Env=req` alone — `Team` is not inherited. The reference gives no `TagSpecifications`-specific merge semantics, only the general "Any additional parameters that you specify for the new instance overwrite the corresponding parameters included in the launch template", and replacement is that rule applied to the whole specification rather than a per-field citation.

**Substrate's own `aws:ec2:fleet-id` stamp does not count as the request naming tags.** A fleet instance already carries that reserved key by the time the merge runs, so the fallback tests for a non-reserved key (`ec2HasUserTags`) rather than for an empty set. Had it tested emptiness, a fleet launched from a tagging template would have silently lost the template's tags — the very defect this PR closes, on the path #443 added. It is the same reserved-key exclusion #469's counter uses, and it has its own test.

**A template's tags are subject to both tag rules**, so a template is not a second unrestricted tagging path. A reserved key or more than 50 tags is rejected at `CreateLaunchTemplate` and at `CreateLaunchTemplateVersion` — the latter *after* any `SourceVersion` inheritance, so an inherited violation is caught rather than propagated. The launch checks again, deliberately and not redundantly: a template written straight into state by a replayed event log can predate these checks, and that launch is where the key would otherwise be applied.

## Scope, stated rather than implied

- **Only the instance scope is stored.** A template may also scope tags to `volume`, `network-interface` or `spot-instances-request`, none of which substrate models, so those specifications are recorded nowhere rather than misapplied to the instance.
- **The profile is stored as the single string the request supplied**, matching the shape an instance holds, so `DescribeLaunchTemplateVersions` echoes it in whichever member it arrived in — `arn` for an `arn:`-prefixed value, `name` otherwise. `DescribeInstances` still surfaces it as an ARN either way, because AWS's instance response shape has no name member; synthesizing the missing member for a *template* read-back would report the template as naming something the caller never wrote.

## Sources

Verified against the AWS reference per CLAUDE.md:

- `ResponseLaunchTemplateData` spells the members `iamInstanceProfile` and `TagSpecificationSet.N`, while the **request** spells them `IamInstanceProfile` and `TagSpecification.N` — so a round-trip test has to use both names. Noted in the code, because getting it backwards produces a template with no tags and nothing to say so.
- `LaunchTemplateIamInstanceProfileSpecification` (response) has exactly `arn` and `name`.
- `LaunchTemplateTagSpecification` (response) has `resourceType` and `TagSet.N`.
- Template tags land on the **instance**: "These tags are not applied to the launch template."
- `Name` is preferred over `Arn` when both are given. AWS documents neither as authoritative, so that choice is substrate's, made for consistency with the call-level path — said so in the field comment rather than implied to be a citation.
- `DescribeLaunchTemplateVersions`' two worked XML examples show only `imageId`/`instanceType` inside `launchTemplateData`, so both new members' element shapes come from the member tables rather than a worked example.

## Refactor

`ec2LaunchTagsForResource` becomes a one-line wrapper over a prefix-taking `ec2TagSpecificationTags`, rather than a fifth copy of the `TagSpecification.N` walk. `LaunchTemplateData.TagSpecification.1.Tag.1.Key` is the same indexed list one level in, and the whole point of PR #468's shared parser is that there is exactly one walk to check. The six existing callers are untouched.

## Tests

New in `emulator/ec2_launchtemplate_test.go`:

- `CreateLaunchTemplate` → `DescribeLaunchTemplateVersions` round-trips both fields, in both the `Name` and `Arn` forms.
- An instance launched from a tagging template reports those tags **and a `tag:Env,Values=prod` filter finds it** — the half a consumer's IaC depends on.
- An instance launched from a profile-naming template reports it, from either request member.
- The full precedence matrix: request-wins / template-fills / neither, for tags and for the profile, with the replace-not-merge row asserting that `Team` is absent.
- `SourceVersion` inheritance does not outrank the new version's own tags or profile — one arm per overlay field.
- A reserved key and a 51st tag are rejected at `CreateLaunchTemplate`; a reserved key is rejected at `CreateLaunchTemplateVersion` and the version is not appended; exactly 50 template tags launch.
- A template written **straight into state** with a reserved key, and one with 51 tags, are both rejected at the *launch*.
- A fleet launched from a tagging template keeps the template's tags **and** `aws:ec2:fleet-id`.

## Verification

From the repo root: `gofmt -l .`, `go build ./...`, `go vet ./...` clean; `golangci-lint run ./...` → **0 issues**; `make test` (race) green; `make docs-reference docs-reference-check docs-versions` clean; `go test -C test/e2e ./...` green.

**Mutation-tested: 19 mutations of the new logic, all 19 killed.** Three survived the first pass and each bought a test — the two `ec2OverlayTemplateData` arms (now covered by the `SourceVersion` case) and the launch-path tag-limit check (now covered by the stored-51-tag case).

## Docs

`docs/services.md` — the "not parsed at all" line is replaced; the per-field precedence table gains four rows; the instance-scope-only limit, the fleet-stamp interaction, the two tag rules and the profile echo direction are all stated. The reserved-key and 50-tag sections gain their launch-template halves.