### PR TITLE
feat(s3): record the server-side-encryption headers and echo them (#492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   following the `SendMessage` size-limit message's precedent, because the message is
   the only place a caller learns which limit they hit. Dispatch on the code.
 
+- **S3 records the server-side-encryption headers and echoes them on every read**
+  (#492). `x-amz-server-side-encryption`,
+  `x-amz-server-side-encryption-aws-kms-key-id` and
+  `x-amz-server-side-encryption-bucket-key-enabled` are recorded on `PutObject` and
+  `CreateMultipartUpload`, and returned on those responses plus `GetObject`,
+  `HeadObject` and `CompleteMultipartUpload`. Substrate previously accepted them and
+  discarded them, so an object written with encryption read back byte-identical to one
+  written without it: a consumer could only assert on what their own request carried,
+  which verifies the line that filled in the request and nothing about the stored
+  object. Every such request assertion is now a stored-object assertion.
+
+  **No cryptography is performed** — the body is stored exactly as it arrived.
+  Encryption at rest is not observable through an API call, but the encryption S3
+  *reports* for an object is, and that report is the assertion a consumer is making.
+
+  An absent header stays **absent on the response, not `false` or empty**, so "no
+  encryption named" remains distinguishable from "encryption named" — the property
+  that makes recording worth anything. That is also why bucket default encryption is
+  deliberately not modelled here: real S3 has applied SSE-S3 unconditionally since
+  January 2023, so adding the default would erase the distinction, and it belongs with
+  the rest of the resolution rules in #493.
+
+  **The KMS key ID round-trips verbatim, as a stated divergence.** Real S3 resolves any
+  of the four accepted forms — a bare UUID, `alias/name`, a key ARN, an alias ARN — to
+  the key ARN before reporting it. Substrate returns the string that was sent, because
+  that is the string the consumer's configuration produced and therefore the assertion
+  they are trying to make; #475's reporter confirms their tests assert the sent form.
+  The difference is observable and documented, so modelling key resolution later has to
+  revisit it rather than silently overtake it.
+
+  Encryption on a multipart upload is fixed at `CreateMultipartUpload` and carried onto
+  the assembled object, because Complete's request accepts only the SSE-C headers.
+  The family is one embedded declaration shared by the object and upload records, so
+  the two write paths cannot drift the way #406's did.
+
+  Nothing is validated, and `CopyObject` records no encryption at all rather than
+  inheriting the source's — both deliberate, both pinned by tests so #493 changes them
+  on purpose. #493 carries the four `InvalidArgument` rejections, bucket defaults, and
+  the copy resolution order. SSE-C is out of scope entirely.
+
 ## [v0.86.0] - 2026-08-02
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -369,16 +369,16 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers; `Cache-Control`, `Content-Disposition`, `Content-Language`, `Expires` — see [Object system metadata](#object-system-metadata); `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums) |
-| GetObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); synthesizes a seedable task-completion record — see [Task-completion records](#task-completion-records) |
-| HeadObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); resolves a synthesized task-completion record exactly as `GetObject` does — see [Task-completion records](#task-completion-records) |
+| PutObject | Supports Content-Type, metadata headers; `Cache-Control`, `Content-Disposition`, `Content-Language`, `Expires` — see [Object system metadata](#object-system-metadata); `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums); records the `x-amz-server-side-encryption` family — see [Server-side encryption](#server-side-encryption) |
+| GetObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); synthesizes a seedable task-completion record — see [Task-completion records](#task-completion-records); echoes recorded encryption — see [Server-side encryption](#server-side-encryption) |
+| HeadObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); resolves a synthesized task-completion record exactly as `GetObject` does — see [Task-completion records](#task-completion-records); echoes recorded encryption — see [Server-side encryption](#server-side-encryption) |
 | DeleteObject | Fires S3 notifications if configured |
-| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums) |
+| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums); records **no** encryption, deliberately — see [Server-side encryption](#server-side-encryption) |
 | ListObjects | Emits `<StorageClass>` per object |
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
-| CreateMultipartUpload | Accepts `x-amz-storage-class` and the [system-metadata family](#object-system-metadata), applied to the assembled object; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums) |
+| CreateMultipartUpload | Accepts `x-amz-storage-class` and the [system-metadata family](#object-system-metadata), applied to the assembled object; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums); records the encryption for the whole upload — see [Server-side encryption](#server-side-encryption) |
 | UploadPart | Verifies the part checksum, including a trailing one — see [Additional checksums](#additional-checksums) |
-| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums) |
+| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums); reports the upload's recorded encryption — see [Server-side encryption](#server-side-encryption) |
 | AbortMultipartUpload | |
 | ListMultipartUploads | Emits `<StorageClass>` per in-progress upload |
 | GetBucketPolicy | |
@@ -508,6 +508,67 @@ consumer's parse-failure branch unreachable.
 metadata too, but each has resolution rules of its own — a default of
 `application/octet-stream`, `aws-chunked` filtering, and a `STANDARD`-means-absent
 read rule — so they are documented in their own sections above.
+
+### Server-side encryption
+
+Three headers are recorded on write and returned on every read:
+
+| Header | Recorded | Echoed |
+|---|---|---|
+| `x-amz-server-side-encryption` | Verbatim — `AES256`, `aws:fsx`, `aws:kms`, `aws:kms:dsse`, or any other token | Whenever set |
+| `x-amz-server-side-encryption-aws-kms-key-id` | Verbatim, in whichever form was sent | Only alongside an algorithm, and only when a key was named |
+| `x-amz-server-side-encryption-bucket-key-enabled` | As a boolean; only `true` (any case) enables it | Only when enabled |
+
+**No cryptography is performed.** The object body is stored exactly as it arrived.
+Encryption at rest is not observable through an API call, but *the encryption S3
+reports for an object* is — and that report is the assertion a consumer is making.
+Substrate previously accepted these headers and discarded them, so an object written
+with encryption read back byte-identical to one written without it: a test could only
+assert on what its own request carried, which proves the line that filled in the
+request and nothing about the stored object.
+
+They are recorded on `PutObject` and on `CreateMultipartUpload`, and echoed on those
+two responses plus `GetObject`, `HeadObject` and `CompleteMultipartUpload`.
+`CreateMultipartUpload` is the only place a multipart upload's encryption can be
+supplied — Complete's request accepts only the SSE-C headers — so it is fixed for the
+whole upload at creation and carried onto the assembled object.
+
+An absent header is **absent on the response, not `false` or empty**. A write that
+never mentioned the bucket-key header produces no bucket-key header, since an SDK
+distinguishing a nil `*bool` from a `false` one would otherwise report the wrong
+answer. The same rule keeps "no encryption named" distinguishable from "encryption
+named", which is the observation that makes recording worth anything.
+
+**The KMS key ID round-trips verbatim, which is a deliberate divergence.** KMS accepts
+four forms — a bare UUID, `alias/name`, a key ARN and an alias ARN — and real S3
+resolves any of them to the key ARN before reporting it. Substrate returns the string
+the caller sent, because that is the string the consumer's configuration produced and
+therefore the assertion they are trying to make. Resolving it would mean modeling KMS
+aliases and cross-account ARNs to answer a question no consumer has asked. The
+difference is observable: if key resolution is ever modeled, this decision has to be
+revisited rather than silently overtaken.
+
+Nothing is validated. A key ID sent with `AES256`, a bucket-key flag without
+`aws:kms`, and an unrecognized algorithm token are all accepted and recorded, where
+real S3 answers `400 InvalidArgument`; `UploadPart` restating an encryption header is
+likewise accepted rather than refused. Those four rejections are
+[#493](https://github.com/scttfrdmn/substrate/issues/493).
+
+Also out of scope there, and worth knowing before relying on this:
+
+- **Bucket default encryption.** `PutBucketEncryption` and its siblings are not
+  modeled, so a write naming no encryption records none. Real S3 has applied SSE-S3 to
+  every new object unconditionally since January 2023, so a real bucket never stores an
+  unencrypted object — modeling that default would remove the absent-versus-set
+  distinction above, which is why it is a deliberate decision rather than a side effect.
+- **`CopyObject` records no encryption at all.** A copy's encryption comes from the
+  request and, failing that, from the bucket default — never from the source. Neither
+  exists yet, so substrate reports none for a copy rather than inheriting the source's.
+  That is a stated gap, not a wrong answer: silently inheriting would hide exactly the
+  bug this half exists to expose, where an in-place metadata copy or a storage-tier
+  transition moves an SSE-KMS object off its customer managed key.
+- **SSE-C** (`x-amz-server-side-encryption-customer-*`) is out of scope entirely; its
+  key material would have to be discarded rather than recorded.
 
 ### Copying objects
 

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -536,23 +536,28 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 	}
 
 	obj := S3Object{
-		Bucket:           bucket,
-		Key:              key,
-		ETag:             etag,
-		ContentType:      contentType,
-		ContentEncoding:  s3PersistedContentEncoding(req.Headers),
-		S3SystemMetadata: resolveSystemMetadata(req.Headers),
-		Size:             int64(len(body)),
-		StorageClass:     storageClass,
-		Checksum:         checksum,
-		LastModified:     p.tc.Now(),
-		UserMetadata:     userMeta,
+		Bucket:                 bucket,
+		Key:                    key,
+		ETag:                   etag,
+		ContentType:            contentType,
+		ContentEncoding:        s3PersistedContentEncoding(req.Headers),
+		S3SystemMetadata:       resolveSystemMetadata(req.Headers),
+		S3ServerSideEncryption: resolveServerSideEncryption(req.Headers),
+		Size:                   int64(len(body)),
+		StorageClass:           storageClass,
+		Checksum:               checksum,
+		LastModified:           p.tc.Now(),
+		UserMetadata:           userMeta,
 	}
 
 	respHeaders := map[string]string{"ETag": etag}
 	// PutObject echoes the checksum unconditionally — checksum-mode gates the read
 	// path, not the write. A single-part PUT is always a full-object checksum.
 	applyChecksumHeaders(respHeaders, checksum, true)
+	// PutObject reports the encryption it recorded, the same values GetObject and
+	// HeadObject will echo — S3 documents all three headers in this response too, and a
+	// consumer that asserts on the PUT rather than a follow-up read must see them.
+	obj.emitSSE(respHeaders)
 
 	// If versioning is enabled, generate a version ID and store the versioned copy.
 	versioningStatus := p.getBucketVersioningStatus(ctx, bucket)
@@ -1074,7 +1079,14 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 		ContentType:      meta.ContentType,
 		ContentEncoding:  meta.ContentEncoding,
 		S3SystemMetadata: meta.System,
-		Size:             srcObj.Size,
+		// S3ServerSideEncryption is deliberately left zero, and the omission is named
+		// rather than silent: a copy's encryption comes from the request and, failing
+		// that, from the bucket default — never from the source (#493). Recording the
+		// request's headers here without that default would decide half of a resolution
+		// order whose other half does not exist yet, so a copy records no encryption at
+		// all for now, and the emulator reports none rather than guessing. There is a
+		// test pinning this, so #493 changes it deliberately.
+		Size: srcObj.Size,
 		// The copy's class comes from the request, never from the source: "if the
 		// x-amz-storage-class header is not used, the copied object will be stored in
 		// the STANDARD Storage Class by default."
@@ -1338,17 +1350,18 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 	}
 
 	upload := S3MultipartUpload{
-		UploadID:          uploadID,
-		Bucket:            bucket,
-		Key:               key,
-		ContentType:       contentType,
-		ContentEncoding:   s3PersistedContentEncoding(req.Headers),
-		S3SystemMetadata:  resolveSystemMetadata(req.Headers),
-		StorageClass:      storageClass,
-		ChecksumAlgorithm: checksumAlgorithm,
-		ChecksumType:      checksumType,
-		Initiated:         p.tc.Now(),
-		UserMetadata:      extractUserMetadata(req.Headers),
+		UploadID:               uploadID,
+		Bucket:                 bucket,
+		Key:                    key,
+		ContentType:            contentType,
+		ContentEncoding:        s3PersistedContentEncoding(req.Headers),
+		S3SystemMetadata:       resolveSystemMetadata(req.Headers),
+		S3ServerSideEncryption: resolveServerSideEncryption(req.Headers),
+		StorageClass:           storageClass,
+		ChecksumAlgorithm:      checksumAlgorithm,
+		ChecksumType:           checksumType,
+		Initiated:              p.tc.Now(),
+		UserMetadata:           extractUserMetadata(req.Headers),
 	}
 
 	data, err := json.Marshal(upload)
@@ -1379,6 +1392,10 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		resp.Headers["x-amz-checksum-algorithm"] = checksumAlgorithm
 		resp.Headers["x-amz-checksum-type"] = checksumType
 	}
+	// The encryption family is echoed for the same reason, and it matters more here:
+	// Complete's request accepts no SSE-S3/KMS header, so this response is the caller's
+	// only chance to confirm the encryption every part will be stored under.
+	upload.emitSSE(resp.Headers)
 	return resp, nil
 }
 
@@ -1601,11 +1618,15 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		// embed the same declaration. A header added to S3SystemMetadata is carried
 		// here without touching this line — which is the point of embedding it.
 		S3SystemMetadata: upload.S3SystemMetadata,
-		Size:             int64(len(combined)),
-		StorageClass:     upload.StorageClass,
-		Checksum:         checksum,
-		LastModified:     p.tc.Now(),
-		UserMetadata:     upload.UserMetadata,
+		// The encryption family crosses the same way, for the same reason. Complete's
+		// request carries no SSE-S3/KMS header to read, so what the create recorded is
+		// the only thing the assembled object can be encrypted under.
+		S3ServerSideEncryption: upload.S3ServerSideEncryption,
+		Size:                   int64(len(combined)),
+		StorageClass:           upload.StorageClass,
+		Checksum:               checksum,
+		LastModified:           p.tc.Now(),
+		UserMetadata:           upload.UserMetadata,
 	}
 	objData, err := json.Marshal(obj)
 	if err != nil {
@@ -1633,7 +1654,7 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		Checksum     []s3ChecksumXML `xml:",any"`
 		ChecksumType string          `xml:"ChecksumType,omitempty"`
 	}
