### PR TITLE
fix(s3): DeleteBucket clears the bucket's namespace (#508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`DeleteBucket` now clears the bucket's namespace instead of only its `bucket:`
+  record** (#508). A bucket-scoped configuration is keyed by bucket name alone, so
+  every one of them outlived its bucket and was inherited by the next bucket created
+  with that name: create a bucket, enable versioning, delete it, create it again, and
+  writes to the "new" bucket came back versioned. All six are now cleared —
+  `bucket_acl:`, `bucket_policy:`, `bucket_lifecycle:`, `bucket_versioning:`,
+  `notification:`, `bucket_public_access_block:`. Two corrections to the issue's
+  table: the notification prefix is `notification:`, not `bucket_notification:`, and
+  **bucket tagging never leaked**, because `PutBucketTagging` writes `Tags` into the
+  `bucket:` record rather than under a key of its own.
+
+  Errors **propagate** and the `bucket:` record is deleted **last**, so a failed
+  clear leaves the bucket present and retryable rather than half-deleted. A
+  discarded `Delete` error is how the leak went unnoticed in the first place.
+
+  Object-scoped leftovers go too. An object ACL and a version index are stored under
+  their own keys and outlive the object they describe, so an *empty* bucket could
+  still own state that a recreated bucket inherited.
+
+- **`DeleteBucket`'s emptiness check counted only live objects** (#508, found while
+  fixing it and not reported in the issue). "All objects (including all object
+  versions and delete markers) in the bucket must be deleted before the bucket
+  itself can be deleted", but the check listed only `object:<bucket>/`, so a bucket
+  holding nothing but a deleted object's history deleted "successfully" and stranded
+  every version. It now counts `object_version:` too, which covers both noncurrent
+  versions and delete markers. The sharpest case is a **versioning-suspended**
+  bucket: substrate's `DELETE` removes the current-version pointer outright there,
+  so the bucket looked empty while the version it wrote was still present — and real
+  S3 keeps that version as well, since "when you suspend versioning, existing
+  objects in your bucket do not change".
+
+  In-flight multipart uploads are **aborted rather than refused**, correcting this
+  release's own plan. The refusal is documented for *directory* buckets, which
+  substrate does not model; for general purpose buckets the reference only
+  recommends that you "remove all incomplete multipart uploads" while emptying. An
+  upload whose destination bucket is gone can never be completed, so the delete
+  aborts it — part records, upload record and part bodies — through the same helper
+  `AbortMultipartUpload` now uses, so the two paths cannot leave different residue.
+  Only uploads whose `Bucket` field names the bucket being deleted are touched; an
+  upload is keyed by upload ID alone, so the scan sees every bucket's.
+
+- **Permanently deleting an object version now updates the current-version pointer**
+  (#508). Deleting a version by ID removed its record and left the `object:` pointer
+  stale, which made a versioned bucket impossible to empty — so `DeleteBucket`'s
+  widened emptiness check could never have been satisfied. Deleting the current
+  version promotes the next one, since "if you delete the current object version,
+  ... the version that is next in the version stack becomes the current version";
+  deleting the last version removes the key entirely. The promoted version's **body**
+  moves with its record: a versioned `PUT` writes the body both under
+  `.versions/<key>/<versionID>` and at the unversioned path an unversioned `GET`
+  reads, so promoting the record alone served the deleted version's bytes under the
+  promoted version's ETag. A delete marker has no body to promote, which an absent
+  versioned body is treated as rather than as an error, and the promotion honours
+  #534's `s3ObjectHasBody` guard — afero reads a directory as an empty body with no
+  error, so an unguarded promote would truncate the object at `dir` while promoting a
+  version of the marker `dir/`.
+
 - **Deleting a directory-marker object no longer strands the keys beneath it**
   (#534). `PUT dir/`, `PUT dir/a.txt`, `DELETE dir/`, `DELETE dir/a.txt` — the last
   call returned **HTTP 500**. S3 keys are opaque strings, but the afero filesystem

--- a/emulator/s3_delete_bucket_faults_test.go
+++ b/emulator/s3_delete_bucket_faults_test.go
@@ -1,0 +1,605 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// Fault-injection tests for #508's propagation rule: every store or filesystem
+// failure along DeleteBucket's clear, and along the current-version promotion, must
+// surface as a 500 and leave the bucket present rather than being swallowed into a
+// 204 that reports a teardown which did not happen. A partial clear is precisely
+// the bug being fixed, so a discarded error here would hide a recurrence.
+//
+// [pabFaultState] in s3_publicaccessblock_test.go targets a single exact key and
+// passes List straight through. These paths scan by prefix and delete keys whose
+// names are generated at request time, so the store here matches on a prefix and
+// can fail List too.
+
+// s3PrefixFaultState fails one operation for every key under a prefix once armed,
+// leaving every other key working. Arming is deferred for the same reason
+// [pabFaultState] defers it: setting the bucket up touches the keys under test, so
+// a store that fails from construction never gets a bucket to delete.
+type s3PrefixFaultState struct {
+	inner    emulator.StateManager
+	prefix   string
+	err      error
+	armed    bool
+	onGet    bool
+	onPut    bool
+	onDelete bool
+	onList   bool
+}
+
+func (m *s3PrefixFaultState) fails(key string, op bool) bool {
+	return m.armed && op && strings.HasPrefix(key, m.prefix)
+}
+
+func (m *s3PrefixFaultState) Get(ctx context.Context, namespace, key string) ([]byte, error) {
+	if m.fails(key, m.onGet) {
+		return nil, m.err
+	}
+	return m.inner.Get(ctx, namespace, key)
+}
+
+func (m *s3PrefixFaultState) Put(ctx context.Context, namespace, key string, value []byte) error {
+	if m.fails(key, m.onPut) {
+		return m.err
+	}
+	return m.inner.Put(ctx, namespace, key, value)
+}
+
+func (m *s3PrefixFaultState) Delete(ctx context.Context, namespace, key string) error {
+	if m.fails(key, m.onDelete) {
+		return m.err
+	}
+	return m.inner.Delete(ctx, namespace, key)
+}
+
+func (m *s3PrefixFaultState) List(ctx context.Context, namespace, prefix string) ([]string, error) {
+	if m.fails(prefix, m.onList) {
+		return nil, m.err
+	}
+	return m.inner.List(ctx, namespace, prefix)
+}
+
+// s3CorruptState returns a value that is not valid JSON for keys under a prefix,
+// which is how a record written by a different schema reads back. The scan over
+// multipart: unmarshals every record it finds, so this reaches an unmarshal failure
+// that a consistent store cannot produce.
+type s3CorruptState struct {
+	emulator.StateManager
+	prefix string
+	armed  bool
+}
+
+func (m *s3CorruptState) Get(ctx context.Context, namespace, key string) ([]byte, error) {
+	if m.armed && strings.HasPrefix(key, m.prefix) {
+		return []byte("{not json"), nil
+	}
+	return m.StateManager.Get(ctx, namespace, key)
+}
+
+// s3VanishingState reports keys from List but nil from Get for a prefix, the shape a
+// key removed between the two calls has.
+type s3VanishingState struct {
+	emulator.StateManager
+	prefix string
+	armed  bool
+}
+
+func (m *s3VanishingState) Get(ctx context.Context, namespace, key string) ([]byte, error) {
+	if m.armed && strings.HasPrefix(key, m.prefix) {
+		return nil, nil
+	}
+	return m.StateManager.Get(ctx, namespace, key)
+}
+
+// s3FaultFs fails one filesystem operation once armed. The object mirror is the
+// other half of the state these paths clear, and a failure there leaks exactly what
+// a failure in the store leaks — an upload's part bodies, or an object body left
+// describing a version that was deleted — so it has to propagate the same way.
+//
+// One operation is selected per test rather than all writes at once because the
+// promotion performs MkdirAll and then WriteFile: failing both would only ever
+// exercise the first.
+type s3FaultFs struct {
+	afero.Fs
+	err           error
+	armed         bool
+	failOpen      bool
+	failOpenFile  bool
+	failMkdirAll  bool
+	failRemove    bool
+	failRemoveAll bool
+}
+
+func (f *s3FaultFs) Open(name string) (afero.File, error) {
+	if f.armed && f.failOpen {
+		return nil, f.err
+	}
+	return f.Fs.Open(name)
+}
+
+func (f *s3FaultFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if f.armed && f.failOpenFile {
+		return nil, f.err
+	}
+	return f.Fs.OpenFile(name, flag, perm)
+}
+
+func (f *s3FaultFs) MkdirAll(path string, perm os.FileMode) error {
+	if f.armed && f.failMkdirAll {
+		return f.err
+	}
+	return f.Fs.MkdirAll(path, perm)
+}
+
+func (f *s3FaultFs) Remove(name string) error {
+	if f.armed && f.failRemove {
+		return f.err
+	}
+	return f.Fs.Remove(name)
+}
+
+func (f *s3FaultFs) RemoveAll(path string) error {
+	if f.armed && f.failRemoveAll {
+		return f.err
+	}
+	return f.Fs.RemoveAll(path)
+}
+
+// TestS3_DeleteBucket_StateFaultsPropagate walks each store operation DeleteBucket's
+// clear performs and requires a 500 with the bucket left in place.
+//
+// The bucket is asserted to survive in every case, not merely reported as failed: a
+// caller that retries must find something to retry against, and HeadBucket must
+// agree with the error rather than contradict it.
+func TestS3_DeleteBucket_StateFaultsPropagate(t *testing.T) {
+	const bucket = "faultbucket"
+
+	tests := []struct {
+		name string
+		// prefix is the state-key prefix whose operations fail.
+		prefix   string
+		onGet    bool
+		onDelete bool
+		onList   bool
+		// seed leaves the state the fault needs something to act on. Any state it
+		// creates is in place before the store is armed.
+		seed func(t *testing.T, srv *emulator.Server)
+	}{
+		{
+			// The lookup that precedes the clear: a store failure reading the
+			// bucket record must not be reported as this bucket's own NoSuchBucket,
+			// which would tell a caller the teardown was already done.
+			name:   "reading the bucket record fails",
+			prefix: "bucket:" + bucket,
+			onGet:  true,
+		},
+		{
+			name:   "listing live objects fails",
+			prefix: "object:" + bucket + "/",
+			onList: true,
+		},
+		{
+			name:   "listing object versions fails",
+			prefix: "object_version:" + bucket + "/",
+			onList: true,
+		},
+		{
+			name:   "listing object ACLs fails",
+			prefix: "object_acl:" + bucket + "/",
+			onList: true,
+		},
+		{
+			name:   "listing version indexes fails",
+			prefix: "object_versions:" + bucket + "/",
+			onList: true,
+		},
+		{
+			name:     "deleting a stranded object ACL fails",
+			prefix:   "object_acl:" + bucket + "/",
+			onDelete: true,
+			seed:     seedS3StrandedObjectACL(bucket),
+		},
+		{
+			name:   "listing multipart uploads fails",
+			prefix: "multipart:",
+			onList: true,
+		},
+		{
+			name:   "reading a multipart upload fails",
+			prefix: "multipart:",
+			onGet:  true,
+			seed:   seedS3MultipartUpload(bucket, false),
+		},
+		{
+			name:     "deleting a multipart upload record fails",
+			prefix:   "multipart:",
+			onDelete: true,
+			seed:     seedS3MultipartUpload(bucket, false),
+		},
+		{
+			name:   "listing an upload's parts fails",
+			prefix: "part:",
+			onList: true,
+			seed:   seedS3MultipartUpload(bucket, false),
+		},
+		{
+			name:     "deleting an upload's part record fails",
+			prefix:   "part:",
+			onDelete: true,
+			seed:     seedS3MultipartUpload(bucket, true),
+		},
+		{
+			name:     "deleting the bucket record itself fails",
+			prefix:   "bucket:" + bucket,
+			onDelete: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &s3PrefixFaultState{
+				inner:    emulator.NewMemoryStateManager(),
+				prefix:   tt.prefix,
+				err:      errors.New("state store unavailable"),
+				onGet:    tt.onGet,
+				onDelete: tt.onDelete,
+				onList:   tt.onList,
+			}
+			srv := newS3TestServerWithState(t, state)
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code)
+			if tt.seed != nil {
+				tt.seed(t, srv)
+			}
+
+			state.armed = true
+			w := s3Request(t, srv, http.MethodDelete, "/"+bucket, nil, nil)
+			assert.Equal(t, http.StatusInternalServerError, w.Code,
+				"a store failure must be reported, not swallowed: %s", w.Body.String())
+
+			state.armed = false
+			assert.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodHead, "/"+bucket, nil, nil).Code,
+				"a failed DeleteBucket must leave the bucket present")
+		})
+	}
+}
+
+// TestS3_DeleteBucket_AbsentBucketIsNotFound pins the other outcome the lookup can
+// have. It is the boundary the fault test above sits against: a bucket that is
+// genuinely absent is a 404, and only a store that cannot answer is a 500 — so the
+// clear never runs against a name that was never a bucket.
+func TestS3_DeleteBucket_AbsentBucketIsNotFound(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	w := s3Request(t, srv, http.MethodDelete, "/neverexisted", nil, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "NoSuchBucket")
+}
+
+// TestS3_DeleteBucket_FilesystemFaultPropagates covers the mirror half of the
+// abort: a failure removing an upload's part bodies is a 500. Reporting success
+// would leave the bodies for the next bucket of this name to inherit, which is the
+// same leak in the filesystem rather than in the store.
+func TestS3_DeleteBucket_FilesystemFaultPropagates(t *testing.T) {
+	t.Parallel()
+	fs := &s3FaultFs{
+		Fs:            afero.NewMemMapFs(),
+		err:           errors.New("filesystem unavailable"),
+		failRemoveAll: true,
+	}
+	srv := newS3TestServerWithFaultFS(t, emulator.NewMemoryStateManager(), fs)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/fsfault", nil, nil).Code)
+	seedS3MultipartUpload("fsfault", true)(t, srv)
+
+	fs.armed = true
+	w := s3Request(t, srv, http.MethodDelete, "/fsfault", nil, nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"a failure removing part bodies must be reported: %s", w.Body.String())
+
+	fs.armed = false
+	assert.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodHead, "/fsfault", nil, nil).Code,
+		"a failed DeleteBucket must leave the bucket present")
+}
+
+// TestS3_AbortMultipartUpload_StateFaultPropagates asserts the explicit abort
+// reports a failed clear too. AbortMultipartUpload and DeleteBucket share one
+// helper so the two paths cannot drift, and this is the half that is reachable
+// directly: an abort that reports 204 while leaving the part records behind is the
+// same false claim of cleanliness, one upload wide instead of one bucket wide.
+func TestS3_AbortMultipartUpload_StateFaultPropagates(t *testing.T) {
+	t.Parallel()
+	state := &s3PrefixFaultState{
+		inner:    emulator.NewMemoryStateManager(),
+		prefix:   "part:",
+		err:      errors.New("state store unavailable"),
+		onDelete: true,
+	}
+	srv := newS3TestServerWithState(t, state)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/abortfault", nil, nil).Code)
+	create := s3Request(t, srv, http.MethodPost, "/abortfault/big?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, create.Code)
+	var initiated struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(create.Body.Bytes(), &initiated))
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+		"/abortfault/big?partNumber=1&uploadId="+initiated.UploadID,
+		[]byte("part"), nil).Code)
+
+	state.armed = true
+	w := s3Request(t, srv, http.MethodDelete,
+		"/abortfault/big?uploadId="+initiated.UploadID, nil, nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"a failed abort must be reported, not swallowed: %s", w.Body.String())
+}
+
+// TestS3_DeleteBucket_CorruptUploadRecordPropagates covers the unmarshal branch of
+// the multipart scan: a record that is not valid JSON is a 500, not an upload
+// quietly skipped. Skipping it would leak the upload under a reusable bucket name
+// while reporting a clean delete.
+func TestS3_DeleteBucket_CorruptUploadRecordPropagates(t *testing.T) {
+	t.Parallel()
+	state := &s3CorruptState{
+		StateManager: emulator.NewMemoryStateManager(),
+		prefix:       "multipart:",
+	}
+	srv := newS3TestServerWithState(t, state)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/corruptmpu", nil, nil).Code)
+	seedS3MultipartUpload("corruptmpu", false)(t, srv)
+
+	state.armed = true
+	w := s3Request(t, srv, http.MethodDelete, "/corruptmpu", nil, nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"an unreadable upload record must be reported: %s", w.Body.String())
+}
+
+// TestS3_DeleteBucket_MissingUploadRecordIsSkipped is the companion to the test
+// above: a key the List returned whose value is no longer readable is not an error.
+// There is nothing left to abort, which is the state a successful abort produces —
+// so the delete completes rather than wedging on a record that is already gone.
+func TestS3_DeleteBucket_MissingUploadRecordIsSkipped(t *testing.T) {
+	t.Parallel()
+	state := &s3VanishingState{
+		StateManager: emulator.NewMemoryStateManager(),
+		prefix:       "multipart:",
+	}
+	srv := newS3TestServerWithState(t, state)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/vanishmpu", nil, nil).Code)
+	seedS3MultipartUpload("vanishmpu", false)(t, srv)
+
+	state.armed = true
+	assert.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/vanishmpu", nil, nil).Code,
+		"an upload record that is already gone is nothing to abort")
+}
+
+// seedS3StrandedObjectACL writes an object with an ACL and then deletes the object,
+// which strands the object_acl: key — the leftover clearBucketState scans for. The
+// bucket is left empty, so the delete under test reaches the clear.
+func seedS3StrandedObjectACL(bucket string) func(t *testing.T, srv *emulator.Server) {
+	return func(t *testing.T, srv *emulator.Server) {
+		t.Helper()
+		require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+			"/"+bucket+"/obj", []byte("x"),
+			map[string]string{"x-amz-acl": "public-read"}).Code)
+		require.Equal(t, http.StatusNoContent,
+			s3Request(t, srv, http.MethodDelete, "/"+bucket+"/obj", nil, nil).Code)
+	}
+}
+
+// seedS3MultipartUpload begins a multipart upload in bucket, optionally uploading
+// one part so the part: scan and the mirror cleanup have something to act on.
+func seedS3MultipartUpload(bucket string, withPart bool) func(t *testing.T, srv *emulator.Server) {
+	return func(t *testing.T, srv *emulator.Server) {
+		t.Helper()
+		create := s3Request(t, srv, http.MethodPost, "/"+bucket+"/big?uploads", nil, nil)
+		require.Equal(t, http.StatusOK, create.Code)
+		if !withPart {
+			return
+		}
+		var initiated struct {
+			UploadID string `xml:"UploadId"`
+		}
+		require.NoError(t, xml.Unmarshal(create.Body.Bytes(), &initiated))
+		require.NotEmpty(t, initiated.UploadID)
+		require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+			"/"+bucket+"/big?partNumber=1&uploadId="+initiated.UploadID,
+			[]byte("part"), nil).Code)
+	}
+}
+
+// TestS3_VersionDelete_StateFaultsPropagate applies the same rule to the
+// current-version promotion. A swallowed failure here leaves object: pointing at a
+// version that no longer exists, so a later unversioned GET serves a deleted
+// version's bytes — reported as a successful delete.
+func TestS3_VersionDelete_StateFaultsPropagate(t *testing.T) {
+	const bucket = "promofault"
+
+	tests := []struct {
+		name     string
+		prefix   string
+		onGet    bool
+		onPut    bool
+		onDelete bool
+		// versions is how many versions to write before deleting the newest, which
+		// selects the promote branch (two) or the no-survivor branch (one).
+		versions int
+	}{
+		{
+			name:     "reading the surviving version fails",
+			prefix:   "object_version:" + bucket + "/",
+			onGet:    true,
+			versions: 2,
+		},
+		{
+			name:     "promoting the surviving version fails",
+			prefix:   "object:" + bucket + "/",
+			onPut:    true,
+			versions: 2,
+		},
+		{
+			name:     "clearing the current pointer fails",
+			prefix:   "object:" + bucket + "/",
+			onDelete: true,
+			versions: 1,
+		},
+		{
+			name:     "clearing the version index fails",
+			prefix:   "object_versions:" + bucket + "/",
+			onDelete: true,
+			versions: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &s3PrefixFaultState{
+				inner:    emulator.NewMemoryStateManager(),
+				prefix:   tt.prefix,
+				err:      errors.New("state store unavailable"),
+				onGet:    tt.onGet,
+				onPut:    tt.onPut,
+				onDelete: tt.onDelete,
+			}
+			srv := newS3TestServerWithState(t, state)
+			newest := seedS3Versions(t, srv, bucket, tt.versions)
+
+			state.armed = true
+			w := s3Request(t, srv, http.MethodDelete,
+				"/"+bucket+"/obj?versionId="+newest, nil, nil)
+			assert.Equal(t, http.StatusInternalServerError, w.Code,
+				"a store failure must be reported, not swallowed: %s", w.Body.String())
+		})
+	}
+}
+
+// TestS3_VersionDelete_FilesystemFaultsPropagate is the mirror half of the
+// promotion: the promoted version's body has to move with its record, so a
+// filesystem failure while moving it must be reported rather than leaving the
+// record promoted and the body still the deleted version's.
+func TestS3_VersionDelete_FilesystemFaultsPropagate(t *testing.T) {
+	const bucket = "promofsfault"
+
+	tests := []struct {
+		name string
+		// arm selects the operation that fails; each corresponds to one step of
+		// moving a body, which is why they are exercised one at a time.
+		arm func(fs *s3FaultFs)
+		// versions selects the promote branch (two) or the no-survivor branch (one).
+		versions int
+	}{
+		{
+			name:     "reading the promoted version's body fails",
+			arm:      func(fs *s3FaultFs) { fs.failOpen = true },
+			versions: 2,
+		},
+		{
+			name:     "creating the promoted body's directory fails",
+			arm:      func(fs *s3FaultFs) { fs.failMkdirAll = true },
+			versions: 2,
+		},
+		{
+			name:     "writing the promoted body fails",
+			arm:      func(fs *s3FaultFs) { fs.failOpenFile = true },
+			versions: 2,
+		},
+		{
+			name:     "removing the last version's body fails",
+			arm:      func(fs *s3FaultFs) { fs.failRemove = true },
+			versions: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fs := &s3FaultFs{
+				Fs:  afero.NewMemMapFs(),
+				err: errors.New("filesystem unavailable"),
+			}
+			tt.arm(fs)
+			srv := newS3TestServerWithFaultFS(t, emulator.NewMemoryStateManager(), fs)
+			newest := seedS3Versions(t, srv, bucket, tt.versions)
+
+			// Armed only here, so the versions above are written normally and there
+			// is a real body to promote.
+			fs.armed = true
+			w := s3Request(t, srv, http.MethodDelete,
+				"/"+bucket+"/obj?versionId="+newest, nil, nil)
+			assert.Equal(t, http.StatusInternalServerError, w.Code,
+				"a filesystem failure must be reported, not swallowed: %s", w.Body.String())
+		})
+	}
+}
+
+// TestS3_VersionDelete_UnreadableSurvivorLeavesNoPointer covers the remaining
+// branch of the promotion: a version ID still in the index whose record cannot be
+// read is treated as no version at all. The alternative is worse than an error —
+// object: would be left pointing at something unreadable, and a GET would report a
+// 500 for a key the caller can neither read nor list.
+func TestS3_VersionDelete_UnreadableSurvivorLeavesNoPointer(t *testing.T) {
+	t.Parallel()
+	state := &s3VanishingState{
+		StateManager: emulator.NewMemoryStateManager(),
+		prefix:       "object_version:",
+	}
+	srv := newS3TestServerWithState(t, state)
+	newest := seedS3Versions(t, srv, "gonesurvivor", 2)
+
+	state.armed = true
+	require.Equal(t, http.StatusNoContent, s3Request(t, srv, http.MethodDelete,
+		"/gonesurvivor/obj?versionId="+newest, nil, nil).Code)
+
+	state.armed = false
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodGet, "/gonesurvivor/obj", nil, nil).Code,
+		"with no readable version left, the key must not exist")
+}
+
+// seedS3Versions creates bucket with versioning enabled and writes count versions
+// of the key "obj", returning the newest version ID.
+func seedS3Versions(t *testing.T, srv *emulator.Server, bucket string, count int) string {
+	t.Helper()
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+		"/"+bucket+"?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status>`+
+			`</VersioningConfiguration>`), nil).Code)
+
+	newest := ""
+	for i := 0; i < count; i++ {
+		w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/obj", []byte("body"), nil)
+		require.Equal(t, http.StatusOK, w.Code)
+		newest = w.Header().Get("x-amz-version-id")
+	}
+	require.NotEmpty(t, newest)
+	return newest
+}

