### PR TITLE
fix(cfn): DeleteStack deletes the stack's resources (#518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,92 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`DeletionPolicy` and `UpdateReplacePolicy` on a template resource** (#518), which
+  no template could previously declare — the attributes were dropped on parse in both
+  the JSON and YAML paths. A value outside `Delete`/`Retain`/`RetainExceptOnCreate`/
+  `Snapshot` is now a template error rather than a silent fall back to the default: a
+  typo'd `Retian` that deletes the resource is precisely what the attribute exists to
+  prevent, and CloudFormation itself rejects the template.
+
+  The default is resolved rather than assumed, because it is not uniformly `Delete`:
+  "the default policy is `Snapshot` for `AWS::RDS::DBCluster` resources and for
+  `AWS::RDS::DBInstance` resources that don't specify the `DBClusterIdentifier`
+  property". A sweep that assumed `Delete` would destroy a database the template asked
+  to be snapshotted. `Snapshot` does **not** retain — substrate deletes the resource
+  and says in the per-resource reason that no snapshot was taken, since no snapshot
+  resource is modelled for any of the eight Snapshot-capable types.
+  `RetainExceptOnCreate` retains for a `DeleteStack` but not for the rollback of the
+  create that made the resource, so the operation is passed into the policy resolver
+  rather than special-cased by a caller. `UpdateReplacePolicy` is parsed and reported
+  but nothing consults it yet: `UpdateStack` is a re-deploy rather than a per-resource
+  replace, so a template that declares it round-trips instead of being silently
+  dropped.
+
 ### Fixed
+- **`DeleteStack` now deletes the stack's resources, not just the stack record**
+  (#518). Every resource a stack created outlived it: create a stack holding a bucket,
+  delete the stack, and `head-bucket` still answered 200 — a test that tore down and
+  asserted cleanliness passed for the wrong reason. `DeleteStack` swept nothing at
+  all, and because the stack record is what *names* the resources, removing it first
+  stranded them with no way left to find them.
+
+  The sweep runs before the record is dropped, in the exact inverse of the deploy:
+  descending deploy priority, ties by descending logical ID. Substrate deploys in
+  priority order rather than from a dependency graph, so inverting that order is what
+  makes teardown ordering observable and assertable — the recorded events for a stack
+  of a role, a bucket, a queue and a topic read `CreateRole, CreateBucket,
+  CreateQueue, CreateTopic` and then `DeleteTopic, DeleteQueue, DeleteBucket,
+  DeleteRole`.
+
+  Deletes are declared in a per-type table that **returns** the request rather than
+  performing it, so the sweep owns ordering, error handling and event recording once
+  and each entry is a data declaration. Three things the table deliberately does not
+  do. It does not assume the physical ID is the delete identifier: SQS records the
+  queue *name* while `DeleteQueue` requires a `QueueUrl`, a standalone security-group
+  rule records its *group* because EC2's opaque `sgr-` ID is not modelled (so the
+  revoke restates the permission the authorize granted, since a revoke built any other
+  way silently removes nothing), and an AppSync resolver's is `TypeName.FieldName`
+  while the path wants the two separately. It does not guess an operation from the
+  type: KMS has no `DeleteKey` at all, so its entry dispatches `ScheduleKeyDeletion`,
+  and neither an SNS topic policy nor a Route 53 record set has a delete of its own —
+  the first is an attribute set back to empty, the second a change batch carrying
+  `Action DELETE`, each the mirror of the call that created it. And it does not read a
+  parent ID off the resource: the composite types re-resolve theirs from the stored
+  template, which is where an API Gateway method's API *and* resource come from.
+
+  A resource that is already absent is a **success**. A resource deleted out of band
+  between the deploy and the sweep must not wedge its stack, so the sweep tolerates 33
+  not-found codes — each one measured by dispatching that type's delete against an
+  empty registry and recording what came back, rather than read off a reference and
+  hoped for.
+
+  Any other refusal is a failure, and a failed sweep **keeps** the stack: its record,
+  its resource list and its name index all survive, and `DescribeStacks` reports
+  `DELETE_FAILED` with the offending resource and the plugin's own error code as the
+  reason. A stack that reported a failed delete and then vanished would be a worse lie
+  than the leak — a caller would have no way to retry and no way to learn what held
+  it. Only a fully successful sweep removes the record. Deleting a stack that does not
+  exist stays a success, as it was: `DeleteStack` documents no not-found error.
+
+  On the wire the failure is reported the way the API reports it: `DeleteStack`
+  "returns success" and the stack reaches `DELETE_FAILED`, which a caller learns by
+  polling `DescribeStacks`. Raising it on the call would be wrong twice over — a
+  caller following AWS semantics would get an exception where the API gives it a
+  status to poll, and the 500 it would have to be makes an SDK **retry** the delete,
+  sweeping a stack already in `DELETE_FAILED`. The in-process deployer still returns
+  an error, so a Go caller sees the failure directly.
+
+  Coverage is **stated**, not implied. Of the 109 types the deployer dispatches, 89
+  have a delete request, 11 are state-only types whose stub record is removed, and the
+  remaining 9 report `DELETE_SKIPPED` with a reason distinguishing "AWS models no
+  delete" from "substrate does not route the one it has" — different facts, and only
+  the second is substrate's to fix. A type the deployer does not recognize at all also
+  skips, but its `cfn_stub` key is now removed rather than left for a redeployed stack
+  to read as the previous one's properties. Reporting `DELETE_COMPLETE` for any of
+  these would claim a deletion that did not happen, and a false claim of cleanliness
+  is worse than a stated gap. `docs/services.md` enumerates all nine.
+
 - **`DeleteBucket` now clears the bucket's namespace instead of only its `bucket:`
   record** (#508). A bucket-scoped configuration is keyed by bucket name alone, so
   every one of them outlived its bucket and was inherited by the next bucket created

--- a/docs/services.md
+++ b/docs/services.md
@@ -174,19 +174,76 @@ The in-process `emulator.BettyClient` deploys into substrate's default partition
 caller identity to take; an in-process caller that needs another partition can set
 one on the deployer with `emulator.WithDeployerIdentity`.
 
-### DeleteStack deletes the stack, not its resources
+### DeleteStack deletes the stack's resources
 
-`DeleteStack` removes the stack record and its name index. The resources the
-stack deployed are **left in place**: a bucket a stack created is still there
-after the stack is gone, and `s3api head-bucket` still answers 200. Real
-CloudFormation deletes them subject to each resource's `DeletionPolicy`, which
-substrate does not model at all. Tracked in
-[#518](https://github.com/scttfrdmn/substrate/issues/518) — a per-type delete
-dispatcher across 113 resource types, in reverse dependency order, with
-`DeletionPolicy` (`Delete`/`Retain`/`Snapshot`) honoured.
+`DeleteStack` sweeps the resources the stack deployed before removing the stack
+record: a bucket a stack created is gone once its stack is, and `s3api head-bucket`
+answers 404.
 
-Until then, a test that deletes a stack and expects the resources to be gone
-should delete them explicitly.
+The sweep is the exact inverse of the deploy — resources are ordered by descending
+deploy priority, ties by descending logical ID — so a resource is deleted before
+whatever it was created after. Substrate deploys in priority order rather than from
+a dependency graph, and inverting that order is what makes the teardown observable:
+the recorded event sequence for a stack of an IAM role, a bucket, a queue and a
+topic reads `CreateRole, CreateBucket, CreateQueue, CreateTopic` and then
+`DeleteTopic, DeleteQueue, DeleteBucket, DeleteRole`.
+
+`DeletionPolicy` and `UpdateReplacePolicy` are parsed from both the JSON and YAML
+template paths, and a value outside `Delete`/`Retain`/`RetainExceptOnCreate`/
+`Snapshot` is a template error rather than a silent default. `Retain` keeps the
+resource and the stack still deletes; `RetainExceptOnCreate` retains for a
+`DeleteStack` but not for the rollback of the create that made the resource. The
+default is `Delete`, **except** `Snapshot` for `AWS::RDS::DBCluster` and for an
+`AWS::RDS::DBInstance` that declares no `DBClusterIdentifier` — a sweep that
+assumed `Delete` would destroy a database the template asked to be snapshotted.
+`Snapshot` does not retain: substrate deletes the resource and records in the
+per-resource reason that no snapshot was taken, since no snapshot resource is
+modelled for any of the eight Snapshot-capable types.
+
+A resource already absent — deleted out of band between the deploy and the sweep —
+is a **success**, not a failure: a stack must not be wedged by a resource someone
+else removed. Any other refusal is a failure, and a stack with a failed deletion
+keeps its record, its resource list and its name index while reporting
+`DELETE_FAILED` in `DescribeStacks`, with the offending resource and the plugin's
+own error code in the reason. A stack that reported a failed delete and then
+vanished would leave a caller no way to retry and no way to learn what held it.
+
+The `delete-stack` **call** still answers 200 in that case, as the API does: real
+`DeleteStack` returns success and the stack reaches `DELETE_FAILED` asynchronously,
+so poll `DescribeStacks` to learn the outcome rather than relying on the call
+raising. The in-process `emulator.StackDeployer.DeleteStack` returns an error
+directly, since a Go caller has no status to poll.
+
+```
+aws cloudformation delete-stack --stack-name probe
+aws s3api head-bucket --bucket probe-data     # 404 — deleted with its stack
+
+aws cloudformation delete-stack --stack-name stuck          # 200
+aws cloudformation describe-stacks --stack-name stuck \
+  --query 'Stacks[0].StackStatus'                           # DELETE_FAILED
+```
+
+Coverage is stated rather than implied. Of the 109 resource types the deployer
+dispatches, 89 have a delete request and 11 are state-only types whose stub record
+is removed. The remaining 9 sweep to a no-op and are reported as `DELETE_SKIPPED`
+naming the reason:
+
+| Type | Why the sweep is a no-op |
+|---|---|
+| `AWS::CloudFront::CloudFrontOriginAccessIdentity` | the deploy records no state to remove |
+| `AWS::ECS::CapacityProvider` | the deploy records no state to remove |
+| `AWS::SSM::Association` | the deploy records no state to remove |
+| `AWS::SecretsManager::SecretTargetAttachment` | the deploy records no state to remove |
+| `AWS::Route53::RecordSetGroup` | its record sets are dispatches the stack does not record individually |
+| `AWS::ECR::LifecyclePolicy` | `DeleteLifecyclePolicy` is not routed; deleting the repository removes the policy |
+| `AWS::ApiGateway::UsagePlanKey` | `DeleteUsagePlanKey` is not routed; the key goes with its usage plan |
+| `AWS::Cognito::IdentityPoolRoleAttachment` | Cognito models no `DeleteIdentityPoolRoles` |
+| `AWS::SecretsManager::RotationSchedule` | `CancelRotateSecret` is not routed; the schedule goes with the secret |
+
+A type the deployer does not recognize at all is also `DELETE_SKIPPED`: its stub
+state is removed, but substrate never created a resource for it, so reporting
+`DELETE_COMPLETE` would claim a deletion that did not happen. A skip is always
+reported — a claim of cleanliness that is not true is worse than a stated gap.
 
 ### A refused resource reports CREATE_FAILED
 

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -86,11 +86,142 @@ type cfnExport struct {
 }
 
 // cfnResource is a single CloudFormation resource declaration.
+//
+// DeletionPolicy and UpdateReplacePolicy are plain string resource attributes, so
+// one field with both tags serves the JSON and YAML template paths alike — both
+// unmarshal into this struct.
 type cfnResource struct {
 	Type       string                 `json:"Type"                yaml:"Type"`
 	Properties map[string]interface{} `json:"Properties"          yaml:"Properties"`
 	DependsOn  interface{}            `json:"DependsOn,omitempty" yaml:"DependsOn,omitempty"`
 	Condition  string                 `json:"Condition,omitempty" yaml:"Condition,omitempty"`
+
+	// DeletionPolicy is what to do with the resource when it leaves the stack:
+	// "Delete", "Retain", "RetainExceptOnCreate" or "Snapshot". Empty means the
+	// template declared none, which is not the same as "Delete" — the default is
+	// Snapshot for two RDS types, so the default is resolved rather than assumed
+	// (see cfnDeletionPolicyFor).
+	DeletionPolicy string `json:"DeletionPolicy,omitempty" yaml:"DeletionPolicy,omitempty"`
+
+	// UpdateReplacePolicy is the same set of values for the resource CloudFormation
+	// leaves behind when an update replaces it. Substrate's UpdateStack is a
+	// re-deploy rather than a per-resource replace, so nothing consults this yet;
+	// it is parsed so a template that declares it round-trips rather than being
+	// silently dropped, and so DescribeStackResources can report it.
+	UpdateReplacePolicy string `json:"UpdateReplacePolicy,omitempty" yaml:"UpdateReplacePolicy,omitempty"`
+}
+
+// CloudFormation deletion policies, as the DeletionPolicy attribute reference
+// defines them.
+const (
+	// cfnPolicyDelete deletes the resource and its content.
+	cfnPolicyDelete = "Delete"
+
+	// cfnPolicyRetain keeps the resource, removing it from the stack's scope only.
+	cfnPolicyRetain = "Retain"
+
+	// cfnPolicyRetainExceptOnCreate behaves like Retain "except for the stack
+	// operation that initially created the resource": if the operation that created
+	// the resource is rolled back, CloudFormation deletes it.
+	cfnPolicyRetainExceptOnCreate = "RetainExceptOnCreate"
+
+	// cfnPolicySnapshot snapshots the resource before deleting it.
+	cfnPolicySnapshot = "Snapshot"
+)
+
+// cfnDeletionOp is the stack operation a deletion policy is being resolved for.
+// RetainExceptOnCreate is the only policy whose meaning depends on it, and it
+// depends on it entirely: the same declaration retains on a delete and deletes on
+// a create rollback. Passing the operation in is what keeps that rule in one place
+// instead of special-cased at each caller.
+type cfnDeletionOp int
+
+const (
+	// cfnDeleteStackOp is a DeleteStack sweep.
+	cfnDeleteStackOp cfnDeletionOp = iota
+
+	// cfnCreateRollbackOp is the rollback of the operation that created the
+	// resource, where RetainExceptOnCreate deletes rather than retains.
+	cfnCreateRollbackOp
+)
+
+// cfnValidDeletionPolicies is the set a template may declare. A value outside it
+// is a template error rather than a silent fall back to the default: a typo'd
+// "Retian" that deletes the resource is exactly what the attribute exists to
+// prevent, and CloudFormation itself rejects the template.
+var cfnValidDeletionPolicies = map[string]bool{
+	cfnPolicyDelete:               true,
+	cfnPolicyRetain:               true,
+	cfnPolicyRetainExceptOnCreate: true,
+	cfnPolicySnapshot:             true,
+}
+
+// cfnSnapshotDefaultTypes are the types whose default deletion policy is Snapshot
+// rather than Delete. "The default policy is Snapshot for AWS::RDS::DBCluster
+// resources and for AWS::RDS::DBInstance resources that don't specify the
+// DBClusterIdentifier property" — the DBInstance condition is a property test, so
+// it lives in cfnDeletionPolicyFor rather than in this set.
+var cfnSnapshotDefaultTypes = map[string]bool{
+	"AWS::RDS::DBCluster":  true,
+	"AWS::RDS::DBInstance": true,
+}
+
+// cfnSnapshotCapableTypes are the eight types the reference lists as supporting
+// Snapshot. Substrate models a delete for four of them; the rest are recorded here
+// so a Snapshot declaration on a type that genuinely supports it is distinguished
+// from one on a type where it means nothing.
+var cfnSnapshotCapableTypes = map[string]bool{
+	"AWS::DocDB::DBCluster":              true,
+	"AWS::EC2::Volume":                   true,
+	"AWS::ElastiCache::CacheCluster":     true,
+	"AWS::ElastiCache::ReplicationGroup": true,
+	"AWS::Neptune::DBCluster":            true,
+	"AWS::RDS::DBCluster":                true,
+	"AWS::RDS::DBInstance":               true,
+	"AWS::Redshift::Cluster":             true,
+}
+
+// cfnDeletionPolicyFor resolves the policy in force for a resource, applying the
+// default the reference specifies for its type.
+//
+// The default is resolved here rather than at the call site because it is not
+// uniformly "Delete": an RDS cluster, and a standalone RDS instance, default to
+// Snapshot. A sweep that assumed Delete would destroy a database the template
+// asked to be snapshotted, which is the one failure mode this attribute exists to
+// prevent.
+func cfnDeletionPolicyFor(res cfnResource) string {
+	if res.DeletionPolicy != "" {
+		return res.DeletionPolicy
+	}
+	if cfnSnapshotDefaultTypes[res.Type] {
+		// "for AWS::RDS::DBInstance resources that don't specify the
+		// DBClusterIdentifier property" — an instance in a cluster follows the
+		// cluster's fate, so its own default is Delete.
+		if res.Type == "AWS::RDS::DBInstance" {
+			if v, ok := res.Properties["DBClusterIdentifier"]; ok && v != nil {
+				return cfnPolicyDelete
+			}
+		}
+		return cfnPolicySnapshot
+	}
+	return cfnPolicyDelete
+}
+
+// cfnPolicyRetainsResource reports whether policy leaves the resource in place for
+// the given operation.
+//
+// Snapshot does not retain: it snapshots and then deletes. Only Retain always
+// retains, and RetainExceptOnCreate retains for every operation except the
+// rollback of the create that made the resource.
+func cfnPolicyRetainsResource(policy string, op cfnDeletionOp) bool {
+	switch policy {
+	case cfnPolicyRetain:
+		return true
+	case cfnPolicyRetainExceptOnCreate:
+		return op != cfnCreateRollbackOp
+	default:
+		return false
+	}
 }
 
 // CFNStackState holds persisted state for a deployed CloudFormation stack.
@@ -143,6 +274,12 @@ type CFNStackState struct {
 
 	// UpdatedAt is the time the stack was last updated.
 	UpdatedAt time.Time `json:"UpdatedAt"`
+
+	// ResourceDeletions records what a delete sweep did with each resource. It is
+	// written only when the sweep failed — a successful sweep removes the whole
+	// record — so its presence and DELETE_FAILED go together, and it is what tells
+	// a caller which resource is holding the stack.
+	ResourceDeletions []CFNResourceDeletion `json:"ResourceDeletions,omitempty"`
 }
 
 // exports returns the stack's export name → resolved value map, joining
@@ -294,6 +431,22 @@ var (
 	// The API's rule: for each AWS account, Export names must be unique within a
 	// Region.
 	ErrCFNExportNameConflict = errors.New("export name already exists")
+
+	// ErrCFNDeleteFailed is returned when a stack's resource sweep could not
+	// delete one of its resources.
+	//
+	// The stack survives in DELETE_FAILED with the per-resource reasons recorded,
+	// so this is not the end of the caller's options: fix what is holding the
+	// resource and delete again. It is substrate's own failure rather than an
+	// invalid request, hence a 500 like the deploy failures.
+	ErrCFNDeleteFailed = errors.New("stack delete failed")
+)
+
+// Stack statuses substrate reports, for the ones written from more than one place.
+const (
+	// cfnStackDeleteFailed is the status a stack carries after a sweep failed to
+	// delete one of its resources. The stack remains in DescribeStacks.
+	cfnStackDeleteFailed = "DELETE_FAILED"
 )
 
 // cfnClassifiedError carries a [StackDeployer] failure's classification
@@ -848,6 +1001,33 @@ func (d *StackDeployer) DeleteStack(ctx context.Context, stackName string) error
 	if err := d.checkExportsNotImported(ctx, stackName); err != nil {
 		return err
 	}
+
+	// Sweep the stack's resources before dropping its record. The record is what
+	// names them, so removing it first would strand every resource with no way
+	// left to find it — which is exactly the leak this fixes (#518).
+	//
+	// A stack whose record is already gone sweeps nothing and succeeds: DeleteStack
+	// documents no not-found error, and deleting an absent stack is a success.
+	stack, err := d.loadStack(ctx, stackName)
+	if err != nil {
+		return err
+	}
+	if stack != nil {
+		deletions := d.deleteStackResources(ctx, stack, stackName, cfnDeleteStackOp)
+		if failed := cfnFailedDeletions(deletions); len(failed) > 0 {
+			// The stack stays visible in DescribeStacks reporting DELETE_FAILED,
+			// with its resource list intact. A stack that reports a failed delete
+			// and then vanishes is a worse lie than the leak: a caller has no way
+			// to retry, and no way to learn which resource is holding it.
+			stack.Status = cfnStackDeleteFailed
+			stack.ResourceDeletions = deletions
+			stack.UpdatedAt = d.tc.Now()
+			d.persistStack(ctx, *stack)
+			return cfnErrf(ErrCFNDeleteFailed, "delete stack %s: %s", stackName,
+				strings.Join(failed, "; "))
+		}
+	}
+
 	if err := d.state.Delete(ctx, cfnNamespace, "stack:"+stackName); err != nil {
 		return fmt.Errorf("delete stack %s: %w", stackName, err)
 	}
@@ -863,6 +1043,42 @@ func (d *StackDeployer) DeleteStack(ctx context.Context, stackName string) error
 		}
 	}
 	return d.saveStackNames(ctx, newNames)
