### PR TITLE
fix(cfn): resolve Fn::ImportValue against a cross-stack export registry (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`ListExports` and `ListImports`** (#522), which were `InvalidAction` before there
+  was anything to list. `ListExports` reports every export in the caller's account
+  and Region with the `ExportingStackId` ARN `DescribeStacks` reports for the same
+  stack, in one page with no `NextToken`; `ListImports` reports stack **names**, and
+  an export nothing imports — including one that does not exist — is an empty list
+  rather than an error, since the reference documents no service-specific errors for
+  it. `DescribeStacks` additionally reports each output's `ExportName` beside it,
+  saving a caller a second call to learn whether an output is importable.
+
 ### Fixed
 - **`Fn::Split` resolves to a list, so a split list no longer loses everything
   after its first element** (#521). `resolveValue` returns a `string`, so every
@@ -167,9 +177,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   built from `AWS::StackId` must find one ARN for one stack, and two builders is
   exactly the divergence #517 fixed for the caller's account.
 
-  `Fn::ImportValue` remains unresolved and #522 stays open for it: resolving it needs
-  an export registry across stacks and a refusal to delete a stack whose export is
-  imported, which is a new cross-stack model rather than another resolver.
+- **`Fn::ImportValue` resolves, against a cross-stack export registry** (#522), which
+  closes the intrinsic list: every function CloudFormation defines now resolves. It
+  was the last one falling through to its JSON encoding, so a template importing
+  another stack's subnet ID deployed a resource whose `SubnetId` was the literal
+  `{"Fn::ImportValue":"net-SubnetID"}` and reported `CREATE_COMPLETE` — the
+  silent-success shape this whole release is about, and the worst instance of it,
+  because the two-stack split is how every non-trivial template is organised.
+
+  An output may now declare `Export: {Name: …}`, absent from `cfnOutput` until now.
+  The name is an expression rather than a string, because the conventional form is
+  `Export: {Name: !Sub '${AWS::StackName}-SubnetID'}` — an export name must be unique
+  per account and Region, so a template that hard-codes one cannot be deployed twice.
+  It resolves before the first resource deploys, which the API permits: an export
+  name may not depend on a resource, so it is knowable from the template and its
+  parameters alone.
+
+  Exports are scoped **per account and Region**, per the documented restriction that
+  cross-stack references are limited to the same account and Region. Getting this
+  wrong in the permissive direction would be worse than not resolving at all: a
+  template would pass under test and fail in AWS. `deleteStack` on the wire now uses
+  the caller's deployer for the same reason — the stack record is unpartitioned, but
+  the export visibility deciding the refusal is not.
+
+  Four rules are enforced, and they are why exports are modelled rather than faked —
+  an import that resolves against nothing enforceable is a lookup, not a reference:
+  an import of an unpublished name **fails the resource** with the name in its
+  `ResourceStatusReason` rather than resolving to `""` or to JSON; an export name
+  already held by another stack is refused; a stack whose export is imported cannot
+  be **deleted**; and an imported export's value cannot be **changed** — nor dropped,
+  which is the same thing from the importer's side, so a removal is refused on the
+  same terms. Re-deploying an unchanged value is not a change, so an idempotent
+  redeploy still works. Both refusals are a `ValidationError` at 400 naming the
+  export and every importing stack.
+
+  What counts as an import is recorded **when the resolver walks the template**, not
+  derived from the template's text, which is the one design decision here that a
+  reader would otherwise get wrong: an `Fn::ImportValue` in the branch of an `Fn::If`
+  that was not taken never happened, and neither did one that failed to resolve, so
+  neither pins an exporting stack. Only the resolver knows which branch it walked.
+
+  `Fn::ImportValue` was deliberately kept out of the intrinsic-name table until it
+  resolved. `resolveNested` (#526) consults that table to decide what is an
+  intrinsic, and admitting an unresolvable one would have resolved every nested
+  import to `""` — strictly worse than the JSON fallback, which at least left the
+  intrinsic visible in the request the plugin refused.
 
 ### Changed
 - **A CloudFormation error code is derived from the failure's classification, not

--- a/docs/services.md
+++ b/docs/services.md
@@ -112,6 +112,8 @@ here.
 | DetectStackDrift | Returns a `StackDriftDetectionId` |
 | DescribeStackDriftDetectionStatus | Resolves that ID to a completed detection |
 | DescribeStackResourceDrifts | Per-resource drift; honours `StackResourceDriftStatusFilters.member.N` |
+| ListExports | Every exported output value in the caller's account and Region, in one page |
+| ListImports | Stack **names** importing an `ExportName`; an export nothing imports is an empty list |
 
 `TemplateURL` is refused with `ValidationError` rather than ignored: fetching a
 template is a network read substrate does not perform, and silently accepting the
@@ -216,16 +218,12 @@ holds only the request a real client would have made.
 113 resource types are supported; each service section below lists the types it
 backs under **Betty CFN resource types**. A template body may be JSON or YAML.
 
-`Ref`, `Fn::GetAtt`, `Fn::Sub`, `Fn::Join`, `Fn::Select`, `Fn::Split`,
-`Fn::Base64`, `Fn::If`, `Fn::Equals`, `Fn::And`, `Fn::Or`, `Fn::Not`,
-`Fn::FindInMap`, `Fn::GetAZs` and `Fn::Cidr` resolve, as do every pseudo-parameter:
-`AWS::Region`, `AWS::AccountId`, `AWS::StackName`, `AWS::StackId`,
-`AWS::Partition`, `AWS::URLSuffix`, `AWS::NotificationARNs` and `AWS::NoValue`.
-`Fn::ImportValue` is the one intrinsic that does **not** resolve — it falls back to
-its JSON encoding, so a template using it deploys with a literal where a value
-should be rather than failing. Tracked in
-[#522](https://github.com/scttfrdmn/substrate/issues/522): resolving it needs an
-export registry across stacks, not another resolver.
+**Every intrinsic function resolves.** `Ref`, `Fn::GetAtt`, `Fn::Sub`, `Fn::Join`,
+`Fn::Select`, `Fn::Split`, `Fn::Base64`, `Fn::If`, `Fn::Equals`, `Fn::And`,
+`Fn::Or`, `Fn::Not`, `Fn::FindInMap`, `Fn::GetAZs`, `Fn::Cidr` and
+`Fn::ImportValue`, as do every pseudo-parameter: `AWS::Region`, `AWS::AccountId`,
+`AWS::StackName`, `AWS::StackId`, `AWS::Partition`, `AWS::URLSuffix`,
+`AWS::NotificationARNs` and `AWS::NoValue`.
 
 `AWS::Partition` and `AWS::URLSuffix` follow the region — `aws-cn` and
 `amazonaws.com.cn` for a `cn-` region, `aws-us-gov` for a `us-gov-` one, `aws` and
@@ -333,6 +331,51 @@ condition is evaluated once, before any resource deploys, and keeps that value f
 the whole deployment — as in real CloudFormation, where conditions are evaluated when
 the stack is created or updated and cannot reference a resource or its attributes.
 
+#### Cross-stack exports and `Fn::ImportValue`
+
+An output that declares `Export: {Name: …}` publishes its value for another stack
+to import; an output without one is readable through `DescribeStacks` and nowhere
+else. `Fn::ImportValue` resolves against those exports, so the two-stack idiom —
+a network stack exporting a subnet ID, an app stack importing it — deploys and reads
+back as it does in AWS. The export name may itself be an intrinsic, which is what
+makes the conventional `Export: {Name: !Sub '${AWS::StackName}-SubnetID'}` work; it
+resolves before the first resource deploys, which the API permits because an export
+name may not depend on a resource.
+
+Exports are scoped **per account and Region**, matching the documented restriction
+that cross-stack references are limited to the same account and Region. A caller in
+another account or another Region does not see them in `ListExports` and cannot
+import them — a template that would fail in AWS fails here rather than resolving
+against an export it is not entitled to.
+
+Four rules are enforced, and they are the reason exports are modelled rather than
+faked:
+
+- **An import of an unpublished name fails the resource**, with the export name in
+  the `ResourceStatusReason`. It does not resolve to the empty string or to the
+  intrinsic's JSON — either would launch a resource named with nonsense and report
+  success.
+- **Export names are unique per account and Region.** A second stack claiming a name
+  another stack already exports is a `ValidationError` at 400 naming the holder.
+- **A stack whose export is imported cannot be deleted.** `DeleteStack` is a
+  `ValidationError` at 400 naming the export and every importing stack; the stack is
+  untouched. Delete the importers first, as AWS requires.
+- **An imported export's value cannot be changed** — nor dropped, which is the same
+  thing from the importer's side. An `UpdateStack` that would change or remove it is
+  refused on the same terms. Re-deploying the *same* value is not a change, so an
+  idempotent redeploy is unaffected.
+
+What counts as an import is decided **when the resolver walks the template**, not
+from the template's text. An `Fn::ImportValue` in the branch of an `Fn::If` that was
+not taken never happened, and neither does one that failed to resolve, so neither
+pins an exporting stack. `DescribeStacks` reports each output's `ExportName` beside
+it, and `ListImports` answers the "who is holding this" question a refused delete
+raises.
+
+The two refusals above use `ValidationError` at 400. The `DeleteStack` reference
+documents only `TokenAlreadyExists`, so that code is substrate's own choice for this
+case — the same code the service uses for every other unsatisfiable request on it.
+
 #### YAML short forms
 
 The YAML tag shorthands are expanded to their long forms before the template is
@@ -348,8 +391,10 @@ takes a two-element list, and the split is on the **first** period only, so
 `!GetAtt Res.Outputs.Nested` is `["Res", "Outputs.Nested"]` — an attribute name
 may itself contain periods.
 
-Expansion is not resolution. `!ImportValue` expands to a long form that is still
-unresolved (#522), and hits the same fallback the long form already does.
+Expansion is not resolution, but nothing is now expanded that does not also
+resolve: every tag in the list above reaches a resolver, `!Transform` excepted —
+it expands to `Fn::Transform`, which substrate carries but does not apply, since a
+macro is code substrate does not run.
 
 A tag substrate does not recognize is **not** dropped: the node's value is kept
 and a `WARN` naming the tag is logged, since a macro or transform may introduce a

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -64,6 +64,25 @@ type cfnOutput struct {
 
 	// Description is a human-readable description of the output.
 	Description string `json:"Description" yaml:"Description"`
+
+	// Export names the output for cross-stack import, or is nil when the output
+	// is local to its stack. Only an exported output is importable: an output
+	// without an Export is readable through DescribeStacks and nowhere else.
+	Export *cfnExport `json:"Export,omitempty" yaml:"Export,omitempty"`
+}
+
+// cfnExport is an output's Export block, which names the value for import by
+// another stack's Fn::ImportValue.
+//
+// Name is an expression rather than a string because the conventional form is
+// `Export: {Name: !Sub '${AWS::StackName}-SubnetID'}` — the export name is
+// namespaced by the exporting stack so two deployments of the same template do
+// not collide. It resolves before any resource deploys, which the API permits:
+// "the value of the Name property of an Export can't use Ref or GetAtt functions
+// that depend on a resource", so an export name is knowable from the template and
+// its parameters alone.
+type cfnExport struct {
+	Name interface{} `json:"Name" yaml:"Name"`
 }
 
 // cfnResource is a single CloudFormation resource declaration.
@@ -91,6 +110,31 @@ type CFNStackState struct {
 	// Outputs holds resolved output values.
 	Outputs map[string]string `json:"Outputs"`
 
+	// ExportNames maps an output key to the export name the template declared for
+	// it, for the outputs that declare one. An output without an Export
+	// contributes nothing: it is readable through DescribeStacks and importable
+	// nowhere.
+	//
+	// Keyed by output key rather than by export name so it is one map serving two
+	// readers without either deriving the other's answer: DescribeStacks reports
+	// the ExportName beside its output, and the export registry joins these keys
+	// against Outputs to get name → value.
+	ExportNames map[string]string `json:"ExportNames,omitempty"`
+
+	// Imports lists the export names this stack resolved, sorted. This is the
+	// record that makes the exporting stack undeletable, and it is written from
+	// what the resolver actually walked rather than from the template text — an
+	// Fn::ImportValue in a false Fn::If branch or in a skipped resource is not an
+	// import.
+	Imports []string `json:"Imports,omitempty"`
+
+	// AccountID and Region scope the two above. Exports and imports are matched
+	// within one account and Region — "for each AWS account, Export names must be
+	// unique within a Region" — so a stack that exports MyApp-SubnetID in
+	// us-east-1 must not satisfy an import of the same name in eu-west-1.
+	AccountID string `json:"AccountID,omitempty"`
+	Region    string `json:"Region,omitempty"`
+
 	// Status is the stack status (e.g., "CREATE_COMPLETE").
 	Status string `json:"Status"`
 
@@ -99,6 +143,25 @@ type CFNStackState struct {
 
 	// UpdatedAt is the time the stack was last updated.
 	UpdatedAt time.Time `json:"UpdatedAt"`
+}
+
+// exports returns the stack's export name → resolved value map, joining
+// ExportNames against Outputs.
+//
+// An export name whose output has since disappeared from Outputs is dropped
+// rather than exported as the empty string: an import that resolved to "" is the
+// silent-literal failure the export model exists to prevent.
+func (s CFNStackState) exports() map[string]string {
+	if len(s.ExportNames) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(s.ExportNames))
+	for outKey, name := range s.ExportNames {
+		if value, ok := s.Outputs[outKey]; ok {
+			out[name] = value
+		}
+	}
+	return out
 }
 
 // cfnContext holds per-deployment resolution context for intrinsic functions.
@@ -130,6 +193,22 @@ type cfnContext struct {
 	// resolves against. Nothing else reads it: a mapping cannot be referenced
 	// any other way.
 	mappings cfnMappings
+
+	// exports holds the export names visible to this deployment — every value
+	// exported by a stack in the same account and Region — which is what
+	// Fn::ImportValue resolves against. Loaded once before the first resource
+	// deploys, because "cross-stack references are limited to the same account
+	// and Region" and nothing a deployment does can add to the set: a stack
+	// cannot import a value it exports itself in the same operation.
+	exports map[string]string
+
+	// imports records the export names this deployment resolved, which is what
+	// makes the exporting stack undeletable — "all the imports must be removed
+	// before you can delete the exporting stack". Recorded at resolution time
+	// rather than derived from the template afterwards, because an Fn::ImportValue
+	// inside a false Fn::If branch or a skipped resource is not an import, and
+	// only the resolver knows which of the two it walked.
+	imports map[string]bool
 
 	// failures records the resolution errors encountered while deploying the
 	// current resource — an Fn::FindInMap naming a key no mapping holds, say.
@@ -200,6 +279,21 @@ var (
 	// ErrCFNStateRequired is returned when an operation needs a state manager and
 	// the deployer was built without one.
 	ErrCFNStateRequired = errors.New("state manager required")
+
+	// ErrCFNExportInUse is returned when a stack cannot be deleted because
+	// another stack imports one of its exported output values.
+	//
+	// The caller's request is what is invalid — "all the imports must be removed
+	// before you can delete the exporting stack" — so this is a 400, unlike the
+	// deploy failures above.
+	ErrCFNExportInUse = errors.New("export in use")
+
+	// ErrCFNExportNameConflict is returned when a stack's Export name is already
+	// exported by a different stack in the same account and Region.
+	//
+	// The API's rule: for each AWS account, Export names must be unique within a
+	// Region.
+	ErrCFNExportNameConflict = errors.New("export name already exists")
 )
 
 // cfnClassifiedError carries a [StackDeployer] failure's classification
@@ -612,6 +706,12 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 	cctx := buildCFNContext(tmpl, params, d.identity.region, d.identity.accountID, stackName)
 	evaluateConditions(tmpl, cctx)
 
+	// Load the exports Fn::ImportValue may resolve against, before the first
+	// resource deploys. The stack being redeployed is excluded: its own exports
+	// are not importable by itself, and leaving them in would let a template
+	// import a name it is in the middle of redefining.
+	cctx.exports = d.loadExports(ctx, stackName)
+
 	// Sort logical IDs by type priority, then alphabetically for stability.
 	type entry struct {
 		logicalID string
@@ -654,10 +754,29 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 		resources = append(resources, dr)
 	}
 
-	// Resolve outputs.
+	// Resolve outputs, and with them the export names this stack publishes.
 	outputs := make(map[string]string)
-	for outKey, outVal := range tmpl.Outputs {
+	exportNames := make(map[string]string)
+	outKeys := make([]string, 0, len(tmpl.Outputs))
+	for outKey := range tmpl.Outputs {
+		outKeys = append(outKeys, outKey)
+	}
+	// Sorted so that a template declaring two outputs with the same export name
+	// reports the same one as the conflict every time.
+	sort.Strings(outKeys)
+	for _, outKey := range outKeys {
+		outVal := tmpl.Outputs[outKey]
 		outputs[outKey] = resolveValue(outVal.Value, cctx)
+		if outVal.Export == nil {
+			continue
+		}
+		if name := resolveValue(outVal.Export.Name, cctx); name != "" {
+			exportNames[outKey] = name
+		}
+	}
+	pending := CFNStackState{Outputs: outputs, ExportNames: exportNames}
+	if err := d.checkExports(ctx, stackName, pending.exports()); err != nil {
+		return nil, err
 	}
 
 	duration := d.tc.Now().Sub(start)
@@ -679,6 +798,10 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 			Parameters:   cctx.params,
 			Resources:    resources,
 			Outputs:      outputs,
+			ExportNames:  exportNames,
+			Imports:      cctx.importedNames(),
+			AccountID:    d.identity.accountID,
+			Region:       d.identity.region,
 			Status:       "CREATE_COMPLETE",
 			CreatedAt:    start,
 			UpdatedAt:    d.tc.Now(),
@@ -711,9 +834,19 @@ func (d *StackDeployer) UpdateStack(ctx context.Context, cfn, stackName string, 
 }
 
 // DeleteStack removes a deployed stack from state.
+//
+// A stack whose exported output another stack imports is refused with
+// [ErrCFNExportInUse]: "after another stack imports an output value, you can't
+// delete the stack that is exporting the output value … all the imports must be
+// removed before you can delete the exporting stack". That refusal is the whole
+// reason exports are modeled rather than faked — an import that resolves against
+// nothing enforceable is a lookup, not a reference.
 func (d *StackDeployer) DeleteStack(ctx context.Context, stackName string) error {
 	if d.state == nil {
 		return nil
+	}
+	if err := d.checkExportsNotImported(ctx, stackName); err != nil {
+		return err
 	}
 	if err := d.state.Delete(ctx, cfnNamespace, "stack:"+stackName); err != nil {
 		return fmt.Errorf("delete stack %s: %w", stackName, err)
@@ -798,6 +931,236 @@ func (d *StackDeployer) saveStackNames(ctx context.Context, names []string) erro
 		return fmt.Errorf("cfn saveStackNames marshal: %w", err)
 	}
 	return d.state.Put(ctx, cfnNamespace, "stack_names", data)
+}
+
+// CFNExport is one exported output value as [StackDeployer.Exports] reports it.
+type CFNExport struct {
+	// Name is the export name, unique per account and Region.
+	Name string `json:"Name"`
+
+	// Value is the resolved output value.
+	Value string `json:"Value"`
+
+	// ExportingStackName names the stack that declared the export. The API
+	// reports an ExportingStackId; the stack ARN is built at the wire boundary,
+	// which is the only place that knows the requesting caller's partition.
+	ExportingStackName string `json:"ExportingStackName"`
+}
+
+// Exports returns every exported output value visible in the deployer's account
+// and Region, sorted by export name.
+//
+// Visibility is scoped rather than global because "for each AWS account, Export
+// names must be unique within a Region" and "cross-stack references are limited to
+// the same account and Region" — an emulator that ignored the scope would resolve
+// an import a real deployment would reject, which is worse than not resolving it.
+func (d *StackDeployer) Exports(ctx context.Context) ([]CFNExport, error) {
+	stacks, err := d.ListStacks(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CFNExport, 0, len(stacks))
+	for _, s := range stacks {
+		if !d.sameScope(s) {
+			continue
+		}
+		for name, value := range s.exports() {
+			out = append(out, CFNExport{Name: name, Value: value, ExportingStackName: s.StackName})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// Imports returns the names of the stacks importing an export, sorted.
+//
+// An unknown export name yields an empty list rather than an error: ListImports
+// documents no service-specific error, and "no stack imports this" and "no such
+// export" are the same answer to the question the API asks.
+func (d *StackDeployer) Imports(ctx context.Context, exportName string) ([]string, error) {
+	stacks, err := d.ListStacks(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, s := range stacks {
+		if !d.sameScope(s) {
+			continue
+		}
+		if containsStr(s.Imports, exportName) {
+			out = append(out, s.StackName)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// sameScope reports whether a persisted stack shares the deployer's account and
+// Region, and so participates in its export namespace.
+//
+// An empty AccountID or Region is treated as in scope. Those fields arrived with
+// exports, so a stack persisted by an earlier substrate has neither, and excluding
+// it would make a restored snapshot's stacks vanish from ListExports rather than
+// simply exporting nothing — a stack with no Exports map contributes nothing here
+// either way.
+func (d *StackDeployer) sameScope(s CFNStackState) bool {
+	if s.AccountID != "" && s.AccountID != d.identity.accountID {
+		return false
+	}
+	return s.Region == "" || s.Region == d.identity.region
+}
+
+// loadExports builds the export-name → value map a deployment resolves
+// Fn::ImportValue against, excluding the stack being deployed.
+//
+// A failure to read state yields an empty map rather than an error: an import that
+// finds no export records a resolution failure on the resource, which is the same
+// observable and reaches the caller as CREATE_FAILED with a reason naming the
+// export. Aborting the whole deployment would be a worse answer to a state read
+// that a redeploy may well satisfy.
+func (d *StackDeployer) loadExports(ctx context.Context, deployingStack string) map[string]string {
+	if d.state == nil {
+		return nil
+	}
+	stacks, err := d.ListStacks(ctx)
+	if err != nil {
+		d.logger.Warn("cfn: could not read exports; Fn::ImportValue will not resolve", "err", err)
+		return nil
+	}
+	out := make(map[string]string)
+	for _, s := range stacks {
+		if s.StackName == deployingStack || !d.sameScope(s) {
+			continue
+		}
+		for name, value := range s.exports() {
+			out[name] = value
+		}
+	}
+	return out
+}
+
+// checkExports refuses a deployment whose exports would break the two rules the
+// export namespace enforces: a name may be exported by only one stack, and an
+// exported value another stack imports may not change.
+//
+// Both run after the resources deploy, because an export name or value may be
+// built from a resource attribute and so is not knowable earlier. The deployment
+// is refused rather than the resources rolled back, which substrate does not model
+// (#520) — the resources exist and the caller is told the stack record was not
+// written, which is the honest observable rather than a fabricated rollback.
+func (d *StackDeployer) checkExports(ctx context.Context, stackName string, exports map[string]string) error {
+	if d.state == nil {
+		return nil
+	}
+	existing, err := d.Exports(ctx)
+	if err != nil {
+		return err
+	}
+
+	// "For each AWS account, Export names must be unique within a Region."
+	owner := make(map[string]string, len(existing))
+	for _, e := range existing {
+		if e.ExportingStackName != stackName {
+			owner[e.Name] = e.ExportingStackName
+		}
+	}
+	for _, name := range sortedStringKeys(exports) {
+		if other, taken := owner[name]; taken {
+			return cfnErrf(ErrCFNExportNameConflict,
+				"cfn Deploy: export name %q is already exported by stack %q", name, other)
+		}
+	}
+
+	// "You can't … modify the exported output value" while it is imported. An
+	// export this stack previously published and now drops is the same
+	// modification from the importer's side — the value it resolved stops
+	// existing — so a removal is refused on the same terms as a change.
+	for _, e := range existing {
+		if e.ExportingStackName != stackName {
+			continue
+		}
+		newValue, still := exports[e.Name]
+		if still && newValue == e.Value {
+			continue
+		}
+		importers, importErr := d.Imports(ctx, e.Name)
+		if importErr != nil {
+			return importErr
+		}
+		if importers = removeStr(importers, stackName); len(importers) == 0 {
+			continue
+		}
+		what := "changed"
+		if !still {
+			what = "removed"
+		}
+		return cfnErrf(ErrCFNExportInUse,
+			"cfn Deploy: export %q cannot be %s while it is imported by %s; "+
+				"all imports must be removed first",
+			e.Name, what, strings.Join(importers, ", "))
+	}
+	return nil
+}
+
+// sortedStringKeys returns a string-keyed map's keys in sorted order, so a loop
+// over them reports the same element first every time.
+func sortedStringKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// checkExportsNotImported refuses to delete a stack whose export another stack
+// imports, naming the export and the importing stacks.
+//
+// The message names them because that is the only way a caller can act on the
+// refusal: the API's own remedy is "first find out which stacks are importing
+// them", and a refusal that withheld the answer would send them to ListImports for
+// something substrate already knows.
+func (d *StackDeployer) checkExportsNotImported(ctx context.Context, stackName string) error {
+	data, err := d.state.Get(ctx, cfnNamespace, "stack:"+stackName)
+	if err != nil {
+		return fmt.Errorf("cfn DeleteStack: read stack %q: %w", stackName, err)
+	}
+	if data == nil {
+		// An absent stack is not an error — DeleteStack documents no not-found
+		// error — and a stack that is not there exports nothing.
+		return nil
+	}
+	var stack CFNStackState
+	if err := json.Unmarshal(data, &stack); err != nil {
+		// A record substrate wrote and cannot read back is corrupt state, not a
+		// caller error. Reporting it beats deleting a stack whose exports could
+		// not be checked, which is how an importer loses its reference silently.
+		return fmt.Errorf("cfn DeleteStack: unmarshal stack %q: %w", stackName, err)
+	}
+	for _, name := range sortedStringKeys(stack.exports()) {
+		importers, err := d.Imports(ctx, name)
+		if err != nil {
+			return err
+		}
+		importers = removeStr(importers, stackName)
+		if len(importers) > 0 {
+			return cfnErrf(ErrCFNExportInUse,
+				"cfn DeleteStack: export %q is imported by %s; all imports must be removed first",
+				name, strings.Join(importers, ", "))
+		}
+	}
+	return nil
+}
+
+// removeStr returns list without any element equal to drop.
+func removeStr(list []string, drop string) []string {
+	out := make([]string, 0, len(list))
+	for _, s := range list {
+		if s != drop {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // CreateChangeSet compares a proposed template against the current stack state
@@ -3213,6 +3576,7 @@ func buildCFNContext(tmpl *cfnTemplate, callerParams map[string]string, region, 
 		stackName:  stackName,
 		evaluating: make(map[string]bool),
 		mappings:   tmpl.Mappings,
+		imports:    make(map[string]bool),
 	}
 }
 
@@ -3385,6 +3749,8 @@ func resolveValue(v interface{}, cctx *cfnContext) string {
 				return resolveFnIf(args, cctx)
 			case "Fn::FindInMap":
 				return resolveFnFindInMap(args, cctx)
+			case "Fn::ImportValue":
+				return resolveFnImportValue(args, cctx)
 			case "Fn::GetAZs", "Fn::Cidr":
 				// Both return an array, and this context has nowhere to put
 				// one, so the elements are rejoined the way Fn::Split's are —
@@ -3707,6 +4073,13 @@ var cfnIntrinsicNames = map[string]bool{
 	"Fn::FindInMap": true,
 	"Fn::GetAZs":    true,
 	"Fn::Cidr":      true,
+
+	// Fn::ImportValue was deliberately withheld from this table until it
+	// resolved: resolveNested consults it to decide what is an intrinsic, and
+	// admitting an unresolvable one would have resolved every import to "" —
+	// worse than the JSON-literal fallback, which at least left the intrinsic
+	// visible in the request the plugin refused.
+	"Fn::ImportValue": true,
 }
 
 // isCFNIntrinsic reports whether a map is an intrinsic function invocation.
@@ -3998,6 +4371,58 @@ func resolveFnFindInMap(args interface{}, cctx *cfnContext) string {
 		return strings.Join(resolveValueList(leaf, cctx), ",")
 	}
 	return resolveValue(leaf, cctx)
+}
+
+// resolveFnImportValue resolves Fn::ImportValue against the exports another stack
+// in the same account and Region published, recording the import so the exporting
+// stack cannot then be deleted.
+//
+// The argument goes through resolveValue because the documented form is an
+// expression — `Fn::ImportValue: !Sub '${NetworkStack}-SubnetID'` — and the
+// functions the API permits inside it (Fn::Base64, Fn::FindInMap, Fn::If,
+// Fn::Join, Fn::Select, Fn::Sub, Ref) are all ones resolveValue already handles,
+// so no special case is needed. The documented restriction is that "the value of
+// these functions can't depend on a resource"; substrate does not enforce it,
+// because by the time an import resolves the resources it could name have already
+// deployed, so honoring such a reference is strictly more permissive than
+// CloudFormation rather than differently behaved.
+//
+// A name that no export supplies is a resolution failure, not the empty string:
+// the whole of #522's silent-literal defect is a value that looks resolved and is
+// not, and an import naming an export that does not exist is a template a real
+// deployment would reject.
+func resolveFnImportValue(args interface{}, cctx *cfnContext) string {
+	name := resolveValue(args, cctx)
+	if name == "" {
+		cctx.fail("Fn::ImportValue requires an export name")
+		return ""
+	}
+	value, found := cctx.exports[name]
+	if !found {
+		cctx.fail("Fn::ImportValue: no exported output named %q in this account and region", name)
+		return ""
+	}
+	// Recorded only on a successful resolution. A failed import leaves the
+	// exporting stack — there is none — deletable, and recording the name would
+	// make a typo'd import block a delete that has nothing to do with it.
+	if cctx.imports == nil {
+		cctx.imports = make(map[string]bool)
+	}
+	cctx.imports[name] = true
+	return value
+}
+
+// importedNames returns the export names this deployment resolved, sorted.
+func (c *cfnContext) importedNames() []string {
+	if len(c.imports) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(c.imports))
+	for name := range c.imports {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // resolveFnFindInMapValue looks a value up in the template's Mappings section,

--- a/emulator/betty_cfn_exports_test.go
+++ b/emulator/betty_cfn_exports_test.go
@@ -1,0 +1,557 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The two stacks every cross-stack test below deploys: a network stack exporting
+// a bucket name under a stack-namespaced export name, and an app stack importing
+// it. The export name is built with Fn::Sub over AWS::StackName because that is
+// the documented idiom — an export name has to be unique per account and Region,
+// so a template that hard-codes one cannot be deployed twice.
+const (
+	cfnExportingTemplate = `{"Resources":{` +
+		`"Data":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-export-bucket"}}},` +
+		`"Outputs":{"BucketName":{"Value":{"Ref":"Data"},` +
+		`"Export":{"Name":{"Fn::Sub":"${AWS::StackName}-BucketName"}}}}}`
+
+	cfnImportingTemplate = `{"Resources":{"Q":{"Type":"AWS::SQS::Queue",` +
+		`"Properties":{"QueueName":{"Fn::ImportValue":"net-BucketName"}}}}}`
+)
+
+// TestCFN_ImportValueResolvesAnotherStacksExport is #522's first gate: an
+// Fn::ImportValue of another stack's export resolves.
+//
+// Before this it fell through resolveValue's JSON-encoding fallback, so the queue
+// was named with the literal `{"Fn::ImportValue":"net-BucketName"}` and the stack
+// still reported CREATE_COMPLETE — the silent-success shape the issue is about.
+func TestCFN_ImportValueResolvesAnotherStacksExport(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnExportingTemplate, "net", nil)
+	require.NoError(t, err)
+
+	result, err := d.Deploy(ctx, cfnImportingTemplate, "app", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.Empty(t, result.Resources[0].Error,
+		"the import must resolve, not fail the resource")
+	assert.Equal(t, "cfn-export-bucket", result.Resources[0].PhysicalID,
+		"the queue is named with the imported value, not the intrinsic's JSON")
+}
+
+// TestCFN_ImportValueOfAnUnknownExportFailsTheResource pins the other half: an
+// import naming an export nothing published fails the resource with a reason,
+// rather than resolving to the empty string or to the intrinsic's JSON.
+//
+// Both of those alternatives are values that look resolved and are not, which is
+// exactly what #522 filed. A CREATE_FAILED with the export name in the reason is
+// the observable a caller can act on.
+func TestCFN_ImportValueOfAnUnknownExportFailsTheResource(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+
+	result, err := d.Deploy(context.Background(), cfnImportingTemplate, "app", nil)
+	require.NoError(t, err, "the resource fails; the stack operation does not")
+	require.Len(t, result.Resources, 1)
+	assert.Contains(t, result.Resources[0].Error, `no exported output named "net-BucketName"`)
+}
+
+// TestCFN_ExportsAreScopedToAccountAndRegion pins the restriction that makes an
+// import a reference rather than a global lookup: "when using Export and
+// Fn::ImportValue, cross-stack references are limited to the same account and
+// Region".
+//
+// An emulator that ignored the scope would resolve an import a real deployment
+// rejects, which is worse than not resolving it: the template passes under test
+// and fails in AWS.
+func TestCFN_ExportsAreScopedToAccountAndRegion(t *testing.T) {
+	_, state := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	east := newTestDeployerWithIdentity(t, state, "123456789012", "us-east-1")
+	_, err := east.Deploy(ctx, cfnExportingTemplate, "net", nil)
+	require.NoError(t, err)
+
+	exports, err := east.Exports(ctx)
+	require.NoError(t, err)
+	require.Len(t, exports, 1)
+	assert.Equal(t, "net-BucketName", exports[0].Name)
+
+	tests := []struct {
+		name      string
+		accountID string
+		region    string
+	}{
+		{name: "another region in the same account", accountID: "123456789012", region: "eu-west-1"},
+		{name: "another account in the same region", accountID: "999988887777", region: "us-east-1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			other := newTestDeployerWithIdentity(t, state, tc.accountID, tc.region)
+
+			otherExports, err := other.Exports(ctx)
+			require.NoError(t, err)
+			assert.Empty(t, otherExports, "the export is not visible outside its scope")
+
+			result, err := other.Deploy(ctx, cfnImportingTemplate, "app-"+tc.region+tc.accountID, nil)
+			require.NoError(t, err)
+			require.Len(t, result.Resources, 1)
+			assert.Contains(t, result.Resources[0].Error, "no exported output named",
+				"an out-of-scope export must not satisfy the import")
+		})
+	}
+}
+
+// TestCFN_DeletingAnExportingStackIsRefused is #522's second gate, and the reason
+// exports are modeled rather than faked: "after another stack imports an output
+// value, you can't delete the stack that is exporting the output value … all the
+// imports must be removed before you can delete the exporting stack".
+//
+// A registry with no enforcement behind it is a lookup table, not a reference. The
+// refusal is what a consumer's teardown ordering is tested against.
+func TestCFN_DeletingAnExportingStackIsRefused(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnExportingTemplate, "net", nil)
+	require.NoError(t, err)
+	_, err = d.Deploy(ctx, cfnImportingTemplate, "app", nil)
+	require.NoError(t, err)
+
+	err = d.DeleteStack(ctx, "net")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, emulator.ErrCFNExportInUse)
+	assert.Contains(t, err.Error(), `export "net-BucketName" is imported by app`,
+		"the refusal must name the importer: the caller's only remedy is to remove it")
+
+	// And the stack is still there — a refused delete must not half-delete.
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	names := make([]string, 0, len(stacks))
+	for _, s := range stacks {
+		names = append(names, s.StackName)
+	}
+	assert.Contains(t, names, "net")
+
+	// Removing the importer releases it, in that order: the importing stack
+	// deletes first, and only then does the exporter.
+	require.NoError(t, d.DeleteStack(ctx, "app"))
+	require.NoError(t, d.DeleteStack(ctx, "net"),
+		"with no importers left the exporting stack deletes")
+}
+
+// TestCFN_DeletingAStackThatExportsNothingImportedSucceeds is the negative that
+// makes the refusal meaningful: an export nobody imports does not pin its stack.
+//
+// Without this a refusal keyed merely on "declares an Export" would pass the test
+// above and make every exporting stack permanently undeletable.
+func TestCFN_DeletingAStackThatExportsNothingImportedSucceeds(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnExportingTemplate, "net", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, d.DeleteStack(ctx, "net"))
+
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, stacks)
+}
+
+// TestCFN_ExportNamesAreUniquePerAccountAndRegion pins "for each AWS account,
+// Export names must be unique within a Region".
+//
+// The same template deployed under two stack names is the common case and must
+// work, because the documented idiom namespaces the export by AWS::StackName. The
+// conflict is a second stack claiming a name that is already taken.
+func TestCFN_ExportNamesAreUniquePerAccountAndRegion(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	const fixedName = `{"Resources":{` +
+		`"Data":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-fixed-export"}}},` +
+		`"Outputs":{"BucketName":{"Value":{"Ref":"Data"},"Export":{"Name":"Shared-Value"}}}}`
+
+	_, err := d.Deploy(ctx, fixedName, "first", nil)
+	require.NoError(t, err)
+
+	_, err = d.Deploy(ctx, fixedName, "second", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, emulator.ErrCFNExportNameConflict)
+	assert.Contains(t, err.Error(), `export name "Shared-Value" is already exported by stack "first"`)
+
+	// Redeploying the *owning* stack is not a conflict with itself.
+	_, err = d.Deploy(ctx, fixedName, "first", nil)
+	require.NoError(t, err, "a stack may keep exporting the name it already owns")
+
+	// And the stack-namespaced idiom deploys twice without collision.
+	_, err = d.Deploy(ctx, cfnExportingTemplate, "net-a", nil)
+	require.NoError(t, err)
+	_, err = d.Deploy(ctx, cfnExportingTemplate, "net-b", nil)
+	require.NoError(t, err,
+		"Fn::Sub over AWS::StackName is the documented way to keep export names unique")
+}
+
+// TestCFN_ChangingAnImportedExportIsRefused pins the other half of the same
+// sentence as the delete refusal: "you can't delete the stack that is exporting the
+// output value **or modify the exported output value**".
+//
+// Substrate had no way to express this before exports existed, and it is the half a
+// consumer hits by accident: an update that changes an exported value silently
+// leaves every importing stack holding a value the exporter no longer publishes.
+func TestCFN_ChangingAnImportedExportIsRefused(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnExportingTemplate, "net", nil)
+	require.NoError(t, err)
+	_, err = d.Deploy(ctx, cfnImportingTemplate, "app", nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		template string
+		wantWhat string
+	}{
+		{
+			name: "the exported value changes",
+			template: `{"Resources":{` +
+				`"Data":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-other-bucket"}}},` +
+				`"Outputs":{"BucketName":{"Value":{"Ref":"Data"},` +
+				`"Export":{"Name":{"Fn::Sub":"${AWS::StackName}-BucketName"}}}}}`,
+			wantWhat: "changed",
+		},
+		{
+			name: "the export is dropped altogether",
+			template: `{"Resources":{` +
+				`"Data":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-export-bucket"}}},` +
+				`"Outputs":{"BucketName":{"Value":{"Ref":"Data"}}}}`,
+			wantWhat: "removed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := d.UpdateStack(ctx, tc.template, "net", nil)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, emulator.ErrCFNExportInUse)
+			assert.Contains(t, err.Error(),
+				`export "net-BucketName" cannot be `+tc.wantWhat+" while it is imported by app")
+		})
+	}
+
+	// Redeploying the same value is not a change, so it is allowed — otherwise an
+	// idempotent redeploy of an exporting stack would be impossible.
+	_, err = d.UpdateStack(ctx, cfnExportingTemplate, "net", nil)
+	require.NoError(t, err)
+}
+
+// TestCFN_ImportIsRecordedOnlyWhenItResolves pins what counts as an import, which
+// is what the delete refusal is keyed on.
+//
+// An Fn::ImportValue inside a false Fn::If branch is never evaluated, so the stack
+// does not import it and must not pin the exporter; an import that failed to
+// resolve has no exporter to pin. Deriving imports from the template text — the
+// obvious alternative — gets both wrong.
+func TestCFN_ImportIsRecordedOnlyWhenItResolves(t *testing.T) {
+	exports := map[string]string{"net-BucketName": "cfn-export-bucket"}
+
+	tests := []struct {
+		name        string
+		value       interface{}
+		wantValue   string
+		wantImports []string
+		wantFailure string
+	}{
+		{
+			name:        "a resolved import is recorded",
+			value:       map[string]interface{}{"Fn::ImportValue": "net-BucketName"},
+			wantValue:   "cfn-export-bucket",
+			wantImports: []string{"net-BucketName"},
+		},
+		{
+			name:        "an unresolved import is not",
+			value:       map[string]interface{}{"Fn::ImportValue": "no-such-export"},
+			wantFailure: `no exported output named "no-such-export"`,
+		},
+		{
+			name: "an import in the branch not taken is not",
+			value: map[string]interface{}{"Fn::If": []interface{}{
+				"Never",
+				map[string]interface{}{"Fn::ImportValue": "net-BucketName"},
+				"literal",
+			}},
+			wantValue: "literal",
+		},
+		{
+			name: "an import name built by Fn::Sub resolves",
+			value: map[string]interface{}{"Fn::ImportValue": map[string]interface{}{
+				"Fn::Sub": "${NetStack}-BucketName",
+			}},
+			wantValue:   "cfn-export-bucket",
+			wantImports: []string{"net-BucketName"},
+		},
+		{
+			name:        "an empty name is a failure, not an import of \"\"",
+			value:       map[string]interface{}{"Fn::ImportValue": ""},
+			wantFailure: "Fn::ImportValue requires an export name",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			value, imports, failures := emulator.CFNResolveImportForTest(
+				tc.value, exports, map[string]string{"NetStack": "net"})
+			assert.Equal(t, tc.wantValue, value)
+			assert.Equal(t, tc.wantImports, imports)
+			if tc.wantFailure == "" {
+				assert.Empty(t, failures)
+				return
+			}
+			require.Len(t, failures, 1)
+			assert.Contains(t, failures[0], tc.wantFailure)
+		})
+	}
+}
+
+// TestCFN_ImportValueResolvesInsideAStructuredProperty pins the reason
+// Fn::ImportValue was withheld from cfnIntrinsicNames until it resolved.
+//
+// resolveNested consults that table to decide what is an intrinsic, so admitting an
+// unresolvable Fn::ImportValue would have resolved every nested import to "" —
+// strictly worse than the JSON-literal fallback, which at least left the intrinsic
+// visible in the request the plugin refused. Now that it resolves, admission is
+// correct and this asserts the depth.
+func TestCFN_ImportValueResolvesInsideAStructuredProperty(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnExportingTemplate, "net", nil)
+	require.NoError(t, err)
+
+	// KeySchema is one of the properties forwarded whole to the plugin, so the
+	// import here is resolved by the nested walk rather than by a scalar
+	// resolution at the top level of a property.
+	const tmpl = `{"Resources":{"T":{"Type":"AWS::DynamoDB::Table","Properties":{` +
+		`"TableName":"cfn-import-nested",` +
+		`"AttributeDefinitions":[{"AttributeName":{"Fn::ImportValue":"net-BucketName"},` +
+		`"AttributeType":"S"}],` +
+		`"KeySchema":[{"AttributeName":{"Fn::ImportValue":"net-BucketName"},` +
+		`"KeyType":"HASH"}]}}}}`
+
+	result, err := d.Deploy(ctx, tmpl, "nested", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.Empty(t, result.Resources[0].Error,
+		"a nested import must resolve; an unresolved one reaches DynamoDB as JSON and is refused")
+
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	var nested *emulator.CFNStackState
+	for i := range stacks {
+		if stacks[i].StackName == "nested" {
+			nested = &stacks[i]
+		}
+	}
+	require.NotNil(t, nested)
+	assert.Equal(t, []string{"net-BucketName"}, nested.Imports,
+		"an import found by the nested walk pins the exporter just as a scalar one does")
+}
+
+// TestCFN_StackExportsJoinNamesAgainstOutputs pins the persisted shape, because it
+// is what a restored snapshot is read back through.
+//
+// ExportNames is keyed by output key, not by export name, so one map serves both
+// DescribeStacks (which reports ExportName beside its output) and the registry
+// (which needs name → value). An export name whose output is gone is dropped rather
+// than exported as "", since an import resolving to "" is the silent-literal
+// failure the whole model exists to prevent.
+func TestCFN_StackExportsJoinNamesAgainstOutputs(t *testing.T) {
+	got := emulator.CFNStackExportsForTest(emulator.CFNStackState{
+		Outputs: map[string]string{
+			"BucketName": "cfn-export-bucket",
+			"Local":      "not-exported",
+		},
+		ExportNames: map[string]string{
+			"BucketName": "net-BucketName",
+			"Vanished":   "net-Vanished",
+		},
+	})
+	assert.Equal(t, map[string]string{"net-BucketName": "cfn-export-bucket"}, got)
+}
+
+// TestCFN_AStackDoesNotImportItsOwnExport pins that the stack being deployed is
+// excluded from the registry its own imports resolve against.
+//
+// Without the exclusion a redeploy would resolve an import against the value the
+// same deployment is in the middle of replacing — a stack reading its own previous
+// output, which no CloudFormation deployment can do. It stays a failed import on
+// every deploy, first and subsequent alike, so the observable does not depend on
+// whether the stack has been deployed before.
+func TestCFN_AStackDoesNotImportItsOwnExport(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	// The stack exports Ouroboros-Name and imports it in the same template.
+	const tmpl = `{"Resources":{` +
+		`"Data":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-self-import"}},` +
+		`"Q":{"Type":"AWS::SQS::Queue","Properties":{` +
+		`"QueueName":{"Fn::ImportValue":"Ouroboros-Name"}}}},` +
+		`"Outputs":{"N":{"Value":{"Ref":"Data"},"Export":{"Name":"Ouroboros-Name"}}}}`
+
+	for _, pass := range []string{"first deploy", "redeploy"} {
+		result, err := d.Deploy(ctx, tmpl, "ouroboros", nil)
+		require.NoError(t, err, pass)
+
+		var queue *emulator.DeployedResource
+		for i := range result.Resources {
+			if result.Resources[i].LogicalID == "Q" {
+				queue = &result.Resources[i]
+			}
+		}
+		require.NotNil(t, queue, pass)
+		assert.Contains(t, queue.Error, `no exported output named "Ouroboros-Name"`,
+			"%s: a stack cannot import the name it is itself exporting", pass)
+	}
+
+	// The export is published for *other* stacks all the same.
+	exports, err := d.Exports(ctx)
+	require.NoError(t, err)
+	require.Len(t, exports, 1)
+	assert.Equal(t, "Ouroboros-Name", exports[0].Name)
+}
+
+// TestCFN_AStacksOwnImportDoesNotPinIt pins the invariant both export checks rest
+// on: a stack is never held open by its own recorded import.
+//
+// The resolver cannot currently produce such a record — a stack's own exports are
+// excluded from what its imports resolve against, per the test above — so this
+// asserts the guard directly against a persisted record rather than through a
+// deploy. It is worth a test because the guard is what makes the two refusals
+// statements about *other* stacks: without it a record like this one, from a
+// restored snapshot or a later substrate that permits self-import, would make the
+// stack permanently undeletable with no remedy the caller could apply.
+func TestCFN_AStacksOwnImportDoesNotPinIt(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	record, err := json.Marshal(emulator.CFNStackState{
+		StackName:   "selfish",
+		Outputs:     map[string]string{"N": "cfn-selfish"},
+		ExportNames: map[string]string{"N": "Selfish-Name"},
+		Imports:     []string{"Selfish-Name"},
+		AccountID:   "123456789012",
+		Region:      "us-east-1",
+		Status:      "CREATE_COMPLETE",
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "cfn", "stack:selfish", record))
+	require.NoError(t, state.Put(ctx, "cfn", "stack_names", []byte(`["selfish"]`)))
+
+	importers, err := d.Imports(ctx, "Selfish-Name")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"selfish"}, importers,
+		"the record says so, and Imports reports what is recorded")
+
+	assert.NoError(t, d.DeleteStack(ctx, "selfish"),
+		"the only importer is the stack itself, so nothing is holding it open")
+}
+
+// TestCFN_LegacySnapshotStacksStayInScope pins the back-compatibility decision in
+// sameScope: a stack persisted before exports existed has no AccountID or Region
+// and is treated as in scope.
+//
+// Excluding it would make a restored snapshot's stacks vanish from ListExports
+// rather than simply exporting nothing, and Snapshot/Restore round-trips these
+// records — so a v0.87 snapshot restored into this release must still list its
+// stacks.
+func TestCFN_LegacySnapshotStacksStayInScope(t *testing.T) {
+	d, state := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	// Written as a raw object so AccountID and Region are genuinely absent rather
+	// than empty, which is what an older substrate wrote.
+	require.NoError(t, state.Put(ctx, "cfn", "stack:legacy", []byte(
+		`{"StackName":"legacy","Outputs":{"N":"legacy-bucket"},`+
+			`"ExportNames":{"N":"Legacy-Name"},"Status":"CREATE_COMPLETE"}`)))
+	require.NoError(t, state.Put(ctx, "cfn", "stack_names", []byte(`["legacy"]`)))
+
+	exports, err := d.Exports(ctx)
+	require.NoError(t, err)
+	require.Len(t, exports, 1, "an unpartitioned stack is in every scope, not none")
+	assert.Equal(t, "Legacy-Name", exports[0].Name)
+	assert.Equal(t, "legacy-bucket", exports[0].Value)
+}
+
+// TestCFN_TheReportedExportConflictIsDeterministic pins the sort behind the
+// uniqueness check.
+//
+// A template declaring two export names that are both already taken has two valid
+// conflicts to report, and iterating the map directly would report whichever Go's
+// randomized order reached first. Nondeterminism is the one outcome an emulator
+// built on deterministic replay must never produce, so the answer is the
+// alphabetically first name on every run — asserted over repeated deploys, since a
+// single run agrees with a coin flip half the time.
+func TestCFN_TheReportedExportConflictIsDeterministic(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	for _, s := range []struct{ stack, export string }{
+		{"holder-a", "Aaa-Name"},
+		{"holder-z", "Zzz-Name"},
+	} {
+		_, err := d.Deploy(ctx, `{"Resources":{"Data":{"Type":"AWS::S3::Bucket",`+
+			`"Properties":{"BucketName":"cfn-`+s.stack+`"}}},`+
+			`"Outputs":{"N":{"Value":{"Ref":"Data"},"Export":{"Name":"`+s.export+`"}}}}`,
+			s.stack, nil)
+		require.NoError(t, err)
+	}
+
+	// Claims both taken names.
+	const claimant = `{"Resources":{"Data":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":"cfn-claimant"}}},` +
+		`"Outputs":{` +
+		`"A":{"Value":{"Ref":"Data"},"Export":{"Name":"Aaa-Name"}},` +
+		`"Z":{"Value":{"Ref":"Data"},"Export":{"Name":"Zzz-Name"}}}}`
+
+	for i := range 20 {
+		_, err := d.Deploy(ctx, claimant, "claimant", nil)
+		require.Error(t, err, "attempt %d", i)
+		assert.ErrorIs(t, err, emulator.ErrCFNExportNameConflict)
+		assert.Contains(t, err.Error(), `export name "Aaa-Name" is already exported by stack "holder-a"`,
+			"attempt %d: the same conflict must be reported every time", i)
+	}
+}
+
+// TestCFN_ImportsListsTheImportingStacks pins the read the API points a caller at
+// when a delete is refused: "to delete or change exported output values, you must
+// first find out which stacks are importing them".
+func TestCFN_ImportsListsTheImportingStacks(t *testing.T) {
+	d, _ := newTestDeployerWithState(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnExportingTemplate, "net", nil)
+	require.NoError(t, err)
+	for _, name := range []string{"app-b", "app-a"} {
+		_, err = d.Deploy(ctx, `{"Resources":{"Q":{"Type":"AWS::SQS::Queue","Properties":{`+
+			`"QueueName":{"Fn::Sub":["${n}-`+name+`",{"n":{"Fn::ImportValue":"net-BucketName"}}]}}}}}`,
+			name, nil)
+		require.NoError(t, err)
+	}
+
+	importers, err := d.Imports(ctx, "net-BucketName")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"app-a", "app-b"}, importers, "sorted, so the answer is stable")
+
+	unknown, err := d.Imports(ctx, "no-such-export")
+	require.NoError(t, err,
+		"ListImports documents no service-specific error: an unknown export is an empty list")
+	assert.Empty(t, unknown)
+}

--- a/emulator/betty_cfn_test.go
+++ b/emulator/betty_cfn_test.go
@@ -2163,9 +2163,26 @@ func TestBettyCFN_EC2NatGateway(t *testing.T) {
 // direct state manipulation in drift tests.
 func newTestDeployerWithState(t *testing.T) (*emulator.StackDeployer, *emulator.MemoryStateManager) {
 	t.Helper()
+	state := emulator.NewMemoryStateManager()
+	return newTestDeployerOverState(t, state), state
+}
+
+// newTestDeployerWithIdentity creates a deployer over an existing state manager,
+// deploying as the given account and region.
+//
+// Sharing the state manager is the point: cross-stack exports are scoped per
+// account and Region, and the only way to assert that scoping is to have two
+// deployers of different identity reading the same persisted stack records.
+func newTestDeployerWithIdentity(t *testing.T, state *emulator.MemoryStateManager, accountID, region string) *emulator.StackDeployer {
+	t.Helper()
+	return newTestDeployerOverState(t, state,
+		emulator.WithDeployerIdentity(accountID, region))
+}
+
+func newTestDeployerOverState(t *testing.T, state *emulator.MemoryStateManager, opts ...emulator.StackDeployerOption) *emulator.StackDeployer {
+	t.Helper()
 	cfg := emulator.DefaultConfig()
 	registry := emulator.NewPluginRegistry()
-	state := emulator.NewMemoryStateManager()
 	logger := emulator.NewDefaultLogger(slog.LevelError, false)
 	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
 	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
@@ -2208,7 +2225,7 @@ func newTestDeployerWithState(t *testing.T) (*emulator.StackDeployer, *emulator.
 	}))
 	registry.Register(sqsPlugin)
 
-	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs), state
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs, opts...)
 }
 
 func TestCFN_ChangeSet_CreateDescribeExecute(t *testing.T) {

--- a/emulator/cloudformation_exports_test.go
+++ b/emulator/cloudformation_exports_test.go
@@ -1,0 +1,313 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The exporting/importing pair as a wire caller sends it. Kept separate from the
+// in-process constants because the wire tests use the S3 and IAM plugins the
+// wire server registers, not the deployer suite's wider set.
+const (
+	cfnWireExportTemplate = `{"Resources":{` +
+		`"Data":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-wire-export"}}},` +
+		`"Outputs":{"BucketName":{"Value":{"Ref":"Data"},"Description":"the bucket",` +
+		`"Export":{"Name":{"Fn::Sub":"${AWS::StackName}-BucketName"}}}}}`
+
+	cfnWireImportTemplate = `{"Resources":{"Copy":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":{"Fn::Sub":["${n}-copy",` +
+		`{"n":{"Fn::ImportValue":"wirenet-BucketName"}}]}}}}}`
+)
+
+// cfnExportMembers unmarshals a ListExports response.
+type cfnExportMembers struct {
+	Exports []struct {
+		Name             string `xml:"Name"`
+		Value            string `xml:"Value"`
+		ExportingStackID string `xml:"ExportingStackId"`
+	} `xml:"ListExportsResult>Exports>member"`
+}
+
+// TestCFNPlugin_ListExports asserts the wire shape of the export registry.
+//
+// The member names are the API's, not substrate's: a caller's SDK unmarshals by
+// them, so Name/Value/ExportingStackId being right is the whole observable. The
+// ARN is asserted against the same builder DescribeStacks uses, because an export
+// that named a different stack ARN than the stack itself would be unusable for
+// the "which stack do I delete" question ListExports exists to answer.
+func TestCFNPlugin_ListExports(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName": "wirenet", "TemplateBody": cfnWireExportTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "ListExports", nil)
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	var doc cfnExportMembers
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc), "body was %s", body)
+	require.Len(t, doc.Exports, 1)
+	assert.Equal(t, "wirenet-BucketName", doc.Exports[0].Name)
+	assert.Equal(t, "cfn-wire-export", doc.Exports[0].Value)
+
+	// The ARN has to be the one DescribeStacks reports for the same stack, or the
+	// "which stack do I delete" question ListExports exists to answer gets an
+	// identifier no other call recognizes.
+	code, describeBody := cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "wirenet"})
+	require.Equal(t, http.StatusOK, code, "body was %s", describeBody)
+	var describe struct {
+		StackID string `xml:"DescribeStacksResult>Stacks>member>StackId"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(describeBody), &describe), "body was %s", describeBody)
+	require.Contains(t, describe.StackID, ":stack/wirenet/")
+	assert.Equal(t, describe.StackID, doc.Exports[0].ExportingStackID,
+		"the exporting stack is identified by its ARN, not its name")
+}
+
+// TestCFNPlugin_ListImports asserts the read the API points a caller at when a
+// delete is refused, including the two edges the reference fixes: ExportName is
+// required, and an export nothing imports is an empty list rather than an error.
+func TestCFNPlugin_ListImports(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	// Ordered, not a map: the exporting stack has to exist before the importing one
+	// resolves against it, which is CloudFormation's own constraint and not an
+	// artifact of the test.
+	for _, s := range []struct{ name, tmpl string }{
+		{"wirenet", cfnWireExportTemplate},
+		{"wireapp", cfnWireImportTemplate},
+	} {
+		code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+			"StackName": s.name, "TemplateBody": s.tmpl,
+		})
+		require.Equal(t, http.StatusOK, code, "creating %s: body was %s", s.name, body)
+	}
+
+	var doc struct {
+		Imports []string `xml:"ListImportsResult>Imports>member"`
+	}
+
+	code, body := cfnAction(t, ts, "ListImports", map[string]string{
+		"ExportName": "wirenet-BucketName",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc), "body was %s", body)
+	assert.Equal(t, []string{"wireapp"}, doc.Imports,
+		"stack names, not ARNs: \"a list of stack names that are importing the "+
+			"specified exported output value\"")
+
+	code, body = cfnAction(t, ts, "ListImports", map[string]string{
+		"ExportName": "no-such-export",
+	})
+	assert.Equal(t, http.StatusOK, code,
+		"ListImports documents no service-specific error, so an unknown export is empty")
+	doc.Imports = nil
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc), "body was %s", body)
+	assert.Empty(t, doc.Imports)
+
+	code, body = cfnAction(t, ts, "ListImports", nil)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "MissingParameter", cfnErrorCode(t, body))
+}
+
+// TestCFNPlugin_DeleteStackRefusedWhileExportIsImported is the wire half of
+// #522's second gate: the refusal has to reach the caller as a documented error
+// code, not as a 500 or a silent success.
+//
+// DeleteStack documents only TokenAlreadyExists, so ValidationError at 400 is
+// substrate's own choice for this case — the same code the API uses for every
+// other "your request cannot be satisfied" refusal on this service.
+func TestCFNPlugin_DeleteStackRefusedWhileExportIsImported(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	for _, s := range []struct{ name, tmpl string }{
+		{"wirenet", cfnWireExportTemplate},
+		{"wireapp", cfnWireImportTemplate},
+	} {
+		code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+			"StackName": s.name, "TemplateBody": s.tmpl,
+		})
+		require.Equal(t, http.StatusOK, code, "creating %s: body was %s", s.name, body)
+	}
+
+	code, body := cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "wirenet"})
+	assert.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+	assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	assert.Contains(t, body, "wirenet-BucketName")
+	assert.Contains(t, body, "wireapp", "the caller is told which stack to remove first")
+
+	// The stack survived the refusal, and deleting the importer first releases it.
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "wirenet"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "wireapp"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "wirenet"})
+	assert.Equal(t, http.StatusOK, code, "body was %s", body)
+}
+
+// TestCFNPlugin_CreateStackRefusesADuplicateExportName pins the uniqueness rule
+// over the wire, since a template that would be rejected by the real API must be
+// rejected here — otherwise substrate green-lights a deployment that cannot ship.
+func TestCFNPlugin_CreateStackRefusesADuplicateExportName(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	const fixed = `{"Resources":{` +
+		`"Data":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-wire-fixed"}}},` +
+		`"Outputs":{"V":{"Value":{"Ref":"Data"},"Export":{"Name":"Wire-Shared"}}}}`
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName": "owner", "TemplateBody": fixed,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName": "claimant", "TemplateBody": fixed,
+	})
+	assert.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+	assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	assert.Contains(t, body, "Wire-Shared")
+	assert.Contains(t, body, "owner", "the conflict names the stack already holding it")
+}
+
+// TestCFNPlugin_DescribeStacksReportsExportName pins ExportName beside its output.
+//
+// The API reports it on the Output structure itself, which saves a caller a second
+// ListExports call to learn whether an output is importable — and an output with no
+// Export must not grow an empty element, since that would read as "exported under
+// the empty name".
+func TestCFNPlugin_DescribeStacksReportsExportName(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName": "wirenet", "TemplateBody": cfnWireExportTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "wirenet"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	var doc struct {
+		Outputs []struct {
+			OutputKey   string `xml:"OutputKey"`
+			OutputValue string `xml:"OutputValue"`
+			ExportName  string `xml:"ExportName"`
+		} `xml:"DescribeStacksResult>Stacks>member>Outputs>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc), "body was %s", body)
+	require.Len(t, doc.Outputs, 1)
+	assert.Equal(t, "BucketName", doc.Outputs[0].OutputKey)
+	assert.Equal(t, "cfn-wire-export", doc.Outputs[0].OutputValue)
+	assert.Equal(t, "wirenet-BucketName", doc.Outputs[0].ExportName)
+
+	// A local output carries no ExportName element at all.
+	code, body = cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName": "wirelocal", "TemplateBody": cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "wirelocal"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.NotContains(t, body, "<ExportName>",
+		"an output without an Export is not importable and says nothing about one")
+}
+
+// TestCFNPlugin_ExportsAreScopedToTheCallersPartition pins that the wire path
+// consults the caller's identity rather than the plugin's default.
+//
+// deleteStack in particular had to switch to the caller's deployer for this: the
+// stack record is unpartitioned, but the export visibility that decides the refusal
+// is not, so the default identity would have consulted the wrong namespace and
+// either refused a legal delete or allowed an illegal one.
+func TestCFNPlugin_ExportsAreScopedToTheCallersPartition(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName": "wirenet", "TemplateBody": cfnWireExportTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	// An unsigned request resolves to the fallback account 000000000000, so the
+	// export is out of scope and invisible.
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "ListExports", "Version": "2010-05-15",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	var doc cfnExportMembers
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc), "body was %s", body)
+	assert.Empty(t, doc.Exports, "another account must not see the export")
+
+	// And an import from that account fails the resource rather than resolving
+	// against an export it is not entitled to see.
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "CreateStack", "Version": "2010-05-15",
+		"StackName": "otheracct", "TemplateBody": cfnWireImportTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "the resource fails; the operation does not: %s", body)
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "DescribeStackResources", "Version": "2010-05-15",
+		"StackName": "otheracct",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "CREATE_FAILED")
+	assert.Contains(t, body, "no exported output named")
+
+	// The refusal to delete is scoped the same way: the other account's stack
+	// imports nothing this account can see, so the exporting stack in the signed
+	// account is still deletable.
+	code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "wirenet"})
+	assert.Equal(t, http.StatusOK, code,
+		"an out-of-scope import must not pin the exporting stack: %s", body)
+}
+
+// TestCFNPlugin_DeleteRefusalUsesTheCallersOwnNamespace pins the reason
+// deleteStack builds a deployer from the caller's identity rather than using the
+// plugin's default one.
+//
+// The stack record is unpartitioned, so the delete itself works either way. The
+// export visibility deciding the refusal is not, so the default identity would
+// consult the wrong namespace — and the direction that matters is this one: a
+// non-default caller's own import is invisible from the default namespace, so a
+// delete that must be refused would be allowed, quietly removing an export another
+// of that caller's stacks is holding. The signed-caller case cannot catch it,
+// because a signed caller's identity *is* the default.
+func TestCFNPlugin_DeleteRefusalUsesTheCallersOwnNamespace(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	// Both stacks unsigned, so both live in the fallback account 000000000000 —
+	// not the default 123456789012 the plugin's own deployer would consult.
+	for _, s := range []struct{ name, tmpl string }{
+		{"wirenet", cfnWireExportTemplate},
+		{"wireapp", cfnWireImportTemplate},
+	} {
+		code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+			"Action": "CreateStack", "Version": "2010-05-15",
+			"StackName": s.name, "TemplateBody": s.tmpl,
+		})
+		require.Equal(t, http.StatusOK, code, "creating %s: body was %s", s.name, body)
+	}
+
+	// The import resolved, which is what makes the refusal below meaningful: an
+	// unresolved import would leave nothing recorded and the delete would be legal.
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "DescribeStackResources", "Version": "2010-05-15",
+		"StackName": "wireapp",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	require.Contains(t, body, "CREATE_COMPLETE")
+	require.NotContains(t, body, "CREATE_FAILED")
+
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		"Action": "DeleteStack", "Version": "2010-05-15", "StackName": "wirenet",
+	})
+	assert.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+	assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	assert.Contains(t, body, "wireapp",
+		"the caller's own import must be seen, not the default account's")
+}

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -145,6 +145,10 @@ func (p *CloudFormationPlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 		return p.listChangeSets(ctx, req)
 	case "DeleteChangeSet":
 		return p.deleteChangeSet(ctx, req)
+	case "ListExports":
+		return p.listExports(ctx, req)
+	case "ListImports":
+		return p.listImports(ctx, req)
 	case "DetectStackDrift":
 		return p.detectStackDrift(ctx, req)
 	case "DescribeStackResourceDrifts":
@@ -281,7 +285,12 @@ func (p *CloudFormationPlugin) deleteStack(reqCtx *RequestContext, req *AWSReque
 	}
 	// DeleteStack documents no not-found error: a deleted stack simply stops
 	// appearing in DescribeStacks, so deleting an absent stack succeeds.
-	if err := p.deployer.DeleteStack(context.Background(), name); err != nil {
+	//
+	// The caller's identity is needed even though the stack record itself is
+	// unpartitioned: the delete is refused when another stack imports one of this
+	// stack's exports, and export visibility is scoped per account and Region, so
+	// the default identity would consult the wrong namespace.
+	if err := p.deployerFor(reqCtx).DeleteStack(context.Background(), name); err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
 
@@ -317,6 +326,12 @@ type cfnParameterXML struct {
 type cfnOutputXML struct {
 	OutputKey   string `xml:"OutputKey"`
 	OutputValue string `xml:"OutputValue"`
+
+	// ExportName is the name under which the output is exported, omitted for an
+	// output the template declares no Export for. It is reported here as well as
+	// by ListExports because that is how a caller holding a DescribeStacks
+	// response learns the name to import, without a second call.
+	ExportName string `xml:"ExportName,omitempty"`
 }
 
 func (p *CloudFormationPlugin) describeStacks(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -358,7 +373,7 @@ func (p *CloudFormationPlugin) describeStacks(reqCtx *RequestContext, req *AWSRe
 			LastUpdatedTime: cfnTime(s.UpdatedAt),
 			StackStatus:     s.Status,
 			Parameters:      cfnParametersXML(s.Parameters),
-			Outputs:         cfnOutputsXML(s.Outputs),
+			Outputs:         cfnOutputsXML(s.Outputs, s.ExportNames),
 		})
 	}
 	return cfnXMLResponse(http.StatusOK, resp)
@@ -779,6 +794,85 @@ func (p *CloudFormationPlugin) deleteChangeSet(reqCtx *RequestContext, req *AWSR
 	return cfnXMLResponse(http.StatusOK, response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)})
 }
 
+// --- Export operations ---
+
+// listExports lists every exported output value in the caller's account and
+// Region.
+//
+// The caller's own identity is used rather than the plugin's default, for the same
+// reason DescribeStacks does: exports are scoped per account and Region, so a
+// eu-west-1 caller asking what it can import must not be shown us-east-1's
+// exports. The API documents no service-specific errors and paginates above 100
+// exports; substrate returns them all in one page and emits no NextToken, which is
+// the documented answer for a result that fits.
+func (p *CloudFormationPlugin) listExports(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
+	exports, err := p.deployerFor(reqCtx).Exports(context.Background())
+	if err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type member struct {
+		Name             string `xml:"Name"`
+		Value            string `xml:"Value"`
+		ExportingStackID string `xml:"ExportingStackId"`
+	}
+	type result struct {
+		Exports []member `xml:"Exports>member"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"ListExportsResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"ListExportsResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	resp := response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)}
+	for _, e := range exports {
+		resp.Result.Exports = append(resp.Result.Exports, member{
+			Name:  e.Name,
+			Value: e.Value,
+			// The stack ARN is built here rather than persisted with the export:
+			// this is the only place that knows the requesting caller's partition,
+			// and the ARN DescribeStacks reports for the same stack has to agree.
+			ExportingStackID: cfnStackID(reqCtx, e.ExportingStackName),
+		})
+	}
+	return cfnXMLResponse(http.StatusOK, resp)
+}
+
+// listImports lists the stacks importing an exported output value.
+//
+// ExportName is required and the API documents no service-specific errors, so an
+// export nothing imports — including one that does not exist — is an empty list
+// rather than a refusal. That is the same answer the real API gives, and it is the
+// one a caller checking "may I delete this stack" needs.
+func (p *CloudFormationPlugin) listImports(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	exportName := req.Params["ExportName"]
+	if exportName == "" {
+		return nil, cfnMissingParameter("ExportName")
+	}
+	importers, err := p.deployerFor(reqCtx).Imports(context.Background(), exportName)
+	if err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
+	type result struct {
+		Imports []string `xml:"Imports>member"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"ListImportsResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"ListImportsResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	// Stack *names*, not ARNs: "a list of stack names that are importing the
+	// specified exported output value".
+	return cfnXMLResponse(http.StatusOK, response{
+		XMLNS:    cfnXMLNS,
+		Result:   result{Imports: importers},
+		Metadata: cfnMetadata(reqCtx),
+	})
+}
+
 // --- Drift operations ---
 
 func (p *CloudFormationPlugin) detectStackDrift(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -1029,7 +1123,13 @@ func cfnMapDeployerError(err error) *AWSError {
 	switch {
 	case errors.Is(err, ErrCFNStackNotFound),
 		errors.Is(err, ErrCFNChangeSetNotFound),
-		errors.Is(err, ErrCFNDriftDetectionNotFound):
+		errors.Is(err, ErrCFNDriftDetectionNotFound),
+		// An export still imported, or a name another stack already exports, is
+		// the caller's request being invalid rather than substrate failing —
+		// "all the imports must be removed before you can delete the exporting
+		// stack" is an instruction to the caller — so both are 400s.
+		errors.Is(err, ErrCFNExportInUse),
+		errors.Is(err, ErrCFNExportNameConflict):
 		return &AWSError{Code: "ValidationError", Message: msg, HTTPStatus: http.StatusBadRequest}
 	case errors.Is(err, ErrCFNTemplateInvalid):
 		return &AWSError{
@@ -1174,8 +1274,9 @@ func cfnParametersXML(params map[string]string) []cfnParameterXML {
 	return out
 }
 
-// cfnOutputsXML renders a resolved output map, sorted by key.
-func cfnOutputsXML(outputs map[string]string) []cfnOutputXML {
+// cfnOutputsXML renders a resolved output map, sorted by key, carrying each
+// output's export name where the template declared one.
+func cfnOutputsXML(outputs, exportNames map[string]string) []cfnOutputXML {
 	keys := make([]string, 0, len(outputs))
 	for k := range outputs {
 		keys = append(keys, k)
@@ -1183,7 +1284,11 @@ func cfnOutputsXML(outputs map[string]string) []cfnOutputXML {
 	sort.Strings(keys)
 	out := make([]cfnOutputXML, 0, len(keys))
 	for _, k := range keys {
-		out = append(out, cfnOutputXML{OutputKey: k, OutputValue: outputs[k]})
+		out = append(out, cfnOutputXML{
+			OutputKey:   k,
+			OutputValue: outputs[k],
+			ExportName:  exportNames[k],
+		})
 	}
 	return out
 }

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -472,6 +472,40 @@ func CFNResolveNestedWithMappingsForTest(
 	return resolveNested(v, cctx), cctx.takeFailures()
 }
 
+// CFNResolveImportForTest resolves v against a set of exports, returning the
+// resolved value, the export names the resolution recorded as imports, and any
+// failure.
+//
+// The imports are the half that has no other observable: whether an
+// Fn::ImportValue counted as an import is what decides if the exporting stack can
+// be deleted, and it is decided at resolution time — an import inside a false
+// Fn::If branch never happened. Reading it here pins that without having to deploy
+// two stacks and then attempt a delete.
+func CFNResolveImportForTest(
+	v interface{},
+	exports map[string]string,
+	params map[string]string,
+) (value string, imports []string, failures []string) {
+	cctx := &cfnContext{
+		params:     params,
+		listParams: map[string]bool{},
+		conditions: map[string]bool{},
+		resources:  map[string]DeployedResource{},
+		evaluating: map[string]bool{},
+		imports:    map[string]bool{},
+		exports:    exports,
+		region:     defaultRegion,
+		accountID:  testAccountID,
+		stackName:  "teststack",
+	}
+	value = resolveValue(v, cctx)
+	return value, cctx.importedNames(), cctx.takeFailures()
+}
+
+// CFNStackExportsForTest returns a persisted stack's export name → value map, the
+// join of ExportNames against Outputs that the registry reads.
+func CFNStackExportsForTest(s CFNStackState) map[string]string { return s.exports() }
+
 // CFNSeededAZsForTest returns the Availability Zone names substrate reports for a
 // region, derived from the same list EC2's DescribeAvailabilityZones uses.
 //


### PR DESCRIPTION
Completes #522 by resolving its last intrinsic. The `Mappings`/`Fn::FindInMap`,
`Fn::GetAZs`, `Fn::Cidr` and pseudo-parameter halves shipped in PR #535; the plan
called for splitting `Fn::ImportValue` out if PR 3 grew, because the export
registry plus the delete-refusal is a new cross-stack model rather than another
resolver. It did, and this is that split.

## The defect

`Fn::ImportValue` was the last intrinsic falling through `resolveValue`'s
JSON-encoding fallback, so a template importing another stack's subnet ID deployed
a resource whose `SubnetId` was the literal `{"Fn::ImportValue":"net-SubnetID"}`
and reported `CREATE_COMPLETE`. Same shape as the rest of v0.88.0 — substrate
reports success where the observable is wrong — and the worst instance of it,
because the two-stack split is how every non-trivial template is organised.

## The model

An output may now declare `Export: {Name: …}`, absent from `cfnOutput` until now.
The name is an **expression** rather than a string, because the conventional form
is `Export: {Name: !Sub '${AWS::StackName}-SubnetID'}` — an export name must be
unique per account and Region, so a template hard-coding one cannot be deployed
twice. It resolves before the first resource deploys, which the API permits: an
export name may not depend on a resource, so it is knowable from the template and
its parameters alone.

Exports are scoped **per account and Region**, per the documented restriction that
cross-stack references are limited to the same account and Region. Getting this
wrong in the permissive direction would be worse than not resolving at all: a
template would pass under test and fail in AWS. `deleteStack` on the wire now uses
the caller's deployer for the same reason — the stack record is unpartitioned, but
the export visibility deciding the refusal is not.

Four rules are enforced, and they are why exports are modeled rather than faked —
an import that resolves against nothing enforceable is a lookup, not a reference:

- an import of an **unpublished name fails the resource**, with the name in its
  `ResourceStatusReason`, rather than resolving to `""` or to JSON;
- an export name **already held by another stack** is refused;
- a stack whose export is imported **cannot be deleted**;
- an imported export's value **cannot be changed** — nor dropped, which is the
  same thing from the importer's side, so a removal is refused on the same terms.
  Re-deploying an unchanged value is not a change, so an idempotent redeploy still
  works.

Both refusals are a `ValidationError` at 400 naming the export and every importing
stack, because the API's own remedy is "first find out which stacks are importing
them" and a refusal that withheld the answer would send the caller to `ListImports`
for something substrate already knows.

## The one decision a reader would otherwise get wrong

What counts as an import is recorded **when the resolver walks the template**, not
derived from the template's text. An `Fn::ImportValue` in the branch of an `Fn::If`
that was not taken never happened, and neither did one that failed to resolve, so
neither pins an exporting stack. Only the resolver knows which branch it walked.

Relatedly: `Fn::ImportValue` was deliberately kept out of `cfnIntrinsicNames` until
it resolved. `resolveNested` (#526) consults that table to decide what is an
intrinsic, and admitting an unresolvable one would have resolved every nested
import to `""` — strictly worse than the JSON fallback, which at least left the
intrinsic visible in the request the plugin refused. The table now carries it, with
that reasoning recorded in place.

## Added

`ListExports` and `ListImports`, which were `InvalidAction` before there was
anything to list. `ListExports` reports the `ExportingStackId` ARN
`DescribeStacks` reports for the same stack, in one page with no `NextToken`;
`ListImports` reports stack **names**, and an export nothing imports — including
one that does not exist — is an empty list rather than an error, since the
reference documents no service-specific errors for it. `DescribeStacks`
additionally reports each output's `ExportName` beside it.

## Provenance

`DeleteStack` documents only `TokenAlreadyExists`, so the `ValidationError`/400 for
both export refusals is **substrate's own choice** — the same code the service uses
for every other unsatisfiable request on it. The messages are substrate's; no
capture of real wording was taken. Everything else here (the scope restriction, the
uniqueness rule, the modify-while-imported prohibition, the permitted inner
functions, `ListExports`/`ListImports` shapes and their absence of
service-specific errors) is from the API reference.

Substrate does not enforce "an export name can't use Ref or GetAtt functions that
depend on a resource": by the time export names resolve, the resources have
deployed. That is strictly more permissive rather than differently behaved.

## Tests

16 new tests over both seams. The plan's stated gate — *an `Fn::ImportValue` of
another stack's export resolves, and deleting the exporting stack is refused* — plus
the account/Region scoping in both directions, the name conflict, the
change-and-drop refusals, the resolution-time import recording (including an import
in a false `Fn::If` branch not counting), resolution at depth inside a structured
property, legacy-snapshot scope back-compatibility, determinism of which conflict is
reported, and the `ListExports`/`ListImports`/`DescribeStacks`-`ExportName` wire
shapes.

**Mutation testing: 27 mutants, 27 CAUGHT, 0 survivors.** Five survived the first
round and each was a real test-design gap, closed with a test rather than argued
equivalent:

- `sameScope` requiring an exact account match → a v0.87 snapshot's stacks vanish
  from `ListExports` rather than exporting nothing (`TestCFN_LegacySnapshotStacksStayInScope`)
- `loadExports` including the deploying stack → a redeploy imports the name it is
  in the middle of redefining (`TestCFN_AStackDoesNotImportItsOwnExport`)
- iterating the conflict map unsorted → which of two conflicts is reported varies
  between runs (`TestCFN_TheReportedExportConflictIsDeterministic`)
- the delete refusal not excluding the stack itself → a stack importing its own
  export is permanently undeletable (`TestCFN_AStacksOwnImportDoesNotPinIt`)
- `deleteStack` using the default identity → a non-default caller's own import is
  invisible, so a delete that must be refused is allowed
  (`TestCFNPlugin_DeleteRefusalUsesTheCallersOwnNamespace`)

## Verification

`gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` →
**0 issues**, `make test` (race) green, `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`,
`go test -C test/e2e ./...` all green.

End to end through the real AWS CLI against `substrate server`: the import
resolves to `e2e-net-bucket` and `sqs list-queues` reads it back; `list-exports`
reports the ARN `describe-stacks` reports; `list-imports` names the importer;
deleting the exporter is refused with the `ValidationError` above; an unknown
export gives `CREATE_FAILED` with `Fn::ImportValue: no exported output named
"nope-Name" in this account and region`; `describe-stacks` shows `ExportName`
beside the output; deleting the importer first releases the exporter.

Closes #522
