### PR TITLE
docs(fidelity): state the position on error message text (#487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one.
 
 ### Changed
+- `docs/fidelity.md` now states substrate's position on **error message text**, which
+  the page previously left unsaid. It committed to verifying "request/response shapes,
+  error codes, pagination, and IAM condition keys" and never mentioned messages — no
+  false claim, but a reader could reasonably have assumed more than substrate delivers.
+  Codes and HTTP statuses are verified and are the contract SDKs dispatch on; message
+  text is faithful only where a capture or a parity-tested reimplementation supplies it,
+  and carries its source in the code comment where so. Elsewhere it is substrate's own
+  and reads as such. The page now also says why the remainder is closed incrementally
+  rather than swept: the reference describes error *conditions* rather than quoting the
+  strings AWS sends, so a blind rewrite would replace recognisably substrate-shaped text
+  with invented text that reads as authoritative. Tracked in #487, which records the
+  measured counts.
 - `CLAUDE.md`'s release procedure now includes publishing the GitHub Release. The
   step was absent, so v0.84.0 and v0.85.0 were tagged and their tags pushed with no
   Release entry behind them — the tag alone does not create one, and v0.83.0 was

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -13,6 +13,32 @@ condition keys — not against built-in assumptions. When Substrate's behaviour
 intentionally differs from real AWS, that divergence is documented alongside the
 behaviour and its rationale.
 
+### Error codes are verified; message text mostly is not
+
+One part of that list deserves to be stated precisely, because the difference matters
+to what you can assert on. **Error codes and HTTP statuses are verified against the
+reference.** They are the contract: botocore and `aws-sdk-go-v2` dispatch on
+`Error.Code` and never on message text, so a caller's error branch turns on the part
+Substrate researches.
+
+**Message text is faithful only where a source supplies it** — a captured real-AWS
+response, or a reimplementation that snapshot-tests against real AWS. Where that
+exists, the wording is reproduced verbatim, right down to typos and stray whitespace,
+and its source is named in the code comment beside the literal. Where it does not, the
+text is Substrate's own and reads as such, and the comment says so.
+
+That distinction cannot be closed by reading the documentation: the reference's Errors
+sections describe error *conditions*, not the strings AWS sends. Rewriting the
+remainder into AWS-*looking* text from inference would replace recognisably
+Substrate-shaped strings with invented ones that read as authoritative — and you could
+no longer tell which messages had actually been researched. So the gap is closed
+incrementally, per service, each message with its own corroborating source
+([#487](https://github.com/scttfrdmn/substrate/issues/487)).
+
+The practical consequence: **assert on `Error.Code` and the HTTP status, not on message
+text.** That is also the advice for code that will run against real AWS, where message
+wording is not a stable contract either.
+
 The guiding question for any addition is the scope test:
 
 > *Is this observable through an API call, or is it resource-internal?*


### PR DESCRIPTION
Refs #487

`docs/fidelity.md` committed to verifying "request/response shapes, error codes,
pagination, and IAM condition keys" and never mentioned **error message text**. That
is not a false claim, but a reader could reasonably have assumed more than substrate
delivers, and the gap was nowhere stated.

The new subsection says it plainly:

- **Codes and HTTP statuses are verified** and are the contract — botocore and
  `aws-sdk-go-v2` dispatch on `Error.Code` and never on message text.
- **Message text is faithful only where a source supplies it** — a captured real-AWS
  response or a reimplementation that snapshot-tests against real AWS — reproduced
  verbatim (typos and stray whitespace included) with its source named in the code
  comment. Elsewhere it is substrate's own and reads as such.
- **Why the remainder is closed incrementally rather than swept**: the reference
  describes error *conditions* rather than quoting the strings AWS sends, so a blind
  rewrite would replace recognisably substrate-shaped text with invented text that
  reads as authoritative — and you could no longer tell which messages had been
  researched.
- The practical advice: assert on `Error.Code` and the status, not on message text.
  That holds against real AWS too, where wording is not a stable contract.

#487 carries the measured counts (1090 `Message:` literals in non-test `emulator/`
code; seven files with provenance notes; 219 `"X is required"`, 214 `"... not found"`).

VitePress build and `check-doc-versions.sh` pass.