+}
+
+// loadStack reads a persisted stack by name, returning (nil, nil) when no stack of
+// that name exists and (nil, nil) when its record does not unmarshal.
+//
+// A corrupt record reads as absent rather than as an error because that is what
+// ListStacks already does with one, and a delete that cannot be completed because
+// the record is unreadable would leave a stack nothing can remove.
+func (d *StackDeployer) loadStack(ctx context.Context, stackName string) (*CFNStackState, error) {
+	data, err := d.state.Get(ctx, cfnNamespace, "stack:"+stackName)
+	if err != nil {
+		return nil, fmt.Errorf("load stack %s: %w", stackName, err)
+	}
+	if data == nil {
+		return nil, nil
+	}
+	var s CFNStackState
+	if unmarshalErr := json.Unmarshal(data, &s); unmarshalErr != nil {
+		d.logger.Warn("cfn: stack record does not unmarshal", "stack", stackName,
+			"error", unmarshalErr.Error())
+		return nil, nil
+	}
+	return &s, nil
+}
+
+// cfnFailedDeletions returns one "LogicalID (Type): reason" description per
+// resource the sweep failed to delete.
+func cfnFailedDeletions(deletions []CFNResourceDeletion) []string {
+	var failed []string
+	for _, del := range deletions {
+		if del.Status == cfnDeleteFailed {
+			failed = append(failed,
+				fmt.Sprintf("%s (%s): %s", del.LogicalID, del.Type, del.Reason))
+		}
+	}
+	return failed
 }
 
 // ListStacks returns all persisted stack states.

