### PR TITLE
feat(ec2): enforce the documented tag key and value length limits (#490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adapter maps them to AWS codes by matching sentinel prefixes — typed errors
   behind the model would remove the string matching and are filed as #502.
 
+- **EC2 tag keys and values now have their documented length limits enforced**
+  (#490). A key longer than 128 characters or a value longer than 256 was accepted
+  everywhere: `CreateTags`, `DeleteTags`, and tag-on-create through `RunInstances`,
+  `CreateFleet`, `CreateImage`, `CreateNatGateway` and a launch template. This was the
+  third restriction in the same table #469 read for the 50-tag count and the only one
+  left unenforced, so a consumer generating tag values from a resource description or a
+  git ref — the case that actually overruns 256 characters — had no way to reach real
+  EC2's rejection, and a test asserting it passed against substrate while the same code
+  failed against AWS. The rejection is `InvalidParameterValue`, HTTP 400, and names
+  which limit was exceeded and by how much.
+
+  **The unit is Unicode characters, not bytes**, per "Maximum key length – 128 Unicode
+  characters in UTF-8". A key of 128 emoji is 128 characters and 512 bytes and is
+  legal; counting bytes would refuse it while reporting a length the caller never sent.
+  The two counts agree on ASCII, which is why an ASCII-only suite cannot tell them
+  apart, so the tests carry emoji and three-byte rows.
+
+  There is no lower bound — "You can set the value of a tag to an empty string, but you
+  can't set the value of a tag to null" — so the check is an upper bound only. That is
+  also what makes `DeleteTags` correct without a special case: it names keys and treats
+  the value as optional, so an absent `Tag.N.Value` is the empty string and passes.
+
+  Reserved `aws:` keys are **not** exempt from the lengths, though they are from the
+  count: the exemption in the restrictions list is scoped to the count alone ("Tags
+  with the `aws:` prefix do not count against your tags per resource limit") and
+  nothing in it exempts a reserved key from either length. That answers the question
+  #490 raised, and it is worth being precise about what it buys — the reserved-key
+  check runs first, so an `aws:`-prefixed key is refused for being reserved before its
+  length is measured, and the choice therefore changes no wire behaviour today. It is
+  the right code for any future path that checks lengths alone, and it is recorded
+  because the adjacent count check does the opposite. Where the length check does bite
+  is the case-sensitive edge: `AWS:` is an ordinary user tag, and an over-long one is
+  refused for its length.
+
+  As with the other two tag restrictions, the whole request is refused before anything
+  is modified, and on a tag-on-create path before the resource exists — a refused
+  `RunInstances` launches no instance, a refused `CreateImage` creates neither the AMI
+  nor its snapshot, and a refused `CreateLaunchTemplate` creates no template. A launch
+  template is checked at creation and at each version as well as at every launch that
+  names it, following #471, so an over-long template tag is reported once at the
+  operation that named it.
+
+  The three tag checks are now applied through one function rather than at each of the
+  nine call sites that had to be found by hand for this fix, so the next restriction is
+  added in one place.
+
+  Provenance is the weakest of the three tag restrictions and is marked as such. The
+  **code** `InvalidParameterValue` with HTTP 400 is by analogy with the reserved-key
+  rejection — the other tag-restriction violation on the same operations, and
+  `CreateTags`' Errors section is empty so the API model supplies nothing. The
+  **message text is substrate's own**: no captured real-AWS length rejection was found,
+  in moto or LocalStack either. It interpolates the limit and the actual length,
+  following the `SendMessage` size-limit message's precedent, because the message is
+  the only place a caller learns which limit they hit. Dispatch on the code.
+
 ## [v0.86.0] - 2026-08-02
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -1527,8 +1527,8 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances, [subject to termination protection](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
-| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) |
-| DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) |
+| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit) |
+| DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) and [over-long keys](#tag-key-and-value-length-limits) |
 
 ### RunInstances requires a resolvable AMI
 
@@ -2251,8 +2251,65 @@ A launch template's instance-scoped tags are counted the same way, at
 that names the template. Exactly 50 template tags launch; 51 are refused at template
 creation.
 
-Two documented restrictions substrate does **not** enforce: a tag key's maximum length
-of 128 Unicode characters, and a value's maximum of 256. Both are tracked separately.
+The third restriction from the same table — the key and value **length** limits — is
+enforced too, with one deliberate difference in how reserved keys are treated. See
+[Tag key and value length limits](#tag-key-and-value-length-limits).
+
+### Tag key and value length limits
+
+A tag key longer than **128 characters** or a value longer than **256** is refused, on
+`CreateTags`, `DeleteTags` and every tag-on-create path:
+
+```
+InvalidParameterValue: Tag key must be no more than 128 Unicode characters in UTF-8; the supplied key is 129
+```
+
+The status is `400`. The message names which of the two limits was exceeded and by how
+much, because that is the only place a caller learns it. From the same restrictions list
+that gives the 50-tag count: "Maximum key length – 128 Unicode characters in UTF-8" and
+"Maximum value length – 256 Unicode characters in UTF-8".
+
+**The unit is Unicode characters, not bytes.** A key of 128 emoji is 128 characters and
+512 bytes, and it is legal; a byte-counting check would refuse it, and refuse it while
+reporting a length the caller never sent. The two counts agree on ASCII, so a suite that
+only tests ASCII keys cannot tell them apart.
+
+There is **no lower bound**. The documentation states that "You can set the value of a
+tag to an empty string, but you can't set the value of a tag to null", so an empty value
+is legal and the check is an upper bound only. That is also what makes `DeleteTags` work
+unremarkably: it names keys and treats the value as optional, so a request with no
+`Tag.N.Value` supplies the empty string and passes. A key is required by the query
+encoding rather than by this check — the tag walk ends on an absent or empty
+`Tag.N.Key` — so an empty key is not expressible in the first place.
+
+As with the other two tag restrictions, the whole request is refused before anything is
+modified, and on a tag-on-create path before the resource is created: a refused
+`RunInstances` launches no instance, a refused `CreateImage` creates neither the AMI nor
+its snapshot, a refused `CreateNatGateway` creates no gateway, and a refused
+`CreateLaunchTemplate` creates no template. A launch template is checked at
+`CreateLaunchTemplate` and `CreateLaunchTemplateVersion` as well as at every launch that
+names it, so a consumer hears about an over-long template tag once, at the operation that
+named it.
+
+**Reserved keys are not exempt from the lengths, though they are from the count.** The
+exemption in the restrictions list is scoped to the count alone — "Tags with the `aws:`
+prefix do not count against your tags per resource limit" — and nothing in it exempts a
+reserved key from either length, so substrate checks them. In practice that decides no
+observation: the reserved-key check runs first, so a caller's `aws:`-prefixed key is
+refused for being reserved before its length is measured. It matters for the code rather
+than the wire, and it is recorded here because the adjacent count check does the opposite.
+Where the length check does bite is the case-sensitive edge: `AWS:` is an ordinary user
+tag, so an over-long `AWS:`-prefixed key is refused for its length.
+
+Provenance is the weakest of the three tag restrictions, and is marked as such
+deliberately. The **code** `InvalidParameterValue` with `400` is by analogy with the
+reserved-key rejection — the other tag-restriction violation on the same operations, and
+`CreateTags`' Errors section is empty so the API model supplies nothing. The **message
+text is substrate's own**: no captured real-AWS length rejection was found, in
+[moto](https://github.com/getmoto/moto) or LocalStack either. It follows the
+`SendMessage` size-limit message's precedent of interpolating the limit and the actual
+value. A consumer's error branch should dispatch on the code, which is the part that
+rests on something.
 
 #### Tag scoping on `CreateImage`
 

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -279,14 +279,14 @@ func (p *EC2Plugin) createFleet(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 	// exactly as RunInstances checks its own. Only the fleet-ID tag substrate adds
 	// afterwards is exempt, and it is exempt by never being part of a request (#468).
 	instanceTags := ec2LaunchTagsForResource(req.Params, "instance")
-	if awsErr := ec2CheckReservedTagKeys(instanceTags); awsErr != nil {
+	if awsErr := ec2CheckTagRules(instanceTags); awsErr != nil {
 		return nil, awsErr
 	}
 	if awsErr := ec2CheckTagLimit(nil, instanceTags); awsErr != nil {
 		return nil, awsErr
 	}
 	fleetTags := ec2LaunchTagsForResource(req.Params, "fleet")
-	if awsErr := ec2CheckReservedTagKeys(fleetTags); awsErr != nil {
+	if awsErr := ec2CheckTagRules(fleetTags); awsErr != nil {
 		return nil, awsErr
 	}
 	if awsErr := ec2CheckTagLimit(nil, fleetTags); awsErr != nil {

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -257,7 +257,7 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 // property this emulator exists for.
 func (p *EC2Plugin) runInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	launchTags := ec2LaunchTagsForResource(req.Params, "instance")
-	if awsErr := ec2CheckReservedTagKeys(launchTags); awsErr != nil {
+	if awsErr := ec2CheckTagRules(launchTags); awsErr != nil {
 		return nil, awsErr
 	}
 	// A new instance starts with no tags, so the request's own tags are the whole count
@@ -433,7 +433,7 @@ func (p *EC2Plugin) runInstancesWithTags(
 			// checks existed, or one written straight into state by a replayed event
 			// log, can still carry a reserved key or more than the limit, and this is
 			// the launch that would otherwise apply them.
-			if awsErr := ec2CheckReservedTagKeys(ltData.TagSpecifications); awsErr != nil {
+			if awsErr := ec2CheckTagRules(ltData.TagSpecifications); awsErr != nil {
 				return nil, awsErr
 			}
 			if awsErr := ec2CheckTagLimit(nil, ltData.TagSpecifications); awsErr != nil {
@@ -2132,15 +2132,16 @@ func (p *EC2Plugin) rebootInstances(_ *RequestContext, _ *AWSRequest) (*AWSRespo
 // createTags handles CreateTags — applies key-value tags to one or more EC2 resources.
 //
 // Keys using the reserved "aws:" prefix are rejected before anything is applied, so a
-// mixed request leaves every named resource untouched (#452), and every resource named
-// is checked against the per-resource tag limit before any of them is modified (#469).
-// Both checks run over the whole request for the same reason: CreateTags accepts up to
-// 1000 resource IDs, and a rejection partway through the apply loop would leave a
-// partially-tagged state real EC2 never produces.
+// mixed request leaves every named resource untouched (#452); a key or value over its
+// length limit likewise (#490); and every resource named is checked against the
+// per-resource tag limit before any of them is modified (#469). All three checks run
+// over the whole request for the same reason: CreateTags accepts up to 1000 resource
+// IDs, and a rejection partway through the apply loop would leave a partially-tagged
+// state real EC2 never produces.
 func (p *EC2Plugin) createTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	resourceIDs := extractIndexedParams(req.Params, "ResourceId")
 	tags := extractEC2Tags(req.Params)
-	if err := ec2CheckReservedTagKeys(tags); err != nil {
+	if err := ec2CheckTagRules(tags); err != nil {
 		return nil, err
 	}
 	for _, id := range resourceIDs {
@@ -2180,10 +2181,15 @@ func (p *EC2Plugin) createTags(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 // "can't be edited or deleted" by a caller — and a DeleteTags that returned success
 // while leaving the tag in place would be its own infidelity, so rejecting is the
 // closer of the two available behaviors.
+//
+// The length limits apply here as well, but asymmetrically: DeleteTags names keys and
+// treats the value as optional, so an absent Tag.N.Value is the empty string and passes
+// the value check unremarked. Only what the request actually supplied is checked
+// (#490), which is what [ec2CheckTagLengths]' upper-bound-only shape gives for free.
 func (p *EC2Plugin) deleteTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	resourceIDs := extractIndexedParams(req.Params, "ResourceId")
 	tags := extractEC2Tags(req.Params)
-	if err := ec2CheckReservedTagKeys(tags); err != nil {
+	if err := ec2CheckTagRules(tags); err != nil {
 		return nil, err
 	}
 	for _, id := range resourceIDs {
@@ -3053,10 +3059,10 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 	snapshotTags := ec2LaunchTagsForResource(req.Params, "snapshot")
 	// Checked before the snapshot and image are written, so a rejected request creates
 	// neither. See [ec2CheckReservedTagKeys] for the rollback rule this follows.
-	if awsErr := ec2CheckReservedTagKeys(tags); awsErr != nil {
+	if awsErr := ec2CheckTagRules(tags); awsErr != nil {
 		return nil, awsErr
 	}
-	if awsErr := ec2CheckReservedTagKeys(snapshotTags); awsErr != nil {
+	if awsErr := ec2CheckTagRules(snapshotTags); awsErr != nil {
 		return nil, awsErr
 	}
 	if awsErr := ec2CheckTagLimit(nil, tags); awsErr != nil {
@@ -3812,7 +3818,7 @@ func (p *EC2Plugin) createNatGateway(reqCtx *RequestContext, req *AWSRequest) (*
 	}
 
 	gw.Tags = ec2LaunchTagsForResource(req.Params, "natgateway")
-	if awsErr := ec2CheckReservedTagKeys(gw.Tags); awsErr != nil {
+	if awsErr := ec2CheckTagRules(gw.Tags); awsErr != nil {
 		return nil, awsErr
 	}
 	if awsErr := ec2CheckTagLimit(nil, gw.Tags); awsErr != nil {

--- a/emulator/ec2_tags.go
+++ b/emulator/ec2_tags.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 )
 
 // ec2ReservedTagPrefix is the tag-key prefix EC2 reserves for its own use. A caller
@@ -95,6 +96,97 @@ func ec2CheckTagLimit(existing, incoming []EC2Tag) *AWSError {
 	return nil
 }
 
+// ec2MaxTagKeyLength and ec2MaxTagValueLength are the tag length limits, from the
+// tagging documentation's restrictions list: "Maximum key length – 128 Unicode
+// characters in UTF-8" and "Maximum value length – 256 Unicode characters in UTF-8".
+//
+// The unit is **Unicode characters, not bytes**, which is why [ec2CheckTagLengths]
+// counts runes. A 128-emoji key is 128 characters and 512 bytes; it is legal, and a
+// byte-counting check would reject it. The two agree on ASCII, so an ASCII-only test
+// suite passes under either and cannot tell them apart.
+//
+// There is no lower bound. The same documentation states "You can set the value of a
+// tag to an empty string, but you can't set the value of a tag to null", so an empty
+// value is legal and the check is upper-bound only. A key is required by the query
+// encoding — [extractEC2Tags] ends its walk on an absent or empty Tag.N.Key — so an
+// empty key is not expressible rather than rejected here.
+const (
+	ec2MaxTagKeyLength   = 128
+	ec2MaxTagValueLength = 256
+)
+
+// ec2TagLengthError returns the error EC2 raises for a tag key or value over its
+// length limit. what names the part that was too long ("key" or "value").
+//
+// Provenance, which is the weakest of any error in the EC2 tagging paths and is marked
+// as such deliberately. The *code* is by analogy with [ec2ReservedTagKeyError]:
+// InvalidParameterValue, HTTP 400, is what real AWS answers for the other
+// tag-restriction violation on the same operations, and CreateTags' Errors section is
+// empty so the model supplies nothing. The *message text is substrate's own* — no
+// captured real-AWS length rejection was found, in moto or LocalStack either. It
+// follows sqsMessageTooLong's precedent of interpolating the limit and the actual
+// length, because the message is the only place a caller learns which of the two
+// limits they hit and by how much.
+func ec2TagLengthError(what string, limit, actual int) *AWSError {
+	return &AWSError{
+		Code: "InvalidParameterValue",
+		Message: fmt.Sprintf(
+			"Tag %s must be no more than %d Unicode characters in UTF-8; the supplied %s is %d",
+			what, limit, what, actual),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2CheckTagLengths returns an error if any tag's key or value exceeds its length
+// limit, or nil. Pass an empty value on a key-only path such as DeleteTags, which
+// names keys and treats the value as optional.
+//
+// **Reserved keys are checked too**, which is deliberately narrower than
+// [ec2CheckTagLimit]'s exemption sitting a few lines above, and the difference is worth
+// stating because the adjacent function doing the opposite is what a reader will trip
+// on. The exemption in the restrictions list is scoped to the count alone — "Tags with
+// the aws: prefix do not count against your tags per resource limit" — and nothing in
+// it exempts a reserved key from either length. Substrate's own [ec2FleetIDTagKey] is
+// far under both limits, so checking them changes nothing it stamps.
+//
+// That choice is currently unobservable, and saying so is more useful than implying
+// otherwise: [ec2CheckTagRules] runs [ec2CheckReservedTagKeys] first, so a caller's
+// reserved key is refused for being reserved before its length is ever measured. The
+// exemption question therefore decides no wire behavior today. Checking reserved keys is
+// still the right code — it is correct for any future path that checks lengths alone, and
+// it is the reading the documentation supports — but it is a clarity decision rather than
+// a behavioral one.
+//
+// Tags are checked in slice order, so which tag a mixed request is rejected on is
+// decided identically on every run — the same reason [ec2CheckReservedTagKeys] avoids a
+// map. Callers on a tag-on-create path must check before the resource is created; see
+// [ec2CheckReservedTagKeys] for the rollback rule all three checks follow.
+func ec2CheckTagLengths(tags []EC2Tag) *AWSError {
+	for _, t := range tags {
+		if n := utf8.RuneCountInString(t.Key); n > ec2MaxTagKeyLength {
+			return ec2TagLengthError("key", ec2MaxTagKeyLength, n)
+		}
+		if n := utf8.RuneCountInString(t.Value); n > ec2MaxTagValueLength {
+			return ec2TagLengthError("value", ec2MaxTagValueLength, n)
+		}
+	}
+	return nil
+}
+
+// ec2CheckTagRules runs every tag restriction substrate models over one tag list:
+// reserved keys, then lengths. It is what a tag-on-create path calls, so a new
+// restriction is added in one place rather than at each of the eleven call sites that
+// had to be found by hand for #490.
+//
+// The per-resource count is *not* included, because it needs the resource's existing
+// tags as well and its callers pass different things for them — see [ec2CheckTagLimit].
+func ec2CheckTagRules(tags []EC2Tag) *AWSError {
+	if awsErr := ec2CheckReservedTagKeys(tags); awsErr != nil {
+		return awsErr
+	}
+	return ec2CheckTagLengths(tags)
+}
+
 // ec2LaunchTagsForResource collects the TagSpecification.N tags scoped to
 // resourceType, in the request's Tag.N order.
 //
@@ -149,17 +241,17 @@ func ec2TagSpecificationTags(params map[string]string, prefix, resourceType stri
 }
 
 // ec2CheckTemplateTags returns an error if a launch template's instance-scoped tags
-// break either tag rule, or nil.
+// break any tag rule, or nil.
 //
 // Run when a template or a version of one is created, so a template carrying a
-// reserved key or more than [ec2MaxTagsPerResource] is refused up front rather than
-// at every launch that names it. Real EC2 rejects at creation too: both rules are on
-// the key and the count, not on the operation.
+// reserved key, an over-long key or value, or more than [ec2MaxTagsPerResource] is
+// refused up front rather than at every launch that names it. Real EC2 rejects at
+// creation too: every rule is on the tag and the count, not on the operation.
 //
 // The launch path checks again, deliberately — see the fallback in
 // [EC2Plugin.runInstancesWithTags] for why a stored template can still carry one.
 func ec2CheckTemplateTags(d EC2LaunchTemplateData) *AWSError {
-	if awsErr := ec2CheckReservedTagKeys(d.TagSpecifications); awsErr != nil {
+	if awsErr := ec2CheckTagRules(d.TagSpecifications); awsErr != nil {
 		return awsErr
 	}
 	return ec2CheckTagLimit(nil, d.TagSpecifications)

--- a/emulator/ec2_tags_test.go
+++ b/emulator/ec2_tags_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1108,4 +1109,527 @@ func TestEC2_CreateTags_UncountedResourceIDs(t *testing.T) {
 				"an ID the apply step ignores must not be counted against")
 		})
 	}
+}
+
+// The tag length limits, restated here because an external test package cannot see
+// ec2MaxTagKeyLength and ec2MaxTagValueLength. As with [ec2TagLimit], that is a
+// feature: the tests assert the documented numbers rather than whatever the constants
+// happen to hold, so editing a constant alone cannot make them pass.
+//
+// From the tagging documentation's restrictions list: "Maximum key length – 128
+// Unicode characters in UTF-8" and "Maximum value length – 256 Unicode characters in
+// UTF-8".
+const (
+	ec2TagKeyLimit   = 128
+	ec2TagValueLimit = 256
+)
+
+// ec2Repeat returns s repeated until it is exactly count *runes* long.
+//
+// strings.Repeat is the whole implementation, and the wrapper exists for the assertion
+// beside it: a test that builds a 129-character key out of a multi-byte rune must be
+// able to state that it built 129 characters and not 129 bytes, or the row that
+// distinguishes the two limits silently stops distinguishing them.
+func ec2Repeat(t *testing.T, s string, count int) string {
+	t.Helper()
+	out := strings.Repeat(s, count)
+	require.Equal(t, count, utf8.RuneCountInString(out),
+		"the test fixture must be %d runes; s must be a single rune", count)
+	return out
+}
+
+// ec2TagLengthMessage is the wording substrate emits for an over-long tag key or
+// value, pinned so it cannot drift silently.
+//
+// This is the weakest provenance of any error in the EC2 tagging paths and is labeled
+// as such deliberately. The *code* InvalidParameterValue with HTTP 400 is by analogy
+// with the reserved-key rejection — the other tag-restriction violation on the same
+// operations, and CreateTags' Errors section is empty so the model supplies nothing.
+// The *message text is substrate's own*: no captured real-AWS length rejection was
+// found, in moto or LocalStack either. It interpolates the limit and the actual length
+// following sqsMessageTooLong's precedent, because the message is the only place a
+// caller learns which limit they hit and by how much.
+func ec2TagLengthMessage(what string, limit, actual int) string {
+	return fmt.Sprintf(
+		"Tag %s must be no more than %d Unicode characters in UTF-8; the supplied %s is %d",
+		what, limit, what, actual)
+}
+
+// TestEC2_CreateTags_EnforcesLengthLimits covers #490: substrate accepted a tag key or
+// value of any length, so a consumer that hit real EC2's 128/256-character ceilings had
+// no way to test the rejection — and a test asserting it passed against substrate while
+// the same code failed against AWS. The #469 count limit came from the same
+// restrictions table and the lengths were left behind.
+//
+// The boundaries are adjacent on purpose: an off-by-one in either direction is the
+// failure mode, and a table testing only 500-character keys catches neither.
+func TestEC2_CreateTags_EnforcesLengthLimits(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		value    string
+		wantWhat string // "" means the tag is legal
+		wantLen  int
+	}{
+		{
+			name:  "a 128-character key is legal",
+			key:   strings.Repeat("k", ec2TagKeyLimit),
+			value: "v",
+		},
+		{
+			name:     "a 129-character key is not",
+			key:      strings.Repeat("k", ec2TagKeyLimit+1),
+			value:    "v",
+			wantWhat: "key",
+			wantLen:  ec2TagKeyLimit + 1,
+		},
+		{
+			name:  "a 256-character value is legal",
+			key:   "k",
+			value: strings.Repeat("v", ec2TagValueLimit),
+		},
+		{
+			name:     "a 257-character value is not",
+			key:      "k",
+			value:    strings.Repeat("v", ec2TagValueLimit+1),
+			wantWhat: "value",
+			wantLen:  ec2TagValueLimit + 1,
+		},
+		{
+			// The limit has no lower bound: "You can set the value of a tag to an empty
+			// string, but you can't set the value of a tag to null." A naive
+			// len(value) > 0 && guard would refuse this.
+			name:  "an empty value is legal",
+			key:   "k",
+			value: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			instID := ec2TagTestInstance(t, ts)
+
+			status, code, message := ec2CreateTags(t, ts, instID, map[string]string{
+				"Tag.1.Key":   tc.key,
+				"Tag.1.Value": tc.value,
+			})
+
+			if tc.wantWhat != "" {
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "InvalidParameterValue", code)
+				assert.Equal(t, ec2TagLengthMessage(tc.wantWhat, map[string]int{
+					"key":   ec2TagKeyLimit,
+					"value": ec2TagValueLimit,
+				}[tc.wantWhat], tc.wantLen), message)
+				assert.Zero(t, ec2InstanceTagCount(t, ts, instID),
+					"a rejected tag must not have been applied")
+				return
+			}
+
+			require.Equal(t, http.StatusOK, status)
+			got, ok := ec2InstanceTagValue(t, ts, instID, tc.key)
+			require.True(t, ok, "the accepted tag must be readable back")
+			assert.Equal(t, tc.value, got)
+		})
+	}
+}
+
+// TestEC2_CreateTags_LengthIsCountedInRunes is the row an ASCII-only suite cannot
+// write, and the one that fails under len().
+//
+// The documented unit is "Unicode characters in UTF-8", so a key of 128 emoji is 128
+// characters — legal — and 512 bytes. A byte-counting check refuses it, and refuses it
+// while reporting a length the caller never sent. The rejected half is the mirror: 129
+// characters is over the limit however many bytes that is.
+func TestEC2_CreateTags_LengthIsCountedInRunes(t *testing.T) {
+	tests := []struct {
+		name    string
+		rune    string
+		count   int
+		reject  bool
+		wantLen int
+	}{
+		{name: "128 emoji make a legal key", rune: "\U0001F600", count: ec2TagKeyLimit},
+		{
+			name: "129 emoji do not", rune: "\U0001F600", count: ec2TagKeyLimit + 1,
+			reject: true, wantLen: ec2TagKeyLimit + 1,
+		},
+		{name: "128 three-byte runes make a legal key", rune: "あ", count: ec2TagKeyLimit},
+		{
+			name: "129 three-byte runes do not", rune: "あ", count: ec2TagKeyLimit + 1,
+			reject: true, wantLen: ec2TagKeyLimit + 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			instID := ec2TagTestInstance(t, ts)
+			key := ec2Repeat(t, tc.rune, tc.count)
+			// Stated so a reader can see that a byte count would answer differently:
+			// the fixture is over the limit in bytes even when it is legal in runes.
+			require.Greater(t, len(key), ec2TagKeyLimit,
+				"the fixture must exceed the limit in bytes, or it proves nothing")
+
+			status, code, message := ec2CreateTags(t, ts, instID, map[string]string{
+				"Tag.1.Key":   key,
+				"Tag.1.Value": "v",
+			})
+
+			if tc.reject {
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "InvalidParameterValue", code)
+				assert.Equal(t, ec2TagLengthMessage("key", ec2TagKeyLimit, tc.wantLen), message,
+					"the reported length must be in characters, not bytes")
+				return
+			}
+
+			require.Equal(t, http.StatusOK, status,
+				"%d characters is within the limit however many bytes they occupy", tc.count)
+			_, ok := ec2InstanceTagValue(t, ts, instID, key)
+			assert.True(t, ok)
+		})
+	}
+}
+
+// TestEC2_CreateTags_LongValueIsCountedInRunes is the value half of the rune count,
+// which has its own limit and its own comparison and so can be wrong independently.
+func TestEC2_CreateTags_LongValueIsCountedInRunes(t *testing.T) {
+	ts := newEC2TestServer(t)
+	instID := ec2TagTestInstance(t, ts)
+
+	value := ec2Repeat(t, "\U0001F600", ec2TagValueLimit)
+	require.Greater(t, len(value), ec2TagValueLimit)
+
+	status, _, _ := ec2CreateTags(t, ts, instID, map[string]string{
+		"Tag.1.Key":   "emoji-value",
+		"Tag.1.Value": value,
+	})
+	require.Equal(t, http.StatusOK, status, "256 characters is legal at any byte width")
+	got, ok := ec2InstanceTagValue(t, ts, instID, "emoji-value")
+	require.True(t, ok)
+	assert.Equal(t, value, got, "the value must round-trip unmangled")
+
+	status, code, message := ec2CreateTags(t, ts, instID, map[string]string{
+		"Tag.1.Key":   "emoji-value-2",
+		"Tag.1.Value": ec2Repeat(t, "\U0001F600", ec2TagValueLimit+1),
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+	assert.Equal(t, ec2TagLengthMessage("value", ec2TagValueLimit, ec2TagValueLimit+1), message)
+}
+
+// TestEC2_TagLength_ReservedKeyIsStillRefused covers the question #490 flagged as
+// needing research, and states plainly what the answer turns out to be worth.
+//
+// The research settles the code: the restrictions list scopes the reserved-key exemption
+// to the count alone — "Tags with the aws: prefix do not count against your tags per
+// resource limit" — and nothing in it exempts a reserved key from either length, so
+// ec2CheckTagLengths checks reserved keys too. That is deliberately narrower than the
+// count check sitting a few lines above it, which is why the code says so.
+//
+// What a caller can *observe*, though, is narrower still, and pretending otherwise would
+// be the wrong test. Every path runs the reserved-key check before the length check, so a
+// reserved key is always refused for being reserved and its length is never reached. The
+// exemption question therefore changes no observation substrate can produce today. This
+// test asserts the two things that are true: the request is refused, and it is refused
+// with the reserved-key error rather than a length one. Checking reserved keys' lengths
+// remains the right code — it is correct if a future path ever checks lengths alone — but
+// it is a code-clarity decision, not a behavioral one, and the CHANGELOG says that.
+//
+// The case-sensitivity row is where the length check genuinely does the work: EC2
+// documents tag keys as case-sensitive, so "AWS:" is an ordinary user tag, reaches the
+// length check, and is refused for its length.
+func TestEC2_TagLength_ReservedKeyIsStillRefused(t *testing.T) {
+	tests := []struct {
+		name        string
+		prefix      string
+		wantMessage string
+	}{
+		{
+			name:        "a reserved key is refused for being reserved, not for its length",
+			prefix:      "aws:",
+			wantMessage: ec2ReservedTagMessage,
+		},
+		{
+			// Not reserved, because the prefix match is case-sensitive — so this key is
+			// an ordinary one and the length check is what refuses it.
+			name:        "an uppercase AWS: key is ordinary and refused for its length",
+			prefix:      "AWS:",
+			wantMessage: ec2TagLengthMessage("key", ec2TagKeyLimit, ec2TagKeyLimit+4),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			instID := ec2TagTestInstance(t, ts)
+
+			key := tc.prefix + strings.Repeat("x", ec2TagKeyLimit)
+			require.Greater(t, utf8.RuneCountInString(key), ec2TagKeyLimit,
+				"the fixture must break the length limit as well as name a prefix")
+
+			status, code, message := ec2CreateTags(t, ts, instID, map[string]string{
+				"Tag.1.Key":   key,
+				"Tag.1.Value": "v",
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Equal(t, tc.wantMessage, message)
+			assert.Zero(t, ec2InstanceTagCount(t, ts, instID),
+				"the refused tag must not have been applied")
+		})
+	}
+}
+
+// TestEC2_DeleteTags_EnforcesKeyLength covers DeleteTags' asymmetry: it names keys and
+// treats the value as optional, so the key limit applies while an absent Tag.N.Value is
+// the empty string and passes the value check unremarked.
+//
+// That falls out of the check being upper-bound only rather than needing a special case,
+// and the second half of this test is what would fail if a lower bound were ever added.
+func TestEC2_DeleteTags_EnforcesKeyLength(t *testing.T) {
+	ts := newEC2TestServer(t)
+	instID := ec2TagTestInstance(t, ts)
+
+	status, _, _ := ec2CreateTags(t, ts, instID, map[string]string{
+		"Tag.1.Key":   "Env",
+		"Tag.1.Value": "prod",
+	})
+	require.Equal(t, http.StatusOK, status)
+
+	// An over-long key is refused on the delete path too.
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":       "DeleteTags",
+		"ResourceId.1": instID,
+		"Tag.1.Key":    strings.Repeat("k", ec2TagKeyLimit+1),
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+	assert.Equal(t, ec2TagLengthMessage("key", ec2TagKeyLimit, ec2TagKeyLimit+1), message)
+
+	// A key with no value at all is an ordinary delete, not a zero-length violation.
+	status, _, _ = ec2ErrorDetail(t, ts, map[string]string{
+		"Action":       "DeleteTags",
+		"ResourceId.1": instID,
+		"Tag.1.Key":    "Env",
+	})
+	require.Equal(t, http.StatusOK, status, "a value-less DeleteTags must be accepted")
+	_, ok := ec2InstanceTagValue(t, ts, instID, "Env")
+	assert.False(t, ok, "the tag must actually have been deleted")
+}
+
+// TestEC2_TagOnCreate_EnforcesLengthLimits covers the length limits on every
+// tag-on-create path, and the rollback that goes with them.
+//
+// The tagging documentation is explicit about the outcome: "If tags cannot be applied
+// during resource creation, we roll back the resource creation process. This ensures
+// that resources are either created with tags or not created at all." So each subtest
+// asserts both halves — the rejection and the absence of the resource — since a check
+// placed after the write produces the right status and the wrong state.
+func TestEC2_TagOnCreate_EnforcesLengthLimits(t *testing.T) {
+	overLongKey := strings.Repeat("k", ec2TagKeyLimit+1)
+
+	t.Run("RunInstances", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":                          "RunInstances",
+			"ImageId":                         "ami-0taglength00000001",
+			"MinCount":                        "2",
+			"MaxCount":                        "2",
+			"TagSpecification.1.ResourceType": "instance",
+			"TagSpecification.1.Tag.1.Key":    "Env",
+			"TagSpecification.1.Tag.1.Value":  "prod",
+			"TagSpecification.1.Tag.2.Key":    overLongKey,
+			"TagSpecification.1.Tag.2.Value":  "v",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Equal(t, ec2TagLengthMessage("key", ec2TagKeyLimit, ec2TagKeyLimit+1), message)
+		assert.Zero(t, ec2InstanceCount(t, ts),
+			"a launch rejected for tag length must not create an instance")
+	})
+
+	t.Run("CreateImage", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		instID := ec2TagTestInstance(t, ts)
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":                          "CreateImage",
+			"InstanceId":                      instID,
+			"Name":                            "over-long-tag-ami",
+			"TagSpecification.1.ResourceType": "image",
+			"TagSpecification.1.Tag.1.Key":    overLongKey,
+			"TagSpecification.1.Tag.1.Value":  "v",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+
+		var images struct {
+			Images []struct {
+				ImageID string `xml:"imageId"`
+			} `xml:"imagesSet>item"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "DescribeImages"}, &images)
+		assert.Empty(t, images.Images, "a rejected CreateImage must not create an AMI")
+	})
+
+	t.Run("CreateImage snapshot scope", func(t *testing.T) {
+		// The snapshot scope is checked separately from the image scope, so it can be
+		// missed independently — as it was before #468 routed both through the shared
+		// parser.
+		ts := newEC2TestServer(t)
+		instID := ec2TagTestInstance(t, ts)
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":                          "CreateImage",
+			"InstanceId":                      instID,
+			"Name":                            "over-long-snapshot-tag-ami",
+			"TagSpecification.1.ResourceType": "snapshot",
+			"TagSpecification.1.Tag.1.Key":    overLongKey,
+			"TagSpecification.1.Tag.1.Value":  "v",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+	})
+
+	t.Run("CreateNatGateway", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		subnetID := ec2TagTestSubnet(t, ts)
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":                          "CreateNatGateway",
+			"SubnetId":                        subnetID,
+			"ConnectivityType":                "private",
+			"TagSpecification.1.ResourceType": "natgateway",
+			"TagSpecification.1.Tag.1.Key":    overLongKey,
+			"TagSpecification.1.Tag.1.Value":  "v",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+
+		var gws struct {
+			Gateways []struct {
+				NatGatewayID string `xml:"natGatewayId"`
+			} `xml:"natGatewaySet>item"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "DescribeNatGateways"}, &gws)
+		assert.Empty(t, gws.Gateways, "a rejected CreateNatGateway must not create a gateway")
+	})
+
+	t.Run("CreateFleet", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		ltID := newFleetLaunchTemplate(t, ts, "tag-length-fleet")
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action": "CreateFleet",
+			"Type":   "instant",
+			"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+			"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+			"TagSpecification.1.ResourceType":                                      "instance",
+			"TagSpecification.1.Tag.1.Key":                                         overLongKey,
+			"TagSpecification.1.Tag.1.Value":                                       "v",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Zero(t, ec2InstanceCount(t, ts),
+			"a rejected fleet must not launch an instance")
+	})
+
+	t.Run("CreateFleet fleet scope", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		ltID := newFleetLaunchTemplate(t, ts, "tag-length-fleet-scope")
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action": "CreateFleet",
+			"Type":   "instant",
+			"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+			"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+			"TagSpecification.1.ResourceType":                                      "fleet",
+			"TagSpecification.1.Tag.1.Key":                                         "Owner",
+			"TagSpecification.1.Tag.1.Value":                                       strings.Repeat("v", ec2TagValueLimit+1),
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Zero(t, ec2InstanceCount(t, ts))
+	})
+}
+
+// TestEC2_LaunchTemplate_EnforcesTagLengthAtCreation covers the template paths, where
+// the check earns its place twice over: refusing at CreateLaunchTemplate means a
+// consumer learns about the over-long tag once, at the operation that named it, rather
+// than at every launch that references the template (#471's precedent).
+func TestEC2_LaunchTemplate_EnforcesTagLengthAtCreation(t *testing.T) {
+	overLongKey := strings.Repeat("k", ec2TagKeyLimit+1)
+
+	t.Run("CreateLaunchTemplate", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		params := map[string]string{
+			"Action":                     "CreateLaunchTemplate",
+			"LaunchTemplateName":         "over-long-tag",
+			"LaunchTemplateData.ImageId": "ami-0lttaglength00001",
+		}
+		for k, v := range ltTagParams([2]string{overLongKey, "v"}) {
+			params[k] = v
+		}
+		status, code, message := ec2ErrorDetail(t, ts, params)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Equal(t, ec2TagLengthMessage("key", ec2TagKeyLimit, ec2TagKeyLimit+1), message)
+
+		// And the template itself was not created, so a second attempt does not collide
+		// with a half-made one.
+		var out struct {
+			Templates []struct {
+				LaunchTemplateID string `xml:"launchTemplateId"`
+			} `xml:"launchTemplates>item"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "DescribeLaunchTemplates"}, &out)
+		assert.Empty(t, out.Templates, "a rejected CreateLaunchTemplate must create nothing")
+	})
+
+	t.Run("CreateLaunchTemplateVersion", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		ltID := createLaunchTemplate(t, ts, "version-tag-length", map[string]string{
+			"LaunchTemplateData.ImageId": "ami-0lttaglength00002",
+		})
+
+		params := map[string]string{
+			"Action":                     "CreateLaunchTemplateVersion",
+			"LaunchTemplateId":           ltID,
+			"LaunchTemplateData.ImageId": "ami-0lttaglength00003",
+		}
+		for k, v := range ltTagParams([2]string{"Env", strings.Repeat("v", ec2TagValueLimit+1)}) {
+			params[k] = v
+		}
+		status, code, message := ec2ErrorDetail(t, ts, params)
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Equal(t, ec2TagLengthMessage("value", ec2TagValueLimit, ec2TagValueLimit+1), message)
+
+		// Version 1 is still the latest: the rejected version was not appended.
+		assert.Equal(t, int64(1), describeLT(t, ts, ltID).LatestVersionNum)
+	})
+
+	t.Run("a legal template still launches with its tags", func(t *testing.T) {
+		// The regression guard on the check's placement: it must refuse the over-long
+		// case without refusing the ordinary one, which is what a mis-scoped comparison
+		// would do.
+		ts := newEC2TestServer(t)
+		data := map[string]string{"LaunchTemplateData.ImageId": "ami-0lttaglength00004"}
+		for k, v := range ltTagParams([2]string{
+			strings.Repeat("k", ec2TagKeyLimit),
+			strings.Repeat("v", ec2TagValueLimit),
+		}) {
+			data[k] = v
+		}
+		ltID := createLaunchTemplate(t, ts, "at-the-limit", data)
+
+		ids := ec2RunInstanceIDs(t, ts, map[string]string{
+			"Action":                          "RunInstances",
+			"LaunchTemplate.LaunchTemplateId": ltID,
+			"MinCount":                        "1",
+			"MaxCount":                        "1",
+		})
+		require.Len(t, ids, 1)
+		value, ok := ec2InstanceTagValue(t, ts, ids[0], strings.Repeat("k", ec2TagKeyLimit))
+		require.True(t, ok, "a tag exactly at both limits must survive the launch")
+		assert.Equal(t, strings.Repeat("v", ec2TagValueLimit), value)
+	})
 }


### PR DESCRIPTION
Closes #490

A tag key longer than **128 characters** or a value longer than **256** was accepted on every path substrate offers: `CreateTags`, `DeleteTags`, and tag-on-create through `RunInstances`, `CreateFleet`, `CreateImage`, `CreateNatGateway` and a launch template. This was the third restriction in the same table #469 read for the 50-tag count, and the only one left unenforced — so a consumer generating tag values from a resource description or a git ref (the case that actually overruns 256 characters) had no way to reach real EC2's rejection, and a test asserting it passed against substrate while the same code failed against AWS. The tracker's recurring shape: substrate returns success where real AWS refuses, so the error branch is unreachable.

The rejection is `InvalidParameterValue`, HTTP 400, naming which limit was exceeded and by how much.

## The unit is Unicode characters, not bytes

From the restrictions list: "Maximum key length – 128 Unicode characters in UTF-8" and "Maximum value length – 256 Unicode characters in UTF-8". So the check counts runes. A key of 128 emoji is 128 characters and 512 bytes, and it is **legal**; a byte-counting check refuses it, and refuses it while reporting a length the caller never sent. The two counts agree on ASCII, which is why an ASCII-only suite cannot tell them apart — hence emoji and three-byte rows in the tests, and an assertion in the fixture builder that it built the intended number of *runes*.

There is no lower bound — "You can set the value of a tag to an empty string, but you can't set the value of a tag to null" — so the check is upper-bound only. That is also what makes `DeleteTags` right without a special case: it names keys and treats the value as optional, so an absent `Tag.N.Value` is the empty string and passes.

## Reserved keys, and being precise about what the answer buys

#490 flagged as needing research whether the `aws:` exemption extends to length. It does not: the exemption in the restrictions list is scoped to the count alone ("Tags with the `aws:` prefix do not count against your **tags per resource limit**") and nothing in it exempts a reserved key from either length. So `ec2CheckTagLengths` checks reserved keys, deliberately narrower than `ec2CheckTagLimit` sitting a few lines above it.

Worth being exact about what that decides, because I nearly shipped a test asserting more than is true: `ec2CheckTagLengths` has exactly one non-test caller, `ec2CheckTagRules`, which runs the reserved-key check first and returns on its error. **No API path can reach the length check with a reserved key**, so the choice changes no wire behaviour today. It is the right code for any future path that checks lengths alone, and it is recorded because the adjacent count check does the opposite — but it is a clarity decision, not a behavioural one, and the comment, the docs and the CHANGELOG all say so rather than implying a fidelity gain that isn't there. Where the length check does bite is the case-sensitive edge: `AWS:` is an ordinary user tag, so an over-long `AWS:`-prefixed key is refused for its length, and that row is tested.

## Rollback, and one refactor

As with the other two restrictions, the whole request is refused before anything is modified, and on a tag-on-create path before the resource exists — per "If tags cannot be applied during resource creation, we roll back the resource creation process." A refused `RunInstances` launches no instance, a refused `CreateImage` creates neither the AMI nor its snapshot, a refused `CreateNatGateway` creates no gateway, and a refused `CreateLaunchTemplate` creates no template. A launch template is checked at creation and at each version as well as at every launch that names it, following #471, so an over-long template tag is reported once at the operation that named it.

The nine call sites that had to be found by hand for this fix now go through one `ec2CheckTagRules`, so the next restriction is added in one place instead of nine.

## Provenance

The weakest of the three tag restrictions, and marked as such in the code, the docs and the CHANGELOG. The **code** `InvalidParameterValue` with HTTP 400 is by analogy with the reserved-key rejection — the other tag-restriction violation on the same operations, and `CreateTags`' Errors section is empty so the API model supplies nothing. The **message text is substrate's own**: no captured real-AWS length rejection was found, in moto or LocalStack either. It interpolates the limit and the actual length following `sqsMessageTooLong`'s precedent, because the message is the only place a caller learns which limit they hit. Dispatch on the code.

## Tests

Seven new tests in `emulator/ec2_tags_test.go`: adjacent boundaries (128 accepted / 129 refused, 256 / 257), the emoji and three-byte rune rows, the empty value, the reserved-vs-`AWS:` pair, `DeleteTags`' key-only asymmetry including a value-less delete that actually deletes, all six tag-on-create paths asserting both the rejection and the absent resource, and the two launch-template paths plus a template exactly at both limits that still launches with its tags.

## Verification

From the repo root: `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` **0 issues**, `make test` (race) green, `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go test -C test/e2e ./...`.

Mutation-tested with 30 mutations: **29 caught, 1 proven equivalent**. The equivalent one is "exempt reserved keys from the length check" — unreachable by construction for the reason above, which is why the harness has an `EQUIVALENT` category requiring a proof rather than reporting a bare survivor. Caught includes both of the plan's highest-value mutations (count bytes instead of runes, for key and value separately), every off-by-one in both directions, adding a lower bound, reordering the two checks, and dropping the check at each of the nine call sites individually.

End-to-end through the AWS CLI against `substrate server`:

```
create-tags Key=<129 chars>  → InvalidParameterValue: … the supplied key is 129
create-tags Key=<128 chars>  → accepted
create-tags Key=<128 emoji>  → accepted        (512 bytes, 128 characters)
create-tags Key=<129 emoji>  → refused, "the supplied key is 129"   (not 516)
create-tags Value=<257>      → InvalidParameterValue: … the supplied value is 257
run-instances --tag-specifications Key=<129 chars>
                             → refused, and the instance count is unchanged
```

The emoji line is the one that matters: the reported length is in characters, so it fails under `len`.
