### PR TITLE
chore(release): v0.88.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.88.0] - 2026-08-03
+
 ### Added
 - **`ListExports` and `ListImports`** (#522), which were `InvalidAction` before there
   was anything to list. `ListExports` reports every export in the caller's account
@@ -4409,7 +4411,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.87.1...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.88.0...HEAD
+[v0.88.0]: https://github.com/scttfrdmn/substrate/compare/v0.87.1...v0.88.0
 [v0.87.1]: https://github.com/scttfrdmn/substrate/compare/v0.87.0...v0.87.1
 [v0.87.0]: https://github.com/scttfrdmn/substrate/compare/v0.86.0...v0.87.0
 [v0.86.0]: https://github.com/scttfrdmn/substrate/compare/v0.85.0...v0.86.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.88.0] - 2026-08-03`, keeping the empty
`## [Unreleased]` heading above it, and adds both compare links.

v0.88.0 is **"The wire says what the API says"** — six issues, every one an instance of
the same defect shape: substrate returned HTTP 200 while the observable a caller parses
was wrong.

- #521 `Fn::Split` resolved to its first element, silently discarding the rest
- #526 an intrinsic nested inside a structured property was never resolved
- #527 a CloudFormation-deployed task definition kept CloudFormation's PascalCase keys
- #522 `Mappings`/`Fn::FindInMap`, `Fn::GetAZs`, `Fn::Cidr`, `Fn::ImportValue` and the
  four remaining pseudo-parameters
- #502 typed `StackDeployer` errors, pulled forward because #522's delete-refusal has no
  resource to blame
- #528 the CloudWatch Logs reads put PascalCase members on the wire, which an SDK parses
  to nothing

No code changes; the release tag follows this merge.