--- a/emulator/betty_cfn_delete.go
+++ b/emulator/betty_cfn_delete.go
@@ -1,0 +1,889 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// cfnDeleteRequestFunc builds the request that deletes one deployed resource.
+//
+// It returns a request rather than performing the delete so every entry in
+// [cfnResourceDeleters] stays a data declaration: the sweep owns ordering, error
+// handling and event recording once, and an entry can be unit-tested by inspecting
+// the request it builds without dispatching anything. It also accommodates all four
+// request shapes the deploy paths use — an action name with query parameters, a JSON
+// body, a REST path, and a path plus parameters — which a single "delete by physical
+// ID" helper could not.
+//
+// props and cctx are the resource's declared Properties and a resolution context
+// rebuilt from the stored template, for the types whose delete needs a parent
+// identifier the DeployedResource does not carry. A nil return means this resource
+// cannot be deleted from what is known about it, which the sweep records as a skip
+// rather than as a success.
+type cfnDeleteRequestFunc func(d *StackDeployer, dr DeployedResource,
+	props map[string]interface{}, cctx *cfnContext) *AWSRequest
+
+// cfnResourceDeleters maps a CloudFormation resource type to the request that
+// deletes it.
+//
+// A type that is absent has no modeled delete, and the sweep reports it as
+// DELETE_SKIPPED naming the type rather than treating it as deleted — the whole
+// point of #518 is that a claim of cleanliness must be true, so a gap is stated
+// rather than implied.
+//
+// Two things this table deliberately does not do:
+//
+//   - It does not assume the physical ID is the delete identifier. SQS records the
+//     queue *name* as its physical ID while DeleteQueue requires a QueueUrl; SNS
+//     records the topic ARN while its own state key is name-derived; an API Gateway
+//     child needs its parent's ID, which lives in the template rather than in the
+//     child's DeployedResource.
+//   - It does not guess an operation name from the type. KMS has no DeleteKey at
+//     all — "you can schedule the deletion of a KMS key" — so its entry dispatches
+//     ScheduleKeyDeletion. Each entry's operation and required parameters were read
+//     off the plugin that must accept it.
+var cfnResourceDeleters = map[string]cfnDeleteRequestFunc{
+	// --- Storage and data ---------------------------------------------------
+	"AWS::S3::Bucket": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		// The bucket must be empty, which DeleteBucket enforces. A stack whose
+		// bucket holds objects the stack did not create reports DELETE_FAILED,
+		// which is what real CloudFormation does too.
+		return &AWSRequest{Service: "s3", Operation: "DELETE", Path: "/" + dr.PhysicalID,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::DynamoDB::Table": jsonBodyDeleter("dynamodb", "DeleteTable", "TableName"),
+	"AWS::Kinesis::Stream": jsonBodyDeleter("kinesis", "DeleteStream", "StreamName"),
+	"AWS::KinesisFirehose::DeliveryStream": jsonBodyDeleter("firehose", "DeleteDeliveryStream",
+		"DeliveryStreamName"),
+	"AWS::EFS::FileSystem":  pathDeleter("efs", "/2015-02-01/file-systems/"),
+	"AWS::EFS::AccessPoint": pathDeleter("efs", "/2015-02-01/access-points/"),
+	"AWS::EFS::MountTarget": pathDeleter("efs", "/2015-02-01/mount-targets/"),
+	"AWS::FSx::FileSystem":  jsonBodyDeleter("fsx", "DeleteFileSystem", "FileSystemId"),
+
+	// --- Messaging ----------------------------------------------------------
+	"AWS::SQS::Queue": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		// DeleteQueue takes a QueueUrl, and the physical ID is the queue name, so
+		// the URL is rebuilt the same way CreateQueue derived it. Passing the name
+		// would look right and delete nothing.
+		return &AWSRequest{Service: "sqs", Operation: "DeleteQueue",
+			Headers: map[string]string{},
+			Params:  map[string]string{"QueueUrl": sqsQueueURL(cctx.region, cctx.accountID, dr.PhysicalID)}}
+	},
+	"AWS::SNS::Topic": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		// The physical ID is already the ARN DeleteTopic wants, but a stack
+		// deployed before that was recorded may hold a bare name, so it is
+		// normalized rather than trusted.
+		arn := dr.PhysicalID
+		if !strings.HasPrefix(arn, "arn:") {
+			arn = fmt.Sprintf("arn:aws:sns:%s:%s:%s", cctx.region, cctx.accountID, arn)
+		}
+		return &AWSRequest{Service: "sns", Operation: "DeleteTopic",
+			Headers: map[string]string{}, Params: map[string]string{"TopicArn": arn}}
+	},
+	"AWS::SNS::Subscription": queryDeleter("sns", "Unsubscribe", "SubscriptionArn"),
+	"AWS::SNS::TopicPolicy": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		// There is no DeleteTopicPolicy: a topic policy is an attribute, and
+		// removing it means setting it back to empty — the mirror of the
+		// SetTopicAttributes the deploy dispatched. The topic itself, if the stack
+		// also owns it, is deleted separately by its own entry.
+		return &AWSRequest{Service: "sns", Operation: "SetTopicAttributes",
+			Headers: map[string]string{},
+			Params: map[string]string{
+				"Action": "SetTopicAttributes", "TopicArn": dr.PhysicalID,
+				"AttributeName": "Policy", "AttributeValue": "",
+			}}
+	},
+	"AWS::Events::Rule": jsonBodyDeleter("eventbridge", "DeleteRule", "Name"),
+
+	// --- Compute ------------------------------------------------------------
+	"AWS::Lambda::Function": pathDeleter("lambda", "/2015-03-31/functions/"),
+	"AWS::Lambda::EventSourceMapping": pathDeleter("lambda",
+		"/2015-03-31/event-source-mappings/"),
+	"AWS::ECS::Cluster": jsonBodyDeleter("ecs", "DeleteCluster", "cluster"),
+	"AWS::ECS::Service": func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		// A service is identified by cluster plus service; the cluster is the
+		// template's, not the service's own physical ID.
+		body, err := json.Marshal(map[string]interface{}{
+			"cluster": resolveStringProp(props, "Cluster", "default", cctx),
+			"service": dr.PhysicalID,
+			// "You must have a service that is either ACTIVE or DRAINING" —
+			// force lets a service with running tasks go, which is what a stack
+			// delete needs.
+			"force": true,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "ecs", Operation: "DeleteService", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::ECS::TaskDefinition": jsonBodyDeleter("ecs", "DeregisterTaskDefinition",
+		"taskDefinition"),
+	"AWS::ECR::Repository": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		body, err := json.Marshal(map[string]interface{}{
+			"repositoryName": dr.PhysicalID,
+			// A repository holding images is refused otherwise, and the images a
+			// stack's repository holds were pushed by something other than the
+			// stack.
+			"force": true,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "ecr", Operation: "DeleteRepository", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+
+	// --- EC2 and networking -------------------------------------------------
+	"AWS::EC2::Instance": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		return &AWSRequest{Service: "ec2", Operation: "TerminateInstances",
+			Headers: map[string]string{},
+			Params:  map[string]string{"InstanceId.1": dr.PhysicalID}}
+	},
+	"AWS::EC2::VPC":             queryDeleter("ec2", "DeleteVpc", "VpcId"),
+	"AWS::EC2::Subnet":          queryDeleter("ec2", "DeleteSubnet", "SubnetId"),
+	"AWS::EC2::SecurityGroup":   queryDeleter("ec2", "DeleteSecurityGroup", "GroupId"),
+	"AWS::EC2::InternetGateway": queryDeleter("ec2", "DeleteInternetGateway", "InternetGatewayId"),
+	"AWS::EC2::RouteTable":      queryDeleter("ec2", "DeleteRouteTable", "RouteTableId"),
+	"AWS::EC2::NatGateway":      queryDeleter("ec2", "DeleteNatGateway", "NatGatewayId"),
+	"AWS::EC2::LaunchTemplate":  queryDeleter("ec2", "DeleteLaunchTemplate", "LaunchTemplateId"),
+	"AWS::EC2::EIP": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		// An address is released, not deleted — there is no DeleteAddress.
+		return &AWSRequest{Service: "ec2", Operation: "ReleaseAddress",
+			Headers: map[string]string{},
+			Params:  map[string]string{"AllocationId": dr.PhysicalID}}
+	},
+	"AWS::EC2::SecurityGroupIngress": sgRuleDeleter("RevokeSecurityGroupIngress"),
+	"AWS::EC2::SecurityGroupEgress":  sgRuleDeleter("RevokeSecurityGroupEgress"),
+
+	// --- Load balancing -----------------------------------------------------
+	"AWS::ElasticLoadBalancingV2::LoadBalancer": queryDeleter("elasticloadbalancing",
+		"DeleteLoadBalancer", "LoadBalancerArn"),
+	"AWS::ElasticLoadBalancingV2::TargetGroup": queryDeleter("elasticloadbalancing",
+		"DeleteTargetGroup", "TargetGroupArn"),
+	"AWS::ElasticLoadBalancingV2::Listener": queryDeleter("elasticloadbalancing",
+		"DeleteListener", "ListenerArn"),
+	"AWS::ElasticLoadBalancingV2::ListenerRule": queryDeleter("elasticloadbalancing",
+		"DeleteRule", "RuleArn"),
+
+	// --- Identity and secrets -----------------------------------------------
+	"AWS::IAM::Role":   iamDeleter("DeleteRole", "RoleName"),
+	"AWS::IAM::Policy": iamDeleter("DeletePolicy", "PolicyArn"),
+	"AWS::IAM::InstanceProfile": iamDeleter("DeleteInstanceProfile",
+		"InstanceProfileName"),
+	"AWS::KMS::Key": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		// KMS models no DeleteKey: a key is scheduled for deletion. The minimum
+		// window is 7 days, which is what CloudFormation itself requests.
+		body, err := json.Marshal(map[string]interface{}{
+			"KeyId": dr.PhysicalID, "PendingWindowInDays": 7,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "kms", Operation: "ScheduleKeyDeletion", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	// A replica key deploys through deployKMSKey, so it is a key as far as substrate
+	// is concerned and is scheduled for deletion the same way.
+	"AWS::KMS::ReplicaKey": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		body, err := json.Marshal(map[string]interface{}{
+			"KeyId": dr.PhysicalID, "PendingWindowInDays": 7,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "kms", Operation: "ScheduleKeyDeletion", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::KMS::Alias": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		body, err := json.Marshal(map[string]interface{}{"AliasName": dr.PhysicalID})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "kms", Operation: "DeleteAlias", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::SecretsManager::Secret": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		body, err := json.Marshal(map[string]interface{}{
+			"SecretId": dr.PhysicalID,
+			// "The default behavior of CloudFormation is to delete the secret
+			// with the ForceDeleteWithoutRecovery flag" — so a recreated stack
+			// does not collide with a secret still in its recovery window.
+			"ForceDeleteWithoutRecovery": true,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "secretsmanager", Operation: "DeleteSecret", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::SSM::Parameter": jsonBodyDeleter("ssm", "DeleteParameter", "Name"),
+
+	// --- Databases and caches -----------------------------------------------
+	"AWS::RDS::DBInstance": queryDeleter("rds", "DeleteDBInstance", "DBInstanceIdentifier"),
+	"AWS::RDS::DBCluster":  queryDeleter("rds", "DeleteDBCluster", "DBClusterIdentifier"),
+	"AWS::RDS::DBParameterGroup": queryDeleter("rds", "DeleteDBParameterGroup",
+		"DBParameterGroupName"),
+	"AWS::RDS::DBSubnetGroup": queryDeleter("rds", "DeleteDBSubnetGroup",
+		"DBSubnetGroupName"),
+	"AWS::ElastiCache::CacheCluster": queryDeleter("elasticache", "DeleteCacheCluster",
+		"CacheClusterId"),
+	"AWS::ElastiCache::ReplicationGroup": queryDeleter("elasticache", "DeleteReplicationGroup",
+		"ReplicationGroupId"),
+	"AWS::ElastiCache::ParameterGroup": queryDeleter("elasticache", "DeleteCacheParameterGroup",
+		"CacheParameterGroupName"),
+	"AWS::ElastiCache::SubnetGroup": queryDeleter("elasticache", "DeleteCacheSubnetGroup",
+		"CacheSubnetGroupName"),
+
+	// --- Observability -------------------------------------------------------
+	"AWS::Logs::LogGroup": jsonBodyDeleter("logs", "DeleteLogGroup", "logGroupName"),
+	"AWS::Logs::LogStream": func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		group := resolveStringProp(props, "LogGroupName", "", cctx)
+		if group == "" {
+			return nil
+		}
+		body, err := json.Marshal(map[string]interface{}{
+			"logGroupName": group, "logStreamName": dr.PhysicalID,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "logs", Operation: "DeleteLogStream", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::CloudWatch::Alarm": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		// DeleteAlarms is plural and takes a list, even for one alarm.
+		return &AWSRequest{Service: "monitoring", Operation: "DeleteAlarms",
+			Headers: map[string]string{},
+			Params:  map[string]string{"AlarmNames.member.1": dr.PhysicalID}}
+	},
+
+	// --- Analytics and ETL ---------------------------------------------------
+	"AWS::Glue::Database":   jsonBodyDeleter("glue", "DeleteDatabase", "Name"),
+	"AWS::Glue::Job":        jsonBodyDeleter("glue", "DeleteJob", "JobName"),
+	"AWS::Glue::Crawler":    jsonBodyDeleter("glue", "DeleteCrawler", "Name"),
+	"AWS::Glue::Connection": jsonBodyDeleter("glue", "DeleteConnection", "ConnectionName"),
+	"AWS::Glue::Table": func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		db := resolveStringProp(props, "DatabaseName", "", cctx)
+		if db == "" {
+			return nil
+		}
+		body, err := json.Marshal(map[string]interface{}{
+			"DatabaseName": db, "Name": dr.PhysicalID,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "glue", Operation: "DeleteTable", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::MSK::Cluster": pathDeleter("msk", "/v1/clusters/"),
+
+	// --- Application integration ---------------------------------------------
+	"AWS::StepFunctions::StateMachine": jsonBodyDeleter("states", "DeleteStateMachine",
+		"stateMachineArn"),
+	"AWS::StepFunctions::Activity": jsonBodyDeleter("states", "DeleteActivity",
+		"activityArn"),
+
+	// --- API Gateway ---------------------------------------------------------
+	// Every child here needs its parent's ID, which lives in the template rather
+	// than in the child's own DeployedResource — this is what props and cctx are
+	// for.
+	"AWS::ApiGateway::RestApi": pathDeleter("apigateway", "/restapis/"),
+	"AWS::ApiGateway::Resource": apiGatewayChildDeleter("RestApiId",
+		func(api, id string) string { return "/restapis/" + api + "/resources/" + id }),
+	"AWS::ApiGateway::Deployment": apiGatewayChildDeleter("RestApiId",
+		func(api, id string) string { return "/restapis/" + api + "/deployments/" + id }),
+	"AWS::ApiGateway::Stage": apiGatewayChildDeleter("RestApiId",
+		func(api, id string) string { return "/restapis/" + api + "/stages/" + id }),
+	"AWS::ApiGateway::Authorizer": apiGatewayChildDeleter("RestApiId",
+		func(api, id string) string { return "/restapis/" + api + "/authorizers/" + id }),
+	"AWS::ApiGateway::Method": func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		// A method is the only child here needing two parents: the API and the
+		// resource it hangs off. Its physical ID is the HTTP verb.
+		api := resolveStringProp(props, "RestApiId", "", cctx)
+		res := resolveStringProp(props, "ResourceId", "", cctx)
+		if api == "" || res == "" {
+			return nil
+		}
+		return &AWSRequest{Service: "apigateway", Operation: "DELETE",
+			Path:    "/restapis/" + api + "/resources/" + res + "/methods/" + dr.PhysicalID,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::ApiGateway::ApiKey":    pathDeleter("apigateway", "/apikeys/"),
+	"AWS::ApiGateway::UsagePlan": pathDeleter("apigateway", "/usageplans/"),
+	"AWS::ApiGatewayV2::Api":     pathDeleter("apigatewayv2", "/v2/apis/"),
+	"AWS::ApiGatewayV2::Route": apiGatewayChildDeleter("ApiId",
+		func(api, id string) string { return "/v2/apis/" + api + "/routes/" + id }),
+	"AWS::ApiGatewayV2::Integration": apiGatewayChildDeleter("ApiId",
+		func(api, id string) string { return "/v2/apis/" + api + "/integrations/" + id }),
+	"AWS::ApiGatewayV2::Stage": apiGatewayChildDeleter("ApiId",
+		func(api, id string) string { return "/v2/apis/" + api + "/stages/" + id }),
+	"AWS::ApiGatewayV2::Authorizer": apiGatewayChildDeleter("ApiId",
+		func(api, id string) string { return "/v2/apis/" + api + "/authorizers/" + id }),
+
+	// --- AppSync -------------------------------------------------------------
+	"AWS::AppSync::GraphQLApi": pathDeleter("appsync", "/v1/apis/"),
+	"AWS::AppSync::DataSource": apiGatewayChildDeleter("ApiId",
+		func(api, id string) string { return "/v1/apis/" + api + "/DataSources/" + id }),
+	"AWS::AppSync::FunctionConfiguration": apiGatewayChildDeleter("ApiId",
+		func(api, id string) string { return "/v1/apis/" + api + "/functions/" + id }),
+	"AWS::AppSync::Resolver": func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		// The physical ID is "TypeName.FieldName" and the path wants the two
+		// separately, so the type comes from the template and the field from the
+		// physical ID's tail — splitting on the last dot, since a GraphQL field
+		// name cannot contain one but this way a type name could.
+		api := resolveStringProp(props, "ApiId", "", cctx)
+		typeName := resolveStringProp(props, "TypeName", "", cctx)
+		field := dr.PhysicalID
+		if i := strings.LastIndex(field, "."); i >= 0 {
+			field = field[i+1:]
+		}
+		if api == "" || typeName == "" || field == "" {
+			return nil
+		}
+		return &AWSRequest{Service: "appsync", Operation: "DELETE",
+			Path:    "/v1/apis/" + api + "/types/" + typeName + "/resolvers/" + field,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+
+	// --- Cognito -------------------------------------------------------------
+	"AWS::Cognito::UserPool": jsonBodyDeleter("cognito-idp", "DeleteUserPool", "UserPoolId"),
+	"AWS::Cognito::UserPoolClient": func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		pool := resolveStringProp(props, "UserPoolId", "", cctx)
+		if pool == "" {
+			return nil
+		}
+		body, err := json.Marshal(map[string]interface{}{
+			"UserPoolId": pool, "ClientId": dr.PhysicalID,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "cognito-idp", Operation: "DeleteUserPoolClient",
+			Body: body, Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::Cognito::UserPoolGroup": func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		pool := resolveStringProp(props, "UserPoolId", "", cctx)
+		if pool == "" {
+			return nil
+		}
+		body, err := json.Marshal(map[string]interface{}{
+			"UserPoolId": pool, "GroupName": dr.PhysicalID,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "cognito-idp", Operation: "DeleteGroup", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::Cognito::UserPoolDomain": jsonBodyDeleter("cognito-idp", "DeleteUserPoolDomain",
+		"Domain"),
+	"AWS::Cognito::IdentityPool": jsonBodyDeleter("cognito-identity", "DeleteIdentityPool",
+		"IdentityPoolId"),
+
+	// --- Everything else -----------------------------------------------------
+	"AWS::Route53::HostedZone": pathDeleter("route53", "/2013-04-01/hostedzone/"),
+	"AWS::Route53::RecordSet": func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		// A record set has no delete operation of its own: it is removed by a
+		// change batch carrying Action DELETE, the mirror of the UPSERT that
+		// created it. The record is keyed by type and name, which is why both
+		// come from the template rather than from the physical ID alone.
+		zone := resolveStringProp(props, "HostedZoneId", "", cctx)
+		if zone == "" || dr.PhysicalID == "" {
+			return nil
+		}
+		rtype := resolveStringProp(props, "Type", "A", cctx)
+		body := `<ChangeResourceRecordSetsRequest ` +
+			`xmlns="https://route53.amazonaws.com/doc/2013-04-01/">` +
+			`<ChangeBatch><Changes><Change><Action>DELETE</Action>` +
+			`<ResourceRecordSet><Name>` + dr.PhysicalID + `</Name>` +
+			`<Type>` + rtype + `</Type></ResourceRecordSet>` +
+			`</Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>`
+		return &AWSRequest{Service: "route53", Operation: "POST",
+			Path: "/2013-04-01/hostedzone/" + zone + "/rrset", Body: []byte(body),
+			Headers: map[string]string{"Content-Type": "application/xml"},
+			Params:  map[string]string{}}
+	},
+	"AWS::CertificateManager::Certificate": jsonBodyDeleter("acm", "DeleteCertificate",
+		"CertificateArn"),
+	"AWS::CloudFront::Distribution": pathDeleter("cloudfront", "/2020-05-31/distribution/"),
+	"AWS::Budgets::Budget": func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		body, err := json.Marshal(map[string]interface{}{
+			"AccountId": cctx.accountID, "BudgetName": dr.PhysicalID,
+		})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "budgets", Operation: "DeleteBudget", Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	},
+	"AWS::SES::EmailIdentity": pathDeleter("sesv2", "/v2/email/identities/"),
+}
+
+// cfnStubDeleteTypes are the resource types whose deploy writes properties into
+// cfnStubNamespace and dispatches no API call.
+//
+// They need a delete of their own because a sweep that dispatched nothing for them
+// would leave the stub key behind, and a stack redeployed under the same logical ID
+// would then read the previous stack's properties — the same "recreated resource
+// inherits the old one's configuration" leak #508 fixed inside S3. There is no
+// request to build, so they are held here rather than in cfnResourceDeleters.
+//
+// The four remaining state-only types (CloudFront::CloudFrontOriginAccessIdentity,
+// ECS::CapacityProvider, SSM::Association, SecretsManager::SecretTargetAttachment)
+// write no state at all: their deploy returns a DeployedResource and nothing else,
+// so there is nothing for a sweep to remove and they are reported as skipped.
+// Route53::RecordSetGroup is state-only in the same sense but not inert — it
+// dispatches one RecordSet per child, and those children are not recorded as
+// resources of their own, so the record sets it wrote outlive the sweep. That gap
+// is reported rather than hidden; see cfnDeleteInertTypes.
+var cfnStubDeleteTypes = map[string]bool{
+	"AWS::Athena::WorkGroup":             true,
+	"AWS::Backup::BackupPlan":            true,
+	"AWS::CloudTrail::Trail":             true,
+	"AWS::CodeBuild::Project":            true,
+	"AWS::CodeDeploy::DeploymentGroup":   true,
+	"AWS::CodePipeline::Pipeline":        true,
+	"AWS::Config::ConfigRule":            true,
+	"AWS::Config::ConfigurationRecorder": true,
+	"AWS::OpenSearchService::Domain":     true,
+	"AWS::Transfer::Server":              true,
+	"AWS::WAFv2::WebACL":                 true,
+}
+
+// cfnDeleteInertTypes maps a type whose sweep is a no-op to why, so the reason a
+// resource is skipped names the cause rather than looking like an unimplemented
+// deleter.
+//
+// Four write no state to remove. The rest are types with no delete to dispatch —
+// the API genuinely has none, or substrate does not route the one it has — and each
+// says which, because "no delete is modeled" and "AWS models no delete" are
+// different facts and only the first is substrate's to fix.
+var cfnDeleteInertTypes = map[string]string{
+	"AWS::CloudFront::CloudFrontOriginAccessIdentity": "the deploy records no state to remove",
+	"AWS::ECS::CapacityProvider":                      "the deploy records no state to remove",
+	"AWS::SSM::Association":                           "the deploy records no state to remove",
+	"AWS::SecretsManager::SecretTargetAttachment":     "the deploy records no state to remove",
+	"AWS::Route53::RecordSetGroup": "the group's record sets were created as " +
+		"AWS::Route53::RecordSet dispatches that the stack does not record, so they " +
+		"are not swept",
+	"AWS::ECR::LifecyclePolicy": "ECR's DeleteLifecyclePolicy is not routed; deleting " +
+		"the repository removes its lifecycle policy with it",
+	"AWS::ApiGateway::UsagePlanKey": "API Gateway's DeleteUsagePlanKey is not routed, " +
+		"so the key stays attached until its usage plan is deleted",
+	"AWS::Cognito::IdentityPoolRoleAttachment": "Cognito models no " +
+		"DeleteIdentityPoolRoles; the roles are removed with the identity pool",
+	"AWS::SecretsManager::RotationSchedule": "Secrets Manager's CancelRotateSecret is " +
+		"not routed, so the schedule stays until the secret is deleted",
+}
+
+// queryDeleter builds a deleter for a query-protocol API: one action name and one
+// parameter naming the resource, which covers most of EC2, RDS, ElastiCache and SNS.
+func queryDeleter(service, operation, param string) cfnDeleteRequestFunc {
+	return func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		return &AWSRequest{Service: service, Operation: operation,
+			Headers: map[string]string{},
+			Params:  map[string]string{param: dr.PhysicalID}}
+	}
+}
+
+// jsonBodyDeleter builds a deleter for a JSON-protocol API: one action name and a
+// body carrying the single field that names the resource.
+func jsonBodyDeleter(service, operation, field string) cfnDeleteRequestFunc {
+	return func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		body, err := json.Marshal(map[string]interface{}{field: dr.PhysicalID})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: service, Operation: operation, Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	}
+}
+
+// pathDeleter builds a deleter for a REST API, where the operation is the HTTP
+// method and the resource is named by the path. The plugin routes on the path, so
+// Operation is "DELETE" rather than an action name — the same asymmetry the deploy
+// side has, where these types dispatch "POST".
+func pathDeleter(service, prefix string) cfnDeleteRequestFunc {
+	return func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		return &AWSRequest{Service: service, Operation: "DELETE",
+			Path: prefix + dr.PhysicalID, Headers: map[string]string{},
+			Params: map[string]string{}}
+	}
+}
+
+// apiGatewayChildDeleter builds a deleter for a REST resource nested under a parent
+// whose ID the child does not carry: the parent comes from the template property
+// named by parentProp, resolved through the stack's own context so a Ref to the
+// parent resolves to the ID the deploy used.
+//
+// A child whose parent property is absent or unresolvable yields nil, which the
+// sweep reports as a skip. Guessing a path without the parent would produce a
+// request the plugin routes somewhere else entirely.
+func apiGatewayChildDeleter(parentProp string, path func(parentID, childID string) string) cfnDeleteRequestFunc {
+	return func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		parent := resolveStringProp(props, parentProp, "", cctx)
+		if parent == "" {
+			return nil
+		}
+		return &AWSRequest{Service: cfnServiceForPath(path(parent, dr.PhysicalID)),
+			Operation: "DELETE", Path: path(parent, dr.PhysicalID),
+			Headers: map[string]string{}, Params: map[string]string{}}
+	}
+}
+
+// cfnServiceForPath names the service a nested REST delete path belongs to. The
+// three families apiGatewayChildDeleter serves are distinguishable by their path
+// prefix, which is what keeps that helper to one parameter instead of two.
+func cfnServiceForPath(path string) string {
+	switch {
+	case strings.HasPrefix(path, "/v2/apis/"):
+		return "apigatewayv2"
+	case strings.HasPrefix(path, "/v1/apis/"):
+		return "appsync"
+	default:
+		return "apigateway"
+	}
+}
+
+// sgRuleDeleter builds the revoke for a standalone security-group rule.
+//
+// A rule is not addressed by an ID: EC2 assigns an opaque sgr- identifier that
+// substrate does not model, so the deploy records the *group* as the physical ID and
+// a revoke has to restate the permission it authorized. The parameters are rebuilt
+// from the template with the same sgRuleParams the deploy used, which is what makes
+// the revoke match — removePerm compares protocol, ports and source, so a revoke
+// built any other way would silently remove nothing.
+func sgRuleDeleter(action string) cfnDeleteRequestFunc {
+	return func(_ *StackDeployer, dr DeployedResource, props map[string]interface{}, cctx *cfnContext) *AWSRequest {
+		if dr.PhysicalID == "" {
+			return nil
+		}
+		params := map[string]string{"Action": action, "GroupId": dr.PhysicalID}
+		for k, v := range sgRuleParams(props, "IpPermissions.1.", cctx) {
+			params[k] = v
+		}
+		return &AWSRequest{Service: "ec2", Operation: action, Params: params,
+			Headers: map[string]string{}}
+	}
+}
+
+// iamDeleter builds a deleter for IAM, which accepts its parameters as a form body
+// rather than as query parameters.
+func iamDeleter(operation, field string) cfnDeleteRequestFunc {
+	return func(_ *StackDeployer, dr DeployedResource, _ map[string]interface{}, _ *cfnContext) *AWSRequest {
+		body, err := json.Marshal(map[string]string{field: dr.PhysicalID})
+		if err != nil {
+			return nil
+		}
+		return &AWSRequest{Service: "iam", Operation: operation, Body: body,
+			Headers: map[string]string{}, Params: map[string]string{}}
+	}
+}
+
+// CFNResourceDeletion records what the sweep did with one resource. It is the
+// per-resource half of a DELETE_FAILED status: a stack that failed to delete has to
+// say which resource failed and why, or a caller cannot act on it.
+type CFNResourceDeletion struct {
+	// LogicalID is the resource's logical ID in the template.
+	LogicalID string `json:"LogicalID"`
+
+	// Type is the CloudFormation resource type.
+	Type string `json:"Type"`
+
+	// Status is "DELETE_COMPLETE", "DELETE_SKIPPED" or "DELETE_FAILED".
+	Status string `json:"Status"`
+
+	// Reason explains a skip or a failure, and is empty for a completed delete.
+	Reason string `json:"Reason,omitempty"`
+}
+
+// Resource deletion statuses, matching the values CloudFormation reports for a
+// resource in DescribeStackEvents.
+const (
+	cfnDeleteComplete = "DELETE_COMPLETE"
+	cfnDeleteSkipped  = "DELETE_SKIPPED"
+	cfnDeleteFailed   = "DELETE_FAILED"
+)
+
+// deleteStackResources deletes a stack's resources in the reverse of the order
+// Deploy created them, and reports what happened to each.
+//
+// Ordering is the exact inverse of Deploy's: descending typePriority, ties broken by
+// descending logical ID. That matters because the priorities encode real
+// dependencies — a subnet cannot go before the instances in it — and reversing the
+// same map is what guarantees the teardown order is consistent with the build order
+// rather than merely plausible.
+//
+// A resource that is already absent counts as deleted. A sweep's goal is that the
+// resource not exist, and a resource deleted out of band has met it; treating
+// not-found as a failure would wedge the stack permanently on a condition the caller
+// cannot fix.
+func (d *StackDeployer) deleteStackResources(
+	ctx context.Context, stack *CFNStackState, streamID string, op cfnDeletionOp,
+) []CFNResourceDeletion {
+	// The template supplies the deletion policies and the properties a nested
+	// resource's delete needs. A template that no longer parses is not a reason to
+	// leave every resource behind: the sweep proceeds with no policies and no
+	// properties, which deletes the types that need neither and skips the rest.
+	var (
+		policies = map[string]string{}
+		props    = map[string]map[string]interface{}{}
+		cctx     *cfnContext
+	)
+	if tmpl, err := d.parseCFNTemplate(stack.TemplateBody); err == nil {
+		cctx = buildCFNContext(tmpl, stack.Parameters, d.identity.region, d.identity.accountID,
+			stack.StackName)
+		evaluateConditions(tmpl, cctx)
+		for logicalID, res := range tmpl.Resources {
+			policies[logicalID] = cfnDeletionPolicyFor(res)
+			props[logicalID] = res.Properties
+		}
+	} else {
+		cctx = &cfnContext{
+			params: stack.Parameters, conditions: map[string]bool{},
+			resources: map[string]DeployedResource{},
+			region:    d.identity.region, accountID: d.identity.accountID,
+			stackName: stack.StackName,
+		}
+		d.logger.Warn("cfn: stack template no longer parses; deleting without policies",
+			"stack", stack.StackName, "error", err.Error())
+	}
+
+	// Ref and GetAtt in a surviving resource's properties must resolve to what the
+	// deploy produced, so the context is seeded with the deployed resources rather
+	// than left empty.
+	for _, dr := range stack.Resources {
+		cctx.resources[dr.LogicalID] = dr
+	}
+
+	ordered := make([]DeployedResource, len(stack.Resources))
+	copy(ordered, stack.Resources)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		pi, pj := cfnTypePriority(ordered[i].Type), cfnTypePriority(ordered[j].Type)
+		if pi != pj {
+			return pi > pj
+		}
+		return ordered[i].LogicalID > ordered[j].LogicalID
+	})
+
+	results := make([]CFNResourceDeletion, 0, len(ordered))
+	for _, dr := range ordered {
+		results = append(results, d.deleteOneResource(ctx, dr, policies[dr.LogicalID],
+			props[dr.LogicalID], cctx, streamID, op))
+	}
+	return results
+}
+
+// deleteOneResource applies a resource's deletion policy and, if it calls for a
+// delete, dispatches it.
+func (d *StackDeployer) deleteOneResource(
+	ctx context.Context, dr DeployedResource, policy string,
+	props map[string]interface{}, cctx *cfnContext, streamID string, op cfnDeletionOp,
+) CFNResourceDeletion {
+	result := CFNResourceDeletion{LogicalID: dr.LogicalID, Type: dr.Type}
+
+	// A resource that never came up has nothing to delete. Its create was refused,
+	// so there is no physical resource behind it — which is also why a rollback
+	// sweep does not report the failed resource as a failed delete.
+	if dr.Error != "" {
+		result.Status = cfnDeleteSkipped
+		result.Reason = "resource was not created: " + dr.Error
+		return result
+	}
+
+	if policy == "" {
+		policy = cfnPolicyDelete
+	}
+	if !cfnValidDeletionPolicies[policy] {
+		result.Status = cfnDeleteFailed
+		result.Reason = fmt.Sprintf("invalid DeletionPolicy %q", policy)
+		return result
+	}
+	if cfnPolicyRetainsResource(policy, op) {
+		result.Status = cfnDeleteSkipped
+		result.Reason = "DeletionPolicy " + policy
+		return result
+	}
+	if policy == cfnPolicySnapshot {
+		// Substrate models no snapshot for any type, so saying so is the honest
+		// answer: the resource is deleted, and the snapshot the template asked for
+		// does not exist. Reporting DELETE_COMPLETE with no reason would imply one
+		// was taken.
+		reason := "Snapshot is not modeled; the resource was deleted without one"
+		if !cfnSnapshotCapableTypes[dr.Type] {
+			reason = "Snapshot is not supported for " + dr.Type +
+				"; the resource was deleted without one"
+		}
+		d.logger.Warn("cfn: DeletionPolicy Snapshot is not modeled",
+			"logical_id", dr.LogicalID, "type", dr.Type)
+		snapshotResult := result
+		snapshotResult.Reason = reason
+		return d.deleteViaTable(ctx, dr, props, cctx, streamID, snapshotResult)
+	}
+
+	return d.deleteViaTable(ctx, dr, props, cctx, streamID, result)
+}
+
+// deleteViaTable looks a resource's deleter up, dispatches what it builds, and
+// returns success carrying the reason already on result — which is how a Snapshot
+// delete keeps its "no snapshot was taken" note while sharing this path.
+func (d *StackDeployer) deleteViaTable(
+	ctx context.Context, dr DeployedResource, props map[string]interface{},
+	cctx *cfnContext, streamID string, result CFNResourceDeletion,
+) CFNResourceDeletion {
+	if cfnStubDeleteTypes[dr.Type] {
+		if err := d.deleteStubKey(ctx, dr, cctx); err != nil {
+			result.Status = cfnDeleteFailed
+			result.Reason = err.Error()
+			return result
+		}
+		result.Status = cfnDeleteComplete
+		return result
+	}
+	if reason, inert := cfnDeleteInertTypes[dr.Type]; inert {
+		result.Status = cfnDeleteSkipped
+		result.Reason = reason
+		return result
+	}
+
+	deleter, ok := cfnResourceDeleters[dr.Type]
+	if !ok {
+		// A type the deployer does not recognize at all went through
+		// deployGenericStub, whose only trace is a cfnStubNamespace key — so
+		// removing that key is the whole of its delete, and leaving it would let a
+		// redeployed stack read the previous one's properties. The result is still a
+		// skip rather than a completion: substrate never created a resource for this
+		// type, and reporting DELETE_COMPLETE would claim it deleted one.
+		if err := d.deleteStubKey(ctx, dr, cctx); err != nil {
+			result.Status = cfnDeleteFailed
+			result.Reason = err.Error()
+			return result
+		}
+		result.Status = cfnDeleteSkipped
+		result.Reason = "no delete is modeled for " + dr.Type
+		return result
+	}
+	req := deleter(d, dr, props, cctx)
+	if req == nil {
+		result.Status = cfnDeleteSkipped
+		result.Reason = "the delete request for " + dr.Type + " could not be built"
+		return result
+	}
+	if failure := d.dispatchResourceDelete(ctx, dr, req, streamID); failure != nil {
+		return *failure
+	}
+	result.Status = cfnDeleteComplete
+	return result
+}
+
+// deleteStubKey removes the cfnStubNamespace entry a state-only deploy wrote, keyed
+// the way stubStore and deployGenericStub both key it: account, Region, logical ID.
+func (d *StackDeployer) deleteStubKey(
+	ctx context.Context, dr DeployedResource, cctx *cfnContext,
+) error {
+	key := fmt.Sprintf("%s/%s/%s", cctx.accountID, cctx.region, dr.LogicalID)
+	if err := d.state.Delete(ctx, cfnStubNamespace, key); err != nil {
+		return fmt.Errorf("delete stub state for %s: %w", dr.LogicalID, err)
+	}
+	return nil
+}
+
+// dispatchResourceDelete dispatches a resource's delete, returning a failure result
+// or nil on success. A not-found is success: see [StackDeployer.deleteStackResources].
+func (d *StackDeployer) dispatchResourceDelete(
+	ctx context.Context, dr DeployedResource, req *AWSRequest, streamID string,
+) *CFNResourceDeletion {
+	_, _, err := d.dispatch(ctx, req, streamID)
+	if err == nil || cfnDeleteIsAbsent(err) {
+		return nil
+	}
+	return &CFNResourceDeletion{LogicalID: dr.LogicalID, Type: dr.Type,
+		Status: cfnDeleteFailed, Reason: err.Error()}
+}
+
+// cfnDeleteAbsentCodes is the set of error codes that mean "the resource is already
+// gone", as the plugins reachable from [cfnResourceDeleters] actually spell it.
+//
+// Every entry was harvested by dispatching each table entry against a registry
+// holding no resources and recording the code that came back — not read off the AWS
+// references. The two sources disagree in ways that matter here: EC2 answers a
+// well-formed but unknown route table with InvalidRouteTableID.NotFound while its
+// security group is InvalidGroup.NotFound (no "ID"), and ECS reports a missing task
+// definition as the generic ClientException. A hand-written list gets those wrong,
+// and getting one wrong means a stack wedges in DELETE_FAILED on a resource that
+// does not exist.
+//
+// Codes are deliberately absent when they are not unambiguously an absence:
+// ValidationError and BadRequestException also carry malformed input, and treating
+// those as success would report a resource deleted that was never asked about
+// correctly.
+var cfnDeleteAbsentCodes = map[string]bool{
+	"ActivityDoesNotExist":              true,
+	"CacheClusterNotFound":              true,
+	"CacheParameterGroupNotFound":       true,
+	"CacheSubnetGroupNotFoundFault":     true,
+	"ClientException":                   true, // ECS's code for an absent task definition.
+	"ClusterNotFoundException":          true,
+	"DBClusterNotFoundFault":            true,
+	"DBInstanceNotFound":                true,
+	"DBParameterGroupNotFound":          true,
+	"DBSubnetGroupNotFoundFault":        true,
+	"FileSystemNotFound":                true,
+	"InvalidAllocationID.NotFound":      true,
+	"InvalidGroup.NotFound":             true,
+	"InvalidInstanceID.NotFound":        true,
+	"InvalidInternetGatewayID.NotFound": true,
+	"InvalidLaunchTemplateId.NotFound":  true,
+	"InvalidRouteTableID.NotFound":      true,
+	"InvalidSubnetID.NotFound":          true,
+	"InvalidVpcID.NotFound":             true,
+	"NatGatewayNotFound":                true,
+	"NoSuchBucket":                      true,
+	"NoSuchDistribution":                true,
+	"NoSuchEntity":                      true,
+	"NoSuchHostedZone":                  true,
+	"NotFound":                          true, // SNS DeleteTopic.
+	"NotFoundException":                 true,
+	"ParameterNotFound":                 true,
+	"QueueDoesNotExist":                 true,
+	"ReplicationGroupNotFoundFault":     true,
+	"RepositoryNotFoundException":       true,
+	"ResourceNotFoundException":         true,
+	"ServiceNotFoundException":          true,
+	"StateMachineDoesNotExist":          true,
+}
+
+// cfnDeleteIsAbsent reports whether a delete failed because the resource was
+// already gone.
+//
+// The match is on the error's code alone, taken from the "Code: Message" prefix
+// [AWSError.Error] and [cfnDispatchError] both produce. Matching the code rather
+// than searching the whole message is what stops a message that merely mentions a
+// resource being read as an absence — "NotFound" appears in plenty of prose — and
+// means rewording a plugin's message cannot turn a tolerated absence into a
+// stack-wedging failure.
+func cfnDeleteIsAbsent(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	code := msg
+	if i := strings.Index(msg, ": "); i >= 0 {
+		code = msg[:i]
+	}
+	return cfnDeleteAbsentCodes[code]
+}
+
+// cfnTypePriority is typePriority's lookup with the same default Deploy uses, so the
+// reverse sweep orders an unlisted type identically to the way Deploy ordered it.
+func cfnTypePriority(resType string) int {
+	if p, ok := typePriority[resType]; ok {
+		return p
+	}
+	return 99
+}

--- a/emulator/betty_cfn_delete_test.go
+++ b/emulator/betty_cfn_delete_test.go
@@ -1,0 +1,495 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The templates the sweep tests deploy. They are declared here rather than inline
+// because several tests deploy the same stack and assert different halves of the
+// outcome, and a divergence between two copies of a template would look like a
+// divergence in the sweep.
+const (
+	// cfnSweepBucketTemplate is #518's own reproduction: one bucket in one stack.
+	cfnSweepBucketTemplate = `{"Resources":{"Data":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":"sweep-data"}}}}`
+
+	// cfnSweepRetainTemplate declares two buckets, one retained. A template with
+	// both is what proves the policy is read per resource rather than per stack.
+	cfnSweepRetainTemplate = `{"Resources":{` +
+		`"Gone":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"sweep-gone"}},` +
+		`"Kept":{"Type":"AWS::S3::Bucket","DeletionPolicy":"Retain",` +
+		`"Properties":{"BucketName":"sweep-kept"}}}}`
+
+	// cfnSweepOrderedTemplate spans four type priorities so the reverse ordering is
+	// observable: IAM::Role is 1, S3::Bucket is 2, and SQS::Queue and SNS::Topic are
+	// both 3 — the tie is what exercises the descending logical-ID tiebreak.
+	cfnSweepOrderedTemplate = `{"Resources":{` +
+		`"Role":{"Type":"AWS::IAM::Role","Properties":{"RoleName":"sweep-role",` +
+		`"AssumeRolePolicyDocument":{"Statement":[]}}},` +
+		`"Bucket":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"sweep-ordered"}},` +
+		`"Queue":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"sweep-queue"}},` +
+		`"Topic":{"Type":"AWS::SNS::Topic","Properties":{"TopicName":"sweep-topic"}}}}`
+)
+
+// newSweepDeployer builds a deployer over the full default plugin set with the
+// event store recording, and returns it with the state manager, the object mirror
+// and the store.
+//
+// It does not reuse newTestDeployer: that helper registers six plugins by hand, and
+// a sweep dispatches into whichever service the template names — so a test asserting
+// "the resource is gone" against a registry missing that service would be asserting
+// ServiceNotAvailable. RegisterDefaultPlugins is also what the server uses, which is
+// the configuration the issue was filed against.
+//
+// The event store matters as much: the reverse-order assertion reads the recorded
+// operations, so recording has to be on. It is on in DefaultConfig, and stating that
+// here is cheaper than discovering later that the ordering test asserted nothing.
+func newSweepDeployer(t *testing.T) (*emulator.StackDeployer,
+	*emulator.MemoryStateManager, afero.Fs, *emulator.EventStore) {
+	t.Helper()
+	ctx := context.Background()
+	cfg := emulator.DefaultConfig()
+	require.True(t, cfg.EventStore.Enabled,
+		"the ordering assertion reads recorded events, so recording must be on")
+
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	registry := emulator.NewPluginRegistry()
+	require.NoError(t, emulator.RegisterDefaultPlugins(ctx, registry, state, tc, logger,
+		store, nil))
+
+	// The S3 plugin RegisterDefaultPlugins built owns its own in-memory mirror, and
+	// a HEAD goes through the plugin rather than the filesystem, so the mirror is
+	// returned only for the tests that inspect object bodies.
+	fs := afero.NewMemMapFs()
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs),
+		state, fs, store
+}
+
+// headBucket reports the status a HeadBucket against name returns, which is the
+// observable #518 is about: "head-bucket → 404, was 200".
+//
+// The error the dispatch returns is deliberately ignored: a 404 is reported as one,
+// and a 404 is the answer these tests are looking for. The status on the response is
+// the observable either way, so requiring no error would make the probe fail on
+// exactly the outcome it exists to detect.
+func headBucket(t *testing.T, d *emulator.StackDeployer, name string) int {
+	t.Helper()
+	resp, _ := d.DispatchForTest(context.Background(), &emulator.AWSRequest{
+		Service: "s3", Operation: "HEAD", Path: "/" + name,
+		Headers: map[string]string{}, Params: map[string]string{},
+	}, "probe")
+	require.NotNil(t, resp, "the probe must reach the plugin")
+	return resp.StatusCode
+}
+
+// sweepOperations returns the operations recorded for a stream, in order. The
+// sweep's ordering is only observable through this: the resources vanish either
+// way, and the order they vanished in is recorded nowhere else.
+func sweepOperations(t *testing.T, store *emulator.EventStore, streamID string) []string {
+	t.Helper()
+	events, err := store.GetEvents(context.Background(),
+		emulator.EventFilter{StreamID: streamID})
+	require.NoError(t, err)
+	ops := make([]string, 0, len(events))
+	for _, ev := range events {
+		ops = append(ops, ev.Operation)
+	}
+	return ops
+}
+
+// TestCFN_DeleteStackDeletesItsResources is #518's own reproduction. Before the
+// sweep, DeleteStack removed the stack record and the bucket stayed: a test that
+// tore its stack down and asserted cleanliness passed for the wrong reason.
+func TestCFN_DeleteStackDeletesItsResources(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnSweepBucketTemplate, "sweep", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, headBucket(t, d, "sweep-data"),
+		"the deploy must have created the bucket, or the delete proves nothing")
+
+	require.NoError(t, d.DeleteStack(ctx, "sweep"))
+
+	assert.Equal(t, http.StatusNotFound, headBucket(t, d, "sweep-data"),
+		"the bucket dies with its stack")
+
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, stacks, "a fully swept stack removes its own record")
+}
+
+// TestCFN_DeletionPolicyRetainKeepsTheResource pins both halves of Retain: the
+// retained resource survives and the stack still goes away.
+//
+// Only asserting the first half would pass on an implementation that refused the
+// whole delete, which is the opposite of what Retain means — "keeps the resource,
+// removing it from the stack's scope only".
+func TestCFN_DeletionPolicyRetainKeepsTheResource(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnSweepRetainTemplate, "retained", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, d.DeleteStack(ctx, "retained"))
+
+	assert.Equal(t, http.StatusNotFound, headBucket(t, d, "sweep-gone"),
+		"the unmarked bucket defaults to Delete")
+	assert.Equal(t, http.StatusOK, headBucket(t, d, "sweep-kept"),
+		"DeletionPolicy Retain keeps the bucket")
+
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, stacks,
+		"a retained resource is not a failed delete: the stack still goes")
+}
+
+// TestCFN_SweepOrderIsTheInverseOfDeploy is the ordering gate, and it asserts the
+// recorded operation *sequence* rather than set membership.
+//
+// The priorities encode real dependencies — a subnet cannot go before the instances
+// in it — so a sweep in any other order is a sweep that happens to work on templates
+// whose resources are independent. Reversing the same map Deploy sorts by is what
+// makes the teardown order consistent with the build order rather than merely
+// plausible, and the recorded events are the only place that is observable.
+func TestCFN_SweepOrderIsTheInverseOfDeploy(t *testing.T) {
+	d, _, _, store := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnSweepOrderedTemplate, "ordered", nil)
+	require.NoError(t, err)
+
+	created := sweepOperations(t, store, "ordered")
+	require.Equal(t, []string{"CreateRole", "CreateBucket", "CreateQueue", "CreateTopic"},
+		created, "ascending priority, ties by ascending logical ID")
+
+	require.NoError(t, d.DeleteStack(ctx, "ordered"))
+
+	all := sweepOperations(t, store, "ordered")
+	deleted := all[len(created):]
+	assert.Equal(t, []string{"DeleteTopic", "DeleteQueue", "DeleteBucket", "DeleteRole"},
+		deleted, "the sweep is the exact inverse: descending priority, ties descending")
+}
+
+// TestCFN_SweepToleratesAResourceDeletedOutOfBand pins that a not-found is a
+// success for a sweep.
+//
+// A sweep's goal is that the resource not exist, and a resource someone deleted by
+// hand has met it. Treating not-found as a failure would wedge the stack in
+// DELETE_FAILED permanently on a condition no caller can fix — the resource cannot
+// be un-deleted.
+func TestCFN_SweepToleratesAResourceDeletedOutOfBand(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnSweepRetainTemplate, "outofband", nil)
+	require.NoError(t, err)
+
+	// Delete one of the buckets behind the stack's back, exactly as a caller
+	// reaching for the S3 API directly would.
+	resp, err := d.DispatchForTest(ctx, &emulator.AWSRequest{
+		Service: "s3", Operation: "DELETE", Path: "/sweep-gone",
+		Headers: map[string]string{}, Params: map[string]string{},
+	}, "outofband")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	assert.NoError(t, d.DeleteStack(ctx, "outofband"),
+		"an already-absent resource is not a failed delete")
+
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, stacks, "so the stack record still goes")
+}
+
+// TestCFN_AFailedDeleteRetainsTheStack pins the retention rule: a stack that
+// reports DELETE_FAILED stays visible, with the failing resource named.
+//
+// A stack that reports a failed delete and then vanishes from DescribeStacks is a
+// worse lie than the leak: the caller has no way to retry and no way to learn which
+// resource is holding it. The failure here is real rather than injected — a bucket
+// holding an object the stack did not create is refused by DeleteBucket, which is
+// what CloudFormation does too.
+func TestCFN_AFailedDeleteRetainsTheStack(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnSweepBucketTemplate, "wedged", nil)
+	require.NoError(t, err)
+
+	resp, err := d.DispatchForTest(ctx, &emulator.AWSRequest{
+		Service: "s3", Operation: "PUT", Path: "/sweep-data/left-behind.txt",
+		Body: []byte("not the stack's"), Headers: map[string]string{},
+		Params: map[string]string{},
+	}, "wedged")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	deleteErr := d.DeleteStack(ctx, "wedged")
+	require.Error(t, deleteErr, "a non-empty bucket cannot be deleted")
+	assert.ErrorIs(t, deleteErr, emulator.ErrCFNDeleteFailed)
+	assert.Contains(t, deleteErr.Error(), "Data",
+		"the error names the resource holding the stack")
+
+	stacks, err := d.ListStacks(ctx)
+	require.Len(t, stacks, 1, "the stack stays visible so the delete can be retried")
+	require.NoError(t, err)
+	assert.Equal(t, "DELETE_FAILED", stacks[0].Status)
+	require.Len(t, stacks[0].ResourceDeletions, 1)
+	assert.Equal(t, "Data", stacks[0].ResourceDeletions[0].LogicalID)
+	assert.Equal(t, "DELETE_FAILED", stacks[0].ResourceDeletions[0].Status)
+	assert.Contains(t, stacks[0].ResourceDeletions[0].Reason, "BucketNotEmpty",
+		"the reason is the plugin's own refusal, not a paraphrase")
+
+	assert.Equal(t, http.StatusOK, headBucket(t, d, "sweep-data"),
+		"and the bucket is still there, which is why the delete failed")
+}
+
+// TestCFN_AnUnmodeledTypeIsReportedAsSkipped pins the difference between a known
+// gap and a false claim of cleanliness.
+//
+// A type substrate does not deploy through any real API has nothing to delete, and
+// the sweep says so — naming the type — rather than reporting DELETE_COMPLETE for a
+// resource it never touched. The stack still deletes: an unmodeled type is not a
+// failure, it is a stated absence.
+func TestCFN_AnUnmodeledTypeIsReportedAsSkipped(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	// AWS::ECR::LifecyclePolicy is in the table's inert set: ECR routes no
+	// DeleteLifecyclePolicy, so there is nothing to dispatch.
+	tmpl := `{"Resources":{` +
+		`"Repo":{"Type":"AWS::ECR::Repository","Properties":{"RepositoryName":"sweep-repo"}},` +
+		`"Policy":{"Type":"AWS::ECR::LifecyclePolicy","Properties":{` +
+		`"RepositoryName":"sweep-repo","LifecyclePolicyText":"{}"}}}}`
+	_, err := d.Deploy(ctx, tmpl, "gapped", nil)
+	require.NoError(t, err)
+
+	deletions := d.DeleteStackResourcesForTest(ctx, "gapped")
+	byID := map[string]emulator.CFNResourceDeletion{}
+	for _, del := range deletions {
+		byID[del.LogicalID] = del
+	}
+	require.Contains(t, byID, "Policy")
+	assert.Equal(t, "DELETE_SKIPPED", byID["Policy"].Status,
+		"a type with no modeled delete is skipped, not silently completed")
+	assert.Contains(t, byID["Policy"].Reason, "DeleteLifecyclePolicy",
+		"and the reason names what is missing")
+	assert.Equal(t, "DELETE_COMPLETE", byID["Repo"].Status,
+		"the repository next to it still deletes")
+
+	// A skip is not a failure, so the record still goes.
+	require.NoError(t, d.DeleteStack(ctx, "gapped"))
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, stacks)
+}
+
+// TestCFN_AStateOnlyTypeLosesItsStubKey pins the leak the stub set exists to close.
+//
+// A state-only resource writes its properties into the cfn_stub namespace and
+// dispatches nothing. A sweep that dispatched nothing for it would leave that key
+// behind, and a stack redeployed under the same logical ID would read the previous
+// stack's properties — the same "recreated resource inherits the old one's
+// configuration" shape #508 fixed inside S3.
+func TestCFN_AStateOnlyTypeLosesItsStubKey(t *testing.T) {
+	d, state, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	tmpl := `{"Resources":{"ACL":{"Type":"AWS::WAFv2::WebACL","Properties":{` +
+		`"Name":"sweep-acl","Scope":"REGIONAL"}}}}`
+	_, err := d.Deploy(ctx, tmpl, "stubbed", nil)
+	require.NoError(t, err)
+
+	keys, err := state.List(ctx, "cfn_stub", "")
+	require.NoError(t, err)
+	require.Contains(t, keys, "123456789012/us-east-1/ACL",
+		"the deploy records the properties, which is the state that can leak")
+
+	require.NoError(t, d.DeleteStack(ctx, "stubbed"))
+
+	keys, err = state.List(ctx, "cfn_stub", "")
+	require.NoError(t, err)
+	assert.NotContains(t, keys, "123456789012/us-east-1/ACL",
+		"and the sweep removes them, so a redeploy starts clean")
+}
+
+// TestCFN_AnInvalidDeletionPolicyFailsTheDelete pins the reason DeletionPolicy is
+// validated rather than defaulted.
+//
+// A typo'd "Retian" that silently fell back to Delete would destroy the resource the
+// attribute was written to protect — the one failure mode the attribute exists to
+// prevent. CloudFormation rejects such a template outright; substrate refuses the
+// delete and names the value, which keeps the resource.
+func TestCFN_AnInvalidDeletionPolicyFailsTheDelete(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	tmpl := `{"Resources":{"Data":{"Type":"AWS::S3::Bucket",` +
+		`"DeletionPolicy":"Retian","Properties":{"BucketName":"sweep-typo"}}}}`
+	_, err := d.Deploy(ctx, tmpl, "typo", nil)
+	require.NoError(t, err)
+
+	deleteErr := d.DeleteStack(ctx, "typo")
+	require.Error(t, deleteErr)
+	assert.ErrorIs(t, deleteErr, emulator.ErrCFNDeleteFailed)
+	assert.Contains(t, deleteErr.Error(), `invalid DeletionPolicy "Retian"`)
+
+	assert.Equal(t, http.StatusOK, headBucket(t, d, "sweep-typo"),
+		"the bucket is kept rather than deleted on a guess")
+}
+
+// TestCFN_SnapshotDeletesAndSaysNoSnapshotWasTaken pins the honest answer for a
+// policy substrate does not model.
+//
+// Snapshot does not retain — it snapshots, then deletes — so reporting the resource
+// as retained would be wrong, and reporting DELETE_COMPLETE with no reason would
+// imply a snapshot exists. The resource goes and the absence is stated.
+func TestCFN_SnapshotDeletesAndSaysNoSnapshotWasTaken(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	// An S3 bucket does not support Snapshot at all, which is the case that has to
+	// be distinguished from a type that does.
+	tmpl := `{"Resources":{"Data":{"Type":"AWS::S3::Bucket",` +
+		`"DeletionPolicy":"Snapshot","Properties":{"BucketName":"sweep-snap"}}}}`
+	_, err := d.Deploy(ctx, tmpl, "snap", nil)
+	require.NoError(t, err)
+
+	deletions := d.DeleteStackResourcesForTest(ctx, "snap")
+	require.Len(t, deletions, 1)
+	assert.Equal(t, "DELETE_COMPLETE", deletions[0].Status,
+		"Snapshot deletes; it does not retain")
+	assert.Contains(t, deletions[0].Reason, "not supported",
+		"and the reason records that no snapshot exists")
+	assert.Equal(t, http.StatusNotFound, headBucket(t, d, "sweep-snap"))
+}
+
+// TestCFN_RDSDefaultsToSnapshotWithoutADeclaration pins the default the reference
+// carves out: "the default policy is Snapshot for AWS::RDS::DBCluster resources and
+// for AWS::RDS::DBInstance resources that don't specify the DBClusterIdentifier
+// property".
+//
+// The observable is the reason, not the outcome: Snapshot and Delete both delete, so
+// a sweep that resolved the default as Delete would look identical except that it
+// would not record a snapshot was expected. An instance inside a cluster follows the
+// cluster's fate, so its own default is Delete — asserted here so the property test
+// cannot quietly become a type test.
+func TestCFN_RDSDefaultsToSnapshotWithoutADeclaration(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	tmpl := `{"Resources":{` +
+		`"Standalone":{"Type":"AWS::RDS::DBInstance","Properties":{` +
+		`"DBInstanceIdentifier":"sweep-solo","DBInstanceClass":"db.t3.micro",` +
+		`"Engine":"postgres"}},` +
+		`"Member":{"Type":"AWS::RDS::DBInstance","Properties":{` +
+		`"DBInstanceIdentifier":"sweep-member","DBInstanceClass":"db.t3.micro",` +
+		`"Engine":"aurora-postgresql","DBClusterIdentifier":"sweep-cluster"}}}}`
+	_, err := d.Deploy(ctx, tmpl, "rds", nil)
+	require.NoError(t, err)
+
+	deletions := d.DeleteStackResourcesForTest(ctx, "rds")
+	byID := map[string]emulator.CFNResourceDeletion{}
+	for _, del := range deletions {
+		byID[del.LogicalID] = del
+	}
+	require.Contains(t, byID, "Standalone")
+	require.Contains(t, byID, "Member")
+	assert.Contains(t, byID["Standalone"].Reason, "Snapshot",
+		"an instance outside a cluster defaults to Snapshot")
+	assert.Empty(t, byID["Member"].Reason,
+		"an instance inside a cluster defaults to Delete, so there is nothing to note")
+}
+
+// TestCFN_ARefusedResourceIsNotAFailedDelete pins the interaction with #516: a
+// resource whose create was refused has no physical resource behind it, so the
+// sweep has nothing to delete and must not report a failure.
+//
+// This is also what keeps a create rollback honest — the resource that failed the
+// deploy is the one thing the rollback definitely cannot delete.
+func TestCFN_ARefusedResourceIsNotAFailedDelete(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	// An uppercase bucket name is refused with InvalidBucketName.
+	tmpl := `{"Resources":{"Bad":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":"Sweep_Invalid_Name"}},` +
+		`"Good":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"sweep-ok"}}}}`
+	result, err := d.Deploy(ctx, tmpl, "refused", nil)
+	require.NoError(t, err)
+	var refused bool
+	for _, r := range result.Resources {
+		if r.LogicalID == "Bad" && r.Error != "" {
+			refused = true
+		}
+	}
+	require.True(t, refused, "the bucket must have been refused, or this proves nothing")
+
+	deletions := d.DeleteStackResourcesForTest(ctx, "refused")
+	byID := map[string]emulator.CFNResourceDeletion{}
+	for _, del := range deletions {
+		byID[del.LogicalID] = del
+	}
+	assert.Equal(t, "DELETE_SKIPPED", byID["Bad"].Status)
+	assert.Contains(t, byID["Bad"].Reason, "not created")
+	assert.Equal(t, "DELETE_COMPLETE", byID["Good"].Status)
+
+	assert.NoError(t, d.DeleteStack(ctx, "refused"),
+		"a resource that never existed does not wedge the stack")
+}
+
+// TestCFN_DeletingAnAbsentStackSucceeds pins the boundary the sweep must not break:
+// DeleteStack documents no not-found error, so deleting a stack that is not there
+// sweeps nothing and succeeds.
+func TestCFN_DeletingAnAbsentStackSucceeds(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	assert.NoError(t, d.DeleteStack(context.Background(), "never-deployed"))
+}
+
+// TestCFN_ASweepWhoseTemplateNoLongerParsesStillDeletes pins the fallback: a stack
+// record whose template has become unparseable is not a reason to leave every
+// resource behind.
+//
+// The template supplies deletion policies and the properties a nested delete needs,
+// so without it the sweep deletes the types that need neither and skips the rest —
+// which is strictly better than skipping all of them, and it is reported per
+// resource either way.
+func TestCFN_ASweepWhoseTemplateNoLongerParsesStillDeletes(t *testing.T) {
+	d, state, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnSweepBucketTemplate, "corrupt", nil)
+	require.NoError(t, err)
+
+	// Rewrite the persisted record with a template body that parses as neither JSON
+	// nor YAML, leaving the deployed resource list intact.
+	data, err := state.Get(ctx, "cfn", "stack:corrupt")
+	require.NoError(t, err)
+	var stack emulator.CFNStackState
+	require.NoError(t, json.Unmarshal(data, &stack))
+	stack.TemplateBody = "{\"Resources\": [this is not a template"
+	rewritten, err := json.Marshal(stack)
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "cfn", "stack:corrupt", rewritten))
+
+	require.NoError(t, d.DeleteStack(ctx, "corrupt"))
+	assert.Equal(t, http.StatusNotFound, headBucket(t, d, "sweep-data"),
+		"a bucket needs no template properties to delete, so it still goes")
+}

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -291,7 +291,20 @@ func (p *CloudFormationPlugin) deleteStack(reqCtx *RequestContext, req *AWSReque
 	// stack's exports, and export visibility is scoped per account and Region, so
 	// the default identity would consult the wrong namespace.
 	if err := p.deployerFor(reqCtx).DeleteStack(context.Background(), name); err != nil {
-		return nil, cfnMapDeployerError(err)
+		// A sweep that could not remove a resource is reported the way the API
+		// reports it: DeleteStack "returns success" and the stack reaches
+		// DELETE_FAILED, which the caller learns by polling DescribeStacks. Raising
+		// it on the call instead would be wrong twice over — a caller following AWS
+		// semantics gets an exception where the API gives it a status to poll, and
+		// the 500 it would have to be makes an SDK *retry* the delete, running the
+		// sweep again against a stack already in DELETE_FAILED.
+		//
+		// This mirrors CreateStack, where a refused resource is CREATE_FAILED on the
+		// resource and 200 on the call. The in-process deployer still returns
+		// [ErrCFNDeleteFailed], so a Go caller sees the failure directly.
+		if !errors.Is(err, ErrCFNDeleteFailed) {
+			return nil, cfnMapDeployerError(err)
+		}
 	}
 
 	type response struct {
@@ -1139,8 +1152,11 @@ func cfnMapDeployerError(err error) *AWSError {
 		}
 	default:
 		// A resource that failed to deploy lands here, as does anything
-		// unclassified: the template parsed and the request named things that
-		// exist, so the failure is substrate's rather than the caller's.
+		// unclassified: the template parsed and the request named things that exist,
+		// so the failure is substrate's rather than the caller's.
+		//
+		// [ErrCFNDeleteFailed] deliberately does not reach here — deleteStack
+		// answers 200 and leaves the stack in DELETE_FAILED, as the API does.
 		return &AWSError{Code: "InternalFailure", Message: msg, HTTPStatus: http.StatusInternalServerError}
 	}
 }

