### PR TITLE
fix(logs): put camelCase member names on the wire for the read operations (#528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it. `DescribeStacks` additionally reports each output's `ExportName` beside it,
   saving a caller a second call to learn whether an output is importable.
 
+- **CloudWatch Logs `PutRetentionPolicy` and `DeleteRetentionPolicy`** (#528), which
+  returned `InvalidAction` while `RetentionInDays` was already modeled, settable
+  through CloudFormation, and reported by `DescribeLogGroups` — so a retention a
+  template set could be read but never changed. `retentionInDays` accepts only the
+  22 values the reference enumerates (1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180,
+  365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653); anything else,
+  including a plausible-looking 45 or 100, is an `InvalidParameterException`, since
+  accepting one would let a template pass under test that the real service rejects.
+  The error message lists the valid values in ascending order so an assertion on it
+  is stable. `Delete` ships with `Put` because it is the documented way to make a
+  group's events never expire — there is no `retentionInDays` value meaning
+  "never", so a group with no policy omits the member rather than reporting `0`.
+  Both report `ResourceNotFoundException` at **HTTP 400**, as their references
+  document: this service carries the error code in the body's `__type`, not the
+  status line.
+
 ### Fixed
+- **CloudWatch Logs read operations put camelCase members on the wire, so an SDK
+  no longer parses every field to null** (#528). `DescribeLogGroups`,
+  `DescribeLogStreams` and `GetLogEvents` emitted **PascalCase** members where this
+  JSON-1.1 service uses camelCase. An SDK matches response members against the
+  service model case-sensitively, so a PascalCase member does not fail to parse —
+  it parses to *nothing*. The caller received one empty object per resource with an
+  HTTP 200 and no error: the count was right and every field read raised
+  `KeyError`, which is why a `len()` assertion passed. Reported against
+  v0.87.1/botocore 1.42.59 with a reproducer using a directly created group, so
+  this was never CloudFormation-specific.
+
+  `FilterLogEvents` was already correct, and that is what made the defect easy to
+  miss — a smoke test using it passes — because it alone declared its own response
+  element type instead of reusing the state struct. That is the pattern the fix
+  copies: each read now projects `CWLogGroup`/`CWLogStream`/`CWLogEvent` onto a
+  response-only type. Retagging the state structs would have been the shorter edit
+  and the wrong one: those structs are also the **persisted** encoding that
+  `Snapshot`/`Restore` round-trips and `betty_debug` replays, and
+  `LambdaPlugin.autoCreateLambdaLogGroup` writes one directly to dodge a registry
+  cycle, so a retag would have changed the wire and the on-disk format together. A
+  v0.87 snapshot still restores unchanged.
+
+  `DescribeLogGroups` now reports **both** ARN forms the reference documents as
+  distinct members, differing only in a trailing `:*`: `logGroupArn` without it,
+  which is what a `logGroupIdentifier` input or a tagging API wants, and `arn` with
+  it, which is what an IAM policy wants for every other action. Substrate
+  previously emitted its single unsuffixed ARN under `ARN`, so a caller who did
+  reach the value got the form the real service rejects in a policy.
 - **`Fn::Split` resolves to a list, so a split list no longer loses everything
   after its first element** (#521). `resolveValue` returns a `string`, so every
   list-valued intrinsic had nowhere to put a list: `resolveFnSplitFirst` was

--- a/docs/services.md
+++ b/docs/services.md
@@ -3053,15 +3053,46 @@ KMS API requests: $0.03 per 10,000 requests.
 | Operation | Notes |
 |-----------|-------|
 | CreateLogGroup | |
-| DeleteLogGroup | |
-| DescribeLogGroups | |
+| DeleteLogGroup | Also removes the group's streams and their events |
+| DescribeLogGroups | Reports both ARN forms — see below |
+| PutRetentionPolicy | `retentionInDays` must be one of the API's 22 enumerated values |
+| DeleteRetentionPolicy | The documented way to make a group's events never expire |
 | CreateLogStream | |
 | DeleteLogStream | |
 | DescribeLogStreams | |
 | PutLogEvents | Accepts up to 10,000 events per call |
 | GetLogEvents | Supports nextForwardToken pagination |
+| FilterLogEvents | Substring match on `filterPattern`; reports `searchedLogStreams` |
 
 Lambda auto-creates `/aws/lambda/{name}` log groups.
+
+### Response members are camelCase
+
+CloudWatch Logs is a JSON-1.1 service whose members are camelCase, and an SDK
+matches response members against the service model **case-sensitively** — a
+PascalCase member does not fail to parse, it parses to *nothing*, so a caller
+receives one empty object per resource with an HTTP 200 and no error. Earlier
+releases had `DescribeLogGroups`, `DescribeLogStreams` and `GetLogEvents` doing
+exactly that (`FilterLogEvents` did not), so a `len()` assertion passed while every
+field read raised `KeyError`. All four now emit the API's member names.
+
+`DescribeLogGroups` reports **both** ARN forms the reference documents as distinct
+members: `logGroupArn` without a trailing `:*`, which is what a
+`logGroupIdentifier` input or a tagging API wants, and `arn` with it, which is
+what an IAM policy wants for most actions. They differ only in that suffix.
+
+A group with no retention policy omits `retentionInDays` entirely rather than
+reporting `0`, because the API has no value meaning "never" — the member's absence
+is the signal, which is why `DeleteRetentionPolicy` exists.
+
+`PutRetentionPolicy` accepts only the enumerated day counts (1, 3, 5, 7, 14, 30,
+60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288,
+3653); anything else — including a plausible 45 or 100 — is an
+`InvalidParameterException`. Note that this service returns
+`ResourceNotFoundException` at **HTTP 400**, not 404, as its reference documents:
+the error code travels in the body's `__type`, not the status line. Substrate's
+older group- and stream-level not-found responses on the other operations still
+use 404 and are not changed here.
 
 ### Betty CFN resource types
 

--- a/emulator/cloudwatch_extra_test.go
+++ b/emulator/cloudwatch_extra_test.go
@@ -328,7 +328,7 @@ func TestLambda_AutoCreatesLogGroup(t *testing.T) {
 
 	var result struct {
 		LogGroups []struct {
-			LogGroupName string `json:"LogGroupName"`
+			LogGroupName string `json:"logGroupName"`
 		} `json:"logGroups"`
 	}
 	require.NoError(t, json.Unmarshal(logsW.Body.Bytes(), &result))

--- a/emulator/cloudwatchlogs_casing_test.go
+++ b/emulator/cloudwatchlogs_casing_test.go
@@ -1,0 +1,567 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// These tests assert on the raw JSON bytes rather than a Go round-trip, which is
+// the whole point of #528: a struct marshaled and unmarshaled by the same
+// definition agrees with itself whatever the casing, so a Go-level assertion
+// passes against a wire body no SDK can read. botocore matches response members
+// against the service model case-sensitively — a PascalCase member does not
+// error, it parses to nothing — so only a byte-level assertion sees the defect.
+//
+// Each read therefore gets a positive on the camelCase member *and* a negative on
+// the PascalCase one, because a body carrying both would satisfy the positive
+// while still telling a caller something the API never says.
+
+// TestCWLogs_DescribeLogGroupsWireCasing pins every LogGroup member a caller
+// reads, by name, on the bytes.
+func TestCWLogs_DescribeLogGroupsWireCasing(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+
+	resp := cwLogsRequest(t, srv, "CreateLogGroup", map[string]any{
+		"logGroupName":    "/probe/casing",
+		"retentionInDays": 7,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp = cwLogsRequest(t, srv, "DescribeLogGroups", map[string]any{})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := string(cwLogsReadBody(t, resp))
+
+	for _, member := range []string{
+		`"logGroupName":`, `"logGroupArn":`, `"arn":`, `"creationTime":`, `"retentionInDays":`,
+	} {
+		assert.Contains(t, body, member, "the API's member name must be on the wire")
+	}
+	for _, wrong := range []string{
+		`"LogGroupName"`, `"ARN"`, `"CreationTime"`, `"RetentionInDays"`,
+	} {
+		assert.NotContains(t, body, wrong,
+			"a PascalCase member parses to nothing in an SDK, silently")
+	}
+
+	// The outer key was already correct before #528, and staying correct matters:
+	// the count assertion is what made the defect survivable in a smoke test.
+	assert.Contains(t, body, `"logGroups":`)
+}
+
+// TestCWLogs_DescribeLogGroupsReportsBothARNForms pins the reference's
+// distinction between `arn` and `logGroupArn`, which differ only in a trailing
+// ":*" and are used for different things — the suffixed one in IAM policies for
+// most actions, the unsuffixed one in logGroupIdentifier and tagging APIs. Naming
+// one value under both members would hand a caller a policy resource the real
+// service rejects.
+func TestCWLogs_DescribeLogGroupsReportsBothARNForms(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+
+	resp := cwLogsRequest(t, srv, "CreateLogGroup", map[string]string{"logGroupName": "/probe/arns"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp = cwLogsRequest(t, srv, "DescribeLogGroups", map[string]any{})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result struct {
+		LogGroups []struct {
+			ARN         string `json:"arn"`
+			LogGroupARN string `json:"logGroupArn"`
+		} `json:"logGroups"`
+	}
+	require.NoError(t, json.Unmarshal(cwLogsReadBody(t, resp), &result))
+	require.Len(t, result.LogGroups, 1)
+
+	got := result.LogGroups[0]
+	assert.Equal(t, "arn:aws:logs:us-east-1:123456789012:log-group:/probe/arns", got.LogGroupARN,
+		"logGroupArn has no trailing :*")
+	assert.Equal(t, got.LogGroupARN+":*", got.ARN,
+		"arn is the same ARN with the trailing :* the reference specifies")
+}
+
+// TestCWLogs_LogGroupPolicyARNEdgeCases covers the two inputs to the `arn`
+// projection that the HTTP path cannot produce, because a group created through
+// CreateLogGroup always carries substrate's own unsuffixed ARN.
+//
+// Both matter to a restored snapshot rather than a live create: a record written
+// before the field existed has an empty ARN, and one written by a future version
+// may already carry the suffix. Appending unconditionally would turn the first
+// into a bare ":*" — an ARN-shaped string that is not an ARN — and double-suffix
+// the second.
+func TestCWLogs_LogGroupPolicyARNEdgeCases(t *testing.T) {
+	const bare = "arn:aws:logs:us-east-1:123456789012:log-group:/probe/edge"
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+		why  string
+	}{
+		{"unsuffixed gains the suffix", bare, bare + ":*",
+			"the common case: substrate's builder produces the unsuffixed form"},
+		{"empty stays empty", "", "",
+			"a bare \":*\" is not an ARN, and an absent ARN must stay absent so omitempty drops it"},
+		{"already suffixed is unchanged", bare + ":*", bare + ":*",
+			"the projection must be idempotent over its own output"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, emulator.CWLogGroupPolicyARNForTest(tt.in), tt.why)
+		})
+	}
+}
+
+// TestCWLogs_ARNlessStateReportsNoARN carries the empty-ARN case through to the
+// wire, which is where it would actually be seen: a snapshot restored from a
+// version that did not record ARNs must report no ARN at all, not two members
+// holding "" and ":*".
+func TestCWLogs_ARNlessStateReportsNoARN(t *testing.T) {
+	srv, state := newCWLogsTestServerWithState(t)
+
+	require.NoError(t, emulator.CWPutLogGroupStateForTest(t.Context(), state,
+		"123456789012", "us-east-1", emulator.CWLogGroup{
+			LogGroupName: "/probe/arnless",
+			CreationTime: 1785728276850,
+		}))
+
+	resp := cwLogsRequest(t, srv, "DescribeLogGroups", map[string]any{})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := string(cwLogsReadBody(t, resp))
+
+	require.Contains(t, body, `"logGroupName":"/probe/arnless"`)
+	assert.NotContains(t, body, `":*"`,
+		"an absent ARN must not become a bare \":*\"")
+	assert.NotContains(t, body, `"arn":`,
+		"omitempty drops the member rather than reporting an empty ARN")
+	assert.NotContains(t, body, `"logGroupArn":`)
+}
+
+// TestCWLogs_DescribeLogStreamsWireCasing pins the LogStream members. The stream
+// is written to before the read so lastIngestionTime and uploadSequenceToken are
+// populated — an omitempty member that is never set cannot be asserted absent
+// from correct output.
+func TestCWLogs_DescribeLogStreamsWireCasing(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogGroup", map[string]string{"logGroupName": "/probe/streams"}).StatusCode)
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogStream", map[string]string{
+			"logGroupName": "/probe/streams", "logStreamName": "s1",
+		}).StatusCode)
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "PutLogEvents", map[string]any{
+			"logGroupName": "/probe/streams", "logStreamName": "s1",
+			"logEvents": []map[string]any{{"timestamp": 1785728276850, "message": "hello"}},
+		}).StatusCode)
+
+	resp := cwLogsRequest(t, srv, "DescribeLogStreams", map[string]string{
+		"logGroupName": "/probe/streams",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := string(cwLogsReadBody(t, resp))
+
+	for _, member := range []string{
+		`"logStreamName":`, `"arn":`, `"creationTime":`, `"lastIngestionTime":`,
+		`"uploadSequenceToken":`,
+	} {
+		assert.Contains(t, body, member)
+	}
+	for _, wrong := range []string{
+		`"LogStreamName"`, `"ARN"`, `"CreationTime"`, `"LastIngestionTime"`,
+		`"UploadSequenceToken"`,
+	} {
+		assert.NotContains(t, body, wrong)
+	}
+
+	// LogStream documents a single `arn` member with no suffix variant, unlike
+	// LogGroup — so there must be no logStreamArn invented for symmetry.
+	assert.NotContains(t, body, `"logStreamArn"`,
+		"the LogStream type has one ARN member, not two")
+}
+
+// TestCWLogs_GetLogEventsWireCasing pins the OutputLogEvent members.
+func TestCWLogs_GetLogEventsWireCasing(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogGroup", map[string]string{"logGroupName": "/probe/events"}).StatusCode)
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogStream", map[string]string{
+			"logGroupName": "/probe/events", "logStreamName": "s1",
+		}).StatusCode)
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "PutLogEvents", map[string]any{
+			"logGroupName": "/probe/events", "logStreamName": "s1",
+			"logEvents": []map[string]any{{"timestamp": 1785728276850, "message": "hello"}},
+		}).StatusCode)
+
+	resp := cwLogsRequest(t, srv, "GetLogEvents", map[string]any{
+		"logGroupName": "/probe/events", "logStreamName": "s1",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := string(cwLogsReadBody(t, resp))
+
+	for _, member := range []string{`"timestamp":`, `"message":`, `"ingestionTime":`} {
+		assert.Contains(t, body, member)
+	}
+	for _, wrong := range []string{`"Timestamp"`, `"Message"`, `"IngestionTime"`} {
+		assert.NotContains(t, body, wrong)
+	}
+
+	// And each member carries its value. A member name present with a zero behind
+	// it is the same silent-success failure in a subtler form: ingestionTime has no
+	// omitempty (the API always reports it), so a dropped projection field shows up
+	// as a plausible 0 rather than as an absence.
+	var result struct {
+		Events []struct {
+			Timestamp     int64  `json:"timestamp"`
+			Message       string `json:"message"`
+			IngestionTime int64  `json:"ingestionTime"`
+		} `json:"events"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &result))
+	require.Len(t, result.Events, 1)
+	got := result.Events[0]
+	assert.Equal(t, int64(1785728276850), got.Timestamp)
+	assert.Equal(t, "hello", got.Message)
+	assert.NotZero(t, got.IngestionTime,
+		"ingestionTime is set by PutLogEvents from the simulated clock, so 0 means the projection dropped it")
+}
+
+// TestCWLogs_FilterLogEventsStaysCorrect guards the operation that was already
+// right. FilterLogEvents is why #528 was easy to miss — a smoke test using it
+// passes — and it is also the pattern the fix copied, so a regression in it would
+// mean the pattern itself was undone.
+func TestCWLogs_FilterLogEventsStaysCorrect(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogGroup", map[string]string{"logGroupName": "/probe/filter"}).StatusCode)
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogStream", map[string]string{
+			"logGroupName": "/probe/filter", "logStreamName": "s1",
+		}).StatusCode)
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "PutLogEvents", map[string]any{
+			"logGroupName": "/probe/filter", "logStreamName": "s1",
+			"logEvents": []map[string]any{{"timestamp": 1785728276850, "message": "hello"}},
+		}).StatusCode)
+
+	resp := cwLogsRequest(t, srv, "FilterLogEvents", map[string]any{
+		"logGroupName": "/probe/filter",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := string(cwLogsReadBody(t, resp))
+
+	for _, member := range []string{
+		`"logStreamName":`, `"timestamp":`, `"message":`, `"ingestionTime":`, `"eventId":`,
+		`"searchedLogStreams":`, `"searchedCompletely":`,
+	} {
+		assert.Contains(t, body, member)
+	}
+	for _, wrong := range []string{`"Timestamp"`, `"Message"`, `"IngestionTime"`} {
+		assert.NotContains(t, body, wrong)
+	}
+}
+
+// TestCWLogs_StateEncodingIsUnchanged is the reason the fix added response
+// element types rather than retagging CWLogGroup and friends.
+//
+// Those structs are the persisted format: Snapshot/Restore round-trips them and
+// betty_debug replays them, and LambdaPlugin.autoCreateLambdaLogGroup writes one
+// directly to dodge a registry cycle. Retagging would have changed the wire and
+// the persisted bytes in one edit, so this asserts the state encoding still uses
+// the PascalCase names a v0.87 snapshot contains — and that a group written under
+// those names is still fully readable over the corrected wire.
+func TestCWLogs_StateEncodingIsUnchanged(t *testing.T) {
+	srv, state := newCWLogsTestServerWithState(t)
+
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogGroup", map[string]any{
+			"logGroupName": "/probe/state", "retentionInDays": 30,
+		}).StatusCode)
+
+	raw, err := state.Get(t.Context(), "logs", "loggroup:123456789012/us-east-1//probe/state")
+	require.NoError(t, err)
+	require.NotNil(t, raw, "the state key layout is what a snapshot restores against")
+
+	stored := string(raw)
+	for _, member := range []string{
+		`"LogGroupName"`, `"ARN"`, `"CreationTime"`, `"RetentionInDays"`,
+	} {
+		assert.Contains(t, stored, member,
+			"the persisted encoding must stay as a v0.87 snapshot wrote it")
+	}
+	assert.NotContains(t, stored, `"logGroupArn"`,
+		"logGroupArn is a wire member; it is not persisted")
+
+	// And the same record reads back over the wire under the API's names, which
+	// is the property that would break if the projection were dropped.
+	resp := cwLogsRequest(t, srv, "DescribeLogGroups", map[string]any{})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result struct {
+		LogGroups []struct {
+			LogGroupName    string `json:"logGroupName"`
+			RetentionInDays int    `json:"retentionInDays"`
+		} `json:"logGroups"`
+	}
+	require.NoError(t, json.Unmarshal(cwLogsReadBody(t, resp), &result))
+	require.Len(t, result.LogGroups, 1)
+	assert.Equal(t, "/probe/state", result.LogGroups[0].LogGroupName)
+	assert.Equal(t, 30, result.LogGroups[0].RetentionInDays)
+}
+
+// TestCWLogs_PutRetentionPolicy covers the operation that was InvalidAction
+// before this change while RetentionInDays was already modeled and reported.
+func TestCWLogs_PutRetentionPolicy(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogGroup", map[string]string{"logGroupName": "/probe/retain"}).StatusCode)
+
+	// No retention until one is set: retentionInDays is omitempty, and the
+	// reference has no value meaning "never", so its absence is the signal.
+	resp := cwLogsRequest(t, srv, "DescribeLogGroups", map[string]any{})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotContains(t, string(cwLogsReadBody(t, resp)), `"retentionInDays"`,
+		"a group with no policy reports no retention, not a zero")
+
+	resp = cwLogsRequest(t, srv, "PutRetentionPolicy", map[string]any{
+		"logGroupName": "/probe/retain", "retentionInDays": 14,
+	})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.JSONEq(t, `{}`, string(cwLogsReadBody(t, resp)),
+		"the API returns 200 with an empty body")
+
+	assert.Equal(t, 14, cwLogsRetention(t, srv, "/probe/retain"))
+
+	// Setting it again replaces rather than accumulating.
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "PutRetentionPolicy", map[string]any{
+			"logGroupName": "/probe/retain", "retentionInDays": 365,
+		}).StatusCode)
+	assert.Equal(t, 365, cwLogsRetention(t, srv, "/probe/retain"))
+}
+
+// TestCWLogs_PutRetentionPolicyRejectsInvalidDays pins the fixed valid set. The
+// API enumerates it rather than accepting a range, so a plausible-looking value
+// is an error — and accepting one would let a template pass under test that the
+// real service rejects.
+func TestCWLogs_PutRetentionPolicyRejectsInvalidDays(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogGroup", map[string]string{"logGroupName": "/probe/bad"}).StatusCode)
+
+	// wantMessage separates the two reasons a request is refused, which share a
+	// code and a status and are distinguishable only in the message. Treating an
+	// absent member as an explicit 0 would tell a caller "0 is not valid" about a
+	// value they never sent, which sends them looking in the wrong place.
+	tests := []struct {
+		name        string
+		body        map[string]any
+		wantMessage string
+		why         string
+	}{
+		{"a plausible round number", map[string]any{
+			"logGroupName": "/probe/bad", "retentionInDays": 45,
+		}, "retentionInDays value of 45 is not valid",
+			"45 is between two valid values and is not itself valid"},
+		{"a hundred days", map[string]any{
+			"logGroupName": "/probe/bad", "retentionInDays": 100,
+		}, "retentionInDays value of 100 is not valid",
+			"100 sits between 90 and 120"},
+		{"zero", map[string]any{
+			"logGroupName": "/probe/bad", "retentionInDays": 0,
+		}, "retentionInDays value of 0 is not valid",
+			"0 means 'never' in substrate's state, but it is not a value the API accepts"},
+		{"negative", map[string]any{
+			"logGroupName": "/probe/bad", "retentionInDays": -1,
+		}, "retentionInDays value of -1 is not valid",
+			"a negative retention is meaningless"},
+		{"absent", map[string]any{
+			"logGroupName": "/probe/bad",
+		}, "retentionInDays is required",
+			"an absent required member is a different fault from an invalid value"},
+		{"no log group", map[string]any{
+			"retentionInDays": 7,
+		}, "logGroupName is required",
+			"logGroupName is a required parameter"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := cwLogsRequest(t, srv, "PutRetentionPolicy", tt.body)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, tt.why)
+			body := cwLogsReadBody(t, resp)
+			assert.Equal(t, "InvalidParameterException", cwLogsErrorTypeFrom(t, body))
+			assert.Contains(t, string(body), tt.wantMessage, tt.why)
+		})
+	}
+
+	// The rejection left no retention behind.
+	assert.Equal(t, 0, cwLogsRetention(t, srv, "/probe/bad"))
+
+	// And the message enumerates the valid values in ascending order, so a
+	// consumer's assertion on it is stable across runs.
+	resp := cwLogsRequest(t, srv, "PutRetentionPolicy", map[string]any{
+		"logGroupName": "/probe/bad", "retentionInDays": 45,
+	})
+	body := string(cwLogsReadBody(t, resp))
+	assert.Contains(t, body, "1, 3, 5, 7, 14, 30")
+	assert.Contains(t, body, "3288, 3653")
+}
+
+// TestCWLogs_PutRetentionPolicyUnknownGroup pins the status code, which is the
+// part a JSON-1.1 service does differently: ResourceNotFoundException is
+// documented at HTTP 400, not 404, because the code travels in the body's
+// "__type" rather than in the status line.
+func TestCWLogs_PutRetentionPolicyUnknownGroup(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+
+	for _, op := range []string{"PutRetentionPolicy", "DeleteRetentionPolicy"} {
+		t.Run(op, func(t *testing.T) {
+			resp := cwLogsRequest(t, srv, op, map[string]any{
+				"logGroupName": "/does/not/exist", "retentionInDays": 7,
+			})
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+				"the reference documents ResourceNotFoundException at 400 for this operation")
+			assert.Equal(t, "ResourceNotFoundException", cwLogsErrorType(t, resp))
+		})
+	}
+}
+
+// TestCWLogs_DeleteRetentionPolicy covers the documented way to make a group's
+// events never expire — there is no retentionInDays value meaning "never", so
+// deleting the policy is the only route.
+func TestCWLogs_DeleteRetentionPolicy(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogGroup", map[string]any{
+			"logGroupName": "/probe/forever", "retentionInDays": 7,
+		}).StatusCode)
+	require.Equal(t, 7, cwLogsRetention(t, srv, "/probe/forever"))
+
+	resp := cwLogsRequest(t, srv, "DeleteRetentionPolicy", map[string]string{
+		"logGroupName": "/probe/forever",
+	})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.JSONEq(t, `{}`, string(cwLogsReadBody(t, resp)))
+
+	resp = cwLogsRequest(t, srv, "DescribeLogGroups", map[string]any{})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotContains(t, string(cwLogsReadBody(t, resp)), `"retentionInDays"`,
+		"the member is gone, not zero: an SDK reads its absence as 'never expires'")
+
+	// Deleting again is not an error — the operation documents none for it, and a
+	// cleanup path that runs twice must not fail the second time.
+	resp = cwLogsRequest(t, srv, "DeleteRetentionPolicy", map[string]string{
+		"logGroupName": "/probe/forever",
+	})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp = cwLogsRequest(t, srv, "DeleteRetentionPolicy", map[string]string{})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "InvalidParameterException", cwLogsErrorType(t, resp))
+}
+
+// TestCWLogs_CFNLogGroupRetentionIsReadable is the end-to-end shape the issue
+// reported: parsl's ECS path creates a log group before registering a task
+// definition and needs to verify it afterwards. The template sets RetentionInDays
+// — as testdata/cfn/ecs_worker.yml does — so this covers the CFN deploy path
+// reaching the same corrected wire.
+func TestCWLogs_CFNLogGroupRetentionIsReadable(t *testing.T) {
+	srv := newCWLogsTestServer(t)
+
+	// Deployed groups are indistinguishable from directly created ones on the
+	// wire, which is the point: #528 was never CloudFormation-specific.
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "CreateLogGroup", map[string]any{
+			"logGroupName": "/ecs/worker-family", "retentionInDays": 7,
+		}).StatusCode)
+
+	resp := cwLogsRequest(t, srv, "DescribeLogGroups", map[string]string{
+		"logGroupNamePrefix": "/ecs/",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result struct {
+		LogGroups []struct {
+			LogGroupName    string `json:"logGroupName"`
+			RetentionInDays int    `json:"retentionInDays"`
+		} `json:"logGroups"`
+	}
+	require.NoError(t, json.Unmarshal(cwLogsReadBody(t, resp), &result))
+	require.Len(t, result.LogGroups, 1)
+	assert.Equal(t, "/ecs/worker-family", result.LogGroups[0].LogGroupName,
+		"verifying a group exists means reading its name back, which is what returned {}")
+	assert.Equal(t, 7, result.LogGroups[0].RetentionInDays)
+
+	// Cleanup verification is the other half the issue names: after the delete,
+	// the prefix read is empty rather than a count that passes for the wrong
+	// reason.
+	require.Equal(t, http.StatusOK,
+		cwLogsRequest(t, srv, "DeleteLogGroup", map[string]string{
+			"logGroupName": "/ecs/worker-family",
+		}).StatusCode)
+	resp = cwLogsRequest(t, srv, "DescribeLogGroups", map[string]string{
+		"logGroupNamePrefix": "/ecs/",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	result.LogGroups = nil
+	require.NoError(t, json.Unmarshal(cwLogsReadBody(t, resp), &result))
+	assert.Empty(t, result.LogGroups)
+}
+
+// cwLogsRetention reads a group's retentionInDays over the wire, returning 0 when
+// the member is absent.
+func cwLogsRetention(t *testing.T, srv *emulator.Server, logGroupName string) int {
+	t.Helper()
+	resp := cwLogsRequest(t, srv, "DescribeLogGroups", map[string]string{
+		"logGroupNamePrefix": logGroupName,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result struct {
+		LogGroups []struct {
+			LogGroupName    string `json:"logGroupName"`
+			RetentionInDays int    `json:"retentionInDays"`
+		} `json:"logGroups"`
+	}
+	require.NoError(t, json.Unmarshal(cwLogsReadBody(t, resp), &result))
+	for _, lg := range result.LogGroups {
+		if lg.LogGroupName == logGroupName {
+			return lg.RetentionInDays
+		}
+	}
+	t.Fatalf("log group %q not reported", logGroupName)
+	return 0
+}
+
+// cwLogsErrorType reads the error code from a JSON-1.1 error body. botocore reads
+// the "__type" member, so that is what an assertion has to check — a code that
+// reached only the header would be invisible to the caller.
+func cwLogsErrorType(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	return cwLogsErrorTypeFrom(t, cwLogsReadBody(t, resp))
+}
+
+// cwLogsErrorTypeFrom is cwLogsErrorType over bytes already read, for a caller
+// that also asserts on the message — the response body can only be read once.
+func cwLogsErrorTypeFrom(t *testing.T, raw []byte) string {
+	t.Helper()
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+	code, _ := body["__type"].(string)
+	// Some services qualify the type with a prefix; compare on the final segment.
+	if i := strings.LastIndex(code, "#"); i >= 0 {
+		code = code[i+1:]
+	}
+	return code
+}

--- a/emulator/cloudwatchlogs_plugin.go
+++ b/emulator/cloudwatchlogs_plugin.go
@@ -13,9 +13,9 @@ import (
 )
 
 // CloudWatchLogsPlugin emulates the Amazon CloudWatch Logs JSON-protocol API.
-// It handles CreateLogGroup, DeleteLogGroup, DescribeLogGroups, CreateLogStream,
-// DeleteLogStream, DescribeLogStreams, PutLogEvents, GetLogEvents, and
-// FilterLogEvents.
+// It handles CreateLogGroup, DeleteLogGroup, DescribeLogGroups,
+// PutRetentionPolicy, DeleteRetentionPolicy, CreateLogStream, DeleteLogStream,
+// DescribeLogStreams, PutLogEvents, GetLogEvents, and FilterLogEvents.
 type CloudWatchLogsPlugin struct {
 	state  StateManager
 	logger Logger
@@ -50,6 +50,10 @@ func (p *CloudWatchLogsPlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 		return p.deleteLogGroup(ctx, req)
 	case "DescribeLogGroups":
 		return p.describeLogGroups(ctx, req)
+	case "PutRetentionPolicy":
+		return p.putRetentionPolicy(ctx, req)
+	case "DeleteRetentionPolicy":
+		return p.deleteRetentionPolicy(ctx, req)
 	case "CreateLogStream":
 		return p.createLogStream(ctx, req)
 	case "DeleteLogStream":
@@ -217,7 +221,7 @@ func (p *CloudWatchLogsPlugin) describeLogGroups(ctx *RequestContext, req *AWSRe
 		end = len(names)
 	}
 
-	groups := make([]CWLogGroup, 0, end-offset)
+	groups := make([]cwLogGroupOut, 0, end-offset)
 	for _, name := range names[offset:end] {
 		data, getErr := p.state.Get(goCtx, cloudwatchLogsNamespace, cwLogGroupKey(ctx.AccountID, ctx.Region, name))
 		if getErr != nil || data == nil {
@@ -227,14 +231,150 @@ func (p *CloudWatchLogsPlugin) describeLogGroups(ctx *RequestContext, req *AWSRe
 		if unmarshalErr := json.Unmarshal(data, &lg); unmarshalErr != nil {
 			continue
 		}
-		groups = append(groups, lg)
+		groups = append(groups, cwLogGroupWire(lg))
 	}
 
 	type response struct {
-		LogGroups []CWLogGroup `json:"logGroups"`
-		NextToken string       `json:"nextToken,omitempty"`
+		LogGroups []cwLogGroupOut `json:"logGroups"`
+		NextToken string          `json:"nextToken,omitempty"`
 	}
 	return cwLogsJSONResponse(http.StatusOK, response{LogGroups: groups, NextToken: nextToken})
+}
+
+// cwRetentionDays is the fixed set of values retentionInDays accepts. The API
+// enumerates it rather than accepting a range, so anything else is an
+// InvalidParameterException — including a plausible-looking 45 or 100.
+var cwRetentionDays = map[int]bool{
+	1: true, 3: true, 5: true, 7: true, 14: true, 30: true, 60: true, 90: true,
+	120: true, 150: true, 180: true, 365: true, 400: true, 545: true, 731: true,
+	1096: true, 1827: true, 2192: true, 2557: true, 2922: true, 3288: true,
+	3653: true,
+}
+
+// putRetentionPolicy sets a log group's retention in days.
+//
+// Both of this operation's failure modes are documented at HTTP 400, including
+// ResourceNotFoundException — the JSON-1.1 protocol carries the error code in the
+// body's "__type", so the status is 400 for every modeled error rather than the
+// 404 an HTTP-shaped API would use.
+func (p *CloudWatchLogsPlugin) putRetentionPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var body struct {
+		LogGroupName    string `json:"logGroupName"`
+		RetentionInDays *int   `json:"retentionInDays"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return nil, &AWSError{Code: "InvalidParameterException", Message: "invalid request body", HTTPStatus: http.StatusBadRequest}
+	}
+	if body.LogGroupName == "" {
+		return nil, &AWSError{Code: "InvalidParameterException", Message: "logGroupName is required", HTTPStatus: http.StatusBadRequest}
+	}
+	// A pointer, not an int: retentionInDays is required, and 0 is not a valid
+	// value, so an absent member and an explicit 0 are both errors — but only a
+	// pointer can tell substrate which one the caller sent.
+	if body.RetentionInDays == nil {
+		return nil, &AWSError{Code: "InvalidParameterException", Message: "retentionInDays is required", HTTPStatus: http.StatusBadRequest}
+	}
+	if !cwRetentionDays[*body.RetentionInDays] {
+		return nil, &AWSError{
+			Code: "InvalidParameterException",
+			Message: fmt.Sprintf(
+				"retentionInDays value of %d is not valid; possible values are: %s",
+				*body.RetentionInDays, cwRetentionDaysList()),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	goCtx := context.Background()
+	stateKey := cwLogGroupKey(ctx.AccountID, ctx.Region, body.LogGroupName)
+	lg, err := p.loadLogGroup(goCtx, stateKey, body.LogGroupName, "putRetentionPolicy")
+	if err != nil {
+		return nil, err
+	}
+
+	lg.RetentionInDays = *body.RetentionInDays
+	if putErr := p.storeLogGroup(goCtx, stateKey, lg, "putRetentionPolicy"); putErr != nil {
+		return nil, putErr
+	}
+	return cwLogsJSONResponse(http.StatusOK, struct{}{})
+}
+
+// deleteRetentionPolicy clears a log group's retention, so its events never
+// expire. The API documents this as the way to make events permanent — there is
+// no retentionInDays value meaning "never".
+func (p *CloudWatchLogsPlugin) deleteRetentionPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var body struct {
+		LogGroupName string `json:"logGroupName"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return nil, &AWSError{Code: "InvalidParameterException", Message: "invalid request body", HTTPStatus: http.StatusBadRequest}
+	}
+	if body.LogGroupName == "" {
+		return nil, &AWSError{Code: "InvalidParameterException", Message: "logGroupName is required", HTTPStatus: http.StatusBadRequest}
+	}
+
+	goCtx := context.Background()
+	stateKey := cwLogGroupKey(ctx.AccountID, ctx.Region, body.LogGroupName)
+	lg, err := p.loadLogGroup(goCtx, stateKey, body.LogGroupName, "deleteRetentionPolicy")
+	if err != nil {
+		return nil, err
+	}
+
+	// Deleting a policy that is not there is not an error — the operation is
+	// idempotent and its documented errors do not include one for it.
+	lg.RetentionInDays = 0
+	if putErr := p.storeLogGroup(goCtx, stateKey, lg, "deleteRetentionPolicy"); putErr != nil {
+		return nil, putErr
+	}
+	return cwLogsJSONResponse(http.StatusOK, struct{}{})
+}
+
+// loadLogGroup reads a log group, reporting ResourceNotFoundException when it is
+// absent. op names the calling operation for the wrapped-error context.
+func (p *CloudWatchLogsPlugin) loadLogGroup(ctx context.Context, stateKey, logGroupName, op string) (CWLogGroup, error) {
+	data, err := p.state.Get(ctx, cloudwatchLogsNamespace, stateKey)
+	if err != nil {
+		return CWLogGroup{}, fmt.Errorf("logs %s state.Get: %w", op, err)
+	}
+	if data == nil {
+		return CWLogGroup{}, &AWSError{
+			Code:       "ResourceNotFoundException",
+			Message:    "The specified log group does not exist: " + logGroupName,
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	var lg CWLogGroup
+	if unmarshalErr := json.Unmarshal(data, &lg); unmarshalErr != nil {
+		return CWLogGroup{}, fmt.Errorf("logs %s unmarshal: %w", op, unmarshalErr)
+	}
+	return lg, nil
+}
+
+// storeLogGroup writes a log group back to state.
+func (p *CloudWatchLogsPlugin) storeLogGroup(ctx context.Context, stateKey string, lg CWLogGroup, op string) error {
+	data, err := json.Marshal(lg)
+	if err != nil {
+		return fmt.Errorf("logs %s marshal: %w", op, err)
+	}
+	if putErr := p.state.Put(ctx, cloudwatchLogsNamespace, stateKey, data); putErr != nil {
+		return fmt.Errorf("logs %s state.Put: %w", op, putErr)
+	}
+	return nil
+}
+
+// cwRetentionDaysList renders the valid retention values in ascending order for
+// an error message. Sorted, not map order: a nondeterministic error message is
+// one a consumer's test cannot assert on.
+func cwRetentionDaysList() string {
+	days := make([]int, 0, len(cwRetentionDays))
+	for d := range cwRetentionDays {
+		days = append(days, d)
+	}
+	sort.Ints(days)
+	parts := make([]string, len(days))
+	for i, d := range days {
+		parts[i] = strconv.Itoa(d)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // --- Log stream operations --------------------------------------------------
@@ -382,7 +522,7 @@ func (p *CloudWatchLogsPlugin) describeLogStreams(ctx *RequestContext, req *AWSR
 		end = len(names)
 	}
 
-	streams := make([]CWLogStream, 0, end-offset)
+	streams := make([]cwLogStreamOut, 0, end-offset)
 	for _, name := range names[offset:end] {
 		data, getErr := p.state.Get(goCtx, cloudwatchLogsNamespace, cwLogStreamKey(ctx.AccountID, ctx.Region, body.LogGroupName, name))
 		if getErr != nil || data == nil {
@@ -392,12 +532,12 @@ func (p *CloudWatchLogsPlugin) describeLogStreams(ctx *RequestContext, req *AWSR
 		if unmarshalErr := json.Unmarshal(data, &ls); unmarshalErr != nil {
 			continue
 		}
-		streams = append(streams, ls)
+		streams = append(streams, cwLogStreamWire(ls))
 	}
 
 	type response struct {
-		LogStreams []CWLogStream `json:"logStreams"`
-		NextToken  string        `json:"nextToken,omitempty"`
+		LogStreams []cwLogStreamOut `json:"logStreams"`
+		NextToken  string           `json:"nextToken,omitempty"`
 	}
 	return cwLogsJSONResponse(http.StatusOK, response{LogStreams: streams, NextToken: nextToken})
 }
@@ -538,13 +678,19 @@ func (p *CloudWatchLogsPlugin) getLogEvents(ctx *RequestContext, req *AWSRequest
 		end = len(filtered)
 	}
 
+	page := filtered[offset:end]
+	events := make([]cwOutputLogEventOut, 0, len(page))
+	for _, ev := range page {
+		events = append(events, cwOutputLogEventWire(ev))
+	}
+
 	type response struct {
-		Events            []CWLogEvent `json:"events"`
-		NextForwardToken  string       `json:"nextForwardToken,omitempty"`
-		NextBackwardToken string       `json:"nextBackwardToken,omitempty"`
+		Events            []cwOutputLogEventOut `json:"events"`
+		NextForwardToken  string                `json:"nextForwardToken,omitempty"`
+		NextBackwardToken string                `json:"nextBackwardToken,omitempty"`
 	}
 	return cwLogsJSONResponse(http.StatusOK, response{
-		Events:           filtered[offset:end],
+		Events:           events,
 		NextForwardToken: nextToken,
 	})
 }

--- a/emulator/cloudwatchlogs_plugin_test.go
+++ b/emulator/cloudwatchlogs_plugin_test.go
@@ -20,6 +20,19 @@ import (
 // newCWLogsTestServer creates a test server with the CloudWatchLogs plugin.
 func newCWLogsTestServer(t *testing.T) *emulator.Server {
 	t.Helper()
+	srv, _ := newCWLogsTestServerWithState(t)
+	return srv
+}
+
+// newCWLogsTestServerWithState is newCWLogsTestServer, additionally handing back
+// the state manager.
+//
+// Reaching the state manager is the point: CWLogGroup and friends are the
+// persisted encoding as well as the source of each wire response, and the only
+// way to assert that #528's fix left the persisted bytes alone is to read them
+// (see TestCWLogs_StateEncodingIsUnchanged).
+func newCWLogsTestServerWithState(t *testing.T) (*emulator.Server, *emulator.MemoryStateManager) {
+	t.Helper()
 	cfg := emulator.DefaultConfig()
 	registry := emulator.NewPluginRegistry()
 	state := emulator.NewMemoryStateManager()
@@ -35,7 +48,7 @@ func newCWLogsTestServer(t *testing.T) *emulator.Server {
 	}))
 	registry.Register(plugin)
 
-	return emulator.NewServer(*cfg, registry, store, state, tc, logger)
+	return emulator.NewServer(*cfg, registry, store, state, tc, logger), state
 }
 
 // cwLogsRequest sends a CloudWatch Logs JSON-protocol request.
@@ -77,7 +90,7 @@ func TestCWLogs_LogGroupLifecycle(t *testing.T) {
 	body := cwLogsReadBody(t, resp)
 	var result struct {
 		LogGroups []struct {
-			LogGroupName string `json:"LogGroupName"`
+			LogGroupName string `json:"logGroupName"`
 		} `json:"logGroups"`
 	}
 	require.NoError(t, json.Unmarshal(body, &result))
@@ -123,7 +136,7 @@ func TestCWLogs_LogGroupPrefix(t *testing.T) {
 	body := cwLogsReadBody(t, resp)
 	var result struct {
 		LogGroups []struct {
-			LogGroupName string `json:"LogGroupName"`
+			LogGroupName string `json:"logGroupName"`
 		} `json:"logGroups"`
 	}
 	require.NoError(t, json.Unmarshal(body, &result))
@@ -152,7 +165,7 @@ func TestCWLogs_LogStreamLifecycle(t *testing.T) {
 	body := cwLogsReadBody(t, resp)
 	var result struct {
 		LogStreams []struct {
-			LogStreamName string `json:"LogStreamName"`
+			LogStreamName string `json:"logStreamName"`
 		} `json:"logStreams"`
 	}
 	require.NoError(t, json.Unmarshal(body, &result))
@@ -208,7 +221,7 @@ func TestCWLogs_PutAndGetLogEvents(t *testing.T) {
 	body = cwLogsReadBody(t, resp)
 	var getResult struct {
 		Events []struct {
-			Message string `json:"Message"`
+			Message string `json:"message"`
 		} `json:"events"`
 	}
 	require.NoError(t, json.Unmarshal(body, &getResult))

--- a/emulator/cloudwatchlogs_types.go
+++ b/emulator/cloudwatchlogs_types.go
@@ -1,5 +1,7 @@
 package emulator
 
+import "strings"
+
 // cloudwatchLogsNamespace is the state namespace used by CloudWatchLogsPlugin.
 const cloudwatchLogsNamespace = "logs"
 
@@ -46,6 +48,101 @@ type CWLogEvent struct {
 
 	// IngestionTime is the time the event was ingested in ms since epoch.
 	IngestionTime int64 `json:"IngestionTime"`
+}
+
+// The three types above are the *state* encoding: they are what
+// CloudWatchLogsPlugin marshals into the state manager, what
+// MemoryStateManager.Snapshot round-trips, and what
+// LambdaPlugin.autoCreateLambdaLogGroup writes directly. Their PascalCase tags
+// are therefore a persisted format and are deliberately left alone.
+//
+// The wire is a different thing. CloudWatch Logs is a JSON-1.1 service whose
+// members are camelCase, and botocore matches response members against the
+// service model case-sensitively: a PascalCase member does not fail to parse, it
+// parses to *nothing*, so the caller gets one empty dict per resource with an
+// HTTP 200 and no error (#528). Reusing one struct for both jobs is what made
+// three of the four reads silently unreadable while FilterLogEvents — which
+// already declared its own response element — stayed correct.
+//
+// So each read projects state onto a response-only element type below. Keeping
+// the two encodings separate is the point: retagging the state structs would
+// have fixed the wire and changed the persisted format in the same edit.
+
+// cwLogGroupOut is the wire encoding of a log group, per the API's LogGroup type.
+type cwLogGroupOut struct {
+	LogGroupName string `json:"logGroupName"`
+
+	// LogGroupARN is the ARN without a trailing ":*". The reference documents
+	// `arn` and `logGroupArn` as *distinct* members differing only in that
+	// suffix, and substrate's builder produces the unsuffixed form, so that
+	// value belongs under this name.
+	LogGroupARN string `json:"logGroupArn,omitempty"`
+
+	// ARN is the same ARN with the trailing ":*" the reference specifies for
+	// this member. It is the version a caller puts in an IAM policy for most
+	// actions, so reporting only the unsuffixed one under both names would hand
+	// out a policy resource the real service rejects.
+	ARN string `json:"arn,omitempty"`
+
+	CreationTime    int64 `json:"creationTime"`
+	RetentionInDays int   `json:"retentionInDays,omitempty"`
+}
+
+// cwLogStreamOut is the wire encoding of a log stream, per the API's LogStream
+// type. LogStream documents a single `arn` member with no suffix variant, so
+// unlike a log group there is only one ARN to report.
+type cwLogStreamOut struct {
+	LogStreamName       string `json:"logStreamName"`
+	ARN                 string `json:"arn,omitempty"`
+	CreationTime        int64  `json:"creationTime"`
+	LastIngestionTime   int64  `json:"lastIngestionTime,omitempty"`
+	UploadSequenceToken string `json:"uploadSequenceToken,omitempty"`
+}
+
+// cwOutputLogEventOut is the wire encoding of a log event, per the API's
+// OutputLogEvent type.
+type cwOutputLogEventOut struct {
+	Timestamp     int64  `json:"timestamp"`
+	Message       string `json:"message"`
+	IngestionTime int64  `json:"ingestionTime"`
+}
+
+// cwLogGroupWire projects a stored log group onto its wire encoding.
+func cwLogGroupWire(lg CWLogGroup) cwLogGroupOut {
+	return cwLogGroupOut{
+		LogGroupName:    lg.LogGroupName,
+		LogGroupARN:     lg.ARN,
+		ARN:             cwLogGroupPolicyARN(lg.ARN),
+		CreationTime:    lg.CreationTime,
+		RetentionInDays: lg.RetentionInDays,
+	}
+}
+
+// cwLogStreamWire projects a stored log stream onto its wire encoding.
+//
+// A conversion rather than a field-by-field literal: the two types are
+// field-identical and differ only in their tags, so this is the projection that
+// stops compiling if a field is added to only one of them — which is exactly the
+// drift #528 came from.
+func cwLogStreamWire(ls CWLogStream) cwLogStreamOut {
+	return cwLogStreamOut(ls)
+}
+
+// cwOutputLogEventWire projects a stored log event onto its wire encoding. A
+// conversion, for the reason given on cwLogStreamWire.
+func cwOutputLogEventWire(ev CWLogEvent) cwOutputLogEventOut {
+	return cwOutputLogEventOut(ev)
+}
+
+// cwLogGroupPolicyARN returns the trailing-":*" form of a log group ARN, which
+// is the API's `arn` member. An empty ARN stays empty rather than becoming a
+// bare ":*", and an ARN that already carries the suffix is returned unchanged so
+// the function is idempotent over its own output.
+func cwLogGroupPolicyARN(arn string) string {
+	if arn == "" || strings.HasSuffix(arn, ":*") {
+		return arn
+	}
+	return arn + ":*"
 }
 
 // cwLogGroupARN constructs the ARN for a CloudWatch Logs log group.

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -506,6 +506,33 @@ func CFNResolveImportForTest(
 // join of ExportNames against Outputs that the registry reads.
 func CFNStackExportsForTest(s CFNStackState) map[string]string { return s.exports() }
 
+// CWLogGroupPolicyARNForTest wraps cwLogGroupPolicyARN for external tests.
+//
+// Exported because two of its cases are not reachable over HTTP: a created group
+// always has substrate's own unsuffixed ARN, so the empty-ARN input (a record a
+// snapshot restored before the field existed) and the already-suffixed input
+// (idempotence over its own output) can only be exercised directly.
+func CWLogGroupPolicyARNForTest(arn string) string { return cwLogGroupPolicyARN(arn) }
+
+// CWPutLogGroupStateForTest writes a log group record into state under the key
+// layout the plugin reads, without going through CreateLogGroup.
+//
+// This is how a test reaches a stored group whose fields the API path would never
+// produce — an ARN-less record from an older snapshot, say — so the wire
+// projection can be asserted over it.
+func CWPutLogGroupStateForTest(ctx context.Context, state StateManager, accountID, region string, lg CWLogGroup) error {
+	data, err := json.Marshal(lg)
+	if err != nil {
+		return fmt.Errorf("CWPutLogGroupStateForTest marshal: %w", err)
+	}
+	key := cwLogGroupKey(accountID, region, lg.LogGroupName)
+	if putErr := state.Put(ctx, cloudwatchLogsNamespace, key, data); putErr != nil {
+		return fmt.Errorf("CWPutLogGroupStateForTest state.Put: %w", putErr)
+	}
+	updateStringIndex(ctx, state, cloudwatchLogsNamespace, cwLogGroupNamesKey(accountID, region), lg.LogGroupName)
+	return nil
+}
+
 // CFNSeededAZsForTest returns the Availability Zone names substrate reports for a
 // region, derived from the same list EC2's DescribeAvailabilityZones uses.
 //


### PR DESCRIPTION
## The defect

CloudWatch Logs is a JSON-1.1 service whose response members are **camelCase**, and
botocore matches response members against the service model **case-sensitively**. That
matters more than it sounds: a PascalCase member does not fail to parse, it parses to
*nothing*. The caller gets one empty object per resource, with an HTTP 200 and no error.

So `describe_log_groups()` returned `{"logGroups": [{}, {}]}`. A `len(...)` assertion
passed — the right number of groups came back — while every field read raised
`KeyError`. That is the shape this repo keeps finding: **substrate reports success where
the observable is wrong.**

Three of the four reads were affected: `DescribeLogGroups`, `DescribeLogStreams`,
`GetLogEvents`. `FilterLogEvents` was already correct, and *why* is the whole story.

## Cause: one struct doing two jobs

`CWLogGroup`, `CWLogStream` and `CWLogEvent` are tagged PascalCase because they are the
**state encoding** — what the plugin marshals into the state manager, what
`MemoryStateManager.Snapshot`/`Restore` round-trips, what `betty_debug` replays, and what
`LambdaPlugin.autoCreateLambdaLogGroup` writes directly to dodge a registry cycle. They
were *also* embedded in each response envelope. The envelopes are declared inline per
handler with correct camelCase tags, which is why only the members were wrong.

`FilterLogEvents` escaped because it does **not** reuse the state struct: it declares a
local `filteredEvent` with camelCase tags. That is the pattern this follows.

## Fix: response-only element types

`cwLogGroupOut`, `cwLogStreamOut` and `cwOutputLogEventOut` in
`cloudwatchlogs_types.go`, with `cwLogGroupWire`/`cwLogStreamWire`/`cwOutputLogEventWire`
projecting state onto them. Retagging the state structs would have fixed the wire and
changed the persisted format in the same edit — survivable, since Go's `json` unmarshals
case-insensitively absent an exact match, but not free, and not something to do silently.
`TestCWLogs_StateEncodingIsUnchanged` reads the state manager directly and asserts the
persisted bytes still carry `"LogGroupName"`/`"ARN"`/`"CreationTime"`/`"RetentionInDays"`
and *not* `"logGroupArn"`, so that separation is an assertable property rather than an
intention.

Two of the three projections are type conversions rather than field-by-field literals.
That is deliberate beyond satisfying staticcheck: a conversion stops compiling if a field
is added to only one of the pair, which is exactly the drift this issue came from.

## Both ARN forms

The plan for this work recorded that substrate emits the unsuffixed ARN "so the accurate
tag is `logGroupArn`". Checking the reference rather than the paraphrase: `arn` and
`logGroupArn` are **both documented, as distinct members**, differing only in a trailing
`:*`. `logGroupArn` (no suffix) is what a `logGroupIdentifier` input and the tagging APIs
want; `arn` (with suffix) is what an IAM policy wants for most actions. Reporting one
value under both names would hand a caller a policy resource the real service rejects, so
`DescribeLogGroups` reports both, and `TestCWLogs_DescribeLogGroupsReportsBothARNForms`
pins `arn == logGroupArn + ":*"`.

`LogStream` documents a single `arn` with no suffix variant, so there is deliberately no
`logStreamArn` invented for symmetry — a test asserts its absence.

`cwLogGroupPolicyARN` leaves an empty ARN empty rather than producing a bare `":*"`, and
is idempotent over its own output. Neither case is reachable through `CreateLogGroup`
(which always stores substrate's own unsuffixed ARN); both are reachable from a restored
snapshot, which is why they are tested through an export seam.

## PutRetentionPolicy and DeleteRetentionPolicy

Both were unrouted (`400 InvalidAction`) while `RetentionInDays` was already modeled and
reported — a group's retention could be read but never set except at create time.

- `retentionInDays` accepts only the API's enumerated values (1, 3, 5, 7, 14, 30, 60, 90,
  120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653). It is an
  enumeration, not a range, so a plausible-looking 45 or 100 is an
  `InvalidParameterException` — accepting one would let a template pass under test that
  the real service rejects.
- The error message enumerates the valid values in **ascending order**, sorted rather
  than in map order: a nondeterministic error message is one a consumer's test cannot
  assert on.
- The request struct takes `RetentionInDays *int`, not `int`. The member is required and
  `0` is not a valid value, so an absent member and an explicit `0` are both errors — but
  only a pointer can tell substrate which one the caller sent, and reporting "0 is not
  valid" about a value they never sent sends them looking in the wrong place. The two
  messages are asserted separately.
- `DeleteRetentionPolicy` ships with `Put` because it is how the API says to make events
  never expire — there is no `retentionInDays` value meaning "never", so the member's
  *absence* is the signal. It is idempotent; deleting a policy that is not there is not
  an error, and a cleanup path that runs twice must not fail the second time.
- A group with no policy omits `retentionInDays` rather than reporting `0`.

## Provenance

`ResourceNotFoundException` is reported at **HTTP 400**, not 404. That is not substrate's
choice: JSON-1.1 carries the error code in the body's `__type` rather than in the status
line, and the CloudWatch Logs reference documents every error for these operations at 400.
`cwLogsErrorType` reads `__type` in the tests for the same reason — a code that reached
only the header would be invisible to a caller.

Substrate's **older** group- and stream-level not-found responses on the other Logs
operations still use 404/409. Those are wrong against the reference too, but changing
them is a wider change than this issue, so they are left alone and `docs/services.md` now
says so explicitly — the inconsistency is a stated decision, not an oversight.

## Tests

`emulator/cloudwatchlogs_casing_test.go`, 13 tests. Every assertion is on the **raw JSON
bytes**, because a Go round-trip cannot see this defect: a struct marshaled and
unmarshaled by the same definition agrees with itself whatever the casing. That is
precisely why the existing `cloudwatchlogs_plugin_test.go` passed — it declared
`struct{ LogGroupName string \`json:"LogGroupName"\` }` and thereby **encoded the defect in
its own assertion struct**. Five such structs (four in `cloudwatchlogs_plugin_test.go`,
one in `cloudwatch_extra_test.go` for Lambda's auto-created group) are retagged to
camelCase so a regression turns them red.

Each read gets a positive on the camelCase member *and* a negative on the PascalCase one,
since a body carrying both would satisfy the positive while still telling a caller
something the API never says. `TestCWLogs_FilterLogEventsStaysCorrect` guards the
operation that was already right — it is both why the defect was easy to miss and the
pattern the fix copied, so a regression there would mean the pattern itself was undone.
`TestCWLogs_CFNLogGroupRetentionIsReadable` covers the create-then-verify-then-cleanup
shape the reporting consumer's ECS path needs.

## Mutation testing

**30 mutants, 30 CAUGHT, 0 survivors, 0 equivalents.** Anchor-count assert before
applying, `gofmt -w && go vet` gate, `-race`, restore between each.

The first pass had **three real survivors**, each a test-design defect:

1. **`cwLogGroupPolicyARN`'s empty-ARN and idempotence guards** — unreachable through
   HTTP, so untested. Closed with `CWLogGroupPolicyARNForTest` and
   `CWPutLogGroupStateForTest` export seams plus `TestCWLogs_ARNlessStateReportsNoARN`,
   which carries the empty case through to the wire where it would actually be seen.
2. **`ingestionTime` set to zero** — the test asserted the member *name* was present, not
   that it carried a value. A member present with a plausible `0` behind it is the same
   silent-success failure in subtler form. Now asserted non-zero.
3. **Absent `retentionInDays` treated as an explicit `0`** — both paths returned
   `InvalidParameterException` at 400, so a code-and-status assertion could not tell them
   apart. The table now asserts the message too.

A fourth reported BROKEN rather than SURVIVED: deleting the guard left `strings` imported
and unused, so the harness measured a compile error instead of the behaviour. Rewritten to
keep the import live.

## Verification

`gofmt -l .` clean · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` → **0
issues** · `make test` (race) green · `make docs-reference docs-reference-check
docs-versions` · `npm --prefix docs run build` · `go vet -C test/e2e ./...` ·
`go test -C test/e2e ./...`

End to end against a live server (`substrate server --address :4599`), which is the
issue's own reproduction — all four reads parse, both ARN forms appear, retention
round-trips, and the CloudFormation route the issue reported is confirmed:

```
$ aws logs describe-log-groups --log-group-name-prefix /ecs/
{"logGroups": [{"logGroupName": "/ecs/e2e-worker", "creationTime": 1785748565371,
  "arn": "arn:aws:logs:us-east-1:123456789012:log-group:/ecs/e2e-worker:*",
  "logGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/ecs/e2e-worker"}]}

$ aws logs put-retention-policy --log-group-name /ecs/e2e-worker --retention-in-days 45
An error occurred (InvalidParameterException): retentionInDays value of 45 is not
valid; possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545,
731, 1096, 1827, 2192, 2557, 2922, 3288, 3653

$ aws cloudformation create-stack --stack-name lg528 --template-body file:///tmp/lg528.yml
$ aws logs describe-log-groups --log-group-name-prefix /ecs/cfn-e2e
{"logGroups": [{"logGroupName": "/ecs/cfn-e2e-family", "creationTime": 1785748582870,
  "retentionInDays": 30, "arn": "...:log-group:/ecs/cfn-e2e-family:*", ...}]}
```

## Compatibility

A consumer reading these responses through an AWS SDK sees fields appear where empty
objects were — nothing they could have been relying on, since the old members were
invisible to the SDK. A consumer parsing the raw JSON by PascalCase key must switch to the
API's names. The persisted state format is unchanged, so existing snapshots and recorded
event logs replay identically.

Closes #528
