### PR TITLE
fix(ec2): TerminateInstances honours termination protection (#489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DescribeSpotPriceHistory`'s `InstanceType.N` is a filter too, per its reference,
   so an unknown type there is an empty history.
 
+- **`TerminateInstances` now honours termination protection** (#489). #473 made
+  `disableApiTermination` observable but nothing acted on it, which is the sharpest
+  case of this tracker's recurring shape: a consumer's test asserting "my teardown
+  does not destroy the protected instance" passed against a code path that ignored
+  protection entirely, so the assertion *could not fail*. A protected instance is now
+  refused with `OperationNotPermitted`, HTTP 400, and stays `running`. Clearing
+  protection with `ModifyInstanceAttribute` and terminating again succeeds, which is
+  the sequence a teardown actually performs.
+
+  **A request naming both protected and unprotected instances fails per Availability
+  Zone, not per request and not per instance.** This is the behaviour a reader will
+  guess wrong in one of two directions, so it is quoted: "The specified instances that
+  are in the same Availability Zone as the protected instance are not terminated. The
+  specified instances that are in different Availability Zones, where no other
+  specified instances are protected, are successfully terminated." So an *unprotected*
+  instance sharing a zone with a protected one survives, while an unprotected instance
+  in another zone is terminated — and the request reports the error **after** those
+  terminations are persisted. Refusing the whole request and terminating every
+  unprotected instance are both wrong, in opposite directions.
+
+  `DeleteFleets --terminate-instances` routes through the same handler, so a protected
+  fleet instance survives its fleet's deletion while an unprotected sibling in another
+  zone does not, and `DeleteFleets` propagates `OperationNotPermitted` rather than
+  folding it into `unsuccessfulFleetDeletionSet` — `DeleteFleetError`'s documented
+  codes are exactly `fleetIdDoesNotExist`, `fleetIdMalformed`,
+  `fleetNotInDeletableState` and `unexpectedError`, so folding it in would mean
+  answering `unexpectedError` and losing the code a caller acts on.
+
+  Provenance is split. The **code** is documented: EC2's client-error table lists
+  `OperationNotPermitted` and names this case first among its examples, "you might be
+  trying to terminate an instance that has termination protection enabled". The
+  **message text is substrate's own** — #489 supplied a remembered console wording
+  that no capture corroborates, so per `docs/fidelity.md` it is not dressed up as
+  observed. Dispatch on the code.
+
+  Unchanged and still divergent: a terminated instance reports code `48` `terminated`
+  immediately, where real EC2 reports code `32` `shutting-down` first. That is
+  pre-existing, unrelated to protection, and tracked separately.
+
 ### Added
+- **EC2 instances now carry and report an Availability Zone** (#489), which is what
+  makes the zone-scoped rule above observable rather than merely internally
+  consistent. It resolves at launch from `Placement.AvailabilityZone`, else the named
+  subnet's zone, else the region's first zone (`<region>a`) — matching the reference's
+  "EC2 automatically selects an Availability Zone for you" — and a fleet pool's
+  `Overrides.N.AvailabilityZone` now reaches the launch, so a fleet spread across
+  zones no longer looks single-zone. `RunInstances` and `DescribeInstances` report it
+  as `<placement><availabilityZone>`, and `DescribeInstances` accepts an
+  `availability-zone` filter (that is the reference's spelling; the placement family's
+  filter names are listed individually, so there is no `placement.availability-zone`).
+  `AvailabilityZoneId` is not modelled. An instance replayed from an event log
+  predating the field reads back with an empty zone, grouping all such instances
+  together — the conservative reading, being what a single-zone account looks like.
+
+
 - **The instance-type catalog now covers whole families** (#485), widened from 8
   types to 57. The old catalog split families mid-way — `c5.xlarge` in and `c5.large`
   out, `m5.large` in and `m5.xlarge` out — which was incidental to #234's consumer and

--- a/docs/services.md
+++ b/docs/services.md
@@ -1480,9 +1480,9 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 
 | Operation | Notes |
 |-----------|-------|
-| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); reports [`groupSet`](#security-groups-on-an-instance) |
-| DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance) |
-| TerminateInstances | [Explicit resource IDs](#explicit-resource-ids) |
+| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); reports [`groupSet`](#security-groups-on-an-instance) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
+| DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time); `availability-zone` filter |
+| TerminateInstances | [Explicit resource IDs](#explicit-resource-ids); [honours termination protection, per Availability Zone](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StartInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeInstanceStatus | [Explicit resource IDs](#explicit-resource-ids) |
@@ -1526,7 +1526,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DeleteLaunchTemplateVersions | Reports per version at HTTP 200; the default version cannot be deleted |
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS |
-| DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances |
+| DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances, [subject to termination protection](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) |
 | DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) |
 
@@ -1867,9 +1867,82 @@ just harder to notice, since it looks like extra rigor.
 an instance's user data is expressible: `UserData.Value=` on a stopped instance empties
 it, and the attribute then reads back as the empty element above.
 
-Termination protection is **recorded and reported but not acted on**: `TerminateInstances`
-still terminates a protected instance, where real EC2 refuses with `OperationNotPermitted`.
-That is tracked separately.
+#### Termination protection is honoured, one Availability Zone at a time
+
+`TerminateInstances` refuses a protected instance with `OperationNotPermitted`, HTTP
+`400`, and the instance stays `running`. The **code** is documented — EC2's client-error
+table lists `OperationNotPermitted` as "The specified operation is not allowed" and names
+this case first among its examples, "you might be trying to terminate an instance that has
+termination protection enabled" — while the **message text is substrate's own**, since no
+capture of the string AWS sends was found. It interpolates the instance ID and names the
+attribute to clear, which is what a caller acts on:
+
+```
+OperationNotPermitted: The instance 'i-0123456789abcdef0' may not be terminated. Modify
+its 'disableApiTermination' instance attribute and try again.
+```
+
+A request naming both protected and unprotected instances is where this gets
+counter-intuitive, and it is worth reading the reference's own words, because the answer is
+neither "the whole request is refused" nor "the unprotected instances are terminated":
+
+> If you terminate multiple instances across multiple Availability Zones, and one or more
+> of the specified instances are enabled for termination protection, the request fails with
+> the following results:
+>
+> - The specified instances that are in the same Availability Zone as the protected
+>   instance are not terminated.
+> - The specified instances that are in different Availability Zones, where no other
+>   specified instances are protected, are successfully terminated.
+
+Partial failure is scoped to the **Availability Zone**. So for the reference's own worked
+example — A and B unprotected in `us-east-1a`, C protected and D unprotected in
+`us-east-1b`, all four named in one request:
+
+| Instance | Zone | Protected | Outcome |
+|---|---|---|---|
+| A | `us-east-1a` | no | **terminated** |
+| B | `us-east-1a` | no | **terminated** |
+| C | `us-east-1b` | yes | still `running` |
+| D | `us-east-1b` | no | still `running` — it shares C's zone |
+
+The request itself reports `OperationNotPermitted`, naming C, **after** the terminations in
+`us-east-1a` have been persisted. An unprotected instance sharing a zone with a protected
+one survives; an unprotected instance in another zone does not.
+
+Because the grouping key is the zone, every instance carries one. It is resolved at launch
+from `Placement.AvailabilityZone`, or from the subnet's zone when the launch named only a
+`SubnetId`, or from the region's first zone (`<region>a`) when it named neither — matching
+the reference's "EC2 automatically selects an Availability Zone for you". `AvailabilityZoneId`
+is not modelled. The zone is reported by `RunInstances` and `DescribeInstances` as
+`<placement><availabilityZone>`, and `DescribeInstances` accepts an `availability-zone`
+filter, so a caller can work out in advance which of their instances a terminate would
+spare. (The filter is named `availability-zone`, not `placement.availability-zone` — the
+placement family's filter names are spelled out individually in the reference's list.)
+
+An instance unmarshalled from an **event log recorded before this field existed** reads back
+with an empty zone, which groups all such instances together. That is the conservative
+reading, being what a single-zone account looks like.
+
+A bad instance ID still fails the whole request before anything is written, per "If you
+specify multiple instances and the request fails (for example, because of a single incorrect
+instance ID), none of the instances are terminated." The protection scan runs as a second
+pre-flight pass, after every named instance resolves, so no state is written for a zone that
+is about to be refused. Terminating an already-terminated instance still succeeds; the
+operation is idempotent and the protection check does not change that.
+
+`DeleteFleets --terminate-instances` goes through the same handler, so the rule applies
+there too: a protected fleet instance **survives** its fleet's deletion, an unprotected
+sibling in another zone does not, and `DeleteFleets` propagates the `OperationNotPermitted`
+rather than folding it into `unsuccessfulFleetDeletionSet`. `DeleteFleetError`'s documented
+codes are exactly `fleetIdDoesNotExist`, `fleetIdMalformed`, `fleetNotInDeletableState` and
+`unexpectedError`, none of which covers termination protection, so folding it in would mean
+answering `unexpectedError` and losing the code the caller acts on.
+
+One divergence remains, unrelated to protection and pre-existing: substrate reports a
+terminated instance as code `48` `terminated` immediately, where real EC2 reports code `32`
+`shutting-down` first and settles to `48`. A consumer polling for `shutting-down` will never
+observe it. That is tracked separately.
 
 ### MinCount and MaxCount
 

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -482,6 +482,13 @@ func (p *EC2Plugin) launchFleetPool(
 	if pool.override.PlacementGroupName != "" {
 		params["Placement.GroupName"] = pool.override.PlacementGroupName
 	}
+	// A pool can name a zone instead of a subnet, so forward it as the launch's
+	// placement. Without this the instance would take the subnet's zone or the
+	// region default, and a fleet spread across zones would look single-zone to
+	// #489's termination-protection grouping.
+	if pool.override.AvailabilityZone != "" {
+		params["Placement.AvailabilityZone"] = pool.override.AvailabilityZone
+	}
 	// The caller's tags travel as already-parsed values rather than as re-emitted
 	// TagSpecification.N params, so the fleet-ID tag can be appended without hunting
 	// for a free index — and, more to the point, without riding the request-tag path

--- a/emulator/ec2_fleet_test.go
+++ b/emulator/ec2_fleet_test.go
@@ -1009,3 +1009,122 @@ func TestEC2_CreateFleet_FleetIDTagZeroCapacity(t *testing.T) {
 		t.Errorf("filter returned %d instances, want 0", len(desc.Instances))
 	}
 }
+
+// TestEC2_DeleteFleets_TerminationProtection asserts the decision #489 records for
+// the fleet path: a protected instance survives DeleteFleets --terminate-instances
+// exactly as it survives a direct TerminateInstances, and the fleet deletion reports
+// the failure rather than quietly leaving a fleet whose instances outlived it.
+//
+// deleteFleets synthesizes a TerminateInstances request through the same handler, so
+// protection applies for free — but "for free" is exactly the kind of behavior that
+// regresses unnoticed, and the AZ grouping makes it non-obvious: the unprotected
+// sibling in the other zone still goes away. DeleteFleets returns the error, so the
+// fleet is not marked deleted and a retry after clearing protection is clean.
+//
+// The reference gives DeleteFleetError exactly four codes — fleetIdDoesNotExist,
+// fleetIdMalformed, fleetNotInDeletableState, unexpectedError — none of which covers
+// termination protection, so folding the refusal into unsuccessfulFleetDeletionSet
+// would mean picking unexpectedError and losing the OperationNotPermitted code the
+// caller acts on. Propagating it is the more useful answer.
+func TestEC2_DeleteFleets_TerminationProtection(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "fleet-protected")
+
+	// Two pools, one per zone, so the fleet spans the grouping the rule is scoped to.
+	var fleet createFleetResp
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"LaunchTemplateConfigs.1.Overrides.1.InstanceType":                     "t3.micro",
+		"LaunchTemplateConfigs.1.Overrides.1.AvailabilityZone":                 "us-east-1a",
+		"LaunchTemplateConfigs.1.Overrides.2.InstanceType":                     "t3.small",
+		"LaunchTemplateConfigs.1.Overrides.2.AvailabilityZone":                 "us-east-1b",
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "2",
+		"TargetCapacitySpecification.DefaultTargetCapacityType":                "on-demand",
+	}, &fleet)
+
+	if len(fleet.Instances) != 2 {
+		t.Fatalf("fleetInstanceSet items = %d, want 2 (one pool per zone); %+v",
+			len(fleet.Instances), fleet.Instances)
+	}
+	var inA, inB string
+	for _, group := range fleet.Instances {
+		if len(group.InstanceIDs) != 1 {
+			t.Fatalf("pool %s launched %v, want exactly 1", group.InstanceType, group.InstanceIDs)
+		}
+		switch group.InstanceType {
+		case "t3.micro":
+			inA = group.InstanceIDs[0]
+		case "t3.small":
+			inB = group.InstanceIDs[0]
+		}
+	}
+	if inA == "" || inB == "" {
+		t.Fatalf("could not identify both pools' instances: %+v", fleet.Instances)
+	}
+
+	// The pool's AvailabilityZone override must reach the launch, or the two
+	// instances land in one zone and the assertions below pass for the wrong reason.
+	var desc struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+			AZ         string `xml:"placement>availabilityZone"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeInstances"}, &desc)
+	zones := map[string]string{}
+	for _, d := range desc.Instances {
+		zones[d.InstanceID] = d.AZ
+	}
+	if zones[inA] != "us-east-1a" || zones[inB] != "us-east-1b" {
+		t.Fatalf("pool zones did not reach the launch: %s=%q %s=%q",
+			inA, zones[inA], inB, zones[inB])
+	}
+
+	// Protect one instance the way a consumer would, after the fleet created it.
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "ModifyInstanceAttribute", "InstanceId": inA,
+		"DisableApiTermination.Value": "true",
+	}, nil)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "DeleteFleets", "FleetId.1": fleet.FleetID,
+		"TerminateInstances": "true",
+	})
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read DeleteFleets body: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close DeleteFleets body: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("DeleteFleets status = %d, want 400; body = %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "OperationNotPermitted") {
+		t.Errorf("DeleteFleets body = %s, want OperationNotPermitted", body)
+	}
+	if !strings.Contains(string(body), inA) {
+		t.Errorf("DeleteFleets body = %s, want it to name the protected instance %s", body, inA)
+	}
+
+	states := map[string]string{}
+	var after struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+			State      string `xml:"instanceState>name"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeInstances"}, &after)
+	for _, d := range after.Instances {
+		states[d.InstanceID] = d.State
+	}
+	if states[inA] != "running" {
+		t.Errorf("protected fleet instance %s state = %q, want running", inA, states[inA])
+	}
+	if states[inB] != "terminated" {
+		t.Errorf("unprotected sibling %s in another zone state = %q, want terminated",
+			inB, states[inB])
+	}
+}

