### PR TITLE
fix(cloudformation): expand YAML short-form intrinsics, report a refused resource (#516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,128 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CloudFormation YAML short-form intrinsics now resolve** (#516). A template
+  written with `!Ref`, `!Sub` or `!If` deployed with unresolved literals where a
+  value should be: `go.yaml.in/yaml/v3` has no notion of CloudFormation's tag
+  shorthands, so it dropped the tag and kept the node value. `!Sub 'x-${P}'` reached
+  the resolver as the plain string `"x-${P}"`, indistinguishable from a literal the
+  template really did intend, and `!If [C, a, b]` arrived as the raw array
+  `["C", "a", "b"]` — which is what a reporting consumer saw stamped into an ECS
+  task-definition family verbatim. The `Fn::`-prefixed long forms were unaffected
+  throughout, so this was purely tag resolution.
+
+  The template is now decoded into a `yaml.Node`, whose `.Tag` survives, and every
+  recognized shorthand is rewritten into its long form before the node is decoded.
+  All eighteen are handled — `!Ref`, `!Condition`, `!GetAtt`, `!Sub`, `!Join`,
+  `!Select`, `!Split`, `!Base64`, `!If`, `!Equals`, `!Not`, `!And`, `!Or`,
+  `!FindInMap`, `!ImportValue`, `!Cidr`, `!GetAZs`, `!Transform` — and the walk is
+  depth-first, children before parents, because the tags nest: `!Not [!Equals
+  [!Ref VpcId, '']]` is three levels deep and is the single most common condition
+  idiom in real templates.
+
+  `!GetAtt` is the one irregular expansion: it takes a dotted string where
+  `Fn::GetAtt` takes a two-element list, and the split is on the **first** period
+  only, since an attribute name may itself contain periods — AWS's own example maps
+  `!GetAtt myELB.SourceSecurityGroup.OwnerAlias` to
+  `["myELB", "SourceSecurityGroup.OwnerAlias"]`.
+
+  A tag substrate does not recognize is **not** dropped: its value is kept and a
+  `WARN` naming the tag is logged. Silently dropping it is the defect being fixed,
+  and refusing the template would reject templates real CloudFormation accepts,
+  since a macro or transform may introduce a tag substrate has never heard of.
+
+  A short form's value is decoded as a string rather than having its YAML type
+  resolved afresh, because CloudFormation values are strings and the long forms are
+  written unquoted the same way. Otherwise `!Sub 12345` would arrive as an `int` and
+  `!Ref 2026-08-02` as a `time.Time`, which matches none of the resolver's cases and
+  would silently empty the property.
+
+  Expansion is not resolution. `!FindInMap`, `!ImportValue`, `!Cidr` and `!GetAZs`
+  now expand to long forms the resolver still ignores, and hit the same documented
+  fallback the long forms already got. That is still an improvement — the two
+  syntaxes now behave *identically*, which is the invariant at issue — but
+  "expanded" must not be read as "resolved"; `docs/services.md` says so, and #522
+  tracks the resolvers (`Fn::FindInMap` needs a `Mappings` model the template struct
+  does not have).
+
+- **`Fn::Sub` now honours the `${!Literal}` escape** (#516). `${!Count.Index}`
+  renders as the literal `${Count.Index}` with no substitution, which is how a
+  template passes a `${…}` through to something that interpolates it later. The
+  escape was unreachable before the expander — with the whole `!Sub` discarded,
+  `substituteTemplate` never saw the string — which is why it ships in the same
+  change rather than separately.
+
+- **A resource a plugin refused now reports `CREATE_FAILED`** (#519). The deployer
+  set a resource's error only when the dispatched request returned a non-nil `error`,
+  and never looked at the response status. But plugins signal a client error two
+  ways, and both are in wide use: S3 (58 sites) and IAM (162) return a 4xx response
+  with a nil error — the same shape a real endpoint puts on the wire — while EC2
+  (49), ECS (27), CloudWatch Logs (20) and SQS (5) return an `*AWSError`. Only the
+  second was ever inspected, so **every S3 and IAM resource failure in a stack was
+  swallowed** and the stack reported `CREATE_COMPLETE` for a resource that does not
+  exist. That asymmetry is also why this survived #483's review.
+
+  One helper now derives the failure from either convention, applied centrally in
+  `dispatch` so all 31 recording sites became correct without being individually
+  edited. The plugin's own error code is lifted from the response body, so the
+  recorded reason is `InvalidBucketName: The specified bucket is not valid.` rather
+  than a bare status number. `deployS3Bucket` also stopped discarding its response
+  and now returns early instead of configuring versioning on a bucket that was
+  refused. The follow-up could not have corrupted the recorded reason — its own
+  result was discarded too — but it did put a `PUT ?versioning` refused with
+  `NoSuchBucket` into the event log, a request no real client would have sent, in the
+  log substrate replays.
+
+  **Compatibility: a resource that genuinely fails now reports `CREATE_FAILED` where
+  it reported `CREATE_COMPLETE`.** A test asserting the old status was asserting a
+  defect, but it will still turn red. The stack status is unchanged, and substrate
+  still does not roll back (#520).
+
+- **A parameter declared `Default: ''` is now a declared parameter** (#516). The
+  empty string was treated as "no default at all", so such a parameter was left
+  undeclared, `Ref` fell through to echoing the parameter's own name back, and the
+  conventional optional-parameter test `!Not [!Equals [!Ref X, '']]` **inverted**: a
+  parameter the caller never set read as set, and every template taking the wrong
+  branch did so silently. `Default: ''` is how an optional parameter is spelled —
+  21 occurrences across the five templates of the consumer that reported #516 — so
+  the distinction is load-bearing rather than pedantic. Found by deploying one of
+  those templates as a checked-in fixture rather than by reading the code.
+
+- **A condition referencing another condition no longer depends on map order**
+  (#516). `Conditions` were evaluated by iterating a Go map, so a condition
+  referencing another via `{"Condition": "Other"}` read the referent's zero value
+  whenever it happened to be evaluated first. The same template deployed differently
+  from one run to the next — nondeterminism, which is the one outcome an emulator
+  built on deterministic replay must never produce. Conditions are now resolved on
+  demand, so a referent is evaluated when it is needed regardless of declaration
+  order, and a reference cycle resolves to `false` (real CloudFormation rejects one
+  at validation time) rather than recursing forever. Names are additionally walked in
+  sorted order, which matters only for a cycle: one running through `Fn::Not`
+  resolves its two members to *opposite* values, so absent the sort the answer would
+  still depend on which member the map happened to yield first.
+
+  Each condition's first answer is also cached for the rest of the deployment. AWS
+  evaluates conditions once, when the stack is created or updated, and forbids a
+  condition from referencing a resource's logical ID or attributes; substrate has no
+  validation pass to reject such a reference, so caching is what keeps a template
+  that makes one anyway from seeing one value in a property resolved early and
+  another in an output resolved last.
+
+### Changed
+- **`docs/services.md` no longer claims `DeleteStack` deletes the stack's
+  resources** (#518). It deletes the stack record and its name index only — a bucket
+  a stack created outlives the stack, and `head-bucket` still answers 200. The
+  correction is documented now, independent of the sweep itself, which is bigger than
+  it looks: 113 resource types need a per-type delete dispatcher, `DeletionPolicy`
+  is not modelled at all, deletion must run in reverse dependency order, and a bucket
+  sweep inherits #508's leak. Tracked in #518.
+
+  The CloudFormation section also now states that a refused resource reports
+  `CREATE_FAILED` while the stack still reaches a terminal status without rolling
+  back (#520), that `Fn::Split` yields only its first element (#521), and what the
+  YAML short forms do and do not resolve.
+
 ## [v0.87.0] - 2026-08-02
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -99,7 +99,7 @@ here.
 |-----------|-------|
 | CreateStack | Deploys every resource in `TemplateBody` and returns the stack ARN |
 | UpdateStack | Re-deploys the template; an omitted `TemplateBody` re-uses the stored one |
-| DeleteStack | Deletes the stack's resources; deleting an absent stack succeeds |
+| DeleteStack | Deletes the stack **record only**, not the resources it deployed (see below); deleting an absent stack succeeds |
 | DescribeStacks | One stack by `StackName`, or every stack when omitted |
 | ListStacks | Summary shape; honours `StackStatusFilter.member.N` |
 | DescribeStackResources | By `StackName` + optional `LogicalResourceId`, or by `PhysicalResourceId` |
@@ -139,6 +139,45 @@ to the in-process API. There is one set of stacks.
 Deleting a stack's resource outside CloudFormation is the drift substrate models
 — `DescribeStackResourceDrifts` reports it as `DELETED`.
 
+### DeleteStack deletes the stack, not its resources
+
+`DeleteStack` removes the stack record and its name index. The resources the
+stack deployed are **left in place**: a bucket a stack created is still there
+after the stack is gone, and `s3api head-bucket` still answers 200. Real
+CloudFormation deletes them subject to each resource's `DeletionPolicy`, which
+substrate does not model at all. Tracked in
+[#518](https://github.com/scttfrdmn/substrate/issues/518) — a per-type delete
+dispatcher across 113 resource types, in reverse dependency order, with
+`DeletionPolicy` (`Delete`/`Retain`/`Snapshot`) honoured.
+
+Until then, a test that deletes a stack and expects the resources to be gone
+should delete them explicitly.
+
+### A refused resource reports CREATE_FAILED
+
+A plugin that refuses a resource — an invalid bucket name, a malformed trust
+policy, a security group that does not exist — makes that resource
+`CREATE_FAILED` in `DescribeStackResources`, with the plugin's **own** error code
+and message as the reason:
+
+```
+aws cloudformation describe-stack-resources --stack-name badname
+# ResourceStatus: CREATE_FAILED
+# ResourceStatusReason: InvalidBucketName: The specified bucket is not valid.
+```
+
+The stack itself still reaches a terminal `CREATE_COMPLETE`, and the resources
+declared after the failed one are **still deployed**. Real CloudFormation would
+roll the whole stack back to `ROLLBACK_COMPLETE`; substrate records the failure
+per resource and carries on. Rollback is not modelled — tracked in
+[#520](https://github.com/scttfrdmn/substrate/issues/520). Assert on the
+per-resource status rather than on the stack status when a template is expected
+to fail.
+
+A refused resource's follow-up configuration requests are not sent either. A bucket
+whose name S3 rejected has no `PUT ?versioning` issued against it, so the event log
+holds only the request a real client would have made.
+
 ### Templates
 
 113 resource types are supported; each service section below lists the types it
@@ -152,7 +191,68 @@ pseudo-parameters. `Fn::FindInMap`, `Fn::ImportValue`, `Fn::Cidr`,
 `AWS::URLSuffix`, `AWS::StackId`, `AWS::NotificationARNs`) are **not** resolved —
 an unrecognized intrinsic falls back to its JSON encoding and an unrecognized
 `Ref` to the reference string itself, so a template using one deploys with a
-literal where a value should be rather than failing.
+literal where a value should be rather than failing. Tracked in
+[#522](https://github.com/scttfrdmn/substrate/issues/522) — `Fn::FindInMap` needs a
+`Mappings` model, which the template struct does not have.
+
+`Fn::Split` resolves to its **first element only**, because the resolver returns
+a string. A template that splits a comma-separated list into a container command
+gets one element where the whole list is meant. Tracked in
+[#521](https://github.com/scttfrdmn/substrate/issues/521).
+
+A parameter declared `Default: ''` is a parameter whose default is the empty
+string, not a parameter without one — which is what makes the conventional
+optional-parameter idiom work:
+
+```yaml
+Parameters:
+  Command: {Type: String, Default: ''}
+Conditions:
+  HasCommand: !Not [!Equals [!Ref Command, '']]
+```
+
+A condition that references another condition by name resolves regardless of the
+order the template declares them in; a reference cycle resolves to `false`. Each
+condition is evaluated once, before any resource deploys, and keeps that value for
+the whole deployment — as in real CloudFormation, where conditions are evaluated when
+the stack is created or updated and cannot reference a resource or its attributes.
+
+#### YAML short forms
+
+The YAML tag shorthands are expanded to their long forms before the template is
+read, so a template written with `!Ref` / `!Sub` / `!If` resolves **identically**
+to the same template written with `Ref` / `Fn::Sub` / `Fn::If`. All of
+`!Ref`, `!Condition`, `!GetAtt`, `!Sub`, `!Join`, `!Select`, `!Split`, `!Base64`,
+`!If`, `!Equals`, `!Not`, `!And`, `!Or`, `!FindInMap`, `!ImportValue`, `!Cidr`,
+`!GetAZs` and `!Transform` are expanded, at any nesting depth — `!Not [!Equals
+[!Ref VpcId, '']]` is three levels and works.
+
+`!GetAtt` is the one irregular form: it takes a dotted string where `Fn::GetAtt`
+takes a two-element list, and the split is on the **first** period only, so
+`!GetAtt Res.Outputs.Nested` is `["Res", "Outputs.Nested"]` — an attribute name
+may itself contain periods.
+
+Expansion is not resolution. `!FindInMap`, `!ImportValue`, `!Cidr` and `!GetAZs`
+expand to long forms that are still unresolved (#522), and hit the same fallback the
+long forms already do.
+
+A tag substrate does not recognize is **not** dropped: the node's value is kept
+and a `WARN` naming the tag is logged, since a macro or transform may introduce a
+tag substrate has never heard of, and refusing the template would reject one real
+CloudFormation accepts.
+
+A short form's value is read as a string, as the long forms' unquoted values are, so
+`!Sub 12345` and `!Sub 2026-08-02` reach the resolver as written rather than as a
+number and a timestamp.
+
+One tag per node is a YAML rule, not a substrate limitation: `!Base64 !Ref P` is a
+parse error, which is why AWS's own examples spell the outer function long-form —
+`Fn::Base64: !Ref P`. That nesting works.
+
+`Fn::Sub` honours the documented `${!Literal}` escape: `${!Count.Index}` renders
+as the literal `${Count.Index}` with no substitution, which is how a template
+passes a `${…}` through to something that interpolates it later, such as Terraform
+or cloud-init.
 
 Parameters use the Query protocol's list encoding, which is what every SDK and
 the CLI send:

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -12,8 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"go.yaml.in/yaml/v3"
 )
 
 // cfnTemplate is the top-level CloudFormation template structure.
@@ -31,8 +29,13 @@ type cfnParam struct {
 	// Type is the CloudFormation parameter type (e.g., "String").
 	Type string `json:"Type" yaml:"Type"`
 
-	// Default is the default value for the parameter.
-	Default string `json:"Default" yaml:"Default"`
+	// Default is the default value for the parameter, or nil when the template
+	// declares none. The pointer distinguishes `Default: ''` — the conventional
+	// way to declare an optional parameter, which every `Fn::Not [Fn::Equals
+	// [Ref X, '']]` condition tests for — from a parameter with no default at
+	// all. Treating the two alike left the parameter undeclared, and Ref then
+	// echoed the parameter's own name back, inverting the condition.
+	Default *string `json:"Default" yaml:"Default"`
 }
 
 // cfnOutput is a CloudFormation template output declaration.
@@ -87,6 +90,15 @@ type cfnContext struct {
 	region     string
 	accountID  string
 	stackName  string
+
+	// conditionExprs holds the template's unevaluated Conditions, so a condition
+	// that references another by name can evaluate its referent on demand rather
+	// than depending on the order the conditions happened to be walked in.
+	conditionExprs map[string]interface{}
+
+	// evaluating tracks the conditions currently being evaluated, so a reference
+	// cycle terminates instead of recursing forever.
+	evaluating map[string]bool
 }
 
 // cfnNamespace is the state namespace for CloudFormation stack state.
@@ -370,7 +382,7 @@ func NewStackDeployer(registry *PluginRegistry, store *EventStore, state StateMa
 // skipped with a warning. The optional params map overrides template parameter
 // defaults.
 func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params map[string]string) (*DeployResult, error) {
-	tmpl, err := parseCFNTemplate(cfn)
+	tmpl, err := d.parseCFNTemplate(cfn)
 	if err != nil {
 		return nil, fmt.Errorf("parse template: %w", err)
 	}
@@ -589,11 +601,11 @@ func (d *StackDeployer) CreateChangeSet(ctx context.Context, stackName, changeSe
 	}
 
 	// Parse old and new templates.
-	oldTmpl, err := parseCFNTemplate(stack.TemplateBody)
+	oldTmpl, err := d.parseCFNTemplate(stack.TemplateBody)
 	if err != nil {
 		return nil, fmt.Errorf("cfn CreateChangeSet: parse old template: %w", err)
 	}
-	newTmpl, err := parseCFNTemplate(templateBody)
+	newTmpl, err := d.parseCFNTemplate(templateBody)
 	if err != nil {
 		return nil, fmt.Errorf("cfn CreateChangeSet: parse new template: %w", err)
 	}
@@ -1001,8 +1013,8 @@ var cfnDriftComparators = map[string]func(ctx context.Context, d *StackDeployer,
 // Properties map plus a resolution context for the given deployed resource.
 // It returns (nil, nil, false) when the template cannot be parsed or the
 // resource is absent, so callers can simply skip drift comparison.
-func cfnDriftResourceProps(stack *CFNStackState, dr DeployedResource) (map[string]interface{}, *cfnContext, bool) {
-	tmpl, err := parseCFNTemplate(stack.TemplateBody)
+func (d *StackDeployer) cfnDriftResourceProps(stack *CFNStackState, dr DeployedResource) (map[string]interface{}, *cfnContext, bool) {
+	tmpl, err := d.parseCFNTemplate(stack.TemplateBody)
 	if err != nil {
 		return nil, nil, false
 	}
@@ -1029,7 +1041,7 @@ func driftDiff(path, expected, actual string) CFNPropertyDiff {
 // compareS3BucketDrift compares a deployed S3 bucket's VersioningConfiguration
 // against its live state, reporting a property difference if they diverge.
 func compareS3BucketDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
-	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	props, cctx, ok := d.cfnDriftResourceProps(stack, dr)
 	if !ok {
 		return nil
 	}
@@ -1055,7 +1067,7 @@ func compareS3BucketDrift(ctx context.Context, d *StackDeployer, stack *CFNStack
 // compareDynamoDBTableDrift compares a deployed DynamoDB table's declared
 // BillingMode and provisioned throughput against live state.
 func compareDynamoDBTableDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
-	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	props, cctx, ok := d.cfnDriftResourceProps(stack, dr)
 	if !ok {
 		return nil
 	}
@@ -1095,7 +1107,7 @@ func compareDynamoDBTableDrift(ctx context.Context, d *StackDeployer, stack *CFN
 // compareLambdaFunctionDrift compares a deployed Lambda function's declared
 // configuration properties against live state.
 func compareLambdaFunctionDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
-	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	props, cctx, ok := d.cfnDriftResourceProps(stack, dr)
 	if !ok {
 		return nil
 	}
@@ -1140,7 +1152,7 @@ func compareLambdaFunctionDrift(ctx context.Context, d *StackDeployer, stack *CF
 // and AssumeRolePolicyDocument against live state. The trust policy is compared
 // order-independently via policyDocumentsEqual.
 func compareIAMRoleDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
-	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	props, cctx, ok := d.cfnDriftResourceProps(stack, dr)
 	if !ok {
 		return nil
 	}
@@ -1195,7 +1207,7 @@ var sqsDriftAttributes = []string{
 // compareSQSQueueDrift compares a deployed SQS queue's declared attribute
 // properties against the live queue attributes.
 func compareSQSQueueDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
-	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	props, cctx, ok := d.cfnDriftResourceProps(stack, dr)
 	if !ok {
 		return nil
 	}
@@ -1237,7 +1249,7 @@ func snsTopicNameFromPhysicalID(physicalID string) string {
 // compareSNSTopicDrift compares a deployed SNS topic's declared DisplayName
 // against live state.
 func compareSNSTopicDrift(ctx context.Context, d *StackDeployer, stack *CFNStackState, dr DeployedResource) []CFNPropertyDiff {
-	props, cctx, ok := cfnDriftResourceProps(stack, dr)
+	props, cctx, ok := d.cfnDriftResourceProps(stack, dr)
 	if !ok {
 		return nil
 	}
@@ -1537,7 +1549,7 @@ func (d *StackDeployer) deployS3Bucket(
 		Params:    map[string]string{},
 	}
 
-	resp, cost, routeErr := d.dispatch(ctx, req, streamID)
+	_, cost, routeErr := d.dispatch(ctx, req, streamID)
 
 	dr := DeployedResource{
 		LogicalID:  logicalID,
@@ -1545,9 +1557,14 @@ func (d *StackDeployer) deployS3Bucket(
 		PhysicalID: bucketName,
 	}
 	if routeErr != nil {
+		// Recorded on the resource, not returned — a returned error aborts the
+		// stack. The early return skips the follow-up configuration requests: a
+		// bucket that was refused has nothing to configure, and each request would
+		// be refused in turn with NoSuchBucket and recorded in the event log,
+		// leaving a replay to explain requests no real client would have sent.
 		dr.Error = routeErr.Error()
+		return dr, cost, nil //nolint:nilerr
 	}
-	_ = resp
 
 	// Apply VersioningConfiguration if present.
 	if vc, ok := props["VersioningConfiguration"].(map[string]interface{}); ok {
@@ -2864,16 +2881,52 @@ func (d *StackDeployer) dispatch(
 
 	_ = d.store.RecordRequest(ctx, reqCtx, req, resp, duration, cost, routeErr)
 
-	return resp, cost, routeErr
+	return resp, cost, cfnDispatchError(resp, routeErr)
+}
+
+// cfnDispatchError reports the failure a dispatched request represents, or nil if
+// it succeeded.
+//
+// Plugins signal a client error one of two ways, and both are in wide use: EC2,
+// ECS, CloudWatch Logs and SQS return an *AWSError, while S3 and IAM return a 4xx
+// *AWSResponse with a nil error — the same shape a real endpoint puts on the wire.
+// PluginRegistry.RouteRequest passes both through unchanged, so a deployer that
+// only checked the error return recorded no failure at all for an S3 or IAM
+// resource that had been refused, and the stack reported CREATE_COMPLETE for a
+// resource that does not exist.
+//
+// The error code is lifted out of the response body so the recorded reason names
+// what went wrong ("InvalidBucketName: The specified bucket is not valid.")
+// rather than a bare status number. Both conventions put it in a <Code> element;
+// a body in any other shape falls back to the status alone.
+func cfnDispatchError(resp *AWSResponse, routeErr error) error {
+	if routeErr != nil {
+		return routeErr
+	}
+	if resp == nil || resp.StatusCode < 400 {
+		return nil
+	}
+	code := extractXMLField(resp.Body, "Code")
+	message := extractXMLField(resp.Body, "Message")
+	switch {
+	case code != "" && message != "":
+		return fmt.Errorf("%s: %s", code, message)
+	case code != "":
+		return fmt.Errorf("%s (HTTP %d)", code, resp.StatusCode)
+	default:
+		return fmt.Errorf("request failed with HTTP %d", resp.StatusCode)
+	}
 }
 
 // buildCFNContext constructs a cfnContext from template parameters and caller-supplied values.
 func buildCFNContext(tmpl *cfnTemplate, callerParams map[string]string, region, accountID, stackName string) *cfnContext {
 	params := make(map[string]string)
-	// Start with template defaults.
+	// Start with template defaults. A declared default is recorded even when it
+	// is the empty string: that is how an optional parameter is spelled, and
+	// leaving it out would make Ref resolve to the parameter's own name.
 	for name, p := range tmpl.Parameters {
-		if p.Default != "" {
-			params[name] = p.Default
+		if p.Default != nil {
+			params[name] = *p.Default
 		}
 	}
 	// Overlay caller-supplied params.
@@ -2887,14 +2940,65 @@ func buildCFNContext(tmpl *cfnTemplate, callerParams map[string]string, region, 
 		region:     region,
 		accountID:  accountID,
 		stackName:  stackName,
+		evaluating: make(map[string]bool),
 	}
 }
 
 // evaluateConditions evaluates all Conditions in the template into cctx.conditions.
+//
+// A condition may reference another by name ({"Condition": "Other"}), so the
+// evaluation order matters. Iterating tmpl.Conditions directly made the result
+// depend on Go's map iteration order: a condition evaluated before the one it
+// references read the referent's zero value and the whole template resolved
+// differently from one run to the next — the one outcome an emulator built on
+// deterministic replay must never produce.
+//
+// Each condition is therefore resolved on demand through cctx.condition, which
+// evaluates a referent the first time it is needed regardless of declaration
+// order. Names are walked in sorted order so that a template containing a
+// reference cycle reports the same result every time.
 func evaluateConditions(tmpl *cfnTemplate, cctx *cfnContext) {
-	for name, expr := range tmpl.Conditions {
-		cctx.conditions[name] = evalConditionExpr(expr, cctx)
+	cctx.conditionExprs = tmpl.Conditions
+
+	names := make([]string, 0, len(tmpl.Conditions))
+	for name := range tmpl.Conditions {
+		names = append(names, name)
 	}
+	sort.Strings(names)
+	for _, name := range names {
+		cctx.condition(name)
+	}
+}
+
+// condition returns the value of the named condition, evaluating it — and any
+// condition it references — on first use.
+//
+// A cycle resolves to false rather than recursing forever: real CloudFormation
+// rejects a circular condition at validation time, and returning false is the same
+// answer an undeclared condition already gets, so a malformed template degrades
+// instead of hanging the deployment.
+func (c *cfnContext) condition(name string) bool {
+	// Memoized, and not only to save work: "CloudFormation evaluates conditions
+	// when creating or updating a stack", once, and a condition "can't reference
+	// resource logical IDs or their attributes". Caching the first answer is what
+	// keeps a condition's value fixed for the whole deployment, so a template that
+	// does reach a resource anyway cannot see one value before that resource
+	// deploys and another after.
+	if v, ok := c.conditions[name]; ok {
+		return v
+	}
+	expr, ok := c.conditionExprs[name]
+	if !ok {
+		return false
+	}
+	if c.evaluating[name] {
+		return false
+	}
+	c.evaluating[name] = true
+	v := evalConditionExpr(expr, c)
+	delete(c.evaluating, name)
+	c.conditions[name] = v
+	return v
 }
 
 // evalConditionExpr evaluates a single condition expression.
@@ -2944,7 +3048,7 @@ func evalConditionExpr(expr interface{}, cctx *cfnContext) bool {
 			if !ok {
 				return false
 			}
-			return cctx.conditions[name]
+			return cctx.condition(name)
 		}
 	}
 	return false
@@ -3058,6 +3162,14 @@ func substituteTemplate(s string, cctx *cfnContext, extra map[string]string) str
 			end := strings.Index(s[i+2:], "}")
 			if end >= 0 {
 				varName := s[i+2 : i+2+end]
+				// "${!Literal}" is Fn::Sub's documented escape for a literal
+				// "${Literal}": the exclamation mark is dropped and the rest is
+				// emitted verbatim, with no substitution.
+				if strings.HasPrefix(varName, "!") {
+					result.WriteString("${" + varName[1:] + "}")
+					i = i + 2 + end + 1
+					continue
+				}
 				if v, ok := extra[varName]; ok {
 					result.WriteString(v)
 				} else {
@@ -3298,7 +3410,12 @@ func resolveFnIf(args interface{}, cctx *cfnContext) string {
 	if !ok {
 		return ""
 	}
-	if cctx.conditions[condName] {
+	// Through the accessor rather than the map so that the two read sites cannot
+	// disagree. evaluateConditions has already resolved every declared condition by
+	// the time any Fn::If is resolved, so a direct map read would behave the same
+	// for a valid template; it would differ only for a name the template never
+	// declared, which both spellings answer false.
+	if cctx.condition(condName) {
 		return resolveValue(arr[1], cctx)
 	}
 	return resolveValue(arr[2], cctx)
@@ -3356,15 +3473,24 @@ func (d *StackDeployer) deployGenericStub(
 	}, 0, nil
 }
 
-// parseCFNTemplate attempts JSON then YAML unmarshalling of a CloudFormation template.
-func parseCFNTemplate(cfn string) (*cfnTemplate, error) {
+// parseCFNTemplate attempts JSON then YAML unmarshalling of a CloudFormation
+// template. The YAML path expands short-form intrinsic tags (!Sub, !Ref, !If, …)
+// into their long forms first, so the two syntaxes resolve identically; see
+// cfnExpandYAMLTags. JSON templates cannot carry tags, so the JSON path is
+// untouched.
+func (d *StackDeployer) parseCFNTemplate(cfn string) (*cfnTemplate, error) {
 	var tmpl cfnTemplate
 	if err := json.Unmarshal([]byte(cfn), &tmpl); err == nil {
 		if len(tmpl.Resources) > 0 {
 			return &tmpl, nil
 		}
 	}
-	if err := yaml.Unmarshal([]byte(cfn), &tmpl); err == nil {
+	if unknown, err := cfnUnmarshalYAMLTemplate(cfn, &tmpl); err == nil {
+		for _, tag := range unknown {
+			d.logger.Warn("cfn: unrecognized YAML tag left unexpanded; its value is used verbatim",
+				"tag", tag,
+			)
+		}
 		if len(tmpl.Resources) > 0 {
 			return &tmpl, nil
 		}

--- a/emulator/betty_cfn_failure_test.go
+++ b/emulator/betty_cfn_failure_test.go
@@ -1,0 +1,201 @@
+package emulator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestCFN_RefusedResourceIsRecordedAsAFailure is the gate for the defect #516's
+// own reproduction exposed without naming: a resource the plugin refused was
+// reported as though it had been created.
+//
+// Plugins signal a client error two ways, and both are in wide use. S3 and IAM
+// return a 4xx *AWSResponse with a nil error — the same shape a real endpoint puts
+// on the wire — while EC2, ECS, CloudWatch Logs and SQS return an *AWSError.
+// StackDeployer only ever looked at the error return, so a refused S3 or IAM
+// resource recorded no error at all, and DescribeStackResources maps an empty
+// error to CREATE_COMPLETE. The stack reported success for a bucket that does not
+// exist.
+//
+// The table covers one resource per convention so that neither path can regress
+// into the other.
+func TestCFN_RefusedResourceIsRecordedAsAFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		// convention names how the plugin reports the refusal, because that is
+		// the axis the defect lay along.
+		convention  string
+		tmpl        string
+		logicalID   string
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			// #516's reproduction: a name S3 rejects (under three characters —
+			// deployS3Bucket lowercases, so a case violation would not survive to
+			// the plugin), refused with a 400, and the stack reported
+			// CREATE_COMPLETE.
+			name:        "S3InvalidBucketName",
+			convention:  "4xx response, nil error",
+			tmpl:        `{"Resources": {"B": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "no"}}}}`,
+			logicalID:   "B",
+			wantCode:    "InvalidBucketName",
+			wantMessage: "not valid",
+		},
+		{
+			// IAM is the other response-style plugin, and a trust policy that is
+			// not JSON is refused with MalformedPolicyDocument.
+			name:       "IAMMalformedPolicyDocument",
+			convention: "4xx response, nil error",
+			tmpl: `{"Resources": {"R": {"Type": "AWS::IAM::Role", "Properties": {
+				"RoleName": "refused-role",
+				"AssumeRolePolicyDocument": "this is not json"}}}}`,
+			logicalID:   "R",
+			wantCode:    "MalformedPolicyDocument",
+			wantMessage: "not valid JSON",
+		},
+		{
+			// EC2 returns an *AWSError, which the deployer already handled. The
+			// case is here so the fix cannot quietly break the path that worked.
+			name:       "EC2GroupNotFound",
+			convention: "*AWSError",
+			tmpl: `{"Resources": {"I": {"Type": "AWS::EC2::SecurityGroupIngress", "Properties": {
+				"GroupId": "sg-does-not-exist",
+				"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22,
+				"CidrIp": "0.0.0.0/0"}}}}`,
+			logicalID:   "I",
+			wantCode:    "InvalidGroup.NotFound",
+			wantMessage: "Security group not found",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newFullTestDeployer(t)
+			result, err := d.Deploy(context.Background(), tc.tmpl, "refused-"+tc.name, nil)
+
+			// The deploy itself succeeds: a per-resource failure is recorded on
+			// the resource, not returned as a stack-level error. That is the
+			// existing behavior and this change does not alter it.
+			require.NoError(t, err)
+			require.Len(t, result.Resources, 1)
+
+			dr := result.Resources[0]
+			assert.Equal(t, tc.logicalID, dr.LogicalID)
+			require.NotEmpty(t, dr.Error,
+				"a resource refused via %s must record the failure", tc.convention)
+			assert.Contains(t, dr.Error, tc.wantCode,
+				"the recorded reason must name the plugin's own error code, not a bare status")
+			assert.Contains(t, dr.Error, tc.wantMessage,
+				"the recorded reason must carry the plugin's message")
+		})
+	}
+}
+
+// TestCFN_RefusedBucketDoesNotExist pins the other half of #516's reproduction:
+// the resource the stack refused really is absent, so a consumer reading it back
+// gets a miss. Reporting CREATE_FAILED would be no use if the bucket were somehow
+// half-created.
+func TestCFN_RefusedBucketDoesNotExist(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+	tmpl := `{"Resources": {"B": {"Type": "AWS::S3::Bucket",
+	                              "Properties": {"BucketName": "no"}}}}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "refused-absent", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.Contains(t, result.Resources[0].Error, "InvalidBucketName")
+
+	v, err := state.Get(context.Background(), "s3", "bucket:no")
+	require.NoError(t, err)
+	assert.Nil(t, v, "the refused bucket must not be in state")
+}
+
+// TestCFN_RefusedBucketSkipsItsSubresources pins that a refused bucket's follow-up
+// configuration requests are never sent. deployS3Bucket discarded the response
+// entirely, so it went on to configure versioning on a bucket that does not exist.
+//
+// The reason to care is the event log, not the recorded error: the follow-up's own
+// result is discarded, so it could not have overwritten the reason. What it did do
+// was record a PUT ?versioning that was refused with NoSuchBucket — a request no
+// real client would have sent, in the log substrate replays. So the assertion is on
+// the stream: the refused bucket's PUT is there, and nothing follows it.
+func TestCFN_RefusedBucketSkipsItsSubresources(t *testing.T) {
+	d, store := newTestDeployerWithStore(t)
+	tmpl := `{"Resources": {"B": {"Type": "AWS::S3::Bucket", "Properties": {
+		"BucketName": "no",
+		"VersioningConfiguration": {"Status": "Enabled"}}}}}`
+
+	ctx := context.Background()
+	result, err := d.Deploy(ctx, tmpl, "refused-subresources", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.Contains(t, result.Resources[0].Error, "InvalidBucketName")
+
+	events, err := store.GetStream(ctx, "refused-subresources")
+	require.NoError(t, err)
+	require.Len(t, events, 1,
+		"only the refused PUT belongs in the log; a follow-up request against a "+
+			"bucket that does not exist is one no real client would have sent")
+	assert.Equal(t, "s3", events[0].Service)
+	for _, ev := range events {
+		assert.NotContains(t, ev.Error, "NoSuchBucket",
+			"no request may be sent against the refused bucket")
+	}
+}
+
+// TestCFN_SucceededResourceRecordsNoError is the negative control. The status
+// check must fire on a refusal and only on a refusal: were it inverted, or were
+// the threshold off by one, a 200 or a 3xx would start reporting CREATE_FAILED for
+// every stack substrate deploys.
+func TestCFN_SucceededResourceRecordsNoError(t *testing.T) {
+	d := newFullTestDeployer(t)
+	tmpl := `{"Resources": {
+		"B": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "accepted-bucket"}},
+		"R": {"Type": "AWS::IAM::Role", "Properties": {
+			"RoleName": "accepted-role",
+			"AssumeRolePolicyDocument": {"Version": "2012-10-17", "Statement": []}}},
+		"Q": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "accepted-queue"}}
+	}}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "accepted", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 3)
+	for _, r := range result.Resources {
+		assert.Empty(t, r.Error, "resource %s must not report a failure", r.LogicalID)
+		assert.NotEmpty(t, r.PhysicalID, "resource %s must have a physical ID", r.LogicalID)
+	}
+}
+
+// TestCFN_FailedResourceDoesNotStopTheStack pins what is deliberately *not*
+// changed here: substrate records a per-resource failure and carries on, while real
+// CloudFormation would roll the stack back to ROLLBACK_COMPLETE. Rollback is a much
+// larger behavior than the status check, so it is filed rather than fixed, and this
+// test states the current contract so the difference is a decision rather than an
+// oversight.
+func TestCFN_FailedResourceDoesNotStopTheStack(t *testing.T) {
+	d := newFullTestDeployer(t)
+	tmpl := `{"Resources": {
+		"Refused": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "no"}},
+		"Accepted": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "after-failure"}}
+	}}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "partial-failure", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 2)
+
+	byLogicalID := map[string]emulator.DeployedResource{}
+	for _, r := range result.Resources {
+		byLogicalID[r.LogicalID] = r
+	}
+	assert.Contains(t, byLogicalID["Refused"].Error, "InvalidBucketName")
+	assert.Empty(t, byLogicalID["Accepted"].Error,
+		"a resource after the failure is still deployed; substrate does not roll back")
+	assert.Equal(t, "after-failure", byLogicalID["Accepted"].PhysicalID,
+		"the queue should have been deployed despite the earlier failure")
+}

--- a/emulator/betty_cfn_test.go
+++ b/emulator/betty_cfn_test.go
@@ -883,6 +883,7 @@ func newFullTestDeployer(t *testing.T) *emulator.StackDeployer {
 		&emulator.MSKPlugin{},
 		&emulator.SESv2Plugin{},
 		&emulator.FirehosePlugin{},
+		&emulator.CloudWatchLogsPlugin{},
 	} {
 		require.NoError(t, p.Initialize(context.Background(), opts))
 		registry.Register(p)

--- a/emulator/betty_cfn_yaml.go
+++ b/emulator/betty_cfn_yaml.go
@@ -1,0 +1,163 @@
+package emulator
+
+import (
+	"fmt"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// cfnShortFormTags maps each CloudFormation YAML short-form tag to the long-form
+// key it expands to.
+//
+// A YAML parser has no notion of these tags: it drops the tag and keeps the node
+// value, so `!Sub 'x-${P}'` decodes to the bare string "x-${P}" and becomes
+// indistinguishable from a literal. Rewriting the tagged node into its long form
+// before decoding is what lets the two syntaxes resolve identically, which is
+// what CloudFormation guarantees.
+//
+// Every entry wraps the node's value unchanged. Two are irregular:
+// Ref and Condition take no "Fn::" prefix, and Fn::GetAtt additionally splits a
+// scalar on its first period (see cfnExpandGetAtt).
+var cfnShortFormTags = map[string]string{
+	"!Ref":         "Ref",
+	"!Condition":   "Condition",
+	"!GetAtt":      "Fn::GetAtt",
+	"!Sub":         "Fn::Sub",
+	"!Join":        "Fn::Join",
+	"!Select":      "Fn::Select",
+	"!Split":       "Fn::Split",
+	"!Base64":      "Fn::Base64",
+	"!If":          "Fn::If",
+	"!Equals":      "Fn::Equals",
+	"!Not":         "Fn::Not",
+	"!And":         "Fn::And",
+	"!Or":          "Fn::Or",
+	"!FindInMap":   "Fn::FindInMap",
+	"!ImportValue": "Fn::ImportValue",
+	"!Cidr":        "Fn::Cidr",
+	"!GetAZs":      "Fn::GetAZs",
+	"!Transform":   "Fn::Transform",
+}
+
+// cfnExpandYAMLTags rewrites every CloudFormation short-form intrinsic tag in n
+// into its long form in place, so that decoding n yields the same structure a
+// long-form template would.
+//
+// The walk is depth-first, children before parents, because the tags nest:
+// `!Not [!Equals [!Ref VpcId, ""]]` has to expand from the inside out or the
+// inner tags are carried into the parent's replacement node and lost.
+//
+// A tag the map does not recognize is left exactly as it is, and reported through
+// unknown so the caller can warn. Dropping it silently is the defect this
+// function exists to fix, and refusing the template outright would reject
+// templates real CloudFormation accepts (a macro or a transform may introduce
+// tags substrate has never heard of). Leaving the node's value in place is what
+// a YAML parser does anyway, so an unrecognized tag is no worse off than before.
+func cfnExpandYAMLTags(n *yaml.Node, unknown *[]string) {
+	// Children first. A mapping's keys are skipped: a key is a scalar in every
+	// CloudFormation template, and replacing one with a mapping would make it
+	// unusable as a map key.
+	if n.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			cfnExpandYAMLTags(n.Content[i+1], unknown)
+		}
+	} else {
+		for _, child := range n.Content {
+			cfnExpandYAMLTags(child, unknown)
+		}
+	}
+
+	if !cfnIsCustomTag(n.Tag) {
+		return
+	}
+	longForm, ok := cfnShortFormTags[n.Tag]
+	if !ok {
+		*unknown = append(*unknown, n.Tag)
+		return
+	}
+
+	// The original node becomes the value of the long-form mapping. Its tag is
+	// replaced rather than cleared: clearing it would let the decoder resolve the
+	// scalar's type afresh, and CloudFormation values are strings — `!Sub 12345`
+	// would decode to an int and `!Ref 2026-08-02` to a time.Time, neither of which
+	// resolveValue's string handling expects. "!!str" is correct for a sequence or
+	// mapping too, because the decoder is kind-driven and ignores the tag on a
+	// composite node.
+	value := new(yaml.Node)
+	*value = *n
+	value.Tag = "!!str"
+	if longForm == "Fn::GetAtt" {
+		value = cfnExpandGetAtt(value)
+	}
+
+	*n = yaml.Node{
+		Kind:   yaml.MappingNode,
+		Tag:    "!!map",
+		Line:   value.Line,
+		Column: value.Column,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: longForm},
+			value,
+		},
+	}
+}
+
+// cfnIsCustomTag reports whether tag is an application-specific YAML tag such as
+// "!Sub", as opposed to a native type tag such as "!!str" or an absent tag.
+func cfnIsCustomTag(tag string) bool {
+	return strings.HasPrefix(tag, "!") && !strings.HasPrefix(tag, "!!")
+}
+
+// cfnExpandGetAtt converts the scalar form of !GetAtt into the two-element
+// sequence Fn::GetAtt requires.
+//
+// !GetAtt is the one irregular short form: it accepts a dotted string where the
+// long form takes a list. The split is on the *first* period only, because an
+// attribute name may itself contain periods — the AWS reference's own example
+// maps `!GetAtt myELB.SourceSecurityGroup.OwnerAlias` to
+// `["myELB", "SourceSecurityGroup.OwnerAlias"]`.
+//
+// A !GetAtt already written as a sequence, and a scalar with no period, are
+// returned unchanged: the first is already in long form, and the second is
+// malformed either way and is left for the resolver to reject.
+func cfnExpandGetAtt(value *yaml.Node) *yaml.Node {
+	if value.Kind != yaml.ScalarNode {
+		return value
+	}
+	logicalID, attribute, found := strings.Cut(value.Value, ".")
+	if !found {
+		return value
+	}
+	return &yaml.Node{
+		Kind:   yaml.SequenceNode,
+		Tag:    "!!seq",
+		Line:   value.Line,
+		Column: value.Column,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: logicalID, Line: value.Line, Column: value.Column},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: attribute, Line: value.Line, Column: value.Column},
+		},
+	}
+}
+
+// cfnUnmarshalYAMLTemplate decodes a YAML CloudFormation template into tmpl,
+// expanding short-form intrinsic tags first. Any tag it does not recognize is
+// returned so the caller can warn about it.
+func cfnUnmarshalYAMLTemplate(cfn string, tmpl *cfnTemplate) ([]string, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(cfn), &doc); err != nil {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+	var unknown []string
+	cfnExpandYAMLTags(&doc, &unknown)
+	// An empty document decodes to a zero Node, which Decode rejects; treat it as
+	// an empty template and let the caller fall through to its JSON error path.
+	if doc.Kind == 0 {
+		return unknown, nil
+	}
+	if err := doc.Decode(tmpl); err != nil {
+		return unknown, fmt.Errorf("decode YAML template: %w", err)
+	}
+	return unknown, nil
+}

--- a/emulator/betty_cfn_yaml_test.go
+++ b/emulator/betty_cfn_yaml_test.go
@@ -1,0 +1,1036 @@
+package emulator_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestCFN_YAMLShortForm_MatchesLongForm is #516's gate, and it asserts the
+// invariant rather than any one expansion: a template written with the YAML short
+// forms must deploy to exactly what the Fn::-prefixed long forms deploy to.
+//
+// Before the fix, go.yaml.in/yaml/v3 dropped the tag and kept the scalar, so
+// `!Sub 'x-${P}'` reached the resolver as the literal "x-${P}" and no downstream
+// code could tell it from a literal the template really did intend.
+func TestCFN_YAMLShortForm_MatchesLongForm(t *testing.T) {
+	cases := []struct {
+		name  string
+		short string
+		long  string
+		want  string
+	}{
+		{
+			name:  "Ref",
+			short: `!Ref P`,
+			long:  `{Ref: P}`,
+			want:  "live",
+		},
+		{
+			name:  "Sub",
+			short: `!Sub 'b-${P}'`,
+			long:  `{Fn::Sub: 'b-${P}'}`,
+			want:  "b-live",
+		},
+		{
+			name:  "SubWithVarMap",
+			short: `!Sub ['b-${Who}', {Who: !Ref P}]`,
+			long:  `{Fn::Sub: ['b-${Who}', {Who: {Ref: P}}]}`,
+			want:  "b-live",
+		},
+		{
+			name:  "Join",
+			short: `!Join ['-', ['b', !Ref P]]`,
+			long:  `{Fn::Join: ['-', ['b', {Ref: P}]]}`,
+			want:  "b-live",
+		},
+		{
+			name:  "Select",
+			short: `!Select ['1', ['zero', !Ref P]]`,
+			long:  `{Fn::Select: ['1', ['zero', {Ref: P}]]}`,
+			want:  "live",
+		},
+		{
+			name:  "Split",
+			short: `!Split [',', 'live,dead']`,
+			long:  `{Fn::Split: [',', 'live,dead']}`,
+			want:  "live",
+		},
+		{
+			// A node carries at most one tag, so `!Base64 !Ref P` is not legal
+			// YAML — which is why AWS's own examples write the outer function in
+			// long form (`Fn::Base64: !Sub |…`). That nesting is covered by
+			// TestCFN_YAMLShortForm_TagUnderLongFormKey.
+			name:  "Base64",
+			short: `!Base64 live`,
+			long:  `{Fn::Base64: live}`,
+			want:  "bGl2ZQ==", // base64("live")
+		},
+		{
+			name:  "IfTrueBranch",
+			short: `!If [IsLive, !Ref P, 'dead']`,
+			long:  `{Fn::If: [IsLive, {Ref: P}, 'dead']}`,
+			want:  "live",
+		},
+		{
+			name:  "Pseudoparameter",
+			short: `!Sub 'b-${AWS::Region}'`,
+			long:  `{Fn::Sub: 'b-${AWS::Region}'}`,
+			want:  "b-us-east-1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shortID := resolveExpr(t, tc.short)
+			longID := resolveExpr(t, tc.long)
+
+			assert.Equal(t, tc.want, shortID, "short form resolved wrongly")
+			assert.Equal(t, shortID, longID,
+				"the short and long forms of the same intrinsic must be indistinguishable")
+		})
+	}
+}
+
+// TestCFN_YAMLShortForm_ConditionsMatchLongForm covers the condition-only
+// intrinsics, which resolve through evalConditionExpr rather than resolveValue
+// and so are a separate code path.
+func TestCFN_YAMLShortForm_ConditionsMatchLongForm(t *testing.T) {
+	cases := []struct {
+		name  string
+		short string
+		long  string
+		want  string
+	}{
+		{
+			name:  "Equals",
+			short: `!Equals [!Ref P, 'live']`,
+			long:  `{Fn::Equals: [{Ref: P}, 'live']}`,
+			want:  "chosen",
+		},
+		{
+			// Verbatim from the consumer's ecs_worker.yml:109 — three tags deep,
+			// which is what forces the expansion to run children before parents.
+			name:  "NotEqualsRef",
+			short: `!Not [!Equals [!Ref P, '']]`,
+			long:  `{Fn::Not: [{Fn::Equals: [{Ref: P}, '']}]}`,
+			want:  "chosen",
+		},
+		{
+			name:  "And",
+			short: `!And [!Equals [!Ref P, 'live'], !Not [!Equals [!Ref P, '']]]`,
+			long:  `{Fn::And: [{Fn::Equals: [{Ref: P}, 'live']}, {Fn::Not: [{Fn::Equals: [{Ref: P}, '']}]}]}`,
+			want:  "chosen",
+		},
+		{
+			name:  "Or",
+			short: `!Or [!Equals [!Ref P, 'nope'], !Equals [!Ref P, 'live']]`,
+			long:  `{Fn::Or: [{Fn::Equals: [{Ref: P}, 'nope']}, {Fn::Equals: [{Ref: P}, 'live']}]}`,
+			want:  "chosen",
+		},
+		{
+			name:  "FalseCondition",
+			short: `!Equals [!Ref P, 'nope']`,
+			long:  `{Fn::Equals: [{Ref: P}, 'nope']}`,
+			want:  "fallback",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shortID := resolveCondition(t, tc.short)
+			longID := resolveCondition(t, tc.long)
+
+			assert.Equal(t, tc.want, shortID, "short form resolved wrongly")
+			assert.Equal(t, shortID, longID,
+				"the short and long forms of the same condition must be indistinguishable")
+		})
+	}
+}
+
+// TestCFN_YAMLShortForm_ConditionTagReferencesAnotherCondition covers !Condition,
+// which is the one short form whose long key carries no "Fn::" prefix.
+func TestCFN_YAMLShortForm_ConditionTagReferencesAnotherCondition(t *testing.T) {
+	for name, inner := range map[string]string{
+		"short": `!Condition IsLive`,
+		"long":  `{Condition: IsLive}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			d := newTestDeployer(t)
+			tmpl := `
+Parameters:
+  P: {Type: String, Default: live}
+Conditions:
+  IsLive: !Equals [!Ref P, 'live']
+  AlsoLive: ` + inner + `
+Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !If [AlsoLive, 'chosen', 'fallback']
+`
+			result, err := d.Deploy(context.Background(), tmpl, "cond-"+name, nil)
+			require.NoError(t, err)
+			require.Len(t, result.Resources, 1)
+			assert.Equal(t, "chosen", result.Resources[0].PhysicalID)
+		})
+	}
+}
+
+// TestCFN_YAMLShortForm_GetAttSplitsOnFirstPeriod pins !GetAtt as the one
+// irregular expansion: it takes a dotted scalar where Fn::GetAtt takes a
+// two-element list, and the split is on the *first* period only, because an
+// attribute name may itself contain periods. The AWS reference's own example is
+// `!GetAtt myELB.SourceSecurityGroup.OwnerAlias` →
+// ["myELB", "SourceSecurityGroup.OwnerAlias"].
+func TestCFN_YAMLShortForm_GetAttSplitsOnFirstPeriod(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+	}{
+		{name: "DottedScalar", expr: `!GetAtt Role.Arn`},
+		{name: "SequenceFormPassesThrough", expr: `!GetAtt [Role, Arn]`},
+		{name: "LongForm", expr: `{Fn::GetAtt: [Role, Arn]}`},
+	}
+
+	var want string
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newTestDeployer(t)
+			// The assertion runs through Outputs, which resolveValue handles
+			// directly: the resolved ARN is not a legal bucket name, and asserting
+			// through one would need Fn::Select over Fn::Split, which resolves to
+			// its first element only (see docs/services.md).
+			tmpl := `
+Resources:
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: getatt-role
+      AssumeRolePolicyDocument: {Version: '2012-10-17', Statement: []}
+Outputs:
+  RoleArn:
+    Value: ` + tc.expr + `
+`
+			result, err := d.Deploy(context.Background(), tmpl, "getatt-"+tc.name, nil)
+			require.NoError(t, err)
+
+			arn := result.Outputs["RoleArn"]
+			assert.Equal(t, "arn:aws:iam::123456789012:role/getatt-role", arn,
+				"GetAtt Arn should resolve to the role's ARN")
+			if i == 0 {
+				want = arn
+			} else {
+				assert.Equal(t, want, arn, "every !GetAtt spelling must agree")
+			}
+		})
+	}
+}
+
+// TestCFN_YAMLShortForm_TagUnderLongFormKey covers a short form nested under a
+// long-form key. YAML allows one tag per node, so an outer short form cannot take
+// a tagged argument directly — `!Base64 !Sub 'x'` is a parse error — and AWS's own
+// examples spell the outer function long-form for exactly that reason. The
+// expander has to descend into a long-form mapping's values, not only into
+// sequence entries.
+func TestCFN_YAMLShortForm_TagUnderLongFormKey(t *testing.T) {
+	d := newTestDeployer(t)
+	tmpl := `
+Parameters:
+  P: {Type: String, Default: live}
+Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: probe-bucket
+Outputs:
+  Encoded:
+    Value:
+      Fn::Base64: !Sub 'y-${P}'
+`
+	result, err := d.Deploy(context.Background(), tmpl, "tag-under-long", nil)
+	require.NoError(t, err)
+	// base64("y-live")
+	assert.Equal(t, "eS1saXZl", result.Outputs["Encoded"])
+}
+
+// TestCFN_YAMLShortForm_GetAttWithNestedAttributeName asserts the split keeps a
+// dotted attribute name whole. GetAtt on an unknown attribute resolves to the
+// empty string, so this asserts through the expansion rather than the resolver:
+// were the split on the last period, the logical ID would be "Role.Outputs"
+// and the resource lookup would miss for a different reason.
+func TestCFN_YAMLShortForm_GetAttWithNestedAttributeName(t *testing.T) {
+	tmpl := `
+Resources:
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: nested-role
+      AssumeRolePolicyDocument: {Version: '2012-10-17', Statement: []}
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Join ['-', ['b', !GetAtt Role.Outputs.Nested]]
+`
+	shortID := deployOneBucket(t, tmpl, "getatt-nested-short")
+
+	tmpl = `
+Resources:
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: nested-role
+      AssumeRolePolicyDocument: {Version: '2012-10-17', Statement: []}
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: {Fn::Join: ['-', ['b', {Fn::GetAtt: [Role, 'Outputs.Nested']}]]}
+`
+	longID := deployOneBucket(t, tmpl, "getatt-nested-long")
+
+	assert.Equal(t, longID, shortID,
+		"a dotted attribute name must survive the split intact")
+}
+
+// TestCFN_FnSub_LiteralEscape covers Fn::Sub's ${!Literal} escape, which emits
+// "${Literal}" verbatim with no substitution.
+//
+// It was unreachable before the expander: the consumer's ec2_worker.yml writes
+// `!Sub 'parsl-worker-${WorkflowId}-${BlockId}-${!Count.Index}'`, and with the
+// whole !Sub discarded the escape never reached substituteTemplate. Expanding the
+// tag is what makes it reachable, which is why it ships in the same change.
+func TestCFN_FnSub_LiteralEscape(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{
+			name: "EscapedRefIsLiteral",
+			expr: `!Sub 'b-${P}-${!Count.Index}'`,
+			want: "b-live-${Count.Index}",
+		},
+		{
+			name: "EscapeOnly",
+			expr: `!Sub '${!Literal}'`,
+			want: "${Literal}",
+		},
+		{
+			name: "EscapeShieldsARealParameter",
+			expr: `!Sub '${!P}'`,
+			want: "${P}",
+		},
+		{
+			name: "LongFormEscapesToo",
+			expr: `{Fn::Sub: 'b-${P}-${!Count.Index}'}`,
+			want: "b-live-${Count.Index}",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The bucket name is not a legal one, so assert through an SQS queue
+			// tag: S3 lowercases and the plugin would refuse the braces.
+			d := newTestDeployer(t)
+			tmpl := `
+Parameters:
+  P: {Type: String, Default: live}
+Resources:
+  Q:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: escape-queue
+      Tags:
+        - Key: Name
+          Value: ` + tc.expr + `
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Join ['|', ['x', ` + tc.expr + `]]
+`
+			result, err := d.Deploy(context.Background(), tmpl, "escape-"+tc.name, nil)
+			require.NoError(t, err)
+
+			var bucket string
+			for _, r := range result.Resources {
+				if r.LogicalID == "B" {
+					bucket = r.PhysicalID
+				}
+			}
+			// deployS3Bucket lowercases the name it sends, so compare against the
+			// lowercased expectation rather than weakening the assertion.
+			assert.Equal(t, strings.ToLower("x|"+tc.want), bucket)
+		})
+	}
+}
+
+// TestCFN_YAMLShortForm_UnrecognizedTagIsWarnedNotDropped pins the decision for a
+// tag the expander does not know: leave the node's value in place and warn.
+//
+// Dropping it silently is exactly the defect #516 reports, and refusing the
+// template would reject templates real CloudFormation accepts, since a macro or a
+// transform may introduce tags substrate has never heard of.
+func TestCFN_YAMLShortForm_UnrecognizedTagIsWarnedNotDropped(t *testing.T) {
+	var buf bytes.Buffer
+	d := newTestDeployerWithLogger(t, newTestLogger(&buf, slog.LevelWarn))
+
+	tmpl := `
+Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Mystery keepme
+`
+	result, err := d.Deploy(context.Background(), tmpl, "mystery", nil)
+	require.NoError(t, err, "an unrecognized tag must not refuse the template")
+	require.Len(t, result.Resources, 1)
+	assert.Equal(t, "keepme", result.Resources[0].PhysicalID,
+		"the tagged node's value must survive")
+
+	assert.Contains(t, buf.String(), "unrecognized YAML tag")
+	assert.Contains(t, buf.String(), "!Mystery",
+		"the warning must name the tag, or an operator cannot act on it")
+}
+
+// TestCFN_YAMLShortForm_GetAttWithoutAPeriod pins that a !GetAtt scalar carrying no
+// period is passed through rather than split into a one-element list.
+//
+// Such a template is malformed either way — Fn::GetAtt needs both a logical ID and
+// an attribute — so the expander leaves it for the resolver to reject rather than
+// inventing an empty attribute name, which would turn a template error into a
+// silently empty property.
+func TestCFN_YAMLShortForm_GetAttWithoutAPeriod(t *testing.T) {
+	assert.Empty(t, resolveExpr(t, "!GetAtt NoPeriodHere"),
+		"a !GetAtt with no attribute must not resolve to anything")
+}
+
+// TestCFN_MalformedYAMLIsRefused pins that a template which is neither valid JSON
+// nor valid YAML is refused with an error rather than deployed as an empty stack.
+func TestCFN_MalformedYAMLIsRefused(t *testing.T) {
+	cases := []struct {
+		name, tmpl string
+	}{
+		{
+			// Two tags on one node. A YAML node carries at most one, so this is a
+			// parse error — which is why AWS's examples spell the outer function
+			// long-form as `Fn::Base64: !Ref P`.
+			name: "TwoTagsOnOneNode",
+			tmpl: "Resources:\n  B:\n    Type: AWS::S3::Bucket\n    Properties:\n" +
+				"      BucketName: !Base64 !Ref P\n",
+		},
+		{
+			// Valid YAML, but a scalar where the decoder needs a mapping.
+			name: "ResourcesIsAScalar",
+			tmpl: "Resources: not-a-mapping\n",
+		},
+		{
+			name: "UnclosedFlowSequence",
+			tmpl: "Resources:\n  B:\n    Type: AWS::S3::Bucket\n    Properties:\n" +
+				"      Tags: [oops\n",
+		},
+		{
+			name: "Empty",
+			tmpl: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newTestDeployer(t)
+			_, err := d.Deploy(context.Background(), tc.tmpl, "malformed-"+tc.name, nil)
+			require.Error(t, err, "a template substrate cannot parse must be refused")
+			assert.Contains(t, err.Error(), "parse template",
+				"the error must say the template could not be parsed")
+		})
+	}
+}
+
+// TestCFN_DispatchErrorPrecedence pins cfnDispatchError's precedence and the
+// degraded shapes of a refusal reason.
+//
+// The two body-derived arms are exercised through deployed stacks in
+// betty_cfn_failure_test.go, which is where they belong. The remaining arms are
+// asserted here against the function, because they cannot be reached from any
+// template: the only two response-style plugins a stack dispatches to are S3 and
+// IAM, and s3ErrorResponseWith and iamErrorResponse both always write a <Code> and
+// a <Message>. Unreachable or not, an empty reason for a 4xx is exactly the
+// CREATE_COMPLETE-for-a-refused-resource defect this release fixes, so the
+// fallbacks have to hold.
+func TestCFN_DispatchErrorPrecedence(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int // 0 means no response at all
+		body     string
+		routeErr error
+		want     string
+	}{
+		{
+			// routeErr wins even against a 4xx, because an *AWSError carries the
+			// plugin's own code and message where a status is a summary of it.
+			name:     "RouteErrorTakesPrecedenceOverTheStatus",
+			status:   http.StatusBadRequest,
+			body:     `<Error><Code>FromBody</Code><Message>from the body</Message></Error>`,
+			routeErr: errors.New("from the error return"),
+			want:     "from the error return",
+		},
+		{
+			name:     "RouteErrorWithNoResponseAtAll",
+			status:   0,
+			routeErr: errors.New("routing failed"),
+			want:     "routing failed",
+		},
+		{
+			name:   "CodeAndMessage",
+			status: http.StatusBadRequest,
+			body:   `<Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message></Error>`,
+			want:   "InvalidBucketName: The specified bucket is not valid.",
+		},
+		{
+			// A code with no message: the status stands in for the missing prose
+			// rather than being dropped, so the reason still says what happened.
+			name:   "CodeWithoutAMessage",
+			status: http.StatusConflict,
+			body:   `<Error><Code>BucketAlreadyExists</Code></Error>`,
+			want:   "BucketAlreadyExists (HTTP 409)",
+		},
+		{
+			// Neither element. The status alone is a poor reason, but it is a
+			// reason, and a resource that reports it is CREATE_FAILED rather than
+			// CREATE_COMPLETE.
+			name:   "NeitherCodeNorMessage",
+			status: http.StatusForbidden,
+			body:   `<html>not an AWS error document</html>`,
+			want:   "request failed with HTTP 403",
+		},
+		{
+			name:   "NoBodyAtAll",
+			status: http.StatusNotFound,
+			want:   "request failed with HTTP 404",
+		},
+		{
+			// A message with no code falls to the status too: without a code there
+			// is nothing to name, and prose alone reads as though substrate
+			// invented it.
+			name:   "MessageWithoutACode",
+			status: http.StatusBadRequest,
+			body:   `<Error><Message>something went wrong</Message></Error>`,
+			want:   "request failed with HTTP 400",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := emulator.CFNDispatchErrorForTest(tc.status, tc.body, tc.routeErr)
+			require.Error(t, err, "a refusal must always produce a reason")
+			assert.Equal(t, tc.want, err.Error())
+		})
+	}
+}
+
+// TestCFN_DispatchErrorAcceptsSuccess is the negative control for the status
+// check: every status below 400 has to stay a success, or the check would report
+// CREATE_FAILED for every stack substrate deploys. 399 and 400 are both present
+// because an off-by-one at the threshold is the mutation this pins.
+func TestCFN_DispatchErrorAcceptsSuccess(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusCreated, http.StatusNoContent,
+		http.StatusMovedPermanently, http.StatusNotModified, 399} {
+		assert.NoError(t, emulator.CFNDispatchErrorForTest(status, "", nil),
+			"HTTP %d must not be reported as a resource failure", status)
+	}
+	assert.NoError(t, emulator.CFNDispatchErrorForTest(0, "", nil),
+		"no response and no error is a success: several deploy paths discard the response")
+	assert.Error(t, emulator.CFNDispatchErrorForTest(http.StatusBadRequest, "", nil),
+		"400 is the first status that is a failure")
+}
+
+// TestCFN_YAMLShortForm_ConsumerTemplate deploys the whole ecs_worker.yml from
+// parsl-aws-provider, which is #516's end-to-end case. The reporter's stack
+// produced a task-definition family containing the unevaluated condition array
+// verbatim:
+//
+//	["HasTaskFamily","TaskFamily","parsl-task-${WorkflowId}-${JobId}"]
+//
+// The template is checked in as testdata so it cannot drift out from under the
+// assertion.
+func TestCFN_YAMLShortForm_ConsumerTemplate(t *testing.T) {
+	body, err := os.ReadFile("testdata/cfn/ecs_worker.yml")
+	require.NoError(t, err)
+
+	d := newFullTestDeployer(t)
+	result, err := d.Deploy(context.Background(), string(body), "ecs-worker", map[string]string{
+		"WorkflowId":     "wf1",
+		"JobId":          "job1",
+		"ContainerImage": "public.ecr.aws/parsl/worker:latest",
+	})
+	require.NoError(t, err)
+
+	byLogicalID := map[string]emulator.DeployedResource{}
+	for _, r := range result.Resources {
+		byLogicalID[r.LogicalID] = r
+	}
+
+	// The physical ID is the task-definition ARN, whose last segment is
+	// "<family>:<revision>" — which is the string #516 quotes as carrying the raw
+	// condition array.
+	td, ok := byLogicalID["TaskDefinition"]
+	require.True(t, ok, "the task definition should have been deployed")
+	assert.Equal(t, "arn:aws:ecs:us-east-1:123456789012:task-definition/parsl-task-wf1-job1:1",
+		td.PhysicalID,
+		"Family: !If [HasTaskFamily, !Ref TaskFamily, !Sub '…'] must pick the !Sub branch")
+	assert.NotContains(t, td.PhysicalID, "HasTaskFamily",
+		"the family must not be the raw, unevaluated condition array")
+	assert.NotContains(t, td.PhysicalID, "${",
+		"the family must not carry an unsubstituted placeholder")
+
+	cluster, ok := byLogicalID["ECSCluster"]
+	require.True(t, ok)
+	assert.Equal(t, "parsl-cluster-wf1", cluster.PhysicalID,
+		"ClusterName: !If [HasClusterName, !Ref ClusterName, !Sub '…']")
+
+	lg, ok := byLogicalID["LogGroup"]
+	require.True(t, ok)
+	assert.Equal(t, "/aws/ecs/parsl-wf1-job1", lg.PhysicalID)
+
+	// Every resource in the template deployed without an error.
+	for _, r := range result.Resources {
+		assert.Empty(t, r.Error, "resource %s failed: %s", r.LogicalID, r.Error)
+	}
+}
+
+// TestCFN_EmptyStringParameterDefaultIsDeclared pins that `Default: ”` declares a
+// parameter whose value is the empty string, not a parameter with no default.
+//
+// This is the idiom for an optional parameter, and every
+// `!Not [!Equals [!Ref X, ”]]` condition exists to test for it — 21 times across
+// the five templates in parsl-aws-provider. buildCFNContext recorded a default
+// only when it was non-empty, so such a parameter was left undeclared, Ref fell
+// through to echoing the parameter's own name back, and the condition **inverted**:
+// a parameter the caller did not set read as set.
+func TestCFN_EmptyStringParameterDefaultIsDeclared(t *testing.T) {
+	cases := []struct {
+		name string
+		tmpl string
+	}{
+		{
+			name: "ShortForm",
+			tmpl: `
+Parameters:
+  Optional: {Type: String, Default: ''}
+Conditions:
+  HasOptional: !Not [!Equals [!Ref Optional, '']]
+Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: probe-bucket
+Outputs:
+  V:
+    Value: !If [HasOptional, !Ref Optional, 'unset']
+`,
+		},
+		{
+			name: "LongForm",
+			tmpl: `{
+				"Parameters": {"Optional": {"Type": "String", "Default": ""}},
+				"Conditions": {
+					"HasOptional": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Optional"}, ""]}]}
+				},
+				"Resources": {"B": {"Type": "AWS::S3::Bucket",
+				                    "Properties": {"BucketName": "probe-bucket"}}},
+				"Outputs": {
+					"V": {"Value": {"Fn::If": ["HasOptional", {"Ref": "Optional"}, "unset"]}}
+				}
+			}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Unset: the condition must be false, and Ref must not echo the name.
+			assert.Equal(t, "unset", deployOneOutput(t, tc.tmpl, "emptydefault-"+tc.name),
+				"an unset optional parameter must read as unset")
+
+			// Set: the same template with the parameter supplied takes the other
+			// branch, which proves the condition is being evaluated rather than
+			// merely defaulting to false.
+			d := newTestDeployer(t)
+			result, err := d.Deploy(context.Background(), tc.tmpl, "setdefault-"+tc.name,
+				map[string]string{"Optional": "supplied"})
+			require.NoError(t, err)
+			assert.Equal(t, "supplied", result.Outputs["V"])
+		})
+	}
+}
+
+// TestCFN_ConditionReferencingConditionIsOrderIndependent pins that a condition
+// referencing another by name resolves the same way however the template declares
+// them.
+//
+// evaluateConditions walked tmpl.Conditions in Go map order, so a condition
+// evaluated before the one it references read the referent's zero value. The same
+// template then deployed differently from one run to the next — nondeterminism,
+// which is the one outcome an emulator built on deterministic replay must never
+// produce. Two names per case, ordered both ways, so neither declaration order nor
+// alphabetical order can accidentally satisfy the test.
+func TestCFN_ConditionReferencingConditionIsOrderIndependent(t *testing.T) {
+	// A three-deep chain: Third → Second → First. Whichever order the map is
+	// walked in, every condition must see its referent's real value.
+	cases := []struct {
+		name       string
+		conditions string
+	}{
+		{
+			name: "ReferentDeclaredFirst",
+			conditions: `
+  AFirst: !Equals [!Ref P, 'live']
+  BSecond: !Condition AFirst
+  CThird: !Condition BSecond`,
+		},
+		{
+			name: "ReferentDeclaredLast",
+			conditions: `
+  CThird: !Condition BSecond
+  BSecond: !Condition AFirst
+  AFirst: !Equals [!Ref P, 'live']`,
+		},
+		{
+			name: "ReferentSortsAfterItsUser",
+			conditions: `
+  ZReferent: !Equals [!Ref P, 'live']
+  AUser: !Condition ZReferent
+  CThird: !Condition AUser`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			third := "CThird"
+			tmpl := `
+Parameters:
+  P: {Type: String, Default: live}
+Conditions:` + tc.conditions + `
+Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: probe-bucket
+Outputs:
+  V:
+    Value: !If [` + third + `, 'chosen', 'fallback']
+`
+			// Deployed repeatedly, because the defect was a map-order race: one
+			// run could easily pass by luck.
+			for i := 0; i < 8; i++ {
+				assert.Equal(t, "chosen",
+					deployOneOutput(t, tmpl, "condorder-"+tc.name+"-"+strconv.Itoa(i)),
+					"a condition referencing another must not depend on map order")
+			}
+		})
+	}
+}
+
+// TestCFN_ConditionCycleTerminates pins that a circular condition reference
+// degrades to false rather than recursing forever. Real CloudFormation rejects the
+// template at validation time; substrate has no validation pass, so the guarantee
+// that matters here is that the deployment terminates and does so identically every
+// time.
+//
+// Negated is the case that makes the *sorted* walk in evaluateConditions
+// load-bearing rather than merely tidy. Where a plain cycle resolves both members to
+// false whichever is entered first, a cycle through Fn::Not resolves them to
+// opposite values, so the answer depends on which member the walk enters — Go's map
+// order, absent the sort.
+//
+// Both members are asserted, because the entry point is only visible in the one the
+// walk reaches second: an unsorted walk still resolves A to true either way, and
+// leaves B disagreeing with itself across runs.
+func TestCFN_ConditionCycleTerminates(t *testing.T) {
+	cases := []struct {
+		name       string
+		conditions string
+		// wantA and wantB are the values of A and B — the outcome that must hold
+		// on every run, not merely on most of them.
+		wantA, wantB string
+	}{
+		{
+			name: "Plain",
+			conditions: `
+  A: !Condition B
+  B: !Condition A`,
+			wantA: "false", wantB: "false",
+		},
+		{
+			// The sorted walk always enters at A, which asks for B; B asks back
+			// for A, meets the cycle guard and takes false, so B memoizes false
+			// and A is !false = true. Entering at B instead inverts only B: B
+			// would ask for A, A's inner B would hit the guard, A would memoize
+			// true and B would read that true. So A is true either way and B is
+			// the member that betrays the entry point.
+			name: "Negated",
+			conditions: `
+  A: !Not [!Condition B]
+  B: !Condition A`,
+			wantA: "true", wantB: "false",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := `
+Conditions:` + tc.conditions + `
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: probe-bucket
+Outputs:
+  VA:
+    Value: !If [A, 'true', 'false']
+  VB:
+    Value: !If [B, 'true', 'false']
+`
+			for i := 0; i < 8; i++ {
+				d := newTestDeployer(t)
+				result, err := d.Deploy(context.Background(), tmpl,
+					"condcycle-"+tc.name+"-"+strconv.Itoa(i), nil)
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantA, result.Outputs["VA"],
+					"a condition cycle must terminate, and resolve identically every run")
+				assert.Equal(t, tc.wantB, result.Outputs["VB"],
+					"the member the walk reaches second is where map order shows")
+			}
+		})
+	}
+}
+
+// TestCFN_ShortFormScalarStaysAString pins that a short form's value is decoded as
+// a string rather than having its type resolved by YAML.
+//
+// The expander replaces the tagged node's tag rather than clearing it. Clearing it
+// would let the decoder resolve the scalar afresh: `!Sub 12345` would arrive as an
+// int and `!Ref 2026-08-02` as a time.Time. resolveValue handles ints, so the first
+// merely round-trips by luck; a time.Time matches none of its cases and resolves to
+// the empty string, silently emptying the property. CloudFormation values are
+// strings, and the long forms are unquoted the same way, so each pair below must
+// agree.
+func TestCFN_ShortFormScalarStaysAString(t *testing.T) {
+	cases := []struct {
+		name string
+		// expr is written unquoted on purpose: quoting it would make the YAML
+		// scalar a string regardless and the test would prove nothing.
+		expr string
+		want string
+	}{
+		{name: "Integer", expr: "!Sub 12345", want: "12345"},
+		{name: "Float", expr: "!Sub 1.50", want: "1.50"},
+		{name: "Boolean", expr: "!Sub true", want: "true"},
+		{name: "DateLooking", expr: "!Sub 2026-08-02", want: "2026-08-02"},
+		{name: "SexagesimalLooking", expr: "!Sub 1:30", want: "1:30"},
+		{name: "LeadingZero", expr: "!Sub 007", want: "007"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveExpr(t, tc.expr),
+				"a short form's scalar must reach the resolver as written")
+		})
+	}
+}
+
+// TestCFN_ConditionIsFrozenBeforeResourcesDeploy pins that a condition's value is
+// fixed for the whole deployment.
+//
+// AWS evaluates conditions once, "when creating or updating a stack", and forbids a
+// condition from referencing "resource logical IDs or their attributes" — so a
+// condition's value cannot legitimately change partway through. substrate has no
+// validation pass to reject the reference, which makes the freeze the thing that has
+// to hold: were each read re-evaluated, a template like this one would see
+// 'before-deploy' in a property resolved early and 'after-deploy' in an output
+// resolved last, and the same template would resolve differently depending on the
+// resource ordering.
+func TestCFN_ConditionIsFrozenBeforeResourcesDeploy(t *testing.T) {
+	// Ref Bucket resolves to the parameter's own name until the bucket deploys, so
+	// the condition is false at evaluation time and would flip to true afterwards.
+	tmpl := `
+Conditions:
+  BucketIsNamed: !Equals [!Ref Bucket, 'probe-bucket']
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: probe-bucket
+Outputs:
+  V:
+    Value: !If [BucketIsNamed, 'after-deploy', 'before-deploy']
+`
+	assert.Equal(t, "before-deploy", deployOneOutput(t, tmpl, "condfrozen"),
+		"a condition evaluated before any resource deployed must keep that value")
+}
+
+// TestCFN_JSONTemplateUnaffected pins that the JSON path is untouched. JSON
+// cannot carry YAML tags, so the expander has nothing to do there — and a JSON
+// template whose keys happen to look like tags must be left exactly as it is.
+func TestCFN_JSONTemplateUnaffected(t *testing.T) {
+	d := newTestDeployer(t)
+	tmpl := `{
+		"Parameters": {"P": {"Type": "String", "Default": "live"}},
+		"Resources": {
+			"B": {"Type": "AWS::S3::Bucket",
+			      "Properties": {"BucketName": {"Fn::Sub": "b-${P}"}}},
+			"Q": {"Type": "AWS::SQS::Queue",
+			      "Properties": {"QueueName": "json-queue",
+			                     "Tags": [{"Key": "Literal", "Value": "!Sub not-a-tag"}]}}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "json-untouched", nil)
+	require.NoError(t, err)
+
+	for _, r := range result.Resources {
+		if r.LogicalID == "B" {
+			assert.Equal(t, "b-live", r.PhysicalID)
+		}
+		assert.Empty(t, r.Error)
+	}
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// resolveExpr deploys a template whose single output is expr and returns the
+// resolved value.
+//
+// The assertion runs through an output rather than a resource property because
+// resolveValue is the same code path for both, and an output carries none of a
+// property's naming constraints — deployS3Bucket lowercases a bucket name, which
+// would silently mask a case difference in, say, a Base64 result.
+func resolveExpr(t *testing.T, expr string) string {
+	t.Helper()
+	tmpl := `
+Parameters:
+  P: {Type: String, Default: live}
+Conditions:
+  IsLive: !Equals [!Ref P, 'live']
+Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: expr-bucket
+Outputs:
+  V:
+    Value: ` + expr + `
+`
+	return deployOneOutput(t, tmpl, "expr")
+}
+
+// resolveCondition deploys a template whose output is chosen by a condition
+// defined as expr, and returns the resolved value.
+func resolveCondition(t *testing.T, expr string) string {
+	t.Helper()
+	tmpl := `
+Parameters:
+  P: {Type: String, Default: live}
+Conditions:
+  C: ` + expr + `
+Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: cond-bucket
+Outputs:
+  V:
+    Value: !If [C, 'chosen', 'fallback']
+`
+	return deployOneOutput(t, tmpl, "cond")
+}
+
+// deployOneOutput deploys tmpl and returns the resolved value of its output "V".
+func deployOneOutput(t *testing.T, tmpl, streamID string) string {
+	t.Helper()
+	d := newTestDeployer(t)
+	result, err := d.Deploy(context.Background(), tmpl, streamID, nil)
+	require.NoError(t, err)
+	for _, r := range result.Resources {
+		require.Empty(t, r.Error, "resource %s failed", r.LogicalID)
+	}
+	v, ok := result.Outputs["V"]
+	require.True(t, ok, "output V was not resolved")
+	return v
+}
+
+// deployOneBucket deploys tmpl and returns the physical ID of its single bucket.
+func deployOneBucket(t *testing.T, tmpl, streamID string) string {
+	t.Helper()
+	d := newTestDeployer(t)
+	result, err := d.Deploy(context.Background(), tmpl, streamID, nil)
+	require.NoError(t, err)
+	for _, r := range result.Resources {
+		if r.Type == "AWS::S3::Bucket" {
+			return r.PhysicalID
+		}
+	}
+	t.Fatalf("no bucket in %d deployed resources", len(result.Resources))
+	return ""
+}
+
+// newTestDeployerWithStore builds a minimal S3-only deployer alongside the event
+// store it records into, so a test can assert which requests were actually sent.
+func newTestDeployerWithStore(t *testing.T) (*emulator.StackDeployer, *emulator.EventStore) {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+
+	s3Plugin := &emulator.S3Plugin{}
+	require.NoError(t, s3Plugin.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"filesystem":      afero.NewMemMapFs(),
+		},
+	}))
+	registry.Register(s3Plugin)
+
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs), store
+}
+
+// newTestDeployerWithLogger builds a minimal deployer whose logger is the one
+// supplied, so a test can assert on what was logged.
+func newTestDeployerWithLogger(t *testing.T, logger emulator.Logger) *emulator.StackDeployer {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+
+	s3Plugin := &emulator.S3Plugin{}
+	require.NoError(t, s3Plugin.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"filesystem":      afero.NewMemMapFs(),
+		},
+	}))
+	registry.Register(s3Plugin)
+
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs)
+}

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -287,3 +287,20 @@ func MarshalAWSErrorForTest(code, message, proto, jsonContentType string, status
 func S3ErrorResponseForTest(code, message string, status int) []byte {
 	return s3ErrorResponseWith(s3Error{Code: code, Message: message, Status: status}).Body
 }
+
+// CFNDispatchErrorForTest wraps cfnDispatchError so its precedence and its
+// degraded reason shapes can be asserted directly.
+//
+// Going through the function rather than a deployed stack is deliberate: every
+// response-style plugin a stack can reach (S3, IAM) writes both a <Code> and a
+// <Message>, so the body-less and message-less arms are unreachable from any
+// template. They still have to be right — a 4xx that produced an empty reason
+// would be recorded as CREATE_COMPLETE, which is the whole defect — so they are
+// pinned here at the unit the plan extracted them into.
+func CFNDispatchErrorForTest(status int, body string, routeErr error) error {
+	var resp *AWSResponse
+	if status != 0 {
+		resp = &AWSResponse{StatusCode: status, Body: []byte(body)}
+	}
+	return cfnDispatchError(resp, routeErr)
+}

--- a/emulator/testdata/cfn/ecs_worker.yml
+++ b/emulator/testdata/cfn/ecs_worker.yml
@@ -1,0 +1,282 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Parsl Ephemeral AWS Provider - ECS/Fargate Worker Resources'
+
+# The RegionMap that used to sit here was dead: no FindInMap referenced it
+# anywhere, and its AMIs dated from a Python 3.9 era. The EC2 path now takes an
+# ImageId parameter, which the caller resolves from SSM (#83).
+
+Parameters:
+  ClusterName:
+    Type: String
+    Description: Name of the ECS cluster
+    Default: ''
+
+  TaskFamily:
+    Type: String
+    Description: Family name for the task definition
+    Default: ''
+
+  ContainerImage:
+    Type: String
+    Description: Docker image for the container
+    Default: 'python:3.12-slim'
+
+  TaskCpu:
+    Type: Number
+    Description: CPU units for the task
+    Default: 1024
+    AllowedValues:
+      - 256
+      - 512
+      - 1024
+      - 2048
+      - 4096
+
+  TaskMemory:
+    Type: Number
+    Description: Memory for the task in MB
+    Default: 2048
+    AllowedValues:
+      - 512
+      - 1024
+      - 2048
+      - 3072
+      - 4096
+      - 5120
+      - 6144
+      - 7168
+      - 8192
+      - 16384
+      - 30720
+
+  Command:
+    Type: String
+    Description: Command to run in the container
+    Default: ''
+
+  VpcId:
+    Type: String
+    Description: VPC ID for task networking
+    Default: ''
+
+  SubnetIds:
+    Type: CommaDelimitedList
+    Description: Subnet IDs for task networking
+    Default: ''
+
+  SecurityGroupIds:
+    Type: CommaDelimitedList
+    Description: Security group IDs for task networking
+    Default: ''
+
+  AssignPublicIp:
+    Type: String
+    Description: Whether to assign a public IP to the task
+    Default: 'ENABLED'
+    AllowedValues:
+      - 'ENABLED'
+      - 'DISABLED'
+
+  WorkflowId:
+    Type: String
+    Description: Unique ID for the workflow
+
+  JobId:
+    Type: String
+    Description: Unique ID for the job
+
+  TaskCount:
+    Type: Number
+    Description: Number of tasks to run
+    Default: 1
+    MinValue: 1
+
+  UseSpot:
+    Type: String
+    Description: Whether to use Fargate Spot
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+
+  Tags:
+    Type: String
+    Description: JSON encoded tags to apply to resources
+    Default: '{}'
+
+Conditions:
+  HasVpcConfig: !Not [!Equals [!Ref VpcId, '']]
+  HasCommand: !Not [!Equals [!Ref Command, '']]
+  UseFargateSpot: !Equals [!Ref UseSpot, 'true']
+  HasClusterName: !Not [!Equals [!Ref ClusterName, '']]
+  HasTaskFamily: !Not [!Equals [!Ref TaskFamily, '']]
+
+Resources:
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !If
+        - HasClusterName
+        - !Ref ClusterName
+        - !Sub 'parsl-cluster-${WorkflowId}'
+      CapacityProviders:
+        - FARGATE
+        - FARGATE_SPOT
+      DefaultCapacityProviderStrategy:
+        - CapacityProvider: !If [UseFargateSpot, 'FARGATE_SPOT', 'FARGATE']
+          Weight: 1
+      Tags:
+        - Key: ParslResource
+          Value: 'true'
+        - Key: ParslWorkflowId
+          Value: !Ref WorkflowId
+
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Tags:
+        - Key: ParslResource
+          Value: 'true'
+        - Key: ParslWorkflowId
+          Value: !Ref WorkflowId
+        - Key: ParslJobId
+          Value: !Ref JobId
+
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Tags:
+        - Key: ParslResource
+          Value: 'true'
+        - Key: ParslWorkflowId
+          Value: !Ref WorkflowId
+        - Key: ParslJobId
+          Value: !Ref JobId
+
+  # The SpotFleetRole that used to live here is gone with the API it served:
+  # CreateFleet has no IamFleetRole member, so an EC2 Fleet needs no service
+  # role at all (#86). Its name also carried the prefix the orphan sweep did not
+  # know about, so every one it made was leaked.
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/ecs/parsl-${WorkflowId}-${JobId}'
+      RetentionInDays: 7
+      Tags:
+        - Key: ParslResource
+          Value: 'true'
+        - Key: ParslWorkflowId
+          Value: !Ref WorkflowId
+        - Key: ParslJobId
+          Value: !Ref JobId
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !If
+        - HasTaskFamily
+        - !Ref TaskFamily
+        - !Sub 'parsl-task-${WorkflowId}-${JobId}'
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: !Ref TaskCpu
+      Memory: !Ref TaskMemory
+      ContainerDefinitions:
+        - Name: !Sub 'parsl-container-${WorkflowId}-${JobId}'
+          Image: !Ref ContainerImage
+          Essential: true
+          Command: !If [HasCommand, !Split [',', !Ref Command], !Ref 'AWS::NoValue']
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: parsl
+      Tags:
+        - Key: ParslResource
+          Value: 'true'
+        - Key: ParslWorkflowId
+          Value: !Ref WorkflowId
+        - Key: ParslJobId
+          Value: !Ref JobId
+
+  ECSService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref ECSCluster
+      TaskDefinition: !Ref TaskDefinition
+      DesiredCount: !Ref TaskCount
+      LaunchType: !If [UseFargateSpot, !Ref 'AWS::NoValue', 'FARGATE']
+      CapacityProviderStrategy: !If
+        - UseFargateSpot
+        - - CapacityProvider: FARGATE_SPOT
+            Weight: 1
+        - !Ref 'AWS::NoValue'
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: !Ref AssignPublicIp
+          Subnets: !Ref SubnetIds
+          SecurityGroups: !Ref SecurityGroupIds
+      Tags:
+        - Key: ParslResource
+          Value: 'true'
+        - Key: ParslWorkflowId
+          Value: !Ref WorkflowId
+        - Key: ParslJobId
+          Value: !Ref JobId
+
+  # This template no longer carries a fleet. It used to hold an AWS::EC2::SpotFleet
+  # and then, briefly, an AWS::EC2::EC2Fleet -- but CloudFormation cannot express
+  # the resource this package needs (#86):
+  #
+  #   The Overrides list is variable-length, one entry per instance type, and
+  #   CFN has no way to build one. Fn::ForEach (AWS::LanguageExtensions) expands
+  #   to a *map*, confirmed by reading the processed template off a change set.
+  #   A fixed set of !Select slots cannot be left partly filled either, because
+  #   an out-of-range !Select fails validation even inside the untaken branch of
+  #   an !If: "Fn::Select cannot select nonexistent value at index 2". Padding
+  #   the slots by repeating a type is rejected by EC2 itself --
+  #   "InvalidFleetConfig: The fleet configuration contains duplicate instance
+  #   pools" -- which a DryRun does not catch.
+  #
+  # ServerlessMode._create_job_fleet() calls CreateFleet directly instead, which
+  # takes the override list natively. Deploying this stack to obtain one fleet
+  # also created an ECS cluster, a task definition, two IAM roles, and a log
+  # group that an EC2 fleet never uses.
+
+Outputs:
+  ClusterName:
+    Description: Name of the ECS cluster
+    Value: !Ref ECSCluster
+
+  TaskDefinitionArn:
+    Description: ARN of the task definition
+    Value: !Ref TaskDefinition
+
+  ServiceName:
+    Description: Name of the ECS service
+    Value: !GetAtt ECSService.Name
+
+  LogGroupName:
+    Description: Name of the CloudWatch Logs log group
+    Value: !Ref LogGroup


### PR DESCRIPTION
Closes #516
Closes #519

`parseCFNTemplate` unmarshalled YAML straight into the template struct, and
`go.yaml.in/yaml/v3` has no notion of CloudFormation's tag shorthands: it drops
the tag and keeps the node value. So `!Sub 'short-${P}'` reached the resolver as
the literal `short-${P}` — indistinguishable from a string the template really
did intend — and `!If [C, a, b]` arrived as the raw array `["C","a","b"]`, which
is what the reporting consumer saw stamped verbatim into an ECS task-definition
family. Nothing downstream was ever handed anything to resolve. The `Fn::` long
forms worked correctly throughout.

The fix decodes into a `yaml.Node`, whose `.Tag` survives, rewrites every
recognized shorthand into its long-form mapping, and decodes that. All eighteen
are handled, and the walk is **depth-first, children before parents**, because
the tags nest — `!Not [!Equals [!Ref VpcId, '']]` is three levels and is the most
common condition idiom in real templates. `!GetAtt` is the one irregular form
(dotted string, split on the *first* period only, per AWS's own
`myELB.SourceSecurityGroup.OwnerAlias` example). An unrecognized tag keeps its
value and logs a `WARN`: dropping it silently is the defect being fixed, and
refusing the template would reject one real CloudFormation accepts.

## Three defects behind it, each reachable only once the tags expand

- **`Fn::Sub`'s `${!Literal}` escape was never implemented.** The reporter's
  `ec2_worker.yml` contains `${!Count.Index}`, which would have resolved as a ref
  named `!Count.Index`. Unreachable before the expander, which is why it ships
  here.
- **`Default: ''` was treated as no default at all**, so the parameter was left
  undeclared and `Ref` echoed its own name back — which **inverts** the
  conventional `!Not [!Equals [!Ref X, '']]` optional-parameter test: a parameter
  the caller never set reads as set. 21 occurrences across the reporter's five
  templates. Found by deploying one of them as a checked-in fixture, not by
  reading the code.
- **Conditions were evaluated by iterating a Go map**, so a condition referencing
  another via `{"Condition": "Other"}` read the referent's zero value whenever it
  was reached first: the same template deployed differently from one run to the
  next, which is the one outcome an emulator built on deterministic replay must
  never produce. They now resolve on demand, and a cycle resolves to `false`.
  Names are additionally walked sorted, which matters only for a cycle running
  through `Fn::Not` — that resolves its two members to *opposite* values, so
  absent the sort the answer would still depend on map order.

## #519 — a refused resource was reported CREATE_COMPLETE

The deployer set a resource's error only when the dispatched request returned a
non-nil `error`, and never read the response status. Plugins signal a client
error two ways, both in wide use: S3 (58 sites) and IAM (162) return a 4xx
response with a nil error — the shape a real endpoint puts on the wire — while
EC2 (49), ECS (27), Logs (20) and SQS (5) return an `*AWSError`. Only the second
was inspected, so **every S3 and IAM resource failure in a stack was swallowed**.
That is #516's own reproduction: invalid bucket name, no bucket, and a stack
reporting success.

`cfnDispatchError` now derives the failure from either convention, applied
centrally in `dispatch` so all 31 recording sites became correct without being
individually edited, and lifts the plugin's own code out of the body so the
reason reads `InvalidBucketName: The specified bucket is not valid.` rather than
a status number. `deployS3Bucket` also stops discarding its response and returns
early rather than configuring versioning on a bucket that was refused — that
follow-up could not corrupt the recorded reason (its result was discarded too),
but it did put a `PUT ?versioning` refused with `NoSuchBucket` into the log
substrate replays.

Rollback is deliberately **not** changed: substrate records the failure per
resource and carries on where real CloudFormation would roll back. Filed as #520.

## Compatibility

**A resource that genuinely fails now reports `CREATE_FAILED` where it reported
`CREATE_COMPLETE`.** A test asserting the old status was asserting a defect, but
it will still turn red. Stack status is unchanged.

Expansion is not resolution: `!FindInMap`, `!ImportValue`, `!Cidr` and `!GetAZs`
now expand to long forms the resolver still ignores and hit the same fallback the
long forms already did (#522 — `Fn::FindInMap` needs a `Mappings` model the
template struct does not have). `Fn::Split` still yields only its first element
(#521). The docs say both, so "expanded" is not read as "resolved". None of the
reporter's templates use the four unresolved intrinsics; one does use `!Split`.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → 0
issues, `make test` (race), the docs targets, `npm --prefix docs run build`, and
the `test/e2e` module — all green. Every new or changed function is at 100%
statement coverage.

**Mutation testing**, 24 mutants: 23 caught. Four were worth more than a tally.
`native-tag-always-str` survived because the branch it mutated was unreachable —
resolved by deleting the code, not by adding a test. `conditions-unsorted-lazy-walk`
survived twice: the lazy accessor, not the sort, is what makes a *chain*
order-independent, so the sort is load-bearing only for a **negated cycle**, and
even with that case added the divergence appears in the member reached *second*,
which the test was not asserting. The remaining survivor is a genuine equivalence
with a written proof at the call site, settled by the AWS docs stating `Fn::If` is
not supported inside a `Conditions` entry.

End to end over the wire against both a fixed and a pre-fix binary, so the claims
are demonstrated in both directions: pre-fix gives `short-${p}`,
`["HasP","role-${P}","role-none"]` and `CREATE_COMPLETE` for the bad bucket;
post-fix gives `short-live`, `role-live`, the GetAtt ARN, the `${Count.Index}`
literal, and `CREATE_FAILED` / `InvalidBucketName`.