--- a/emulator/s3_delete_bucket_state_test.go
+++ b/emulator/s3_delete_bucket_state_test.go
@@ -1,0 +1,768 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// Regression tests for #508: DeleteBucket removed the bucket: record and left
+// every key scoped to that bucket behind, so a bucket created with the same name
+// inherited the deleted bucket's configuration.
+//
+// The bucket name is the entire key for a bucket-scoped configuration, which is why
+// the leak is observable rather than merely untidy.
+
+// s3BucketSubresource describes one bucket-scoped configuration: how to set it, and
+// what an *unconfigured* bucket reports for it. The recreated bucket must report the
+// unconfigured value.
+type s3BucketSubresource struct {
+	name string
+	// configure applies the configuration to bucket "recycled".
+	configure func(t *testing.T, srv *emulator.Server)
+	// stateKey is the state key the configuration is stored under. Asserting on it
+	// directly is what proves DeleteBucket cleared *this* key: bucket_acl: is also
+	// cleared by CreateBucket (s3CreateBucketACL), so a read after the recreate
+	// cannot distinguish the delete having cleared it from the create having done so.
+	stateKey string
+	// readPath is the sub-resource query appended to the bucket path.
+	readPath string
+	// wantStatus is what a GET reports when nothing is configured.
+	wantStatus int
+	// wantBodyExcludes is a fragment that must be absent from an unconfigured
+	// read — the marker of the configuration having survived.
+	wantBodyExcludes string
+}
+
+func s3DeleteBucketSubresources() []s3BucketSubresource {
+	return []s3BucketSubresource{
+		{
+			name: "bucket ACL",
+			configure: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+					"/recycled?acl", nil,
+					map[string]string{"x-amz-acl": "public-read"}).Code)
+			},
+			stateKey:   "bucket_acl:recycled",
+			readPath:   "?acl",
+			wantStatus: http.StatusOK,
+			// The public-read grant a public ACL carries.
+			wantBodyExcludes: "AllUsers",
+		},
+		{
+			name: "bucket policy",
+			configure: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				policy := `{"Version":"2012-10-17","Statement":[{"Sid":"LeakMarker",` +
+					`"Effect":"Allow","Principal":"*","Action":"s3:GetObject",` +
+					`"Resource":"arn:aws:s3:::recycled/*"}]}`
+				require.Equal(t, http.StatusNoContent, s3Request(t, srv, http.MethodPut,
+					"/recycled?policy", []byte(policy), nil).Code)
+			},
+			stateKey: "bucket_policy:recycled",
+			readPath: "?policy",
+			// A bucket with no policy is NoSuchBucketPolicy, not an empty policy.
+			wantStatus:       http.StatusNotFound,
+			wantBodyExcludes: "LeakMarker",
+		},
+		{
+			name: "bucket lifecycle",
+			configure: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				cfg := `<LifecycleConfiguration><Rule><ID>LeakMarker</ID>` +
+					`<Status>Enabled</Status><Filter><Prefix></Prefix></Filter>` +
+					`<Expiration><Days>1</Days></Expiration></Rule></LifecycleConfiguration>`
+				code := s3Request(t, srv, http.MethodPut, "/recycled?lifecycle",
+					[]byte(cfg), nil).Code
+				require.Contains(t, []int{http.StatusOK, http.StatusNoContent}, code)
+			},
+			stateKey:         "bucket_lifecycle:recycled",
+			readPath:         "?lifecycle",
+			wantStatus:       http.StatusNotFound,
+			wantBodyExcludes: "LeakMarker",
+		},
+		{
+			name: "bucket versioning",
+			configure: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				code := s3Request(t, srv, http.MethodPut, "/recycled?versioning",
+					[]byte(`<VersioningConfiguration><Status>Enabled</Status>`+
+						`</VersioningConfiguration>`), nil).Code
+				require.Contains(t, []int{http.StatusOK, http.StatusNoContent}, code)
+			},
+			stateKey: "bucket_versioning:recycled",
+			readPath: "?versioning",
+			// An unversioned bucket reports an empty configuration, 200.
+			wantStatus:       http.StatusOK,
+			wantBodyExcludes: "Enabled",
+		},
+		{
+			name: "bucket notification configuration",
+			configure: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				// Substrate unmarshals this body by Go field name, so the element
+				// names are QueueConfigurations/QueueArn/Events rather than real
+				// S3's QueueConfiguration/Queue/Event, and the marker is the queue
+				// ARN rather than an Id. Written the AWS way the body parses to an
+				// empty configuration and stores nothing — which would make this
+				// sub-test pass whether the key is cleared or not (#542).
+				cfg := `<NotificationConfiguration><QueueConfigurations>` +
+					`<QueueArn>arn:aws:sqs:us-east-1:123456789012:leak-marker</QueueArn>` +
+					`<Events>s3:ObjectCreated:*</Events>` +
+					`</QueueConfigurations></NotificationConfiguration>`
+				code := s3Request(t, srv, http.MethodPut, "/recycled?notification",
+					[]byte(cfg), nil).Code
+				require.Contains(t, []int{http.StatusOK, http.StatusNoContent}, code)
+
+				// Pin that the configuration really was stored, so the assertion
+				// after the recreate is about inheritance.
+				read := s3Request(t, srv, http.MethodGet, "/recycled?notification", nil, nil)
+				require.Contains(t, read.Body.String(), "leak-marker",
+					"the notification configuration must be stored before the delete")
+			},
+			stateKey:         "notification:recycled",
+			readPath:         "?notification",
+			wantStatus:       http.StatusOK,
+			wantBodyExcludes: "leak-marker",
+		},
+		{
+			name: "block public access",
+			configure: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				cfg := `<PublicAccessBlockConfiguration>` +
+					`<BlockPublicAcls>true</BlockPublicAcls>` +
+					`<IgnorePublicAcls>true</IgnorePublicAcls>` +
+					`<BlockPublicPolicy>true</BlockPublicPolicy>` +
+					`<RestrictPublicBuckets>true</RestrictPublicBuckets>` +
+					`</PublicAccessBlockConfiguration>`
+				code := s3Request(t, srv, http.MethodPut, "/recycled?publicAccessBlock",
+					[]byte(cfg), nil).Code
+				require.Contains(t, []int{http.StatusOK, http.StatusNoContent}, code)
+			},
+			stateKey: "bucket_public_access_block:recycled",
+			readPath: "?publicAccessBlock",
+			// No configuration is NoSuchPublicAccessBlockConfiguration, which is
+			// distinct from a configuration with all four settings false.
+			wantStatus:       http.StatusNotFound,
+			wantBodyExcludes: "<BlockPublicAcls>true</BlockPublicAcls>",
+		},
+	}
+}
+
+// TestS3_DeleteBucket_ClearsBucketScopedConfiguration is the core assertion: for
+// each bucket-scoped configuration, configure it, delete the bucket, create a
+// bucket of the same name, and require the recreated bucket to report the
+// *unconfigured* value.
+//
+// One sub-test per configuration rather than one test setting all six: a single
+// combined test passes as soon as any one key is cleared, so it cannot show that
+// each is covered.
+//
+// Each sub-test asserts twice: on the state key immediately after the delete, and on
+// the recreated bucket's read. The state assertion is the one that attributes the
+// clear to DeleteBucket — CreateBucket clears bucket_acl: itself, so for that key the
+// read alone would pass with no fix at all.
+func TestS3_DeleteBucket_ClearsBucketScopedConfiguration(t *testing.T) {
+	t.Parallel()
+
+	for _, sub := range s3DeleteBucketSubresources() {
+		t.Run(sub.name, func(t *testing.T) {
+			t.Parallel()
+			state := emulator.NewMemoryStateManager()
+			srv := newS3TestServerWithState(t, state)
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/recycled", nil, nil).Code)
+			sub.configure(t, srv)
+
+			stored, err := state.Get(context.Background(), "s3", sub.stateKey)
+			require.NoError(t, err)
+			require.NotNil(t, stored,
+				"%s must hold the configuration before the delete", sub.stateKey)
+
+			require.Equal(t, http.StatusNoContent,
+				s3Request(t, srv, http.MethodDelete, "/recycled", nil, nil).Code)
+
+			cleared, err := state.Get(context.Background(), "s3", sub.stateKey)
+			require.NoError(t, err)
+			assert.Nil(t, cleared, "DeleteBucket must clear %s", sub.stateKey)
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/recycled", nil, nil).Code)
+
+			w := s3Request(t, srv, http.MethodGet, "/recycled"+sub.readPath, nil, nil)
+			assert.Equal(t, sub.wantStatus, w.Code,
+				"a recreated bucket must report the unconfigured value")
+			assert.NotContains(t, w.Body.String(), sub.wantBodyExcludes,
+				"the deleted bucket's configuration must not survive its bucket")
+		})
+	}
+}
+
+// TestS3_DeleteBucket_RecreatedBucketDoesNotInheritBPA asserts the Block Public
+// Access leak through *behavior* rather than through a read of the configuration,
+// which is what the issue asks for: an inherited BPA silently refuses a write the
+// caller's fixtures expect to succeed.
+func TestS3_DeleteBucket_RecreatedBucketDoesNotInheritBPA(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/bpa-recycled", nil, nil)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+		"/bpa-recycled?publicAccessBlock",
+		[]byte(`<PublicAccessBlockConfiguration>`+
+			`<BlockPublicAcls>true</BlockPublicAcls>`+
+			`</PublicAccessBlockConfiguration>`), nil).Code)
+
+	// With BPA in force, a public-ACL write is refused. This pins that the
+	// configuration was really in effect, so the assertion after the recreate is
+	// about inheritance rather than about BPA not working at all.
+	blocked := s3Request(t, srv, http.MethodPut, "/bpa-recycled/obj", []byte("x"),
+		map[string]string{"x-amz-acl": "public-read"})
+	require.Equal(t, http.StatusForbidden, blocked.Code,
+		"BlockPublicAcls must refuse a public-ACL write while configured")
+
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/bpa-recycled/obj", nil, nil).Code)
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/bpa-recycled", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/bpa-recycled", nil, nil).Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/bpa-recycled/obj", []byte("x"),
+		map[string]string{"x-amz-acl": "public-read"})
+	assert.Equal(t, http.StatusOK, w.Code,
+		"a fresh bucket has no Block Public Access configuration, so the write succeeds")
+}
+
+// TestS3_DeleteBucket_RecreatedBucketDoesNotInheritVersioning asserts the
+// versioning leak through behavior: an inherited Enabled status makes every write
+// versioned, which a consumer sees as an unexpected x-amz-version-id.
+func TestS3_DeleteBucket_RecreatedBucketDoesNotInheritVersioning(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/ver-recycled", nil, nil)
+	s3Request(t, srv, http.MethodPut, "/ver-recycled?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+
+	versioned := s3Request(t, srv, http.MethodPut, "/ver-recycled/obj", []byte("x"), nil)
+	require.Equal(t, http.StatusOK, versioned.Code)
+	require.NotEmpty(t, versioned.Header().Get("x-amz-version-id"),
+		"versioning must be in effect before the delete, or the test proves nothing")
+
+	// Emptying a versioned bucket means removing the versions, not just the keys:
+	// a plain DELETE inserts a delete marker, which still counts as content.
+	s3Request(t, srv, http.MethodDelete,
+		"/ver-recycled/obj?versionId="+versioned.Header().Get("x-amz-version-id"), nil, nil)
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/ver-recycled", nil, nil).Code)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/ver-recycled", nil, nil).Code)
+
+	w := s3Request(t, srv, http.MethodPut, "/ver-recycled/obj", []byte("x"), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("x-amz-version-id"),
+		"a fresh bucket is unversioned, so a write reports no version ID")
+}
+
+// TestS3_DeleteBucket_RefusesNoncurrentVersions asserts the widened emptiness
+// check. "All objects (including all object versions and delete markers) in the
+// bucket must be deleted before the bucket itself can be deleted" — a bucket whose
+// only remaining content is a deleted object's history is not empty.
+func TestS3_DeleteBucket_RefusesNoncurrentVersions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// leave puts bucket "notempty" into the state under test, having already
+		// enabled versioning and written one object.
+		leave func(t *testing.T, srv *emulator.Server, versionID string)
+	}{
+		{
+			name: "a delete marker over the only object",
+			leave: func(t *testing.T, srv *emulator.Server, _ string) {
+				t.Helper()
+				// A plain DELETE on a versioned bucket inserts a delete marker: the
+				// key stops being listed but its history remains.
+				require.Equal(t, http.StatusNoContent,
+					s3Request(t, srv, http.MethodDelete, "/notempty/obj", nil, nil).Code)
+			},
+		},
+		{
+			// The case that distinguishes the widened check from the old one: with
+			// versioning suspended, substrate's DELETE removes the object: pointer
+			// outright, so the bucket looks empty to a check that reads only
+			// object: while the version it wrote is still there. Real S3 keeps that
+			// version too — "when you suspend versioning, existing objects in your
+			// bucket do not change" — so the bucket is not empty either way.
+			name: "a version left by a delete under suspended versioning",
+			leave: func(t *testing.T, srv *emulator.Server, _ string) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+					"/notempty?versioning",
+					[]byte(`<VersioningConfiguration><Status>Suspended</Status>`+
+						`</VersioningConfiguration>`), nil).Code)
+				require.Equal(t, http.StatusNoContent,
+					s3Request(t, srv, http.MethodDelete, "/notempty/obj", nil, nil).Code)
+			},
+		},
+		{
+			name: "a noncurrent version under a newer one",
+			leave: func(t *testing.T, srv *emulator.Server, versionID string) {
+				t.Helper()
+				// Overwrite, then permanently remove only the newest version.
+				w := s3Request(t, srv, http.MethodPut, "/notempty/obj", []byte("v2"), nil)
+				require.Equal(t, http.StatusOK, w.Code)
+				newest := w.Header().Get("x-amz-version-id")
+				require.NotEqual(t, versionID, newest)
+				require.Equal(t, http.StatusNoContent, s3Request(t, srv,
+					http.MethodDelete, "/notempty/obj?versionId="+newest, nil, nil).Code)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv, _ := newS3TestServer(t)
+
+			s3Request(t, srv, http.MethodPut, "/notempty", nil, nil)
+			s3Request(t, srv, http.MethodPut, "/notempty?versioning",
+				[]byte(`<VersioningConfiguration><Status>Enabled</Status>`+
+					`</VersioningConfiguration>`), nil)
+			w := s3Request(t, srv, http.MethodPut, "/notempty/obj", []byte("v1"), nil)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			tt.leave(t, srv, w.Header().Get("x-amz-version-id"))
+
+			// The key is not listed as live...
+			list := s3Request(t, srv, http.MethodGet, "/notempty?list-type=2", nil, nil)
+			require.Equal(t, http.StatusOK, list.Code)
+
+			// ...but the bucket is not empty.
+			del := s3Request(t, srv, http.MethodDelete, "/notempty", nil, nil)
+			assert.Equal(t, http.StatusConflict, del.Code)
+			assert.Contains(t, del.Body.String(), "BucketNotEmpty")
+		})
+	}
+}
+
+// TestS3_DeleteBucket_AllVersionsRemovedIsEmpty is the companion to the test
+// above: once every version is permanently gone the bucket really is empty, so the
+// widened check must not have made DeleteBucket impossible to satisfy.
+func TestS3_DeleteBucket_AllVersionsRemovedIsEmpty(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	s3Request(t, srv, http.MethodPut, "/emptied", nil, nil)
+	s3Request(t, srv, http.MethodPut, "/emptied?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+
+	w := s3Request(t, srv, http.MethodPut, "/emptied/obj", []byte("v1"), nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	first := w.Header().Get("x-amz-version-id")
+
+	// Delete it the way a caller does: a marker, then both versions by ID.
+	marker := s3Request(t, srv, http.MethodDelete, "/emptied/obj", nil, nil)
+	require.Equal(t, http.StatusNoContent, marker.Code)
+	markerVersion := marker.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, markerVersion)
+
+	require.Equal(t, http.StatusNoContent, s3Request(t, srv, http.MethodDelete,
+		"/emptied/obj?versionId="+markerVersion, nil, nil).Code)
+	require.Equal(t, http.StatusNoContent, s3Request(t, srv, http.MethodDelete,
+		"/emptied/obj?versionId="+first, nil, nil).Code)
+
+	assert.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/emptied", nil, nil).Code,
+		"with every version gone the bucket is empty and deletes")
+}
+
+// TestS3_DeleteBucket_AbortsInFlightMultipartUploads asserts the multipart
+// treatment. For a general purpose bucket the reference only *recommends* removing
+// incomplete uploads ("While emptying your bucket, we recommend that you also
+// remove all incomplete multipart uploads"); the refusal is documented for
+// directory buckets, which substrate does not model. So the delete succeeds and the
+// upload is aborted — an upload whose destination bucket is gone can never
+// complete, and left behind it is inherited by the next bucket of that name.
+func TestS3_DeleteBucket_AbortsInFlightMultipartUploads(t *testing.T) {
+	t.Parallel()
+	state := emulator.NewMemoryStateManager()
+	srv, fs := newS3TestServerWithFS(t, state)
+
+	s3Request(t, srv, http.MethodPut, "/mpu-recycled", nil, nil)
+
+	create := s3Request(t, srv, http.MethodPost, "/mpu-recycled/big?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, create.Code)
+	var initiated struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(create.Body.Bytes(), &initiated))
+	require.NotEmpty(t, initiated.UploadID)
+
+	// A part large enough to be a legal non-final part.
+	part := []byte(strings.Repeat("p", 5*1024*1024))
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+		"/mpu-recycled/big?partNumber=1&uploadId="+initiated.UploadID, part, nil).Code)
+
+	// The upload is in progress and holds a part body in the mirror.
+	uploads := s3Request(t, srv, http.MethodGet, "/mpu-recycled?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, uploads.Code)
+	require.Contains(t, uploads.Body.String(), initiated.UploadID)
+
+	// The part records are asserted on the state store rather than through an API
+	// read: once the upload is aborted there is no operation that reports its parts,
+	// so a stranded part: key is invisible from outside and would leak silently.
+	partKeys, err := state.List(context.Background(), "s3", "part:"+initiated.UploadID+"/")
+	require.NoError(t, err)
+	require.NotEmpty(t, partKeys, "the uploaded part must be recorded before the delete")
+
+	assert.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/mpu-recycled", nil, nil).Code,
+		"an in-flight upload does not refuse a general purpose bucket delete")
+
+	// Recreate: the upload must be gone, not inherited.
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/mpu-recycled", nil, nil).Code)
+	after := s3Request(t, srv, http.MethodGet, "/mpu-recycled?uploads", nil, nil)
+	assert.Equal(t, http.StatusOK, after.Code)
+	assert.NotContains(t, after.Body.String(), initiated.UploadID,
+		"a recreated bucket must not inherit the deleted bucket's uploads")
+
+	// Uploading a further part to the aborted upload must fail rather than resume.
+	resume := s3Request(t, srv, http.MethodPut,
+		"/mpu-recycled/big?partNumber=2&uploadId="+initiated.UploadID, part, nil)
+	assert.Equal(t, http.StatusNotFound, resume.Code)
+
+	// And neither the part records nor the part bodies are left behind.
+	strandedParts, err := state.List(context.Background(), "s3", "part:"+initiated.UploadID+"/")
+	require.NoError(t, err)
+	assert.Empty(t, strandedParts, "an aborted upload's part records must not be left behind")
+
+	exists, err := afero.DirExists(fs, "/.multipart/"+initiated.UploadID)
+	require.NoError(t, err)
+	assert.False(t, exists, "an aborted upload's part bodies must not be left behind")
+}
+
+// TestS3_DeleteBucket_AbortsOnlyThisBucketsUploads is the other half of the abort:
+// a multipart upload is keyed by upload ID alone, so the scan sees every bucket's
+// uploads and must abort only the ones whose Bucket field names the bucket being
+// deleted. Without that comparison, deleting one bucket silently destroys an
+// unrelated bucket's in-flight upload.
+func TestS3_DeleteBucket_AbortsOnlyThisBucketsUploads(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	begin := func(bucket string) string {
+		t.Helper()
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code)
+		create := s3Request(t, srv, http.MethodPost, "/"+bucket+"/big?uploads", nil, nil)
+		require.Equal(t, http.StatusOK, create.Code)
+		var initiated struct {
+			UploadID string `xml:"UploadId"`
+		}
+		require.NoError(t, xml.Unmarshal(create.Body.Bytes(), &initiated))
+		require.NotEmpty(t, initiated.UploadID)
+		return initiated.UploadID
+	}
+
+	doomed := begin("mpu-doomed")
+	survivor := begin("mpu-survivor")
+	require.NotEqual(t, doomed, survivor)
+
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/mpu-doomed", nil, nil).Code)
+
+	uploads := s3Request(t, srv, http.MethodGet, "/mpu-survivor?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, uploads.Code)
+	assert.Contains(t, uploads.Body.String(), survivor,
+		"deleting one bucket must not abort another bucket's upload")
+
+	// And it is still usable, not merely still listed.
+	part := []byte(strings.Repeat("p", 5*1024*1024))
+	assert.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+		"/mpu-survivor/big?partNumber=1&uploadId="+survivor, part, nil).Code)
+}
+
+// TestS3_DeleteBucket_VersionDeletePromotesPredecessor pins the promotion half of
+// [S3Plugin.promoteCurrentVersion]: "if you delete the current object version, ...
+// the version that is next in the version stack becomes the current version". A
+// pointer left stale reports the deleted version's body; a pointer merely cleared
+// loses an object that still has versions.
+func TestS3_DeleteBucket_VersionDeletePromotesPredecessor(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/promoted", nil, nil).Code)
+	s3Request(t, srv, http.MethodPut, "/promoted?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+
+	first := s3Request(t, srv, http.MethodPut, "/promoted/obj", []byte("older"), nil)
+	require.Equal(t, http.StatusOK, first.Code)
+	second := s3Request(t, srv, http.MethodPut, "/promoted/obj", []byte("newer"), nil)
+	require.Equal(t, http.StatusOK, second.Code)
+	newest := second.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, newest)
+
+	require.Equal(t, http.StatusNoContent, s3Request(t, srv, http.MethodDelete,
+		"/promoted/obj?versionId="+newest, nil, nil).Code)
+
+	// An unversioned GET reads the current pointer, so this is what a caller sees.
+	get := s3Request(t, srv, http.MethodGet, "/promoted/obj", nil, nil)
+	require.Equal(t, http.StatusOK, get.Code,
+		"the key still has a version, so it must still be readable")
+	assert.Equal(t, "older", get.Body.String(),
+		"deleting the current version promotes the next one in the version stack")
+	assert.Equal(t, first.Header().Get("ETag"), get.Header().Get("ETag"),
+		"the promoted body and its recorded ETag must describe the same bytes")
+
+	// And the key is still listed: a cleared pointer would drop it entirely.
+	list := s3Request(t, srv, http.MethodGet, "/promoted?list-type=2", nil, nil)
+	require.Equal(t, http.StatusOK, list.Code)
+	assert.Contains(t, list.Body.String(), "<Key>obj</Key>")
+}
+
+// TestS3_DeleteBucket_VersionDeletePromotesDeleteMarker is the promotion case with
+// no body to promote: a delete marker is a version in the stack, so deleting the
+// newer object version above it makes the marker current again and the key stops
+// being readable. A marker has no stored body, so treating an absent versioned body
+// as a failure would turn this ordinary sequence into a 500.
+func TestS3_DeleteBucket_VersionDeletePromotesDeleteMarker(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/markerpromo", nil, nil).Code)
+	s3Request(t, srv, http.MethodPut, "/markerpromo?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/markerpromo/obj", []byte("v1"), nil).Code)
+
+	// A plain delete stacks a marker on top...
+	marker := s3Request(t, srv, http.MethodDelete, "/markerpromo/obj", nil, nil)
+	require.Equal(t, http.StatusNoContent, marker.Code)
+	require.NotEmpty(t, marker.Header().Get("x-amz-version-id"))
+
+	// ...a write stacks a new version above the marker...
+	second := s3Request(t, srv, http.MethodPut, "/markerpromo/obj", []byte("v2"), nil)
+	require.Equal(t, http.StatusOK, second.Code)
+
+	// ...and removing that version makes the marker current again.
+	require.Equal(t, http.StatusNoContent, s3Request(t, srv, http.MethodDelete,
+		"/markerpromo/obj?versionId="+second.Header().Get("x-amz-version-id"), nil, nil).Code)
+
+	get := s3Request(t, srv, http.MethodGet, "/markerpromo/obj", nil, nil)
+	assert.Equal(t, http.StatusNotFound, get.Code,
+		"a key whose current version is a delete marker is a 404, not a 500")
+	assert.Equal(t, "true", get.Header().Get("x-amz-delete-marker"))
+}
+
+// TestS3_DeleteBucket_PromotingADirectoryMarkerTouchesNoBody extends #534 to the
+// promotion path: promoting a version of a key ending in "/" must not write to the
+// object mirror, whose path for such a key is the directory node holding its
+// children. Nothing warns of the collision — afero's ReadFile of a directory returns
+// an empty body and no error, so an unguarded promote writes an empty file over the
+// node and the next child delete panics.
+func TestS3_DeleteBucket_PromotingADirectoryMarkerTouchesNoBody(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/promomarker", nil, nil).Code)
+	s3Request(t, srv, http.MethodPut, "/promomarker?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+
+	// Two versions of the directory marker, and a child beneath it.
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/promomarker/dir/", nil, nil).Code)
+	newer := s3Request(t, srv, http.MethodPut, "/promomarker/dir/", nil, nil)
+	require.Equal(t, http.StatusOK, newer.Code)
+	require.NotEmpty(t, newer.Header().Get("x-amz-version-id"))
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+		"/promomarker/dir/child.txt", []byte("child body"), nil).Code)
+
+	// Removing the newer marker version promotes the older one.
+	require.Equal(t, http.StatusNoContent, s3Request(t, srv, http.MethodDelete,
+		"/promomarker/dir/?versionId="+newer.Header().Get("x-amz-version-id"), nil, nil).Code)
+
+	// The child is intact and still deletable — the delete is the call that reaches
+	// afero's Remove and panics when the directory node has been overwritten.
+	child := s3Request(t, srv, http.MethodGet, "/promomarker/dir/child.txt", nil, nil)
+	assert.Equal(t, http.StatusOK, child.Code)
+	assert.Equal(t, "child body", child.Body.String())
+	assert.Equal(t, http.StatusNoContent, s3Request(t, srv, http.MethodDelete,
+		"/promomarker/dir/child.txt?versionId="+
+			childVersionID(t, srv, "/promomarker", "dir/child.txt"), nil, nil).Code)
+}
+
+// TestS3_DeleteBucket_PromotingAMarkerDoesNotClobberItsSibling is the destructive
+// half of the case above, and needs no children: "dir" and "dir/" are distinct S3
+// keys whose mirror paths coincide, so promoting a version of the marker "dir/" must
+// not write to the body of the object at "dir".
+//
+// It is reachable because the marker's versioned source path collides too:
+// .versions/dir//<versionID> normalizes onto .versions/dir/<versionID>, which is the
+// directory holding the versions of a child key named dir/<versionID>. afero reads
+// that directory as an empty body with no error, so the unguarded promote truncates
+// the sibling to zero bytes and reports success.
+func TestS3_DeleteBucket_PromotingAMarkerDoesNotClobberItsSibling(t *testing.T) {
+	t.Parallel()
+	srv, _ := newS3TestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sibpromo", nil, nil).Code)
+	s3Request(t, srv, http.MethodPut, "/sibpromo?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+		"/sibpromo/dir", []byte("real body"), nil).Code)
+
+	// Two versions of the marker, so removing one promotes the other.
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/sibpromo/dir/", nil, nil).Code)
+	newer := s3Request(t, srv, http.MethodPut, "/sibpromo/dir/", nil, nil)
+	require.Equal(t, http.StatusOK, newer.Code)
+
+	// A child key whose name begins with the promoted version's ID is what makes
+	// the collided source path a directory rather than absent.
+	older := childVersionID(t, srv, "/sibpromo", "dir/")
+	require.NotEqual(t, newer.Header().Get("x-amz-version-id"), older)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+		"/sibpromo/dir/"+older, []byte("collider"), nil).Code)
+
+	require.Equal(t, http.StatusNoContent, s3Request(t, srv, http.MethodDelete,
+		"/sibpromo/dir/?versionId="+newer.Header().Get("x-amz-version-id"), nil, nil).Code)
+
+	sibling := s3Request(t, srv, http.MethodGet, "/sibpromo/dir", nil, nil)
+	assert.Equal(t, http.StatusOK, sibling.Code)
+	assert.Equal(t, "real body", sibling.Body.String(),
+		`promoting a version of "dir/" must not touch the object at "dir"`)
+}
+
+// childVersionID returns the oldest version ID of key in bucket, read back from
+// ListObjectVersions the way a client would.
+func childVersionID(t *testing.T, srv *emulator.Server, bucketPath, key string) string {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, bucketPath+"?versions", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	var listing struct {
+		Versions []struct {
+			Key       string `xml:"Key"`
+			VersionID string `xml:"VersionId"`
+		} `xml:"Version"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &listing))
+	// The listing is newest-first, so the last match is the oldest version.
+	id := ""
+	for _, v := range listing.Versions {
+		if v.Key == key {
+			id = v.VersionID
+		}
+	}
+	if id == "" {
+		t.Fatalf("no version of %q in %s", key, w.Body.String())
+	}
+	return id
+}
+
+// TestS3_DeleteBucket_ClearsObjectScopedLeftovers covers the keys that outlive the
+// object they describe. An object ACL is stored under its own key, so a plain
+// DeleteObject leaves it behind; the bucket then satisfies the emptiness check and
+// its delete used to strand the ACL under a name a later CreateBucket reuses.
+//
+// The assertion is over the *whole* s3 namespace rather than a read of the recreated
+// bucket, for two reasons. A fresh write clears its own object_acl: entry
+// ([S3Plugin.s3StoreObjectACL]), so a behavioral read cannot see the leftover at
+// all; and the invariant being fixed is that no key scoped to the deleted bucket
+// survives it, which is a statement about the namespace, not about one read.
+func TestS3_DeleteBucket_ClearsObjectScopedLeftovers(t *testing.T) {
+	t.Parallel()
+	state := emulator.NewMemoryStateManager()
+	srv := newS3TestServerWithState(t, state)
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/leftovers", nil, nil).Code)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/leftovers/obj",
+		[]byte("x"), map[string]string{"x-amz-acl": "public-read"}).Code)
+
+	// A plain delete removes the object but not its ACL: that is the leftover.
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/leftovers/obj", nil, nil).Code)
+	stranded, err := state.List(context.Background(), "s3", "object_acl:leftovers/")
+	require.NoError(t, err)
+	require.NotEmpty(t, stranded,
+		"the object ACL must outlive its object, or the test proves nothing")
+
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/leftovers", nil, nil).Code)
+
+	// object_versions: is in the clear list for the same reason even though the
+	// version-delete path now tidies it up itself ([S3Plugin.promoteCurrentVersion]):
+	// the bucket's namespace is cleared as a whole, so a future key that outlives its
+	// object cannot reintroduce this leak.
+	for _, prefix := range []string{
+		"object:", "object_version:", "object_versions:", "object_acl:",
+	} {
+		keys, listErr := state.List(context.Background(), "s3", prefix+"leftovers/")
+		require.NoError(t, listErr)
+		assert.Empty(t, keys, "no %s key may outlive its bucket", prefix)
+	}
+}
+
+// TestS3_DeleteBucket_ErrorsPropagate asserts the judgement call the issue leaves
+// open: a failure to clear a bucket-scoped key is reported rather than swallowed,
+// and the bucket record survives it. A silent partial clear is the bug being fixed,
+// so a discarded error here would hide a recurrence.
+func TestS3_DeleteBucket_ErrorsPropagate(t *testing.T) {
+	// Not parallel: pabFaultState is armed after setup, and the shared bucket name
+	// keeps each case's keys distinct anyway.
+	for _, key := range []string{
+		"bucket_acl:failbucket",
+		"bucket_policy:failbucket",
+		"bucket_lifecycle:failbucket",
+		"bucket_versioning:failbucket",
+		"notification:failbucket",
+		"bucket_public_access_block:failbucket",
+	} {
+		t.Run(key, func(t *testing.T) {
+			state := &pabFaultState{
+				inner:   emulator.NewMemoryStateManager(),
+				key:     key,
+				err:     errors.New("state store unavailable"),
+				onDelet: true,
+			}
+			srv := newS3TestServerWithState(t, state)
+
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/failbucket", nil, nil).Code)
+
+			state.armed = true
+
+			w := s3Request(t, srv, http.MethodDelete, "/failbucket", nil, nil)
+			assert.Equal(t, http.StatusInternalServerError, w.Code,
+				"a failed clear must be reported, not swallowed: %s", w.Body.String())
+
+			// The bucket is still there: the delete failed, so it must not have
+			// half happened. A caller can retry, and HeadBucket agrees with the
+			// error rather than contradicting it.
+			state.armed = false
+			assert.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodHead, "/failbucket", nil, nil).Code,
+				"a failed DeleteBucket must leave the bucket present")
+		})
+	}
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -499,13 +500,12 @@ func (p *S3Plugin) s3StoreObjectACL(ctx context.Context, bucket, key string, acl
 // copy of it. The two are identical in content; storing nothing keeps the state
 // store's contents a record of what the caller actually asked for.
 //
-// The clear is not hypothetical tidiness: DeleteBucket removes the bucket: entry and
-// leaves its sub-resources behind, so without it a bucket created, given a public
-// ACL, deleted and created again would report the deleted bucket's ACL. That the
-// create is authoritative either way is the same whole-resource-replacement rule
-// [S3Plugin.s3StoreObjectACL] follows. Other bucket sub-resources — the policy, the
-// Block Public Access configuration, tagging — still outlive a DeleteBucket; that is
-// pre-existing and wider than this fix (#508).
+// The clear is redundant with DeleteBucket, which now clears every bucket-scoped key
+// including this one (#508), and is kept deliberately: it makes the create
+// authoritative regardless of how the previous bucket of this name went away, which
+// is the same whole-resource-replacement rule [S3Plugin.s3StoreObjectACL] follows.
+// A CreateBucket that does not name an ACL must report the default, not whatever a
+// predecessor stored.
 //
 // **Block Public Access cannot refuse a CreateBucket in substrate, and that is a
 // stated scope boundary rather than an oversight** (#470). Real S3 refuses one:
@@ -555,7 +555,53 @@ func (p *S3Plugin) headBucket(_ *RequestContext, _ *AWSRequest, bucket string) (
 	return &AWSResponse{StatusCode: http.StatusOK, Headers: map[string]string{}}, nil
 }
 
+// s3BucketSubresourceKey returns the state key holding one of a bucket's
+// singleton sub-resource configurations, for each prefix in
+// [s3BucketSubresourcePrefixes].
+func s3BucketSubresourceKey(prefix, bucket string) string {
+	return prefix + bucket
+}
+
+// s3BucketSubresourcePrefixes are the state-key prefixes of every configuration
+// scoped to a bucket as a whole, each keyed by bucket name alone.
+//
+// DeleteBucket must clear all of them: the bucket name is the entire key, so a
+// configuration left behind is inherited by the next bucket created with that name
+// (#508). Keeping them in one list rather than open-coding the deletes is what
+// makes adding a new bucket-scoped configuration a change to this slice — the
+// alternative is the drift that produced the bug, where only bucket_acl: was
+// cleared and five others were not.
+//
+// Bucket tagging is deliberately absent: PutBucketTagging writes Tags into the
+// bucket: record itself, so tagging cannot outlive the bucket. Block Public Access
+// is present via [s3PublicAccessBlockKey]'s prefix, which is why that key is
+// spelled here rather than derived — the two must not disagree.
+var s3BucketSubresourcePrefixes = []string{
+	"bucket_acl:",
+	"bucket_policy:",
+	"bucket_lifecycle:",
+	"bucket_versioning:",
+	"notification:",
+	"bucket_public_access_block:",
+}
+
 // deleteBucket handles DELETE /<bucket>.
+//
+// The bucket's own record is removed last, after every key scoped to it: an error
+// part-way through leaves the bucket present and reports a failure, rather than
+// removing the bucket and stranding its sub-resources under a name a later
+// CreateBucket will reuse. Errors propagate for the same reason — a discarded
+// Delete error is exactly how the leak this fixes went unnoticed (#508).
+//
+// "All objects (including all object versions and delete markers) in the bucket
+// must be deleted before the bucket itself can be deleted", so noncurrent versions
+// and delete markers refuse the delete with BucketNotEmpty alongside live objects.
+// Incomplete multipart uploads do **not** refuse it: for general purpose buckets
+// the reference only recommends removing them ("While emptying your bucket, we
+// recommend that you also remove all incomplete multipart uploads"), and the
+// refusal is documented for directory buckets, which substrate does not model. They
+// are aborted as part of the delete instead, since an upload whose destination
+// bucket is gone can never be completed.
 func (p *S3Plugin) deleteBucket(_ *RequestContext, _ *AWSRequest, bucket string) (*AWSResponse, error) {
 	ctx := context.Background()
 
@@ -567,18 +613,120 @@ func (p *S3Plugin) deleteBucket(_ *RequestContext, _ *AWSRequest, bucket string)
 		return s3ErrorResponse("NoSuchBucket", "The specified bucket does not exist.", http.StatusNotFound), nil
 	}
 
-	objKeys, listErr := p.state.List(ctx, s3Namespace, "object:"+bucket+"/")
-	if listErr != nil {
-		return nil, fmt.Errorf("list objects: %w", listErr)
+	// Live objects, noncurrent versions and delete markers all count towards
+	// emptiness. object_version: covers the latter two — a delete marker is stored
+	// as one — so a bucket whose only content is the history of a deleted object is
+	// refused, as real S3 refuses it.
+	for _, prefix := range []string{"object:", "object_version:"} {
+		keys, listErr := p.state.List(ctx, s3Namespace, prefix+bucket+"/")
+		if listErr != nil {
+			return nil, fmt.Errorf("list %s%s: %w", prefix, bucket, listErr)
+		}
+		if len(keys) > 0 {
+			return s3ErrorResponse("BucketNotEmpty",
+				"The bucket you tried to delete is not empty.", http.StatusConflict), nil
+		}
 	}
-	if len(objKeys) > 0 {
-		return s3ErrorResponse("BucketNotEmpty", "The bucket you tried to delete is not empty.", http.StatusConflict), nil
+
+	if err := p.clearBucketState(ctx, bucket); err != nil {
+		return nil, err
 	}
 
 	if err := p.state.Delete(ctx, s3Namespace, "bucket:"+bucket); err != nil {
 		return nil, fmt.Errorf("delete bucket: %w", err)
 	}
 	return &AWSResponse{StatusCode: http.StatusNoContent, Headers: map[string]string{}}, nil
+}
+
+// clearBucketState removes every state key scoped to bucket except the bucket:
+// record itself, which its caller removes last.
+//
+// An empty bucket can still own state: an object's ACL and version index outlive
+// the object they describe, and a multipart upload is not an object until it
+// completes. None of it is reachable through the API once the bucket is gone, and
+// all of it is inherited by the next bucket of the same name if left behind.
+func (p *S3Plugin) clearBucketState(ctx context.Context, bucket string) error {
+	for _, prefix := range s3BucketSubresourcePrefixes {
+		if err := p.state.Delete(ctx, s3Namespace, s3BucketSubresourceKey(prefix, bucket)); err != nil {
+			return fmt.Errorf("clear %s%s: %w", prefix, bucket, err)
+		}
+	}
+
+	// Object-scoped leftovers. object_acl: and object_versions: are keyed by
+	// object, so they need a prefix scan rather than a single delete.
+	for _, prefix := range []string{"object_acl:", "object_versions:"} {
+		keys, listErr := p.state.List(ctx, s3Namespace, prefix+bucket+"/")
+		if listErr != nil {
+			return fmt.Errorf("list %s%s: %w", prefix, bucket, listErr)
+		}
+		for _, k := range keys {
+			if err := p.state.Delete(ctx, s3Namespace, k); err != nil {
+				return fmt.Errorf("clear %s: %w", k, err)
+			}
+		}
+	}
+
+	if err := p.abortBucketMultipartUploads(ctx, bucket); err != nil {
+		return err
+	}
+	return nil
+}
+
+// abortBucketMultipartUploads aborts every in-progress multipart upload targeting
+// bucket, discarding its parts.
+//
+// A multipart upload is keyed by upload ID alone, so its bucket is a field on the
+// record rather than part of the key and every upload must be read to know whether
+// it belongs to this bucket — the same scan [S3Plugin.listMultipartUploads]
+// performs.
+func (p *S3Plugin) abortBucketMultipartUploads(ctx context.Context, bucket string) error {
+	uploadKeys, listErr := p.state.List(ctx, s3Namespace, "multipart:")
+	if listErr != nil {
+		return fmt.Errorf("list multipart uploads: %w", listErr)
+	}
+	for _, k := range uploadKeys {
+		data, getErr := p.state.Get(ctx, s3Namespace, k)
+		if getErr != nil {
+			return fmt.Errorf("get %s: %w", k, getErr)
+		}
+		if data == nil {
+			continue
+		}
+		var upload S3MultipartUpload
+		if unmarshalErr := json.Unmarshal(data, &upload); unmarshalErr != nil {
+			return fmt.Errorf("unmarshal %s: %w", k, unmarshalErr)
+		}
+		if upload.Bucket != bucket {
+			continue
+		}
+		if err := p.abortUploadState(ctx, upload.UploadID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// abortUploadState removes a multipart upload's record, its part records and the
+// part bodies in the object mirror. It is the state half of AbortMultipartUpload,
+// shared with DeleteBucket so an aborted-by-bucket-delete upload leaves exactly
+// what an explicit abort leaves: nothing.
+func (p *S3Plugin) abortUploadState(ctx context.Context, uploadID string) error {
+	partKeys, listErr := p.state.List(ctx, s3Namespace, "part:"+uploadID+"/")
+	if listErr != nil {
+		return fmt.Errorf("list parts of %s: %w", uploadID, listErr)
+	}
+	for _, pk := range partKeys {
+		if err := p.state.Delete(ctx, s3Namespace, pk); err != nil {
+			return fmt.Errorf("delete %s: %w", pk, err)
+		}
+	}
+	if err := p.state.Delete(ctx, s3Namespace, "multipart:"+uploadID); err != nil {
+		return fmt.Errorf("delete multipart:%s: %w", uploadID, err)
+	}
+	if err := p.fs.RemoveAll("/.multipart/" + uploadID); err != nil {
+		return fmt.Errorf("remove parts of %s: %w", uploadID, err)
+	}
+	return nil
 }
 
 // s3ObjectHasBody reports whether an object key has a body stored in the afero
@@ -967,6 +1115,9 @@ func (p *S3Plugin) deleteObject(reqCtx *RequestContext, req *AWSRequest, bucket,
 			}
 		}
 		p.saveVersionIDs(ctx, bucket, key, filtered)
+		if err := p.promoteCurrentVersion(ctx, bucket, key, filtered); err != nil {
+			return nil, err
+		}
 		return &AWSResponse{
 			StatusCode: http.StatusNoContent,
 			Headers:    map[string]string{"x-amz-version-id": versionID},
@@ -1986,16 +2137,9 @@ func (p *S3Plugin) abortMultipartUpload(_ *RequestContext, req *AWSRequest, buck
 		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
 	}
 
-	_ = p.state.Delete(ctx, s3Namespace, "multipart:"+uploadID)
-
-	// Delete all stored parts.
-	partKeys, listErr := p.state.List(ctx, s3Namespace, "part:"+uploadID+"/")
-	if listErr == nil {
-		for _, k := range partKeys {
-			_ = p.state.Delete(ctx, s3Namespace, k)
-		}
+	if abortErr := p.abortUploadState(ctx, uploadID); abortErr != nil {
+		return nil, abortErr
 	}
-	_ = p.fs.RemoveAll(fmt.Sprintf("/.multipart/%s", uploadID))
 
 	return &AWSResponse{StatusCode: http.StatusNoContent, Headers: map[string]string{}}, nil
 }
@@ -3275,6 +3419,89 @@ func (p *S3Plugin) getBucketVersioningStatus(ctx context.Context, bucket string)
 		return ""
 	}
 	return string(data)
+}
+
+// promoteCurrentVersion resets the object: current-version pointer for bucket/key
+// after a version was permanently deleted, given the key's remaining newest-first
+// version IDs.
+//
+// Deleting a version by ID leaves the current pointer stale, and the pointer is what
+// ListObjectsV2 and an unversioned GET read. Deleting the newest version must
+// promote the next one — "if you delete the current object version, ... the version
+// that is next in the version stack becomes the current version" — and deleting the
+// *last* version must remove the pointer, or the key stays listed forever. Without
+// the second case a versioned bucket can never be emptied, so DeleteBucket's
+// emptiness check could never be satisfied (#508).
+//
+// The promoted version's *body* moves with its record. A versioned PUT writes the
+// body twice — once under .versions/<key>/<versionID> and once at the unversioned
+// path — and an unversioned GET reads the unversioned one, so promoting the record
+// alone would serve the deleted version's bytes under the promoted version's ETag.
+// A delete marker has no body to copy, which is why the copy is conditional on one
+// existing rather than on the marker flag.
+//
+// A remaining version whose record is missing is treated as no version at all rather
+// than as an error: the pointer must not be left describing something unreadable.
+func (p *S3Plugin) promoteCurrentVersion(ctx context.Context, bucket, key string, remaining []string) error {
+	currentKey := "object:" + bucket + "/" + key
+
+	for _, vid := range remaining {
+		data, err := p.state.Get(ctx, s3Namespace, "object_version:"+bucket+"/"+key+"/"+vid)
+		if err != nil {
+			return fmt.Errorf("get version %s of %s: %w", vid, key, err)
+		}
+		if data == nil {
+			continue
+		}
+		if putErr := p.state.Put(ctx, s3Namespace, currentKey, data); putErr != nil {
+			return fmt.Errorf("promote version %s of %s: %w", vid, key, putErr)
+		}
+		if err := p.promoteVersionBody(bucket, key, vid); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// No version survives, so neither does the key.
+	if err := p.state.Delete(ctx, s3Namespace, currentKey); err != nil {
+		return fmt.Errorf("clear current version of %s: %w", key, err)
+	}
+	if err := p.state.Delete(ctx, s3Namespace, "object_versions:"+bucket+"/"+key); err != nil {
+		return fmt.Errorf("clear version index of %s: %w", key, err)
+	}
+	if s3ObjectHasBody(key) {
+		if err := p.fs.Remove("/" + bucket + "/" + key); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove body of %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// promoteVersionBody copies a version's stored body to the unversioned path an
+// unversioned GET reads, for [S3Plugin.promoteCurrentVersion].
+//
+// An absent versioned body is not an error: a delete marker has none, and an object
+// written before versioning was enabled has only the unversioned copy — which is
+// already the right body, since it is the one being promoted.
+func (p *S3Plugin) promoteVersionBody(bucket, key, versionID string) error {
+	if !s3ObjectHasBody(key) {
+		return nil
+	}
+	body, err := afero.ReadFile(p.fs, "/"+bucket+"/.versions/"+key+"/"+versionID)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read version %s of %s: %w", versionID, key, err)
+	}
+	path := "/" + bucket + "/" + key
+	if mkErr := p.fs.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+		return fmt.Errorf("mkdir for %s: %w", key, mkErr)
+	}
+	if wErr := afero.WriteFile(p.fs, path, body, 0o644); wErr != nil {
+		return fmt.Errorf("promote body of %s: %w", key, wErr)
+	}
+	return nil
 }
 
 // loadVersionIDs returns the newest-first list of version IDs for bucket/key.

--- a/emulator/s3_plugin_test.go
+++ b/emulator/s3_plugin_test.go
@@ -40,10 +40,19 @@ func newS3TestServerWithState(t *testing.T, state emulator.StateManager) *emulat
 // newS3TestServerWithFS builds the shared S3 test server over state.
 func newS3TestServerWithFS(t *testing.T, state emulator.StateManager) (*emulator.Server, afero.Fs) {
 	t.Helper()
+	fs := afero.NewMemMapFs()
+	return newS3TestServerWithFaultFS(t, state, fs), fs
+}
+
+// newS3TestServerWithFaultFS is newS3TestServerWithFS with a caller-supplied
+// filesystem, for tests that need the object mirror to fail. The mirror is the other
+// half of the state the plugin keeps, so a fault there is as observable as one in
+// the store.
+func newS3TestServerWithFaultFS(t *testing.T, state emulator.StateManager, fs afero.Fs) *emulator.Server {
+	t.Helper()
 	cfg := emulator.DefaultConfig()
 	logger := emulator.NewDefaultLogger(slog.LevelError, false)
 	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
-	fs := afero.NewMemMapFs()
 
 	s3p := &emulator.S3Plugin{}
 	err := s3p.Initialize(context.Background(), emulator.PluginConfig{
@@ -76,7 +85,7 @@ func newS3TestServerWithFS(t *testing.T, state emulator.StateManager) (*emulator
 		emulator.ServerOptions{Costs: costCtrl},
 	)
 
-	return srv, fs
+	return srv
 }
 
 // s3Request is a helper for issuing HTTP requests to the S3 server and


### PR DESCRIPTION
Closes #508.

`DeleteBucket` removed `bucket:<name>` and nothing else. Since a bucket-scoped
configuration is keyed by the bucket **name alone**, every one of them outlived its
bucket and was inherited by the next bucket created with that name — reproduced end
to end against a binary built from this branch's parent:

```
$ aws s3api put-bucket-versioning --bucket probe508 --versioning-configuration Status=Enabled
$ aws s3api delete-bucket --bucket probe508 && aws s3api create-bucket --bucket probe508
$ aws s3api get-bucket-versioning --bucket probe508
{ "Status": "Enabled" }        # a bucket nobody ever configured
```

## What is cleared

All six: `bucket_acl:`, `bucket_policy:`, `bucket_lifecycle:`,
`bucket_versioning:`, `notification:`, `bucket_public_access_block:` — held in one
`s3BucketSubresourcePrefixes` slice, so adding a bucket-scoped configuration is a
change to that slice rather than a seventh open-coded delete. The drift between one
cleared key and five uncleared ones is what this bug was.

Two corrections to the issue's table, both verified in the source rather than
assumed: the notification prefix is `notification:`, not `bucket_notification:`; and
**bucket tagging never leaked**, because `PutBucketTagging` writes `Tags` into the
`bucket:` record rather than under a key of its own.

Object-scoped leftovers go too. An object ACL and a version index are stored under
their own keys and outlive the object they describe, so an *empty* bucket could
still own state a recreated bucket inherited.

On the issue's open question — best-effort vs propagated: **propagated**. A partial
clear is precisely the bug being fixed, so `_ = state.Delete(...)` would hide a
recurrence. The `bucket:` record is deleted **last**, so a failed clear leaves the
bucket present and retryable rather than half-deleted, and `HeadBucket` agrees with
the error instead of contradicting it.

## The emptiness check was undercounting (not in the issue)

"All objects (including all object versions and delete markers) in the bucket must
be deleted before the bucket itself can be deleted", but the check listed only
`object:<bucket>/`. A bucket holding nothing but a deleted object's history deleted
"successfully" and stranded every version. It now counts `object_version:` as well,
which covers noncurrent versions and delete markers alike.

The sharpest case is a **versioning-suspended** bucket: substrate's `DELETE` removes
the current-version pointer outright there, so the bucket looked empty while the
version it wrote was still present. Real S3 keeps that version too — "when you
suspend versioning, existing objects in your bucket do not change" — so it is not
empty either way.

## Multipart: aborted, not refused — correcting my own plan

The plan said an in-flight upload should refuse the delete. The reference says
otherwise, and the reference wins: **the refusal is documented for directory
buckets**, which substrate does not model. For general purpose buckets the guidance
is only that "while emptying your bucket, we recommend that you also remove all
incomplete multipart uploads". An upload whose destination bucket is gone can never
be completed, so the delete aborts it — part records, upload record, and part bodies
— through the same helper `AbortMultipartUpload` now calls, so the two paths cannot
leave different residue. Only uploads whose `Bucket` field names the bucket being
deleted are touched: an upload is keyed by upload ID alone, so the scan sees every
bucket's.

## A pre-existing defect that blocked this one outright

Permanently deleting a version by ID never updated the `object:` current-version
pointer. A versioned bucket could therefore **never be emptied** — the key stayed
listed with a 200 `GET` after its last version was gone — so the widened emptiness
check above could never have been satisfied. Fixing #508 required fixing this.

`promoteCurrentVersion` promotes the newest surviving version, since "if you delete
the current object version, … the version that is next in the version stack becomes
the current version", and removes the key entirely when none survives. The promoted
version's **body** moves with its record: a versioned `PUT` writes the body both
under `.versions/<key>/<versionID>` and at the unversioned path an unversioned `GET`
reads, so promoting the record alone served the deleted version's bytes under the
promoted version's ETag.

Two subtleties, each pinned by a test because each was found by a surviving mutant:
a delete marker has no body to promote (an absent versioned body is not an error),
and the promotion honours #534's `s3ObjectHasBody` guard — afero reads a *directory*
as an empty body with no error, so an unguarded promote truncates the object at
`dir` to zero bytes while promoting a version of the marker `dir/`, and reports
success.

## Tests

`emulator/s3_delete_bucket_state_test.go`, all failing before the change:

| Test | Asserts |
|---|---|
| `ClearsBucketScopedConfiguration` | one sub-test per key, asserting the **state key** after the delete and the read after the recreate |
| `RecreatedBucketDoesNotInheritBPA` | behaviorally: a public-ACL write against the recreated bucket succeeds |
| `RecreatedBucketDoesNotInheritVersioning` | behaviorally: a write reports no `x-amz-version-id` |
| `RefusesNoncurrentVersions` | delete marker / noncurrent version / **suspended-versioning** leftover → `BucketNotEmpty` |
| `AllVersionsRemovedIsEmpty` | the widened check did not make `DeleteBucket` impossible to satisfy |
| `AbortsInFlightMultipartUploads` | 204, upload not inherited, not resumable, part records and bodies gone |
| `AbortsOnlyThisBucketsUploads` | another bucket's upload survives and is still usable |
| `ClearsObjectScopedLeftovers` | no key under any object prefix outlives its bucket |
| `VersionDeletePromotesPredecessor` | the promoted body **and its ETag** |
| `VersionDeletePromotesDeleteMarker` | promoting a marker is a 404, not a 500 |
| `PromotingADirectoryMarkerTouchesNoBody` | the child survives and is still deletable |
| `PromotingAMarkerDoesNotClobberItsSibling` | the object at `dir` keeps its body |
| `ErrorsPropagate` | one sub-case per key: 500 reported, and `HeadBucket` still 200 |

Two test-design notes worth stating, since both were cases of a test passing for the
wrong reason:

- `bucket_acl:` is *also* cleared by `CreateBucket`, so a read after the recreate
  passes with no fix at all. Every sub-test therefore asserts on the state key
  immediately after the delete, which is what attributes the clear to `DeleteBucket`.
- the notification sub-test passed before the fix because a body written **the AWS
  way** stores nothing: substrate unmarshals that XML by Go field name, so
  `<QueueConfiguration><Queue>` never matches. There was no leak to observe. Filed
  as #542; the test carries a comment pointing there and uses substrate's shape so
  it fails for the right reason today.

## Mutation testing

30 mutants across the clear list, the emptiness check, error propagation, delete
ordering, the multipart abort and the promotion. **27 applied and all CAUGHT, zero
survivors**; 3 were stale duplicate anchors superseded by working forms in the same
run.

Five survived initially, and each was a genuine test-design gap rather than an
equivalence, so the tests were strengthened rather than the mutants excused:

- the emptiness check reverted to `object:` only — no case reached "`object:` empty,
  versions remaining" until the suspended-versioning sub-case was added, which the
  AWS reference confirmed is a real state rather than a substrate artefact;
- the object-scoped scan dropped — the original test used the *versioned* delete
  path, which `promoteCurrentVersion` now tidies itself, so it needed the plain
  delete that genuinely strands an `object_acl:` key;
- the abort ignoring `upload.Bucket` — no test had uploads in two buckets;
- the promotion writing the record but not the body — no test read the promoted
  content;
- the promotion's marker guard dropped — proved reachable and destructive with an
  afero probe first (truncates the sibling at `dir` to zero bytes, no error), then
  pinned end to end.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0
issues**, `make test` (race), `make docs-reference docs-reference-check
docs-versions` (no diff — no plugin added), `npm --prefix docs run build`,
`go vet -C test/e2e ./...`, `go test -C test/e2e ./...`. Plus the end-to-end
sequences above against `substrate server`: the recreated bucket reports the
unconfigured default for versioning and BPA, a bucket holding only a delete marker
is refused and deletes once its versions are gone, an in-flight upload is aborted
rather than refused and is not resumable, and the promoted version serves `older`
while the key stays listed.

## Compatibility

No state-format change, so existing snapshots and recorded event logs replay
identically. Three behaviour changes a consumer may be asserting on:

- a `DeleteBucket` on a bucket holding noncurrent versions or delete markers now
  returns **409 `BucketNotEmpty`** where it returned 204. A test that deleted such a
  bucket successfully was relying on the leak.
- a recreated bucket no longer reports its predecessor's configuration. A fixture
  that leaned on the inheritance — deliberately or not — will see defaults.
- deleting an object version now changes what an unversioned `GET` and
  `ListObjectsV2` report for that key, which is what real S3 does.
