### PR TITLE
feat(ec2): read an instance's user data back with DescribeInstanceAttribute (#473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The rules apply on send, not on receive: a message written into state before they
   existed is still returned as stored, because withholding it would make a recorded run
   unreplayable. Tracked separately.
+- **`DescribeInstanceAttribute`** (#473), which is the only way to read an instance's
+  user data back. `RunInstances` recorded `UserData` and nothing could observe it, so a
+  consumer could not assert that the user data their IaC intended reached the instance —
+  and #453's launch-template `UserData` fallback could only ever be tested indirectly,
+  meaning it could regress with nothing observable changing. Four attributes are
+  readable, being the ones backed by state substrate holds: `userData` (returned as
+  stored, still base64), `instanceType`, `disableApiTermination`, and `groupSet` (the
+  same `groupSet>item` shape `DescribeInstances` reports, per #444). Scalars are wrapped
+  in a `<value>` element, as all three of the reference's worked examples show, and
+  exactly one attribute appears per response.
+
+  Every other name in AWS's valid-values list is **refused rather than defaulted**, with
+  `InvalidParameterValue`, HTTP 400, and `Value (enaSupport) for parameter attribute is
+  invalid. Unknown attribute.` Answering `sourceDestCheck` with a default `false` would
+  be indistinguishable from a real instance that has it disabled, and a consumer
+  asserting on it would get a green test built on a value substrate invented. This
+  message has the strongest provenance in the release: it is captured from real AWS in
+  [aws/aws-cli#4273](https://github.com/aws/aws-cli/issues/4273) and is byte-identical
+  to moto's string — a capture and an independent reimplementation agreeing. The
+  reference could not have supplied it, its Errors section being empty. `enaSupport` is
+  in AWS's own valid-values list while the same page says the attribute "is not
+  supported", and #4273 captures exactly that rejection, so refusing it is fidelity.
+
+  An attribute that was never set is reported as a **present but empty element**
+  (`<userData></userData>`), not an omitted one. This is the one shape the reference
+  cannot settle — all three examples show an attribute that has a value — so it ships
+  from moto's `test_describe_instance_attribute` asserting `response["UserData"] == {}`.
+  That is weaker provenance than a capture and is labelled as such in the code and the
+  docs, because the two shapes are not interchangeable: an SDK maps a present-but-empty
+  element to an empty struct and an omitted one to nil, so `resp.UserData.Value` panics
+  under one and not the other.
+
+  `ModifyInstanceAttribute` gained `UserData.Value` and `DisableApiTermination.Value`
+  alongside the existing `InstanceType.Value`, and its errors now match the reference's
+  wording for a missing or unknown instance instead of substrate's own. `UserData.Value`
+  is presence-checked rather than non-empty-checked, so clearing an instance's user data
+  is expressible.
+
+  **`ModifyInstanceAttribute` now requires a `stopped` instance for `userData` and
+  `instanceType`, where changing a running instance's type previously succeeded** — a new
+  rejection on a path that worked before, so a test asserting the old behavior will now
+  see `IncorrectInstanceState`, HTTP 400. The reference's Example 1 states it plainly
+  ("The instance must be in the `stopped` state"), and the client-error table names user
+  data as the same rule's worked example; the code is documented while the message text
+  is substrate's own. `disableApiTermination` is deliberately exempt, because
+  `RunInstances` documents that termination protection can be enabled "when you launch an
+  instance, while the instance is running, or while the instance is stopped" — gating it
+  would refuse a call real EC2 accepts, which is the same defect in the other direction.
+  Termination protection is recorded and reported but not acted on: `TerminateInstances`
+  still terminates a protected instance, which is tracked separately.
 - `make tag-releases-check` (`scripts/check-tag-releases.sh`) fails if a published
   `vX.Y.Z` tag has no GitHub Release behind it, run daily by the new `Release Audit`
   workflow. Pushing a tag does not create a Release and nothing asserted otherwise,

--- a/docs/services.md
+++ b/docs/services.md
@@ -1308,6 +1308,8 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StartInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeInstanceStatus | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeInstanceAttribute | Four attributes, `<value>`-wrapped — see [Instance attributes](#instance-attributes) |
+| ModifyInstanceAttribute | `InstanceType.Value`, `UserData.Value`, `DisableApiTermination.Value`; the first two [require a stopped instance](#instance-attributes) |
 | CreateVpc | |
 | DescribeVpcs | [Explicit resource IDs](#explicit-resource-ids) |
 | DeleteVpc | [Explicit resource IDs](#explicit-resource-ids) |
@@ -1572,6 +1574,121 @@ source supplied them:
 the group is deleted while the instance it was launched with still exists. The
 `groupId` is still reported, because that is what the launch actually recorded; a
 name is not invented to fill the field.
+
+### Instance attributes
+
+`DescribeInstanceAttribute` reads one attribute off an instance. It is the only way
+to read an instance's **user data** back: `RunInstances` recorded `UserData` and
+nothing could observe it, so a consumer could not assert that the user data their IaC
+intended reached the instance — including the value a
+[launch template supplied](#a-launch-template-merges-with-the-request-field-by-field).
+
+Four attributes are readable, being the ones that correspond to state substrate holds:
+
+| `Attribute` | Reports |
+|---|---|
+| `userData` | The value as stored, still base64-encoded |
+| `instanceType` | |
+| `disableApiTermination` | `true` or `false`; recorded at launch and by `ModifyInstanceAttribute` |
+| `groupSet` | `groupSet>item` with `groupId`/`groupName`, the same shape [`DescribeInstances` reports](#security-groups-on-an-instance) |
+
+Scalar values are **wrapped in a `<value>` element**, which all three of the
+reference's worked examples show and which matches the `AttributeValue` type the
+response elements carry:
+
+```xml
+<DescribeInstanceAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+  <instanceId>i-0123456789abcdef0</instanceId>
+  <instanceType><value>t3.micro</value></instanceType>
+</DescribeInstanceAttributeResponse>
+```
+
+Exactly one attribute appears per response — the one asked for. `groupSet` is the
+exception to the wrapper: it is an array of `GroupIdentifier`, not an `AttributeValue`.
+
+`Attribute` is **Required: Yes**, so an absent one fails with `MissingParameter`
+(`The request must contain the parameter Attribute`). An unknown instance ID fails
+with `InvalidInstanceID.NotFound`, and a malformed one with `InvalidInstanceID.Malformed`,
+as [everywhere else](#explicit-resource-ids).
+
+#### Unmodelled attributes are refused, not defaulted
+
+Every other name in the documented valid-values list — `kernel`, `ramdisk`,
+`sourceDestCheck`, `blockDeviceMapping`, `productCodes`, `ebsOptimized`,
+`rootDeviceName`, `sriovNetSupport`, `enaSupport`, `enclaveOptions`,
+`instanceInitiatedShutdownBehavior`, `disableApiStop` — is rejected:
+
+```
+InvalidParameterValue: Value (enaSupport) for parameter attribute is invalid. Unknown attribute.
+```
+
+The status is `400`, and the offending value is interpolated. Refusing is deliberate
+rather than a gap: answering `sourceDestCheck` with a default `false` would be
+indistinguishable from a real instance that has it disabled, and a consumer asserting
+on it would get a green test built on a value substrate invented.
+
+This message has the strongest provenance of any in the EC2 plugin. It is **captured
+from real AWS** in [aws/aws-cli#4273](https://github.com/aws/aws-cli/issues/4273),
+where `aws ec2 describe-instance-attribute --attribute enaSupport` returns exactly it,
+and it is byte-identical to [moto](https://github.com/getmoto/moto)'s string — a
+capture and an independent reimplementation agreeing. The reference could not have
+supplied it: `DescribeInstanceAttribute`'s Errors section is empty.
+
+`enaSupport` is the case that makes the boundary concrete. It is *in* AWS's own valid-values
+list, and the same reference says "Note that the `enaSupport` attribute is not supported."
+Real AWS rejects a value its documentation lists, and #4273 is the capture of that
+rejection — so substrate rejecting it is fidelity rather than a shortfall.
+
+Attribute names are matched **case-sensitively**, as AWS's valid values are: `InstanceType`
+is rejected, `instanceType` is not.
+
+#### An attribute that was never set
+
+An unset attribute is reported as a **present but empty element** — `<userData></userData>`
+— rather than an omitted one. An empty `groupSet` likewise appears, empty.
+
+This is the one shape here the reference cannot settle: all three of its worked examples
+show an attribute that *has* a value. It ships from moto's `test_describe_instance_attribute`,
+which asserts `response["UserData"] == {}` — an empty mapping, which is what an SDK
+produces from a present element with no children. That is **weaker provenance than a
+capture**, and worth stating, because the two shapes are not interchangeable to a caller:
+an SDK maps a present-but-empty element to an empty struct and an omitted one to nil, so
+`resp.UserData.Value` panics under one and not the other.
+
+#### Modifying an attribute requires a stopped instance
+
+`ModifyInstanceAttribute` writes `InstanceType.Value`, `UserData.Value` and
+`DisableApiTermination.Value`. The first two require the instance to be `stopped`:
+
+```
+IncorrectInstanceState: The instance 'userData' attribute cannot be modified while the
+instance is in the 'running' state; stop the instance first
+```
+
+The status is `400`. The **code** is documented — EC2's client-error table lists
+`IncorrectInstanceState` as "some instance attributes, such as user data, can only be
+modified if the instance is in a 'stopped' state" — while the **message text is
+substrate's own**, since the table describes the condition rather than quoting the
+string AWS sends, and no capture of this rejection was found.
+
+This is a behaviour change for `instanceType`, which substrate previously changed on a
+running instance. `ModifyInstanceAttribute`'s Example 1 states the requirement plainly:
+"The instance must be in the `stopped` state." A test that asserted the old behaviour
+will now see a `400`.
+
+`disableApiTermination` is deliberately **exempt** from the gate, because `RunInstances`'
+reference says so: "You can enable termination protection when you launch an instance,
+while the instance is running, or while the instance is stopped." Gating it would refuse
+a call real EC2 accepts — the same class of defect as accepting one real EC2 refuses,
+just harder to notice, since it looks like extra rigor.
+
+`UserData.Value` is read with a presence check rather than a non-empty one, so clearing
+an instance's user data is expressible: `UserData.Value=` on a stopped instance empties
+it, and the attribute then reads back as the empty element above.
+
+Termination protection is **recorded and reported but not acted on**: `TerminateInstances`
+still terminates a protected instance, where real EC2 refuses with `OperationNotPermitted`.
+That is tracked separately.
 
 ### MinCount and MaxCount
 

--- a/emulator/ec2_instanceattribute.go
+++ b/emulator/ec2_instanceattribute.go
@@ -1,0 +1,286 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// EC2 instance attributes, per DescribeInstanceAttribute's documented Valid Values:
+//
+//	instanceType | kernel | ramdisk | userData | disableApiTermination |
+//	instanceInitiatedShutdownBehavior | rootDeviceName | blockDeviceMapping |
+//	productCodes | sourceDestCheck | groupSet | ebsOptimized | sriovNetSupport |
+//	enaSupport | enclaveOptions | disableApiStop
+//
+// Substrate reads the four that correspond to state it actually holds. The rest are
+// deliberately rejected rather than answered with a default: reporting
+// sourceDestCheck as false, say, would be indistinguishable from a real instance
+// that has it disabled, and a consumer asserting on it would get a green test built
+// on a value substrate invented. An error is the honest answer, and it is the same
+// error real EC2 gives for a name it does not accept.
+//
+// enaSupport is the case that makes this concrete. It is in the Valid Values list,
+// and the reference still says "Note that the enaSupport attribute is not
+// supported." — real AWS rejects a value its own documentation lists. Substrate
+// rejecting it is fidelity rather than a gap.
+const (
+	ec2AttrUserData              = "userData"
+	ec2AttrInstanceType          = "instanceType"
+	ec2AttrGroupSet              = "groupSet"
+	ec2AttrDisableAPITermination = "disableApiTermination"
+)
+
+// ec2InstanceAttributeXML is one DescribeInstanceAttribute response.
+//
+// Every scalar attribute is wrapped in a <value> element rather than emitted
+// directly — <instanceType><value>t1.micro</value></instanceType> — which all three
+// of the reference's worked examples show and which matches the AttributeValue shape
+// the response elements are typed as. An SDK unmarshals the wrapper into a struct
+// with a Value field, so flattening it would leave every field nil.
+//
+// The attribute fields are pointers so that exactly one appears per response: AWS
+// returns only the attribute that was asked for, and an empty non-pointer struct
+// would still marshal its element. The distinction matters for the attribute that
+// was never set — see [ec2AttributeValueXML].
+type ec2InstanceAttributeXML struct {
+	XMLName    xml.Name `xml:"DescribeInstanceAttributeResponse"`
+	XMLNS      string   `xml:"xmlns,attr"`
+	RequestID  string   `xml:"requestId,omitempty"`
+	InstanceID string   `xml:"instanceId"`
+
+	UserData     *ec2AttributeValueXML `xml:"userData,omitempty"`
+	InstanceType *ec2AttributeValueXML `xml:"instanceType,omitempty"`
+
+	// DisableAPITermination carries the wire name disableApiTermination; the Go
+	// field follows the initialism convention the linter enforces.
+	DisableAPITermination *ec2AttributeValueXML `xml:"disableApiTermination,omitempty"`
+
+	// Groups is an Array of GroupIdentifier, not an AttributeValue — the one
+	// supported attribute that is not <value>-wrapped, per the response elements.
+	//
+	// It is a pointer to a wrapper struct rather than a plain []ec2GroupItem with a
+	// `groupSet>item` path, because encoding/xml emits the *parent* element of such a
+	// path even when the slice is empty: every response would carry a stray
+	// <groupSet></groupSet>, and a caller asking for userData would be told the
+	// instance has no security groups. A nil pointer is skipped outright.
+	Groups *ec2GroupSetXML `xml:"groupSet,omitempty"`
+}
+
+// ec2GroupSetXML wraps the groupSet items so the element can be omitted entirely.
+//
+// It reuses [ec2GroupItem] so this response cannot drift from the groupSet that
+// RunInstances and DescribeInstances report (#444).
+type ec2GroupSetXML struct {
+	Items []ec2GroupItem `xml:"item"`
+}
+
+// ec2AttributeValueXML is AWS's AttributeValue: a single <value> child.
+//
+// An attribute that was never set is reported as a present-but-empty element —
+// <userData/> — rather than an omitted one. The reference cannot settle this: all
+// three of its examples show an attribute that *has* a value. The shape comes from
+// moto's test_describe_instance_attribute, which asserts `response["UserData"] ==
+// {}` against its reimplementation — an empty mapping, which is what an SDK produces
+// from a present element with no children. That is weaker provenance than a capture,
+// and it is worth stating because the two shapes are not interchangeable to a
+// caller: an SDK maps a present-but-empty element to an empty struct and an omitted
+// one to nil, so `resp.UserData.Value` panics under one and not the other.
+type ec2AttributeValueXML struct {
+	Value string `xml:"value,omitempty"`
+}
+
+// describeInstanceAttribute handles DescribeInstanceAttribute.
+//
+// This is the only operation that reads an instance's user data back. Substrate
+// recorded UserData at launch, and #453 made a launch template's user data reach the
+// instance, but nothing could observe either: the field was write-only, so a
+// consumer could not assert that the user data their IaC intended arrived, and
+// #453's fallback was only ever tested indirectly (#473).
+//
+// Per CLAUDE.md's boundary, this reports recorded intent. Substrate does not execute
+// user data or cloud-init, and reporting the value back is exactly the observable
+// half of it.
+func (p *EC2Plugin) describeInstanceAttribute(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	instID := req.Params["InstanceId"]
+	if instID == "" {
+		return nil, ec2MissingParameter("InstanceId")
+	}
+	// Attribute is Required: Yes on this operation, unlike on
+	// ModifyInstanceAttribute where the .Value suffix carries the selection.
+	attr := req.Params["Attribute"]
+	if attr == "" {
+		return nil, ec2MissingParameter("Attribute")
+	}
+
+	// The attribute name is validated before the instance is looked up, so a
+	// request that is wrong in both ways reports the attribute: the instance ID
+	// might be a legitimate not-yet-propagated ID, while an unsupported attribute
+	// name is a defect in the request that no amount of retrying fixes.
+	if !ec2AttributeSupported(attr) {
+		return nil, ec2UnknownInstanceAttribute(attr)
+	}
+
+	inst, awsErr, err := p.loadInstance(reqCtx, instID, "describeInstanceAttribute")
+	if err != nil || awsErr != nil {
+		return nil, errOrAWS(err, awsErr)
+	}
+
+	resp := ec2InstanceAttributeXML{
+		XMLNS:      "http://ec2.amazonaws.com/doc/2016-11-15/",
+		InstanceID: inst.InstanceID,
+	}
+	switch attr {
+	case ec2AttrUserData:
+		// Already base64 as stored: RunInstances' UserData parameter is documented
+		// as base64-encoded on the way in ("User data must be base64-encoded"), and
+		// substrate stores the parameter verbatim. Re-encoding here would double it.
+		resp.UserData = &ec2AttributeValueXML{Value: inst.UserData}
+	case ec2AttrInstanceType:
+		resp.InstanceType = &ec2AttributeValueXML{Value: inst.InstanceType}
+	case ec2AttrDisableAPITermination:
+		resp.DisableAPITermination = &ec2AttributeValueXML{
+			Value: fmt.Sprintf("%t", inst.DisableAPITermination),
+		}
+	case ec2AttrGroupSet:
+		// Always a present element, empty when the instance has no groups, for the
+		// same reason an unset userData is present: an SDK distinguishes an empty
+		// array from a nil one.
+		resp.Groups = &ec2GroupSetXML{Items: p.ec2GroupItems(reqCtx, inst.SecurityGroupIDs)}
+	}
+	return ec2XMLResponse(http.StatusOK, resp)
+}
+
+// ec2AttributeSupported reports whether substrate can read attr off stored state.
+func ec2AttributeSupported(attr string) bool {
+	switch attr {
+	case ec2AttrUserData, ec2AttrInstanceType, ec2AttrGroupSet, ec2AttrDisableAPITermination:
+		return true
+	default:
+		return false
+	}
+}
+
+// ec2UnknownInstanceAttribute returns the error EC2 raises for an attribute name it
+// will not answer.
+//
+// This is the strongest message provenance in the release: the wording is captured
+// from real AWS in aws/aws-cli#4273, where `aws ec2 describe-instance-attribute
+// --attribute enaSupport` returns it, and it is byte-identical to moto's string — an
+// independent reimplementation and a capture agreeing. The offending value is
+// interpolated, as the capture does.
+//
+// DescribeInstanceAttribute's own Errors section is empty (it points only at the
+// common error types), so the doc could not have supplied this.
+func ec2UnknownInstanceAttribute(attr string) *AWSError {
+	return &AWSError{
+		Code:       "InvalidParameterValue",
+		Message:    "Value (" + attr + ") for parameter attribute is invalid. Unknown attribute.",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2ModifiableWhenStopped names the attributes whose modification requires a
+// stopped instance, mapped to the ModifyInstanceAttribute parameter that sets each.
+//
+// ModifyInstanceAttribute's reference states the rule generally — "To modify some
+// attributes, the instance must be stopped" — and names which in two places: Example
+// 1, on instanceType, says "The instance must be in the stopped state", and the
+// client-error table's IncorrectInstanceState entry says "some instance attributes,
+// such as user data, can only be modified if the instance is in a 'stopped' state".
+//
+// disableApiTermination is deliberately absent. RunInstances' reference says it
+// plainly: "You can enable termination protection when you launch an instance, while
+// the instance is running, or while the instance is stopped." Gating it would refuse
+// a call real EC2 accepts, which is the same class of defect as accepting one real
+// EC2 refuses.
+var ec2ModifiableWhenStopped = map[string]string{
+	ec2AttrUserData:     "UserData.Value",
+	ec2AttrInstanceType: "InstanceType.Value",
+}
+
+// ec2IncorrectInstanceState returns the error for modifying a stopped-only attribute
+// on an instance that is not stopped.
+//
+// The code is documented — EC2's client-error table lists IncorrectInstanceState with
+// user data as its worked example — while the message text is substrate's own: the
+// table gives a description of the condition, not the string AWS sends, and no
+// capture of this particular rejection was found. The attribute and the state are
+// interpolated because they are the two facts a caller needs to act, and neither is
+// recoverable from the code alone.
+func ec2IncorrectInstanceState(attr, state string) *AWSError {
+	return &AWSError{
+		Code: "IncorrectInstanceState",
+		Message: "The instance '" + attr + "' attribute cannot be modified while the instance is in the '" +
+			state + "' state; stop the instance first",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// loadInstance reads one instance out of state, returning the AWS error for an ID
+// that is malformed or names nothing.
+//
+// The two error returns are separate because they mean different things to the
+// caller: err is an internal failure to wrap, while awsErr is a response to send.
+// op names the calling operation in the wrapped error.
+func (p *EC2Plugin) loadInstance(reqCtx *RequestContext, instID, op string) (*EC2Instance, *AWSError, error) {
+	stateKey := "instance:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + instID
+	data, err := p.state.Get(context.Background(), ec2Namespace, stateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ec2 %s get: %w", op, err)
+	}
+	switch {
+	case !ec2InstanceIDKind.wellFormed(instID):
+		return nil, ec2InstanceIDKind.malformedError(instID), nil
+	case data == nil:
+		return nil, ec2InstanceIDKind.notFoundError(instID), nil
+	}
+	var inst EC2Instance
+	if err := json.Unmarshal(data, &inst); err != nil {
+		return nil, nil, fmt.Errorf("ec2 %s unmarshal: %w", op, err)
+	}
+	return &inst, nil, nil
+}
+
+// errOrAWS collapses [EC2Plugin.loadInstance]'s two error returns into the single
+// error a handler returns, preferring the internal failure.
+//
+// A typed-nil *AWSError returned directly as an error interface is non-nil, which is
+// the bug this exists to prevent: `return nil, awsErr` on a nil awsErr would send an
+// empty error response instead of the success the caller earned.
+func errOrAWS(err error, awsErr *AWSError) error {
+	if err != nil {
+		return err
+	}
+	if awsErr != nil {
+		return awsErr
+	}
+	return nil
+}
+
+// ec2AttributeModificationState reports the attribute a request means to modify and
+// whether the instance's state permits it.
+//
+// It returns the attribute name for the first stopped-only parameter present in the
+// request, so the check runs on the same one the apply step will act on. AWS allows
+// only one attribute per call ("You can specify only one attribute at a time"), so
+// the iteration order over a request naming two is not a behavior substrate needs to
+// define — but the map is walked in a fixed order anyway, since a nondeterministic
+// error from a fixed request is the opposite of what this emulator is for.
+func ec2AttributeModificationState(params map[string]string) string {
+	for _, attr := range []string{ec2AttrUserData, ec2AttrInstanceType} {
+		if _, ok := params[ec2ModifiableWhenStopped[attr]]; ok {
+			return attr
+		}
+	}
+	return ""
+}
+
+// ec2InstanceStopped reports whether an instance is in the state a stopped-only
+// attribute modification requires.
+func ec2InstanceStopped(inst *EC2Instance) bool {
+	return strings.EqualFold(inst.State.Name, "stopped")
+}

--- a/emulator/ec2_instanceattribute_test.go
+++ b/emulator/ec2_instanceattribute_test.go
@@ -1,0 +1,601 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// instanceAttribute is a decoded DescribeInstanceAttribute response.
+//
+// Every attribute field is a pointer so the tests can tell an *absent* element from
+// a present-but-empty one. That distinction is the whole of #473's hardest
+// acceptance criterion: an SDK maps <userData/> to an empty struct and an omitted
+// userData to nil, and a consumer's assertion differs between them. A value-typed
+// field would decode both to the same zero and the criterion would be untestable.
+type instanceAttribute struct {
+	XMLName    xml.Name `xml:"DescribeInstanceAttributeResponse"`
+	InstanceID string   `xml:"instanceId"`
+
+	UserData     *attrValue `xml:"userData"`
+	InstanceType *attrValue `xml:"instanceType"`
+	DisableAPI   *attrValue `xml:"disableApiTermination"`
+
+	Groups []struct {
+		GroupID   string `xml:"groupId"`
+		GroupName string `xml:"groupName"`
+	} `xml:"groupSet>item"`
+}
+
+// attrValue is AWS's AttributeValue wrapper: a single <value> child.
+type attrValue struct {
+	Value string `xml:"value"`
+}
+
+// describeInstanceAttribute reads one attribute off an instance, requiring 200.
+func describeInstanceAttribute(t *testing.T, ts *httptest.Server, instID, attr string) instanceAttribute {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":     "DescribeInstanceAttribute",
+		"InstanceId": instID,
+		"Attribute":  attr,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"DescribeInstanceAttribute(%s) must succeed", attr)
+	var out instanceAttribute
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	return out
+}
+
+// modifyInstanceAttribute sends ModifyInstanceAttribute and returns the status.
+func modifyInstanceAttribute(t *testing.T, ts *httptest.Server, params map[string]string) int {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	return resp.StatusCode
+}
+
+// stopInstance moves an instance to the stopped state, which is what the gated
+// attribute modifications require.
+func stopInstance(t *testing.T, ts *httptest.Server, instID string) {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "StopInstances", "InstanceId.1": instID,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "StopInstances must succeed")
+}
+
+// TestEC2_InstanceAttribute_UserData is #473's reason for existing: RunInstances
+// recorded UserData and nothing could read it back, so a consumer could not assert
+// that the user data their IaC intended reached the instance.
+//
+// The value is asserted as the exact base64 string the launch sent, not a decoded
+// form: AWS documents UserData as base64-encoded on the way in ("User data must be
+// base64-encoded"), and substrate stores the parameter verbatim, so re-encoding on
+// read would double it. A test asserting the decoded plaintext would pass against
+// that bug.
+func TestEC2_InstanceAttribute_UserData(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("#!/bin/bash\necho hello\n"))
+	id := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro", "UserData": encoded,
+	})
+
+	got := describeInstanceAttribute(t, ts, id, "userData")
+	require.NotNil(t, got.UserData, "userData must be present")
+	assert.Equal(t, encoded, got.UserData.Value,
+		"the recorded value is returned as stored, still base64")
+	assert.Equal(t, id, got.InstanceID, "the response names the instance")
+
+	// Only the attribute asked for comes back. AWS returns one attribute per call,
+	// so a response carrying instanceType alongside userData would be wrong even
+	// though every value in it is right.
+	assert.Nil(t, got.InstanceType, "instanceType must not appear in a userData response")
+	assert.Nil(t, got.DisableAPI, "disableApiTermination must not appear either")
+}
+
+// TestEC2_InstanceAttribute_UserDataFromLaunchTemplate is the assertion #473 exists
+// to make possible, and the regression guard on #453's UserData fallback.
+//
+// Before DescribeInstanceAttribute the fallback was only ever tested indirectly,
+// which means it could have regressed silently: nothing observable would change.
+func TestEC2_InstanceAttribute_UserDataFromLaunchTemplate(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("from-the-template"))
+	ltID := createLaunchTemplate(t, ts, "lt-userdata", map[string]string{
+		"LaunchTemplateData.ImageId":      "ami-tmpl",
+		"LaunchTemplateData.InstanceType": "t3.small",
+		"LaunchTemplateData.UserData":     encoded,
+	})
+
+	id := runInstance(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateId": ltID,
+	})
+
+	got := describeInstanceAttribute(t, ts, id, "userData")
+	require.NotNil(t, got.UserData)
+	assert.Equal(t, encoded, got.UserData.Value,
+		"a launch that took its UserData from a template reports the template's value")
+}
+
+// TestEC2_InstanceAttribute_RequestBeatsTemplate pins that the read reports what the
+// launch actually resolved rather than either source unconditionally. The request
+// wins, per the RunInstances rule that "any additional parameters that you specify
+// for the new instance overwrite the corresponding parameters included in the launch
+// template".
+func TestEC2_InstanceAttribute_RequestBeatsTemplate(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	tmpl := base64.StdEncoding.EncodeToString([]byte("template"))
+	req := base64.StdEncoding.EncodeToString([]byte("request"))
+	ltID := createLaunchTemplate(t, ts, "lt-userdata-override", map[string]string{
+		"LaunchTemplateData.ImageId":  "ami-tmpl",
+		"LaunchTemplateData.UserData": tmpl,
+	})
+
+	id := runInstance(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateId": ltID,
+		"UserData":                        req,
+	})
+
+	got := describeInstanceAttribute(t, ts, id, "userData")
+	require.NotNil(t, got.UserData)
+	assert.Equal(t, req, got.UserData.Value, "the request's UserData wins over the template's")
+}
+
+// TestEC2_InstanceAttribute_UnsetIsPresentButEmpty covers the criterion the
+// reference cannot settle. All three of its worked examples show an attribute that
+// *has* a value, so the unset shape comes from moto's
+// test_describe_instance_attribute, which asserts `response["UserData"] == {}` — an
+// empty mapping, i.e. a present element with no children.
+//
+// Both halves are asserted, because they fail differently: an omitted element
+// decodes to a nil pointer (and gives an SDK caller a nil deref on .Value), while a
+// present element carrying a fabricated value would be worse still.
+func TestEC2_InstanceAttribute_UnsetIsPresentButEmpty(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	id := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+	})
+
+	got := describeInstanceAttribute(t, ts, id, "userData")
+	require.NotNil(t, got.UserData,
+		"an unset userData is a present element, not an omitted one")
+	assert.Empty(t, got.UserData.Value, "and it carries no value")
+}
+
+// TestEC2_InstanceAttribute_SupportedAttributes round-trips the three attributes
+// besides userData that read state substrate already holds.
+func TestEC2_InstanceAttribute_SupportedAttributes(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	vpcID := createVPC(t, ts, "10.9.0.0/16")
+	sgID := createSecurityGroup(t, ts, vpcID, "attr-sg")
+	subnetID := createSubnet(t, ts, vpcID, "10.9.1.0/24")
+
+	id := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.large",
+		"SubnetId": subnetID, "SecurityGroupId.1": sgID,
+		"DisableApiTermination": "true",
+	})
+
+	t.Run("instanceType", func(t *testing.T) {
+		got := describeInstanceAttribute(t, ts, id, "instanceType")
+		require.NotNil(t, got.InstanceType)
+		assert.Equal(t, "t3.large", got.InstanceType.Value)
+	})
+
+	t.Run("disableApiTermination", func(t *testing.T) {
+		got := describeInstanceAttribute(t, ts, id, "disableApiTermination")
+		require.NotNil(t, got.DisableAPI)
+		assert.Equal(t, "true", got.DisableAPI.Value,
+			"the launch-time DisableApiTermination is recorded and reported")
+	})
+
+	t.Run("groupSet is an array, not a value wrapper", func(t *testing.T) {
+		got := describeInstanceAttribute(t, ts, id, "groupSet")
+		require.Len(t, got.Groups, 1,
+			"groupSet is an Array of GroupIdentifier, so it decodes from groupSet>item")
+		assert.Equal(t, sgID, got.Groups[0].GroupID)
+		assert.Equal(t, "attr-sg", got.Groups[0].GroupName)
+	})
+}
+
+// TestEC2_InstanceAttribute_DisableAPITerminationDefaultsFalse pins the documented
+// default. It is the zero value, so an instance from an event log written before the
+// field existed also reads back this way.
+func TestEC2_InstanceAttribute_DisableAPITerminationDefaultsFalse(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+
+	got := describeInstanceAttribute(t, ts, id, "disableApiTermination")
+	require.NotNil(t, got.DisableAPI)
+	assert.Equal(t, "false", got.DisableAPI.Value,
+		"AWS documents the default as false, and it is reported rather than omitted")
+}
+
+// TestEC2_InstanceAttribute_UnknownAttribute covers the strongest message provenance
+// in this change: the wording is captured from real AWS in aws/aws-cli#4273 and is
+// byte-identical to moto's string.
+//
+// enaSupport is the row that matters most. It is in DescribeInstanceAttribute's own
+// Valid Values list, and the same reference says "Note that the enaSupport attribute
+// is not supported." — #4273 captures real AWS rejecting exactly it. Substrate
+// refusing a value AWS's own docs list is fidelity, not a gap, and a reader who
+// checks only the valid-values list would "fix" this into a regression.
+func TestEC2_InstanceAttribute_UnknownAttribute(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+
+	for _, attr := range []string{
+		"enaSupport", // listed by AWS, rejected by AWS
+		"abc",        // not an attribute at all
+		"kernel",     // listed, and unmodelled by substrate
+		"sourceDestCheck",
+		"blockDeviceMapping",
+		"InstanceType", // valid name in the wrong case — the values are case-sensitive
+	} {
+		t.Run(attr, func(t *testing.T) {
+			status, code, msg := ec2ErrorDetail(t, ts, map[string]string{
+				"Action": "DescribeInstanceAttribute", "InstanceId": id, "Attribute": attr,
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Equal(t,
+				"Value ("+attr+") for parameter attribute is invalid. Unknown attribute.",
+				msg, "the message interpolates the offending value, as the capture does")
+		})
+	}
+}
+
+// TestEC2_InstanceAttribute_AttributeCheckedBeforeInstance pins the ordering: a
+// request that is wrong in both ways reports the attribute.
+//
+// The reasoning is the same one #472's send path uses. A not-found instance ID can be
+// a legitimately not-yet-propagated one — AWS's own InvalidInstanceID.NotFound
+// description says so — and is worth retrying; an unsupported attribute name is a
+// defect in the request that no retry fixes.
+func TestEC2_InstanceAttribute_AttributeCheckedBeforeInstance(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action": "DescribeInstanceAttribute",
+		// Well-formed, so it reaches the not-found branch rather than the malformed one.
+		"InstanceId": "i-0123456789abcdef0",
+		"Attribute":  "enaSupport",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code,
+		"the unsupported attribute is reported, not the missing instance")
+}
+
+// TestEC2_InstanceAttribute_RequiredParameters covers the two parameters the
+// reference marks Required: Yes, and the instance-ID errors.
+//
+// Attribute being required is the difference from ModifyInstanceAttribute, where it
+// is Required: No because the .Value parameter suffix carries the selection. Getting
+// that backwards would make an attribute-less describe return some default.
+func TestEC2_InstanceAttribute_RequiredParameters(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		code   string
+		msg    string
+	}{
+		{
+			name:   "absent Attribute",
+			params: map[string]string{"InstanceId": id},
+			code:   "MissingParameter",
+			msg:    "The request must contain the parameter Attribute",
+		},
+		{
+			name:   "absent InstanceId",
+			params: map[string]string{"Attribute": "userData"},
+			code:   "MissingParameter",
+			msg:    "The request must contain the parameter InstanceId",
+		},
+		{
+			name:   "unknown instance",
+			params: map[string]string{"InstanceId": "i-0123456789abcdef0", "Attribute": "userData"},
+			code:   "InvalidInstanceID.NotFound",
+			msg:    "The instance ID 'i-0123456789abcdef0' does not exist",
+		},
+		{
+			name:   "malformed instance ID",
+			params: map[string]string{"InstanceId": "not-an-id", "Attribute": "userData"},
+			code:   "InvalidInstanceID.Malformed",
+			msg:    `Invalid id: "not-an-id"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"Action": "DescribeInstanceAttribute"}
+			for k, v := range tt.params {
+				params[k] = v
+			}
+			status, code, msg := ec2ErrorDetail(t, ts, params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tt.code, code)
+			assert.Equal(t, tt.msg, msg)
+		})
+	}
+}
+
+// TestEC2_InstanceAttribute_ModifyUserData covers ModifyInstanceAttribute for
+// userData on a stopped instance, which is how a consumer changes user data.
+func TestEC2_InstanceAttribute_ModifyUserData(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	first := base64.StdEncoding.EncodeToString([]byte("first"))
+	second := base64.StdEncoding.EncodeToString([]byte("second"))
+	id := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro", "UserData": first,
+	})
+	stopInstance(t, ts, id)
+
+	status := modifyInstanceAttribute(t, ts, map[string]string{
+		"Action": "ModifyInstanceAttribute", "InstanceId": id, "UserData.Value": second,
+	})
+	require.Equal(t, http.StatusOK, status)
+
+	got := describeInstanceAttribute(t, ts, id, "userData")
+	require.NotNil(t, got.UserData)
+	assert.Equal(t, second, got.UserData.Value, "the modified value reads back")
+}
+
+// TestEC2_InstanceAttribute_ModifyUserDataCanClear pins that an empty UserData.Value
+// clears the value rather than being read as "unchanged".
+//
+// AWS's SecureBlobAttributeValue carries whatever the caller sends, including
+// nothing, so a presence check is required where the pre-existing InstanceType.Value
+// read uses a non-empty one. Treating "" as unchanged would make a deliberate clear a
+// silent no-op — the same silent-success shape this tracker exists to close.
+func TestEC2_InstanceAttribute_ModifyUserDataCanClear(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	id := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"UserData": base64.StdEncoding.EncodeToString([]byte("to-be-cleared")),
+	})
+	stopInstance(t, ts, id)
+
+	status := modifyInstanceAttribute(t, ts, map[string]string{
+		"Action": "ModifyInstanceAttribute", "InstanceId": id, "UserData.Value": "",
+	})
+	require.Equal(t, http.StatusOK, status)
+
+	got := describeInstanceAttribute(t, ts, id, "userData")
+	require.NotNil(t, got.UserData, "a cleared attribute is still a present element")
+	assert.Empty(t, got.UserData.Value, "the value is gone, not left as it was")
+}
+
+// TestEC2_InstanceAttribute_ModifyRequiresStopped is the behavior change, asserted
+// deliberately: substrate used to change the user data or the type of a *running*
+// instance, which real EC2 refuses.
+//
+// The value is re-read after each rejection, because a 400 that had already written
+// state would be worse than no check at all — the caller would see an error and the
+// change would have happened anyway.
+func TestEC2_InstanceAttribute_ModifyRequiresStopped(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		param string
+		value string
+		attr  string
+		read  string
+	}{
+		{
+			name: "userData", param: "UserData.Value", attr: "userData",
+			value: base64.StdEncoding.EncodeToString([]byte("new")), read: "userData",
+		},
+		{
+			name: "instanceType", param: "InstanceType.Value", attr: "instanceType",
+			value: "t3.2xlarge", read: "instanceType",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+
+			original := base64.StdEncoding.EncodeToString([]byte("original"))
+			id := runInstance(t, ts, map[string]string{
+				"ImageId": "ami-1", "InstanceType": "t3.micro", "UserData": original,
+			})
+
+			status, code, msg := ec2ErrorDetail(t, ts, map[string]string{
+				"Action": "ModifyInstanceAttribute", "InstanceId": id, tt.param: tt.value,
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "IncorrectInstanceState", code)
+			assert.Contains(t, msg, tt.attr, "the message names the attribute")
+			assert.Contains(t, msg, "running", "and the state that blocked it")
+
+			// Nothing changed.
+			got := describeInstanceAttribute(t, ts, id, tt.read)
+			switch tt.read {
+			case "userData":
+				require.NotNil(t, got.UserData)
+				assert.Equal(t, original, got.UserData.Value, "the refused change did not land")
+			case "instanceType":
+				require.NotNil(t, got.InstanceType)
+				assert.Equal(t, "t3.micro", got.InstanceType.Value, "the refused change did not land")
+			}
+
+			// And the same call succeeds once the instance is stopped, which is what
+			// makes this a state gate rather than a blanket rejection.
+			stopInstance(t, ts, id)
+			assert.Equal(t, http.StatusOK, modifyInstanceAttribute(t, ts, map[string]string{
+				"Action": "ModifyInstanceAttribute", "InstanceId": id, tt.param: tt.value,
+			}))
+		})
+	}
+}
+
+// TestEC2_InstanceAttribute_TerminationProtectionNotGated pins that
+// disableApiTermination is *not* subject to the stopped-state gate.
+//
+// RunInstances' reference is explicit: "You can enable termination protection when
+// you launch an instance, while the instance is running, or while the instance is
+// stopped." Gating it would refuse a call real EC2 accepts, which is the same class
+// of defect as accepting one real EC2 refuses — just in the other direction, and
+// harder to notice because it looks like extra rigor.
+func TestEC2_InstanceAttribute_TerminationProtectionNotGated(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+
+	// Still running.
+	status := modifyInstanceAttribute(t, ts, map[string]string{
+		"Action": "ModifyInstanceAttribute", "InstanceId": id,
+		"DisableApiTermination.Value": "true",
+	})
+	require.Equal(t, http.StatusOK, status,
+		"termination protection is modifiable on a running instance")
+
+	got := describeInstanceAttribute(t, ts, id, "disableApiTermination")
+	require.NotNil(t, got.DisableAPI)
+	assert.Equal(t, "true", got.DisableAPI.Value)
+
+	// And it can be turned back off.
+	require.Equal(t, http.StatusOK, modifyInstanceAttribute(t, ts, map[string]string{
+		"Action": "ModifyInstanceAttribute", "InstanceId": id,
+		"DisableApiTermination.Value": "false",
+	}))
+	off := describeInstanceAttribute(t, ts, id, "disableApiTermination")
+	require.NotNil(t, off.DisableAPI)
+	assert.Equal(t, "false", off.DisableAPI.Value)
+}
+
+// TestEC2_InstanceAttribute_ModifyUnknownInstance covers the errors on the modify
+// path, which previously reported substrate-shaped strings ("Instance not found:
+// i-abc", "InstanceId is required") and now share the reference's wording with every
+// other operation that names an instance ID (#391).
+func TestEC2_InstanceAttribute_ModifyUnknownInstance(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	status, code, msg := ec2ErrorDetail(t, ts, map[string]string{
+		"Action": "ModifyInstanceAttribute", "InstanceId": "i-0123456789abcdef0",
+		"InstanceType.Value": "t3.micro",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidInstanceID.NotFound", code)
+	assert.Equal(t, "The instance ID 'i-0123456789abcdef0' does not exist", msg)
+
+	status, code, msg = ec2ErrorDetail(t, ts, map[string]string{
+		"Action": "ModifyInstanceAttribute", "InstanceType.Value": "t3.micro",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "MissingParameter", code)
+	assert.Equal(t, "The request must contain the parameter InstanceId", msg)
+}
+
+// TestEC2_InstanceAttribute_ResponseWrapsTheValue asserts the wire shape directly
+// rather than through a decoder, because the decoder is exactly what hides the bug:
+// a response emitting <instanceType>t3.micro</instanceType> unwrapped would decode
+// into a struct whose Value field is empty, and every value assertion above would
+// still fail for a reason that reads like a lookup problem.
+//
+// All three of the reference's worked examples show the wrapper.
+func TestEC2_InstanceAttribute_ResponseWrapsTheValue(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "DescribeInstanceAttribute", "InstanceId": id, "Attribute": "instanceType",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	wire := string(body)
+
+	assert.Contains(t, wire, "<instanceType><value>t3.micro</value></instanceType>",
+		"the value is wrapped in <value>, per all three worked examples")
+	assert.Contains(t, wire, `xmlns="http://ec2.amazonaws.com/doc/2016-11-15/"`)
+	assert.True(t, strings.Contains(wire, "<instanceId>"+id+"</instanceId>"),
+		"the response names the instance alongside the attribute")
+
+	// No other attribute's element rides along. groupSet is the one that can:
+	// encoding/xml emits the parent element of a `groupSet>item` path even for an
+	// empty slice, so the naive field declaration puts <groupSet></groupSet> in every
+	// response — telling a caller who asked about instanceType that the instance has
+	// no security groups. A struct decoder cannot see this; only the wire can.
+	assert.NotContains(t, wire, "groupSet",
+		"an unasked-for attribute contributes no element at all")
+	assert.NotContains(t, wire, "userData")
+}
+
+// TestEC2_InstanceAttribute_EmptyGroupSetIsStillPresent covers the other side of that
+// pointer: when groupSet *is* the attribute asked for and the instance has no groups,
+// the element is present and empty rather than omitted — the same shape rule as an
+// unset userData, since an SDK distinguishes an empty array from a nil one.
+//
+// The instance is written into state directly because a launch always resolves a
+// security group: substrate falls back to the default VPC's, so there is no request
+// that produces a group-less instance. The state is the only place the case exists.
+func TestEC2_InstanceAttribute_EmptyGroupSetIsStillPresent(t *testing.T) {
+	t.Parallel()
+	state := emulator.NewMemoryStateManager()
+	ts := newEC2TestServerWithState(t, state)
+
+	const instID = "i-00000000000000001"
+	inst := map[string]any{
+		"instance_id":   instID,
+		"instance_type": "t3.micro",
+		"image_id":      "ami-1",
+		"state":         map[string]any{"code": 16, "name": "running"},
+		"account_id":    "000000000000",
+		"region":        "us-east-1",
+	}
+	raw, err := json.Marshal(inst)
+	require.NoError(t, err)
+	require.NoError(t, state.Put(context.Background(), "ec2",
+		"instance:000000000000/us-east-1/"+instID, raw))
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "DescribeInstanceAttribute", "InstanceId": instID, "Attribute": "groupSet",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(body), "<groupSet></groupSet>",
+		"groupSet is present and empty when it is what was asked for")
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -132,6 +132,8 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.deleteTags(ctx, req)
 	case "ModifyInstanceAttribute":
 		return p.modifyInstanceAttribute(ctx, req)
+	case "DescribeInstanceAttribute":
+		return p.describeInstanceAttribute(ctx, req)
 	// Key pair operations
 	case "CreateKeyPair":
 		return p.createKeyPair(ctx, req)
@@ -309,6 +311,9 @@ func (p *EC2Plugin) runInstancesWithTags(
 		iamInstanceProfile = req.Params["IamInstanceProfile.Arn"]
 	}
 	userData := req.Params["UserData"]
+	// Recorded so DescribeInstanceAttribute can report it (#473). AWS documents the
+	// default as false, so an absent parameter and an explicit "false" agree.
+	disableAPITermination := strings.EqualFold(req.Params["DisableApiTermination"], "true")
 
 	subnetID := req.Params["SubnetId"]
 	sgID := req.Params["SecurityGroupId.1"]
@@ -531,6 +536,8 @@ func (p *EC2Plugin) runInstancesWithTags(
 			IamInstanceProfile: iamInstanceProfile,
 			UserData:           userData,
 			Tags:               tags,
+
+			DisableAPITermination: disableAPITermination,
 		}
 
 		// Look up VPCID from subnet and decide whether to assign a public IP.
@@ -2112,30 +2119,47 @@ func (p *EC2Plugin) deleteTags(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
 }
 
-// modifyInstanceAttribute handles ModifyInstanceAttribute — supports InstanceType changes.
+// modifyInstanceAttribute handles ModifyInstanceAttribute — supports InstanceType,
+// UserData and DisableApiTermination changes.
+//
+// Attribute is Required: No on this operation, unlike on DescribeInstanceAttribute:
+// the .Value suffix on the parameter carries the selection, so a request setting
+// UserData.Value needs no Attribute at all.
 func (p *EC2Plugin) modifyInstanceAttribute(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	instID := req.Params["InstanceId"]
 	if instID == "" {
-		return nil, &AWSError{Code: "MissingParameter", Message: "InstanceId is required", HTTPStatus: http.StatusBadRequest}
+		return nil, ec2MissingParameter("InstanceId")
 	}
 
 	stateKey := "instance:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + instID
-	data, err := p.state.Get(context.Background(), ec2Namespace, stateKey)
-	if err != nil {
-		return nil, fmt.Errorf("ec2 modifyInstanceAttribute get: %w", err)
-	}
-	if data == nil {
-		return nil, &AWSError{Code: "InvalidInstanceID.NotFound", Message: "Instance not found: " + instID, HTTPStatus: http.StatusBadRequest}
+	inst, awsErr, err := p.loadInstance(reqCtx, instID, "modifyInstanceAttribute")
+	if err != nil || awsErr != nil {
+		return nil, errOrAWS(err, awsErr)
 	}
 
-	var inst EC2Instance
-	if err := json.Unmarshal(data, &inst); err != nil {
-		return nil, fmt.Errorf("ec2 modifyInstanceAttribute unmarshal: %w", err)
+	// Some attributes can only be modified while the instance is stopped, and the
+	// check runs before anything is written so a refused call leaves the value
+	// untouched (#473). This is a new rejection on a path that used to succeed:
+	// substrate previously changed the type of a running instance, which real EC2
+	// refuses — see [ec2ModifiableWhenStopped] for which attributes are gated and
+	// why disableApiTermination is not among them.
+	if attr := ec2AttributeModificationState(req.Params); attr != "" && !ec2InstanceStopped(inst) {
+		return nil, ec2IncorrectInstanceState(attr, inst.State.Name)
 	}
 
 	// Apply supported attribute modifications.
 	if v := req.Params["InstanceType.Value"]; v != "" {
 		inst.InstanceType = v
+	}
+	// UserData.Value is read with a presence check rather than a non-empty one, so
+	// clearing an instance's user data is expressible: AWS's SecureBlobAttributeValue
+	// carries whatever the caller sends, including nothing, and treating "" as
+	// "unchanged" would make the clear silently a no-op.
+	if v, ok := req.Params["UserData.Value"]; ok {
+		inst.UserData = v
+	}
+	if v, ok := req.Params["DisableApiTermination.Value"]; ok {
+		inst.DisableAPITermination = strings.EqualFold(v, "true")
 	}
 
 	updated, err := json.Marshal(inst)

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -21,9 +21,16 @@ import (
 // newEC2TestServer builds a minimal Server with the EC2 plugin registered.
 func newEC2TestServer(t *testing.T) *httptest.Server {
 	t.Helper()
+	return newEC2TestServerWithState(t, emulator.NewMemoryStateManager())
+}
+
+// newEC2TestServerWithState is [newEC2TestServer] with the caller's StateManager, so
+// a test can write a stored shape no request produces — a pre-migration record, or an
+// instance with no security groups — and read it back through the API.
+func newEC2TestServerWithState(t *testing.T, state emulator.StateManager) *httptest.Server {
+	t.Helper()
 	registry := emulator.NewPluginRegistry()
 	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
-	state := emulator.NewMemoryStateManager()
 	tc := emulator.NewTimeController(time.Now())
 	logger := emulator.NewDefaultLogger(0, false)
 
@@ -1081,6 +1088,19 @@ func TestEC2_ModifyInstanceAttribute(t *testing.T) {
 	}
 	runResp.Body.Close() //nolint:errcheck
 	id := runResult.Instances[0].InstanceID
+
+	// The instance must be stopped first: instanceType is one of the attributes real
+	// EC2 only modifies on a stopped instance, and substrate now enforces that
+	// (#473). This test asserted the old behavior — a running instance changing type
+	// — which was the defect, so the stop is the assertion's correction rather than
+	// setup noise. TestEC2_InstanceAttribute_ModifyRequiresStopped owns the rejection.
+	stopResp := ec2Request(t, ts, map[string]string{
+		"Action": "StopInstances", "InstanceId.1": id,
+	})
+	if stopResp.StatusCode != http.StatusOK {
+		t.Fatalf("StopInstances: expected 200, got %d", stopResp.StatusCode)
+	}
+	stopResp.Body.Close() //nolint:errcheck
 
 	// Modify to t3.medium.
 	modResp := ec2Request(t, ts, map[string]string{

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -94,6 +94,15 @@ type EC2Instance struct {
 	// UserData is the base64-encoded user-data supplied at launch (stored so
 	// callers can verify it was accepted; not executed).
 	UserData string `json:"user_data,omitempty"`
+
+	// DisableAPITermination reports whether termination protection is enabled.
+	// AWS documents the default as false, which is the zero value, so an instance
+	// unmarshalled from an event log predating this field reads back correctly.
+	//
+	// Substrate records and reports it but does not act on it: TerminateInstances
+	// still terminates a protected instance. Real EC2 refuses with
+	// OperationNotPermitted, which is tracked separately.
+	DisableAPITermination bool `json:"disable_api_termination,omitempty"`
 }
 
 // EC2KeyPair represents an EC2 key pair (public/private key used for SSH access).


### PR DESCRIPTION
Closes #473

`DescribeInstanceAttribute` was absent entirely, which made an instance's user data
write-only: `RunInstances` recorded `UserData` and nothing could read it back, so a
consumer could not assert that the user data their IaC intended reached the instance.
It also left #453's launch-template `UserData` fallback testable only indirectly —
it could have regressed with nothing observable changing.

## What reads back

Four attributes, being the ones backed by state substrate holds:

| `Attribute` | Reports |
|---|---|
| `userData` | The value as stored, still base64 — re-encoding would double it |
| `instanceType` | |
| `disableApiTermination` | Now recorded at launch and by `ModifyInstanceAttribute` |
| `groupSet` | `groupSet>item`, the same shape `DescribeInstances` reports (#444) |

Scalars are `<value>`-wrapped, as all three of the reference's worked examples show,
and exactly one attribute appears per response.

## Unmodelled attributes are refused, not defaulted

`InvalidParameterValue`, 400, `Value (enaSupport) for parameter attribute is invalid.
Unknown attribute.` Answering `sourceDestCheck` with a default `false` would be
indistinguishable from a real instance that has it disabled, and a consumer asserting
on it would get a green test built on a value substrate invented.

This is the strongest message provenance in the release: **captured from real AWS** in
aws/aws-cli#4273 and byte-identical to moto's string — a capture and an independent
reimplementation agreeing. The reference could not have supplied it; its Errors
section is empty. `enaSupport` is in AWS's own valid-values list while the same page
says the attribute "is not supported", and #4273 captures exactly that rejection.

## The criterion the reference cannot settle

An unset attribute is a **present but empty** element (`<userData></userData>`), not
an omitted one. All three of the reference's examples show an attribute that *has* a
value, so this ships from moto's `test_describe_instance_attribute` asserting
`response["UserData"] == {}`. That is weaker provenance than a capture and is
labelled as such in the code and the docs, because the shapes are not
interchangeable: an SDK maps a present-but-empty element to an empty struct and an
omitted one to nil, so `resp.UserData.Value` panics under one and not the other.

## Behaviour change: `ModifyInstanceAttribute` requires a stopped instance

`userData` and `instanceType` now need `stopped`, where changing a running
instance's type previously succeeded — `IncorrectInstanceState`, 400. The
reference's Example 1 says so plainly, and the client-error table names user data as
the same rule's worked example. `TestEC2_ModifyInstanceAttribute` asserted the old
behaviour and is corrected here; the rejection's own assertion lives in
`TestEC2_InstanceAttribute_ModifyRequiresStopped`.

`disableApiTermination` is **deliberately exempt**. `RunInstances` documents that
termination protection can be enabled "when you launch an instance, while the
instance is running, or while the instance is stopped", so gating it would refuse a
call real EC2 accepts — the same class of defect in the other direction, and harder
to notice because it looks like extra rigor. `TestEC2_InstanceAttribute_TerminationProtectionNotGated`
pins it.

## One bug found while writing the tests

Go's `encoding/xml` emits the **parent** element of an `a>b` path even for an empty
slice, so a `groupSet>item` field put `<groupSet></groupSet>` in *every* response: a
caller asking for `userData` was told the instance had no security groups. No struct
decoder can see this — only the raw wire. Fixed with a nil-able wrapper, and pinned
from both directions (`NotContains` on the wire, plus
`TestEC2_InstanceAttribute_EmptyGroupSetIsStillPresent` for the case where an empty
`groupSet` *is* what was asked for).

## Verification

16 new tests. `gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...`
(0 issues), `make test` (race), `make docs-reference docs-reference-check
docs-versions`, `go test -C test/e2e ./...`, and the VitePress build all pass.

**Mutation-tested 18/18 caught**, including: omitting the empty `<userData/>`;
flattening the `<value>` wrapper; the `groupSet` leak above; gating
`disableApiTermination`; dropping the stopped gate; a non-empty check on
`UserData.Value` (which would make clearing user data inexpressible);
case-insensitive attribute matching; and looking the instance up before validating
the attribute.

Termination protection is recorded and reported but not acted on — `TerminateInstances`
still terminates a protected instance, where real EC2 refuses with
`OperationNotPermitted`. Noted in the code and docs; being filed separately.