### PR TITLE
fix(cloudformation): deploy a stack into the calling account and region (#517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defect, but it will still turn red. The stack status is unchanged, and substrate
   still does not roll back (#520).
 
+- **A stack now deploys into the calling account and region** (#517). The deployer
+  synthesized its own request context from substrate's package defaults —
+  `123456789012` and `us-east-1` — regardless of who created the stack. Most plugins
+  embed the account, and some the region, in their state keys
+  (`instance:<account>/<region>/<id>`, `table:<account>/<name>`,
+  `queue:<account>/<name>`, `topic:<account>/<region>/<name>`), so a caller in any
+  other partition got a stack ARN naming their own account whose resources were
+  written where they could not read them. An unsigned client — which resolves to
+  `000000000000` — created a stack reporting `CREATE_COMPLETE` with a
+  `PhysicalResourceId` of `i-…`, and `DescribeInstances` then correctly returned
+  nothing. **Every read scoped to the caller was right; the write was in the wrong
+  place.**
+
+  The reporting consumer read that as `AWS::EC2::*` being stubbed while
+  `AWS::IAM::*` worked, which is worth stating plainly because the asymmetry is real
+  but the diagnosis was not: S3 (`bucket:<name>`) and IAM (`role:<name>`) key their
+  state *unpartitioned*, so a resource written under the wrong identity is still
+  found by a read under the right one. Both families were fully implemented. That is
+  also why this survived #483's review — its shared-state test asserted a bucket
+  through S3 and a role through IAM, the only two services that could not see the
+  bug.
+
+  Identity now rides on the deployer as an explicit account and region, defaulting to
+  today's constants, and the CloudFormation plugin builds a deployer carrying the
+  requesting caller's identity for every path that deploys or reads a resource. A
+  deployer is six pointer copies with no I/O, so one per deploying request is cheaper
+  than making a single deployer's identity mutable and therefore racy. Two strings
+  rather than a whole request context, deliberately: a deployer holding one would
+  carry a single request's ID and timestamp across every resource it deploys, and
+  would invite a future reader to propagate the principal, which is a separate
+  decision (#411). Because the default is unchanged, no existing caller behaves
+  differently.
+
+  Six sites read that identity, and threading only the obvious one would have left a
+  half-fix. `dispatch` builds each resource's request context, so it is the write
+  path. Both `buildCFNContext` calls resolve `AWS::AccountId` and `AWS::Region`, so
+  before this a template whose bucket name was `{"Fn::Sub": "b-${AWS::AccountId}"}`
+  named substrate's account rather than the caller's — a defect neither the issue nor
+  the reporter named, and one that produced a *wrong physical name* rather than a
+  misplaced resource. And three drift comparators read their own partitioned state
+  keys directly (DynamoDB, SQS, SNS), which drift detection needs on top of the
+  existence checkers: a wrong-partition existence check reports `DELETED` for a
+  resource that is fine, and a wrong-partition comparator finds nothing to compare
+  and reports no difference at all — drift silently blind, which no `IN_SYNC`
+  assertion can distinguish from drift working.
+
+  `BettyClient` keeps the defaults, and that is a decision rather than an oversight:
+  it is the in-process validation client, its callers never sign a request, so there
+  is no caller whose identity could be threaded. Its deployer is now built through
+  the constructor rather than as a struct literal, so there is one construction path
+  and the default cannot drift away from it — the literal left both fields empty,
+  which was harmless only for as long as nothing read them. An in-process caller that
+  does need another partition can set the identity on the deployer directly.
+
+  The comment #483 left on the stack-ARN builder described this as a discrepancy
+  confined to the two pseudo-parameters. That understated it considerably and has
+  been rewritten.
+
 - **A parameter declared `Default: ''` is now a declared parameter** (#516). The
   empty string was treated as "no default at all", so such a parameter was left
   undeclared, `Ref` fell through to echoing the parameter's own name back, and the

--- a/docs/services.md
+++ b/docs/services.md
@@ -139,6 +139,31 @@ to the in-process API. There is one set of stacks.
 Deleting a stack's resource outside CloudFormation is the drift substrate models
 — `DescribeStackResourceDrifts` reports it as `DELETED`.
 
+#### A stack deploys into the calling account and region
+
+Most plugins scope a resource to the account, and some also to the region, of the
+request that created it. A stack's resources are created under the identity of the
+caller that created the stack, so they are visible to that caller's reads and no
+one else's:
+
+```
+# unsigned, so the caller is 000000000000
+aws --endpoint-url http://localhost:4566 cloudformation create-stack \
+  --stack-name acct --template-body '{"Resources":{"I":{"Type":"AWS::EC2::Instance",
+                     "Properties":{"ImageId":"ami-12345678","InstanceType":"t3.micro"}}}}'
+aws --endpoint-url http://localhost:4566 ec2 describe-instances   # 1 reservation
+aws --endpoint-url http://localhost:4566 --region eu-west-1 \
+  ec2 describe-instances                                          # 0 — a different partition
+```
+
+`AWS::AccountId` and `AWS::Region` resolve to the same caller, so a physical name
+built from either agrees with the stack ARN.
+
+The in-process `emulator.BettyClient` deploys into substrate's default partition
+(`123456789012` / `us-east-1`). Its callers never sign a request, so there is no
+caller identity to take; an in-process caller that needs another partition can set
+one on the deployer with `emulator.WithDeployerIdentity`.
+
 ### DeleteStack deletes the stack, not its resources
 
 `DeleteStack` removes the stack record and its name index. The resources the

--- a/emulator/betty.go
+++ b/emulator/betty.go
@@ -92,14 +92,17 @@ func NewBettyClient(
 func (b *BettyClient) Deploy(ctx context.Context, cfn string, intent Intent) (*DeployResult, error) {
 	b.intent = intent
 
-	deployer := &StackDeployer{
-		registry: b.registry,
-		store:    b.store,
-		state:    b.state,
-		tc:       b.tc,
-		logger:   b.logger,
-		costs:    b.costs,
-	}
+	// Built through the constructor rather than as a struct literal so there is one
+	// construction path and the deployer's defaults cannot drift away from it. A
+	// literal left the account and region empty, which was harmless until the
+	// deployer started reading them.
+	//
+	// No identity option: BettyClient is the in-process validation client and its
+	// callers never sign a request, so there is no caller whose identity could be
+	// threaded — substrate's defaults are the right answer here rather than a
+	// placeholder for one. An in-process caller that does need another partition
+	// can pass WithDeployerIdentity to NewStackDeployer directly.
+	deployer := NewStackDeployer(b.registry, b.store, b.state, b.tc, b.logger, b.costs)
 
 	streamID := fmt.Sprintf("deploy-%d", b.tc.Now().UnixNano())
 	result, err := deployer.Deploy(ctx, cfn, streamID, nil)

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -354,6 +354,18 @@ var typePriority = map[string]int{
 	"AWS::Athena::WorkGroup":             2,
 }
 
+// cfnIdentity is the AWS account and region a StackDeployer deploys into.
+//
+// Two strings rather than a whole *RequestContext: a deployer that carried one
+// would carry a single request's ID and timestamp across every resource it
+// deploys, which is wrong — each dispatch generates its own — and would invite a
+// future reader to propagate Principal, which is a separate decision about how
+// stack-deployed requests are authorized.
+type cfnIdentity struct {
+	accountID string
+	region    string
+}
+
 // StackDeployer parses and deploys a CloudFormation template using in-process
 // plugin dispatch.
 type StackDeployer struct {
@@ -363,18 +375,55 @@ type StackDeployer struct {
 	tc       *TimeController
 	logger   Logger
 	costs    *CostController
+
+	// identity is the account and region every request this deployer dispatches
+	// is made under, and which the AWS::AccountId and AWS::Region
+	// pseudo-parameters resolve to. It defaults to substrate's own defaults; see
+	// WithDeployerIdentity for why a caller would set it.
+	identity cfnIdentity
+}
+
+// StackDeployerOption configures optional behavior of a [StackDeployer].
+type StackDeployerOption func(*StackDeployer)
+
+// WithDeployerIdentity sets the AWS account and region the deployer deploys
+// into.
+//
+// Without it a deployer uses substrate's default account and region, which is
+// right for an in-process caller that never signs a request but wrong for one
+// reached over the wire: a request signed for another account created a stack
+// whose ARN named that account while every resource in it was written into
+// substrate's default partition. Most state keys embed the account and region
+// (EC2 instances, ECS clusters, log groups), so those resources were invisible
+// to the very caller that had just created them — DescribeInstances correctly
+// reported nothing.
+//
+// Passing the caller's identity is what keeps the stack ARN and the resources
+// inside it in one partition.
+func WithDeployerIdentity(accountID, region string) StackDeployerOption {
+	return func(d *StackDeployer) {
+		d.identity = cfnIdentity{accountID: accountID, region: region}
+	}
 }
 
 // NewStackDeployer creates a StackDeployer wired to the provided dependencies.
-func NewStackDeployer(registry *PluginRegistry, store *EventStore, state StateManager, tc *TimeController, logger Logger, costs *CostController) *StackDeployer {
-	return &StackDeployer{
+//
+// The deployer deploys into substrate's default account and region unless
+// [WithDeployerIdentity] says otherwise.
+func NewStackDeployer(registry *PluginRegistry, store *EventStore, state StateManager, tc *TimeController, logger Logger, costs *CostController, opts ...StackDeployerOption) *StackDeployer {
+	d := &StackDeployer{
 		registry: registry,
 		store:    store,
 		state:    state,
 		tc:       tc,
 		logger:   logger,
 		costs:    costs,
+		identity: cfnIdentity{accountID: testAccountID, region: defaultRegion},
 	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
 }
 
 // Deploy parses cfn and deploys all resources, returning a DeployResult.
@@ -391,7 +440,7 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 	start := d.tc.Now()
 
 	// Build resolution context.
-	cctx := buildCFNContext(tmpl, params, defaultRegion, testAccountID, stackName)
+	cctx := buildCFNContext(tmpl, params, d.identity.region, d.identity.accountID, stackName)
 	evaluateConditions(tmpl, cctx)
 
 	// Sort logical IDs by type priority, then alphabetically for stability.
@@ -746,7 +795,7 @@ func (d *StackDeployer) DetectStackDrift(ctx context.Context, stackName string) 
 
 		checker, ok := cfnDriftCheckers[dr.Type]
 		if ok {
-			exists := checker(d, ctx, testAccountID, defaultRegion, dr.PhysicalID)
+			exists := checker(d, ctx, d.identity.accountID, d.identity.region, dr.PhysicalID)
 			switch {
 			case !exists:
 				entry.DriftStatus = "DELETED"
@@ -1022,7 +1071,7 @@ func (d *StackDeployer) cfnDriftResourceProps(stack *CFNStackState, dr DeployedR
 	if !ok {
 		return nil, nil, false
 	}
-	cctx := buildCFNContext(tmpl, stack.Parameters, defaultRegion, testAccountID, stack.StackName)
+	cctx := buildCFNContext(tmpl, stack.Parameters, d.identity.region, d.identity.accountID, stack.StackName)
 	evaluateConditions(tmpl, cctx)
 	return res.Properties, cctx, true
 }
@@ -1071,7 +1120,7 @@ func compareDynamoDBTableDrift(ctx context.Context, d *StackDeployer, stack *CFN
 	if !ok {
 		return nil
 	}
-	data, _ := d.state.Get(ctx, "dynamodb", "table:"+testAccountID+"/"+dr.PhysicalID)
+	data, _ := d.state.Get(ctx, "dynamodb", "table:"+d.identity.accountID+"/"+dr.PhysicalID)
 	if data == nil {
 		return nil
 	}
@@ -1211,7 +1260,7 @@ func compareSQSQueueDrift(ctx context.Context, d *StackDeployer, stack *CFNStack
 	if !ok {
 		return nil
 	}
-	data, _ := d.state.Get(ctx, "sqs", "queue:"+testAccountID+"/"+dr.PhysicalID)
+	data, _ := d.state.Get(ctx, "sqs", "queue:"+d.identity.accountID+"/"+dr.PhysicalID)
 	if data == nil {
 		return nil
 	}
@@ -1257,7 +1306,7 @@ func compareSNSTopicDrift(ctx context.Context, d *StackDeployer, stack *CFNStack
 		return nil
 	}
 	name := snsTopicNameFromPhysicalID(dr.PhysicalID)
-	data, _ := d.state.Get(ctx, "sns", "topic:"+testAccountID+"/"+defaultRegion+"/"+name)
+	data, _ := d.state.Get(ctx, "sns", "topic:"+d.identity.accountID+"/"+d.identity.region+"/"+name)
 	if data == nil {
 		return nil
 	}
@@ -2868,8 +2917,8 @@ func (d *StackDeployer) dispatch(
 ) (*AWSResponse, float64, error) {
 	reqCtx := &RequestContext{
 		RequestID: generateRequestID(),
-		AccountID: testAccountID,
-		Region:    defaultRegion,
+		AccountID: d.identity.accountID,
+		Region:    d.identity.region,
 		Timestamp: d.tc.Now(),
 		Metadata:  map[string]interface{}{"stream_id": streamID},
 	}

--- a/emulator/cloudformation_identity_test.go
+++ b/emulator/cloudformation_identity_test.go
@@ -1,0 +1,719 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The tests in this file are #517's gate, and their design is driven by why #517
+// survived #483's review.
+//
+// #483 shipped a shared-state test (TestCFNPlugin_StackSharesStateWithOtherPlugins)
+// asserting a stack's bucket through the S3 plugin and its role through IAM. Both
+// of those plugins key their state *unpartitioned* — "bucket:<name>",
+// "role:<name>" — so a resource written under the wrong account and region is
+// still found by a read under the right one. The stack's resources were being
+// written into substrate's default partition regardless of who asked, and that test
+// could not see it.
+//
+// EC2, ECS, CloudWatch Logs, DynamoDB, SQS and SNS embed the account — and for
+// some of them the region — in their state keys. Those are the only honest
+// subjects for this fix, so every case below uses one.
+
+// newCFNIdentityTestServer builds a server with CloudFormation registered
+// alongside the *partitioned* plugins: EC2, ECS, CloudWatch Logs, DynamoDB, SQS
+// and SNS. S3 and IAM are deliberately absent — a stack whose resources are all
+// unpartitioned cannot distinguish a threaded identity from a hardcoded one.
+func newCFNIdentityTestServer(t *testing.T) *cfnTestServer {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	registry := emulator.NewPluginRegistry()
+
+	opts := emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"filesystem":      afero.NewMemMapFs(),
+			"registry":        registry,
+		},
+	}
+	for _, p := range []emulator.Plugin{
+		&emulator.EC2Plugin{},
+		&emulator.ECSPlugin{},
+		&emulator.CloudWatchLogsPlugin{},
+		// DynamoDB, SQS and SNS are here for the drift cases alone: drift needs a
+		// resource type with an existence checker, and of those types these three
+		// are the partitioned ones. EC2 instances have no checker, so a stack of
+		// them reports NOT_CHECKED and could not tell the partitions apart.
+		&emulator.DynamoDBPlugin{},
+		&emulator.SQSPlugin{},
+		&emulator.SNSPlugin{},
+	} {
+		require.NoError(t, p.Initialize(context.Background(), opts))
+		registry.Register(p)
+	}
+
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
+	cfnp := &emulator.CloudFormationPlugin{}
+	require.NoError(t, cfnp.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"registry":        registry,
+			"event_store":     store,
+		},
+	}))
+	registry.Register(cfnp)
+
+	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger,
+		emulator.ServerOptions{Costs: emulator.NewCostController(emulator.CostConfig{Enabled: true})})
+
+	return &cfnTestServer{srv: srv, state: state, registry: registry, tc: tc}
+}
+
+// cfnIdentityRequest posts a query-protocol request to any service, optionally
+// signed and optionally to a non-default region, so a test can vary exactly the
+// two things #517 is about.
+//
+// An empty authHeader means an unsigned request, which resolves to the fallback
+// account 000000000000 — the identity #517's reporter had, since their client
+// signed nothing.
+func cfnIdentityRequest(t *testing.T, ts *cfnTestServer, service, region, authHeader string, params map[string]string) (int, string) {
+	t.Helper()
+	form := url.Values{}
+	for k, v := range params {
+		form.Set(k, v)
+	}
+	host := service + "." + region + ".amazonaws.com"
+	r := httptest.NewRequest(http.MethodPost, "http://"+host+"/", strings.NewReader(form.Encode()))
+	r.Host = host
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if authHeader != "" {
+		r.Header.Set("Authorization", authHeader)
+	}
+	w := httptest.NewRecorder()
+	ts.srv.ServeHTTP(w, r)
+	return w.Code, w.Body.String()
+}
+
+// cfnJSONRequest posts a JSON-protocol request, for the services that use one
+// (ECS and CloudWatch Logs).
+func cfnJSONRequest(t *testing.T, ts *cfnTestServer, service, region, target, authHeader, body string) (int, string) {
+	t.Helper()
+	host := service + "." + region + ".amazonaws.com"
+	r := httptest.NewRequest(http.MethodPost, "http://"+host+"/", strings.NewReader(body))
+	r.Host = host
+	r.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	r.Header.Set("X-Amz-Target", target)
+	if authHeader != "" {
+		r.Header.Set("Authorization", authHeader)
+	}
+	w := httptest.NewRecorder()
+	ts.srv.ServeHTTP(w, r)
+	return w.Code, w.Body.String()
+}
+
+// signedAuthHeader builds an AKIA-signed Authorization header, which resolves to
+// the well-known test account 123456789012.
+func signedAuthHeader(service, region string) string {
+	return "AWS4-HMAC-SHA256 Credential=AKIATEST1234567890/20260101/" +
+		region + "/" + service + "/aws4_request, SignedHeaders=host, Signature=fake"
+}
+
+// cfnXMLValue extracts the text of the first tag element in an XML body. Enough
+// for a single-valued response field, and it keeps these tests reading as the
+// wire assertions they are rather than as unmarshalling exercises.
+func cfnXMLValue(t *testing.T, body, tag string) string {
+	t.Helper()
+	open, close := "<"+tag+">", "</"+tag+">"
+	i := strings.Index(body, open)
+	require.GreaterOrEqual(t, i, 0, "no %s in %s", tag, body)
+	rest := body[i+len(open):]
+	j := strings.Index(rest, close)
+	require.GreaterOrEqual(t, j, 0, "unterminated %s in %s", tag, body)
+	return rest[:j]
+}
+
+// cfnPhysicalID extracts the PhysicalResourceId of a stack's single resource from
+// a DescribeStackResources body.
+func cfnPhysicalID(t *testing.T, body string) string {
+	t.Helper()
+	return cfnXMLValue(t, body, "PhysicalResourceId")
+}
+
+const cfnInstanceTemplate = `{"Resources":{"I":{"Type":"AWS::EC2::Instance",` +
+	`"Properties":{"ImageId":"ami-12345678","InstanceType":"t3.micro"}}}}`
+
+// TestCFNIdentity_UnsignedCallerFindsItsOwnInstance is #517's reproduction, and
+// it fails before the fix.
+//
+// An unsigned request resolves to account 000000000000. The stack ARN named that
+// account, but the deployer dispatched RunInstances under substrate's default
+// 123456789012, and the EC2 plugin keys an instance by account and region — so
+// DescribeInstances, correctly scoped to the caller, reported nothing. The
+// reporter read that as EC2 support being stubbed out; it was a partition split.
+func TestCFNIdentity_UnsignedCallerFindsItsOwnInstance(t *testing.T) {
+	ts := newCFNIdentityTestServer(t)
+
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action":       "CreateStack",
+		"Version":      "2010-05-15",
+		"StackName":    "unsigned",
+		"TemplateBody": cfnInstanceTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, ":000000000000:stack/unsigned",
+		"the stack ARN should name the unsigned caller's account")
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action":    "DescribeStackResources",
+		"Version":   "2010-05-15",
+		"StackName": "unsigned",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	instanceID := cfnPhysicalID(t, body)
+	require.True(t, strings.HasPrefix(instanceID, "i-"), "physical ID was %q", instanceID)
+
+	// The gate: the same caller that created the stack must see the instance.
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+		"Action":  "DescribeInstances",
+		"Version": "2016-11-15",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, instanceID,
+		"the unsigned caller's DescribeInstances must find the instance its own stack created")
+
+	// And by ID, which is the lookup that answered InvalidInstanceID.NotFound.
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+		"Action":       "DescribeInstances",
+		"Version":      "2016-11-15",
+		"InstanceId.1": instanceID,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.NotContains(t, body, "InvalidInstanceID.NotFound")
+	assert.Contains(t, body, instanceID)
+}
+
+// TestCFNIdentity_PartitionedServices covers one resource per service family the
+// reporter named. Each of these plugins embeds the account and region in its state
+// key, so each is a resource that vanished; S3 and IAM would pass either way.
+func TestCFNIdentity_PartitionedServices(t *testing.T) {
+	cases := []struct {
+		name     string
+		tmpl     string
+		wantID   string
+		readBack func(t *testing.T, ts *cfnTestServer) (int, string)
+	}{
+		{
+			name: "ECSCluster",
+			tmpl: `{"Resources":{"C":{"Type":"AWS::ECS::Cluster",` +
+				`"Properties":{"ClusterName":"identity-cluster"}}}}`,
+			wantID: "identity-cluster",
+			readBack: func(t *testing.T, ts *cfnTestServer) (int, string) {
+				return cfnJSONRequest(t, ts, "ecs", "us-east-1",
+					"AmazonEC2ContainerServiceV20141113.ListClusters", "", `{}`)
+			},
+		},
+		{
+			name: "LogsLogGroup",
+			tmpl: `{"Resources":{"G":{"Type":"AWS::Logs::LogGroup",` +
+				`"Properties":{"LogGroupName":"/identity/group"}}}}`,
+			wantID: "/identity/group",
+			readBack: func(t *testing.T, ts *cfnTestServer) (int, string) {
+				return cfnJSONRequest(t, ts, "logs", "us-east-1",
+					"Logs_20140328.DescribeLogGroups", "", `{}`)
+			},
+		},
+		{
+			name: "EC2LaunchTemplate",
+			tmpl: `{"Resources":{"T":{"Type":"AWS::EC2::LaunchTemplate",` +
+				`"Properties":{"LaunchTemplateName":"identity-lt",` +
+				`"LaunchTemplateData":{"ImageId":"ami-12345678","InstanceType":"t3.micro"}}}}}`,
+			wantID: "identity-lt",
+			readBack: func(t *testing.T, ts *cfnTestServer) (int, string) {
+				return cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+					"Action":  "DescribeLaunchTemplates",
+					"Version": "2016-11-15",
+				})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newCFNIdentityTestServer(t)
+
+			code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+				"Action":       "CreateStack",
+				"Version":      "2010-05-15",
+				"StackName":    "partitioned",
+				"TemplateBody": tc.tmpl,
+			})
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+			code, body = tc.readBack(t, ts)
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+			assert.Contains(t, body, tc.wantID,
+				"the unsigned caller must see the resource its own stack created")
+		})
+	}
+}
+
+// TestCFNIdentity_NonDefaultRegion is the case that a caller in substrate's own
+// default account still exercises: partitioning is by account *and* region, so a
+// stack created in eu-west-1 has to land in eu-west-1 and be absent from
+// us-east-1. A test that only ever used the default region would pass with the
+// region hardcoded.
+func TestCFNIdentity_NonDefaultRegion(t *testing.T) {
+	ts := newCFNIdentityTestServer(t)
+
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1",
+		signedAuthHeader("cloudformation", "eu-west-1"), map[string]string{
+			"Action":       "CreateStack",
+			"Version":      "2010-05-15",
+			"StackName":    "euwest",
+			"TemplateBody": cfnInstanceTemplate,
+		})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "arn:aws:cloudformation:eu-west-1:")
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1",
+		signedAuthHeader("cloudformation", "eu-west-1"), map[string]string{
+			"Action":    "DescribeStackResources",
+			"Version":   "2010-05-15",
+			"StackName": "euwest",
+		})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	instanceID := cfnPhysicalID(t, body)
+
+	code, body = cfnIdentityRequest(t, ts, "ec2", "eu-west-1",
+		signedAuthHeader("ec2", "eu-west-1"), map[string]string{
+			"Action": "DescribeInstances", "Version": "2016-11-15",
+		})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, instanceID, "the instance belongs to eu-west-1")
+
+	// Absent from another region, which is the half that proves partitioning still
+	// holds rather than having been widened away.
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1",
+		signedAuthHeader("ec2", "us-east-1"), map[string]string{
+			"Action": "DescribeInstances", "Version": "2016-11-15",
+		})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.NotContains(t, body, instanceID,
+		"a eu-west-1 instance must not be visible in us-east-1")
+}
+
+// TestCFNIdentity_SignedAndUnsignedAreIsolated pins that the fix threads identity
+// rather than widening a lookup. The same template deployed by a signed caller
+// (123456789012) and an unsigned one (000000000000) yields two instances, each
+// visible only to the caller that created it.
+func TestCFNIdentity_SignedAndUnsignedAreIsolated(t *testing.T) {
+	ts := newCFNIdentityTestServer(t)
+	signed := signedAuthHeader("cloudformation", "us-east-1")
+
+	create := func(auth, stackName string) string {
+		code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", auth,
+			map[string]string{
+				"Action": "CreateStack", "Version": "2010-05-15",
+				"StackName": stackName, "TemplateBody": cfnInstanceTemplate,
+			})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", auth,
+			map[string]string{
+				"Action": "DescribeStackResources", "Version": "2010-05-15",
+				"StackName": stackName,
+			})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		return cfnPhysicalID(t, body)
+	}
+
+	signedID := create(signed, "by-signed")
+	unsignedID := create("", "by-unsigned")
+	require.NotEqual(t, signedID, unsignedID, "two stacks, two instances")
+
+	describe := func(auth string) string {
+		code, body := cfnIdentityRequest(t, ts, "ec2", "us-east-1", auth,
+			map[string]string{"Action": "DescribeInstances", "Version": "2016-11-15"})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		return body
+	}
+
+	signedView := describe(signedAuthHeader("ec2", "us-east-1"))
+	assert.Contains(t, signedView, signedID)
+	assert.NotContains(t, signedView, unsignedID,
+		"the signed caller must not see the unsigned caller's instance")
+
+	unsignedView := describe("")
+	assert.Contains(t, unsignedView, unsignedID)
+	assert.NotContains(t, unsignedView, signedID,
+		"the unsigned caller must not see the signed caller's instance")
+}
+
+// TestCFNIdentity_PseudoParametersMatchTheStackARN is the buildCFNContext half of
+// the fix, and it fails if only dispatch is threaded.
+//
+// AWS::AccountId and AWS::Region were resolved against substrate's defaults too,
+// from a second hardcode neither issue named. A template naming itself after its
+// own account and region would disagree with the stack ARN reported by the very
+// call that created it.
+func TestCFNIdentity_PseudoParametersMatchTheStackARN(t *testing.T) {
+	ts := newCFNIdentityTestServer(t)
+
+	tmpl := `{"Resources":{"G":{"Type":"AWS::Logs::LogGroup","Properties":{
+		"LogGroupName":{"Fn::Sub":"/g-${AWS::AccountId}-${AWS::Region}"}}}}}`
+
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1", "", map[string]string{
+		"Action": "CreateStack", "Version": "2010-05-15",
+		"StackName": "pseudo", "TemplateBody": tmpl,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	require.Contains(t, body, "arn:aws:cloudformation:eu-west-1:000000000000:stack/pseudo",
+		"the stack ARN names the caller")
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1", "", map[string]string{
+		"Action": "DescribeStackResources", "Version": "2010-05-15",
+		"StackName": "pseudo",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Equal(t, "/g-000000000000-eu-west-1", cfnPhysicalID(t, body),
+		"the pseudo-parameters must resolve to the caller's identity, not substrate's defaults")
+}
+
+// TestCFNIdentity_DriftFindsTheCallersResources pins the drift paths, which
+// resolve each resource by the same partitioned state key. Left on the default
+// identity they would report every resource of another caller's stack as DELETED —
+// a false drift report, which is worse than none.
+//
+// The table covers all three drift-checkable types whose state keys are
+// partitioned. EC2 instances are not among them: they have no existence checker
+// and report NOT_CHECKED, which would pass whichever partition drift looked in.
+//
+// Each case asserts IN_SYNC *and then* MODIFIED, because they fail differently. A
+// wrong-partition existence check finds nothing and reports DELETED — loud. A
+// wrong-partition comparator finds nothing, compares nothing, and reports no
+// difference — drift silently blind, which IN_SYNC alone cannot distinguish from
+// drift working. Both reads are separately hardcoded, so both are asserted.
+func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
+	// A non-default region throughout, because the SNS key embeds the region as
+	// well as the account: run in us-east-1 and a comparator that threaded only the
+	// account would still find the topic, since us-east-1 is substrate's default.
+	const region = "eu-west-1"
+
+	cases := []struct {
+		name string
+		tmpl string
+		// namespace and key locate the resource in the *unsigned* caller's
+		// partition, which is where it must be for drift to have any chance.
+		namespace string
+		key       string
+		// mutate changes the live resource behind CloudFormation's back, which is
+		// the drift substrate models.
+		mutate   func(m map[string]any)
+		wantPath string
+	}{
+		{
+			name: "DynamoDBTable",
+			tmpl: `{"Resources":{"T":{"Type":"AWS::DynamoDB::Table","Properties":{
+				"TableName":"drift-table","BillingMode":"PAY_PER_REQUEST",
+				"KeySchema":[{"AttributeName":"pk","KeyType":"HASH"}],
+				"AttributeDefinitions":[{"AttributeName":"pk","AttributeType":"S"}]}}}}`,
+			namespace: "dynamodb",
+			key:       "table:000000000000/drift-table",
+			mutate: func(m map[string]any) {
+				m["BillingModeSummary"] = map[string]any{"BillingMode": "PROVISIONED"}
+			},
+			wantPath: "/BillingMode",
+		},
+		{
+			name: "SQSQueue",
+			tmpl: `{"Resources":{"Q":{"Type":"AWS::SQS::Queue","Properties":{
+				"QueueName":"drift-queue","VisibilityTimeout":45}}}}`,
+			namespace: "sqs",
+			key:       "queue:000000000000/drift-queue",
+			mutate: func(m map[string]any) {
+				attrs, _ := m["Attributes"].(map[string]any)
+				if attrs == nil {
+					attrs = map[string]any{}
+				}
+				attrs["VisibilityTimeout"] = "90"
+				m["Attributes"] = attrs
+			},
+			wantPath: "/VisibilityTimeout",
+		},
+		{
+			// The only comparator keyed by region as well as account, so it is the
+			// one that would survive threading the account alone.
+			//
+			// Its DisplayName carries both pseudo-parameters on purpose. A comparator
+			// reads the live value from state but resolves the *expected* value out
+			// of the template, through a context built separately from the deploy
+			// path's — a third identity read, and the only place either
+			// pseudo-parameter is resolved twice. Deploy stamps
+			// "000000000000 in eu-west-1"; a comparator resolving against the
+			// defaults expects "123456789012 in us-east-1" and reports MODIFIED on a
+			// topic nobody touched. A false drift report is the failure mode, so the
+			// IN_SYNC half of this case is what pins it.
+			name: "SNSTopic",
+			tmpl: `{"Resources":{"Tp":{"Type":"AWS::SNS::Topic","Properties":{
+				"TopicName":"drift-topic",
+				"DisplayName":{"Fn::Sub":"${AWS::AccountId} in ${AWS::Region}"}}}}}`,
+			namespace: "sns",
+			key:       "topic:000000000000/" + region + "/drift-topic",
+			mutate: func(m map[string]any) {
+				m["Attributes"] = map[string]any{"DisplayName": "Renamed"}
+			},
+			wantPath: "/DisplayName",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newCFNIdentityTestServer(t)
+
+			code, body := cfnIdentityRequest(t, ts, "cloudformation", region, "",
+				map[string]string{
+					"Action": "CreateStack", "Version": "2010-05-15",
+					"StackName": "drift", "TemplateBody": tc.tmpl,
+				})
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+			drifts := func() string {
+				code, body := cfnIdentityRequest(t, ts, "cloudformation", region, "",
+					map[string]string{
+						"Action": "DescribeStackResourceDrifts", "Version": "2010-05-15",
+						"StackName": "drift",
+					})
+				require.Equal(t, http.StatusOK, code, "body was %s", body)
+				return body
+			}
+
+			body = drifts()
+			assert.Contains(t, body, "<StackResourceDriftStatus>IN_SYNC</StackResourceDriftStatus>",
+				"the resource exists, so it is in sync; DELETED means the existence "+
+					"check looked in the wrong partition")
+			assert.NotContains(t, body, "DELETED")
+
+			// DetectStackDrift is the asynchronous sibling and a separate handler.
+			// It reports no per-resource statuses, only a count and a stack-level
+			// verdict, so its own assertion is the count: on the wrong identity
+			// every resource reads as DELETED and the stack comes back DRIFTED.
+			code, body = cfnIdentityRequest(t, ts, "cloudformation", region, "",
+				map[string]string{
+					"Action": "DetectStackDrift", "Version": "2010-05-15",
+					"StackName": "drift",
+				})
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+			detectionID := cfnXMLValue(t, body, "StackDriftDetectionId")
+
+			code, body = cfnIdentityRequest(t, ts, "cloudformation", region, "",
+				map[string]string{
+					"Action": "DescribeStackDriftDetectionStatus", "Version": "2010-05-15",
+					"StackDriftDetectionId": detectionID,
+				})
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+			assert.Contains(t, body, "<DetectionStatus>DETECTION_COMPLETE</DetectionStatus>")
+			assert.Contains(t, body, "<StackDriftStatus>IN_SYNC</StackDriftStatus>",
+				"detection must look in the partition the resource was deployed into")
+			assert.Contains(t, body, "<DriftedStackResourceCount>0</DriftedStackResourceCount>")
+
+			raw, err := ts.state.Get(context.Background(), tc.namespace, tc.key)
+			require.NoError(t, err)
+			require.NotNil(t, raw, "the resource must be in the unsigned caller's partition")
+			var live map[string]any
+			require.NoError(t, json.Unmarshal(raw, &live))
+			tc.mutate(live)
+			mutated, err := json.Marshal(live)
+			require.NoError(t, err)
+			require.NoError(t, ts.state.Put(context.Background(), tc.namespace, tc.key, mutated))
+
+			body = drifts()
+			assert.Contains(t, body, "<StackResourceDriftStatus>MODIFIED</StackResourceDriftStatus>",
+				"the comparator must read the partition the resource is in")
+			assert.Contains(t, body, "<PropertyPath>"+tc.wantPath+"</PropertyPath>")
+		})
+	}
+}
+
+// TestCFNIdentity_ExecuteChangeSetUsesTheExecutingCaller covers the third
+// deploying entry point. ExecuteChangeSet routes through UpdateStack to Deploy, so
+// it creates resources and needs the caller's identity exactly as CreateStack
+// does — and it is the path a CDK deploy actually takes.
+func TestCFNIdentity_ExecuteChangeSetUsesTheExecutingCaller(t *testing.T) {
+	ts := newCFNIdentityTestServer(t)
+
+	// A stack to change: created empty so the change set is what deploys the
+	// instance.
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "CreateStack", "Version": "2010-05-15",
+		"StackName": "cs", "TemplateBody": `{"Resources":{}}`,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "CreateChangeSet", "Version": "2010-05-15",
+		"StackName": "cs", "ChangeSetName": "add-instance",
+		"TemplateBody": cfnInstanceTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "ExecuteChangeSet", "Version": "2010-05-15",
+		"StackName": "cs", "ChangeSetName": "add-instance",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "DescribeStackResources", "Version": "2010-05-15", "StackName": "cs",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	instanceID := cfnPhysicalID(t, body)
+
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+		"Action": "DescribeInstances", "Version": "2016-11-15",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, instanceID,
+		"an instance created by executing a change set belongs to the caller that executed it")
+}
+
+// TestCFNIdentity_UpdateStackUsesTheUpdatingCaller covers UpdateStack as its own
+// entry point rather than through a change set.
+//
+// The change-set test above reaches UpdateStack indirectly, so it would pass with
+// UpdateStack itself left on the default identity as long as ExecuteChangeSet were
+// threaded. Adding a resource by updating a stack directly is what a
+// `aws cloudformation update-stack` or a Terraform-managed template does, and it
+// has to land in the caller's partition too.
+func TestCFNIdentity_UpdateStackUsesTheUpdatingCaller(t *testing.T) {
+	ts := newCFNIdentityTestServer(t)
+
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "CreateStack", "Version": "2010-05-15",
+		"StackName": "upd", "TemplateBody": `{"Resources":{}}`,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "UpdateStack", "Version": "2010-05-15",
+		"StackName": "upd", "TemplateBody": cfnInstanceTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "DescribeStackResources", "Version": "2010-05-15", "StackName": "upd",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	instanceID := cfnPhysicalID(t, body)
+	require.True(t, strings.HasPrefix(instanceID, "i-"), "physical ID was %q", instanceID)
+
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+		"Action": "DescribeInstances", "Version": "2016-11-15",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, instanceID,
+		"an instance added by an update belongs to the caller that updated the stack")
+}
+
+// TestCFNIdentity_UnpartitionedServicesStillWork is the regression guard for
+// #483's own test. S3 and IAM keys carry no account or region, so they worked
+// before the fix and must keep working after it: the fix threads identity, and
+// must not have made an unpartitioned lookup depend on one.
+func TestCFNIdentity_UnpartitionedServicesStillWork(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "unpartitioned",
+		"TemplateBody": cfnBucketRoleTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	// Read back as an *unsigned* caller, which is a different account from the
+	// signed one that created the stack. An unpartitioned key is found anyway,
+	// which is the pre-existing behavior this fix must not change.
+	head := httptest.NewRequest(http.MethodHead, "http://s3.amazonaws.com/cfn-shared-bucket", nil)
+	head.Host = "s3.amazonaws.com"
+	hw := httptest.NewRecorder()
+	ts.srv.ServeHTTP(hw, head)
+	assert.Equal(t, http.StatusOK, hw.Code,
+		"an S3 bucket is keyed without an account, so it is visible across partitions")
+}
+
+// TestCFNIdentity_InProcessDeployerDefaultsToSubstratesOwn pins the recorded
+// decision that a deployer built without an identity uses substrate's defaults.
+//
+// BettyClient is the in-process validation client and its callers never sign a
+// request, so there is no caller identity to thread — the defaults are the answer
+// rather than a placeholder for one. The default is load-bearing: were it the zero
+// value, every in-process deploy would write into account "" and the resources
+// would be unreachable from any read.
+func TestCFNIdentity_InProcessDeployerDefaultsToSubstratesOwn(t *testing.T) {
+	ts := newCFNIdentityTestServer(t)
+
+	d := emulator.NewStackDeployer(ts.registry,
+		emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false}),
+		ts.state, ts.tc, emulator.NewDefaultLogger(slog.LevelError, false),
+		emulator.NewCostController(emulator.CostConfig{Enabled: false}))
+
+	result, err := d.Deploy(context.Background(), cfnInstanceTemplate, "in-process", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.Empty(t, result.Resources[0].Error)
+	instanceID := result.Resources[0].PhysicalID
+
+	// Visible to a default-partition read: signed (123456789012) in us-east-1.
+	code, body := cfnIdentityRequest(t, ts, "ec2", "us-east-1",
+		signedAuthHeader("ec2", "us-east-1"), map[string]string{
+			"Action": "DescribeInstances", "Version": "2016-11-15",
+		})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, instanceID,
+		"an in-process deploy lands in substrate's default partition")
+}
+
+// TestCFNIdentity_ExplicitIdentityOverridesTheDefault pins the option itself, so
+// an in-process caller that does need another partition has a seam and it is
+// tested. This is what the BettyClient comment points at.
+func TestCFNIdentity_ExplicitIdentityOverridesTheDefault(t *testing.T) {
+	ts := newCFNIdentityTestServer(t)
+
+	d := emulator.NewStackDeployer(ts.registry,
+		emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false}),
+		ts.state, ts.tc, emulator.NewDefaultLogger(slog.LevelError, false),
+		emulator.NewCostController(emulator.CostConfig{Enabled: false}),
+		emulator.WithDeployerIdentity("999988887777", "ap-southeast-2"))
+
+	tmpl := `{"Resources":{"G":{"Type":"AWS::Logs::LogGroup","Properties":{
+		"LogGroupName":{"Fn::Sub":"/g-${AWS::AccountId}-${AWS::Region}"}}}}}`
+	result, err := d.Deploy(context.Background(), tmpl, "explicit", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.Empty(t, result.Resources[0].Error)
+	assert.Equal(t, "/g-999988887777-ap-southeast-2", result.Resources[0].PhysicalID,
+		"the option must reach the pseudo-parameters as well as the dispatch")
+
+	// And the log group is in that partition, not the default one.
+	code, body := cfnJSONRequest(t, ts, "logs", "us-east-1",
+		"Logs_20140328.DescribeLogGroups", signedAuthHeader("logs", "us-east-1"), `{}`)
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.NotContains(t, body, "/g-999988887777-ap-southeast-2",
+		"a default-partition read must not see it")
+}

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -32,10 +32,36 @@ const cfnXMLNS = "http://cloudformation.amazonaws.com/doc/2010-05-15/"
 // real resources in the other plugins: the bucket in an AWS::S3::Bucket is a
 // bucket the S3 plugin serves, not a private CloudFormation-only record.
 type CloudFormationPlugin struct {
-	state    StateManager
-	logger   Logger
-	tc       *TimeController
+	state  StateManager
+	logger Logger
+	tc     *TimeController
+
+	// deployer serves the paths that touch no resource: the stack and change-set
+	// records themselves, which are stored unpartitioned, so its identity never
+	// matters. CreateChangeSet is among them — it parses and diffs two templates
+	// without dispatching anything. Every path that deploys or reads a resource
+	// uses deployerFor instead.
 	deployer *StackDeployer
+
+	// registry, store and costs are kept so deployerFor can build a deployer
+	// carrying the requesting caller's identity. A deployer is six pointer copies
+	// with no I/O, so building one per deploying request is cheaper than the
+	// alternative of making one deployer's identity mutable and therefore racy.
+	registry *PluginRegistry
+	store    *EventStore
+	costs    *CostController
+}
+
+// deployerFor returns a [StackDeployer] that deploys into the requesting
+// caller's account and region.
+//
+// Identity is a property of the request, not of the plugin, so it cannot be fixed
+// at Initialize time. A caller signing for another account used to get a stack
+// whose ARN named that account while the resources inside it were written into
+// substrate's defaults, which put them in a partition that caller could not read.
+func (p *CloudFormationPlugin) deployerFor(reqCtx *RequestContext) *StackDeployer {
+	return NewStackDeployer(p.registry, p.store, p.state, p.tc, p.logger, p.costs,
+		WithDeployerIdentity(reqCtx.AccountID, reqCtx.Region))
 }
 
 // Name returns the service name "cloudformation".