--- a/emulator/ec2_instanceattribute_test.go
+++ b/emulator/ec2_instanceattribute_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -598,4 +599,372 @@ func TestEC2_InstanceAttribute_EmptyGroupSetIsStillPresent(t *testing.T) {
 
 	assert.Contains(t, string(body), "<groupSet></groupSet>",
 		"groupSet is present and empty when it is what was asked for")
+}
+
+// createSubnetInAZ creates a subnet in a named Availability Zone. The existing
+// createSubnet helper lets CreateSubnet pick the zone, which is not enough for a
+// test whose subject is the zone grouping.
+func createSubnetInAZ(t *testing.T, ts *httptest.Server, vpcID, cidr, az string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "CreateSubnet", "VpcId": vpcID,
+		"CidrBlock": cidr, "AvailabilityZone": az,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out struct {
+		Subnet struct {
+			SubnetID         string `xml:"subnetId"`
+			AvailabilityZone string `xml:"availabilityZone"`
+		} `xml:"subnet"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	require.Equal(t, az, out.Subnet.AvailabilityZone, "the subnet must hold the zone asked for")
+	return out.Subnet.SubnetID
+}
+
+// terminateInstances sends TerminateInstances for the given IDs and returns the
+// status and body, so a test can assert both the refusal and what it says.
+func terminateInstances(t *testing.T, ts *httptest.Server, ids ...string) (int, string) {
+	t.Helper()
+	params := map[string]string{"Action": "TerminateInstances"}
+	for i, id := range ids {
+		params[fmt.Sprintf("InstanceId.%d", i+1)] = id
+	}
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}
+
+// instanceState reads an instance's current state name through DescribeInstances,
+// which is how a consumer checks whether their teardown destroyed something.
+func instanceState(t *testing.T, ts *httptest.Server, instID string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "DescribeInstances", "InstanceId.1": instID,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+			State      struct {
+				Name string `xml:"name"`
+			} `xml:"instanceState"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	require.Len(t, out.Instances, 1, "DescribeInstances must find %s", instID)
+	return out.Instances[0].State.Name
+}
+
+// ec2ErrorCodeOf extracts the code from an already-read EC2 error document. It is
+// the sibling of ec2ErrorCode, which sends the request itself — TerminateInstances
+// tests need the body as well as the code, so the two steps are separate here.
+func ec2ErrorCodeOf(t *testing.T, body string) string {
+	t.Helper()
+	var out struct {
+		Code string `xml:"Error>Code"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &out), "body was %s", body)
+	return out.Code
+}
+
+// TestEC2_TerminateInstances_ProtectionRefused is #489's gate. Before this,
+// termination protection was recorded and reported but not acted on, so a test
+// asserting "my teardown does not destroy the protected instance" passed against a
+// code path that ignored protection entirely — the assertion could not fail.
+func TestEC2_TerminateInstances_ProtectionRefused(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	id := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"DisableApiTermination": "true",
+	})
+
+	code, body := terminateInstances(t, ts, id)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "OperationNotPermitted", ec2ErrorCodeOf(t, body))
+	assert.Contains(t, body, id, "the refusal names the instance a caller must act on")
+	assert.Contains(t, body, "disableApiTermination",
+		"and names the attribute to clear")
+
+	assert.Equal(t, "running", instanceState(t, ts, id),
+		"a refused terminate leaves the instance running")
+}
+
+// TestEC2_TerminateInstances_ProtectionClearedThenTerminates is the sequence a
+// consumer's teardown actually performs: clear protection, then terminate.
+func TestEC2_TerminateInstances_ProtectionClearedThenTerminates(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	id := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"DisableApiTermination": "true",
+	})
+	require.Equal(t, http.StatusOK, modifyInstanceAttribute(t, ts, map[string]string{
+		"Action": "ModifyInstanceAttribute", "InstanceId": id,
+		"DisableApiTermination.Value": "false",
+	}))
+
+	code, body := terminateInstances(t, ts, id)
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Equal(t, "terminated", instanceState(t, ts, id))
+}
+
+// TestEC2_TerminateInstances_UnprotectedUnaffected guards the ordinary path: the
+// protection check must not refuse a request naming no protected instance.
+func TestEC2_TerminateInstances_UnprotectedUnaffected(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	a := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	b := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+
+	code, body := terminateInstances(t, ts, a, b)
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Equal(t, "terminated", instanceState(t, ts, a))
+	assert.Equal(t, "terminated", instanceState(t, ts, b))
+}
+
+// TestEC2_TerminateInstances_ProtectionIsZoneScoped is the reference's own
+// four-instance worked example, and the assertion neither of #489's two guesses
+// would satisfy. Quoting TerminateInstances:
+//
+//	The specified instances that are in the same Availability Zone as the
+//	protected instance are not terminated. The specified instances that are in
+//	different Availability Zones, where no other specified instances are
+//	protected, are successfully terminated.
+//
+// So the request reports failure while A and B — unprotected and in a zone with no
+// protected instance — are terminated anyway. Refusing the whole request fails this
+// test on A and B; terminating per-instance fails it on D.
+func TestEC2_TerminateInstances_ProtectionIsZoneScoped(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	launch := func(az string, protected bool) string {
+		params := map[string]string{
+			"ImageId": "ami-1", "InstanceType": "t3.micro",
+			"Placement.AvailabilityZone": az,
+		}
+		if protected {
+			params["DisableApiTermination"] = "true"
+		}
+		return runInstance(t, ts, params)
+	}
+	a := launch("us-east-1a", false)
+	b := launch("us-east-1a", false)
+	c := launch("us-east-1b", true)
+	d := launch("us-east-1b", false)
+
+	code, body := terminateInstances(t, ts, a, b, c, d)
+	assert.Equal(t, http.StatusBadRequest, code, "the request reports failure")
+	assert.Equal(t, "OperationNotPermitted", ec2ErrorCodeOf(t, body))
+	assert.Contains(t, body, c, "the error names the protected instance, not a sibling")
+
+	assert.Equal(t, "terminated", instanceState(t, ts, a),
+		"A is in a zone with no protected instance, so it terminates")
+	assert.Equal(t, "terminated", instanceState(t, ts, b), "and so does B")
+	assert.Equal(t, "running", instanceState(t, ts, c), "C is protected")
+	assert.Equal(t, "running", instanceState(t, ts, d),
+		"D shares C's zone, so it survives despite being unprotected")
+}
+
+// TestEC2_TerminateInstances_ProtectedAloneInItsZone is the simpler half of the
+// same rule, kept separate because it is the case a per-instance implementation
+// also passes: with one instance per zone, zone-scoped and per-instance agree.
+func TestEC2_TerminateInstances_ProtectedAloneInItsZone(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	protected := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"Placement.AvailabilityZone": "us-east-1a",
+		"DisableApiTermination":      "true",
+	})
+	other := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"Placement.AvailabilityZone": "us-east-1b",
+	})
+
+	code, _ := terminateInstances(t, ts, protected, other)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "running", instanceState(t, ts, protected))
+	assert.Equal(t, "terminated", instanceState(t, ts, other))
+}
+
+// TestEC2_TerminateInstances_BadIDTerminatesNothing pins that the pre-flight order
+// did not regress: an unresolvable ID fails the whole request before any state is
+// written. The reference states it directly — "If you specify multiple instances and
+// the request fails (for example, because of a single incorrect instance ID), none of
+// the instances are terminated" — and the protection scan runs after that resolution
+// pass, so neither check can write partial state.
+func TestEC2_TerminateInstances_BadIDTerminatesNothing(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	good := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+
+	code, _ := terminateInstances(t, ts, good, "i-0deadbeefdeadbeef")
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "running", instanceState(t, ts, good),
+		"a request that fails on one ID terminates none of the instances")
+}
+
+// TestEC2_TerminateInstances_Idempotent guards the reference's statement that the
+// operation is idempotent: terminating an already-terminated instance succeeds. The
+// protection check must not turn a repeat call into a refusal.
+func TestEC2_TerminateInstances_Idempotent(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	code, _ := terminateInstances(t, ts, id)
+	require.Equal(t, http.StatusOK, code)
+	code, body := terminateInstances(t, ts, id)
+	assert.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Equal(t, "terminated", instanceState(t, ts, id))
+}
+
+// TestEC2_TerminateInstances_ZoneFromSubnet asserts the grouping works for a launch
+// that named no Placement.AvailabilityZone, which is the common case: the zone comes
+// from the subnet, so two subnets in different zones are two groups.
+//
+// Without this, protection would look zone-scoped only for callers who pass
+// Placement.AvailabilityZone explicitly, and collapse to whole-request refusal for
+// everyone else — the wrong behavior, reached by the right code.
+func TestEC2_TerminateInstances_ZoneFromSubnet(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	vpcID := createVPC(t, ts, "10.0.0.0/16")
+	subnetA := createSubnetInAZ(t, ts, vpcID, "10.0.1.0/24", "us-east-1a")
+	subnetB := createSubnetInAZ(t, ts, vpcID, "10.0.2.0/24", "us-east-1b")
+
+	protected := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"SubnetId": subnetA, "DisableApiTermination": "true",
+	})
+	sameZone := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro", "SubnetId": subnetA,
+	})
+	otherZone := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro", "SubnetId": subnetB,
+	})
+
+	code, _ := terminateInstances(t, ts, protected, sameZone, otherZone)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "running", instanceState(t, ts, protected))
+	assert.Equal(t, "running", instanceState(t, ts, sameZone),
+		"the subnet supplied the zone, so this instance shares the protected one's")
+	assert.Equal(t, "terminated", instanceState(t, ts, otherZone))
+}
+
+// TestEC2_Instance_ReportsAvailabilityZone asserts the zone is observable, which is
+// what makes the rule above assertable by a consumer rather than only internally
+// consistent. A caller reasoning about which of their instances a terminate would
+// spare has to be able to read the grouping key.
+func TestEC2_Instance_ReportsAvailabilityZone(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	// RunInstances reports it directly, so no follow-up describe is needed.
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "RunInstances", "MinCount": "1", "MaxCount": "1",
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"Placement.AvailabilityZone": "us-west-2c",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	launched, err := io.ReadAll(resp.Body)
+	require.NoError(t, resp.Body.Close())
+	require.NoError(t, err)
+	assert.Contains(t, string(launched), "<availabilityZone>us-west-2c</availabilityZone>",
+		"RunInstances reports the placement it applied")
+
+	var out struct {
+		Instances []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(launched, &out))
+	require.Len(t, out.Instances, 1)
+	id := out.Instances[0].InstanceID
+
+	described := ec2Request(t, ts, map[string]string{
+		"Action": "DescribeInstances", "InstanceId.1": id,
+	})
+	require.Equal(t, http.StatusOK, described.StatusCode)
+	body, err := io.ReadAll(described.Body)
+	require.NoError(t, described.Body.Close())
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "<availabilityZone>us-west-2c</availabilityZone>",
+		"and DescribeInstances reports it too")
+}
+
+// TestEC2_DescribeInstances_AvailabilityZoneFilter covers the filter that lets a
+// caller enumerate a zone's instances, which is how they would work out what a
+// terminate is about to spare.
+func TestEC2_DescribeInstances_AvailabilityZoneFilter(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	inA := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"Placement.AvailabilityZone": "eu-west-1a",
+	})
+	inB := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"Placement.AvailabilityZone": "eu-west-1b",
+	})
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":        "DescribeInstances",
+		"Filter.1.Name": "availability-zone", "Filter.1.Value.1": "eu-west-1a",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(body), inA)
+	assert.NotContains(t, string(body), inB)
+}
+
+// TestEC2_Instance_AlwaysCarriesAZone pins the invariant the zone grouping depends
+// on: every instance has a zone, whatever the launch named. An instance with an empty
+// zone would group with every other zoneless instance, so a whole-request refusal
+// would masquerade as the zone-scoped rule.
+//
+// The path that reaches the region-default fallback is a launch naming a SubnetId that
+// resolves to nothing — RunInstances does not validate the ID, which is a pre-existing
+// looseness this test relies on rather than endorses. An absent SubnetId cannot reach
+// it, because the auto-created default subnet already supplies a zone.
+func TestEC2_Instance_AlwaysCarriesAZone(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	id := runInstance(t, ts, map[string]string{
+		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"SubnetId": "subnet-0000000000000dead",
+	})
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "DescribeInstances", "InstanceId.1": id,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out struct {
+		Instances []struct {
+			AZ string `xml:"placement>availabilityZone"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	require.Len(t, out.Instances, 1)
+	assert.Equal(t, "us-east-1a", out.Instances[0].AZ,
+		"a launch resolving no subnet still lands in the region's first zone")
 }

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -311,9 +311,18 @@ func (p *EC2Plugin) runInstancesWithTags(
 		iamInstanceProfile = req.Params["IamInstanceProfile.Arn"]
 	}
 	userData := req.Params["UserData"]
-	// Recorded so DescribeInstanceAttribute can report it (#473). AWS documents the
-	// default as false, so an absent parameter and an explicit "false" agree.
+	// Recorded so DescribeInstanceAttribute can report it (#473) and so
+	// TerminateInstances can refuse (#489). AWS documents the default as false, so
+	// an absent parameter and an explicit "false" agree.
 	disableAPITermination := strings.EqualFold(req.Params["DisableApiTermination"], "true")
+	// Placement.AvailabilityZone is optional; the reference says EC2 selects a zone
+	// when neither it nor AvailabilityZoneId is given. Substrate resolves an absent
+	// value from the subnet below, which is where a real launch's zone comes from
+	// too, and only falls back to the region's first zone when there is no subnet.
+	// AvailabilityZoneId is not modeled: substrate has no per-account zone-ID
+	// mapping to resolve it through, and inventing one would be an observation
+	// nothing backs.
+	placementAZ := req.Params["Placement.AvailabilityZone"]
 
 	subnetID := req.Params["SubnetId"]
 	sgID := req.Params["SecurityGroupId.1"]
@@ -538,6 +547,7 @@ func (p *EC2Plugin) runInstancesWithTags(
 			Tags:               tags,
 
 			DisableAPITermination: disableAPITermination,
+			AvailabilityZone:      placementAZ,
 		}
 
 		// Look up VPCID from subnet and decide whether to assign a public IP.
@@ -546,6 +556,13 @@ func (p *EC2Plugin) runInstancesWithTags(
 			var subnet EC2Subnet
 			if json.Unmarshal(subnetData, &subnet) == nil {
 				inst.VPCID = subnet.VPCID
+				// A launch that named no zone lands in the subnet's, which is how a
+				// real launch resolves it. An explicit Placement.AvailabilityZone
+				// wins, because that is the caller's stated intent even where it
+				// disagrees with the subnet.
+				if inst.AvailabilityZone == "" {
+					inst.AvailabilityZone = subnet.AvailabilityZone
+				}
 				// Always set private DNS name.
 				inst.PrivateDNSName = ec2PrivateDNSName(inst.PrivateIPAddress, reqCtx.Region)
 				// Assign public IP for default subnets, subnets with
@@ -556,6 +573,13 @@ func (p *EC2Plugin) runInstancesWithTags(
 					inst.PublicDNSName = ec2PublicDNSName(inst.PublicIPAddress, reqCtx.Region)
 				}
 			}
+		}
+		// A launch naming neither a zone nor a resolvable subnet still runs
+		// somewhere. Default to the region's first zone, matching what CreateSubnet
+		// does with an absent AvailabilityZone, so every instance carries a zone and
+		// #489's grouping has something to group by.
+		if inst.AvailabilityZone == "" {
+			inst.AvailabilityZone = reqCtx.Region + "a"
 		}
 
 		data, err := json.Marshal(inst)
@@ -621,18 +645,25 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 		Key   string `xml:"key"`
 		Value string `xml:"value"`
 	}
+	// See [EC2Plugin.describeInstances]'s placement item: RunInstances reports the
+	// zone too, so a caller launching into two zones can read back which is which
+	// without a follow-up describe.
+	type placementItem struct {
+		AvailabilityZone string `xml:"availabilityZone"`
+	}
 	type ec2InstanceItem struct {
-		InstanceID       string `xml:"instanceId"`
-		ImageID          string `xml:"imageId"`
-		InstanceType     string `xml:"instanceType"`
-		LaunchTime       string `xml:"launchTime"`
-		PrivateIPAddress string `xml:"privateIpAddress"`
-		PublicIPAddress  string `xml:"publicIpAddress,omitempty"`
-		PublicDNSName    string `xml:"dnsName,omitempty"`
-		PrivateDNSName   string `xml:"privateDnsName,omitempty"`
-		SubnetID         string `xml:"subnetId"`
-		VpcID            string `xml:"vpcId"`
-		KeyName          string `xml:"keyName,omitempty"`
+		InstanceID       string        `xml:"instanceId"`
+		ImageID          string        `xml:"imageId"`
+		InstanceType     string        `xml:"instanceType"`
+		LaunchTime       string        `xml:"launchTime"`
+		PrivateIPAddress string        `xml:"privateIpAddress"`
+		PublicIPAddress  string        `xml:"publicIpAddress,omitempty"`
+		PublicDNSName    string        `xml:"dnsName,omitempty"`
+		PrivateDNSName   string        `xml:"privateDnsName,omitempty"`
+		SubnetID         string        `xml:"subnetId"`
+		VpcID            string        `xml:"vpcId"`
+		KeyName          string        `xml:"keyName,omitempty"`
+		Placement        placementItem `xml:"placement"`
 		State            struct {
 			Code int    `xml:"code"`
 			Name string `xml:"name"`
@@ -666,6 +697,7 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 			SubnetID:         inst.SubnetID,
 			VpcID:            inst.VPCID,
 			KeyName:          inst.KeyName,
+			Placement:        placementItem{AvailabilityZone: inst.AvailabilityZone},
 		}
 		item.State.Code = inst.State.Code
 		item.State.Name = inst.State.Name
@@ -724,6 +756,11 @@ func ec2InstanceMatchesFilter(inst EC2Instance, name string, values []string) bo
 		return containsStr(values, inst.SubnetID)
 	case "key-name":
 		return containsStr(values, inst.KeyName)
+	case "availability-zone":
+		// The reference names this filter "availability-zone", not
+		// "placement.availability-zone" — the placement family's filters are
+		// spelled out individually in DescribeInstances' filter list.
+		return containsStr(values, inst.AvailabilityZone)
 	case "tag-key":
 		// Instance has a tag with any of the requested keys (any value).
 		for _, t := range inst.Tags {
@@ -762,6 +799,12 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		ARN string `xml:"arn"`
 		ID  string `xml:"id"`
 	}
+	// placementItem is the instance's placement structure. Only availabilityZone is
+	// emitted: it is the one member substrate records, and it must be readable for a
+	// caller to reason about TerminateInstances' zone-scoped protection rule (#489).
+	type placementItem struct {
+		AvailabilityZone string `xml:"availabilityZone"`
+	}
 	type ec2InstanceItem struct {
 		InstanceID         string          `xml:"instanceId"`
 		ImageID            string          `xml:"imageId"`
@@ -776,6 +819,7 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		KeyName            string          `xml:"keyName,omitempty"`
 		IamInstanceProfile *iamProfileItem `xml:"iamInstanceProfile,omitempty"`
 		State              ec2StateItem    `xml:"instanceState"`
+		Placement          placementItem   `xml:"placement"`
 		Groups             []ec2GroupItem  `xml:"groupSet>item"`
 		Tags               []tagItem       `xml:"tagSet>item"`
 	}
@@ -823,6 +867,7 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 			SubnetID:         inst.SubnetID,
 			VpcID:            inst.VPCID,
 			KeyName:          inst.KeyName,
+			Placement:        placementItem{AvailabilityZone: inst.AvailabilityZone},
 		}
 		item.State.Code = inst.State.Code
 		item.State.Name = inst.State.Name
@@ -880,6 +925,14 @@ func (p *EC2Plugin) terminateInstances(reqCtx *RequestContext, req *AWSRequest) 
 	}
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 
+	// Pass 1: resolve every named instance before terminating any. A bad ID fails
+	// the whole request without writing state, which is what the reference means by
+	// "If you specify multiple instances and the request fails (for example,
+	// because of a single incorrect instance ID), none of the instances are
+	// terminated." Termination protection is the other pre-flight, and it needs the
+	// full set in hand because its scope is the Availability Zone (#489).
+	instances := make([]EC2Instance, 0, len(ids))
+	keys := make([]string, 0, len(ids))
 	for _, id := range ids {
 		key := "instance:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + id
 		data, err := p.state.Get(context.Background(), ec2Namespace, key)
@@ -893,18 +946,45 @@ func (p *EC2Plugin) terminateInstances(reqCtx *RequestContext, req *AWSRequest) 
 		if err := json.Unmarshal(data, &inst); err != nil {
 			return nil, fmt.Errorf("ec2 terminateInstances unmarshal: %w", err)
 		}
+		instances = append(instances, inst)
+		keys = append(keys, key)
+	}
+
+	// Pass 2: terminate every instance in a zone that holds no protected instance,
+	// then report the failure if any zone was blocked. The terminations persist —
+	// the request "reports failure" while the unaffected zones still went through —
+	// so the ordering here is the behavior, not an implementation detail.
+	blocked := ec2TerminationProtectionBlocked(instances)
+	for i, inst := range instances {
+		if _, azBlocked := blocked[inst.AvailabilityZone]; azBlocked {
+			continue
+		}
 		prev := inst.State
 		inst.State = EC2InstanceState{Code: 48, Name: "terminated"}
 		inst.TerminatedTime = p.tc.Now().UTC().Format(time.RFC3339)
-		newData, _ := json.Marshal(inst)
-		_ = p.state.Put(context.Background(), ec2Namespace, key, newData)
+		newData, err := json.Marshal(inst)
+		if err != nil {
+			return nil, fmt.Errorf("ec2 terminateInstances marshal: %w", err)
+		}
+		if err := p.state.Put(context.Background(), ec2Namespace, keys[i], newData); err != nil {
+			return nil, fmt.Errorf("ec2 terminateInstances state.Put: %w", err)
+		}
 
-		sc := stateChange{InstanceID: id}
+		sc := stateChange{InstanceID: inst.InstanceID}
 		sc.CurrentState.Code = inst.State.Code
 		sc.CurrentState.Name = inst.State.Name
 		sc.PreviousState.Code = prev.Code
 		sc.PreviousState.Name = prev.Name
 		resp.Items = append(resp.Items, sc)
+	}
+	if len(blocked) > 0 {
+		// Report the protected instance that appeared first in request order, so the
+		// message is stable across replays rather than depending on map iteration.
+		for _, inst := range instances {
+			if blockingID, azBlocked := blocked[inst.AvailabilityZone]; azBlocked {
+				return nil, ec2TerminationProtectedError(blockingID)
+			}
+		}
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }

