### PR TITLE
feat(sqs): validate message attributes against their documented rules (#472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CLI help, moto — which does not implement the operation — LocalStack, and the SDK
   models); the message is the reference's own sentence. Both are inferred, not
   captured.
+- **SQS message attributes are now validated against their documented rules** (#472).
+  Every attribute was stored and returned as sent, so an eleventh attribute, a name real
+  SQS reserves, a `DataType` that is not one of the three, and a `Number` attribute
+  holding `"abc"` were all accepted and delivered. That last one is the shape this
+  tracker exists to close: a consumer whose handler parses a `Number` attribute had no
+  way to reach its parse-failure branch, and a test of that branch passed against
+  substrate while the same code broke against AWS.
+
+  `SendMessage` and each `SendMessageBatch` entry now enforce, all as
+  `InvalidParameterValue` / HTTP 400: the maximum of 10 attributes; a name shorter than
+  256 bytes drawn from alphanumerics, `_`, `-` and `.`, with no `AWS.`/`Amazon.` prefix
+  and no leading, trailing or sequential period; a `DataType` shorter than 256 bytes
+  prefixed `String`, `Number` or `Binary`; a non-empty value on a `String` attribute; and
+  a `Number` value that parses as a decimal number within −10^128 … 10^126. Both length
+  bounds are exclusive — the guide says "up to 256 characters" while the error says "must
+  be shorter than 256 Bytes", and the error is the more specific evidence.
+
+  **The reserved-prefix check is case-insensitive**, so `aws.trace` and `AwS.trace` are
+  refused too, per the guide's "or any casing variations". This is the **opposite** of
+  #468's `aws:` tag-key rule, where `AWS:foo` remains a legal key. Both are correct, the
+  two services document different rules, and the checks are deliberately not shared —
+  which is the detail a reader arriving from one will get wrong about the other.
+
+  A rejected send **enqueues nothing**. On a FIFO queue the check runs before the
+  deduplication ID is recorded, so a corrected retry reusing the same
+  `MessageDeduplicationId` is delivered rather than swallowed as a duplicate — the same
+  ordering #454's size check established, for the same reason.
+
+  `SendMessageBatch` reports a violation **per entry**: a `BatchResultErrorEntry` in
+  `Failed` with `SenderFault: true` at HTTP **200**, the offending entry not enqueued and
+  its siblings delivered. Substrate had no such type — both batch paths emitted an empty
+  `Failed` placeholder — so a consumer's per-entry error handling had nothing to
+  exercise, and the reference warns that "you should check for batch errors even when the
+  call returns an HTTP status code of `200`". `Failed` is now always present, empty rather
+  than absent on full success. This is deliberately unlike the batch size checks a few
+  lines away, which still fail the whole request with `BatchRequestTooLong`: the payload
+  cap is a property of the aggregate the caller transmitted, while a malformed attribute
+  is a defect in one entry.
+
+  Provenance, strongest first, and recorded per message in the code. **Real-AWS
+  captures**: the count rejection's message (an SDK exception quoting an AWS Request ID
+  and status 400), the `Number` cast failure (code *and* message, from boto3 against live
+  SQS), and the empty-`String`-value message (captured twice independently). **A
+  snapshot-tested reimplementation**: the name and type messages, from LocalStack, whose
+  character-class string is reproduced verbatim including its "upper and lower score
+  characters" phrasing and its trailing space. **A single reimplementation, the weakest
+  claim here and labelled as such in the file**: the `Number` range message, which only
+  elasticmq supplies. The count rejection's *code* is absent from its capture and comes
+  from agreement across five reimplementations; neither moto nor LocalStack enforces the
+  count at all, which is why substrate accepting an eleventh attribute went unnoticed
+  until #461 made attributes observable.
+
+  The rules apply on send, not on receive: a message written into state before they
+  existed is still returned as stored, because withholding it would make a recorded run
+  unreplayable. Tracked separately.
 - `make tag-releases-check` (`scripts/check-tag-releases.sh`) fails if a published
   `vX.Y.Z` tag has no GitHub Release behind it, run daily by the new `Release Audit`
   workflow. Pushing a tag does not create a Release and nothing asserted otherwise,

--- a/docs/services.md
+++ b/docs/services.md
@@ -875,8 +875,8 @@ Lambda invocations: $0.0000002 per request.
 | SetQueueAttributes | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteQueue | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | ListQueues | |
