### PR TITLE
fix(s3): resolve x-amz-acl and x-amz-grant-* on the operations that create (#470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immediately, where real EC2 reports code `32` `shutting-down` first. That is
   pre-existing, unrelated to protection, and tracked separately.
 
+- **S3 now stores the ACL a write names, and `BlockPublicAcls` refuses the writes it
+  should** (#470). `PutObject` and `CreateBucket` read `x-amz-acl` not at all, so the
+  ACL `GetObjectAcl` and `GetBucketAcl` reported was never the one the write set — a
+  consumer asserting "my upload is publicly readable" saw the default owner-only ACL
+  with no signal the header had been discarded. An ACL expressed through the five
+  `x-amz-grant-*` headers was stored by **no** operation, `PutBucketAcl` and
+  `PutObjectAcl` included: the headers were parsed only to decide whether #458's
+  public-access check should refuse, so a non-public grant was silently dropped and a
+  public one was refused without ever being storable. Six operations now resolve and
+  store an ACL — `CreateBucket`, `PutObject`, `CopyObject`, `CreateMultipartUpload`,
+  `PutBucketAcl`, `PutObjectAcl` — and the canned-ACL table is modelled per resource
+  kind, so `log-delivery-write` grants the `LogDelivery` group on a bucket and nothing
+  on an object, per its "Applies to: Bucket".
+
+  **`authenticated-read` resolved to owner-only, which let a blocked bucket be walked
+  straight through.** `AuthenticatedUsers` is every AWS account, not every account in
+  yours, so an ACL granting it is public by Block Public Access's own definition — and
+  a canned ACL that resolved to no group grant was invisible to the check. It now
+  resolves to an `AuthenticatedUsers` `READ` grant and is refused where the two
+  `public-*` names are.
+
+  With an ACL to examine, `BlockPublicAcls` now enforces its other documented bullet:
+  "PUT Object calls fail if the request includes a public ACL". `PutObject`,
+  `CopyObject` and `CreateMultipartUpload` are refused with `403 AccessDenied`
+  **before anything is written**, so a refused upload stores no object, a refused copy
+  stores no destination object, a refused multipart create leaves no upload ID behind,
+  and a refused overwrite leaves the object already at the key untouched — body and
+  ACL both. A copy is judged against the **destination** bucket's configuration, since
+  reading the source's would let a public ACL be laundered into a blocked bucket by
+  copying rather than uploading.
+
+  A write replaces the whole ACL rather than part of it, per "You cannot use
+  `PutObject` to only update a single piece of metadata for an existing object. You
+  must put the entire object with updated metadata". So an overwrite naming no ACL
+  clears one the key already had, whether it arrived through the original write or a
+  later `PutObjectAcl`; `CompleteMultipartUpload` and `CopyObject` replace it the same
+  way. A copy never inherits: "When you copy an object, the ACL metadata is not
+  preserved and is set to `private` by default." A multipart upload's ACL is fixed at
+  create and carried on the upload record, because Complete's request accepts no ACL
+  header — the same shape #492 established for encryption.
+
+  Fixed along the way: `bucket_acl:<bucket>` outlived `DeleteBucket`, so creating a
+  bucket with a public ACL, deleting it and creating it again reported the deleted
+  bucket's ACL on the new one. `CreateBucket` is now authoritative and clears it. The
+  six *other* bucket sub-resources still leak this way — three of them changing
+  behaviour rather than just a `GET` — and that is tracked separately.
+
+  **`CreateBucket` with a public ACL is still accepted, and that gap is now stated
+  rather than left ambiguous.** The setting's third bullet refuses such a call, but the
+  configuration that does so is the **account-level** one — a bucket-level
+  configuration cannot exist before the bucket does — and substrate models no
+  account-level Block Public Access, so gating this one operation would mean modeling a
+  control the emulator does not otherwise have. A test pins the acceptance so adding
+  account-level support later changes a failing test rather than passing silently.
+
+  An `emailAddress` grantee is skipped rather than refused with the `HTTP 405` S3 has
+  returned since October 1 2025: the 405 is Region-conditional and applies to the XML
+  body form too, so it is filed rather than guessed at. A canned name substrate does
+  not recognize resolves to owner-only rather than being refused, because the
+  per-operation Valid Values lists differ (four names on `CreateBucket`, seven on
+  `PutObject`) and no error code is documented for a name outside them.
+
 ### Added
 - **EC2 instances now carry and report an Availability Zone** (#489), which is what
   makes the zone-scoped rule above observable rather than merely internally

--- a/docs/services.md
+++ b/docs/services.md
@@ -365,20 +365,20 @@ STS operations are free.
 
 | Operation | Notes |
 |-----------|-------|
-| CreateBucket | |
+| CreateBucket | Stores an ACL named by `x-amz-acl` / `x-amz-grant-*` — see [Access control lists](#access-control-lists) |
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers; `Cache-Control`, `Content-Disposition`, `Content-Language`, `Expires` — see [Object system metadata](#object-system-metadata); `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums); records the `x-amz-server-side-encryption` family — see [Server-side encryption](#server-side-encryption) |
+| PutObject | Supports Content-Type, metadata headers; `Cache-Control`, `Content-Disposition`, `Content-Language`, `Expires` — see [Object system metadata](#object-system-metadata); `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums); records the `x-amz-server-side-encryption` family — see [Server-side encryption](#server-side-encryption); stores an ACL named by `x-amz-acl` / `x-amz-grant-*` — see [Access control lists](#access-control-lists) |
 | GetObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); synthesizes a seedable task-completion record — see [Task-completion records](#task-completion-records); echoes recorded encryption — see [Server-side encryption](#server-side-encryption) |
 | HeadObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); resolves a synthesized task-completion record exactly as `GetObject` does — see [Task-completion records](#task-completion-records); echoes recorded encryption — see [Server-side encryption](#server-side-encryption) |
 | DeleteObject | Fires S3 notifications if configured |
-| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums); records **no** encryption, deliberately — see [Server-side encryption](#server-side-encryption) |
+| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums); records **no** encryption, deliberately — see [Server-side encryption](#server-side-encryption); takes its ACL from the copy request and never from the source — see [Access control lists](#access-control-lists) |
 | ListObjects | Emits `<StorageClass>` per object |
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
-| CreateMultipartUpload | Accepts `x-amz-storage-class` and the [system-metadata family](#object-system-metadata), applied to the assembled object; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums); records the encryption for the whole upload — see [Server-side encryption](#server-side-encryption) |
+| CreateMultipartUpload | Accepts `x-amz-storage-class` and the [system-metadata family](#object-system-metadata), applied to the assembled object; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums); records the encryption for the whole upload — see [Server-side encryption](#server-side-encryption); records the ACL for the whole upload — see [Access control lists](#access-control-lists) |
 | UploadPart | Verifies the part checksum, including a trailing one — see [Additional checksums](#additional-checksums) |
-| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums); reports the upload's recorded encryption — see [Server-side encryption](#server-side-encryption) |
+| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums); reports the upload's recorded encryption — see [Server-side encryption](#server-side-encryption); applies the upload's recorded ACL — see [Access control lists](#access-control-lists) |
 | AbortMultipartUpload | |
 | ListMultipartUploads | Emits `<StorageClass>` per in-progress upload |
 | GetBucketPolicy | |
@@ -387,10 +387,10 @@ STS operations are free.
 | PutPublicAccessBlock | Records the configuration and enforces `BlockPublicAcls` / `BlockPublicPolicy`; a partial body reports omitted settings as `false` — see [Block Public Access](#block-public-access) |
 | GetPublicAccessBlock | `404 NoSuchPublicAccessBlockConfiguration` when the bucket has none — see [Block Public Access](#block-public-access) |
 | DeletePublicAccessBlock | Idempotent; removes only the configuration, never the bucket — see [Block Public Access](#block-public-access) |
-| GetBucketAcl | |
-| PutBucketAcl | Accepts a canned `x-amz-acl` or an XML body; `403 AccessDenied` for a public ACL when `BlockPublicAcls` is set — see [Block Public Access](#block-public-access) |
-| GetObjectAcl | |
-| PutObjectAcl | `403 AccessDenied` for a public ACL when the *bucket* has `BlockPublicAcls` set — see [Block Public Access](#block-public-access) |
+| GetBucketAcl | Reports the stored ACL, or the default owner-only one — see [Access control lists](#access-control-lists) |
+| PutBucketAcl | Accepts an XML body, a canned `x-amz-acl` or the `x-amz-grant-*` family — see [Access control lists](#access-control-lists); `403 AccessDenied` for a public ACL when `BlockPublicAcls` is set — see [Block Public Access](#block-public-access) |
+| GetObjectAcl | Reports the stored ACL, or the default owner-only one — see [Access control lists](#access-control-lists) |
+| PutObjectAcl | Accepts an XML body, a canned `x-amz-acl` or the `x-amz-grant-*` family — see [Access control lists](#access-control-lists); `403 AccessDenied` for a public ACL when the *bucket* has `BlockPublicAcls` set — see [Block Public Access](#block-public-access) |
 | GetBucketNotificationConfiguration | |
 | PutBucketNotificationConfiguration | Triggers Lambda/SQS on PutObject/DeleteObject |
 | PutBucketTagging | |
@@ -971,7 +971,19 @@ carrying either setting refuses the call that would make it public:
 | Setting | Refuses | Response |
 |---------|---------|----------|
 | `BlockPublicAcls` | `PutBucketAcl`, `PutObjectAcl` with a public ACL | `403 AccessDenied` / `Access Denied` |
+| `BlockPublicAcls` | `PutObject`, `CopyObject`, `CreateMultipartUpload` whose request includes a public ACL | `403 AccessDenied` / `Access Denied` |
 | `BlockPublicPolicy` | `PutBucketPolicy` with a public policy | `403 AccessDenied` / `Access Denied` |
+
+The three create operations are their own bullet on the setting — "PUT Object calls
+fail if the request includes a public ACL" — and were unenforceable until substrate
+read an ACL from a create at all. **The refusal precedes every write**, so a refused
+`PutObject` stores no object, a refused `CopyObject` stores no destination object, and
+a refused `CreateMultipartUpload` leaves no upload ID behind; an overwrite refused this
+way leaves the object that was already at the key untouched, body and ACL both. The
+configuration consulted on a copy is the **destination** bucket's, since that is where
+the object lands.
+
+`CreateBucket` is the documented case substrate does **not** refuse; see below.
 
 A rejection stores nothing: the bucket or object keeps the ACL or policy it already
 had, matching "existing policies and ACLs for buckets and objects aren't modified".
@@ -994,10 +1006,18 @@ groups". `AuthenticatedUsers` is every AWS account, not every account in yours, 
 is why it counts despite the name. The permission itself is not inspected — `READ`,
 `WRITE`, `READ_ACP`, `WRITE_ACP` and `FULL_CONTROL` all count. All three ways a public
 ACL arrives are covered: the `x-amz-acl` canned header (`public-read`,
-`public-read-write`), an XML `Grant` naming a public group URI, and an
-`x-amz-grant-*` header whose grantee list contains one. The grant headers are read for
-this check only; substrate does not otherwise model them, so an ACL set through them
-is still not stored.
+`public-read-write`, `authenticated-read`), an XML `Grant` naming a public group URI,
+and an `x-amz-grant-*` header whose grantee list contains one. See
+[Access control lists](#access-control-lists) for how each form resolves.
+
+**`CreateBucket` with a public ACL is accepted, and that is a stated gap.** The
+setting's third bullet says "PUT Bucket calls fail if the request includes a public
+ACL", but the configuration that refuses such a call is the **account-level** one — a
+bucket-level configuration cannot exist before the bucket does. Substrate models no
+account-level Block Public Access, so gating this one operation would mean modeling a
+control the emulator does not otherwise have. A bucket created with `--acl public-read`
+therefore succeeds and reports the public grant, and the next `PutBucketAcl` on it is
+subject to whatever configuration has since been written.
 
 **A public policy is decided by assuming public and then trying to disqualify —
 not by looking for `Principal: "*"`.** This is stronger than wildcard-detection and is
@@ -1046,9 +1066,110 @@ does not model the guide's unsupported-action clause (S3 treats a statement gran
 action S3 does not support as potentially public), which would need an authoritative
 list of every supported `s3:` action.
 
-**`PutObject` and `CreateBucket` with a public ACL are not yet refused.** Real
-`BlockPublicAcls` rejects those too, but neither handler reads `x-amz-acl` at all, so
-covering them means first modelling ACL-on-create. Tracked separately.
+### Access control lists
+
+An ACL named on a write is **stored**, and reported by `GetBucketAcl` /
+`GetObjectAcl`. Six operations resolve one:
+
+| Operation | ACL source | On no ACL header |
+|-----------|-----------|-----------------|
+| `CreateBucket` | `x-amz-acl`, `x-amz-grant-*` | nothing stored; the default owner-only ACL is reported |
+| `PutObject` | `x-amz-acl`, `x-amz-grant-*` | nothing stored, and any ACL the key already had is **cleared** |
+| `CopyObject` | the copy request's own headers only | as `PutObject` — a copy never inherits the source's ACL |
+| `CreateMultipartUpload` | `x-amz-acl`, `x-amz-grant-*`, carried to the object `CompleteMultipartUpload` assembles | as `PutObject` |
+| `PutBucketAcl` | an XML body, else the headers | an empty request resolves to `private` |
+| `PutObjectAcl` | an XML body, else the headers | an empty request resolves to `private` |
+
+Before this, `PutObject` and `CreateBucket` read no ACL header at all, so the ACL
+`GetObjectAcl` reported was never the one the write set — and an ACL expressed through
+`x-amz-grant-*` was stored by **no** operation, `PutBucketAcl` and `PutObjectAcl`
+included: the grant headers were parsed only to decide whether Block Public Access
+should refuse.
+
+**A write replaces the whole ACL, not part of it.** "You cannot use `PutObject` to only
+update a single piece of metadata for an existing object. You must put the entire object
+with updated metadata" — so an overwrite naming no ACL reports owner-only afterwards
+even if the key previously carried a public grant, whether that grant arrived through
+the original `PutObject` or through a later `PutObjectAcl`. `CompleteMultipartUpload`
+and `CopyObject` replace it the same way, and `CreateBucket` clears any ACL a
+same-named bucket left behind when it was deleted.
+
+**A copy takes its ACL from the request and nowhere else**: "When you copy an object,
+the ACL metadata is not preserved and is set to `private` by default. Only the owner has
+full access control. To override the default ACL setting, specify a new ACL when you
+generate a copy request." That is the opposite of the metadata families, where `COPY` is
+the default directive — see [Copying objects](#copying-objects).
+
+**A multipart upload's ACL is fixed at create.** `CompleteMultipartUpload`'s request
+accepts no ACL header, exactly as it accepts no encryption header, so an ACL not named
+at `CreateMultipartUpload` cannot be supplied later.
+
+**The canned names resolve from the user guide's Canned ACL table**, and three of them
+mean different things on a bucket than on an object:
+
+| `x-amz-acl` | Bucket | Object |
+|-------------|--------|--------|
+| `private` | owner `FULL_CONTROL` | owner `FULL_CONTROL` |
+| `public-read` | + `AllUsers` `READ` | + `AllUsers` `READ` |
+| `public-read-write` | + `AllUsers` `READ`, `WRITE` | + `AllUsers` `READ`, `WRITE` |
+| `authenticated-read` | + `AuthenticatedUsers` `READ` | + `AuthenticatedUsers` `READ` |
+| `log-delivery-write` | + `LogDelivery` `WRITE`, `READ_ACP` | owner-only — "Applies to: Bucket" |
+| `aws-exec-read` | owner-only | owner-only |
+| `bucket-owner-read` | owner-only — S3 "ignores it" on a bucket | owner-only |
+| `bucket-owner-full-control` | owner-only | owner-only |
+
+The owner grant is present in every row because a canned ACL is applied on top of the
+ACL the resource already has: "When Amazon S3 receives a request with a canned ACL in
+the request, it adds the predefined grants to the ACL of the resource". `aws-exec-read`
+resolves to owner-only because it grants Amazon EC2 `READ` and AWS does not publish that
+canonical user ID; the two `bucket-owner-*` names collapse because substrate has one
+owner identity per bucket, so the object owner and the bucket owner are the same
+principal. **`authenticated-read` is public** by Block Public Access's own definition,
+which is the row that matters most: substrate resolved it to owner-only before, so the
+block could be walked straight through.
+
+A canned name substrate does not recognize resolves to owner-only rather than being
+refused. The per-operation Valid Values lists differ — `CreateBucket` and `PutBucketAcl`
+document four names, `PutObject`, `PutObjectAcl`, `CopyObject` and
+`CreateMultipartUpload` seven — and no error code is documented for a name outside them,
+so refusing would mean rejecting a request real S3 may accept.
+
+**The five `x-amz-grant-*` headers add to the default ACL**, they do not replace it:
+"you specify explicit access permissions and grantees … These permissions are then added
+to the ACL on the object", so the owner keeps `FULL_CONTROL`.
+
+| Header | Permission |
+|--------|-----------|
+| `x-amz-grant-full-control` | `FULL_CONTROL` |
+| `x-amz-grant-read` | `READ` |
+| `x-amz-grant-read-acp` | `READ_ACP` |
+| `x-amz-grant-write` | `WRITE` |
+| `x-amz-grant-write-acp` | `WRITE_ACP` |
+
+Each value is a comma-separated list of `type=value` pairs — `id="abc123",
+uri="http://acs.amazonaws.com/groups/global/AllUsers"` — with the quotes optional and
+the type read case-insensitively. Only `id` and `uri` produce a grantee, which is the
+pair the user guide's "Who is a grantee?" section lists. `PutObject`'s request syntax
+omits `x-amz-grant-write` (the permissions table gives `WRITE` no object meaning);
+substrate records it there anyway rather than inventing a rejection no error code is
+documented for.
+
+**An `emailAddress` grantee is skipped, not refused.** S3 ended support for it — "As of
+October 1, 2025, Amazon S3 has discontinued support for Email Grantee Access Control
+Lists (ACLs) … the request will receive an `HTTP 405` (Method Not Allowed) error" — and
+substrate's clock is past that date, but the 405 is Region-conditional and applies to the
+XML body form too, so returning it is tracked separately rather than guessed at.
+
+**The two forms are documented mutually exclusive** — "If you use these ACL-specific
+headers, you cannot use the `x-amz-acl` header to set a canned ACL" — but no error code
+is documented for sending both, so substrate resolves rather than refuses and the grant
+headers win, being the more specific expression. On `PutBucketAcl` and `PutObjectAcl` an
+XML body wins over both.
+
+**The owner identity is derived from the bucket name** (`<bucket>-owner`), because
+substrate has no canonical user IDs: there is one owner per bucket and it owns everything
+in it. An ACL's `Owner` and its `CanonicalUser` `FULL_CONTROL` grantee are therefore
+always the same ID, and an object's owner is its bucket's.
 
 ### Betty CFN resource types
 

--- a/emulator/s3_acl.go
+++ b/emulator/s3_acl.go
@@ -1,0 +1,258 @@
+package emulator
+
+import "strings"
+
+// s3CannedACLHeader is the request header carrying a canned ACL name, and
+// s3GroupLogDelivery the third predefined group — the one that is not public.
+//
+// The two public group URIs live in s3_publicaccess.go, where the definition of
+// "public" is. LogDelivery is here instead because it is only ever a grantee, never
+// a reason to refuse a request: "WRITE permission on a bucket enables this group to
+// write server access logs" (S3 user guide, ACL overview, Amazon S3 predefined
+// groups).
+const (
+	s3CannedACLHeader   = "x-amz-acl"
+	s3GroupLogDelivery  = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+	s3PermissionRead    = "READ"
+	s3PermissionWrite   = "WRITE"
+	s3PermissionReadACP = "READ_ACP"
+	s3PermissionFull    = "FULL_CONTROL"
+)
+
+// s3ACLResourceKind says whether an ACL is being resolved for a bucket or for an
+// object.
+//
+// Two canned ACLs mean different things on the two, so the resolver cannot be
+// kind-blind: log-delivery-write is documented "Applies to: Bucket" and
+// bucket-owner-read/bucket-owner-full-control as "Applies to: Object", the latter
+// pair adding "If you specify this canned ACL when creating a bucket, Amazon S3
+// ignores it" (S3 user guide, ACL overview, Canned ACL table).
+type s3ACLResourceKind int
+
+// The two resource kinds an ACL can be resolved for.
+const (
+	s3ACLBucket s3ACLResourceKind = iota
+	s3ACLObject
+)
+
+// s3GrantHeader pairs one x-amz-grant-* header with the ACL permission it grants.
+type s3GrantHeader struct {
+	name       string
+	permission string
+}
+
+// s3GrantHeaders are the five headers that name grantees for one permission each,
+// in the order the API reference lists them.
+//
+// The set is uniform across the four operations substrate resolves ACLs on, with
+// one documented exception: PutObject's request syntax omits x-amz-grant-write,
+// consistent with the permissions table giving WRITE no object meaning ("Not
+// applicable"). Substrate records it there anyway rather than inventing a
+// rejection — no error code is documented for an unaccepted grant header, and
+// refusing a request real S3 may accept is the defect this family of fixes exists
+// to remove. WRITE on an object is inert either way.
+var s3GrantHeaders = []s3GrantHeader{
+	{"x-amz-grant-full-control", s3PermissionFull},
+	{"x-amz-grant-read", s3PermissionRead},
+	{"x-amz-grant-read-acp", s3PermissionReadACP},
+	{"x-amz-grant-write", s3PermissionWrite},
+	{"x-amz-grant-write-acp", "WRITE_ACP"},
+}
+
+// s3ParseGrantees parses one x-amz-grant-* header value into its grantees.
+//
+// The value is a comma-separated list of type=value pairs — for example
+// `uri="http://acs.amazonaws.com/groups/global/AllUsers", id="abc123"`. Values may
+// be quoted, so quotes are trimmed, and the type is matched case-insensitively
+// because the documented spelling of one of them is mixed-case (emailAddress).
+//
+// Only id and uri produce a grantee, which is exactly the pair the user guide's
+// "Who is a grantee?" section lists. An emailAddress grantee is skipped rather
+// than stored: S3 has ended support for it — "As of October 1, 2025, Amazon S3 has
+// discontinued support for Email Grantee Access Control Lists (ACLs). If you
+// attempt to use an Email Grantee ACL in a request after October 1, 2025, the
+// request will receive an HTTP 405 (Method Not Allowed) error" — and substrate's
+// clock is past that date. Returning the 405 is a separate behavior, scoped out
+// because it is Region-conditional and applies to the XML body form too (#507).
+func s3ParseGrantees(value string) []S3Grantee {
+	if value == "" {
+		return nil
+	}
+	var grantees []S3Grantee
+	for _, entry := range strings.Split(value, ",") {
+		kind, val, found := strings.Cut(strings.TrimSpace(entry), "=")
+		if !found {
+			continue
+		}
+		val = strings.Trim(strings.TrimSpace(val), `"`)
+		if val == "" {
+			continue
+		}
+		switch {
+		case strings.EqualFold(strings.TrimSpace(kind), "id"):
+			grantees = append(grantees, S3Grantee{Type: "CanonicalUser", ID: val})
+		case strings.EqualFold(strings.TrimSpace(kind), "uri"):
+			grantees = append(grantees, S3Grantee{Type: "Group", URI: val})
+		}
+	}
+	return grantees
+}
+
+// s3GrantsFromHeaders resolves the x-amz-grant-* headers on a request into grants,
+// or nil when the request carries none.
+//
+// Header names are read case-insensitively through [headerValueFold]: an
+// in-process request never passes through net/http's canonicalization, so a
+// canonical-case map lookup silently misses one.
+func s3GrantsFromHeaders(headers map[string]string) []S3Grant {
+	var grants []S3Grant
+	for _, gh := range s3GrantHeaders {
+		for _, grantee := range s3ParseGrantees(headerValueFold(headers, gh.name)) {
+			grants = append(grants, S3Grant{Grantee: grantee, Permission: gh.permission})
+		}
+	}
+	return grants
+}
+
+// s3RequestNamesACL reports whether a request carries any of the six ACL headers.
+//
+// PutObject and CreateBucket use this to store an ACL only when one was asked for,
+// keeping "the caller named an ACL" distinguishable in state from "the caller named
+// none and got the default". PutBucketAcl and PutObjectAcl do not: their whole
+// purpose is to set an ACL, and one sent with no header at all is documented to
+// resolve to private.
+func s3RequestNamesACL(headers map[string]string) bool {
+	if headerValueFold(headers, s3CannedACLHeader) != "" {
+		return true
+	}
+	for _, gh := range s3GrantHeaders {
+		if headerValueFold(headers, gh.name) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// s3RequestACL resolves the ACL a create operation named, or nil when it named
+// none.
+//
+// The nil is the whole point: PutObject, CopyObject, CreateMultipartUpload and
+// CreateBucket all store an ACL only when one was asked for, so "the caller named
+// none and got the default" stays distinguishable in state from "the caller named
+// the default". [S3Plugin.s3StoreObjectACL] and
+// [S3Plugin.s3RequestACLDenied] both read the distinction from this one pointer
+// rather than from a parallel boolean.
+func s3RequestACL(headers map[string]string, resource string, kind s3ACLResourceKind) *S3AccessControlList {
+	if !s3RequestNamesACL(headers) {
+		return nil
+	}
+	acl := s3ResolveRequestACL(headers, resource, kind)
+	return &acl
+}
+
+// s3ResolveRequestACL resolves the ACL a request expresses through its headers,
+// for a resource whose owner is derived from resource.
+//
+// A request with no ACL header at all resolves to the owner-only ACL, which is
+// what makes this safe to call unconditionally on every create: "By default, all
+// objects are private. Only the owner has full access control" (PutObject,
+// x-amz-acl).
+//
+// The two forms are documented as mutually exclusive — "If you use these ACL-
+// specific headers, you cannot use the x-amz-acl header to set a canned ACL" — but
+// no error code is documented for sending both, so substrate resolves rather than
+// refuses and the grant headers win, being the more specific expression. Which one
+// wins cannot open a Block Public Access hole either way: [S3Plugin.s3PublicACLDenied]
+// examines the resolved ACL *and* the raw headers.
+func s3ResolveRequestACL(headers map[string]string, resource string, kind s3ACLResourceKind) S3AccessControlList {
+	grants := s3GrantsFromHeaders(headers)
+	if len(grants) == 0 {
+		return s3CannedACL(headerValueFold(headers, s3CannedACLHeader), resource, kind)
+	}
+
+	// The named grants are added to the default ACL rather than replacing it: "you
+	// specify explicit access permissions and grantees … These permissions are then
+	// added to the ACL on the object. By default, all objects are private. Only the
+	// owner has full access control" (PutObject, x-amz-acl). So the owner keeps
+	// FULL_CONTROL, which is also what makes every ACL substrate stores have an
+	// owner grant, as every ACL in the API reference's own examples does.
+	acl := s3DefaultACL(resource)
+	acl.Grants = append(acl.Grants, grants...)
+	return acl
+}
+
+// s3CannedACL maps a canned ACL name (the x-amz-acl header) to an
+// S3AccessControlList, from the user guide's Canned ACL table.
+//
+// The owner grant is present in every case because a canned ACL is applied on top
+// of the ACL the resource already has: "When Amazon S3 receives a request with a
+// canned ACL in the request, it adds the predefined grants to the ACL of the
+// resource", and a new bucket or object starts with an ACL granting its owner
+// FULL_CONTROL. That is why log-delivery-write keeps the owner grant even though
+// the table's entry for it names only the LogDelivery grants.
+//
+// Four canned names resolve to owner-only, each for its own documented reason
+// rather than by falling through:
+//
+//   - private — "Owner gets FULL_CONTROL. No one else has access rights (default)."
+//   - aws-exec-read — grants Amazon EC2 READ, whose canonical user ID AWS does not
+//     publish, so substrate cannot name the grantee and records no second grant.
+//   - bucket-owner-read and bucket-owner-full-control — both distinguish the object
+//     owner from the bucket owner, and substrate has one owner identity per bucket,
+//     so the two principals are the same and the grants collapse. On a bucket the
+//     table says S3 "ignores it", which is the same answer.
+//
+// An unrecognized value also resolves to owner-only rather than being refused: the
+// per-operation Valid Values lists differ (CreateBucket and PutBucketAcl document
+// four names, PutObject and PutObjectAcl seven), and no error code is documented
+// for a canned name outside them.
+func s3CannedACL(cannedACL, resource string, kind s3ACLResourceKind) S3AccessControlList {
+	acl := s3DefaultACL(resource)
+	group := func(uri, permission string) S3Grant {
+		return S3Grant{Grantee: S3Grantee{Type: "Group", URI: uri}, Permission: permission}
+	}
+
+	switch cannedACL {
+	case "public-read":
+		acl.Grants = append(acl.Grants, group(s3GroupAllUsers, s3PermissionRead))
+	case "public-read-write":
+		acl.Grants = append(acl.Grants,
+			group(s3GroupAllUsers, s3PermissionRead),
+			group(s3GroupAllUsers, s3PermissionWrite))
+	case "authenticated-read":
+		// AuthenticatedUsers is every AWS account, not every account in yours, so
+		// this ACL is public by Block Public Access's definition and a bucket that
+		// blocks public ACLs refuses it. Substrate resolved it to owner-only until
+		// #470, which meant the block could be walked straight through.
+		acl.Grants = append(acl.Grants, group(s3GroupAuthenticatedUsers, s3PermissionRead))
+	case "log-delivery-write":
+		// "Applies to: Bucket" — the table gives this name no object meaning, so on
+		// an object it resolves to owner-only like any other unrecognized value.
+		if kind == s3ACLBucket {
+			acl.Grants = append(acl.Grants,
+				group(s3GroupLogDelivery, s3PermissionWrite),
+				group(s3GroupLogDelivery, s3PermissionReadACP))
+		}
+	}
+	return acl
+}
+
+// s3DefaultACL returns the ACL a bucket or object has when nothing has set one:
+// its owner with FULL_CONTROL and no other grant.
+//
+// "When you create a bucket or an object, Amazon S3 creates a default ACL that
+// grants the resource owner full control over the resource" — and the sample that
+// follows notes the default object ACL has the same structure, which is why one
+// function serves both kinds.
+//
+// The owner identity is derived from the resource name because substrate has no
+// canonical user IDs: there is one owner per bucket and it owns everything in it.
+func s3DefaultACL(resource string) S3AccessControlList {
+	return S3AccessControlList{
+		Owner: S3Owner{ID: resource + "-owner", DisplayName: resource},
+		Grants: []S3Grant{{
+			Grantee:    S3Grantee{Type: "CanonicalUser", ID: resource + "-owner"},
+			Permission: s3PermissionFull,
+		}},
+	}
+}

--- a/emulator/s3_acl_test.go
+++ b/emulator/s3_acl_test.go
@@ -1,0 +1,654 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The predefined LogDelivery group, spelled out here for the same reason the two
+// public groups are in s3_publicaccess_test.go: a change to the package's constant
+// has to be reflected deliberately.
+const testGroupLogDelivery = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+
+// ownerGrant renders the owner's FULL_CONTROL grant for a bucket, which every ACL
+// substrate stores carries: "When Amazon S3 receives a request with a canned ACL in
+// the request, it adds the predefined grants to the ACL of the resource", and a new
+// bucket or object starts with one granting its owner FULL_CONTROL.
+func ownerGrant(bucket string) string {
+	return bucket + "-owner/FULL_CONTROL"
+}
+
+// putObjectWithACL writes an object with the supplied headers, requiring a 200. It
+// exists so a test asserting on the resulting ACL cannot accidentally pass because
+// the write itself was refused.
+func putObjectWithACL(t *testing.T, srv *emulator.Server, bucket, key string, headers map[string]string) {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("payload"), headers)
+	require.Equal(t, http.StatusOK, w.Code, "PutObject: %s", w.Body.String())
+}
+
+// createBucketWithACL creates a bucket with the supplied headers, requiring a 200.
+func createBucketWithACL(t *testing.T, srv *emulator.Server, bucket string, headers map[string]string) {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket, nil, headers)
+	require.Equal(t, http.StatusOK, w.Code, "CreateBucket: %s", w.Body.String())
+}
+
+// storedACLAbsent reports whether no ACL is stored for a key at all, which is a
+// different observation from a stored owner-only ACL: the two report identically
+// through GetObjectAcl, and only one of them records that the caller named an ACL.
+func storedACLAbsent(t *testing.T, state emulator.StateManager, stateKey string) bool {
+	t.Helper()
+	raw, err := state.Get(t.Context(), "s3", stateKey)
+	require.NoError(t, err)
+	return raw == nil
+}
+
+// cannedACLCase is one canned ACL name and the grants it resolves to on each kind
+// of resource, from the user guide's Canned ACL table.
+type cannedACLCase struct {
+	name string
+	// bucketExtra and objectExtra are the grants beyond the owner's, which differ
+	// between the two kinds for three of the seven names.
+	bucketExtra []string
+	objectExtra []string
+}
+
+// cannedACLCases is the Canned ACL table, reduced to cases. Every entry names its
+// documented outcome, including the four that resolve to owner-only — each for its
+// own reason rather than by falling through, which is why they are listed rather
+// than assumed.
+func cannedACLCases() []cannedACLCase {
+	return []cannedACLCase{
+		{
+			// "Owner gets FULL_CONTROL. No one else has access rights (default)."
+			name: "private",
+		},
+		{
+			// "The AllUsers group … gets READ access."
+			name:        "public-read",
+			bucketExtra: []string{testGroupAllUsers + "/READ"},
+			objectExtra: []string{testGroupAllUsers + "/READ"},
+		},
+		{
+			// "AllUsers group gets READ and WRITE access."
+			name:        "public-read-write",
+			bucketExtra: []string{testGroupAllUsers + "/READ", testGroupAllUsers + "/WRITE"},
+			objectExtra: []string{testGroupAllUsers + "/READ", testGroupAllUsers + "/WRITE"},
+		},
+		{
+			// "The AuthenticatedUsers group gets READ access." Public by Block Public
+			// Access's own definition, which is what makes this row load-bearing rather
+			// than decorative — see TestS3_ACL_AuthenticatedReadIsPublic.
+			name:        "authenticated-read",
+			bucketExtra: []string{testGroupAuthenticatedUsers + "/READ"},
+			objectExtra: []string{testGroupAuthenticatedUsers + "/READ"},
+		},
+		{
+			// "Applies to: Bucket" — "The LogDelivery group gets WRITE and READ_ACP
+			// permissions on the bucket." The table gives it no object meaning, so on an
+			// object it resolves to owner-only.
+			name: "log-delivery-write",
+			bucketExtra: []string{
+				testGroupLogDelivery + "/WRITE",
+				testGroupLogDelivery + "/READ_ACP",
+			},
+		},
+		{
+			// Grants Amazon EC2 READ, whose canonical user ID AWS does not publish, so
+			// substrate cannot name the grantee and records no second grant.
+			name: "aws-exec-read",
+		},
+		{
+			// "Applies to: Object", and substrate has one owner identity per bucket, so
+			// the object owner and the bucket owner are the same principal and the grants
+			// collapse. On a bucket, "Amazon S3 ignores it" — the same answer.
+			name: "bucket-owner-read",
+		},
+		{
+			name: "bucket-owner-full-control",
+		},
+	}
+}
+
+// TestS3_ACL_CannedOnPutObject asserts a canned ACL named on PutObject is stored and
+// reported by GetObjectAcl.
+//
+// This is #470's first consequence, independent of Block Public Access: putObject did
+// not read x-amz-acl at all, so the ACL GetObjectAcl reported was never the one the
+// write set. A consumer asserting "my upload is publicly readable" saw the default
+// owner-only ACL and had no way to tell the header had been discarded.
+func TestS3_ACL_CannedOnPutObject(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range cannedACLCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+			createBucketWithACL(t, srv, "canned-obj", nil)
+			putObjectWithACL(t, srv, "canned-obj", "k.txt", map[string]string{"x-amz-acl": tc.name})
+
+			want := append([]string{ownerGrant("canned-obj")}, tc.objectExtra...)
+			assert.Equal(t, want, getObjectACLGrants(t, srv, "canned-obj", "k.txt"))
+		})
+	}
+}
+
+// TestS3_ACL_CannedOnCreateBucket is the bucket-level counterpart. createBucket read
+// no ACL header either, so a bucket created public reported itself private.
+func TestS3_ACL_CannedOnCreateBucket(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range cannedACLCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+			createBucketWithACL(t, srv, "canned-bkt", map[string]string{"x-amz-acl": tc.name})
+
+			want := append([]string{ownerGrant("canned-bkt")}, tc.bucketExtra...)
+			assert.Equal(t, want, getBucketACLGrants(t, srv, "canned-bkt"))
+		})
+	}
+}
+
+// TestS3_ACL_LogDeliveryWriteIsBucketOnly pins the resource-kind distinction on its
+// own, because it is the one a kind-blind resolver gets wrong in both directions: it
+// would either grant LogDelivery WRITE on an object, which the table gives no
+// meaning, or drop it on a bucket, where the table is explicit.
+func TestS3_ACL_LogDeliveryWriteIsBucketOnly(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "logs", map[string]string{"x-amz-acl": "log-delivery-write"})
+	putObjectWithACL(t, srv, "logs", "k.txt", map[string]string{"x-amz-acl": "log-delivery-write"})
+
+	assert.Equal(t, []string{
+		ownerGrant("logs"),
+		testGroupLogDelivery + "/WRITE",
+		testGroupLogDelivery + "/READ_ACP",
+	}, getBucketACLGrants(t, srv, "logs"), "the table says Applies to: Bucket")
+
+	assert.Equal(t, []string{ownerGrant("logs")}, getObjectACLGrants(t, srv, "logs", "k.txt"),
+		"the table gives log-delivery-write no object meaning")
+}
+
+// TestS3_ACL_UnrecognizedCannedValueIsOwnerOnly asserts a canned name substrate does
+// not know is accepted and resolves to owner-only rather than being refused.
+//
+// The per-operation Valid Values lists differ — CreateBucket and PutBucketAcl document
+// four names, PutObject and PutObjectAcl seven — and no error code is documented for a
+// name outside them, so refusing would be substrate rejecting a request real S3 may
+// accept. That includes the three object-only names on a bucket, which the table says
+// S3 "ignores".
+func TestS3_ACL_UnrecognizedCannedValueIsOwnerOnly(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "unknown-canned", map[string]string{"x-amz-acl": "not-a-canned-acl"})
+	putObjectWithACL(t, srv, "unknown-canned", "k.txt", map[string]string{"x-amz-acl": "also-not-one"})
+
+	assert.Equal(t, []string{ownerGrant("unknown-canned")}, getBucketACLGrants(t, srv, "unknown-canned"))
+	assert.Equal(t, []string{ownerGrant("unknown-canned")}, getObjectACLGrants(t, srv, "unknown-canned", "k.txt"))
+}
+
+// grantHeaderCase is one x-amz-grant-* header and the permission it grants.
+type grantHeaderCase struct {
+	header     string
+	permission string
+}
+
+// grantHeaderCases are the five headers, each naming grantees for one permission.
+//
+// x-amz-grant-write is included for PutObject even though its request syntax omits it
+// — the permissions table gives WRITE no object meaning ("Not applicable"). Substrate
+// records it rather than inventing a rejection no error code is documented for, and
+// this table pins that choice: refusing a request real S3 may accept is the defect
+// this family of fixes exists to remove.
+func grantHeaderCases() []grantHeaderCase {
+	return []grantHeaderCase{
+		{header: "x-amz-grant-full-control", permission: "FULL_CONTROL"},
+		{header: "x-amz-grant-read", permission: "READ"},
+		{header: "x-amz-grant-read-acp", permission: "READ_ACP"},
+		{header: "x-amz-grant-write", permission: "WRITE"},
+		{header: "x-amz-grant-write-acp", permission: "WRITE_ACP"},
+	}
+}
+
+// TestS3_ACL_GrantHeadersStored asserts every x-amz-grant-* header is stored on every
+// operation that accepts the family.
+//
+// An ACL set through grant headers was stored by **no** operation before #470 —
+// including PutBucketAcl and PutObjectAcl, whose whole purpose is to set one. That is
+// wider than #470's title suggests: the headers were parsed only to decide whether a
+// Block Public Access check should refuse, so a non-public grant was silently
+// discarded and a public one was refused without ever being storable.
+func TestS3_ACL_GrantHeadersStored(t *testing.T) {
+	t.Parallel()
+
+	for _, gh := range grantHeaderCases() {
+		t.Run(gh.header, func(t *testing.T) {
+			t.Parallel()
+			headers := map[string]string{gh.header: `id="grantee-1"`}
+			want := []string{ownerGrant("grants"), "grantee-1/" + gh.permission}
+
+			// CreateBucket and PutObject, the two operations #470 names.
+			srv, _ := newS3TestServer(t)
+			createBucketWithACL(t, srv, "grants", headers)
+			putObjectWithACL(t, srv, "grants", "k.txt", headers)
+			assert.Equal(t, want, getBucketACLGrants(t, srv, "grants"), "CreateBucket")
+			assert.Equal(t, want, getObjectACLGrants(t, srv, "grants", "k.txt"), "PutObject")
+
+			// PutBucketAcl and PutObjectAcl, which were equally affected. A fresh
+			// server, so these cannot pass on what the writes above stored.
+			srv2, _ := newS3TestServer(t)
+			createBucketWithACL(t, srv2, "grants", nil)
+			putObjectWithACL(t, srv2, "grants", "k.txt", nil)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv2, http.MethodPut, "/grants?acl", nil, headers).Code)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv2, http.MethodPut, "/grants/k.txt?acl", nil, headers).Code)
+			assert.Equal(t, want, getBucketACLGrants(t, srv2, "grants"), "PutBucketAcl")
+			assert.Equal(t, want, getObjectACLGrants(t, srv2, "grants", "k.txt"), "PutObjectAcl")
+		})
+	}
+}
+
+// TestS3_ACL_GrantHeaderGranteeForms covers the grantee spellings one header value can
+// carry: the two supported types, a quoted and an unquoted value, and a multi-grantee
+// list.
+func TestS3_ACL_GrantHeaderGranteeForms(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{name: "quoted id", value: `id="abc123"`, want: []string{"abc123/READ"}},
+		{name: "unquoted id", value: "id=abc123", want: []string{"abc123/READ"}},
+		{name: "uri", value: `uri="` + testGroupLogDelivery + `"`, want: []string{testGroupLogDelivery + "/READ"}},
+		{
+			name:  "list of id and uri",
+			value: `id="abc123", uri="` + testGroupLogDelivery + `"`,
+			want:  []string{"abc123/READ", testGroupLogDelivery + "/READ"},
+		},
+		{
+			// The grantee type is matched case-insensitively, because the documented
+			// spelling of one of the three is mixed-case (emailAddress).
+			name:  "mixed-case type",
+			value: `ID="abc123"`,
+			want:  []string{"abc123/READ"},
+		},
+		{
+			// A value that is not type=value produces no grantee rather than a
+			// malformed one. No error code is documented for a malformed grant header.
+			name:  "no equals sign",
+			value: "abc123",
+			want:  nil,
+		},
+		{
+			// An empty value is skipped and the rest of the list still parsed. A
+			// parser that stopped at the first unusable entry would silently drop
+			// every grantee after it, which is the direction that loses a grant the
+			// caller asked for.
+			name:  "empty value before a good one",
+			value: `id=, uri="` + testGroupLogDelivery + `"`,
+			want:  []string{testGroupLogDelivery + "/READ"},
+		},
+		{
+			name:  "empty value after a good one",
+			value: `id="abc123", uri=`,
+			want:  []string{"abc123/READ"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+			createBucketWithACL(t, srv, "forms", map[string]string{"x-amz-grant-read": tc.value})
+
+			assert.Equal(t, append([]string{ownerGrant("forms")}, tc.want...),
+				getBucketACLGrants(t, srv, "forms"))
+		})
+	}
+}
+
+// TestS3_ACL_EmailGranteeSkipped pins the scope decision behind #507: an emailAddress
+// grantee is skipped, not stored and not refused.
+//
+// S3 has ended support for email grantees — "As of October 1, 2025 … the request will
+// receive an HTTP 405 (Method Not Allowed) error" — and substrate's clock is past that
+// date, but returning the 405 is Region-conditional and applies to the XML body form
+// too, so it is filed rather than guessed at. This test exists so that when #507 lands
+// it changes this behavior deliberately.
+func TestS3_ACL_EmailGranteeSkipped(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "email-grantee", map[string]string{
+		"x-amz-grant-read": `emailAddress="someone@example.com"`,
+	})
+
+	assert.Equal(t, []string{ownerGrant("email-grantee")}, getBucketACLGrants(t, srv, "email-grantee"),
+		"an email grantee is skipped today; #507 makes it a 405")
+}
+
+// TestS3_ACL_GrantHeadersAugmentTheOwnerGrant asserts a grant header adds to the
+// default ACL rather than replacing it.
+//
+// "you specify explicit access permissions and grantees … These permissions are then
+// added to the ACL on the object. By default, all objects are private. Only the owner
+// has full access control." A resolver that built the ACL from the headers alone would
+// silently drop the owner's FULL_CONTROL, which is a lockout rather than a grant.
+func TestS3_ACL_GrantHeadersAugmentTheOwnerGrant(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "augment", map[string]string{
+		"x-amz-grant-read":         `id="reader"`,
+		"x-amz-grant-full-control": `id="admin"`,
+	})
+
+	grants := getBucketACLGrants(t, srv, "augment")
+	assert.Equal(t, ownerGrant("augment"), grants[0], "the owner keeps FULL_CONTROL")
+	assert.ElementsMatch(t, []string{ownerGrant("augment"), "reader/READ", "admin/FULL_CONTROL"}, grants)
+}
+
+// TestS3_ACL_GrantHeadersWinOverCannedHeader pins the precedence between the two
+// forms.
+//
+// They are documented mutually exclusive — "If you use these ACL-specific headers, you
+// cannot use the x-amz-acl header to set a canned ACL" — but no error code is
+// documented for sending both, so substrate resolves rather than refuses and the grant
+// headers win, being the more specific expression. Which one wins cannot open a Block
+// Public Access hole either way, since the check reads the resolved ACL and the raw
+// headers both.
+func TestS3_ACL_GrantHeadersWinOverCannedHeader(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "both-forms", map[string]string{
+		"x-amz-acl":        "public-read",
+		"x-amz-grant-read": `id="reader"`,
+	})
+
+	assert.Equal(t, []string{ownerGrant("both-forms"), "reader/READ"},
+		getBucketACLGrants(t, srv, "both-forms"),
+		"the grant headers are the more specific expression")
+}
+
+// TestS3_ACL_NoHeaderStoresNothing asserts a write naming no ACL stores no ACL, and
+// still reports the owner-only default.
+//
+// The stored-state half is the point: a stored owner-only ACL and no stored ACL report
+// identically through GetObjectAcl, and only one of them records that the caller asked
+// for anything. Keeping the distinction is what lets an overwrite clear a previous ACL
+// without a parallel "was one named" flag threaded through every write path.
+func TestS3_ACL_NoHeaderStoresNothing(t *testing.T) {
+	t.Parallel()
+	state := emulator.NewMemoryStateManager()
+	srv, _ := newS3TestServerWithFS(t, state)
+	createBucketWithACL(t, srv, "bare", nil)
+	putObjectWithACL(t, srv, "bare", "k.txt", nil)
+
+	assert.Equal(t, []string{ownerGrant("bare")}, getBucketACLGrants(t, srv, "bare"))
+	assert.Equal(t, []string{ownerGrant("bare")}, getObjectACLGrants(t, srv, "bare", "k.txt"))
+
+	assert.True(t, storedACLAbsent(t, state, "bucket_acl:bare"),
+		"CreateBucket named no ACL, so nothing should be stored")
+	assert.True(t, storedACLAbsent(t, state, "object_acl:bare/k.txt"),
+		"PutObject named no ACL, so nothing should be stored")
+}
+
+// TestS3_ACL_ExplicitPrivateStoresAnACL is the converse of
+// TestS3_ACL_NoHeaderStoresNothing, and the assertion that keeps "named none" from
+// collapsing into "named the default".
+//
+// An x-amz-acl of private resolves to the same owner-only grants as the default, so the
+// two are indistinguishable through GetObjectAcl. The stored state is where they differ,
+// and the difference is load-bearing: only a request that named nothing may inherit
+// whatever the resolver later decides a default is, and only a stored ACL survives as a
+// record that the caller asked for one.
+func TestS3_ACL_ExplicitPrivateStoresAnACL(t *testing.T) {
+	t.Parallel()
+	state := emulator.NewMemoryStateManager()
+	srv, _ := newS3TestServerWithFS(t, state)
+	createBucketWithACL(t, srv, "explicit", map[string]string{"x-amz-acl": "private"})
+	putObjectWithACL(t, srv, "explicit", "k.txt", map[string]string{"x-amz-acl": "private"})
+
+	assert.Equal(t, []string{ownerGrant("explicit")}, getBucketACLGrants(t, srv, "explicit"))
+	assert.Equal(t, []string{ownerGrant("explicit")}, getObjectACLGrants(t, srv, "explicit", "k.txt"))
+
+	assert.False(t, storedACLAbsent(t, state, "bucket_acl:explicit"),
+		"CreateBucket named private, so an ACL should be stored")
+	assert.False(t, storedACLAbsent(t, state, "object_acl:explicit/k.txt"),
+		"PutObject named private, so an ACL should be stored")
+}
+
+// TestS3_ACL_OverwriteWithNoHeaderClearsStoredACL is the one a convenient
+// implementation gets wrong.
+//
+// A PUT is a whole-object replacement — "You cannot use PutObject to only update a
+// single piece of metadata for an existing object. You must put the entire object with
+// updated metadata" — so an overwrite naming no ACL must report owner-only afterwards
+// even if the key previously carried a public grant. Skipping the clear would silently
+// preserve a public grant across an overwrite that asked for none, which is the
+// direction that leaves data exposed.
+func TestS3_ACL_OverwriteWithNoHeaderClearsStoredACL(t *testing.T) {
+	t.Parallel()
+	state := emulator.NewMemoryStateManager()
+	srv, _ := newS3TestServerWithFS(t, state)
+	createBucketWithACL(t, srv, "overwrite", nil)
+
+	putObjectWithACL(t, srv, "overwrite", "k.txt", map[string]string{"x-amz-acl": "public-read"})
+	require.Equal(t, []string{ownerGrant("overwrite"), testGroupAllUsers + "/READ"},
+		getObjectACLGrants(t, srv, "overwrite", "k.txt"))
+
+	putObjectWithACL(t, srv, "overwrite", "k.txt", nil)
+	assert.Equal(t, []string{ownerGrant("overwrite")}, getObjectACLGrants(t, srv, "overwrite", "k.txt"),
+		"a PUT replaces the whole object, its ACL included")
+	assert.True(t, storedACLAbsent(t, state, "object_acl:overwrite/k.txt"))
+}
+
+// TestS3_ACL_OverwriteClearsAnACLSetByPutObjectAcl is the same rule against the other
+// way an ACL arrives: an ACL set by a separate PutObjectAcl call does not survive a
+// later PutObject either, because the PUT replaced the object it was attached to.
+func TestS3_ACL_OverwriteClearsAnACLSetByPutObjectAcl(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "overwrite2", nil)
+	putObjectWithACL(t, srv, "overwrite2", "k.txt", nil)
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/overwrite2/k.txt?acl", nil,
+		map[string]string{"x-amz-acl": "public-read"}).Code)
+	require.Contains(t, getObjectACLGrants(t, srv, "overwrite2", "k.txt"), testGroupAllUsers+"/READ")
+
+	putObjectWithACL(t, srv, "overwrite2", "k.txt", nil)
+	assert.Equal(t, []string{ownerGrant("overwrite2")}, getObjectACLGrants(t, srv, "overwrite2", "k.txt"))
+}
+
+// TestS3_ACL_CopyObjectDoesNotInherit asserts a copy takes its ACL from the request
+// and never from the source.
+//
+// "When you copy an object, the ACL metadata is not preserved and is set to private by
+// default. Only the owner has full access control. To override the default ACL setting,
+// specify a new ACL when you generate a copy request." So a copy of a public object is
+// private unless the copy request says otherwise — the opposite of the metadata
+// families, where COPY is the default directive.
+func TestS3_ACL_CopyObjectDoesNotInherit(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "copy-acl", nil)
+	putObjectWithACL(t, srv, "copy-acl", "src", map[string]string{"x-amz-acl": "public-read"})
+	require.Contains(t, getObjectACLGrants(t, srv, "copy-acl", "src"), testGroupAllUsers+"/READ")
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/copy-acl/plain", nil,
+		map[string]string{"X-Amz-Copy-Source": "/copy-acl/src"}).Code)
+	assert.Equal(t, []string{ownerGrant("copy-acl")}, getObjectACLGrants(t, srv, "copy-acl", "plain"),
+		"the source's public grant must not cross the copy")
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/copy-acl/granted", nil,
+		map[string]string{
+			"X-Amz-Copy-Source": "/copy-acl/src",
+			"x-amz-grant-read":  `id="reader"`,
+		}).Code)
+	assert.Equal(t, []string{ownerGrant("copy-acl"), "reader/READ"},
+		getObjectACLGrants(t, srv, "copy-acl", "granted"),
+		"the copy request's own ACL is honored")
+}
+
+// TestS3_ACL_CopyOverAPublicObjectClearsItsACL is the copy path's version of the
+// overwrite rule: a copy onto a key that already carries a public ACL replaces the
+// whole object, so the ACL goes with it.
+func TestS3_ACL_CopyOverAPublicObjectClearsItsACL(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "copy-over", nil)
+	putObjectWithACL(t, srv, "copy-over", "src", nil)
+	putObjectWithACL(t, srv, "copy-over", "dst", map[string]string{"x-amz-acl": "public-read"})
+	require.Contains(t, getObjectACLGrants(t, srv, "copy-over", "dst"), testGroupAllUsers+"/READ")
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/copy-over/dst", nil,
+		map[string]string{"X-Amz-Copy-Source": "/copy-over/src"}).Code)
+	assert.Equal(t, []string{ownerGrant("copy-over")}, getObjectACLGrants(t, srv, "copy-over", "dst"))
+}
+
+// completeUpload runs a whole one-part multipart upload against an existing bucket and
+// returns the upload ID, so an ACL assertion can be made against the assembled object.
+func completeUpload(t *testing.T, srv *emulator.Server, bucket, key string, headers map[string]string) string {
+	t.Helper()
+	iw := s3Request(t, srv, http.MethodPost, "/"+bucket+"/"+key+"?uploads", nil, headers)
+	require.Equal(t, http.StatusOK, iw.Code, "CreateMultipartUpload: %s", iw.Body.String())
+
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	etag := uploadPart(t, srv, bucket, key, ir.UploadID, 1, []byte("part one"))
+	cw := s3Request(t, srv, http.MethodPost,
+		fmt.Sprintf("/%s/%s?uploadId=%s", bucket, key, ir.UploadID), completeBody(etag), nil)
+	require.Equal(t, http.StatusOK, cw.Code, "CompleteMultipartUpload: %s", cw.Body.String())
+	return ir.UploadID
+}
+
+// TestS3_ACL_MultipartCarriesTheCreateACL asserts an ACL named at
+// CreateMultipartUpload reaches the object CompleteMultipartUpload assembles.
+//
+// Create is the only place it can be supplied — Complete's request accepts no ACL
+// header, exactly as it accepts no encryption header — so an ACL not carried on the
+// upload record is lost for good. That is the same shape #492 established for
+// server-side encryption, which is why the field sits beside it.
+func TestS3_ACL_MultipartCarriesTheCreateACL(t *testing.T) {
+	t.Parallel()
+	state := emulator.NewMemoryStateManager()
+	srv, _ := newS3TestServerWithFS(t, state)
+	createBucketWithACL(t, srv, "mpu-acl", nil)
+
+	uploadID := completeUpload(t, srv, "mpu-acl", "big.bin", map[string]string{
+		"x-amz-acl": "public-read",
+	})
+
+	assert.Equal(t, []string{ownerGrant("mpu-acl"), testGroupAllUsers + "/READ"},
+		getObjectACLGrants(t, srv, "mpu-acl", "big.bin"))
+
+	// The upload record is deleted by Complete, so the ACL is asserted on a second,
+	// still-open upload — the storage half of the round-trip, which a header echo
+	// could not prove.
+	iw := s3Request(t, srv, http.MethodPost, "/mpu-acl/other.bin?uploads", nil,
+		map[string]string{"x-amz-grant-read": `id="reader"`})
+	require.Equal(t, http.StatusOK, iw.Code)
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+	require.NotEqual(t, uploadID, ir.UploadID)
+
+	raw, err := state.Get(t.Context(), "s3", "multipart:"+ir.UploadID)
+	require.NoError(t, err)
+	var upload emulator.S3MultipartUpload
+	require.NoError(t, json.Unmarshal(raw, &upload))
+	require.NotNil(t, upload.ACL, "the create's ACL is recorded on the upload")
+	assert.Equal(t, "reader", upload.ACL.Grants[1].Grantee.ID)
+}
+
+// TestS3_ACL_MultipartWithNoACLClearsAPreviousOne is Complete's version of the
+// overwrite rule. Complete replaces the object at the key wholesale, so an upload that
+// named no ACL must clear one a previous object at that key carried.
+func TestS3_ACL_MultipartWithNoACLClearsAPreviousOne(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "mpu-clear", nil)
+	putObjectWithACL(t, srv, "mpu-clear", "big.bin", map[string]string{"x-amz-acl": "public-read"})
+	require.Contains(t, getObjectACLGrants(t, srv, "mpu-clear", "big.bin"), testGroupAllUsers+"/READ")
+
+	completeUpload(t, srv, "mpu-clear", "big.bin", nil)
+	assert.Equal(t, []string{ownerGrant("mpu-clear")}, getObjectACLGrants(t, srv, "mpu-clear", "big.bin"))
+}
+
+// TestS3_ACL_CreateBucketClearsAStaleACL covers the recreate-after-delete case.
+//
+// DeleteBucket removes the bucket: entry and leaves its sub-resources behind, so
+// without a clear on create, a bucket created public, deleted and created again would
+// report the deleted bucket's ACL. The create is authoritative either way — the same
+// whole-resource-replacement rule the object path follows. The other bucket
+// sub-resources still leak, which is #508 rather than this fix.
+func TestS3_ACL_CreateBucketClearsAStaleACL(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	createBucketWithACL(t, srv, "recreated", map[string]string{"x-amz-acl": "public-read"})
+	require.Contains(t, getBucketACLGrants(t, srv, "recreated"), testGroupAllUsers+"/READ")
+
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/recreated", nil, nil).Code)
+	createBucketWithACL(t, srv, "recreated", nil)
+
+	assert.Equal(t, []string{ownerGrant("recreated")}, getBucketACLGrants(t, srv, "recreated"),
+		"a recreated bucket must not inherit the deleted bucket's ACL")
+}
+
+// TestS3_ACL_NonCanonicalHeaderNames asserts every ACL header is read
+// case-insensitively.
+//
+// Requests reaching a plugin have not always been through net/http's canonicalization
+// — substrate builds them in-process too — so the plugin is exercised directly here.
+// Sending lowercase names through the server would prove nothing, because Go would
+// canonicalize them on the way in.
+func TestS3_ACL_NonCanonicalHeaderNames(t *testing.T) {
+	p := newS3PluginDirect(t)
+	rctx := &emulator.RequestContext{AccountID: "000000000000", Region: "us-east-1"}
+
+	// Operation carries the HTTP verb on entry; the plugin resolves the semantic
+	// operation from it and the path, exactly as the server pipeline does.
+	_, err := p.HandleRequest(rctx, &emulator.AWSRequest{
+		Service: "s3", Operation: http.MethodPut, Path: "/acl-fold",
+		Params:  map[string]string{},
+		Headers: map[string]string{"X-AMZ-ACL": "public-read"}, // canonical is X-Amz-Acl
+	})
+	require.NoError(t, err)
+
+	_, err = p.HandleRequest(rctx, &emulator.AWSRequest{
+		Service: "s3", Operation: http.MethodPut, Path: "/acl-fold/k.txt", Body: []byte("x"),
+		Params:  map[string]string{},
+		Headers: map[string]string{"x-amz-grant-READ": `uri="` + testGroupLogDelivery + `"`},
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct{ path, want string }{
+		{"/acl-fold", testGroupAllUsers + "/READ"},
+		{"/acl-fold/k.txt", testGroupLogDelivery + "/READ"},
+	} {
+		resp, aclErr := p.HandleRequest(rctx, &emulator.AWSRequest{
+			Service: "s3", Operation: http.MethodGet, Path: tc.path,
+			Headers: map[string]string{}, Params: map[string]string{"acl": "1"},
+		})
+		require.NoError(t, aclErr)
+		require.Equal(t, http.StatusOK, resp.StatusCode, tc.path)
+
+		assert.Equal(t, []string{ownerGrant("acl-fold"), tc.want}, aclGrantPairs(t, resp.Body), tc.path)
+	}
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -381,7 +381,7 @@ func (p *S3Plugin) listBuckets(_ *RequestContext, _ *AWSRequest) (*AWSResponse, 
 }
 
 // createBucket handles PUT /<bucket>.
-func (p *S3Plugin) createBucket(reqCtx *RequestContext, _ *AWSRequest, bucket string) (*AWSResponse, error) {
+func (p *S3Plugin) createBucket(reqCtx *RequestContext, req *AWSRequest, bucket string) (*AWSResponse, error) {
 	if !validateBucketName(bucket) {
 		return s3ErrorResponse("InvalidBucketName", "The specified bucket is not valid.", http.StatusBadRequest), nil
 	}
@@ -416,10 +416,101 @@ func (p *S3Plugin) createBucket(reqCtx *RequestContext, _ *AWSRequest, bucket st
 		return nil, fmt.Errorf("save bucket: %w", err)
 	}
 
+	// The ACL is stored after the bucket, not before: a bucket_acl: entry for a
+	// bucket that does not exist would be readable through no operation and would
+	// outlive a DeleteBucket. Nothing between the two writes can fail, so there is
+	// no window in which one lands without the other.
+	//
+	// Block Public Access is not consulted here, and deliberately: substrate models
+	// no account-level configuration, and a bucket-level one cannot exist before the
+	// bucket does. See [S3Plugin.s3CreateBucketACL].
+	if err := p.s3CreateBucketACL(ctx, req, bucket); err != nil {
+		return nil, err
+	}
+
 	return &AWSResponse{
 		StatusCode: http.StatusOK,
 		Headers:    map[string]string{"Location": "/" + bucket},
 	}, nil
+}
+
+// s3StoreObjectACL persists the ACL a write named, or clears any stored ACL when
+// it named none.
+//
+// The delete is the part that is easy to leave out and wrong to: every operation
+// that reaches here writes a whole object, so a write that names no ACL must report
+// the default owner-only ACL afterwards even if the key previously carried a public
+// one — "You cannot use PutObject to only update a single piece of metadata for an
+// existing object. You must put the entire object with updated metadata." Not
+// clearing would leave a grant the caller's last write did not ask for, which is
+// the same silent-carry-across the copy path is documented to avoid.
+func (p *S3Plugin) s3StoreObjectACL(ctx context.Context, bucket, key string, acl *S3AccessControlList) error {
+	stateKey := "object_acl:" + bucket + "/" + key
+	if acl == nil {
+		if err := p.state.Delete(ctx, s3Namespace, stateKey); err != nil {
+			return fmt.Errorf("clear object acl: %w", err)
+		}
+		return nil
+	}
+	raw, err := json.Marshal(acl)
+	if err != nil {
+		return fmt.Errorf("marshal object acl: %w", err)
+	}
+	if err := p.state.Put(ctx, s3Namespace, stateKey, raw); err != nil {
+		return fmt.Errorf("put object acl: %w", err)
+	}
+	return nil
+}
+
+// s3CreateBucketACL stores the ACL a CreateBucket request named, or clears any
+// bucket_acl: entry left behind by a previous bucket of the same name.
+//
+// A request with no ACL header stores nothing, so an unconfigured bucket keeps
+// reporting the default ACL [s3DefaultACL] synthesizes on read rather than a stored
+// copy of it. The two are identical in content; storing nothing keeps the state
+// store's contents a record of what the caller actually asked for.
+//
+// The clear is not hypothetical tidiness: DeleteBucket removes the bucket: entry and
+// leaves its sub-resources behind, so without it a bucket created, given a public
+// ACL, deleted and created again would report the deleted bucket's ACL. That the
+// create is authoritative either way is the same whole-resource-replacement rule
+// [S3Plugin.s3StoreObjectACL] follows. Other bucket sub-resources — the policy, the
+// Block Public Access configuration, tagging — still outlive a DeleteBucket; that is
+// pre-existing and wider than this fix (#508).
+//
+// **Block Public Access cannot refuse a CreateBucket in substrate, and that is a
+// stated scope boundary rather than an oversight** (#470). Real S3 refuses one:
+// "if your desired bucket ACL grants public access, you must first create the
+// bucket (without the bucket ACL) and then explicitly disable Block Public Access
+// on the bucket before using PutBucketAcl to set the ACL. If you try to create a
+// bucket with a public ACL, the request will fail." But the configuration that
+// refuses it is the *account-level* one — a bucket-level configuration cannot
+// exist before the bucket — and substrate models no account-level Block Public
+// Access at all. Inventing one to gate this single operation would be modeling a
+// control the emulator does not otherwise have, and would refuse a create that
+// every consumer's current fixtures expect to succeed. The bucket ACL a create
+// stores is enforced from then on: PutObject, PutObjectAcl and PutBucketAcl all
+// consult the bucket's configuration.
+func (p *S3Plugin) s3CreateBucketACL(ctx context.Context, req *AWSRequest, bucket string) error {
+	if req == nil {
+		return nil
+	}
+	stateKey := "bucket_acl:" + bucket
+	acl := s3RequestACL(req.Headers, bucket, s3ACLBucket)
+	if acl == nil {
+		if err := p.state.Delete(ctx, s3Namespace, stateKey); err != nil {
+			return fmt.Errorf("clear bucket acl: %w", err)
+		}
+		return nil
+	}
+	raw, err := json.Marshal(acl)
+	if err != nil {
+		return fmt.Errorf("marshal bucket acl: %w", err)
+	}
+	if err := p.state.Put(ctx, s3Namespace, stateKey, raw); err != nil {
+		return fmt.Errorf("put bucket acl: %w", err)
+	}
+	return nil
 }
 
 // headBucket handles HEAD /<bucket>.
@@ -478,6 +569,20 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 	storageClass, scErr := resolveStorageClass(req.Headers)
 	if scErr != nil {
 		return scErr, nil
+	}
+
+	// BlockPublicAcls rejects a PutObject carrying a public ACL — "PUT Object calls
+	// fail if the request includes a public ACL" — and rejects it here, before the
+	// body reaches the filesystem and before any metadata is stored, so a refused
+	// upload leaves the key exactly as it was. That all-or-nothing property is what
+	// lets a consumer assert the object is absent afterwards (#470). Substrate
+	// accepted such an upload with a 200 until this fix, which meant a bucket real S3
+	// would have refused took the object.
+	objectACL := s3RequestACL(req.Headers, bucket, s3ACLObject)
+	if denied, dErr := p.s3RequestACLDenied(ctx, bucket, objectACL, req.Headers); dErr != nil {
+		return nil, dErr
+	} else if denied != nil {
+		return denied, nil
 	}
 
 	// Conditional writes must not race: the existence check and the write below have
@@ -597,6 +702,13 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 
 	if err := p.state.Put(ctx, s3Namespace, "object:"+bucket+"/"+key, data); err != nil {
 		return nil, fmt.Errorf("save object metadata: %w", err)
+	}
+
+	// A PUT replaces the whole object, its ACL included, so an overwrite that names no
+	// ACL resets one a previous PutObjectAcl had set rather than inheriting it. See
+	// [S3Plugin.s3StoreObjectACL], where the reasoning and the citation are.
+	if err := p.s3StoreObjectACL(ctx, bucket, key, objectACL); err != nil {
+		return nil, err
 	}
 
 	p.fireNotifications(reqCtx, bucket, key, "s3:ObjectCreated:Put", obj.Size, etag)
@@ -1023,6 +1135,24 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 		return cksErr, nil
 	}
 
+	// A copy's ACL comes from the request and from nowhere else: "When you copy an
+	// object, the ACL metadata is not preserved and is set to private by default. Only
+	// the owner has full access control. To override the default ACL setting, specify a
+	// new ACL when you generate a copy request." So a nil here — the request named no
+	// ACL — must clear the destination's stored ACL rather than leave the source's or
+	// the destination's previous one in place, which is exactly what
+	// [S3Plugin.s3StoreObjectACL] does with it below.
+	//
+	// The configuration consulted is the *destination* bucket's, and it is consulted
+	// before the body is written, so a refused copy leaves the destination key exactly
+	// as it was — the same all-or-nothing property PutObject has.
+	dstACL := s3RequestACL(req.Headers, dstBucket, s3ACLObject)
+	if denied, dErr := p.s3RequestACLDenied(ctx, dstBucket, dstACL, req.Headers); dErr != nil {
+		return nil, dErr
+	} else if denied != nil {
+		return denied, nil
+	}
+
 	// Source preconditions gate whether the copy may read; destination
 	// preconditions gate whether it may overwrite. Both are checked before any
 	// write, so a rejected copy leaves the destination untouched.
@@ -1103,6 +1233,10 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 	}
 	if err := p.state.Put(ctx, s3Namespace, "object:"+dstBucket+"/"+dstKey, dstMeta); err != nil {
 		return nil, fmt.Errorf("save dest metadata: %w", err)
+	}
+
+	if err := p.s3StoreObjectACL(ctx, dstBucket, dstKey, dstACL); err != nil {
+		return nil, err
 	}
 
 	type copyObjectResult struct {
@@ -1338,6 +1472,19 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		return cksErr, nil
 	}
 
+	// The ACL is fixed here too, and for the same reason the encryption is: Complete's
+	// request carries no ACL header, so an ACL not recorded on the upload is lost for
+	// good. BlockPublicAcls is therefore evaluated here as well — a public ACL named at
+	// create is refused before an upload ID exists, so a consumer cannot upload parts
+	// against an upload whose Complete was always going to be refused. Nothing has been
+	// written at this point, so the refusal leaves no upload behind.
+	uploadACL := s3RequestACL(req.Headers, bucket, s3ACLObject)
+	if denied, dErr := p.s3RequestACLDenied(ctx, bucket, uploadACL, req.Headers); dErr != nil {
+		return nil, dErr
+	} else if denied != nil {
+		return denied, nil
+	}
+
 	uploadID := generateUploadID()
 
 	// Resolved case-insensitively, like every other header this function reads
@@ -1358,6 +1505,7 @@ func (p *S3Plugin) createMultipartUpload(_ *RequestContext, req *AWSRequest, buc
 		S3SystemMetadata:       resolveSystemMetadata(req.Headers),
 		S3ServerSideEncryption: resolveServerSideEncryption(req.Headers),
 		StorageClass:           storageClass,
+		ACL:                    uploadACL,
 		ChecksumAlgorithm:      checksumAlgorithm,
 		ChecksumType:           checksumType,
 		Initiated:              p.tc.Now(),
@@ -1634,6 +1782,15 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 	}
 	if err := p.state.Put(ctx, s3Namespace, "object:"+bucket+"/"+key, objData); err != nil {
 		return nil, fmt.Errorf("save assembled object metadata: %w", err)
+	}
+
+	// The ACL crosses from the upload the same way the metadata families do, and for
+	// the same reason: this request carries no ACL header to read. Storing it here
+	// rather than at create keeps the invariant every other write path has — an
+	// object_acl: entry exists only for an object that exists — and a nil clears any
+	// ACL a previous object at this key had, since Complete replaces it wholesale.
+	if err := p.s3StoreObjectACL(ctx, bucket, key, upload.ACL); err != nil {
+		return nil, err
 	}
 
 	// Clean up multipart state.
@@ -2537,8 +2694,10 @@ func (p *S3Plugin) putBucketACL(_ *RequestContext, req *AWSRequest, bucket strin
 				"The XML you provided was not well-formed.", http.StatusBadRequest), nil
 		}
 	} else {
-		// Honor the x-amz-acl canned ACL header.
-		acl = s3CannedACL(req.Headers["X-Amz-Acl"], bucket)
+		// Honor the x-amz-acl canned ACL header and the x-amz-grant-* family. Until
+		// #470 only the canned header was read here, so an ACL set through grant
+		// headers was refused when public and silently discarded when not.
+		acl = s3ResolveRequestACL(req.Headers, bucket, s3ACLBucket)
 	}
 
 	// BlockPublicAcls rejects a PutBucketAcl carrying a public ACL, without