-	return s3XMLResponse(http.StatusOK, completeMultipartUploadResult{
+	resp, err := s3XMLResponse(http.StatusOK, completeMultipartUploadResult{
 		Location:     "https://s3.amazonaws.com/" + bucket + "/" + key,
 		Bucket:       bucket,
 		Key:          key,
@@ -1641,6 +1662,14 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		Checksum:     checksumXMLElements(checksum),
 		ChecksumType: checksum.Type,
 	})
+	if err != nil {
+		return nil, err
+	}
+	// The encryption family *is* returned as headers here, unlike the checksum on the
+	// line above: S3 documents all three SSE headers in Complete's response syntax, and
+	// only the checksum moved into the body.
+	obj.emitSSE(resp.Headers)
+	return resp, nil
 }
 
 // validateCompleteParts resolves each part named in a CompleteMultipartUpload
@@ -2238,6 +2267,10 @@ func objectResponseHeaders(obj *S3Object) map[string]string {
 	// only when the object carries it: S3 returns no header for metadata that was
 	// never set, and an empty value is a different observation from an absent one.
 	obj.emit(headers)
+	// The server-side-encryption family, on the same terms. Emitted here rather than in
+	// the two handlers because this function is the single place both GetObject and
+	// HeadObject build their headers, and S3 reports encryption identically on each.
+	obj.emitSSE(headers)
 	if obj.VersionID != "" {
 		headers["x-amz-version-id"] = obj.VersionID
 	}

--- a/emulator/s3_sse.go
+++ b/emulator/s3_sse.go
@@ -1,0 +1,149 @@
+package emulator
+
+import "strings"
+
+// The three server-side-encryption headers substrate records. Named as constants
+// because each is read on a write path and written on a read path, and a typo in one
+// of the two halves would produce a header that is recorded and never echoed —
+// silently, since an absent SSE header is a legal observation.
+const (
+	s3SSEAlgorithmHeader        = "x-amz-server-side-encryption"
+	s3SSEKMSKeyIDHeader         = "x-amz-server-side-encryption-aws-kms-key-id"
+	s3SSEBucketKeyEnabledHeader = "x-amz-server-side-encryption-bucket-key-enabled"
+)
+
+// s3SSEBucketKeyEnabledValue is the only value that enables an S3 Bucket Key. The
+// header is a boolean, and S3 documents no meaning for any other token: "Setting this
+// header to true causes Amazon S3 to use an S3 Bucket Key for object encryption with
+// SSE-KMS". Substrate treats anything else as not-enabled and records nothing;
+// rejecting a malformed token is one of #493's four validations.
+const s3SSEBucketKeyEnabledValue = "true"
+
+// S3ServerSideEncryption holds the server-side-encryption headers S3 records on an
+// object and returns on every read: x-amz-server-side-encryption, the KMS key ID, and
+// the S3 Bucket Key flag (#492).
+//
+// **No cryptography is performed.** Substrate records what the request asked for and
+// echoes it back; the object body is stored exactly as it arrived. That is the whole
+// of the model, and it is the right boundary: encryption at rest is not observable
+// through an API call, but *the encryption S3 reports for an object* is — and that
+// report is the assertion a consumer is trying to make. With SSE unmodeled an object
+// written with the header read back byte-identical to one written without it, so a
+// test could only assert on what the request carried, which is one inference away
+// from the defect #475 was filed for.
+//
+// It is embedded in both [S3Object] and [S3MultipartUpload] rather than declared
+// twice, following [S3SystemMetadata] for the same reason: the two write paths cannot
+// disagree about a family declared once. #406 was exactly that divergence for
+// Content-Encoding, and CompleteMultipartUpload copies the whole struct in one
+// assignment, so a field added here is carried by both paths or by neither.
+//
+// Deliberately *not* in [S3SystemMetadata], though it would fit the shape: that family
+// is defined by being recorded verbatim and echoed verbatim with no rules of its own,
+// and SSE has resolution rules coming in #493 — a bucket default, a CopyObject
+// asymmetry, and four rejected combinations. Content-Type and the storage class stayed
+// out for the same reason. #475 raised the question explicitly; this is the answer.
+//
+// Out of scope here, all of it #493: bucket default encryption, CopyObject's
+// non-inheritance of the source's encryption, and the invalid-combination 400s. SSE-C
+// (x-amz-server-side-encryption-customer-*) is out of scope entirely — no consumer has
+// asked for it, and its key material would have to be discarded rather than recorded.
+type S3ServerSideEncryption struct {
+	// Algorithm is the x-amz-server-side-encryption value recorded on write and
+	// echoed on read — AES256 for SSE-S3, aws:kms for SSE-KMS. Empty when the write
+	// named no encryption, which stays a distinct observation from any value: see
+	// [S3ServerSideEncryption.emitSSE].
+	//
+	// Recorded verbatim and not validated against the documented set
+	// (AES256, aws:fsx, aws:kms, aws:kms:dsse); rejecting an unrecognized token is
+	// #493's.
+	Algorithm string `json:"sse_algorithm,omitempty"`
+
+	// KMSKeyID is the x-amz-server-side-encryption-aws-kms-key-id value, recorded and
+	// echoed **verbatim**.
+	//
+	// This is a deliberate divergence from real S3, which echoes the *resolved key
+	// ARN* regardless of which of the accepted forms was sent — the header takes a
+	// "Key ID, Key ARN, or Key Alias". Substrate echoes the string the caller sent,
+	// because that is the string the consumer's configuration produced and therefore
+	// the one their assertion is about; #475's reporter confirms their tests assert
+	// the sent form. Resolving it would require modeling KMS key aliases and
+	// cross-account ARNs to answer a question no consumer asked.
+	//
+	// The divergence is observable and is documented in docs/services.md beside the
+	// behavior, in the same spirit as the CopyObject MetadataDirective asymmetry in
+	// s3_copy_metadata.go. If key resolution is ever modeled, this decision has to
+	// be revisited rather than silently overtaken.
+	//
+	// Recorded whatever the algorithm is, including the AES256 combination real S3
+	// rejects with InvalidArgument — that rejection is #493's, and recording keeps the
+	// value observable until it exists.
+	KMSKeyID string `json:"sse_kms_key_id,omitempty"`
+
+	// BucketKeyEnabled is true when the write set
+	// x-amz-server-side-encryption-bucket-key-enabled to [s3SSEBucketKeyEnabledValue].
+	//
+	// A bool rather than a string because only the enabled case is echoed, so the
+	// three states a string would carry — "true", "false", absent — collapse to two
+	// observations on the wire. See [S3ServerSideEncryption.emitSSE].
+	BucketKeyEnabled bool `json:"sse_bucket_key_enabled,omitempty"`
+}
+
+// resolveServerSideEncryption reads the encryption family from request headers.
+//
+// Headers are matched case-insensitively via [headerValueFold], like every other
+// header the S3 plugin reads: an [AWSRequest] reaching a plugin has not always been
+// through net/http's canonicalization, since substrate builds requests in-process too
+// (see betty_cfn.go), and RFC 9110 header names are case-insensitive regardless.
+//
+// The header *values* are not folded. An algorithm token and a KMS key ID are both
+// case-sensitive identifiers — aws:kms and AWS:KMS are not the same token, and a KMS
+// alias is case-sensitive — so normalizing either would corrupt the verbatim
+// round-trip [S3ServerSideEncryption.KMSKeyID] exists to provide.
+//
+// The Bucket Key flag is the exception, being a boolean rather than an identifier: its
+// value is compared case-insensitively, the way s3ChecksumModeEnabled reads
+// x-amz-checksum-mode.
+func resolveServerSideEncryption(headers map[string]string) S3ServerSideEncryption {
+	bucketKey := headerValueFold(headers, s3SSEBucketKeyEnabledHeader)
+	return S3ServerSideEncryption{
+		Algorithm:        headerValueFold(headers, s3SSEAlgorithmHeader),
+		KMSKeyID:         headerValueFold(headers, s3SSEKMSKeyIDHeader),
+		BucketKeyEnabled: strings.EqualFold(bucketKey, s3SSEBucketKeyEnabledValue),
+	}
+}
+
+// emitSSE adds the recorded encryption headers to a response header map, skipping
+// the ones the object does not carry.
+//
+// Named emitSSE rather than emit because [S3Object] embeds this struct alongside
+// [S3SystemMetadata], and two embedded types with a method of the same name at the
+// same depth make the selector ambiguous.
+//
+// Every header is conditional, and each condition is a distinct observation rather
+// than a tidiness measure:
+//
+//   - No algorithm means no header. An object written without SSE must read back with
+//     none, so "no header sent" stays distinguishable from "header sent" — the
+//     property that makes recording worth anything at all. Real S3 has applied SSE-S3
+//     to every new object unconditionally since January 2023, so a real bucket never
+//     stores one; modeling that default is #493's item and would remove this
+//     distinction, which is why it is #493's decision to make deliberately.
+//   - An empty KMS key ID means no header, matching S3's own "if present, indicates
+//     the ID of the KMS key that was used for object encryption" — an SSE-KMS write
+//     that named no key gets the AWS managed key and no ID to report.
+//   - The Bucket Key header appears only when it was enabled. Absent and false are
+//     different observations, and an SDK that distinguishes a nil *bool from a false
+//     one would otherwise report the wrong answer for a write that never mentioned it.
+func (e *S3ServerSideEncryption) emitSSE(dst map[string]string) {
+	if e.Algorithm == "" {
+		return
+	}
+	dst[s3SSEAlgorithmHeader] = e.Algorithm
+	if e.KMSKeyID != "" {
+		dst[s3SSEKMSKeyIDHeader] = e.KMSKeyID
+	}
+	if e.BucketKeyEnabled {
+		dst[s3SSEBucketKeyEnabledHeader] = s3SSEBucketKeyEnabledValue
+	}
+}

--- a/emulator/s3_sse_test.go
+++ b/emulator/s3_sse_test.go
@@ -1,0 +1,455 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The three headers under test (#492), named here so a test asserts on the same
+// strings the plugin emits rather than on a retyped copy of them.
+const (
+	sseAlgorithmHeader = "x-amz-server-side-encryption"
+	sseKeyIDHeader     = "x-amz-server-side-encryption-aws-kms-key-id"
+	sseBucketKeyHeader = "x-amz-server-side-encryption-bucket-key-enabled"
+)
+
+// assertNoSSE asserts the response carries none of the family. Absence is checked on
+// the header map rather than through Get, because Get cannot tell an absent header
+// from an empty one and "no encryption" versus "encryption with an empty value" is
+// exactly the distinction #492's fourth criterion exists to preserve.
+func assertNoSSE(t *testing.T, got http.Header, context string) {
+	t.Helper()
+	for _, h := range []string{sseAlgorithmHeader, sseKeyIDHeader, sseBucketKeyHeader} {
+		_, present := got[http.CanonicalHeaderKey(h)]
+		assert.False(t, present, "%s: %s must be absent, not empty", context, h)
+	}
+}
+
+// getStoredObject reads an object's stored metadata straight out of the state store,
+// bypassing every response path.
+//
+// This is what makes the storage criterion an actual assertion: a header round-trip
+// passes if the plugin echoes the request it was handed, whether or not anything was
+// persisted. The namespace literal is "s3" because s3Namespace is unexported, and the
+// key layout matches what putObject writes.
+func getStoredObject(t *testing.T, state emulator.StateManager, bucket, key string) emulator.S3Object {
+	t.Helper()
+	data, err := state.Get(t.Context(), "s3", "object:"+bucket+"/"+key)
+	require.NoError(t, err)
+	var obj emulator.S3Object
+	require.NoError(t, json.Unmarshal(data, &obj))
+	return obj
+}
+
+// TestS3_SSE_PutObjectRoundTrip asserts SSE-S3 recorded on a write is echoed by both
+// reads. Substrate previously accepted these headers and discarded them, so an object
+// written with encryption read back byte-identical to one written without it and a
+// consumer could only assert on what their own request carried (#492).
+func TestS3_SSE_PutObjectRoundTrip(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse", nil, nil).Code)
+
+	pw := s3Request(t, srv, http.MethodPut, "/sse/doc", []byte("payload"),
+		map[string]string{sseAlgorithmHeader: "AES256"})
+	require.Equal(t, http.StatusOK, pw.Code)
+	assert.Equal(t, "AES256", pw.Header().Get(sseAlgorithmHeader),
+		"PutObject reports the encryption it recorded")
+
+	gw := s3Request(t, srv, http.MethodGet, "/sse/doc", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Equal(t, "AES256", gw.Header().Get(sseAlgorithmHeader), "GetObject")
+
+	hw := s3Request(t, srv, http.MethodHead, "/sse/doc", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "AES256", hw.Header().Get(sseAlgorithmHeader), "HeadObject")
+}
+
+// TestS3_SSE_KMSKeyIDVerbatim asserts the key ID survives byte-identically for each
+// form KMS accepts.
+//
+// The verbatim echo is a deliberate divergence: real S3 resolves any of these to the
+// key ARN. Substrate returns the string the caller sent, because that is the string
+// their configuration produced and therefore the assertion they are making — and this
+// table is what pins it, since three of the four forms would silently pass under a
+// resolver that normalized to an ARN.
+func TestS3_SSE_KMSKeyIDVerbatim(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		keyID string
+	}{
+		{"bare UUID", "1234abcd-12ab-34cd-56ef-1234567890ab"},
+		{"alias name", "alias/my-substrate-key"},
+		{"key ARN", "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab"},
+		{"alias ARN", "arn:aws:kms:us-east-1:123456789012:alias/my-substrate-key"},
+		// A KMS alias is case-sensitive, so the recorded value must not be folded on
+		// the way in or out. Every other row here is lowercase and would survive a
+		// strings.ToLower on the capture path.
+		{"mixed-case alias name", "alias/Prod-Data-Key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sse-kms", nil, nil).Code)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sse-kms/obj", []byte("x"), map[string]string{
+					sseAlgorithmHeader: "aws:kms",
+					sseKeyIDHeader:     tc.keyID,
+				}).Code)
+
+			for _, read := range []struct {
+				name   string
+				method string
+			}{{"GetObject", http.MethodGet}, {"HeadObject", http.MethodHead}} {
+				w := s3Request(t, srv, read.method, "/sse-kms/obj", nil, nil)
+				require.Equal(t, http.StatusOK, w.Code)
+				assert.Equal(t, "aws:kms", w.Header().Get(sseAlgorithmHeader), read.name)
+				assert.Equal(t, tc.keyID, w.Header().Get(sseKeyIDHeader),
+					"%s: the key ID round-trips verbatim, unresolved", read.name)
+			}
+		})
+	}
+}
+
+// TestS3_SSE_AlgorithmValuesRecordedVerbatim asserts each documented algorithm token
+// is recorded as sent. The valid values are AES256, aws:fsx, aws:kms and aws:kms:dsse;
+// substrate validates none of them, since rejecting an unrecognized token is #493's,
+// and the two colon-bearing tokens are the ones a naive normalizer would mangle.
+func TestS3_SSE_AlgorithmValuesRecordedVerbatim(t *testing.T) {
+	for _, algorithm := range []string{"AES256", "aws:fsx", "aws:kms", "aws:kms:dsse"} {
+		t.Run(algorithm, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sse-alg", nil, nil).Code)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sse-alg/obj", []byte("x"),
+					map[string]string{sseAlgorithmHeader: algorithm}).Code)
+
+			hw := s3Request(t, srv, http.MethodHead, "/sse-alg/obj", nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code)
+			assert.Equal(t, algorithm, hw.Header().Get(sseAlgorithmHeader))
+		})
+	}
+}
+
+// TestS3_SSE_BucketKeyEnabled asserts the bucket-key header is echoed only when the
+// write enabled it.
+//
+// Absent and false are different observations, so a write that never mentioned the
+// header must produce no header rather than "false" — an SDK that distinguishes a nil
+// *bool from a false one would otherwise report the wrong answer. The false and
+// garbage rows pin that only the documented value enables it.
+func TestS3_SSE_BucketKeyEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sent string
+		want string // "" means the header must be absent
+	}{
+		{"enabled", "true", "true"},
+		{"enabled uppercase", "TRUE", "true"},
+		{"disabled", "false", ""},
+		{"unset", "", ""},
+		{"unrecognized", "yes", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sse-bk", nil, nil).Code)
+
+			headers := map[string]string{sseAlgorithmHeader: "aws:kms"}
+			if tc.sent != "" {
+				headers[sseBucketKeyHeader] = tc.sent
+			}
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sse-bk/obj", []byte("x"), headers).Code)
+
+			hw := s3Request(t, srv, http.MethodHead, "/sse-bk/obj", nil, nil)
+			require.Equal(t, http.StatusOK, hw.Code)
+			if tc.want == "" {
+				_, present := hw.Header()[http.CanonicalHeaderKey(sseBucketKeyHeader)]
+				assert.False(t, present, "the bucket-key header must be absent, not false")
+				return
+			}
+			assert.Equal(t, tc.want, hw.Header().Get(sseBucketKeyHeader))
+		})
+	}
+}
+
+// TestS3_SSE_AbsentNotEmitted asserts an object written with no SSE headers reads back
+// with none. This is the regression guard on every object written before #492 existed,
+// and the property that makes recording worth anything: "no header sent" has to stay
+// distinguishable from "header sent". A default applied here would erase it, which is
+// why bucket default encryption is #493's decision to make deliberately.
+func TestS3_SSE_AbsentNotEmitted(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-bare", nil, nil).Code)
+
+	pw := s3Request(t, srv, http.MethodPut, "/sse-bare/obj", []byte("plain"), nil)
+	require.Equal(t, http.StatusOK, pw.Code)
+	assertNoSSE(t, pw.Header(), "PutObject")
+
+	gw := s3Request(t, srv, http.MethodGet, "/sse-bare/obj", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assertNoSSE(t, gw.Header(), "GetObject")
+
+	hw := s3Request(t, srv, http.MethodHead, "/sse-bare/obj", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assertNoSSE(t, hw.Header(), "HeadObject")
+}
+
+// TestS3_SSE_KeyIDWithoutAlgorithmNotEmitted asserts a key ID sent with no algorithm
+// emits nothing. There is no such thing as a KMS key ID on an unencrypted object, and
+// #493 rejects the combination outright; until then the write must not report an
+// encryption the caller never named.
+func TestS3_SSE_KeyIDWithoutAlgorithmNotEmitted(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-orphan", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-orphan/obj", []byte("x"), map[string]string{
+			sseKeyIDHeader:     "alias/orphan",
+			sseBucketKeyHeader: "true",
+		}).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sse-orphan/obj", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assertNoSSE(t, hw.Header(), "HeadObject")
+}
+
+// TestS3_SSE_AlgorithmWithoutKeyIDEmitsAlgorithmOnly asserts an SSE-KMS write naming
+// no key emits the algorithm and no key-ID header. Real S3 protects such an object
+// with the AWS managed key and reports the ID only "if present", so there is nothing
+// for substrate to echo — and inventing an aws/s3 ARN would be fabricating an
+// observation.
+func TestS3_SSE_AlgorithmWithoutKeyIDEmitsAlgorithmOnly(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-nokey", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-nokey/obj", []byte("x"),
+			map[string]string{sseAlgorithmHeader: "aws:kms"}).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sse-nokey/obj", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "aws:kms", hw.Header().Get(sseAlgorithmHeader))
+	_, present := hw.Header()[http.CanonicalHeaderKey(sseKeyIDHeader)]
+	assert.False(t, present, "no key was named, so there is no key ID to report")
+}
+
+// TestS3_SSE_StoredOnObject asserts the values are persisted on the object record,
+// read out of the state store rather than off a response.
+//
+// A header round-trip alone would pass if the plugin echoed the request it was handed
+// without storing anything, which is precisely the failure #492's storage criterion
+// guards against. Reading state also pins the JSON field names, so an object written
+// by this release still reads back after one that renames them.
+func TestS3_SSE_StoredOnObject(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	srv, _ := newS3TestServerWithFS(t, state)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-state", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-state/obj", []byte("x"), map[string]string{
+			sseAlgorithmHeader: "aws:kms",
+			sseKeyIDHeader:     "alias/stored",
+			sseBucketKeyHeader: "true",
+		}).Code)
+
+	obj := getStoredObject(t, state, "sse-state", "obj")
+	assert.Equal(t, "aws:kms", obj.Algorithm)
+	assert.Equal(t, "alias/stored", obj.KMSKeyID)
+	assert.True(t, obj.BucketKeyEnabled)
+}
+
+// TestS3_SSE_StoredAbsentOnUnencryptedObject asserts an unencrypted write stores the
+// zero value, so an object written before this field existed reads back with no
+// encryption rather than a fabricated default. That is the state half of
+// TestS3_SSE_AbsentNotEmitted, and the reason the fields are omitempty.
+func TestS3_SSE_StoredAbsentOnUnencryptedObject(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	srv, _ := newS3TestServerWithFS(t, state)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-state-bare", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-state-bare/obj", []byte("x"), nil).Code)
+
+	obj := getStoredObject(t, state, "sse-state-bare", "obj")
+	assert.Empty(t, obj.Algorithm)
+	assert.Empty(t, obj.KMSKeyID)
+	assert.False(t, obj.BucketKeyEnabled)
+}
+
+// TestS3_SSE_NonCanonicalHeaderNames asserts the headers are read case-insensitively.
+//
+// Requests reaching a plugin have not always been through net/http's canonicalization
+// — substrate builds them in-process too — so the plugin is exercised directly here.
+// Sending lowercase names through the server would prove nothing, because Go would
+// canonicalize them on the way in.
+func TestS3_SSE_NonCanonicalHeaderNames(t *testing.T) {
+	p := newS3PluginDirect(t)
+	rctx := &emulator.RequestContext{AccountID: "000000000000", Region: "us-east-1"}
+
+	// Operation carries the HTTP verb on entry; the plugin resolves the semantic
+	// operation from it and the path, exactly as the server pipeline does.
+	_, err := p.HandleRequest(rctx, &emulator.AWSRequest{
+		Service: "s3", Operation: http.MethodPut, Path: "/sse-fold",
+		Headers: map[string]string{}, Params: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	_, err = p.HandleRequest(rctx, &emulator.AWSRequest{
+		Service:   "s3",
+		Operation: http.MethodPut,
+		Path:      "/sse-fold/obj",
+		Body:      []byte("x"),
+		Params:    map[string]string{},
+		Headers: map[string]string{
+			"X-AMZ-SERVER-SIDE-ENCRYPTION":                    "aws:kms",
+			"x-amz-server-side-encryption-aws-kms-key-id":     "alias/folded",
+			"X-Amz-Server-Side-Encryption-Bucket-Key-Enabled": "true",
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := p.HandleRequest(rctx, &emulator.AWSRequest{
+		Service: "s3", Operation: http.MethodHead, Path: "/sse-fold/obj",
+		Headers: map[string]string{}, Params: map[string]string{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "aws:kms", resp.Headers[sseAlgorithmHeader])
+	assert.Equal(t, "alias/folded", resp.Headers[sseKeyIDHeader])
+	assert.Equal(t, "true", resp.Headers[sseBucketKeyHeader])
+}
+
+// TestS3_SSE_MultipartRoundTrip asserts the encryption named at CreateMultipartUpload
+// reaches the assembled object.
+//
+// Create is the only place it can be supplied: Complete's request accepts only the
+// SSE-C headers, so encryption not carried on the upload record is lost for good —
+// the #406 failure shape, which is why the family is one embedded declaration shared
+// by both records.
+func TestS3_SSE_MultipartRoundTrip(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-mpu", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/sse-mpu/big?uploads", nil, map[string]string{
+		sseAlgorithmHeader: "aws:kms",
+		sseKeyIDHeader:     "alias/mpu",
+		sseBucketKeyHeader: "true",
+	})
+	require.Equal(t, http.StatusOK, iw.Code)
+	assert.Equal(t, "aws:kms", iw.Header().Get(sseAlgorithmHeader),
+		"Create echoes it: Complete accepts no SSE header, so this is the only confirmation")
+	assert.Equal(t, "alias/mpu", iw.Header().Get(sseKeyIDHeader))
+	assert.Equal(t, "true", iw.Header().Get(sseBucketKeyHeader))
+
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	etag := uploadPart(t, srv, "sse-mpu", "big", ir.UploadID, 1, []byte("a single part is exempt from the floor"))
+	cw := s3Request(t, srv, http.MethodPost, "/sse-mpu/big?uploadId="+ir.UploadID, completeBody(etag), nil)
+	require.Equal(t, http.StatusOK, cw.Code)
+	assert.Equal(t, "aws:kms", cw.Header().Get(sseAlgorithmHeader), "Complete")
+	assert.Equal(t, "alias/mpu", cw.Header().Get(sseKeyIDHeader), "Complete")
+	assert.Equal(t, "true", cw.Header().Get(sseBucketKeyHeader), "Complete")
+
+	hw := s3Request(t, srv, http.MethodHead, "/sse-mpu/big", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "aws:kms", hw.Header().Get(sseAlgorithmHeader), "HeadObject after Complete")
+	assert.Equal(t, "alias/mpu", hw.Header().Get(sseKeyIDHeader), "HeadObject after Complete")
+	assert.Equal(t, "true", hw.Header().Get(sseBucketKeyHeader), "HeadObject after Complete")
+}
+
+// TestS3_SSE_MultipartAbsentNotEmitted asserts a multipart object created without
+// encryption emits none, so the carry through Complete cannot smuggle in empty
+// headers.
+func TestS3_SSE_MultipartAbsentNotEmitted(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-mpu-bare", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/sse-mpu-bare/big?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, iw.Code)
+	assertNoSSE(t, iw.Header(), "CreateMultipartUpload")
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	etag := uploadPart(t, srv, "sse-mpu-bare", "big", ir.UploadID, 1, []byte("body"))
+	cw := s3Request(t, srv, http.MethodPost, "/sse-mpu-bare/big?uploadId="+ir.UploadID, completeBody(etag), nil)
+	require.Equal(t, http.StatusOK, cw.Code)
+	assertNoSSE(t, cw.Header(), "CompleteMultipartUpload")
+
+	hw := s3Request(t, srv, http.MethodHead, "/sse-mpu-bare/big", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assertNoSSE(t, hw.Header(), "HeadObject after Complete")
+}
+
+// TestS3_SSE_CopyObjectDoesNotInherit pins the scope boundary against #493: a copy
+// records no encryption, not the source's.
+//
+// A copy's encryption comes from the request and, failing that, from the bucket
+// default — never from the source. Neither of those exists yet, so a copy reports
+// none, which is a stated gap rather than a wrong answer. The test is here so #493
+// changes this deliberately: silently inheriting is the live bug #475 found twice, and
+// it would otherwise be the easiest thing for a later change to introduce.
+func TestS3_SSE_CopyObjectDoesNotInherit(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-copy", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-copy/src", []byte("x"), map[string]string{
+			sseAlgorithmHeader: "aws:kms",
+			sseKeyIDHeader:     "alias/source",
+		}).Code)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-copy/dst", nil, map[string]string{
+			"x-amz-copy-source": "/sse-copy/src",
+		}).Code)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sse-copy/dst", nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assertNoSSE(t, hw.Header(), "CopyObject destination")
+
+	sw := s3Request(t, srv, http.MethodHead, "/sse-copy/src", nil, nil)
+	require.Equal(t, http.StatusOK, sw.Code)
+	assert.Equal(t, "aws:kms", sw.Header().Get(sseAlgorithmHeader),
+		"the source keeps its own encryption")
+}
+
+// TestS3_SSE_VersionedObjectRoundTrip asserts the family survives on a versioned
+// write, which stores a second copy of the metadata under its own key. A field set on
+// the object after the versioned copy is marshaled would be missing from it.
+func TestS3_SSE_VersionedObjectRoundTrip(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-ver", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sse-ver?versioning", []byte(
+			`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil).Code)
+
+	pw := s3Request(t, srv, http.MethodPut, "/sse-ver/obj", []byte("x"), map[string]string{
+		sseAlgorithmHeader: "AES256",
+	})
+	require.Equal(t, http.StatusOK, pw.Code)
+	versionID := pw.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, versionID)
+
+	hw := s3Request(t, srv, http.MethodHead, "/sse-ver/obj?versionId="+versionID, nil, nil)
+	require.Equal(t, http.StatusOK, hw.Code)
+	assert.Equal(t, "AES256", hw.Header().Get(sseAlgorithmHeader))
+}

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -49,6 +49,12 @@ type S3Object struct {
 	// drifting on the family.
 	S3SystemMetadata
 
+	// S3ServerSideEncryption carries the x-amz-server-side-encryption family
+	// recorded on write and echoed on every read. Embedded and shared with
+	// [S3MultipartUpload] for the same reason S3SystemMetadata is; no cryptography
+	// is performed, and the type's own doc says why that is the right boundary.
+	S3ServerSideEncryption
+
 	// Size is the byte length of the object body.
 	Size int64 `json:"size"`
 
@@ -167,6 +173,16 @@ type S3MultipartUpload struct {
 	// is literally the same declaration [S3Object] uses and Complete can carry the
 	// family across in one assignment.
 	S3SystemMetadata
+
+	// S3ServerSideEncryption carries the encryption family supplied at upload
+	// creation, applied to the object CompleteMultipartUpload assembles. Create is
+	// the only place it can be supplied — Complete's request accepts only the SSE-C
+	// headers, so encryption is fixed for the whole upload at creation.
+	//
+	// Embedded here as well as on [S3Object] so the family is one declaration and
+	// Complete carries it across in a single assignment. Resolving a bucket default
+	// onto an upload is #493's; recording what the create named is this release's.
+	S3ServerSideEncryption
 
 	// StorageClass is the storage class supplied at upload creation, applied to
 	// the object CompleteMultipartUpload assembles. Empty means STANDARD.


### PR DESCRIPTION
Closes #492.

The three server-side-encryption headers were accepted and discarded, so an object written with encryption read back byte-identical to one written without it. A consumer could only assert on what their own request carried — which verifies the line that filled in the request and nothing about the stored object. Every one of those request assertions is now a stored-object assertion.

## What changed

`x-amz-server-side-encryption`, `x-amz-server-side-encryption-aws-kms-key-id` and `x-amz-server-side-encryption-bucket-key-enabled` are recorded on `PutObject` and `CreateMultipartUpload`, and echoed on those two responses plus `GetObject`, `HeadObject` and `CompleteMultipartUpload` — all five are documented response headers in the API reference.

**No cryptography is performed.** The body is stored exactly as it arrived. Encryption at rest is not observable through an API call, but *the encryption S3 reports for an object* is, and that report is the assertion a consumer is making.

New `emulator/s3_sse.go` holds an `S3ServerSideEncryption` struct embedded in both `S3Object` and `S3MultipartUpload`, following `S3SystemMetadata`: one declaration, so the two write paths cannot drift the way #406's did, and `CompleteMultipartUpload` carries the family across in a single assignment. Echo goes through `objectResponseHeaders`, already the single place `GetObject` and `HeadObject` build headers.

Multipart encryption is fixed at create, because Complete's request accepts only the SSE-C headers.

## Decisions worth reviewing

**SSE gets its own struct rather than joining `S3SystemMetadata`.** Both #475 and #493 flag this as a real question. That family is defined by being recorded and echoed with no rules of its own; SSE has resolution rules coming in #493 — a bucket default, a `CopyObject` asymmetry, four rejected combinations — so it stays out for the same reason `Content-Type` and the storage class did. Stated in the type's doc comment.

**The KMS key ID round-trips verbatim.** Real S3 resolves any of the four accepted forms (bare UUID, `alias/name`, key ARN, alias ARN) to the key ARN — its own response doc says the header "indicates the ID of the KMS key that **was used**". Substrate returns the string the caller sent, because that is what their configuration produced and therefore the assertion they are making; #475's reporter confirms their tests assert the sent form. Documented as a divergence beside the field and in `docs/services.md`, so modelling key resolution later has to revisit it rather than silently overtake it.

**Absent stays absent, not `false` or empty.** A write that never mentioned the bucket-key header produces no header. Verified through the real AWS CLI: `ServerSideEncryption` is entirely missing from an unencrypted object's `head-object` output, and `BucketKeyEnabled` is absent rather than `false`.

**Reads use `headerValueFold`, not canonical-case map access** — matching every other `x-amz` read in the plugin, because in-process requests from `betty_cfn.go` never pass through net/http canonicalization. Header *values* are not folded: an algorithm token and a KMS alias are case-sensitive identifiers, and folding either would corrupt the verbatim round-trip. The bucket-key flag is the exception, being a boolean.

## Scope boundary against #493, pinned by tests

`CopyObject` records **no** encryption rather than inheriting the source's, and nothing is validated. Both are stated gaps with tests, so #493 changes them deliberately — silently inheriting is the live bug #475 found twice, and it is the easiest thing for a later change to introduce. Bucket default encryption is likewise out: adding it would erase the absent-versus-set distinction this half exists to create. SSE-C is out entirely.

## Verification

14 new tests (41 with subtests) in `emulator/s3_sse_test.go`, including the state-round-trip read straight out of the store — a header echo alone would pass without persisting anything.

Mutation-tested with a 26-mutant harness: **26 caught, 0 survived, 0 needing an equivalence exemption.** It covers resolving the key ID to an ARN, folding the algorithm or a mixed-case alias, each of the three emit conditions, each header-name typo, all four capture/carry sites, all four echo sites, dropping the JSON tags, un-embedding the struct, and both #493 behaviours (inheriting on copy, defaulting to AES256). The mixed-case-alias test row was added because the first run found a real gap: every other row was lowercase, so folding the key ID on the way in survived.

From the repo root: `gofmt -l`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go test -C test/e2e ./...` — all green.

End-to-end through the real AWS CLI: `put-object --server-side-encryption aws:kms --ssekms-key-id alias/mine --bucket-key-enabled` → `head-object` reports `aws:kms`, `alias/mine` verbatim and `BucketKeyEnabled: true`; an unencrypted object reports no SSE keys at all; the multipart create → part → complete → head chain carries a key ARN through unchanged; a copy reports none.

New `docs/services.md` §"Server-side encryption" covers the recorded headers, the echo sites, the verbatim key-ID divergence, and what #493 owns. Cross-referenced from the six affected operation rows.
