### PR TITLE
chore(release): v0.89.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.89.0] - 2026-08-03
+
 ### Added
 - **`DeletionPolicy` and `UpdateReplacePolicy` on a template resource** (#518), which
   no template could previously declare — the attributes were dropped on parse in both
@@ -4640,7 +4642,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.88.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.89.0...HEAD
+[v0.89.0]: https://github.com/scttfrdmn/substrate/compare/v0.88.0...v0.89.0
 [v0.88.0]: https://github.com/scttfrdmn/substrate/compare/v0.87.1...v0.88.0
 [v0.87.1]: https://github.com/scttfrdmn/substrate/compare/v0.87.0...v0.87.1
 [v0.87.0]: https://github.com/scttfrdmn/substrate/compare/v0.86.0...v0.87.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.89.0] - 2026-08-03` and adds both compare links.

v0.89.0 is the teardown half of v0.88.0's shape: substrate reported a successful deletion of something it did not delete, and a successful creation of a stack real CloudFormation would have rolled back. Four issues, one coupled model — #534 (a directory marker stranding its children, then panicking), #508 (`DeleteBucket` leaking the bucket's namespace), #518 (`DeleteStack` deleting nothing but the record) and #520 (a failed resource never rolling back) — because #518's sweep calls the leaky deletes and #520 needs its dispatcher.

No code change; the tag is cut against this merge commit.