### PR TITLE
fix(s3): a directory marker must not touch the object mirror (#534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Deleting a directory-marker object no longer strands the keys beneath it**
+  (#534). `PUT dir/`, `PUT dir/a.txt`, `DELETE dir/`, `DELETE dir/a.txt` — the last
+  call returned **HTTP 500**. S3 keys are opaque strings, but the afero filesystem
+  the plugin mirrors object *bodies* into is hierarchical, and `filepath.Clean`
+  normalizes `/bucket/dir/` to `/bucket/dir`: the same path as the directory node
+  `MkdirAll` created to hold `dir/a.txt`. Removing the marker therefore removed that
+  node, orphaning its children, and the child's own delete then panicked inside
+  `MemMapFs` and surfaced as a 500. The multi-object `DeleteObjects` inherited it,
+  since it delegates per key.
+
+  The write path already had the right guard — a marker is never written to the
+  mirror, because its body is always empty — and the delete and copy paths simply
+  did not. All six sites now go through one `s3ObjectHasBody(key)` predicate rather
+  than four hand-copied `strings.HasSuffix` checks, which is the drift that produced
+  the bug. This also closes two adjacent cases the reproduction did not name: `dir`
+  and `dir/` are **distinct S3 keys** that collide on a single mirror path, so a
+  marker operation used to truncate or delete the body of the object one character
+  away from it; and a marker's versioned path `.versions/dir//<versionID>`
+  normalizes onto the directory holding the versions of a child key named
+  `dir/<versionID>` — reachable, not theoretical, since a client reads that version
+  ID off the marker's own `PUT` response. `CopyObject` over a marker now succeeds
+  in both directions, yielding the empty object a marker is, where reading one as a
+  source used to fail outright.
+
 ## [v0.88.0] - 2026-08-03
 
 ### Added

--- a/emulator/s3_directory_marker_test.go
+++ b/emulator/s3_directory_marker_test.go
@@ -1,0 +1,398 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// Regression tests for #534: deleting a directory-marker object ("prefix/")
+// removed the afero directory node that holds the keys beneath it, so the next
+// delete of a child panicked inside MemMapFs and surfaced as a 500.
+//
+// The invariant these assert is that the afero mirror holds object *bodies*, and
+// a marker has none: no marker key may reach the filesystem on any path.
+
+// TestS3_DirectoryMarker_DeleteDoesNotStrandChildren walks the reproduction from
+// the issue — create a marker, create a key beneath it, delete the marker, then
+// delete the child.
+func TestS3_DirectoryMarker_DeleteDoesNotStrandChildren(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/marker-del", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/marker-del/dir/", []byte{}, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/marker-del/dir/a.txt", []byte("a"), nil).Code)
+
+	assert.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/marker-del/dir/", nil, nil).Code,
+		"deleting the marker must succeed")
+
+	assert.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/marker-del/dir/a.txt", nil, nil).Code,
+		"deleting the child after its marker must not fail: the marker's delete "+
+			"must not have removed the directory node the child lives in")
+
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodGet, "/marker-del/dir/a.txt", nil, nil).Code)
+}
+
+// TestS3_DirectoryMarker_DeleteObjectsDoesNotStrandChildren asserts the same
+// through the multi-object delete, which routes per key through deleteObject and
+// so inherited the identical failure. Marker first in the batch, so the child's
+// delete follows it within one request.
+func TestS3_DirectoryMarker_DeleteObjectsDoesNotStrandChildren(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/marker-batch", nil, nil)
+	s3Request(t, srv, http.MethodPut, "/marker-batch/dir/", []byte{}, nil)
+	s3Request(t, srv, http.MethodPut, "/marker-batch/dir/a.txt", []byte("a"), nil)
+	s3Request(t, srv, http.MethodPut, "/marker-batch/dir/b.txt", []byte("b"), nil)
+
+	deleteXML := []byte(`<Delete>` +
+		`<Object><Key>dir/</Key></Object>` +
+		`<Object><Key>dir/a.txt</Key></Object>` +
+		`<Object><Key>dir/b.txt</Key></Object>` +
+		`</Delete>`)
+	w := s3Request(t, srv, http.MethodPost, "/marker-batch?delete", deleteXML,
+		map[string]string{"Content-Type": "application/xml"})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var result struct {
+		Deleted []struct {
+			Key string `xml:"Key"`
+		} `xml:"Deleted"`
+		Errors []struct {
+			Key  string `xml:"Key"`
+			Code string `xml:"Code"`
+		} `xml:"Error"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &result))
+	assert.Empty(t, result.Errors, "no key in the batch may report an error")
+	assert.Len(t, result.Deleted, 3)
+}
+
+// TestS3_DirectoryMarker_DeleteThenReadChild asserts the child is still readable
+// after its marker is deleted. Deleting a marker deletes one zero-byte object; it
+// says nothing about the keys that share its prefix.
+func TestS3_DirectoryMarker_DeleteThenReadChild(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/marker-read", nil, nil)
+	s3Request(t, srv, http.MethodPut, "/marker-read/dir/", []byte{}, nil)
+	s3Request(t, srv, http.MethodPut, "/marker-read/dir/a.txt", []byte("payload"), nil)
+
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/marker-read/dir/", nil, nil).Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/marker-read/dir/a.txt", nil, nil)
+	assert.Equal(t, http.StatusOK, w.Code, "the child outlives its marker")
+	assert.Equal(t, "payload", w.Body.String())
+
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodGet, "/marker-read/dir/", nil, nil).Code,
+		"the marker itself is gone")
+}
+
+// TestS3_DirectoryMarker_DeleteLeavesFilesystemIntact inspects the afero mirror
+// directly: the marker was never written to it, so its delete must leave the
+// directory node MkdirAll created for the child untouched.
+func TestS3_DirectoryMarker_DeleteLeavesFilesystemIntact(t *testing.T) {
+	t.Parallel()
+	srv, fs := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/marker-fs", nil, nil)
+	s3Request(t, srv, http.MethodPut, "/marker-fs/dir/", []byte{}, nil)
+	s3Request(t, srv, http.MethodPut, "/marker-fs/dir/a.txt", []byte("a"), nil)
+
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/marker-fs/dir/", nil, nil).Code)
+
+	exists, err := afero.DirExists(fs, "/marker-fs/dir")
+	require.NoError(t, err)
+	assert.True(t, exists, "the directory node holding the child must survive the marker's delete")
+
+	body, readErr := afero.ReadFile(fs, "/marker-fs/dir/a.txt")
+	require.NoError(t, readErr)
+	assert.Equal(t, "a", string(body))
+}
+
+// TestS3_DirectoryMarker_VersionedDelete covers the versioned branches: a marker
+// written and permanently deleted by version ID must not touch the mirror either,
+// since its versioned path collides the same way.
+func TestS3_DirectoryMarker_VersionedDelete(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/marker-ver", nil, nil)
+	s3Request(t, srv, http.MethodPut, "/marker-ver?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+
+	w := s3Request(t, srv, http.MethodPut, "/marker-ver/dir/", []byte{}, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	versionID := w.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, versionID)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/marker-ver/dir/a.txt", []byte("a"), nil).Code)
+
+	assert.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/marker-ver/dir/?versionId="+versionID, nil, nil).Code,
+		"permanently deleting the marker version must succeed")
+
+	w = s3Request(t, srv, http.MethodGet, "/marker-ver/dir/a.txt", nil, nil)
+	assert.Equal(t, http.StatusOK, w.Code, "the child must remain readable")
+	assert.Equal(t, "a", w.Body.String())
+}
+
+// TestS3_DirectoryMarker_WritesNoFileToTheMirror asserts the invariant the whole
+// fix rests on, directly rather than through a symptom: a marker's PUT writes no
+// file to the afero mirror. Both the unversioned and versioned write paths are
+// covered, since each builds its own path from the key.
+func TestS3_DirectoryMarker_WritesNoFileToTheMirror(t *testing.T) {
+	t.Parallel()
+
+	for _, versioned := range []bool{false, true} {
+		name := "unversioned"
+		bucket := "mirror-unver"
+		if versioned {
+			name = "versioned"
+			bucket = "mirror-ver"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			srv, fs := newS3TestServer(t)
+
+			s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil)
+			if versioned {
+				s3Request(t, srv, http.MethodPut, "/"+bucket+"?versioning",
+					[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+			}
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/"+bucket+"/dir/", []byte{}, nil).Code)
+
+			// Walk from the root: a marker-only bucket need not have a directory
+			// node at all, and asserting on "/"+bucket would fail for the right
+			// reason in a confusing way.
+			var files []string
+			walkErr := afero.Walk(fs, "/", func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if !info.IsDir() {
+					files = append(files, path)
+				}
+				return nil
+			})
+			require.NoError(t, walkErr)
+			assert.Empty(t, files,
+				"a directory marker has no body, so it must put no file in the mirror")
+		})
+	}
+}
+
+// TestS3_DirectoryMarker_VersionedDeleteDoesNotStrandChildVersions pins the
+// versioned mirror's own instance of the collision. A marker's versioned path is
+// "<bucket>/.versions/<key>/<versionID>", which for key "dir/" normalizes to
+// ".../dir/<versionID>" — exactly the directory node holding the versions of a
+// child key literally named "dir/<versionID>". The version ID is not secret: a
+// client reads it off the marker's PUT, so this sequence is reachable rather than
+// theoretical.
+func TestS3_DirectoryMarker_VersionedDeleteDoesNotStrandChildVersions(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/marker-vercollide", nil, nil)
+	s3Request(t, srv, http.MethodPut, "/marker-vercollide?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+
+	w := s3Request(t, srv, http.MethodPut, "/marker-vercollide/dir/", []byte{}, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	markerVersion := w.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, markerVersion)
+
+	// A child key named after the marker's version ID. Legal S3, and its versioned
+	// mirror path is the directory the marker's version path names.
+	child := "dir/" + markerVersion
+	cw := s3Request(t, srv, http.MethodPut, "/marker-vercollide/"+child, []byte("child"), nil)
+	require.Equal(t, http.StatusOK, cw.Code)
+	childVersion := cw.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, childVersion)
+
+	assert.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete,
+			"/marker-vercollide/dir/?versionId="+markerVersion, nil, nil).Code)
+
+	// Reading the child by explicit version ID goes to the mirror path under the
+	// directory node the marker's delete named.
+	got := s3Request(t, srv, http.MethodGet,
+		"/marker-vercollide/"+child+"?versionId="+childVersion, nil, nil)
+	assert.Equal(t, http.StatusOK, got.Code, "the child's version must survive")
+	assert.Equal(t, "child", got.Body.String())
+
+	// And permanently deleting that version must still work: this is the call that
+	// removes the child's own mirror entry, so it is where a stranded node bites.
+	assert.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete,
+			"/marker-vercollide/"+child+"?versionId="+childVersion, nil, nil).Code,
+		"the child's version must still be permanently deletable")
+}
+
+// TestS3_DirectoryMarker_SiblingKeyIsNotClobbered pins the collision from the
+// other side. "dir" and "dir/" are two distinct S3 keys, but filepath.Clean maps
+// both to the same mirror path — so a marker that reaches the filesystem truncates
+// or deletes the body of the object one character away from it. Each step is a
+// separate operation on the marker; the object at "dir" must be unaffected by all
+// of them.
+func TestS3_DirectoryMarker_SiblingKeyIsNotClobbered(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// act performs one marker operation against bucket "sibling".
+		act func(t *testing.T, srv *emulator.Server)
+	}{
+		{
+			name: "put the marker",
+			act: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				assert.Equal(t, http.StatusOK,
+					s3Request(t, srv, http.MethodPut, "/sibling/dir/", []byte{}, nil).Code)
+			},
+		},
+		{
+			name: "put then delete the marker",
+			act: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				s3Request(t, srv, http.MethodPut, "/sibling/dir/", []byte{}, nil)
+				assert.Equal(t, http.StatusNoContent,
+					s3Request(t, srv, http.MethodDelete, "/sibling/dir/", nil, nil).Code)
+			},
+		},
+		{
+			name: "delete a marker that was never written",
+			act: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				// S3's DELETE is idempotent, so this is a 204 either way — the
+				// point is that it must not reach the mirror.
+				assert.Equal(t, http.StatusNoContent,
+					s3Request(t, srv, http.MethodDelete, "/sibling/dir/", nil, nil).Code)
+			},
+		},
+		{
+			name: "copy onto the marker",
+			act: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				s3Request(t, srv, http.MethodPut, "/sibling/other.txt", []byte("other"), nil)
+				assert.Equal(t, http.StatusOK,
+					s3Request(t, srv, http.MethodPut, "/sibling/dir/", nil,
+						map[string]string{"x-amz-copy-source": "/sibling/other.txt"}).Code)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+
+			s3Request(t, srv, http.MethodPut, "/sibling", nil, nil)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/sibling/dir", []byte("real body"), nil).Code)
+
+			tt.act(t, srv)
+
+			w := s3Request(t, srv, http.MethodGet, "/sibling/dir", nil, nil)
+			assert.Equal(t, http.StatusOK, w.Code, `the object at key "dir" must survive`)
+			assert.Equal(t, "real body", w.Body.String(),
+				`the object at key "dir" must keep its body: "dir/" is a different key`)
+		})
+	}
+}
+
+// TestS3_DirectoryMarker_Copy asserts CopyObject over marker keys. A marker has no
+// body in the mirror, so both directions had to be guarded independently: reading
+// one as a source used to fail on ReadFile, and writing one as a destination would
+// corrupt the directory node for the keys beneath it.
+func TestS3_DirectoryMarker_Copy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		srcKey  string
+		dstKey  string
+		srcBody []byte
+		// wantBody is what a GET of the destination must return. A marker
+		// destination is an empty object regardless of the source.
+		wantBody string
+	}{
+		{
+			name:     "marker to marker",
+			srcKey:   "dir/",
+			dstKey:   "copied/",
+			srcBody:  []byte{},
+			wantBody: "",
+		},
+		{
+			name:     "marker to regular key",
+			srcKey:   "dir/",
+			dstKey:   "flattened.txt",
+			srcBody:  []byte{},
+			wantBody: "",
+		},
+		{
+			name:     "regular key to marker",
+			srcKey:   "src.txt",
+			dstKey:   "dir2/",
+			srcBody:  []byte("content"),
+			wantBody: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+
+			s3Request(t, srv, http.MethodPut, "/marker-copy", nil, nil)
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/marker-copy/"+tt.srcKey, tt.srcBody, nil).Code)
+			// A key beneath the destination prefix, so a mishandled destination
+			// write would corrupt a directory node that is actually in use.
+			s3Request(t, srv, http.MethodPut, "/marker-copy/dir2/child.txt", []byte("c"), nil)
+
+			w := s3Request(t, srv, http.MethodPut, "/marker-copy/"+tt.dstKey, nil,
+				map[string]string{"x-amz-copy-source": "/marker-copy/" + tt.srcKey})
+			assert.Equal(t, http.StatusOK, w.Code, "CopyObject must succeed")
+
+			got := s3Request(t, srv, http.MethodGet, "/marker-copy/"+tt.dstKey, nil, nil)
+			assert.Equal(t, http.StatusOK, got.Code)
+			assert.Equal(t, tt.wantBody, got.Body.String())
+
+			// The unrelated key beneath dir2/ is untouched either way.
+			child := s3Request(t, srv, http.MethodGet, "/marker-copy/dir2/child.txt", nil, nil)
+			assert.Equal(t, http.StatusOK, child.Code)
+			assert.Equal(t, "c", child.Body.String())
+
+			// And it is still deletable. This is the assertion that makes a bad
+			// destination write observable: writing a marker key into the mirror
+			// replaces the directory node dir2/child.txt lives in with a file, and
+			// the corruption only surfaces when something removes the child.
+			assert.Equal(t, http.StatusNoContent,
+				s3Request(t, srv, http.MethodDelete, "/marker-copy/dir2/child.txt", nil, nil).Code)
+		})
+	}
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -581,6 +581,19 @@ func (p *S3Plugin) deleteBucket(_ *RequestContext, _ *AWSRequest, bucket string)
 	return &AWSResponse{StatusCode: http.StatusNoContent, Headers: map[string]string{}}, nil
 }
 
+// s3ObjectHasBody reports whether an object key has a body stored in the afero
+// filesystem the plugin mirrors object contents into.
+//
+// The mirror holds bodies only. A key ending in "/" is a directory marker: it has
+// no body, and its filesystem path collides with the directory node MkdirAll
+// created for the keys beneath it — so writing one corrupts that node and removing
+// one deletes it, stranding every child. Every path that touches the mirror for a
+// named object key must be gated on this, which is why it is one function rather
+// than a strings.HasSuffix at each site.
+func s3ObjectHasBody(key string) bool {
+	return !strings.HasSuffix(key, "/")
+}
+
 // putObject handles PUT /<bucket>/<key>.
 func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, key string) (*AWSResponse, error) {
 	ctx := context.Background()
@@ -648,11 +661,7 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		return cksErr, nil
 	}
 
-	// Directory-marker objects (key ends with "/") must not be written to the
-	// afero filesystem: filepath.Clean inside MemMapFs would strip the trailing
-	// slash, corrupting the path and conflicting with real sub-key directories.
-	// State metadata is sufficient for directory markers (body is always empty).
-	if !strings.HasSuffix(key, "/") {
+	if s3ObjectHasBody(key) {
 		filePath := "/" + bucket + "/" + key
 		if mkdirErr := p.fs.MkdirAll(filepath.Dir(filePath), 0o755); mkdirErr != nil {
 			return nil, fmt.Errorf("mkdir: %w", mkdirErr)
@@ -699,8 +708,7 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 		versionID := fmt.Sprintf("v%d-%d", p.tc.Now().UnixNano(), atomic.AddInt64(&p.versionSeq, 1))
 		obj.VersionID = versionID
 		// Write body to version-specific filesystem path.
-		// Skip filesystem for directory-marker keys (same reason as above).
-		if !strings.HasSuffix(key, "/") {
+		if s3ObjectHasBody(key) {
 			vfPath := "/" + bucket + "/.versions/" + key + "/" + versionID
 			if mkErr := p.fs.MkdirAll(filepath.Dir(vfPath), 0o755); mkErr != nil {
 				return nil, fmt.Errorf("mkdir versioned path: %w", mkErr)
@@ -804,9 +812,7 @@ func (p *S3Plugin) getObject(_ *RequestContext, req *AWSRequest, bucket, key str
 			return s3DeleteMarkerResponse(versionID != "", obj.VersionID), nil
 		}
 
-		// Directory-marker objects (key ends with "/") are never written to the
-		// afero filesystem; their body is always empty.
-		if !strings.HasSuffix(key, "/") {
+		if s3ObjectHasBody(key) {
 			// Try versioned fs path first, then fallback to main path.
 			var readErr error
 			body, readErr = afero.ReadFile(p.fs, fsPath)
@@ -949,7 +955,9 @@ func (p *S3Plugin) deleteObject(reqCtx *RequestContext, req *AWSRequest, bucket,
 		// Permanently remove a specific version.
 		versionedKey := "object_version:" + bucket + "/" + key + "/" + versionID
 		_ = p.state.Delete(ctx, s3Namespace, versionedKey)
-		_ = p.fs.Remove("/" + bucket + "/.versions/" + key + "/" + versionID)
+		if s3ObjectHasBody(key) {
+			_ = p.fs.Remove("/" + bucket + "/.versions/" + key + "/" + versionID)
+		}
 		// Remove from version list.
 		vids := p.loadVersionIDs(ctx, bucket, key)
 		filtered := vids[:0]
@@ -1001,7 +1009,9 @@ func (p *S3Plugin) deleteObject(reqCtx *RequestContext, req *AWSRequest, bucket,
 	}
 
 	_ = p.state.Delete(ctx, s3Namespace, "object:"+bucket+"/"+key)
-	_ = p.fs.Remove("/" + bucket + "/" + key)
+	if s3ObjectHasBody(key) {
+		_ = p.fs.Remove("/" + bucket + "/" + key)
+	}
 
 	p.fireNotifications(reqCtx, bucket, key, "s3:ObjectRemoved:Delete", 0, "")
 
@@ -1207,17 +1217,28 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 		}
 	}
 
-	srcBody, readErr := afero.ReadFile(p.fs, "/"+srcBucket+"/"+srcKey)
-	if readErr != nil {
-		return nil, fmt.Errorf("read source body: %w", readErr)
+	// Source and destination are guarded independently: copying a marker onto a
+	// regular key yields the empty object the marker is, and copying anything onto a
+	// marker key records only state. srcBody stays nil for a marker source, which is
+	// the body it has, so the ETag and checksum below are computed over the right
+	// bytes either way.
+	var srcBody []byte
+	if s3ObjectHasBody(srcKey) {
+		read, readErr := afero.ReadFile(p.fs, "/"+srcBucket+"/"+srcKey)
+		if readErr != nil {
+			return nil, fmt.Errorf("read source body: %w", readErr)
+		}
+		srcBody = read
 	}
 
-	dstFilePath := "/" + dstBucket + "/" + dstKey
-	if mkdirErr := p.fs.MkdirAll(filepath.Dir(dstFilePath), 0o755); mkdirErr != nil {
-		return nil, fmt.Errorf("mkdir dest: %w", mkdirErr)
-	}
-	if writeErr := afero.WriteFile(p.fs, dstFilePath, srcBody, 0o644); writeErr != nil {
-		return nil, fmt.Errorf("write dest body: %w", writeErr)
+	if s3ObjectHasBody(dstKey) {
+		dstFilePath := "/" + dstBucket + "/" + dstKey
+		if mkdirErr := p.fs.MkdirAll(filepath.Dir(dstFilePath), 0o755); mkdirErr != nil {
+			return nil, fmt.Errorf("mkdir dest: %w", mkdirErr)
+		}
+		if writeErr := afero.WriteFile(p.fs, dstFilePath, srcBody, 0o644); writeErr != nil {
+			return nil, fmt.Errorf("write dest body: %w", writeErr)
+		}
 	}
 
 	now := p.tc.Now()


### PR DESCRIPTION
Closes #534.

`PUT dir/`, `PUT dir/a.txt`, `DELETE dir/`, `DELETE dir/a.txt` — the last call
returned **HTTP 500**, reproduced end to end against a binary built from `v0.88.0`:

```
$ aws s3api delete-object --bucket probe534 --key dir/a.txt
aws: [ERROR]: An error occurred (500) when calling the DeleteObject operation
  (reached max retries: 2): Internal Server Error
```

## Why

S3 keys are opaque strings, but the afero filesystem the plugin mirrors object
*bodies* into is hierarchical, and `filepath.Clean` normalizes `/bucket/dir/` to
`/bucket/dir` — the same path as the directory node `MkdirAll` created to hold
`dir/a.txt`. Removing the marker removed that node, orphaning its children, and the
child's own delete then hit `log.Panic` in `unRegisterWithParent`
(`memmap.go:73`), recovered as a 500. `DeleteObjects` inherited it, since it
delegates per key.

I verified the mechanism against afero v1.15.0 using substrate's *actual* call
pattern rather than the issue's simplified one, which matters: the marker is
already never written to the mirror, so the node that gets destroyed is the one
created implicitly for the **child**, not the marker's own file.

## The fix — option 1 from the issue, not option 2

The write path already had the right guard; the delete and copy paths did not. All
six sites now go through one predicate:

```go
// s3ObjectHasBody reports whether an object key has a body stored in the afero
// filesystem the plugin mirrors object contents into.
//
// The mirror holds bodies only. A key ending in "/" is a directory marker: it has
// no body, and its filesystem path collides with the directory node MkdirAll
// created for the keys beneath it …
```

One function rather than a fourth hand-copied `strings.HasSuffix` — the drift
between three guarded sites and three unguarded ones is what produced this bug. No
new encoding is introduced, which is why option 2 (a distinct on-disk
representation for markers) is not needed: skipping the mirror *restores* the
invariant the write path already assumed.

## Two adjacent cases the reproduction does not name

Both surfaced from mutation testing, and both are reachable:

1. **`dir` and `dir/` are distinct S3 keys** that collide on a single mirror path.
   Before this change, putting, deleting, or copying onto the marker `dir/`
   truncated or deleted the body of the ordinary object at `dir`. This is the
   sharper test: it needs no children at all.
2. **A marker's versioned path collides too.** `.versions/dir//<versionID>`
   normalizes onto the directory holding the versions of a child key named
   `dir/<versionID>`. That is not theoretical — a client reads the version ID off
   the marker's own `PUT` response, so the sequence is constructible.

`CopyObject` over a marker now succeeds in both directions, yielding the empty
object a marker is; reading one as a source used to fail outright on `ReadFile`.
Source and destination are guarded independently so a marker→regular copy produces
an empty object rather than an error.

## Tests

`emulator/s3_directory_marker_test.go`, all failing before the change:

| Test | Asserts |
|---|---|
| `DeleteDoesNotStrandChildren` | the issue's reproduction: the child's delete is **204**, was a panic |
| `DeleteObjectsDoesNotStrandChildren` | the same within one multi-object delete, marker first in the batch |
| `DeleteThenReadChild` | a child outlives its marker — deleting `dir/` deletes one zero-byte object |
| `DeleteLeavesFilesystemIntact` | the mirror directly: the child's directory node survives |
| `WritesNoFileToTheMirror` | the invariant itself, walked from the root, versioned and not |
| `VersionedDeleteDoesNotStrandChildVersions` | case 2 above, end to end through the API |
| `SiblingKeyIsNotClobbered` | case 1 above, table-driven over put / delete / delete-absent / copy |
| `Copy` | marker→marker, marker→key, key→marker; each leaves an unrelated child intact and deletable |

## Mutation testing

Ten mutants across the predicate and all six guard sites — inverted, always-true,
always-false, and each guard dropped in turn. **All caught, no survivors.**

Three survived initially and each was a genuine test-design gap rather than an
equivalence, so the tests were strengthened rather than the mutants excused:
dropping the `copyObject` destination guard and the `putObject` write guard were
both invisible until `SiblingKeyIsNotClobbered` existed (the corruption only bites
on a later `Remove`, which no test performed), and dropping the versioned-delete
guard needed `VersionedDeleteDoesNotStrandChildVersions` asserting on the child's
*permanent* version delete — the call that actually reaches `fs.Remove`.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0
issues**, `make test` (race), `make docs-reference docs-reference-check
docs-versions` (no diff — no plugin added), `npm --prefix docs run build`,
`go vet -C test/e2e ./...`, `go test -C test/e2e ./...`. Plus the end-to-end
sequence above against `substrate server`, which now returns a clean 204 and an
empty bucket listing.

## Compatibility

No state-format change, so existing snapshots and recorded event logs replay
identically. A caller that was receiving a 500 now receives the documented
response; nothing that previously succeeded changes behaviour.