@@ -76,6 +102,9 @@ func (p *CloudFormationPlugin) Initialize(_ context.Context, cfg PluginConfig) e
 		costs = NewCostController(CostConfig{Enabled: false})
 	}
 
+	p.registry = registry
+	p.store = store
+	p.costs = costs
 	p.deployer = NewStackDeployer(registry, store, cfg.State, p.tc, cfg.Logger, costs)
 	return nil
 }
@@ -180,7 +209,7 @@ func (p *CloudFormationPlugin) createStack(reqCtx *RequestContext, req *AWSReque
 	// instead passes deploy-<unixnano>, which is right for a one-shot in-process
 	// validation run but would make a wire-created stack undiscoverable by the
 	// name the caller asked for.
-	if _, err := p.deployer.Deploy(context.Background(), body, name,
+	if _, err := p.deployerFor(reqCtx).Deploy(context.Background(), body, name,
 		cfnRequestParameters(req.Params, nil)); err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -223,7 +252,7 @@ func (p *CloudFormationPlugin) updateStack(reqCtx *RequestContext, req *AWSReque
 		// UsePreviousTemplate is the documented way to change only parameters.
 		body = stack.TemplateBody
 	}
-	if _, err := p.deployer.UpdateStack(context.Background(), body, name,
+	if _, err := p.deployerFor(reqCtx).UpdateStack(context.Background(), body, name,
 		cfnRequestParameters(req.Params, stack.Parameters)); err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -661,7 +690,9 @@ func (p *CloudFormationPlugin) executeChangeSet(reqCtx *RequestContext, req *AWS
 	if cs == nil {
 		return nil, cfnChangeSetNotFound(changeSetName)
 	}
-	if _, err := p.deployer.ExecuteChangeSet(context.Background(), cs.StackName, cs.ChangeSetName); err != nil {
+	// ExecuteChangeSet routes through UpdateStack to Deploy, so it deploys
+	// resources and takes the executing caller's identity like the other two.
+	if _, err := p.deployerFor(reqCtx).ExecuteChangeSet(context.Background(), cs.StackName, cs.ChangeSetName); err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
 
@@ -754,7 +785,11 @@ func (p *CloudFormationPlugin) detectStackDrift(reqCtx *RequestContext, req *AWS
 	if stackName == "" {
 		return nil, cfnMissingParameter("StackName")
 	}
-	detectionID, err := p.deployer.StartStackDriftDetection(context.Background(), stackName)
+	// Drift resolves each resource by a state key that embeds the account and
+	// region, so detection has to look where the resources were actually
+	// deployed. On the default identity it would report every resource of another
+	// caller's stack as DELETED.
+	detectionID, err := p.deployerFor(reqCtx).StartStackDriftDetection(context.Background(), stackName)
 	if err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -781,7 +816,9 @@ func (p *CloudFormationPlugin) describeStackResourceDrifts(reqCtx *RequestContex
 		return nil, cfnMissingParameter("StackName")
 	}
 	filters := extractIndexedParams(req.Params, "StackResourceDriftStatusFilters.member")
-	drifts, err := p.deployer.DescribeStackResourceDrifts(context.Background(), stackName, filters)
+	// Recomputes drift, so it needs the caller's identity for the same reason
+	// detectStackDrift does.
+	drifts, err := p.deployerFor(reqCtx).DescribeStackResourceDrifts(context.Background(), stackName, filters)
 	if err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -1036,11 +1073,16 @@ func cfnTime(t time.Time) string {
 
 // cfnStackID builds the stack ARN.
 //
-// The region and account come from the request, not from the deployer: a caller
-// signing for eu-west-1 should see a eu-west-1 stack ARN. Note that
-// StackDeployer.Deploy resolves the AWS::Region and AWS::AccountId
-// pseudo-parameters inside the template against substrate's defaults instead, so
-// the two can disagree for a non-default region.
+// The region and account come from the request: a caller signing for eu-west-1
+// sees a eu-west-1 stack ARN. The deployer takes the same identity, so the ARN and
+// the resources inside the stack cannot disagree.
+//
+// They used to. #483 shipped this comment claiming the disagreement was confined
+// to the AWS::Region and AWS::AccountId pseudo-parameters, which understated it
+// considerably: the deployer dispatched every resource under substrate's default
+// account and region, and most state keys embed both, so a stack created by a
+// caller in any other partition wrote its EC2 instances, ECS clusters and log
+// groups where that caller could not see them. Fixed in #517.
 func cfnStackID(reqCtx *RequestContext, stackName string) string {
 	return fmt.Sprintf("arn:aws:cloudformation:%s:%s:stack/%s/%s",
 		reqCtx.Region, reqCtx.AccountID, stackName,


### PR DESCRIPTION
## The defect

`StackDeployer.dispatch` synthesized its own `RequestContext` from substrate's
package defaults — `testAccountID` (123456789012) and `defaultRegion`
(us-east-1) — regardless of who created the stack. Most plugins embed the
account, and some the region, in their state keys:

| plugin | key |
|---|---|
| EC2 | `instance:<account>/<region>/<id>` |
| DynamoDB | `table:<account>/<name>` |
| SQS | `queue:<account>/<name>` |
| SNS | `topic:<account>/<region>/<name>` |
| S3 | `bucket:<name>` — **unpartitioned** |
| IAM | `role:<name>` — **unpartitioned** |

So a caller in any other partition got a stack ARN naming their own account
whose resources were written where they could not read them. #517's
reproduction: an unsigned client (which resolves to `000000000000`) created a
stack reporting `CREATE_COMPLETE` with a `PhysicalResourceId` of `i-…`, and
`DescribeInstances` then returned nothing. Every read scoped to the caller was
right; the write was in the wrong place.

The reporter read that as `AWS::EC2::*` being stubbed while `AWS::IAM::*`
worked. The asymmetry is real but the diagnosis was not — the two families that
appeared to work are exactly the two whose keys carry no account. That is also
why this survived #483's review: its shared-state test asserted a bucket
through S3 and a role through IAM.

## The fix

Identity rides on the deployer as an explicit account and region, defaulting to
today's constants, set through `WithDeployerIdentity`. `Deploy` has 145 test
call sites; an option touches none of them, and because the default is unchanged
no existing caller behaves differently.

Two strings rather than a whole `*RequestContext`: a deployer holding one would
carry a single request's ID and timestamp across every resource it deploys, and
would invite a future reader to propagate `Principal`, which is #411's decision.

`CloudFormationPlugin.deployerFor(reqCtx)` builds a deployer per deploying
request — six pointer copies with no I/O, cheaper than making one deployer's
identity mutable and therefore racy. `p.deployer` stays for the paths that touch
no resource (the stack and change-set records, which are unpartitioned;
`CreateChangeSet` is among them since it only parses and diffs two templates).

**Six sites read that identity, and threading `dispatch` alone would have left a
half-fix:**

- `dispatch` — the write path.
- both `buildCFNContext` calls — `AWS::AccountId` and `AWS::Region`. Before this,
  a bucket named `{"Fn::Sub": "b-${AWS::AccountId}"}` got substrate's account
  rather than the caller's: a *wrong physical name*, not a misplaced resource.
  Neither the issue nor the reporter named this.
- the drift existence checkers, plus the DynamoDB, SQS and SNS comparators'
  own state reads. A wrong-partition existence check reports `DELETED` for a
  resource that is fine; a wrong-partition comparator finds nothing to compare
  and reports no difference at all — drift silently blind, which no `IN_SYNC`
  assertion can distinguish from drift working.

`BettyClient` keeps the defaults deliberately — it is the in-process validation
client and its callers never sign a request, so there is no caller identity to
take. Its deployer now goes through the constructor rather than a struct
literal, which had left both fields empty; harmless only for as long as nothing
read them.

The comment #483 left on `cfnStackID` called this a pseudo-parameter
discrepancy. That understated it and has been rewritten.

## Tests

`emulator/cloudformation_identity_test.go`, 11 tests using **only partitioned
services** — the test-design lesson from #483:

- #517's reproduction: an unsigned caller finds its own instance, by
  `DescribeInstances` and by ID.
- One resource per family the reporter named: `ECS::Cluster`, `Logs::LogGroup`,
  `EC2::LaunchTemplate`.
- A non-default region: present in `eu-west-1`, **absent** from `us-east-1`.
- Signed and unsigned callers deploying the same template see one instance each.
- Pseudo-parameters agree with the stack ARN.
- All three deploying entry points: `CreateStack`, `UpdateStack`,
  `ExecuteChangeSet`. `UpdateStack` gets its own case because the change-set
  test reaches it indirectly and would pass with it left unthreaded.
- Drift, tabled over all three partitioned drift-checkable types, in
  `eu-west-1`, asserting `IN_SYNC` *and then* `MODIFIED` after a mutation —
  both reads are separately hardcoded. Both `DescribeStackResourceDrifts` and
  the `DetectStackDrift` / `DescribeStackDriftDetectionStatus` pair. The SNS
  case's `DisplayName` is `{"Fn::Sub": "${AWS::AccountId} in ${AWS::Region}"}`,
  which is the only place either pseudo-parameter is resolved twice.
- S3 and IAM still work — the unpartitioned keys must not regress.
- `BettyClient` deploys into the default partition; the option overrides it.

**Mutation testing: 18 mutants, 18 CAUGHT, no survivors.** Three of them were
survivors first and drove test changes: the SQS and SNS comparators (fixed by
tabling drift over all three types), `updateStack` (its own test), and
`cfnDriftResourceProps`'s context — which needed both pseudo-parameters in a
drift-compared property, since a comparator resolving the *expected* value
against the wrong identity reports `MODIFIED` on a resource nobody touched.
`StartStackDriftDetection` also survived until `DetectStackDrift` was asserted
over the wire. Mutating the constants default fails 23 pre-existing tests,
confirming it is load-bearing.

## Verified over the wire

Against `substrate server`, two callers in `us-west-2`:

```
# non-AKIA key → 000000000000
create-stack acct   → arn:aws:cloudformation:us-west-2:000000000000:stack/acct/…
describe-instances                    → i-f824919e3601d6a3   (was 0 reservations)
describe-instances --instance-ids …   → found                (was InvalidInstanceID.NotFound)
--region us-east-1 describe-instances → []                   — partitioning still holds

# AKIA key → 123456789012, same template
describe-instances → i-e9e26543b96942f1 only
```

Pseudo-parameters in `eu-west-1` produced `q-000000000000-eu-west-1`, and
`sqs get-queue-url` found that queue. Drift reported `IN_SYNC` /
`DETECTION_COMPLETE` / 0 drifted.

`gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues), `make test` (race),
the docs targets, the VitePress build and the `test/e2e` module all pass.

Closes #517