@@ -2619,7 +2778,7 @@ func (p *S3Plugin) putObjectACL(_ *RequestContext, req *AWSRequest, bucket, key 
 				"The XML you provided was not well-formed.", http.StatusBadRequest), nil
 		}
 	} else {
-		acl = s3CannedACL(req.Headers["X-Amz-Acl"], bucket)
+		acl = s3ResolveRequestACL(req.Headers, bucket, s3ACLObject)
 	}
 
 	// The configuration consulted is the *bucket's*: Block Public Access has no
@@ -2642,17 +2801,6 @@ func (p *S3Plugin) putObjectACL(_ *RequestContext, req *AWSRequest, bucket, key 
 		StatusCode: http.StatusOK,
 		Headers:    map[string]string{},
 	}, nil
-}
-
-// s3DefaultACL returns an owner-full-control ACL for the given resource.
-func s3DefaultACL(resource string) S3AccessControlList {
-	return S3AccessControlList{
-		Owner: S3Owner{ID: resource + "-owner", DisplayName: resource},
-		Grants: []S3Grant{{
-			Grantee:    S3Grantee{Type: "CanonicalUser", ID: resource + "-owner"},
-			Permission: "FULL_CONTROL",
-		}},
-	}
 }
 
 // getBucketNotificationConfiguration handles GET /<bucket>?notification.
