### PR TITLE
chore(release): v0.87.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.87.0] - 2026-08-02
+
 ### Fixed
 - **`DescribeInstanceTypes` now refuses an instance type it does not model** (#485).
   An unknown type was answered with HTTP 200 and an empty list, so a consumer
@@ -3929,7 +3931,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.86.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.87.0...HEAD
+[v0.87.0]: https://github.com/scttfrdmn/substrate/compare/v0.86.0...v0.87.0
 [v0.86.0]: https://github.com/scttfrdmn/substrate/compare/v0.85.0...v0.86.0
 [v0.85.0]: https://github.com/scttfrdmn/substrate/compare/v0.84.0...v0.85.0
 [v0.84.0]: https://github.com/scttfrdmn/substrate/compare/v0.83.0...v0.84.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.87.0] - 2026-08-02` and adds the comparison link. No code changes.

Nine consumer-filed issues, in three threads.

**The three that kept moto in a downstream suite** — parsl-aws-provider#183 could only be answered partially because of exactly these:
- #483 — CloudFormation is reachable over the wire; a wire-created stack's resources are real resources in the other plugins. `DescribeStackEvents` scoped out with its reason.
- #484 — five service-role managed policies seeded, and the catalog can now express a path.
- #485 — an unknown instance type is refused; the offerings filter works for the first time (it read a parameter the operation does not have); the catalog covers whole families.

**Three v0.86.0 follow-ups**, each closing a gap a v0.86.0 fix exposed:
- #489 — termination protection is honoured, with the Availability-Zone-scoped partial-failure rule.
- #490 — tag key/value length limits, counted in Unicode characters, with reserved keys not exempt.
- #491 — the SQS stored-attribute decision: warn, and still return the message.

**S3 and fault injection:**
- #492 — SSE headers recorded and echoed, with the verbatim key ID as a stated divergence.
- #470 — `x-amz-acl` and `x-amz-grant-*` stored on the operations that create.
- #480 — four fault-injection findings: an S3 rule can name a semantic operation, a rule can be bounded, a fired count is observable, and an injected error is byte-indistinguishable from a real one.

Also `### Changed`: the shared-PRNG caveat (#510) is documented rather than fixed.

The tag is cut against this PR's merge commit after it lands, then the Release is published in the same sitting per `CLAUDE.md`.