### PR TITLE
chore(cfn): classify StackDeployer failures with sentinels, not substrings (#502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an export registry across stacks and a refusal to delete a stack whose export is
   imported, which is a new cross-stack model rather than another resolver.
 
+### Changed
+- **A CloudFormation error code is derived from the failure's classification, not
+  from its message text** (#502). `cfnMapDeployerError` recovered the AWS error code
+  and HTTP status by running `strings.Contains` over the deployer's message, which
+  coupled two things that have no business being coupled. Rewording
+  `stack %q not found` — an ordinary copy-edit — silently turned a `ValidationError`
+  at 400 into an `InternalFailure` at 500 for every consumer, with no compiler error
+  and no failing test outside the plugin's own suite. And it was lossy the other
+  way: `deploy resource %s: %w` wraps whatever the plugin returned, and a plugin's
+  own message may well contain "not found" — an instance whose AMI does not resolve,
+  say — so a genuine resource-level failure was reported as though the *request* had
+  named an absent stack, at 400 rather than 500.
+
+  `StackDeployer` now wraps one of `ErrCFNStackNotFound`,
+  `ErrCFNChangeSetNotFound`, `ErrCFNDriftDetectionNotFound`,
+  `ErrCFNTemplateInvalid`, `ErrCFNResourceDeployFailed` or `ErrCFNStateRequired`,
+  and the plugin classifies with `errors.Is`. **Every message is unchanged byte for
+  byte**, which is what makes this safe to land on its own: anything reading a
+  substrate log sees exactly what it saw before, and only the classification is new.
+  The classification lives in a field rather than being wrapped into the text with a
+  second `%w`, precisely so that the text and the code stay independent — a test
+  hands the mapping a message sharing no word with the old switch's strings and
+  asserts the code still resolves.
+
+  A failed resource additionally carries its logical ID on a typed
+  `CFNResourceDeployError`, so a caller need not re-parse the message to learn which
+  resource failed. `DescribeStackResources` reads a failure off the resource record
+  rather than off this error (#519), but a deploy that fails outright returns before
+  any record is written, so the logical ID has to travel with the error or it is
+  lost.
+
+  Landed here rather than deferred because #522's delete-refusal has no resource to
+  blame and so must come back through `DeleteStack`'s error return — the trigger the
+  issue's own analysis named for pulling this forward instead of widening the
+  substring switch.
+
 ## [v0.87.1] - 2026-08-03
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -117,6 +117,14 @@ here.
 template is a network read substrate does not perform, and silently accepting the
 parameter deployed a stack with no resources in it.
 
+A request that names something absent — a stack, a change set, a drift detection —
+is a `ValidationError` at 400, and a template body that cannot be decoded is a
+`ValidationError` at 400 prefixed `Template format error:`. A resource that failed
+to deploy after the template parsed is an `InternalFailure` at 500, because the
+request was well-formed and the failure is substrate's. That distinction is drawn
+from the classification the stack model attaches to a failure, not from its
+message, so a message may be reworded without moving any consumer's error code.
+
 ### Stacks share state with every other plugin
 
 The plugin is a thin adapter over the same stack model substrate has always

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/netip"
 	"reflect"
@@ -156,6 +157,118 @@ func (c *cfnContext) takeFailures() []string {
 	c.failures = nil
 	return out
 }
+
+// The sentinel errors a [StackDeployer] operation wraps, so a caller can
+// classify a failure with [errors.Is] rather than by matching the message.
+//
+// The wire plugin has to turn a deployer failure into an AWS error code and an
+// HTTP status, and until these existed it did so with strings.Contains over the
+// message (#502). That worked and was fragile in two directions. Rewording
+// "stack %q not found" — an ordinary copy-edit — silently turned a
+// ValidationError at 400 into an InternalFailure at 500 for every consumer, with
+// no compiler error and no failing test outside the plugin's own suite. And it
+// was lossy the other way: a resource-level deploy failure whose wrapped cause
+// happened to contain "not found" (an instance whose AMI does not resolve, say)
+// was reported as though the *request* had named something absent.
+//
+// Each site wraps the sentinel with %w and keeps its message text byte for byte,
+// so anything reading a log is unaffected; only the classification changes.
+var (
+	// ErrCFNStackNotFound is returned when an operation names a stack that does
+	// not exist.
+	ErrCFNStackNotFound = errors.New("stack not found")
+
+	// ErrCFNChangeSetNotFound is returned when an operation names a change set
+	// that does not exist.
+	ErrCFNChangeSetNotFound = errors.New("change set not found")
+
+	// ErrCFNDriftDetectionNotFound is returned when a drift-detection ID does
+	// not resolve.
+	ErrCFNDriftDetectionNotFound = errors.New("drift detection not found")
+
+	// ErrCFNTemplateInvalid is returned when a template body cannot be parsed.
+	ErrCFNTemplateInvalid = errors.New("invalid template")
+
+	// ErrCFNResourceDeployFailed is returned when a template resource could not
+	// be deployed.
+	//
+	// This is deliberately distinct from ErrCFNTemplateInvalid: the template
+	// parsed, so the caller's request was well-formed and the failure is
+	// substrate's, which is a 500 rather than a 400.
+	ErrCFNResourceDeployFailed = errors.New("resource deploy failed")
+
+	// ErrCFNStateRequired is returned when an operation needs a state manager and
+	// the deployer was built without one.
+	ErrCFNStateRequired = errors.New("state manager required")
+)
+
+// cfnClassifiedError carries a [StackDeployer] failure's classification
+// alongside its message, so the two can be independent.
+//
+// Wrapping the sentinel into the message with a second %w would have worked for
+// errors.Is and changed the text every consumer's logs already carry — and
+// "message unchanged" is the property that makes this refactor safe to land on
+// its own. Holding the class in a field instead means a message may be reworded
+// freely without moving the wire code, which was the whole complaint.
+type cfnClassifiedError struct {
+	class error
+	msg   string
+	cause error
+}
+
+// Error implements the error interface.
+func (e *cfnClassifiedError) Error() string { return e.msg }
+
+// Unwrap returns the wrapped cause, or the classification when there is none, so
+// errors.Is finds the class either way.
+func (e *cfnClassifiedError) Unwrap() error {
+	if e.cause != nil {
+		return e.cause
+	}
+	return e.class
+}
+
+// Is reports whether the error carries the given classification.
+func (e *cfnClassifiedError) Is(target error) bool { return target == e.class }
+
+// cfnErrf builds a classified deployer error whose message is exactly format
+// applied to args. A %w in format is unwrapped as usual, so a parse failure's
+// cause survives underneath the classification.
+func cfnErrf(class error, format string, args ...interface{}) error {
+	wrapped := fmt.Errorf(format, args...)
+	return &cfnClassifiedError{
+		class: class,
+		msg:   wrapped.Error(),
+		cause: errors.Unwrap(wrapped),
+	}
+}
+
+// CFNResourceDeployError reports a template resource that could not be deployed,
+// naming the resource so a caller need not re-parse the message to find it.
+//
+// DescribeStackResources reads the failure off the resource record rather than
+// this error, but a deploy that fails outright returns before any record is
+// written — so the logical ID has to travel with the error or it is lost.
+type CFNResourceDeployError struct {
+	// LogicalID is the template logical ID of the resource that failed.
+	LogicalID string
+
+	// Err is the underlying failure.
+	Err error
+}
+
+// Error implements the error interface.
+func (e *CFNResourceDeployError) Error() string {
+	return fmt.Sprintf("deploy resource %s: %v", e.LogicalID, e.Err)
+}
+
+// Unwrap returns the underlying failure.
+func (e *CFNResourceDeployError) Unwrap() error { return e.Err }
+
+// Is reports that a CFNResourceDeployError matches ErrCFNResourceDeployFailed,
+// so a caller can classify it without also matching whatever the wrapped cause
+// happens to be.
+func (e *CFNResourceDeployError) Is(target error) bool { return target == ErrCFNResourceDeployFailed }
 
 // cfnNamespace is the state namespace for CloudFormation stack state.
 const cfnNamespace = "cfn"
@@ -489,7 +602,7 @@ func NewStackDeployer(registry *PluginRegistry, store *EventStore, state StateMa
 func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params map[string]string) (*DeployResult, error) {
 	tmpl, err := d.parseCFNTemplate(cfn)
 	if err != nil {
-		return nil, fmt.Errorf("parse template: %w", err)
+		return nil, cfnErrf(ErrCFNTemplateInvalid, "parse template: %w", err)
 	}
 
 	stackName := streamID
@@ -534,7 +647,7 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 	for _, e := range entries {
 		dr, cost, deployErr := d.deployResource(ctx, e.logicalID, e.resource, streamID, cctx)
 		if deployErr != nil {
-			return nil, fmt.Errorf("deploy resource %s: %w", e.logicalID, deployErr)
+			return nil, &CFNResourceDeployError{LogicalID: e.logicalID, Err: deployErr}
 		}
 		totalCost += cost
 		cctx.resources[e.logicalID] = dr
@@ -692,13 +805,13 @@ func (d *StackDeployer) saveStackNames(ctx context.Context, names []string) erro
 // in state and can be executed later via [StackDeployer.ExecuteChangeSet].
 func (d *StackDeployer) CreateChangeSet(ctx context.Context, stackName, changeSetName, templateBody string, params map[string]string) (*CFNChangeSet, error) {
 	if d.state == nil {
-		return nil, fmt.Errorf("cfn CreateChangeSet: state manager required")
+		return nil, cfnErrf(ErrCFNStateRequired, "cfn CreateChangeSet: state manager required")
 	}
 
 	// Load existing stack.
 	data, err := d.state.Get(ctx, cfnNamespace, "stack:"+stackName)
 	if err != nil || data == nil {
-		return nil, fmt.Errorf("cfn CreateChangeSet: stack %q not found", stackName)
+		return nil, cfnErrf(ErrCFNStackNotFound, "cfn CreateChangeSet: stack %q not found", stackName)
 	}
 	var stack CFNStackState
 	if err := json.Unmarshal(data, &stack); err != nil {
@@ -708,11 +821,11 @@ func (d *StackDeployer) CreateChangeSet(ctx context.Context, stackName, changeSe
 	// Parse old and new templates.
 	oldTmpl, err := d.parseCFNTemplate(stack.TemplateBody)
 	if err != nil {
-		return nil, fmt.Errorf("cfn CreateChangeSet: parse old template: %w", err)
+		return nil, cfnErrf(ErrCFNTemplateInvalid, "cfn CreateChangeSet: parse old template: %w", err)
 	}
 	newTmpl, err := d.parseCFNTemplate(templateBody)
 	if err != nil {
-		return nil, fmt.Errorf("cfn CreateChangeSet: parse new template: %w", err)
+		return nil, cfnErrf(ErrCFNTemplateInvalid, "cfn CreateChangeSet: parse new template: %w", err)
 	}
 
 	// Diff resources.
@@ -749,11 +862,11 @@ func (d *StackDeployer) CreateChangeSet(ctx context.Context, stackName, changeSe
 // DescribeChangeSet returns a previously created change set.
 func (d *StackDeployer) DescribeChangeSet(ctx context.Context, stackName, changeSetName string) (*CFNChangeSet, error) {
 	if d.state == nil {
-		return nil, fmt.Errorf("cfn DescribeChangeSet: state manager required")
+		return nil, cfnErrf(ErrCFNStateRequired, "cfn DescribeChangeSet: state manager required")
 	}
 	data, err := d.state.Get(ctx, cfnNamespace, "changeset:"+stackName+"/"+changeSetName)
 	if err != nil || data == nil {
-		return nil, fmt.Errorf("cfn DescribeChangeSet: change set %q not found", changeSetName)
+		return nil, cfnErrf(ErrCFNChangeSetNotFound, "cfn DescribeChangeSet: change set %q not found", changeSetName)
 	}
 	var cs CFNChangeSet
 	if err := json.Unmarshal(data, &cs); err != nil {
@@ -824,11 +937,11 @@ func (d *StackDeployer) DeleteChangeSet(ctx context.Context, stackName, changeSe
 // any resource has been deleted outside of CloudFormation.
 func (d *StackDeployer) DetectStackDrift(ctx context.Context, stackName string) (*CFNDriftResult, error) {
 	if d.state == nil {
-		return nil, fmt.Errorf("cfn DetectStackDrift: state manager required")
+		return nil, cfnErrf(ErrCFNStateRequired, "cfn DetectStackDrift: state manager required")
 	}
 	data, err := d.state.Get(ctx, cfnNamespace, "stack:"+stackName)
 	if err != nil || data == nil {
-		return nil, fmt.Errorf("cfn DetectStackDrift: stack %q not found", stackName)
+		return nil, cfnErrf(ErrCFNStackNotFound, "cfn DetectStackDrift: stack %q not found", stackName)
 	}
 	var stack CFNStackState
 	if err := json.Unmarshal(data, &stack); err != nil {
@@ -909,10 +1022,10 @@ func (d *StackDeployer) DescribeStackResourceDrifts(ctx context.Context, stackNa
 // [StackDeployer.DescribeStackDriftDetectionStatus] read can observe it.
 func (d *StackDeployer) StartStackDriftDetection(ctx context.Context, stackName string) (string, error) {
 	if d.state == nil {
-		return "", fmt.Errorf("cfn StartStackDriftDetection: state manager required")
+		return "", cfnErrf(ErrCFNStateRequired, "cfn StartStackDriftDetection: state manager required")
 	}
 	if data, err := d.state.Get(ctx, cfnNamespace, "stack:"+stackName); err != nil || data == nil {
-		return "", fmt.Errorf("cfn StartStackDriftDetection: stack %q not found", stackName)
+		return "", cfnErrf(ErrCFNStackNotFound, "cfn StartStackDriftDetection: stack %q not found", stackName)
 	}
 
 	detectionID := generateRequestID()
@@ -958,7 +1071,7 @@ func (d *StackDeployer) StartStackDriftDetection(ctx context.Context, stackName 
 func (d *StackDeployer) DescribeStackDriftDetectionStatus(ctx context.Context, detectionID string) (*CFNDriftDetectionStatus, error) {
 	data, err := d.state.Get(ctx, cfnNamespace, "drift_detection:"+detectionID)
 	if err != nil || data == nil {
-		return nil, fmt.Errorf("cfn DescribeStackDriftDetectionStatus: detection %q not found", detectionID)
+		return nil, cfnErrf(ErrCFNDriftDetectionNotFound, "cfn DescribeStackDriftDetectionStatus: detection %q not found", detectionID)
 	}
 	var status CFNDriftDetectionStatus
 	if err := json.Unmarshal(data, &status); err != nil {

--- a/emulator/betty_cfn_errors_test.go
+++ b/emulator/betty_cfn_errors_test.go
@@ -1,0 +1,322 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestCFN_DeployerErrorsCarryTheirClassification asserts that every
+// StackDeployer failure the wire plugin has to classify wraps a sentinel, and
+// that the message it carries is byte-for-byte what it was before the sentinels
+// existed.
+//
+// Both halves matter. The sentinel is what lets cfnMapDeployerError use
+// errors.Is; the unchanged message is what makes the change safe to land on its
+// own, since anything reading a substrate log sees exactly what it saw before.
+func TestCFN_DeployerErrorsCarryTheirClassification(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	const tmpl = `{"Resources":{"B":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":"cls-bucket"}}}}`
+	_, err := d.Deploy(ctx, tmpl, "cls-stack", nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		call    func() error
+		class   error
+		message string
+	}{
+		{
+			name: "CreateChangeSet on an absent stack",
+			call: func() error {
+				_, err := d.CreateChangeSet(ctx, "no-such-stack", "cs", tmpl, nil)
+				return err
+			},
+			class:   emulator.ErrCFNStackNotFound,
+			message: `cfn CreateChangeSet: stack "no-such-stack" not found`,
+		},
+		{
+			name: "DescribeChangeSet on an absent change set",
+			call: func() error {
+				_, err := d.DescribeChangeSet(ctx, "cls-stack", "no-such-cs")
+				return err
+			},
+			class:   emulator.ErrCFNChangeSetNotFound,
+			message: `cfn DescribeChangeSet: change set "no-such-cs" not found`,
+		},
+		{
+			name: "DetectStackDrift on an absent stack",
+			call: func() error {
+				_, err := d.DetectStackDrift(ctx, "no-such-stack")
+				return err
+			},
+			class:   emulator.ErrCFNStackNotFound,
+			message: `cfn DetectStackDrift: stack "no-such-stack" not found`,
+		},
+		{
+			name: "StartStackDriftDetection on an absent stack",
+			call: func() error {
+				_, err := d.StartStackDriftDetection(ctx, "no-such-stack")
+				return err
+			},
+			class:   emulator.ErrCFNStackNotFound,
+			message: `cfn StartStackDriftDetection: stack "no-such-stack" not found`,
+		},
+		{
+			name: "DescribeStackDriftDetectionStatus on an absent detection",
+			call: func() error {
+				_, err := d.DescribeStackDriftDetectionStatus(ctx, "no-such-detection")
+				return err
+			},
+			class:   emulator.ErrCFNDriftDetectionNotFound,
+			message: `cfn DescribeStackDriftDetectionStatus: detection "no-such-detection" not found`,
+		},
+		{
+			name: "Deploy with an unparseable template",
+			call: func() error {
+				_, err := d.Deploy(ctx, "{ not a template", "bad-stack", nil)
+				return err
+			},
+			class: emulator.ErrCFNTemplateInvalid,
+		},
+		{
+			name: "CreateChangeSet with an unparseable new template",
+			call: func() error {
+				_, err := d.CreateChangeSet(ctx, "cls-stack", "cs", "{ not a template", nil)
+				return err
+			},
+			class: emulator.ErrCFNTemplateInvalid,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tc.class)
+			if tc.message != "" {
+				assert.Equal(t, tc.message, err.Error(),
+					"the message must be unchanged: a consumer's logs already carry it")
+			}
+		})
+	}
+}
+
+// TestCFN_TemplateParseFailureKeepsItsCause asserts that classifying a parse
+// failure did not swallow the underlying decoder error.
+//
+// cfnErrf builds the message with fmt.Errorf, so a %w in the format still wraps.
+// Losing that would leave a caller with "parse template" and no statement of what
+// about the template was wrong.
+func TestCFN_TemplateParseFailureKeepsItsCause(t *testing.T) {
+	d := newTestDeployer(t)
+	_, err := d.Deploy(context.Background(), "{ not a template", "bad-stack", nil)
+	require.Error(t, err)
+
+	assert.ErrorIs(t, err, emulator.ErrCFNTemplateInvalid)
+	assert.Contains(t, err.Error(), "parse template: ")
+	assert.NotErrorIs(t, err, emulator.ErrCFNStackNotFound)
+
+	// The decoder's own error must still be reachable, not merely quoted in the
+	// message. A caller that wants to know *what* was malformed reads the
+	// SyntaxError's offset; a classification that replaced the cause rather than
+	// sitting above it would leave only prose.
+	var syntaxErr *json.SyntaxError
+	require.ErrorAs(t, err, &syntaxErr,
+		"the decoder's error must survive underneath the classification")
+	assert.Positive(t, syntaxErr.Offset)
+}
+
+// TestCFN_ResourceDeployFailureFromATemplate provokes the deploy-resource path
+// through a real template rather than by building the error, so the wrapping at
+// the call site is asserted too.
+//
+// A YAML mapping with a non-string key decodes fine and then cannot be
+// JSON-marshaled into a plugin request, which is a resource that failed to
+// deploy for a reason the caller did cause but that no pre-flight catches — the
+// one shape reaching Deploy's error return.
+func TestCFN_ResourceDeployFailureFromATemplate(t *testing.T) {
+	d := newTestDeployer(t)
+
+	const tmpl = "Resources:\n" +
+		"  Table:\n" +
+		"    Type: AWS::DynamoDB::Table\n" +
+		"    Properties:\n" +
+		"      TableName: unmarshalable\n" +
+		"      KeySchema:\n" +
+		"        - 1: pk\n"
+
+	_, err := d.Deploy(context.Background(), tmpl, "resource-fail", nil)
+	require.Error(t, err)
+
+	assert.ErrorIs(t, err, emulator.ErrCFNResourceDeployFailed)
+	assert.NotErrorIs(t, err, emulator.ErrCFNTemplateInvalid,
+		"the template parsed; it was the resource that could not be deployed")
+	assert.NotErrorIs(t, err, emulator.ErrCFNStackNotFound)
+
+	var deployErr *emulator.CFNResourceDeployError
+	require.ErrorAs(t, err, &deployErr)
+	assert.Equal(t, "Table", deployErr.LogicalID,
+		"the failing resource must be named without re-parsing the message")
+	assert.Equal(t, "deploy resource Table: marshal dynamodb body: "+
+		"json: unsupported type: map[interface {}]interface {}", err.Error())
+
+	awsErr := emulator.CFNMapDeployerErrorForTest(err)
+	require.NotNil(t, awsErr)
+	assert.Equal(t, "InternalFailure", awsErr.Code)
+	assert.Equal(t, http.StatusInternalServerError, awsErr.HTTPStatus)
+}
+
+// TestCFN_ResourceDeployFailureNamesTheResource pins the one classification a
+// substring match could not make.
+//
+// "deploy resource %s: %w" wraps whatever the plugin returned, and a plugin's own
+// message may well contain "not found" — an instance whose AMI does not resolve,
+// say. Under the old string match that reported ValidationError at 400, as though
+// the caller had named an absent stack. It is substrate failing to build
+// something the caller correctly asked for, which is a 500.
+func TestCFN_ResourceDeployFailureNamesTheResource(t *testing.T) {
+	inner := errors.New("security group sg-missing not found")
+	err := fmt.Errorf("wrapped: %w", &emulator.CFNResourceDeployError{
+		LogicalID: "Worker",
+		Err:       inner,
+	})
+
+	assert.ErrorIs(t, err, emulator.ErrCFNResourceDeployFailed)
+	assert.NotErrorIs(t, err, emulator.ErrCFNStackNotFound,
+		"a resource failure whose cause says 'not found' is not a missing stack")
+	assert.ErrorIs(t, err, inner, "the plugin's own reason must still be reachable")
+
+	var deployErr *emulator.CFNResourceDeployError
+	require.ErrorAs(t, err, &deployErr)
+	assert.Equal(t, "Worker", deployErr.LogicalID)
+	assert.Contains(t, err.Error(), "deploy resource Worker: ")
+
+	awsErr := emulator.CFNMapDeployerErrorForTest(err)
+	require.NotNil(t, awsErr)
+	assert.Equal(t, "InternalFailure", awsErr.Code)
+	assert.Equal(t, http.StatusInternalServerError, awsErr.HTTPStatus)
+}
+
+// TestCFN_ErrorCodeDoesNotDependOnMessageWording is the regression test for
+// #502's actual complaint.
+//
+// Each case carries a message that shares no word with the strings the old switch
+// matched on, so a mapping that still read the text would fall through to
+// InternalFailure at 500. Rewording a deployer message is now a copy-edit rather
+// than a silent change to every consumer's error handling.
+func TestCFN_ErrorCodeDoesNotDependOnMessageWording(t *testing.T) {
+	tests := []struct {
+		name       string
+		class      error
+		message    string
+		wantCode   string
+		wantStatus int
+		wantPrefix string
+	}{
+		{
+			name:       "a reworded stack lookup is still a ValidationError",
+			class:      emulator.ErrCFNStackNotFound,
+			message:    `cfn CreateChangeSet: no stack named "x" exists`,
+			wantCode:   "ValidationError",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "a reworded change-set lookup is still a ValidationError",
+			class:      emulator.ErrCFNChangeSetNotFound,
+			message:    `cfn DescribeChangeSet: no such change set "y"`,
+			wantCode:   "ValidationError",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "a reworded drift lookup is still a ValidationError",
+			class:      emulator.ErrCFNDriftDetectionNotFound,
+			message:    `cfn DescribeStackDriftDetectionStatus: unknown detection "z"`,
+			wantCode:   "ValidationError",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "a reworded decode failure is still a template format error",
+			class:      emulator.ErrCFNTemplateInvalid,
+			message:    "the body could not be decoded as JSON or YAML",
+			wantCode:   "ValidationError",
+			wantStatus: http.StatusBadRequest,
+			wantPrefix: "Template format error: ",
+		},
+		{
+			name:       "a resource failure is a 500 whatever it says",
+			class:      emulator.ErrCFNResourceDeployFailed,
+			message:    "deploy resource Worker: bucket not found",
+			wantCode:   "InternalFailure",
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "a state-manager refusal is a 500",
+			class:      emulator.ErrCFNStateRequired,
+			message:    "cfn CreateChangeSet: state manager required",
+			wantCode:   "InternalFailure",
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := emulator.CFNClassifiedErrorForTest(tc.class, tc.message)
+			require.ErrorIs(t, err, tc.class)
+			assert.Equal(t, tc.message, err.Error())
+
+			awsErr := emulator.CFNMapDeployerErrorForTest(err)
+			require.NotNil(t, awsErr)
+			assert.Equal(t, tc.wantCode, awsErr.Code)
+			assert.Equal(t, tc.wantStatus, awsErr.HTTPStatus)
+			assert.Equal(t, tc.wantPrefix+tc.message, awsErr.Message)
+		})
+	}
+}
+
+// TestCFN_MapDeployerErrorClassifiesUnknownFailuresAsInternal pins the two edges
+// of the mapping: nil in, nil out, and an unclassified error as a 500 rather than
+// a 400.
+//
+// An unclassified error is one no deployer path builds, so treating it as the
+// caller's fault would be a guess. Reporting it as substrate's failure is the
+// honest answer and the one a consumer can act on — a 400 tells them to fix their
+// request, which would be wrong.
+func TestCFN_MapDeployerErrorClassifiesUnknownFailuresAsInternal(t *testing.T) {
+	assert.Nil(t, emulator.CFNMapDeployerErrorForTest(nil))
+
+	awsErr := emulator.CFNMapDeployerErrorForTest(errors.New("stack not found somewhere"))
+	require.NotNil(t, awsErr)
+	assert.Equal(t, "InternalFailure", awsErr.Code,
+		"an unwrapped error that merely reads like a lookup failure is not one")
+	assert.Equal(t, http.StatusInternalServerError, awsErr.HTTPStatus)
+}
+
+// TestCFNPlugin_ClassifiedErrorsReachTheWire asserts the classification survives
+// the whole path a consumer uses, not just the mapping function.
+//
+// The handlers pre-flight most not-found cases themselves, so this asserts the
+// path that has no pre-flight: an unparseable body handed to CreateStack, which
+// reaches the deployer and comes back as a ValidationError at 400.
+func TestCFNPlugin_ClassifiedErrorsReachTheWire(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	status, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "bad-body",
+		"TemplateBody": "{ not a template",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	assert.Contains(t, body, "Template format error")
+}

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -1010,28 +1011,36 @@ func cfnTemplateURLUnsupported() *AWSError {
 
 // cfnMapDeployerError maps a StackDeployer failure onto a wire error code.
 //
-// StackDeployer reports failures as fmt.Errorf strings, so the mapping matches on
-// the sentinel text it emits. The handlers above pre-flight the not-found cases
-// themselves, so those codes are right by construction and this is the fallback
-// for anything that escapes; typed errors in betty_cfn.go would remove the string
-// matching entirely and are tracked in #502.
+// The classification comes from the sentinels StackDeployer wraps, read with
+// errors.Is, not from the message. Matching substrings was how this worked
+// through v0.87.1 and it coupled two things that have no business being coupled
+// (#502): rewording a deployer message silently moved a consumer's error code and
+// HTTP status, and a resource-level deploy failure whose wrapped cause happened
+// to contain "not found" was reported as though the request had named an absent
+// stack. Both are gone — a message may now be reworded freely.
+//
+// The handlers above pre-flight the not-found cases themselves, so those codes
+// are right by construction and this is the fallback for anything that escapes.
 func cfnMapDeployerError(err error) *AWSError {
 	if err == nil {
 		return nil
 	}
 	msg := err.Error()
 	switch {
-	case strings.Contains(msg, "not found"):
+	case errors.Is(err, ErrCFNStackNotFound),
+		errors.Is(err, ErrCFNChangeSetNotFound),
+		errors.Is(err, ErrCFNDriftDetectionNotFound):
 		return &AWSError{Code: "ValidationError", Message: msg, HTTPStatus: http.StatusBadRequest}
-	case strings.Contains(msg, "parse template"),
-		strings.Contains(msg, "parse old template"),
-		strings.Contains(msg, "parse new template"):
+	case errors.Is(err, ErrCFNTemplateInvalid):
 		return &AWSError{
 			Code:       "ValidationError",
 			Message:    "Template format error: " + msg,
 			HTTPStatus: http.StatusBadRequest,
 		}
 	default:
+		// A resource that failed to deploy lands here, as does anything
+		// unclassified: the template parsed and the request named things that
+		// exist, so the failure is substrate's rather than the caller's.
 		return &AWSError{Code: "InternalFailure", Message: msg, HTTPStatus: http.StatusInternalServerError}
 	}
 }

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -305,6 +305,22 @@ func CFNDispatchErrorForTest(status int, body string, routeErr error) error {
 	return cfnDispatchError(resp, routeErr)
 }
 
+// CFNMapDeployerErrorForTest wraps cfnMapDeployerError so the classification it
+// derives can be asserted against an error built by hand, rather than only
+// against whichever deployer path a test happens to be able to provoke.
+func CFNMapDeployerErrorForTest(err error) *AWSError { return cfnMapDeployerError(err) }
+
+// CFNClassifiedErrorForTest builds a classified deployer error carrying class and
+// an arbitrary message.
+//
+// The message being arbitrary is the point: it is what proves the wire code no
+// longer depends on the wording. A test can hand this a message that says nothing
+// a substring match would have recognized and assert the code still resolves,
+// which is the regression #502 removed.
+func CFNClassifiedErrorForTest(class error, message string) error {
+	return cfnErrf(class, "%s", message)
+}
+
 // ResolveValueListForTest wraps resolveValueList so its conventions can be
 // asserted at the seam rather than only through a deployer.
 //


### PR DESCRIPTION
`cfnMapDeployerError` recovered a CloudFormation error code and HTTP status by
running `strings.Contains` over the deployer's message. That worked, and it coupled
two things that have no business being coupled.

It was fragile in both directions. Rewording `stack %q not found` — an ordinary
copy-edit — silently turned a `ValidationError` at 400 into an `InternalFailure` at
500 for every consumer, with no compiler error and no failing test outside the
plugin's own suite. And it was lossy the other way: `deploy resource %s: %w` wraps
whatever the plugin returned, and a plugin's own message may well contain
"not found" — an instance whose AMI does not resolve, say — so a genuine
resource-level failure was reported as though the *request* had named an absent
stack, at 400 rather than 500.

## What changed

`StackDeployer` wraps one of six sentinels — `ErrCFNStackNotFound`,
`ErrCFNChangeSetNotFound`, `ErrCFNDriftDetectionNotFound`, `ErrCFNTemplateInvalid`,
`ErrCFNResourceDeployFailed`, `ErrCFNStateRequired` — and the plugin classifies with
`errors.Is`. No `strings.Contains` remains.

**Every message is unchanged byte for byte.** That is what makes this safe to land
on its own: anything reading a substrate log sees exactly what it saw before, and
only the classification is new. The classification is held in a field on
`cfnClassifiedError` rather than wrapped into the text with a second `%w`,
*precisely* so text and code stay independent — wrapping the sentinel into the
message would have satisfied `errors.Is` and changed the text every consumer's logs
already carry, which is the coupling the issue is about, reintroduced from the other
end.

A failed resource additionally carries its logical ID on a typed
`CFNResourceDeployError`. `DescribeStackResources` reads a failure off the resource
record rather than off this error (#519), but a deploy that fails outright returns
before any record is written, so the logical ID has to travel with the error or it
is lost.

## Why now

The v0.88.0 plan parked #502 with a **stated trigger**: it joins the release if
#522 surfaces its new failures through `Deploy`/`DeleteStack`'s error return rather
than on a resource. #522's remaining half is `Fn::ImportValue`, whose delete-refusal
("you can't delete the stack that is exporting the output value") has no resource to
blame and so must come back through `DeleteStack`. The trigger fired, so this lands
first as a pure mechanical refactor and the export work builds on typed errors
instead of widening the substring switch.

## Tests

`emulator/betty_cfn_errors_test.go`. Two assertions carry the weight:

- **The message is unchanged.** Every not-found path asserts `err.Error()` against
  the exact string it produced before, byte for byte.
- **The code does not depend on the wording.** Six cases hand the mapping a message
  sharing no word with the old switch's strings (`no stack named "x" exists`,
  `the body could not be decoded as JSON or YAML`) and assert the code and status
  still resolve. Under the old mapping every one falls through to `InternalFailure`.

Plus: the parse failure's `*json.SyntaxError` is still reachable through `errors.As`
underneath the classification; a resource failure whose cause reads "not found" is
`NotErrorIs` a missing stack; and the deploy-resource path is provoked through a
**real template** (a YAML mapping with a non-string key decodes fine and then cannot
be JSON-marshaled into a plugin request) rather than by building the error, so the
wrapping at the call site is asserted too.

## Mutation testing

18 mutants: **18 CAUGHT, 0 SURVIVED, 0 EQUIVALENT.** Anchor-count assert before
applying, `gofmt -w && go vet` gate, `-race`.

Three survived the first pass and each was a real test-design gap, closed rather
than proved equivalent:

- `classified-error-loses-its-cause` and `errf-drops-the-cause` — nothing asserted
  the decoder's own error was *reachable*, only that the message mentioned parsing.
  Closed by the `errors.As(&syntaxErr)` assertion.
- `deploy-returns-an-unclassified-error` (the pre-#502 untyped wrap at the deploy
  site) — no test reached that line from a template. Closed by
  `TestCFN_ResourceDeployFailureFromATemplate`.

The highest-value mutant, `map-falls-back-to-substring-match`, restores the exact
pre-#502 switch and is caught by three tests.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues,
unpiped), `make test` (race), `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`,
`go test -C test/e2e ./...` — all green.

Docs: `docs/services.md` §CloudFormation now states the code/status a consumer gets
for each class of failure, and that it is derived from the classification rather
than the message. CHANGELOG under `## [Unreleased]` → `### Changed`.

Closes #502