@@ -3066,34 +3214,6 @@ func (p *S3Plugin) deleteObjectTagging(_ *RequestContext, _ *AWSRequest, bucket,
 		return nil, fmt.Errorf("deleteObjectTagging state.Put: %w", putErr)
 	}
 	return &AWSResponse{StatusCode: http.StatusNoContent, Headers: map[string]string{"Content-Type": "application/xml"}, Body: nil}, nil
-}
-
-// s3CannedACL maps a canned ACL name (x-amz-acl header) to an S3AccessControlList.
-// Unsupported or empty canned ACL values fall back to the private (owner-only) ACL.
-func s3CannedACL(cannedACL, resource string) S3AccessControlList {
-	owner := S3Owner{ID: resource + "-owner", DisplayName: resource}
-	fullControlGrant := S3Grant{
-		Grantee:    S3Grantee{Type: "CanonicalUser", ID: resource + "-owner"},
-		Permission: "FULL_CONTROL",
-	}
-	publicReadGrant := S3Grant{
-		Grantee:    S3Grantee{Type: "Group", URI: "http://acs.amazonaws.com/groups/global/AllUsers"},
-		Permission: "READ",
-	}
-
-	switch cannedACL {
-	case "public-read":
-		return S3AccessControlList{Owner: owner, Grants: []S3Grant{fullControlGrant, publicReadGrant}}
-	case "public-read-write":
-		return S3AccessControlList{Owner: owner, Grants: []S3Grant{
-			fullControlGrant,
-			publicReadGrant,
-			{Grantee: S3Grantee{Type: "Group", URI: "http://acs.amazonaws.com/groups/global/AllUsers"}, Permission: "WRITE"},
-		}}
-	default:
-		// "private" and all other values → owner-only.
-		return S3AccessControlList{Owner: owner, Grants: []S3Grant{fullControlGrant}}
-	}
 }
 
 // --- Versioning helpers ------------------------------------------------------