--- a/emulator/ec2_termination.go
+++ b/emulator/ec2_termination.go
@@ -1,0 +1,65 @@
+package emulator
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ec2TerminationProtectionBlocked groups instances by Availability Zone and
+// returns, for each zone holding at least one protected instance, the ID of the
+// protected instance that blocks it. A zone absent from the result has no
+// protected instance among those named and may be terminated.
+//
+// The grouping is the whole behavior of a mixed TerminateInstances request, and
+// it is neither per-request nor per-instance. Quoting the TerminateInstances
+// reference, which is the only place this is stated:
+//
+//	If you terminate multiple instances across multiple Availability Zones, and
+//	one or more of the specified instances are enabled for termination
+//	protection, the request fails with the following results:
+//	  - The specified instances that are in the same Availability Zone as the
+//	    protected instance are not terminated.
+//	  - The specified instances that are in different Availability Zones, where
+//	    no other specified instances are protected, are successfully terminated.
+//
+// So an unprotected instance sharing a zone with a protected one survives, while
+// an unprotected instance in another zone does not. Refusing the whole request
+// and terminating every unprotected instance are both wrong, in opposite
+// directions.
+//
+// When two protected instances share a zone the first in request order is
+// reported, so the error names a stable instance across replays.
+func ec2TerminationProtectionBlocked(instances []EC2Instance) map[string]string {
+	blocked := make(map[string]string)
+	for _, inst := range instances {
+		if !inst.DisableAPITermination {
+			continue
+		}
+		if _, seen := blocked[inst.AvailabilityZone]; !seen {
+			blocked[inst.AvailabilityZone] = inst.InstanceID
+		}
+	}
+	return blocked
+}
+
+// ec2TerminationProtectedError reports that instanceID may not be terminated
+// because termination protection is enabled.
+//
+// The code is a doc citation: the EC2 client-error table lists
+// OperationNotPermitted as "The specified operation is not allowed", naming this
+// case first among its examples — "you might be trying to terminate an instance
+// that has termination protection enabled". The message text is substrate's own.
+// #489 supplied a remembered console wording, which no capture corroborates, so
+// per docs/fidelity.md the text is not dressed up as observed; it interpolates
+// the instance ID and names the attribute to clear, which is what a caller acts
+// on.
+func ec2TerminationProtectedError(instanceID string) *AWSError {
+	return &AWSError{
+		Code: "OperationNotPermitted",
+		Message: fmt.Sprintf(
+			"The instance '%s' may not be terminated. "+
+				"Modify its 'disableApiTermination' instance attribute and try again.",
+			instanceID),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -99,10 +99,19 @@ type EC2Instance struct {
 	// AWS documents the default as false, which is the zero value, so an instance
 	// unmarshalled from an event log predating this field reads back correctly.
 	//
-	// Substrate records and reports it but does not act on it: TerminateInstances
-	// still terminates a protected instance. Real EC2 refuses with
-	// OperationNotPermitted, which is tracked separately.
+	// TerminateInstances honors it (#489), refusing with OperationNotPermitted.
+	// Because the refusal is scoped to the Availability Zone rather than to the
+	// request or the instance, it is read together with AvailabilityZone; see
+	// [ec2TerminationProtectionBlocked].
 	DisableAPITermination bool `json:"disable_api_termination,omitempty"`
+
+	// AvailabilityZone is the zone the instance runs in, taken from
+	// Placement.AvailabilityZone or from the subnet's zone when the launch named
+	// neither. An instance unmarshalled from an event log predating this field
+	// reads back as the empty string, which groups all such instances into one
+	// zone — the conservative reading, since it is what a single-zone account
+	// looks like.
+	AvailabilityZone string `json:"availability_zone,omitempty"`
 }
 
 // EC2KeyPair represents an EC2 key pair (public/private key used for SSH access).


### PR DESCRIPTION
## What

`TerminateInstances` now honours termination protection, and does so **per Availability Zone**.

Closes #489

## Why it mattered

#473 made `disableApiTermination` observable but nothing acted on it. That is the sharpest case of this tracker's recurring shape: a consumer's test asserting *"my teardown does not destroy the protected instance"* passed against a code path that ignored protection entirely — so the assertion **could not fail**. The test was green and verified nothing.

## The AZ rule — neither of #489's two guesses

#489 asked whether a mixed request refuses whole or terminates the unprotected instances, and noted that getting it backwards is the same defect in the other direction. The reference's answer is a third thing:

> The specified instances that are in the same Availability Zone as the protected instance are not terminated. The specified instances that are in different Availability Zones, where no other specified instances are protected, are successfully terminated.

For the reference's own four-instance example — A and B unprotected in `us-east-1a`, C protected and D unprotected in `us-east-1b`, all named in one request:

| Instance | Zone | Protected | Outcome |
|---|---|---|---|
| A | `us-east-1a` | no | **terminated** |
| B | `us-east-1a` | no | **terminated** |
| C | `us-east-1b` | yes | still `running` |
| D | `us-east-1b` | no | still `running` — shares C's zone |

The request reports `OperationNotPermitted` naming C, **after** the `us-east-1a` terminations are persisted. That ordering is the behaviour, not an implementation detail.

## The zone had to be modelled first

`EC2Instance` carried no `AvailabilityZone` at all, so the rule was neither implementable nor observable. Added and resolved at launch: `Placement.AvailabilityZone` → the named subnet's zone → the region's first zone (`<region>a`, matching "EC2 automatically selects an Availability Zone for you"). A fleet pool's `Overrides.N.AvailabilityZone` now reaches the launch, so a fleet spread across zones no longer looks single-zone. `RunInstances` and `DescribeInstances` report `<placement><availabilityZone>`, and `DescribeInstances` accepts an `availability-zone` filter — that is the reference's spelling, not `placement.availability-zone`. `AvailabilityZoneId` is not modelled.

An instance replayed from an event log predating the field reads back with an empty zone, grouping all such instances together — the conservative reading, being what a single-zone account looks like.

## The fleet path

`DeleteFleets --terminate-instances` synthesizes a `TerminateInstances` through the same handler, so a protected fleet instance survives its fleet's deletion while an unprotected sibling in another zone does not. `DeleteFleets` **propagates** the error rather than folding it into `unsuccessfulFleetDeletionSet`: `DeleteFleetError`'s documented codes are exactly `fleetIdDoesNotExist`, `fleetIdMalformed`, `fleetNotInDeletableState` and `unexpectedError`, so folding it in would mean answering `unexpectedError` and losing the code a caller acts on.

## Provenance

Split, and labelled as such in the code. The **code** is documented — EC2's client-error table lists `OperationNotPermitted` and names this case *first* among its examples: "you might be trying to terminate an instance that has termination protection enabled". The **message text is substrate's own**: #489 supplied a remembered console wording that no capture corroborates, so per `docs/fidelity.md` it is not dressed up as observed. It interpolates the instance ID and names the attribute to clear, which is what a caller acts on.

## Out of scope, deliberately

A terminated instance still reports code `48` `terminated` immediately, where real EC2 reports code `32` `shutting-down` first. Pre-existing, unrelated to protection, and widening this into a lifecycle change would have put #489's gate at risk. Filed separately.

## Tests

Eleven new tests. The gates:

- **The AZ table** — fails under *both* behaviours #489 guessed at.
- A protected instance stays `running`; clearing protection then terminating succeeds.
- A protected fleet instance survives `DeleteFleets --terminate-instances`; the unprotected sibling in another zone does not.
- A bad ID terminates nothing; an already-terminated instance still succeeds (the operation is idempotent and the protection check must not change that).
- Zone from a subnet, so the rule is zone-scoped for callers who never pass `Placement.AvailabilityZone` — without this it would collapse to whole-request refusal for the common case.
- Every instance carries a zone, whatever the launch named; an empty zone would let a whole-request refusal masquerade as the zone rule.

**Mutation-tested: 25 mutations, 25 caught, 0 survivors.** Including both of #489's wrong answers (refuse the whole request; terminate per-instance), ignoring protection entirely, terminating the blocked zone while still reporting the error, dropping the zone from either response builder, losing a fleet pool's zone override, `DeleteFleets` swallowing the refusal, and `json:"-"` on the new field.

## Verification

From the repo root: `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go test -C test/e2e ./...` — all clean.

End-to-end through the AWS CLI against `substrate server`:

```
$ aws ec2 terminate-instances --instance-ids $A $B      # A protected in 1b, B in 1a
An error occurred (OperationNotPermitted) ...: The instance 'i-f41e...' may not be
terminated. Modify its 'disableApiTermination' instance attribute and try again.

$ aws ec2 describe-instances --instance-ids $A $B
i-2c92c2fd60987400   us-east-1a   terminated
i-f41e4d3745ed8a40   us-east-1b   running

$ aws ec2 describe-instances --filters Name=availability-zone,Values=us-east-1b
i-f41e4d3745ed8a40

$ aws ec2 modify-instance-attribute --instance-id $A --no-disable-api-termination
$ aws ec2 terminate-instances --instance-ids $A
i-f41e4d3745ed8a40   terminated
```

## Docs

`docs/services.md` — the "recorded and reported but not acted on" caveat is gone, replaced by a new §"Termination protection is honoured, one Availability Zone at a time" carrying the quote, the four-instance table, the zone-resolution order, the filter name, the fleet behaviour, the event-log note and the `shutting-down` divergence. Operations table rows updated for `RunInstances`, `DescribeInstances`, `TerminateInstances` and `DeleteFleets`.
