### PR TITLE
fix(cfn): Fn::Split resolves to a list, not its first element (#521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`Fn::Split` resolves to a list, so a split list no longer loses everything
+  after its first element** (#521). `resolveValue` returns a `string`, so every
+  list-valued intrinsic had nowhere to put a list: `resolveFnSplitFirst` was
+  honest about it in its own name, and a container command of `python,-m,worker`
+  deployed as `python` while the resource reported `CREATE_COMPLETE`. That was
+  reachable from conventional YAML only from v0.87.1 onward — before #516 the
+  whole `!Split` tag was dropped before the resolver saw it.
+
+  The resolver gains a list-returning sibling, `resolveValueList`, which the
+  list-valued property paths call. `resolveStringList` delegates to it, so all its
+  existing call sites gain full split results with no signature change. Its
+  conventions are the ones CloudFormation states: a scalar is a one-element list;
+  `Ref AWS::NoValue` contributes **no** element, which is what makes
+  `!If [HasCommand, !Split [',', !Ref Command], !Ref 'AWS::NoValue']` mean what it
+  says; a nested list-valued intrinsic splices rather than nesting, since a list
+  of lists is not a shape any AWS API member has; and empty elements are preserved,
+  because `!Split ['|', 'a||c|']` is documented to return `["a", "", "c", ""]`.
+
+- **`Fn::Select` over `Fn::Split` resolves** (#521). This is the idiom the AWS
+  `Fn::Split` reference itself leads with — `!Select ['2', !Split [':', arn]]` —
+  and it silently produced the empty string: `resolveFnSelect` required its second
+  argument to be a literal list, so every one of the six functions the `Fn::Select`
+  reference permits there (`Fn::FindInMap`, `Fn::GetAtt`, `Fn::GetAZs`, `Fn::If`,
+  `Fn::Split`, `Ref`) resolved to nothing with no error reported. The list argument
+  now goes through `resolveValueList`.
+
+- **A `Ref` to a `CommaDelimitedList` or `List<…>` parameter is list-valued**
+  (#521). `SecurityGroupIds: !Ref SubnetIds` reached the API as one string
+  containing commas rather than as several IDs. Which parameters are list-valued
+  comes from the **declared type** rather than from whether a value happens to
+  contain a comma — a `String` parameter holding `a,b` is one value — and each
+  member is space-trimmed, as the Parameters reference specifies.
+
+- **`Fn::Split` in a scalar context rejoins rather than truncates** (#521). A
+  scalar property has nowhere to put a list, and real CloudFormation rejects the
+  template; substrate resolves rather than rejects, so of the two ways to spell a
+  list as one string it now picks the one that loses nothing.
+
+- **A multi-key map is no longer resolved as an intrinsic** (#521). Every
+  intrinsic CloudFormation defines is a one-member object, but the resolver walked
+  a map of any size and returned whichever recognized key Go's map iteration
+  reached first — so a property holding both `Ref` and another member resolved two
+  different ways across runs. Nondeterminism is the sharper half of the defect: it
+  is the one outcome an emulator built on deterministic replay must never produce.
+  Such a map now falls through to its JSON encoding, which also leaves user data
+  that happens to carry a member named `Ref` — an ECS container definition, an IAM
+  policy document — untouched.
+
 ## [v0.87.1] - 2026-08-03
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -220,10 +220,22 @@ literal where a value should be rather than failing. Tracked in
 [#522](https://github.com/scttfrdmn/substrate/issues/522) — `Fn::FindInMap` needs a
 `Mappings` model, which the template struct does not have.
 
-`Fn::Split` resolves to its **first element only**, because the resolver returns
-a string. A template that splits a comma-separated list into a container command
-gets one element where the whole list is meant. Tracked in
-[#521](https://github.com/scttfrdmn/substrate/issues/521).
+`Fn::Split` resolves to a **list**, and a list-valued property receives every
+element. A `CommaDelimitedList` (or `List<…>`) parameter is list-valued too: a
+`Ref` to one yields one member per comma, each space-trimmed, so
+`!Select ['2', !Split [':', arn]]` picks the third field and
+`SecurityGroupIds: !Ref SubnetIds` reaches the API as several IDs rather than one
+string. Whether a `Ref` is list-valued comes from the parameter's declared type,
+not from whether its value happens to contain a comma.
+
+`Ref 'AWS::NoValue'` in a list position contributes **no** element, which is what
+makes the conventional `!If [HasCommand, !Split [',', !Ref Command], !Ref
+'AWS::NoValue']` idiom work.
+
+Where the property is scalar and has nowhere to put a list — an `Outputs` value,
+say — `Fn::Split`'s elements are rejoined on the delimiter, reproducing the
+source string. Real CloudFormation rejects the template instead; substrate
+resolves rather than rejects, and rejoining is the spelling that loses nothing.
 
 A parameter declared `Default: ''` is a parameter whose default is the empty
 string, not a parameter without one — which is what makes the conventional

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -91,6 +91,13 @@ type cfnContext struct {
 	accountID  string
 	stackName  string
 
+	// listParams records which parameters were declared with a list type
+	// (CommaDelimitedList, List<Number>, List<AWS::EC2::Subnet::Id>, …). A Ref
+	// to one is list-valued, and only the declaration says so: the value is a
+	// comma-separated string either way, and a String parameter that happens to
+	// contain a comma is a single value.
+	listParams map[string]bool
+
 	// conditionExprs holds the template's unevaluated Conditions, so a condition
 	// that references another by name can evaluate its referent on demand rather
 	// than depending on the order the conditions happened to be walked in.
@@ -2970,12 +2977,16 @@ func cfnDispatchError(resp *AWSResponse, routeErr error) error {
 // buildCFNContext constructs a cfnContext from template parameters and caller-supplied values.
 func buildCFNContext(tmpl *cfnTemplate, callerParams map[string]string, region, accountID, stackName string) *cfnContext {
 	params := make(map[string]string)
+	listParams := make(map[string]bool)
 	// Start with template defaults. A declared default is recorded even when it
 	// is the empty string: that is how an optional parameter is spelled, and
 	// leaving it out would make Ref resolve to the parameter's own name.
 	for name, p := range tmpl.Parameters {
 		if p.Default != nil {
 			params[name] = *p.Default
+		}
+		if cfnListParameterType(p.Type) {
+			listParams[name] = true
 		}
 	}
 	// Overlay caller-supplied params.
@@ -2984,6 +2995,7 @@ func buildCFNContext(tmpl *cfnTemplate, callerParams map[string]string, region, 
 	}
 	return &cfnContext{
 		params:     params,
+		listParams: listParams,
 		conditions: make(map[string]bool),
 		resources:  make(map[string]DeployedResource),
 		region:     region,
@@ -3123,6 +3135,17 @@ func resolveValue(v interface{}, cctx *cfnContext) string {
 		}
 		return "false"
 	case map[string]interface{}:
+		// A single key is what makes a map an intrinsic; every intrinsic
+		// CloudFormation defines is a one-member object. A map carrying other
+		// keys alongside is user data — a container definition or a policy
+		// document may hold a member named "Ref" — and walking it returned
+		// whichever recognized key Go's map iteration reached first, so the same
+		// template resolved differently from one run to the next. That is the
+		// one outcome an emulator built on deterministic replay must never
+		// produce; such a map falls through to the JSON encoding below.
+		if len(val) != 1 {
+			break
+		}
 		for fn, args := range val {
 			switch fn {
 			case "Ref":
@@ -3138,8 +3161,11 @@ func resolveValue(v interface{}, cctx *cfnContext) string {
 			case "Fn::Select":
 				return resolveFnSelect(args, cctx)
 			case "Fn::Split":
-				// Returns a list; return first element as string.
-				return resolveFnSplitFirst(args, cctx)
+				// Fn::Split returns a list and this context has nowhere to put
+				// one, so the elements are rejoined on the delimiter. See
+				// resolveFnSplitJoined for why that beats truncating, and
+				// resolveValueList for the context that keeps the list.
+				return resolveFnSplitJoined(args, cctx)
 			case "Fn::Base64":
 				return resolveFnBase64(args, cctx)
 			case "Fn::GetAtt":
@@ -3152,6 +3178,127 @@ func resolveValue(v interface{}, cctx *cfnContext) string {
 	// Fallback: JSON-encode.
 	b, _ := json.Marshal(v)
 	return string(b)
+}
+
+// resolveValueList resolves a CloudFormation value in a list-valued context.
+//
+// resolveValue returns a string, so every list-valued intrinsic — Fn::Split, a
+// Ref to a CommaDelimitedList parameter, and (once modeled) Fn::GetAZs and
+// Fn::Cidr — had nowhere to put its list and lost everything but one element
+// (#521). This is that missing return shape; the two live side by side because
+// CloudFormation itself distinguishes the contexts: the same intrinsic in a
+// scalar property is an error there and a rejoined string here.
+//
+// Conventions, which resolveStringList and resolveFnSelect both depend on:
+//
+//   - A scalar resolves to a one-element list, so a property that accepts either
+//     a single value or a list needs no special case at the call site.
+//   - Ref AWS::NoValue contributes *no* element, matching CloudFormation's
+//     removal semantics — a template writes
+//     `!If [HasCommand, !Split [...], !Ref 'AWS::NoValue']` precisely to say
+//     "and otherwise nothing".
+//   - An element that is itself list-valued splices rather than nesting, since
+//     a list of lists is not a shape any AWS API member has.
+//   - Empty elements are preserved: `!Split ['|', 'a||c|']` is documented to
+//     return ["a", "", "c", ""]. A caller that cannot use an empty member
+//     filters them itself; resolveStringList does.
+//   - Only a *single-key* map is an intrinsic. A map that also carries other
+//     keys is user data — an ECS container definition naming a member "Ref", say
+//     — and resolving it would both corrupt that data and make the result depend
+//     on Go's map iteration order, since the walk would return whichever
+//     recognized key it reached first.
+func resolveValueList(v interface{}, cctx *cfnContext) []string {
+	switch val := v.(type) {
+	case nil:
+		return nil
+	case []interface{}:
+		out := make([]string, 0, len(val))
+		for _, item := range val {
+			out = append(out, resolveValueList(item, cctx)...)
+		}
+		return out
+	case map[string]interface{}:
+		if len(val) == 1 {
+			for fn, args := range val {
+				switch fn {
+				case "Ref":
+					ref, ok := args.(string)
+					if !ok {
+						return nil
+					}
+					return resolveRefList(ref, cctx)
+				case "Fn::Split":
+					arr, ok := args.([]interface{})
+					if !ok || len(arr) < 2 {
+						return nil
+					}
+					sep, ok := arr[0].(string)
+					if !ok {
+						return nil
+					}
+					return splitFnSplit(sep, resolveValue(arr[1], cctx))
+				case "Fn::If":
+					arr, ok := args.([]interface{})
+					if !ok || len(arr) < 3 {
+						return nil
+					}
+					condName, ok := arr[0].(string)
+					if !ok {
+						return nil
+					}
+					if cctx.condition(condName) {
+						return resolveValueList(arr[1], cctx)
+					}
+					return resolveValueList(arr[2], cctx)
+				}
+			}
+		}
+	}
+	return []string{resolveValue(v, cctx)}
+}
+
+// resolveRefList resolves a Ref in a list-valued context.
+//
+// A Ref is list-valued exactly when it names a parameter whose declared type is
+// a list type, so the parameter declarations have to be consulted rather than
+// the value guessed at: a String parameter that happens to hold a comma is one
+// value, not several.
+func resolveRefList(ref string, cctx *cfnContext) []string {
+	if ref == "AWS::NoValue" {
+		return nil
+	}
+	if cctx.listParams[ref] {
+		if v, ok := cctx.params[ref]; ok {
+			return splitParameterList(v)
+		}
+	}
+	return []string{resolveRef(ref, cctx)}
+}
+
+// splitParameterList splits a list-typed parameter's value on commas.
+//
+// "The total number of strings should be one more than the total number of
+// commas. Also, each member string is space trimmed." An empty value is an empty
+// list rather than a list holding one empty string, which is how a template
+// spells "no members" with `Default: ”`.
+func splitParameterList(v string) []string {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, strings.TrimSpace(p))
+	}
+	return out
+}
+
+// cfnListParameterType reports whether a declared parameter type holds a list.
+//
+// CommaDelimitedList is the literal-string form; every AWS-specific and Number
+// list type is spelled List<…> (List<Number>, List<AWS::EC2::Subnet::Id>, …).
+func cfnListParameterType(t string) bool {
+	return t == "CommaDelimitedList" || strings.HasPrefix(t, "List<")
 }
 
 func resolveRef(ref string, cctx *cfnContext) string {
@@ -3254,6 +3401,19 @@ func resolveFnJoin(args interface{}, cctx *cfnContext) string {
 	return strings.Join(parts, sep)
 }
 
+// resolveFnSelect resolves Fn::Select by index.
+//
+// The list argument goes through resolveValueList rather than being required to
+// be a literal []interface{}: the Fn::Select reference permits Fn::FindInMap,
+// Fn::GetAtt, Fn::GetAZs, Fn::If, Fn::Split and Ref there, and
+// `!Select ['2', !Split [':', arn]]` is the example the Fn::Split reference
+// itself leads with. Requiring a literal made every one of those resolve to the
+// empty string with nothing reporting a problem (#521).
+//
+// An out-of-range index yields the empty string. Real CloudFormation fails the
+// stack — "Fn::Select cannot select nonexistent value at index N" — which is
+// #502's typed-error work; until then the resolver keeps its existing shape
+// rather than acquiring a second, inconsistent failure mode.
 func resolveFnSelect(args interface{}, cctx *cfnContext) string {
 	arr, ok := args.([]interface{})
 	if !ok || len(arr) < 2 {
@@ -3262,25 +3422,48 @@ func resolveFnSelect(args interface{}, cctx *cfnContext) string {
 	idxStr := resolveValue(arr[0], cctx)
 	var idx int
 	_, _ = fmt.Sscanf(idxStr, "%d", &idx)
-	items, ok := arr[1].([]interface{})
-	if !ok || idx < 0 || idx >= len(items) {
+	items := resolveValueList(arr[1], cctx)
+	if idx < 0 || idx >= len(items) {
 		return ""
 	}
-	return resolveValue(items[idx], cctx)
+	return items[idx]
 }
 
-func resolveFnSplitFirst(args interface{}, cctx *cfnContext) string {
+// resolveFnSplitJoined resolves Fn::Split in a scalar context by rejoining the
+// elements on the delimiter, which reproduces the source string.
+//
+// Fn::Split returns a list, so a scalar property is a context CloudFormation
+// itself would reject. Substrate resolves rather than rejects — a template that
+// deploys against AWS must deploy here — and of the two ways to spell a list as
+// one string, rejoining loses nothing while truncating to the first element
+// silently dropped everything after the first delimiter (#521). A list-valued
+// property gets the list itself, through resolveValueList.
+func resolveFnSplitJoined(args interface{}, cctx *cfnContext) string {
 	arr, ok := args.([]interface{})
 	if !ok || len(arr) < 2 {
 		return ""
 	}
-	sep := resolveValue(arr[0], cctx)
-	s := resolveValue(arr[1], cctx)
-	parts := strings.SplitN(s, sep, 2)
-	if len(parts) > 0 {
-		return parts[0]
+	sep, ok := arr[0].(string)
+	if !ok {
+		// "For the Fn::Split delimiter, you can't use any functions. You must
+		// specify a string value."
+		return ""
 	}
-	return s
+	return strings.Join(splitFnSplit(sep, resolveValue(arr[1], cctx)), sep)
+}
+
+// splitFnSplit applies Fn::Split's documented split semantics: every delimiter
+// divides, so consecutive delimiters and a trailing delimiter each produce an
+// empty element — `!Split ['|', 'a||c|']` is ["a", "", "c", ""].
+//
+// An empty delimiter has no documented behavior; it yields the source string as
+// a single element rather than one element per byte, which is what strings.Split
+// would give.
+func splitFnSplit(sep, s string) []string {
+	if sep == "" {
+		return []string{s}
+	}
+	return strings.Split(s, sep)
 }
 
 func resolveFnBase64(args interface{}, cctx *cfnContext) string {

--- a/emulator/betty_cfn_fnsplit_test.go
+++ b/emulator/betty_cfn_fnsplit_test.go
@@ -1,0 +1,528 @@
+package emulator_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestCFN_FnSelect_OverFnSplit covers the idiom the CloudFormation Fn::Split
+// reference leads with: split a string, then Fn::Select an element out of the
+// resulting list. Before #521 this resolved to the empty string, because
+// Fn::Select required its second argument to be a literal list and an intrinsic
+// resolved to a single string.
+func TestCFN_FnSelect_OverFnSplit(t *testing.T) {
+	d := newTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {
+			"QueueArn": {"Type": "String", "Default": "arn:aws:sqs:us-east-1:123456789012:jobs"}
+		},
+		"Resources": {
+			"MyBucket": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "select-over-split"}}
+		},
+		"Outputs": {
+			"Service":   {"Value": {"Fn::Select": ["2", {"Fn::Split": [":", {"Ref": "QueueArn"}]}]}},
+			"QueueName": {"Value": {"Fn::Select": ["5", {"Fn::Split": [":", {"Ref": "QueueArn"}]}]}}
+		}
+	}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "select-split-stack", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "sqs", result.Outputs["Service"])
+	assert.Equal(t, "jobs", result.Outputs["QueueName"])
+}
+
+// TestCFN_FnSplit_ScalarContextJoins pins the documented behavior of Fn::Split
+// where the property is scalar and has nowhere to put a list: the elements are
+// rejoined on the delimiter, reproducing the source string, rather than
+// truncating to the first element.
+func TestCFN_FnSplit_ScalarContextJoins(t *testing.T) {
+	d := newTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyBucket": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "split-scalar"}}
+		},
+		"Outputs": {
+			"Path": {"Value": {"Fn::Split": ["/", "a/b/c"]}}
+		}
+	}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "split-scalar-stack", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "a/b/c", result.Outputs["Path"])
+}
+
+// newVPCWithGroups creates a VPC, one subnet in it, and n security groups, and
+// returns the subnet ID and the group IDs.
+//
+// A list-valued SecurityGroupIds property is only observable end to end against
+// groups that exist and belong to the launch subnet's VPC — RunInstances rejects
+// both an unknown group and one from another VPC — so the IDs a test splits have
+// to come from the API rather than be invented.
+func newVPCWithGroups(t *testing.T, registry *emulator.PluginRegistry, n int) (string, []string) {
+	t.Helper()
+	vpcID := extractXMLTag(t, routeQuery(t, registry, "ec2", map[string]string{
+		"Action":    "CreateVpc",
+		"CidrBlock": "10.0.0.0/16",
+	}), "vpcId")
+	subnetID := extractXMLTag(t, routeQuery(t, registry, "ec2", map[string]string{
+		"Action":    "CreateSubnet",
+		"VpcId":     vpcID,
+		"CidrBlock": "10.0.1.0/24",
+	}), "subnetId")
+
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		body := routeQuery(t, registry, "ec2", map[string]string{
+			"Action":           "CreateSecurityGroup",
+			"VpcId":            vpcID,
+			"GroupName":        fmt.Sprintf("split-group-%d", i),
+			"GroupDescription": "list-valued property fixture",
+		})
+		id := extractXMLTag(t, body, "groupId")
+		require.NotEmpty(t, id)
+		ids = append(ids, id)
+	}
+	return subnetID, ids
+}
+
+// extractXMLTag returns the text content of the first <name> element in body.
+func extractXMLTag(t *testing.T, body, name string) string {
+	t.Helper()
+	openTag, closeTag := "<"+name+">", "</"+name+">"
+	start := strings.Index(body, openTag)
+	require.GreaterOrEqual(t, start, 0, "%s not found in %s", name, body)
+	start += len(openTag)
+	end := strings.Index(body[start:], closeTag)
+	require.GreaterOrEqual(t, end, 0, "%s unterminated in %s", name, body)
+	return body[start : start+end]
+}
+
+// TestCFN_FnSplit_ListValuedProperty verifies that a list-valued property fed by
+// Fn::Split reaches the API with every element, observed through
+// DescribeInstances rather than through the deploy result — a consumer reads the
+// security groups off the instance, not off the template.
+func TestCFN_FnSplit_ListValuedProperty(t *testing.T) {
+	d, registry := newEC2IAMTestDeployer(t)
+	subnetID, groups := newVPCWithGroups(t, registry, 3)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {
+			"Groups": {"Type": "String", "Default": ""},
+			"Subnet": {"Type": "String", "Default": ""}
+		},
+		"Resources": {
+			"Node": {
+				"Type": "AWS::EC2::Instance",
+				"Properties": {
+					"ImageId": "ami-0abc1234",
+					"InstanceType": "c5.large",
+					"SubnetId": {"Ref": "Subnet"},
+					"SecurityGroupIds": {"Fn::Split": [",", {"Ref": "Groups"}]}
+				}
+			}
+		}
+	}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "split-sg-stack", map[string]string{
+		"Groups": strings.Join(groups, ","),
+		"Subnet": subnetID,
+	})
+	require.NoError(t, err)
+	node := findResource(t, result, "Node")
+	assert.Empty(t, node.Error)
+
+	body := routeQuery(t, registry, "ec2", map[string]string{"Action": "DescribeInstances"})
+	for _, sg := range groups {
+		assert.Contains(t, body, sg, "every element of the split list must reach RunInstances")
+	}
+}
+
+// TestCFN_FnIf_ListBranch covers an Fn::If whose branches are lists — the form
+// ecs_worker.yml uses for a container command:
+// !If [HasCommand, !Split [',', !Ref Command], !Ref 'AWS::NoValue'].
+func TestCFN_FnIf_ListBranch(t *testing.T) {
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {
+			"Groups": {"Type": "String", "Default": ""},
+			"Subnet": {"Type": "String", "Default": ""}
+		},
+		"Conditions": {
+			"HasGroups": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Groups"}, ""]}]}
+		},
+		"Resources": {
+			"Node": {
+				"Type": "AWS::EC2::Instance",
+				"Properties": {
+					"ImageId": "ami-0abc1234",
+					"InstanceType": "c5.large",
+					"SubnetId": {"Ref": "Subnet"},
+					"SecurityGroupIds": {"Fn::If": [
+						"HasGroups",
+						{"Fn::Split": [",", {"Ref": "Groups"}]},
+						{"Ref": "AWS::NoValue"}
+					]}
+				}
+			}
+		}
+	}`
+
+	t.Run("condition true splices the list", func(t *testing.T) {
+		d, registry := newEC2IAMTestDeployer(t)
+		subnetID, groups := newVPCWithGroups(t, registry, 2)
+		result, err := d.Deploy(context.Background(), tmpl, "if-list-true", map[string]string{
+			"Groups": strings.Join(groups, ","),
+			"Subnet": subnetID,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, findResource(t, result, "Node").Error)
+
+		body := routeQuery(t, registry, "ec2", map[string]string{"Action": "DescribeInstances"})
+		for _, sg := range groups {
+			assert.Contains(t, body, sg)
+		}
+	})
+
+	t.Run("condition false contributes no group", func(t *testing.T) {
+		d, registry := newEC2IAMTestDeployer(t)
+		result, err := d.Deploy(context.Background(), tmpl, "if-list-false", nil)
+		require.NoError(t, err)
+		assert.Empty(t, findResource(t, result, "Node").Error)
+
+		// AWS::NoValue in a list position yields no element, so the instance
+		// lands in the default group rather than one named for the empty
+		// string. EC2 assigns "default" itself, which is why the assertion is
+		// on the group name and not on the absence of any group at all.
+		body := routeQuery(t, registry, "ec2", map[string]string{"Action": "DescribeInstances"})
+		assert.Contains(t, body, "<groupName>default</groupName>")
+	})
+}
+
+// TestCFN_Ref_CommaDelimitedListParameter verifies that a Ref to a
+// CommaDelimitedList parameter resolves to a list in a list context, with each
+// member space-trimmed as the Parameters reference specifies, and that
+// Fn::Select can pick one out of it — the second example in the Fn::Select
+// reference.
+func TestCFN_Ref_CommaDelimitedListParameter(t *testing.T) {
+	d, registry := newEC2IAMTestDeployer(t)
+	subnetID, groups := newVPCWithGroups(t, registry, 2)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {
+			"Groups": {"Type": "CommaDelimitedList", "Default": ""},
+			"Subnet": {"Type": "String", "Default": ""}
+		},
+		"Resources": {
+			"Node": {
+				"Type": "AWS::EC2::Instance",
+				"Properties": {
+					"ImageId": "ami-0abc1234",
+					"InstanceType": "c5.large",
+					"SubnetId": {"Ref": "Subnet"},
+					"SecurityGroupIds": {"Ref": "Groups"}
+				}
+			}
+		},
+		"Outputs": {
+			"Second": {"Value": {"Fn::Select": ["1", {"Ref": "Groups"}]}}
+		}
+	}`
+
+	// A space after the comma, because the Parameters reference specifies that
+	// "each member string is space trimmed" — an untrimmed member would be an
+	// unknown security group.
+	result, err := d.Deploy(context.Background(), tmpl, "cdl-stack", map[string]string{
+		"Groups": strings.Join(groups, ", "),
+		"Subnet": subnetID,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, findResource(t, result, "Node").Error)
+	assert.Equal(t, groups[1], result.Outputs["Second"])
+
+	body := routeQuery(t, registry, "ec2", map[string]string{"Action": "DescribeInstances"})
+	for _, sg := range groups {
+		assert.Contains(t, body, sg)
+	}
+}
+
+// TestResolveValueList_Conventions pins resolveValueList's conventions at the
+// seam. Each is a rule CloudFormation states, and each is invisible through the
+// current call sites — resolveStringList drops empty members, since a query API
+// numbers its list parameters and would otherwise send `Member.2=`.
+func TestResolveValueList_Conventions(t *testing.T) {
+	params := map[string]string{
+		"Command":  "python,-m,worker",
+		"Subnets":  "subnet-1, subnet-2 , subnet-3",
+		"Empty":    "",
+		"OneValue": "a,b",
+	}
+	listParams := map[string]bool{"Subnets": true, "Empty": true}
+	conditions := map[string]bool{"Yes": true, "No": false}
+
+	cases := []struct {
+		name string
+		in   interface{}
+		want []string
+	}{
+		{
+			name: "scalar is a one-element list",
+			in:   "single",
+			want: []string{"single"},
+		},
+		{
+			name: "Fn::Split keeps every element",
+			in:   map[string]interface{}{"Fn::Split": []interface{}{",", map[string]interface{}{"Ref": "Command"}}},
+			want: []string{"python", "-m", "worker"},
+		},
+		{
+			// "If you split a string with consecutive delimiters, the resulting
+			// list will include an empty string": !Split ['|','a||c|'] is
+			// ["a", "", "c", ""].
+			name: "consecutive and trailing delimiters yield empty elements",
+			in:   map[string]interface{}{"Fn::Split": []interface{}{"|", "a||c|"}},
+			want: []string{"a", "", "c", ""},
+		},
+		{
+			name: "Ref to a list parameter splits and trims each member",
+			in:   map[string]interface{}{"Ref": "Subnets"},
+			want: []string{"subnet-1", "subnet-2", "subnet-3"},
+		},
+		{
+			// The declared type is what makes a Ref list-valued, not the comma.
+			name: "Ref to a String parameter is one value even with a comma",
+			in:   map[string]interface{}{"Ref": "OneValue"},
+			want: []string{"a,b"},
+		},
+		{
+			name: "Ref to an empty list parameter is no members",
+			in:   map[string]interface{}{"Ref": "Empty"},
+			want: nil,
+		},
+		{
+			name: "Ref AWS::NoValue contributes no element",
+			in:   map[string]interface{}{"Ref": "AWS::NoValue"},
+			want: nil,
+		},
+		{
+			name: "AWS::NoValue inside a literal list drops only itself",
+			in: []interface{}{
+				"keep",
+				map[string]interface{}{"Ref": "AWS::NoValue"},
+				"also-keep",
+			},
+			want: []string{"keep", "also-keep"},
+		},
+		{
+			name: "Fn::If takes the true branch's list",
+			in: map[string]interface{}{"Fn::If": []interface{}{
+				"Yes",
+				map[string]interface{}{"Fn::Split": []interface{}{",", map[string]interface{}{"Ref": "Command"}}},
+				map[string]interface{}{"Ref": "AWS::NoValue"},
+			}},
+			want: []string{"python", "-m", "worker"},
+		},
+		{
+			name: "Fn::If taking AWS::NoValue yields no element at all",
+			in: map[string]interface{}{"Fn::If": []interface{}{
+				"No",
+				map[string]interface{}{"Fn::Split": []interface{}{",", map[string]interface{}{"Ref": "Command"}}},
+				map[string]interface{}{"Ref": "AWS::NoValue"},
+			}},
+			want: nil,
+		},
+		{
+			// A list of lists is not a shape any AWS API member has.
+			name: "a nested list-valued intrinsic splices rather than nesting",
+			in: []interface{}{
+				"first",
+				map[string]interface{}{"Fn::Split": []interface{}{",", "second,third"}},
+			},
+			want: []string{"first", "second", "third"},
+		},
+		{
+			// "For the Fn::Split delimiter, you can't use any functions."
+			name: "an intrinsic delimiter is not resolved",
+			in: map[string]interface{}{"Fn::Split": []interface{}{
+				map[string]interface{}{"Ref": "Command"}, "a,b",
+			}},
+			want: nil,
+		},
+		{
+			// A single key is what makes a map an intrinsic. A map carrying
+			// other keys is user data — an ECS container definition may have a
+			// member literally named "Ref" — and resolving it would also make
+			// the result depend on Go's map iteration order.
+			name: "a multi-key map containing Ref is not an intrinsic",
+			in: map[string]interface{}{
+				"Ref":   "Command",
+				"Other": "value",
+			},
+			want: []string{`{"Other":"value","Ref":"Command"}`},
+		},
+		{
+			// An empty delimiter has no documented behavior; the source string
+			// comes back as one element rather than one element per byte, which
+			// is what strings.Split would give.
+			name: "an empty delimiter yields the source string",
+			in:   map[string]interface{}{"Fn::Split": []interface{}{"", "abc"}},
+			want: []string{"abc"},
+		},
+		{
+			name: "a one-argument Fn::Split is no members",
+			in:   map[string]interface{}{"Fn::Split": []interface{}{","}},
+			want: nil,
+		},
+		{
+			name: "a two-argument Fn::If is no members",
+			in:   map[string]interface{}{"Fn::If": []interface{}{"Yes", "only"}},
+			want: nil,
+		},
+		{
+			name: "a non-string Ref argument is no members",
+			in:   map[string]interface{}{"Ref": []interface{}{"not", "a", "name"}},
+			want: nil,
+		},
+		{
+			name: "an unrecognized intrinsic falls through to its JSON encoding",
+			in:   map[string]interface{}{"Fn::Unknown": "x"},
+			want: []string{`{"Fn::Unknown":"x"}`},
+		},
+		{
+			name: "nil is no members",
+			in:   nil,
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := emulator.ResolveValueListForTest(tc.in, params, listParams, conditions)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCFNListParameterType pins which declared parameter types make a Ref
+// list-valued: CommaDelimitedList is the literal-string form and every other
+// list type — Number and the AWS-specific ones — is spelled List<…>.
+func TestCFNListParameterType(t *testing.T) {
+	for _, listType := range []string{
+		"CommaDelimitedList",
+		"List<Number>",
+		"List<AWS::EC2::Subnet::Id>",
+		"List<AWS::EC2::SecurityGroup::Id>",
+		"List<AWS::SSM::Parameter::Value<String>>",
+	} {
+		assert.True(t, emulator.CFNListParameterTypeForTest(listType), listType)
+	}
+	for _, scalarType := range []string{
+		"String",
+		"Number",
+		"AWS::EC2::Subnet::Id",
+		"AWS::SSM::Parameter::Value<String>",
+		"",
+	} {
+		assert.False(t, emulator.CFNListParameterTypeForTest(scalarType), scalarType)
+	}
+}
+
+// TestCFN_MultiKeyMapIsNotAnIntrinsic pins that a map carrying a recognized
+// intrinsic key alongside others is left alone.
+//
+// Determinism is the reason and not only fidelity: the resolver walked the map
+// and returned whichever recognized key Go's map iteration reached first, so the
+// same template could resolve two ways across runs — the one outcome an emulator
+// built on deterministic replay must never produce. The same rule covers user
+// data that happens to hold a member named "Ref".
+func TestCFN_MultiKeyMapIsNotAnIntrinsic(t *testing.T) {
+	d := newTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {"P": {"Type": "String", "Default": "resolved"}},
+		"Resources": {
+			"MyBucket": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "multikey-bucket"}}
+		},
+		"Outputs": {
+			"Both": {"Value": {"Ref": "P", "Fn::Sub": "also-${P}"}}
+		}
+	}`
+
+	// Deployed repeatedly, because the defect is a race with map iteration
+	// order: a single run could pass by luck.
+	for i := 0; i < 20; i++ {
+		result, err := d.Deploy(context.Background(), tmpl, fmt.Sprintf("multikey-%d", i), nil)
+		require.NoError(t, err)
+		assert.NotEqual(t, "resolved", result.Outputs["Both"],
+			"a two-key map is not a Ref")
+		assert.NotEqual(t, "also-resolved", result.Outputs["Both"],
+			"a two-key map is not an Fn::Sub either")
+	}
+}
+
+// TestCFN_FnSelect_OutOfRange pins that an out-of-range or malformed Fn::Select
+// resolves to the empty string.
+//
+// Real CloudFormation fails the stack — "Fn::Select cannot select nonexistent
+// value at index N" — which needs the typed deployer errors tracked in #502. Until
+// then the resolver keeps its existing shape rather than acquiring a second,
+// inconsistent failure mode, and this test says so out loud so the behavior is a
+// decision rather than an accident.
+func TestCFN_FnSelect_OutOfRange(t *testing.T) {
+	d := newTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyBucket": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "select-range"}}
+		},
+		"Outputs": {
+			"TooHigh":  {"Value": {"Fn::Select": ["9", {"Fn::Split": [",", "a,b"]}]}},
+			"Negative": {"Value": {"Fn::Select": ["-1", {"Fn::Split": [",", "a,b"]}]}},
+			"OneArg":   {"Value": {"Fn::Select": ["0"]}},
+			"InRange":  {"Value": {"Fn::Select": ["1", {"Fn::Split": [",", "a,b"]}]}}
+		}
+	}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "select-range-stack", nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.Outputs["TooHigh"])
+	assert.Empty(t, result.Outputs["Negative"])
+	assert.Empty(t, result.Outputs["OneArg"])
+	assert.Equal(t, "b", result.Outputs["InRange"])
+}
+
+// TestCFN_FnSplit_MalformedArguments pins that a malformed Fn::Split in a scalar
+// context resolves to the empty string rather than panicking — one argument, and
+// an intrinsic where the delimiter must be a literal ("For the Fn::Split
+// delimiter, you can't use any functions").
+func TestCFN_FnSplit_MalformedArguments(t *testing.T) {
+	d := newTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {"Sep": {"Type": "String", "Default": ","}},
+		"Resources": {
+			"MyBucket": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "split-malformed"}}
+		},
+		"Outputs": {
+			"OneArg":         {"Value": {"Fn::Split": [","]}},
+			"NotAList":       {"Value": {"Fn::Split": "a,b"}},
+			"IntrinsicSep":   {"Value": {"Fn::Split": [{"Ref": "Sep"}, "a,b"]}},
+			"EmptyDelimiter": {"Value": {"Fn::Split": ["", "abc"]}}
+		}
+	}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "split-malformed-stack", nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.Outputs["OneArg"])
+	assert.Empty(t, result.Outputs["NotAList"])
+	assert.Empty(t, result.Outputs["IntrinsicSep"])
+	assert.Equal(t, "abc", result.Outputs["EmptyDelimiter"])
+}

--- a/emulator/betty_cfn_test.go
+++ b/emulator/betty_cfn_test.go
@@ -574,7 +574,9 @@ func TestCFN_FnSub_WithMap(t *testing.T) {
 	assert.Equal(t, "Hello World", result.Outputs["Greeting"])
 }
 
-// TestCFN_FnSplit verifies that Fn::Split returns the first element.
+// TestCFN_FnSplit verifies that Fn::Split in a scalar context keeps every
+// element. An Output is a scalar context, so the elements are rejoined on the
+// delimiter; before #521 everything after the first delimiter was dropped.
 func TestCFN_FnSplit(t *testing.T) {
 	d := newTestDeployer(t)
 	tmpl := `{
@@ -583,7 +585,7 @@ func TestCFN_FnSplit(t *testing.T) {
 			"MyBucket": {"Type": "AWS::S3::Bucket", "Properties": {"BucketName": "fnsplit-bucket"}}
 		},
 		"Outputs": {
-			"FirstPart": {
+			"Path": {
 				"Value": {"Fn::Split": ["/", "a/b/c"]}
 			}
 		}
@@ -591,8 +593,7 @@ func TestCFN_FnSplit(t *testing.T) {
 
 	result, err := d.Deploy(context.Background(), tmpl, "fn-split-stack", nil)
 	require.NoError(t, err)
-	// resolveFnSplitFirst returns only the first part.
-	assert.Equal(t, "a", result.Outputs["FirstPart"])
+	assert.Equal(t, "a/b/c", result.Outputs["Path"])
 }
 
 // TestCFN_Condition_And verifies the Fn::And condition combinator using inline

--- a/emulator/betty_cfn_v77_plugins.go
+++ b/emulator/betty_cfn_v77_plugins.go
@@ -342,26 +342,25 @@ func (d *StackDeployer) servicePluginLoaded(resType string) bool {
 	return false
 }
 
-// resolveStringList resolves a CFN list-valued property to a string slice,
-// resolving each element through Ref/Fn::GetAtt. A single scalar is treated as a
-// one-element list, which is what templates that omit the YAML list syntax
-// produce.
+// resolveStringList resolves a CFN list-valued property to a string slice for a
+// caller that indexes the result into an AWS query parameter (Member.1,
+// Member.2, …).
+//
+// It delegates the resolution to resolveValueList and drops empty members. The
+// numbering is what makes that necessary: an empty member would still occupy an
+// index, so a query API would receive `SecurityGroupId.2=` and reject it. A
+// caller that needs Fn::Split's documented empty elements preserved uses
+// resolveValueList directly.
 func resolveStringList(v interface{}, cctx *cfnContext) []string {
-	switch val := v.(type) {
-	case nil:
-		return nil
-	case []interface{}:
-		out := make([]string, 0, len(val))
-		for _, item := range val {
-			if s := resolveValue(item, cctx); s != "" {
-				out = append(out, s)
-			}
+	resolved := resolveValueList(v, cctx)
+	out := make([]string, 0, len(resolved))
+	for _, s := range resolved {
+		if s != "" {
+			out = append(out, s)
 		}
-		return out
-	default:
-		if s := resolveValue(v, cctx); s != "" {
-			return []string{s}
-		}
+	}
+	if len(out) == 0 {
 		return nil
 	}
+	return out
 }

--- a/emulator/betty_cfn_yaml_test.go
+++ b/emulator/betty_cfn_yaml_test.go
@@ -64,10 +64,11 @@ func TestCFN_YAMLShortForm_MatchesLongForm(t *testing.T) {
 			want:  "live",
 		},
 		{
+			// Scalar context, so the list is rejoined on the delimiter (#521).
 			name:  "Split",
 			short: `!Split [',', 'live,dead']`,
 			long:  `{Fn::Split: [',', 'live,dead']}`,
-			want:  "live",
+			want:  "live,dead",
 		},
 		{
 			// A node carries at most one tag, so `!Base64 !Ref P` is not legal
@@ -211,9 +212,7 @@ func TestCFN_YAMLShortForm_GetAttSplitsOnFirstPeriod(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := newTestDeployer(t)
 			// The assertion runs through Outputs, which resolveValue handles
-			// directly: the resolved ARN is not a legal bucket name, and asserting
-			// through one would need Fn::Select over Fn::Split, which resolves to
-			// its first element only (see docs/services.md).
+			// directly: the resolved ARN is not a legal bucket name.
 			tmpl := `
 Resources:
   Role:

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -304,3 +304,30 @@ func CFNDispatchErrorForTest(status int, body string, routeErr error) error {
 	}
 	return cfnDispatchError(resp, routeErr)
 }
+
+// ResolveValueListForTest wraps resolveValueList so its conventions can be
+// asserted at the seam rather than only through a deployer.
+//
+// The distinctions it draws are invisible downstream: resolveStringList drops
+// empty members because a query API numbers its list parameters, so "AWS::NoValue
+// contributes no element" and "an empty member is preserved" — two rules
+// CloudFormation states and that a nested Fn::Split depends on — produce the same
+// observable through every current call site. Pinning them here is what makes
+// them regressions rather than accidents.
+//
+// listParams names the parameters declared with a list type, which is the only
+// thing that makes a Ref list-valued.
+func ResolveValueListForTest(v interface{}, params map[string]string, listParams map[string]bool, conditions map[string]bool) []string {
+	cctx := &cfnContext{
+		params:     params,
+		listParams: listParams,
+		conditions: conditions,
+		resources:  map[string]DeployedResource{},
+		evaluating: map[string]bool{},
+	}
+	return resolveValueList(v, cctx)
+}
+
+// CFNListParameterTypeForTest wraps cfnListParameterType so the set of declared
+// types that make a Ref list-valued can be asserted directly.
+func CFNListParameterTypeForTest(t string) bool { return cfnListParameterType(t) }

--- a/emulator/v016_extra_test.go
+++ b/emulator/v016_extra_test.go
@@ -819,7 +819,7 @@ func TestCFN_ResolveValueTypes(t *testing.T) {
 			"AccountId":  {"Value": {"Ref": "AWS::AccountId"}},
 			"NoValue":    {"Value": {"Ref": "AWS::NoValue"}},
 			"JoinResult": {"Value": {"Fn::Join": ["-", ["x", "y", "z"]]}},
-			"SplitFirst": {"Value": {"Fn::Split": ["/", "a/b/c"]}}
+			"SplitJoined": {"Value": {"Fn::Split": ["/", "a/b/c"]}}
 		}
 	}`
 
@@ -828,6 +828,8 @@ func TestCFN_ResolveValueTypes(t *testing.T) {
 	assert.Equal(t, "a", result.Outputs["Selected"])
 	assert.Equal(t, "resolve-types-stack", result.Outputs["StackName"])
 	assert.Equal(t, "x-y-z", result.Outputs["JoinResult"])
+	// A scalar context rejoins Fn::Split's list rather than truncating (#521).
+	assert.Equal(t, "a/b/c", result.Outputs["SplitJoined"])
 	assert.NotEmpty(t, result.Outputs["AccountId"])
 }
 


### PR DESCRIPTION
## Summary

`Fn::Split` resolved to its **first element only**. `resolveValue` returns a
`string`, so every list-valued intrinsic had nowhere to put a list —
`resolveFnSplitFirst` was honest about it in its own name. A container command of
`python,-m,worker` deployed as `python` while the resource reported
`CREATE_COMPLETE`: substrate reported success where the observable was wrong.

This became reachable from conventional YAML in v0.87.1. Before #516 the whole
`!Split` tag was dropped before the resolver ever saw it.

## What changed

**`resolveValueList` — the missing return shape.** A list-returning sibling to
`resolveValue`, called by the list-valued property paths. `resolveStringList`
delegates to it, so all three of its existing call sites gain full split results
with no signature change. The two live side by side because CloudFormation itself
distinguishes the contexts: the same intrinsic in a scalar property is a template
error there and a rejoined string here.

Its conventions are the ones the references state, each pinned at the seam because
the current call sites cannot observe them (`resolveStringList` drops empty members,
since a query API numbers its list parameters and would otherwise send `Member.2=`):

- a scalar is a one-element list, so a property accepting either shape needs no
  special case at the call site;
- `Ref AWS::NoValue` contributes **no** element — which is what makes
  `!If [HasCommand, !Split [',', !Ref Command], !Ref 'AWS::NoValue']` mean what it
  says;
- a nested list-valued intrinsic **splices** rather than nesting, since a list of
  lists is not a shape any AWS API member has;
- empty elements are **preserved**: `!Split ['|', 'a||c|']` is documented to return
  `["a", "", "c", ""]`.

**`Fn::Select` over `Fn::Split`.** This is the idiom the AWS `Fn::Split` reference
itself leads with, and it silently produced `""`: `resolveFnSelect` required its
second argument to be a literal `[]interface{}`, so every one of the six functions
the `Fn::Select` reference permits there — `Fn::FindInMap`, `Fn::GetAtt`,
`Fn::GetAZs`, `Fn::If`, `Fn::Split`, `Ref` — resolved to nothing with no error
reported. The list argument now goes through `resolveValueList`.

**A `Ref` to a list-typed parameter is list-valued.** `SecurityGroupIds: !Ref
SubnetIds` reached the API as one string containing commas rather than as several
IDs. Which parameters are list-valued comes from the **declared type**
(`CommaDelimitedList`, `List<Number>`, `List<AWS::EC2::Subnet::Id>`, …) rather than
from whether a value happens to contain a comma — a `String` holding `a,b` is one
value — and each member is space-trimmed, as the Parameters reference specifies:
*"each member string is space trimmed"*.

**Scalar context rejoins rather than truncates.** A scalar property has nowhere to
put a list, and real CloudFormation rejects the template. Substrate resolves rather
than rejects — a template that deploys against AWS must deploy here — so of the two
ways to spell a list as one string it now picks the one that loses nothing.
`resolveFnSplitFirst` is renamed `resolveFnSplitJoined` accordingly.

**A multi-key map is no longer resolved as an intrinsic.** Found by mutation
testing, and the sharper half of the defect. Every intrinsic CloudFormation defines
is a one-member object, but the resolver walked a map of *any* size and returned
whichever recognized key Go's map iteration reached first — so a property carrying
both `Ref` and another member resolved two different ways across runs. That is the
one outcome an emulator built on deterministic replay must never produce. Such a map
now falls through to its JSON encoding, which also leaves user data holding a member
named `Ref` — an ECS container definition, an IAM policy document — untouched.

## Acceptance criteria (#521)

- [x] `Fn::Split` in a list-valued property resolves to every element.
- [x] `Fn::Select` over an `Fn::Split` resolves against the full list.
- [x] `Fn::Split` in a scalar context keeps a defined, documented behavior.
- [x] The nested case works: `!If [C, !Split [',', !Ref X], !Ref 'AWS::NoValue']`,
      taken verbatim from `ecs_worker.yml`.
- [x] The `Fn::Split` caveat is removed from `docs/services.md`.

## Tests

Every gate was confirmed red before the fix. The end-to-end assertions read the
observable back through `DescribeInstances` rather than off the deploy result — a
consumer reads security groups off the instance, not off the template — and the
groups are created through the API, because `RunInstances` rejects both an unknown
group and one from another VPC, so invented IDs would have made the test pass for
the wrong reason.

Three existing tests encoded the truncation in their own assertions
(`TestCFN_FnSplit` expecting `"a"` from `a/b/c`, the YAML short-form `Split` case,
and `v016`'s `SplitFirst` output) and are retargeted, the last of them gaining the
assertion it never made.

**Mutation testing: 8 mutants, 8 CAUGHT.** Two survived on first run and each drove
a new test rather than being written off:

| Mutant | First run | After |
|---|---|---|
| `resolveValueList` truncates `Fn::Split` to `[:1]` | CAUGHT | — |
| `AWS::NoValue` yields an empty element instead of none | **SURVIVED** — every caller filters empties, so no test could see it | CAUGHT by the seam test |
| `resolveRefList` ignores the declared type | CAUGHT | — |
| `resolveFnSelect` reverts to requiring a literal list | CAUGHT | — |
| `splitFnSplit` drops empty elements | CAUGHT | — |
| `resolveValueList` resolves a multi-key map | **SURVIVED** — this was a real defect, not an equivalent mutant | fixed in `resolveValue` too; CAUGHT |
| `splitParameterList` does not trim members | CAUGHT | — |
| `resolveFnSplitJoined` truncates (the original defect) | CAUGHT | — |

New functions are at 96.7–100% statement coverage.

## Compatibility

Two resolutions change for a template that already deployed:

- `Fn::Split` in a **scalar** property now yields the whole source string where it
  yielded the first element. A test asserting on the truncated value will need
  updating; it was asserting on a defect.
- A property that is a **multi-key** map containing `Ref` (or another intrinsic
  name) alongside other keys is now left alone rather than resolved. Which key it
  resolved to before depended on map iteration order, so nothing could have relied
  on it.

## Verification

`gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → 0
issues, `make test` (race), `make docs-reference-check docs-versions`,
`npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test -C test/e2e
./...` — all pass.

Closes #521