--- a/emulator/s3_publicaccess.go
+++ b/emulator/s3_publicaccess.go
@@ -84,13 +84,34 @@ func (p *S3Plugin) s3BlocksPublicPolicy(ctx context.Context, bucket string) (boo
 	return cfg != nil && cfg.BlockPublicPolicy, nil
 }
 
+// s3RequestACLDenied returns the 403 to send when a create operation named a
+// public ACL on a bucket that blocks them, or nil when the write may proceed.
+//
+// A nil acl — the request named none — proceeds without consulting the bucket at
+// all. That short-circuit is safe rather than convenient: [s3RequestACL] returns
+// nil only when [s3RequestNamesACL] found none of the six headers in any case, so
+// there is nothing for either half of [S3Plugin.s3PublicACLDenied] to find, and the
+// resolved default ACL grants only the owner.
+//
+// PutObject, CopyObject, CreateMultipartUpload and CreateBucket all go through
+// here; PutBucketAcl and PutObjectAcl call s3PublicACLDenied directly, because an
+// ACL is never absent from those two — an empty body resolves to private.
+func (p *S3Plugin) s3RequestACLDenied(ctx context.Context, bucket string, acl *S3AccessControlList, headers map[string]string) (*AWSResponse, error) {
+	if acl == nil {
+		return nil, nil
+	}
+	return p.s3PublicACLDenied(ctx, bucket, *acl, headers)
+}
+
 // s3PublicACLDenied returns the 403 to send when a bucket blocks public ACLs and
 // the request carries one, or nil when the request may proceed.
 //
 // The ACL and the headers are both examined because they are two of the three ways
