### PR TITLE
fix(ec2): refuse an unmodelled instance type, and make the offerings filter work (#485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`DescribeInstanceTypes` now refuses an instance type it does not model** (#485).
+  An unknown type was answered with HTTP 200 and an empty list, so a consumer
+  validating a user-supplied instance type got no signal at all and their validation
+  branch was unreachable — the same shape as #391's unknown instance ID. Real
+  `us-east-1` answers `InvalidInstanceType`, HTTP 400, and substrate now does too,
+  collecting every unknown type in the request into one bracketed list in request
+  order. One bad type fails the whole request; the known types are not returned,
+  because `InstanceType.N` asserts that the types supplied exist.
+
+  The code is documented in EC2's client-error table. The message is verbatim from
+  the single real-`us-east-1` capture reported in #485, so the brackets and the
+  plural phrasing are observed; the `", "` separator for a multi-type list is
+  **not** corroborated and is substrate's choice. Dispatch on the code.
+
+- **The `DescribeInstanceTypeOfferings` instance-type filter now works** (#485). It
+  had never worked: the handler built its filter from an `InstanceType.N` parameter
+  the operation does not have — its reference lists exactly `DryRun`, `Filter.N`,
+  `LocationType`, `MaxResults` and `NextToken`, and botocore rejects `InstanceTypes`
+  outright — so the filter map was always empty and every query returned the whole
+  catalog in every zone. A caller asking "is `m5.xlarge` offered here?" got yes for
+  any input, including nonsense. The pattern had been copied from
+  `DescribeInstanceTypes`, where the parameter does exist.
+
+  Both documented filter names are now applied — `instance-type` and `location` —
+  with EC2's documented wildcards (`*` for zero or more characters, `?` for zero or
+  **one**, `\` to escape a literal), case-sensitive values, all `Filter.N.Value.M`
+  values as an OR, and separate `Filter.N` entries ANDed. Any other filter name is
+  **refused** with `InvalidParameterValue` rather than ignored, since silently
+  dropping a filter is how this defect went unnoticed for four releases.
+  `location-type` is among the refused: it is not a filter name, contrary to #485's
+  aside — `LocationType` is a separate top-level parameter, now honoured for
+  `availability-zone` (the default) and `region`. `availability-zone-id` and
+  `outpost` are real AWS values substrate does not model and are refused with a
+  message naming substrate, rather than answered with zone names under a
+  `locationType` claiming they are IDs or Outpost ARNs.
+
+  An `instance-type` filter matching nothing is **zero offerings and HTTP 200**, not
+  an error — deliberately the opposite of `DescribeInstanceTypes`' identically
+  spelled parameter, and confirmed by #485's real-AWS diff of both. The two are
+  different questions: a filter narrows a result set, so an unmatched value is a
+  legitimate empty answer, while `InstanceType.N` asserts existence. Both halves are
+  pinned by tests so neither can later be "tidied" into consistency with the other.
+  `DescribeSpotPriceHistory`'s `InstanceType.N` is a filter too, per its reference,
+  so an unknown type there is an empty history.
+
+### Added
+- **The instance-type catalog now covers whole families** (#485), widened from 8
+  types to 57. The old catalog split families mid-way — `c5.xlarge` in and `c5.large`
+  out, `m5.large` in and `m5.xlarge` out — which was incidental to #234's consumer and
+  became a correctness problem the moment an absent type started being *refused*: a
+  catalog stopping at `c5.xlarge` answers `InvalidInstanceType` for `c5.large`, the
+  right code for a bogus type and the wrong one for a real one. `t3`, `t3a`, `m5`,
+  `m5a`, `c5`, `c5a` and `r5` are now complete (note `c5`'s ladder differs from
+  `c5a`'s: `9xlarge`/`18xlarge` against `8xlarge`/`16xlarge`), alongside the three
+  accelerated sizes #234 seeded. All ten types #485 names are present; five were not.
+
+  Bare-metal sizes are deliberately excluded and the exclusion is pinned by a test:
+  they are real types, but nothing else in the plugin models their behaviour.
+
+  Spot prices are now generated from the same per-family table as the specs, so a
+  type cannot be in the catalog and missing from the price index — the previous pair
+  of parallel maps had exactly that hazard, and `DescribeSpotPriceHistory` silently
+  dropped any type absent from the price map. The eight prices #234 shipped are
+  preserved verbatim so no recorded fixture moves. They remain deterministic stubs,
+  not AWS prices.
+
+  `DescribeAvailabilityZones`, `DescribeInstanceTypeOfferings` and
+  `DescribeSpotPriceHistory` now derive their zone names from one list, so filtering
+  an offerings query by a zone you just enumerated cannot return empty.
+
 ## [v0.86.0] - 2026-08-02
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -1327,8 +1327,11 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | AttachInternetGateway | |
 | DescribeInternetGateways | [Explicit resource IDs](#explicit-resource-ids) |
 | DeleteInternetGateway | [Explicit resource IDs](#explicit-resource-ids) |
-| DescribeAvailabilityZones | |
+| DescribeAvailabilityZones | Three zones per region, from the same list the offerings and spot-price operations use — see [Instance types are a seeded catalog](#instance-types-are-a-seeded-catalog) |
 | DescribeRegions | |
+| DescribeInstanceTypes | Answers from a [seeded catalog](#instance-types-are-a-seeded-catalog). `InstanceType.N` is an assertion: a type outside the catalog is refused with `InvalidInstanceType`. `Filter.N` is not applied |
+| DescribeInstanceTypeOfferings | `instance-type` and `location` filters (both with [wildcards](#instance-types-are-a-seeded-catalog)) and the `LocationType` parameter; an unmatched filter is an empty answer, not an error |
+| DescribeSpotPriceHistory | One stub price per catalog type per zone. `InstanceType.N` here is a *filter*, so an unknown type is an empty history — [see below](#instance-types-are-a-seeded-catalog) |
 | CreateRouteTable | |
 | AssociateRouteTable | |
 | DescribeRouteTables | [Explicit resource IDs](#explicit-resource-ids) |
@@ -1725,6 +1728,97 @@ describe two parameters AWS documents as used together; the defect is the *value
 
 The upper bound is a per-account, per-instance-type quota substrate does not model,
 so it is not enforced: any count at or above 1 is accepted.
+
+### Instance types are a seeded catalog
+
+`DescribeInstanceTypes`, `DescribeInstanceTypeOfferings` and
+`DescribeSpotPriceHistory` all answer from one seeded catalog. It is **not
+exhaustive** — EC2 offers some 800 types — but it is **complete per family**:
+
+| Family | Sizes |
+|---|---|
+| `t3`, `t3a` | `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge` |
+| `m5`, `m5a`, `r5`, `c5a` | `large`, `xlarge`, `2xlarge`, `4xlarge`, `8xlarge`, `12xlarge`, `16xlarge`, `24xlarge` |
+| `c5` | `large`, `xlarge`, `2xlarge`, `4xlarge`, `9xlarge`, `12xlarge`, `18xlarge`, `24xlarge` — note the ladder is **not** the same as `c5a`'s |
+| accelerated | `p3.2xlarge`, `g4dn.xlarge`, `inf1.xlarge` |
+
+Whole families rather than a sample, because an absent type is *refused* (below) —
+a catalog stopping at `c5.xlarge` would answer `InvalidInstanceType` for
+`c5.large`, which is the right code for a bogus type and the wrong one for a real
+one. Bare-metal sizes (`m5.metal` and friends) are deliberately excluded: they are
+real types, but nothing else in the plugin models their behaviour, so returning
+them would advertise fidelity that is not there. vCPU and memory figures come from
+the AWS instance-type guides. `inf1`'s Inferentia accelerator is not reported
+through `gpuInfo`, matching real EC2, so its GPU count is zero.
+
+#### A type outside the catalog: refused, or empty?
+
+Both — and which one depends on whether the parameter is an assertion or a filter.
+This asymmetry is deliberate and matches real AWS; #485 diffed all three
+operations against `us-east-1`.
+
+| Request | Answer |
+|---|---|
+| `DescribeInstanceTypes --instance-types zz9.bogus` | `InvalidInstanceType`, HTTP 400 — `InstanceType.N` asserts the types exist |
+| `DescribeInstanceTypeOfferings --filters Name=instance-type,Values=zz9.bogus` | **0 offerings, HTTP 200** — a filter that matches nothing is a legitimate empty answer |
+| `DescribeSpotPriceHistory --instance-types zz9.bogus` | **Empty history, HTTP 200** — the reference describes this parameter as filtering the results |
+
+Every unknown type in one `DescribeInstanceTypes` request is collected into a
+single error, in request order:
+
+```
+InvalidInstanceType: The following supplied instance types do not exist: [zz9.bogus, aa1.nope]
+```
+
+One bad type fails the whole request; the known types are not returned. The
+message is verbatim from a real `us-east-1` capture for the single-type case; the
+`", "` separator for a list is substrate's choice, so dispatch on the code.
+
+`DescribeInstanceTypes` ignores `Filter.N` entirely. The operation documents some
+60 filter names, nearly all over response fields the seeded catalog does not carry,
+and applying the handful that are answerable while silently dropping the rest is
+the same defect as an ignored filter. Tracked in
+[#495](https://github.com/scttfrdmn/substrate/issues/495).
+
+#### Offerings filters and wildcards
+
+`DescribeInstanceTypeOfferings` accepts exactly the two filter names its reference
+documents — `instance-type` and `location`. **Any other name is refused** with
+`InvalidParameterValue` rather than ignored. Multiple `Filter.N.Value.M` values are
+an OR; separate `Filter.N` entries AND together.
+
+Filter values honour EC2's documented wildcards, and are **case-sensitive**:
+
+| Value | Matches |
+|---|---|
+| `c5.2xlarge` | that type |
+| `c5.*` | the eight `c5` sizes |
+| `c5*` | `c5` **and** `c5a` — `*` matches zero or more characters, including the `a` |
+| `t3?.micro` | `t3.micro` and `t3a.micro` — `?` matches zero **or one** character |
+| `m5.larg\*` | nothing; a backslash escapes a literal wildcard |
+| `M5.XLarge` | nothing |
+
+`LocationType` is a top-level **parameter**, not a filter name (`location-type` is
+refused as a filter). `availability-zone` is the default and `region` returns one
+offering per type located at the region. `availability-zone-id` and `outpost` are
+valid AWS values that substrate does **not** model, and are refused with a message
+naming substrate — treating them as `availability-zone` would return zone *names*
+under a `locationType` claiming they are IDs or Outpost ARNs, which a caller
+matching the two would silently mis-read.
+
+The three zones `DescribeAvailabilityZones` reports are the same three the
+offerings and spot-price operations use, so filtering an offerings query by a zone
+you just enumerated always returns an answer.
+
+#### Spot prices are stubs
+
+The `spotPrice` values are **deterministic stubs, not AWS prices**: substrate has
+no price feed, and the numbers exist so a spot-price response has a plausible,
+stable figure in it. Within a family they are a fixed rate per GiB, so they stay
+monotonic in size. Assert on the *shape* of a spot-price response, never on the
+amount. Every catalog type has a price — the two are generated together, so a type
+cannot appear in `DescribeInstanceTypes` and be missing from
+`DescribeSpotPriceHistory`.
 
 ### Explicit resource IDs
 

--- a/emulator/ec2_instancetypes.go
+++ b/emulator/ec2_instancetypes.go
@@ -1,0 +1,372 @@
+package emulator
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ec2InstanceTypeInfo holds the details for one instance type in the seeded catalog.
+type ec2InstanceTypeInfo struct {
+	// InstanceType is the full type name, e.g. "c5.2xlarge".
+	InstanceType string
+	// VCpus is reported as vCpuInfo.defaultVCpus.
+	VCpus int
+	// MemoryMiB is reported as memoryInfo.sizeInMiB.
+	MemoryMiB int
+	// GPU is the accelerator count reported through gpuInfo when non-zero.
+	GPU int
+	// SpotPrice is the stub spot price in USD/hour. See [ec2InstanceTypeFamilies].
+	SpotPrice string
+	// SupportedArchs is reported as processorInfo.supportedArchitectures.
+	SupportedArchs []string
+	// SupportedUsageClasses is reported as supportedUsageClasses.
+	SupportedUsageClasses []string
+}
+
+// ec2InstanceTypeSize is one size within an [ec2InstanceTypeFamily].
+type ec2InstanceTypeSize struct {
+	// Size is the part of the instance type after the dot, e.g. "2xlarge".
+	Size string
+	// VCpus is the default vCPU count.
+	VCpus int
+	// MemoryMiB is the memory size in MiB.
+	MemoryMiB int
+	// SpotPrice is the stub spot price in USD/hour.
+	SpotPrice string
+}
+
+// ec2InstanceTypeFamily describes one instance-type family in the seeded catalog.
+type ec2InstanceTypeFamily struct {
+	// Name is the family prefix, e.g. "c5".
+	Name string
+	// GPUs is the accelerator count every size in the family carries. Sizes within a
+	// real family differ here; the catalog holds a single accelerated size per family,
+	// so one value per family is enough.
+	GPUs int
+	// Sizes are the family's members, smallest first.
+	Sizes []ec2InstanceTypeSize
+}
+
+// ec2InstanceTypeFamilies is the seeded instance-type catalog, by family.
+//
+// The catalog is deliberately **not** exhaustive — EC2 offers some 800 types — but it is
+// complete per family, which is the property that makes the rest of the modeling honest.
+// [ec2CheckInstanceTypesExist] refuses a type the catalog does not carry, so a catalog
+// that stopped mid-family (as the eight-type catalog #234 shipped did: c5.xlarge in,
+// c5.large out) would answer InvalidInstanceType for types that plainly exist. Whole
+// families mean "absent from the catalog" and "not a real instance type" line up for the
+// common general-purpose, compute-optimized, memory-optimized and burstable families.
+// A family substrate does not carry at all is still refused; see the doc for which.
+//
+// vCPU and memory figures come from the AWS instance-type guides — general purpose
+// (https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html), compute optimized
+// (.../co.html) and memory optimized (.../mo.html). Bare-metal sizes are excluded: they
+// are real types, but their specs and behavior are not modeled anywhere else in the
+// plugin, so returning them would advertise fidelity that is not there.
+//
+// SpotPrice values are **deterministic stubs, not AWS prices**, and are not researched
+// against AWS pricing — the emulator has no price feed and the values exist so a spot
+// price history response has a plausible, stable number in it. Within a family they are a
+// fixed rate per GiB of memory, which keeps them monotonic in size. The eight values
+// #234's catalog shipped (t3.micro 0.0042, c5.xlarge 0.068, c5.2xlarge 0.136, m5.large
+// 0.038, r5.xlarge 0.076, p3.2xlarge 0.918, g4dn.xlarge 0.188, inf1.xlarge 0.076) are
+// preserved verbatim and every family's rate is calibrated to them, so no existing
+// fixture moves. Assert on the shape of a spot price response, never on the amount.
+var ec2InstanceTypeFamilies = []ec2InstanceTypeFamily{
+	// Burstable, Intel. 0.0042 USD/GiB.
+	{Name: "t3", Sizes: []ec2InstanceTypeSize{
+		{"nano", 2, 512, "0.0021"},
+		{"micro", 2, 1024, "0.0042"},
+		{"small", 2, 2048, "0.0084"},
+		{"medium", 2, 4096, "0.0168"},
+		{"large", 2, 8192, "0.0336"},
+		{"xlarge", 4, 16384, "0.0672"},
+		{"2xlarge", 8, 32768, "0.1344"},
+	}},
+	// Burstable, AMD. 0.0038 USD/GiB.
+	{Name: "t3a", Sizes: []ec2InstanceTypeSize{
+		{"nano", 2, 512, "0.0019"},
+		{"micro", 2, 1024, "0.0038"},
+		{"small", 2, 2048, "0.0076"},
+		{"medium", 2, 4096, "0.0152"},
+		{"large", 2, 8192, "0.0304"},
+		{"xlarge", 4, 16384, "0.0608"},
+		{"2xlarge", 8, 32768, "0.1216"},
+	}},
+	// General purpose, Intel. 0.00475 USD/GiB.
+	{Name: "m5", Sizes: []ec2InstanceTypeSize{
+		{"large", 2, 8192, "0.038"},
+		{"xlarge", 4, 16384, "0.076"},
+		{"2xlarge", 8, 32768, "0.152"},
+		{"4xlarge", 16, 65536, "0.304"},
+		{"8xlarge", 32, 131072, "0.608"},
+		{"12xlarge", 48, 196608, "0.912"},
+		{"16xlarge", 64, 262144, "1.216"},
+		{"24xlarge", 96, 393216, "1.824"},
+	}},
+	// General purpose, AMD. 0.00425 USD/GiB.
+	{Name: "m5a", Sizes: []ec2InstanceTypeSize{
+		{"large", 2, 8192, "0.034"},
+		{"xlarge", 4, 16384, "0.068"},
+		{"2xlarge", 8, 32768, "0.136"},
+		{"4xlarge", 16, 65536, "0.272"},
+		{"8xlarge", 32, 131072, "0.544"},
+		{"12xlarge", 48, 196608, "0.816"},
+		{"16xlarge", 64, 262144, "1.088"},
+		{"24xlarge", 96, 393216, "1.632"},
+	}},
+	// Compute optimized, Intel. 0.0085 USD/GiB. Note the size ladder is not shared with
+	// c5a: c5 has 9xlarge and 18xlarge where c5a has 8xlarge and 16xlarge.
+	{Name: "c5", Sizes: []ec2InstanceTypeSize{
+		{"large", 2, 4096, "0.034"},
+		{"xlarge", 4, 8192, "0.068"},
+		{"2xlarge", 8, 16384, "0.136"},
+		{"4xlarge", 16, 32768, "0.272"},
+		{"9xlarge", 36, 73728, "0.612"},
+		{"12xlarge", 48, 98304, "0.816"},
+		{"18xlarge", 72, 147456, "1.224"},
+		{"24xlarge", 96, 196608, "1.632"},
+	}},
+	// Compute optimized, AMD. 0.00765 USD/GiB.
+	{Name: "c5a", Sizes: []ec2InstanceTypeSize{
+		{"large", 2, 4096, "0.0306"},
+		{"xlarge", 4, 8192, "0.0612"},
+		{"2xlarge", 8, 16384, "0.1224"},
+		{"4xlarge", 16, 32768, "0.2448"},
+		{"8xlarge", 32, 65536, "0.4896"},
+		{"12xlarge", 48, 98304, "0.7344"},
+		{"16xlarge", 64, 131072, "0.9792"},
+		{"24xlarge", 96, 196608, "1.4688"},
+	}},
+	// Memory optimized, Intel. 0.002375 USD/GiB.
+	{Name: "r5", Sizes: []ec2InstanceTypeSize{
+		{"large", 2, 16384, "0.038"},
+		{"xlarge", 4, 32768, "0.076"},
+		{"2xlarge", 8, 65536, "0.152"},
+		{"4xlarge", 16, 131072, "0.304"},
+		{"8xlarge", 32, 262144, "0.608"},
+		{"12xlarge", 48, 393216, "0.912"},
+		{"16xlarge", 64, 524288, "1.216"},
+		{"24xlarge", 96, 786432, "1.824"},
+	}},
+	// Accelerated. These are the single sizes #234 seeded rather than whole families:
+	// the accelerated families are large, their specs vary widely across sizes, and no
+	// consumer has asked for more of them. p3.2xlarge carries one NVIDIA V100 and
+	// g4dn.xlarge one T4; inf1.xlarge's accelerator is an AWS Inferentia chip, which
+	// real EC2 does not report through gpuInfo, so its GPU count stays zero.
+	{Name: "p3", GPUs: 1, Sizes: []ec2InstanceTypeSize{
+		{"2xlarge", 8, 62464, "0.918"},
+	}},
+	{Name: "g4dn", GPUs: 1, Sizes: []ec2InstanceTypeSize{
+		{"xlarge", 4, 16384, "0.188"},
+	}},
+	{Name: "inf1", Sizes: []ec2InstanceTypeSize{
+		{"xlarge", 4, 8192, "0.076"},
+	}},
+}
+
+// ec2InstanceTypeCatalog is the flattened [ec2InstanceTypeFamilies], in family and then
+// size order. ec2InstanceTypeIndex is the same data keyed by type name.
+//
+// Both are built by one function so a type can never be in one and not the other — the
+// eight-type catalog and its parallel spot-price map had exactly that hazard, and a type
+// missing from the price map was silently dropped from DescribeSpotPriceHistory.
+var ec2InstanceTypeCatalog, ec2InstanceTypeIndex = buildEC2InstanceTypeCatalog()
+
+// buildEC2InstanceTypeCatalog flattens [ec2InstanceTypeFamilies] into the catalog slice
+// and its by-name index.
+//
+// Every catalog entry is x86_64 and supports both on-demand and spot. That is true of
+// every family listed, so it is applied here rather than repeated per row; a family with
+// a different architecture or usage class would need this widening first.
+func buildEC2InstanceTypeCatalog() ([]ec2InstanceTypeInfo, map[string]ec2InstanceTypeInfo) {
+	var catalog []ec2InstanceTypeInfo
+	index := make(map[string]ec2InstanceTypeInfo)
+	for _, family := range ec2InstanceTypeFamilies {
+		for _, size := range family.Sizes {
+			info := ec2InstanceTypeInfo{
+				InstanceType:          family.Name + "." + size.Size,
+				VCpus:                 size.VCpus,
+				MemoryMiB:             size.MemoryMiB,
+				GPU:                   family.GPUs,
+				SpotPrice:             size.SpotPrice,
+				SupportedArchs:        []string{"x86_64"},
+				SupportedUsageClasses: []string{"on-demand", "spot"},
+			}
+			catalog = append(catalog, info)
+			index[info.InstanceType] = info
+		}
+	}
+	return catalog, index
+}
+
+// ec2SeededAZSuffixes are the Availability Zone letters the emulator reports for every
+// region. DescribeAvailabilityZones, DescribeInstanceTypeOfferings and
+// DescribeSpotPriceHistory all derive their zone names from this one list, so a caller
+// filtering an offerings query by a zone DescribeAvailabilityZones reported gets an
+// answer rather than an empty set.
+var ec2SeededAZSuffixes = []string{"a", "b", "c"}
+
+// ec2InvalidInstanceTypeError returns the error EC2 raises when DescribeInstanceTypes is
+// asked for types that do not exist.
+//
+// Provenance, which is split. The *code* is documented: EC2's client-error table lists
+// InvalidInstanceType. The *message* comes from a single capture against real us-east-1,
+// reported in #485 alongside the substrate response it was diffed against — one type
+// produced `The following supplied instance types do not exist: [zz9.nonexistent]`, so
+// the brackets and the plural phrasing are observed, and the list form is what the
+// capture shows for a single element. The separator for a multi-type list is **not**
+// corroborated; ", " is substrate's choice, and a consumer must dispatch on the code.
+func ec2InvalidInstanceTypeError(types []string) *AWSError {
+	return &AWSError{
+		Code:       "InvalidInstanceType",
+		Message:    "The following supplied instance types do not exist: [" + strings.Join(types, ", ") + "]",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2CheckInstanceTypesExist returns an error naming every requested type absent from
+// [ec2InstanceTypeCatalog], in request order, or nil.
+//
+// This is deliberately asymmetric with the instance-type *filter*, which answers an
+// unmatched value with an empty result set and HTTP 200. The two are different questions:
+// InstanceType.N asserts the types exist, so a type that does not is a bad request, while
+// a filter narrows a result set, so a value that matches nothing is a legitimate empty
+// answer. #485 diffed both against real AWS and they diverge there too.
+//
+// All misses are collected into one error rather than raising on the first, because the
+// captured message carries a list.
+func ec2CheckInstanceTypesExist(types []string) *AWSError {
+	var unknown []string
+	for _, t := range types {
+		if _, ok := ec2InstanceTypeIndex[t]; !ok {
+			unknown = append(unknown, t)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	return ec2InvalidInstanceTypeError(unknown)
+}
+
+// ec2InvalidFilterError returns the error EC2 raises for a filter name an operation does
+// not accept.
+//
+// Provenance: the code is documented — EC2's client-error table lists
+// InvalidParameterValue as covering a value that "is not valid, is unsupported, or cannot
+// be used". The message is substrate's own; no capture of a rejected filter name exists,
+// and the API reference's Errors sections describe conditions rather than strings. It
+// names the offending filter because that is the one thing a caller needs.
+func ec2InvalidFilterError(name string) *AWSError {
+	return &AWSError{
+		Code:       "InvalidParameterValue",
+		Message:    fmt.Sprintf("The filter %q is not valid for this request", name),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2InvalidLocationTypeError returns the error EC2 raises for a LocationType outside the
+// documented set.
+//
+// DescribeInstanceTypeOfferings' reference gives the valid values as "region |
+// availability-zone | availability-zone-id | outpost", so a value outside that set is a
+// bad request whether or not substrate models it. Code documented, message substrate's
+// own — the wording follows [ec2UnknownInstanceAttribute]'s captured form, which is the
+// closest corroborated analog for a rejected EC2 parameter value.
+func ec2InvalidLocationTypeError(value string) *AWSError {
+	return &AWSError{
+		Code:       "InvalidParameterValue",
+		Message:    "Value (" + value + ") for parameter LocationType is invalid",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2UnmodelledLocationTypeError returns the error substrate raises for a LocationType
+// real EC2 accepts but substrate does not model.
+//
+// availability-zone-id and outpost are both valid values. Substrate reports AZ IDs from
+// DescribeAvailabilityZones but does not key offerings by them, and models no Outposts at
+// all. Refusing is the honest answer: treating either as availability-zone would return
+// zone *names* under a locationType saying they are IDs or ARNs, which a caller matching
+// the two would silently mis-read. The message names substrate so the divergence is not
+// mistaken for AWS behavior.
+func ec2UnmodelledLocationTypeError(value string) *AWSError {
+	return &AWSError{
+		Code: "InvalidParameterValue",
+		Message: "Value (" + value + ") for parameter LocationType is not modeled by " +
+			"substrate; use availability-zone or region",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2FilterValueMatches reports whether value satisfies one EC2 filter value.
+//
+// EC2's resource-filtering documentation gives the rules for API filters: "An asterisk
+// (*) matches zero or more characters, and a question mark (?) matches zero or one
+// character", a literal wildcard is escaped with a preceding backslash, and filter values
+// are case-sensitive — so the comparison here is too. DescribeInstanceTypes' reference
+// documents the form explicitly for this filter: "instance-type - The instance type (for
+// example c5.2xlarge or c5*)".
+//
+// path.Match is not used because its '?' matches exactly one character where EC2's
+// matches zero or one, and because it treats '/' specially.
+func ec2FilterValueMatches(pattern, value string) bool {
+	return ec2globMatch([]rune(pattern), []rune(value))
+}
+
+// ec2globMatch is [ec2FilterValueMatches] over runes. Matching is per character rather
+// than per byte so a multi-byte value is not split mid-rune by '?'.
+func ec2globMatch(pattern, value []rune) bool {
+	for len(pattern) > 0 {
+		switch pattern[0] {
+		case '*':
+			// Zero or more characters: try every split of the remaining value.
+			for i := 0; i <= len(value); i++ {
+				if ec2globMatch(pattern[1:], value[i:]) {
+					return true
+				}
+			}
+			return false
+		case '?':
+			// Zero or one character, so both branches must be tried.
+			if ec2globMatch(pattern[1:], value) {
+				return true
+			}
+			return len(value) > 0 && ec2globMatch(pattern[1:], value[1:])
+		case '\\':
+			if len(pattern) == 1 {
+				// A trailing backslash has nothing to escape; match it literally.
+				return len(value) == 1 && value[0] == '\\'
+			}
+			if len(value) == 0 || value[0] != pattern[1] {
+				return false
+			}
+			pattern, value = pattern[2:], value[1:]
+		default:
+			if len(value) == 0 || value[0] != pattern[0] {
+				return false
+			}
+			pattern, value = pattern[1:], value[1:]
+		}
+	}
+	return len(value) == 0
+}
+
+// ec2FilterAccepts reports whether value satisfies a filter's value list, which EC2
+// joins with OR.
+//
+// A filter carrying no values at all is treated as absent rather than as matching
+// nothing: [extractEC2Filters] records such a filter with an empty list, and dropping
+// every result for it would turn a malformed request into a silently empty answer.
+func ec2FilterAccepts(values []string, value string) bool {
+	if len(values) == 0 {
+		return true
+	}
+	for _, v := range values {
+		if ec2FilterValueMatches(v, value) {
+			return true
+		}
+	}
+	return false
+}

--- a/emulator/ec2_instancetypes_test.go
+++ b/emulator/ec2_instancetypes_test.go
@@ -1,0 +1,699 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ec2CatalogTypes returns every instance type DescribeInstanceTypes reports, sorted.
+//
+// The catalog is package-private, so these tests read it back through the API rather than
+// referencing the Go variable. That is deliberate beyond the package boundary: the
+// assertions then hold on the observation a consumer makes, which is the thing #485 was
+// filed about.
+func ec2CatalogTypes(t *testing.T, ts *httptest.Server) []string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{"Action": "DescribeInstanceTypes"})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result struct {
+		InstanceTypes []struct {
+			InstanceType string `xml:"instanceType"`
+		} `xml:"instanceTypeSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+	types := make([]string, 0, len(result.InstanceTypes))
+	for _, it := range result.InstanceTypes {
+		types = append(types, it.InstanceType)
+	}
+	sort.Strings(types)
+	return types
+}
+
+// catalogSize returns the number of types in the seeded instance-type catalog.
+func catalogSize(t *testing.T, ts *httptest.Server) int {
+	t.Helper()
+	return len(ec2CatalogTypes(t, ts))
+}
+
+// ec2Offerings returns the (instanceType, location, locationType) triples
+// DescribeInstanceTypeOfferings reports for params.
+func ec2Offerings(t *testing.T, ts *httptest.Server, params map[string]string) []ec2Offering {
+	t.Helper()
+	params["Action"] = "DescribeInstanceTypeOfferings"
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result struct {
+		Offerings []ec2Offering `xml:"instanceTypeOfferingSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+	return result.Offerings
+}
+
+// ec2Offering is one item of a DescribeInstanceTypeOfferings response.
+type ec2Offering struct {
+	InstanceType string `xml:"instanceType"`
+	LocationType string `xml:"locationType"`
+	Location     string `xml:"location"`
+}
+
+// offeringTypes returns the distinct instance types in a set of offerings, sorted.
+func offeringTypes(offerings []ec2Offering) []string {
+	seen := map[string]bool{}
+	var types []string
+	for _, o := range offerings {
+		if !seen[o.InstanceType] {
+			seen[o.InstanceType] = true
+			types = append(types, o.InstanceType)
+		}
+	}
+	sort.Strings(types)
+	return types
+}
+
+// TestEC2_DescribeInstanceTypes_UnknownTypeRejected covers #485 item 1: an instance type
+// absent from the catalog was answered with HTTP 200 and an empty list, where real AWS
+// raises InvalidInstanceType.
+//
+// This is the same failure shape as #391 (an unknown instance ID returned 200 and an
+// empty list rather than InvalidInstanceID.NotFound), and it matters for the same reason:
+// an empty list is indistinguishable from "the type exists but matched nothing", so a
+// consumer validating a user-supplied instance type gets no signal at all and their
+// validation branch is unreachable.
+func TestEC2_DescribeInstanceTypes_UnknownTypeRejected(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":         "DescribeInstanceTypes",
+		"InstanceType.1": "zz9.nonexistent",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidInstanceType", code)
+	// Verbatim from the real us-east-1 capture reported in #485.
+	assert.Equal(t, "The following supplied instance types do not exist: [zz9.nonexistent]", message)
+}
+
+// TestEC2_DescribeInstanceTypes_UnknownTypesListedTogether pins that every unknown type
+// is collected into one error, in request order, rather than raising on the first.
+//
+// The captured message carries a bracketed list, so a per-type error would be the wrong
+// shape. Request order rather than sorted order, because that is the only ordering the
+// caller can predict.
+func TestEC2_DescribeInstanceTypes_UnknownTypesListedTogether(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":         "DescribeInstanceTypes",
+		"InstanceType.1": "zz9.nonexistent",
+		"InstanceType.2": "aa1.bogus",
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidInstanceType", code)
+	assert.Equal(t, "The following supplied instance types do not exist: [zz9.nonexistent, aa1.bogus]", message)
+}
+
+// TestEC2_DescribeInstanceTypes_MixedKnownAndUnknown pins that one bad type fails the
+// whole request rather than returning the good ones.
+//
+// The message is an assertion that the *supplied* types exist, so a partial answer would
+// let a caller that checks only the result set miss the bad input entirely — which is the
+// defect #485 reported, just narrowed to one element of the request.
+func TestEC2_DescribeInstanceTypes_MixedKnownAndUnknown(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":         "DescribeInstanceTypes",
+		"InstanceType.1": "m5.xlarge",
+		"InstanceType.2": "zz9.nonexistent",
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidInstanceType", code)
+	assert.Equal(t, "The following supplied instance types do not exist: [zz9.nonexistent]", message,
+		"only the unknown type belongs in the message")
+}
+
+// TestEC2_DescribeInstanceTypes_KnownTypeUnaffected is the regression guard on the
+// rejection: a type in the catalog still returns its full item, and no filter still
+// returns the whole catalog.
+func TestEC2_DescribeInstanceTypes_KnownTypeUnaffected(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":         "DescribeInstanceTypes",
+		"InstanceType.1": "m5.xlarge",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result struct {
+		InstanceTypes []struct {
+			InstanceType string `xml:"instanceType"`
+			VCpuInfo     struct {
+				DefaultVCpus int `xml:"defaultVCpus"`
+			} `xml:"vCpuInfo"`
+			MemoryInfo struct {
+				SizeInMiB int `xml:"sizeInMiB"`
+			} `xml:"memoryInfo"`
+		} `xml:"instanceTypeSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+	require.Len(t, result.InstanceTypes, 1)
+	assert.Equal(t, "m5.xlarge", result.InstanceTypes[0].InstanceType)
+	assert.Equal(t, 4, result.InstanceTypes[0].VCpuInfo.DefaultVCpus)
+	assert.Equal(t, 16384, result.InstanceTypes[0].MemoryInfo.SizeInMiB)
+}
+
+// TestEC2_InstanceTypeCatalog_Specs pins a handful of vCPU and memory figures against the
+// AWS instance-type guides.
+//
+// The catalog is generated from per-family size lists rather than hand-written rows, so a
+// mistake in the generation would move every type at once — these rows are the fixed
+// points that catch it. They deliberately span the shapes that differ: the smallest
+// burstable size (sub-GiB memory), the size ladders that are *not* shared between an
+// Intel family and its AMD sibling (c5 has 9xlarge and 18xlarge where c5a has 8xlarge and
+// 16xlarge), the memory-optimized ratio, and the accelerated single sizes.
+func TestEC2_InstanceTypeCatalog_Specs(t *testing.T) {
+	tests := []struct {
+		instanceType string
+		vcpus        int
+		memoryMiB    int
+		gpus         int
+	}{
+		{instanceType: "t3.nano", vcpus: 2, memoryMiB: 512},
+		{instanceType: "t3.micro", vcpus: 2, memoryMiB: 1024},
+		{instanceType: "t3a.medium", vcpus: 2, memoryMiB: 4096},
+		{instanceType: "t3.2xlarge", vcpus: 8, memoryMiB: 32768},
+		{instanceType: "m5.large", vcpus: 2, memoryMiB: 8192},
+		{instanceType: "m5.24xlarge", vcpus: 96, memoryMiB: 393216},
+		{instanceType: "m5a.xlarge", vcpus: 4, memoryMiB: 16384},
+		{instanceType: "c5.large", vcpus: 2, memoryMiB: 4096},
+		{instanceType: "c5.9xlarge", vcpus: 36, memoryMiB: 73728},
+		{instanceType: "c5.18xlarge", vcpus: 72, memoryMiB: 147456},
+		{instanceType: "c5a.8xlarge", vcpus: 32, memoryMiB: 65536},
+		{instanceType: "c5a.16xlarge", vcpus: 64, memoryMiB: 131072},
+		{instanceType: "r5.large", vcpus: 2, memoryMiB: 16384},
+		{instanceType: "r5.24xlarge", vcpus: 96, memoryMiB: 786432},
+		{instanceType: "p3.2xlarge", vcpus: 8, memoryMiB: 62464, gpus: 1},
+		{instanceType: "g4dn.xlarge", vcpus: 4, memoryMiB: 16384, gpus: 1},
+		// inf1's accelerator is an Inferentia chip, which real EC2 does not report
+		// through gpuInfo, so the GPU count stays zero.
+		{instanceType: "inf1.xlarge", vcpus: 4, memoryMiB: 8192},
+	}
+
+	ts := newEC2TestServer(t)
+	for _, tt := range tests {
+		t.Run(tt.instanceType, func(t *testing.T) {
+			resp := ec2Request(t, ts, map[string]string{
+				"Action":         "DescribeInstanceTypes",
+				"InstanceType.1": tt.instanceType,
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var result struct {
+				InstanceTypes []struct {
+					InstanceType string `xml:"instanceType"`
+					VCpuInfo     struct {
+						DefaultVCpus int `xml:"defaultVCpus"`
+					} `xml:"vCpuInfo"`
+					MemoryInfo struct {
+						SizeInMiB int `xml:"sizeInMiB"`
+					} `xml:"memoryInfo"`
+					GpuInfo *struct {
+						Count int `xml:"gpus>item>count"`
+					} `xml:"gpuInfo"`
+				} `xml:"instanceTypeSet>item"`
+			}
+			require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+			require.Len(t, result.InstanceTypes, 1)
+			got := result.InstanceTypes[0]
+			assert.Equal(t, tt.vcpus, got.VCpuInfo.DefaultVCpus, "vCPUs")
+			assert.Equal(t, tt.memoryMiB, got.MemoryInfo.SizeInMiB, "memory MiB")
+			if tt.gpus == 0 {
+				assert.Nil(t, got.GpuInfo, "gpuInfo must be omitted for a type with no accelerator")
+				return
+			}
+			require.NotNil(t, got.GpuInfo)
+			assert.Equal(t, tt.gpus, got.GpuInfo.Count, "GPUs")
+		})
+	}
+}
+
+// TestEC2_InstanceTypeCatalog_WholeFamilies covers #485 item 3: the eight-type catalog
+// split families mid-way, so which sizes were present was incidental to #234's consumer.
+//
+// The ten types #485 names as the ones parsl-aws-provider references are asserted
+// present, five of which were absent before. Whole families matter beyond coverage: item
+// 1 refuses a type the catalog lacks, so a catalog that stopped at c5.xlarge would answer
+// InvalidInstanceType for c5.large — the right code for a bogus type and the wrong one
+// for a real one.
+func TestEC2_InstanceTypeCatalog_WholeFamilies(t *testing.T) {
+	ts := newEC2TestServer(t)
+	present := map[string]bool{}
+	for _, it := range ec2CatalogTypes(t, ts) {
+		present[it] = true
+	}
+
+	// The ten types #485 lists, with the five it reported ABSENT marked.
+	for _, want := range []string{
+		"t3.micro",   // present before
+		"t3.small",   // was absent
+		"t3.medium",  // was absent
+		"t3a.small",  // was absent
+		"t3a.medium", // was absent
+		"m5.large",   // present before
+		"m5.xlarge",  // was absent
+		"m5a.large",  // was absent
+		"c5.large",   // was absent
+		"c5.xlarge",  // present before
+	} {
+		assert.True(t, present[want], "#485 names %s; it must be in the catalog", want)
+	}
+
+	// Every family is complete, so no family has a hole a caller could trip on.
+	families := map[string][]string{
+		"t3":  {"nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"},
+		"t3a": {"nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"},
+		"m5":  {"large", "xlarge", "2xlarge", "4xlarge", "8xlarge", "12xlarge", "16xlarge", "24xlarge"},
+		"m5a": {"large", "xlarge", "2xlarge", "4xlarge", "8xlarge", "12xlarge", "16xlarge", "24xlarge"},
+		"c5":  {"large", "xlarge", "2xlarge", "4xlarge", "9xlarge", "12xlarge", "18xlarge", "24xlarge"},
+		"c5a": {"large", "xlarge", "2xlarge", "4xlarge", "8xlarge", "12xlarge", "16xlarge", "24xlarge"},
+		"r5":  {"large", "xlarge", "2xlarge", "4xlarge", "8xlarge", "12xlarge", "16xlarge", "24xlarge"},
+	}
+	for family, sizes := range families {
+		for _, size := range sizes {
+			assert.True(t, present[family+"."+size], "%s.%s missing from the catalog", family, size)
+		}
+	}
+
+	// Bare-metal sizes are deliberately excluded: they are real types, but nothing else in
+	// the plugin models their behavior, so returning them would advertise fidelity that
+	// is not there. Pinned so the exclusion is a decision rather than an oversight.
+	for _, metal := range []string{"m5.metal", "c5.metal", "r5.metal"} {
+		assert.False(t, present[metal], "%s should not be in the catalog", metal)
+	}
+}
+
+// TestEC2_SpotPriceCatalog_Parity pins that every catalog type has a spot price.
+//
+// The catalog and the prices were two parallel structures with the same eight keys, and a
+// type in one and not the other was the next bug: describeSpotPriceHistory silently
+// skipped any type absent from the price map, so a caller would see the type from
+// DescribeInstanceTypes and no price for it. They are now generated together; this asserts
+// the property that made that safe, through the API rather than the Go types.
+func TestEC2_SpotPriceCatalog_Parity(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":           "DescribeSpotPriceHistory",
+		"AvailabilityZone": "us-east-1a",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result struct {
+		Items []struct {
+			InstanceType string `xml:"instanceType"`
+			SpotPrice    string `xml:"spotPrice"`
+		} `xml:"spotPriceHistorySet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+
+	priced := map[string]string{}
+	for _, item := range result.Items {
+		priced[item.InstanceType] = item.SpotPrice
+	}
+	for _, it := range ec2CatalogTypes(t, ts) {
+		price, ok := priced[it]
+		assert.True(t, ok, "%s is in the instance-type catalog but has no spot price", it)
+		assert.NotEmpty(t, price, "%s has an empty spot price", it)
+	}
+	assert.Len(t, priced, catalogSize(t, ts), "spot prices exist for types not in the catalog")
+}
+
+// TestEC2_SpotPriceCatalog_PreservesSeededPrices pins the eight prices #234's catalog
+// shipped, unchanged by the widening.
+//
+// The prices are deterministic stubs, not researched AWS figures, so the reason to pin
+// them is fixture stability rather than fidelity: a consumer with a recorded run must not
+// see its numbers move because the catalog grew.
+func TestEC2_SpotPriceCatalog_PreservesSeededPrices(t *testing.T) {
+	seeded := map[string]string{
+		"t3.micro":    "0.0042",
+		"c5.xlarge":   "0.068",
+		"c5.2xlarge":  "0.136",
+		"m5.large":    "0.038",
+		"r5.xlarge":   "0.076",
+		"p3.2xlarge":  "0.918",
+		"g4dn.xlarge": "0.188",
+		"inf1.xlarge": "0.076",
+	}
+
+	ts := newEC2TestServer(t)
+	for instanceType, want := range seeded {
+		t.Run(instanceType, func(t *testing.T) {
+			resp := ec2Request(t, ts, map[string]string{
+				"Action":           "DescribeSpotPriceHistory",
+				"InstanceType.1":   instanceType,
+				"AvailabilityZone": "us-east-1a",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			var result struct {
+				Items []struct {
+					SpotPrice string `xml:"spotPrice"`
+				} `xml:"spotPriceHistorySet>item"`
+			}
+			require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+			require.Len(t, result.Items, 1)
+			assert.Equal(t, want, result.Items[0].SpotPrice)
+		})
+	}
+}
+
+// TestEC2_DescribeSpotPriceHistory_UnknownTypeIsEmpty pins that InstanceType.N here is a
+// filter, not an assertion.
+//
+// The reference describes it as filtering the results, unlike DescribeInstanceTypes' same-
+// named parameter, so an unknown type is an empty history and HTTP 200. Asserted
+// deliberately: the two operations spell the parameter identically and behave differently,
+// which is exactly the kind of thing a later change would "tidy" into consistency.
+func TestEC2_DescribeSpotPriceHistory_UnknownTypeIsEmpty(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":         "DescribeSpotPriceHistory",
+		"InstanceType.1": "zz9.nonexistent",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result struct {
+		Items []struct {
+			InstanceType string `xml:"instanceType"`
+		} `xml:"spotPriceHistorySet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&result))
+	assert.Empty(t, result.Items)
+}
+
+// TestEC2_DescribeInstanceTypeOfferings_InstanceTypeFilter covers #485 item 2: the
+// instance-type filter was unreachable dead code, so every offerings query returned the
+// whole catalog in every AZ regardless of the filter.
+//
+// The cause was that the handler built its type filter from an `InstanceType.N` parameter
+// the operation does not have — the reference's parameters are DryRun, Filter.N,
+// LocationType, MaxResults and NextToken, and botocore rejects `InstanceTypes` outright —
+// so the filter map was always empty. A caller asking "is m5.xlarge offered in this AZ?"
+// got yes for any input, including nonsense.
+func TestEC2_DescribeInstanceTypeOfferings_InstanceTypeFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		values    map[string]string
+		wantTypes []string
+		// wantAllCatalog asserts the answer is the whole catalog, for the no-filter case.
+		wantAllCatalog bool
+		// wantEmpty asserts zero offerings and HTTP 200.
+		wantEmpty bool
+	}{
+		{
+			name:      "one exact type",
+			values:    map[string]string{"Filter.1.Name": "instance-type", "Filter.1.Value.1": "m5.xlarge"},
+			wantTypes: []string{"m5.xlarge"},
+		},
+		{
+			name: "two values are an OR",
+			values: map[string]string{
+				"Filter.1.Name":    "instance-type",
+				"Filter.1.Value.1": "m5.xlarge",
+				"Filter.1.Value.2": "c5.large",
+			},
+			wantTypes: []string{"c5.large", "m5.xlarge"},
+		},
+		{
+			// The reference documents this form on DescribeInstanceTypes' instance-type
+			// filter: "The instance type (for example c5.2xlarge or c5*)".
+			name:   "trailing wildcard selects a family",
+			values: map[string]string{"Filter.1.Name": "instance-type", "Filter.1.Value.1": "c5.*"},
+			wantTypes: []string{
+				"c5.12xlarge", "c5.18xlarge", "c5.24xlarge", "c5.2xlarge",
+				"c5.4xlarge", "c5.9xlarge", "c5.large", "c5.xlarge",
+			},
+		},
+		{
+			// c5* without the dot also matches the c5a family, since * matches any
+			// characters — including the "a".
+			name:   "wildcard without the dot spans sibling families",
+			values: map[string]string{"Filter.1.Name": "instance-type", "Filter.1.Value.1": "c5*"},
+			wantTypes: []string{
+				"c5.12xlarge", "c5.18xlarge", "c5.24xlarge", "c5.2xlarge",
+				"c5.4xlarge", "c5.9xlarge", "c5.large", "c5.xlarge",
+				"c5a.12xlarge", "c5a.16xlarge", "c5a.24xlarge", "c5a.2xlarge",
+				"c5a.4xlarge", "c5a.8xlarge", "c5a.large", "c5a.xlarge",
+			},
+		},
+		{
+			name:      "a mid-string wildcard",
+			values:    map[string]string{"Filter.1.Name": "instance-type", "Filter.1.Value.1": "*.24xlarge"},
+			wantTypes: []string{"c5.24xlarge", "c5a.24xlarge", "m5.24xlarge", "m5a.24xlarge", "r5.24xlarge"},
+		},
+		{
+			// EC2 documents API filter values as case-sensitive.
+			name:      "filter values are case sensitive",
+			values:    map[string]string{"Filter.1.Name": "instance-type", "Filter.1.Value.1": "M5.XLarge"},
+			wantEmpty: true,
+		},
+		{
+			// #485's real-AWS diff: 0 offerings, not an error. A filter that matches
+			// nothing is a legitimate empty answer, unlike InstanceType.N on
+			// DescribeInstanceTypes, which asserts the type exists.
+			name:      "an unknown type yields zero offerings",
+			values:    map[string]string{"Filter.1.Name": "instance-type", "Filter.1.Value.1": "zz9.bogus"},
+			wantEmpty: true,
+		},
+		{
+			name:           "no filter returns the whole catalog",
+			values:         map[string]string{},
+			wantAllCatalog: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			offerings := ec2Offerings(t, ts, tt.values)
+
+			switch {
+			case tt.wantEmpty:
+				assert.Empty(t, offerings, "an unmatched filter must be an empty answer, not an error")
+			case tt.wantAllCatalog:
+				assert.Equal(t, ec2CatalogTypes(t, ts), offeringTypes(offerings))
+				assert.Len(t, offerings, catalogSize(t, ts)*3, "one offering per type per seeded AZ")
+			default:
+				assert.Equal(t, tt.wantTypes, offeringTypes(offerings))
+				assert.Len(t, offerings, len(tt.wantTypes)*3, "one offering per type per seeded AZ")
+			}
+		})
+	}
+}
+
+// TestEC2_DescribeInstanceTypeOfferings_LocationValues pins that all of a location
+// filter's values are read, not just Value.1, and that the two filters AND together.
+//
+// The old handler read `Filter.N.Value.1` for the location and discarded the rest, so a
+// two-AZ query silently answered for one AZ.
+func TestEC2_DescribeInstanceTypeOfferings_LocationValues(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	offerings := ec2Offerings(t, ts, map[string]string{
+		"Filter.1.Name":    "location",
+		"Filter.1.Value.1": "us-east-1a",
+		"Filter.1.Value.2": "us-east-1c",
+		"Filter.2.Name":    "instance-type",
+		"Filter.2.Value.1": "m5.large",
+	})
+	require.Len(t, offerings, 2, "one type in two of the three AZs")
+	locations := []string{offerings[0].Location, offerings[1].Location}
+	sort.Strings(locations)
+	assert.Equal(t, []string{"us-east-1a", "us-east-1c"}, locations)
+	for _, o := range offerings {
+		assert.Equal(t, "m5.large", o.InstanceType)
+	}
+}
+
+// TestEC2_DescribeInstanceTypeOfferings_LocationType covers the top-level LocationType
+// parameter, which #485 mistook for a filter name.
+//
+// The reference lists it as a separate parameter with four valid values, and lists exactly
+// two filter names (instance-type, location) — so `location-type` is not a filter at all.
+// region and availability-zone are modeled; availability-zone-id and outpost are refused
+// rather than silently answered as zone names, since a caller matching the locationType
+// against the location would otherwise mis-read zone names as AZ IDs or Outpost ARNs.
+func TestEC2_DescribeInstanceTypeOfferings_LocationType(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	t.Run("region gives one offering per type", func(t *testing.T) {
+		offerings := ec2Offerings(t, ts, map[string]string{"LocationType": "region"})
+		assert.Len(t, offerings, catalogSize(t, ts))
+		for _, o := range offerings {
+			assert.Equal(t, "region", o.LocationType)
+			assert.Equal(t, "us-east-1", o.Location)
+		}
+	})
+
+	t.Run("availability-zone is the default", func(t *testing.T) {
+		defaulted := ec2Offerings(t, ts, map[string]string{})
+		explicit := ec2Offerings(t, ts, map[string]string{"LocationType": "availability-zone"})
+		assert.Equal(t, defaulted, explicit)
+		require.NotEmpty(t, defaulted)
+		assert.Equal(t, "availability-zone", defaulted[0].LocationType)
+	})
+
+	t.Run("region honors a location filter naming the region", func(t *testing.T) {
+		offerings := ec2Offerings(t, ts, map[string]string{
+			"LocationType":     "region",
+			"Filter.1.Name":    "location",
+			"Filter.1.Value.1": "us-east-1",
+			"Filter.2.Name":    "instance-type",
+			"Filter.2.Value.1": "t3.micro",
+		})
+		require.Len(t, offerings, 1)
+		assert.Equal(t, "us-east-1", offerings[0].Location)
+	})
+
+	for _, unmodelled := range []string{"availability-zone-id", "outpost"} {
+		t.Run(unmodelled+" is refused", func(t *testing.T) {
+			status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+				"Action":       "DescribeInstanceTypeOfferings",
+				"LocationType": unmodelled,
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Contains(t, message, "not modeled by substrate",
+				"the message must name substrate, so the divergence is not read as AWS behavior")
+		})
+	}
+
+	t.Run("a value outside the documented set is refused", func(t *testing.T) {
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":       "DescribeInstanceTypeOfferings",
+			"LocationType": "planet",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+	})
+}
+
+// TestEC2_DescribeInstanceTypeOfferings_UnknownFilterRefused pins that a filter name the
+// operation does not document is refused rather than ignored.
+//
+// Silently ignoring a filter is precisely how #485's defect went unnoticed: the query
+// looked like it had been narrowed and had not been. The operation documents exactly two
+// filter names, so anything else — including `location-type`, which #485 believed was one
+// — is a bad request.
+func TestEC2_DescribeInstanceTypeOfferings_UnknownFilterRefused(t *testing.T) {
+	for _, name := range []string{"location-type", "instance-family", "vcpu-info.default-vcpus"} {
+		t.Run(name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+				"Action":           "DescribeInstanceTypeOfferings",
+				"Filter.1.Name":    name,
+				"Filter.1.Value.1": "whatever",
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Contains(t, message, name, "the message should name the offending filter")
+		})
+	}
+}
+
+// TestEC2_DescribeInstanceTypeOfferings_LocationsMatchDescribeAvailabilityZones pins that
+// an offerings query filtered by a zone DescribeAvailabilityZones reported returns
+// something.
+//
+// Both derive their zone list from one place. Two independent lists is a plausible-looking
+// bug: a caller enumerating zones and then asking which types each offers would get an
+// empty answer for a zone that exists.
+func TestEC2_DescribeInstanceTypeOfferings_LocationsMatchDescribeAvailabilityZones(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{"Action": "DescribeAvailabilityZones"})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var zones struct {
+		Zones []struct {
+			ZoneName string `xml:"zoneName"`
+		} `xml:"availabilityZoneInfo>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&zones))
+	require.NotEmpty(t, zones.Zones)
+
+	for _, z := range zones.Zones {
+		offerings := ec2Offerings(t, ts, map[string]string{
+			"Filter.1.Name":    "location",
+			"Filter.1.Value.1": z.ZoneName,
+		})
+		assert.Len(t, offerings, catalogSize(t, ts), "zone %s offers no instance types", z.ZoneName)
+	}
+}
+
+// TestEC2_FilterWildcards covers the wildcard rules EC2 documents for API filter values,
+// through the instance-type filter.
+//
+// The rules, from EC2's resource-filtering documentation: "An asterisk (*) matches zero or
+// more characters, and a question mark (?) matches zero or one character", and a literal
+// wildcard is escaped with a backslash. The '?' rule is the one that rules out
+// path.Match, whose '?' matches exactly one character — the doc's own example is that
+// against prod/prods/production, "prod?" matches only prod and prods.
+func TestEC2_FilterWildcards(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantTypes []string
+	}{
+		{
+			name:      "asterisk matches zero characters",
+			value:     "m5.large*",
+			wantTypes: []string{"m5.large"},
+		},
+		{
+			name:      "question mark matches zero or one character",
+			value:     "t3?.micro",
+			wantTypes: []string{"t3.micro", "t3a.micro"},
+		},
+		{
+			name:      "a bare asterisk matches everything",
+			value:     "*",
+			wantTypes: nil, // the whole catalog; asserted below
+		},
+		{
+			name:      "an escaped asterisk is a literal",
+			value:     `m5.larg\*`,
+			wantTypes: nil, // matches nothing; no type contains an asterisk
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			offerings := ec2Offerings(t, ts, map[string]string{
+				"Filter.1.Name":    "instance-type",
+				"Filter.1.Value.1": tt.value,
+			})
+			switch {
+			case tt.value == "*":
+				assert.Equal(t, ec2CatalogTypes(t, ts), offeringTypes(offerings))
+			case strings.Contains(tt.value, `\`):
+				assert.Empty(t, offerings, "an escaped wildcard must not match as a wildcard")
+			default:
+				assert.Equal(t, tt.wantTypes, offeringTypes(offerings))
+			}
+		})
+	}
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -3243,7 +3243,6 @@ func (p *EC2Plugin) describeAvailabilityZones(reqCtx *RequestContext, _ *AWSRequ
 	region := reqCtx.Region
 	// Derive abbreviated region for zoneId (e.g. "use1" from "us-east-1").
 	abbrev := azRegionAbbrev(region)
-	azSuffixes := []string{"a", "b", "c"}
 	type azItem struct {
 		ZoneName   string `xml:"zoneName"`
 		State      string `xml:"zoneState"`
@@ -3256,7 +3255,7 @@ func (p *EC2Plugin) describeAvailabilityZones(reqCtx *RequestContext, _ *AWSRequ
 		AvailabilityZones []azItem `xml:"availabilityZoneInfo>item"`
 	}
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
-	for i, suffix := range azSuffixes {
+	for i, suffix := range ec2SeededAZSuffixes {
 		resp.AvailabilityZones = append(resp.AvailabilityZones, azItem{
 			ZoneName:   region + suffix,
 			State:      "available",
@@ -3938,54 +3937,24 @@ func (p *EC2Plugin) describeRegions(_ *RequestContext, req *AWSRequest) (*AWSRes
 	return ec2XMLResponse(http.StatusOK, resp)
 }
 
-// --- Instance type and spot price catalog ------------------------------------
-
-// ec2InstanceTypeCatalog is a pre-seeded catalog of common instance types
-// available for use without real AWS credentials.
-var ec2InstanceTypeCatalog = []ec2InstanceTypeInfo{
-	{InstanceType: "t3.micro", VCpus: 2, MemoryMiB: 1024, GPU: 0, SupportedArchs: []string{"x86_64"}, SupportedUsageClasses: []string{"on-demand", "spot"}},
-	{InstanceType: "c5.xlarge", VCpus: 4, MemoryMiB: 8192, GPU: 0, SupportedArchs: []string{"x86_64"}, SupportedUsageClasses: []string{"on-demand", "spot"}},
-	{InstanceType: "c5.2xlarge", VCpus: 8, MemoryMiB: 16384, GPU: 0, SupportedArchs: []string{"x86_64"}, SupportedUsageClasses: []string{"on-demand", "spot"}},
-	{InstanceType: "m5.large", VCpus: 2, MemoryMiB: 8192, GPU: 0, SupportedArchs: []string{"x86_64"}, SupportedUsageClasses: []string{"on-demand", "spot"}},
-	{InstanceType: "r5.xlarge", VCpus: 4, MemoryMiB: 32768, GPU: 0, SupportedArchs: []string{"x86_64"}, SupportedUsageClasses: []string{"on-demand", "spot"}},
-	{InstanceType: "p3.2xlarge", VCpus: 8, MemoryMiB: 62464, GPU: 1, SupportedArchs: []string{"x86_64"}, SupportedUsageClasses: []string{"on-demand", "spot"}},
-	{InstanceType: "g4dn.xlarge", VCpus: 4, MemoryMiB: 16384, GPU: 1, SupportedArchs: []string{"x86_64"}, SupportedUsageClasses: []string{"on-demand", "spot"}},
-	{InstanceType: "inf1.xlarge", VCpus: 4, MemoryMiB: 8192, GPU: 0, SupportedArchs: []string{"x86_64"}, SupportedUsageClasses: []string{"on-demand", "spot"}},
-}
-
-// ec2SpotPriceCatalog maps instance type to stub spot price (USD/hr).
-var ec2SpotPriceCatalog = map[string]string{
-	"t3.micro":    "0.0042",
-	"c5.xlarge":   "0.068",
-	"c5.2xlarge":  "0.136",
-	"m5.large":    "0.038",
-	"r5.xlarge":   "0.076",
-	"p3.2xlarge":  "0.918",
-	"g4dn.xlarge": "0.188",
-	"inf1.xlarge": "0.076",
-}
-
-// ec2InstanceTypeInfo holds the details for one instance type in the catalog.
-type ec2InstanceTypeInfo struct {
-	InstanceType          string
-	VCpus                 int
-	MemoryMiB             int
-	GPU                   int
-	SupportedArchs        []string
-	SupportedUsageClasses []string
-}
-
 // --- DescribeInstanceTypes ---------------------------------------------------
 
-func (p *EC2Plugin) describeInstanceTypes(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	// Build filter set from InstanceType.N params.
+// describeInstanceTypes answers from the seeded [ec2InstanceTypeCatalog].
+//
+// Filter.N is not applied. The operation documents some 60 filter names, nearly all over
+// response fields the seeded catalog does not carry, so applying the handful that are
+// modellable and ignoring the rest would be the same silent-narrowing defect #485
+// reported on the offerings operation (TODO(#495): apply the filters the catalog can
+// answer and refuse the rest). InstanceType.N is honored, and unlike a filter it is an
+// assertion that the types exist.
+func (p *EC2Plugin) describeInstanceTypes(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	requested := indexedParams(req.Params, "InstanceType.%d")
+	if err := ec2CheckInstanceTypesExist(requested); err != nil {
+		return nil, err
+	}
 	wanted := map[string]bool{}
-	for i := 1; ; i++ {
-		v := req.Params[fmt.Sprintf("InstanceType.%d", i)]
-		if v == "" {
-			break
-		}
-		wanted[v] = true
+	for _, t := range requested {
+		wanted[t] = true
 	}
 
 	type gpuInfoItem struct {
@@ -4043,30 +4012,51 @@ func (p *EC2Plugin) describeInstanceTypes(reqCtx *RequestContext, req *AWSReques
 
 // --- DescribeInstanceTypeOfferings ------------------------------------------
 
+// describeInstanceTypeOfferings lists the seeded catalog's types per location.
+//
+// The operation's filters are exactly two — its reference lists `instance-type` and
+// `location` and no others — so both are applied and any other name is refused. Before
+// #485 this read `wantedTypes` from an `InstanceType.N` parameter the operation does not
+// have (the reference's parameters are `DryRun`, `Filter.N`, `LocationType`, `MaxResults`
+// and `NextToken`; botocore rejects `InstanceTypes` outright), so the type filter was
+// unreachable dead code and every query returned the whole catalog. The pattern had been
+// copied from describeInstanceTypes, where the parameter does exist.
+//
+// An `instance-type` value matching nothing yields **zero offerings and HTTP 200**, not
+// InvalidInstanceType. That is deliberately the opposite of DescribeInstanceTypes'
+// InstanceType.N; see [ec2CheckInstanceTypesExist] for why, and #485 for the real-AWS
+// diff of both.
 func (p *EC2Plugin) describeInstanceTypeOfferings(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	// Build filter map from Filter.N.{Name,Value.1} params.
-	locationFilter := ""
-	for i := 1; ; i++ {
-		name := req.Params[fmt.Sprintf("Filter.%d.Name", i)]
-		if name == "" {
-			break
+	filters := extractEC2Filters(req.Params)
+	for name := range filters {
+		if name != "instance-type" && name != "location" {
+			return nil, ec2InvalidFilterError(name)
 		}
-		if name == "location" {
-			locationFilter = req.Params[fmt.Sprintf("Filter.%d.Value.1", i)]
-		}
-	}
-	// Build instance-type filter from InstanceType.N params.
-	wantedTypes := map[string]bool{}
-	for i := 1; ; i++ {
-		v := req.Params[fmt.Sprintf("InstanceType.%d", i)]
-		if v == "" {
-			break
-		}
-		wantedTypes[v] = true
 	}
 
-	region := reqCtx.Region
-	azSuffixes := []string{"a", "b", "c"}
+	// LocationType is a top-level parameter, not a filter name, and it selects what the
+	// locations in the response *are*. Only availability-zone (the default per the
+	// reference — "If no location is specified, the default is to list the instance types
+	// that are offered in the current Region") and region are modeled;
+	// availability-zone-id and outpost are documented as unmodelled in docs/services.md,
+	// and are refused rather than silently treated as availability-zone.
+	locationType := req.Params["LocationType"]
+	if locationType == "" {
+		locationType = "availability-zone"
+	}
+	var locations []string
+	switch locationType {
+	case "availability-zone":
+		for _, suffix := range ec2SeededAZSuffixes {
+			locations = append(locations, reqCtx.Region+suffix)
+		}
+	case "region":
+		locations = []string{reqCtx.Region}
+	case "availability-zone-id", "outpost":
+		return nil, ec2UnmodelledLocationTypeError(locationType)
+	default:
+		return nil, ec2InvalidLocationTypeError(locationType)
+	}
 
 	type offeringItem struct {
 		InstanceType string `xml:"instanceType"`
@@ -4081,18 +4071,17 @@ func (p *EC2Plugin) describeInstanceTypeOfferings(reqCtx *RequestContext, req *A
 
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 	for _, info := range ec2InstanceTypeCatalog {
-		if len(wantedTypes) > 0 && !wantedTypes[info.InstanceType] {
+		if !ec2FilterAccepts(filters["instance-type"], info.InstanceType) {
 			continue
 		}
-		for _, suffix := range azSuffixes {
-			az := region + suffix
-			if locationFilter != "" && locationFilter != az && locationFilter != region {
+		for _, loc := range locations {
+			if !ec2FilterAccepts(filters["location"], loc) {
 				continue
 			}
 			resp.InstanceTypeOfferings = append(resp.InstanceTypeOfferings, offeringItem{
 				InstanceType: info.InstanceType,
-				LocationType: "availability-zone",
-				Location:     az,
+				LocationType: locationType,
+				Location:     loc,
 			})
 		}
 	}
@@ -4101,15 +4090,17 @@ func (p *EC2Plugin) describeInstanceTypeOfferings(reqCtx *RequestContext, req *A
 
 // --- DescribeSpotPriceHistory ------------------------------------------------
 
+// describeSpotPriceHistory reports one stub price per catalog type per Availability Zone.
+//
+// InstanceType.N here is a filter, not an assertion: the reference describes it as
+// "Filters the results by the specified instance types", so an unknown type yields an
+// empty history rather than InvalidInstanceType. That is the opposite of
+// DescribeInstanceTypes, whose InstanceType.N asserts existence; see
+// [ec2CheckInstanceTypesExist].
 func (p *EC2Plugin) describeSpotPriceHistory(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	// Build instance-type filter from InstanceType.N params.
 	wantedTypes := map[string]bool{}
-	for i := 1; ; i++ {
-		v := req.Params[fmt.Sprintf("InstanceType.%d", i)]
-		if v == "" {
-			break
-		}
-		wantedTypes[v] = true
+	for _, t := range indexedParams(req.Params, "InstanceType.%d") {
+		wantedTypes[t] = true
 	}
 	// AZ filter.
 	azFilter := req.Params["AvailabilityZone"]
@@ -4117,7 +4108,6 @@ func (p *EC2Plugin) describeSpotPriceHistory(reqCtx *RequestContext, req *AWSReq
 	pdFilter := req.Params["ProductDescription.1"]
 
 	region := reqCtx.Region
-	azSuffixes := []string{"a", "b", "c"}
 	// Stub timestamp: use time controller's current time.
 	ts := p.tc.Now().UTC().Format(time.RFC3339)
 
@@ -4139,15 +4129,11 @@ func (p *EC2Plugin) describeSpotPriceHistory(reqCtx *RequestContext, req *AWSReq
 		if len(wantedTypes) > 0 && !wantedTypes[info.InstanceType] {
 			continue
 		}
-		price, ok := ec2SpotPriceCatalog[info.InstanceType]
-		if !ok {
-			continue
-		}
 		desc := "Linux/UNIX"
 		if pdFilter != "" && pdFilter != desc {
 			continue
 		}
-		for _, suffix := range azSuffixes {
+		for _, suffix := range ec2SeededAZSuffixes {
 			az := region + suffix
 			if azFilter != "" && azFilter != az {
 				continue
@@ -4155,7 +4141,7 @@ func (p *EC2Plugin) describeSpotPriceHistory(reqCtx *RequestContext, req *AWSReq
 			resp.SpotPriceHistory = append(resp.SpotPriceHistory, spotPriceItem{
 				InstanceType:       info.InstanceType,
 				ProductDescription: desc,
-				SpotPrice:          price,
+				SpotPrice:          info.SpotPrice,
 				Timestamp:          ts,
 				AvailabilityZone:   az,
 			})

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -2466,9 +2466,12 @@ func TestEC2_DescribeInstanceTypeOfferings(t *testing.T) {
 	if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	// 8 types * 3 AZs = 24 offerings.
-	if len(result.Offerings) != 24 {
-		t.Fatalf("expected 24 offerings (8 types * 3 AZs), got %d", len(result.Offerings))
+	// Every catalog type in each of the three seeded AZs. Derived from the catalog rather
+	// than a literal: #485 widened the catalog from 8 types to whole families, and a
+	// hardcoded count made every such widening look like a regression.
+	want := catalogSize(t, ts) * 3
+	if len(result.Offerings) != want {
+		t.Fatalf("expected %d offerings (catalog * 3 AZs), got %d", want, len(result.Offerings))
 	}
 }
 
@@ -2494,9 +2497,8 @@ func TestEC2_DescribeInstanceTypeOfferings_LocationFilter(t *testing.T) {
 	if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	// 8 types * 1 AZ = 8 offerings.
-	if len(result.Offerings) != 8 {
-		t.Fatalf("expected 8 offerings for us-east-1a, got %d", len(result.Offerings))
+	if want := catalogSize(t, ts); len(result.Offerings) != want {
+		t.Fatalf("expected %d offerings for us-east-1a, got %d", want, len(result.Offerings))
 	}
 	for _, o := range result.Offerings {
 		if o.Location != "us-east-1a" {
@@ -2563,9 +2565,8 @@ func TestEC2_DescribeSpotPriceHistory_AZFilter(t *testing.T) {
 	if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	// 8 types * 1 AZ = 8 items.
-	if len(result.Items) != 8 {
-		t.Fatalf("expected 8 spot price items (8 types * us-east-1b), got %d", len(result.Items))
+	if want := catalogSize(t, ts); len(result.Items) != want {
+		t.Fatalf("expected %d spot price items (catalog * us-east-1b), got %d", want, len(result.Items))
 	}
 	for _, item := range result.Items {
 		if item.AZ != "us-east-1b" {


### PR DESCRIPTION
Closes #485

All three of #485's items, in one PR because they depend on each other: refusing a
type the catalog lacks is only honest once the catalog holds whole families.

## 1. `DescribeInstanceTypes` refuses an unknown type

An unknown type was answered with HTTP 200 and an empty list. Real `us-east-1`
raises `InvalidInstanceType` / 400. This is the #391 shape again — an empty list is
indistinguishable from "the type exists but matched nothing", so a consumer
validating a user-supplied instance type has an unreachable error branch.

Every unknown type in the request is collected into one bracketed list, in request
order, and one bad type fails the whole request: `InstanceType.N` is an assertion
that the supplied types exist, so a partial answer would let a caller checking only
the result set miss the bad input.

**Provenance is split.** The code is from EC2's client-error table. The message is
verbatim from the single real-`us-east-1` capture in #485, so the brackets and
plural phrasing are observed; the `", "` separator for a multi-type list is **not**
corroborated and is substrate's choice.

## 2. The offerings `instance-type` filter now works

It had never worked. The handler built its filter from an `InstanceType.N`
parameter **the operation does not have** — the reference lists exactly `DryRun`,
`Filter.N`, `LocationType`, `MaxResults`, `NextToken`, and botocore rejects
`InstanceTypes` outright. So the filter map was always empty and every query
returned the whole catalog in every zone: "is `m5.xlarge` offered here?" answered
yes for any input. The pattern was copied from `DescribeInstanceTypes`, where the
parameter does exist.

Both documented filter names now apply, with EC2's documented wildcards (`*` zero
or more, `?` zero **or one**, `\` escapes), case-sensitive values, all
`Filter.N.Value.M` as an OR and separate `Filter.N` ANDed. `path.Match` is unusable
here: its `?` matches exactly one character.

Any other filter name is **refused**, not ignored — silently dropping a filter is
how this went unnoticed for four releases. That includes `location-type`, which
#485's aside believed was a filter name; it is not, and a test pins the rejection.
`LocationType` is honoured as the top-level parameter it is: `availability-zone`
(default) and `region`. `availability-zone-id` and `outpost` are real AWS values
substrate does not model and are refused with a message naming substrate — treating
either as `availability-zone` would return zone *names* under a `locationType`
claiming they are IDs or Outpost ARNs.

An unmatched filter is **0 offerings at HTTP 200**, deliberately the opposite of
`InstanceType.N` and confirmed by #485's real-AWS diff of both. A filter narrows a
result set; `InstanceType.N` asserts existence. Both halves are pinned so neither
can later be "tidied" into consistency with the other.

## 3. The catalog covers whole families

8 types → 57. The old catalog split families mid-way (`c5.xlarge` in, `c5.large`
out), which was incidental to #234's consumer and becomes a correctness problem the
moment an absent type is refused. `t3`, `t3a`, `m5`, `m5a`, `c5`, `c5a`, `r5` are
complete — note `c5`'s ladder differs from `c5a`'s (`9xlarge`/`18xlarge` vs
`8xlarge`/`16xlarge`) — plus the three accelerated sizes. All ten types #485 names
are present; five were not. Bare metal is excluded, pinned by a test.

Spot prices are generated from the same per-family table as the specs, so the
old parallel-map hazard is gone (`DescribeSpotPriceHistory` silently dropped any
type absent from the price map). The eight prices #234 shipped are preserved
verbatim so no recorded fixture moves. The three zone-name sites share one list, so
filtering an offerings query by a zone `DescribeAvailabilityZones` just reported
cannot return empty.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `make test`
(race), `make docs-reference docs-reference-check docs-versions`, VitePress build,
`go test -C test/e2e ./...` — all clean.

**Mutation tested: 27 mutations, 27 caught, 0 survived.** Including both directions
the plan called for — returning empty instead of `InvalidInstanceType`, *and*
raising on an unmatched offerings filter — plus counting `?` as exactly-one,
case-insensitive matching, byte-vs-rune, a mid-family catalog split, bare metal
re-added, a moved seeded price, and the offerings zone list diverging from
`DescribeAvailabilityZones`.

End to end against `substrate server`: 57 types; 171 = 57×3 offerings unfiltered;
`LocationType=region` → 57 at one location; `m5.xlarge` → 3; `zz9.bogus` → 0 at
200; `zz9.nonexistent` → 400 `InvalidInstanceType`; `location-type` → 400;
`outpost` → 400 naming substrate; `t3.micro` price still `0.0042`.

## Follow-up filed

#495 — `DescribeInstanceTypes` ignores `Filter.N` entirely. The operation documents
~60 filter names, nearly all over fields the seeded catalog does not carry;
applying the answerable handful and dropping the rest would be this same
silent-narrowing defect. Marked with a `TODO(#495)` rather than half-done.
