### PR TITLE
chore(release): v0.86.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.86.0] - 2026-08-02
+
 ### Added
 - **Reserved `aws:` tag keys are now rejected on every tag-on-create path** (#468).
   #452 closed this for `CreateTags` and `DeleteTags` but deliberately left it off
@@ -3434,7 +3436,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.85.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.86.0...HEAD
+[v0.86.0]: https://github.com/scttfrdmn/substrate/compare/v0.85.0...v0.86.0
 [v0.85.0]: https://github.com/scttfrdmn/substrate/compare/v0.84.0...v0.85.0
 [v0.84.0]: https://github.com/scttfrdmn/substrate/compare/v0.83.0...v0.84.0
 [v0.83.0]: https://github.com/scttfrdmn/substrate/compare/v0.82.0...v0.83.0


### PR DESCRIPTION
Moves `## [Unreleased]` to `## [v0.86.0] - 2026-08-02` and adds the comparison link.

The date is UTC, matching v0.85.0's section — the local clock is `-0700`, so a local
date would read `2026-08-01` and appear to precede a release it follows.

Per `CLAUDE.md`, the tag is cut **after** this merges, against the merge commit, and the
GitHub Release is published in the same sitting — a pushed tag does not create one, and
`make tag-releases-check` only catches the omission after its two-hour grace window.

## What v0.86.0 contains

Six consumer-filed fidelity issues, all closed:

| Issue | PR | Change |
|---|---|---|
| #456 | #477 | Launch-template versioning — four operations; an absent `Version` resolves to the **default**, not the latest |
| #468 | #478 | Reserved `aws:` keys rejected on every tag-on-create path, with nothing created on rejection |
| #469 | #479 | The 50-tag-per-resource limit, with the `aws:` exemption and overwrite-at-the-limit both modelled |
| #471 | #481 | A launch template's `TagSpecifications` and `IamInstanceProfile` now reach the instance |
| #472 | #482 | SQS message-attribute count, name, type and `Number` rules, with per-entry batch failures |
| #473 | #486 | `DescribeInstanceAttribute` — an instance's user data is finally observable |

Plus two release-process changes that landed first (#474, #476) and `docs/fidelity.md`'s
statement of the error-message-text position (#487, PR #488).

The unifying defect shape across all six is the tracker's recurring one: substrate
returned success, or a silently different result, where real AWS refuses — so a
consumer's error branch was unreachable and their suite reported green while verifying
nothing.

Deferred to v0.87.0: #455, #411, #470. Six issues were filed from this release's work
(#487, #489–#493).