-// a public grant arrives: acl is what PutBucketAcl/PutObjectAcl resolved from the
-// XML body or the x-amz-acl canned header, and headers still needs reading for
-// x-amz-grant-*, which substrate does not fold into the resolved ACL.
+// a public grant arrives: acl is what the caller's XML body or x-amz-acl canned
+// header resolved to, and headers still needs reading for x-amz-grant-* — which
+// [s3ResolveRequestACL] does fold into the resolved ACL as of #470, but only when
+// the caller sent no XML body. PutBucketAcl with a private body and a public grant
+// header is the case the second half still catches.
 //
 // The error return is reserved for a state-store failure, which the caller must
 // propagate rather than report as an authorization decision.
@@ -126,40 +147,24 @@ func s3ACLIsPublic(acl S3AccessControlList) bool {
 	return false
 }
 
-// s3GrantHeaderNames are the x-amz-grant-* headers PutBucketAcl and PutObjectAcl
-// accept, each naming grantees for one permission.
-//
-// Substrate does not otherwise model these headers — an ACL set through them is
-// not stored, which is a separate gap. They are parsed here because a header
-// naming a public group URI is a public ACL expressed the third documented way,
-// and a Block Public Access check that ignored them would have a hole a consumer
-// could drive a public grant straight through.
-var s3GrantHeaderNames = []string{
-	"X-Amz-Grant-Read",
-	"X-Amz-Grant-Write",
-	"X-Amz-Grant-Read-Acp",
-	"X-Amz-Grant-Write-Acp",
-	"X-Amz-Grant-Full-Control",
-}
-
 // s3GrantHeadersArePublic reports whether any x-amz-grant-* header names a
 // predefined public group.
 //
