### PR TITLE
fix(cfn): resolve intrinsics at any depth, and map ECS member names (#526, #527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that happens to carry a member named `Ref` — an ECS container definition, an IAM
   policy document — untouched.
 
+- **Intrinsics resolve at any depth inside a structured property** (#526).
+  `resolveValue` resolves a value that *is* an intrinsic; nothing walked into a map
+  or a list to resolve one nested within. So a deploy path that forwarded a
+  structured property whole handed the plugin `{"Ref": "PK"}` as a literal object:
+  DynamoDB's typed plugin rejected it (`SerializationException: cannot unmarshal
+  object into Go struct field … of type string`, the resource `CREATE_FAILED`) while
+  an untyped plugin stored it and echoed it back. Which of a consumer's properties
+  resolved depended on how each deploy path happened to have been written — some
+  enumerate their members key by key, others forward them verbatim.
+
+  A new `resolveNested` walks a property and returns a structurally identical value
+  with every intrinsic resolved, applied at the verbatim-forwarding sites: ECS's
+  `ContainerDefinitions`, DynamoDB's `KeySchema`, `AttributeDefinitions`,
+  `ProvisionedThroughput`, `GlobalSecondaryIndexes`, `LocalSecondaryIndexes` and
+  `StreamSpecification`, ACM's `SubjectAlternativeNames`, MSK's `BrokerNodeGroupInfo`
+  and FSx's `SubnetIds` and `Tags` — the last three had asserted their property was a
+  literal `string` and silently dropped anything else, so a `!Ref`-valued subnet list
+  or the near-universal `Value: !Sub '${AWS::StackName}-data'` tag never reached the
+  API at all. Four rules a naive walk gets wrong are pinned by tests: only a
+  single-key map is an intrinsic (a multi-key map is user data even when one key is
+  `Ref` — the same map-iteration nondeterminism #521 fixed a level up); a
+  list-valued intrinsic in a list position splices its elements; an `Fn::If`
+  yielding `AWS::NoValue` **removes** the property rather than leaving an empty
+  string behind; and resolution never rewrites a key, since that is what would
+  mangle a `logConfiguration.options` whose keys are user data.
+
+- **ECS container definitions reach the ECS API under the ECS API's member names**
+  (#527). CloudFormation spells a container's members in PascalCase where the ECS
+  API spells them in camelCase, and the CFN deploy path forwarded them as written.
+  `ContainerDefinitions` is untyped both in `RegisterTaskDefinition`'s request and
+  in state, so there was nothing to reject them: the stack reached
+  `CREATE_COMPLETE`, `DescribeTaskDefinition` answered `200`, and
+  `--query 'taskDefinition.containerDefinitions'` returned `[{}]` — every member
+  present under a name no SDK reads. A direct `RegisterTaskDefinition` call was
+  never affected; the mismatch was introduced by the deploy path alone.
+
+  The mapping is an explicit table of all 42 `ContainerDefinition` members plus the
+  11 nested types (`environment`, `secrets`, `portMappings`, `logConfiguration`,
+  `mountPoints`, `volumesFrom`, `healthCheck`, `ulimits`, `dependsOn`,
+  `extraHosts`, `systemControls`), verified member by member against each type's own
+  API reference page. It is deliberately a table rather than a first-letter-lowering
+  function — which would be right for all 42 today — because only a table can tell
+  "not mapped" from "mapped to itself", so a member added to the API later passes
+  through verbatim instead of being renamed to something ECS does not accept. It is
+  also deliberately **per-service**: DynamoDB, ACM and MSK are natively PascalCase,
+  and a generic converter is precisely the change that would break them.
+  `logConfiguration.options` and `dockerLabels` are named by their parent's table and
+  then left whole, their keys being user data.
+
 ## [v0.87.1] - 2026-08-03
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -228,9 +228,31 @@ element. A `CommaDelimitedList` (or `List<…>`) parameter is list-valued too: a
 string. Whether a `Ref` is list-valued comes from the parameter's declared type,
 not from whether its value happens to contain a comma.
 
-`Ref 'AWS::NoValue'` in a list position contributes **no** element, which is what
-makes the conventional `!If [HasCommand, !Split [',', !Ref Command], !Ref
-'AWS::NoValue']` idiom work.
+`Ref 'AWS::NoValue'` in a list position contributes **no** element, and as a
+*property's whole value* it **removes the property**, which is what makes the
+conventional `!If [HasCommand, !Split [',', !Ref Command], !Ref 'AWS::NoValue']`
+idiom work: the property is absent rather than present-and-empty, and an API that
+rejects an empty value sees what it would see from real CloudFormation.
+
+Intrinsics resolve **at any depth** inside a structured property, not only where
+the property's whole value is one. A `Ref` inside `KeySchema`, an `Fn::Sub` inside
+a container definition's `Environment`, an `Fn::Split` nested in a list — all
+resolve, and a nested list-valued intrinsic contributes its elements to the list
+holding it rather than one rejoined string. Two rules bound the walk:
+
+- Only a **single-key** map is an intrinsic. A map with several keys is user data
+  even when one of them is named `Ref`, so a property whose interior is a
+  caller-supplied map — a log driver's `Options`, an IAM policy `Condition` block
+  — keeps its own shape.
+- **Keys are never rewritten by resolution.** Where a property's member names
+  differ between CloudFormation and the service's API — ECS spells a container's
+  members in camelCase where CloudFormation spells them PascalCase — that mapping
+  is per-service and applied separately, and it stops at any member whose keys are
+  user-supplied.
+
+A resolved intrinsic is a **string**, or a list of strings where the intrinsic is
+list-valued. So `"Cpu": {"Ref": "Cpu"}` reaches the API as `"256"` where a literal
+`256` would have stayed a number; a literal is never retyped.
 
 Where the property is scalar and has nowhere to put a list — an `Outputs` value,
 say — `Fn::Split`'s elements are rejoined on the delimiter, reproducing the

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -1874,26 +1874,28 @@ func (d *StackDeployer) deployDynamoDBTable(
 		"TableName": tableName,
 	}
 
-	if keySchema, ok := props["KeySchema"]; ok {
-		body["KeySchema"] = keySchema
-	}
-	if attrDefs, ok := props["AttributeDefinitions"]; ok {
-		body["AttributeDefinitions"] = attrDefs
+	// The DynamoDB API is natively PascalCase, so these properties are forwarded
+	// under CloudFormation's own member names — only the intrinsics inside them
+	// need resolving (#526).
+	// A literal passes through resolveNested untouched, so walking these costs a
+	// numeric member nothing: `{"ReadCapacityUnits": 5}` stays the integer 5. An
+	// intrinsic *inside* a numeric member is the one case still unresolvable,
+	// since a resolved intrinsic is a string — but that member fails to
+	// unmarshal today either way, so the walk does not make it worse.
+	for _, key := range []string{
+		"KeySchema",
+		"AttributeDefinitions",
+		"ProvisionedThroughput",
+		"GlobalSecondaryIndexes",
+		"LocalSecondaryIndexes",
+		"StreamSpecification",
+	} {
+		if v, ok := props[key]; ok {
+			body[key] = resolveNested(v, cctx)
+		}
 	}
 	if billingMode, ok := props["BillingMode"]; ok {
 		body["BillingMode"] = resolveValue(billingMode, cctx)
-	}
-	if pt, ok := props["ProvisionedThroughput"]; ok {
-		body["ProvisionedThroughput"] = pt
-	}
-	if gsis, ok := props["GlobalSecondaryIndexes"]; ok {
-		body["GlobalSecondaryIndexes"] = gsis
-	}
-	if lsis, ok := props["LocalSecondaryIndexes"]; ok {
-		body["LocalSecondaryIndexes"] = lsis
-	}
-	if ss, ok := props["StreamSpecification"]; ok {
-		body["StreamSpecification"] = ss
 	}
 
 	bodyBytes, err := json.Marshal(body)
@@ -3299,6 +3301,201 @@ func splitParameterList(v string) []string {
 // list type is spelled List<…> (List<Number>, List<AWS::EC2::Subnet::Id>, …).
 func cfnListParameterType(t string) bool {
 	return t == "CommaDelimitedList" || strings.HasPrefix(t, "List<")
+}
+
+// resolveNested resolves intrinsics at any depth inside a structured property,
+// returning a structurally identical value.
+//
+// resolveValue resolves a value that *is* an intrinsic; nothing walked into a
+// map or a list to resolve one nested within (#526). So a deploy path that
+// forwards a structured property whole — ContainerDefinitions, KeySchema,
+// AttributeDefinitions — handed the plugin `{"Ref": "PK"}` as a literal object,
+// which a typed plugin rejects and an untyped one stores. Real CloudFormation
+// resolves intrinsics at any depth, and which of a consumer's properties
+// resolved here depended on how each deploy path happened to have been written.
+//
+// Four rules that a naive walk gets wrong:
+//
+//   - Only a *single-key* map is an intrinsic, even when one of several keys is
+//     "Ref". A multi-key map is user data — and resolving one made the result
+//     depend on Go's map iteration order, which #521 fixed in resolveValue for
+//     the same reason.
+//   - A recognized intrinsic in a *list* position resolves through
+//     resolveValueList and splices, so a nested Fn::Split contributes its
+//     elements rather than one rejoined string.
+//   - Fn::If yielding AWS::NoValue *removes* the property, as CloudFormation
+//     does, rather than leaving an empty string behind. That is what
+//     `!If [HasCommand, !Split [...], !Ref 'AWS::NoValue']` is written to say.
+//   - Keys are never rewritten. Mapping a property's member names is a
+//     per-service concern (#527) and conflating it with resolution is how
+//     logConfiguration.options — whose keys are user data — would get mangled.
+//
+// A resolved intrinsic becomes a string, or a list of strings when the intrinsic
+// is list-valued — this walk returns interface{}, so unlike resolveValue it can
+// carry the list rather than rejoining it (#521). A resolved scalar is always a
+// *string*, though: a template that writes `"Cpu": {"Ref": "Cpu"}` gets "256"
+// where a literal `256` would have stayed a number, so a plugin needing a typed
+// member keeps resolving that member itself.
+func resolveNested(v interface{}, cctx *cfnContext) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		if isCFNIntrinsic(val) {
+			return resolveIntrinsicPreservingShape(val, cctx)
+		}
+		out := make(map[string]interface{}, len(val))
+		for k, item := range val {
+			// An Fn::If choosing AWS::NoValue removes the member, so the walk
+			// has to distinguish "resolved to nothing" from "resolved to an
+			// empty string" before writing the key back.
+			if isCFNNoValue(item, cctx) {
+				continue
+			}
+			out[k] = resolveNested(item, cctx)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, 0, len(val))
+		for _, item := range val {
+			m, isMap := item.(map[string]interface{})
+			if isMap && isCFNIntrinsic(m) {
+				// A list position is where a list-valued intrinsic belongs, so
+				// its elements splice in rather than nesting.
+				for _, s := range resolveValueList(m, cctx) {
+					out = append(out, s)
+				}
+				continue
+			}
+			out = append(out, resolveNested(item, cctx))
+		}
+		return out
+	}
+	return v
+}
+
+// resolveIntrinsicPreservingShape resolves an intrinsic to a string or, when the
+// intrinsic is list-valued, to a list of strings.
+//
+// A structured property's member can hold either shape — ECS's `command` is a
+// list of strings where its `image` is one string — and JSON can express both, so
+// resolveValue's rejoin (#521), which exists only because it must return a
+// string, would be a loss here. The list-valued forms are exactly the ones
+// resolveValueList recognizes: Fn::Split, a Ref to a list-typed parameter, and an
+// Fn::If whose chosen branch is one of those.
+func resolveIntrinsicPreservingShape(m map[string]interface{}, cctx *cfnContext) interface{} {
+	if !cfnListValuedIntrinsic(m, cctx) {
+		return resolveValue(m, cctx)
+	}
+	list := resolveValueList(m, cctx)
+	// []string would marshal correctly, but []interface{} keeps the walk's
+	// result comparable to the literal lists alongside it, which arrive from
+	// encoding/json as []interface{}.
+	out := make([]interface{}, 0, len(list))
+	for _, s := range list {
+		out = append(out, s)
+	}
+	return out
+}
+
+// cfnListValuedIntrinsic reports whether an intrinsic resolves to a list.
+//
+// Fn::If is transparent: it is list-valued exactly when the branch its condition
+// selects is, which is why the condition has to be evaluated here rather than the
+// two branches inspected structurally.
+func cfnListValuedIntrinsic(m map[string]interface{}, cctx *cfnContext) bool {
+	if len(m) != 1 {
+		return false
+	}
+	for fn, args := range m {
+		switch fn {
+		case "Fn::Split":
+			return true
+		case "Ref":
+			name, ok := args.(string)
+			return ok && cctx.listParams[name]
+		case "Fn::If":
+			arr, ok := args.([]interface{})
+			if !ok || len(arr) < 3 {
+				return false
+			}
+			condName, ok := arr[0].(string)
+			if !ok {
+				return false
+			}
+			branch := arr[2]
+			if cctx.condition(condName) {
+				branch = arr[1]
+			}
+			// A literal list branch is list-valued too:
+			// `!If [C, ['a','b'], !Ref 'AWS::NoValue']`.
+			if _, isList := branch.([]interface{}); isList {
+				return true
+			}
+			inner, isMap := branch.(map[string]interface{})
+			return isMap && cfnListValuedIntrinsic(inner, cctx)
+		}
+	}
+	return false
+}
+
+// cfnIntrinsicNames are the intrinsic function keys resolveValue recognizes,
+// plus Ref. A map is an intrinsic only when it has exactly one key and that key
+// is one of these.
+var cfnIntrinsicNames = map[string]bool{
+	"Ref":        true,
+	"Fn::Sub":    true,
+	"Fn::Join":   true,
+	"Fn::Select": true,
+	"Fn::Split":  true,
+	"Fn::Base64": true,
+	"Fn::GetAtt": true,
+	"Fn::If":     true,
+}
+
+// isCFNIntrinsic reports whether a map is an intrinsic function invocation.
+//
+// Every intrinsic CloudFormation defines is a one-member object, so a map with
+// any other size is user data regardless of what its keys are named.
+func isCFNIntrinsic(m map[string]interface{}) bool {
+	if len(m) != 1 {
+		return false
+	}
+	for k := range m {
+		return cfnIntrinsicNames[k]
+	}
+	return false
+}
+
+// isCFNNoValue reports whether a value resolves to AWS::NoValue, directly or
+// through an Fn::If branch, and so should remove the member holding it.
+//
+// The recursion follows Fn::If only: that is the one intrinsic whose result can
+// *be* a Ref to AWS::NoValue, and it is the form a template uses to say "this
+// property, or nothing".
+func isCFNNoValue(v interface{}, cctx *cfnContext) bool {
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) != 1 {
+		return false
+	}
+	if ref, has := m["Ref"]; has {
+		name, isStr := ref.(string)
+		return isStr && name == "AWS::NoValue"
+	}
+	args, has := m["Fn::If"]
+	if !has {
+		return false
+	}
+	arr, isArr := args.([]interface{})
+	if !isArr || len(arr) < 3 {
+		return false
+	}
+	name, isStr := arr[0].(string)
+	if !isStr {
+		return false
+	}
+	if cctx.condition(name) {
+		return isCFNNoValue(arr[1], cctx)
+	}
+	return isCFNNoValue(arr[2], cctx)
 }
 
 func resolveRef(ref string, cctx *cfnContext) string {

--- a/emulator/betty_cfn_nested_test.go
+++ b/emulator/betty_cfn_nested_test.go
@@ -1,0 +1,903 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// newECSDynamoTestDeployer creates a StackDeployer with the ECS and DynamoDB
+// plugins and returns the registry, so a test can read a deployed resource back
+// through the same API a consumer's SDK would call.
+//
+// Reading back through the plugin is the point: #527's whole symptom is that the
+// deploy result and the stack status are both correct while the container list a
+// consumer parses is empty, so an assertion on the DeployResult cannot see it.
+func newECSDynamoTestDeployer(t *testing.T) (*emulator.StackDeployer, *emulator.PluginRegistry, *emulator.EventStore) {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	// IncludeBodies, so a test can assert on the exact bytes a deploy path put on
+	// the wire. That is the only place a *casing* defect is observable for a
+	// service whose plugin is typed: encoding/json matches a field
+	// case-insensitively absent an exact match, so DynamoDB's PascalCase struct
+	// reads "keySchema" perfectly well and a read-back agrees with the defect.
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:       true,
+		Backend:       "memory",
+		IncludeBodies: true,
+	})
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+
+	opts := emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}
+	for _, p := range []emulator.Plugin{
+		&emulator.ECSPlugin{},
+		&emulator.DynamoDBPlugin{},
+	} {
+		require.NoError(t, p.Initialize(context.Background(), opts))
+		registry.Register(p)
+	}
+
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs), registry, store
+}
+
+// dispatchedBody returns the raw request body the deploy path sent for the named
+// service and operation.
+//
+// The event store is the only view of what actually went over the wire. A
+// read-back through the plugin cannot substitute for it when the question is a
+// member's *name*, because the plugin unmarshals the name it was sent and
+// re-marshals the name its own struct is tagged with.
+func dispatchedBody(t *testing.T, store *emulator.EventStore, service, operation string) []byte {
+	t.Helper()
+	events, err := store.GetEvents(context.Background(), emulator.EventFilter{
+		Service:   service,
+		Operation: operation,
+	})
+	require.NoError(t, err)
+	require.Len(t, events, 1, "expected exactly one %s %s request", service, operation)
+	require.NotNil(t, events[0].Request, "the event store must have captured the body")
+	return events[0].Request.Body
+}
+
+// routeJSON sends a JSON-protocol request through the registry.
+func routeJSON(
+	t *testing.T,
+	registry *emulator.PluginRegistry,
+	service, target, op string,
+	body []byte,
+) (*emulator.AWSResponse, error) {
+	t.Helper()
+	return registry.RouteRequest(&emulator.RequestContext{
+		RequestID: "test-request",
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		Timestamp: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+	}, &emulator.AWSRequest{
+		Service:   service,
+		Operation: op,
+		Headers:   map[string]string{"X-Amz-Target": target},
+		Body:      body,
+		Params:    map[string]string{},
+	})
+}
+
+// describeTaskDefinition reads a task definition back through the ECS plugin and
+// returns its containerDefinitions as raw JSON.
+//
+// The container list is returned as json.RawMessage rather than unmarshalled into
+// a typed struct because the defect is a *key name*: a struct with `json:"name"`
+// tags would read nothing from a PascalCase body, and a struct tagged PascalCase
+// would agree with the defect. Only the raw member names can tell them apart.
+func describeTaskDefinition(t *testing.T, registry *emulator.PluginRegistry, family string) []map[string]json.RawMessage {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"taskDefinition": family})
+	require.NoError(t, err)
+
+	resp, err := routeJSON(t, registry, "ecs",
+		"AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition", "DescribeTaskDefinition", body)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode, "DescribeTaskDefinition: %s", resp.Body)
+
+	var out struct {
+		TaskDefinition struct {
+			ContainerDefinitions []map[string]json.RawMessage `json:"containerDefinitions"`
+		} `json:"taskDefinition"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	return out.TaskDefinition.ContainerDefinitions
+}
+
+// rawString unmarshals a JSON member expected to hold a string.
+func rawString(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var s string
+	require.NoError(t, json.Unmarshal(raw, &s), "not a JSON string: %s", raw)
+	return s
+}
+
+// TestCFN_ECSContainerDefinitions_MemberNamesAndNesting is #527's own
+// reproduction plus #526's: a CloudFormation-declared container reaches the ECS
+// plugin under the ECS API's member names, with the intrinsics inside it
+// resolved.
+//
+// Before this, the stack reached CREATE_COMPLETE, DescribeTaskDefinition answered
+// 200, and `--query 'taskDefinition.containerDefinitions'` returned `[{}]`.
+func TestCFN_ECSContainerDefinitions_MemberNamesAndNesting(t *testing.T) {
+	d, registry, _ := newECSDynamoTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {
+			"Image":    {"Type": "String", "Default": "python:3.11"},
+			"Command":  {"Type": "String", "Default": "python,-m,worker"},
+			"LogGroup": {"Type": "String", "Default": "/ecs/worker"}
+		},
+		"Resources": {
+			"TD": {
+				"Type": "AWS::ECS::TaskDefinition",
+				"Properties": {
+					"Family": "member-names",
+					"ContainerDefinitions": [{
+						"Name": "worker",
+						"Image": {"Ref": "Image"},
+						"Essential": true,
+						"Command": {"Fn::Split": [",", {"Ref": "Command"}]},
+						"Environment": [
+							{"Name": "MODE", "Value": {"Fn::Sub": "${AWS::Region}-prod"}}
+						],
+						"PortMappings": [
+							{"ContainerPort": 8080, "Protocol": "tcp"}
+						],
+						"LogConfiguration": {
+							"LogDriver": "awslogs",
+							"Options": {
+								"awslogs-group":         {"Ref": "LogGroup"},
+								"awslogs-region":        {"Ref": "AWS::Region"},
+								"awslogs-stream-prefix": "worker"
+							}
+						}
+					}]
+				}
+			}
+		}
+	}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "member-names-stack", nil)
+	require.NoError(t, err)
+	assert.Empty(t, findResource(t, result, "TD").Error)
+
+	cdefs := describeTaskDefinition(t, registry, "member-names")
+	require.Len(t, cdefs, 1)
+	c := cdefs[0]
+
+	// The keys an SDK reads.
+	assert.Equal(t, "worker", rawString(t, c["name"]))
+	assert.Equal(t, "python:3.11", rawString(t, c["image"]), "a Ref inside a container definition resolves")
+	assert.JSONEq(t, `true`, string(c["essential"]))
+
+	// The PascalCase names must be gone entirely, not merely duplicated.
+	for _, pascal := range []string{"Name", "Image", "Essential", "Command", "Environment", "PortMappings", "LogConfiguration"} {
+		assert.NotContains(t, c, pascal, "CloudFormation's %q must not reach the ECS API", pascal)
+	}
+
+	// #521's list return, observed where it was reported: the command is three
+	// elements, not one string and not an Fn::Split object.
+	assert.JSONEq(t, `["python","-m","worker"]`, string(c["command"]))
+
+	// A nested structured member's own keys are mapped too, and an Fn::Sub
+	// inside one resolves.
+	assert.JSONEq(t, `[{"name":"MODE","value":"us-east-1-prod"}]`, string(c["environment"]))
+	assert.JSONEq(t, `[{"containerPort":8080,"protocol":"tcp"}]`, string(c["portMappings"]),
+		"a literal number stays a number")
+
+	// logConfiguration's own members are mapped; its options keys are user data
+	// and are carried through verbatim, values resolved.
+	assert.JSONEq(t, `{
+		"logDriver": "awslogs",
+		"options": {
+			"awslogs-group":         "/ecs/worker",
+			"awslogs-region":        "us-east-1",
+			"awslogs-stream-prefix": "worker"
+		}
+	}`, string(c["logConfiguration"]))
+}
+
+// TestCFN_ECSContainerDefinitions_UnknownMemberSurvives pins that a member
+// substrate has not enumerated passes through unchanged rather than being
+// lowercased or dropped.
+//
+// The alternative — a first-letter-lowering function — would be shorter and would
+// even be right for all 42 members ECS defines today, but it cannot tell "not
+// mapped" from "mapped to itself", so a member added to the API after this table
+// was written would be silently renamed to something ECS does not accept. A
+// verbatim unknown member is visible in a response; a corrupted one is not.
+func TestCFN_ECSContainerDefinitions_UnknownMemberSurvives(t *testing.T) {
+	d, registry, _ := newECSDynamoTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"TD": {
+				"Type": "AWS::ECS::TaskDefinition",
+				"Properties": {
+					"Family": "unknown-member",
+					"ContainerDefinitions": [{
+						"Name": "worker",
+						"SomeFutureMember": "kept-verbatim"
+					}]
+				}
+			}
+		}
+	}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "unknown-member-stack", nil)
+	require.NoError(t, err)
+	assert.Empty(t, findResource(t, result, "TD").Error)
+
+	cdefs := describeTaskDefinition(t, registry, "unknown-member")
+	require.Len(t, cdefs, 1)
+	assert.Equal(t, "worker", rawString(t, cdefs[0]["name"]))
+	assert.Equal(t, "kept-verbatim", rawString(t, cdefs[0]["SomeFutureMember"]),
+		"an unmapped member is delivered verbatim rather than guessed at")
+}
+
+// TestCFN_ECSContainerDefinitions_NoValueRemovesMember covers the form
+// ecs_worker.yml writes: a property that is present or absent according to a
+// condition.
+//
+// CloudFormation *removes* the property when Fn::If chooses AWS::NoValue. Leaving
+// an empty string or an empty list behind would make ECS see a container that
+// overrides its image's entrypoint with nothing.
+func TestCFN_ECSContainerDefinitions_NoValueRemovesMember(t *testing.T) {
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {
+			"Command": {"Type": "String", "Default": ""}
+		},
+		"Conditions": {
+			"HasCommand": {"Fn::Not": [{"Fn::Equals": [{"Ref": "Command"}, ""]}]}
+		},
+		"Resources": {
+			"TD": {
+				"Type": "AWS::ECS::TaskDefinition",
+				"Properties": {
+					"Family": "novalue",
+					"ContainerDefinitions": [{
+						"Name": "worker",
+						"Image": "python:3.11",
+						"Command": {"Fn::If": [
+							"HasCommand",
+							{"Fn::Split": [",", {"Ref": "Command"}]},
+							{"Ref": "AWS::NoValue"}
+						]}
+					}]
+				}
+			}
+		}
+	}`
+
+	t.Run("condition false removes the member", func(t *testing.T) {
+		d, registry, _ := newECSDynamoTestDeployer(t)
+		result, err := d.Deploy(context.Background(), tmpl, "novalue-absent", nil)
+		require.NoError(t, err)
+		assert.Empty(t, findResource(t, result, "TD").Error)
+
+		cdefs := describeTaskDefinition(t, registry, "novalue")
+		require.Len(t, cdefs, 1)
+		assert.NotContains(t, cdefs[0], "command",
+			"AWS::NoValue removes the member rather than emptying it")
+		assert.NotContains(t, cdefs[0], "Command")
+		assert.Equal(t, "python:3.11", rawString(t, cdefs[0]["image"]))
+	})
+
+	t.Run("condition true resolves the list", func(t *testing.T) {
+		d, registry, _ := newECSDynamoTestDeployer(t)
+		result, err := d.Deploy(context.Background(), tmpl, "novalue-present", map[string]string{
+			"Command": "python,-m,worker",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, findResource(t, result, "TD").Error)
+
+		cdefs := describeTaskDefinition(t, registry, "novalue")
+		require.Len(t, cdefs, 1)
+		assert.JSONEq(t, `["python","-m","worker"]`, string(cdefs[0]["command"]))
+	})
+}
+
+// TestCFN_DynamoDB_NestedRefInKeySchema is #526's own reproduction. A
+// `{"Ref": "PK"}` inside KeySchema failed the resource outright, the typed
+// DynamoDB plugin rejecting the object:
+//
+//	SerializationException: Failed to parse request: json: cannot unmarshal
+//	object into Go struct field
+//	DynamoDBAttributeDefinition.AttributeDefinitions.AttributeName of type string
+//
+// The table is read back through DescribeTable, because a resource reporting
+// CREATE_COMPLETE is exactly what #519 taught not to trust on its own.
+func TestCFN_DynamoDB_NestedRefInKeySchema(t *testing.T) {
+	d, registry, store := newECSDynamoTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {"PK": {"Type": "String", "Default": "pk"}},
+		"Resources": {
+			"T": {
+				"Type": "AWS::DynamoDB::Table",
+				"Properties": {
+					"TableName": "nested-probe",
+					"BillingMode": "PAY_PER_REQUEST",
+					"KeySchema": [{"AttributeName": {"Ref": "PK"}, "KeyType": "HASH"}],
+					"AttributeDefinitions": [{"AttributeName": {"Ref": "PK"}, "AttributeType": "S"}]
+				}
+			}
+		}
+	}`
+
+	result, err := d.Deploy(context.Background(), tmpl, "ddb-nested-stack", nil)
+	require.NoError(t, err)
+	assert.Empty(t, findResource(t, result, "T").Error)
+
+	body, err := json.Marshal(map[string]any{"TableName": "nested-probe"})
+	require.NoError(t, err)
+	resp, err := routeJSON(t, registry, "dynamodb",
+		"DynamoDB_20120810.DescribeTable", "DescribeTable", body)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode, "DescribeTable: %s", resp.Body)
+
+	var out struct {
+		Table struct {
+			KeySchema []struct {
+				AttributeName string `json:"AttributeName"`
+				KeyType       string `json:"KeyType"`
+			} `json:"KeySchema"`
+			AttributeDefinitions []struct {
+				AttributeName string `json:"AttributeName"`
+				AttributeType string `json:"AttributeType"`
+			} `json:"AttributeDefinitions"`
+		} `json:"Table"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+
+	// DynamoDB's API is natively PascalCase, so these member names are
+	// CloudFormation's own — the guard against a generic case converter.
+	require.Len(t, out.Table.KeySchema, 1)
+	assert.Equal(t, "pk", out.Table.KeySchema[0].AttributeName)
+	assert.Equal(t, "HASH", out.Table.KeySchema[0].KeyType)
+	require.Len(t, out.Table.AttributeDefinitions, 1)
+	assert.Equal(t, "pk", out.Table.AttributeDefinitions[0].AttributeName)
+	assert.Equal(t, "S", out.Table.AttributeDefinitions[0].AttributeType)
+
+	// The bytes, not the round-trip. #527's key mapping is per-service precisely
+	// because a converter that helped ECS would corrupt this request, and only the
+	// raw body can tell — the assertions above pass either way.
+	sent := string(dispatchedBody(t, store, "dynamodb", "CreateTable"))
+	for _, member := range []string{
+		`"TableName"`, `"KeySchema"`, `"AttributeName"`, `"KeyType"`,
+		`"AttributeDefinitions"`, `"AttributeType"`, `"BillingMode"`,
+	} {
+		assert.Contains(t, sent, member,
+			"the DynamoDB API is natively PascalCase; %s must reach it as CloudFormation spells it", member)
+	}
+	for _, camel := range []string{
+		`"tableName"`, `"keySchema"`, `"attributeName"`, `"keyType"`,
+		`"attributeDefinitions"`, `"attributeType"`, `"billingMode"`,
+	} {
+		assert.NotContains(t, sent, camel,
+			"a generic case converter would produce %s, which DynamoDB does not define", camel)
+	}
+}
+
+// TestResolveNested_Conventions pins resolveNested's four rules at the seam.
+//
+// Each is a rule a naive walk gets wrong, and most are invisible through the
+// deploy paths: a plugin that stores an untyped property cannot report that a key
+// was rewritten, and a multi-key map resolving to whichever key Go's map
+// iteration reached first is a race that a single deploy passes by luck.
+func TestResolveNested_Conventions(t *testing.T) {
+	params := map[string]string{
+		"Image":   "python:3.11",
+		"Command": "python,-m,worker",
+		"Empty":   "",
+		"Subnets": "subnet-1, subnet-2",
+	}
+	listParams := map[string]bool{"Subnets": true}
+	conditions := map[string]bool{"Yes": true, "No": false}
+
+	cases := []struct {
+		name string
+		in   interface{}
+		want interface{}
+	}{
+		{
+			name: "a literal is returned unchanged, keeping its type",
+			in:   map[string]interface{}{"ContainerPort": float64(8080), "Essential": true},
+			want: map[string]interface{}{"ContainerPort": float64(8080), "Essential": true},
+		},
+		{
+			name: "an intrinsic nested in a map resolves",
+			in:   map[string]interface{}{"Image": map[string]interface{}{"Ref": "Image"}},
+			want: map[string]interface{}{"Image": "python:3.11"},
+		},
+		{
+			name: "an intrinsic nested in a list element resolves",
+			in: []interface{}{
+				map[string]interface{}{"AttributeName": map[string]interface{}{"Ref": "Command"}},
+			},
+			want: []interface{}{map[string]interface{}{"AttributeName": "python,-m,worker"}},
+		},
+		{
+			name: "an intrinsic at arbitrary depth resolves",
+			in: map[string]interface{}{
+				"a": []interface{}{map[string]interface{}{
+					"b": map[string]interface{}{"c": map[string]interface{}{"Ref": "Image"}},
+				}},
+			},
+			want: map[string]interface{}{
+				"a": []interface{}{map[string]interface{}{
+					"b": map[string]interface{}{"c": "python:3.11"},
+				}},
+			},
+		},
+		{
+			// A list position is where a list-valued intrinsic belongs, so its
+			// elements splice rather than nesting.
+			name: "a list-valued intrinsic in a list position splices",
+			in: []interface{}{
+				"first",
+				map[string]interface{}{"Fn::Split": []interface{}{",", map[string]interface{}{"Ref": "Command"}}},
+			},
+			want: []interface{}{"first", "python", "-m", "worker"},
+		},
+		{
+			// The property itself is the intrinsic, which is how ECS's
+			// `"Command": !Split [',', !Ref Command]` arrives — and a `command`
+			// is a list of strings, so this member must *be* a list.
+			//
+			// This is where resolveNested departs from resolveValue rather than
+			// delegating to it: resolveValue rejoins on the delimiter (#521)
+			// because it has to return a string, and returning interface{} means
+			// this walk does not have to make that trade.
+			name: "a member that is a list-valued intrinsic resolves to a list",
+			in: map[string]interface{}{
+				"Command": map[string]interface{}{
+					"Fn::Split": []interface{}{",", map[string]interface{}{"Ref": "Command"}},
+				},
+			},
+			want: map[string]interface{}{
+				"Command": []interface{}{"python", "-m", "worker"},
+			},
+		},
+		{
+			// A scalar intrinsic in the same position stays a string, so the
+			// list shape is the list-valued intrinsics' own and not a blanket
+			// promotion of every resolved member.
+			name: "a member that is a scalar intrinsic resolves to a string",
+			in:   map[string]interface{}{"Image": map[string]interface{}{"Fn::Join": []interface{}{":", []interface{}{"python", "3.11"}}}},
+			want: map[string]interface{}{"Image": "python:3.11"},
+		},
+		{
+			// Fn::If is transparent to list-valuedness: whether the member is a
+			// list depends on which branch the condition selects, so the
+			// condition has to be evaluated rather than the branches inspected.
+			name: "Fn::If choosing a list branch resolves to a list",
+			in: map[string]interface{}{
+				"Command": map[string]interface{}{"Fn::If": []interface{}{
+					"Yes",
+					map[string]interface{}{"Fn::Split": []interface{}{",", map[string]interface{}{"Ref": "Command"}}},
+					map[string]interface{}{"Ref": "Image"},
+				}},
+			},
+			want: map[string]interface{}{
+				"Command": []interface{}{"python", "-m", "worker"},
+			},
+		},
+		{
+			name: "Fn::If choosing a scalar branch resolves to a string",
+			in: map[string]interface{}{
+				"Command": map[string]interface{}{"Fn::If": []interface{}{
+					"No",
+					map[string]interface{}{"Fn::Split": []interface{}{",", map[string]interface{}{"Ref": "Command"}}},
+					map[string]interface{}{"Ref": "Image"},
+				}},
+			},
+			want: map[string]interface{}{"Command": "python:3.11"},
+		},
+		{
+			name: "Fn::If choosing a literal list branch resolves to a list",
+			in: map[string]interface{}{
+				"Command": map[string]interface{}{"Fn::If": []interface{}{
+					"Yes",
+					[]interface{}{"a", "b"},
+					map[string]interface{}{"Ref": "AWS::NoValue"},
+				}},
+			},
+			want: map[string]interface{}{"Command": []interface{}{"a", "b"}},
+		},
+		{
+			name: "Ref AWS::NoValue removes the member",
+			in: map[string]interface{}{
+				"Keep": "kept",
+				"Drop": map[string]interface{}{"Ref": "AWS::NoValue"},
+			},
+			want: map[string]interface{}{"Keep": "kept"},
+		},
+		{
+			name: "Fn::If choosing AWS::NoValue removes the member",
+			in: map[string]interface{}{
+				"Keep": "kept",
+				"Drop": map[string]interface{}{"Fn::If": []interface{}{
+					"No",
+					map[string]interface{}{"Ref": "Image"},
+					map[string]interface{}{"Ref": "AWS::NoValue"},
+				}},
+			},
+			want: map[string]interface{}{"Keep": "kept"},
+		},
+		{
+			name: "Fn::If choosing a value keeps the member",
+			in: map[string]interface{}{
+				"Image": map[string]interface{}{"Fn::If": []interface{}{
+					"Yes",
+					map[string]interface{}{"Ref": "Image"},
+					map[string]interface{}{"Ref": "AWS::NoValue"},
+				}},
+			},
+			want: map[string]interface{}{"Image": "python:3.11"},
+		},
+		{
+			// A property resolving to the *empty string* is not the same as an
+			// absent one: `Default: ''` plus Ref is how a template spells an
+			// optional value, and CloudFormation passes it through.
+			name: "a Ref to an empty parameter keeps the member as an empty string",
+			in:   map[string]interface{}{"Image": map[string]interface{}{"Ref": "Empty"}},
+			want: map[string]interface{}{"Image": ""},
+		},
+		{
+			// The rule #521 established for resolveValue and resolveValueList,
+			// applied here for the same two reasons: an ECS container definition
+			// or an IAM policy document may hold a member named "Ref", and
+			// resolving a multi-key map returns whichever key Go's map iteration
+			// reached first.
+			name: "a multi-key map containing Ref is user data, not an intrinsic",
+			in: map[string]interface{}{
+				"Ref":   "Image",
+				"Other": "value",
+			},
+			want: map[string]interface{}{
+				"Ref":   "Image",
+				"Other": "value",
+			},
+		},
+		{
+			name: "a multi-key map's own members still resolve",
+			in: map[string]interface{}{
+				"Ref":   map[string]interface{}{"Ref": "Image"},
+				"Other": "value",
+			},
+			want: map[string]interface{}{
+				"Ref":   "python:3.11",
+				"Other": "value",
+			},
+		},
+		{
+			// Rewriting a key is #527's job. Conflating the two is how
+			// logConfiguration.options — whose keys are user data — would get
+			// mangled.
+			name: "keys are never rewritten",
+			in: map[string]interface{}{
+				"awslogs-group": map[string]interface{}{"Ref": "Image"},
+				"MixedCase":     "kept",
+			},
+			want: map[string]interface{}{
+				"awslogs-group": "python:3.11",
+				"MixedCase":     "kept",
+			},
+		},
+		{
+			name: "an unrecognized intrinsic name is an ordinary member",
+			in:   map[string]interface{}{"Fn::Unknown": "x"},
+			want: map[string]interface{}{"Fn::Unknown": "x"},
+		},
+		{
+			// A Ref is list-valued when the parameter's *declared type* is,
+			// which is the one list-valued intrinsic whose shape cannot be seen
+			// from the template expression alone.
+			name: "a Ref to a list-typed parameter resolves to a list",
+			in:   map[string]interface{}{"SubnetIds": map[string]interface{}{"Ref": "Subnets"}},
+			want: map[string]interface{}{"SubnetIds": []interface{}{"subnet-1", "subnet-2"}},
+		},
+		{
+			name: "a Ref to a String parameter resolves to a string",
+			in:   map[string]interface{}{"SubnetId": map[string]interface{}{"Ref": "Image"}},
+			want: map[string]interface{}{"SubnetId": "python:3.11"},
+		},
+		{
+			name: "a scalar is returned as itself",
+			in:   "plain",
+			want: "plain",
+		},
+		{
+			name: "nil is returned as nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "an empty list stays an empty list",
+			in:   []interface{}{},
+			want: []interface{}{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := emulator.ResolveNestedForTest(tc.in, params, listParams, conditions)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestECSRewriteKeys_UserDataMembers pins that the key rewrite refuses to descend
+// into a member whose keys are user-supplied.
+//
+// logConfiguration.options is keyed by log-driver option names and dockerLabels
+// by whatever the consumer chose. A rewrite walk cannot tell a member name it has
+// never heard of from a user's label, so the only safe rule is to stop.
+func TestECSRewriteKeys_UserDataMembers(t *testing.T) {
+	in := []interface{}{map[string]interface{}{
+		"Name": "worker",
+		"LogConfiguration": map[string]interface{}{
+			"LogDriver": "awslogs",
+			"Options": map[string]interface{}{
+				// Deliberately named like members the table maps, to prove the
+				// walk stopped rather than merely missing them.
+				"Name":          "not-a-member",
+				"Image":         "not-a-member",
+				"awslogs-group": "/ecs/worker",
+			},
+		},
+		"DockerLabels": map[string]interface{}{
+			"Name":             "not-a-member",
+			"com.example.team": "platform",
+		},
+	}}
+
+	got := emulator.ECSRewriteContainerKeysForTest(in)
+	assert.Equal(t, []interface{}{map[string]interface{}{
+		"name": "worker",
+		"logConfiguration": map[string]interface{}{
+			"logDriver": "awslogs",
+			"options": map[string]interface{}{
+				"Name":          "not-a-member",
+				"Image":         "not-a-member",
+				"awslogs-group": "/ecs/worker",
+			},
+		},
+		"dockerLabels": map[string]interface{}{
+			"Name":             "not-a-member",
+			"com.example.team": "platform",
+		},
+	}}, got)
+}
+
+// TestECSContainerDefinitionKeys_MatchAPICase asserts the mapping table against
+// the rule every one of ECS's 42 ContainerDefinition members follows: the API
+// member name is the CloudFormation property name with its first letter lowered.
+//
+// The table is still written out rather than generated from this rule, because
+// the rule is a coincidence of this one type — an unmapped key must pass through
+// unchanged, and only a table can tell "not mapped" from "mapped to itself". This
+// test is what keeps a typo in 42 hand-written entries from shipping.
+func TestECSContainerDefinitionKeys_MatchAPICase(t *testing.T) {
+	for cfnName, apiName := range emulator.ECSContainerDefinitionKeysForTest() {
+		require.NotEmpty(t, cfnName)
+		want := string(cfnName[0]|0x20) + cfnName[1:]
+		assert.Equal(t, want, apiName, "CFN %q", cfnName)
+	}
+}
+
+// newCollateralTestDeployer creates a StackDeployer with the ACM, MSK and FSx
+// plugins and an event store that captures bodies.
+//
+// These three are #526's collateral: their deploy paths asserted a property was a
+// literal `string` and silently dropped anything else, so a `!Ref`-valued subnet
+// list or an `!Sub`-valued tag never reached the API while the resource reported
+// CREATE_COMPLETE. Their observable is the request body, since none of the three
+// echoes these members back.
+func newCollateralTestDeployer(t *testing.T) (*emulator.StackDeployer, *emulator.EventStore) {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:       true,
+		Backend:       "memory",
+		IncludeBodies: true,
+	})
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+
+	opts := emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}
+	for _, p := range []emulator.Plugin{
+		&emulator.ACMPlugin{},
+		&emulator.MSKPlugin{},
+		&emulator.FSxPlugin{},
+	} {
+		require.NoError(t, p.Initialize(context.Background(), opts))
+		registry.Register(p)
+	}
+
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs), store
+}
+
+// TestCFN_ACMSubjectAlternativeNames_Resolved pins that a SAN list carrying
+// intrinsics reaches ACM resolved and complete.
+//
+// ACM's RequestCertificate is natively PascalCase, so the member name is
+// CloudFormation's own — this is the second guard against a generic converter,
+// in a different plugin from DynamoDB's.
+func TestCFN_ACMSubjectAlternativeNames_Resolved(t *testing.T) {
+	d, store := newCollateralTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {
+			"Env":  {"Type": "String", "Default": "prod"},
+			"Alts": {"Type": "String", "Default": "a.example.com,b.example.com"}
+		},
+		"Resources": {
+			"Cert": {
+				"Type": "AWS::CertificateManager::Certificate",
+				"Properties": {
+					"DomainName": "example.com",
+					"SubjectAlternativeNames": [
+						{"Fn::Sub": "${Env}.example.com"},
+						{"Fn::Split": [",", {"Ref": "Alts"}]}
+					]
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "acm-sans", nil)
+	require.NoError(t, err)
+	assert.Empty(t, findResource(t, result, "Cert").Error)
+
+	var sent struct {
+		DomainName              string   `json:"DomainName"`
+		SubjectAlternativeNames []string `json:"SubjectAlternativeNames"`
+	}
+	require.NoError(t, json.Unmarshal(dispatchedBody(t, store, "acm", "RequestCertificate"), &sent))
+	assert.Equal(t, "example.com", sent.DomainName)
+	// The Fn::Split contributes both of its elements rather than one rejoined
+	// string, which is #521's list return observed through #526's walk.
+	assert.Equal(t, []string{"prod.example.com", "a.example.com", "b.example.com"},
+		sent.SubjectAlternativeNames)
+}
+
+// TestCFN_MSKClientSubnets_Resolved pins that a `!Ref`-valued ClientSubnets
+// reaches MSK, which a `.(string)` assertion dropped: a template names its
+// subnets with a Ref far more often than as literals.
+func TestCFN_MSKClientSubnets_Resolved(t *testing.T) {
+	d, store := newCollateralTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {
+			"Subnets": {"Type": "List<String>", "Default": "subnet-a,subnet-b"},
+			"Size":    {"Type": "String", "Default": "kafka.m5.xlarge"}
+		},
+		"Resources": {
+			"Cluster": {
+				"Type": "AWS::MSK::Cluster",
+				"Properties": {
+					"ClusterName": "cfn-kafka",
+					"BrokerNodeGroupInfo": {
+						"InstanceType": {"Ref": "Size"},
+						"ClientSubnets": {"Ref": "Subnets"}
+					}
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "msk-subnets", nil)
+	require.NoError(t, err)
+	assert.Empty(t, findResource(t, result, "Cluster").Error)
+
+	var sent struct {
+		BrokerNodeGroupInfo struct {
+			InstanceType  string   `json:"InstanceType"`
+			ClientSubnets []string `json:"ClientSubnets"`
+		} `json:"BrokerNodeGroupInfo"`
+	}
+	require.NoError(t, json.Unmarshal(dispatchedBody(t, store, "msk", "POST"), &sent))
+	assert.Equal(t, "kafka.m5.xlarge", sent.BrokerNodeGroupInfo.InstanceType)
+	assert.Equal(t, []string{"subnet-a", "subnet-b"}, sent.BrokerNodeGroupInfo.ClientSubnets)
+}
+
+// TestCFN_MSKClientSubnets_AbsentStaysEmptyList pins that an absent
+// ClientSubnets keeps its empty-slice default rather than becoming a JSON null.
+//
+// The resolved value overwrites the default only when it resolved to something,
+// because `null` and `[]` are different requests: a consumer decoding the body
+// gets a nil slice for one and an empty one for the other, and MSK's own
+// validation distinguishes them.
+func TestCFN_MSKClientSubnets_AbsentStaysEmptyList(t *testing.T) {
+	d, store := newCollateralTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"Cluster": {
+				"Type": "AWS::MSK::Cluster",
+				"Properties": {
+					"ClusterName": "cfn-kafka-bare",
+					"BrokerNodeGroupInfo": {"InstanceType": "kafka.m5.large"}
+				}
+			}
+		}
+	}`
+	_, err := d.Deploy(context.Background(), tmpl, "msk-bare", nil)
+	require.NoError(t, err)
+
+	sent := string(dispatchedBody(t, store, "msk", "POST"))
+	assert.Contains(t, sent, `"ClientSubnets":[]`)
+	assert.NotContains(t, sent, `"ClientSubnets":null`)
+}
+
+// TestCFN_FSxIntrinsicProperties_Resolved pins FSx's two dropped properties: a
+// `!Ref`-valued SubnetIds list and an `!Sub`-valued tag value.
+//
+// `Value: !Sub '${AWS::StackName}-data'` is the single most common way a template
+// writes a tag, and a `.(string)` assertion dropped every one of them — leaving
+// the key present with an empty value, which is worse than absent because it
+// looks deliberate.
+func TestCFN_FSxIntrinsicProperties_Resolved(t *testing.T) {
+	d, store := newCollateralTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Parameters": {"Subnets": {"Type": "List<String>", "Default": "subnet-a,subnet-b"}},
+		"Resources": {
+			"FS": {
+				"Type": "AWS::FSx::FileSystem",
+				"Properties": {
+					"FileSystemType": "LUSTRE",
+					"StorageCapacity": 1200,
+					"SubnetIds": {"Ref": "Subnets"},
+					"Tags": [
+						{"Key": "Name", "Value": {"Fn::Sub": "${AWS::StackName}-data"}},
+						{"Key": {"Fn::Sub": "Owner"}, "Value": "team"}
+					]
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "fsx-stack", nil)
+	require.NoError(t, err)
+	assert.Empty(t, findResource(t, result, "FS").Error)
+
+	var sent struct {
+		SubnetIds []string `json:"SubnetIds"`
+		Tags      []struct {
+			Key   string `json:"Key"`
+			Value string `json:"Value"`
+		} `json:"Tags"`
+	}
+	require.NoError(t, json.Unmarshal(dispatchedBody(t, store, "fsx", "CreateFileSystem"), &sent))
+	assert.Equal(t, []string{"subnet-a", "subnet-b"}, sent.SubnetIds)
+	require.Len(t, sent.Tags, 2)
+	assert.Equal(t, "Name", sent.Tags[0].Key)
+	assert.Equal(t, "fsx-stack-data", sent.Tags[0].Value)
+	assert.Equal(t, "Owner", sent.Tags[1].Key)
+	assert.Equal(t, "team", sent.Tags[1].Value)
+}

--- a/emulator/betty_cfn_test.go
+++ b/emulator/betty_cfn_test.go
@@ -842,6 +842,18 @@ func TestCFN_EC2Instance(t *testing.T) {
 // APIGateway, StepFunctions, ECR, ECS, Cognito, Kinesis, CloudFront and ACM.
 func newFullTestDeployer(t *testing.T) *emulator.StackDeployer {
 	t.Helper()
+	d, _ := newFullTestDeployerWithRegistry(t)
+	return d
+}
+
+// newFullTestDeployerWithRegistry is newFullTestDeployer, additionally returning
+// the registry so a test can read a deployed resource back through the same API a
+// consumer's SDK would call.
+//
+// Reading back through the registry is what a DeployResult assertion cannot do:
+// #527's symptom was a correct deploy result over an empty container list.
+func newFullTestDeployerWithRegistry(t *testing.T) (*emulator.StackDeployer, *emulator.PluginRegistry) {
+	t.Helper()
 	cfg := emulator.DefaultConfig()
 	registry := emulator.NewPluginRegistry()
 	state := emulator.NewMemoryStateManager()
@@ -890,7 +902,7 @@ func newFullTestDeployer(t *testing.T) *emulator.StackDeployer {
 		registry.Register(p)
 	}
 
-	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs)
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs), registry
 }
 
 func TestCFN_ACMCertificate(t *testing.T) {

--- a/emulator/betty_cfn_v19_plugins.go
+++ b/emulator/betty_cfn_v19_plugins.go
@@ -26,7 +26,10 @@ func (d *StackDeployer) deployACMCertificate(
 		"DomainName": domain,
 	}
 	if sans, ok := props["SubjectAlternativeNames"]; ok {
-		body["SubjectAlternativeNames"] = sans
+		// A list of domain names, so a nested Ref or Fn::Split resolves and
+		// splices (#526). ACM's RequestCertificate is natively PascalCase, so
+		// the member name is forwarded as CloudFormation spells it.
+		body["SubjectAlternativeNames"] = resolveValueList(sans, cctx)
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {

--- a/emulator/betty_cfn_v21_plugins.go
+++ b/emulator/betty_cfn_v21_plugins.go
@@ -148,7 +148,7 @@ func (d *StackDeployer) deployECSTaskDefinition(
 		"requiresCompatibilities": []string{resolveStringProp(props, "RequiresCompatibilities.0", "EC2", cctx)},
 	}
 	if cdefs, ok := props["ContainerDefinitions"]; ok {
-		body["containerDefinitions"] = cdefs
+		body["containerDefinitions"] = ecsContainerDefinitions(cdefs, cctx)
 	}
 	if cpu, ok := props["Cpu"]; ok {
 		body["cpu"] = resolveValue(cpu, cctx)
@@ -246,4 +246,194 @@ func (d *StackDeployer) deployECSCapacityProvider(
 		Type:       "AWS::ECS::CapacityProvider",
 		PhysicalID: name,
 	}, 0, nil
+}
+
+// ecsContainerDefinitionKeys maps CloudFormation's ContainerDefinition property
+// names to the member names the ECS API uses.
+//
+// CloudFormation spells the property `Image` where every ECS SDK reads `image`,
+// and the ECS plugin types ContainerDefinitions as []interface{}, so a
+// PascalCase member was stored and echoed with nothing to reject it: the stack
+// reported CREATE_COMPLETE, DescribeTaskDefinition answered 200, and
+// `describe-task-definition --query 'taskDefinition.containerDefinitions'`
+// returned `[{}]` (#527).
+//
+// The table is explicit rather than a first-letter-lowering function even though
+// all 42 members happen to follow that rule, because the rule is a coincidence
+// of this one type and not a property of AWS APIs: an unmapped key must pass
+// through *unchanged* so a member substrate has not enumerated survives instead
+// of being corrupted, and only a table can tell "not mapped" from "mapped to
+// itself". It is also deliberately not a generic case converter — DynamoDB's
+// verbatim PascalCase forwarding is correct, its API being natively PascalCase,
+// and a generic converter is exactly the change that would break it.
+//
+// Member names are from the ECS ContainerDefinition API reference.
+var ecsContainerDefinitionKeys = map[string]string{
+	"Command":                "command",
+	"Cpu":                    "cpu",
+	"CredentialSpecs":        "credentialSpecs",
+	"DependsOn":              "dependsOn",
+	"DisableNetworking":      "disableNetworking",
+	"DnsSearchDomains":       "dnsSearchDomains",
+	"DnsServers":             "dnsServers",
+	"DockerLabels":           "dockerLabels",
+	"DockerSecurityOptions":  "dockerSecurityOptions",
+	"EntryPoint":             "entryPoint",
+	"Environment":            "environment",
+	"EnvironmentFiles":       "environmentFiles",
+	"Essential":              "essential",
+	"ExtraHosts":             "extraHosts",
+	"FirelensConfiguration":  "firelensConfiguration",
+	"HealthCheck":            "healthCheck",
+	"Hostname":               "hostname",
+	"Image":                  "image",
+	"Interactive":            "interactive",
+	"Links":                  "links",
+	"LinuxParameters":        "linuxParameters",
+	"LogConfiguration":       "logConfiguration",
+	"Memory":                 "memory",
+	"MemoryReservation":      "memoryReservation",
+	"MountPoints":            "mountPoints",
+	"Name":                   "name",
+	"PortMappings":           "portMappings",
+	"Privileged":             "privileged",
+	"PseudoTerminal":         "pseudoTerminal",
+	"ReadonlyRootFilesystem": "readonlyRootFilesystem",
+	"RepositoryCredentials":  "repositoryCredentials",
+	"ResourceRequirements":   "resourceRequirements",
+	"RestartPolicy":          "restartPolicy",
+	"Secrets":                "secrets",
+	"StartTimeout":           "startTimeout",
+	"StopTimeout":            "stopTimeout",
+	"SystemControls":         "systemControls",
+	"Ulimits":                "ulimits",
+	"User":                   "user",
+	"VersionConsistency":     "versionConsistency",
+	"VolumesFrom":            "volumesFrom",
+	"WorkingDirectory":       "workingDirectory",
+}
+
+// ecsNestedContainerKeys maps the member names of the structured types nested
+// inside a container definition, keyed by the container-definition member that
+// holds them.
+//
+// Only the types whose members a consumer asserts on are enumerated; a member
+// holding a type absent from this map has its *values* resolved but its keys
+// left alone, which is the safe direction — an unmapped key reaching ECS is
+// visible in a response, where a wrongly rewritten one is silently lost.
+//
+// That is also what keeps user-supplied keys intact, and it is why membership
+// here is a decision rather than a completeness exercise: logConfiguration's
+// `options` is keyed by log-driver option names (`awslogs-group`) and
+// `dockerLabels` by whatever labels the consumer chose, so neither may ever
+// appear here. Both are *named* by their parent's table — "Options" →
+// "options" — and then left whole, because the walk cannot tell a member name
+// it has never heard of from a user's label.
+//
+// Member names are from each type's own ECS API reference page.
+var ecsNestedContainerKeys = map[string]map[string]string{
+	"environment": {"Name": "name", "Value": "value"},
+	"secrets":     {"Name": "name", "ValueFrom": "valueFrom"},
+	"portMappings": {
+		"AppProtocol":        "appProtocol",
+		"ContainerPort":      "containerPort",
+		"ContainerPortRange": "containerPortRange",
+		"HostPort":           "hostPort",
+		"Name":               "name",
+		"Protocol":           "protocol",
+	},
+	"logConfiguration": {
+		"LogDriver":     "logDriver",
+		"Options":       "options",
+		"SecretOptions": "secretOptions",
+	},
+	"mountPoints": {
+		"ContainerPath": "containerPath",
+		"ReadOnly":      "readOnly",
+		"SourceVolume":  "sourceVolume",
+	},
+	"volumesFrom": {
+		"ReadOnly":        "readOnly",
+		"SourceContainer": "sourceContainer",
+	},
+	"healthCheck": {
+		"Command":     "command",
+		"Interval":    "interval",
+		"Retries":     "retries",
+		"StartPeriod": "startPeriod",
+		"Timeout":     "timeout",
+	},
+	"ulimits": {
+		"HardLimit": "hardLimit",
+		"Name":      "name",
+		"SoftLimit": "softLimit",
+	},
+	"dependsOn": {
+		"Condition":     "condition",
+		"ContainerName": "containerName",
+	},
+	"extraHosts": {
+		"Hostname":  "hostname",
+		"IpAddress": "ipAddress",
+	},
+	"systemControls": {
+		"Namespace": "namespace",
+		"Value":     "value",
+	},
+}
+
+// ecsContainerDefinitions converts a CloudFormation ContainerDefinitions
+// property into the shape RegisterTaskDefinition expects: intrinsics resolved at
+// any depth (#526) and member names in the ECS API's case (#527).
+//
+// The two passes are separate on purpose: resolution must not rewrite keys, which
+// is what would mangle logConfiguration.options.
+//
+// They also commute, and it is worth knowing why rather than relying on the
+// order. ecsRewriteKeys touches keys only, through tables that contain no
+// intrinsic name, so it cannot change whether a map is an intrinsic; resolveNested
+// replaces values only, so it cannot change which table ecsRewriteKeys selects.
+// Resolution runs first because reading the result of a single pass over final
+// values is easier than reasoning about a rename applied to an unresolved tree —
+// not because the other order is wrong.
+func ecsContainerDefinitions(v interface{}, cctx *cfnContext) interface{} {
+	return ecsRewriteKeys(resolveNested(v, cctx), ecsContainerDefinitionKeys)
+}
+
+// ecsRewriteKeys rewrites the keys of each map in v using table, recursing into
+// nested members with whichever table ecsNestedContainerKeys names for them.
+//
+// An unmapped key passes through unchanged rather than being lowercased, for the
+// same reason #516's expander warns about an unrecognized tag instead of
+// dropping it: a member substrate has not enumerated is better delivered
+// verbatim than guessed at.
+func ecsRewriteKeys(v interface{}, table map[string]string) interface{} {
+	switch val := v.(type) {
+	case []interface{}:
+		out := make([]interface{}, 0, len(val))
+		for _, item := range val {
+			out = append(out, ecsRewriteKeys(item, table))
+		}
+		return out
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, item := range val {
+			name, mapped := table[k]
+			if !mapped {
+				name = k
+			}
+			if nested, has := ecsNestedContainerKeys[name]; has {
+				out[name] = ecsRewriteKeys(item, nested)
+				continue
+			}
+			// No table for this member, so the walk stops here rather than
+			// guessing: the value is carried through with neither its keys nor
+			// its nested keys touched. This is what protects
+			// logConfiguration.options and dockerLabels, whose keys are user
+			// data — see ecsNestedContainerKeys.
+			out[name] = item
+		}
+		return out
+	}
+	return v
 }

--- a/emulator/betty_cfn_v34_plugins.go
+++ b/emulator/betty_cfn_v34_plugins.go
@@ -79,16 +79,17 @@ func (d *StackDeployer) deployMSKCluster(
 		"ClientSubnets": []string{},
 	}
 	if bi, ok := props["BrokerNodeGroupInfo"].(map[string]interface{}); ok {
-		if it, ok := bi["InstanceType"].(string); ok && it != "" {
+		// Resolved rather than asserted on string: a template names its subnets
+		// with a Ref far more often than as literals, and a string assertion
+		// dropped every one of them (#526). MSK's API is natively PascalCase, so
+		// only the values need attention.
+		if it := resolveValue(bi["InstanceType"], cctx); it != "" {
 			brokerInfo["InstanceType"] = it
 		}
-		if cs, ok := bi["ClientSubnets"].([]interface{}); ok {
-			subnets := make([]string, 0, len(cs))
-			for _, s := range cs {
-				if sv, ok := s.(string); ok {
-					subnets = append(subnets, sv)
-				}
-			}
+		if subnets := resolveStringList(bi["ClientSubnets"], cctx); len(subnets) > 0 {
+			// Only overwritten when the property resolves to something, so an
+			// absent or empty ClientSubnets keeps the empty-slice default rather
+			// than becoming a JSON null.
 			brokerInfo["ClientSubnets"] = subnets
 		}
 	}

--- a/emulator/betty_cfn_v43_plugins.go
+++ b/emulator/betty_cfn_v43_plugins.go
@@ -33,25 +33,23 @@ func (d *StackDeployer) deployFSxFileSystem(
 	}
 	storageType := resolveStringProp(props, "StorageType", "SSD", cctx)
 
-	var subnetIDs []string
-	if si, ok := props["SubnetIds"]; ok {
-		if arr, ok2 := si.([]interface{}); ok2 {
-			for _, item := range arr {
-				if s := resolveValue(item, cctx); s != "" {
-					subnetIDs = append(subnetIDs, s)
-				}
-			}
-		}
-	}
+	// resolveStringList rather than a hand-rolled loop, so the whole property is
+	// list-aware: a Ref to a List<AWS::EC2::Subnet::Id> parameter or a nested
+	// Fn::Split contributes every subnet rather than one (#521, #526).
+	subnetIDs := resolveStringList(props["SubnetIds"], cctx)
 
 	var tags []FSxTag
 	if t, ok := props["Tags"]; ok {
 		if arr, ok2 := t.([]interface{}); ok2 {
 			for _, item := range arr {
 				if m, ok3 := item.(map[string]interface{}); ok3 {
-					k, _ := m["Key"].(string)
-					v, _ := m["Value"].(string)
-					tags = append(tags, FSxTag{Key: k, Value: v})
+					// resolveValue rather than a string assertion: a tag value
+					// is very often `{"Fn::Sub": "${AWS::StackName}-data"}`, and
+					// asserting on string dropped it silently (#526).
+					tags = append(tags, FSxTag{
+						Key:   resolveValue(m["Key"], cctx),
+						Value: resolveValue(m["Value"], cctx),
+					})
 				}
 			}
 		}

--- a/emulator/betty_cfn_yaml_test.go
+++ b/emulator/betty_cfn_yaml_test.go
@@ -568,11 +568,12 @@ func TestCFN_YAMLShortForm_ConsumerTemplate(t *testing.T) {
 	body, err := os.ReadFile("testdata/cfn/ecs_worker.yml")
 	require.NoError(t, err)
 
-	d := newFullTestDeployer(t)
+	d, registry := newFullTestDeployerWithRegistry(t)
 	result, err := d.Deploy(context.Background(), string(body), "ecs-worker", map[string]string{
 		"WorkflowId":     "wf1",
 		"JobId":          "job1",
 		"ContainerImage": "public.ecr.aws/parsl/worker:latest",
+		"Command":        "python,-m,worker",
 	})
 	require.NoError(t, err)
 
@@ -607,6 +608,61 @@ func TestCFN_YAMLShortForm_ConsumerTemplate(t *testing.T) {
 	for _, r := range result.Resources {
 		assert.Empty(t, r.Error, "resource %s failed: %s", r.LogicalID, r.Error)
 	}
+
+	// #521/#526/#527 end to end, in the template that reported them. The
+	// container is declared as
+	//
+	//	- Name: !Sub 'parsl-container-${WorkflowId}-${JobId}'
+	//	  Image: !Ref ContainerImage
+	//	  Command: !If [HasCommand, !Split [',', !Ref Command], !Ref 'AWS::NoValue']
+	//	  LogConfiguration: {LogDriver: awslogs, Options: {awslogs-group: !Ref LogGroup, …}}
+	//
+	// so reading it back exercises all three fixes at once: the member names an
+	// SDK reads (#527), the intrinsics nested inside a forwarded property (#526),
+	// and Fn::Split contributing three elements rather than one rejoined string
+	// (#521). Before them, this query returned [{}].
+	cdefs := describeTaskDefinition(t, registry, "parsl-task-wf1-job1")
+	require.Len(t, cdefs, 1)
+	c := cdefs[0]
+	assert.Equal(t, "parsl-container-wf1-job1", rawString(t, c["name"]))
+	assert.Equal(t, "public.ecr.aws/parsl/worker:latest", rawString(t, c["image"]))
+	assert.JSONEq(t, `["python","-m","worker"]`, string(c["command"]),
+		"Command: !If [HasCommand, !Split [',', !Ref Command], …] is the whole list")
+	assert.JSONEq(t, `{
+		"logDriver": "awslogs",
+		"options": {
+			"awslogs-group":         "/aws/ecs/parsl-wf1-job1",
+			"awslogs-region":        "us-east-1",
+			"awslogs-stream-prefix": "parsl"
+		}
+	}`, string(c["logConfiguration"]),
+		"the options keys are user data and survive verbatim with their values resolved")
+}
+
+// TestCFN_YAMLShortForm_ConsumerTemplateNoCommand is the same template with
+// Command left at its `Default: ”`, which makes HasCommand false and the
+// container's Command an `!Ref 'AWS::NoValue'`.
+//
+// CloudFormation removes the property rather than sending an empty value, and ECS
+// rejects an empty `command`, so the absence is the observable that matters here
+// — a resolved-to-"" member would be a different defect wearing the same 200.
+func TestCFN_YAMLShortForm_ConsumerTemplateNoCommand(t *testing.T) {
+	body, err := os.ReadFile("testdata/cfn/ecs_worker.yml")
+	require.NoError(t, err)
+
+	d, registry := newFullTestDeployerWithRegistry(t)
+	_, err = d.Deploy(context.Background(), string(body), "ecs-worker-nocmd", map[string]string{
+		"WorkflowId":     "wf2",
+		"JobId":          "job2",
+		"ContainerImage": "public.ecr.aws/parsl/worker:latest",
+	})
+	require.NoError(t, err)
+
+	cdefs := describeTaskDefinition(t, registry, "parsl-task-wf2-job2")
+	require.Len(t, cdefs, 1)
+	assert.NotContains(t, cdefs[0], "command",
+		"!Ref 'AWS::NoValue' removes the member; it does not resolve to an empty value")
+	assert.NotContains(t, cdefs[0], "Command")
 }
 
 // TestCFN_EmptyStringParameterDefaultIsDeclared pins that `Default: ”` declares a

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -331,3 +331,34 @@ func ResolveValueListForTest(v interface{}, params map[string]string, listParams
 // CFNListParameterTypeForTest wraps cfnListParameterType so the set of declared
 // types that make a Ref list-valued can be asserted directly.
 func CFNListParameterTypeForTest(t string) bool { return cfnListParameterType(t) }
+
+// ResolveNestedForTest wraps resolveNested so its four rules can be asserted at
+// the seam rather than only through a deployer.
+//
+// Most of them are invisible downstream: a plugin that stores an untyped property
+// cannot report that a key was rewritten, and a multi-key map resolving to
+// whichever key Go's map iteration reached first is a race a single deploy passes
+// by luck.
+func ResolveNestedForTest(v interface{}, params map[string]string, listParams map[string]bool, conditions map[string]bool) interface{} {
+	cctx := &cfnContext{
+		params:     params,
+		listParams: listParams,
+		conditions: conditions,
+		resources:  map[string]DeployedResource{},
+		evaluating: map[string]bool{},
+		region:     "us-east-1",
+		accountID:  "123456789012",
+	}
+	return resolveNested(v, cctx)
+}
+
+// ECSRewriteContainerKeysForTest wraps the ECS container-definition key rewrite,
+// so the members it must refuse to descend into can be asserted without a deploy.
+func ECSRewriteContainerKeysForTest(v interface{}) interface{} {
+	return ecsRewriteKeys(v, ecsContainerDefinitionKeys)
+}
+
+// ECSContainerDefinitionKeysForTest returns the ECS container-definition key
+// mapping, so a typo in a hand-written table is caught by asserting the whole
+// table against the rule its entries follow.
+func ECSContainerDefinitionKeysForTest() map[string]string { return ecsContainerDefinitionKeys }


### PR DESCRIPTION
## What

Two `priority: high` defects with the same cause and the same symptom shape — substrate returns HTTP 200 while the observable a caller parses is wrong or empty.

Closes #526
Closes #527

## #526 — intrinsics never resolved below the top level

`resolveValue` resolves a value that *is* an intrinsic; nothing walked into a map or a list to resolve one nested within. So a deploy path that forwarded a structured property whole handed the plugin `{"Ref": "PK"}` as a literal object: DynamoDB's typed plugin rejected it —

```
SerializationException: Failed to parse request: json: cannot unmarshal object
into Go struct field …AttributeDefinitions.AttributeName of type string
```

— and the resource `CREATE_FAILED`, while an untyped plugin stored the object and echoed it back. Which of a consumer's properties resolved depended on how each deploy path happened to have been written: `LaunchTemplateData` and security-group rules enumerate their members key by key, `ContainerDefinitions`/`KeySchema`/`AttributeDefinitions` were forwarded verbatim.

`resolveNested` walks a property and returns a structurally identical value with every intrinsic resolved. Four rules a naive walk gets wrong, each pinned by a test:

- **Only a single-key map is an intrinsic.** A multi-key map is user data even when one key is named `Ref` — and resolving one made the result depend on Go's map iteration order, which is the same nondeterminism #521 fixed one level up.
- **A list-valued intrinsic in a list position splices**, so a nested `Fn::Split` contributes its elements rather than one rejoined string.
- **`Fn::If` yielding `AWS::NoValue` removes the property**, as CloudFormation does, rather than leaving an empty string behind. That is what `!If [HasCommand, !Split [...], !Ref 'AWS::NoValue']` is written to say, and ECS rejects an empty `command`.
- **Resolution never rewrites a key.** Mapping member names is a per-service concern (#527) and conflating it with resolution is how `logConfiguration.options` — whose keys are user data — would get mangled.

`resolveNested` returns `interface{}` rather than `resolveValue`'s `string`, so a member that *is* a list-valued intrinsic keeps its list instead of inheriting #521's scalar-context rejoin. A literal passes through untouched, so `{"ContainerPort": 8080}` stays the number 8080.

Applied at the verbatim-forwarding sites, and at three more the audit found where a `.(string)` assertion was silently dropping intrinsic-valued members — the same defect wearing a different plugin:

| Path | What was dropped |
|---|---|
| ECS `ContainerDefinitions` | everything nested |
| DynamoDB `KeySchema`, `AttributeDefinitions`, `ProvisionedThroughput`, `GlobalSecondaryIndexes`, `LocalSecondaryIndexes`, `StreamSpecification` | resource `CREATE_FAILED` |
| ACM `SubjectAlternativeNames` | a `!Ref`- or `!Split`-valued SAN |
| MSK `BrokerNodeGroupInfo.InstanceType`, `.ClientSubnets` | a `!Ref`-valued subnet list — how a template names subnets far more often than as literals |
| FSx `SubnetIds`, `Tags` | `Value: !Sub '${AWS::StackName}-data'`, the single most common way a template writes a tag |

MSK's `ClientSubnets` is overwritten only when it resolves to something, so an absent property keeps its `[]` default rather than becoming a JSON `null` — different requests to a decoding consumer.

## #527 — ECS container definitions carried CloudFormation's casing onto the wire

CloudFormation spells a container's members in PascalCase where the ECS API spells them camelCase. `ContainerDefinitions` is untyped both in `RegisterTaskDefinition`'s request and in state, so there was nothing to reject them: the stack reached `CREATE_COMPLETE`, `DescribeTaskDefinition` answered 200, and `--query 'taskDefinition.containerDefinitions'` returned `[{}]` — every member present under a name no SDK reads. A direct `RegisterTaskDefinition` call was never affected; the mismatch was introduced by the deploy path alone.

The mapping is an explicit table of all **42** `ContainerDefinition` members plus the **11** nested types (`environment`, `secrets`, `portMappings`, `logConfiguration`, `mountPoints`, `volumesFrom`, `healthCheck`, `ulimits`, `dependsOn`, `extraHosts`, `systemControls`), each verified member by member against its own API reference page. Two decisions worth stating:

- **A table, not a first-letter-lowering function** — which would be right for all 42 members today. Only a table can tell "not mapped" from "mapped to itself", so a member ECS adds later passes through verbatim rather than being renamed to something the API does not accept. `TestECSContainerDefinitionKeys_MatchAPICase` asserts the table against the rule, so the rule's safety is kept without its fragility.
- **Per-service, never generic.** DynamoDB, ACM and MSK are natively PascalCase; a generic converter is precisely the change that would break them. `logConfiguration.options` and `dockerLabels` are named by their parent's table and then left whole, their keys being user data.

## Tests

Every new gate was confirmed to fail with the fix reverted. Assertions are on **raw JSON bytes** where the defect is a member's *name* — a Go round-trip cannot see a casing defect, since `encoding/json` matches a field case-insensitively absent an exact match, so DynamoDB's PascalCase struct reads `"keySchema"` perfectly well and a read-back agrees with the defect. The DynamoDB guard therefore reads the bytes the deploy path put on the wire, out of the event store.

- `TestCFN_ECSContainerDefinitions_MemberNamesAndNesting` — the member names an SDK reads, a loop asserting the seven PascalCase names are **absent**, and `logConfiguration.options` verbatim with its values resolved.
- `TestCFN_ECSContainerDefinitions_UnknownMemberSurvives` — an unenumerated member is delivered unchanged.
- `TestCFN_ECSContainerDefinitions_NoValueRemovesMember` — both condition branches.
- `TestCFN_DynamoDB_NestedRefInKeySchema` — #526's own reproduction, read back through `DescribeTable`, plus positive **and negative** assertions on the raw `CreateTable` body: the guard against a generic converter.
- `TestResolveNested_Conventions` — 23 cases at the seam, most of them invisible through any deploy path.
- `TestECSRewriteKeys_UserDataMembers` — `Options`/`DockerLabels` holding keys named `Name` and `Image`, so the walk is proved to have *stopped* rather than merely missed them.
- `TestCFN_ACMSubjectAlternativeNames_Resolved`, `TestCFN_MSKClientSubnets_Resolved`, `TestCFN_MSKClientSubnets_AbsentStaysEmptyList`, `TestCFN_FSxIntrinsicProperties_Resolved` — the collateral paths, asserted on the dispatched body since none of the three echoes these members back.
- `TestCFN_YAMLShortForm_ConsumerTemplate` and a new `…NoCommand` sibling — the end-to-end gate on the checked-in `ecs_worker.yml`, which is where #521/#526/#527 were all reported. All three fixes are exercised at once, and the `Command`-unset case asserts the member is **absent**.

### Mutation testing

18 mutants, 16 CAUGHT. Both survivors are accounted for rather than left open:

- *The ECS key table also applied to DynamoDB's properties* — SURVIVED, and provably equivalent: the two vocabularies are disjoint (verified by set intersection over the table and DynamoDB's member names), so the walk is structural identity. The mutant that matters here is a **generic** converter, and `M8b` — first-letter-lowering applied to DynamoDB — is CAUGHT by the new raw-body assertions.
- *The two ECS passes run in the opposite order* — SURVIVED, and they commute: `ecsRewriteKeys` touches keys only, through tables containing no intrinsic name, so it cannot change whether a map is an intrinsic; `resolveNested` replaces values only, so it cannot change which table is selected. The doc comment was corrected to say so rather than claim an ordering constraint that does not exist.

One mutant found a real test-design defect and one found a redundant guard, both fixed rather than accepted:

- `ecsUserDataMembers` was a no-op — a member with no nested table is already never descended into, so the guard had no observable effect. Removed, and the reasoning moved to `ecsNestedContainerKeys`, where membership is the actual decision: `options` and `dockerLabels` must never appear there.
- The DynamoDB guard passed under a generic converter, for the `encoding/json` reason above. It now asserts on the wire bytes.

## Verified over the wire

Against `substrate server`, the three reproductions from the issues:

```
$ aws ecs describe-task-definition --task-definition json-family \
    --query 'taskDefinition.containerDefinitions'
[{"name": "worker", "image": "python:3.11"}]          # was [{}]

$ aws dynamodb describe-table --table-name nested-probe \
    --query 'Table.KeySchema[0].AttributeName'
"pk"                                                   # was CREATE_FAILED

$ aws ecs describe-task-definition --task-definition split-family \
    --query 'taskDefinition.containerDefinitions[0].command'
["python", "-m", "worker"]                             # was ["python,-m,worker"]

$ … --query 'taskDefinition.containerDefinitions[0].logConfiguration'
{"logDriver": "awslogs", "options": {"awslogs-group": "/ecs/probe", "awslogs-region": "us-west-2"}}
```

## Docs

`docs/services.md` §Templates gains the invariant a consumer needs to predict behaviour — intrinsics resolve at any depth — with the two rules that bound the walk (single-key maps only; keys are never rewritten by resolution) and the note that a resolved scalar is a string while a literal is never retyped. The `AWS::NoValue` paragraph now covers the whole-property case, not only the list position. `make docs-reference` produces no diff; no plugin was added.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test -C test/e2e ./...` — all green.
