### PR TITLE
fix(cfn): a failed create rolls the stack back (#520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in both directions, yielding the empty object a marker is, where reading one as a
   source used to fail outright.
 
+- **A create whose resource failed now rolls the stack back** (#520). A stack holding
+  a resource a plugin refused still reported a terminal `CREATE_COMPLETE`, with every
+  resource beside it left in place — so a consumer's failure-handling path could not
+  be tested at all, because substrate never produced the failure that path exists to
+  handle. The default is `ROLLBACK`, as the API's is: the resources the create had
+  already made are swept through #518's dispatcher in the same reverse order a
+  `DeleteStack` uses, and the stack reaches `ROLLBACK_COMPLETE` naming the failed
+  resource and the plugin's own error code. The stack record stays, because a
+  `ROLLBACK_COMPLETE` stack still blocks a create of the same name — which is the one
+  thing that makes the failure impossible to miss.
+
+  `CreateStack`'s two failure parameters are read and honoured for the first time.
+  They are **mutually exclusive** — "you can specify either `DisableRollback` or
+  `OnFailure`, but not both" — so giving both is a `ValidationError` rather than a
+  precedence rule, and the test is *presence* rather than value: the CLI's
+  `--no-disable-rollback` sends `DisableRollback=false` explicitly, so a rule that
+  ignored a `false` would accept a combination the API rejects. `OnFailure=DO_NOTHING`
+  (equivalently `DisableRollback=true`) leaves everything standing at `CREATE_FAILED`,
+  which is what substrate used to do unconditionally; `OnFailure=DELETE` sweeps and
+  removes the record, so the `DeployResult`'s `DELETE_COMPLETE` is the only place that
+  outcome is readable. `DescribeStacks` now reports the option it was given rather
+  than emitting `DisableRollback: false` for every stack. A sweep that cannot delete
+  gives `ROLLBACK_FAILED` and keeps the record, so the undeleted resource is
+  discoverable. All of these answer **200** on the wire: real `CreateStack` returns
+  its `StackId` before any rollback happens, so a rolled-back stack is not a failed
+  call, and returning a 5xx would make an SDK retry a create that already ran.
+
+  A failed stack publishes **no outputs**, and therefore exports none — an import
+  resolving against a value whose resource never deployed is the silent-literal
+  failure the export model exists to prevent. A duplicate export name is still
+  answered as an error rather than as a rolled-back stack, because it is a refusal of
+  the *request*: a request substrate declines outright never became a stack whose
+  resources could roll back, and the refusal now reads the same whether or not some
+  resource beside it also failed.
+
+  A failed `UpdateStack` reports `UPDATE_ROLLBACK_COMPLETE`, and the approximation
+  behind that is stated rather than implied: `UpdateStack` is a re-`Deploy`, so the
+  stored previous template is the only description of the previous state substrate
+  holds, and the rollback re-deploys it. It converges on that template's *declared*
+  state rather than restoring properties field by field, so a resource the failed
+  update replaced may keep a new physical ID. A previous record that cannot be read
+  leaves the stack at `UPDATE_FAILED` with the reason logged, rather than a rollback
+  attempted against nothing.
+
+- **An unchanged resource no longer looks like a failed create on every update**
+  (#520), found while building the rollback rather than reported. Because
+  `UpdateStack` is a re-`Deploy` of the whole template, every unchanged resource's
+  create is re-issued and its plugin refuses it as already existing — where real
+  CloudFormation issues no call at all for a resource it is not changing. Before
+  rollback this was merely invisible: the refusal landed on the resource's error field
+  and the stack still said `UPDATE_COMPLETE`. With rollback added it becomes data
+  loss, since every `UpdateStack` would see failures and sweep the resources it was
+  asked to keep.
+
+  So an already-exists refusal is cleared when — and only when — the stack's previous
+  deployment created that logical ID *successfully* and the template still declares it
+  identically, compared as canonically marshalled JSON. Each of those conditions is
+  load-bearing: a rename into a name another stack owns, a resource that failed the
+  previous time (so this stack never owned the name), and a record belonging to
+  another account or region all remain real failures. The refusal cannot be keyed on
+  the physical ID, because a refused create returns an empty one.
+
 ## [v0.88.0] - 2026-08-03
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -258,13 +258,67 @@ aws cloudformation describe-stack-resources --stack-name badname
 # ResourceStatusReason: InvalidBucketName: The specified bucket is not valid.
 ```
 
-The stack itself still reaches a terminal `CREATE_COMPLETE`, and the resources
-declared after the failed one are **still deployed**. Real CloudFormation would
-roll the whole stack back to `ROLLBACK_COMPLETE`; substrate records the failure
-per resource and carries on. Rollback is not modelled — tracked in
-[#520](https://github.com/scttfrdmn/substrate/issues/520). Assert on the
-per-resource status rather than on the stack status when a template is expected
-to fail.
+**The stack rolls back.** By default the resources the create had already made are
+swept — in the same reverse order a `DeleteStack` uses — and the stack reaches
+`ROLLBACK_COMPLETE`, naming the resource that failed and the plugin's error code in
+its reason:
+
+```
+aws cloudformation create-stack --stack-name partial --template-body file:///tmp/partial.json
+aws cloudformation describe-stacks --stack-name partial \
+  --query 'Stacks[0].StackStatus'                    # ROLLBACK_COMPLETE
+aws sqs get-queue-url --queue-name still-here        # absent — swept with the stack
+```
+
+`CreateStack`'s two failure options both work, and are **mutually exclusive** as the
+API makes them: specifying `OnFailure` and `DisableRollback` together is a
+`ValidationError`, and the test is *presence* rather than value, so the CLI's
+`--no-disable-rollback` counts as specifying it.
+
+| Option | Outcome |
+|---|---|
+| `OnFailure=ROLLBACK` (default), `DisableRollback=false` | resources swept, stack reports `ROLLBACK_COMPLETE` |
+| `OnFailure=DO_NOTHING`, `DisableRollback=true` | nothing swept, stack reports `CREATE_FAILED` |
+| `OnFailure=DELETE` | resources swept and the stack record removed |
+
+Whichever was given is reported back: `DescribeStacks` emits `DisableRollback` as
+`true` for a `DO_NOTHING` stack rather than always `false`. A sweep that cannot
+delete a resource gives `ROLLBACK_FAILED`, and the stack keeps its record so the
+undeleted resource is discoverable. All of these answer **200** on the wire — real
+`CreateStack` has returned its `StackId` before the rollback happens, so a
+rolled-back stack is not a failed call; poll `DescribeStacks` for the outcome.
+
+`RetainExceptOnCreate` interacts here: it retains a resource for a `DeleteStack`
+sweep but **deletes** it for the rollback of the create that made it.
+
+A failed stack publishes **no outputs**, and therefore exports none — an import
+against a value whose resource never deployed would resolve against nothing. A
+duplicate export name is still refused as an error rather than as a rolled-back
+stack, so that refusal reads the same whether or not a resource beside it failed.
+
+Two divergences are substrate's own, both deliberate:
+
+- Substrate deploys the resources declared **after** the failure, where real
+  CloudFormation stops at the first one, so a single deploy reports every refusal a
+  template contains rather than only the first. The stack status is the same either
+  way, and the status is what a caller keys off. Under `DO_NOTHING` those later
+  resources are therefore left in place too.
+- A failed `UpdateStack` reports `UPDATE_ROLLBACK_COMPLETE` by **re-deploying the
+  stored previous template**, since that is the only description of the previous
+  state substrate holds. It converges on the previous template's *declared* state
+  rather than restoring properties field by field, so a resource the failed update
+  replaced may keep a new physical ID. A previous record that cannot be read leaves
+  the stack at `UPDATE_FAILED` with the reason logged rather than a rollback
+  attempted against nothing.
+
+Because an update is a re-deploy, an unchanged resource's create is re-issued and
+the plugin refuses it as already existing. That refusal is **not** a failure of the
+update: substrate clears it when the stack's previous deployment created that
+logical ID successfully *and* the template still declares it identically. A rename
+into a name another stack owns, a resource that failed the previous time, and a
+record belonging to another account or region are all left standing as real
+failures — without that guard every `UpdateStack` would roll back the resources it
+was asked to keep.
 
 A refused resource's follow-up configuration requests are not sent either. A bucket
 whose name S3 rejected has no `PUT ?versioning` issued against it, so the event log

--- a/emulator/betty.go
+++ b/emulator/betty.go
@@ -53,6 +53,25 @@ type DeployResult struct {
 
 	// Outputs contains the resolved CloudFormation Outputs section values.
 	Outputs map[string]string
+
+	// Status is the terminal stack status the deploy reached: CREATE_COMPLETE,
+	// UPDATE_COMPLETE, or one of the failure statuses when a resource failed —
+	// CREATE_FAILED, ROLLBACK_COMPLETE, ROLLBACK_FAILED, DELETE_COMPLETE,
+	// UPDATE_ROLLBACK_COMPLETE, UPDATE_ROLLBACK_FAILED.
+	//
+	// A failed create is reported here rather than as an error, the way the API
+	// reports it: real CreateStack has already returned its StackId before the
+	// rollback happens, so a rolled-back stack is not a failed call. For
+	// OnFailure=DELETE this is the *only* place the outcome is readable, since the
+	// stack record is gone.
+	Status string
+
+	// StatusReason explains a non-successful Status, and is empty otherwise.
+	StatusReason string
+
+	// ResourceDeletions records what a rollback did with each resource the failed
+	// create had created, and is empty when nothing was rolled back.
+	ResourceDeletions []CFNResourceDeletion
 }
 
 // BettyClient is a convenience wrapper for the full Betty.codes validation workflow.

--- a/emulator/betty_cfn.go
+++ b/emulator/betty_cfn.go
@@ -269,16 +269,33 @@ type CFNStackState struct {
 	// Status is the stack status (e.g., "CREATE_COMPLETE").
 	Status string `json:"Status"`
 
+	// StatusReason is the "success/failure message associated with the stack
+	// status", which for substrate is always a failure message: the reasons the
+	// resources that failed gave, or what a rollback could not delete. It is what a
+	// caller reads to learn *why* a stack is not CREATE_COMPLETE without walking
+	// every resource.
+	StatusReason string `json:"StatusReason,omitempty"`
+
+	// OnFailure is the failure action the create was requested with, empty for a
+	// stack created before the option was modeled. It is persisted because
+	// DescribeStacks reports DisableRollback, which is this value in another form —
+	// see cfnStackDisablesRollback.
+	OnFailure string `json:"OnFailure,omitempty"`
+
 	// CreatedAt is the time the stack was first deployed.
 	CreatedAt time.Time `json:"CreatedAt"`
 
 	// UpdatedAt is the time the stack was last updated.
 	UpdatedAt time.Time `json:"UpdatedAt"`
 
-	// ResourceDeletions records what a delete sweep did with each resource. It is
-	// written only when the sweep failed — a successful sweep removes the whole
-	// record — so its presence and DELETE_FAILED go together, and it is what tells
-	// a caller which resource is holding the stack.
+	// ResourceDeletions records what a delete or rollback sweep did with each
+	// resource, and is what tells a caller which resource is holding a stack.
+	//
+	// Written whenever a sweep ran and the record survived it, which is two cases: a
+	// DeleteStack sweep that failed (a successful one removes the whole record), and
+	// a create rollback, where the stack remains in ROLLBACK_COMPLETE or
+	// ROLLBACK_FAILED with the resources gone. So its presence does not by itself
+	// mean failure — the Status says which.
 	ResourceDeletions []CFNResourceDeletion `json:"ResourceDeletions,omitempty"`
 }
 
@@ -440,6 +457,15 @@ var (
 	// resource and delete again. It is substrate's own failure rather than an
 	// invalid request, hence a 500 like the deploy failures.
 	ErrCFNDeleteFailed = errors.New("stack delete failed")
+
+	// ErrCFNInvalidOnFailure is returned when a create's failure options are not
+	// ones CreateStack accepts: an OnFailure outside DO_NOTHING/ROLLBACK/DELETE, a
+	// DisableRollback that is not a boolean, or both parameters at once — "you can
+	// specify either DisableRollback or OnFailure, but not both".
+	//
+	// The caller's request is malformed rather than substrate failing, so this maps
+	// to a ValidationError at 400.
+	ErrCFNInvalidOnFailure = errors.New("invalid stack failure option")
 )
 
 // Stack statuses substrate reports, for the ones written from more than one place.
@@ -846,7 +872,26 @@ func NewStackDeployer(registry *PluginRegistry, store *EventStore, state StateMa
 // Resources are deployed in type-priority order. Unknown resource types are
 // skipped with a warning. The optional params map overrides template parameter
 // defaults.
+//
+// A resource that fails rolls the stack back, which is CreateStack's default: "although
+// the default setting is ROLLBACK". Use [StackDeployer.DeployWithOptions] to ask for
+// DO_NOTHING or DELETE instead.
 func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params map[string]string) (*DeployResult, error) {
+	return d.DeployWithOptions(ctx, cfn, streamID, params, CFNDeployOptions{})
+}
+
+// DeployWithOptions is [StackDeployer.Deploy] with the stack-level failure options a
+// create was requested with.
+//
+// Deploy remains the whole of the API for the succeeding case; this exists because
+// what happens to a *failed* create is the caller's decision, not substrate's, and
+// the zero CFNDeployOptions is CloudFormation's own default.
+func (d *StackDeployer) DeployWithOptions(
+	ctx context.Context, cfn, streamID string, params map[string]string, opts CFNDeployOptions,
+) (*DeployResult, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
 	tmpl, err := d.parseCFNTemplate(cfn)
 	if err != nil {
 		return nil, cfnErrf(ErrCFNTemplateInvalid, "parse template: %w", err)
@@ -907,6 +952,15 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 		resources = append(resources, dr)
 	}
 
+	// A refusal that only says "this already exists" is not a failure of this
+	// deployment, because a real deployment would not have made the call. Cleared
+	// before the stack's fate is decided, or every redeploy of an unchanged template
+	// would look like a failed create and roll back the resources it was asked to
+	// keep.
+	if prev, prevErr := d.previousStack(ctx, stackName); prevErr == nil {
+		d.clearUnchangedRedeploys(prev, tmpl.Resources, resources)
+	}
+
 	// Resolve outputs, and with them the export names this stack publishes.
 	outputs := make(map[string]string)
 	exportNames := make(map[string]string)
@@ -932,6 +986,30 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 		return nil, err
 	}
 
+	// Only now is the stack's fate decided. The export checks run first because they
+	// are refusals of the *request* — substrate answers them as errors rather than as
+	// a rolled-back stack (see [StackDeployer.checkExports]) — and a request substrate
+	// refuses outright never became a stack whose resources could roll back.
+	//
+	// The outputs resolved above are then deliberately discarded: a failed stack
+	// publishes none, and therefore exports none. Publishing them would let another
+	// stack import a value whose resource either never deployed or is about to be
+	// swept, which is the resolves-against-nothing failure the export model exists to
+	// prevent.
+	if failures := cfnFailedResources(resources); len(failures) > 0 {
+		return d.handleFailedCreate(ctx, cfnFailedCreate{
+			stackName:    stackName,
+			templateBody: cfn,
+			params:       cctx.params,
+			resources:    resources,
+			failures:     failures,
+			streamID:     streamID,
+			totalCost:    totalCost,
+			start:        start,
+			onFailure:    opts.resolve(),
+		})
+	}
+
 	duration := d.tc.Now().Sub(start)
 
 	result := &DeployResult{
@@ -941,6 +1019,7 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 		TotalCost: totalCost,
 		Duration:  duration,
 		Outputs:   outputs,
+		Status:    cfnStackCreateComplete,
 	}
 
 	// Persist stack state if state manager is available.
@@ -955,7 +1034,8 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 			Imports:      cctx.importedNames(),
 			AccountID:    d.identity.accountID,
 			Region:       d.identity.region,
-			Status:       "CREATE_COMPLETE",
+			Status:       cfnStackCreateComplete,
+			OnFailure:    opts.resolve(),
 			CreatedAt:    start,
 			UpdatedAt:    d.tc.Now(),
 		}
@@ -966,23 +1046,65 @@ func (d *StackDeployer) Deploy(ctx context.Context, cfn, streamID string, params
 }
 
 // UpdateStack re-deploys a previously deployed stack with new template or parameters.
+//
+// A resource that fails during the update rolls the stack back onto the template that
+// was deployed before it and reports UPDATE_ROLLBACK_COMPLETE. That is a *re-deploy of
+// the previous template*, not CloudFormation's per-resource restore — see
+// [StackDeployer.rollbackFailedUpdate] for what the difference costs. An update whose
+// rollback is not wanted has no option to disable it: DisableRollback and OnFailure are
+// CreateStack parameters, and UpdateStack models neither.
 func (d *StackDeployer) UpdateStack(ctx context.Context, cfn, stackName string, params map[string]string) (*DeployResult, error) {
-	result, err := d.Deploy(ctx, cfn, stackName, params)
+	// Read before the update, because the update overwrites it: this is the only
+	// description of the pre-update state a rollback has to converge on.
+	prev, prevErr := d.loadStack(ctx, stackName)
+
+	// DO_NOTHING, so a failed update does not take the create-rollback path and
+	// delete the resources: an update failure rolls *back to a template*, and
+	// deleting what the previous template declares is the opposite of that.
+	result, err := d.DeployWithOptions(ctx, cfn, stackName, params,
+		CFNDeployOptions{OnFailure: CFNOnFailureDoNothing})
 	if err != nil {
 		return nil, fmt.Errorf("update stack %s: %w", stackName, err)
 	}
+
+	if failures := cfnFailedResources(result.Resources); len(failures) > 0 {
+		// With no readable previous template there is nothing to converge on, so
+		// the update stops at UPDATE_FAILED rather than claiming a rollback it
+		// could not perform.
+		if prevErr != nil || prev == nil || prev.TemplateBody == "" {
+			reason := strings.Join(failures, "; ")
+			result.Status = cfnStackUpdateFailed
+			result.StatusReason = reason
+			d.setStackStatus(ctx, stackName, cfnStackUpdateFailed, reason)
+			// prevErr is logged rather than returned, and this is the one place that
+			// choice is not obvious. Failing to read the *previous* state is not a
+			// failure of this update: the update itself already ran and its resources
+			// already deployed, so returning an error here would report a call that
+			// did not happen and lose the UPDATE_FAILED status the caller needs. The
+			// unreadable record is why no rollback was attempted, which is what the
+			// log line says.
+			d.logger.Warn("cfn: stack update failed and no previous template is readable; "+
+				"not rolling back", "stack", stackName, "failures", len(failures),
+				"previous_state_error", cfnErrText(prevErr))
+			return result, nil //nolint:nilerr
+		}
+		return d.rollbackFailedUpdate(ctx, *prev, failures, stackName)
+	}
+
 	// Overwrite the persisted status.
 	if d.state != nil {
 		data, getErr := d.state.Get(ctx, cfnNamespace, "stack:"+stackName)
 		if getErr == nil && data != nil {
 			var s CFNStackState
 			if unmarshalErr := json.Unmarshal(data, &s); unmarshalErr == nil {
-				s.Status = "UPDATE_COMPLETE"
+				s.Status = cfnStackUpdateComplete
+				s.StatusReason = ""
 				s.UpdatedAt = d.tc.Now()
 				d.persistStack(ctx, s)
 			}
 		}
 	}
+	result.Status = cfnStackUpdateComplete
 	return result, nil
 }
 
@@ -1028,21 +1150,7 @@ func (d *StackDeployer) DeleteStack(ctx context.Context, stackName string) error
 		}
 	}
 
-	if err := d.state.Delete(ctx, cfnNamespace, "stack:"+stackName); err != nil {
-		return fmt.Errorf("delete stack %s: %w", stackName, err)
-	}
-	// Remove from stack names list.
-	names, err := d.loadStackNames(ctx)
-	if err != nil {
-		return err
-	}
-	newNames := make([]string, 0, len(names))
-	for _, n := range names {
-		if n != stackName {
-			newNames = append(newNames, n)
-		}
-	}
-	return d.saveStackNames(ctx, newNames)
+	return d.removeStackRecord(ctx, stackName)
 }
 
 // loadStack reads a persisted stack by name, returning (nil, nil) when no stack of
@@ -1260,10 +1368,13 @@ func (d *StackDeployer) loadExports(ctx context.Context, deployingStack string) 
 // exported value another stack imports may not change.
 //
 // Both run after the resources deploy, because an export name or value may be
-// built from a resource attribute and so is not knowable earlier. The deployment
-// is refused rather than the resources rolled back, which substrate does not model
-// (#520) — the resources exist and the caller is told the stack record was not
-// written, which is the honest observable rather than a fabricated rollback.
+// built from a resource attribute and so is not knowable earlier. The deployment is
+// refused rather than rolled back: this is a refusal of the *request*, reported as
+// an error, and it is checked before a failed resource is allowed to roll the stack
+// back so that a duplicate export name is answered the same way whether or not some
+// resource beside it also failed. The resources exist and the caller is told the
+// stack record was not written, which is the honest observable rather than a
+// fabricated rollback.
 func (d *StackDeployer) checkExports(ctx context.Context, stackName string, exports map[string]string) error {
 	if d.state == nil {
 		return nil

--- a/emulator/betty_cfn_delete_test.go
+++ b/emulator/betty_cfn_delete_test.go
@@ -58,6 +58,20 @@ const (
 func newSweepDeployer(t *testing.T) (*emulator.StackDeployer,
 	*emulator.MemoryStateManager, afero.Fs, *emulator.EventStore) {
 	t.Helper()
+	d, state, fs, store, _ := newSweepDeployerShared(t)
+	return d, state, fs, store
+}
+
+// newSweepDeployerShared is newSweepDeployer with a factory for building further
+// deployers over the same registry, state and store.
+//
+// The factory exists for the identity tests: a persisted record is only the *previous*
+// deployment of a stack when it belongs to the same account and Region, and the only
+// way to assert that is two deployers of differing identity reading the same records.
+func newSweepDeployerShared(t *testing.T) (*emulator.StackDeployer,
+	*emulator.MemoryStateManager, afero.Fs, *emulator.EventStore,
+	func(accountID, region string) *emulator.StackDeployer) {
+	t.Helper()
 	ctx := context.Background()
 	cfg := emulator.DefaultConfig()
 	require.True(t, cfg.EventStore.Enabled,
@@ -76,8 +90,12 @@ func newSweepDeployer(t *testing.T) (*emulator.StackDeployer,
 	// returned only for the tests that inspect object bodies.
 	fs := afero.NewMemMapFs()
 	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+	as := func(accountID, region string) *emulator.StackDeployer {
+		return emulator.NewStackDeployer(registry, store, state, tc, logger, costs,
+			emulator.WithDeployerIdentity(accountID, region))
+	}
 	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs),
-		state, fs, store
+		state, fs, store, as
 }
 
 // headBucket reports the status a HeadBucket against name returns, which is the

--- a/emulator/betty_cfn_exports_test.go
+++ b/emulator/betty_cfn_exports_test.go
@@ -406,8 +406,14 @@ func TestCFN_AStackDoesNotImportItsOwnExport(t *testing.T) {
 		`"QueueName":{"Fn::ImportValue":"Ouroboros-Name"}}}},` +
 		`"Outputs":{"N":{"Value":{"Ref":"Data"},"Export":{"Name":"Ouroboros-Name"}}}}`
 
+	// DO_NOTHING keeps the stack across both passes, which is what makes the second
+	// pass a redeploy of an existing stack rather than a first deploy again. Under the
+	// default ROLLBACK the queue's failure would sweep the bucket away each time and
+	// both passes would be identical, so the "first deploy vs redeploy" distinction —
+	// the whole point of looping — would assert nothing.
+	opts := emulator.CFNDeployOptions{OnFailure: emulator.CFNOnFailureDoNothing}
 	for _, pass := range []string{"first deploy", "redeploy"} {
-		result, err := d.Deploy(ctx, tmpl, "ouroboros", nil)
+		result, err := d.DeployWithOptions(ctx, tmpl, "ouroboros", nil, opts)
 		require.NoError(t, err, pass)
 
 		var queue *emulator.DeployedResource
@@ -421,11 +427,15 @@ func TestCFN_AStackDoesNotImportItsOwnExport(t *testing.T) {
 			"%s: a stack cannot import the name it is itself exporting", pass)
 	}
 
-	// The export is published for *other* stacks all the same.
+	// And the export is not published, because the stack failed. Before #520 it was:
+	// the stack reached CREATE_COMPLETE with a broken resource inside it and published
+	// its outputs regardless. A stack that did not succeed publishing an export other
+	// stacks could import is the resolves-against-nothing shape the export model exists
+	// to prevent, so the failure now withholds it — which is also what real
+	// CloudFormation does, since a rolled-back stack has no outputs.
 	exports, err := d.Exports(ctx)
 	require.NoError(t, err)
-	require.Len(t, exports, 1)
-	assert.Equal(t, "Ouroboros-Name", exports[0].Name)
+	assert.Empty(t, exports, "a stack whose resource failed publishes no exports")
 }
 
 // TestCFN_AStacksOwnImportDoesNotPinIt pins the invariant both export checks rest

--- a/emulator/betty_cfn_failure_test.go
+++ b/emulator/betty_cfn_failure_test.go
@@ -172,12 +172,22 @@ func TestCFN_SucceededResourceRecordsNoError(t *testing.T) {
 	}
 }
 
-// TestCFN_FailedResourceDoesNotStopTheStack pins what is deliberately *not*
-// changed here: substrate records a per-resource failure and carries on, while real
-// CloudFormation would roll the stack back to ROLLBACK_COMPLETE. Rollback is a much
-// larger behavior than the status check, so it is filed rather than fixed, and this
-// test states the current contract so the difference is a decision rather than an
-// oversight.
+// TestCFN_FailedResourceDoesNotStopTheStack is the DO_NOTHING case, and it is this
+// test rather than a new one because the behavior it pins did not go away — it
+// stopped being unconditional.
+//
+// Until #520 this asserted "substrate does not roll back" as substrate's whole
+// contract: a refused resource left the stack complete and every resource beside it
+// in place. That is now what OnFailure=DO_NOTHING asks for, so the same assertions
+// stand with the option named, and the difference between the old default and the new
+// one is exactly the option.
+//
+// Substrate still deploys the resources *after* the failure, where real
+// CloudFormation stops at the first one. That divergence is deliberate and predates
+// rollback: it is what makes a single deploy report every refusal a template contains
+// rather than only the first, which is the more useful observable for the
+// validation-run case substrate exists to serve. The stack status is the same either
+// way, and the status is what a caller keys off.
 func TestCFN_FailedResourceDoesNotStopTheStack(t *testing.T) {
 	d := newFullTestDeployer(t)
 	tmpl := `{"Resources": {
@@ -185,9 +195,16 @@ func TestCFN_FailedResourceDoesNotStopTheStack(t *testing.T) {
 		"Accepted": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "after-failure"}}
 	}}`
 
-	result, err := d.Deploy(context.Background(), tmpl, "partial-failure", nil)
-	require.NoError(t, err)
+	result, err := d.DeployWithOptions(context.Background(), tmpl, "partial-failure", nil,
+		emulator.CFNDeployOptions{OnFailure: emulator.CFNOnFailureDoNothing})
+	require.NoError(t, err, "a failed resource is a stack status, not a failed call")
 	require.Len(t, result.Resources, 2)
+
+	assert.Equal(t, "CREATE_FAILED", result.Status,
+		"DO_NOTHING leaves the failure standing rather than rolling it back")
+	assert.Contains(t, result.StatusReason, "InvalidBucketName",
+		"the stack's reason names what failed")
+	assert.Empty(t, result.ResourceDeletions, "DO_NOTHING deletes nothing")
 
 	byLogicalID := map[string]emulator.DeployedResource{}
 	for _, r := range result.Resources {
@@ -195,7 +212,7 @@ func TestCFN_FailedResourceDoesNotStopTheStack(t *testing.T) {
 	}
 	assert.Contains(t, byLogicalID["Refused"].Error, "InvalidBucketName")
 	assert.Empty(t, byLogicalID["Accepted"].Error,
-		"a resource after the failure is still deployed; substrate does not roll back")
+		"a resource after the failure is still deployed")
 	assert.Equal(t, "after-failure", byLogicalID["Accepted"].PhysicalID,
 		"the queue should have been deployed despite the earlier failure")
 }

--- a/emulator/betty_cfn_rollback.go
+++ b/emulator/betty_cfn_rollback.go
@@ -1,0 +1,568 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CloudFormation stack statuses, from the Stack data type's enumeration. Only the
+// ones substrate can reach are named: it deploys synchronously, so no caller ever
+// observes an IN_PROGRESS status except the one a rollback persists before it
+// sweeps, which is what makes a wedged rollback inspectable.
+const (
+	cfnStackCreateComplete = "CREATE_COMPLETE"
+
+	// cfnStackCreateFailed is a create whose failure was not rolled back, which is
+	// what OnFailure DO_NOTHING and DisableRollback ask for.
+	cfnStackCreateFailed = "CREATE_FAILED"
+
+	// cfnStackRollbackInProgress is persisted before the rollback sweep starts, so
+	// a sweep that cannot finish leaves a stack saying so rather than a stack that
+	// still claims to be creating.
+	cfnStackRollbackInProgress = "ROLLBACK_IN_PROGRESS"
+
+	// cfnStackRollbackComplete is a create that failed and whose resources were
+	// removed. The stack itself remains: a ROLLBACK_COMPLETE stack is still
+	// returned by DescribeStacks and still blocks a create of the same name until
+	// it is deleted.
+	cfnStackRollbackComplete = "ROLLBACK_COMPLETE"
+
+	// cfnStackRollbackFailed is a rollback whose own sweep could not remove a
+	// resource. Claiming ROLLBACK_COMPLETE there would assert a cleanliness that
+	// does not hold.
+	cfnStackRollbackFailed = "ROLLBACK_FAILED"
+
+	cfnStackUpdateComplete = "UPDATE_COMPLETE"
+
+	// cfnStackUpdateFailed is an update whose failure was not rolled back.
+	cfnStackUpdateFailed = "UPDATE_FAILED"
+
+	// cfnStackUpdateRollbackComplete is an update that failed and was converged
+	// back onto the previously deployed template.
+	cfnStackUpdateRollbackComplete = "UPDATE_ROLLBACK_COMPLETE"
+
+	// cfnStackUpdateRollbackFailed is an update rollback whose re-deploy of the
+	// previous template itself failed, leaving the stack in neither the old shape
+	// nor the new one.
+	cfnStackUpdateRollbackFailed = "UPDATE_ROLLBACK_FAILED"
+
+	// cfnStackDeleteComplete is what OnFailure DELETE leaves behind: the record is
+	// gone, so this is reported on the DeployResult rather than persisted.
+	cfnStackDeleteComplete = "DELETE_COMPLETE"
+)
+
+// CloudFormation CreateStack OnFailure values: "this must be one of: DO_NOTHING,
+// ROLLBACK, or DELETE".
+const (
+	// CFNOnFailureDoNothing leaves a failed stack and its resources in place. This
+	// is what DisableRollback=true asks for by another name.
+	CFNOnFailureDoNothing = "DO_NOTHING"
+
+	// CFNOnFailureRollback deletes the resources the failed create had made and
+	// leaves the stack reporting ROLLBACK_COMPLETE. "Although the default setting
+	// is ROLLBACK", so this is what an unspecified option resolves to.
+	CFNOnFailureRollback = "ROLLBACK"
+
+	// CFNOnFailureDelete deletes the resources and the stack, leaving nothing.
+	CFNOnFailureDelete = "DELETE"
+)
+
+// cfnValidOnFailure is the set CreateStack accepts. A value outside it is rejected
+// rather than defaulted, because every alternative reading of an unrecognized
+// value is a wrong one: treating it as ROLLBACK deletes resources a caller may have
+// meant to keep, and treating it as DO_NOTHING keeps resources it may have meant to
+// remove.
+var cfnValidOnFailure = map[string]bool{
+	CFNOnFailureDoNothing: true,
+	CFNOnFailureRollback:  true,
+	CFNOnFailureDelete:    true,
+}
+
+// CFNDeployOptions carries the stack-level failure options a create or update was
+// requested with.
+//
+// The zero value is what the API's defaults resolve to — an unspecified OnFailure is
+// ROLLBACK — so a caller that does not care passes nothing and gets CloudFormation's
+// behavior rather than substrate's.
+type CFNDeployOptions struct {
+	// OnFailure is "DO_NOTHING", "ROLLBACK", "DELETE", or empty for the default.
+	//
+	// DisableRollback is deliberately absent: it is the same knob under another
+	// name ("set to true to disable rollback of the stack if stack creation
+	// failed"), and the two are mutually exclusive on the wire, so the wire layer
+	// resolves whichever was given into this one field. Carrying both would invite
+	// a caller to set them inconsistently and force every reader to decide which
+	// wins.
+	OnFailure string
+}
+
+// resolve returns the OnFailure value in force, applying the API's default.
+func (o CFNDeployOptions) resolve() string {
+	if o.OnFailure == "" {
+		return CFNOnFailureRollback
+	}
+	return o.OnFailure
+}
+
+// validate reports whether the options name an action CreateStack accepts.
+func (o CFNDeployOptions) validate() error {
+	if o.OnFailure != "" && !cfnValidOnFailure[o.OnFailure] {
+		return cfnErrf(ErrCFNInvalidOnFailure,
+			"OnFailure must be one of DO_NOTHING, ROLLBACK or DELETE, got %q", o.OnFailure)
+	}
+	return nil
+}
+
+// cfnFailedResources names the resources that failed to deploy, in the order they
+// were attempted.
+func cfnFailedResources(resources []DeployedResource) []string {
+	var failed []string
+	for _, r := range resources {
+		if r.Error != "" {
+			failed = append(failed, fmt.Sprintf("%s (%s): %s", r.LogicalID, r.Type, r.Error))
+		}
+	}
+	return failed
+}
+
+// cfnCreateExistsCodes is the set of error codes that mean "a resource of this name
+// already exists", as the plugins reachable from Deploy actually spell it.
+//
+// It exists because [StackDeployer.UpdateStack] is a re-Deploy of the whole template:
+// a resource the update leaves alone is created a second time and its plugin refuses
+// the duplicate. Real CloudFormation issues no create call at all for an unchanged
+// resource, so there is no real refusal being modeled here — the refusal is an
+// artifact of substrate's re-deploy, and reading it as a failed resource would make
+// every update of an unchanged template roll back and delete what it was asked to
+// keep.
+//
+// Every entry was harvested by deploying a template twice against the default
+// registry and recording the code that came back, the same way
+// [cfnDeleteAbsentCodes] was built. Reading them off the AWS references would have
+// missed that substrate's DynamoDB, Kinesis and Firehose all answer the shared
+// ResourceInUseException while Step Functions has a code per resource
+// (StateMachineAlreadyExists, ActivityAlreadyExists).
+//
+// Codes are absent when they are not unambiguously a name collision. ConflictException
+// and AlreadyExistsException are each used by several services for conditions that are
+// not a duplicate create, and clearing one of those would hide a real failure — the
+// opposite and worse error. Missing an entry only leaves the pre-existing behavior of
+// reporting the refusal, so the conservative side is the safe one.
+var cfnCreateExistsCodes = map[string]bool{
+	"ActivityAlreadyExists":                            true,
+	"BucketAlreadyExists":                              true,
+	"EntityAlreadyExists":                              true,
+	"InvalidLaunchTemplateName.AlreadyExistsException": true,
+	"RepositoryAlreadyExistsException":                 true,
+	"ResourceAlreadyExistsException":                   true,
+	"ResourceConflictException":                        true,
+	"ResourceExistsException":                          true,
+	"ResourceInUseException":                           true,
+	"StateMachineAlreadyExists":                        true,
+}
+
+// cfnCreateIsExists reports whether a recorded resource error is only a duplicate-name
+// refusal. The code is the text before the first ": ", matching how a dispatch error
+// is rendered.
+func cfnCreateIsExists(recorded string) bool {
+	code := recorded
+	if i := strings.Index(recorded, ": "); i >= 0 {
+		code = recorded[:i]
+	}
+	return cfnCreateExistsCodes[code]
+}
+
+// previousStack returns the record this deploy is replacing, or nil when there is
+// none. A stack outside this deployer's account and Region is not it: the record
+// belongs to another scope and its resources are not the ones being redeployed.
+func (d *StackDeployer) previousStack(ctx context.Context, stackName string) (*CFNStackState, error) {
+	if d.state == nil {
+		return nil, nil
+	}
+	prev, err := d.loadStack(ctx, stackName)
+	if err != nil || prev == nil {
+		return nil, err
+	}
+	if !d.sameScope(*prev) {
+		return nil, nil
+	}
+	return prev, nil
+}
+
+// clearUnchangedRedeploys drops the duplicate-name refusal from every resource this
+// stack already deployed and whose *declaration* the template still spells the same
+// way, in place.
+//
+// Three conditions, each load-bearing. Without a previous record for the stack, a
+// first-time collision with a resource some *other* stack owns would be cleared — a
+// real failure that CloudFormation reports. The previous record must show the slot
+// deployed successfully, or there is nothing this stack owns to be re-creating.
+//
+// The third is the declaration, and it is why the physical ID cannot be the key: a
+// refused create returns no physical ID at all (measured — an already-taken
+// LaunchTemplate name comes back with PhysicalID empty), so comparing IDs would never
+// match for any type whose identifier the service generates. Comparing the declared
+// Type and Properties instead distinguishes the two cases that matter: an unchanged
+// redeploy declares the resource identically, while a template edited to point the
+// slot at an existing foreign resource declares it differently and must still fail.
+//
+// The comparison is on *declared* properties, before intrinsics resolve. A resolved
+// comparison would find spurious differences, since a Ref to a sibling resolves to a
+// freshly generated ID on every deploy.
+func (d *StackDeployer) clearUnchangedRedeploys(
+	prev *CFNStackState, declared map[string]cfnResource, resources []DeployedResource,
+) {
+	if prev == nil || prev.TemplateBody == "" {
+		return
+	}
+	prevTmpl, err := d.parseCFNTemplate(prev.TemplateBody)
+	if err != nil {
+		// The previous template is unreadable, so nothing can be shown unchanged. The
+		// refusals stand, which is the pre-existing behavior.
+		d.logger.Warn("cfn: previous template does not parse; cannot tell an unchanged "+
+			"redeploy from a new collision", "stack", prev.StackName, "error", err.Error())
+		return
+	}
+	deployed := make(map[string]bool, len(prev.Resources))
+	for _, r := range prev.Resources {
+		if r.Error == "" {
+			deployed[r.LogicalID] = true
+		}
+	}
+	for i := range resources {
+		r := &resources[i]
+		if r.Error == "" || !cfnCreateIsExists(r.Error) || !deployed[r.LogicalID] {
+			continue
+		}
+		if !cfnSameDeclaration(prevTmpl.Resources[r.LogicalID], declared[r.LogicalID]) {
+			continue
+		}
+		d.logger.Debug("cfn: resource already exists and its declaration is unchanged; "+
+			"not a failure of this deployment",
+			"logical_id", r.LogicalID, "type", r.Type)
+		r.Error = ""
+	}
+}
+
+// cfnSameDeclaration reports whether two template declarations of the same logical ID
+// describe the same resource.
+//
+// Compared as marshaled JSON because Properties is an arbitrarily nested
+// map[string]interface{}; Go's encoder sorts map keys, so the encoding is canonical
+// and two declarations differing only in key order compare equal. A marshal error
+// yields false, which keeps the refusal — the conservative direction.
+func cfnSameDeclaration(before, after cfnResource) bool {
+	if before.Type == "" || before.Type != after.Type {
+		return false
+	}
+	beforeJSON, err := json.Marshal(before.Properties)
+	if err != nil {
+		return false
+	}
+	afterJSON, err := json.Marshal(after.Properties)
+	if err != nil {
+		return false
+	}
+	return string(beforeJSON) == string(afterJSON)
+}
+
+// cfnCreatedResources returns the resources a failed create did create, which are
+// the ones a rollback has to remove.
+//
+// A resource carrying an error is excluded: the plugin refused the request, so there
+// is nothing on the other side to delete, and dispatching its delete anyway would
+// send a request built from the same rejected identifier — a bucket the plugin
+// refused as invalidly named yields an equally invalid DeleteBucket, whose refusal
+// is not a not-found and would turn a clean rollback into ROLLBACK_FAILED.
+func cfnCreatedResources(resources []DeployedResource) []DeployedResource {
+	created := make([]DeployedResource, 0, len(resources))
+	for _, r := range resources {
+		if r.Error == "" {
+			created = append(created, r)
+		}
+	}
+	return created
+}
+
+// cfnFailedCreate is everything the failure path needs about the create that failed.
+// A struct rather than nine parameters, and unexported because it is an internal
+// hand-off rather than API.
+type cfnFailedCreate struct {
+	stackName    string
+	templateBody string
+	params       map[string]string
+	resources    []DeployedResource
+	failures     []string
+	streamID     string
+	totalCost    float64
+	start        time.Time
+	onFailure    string
+}
+
+// handleFailedCreate applies the stack's OnFailure option to a create that had at
+// least one failed resource.
+//
+// Substrate deploys synchronously, so unlike the API this decision is reached within
+// the call. The outcome is still reported the way the API reports it — as the stack's
+// status rather than as an error — because that is what a caller polling
+// DescribeStacks reads, and because a create whose stack rolled back is not a failed
+// API call: real CreateStack has already returned its StackId by the time the
+// rollback happens.
+func (d *StackDeployer) handleFailedCreate(ctx context.Context, fc cfnFailedCreate) (*DeployResult, error) {
+	result := &DeployResult{
+		StackName: fc.stackName,
+		Resources: fc.resources,
+		StreamID:  fc.streamID,
+		TotalCost: fc.totalCost,
+		Duration:  d.tc.Now().Sub(fc.start),
+		Outputs:   map[string]string{},
+	}
+
+	// A failed stack publishes no outputs, and therefore no exports. Resolving them
+	// would let another stack import a value whose resource either failed to deploy
+	// or is about to be rolled back — an import that resolves against nothing is
+	// the silent-literal failure the export model exists to prevent.
+	state := CFNStackState{
+		StackName:    fc.stackName,
+		TemplateBody: fc.templateBody,
+		Parameters:   fc.params,
+		Resources:    fc.resources,
+		Outputs:      map[string]string{},
+		AccountID:    d.identity.accountID,
+		Region:       d.identity.region,
+		OnFailure:    fc.onFailure,
+		CreatedAt:    fc.start,
+		UpdatedAt:    d.tc.Now(),
+	}
+
+	if fc.onFailure == CFNOnFailureDoNothing {
+		// The resources stay, including the ones deployed after the failure.
+		// Substrate deploys the whole template rather than stopping at the first
+		// failure, and that is what makes DO_NOTHING different from the API's: real
+		// CloudFormation stops. The status is the same, and it is the status a
+		// caller keys off.
+		state.Status = cfnStackCreateFailed
+		state.StatusReason = strings.Join(fc.failures, "; ")
+		result.Status = cfnStackCreateFailed
+		result.StatusReason = state.StatusReason
+		if d.state != nil {
+			d.persistStack(ctx, state)
+		}
+		d.logger.Warn("cfn: stack create failed and rollback is disabled",
+			"stack", fc.stackName, "failures", len(fc.failures))
+		return result, nil
+	}
+
+	// Persisted before the sweep, not after: the sweep dispatches real deletes, and
+	// a stack that cannot finish rolling back must be discoverable as a rollback
+	// that did not finish rather than as a stack that never started one.
+	state.Status = cfnStackRollbackInProgress
+	state.StatusReason = strings.Join(fc.failures, "; ")
+	if d.state != nil {
+		d.persistStack(ctx, state)
+	}
+
+	// Only the resources that were created are swept, and with cfnCreateRollbackOp:
+	// this is "the rollback of the stack operation that initially created the
+	// resource", so RetainExceptOnCreate deletes here where a DeleteStack sweep
+	// would have kept it.
+	sweep := state
+	sweep.Resources = cfnCreatedResources(fc.resources)
+	deletions := d.deleteStackResources(ctx, &sweep, fc.streamID, cfnCreateRollbackOp)
+	state.ResourceDeletions = deletions
+	state.UpdatedAt = d.tc.Now()
+	result.ResourceDeletions = deletions
+
+	if failed := cfnFailedDeletions(deletions); len(failed) > 0 {
+		state.Status = cfnStackRollbackFailed
+		state.StatusReason = "rollback could not delete: " + strings.Join(failed, "; ")
+		result.Status = cfnStackRollbackFailed
+		result.StatusReason = state.StatusReason
+		if d.state != nil {
+			d.persistStack(ctx, state)
+		}
+		d.logger.Warn("cfn: stack rollback failed",
+			"stack", fc.stackName, "undeleted", len(failed))
+		return result, nil
+	}
+
+	if fc.onFailure == CFNOnFailureDelete {
+		// Nothing is left to report a status on, so the record goes too. The
+		// DeployResult still carries DELETE_COMPLETE, which is the only place a
+		// caller can learn what happened.
+		result.Status = cfnStackDeleteComplete
+		result.StatusReason = strings.Join(fc.failures, "; ")
+		if d.state != nil {
+			if err := d.removeStackRecord(ctx, fc.stackName); err != nil {
+				return result, err
+			}
+		}
+		d.logger.Warn("cfn: stack create failed and the stack was deleted",
+			"stack", fc.stackName, "failures", len(fc.failures))
+		return result, nil
+	}
+
+	// The stack stays. A ROLLBACK_COMPLETE stack is still reported by
+	// DescribeStacks and still blocks a create of the same name until it is
+	// deleted, which is the one thing that makes the failure impossible to miss.
+	state.Status = cfnStackRollbackComplete
+	state.StatusReason = strings.Join(fc.failures, "; ")
+	result.Status = cfnStackRollbackComplete
+	result.StatusReason = state.StatusReason
+	if d.state != nil {
+		d.persistStack(ctx, state)
+	}
+	d.logger.Warn("cfn: stack create failed and was rolled back",
+		"stack", fc.stackName, "failures", len(fc.failures))
+	return result, nil
+}
+
+// rollbackFailedUpdate converges a failed update back onto the template that was
+// deployed before it, and reports UPDATE_ROLLBACK_COMPLETE.
+//
+// This is a **re-deploy of the previous template**, not a per-resource restore.
+// UpdateStack is itself a re-deploy, so the previous template is the only
+// description of the previous state substrate holds; converging on it reaches that
+// template's *declared* state, which is not identical to CloudFormation's rollback.
+// A resource the failed update had replaced may come back with a new physical ID,
+// and a property the previous template never declared keeps whatever the failed
+// update set it to. Recording that divergence is the point: an undocumented
+// approximation is worse than a documented one.
+func (d *StackDeployer) rollbackFailedUpdate(
+	ctx context.Context, prev CFNStackState, failures []string, streamID string,
+) (*DeployResult, error) {
+	d.logger.Warn("cfn: stack update failed; rolling back to the previous template",
+		"stack", prev.StackName, "failures", len(failures))
+
+	// DO_NOTHING so the re-deploy reports its own failures instead of rolling back:
+	// a create rollback here would delete the resources the previous template
+	// declares, which is the opposite of converging on it.
+	result, err := d.DeployWithOptions(ctx, prev.TemplateBody, streamID, prev.Parameters,
+		CFNDeployOptions{OnFailure: CFNOnFailureDoNothing})
+	if err != nil {
+		return nil, fmt.Errorf("roll back update of stack %s: %w", prev.StackName, err)
+	}
+
+	reason := strings.Join(failures, "; ")
+	status := cfnStackUpdateRollbackComplete
+	if reDeployFailures := cfnFailedResources(result.Resources); len(reDeployFailures) > 0 {
+		// The stack is now in neither shape. Saying so is the whole value of the
+		// status: the previous template no longer describes what is deployed.
+		status = cfnStackUpdateRollbackFailed
+		reason += " (rollback also failed: " + strings.Join(reDeployFailures, "; ") + ")"
+	}
+	result.Status = status
+	result.StatusReason = reason
+	d.setStackStatus(ctx, prev.StackName, status, reason)
+	return result, nil
+}
+
+// setStackStatus overwrites a persisted stack's status and reason, leaving the rest
+// of the record as the deploy wrote it.
+func (d *StackDeployer) setStackStatus(ctx context.Context, stackName, status, reason string) {
+	if d.state == nil {
+		return
+	}
+	stack, err := d.loadStack(ctx, stackName)
+	if err != nil || stack == nil {
+		d.logger.Warn("cfn: cannot set stack status; stack not readable",
+			"stack", stackName, "status", status)
+		return
+	}
+	stack.Status = status
+	stack.StatusReason = reason
+	stack.UpdatedAt = d.tc.Now()
+	d.persistStack(ctx, *stack)
+}
+
+// removeStackRecord deletes a stack's record and its entry in the names index.
+//
+// Extracted from DeleteStack so the OnFailure=DELETE path removes a stack exactly
+// the way a delete does. Two ways to unpersist a stack would eventually disagree,
+// and the disagreement would be a stack that is gone from one listing and present in
+// the other.
+func (d *StackDeployer) removeStackRecord(ctx context.Context, stackName string) error {
+	if err := d.state.Delete(ctx, cfnNamespace, "stack:"+stackName); err != nil {
+		return fmt.Errorf("delete stack %s: %w", stackName, err)
+	}
+	names, err := d.loadStackNames(ctx)
+	if err != nil {
+		return err
+	}
+	remaining := make([]string, 0, len(names))
+	for _, n := range names {
+		if n != stackName {
+			remaining = append(remaining, n)
+		}
+	}
+	return d.saveStackNames(ctx, remaining)
+}
+
+// cfnResolveFailureOptions turns CreateStack's two mutually exclusive failure
+// parameters into the single action they describe.
+//
+// "You can specify either DisableRollback or OnFailure, but not both", so specifying
+// both is a ValidationError rather than a precedence rule — and the test is
+// *presence*, not value: the CLI's --no-disable-rollback sends DisableRollback=false
+// explicitly, so a rule that ignored a false would accept a combination the API
+// rejects. This was measured against the CLI rather than assumed.
+//
+// present tells this apart from absent for DisableRollback, which is why the wire
+// layer passes the raw parameter map rather than a bool.
+func cfnResolveFailureOptions(onFailure, disableRollback string, disableRollbackPresent bool) (CFNDeployOptions, error) {
+	if onFailure != "" && disableRollbackPresent {
+		return CFNDeployOptions{}, cfnErrf(ErrCFNInvalidOnFailure,
+			"You can specify either DisableRollback or OnFailure, but not both")
+	}
+	if disableRollbackPresent {
+		switch strings.ToLower(disableRollback) {
+		case "true":
+			return CFNDeployOptions{OnFailure: CFNOnFailureDoNothing}, nil
+		case "false":
+			return CFNDeployOptions{OnFailure: CFNOnFailureRollback}, nil
+		default:
+			return CFNDeployOptions{}, cfnErrf(ErrCFNInvalidOnFailure,
+				"DisableRollback must be true or false, got %q", disableRollback)
+		}
+	}
+	opts := CFNDeployOptions{OnFailure: onFailure}
+	if err := opts.validate(); err != nil {
+		return CFNDeployOptions{}, err
+	}
+	return opts, nil
+}
+
+// cfnDeletionFor finds a sweep's record for one logical ID, or nil when the sweep
+// did not touch it — which for a rollback means the resource was never created.
+func cfnDeletionFor(deletions []CFNResourceDeletion, logicalID string) *CFNResourceDeletion {
+	for i := range deletions {
+		if deletions[i].LogicalID == logicalID {
+			return &deletions[i]
+		}
+	}
+	return nil
+}
+
+// cfnStackDisablesRollback reports what DescribeStacks should say for a stack's
+// DisableRollback member.
+//
+// It is derived from OnFailure rather than stored beside it because they are one
+// knob: DisableRollback=true is DO_NOTHING. Storing both would let a record say
+// DO_NOTHING and DisableRollback=false at once, and nothing could resolve which the
+// caller had asked for.
+func cfnStackDisablesRollback(onFailure string) bool {
+	return onFailure == CFNOnFailureDoNothing
+}
+
+// cfnErrText renders an error for a log field, or "none" when there is no error. A
+// bare err.Error() would panic on nil, and a nil-valued field logs as "<nil>", which
+// reads as a failure that did not happen.
+func cfnErrText(err error) string {
+	if err == nil {
+		return "none"
+	}
+	return err.Error()
+}

--- a/emulator/betty_cfn_rollback_test.go
+++ b/emulator/betty_cfn_rollback_test.go
@@ -1,0 +1,488 @@
+package emulator_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The templates the rollback tests deploy.
+//
+// Every one of them fails at a *real* refusal rather than an injected one, and the
+// refusal is always the same: "no" is shorter than S3's three-character minimum, so
+// CreateBucket answers InvalidBucketName. A rollback test whose failure came from a
+// missing plugin would be testing ServiceNotAvailable, which is substrate's own
+// condition rather than one a caller can hit against AWS.
+const (
+	// cfnRollbackTemplate is #520's own reproduction: a resource that is refused and
+	// a resource beside it that deploys and must therefore be swept. The queue sorts
+	// after the bucket by type priority, so it is created *after* the failure — which
+	// is what makes "the trailing queue is gone" the assertion the issue asks for.
+	cfnRollbackTemplate = `{"Resources":{` +
+		`"Refused":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"no"}},` +
+		`"Kept":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"rollback-kept"}},` +
+		`"Trailing":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"rollback-trailing"}}}}`
+
+	// cfnRollbackCleanTemplate is the same shape with nothing refused, for the tests
+	// that need a stack to succeed first.
+	cfnRollbackCleanTemplate = `{"Resources":{` +
+		`"Kept":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"rollback-kept"}},` +
+		`"Trailing":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"rollback-trailing"}}}}`
+)
+
+// queueExists reports whether a queue of this name is still there, which is the
+// observable #520 asks for by name ("get-queue-url --queue-name still-here → absent").
+func queueExists(t *testing.T, d *emulator.StackDeployer, name string) bool {
+	t.Helper()
+	resp, _ := d.DispatchForTest(context.Background(), &emulator.AWSRequest{
+		Service: "sqs", Operation: "GetQueueUrl", Path: "/",
+		Headers: map[string]string{}, Params: map[string]string{"QueueName": name},
+	}, "probe")
+	return resp != nil && resp.StatusCode == http.StatusOK
+}
+
+// TestCFN_AFailedResourceRollsTheStackBack is #520's own reproduction, and it is the
+// release's headline: before it, a stack containing a resource that was refused still
+// reported CREATE_COMPLETE, so a consumer's failure-handling path could not be tested
+// at all — substrate never produced the failure it exists to reproduce.
+func TestCFN_AFailedResourceRollsTheStackBack(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	result, err := d.Deploy(ctx, cfnRollbackTemplate, "rolled", nil)
+	require.NoError(t, err,
+		"a rolled-back create is a stack status, not a failed call: real CreateStack "+
+			"has returned its StackId before the rollback happens")
+
+	assert.Equal(t, "ROLLBACK_COMPLETE", result.Status,
+		"ROLLBACK is CreateStack's default and nothing asked for another")
+	assert.Contains(t, result.StatusReason, "InvalidBucketName",
+		"the stack's reason names the resource that failed and why")
+	assert.Contains(t, result.StatusReason, "Refused")
+	assert.Empty(t, result.Outputs, "a rolled-back stack publishes no outputs")
+
+	assert.Equal(t, http.StatusNotFound, headBucket(t, d, "rollback-kept"),
+		"the bucket that deployed is swept: rollback removes what the create made")
+	assert.False(t, queueExists(t, d, "rollback-trailing"),
+		"and so is the resource deployed after the failure")
+
+	// The stack stays, reporting ROLLBACK_COMPLETE. That is what makes the failure
+	// impossible to miss — it blocks a create of the same name until it is deleted.
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	require.Len(t, stacks, 1)
+	assert.Equal(t, "ROLLBACK_COMPLETE", stacks[0].Status)
+	assert.Contains(t, stacks[0].StatusReason, "InvalidBucketName")
+}
+
+// TestCFN_RollbackSweepsInReverseOrder pins that the rollback reuses #518's sweep
+// rather than deleting in whatever order the resources happen to be listed.
+//
+// The type priorities encode real dependencies, so a rollback in any other order is
+// one that happens to work on templates whose resources are independent. Asserting the
+// recorded operation sequence is the only way that is observable.
+func TestCFN_RollbackSweepsInReverseOrder(t *testing.T) {
+	d, _, _, store := newSweepDeployer(t)
+	ctx := context.Background()
+
+	// A role (priority 1), a bucket (2) and a queue (3) all deploy; a second bucket
+	// with an invalid name is refused, which triggers the rollback.
+	tmpl := `{"Resources":{` +
+		`"Role":{"Type":"AWS::IAM::Role","Properties":{"RoleName":"rollback-role",` +
+		`"AssumeRolePolicyDocument":{"Statement":[]}}},` +
+		`"Bucket":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"rollback-ordered"}},` +
+		`"Refused":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"no"}},` +
+		`"Queue":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"rollback-ordered-q"}}}}`
+
+	result, err := d.Deploy(ctx, tmpl, "revorder", nil)
+	require.NoError(t, err)
+	require.Equal(t, "ROLLBACK_COMPLETE", result.Status)
+
+	ops := sweepOperations(t, store, "revorder")
+
+	// The creates come first, in ascending priority. The refused bucket's CreateBucket
+	// is recorded too — the request was made and refused — so the creates are located
+	// by finding where the deletes begin rather than by counting.
+	var deletes []string
+	for _, op := range ops {
+		switch op {
+		case "DeleteRole", "DeleteBucket", "DeleteQueue":
+			deletes = append(deletes, op)
+		}
+	}
+	assert.Equal(t, []string{"DeleteQueue", "DeleteBucket", "DeleteRole"}, deletes,
+		"descending priority, the exact inverse of the deploy order")
+}
+
+// TestCFN_RollbackDoesNotDeleteWhatWasNeverCreated pins that the sweep skips the
+// resource that failed.
+//
+// Its create was refused, so there is nothing on the other side to delete, and the
+// delete request would be built from the same rejected identifier — an invalid bucket
+// name yields an equally invalid DeleteBucket, whose refusal is not a not-found and
+// would turn a clean rollback into ROLLBACK_FAILED.
+func TestCFN_RollbackDoesNotDeleteWhatWasNeverCreated(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	result, err := d.Deploy(ctx, cfnRollbackTemplate, "notcreated", nil)
+	require.NoError(t, err)
+	require.Equal(t, "ROLLBACK_COMPLETE", result.Status,
+		"the refused resource must not have wedged the rollback")
+
+	byID := map[string]emulator.CFNResourceDeletion{}
+	for _, del := range result.ResourceDeletions {
+		byID[del.LogicalID] = del
+	}
+	assert.NotContains(t, byID, "Refused",
+		"the resource that failed is not swept; its create never happened")
+	assert.Contains(t, byID, "Kept")
+	assert.Contains(t, byID, "Trailing")
+}
+
+// TestCFN_OnFailureDeleteRemovesTheStack pins the third option: nothing is left, not
+// even the record.
+func TestCFN_OnFailureDeleteRemovesTheStack(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	result, err := d.DeployWithOptions(ctx, cfnRollbackTemplate, "deleted", nil,
+		emulator.CFNDeployOptions{OnFailure: emulator.CFNOnFailureDelete})
+	require.NoError(t, err)
+
+	assert.Equal(t, "DELETE_COMPLETE", result.Status,
+		"the result is the only place this outcome is readable, since the record is gone")
+	assert.Contains(t, result.StatusReason, "InvalidBucketName")
+
+	assert.Equal(t, http.StatusNotFound, headBucket(t, d, "rollback-kept"))
+	assert.False(t, queueExists(t, d, "rollback-trailing"))
+
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, stacks, "OnFailure DELETE leaves no stack behind")
+}
+
+// TestCFN_ARollbackThatCannotDeleteReportsRollbackFailed pins the honest status for a
+// rollback that did not finish.
+//
+// Claiming ROLLBACK_COMPLETE here would assert a cleanliness that does not hold, and
+// the resource still standing is exactly what the caller needs to know about. The
+// failure is real rather than injected: an object written into the bucket behind the
+// stack's back makes DeleteBucket answer BucketNotEmpty, which is what S3 does.
+func TestCFN_ARollbackThatCannotDeleteReportsRollbackFailed(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	// First a clean deploy, so the bucket exists to be written into.
+	_, err := d.Deploy(ctx, cfnRollbackCleanTemplate, "wedgedback", nil)
+	require.NoError(t, err)
+
+	resp, err := d.DispatchForTest(ctx, &emulator.AWSRequest{
+		Service: "s3", Operation: "PUT", Path: "/rollback-kept/left-behind.txt",
+		Body: []byte("not the stack's"), Headers: map[string]string{},
+		Params: map[string]string{},
+	}, "wedgedback")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Now redeploy with a resource that will be refused. The bucket's declaration is
+	// unchanged, so its already-exists refusal is not counted as a failure, and the
+	// rollback then cannot delete it.
+	result, err := d.Deploy(ctx, `{"Resources":{`+
+		`"Refused":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"no"}},`+
+		`"Kept":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"rollback-kept"}},`+
+		`"Trailing":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"rollback-trailing"}}}}`,
+		"wedgedback", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ROLLBACK_FAILED", result.Status)
+	assert.Contains(t, result.StatusReason, "BucketNotEmpty",
+		"the reason is the plugin's own refusal, not a paraphrase")
+	assert.Contains(t, result.StatusReason, "Kept",
+		"and it names the resource still standing")
+
+	assert.Equal(t, http.StatusOK, headBucket(t, d, "rollback-kept"),
+		"which is still there, and is why the rollback failed")
+
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	require.Len(t, stacks, 1)
+	assert.Equal(t, "ROLLBACK_FAILED", stacks[0].Status,
+		"the stack stays so the caller can see what is holding it")
+}
+
+// TestCFN_RetainDoesNotSurviveACreateRollback pins RetainExceptOnCreate's whole
+// reason for existing, and the one place it differs from Retain.
+//
+// "Except for the stack operation that initially created the resource": a
+// RetainExceptOnCreate resource is kept by a DeleteStack sweep and deleted by the
+// rollback of the create that made it. Plain Retain is kept by both. Asserting the two
+// side by side is what proves the policy resolver reads the *operation* rather than
+// just the policy name.
+func TestCFN_RetainDoesNotSurviveACreateRollback(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	result, err := d.Deploy(ctx, `{"Resources":{`+
+		`"Refused":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"no"}},`+
+		`"Retained":{"Type":"AWS::S3::Bucket","DeletionPolicy":"Retain",`+
+		`"Properties":{"BucketName":"rollback-retained"}},`+
+		`"ExceptOnCreate":{"Type":"AWS::S3::Bucket","DeletionPolicy":"RetainExceptOnCreate",`+
+		`"Properties":{"BucketName":"rollback-except"}}}}`, "retainroll", nil)
+	require.NoError(t, err)
+	require.Equal(t, "ROLLBACK_COMPLETE", result.Status)
+
+	assert.Equal(t, http.StatusOK, headBucket(t, d, "rollback-retained"),
+		"Retain survives a create rollback")
+	assert.Equal(t, http.StatusNotFound, headBucket(t, d, "rollback-except"),
+		"RetainExceptOnCreate does not: this is the create that made it")
+}
+
+// TestCFN_AnUnchangedRedeployIsNotAFailedCreate pins the guard that keeps rollback
+// from eating the resources it was asked to keep.
+//
+// StackDeployer.UpdateStack is a re-Deploy of the whole template, so a resource the
+// update leaves alone is created a *second* time and its plugin refuses the duplicate.
+// Real CloudFormation issues no create call at all for an unchanged resource, so there
+// is no real refusal here to model — and reading it as a failure would make every
+// update of an unchanged template roll back. This is the defect the rollback work
+// introduced and this test is what pins it shut.
+func TestCFN_AnUnchangedRedeployIsNotAFailedCreate(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	first, err := d.Deploy(ctx, cfnRollbackCleanTemplate, "redeployed", nil)
+	require.NoError(t, err)
+	require.Equal(t, "CREATE_COMPLETE", first.Status)
+
+	second, err := d.Deploy(ctx, cfnRollbackCleanTemplate, "redeployed", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "CREATE_COMPLETE", second.Status,
+		"redeploying an unchanged template is not a failed create")
+	for _, r := range second.Resources {
+		assert.Empty(t, r.Error, "%s: an already-exists refusal of an unchanged "+
+			"resource is not this deployment's failure", r.LogicalID)
+	}
+	assert.Empty(t, second.ResourceDeletions, "and nothing is swept")
+
+	assert.Equal(t, http.StatusOK, headBucket(t, d, "rollback-kept"),
+		"the resources the caller asked to keep are still there")
+	assert.True(t, queueExists(t, d, "rollback-trailing"))
+}
+
+// TestCFN_AForeignNameCollisionIsStillAFailure is the other half of the guard, and
+// the reason it compares declarations rather than merely matching logical IDs.
+//
+// A template edited to point a slot at a name another stack already owns is a real
+// failure that CloudFormation reports. Clearing every already-exists refusal for a
+// stack that has been deployed before would hide it — so the refusal is cleared only
+// when the declaration is byte-identical to the one that succeeded.
+func TestCFN_AForeignNameCollisionIsStillAFailure(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	// Another stack owns rollback-foreign.
+	_, err := d.Deploy(ctx, `{"Resources":{"Owned":{"Type":"AWS::S3::Bucket",`+
+		`"Properties":{"BucketName":"rollback-foreign"}}}}`, "owner", nil)
+	require.NoError(t, err)
+
+	// This stack deploys cleanly at its own name first, so it has a previous record.
+	_, err = d.Deploy(ctx, `{"Resources":{"Slot":{"Type":"AWS::S3::Bucket",`+
+		`"Properties":{"BucketName":"rollback-own"}}}}`, "renamer", nil)
+	require.NoError(t, err)
+
+	// Then the same slot is repointed at the name the other stack holds.
+	result, err := d.DeployWithOptions(ctx, `{"Resources":{"Slot":{"Type":"AWS::S3::Bucket",`+
+		`"Properties":{"BucketName":"rollback-foreign"}}}}`, "renamer", nil,
+		emulator.CFNDeployOptions{OnFailure: emulator.CFNOnFailureDoNothing})
+	require.NoError(t, err)
+	assert.Equal(t, "CREATE_FAILED", result.Status,
+		"a rename into a name another stack owns is a real failure")
+	assert.Contains(t, result.StatusReason, "BucketAlreadyExists")
+
+	assert.Equal(t, http.StatusOK, headBucket(t, d, "rollback-foreign"),
+		"and the other stack's bucket is untouched")
+}
+
+// TestCFN_ARepeatedForeignCollisionIsStillAFailure pins that "this stack already
+// deployed it" is read from the previous record's *outcome*, not merely from the
+// previous record naming the logical ID.
+//
+// A stack left standing at CREATE_FAILED (DO_NOTHING, or a rollback that could not
+// finish) holds a record listing the resource it failed to create. Deploying it again
+// unchanged draws the same refusal from the same owner. Nothing changed and nothing was
+// fixed, so the second attempt must fail exactly as the first did — reading the record
+// as "I own this name" would turn a permanent collision into a success on the second
+// try, and the caller would be told a bucket is theirs while another stack holds it.
+func TestCFN_ARepeatedForeignCollisionIsStillAFailure(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	const squat = `{"Resources":{"Slot":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":"rollback-repeat"}}}}`
+
+	_, err := d.Deploy(ctx, `{"Resources":{"Owned":{"Type":"AWS::S3::Bucket",`+
+		`"Properties":{"BucketName":"rollback-repeat"}}}}`, "owner", nil)
+	require.NoError(t, err)
+
+	// DO_NOTHING so the failed record survives to be read by the second attempt.
+	opts := emulator.CFNDeployOptions{OnFailure: emulator.CFNOnFailureDoNothing}
+	first, err := d.DeployWithOptions(ctx, squat, "squatter", nil, opts)
+	require.NoError(t, err)
+	require.Equal(t, "CREATE_FAILED", first.Status)
+
+	second, err := d.DeployWithOptions(ctx, squat, "squatter", nil, opts)
+	require.NoError(t, err)
+	assert.Equal(t, "CREATE_FAILED", second.Status,
+		"the resource failed the first time, so this stack never owned the name; "+
+			"an unchanged retry against an unchanged owner fails the same way")
+	assert.Contains(t, second.StatusReason, "BucketAlreadyExists")
+}
+
+// TestCFN_AFailedUpdateRollsBackToThePreviousTemplate pins UPDATE_ROLLBACK_COMPLETE,
+// and the approximation behind it.
+//
+// UpdateStack is a re-Deploy, so the previous template is the only description of the
+// previous state substrate holds; the rollback re-deploys it. That converges on the
+// previous template's *declared* state, which is not identical to CloudFormation's
+// per-resource restore — see StackDeployer.rollbackFailedUpdate. What is asserted here
+// is the part that does hold: the status, and that the resource the failed update
+// declared is not left behind.
+func TestCFN_AFailedUpdateRollsBackToThePreviousTemplate(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnRollbackCleanTemplate, "updated", nil)
+	require.NoError(t, err)
+
+	// The update keeps both resources and adds one that will be refused.
+	result, err := d.UpdateStack(ctx, `{"Resources":{`+
+		`"Kept":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"rollback-kept"}},`+
+		`"Trailing":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"rollback-trailing"}},`+
+		`"Added":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"no"}}}}`,
+		"updated", nil)
+	require.NoError(t, err, "a rolled-back update is a status, not a failed call")
+
+	assert.Equal(t, "UPDATE_ROLLBACK_COMPLETE", result.Status)
+	assert.Contains(t, result.StatusReason, "InvalidBucketName")
+	assert.Contains(t, result.StatusReason, "Added")
+
+	// The resources the previous template declared are still there: an update
+	// rollback converges *onto* that template rather than deleting what it declares.
+	assert.Equal(t, http.StatusOK, headBucket(t, d, "rollback-kept"),
+		"an update rollback is not a create rollback; it does not sweep")
+	assert.True(t, queueExists(t, d, "rollback-trailing"))
+
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	require.Len(t, stacks, 1)
+	assert.Equal(t, "UPDATE_ROLLBACK_COMPLETE", stacks[0].Status)
+}
+
+// TestCFN_AnUnchangedUpdateStillReportsUpdateComplete is the regression this release
+// came closest to shipping: with rollback added and no redeploy guard, an update that
+// changed nothing would have reported UPDATE_ROLLBACK_COMPLETE and deleted nothing —
+// or worse, taken the create-rollback path and deleted everything.
+func TestCFN_AnUnchangedUpdateStillReportsUpdateComplete(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, cfnRollbackCleanTemplate, "noop", nil)
+	require.NoError(t, err)
+
+	result, err := d.UpdateStack(ctx, cfnRollbackCleanTemplate, "noop", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "UPDATE_COMPLETE", result.Status,
+		"an update that changes nothing succeeds")
+	assert.Empty(t, result.StatusReason)
+
+	assert.Equal(t, http.StatusOK, headBucket(t, d, "rollback-kept"))
+	assert.True(t, queueExists(t, d, "rollback-trailing"))
+}
+
+// TestCFNDeployOptionsAreValidated pins that an unrecognized OnFailure is refused
+// rather than defaulted.
+//
+// Every alternative reading of an unrecognized value is a wrong one: treating it as
+// ROLLBACK deletes resources the caller may have meant to keep, and treating it as
+// DO_NOTHING keeps resources they may have meant to remove. A typo'd "ROLBACK" that
+// silently deletes is the failure this rejection exists to prevent.
+func TestCFNDeployOptionsAreValidated(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+
+	tests := []struct {
+		name      string
+		onFailure string
+		wantErr   bool
+	}{
+		{name: "empty is the default", onFailure: "", wantErr: false},
+		{name: "ROLLBACK", onFailure: emulator.CFNOnFailureRollback, wantErr: false},
+		{name: "DO_NOTHING", onFailure: emulator.CFNOnFailureDoNothing, wantErr: false},
+		{name: "DELETE", onFailure: emulator.CFNOnFailureDelete, wantErr: false},
+		{name: "a typo is not a default", onFailure: "ROLBACK", wantErr: true},
+		{name: "the wrong case is not the value", onFailure: "rollback", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := d.DeployWithOptions(context.Background(), cfnRollbackCleanTemplate,
+				"validated-"+tc.name, nil,
+				emulator.CFNDeployOptions{OnFailure: tc.onFailure})
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, emulator.ErrCFNInvalidOnFailure)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestCFN_AnotherAccountsStackIsNotAPreviousDeployment pins the scope check behind the
+// redeploy guard.
+//
+// Export names are scoped per account and Region, and so is stack identity: a record
+// under the same *name* in another account is a different stack, and its resources are
+// not the ones being redeployed. Reading it as the previous deployment would clear a
+// genuine collision — the deployer would decide "I already own this, so the refusal is
+// not a failure" on the strength of a record belonging to someone else, which is the
+// one direction the guard must never err in.
+//
+// The collision is real rather than contrived: substrate's S3 bucket namespace is
+// global, as AWS's is, so the second account's create is refused exactly as it would be.
+func TestCFN_AnotherAccountsStackIsNotAPreviousDeployment(t *testing.T) {
+	east, _, _, _, as := newSweepDeployerShared(t)
+	ctx := context.Background()
+
+	const tmpl = `{"Resources":{"Slot":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":"rollback-scoped"}}}}`
+
+	first, err := east.Deploy(ctx, tmpl, "scoped", nil)
+	require.NoError(t, err)
+	require.Equal(t, "CREATE_COMPLETE", first.Status)
+
+	tests := []struct {
+		name      string
+		accountID string
+		region    string
+	}{
+		{name: "another account in the same region", accountID: "999988887777", region: "us-east-1"},
+		{name: "another region in the same account", accountID: "123456789012", region: "eu-west-1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			other := as(tc.accountID, tc.region)
+			result, err := other.DeployWithOptions(ctx, tmpl, "scoped", nil,
+				emulator.CFNDeployOptions{OnFailure: emulator.CFNOnFailureDoNothing})
+			require.NoError(t, err)
+			assert.Equal(t, "CREATE_FAILED", result.Status,
+				"a stack of the same name in another scope is not this stack's previous "+
+					"deployment, so the collision stands")
+			assert.Contains(t, result.StatusReason, "BucketAlreadyExists")
+		})
+	}
+}

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -209,13 +209,29 @@ func (p *CloudFormationPlugin) createStack(reqCtx *RequestContext, req *AWSReque
 		}
 	}
 