--- a/emulator/cloudformation_plugin_test.go
+++ b/emulator/cloudformation_plugin_test.go
@@ -559,6 +559,70 @@ func TestCFNPlugin_DeleteStack(t *testing.T) {
 	assert.Equal(t, http.StatusOK, code, "body was %s", body)
 }
 
+// TestCFNPlugin_DeleteStackSweepsItsResources is the wire half of #518: the
+// resource goes with the stack, and a resource that cannot be deleted leaves the
+// stack visible in DELETE_FAILED while the call itself still answers 200.
+//
+// The 200 is the point of the second half. Real DeleteStack "returns success" and
+// the stack reaches DELETE_FAILED asynchronously, which a caller learns by polling
+// DescribeStacks — so raising the failure on the call would both break a caller
+// following AWS semantics and, being a 500, make an SDK retry the delete and sweep
+// a stack already in DELETE_FAILED.
+func TestCFNPlugin_DeleteStackSweepsItsResources(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "swept",
+		"TemplateBody": cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	require.Equal(t, http.StatusOK, cfnHeadBucket(t, ts, "cfn-wire-bucket"),
+		"the stack's bucket exists before the delete")
+
+	code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "swept"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Equal(t, http.StatusNotFound, cfnHeadBucket(t, ts, "cfn-wire-bucket"),
+		"the bucket is deleted with its stack (#518)")
+
+	t.Run("a refused delete answers 200 and reports DELETE_FAILED", func(t *testing.T) {
+		code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+			"StackName":    "stuck",
+			"TemplateBody": cfnBucketTemplate,
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+		// A bucket holding an object the stack did not create is refused with
+		// BucketNotEmpty, which is a real refusal rather than an injected one.
+		put := httptest.NewRequest(http.MethodPut,
+			"http://s3.amazonaws.com/cfn-wire-bucket/keeper.txt", strings.NewReader("x"))
+		put.Host = "s3.amazonaws.com"
+		pw := httptest.NewRecorder()
+		ts.srv.ServeHTTP(pw, put)
+		require.Equal(t, http.StatusOK, pw.Code)
+
+		code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "stuck"})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+		code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "stuck"})
+		require.Equal(t, http.StatusOK, code, "the stack stays visible so a caller can retry")
+		assert.Contains(t, body, "<StackStatus>DELETE_FAILED</StackStatus>")
+		assert.Equal(t, http.StatusOK, cfnHeadBucket(t, ts, "cfn-wire-bucket"),
+			"the bucket the sweep could not delete is still there")
+	})
+}
+
+// cfnHeadBucket reports the status of a HEAD against a bucket, which is how a test
+// observes whether a swept resource is really gone. It goes through the same server
+// the stack deployed into: a bucket read from a registry of its own would be a
+// different bucket.
+func cfnHeadBucket(t *testing.T, ts *cfnTestServer, bucket string) int {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodHead, "http://s3.amazonaws.com/"+bucket, nil)
+	r.Host = "s3.amazonaws.com"
+	w := httptest.NewRecorder()
+	ts.srv.ServeHTTP(w, r)
+	return w.Code
+}
+
 // TestCFNPlugin_UpdateStack asserts the status moves to UPDATE_COMPLETE and that
 // the new template's resources are deployed.
 func TestCFNPlugin_UpdateStack(t *testing.T) {

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -546,3 +546,36 @@ func CFNSeededAZsForTest(region string) []string {
 	}
 	return out
 }
