### PR TITLE
feat(iam): bundle the five service-role managed policies (#484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DescribeSpotPriceHistory` now derive their zone names from one list, so filtering
   an offerings query by a zone you just enumerated cannot return empty.
 
+- **Five service-role AWS managed policies are now bundled** (#484), taking the
+  catalog from 47 policies to 52: `AmazonSSMManagedInstanceCore`,
+  `AmazonEC2ContainerRegistryReadOnly`,
+  `service-role/AmazonECSTaskExecutionRolePolicy`,
+  `service-role/AWSLambdaBasicExecutionRole` and
+  `service-role/AWSLambdaVPCAccessExecutionRole`. `GetPolicy` on any of them returned
+  `NoSuchEntity` before, so the sequence every consumer provisioning an SSM-managed
+  instance profile performs — `CreateRole`, `AttachRolePolicy`, `GetPolicy` — failed
+  at the last step on an ARN the attach had just accepted.
+
+  The gap was a population gap rather than an oversight about any one policy. All 47
+  bundled policies were human-operator policies: `AdministratorAccess`,
+  `PowerUserAccess`, and per-service `FullAccess`/`ReadOnlyAccess` pairs, which are
+  attached to users and groups. None was a service-role policy — what an *instance
+  profile* or *execution role* carries, and therefore what IaC actually provisions.
+  `AmazonSSMFullAccess` was present; `AmazonSSMManagedInstanceCore`, the policy an
+  SSM-managed instance needs, was not.
+
+  Each document is verbatim from the policy's page in the AWS managed policy
+  reference, and each policy ID is real, from a recorded `get-policy` snapshot rather
+  than synthesised — so a consumer asserting on an `ANPA…` ID sees the value AWS
+  reports. Default versions likewise follow AWS (`v2` for
+  `AmazonSSMManagedInstanceCore`, `v3` for `AmazonEC2ContainerRegistryReadOnly` and
+  `AWSLambdaVPCAccessExecutionRole`) instead of a blanket `v1`. The documents are read
+  by the IAM policy evaluator, so they are behaviour and not decoration.
+
+  The catalog can now express a **path**, which three of the five need. A policy under
+  a path reports it in `Path` (`/service-role/`) and keeps it out of `PolicyName`,
+  matching AWS — the distinction `ListPolicies --path-prefix` reads, and getting it
+  wrong would make a policy findable by ARN and invisible to a path query. Bundled
+  policies are constructed through one function so the ARN and the path cannot
+  disagree.
+
+  `AttachRolePolicy` still accepts a policy ARN that no `GetPolicy` can resolve, which
+  is the general asymmetry #484 also offered to fix. Not taken, deliberately:
+  substrate bundles 52 of roughly 1,200 AWS managed policies, so refusing an
+  unresolvable ARN would fail every attach of the other ~1,150 — breaking working
+  consumer code, where the current behaviour merely fails to catch a typo. Seeding the
+  catalog fixes the reported case; the asymmetry is tracked in #499 so the decision is
+  recorded rather than implied. Two further gaps found while verifying this one are
+  filed: `ListPolicies` applies neither `Scope` nor `PathPrefix` and never lists
+  bundled policies (#497), and `GetPolicyVersion` is unimplemented, so no policy
+  document is observable over the wire at all (#498).
+
 ## [v0.86.0] - 2026-08-02
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -108,16 +108,16 @@ here.
 | GetGroup | |
 | DeleteGroup | |
 | ListGroups | |
-| AttachUserPolicy | |
+| AttachUserPolicy | Does not verify the policy ARN resolves ([#499](https://github.com/scttfrdmn/substrate/issues/499)) |
 | DetachUserPolicy | |
 | ListAttachedUserPolicies | |
-| AttachRolePolicy | |
+| AttachRolePolicy | Does not verify the policy ARN resolves ([#499](https://github.com/scttfrdmn/substrate/issues/499)) |
 | DetachRolePolicy | |
 | ListAttachedRolePolicies | |
 | CreatePolicy | |
-| GetPolicy | |
+| GetPolicy | Resolves a bundled AWS managed policy or a `CreatePolicy` one; metadata only, as on AWS |
 | DeletePolicy | |
-| ListPolicies | |
+| ListPolicies | Lists `CreatePolicy` policies only; `Scope` and `PathPrefix` are accepted and not applied ([#497](https://github.com/scttfrdmn/substrate/issues/497)) |
 | CreateAccessKey | |
 | DeleteAccessKey | |
 | ListAccessKeys | |
@@ -142,6 +142,52 @@ here.
 | CreateInstanceProfile | |
 | GetInstanceProfile | |
 | AddRoleToInstanceProfile | |
+
+### AWS managed policies are a seeded catalog
+
+Substrate bundles **52** AWS managed policies, not the ~1,200 AWS publishes. Each carries
+its real ARN, policy ID, path and default version, and a policy document copied verbatim
+from its page in the [AWS managed policy
+reference](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/). `GetPolicy`
+resolves a bundled ARN exactly as it resolves one from `CreatePolicy`.
+
+The catalog covers two populations:
+
+| Population | Examples |
+|---|---|
+| Human-operator policies (47) | `AdministratorAccess`, `PowerUserAccess`, `ReadOnlyAccess`, and per-service `…FullAccess` / `…ReadOnlyAccess` pairs |
+| Service-role policies (5) | `AmazonSSMManagedInstanceCore`, `AmazonEC2ContainerRegistryReadOnly`, `service-role/AmazonECSTaskExecutionRolePolicy`, `service-role/AWSLambdaBasicExecutionRole`, `service-role/AWSLambdaVPCAccessExecutionRole` |
+
+The distinction matters because they are attached by different callers. A human-operator
+policy is attached to a user or group; a service-role policy is what an **instance profile
+or execution role** carries, and those are the ones IaC provisions. Substrate bundled
+`AmazonSSMFullAccess` — the operator policy — but not `AmazonSSMManagedInstanceCore`, which
+is the policy an SSM-managed instance actually needs.
+
+A policy under a path reports the path in `Path` and keeps it out of `PolicyName`:
+`service-role/AWSLambdaBasicExecutionRole` has `Path: /service-role/` and `PolicyName:
+AWSLambdaBasicExecutionRole`, matching AWS. The full ARN includes the path component.
+
+#### Attaching a policy substrate does not bundle
+
+`AttachRolePolicy` and `AttachUserPolicy` accept **any** policy ARN without checking that
+it resolves, so attaching one of the ~1,150 unbundled managed policies succeeds and
+`GetPolicy` on the same ARN then returns `NoSuchEntity`. Real IAM refuses the attach.
+
+This asymmetry is deliberate for now: refusing an ARN substrate cannot resolve would fail
+every attach of an unbundled managed policy — breaking working consumer code — where the
+current behaviour merely fails to catch a typo. Tracked in
+[#499](https://github.com/scttfrdmn/substrate/issues/499). A consumer who needs the attach
+verified should follow it with `GetPolicy`, which is exact.
+
+#### Policy documents are not observable over the wire
+
+`GetPolicy` returns metadata only — policy ID, name, ARN, path, default version,
+attachment count and dates — which is what AWS returns. On AWS the document comes from
+`GetPolicyVersion`, which substrate does not implement
+([#498](https://github.com/scttfrdmn/substrate/issues/498)). The seeded documents are
+readable in process through `emulator.GetManagedPolicy` and are what the IAM policy
+evaluator reads.
 
 ### Betty CFN resource types
 

--- a/emulator/iam_managed.go
+++ b/emulator/iam_managed.go
@@ -9,7 +9,9 @@ import (
 // AWS managed policies.
 var managedPolicyDate = time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)
 
-// managedPolicies holds the 47 bundled AWS managed policies.
+// managedPolicies holds the 52 bundled AWS managed policies — 47 human-operator policies
+// and, at the end of the slice, the five service-role policies an instance profile or
+// execution role carries.
 // Policy documents sourced from https://docs.aws.amazon.com/aws-managed-policy/latest/reference/
 // The slice itself is never mutated after package initialisation.
 var managedPolicies = []*IAMPolicy{
@@ -2031,15 +2033,184 @@ var managedPolicies = []*IAMPolicy{
 				Resource: StringOrSlice{"*"},
 			},
 		}}),
+
+	// --- Service-role policies -------------------------------------------------
+	//
+	// The 47 policies above are all human-operator policies — AdministratorAccess,
+	// PowerUserAccess and per-service FullAccess/ReadOnlyAccess pairs. The five below are
+	// the ones an *instance profile* or *execution role* is given, which is a different
+	// population and the gap #484 reported: AmazonSSMFullAccess was seeded while
+	// AmazonSSMManagedInstanceCore, the policy an SSM-managed instance actually carries,
+	// was not.
+	//
+	// Documents are verbatim from each policy's page under
+	// https://docs.aws.amazon.com/aws-managed-policy/latest/reference/. Statement order
+	// follows the page. PolicyId values are real, from a recorded get-policy snapshot
+	// (github.com/glassechidna/trackiam), and DefaultVersionID is the page's current
+	// default version rather than [mp]'s v1 — a consumer that pins a version would
+	// otherwise see v1 for a policy AWS reports as v2 or v3.
+
+	withVersion("v2", mp("AmazonSSMManagedInstanceCore", "ANPAIXSHM2BNB2D3AXXRU",
+		"The policy for Amazon EC2 Role to enable AWS Systems Manager service core functionality.",
+		PolicyDocument{Version: "2012-10-17", Statement: []PolicyStatement{
+			{
+				Effect: IAMEffectAllow,
+				Action: StringOrSlice{
+					"ssm:DescribeAssociation",
+					"ssm:GetDeployablePatchSnapshotForInstance",
+					"ssm:GetDocument",
+					"ssm:DescribeDocument",
+					"ssm:GetManifest",
+					"ssm:GetParameter",
+					"ssm:GetParameters",
+					"ssm:ListAssociations",
+					"ssm:ListInstanceAssociations",
+					"ssm:PutInventory",
+					"ssm:PutComplianceItems",
+					"ssm:PutConfigurePackageResult",
+					"ssm:UpdateAssociationStatus",
+					"ssm:UpdateInstanceAssociationStatus",
+					"ssm:UpdateInstanceInformation",
+				},
+				Resource: StringOrSlice{"*"},
+			},
+			{
+				Effect: IAMEffectAllow,
+				Action: StringOrSlice{
+					"ssmmessages:CreateControlChannel",
+					"ssmmessages:CreateDataChannel",
+					"ssmmessages:OpenControlChannel",
+					"ssmmessages:OpenDataChannel",
+				},
+				Resource: StringOrSlice{"*"},
+			},
+			{
+				Effect: IAMEffectAllow,
+				Action: StringOrSlice{
+					"ec2messages:AcknowledgeMessage",
+					"ec2messages:DeleteMessage",
+					"ec2messages:FailMessage",
+					"ec2messages:GetEndpoint",
+					"ec2messages:GetMessages",
+					"ec2messages:SendReply",
+				},
+				Resource: StringOrSlice{"*"},
+			},
+		}})),
+
+	withVersion("v3", mp("AmazonEC2ContainerRegistryReadOnly", "ANPAIFYZPA37OOHVIH7KQ",
+		"Provides read-only access to Amazon EC2 Container Registry repositories.",
+		PolicyDocument{Version: "2012-10-17", Statement: []PolicyStatement{
+			{
+				Effect: IAMEffectAllow,
+				Action: StringOrSlice{
+					"ecr:GetAuthorizationToken",
+					"ecr:BatchCheckLayerAvailability",
+					"ecr:GetDownloadUrlForLayer",
+					"ecr:GetRepositoryPolicy",
+					"ecr:DescribeRepositories",
+					"ecr:ListImages",
+					"ecr:DescribeImages",
+					"ecr:BatchGetImage",
+					"ecr:GetLifecyclePolicy",
+					"ecr:GetLifecyclePolicyPreview",
+					"ecr:ListTagsForResource",
+					"ecr:DescribeImageScanFindings",
+				},
+				Resource: StringOrSlice{"*"},
+			},
+		}})),
+
+	mpAt("service-role", "AmazonECSTaskExecutionRolePolicy", "ANPAJG4T4G4PV56DE72PY",
+		"Provides access to other AWS service resources that are required to run Amazon ECS tasks",
+		PolicyDocument{Version: "2012-10-17", Statement: []PolicyStatement{
+			{
+				Effect: IAMEffectAllow,
+				Action: StringOrSlice{
+					"ecr:GetAuthorizationToken",
+					"ecr:BatchCheckLayerAvailability",
+					"ecr:GetDownloadUrlForLayer",
+					"ecr:BatchGetImage",
+					"logs:CreateLogStream",
+					"logs:PutLogEvents",
+				},
+				Resource: StringOrSlice{"*"},
+			},
+		}}),
+
+	mpAt("service-role", "AWSLambdaBasicExecutionRole", "ANPAJNCQGXC42545SKXIK",
+		"Provides write permissions to CloudWatch Logs.",
+		PolicyDocument{Version: "2012-10-17", Statement: []PolicyStatement{
+			{
+				Effect: IAMEffectAllow,
+				Action: StringOrSlice{
+					"logs:CreateLogGroup",
+					"logs:CreateLogStream",
+					"logs:PutLogEvents",
+				},
+				Resource: StringOrSlice{"*"},
+			},
+		}}),
+
+	withVersion("v3", mpAt("service-role", "AWSLambdaVPCAccessExecutionRole", "ANPAJVTME3YLVNL72YR2K",
+		"Provides minimum permissions for a Lambda function to execute while accessing a resource within a VPC - create, describe, delete network interfaces and write permissions to CloudWatch Logs.",
+		PolicyDocument{Version: "2012-10-17", Statement: []PolicyStatement{
+			{
+				Sid:    "AWSLambdaVPCAccessExecutionPermissions",
+				Effect: IAMEffectAllow,
+				Action: StringOrSlice{
+					"logs:CreateLogGroup",
+					"logs:CreateLogStream",
+					"logs:PutLogEvents",
+					"ec2:CreateNetworkInterface",
+					"ec2:DescribeNetworkInterfaces",
+					"ec2:DescribeSubnets",
+					"ec2:DeleteNetworkInterface",
+					"ec2:AssignPrivateIpAddresses",
+					"ec2:UnassignPrivateIpAddresses",
+				},
+				Resource: StringOrSlice{"*"},
+			},
+		}})),
 }
 
-// mp is a helper for constructing a bundled managed IAMPolicy.
+// withVersion overrides a bundled policy's default version ID.
+//
+// [mp] and [mpAt] stamp "v1", which is right for most of the catalog. AWS has since
+// edited some policies, and its reference page reports the current default version — a
+// consumer reading DefaultVersionId back would otherwise see v1 for a policy AWS reports
+// as v2 or v3. Only the policies whose pages say so carry an override.
+func withVersion(version string, p *IAMPolicy) *IAMPolicy {
+	p.DefaultVersionID = version
+	return p
+}
+
+// mp is a helper for constructing a bundled managed IAMPolicy at the root path.
 func mp(name, id, description string, doc PolicyDocument) *IAMPolicy {
+	return mpAt("", name, id, description, doc)
+}
+
+// mpAt is a helper for constructing a bundled managed IAMPolicy under a path.
+//
+// path is the component between the ARN's "policy/" and the policy name, without
+// surrounding slashes — "service-role" yields
+// arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole and Path
+// "/service-role/". An empty path is the root, which is what [mp] passes.
+//
+// PolicyName stays the bare name; the path is a separate field. That distinction is what
+// ListPolicies --path-prefix reads, and conflating them would make a policy findable by
+// ARN while invisible to a path query. [GetManagedPolicy] needs no change either way: it
+// is an exact-ARN map lookup, and the ARN built here is the real one.
+func mpAt(path, name, id, description string, doc PolicyDocument) *IAMPolicy {
+	arnPath, policyPath := "", "/"
+	if path != "" {
+		arnPath, policyPath = path+"/", "/"+path+"/"
+	}
 	return &IAMPolicy{
 		PolicyName:       name,
 		PolicyID:         id,
-		ARN:              "arn:aws:iam::aws:policy/" + name,
-		Path:             "/",
+		ARN:              "arn:aws:iam::aws:policy/" + arnPath + name,
+		Path:             policyPath,
 		Description:      description,
 		DefaultVersionID: "v1",
 		IsAttachable:     true,
@@ -2061,7 +2232,7 @@ func initManagedPolicyMap() {
 	}
 }
 
-// ListManagedPolicies returns all 47 bundled AWS managed policies.
+// ListManagedPolicies returns all 52 bundled AWS managed policies.
 func ListManagedPolicies() []*IAMPolicy {
 	return managedPolicies
 }

--- a/emulator/iam_managed_test.go
+++ b/emulator/iam_managed_test.go
@@ -12,9 +12,15 @@ import (
 
 func TestListManagedPolicies_Count(t *testing.T) {
 	policies := emulator.ListManagedPolicies()
-	assert.Len(t, policies, 47, "expected exactly 47 bundled managed policies")
+	assert.Len(t, policies, 52, "expected exactly 52 bundled managed policies")
 }
 
+// TestListManagedPolicies_ARNFormat asserts each ARN is the policy's Path and PolicyName
+// composed, which is the invariant that survived #484's addition of paths.
+//
+// It previously asserted the ARN suffix was the bare PolicyName, which held only while
+// every bundled policy sat at "/". A `service-role/` policy carries its path in the ARN and
+// not in PolicyName — the distinction ListPolicies --path-prefix reads.
 func TestListManagedPolicies_ARNFormat(t *testing.T) {
 	policies := emulator.ListManagedPolicies()
 	for _, p := range policies {
@@ -22,8 +28,12 @@ func TestListManagedPolicies_ARNFormat(t *testing.T) {
 			strings.HasPrefix(p.ARN, "arn:aws:iam::aws:policy/"),
 			"policy %s has unexpected ARN %s", p.PolicyName, p.ARN,
 		)
-		assert.Equal(t, p.PolicyName, strings.TrimPrefix(p.ARN, "arn:aws:iam::aws:policy/"),
-			"policy name should match ARN suffix for %s", p.PolicyName)
+		suffix := strings.TrimPrefix(p.ARN, "arn:aws:iam::aws:policy/")
+		wantSuffix := strings.TrimPrefix(p.Path, "/") + p.PolicyName
+		assert.Equal(t, wantSuffix, suffix,
+			"the ARN suffix should be Path+PolicyName for %s", p.PolicyName)
+		assert.NotContains(t, p.PolicyName, "/",
+			"PolicyName must be the bare name; the path is a separate field (%s)", p.PolicyName)
 	}
 }
 
@@ -51,7 +61,10 @@ func TestListManagedPolicies_RequiredFields(t *testing.T) {
 		assert.NotEmpty(t, p.PolicyName, "PolicyName missing")
 		assert.NotEmpty(t, p.PolicyID, "PolicyID missing for %s", p.PolicyName)
 		assert.NotEmpty(t, p.ARN, "ARN missing for %s", p.PolicyName)
-		assert.Equal(t, "/", p.Path, "Path should be '/' for %s", p.PolicyName)
+		// A path is "/" or "/name/" — the service-role policies added in #484 are the
+		// latter. Both forms open and close with a slash, which is what IAM reports.
+		assert.True(t, strings.HasPrefix(p.Path, "/") && strings.HasSuffix(p.Path, "/"),
+			"Path %q should be slash-delimited for %s", p.Path, p.PolicyName)
 		assert.True(t, p.IsAttachable, "IsAttachable should be true for %s", p.PolicyName)
 		assert.NotEmpty(t, p.DefaultVersionID, "DefaultVersionId missing for %s", p.PolicyName)
 	}
@@ -109,6 +122,186 @@ func TestGetManagedPolicy_Concurrent(t *testing.T) {
 	}
 	for i := 0; i < 10; i++ {
 		<-done
+	}
+}
+
+// --- Service-role policies (#484) ------------------------------------------
+
+// iamServiceRolePolicies are the five policies #484 asks for: the ones an instance
+// profile or an execution role carries, as opposed to the human-operator policies the
+// catalog held before. Path is the value IAM reports, not a component of PolicyName.
+var iamServiceRolePolicies = []struct {
+	arn      string
+	name     string
+	path     string
+	policyID string
+	version  string
+}{
+	{
+		arn:      "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+		name:     "AmazonSSMManagedInstanceCore",
+		path:     "/",
+		policyID: "ANPAIXSHM2BNB2D3AXXRU",
+		version:  "v2",
+	},
+	{
+		arn:      "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+		name:     "AmazonEC2ContainerRegistryReadOnly",
+		path:     "/",
+		policyID: "ANPAIFYZPA37OOHVIH7KQ",
+		version:  "v3",
+	},
+	{
+		arn:      "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+		name:     "AmazonECSTaskExecutionRolePolicy",
+		path:     "/service-role/",
+		policyID: "ANPAJG4T4G4PV56DE72PY",
+		version:  "v1",
+	},
+	{
+		arn:      "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+		name:     "AWSLambdaBasicExecutionRole",
+		path:     "/service-role/",
+		policyID: "ANPAJNCQGXC42545SKXIK",
+		version:  "v1",
+	},
+	{
+		arn:      "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+		name:     "AWSLambdaVPCAccessExecutionRole",
+		path:     "/service-role/",
+		policyID: "ANPAJVTME3YLVNL72YR2K",
+		version:  "v3",
+	},
+}
+
+// TestGetManagedPolicy_ServiceRolePolicies asserts each of the five resolves in process
+// with the metadata AWS reports and a non-empty document.
+//
+// The document is asserted here rather than over the wire because it is not observable
+// over the wire at all: GetPolicy returns metadata only, and GetPolicyVersion — the one
+// operation that returns a document — is unimplemented (#498). The documents still matter
+// in process: they are what the IAM evaluator reads.
+func TestGetManagedPolicy_ServiceRolePolicies(t *testing.T) {
+	for _, tc := range iamServiceRolePolicies {
+		t.Run(tc.name, func(t *testing.T) {
+			p, ok := emulator.GetManagedPolicy(tc.arn)
+			require.True(t, ok, "%s should resolve", tc.arn)
+
+			assert.Equal(t, tc.name, p.PolicyName)
+			assert.Equal(t, tc.path, p.Path)
+			assert.Equal(t, tc.policyID, p.PolicyID)
+			assert.Equal(t, tc.version, p.DefaultVersionID)
+			assert.NotEmpty(t, p.Description, "Description missing for %s", tc.name)
+
+			require.NotEmpty(t, p.Document.Statement, "document should not be empty")
+			assert.Equal(t, "2012-10-17", p.Document.Version)
+			for i, stmt := range p.Document.Statement {
+				assert.Equal(t, emulator.IAMEffectAllow, stmt.Effect,
+					"statement %d of %s should Allow", i, tc.name)
+				assert.NotEmpty(t, stmt.Action, "statement %d of %s has no Action", i, tc.name)
+				assert.NotEmpty(t, stmt.Resource, "statement %d of %s has no Resource", i, tc.name)
+			}
+		})
+	}
+}
+
+// TestGetManagedPolicy_ServiceRolePath asserts a service-role policy keeps the path out
+// of PolicyName. ListPolicies --path-prefix reads Path; a name carrying "service-role/"
+// would be findable by ARN and invisible to a path query.
+func TestGetManagedPolicy_ServiceRolePath(t *testing.T) {
+	p, ok := emulator.GetManagedPolicy(
+		"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole")
+	require.True(t, ok)
+
+	assert.Equal(t, "/service-role/", p.Path)
+	assert.Equal(t, "AWSLambdaBasicExecutionRole", p.PolicyName)
+	assert.NotContains(t, p.PolicyName, "service-role")
+}
+
+// TestGetManagedPolicy_SSMCoreDocument pins the AmazonSSMManagedInstanceCore document
+// against its AWS managed-policy reference page: three Allow statements over the ssm,
+// ssmmessages and ec2messages prefixes on "*". This is the policy #484 reproduces with,
+// and the one an SSM-managed instance profile cannot work without.
+func TestGetManagedPolicy_SSMCoreDocument(t *testing.T) {
+	p, ok := emulator.GetManagedPolicy("arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore")
+	require.True(t, ok)
+	require.Len(t, p.Document.Statement, 3)
+
+	byPrefix := map[string]int{}
+	for _, stmt := range p.Document.Statement {
+		assert.Equal(t, []string{"*"}, []string(stmt.Resource))
+		for _, action := range stmt.Action {
+			prefix, _, found := strings.Cut(action, ":")
+			require.True(t, found, "action %q should be prefix:Name", action)
+			byPrefix[prefix]++
+		}
+	}
+
+	assert.Equal(t, map[string]int{"ssm": 15, "ssmmessages": 4, "ec2messages": 6}, byPrefix)
+}
+
+// TestGetManagedPolicy_ServiceRoleEvaluation asserts the seeded documents evaluate, which
+// is the reason the catalog carries documents at all.
+func TestGetManagedPolicy_ServiceRoleEvaluation(t *testing.T) {
+	tests := []struct {
+		name   string
+		arn    string
+		action string
+		want   string
+	}{
+		{
+			name:   "SSM core allows UpdateInstanceInformation",
+			arn:    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+			action: "ssm:UpdateInstanceInformation",
+			want:   emulator.DecisionAllow,
+		},
+		{
+			name:   "SSM core does not allow s3:GetObject",
+			arn:    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+			action: "s3:GetObject",
+			want:   emulator.DecisionImplicitDeny,
+		},
+		{
+			name:   "Lambda basic execution allows PutLogEvents",
+			arn:    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+			action: "logs:PutLogEvents",
+			want:   emulator.DecisionAllow,
+		},
+		{
+			name:   "Lambda basic execution does not allow ec2:CreateNetworkInterface",
+			arn:    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+			action: "ec2:CreateNetworkInterface",
+			want:   emulator.DecisionImplicitDeny,
+		},
+		{
+			name:   "Lambda VPC access allows ec2:CreateNetworkInterface",
+			arn:    "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+			action: "ec2:CreateNetworkInterface",
+			want:   emulator.DecisionAllow,
+		},
+		{
+			name:   "ECR read-only allows BatchGetImage",
+			arn:    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+			action: "ecr:BatchGetImage",
+			want:   emulator.DecisionAllow,
+		},
+		{
+			name:   "ECR read-only does not allow PutImage",
+			arn:    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+			action: "ecr:PutImage",
+			want:   emulator.DecisionImplicitDeny,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, ok := emulator.GetManagedPolicy(tc.arn)
+			require.True(t, ok)
+
+			r := emulator.Evaluate([]emulator.PolicyDocument{p.Document},
+				emulator.EvaluationRequest{Action: tc.action, Resource: "*"})
+			assert.Equal(t, tc.want, r.Decision)
+		})
 	}
 }
 

--- a/emulator/iam_plugin_test.go
+++ b/emulator/iam_plugin_test.go
@@ -540,6 +540,84 @@ func TestIAMPlugin_GetPolicy_Managed(t *testing.T) {
 	assert.Equal(t, "AdministratorAccess", pol["PolicyName"])
 }
 
+// TestIAMPlugin_AttachThenGetServiceRolePolicy is #484's reported sequence end to end:
+// AttachRolePolicy accepted the ARN and GetPolicy then reported NoSuchEntity, so a
+// consumer provisioning an SSM-managed instance profile could attach a policy that did
+// not exist. GetPolicy was always correct — it checks the managed catalog first — and the
+// catalog was the gap.
+func TestIAMPlugin_AttachThenGetServiceRolePolicy(t *testing.T) {
+	arns := []string{
+		"arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+		"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+		"arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+		"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+		"arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+	}
+
+	for _, arn := range arns {
+		t.Run(arn, func(t *testing.T) {
+			srv := newIAMTestServer(t)
+			iamRequest(t, srv, "CreateRole", map[string]any{"RoleName": "myrole"})
+
+			attachResp := iamRequest(t, srv, "AttachRolePolicy", map[string]any{
+				"RoleName":  "myrole",
+				"PolicyArn": arn,
+			})
+			assert.Equal(t, http.StatusOK, attachResp.StatusCode)
+
+			resp := iamRequest(t, srv, "GetPolicy", map[string]any{"PolicyArn": arn})
+			require.Equal(t, http.StatusOK, resp.StatusCode,
+				"GetPolicy should resolve an ARN AttachRolePolicy accepted")
+
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			pol := result["Policy"].(map[string]any)
+			assert.Equal(t, arn, pol["Arn"])
+			assert.NotEmpty(t, pol["PolicyId"])
+		})
+	}
+}
+
+// TestIAMPlugin_GetPolicy_ServiceRolePathReported asserts the wire response separates the
+// path from the name. A consumer reading PolicyName must not get "service-role/…" back,
+// and Path is what carries it.
+func TestIAMPlugin_GetPolicy_ServiceRolePathReported(t *testing.T) {
+	srv := newIAMTestServer(t)
+	resp := iamRequest(t, srv, "GetPolicy", map[string]any{
+		"PolicyArn": "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	pol := result["Policy"].(map[string]any)
+
+	assert.Equal(t, "AWSLambdaVPCAccessExecutionRole", pol["PolicyName"])
+	assert.Equal(t, "/service-role/", pol["Path"])
+	assert.Equal(t, "v3", pol["DefaultVersionId"])
+}
+
+// TestIAMPlugin_GetPolicy_UnbundledManagedPolicy pins the decision #484 offered an
+// alternative to. AttachRolePolicy deliberately still accepts a managed ARN the catalog
+// does not bundle: rejecting would refuse every attach of the ~1,200 AWS managed policies
+// substrate does not carry, trading a confusing success for a wrong failure. The
+// asymmetry is tracked in #499 rather than closed here.
+func TestIAMPlugin_GetPolicy_UnbundledManagedPolicy(t *testing.T) {
+	srv := newIAMTestServer(t)
+	arn := "arn:aws:iam::aws:policy/service-role/AWSNotBundledBySubstrate"
+
+	iamRequest(t, srv, "CreateRole", map[string]any{"RoleName": "myrole"})
+	attachResp := iamRequest(t, srv, "AttachRolePolicy", map[string]any{
+		"RoleName":  "myrole",
+		"PolicyArn": arn,
+	})
+	assert.Equal(t, http.StatusOK, attachResp.StatusCode,
+		"an unbundled managed ARN is still accepted on attach")
+
+	resp := iamRequest(t, srv, "GetPolicy", map[string]any{"PolicyArn": arn})
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
 func TestIAMPlugin_DeletePolicy(t *testing.T) {
 	srv := newIAMTestServer(t)
 	iamRequest(t, srv, "CreatePolicy", map[string]any{"PolicyName": "tmp-policy"})


### PR DESCRIPTION
`GetPolicy` returned `NoSuchEntity` for `AmazonSSMManagedInstanceCore` and four sibling
service-role policies, so the sequence every consumer provisioning an SSM-managed instance
profile performs — `CreateRole`, `AttachRolePolicy`, `GetPolicy` — failed at the last step
on an ARN the attach had just accepted.

## The gap was a population gap

All 47 bundled policies were **human-operator** policies: `AdministratorAccess`,
`PowerUserAccess`, and per-service `FullAccess`/`ReadOnlyAccess` pairs, which are attached
to users and groups. None was a **service-role** policy — what an instance profile or
execution role carries, and therefore what IaC actually provisions. `AmazonSSMFullAccess`
was present; `AmazonSSMManagedInstanceCore`, the policy an SSM-managed instance needs, was
not.

Five policies added, taking the catalog from 47 to 52:

| Policy | Path | Default version |
|---|---|---|
| `AmazonSSMManagedInstanceCore` | `/` | v2 |
| `AmazonEC2ContainerRegistryReadOnly` | `/` | v3 |
| `AmazonECSTaskExecutionRolePolicy` | `/service-role/` | v1 |
| `AWSLambdaBasicExecutionRole` | `/service-role/` | v1 |
| `AWSLambdaVPCAccessExecutionRole` | `/service-role/` | v3 |

## Provenance

Each document is **verbatim** from the policy's page in the [AWS managed policy
reference](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/), fetched at
implementation time rather than written from memory — these are documents the IAM evaluator
reads, so they are behavior, not decoration.

Neither the AWS pages, moto, nor `iann0036/iam-dataset` carry the real `ANPA…` policy IDs.
They come from `glassechidna/trackiam`, which holds per-policy snapshots of real
`get-policy` output, and which independently corroborated each path and default version.
Default versions follow AWS rather than `mp`'s blanket `v1`, so a consumer reading
`DefaultVersionId` back sees what AWS reports.

## The catalog can now express a path

`mp` hardcoded `Path: "/"` and an ARN without a path component, so a `service-role/` policy
could not be expressed at all. New `mpAt` builds the ARN and the `Path` field from one
argument so they cannot disagree, and `mp` is expressed in terms of it. `PolicyName` stays
the bare name — the distinction `ListPolicies --path-prefix` reads, and conflating them
would make a policy findable by ARN and invisible to a path query.

Three pre-existing tests assumed a root path or a count of 47 and are updated:
`TestListManagedPolicies_Count`, `_ARNFormat` (now asserts the ARN suffix is
`Path`+`PolicyName`, the invariant that survives paths) and `_RequiredFields`.

## What this deliberately does not do

#484 offered an alternative: make `AttachRolePolicy` **reject** an unresolvable ARN so the
two operations agree. Not taken. Substrate bundles 52 of roughly 1,200 AWS managed
policies, so refusing would fail every attach of the other ~1,150 — a consumer attaching
`AmazonEKSWorkerNodePolicy` would get a hard failure where AWS succeeds. That trades a
confusing success for a wrong failure, and the wrong failure is worse: it breaks working
consumer code rather than merely failing to catch a typo. A test pins the accepted
behaviour so the decision cannot be changed by accident, and #499 records it.

## Follow-ups filed while verifying this

- **#497** — `ListPolicies` parses `Scope` and `PathPrefix` and applies neither, and never
  lists bundled policies, so `--scope AWS` returns zero of the 52.
- **#498** — `GetPolicyVersion` is unimplemented, so no policy document is observable over
  the wire at all. The seeded documents are readable in process; the AWS operation that
  returns one is absent.
- **#499** — the attach/get asymmetry above, with the reasoning recorded.

## Verification

- `gofmt -l .`, `go build ./...`, `go vet ./...` clean; `golangci-lint run ./...` → **0 issues**
- `make test` (race) passes; `go test -C test/e2e ./...` passes
- `make docs-reference docs-reference-check docs-versions` clean (no new plugin, so no
  generator diff); `npm --prefix docs run build` succeeds
- **Mutation testing: 17 mutations, 17 caught, 0 survived.** Covers the path dropped from
  the ARN, the path leaking into `PolicyName`, `Path` reported without its slashes, a
  root-path policy reporting an empty `Path`, `withVersion` as a no-op, a policy missing
  entirely, a service-role policy bundled at the root or under the wrong path, a
  synthesised policy ID, a dropped statement, a dropped or added action, `Allow` flipped to
  `Deny`, a document scoped away from `*`, and a dropped description. Two initial harness
  bugs were found and fixed rather than reported as results: one anchor missed gofmt's
  struct alignment, and one matched an identical action string in an existing policy
  earlier in the slice, mutating a policy this PR did not add.
- End to end through the AWS CLI: all five attach and then resolve, reporting the paths,
  policy IDs and default versions in the table above; an unbundled managed ARN attaches and
  then 404s, which is the #499 behaviour this PR pins.

Closes #484