+	// Whether a failed create rolls back is the caller's choice, and the two
+	// parameters that express it are mutually exclusive. Presence, not value,
+	// decides: the CLI's --no-disable-rollback sends DisableRollback=false
+	// explicitly, so testing the value would accept a pairing the API rejects.
+	disableRollback, disableRollbackPresent := req.Params["DisableRollback"]
+	opts, err := cfnResolveFailureOptions(req.Params["OnFailure"], disableRollback,
+		disableRollbackPresent)
+	if err != nil {
+		return nil, cfnMapDeployerError(err)
+	}
+
 	// The stack name is passed as the deployer's stream ID because
 	// StackDeployer.Deploy derives the persisted stack name from it. BettyClient
 	// instead passes deploy-<unixnano>, which is right for a one-shot in-process
 	// validation run but would make a wire-created stack undiscoverable by the
 	// name the caller asked for.
-	if _, err := p.deployerFor(reqCtx).Deploy(context.Background(), body, name,
-		cfnRequestParameters(req.Params, nil)); err != nil {
+	//
+	// A failed resource is not an error here: the create's outcome is the stack's
+	// status, which is where the API puts it — real CreateStack has returned its
+	// StackId before any rollback happens — so a rolled-back stack answers 200 and
+	// says ROLLBACK_COMPLETE through DescribeStacks.
+	if _, err := p.deployerFor(reqCtx).DeployWithOptions(context.Background(), body, name,
+		cfnRequestParameters(req.Params, nil), opts); err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
 
@@ -319,11 +335,20 @@ func (p *CloudFormationPlugin) deleteStack(reqCtx *RequestContext, req *AWSReque
 // members substrate can answer from CFNStackState are emitted; CreationTime,
 // StackName and StackStatus are the three the API marks required.
 type cfnStackItem struct {
-	StackID         string            `xml:"StackId"`
-	StackName       string            `xml:"StackName"`
-	CreationTime    string            `xml:"CreationTime"`
-	LastUpdatedTime string            `xml:"LastUpdatedTime,omitempty"`
-	StackStatus     string            `xml:"StackStatus"`
+	StackID         string `xml:"StackId"`
+	StackName       string `xml:"StackName"`
+	CreationTime    string `xml:"CreationTime"`
+	LastUpdatedTime string `xml:"LastUpdatedTime,omitempty"`
+	StackStatus     string `xml:"StackStatus"`
+
+	// StackStatusReason is the "success/failure message associated with the stack
+	// status", omitted when there is none — a CREATE_COMPLETE stack has no reason
+	// to report, and emitting an empty one would suggest otherwise.
+	StackStatusReason string `xml:"StackStatusReason,omitempty"`
+
+	// DisableRollback is derived from the stack's stored OnFailure rather than being
+	// stored beside it: DisableRollback=true *is* DO_NOTHING, and a record holding
+	// both could contradict itself.
 	DisableRollback bool              `xml:"DisableRollback"`
 	Parameters      []cfnParameterXML `xml:"Parameters>member,omitempty"`
 	Outputs         []cfnOutputXML    `xml:"Outputs>member,omitempty"`
@@ -380,13 +405,15 @@ func (p *CloudFormationPlugin) describeStacks(reqCtx *RequestContext, req *AWSRe
 	resp := response{XMLNS: cfnXMLNS, Metadata: cfnMetadata(reqCtx)}
 	for _, s := range stacks {
 		resp.Result.Stacks = append(resp.Result.Stacks, cfnStackItem{
-			StackID:         cfnStackID(reqCtx, s.StackName),
-			StackName:       s.StackName,
-			CreationTime:    cfnTime(s.CreatedAt),
-			LastUpdatedTime: cfnTime(s.UpdatedAt),
-			StackStatus:     s.Status,
-			Parameters:      cfnParametersXML(s.Parameters),
-			Outputs:         cfnOutputsXML(s.Outputs, s.ExportNames),
+			StackID:           cfnStackID(reqCtx, s.StackName),
+			StackName:         s.StackName,
+			CreationTime:      cfnTime(s.CreatedAt),
+			LastUpdatedTime:   cfnTime(s.UpdatedAt),
+			StackStatus:       s.Status,
+			StackStatusReason: s.StatusReason,
+			DisableRollback:   cfnStackDisablesRollback(s.OnFailure),
+			Parameters:        cfnParametersXML(s.Parameters),
+			Outputs:           cfnOutputsXML(s.Outputs, s.ExportNames),
 		})
 	}
 	return cfnXMLResponse(http.StatusOK, resp)
@@ -501,6 +528,13 @@ func (p *CloudFormationPlugin) describeStackResources(reqCtx *RequestContext, re
 			status, reason := "CREATE_COMPLETE", ""
 			if r.Error != "" {
 				status, reason = "CREATE_FAILED", r.Error
+			}
+			// A rollback swept the resources the failed create had created, so
+			// reporting CREATE_COMPLETE for one would claim a resource that is gone.
+			// The sweep's own record is what says which, and why.
+			if del := cfnDeletionFor(s.ResourceDeletions, r.LogicalID); del != nil && r.Error == "" {
+				status = del.Status
+				reason = del.Reason
 			}
 			resp.Result.Resources = append(resp.Result.Resources, resourceItem{
 				StackID:              cfnStackID(reqCtx, s.StackName),
@@ -1142,7 +1176,11 @@ func cfnMapDeployerError(err error) *AWSError {
 		// "all the imports must be removed before you can delete the exporting
 		// stack" is an instruction to the caller — so both are 400s.
 		errors.Is(err, ErrCFNExportInUse),
-		errors.Is(err, ErrCFNExportNameConflict):
+		errors.Is(err, ErrCFNExportNameConflict),
+		// An OnFailure outside the three values, a non-boolean DisableRollback, or
+		// both parameters at once, are all the request being malformed. The API
+		// documents no code of its own for them.
+		errors.Is(err, ErrCFNInvalidOnFailure):
 		return &AWSError{Code: "ValidationError", Message: msg, HTTPStatus: http.StatusBadRequest}
 	case errors.Is(err, ErrCFNTemplateInvalid):
 		return &AWSError{

--- a/emulator/cloudformation_plugin_test.go
+++ b/emulator/cloudformation_plugin_test.go
@@ -346,6 +346,12 @@ func TestCFNPlugin_CreateStack_TemplateURLRefused(t *testing.T) {
 // a broken resource inside it. A stack reporting every resource complete
 // regardless is the failure mode this pins: a consumer asserting on a resource's
 // status would be told a queue exists that does not.
+//
+// DisableRollback because the per-resource status is what is under test: the default
+// ROLLBACK would sweep the good bucket away and report it DELETE_COMPLETE, so the
+// assertion that a resource beside a failure is CREATE_COMPLETE would be asserting the
+// rollback instead. Sent as the wire parameter rather than OnFailure so this also
+// covers the parameter a caller reaches for most often.
 func TestCFNPlugin_ResourceFailureReported(t *testing.T) {
 	ts := newCFNTestServer(t)
 
@@ -353,7 +359,8 @@ func TestCFNPlugin_ResourceFailureReported(t *testing.T) {
 	// dispatch comes back ServiceNotAvailable while the bucket beside it deploys.
 	require.NotContains(t, ts.registry.Names(), "sqs")
 	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
-		"StackName": "half-broken",
+		"StackName":       "half-broken",
+		"DisableRollback": "true",
 		"TemplateBody": `{"Resources":{` +
 			`"Good":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-good-bucket"}},` +
 			`"Bad":{"Type":"AWS::SQS::Queue","Properties":{"QueueName":"cfn-doomed-queue"}}}}`,
@@ -621,6 +628,209 @@ func cfnHeadBucket(t *testing.T, ts *cfnTestServer, bucket string) int {
 	w := httptest.NewRecorder()
 	ts.srv.ServeHTTP(w, r)
 	return w.Code
+}
+
+// cfnRollbackWireTemplate is the wire tests' failing stack: a bucket that deploys and
+// one whose name is shorter than S3's three-character minimum, so CreateBucket answers
+// InvalidBucketName. A real refusal rather than an injected one, and one reachable in a
+// registry holding only S3, IAM and CloudFormation.
+const cfnRollbackWireTemplate = `{"Resources":{` +
+	`"Good":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"cfn-wire-rollback"}},` +
+	`"Bad":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"no"}}}}`
+
+// TestCFNPlugin_CreateStackRollsBackOnTheWire is #520 as a caller sees it: the create
+// answers 200 and DescribeStacks reports ROLLBACK_COMPLETE.
+//
+// The 200 is not incidental. Real CreateStack has returned its StackId before any
+// rollback happens, so the outcome is a status a caller polls for, not an exception —
+// the same rule DeleteStack follows for DELETE_FAILED. A 500 here would break every
+// caller written against AWS semantics.
+func TestCFNPlugin_CreateStackRollsBackOnTheWire(t *testing.T) {
+	ts := newCFNTestServer(t)
+
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "wire-rolled",
+		"TemplateBody": cfnRollbackWireTemplate,
+	})
+	require.Equal(t, http.StatusOK, code,
+		"a rolled-back create still answers 200; body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "wire-rolled"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<StackStatus>ROLLBACK_COMPLETE</StackStatus>")
+	assert.Contains(t, body, "InvalidBucketName",
+		"StackStatusReason carries what failed, which is where a caller reads it")
+
+	assert.Equal(t, http.StatusNotFound, cfnHeadBucket(t, ts, "cfn-wire-rollback"),
+		"the bucket that did deploy was swept")
+}
+
+// TestCFNPlugin_DisableRollbackIsHonouredAndReported pins both halves of the
+// parameter: it changes the outcome, and DescribeStacks reports it back.
+//
+// Before #520 DescribeStacks emitted DisableRollback unconditionally false while
+// createStack read the parameter not at all — a field substrate reported wrongly for
+// every stack. A caller that set it and read it back was told it had not taken effect.
+func TestCFNPlugin_DisableRollbackIsHonouredAndReported(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     map[string]string
+		wantStatus string
+		wantFlag   string
+		wantBucket int
+	}{
+		{
+			name:       "DisableRollback=true keeps the failed stack",
+			params:     map[string]string{"DisableRollback": "true"},
+			wantStatus: "CREATE_FAILED",
+			wantFlag:   "<DisableRollback>true</DisableRollback>",
+			wantBucket: http.StatusOK,
+		},
+		{
+			// The CLI's --no-disable-rollback sends this explicitly, so it has to
+			// mean the default rather than being ignored as a zero value.
+			name:       "DisableRollback=false rolls back",
+			params:     map[string]string{"DisableRollback": "false"},
+			wantStatus: "ROLLBACK_COMPLETE",
+			wantFlag:   "<DisableRollback>false</DisableRollback>",
+			wantBucket: http.StatusNotFound,
+		},
+		{
+			name:       "OnFailure=DO_NOTHING is the same knob by another name",
+			params:     map[string]string{"OnFailure": "DO_NOTHING"},
+			wantStatus: "CREATE_FAILED",
+			wantFlag:   "<DisableRollback>true</DisableRollback>",
+			wantBucket: http.StatusOK,
+		},
+		{
+			name:       "OnFailure=DELETE leaves nothing",
+			params:     map[string]string{"OnFailure": "DELETE"},
+			wantStatus: "",
+			wantBucket: http.StatusNotFound,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// A server per case: the bucket names are shared, and a stack left over
+			// from another case would make the create collide rather than fail the
+			// way the case intends.
+			ts := newCFNTestServer(t)
+			params := map[string]string{
+				"StackName":    "wire-opt",
+				"TemplateBody": cfnRollbackWireTemplate,
+			}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			code, body := cfnAction(t, ts, "CreateStack", params)
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+			code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "wire-opt"})
+			if tc.wantStatus == "" {
+				assert.Equal(t, http.StatusBadRequest, code,
+					"OnFailure DELETE removes the stack, so there is nothing to describe")
+			} else {
+				require.Equal(t, http.StatusOK, code, "body was %s", body)
+				assert.Contains(t, body, "<StackStatus>"+tc.wantStatus+"</StackStatus>")
+				assert.Contains(t, body, tc.wantFlag,
+					"the flag is reported back as the caller set it")
+			}
+			assert.Equal(t, tc.wantBucket, cfnHeadBucket(t, ts, "cfn-wire-rollback"))
+		})
+	}
+}
+
+// TestCFNPlugin_OnFailureAndDisableRollbackAreMutuallyExclusive pins the refusal:
+// "you can specify either DisableRollback or OnFailure, but not both".
+//
+// The test is *presence*, not value, which is why the false/DO_NOTHING pairing below is
+// refused even though the two agree: --no-disable-rollback sends DisableRollback=false
+// explicitly, so a rule that ignored a false value would accept a request the API
+// rejects and silently pick a winner.
+func TestCFNPlugin_OnFailureAndDisableRollbackAreMutuallyExclusive(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]string
+	}{
+		{
+			name:   "both set and agreeing",
+			params: map[string]string{"OnFailure": "DO_NOTHING", "DisableRollback": "true"},
+		},
+		{
+			name:   "both set and disagreeing",
+			params: map[string]string{"OnFailure": "ROLLBACK", "DisableRollback": "true"},
+		},
+		{
+			name:   "an explicit false is still a specification",
+			params: map[string]string{"OnFailure": "DO_NOTHING", "DisableRollback": "false"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newCFNTestServer(t)
+			params := map[string]string{
+				"StackName":    "wire-both",
+				"TemplateBody": cfnBucketTemplate,
+			}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			code, body := cfnAction(t, ts, "CreateStack", params)
+			assert.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+			assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+			assert.Contains(t, body, "but not both")
+		})
+	}
+
+	t.Run("an unrecognized OnFailure is refused rather than defaulted", func(t *testing.T) {
+		ts := newCFNTestServer(t)
+		code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+			"StackName":    "wire-typo",
+			"TemplateBody": cfnBucketTemplate,
+			"OnFailure":    "ROLBACK",
+		})
+		assert.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+		assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+	})
+}
+
+// TestCFNPlugin_DescribeStackResourcesShowsTheRollback pins that the per-resource view
+// reflects the sweep rather than the create that preceded it.
+//
+// A resource the rollback deleted reporting CREATE_COMPLETE would tell a caller a
+// bucket exists that does not, which is the same silent-success shape as the stack
+// status itself.
+func TestCFNPlugin_DescribeStackResourcesShowsTheRollback(t *testing.T) {
+	ts := newCFNTestServer(t)
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "wire-resources",
+		"TemplateBody": cfnRollbackWireTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = cfnAction(t, ts, "DescribeStackResources",
+		map[string]string{"StackName": "wire-resources"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	var doc struct {
+		Resources []struct {
+			LogicalID string `xml:"LogicalResourceId"`
+			Status    string `xml:"ResourceStatus"`
+			Reason    string `xml:"ResourceStatusReason"`
+		} `xml:"DescribeStackResourcesResult>StackResources>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+	byLogical := map[string]string{}
+	reasons := map[string]string{}
+	for _, r := range doc.Resources {
+		byLogical[r.LogicalID] = r.Status
+		reasons[r.LogicalID] = r.Reason
+	}
+	assert.Equal(t, "DELETE_COMPLETE", byLogical["Good"],
+		"the resource the rollback swept says so")
+	assert.Equal(t, "CREATE_FAILED", byLogical["Bad"],
+		"the resource that failed keeps its own status; the sweep never touched it")
+	assert.Contains(t, reasons["Bad"], "InvalidBucketName")
 }
 
 // TestCFNPlugin_UpdateStack asserts the status moves to UPDATE_COMPLETE and that


### PR DESCRIPTION
Closes #520

## The defect

A stack holding a resource a plugin refused reported a terminal `CREATE_COMPLETE`, with every resource beside it left in place. A consumer's failure-handling path could not be tested at all, because substrate never produced the failure that path exists to handle — the teardown-side twin of the v0.88.0 cluster: HTTP 200 while the observable a caller parses is wrong.

```
aws cloudformation create-stack --stack-name partial --template-body file:///tmp/partial.json
aws cloudformation describe-stacks --stack-name partial --query 'Stacks[0].StackStatus'
# before: CREATE_COMPLETE      after: ROLLBACK_COMPLETE
aws sqs get-queue-url --queue-name still-here
# before: 200                  after: QueueDoesNotExist
```

## What changed

`ROLLBACK` is the default, as the API's is. The resources the create had already made are swept through #518's dispatcher in the inverse of the deploy order, and the stack reaches `ROLLBACK_COMPLETE` naming the failed resource and the plugin's own error code. The record stays, because a `ROLLBACK_COMPLETE` stack still blocks a create of the same name — the one thing that makes the failure impossible to miss.

`CreateStack`'s two failure parameters are read and honoured for the first time, and they are **mutually exclusive** — "you can specify either `DisableRollback` or `OnFailure`, but not both" — so giving both is a `ValidationError` rather than a precedence rule. The test is *presence*, not value: the CLI's `--no-disable-rollback` sends `DisableRollback=false` explicitly, so a rule that ignored a false would accept a combination the API rejects. This was measured against the CLI rather than assumed.

| Option | Outcome |
|---|---|
| `OnFailure=ROLLBACK` / `DisableRollback=false` | swept, `ROLLBACK_COMPLETE` |
| `OnFailure=DO_NOTHING` / `DisableRollback=true` | nothing swept, `CREATE_FAILED` — what substrate used to do unconditionally |
| `OnFailure=DELETE` | swept and the record removed |

`DescribeStacks` reports the option it was given rather than emitting `DisableRollback: false` for every stack. A sweep that cannot delete gives `ROLLBACK_FAILED` and keeps the record so the undeleted resource is discoverable. All of these answer **200** on the wire: real `CreateStack` returns its `StackId` before any rollback happens, so a rolled-back stack is not a failed call, and a 5xx would make an SDK retry a create that already ran.

A failed stack publishes **no outputs**, and therefore exports none. A duplicate export name is still answered as an error rather than as a rolled-back stack, because it is a refusal of the *request*: a request substrate declines outright never became a stack whose resources could roll back. That ordering — resource loop, then the redeploy guard, then export checks, then the failure branch — is the fix for eight tests that collided when the failure branch ran first.

## A second defect, found rather than reported

`UpdateStack` is a re-`Deploy` of the whole template, so every unchanged resource's create is re-issued and its plugin refuses it as already existing — where real CloudFormation issues no call at all for a resource it is not changing. Before rollback this was merely invisible: the refusal landed on the resource's error field and the stack still said `UPDATE_COMPLETE`. **With rollback added it becomes data loss**, since every `UpdateStack` would see failures and sweep the resources it was asked to keep.

So an already-exists refusal is cleared when — and only when — the stack's previous deployment created that logical ID *successfully* **and** the template still declares it identically (canonically marshalled JSON, since Go's encoder sorts map keys). Each condition is load-bearing and each has a test: a rename into a name another stack owns, a resource that failed the previous time (so this stack never owned the name), and a record belonging to another account or Region all remain real failures. The refusal cannot be keyed on the physical ID — a refused create returns an empty one, measured on `AWS::EC2::LaunchTemplate`.

The error-code set was harvested by deploying twice against the default registry, the same way `cfnDeleteAbsentCodes` was. Ambiguous codes (`ConflictException`, `AlreadyExistsException`) are deliberately absent: clearing one would hide a real failure, whereas a missing entry only preserves the pre-existing behaviour.

## Update rollback is an approximation, stated as one

A failed `UpdateStack` reports `UPDATE_ROLLBACK_COMPLETE` by re-deploying the stored previous template, since that is the only description of the previous state substrate holds. It converges on that template's *declared* state rather than restoring properties field by field, so a resource the failed update replaced may keep a new physical ID. Recorded in the doc comment and in `docs/services.md` — an undocumented approximation is the defect shape this release is about. A previous record that cannot be read leaves the stack at `UPDATE_FAILED` with the reason logged (`//nolint:nilerr`, explained at the site) rather than a rollback attempted against nothing.

## Tests

15 new (11 deployer-level, 4 on the wire), plus three existing contracts updated with their reasoning recorded. `TestCFN_FailedResourceDoesNotStopTheStack` was **rewritten** rather than deleted, per the plan: the behaviour it pinned did not go away, it stopped being unconditional, so it is now the `DO_NOTHING` case. Every failure is a *real* refusal — `"no"` is under S3's three-character minimum — never an injected one or a missing plugin, since `ServiceNotAvailable` is substrate's own condition rather than one a caller hits against AWS.

**Mutation testing: 11 applied, 11 caught.** Two survived on first pass and each is now pinned by a test written for it — a stack record from another account/Region being read as the previous deployment, and a resource that *failed* previously being read as one this stack owns. Others covered: `OnFailure` defaulting to `DO_NOTHING`, sweeping the refused resource, `cfnDeleteStackOp` for a create rollback, the redeploy guard removed entirely, the declaration check dropped, the presence test weakened to a value test, the error-code prefix split dropped, and the `ROLLBACK_FAILED` branch made unreachable.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test -C test/e2e ./...`.

End to end against a live server: the plan's own reproduction, all four option outcomes, both mutual-exclusion errors, an unchanged-resource update reaching `UPDATE_COMPLETE` with its bucket alive, and a failed update reaching `UPDATE_ROLLBACK_COMPLETE`.

## Compatibility

A test asserting that a partial stack reaches `CREATE_COMPLETE`, or that a resource beside a failed one survives, **will go red**. That is the fix. Pass `OnFailure=DO_NOTHING` (or `DisableRollback=true`) to keep the old outcome deliberately.
