### PR TITLE
fix(sqs): warn on a stored attribute violation, still return the message (#491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,6 +474,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the outcome of every existing seeded run, so it is filed as #510 rather than changed
   inside a fix for something else.
 
+- **`ReceiveMessage` now warns when a stored message's attributes violate a current
+  rule, and still returns the message** (#491). v0.86.0 added SQS's message-attribute
+  count, name, type and `Number` value rules on send. A message written into state
+  before they existed — replayed from an event log recorded against an older substrate —
+  can still carry an illegal name, an eleventh attribute or a `Number` holding `"abc"`.
+  It is returned as stored, in full, and a `WARN` line names the queue, the message ID
+  and the violated rule.
+
+  **Returning it is the decision, not an omission.** Substrate's core property is that
+  replaying an event log reproduces the same observations, and the message was accepted
+  by the substrate that recorded it — so withholding or dropping it would make a recorded
+  run unreplayable, which is the property everything else rests on. A receive-time
+  rejection also has no AWS behaviour to imitate: real SQS never accepted the message, so
+  there is nothing to copy. The suite now fails if anyone adds one, which is what makes
+  this a recorded decision rather than an unfixed gap.
+
+  The warning covers the whole stored attribute set rather than the subset the request
+  named, because the violation is a property of state and a request naming no attributes
+  gets none back — checking only the selection would hide it from exactly the caller most
+  likely to be replaying an old log. It fires on every receive rather than once, since
+  remembering which messages had already warned would be per-process state a replay could
+  not reproduce. Send-time rejection is unchanged, so no new run can produce this state.
+  A replay-time report is the more principled home for the signal and is filed as #512;
+  it needs a surface in the replay machinery that does not exist, and the warning delivers
+  the operator-facing value now.
+
 ## [v0.86.0] - 2026-08-02
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -1530,9 +1530,30 @@ reimplementations. Neither moto nor LocalStack enforces the count at all, which 
 substrate accepting an eleventh attribute went unnoticed until message attributes became
 observable.
 
-The rules apply on send, not on receive. A message written into state before they existed
-— replayed from an older event log — is returned as stored rather than withheld, since
-withholding it would make a recorded run unreplayable.
+### The rules apply on send, not on receive
+
+A message written into state before the rules existed — replayed from an older event log
+— is **returned as stored**, in full: same body, same attributes, nothing filtered,
+nothing corrected. `ReceiveMessage` logs a warning at `WARN` naming the queue, the message
+ID and the violated rule, and that is the whole of the receive-side behaviour.
+
+Returning it is the decision, not an omission. Substrate's core property is that
+replaying an event log reproduces the same observations, and the message was accepted by
+the substrate that recorded it. Withholding or dropping it now would make a recorded run
+unreplayable — the one property the emulator rests on — and a receive-time rejection has
+no AWS behaviour to imitate: real SQS never accepted the message, so there is nothing to
+copy. Rejecting on receive is deliberately not done, and the test suite fails if anyone
+adds it.
+
+The warning covers the **whole stored attribute set**, not the subset the request named.
+The violation is a property of what is in state, and a request that names no attribute
+names gets no attributes back, so checking only the selection would hide it from exactly
+the caller most likely to be replaying an old log. It also fires on every receive of the
+same message rather than once: a redelivery after the visibility timeout is the fixture
+being exercised again, and remembering which messages had already warned would be
+per-process state a replay could not reproduce.
+
+Send-time rejection is unchanged, so no new run can produce this state.
 
 ### QueueNameExists
 

--- a/emulator/sqs_messageattrrules.go
+++ b/emulator/sqs_messageattrrules.go
@@ -118,6 +118,42 @@ func sqsCheckMessageAttributes(attrs map[string]SQSMessageAttribute) *AWSError {
 	return nil
 }
 
+// sqsWarnStoredAttributes logs at WARN when a stored message's attributes violate a
+// rule that [sqsCheckMessageAttributes] enforces on send, and does nothing else. The
+// message is still returned, in full, exactly as stored (#491).
+//
+// Returning it is the decision, not an omission. Substrate's core property is that
+// replaying an event log reproduces the same observations, and a message written by an
+// older substrate was accepted by the substrate that recorded it — so withholding or
+// dropping it now would make a recorded run unreplayable, which is the one outcome #491
+// rules out. The warning gives an operator the signal that their fixture predates the
+// rules without changing what any caller observes.
+//
+// The whole stored attribute set is checked rather than the subset the request asked
+// for: the violation is a property of what is in state, and #461's selection means a
+// request naming no attribute names would otherwise hide it entirely.
+//
+// It fires on every receive of the same message rather than once. A message redelivered
+// after its visibility timeout is a fixture being exercised again, and remembering which
+// messages have already warned would be per-process state that a replay could not
+// reproduce.
+//
+// The attribute-free fast path is the common case — most messages carry no attributes at
+// all — and skips a sort and an allocation per message in the receive loop.
+func sqsWarnStoredAttributes(logger Logger, queueURL string, msg *SQSMessage) {
+	if len(msg.MessageAttributes) == 0 {
+		return
+	}
+	awsErr := sqsCheckMessageAttributes(msg.MessageAttributes)
+	if awsErr == nil {
+		return
+	}
+	logger.Warn("sqs receiveMessage: stored message attributes violate a current rule; "+
+		"returning the message as stored so the run stays replayable",
+		"queue", queueURL, "messageId", msg.MessageID,
+		"code", awsErr.Code, "violation", awsErr.Message)
+}
+
 // sqsCheckAttributeName validates one attribute name against the guide's rules.
 //
 // The prefix rule is **case-INsensitive**, and that is the detail a reader arriving

--- a/emulator/sqs_messageattrrules_test.go
+++ b/emulator/sqs_messageattrrules_test.go
@@ -1,13 +1,16 @@
 package emulator_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -769,51 +772,244 @@ func TestSQS_MessageAttributes_ErrorIsDeterministicAcrossRules(t *testing.T) {
 	}
 }
 
-// TestSQS_MessageAttributes_StoredAttributesAreNotRechecked records the deliberate
-// scope boundary: the rules apply on send, not on receive.
+// storeIllegalAttributes replaces a stored message's MessageAttributes with attrs,
+// writing straight into the state store, and returns the message ID.
 //
-// A message written into state before these checks existed — the only way an illegal
-// name can still be there, since no API path stores one now — is returned as stored
-// rather than withheld. Withholding it would make a recorded run unreplayable, which is
-// the property the whole emulator rests on, and a receive-time rejection has no AWS
-// behavior behind it: real SQS never accepted the message, so there is nothing to
-// imitate. Tracked separately; this test pins the choice rather than the gap.
+// Going around the API is the point rather than a shortcut: no send path stores an
+// illegal attribute any more, so the only way this state exists is an event log recorded
+// against a substrate that predates the rules. Reaching it through the API is impossible
+// by construction, and anything weaker would not exercise the path at all.
 //
-// The illegal name is written directly into state, which is what a pre-#472 event log
-// replays into. Reaching it through the API is impossible by construction now, so
-// nothing weaker would exercise the path.
-func TestSQS_MessageAttributes_StoredAttributesAreNotRechecked(t *testing.T) {
-	state := emulator.NewMemoryStateManager()
-	srv, _ := newSQSTestServerWithState(t, state)
-	queueURL := createAttrQueue(t, srv, "attr-stored")
-
-	status, code := sendMessageWithAttrs(t, srv, queueURL, "body",
-		[]sqsMessageAttr{{name: "trace", dataType: "String", stringValue: "v"}}, false)
-	require.Equal(t, http.StatusOK, status, "send failed: %s", code)
-
-	// Rename the stored attribute to one the send path would now refuse.
+// The queue must hold exactly one message, which every caller here arranges by sending
+// one legal message first.
+func storeIllegalAttributes(t *testing.T, state emulator.StateManager, queueName string,
+	attrs map[string]interface{},
+) string {
+	t.Helper()
 	ctx := context.Background()
-	idsRaw, err := state.Get(ctx, "sqs", "msg_ids:000000000000/attr-stored")
+	urlKey := "000000000000/" + queueName
+
+	idsRaw, err := state.Get(ctx, "sqs", "msg_ids:"+urlKey)
 	require.NoError(t, err)
 	var ids []string
 	require.NoError(t, json.Unmarshal(idsRaw, &ids))
-	require.Len(t, ids, 1)
+	require.Len(t, ids, 1, "the helper assumes one stored message")
 
-	msgKey := "msg:000000000000/attr-stored:" + ids[0]
+	msgKey := "msg:" + urlKey + ":" + ids[0]
 	raw, err := state.Get(ctx, "sqs", msgKey)
 	require.NoError(t, err)
 	var stored map[string]interface{}
 	require.NoError(t, json.Unmarshal(raw, &stored))
-	attrs, ok := stored["MessageAttributes"].(map[string]interface{})
-	require.True(t, ok, "stored message has no MessageAttributes: %v", stored)
-	attrs["AWS.trace"] = attrs["trace"]
-	delete(attrs, "trace")
+	stored["MessageAttributes"] = attrs
 	mutated, err := json.Marshal(stored)
 	require.NoError(t, err)
 	require.NoError(t, state.Put(ctx, "sqs", msgKey, mutated))
+	return ids[0]
+}
 
-	msgs := receiveMessages(t, srv, queueURL, []string{"All"}, false)
-	require.Len(t, msgs, 1, "a stored message must still be delivered")
-	assert.Equal(t, "v", msgs[0].attributes["AWS.trace"].stringValue,
-		"the illegal name is returned as stored, not corrected or withheld")
+// newSQSServerCapturingLogs builds an SQS test server whose logger writes to buf, so a
+// warning can be asserted rather than assumed.
+func newSQSServerCapturingLogs(t *testing.T, state emulator.StateManager,
+	buf *bytes.Buffer,
+) *emulator.Server {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	logger := newTestLogger(buf, slog.LevelWarn)
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	plugin := &emulator.SQSPlugin{}
+	require.NoError(t, plugin.Initialize(context.TODO(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(plugin)
+
+	return emulator.NewServer(*cfg, registry, store, state, tc, logger)
+}
+
+// TestSQS_MessageAttributes_StoredAttributesAreReturnedNotWithheld is #491's decision,
+// and the guarantee it protects is replay rather than validation.
+//
+// The rules apply on send, not on receive. A message written into state before they
+// existed is returned as stored, in full, because substrate's core property is that
+// replaying an event log reproduces the same observations — and the message was accepted
+// by the substrate that recorded it. Withholding or dropping it now would break exactly
+// that, and a receive-time rejection has no AWS behavior behind it to imitate: real SQS
+// never accepted the message, so there is nothing to copy.
+//
+// This test must fail if anyone later "fixes" receive to validate. All three violation
+// families are covered, because a fix that withheld would most likely be written against
+// one of them and the other two would silently follow.
+func TestSQS_MessageAttributes_StoredAttributesAreReturnedNotWithheld(t *testing.T) {
+	// Eleven attributes: the count rule, which is a property of the set rather than of
+	// any one attribute, so it is the one a per-attribute filter would miss.
+	eleven := make(map[string]interface{}, 11)
+	for i := 0; i < 11; i++ {
+		eleven["attr"+strconv.Itoa(i)] = map[string]interface{}{
+			"DataType": "String", "StringValue": "v" + strconv.Itoa(i),
+		}
+	}
+
+	tests := []struct {
+		name  string
+		attrs map[string]interface{}
+		// want is the attribute name and value that must come back unchanged.
+		wantName, wantValue string
+	}{
+		{
+			name: "a reserved name prefix",
+			attrs: map[string]interface{}{
+				"AWS.trace": map[string]interface{}{"DataType": "String", "StringValue": "v"},
+			},
+			wantName: "AWS.trace", wantValue: "v",
+		},
+		{
+			name:     "an eleventh attribute",
+			attrs:    eleven,
+			wantName: "attr10", wantValue: "v10",
+		},
+		{
+			name: "a Number attribute holding a non-number",
+			attrs: map[string]interface{}{
+				"Age": map[string]interface{}{"DataType": "Number", "StringValue": "abc"},
+			},
+			wantName: "Age", wantValue: "abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bothProtocols(t, func(t *testing.T, jsonProto bool) {
+				state := emulator.NewMemoryStateManager()
+				srv, _ := newSQSTestServerWithState(t, state)
+				queueName := "attr-stored"
+				queueURL := createAttrQueue(t, srv, queueName)
+
+				status, code := sendMessageWithAttrs(t, srv, queueURL, "body",
+					[]sqsMessageAttr{{name: "trace", dataType: "String", stringValue: "v"}},
+					jsonProto)
+				require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+				msgID := storeIllegalAttributes(t, state, queueName, tt.attrs)
+
+				msgs := receiveMessages(t, srv, queueURL, []string{"All"}, jsonProto)
+				require.Len(t, msgs, 1, "a stored message must still be delivered")
+				assert.Equal(t, msgID, msgs[0].messageID)
+				assert.Equal(t, "body", msgs[0].body, "the body is returned as stored")
+				assert.Len(t, msgs[0].attributes, len(tt.attrs),
+					"every stored attribute is returned, none filtered out")
+				assert.Equal(t, tt.wantValue, msgs[0].attributes[tt.wantName].stringValue,
+					"the illegal attribute is returned as stored, not corrected or withheld")
+			})
+		})
+	}
+}
+
+// TestSQS_MessageAttributes_StoredViolationWarns is the signal #491 chose over silence:
+// an operator whose fixture predates the rules learns about it, and the observation does
+// not change.
+//
+// The warning is asserted through a capturing logger rather than assumed, and its
+// absence for a legal message is asserted too — a warning that fires on every receive
+// would be noise an operator learns to ignore, which is the failure mode that would make
+// the whole decision worthless.
+func TestSQS_MessageAttributes_StoredViolationWarns(t *testing.T) {
+	t.Run("a violation warns and names what to look at", func(t *testing.T) {
+		state := emulator.NewMemoryStateManager()
+		var buf bytes.Buffer
+		srv := newSQSServerCapturingLogs(t, state, &buf)
+		queueName := "attr-warn"
+		queueURL := createAttrQueue(t, srv, queueName)
+
+		status, code := sendMessageWithAttrs(t, srv, queueURL, "body",
+			[]sqsMessageAttr{{name: "trace", dataType: "String", stringValue: "v"}}, false)
+		require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+		msgID := storeIllegalAttributes(t, state, queueName, map[string]interface{}{
+			"Age": map[string]interface{}{"DataType": "Number", "StringValue": "abc"},
+		})
+
+		msgs := receiveMessages(t, srv, queueURL, nil, false)
+		require.Len(t, msgs, 1)
+
+		logged := buf.String()
+		assert.Contains(t, logged, "stored message attributes violate a current rule")
+		assert.Contains(t, logged, msgID, "the message ID is what an operator greps for")
+		assert.Contains(t, logged, queueName, "the queue names which fixture to look at")
+		assert.Contains(t, logged, "Can't cast the value of message (user) attribute 'Age'",
+			"the violation itself is reported, not merely that there was one")
+	})
+
+	t.Run("the request naming no attributes still warns", func(t *testing.T) {
+		// The violation is a property of what is in state, not of what was asked for.
+		// Checking only the selected subset would hide it from exactly the caller most
+		// likely to be replaying an old log, since #461 returns nothing by default.
+		state := emulator.NewMemoryStateManager()
+		var buf bytes.Buffer
+		srv := newSQSServerCapturingLogs(t, state, &buf)
+		queueName := "attr-warn-unselected"
+		queueURL := createAttrQueue(t, srv, queueName)
+
+		status, code := sendMessageWithAttrs(t, srv, queueURL, "body",
+			[]sqsMessageAttr{{name: "trace", dataType: "String", stringValue: "v"}}, false)
+		require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+		storeIllegalAttributes(t, state, queueName, map[string]interface{}{
+			"AWS.trace": map[string]interface{}{"DataType": "String", "StringValue": "v"},
+		})
+
+		msgs := receiveMessages(t, srv, queueURL, nil, false)
+		require.Len(t, msgs, 1)
+		assert.Empty(t, msgs[0].attributes, "no selector was sent, so none are returned")
+		assert.Contains(t, buf.String(), "stored message attributes violate a current rule")
+	})
+
+	t.Run("a legal message logs nothing", func(t *testing.T) {
+		state := emulator.NewMemoryStateManager()
+		var buf bytes.Buffer
+		srv := newSQSServerCapturingLogs(t, state, &buf)
+		queueURL := createAttrQueue(t, srv, "attr-quiet")
+
+		status, code := sendMessageWithAttrs(t, srv, queueURL, "body", []sqsMessageAttr{
+			{name: "trace", dataType: "String", stringValue: "v"},
+			{name: "Age", dataType: "Number", stringValue: "42"},
+		}, false)
+		require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+
+		msgs := receiveMessages(t, srv, queueURL, []string{"All"}, false)
+		require.Len(t, msgs, 1)
+		assert.Empty(t, buf.String(), "a legal message must produce no warning")
+	})
+
+	t.Run("a message with no attributes logs nothing", func(t *testing.T) {
+		state := emulator.NewMemoryStateManager()
+		var buf bytes.Buffer
+		srv := newSQSServerCapturingLogs(t, state, &buf)
+		queueURL := createAttrQueue(t, srv, "attr-none")
+
+		status, code := sendMessage(t, srv, queueURL, "body", false)
+		require.Equal(t, http.StatusOK, status, "send failed: %s", code)
+
+		msgs := receiveMessages(t, srv, queueURL, []string{"All"}, false)
+		require.Len(t, msgs, 1)
+		assert.Empty(t, buf.String())
+	})
+}
+
+// TestSQS_MessageAttributes_SendTimeRejectionIsUnchanged guards the other half of the
+// decision. Warning on receive must not have softened the send path: a message with an
+// illegal attribute is still refused before it is stored, so no new run can produce the
+// state the warning exists to report.
+func TestSQS_MessageAttributes_SendTimeRejectionIsUnchanged(t *testing.T) {
+	bothProtocols(t, func(t *testing.T, jsonProto bool) {
+		srv, _ := newSQSTestServer(t)
+		queueURL := createAttrQueue(t, srv, "attr-send-still-refuses")
+
+		status, code, message := sendAttrError(t, srv, queueURL,
+			sqsMessageAttr{name: "AWS.trace", dataType: "String", stringValue: "v"}, jsonProto)
+		require.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Contains(t, message, "reserved for internal use")
+		assert.Equal(t, 0, sqsQueueDepth(t, srv, queueURL), "a refused send stores nothing")
+	})
 }

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -1368,6 +1368,12 @@ func (p *SQSPlugin) receiveMessage(ctx *RequestContext, req *AWSRequest) (*AWSRe
 			continue
 		}
 
+		// Warn, but return the message unchanged, when its stored attributes violate a
+		// rule enforced on send (#491). The observation is deliberately untouched: the
+		// message was accepted by the substrate that recorded it, so withholding it here
+		// would make an older event log unreplayable.
+		sqsWarnStoredAttributes(p.logger, queueURL, msg)
+
 		// The digest covers what is being returned, not what was sent: a request
 		// naming a subset gets the digest of that subset, which is what lets a caller
 		// checksum the attributes actually in hand. Reusing the send-time digest would


### PR DESCRIPTION
Closes #491

`ReceiveMessage` now logs at `WARN` when a stored message's attributes violate a rule `sqsCheckMessageAttributes` enforces on send, naming the queue, the message ID and the rule that was violated. **The message is still returned, in full, exactly as stored.**

#491 is explicit that it is not a "validate on receive" bug report, and this PR is mostly the recorded decision it asks for.

## The decision: warn, don't withhold

Returning the message is the decision, not an omission.

Substrate's core property is that replaying an event log reproduces the same observations, and a message written by an older substrate **was accepted by the substrate that recorded it**. Withholding or dropping it now would make a recorded run unreplayable, which is the one outcome #491 rules out.

A receive-time rejection also has no AWS behaviour to imitate: real SQS never accepted the message in the first place, so there is no real response to copy. Substrate would be inventing an observation.

Option 1 (do nothing) leaves an operator with a fixture that quietly predates the rules. The warning gives them the signal without changing what any caller observes.

Option 3 — a replay-time report of recorded data a current substrate would refuse — is the more principled home, because the violation is a property of the log rather than of any one request. It needs a surface in the replay machinery that does not exist today, so it is filed as **#512** rather than dropped, and this PR says so in the CHANGELOG and in the code comment.

## Two scope choices, both deliberate and both mutation-tested

**The whole stored attribute set is checked, not the subset the request asked for.** The violation is a property of what is in state. #461's selection rule means a request naming no attribute names gets no attributes back — so a subset check would hide the violation from exactly the caller most likely to be replaying an old log.

**It fires on every receive, not once per message.** A message redelivered after its visibility timeout is a fixture being exercised again, and remembering which messages have already warned would be per-process state that a replay could not reproduce.

## Send is unchanged

No new run can produce this state — the send path still refuses an illegal attribute set with `InvalidParameterValue`. `TestSQS_MessageAttributes_SendTimeRejectionIsUnchanged` pins that, including that the queue depth stays at zero.

## Tests

`emulator/sqs_messageattrrules_test.go`. Two helpers:

- `storeIllegalAttributes` writes an illegal attribute set directly into state. Going around the API is the point rather than a shortcut: no send path stores an illegal attribute any more, so the only way this state exists is an event log recorded against a substrate that predates the rules.
- `newSQSServerCapturingLogs` builds a server whose logger writes into a buffer at `WARN`, so the warning is asserted rather than assumed.

- `TestSQS_MessageAttributes_StoredAttributesAreReturnedNotWithheld` — three violation families (a reserved `AWS.trace` name, an eleventh attribute, `Age` = `Number`/`"abc"`), each over both protocols, asserting the message ID, the body and that **every** stored attribute comes back with its stored value. This is the replay gate: it must fail if anyone later "fixes" receive to validate.
- `TestSQS_MessageAttributes_StoredViolationWarns` — the warning names the message, the queue and the rule; a request naming no attributes still warns (with `Empty(attributes)` in the same subtest, since that is the case a subset check would miss); a legal message logs nothing; a message with no attributes logs nothing.
- `TestSQS_MessageAttributes_SendTimeRejectionIsUnchanged` — 400 / `InvalidParameterValue` / the cast message / depth 0.

The old `TestSQS_MessageAttributes_StoredAttributesAreNotRechecked` is replaced: it asserted the absence of a check, which is now the weaker half of what is asserted.

## Verification

From the repo root: `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race) → ok, `make docs-reference docs-reference-check docs-versions` → no diff, `npm --prefix docs run build` → complete, `go vet -C test/e2e ./...` and `go test -C test/e2e ./...` → ok.

**Mutation testing** — 14 mutants over `sqs_messageattrrules.go` and `sqs_plugin.go`: **13 caught, 1 proven equivalent, 0 survived.**

The four mutants #491 exists to forbid are all caught by the replay gate:

| Mutant | Caught by |
|---|---|
| withhold the message (`continue`) | `…AreReturnedNotWithheld` |
| reject the whole `ReceiveMessage` | `…AreReturnedNotWithheld` |
| strip the offending attributes | `…AreReturnedNotWithheld` |
| blank the body as a "safe" redaction | `…AreReturnedNotWithheld` |

The warning mutants — never warn, warn unconditionally, drop the message ID, drop the queue, drop which rule was violated, downgrade to `Debug` — are all caught by `…StoredViolationWarns`. Both scope mutants (check only the requested subset; skip the check when nothing was requested) are caught by the "request naming no attributes still warns" subtest, which is why it exists. Softening the send path (`sqsCheckMessageAttributes(nil)`) is caught by `…SendTimeRejectionIsUnchanged`.

The one equivalent mutant is removing the `len(msg.MessageAttributes) == 0` fast path: `sqsCheckMessageAttributes` returns `nil` for an empty or nil map, so no input distinguishes the two forms. It stays on cost grounds — most messages carry no attributes, and the guard skips a sort and an allocation per message in the receive loop — and the comment says that rather than implying correctness.

A first run had one survivor: a `logger == nil` guard. No other `logger == nil` guard exists in the package and `receiveMessage` already calls `p.logger.Warn` unguarded a few lines away, so it was inconsistent defensive code for an unreachable path. **Resolved by deleting the guard, not by adding a test for it.**

## End to end

```
$ aws sqs send-message --queue-url .../replay-probe --message-body body \
    --message-attributes '{"trace":{"DataType":"String","StringValue":"v"}}'
c07a7c78-91ab-8e53-9175-dd70f0a3fd60

$ aws sqs send-message --queue-url .../replay-probe --message-body body \
    --message-attributes '{"Age":{"DataType":"Number","StringValue":"abc"}}'
An error occurred (InvalidParameterValue) when calling the SendMessage operation:
Can't cast the value of message (user) attribute 'Age' to a number.

$ aws sqs receive-message --queue-url .../replay-probe --message-attribute-names All
{"trace": {"StringValue": "v", "DataType": "String"}}      # attributes intact
# server log: 0 WARN lines
```

Send still refuses, a legal message warns nothing, and the illegal-stored case is only reachable by writing state directly — which is exactly the fixture the unit tests build.

## Docs

`docs/services.md` §"Message attributes" gains a `### The rules apply on send, not on receive` subsection: the message is returned in full with a `WARN` naming the queue, message ID and rule; the replay argument and the no-AWS-behaviour-to-imitate argument; that rejecting on receive is deliberately not done and the suite fails if anyone adds it; the whole-set-not-subset and every-receive rationales; and that send-time rejection is unchanged so no new run can produce this state.