+
+// DispatchForTest routes req through the deployer's own registry, so a test can
+// observe a resource the way the sweep does.
+//
+// It exists because the delete sweep's whole claim is about state a caller can
+// observe through an API call: asserting a bucket is gone by reading the state
+// manager would assert the implementation rather than the observable, and a test
+// server of its own would be a second registry that need not agree with the one the
+// sweep dispatched into.
+func (d *StackDeployer) DispatchForTest(
+	ctx context.Context, req *AWSRequest, streamID string,
+) (*AWSResponse, error) {
+	resp, _, err := d.dispatch(ctx, req, streamID)
+	return resp, err
+}
+
+// DeleteStackResourcesForTest sweeps a persisted stack's resources and returns the
+// per-resource outcome, without touching the stack record.
+//
+// DeleteStack reports the per-resource detail only on failure — a successful sweep
+// removes the whole record — so this is the only way to assert what a *successful*
+// sweep decided: that a Snapshot policy deleted without a snapshot, that an
+// unmodeled type was skipped with a reason naming it, or that an RDS instance
+// resolved its default policy as Snapshot.
+func (d *StackDeployer) DeleteStackResourcesForTest(
+	ctx context.Context, stackName string,
+) []CFNResourceDeletion {
+	stack, err := d.loadStack(ctx, stackName)
+	if err != nil || stack == nil {
+		return nil
+	}
+	return d.deleteStackResources(ctx, stack, stackName, cfnDeleteStackOp)
+}


