### PR TITLE
feat(cloudformation): serve the stack operations over the wire (#483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bundled policies (#497), and `GetPolicyVersion` is unimplemented, so no policy
   document is observable over the wire at all (#498).
 
+- **CloudFormation is now reachable over the wire** (#483). Every CloudFormation
+  call returned `ServiceNotAvailable` at HTTP 501 — no plugin served the service —
+  even though the stack model behind it was complete and had been for many releases.
+  It was simply reachable only from Go, through `emulator.BettyClient`. A consumer
+  driving substrate the way CDK, CloudFormation and Terraform users actually do,
+  with the AWS CLI or an SDK, could not create a stack at all, while `README.md` and
+  the docs advertised CloudFormation as a first-class target. The advertisement is
+  now true at both layers.
+
+  Fifteen operations: `CreateStack`, `UpdateStack`, `DeleteStack`,
+  `DescribeStacks`, `ListStacks`, `DescribeStackResources`, `GetTemplate`, the five
+  change-set operations (`CreateChangeSet`, `DescribeChangeSet`, `ExecuteChangeSet`,
+  `ListChangeSets`, `DeleteChangeSet`) and the three drift operations
+  (`DetectStackDrift`, `DescribeStackResourceDrifts`,
+  `DescribeStackDriftDetectionStatus`). 113 resource types and the `Ref`/`Fn::*`
+  intrinsics the deployer already resolved are available unchanged, which is why
+  this is a wire adapter of about 1,000 lines rather than a new service.
+
+  **A stack's resources are real resources in the other plugins**, because the
+  adapter deploys through the same plugin registry the server routes with. A
+  template declaring an `AWS::S3::Bucket` produces a bucket `s3api head-bucket`
+  finds and `s3api put-object` writes to; a stack created over the wire is visible
+  to the in-process API and vice versa. There is one set of stacks and one set of
+  resources, not a CloudFormation-shaped world beside the emulator.
+
+  `DescribeStackEvents` is deliberately **not** supported and returns
+  `UnsupportedOperation` — substrate's own signal, not a CloudFormation code, since
+  real CloudFormation has no error for an operation it implements. A stack carries
+  one status string and there is no per-resource event model behind it, so
+  answering the call would mean fabricating a `CREATE_IN_PROGRESS →
+  CREATE_COMPLETE` pair per resource with invented timestamps. A consumer polling
+  for completion should poll `DescribeStacks`. What a real event model needs is
+  filed as #501. `ChangeSetType=CREATE` is refused for the same class of reason: it
+  requires a stack in `REVIEW_IN_PROGRESS`, a state the model cannot represent.
+
+  `TemplateURL` is refused with `ValidationError` rather than ignored — fetching a
+  template is a network read substrate does not perform, and accepting the
+  parameter silently deployed an empty stack. Template transforms are not applied,
+  so a SAM template reaches the deployer unexpanded and `GetTemplate` reports
+  `StagesAvailable: [Original]`.
+
+  Stack and change-set ARNs derive their UUID from the account, region and name
+  rather than a clock or a PRNG, so a recorded response replays byte-identically.
+  `CreateStack` returns with the stack already `CREATE_COMPLETE` — there is no
+  `*_IN_PROGRESS` window, so `wait stack-create-complete` returns at once instead of
+  polling.
+
+  CloudFormation was also missing from the error-protocol table, which would have
+  left its error-document shape to Content-Type sniffing; it is now explicitly
+  Query/XML. `StackDeployer` reports its failures as `fmt.Errorf` strings, so the
+  adapter maps them to AWS codes by matching sentinel prefixes — typed errors
+  behind the model would remove the string matching and are filed as #502.
+
 ## [v0.86.0] - 2026-08-02
 
 ### Added

--- a/cmd/gen-service-reference/main.go
+++ b/cmd/gen-service-reference/main.go
@@ -60,6 +60,7 @@ var meta = map[string]pluginMeta{
 	"bedrock-runtime":      {"Bedrock Runtime", "REST/JSON"},
 	"budgets":              {"Budgets", "JSON"},
 	"ce":                   {"Cost Explorer", "JSON"},
+	"cloudformation":       {"CloudFormation", "Query"},
 	"cloudfront":           {"CloudFront", "REST/XML"},
 	"cloudtrail":           {"CloudTrail", "JSON"},
 	"codebuild":            {"CodeBuild", "JSON"},

--- a/docs/services.md
+++ b/docs/services.md
@@ -3,7 +3,7 @@
 ## Coverage matrix
 
 <!-- BEGIN GENERATED COVERAGE MATRIX -->
-Substrate ships **64 built-in service plugins**. This section is generated
+Substrate ships **65 built-in service plugins**. This section is generated
 from the plugin registry (`make docs-reference`), so the count and plugin list
 cannot drift from the implementation. The live count is also available from the
 `/ready` endpoint (`curl http://localhost:4566/ready`). Per-service operation,
@@ -21,60 +21,61 @@ CloudFormation, and cost detail follows below the matrix.
 | 8 | Bedrock Runtime | `bedrock-runtime` | REST/JSON |
 | 9 | Budgets | `budgets` | JSON |
 | 10 | Cost Explorer | `ce` | JSON |
-| 11 | CloudFront | `cloudfront` | REST/XML |
-| 12 | CloudTrail | `cloudtrail` | JSON |
-| 13 | CodeBuild | `codebuild` | JSON |
-| 14 | CodeDeploy | `codedeploy` | JSON |
-| 15 | CodePipeline | `codepipeline` | JSON |
-| 16 | Cognito Identity | `cognito-identity` | JSON |
-| 17 | Cognito Identity Provider | `cognito-idp` | JSON |
-| 18 | DynamoDB | `dynamodb` | JSON |
-| 19 | EC2 / VPC | `ec2` | Query |
-| 20 | ECR | `ecr` | JSON |
-| 21 | ECS | `ecs` | JSON |
-| 22 | EFS | `efs` | REST/JSON |
-| 23 | ElastiCache | `elasticache` | Query |
-| 24 | ELBv2 | `elasticloadbalancing` | Query |
-| 25 | EMR Serverless | `emrserverless` | REST/JSON |
-| 26 | EventBridge | `eventbridge` | JSON |
-| 27 | API Gateway (execute-api) | `execute-api` | REST/JSON |
-| 28 | Kinesis Data Firehose | `firehose` | JSON |
-| 29 | FSx | `fsx` | JSON |
-| 30 | Glue | `glue` | JSON |
-| 31 | Health | `health` | JSON |
-| 32 | IAM | `iam` | Query |
-| 33 | Kinesis Data Streams | `kinesis` | JSON |
-| 34 | KMS | `kms` | JSON |
-| 35 | Lambda | `lambda` | REST/JSON |
-| 36 | CloudWatch Logs | `logs` | JSON |
-| 37 | CloudWatch | `monitoring` | Query |
-| 38 | MSK | `msk` | REST/JSON |
-| 39 | HealthOmics | `omics` | REST/JSON |
-| 40 | OpenSearch | `opensearch` | REST/JSON |
-| 41 | Organizations | `organizations` | JSON |
-| 42 | Price List Query API | `pricing` | JSON |
-| 43 | QuickSight | `quicksight` | REST/JSON |
-| 44 | RAM | `ram` | REST/JSON |
-| 45 | RDS | `rds` | Query |
-| 46 | Redshift | `redshift` | Query |
-| 47 | Redshift Data API | `redshift-data` | JSON |
-| 48 | Route 53 | `route53` | REST/XML |
-| 49 | S3 | `s3` | REST/XML |
-| 50 | SageMaker | `sagemaker` | JSON |
-| 51 | EventBridge Scheduler | `scheduler` | REST/JSON |
-| 52 | Secrets Manager | `secretsmanager` | JSON |
-| 53 | Service Quotas | `servicequotas` | JSON |
-| 54 | SES v2 | `sesv2` | REST/JSON |
-| 55 | SNS | `sns` | Query |
-| 56 | SQS | `sqs` | JSON |
-| 57 | SSM | `ssm` | JSON |
-| 58 | SSO / Identity Store | `sso` | REST/JSON |
-| 59 | Step Functions | `states` | JSON |
-| 60 | STS | `sts` | Query |
-| 61 | Resource Groups Tagging | `tagging` | JSON |
-| 62 | Timestream | `timestream` | JSON |
-| 63 | Transfer Family | `transfer` | JSON |
-| 64 | WAFv2 | `wafv2` | JSON |
+| 11 | CloudFormation | `cloudformation` | Query |
+| 12 | CloudFront | `cloudfront` | REST/XML |
+| 13 | CloudTrail | `cloudtrail` | JSON |
+| 14 | CodeBuild | `codebuild` | JSON |
+| 15 | CodeDeploy | `codedeploy` | JSON |
+| 16 | CodePipeline | `codepipeline` | JSON |
+| 17 | Cognito Identity | `cognito-identity` | JSON |
+| 18 | Cognito Identity Provider | `cognito-idp` | JSON |
+| 19 | DynamoDB | `dynamodb` | JSON |
+| 20 | EC2 / VPC | `ec2` | Query |
+| 21 | ECR | `ecr` | JSON |
+| 22 | ECS | `ecs` | JSON |
+| 23 | EFS | `efs` | REST/JSON |
+| 24 | ElastiCache | `elasticache` | Query |
+| 25 | ELBv2 | `elasticloadbalancing` | Query |
+| 26 | EMR Serverless | `emrserverless` | REST/JSON |
+| 27 | EventBridge | `eventbridge` | JSON |
+| 28 | API Gateway (execute-api) | `execute-api` | REST/JSON |
+| 29 | Kinesis Data Firehose | `firehose` | JSON |
+| 30 | FSx | `fsx` | JSON |
+| 31 | Glue | `glue` | JSON |
+| 32 | Health | `health` | JSON |
+| 33 | IAM | `iam` | Query |
+| 34 | Kinesis Data Streams | `kinesis` | JSON |
+| 35 | KMS | `kms` | JSON |
+| 36 | Lambda | `lambda` | REST/JSON |
+| 37 | CloudWatch Logs | `logs` | JSON |
+| 38 | CloudWatch | `monitoring` | Query |
+| 39 | MSK | `msk` | REST/JSON |
+| 40 | HealthOmics | `omics` | REST/JSON |
+| 41 | OpenSearch | `opensearch` | REST/JSON |
+| 42 | Organizations | `organizations` | JSON |
+| 43 | Price List Query API | `pricing` | JSON |
+| 44 | QuickSight | `quicksight` | REST/JSON |
+| 45 | RAM | `ram` | REST/JSON |
+| 46 | RDS | `rds` | Query |
+| 47 | Redshift | `redshift` | Query |
+| 48 | Redshift Data API | `redshift-data` | JSON |
+| 49 | Route 53 | `route53` | REST/XML |
+| 50 | S3 | `s3` | REST/XML |
+| 51 | SageMaker | `sagemaker` | JSON |
+| 52 | EventBridge Scheduler | `scheduler` | REST/JSON |
+| 53 | Secrets Manager | `secretsmanager` | JSON |
+| 54 | Service Quotas | `servicequotas` | JSON |
+| 55 | SES v2 | `sesv2` | REST/JSON |
+| 56 | SNS | `sns` | Query |
+| 57 | SQS | `sqs` | JSON |
+| 58 | SSM | `ssm` | JSON |
+| 59 | SSO / Identity Store | `sso` | REST/JSON |
+| 60 | Step Functions | `states` | JSON |
+| 61 | STS | `sts` | Query |
+| 62 | Resource Groups Tagging | `tagging` | JSON |
+| 63 | Timestream | `timestream` | JSON |
+| 64 | Transfer Family | `transfer` | JSON |
+| 65 | WAFv2 | `wafv2` | JSON |
 <!-- END GENERATED COVERAGE MATRIX -->
 
 ---
@@ -84,6 +85,137 @@ CloudFormation resource types, and cost notes for the most heavily used plugins.
 They are maintained by hand and cover a subset of the plugins in the matrix
 above; the remaining plugins are registered and functional but not yet detailed
 here.
+
+---
+
+## CloudFormation
+
+**Endpoint:** `cloudformation.{region}.amazonaws.com`
+**Protocol:** AWS Query (form-encoded, `Action=` parameter)
+
+### Supported operations
+
+| Operation | Notes |
+|-----------|-------|
+| CreateStack | Deploys every resource in `TemplateBody` and returns the stack ARN |
+| UpdateStack | Re-deploys the template; an omitted `TemplateBody` re-uses the stored one |
+| DeleteStack | Deletes the stack's resources; deleting an absent stack succeeds |
+| DescribeStacks | One stack by `StackName`, or every stack when omitted |
+| ListStacks | Summary shape; honours `StackStatusFilter.member.N` |
+| DescribeStackResources | By `StackName` + optional `LogicalResourceId`, or by `PhysicalResourceId` |
+| GetTemplate | Returns the stored `TemplateBody` byte-for-byte |
+| CreateChangeSet | `ChangeSetType=UPDATE` only; see below |
+| DescribeChangeSet | Accepts a bare change-set name or its ARN |
+| ExecuteChangeSet | Applies the change and consumes the set |
+| ListChangeSets | Pending change sets for a stack |
+| DeleteChangeSet | Discards a pending set; deleting an absent set succeeds |
+| DetectStackDrift | Returns a `StackDriftDetectionId` |
+| DescribeStackDriftDetectionStatus | Resolves that ID to a completed detection |
+| DescribeStackResourceDrifts | Per-resource drift; honours `StackResourceDriftStatusFilters.member.N` |
+
+`TemplateURL` is refused with `ValidationError` rather than ignored: fetching a
+template is a network read substrate does not perform, and silently accepting the
+parameter deployed a stack with no resources in it.
+
+### Stacks share state with every other plugin
+
+The plugin is a thin adapter over the same stack model substrate has always
+exposed to in-process Go callers, and it deploys through the same plugin registry
+the server routes with. A resource a template declares is therefore a **real**
+resource in the corresponding plugin:
+
+```
+aws cloudformation create-stack --stack-name probe \
+  --template-body '{"Resources":{"B":{"Type":"AWS::S3::Bucket",
+                    "Properties":{"BucketName":"probe-data"}}}}'
+aws s3api head-bucket --bucket probe-data      # 200 — a real bucket
+aws s3api put-object --bucket probe-data --key k --body f
+```
+
+The reverse also holds: a stack created in process through `emulator.BettyClient`
+is visible to `DescribeStacks` over the wire, and a wire-created stack is visible
+to the in-process API. There is one set of stacks.
+
+Deleting a stack's resource outside CloudFormation is the drift substrate models
+— `DescribeStackResourceDrifts` reports it as `DELETED`.
+
+### Templates
+
+113 resource types are supported; each service section below lists the types it
+backs under **Betty CFN resource types**. A template body may be JSON or YAML.
+
+`Ref`, `Fn::GetAtt`, `Fn::Sub`, `Fn::Join`, `Fn::Select`, `Fn::Split`,
+`Fn::Base64`, `Fn::If`, `Fn::Equals`, `Fn::And`, `Fn::Or` and `Fn::Not` resolve,
+as do the `AWS::Region`, `AWS::AccountId`, `AWS::StackName` and `AWS::NoValue`
+pseudo-parameters. `Fn::FindInMap`, `Fn::ImportValue`, `Fn::Cidr`,
+`Fn::GetAZs` and the remaining pseudo-parameters (`AWS::Partition`,
+`AWS::URLSuffix`, `AWS::StackId`, `AWS::NotificationARNs`) are **not** resolved —
+an unrecognized intrinsic falls back to its JSON encoding and an unrecognized
+`Ref` to the reference string itself, so a template using one deploys with a
+literal where a value should be rather than failing.
+
+Parameters use the Query protocol's list encoding, which is what every SDK and
+the CLI send:
+
+```
+Parameters.member.1.ParameterKey=Env
+Parameters.member.1.ParameterValue=staging
+Parameters.member.2.ParameterKey=Size
+Parameters.member.2.UsePreviousValue=true
+```
+
+`UsePreviousValue=true` resolves against the stack's stored parameters, so an
+`UpdateStack` need not repeat every value.
+
+Template **transforms** are not applied — `GetTemplate` reports
+`StagesAvailable: [Original]` only, and a SAM or macro template reaches the
+deployer unexpanded.
+
+### Change sets describe, they do not stage
+
+A change set records the template that would be applied and reports the
+resource-level changes it implies. `ExecuteChangeSet` applies it and deletes the
+set, so `DescribeChangeSet` afterwards reports `ChangeSetNotFound` (404 — unlike
+the stack family, which reports `ValidationError` at 400).
+
+`ChangeSetType=CREATE` is refused: it would have to produce a stack in
+`REVIEW_IN_PROGRESS`, a state the stack model has no representation for. Create
+the stack, then change-set the update.
+
+### DescribeStackEvents is not supported
+
+`DescribeStackEvents` returns `UnsupportedOperation` (400). This is deliberate,
+and `UnsupportedOperation` is substrate's own signal rather than a documented
+CloudFormation code — real CloudFormation has no error for an operation it
+implements.
+
+A stack carries one status string; there is no per-resource event model behind
+it. Answering the call would mean synthesizing a plausible
+`CREATE_IN_PROGRESS → CREATE_COMPLETE` pair per resource with invented
+timestamps, which is inventing observations — the opposite of what an emulator
+that exists to be trusted should do. A consumer polling events for completion
+should poll `DescribeStacks` for `StackStatus` instead. Tracked in
+[#501](https://github.com/scttfrdmn/substrate/issues/501).
+
+### Stack status is terminal on return
+
+`CreateStack` deploys synchronously and returns with the stack already
+`CREATE_COMPLETE`; `UpdateStack` returns `UPDATE_COMPLETE`. There is no
+`*_IN_PROGRESS` window, so a `wait stack-create-complete` succeeds immediately
+rather than polling. That is the deterministic-clock trade: a stack's observable
+state does not depend on how long a test waited.
+
+### Stack and change-set ARNs are deterministic
+
+The UUID in a stack or change-set ARN is derived from the account, region and
+name, not from a clock or a PRNG, so the same call produces the same ARN on a
+replay. `StackId` is stable across `CreateStack`, `DescribeStacks` and
+`ListStacks`.
+
+### Cost
+
+CloudFormation operations are free. The resources a template deploys are costed
+by their own plugins, so a stack's cost shows up under S3, EC2 and so on.
 
 ---
 

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -1,0 +1,1137 @@
+package emulator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// cfnXMLNS is the CloudFormation Query-protocol XML namespace.
+const cfnXMLNS = "http://cloudformation.amazonaws.com/doc/2010-05-15/"
+
+// CloudFormationPlugin exposes substrate's CloudFormation model over the wire
+// using the AWS Query protocol.
+//
+// It is deliberately a thin adapter: every handler translates query parameters
+// in and XML out, and all stack, change-set and drift behavior lives in
+// [StackDeployer], which substrate has always exposed to in-process Go callers
+// through [BettyClient]. Before #483 that model was reachable only from Go, so a
+// consumer driving the emulator with the AWS CLI or an SDK — the way CDK,
+// CloudFormation and Terraform users actually do — got ServiceNotAvailable from
+// [PluginRegistry.RouteRequest] for a service README.md advertises as a
+// first-class target.
+//
+// Because the deployer dispatches each resource back through the same
+// *PluginRegistry the server routes with, a stack created over the wire creates
+// real resources in the other plugins: the bucket in an AWS::S3::Bucket is a
+// bucket the S3 plugin serves, not a private CloudFormation-only record.
+type CloudFormationPlugin struct {
+	state    StateManager
+	logger   Logger
+	tc       *TimeController
+	deployer *StackDeployer
+}
+
+// Name returns the service name "cloudformation".
+func (p *CloudFormationPlugin) Name() string { return "cloudformation" }
+
+// Initialize sets up the CloudFormationPlugin with the provided configuration.
+//
+// Options["registry"] is required: the plugin's [StackDeployer] deploys each
+// template resource by routing a synthetic request through the registry, so
+// without one there is nothing to deploy into. The registry is captured as a
+// pointer and read at request time, so plugins registered after this one are
+// still reachable.
+//
+// Options["event_store"] and Options["cost_controller"] are optional but are
+// substituted with disabled instances when absent, never left nil:
+// [StackDeployer.dispatch] dereferences both on every resource it deploys, and
+// callers of [RegisterDefaultPlugins] are permitted to pass a nil *EventStore.
+func (p *CloudFormationPlugin) Initialize(_ context.Context, cfg PluginConfig) error {
+	p.state = cfg.State
+	p.logger = cfg.Logger
+	if tc, ok := cfg.Options["time_controller"].(*TimeController); ok {
+		p.tc = tc
+	} else {
+		p.tc = NewTimeController(time.Now())
+	}
+
+	registry, ok := cfg.Options["registry"].(*PluginRegistry)
+	if !ok || registry == nil {
+		return fmt.Errorf("cloudformation plugin: Options[registry] must hold a non-nil *PluginRegistry")
+	}
+
+	store, ok := cfg.Options["event_store"].(*EventStore)
+	if !ok || store == nil {
+		store = NewEventStore(EventStoreConfig{Enabled: false})
+	}
+	costs, ok := cfg.Options["cost_controller"].(*CostController)
+	if !ok || costs == nil {
+		costs = NewCostController(CostConfig{Enabled: false})
+	}
+
+	p.deployer = NewStackDeployer(registry, store, cfg.State, p.tc, cfg.Logger, costs)
+	return nil
+}
+
+// Shutdown is a no-op for CloudFormationPlugin.
+func (p *CloudFormationPlugin) Shutdown(_ context.Context) error { return nil }
+
+// HandleRequest dispatches a CloudFormation query-protocol request to the
+// appropriate handler.
+func (p *CloudFormationPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	action := req.Operation
+	if action == "" {
+		action = req.Params["Action"]
+	}
+	switch action {
+	case "CreateStack":
+		return p.createStack(ctx, req)
+	case "UpdateStack":
+		return p.updateStack(ctx, req)
+	case "DeleteStack":
+		return p.deleteStack(ctx, req)
+	case "DescribeStacks":
+		return p.describeStacks(ctx, req)
+	case "ListStacks":
+		return p.listStacks(ctx, req)
+	case "DescribeStackResources":
+		return p.describeStackResources(ctx, req)
+	case "GetTemplate":
+		return p.getTemplate(ctx, req)
+	case "CreateChangeSet":
+		return p.createChangeSet(ctx, req)
+	case "DescribeChangeSet":
+		return p.describeChangeSet(ctx, req)
+	case "ExecuteChangeSet":
+		return p.executeChangeSet(ctx, req)
+	case "ListChangeSets":
+		return p.listChangeSets(ctx, req)
+	case "DeleteChangeSet":
+		return p.deleteChangeSet(ctx, req)
+	case "DetectStackDrift":
+		return p.detectStackDrift(ctx, req)
+	case "DescribeStackResourceDrifts":
+		return p.describeStackResourceDrifts(ctx, req)
+	case "DescribeStackDriftDetectionStatus":
+		return p.describeStackDriftDetectionStatus(ctx, req)
+	case "DescribeStackEvents":
+		// Scoped out deliberately rather than fabricated. CFNStackState carries a
+		// single Status string; there is no per-resource event model behind it, so
+		// synthesizing a plausible CREATE_IN_PROGRESS/CREATE_COMPLETE pair per
+		// resource would invent observations a real stack never produced — the
+		// opposite of the provenance rule in docs/fidelity.md. A caller polling
+		// events gets a clear refusal instead and can poll DescribeStacks. See #501.
+		//
+		// UnsupportedOperation is not a documented CloudFormation error code; it is
+		// substrate's own signal that the operation exists but is unmodelled, chosen
+		// over inventing a stack-event stream.
+		return nil, &AWSError{
+			Code:       "UnsupportedOperation",
+			Message:    "CloudFormation DescribeStackEvents is not emulated: substrate models stack status, not per-resource stack events",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	default:
+		return nil, &AWSError{
+			Code:       "InvalidAction",
+			Message:    "CloudFormationPlugin: unknown action " + action,
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+}
+
+// --- Stack operations ---
+
+func (p *CloudFormationPlugin) createStack(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	name := req.Params["StackName"]
+	if name == "" {
+		return nil, cfnMissingParameter("StackName")
+	}
+	if req.Params["TemplateBody"] == "" && req.Params["TemplateURL"] != "" {
+		return nil, cfnTemplateURLUnsupported()
+	}
+	body := req.Params["TemplateBody"]
+	if body == "" {
+		return nil, cfnMissingParameter("TemplateBody")
+	}
+
+	existing, err := p.findStack(name)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		// AlreadyExists is CreateStack's documented duplicate-name code (400). The
+		// message is substrate's own; no capture of the real wording was taken.
+		return nil, &AWSError{
+			Code:       "AlreadyExists",
+			Message:    fmt.Sprintf("Stack [%s] already exists", name),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	// The stack name is passed as the deployer's stream ID because
+	// StackDeployer.Deploy derives the persisted stack name from it. BettyClient
+	// instead passes deploy-<unixnano>, which is right for a one-shot in-process
+	// validation run but would make a wire-created stack undiscoverable by the
+	// name the caller asked for.
+	if _, err := p.deployer.Deploy(context.Background(), body, name,
+		cfnRequestParameters(req.Params, nil)); err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type result struct {
+		StackID string `xml:"StackId"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"CreateStackResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"CreateStackResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	return cfnXMLResponse(http.StatusOK, response{
+		XMLNS:    cfnXMLNS,
+		Result:   result{StackID: cfnStackID(reqCtx, name)},
+		Metadata: cfnMetadata(reqCtx),
+	})
+}
+
+func (p *CloudFormationPlugin) updateStack(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	name := req.Params["StackName"]
+	if name == "" {
+		return nil, cfnMissingParameter("StackName")
+	}
+	if req.Params["TemplateBody"] == "" && req.Params["TemplateURL"] != "" {
+		return nil, cfnTemplateURLUnsupported()
+	}
+
+	stack, err := p.findStack(name)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		return nil, cfnStackNotFound(name)
+	}
+
+	body := req.Params["TemplateBody"]
+	if body == "" {
+		// UsePreviousTemplate is the documented way to change only parameters.
+		body = stack.TemplateBody
+	}
+	if _, err := p.deployer.UpdateStack(context.Background(), body, name,
+		cfnRequestParameters(req.Params, stack.Parameters)); err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type result struct {
+		StackID string `xml:"StackId"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"UpdateStackResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"UpdateStackResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	return cfnXMLResponse(http.StatusOK, response{
+		XMLNS:    cfnXMLNS,
+		Result:   result{StackID: cfnStackID(reqCtx, name)},
+		Metadata: cfnMetadata(reqCtx),
+	})
+}
+
+func (p *CloudFormationPlugin) deleteStack(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	name := req.Params["StackName"]
+	if name == "" {
+		return nil, cfnMissingParameter("StackName")
+	}
+	// DeleteStack documents no not-found error: a deleted stack simply stops
+	// appearing in DescribeStacks, so deleting an absent stack succeeds.
+	if err := p.deployer.DeleteStack(context.Background(), name); err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type response struct {
+		XMLName  xml.Name            `xml:"DeleteStackResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	return cfnXMLResponse(http.StatusOK, response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)})
+}
+
+// cfnStackItem is the wire shape of a CloudFormation Stack structure. Only the
+// members substrate can answer from CFNStackState are emitted; CreationTime,
+// StackName and StackStatus are the three the API marks required.
+type cfnStackItem struct {
+	StackID         string            `xml:"StackId"`
+	StackName       string            `xml:"StackName"`
+	CreationTime    string            `xml:"CreationTime"`
+	LastUpdatedTime string            `xml:"LastUpdatedTime,omitempty"`
+	StackStatus     string            `xml:"StackStatus"`
+	DisableRollback bool              `xml:"DisableRollback"`
+	Parameters      []cfnParameterXML `xml:"Parameters>member,omitempty"`
+	Outputs         []cfnOutputXML    `xml:"Outputs>member,omitempty"`
+}
+
+// cfnParameterXML is a resolved template parameter as DescribeStacks reports it.
+type cfnParameterXML struct {
+	ParameterKey   string `xml:"ParameterKey"`
+	ParameterValue string `xml:"ParameterValue"`
+}
+
+// cfnOutputXML is a resolved template output as DescribeStacks reports it.
+type cfnOutputXML struct {
+	OutputKey   string `xml:"OutputKey"`
+	OutputValue string `xml:"OutputValue"`
+}
+
+func (p *CloudFormationPlugin) describeStacks(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	name := req.Params["StackName"]
+
+	var stacks []CFNStackState
+	if name == "" {
+		all, err := p.listAllStacks()
+		if err != nil {
+			return nil, err
+		}
+		stacks = all
+	} else {
+		stack, err := p.findStack(name)
+		if err != nil {
+			return nil, err
+		}
+		if stack == nil {
+			return nil, cfnStackNotFound(name)
+		}
+		stacks = []CFNStackState{*stack}
+	}
+
+	type result struct {
+		Stacks []cfnStackItem `xml:"Stacks>member"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"DescribeStacksResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"DescribeStacksResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	resp := response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)}
+	for _, s := range stacks {
+		resp.Result.Stacks = append(resp.Result.Stacks, cfnStackItem{
+			StackID:         cfnStackID(reqCtx, s.StackName),
+			StackName:       s.StackName,
+			CreationTime:    cfnTime(s.CreatedAt),
+			LastUpdatedTime: cfnTime(s.UpdatedAt),
+			StackStatus:     s.Status,
+			Parameters:      cfnParametersXML(s.Parameters),
+			Outputs:         cfnOutputsXML(s.Outputs),
+		})
+	}
+	return cfnXMLResponse(http.StatusOK, resp)
+}
+
+func (p *CloudFormationPlugin) listStacks(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	filters := extractIndexedParams(req.Params, "StackStatusFilter.member")
+	stacks, err := p.listAllStacks()
+	if err != nil {
+		return nil, err
+	}
+
+	type summary struct {
+		StackID         string `xml:"StackId"`
+		StackName       string `xml:"StackName"`
+		CreationTime    string `xml:"CreationTime"`
+		LastUpdatedTime string `xml:"LastUpdatedTime,omitempty"`
+		StackStatus     string `xml:"StackStatus"`
+	}
+	type result struct {
+		Summaries []summary `xml:"StackSummaries>member"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"ListStacksResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"ListStacksResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	resp := response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)}
+	for _, s := range stacks {
+		if len(filters) > 0 && !containsStr(filters, s.Status) {
+			continue
+		}
+		resp.Result.Summaries = append(resp.Result.Summaries, summary{
+			StackID:         cfnStackID(reqCtx, s.StackName),
+			StackName:       s.StackName,
+			CreationTime:    cfnTime(s.CreatedAt),
+			LastUpdatedTime: cfnTime(s.UpdatedAt),
+			StackStatus:     s.Status,
+		})
+	}
+	return cfnXMLResponse(http.StatusOK, resp)
+}
+
+func (p *CloudFormationPlugin) describeStackResources(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	name := req.Params["StackName"]
+	physicalID := req.Params["PhysicalResourceId"]
+	logicalID := req.Params["LogicalResourceId"]
+
+	// The API refuses both together: "you cannot specify StackName and
+	// PhysicalResourceId in the same request".
+	if name != "" && physicalID != "" {
+		return nil, &AWSError{
+			Code:       "ValidationError",
+			Message:    "StackName and PhysicalResourceId cannot both be specified",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	if name == "" && physicalID == "" {
+		return nil, cfnMissingParameter("StackName")
+	}
+
+	var stacks []CFNStackState
+	if name != "" {
+		stack, err := p.findStack(name)
+		if err != nil {
+			return nil, err
+		}
+		if stack == nil {
+			return nil, cfnStackNotFound(name)
+		}
+		stacks = []CFNStackState{*stack}
+	} else {
+		all, err := p.listAllStacks()
+		if err != nil {
+			return nil, err
+		}
+		stacks = all
+	}
+
+	type resourceItem struct {
+		StackID              string `xml:"StackId"`
+		StackName            string `xml:"StackName"`
+		LogicalResourceID    string `xml:"LogicalResourceId"`
+		PhysicalResourceID   string `xml:"PhysicalResourceId,omitempty"`
+		ResourceType         string `xml:"ResourceType"`
+		Timestamp            string `xml:"Timestamp"`
+		ResourceStatus       string `xml:"ResourceStatus"`
+		ResourceStatusReason string `xml:"ResourceStatusReason,omitempty"`
+	}
+	type result struct {
+		Resources []resourceItem `xml:"StackResources>member"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"DescribeStackResourcesResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"DescribeStackResourcesResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	resp := response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)}
+	for _, s := range stacks {
+		for _, r := range s.Resources {
+			if physicalID != "" && r.PhysicalID != physicalID {
+				continue
+			}
+			if logicalID != "" && r.LogicalID != logicalID {
+				continue
+			}
+			// The per-resource status is derived from whether the resource actually
+			// deployed, not invented: DeployedResource.Error is set when a resource
+			// failed, and empty when it succeeded.
+			status, reason := "CREATE_COMPLETE", ""
+			if r.Error != "" {
+				status, reason = "CREATE_FAILED", r.Error
+			}
+			resp.Result.Resources = append(resp.Result.Resources, resourceItem{
+				StackID:              cfnStackID(reqCtx, s.StackName),
+				StackName:            s.StackName,
+				LogicalResourceID:    r.LogicalID,
+				PhysicalResourceID:   r.PhysicalID,
+				ResourceType:         r.Type,
+				Timestamp:            cfnTime(s.UpdatedAt),
+				ResourceStatus:       status,
+				ResourceStatusReason: reason,
+			})
+		}
+	}
+	return cfnXMLResponse(http.StatusOK, resp)
+}
+
+func (p *CloudFormationPlugin) getTemplate(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	stackName := req.Params["StackName"]
+	changeSetName := cfnChangeSetName(req.Params["ChangeSetName"])
+
+	var body string
+	switch {
+	case changeSetName != "":
+		cs, err := p.findChangeSet(stackName, changeSetName)
+		if err != nil {
+			return nil, err
+		}
+		if cs == nil {
+			return nil, cfnChangeSetNotFound(changeSetName)
+		}
+		body = cs.TemplateBody
+	case stackName != "":
+		stack, err := p.findStack(stackName)
+		if err != nil {
+			return nil, err
+		}
+		if stack == nil {
+			return nil, cfnStackNotFound(stackName)
+		}
+		body = stack.TemplateBody
+	default:
+		return nil, cfnMissingParameter("StackName")
+	}
+
+	type result struct {
+		TemplateBody    string   `xml:"TemplateBody"`
+		StagesAvailable []string `xml:"StagesAvailable>member"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"GetTemplateResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"GetTemplateResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	// Only Original is available: substrate applies no template transforms, so
+	// there is no processed template distinct from the one that was submitted.
+	return cfnXMLResponse(http.StatusOK, response{
+		XMLNS:    cfnXMLNS,
+		Result:   result{TemplateBody: body, StagesAvailable: []string{"Original"}},
+		Metadata: cfnMetadata(reqCtx),
+	})
+}
+
+// --- Change-set operations ---
+
+func (p *CloudFormationPlugin) createChangeSet(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	stackName := req.Params["StackName"]
+	changeSetName := req.Params["ChangeSetName"]
+	if changeSetName == "" {
+		return nil, cfnMissingParameter("ChangeSetName")
+	}
+	if stackName == "" {
+		return nil, cfnMissingParameter("StackName")
+	}
+	if req.Params["TemplateBody"] == "" && req.Params["TemplateURL"] != "" {
+		return nil, cfnTemplateURLUnsupported()
+	}
+	// ChangeSetType=CREATE would have to persist a stack in REVIEW_IN_PROGRESS
+	// carrying no template, a state CFNStackState cannot represent and
+	// StackDeployer.CreateChangeSet cannot diff against. Refuse it rather than
+	// half-model it; the change-set family operates on existing stacks.
+	if t := req.Params["ChangeSetType"]; t != "" && t != "UPDATE" {
+		return nil, &AWSError{
+			Code:       "ValidationError",
+			Message:    "ChangeSetType " + t + " is not emulated: substrate supports UPDATE change sets on an existing stack",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	stack, err := p.findStack(stackName)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		return nil, cfnStackNotFound(stackName)
+	}
+	if existing, err := p.findChangeSet(stackName, changeSetName); err != nil {
+		return nil, err
+	} else if existing != nil {
+		return nil, &AWSError{
+			Code:       "AlreadyExists",
+			Message:    fmt.Sprintf("ChangeSet [%s] already exists for stack [%s]", changeSetName, stackName),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	body := req.Params["TemplateBody"]
+	if body == "" {
+		body = stack.TemplateBody
+	}
+	if _, err := p.deployer.CreateChangeSet(context.Background(), stackName, changeSetName, body,
+		cfnRequestParameters(req.Params, stack.Parameters)); err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type result struct {
+		ID      string `xml:"Id"`
+		StackID string `xml:"StackId"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"CreateChangeSetResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"CreateChangeSetResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	return cfnXMLResponse(http.StatusOK, response{
+		XMLNS: cfnXMLNS,
+		Result: result{
+			ID:      cfnChangeSetID(reqCtx, stackName, changeSetName),
+			StackID: cfnStackID(reqCtx, stackName),
+		},
+		Metadata: cfnMetadata(reqCtx),
+	})
+}
+
+func (p *CloudFormationPlugin) describeChangeSet(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	changeSetName := cfnChangeSetName(req.Params["ChangeSetName"])
+	if changeSetName == "" {
+		return nil, cfnMissingParameter("ChangeSetName")
+	}
+	cs, err := p.findChangeSet(req.Params["StackName"], changeSetName)
+	if err != nil {
+		return nil, err
+	}
+	if cs == nil {
+		return nil, cfnChangeSetNotFound(changeSetName)
+	}
+
+	type resourceChange struct {
+		Action             string `xml:"Action"`
+		LogicalResourceID  string `xml:"LogicalResourceId"`
+		PhysicalResourceID string `xml:"PhysicalResourceId,omitempty"`
+		ResourceType       string `xml:"ResourceType"`
+		Replacement        string `xml:"Replacement,omitempty"`
+	}
+	type change struct {
+		Type           string         `xml:"Type"`
+		ResourceChange resourceChange `xml:"ResourceChange"`
+	}
+	type result struct {
+		ChangeSetID     string            `xml:"ChangeSetId"`
+		ChangeSetName   string            `xml:"ChangeSetName"`
+		StackID         string            `xml:"StackId"`
+		StackName       string            `xml:"StackName"`
+		Status          string            `xml:"Status"`
+		ExecutionStatus string            `xml:"ExecutionStatus"`
+		CreationTime    string            `xml:"CreationTime"`
+		Parameters      []cfnParameterXML `xml:"Parameters>member,omitempty"`
+		Changes         []change          `xml:"Changes>member"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"DescribeChangeSetResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"DescribeChangeSetResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	resp := response{
+		XMLNS: cfnXMLNS,
+		Result: result{
+			ChangeSetID:   cfnChangeSetID(reqCtx, cs.StackName, cs.ChangeSetName),
+			ChangeSetName: cs.ChangeSetName,
+			StackID:       cfnStackID(reqCtx, cs.StackName),
+			StackName:     cs.StackName,
+			Status:        cs.Status,
+			// A change set is deleted when it is executed, so any change set that
+			// still resolves is one that has not run yet and is available to run.
+			ExecutionStatus: "AVAILABLE",
+			CreationTime:    cfnTime(cs.CreatedAt),
+			Parameters:      cfnParametersXML(cs.Parameters),
+		},
+		Metadata: cfnMetadata(reqCtx),
+	}
+	for _, c := range cs.Changes {
+		resp.Result.Changes = append(resp.Result.Changes, change{
+			Type: "Resource",
+			ResourceChange: resourceChange{
+				Action:            c.Action,
+				LogicalResourceID: c.LogicalID,
+				ResourceType:      c.ResourceType,
+				Replacement:       c.Replacement,
+			},
+		})
+	}
+	return cfnXMLResponse(http.StatusOK, resp)
+}
+
+func (p *CloudFormationPlugin) executeChangeSet(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	changeSetName := cfnChangeSetName(req.Params["ChangeSetName"])
+	if changeSetName == "" {
+		return nil, cfnMissingParameter("ChangeSetName")
+	}
+	cs, err := p.findChangeSet(req.Params["StackName"], changeSetName)
+	if err != nil {
+		return nil, err
+	}
+	if cs == nil {
+		return nil, cfnChangeSetNotFound(changeSetName)
+	}
+	if _, err := p.deployer.ExecuteChangeSet(context.Background(), cs.StackName, cs.ChangeSetName); err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type response struct {
+		XMLName  xml.Name            `xml:"ExecuteChangeSetResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   struct{}            `xml:"ExecuteChangeSetResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	return cfnXMLResponse(http.StatusOK, response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)})
+}
+
+func (p *CloudFormationPlugin) listChangeSets(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	stackName := req.Params["StackName"]
+	if stackName == "" {
+		return nil, cfnMissingParameter("StackName")
+	}
+	stack, err := p.findStack(stackName)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		return nil, cfnStackNotFound(stackName)
+	}
+	sets, err := p.deployer.ListChangeSets(context.Background(), stackName)
+	if err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type summary struct {
+		ChangeSetID   string `xml:"ChangeSetId"`
+		ChangeSetName string `xml:"ChangeSetName"`
+		StackID       string `xml:"StackId"`
+		StackName     string `xml:"StackName"`
+		Status        string `xml:"Status"`
+		CreationTime  string `xml:"CreationTime"`
+	}
+	type result struct {
+		Summaries []summary `xml:"Summaries>member"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"ListChangeSetsResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"ListChangeSetsResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	resp := response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)}
+	for _, cs := range sets {
+		resp.Result.Summaries = append(resp.Result.Summaries, summary{
+			ChangeSetID:   cfnChangeSetID(reqCtx, cs.StackName, cs.ChangeSetName),
+			ChangeSetName: cs.ChangeSetName,
+			StackID:       cfnStackID(reqCtx, cs.StackName),
+			StackName:     cs.StackName,
+			Status:        cs.Status,
+			CreationTime:  cfnTime(cs.CreatedAt),
+		})
+	}
+	return cfnXMLResponse(http.StatusOK, resp)
+}
+
+func (p *CloudFormationPlugin) deleteChangeSet(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	changeSetName := cfnChangeSetName(req.Params["ChangeSetName"])
+	if changeSetName == "" {
+		return nil, cfnMissingParameter("ChangeSetName")
+	}
+	// DeleteChangeSet documents no not-found error, so deleting an absent change
+	// set succeeds; only a wrong-status change set is refused, and substrate has
+	// no in-progress status to refuse.
+	if cs, err := p.findChangeSet(req.Params["StackName"], changeSetName); err != nil {
+		return nil, err
+	} else if cs != nil {
+		if err := p.deployer.DeleteChangeSet(context.Background(), cs.StackName, cs.ChangeSetName); err != nil {
+			return nil, cfnMapDeployerError(err)
+		}
+	}
+
+	type response struct {
+		XMLName  xml.Name            `xml:"DeleteChangeSetResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   struct{}            `xml:"DeleteChangeSetResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	return cfnXMLResponse(http.StatusOK, response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)})
+}
+
+// --- Drift operations ---
+
+func (p *CloudFormationPlugin) detectStackDrift(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	stackName := req.Params["StackName"]
+	if stackName == "" {
+		return nil, cfnMissingParameter("StackName")
+	}
+	detectionID, err := p.deployer.StartStackDriftDetection(context.Background(), stackName)
+	if err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type result struct {
+		StackDriftDetectionID string `xml:"StackDriftDetectionId"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"DetectStackDriftResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"DetectStackDriftResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	return cfnXMLResponse(http.StatusOK, response{
+		XMLNS:    cfnXMLNS,
+		Result:   result{StackDriftDetectionID: detectionID},
+		Metadata: cfnMetadata(reqCtx),
+	})
+}
+
+func (p *CloudFormationPlugin) describeStackResourceDrifts(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	stackName := req.Params["StackName"]
+	if stackName == "" {
+		return nil, cfnMissingParameter("StackName")
+	}
+	filters := extractIndexedParams(req.Params, "StackResourceDriftStatusFilters.member")
+	drifts, err := p.deployer.DescribeStackResourceDrifts(context.Background(), stackName, filters)
+	if err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type propertyDifference struct {
+		PropertyPath   string `xml:"PropertyPath"`
+		ExpectedValue  string `xml:"ExpectedValue"`
+		ActualValue    string `xml:"ActualValue"`
+		DifferenceType string `xml:"DifferenceType"`
+	}
+	type driftItem struct {
+		StackID                  string               `xml:"StackId"`
+		LogicalResourceID        string               `xml:"LogicalResourceId"`
+		PhysicalResourceID       string               `xml:"PhysicalResourceId,omitempty"`
+		ResourceType             string               `xml:"ResourceType"`
+		StackResourceDriftStatus string               `xml:"StackResourceDriftStatus"`
+		Timestamp                string               `xml:"Timestamp"`
+		PropertyDifferences      []propertyDifference `xml:"PropertyDifferences>member,omitempty"`
+	}
+	type result struct {
+		Drifts []driftItem `xml:"StackResourceDrifts>member"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"DescribeStackResourceDriftsResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"DescribeStackResourceDriftsResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	now := cfnTime(p.tc.Now())
+	resp := response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)}
+	for _, d := range drifts {
+		item := driftItem{
+			StackID:                  cfnStackID(reqCtx, stackName),
+			LogicalResourceID:        d.LogicalID,
+			PhysicalResourceID:       d.PhysicalID,
+			ResourceType:             d.ResourceType,
+			StackResourceDriftStatus: d.DriftStatus,
+			Timestamp:                now,
+		}
+		for _, diff := range d.PropertyDifferences {
+			// The wire struct differs from CFNPropertyDiff only in its tags, which
+			// a conversion ignores. If the two ever diverge in field names, types
+			// or order this stops compiling, which is the right place to notice.
+			item.PropertyDifferences = append(item.PropertyDifferences, propertyDifference(diff))
+		}
+		resp.Result.Drifts = append(resp.Result.Drifts, item)
+	}
+	return cfnXMLResponse(http.StatusOK, resp)
+}
+
+func (p *CloudFormationPlugin) describeStackDriftDetectionStatus(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	detectionID := req.Params["StackDriftDetectionId"]
+	if detectionID == "" {
+		return nil, cfnMissingParameter("StackDriftDetectionId")
+	}
+	status, err := p.deployer.DescribeStackDriftDetectionStatus(context.Background(), detectionID)
+	if err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type result struct {
+		StackID                   string `xml:"StackId"`
+		StackDriftDetectionID     string `xml:"StackDriftDetectionId"`
+		DetectionStatus           string `xml:"DetectionStatus"`
+		StackDriftStatus          string `xml:"StackDriftStatus,omitempty"`
+		DriftedStackResourceCount int    `xml:"DriftedStackResourceCount"`
+		Timestamp                 string `xml:"Timestamp"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"DescribeStackDriftDetectionStatusResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"DescribeStackDriftDetectionStatusResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	return cfnXMLResponse(http.StatusOK, response{
+		XMLNS: cfnXMLNS,
+		Result: result{
+			StackID:                   cfnStackID(reqCtx, status.StackName),
+			StackDriftDetectionID:     status.StackDriftDetectionID,
+			DetectionStatus:           status.DetectionStatus,
+			StackDriftStatus:          status.StackDriftStatus,
+			DriftedStackResourceCount: status.DriftedStackResourceCount,
+			Timestamp:                 cfnTime(status.Timestamp),
+		},
+		Metadata: cfnMetadata(reqCtx),
+	})
+}
+
+// --- Lookups ---
+
+// listAllStacks returns every persisted stack.
+func (p *CloudFormationPlugin) listAllStacks() ([]CFNStackState, error) {
+	stacks, err := p.deployer.ListStacks(context.Background())
+	if err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+	return stacks, nil
+}
+
+// findStack returns the stack named name, or nil when no such stack exists.
+//
+// The lookup goes through StackDeployer.ListStacks rather than reading the
+// cfn namespace directly so the state key layout stays betty_cfn.go's business.
+func (p *CloudFormationPlugin) findStack(name string) (*CFNStackState, error) {
+	stacks, err := p.listAllStacks()
+	if err != nil {
+		return nil, err
+	}
+	for i := range stacks {
+		if stacks[i].StackName == name {
+			return &stacks[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// findChangeSet resolves a change set by name. An empty stackName searches every
+// stack, which is what lets DescribeChangeSet and ExecuteChangeSet accept a
+// change-set ARN with no StackName the way the API documents.
+func (p *CloudFormationPlugin) findChangeSet(stackName, changeSetName string) (*CFNChangeSet, error) {
+	stackNames := []string{stackName}
+	if stackName == "" {
+		stacks, err := p.listAllStacks()
+		if err != nil {
+			return nil, err
+		}
+		stackNames = stackNames[:0]
+		for _, s := range stacks {
+			stackNames = append(stackNames, s.StackName)
+		}
+	}
+	for _, sn := range stackNames {
+		sets, err := p.deployer.ListChangeSets(context.Background(), sn)
+		if err != nil {
+			return nil, cfnMapDeployerError(err)
+		}
+		for i := range sets {
+			if sets[i].ChangeSetName == changeSetName {
+				return &sets[i], nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// --- Errors ---
+
+// cfnMissingParameter reports an absent required query parameter. MissingParameter
+// is a documented CloudFormation common error whose description is exactly this
+// case: a required parameter for the specified action is not included.
+func cfnMissingParameter(name string) *AWSError {
+	return &AWSError{
+		Code:       "MissingParameter",
+		Message:    "Missing required parameter " + name,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// cfnStackNotFound reports an unknown stack. DescribeStacks and GetTemplate both
+// document ValidationError for this case; the message wording is substrate's own.
+func cfnStackNotFound(name string) *AWSError {
+	return &AWSError{
+		Code:       "ValidationError",
+		Message:    fmt.Sprintf("Stack with id %s does not exist", name),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// cfnChangeSetNotFound reports an unknown change set. ChangeSetNotFound is
+// documented at HTTP 404, unlike the stack case.
+func cfnChangeSetNotFound(name string) *AWSError {
+	return &AWSError{
+		Code:       "ChangeSetNotFound",
+		Message:    fmt.Sprintf("ChangeSet [%s] does not exist", name),
+		HTTPStatus: http.StatusNotFound,
+	}
+}
+
+// cfnTemplateURLUnsupported refuses TemplateURL. Fetching a template from S3 or
+// an HTTP URL is a network read substrate deliberately does not perform; a
+// caller passes TemplateBody instead.
+func cfnTemplateURLUnsupported() *AWSError {
+	return &AWSError{
+		Code:       "ValidationError",
+		Message:    "TemplateURL is not emulated: pass the template inline with TemplateBody",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// cfnMapDeployerError maps a StackDeployer failure onto a wire error code.
+//
+// StackDeployer reports failures as fmt.Errorf strings, so the mapping matches on
+// the sentinel text it emits. The handlers above pre-flight the not-found cases
+// themselves, so those codes are right by construction and this is the fallback
+// for anything that escapes; typed errors in betty_cfn.go would remove the string
+// matching entirely and are tracked in #502.
+func cfnMapDeployerError(err error) *AWSError {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "not found"):
+		return &AWSError{Code: "ValidationError", Message: msg, HTTPStatus: http.StatusBadRequest}
+	case strings.Contains(msg, "parse template"),
+		strings.Contains(msg, "parse old template"),
+		strings.Contains(msg, "parse new template"):
+		return &AWSError{
+			Code:       "ValidationError",
+			Message:    "Template format error: " + msg,
+			HTTPStatus: http.StatusBadRequest,
+		}
+	default:
+		return &AWSError{Code: "InternalFailure", Message: msg, HTTPStatus: http.StatusInternalServerError}
+	}
+}
+
+// --- Wire helpers ---
+
+// cfnResponseMetadata is the ResponseMetadata element every CloudFormation
+// Query response carries.
+type cfnResponseMetadata struct {
+	RequestID string `xml:"RequestId"`
+}
+
+func cfnMetadata(reqCtx *RequestContext) cfnResponseMetadata {
+	return cfnResponseMetadata{RequestID: reqCtx.RequestID}
+}
+
+// cfnXMLResponse serializes v to XML and returns an AWSResponse.
+func cfnXMLResponse(status int, v interface{}) (*AWSResponse, error) {
+	body, err := xml.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("cloudformation xml marshal: %w", err)
+	}
+	return &AWSResponse{
+		StatusCode: status,
+		Headers:    map[string]string{"Content-Type": "text/xml; charset=UTF-8"},
+		Body:       append([]byte(xml.Header), body...),
+	}, nil
+}
+
+// cfnTime formats t the way CloudFormation reports a timestamp. A zero time
+// yields the empty string so an omitempty member is dropped rather than
+// reporting year 1.
+func cfnTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// cfnStackID builds the stack ARN.
+//
+// The region and account come from the request, not from the deployer: a caller
+// signing for eu-west-1 should see a eu-west-1 stack ARN. Note that
+// StackDeployer.Deploy resolves the AWS::Region and AWS::AccountId
+// pseudo-parameters inside the template against substrate's defaults instead, so
+// the two can disagree for a non-default region.
+func cfnStackID(reqCtx *RequestContext, stackName string) string {
+	return fmt.Sprintf("arn:aws:cloudformation:%s:%s:stack/%s/%s",
+		reqCtx.Region, reqCtx.AccountID, stackName,
+		cfnDeterministicUUID(reqCtx.Region, reqCtx.AccountID, stackName))
+}
+
+// cfnChangeSetID builds the change-set ARN.
+func cfnChangeSetID(reqCtx *RequestContext, stackName, changeSetName string) string {
+	return fmt.Sprintf("arn:aws:cloudformation:%s:%s:changeSet/%s/%s",
+		reqCtx.Region, reqCtx.AccountID, changeSetName,
+		cfnDeterministicUUID(reqCtx.Region, reqCtx.AccountID, stackName, changeSetName))
+}
+
+// cfnDeterministicUUID derives a stable UUID-shaped suffix from parts, so the
+// same stack reports the same ARN on every call and across a replay.
+func cfnDeterministicUUID(parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "/")))
+	h := hex.EncodeToString(sum[:])
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}
+
+// cfnChangeSetName accepts either a bare change-set name or a change-set ARN and
+// returns the name, which is how StackDeployer keys change sets.
+func cfnChangeSetName(nameOrARN string) string {
+	const token = ":changeSet/"
+	idx := strings.Index(nameOrARN, token)
+	if idx < 0 {
+		return nameOrARN
+	}
+	rest := nameOrARN[idx+len(token):]
+	if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+		return rest[:slash]
+	}
+	return rest
+}
+
+// cfnRequestParameters parses Parameters.member.N.ParameterKey and
+// .ParameterValue into the map StackDeployer takes.
+//
+// A member with UsePreviousValue=true takes its value from previous — the
+// currently deployed stack's resolved parameters — rather than sending an empty
+// string, which would silently overwrite the stored value with nothing.
+func cfnRequestParameters(params, previous map[string]string) map[string]string {
+	out := make(map[string]string)
+	for i := 1; ; i++ {
+		key, ok := params[fmt.Sprintf("Parameters.member.%d.ParameterKey", i)]
+		if !ok {
+			break
+		}
+		if key == "" {
+			continue
+		}
+		if params[fmt.Sprintf("Parameters.member.%d.UsePreviousValue", i)] == "true" {
+			if prev, found := previous[key]; found {
+				out[key] = prev
+			}
+			continue
+		}
+		out[key] = params[fmt.Sprintf("Parameters.member.%d.ParameterValue", i)]
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// cfnParametersXML renders a resolved parameter map, sorted by key so a response
+// is byte-identical across calls.
+func cfnParametersXML(params map[string]string) []cfnParameterXML {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]cfnParameterXML, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, cfnParameterXML{ParameterKey: k, ParameterValue: params[k]})
+	}
+	return out
+}
+
+// cfnOutputsXML renders a resolved output map, sorted by key.
+func cfnOutputsXML(outputs map[string]string) []cfnOutputXML {
+	keys := make([]string, 0, len(outputs))
+	for k := range outputs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]cfnOutputXML, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, cfnOutputXML{OutputKey: k, OutputValue: outputs[k]})
+	}
+	return out
+}

--- a/emulator/cloudformation_plugin_test.go
+++ b/emulator/cloudformation_plugin_test.go
@@ -1,0 +1,1167 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/xml"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// cfnTestServer bundles the CloudFormation wire server with the state and
+// registry behind it, so a test can assert both over the wire and in process.
+type cfnTestServer struct {
+	srv      *emulator.Server
+	state    emulator.StateManager
+	registry *emulator.PluginRegistry
+	tc       *emulator.TimeController
+}
+
+// newCFNTestServer builds a server with the CloudFormation plugin registered
+// alongside the S3 and IAM plugins.
+//
+// The S3 and IAM plugins are registered deliberately rather than for
+// convenience: the point of #483's fix is that a stack created over the wire
+// deploys into the same registry the server routes with, so a template's bucket
+// has to be reachable through the S3 plugin afterwards. A CFN-only registry
+// could not tell a shared world from a private one.
+func newCFNTestServer(t *testing.T) *cfnTestServer {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	registry := emulator.NewPluginRegistry()
+
+	s3p := &emulator.S3Plugin{}
+	require.NoError(t, s3p.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"filesystem":      afero.NewMemMapFs(),
+			"registry":        registry,
+		},
+	}))
+	registry.Register(s3p)
+
+	iamp := &emulator.IAMPlugin{}
+	require.NoError(t, iamp.Initialize(context.Background(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(iamp)
+
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
+
+	cfnp := &emulator.CloudFormationPlugin{}
+	require.NoError(t, cfnp.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"registry":        registry,
+			"event_store":     store,
+		},
+	}))
+	registry.Register(cfnp)
+
+	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger,
+		emulator.ServerOptions{Costs: emulator.NewCostController(emulator.CostConfig{Enabled: true})})
+
+	return &cfnTestServer{srv: srv, state: state, registry: registry, tc: tc}
+}
+
+// cfnAuthHeader is a SigV4 Authorization header carrying a fake AKIA access
+// key, which extractAccount maps to the well-known test account 123456789012.
+const cfnAuthHeader = "AWS4-HMAC-SHA256 Credential=AKIATEST1234567890/20260101/" +
+	"us-east-1/cloudformation/aws4_request, SignedHeaders=host, Signature=fake"
+
+// cfnRequest posts a CloudFormation query-protocol request and returns the
+// status code and body.
+func cfnRequest(t *testing.T, ts *cfnTestServer, params map[string]string) (int, string) {
+	t.Helper()
+	form := url.Values{}
+	for k, v := range params {
+		form.Set(k, v)
+	}
+	r := httptest.NewRequest(http.MethodPost, "http://cloudformation.us-east-1.amazonaws.com/",
+		strings.NewReader(form.Encode()))
+	r.Host = "cloudformation.us-east-1.amazonaws.com"
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Signing with an AKIA key resolves the request to the well-known test
+	// account, which is what a signed CLI or SDK request carries; without it the
+	// stack ARNs would name the zero account.
+	r.Header.Set("Authorization", cfnAuthHeader)
+	w := httptest.NewRecorder()
+	ts.srv.ServeHTTP(w, r)
+	body, err := io.ReadAll(w.Body)
+	require.NoError(t, err)
+	return w.Code, string(body)
+}
+
+// cfnAction posts an Action=<name> request with the supplied extra parameters.
+func cfnAction(t *testing.T, ts *cfnTestServer, action string, params map[string]string) (int, string) {
+	t.Helper()
+	all := map[string]string{"Action": action, "Version": "2010-05-15"}
+	for k, v := range params {
+		all[k] = v
+	}
+	return cfnRequest(t, ts, all)
+}
+
+// cfnErrorCode extracts the error code from an <ErrorResponse> document.
+func cfnErrorCode(t *testing.T, body string) string {
+	t.Helper()
+	var doc struct {
+		Code string `xml:"Error>Code"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc), "body was %s", body)
+	return doc.Code
+}
+
+// The templates below are the smallest ones that exercise each path.
+const (
+	cfnEmptyTemplate  = `{"Resources":{}}`
+	cfnBucketTemplate = `{"Resources":{"Data":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":"cfn-wire-bucket"}}},` +
+		`"Outputs":{"BucketName":{"Value":{"Ref":"Data"}}}}`
+	cfnBucketRoleTemplate = `{"Resources":{` +
+		`"Data":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-shared-bucket"}},` +
+		`"Runner":{"Type":"AWS::IAM::Role","Properties":{"RoleName":"cfn-shared-role",` +
+		`"AssumeRolePolicyDocument":{"Version":"2012-10-17","Statement":[]}}}}}`
+	cfnParamTemplate = `{"Parameters":{"BucketSuffix":{"Type":"String","Default":"default"}},` +
+		`"Resources":{"Data":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":{"Fn::Sub":"cfn-param-${BucketSuffix}"}}}}}`
+)
+
+// TestCFNPlugin_CreateStack is #483's gate: the reporter's exact reproduction.
+//
+// Before the plugin existed, PluginRegistry.RouteRequest had no entry for
+// "cloudformation" and answered ServiceNotAvailable with HTTP 501 for every
+// CloudFormation call, even though the whole stack model was already
+// implemented and reachable from Go.
+func TestCFNPlugin_CreateStack(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "probe",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.NotContains(t, body, "ServiceNotAvailable")
+
+	var doc struct {
+		StackID string `xml:"CreateStackResult>StackId"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+	assert.Contains(t, doc.StackID, "arn:aws:cloudformation:us-east-1:123456789012:stack/probe/")
+}
+
+// TestCFNPlugin_UnregisteredServiceStillRefused pins that the fix is a
+// registration and not a change to the routing fallback: an unemulated service
+// still reports ServiceNotAvailable.
+func TestCFNPlugin_UnregisteredServiceStillRefused(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	r := httptest.NewRequest(http.MethodPost, "http://madeupservice.us-east-1.amazonaws.com/",
+		strings.NewReader("Action=DoThing"))
+	r.Host = "madeupservice.us-east-1.amazonaws.com"
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	ts.srv.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNotImplemented, w.Code)
+	assert.Contains(t, w.Body.String(), "ServiceNotAvailable")
+}
+
+// TestCFNPlugin_StackSharesStateWithOtherPlugins is the assertion that proves
+// the adapter deploys into the same emulator rather than a private world: the
+// bucket a template declares is served by the S3 plugin over the wire, and the
+// role by the IAM plugin.
+func TestCFNPlugin_StackSharesStateWithOtherPlugins(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "shared",
+		"TemplateBody": cfnBucketRoleTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	// DescribeStacks reports the stack complete with both resources.
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "shared"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<StackStatus>CREATE_COMPLETE</StackStatus>")
+
+	code, body = cfnAction(t, ts, "DescribeStackResources", map[string]string{"StackName": "shared"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "cfn-shared-bucket")
+	assert.Contains(t, body, "cfn-shared-role")
+	assert.Contains(t, body, "AWS::S3::Bucket")
+	assert.Contains(t, body, "AWS::IAM::Role")
+
+	// The bucket is reachable through the S3 plugin over the wire.
+	head := httptest.NewRequest(http.MethodHead, "http://s3.amazonaws.com/cfn-shared-bucket", nil)
+	head.Host = "s3.amazonaws.com"
+	hw := httptest.NewRecorder()
+	ts.srv.ServeHTTP(hw, head)
+	assert.Equal(t, http.StatusOK, hw.Code, "the stack's bucket should be a real S3 bucket")
+
+	// And the role through the IAM plugin.
+	form := url.Values{"Action": {"GetRole"}, "RoleName": {"cfn-shared-role"}, "Version": {"2010-05-08"}}
+	ir := httptest.NewRequest(http.MethodPost, "http://iam.amazonaws.com/", strings.NewReader(form.Encode()))
+	ir.Host = "iam.amazonaws.com"
+	ir.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	iw := httptest.NewRecorder()
+	ts.srv.ServeHTTP(iw, ir)
+	assert.Equal(t, http.StatusOK, iw.Code, "the stack's role should be a real IAM role")
+	assert.Contains(t, iw.Body.String(), "cfn-shared-role")
+}
+
+// TestCFNPlugin_WireStackVisibleInProcess asserts the wire and the in-process
+// StackDeployer see one set of stacks, which is the property that makes the
+// adapter an adapter.
+func TestCFNPlugin_WireStackVisibleInProcess(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "crossover",
+		"TemplateBody": cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	deployer := emulator.NewStackDeployer(ts.registry, nil, ts.state, ts.tc,
+		emulator.NewDefaultLogger(slog.LevelError, false),
+		emulator.NewCostController(emulator.CostConfig{Enabled: false}))
+	stacks, err := deployer.ListStacks(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, stacks, 1)
+	assert.Equal(t, "crossover", stacks[0].StackName)
+	assert.Equal(t, "CREATE_COMPLETE", stacks[0].Status)
+	assert.Equal(t, cfnBucketTemplate, stacks[0].TemplateBody)
+	require.Len(t, stacks[0].Resources, 1)
+	assert.Equal(t, "cfn-wire-bucket", stacks[0].Resources[0].PhysicalID)
+}
+
+// TestCFNPlugin_DescribeStacks covers the listing and the not-found code.
+func TestCFNPlugin_DescribeStacks(t *testing.T) {
+	ts := newCFNTestServer(t)
+	for _, name := range []string{"alpha", "beta"} {
+		code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+			"StackName":    name,
+			"TemplateBody": cfnEmptyTemplate,
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+	}
+
+	t.Run("no name lists all", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "DescribeStacks", nil)
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+		var doc struct {
+			Names []string `xml:"DescribeStacksResult>Stacks>member>StackName"`
+		}
+		require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+		assert.ElementsMatch(t, []string{"alpha", "beta"}, doc.Names)
+	})
+
+	t.Run("unknown name is a ValidationError", func(t *testing.T) {
+		// DescribeStacks documents this explicitly: "If the stack does not exist,
+		// a ValidationError is returned."
+		code, body := cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "absent"})
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	})
+
+	t.Run("missing StackName on CreateStack", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "CreateStack", map[string]string{"TemplateBody": cfnEmptyTemplate})
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "MissingParameter", cfnErrorCode(t, body))
+	})
+}
+
+// TestCFNPlugin_CreateStack_DuplicateName pins the documented duplicate-name
+// code, which is AlreadyExists at 400 — not AlreadyExistsException.
+func TestCFNPlugin_CreateStack_DuplicateName(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "twice",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "twice",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "AlreadyExists", cfnErrorCode(t, body))
+}
+
+// TestCFNPlugin_CreateStack_UnparseableTemplate asserts a template that will not
+// parse is a ValidationError rather than an InternalFailure.
+func TestCFNPlugin_CreateStack_UnparseableTemplate(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "broken",
+		"TemplateBody": `{"Resources": [this is not a template`,
+	})
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+}
+
+// TestCFNPlugin_CreateStack_TemplateURLRefused asserts TemplateURL is refused
+// rather than silently ignored: fetching a template is a network read substrate
+// does not perform, and a caller who passed a URL got no resources at all.
+func TestCFNPlugin_CreateStack_TemplateURLRefused(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":   "remote",
+		"TemplateURL": "https://example.invalid/template.json",
+	})
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	assert.Contains(t, body, "TemplateBody")
+}
+
+// TestCFNPlugin_ResourceFailureReported asserts a resource that failed to deploy
+// is reported CREATE_FAILED with its reason, not CREATE_COMPLETE.
+//
+// The path is reachable because every deploy helper records the routing error on
+// DeployedResource.Error and then returns a nil error, so a stack completes with
+// a broken resource inside it. A stack reporting every resource complete
+// regardless is the failure mode this pins: a consumer asserting on a resource's
+// status would be told a queue exists that does not.
+func TestCFNPlugin_ResourceFailureReported(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	// This registry holds S3, IAM and CloudFormation but not SQS, so the queue's
+	// dispatch comes back ServiceNotAvailable while the bucket beside it deploys.
+	require.NotContains(t, ts.registry.Names(), "sqs")
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName": "half-broken",
+		"TemplateBody": `{"Resources":{` +
+			`"Good":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-good-bucket"}},` +
+			`"Bad":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cfn-doomed-queue"}}}}`,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStackResources", map[string]string{"StackName": "half-broken"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	var doc struct {
+		Resources []struct {
+			LogicalID string `xml:"LogicalResourceId"`
+			Status    string `xml:"ResourceStatus"`
+			Reason    string `xml:"ResourceStatusReason"`
+		} `xml:"DescribeStackResourcesResult>StackResources>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+	require.Len(t, doc.Resources, 2)
+
+	byLogical := map[string]struct {
+		LogicalID string `xml:"LogicalResourceId"`
+		Status    string `xml:"ResourceStatus"`
+		Reason    string `xml:"ResourceStatusReason"`
+	}{}
+	for _, r := range doc.Resources {
+		byLogical[r.LogicalID] = r
+	}
+	assert.Equal(t, "CREATE_FAILED", byLogical["Bad"].Status)
+	assert.NotEmpty(t, byLogical["Bad"].Reason, "a failure must carry its reason")
+	assert.Equal(t, "CREATE_COMPLETE", byLogical["Good"].Status)
+	assert.Empty(t, byLogical["Good"].Reason)
+}
+
+// TestCFNPlugin_GetTemplate_ChangeSet asserts GetTemplate reads the change set's
+// template when ChangeSetName is supplied and the stack's otherwise, so the two
+// arms cannot be confused for one another.
+func TestCFNPlugin_GetTemplate_ChangeSet(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "two-templates",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	code, body = cfnAction(t, ts, "CreateChangeSet", map[string]string{
+		"StackName":     "two-templates",
+		"ChangeSetName": "pending",
+		"TemplateBody":  cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	var doc struct {
+		TemplateBody string `xml:"GetTemplateResult>TemplateBody"`
+	}
+
+	// The stack still reports the deployed template, not the pending one.
+	code, body = cfnAction(t, ts, "GetTemplate", map[string]string{"StackName": "two-templates"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+	assert.Equal(t, cfnEmptyTemplate, doc.TemplateBody)
+
+	// Naming the change set reports the pending template.
+	code, body = cfnAction(t, ts, "GetTemplate", map[string]string{
+		"StackName":     "two-templates",
+		"ChangeSetName": "pending",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+	assert.Equal(t, cfnBucketTemplate, doc.TemplateBody)
+}
+
+// TestCFNPlugin_Parameters_ManyMembers asserts the Parameters.member.N walk does
+// not stop after the first entry. A one-parameter test passes under an off-by-one
+// that drops every later member, which is why this uses four.
+func TestCFNPlugin_Parameters_ManyMembers(t *testing.T) {
+	ts := newCFNTestServer(t)
+	tmpl := `{"Parameters":{` +
+		`"A":{"Type":"String","Default":"da"},"B":{"Type":"String","Default":"db"},` +
+		`"C":{"Type":"String","Default":"dc"},"D":{"Type":"String","Default":"dd"}},` +
+		`"Resources":{"Data":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":{"Fn::Sub":"cfn-${A}-${B}-${C}-${D}"}}}}}`
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":                          "four-params",
+		"TemplateBody":                       tmpl,
+		"Parameters.member.1.ParameterKey":   "A",
+		"Parameters.member.1.ParameterValue": "sa",
+		"Parameters.member.2.ParameterKey":   "B",
+		"Parameters.member.2.ParameterValue": "sb",
+		"Parameters.member.3.ParameterKey":   "C",
+		"Parameters.member.3.ParameterValue": "sc",
+		"Parameters.member.4.ParameterKey":   "D",
+		"Parameters.member.4.ParameterValue": "sd",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	head := httptest.NewRequest(http.MethodHead, "http://s3.amazonaws.com/cfn-sa-sb-sc-sd", nil)
+	head.Host = "s3.amazonaws.com"
+	hw := httptest.NewRecorder()
+	ts.srv.ServeHTTP(hw, head)
+	assert.Equal(t, http.StatusOK, hw.Code, "every supplied parameter should have been read")
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "four-params"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	var doc struct {
+		Params []struct {
+			Key   string `xml:"ParameterKey"`
+			Value string `xml:"ParameterValue"`
+		} `xml:"DescribeStacksResult>Stacks>member>Parameters>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+	require.Len(t, doc.Params, 4)
+	assert.Equal(t, "sd", doc.Params[3].Value)
+}
+
+// TestCFNPlugin_ListStacks covers the summary shape and the status filter.
+func TestCFNPlugin_ListStacks(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "listed",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "ListStacks", nil)
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	var doc struct {
+		Summaries []struct {
+			StackName    string `xml:"StackName"`
+			StackStatus  string `xml:"StackStatus"`
+			StackID      string `xml:"StackId"`
+			CreationTime string `xml:"CreationTime"`
+		} `xml:"ListStacksResult>StackSummaries>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+	require.Len(t, doc.Summaries, 1)
+	assert.Equal(t, "listed", doc.Summaries[0].StackName)
+	assert.Equal(t, "CREATE_COMPLETE", doc.Summaries[0].StackStatus)
+	assert.Equal(t, "2026-01-01T12:00:00Z", doc.Summaries[0].CreationTime)
+
+	t.Run("status filter selects", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "ListStacks", map[string]string{
+			"StackStatusFilter.member.1": "CREATE_COMPLETE",
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		assert.Contains(t, body, "<StackName>listed</StackName>")
+	})
+
+	t.Run("status filter excludes", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "ListStacks", map[string]string{
+			"StackStatusFilter.member.1": "DELETE_COMPLETE",
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		assert.NotContains(t, body, "<StackName>listed</StackName>")
+	})
+}
+
+// TestCFNPlugin_GetTemplate asserts the body round-trips byte-for-byte.
+func TestCFNPlugin_GetTemplate(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "templated",
+		"TemplateBody": cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "GetTemplate", map[string]string{"StackName": "templated"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	var doc struct {
+		TemplateBody string   `xml:"GetTemplateResult>TemplateBody"`
+		Stages       []string `xml:"GetTemplateResult>StagesAvailable>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+	assert.Equal(t, cfnBucketTemplate, doc.TemplateBody)
+	assert.Equal(t, []string{"Original"}, doc.Stages)
+
+	t.Run("unknown stack", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "GetTemplate", map[string]string{"StackName": "absent"})
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	})
+}
+
+// TestCFNPlugin_DeleteStack asserts the stack stops being reported, and that
+// deleting an absent stack succeeds — DeleteStack documents no not-found error.
+func TestCFNPlugin_DeleteStack(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "doomed",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "doomed"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "doomed"})
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+
+	code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "never-existed"})
+	assert.Equal(t, http.StatusOK, code, "body was %s", body)
+}
+
+// TestCFNPlugin_UpdateStack asserts the status moves to UPDATE_COMPLETE and that
+// the new template's resources are deployed.
+func TestCFNPlugin_UpdateStack(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "evolving",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "UpdateStack", map[string]string{
+		"StackName":    "evolving",
+		"TemplateBody": cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "evolving"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<StackStatus>UPDATE_COMPLETE</StackStatus>")
+
+	head := httptest.NewRequest(http.MethodHead, "http://s3.amazonaws.com/cfn-wire-bucket", nil)
+	head.Host = "s3.amazonaws.com"
+	hw := httptest.NewRecorder()
+	ts.srv.ServeHTTP(hw, head)
+	assert.Equal(t, http.StatusOK, hw.Code)
+
+	t.Run("unknown stack", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "UpdateStack", map[string]string{
+			"StackName":    "absent",
+			"TemplateBody": cfnEmptyTemplate,
+		})
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	})
+
+	// An update carrying no template reuses the deployed one, which is what
+	// UsePreviousTemplate means: a parameter-only change must not blank the stack.
+	t.Run("no template reuses the previous one", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "UpdateStack", map[string]string{"StackName": "evolving"})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+		code, body = cfnAction(t, ts, "GetTemplate", map[string]string{"StackName": "evolving"})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		var doc struct {
+			TemplateBody string `xml:"GetTemplateResult>TemplateBody"`
+		}
+		require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+		assert.Equal(t, cfnBucketTemplate, doc.TemplateBody)
+	})
+}
+
+// TestCFNPlugin_Parameters asserts Parameters.member.N reaches template parameter
+// resolution, which is the encoding every SDK sends the parameter list in.
+func TestCFNPlugin_Parameters(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":                          "parameterized",
+		"TemplateBody":                       cfnParamTemplate,
+		"Parameters.member.1.ParameterKey":   "BucketSuffix",
+		"Parameters.member.1.ParameterValue": "supplied",
+		"Parameters.member.2.ParameterKey":   "Unused",
+		"Parameters.member.2.ParameterValue": "ignored",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	// The supplied value, not the template default, decided the bucket name.
+	head := httptest.NewRequest(http.MethodHead, "http://s3.amazonaws.com/cfn-param-supplied", nil)
+	head.Host = "s3.amazonaws.com"
+	hw := httptest.NewRecorder()
+	ts.srv.ServeHTTP(hw, head)
+	require.Equal(t, http.StatusOK, hw.Code, "the parameter should have reached Fn::Sub")
+
+	// And DescribeStacks reports the resolved parameters.
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "parameterized"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<ParameterKey>BucketSuffix</ParameterKey>")
+	assert.Contains(t, body, "<ParameterValue>supplied</ParameterValue>")
+}
+
+// TestCFNPlugin_Parameters_UsePreviousValue asserts a member marked
+// UsePreviousValue keeps the deployed value instead of overwriting it with the
+// empty string the request carries.
+func TestCFNPlugin_Parameters_UsePreviousValue(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":                          "previous",
+		"TemplateBody":                       cfnParamTemplate,
+		"Parameters.member.1.ParameterKey":   "BucketSuffix",
+		"Parameters.member.1.ParameterValue": "original",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "UpdateStack", map[string]string{
+		"StackName":                            "previous",
+		"TemplateBody":                         cfnParamTemplate,
+		"Parameters.member.1.ParameterKey":     "BucketSuffix",
+		"Parameters.member.1.UsePreviousValue": "true",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "previous"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<ParameterValue>original</ParameterValue>")
+}
+
+// TestCFNPlugin_ChangeSetFlow walks the change-set family over the wire and
+// asserts the change is visible only after the set executes.
+func TestCFNPlugin_ChangeSetFlow(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "staged",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "CreateChangeSet", map[string]string{
+		"StackName":     "staged",
+		"ChangeSetName": "add-bucket",
+		"TemplateBody":  cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	var created struct {
+		ID      string `xml:"CreateChangeSetResult>Id"`
+		StackID string `xml:"CreateChangeSetResult>StackId"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &created))
+	assert.Contains(t, created.ID, ":changeSet/add-bucket/")
+
+	// The change set describes the pending Add without having applied it.
+	code, body = cfnAction(t, ts, "DescribeChangeSet", map[string]string{
+		"StackName":     "staged",
+		"ChangeSetName": "add-bucket",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	var describe struct {
+		Status          string `xml:"DescribeChangeSetResult>Status"`
+		ExecutionStatus string `xml:"DescribeChangeSetResult>ExecutionStatus"`
+		Changes         []struct {
+			Type      string `xml:"Type"`
+			Action    string `xml:"ResourceChange>Action"`
+			LogicalID string `xml:"ResourceChange>LogicalResourceId"`
+			Type2     string `xml:"ResourceChange>ResourceType"`
+		} `xml:"DescribeChangeSetResult>Changes>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &describe))
+	assert.Equal(t, "CREATE_COMPLETE", describe.Status)
+	assert.Equal(t, "AVAILABLE", describe.ExecutionStatus)
+	require.Len(t, describe.Changes, 1)
+	assert.Equal(t, "Resource", describe.Changes[0].Type)
+	assert.Equal(t, "Add", describe.Changes[0].Action)
+	assert.Equal(t, "Data", describe.Changes[0].LogicalID)
+	assert.Equal(t, "AWS::S3::Bucket", describe.Changes[0].Type2)
+
+	head := httptest.NewRequest(http.MethodHead, "http://s3.amazonaws.com/cfn-wire-bucket", nil)
+	head.Host = "s3.amazonaws.com"
+	hw := httptest.NewRecorder()
+	ts.srv.ServeHTTP(hw, head)
+	require.Equal(t, http.StatusNotFound, hw.Code, "a described change set must not have been applied")
+
+	// ListChangeSets reports it while it is pending.
+	code, body = cfnAction(t, ts, "ListChangeSets", map[string]string{"StackName": "staged"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<ChangeSetName>add-bucket</ChangeSetName>")
+
+	// Executing it applies the change and consumes the set.
+	code, body = cfnAction(t, ts, "ExecuteChangeSet", map[string]string{
+		"StackName":     "staged",
+		"ChangeSetName": "add-bucket",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	hw = httptest.NewRecorder()
+	head = httptest.NewRequest(http.MethodHead, "http://s3.amazonaws.com/cfn-wire-bucket", nil)
+	head.Host = "s3.amazonaws.com"
+	ts.srv.ServeHTTP(hw, head)
+	assert.Equal(t, http.StatusOK, hw.Code, "the executed change should be visible")
+
+	code, body = cfnAction(t, ts, "DescribeChangeSet", map[string]string{
+		"StackName":     "staged",
+		"ChangeSetName": "add-bucket",
+	})
+	assert.Equal(t, http.StatusNotFound, code)
+	assert.Equal(t, "ChangeSetNotFound", cfnErrorCode(t, body), "body was %s", body)
+}
+
+// TestCFNPlugin_ChangeSetErrors covers the codes and their statuses. The
+// change-set family reports 404 for a missing set, unlike the stack family's 400.
+func TestCFNPlugin_ChangeSetErrors(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "cs-errors",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	tests := []struct {
+		name       string
+		action     string
+		params     map[string]string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "CreateChangeSet without ChangeSetName",
+			action:     "CreateChangeSet",
+			params:     map[string]string{"StackName": "cs-errors", "TemplateBody": cfnEmptyTemplate},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "MissingParameter",
+		},
+		{
+			name:       "CreateChangeSet on an unknown stack",
+			action:     "CreateChangeSet",
+			params:     map[string]string{"StackName": "absent", "ChangeSetName": "cs", "TemplateBody": cfnEmptyTemplate},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "ValidationError",
+		},
+		{
+			name:       "CreateChangeSet with ChangeSetType CREATE",
+			action:     "CreateChangeSet",
+			params:     map[string]string{"StackName": "cs-errors", "ChangeSetName": "cs", "TemplateBody": cfnEmptyTemplate, "ChangeSetType": "CREATE"},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "ValidationError",
+		},
+		{
+			name:       "DescribeChangeSet on an unknown set",
+			action:     "DescribeChangeSet",
+			params:     map[string]string{"StackName": "cs-errors", "ChangeSetName": "absent"},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "ChangeSetNotFound",
+		},
+		{
+			name:       "ExecuteChangeSet on an unknown set",
+			action:     "ExecuteChangeSet",
+			params:     map[string]string{"StackName": "cs-errors", "ChangeSetName": "absent"},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "ChangeSetNotFound",
+		},
+		{
+			name:       "ListChangeSets requires StackName",
+			action:     "ListChangeSets",
+			params:     nil,
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "MissingParameter",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, body := cfnAction(t, ts, tc.action, tc.params)
+			assert.Equal(t, tc.wantStatus, code, "body was %s", body)
+			assert.Equal(t, tc.wantCode, cfnErrorCode(t, body))
+		})
+	}
+}
+
+// TestCFNPlugin_DeleteChangeSet asserts a set can be discarded unexecuted, and
+// that deleting an absent one succeeds — DeleteChangeSet documents no
+// not-found error.
+func TestCFNPlugin_DeleteChangeSet(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "discard",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	code, body = cfnAction(t, ts, "CreateChangeSet", map[string]string{
+		"StackName":     "discard",
+		"ChangeSetName": "unwanted",
+		"TemplateBody":  cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DeleteChangeSet", map[string]string{
+		"StackName":     "discard",
+		"ChangeSetName": "unwanted",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "ListChangeSets", map[string]string{"StackName": "discard"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.NotContains(t, body, "unwanted")
+
+	code, body = cfnAction(t, ts, "DeleteChangeSet", map[string]string{
+		"StackName":     "discard",
+		"ChangeSetName": "never-existed",
+	})
+	assert.Equal(t, http.StatusOK, code, "body was %s", body)
+}
+
+// TestCFNPlugin_ChangeSetARNAccepted asserts a change-set ARN works where a bare
+// name does, and with no StackName — the form DescribeChangeSet documents and
+// the one the CLI echoes back from CreateChangeSet.
+func TestCFNPlugin_ChangeSetARNAccepted(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "arn-addressed",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	code, body = cfnAction(t, ts, "CreateChangeSet", map[string]string{
+		"StackName":     "arn-addressed",
+		"ChangeSetName": "by-arn",
+		"TemplateBody":  cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	var created struct {
+		ID string `xml:"CreateChangeSetResult>Id"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &created))
+	require.NotEmpty(t, created.ID)
+
+	code, body = cfnAction(t, ts, "DescribeChangeSet", map[string]string{"ChangeSetName": created.ID})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<ChangeSetName>by-arn</ChangeSetName>")
+	assert.Contains(t, body, "<StackName>arn-addressed</StackName>")
+}
+
+// TestCFNPlugin_DriftFlow walks the drift family over the wire. A resource
+// deleted outside CloudFormation is the drift substrate models.
+func TestCFNPlugin_DriftFlow(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "drifty",
+		"TemplateBody": cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	t.Run("in sync before any change", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "DetectStackDrift", map[string]string{"StackName": "drifty"})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		var doc struct {
+			ID string `xml:"DetectStackDriftResult>StackDriftDetectionId"`
+		}
+		require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+		require.NotEmpty(t, doc.ID)
+
+		code, body = cfnAction(t, ts, "DescribeStackDriftDetectionStatus",
+			map[string]string{"StackDriftDetectionId": doc.ID})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		assert.Contains(t, body, "<DetectionStatus>DETECTION_COMPLETE</DetectionStatus>")
+		assert.Contains(t, body, "<StackDriftStatus>IN_SYNC</StackDriftStatus>")
+		assert.Contains(t, body, "<DriftedStackResourceCount>0</DriftedStackResourceCount>")
+	})
+
+	t.Run("deleting the bucket outside CFN drifts the stack", func(t *testing.T) {
+		del := httptest.NewRequest(http.MethodDelete, "http://s3.amazonaws.com/cfn-wire-bucket", nil)
+		del.Host = "s3.amazonaws.com"
+		dw := httptest.NewRecorder()
+		ts.srv.ServeHTTP(dw, del)
+		require.Equal(t, http.StatusNoContent, dw.Code, "body was %s", dw.Body.String())
+
+		code, body := cfnAction(t, ts, "DescribeStackResourceDrifts", map[string]string{"StackName": "drifty"})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		assert.Contains(t, body, "<StackResourceDriftStatus>DELETED</StackResourceDriftStatus>")
+		assert.Contains(t, body, "<LogicalResourceId>Data</LogicalResourceId>")
+
+		code, body = cfnAction(t, ts, "DescribeStackResourceDrifts", map[string]string{
+			"StackName": "drifty",
+			"StackResourceDriftStatusFilters.member.1": "IN_SYNC",
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		assert.NotContains(t, body, "<LogicalResourceId>Data</LogicalResourceId>",
+			"the filter should exclude the DELETED entry")
+	})
+
+	t.Run("drift errors", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "DetectStackDrift", map[string]string{"StackName": "absent"})
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+
+		code, body = cfnAction(t, ts, "DescribeStackResourceDrifts", nil)
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "MissingParameter", cfnErrorCode(t, body))
+
+		code, body = cfnAction(t, ts, "DescribeStackDriftDetectionStatus",
+			map[string]string{"StackDriftDetectionId": "req-absent"})
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	})
+}
+
+// TestCFNPlugin_DescribeStackResources covers the two lookup keys and the
+// documented refusal to accept both.
+func TestCFNPlugin_DescribeStackResources(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "resourceful",
+		"TemplateBody": cfnBucketRoleTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	t.Run("by logical ID", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "DescribeStackResources", map[string]string{
+			"StackName":         "resourceful",
+			"LogicalResourceId": "Runner",
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		assert.Contains(t, body, "cfn-shared-role")
+		assert.NotContains(t, body, "cfn-shared-bucket")
+	})
+
+	t.Run("by physical ID with no stack name", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "DescribeStackResources", map[string]string{
+			"PhysicalResourceId": "cfn-shared-bucket",
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		assert.Contains(t, body, "<LogicalResourceId>Data</LogicalResourceId>")
+		assert.NotContains(t, body, "cfn-shared-role")
+	})
+
+	t.Run("both keys is a ValidationError", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "DescribeStackResources", map[string]string{
+			"StackName":          "resourceful",
+			"PhysicalResourceId": "cfn-shared-bucket",
+		})
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	})
+
+	t.Run("neither key is a MissingParameter", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "DescribeStackResources", nil)
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "MissingParameter", cfnErrorCode(t, body))
+	})
+}
+
+// TestCFNPlugin_DescribeStackEvents pins the scope decision deliberately rather
+// than leaving it incidental.
+//
+// CFNStackState carries one Status string; there is no per-resource event model,
+// so a plausible CREATE_IN_PROGRESS/CREATE_COMPLETE sequence would be invented
+// observations. A caller gets a refusal they can see instead. If someone later
+// adds a real event model, this test is the one that must be changed knowingly.
+func TestCFNPlugin_DescribeStackEvents(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "eventful",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStackEvents", map[string]string{"StackName": "eventful"})
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "UnsupportedOperation", cfnErrorCode(t, body))
+}
+
+// TestCFNPlugin_UnknownAction asserts an unmodelled action is InvalidAction, not
+// a panic or a silent success.
+func TestCFNPlugin_UnknownAction(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStackSet", map[string]string{"StackSetName": "s"})
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "InvalidAction", cfnErrorCode(t, body))
+}
+
+// TestCFNPlugin_ErrorProtocolIsQueryXML asserts an error carries the code where
+// a Query-protocol SDK reads it. CloudFormation was absent from
+// serviceErrorProtocols, which would have left the shape to Content-Type
+// sniffing on a form-encoded request.
+func TestCFNPlugin_ErrorProtocolIsQueryXML(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "absent"})
+	require.Equal(t, http.StatusBadRequest, code)
+
+	var doc struct {
+		XMLName xml.Name `xml:"ErrorResponse"`
+		Type    string   `xml:"Error>Type"`
+		Code    string   `xml:"Error>Code"`
+		Message string   `xml:"Error>Message"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc), "body was %s", body)
+	assert.Equal(t, "ErrorResponse", doc.XMLName.Local)
+	assert.Equal(t, "Sender", doc.Type)
+	assert.Equal(t, "ValidationError", doc.Code)
+	assert.Contains(t, doc.Message, "absent")
+}
+
+// TestCFNPlugin_RegisteredByDefault asserts the plugin is in the default set, so
+// a consumer running `substrate server` reaches it without extra wiring — the
+// configuration #483 actually reported against.
+func TestCFNPlugin_RegisteredByDefault(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+	assert.Contains(t, ts.Registry().Names(), "cloudformation")
+}
+
+// TestCFNPlugin_Initialize_RequiresRegistry asserts the one hard dependency is
+// checked rather than deferred to a nil dereference at request time.
+func TestCFNPlugin_Initialize_RequiresRegistry(t *testing.T) {
+	p := &emulator.CloudFormationPlugin{}
+	err := p.Initialize(context.Background(), emulator.PluginConfig{
+		State:  emulator.NewMemoryStateManager(),
+		Logger: emulator.NewDefaultLogger(slog.LevelError, false),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registry")
+}
+
+// TestCFNPlugin_Initialize_NilStoreAndCosts asserts a stack deploys when neither
+// an EventStore nor a CostController is supplied.
+//
+// This is not hypothetical: RegisterDefaultPlugins documents store as optional
+// and debug_ui.go's state-reset path passes nil, while no caller passes a
+// CostController at all. StackDeployer.dispatch dereferences both on every
+// resource it deploys, so Initialize substitutes disabled instances rather than
+// storing nil.
+func TestCFNPlugin_Initialize_NilStoreAndCosts(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	registry := emulator.NewPluginRegistry()
+
+	s3p := &emulator.S3Plugin{}
+	require.NoError(t, s3p.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"filesystem":      afero.NewMemMapFs(),
+		},
+	}))
+	registry.Register(s3p)
+
+	p := &emulator.CloudFormationPlugin{}
+	require.NoError(t, p.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"registry":        registry,
+			// event_store and cost_controller deliberately absent.
+		},
+	}))
+	registry.Register(p)
+
+	cfg := emulator.DefaultConfig()
+	srv := emulator.NewServer(*cfg, registry,
+		emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false}), state, tc, logger)
+
+	form := url.Values{
+		"Action":       {"CreateStack"},
+		"StackName":    {"nil-deps"},
+		"TemplateBody": {cfnBucketTemplate},
+	}
+	r := httptest.NewRequest(http.MethodPost, "http://cloudformation.us-east-1.amazonaws.com/",
+		strings.NewReader(form.Encode()))
+	r.Host = "cloudformation.us-east-1.amazonaws.com"
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "body was %s", w.Body.String())
+}
+
+// TestCFNPlugin_StackIDIsStable asserts the stack ARN does not change between
+// calls. A UUID from a clock or a PRNG would make a recorded response
+// unreproducible on replay, which is the property substrate exists to hold.
+func TestCFNPlugin_StackIDIsStable(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "stable",
+		"TemplateBody": cfnEmptyTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	var created struct {
+		StackID string `xml:"CreateStackResult>StackId"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &created))
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "stable"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	var described struct {
+		StackID string `xml:"DescribeStacksResult>Stacks>member>StackId"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &described))
+
+	assert.Equal(t, created.StackID, described.StackID)
+
+	code, body = cfnAction(t, ts, "ListStacks", nil)
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, created.StackID)
+}
+
+// TestCFNPlugin_Outputs asserts resolved template outputs reach DescribeStacks,
+// which is how a consumer reads a stack's exported values.
+func TestCFNPlugin_Outputs(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "outputting",
+		"TemplateBody": cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "outputting"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	var doc struct {
+		Outputs []struct {
+			Key   string `xml:"OutputKey"`
+			Value string `xml:"OutputValue"`
+		} `xml:"DescribeStacksResult>Stacks>member>Outputs>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+	require.Len(t, doc.Outputs, 1)
+	assert.Equal(t, "BucketName", doc.Outputs[0].Key)
+	assert.Equal(t, "cfn-wire-bucket", doc.Outputs[0].Value)
+}

--- a/emulator/error_protocol.go
+++ b/emulator/error_protocol.go
@@ -50,6 +50,7 @@ const (
 //     answers successes in query XML, so its errors match that.
 var serviceErrorProtocols = map[string]awsErrorProtocol{
 	// Query, ec2 and REST-XML.
+	"cloudformation":       errProtoQueryXML,
 	"cloudfront":           errProtoQueryXML,
 	"ec2":                  errProtoQueryXML,
 	"elasticache":          errProtoQueryXML,

--- a/emulator/error_protocol_test.go
+++ b/emulator/error_protocol_test.go
@@ -222,6 +222,10 @@ func TestErrorProtocolFor_Classification(t *testing.T) {
 	}{
 		{"s3 is xml", "s3", "", emulator.ErrProtoQueryXMLForTest},
 		{"iam is xml", "iam", "application/x-amz-json-1.1", emulator.ErrProtoQueryXMLForTest},
+		// CloudFormation is a Query service whose errors are XML. The unknown-service
+		// fallback below happens to answer XML for a form-encoded body too, so only a
+		// direct assertion pins the table entry rather than the fallback.
+		{"cloudformation is xml", "cloudformation", "application/x-amz-json-1.1", emulator.ErrProtoQueryXMLForTest},
 		{"ssm is json rpc", "ssm", "application/x-amz-json-1.1", emulator.ErrProtoJSONRPCForTest},
 		{"dynamodb is json rpc", "dynamodb", "application/x-amz-json-1.0", emulator.ErrProtoJSONRPCForTest},
 		{"lambda is rest json", "lambda", "application/json", emulator.ErrProtoRESTJSONForTest},

--- a/emulator/plugins.go
+++ b/emulator/plugins.go
@@ -122,6 +122,28 @@ func RegisterDefaultPlugins(
 	}
 	registry.Register(s3Plugin)
 
+	// The CloudFormation plugin adapts the StackDeployer that BettyClient already
+	// drives in process, so it needs the registry to deploy each template resource
+	// into. It is registered after S3/IAM/Lambda only for readability: the registry
+	// is captured as a pointer and read at request time, so ordering does not
+	// affect which resource types a template can create.
+	cfnPlugin := &CloudFormationPlugin{}
+	cfnOpts := map[string]any{
+		"time_controller": tc,
+		"registry":        registry,
+	}
+	if store != nil {
+		cfnOpts["event_store"] = store
+	}
+	if err := cfnPlugin.Initialize(ctx, PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: cfnOpts,
+	}); err != nil {
+		return fmt.Errorf("initialize cloudformation plugin: %w", err)
+	}
+	registry.Register(cfnPlugin)
+
 	elbPlugin := &ELBPlugin{}
 	if err := elbPlugin.Initialize(ctx, PluginConfig{
 		State:   state,


### PR DESCRIPTION
## Summary

CloudFormation was fully modelled in process — `StackDeployer` exports 13 methods and 113 resource types deploy through the plugin registry — but **no plugin served the `cloudformation` service**, so every wire caller got `ServiceNotAvailable`/501 (`types.go:264-276`). `README.md` and `docs/index.md` advertise CloudFormation as a first-class target, which is what made this read as a bug from outside rather than a boundary.

This registers a `CloudFormationPlugin`: a deliberately thin Query-protocol adapter over the existing `StackDeployer`. **No CFN logic moves into the plugin** — every handler translates params in and XML out.

The reporter offered two resolutions and would have accepted either (register the plugin, or document CloudFormation as out of scope over the wire). **Decision: register the plugin**, because the modelling was already done and option 2 meant visibly walking back an advertised capability.

## Stacks share state with every other plugin

The deployer is constructed over the **same registry and state** the server already holds, so a wire-created stack creates real resources elsewhere in the emulator rather than in a private world:

```
$ aws cloudformation create-stack --stack-name probe \
    --template-body '{"Resources":{"B":{"Type":"AWS::S3::Bucket",
                      "Properties":{"BucketName":"probe-e2e-bucket"}}}}'
{ "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/probe/a5e7a132-..." }

$ aws cloudformation describe-stacks --stack-name probe   # → CREATE_COMPLETE
$ aws s3api head-bucket --bucket probe-e2e-bucket         # → 200
```

`TestCFNPlugin_StackSharesStateWithOtherPlugins` is the assertion that pins this: a template creating a bucket and a role, then reached through the S3 and IAM plugins over the wire.

## Operations

| Family | Operations |
|---|---|
| Stacks | `CreateStack`, `UpdateStack`, `DeleteStack`, `DescribeStacks`, `ListStacks`, `GetTemplate`, `DescribeStackResources` |
| Change sets | `CreateChangeSet`, `DescribeChangeSet`, `ExecuteChangeSet`, `ListChangeSets`, `DeleteChangeSet` |
| Drift | `DetectStackDrift`, `DescribeStackResourceDrifts`, `DescribeStackDriftDetectionStatus` |

`Deploy` derives the stack name from its stream ID, so the plugin passes the caller's `StackName` as the stream ID — `BettyClient.Deploy` uses `deploy-<unixnano>`, which would make a wire-created stack undiscoverable by name. The comment says why.

## DescribeStackEvents is refused, not answered

`CFNStackState` carries a single `Status` string, hardcoded `CREATE_COMPLETE`. Synthesizing a per-resource `CREATE_IN_PROGRESS → CREATE_COMPLETE` sequence would be **inventing observations**, which is the opposite of this repo's provenance discipline. It returns `UnsupportedOperation`/400 with a message naming the reason, is documented in `docs/services.md`, and is asserted deliberately so the scope decision is pinned rather than incidental. Filed as #501.

#502 covers the other deferral: `StackDeployer` reports failures as `fmt.Errorf` strings, so the adapter matches on prefixes to map AWS codes.

## Tests — 30 in a new `emulator/cloudformation_plugin_test.go`

The test server registers **S3 + IAM + CloudFormation in one registry**, since a CFN-only registry could not distinguish a shared world from a private one.

- **The #483 gate**: the reporter's exact reproduction → 200, not `ServiceNotAvailable`, with a correct account in the stack ARN.
- An unregistered service still gets 501, so the fix is not a blanket router change.
- Every family end to end over the wire, including the change-set flow and a drift run that deletes the bucket **through S3** and observes `DELETED`.
- A resource that fails to deploy reports `CREATE_FAILED` with its reason while its sibling reports `CREATE_COMPLETE`.
- `DescribeStackEvents` → `UnsupportedOperation`.
- Stack and change-set ARNs are deterministic (sha256, not the clock) — a replay must produce the same ARN.
- The in-process `BettyClient` path is untouched: `betty_cfn_test.go` passes unchanged, and a wire-created stack is visible to an in-process `ListStacks`.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (**0 issues**), `make test` (race), `make docs-reference docs-reference-check docs-versions` (64 → 65 plugins), `npm --prefix docs run build`, `go test -C test/e2e ./...` — all pass from the repo root.

**Mutation-tested 32/32.** Mutations covered not registering the plugin, registering under an unroutable name, handing the deployer a fresh registry or its own state (the shared-state property), forwarding a nil event store or cost controller (`dispatch` dereferences both), using BettyClient's synthetic stream ID, each error code and status, the missing `serviceErrorProtocols` entry, the `Parameters.member.N` walk, clock-derived ARNs, both status filters, and reporting a failed resource as complete. Three mutations initially reported a wrong result for harness reasons (a non-unique anchor hitting `updateStack` instead of `getTemplate`, an anchor that did not match post-gofmt text, and a mutant that did not compile) and were re-authored before being trusted.

End-to-end verified against a running `substrate server` with the real AWS CLI — every response above was parsed by the SDK, not just asserted as XML.

Closes #483
