### PR TITLE
feat(s3): route UploadPartCopy and ListParts (#532, #551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GitHub label was renamed in place to `area: cloudformation`, which preserves it on
   every issue already carrying it.
 
+### Added
+- **S3 `UploadPartCopy` and `ListParts`** (#532, #551). Both were unroutable, and
+  both for the same reason: `parseS3Operation`'s object-level verb arms had drifted
+  apart on when they test `uploadId`.
+
+  A part copy — a `PUT` carrying `partNumber`, `uploadId` **and**
+  `x-amz-copy-source` — was claimed by `CopyObject`, whose copy-source test came
+  first. The consequence was worse than a missing operation: the request answered
+  `200` with a correctly-shaped `CopyPartResult`, so nothing looked wrong, while it
+  **wrote the destination object** instead of storing a part. A `HeadObject` on the
+  destination mid-upload therefore reported a `ContentLength` real S3 never exposes,
+  and the `CompleteMultipartUpload` that followed failed with `InvalidPart` because
+  no part had been stored. `UploadPartCopy` now stores a part and leaves the
+  destination key absent until Complete assembles it, honors
+  `x-amz-copy-source-range` and the `x-amz-copy-source-if-*` preconditions, and
+  returns the copied part's `ETag` and `LastModified` in a `CopyPartResult` body.
+  Copied and uploaded parts mix in one upload, and a copied part's checksum is
+  computed under the upload's algorithm so Complete still assembles a `COMPOSITE`
+  object checksum over the mixture.
+
+  `ListParts` had no handler at all, and the `GET` arm tested no `uploadId`, so
+  `GET /<bucket>/<key>?uploadId=…` reached `GetObject` and answered `404 NoSuchKey`
+  — for an upload whose parts substrate had stored and could list. A caller polling
+  its own upload could not tell an upload with parts from a key that does not exist.
+  It now returns a `ListPartsResult` with `max-parts`/`part-number-marker` paging,
+  the upload's storage class and checksum configuration, and each part's number,
+  `ETag`, size, `LastModified` and checksum. An upload with **no** parts is a `200`
+  with an empty list, not a `404`; an unknown `uploadId`, or one addressed through
+  the wrong key, is `404 NoSuchUpload` rather than the `NoSuchKey` `GetObject` was
+  answering.
+
+  The asymmetry was the tell: `PUT`, `DELETE` and `POST` all tested `uploadId`;
+  `GET` alone did not. The invariant is now stated once in the router where all four
+  arms are visible — *a multipart request is identified by its `uploadId`, and the
+  general object-verb operation is a fall-through the router must reach only after
+  every multipart test has failed* — because four arms drifting apart is what
+  produced both bugs, and a comment on one arm would not have prevented the other.
+
+  Two refusals are substrate's own choice rather than the API model's. A malformed
+  or out-of-bounds `x-amz-copy-source-range` is `400 InvalidArgument`: the reference
+  documents only `InvalidRequest` for an unsupported byte-range *source*, and unlike
+  a `GET`'s advisory `Range` header — malformed is ignored, past-EOF is clamped — a
+  copy-source range is part of the request's meaning, so a range substrate cannot
+  honor is refused rather than silently turned into a different copy. And
+  `bytes=0-` is refused where a `GET` would accept it, because an open-ended range
+  does not describe the extent of a part.
+
 ## [v0.89.0] - 2026-08-03
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -749,6 +749,8 @@ STS operations are free.
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
 | CreateMultipartUpload | Accepts `x-amz-storage-class` and the [system-metadata family](#object-system-metadata), applied to the assembled object; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums); records the encryption for the whole upload — see [Server-side encryption](#server-side-encryption); records the ACL for the whole upload — see [Access control lists](#access-control-lists) |
 | UploadPart | Verifies the part checksum, including a trailing one — see [Additional checksums](#additional-checksums) |
+| UploadPartCopy | Copies an existing object, or a byte range of one, into a part — see [Copying into a part](#copying-into-a-part) |
+| ListParts | Lists an upload's stored parts, with `max-parts` / `part-number-marker` paging; an upload with no parts is `200` with an empty list |
 | CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums); reports the upload's recorded encryption — see [Server-side encryption](#server-side-encryption); applies the upload's recorded ACL — see [Access control lists](#access-control-lists) |
 | AbortMultipartUpload | |
 | ListMultipartUploads | Emits `<StorageClass>` per in-progress upload |
@@ -1139,6 +1141,38 @@ The `EntityTooSmall` body identifies the offending part:
   <PartNumber>1</PartNumber>
 </Error>
 ```
+
+#### Copying into a part
+
+`UploadPartCopy` — a `PUT` to the destination key carrying `partNumber`, `uploadId`
+**and** `x-amz-copy-source` — copies an existing object into a part of an open
+upload. What distinguishes it from `CopyObject` is where the bytes land: **the
+destination key stays absent until `CompleteMultipartUpload` assembles it.** A
+`HeadObject` on the destination mid-upload is a `404`, and `ListParts` is the only
+place the copied bytes are observable. Copied and uploaded parts mix freely in one
+upload, and a copied part's checksum is computed under the upload's algorithm, so
+`CompleteMultipartUpload` still assembles a `COMPOSITE` object checksum over the
+mixture.
+
+`x-amz-copy-source-range` selects a byte range of the source. Unlike a `GET`'s
+`Range` header — which S3 treats as advisory, ignoring a malformed value and
+clamping one that runs past the end — a copy-source range is part of the request's
+meaning, so substrate refuses a range it cannot honor rather than silently copying
+different bytes:
+
+| Condition | Result |
+|---|---|
+| `bytes=first-last`, both offsets within the source | that range is copied |
+| No range header | the whole source object is copied |
+| Malformed, or missing either offset (`bytes=0-`, `bytes=-9`) | `400 InvalidArgument` |
+| `last` at or beyond the source's size | `400 InvalidArgument` |
+| Any range against a source of 5 MB or less | `400 InvalidRequest` — the reference's documented special error, since "you can copy a range only if the source object is greater than 5 MB" |
+| `uploadId` unknown, or for a different bucket or key | `404 NoSuchUpload` |
+| Copy source does not exist | `404 NoSuchKey` |
+
+The `x-amz-copy-source-if-*` preconditions gate reading the source and answer
+`412 PreconditionFailed` on failure. There are no destination preconditions, since
+there is no destination object yet.
 
 #### Metadata carried from CreateMultipartUpload
 

--- a/emulator/s3_part_copy_test.go
+++ b/emulator/s3_part_copy_test.go
@@ -1,0 +1,405 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// These are the #532 and #551 gates: UploadPartCopy and ListParts are both
+// addressed exactly like a general object operation of the same verb, so nothing
+// but parseS3Operation's ordering distinguishes them from CopyObject and GetObject.
+// Every assertion here is against the raw wire response, not a Go round-trip,
+// because the defects were in what the router chose rather than in any struct.
+
+// s3CopyPartResult is the parsed form of UploadPartCopy's response body.
+type s3CopyPartResult struct {
+	XMLName      xml.Name `xml:"CopyPartResult"`
+	ETag         string   `xml:"ETag"`
+	LastModified string   `xml:"LastModified"`
+}
+
+// s3ListPartsResult is the parsed form of ListParts' response body.
+type s3ListPartsResult struct {
+	XMLName              xml.Name `xml:"ListPartsResult"`
+	Bucket               string   `xml:"Bucket"`
+	Key                  string   `xml:"Key"`
+	UploadID             string   `xml:"UploadId"`
+	PartNumberMarker     int      `xml:"PartNumberMarker"`
+	NextPartNumberMarker int      `xml:"NextPartNumberMarker"`
+	MaxParts             int      `xml:"MaxParts"`
+	IsTruncated          bool     `xml:"IsTruncated"`
+	StorageClass         string   `xml:"StorageClass"`
+	Parts                []struct {
+		PartNumber   int    `xml:"PartNumber"`
+		ETag         string `xml:"ETag"`
+		Size         int64  `xml:"Size"`
+		LastModified string `xml:"LastModified"`
+	} `xml:"Part"`
+}
+
+// partBody builds a part or object body of n bytes filled with fill.
+func partBody(fill byte, n int) []byte {
+	return bytes.Repeat([]byte{fill}, n)
+}
+
+// partCopyFixture creates a source bucket holding one object of size bytes, plus a
+// destination bucket with an open multipart upload, and returns the upload ID.
+func partCopyFixture(t *testing.T, size int) (*emulator.Server, string) {
+	t.Helper()
+	srv, uploadID := multipartFixture(t, "dst", "joined")
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/src", nil, nil).Code, "create source bucket")
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/src/big", partBody('s', size), nil).Code, "put source object")
+	return srv, uploadID
+}
+
+// uploadPartCopy issues one UploadPartCopy against src/big and returns the recorder.
+func uploadPartCopy(t *testing.T, srv *emulator.Server, uploadID string, partNumber int, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	h := map[string]string{"X-Amz-Copy-Source": "/src/big"}
+	for k, v := range headers {
+		h[k] = v
+	}
+	return s3Request(t, srv, http.MethodPut,
+		fmt.Sprintf("/dst/joined?partNumber=%d&uploadId=%s", partNumber, uploadID), nil, h)
+}
+
+// listParts issues a ListParts request with the given query suffix.
+func listParts(t *testing.T, srv *emulator.Server, uploadID, extra string) (int, s3ListPartsResult, []byte) {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/dst/joined?uploadId="+uploadID+extra, nil, nil)
+	var out s3ListPartsResult
+	if w.Code == http.StatusOK {
+		require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &out), "decode ListPartsResult: %s", w.Body.Bytes())
+	}
+	return w.Code, out, w.Body.Bytes()
+}
+
+// TestS3UploadPartCopy_DestinationKeyStaysAbsent is #532's headline gate. Before
+// the fix the request was routed to CopyObject, which wrote the destination object,
+// so a HeadObject mid-upload reported a ContentLength real S3 never exposes.
+func TestS3UploadPartCopy_DestinationKeyStaysAbsent(t *testing.T) {
+	srv, uploadID := partCopyFixture(t, s3MinPartSize+1024)
+
+	resp := uploadPartCopy(t, srv, uploadID, 1, nil)
+	require.Equal(t, http.StatusOK, resp.Code, "upload part copy: %s", resp.Body.Bytes())
+
+	var result s3CopyPartResult
+	require.NoError(t, xml.Unmarshal(resp.Body.Bytes(), &result), "decode CopyPartResult: %s", resp.Body.Bytes())
+	assert.NotEmpty(t, result.ETag, "CopyPartResult must carry the part's ETag")
+	assert.NotEmpty(t, result.LastModified, "CopyPartResult must carry LastModified")
+	assert.Contains(t, resp.Body.String(), "<CopyPartResult>",
+		"the wire body must be a CopyPartResult, not a CopyObjectResult")
+	assert.NotContains(t, resp.Body.String(), "CopyObjectResult")
+
+	// The observable that a routed-to-CopyObject part copy broke.
+	hw := s3Request(t, srv, http.MethodHead, "/dst/joined", nil, nil)
+	assert.Equal(t, http.StatusNotFound, hw.Code,
+		"the destination key must not exist until CompleteMultipartUpload")
+
+	gw := s3Request(t, srv, http.MethodGet, "/dst/joined", nil, nil)
+	assert.Equal(t, http.StatusNotFound, gw.Code, "GetObject on the destination must be 404 too")
+}
+
+// TestS3UploadPartCopy_CompletesTheUpload proves the copied bytes are a real part:
+// Complete assembles them, and the assembled object is the source's bytes.
+func TestS3UploadPartCopy_CompletesTheUpload(t *testing.T) {
+	srv, uploadID := partCopyFixture(t, s3MinPartSize+1024)
+
+	resp := uploadPartCopy(t, srv, uploadID, 1, nil)
+	require.Equal(t, http.StatusOK, resp.Code, "upload part copy: %s", resp.Body.Bytes())
+	var result s3CopyPartResult
+	require.NoError(t, xml.Unmarshal(resp.Body.Bytes(), &result))
+
+	cw := s3Request(t, srv, http.MethodPost, "/dst/joined?uploadId="+uploadID,
+		completeBody(result.ETag), nil)
+	require.Equal(t, http.StatusOK, cw.Code, "complete after a part copy: %s", cw.Body.Bytes())
+
+	gw := s3Request(t, srv, http.MethodGet, "/dst/joined", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code, "the assembled object must be readable")
+	assert.Equal(t, partBody('s', s3MinPartSize+1024), gw.Body.Bytes(),
+		"the assembled object must be the copied source bytes")
+}
+
+// TestS3UploadPartCopy_MixedWithUploadedParts proves a copied part and an uploaded
+// part assemble together, in part-number order — the reason UploadPartCopy exists.
+func TestS3UploadPartCopy_MixedWithUploadedParts(t *testing.T) {
+	srv, uploadID := partCopyFixture(t, s3MinPartSize+1024)
+
+	resp := uploadPartCopy(t, srv, uploadID, 1, nil)
+	require.Equal(t, http.StatusOK, resp.Code, "upload part copy: %s", resp.Body.Bytes())
+	var copied s3CopyPartResult
+	require.NoError(t, xml.Unmarshal(resp.Body.Bytes(), &copied))
+
+	tail := partBody('t', 64)
+	uploadedETag := uploadPart(t, srv, "dst", "joined", uploadID, 2, tail)
+
+	cw := s3Request(t, srv, http.MethodPost, "/dst/joined?uploadId="+uploadID,
+		completeBody(copied.ETag, uploadedETag), nil)
+	require.Equal(t, http.StatusOK, cw.Code, "complete a mixed upload: %s", cw.Body.Bytes())
+
+	gw := s3Request(t, srv, http.MethodGet, "/dst/joined", nil, nil)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Equal(t, append(partBody('s', s3MinPartSize+1024), tail...), gw.Body.Bytes(),
+		"the copied part must precede the uploaded one")
+}
+
+// TestS3UploadPartCopy_SourceRange covers x-amz-copy-source-range: the honored
+// case, and each way a range must be refused rather than quietly widened.
+func TestS3UploadPartCopy_SourceRange(t *testing.T) {
+	const srcSize = s3MinPartSize + 1024
+
+	t.Run("honors an explicit range", func(t *testing.T) {
+		srv, uploadID := partCopyFixture(t, srcSize)
+		resp := uploadPartCopy(t, srv, uploadID, 1,
+			map[string]string{"x-amz-copy-source-range": "bytes=0-9"})
+		require.Equal(t, http.StatusOK, resp.Code, "ranged part copy: %s", resp.Body.Bytes())
+
+		_, result, raw := listParts(t, srv, uploadID, "")
+		require.Len(t, result.Parts, 1, "raw: %s", raw)
+		assert.Equal(t, int64(10), result.Parts[0].Size,
+			"only the named ten bytes may be copied")
+	})
+
+	t.Run("refuses a range past the end of the source", func(t *testing.T) {
+		srv, uploadID := partCopyFixture(t, srcSize)
+		resp := uploadPartCopy(t, srv, uploadID, 1,
+			map[string]string{"x-amz-copy-source-range": fmt.Sprintf("bytes=0-%d", srcSize)})
+		require.Equal(t, http.StatusBadRequest, resp.Code, "body: %s", resp.Body.Bytes())
+		assert.Equal(t, "InvalidArgument", parseS3Error(t, resp.Body.Bytes()).Code)
+	})
+
+	t.Run("refuses a malformed range", func(t *testing.T) {
+		srv, uploadID := partCopyFixture(t, srcSize)
+		for _, bad := range []string{"0-9", "bytes=9-0", "bytes=abc-def", "bytes=0", "bytes=-9", "bytes=0-"} {
+			resp := uploadPartCopy(t, srv, uploadID, 1,
+				map[string]string{"x-amz-copy-source-range": bad})
+			require.Equal(t, http.StatusBadRequest, resp.Code, "range %q must be refused: %s", bad, resp.Body.Bytes())
+			assert.Equal(t, "InvalidArgument", parseS3Error(t, resp.Body.Bytes()).Code, "range %q", bad)
+		}
+	})
+
+	t.Run("refuses a range against a source of 5 MB or less", func(t *testing.T) {
+		srv, uploadID := partCopyFixture(t, s3MinPartSize)
+		resp := uploadPartCopy(t, srv, uploadID, 1,
+			map[string]string{"x-amz-copy-source-range": "bytes=0-9"})
+		require.Equal(t, http.StatusBadRequest, resp.Code, "body: %s", resp.Body.Bytes())
+		assert.Equal(t, "InvalidRequest", parseS3Error(t, resp.Body.Bytes()).Code,
+			"the reference's documented special error for an unsupported byte-range source")
+	})
+
+	t.Run("copies the whole source when no range is named", func(t *testing.T) {
+		srv, uploadID := partCopyFixture(t, s3MinPartSize)
+		resp := uploadPartCopy(t, srv, uploadID, 1, nil)
+		require.Equal(t, http.StatusOK, resp.Code, "an unranged copy of a small source is fine: %s", resp.Body.Bytes())
+	})
+}
+
+// TestS3UploadPartCopy_Errors covers the refusals whose codes a caller's retry
+// logic branches on.
+func TestS3UploadPartCopy_Errors(t *testing.T) {
+	t.Run("unknown upload is NoSuchUpload", func(t *testing.T) {
+		srv, _ := partCopyFixture(t, s3MinPartSize+1024)
+		resp := uploadPartCopy(t, srv, "no-such-upload", 1, nil)
+		require.Equal(t, http.StatusNotFound, resp.Code, "body: %s", resp.Body.Bytes())
+		assert.Equal(t, "NoSuchUpload", parseS3Error(t, resp.Body.Bytes()).Code)
+	})
+
+	t.Run("absent source is NoSuchKey", func(t *testing.T) {
+		srv, uploadID := partCopyFixture(t, s3MinPartSize+1024)
+		w := s3Request(t, srv, http.MethodPut,
+			fmt.Sprintf("/dst/joined?partNumber=1&uploadId=%s", uploadID), nil,
+			map[string]string{"X-Amz-Copy-Source": "/src/missing"})
+		require.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body.Bytes())
+		assert.Equal(t, "NoSuchKey", parseS3Error(t, w.Body.Bytes()).Code)
+	})
+
+	t.Run("out-of-range part number is InvalidPart", func(t *testing.T) {
+		srv, uploadID := partCopyFixture(t, s3MinPartSize+1024)
+		for _, n := range []int{0, 10001} {
+			resp := uploadPartCopy(t, srv, uploadID, n, nil)
+			require.Equal(t, http.StatusBadRequest, resp.Code, "part %d: %s", n, resp.Body.Bytes())
+			assert.Equal(t, "InvalidPart", parseS3Error(t, resp.Body.Bytes()).Code, "part %d", n)
+		}
+	})
+
+	t.Run("a failed source precondition is 412", func(t *testing.T) {
+		srv, uploadID := partCopyFixture(t, s3MinPartSize+1024)
+		resp := uploadPartCopy(t, srv, uploadID, 1,
+			map[string]string{"x-amz-copy-source-if-match": `"not-the-etag"`})
+		assert.Equal(t, http.StatusPreconditionFailed, resp.Code, "body: %s", resp.Body.Bytes())
+	})
+}
+
+// TestS3UploadPartCopy_DoesNotDisturbCopyObject pins the other side of the
+// reordering: a copy with no partNumber/uploadId is still CopyObject, and does
+// still write the destination object.
+func TestS3UploadPartCopy_DoesNotDisturbCopyObject(t *testing.T) {
+	srv, _ := partCopyFixture(t, 32)
+
+	w := s3Request(t, srv, http.MethodPut, "/dst/plain", nil,
+		map[string]string{"X-Amz-Copy-Source": "/src/big"})
+	require.Equal(t, http.StatusOK, w.Code, "plain copy: %s", w.Body.Bytes())
+	assert.Contains(t, w.Body.String(), "<CopyObjectResult>",
+		"a copy without a part number is still CopyObject")
+
+	hw := s3Request(t, srv, http.MethodHead, "/dst/plain", nil, nil)
+	assert.Equal(t, http.StatusOK, hw.Code, "CopyObject must still write the destination")
+	assert.Equal(t, "32", hw.Header().Get("Content-Length"))
+}
+
+// TestS3ListParts_EmptyUpload is #551's headline gate: an open upload with no parts
+// is a 200 with an empty list. Before the fix the request reached GetObject and
+// answered 404 NoSuchKey, so a caller could not tell an upload from a missing key.
+func TestS3ListParts_EmptyUpload(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "dst", "joined")
+
+	code, result, raw := listParts(t, srv, uploadID, "")
+	require.Equal(t, http.StatusOK, code, "body: %s", raw)
+	assert.Contains(t, string(raw), "<ListPartsResult>",
+		"the wire body must be a ListPartsResult")
+	assert.Empty(t, result.Parts, "a fresh upload has no parts")
+	assert.False(t, result.IsTruncated)
+	assert.Equal(t, "dst", result.Bucket)
+	assert.Equal(t, "joined", result.Key)
+	assert.Equal(t, uploadID, result.UploadID)
+	assert.Equal(t, 1000, result.MaxParts, "the documented default")
+	assert.Equal(t, "STANDARD", result.StorageClass)
+}
+
+// TestS3ListParts_ReportsUploadedParts covers the ordering that state keys get
+// wrong on their own: part 10 sorts before part 2 lexicographically.
+func TestS3ListParts_ReportsUploadedParts(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "dst", "joined")
+
+	for _, n := range []int{2, 10, 1} {
+		uploadPart(t, srv, "dst", "joined", uploadID, n, partBody('a', 16*n))
+	}
+
+	code, result, raw := listParts(t, srv, uploadID, "")
+	require.Equal(t, http.StatusOK, code, "body: %s", raw)
+	require.Len(t, result.Parts, 3)
+
+	var numbers []int
+	for _, p := range result.Parts {
+		numbers = append(numbers, p.PartNumber)
+		assert.NotEmpty(t, p.ETag, "part %d must report an ETag", p.PartNumber)
+		assert.NotEmpty(t, p.LastModified, "part %d must report LastModified", p.PartNumber)
+		assert.Equal(t, int64(16*p.PartNumber), p.Size, "part %d size", p.PartNumber)
+	}
+	assert.Equal(t, []int{1, 2, 10}, numbers, "parts must be listed in ascending part-number order")
+}
+
+// TestS3ListParts_Pagination covers max-parts and part-number-marker, the two
+// parameters a caller listing a large upload depends on to see all of it.
+func TestS3ListParts_Pagination(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "dst", "joined")
+	for n := 1; n <= 3; n++ {
+		uploadPart(t, srv, "dst", "joined", uploadID, n, partBody('a', 16))
+	}
+
+	code, page1, raw := listParts(t, srv, uploadID, "&max-parts=2")
+	require.Equal(t, http.StatusOK, code, "body: %s", raw)
+	require.Len(t, page1.Parts, 2)
+	assert.Equal(t, 2, page1.MaxParts)
+	assert.True(t, page1.IsTruncated, "a third part remains")
+	assert.Equal(t, 2, page1.NextPartNumberMarker, "resume after the last part returned")
+
+	code, page2, raw := listParts(t, srv, uploadID,
+		fmt.Sprintf("&max-parts=2&part-number-marker=%d", page1.NextPartNumberMarker))
+	require.Equal(t, http.StatusOK, code, "body: %s", raw)
+	require.Len(t, page2.Parts, 1, "only parts above the marker are listed")
+	assert.Equal(t, 3, page2.Parts[0].PartNumber)
+	assert.False(t, page2.IsTruncated)
+	assert.Equal(t, 2, page2.PartNumberMarker, "the marker is echoed")
+
+	code, all, raw := listParts(t, srv, uploadID, "&max-parts=99999")
+	require.Equal(t, http.StatusOK, code, "body: %s", raw)
+	assert.Len(t, all.Parts, 3)
+	assert.Equal(t, 1000, all.MaxParts, "max-parts above the documented ceiling is clamped")
+}
+
+// TestS3ListParts_Errors covers the refusal that distinguishes #551's fix from its
+// symptom: an unknown upload is NoSuchUpload, not the NoSuchKey GetObject answered.
+func TestS3ListParts_Errors(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "dst", "joined")
+
+	t.Run("unknown upload", func(t *testing.T) {
+		w := s3Request(t, srv, http.MethodGet, "/dst/joined?uploadId=no-such-upload", nil, nil)
+		require.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body.Bytes())
+		assert.Equal(t, "NoSuchUpload", parseS3Error(t, w.Body.Bytes()).Code,
+			"an unknown upload is NoSuchUpload, not the NoSuchKey a GetObject would answer")
+	})
+
+	t.Run("upload addressed through the wrong key", func(t *testing.T) {
+		w := s3Request(t, srv, http.MethodGet, "/dst/other?uploadId="+uploadID, nil, nil)
+		require.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body.Bytes())
+		assert.Equal(t, "NoSuchUpload", parseS3Error(t, w.Body.Bytes()).Code)
+	})
+
+	t.Run("after abort", func(t *testing.T) {
+		aw := s3Request(t, srv, http.MethodDelete, "/dst/joined?uploadId="+uploadID, nil, nil)
+		require.Equal(t, http.StatusNoContent, aw.Code)
+		w := s3Request(t, srv, http.MethodGet, "/dst/joined?uploadId="+uploadID, nil, nil)
+		require.Equal(t, http.StatusNotFound, w.Code)
+		assert.Equal(t, "NoSuchUpload", parseS3Error(t, w.Body.Bytes()).Code)
+	})
+}
+
+// TestS3ListParts_DoesNotDisturbGetObject pins the other side of #551's fix: a GET
+// with no uploadId is still GetObject, including for a key that shares its name
+// with an open upload's key.
+func TestS3ListParts_DoesNotDisturbGetObject(t *testing.T) {
+	srv, uploadID := multipartFixture(t, "dst", "joined")
+	uploadPart(t, srv, "dst", "joined", uploadID, 1, partBody('a', 16))
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/dst/plain", []byte("hello"), nil).Code)
+
+	w := s3Request(t, srv, http.MethodGet, "/dst/plain", nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "hello", w.Body.String())
+
+	// The upload's own key still has no object, and a GET without uploadId says so
+	// rather than falling through to the parts list.
+	nw := s3Request(t, srv, http.MethodGet, "/dst/joined", nil, nil)
+	require.Equal(t, http.StatusNotFound, nw.Code)
+	assert.Equal(t, "NoSuchKey", parseS3Error(t, nw.Body.Bytes()).Code)
+}
+
+// TestS3ListParts_ReportsChecksumConfiguration covers the members a caller uses to
+// confirm the checksum type it asked for before it commits to a Complete.
+func TestS3ListParts_ReportsChecksumConfiguration(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/dst", nil, nil).Code)
+
+	iw := s3Request(t, srv, http.MethodPost, "/dst/joined?uploads", nil,
+		map[string]string{"x-amz-checksum-algorithm": "SHA256"})
+	require.Equal(t, http.StatusOK, iw.Code, "body: %s", iw.Body.Bytes())
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+
+	uploadPart(t, srv, "dst", "joined", ir.UploadID, 1, partBody('a', 16))
+
+	w := s3Request(t, srv, http.MethodGet, "/dst/joined?uploadId="+ir.UploadID, nil, nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.Bytes())
+	raw := w.Body.String()
+	assert.Contains(t, raw, "<ChecksumAlgorithm>SHA256</ChecksumAlgorithm>")
+	assert.Contains(t, raw, "<ChecksumSHA256>", "each part reports its own checksum")
+	assert.True(t, strings.Contains(raw, "<ChecksumType>COMPOSITE</ChecksumType>") ||
+		strings.Contains(raw, "<ChecksumType>FULL_OBJECT</ChecksumType>"),
+		"the upload's checksum type must be reported: %s", raw)
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -40,7 +40,8 @@ const (
 // It handles CreateBucket, HeadBucket, DeleteBucket, ListBuckets,
 // PutObject, GetObject, HeadObject, DeleteObject, CopyObject,
 // ListObjects, ListObjectsV2, CreateMultipartUpload, UploadPart,
-// CompleteMultipartUpload, AbortMultipartUpload, and ListMultipartUploads.
+// UploadPartCopy, CompleteMultipartUpload, AbortMultipartUpload, ListParts,
+// and ListMultipartUploads.
 // Object bodies are stored in an afero.Fs; metadata is stored via StateManager.
 type S3Plugin struct {
 	state      StateManager
@@ -125,6 +126,10 @@ func (p *S3Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return p.createMultipartUpload(ctx, req, bucket, key)
 	case "UploadPart":
 		return p.uploadPart(ctx, req, bucket, key)
+	case "UploadPartCopy":
+		return p.uploadPartCopy(ctx, req, bucket, key)
+	case "ListParts":
+		return p.listParts(ctx, req, bucket, key)
 	case "CompleteMultipartUpload":
 		return p.completeMultipartUpload(ctx, req, bucket, key)
 	case "AbortMultipartUpload":
@@ -323,6 +328,16 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 		}
 	} else {
 		// Object-level operations.
+		//
+		// The invariant across all four verb arms below: a multipart request is
+		// identified by its uploadId, and the general object-verb operation is a
+		// fall-through the router must reach only after every multipart test has
+		// failed. PUT/GET/DELETE/POST each address the same key with the same verb
+		// as their multipart counterpart, so nothing but the ordering distinguishes
+		// them. It is stated once here because the four arms drifting apart is
+		// exactly what produced #532 (UploadPartCopy claimed by CopyObject, whose
+		// X-Amz-Copy-Source test came first) and #551 (ListParts claimed by
+		// GetObject, whose arm tested no uploadId at all).
 		switch method {
 		case "PUT":
 			if req.Params["acl"] == "1" {
@@ -331,11 +346,16 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 			if _, ok := req.Params["tagging"]; ok {
 				return bucket, key, "PutObjectTagging"
 			}
+			if req.Params["partNumber"] != "" && req.Params["uploadId"] != "" {
+				// A part carrying a copy source is UploadPartCopy, not UploadPart;
+				// both are parts, so this test precedes the copy-source one below.
+				if req.Headers["X-Amz-Copy-Source"] != "" {
+					return bucket, key, "UploadPartCopy"
+				}
+				return bucket, key, "UploadPart"
+			}
 			if req.Headers["X-Amz-Copy-Source"] != "" {
 				return bucket, key, "CopyObject"
-			}
-			if req.Params["partNumber"] != "" && req.Params["uploadId"] != "" {
-				return bucket, key, "UploadPart"
 			}
 			return bucket, key, "PutObject"
 		case "GET":
@@ -344,6 +364,9 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 			}
 			if _, ok := req.Params["tagging"]; ok {
 				return bucket, key, "GetObjectTagging"
+			}
+			if req.Params["uploadId"] != "" {
+				return bucket, key, "ListParts"
 			}
 			return bucket, key, "GetObject"
 		case "HEAD":
@@ -1254,13 +1277,15 @@ func (p *S3Plugin) deleteObjects(reqCtx *RequestContext, req *AWSRequest, bucket
 	return s3XMLResponse(http.StatusOK, result)
 }
 
-// copyObject handles PUT /<bucket>/<key> with X-Amz-Copy-Source header.
-func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dstKey string) (*AWSResponse, error) {
-	ctx := context.Background()
-
-	copySource := req.Headers["X-Amz-Copy-Source"]
+// parseS3CopySource resolves an X-Amz-Copy-Source header into its bucket and key.
+// A non-nil *AWSResponse is the S3 error to return.
+//
+// Shared by CopyObject and UploadPartCopy, which document the same header with the
+// same `\/?.+\/.+` pattern. It is one function because the two are otherwise
+// unrelated code paths that must agree on what a copy source means (#532).
+func parseS3CopySource(copySource string) (string, string, *AWSResponse) {
 	if copySource == "" {
-		return s3ErrorResponse("InvalidArgument", "Copy Source must be specified.", http.StatusBadRequest), nil
+		return "", "", s3ErrorResponse("InvalidArgument", "Copy Source must be specified.", http.StatusBadRequest)
 	}
 
 	// URL-decode the source path.
@@ -1272,10 +1297,19 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 
 	slashIdx := strings.IndexByte(srcPath, '/')
 	if slashIdx < 0 {
-		return s3ErrorResponse("InvalidArgument", "Copy source must include an object key.", http.StatusBadRequest), nil
+		return "", "", s3ErrorResponse("InvalidArgument", "Copy source must include an object key.", http.StatusBadRequest)
 	}
-	srcBucket := srcPath[:slashIdx]
-	srcKey := srcPath[slashIdx+1:]
+	return srcPath[:slashIdx], srcPath[slashIdx+1:], nil
+}
+
+// copyObject handles PUT /<bucket>/<key> with X-Amz-Copy-Source header.
+func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dstKey string) (*AWSResponse, error) {
+	ctx := context.Background()
+
+	srcBucket, srcKey, srcErr := parseS3CopySource(req.Headers["X-Amz-Copy-Source"])
+	if srcErr != nil {
+		return srcErr, nil
+	}
 
 	srcMeta, err := p.state.Get(ctx, s3Namespace, "object:"+srcBucket+"/"+srcKey)
 	if err != nil {
@@ -1760,20 +1794,12 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		return s3ErrorResponse("InvalidPart", "The part number must be an integer between 1 and 10000.", http.StatusBadRequest), nil
 	}
 
-	uploadData, err := p.state.Get(ctx, s3Namespace, "multipart:"+uploadID)
+	upload, uploadResp, err := p.loadUploadFor(ctx, uploadID, bucket, key)
 	if err != nil {
-		return nil, fmt.Errorf("get upload metadata: %w", err)
+		return nil, err
 	}
-	if uploadData == nil {
-		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
-	}
-
-	var upload S3MultipartUpload
-	if err := json.Unmarshal(uploadData, &upload); err != nil {
-		return nil, fmt.Errorf("unmarshal upload metadata: %w", err)
-	}
-	if upload.Bucket != bucket || upload.Key != key {
-		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
+	if uploadResp != nil {
+		return uploadResp, nil
 	}
 
 	body, trailers := decodeAWSChunkedWithTrailers(req.Headers, req.Body)
@@ -1791,27 +1817,14 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		return cksErr, nil
 	}
 
-	partPath := fmt.Sprintf("/.multipart/%s/%d", uploadID, partNum)
-	if mkdirErr := p.fs.MkdirAll(filepath.Dir(partPath), 0o755); mkdirErr != nil {
-		return nil, fmt.Errorf("mkdir parts dir: %w", mkdirErr)
-	}
-	if writeErr := afero.WriteFile(p.fs, partPath, body, 0o644); writeErr != nil {
-		return nil, fmt.Errorf("write part body: %w", writeErr)
-	}
-
-	part := S3Part{
+	if err := p.writePart(ctx, uploadID, S3Part{
 		PartNumber:   partNum,
 		ETag:         etag,
 		Size:         int64(len(body)),
 		Checksum:     checksum,
 		LastModified: p.tc.Now(),
-	}
-	partData, err := json.Marshal(part)
-	if err != nil {
-		return nil, fmt.Errorf("marshal part metadata: %w", err)
-	}
-	if err := p.state.Put(ctx, s3Namespace, fmt.Sprintf("part:%s/%d", uploadID, partNum), partData); err != nil {
-		return nil, fmt.Errorf("save part metadata: %w", err)
+	}, body); err != nil {
+		return nil, err
 	}
 
 	respHeaders := map[string]string{"ETag": etag}
@@ -1825,6 +1838,351 @@ func (p *S3Plugin) uploadPart(_ *RequestContext, req *AWSRequest, bucket, key st
 		StatusCode: http.StatusOK,
 		Headers:    respHeaders,
 	}, nil
+}
+
+// uploadPartCopy handles PUT /<bucket>/<key>?partNumber=N&uploadId=ID carrying an
+// X-Amz-Copy-Source header.
+//
+// What makes this a distinct operation rather than a variant of CopyObject is where
+// the bytes land: they become a *part* of an open upload, and the destination key
+// stays absent until CompleteMultipartUpload assembles it. Routing it to CopyObject
+// wrote the destination object instead, so a HeadObject mid-upload reported a
+// ContentLength real S3 never exposes and the Complete that followed failed with
+// InvalidPart because no part had been stored (#532).
+func (p *S3Plugin) uploadPartCopy(_ *RequestContext, req *AWSRequest, bucket, key string) (*AWSResponse, error) {
+	ctx := context.Background()
+
+	uploadID := req.Params["uploadId"]
+
+	partNum, _ := strconv.Atoi(req.Params["partNumber"]) // non-numeric → 0, fails range check below
+	if partNum < 1 || partNum > 10000 {
+		return s3ErrorResponse("InvalidPart", "The part number must be an integer between 1 and 10000.", http.StatusBadRequest), nil
+	}
+
+	upload, uploadResp, err := p.loadUploadFor(ctx, uploadID, bucket, key)
+	if err != nil {
+		return nil, err
+	}
+	if uploadResp != nil {
+		return uploadResp, nil
+	}
+
+	srcBucket, srcKey, srcErr := parseS3CopySource(req.Headers["X-Amz-Copy-Source"])
+	if srcErr != nil {
+		return srcErr, nil
+	}
+
+	srcMeta, err := p.state.Get(ctx, s3Namespace, "object:"+srcBucket+"/"+srcKey)
+	if err != nil {
+		return nil, fmt.Errorf("get copy source metadata: %w", err)
+	}
+	if srcMeta == nil {
+		return s3ErrorResponse("NoSuchKey", "The specified key does not exist.", http.StatusNotFound), nil
+	}
+	var srcObj S3Object
+	if err := json.Unmarshal(srcMeta, &srcObj); err != nil {
+		return nil, fmt.Errorf("unmarshal copy source metadata: %w", err)
+	}
+
+	// An archived source has no readable body, exactly as for CopyObject: "you must
+	// restore a copy of this object before you can use it as a source object for the
+	// copy operation."
+	if resp := evaluateStorageClassRead(&srcObj); resp != nil {
+		return resp, nil
+	}
+
+	// The source preconditions gate reading the source. There is no destination
+	// object to guard, so unlike CopyObject there are no unprefixed conditions to
+	// evaluate — UploadPartCopy documents only the x-amz-copy-source-if-* four.
+	if evaluateReadPreconditions(copySourceConditionalHeaders(req.Headers), &srcObj) != nil {
+		return s3PreconditionFailedResponse(), nil
+	}
+
+	var srcBody []byte
+	if s3ObjectHasBody(srcKey) {
+		read, readErr := afero.ReadFile(p.fs, "/"+srcBucket+"/"+srcKey)
+		if readErr != nil {
+			return nil, fmt.Errorf("read copy source body: %w", readErr)
+		}
+		srcBody = read
+	}
+
+	body, rangeResp := s3CopySourceRangeBytes(headerValueFold(req.Headers, "x-amz-copy-source-range"), srcBody)
+	if rangeResp != nil {
+		return rangeResp, nil
+	}
+
+	// The part's checksum is computed over the copied bytes under the upload's
+	// algorithm. An empty header map is passed deliberately: a copy request carries
+	// no per-part checksum for the caller to supply, so there is nothing to verify
+	// and the digest is substrate's own — which is what lets Complete still assemble
+	// a COMPOSITE object checksum over a mix of uploaded and copied parts.
+	checksum, cksErr := resolvePartChecksum(map[string]string{}, body, upload.ChecksumAlgorithm)
+	if cksErr != nil {
+		return cksErr, nil
+	}
+
+	now := p.tc.Now()
+	hash := md5.Sum(body) //nolint:gosec // nosemgrep
+	etag := fmt.Sprintf(`"%x"`, hash)
+
+	if err := p.writePart(ctx, uploadID, S3Part{
+		PartNumber:   partNum,
+		ETag:         etag,
+		Size:         int64(len(body)),
+		Checksum:     checksum,
+		LastModified: now,
+	}, body); err != nil {
+		return nil, err
+	}
+
+	type copyPartResult struct {
+		XMLName      xml.Name        `xml:"CopyPartResult"`
+		LastModified string          `xml:"LastModified"`
+		ETag         string          `xml:"ETag"`
+		Checksum     []s3ChecksumXML `xml:",any"`
+	}
+	// No ETag response header: UploadPartCopy returns the tag in the body only, and a
+	// caller that reads the header instead of the body would silently see none.
+	return s3XMLResponse(http.StatusOK, copyPartResult{
+		LastModified: now.UTC().Format(time.RFC3339),
+		ETag:         etag,
+		Checksum:     checksumXMLElements(checksum),
+	})
+}
+
+// s3CopySourceRangeBytes resolves an x-amz-copy-source-range header against the
+// source body, returning the bytes UploadPartCopy should store. A non-nil
+// *AWSResponse is the S3 error to return.
+//
+// This deliberately does not reuse [parseByteRange]: a GET's Range header is
+// advisory — malformed is ignored and past-EOF is clamped — whereas a copy source
+// range is part of the request's meaning, so a range substrate cannot honor must
+// be refused rather than quietly turned into a different copy. The two error codes
+// come from different places, and the difference is worth stating: InvalidRequest
+// with this message is the reference's own documented special error for a source
+// that is not a valid byte-range copy source ("You can copy a range only if the
+// source object is greater than 5 MB"), while InvalidArgument for a malformed or
+// out-of-bounds range is substrate's choice of the closest documented S3 code.
+func s3CopySourceRangeBytes(header string, srcBody []byte) ([]byte, *AWSResponse) {
+	if strings.TrimSpace(header) == "" {
+		return srcBody, nil
+	}
+
+	total := int64(len(srcBody))
+	if total <= s3MinPartSize {
+		return nil, s3ErrorResponse("InvalidRequest",
+			"The specified copy source is not supported as a byte-range copy source.",
+			http.StatusBadRequest)
+	}
+
+	malformed := s3ErrorResponseWith(s3Error{
+		Code: "InvalidArgument",
+		Message: "The x-amz-copy-source-range value must be of the form bytes=first-last " +
+			"where first and last are the zero-based byte offsets to copy.",
+		Status:  http.StatusBadRequest,
+		Details: []s3ErrorDetail{{Name: "ArgumentName", Value: "x-amz-copy-source-range"}, {Name: "ArgumentValue", Value: header}},
+	})
+
+	spec, ok := strings.CutPrefix(strings.ToLower(strings.TrimSpace(header)), "bytes=")
+	if !ok {
+		return nil, malformed
+	}
+	first, last, ok := strings.Cut(spec, "-")
+	if !ok {
+		return nil, malformed
+	}
+	start, sErr := strconv.ParseInt(strings.TrimSpace(first), 10, 64)
+	end, eErr := strconv.ParseInt(strings.TrimSpace(last), 10, 64)
+	if sErr != nil || eErr != nil || start < 0 || end < start {
+		// Both offsets are required: unlike a GET, "bytes=500-" names no last byte
+		// and so does not describe the range of a part.
+		return nil, malformed
+	}
+	if end >= total {
+		return nil, s3ErrorResponseWith(s3Error{
+			Code:    "InvalidArgument",
+			Message: fmt.Sprintf("Range specified is not valid for source object of size: %d", total),
+			Status:  http.StatusBadRequest,
+			Details: []s3ErrorDetail{{Name: "ArgumentName", Value: "x-amz-copy-source-range"}, {Name: "ArgumentValue", Value: header}},
+		})
+	}
+	return srcBody[start : end+1], nil
+}
+
+// listParts handles GET /<bucket>/<key>?uploadId=ID.
+//
+// Before #551 the object-level GET arm tested no uploadId, so this request reached
+// GetObject and answered 404 NoSuchKey — for an upload whose parts substrate had
+// stored and could list. A caller polling its own upload's progress therefore could
+// not tell an upload with parts from a key that does not exist.
+func (p *S3Plugin) listParts(_ *RequestContext, req *AWSRequest, bucket, key string) (*AWSResponse, error) {
+	ctx := context.Background()
+
+	uploadID := req.Params["uploadId"]
+
+	upload, uploadResp, err := p.loadUploadFor(ctx, uploadID, bucket, key)
+	if err != nil {
+		return nil, err
+	}
+	if uploadResp != nil {
+		return uploadResp, nil
+	}
+
+	// "The ListParts request returns a maximum of 1,000 uploaded parts. The limit of
+	// 1,000 parts is also the default value."
+	maxParts := s3MaxParts
+	if mp := req.Params["max-parts"]; mp != "" {
+		if n, convErr := strconv.Atoi(mp); convErr == nil && n >= 0 && n < s3MaxParts {
+			maxParts = n
+		}
+	}
+	// "Specifies the part after which listing should begin. Only parts with higher
+	// part numbers will be listed." A non-numeric marker lists from the start, which
+	// is how the other list operations treat an unusable token.
+	marker, _ := strconv.Atoi(req.Params["part-number-marker"])
+
+	stored, err := p.loadUploadParts(ctx, uploadID)
+	if err != nil {
+		return nil, err
+	}
+
+	type partEntry struct {
+		PartNumber   int             `xml:"PartNumber"`
+		LastModified string          `xml:"LastModified"`
+		ETag         string          `xml:"ETag"`
+		Size         int64           `xml:"Size"`
+		Checksum     []s3ChecksumXML `xml:",any"`
+	}
+	type listPartsResult struct {
+		XMLName xml.Name `xml:"ListPartsResult"`
+		Bucket  string   `xml:"Bucket"`
+		Key     string   `xml:"Key"`
+		//nolint:revive // matches AWS XML field name
+		UploadId             string      `xml:"UploadId"`
+		PartNumberMarker     int         `xml:"PartNumberMarker"`
+		NextPartNumberMarker int         `xml:"NextPartNumberMarker,omitempty"`
+		MaxParts             int         `xml:"MaxParts"`
+		IsTruncated          bool        `xml:"IsTruncated"`
+		Parts                []partEntry `xml:"Part"`
+		StorageClass         string      `xml:"StorageClass"`
+		ChecksumAlgorithm    string      `xml:"ChecksumAlgorithm,omitempty"`
+		ChecksumType         string      `xml:"ChecksumType,omitempty"`
+	}
+
+	storageClass := upload.StorageClass
+	if storageClass == "" {
+		storageClass = S3StorageClassStandard
+	}
+	result := listPartsResult{
+		Bucket:            bucket,
+		Key:               key,
+		UploadId:          uploadID,
+		PartNumberMarker:  marker,
+		MaxParts:          maxParts,
+		StorageClass:      storageClass,
+		ChecksumAlgorithm: upload.ChecksumAlgorithm,
+		ChecksumType:      upload.ChecksumType,
+	}
+
+	for _, part := range stored {
+		if part.PartNumber <= marker {
+			continue
+		}
+		if len(result.Parts) == maxParts {
+			// A part remains beyond the page, so the caller is told where to resume
+			// rather than left to assume it has seen the whole upload.
+			result.IsTruncated = true
+			result.NextPartNumberMarker = result.Parts[len(result.Parts)-1].PartNumber
+			break
+		}
+		result.Parts = append(result.Parts, partEntry{
+			PartNumber:   part.PartNumber,
+			LastModified: part.LastModified.UTC().Format(time.RFC3339),
+			ETag:         part.ETag,
+			Size:         part.Size,
+			Checksum:     checksumXMLElements(part.Checksum),
+		})
+	}
+
+	// An upload with no parts is a 200 with an empty list, not a 404: the upload
+	// exists, and "a response can contain zero or more Part elements".
+	return s3XMLResponse(http.StatusOK, result)
+}
+
+// s3MaxParts is both the default and the maximum value of ListParts' max-parts.
+const s3MaxParts = 1000
+
+// loadUploadFor loads the multipart upload named by uploadID and confirms it
+// targets bucket/key. A non-nil *AWSResponse is the NoSuchUpload to return.
+//
+// The bucket/key confirmation is the reason this is shared: an upload ID addressed
+// through the wrong key is not that upload, and every multipart operation must
+// answer NoSuchUpload for it rather than act on a different upload's parts.
+func (p *S3Plugin) loadUploadFor(ctx context.Context, uploadID, bucket, key string) (S3MultipartUpload, *AWSResponse, error) {
+	var upload S3MultipartUpload
+
+	uploadData, err := p.state.Get(ctx, s3Namespace, "multipart:"+uploadID)
+	if err != nil {
+		return upload, nil, fmt.Errorf("get upload metadata: %w", err)
+	}
+	if uploadData == nil {
+		return upload, s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
+	}
+	if err := json.Unmarshal(uploadData, &upload); err != nil {
+		return upload, nil, fmt.Errorf("unmarshal upload metadata: %w", err)
+	}
+	if upload.Bucket != bucket || upload.Key != key {
+		return upload, s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
+	}
+	return upload, nil, nil
+}
+
+// loadUploadParts returns an upload's stored parts in ascending part-number order.
+func (p *S3Plugin) loadUploadParts(ctx context.Context, uploadID string) ([]S3Part, error) {
+	partKeys, err := p.state.List(ctx, s3Namespace, "part:"+uploadID+"/")
+	if err != nil {
+		return nil, fmt.Errorf("list parts of %s: %w", uploadID, err)
+	}
+	parts := make([]S3Part, 0, len(partKeys))
+	for _, pk := range partKeys {
+		data, getErr := p.state.Get(ctx, s3Namespace, pk)
+		if getErr != nil {
+			return nil, fmt.Errorf("get %s: %w", pk, getErr)
+		}
+		if data == nil {
+			continue
+		}
+		var part S3Part
+		if unmarshalErr := json.Unmarshal(data, &part); unmarshalErr != nil {
+			return nil, fmt.Errorf("unmarshal %s: %w", pk, unmarshalErr)
+		}
+		parts = append(parts, part)
+	}
+	// State keys sort lexicographically, which puts part 10 before part 2.
+	sort.Slice(parts, func(i, j int) bool { return parts[i].PartNumber < parts[j].PartNumber })
+	return parts, nil
+}
+
+// writePart stores one part's body and metadata, the write half shared by
+// UploadPart and UploadPartCopy. Both must land in the same place under the same
+// key scheme, or a Complete naming a copied part cannot resolve it.
+func (p *S3Plugin) writePart(ctx context.Context, uploadID string, part S3Part, body []byte) error {
+	partPath := fmt.Sprintf("/.multipart/%s/%d", uploadID, part.PartNumber)
+	if mkdirErr := p.fs.MkdirAll(filepath.Dir(partPath), 0o755); mkdirErr != nil {
+		return fmt.Errorf("mkdir parts dir: %w", mkdirErr)
+	}
+	if writeErr := afero.WriteFile(p.fs, partPath, body, 0o644); writeErr != nil {
+		return fmt.Errorf("write part body: %w", writeErr)
+	}
+	partData, err := json.Marshal(part)
+	if err != nil {
+		return fmt.Errorf("marshal part metadata: %w", err)
+	}
+	if err := p.state.Put(ctx, s3Namespace, fmt.Sprintf("part:%s/%d", uploadID, part.PartNumber), partData); err != nil {
+		return fmt.Errorf("save part metadata: %w", err)
+	}
+	return nil
 }
 
 // s3MinPartSize is the minimum size in bytes of every part in a multipart upload
@@ -1851,20 +2209,12 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 
 	uploadID := req.Params["uploadId"]
 
-	uploadData, err := p.state.Get(ctx, s3Namespace, "multipart:"+uploadID)
+	upload, uploadResp, err := p.loadUploadFor(ctx, uploadID, bucket, key)
 	if err != nil {
-		return nil, fmt.Errorf("get upload metadata: %w", err)
+		return nil, err
 	}
-	if uploadData == nil {
-		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
-	}
-
-	var upload S3MultipartUpload
-	if err := json.Unmarshal(uploadData, &upload); err != nil {
-		return nil, fmt.Errorf("unmarshal upload metadata: %w", err)
-	}
-	if upload.Bucket != bucket || upload.Key != key {
-		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
+	if uploadResp != nil {
+		return uploadResp, nil
 	}
 
 	var cReq s3CompleteMultipartUploadRequest
@@ -2121,20 +2471,12 @@ func (p *S3Plugin) abortMultipartUpload(_ *RequestContext, req *AWSRequest, buck
 
 	uploadID := req.Params["uploadId"]
 
-	uploadData, err := p.state.Get(ctx, s3Namespace, "multipart:"+uploadID)
+	_, uploadResp, err := p.loadUploadFor(ctx, uploadID, bucket, key)
 	if err != nil {
-		return nil, fmt.Errorf("get upload metadata: %w", err)
+		return nil, err
 	}
-	if uploadData == nil {
-		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
-	}
-
-	var upload S3MultipartUpload
-	if err := json.Unmarshal(uploadData, &upload); err != nil {
-		return nil, fmt.Errorf("unmarshal upload metadata: %w", err)
-	}
-	if upload.Bucket != bucket || upload.Key != key {
-		return s3ErrorResponse("NoSuchUpload", s3NoSuchUploadMessage, http.StatusNotFound), nil
+	if uploadResp != nil {
+		return uploadResp, nil
 	}
 
 	if abortErr := p.abortUploadState(ctx, uploadID); abortErr != nil {


### PR DESCRIPTION
Closes #532
Closes #551

Two S3 multipart operations were unroutable, and both for the same reason, so they ship as one review of `parseS3Operation`'s precedence order rather than two separate reorderings.

## The shared cause

The object-level verb arms had drifted apart on when they test `uploadId`. `PUT`, `DELETE` and `POST` all tested it; **`GET` alone did not**, and `PUT` tested `X-Amz-Copy-Source` *before* it. Since every multipart operation addresses the same key with the same verb as its general-object counterpart, nothing but the ordering distinguishes them.

The invariant is now stated once in the router where all four arms are visible — *a multipart request is identified by its `uploadId`, and the general object-verb operation is a fall-through the router must reach only after every multipart test has failed*. A comment on one arm would not have prevented the other.

## #532 — `UploadPartCopy` was worse than filed

Measured against v0.89.0 on a live server, not inferred: the request answered **`200` with a correctly-shaped `CopyPartResult`**, so nothing looked wrong — while `CopyObject` **wrote the destination object**. A `head-object` on the destination mid-upload returned `ContentLength 6291456`, which real S3 never exposes, and the `complete-multipart-upload` that followed failed `InvalidPart` because no part had been stored.

Now: stores a part, leaves the destination key absent until Complete, honors `x-amz-copy-source-range` and the `x-amz-copy-source-if-*` preconditions, returns `ETag`/`LastModified` in a `CopyPartResult`. Copied and uploaded parts mix in one upload and a copied part's checksum is computed under the upload's algorithm, so Complete still assembles a `COMPOSITE` object checksum over the mixture.

## #551 — `ListParts` had no handler at all

Found while reproducing #532. `GET /<bucket>/<key>?uploadId=…` reached `GetObject` → `404 NoSuchKey`, for an upload whose parts substrate had stored and could list. A caller polling its own upload could not tell an upload with parts from a key that does not exist.

Now: `ListPartsResult` with `max-parts`/`part-number-marker` paging, the upload's storage class and checksum configuration, and each part's number, `ETag`, size, `LastModified` and checksum. Zero parts is **`200` with an empty list**, not a `404`. An unknown `uploadId`, or one addressed through the wrong key, is `404 NoSuchUpload` rather than the `NoSuchKey` `GetObject` answered.

## Provenance

Two refusals are substrate's own choice, not the API model's:

- A malformed or out-of-bounds `x-amz-copy-source-range` is `400 InvalidArgument`. The reference documents only `InvalidRequest`, and for an unsupported byte-range *source*. Unlike a `GET`'s advisory `Range` header — malformed is ignored, past-EOF is clamped — a copy-source range is part of the request's meaning, so a range substrate cannot honor is refused rather than silently turned into a different copy.
- `bytes=0-` is refused where a `GET` would accept it: an open-ended range does not describe the extent of a part.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test -C test/e2e ./...` — all clean.

**Each gate fails before the fix.** Reverting only the router ordering (leaving both handlers in place) turns every new test red, and #532's and #551's gates go red independently.

End to end against a live server, matching the plan's checks:

```
$ aws s3api list-parts --bucket mpu-dst --key j --upload-id "$UP"      # 200, empty list (was 404 NoSuchKey)
$ aws s3api upload-part-copy --bucket mpu-dst --key j --part-number 1 --upload-id "$UP" --copy-source mpu-src/big
{"CopyPartResult": {"ETag": "\"ba0f00...\"", "LastModified": "2026-08-04T00:27:11+00:00"}}
$ aws s3api head-object --bucket mpu-dst --key j                       # 404 (was ContentLength 6291456)
$ aws s3api list-parts --bucket mpu-dst --key j --upload-id "$UP"      # 1 part, Size 6291456
$ aws s3api complete-multipart-upload ...                              # 200 (was InvalidPart)
$ aws s3api head-object --bucket mpu-dst --key j --query ContentLength # 6291456 — now the key exists
$ aws s3api list-parts --bucket mpu-dst --key j --upload-id nope       # NoSuchUpload
$ aws s3api upload-part-copy ... --copy-source-range bytes=0-9         # Size 10
$ aws s3api upload-part-copy ... --copy-source-range bytes=0-9999999   # InvalidArgument
```

## Mutation testing

Seven mutants, all **CAUGHT**, none survived — anchor-count asserted before applying, `gofmt -w && go vet` gated, run under `-race`:

| Mutant | Caught by |
|---|---|
| the part copy writes the destination object as well as the part | `DestinationKeyStaysAbsent` |
| `ListParts` drops the ascending part-number sort | `ReportsUploadedParts`, `Pagination` |
| `loadUploadFor` stops confirming bucket/key | `ListParts_Errors/wrong_key`, **and an existing Complete test** |
| an upload with no parts answers 404 | `ListParts_EmptyUpload` |
| `x-amz-copy-source-range` is ignored | all three `SourceRange` subtests |
| `IsTruncated` never reported | `Pagination` |
| `part-number-marker` ignored | `Pagination` |

Plus the two router reversions above, which each go red independently.

## Compatibility

A test that asserts a part copy writes the destination object, or that `GET ?uploadId` answers `404 NoSuchKey`, **will go red**. That is the fix. `CopyObject` and `GetObject` without multipart parameters are unchanged, and two tests pin that explicitly.

## Refactors carried along

`parseS3CopySource` is extracted so `CopyObject` and `UploadPartCopy` cannot drift on what a copy source means. `loadUploadFor` and `writePart` are extracted so all four multipart operations resolve an upload and store a part the same way — the mutation run confirms the shared `loadUploadFor` is covered by both the new tests and the existing Complete tests.