### PR DESCRIPTION
## The defect

Every resource a stack created outlived it. `DeleteStack` removed the stack record
and its name index and swept nothing:

```
aws cloudformation create-stack --stack-name probe --template-body file:///tmp/probe.json
aws cloudformation delete-stack --stack-name probe
aws s3api head-bucket --bucket probe-data     # 200 before, 404 now
```

A test that tears down and asserts cleanliness passed for the wrong reason. And
because the stack record is what *names* the resources, removing it first stranded
every one of them with no way left to find it.

## The sweep

Runs after `checkExportsNotImported` and before the record is dropped, in the exact
inverse of the deploy: descending `typePriority`, ties by descending logical ID.
Substrate deploys in priority order rather than from a dependency graph, so
inverting that order is what makes teardown ordering *observable* — the test asserts
the recorded event sequence, not set membership:

```
CreateRole, CreateBucket, CreateQueue, CreateTopic
DeleteTopic, DeleteQueue, DeleteBucket, DeleteRole
```

## A table, not a switch

`cfnResourceDeleters` follows `cfnDriftCheckers`: each entry **returns** an
`*AWSRequest` rather than performing the delete, so the sweep owns ordering, error
handling and event recording once and every entry stays a data declaration. It also
accommodates the four request shapes the deploy paths use — action-plus-params, JSON
body, REST path (routed *by path*, so `Operation` is the HTTP method), and
path-plus-parent-ID — which a single "delete by physical ID" helper could not.