-// The header value is a comma-separated list of grantees, each written as
-// type=value — for example `uri="http://acs.amazonaws.com/groups/global/AllUsers"`.
-// Values may be quoted, so quotes are trimmed before the comparison.
+// A header naming a public group URI is a public ACL expressed the third
+// documented way, so a Block Public Access check that ignored them would have a
+// hole a consumer could drive a public grant straight through. Since #470 an ACL
+// set through them is also *stored*, which means [s3ACLIsPublic] catches most of
+// these first; this stays the check that covers the one case it cannot, a
+// PutBucketAcl or PutObjectAcl whose XML body wins over its headers.
+//
+// The names and the grantee parsing are [s3GrantHeaders] and [s3ParseGrantees],
+// shared with the resolver so the two can never disagree about which headers exist
+// or how a grantee is spelled — and the read is case-insensitive for the reason
+// [s3GrantsFromHeaders] gives.
 func s3GrantHeadersArePublic(headers map[string]string) bool {
-	for _, name := range s3GrantHeaderNames {
-		value := headers[name]
-		if value == "" {
-			continue
-		}
-		for _, grantee := range strings.Split(value, ",") {
-			key, val, found := strings.Cut(strings.TrimSpace(grantee), "=")
-			if !found || !strings.EqualFold(strings.TrimSpace(key), "uri") {
-				continue
-			}
-			switch strings.Trim(strings.TrimSpace(val), `"`) {
+	for _, gh := range s3GrantHeaders {
+		for _, grantee := range s3ParseGrantees(headerValueFold(headers, gh.name)) {
+			switch grantee.URI {
 			case s3GroupAllUsers, s3GroupAuthenticatedUsers:
 				return true
 			}

--- a/emulator/s3_publicaccess_test.go
+++ b/emulator/s3_publicaccess_test.go
@@ -211,6 +211,18 @@ func publicACLCases() []aclCase {
 			},
 			public: true,
 		},
+		{
+			// A body and a grant header together: the body wins as the ACL, so the
+			// resolved ACL is owner-only and only the separate grant-header check sees
+			// the public grantee. Since #470 resolved every other route through the
+			// ACL itself, this is the one case that check still uniquely catches — and
+			// a public grant reaching the wire alongside a private body is exactly the
+			// request Block Public Access exists to refuse.
+			name:    "private xml body with a public grant header",
+			body:    aclXML("", ""),
+			headers: map[string]string{"x-amz-grant-read": `uri="` + testGroupAllUsers + `"`},
+			public:  true,
+		},
 		{name: "canned private", headers: map[string]string{"x-amz-acl": "private"}, public: false},
 		{name: "owner-only xml", body: aclXML("", ""), public: false},
 		{
@@ -714,4 +726,188 @@ func nilIfEmptyBody(body string) []byte {
 		return nil
 	}
 	return []byte(body)
+}
+
+// headerACLCases are the publicACLCases that arrive through headers alone.
+//
+// The three create operations accept no ACL body, so the XML rows are not
+// expressible against them. Filtering rather than writing a second table keeps the
+// definition of "public" in one place: a case added to publicACLCases is picked up
+// here automatically.
+func headerACLCases() []aclCase {
+	var cases []aclCase
+	for _, tc := range publicACLCases() {
+		if tc.body == "" {
+			cases = append(cases, tc)
+		}
+	}
+	return cases
+}
+
+// TestS3_BlockPublicAcls_PutObject asserts BlockPublicAcls refuses a PutObject
+// carrying a public ACL, and that the object is not stored.
+//
+// This is the operation #458 could not cover: putObject read no ACL header at all,
+// so there was nothing for the check to examine — a consumer could upload a
+// public-read object to a bucket that blocks public ACLs and get a 200. The rule is
+// its own bullet on the setting: "PUT Object calls fail if the request includes a
+// public ACL."
+//
+// The not-stored half is the assertion that matters. Refusing after the body reached
+// the filesystem would leave a key behind that GetObject serves and GetObjectAcl
+// reports as private, which is worse than either accepting or refusing cleanly.
+func TestS3_BlockPublicAcls_PutObject(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range headerACLCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+			bucket := newPABBucket(t, srv, "put-object-acl")
+			require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabBlockACLsOnly).Code)
+
+			w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/k.txt", []byte("hi"), tc.headers)
+			if !tc.public {
+				require.Equal(t, http.StatusOK, w.Code, "PutObject should be accepted: %s", w.Body.String())
+				return
+			}
+
+			require.Equal(t, http.StatusForbidden, w.Code, "PutObject should be refused: %s", w.Body.String())
+			assert.Equal(t, "AccessDenied", s3ErrorCode(t, w.Body.Bytes()))
+			assert.Equal(t, "Access Denied", s3ErrorMessage(t, w.Body.Bytes()))
+
+			assert.Equal(t, http.StatusNotFound,
+				s3Request(t, srv, http.MethodGet, "/"+bucket+"/k.txt", nil, nil).Code,
+				"a refused PutObject must not store the object")
+		})
+	}
+}
+
+// TestS3_BlockPublicAcls_PutObjectDoesNotClobber is the overwrite case: a refused
+// PutObject must leave the object that was already at the key exactly as it was,
+// body and ACL both.
+//
+// "Enabling this setting doesn't affect existing policies or ACLs" — and a check
+// that ran after the write would satisfy the status code while destroying the
+// object, which no assertion on the response alone would catch.
+func TestS3_BlockPublicAcls_PutObjectDoesNotClobber(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "no-clobber")
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+bucket+"/k.txt", []byte("original"), nil).Code)
+	require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabBlockACLsOnly).Code)
+
+	before := getObjectACLGrants(t, srv, bucket, "k.txt")
+
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/k.txt", []byte("replacement"),
+		map[string]string{"x-amz-acl": "public-read"})
+	require.Equal(t, http.StatusForbidden, w.Code, "%s", w.Body.String())
+
+	gw := s3Request(t, srv, http.MethodGet, "/"+bucket+"/k.txt", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Equal(t, "original", gw.Body.String(), "a refused overwrite must not replace the body")
+	assert.Equal(t, before, getObjectACLGrants(t, srv, bucket, "k.txt"))
+}
+
+// TestS3_BlockPublicAcls_CopyObject asserts the check applies to a copy, against the
+// *destination* bucket's configuration.
+//
+// A copy is a PutObject that names its body by reference, so the same rule reaches
+// it — and the bucket whose setting decides is the one the object lands in. Reading
+// the source's instead would let a consumer launder a public ACL into a blocked
+// bucket by copying rather than uploading.
+func TestS3_BlockPublicAcls_CopyObject(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	src := newPABBucket(t, srv, "copy-src")
+	dst := newPABBucket(t, srv, "copy-dst")
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+src+"/k.txt", []byte("hi"), nil).Code)
+	require.Equal(t, http.StatusOK, putPAB(t, srv, dst, pabBlockACLsOnly).Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/"+dst+"/k.txt", nil, map[string]string{
+		"X-Amz-Copy-Source": "/" + src + "/k.txt",
+		"x-amz-acl":         "public-read",
+	})
+	require.Equal(t, http.StatusForbidden, w.Code, "%s", w.Body.String())
+	assert.Equal(t, "AccessDenied", s3ErrorCode(t, w.Body.Bytes()))
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodGet, "/"+dst+"/k.txt", nil, nil).Code,
+		"a refused CopyObject must not store the destination object")
+
+	// The mirror image: the source blocks public ACLs, the destination does not, and
+	// the copy is allowed. It is the destination's setting that governs.
+	require.Equal(t, http.StatusOK, putPAB(t, srv, src, pabBlockACLsOnly).Code)
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/"+dst+"?publicAccessBlock", nil, nil).Code)
+
+	allowed := s3Request(t, srv, http.MethodPut, "/"+dst+"/k.txt", nil, map[string]string{
+		"X-Amz-Copy-Source": "/" + src + "/k.txt",
+		"x-amz-acl":         "public-read",
+	})
+	assert.Equal(t, http.StatusOK, allowed.Code, "%s", allowed.Body.String())
+	assert.Contains(t, getObjectACLGrants(t, srv, dst, "k.txt"), testGroupAllUsers+"/READ")
+}
+
+// TestS3_BlockPublicAcls_CreateMultipartUpload asserts the refusal lands at create
+// rather than at complete, and that no upload is left behind.
+//
+// Create is the only place a multipart upload's ACL can be named — Complete's request
+// accepts no ACL header — so it is also the only place the check can run. Deferring
+// it to Complete would let a consumer upload every part of a large object before
+// discovering the write was always going to be refused, and would leave an upload ID
+// behind that only AbortMultipartUpload could clean up.
+func TestS3_BlockPublicAcls_CreateMultipartUpload(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+	bucket := newPABBucket(t, srv, "mpu-blocked")
+	require.Equal(t, http.StatusOK, putPAB(t, srv, bucket, pabBlockACLsOnly).Code)
+
+	w := s3Request(t, srv, http.MethodPost, "/"+bucket+"/big.bin?uploads", nil,
+		map[string]string{"x-amz-acl": "public-read"})
+	require.Equal(t, http.StatusForbidden, w.Code, "%s", w.Body.String())
+	assert.Equal(t, "AccessDenied", s3ErrorCode(t, w.Body.Bytes()))
+
+	lw := s3Request(t, srv, http.MethodGet, "/"+bucket+"?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, lw.Code)
+	assert.NotContains(t, lw.Body.String(), "big.bin",
+		"a refused CreateMultipartUpload must leave no upload behind")
+
+	// The positive control, without which the assertion above would pass even if
+	// ListMultipartUploads reported nothing at all: an accepted create is listed.
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPost, "/"+bucket+"/allowed.bin?uploads", nil,
+			map[string]string{"x-amz-acl": "private"}).Code)
+	lw2 := s3Request(t, srv, http.MethodGet, "/"+bucket+"?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, lw2.Code)
+	assert.Contains(t, lw2.Body.String(), "allowed.bin")
+}
+
+// TestS3_BlockPublicAcls_CreateBucket pins the account-level scope decision: a
+// CreateBucket naming a public ACL is **accepted**.
+//
+// The setting's own bullet says such a call fails — "PUT Bucket calls fail if the
+// request includes a public ACL" — but the configuration that would refuse it is the
+// *account-level* one, since a bucket-level configuration cannot exist before the
+// bucket does. Substrate models no account-level Block Public Access, so gating this
+// one operation would be modeling a control the emulator does not otherwise have.
+//
+// This test asserts the gap deliberately rather than leaving it untested, so that
+// adding account-level support later changes a failing test rather than passing
+// silently in whichever direction the new code happens to take.
+func TestS3_BlockPublicAcls_CreateBucket(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	// An existing bucket's configuration cannot reach a different bucket's creation,
+	// which is the near-miss worth ruling out: the block is per-bucket.
+	blocked := newPABBucket(t, srv, "already-blocked")
+	require.Equal(t, http.StatusOK, putPAB(t, srv, blocked, pabAllTrue).Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/fresh-public", nil,
+		map[string]string{"x-amz-acl": "public-read"})
+	require.Equal(t, http.StatusOK, w.Code,
+		"substrate models no account-level Block Public Access: %s", w.Body.String())
+	assert.Contains(t, getBucketACLGrants(t, srv, "fresh-public"), testGroupAllUsers+"/READ")
 }

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -188,6 +188,18 @@ type S3MultipartUpload struct {
 	// the object CompleteMultipartUpload assembles. Empty means STANDARD.
 	StorageClass string `json:"storage_class,omitempty"`
 
+	// ACL is the access control list the x-amz-acl or x-amz-grant-* headers named at
+	// upload creation, applied to the object CompleteMultipartUpload assembles. Nil
+	// when the create named none, which is what makes the assembled object report the
+	// default owner-only ACL rather than a stored copy of it.
+	//
+	// Create is the only place an ACL can be supplied — Complete's request accepts no
+	// ACL header, exactly as it accepts no encryption header — so a multipart object's
+	// ACL is fixed for the whole upload at creation. A pointer rather than a value
+	// because "named none" and "named private" are different observations here in the
+	// same way they are on [S3Plugin.s3StoreObjectACL].
+	ACL *S3AccessControlList `json:"acl,omitempty"`
+
 	// ChecksumAlgorithm is the algorithm named in x-amz-checksum-algorithm at
 	// upload creation, applied to every part and to the assembled object. Empty
 	// when the upload was created without one.


### PR DESCRIPTION
Closes #470

Follow-up to #458, which enforced `BlockPublicAcls` on `PutBucketAcl`/`PutObjectAcl` only. The other operations were uncoverable because none of them read `x-amz-acl`.

## What was broken

Two defects, one of which hid the other:

1. **No create operation resolved an ACL.** `PutObject`, `CopyObject`, `CreateMultipartUpload` and `CreateBucket` all discarded `x-amz-acl`, so `GetObjectAcl`/`GetBucketAcl` reported the owner-only default regardless of what the write asked for. A consumer asserting "my upload is publicly readable" saw the default and had no way to tell the header had been dropped.
2. **The `x-amz-grant-*` family was stored by no operation** — including `PutBucketAcl` and `PutObjectAcl`, which is wider than the issue title suggests. `s3GrantHeadersArePublic` parsed the grantee lists for #458's check, but nothing persisted them.

Together those left Block Public Access covering two of six operations, because the other four had no ACL to judge. **`authenticated-read` was the hole that mattered**: it is public by BPA's own definition ("`AuthenticatedUsers` group gets READ access"), so a bucket with `BlockPublicAcls` set could be walked through with one `PutObject --acl authenticated-read`.

## The change

The ACL model moves to a new `emulator/s3_acl.go`. `s3RequestACL` returns **`nil` when a request names no ACL**, which keeps "named none" distinguishable from "named the default" — the two report identically through `GetObjectAcl`, and only the distinction lets an overwrite clear a previous ACL without a parallel "was one named" flag threaded through every write path. Grant headers **augment** the owner's `FULL_CONTROL` rather than replacing it (replacing it is a lockout, not a grant) and **win over** a canned header when both are sent.

Six operations now resolve and store an ACL: `PutObject`, `CopyObject`, `CreateMultipartUpload`, `CreateBucket`, `PutBucketAcl`, `PutObjectAcl`.

Block Public Access refuses the three creates **before any write**, with a copy judged against the **destination** bucket's configuration. So a refusal leaves no object, no destination object and no open upload — the same all-or-nothing property #468 established on the EC2 side. A `CopyObject` never inherits the source's ACL; a multipart upload's ACL is fixed at create and applied at completion.

Also fixed in passing: `DeleteBucket` leaked the `bucket_acl:` key. The other six S3 per-bucket keys it also leaks are tracked separately.

## The account-level question

#470's fourth criterion offers a fork, and this takes the second branch. `CreateBucket` with a public ACL is **still accepted**: a bucket-level BPA configuration cannot exist before the bucket does, so the operation is only refusable at the *account* level, which substrate does not model at all. Inventing one to gate `CreateBucket` would be modelling a control the emulator otherwise lacks.

The gap is documented in `docs/services.md` **and pinned by a test**, with an already-blocked sibling bucket present to rule out cross-bucket leakage. Adding account-level BPA later therefore changes a *failing* test rather than passing silently in whichever direction the new code happens to take.

## Scope notes

- An `emailAddress` grantee is **skipped**, not stored and not refused. S3 ended support for email grantees as of 2025-10-01 with an HTTP 405, but that is Region-conditional and applies to the XML body form too, so it is filed as #507 rather than guessed at. A test pins today's behaviour so #507 changes it deliberately.
- An unrecognized canned name resolves to owner-only rather than being refused — the per-operation `Valid Values` lists differ between operations and no error code is documented for a bad one.

## Tests

New `emulator/s3_acl_test.go` (45 subtests) plus five new BPA tests in `emulator/s3_publicaccess_test.go`:

- All 8 canned names × bucket and object, each row quoting its documented outcome — three of the eight differ between the two kinds, and `log-delivery-write` is bucket-only in the table.
- All 5 grant headers × 4 operations; grantee forms (quoted, unquoted, `uri`, lists, mixed-case type, empty entries mid-list).
- The whole-replacement rule: an overwrite naming no ACL clears a previous public grant, including one set by a separate `PutObjectAcl`.
- `--acl private` **stores** an ACL while no header stores nothing — the assertion that keeps the nil-means-unnamed distinction from collapsing.
- Every BPA refusal asserts the **not-stored** half: object absent, destination absent, no upload ID, and a refused overwrite leaving the prior body *and* ACL intact.
- `CreateMultipartUpload` refusal carries a **positive control** (an accepted upload *is* listed), so the "nothing left behind" assertion cannot pass vacuously.
- `headerACLCases()` filters the existing `publicACLCases()` rather than re-listing rows, so any case added for #458 is automatically exercised against the three creates. A new row covers a private XML body with a public grant header — the one case the standalone grant-header check still uniquely catches.
- The #458 suite passes unchanged, which is #470's own final criterion.

## Verification

From the repo root: `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go test -C test/e2e ./...` — all clean.

**Mutation-tested with 32 mutants: caught=32, survived=0, equivalent=0.** The catches include both ordering mutants (store-before-check, drop-the-check), the source-vs-destination swap on copy, both clear-omission mutants, the multipart carry and its persistence, source-ACL inheritance on copy, the `authenticated-read` regression, both `log-delivery-write` kind mutants, and every grant-header parsing mutant.

Probed end to end against `substrate server` with the AWS CLI: `put-object --acl public-read` on a blocked bucket → `AccessDenied` with `head-object` 404; `copy-object` and `create-multipart-upload` likewise, with `list-multipart-uploads` empty; `--acl private` still accepted; grant headers reported by `get-object-acl`; an overwrite naming no ACL back to owner-only.
