### PR TITLE
fix(fault): make an injected fault targetable, bounded and indistinguishable (#480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-operation Valid Values lists differ (four names on `CreateBucket`, seven on
   `PutObject`) and no error code is documented for a name outside them.
 
+- **An injected S3 fault is no longer distinguishable from a real S3 error** (#480).
+  This is the one property a fault injector must not have, and it had it. Faults are
+  evaluated before any plugin runs, so an injected error was serialized by the
+  pipeline's generic Query arm as `<ErrorResponse><Error><Type>Sender</Type>…`, while
+  a genuine S3 error is a bare `<Error>` document with an XML declaration and a
+  `<RequestId>`. S3's parser recovers no code from the wrapped form and falls back to
+  the HTTP status, so a fault armed as `SlowDown` arrived at the client as
+  `ServiceUnavailable`: a consumer whose retry policy matches on `SlowDown` never saw
+  their own fault fire, and a caller able to tell an injected error from a real one can
+  tell a fixture from production. The bytes now come from the same function the S3
+  plugin uses, so the two documents are byte-identical — asserted both at the
+  marshaller and over the wire against a genuine `NoSuchKey`, since only comparing two
+  independently produced documents proves it.
+
+  `cloudfront` and `route53` are REST-XML like S3 and keep the `<ErrorResponse>` shape
+  deliberately: their real error documents genuinely are wrapped, so they were already
+  correct and are pinned by tests against being swept along. EC2's Query XML and SQS's
+  JSON RPC are likewise unchanged.
+
+- **A fault rule can now name an S3 operation, and be bounded to N occurrences**
+  (#480). Three defects that compounded into fixtures that were silently wrong rather
+  than merely limited:
+
+  **An S3 rule could not name a semantic operation.** Faults are evaluated one pipeline
+  step before the S3 plugin resolves a REST request to its operation name, so
+  `req.Operation` was still the bare HTTP verb: `operation: PutObject` matched
+  **nothing at all**, and `operation: PUT` took out `UploadPart` and every other
+  object-path `PUT` alongside it. A fixture arming a `PutObject` fault therefore either
+  did nothing or failed a part upload somewhere the test was not looking. The parser
+  now resolves an S3 request's operation up front, so the name is canonical before
+  faults, quotas, cost attribution and consistency tracking all see it — the S3 cost
+  entries keyed on `s3/PutObject` and `s3/GetObject` were unreachable for any request
+  that errored before reaching the plugin, and the event log recorded `PUT` where it
+  now records the operation.
+
+  **A rule could not be bounded, so recovery was unobservable.** `Times` bounds how
+  many matching requests a rule fires on. Fail twice, then succeed, is the outcome that
+  distinguishes working retry from no retry, and an unbounded rule can only ever
+  produce failure — so the one thing a retry test needs to observe could not be
+  produced. Zero means **one**, not unlimited: reading a missing field as unlimited
+  turns a typo into a fixture that consumes a consumer's whole retry budget. A negative
+  value is unlimited and has to be asked for. The match, the probability roll and the
+  increment happen under one lock, so `Times: 1` with N concurrent requests yields
+  exactly one failure — atomicity a client-side counter cannot arrange, and the reason
+  the controller's locking was restructured rather than a counter bolted on.
+
+  **A rule that matched nothing looked exactly like a consumer's retry working.** Each
+  rule now reports a `fired` count through `GET /v1/fault/rules`, with `FaultsFired()`
+  summing them in process. A fixture that arms a fault and observes success has proven
+  nothing without asserting the count — and the first of these three defects would have
+  been caught immediately by any test that did. Arming rules again replaces the
+  configuration and resets the counts, so a fixture re-arming between phases gets its
+  full budget rather than a spent one.
+
+  Three wire matchers are added for distinctions an operation name does not carry:
+  `PathSuffix`, `QueryKey` and `HeaderPrefix`, AND-ed with `Service` and `Operation`.
+  `QueryKey` is what separates the multipart sub-operations, which share a path and
+  differ by a sub-resource parameter — so #480's own previously unwritable test, "fail
+  `CompleteMultipartUpload` after every part has uploaded and assert no orphaned
+  upload", is now writable and is written. Presence is what those parameters signal, so
+  the value is not compared.
+
+  Fixed along the way: `NewFaultController` and `UpdateConfig` stored the caller's rule
+  slice, so incrementing a fired count reached into the caller's own `FaultConfig` —
+  arming the same value twice found the second arming already spent.
+
 ### Added
 - **EC2 instances now carry and report an Availability Zone** (#489), which is what
   makes the zone-scoped rule above observable rather than merely internally
@@ -385,6 +451,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inheriting the source's — both deliberate, both pinned by tests so #493 changes them
   on purpose. #493 carries the four `InvalidArgument` rejections, bucket defaults, and
   the copy resolution order. SSE-C is out of scope entirely.
+
+### Changed
+- **A fault rule naming a bare HTTP method no longer matches an S3 request** (#480).
+  This is the one compatibility consequence of resolving an S3 request's semantic
+  operation before faults are evaluated. A rule written as `{"service": "s3",
+  "operation": "PUT"}` matched every object-path `PUT` and now matches nothing; write
+  the operation it meant — `PutObject`, `UploadPart`, `CopyObject` — or leave
+  `operation` empty to match every S3 operation. A bare-method rule still fires for a
+  service whose operation genuinely is its HTTP method, such as `execute-api`. Rules
+  naming a semantic S3 operation were matching nothing before this release, so no rule
+  that worked stops working; a rule that appeared to work by naming a verb was firing
+  on requests it did not mean.
+
+- **`FaultRule.Probability`'s shared PRNG is now documented rather than implied**
+  (#480). One PRNG serves every rule in a `FaultConfig` and is rolled once per
+  *matching* rule per request, so a fixed seed reproduces a run only while the whole
+  sequence of requests is unchanged — adding a request upstream, or a retry, shifts
+  every later roll, including for rules that request never touched. No behaviour
+  changed; the coupling was real and undocumented, and `Times` is the bounded outcome
+  to prefer since it needs no roll at all. Per-rule PRNGs would fix it and would move
+  the outcome of every existing seeded run, so it is filed as #510 rather than changed
+  inside a fix for something else.
 
 ## [v0.86.0] - 2026-08-02
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -3573,3 +3573,103 @@ SES outbound email: $0.10 per 1,000 emails.
 ### Cost
 
 Firehose data ingestion: $0.029 per GB.
+
+---
+
+## Fault injection
+
+Fault injection is cross-service rather than a plugin, so it lives here rather than in a
+per-service section. Rules are armed in process through `NewFaultController`, from a
+configuration file's `fault:` block, or over the wire:
+
+```
+POST   /v1/fault/rules   {"enabled":true,"rules":[{…}]}
+GET    /v1/fault/rules   → the live configuration, each rule carrying its fired count
+DELETE /v1/fault/rules   → disable and clear
+```
+
+Faults are evaluated **before the request reaches a plugin**, so a rule fires whether or
+not the operation it names is implemented, and no state is written for a request a fault
+refuses. `POST /v1/state/reset` clears the rules along with the state.
+
+A rule matches on five fields, all AND-ed, each ignored when empty:
+
+| Matcher | Matches |
+|---------|---------|
+| `service` | the service name (`s3`, `ec2`, …) |
+| `operation` | the **semantic** operation name (`PutObject`, `UploadPart`, …) |
+| `path_suffix` | requests whose path ends with the string (`.parquet`, `/big.bin`) |
+| `query_key` | requests carrying the query parameter, whatever its value (`uploads`, `uploadId`, `partNumber`) |
+| `header_prefix` | requests carrying a header whose name starts with the prefix, compared case-insensitively |
+
+**S3 operations are named semantically, like every other service's.** The request parser
+resolves an S3 REST request to `PutObject`, `UploadPart`, `CompleteMultipartUpload` and
+so on before faults are evaluated, so a rule naming `PutObject` fires on `PutObject` and
+not on `UploadPart`, which is also a `PUT` to an object path. Previously an S3 request
+carried its bare HTTP verb at this point, so `operation: PutObject` matched nothing at
+all and `operation: PUT` took out both. **A rule naming a bare HTTP method therefore no
+longer matches an S3 request** — a rule on `GET` still fires for a service whose
+operation genuinely is its method, such as `execute-api`.
+
+**`query_key` is what separates the multipart sub-operations.** `CreateMultipartUpload`,
+`UploadPart` and `CompleteMultipartUpload` share a path and differ from each other by a
+`POST`-versus-`PUT` and by a sub-resource parameter — `?uploads`, `?partNumber=&uploadId=`,
+`?uploadId=`. Presence is what those parameters signal, so the value is not compared. The
+three wire matchers exist for distinctions an operation name does not carry: one key
+rather than every key, or one header family rather than every request.
+
+### `times` bounds a rule, and zero means one
+
+| `times` | Fires on |
+|---------|----------|
+| absent / `0` | exactly **one** matching request |
+| `n > 0` | the first `n` matching requests |
+| negative | every matching request |
+
+The bound is what makes retry assertable: fail twice, then succeed, is the outcome that
+distinguishes working retry from no retry, and an unbounded rule can only ever produce
+failure. **Zero means one rather than unlimited** deliberately — reading a missing field
+as unlimited turns a typo into a fixture that consumes a consumer's whole retry budget.
+
+A rule that has reached its bound is skipped rather than ending evaluation, so a later
+rule still gets its turn. The match, the probability roll and the increment all happen
+under one lock: with `times: 1`, N concurrent requests produce exactly one failure, which
+is not something a counter on the client side can arrange.
+
+Set `times: -1` when a fixture arms a fault and then clears it to assert the retry
+succeeds — with the default of one the rule would already be spent, and the assertion
+would pass whether or not clearing worked.
+
+### The fired count
+
+Each rule reports a `fired` count through `GET /v1/fault/rules`; `FaultsFired()` sums
+them for an in-process test. **A rule that matches nothing produces exactly the same
+passing test as a consumer's retry working**, so a fixture that arms a fault and then
+observes success has proven nothing without asserting the count. Arming rules again
+replaces the configuration and resets every count, so a fixture that re-arms the same
+rule between phases gets its full budget back rather than a spent one.
+
+### An injected error is indistinguishable from a real one
+
+An injected error is serialized in the wire shape the target service's own errors use.
+That matters most for S3, whose error document is a bare `<Error>` with a `<RequestId>`
+rather than the `<ErrorResponse>` wrapper the Query protocol uses: an SDK recovers no
+code from the wrapped form and falls back to the HTTP status, so an injected `SlowDown`
+used to arrive at the client as `ServiceUnavailable` and a consumer matching on
+`SlowDown` never saw their own fault. The bytes now come from the same function the S3
+plugin uses, so an injected `NoSuchKey` and a genuine one are byte-identical — which is
+the one property a fault injector must not lack, since a caller who can tell the two
+apart can tell a fixture from production.
+
+`cloudfront` and `route53` are REST-XML like S3 but keep the `<ErrorResponse>` shape:
+their real error documents genuinely are wrapped, so they were already correct.
+
+### `probability` determinism depends on request ordering
+
+The PRNG behind `probability` is shared by every rule in a configuration and is rolled
+once per *matching* rule per request, so a fixed seed reproduces a run only while the
+whole sequence of requests is unchanged. Adding a request upstream, or a retry, shifts
+every later roll — including for rules that request never touched. Prefer `times` for a
+bounded outcome: it needs no roll at all. Per-rule PRNGs would fix this and would change
+the outcome of existing seeded runs, so it is tracked separately as
+[#510](https://github.com/scttfrdmn/substrate/issues/510).

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -406,15 +406,47 @@ func TestRetryOnS3Error(t *testing.T) {
 | Field | Description |
 |-------|-------------|
 | `Service` | AWS service name (`"s3"`, `"lambda"`, …). Empty = all services. |
-| `Operation` | Operation name (`"PutObject"`, …). Empty = all operations. |
+| `Operation` | Operation name (`"PutObject"`, …). Empty = all operations. Always the semantic operation, S3 included. |
+| `PathSuffix` | Request path must end with this (`".parquet"`, `"/big.bin"`). Empty = any path. |
+| `QueryKey` | Request must carry this query parameter (`"uploads"`, `"uploadId"`, `"partNumber"`). The value is not compared. Empty = any request. |
+| `HeaderPrefix` | Request must carry a header whose name starts with this, compared case-insensitively. Empty = any request. |
 | `FaultType` | `"error"` or `"latency"`. |
 | `ErrorCode` | AWS error code returned on `"error"` faults. |
 | `HTTPStatus` | HTTP status code (default 500). |
 | `ErrorMsg` | Human-readable error message. |
 | `LatencyMs` | Artificial delay in milliseconds for `"latency"` faults. |
 | `Probability` | Fraction of matching requests that fire [0.0, 1.0]. |
+| `Times` | How many matching requests the rule fires on. **Zero means one**, not unlimited; a negative value is unlimited. |
+| `Fired` | Read-only: how many faults this rule has injected. Reported by `GET /v1/fault/rules` and summed by `FaultsFired()`. |
 
-Rules are evaluated in order; the first matching rule fires.
+Rules are evaluated in order; the first matching rule that has not reached its
+`Times` bound fires. Every non-empty matcher must hold, so a rule naming both an
+operation and a `QueryKey` fires only where both apply.
+
+Four things are worth knowing before writing a fixture (all four are #480):
+
+- **`Operation` is the semantic name for S3 too.** A rule naming `PutObject` fires
+  on `PutObject` and not on `UploadPart`, which is also a `PUT`. A rule naming a
+  bare HTTP method no longer matches an S3 request at all.
+- **`Times` is what makes retry assertable.** Fail twice, then succeed, is the
+  outcome that distinguishes working retry from no retry; an unbounded rule can
+  only ever produce failure. Set `Times: -1` when a fixture deliberately wants the
+  old unbounded behavior — for instance when the test itself clears the rule and
+  asserts the retry succeeds, which passes vacuously against a spent rule.
+- **Assert `Fired`.** A rule that matches nothing produces exactly the same passing
+  test as a consumer's retry working. `FaultsFired()` in process, or the per-rule
+  `fired` member of `GET /v1/fault/rules` over the wire, is what tells them apart.
+  Arming rules again resets the counts, so a fixture that re-arms between phases
+  gets its full budget back.
+- **`Probability` depends on request ordering.** The PRNG is shared by every rule in
+  a `FaultConfig` and is rolled once per matching rule per request, so a fixed seed
+  reproduces a run only while the sequence of requests is unchanged — adding a
+  request upstream, or a retry, shifts every later roll. Prefer `Times` for a
+  bounded outcome: it needs no roll at all. See #510.
+
+An injected error is serialized in the same wire shape the target service's own
+errors use, so an SDK recovers the code rather than falling back to the HTTP status
+(an injected S3 `SlowDown` used to arrive as `ServiceUnavailable`).
 
 <!-- TODO(#178): document server.WithFaultController option once stabilised -->
 

--- a/emulator/config.go
+++ b/emulator/config.go
@@ -337,7 +337,21 @@ type FaultRuleCfg struct {
 	Service string `mapstructure:"service"`
 
 	// Operation restricts the rule to a specific AWS operation. Empty matches all.
+	// The name is the semantic operation for every service, S3 included; see
+	// [FaultRule.Operation].
 	Operation string `mapstructure:"operation"`
+
+	// PathSuffix restricts the rule to requests whose path ends with this string.
+	// Empty matches all. See [FaultRule.PathSuffix].
+	PathSuffix string `mapstructure:"path_suffix"`
+
+	// QueryKey restricts the rule to requests carrying this query parameter.
+	// Empty matches all. See [FaultRule.QueryKey].
+	QueryKey string `mapstructure:"query_key"`
+
+	// HeaderPrefix restricts the rule to requests carrying a header whose name
+	// begins with this prefix. Empty matches all. See [FaultRule.HeaderPrefix].
+	HeaderPrefix string `mapstructure:"header_prefix"`
 
 	// FaultType selects the fault kind: "error" or "latency".
 	FaultType string `mapstructure:"fault_type"`
@@ -357,14 +371,36 @@ type FaultRuleCfg struct {
 	// Probability is the fraction of matching requests that trigger the fault.
 	// Range [0.0, 1.0]; default 1.0.
 	Probability float64 `mapstructure:"probability"`
+
+	// Times bounds how many matching requests the rule fires on. Zero means one
+	// and a negative value means unlimited; see [FaultRule.Times] for why zero is
+	// not unlimited.
+	Times int `mapstructure:"times"`
 }
 
 // ToFaultConfig converts FaultCfg to the [FaultConfig] type used by
 // [NewFaultController].
+//
+// The fields are copied one by one rather than converted wholesale: [FaultRule]
+// carries a Fired count the controller maintains, which has no place in a
+// configuration file, so the two structs are deliberately not identical.
 func (c FaultCfg) ToFaultConfig() FaultConfig {
 	rules := make([]FaultRule, len(c.Rules))
 	for i, r := range c.Rules {
-		rules[i] = FaultRule(r)
+		rules[i] = FaultRule{
+			Service:      r.Service,
+			Operation:    r.Operation,
+			PathSuffix:   r.PathSuffix,
+			QueryKey:     r.QueryKey,
+			HeaderPrefix: r.HeaderPrefix,
+			FaultType:    r.FaultType,
+			ErrorCode:    r.ErrorCode,
+			HTTPStatus:   r.HTTPStatus,
+			ErrorMsg:     r.ErrorMsg,
+			LatencyMs:    r.LatencyMs,
+			Probability:  r.Probability,
+			Times:        r.Times,
+		}
 	}
 	return FaultConfig{
 		Enabled: c.Enabled,

--- a/emulator/error_protocol.go
+++ b/emulator/error_protocol.go
@@ -26,6 +26,15 @@ const (
 	// x-amzn-errortype response header, which botocore's RestJSONParser prefers
 	// over the body.
 	errProtoRESTJSON
+
+	// errProtoS3XML is S3's own REST-XML error document: a bare <Error> element
+	// with an XML declaration and a <RequestId>, not the <ErrorResponse> wrapper
+	// the Query protocol uses. S3's parser does not recover a code from the
+	// wrapped form and falls back to the HTTP status, so an error raised outside
+	// the S3 plugin — an injected fault, evaluated before any plugin runs — was
+	// distinguishable from a genuine S3 error by the client, which is the one
+	// property a fault injector must not have (#480).
+	errProtoS3XML
 )
 
 // serviceErrorProtocols maps a service name (as reported by Plugin.Name) to the
@@ -43,13 +52,20 @@ const (
 //     on-the-wire error documents differ in the root element (ErrorResponse,
 //     Response/Errors and Error respectively), but every one of their parsers
 //     recovers the code from an <ErrorResponse><Error><Code> document, so a
-//     single shape serves all three. Plugins that need a byte-exact document
-//     build it themselves (see s3ErrorResponse).
+//     single shape serves all three. S3 is the exception and has its own arm:
+//     its parser does not read a code out of the wrapped form at all, so an
+//     error leaving the pipeline before the plugin runs lost its code (#480).
+//     errProtoS3XML delegates to s3ErrorResponseWith, which stays the single
+//     source of truth for the byte shape.
 //   - "monitoring" (CloudWatch) models as smithy-rpc-v2-cbor today, but query
 //     remains in its supported protocol list and substrate's CloudWatch plugin
 //     answers successes in query XML, so its errors match that.
 var serviceErrorProtocols = map[string]awsErrorProtocol{
 	// Query, ec2 and REST-XML.
+	//
+	// cloudfront and route53 are REST-XML like S3 but stay here deliberately:
+	// their real error documents are <ErrorResponse>, so the Query shape is
+	// already byte-correct for them. Only S3 returns a bare <Error>.
 	"cloudformation":       errProtoQueryXML,
 	"cloudfront":           errProtoQueryXML,
 	"ec2":                  errProtoQueryXML,
@@ -60,9 +76,11 @@ var serviceErrorProtocols = map[string]awsErrorProtocol{
 	"rds":                  errProtoQueryXML,
 	"redshift":             errProtoQueryXML,
 	"route53":              errProtoQueryXML,
-	"s3":                   errProtoQueryXML,
 	"sns":                  errProtoQueryXML,
 	"sts":                  errProtoQueryXML,
+
+	// S3's own REST-XML error document.
+	"s3": errProtoS3XML,
 
 	// JSON RPC (x-amz-json-1.0 / 1.1).
 	"acm":              errProtoJSONRPC,
@@ -140,6 +158,9 @@ func errorProtocolFor(service, contentType string) awsErrorProtocol {
 // The shapes are what the AWS SDKs actually parse:
 //
 //   - Query/REST-XML: <ErrorResponse><Error><Code>…</Code></Error></ErrorResponse>
+//   - S3: a bare <Error><Code>…</Code><RequestId>…</RequestId></Error> document
+//     with an XML declaration, built by the same function the S3 plugin uses so
+//     an error the pipeline raises is byte-identical to one the plugin raises.
 //   - JSON RPC: {"__type":"Code","message":"…"} — "__type" is the member
 //     botocore reads; a body carrying only "Code" leaves the SDK to fall back to
 //     the stringified HTTP status.
@@ -151,6 +172,10 @@ func errorProtocolFor(service, contentType string) awsErrorProtocol {
 // that member keep working.
 func marshalAWSError(e *AWSError, proto awsErrorProtocol, jsonContentType string) (body []byte, contentType string, headers map[string]string) {
 	switch proto {
+	case errProtoS3XML:
+		resp := s3ErrorResponseWith(s3Error{Code: e.Code, Message: e.Message, Status: e.HTTPStatus})
+		return resp.Body, resp.Headers["Content-Type"], nil
+
 	case errProtoJSONRPC:
 		ct := jsonContentType
 		if !strings.HasPrefix(ct, "application/x-amz-json") {

--- a/emulator/error_protocol_test.go
+++ b/emulator/error_protocol_test.go
@@ -220,7 +220,12 @@ func TestErrorProtocolFor_Classification(t *testing.T) {
 		contentType string
 		want        string
 	}{
-		{"s3 is xml", "s3", "", emulator.ErrProtoQueryXMLForTest},
+		// S3 is REST-XML like cloudfront and route53 but has its own arm: its real
+		// error document is a bare <Error>, not the <ErrorResponse> wrapper, and its
+		// parser recovers no code from the wrapped form (#480).
+		{"s3 is s3 xml", "s3", "", emulator.ErrProtoS3XMLForTest},
+		{"cloudfront stays query xml", "cloudfront", "", emulator.ErrProtoQueryXMLForTest},
+		{"route53 stays query xml", "route53", "", emulator.ErrProtoQueryXMLForTest},
 		{"iam is xml", "iam", "application/x-amz-json-1.1", emulator.ErrProtoQueryXMLForTest},
 		// CloudFormation is a Query service whose errors are XML. The unknown-service
 		// fallback below happens to answer XML for a form-encoded body too, so only a
@@ -267,7 +272,7 @@ func TestErrorProtocolFor_Classification(t *testing.T) {
 func TestMarshalAWSError_JSONRPCDefaultsContentType(t *testing.T) {
 	t.Parallel()
 	body, ct, headers := emulator.MarshalAWSErrorForTest(
-		"ParameterNotFound", "nope", emulator.ErrProtoJSONRPCForTest, "text/plain")
+		"ParameterNotFound", "nope", emulator.ErrProtoJSONRPCForTest, "text/plain", http.StatusNotFound)
 	assert.Equal(t, "application/x-amz-json-1.1", ct)
 	assert.Equal(t, "ParameterNotFound", headers["x-amzn-ErrorType"])
 
@@ -281,7 +286,7 @@ func TestMarshalAWSError_JSONRPCDefaultsContentType(t *testing.T) {
 func TestMarshalAWSError_XMLEscapesMessage(t *testing.T) {
 	t.Parallel()
 	body, ct, headers := emulator.MarshalAWSErrorForTest(
-		"NoSuchKey", `a<b&c>"d"`, emulator.ErrProtoQueryXMLForTest, "")
+		"NoSuchKey", `a<b&c>"d"`, emulator.ErrProtoQueryXMLForTest, "", http.StatusNotFound)
 	assert.Equal(t, "text/xml; charset=UTF-8", ct)
 	assert.Empty(t, headers)
 
@@ -295,6 +300,35 @@ func TestMarshalAWSError_XMLEscapesMessage(t *testing.T) {
 	require.NoError(t, xml.Unmarshal(body, &doc), "body was %s", body)
 	assert.Equal(t, "NoSuchKey", doc.Error.Code)
 	assert.Equal(t, `a<b&c>"d"`, doc.Error.Message)
+}
+
+// TestMarshalAWSError_S3IsByteIdenticalToThePlugin is the #480 finding-4 gate at
+// the unit level: the pipeline's S3 arm must produce the same bytes the S3 plugin
+// produces for the same error, because a caller that can tell an injected error
+// from a genuine one can tell a fault fixture from production.
+func TestMarshalAWSError_S3IsByteIdenticalToThePlugin(t *testing.T) {
+	t.Parallel()
+	body, ct, headers := emulator.MarshalAWSErrorForTest(
+		"SlowDown", "injected fault", emulator.ErrProtoS3XMLForTest, "", http.StatusServiceUnavailable)
+
+	want := emulator.S3ErrorResponseForTest("SlowDown", "injected fault", http.StatusServiceUnavailable)
+	assert.Equal(t, string(want), string(body))
+	assert.Equal(t, "text/xml; charset=UTF-8", ct)
+	assert.Empty(t, headers)
+
+	// The shape itself, asserted independently of the plugin so a change to both
+	// at once cannot slip through: a bare <Error>, not the <ErrorResponse> wrapper.
+	var doc struct {
+		XMLName   xml.Name `xml:"Error"`
+		Code      string   `xml:"Code"`
+		Message   string   `xml:"Message"`
+		RequestID string   `xml:"RequestId"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &doc), "body was %s", body)
+	assert.Equal(t, "SlowDown", doc.Code)
+	assert.Equal(t, "injected fault", doc.Message)
+	assert.NotEmpty(t, doc.RequestID)
+	assert.NotContains(t, string(body), "<ErrorResponse")
 }
 
 // errAfterGetsStateManager is a StateManager that serves the first n Get calls

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -245,6 +245,7 @@ const (
 	ErrProtoQueryXMLForTest = "query-xml"
 	ErrProtoJSONRPCForTest  = "json-rpc"
 	ErrProtoRESTJSONForTest = "rest-json"
+	ErrProtoS3XMLForTest    = "s3-xml"
 	ErrProtoUnknownForTest  = "unknown"
 )
 
@@ -258,20 +259,31 @@ func ErrorProtocolForTest(service, contentType string) string {
 		return ErrProtoJSONRPCForTest
 	case errProtoRESTJSON:
 		return ErrProtoRESTJSONForTest
+	case errProtoS3XML:
+		return ErrProtoS3XMLForTest
 	default:
 		return ErrProtoUnknownForTest
 	}
 }
 
 // MarshalAWSErrorForTest wraps marshalAWSError, selecting the protocol by one of
-// the ErrProto*ForTest names.
-func MarshalAWSErrorForTest(code, message, proto, jsonContentType string) (body []byte, contentType string, headers map[string]string) {
+// the ErrProto*ForTest names. status is the HTTP status the error carries, which
+// the S3 arm needs because it builds a whole response rather than a body alone.
+func MarshalAWSErrorForTest(code, message, proto, jsonContentType string, status int) (body []byte, contentType string, headers map[string]string) {
 	p := errProtoQueryXML
 	switch proto {
 	case ErrProtoJSONRPCForTest:
 		p = errProtoJSONRPC
 	case ErrProtoRESTJSONForTest:
 		p = errProtoRESTJSON
+	case ErrProtoS3XMLForTest:
+		p = errProtoS3XML
 	}
-	return marshalAWSError(&AWSError{Code: code, Message: message}, p, jsonContentType)
+	return marshalAWSError(&AWSError{Code: code, Message: message, HTTPStatus: status}, p, jsonContentType)
+}
+
+// S3ErrorResponseForTest wraps s3ErrorResponseWith so a test can compare an
+// error the S3 plugin builds against one the pipeline builds, byte for byte.
+func S3ErrorResponseForTest(code, message string, status int) []byte {
+	return s3ErrorResponseWith(s3Error{Code: code, Message: message, Status: status}).Body
 }

--- a/emulator/fault.go
+++ b/emulator/fault.go
@@ -3,6 +3,7 @@ package emulator
 import (
 	"math/rand" // nosemgrep
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -16,13 +17,43 @@ type FaultRule struct {
 
 	// Operation restricts the rule to a specific AWS operation (e.g. "PutObject").
 	// An empty string matches all operations.
+	//
+	// The name is the semantic operation for every service, S3 included: the
+	// request parser resolves an S3 REST request to its operation name before
+	// faults are evaluated, so a rule naming PutObject fires on PutObject and
+	// not on UploadPart, which is also a PUT (#480). A rule naming a bare HTTP
+	// method therefore no longer matches an S3 request.
 	Operation string `json:"operation,omitempty"`
+
+	// PathSuffix restricts the rule to requests whose path ends with this
+	// string (e.g. ".parquet", or "/big.bin"). An empty string matches any path.
+	//
+	// This and the two matchers below select on the wire request rather than on
+	// its resolved operation, which is how a rule expresses a distinction the
+	// operation name does not carry: one key rather than every key, or one
+	// header family rather than every request.
+	PathSuffix string `json:"path_suffix,omitempty"`
+
+	// QueryKey restricts the rule to requests carrying this query parameter
+	// (e.g. "uploads", "uploadId", "partNumber"). An empty string matches any
+	// request. The parameter's value is not compared, because presence is what
+	// S3's sub-resource parameters signal, and they are what separate
+	// operations that share a method and a path.
+	QueryKey string `json:"query_key,omitempty"`
+
+	// HeaderPrefix restricts the rule to requests carrying at least one header
+	// whose name begins with this prefix, compared case-insensitively (e.g.
+	// "x-amz-copy-source", "x-amz-server-side-encryption"). An empty string
+	// matches any request.
+	HeaderPrefix string `json:"header_prefix,omitempty"`
 
 	// FaultType selects the kind of fault: "error" or "latency".
 	FaultType string `json:"fault_type"`
 
 	// ErrorCode is the AWS error code returned when FaultType is "error"
-	// (e.g. "InternalError").
+	// (e.g. "InternalError"). It reaches the client as sent: an injected error
+	// is serialized in the same wire shape the target service's own errors use,
+	// so an SDK recovers the code rather than falling back to the HTTP status.
 	ErrorCode string `json:"error_code,omitempty"`
 
 	// HTTPStatus is the HTTP status code returned with an injected error.
@@ -39,7 +70,48 @@ type FaultRule struct {
 	// Probability is the fraction of matching requests that actually trigger the
 	// fault, in the range [0.0, 1.0]. A value of 1.0 (the default) fires on
 	// every matching request.
+	//
+	// The PRNG behind this is shared by every rule in a FaultConfig and is
+	// rolled once per matching rule per request, so a fixed seed reproduces a
+	// run only while the sequence of requests is unchanged. Adding a request
+	// upstream, or a retry, shifts every later roll. Prefer Times for a bounded
+	// outcome: it needs no roll at all. See #510.
 	Probability float64 `json:"probability,omitempty"`
+
+	// Times bounds how many matching requests the rule fires on. Zero means
+	// one, not unlimited — a rule that fires on nothing is never what a caller
+	// meant, and reading zero as unlimited turns a mistyped field into a test
+	// that consumes the whole retry budget. A negative value means unlimited,
+	// which is the behavior before this field existed and now has to be asked
+	// for explicitly.
+	//
+	// The bound is what makes retry assertable: fail twice, then succeed, is
+	// the outcome that distinguishes working retry from no retry, and an
+	// unbounded rule can only ever produce failure.
+	Times int `json:"times,omitempty"`
+
+	// Fired counts the requests this rule has injected a fault into. The
+	// controller maintains it; a value supplied when the rule is armed is kept
+	// as the starting count, and GET /v1/fault/rules reports the running total.
+	//
+	// It exists because a rule that matches nothing produces exactly the same
+	// passing test as a consumer's retry working. Asserting a non-zero count is
+	// what tells those two apart.
+	Fired int `json:"fired,omitempty"`
+}
+
+// remaining reports whether the rule may still fire. It is only meaningful for
+// a rule that has already matched. A negative Times is unlimited; zero means
+// one, per the field's documentation.
+func (r FaultRule) remaining() bool {
+	if r.Times < 0 {
+		return true
+	}
+	limit := r.Times
+	if limit == 0 {
+		limit = 1
+	}
+	return r.Fired < limit
 }
 
 // FaultConfig holds the configuration for fault injection.
@@ -48,7 +120,7 @@ type FaultConfig struct {
 	Enabled bool `json:"enabled"`
 
 	// Rules is the ordered list of fault rules. Rules are evaluated in order;
-	// the first matching rule fires.
+	// the first matching rule that has not reached its Times bound fires.
 	Rules []FaultRule `json:"rules"`
 }
 
@@ -56,52 +128,71 @@ type FaultConfig struct {
 // Substrate request pipeline. It uses a seeded, non-global PRNG for
 // deterministic fault firing in tests.
 type FaultController struct {
-	mu     sync.RWMutex
+	mu     sync.Mutex
 	config FaultConfig
 	rng    *rand.Rand
 }
 
 // NewFaultController creates a FaultController with the given configuration.
 // seed controls the PRNG used for probabilistic fault firing; use a fixed seed
-// in tests for determinism.
+// in tests for determinism, subject to the caveat on [FaultRule.Probability]
+// that makes a bounded [FaultRule.Times] the more reproducible choice.
 func NewFaultController(cfg FaultConfig, seed int64) *FaultController {
 	return &FaultController{
-		config: cfg,
+		config: cfg.withOwnedRules(),
 		rng:    rand.New(rand.NewSource(seed)), //nolint:gosec // not used for cryptography
 	}
+}
+
+// withOwnedRules returns cfg with a private copy of its rule slice, so the
+// controller's fired counts are written to memory no caller shares.
+//
+// Without the copy, incrementing a count reaches into the caller's own slice:
+// a test that arms the same FaultConfig value twice would find its second arming
+// already spent, because the first run had mutated the literal it passed in.
+func (c FaultConfig) withOwnedRules() FaultConfig {
+	if c.Rules == nil {
+		return c
+	}
+	c.Rules = append([]FaultRule(nil), c.Rules...)
+	return c
 }
 
 // InjectFault evaluates the fault rules against the request. It returns a
 // non-nil [*AWSError] when an error fault fires, and a non-zero [time.Duration]
 // when a latency fault fires. Both values are zero when no rule matches or
 // fault injection is disabled.
+//
+// The match, the probability roll and the fired-count increment all happen
+// under one lock. That atomicity is the property the mechanism exists for:
+// with Times set to 1, N concurrent requests must produce exactly one failure,
+// which is not something a counter on the client side can arrange.
 func (f *FaultController) InjectFault(_ *RequestContext, req *AWSRequest) (*AWSError, time.Duration) {
-	f.mu.RLock()
-	cfg := f.config
-	f.mu.RUnlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
 
-	if !cfg.Enabled {
+	if !f.config.Enabled {
 		return nil, 0
 	}
 
-	for _, rule := range cfg.Rules {
-		if !ruleMatches(rule, req) {
+	for i := range f.config.Rules {
+		rule := &f.config.Rules[i]
+		if !ruleMatches(*rule, req) || !rule.remaining() {
 			continue
 		}
 		p := rule.Probability
 		if p <= 0 {
 			p = 1.0
 		}
-		f.mu.Lock()
-		roll := f.rng.Float64()
-		f.mu.Unlock()
-		if roll >= p {
+		if f.rng.Float64() >= p {
 			continue
 		}
 		switch rule.FaultType {
 		case "latency":
+			rule.Fired++
 			return nil, time.Duration(rule.LatencyMs) * time.Millisecond
 		case "error":
+			rule.Fired++
 			status := rule.HTTPStatus
 			if status == 0 {
 				status = http.StatusInternalServerError
@@ -125,23 +216,45 @@ func (f *FaultController) InjectFault(_ *RequestContext, req *AWSRequest) (*AWSE
 }
 
 // UpdateConfig replaces the fault injection configuration. It is safe to call
-// concurrently with InjectFault.
+// concurrently with InjectFault. Arming a rule again starts its Times bound
+// over, because the incoming rules carry their own fired counts.
 func (f *FaultController) UpdateConfig(cfg FaultConfig) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.config = cfg
+	f.config = cfg.withOwnedRules()
 }
 
-// GetConfig returns a snapshot of the current fault injection configuration.
-// It is safe to call concurrently with InjectFault and UpdateConfig.
+// GetConfig returns a snapshot of the current fault injection configuration,
+// including each rule's fired count. The rule slice is copied, so a caller
+// reading a count cannot race a concurrent InjectFault incrementing it. It is
+// safe to call concurrently with InjectFault and UpdateConfig.
 func (f *FaultController) GetConfig() FaultConfig {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	return f.config
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cfg := f.config
+	if f.config.Rules != nil {
+		cfg.Rules = append([]FaultRule(nil), f.config.Rules...)
+	}
+	return cfg
 }
 
-// ruleMatches reports whether rule applies to req based on Service and Operation
-// filters.
+// FaultsFired returns the total number of faults injected across all rules.
+// A test that arms a rule and then observes success has proven nothing unless
+// the fault actually fired, and a rule matching no request at all looks exactly
+// like a consumer's retry working.
+func (f *FaultController) FaultsFired() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	total := 0
+	for _, rule := range f.config.Rules {
+		total += rule.Fired
+	}
+	return total
+}
+
+// ruleMatches reports whether rule applies to req. Every non-empty matcher must
+// match: Service and Operation select the API call, and PathSuffix, QueryKey
+// and HeaderPrefix select a wire request within it.
 func ruleMatches(rule FaultRule, req *AWSRequest) bool {
 	if rule.Service != "" && rule.Service != req.Service {
 		return false
@@ -149,5 +262,29 @@ func ruleMatches(rule FaultRule, req *AWSRequest) bool {
 	if rule.Operation != "" && rule.Operation != req.Operation {
 		return false
 	}
+	if rule.PathSuffix != "" && !strings.HasSuffix(req.Path, rule.PathSuffix) {
+		return false
+	}
+	if rule.QueryKey != "" {
+		if _, ok := req.Params[rule.QueryKey]; !ok {
+			return false
+		}
+	}
+	if rule.HeaderPrefix != "" && !hasHeaderPrefix(req.Headers, rule.HeaderPrefix) {
+		return false
+	}
 	return true
+}
+
+// hasHeaderPrefix reports whether any header name begins with prefix, compared
+// case-insensitively: a header name is case-insensitive on the wire, and the
+// SDKs do not agree on a canonical spelling.
+func hasHeaderPrefix(headers map[string]string, prefix string) bool {
+	lower := strings.ToLower(prefix)
+	for name := range headers {
+		if strings.HasPrefix(strings.ToLower(name), lower) {
+			return true
+		}
+	}
+	return false
 }

--- a/emulator/fault_control.go
+++ b/emulator/fault_control.go
@@ -15,7 +15,11 @@ import (
 //
 //	{"enabled": true, "rules": [{"service":"s3","operation":"GetObject",
 //	  "fault_type":"error","error_code":"NoSuchKey","http_status":404,
-//	  "probability":1.0}]}
+//	  "times":2}]}
+//
+// Posting rules replaces the whole configuration, which resets every rule's
+// fired count. See [FaultRule] for the matcher fields and for why "times"
+// defaults to one rather than to unlimited.
 func (s *Server) handleFaultSetRules(w http.ResponseWriter, r *http.Request) {
 	if s.opts.Fault == nil {
 		http.Error(w, `{"error":"fault injection not enabled on this server"}`, http.StatusNotImplemented)
@@ -47,8 +51,13 @@ func (s *Server) handleFaultClearRules(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleFaultGetRules handles GET /v1/fault/rules.
-// It returns the current FaultConfig as JSON. Returns 501 when the server was
-// started without a FaultController.
+// It returns the current FaultConfig as JSON, each rule carrying the "fired"
+// count of requests it has injected a fault into. Returns 501 when the server
+// was started without a FaultController.
+//
+// The count is the assertion that separates "my retry worked" from "the rule
+// matched nothing": a rule that never fired produces the same passing test as a
+// consumer's retry handling the failure.
 func (s *Server) handleFaultGetRules(w http.ResponseWriter, r *http.Request) {
 	if s.opts.Fault == nil {
 		http.Error(w, `{"error":"fault injection not enabled on this server"}`, http.StatusNotImplemented)

--- a/emulator/fault_control_test.go
+++ b/emulator/fault_control_test.go
@@ -128,6 +128,143 @@ func TestFaultControl_SetGetClearRules(t *testing.T) {
 	}
 }
 
+// TestFaultControl_ReportsFiredCount covers the #480 companion finding over the
+// control plane. A rule that matches nothing produces exactly the same passing test
+// as a consumer's retry working, so a fixture that arms a fault and then sees success
+// has proven nothing without this count. It rides on the existing GET, since that
+// handler already marshals the whole FaultConfig.
+func TestFaultControl_ReportsFiredCount(t *testing.T) {
+	ts, fc := newFaultTestServer(t)
+
+	payload := emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{
+			{Service: "s3", Operation: "PutObject", FaultType: "error", ErrorCode: "SlowDown", Times: 2},
+			// A second rule that no request below touches, so its count stays zero and
+			// the report is per-rule rather than a single total.
+			{Service: "dynamodb", Operation: "PutItem", FaultType: "error", ErrorCode: "InternalError", Times: -1},
+		},
+	}
+	postBody, _ := json.Marshal(payload)
+	postResp, err := http.Post(ts.URL+"/v1/fault/rules", "application/json", bytes.NewReader(postBody))
+	if err != nil {
+		t.Fatalf("POST rules: %v", err)
+	}
+	_, _ = io.ReadAll(postResp.Body)
+	_ = postResp.Body.Close()
+
+	// A freshly armed rule reports zero, which is what makes a non-zero count later
+	// an assertion rather than an artifact of the rule having been armed.
+	if got := faultRuleCounts(t, ts); got[0] != 0 || got[1] != 0 {
+		t.Fatalf("fired counts before any request = %v, want [0 0]", got)
+	}
+
+	req := &emulator.AWSRequest{Service: "s3", Operation: "PutObject"}
+	for i := 0; i < 3; i++ {
+		_, _ = fc.InjectFault(&emulator.RequestContext{}, req)
+	}
+
+	got := faultRuleCounts(t, ts)
+	if got[0] != 2 {
+		t.Errorf("s3 rule fired = %d, want 2 (its Times bound)", got[0])
+	}
+	if got[1] != 0 {
+		t.Errorf("dynamodb rule fired = %d, want 0 — it matched nothing", got[1])
+	}
+
+	// Re-arming replaces the configuration, so the counts start over. A fixture that
+	// arms the same rule between phases needs its full budget, not a spent one.
+	rearm, err := http.Post(ts.URL+"/v1/fault/rules", "application/json", bytes.NewReader(postBody))
+	if err != nil {
+		t.Fatalf("re-POST rules: %v", err)
+	}
+	_, _ = io.ReadAll(rearm.Body)
+	_ = rearm.Body.Close()
+	if got := faultRuleCounts(t, ts); got[0] != 0 {
+		t.Errorf("s3 rule fired = %d after re-arming, want 0", got[0])
+	}
+}
+
+// faultRuleCounts GETs the control plane's rule list and returns each rule's fired
+// count, in the order the rules were armed.
+func faultRuleCounts(t *testing.T, ts *httptest.Server) []int {
+	t.Helper()
+	resp, err := http.Get(ts.URL + "/v1/fault/rules")
+	if err != nil {
+		t.Fatalf("GET /v1/fault/rules: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /v1/fault/rules: status %d: %s", resp.StatusCode, body)
+	}
+	var cfg emulator.FaultConfig
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		t.Fatalf("unmarshal GET response: %v", err)
+	}
+	counts := make([]int, 0, len(cfg.Rules))
+	for _, rule := range cfg.Rules {
+		counts = append(counts, rule.Fired)
+	}
+	return counts
+}
+
+// TestFaultControl_RoundTripsTheWireMatchers asserts the three matchers #480 added
+// survive the control plane's JSON encoding. They are useless if a rule armed over
+// HTTP loses them, and the field tags are the only thing that carries them.
+func TestFaultControl_RoundTripsTheWireMatchers(t *testing.T) {
+	ts, _ := newFaultTestServer(t)
+
+	payload := emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:      "s3",
+			Operation:    "CompleteMultipartUpload",
+			PathSuffix:   ".parquet",
+			QueryKey:     "uploadId",
+			HeaderPrefix: "x-amz-server-side-encryption",
+			FaultType:    "error",
+			ErrorCode:    "InternalError",
+			Times:        3,
+		}},
+	}
+	postBody, _ := json.Marshal(payload)
+	postResp, err := http.Post(ts.URL+"/v1/fault/rules", "application/json", bytes.NewReader(postBody))
+	if err != nil {
+		t.Fatalf("POST rules: %v", err)
+	}
+	_, _ = io.ReadAll(postResp.Body)
+	_ = postResp.Body.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/fault/rules")
+	if err != nil {
+		t.Fatalf("GET rules: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	var cfg emulator.FaultConfig
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(cfg.Rules) != 1 {
+		t.Fatalf("want 1 rule, got %d", len(cfg.Rules))
+	}
+	got := cfg.Rules[0]
+	if got.PathSuffix != ".parquet" {
+		t.Errorf("PathSuffix = %q, want .parquet", got.PathSuffix)
+	}
+	if got.QueryKey != "uploadId" {
+		t.Errorf("QueryKey = %q, want uploadId", got.QueryKey)
+	}
+	if got.HeaderPrefix != "x-amz-server-side-encryption" {
+		t.Errorf("HeaderPrefix = %q, want x-amz-server-side-encryption", got.HeaderPrefix)
+	}
+	if got.Times != 3 {
+		t.Errorf("Times = %d, want 3", got.Times)
+	}
+}
+
 func TestFaultControl_NilController_Returns501(t *testing.T) {
 	// Build a server WITHOUT a FaultController.
 	cfg := emulator.DefaultConfig()

--- a/emulator/fault_s3_test.go
+++ b/emulator/fault_s3_test.go
@@ -1,0 +1,477 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// newS3FaultServer builds an S3 server with a FaultController attached, returning
+// both so a test can arm rules in process and observe the wire response.
+//
+// It mirrors newS3TestServerWithFS rather than calling it because the controller has
+// to be present when the server is constructed: ServerOptions is read once, and a
+// fault evaluated at pipeline step 4.5 cannot be added afterwards.
+func newS3FaultServer(t *testing.T, cfg emulator.FaultConfig) (*emulator.Server, *emulator.FaultController) {
+	t.Helper()
+	conf := emulator.DefaultConfig()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+
+	s3p := &emulator.S3Plugin{}
+	state := emulator.NewMemoryStateManager()
+	require.NoError(t, s3p.Initialize(t.Context(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"filesystem":      afero.NewMemMapFs(),
+		},
+	}))
+
+	registry := emulator.NewPluginRegistry()
+	registry.Register(s3p)
+
+	fc := emulator.NewFaultController(cfg, 42)
+	srv := emulator.NewServer(*conf, registry,
+		emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"}),
+		state, tc, logger, emulator.ServerOptions{Fault: fc})
+
+	return srv, fc
+}
+
+// newFaultOnlyServer builds a server with a fault controller and no plugins at all.
+// Faults are evaluated at pipeline step 4.5, before routing, so a rule fires without
+// any plugin being registered — which is exactly why the error's wire shape is the
+// pipeline's responsibility rather than a plugin's.
+func newFaultOnlyServer(t *testing.T, cfg emulator.FaultConfig) *httptest.Server {
+	t.Helper()
+	conf := emulator.DefaultConfig()
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	srv := emulator.NewServer(*conf, emulator.NewPluginRegistry(),
+		emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"}),
+		state, tc, emulator.NewDefaultLogger(slog.LevelError, false),
+		emulator.ServerOptions{Fault: emulator.NewFaultController(cfg, 42)})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestFault_OtherProtocolsAreUnchanged is the regression guard on #480's error-shape
+// fix: only S3's document was wrong, so every other service must serialize an injected
+// error exactly as it did before. EC2 is the Query protocol and SQS is JSON RPC, which
+// are the two shapes the S3 arm was carved out of and beside.
+func TestFault_OtherProtocolsAreUnchanged(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ec2 stays query xml", func(t *testing.T) {
+		t.Parallel()
+		ts := newFaultOnlyServer(t, emulator.FaultConfig{
+			Enabled: true,
+			Rules: []emulator.FaultRule{{
+				Service:    "ec2",
+				FaultType:  "error",
+				ErrorCode:  "RequestLimitExceeded",
+				HTTPStatus: http.StatusServiceUnavailable,
+				ErrorMsg:   "Request limit exceeded.",
+				Times:      -1,
+			}},
+		})
+
+		resp := ec2Request(t, ts, map[string]string{"Action": "DescribeInstances"})
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		assert.Equal(t, "text/xml; charset=UTF-8", resp.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var doc struct {
+			XMLName xml.Name `xml:"ErrorResponse"`
+			Error   struct {
+				Type string `xml:"Type"`
+				Code string `xml:"Code"`
+			} `xml:"Error"`
+		}
+		require.NoError(t, xml.Unmarshal(body, &doc), "body was %s", body)
+		assert.Equal(t, "RequestLimitExceeded", doc.Error.Code)
+		assert.Equal(t, "Sender", doc.Error.Type)
+	})
+
+	t.Run("sqs stays json rpc", func(t *testing.T) {
+		t.Parallel()
+		ts := newFaultOnlyServer(t, emulator.FaultConfig{
+			Enabled: true,
+			Rules: []emulator.FaultRule{{
+				Service:    "sqs",
+				FaultType:  "error",
+				ErrorCode:  "RequestThrottled",
+				HTTPStatus: http.StatusServiceUnavailable,
+				ErrorMsg:   "Request throttled.",
+				Times:      -1,
+			}},
+		})
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", strings.NewReader(`{}`))
+		require.NoError(t, err)
+		req.Host = "sqs.us-east-1.amazonaws.com"
+		req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+		req.Header.Set("X-Amz-Target", "AmazonSQS.SendMessage")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var out map[string]string
+		require.NoError(t, json.Unmarshal(body, &out), "body was %s", body)
+		// "__type" is the member botocore's JSON parser reads; the header is what a
+		// REST-JSON parser would read, and SQS sends both today.
+		assert.Equal(t, "RequestThrottled", out["__type"])
+		assert.Equal(t, "RequestThrottled", resp.Header.Get("x-amzn-ErrorType"))
+		assert.NotContains(t, string(body), "<Error")
+	})
+}
+
+// TestS3Fault_ErrorCodeReachesTheClient covers #480 findings 3 and 4 together, over
+// the wire. Finding 4 causes finding 3: the pipeline serialized an injected error as
+// the wrapped <ErrorResponse> document, S3's parser recovers no code from that shape,
+// and so a requested SlowDown arrived as ServiceUnavailable — the HTTP status the SDK
+// falls back to. A consumer matching on SlowDown never saw their own fault.
+func TestS3Fault_ErrorCodeReachesTheClient(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3FaultServer(t, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:    "s3",
+			Operation:  "PutObject",
+			FaultType:  "error",
+			ErrorCode:  "SlowDown",
+			HTTPStatus: http.StatusServiceUnavailable,
+			ErrorMsg:   "Please reduce your request rate.",
+			Times:      -1,
+		}},
+	})
+
+	w := s3Request(t, srv, http.MethodPut, "/faulty/k", []byte("v"), nil)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	body := parseS3Error(t, w.Body.Bytes())
+	assert.Equal(t, "SlowDown", body.Code)
+	assert.Equal(t, "Please reduce your request rate.", body.Message)
+	assert.NotEqual(t, "ServiceUnavailable", body.Code,
+		"the SDK falls back to the status when the document shape is wrong")
+}
+
+// TestS3Fault_ErrorIsByteIdenticalToAGenuineOne is the assertion that proves
+// indistinguishability, which is the one property a fault injector must not lack: a
+// caller able to tell an injected NoSuchKey from a real one can tell a fault fixture
+// from production. Comparing the documents byte for byte is the only way to assert it.
+func TestS3Fault_ErrorIsByteIdenticalToAGenuineOne(t *testing.T) {
+	t.Parallel()
+
+	// A genuine NoSuchKey, raised by the plugin from a bucket that exists.
+	plain, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, plain, http.MethodPut, "/real", nil, nil).Code)
+	genuine := s3Request(t, plain, http.MethodGet, "/real/absent", nil, nil)
+	require.Equal(t, http.StatusNotFound, genuine.Code)
+
+	// The same code injected by the pipeline, which never reaches the plugin at all.
+	srv, _ := newS3FaultServer(t, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:    "s3",
+			Operation:  "GetObject",
+			FaultType:  "error",
+			ErrorCode:  "NoSuchKey",
+			HTTPStatus: http.StatusNotFound,
+			ErrorMsg:   "The specified key does not exist.",
+			Times:      -1,
+		}},
+	})
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/real", nil, nil).Code)
+	injected := s3Request(t, srv, http.MethodGet, "/real/absent", nil, nil)
+
+	assert.Equal(t, genuine.Code, injected.Code)
+	assert.Equal(t, genuine.Body.String(), injected.Body.String())
+	assert.Equal(t, genuine.Header().Get("Content-Type"), injected.Header().Get("Content-Type"))
+
+	// And the shape itself: a bare <Error> with a <RequestId>, not the
+	// <ErrorResponse> wrapper the Query protocol uses.
+	var doc struct {
+		XMLName   xml.Name `xml:"Error"`
+		Code      string   `xml:"Code"`
+		RequestID string   `xml:"RequestId"`
+	}
+	require.NoError(t, xml.Unmarshal(injected.Body.Bytes(), &doc), "body was %s", injected.Body.String())
+	assert.Equal(t, "NoSuchKey", doc.Code)
+	assert.NotEmpty(t, doc.RequestID)
+	assert.NotContains(t, injected.Body.String(), "<ErrorResponse")
+}
+
+// TestS3Fault_OperationRuleDoesNotHitUploadPart is the #480 finding-1 gate on the
+// wire. PutObject and UploadPart are both a PUT to an object path, so a rule that
+// could only name the HTTP method took out both — and a fixture arming a PutObject
+// fault would fail a part upload instead, somewhere the test was not looking.
+func TestS3Fault_OperationRuleDoesNotHitUploadPart(t *testing.T) {
+	t.Parallel()
+	srv, fc := newS3FaultServer(t, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:    "s3",
+			Operation:  "PutObject",
+			FaultType:  "error",
+			ErrorCode:  "SlowDown",
+			HTTPStatus: http.StatusServiceUnavailable,
+			Times:      -1,
+		}},
+	})
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/multipart-scope", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/multipart-scope/big.bin?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, iw.Code, "CreateMultipartUpload must not match a PutObject rule")
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	// UploadPart is a PUT to the same path and must not match.
+	pw := s3Request(t, srv, http.MethodPut,
+		"/multipart-scope/big.bin?partNumber=1&uploadId="+ir.UploadID, []byte("data"), nil)
+	assert.Equal(t, http.StatusOK, pw.Code, "UploadPart must not match a PutObject rule")
+	assert.Equal(t, 0, fc.FaultsFired(), "no fault should have fired yet")
+
+	// A plain PutObject does match.
+	ow := s3Request(t, srv, http.MethodPut, "/multipart-scope/plain.txt", []byte("v"), nil)
+	assert.Equal(t, http.StatusServiceUnavailable, ow.Code)
+	assert.Equal(t, "SlowDown", parseS3Error(t, ow.Body.Bytes()).Code)
+	assert.Equal(t, 1, fc.FaultsFired())
+}
+
+// TestS3Fault_CompleteFailsLeavingNoOrphanedUpload is the test #480's reporter could
+// not write. Failing CompleteMultipartUpload after every part has uploaded needs a
+// rule that hits exactly that request: it shares POST and the object path with
+// CreateMultipartUpload and differs only in its query parameter, so neither an
+// operation-less rule nor one naming the HTTP method could reach it without also
+// killing the create. QueryKey plus the semantic name select it precisely.
+//
+// The assertion is that a failed Complete leaves the upload open — which is real S3's
+// behavior, and the reason a consumer's cleanup path exists: the parts are still
+// billable until something aborts them.
+func TestS3Fault_CompleteFailsLeavingNoOrphanedUpload(t *testing.T) {
+	t.Parallel()
+	srv, fc := newS3FaultServer(t, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:    "s3",
+			Operation:  "CompleteMultipartUpload",
+			QueryKey:   "uploadId",
+			FaultType:  "error",
+			ErrorCode:  "InternalError",
+			HTTPStatus: http.StatusInternalServerError,
+			Times:      1,
+		}},
+	})
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/orphan", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/orphan/big.bin?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, iw.Code)
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	etag := uploadPart(t, srv, "orphan", "big.bin", ir.UploadID, 1, []byte("only part"))
+
+	// Complete fails once.
+	cw := s3Request(t, srv, http.MethodPost,
+		"/orphan/big.bin?uploadId="+ir.UploadID, completeBody(etag), nil)
+	require.Equal(t, http.StatusInternalServerError, cw.Code)
+	assert.Equal(t, "InternalError", parseS3Error(t, cw.Body.Bytes()).Code)
+	assert.Equal(t, 1, fc.FaultsFired(), "the rule must have fired, not merely matched nothing")
+
+	// The upload is still open, and the object was never assembled.
+	assert.Equal(t, []string{ir.UploadID}, openUploadIDs(t, srv, "orphan"),
+		"a failed Complete leaves the upload for the caller to abort")
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodGet, "/orphan/big.bin", nil, nil).Code)
+
+	// With the rule spent (Times: 1), a retry succeeds — which is what makes the
+	// consumer's retry path assertable rather than merely armed.
+	retry := s3Request(t, srv, http.MethodPost,
+		"/orphan/big.bin?uploadId="+ir.UploadID, completeBody(etag), nil)
+	require.Equal(t, http.StatusOK, retry.Code)
+	assert.Empty(t, openUploadIDs(t, srv, "orphan"))
+	assert.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodGet, "/orphan/big.bin", nil, nil).Code)
+}
+
+// TestS3Fault_QueryKeySelectsTheCreate is the other half of the multipart split: a
+// rule naming the create's sub-resource parameter must not reach the parts, which
+// share the method and path with it under a different parameter.
+func TestS3Fault_QueryKeySelectsTheCreate(t *testing.T) {
+	t.Parallel()
+	srv, fc := newS3FaultServer(t, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:    "s3",
+			QueryKey:   "uploads",
+			FaultType:  "error",
+			ErrorCode:  "SlowDown",
+			HTTPStatus: http.StatusServiceUnavailable,
+			Times:      1,
+		}},
+	})
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/querykey-scope", nil, nil).Code)
+
+	blocked := s3Request(t, srv, http.MethodPost, "/querykey-scope/big.bin?uploads", nil, nil)
+	require.Equal(t, http.StatusServiceUnavailable, blocked.Code)
+	assert.Equal(t, 1, fc.FaultsFired())
+
+	// The rule is spent; the same request now succeeds and the parts are untouched.
+	iw := s3Request(t, srv, http.MethodPost, "/querykey-scope/big.bin?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, iw.Code)
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+	uploadPart(t, srv, "querykey-scope", "big.bin", ir.UploadID, 1, []byte("data"))
+	assert.Equal(t, 1, fc.FaultsFired(), "UploadPart carries no ?uploads and must not match")
+}
+
+// TestS3Fault_PathSuffixSelectsOneKey pins the matcher a caller reaches for when the
+// operation name is right but the target is not: one key, or one file extension,
+// rather than every write to the bucket.
+func TestS3Fault_PathSuffixSelectsOneKey(t *testing.T) {
+	t.Parallel()
+	srv, fc := newS3FaultServer(t, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:    "s3",
+			Operation:  "PutObject",
+			PathSuffix: ".parquet",
+			FaultType:  "error",
+			ErrorCode:  "SlowDown",
+			HTTPStatus: http.StatusServiceUnavailable,
+			Times:      -1,
+		}},
+	})
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/pathsuffix-scope", nil, nil).Code)
+	assert.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/pathsuffix-scope/notes.txt", []byte("v"), nil).Code)
+	assert.Equal(t, http.StatusServiceUnavailable,
+		s3Request(t, srv, http.MethodPut, "/pathsuffix-scope/data.parquet", []byte("v"), nil).Code)
+	assert.Equal(t, 1, fc.FaultsFired())
+}
+
+// TestS3Fault_HeaderPrefixSelectsARequestFamily covers the third wire matcher, on the
+// case it exists for: a header family is a property of the request that no operation
+// name carries, so a rule targeting encrypted writes alone needs it.
+func TestS3Fault_HeaderPrefixSelectsARequestFamily(t *testing.T) {
+	t.Parallel()
+	srv, fc := newS3FaultServer(t, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:      "s3",
+			Operation:    "PutObject",
+			HeaderPrefix: "x-amz-server-side-encryption",
+			FaultType:    "error",
+			ErrorCode:    "KMS.KeyUnavailableException",
+			HTTPStatus:   http.StatusServiceUnavailable,
+			Times:        -1,
+		}},
+	})
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/headerprefix-scope", nil, nil).Code)
+	assert.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/headerprefix-scope/plain.txt", []byte("v"), nil).Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/headerprefix-scope/secret.txt", []byte("v"),
+		map[string]string{"x-amz-server-side-encryption": "aws:kms"})
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, "KMS.KeyUnavailableException", parseS3Error(t, w.Body.Bytes()).Code)
+	assert.Equal(t, 1, fc.FaultsFired())
+}
+
+// TestS3Fault_TimesTwoThenSuccess is the retry outcome the bound exists to produce,
+// asserted end to end: two failures, then the write lands. Before Times existed a rule
+// could only fail forever, so the one thing a retry test needs to observe — recovery —
+// was unobservable.
+func TestS3Fault_TimesTwoThenSuccess(t *testing.T) {
+	t.Parallel()
+	srv, fc := newS3FaultServer(t, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:    "s3",
+			Operation:  "PutObject",
+			FaultType:  "error",
+			ErrorCode:  "SlowDown",
+			HTTPStatus: http.StatusServiceUnavailable,
+			Times:      2,
+		}},
+	})
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/retry", nil, nil).Code)
+
+	codes := make([]int, 0, 3)
+	for i := 0; i < 3; i++ {
+		codes = append(codes, s3Request(t, srv, http.MethodPut, "/retry/k", []byte("v"), nil).Code)
+	}
+	assert.Equal(t, []int{
+		http.StatusServiceUnavailable,
+		http.StatusServiceUnavailable,
+		http.StatusOK,
+	}, codes)
+	assert.Equal(t, 2, fc.FaultsFired())
+
+	// The third write actually stored the object; a spent rule must let the request
+	// through to the plugin rather than merely stop reporting an error.
+	gw := s3Request(t, srv, http.MethodGet, "/retry/k", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Equal(t, "v", gw.Body.String())
+}
+
+// TestS3Fault_DefaultTimesFiresExactlyOnce asserts the zero-means-one default through
+// the wire, deliberately: it is a choice, not an inevitability, and reading zero as
+// unlimited would turn a mistyped field into a fixture that consumes the whole retry
+// budget.
+func TestS3Fault_DefaultTimesFiresExactlyOnce(t *testing.T) {
+	t.Parallel()
+	srv, fc := newS3FaultServer(t, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:    "s3",
+			Operation:  "PutObject",
+			FaultType:  "error",
+			ErrorCode:  "SlowDown",
+			HTTPStatus: http.StatusServiceUnavailable,
+		}},
+	})
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/once", nil, nil).Code)
+	assert.Equal(t, http.StatusServiceUnavailable,
+		s3Request(t, srv, http.MethodPut, "/once/k", []byte("v"), nil).Code)
+	assert.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/once/k", []byte("v"), nil).Code)
+	assert.Equal(t, 1, fc.FaultsFired())
+}

--- a/emulator/fault_test.go
+++ b/emulator/fault_test.go
@@ -1,6 +1,9 @@
 package emulator_test
 
 import (
+	"net/http"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -163,6 +166,448 @@ func TestFaultController_OperationFilter(t *testing.T) {
 	awsErr, _ = fc.InjectFault(reqCtx, getReq)
 	if awsErr != nil {
 		t.Errorf("rule should not fire for non-matching operation, got %v", awsErr)
+	}
+}
+
+// errorRule builds a one-rule config that fires an error on every match, so a test
+// only has to state the matchers it is about.
+func errorRule(rule emulator.FaultRule) emulator.FaultConfig {
+	rule.FaultType = "error"
+	if rule.ErrorCode == "" {
+		rule.ErrorCode = "InternalError"
+	}
+	if rule.Times == 0 {
+		rule.Times = -1
+	}
+	return emulator.FaultConfig{Enabled: true, Rules: []emulator.FaultRule{rule}}
+}
+
+// TestFaultController_WireMatchers covers #480 finding 1 option 3: PathSuffix,
+// QueryKey and HeaderPrefix select on the wire request rather than on its resolved
+// operation name, and every non-empty matcher must hold. QueryKey is the one that
+// separates the multipart sub-operations, which share a method and a path and differ
+// only by a sub-resource parameter.
+func TestFaultController_WireMatchers(t *testing.T) {
+	t.Parallel()
+
+	createUpload := &emulator.AWSRequest{
+		Service:   "s3",
+		Operation: "CreateMultipartUpload",
+		Path:      "/b/big.bin",
+		Params:    map[string]string{"uploads": "1"},
+		Headers:   map[string]string{"X-Amz-Server-Side-Encryption": "AES256"},
+	}
+	uploadPart := &emulator.AWSRequest{
+		Service:   "s3",
+		Operation: "UploadPart",
+		Path:      "/b/big.bin",
+		Params:    map[string]string{"uploadId": "u", "partNumber": "1"},
+		Headers:   map[string]string{},
+	}
+	// A sub-resource sent as "?tagging=" rather than bare "?tagging": the parser
+	// records a bare key as the sentinel "1" and an explicitly empty one as "",
+	// and QueryKey compares presence rather than the value, so both must match.
+	emptyValued := &emulator.AWSRequest{
+		Service:   "s3",
+		Operation: "PutObjectTagging",
+		Path:      "/b/k",
+		Params:    map[string]string{"tagging": ""},
+		Headers:   map[string]string{},
+	}
+	putParquet := &emulator.AWSRequest{
+		Service:   "s3",
+		Operation: "PutObject",
+		Path:      "/b/data.parquet",
+		Params:    map[string]string{},
+		Headers:   map[string]string{},
+	}
+
+	tests := []struct {
+		name string
+		rule emulator.FaultRule
+		req  *emulator.AWSRequest
+		want bool
+	}{
+		// The finding-1 gate: naming the semantic operation hits that operation and
+		// nothing else that shares its HTTP method.
+		{"operation hits PutObject", emulator.FaultRule{Service: "s3", Operation: "PutObject"}, putParquet, true},
+		{"operation misses UploadPart", emulator.FaultRule{Service: "s3", Operation: "PutObject"}, uploadPart, false},
+		// A bare HTTP method no longer matches an S3 request at all, because the
+		// parser resolves the name before faults are evaluated.
+		{"bare method no longer matches s3", emulator.FaultRule{Service: "s3", Operation: "PUT"}, putParquet, false},
+
+		{"query key hits create", emulator.FaultRule{QueryKey: "uploads"}, createUpload, true},
+		{"query key misses part", emulator.FaultRule{QueryKey: "uploads"}, uploadPart, false},
+		{"query key hits part", emulator.FaultRule{QueryKey: "partNumber"}, uploadPart, true},
+		// Presence is what a sub-resource parameter signals, so the value is not
+		// compared: ?uploads arrives as the bare-key sentinel, ?uploadId=u as a value.
+		{"query key ignores the value", emulator.FaultRule{QueryKey: "uploadId"}, uploadPart, true},
+		// …and an explicitly empty value is still present. Comparing the value
+		// instead of testing for the key would silently miss this form.
+		{"query key matches an empty value", emulator.FaultRule{QueryKey: "tagging"}, emptyValued, true},
+		{"query key misses an absent key", emulator.FaultRule{QueryKey: "acl"}, emptyValued, false},
+
+		{"path suffix selects an extension", emulator.FaultRule{PathSuffix: ".parquet"}, putParquet, true},
+		{"path suffix misses another key", emulator.FaultRule{PathSuffix: ".parquet"}, uploadPart, false},
+		{"path suffix selects a whole key", emulator.FaultRule{PathSuffix: "/big.bin"}, uploadPart, true},
+
+		{"header prefix selects", emulator.FaultRule{HeaderPrefix: "x-amz-server-side-encryption"}, createUpload, true},
+		{"header prefix misses", emulator.FaultRule{HeaderPrefix: "x-amz-server-side-encryption"}, uploadPart, false},
+		// The comparison is case-insensitive both ways: a header name is
+		// case-insensitive on the wire and the SDKs do not agree on a spelling.
+		{"header prefix ignores case", emulator.FaultRule{HeaderPrefix: "X-Amz-Server-Side-"}, createUpload, true},
+
+		// All matchers AND together, so a rule that gets one wrong fires on nothing.
+		{
+			name: "all matchers together",
+			rule: emulator.FaultRule{
+				Service: "s3", Operation: "CreateMultipartUpload",
+				PathSuffix: ".bin", QueryKey: "uploads",
+				HeaderPrefix: "x-amz-server-side-encryption",
+			},
+			req:  createUpload,
+			want: true,
+		},
+		{
+			name: "one wrong matcher blocks the rest",
+			rule: emulator.FaultRule{
+				Service: "s3", Operation: "CreateMultipartUpload",
+				PathSuffix: ".parquet", QueryKey: "uploads",
+			},
+			req:  createUpload,
+			want: false,
+		},
+		// The AND is asserted from both sides: a matching wire matcher must not
+		// rescue a rule whose operation is wrong, which is what an OR would do and
+		// what would put a PutObject rule back onto UploadPart by another route.
+		{
+			name: "a matching path suffix does not rescue a wrong operation",
+			rule: emulator.FaultRule{Service: "s3", Operation: "PutObject", PathSuffix: "/big.bin"},
+			req:  uploadPart,
+			want: false,
+		},
+		{
+			name: "a matching query key does not rescue a wrong operation",
+			rule: emulator.FaultRule{Service: "s3", Operation: "PutObject", QueryKey: "uploadId"},
+			req:  uploadPart,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fc := emulator.NewFaultController(errorRule(tt.rule), 42)
+			awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, tt.req)
+			if tt.want && awsErr == nil {
+				t.Error("expected the rule to fire")
+			}
+			if !tt.want && awsErr != nil {
+				t.Errorf("expected the rule not to fire, got %v", awsErr)
+			}
+		})
+	}
+}
+
+// TestFaultController_NonS3BareMethodStillFires is the regression guard for the other
+// side of the semantic-name change: only S3 requests are renamed, so a rule on a bare
+// method still fires for a service whose operation genuinely is its HTTP method.
+func TestFaultController_NonS3BareMethodStillFires(t *testing.T) {
+	t.Parallel()
+	fc := emulator.NewFaultController(errorRule(emulator.FaultRule{Operation: http.MethodGet}), 42)
+	req := &emulator.AWSRequest{Service: "execute-api", Operation: http.MethodGet, Path: "/prod/items"}
+	awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, req)
+	if awsErr == nil {
+		t.Error("a bare-method rule should still fire for a non-S3 service")
+	}
+}
+
+// TestFaultController_ErrorDefaults pins what a rule naming only its fault type
+// produces. Every field of an injected error is optional, and the defaults are the
+// difference between a usable fault and one an SDK cannot see: a zero HTTPStatus
+// serialized as HTTP 200 would arrive as a success carrying an error document, and an
+// empty code leaves the SDK nothing to dispatch on.
+func TestFaultController_ErrorDefaults(t *testing.T) {
+	t.Parallel()
+	fc := emulator.NewFaultController(emulator.FaultConfig{
+		Enabled: true,
+		Rules:   []emulator.FaultRule{{FaultType: "error"}},
+	}, 42)
+
+	awsErr, _ := fc.InjectFault(&emulator.RequestContext{},
+		&emulator.AWSRequest{Service: "s3", Operation: "PutObject"})
+	if awsErr == nil {
+		t.Fatal("expected a fault with only FaultType set to fire")
+	}
+	if awsErr.Code != "InternalError" {
+		t.Errorf("Code = %q, want InternalError", awsErr.Code)
+	}
+	if awsErr.HTTPStatus != http.StatusInternalServerError {
+		t.Errorf("HTTPStatus = %d, want %d", awsErr.HTTPStatus, http.StatusInternalServerError)
+	}
+	if awsErr.Message != "injected fault" {
+		t.Errorf("Message = %q, want \"injected fault\"", awsErr.Message)
+	}
+}
+
+// TestFaultController_Times covers #480 finding 2. The bound is what makes retry
+// assertable — fail twice then succeed is the outcome that distinguishes working
+// retry from no retry, and an unbounded rule can only ever produce failure.
+func TestFaultController_Times(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		// times is the FaultRule.Times value under test, written out rather than
+		// defaulted so the zero case is deliberate.
+		times int
+		// wantFailures is how many of six successive requests fail.
+		wantFailures int
+	}{
+		// Zero means one, not unlimited: a rule that fires on nothing is never what a
+		// caller meant, and reading zero as unlimited turns a mistyped field into a
+		// test that consumes the whole retry budget. Asserted deliberately because it
+		// is a choice, not an inevitability.
+		{"zero means one", 0, 1},
+		{"one", 1, 1},
+		{"two failures then success", 2, 2},
+		{"negative is unlimited", -1, 6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fc := emulator.NewFaultController(emulator.FaultConfig{
+				Enabled: true,
+				Rules: []emulator.FaultRule{{
+					Service:   "s3",
+					Operation: "PutObject",
+					FaultType: "error",
+					ErrorCode: "SlowDown",
+					Times:     tt.times,
+				}},
+			}, 42)
+
+			req := &emulator.AWSRequest{Service: "s3", Operation: "PutObject"}
+			failures := 0
+			for i := 0; i < 6; i++ {
+				if awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, req); awsErr != nil {
+					failures++
+				}
+			}
+			if failures != tt.wantFailures {
+				t.Errorf("failures = %d, want %d", failures, tt.wantFailures)
+			}
+			if fired := fc.FaultsFired(); fired != tt.wantFailures {
+				t.Errorf("FaultsFired() = %d, want %d", fired, tt.wantFailures)
+			}
+		})
+	}
+}
+
+// TestFaultController_TimesBoundsLatencyToo asserts the bound applies to a latency
+// fault as well as an error one. A latency rule is the one a caller is most likely to
+// arm unbounded by accident, since it produces no visible failure to notice.
+func TestFaultController_TimesBoundsLatencyToo(t *testing.T) {
+	t.Parallel()
+	fc := emulator.NewFaultController(emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:   "s3",
+			FaultType: "latency",
+			LatencyMs: 5,
+			Times:     2,
+		}},
+	}, 42)
+
+	req := &emulator.AWSRequest{Service: "s3", Operation: "GetObject"}
+	delays := 0
+	for i := 0; i < 5; i++ {
+		if _, delay := fc.InjectFault(&emulator.RequestContext{}, req); delay > 0 {
+			delays++
+		}
+	}
+	if delays != 2 {
+		t.Errorf("delays = %d, want 2", delays)
+	}
+	if fired := fc.FaultsFired(); fired != 2 {
+		t.Errorf("FaultsFired() = %d, want 2", fired)
+	}
+}
+
+// TestFaultController_SpentRuleFallsThroughToTheNext asserts a rule that has reached
+// its bound is skipped rather than stopping evaluation, so a later rule still gets its
+// turn. Returning early on a spent rule would silently disarm every rule after it.
+func TestFaultController_SpentRuleFallsThroughToTheNext(t *testing.T) {
+	t.Parallel()
+	fc := emulator.NewFaultController(emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{
+			{Service: "s3", FaultType: "error", ErrorCode: "SlowDown", Times: 1},
+			{Service: "s3", FaultType: "error", ErrorCode: "InternalError", Times: -1},
+		},
+	}, 42)
+
+	req := &emulator.AWSRequest{Service: "s3", Operation: "PutObject"}
+	first, _ := fc.InjectFault(&emulator.RequestContext{}, req)
+	if first == nil || first.Code != "SlowDown" {
+		t.Fatalf("first request: got %v, want SlowDown", first)
+	}
+	second, _ := fc.InjectFault(&emulator.RequestContext{}, req)
+	if second == nil || second.Code != "InternalError" {
+		t.Fatalf("second request: got %v, want InternalError", second)
+	}
+}
+
+// TestFaultController_TimesIsAtomic is the race gate for #480 finding 2, and must run
+// under -race. With Times set to 1, N concurrent requests have to produce exactly one
+// failure; that atomicity is the property the mechanism exists for, and it is not
+// something a counter on the client side can arrange.
+func TestFaultController_TimesIsAtomic(t *testing.T) {
+	t.Parallel()
+	fc := emulator.NewFaultController(emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:   "s3",
+			Operation: "PutObject",
+			FaultType: "error",
+			ErrorCode: "SlowDown",
+			Times:     1,
+		}},
+	}, 42)
+
+	const workers = 10
+	var wg sync.WaitGroup
+	var failures atomic.Int64
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := &emulator.AWSRequest{Service: "s3", Operation: "PutObject"}
+			if awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, req); awsErr != nil {
+				failures.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := failures.Load(); got != 1 {
+		t.Errorf("failures across %d concurrent requests = %d, want 1", workers, got)
+	}
+	if fired := fc.FaultsFired(); fired != 1 {
+		t.Errorf("FaultsFired() = %d, want 1", fired)
+	}
+}
+
+// TestFaultController_GetConfigCopiesRules asserts the snapshot is a copy: a caller
+// reading a fired count must not share the slice InjectFault increments, or the read
+// races the write and -race reports it.
+func TestFaultController_GetConfigCopiesRules(t *testing.T) {
+	t.Parallel()
+	fc := emulator.NewFaultController(emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{
+			{Service: "s3", FaultType: "error", ErrorCode: "SlowDown", Times: -1},
+		},
+	}, 42)
+
+	req := &emulator.AWSRequest{Service: "s3", Operation: "PutObject"}
+	_, _ = fc.InjectFault(&emulator.RequestContext{}, req)
+	snapshot := fc.GetConfig()
+	if snapshot.Rules[0].Fired != 1 {
+		t.Fatalf("snapshot fired = %d, want 1", snapshot.Rules[0].Fired)
+	}
+
+	_, _ = fc.InjectFault(&emulator.RequestContext{}, req)
+	if snapshot.Rules[0].Fired != 1 {
+		t.Errorf("snapshot fired = %d after a second fault, want the copy to be unchanged", snapshot.Rules[0].Fired)
+	}
+	if live := fc.GetConfig().Rules[0].Fired; live != 2 {
+		t.Errorf("live fired = %d, want 2", live)
+	}
+}
+
+// TestFaultController_FaultsFiredIsZeroForARuleThatMatchedNothing is the assertion
+// that gives the count its point: a rule matching no request produces exactly the same
+// passing test as a consumer's retry working, and only the count tells them apart.
+func TestFaultController_FaultsFiredIsZeroForARuleThatMatchedNothing(t *testing.T) {
+	t.Parallel()
+	fc := emulator.NewFaultController(errorRule(emulator.FaultRule{
+		Service:   "s3",
+		Operation: "PutObject",
+	}), 42)
+
+	req := &emulator.AWSRequest{Service: "s3", Operation: "GetObject"}
+	if awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, req); awsErr != nil {
+		t.Fatalf("rule should not have fired, got %v", awsErr)
+	}
+	if fired := fc.FaultsFired(); fired != 0 {
+		t.Errorf("FaultsFired() = %d, want 0", fired)
+	}
+	if fired := fc.GetConfig().Rules[0].Fired; fired != 0 {
+		t.Errorf("rule fired = %d, want 0", fired)
+	}
+}
+
+// TestFaultController_UpdateConfigResetsFiredCounts pins the control-plane contract:
+// arming rules replaces the configuration, so a fixture that re-arms the same rule
+// between test phases gets its full Times budget rather than a spent one.
+func TestFaultController_UpdateConfigResetsFiredCounts(t *testing.T) {
+	t.Parallel()
+	cfg := emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{
+			{Service: "s3", FaultType: "error", ErrorCode: "SlowDown", Times: 1},
+		},
+	}
+	fc := emulator.NewFaultController(cfg, 42)
+	req := &emulator.AWSRequest{Service: "s3", Operation: "PutObject"}
+
+	if awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, req); awsErr == nil {
+		t.Fatal("expected the first request to fail")
+	}
+	if awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, req); awsErr != nil {
+		t.Fatal("expected the rule to be spent")
+	}
+
+	fc.UpdateConfig(cfg)
+	if fired := fc.FaultsFired(); fired != 0 {
+		t.Errorf("FaultsFired() = %d after re-arming, want 0", fired)
+	}
+	if awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, req); awsErr == nil {
+		t.Error("expected a re-armed rule to fire again")
+	}
+}
+
+// TestFaultController_UpdateConfigDoesNotMutateTheCallersRules is the second half of
+// the private-copy guarantee. [TestFaultController_UpdateConfigResetsFiredCounts] only
+// exercises the copy NewFaultController makes: the value it re-arms with is still
+// pristine because the first arming copied it. Arming twice through UpdateConfig is
+// what reaches the second copy — without it, the fired count is written into the
+// caller's own slice and the second arming starts spent.
+func TestFaultController_UpdateConfigDoesNotMutateTheCallersRules(t *testing.T) {
+	t.Parallel()
+	cfg := emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{
+			{Service: "s3", FaultType: "error", ErrorCode: "SlowDown", Times: 1},
+		},
+	}
+	fc := emulator.NewFaultController(emulator.FaultConfig{Enabled: false}, 42)
+	req := &emulator.AWSRequest{Service: "s3", Operation: "PutObject"}
+
+	fc.UpdateConfig(cfg)
+	if awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, req); awsErr == nil {
+		t.Fatal("expected the first request to fail")
+	}
+
+	// The caller's literal must be untouched, so a fixture holding one value and
+	// arming it between phases gets its full budget every time.
+	if cfg.Rules[0].Fired != 0 {
+		t.Errorf("the caller's rule was mutated: Fired = %d, want 0", cfg.Rules[0].Fired)
+	}
+
+	fc.UpdateConfig(cfg)
+	if awsErr, _ := fc.InjectFault(&emulator.RequestContext{}, req); awsErr == nil {
+		t.Error("expected the same config, armed again, to fire again")
 	}
 }
 

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -118,6 +118,21 @@ func ParseAWSRequest(r *http.Request) (*AWSRequest, *RequestContext, error) {
 		Path:      effectivePath,
 	}
 
+	// S3 supplies none of extractOperation's first three signals, so it fell
+	// through to the HTTP-method fallback and every S3 request entered the
+	// pipeline named "PUT"/"GET"/"POST"/"DELETE"/"HEAD". The plugin resolved the
+	// semantic name, but not until it handled the request — one step after fault
+	// injection, cost and consistency had already read req.Operation. A fault
+	// rule naming PutObject therefore matched nothing while a rule naming PUT
+	// took out UploadPart too (#480). parseS3Operation is pure and depends only
+	// on fields already populated above, so resolving here makes the canonical
+	// name available to every step.
+	if service == "s3" {
+		if _, _, op := parseS3Operation(req); op != "" {
+			req.Operation = op
+		}
+	}
+
 	reqCtx := &RequestContext{
 		RequestID: generateRequestID(),
 		AccountID: account,

--- a/emulator/parser_test.go
+++ b/emulator/parser_test.go
@@ -146,6 +146,85 @@ func TestParseAWSRequest_Operation(t *testing.T) {
 	}
 }
 
+// TestParseAWSRequest_S3SemanticOperation covers #480 finding 1. S3 supplies none
+// of extractOperation's first three signals, so every S3 request used to enter the
+// pipeline named after its HTTP method and only acquired a semantic name inside the
+// plugin — one step after fault injection, cost and consistency had already read it.
+// A fault rule naming PutObject matched nothing while one naming PUT also took out
+// UploadPart, and the two cannot be told apart from the caller's side.
+func TestParseAWSRequest_S3SemanticOperation(t *testing.T) {
+	tests := []struct {
+		name    string
+		method  string
+		url     string
+		headers map[string]string
+		want    string
+	}{
+		{"put object", http.MethodPut, "http://s3.amazonaws.com/b/k", nil, "PutObject"},
+		{"get object", http.MethodGet, "http://s3.amazonaws.com/b/k", nil, "GetObject"},
+		{"head object", http.MethodHead, "http://s3.amazonaws.com/b/k", nil, "HeadObject"},
+		{"delete object", http.MethodDelete, "http://s3.amazonaws.com/b/k", nil, "DeleteObject"},
+		{"create bucket", http.MethodPut, "http://s3.amazonaws.com/b", nil, "CreateBucket"},
+		{"head bucket", http.MethodHead, "http://s3.amazonaws.com/b", nil, "HeadBucket"},
+		{"list buckets", http.MethodGet, "http://s3.amazonaws.com/", nil, "ListBuckets"},
+		{"list objects v2", http.MethodGet, "http://s3.amazonaws.com/b?list-type=2", nil, "ListObjectsV2"},
+		// The multipart family: three sub-operations sharing a method and a path,
+		// separated only by a query parameter. These are what a rule on the bare
+		// method could not distinguish.
+		{"create multipart upload", http.MethodPost, "http://s3.amazonaws.com/b/k?uploads", nil, "CreateMultipartUpload"},
+		{"upload part", http.MethodPut, "http://s3.amazonaws.com/b/k?partNumber=1&uploadId=u", nil, "UploadPart"},
+		{"complete multipart upload", http.MethodPost, "http://s3.amazonaws.com/b/k?uploadId=u", nil, "CompleteMultipartUpload"},
+		{"abort multipart upload", http.MethodDelete, "http://s3.amazonaws.com/b/k?uploadId=u", nil, "AbortMultipartUpload"},
+		{
+			name:    "copy object",
+			method:  http.MethodPut,
+			url:     "http://s3.amazonaws.com/b/k",
+			headers: map[string]string{"X-Amz-Copy-Source": "/src/k"},
+			want:    "CopyObject",
+		},
+		{"put object acl", http.MethodPut, "http://s3.amazonaws.com/b/k?acl", nil, "PutObjectAcl"},
+		{"get bucket acl", http.MethodGet, "http://s3.amazonaws.com/b?acl", nil, "GetBucketAcl"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(tt.method, tt.url, nil)
+			r.Host = "s3.amazonaws.com"
+			for k, v := range tt.headers {
+				r.Header.Set(k, v)
+			}
+			req, _, err := emulator.ParseAWSRequest(r)
+			require.NoError(t, err)
+			assert.Equal(t, "s3", req.Service)
+			assert.Equal(t, tt.want, req.Operation)
+		})
+	}
+}
+
+// TestParseAWSRequest_S3VirtualHostSemanticOperation asserts the resolution reads
+// the normalized path, not the raw one: virtual-hosted addressing puts the bucket in
+// the Host, so a request whose URL path is "/k" is still a PutObject rather than a
+// CreateBucket for a bucket named "k". Getting this backwards would arm a rule on
+// the wrong operation for every SDK using the default addressing style.
+func TestParseAWSRequest_S3VirtualHostSemanticOperation(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPut, "http://mybucket.s3.amazonaws.com/k", nil)
+	r.Host = "mybucket.s3.amazonaws.com"
+	req, _, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	assert.Equal(t, "s3", req.Service)
+	assert.Equal(t, "PutObject", req.Operation)
+}
+
+// TestParseAWSRequest_NonS3KeepsMethodFallback guards the other side: only S3 is
+// resolved here, so a service without an Action or an X-Amz-Target still reports its
+// HTTP method and no existing fault fixture on a bare method regresses.
+func TestParseAWSRequest_NonS3KeepsMethodFallback(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "http://localhost/anything", nil)
+	req, _, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	assert.NotEqual(t, "s3", req.Service)
+	assert.Equal(t, http.MethodGet, req.Operation)
+}
+
 func TestParseAWSRequest_Region(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -82,12 +82,16 @@ func (p *S3Plugin) Initialize(_ context.Context, cfg PluginConfig) error {
 func (p *S3Plugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches the S3 REST operation to the appropriate handler.
-// It derives the semantic operation from the HTTP method, URL path, and query
-// parameters, then mutates req.Operation so the server pipeline's cost and
-// consistency tracking see the canonical name.
+// It derives the semantic operation, bucket and key from the HTTP method, URL
+// path and query parameters.
+//
+// For a request off the wire ParseAWSRequest has already resolved the operation
+// name, so that call returns it unchanged; the assignment stays because an
+// in-process caller can build an AWSRequest carrying a bare HTTP method, and
+// the pipeline's cost, consistency and metrics steps read req.Operation.
 func (p *S3Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	bucket, key, op := parseS3Operation(req)
-	req.Operation = op // mutate so server pipeline sees semantic name
+	req.Operation = op
 
 	switch op {
 	case "ListBuckets":
@@ -183,12 +187,30 @@ func (p *S3Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	}
 }
 
-// parseS3Operation derives the semantic S3 operation name, bucket, and key
-// from an AWSRequest whose Operation field still holds the raw HTTP method.
+// s3HTTPMethods is the set of raw HTTP methods parseS3Operation can be handed in
+// place of a resolved operation name. It is what makes the function idempotent:
+// ParseAWSRequest resolves the name before the request enters the pipeline
+// (#480), while an in-process caller building an AWSRequest by hand still passes
+// a bare verb, and both must reach the same answer.
+var s3HTTPMethods = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPut:    true,
+	http.MethodPost:   true,
+	http.MethodDelete: true,
+	http.MethodHead:   true,
+}
+
+// parseS3Operation derives the semantic S3 operation name, bucket, and key from
+// an AWSRequest. Operation may hold either the raw HTTP method or an already
+// resolved operation name; a resolved name is returned unchanged, so calling
+// this twice on the same request is safe.
 func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 	// Strip leading slash and split on the first "/" to get bucket and key.
 	path := strings.TrimPrefix(req.Path, "/")
 	if path == "" || path == "/" {
+		if !s3HTTPMethods[req.Operation] {
+			return "", "", req.Operation
+		}
 		return "", "", "ListBuckets"
 	}
 
@@ -208,7 +230,14 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 		key = ""
 	}
 
-	method := req.Operation // still the HTTP verb at this point
+	// A resolved operation name arrives when ParseAWSRequest already named it,
+	// which is every request off the wire. Returning it as-is keeps the bucket
+	// and key derivation available to the plugin without re-deriving a name that
+	// the switch below would not recognize anyway.
+	method := req.Operation
+	if !s3HTTPMethods[method] {
+		return bucket, key, method
+	}
 
 	if key == "" {
 		// Bucket-level operations.

--- a/emulator/server_test.go
+++ b/emulator/server_test.go
@@ -111,16 +111,21 @@ func TestServer_PluginError_ReturnsAWSError(t *testing.T) {
 	resp := w.Result()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
+	// S3's error document is a bare <Error> with a <RequestId>, not the Query
+	// protocol's <ErrorResponse> wrapper (#480). The pipeline serializes an error the
+	// S3 plugin returned in the same shape the plugin's own errors use, which is what
+	// keeps an error raised before routing indistinguishable from one raised after it.
 	body, _ := io.ReadAll(resp.Body)
 	var errResp struct {
-		XMLName xml.Name `xml:"ErrorResponse"`
-		Error   struct {
-			Code    string `xml:"Code"`
-			Message string `xml:"Message"`
-		} `xml:"Error"`
+		XMLName   xml.Name `xml:"Error"`
+		Code      string   `xml:"Code"`
+		Message   string   `xml:"Message"`
+		RequestID string   `xml:"RequestId"`
 	}
 	require.NoError(t, xml.Unmarshal(body, &errResp))
-	assert.Equal(t, "NoSuchBucket", errResp.Error.Code)
+	assert.Equal(t, "NoSuchBucket", errResp.Code)
+	assert.Equal(t, "the specified bucket does not exist", errResp.Message)
+	assert.NotEmpty(t, errResp.RequestID)
 }
 
 func TestServer_EventsAreRecorded(t *testing.T) {

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.30
 	github.com/aws/aws-sdk-go-v2/service/iam v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.0
+	github.com/aws/smithy-go v1.27.3
 	github.com/scttfrdmn/substrate v0.0.0
 	github.com/spf13/afero v1.15.0
 	github.com/stretchr/testify v1.11.1
@@ -29,7 +30,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.0 // indirect
-	github.com/aws/smithy-go v1.27.3 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/test/e2e/journey_throttling_test.go
+++ b/test/e2e/journey_throttling_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 
 	emulator "github.com/scttfrdmn/substrate/emulator"
 )
@@ -38,25 +40,33 @@ func TestJourney_SeededThrottling(t *testing.T) {
 		t.Fatalf("CreateBucket: %v", err)
 	}
 
-	// Seed a throttling fault on S3 writes via the control plane. Fault rules are
-	// evaluated before the S3 plugin resolves the semantic operation name, so for
-	// S3's REST protocol the operation at match time is the HTTP method ("PUT");
-	// an empty Operation (match all S3 ops) works too. JSON-protocol services
-	// (e.g. DynamoDB "PutItem") match on the semantic name directly.
+	// Seed a throttling fault on S3 writes via the control plane. The operation is
+	// the semantic name for every service, S3 included: the request parser resolves
+	// an S3 REST request before faults are evaluated (#480), so "PutObject" fires on
+	// PutObject alone and not on UploadPart, which is also a PUT. An empty Operation
+	// (match all S3 ops) works too.
+	//
+	// Times is -1 (unlimited) deliberately: the default of one would make the
+	// "clear the fault and retry" step below succeed whether or not clearing worked,
+	// since the rule would already be spent.
 	seedFaultRules(t, ts, emulator.FaultConfig{
 		Enabled: true,
 		Rules: []emulator.FaultRule{{
 			Service:     "s3",
-			Operation:   "PUT",
+			Operation:   "PutObject",
 			FaultType:   "error",
 			ErrorCode:   "SlowDown",
 			HTTPStatus:  503,
 			ErrorMsg:    "Please reduce your request rate.",
 			Probability: 1.0,
+			Times:       -1,
 		}},
 	})
 
-	// PutObject now fails with the seeded throttling error.
+	// PutObject now fails with the seeded throttling error, and the SDK surfaces the
+	// code that was armed. Before #480 the injected error used the wrapped
+	// <ErrorResponse> document S3's parser reads no code out of, so this arrived as
+	// ServiceUnavailable and a consumer matching on SlowDown never saw their fault.
 	_, err = client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String("k"),
@@ -64,6 +74,20 @@ func TestJourney_SeededThrottling(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected seeded throttling error, got nil")
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected a smithy.APIError, got %T: %v", err, err)
+	}
+	if apiErr.ErrorCode() != "SlowDown" {
+		t.Fatalf("ErrorCode() = %q, want SlowDown", apiErr.ErrorCode())
+	}
+
+	// The rule reports having fired. A rule that matched nothing produces exactly the
+	// same passing test as a consumer's retry working, so the count is what tells
+	// those two apart.
+	if fired := faultsFired(t, ts); fired != 1 {
+		t.Fatalf("fired = %d, want 1", fired)
 	}
 
 	// Clear the fault; the same call now succeeds.
@@ -92,6 +116,30 @@ func seedFaultRules(t *testing.T, ts *emulator.TestServer, cfg emulator.FaultCon
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("POST /v1/fault/rules: status %d", resp.StatusCode)
 	}
+}
+
+// faultsFired GETs the control plane's rule list and totals each rule's fired
+// count, which is the assertion that separates a fault that fired from a rule
+// that matched nothing.
+func faultsFired(t *testing.T, ts *emulator.TestServer) int {
+	t.Helper()
+	resp, err := http.Get(ts.URL + "/v1/fault/rules") //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET /v1/fault/rules: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /v1/fault/rules: status %d", resp.StatusCode)
+	}
+	var cfg emulator.FaultConfig
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode fault config: %v", err)
+	}
+	total := 0
+	for _, rule := range cfg.Rules {
+		total += rule.Fired
+	}
+	return total
 }
 
 // clearFaultRules DELETEs all active fault rules.


### PR DESCRIPTION
Closes #480

Four findings from #480, taken in the reporter's own priority order. They
compound: together they mean an armed S3 fault often fires on the wrong request,
or fires and cannot be told apart from a real error — and a test that arms one
and sees success has proven nothing.

## Finding 1 — an S3 rule could not name a semantic operation

Faults evaluate at `server.go`'s step 4.5 against `req.Operation`; the S3 plugin
assigns the semantic name at step 5, one step later. So the fault matcher saw the
bare HTTP verb: a rule on `PutObject` never fired, and a rule on `PUT` took out
`UploadPart` too.

The reporter asked for **both** of their options, and both are right:

- **Option 2** — `extractOperation` now calls the already-pure
  `parseS3Operation` when `service == "s3"`, so `req.Operation` is canonical from
  the start. This also fixes cost and consistency attribution for any request
  that errors before routing, which is wider than faults. The S3 plugin keeps its
  `parseS3Operation` call (it is how `bucket`/`key` are derived) and drops the
  mutation.
- **Option 3** — `PathSuffix`, `QueryKey` and `HeaderPrefix` target the wire
  request within an operation, AND-ed with `Service`/`Operation`. `QueryKey` is
  what separates the multipart sub-operations (`uploads` vs `uploadId` vs
  `partNumber`), which is what makes the reporter's own previously-unwritable
  test — "Complete fails after all parts uploaded, assert no orphaned upload" —
  writable. It is written.

Option 2 had to land with option 3, because `QueryKey` is only useful once
operations are named correctly.

## Finding 2 — no occurrence bound, and no way to know a rule fired

`FaultRule.Times` bounds a rule to N occurrences. **Zero means one, not
unlimited**: fail twice then succeed is the outcome that distinguishes working
retry from no retry, an unbounded rule can only ever produce failure, and reading
a mistyped zero as unlimited consumes the whole retry budget. A negative value
asks for unlimited explicitly.

Per-rule `Fired` counts surface through the existing `GET /v1/fault/rules` (a
field, not a new endpoint) and a `FaultsFired()` accessor. The reporter's point is
the one that matters: a rule matching nothing produces exactly the same passing
test as a consumer's retry working, and finding 1 would have been caught instantly
by any test asserting a non-zero count.

The match, the probability roll and the increment now happen under **one** lock —
`InjectFault` previously took `RLock` to snapshot the config and a separate write
lock for the roll, which is a race for a counter. With `Times: 1`, N concurrent
requests must produce exactly one failure, and that atomicity is what a
client-side counter cannot provide.

## Findings 3 and 4 — an injected error was distinguishable from a real one

Finding 4 *causes* finding 3, and this is the one property a fault injector must
not have. `marshalAWSError`'s default arm emitted the Query protocol's
`<ErrorResponse><Error><Type>Sender</Type>…` document, while genuine S3 errors
come from `s3ErrorResponseWith` as a bare `<Error>` with an XML declaration and a
`<RequestId>`. The SDK could not read the code out of the wrong shape, so it fell
back to the HTTP status: a requested `SlowDown` arrived as `ServiceUnavailable`.

Fixed at the marshaller. `errProtoS3XML` builds the document by calling
`s3ErrorResponseWith`, so that function stays the single source of truth for the
byte shape — `error_protocol.go`'s existing "plugins that need a byte-exact
document build it themselves" pointer is now real rather than aspirational.

`cloudfront` and `route53` are REST-XML too and share the Query arm, but their
real error documents *are* `<ErrorResponse>`, so they are correct where they are
and this PR does not sweep them along. The map says so, since the next reader
will wonder.

## Also

`FaultRule.Probability`'s PRNG is shared across every rule in a config, so a roll
for any rule advances it for all and a fixed seed reproduces a run only while the
sequence of requests is unchanged. Confirmed, documented, and filed as #510 —
per-rule PRNGs would change existing seeded behaviour, so it is not changed here.

Fixed along the way: `NewFaultController` and `UpdateConfig` stored the caller's
rule slice, so incrementing a count reached into the caller's own literal and a
config armed twice started its second arming already spent.

## Tests

- A rule on `PutObject` fires on `PutObject` and **not** on `UploadPart`; a rule
  on `GET` no longer matches an S3 request, which is the deliberate compatibility
  break.
- `QueryKey: uploads` hits `CreateMultipartUpload` and not `UploadPart`; the
  orphaned-upload test the reporter could not write.
- `PathSuffix` and `HeaderPrefix` each select, and every matcher ANDs — asserted
  from both sides, so a matching wire matcher cannot rescue a wrong operation.
- `Times: 2` → two failures then success; `Times` absent → **exactly one**,
  asserted deliberately because it is a choice; negative → unlimited.
- `Times: 1` with 10 parallel requests → exactly one failure, under `-race`.
- `GET /v1/fault/rules` reports `fired`; a rule that matched nothing reports `0`.
- `error_code: SlowDown` arrives at the client as `SlowDown`, and the raw body is
  **byte-identical** to a genuine `NoSuchKey` document modulo the code and
  message — asserted two ways, since the byte comparison is the only assertion
  that proves indistinguishability.
- EC2 (Query) and SQS (JSON RPC) injected errors are unchanged, against a
  fault-armed server with no plugins registered at all.

`TestServer_PluginError_ReturnsAWSError` was asserting the wrapped shape for an
S3 plugin error; it now asserts the bare `<Error>` and its `<RequestId>`, which
is the fix's point.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0
issues), `make test` (race), `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go test -C test/e2e ./...` — all
clean.

Mutation-tested at 32 mutants: **31 caught, 1 proven equivalent, 0 survived.**
`-race` is part of that harness's gate rather than an extra, because the
atomicity mutants are only detectable as a reported race. Four mutants survived
the first run and produced four new tests (`ErrorDefaults`,
`UpdateConfigDoesNotMutateTheCallersRules`, and two `WireMatchers` rows for an
explicitly-empty query value and for the AND asserted from the operation side).
The one equivalent mutant carries a written proof: `parseS3Operation` returns
`""` only when `req.Operation` is already `""`, so the guard it removes can never
suppress a write that would change anything.

End to end through the AWS CLI against `substrate server`:

```
POST /v1/fault/rules {"service":"s3","operation":"PutObject",
                      "error_code":"SlowDown","http_status":503,"times":2}
put-object ×3        → SlowDown, SlowDown, 200
GET /v1/fault/rules  → "fired": 2
```

The injected document on the wire, beside a genuine one:

```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>SlowDown</Code><Message>injected fault</Message><RequestId>SUBSTRATE</RequestId></Error>
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist.</Message><RequestId>SUBSTRATE</RequestId></Error>
```

And the semantic-operation fix, both requests being `PUT`:

```
rule {"service":"s3","operation":"UploadPart","times":-1}
put-object   → 200
upload-part  → InternalError
```