Three things the table deliberately does not do:

- **It does not assume the physical ID is the delete identifier.** SQS records the
  queue *name* while `DeleteQueue` requires a `QueueUrl`. A standalone
  security-group rule records its *group*, because EC2's opaque `sgr-` ID is not
  modelled — so the revoke restates the permission the authorize granted, rebuilt
  through the same `sgRuleParams` the deploy used, since `removePerm` compares
  protocol, ports and source and a revoke built any other way silently removes
  nothing. An AppSync resolver's is `TypeName.FieldName` while the path wants the two
  separately.
- **It does not guess an operation from the type.** KMS has no `DeleteKey` at all, so
  its entry dispatches `ScheduleKeyDeletion`. Neither an SNS topic policy nor a
  Route 53 record set has a delete of its own: the first is an attribute set back to
  empty, the second a change batch carrying `Action DELETE` — each the mirror of the
  call that created it.
- **It does not read a parent ID off the resource.** The composite types re-resolve
  theirs from the stored template, which is where an API Gateway method's API *and*
  resource come from.

## Not-found is a success; anything else keeps the stack

A resource deleted out of band between the deploy and the sweep must not wedge its
stack, so the sweep tolerates 33 not-found codes. Each was **measured** — every
table entry dispatched against a registry holding no resources and the code
recorded — rather than read off a reference and hoped for.

