### PR TITLE
chore(release): v0.87.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.87.1] - 2026-08-03
+
 ### Fixed
 - **CloudFormation YAML short-form intrinsics now resolve** (#516). A template
   written with `!Ref`, `!Sub` or `!If` deployed with unresolved literals where a
@@ -4111,7 +4113,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.87.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.87.1...HEAD
+[v0.87.1]: https://github.com/scttfrdmn/substrate/compare/v0.87.0...v0.87.1
 [v0.87.0]: https://github.com/scttfrdmn/substrate/compare/v0.86.0...v0.87.0
 [v0.86.0]: https://github.com/scttfrdmn/substrate/compare/v0.85.0...v0.86.0
 [v0.85.0]: https://github.com/scttfrdmn/substrate/compare/v0.84.0...v0.85.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.87.1] - 2026-08-03` and adds the
comparison link.

A patch release cut the day after v0.87.0 shipped CloudFormation over the wire
(#483), because a named consumer exercised the new endpoint against five real
templates within a day and filed two high-priority bugs. Both share one
consequence — the stack reported `CREATE_COMPLETE` for resources that were never
usefully created — which is the worst shape a fidelity defect can take, since the
consumer's waiter converges and their assertion passes.

| issue | PR |
|---|---|
| #516 — YAML short-form intrinsics were dropped | #523 |
| #519 — a plugin's 4xx response was neither an error nor a status | #523 |
| #517 — the deployer dispatched under substrate's own account and region | #524 |

Three further defects were found while fixing those and ship with them: `Default: ''`
was treated as no default at all (so the conventional `!Not [!Equals [!Ref X, '']]`
optional-parameter test inverted), and `Conditions` were evaluated in Go map order,
which made the same template deploy differently from one run to the next.

Next: tag the merge commit and publish the Release.