### PR TITLE
fix(cfn): read Mappings and resolve FindInMap, GetAZs, Cidr and the pseudo-parameters (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `logConfiguration.options` and `dockerLabels` are named by their parent's table and
   then left whole, their keys being user data.
 
+- **A template's `Mappings` section is read, and `Fn::FindInMap` resolves against
+  it** (#522). `cfnTemplate` had no `Mappings` field, so the section every
+  region→AMI template carries was discarded at parse time and the intrinsic fell
+  back to its JSON encoding: the near-universal
+  `ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]` reached `RunInstances`
+  as the literal string `{"Fn::FindInMap":["RegionMap",…]}` and **the instance
+  launched**, the resource reporting `CREATE_COMPLETE`.
+
+  All three levels resolve, including the nested form the reference leads with,
+  where the second-level key is itself a `Ref` or a `Fn::FindInMap`. A leaf may be a
+  string or a **list**, since "the values can be of type String or List", so a
+  list-valued lookup contributes its members to a list-valued property and is
+  rejoined on commas in a scalar one. The optional fourth argument is honored — but
+  only spelled exactly `{DefaultValue: …}`, because a map with any other key is not
+  a default and guessing at the intent is how a template gets a value neither
+  CloudFormation nor the author asked for.
+
+  A lookup that misses now **fails the resource** — `CREATE_FAILED` with a
+  `ResourceStatusReason` naming the intrinsic and the key that missed — rather than
+  falling back to the literal. That is the whole point of modelling `Mappings` rather
+  than tolerating it: a nonsense `ImageId` reported as success is the defect, and a
+  template CloudFormation would have rejected must not deploy. The rest of the stack
+  still deploys, matching the per-resource failure reporting #519 established.
+  Reporting it needed a new channel — a resolver returns a `string`, in which "no
+  such key" and "the key held an empty string" are the same value — so `cfnContext`
+  now accumulates failures, drained per resource onto `DeployedResource.Error`, which
+  is already what `DescribeStackResources` derives `CREATE_FAILED` from.
+
+- **`Fn::GetAZs` resolves, to the same zones `DescribeAvailabilityZones` reports**
+  (#522). A subnet placed with the conventional `!Select [0, !GetAZs '']` had the
+  intrinsic's JSON encoding as its `AvailabilityZone`. It now derives from the same
+  seeded zone list EC2's own `DescribeAvailabilityZones` answers from rather than
+  carrying a second list, so the two cannot disagree — a subnet in a zone the
+  emulator does not report is not something a caller can then query, and two
+  independent lists is how that happens. An empty string means the caller's region,
+  as the reference specifies.
+
+- **`Fn::Cidr` resolves, for IPv4 and IPv6** (#522). `!Cidr ['192.168.0.0/24', 6, 5]`
+  yields six `/27`s and `!Cidr ['2001:db8::/56', 1, 64]` a `/64`, the mask taken
+  from the address family rather than assumed — both are the reference's own
+  examples, and both are asserted against it. A request the block cannot satisfy
+  fails the resource rather than returning a short list: a `count` larger than the
+  number of blocks that fit, a `cidrBits` that would widen the block, a `count`
+  outside the documented 1–256, or an `ipBlock` that is not a CIDR block. A short
+  list is the worse failure, because `!Select [3, !Cidr [...]]` reads an empty string
+  out of it and deploys.
+
+- **The four remaining pseudo-parameters resolve** (#522), which closes the
+  unresolved list rather than shortening it. `AWS::Partition` and `AWS::URLSuffix`
+  follow the region (`aws-cn`/`amazonaws.com.cn`, `aws-us-gov`, else
+  `aws`/`amazonaws.com`), so an ARN a template builds with
+  `!Sub 'arn:${AWS::Partition}:s3:::${Bucket}'` is an ARN rather than a string with
+  a placeholder in it. `AWS::NotificationARNs` is an **empty list** — substrate has
+  no notification model, and empty is the accurate answer for a stack created
+  without any, where the reference string was not.
+
+  `AWS::StackId` resolves to the stack's ARN, and the builder is now shared with the
+  wire's `CreateStack`/`DescribeStacks` rather than duplicated: a consumer that
+  captures `StackId` from `CreateStack` and compares it against a resource property
+  built from `AWS::StackId` must find one ARN for one stack, and two builders is
+  exactly the divergence #517 fixed for the caller's account.
+
+  `Fn::ImportValue` remains unresolved and #522 stays open for it: resolving it needs
+  an export registry across stacks and a refusal to delete a stack whose export is
+  imported, which is a new cross-stack model rather than another resolver.
+
 ## [v0.87.1] - 2026-08-03
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -209,16 +209,64 @@ holds only the request a real client would have made.
 backs under **Betty CFN resource types**. A template body may be JSON or YAML.
 
 `Ref`, `Fn::GetAtt`, `Fn::Sub`, `Fn::Join`, `Fn::Select`, `Fn::Split`,
-`Fn::Base64`, `Fn::If`, `Fn::Equals`, `Fn::And`, `Fn::Or` and `Fn::Not` resolve,
-as do the `AWS::Region`, `AWS::AccountId`, `AWS::StackName` and `AWS::NoValue`
-pseudo-parameters. `Fn::FindInMap`, `Fn::ImportValue`, `Fn::Cidr`,
-`Fn::GetAZs` and the remaining pseudo-parameters (`AWS::Partition`,
-`AWS::URLSuffix`, `AWS::StackId`, `AWS::NotificationARNs`) are **not** resolved —
-an unrecognized intrinsic falls back to its JSON encoding and an unrecognized
-`Ref` to the reference string itself, so a template using one deploys with a
-literal where a value should be rather than failing. Tracked in
-[#522](https://github.com/scttfrdmn/substrate/issues/522) — `Fn::FindInMap` needs a
-`Mappings` model, which the template struct does not have.
+`Fn::Base64`, `Fn::If`, `Fn::Equals`, `Fn::And`, `Fn::Or`, `Fn::Not`,
+`Fn::FindInMap`, `Fn::GetAZs` and `Fn::Cidr` resolve, as do every pseudo-parameter:
+`AWS::Region`, `AWS::AccountId`, `AWS::StackName`, `AWS::StackId`,
+`AWS::Partition`, `AWS::URLSuffix`, `AWS::NotificationARNs` and `AWS::NoValue`.
+`Fn::ImportValue` is the one intrinsic that does **not** resolve — it falls back to
+its JSON encoding, so a template using it deploys with a literal where a value
+should be rather than failing. Tracked in
+[#522](https://github.com/scttfrdmn/substrate/issues/522): resolving it needs an
+export registry across stacks, not another resolver.
+
+`AWS::Partition` and `AWS::URLSuffix` follow the region — `aws-cn` and
+`amazonaws.com.cn` for a `cn-` region, `aws-us-gov` for a `us-gov-` one, `aws` and
+`amazonaws.com` otherwise. `AWS::StackId` is the same ARN `CreateStack` returned
+and `DescribeStacks` reports for the stack, so a template that writes its own
+stack ID into a property and a caller that captured `StackId` agree.
+`AWS::NotificationARNs` is an **empty list**, which is the accurate answer for a
+stack created without any: substrate has no notification model, so there is never
+an ARN to report, and `!Select ['0', !Ref 'AWS::NotificationARNs']` yields the
+empty string rather than the reference string.
+
+#### `Mappings` and `Fn::FindInMap`
+
+A template's `Mappings` section is read and `Fn::FindInMap` resolves all three
+levels — map name, top-level key, second-level key — including the nested form the
+reference leads with, where the second-level key is itself a `Ref` or a
+`Fn::FindInMap`. A mapping's leaf value may be a string or a **list**, so
+`SecurityGroupIds: !FindInMap [SGs, Prod, Ids]` contributes several IDs; in a
+scalar context the members are rejoined on commas, as `Fn::Split`'s are.
+
+A lookup that misses **fails the resource**: it reports `CREATE_FAILED` with a
+`ResourceStatusReason` naming the intrinsic and the key, and the resource is not
+created. This is deliberate and it is the point of the model — the JSON-encoding
+fallback would have turned a missing AMI into a nonsense `ImageId` that launched an
+instance, reporting success for a template real CloudFormation rejects. The rest of
+the stack still deploys; one unresolvable property does not abort it, matching the
+per-resource failure reporting above.
+
+The optional fourth argument supplies a fallback: `!FindInMap [M, K1, K2, {DefaultValue: x}]`
+resolves to `x` when either key is missing, and the fallback is not consulted when
+the lookup succeeds. It must be spelled exactly `DefaultValue` — a map with any
+other key is not a default and the lookup fails as it would without one, rather
+than substrate guessing at the intent.
+
+#### `Fn::GetAZs` and `Fn::Cidr`
+
+`Fn::GetAZs` resolves to the **same zone names EC2's `DescribeAvailabilityZones`
+reports** for that region, from the same list, so a subnet placed with
+`!Select [0, !GetAZs '']` names a zone the caller can afterwards query. An empty
+string means the caller's region, as `Ref 'AWS::Region'` does.
+
+`Fn::Cidr` splits `ipBlock` into `count` blocks whose mask is the address width
+less `cidrBits`, for IPv4 and IPv6 alike — `!Cidr ['192.168.0.0/24', 6, 5]` gives
+six `/27`s, and `!Cidr ['2001:db8::/56', 1, 64]` gives a `/64`. A request the block
+cannot satisfy — a `count` larger than the number of blocks that fit, a `cidrBits`
+that would widen the block, a `count` outside 1–256, an `ipBlock` that is not a
+CIDR block — fails the resource rather than returning a short list, for the same
+reason: `!Select [3, !Cidr [...]]` over a short list would read an empty string out
+of it and deploy.
 
 `Fn::Split` resolves to a **list**, and a list-valued property receives every
 element. A `CommaDelimitedList` (or `List<…>`) parameter is list-valued too: a
@@ -256,7 +304,8 @@ list-valued. So `"Cpu": {"Ref": "Cpu"}` reaches the API as `"256"` where a liter
 
 Where the property is scalar and has nowhere to put a list — an `Outputs` value,
 say — `Fn::Split`'s elements are rejoined on the delimiter, reproducing the
-source string. Real CloudFormation rejects the template instead; substrate
+source string, and `Fn::GetAZs`, `Fn::Cidr` and a list-valued `Fn::FindInMap` leaf
+are rejoined on commas. Real CloudFormation rejects the template instead; substrate
 resolves rather than rejects, and rejoining is the spelling that loses nothing.
 
 A parameter declared `Default: ''` is a parameter whose default is the empty
@@ -291,9 +340,8 @@ takes a two-element list, and the split is on the **first** period only, so
 `!GetAtt Res.Outputs.Nested` is `["Res", "Outputs.Nested"]` — an attribute name
 may itself contain periods.
 
-Expansion is not resolution. `!FindInMap`, `!ImportValue`, `!Cidr` and `!GetAZs`
-expand to long forms that are still unresolved (#522), and hit the same fallback the
-long forms already do.
+Expansion is not resolution. `!ImportValue` expands to a long form that is still
+unresolved (#522), and hits the same fallback the long form already does.
 
 A tag substrate does not recognize is **not** dropped: the node's value is kept
 and a `WARN` naming the tag is logged, since a macro or transform may introduce a

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"net/netip"
 	"reflect"
 	"sort"
 	"strconv"
@@ -19,10 +20,27 @@ type cfnTemplate struct {
 	AWSTemplateFormatVersion string                 `json:"AWSTemplateFormatVersion" yaml:"AWSTemplateFormatVersion"`
 	Description              string                 `json:"Description,omitempty"    yaml:"Description,omitempty"`
 	Parameters               map[string]cfnParam    `json:"Parameters,omitempty"     yaml:"Parameters,omitempty"`
+	Mappings                 cfnMappings            `json:"Mappings,omitempty"       yaml:"Mappings,omitempty"`
 	Conditions               map[string]interface{} `json:"Conditions,omitempty"     yaml:"Conditions,omitempty"`
 	Resources                map[string]cfnResource `json:"Resources"                yaml:"Resources"`
 	Outputs                  map[string]cfnOutput   `json:"Outputs,omitempty"        yaml:"Outputs,omitempty"`
 }
+
+// cfnMappings is the template's Mappings section: a mapping name, a top-level
+// key, a second-level key, and a value.
+//
+// Exactly three levels of map, because that is what CloudFormation defines —
+// "within the mapping, each map is a key followed by another mapping", and
+// Fn::FindInMap takes exactly a map name and two keys. The leaf is interface{}
+// because "the values can be of type String or List", which is why Fn::FindInMap
+// is one of the intrinsics that can resolve to a list.
+//
+// The first three levels being typed is also a check: "the keys in mappings must
+// be literal strings" and "you can't include parameters, pseudo parameters, or
+// intrinsic functions in the Mappings section", so a template that puts an
+// intrinsic where a key belongs fails to decode here rather than resolving to
+// something CloudFormation would have rejected.
+type cfnMappings map[string]map[string]map[string]interface{}
 
 // cfnParam is a CloudFormation template parameter declaration.
 type cfnParam struct {
@@ -106,6 +124,37 @@ type cfnContext struct {
 	// evaluating tracks the conditions currently being evaluated, so a reference
 	// cycle terminates instead of recursing forever.
 	evaluating map[string]bool
+
+	// mappings holds the template's Mappings section, which Fn::FindInMap
+	// resolves against. Nothing else reads it: a mapping cannot be referenced
+	// any other way.
+	mappings cfnMappings
+
+	// failures records the resolution errors encountered while deploying the
+	// current resource — an Fn::FindInMap naming a key no mapping holds, say.
+	//
+	// A resolver returns a string, and there is no shape in which it can report
+	// "there is no answer": returning the empty string is indistinguishable from
+	// a property that legitimately resolved to one, and returning the JSON
+	// encoding of the intrinsic is the silent-literal defect (#522). So the
+	// failure is collected here and read by deployResource, which records it on
+	// the resource — that surfaces as CREATE_FAILED with the reason, the same
+	// observable a plugin's own refusal already produces (#519), rather than
+	// failing the whole Deploy call and needing #502's typed errors first.
+	failures []string
+}
+
+// fail records a resolution failure against the resource being deployed.
+func (c *cfnContext) fail(format string, args ...interface{}) {
+	c.failures = append(c.failures, fmt.Sprintf(format, args...))
+}
+
+// takeFailures returns the failures recorded since the last call and clears
+// them, so each resource reports only its own.
+func (c *cfnContext) takeFailures() []string {
+	out := c.failures
+	c.failures = nil
+	return out
 }
 
 // cfnNamespace is the state namespace for CloudFormation stack state.
@@ -1330,8 +1379,54 @@ func compareSNSTopicDrift(ctx context.Context, d *StackDeployer, stack *CFNStack
 	return []CFNPropertyDiff{driftDiff("/DisplayName", exp, act)}
 }
 
-// deployResource dispatches a single CFN resource to the correct deploy helper.
+// deployResource dispatches a single CFN resource to the correct deploy helper
+// and reports any intrinsic that could not be resolved.
+//
+// A resolver cannot report a failure through its return value — a string has no
+// shape for "there is no answer", which is why an unresolvable Fn::FindInMap used
+// to reach the API as a JSON literal (#522). So resolution failures accumulate on
+// the context and are drained here, after the helper has run: the resource is
+// marked CREATE_FAILED with the reason, exactly as a plugin's own refusal is
+// (#519), and the rest of the stack still deploys.
+//
+// The failure is recorded rather than returned because Deploy's error return
+// aborts the whole stack, and CloudFormation fails the *resource*. It also keeps
+// the reason a per-resource observable, which is what DescribeStackResources
+// reports; #502's typed errors are about the request-level codes and are not
+// needed for this.
 func (d *StackDeployer) deployResource(
+	ctx context.Context,
+	logicalID string,
+	res cfnResource,
+	streamID string,
+	cctx *cfnContext,
+) (DeployedResource, float64, error) {
+	// Drain anything a previous resource left behind, so this resource cannot
+	// inherit a reason that is not its own. Nothing should have: Deploy drains
+	// after every resource. Outputs are resolved after the last resource and are
+	// not attributable to one, so their failures are dropped here deliberately.
+	cctx.takeFailures()
+
+	dr, cost, err := d.dispatchResource(ctx, logicalID, res, streamID, cctx)
+	failures := cctx.takeFailures()
+	if err != nil || len(failures) == 0 {
+		return dr, cost, err
+	}
+	// A resolution failure takes precedence over a dispatch error: the request
+	// the plugin refused was built from a value that never resolved, so the
+	// resolver's reason is the cause and the plugin's is the symptom.
+	reason := strings.Join(failures, "; ")
+	if dr.Error != "" {
+		reason += " (request also refused: " + dr.Error + ")"
+	}
+	dr.Error = reason
+	d.logger.Warn("cfn: resource failed to resolve an intrinsic",
+		"logical_id", logicalID, "type", res.Type, "reason", reason)
+	return dr, cost, nil
+}
+
+// dispatchResource routes a CFN resource type to its deploy helper.
+func (d *StackDeployer) dispatchResource(
 	ctx context.Context,
 	logicalID string,
 	res cfnResource,
@@ -3004,6 +3099,7 @@ func buildCFNContext(tmpl *cfnTemplate, callerParams map[string]string, region, 
 		accountID:  accountID,
 		stackName:  stackName,
 		evaluating: make(map[string]bool),
+		mappings:   tmpl.Mappings,
 	}
 }
 
@@ -3174,6 +3270,14 @@ func resolveValue(v interface{}, cctx *cfnContext) string {
 				return resolveFnGetAtt(args, cctx)
 			case "Fn::If":
 				return resolveFnIf(args, cctx)
+			case "Fn::FindInMap":
+				return resolveFnFindInMap(args, cctx)
+			case "Fn::GetAZs", "Fn::Cidr":
+				// Both return an array, and this context has nowhere to put
+				// one, so the elements are rejoined the way Fn::Split's are —
+				// see resolveFnSplitJoined. resolveValueList is the context
+				// that keeps the list.
+				return strings.Join(resolveValueList(val, cctx), ",")
 			}
 		}
 	}
@@ -3252,6 +3356,20 @@ func resolveValueList(v interface{}, cctx *cfnContext) []string {
 						return resolveValueList(arr[1], cctx)
 					}
 					return resolveValueList(arr[2], cctx)
+				case "Fn::GetAZs":
+					return resolveFnGetAZs(args, cctx)
+				case "Fn::Cidr":
+					return resolveFnCidr(args, cctx)
+				case "Fn::FindInMap":
+					// A mapping's values "can be of type String or List", so a
+					// lookup whose leaf is a list contributes its members here
+					// and is rejoined in a scalar context. resolveFnFindInMap
+					// returns the leaf untouched for exactly this reason.
+					leaf, ok := resolveFnFindInMapValue(args, cctx)
+					if !ok {
+						return nil
+					}
+					return resolveValueList(leaf, cctx)
 				}
 			}
 		}
@@ -3267,6 +3385,17 @@ func resolveValueList(v interface{}, cctx *cfnContext) []string {
 // value, not several.
 func resolveRefList(ref string, cctx *cfnContext) []string {
 	if ref == "AWS::NoValue" {
+		return nil
+	}
+	if ref == "AWS::NotificationARNs" {
+		// "Unlike other pseudo parameters, AWS::NotificationARNs returns a list
+		// of ARNs", so it belongs here as well as in resolveRef. The list is
+		// always empty: substrate has no notification model — CreateStack's
+		// NotificationARNs parameter is not recorded and no stack event is
+		// published — so an empty list is the accurate answer rather than a
+		// placeholder. A template's `!Select [0, !Ref 'AWS::NotificationARNs']`
+		// therefore resolves to the empty string, which is what a stack created
+		// without notification ARNs would give.
 		return nil
 	}
 	if cctx.listParams[ref] {
@@ -3407,11 +3536,24 @@ func cfnListValuedIntrinsic(m map[string]interface{}, cctx *cfnContext) bool {
 	}
 	for fn, args := range m {
 		switch fn {
-		case "Fn::Split":
+		case "Fn::Split", "Fn::GetAZs", "Fn::Cidr":
 			return true
+		case "Fn::FindInMap":
+			// List-valued exactly when the leaf it finds is a list, since "the
+			// values can be of type String or List". A failed lookup is not
+			// list-valued, and asking here does not double-report the failure:
+			// resolveIntrinsicPreservingShape resolves the same intrinsic
+			// immediately after, and a resource carrying the same reason twice
+			// would be noise.
+			leaf, found, _ := cfnFindInMapLeaf(args, cctx)
+			if !found {
+				return false
+			}
+			_, isList := leaf.([]interface{})
+			return isList
 		case "Ref":
 			name, ok := args.(string)
-			return ok && cctx.listParams[name]
+			return ok && (cctx.listParams[name] || name == "AWS::NotificationARNs")
 		case "Fn::If":
 			arr, ok := args.([]interface{})
 			if !ok || len(arr) < 3 {
@@ -3441,14 +3583,17 @@ func cfnListValuedIntrinsic(m map[string]interface{}, cctx *cfnContext) bool {
 // plus Ref. A map is an intrinsic only when it has exactly one key and that key
 // is one of these.
 var cfnIntrinsicNames = map[string]bool{
-	"Ref":        true,
-	"Fn::Sub":    true,
-	"Fn::Join":   true,
-	"Fn::Select": true,
-	"Fn::Split":  true,
-	"Fn::Base64": true,
-	"Fn::GetAtt": true,
-	"Fn::If":     true,
+	"Ref":           true,
+	"Fn::Sub":       true,
+	"Fn::Join":      true,
+	"Fn::Select":    true,
+	"Fn::Split":     true,
+	"Fn::Base64":    true,
+	"Fn::GetAtt":    true,
+	"Fn::If":        true,
+	"Fn::FindInMap": true,
+	"Fn::GetAZs":    true,
+	"Fn::Cidr":      true,
 }
 
 // isCFNIntrinsic reports whether a map is an intrinsic function invocation.
@@ -3509,6 +3654,18 @@ func resolveRef(ref string, cctx *cfnContext) string {
 		return cctx.stackName
 	case "AWS::NoValue":
 		return ""
+	case "AWS::Partition":
+		return cfnPartition(cctx.region)
+	case "AWS::URLSuffix":
+		return cfnURLSuffix(cctx.region)
+	case "AWS::StackId":
+		return cfnStackARN(cctx.region, cctx.accountID, cctx.stackName)
+	case "AWS::NotificationARNs":
+		// A list-valued pseudo-parameter in a scalar context. Empty rather than
+		// the reference string, since the accurate answer is "this stack has no
+		// notification ARNs" — see resolveRefList, which is where a template
+		// using it in a list position lands.
+		return ""
 	}
 	// Parameter reference.
 	if v, ok := cctx.params[ref]; ok {
@@ -3519,6 +3676,55 @@ func resolveRef(ref string, cctx *cfnContext) string {
 		return dr.PhysicalID
 	}
 	return ref
+}
+
+// cfnPartition returns the ARN partition a region belongs to.
+//
+// "For standard AWS Regions, the partition is aws. For resources in other
+// partitions, the partition is aws-{partitionname}. For example, the partition
+// for resources in the China (Beijing and Ningxia) Regions is aws-cn and the
+// partition for resources in the AWS GovCloud (US-West) Region is aws-us-gov."
+//
+// Derived from the region prefix rather than fixed at "aws", so a template that
+// builds an ARN with `!Sub arn:${AWS::Partition}:s3:::bucket` gets the value real
+// CloudFormation would give it. Note the rest of substrate mints ARNs in the aws
+// partition unconditionally, so in a cn- or us-gov- region this value and a
+// deployed resource's ARN disagree; that is pre-existing and not something this
+// resolver can decide on its own.
+func cfnPartition(region string) string {
+	switch {
+	case strings.HasPrefix(region, "cn-"):
+		return "aws-cn"
+	case strings.HasPrefix(region, "us-gov-"):
+		return "aws-us-gov"
+	default:
+		return "aws"
+	}
+}
+
+// cfnURLSuffix returns the AWS domain suffix for a region.
+//
+// "The suffix is typically amazonaws.com, but for the China (Beijing) Region, the
+// suffix is amazonaws.com.cn." Both China regions take the .cn suffix, so the
+// test is on the partition rather than on the one region the sentence names.
+func cfnURLSuffix(region string) string {
+	if cfnPartition(region) == "aws-cn" {
+		return "amazonaws.com.cn"
+	}
+	return "amazonaws.com"
+}
+
+// cfnStackARN builds a stack's ARN — the value of AWS::StackId, and what
+// CreateStack reports as its StackId.
+//
+// One function so the two cannot disagree: a template that writes its own
+// AWS::StackId into a resource property and a caller reading StackId off
+// CreateStack are describing the same stack, and #517 is what happens when two
+// places derive an identity separately.
+func cfnStackARN(region, accountID, stackName string) string {
+	return fmt.Sprintf("arn:%s:cloudformation:%s:%s:stack/%s/%s",
+		cfnPartition(region), region, accountID, stackName,
+		cfnDeterministicUUID(region, accountID, stackName))
 }
 
 func resolveFnSub(args interface{}, cctx *cfnContext) string {
@@ -3661,6 +3867,251 @@ func splitFnSplit(sep, s string) []string {
 		return []string{s}
 	}
 	return strings.Split(s, sep)
+}
+
+// resolveFnFindInMap resolves Fn::FindInMap in a scalar context.
+//
+// A lookup whose leaf is a list is rejoined on commas, for the same reason
+// Fn::Split's is (see resolveFnSplitJoined): the context has nowhere to put a
+// list, and a comma is the separator every list-valued property in this codebase
+// is split on. A failed lookup returns the empty string *and* records a failure,
+// which is what stops it being the silent literal #522 reported.
+func resolveFnFindInMap(args interface{}, cctx *cfnContext) string {
+	leaf, ok := resolveFnFindInMapValue(args, cctx)
+	if !ok {
+		return ""
+	}
+	if _, isList := leaf.([]interface{}); isList {
+		return strings.Join(resolveValueList(leaf, cctx), ",")
+	}
+	return resolveValue(leaf, cctx)
+}
+
+// resolveFnFindInMapValue looks a value up in the template's Mappings section,
+// returning the leaf *unresolved* so a list-valued leaf keeps its shape. ok is
+// false when the lookup failed, in which case the reason has been recorded on
+// cctx and the resource will report CREATE_FAILED.
+func resolveFnFindInMapValue(args interface{}, cctx *cfnContext) (interface{}, bool) {
+	leaf, ok, reason := cfnFindInMapLeaf(args, cctx)
+	if !ok {
+		cctx.fail("%s", reason)
+	}
+	return leaf, ok
+}
+
+// cfnFindInMapLeaf performs the lookup without recording anything, returning the
+// reason a caller should report if it fails. Two callers need the answer without
+// the side effect — cfnListValuedIntrinsic asks only about the leaf's shape, and
+// would otherwise record the same failure twice for one intrinsic.
+//
+// Both keys go through resolveValue: the documented form is
+// `!FindInMap [RegionMap, !Ref 'AWS::Region', InstanceType]`, and the two
+// functions permitted inside the arguments without the AWS::LanguageExtensions
+// transform are Fn::FindInMap and Ref — both of which resolveValue handles, so
+// the nested-key form (`!FindInMap [Arch2AMI, !Ref 'AWS::Region', !FindInMap
+// [Type2Arch, !Ref InstanceType, Arch]]`) resolves without a special case. The
+// map *name* is resolved too, which costs nothing: a literal string resolves to
+// itself, and the documented restriction is on what a template may write, not on
+// what this may read.
+//
+// A missing key is a failure rather than a fallback, unless the optional fourth
+// argument supplies one: "if omitted, Fn::FindInMap raises an error when a key is
+// not found", and "the fourth parameter must be a map with the key DefaultValue".
+// A present top-level key holding no such second-level key takes the same path,
+// since the documented DefaultValue covers "either the TopLevelKey or
+// SecondLevelKey is not found".
+func cfnFindInMapLeaf(args interface{}, cctx *cfnContext) (leaf interface{}, ok bool, reason string) {
+	arr, isArr := args.([]interface{})
+	if !isArr || len(arr) < 3 {
+		return nil, false, "Fn::FindInMap requires a map name and two keys"
+	}
+	mapName := resolveValue(arr[0], cctx)
+	topKey := resolveValue(arr[1], cctx)
+	secondKey := resolveValue(arr[2], cctx)
+
+	defaultValue, hasDefault := cfnFindInMapDefault(arr)
+
+	top, found := cctx.mappings[mapName]
+	if !found {
+		if hasDefault {
+			return defaultValue, true, ""
+		}
+		return nil, false, fmt.Sprintf(
+			"Fn::FindInMap: no mapping named %q in the template's Mappings section", mapName)
+	}
+	second, found := top[topKey]
+	if !found {
+		if hasDefault {
+			return defaultValue, true, ""
+		}
+		return nil, false, fmt.Sprintf(
+			"Fn::FindInMap: mapping %q has no top-level key %q", mapName, topKey)
+	}
+	value, found := second[secondKey]
+	if !found {
+		if hasDefault {
+			return defaultValue, true, ""
+		}
+		return nil, false, fmt.Sprintf(
+			"Fn::FindInMap: mapping %q key %q has no second-level key %q", mapName, topKey, secondKey)
+	}
+	return value, true, ""
+}
+
+// cfnFindInMapDefault reads Fn::FindInMap's optional fourth argument.
+//
+// The argument is a map with exactly the key DefaultValue; anything else is not
+// the documented form and is ignored rather than guessed at, so a template that
+// misspells it gets the lookup failure it would get from CloudFormation instead
+// of a silently different value.
+func cfnFindInMapDefault(arr []interface{}) (interface{}, bool) {
+	if len(arr) < 4 {
+		return nil, false
+	}
+	m, ok := arr[3].(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	v, has := m["DefaultValue"]
+	return v, has
+}
+
+// resolveFnGetAZs resolves Fn::GetAZs to the Availability Zones of a region.
+//
+// The zones come from ec2SeededAZSuffixes, the same list EC2's
+// DescribeAvailabilityZones, DescribeInstanceTypeOfferings and
+// DescribeSpotPriceHistory derive their zone names from, so a template that picks
+// a zone with !Select over !GetAZs names a zone a caller can then query. Two
+// independent lists would be the defect worth avoiding here: a subnet in a zone
+// DescribeAvailabilityZones does not report is not observable-consistent.
+//
+// "Specifying an empty string is equivalent to specifying AWS::Region", and the
+// one function permitted inside is Ref — which is how the documented
+// `{"Fn::GetAZs": {"Ref": "AWS::Region"}}` form arrives — so the argument goes
+// through resolveValue and an empty result falls back to the caller's region.
+//
+// Substrate reports every zone for every region, where real CloudFormation
+// "returns only Availability Zones that have a default subnet" and warns the
+// order "isn't guaranteed". Substrate's order is fixed, which is what a
+// deterministic emulator owes a caller indexing into the list.
+func resolveFnGetAZs(args interface{}, cctx *cfnContext) []string {
+	region := resolveValue(args, cctx)
+	if region == "" {
+		region = cctx.region
+	}
+	out := make([]string, 0, len(ec2SeededAZSuffixes))
+	for _, suffix := range ec2SeededAZSuffixes {
+		out = append(out, region+suffix)
+	}
+	return out
+}
+
+// resolveFnCidr resolves Fn::Cidr to a list of CIDR blocks.
+//
+// The arguments are `[ipBlock, count, cidrBits]`: "count — the number of CIDRs to
+// generate. Valid range is between 1 and 256", and "cidrBits — the number of
+// subnet bits for the CIDR. For example, specifying a value "8" for this
+// parameter will create a CIDR with a mask of "/24"". So the generated mask is
+// (address bits − cidrBits): the documented example
+// `{"Fn::Cidr": ["192.168.0.0/24", "6", "5"]}` yields six /27 blocks, since
+// 32 − 5 = 27.
+//
+// Both IPv4 and IPv6 are handled, because the documented IPv6 example asks for
+// cidrBits 64 against a /56 — the address width has to come from the parsed
+// block rather than being assumed to be 32.
+//
+// A malformed or impossible request records a failure rather than returning a
+// short list: a caller doing `!Select [3, !Cidr [...]]` would otherwise read an
+// empty string out of a list that was silently too short.
+func resolveFnCidr(args interface{}, cctx *cfnContext) []string {
+	arr, ok := args.([]interface{})
+	if !ok || len(arr) < 3 {
+		cctx.fail("Fn::Cidr requires an ipBlock, a count and a cidrBits value")
+		return nil
+	}
+	ipBlock := resolveValue(arr[0], cctx)
+	count, err := strconv.Atoi(resolveValue(arr[1], cctx))
+	if err != nil || count < 1 || count > 256 {
+		cctx.fail("Fn::Cidr: count %q is not in the valid range 1-256", resolveValue(arr[1], cctx))
+		return nil
+	}
+	cidrBits, err := strconv.Atoi(resolveValue(arr[2], cctx))
+	if err != nil || cidrBits < 1 {
+		cctx.fail("Fn::Cidr: cidrBits %q is not a positive integer", resolveValue(arr[2], cctx))
+		return nil
+	}
+	blocks, err := cfnCidrBlocks(ipBlock, count, cidrBits)
+	if err != nil {
+		cctx.fail("Fn::Cidr: %s", err)
+		return nil
+	}
+	return blocks
+}
+
+// cfnCidrBlocks splits ipBlock into count subnets whose host part is cidrBits
+// wide, in ascending order.
+//
+// net/netip rather than net: netip.Prefix carries the address family, which is
+// what decides whether the new mask is 32 − cidrBits or 128 − cidrBits, and
+// netip.Addr's bytes can be incremented without the allocation-per-address that
+// net.IP arithmetic needs.
+func cfnCidrBlocks(ipBlock string, count, cidrBits int) ([]string, error) {
+	prefix, err := netip.ParsePrefix(ipBlock)
+	if err != nil {
+		return nil, fmt.Errorf("ipBlock %q is not a CIDR block: %w", ipBlock, err)
+	}
+	prefix = prefix.Masked()
+	addrBits := prefix.Addr().BitLen()
+	newMask := addrBits - cidrBits
+	if newMask < prefix.Bits() {
+		return nil, fmt.Errorf("cidrBits %d would widen %s to /%d, which is larger than the block itself",
+			cidrBits, ipBlock, newMask)
+	}
+	// Each subnet is 2^cidrBits addresses, so the number that fit is
+	// 2^(newMask − prefix.Bits()). Computed as a shift over the exponent rather
+	// than over the count itself, since a /0 with cidrBits 1 would overflow.
+	if exp := newMask - prefix.Bits(); exp < 9 && count > 1<<exp {
+		return nil, fmt.Errorf("%s holds only %d /%d blocks, not %d", ipBlock, 1<<exp, newMask, count)
+	}
+	out := make([]string, 0, count)
+	addr := prefix.Addr()
+	for i := 0; i < count; i++ {
+		out = append(out, netip.PrefixFrom(addr, newMask).String())
+		if i == count-1 {
+			// Not advanced past the last block, so a request for the single
+			// block that fills the whole address space succeeds rather than
+			// failing on an increment nobody needed.
+			break
+		}
+		addr, err = cfnCidrAdvance(addr, cidrBits)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// cfnCidrAdvance returns the address 2^hostBits above addr, which is the first
+// address of the next subnet of that size.
+func cfnCidrAdvance(addr netip.Addr, hostBits int) (netip.Addr, error) {
+	b := addr.AsSlice()
+	// The increment lands on the bit hostBits from the right, so it is applied to
+	// byte len(b)-1-hostBits/8 at bit hostBits%8, and any carry propagates left.
+	idx := len(b) - 1 - hostBits/8
+	if idx < 0 {
+		return netip.Addr{}, fmt.Errorf("cidrBits %d exceeds the address width", hostBits)
+	}
+	carry := uint16(1) << (hostBits % 8)
+	for ; idx >= 0 && carry != 0; idx-- {
+		sum := uint16(b[idx]) + carry
+		b[idx] = byte(sum)
+		carry = sum >> 8
+	}
+	next, ok := netip.AddrFromSlice(b)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("advancing %s by 2^%d produced an invalid address", addr, hostBits)
+	}
+	return next, nil
 }
 
 func resolveFnBase64(args interface{}, cctx *cfnContext) string {

--- a/emulator/betty_cfn_mappings_test.go
+++ b/emulator/betty_cfn_mappings_test.go
@@ -1,0 +1,842 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// regionAMIMappings is the region→AMI shape the Fn::FindInMap reference leads
+// with, plus a list-valued leaf, since "the values can be of type String or
+// List".
+var regionAMIMappings = map[string]map[string]map[string]interface{}{
+	"AWSInstanceType2Arch": {
+		"t3.micro": {"Arch": "HVM64"},
+		"t4g.nano": {"Arch": "ARM64"},
+	},
+	"AWSRegionArch2AMI": {
+		"us-east-1": {"HVM64": "ami-0e1", "ARM64": "ami-0a1"},
+		"eu-west-1": {"HVM64": "ami-0e2", "ARM64": "ami-0a2"},
+	},
+	"SecurityGroups": {
+		"Dev":  {"Ids": []interface{}{"sg-dev1"}},
+		"Prod": {"Ids": []interface{}{"sg-prod1", "sg-prod2"}},
+	},
+}
+
+// TestCFN_FindInMap_Conventions pins every branch of the lookup, including the
+// two a resolver returning a string cannot otherwise distinguish: a key that is
+// missing and a key whose value is the empty string.
+func TestCFN_FindInMap_Conventions(t *testing.T) {
+	t.Parallel()
+
+	findInMap := func(args ...interface{}) map[string]interface{} {
+		return map[string]interface{}{"Fn::FindInMap": args}
+	}
+	ref := func(name string) map[string]interface{} {
+		return map[string]interface{}{"Ref": name}
+	}
+
+	tests := []struct {
+		name         string
+		value        interface{}
+		region       string
+		params       map[string]string
+		want         string
+		wantFailures int
+	}{
+		{
+			name:   "three literal keys",
+			value:  findInMap("AWSRegionArch2AMI", "us-east-1", "HVM64"),
+			region: "us-east-1",
+			want:   "ami-0e1",
+		},
+		{
+			name:   "top-level key from a pseudo-parameter",
+			value:  findInMap("AWSRegionArch2AMI", ref("AWS::Region"), "HVM64"),
+			region: "eu-west-1",
+			want:   "ami-0e2",
+		},
+		{
+			name: "nested FindInMap as the second-level key",
+			// The documented region→arch→AMI form, which is the reason
+			// Fn::FindInMap is one of the two functions permitted inside a
+			// Fn::FindInMap's own arguments.
+			value: findInMap("AWSRegionArch2AMI", ref("AWS::Region"),
+				findInMap("AWSInstanceType2Arch", ref("InstanceType"), "Arch")),
+			region: "us-east-1",
+			params: map[string]string{"InstanceType": "t4g.nano"},
+			want:   "ami-0a1",
+		},
+		{
+			name:   "a list-valued leaf is rejoined in a scalar context",
+			value:  findInMap("SecurityGroups", "Prod", "Ids"),
+			region: "us-east-1",
+			want:   "sg-prod1,sg-prod2",
+		},
+		{
+			name:         "an unknown mapping name fails rather than yielding a literal",
+			value:        findInMap("NoSuchMap", "us-east-1", "HVM64"),
+			region:       "us-east-1",
+			want:         "",
+			wantFailures: 1,
+		},
+		{
+			name:         "an unknown top-level key fails",
+			value:        findInMap("AWSRegionArch2AMI", "ap-south-1", "HVM64"),
+			region:       "us-east-1",
+			want:         "",
+			wantFailures: 1,
+		},
+		{
+			name:         "an unknown second-level key fails",
+			value:        findInMap("AWSRegionArch2AMI", "us-east-1", "RISCV"),
+			region:       "us-east-1",
+			want:         "",
+			wantFailures: 1,
+		},
+		{
+			name: "DefaultValue covers a missing top-level key",
+			value: findInMap("AWSRegionArch2AMI", "ap-south-1", "HVM64",
+				map[string]interface{}{"DefaultValue": "ami-fallback"}),
+			region: "us-east-1",
+			want:   "ami-fallback",
+		},
+		{
+			name: "DefaultValue covers a missing second-level key",
+			value: findInMap("AWSRegionArch2AMI", "us-east-1", "RISCV",
+				map[string]interface{}{"DefaultValue": "ami-fallback"}),
+			region: "us-east-1",
+			want:   "ami-fallback",
+		},
+		{
+			name: "DefaultValue is not consulted when the key resolves",
+			value: findInMap("AWSRegionArch2AMI", "us-east-1", "HVM64",
+				map[string]interface{}{"DefaultValue": "ami-fallback"}),
+			region: "us-east-1",
+			want:   "ami-0e1",
+		},
+		{
+			name: "a misspelled fourth argument is not a default",
+			// The fourth parameter "must be a map with the key DefaultValue", so
+			// a template that writes Default instead gets the lookup failure
+			// CloudFormation would give it rather than a silently different
+			// value.
+			value: findInMap("AWSRegionArch2AMI", "ap-south-1", "HVM64",
+				map[string]interface{}{"Default": "ami-fallback"}),
+			region:       "us-east-1",
+			want:         "",
+			wantFailures: 1,
+		},
+		{
+			name:         "too few arguments fails",
+			value:        findInMap("AWSRegionArch2AMI", "us-east-1"),
+			region:       "us-east-1",
+			want:         "",
+			wantFailures: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, failures := emulator.CFNResolveWithMappingsForTest(
+				tt.value, regionAMIMappings, tt.params, tt.region)
+			assert.Equal(t, tt.want, got)
+			assert.Len(t, failures, tt.wantFailures,
+				"failures recorded: %v", failures)
+			for _, f := range failures {
+				assert.Contains(t, f, "Fn::FindInMap",
+					"a reason reaches DescribeStackResources, so it must name the intrinsic")
+			}
+		})
+	}
+}
+
+// TestCFN_FindInMap_ListLeafKeepsElements pins that a list-valued mapping leaf
+// contributes its members in a list-valued context rather than one rejoined
+// string — the `SecurityGroupIds: !FindInMap [...]` form.
+func TestCFN_FindInMap_ListLeafKeepsElements(t *testing.T) {
+	t.Parallel()
+
+	got, failures := emulator.CFNResolveListWithMappingsForTest(
+		map[string]interface{}{"Fn::FindInMap": []interface{}{"SecurityGroups", "Prod", "Ids"}},
+		regionAMIMappings, nil, "us-east-1")
+	assert.Empty(t, failures)
+	assert.Equal(t, []string{"sg-prod1", "sg-prod2"}, got)
+
+	// A failed lookup contributes nothing rather than one empty member, so a
+	// property built from it is absent instead of holding "".
+	got, failures = emulator.CFNResolveListWithMappingsForTest(
+		map[string]interface{}{"Fn::FindInMap": []interface{}{"SecurityGroups", "Staging", "Ids"}},
+		regionAMIMappings, nil, "us-east-1")
+	assert.Empty(t, got)
+	assert.Len(t, failures, 1)
+}
+
+// TestCFN_GetAZs_AgreesWithDescribeAvailabilityZones is the assertion the issue
+// asks for: Fn::GetAZs and EC2's own DescribeAvailabilityZones must name the same
+// zones, because a subnet placed in a zone EC2 does not report is not something a
+// caller can then query.
+func TestCFN_GetAZs_AgreesWithDescribeAvailabilityZones(t *testing.T) {
+	// ec2Request pins the Host to ec2.us-east-1.amazonaws.com, so that is the
+	// region both answers are read for.
+	const region = "us-east-1"
+
+	ts := newEC2TestServer(t)
+	resp := ec2Request(t, ts, map[string]string{"Action": "DescribeAvailabilityZones"})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read the zone names off the wire rather than out of a Go-side list: the point
+	// of the assertion is that the two answers a caller can obtain agree.
+	var described struct {
+		AZs []struct {
+			ZoneName string `xml:"zoneName"`
+		} `xml:"availabilityZoneInfo>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&described))
+	wire := make([]string, 0, len(described.AZs))
+	for _, az := range described.AZs {
+		wire = append(wire, az.ZoneName)
+	}
+	require.NotEmpty(t, wire)
+
+	azs, failures := emulator.CFNResolveListWithMappingsForTest(
+		map[string]interface{}{"Fn::GetAZs": ""}, nil, nil, region)
+	assert.Empty(t, failures)
+	// Equal, not Subset, in both directions at once: a resolver that invented a
+	// fourth zone and one that reported only the first are both wrong, and a
+	// containment assertion catches only one of them.
+	assert.Equal(t, wire, azs,
+		"Fn::GetAZs and DescribeAvailabilityZones must name the same zones")
+}
+
+// TestCFN_GetAZs_Conventions pins the region argument's three documented forms.
+func TestCFN_GetAZs_Conventions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args interface{}
+		want []string
+	}{
+		{
+			// "Specifying an empty string is equivalent to specifying
+			// AWS::Region."
+			name: "an empty string means the caller's region",
+			args: "",
+			want: emulator.CFNSeededAZsForTest("us-west-2"),
+		},
+		{
+			name: "Ref AWS::Region, the documented long form",
+			args: map[string]interface{}{"Ref": "AWS::Region"},
+			want: emulator.CFNSeededAZsForTest("us-west-2"),
+		},
+		{
+			name: "an explicit region is not the caller's",
+			args: "ap-northeast-1",
+			want: emulator.CFNSeededAZsForTest("ap-northeast-1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, failures := emulator.CFNResolveListWithMappingsForTest(
+				map[string]interface{}{"Fn::GetAZs": tt.args}, nil, nil, "us-west-2")
+			assert.Empty(t, failures)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestCFN_Cidr_DocumentedExamples pins Fn::Cidr against the reference's own
+// examples, and against the requests it must refuse.
+//
+// Refusing matters as much as answering: a template doing
+// `!Select [3, !Cidr [...]]` over a list that came back short would read an empty
+// string out of it, which is the shape of defect #522 is about.
+func TestCFN_Cidr_DocumentedExamples(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		block   string
+		count   int
+		bits    int
+		want    []string
+		wantErr string
+	}{
+		{
+			// "This example creates 6 CIDRs with a subnet mask "/27" inside from
+			// a CIDR with a mask of "/24"."
+			name:  "the reference's basic example",
+			block: "192.168.0.0/24",
+			count: 6,
+			bits:  5,
+			want: []string{
+				"192.168.0.0/27", "192.168.0.32/27", "192.168.0.64/27",
+				"192.168.0.96/27", "192.168.0.128/27", "192.168.0.160/27",
+			},
+		},
+		{
+			// The IPv6-enabled-VPC example: cidrBits 8 against the VPC's /16.
+			name:  "cidrBits 8 gives a /24",
+			block: "10.0.0.0/16",
+			count: 4,
+			bits:  8,
+			want:  []string{"10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"},
+		},
+		{
+			// The same example's Ipv6CidrBlock: cidrBits 64 against a /56. The
+			// mask is 128 − 64, so the address family has to come from the block
+			// rather than being assumed to be IPv4.
+			name:  "IPv6 takes its width from the address",
+			block: "2001:db8::/56",
+			count: 2,
+			bits:  64,
+			want:  []string{"2001:db8::/64", "2001:db8:0:1::/64"},
+		},
+		{
+			name:  "an unaligned block is masked first",
+			block: "10.0.0.17/16",
+			count: 1,
+			bits:  8,
+			want:  []string{"10.0.0.0/24"},
+		},
+		{
+			name:    "a count the block cannot hold is refused",
+			block:   "10.0.0.0/24",
+			count:   3,
+			bits:    7,
+			wantErr: "holds only 2",
+		},
+		{
+			name:    "cidrBits wider than the block is refused",
+			block:   "10.0.0.0/24",
+			count:   1,
+			bits:    16,
+			wantErr: "would widen",
+		},
+		{
+			name:    "a malformed ipBlock is refused",
+			block:   "10.0.0.0",
+			count:   1,
+			bits:    8,
+			wantErr: "is not a CIDR block",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := emulator.CFNCidrBlocksForTest(tt.block, tt.count, tt.bits)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Empty(t, got, "a refused request must not return a partial list")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestCFN_Cidr_ThroughResolver pins the count/cidrBits validation the resolver
+// applies before the split, and that a bad request records a reason.
+func TestCFN_Cidr_ThroughResolver(t *testing.T) {
+	t.Parallel()
+
+	cidr := func(args ...interface{}) map[string]interface{} {
+		return map[string]interface{}{"Fn::Cidr": args}
+	}
+
+	tests := []struct {
+		name         string
+		value        interface{}
+		want         []string
+		wantFailures int
+	}{
+		{
+			name:  "numeric strings, as the JSON example writes them",
+			value: cidr("192.168.0.0/24", "2", "5"),
+			want:  []string{"192.168.0.0/27", "192.168.0.32/27"},
+		},
+		{
+			name:  "YAML numbers, as the short form writes them",
+			value: cidr("192.168.0.0/24", float64(2), float64(5)),
+			want:  []string{"192.168.0.0/27", "192.168.0.32/27"},
+		},
+		{
+			// "count — The number of CIDRs to generate. Valid range is between
+			// 1 and 256."
+			name:         "count above 256 is refused",
+			value:        cidr("10.0.0.0/8", "257", "8"),
+			wantFailures: 1,
+		},
+		{
+			name:         "count of zero is refused",
+			value:        cidr("10.0.0.0/8", "0", "8"),
+			wantFailures: 1,
+		},
+		{
+			name:         "too few arguments is refused",
+			value:        cidr("10.0.0.0/8", "2"),
+			wantFailures: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, failures := emulator.CFNResolveListWithMappingsForTest(tt.value, nil, nil, "us-east-1")
+			assert.Len(t, failures, tt.wantFailures, "failures: %v", failures)
+			if tt.wantFailures == 0 {
+				assert.Equal(t, tt.want, got)
+				return
+			}
+			assert.Empty(t, got)
+			for _, f := range failures {
+				assert.Contains(t, f, "Fn::Cidr")
+			}
+		})
+	}
+}
+
+// TestCFN_PseudoParameters pins the four #522 adds, including the two whose value
+// depends on the caller's partition.
+func TestCFN_PseudoParameters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("partition and URL suffix follow the region", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			region        string
+			wantPartition string
+			wantSuffix    string
+		}{
+			{"us-east-1", "aws", "amazonaws.com"},
+			{"eu-west-1", "aws", "amazonaws.com"},
+			// "the partition for resources in the China (Beijing and Ningxia)
+			// Regions is aws-cn"
+			{"cn-north-1", "aws-cn", "amazonaws.com.cn"},
+			{"cn-northwest-1", "aws-cn", "amazonaws.com.cn"},
+			// "the partition for resources in the AWS GovCloud (US-West) Region
+			// is aws-us-gov"
+			{"us-gov-west-1", "aws-us-gov", "amazonaws.com"},
+			{"us-gov-east-1", "aws-us-gov", "amazonaws.com"},
+		}
+		for _, tt := range tests {
+			assert.Equal(t, tt.wantPartition, emulator.CFNPartitionForTest(tt.region), tt.region)
+			assert.Equal(t, tt.wantSuffix, emulator.CFNURLSuffixForTest(tt.region), tt.region)
+		}
+	})
+
+	t.Run("resolved through Ref and Fn::Sub alike", func(t *testing.T) {
+		t.Parallel()
+		// Both spellings reach resolveRef, which is the invariant worth pinning:
+		// a template writes `!Sub 'arn:${AWS::Partition}:s3:::b'` far more often
+		// than it writes a bare Ref.
+		got, failures := emulator.CFNResolveWithMappingsForTest(
+			map[string]interface{}{"Ref": "AWS::Partition"}, nil, nil, "cn-north-1")
+		assert.Empty(t, failures)
+		assert.Equal(t, "aws-cn", got)
+
+		got, failures = emulator.CFNResolveWithMappingsForTest(
+			map[string]interface{}{"Fn::Sub": "arn:${AWS::Partition}:s3:::${AWS::URLSuffix}"},
+			nil, nil, "cn-north-1")
+		assert.Empty(t, failures)
+		assert.Equal(t, "arn:aws-cn:s3:::amazonaws.com.cn", got)
+	})
+
+	t.Run("StackId is the stack ARN", func(t *testing.T) {
+		t.Parallel()
+		got, failures := emulator.CFNResolveWithMappingsForTest(
+			map[string]interface{}{"Ref": "AWS::StackId"}, nil, nil, "us-east-1")
+		assert.Empty(t, failures)
+		// "arn:aws:cloudformation:us-west-2:123456789012:stack/teststack/51af…"
+		assert.Regexp(t,
+			`^arn:aws:cloudformation:us-east-1:123456789012:stack/teststack/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+			got)
+		// Deterministic, which is the property a replay depends on.
+		again, _ := emulator.CFNResolveWithMappingsForTest(
+			map[string]interface{}{"Ref": "AWS::StackId"}, nil, nil, "us-east-1")
+		assert.Equal(t, got, again)
+	})
+
+	t.Run("NotificationARNs is an empty list", func(t *testing.T) {
+		t.Parallel()
+		// "Unlike other pseudo parameters […] returns a list of ARNs." Substrate
+		// has no notification model, so the list is empty — and empty is the
+		// accurate answer for a stack created without any, not a placeholder.
+		got, failures := emulator.CFNResolveListWithMappingsForTest(
+			map[string]interface{}{"Ref": "AWS::NotificationARNs"}, nil, nil, "us-east-1")
+		assert.Empty(t, failures)
+		assert.Empty(t, got)
+
+		// The documented `!Select ['0', !Ref 'AWS::NotificationARNs']` therefore
+		// resolves to the empty string rather than to the reference string, which
+		// is what would have reached a TopicARN property before (#522).
+		scalar, failures := emulator.CFNResolveWithMappingsForTest(
+			map[string]interface{}{"Fn::Select": []interface{}{
+				"0", map[string]interface{}{"Ref": "AWS::NotificationARNs"},
+			}}, nil, nil, "us-east-1")
+		assert.Empty(t, failures)
+		assert.Empty(t, scalar)
+	})
+}
+
+// TestCFN_FindInMap_UnknownKeyFailsTheResource is the end-to-end gate: the
+// template the issue describes — a region→AMI lookup that misses — must make the
+// instance CREATE_FAILED rather than launching with the intrinsic's JSON encoding
+// as its ImageId.
+func TestCFN_FindInMap_UnknownKeyFailsTheResource(t *testing.T) {
+	t.Parallel()
+
+	deployer, _ := newFullTestDeployerWithRegistry(t)
+
+	const template = `
+AWSTemplateFormatVersion: '2010-09-09'
+Mappings:
+  RegionMap:
+    eu-west-1:
+      AMI: ami-0eu1
+Resources:
+  Good:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !FindInMap [RegionMap, eu-west-1, AMI]
+      InstanceType: t3.micro
+  Bad:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !FindInMap [RegionMap, ap-south-1, AMI]
+      InstanceType: t3.micro
+`
+	result, err := deployer.Deploy(context.Background(), template, "findinmap-stack", nil)
+	require.NoError(t, err, "one unresolvable property must not abort the stack")
+
+	byLogicalID := map[string]emulator.DeployedResource{}
+	for _, r := range result.Resources {
+		byLogicalID[r.LogicalID] = r
+	}
+
+	good, ok := byLogicalID["Good"]
+	require.True(t, ok)
+	assert.Empty(t, good.Error, "a resolvable lookup must deploy")
+
+	bad, ok := byLogicalID["Bad"]
+	require.True(t, ok)
+	require.NotEmpty(t, bad.Error,
+		"an unknown mapping key must fail the resource, not launch it with a JSON literal")
+	assert.Contains(t, bad.Error, "Fn::FindInMap")
+	assert.Contains(t, bad.Error, "ap-south-1")
+
+	// The reason reaches DescribeStackResources as CREATE_FAILED, which is the
+	// observable a consumer polls — see the refused-resource behavior #519
+	// established.
+	assert.NotContains(t, good.Error, "Fn::FindInMap",
+		"the failure must be attributed to the resource that caused it, not carried forward")
+}
+
+// TestCFN_MappingsIntrinsics_ThroughDeploy pins that the three new intrinsics
+// reach a real deploy path with their values resolved, since a resolver that is
+// right in isolation is still wrong if no template can reach it.
+func TestCFN_MappingsIntrinsics_ThroughDeploy(t *testing.T) {
+	t.Parallel()
+
+	deployer, registry := newFullTestDeployerWithRegistry(t)
+
+	const template = `
+AWSTemplateFormatVersion: '2010-09-09'
+Mappings:
+  EnvMap:
+    Prod:
+      Cidr: 10.0.0.0/16
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !FindInMap [EnvMap, Prod, Cidr]
+  Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select
+        - 0
+        - !Cidr
+          - !FindInMap [EnvMap, Prod, Cidr]
+          - 4
+          - 8
+      AvailabilityZone: !Select
+        - 1
+        - !GetAZs ''
+`
+	result, err := deployer.Deploy(context.Background(), template, "intrinsics-stack", nil)
+	require.NoError(t, err)
+	for _, r := range result.Resources {
+		assert.Empty(t, r.Error, "%s failed: %s", r.LogicalID, r.Error)
+	}
+	subnet := findResource(t, result, "Subnet")
+	require.NotEmpty(t, subnet.PhysicalID)
+
+	// Read the subnet back through EC2 rather than asserting on DeployResult: the
+	// deploy result reports what the deployer intended, and #527's symptom was a
+	// correct-looking result over a wrong stored value.
+	body := routeQuery(t, registry, "ec2", map[string]string{
+		"Action":     "DescribeSubnets",
+		"SubnetId.1": subnet.PhysicalID,
+	})
+
+	// The first /24 of the mapped /16, so Fn::Cidr ran over Fn::FindInMap's result
+	// rather than over the intrinsic's JSON encoding.
+	assert.Contains(t, body, "<cidrBlock>10.0.0.0/24</cidrBlock>")
+
+	// The second zone the same emulator reports for this region — index 1, so a
+	// resolver that truncated Fn::GetAZs to one element would fail here.
+	zones := emulator.CFNSeededAZsForTest("us-east-1")
+	require.GreaterOrEqual(t, len(zones), 2)
+	assert.Contains(t, body, "<availabilityZone>"+zones[1]+"</availabilityZone>")
+}
+
+// TestCFNPlugin_FindInMapFailureReachesTheWire is the observable a consumer
+// actually polls: DescribeStackResources over the wire, not a DeployResult a Go
+// caller reads.
+//
+// A resolution failure recorded on the resource is only useful if it survives to
+// the XML, and the derivation that carries it — DeployedResource.Error →
+// CREATE_FAILED plus ResourceStatusReason — is the one #519 established.
+func TestCFNPlugin_FindInMapFailureReachesTheWire(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	const template = `{"Mappings":{"RegionMap":{"eu-west-1":{"Bucket":"eu-data"}}},` +
+		`"Resources":{"Data":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":{"Fn::FindInMap":["RegionMap","ap-south-1","Bucket"]}}}}}`
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "findinmap-wire",
+		"TemplateBody": template,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStackResources", map[string]string{
+		"StackName": "findinmap-wire",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<ResourceStatus>CREATE_FAILED</ResourceStatus>")
+	assert.Contains(t, body, "Fn::FindInMap")
+	assert.Contains(t, body, "ap-south-1")
+}
+
+// TestCFNPlugin_StackIDPseudoParameterMatchesCreateStack pins that the stack ARN a
+// template can read about itself is the one CreateStack reported.
+//
+// Two builders would have been the easy implementation and the wrong one: a
+// consumer that captures StackId from CreateStack and then compares it against a
+// resource property built from AWS::StackId would find two different ARNs for one
+// stack, which is the divergence #517 fixed for the caller's account.
+func TestCFNPlugin_StackIDPseudoParameterMatchesCreateStack(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	const template = `{"Resources":{},"Outputs":{` +
+		`"SelfID":{"Value":{"Ref":"AWS::StackId"}},` +
+		`"Partition":{"Value":{"Ref":"AWS::Partition"}},` +
+		`"Suffix":{"Value":{"Ref":"AWS::URLSuffix"}}}}`
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "selfaware",
+		"TemplateBody": template,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	var created struct {
+		StackID string `xml:"CreateStackResult>StackId"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &created))
+	require.NotEmpty(t, created.StackID)
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "selfaware"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	var described struct {
+		Outputs []struct {
+			Key   string `xml:"OutputKey"`
+			Value string `xml:"OutputValue"`
+		} `xml:"DescribeStacksResult>Stacks>member>Outputs>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &described))
+
+	outputs := map[string]string{}
+	for _, o := range described.Outputs {
+		outputs[o.Key] = o.Value
+	}
+	assert.Equal(t, created.StackID, outputs["SelfID"],
+		"AWS::StackId and CreateStack's StackId must describe the same stack")
+	assert.Equal(t, "aws", outputs["Partition"])
+	assert.Equal(t, "amazonaws.com", outputs["Suffix"])
+}
+
+// TestCFN_ListValuedShapeInsideAStructuredProperty pins the *shape* an intrinsic
+// resolves to inside a structured property, which no scalar assertion can reach.
+//
+// A scalar context rejoins a list on commas, so a resolver that had lost the list
+// and one that kept it produce the same string there. Inside a property the two are
+// different JSON — an array against a string — and the array is what a typed plugin
+// unmarshals into a `[]string` member.
+func TestCFN_ListValuedShapeInsideAStructuredProperty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value interface{}
+		want  interface{}
+	}{
+		{
+			name:  "a list-valued mapping leaf becomes an array",
+			value: map[string]interface{}{"Fn::FindInMap": []interface{}{"SecurityGroups", "Prod", "Ids"}},
+			want:  []interface{}{"sg-prod1", "sg-prod2"},
+		},
+		{
+			// One-element, not a bare string: the leaf's declared shape decides,
+			// not how many members it happens to hold.
+			name:  "a single-member list leaf is still an array",
+			value: map[string]interface{}{"Fn::FindInMap": []interface{}{"SecurityGroups", "Dev", "Ids"}},
+			want:  []interface{}{"sg-dev1"},
+		},
+		{
+			// A string leaf must *not* become a one-element array, or every
+			// scalar property built from a mapping would arrive as a list.
+			name:  "a string leaf stays a string",
+			value: map[string]interface{}{"Fn::FindInMap": []interface{}{"AWSRegionArch2AMI", "us-east-1", "HVM64"}},
+			want:  "ami-0e1",
+		},
+		{
+			name:  "Fn::GetAZs is an array",
+			value: map[string]interface{}{"Fn::GetAZs": ""},
+			want:  []interface{}{"us-east-1a", "us-east-1b", "us-east-1c"},
+		},
+		{
+			name: "Fn::Cidr is an array",
+			value: map[string]interface{}{"Fn::Cidr": []interface{}{
+				"10.0.0.0/16", "2", "8",
+			}},
+			want: []interface{}{"10.0.0.0/24", "10.0.1.0/24"},
+		},
+		{
+			// The whole reason AWS::NotificationARNs is modeled at all: a
+			// property that takes a list of ARNs must receive an empty list, not
+			// the one-element list holding "" that a scalar Ref would give.
+			name:  "AWS::NotificationARNs is an empty array, not a one-element one",
+			value: map[string]interface{}{"Ref": "AWS::NotificationARNs"},
+			want:  []interface{}{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Wrapped in a property map, since resolveNested's list-splicing and
+			// shape-preserving arms are reached through a member rather than at
+			// the top level.
+			got, failures := emulator.CFNResolveNestedWithMappingsForTest(
+				map[string]interface{}{"Member": tt.value},
+				regionAMIMappings, nil, "us-east-1")
+			assert.Empty(t, failures)
+			assert.Equal(t, map[string]interface{}{"Member": tt.want}, got)
+		})
+	}
+}
+
+// TestCFN_ResolutionFailureIsNotInheritedByALaterResource pins that a reason is
+// attributed to the resource that caused it.
+//
+// The failure channel is state on the context, shared across every resource in the
+// stack, so the drain is what keeps it per-resource. Getting that wrong is worse
+// than not reporting at all: a stack whose first resource has a bad mapping key
+// would report every *later* resource CREATE_FAILED too, and a consumer would
+// chase a defect in the wrong resource.
+func TestCFN_ResolutionFailureIsNotInheritedByALaterResource(t *testing.T) {
+	t.Parallel()
+
+	deployer := newFullTestDeployer(t)
+
+	// Bad sorts before Later alphabetically and both are the same type, so the
+	// deploy order puts the failing resource first whichever way ties are broken.
+	const template = `
+AWSTemplateFormatVersion: '2010-09-09'
+Mappings:
+  RegionMap:
+    eu-west-1:
+      Name: eu-bucket
+Resources:
+  Bad:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !FindInMap [RegionMap, ap-south-1, Name]
+  Later:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: later-bucket
+  Third:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: third-bucket
+`
+	result, err := deployer.Deploy(context.Background(), template, "inherit-stack", nil)
+	require.NoError(t, err)
+
+	bad := findResource(t, result, "Bad")
+	require.NotEmpty(t, bad.Error, "the failing resource must carry the reason")
+
+	for _, id := range []string{"Later", "Third"} {
+		r := findResource(t, result, id)
+		assert.Empty(t, r.Error,
+			"%s did not fail; a reason recorded against Bad must not be reported against it", id)
+		assert.NotEmpty(t, r.PhysicalID, "%s must still have been created", id)
+	}
+}
+
+// TestCFN_ConditionResolutionFailureIsNotBlamedOnAResource covers the one place a
+// failure is recorded with no resource to attribute it to.
+//
+// Conditions are evaluated once, before any resource deploys, and a condition may
+// contain a `Fn::FindInMap` — `!Not [!Equals [!FindInMap [M, K1, K2], ”]]` is the
+// conventional shape. A lookup that misses there records a reason against a context
+// that has not begun deploying anything, so without a drain before the first
+// dispatch the first resource in the stack inherits it and reports CREATE_FAILED for
+// a property it never had.
+//
+// Dropping the reason rather than reporting it elsewhere is deliberate: a condition
+// is not a resource, `DescribeStackResources` has no row for one, and blaming an
+// unrelated resource is worse than the failure being visible only in the log.
+func TestCFN_ConditionResolutionFailureIsNotBlamedOnAResource(t *testing.T) {
+	t.Parallel()
+
+	deployer := newFullTestDeployer(t)
+
+	const template = `
+AWSTemplateFormatVersion: '2010-09-09'
+Mappings:
+  RegionMap:
+    eu-west-1:
+      Flag: 'yes'
+Conditions:
+  # ap-south-1 is absent from RegionMap, so this lookup fails during condition
+  # evaluation — before any resource exists to carry the reason.
+  Enabled: !Equals [!FindInMap [RegionMap, ap-south-1, Flag], 'yes']
+Resources:
+  First:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: first-bucket
+`
+	result, err := deployer.Deploy(context.Background(), template, "condfail-stack", nil)
+	require.NoError(t, err)
+
+	first := findResource(t, result, "First")
+	assert.Empty(t, first.Error,
+		"a condition's resolution failure must not be reported against the first resource")
+	assert.NotEmpty(t, first.PhysicalID, "the resource must still have been created")
+}

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -1083,10 +1083,11 @@ func cfnTime(t time.Time) string {
 // account and region, and most state keys embed both, so a stack created by a
 // caller in any other partition wrote its EC2 instances, ECS clusters and log
 // groups where that caller could not see them. Fixed in #517.
+// The ARN is built by cfnStackARN, which the AWS::StackId pseudo-parameter also
+// uses (#522): a template writing its own stack ID into a resource property and a
+// caller reading StackId off CreateStack must describe the same stack.
 func cfnStackID(reqCtx *RequestContext, stackName string) string {
-	return fmt.Sprintf("arn:aws:cloudformation:%s:%s:stack/%s/%s",
-		reqCtx.Region, reqCtx.AccountID, stackName,
-		cfnDeterministicUUID(reqCtx.Region, reqCtx.AccountID, stackName))
+	return cfnStackARN(reqCtx.Region, reqCtx.AccountID, stackName)
 }
 
 // cfnChangeSetID builds the change-set ARN.

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -362,3 +362,110 @@ func ECSRewriteContainerKeysForTest(v interface{}) interface{} {
 // mapping, so a typo in a hand-written table is caught by asserting the whole
 // table against the rule its entries follow.
 func ECSContainerDefinitionKeysForTest() map[string]string { return ecsContainerDefinitionKeys }
+
+// CFNCidrBlocksForTest wraps cfnCidrBlocks so the documented examples — and the
+// requests it must refuse rather than answer with a short list — can be asserted
+// without a template.
+func CFNCidrBlocksForTest(ipBlock string, count, cidrBits int) ([]string, error) {
+	return cfnCidrBlocks(ipBlock, count, cidrBits)
+}
+
+// CFNPartitionForTest wraps cfnPartition.
+func CFNPartitionForTest(region string) string { return cfnPartition(region) }
+
+// CFNURLSuffixForTest wraps cfnURLSuffix.
+func CFNURLSuffixForTest(region string) string { return cfnURLSuffix(region) }
+
+// CFNResolveWithMappingsForTest resolves v against a template's Mappings section,
+// returning the resolved value and any failure the resolution recorded.
+//
+// The failures are the point: a resolver returns a string, so "no such mapping
+// key" and "the key held an empty string" are the same observable downstream, and
+// the whole of #522's silent-literal defect lives in that gap. Reading them here
+// pins which lookups fail and which fall back to a DefaultValue.
+func CFNResolveWithMappingsForTest(
+	v interface{},
+	mappings map[string]map[string]map[string]interface{},
+	params map[string]string,
+	region string,
+) (string, []string) {
+	cctx := &cfnContext{
+		params:     params,
+		listParams: map[string]bool{},
+		conditions: map[string]bool{},
+		resources:  map[string]DeployedResource{},
+		evaluating: map[string]bool{},
+		mappings:   mappings,
+		region:     region,
+		accountID:  testAccountID,
+		stackName:  "teststack",
+	}
+	return resolveValue(v, cctx), cctx.takeFailures()
+}
+
+// CFNResolveListWithMappingsForTest is CFNResolveWithMappingsForTest for a
+// list-valued context, which is where Fn::GetAZs, Fn::Cidr and a list-valued
+// mapping leaf keep their elements rather than being rejoined.
+func CFNResolveListWithMappingsForTest(
+	v interface{},
+	mappings map[string]map[string]map[string]interface{},
+	params map[string]string,
+	region string,
+) ([]string, []string) {
+	cctx := &cfnContext{
+		params:     params,
+		listParams: map[string]bool{},
+		conditions: map[string]bool{},
+		resources:  map[string]DeployedResource{},
+		evaluating: map[string]bool{},
+		mappings:   mappings,
+		region:     region,
+		accountID:  testAccountID,
+		stackName:  "teststack",
+	}
+	return resolveValueList(v, cctx), cctx.takeFailures()
+}
+
+// CFNResolveNestedWithMappingsForTest resolves v as a *structured property* rather
+// than as a whole value, which is the only context where an intrinsic's resolved
+// **shape** is observable.
+//
+// A scalar context rejoins a list, so "resolved to a list" and "resolved to a
+// comma-joined string" are the same observable there. Inside a structured property
+// they are not: a member holding a list and a member holding one string are
+// different JSON, and different again from a member holding "". That distinction is
+// what decides whether a list-valued mapping leaf or AWS::NotificationARNs reaches
+// a plugin as an array.
+func CFNResolveNestedWithMappingsForTest(
+	v interface{},
+	mappings map[string]map[string]map[string]interface{},
+	params map[string]string,
+	region string,
+) (interface{}, []string) {
+	cctx := &cfnContext{
+		params:     params,
+		listParams: map[string]bool{},
+		conditions: map[string]bool{},
+		resources:  map[string]DeployedResource{},
+		evaluating: map[string]bool{},
+		mappings:   mappings,
+		region:     region,
+		accountID:  testAccountID,
+		stackName:  "teststack",
+	}
+	return resolveNested(v, cctx), cctx.takeFailures()
+}
+
+// CFNSeededAZsForTest returns the Availability Zone names substrate reports for a
+// region, derived from the same list EC2's DescribeAvailabilityZones uses.
+//
+// Exported so a test can assert Fn::GetAZs against EC2's own answer without
+// hard-coding a zone list in a second place — which is the disagreement the
+// resolver exists to avoid.
+func CFNSeededAZsForTest(region string) []string {
+	out := make([]string, 0, len(ec2SeededAZSuffixes))
+	for _, suffix := range ec2SeededAZSuffixes {
+		out = append(out, region+suffix)
+	}
+	return out
+}


### PR DESCRIPTION
Part 1 of #522. **Does not close it** — `Fn::ImportValue` is deliberately split out; see *What this leaves* below.

## The defect

`cfnTemplate` had no `Mappings` field, so the section every region→AMI template carries was discarded at parse time and `Fn::FindInMap` fell through to the JSON-encoding fallback. The near-universal

```yaml
ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]
```

reached `RunInstances` as the literal string `{"Fn::FindInMap":["RegionMap",...]}` and **the instance launched**, the resource reporting `CREATE_COMPLETE`. Same shape as #516/#517/#521/#526/#527: substrate returns 200 while the observable a caller parses is wrong.

## What resolves now

**`Mappings` + `Fn::FindInMap`** — all three levels, including the nested-key form the reference leads with (`!FindInMap [Arch2AMI, !Ref 'AWS::Region', !FindInMap [Type2Arch, !Ref InstanceType, Arch]]`). A leaf may be a string or a **list**, since "the values can be of type String or List", so a list-valued lookup splices into a list-valued property and is rejoined on commas in a scalar one. The optional fourth argument is honored, spelled exactly `{DefaultValue: …}` — a map with any other key is not a default and the lookup fails as it would without one, rather than substrate guessing at the intent.

**A lookup that misses fails the resource.** `CREATE_FAILED` with a `ResourceStatusReason` naming the intrinsic and the key that missed; the rest of the stack still deploys, per #519. That is the point of modelling `Mappings` rather than tolerating it — a nonsense `ImageId` reported as success is the defect.

Reporting it needed a **new channel**, because a resolver returns a `string` and in that type "no such key" and "the key held an empty string" are the same value. `cfnContext` now accumulates failures, drained per resource onto `DeployedResource.Error` — which `DescribeStackResources` already derives `CREATE_FAILED` from (`cloudformation_plugin.go:474`). `deployResource` is split into that drain plus `dispatchResource`, so the ~100-arm type switch is renamed rather than edited.

**`Fn::GetAZs`** derives from `ec2SeededAZSuffixes`, the same list EC2's `DescribeAvailabilityZones` answers from, rather than carrying a second one — a subnet in a zone the emulator does not report is not something a caller can query, and two independent lists is how that happens.

**`Fn::Cidr`** for IPv4 and IPv6 via `net/netip` (the mask comes from the parsed block's address family; both of the reference's examples are asserted). An impossible request fails the resource rather than returning a short list, since `!Select [3, !Cidr [...]]` reads an empty string out of a short list and deploys.

**The four remaining pseudo-parameters.** `AWS::Partition`/`AWS::URLSuffix` follow the region; `AWS::NotificationARNs` is an **empty list** (accurate — substrate has no notification model); `AWS::StackId` now **shares its builder with the wire's `cfnStackID`**, so a consumer that captures `StackId` from `CreateStack` and compares it against a property built from `AWS::StackId` finds one ARN for one stack. Two builders would have been the same divergence #517 fixed for the caller's account.

## What this leaves

`Fn::ImportValue` is still unresolved and **#522 stays open for it**. Per the plan's own stated trigger — *"if PR 3 grows past PR 1+2 combined, split `Fn::ImportValue` out"* — it needs an export registry populated from `Outputs.*.Export.Name` (`Export` is absent from `cfnOutput` today) plus a refusal to delete a stack whose export is imported. That is a new cross-stack model, not another resolver, and it ships as a follow-up PR. `Fn::ImportValue` is deliberately **not** admitted to `cfnIntrinsicNames` here: doing so would make `resolveNested` resolve it to the empty string, which is worse than the current JSON-literal fallback.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues), `make test` (race), docs reference/versions checks, `npm --prefix docs run build`, `test/e2e` vet+test — all green.

End to end over the wire against `substrate server`, region matched to the signed request:

```
$ aws cloudformation describe-stack-resources --stack-name mappings522b \
    --query 'StackResources[].[LogicalResourceId,ResourceStatus]'
VPC       CREATE_COMPLETE
Subnet    CREATE_COMPLETE
Instance  CREATE_COMPLETE

$ aws ec2 describe-vpcs --query 'Vpcs[].CidrBlock'          # !FindInMap
10.42.0.0/16
$ aws ec2 describe-subnets --query 'Subnets[].[CidrBlock,AvailabilityZone]'
10.42.2.0/24   us-east-1b       # !Select [2, !Cidr [...]] and !Select [1, !GetAZs '']
$ aws ec2 describe-availability-zones --query 'AvailabilityZones[].ZoneName'
us-east-1a  us-east-1b  us-east-1c     # the same zones — they agree
$ aws ec2 describe-instances --query 'Reservations[].Instances[].ImageId'
ami-0abcdef1234567890                   # the mapped AMI, not a JSON literal
```

And the failure path, with the rest of the stack unaffected:

```
$ aws cloudformation describe-stack-resources --stack-name badmap522 \
    --query 'StackResources[].[LogicalResourceId,ResourceStatus,ResourceStatusReason]'
Good  CREATE_COMPLETE  None
Bad   CREATE_FAILED    Fn::FindInMap: mapping "RegionMap" has no top-level key "us-east-1"
```

## Mutation testing

21 mutants, **all CAUGHT**, no survivors and no equivalents — including the plan's nominated highest-value one (`Fn::FindInMap` falling back to the JSON literal instead of failing the resource), the failure channel going silent, `Fn::GetAZs` inventing its own zone list, `Fn::Cidr` assuming IPv4, and `cfnStackID` diverging from `cfnStackARN`.

The pass exposed **three test-design gaps**, each closed by a test rather than argued away as equivalent:

- **The resolved *shape* inside a structured property was unasserted.** A scalar context rejoins a list, so "resolved to a list" and "resolved to a comma-joined string" are the same observable there — `cfnListValuedIntrinsic` could return a constant and nothing failed. `TestCFN_ListValuedShapeInsideAStructuredProperty` asserts the JSON shape a member receives, which is also where `AWS::NotificationARNs` being an *empty* array rather than a one-element `[""]` becomes visible.
- **A failure being inherited by a later resource was unasserted.** The channel is state on the shared context, so the drain is what keeps it per-resource; getting it wrong would report every *later* resource `CREATE_FAILED` and send a consumer chasing the wrong one.
- **A condition's failure had no attribution test.** Conditions are evaluated once before any resource deploys, and `!Not [!Equals [!FindInMap [M, K1, K2], '']]` is conventional — so a failing lookup there records against a context with nothing to blame. Dropping it is deliberate (`DescribeStackResources` has no row for a condition); blaming the first resource is the bug the pre-drain prevents.

Refs #522