Any other refusal is a failure, and a failed sweep keeps the stack: record, resource
list and name index all survive while `DescribeStacks` reports `DELETE_FAILED` with
the offending resource and the plugin's own error code as the reason. A stack that
reported a failed delete and then vanished would be a worse lie than the leak — a
caller would have no way to retry and no way to learn what held it.

**Found while verifying end to end, and not in the plan:** on the wire that failure
must be a **200**. Real `DeleteStack` "returns success" and the stack reaches
`DELETE_FAILED` asynchronously. Raising it on the call was wrong twice over — a
caller following AWS semantics got an exception where the API gives it a status to
poll, and the 500 it mapped to made the CLI **retry** the delete, sweeping a stack
already in `DELETE_FAILED` two more times. The in-process deployer still returns
`ErrCFNDeleteFailed`, so a Go caller sees the failure directly.

## DeletionPolicy

`DeletionPolicy` and `UpdateReplacePolicy` are added to `cfnResource` with both
`json` and `yaml` tags, which is the whole change for both template syntaxes. A
value outside the four is a template error rather than a silent default: a typo'd
`Retian` that deletes the resource is exactly what the attribute exists to prevent.

The default is resolved rather than assumed, because it is not uniformly `Delete` —
`Snapshot` for `AWS::RDS::DBCluster` and for an `AWS::RDS::DBInstance` declaring no
`DBClusterIdentifier`. `Snapshot` does not retain: substrate deletes and records in
the reason that no snapshot was taken, since no snapshot resource is modelled for
any of the eight Snapshot-capable types. `RetainExceptOnCreate` takes the operation
as a parameter rather than being special-cased by a caller, which is what #520's
create rollback needs.

## Coverage is stated, not implied

Of the **109** types the deployer dispatches: **89** have a delete request, **11**
are state-only types whose stub record is removed, and **9** report
`DELETE_SKIPPED` with a reason distinguishing "AWS models no delete" from "substrate
does not route the one it has" — different facts, and only the second is substrate's
to fix. `docs/services.md` enumerates all nine. 0 uncovered, 0 orphans, 0 overlaps.

This corrects the numbers in the issue ("113 types") and in the plan ("90/19"); both
were measured differently and neither matched.

A type the deployer does not recognize at all also skips — **a second leak found
here**: it deploys through `deployGenericStub`, which *does* write a `cfn_stub` key,
and the skip left it behind for a redeployed stack to read as the previous one's
properties. The key now goes, while the status stays `DELETE_SKIPPED` because
substrate never created a resource.

## Tests

13 new tests in `emulator/betty_cfn_delete_test.go` plus the wire half in
`cloudformation_plugin_test.go`, covering the issue's reproduction, `Retain`, the
ordering sequence, out-of-band deletion, `DELETE_FAILED` retention (via a *real*
`BucketNotEmpty` refusal, not an injected one), the unmodeled and state-only paths,
an invalid policy, the two `Snapshot` cases, a refused resource, an absent stack, and
a stack whose template no longer parses.

**Mutation testing — 7 applied, 7 CAUGHT, 0 EQUIVALENT, 0 SURVIVED:**

| Mutant | Result |
|---|---|
| sweep ordering not reversed | CAUGHT — the sequence assertion, so it is order and not membership |
| `Retain` treated as `Delete` | CAUGHT |
| `Delete` treated as `Retain` | CAUGHT (10 tests) |
| RDS default flipped to `Delete` | CAUGHT |
| a not-found treated as a failure | CAUGHT (3 tests) |
| `DELETE_FAILED` still removing the record | CAUGHT |
| `DELETE_FAILED` raised as a 500 | CAUGHT |

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → 0 issues,
`make test` (race), `make docs-reference-check docs-versions`, `npm --prefix docs run
build`, `go vet -C test/e2e ./...`, `go test -C test/e2e ./...` — all clean. End to
end against a running server: the swept bucket 404s, a `Retain` bucket stays at 200
while its stack goes, and the refused delete answers 200 with `DELETE_FAILED` and the
bucket intact.

## Compatibility

**A test asserting that a resource outlives its stack will go red — that is the
fix.** A test that deleted a stack and then deleted its resources explicitly now
finds them already gone; a not-found is tolerated by the sweep but not necessarily by
that test's own assertions.

Closes #518