-| SendMessage | Returns MessageId; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; enforces [`MaximumMessageSize`](#message-size-enforcement); stores [message attributes](#message-attributes) and returns `MD5OfMessageAttributes` |
-| SendMessageBatch | Enforces both the [per-message and batch-total size limits](#message-size-enforcement); stores [message attributes](#message-attributes) per entry |
+| SendMessage | Returns MessageId; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; enforces [`MaximumMessageSize`](#message-size-enforcement); stores [message attributes](#message-attributes) and returns `MD5OfMessageAttributes`; enforces the [attribute count, name, type and `Number` rules](#attribute-rules) |
+| SendMessageBatch | Enforces both the [per-message and batch-total size limits](#message-size-enforcement); stores [message attributes](#message-attributes) per entry; reports an [attribute-rule violation per entry](#batch-failures-are-per-entry) in `Failed` at HTTP 200 |
 | ReceiveMessage | Supports MaxNumberOfMessages, WaitTimeSeconds; [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent; returns [message attributes](#message-attributes) for the names requested |
 | DeleteMessage | [`QueueDoesNotExist`](#queuedoesnotexist) when the queue is absent |
 | DeleteMessageBatch | |
@@ -1095,10 +1095,84 @@ A deduplicated FIFO send reports the digest of *that request's* attributes rathe
 the stored original's, for the same reason: the digest is a checksum of what the caller
 sent.
 
-Two limits are **not** enforced (tracked separately): the documented maximum of 10
-attributes per message, and the attribute-name character rules (no `AWS.` or `Amazon.`
-prefix, no leading, trailing or sequential periods). A 10-attribute message is accepted,
-which is the boundary rather than a rejection.
+#### Attribute rules
+
+Every rule below is checked on `SendMessage` and on each `SendMessageBatch` entry, under
+both protocols, and every rejection is `InvalidParameterValue` with HTTP 400. A rejected
+send **enqueues nothing** — on a FIFO queue the check runs before the deduplication ID is
+recorded, so a corrected retry reusing the same `MessageDeduplicationId` is delivered
+rather than swallowed as a duplicate.
+
+| Rule | Rejected |
+|---|---|
+| count | more than 10 attributes on one message |
+| name length | 256 bytes or more |
+| name characters | anything outside `A-Z`, `a-z`, `0-9`, `_`, `-`, `.` |
+| reserved prefix | starting with `AWS.` or `Amazon.`, **any casing** |
+| periods | a leading or trailing `.`, or two in sequence |
+| type | a `DataType` not prefixed `String`, `Number` or `Binary`; an absent one |
+| type length | 256 bytes or more |
+| empty value | a `String` attribute with no value |
+| `Number` value | not a decimal number, or outside −10^128 … 10^126 |
+
+Both length bounds are **exclusive**: 255 bytes is legal, 256 is not. The developer guide
+says "up to 256 characters" while the error text says "must be shorter than 256 Bytes";
+the error is the more specific evidence, and the conflict is recorded rather than quietly
+resolved.
+
+A custom suffix on a type is legal and preserved — `Number.java.lang.Long`, `Binary.gif`
+— and a `Number` is range-checked whatever its suffix. Scientific notation (`1e5`) is
+accepted, which is the permissive reading of a detail no source settles. Uniqueness
+within a message is structural rather than checked: attributes are keyed by name.
+
+**The reserved-prefix check is case-insensitive**, so `aws.trace` and `AwS.trace` are
+refused alongside `AWS.trace`. This is the **opposite** of EC2's `aws:` tag-key rule,
+where [`AWS:foo` is a legal key](#reserved-tag-keys) — the two services document
+different rules, and unifying them would break one of the two. A name merely beginning
+with those letters and no period (`AWSfoo`) is not reserved.
+
+A message breaking two rules always reports the same one: attributes are visited in
+sorted name order, because a walk over the Go map would report one error on some runs and
+the other on others.
+
+#### Batch failures are per entry
+
+`SendMessageBatch` reports an attribute violation as a **`BatchResultErrorEntry` in
+`Failed`** with `SenderFault: true`, at HTTP **200** — the offending entry does not
+enqueue while its siblings do. This is what the reference warns about: "you should check
+for batch errors even when the call returns an HTTP status code of `200`". `Failed` is
+always present, empty rather than absent on a fully successful batch. The ten-attribute
+maximum is per message, so three entries of nine attributes each is legal.
+
+That differs deliberately from the [size checks](#message-size-enforcement) ten lines
+away in the same operation, which fail the **whole request** with `BatchRequestTooLong`:
+the payload cap is a documented property of the aggregate the caller transmitted, while a
+malformed attribute is a defect in one entry.
+
+#### Provenance
+
+Message text carries different weights, and the code says which is which:
+
+- **Real-AWS captures**: the count rejection (an SDK exception quoting a Request ID and
+  status 400), the `Number` cast failure (`Can't cast the value of message (user)
+  attribute '…' to a number.`, captured from boto3 against live SQS, code and message
+  together), and the empty-`String`-value message (captured twice independently).
+- **Snapshot-tested reimplementation**: the name and type messages, from LocalStack's
+  `check_attributes`, which snapshot-tests against real AWS. The character-class message
+  is reproduced verbatim including its odd "upper and lower score characters" phrasing
+  and its trailing space — a tidied string is no longer the one a consumer sees.
+- **A single reimplementation, and the weakest claim here**: the `Number` **range**
+  message (`Number attribute value … should be in range (-10**128..10**126)`), which only
+  elasticmq supplies.
+
+The count rejection's **code** is not in the capture; it comes from agreement across five
+reimplementations. Neither moto nor LocalStack enforces the count at all, which is why
+substrate accepting an eleventh attribute went unnoticed until message attributes became
+observable.
+
+The rules apply on send, not on receive. A message written into state before they existed
+— replayed from an older event log — is returned as stored rather than withheld, since
+withholding it would make a recorded run unreplayable.
 
 ### QueueNameExists
 

--- a/emulator/sqs_messageattributes_test.go
+++ b/emulator/sqs_messageattributes_test.go
@@ -618,11 +618,14 @@ func TestSQS_MessageAttributes_SurviveRedelivery(t *testing.T) {
 // TestSQS_MessageAttributes_TenAttributesAccepted pins AWS's documented per-message
 // maximum as the boundary it is, not as a rejection.
 //
-// The reference states a message "can have up to 10 metadata attributes", and
-// substrate does not enforce the count — so this asserts the legal case works rather
-// than asserting an error substrate does not raise. Enforcing the maximum is tracked
-// separately; pinning the boundary here is what makes that change visible when it
-// lands, instead of silently turning a passing test into a failing one.
+// The reference states a message "can have up to 10 metadata attributes", so ten is
+// legal and the eleventh is not. This test owns the legal side, and it is the guard
+// #472's enforcement had to survive: an off-by-one in the count check turns a documented
+// maximum into a rejection at nine.
+//
+// It also asserts all ten come back, which the rejection test cannot: a count check that
+// dropped an attribute instead of refusing the message would pass an error-code
+// assertion.
 func TestSQS_MessageAttributes_TenAttributesAccepted(t *testing.T) {
 	bothProtocols(t, func(t *testing.T, jsonProto bool) {
 		srv, _ := newSQSTestServer(t)

--- a/emulator/sqs_messageattrrules.go
+++ b/emulator/sqs_messageattrrules.go
@@ -1,0 +1,417 @@
+package emulator
+
+import (
+	"fmt"
+	"math/big"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// The documented limits on a message's user-defined attributes, from the SQS
+// developer guide's "Message metadata" page.
+//
+// The two length bounds are **exclusive**, which is not what the guide's prose says.
+// The guide states a name and a type "can be up to 256 characters long", but the error
+// AWS returns reads "must be shorter than 256 Bytes" and LocalStack — which snapshot-
+// tests its SQS provider against the live service — rejects at exactly 256. The
+// message is the more specific evidence of where the boundary sits, so a 256-byte name
+// is refused here and the conflict is recorded rather than quietly resolved.
+//
+// "Bytes" is also the message's own word where the guide says "characters", so the
+// length is measured in UTF-8 bytes — Go's len on a string — not in runes.
+const (
+	sqsMaxMessageAttributes     = 10
+	sqsMaxAttributeNameLength   = 256
+	sqsMaxAttributeTypeLength   = 256
+	sqsAttributeNumberPrecision = 512
+)
+
+// sqsNumberAttributeMin and sqsNumberAttributeMax bound a Number attribute's value.
+//
+// The guide states a Number "can have up to 38 digits of precision, and it can be
+// between 10^-128 and 10^+126". That phrasing is ambiguous between magnitude bounds
+// and signed bounds; the signed reading is taken here because it is the one an
+// independent implementation arrived at (elasticmq's numberAttributeValueLimit is
+// -10^128..10^126) and because the same sentence describes the type as holding
+// "positive or negative numerical values".
+//
+// They are [big.Float] rather than float64 because 10^126 is not exactly representable
+// in float64, so a float64 comparison would land on the wrong side of the boundary for
+// a value written out in full. The precision is set well above the ~419 bits 10^126
+// needs so both bounds are exact.
+//
+// Computed once at package scope rather than per call, following
+// [sqsMaxBatchPayloadSize]: the values are immutable, and rebuilding a 128-digit
+// integer on every attribute check would be waste in the send path.
+var (
+	sqsNumberAttributeMin = new(big.Float).SetPrec(sqsAttributeNumberPrecision).
+				Neg(sqsPowerOfTen(128))
+	sqsNumberAttributeMax = sqsPowerOfTen(126)
+)
+
+// sqsPowerOfTen returns 10^exp as an exact [big.Float].
+func sqsPowerOfTen(exp int64) *big.Float {
+	i := new(big.Int).Exp(big.NewInt(10), big.NewInt(exp), nil)
+	return new(big.Float).SetPrec(sqsAttributeNumberPrecision).SetInt(i)
+}
+
+// sqsCheckMessageAttributes validates a message's user-defined attributes, returning
+// the error AWS raises for the first violation or nil.
+//
+// Every rule here is a documented constraint substrate previously ignored, which is the
+// silent-success shape this tracker exists to close: a caller whose eleventh attribute
+// is dropped by real SQS, or whose Number attribute holds "abc", saw substrate accept
+// the send and had no reachable error branch to test (#472).
+//
+// Attributes are visited **in sorted name order** so a message violating two rules
+// always reports the same one. Go map iteration is randomized, so visiting in map order
+// would make the reported error differ between two identical requests — the precise
+// nondeterminism this emulator exists to remove.
+//
+// The count is checked before any individual attribute, so an eleven-attribute message
+// that also carries an illegal name reports the count. No capture settles that
+// ordering; it is chosen because the count is a property of the set rather than of any
+// one attribute, and because it is the cheap check.
+//
+// Provenance, by rule, strongest first. Substrate matches AWS on codes; message text is
+// only as good as its source, and the tiers differ here:
+//
+//   - The count and the Number cast are **real-AWS captures**, quoted below.
+//   - The empty-String-value message is a real-AWS capture, twice over
+//     (open-telemetry/opentelemetry-js-contrib#1528, and a direct `aws sqs send-message`
+//     against sqs.ap-northeast-1.amazonaws.com in softwaremill/elasticmq#373).
+//   - The name and type messages come from LocalStack's check_attributes, which
+//     snapshot-tests against the live service. No independent capture was found for any
+//     of them; moto implements none of these rules and uses different wording for the
+//     one name check it has, so LocalStack's strings stand alone.
+//   - The Number **range** message is one reimplementation's own wording with no
+//     capture and no snapshot testing behind it. It is the weakest claim in this file
+//     and is labeled as such where it is raised.
+//
+// Two documented rules are deliberately not coded here. **Uniqueness within a message**
+// is structural: attributes arrive as a Go map keyed by name, so a duplicate name
+// cannot survive parsing to be rejected. And the **empty-value rule is applied to
+// String only**, following the one source that specifies a message for it; a Binary
+// attribute with an empty value is still accepted, which is what keeps the
+// transport-byte case in TestSQS_MessageAttributes_BinaryIsIdentifiedByDataType
+// reachable through the public API.
+func sqsCheckMessageAttributes(attrs map[string]SQSMessageAttribute) *AWSError {
+	if len(attrs) > sqsMaxMessageAttributes {
+		return sqsTooManyMessageAttributes(len(attrs))
+	}
+
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if awsErr := sqsCheckAttributeName(name); awsErr != nil {
+			return awsErr
+		}
+		if awsErr := sqsCheckAttributeValue(name, attrs[name]); awsErr != nil {
+			return awsErr
+		}
+	}
+	return nil
+}
+
+// sqsCheckAttributeName validates one attribute name against the guide's rules.
+//
+// The prefix rule is **case-INsensitive**, and that is the detail a reader arriving
+// from EC2's reserved tag keys will get wrong. The guide says a name "can't start with
+// AWS. or Amazon. (or any casing variations)", and LocalStack matches its
+// prefix regex against name.lower(). EC2's aws: tag prefix is the opposite —
+// case-*sensitive*, so AWS:foo is a legal tag key (see ec2CheckReservedTagKeys and
+// #452). Both findings are correct; the two services document different rules, and
+// unifying them would break one of the two.
+//
+// The character class follows the **developer guide** — alphanumerics, underscore,
+// hyphen and period — rather than LocalStack's regex, which additionally admits the
+// Latin-1 supplement range U+00C0..U+017F. The guide is the authoritative source and
+// the wider class is unattributed, so the narrower rule is enforced; a name outside the
+// guide's class is rejected here even though LocalStack would accept it.
+//
+// Sequential periods need their own check: ".." satisfies the character class, so the
+// guide's "must not have periods in a sequence" is invisible to a class test.
+func sqsCheckAttributeName(name string) *AWSError {
+	if len(name) >= sqsMaxAttributeNameLength {
+		return sqsInvalidAttributeParameter(
+			"Message (user) attribute names must be shorter than 256 Bytes")
+	}
+	if !sqsAttributeNameCharsLegal(name) {
+		// Reproduced verbatim from the observed text, trailing space and all: "upper
+		// and lower score characters" is AWS's own odd phrasing, and the string ends
+		// with a space. A tidied version is no longer the string a consumer asserting
+		// on real SQS would see, so neither is corrected here.
+		return sqsInvalidAttributeParameter("Message (user) attributes name can only " +
+			"contain upper and lower score characters, digits, periods, hyphens and underscores. ")
+	}
+	lower := strings.ToLower(name)
+	if strings.HasPrefix(lower, "aws.") || strings.HasPrefix(lower, "amazon.") ||
+		strings.HasPrefix(lower, ".") || strings.HasSuffix(lower, ".") {
+		return sqsInvalidAttributeParameter("You can't use message attribute names " +
+			"beginning with 'AWS.' or 'Amazon.'. These strings are reserved for internal use. " +
+			"Additionally, they cannot start or end with '.'.")
+	}
+	if strings.Contains(name, "..") {
+		// A separate message, from a third reimplementation (Inqnuam/local-aws-sqs),
+		// because LocalStack has no sequential-period check at all and so supplies no
+		// wording for it. Whether real AWS reports this under the message above or a
+		// distinct one is unsettled — no capture of either was found.
+		return sqsInvalidAttributeParameter(
+			"Message (user) attribute name must not have successive '.' characters.")
+	}
+	return nil
+}
+
+// sqsAttributeNameCharsLegal reports whether every byte of a name is in the character
+// class the developer guide allows: A-Z, a-z, 0-9, underscore, hyphen and period.
+//
+// Written as a loop rather than a regexp so the class is readable beside the guide's
+// sentence and the package keeps no compiled-pattern globals. Byte-wise is sufficient
+// because every legal character is ASCII, so any multi-byte rune fails on its first
+// byte.
+func sqsAttributeNameCharsLegal(name string) bool {
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '_', c == '-', c == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// sqsCheckAttributeValue validates one attribute's DataType and value.
+//
+// The type must be prefixed with String, Binary or Number, with any trailing text
+// forming a custom type — "Number.java.lang.Long" and "Binary.gif" are both documented
+// and both legal. The prefix is matched case-sensitively: the guide states the type "is
+// case-sensitive", so "string" is not a String.
+func sqsCheckAttributeValue(name string, attr SQSMessageAttribute) *AWSError {
+	if attr.DataType == "" {
+		return sqsInvalidAttributeParameter("Missing required parameter DataType")
+	}
+	base, _, _ := strings.Cut(attr.DataType, ".")
+	if base != "String" && base != "Number" && base != "Binary" {
+		// LocalStack's own f-string joins "must be prefixed" to "with" without a
+		// space, which is visibly a Python string-concatenation slip rather than
+		// observed text; the grammatical form is emitted here. The literal
+		// "MessageAttributes.Attribute_name.DataType" is left uninterpolated because
+		// that is how the source has it and the "but was" clause already tells a
+		// caller which value was refused.
+		return sqsInvalidAttributeParameter(fmt.Sprintf("Type for parameter "+
+			"MessageAttributes.Attribute_name.DataType must be prefixed with \"String\", "+
+			"\"Binary\", or \"Number\", but was: %s", attr.DataType))
+	}
+	if len(attr.DataType) >= sqsMaxAttributeTypeLength {
+		return sqsInvalidAttributeParameter(
+			"Message (user) attribute types must be shorter than 256 Bytes")
+	}
+
+	// The exact type, not the base: a custom "String.json" carries no source for this
+	// rejection, so only the plain String type is held to it.
+	if attr.DataType == "String" && attr.StringValue == "" {
+		return sqsInvalidAttributeParameter(fmt.Sprintf(
+			"Message (user) attribute '%s' must contain a non-empty value of type 'String'.", name))
+	}
+	if base == "Number" {
+		return sqsCheckNumberAttribute(name, attr.StringValue)
+	}
+	return nil
+}
+
+// sqsCheckNumberAttribute validates a Number attribute's value.
+//
+// A non-numeric value is the case #472 names, and it is the silent-success shape this
+// tracker exists to close: a caller storing a counter or a timestamp in a Number
+// attribute has substrate accept "abc" and their consumer's parse-failure branch
+// unreachable.
+//
+// The rejection is a **real-AWS capture**, code and message together: boto3 calling
+// SendMessage against live SQS with {'StringValue': 'Hello', 'DataType': 'Number'}
+// reports `An error occurred (InvalidParameterValue) when calling the SendMessage
+// operation: Can't cast the value of message (user) attribute 'Age' to a number.` — the
+// offending attribute's name interpolated, as reproduced here. An independent
+// reimplementation (Inqnuam/local-aws-sqs) emits the same sentence.
+//
+// The syntax is validated before the value is parsed, and that ordering is load-bearing
+// rather than stylistic: [big.Float]'s SetString parses in base 0, which would also
+// accept hexadecimal and underscore-separated forms real SQS has no reason to allow, so
+// a decimal-only scan runs first and SetString only ever sees input it has already
+// approved. It also bounds the work — a bare exponent like "1e999999999" is syntax that
+// scans in constant time, and big.Float overflows it to +Inf, which the range check
+// then refuses without materializing anything.
+func sqsCheckNumberAttribute(name, value string) *AWSError {
+	cantCast := sqsInvalidAttributeParameter(fmt.Sprintf(
+		"Can't cast the value of message (user) attribute '%s' to a number.", name))
+	if !sqsIsDecimalNumber(value) {
+		return cantCast
+	}
+	f, _, err := big.ParseFloat(value, 10, sqsAttributeNumberPrecision, big.ToNearestEven)
+	if err != nil {
+		// Unreachable for input sqsIsDecimalNumber approved. Reported as the cast
+		// failure rather than discarded so that a divergence between the scanner and
+		// the parser surfaces as a rejection a test can see, not as an accepted value.
+		return cantCast
+	}
+	if f.Cmp(sqsNumberAttributeMin) < 0 || f.Cmp(sqsNumberAttributeMax) > 0 {
+		return sqsNumberAttributeOutOfRange(value)
+	}
+	return nil
+}
+
+// sqsIsDecimalNumber reports whether a string is a plain decimal numeral: an optional
+// sign, digits with at most one point, and an optional decimal exponent.
+//
+// Scientific notation is accepted because the one implementation that bounds the range
+// parses it (elasticmq, via BigDecimal) and because the guide describes the type by its
+// value range rather than by a literal syntax. No capture settles whether real SQS
+// accepts "1e5" as a Number, so this is the permissive reading of an unsettled detail —
+// stated here rather than implied.
+func sqsIsDecimalNumber(s string) bool {
+	s = strings.TrimPrefix(strings.TrimPrefix(s, "-"), "+")
+	mantissa, exponent, hasExponent := s, "", false
+	if i := strings.IndexAny(s, "eE"); i >= 0 {
+		mantissa, exponent, hasExponent = s[:i], s[i+1:], true
+	}
+	whole, frac, hasPoint := strings.Cut(mantissa, ".")
+	if !isDigitsOnly(whole) || (hasPoint && !isDigitsOnly(frac)) {
+		return false
+	}
+	// At least one digit somewhere in the mantissa: "." and "-" are not numbers, and
+	// neither is the empty string a caller left in a Number attribute.
+	if whole == "" && frac == "" {
+		return false
+	}
+	if hasExponent {
+		exponent = strings.TrimPrefix(strings.TrimPrefix(exponent, "-"), "+")
+		if exponent == "" || !isDigitsOnly(exponent) {
+			return false
+		}
+	}
+	return true
+}
+
+// isDigitsOnly reports whether every byte of s is an ASCII digit. An empty string
+// reports true, which is what lets a caller distinguish "12." from "." by checking the
+// two halves separately.
+func isDigitsOnly(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// sqsTooManyMessageAttributes returns the error SendMessage raises for a message
+// carrying more than the documented ten attributes.
+//
+// The message is a **real-AWS capture**. A stack trace in
+// open-telemetry/opentelemetry-java-instrumentation#13799 records the AWS SDK for Java
+// receiving `SqsException: Number of message attributes [11] exceeds the allowed maximum
+// [10]. (Service: Sqs, Status Code: 400, Request ID: f5704601-82c5-5752-a930-266672732710)`
+// from live SQS — an AWS request ID and HTTP 400, reproduced here with both numbers
+// interpolated as the capture shows them.
+//
+// The **code** is not in that trace, and comes instead from convergence: five
+// independent reimplementations (elasticmq, jennyEckstein/sqslite, Inqnuam/local-aws-sqs,
+// tyrchen/rustack, jacoelho/cloudish) all raise this exact sentence as
+// InvalidParameterValue, which is also the code its sibling attribute rules carry. One
+// of them hardcodes the count as `[12]` while checking for more than ten, which is the
+// signature of a string transcribed from a response rather than composed — further
+// evidence the wording is AWS's own.
+//
+// Neither moto nor LocalStack enforces the count at all, which is why substrate
+// accepting an eleventh attribute went unnoticed until #461 made attributes observable.
+func sqsTooManyMessageAttributes(count int) *AWSError {
+	return &AWSError{
+		Code: "InvalidParameterValue",
+		Message: fmt.Sprintf("Number of message attributes [%d] exceeds the allowed maximum [%d].",
+			count, sqsMaxMessageAttributes),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// sqsNumberAttributeOutOfRange returns the error raised for a Number attribute whose
+// value is numeric but outside the documented range.
+//
+// This carries the **weakest provenance in this file** and the label belongs on it: the
+// range itself is documented ("between 10^-128 and 10^+126"), but the wording is
+// elasticmq's own — one reimplementation, with no snapshot testing against the live
+// service behind it and no capture of this rejection found anywhere. It is used in
+// preference to inventing a sentence because a transcription attempt by an independent
+// project is at worst no further from AWS's text than substrate's would be.
+func sqsNumberAttributeOutOfRange(value string) *AWSError {
+	return &AWSError{
+		Code: "InvalidParameterValue",
+		Message: fmt.Sprintf("Number attribute value %s should be in range (-10**128..10**126)",
+			value),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// sqsInvalidAttributeParameter wraps an attribute-rule message in the code and status
+// every one of them carries: InvalidParameterValue, HTTP 400.
+//
+// The code is shared deliberately. SendMessage's Errors section names neither these
+// rules nor any code for them, so the evidence is LocalStack reporting all of them as
+// InvalidParameterValue plus the two captures above showing real SQS doing the same for
+// two members of the family. A single constructor keeps that one claim in one place
+// instead of repeating it at each call site.
+func sqsInvalidAttributeParameter(message string) *AWSError {
+	return &AWSError{
+		Code:       "InvalidParameterValue",
+		Message:    message,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// sqsBatchResultErrorEntry is one failed entry in a batch operation's response.
+//
+// SendMessageBatch reports per-entry failures rather than failing the request: "The
+// result of sending each message is reported individually in the response. Because the
+// batch request can result in a combination of successful and unsuccessful actions, you
+// should check for batch errors even when the call returns an HTTP status code of 200."
+// Substrate had no type for this — both batch paths emitted an empty Failed list — so a
+// consumer's per-entry error handling had nothing to exercise.
+//
+// One struct carries both wire shapes. The element name is BatchResultErrorEntry rather
+// than the member name Failed, because the query-protocol model declares
+// BatchResultErrorEntryList flattened with locationName "BatchResultErrorEntry" under
+// resultWrapper SendMessageBatchResult — so an SDK parses repeated
+// BatchResultErrorEntry elements, not a Failed wrapper. Field order follows the model's
+// member order. Message is the only optional member of the four.
+type sqsBatchResultErrorEntry struct {
+	ID          string `xml:"Id" json:"Id"`
+	SenderFault bool   `xml:"SenderFault" json:"SenderFault"`
+	Code        string `xml:"Code" json:"Code"`
+	Message     string `xml:"Message,omitempty" json:"Message,omitempty"`
+}
+
+// sqsBatchFailure converts an attribute-rule rejection into a batch entry failure.
+//
+// SenderFault is true: the model documents it as "whether the error happened due to the
+// caller of the batch API action", and a malformed attribute is the caller's. Getting it
+// backwards would tell a consumer's retry logic that a permanent request defect was a
+// service-side fault worth retrying.
+//
+// This is deliberately different from the batch **size** failures a few lines away in
+// sendMessageBatch, which fail the whole request with a 400. BatchRequestTooLong is a
+// documented request-level error about the aggregate payload, and an oversized single
+// entry is observed to be reported the same way; an attribute violation is per-entry.
+// Both are faithful, and the distinction matters now that the two sit together.
+func sqsBatchFailure(entryID string, awsErr *AWSError) sqsBatchResultErrorEntry {
+	return sqsBatchResultErrorEntry{
+		ID:          entryID,
+		SenderFault: true,
+		Code:        awsErr.Code,
+		Message:     awsErr.Message,
+	}
+}

--- a/emulator/sqs_messageattrrules_test.go
+++ b/emulator/sqs_messageattrrules_test.go
@@ -1,0 +1,819 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// batchFailure is one BatchResultErrorEntry as a test observes it, normalized across
+// the two protocols.
+type batchFailure struct {
+	id          string
+	code        string
+	message     string
+	senderFault bool
+}
+
+// sendBatchWithResults sends a batch and returns the successful entry IDs and the
+// failures, plus the HTTP status.
+//
+// The status is returned rather than asserted here because the whole point of #472's
+// batch half is that a partially-failing batch is a 200 — a helper that required 200
+// could not express the request-level size failure the same operation still has.
+func sendBatchWithResults(t *testing.T, srv *emulator.Server, queueURL string,
+	entries []sqsBatchEntry, jsonProto bool,
+) (int, []string, []batchFailure) {
+	t.Helper()
+
+	if jsonProto {
+		list := make([]map[string]interface{}, 0, len(entries))
+		for _, e := range entries {
+			entry := map[string]interface{}{"Id": e.id, "MessageBody": e.body}
+			if len(e.attrs) > 0 {
+				entry["MessageAttributes"] = jsonAttrMap(e.attrs)
+			}
+			list = append(list, entry)
+		}
+		resp := sqsJSONRequest(t, srv, "SendMessageBatch",
+			map[string]interface{}{"QueueUrl": queueURL, "Entries": list})
+		if resp.StatusCode != http.StatusOK {
+			status, _ := sqsErrorCode(t, resp)
+			return status, nil, nil
+		}
+		body := readJSONBody(t, resp)
+
+		var ids []string
+		if raw, ok := body["Successful"].([]interface{}); ok {
+			for _, item := range raw {
+				m, isObj := item.(map[string]interface{})
+				require.True(t, isObj, "Successful entry is not an object: %v", item)
+				id, _ := m["Id"].(string)
+				ids = append(ids, id)
+			}
+		}
+		var failures []batchFailure
+		raw, present := body["Failed"].([]interface{})
+		require.True(t, present, "Failed must be present even when empty: %v", body)
+		for _, item := range raw {
+			m, isObj := item.(map[string]interface{})
+			require.True(t, isObj, "Failed entry is not an object: %v", item)
+			f := batchFailure{}
+			f.id, _ = m["Id"].(string)
+			f.code, _ = m["Code"].(string)
+			f.message, _ = m["Message"].(string)
+			f.senderFault, _ = m["SenderFault"].(bool)
+			failures = append(failures, f)
+		}
+		return resp.StatusCode, ids, failures
+	}
+
+	params := map[string]string{"Action": "SendMessageBatch", "QueueUrl": queueURL}
+	for i, e := range entries {
+		base := "SendMessageBatchRequestEntry." + strconv.Itoa(i+1) + "."
+		params[base+"Id"] = e.id
+		params[base+"MessageBody"] = e.body
+		for j, a := range e.attrs {
+			ab := base + "MessageAttribute." + strconv.Itoa(j+1) + "."
+			params[ab+"Name"] = a.name
+			params[ab+"Value.DataType"] = a.dataType
+			if a.stringValue != "" {
+				params[ab+"Value.StringValue"] = a.stringValue
+			}
+		}
+	}
+	resp := sqsRequest(t, srv, params)
+	if resp.StatusCode != http.StatusOK {
+		status, _ := sqsErrorCode(t, resp)
+		return status, nil, nil
+	}
+
+	var parsed struct {
+		Result struct {
+			Entry []struct {
+				ID string `xml:"Id"`
+			} `xml:"SendMessageBatchResultEntry"`
+			Failed []struct {
+				ID          string `xml:"Id"`
+				SenderFault bool   `xml:"SenderFault"`
+				Code        string `xml:"Code"`
+				Message     string `xml:"Message"`
+			} `xml:"BatchResultErrorEntry"`
+		} `xml:"SendMessageBatchResult"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(readBody(t, resp)), &parsed))
+
+	var ids []string
+	for _, e := range parsed.Result.Entry {
+		ids = append(ids, e.ID)
+	}
+	var failures []batchFailure
+	for _, f := range parsed.Result.Failed {
+		failures = append(failures, batchFailure{
+			id: f.ID, code: f.Code, message: f.Message, senderFault: f.SenderFault,
+		})
+	}
+	return resp.StatusCode, ids, failures
+}
+
+// sendAttrError sends a single-attribute message and returns the status, code and
+// message, so the wire text can be asserted and not merely the code.
+func sendAttrError(t *testing.T, srv *emulator.Server, queueURL string,
+	attr sqsMessageAttr, jsonProto bool,
+) (int, string, string) {
+	t.Helper()
+	if jsonProto {
+		resp := sqsJSONRequest(t, srv, "SendMessage", map[string]interface{}{
+			"QueueUrl":          queueURL,
+			"MessageBody":       "body",
+			"MessageAttributes": jsonAttrMap([]sqsMessageAttr{attr}),
+		})
+		if resp.StatusCode == http.StatusOK {
+			resp.Body.Close() //nolint:errcheck
+			return resp.StatusCode, "", ""
+		}
+		body := readJSONBody(t, resp)
+		code, _ := body["__type"].(string)
+		message, _ := body["message"].(string)
+		return resp.StatusCode, code, message
+	}
+
+	params := map[string]string{
+		"Action": "SendMessage", "QueueUrl": queueURL, "MessageBody": "body",
+		"MessageAttribute.1.Name":           attr.name,
+		"MessageAttribute.1.Value.DataType": attr.dataType,
+	}
+	// Set only when non-empty, so the empty-value case sends no StringValue at all
+	// rather than an empty one — the query protocol cannot distinguish them, and the
+	// rule under test is about the value being absent or empty either way.
+	if attr.stringValue != "" {
+		params["MessageAttribute.1.Value.StringValue"] = attr.stringValue
+	}
+	resp := sqsRequest(t, srv, params)
+	if resp.StatusCode == http.StatusOK {
+		resp.Body.Close() //nolint:errcheck
+		return resp.StatusCode, "", ""
+	}
+	body := readJSONBody(t, resp)
+	code, _ := body["__type"].(string)
+	message, _ := body["message"].(string)
+	return resp.StatusCode, code, message
+}
+
+// TestSQS_MessageAttributes_CountIsEnforced is #472's first criterion: an eleventh
+// attribute was accepted, so a caller near the documented maximum — a tracing agent
+// adding headers to a message that already carries nine of its own is the reported
+// case — saw substrate deliver a message real SQS refuses.
+//
+// The message is a real-AWS capture, quoted in the test rather than only in the code so
+// that changing one without the other fails here. The count and the limit are both
+// interpolated, which is the shape the captured response has.
+func TestSQS_MessageAttributes_CountIsEnforced(t *testing.T) {
+	attrs := func(n int) []sqsMessageAttr {
+		out := make([]sqsMessageAttr, 0, n)
+		for i := 0; i < n; i++ {
+			out = append(out, sqsMessageAttr{
+				name: "attr" + strconv.Itoa(i), dataType: "String",
+				stringValue: "v" + strconv.Itoa(i),
+			})
+		}
+		return out
+	}
+
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		t.Run("ten are accepted", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createAttrQueue(t, srv, "count-ten")
+
+			status, code := sendMessageWithAttrs(t, srv, queueURL, "body", attrs(10), jsonProto)
+			require.Equal(t, http.StatusOK, status, "ten is the boundary, not a rejection: %s", code)
+			assert.Equal(t, 1, sqsQueueDepth(t, srv, queueURL))
+		})
+
+		t.Run("eleven are rejected and nothing is enqueued", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createAttrQueue(t, srv, "count-eleven")
+
+			status, code := sendMessageWithAttrs(t, srv, queueURL, "body", attrs(11), jsonProto)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL),
+				"a rejected send must enqueue nothing")
+		})
+	})
+}
+
+// TestSQS_MessageAttributes_CountErrorNamesBothNumbers pins the captured wording,
+// including that the offending count is reported alongside the limit.
+//
+// A caller learns from this message alone how far over they are. Two counts are asserted
+// rather than one, and that is the point of the test: one of the reimplementations that
+// transcribed this string hardcoded the count as `[12]` while checking for more than ten,
+// which a single-count assertion cannot distinguish from a correctly interpolated one.
+func TestSQS_MessageAttributes_CountErrorNamesBothNumbers(t *testing.T) {
+	for _, count := range []int{11, 12, 25} {
+		t.Run(strconv.Itoa(count)+" attributes", func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createAttrQueue(t, srv, "count-message")
+
+			attrs := make([]sqsMessageAttr, 0, count)
+			for i := 0; i < count; i++ {
+				attrs = append(attrs, sqsMessageAttr{
+					name: "attr" + strconv.Itoa(i), dataType: "String", stringValue: "v",
+				})
+			}
+
+			resp := sqsJSONRequest(t, srv, "SendMessage", map[string]interface{}{
+				"QueueUrl": queueURL, "MessageBody": "body",
+				"MessageAttributes": jsonAttrMap(attrs),
+			})
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			body := readJSONBody(t, resp)
+			assert.Equal(t, "Number of message attributes ["+strconv.Itoa(count)+
+				"] exceeds the allowed maximum [10].", body["message"])
+		})
+	}
+}
+
+// TestSQS_MessageAttributes_NameRules covers #472's name criteria in one table.
+//
+// The four casing rows are the point of the table. The prefix rule is
+// case-**insensitive** — the guide says "or any casing variations" — which is the
+// opposite of EC2's aws: tag prefix, where AWS:foo is a legal key (#452). A check
+// copied from the tag code passes the AWS.foo row and fails aws.foo and AwS.foo, which
+// is exactly what these rows exist to catch.
+//
+// AWSfoo and amazonfoo are legal and asserted so: the reserved form is the prefix
+// *with* its period, so a name that merely starts with those letters is not reserved.
+func TestSQS_MessageAttributes_NameRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		attrName  string
+		wantOK    bool
+		wantInMsg string
+	}{
+		{name: "AWS. prefix", attrName: "AWS.trace", wantInMsg: "reserved for internal use"},
+		{name: "Amazon. prefix", attrName: "Amazon.trace", wantInMsg: "reserved for internal use"},
+		{name: "lowercase aws. prefix", attrName: "aws.trace", wantInMsg: "reserved for internal use"},
+		{name: "mixed-case AwS. prefix", attrName: "AwS.trace", wantInMsg: "reserved for internal use"},
+		{name: "uppercase AMAZON. prefix", attrName: "AMAZON.trace", wantInMsg: "reserved for internal use"},
+		{name: "leading period", attrName: ".trace", wantInMsg: "cannot start or end with '.'"},
+		{name: "trailing period", attrName: "trace.", wantInMsg: "cannot start or end with '.'"},
+		{name: "sequential periods", attrName: "trace..id", wantInMsg: "successive '.' characters"},
+		{name: "space", attrName: "trace id", wantInMsg: "can only contain"},
+		{name: "at sign", attrName: "trace@id", wantInMsg: "can only contain"},
+		{name: "colon", attrName: "trace:id", wantInMsg: "can only contain"},
+		{name: "non-ASCII", attrName: "traceÀid", wantInMsg: "can only contain"},
+		{name: "256 bytes", attrName: strings.Repeat("a", 256), wantInMsg: "shorter than 256 Bytes"},
+		{name: "257 bytes", attrName: strings.Repeat("a", 257), wantInMsg: "shorter than 256 Bytes"},
+
+		{name: "AWSfoo without a period", attrName: "AWSfoo", wantOK: true},
+		{name: "amazonfoo without a period", attrName: "amazonfoo", wantOK: true},
+		{name: "aws-foo", attrName: "aws-foo", wantOK: true},
+		{name: "an interior period", attrName: "trace.id", wantOK: true},
+		{name: "mixed legal characters", attrName: "Foo_Bar-1.2", wantOK: true},
+		{name: "255 bytes", attrName: strings.Repeat("a", 255), wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bothProtocols(t, func(t *testing.T, jsonProto bool) {
+				srv, _ := newSQSTestServer(t)
+				queueURL := createAttrQueue(t, srv, "name-rules")
+
+				status, code, message := sendAttrError(t, srv, queueURL,
+					sqsMessageAttr{name: tt.attrName, dataType: "String", stringValue: "v"},
+					jsonProto)
+
+				if tt.wantOK {
+					require.Equal(t, http.StatusOK, status, "should be legal: %s %s", code, message)
+					assert.Equal(t, 1, sqsQueueDepth(t, srv, queueURL))
+					return
+				}
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "InvalidParameterValue", code)
+				assert.Contains(t, message, tt.wantInMsg)
+				assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL),
+					"a rejected send must enqueue nothing")
+			})
+		})
+	}
+}
+
+// TestSQS_MessageAttributes_NameCharacterMessageIsVerbatim pins the observed wording
+// exactly, oddities included: "upper and lower score characters" is AWS's own phrasing
+// and the string ends with a space.
+//
+// Asserted with Equal rather than Contains because both quirks are the kind a reader
+// tidies in passing, and a tidied string is no longer the one a consumer sees from real
+// SQS. This test is the reason not to.
+func TestSQS_MessageAttributes_NameCharacterMessageIsVerbatim(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createAttrQueue(t, srv, "name-verbatim")
+
+	_, _, message := sendAttrError(t, srv, queueURL,
+		sqsMessageAttr{name: "trace id", dataType: "String", stringValue: "v"}, false)
+	assert.Equal(t, "Message (user) attributes name can only contain upper and lower "+
+		"score characters, digits, periods, hyphens and underscores. ", message)
+}
+
+// TestSQS_MessageAttributes_TypeRules covers the DataType criteria.
+//
+// The three base types and their custom-suffixed forms are legal; anything else is not.
+// The "string" row pins that the match is case-sensitive, which the guide states
+// directly ("Is case-sensitive") and which is the opposite of the name prefix rule in
+// the same request — a single check reused for both would be wrong for one of them.
+func TestSQS_MessageAttributes_TypeRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataType  string
+		value     string
+		wantOK    bool
+		wantInMsg string
+	}{
+		{name: "String", dataType: "String", value: "v", wantOK: true},
+		{name: "Number", dataType: "Number", value: "1", wantOK: true},
+		{name: "Binary", dataType: "Binary", wantOK: true},
+		{name: "custom Number suffix", dataType: "Number.java.lang.Long", value: "1", wantOK: true},
+		{name: "custom Binary suffix", dataType: "Binary.gif", wantOK: true},
+		{name: "custom String suffix", dataType: "String.json", value: "{}", wantOK: true},
+
+		{name: "truncated base type", dataType: "Str", value: "v", wantInMsg: "must be prefixed with"},
+		{name: "unknown type", dataType: "int", value: "1", wantInMsg: "must be prefixed with"},
+		{name: "lowercase string", dataType: "string", value: "v", wantInMsg: "must be prefixed with"},
+		{name: "empty type", dataType: "", value: "v", wantInMsg: "Missing required parameter DataType"},
+		{
+			name: "256 bytes", dataType: "String." + strings.Repeat("a", 249), value: "v",
+			wantInMsg: "types must be shorter than 256 Bytes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bothProtocols(t, func(t *testing.T, jsonProto bool) {
+				srv, _ := newSQSTestServer(t)
+				queueURL := createAttrQueue(t, srv, "type-rules")
+
+				status, code, message := sendAttrError(t, srv, queueURL,
+					sqsMessageAttr{name: "attr", dataType: tt.dataType, stringValue: tt.value},
+					jsonProto)
+
+				if tt.wantOK {
+					require.Equal(t, http.StatusOK, status, "should be legal: %s %s", code, message)
+					return
+				}
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "InvalidParameterValue", code)
+				assert.Contains(t, message, tt.wantInMsg)
+			})
+		})
+	}
+}
+
+// TestSQS_MessageAttributes_TypeLengthBoundIsExclusive pins that 255 bytes of type is
+// legal and 256 is not.
+//
+// The guide says a type "can be up to 256 characters long" while the error says "must
+// be shorter than 256 Bytes", and the two readings differ by exactly this case. The
+// message is the more specific evidence, so 256 is refused — and the disagreement is
+// pinned here so that flipping the bound is a visible decision rather than an
+// off-by-one.
+func TestSQS_MessageAttributes_TypeLengthBoundIsExclusive(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createAttrQueue(t, srv, "type-bound")
+
+	legal := "String." + strings.Repeat("a", 255-len("String."))
+	require.Len(t, legal, 255)
+	status, code, message := sendAttrError(t, srv, queueURL,
+		sqsMessageAttr{name: "attr", dataType: legal, stringValue: "v"}, false)
+	assert.Equal(t, http.StatusOK, status, "255 is legal: %s %s", code, message)
+
+	status, code, _ = sendAttrError(t, srv, queueURL,
+		sqsMessageAttr{name: "attr", dataType: legal + "a", stringValue: "v"}, false)
+	assert.Equal(t, http.StatusBadRequest, status, "256 is not")
+	assert.Equal(t, "InvalidParameterValue", code)
+}
+
+// TestSQS_MessageAttributes_EmptyStringValueRejected covers the documented rule that
+// an attribute's "Name, Type, Value, and the message body must not be empty or null".
+//
+// The message has two independent real-AWS captures behind it — an SDK error in
+// open-telemetry/opentelemetry-js-contrib#1528, and a direct `aws sqs send-message`
+// against sqs.ap-northeast-1.amazonaws.com recorded in softwaremill/elasticmq#373 —
+// which is why the attribute name is asserted to appear interpolated in it.
+//
+// A Binary attribute with an empty value is still accepted, which is deliberate: only
+// the String case has a source specifying its message. That is also what keeps
+// TestSQS_MessageAttributes_BinaryIsIdentifiedByDataType reachable through the API.
+func TestSQS_MessageAttributes_EmptyStringValueRejected(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "empty-value")
+
+		status, code, message := sendAttrError(t, srv, queueURL,
+			sqsMessageAttr{name: "tracestate", dataType: "String"}, jsonProto)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Equal(t, "Message (user) attribute 'tracestate' must contain a "+
+			"non-empty value of type 'String'.", message)
+		assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL))
+
+		// The Binary case is not held to this rule; see the doc comment.
+		status, code = sendMessageWithAttrs(t, srv, queueURL, "body",
+			[]sqsMessageAttr{{name: "payload", dataType: "Binary"}}, jsonProto)
+		assert.Equal(t, http.StatusOK, status, "an empty Binary value stays legal: %s", code)
+	})
+}
+
+// TestSQS_MessageAttributes_NumberValidation is #472's Number criterion, and the
+// silent-success shape it names: a Number attribute holding "abc" was accepted, so a
+// consumer's parse-failure branch was unreachable.
+//
+// The rejection is a real-AWS capture — boto3 sending {'StringValue': 'Hello',
+// 'DataType': 'Number'} to live SQS gets InvalidParameterValue with this exact sentence
+// — so the attribute name is asserted interpolated into it.
+//
+// The range rows are a weaker claim, and their own test below says so. Scientific
+// notation is accepted as the permissive reading of an unsettled detail: no capture
+// shows whether real SQS takes "1e5" as a Number.
+func TestSQS_MessageAttributes_NumberValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantOK    bool
+		wantInMsg string
+	}{
+		{name: "integer", value: "42", wantOK: true},
+		{name: "negative", value: "-42", wantOK: true},
+		{name: "explicit plus", value: "+42", wantOK: true},
+		{name: "decimal", value: "3.14159", wantOK: true},
+		{name: "leading zeroes", value: "007", wantOK: true},
+		{name: "trailing point", value: "42.", wantOK: true},
+		{name: "leading point", value: ".5", wantOK: true},
+		{name: "scientific", value: "1e5", wantOK: true},
+		{name: "negative exponent", value: "1.5e-10", wantOK: true},
+		{name: "38 digits of precision", value: strings.Repeat("9", 38), wantOK: true},
+
+		{name: "letters", value: "abc", wantInMsg: "to a number"},
+		{name: "empty", value: "", wantInMsg: "to a number"},
+		{name: "a bare sign", value: "-", wantInMsg: "to a number"},
+		{name: "a bare point", value: ".", wantInMsg: "to a number"},
+		{name: "two points", value: "1.2.3", wantInMsg: "to a number"},
+		{name: "trailing letters", value: "42abc", wantInMsg: "to a number"},
+		{name: "internal space", value: "4 2", wantInMsg: "to a number"},
+		{name: "thousands separator", value: "1,000", wantInMsg: "to a number"},
+		{name: "hexadecimal", value: "0x1f", wantInMsg: "to a number"},
+		{name: "underscore separator", value: "1_000", wantInMsg: "to a number"},
+		{name: "an exponent with no digits", value: "1e", wantInMsg: "to a number"},
+		{name: "infinity", value: "Inf", wantInMsg: "to a number"},
+		{name: "not a number", value: "NaN", wantInMsg: "to a number"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bothProtocols(t, func(t *testing.T, jsonProto bool) {
+				srv, _ := newSQSTestServer(t)
+				queueURL := createAttrQueue(t, srv, "number-rules")
+
+				status, code, message := sendAttrError(t, srv, queueURL,
+					sqsMessageAttr{name: "Age", dataType: "Number", stringValue: tt.value},
+					jsonProto)
+
+				if tt.wantOK {
+					require.Equal(t, http.StatusOK, status, "should be legal: %s %s", code, message)
+					return
+				}
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "InvalidParameterValue", code)
+				assert.Contains(t, message, tt.wantInMsg)
+				assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL))
+			})
+		})
+	}
+}
+
+// TestSQS_MessageAttributes_NumberCastMessageNamesTheAttribute pins the captured
+// wording, with the offending attribute's name interpolated as the capture shows it.
+func TestSQS_MessageAttributes_NumberCastMessageNamesTheAttribute(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createAttrQueue(t, srv, "number-message")
+
+	_, _, message := sendAttrError(t, srv, queueURL,
+		sqsMessageAttr{name: "Age", dataType: "Number", stringValue: "Hello"}, false)
+	assert.Equal(t, "Can't cast the value of message (user) attribute 'Age' to a number.",
+		message)
+}
+
+// TestSQS_MessageAttributes_NumberRangeBounds covers the documented range, "between
+// 10^-128 and 10^+126".
+//
+// The bounds are computed as literal digit strings rather than through a float, because
+// 10^126 is not representable exactly in float64 — a float64 comparison lands on the
+// wrong side of the boundary for a value written out in full, which is precisely the
+// case these rows exercise.
+//
+// A custom-suffixed Number is held to the same range: the suffix names a caller's own
+// type, not a different value domain.
+func TestSQS_MessageAttributes_NumberRangeBounds(t *testing.T) {
+	// 10^126 exactly, and one more than it.
+	max := "1" + strings.Repeat("0", 126)
+	overMax := "2" + strings.Repeat("0", 126)
+	underMin := "-2" + strings.Repeat("0", 128)
+
+	tests := []struct {
+		name     string
+		dataType string
+		value    string
+		wantOK   bool
+	}{
+		{name: "at the maximum", dataType: "Number", value: max, wantOK: true},
+		{name: "at the negative minimum", dataType: "Number", value: "-1" + strings.Repeat("0", 128), wantOK: true},
+		{name: "zero", dataType: "Number", value: "0", wantOK: true},
+		{name: "over the maximum", dataType: "Number", value: overMax},
+		{name: "under the minimum", dataType: "Number", value: underMin},
+		{name: "an overflowing exponent", dataType: "Number", value: "1e999999999"},
+		{name: "a custom type is bounded too", dataType: "Number.java.lang.Long", value: overMax},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newSQSTestServer(t)
+			queueURL := createAttrQueue(t, srv, "number-range")
+
+			status, code, message := sendAttrError(t, srv, queueURL,
+				sqsMessageAttr{name: "n", dataType: tt.dataType, stringValue: tt.value}, false)
+
+			if tt.wantOK {
+				require.Equal(t, http.StatusOK, status, "within range: %s %s", code, message)
+				return
+			}
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Contains(t, message, "should be in range (-10**128..10**126)")
+		})
+	}
+}
+
+// TestSQS_MessageAttributes_FifoRejectionPrecedesDedup pins that an attribute rejection
+// on a FIFO queue happens before the deduplication ID is recorded.
+//
+// This is #454's ordering property, re-asserted rather than assumed to have survived: a
+// send that recorded its dedup ID and then failed would swallow the corrected retry as
+// a duplicate and never deliver it — a failure that looks like success, which is worse
+// than the one being fixed.
+func TestSQS_MessageAttributes_FifoRejectionPrecedesDedup(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	status, code := createQueueWithAttrs(t, srv, "attr-rules.fifo",
+		map[string]string{"FifoQueue": "true"}, false)
+	require.Equal(t, http.StatusOK, status, "create failed: %s", code)
+	queueURL := "http://sqs.us-east-1.localhost/000000000000/attr-rules.fifo"
+
+	send := func(attrName string) *http.Response {
+		t.Helper()
+		return sqsRequest(t, srv, map[string]string{
+			"Action": "SendMessage", "QueueUrl": queueURL, "MessageBody": "body",
+			"MessageGroupId": "g1", "MessageDeduplicationId": "dedup-1",
+			"MessageAttribute.1.Name":              attrName,
+			"MessageAttribute.1.Value.DataType":    "String",
+			"MessageAttribute.1.Value.StringValue": "v",
+		})
+	}
+
+	rejected := send("AWS.trace")
+	require.Equal(t, http.StatusBadRequest, rejected.StatusCode)
+	rejected.Body.Close() //nolint:errcheck
+
+	// The corrected retry reuses the same deduplication ID and must be delivered.
+	accepted := send("trace")
+	require.Equal(t, http.StatusOK, accepted.StatusCode)
+	accepted.Body.Close() //nolint:errcheck
+
+	msgs := receiveMessages(t, srv, queueURL, []string{"All"}, false)
+	require.Len(t, msgs, 1, "the corrected retry must not be swallowed as a duplicate")
+	assert.Equal(t, "v", msgs[0].attributes["trace"].stringValue)
+}
+
+// TestSQS_MessageAttributes_BatchReportsPerEntryFailures is #472's batch criterion, and
+// the half substrate had no type for: both batch paths emitted an empty Failed list, so
+// a consumer's per-entry error handling had nothing to exercise.
+//
+// The response is a **200** with one entry in Failed and two in Successful, which is
+// what the reference describes: "you should check for batch errors even when the call
+// returns an HTTP status code of 200". Exactly two messages are receivable, so the bad
+// entry is refused without taking its siblings with it.
+func TestSQS_MessageAttributes_BatchReportsPerEntryFailures(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "batch-per-entry")
+
+		status, ids, failures := sendBatchWithResults(t, srv, queueURL, []sqsBatchEntry{
+			{id: "good-1", body: "one", attrs: []sqsMessageAttr{
+				{name: "trace", dataType: "String", stringValue: "a"},
+			}},
+			{id: "bad", body: "two", attrs: []sqsMessageAttr{
+				{name: "AWS.trace", dataType: "String", stringValue: "b"},
+			}},
+			{id: "good-2", body: "three", attrs: []sqsMessageAttr{
+				{name: "trace", dataType: "String", stringValue: "c"},
+			}},
+		}, jsonProto)
+
+		require.Equal(t, http.StatusOK, status,
+			"a partially-failing batch is a 200, not a request-level error")
+		assert.ElementsMatch(t, []string{"good-1", "good-2"}, ids)
+
+		require.Len(t, failures, 1)
+		assert.Equal(t, "bad", failures[0].id)
+		assert.Equal(t, "InvalidParameterValue", failures[0].code)
+		assert.True(t, failures[0].senderFault,
+			"a malformed attribute is the caller's fault, and a retry loop reads this")
+		assert.Contains(t, failures[0].message, "reserved for internal use")
+
+		assert.Equal(t, 2, sqsQueueDepth(t, srv, queueURL),
+			"the failed entry must not enqueue, and its siblings must")
+	})
+}
+
+// TestSQS_MessageAttributes_BatchFailedIsPresentWhenEmpty pins that Failed is an empty
+// list rather than absent on a fully successful batch.
+//
+// The model declares Failed required, and an SDK distinguishes an empty list from a
+// missing one: a consumer looping over the field would see nil where AWS sends an empty
+// collection. Substrate already emitted a placeholder here, so this is a regression
+// guard on replacing it with the real list.
+func TestSQS_MessageAttributes_BatchFailedIsPresentWhenEmpty(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "batch-empty-failed")
+
+		status, ids, failures := sendBatchWithResults(t, srv, queueURL, []sqsBatchEntry{
+			{id: "a", body: "one"},
+			{id: "b", body: "two", attrs: []sqsMessageAttr{
+				{name: "trace", dataType: "String", stringValue: "v"},
+			}},
+		}, jsonProto)
+
+		require.Equal(t, http.StatusOK, status)
+		assert.ElementsMatch(t, []string{"a", "b"}, ids)
+		assert.Empty(t, failures)
+		assert.Equal(t, 2, sqsQueueDepth(t, srv, queueURL))
+	})
+}
+
+// TestSQS_MessageAttributes_BatchSizeStillFailsWholeRequest pins the distinction the
+// two checks now sit ten lines apart on.
+//
+// An attribute violation fails its entry; an oversized payload fails the request with a
+// 400. BatchRequestTooLong is a documented request-level error about the aggregate, and
+// a single oversized entry is observed to be reported the same way (#454), so adding
+// per-entry failures must not have converted the size checks into them.
+func TestSQS_MessageAttributes_BatchSizeStillFailsWholeRequest(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createSizedQueue(t, srv, "batch-size-vs-attr", "1024")
+
+		status, ids, failures := sendBatchWithResults(t, srv, queueURL, []sqsBatchEntry{
+			{id: "small", body: "one"},
+			{id: "huge", body: strings.Repeat("x", 2048)},
+		}, jsonProto)
+
+		assert.Equal(t, http.StatusBadRequest, status,
+			"an oversized entry is still a request-level failure, not a Failed entry")
+		assert.Empty(t, ids)
+		assert.Empty(t, failures)
+		assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL))
+	})
+}
+
+// TestSQS_MessageAttributes_BatchCountIsPerEntry pins that the ten-attribute maximum
+// applies to each entry rather than to the batch's total attribute count.
+//
+// Three entries of nine attributes each is 27 in the request and legal, because the
+// documented limit is per message. A check written over the accumulated set would
+// reject this whole batch.
+func TestSQS_MessageAttributes_BatchCountIsPerEntry(t *testing.T) {
+	nine := make([]sqsMessageAttr, 0, 9)
+	for i := 0; i < 9; i++ {
+		nine = append(nine, sqsMessageAttr{
+			name: "attr" + strconv.Itoa(i), dataType: "String", stringValue: "v",
+		})
+	}
+	eleven := make([]sqsMessageAttr, 0, 11)
+	for i := 0; i < 11; i++ {
+		eleven = append(eleven, sqsMessageAttr{
+			name: "attr" + strconv.Itoa(i), dataType: "String", stringValue: "v",
+		})
+	}
+
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "batch-count")
+
+		status, ids, failures := sendBatchWithResults(t, srv, queueURL, []sqsBatchEntry{
+			{id: "a", body: "one", attrs: nine},
+			{id: "b", body: "two", attrs: nine},
+			{id: "c", body: "three", attrs: eleven},
+		}, jsonProto)
+
+		require.Equal(t, http.StatusOK, status)
+		assert.ElementsMatch(t, []string{"a", "b"}, ids,
+			"27 attributes across three entries is legal; the limit is per message")
+		require.Len(t, failures, 1)
+		assert.Equal(t, "c", failures[0].id)
+		assert.Contains(t, failures[0].message, "exceeds the allowed maximum [10]")
+	})
+}
+
+// TestSQS_MessageAttributes_ErrorIsDeterministicAcrossRules pins that a message
+// breaking two rules always reports the same one.
+//
+// Attributes are visited in sorted name order for exactly this reason: Go map iteration
+// is randomized, so an implementation walking the map would report one error on some
+// runs and the other on others — a flaky assertion in a consumer's suite, produced by
+// the emulator that exists to remove flakiness. Repeated because a single run of a
+// randomized walk can agree by chance.
+func TestSQS_MessageAttributes_ErrorIsDeterministicAcrossRules(t *testing.T) {
+	srv, _ := newSQSTestServer(t)
+	queueURL := createAttrQueue(t, srv, "attr-determinism")
+
+	// "AWS.first" sorts before "zz bad", so the prefix rule is the one reported.
+	attrs := []sqsMessageAttr{
+		{name: "zz bad", dataType: "String", stringValue: "v"},
+		{name: "AWS.first", dataType: "String", stringValue: "v"},
+	}
+
+	var first string
+	for i := 0; i < 20; i++ {
+		resp := sqsJSONRequest(t, srv, "SendMessage", map[string]interface{}{
+			"QueueUrl": queueURL, "MessageBody": "body",
+			"MessageAttributes": jsonAttrMap(attrs),
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		message, _ := readJSONBody(t, resp)["message"].(string)
+		if i == 0 {
+			first = message
+			assert.Contains(t, first, "reserved for internal use",
+				"the alphabetically first offending attribute is the one reported")
+			continue
+		}
+		require.Equal(t, first, message, "the reported rule must not vary between runs")
+	}
+}
+
+// TestSQS_MessageAttributes_StoredAttributesAreNotRechecked records the deliberate
+// scope boundary: the rules apply on send, not on receive.
+//
+// A message written into state before these checks existed — the only way an illegal
+// name can still be there, since no API path stores one now — is returned as stored
+// rather than withheld. Withholding it would make a recorded run unreplayable, which is
+// the property the whole emulator rests on, and a receive-time rejection has no AWS
+// behavior behind it: real SQS never accepted the message, so there is nothing to
+// imitate. Tracked separately; this test pins the choice rather than the gap.
+//
+// The illegal name is written directly into state, which is what a pre-#472 event log
+// replays into. Reaching it through the API is impossible by construction now, so
+// nothing weaker would exercise the path.
+func TestSQS_MessageAttributes_StoredAttributesAreNotRechecked(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	srv, _ := newSQSTestServerWithState(t, state)
+	queueURL := createAttrQueue(t, srv, "attr-stored")
+
+	status, code := sendMessageWithAttrs(t, srv, queueURL, "body",
+		[]sqsMessageAttr{{name: "trace", dataType: "String", stringValue: "v"}}, false)
+	require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+
+	// Rename the stored attribute to one the send path would now refuse.
+	ctx := context.Background()
+	idsRaw, err := state.Get(ctx, "sqs", "msg_ids:000000000000/attr-stored")
+	require.NoError(t, err)
+	var ids []string
+	require.NoError(t, json.Unmarshal(idsRaw, &ids))
+	require.Len(t, ids, 1)
+
+	msgKey := "msg:000000000000/attr-stored:" + ids[0]
+	raw, err := state.Get(ctx, "sqs", msgKey)
+	require.NoError(t, err)
+	var stored map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &stored))
+	attrs, ok := stored["MessageAttributes"].(map[string]interface{})
+	require.True(t, ok, "stored message has no MessageAttributes: %v", stored)
+	attrs["AWS.trace"] = attrs["trace"]
+	delete(attrs, "trace")
+	mutated, err := json.Marshal(stored)
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "sqs", msgKey, mutated))
+
+	msgs := receiveMessages(t, srv, queueURL, []string{"All"}, false)
+	require.Len(t, msgs, 1, "a stored message must still be delivered")
+	assert.Equal(t, "v", msgs[0].attributes["AWS.trace"].stringValue,
+		"the illegal name is returned as stored, not corrected or withheld")
+}

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -802,10 +802,20 @@ func (p *SQSPlugin) sendMessage(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		msgAttrs = sqsQueryMessageAttributes(req.Params, "")
 	}
 
+	// Validate the attributes before measuring them (#472). A message that is both
+	// malformed and oversized reports the malformation, which is the more specific
+	// fault: the size is a property of what was sent, while an illegal attribute name
+	// or a non-numeric Number is a defect in the request itself, and shrinking the
+	// message would not fix it.
+	if awsErr := sqsCheckMessageAttributes(msgAttrs); awsErr != nil {
+		return nil, awsErr
+	}
+
 	// Enforce MaximumMessageSize before anything else observable happens (#454).
 	// Ahead of the FIFO branch deliberately: both queue types enforce it, and a FIFO
 	// send that recorded a deduplication ID before failing would poison the dedup
-	// window for the corrected retry that follows.
+	// window for the corrected retry that follows. The attribute check above inherits
+	// that ordering for the same reason.
 	if limit := sqsEffectiveMaximumMessageSize(q); sqsMessageSize(msgBody, msgAttrs) > limit {
 		return nil, sqsMessageTooLong(limit)
 	}
@@ -1034,6 +1044,11 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 	var successesXML []successEntryXML
 	var successesJSON []successEntryJSON
 
+	// Failed entries, shared by both protocol branches. An attribute-rule violation
+	// fails only its own entry (#472) — see [sqsBatchFailure] for why that differs from
+	// the size checks below, which fail the whole request.
+	var failures []sqsBatchResultErrorEntry
+
 	// The per-message limit is the queue's effective MaximumMessageSize; the batch
 	// total has its own cap. Both are checked before any entry is stored, so a
 	// rejected batch enqueues nothing — a partially-applied batch would leave a
@@ -1058,6 +1073,15 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 			return nil, sizeErr
 		}
 		for _, entry := range input.Entries {
+			// A malformed entry fails alone and is not stored, while its siblings
+			// proceed. The sizes above were measured over every entry as sent,
+			// including this one: the payload cap is about what the caller
+			// transmitted, so a whole-request size failure still supersedes a
+			// per-entry one.
+			if awsErr := sqsCheckMessageAttributes(entry.MessageAttributes); awsErr != nil {
+				failures = append(failures, sqsBatchFailure(entry.ID, awsErr))
+				continue
+			}
 			msgID := generateSQSMessageID()
 			md5Body := computeMD5(entry.MessageBody)
 			msg := &SQSMessage{
@@ -1096,9 +1120,14 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 		if successesJSON == nil {
 			successesJSON = make([]successEntryJSON, 0)
 		}
+		if failures == nil {
+			failures = make([]sqsBatchResultErrorEntry, 0)
+		}
+		// HTTP 200 even when entries failed, per the reference: a caller "should check
+		// for batch errors even when the call returns an HTTP status code of 200".
 		return sqsJSONResponse(http.StatusOK, map[string]interface{}{
 			"Successful": successesJSON,
-			"Failed":     []struct{}{},
+			"Failed":     failures,
 		})
 	}
 
@@ -1131,6 +1160,12 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 		delayStr := req.Params[entryPrefix+"DelaySeconds"]
 		delay, _ := strconv.Atoi(delayStr)
 		entryAttrs := sqsQueryMessageAttributes(req.Params, entryPrefix)
+
+		// Per-entry, as in the JSON branch above.
+		if awsErr := sqsCheckMessageAttributes(entryAttrs); awsErr != nil {
+			failures = append(failures, sqsBatchFailure(entryID, awsErr))
+			continue
+		}
 
 		msgID := generateSQSMessageID()
 		md5Body := computeMD5(body)
@@ -1172,8 +1207,12 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 		})
 	}
 
+	// Both lists sit directly under the result wrapper as repeated elements, since the
+	// query-protocol model declares each flattened with its own locationName rather
+	// than nested under a Successful or Failed wrapper.
 	type result struct {
-		SendMessageBatchResultEntry []successEntryXML `xml:"SendMessageBatchResultEntry"`
+		SendMessageBatchResultEntry []successEntryXML          `xml:"SendMessageBatchResultEntry"`
+		BatchResultErrorEntry       []sqsBatchResultErrorEntry `xml:"BatchResultErrorEntry"`
 	}
 	type response struct {
 		XMLName                xml.Name         `xml:"SendMessageBatchResponse"`
@@ -1181,10 +1220,14 @@ func (p *SQSPlugin) sendMessageBatch(ctx *RequestContext, req *AWSRequest) (*AWS
 		SendMessageBatchResult result           `xml:"SendMessageBatchResult"`
 		ResponseMetadata       responseMetadata `xml:"ResponseMetadata"`
 	}
+	// HTTP 200 with failures present, as in the JSON branch.
 	return sqsXMLResponse(http.StatusOK, response{
-		Xmlns:                  "http://queue.amazonaws.com/doc/2012-11-05/",
-		SendMessageBatchResult: result{SendMessageBatchResultEntry: successesXML},
-		ResponseMetadata:       responseMetadata{RequestID: ctx.RequestID},
+		Xmlns: "http://queue.amazonaws.com/doc/2012-11-05/",
+		SendMessageBatchResult: result{
+			SendMessageBatchResultEntry: successesXML,
+			BatchResultErrorEntry:       failures,
+		},
+		ResponseMetadata: responseMetadata{RequestID: ctx.RequestID},
 	})
 }
 


### PR DESCRIPTION
Closes #472

## The gap

Substrate stored and returned every user-defined message attribute exactly as sent. So all of these were accepted and delivered:

- an **eleventh** attribute, past AWS's documented maximum of ten;
- a name real SQS reserves — `AWS.trace`, `.trace`, `trace.`, `trace..id`, `trace id`;
- a `DataType` that is not prefixed `String`, `Number` or `Binary`;
- a `String` attribute with no value;
- a **`Number` attribute holding `"abc"`**.

That last one is the shape this tracker exists to close. A consumer whose handler parses a `Number` attribute had no way to reach its parse-failure branch: substrate accepted the send, the attribute came back verbatim, and a test asserting the rejection passed while the same code broke against AWS.

## What now happens

`SendMessage` and each `SendMessageBatch` entry enforce the rules below, all as `InvalidParameterValue` / HTTP 400.

| Rule | Rejected |
|---|---|
| count | more than 10 attributes on one message |
| name length | 256 bytes or more |
| name characters | anything outside `A-Z`, `a-z`, `0-9`, `_`, `-`, `.` |
| reserved prefix | starting with `AWS.` or `Amazon.`, **any casing** |
| periods | a leading or trailing `.`, or two in sequence |
| type | a `DataType` not prefixed `String`, `Number` or `Binary`; an absent one |
| type length | 256 bytes or more |
| empty value | a `String` attribute with no value |
| `Number` value | not a decimal number, or outside −10^128 … 10^126 |

A rejected send **enqueues nothing**. On a FIFO queue the check runs before the deduplication ID is recorded, so a corrected retry reusing the same `MessageDeduplicationId` is delivered rather than swallowed as a duplicate — the same ordering #454's size check established, asserted rather than assumed to have survived.

Both length bounds are **exclusive**: 255 bytes is legal, 256 is not. The developer guide says "up to 256 characters" while the error text says "must be shorter than 256 Bytes"; the error is the more specific evidence, and the conflict is recorded in the code rather than quietly resolved.

## Three findings worth flagging

**1. The prefix check is case-INsensitive — the opposite of #468's `aws:` tag rule.** The guide says a name "can't start with `AWS.` or `Amazon.` (or any casing variations)", and LocalStack matches its regex against `name.lower()`. EC2's `aws:` tag prefix is case-*sensitive*, so `AWS:foo` remains a legal tag key (`ec2CheckReservedTagKeys`, #452/#468). Both findings are correct — the two services document different rules — and unifying the checks would break one of them. This is called out in the code, the CHANGELOG and `docs/services.md`, because a reader arriving from one will assume the other.

**2. Batch failures are per entry, at HTTP 200.** Substrate had **no `BatchResultErrorEntry` type at all** — both batch paths emitted an empty `Failed` placeholder — so a consumer's per-entry error handling had nothing to exercise, while the reference warns you "should check for batch errors even when the call returns an HTTP status code of `200`". An attribute violation now produces a `Failed` entry with `SenderFault: true`, does not enqueue, and leaves its siblings delivered. `Failed` is always present, empty rather than absent on full success. The XML element name comes from the query-protocol model, which declares `BatchResultErrorEntryList` flattened with `locationName: "BatchResultErrorEntry"` under `resultWrapper: "SendMessageBatchResult"`.

This is deliberately unlike the batch **size** checks ten lines away, which still fail the whole request with `BatchRequestTooLong`: the payload cap is a documented property of the aggregate the caller transmitted, while a malformed attribute is a defect in one entry. A test pins that the size behaviour did not become per-entry by accident.

**3. The provenance is better than planned, and the plan was wrong on one point.** The plan recorded that the 10-attribute rejection has "no capture anywhere". It does: [opentelemetry-java-instrumentation#13799](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13799) records live SQS returning `SqsException: Number of message attributes [11] exceeds the allowed maximum [10]. (Service: Sqs, Status Code: 400, Request ID: f5704601-…)` — an AWS Request ID and a 400. Likewise the `Number` cast failure turned out to be a real boto3 capture carrying **both** code and message, not substrate's own text.

Tiers, recorded per message in the file:

- **Real-AWS captures** — the count message; the `Number` cast failure (code *and* message); the empty-`String`-value message, captured twice independently.
- **Snapshot-tested reimplementation** — the name and type messages, from LocalStack. The character-class string is reproduced verbatim including its "upper and lower score characters" phrasing and its **trailing space**; a tidied string is no longer the one a consumer sees.
- **One reimplementation, the weakest claim here and labeled as such in the code** — the `Number` **range** message, which only elasticmq supplies.

The count rejection's *code* is absent from its capture and comes from agreement across five reimplementations. Neither moto nor LocalStack enforces the count at all, which is why substrate accepting an eleventh attribute went unnoticed until #461 made attributes observable.

## Scope decisions, stated rather than silent

- **Uniqueness is structural, not checked**: attributes arrive as a Go map keyed by name, so a duplicate cannot survive parsing to be rejected.
- **The empty-value rule is `String`-only**, following the one source that specifies a message for it. An empty `Binary` value is still accepted — which is what keeps `TestSQS_MessageAttributes_BinaryIsIdentifiedByDataType`'s transport-byte case reachable through the public API. Scoping this to the exact type rather than the base type was load-bearing; a mutation confirms the broader form breaks that test.
- **Scientific notation is accepted** (`1e5`) as the permissive reading of a detail no source settles, stated in the code rather than implied.
- **The character class follows the developer guide**, not LocalStack's wider regex admitting U+00C0..U+017F, which is unattributed.
- **The rules apply on send, not on receive.** A message written into state before they existed — replayed from an older event log — is returned as stored, because withholding it would make a recorded run unreplayable. A test writes an illegal name directly into state and asserts it is still delivered. Tracked separately.

Attributes are visited **in sorted name order** so a message breaking two rules always reports the same one; a walk over the Go map would report one error on some runs and the other on others, which is the precise nondeterminism this emulator exists to remove.

## Verification

- `gofmt -l .`, `go build ./...`, `go vet ./...` clean; `golangci-lint run ./...` → **0 issues**; `make test` (race) → exit 0; `make docs-reference docs-reference-check docs-versions` → exit 0; `go test -C test/e2e ./...` → ok; VitePress build → clean, so the new anchors resolve.
- **#461's 10-attribute boundary test still passes** — run, not assumed. Its doc comment said the count was unenforced and that enforcing it was "tracked separately"; that is now false, so it is reworded to describe the guard it has become.
- New file coverage: 100% on every function except the deliberately-unreachable scanner/parser divergence guard in `sqsCheckNumberAttribute`, which is documented as such.
- **24 mutations, all caught.** Highest-value ones: making the prefix check case-**sensitive** (18 tests fail); failing the whole batch instead of the entry, in each protocol branch; dropping the count check; an off-by-one rejecting at ten; hardcoding the count in its own message (the mistake one reimplementation actually made); dropping the sequential-period check; accepting anything as a `Number`; comparing the range through `float64`, where 10^126 is inexact; rejecting an empty `Binary` value too; reporting `SenderFault: false`; omitting `Failed` when empty; and moving the send check after the FIFO dedup record.

Docs: `docs/services.md` §"Message attributes" gains "Attribute rules", "Batch failures are per entry" and "Provenance" subsections, replacing the "Two limits are **not** enforced" paragraph; the SQS operation table rows for `SendMessage`/`SendMessageBatch` link to them.
