### PR TITLE
fix(s3): parse a notification configuration off the wire (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bytes=0-` is refused where a `GET` would accept it, because an open-ended range
   does not describe the extent of a part.
 
+### Fixed
+- **An S3 bucket notification configuration submitted the way the API documents it
+  is now parsed, stored, reported back — and dispatched** (#542). This is not a
+  lost-configuration bug. It is a working feature that could not be turned on: every
+  S3 event notification configured through the real API was silently off.
+
+  `PutBucketNotificationConfiguration` unmarshalled the request body into
+  `S3NotificationConfiguration`, a struct carrying only `json` tags. Go's XML decoder
+  falls back to matching Go field *names* when a field has no `xml` tag, and none of
+  the API's element names are substrate's field names: the wire names each
+  configuration in the **singular** (`TopicConfiguration`, `QueueConfiguration`,
+  `CloudFunctionConfiguration`), names the destination after the service rather than
+  the field (`Topic`, `Queue`, `CloudFunction` — not `TopicArn`, `QueueArn`,
+  `LambdaFunctionArn`), repeats a bare `Event` per event rather than nesting under
+  `Events`, and names the key filter's inner element `S3Key` rather than `Key`. So a
+  real-S3 body matched **nothing**.
+
+  What made it invisible is that `xml.Unmarshal` reports **no error** for a body
+  whose elements match no field. The handler's JSON fallback therefore never ran, an
+  empty configuration was persisted, and the request answered `200`. Since an empty
+  configuration is also the documented way to *disable* notifications, the effect of
+  configuring a notification the AWS way was to turn notifications off.
+
+  `fireNotifications` reads that same record, which is the more serious half and was
+  not in the report: with an empty configuration stored, no event was ever
+  dispatched. A test asserting a message arrives failed far from its assertion, and
+  one asserting no message arrives passed vacuously.
+
+  The remedy follows the one #528 established for CloudWatch Logs, because the struct
+  is dual-role — it is also the persisted encoding, so retagging it would have fixed
+  the wire and changed the stored format in the same edit, stranding existing
+  records. The state struct and its `json` tags are untouched; a set of wire types
+  with the correct `xml` element names sits beside them, with projections both ways,
+  and `EventBridgeConfiguration` is now recognized, stored and reported (delivery to
+  EventBridge is still not dispatched — substrate has no bus-to-target path for S3
+  events, and `docs/services.md` says so). `fireNotifications` and the API read now
+  share one loader, so a read-back that passes while delivery stays broken is no
+  longer reachable.
+
+  **A non-empty body naming no recognized element is now `400 MalformedXML`.** This
+  refusal is substrate's own choice, not the API model's: without it, a body with the
+  wrong element names is indistinguishable from a deliberate disable, which is
+  exactly how this defect stayed invisible. Substrate's pre-existing JSON body form,
+  keyed on the state shape's `json` tags, is still accepted.
+
+  Two existing tests are worth naming. The round-trip test passed throughout, because
+  a struct marshalled and unmarshalled by its own definition agrees with itself
+  whatever its tags say — the lesson #528/#529 already paid for, and why every new
+  assertion here is against raw wire bytes. And a delete-bucket sub-test had a
+  comment explaining that it wrote a substrate-shaped body *because* the AWS-shaped
+  one stored nothing; it now writes the AWS shape, so what it pins is again the
+  delete clearing the key.
+
 ## [v0.89.0] - 2026-08-03
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -764,8 +764,8 @@ STS operations are free.
 | PutBucketAcl | Accepts an XML body, a canned `x-amz-acl` or the `x-amz-grant-*` family — see [Access control lists](#access-control-lists); `403 AccessDenied` for a public ACL when `BlockPublicAcls` is set — see [Block Public Access](#block-public-access) |
 | GetObjectAcl | Reports the stored ACL, or the default owner-only one — see [Access control lists](#access-control-lists) |
 | PutObjectAcl | Accepts an XML body, a canned `x-amz-acl` or the `x-amz-grant-*` family — see [Access control lists](#access-control-lists); `403 AccessDenied` for a public ACL when the *bucket* has `BlockPublicAcls` set — see [Block Public Access](#block-public-access) |
-| GetBucketNotificationConfiguration | |
-| PutBucketNotificationConfiguration | Triggers Lambda/SQS on PutObject/DeleteObject |
+| GetBucketNotificationConfiguration | Reports the stored configuration in the API's element names; an unconfigured bucket is an empty `NotificationConfiguration` — see [Event notifications](#event-notifications) |
+| PutBucketNotificationConfiguration | Dispatches to Lambda, SQS and SNS on `PutObject`/`DeleteObject`; a body naming no recognized element is `400 MalformedXML` — see [Event notifications](#event-notifications) |
 | PutBucketTagging | |
 | GetBucketTagging | |
 | DeleteBucketTagging | |
@@ -1575,6 +1575,37 @@ XML body wins over both.
 substrate has no canonical user IDs: there is one owner per bucket and it owns everything
 in it. An ACL's `Owner` and its `CanonicalUser` `FULL_CONTROL` grantee are therefore
 always the same ID, and an object's owner is its bucket's.
+
+### Event notifications
+
+`PutBucketNotificationConfiguration` accepts the API's XML body and
+`GetBucketNotificationConfiguration` returns it in the same shape. Note the element
+names, which are not the SDK member names:
+
+| Destination | Configuration element | Destination element |
+|---|---|---|
+| SNS topic | `TopicConfiguration` | `Topic` |
+| SQS queue | `QueueConfiguration` | `Queue` |
+| Lambda function | `CloudFunctionConfiguration` | `CloudFunction` |
+| EventBridge | `EventBridgeConfiguration` | — (no members) |
+
+Each configuration takes an optional `Id`, one or more repeated `Event` elements, and
+an optional `Filter` → `S3Key` → repeated `FilterRule` with `Name` (`prefix` or
+`suffix`) and `Value`. Substrate also accepts a JSON body keyed on the SDK's member
+names as a convenience; the response is always XML.
+
+A configured notification is **dispatched**: `PutObject` and `DeleteObject` invoke the
+named Lambda function, send to the named SQS queue, and publish to the named SNS
+topic, with the key filter applied. EventBridge delivery is recorded and reported but
+not dispatched — substrate has no bus-to-target path for S3 events.
+
+An **empty** `NotificationConfiguration` is the documented way to turn notifications
+off, and an unconfigured bucket reads back as one. A non-empty body naming no
+recognized element is `400 MalformedXML` rather than being accepted as a disable: an
+XML decoder reports no error for a body whose elements match no field, so without that
+refusal a body with the wrong element names is indistinguishable from a deliberate
+disable, which is how a configuration could be accepted with a `200` and silently
+never fire (#542).
 
 ### CloudFormation resource types
 

--- a/emulator/s3_delete_bucket_state_test.go
+++ b/emulator/s3_delete_bucket_state_test.go
@@ -110,16 +110,15 @@ func s3DeleteBucketSubresources() []s3BucketSubresource {
 			name: "bucket notification configuration",
 			configure: func(t *testing.T, srv *emulator.Server) {
 				t.Helper()
-				// Substrate unmarshals this body by Go field name, so the element
-				// names are QueueConfigurations/QueueArn/Events rather than real
-				// S3's QueueConfiguration/Queue/Event, and the marker is the queue
-				// ARN rather than an Id. Written the AWS way the body parses to an
-				// empty configuration and stores nothing — which would make this
-				// sub-test pass whether the key is cleared or not (#542).
-				cfg := `<NotificationConfiguration><QueueConfigurations>` +
-					`<QueueArn>arn:aws:sqs:us-east-1:123456789012:leak-marker</QueueArn>` +
-					`<Events>s3:ObjectCreated:*</Events>` +
-					`</QueueConfigurations></NotificationConfiguration>`
+				// Real S3's element names, singular and with the destination named
+				// after the service. Until #542 substrate matched this body by Go
+				// field name, so written this way it parsed to an empty
+				// configuration and stored nothing — which made this sub-test pass
+				// whether or not the delete cleared the key.
+				cfg := `<NotificationConfiguration><QueueConfiguration>` +
+					`<Queue>arn:aws:sqs:us-east-1:123456789012:leak-marker</Queue>` +
+					`<Event>s3:ObjectCreated:*</Event>` +
+					`</QueueConfiguration></NotificationConfiguration>`
 				code := s3Request(t, srv, http.MethodPut, "/recycled?notification",
 					[]byte(cfg), nil).Code
 				require.Contains(t, []int{http.StatusOK, http.StatusNoContent}, code)

--- a/emulator/s3_notification_wire_test.go
+++ b/emulator/s3_notification_wire_test.go
@@ -1,0 +1,370 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// These are #542's gates. Every body here is written the way real S3 writes it —
+// singular configuration elements, the destination named after the service, a
+// repeated bare Event — and every assertion is against the raw wire response.
+//
+// A round-trip through substrate's own struct is what hid this: a type
+// marshaled and unmarshaled by its own definition agrees with itself whatever
+// its tags say. The pre-existing round-trip test passed throughout, and so did a
+// delete-bucket test whose "stored configuration" was never stored at all.
+
+// notificationXML is the request body a caller writes to configure one SQS
+// destination, in real S3's element names.
+func notificationXML(queueARN string) []byte {
+	return []byte(`<NotificationConfiguration>` +
+		`<QueueConfiguration>` +
+		`<Id>toSQS</Id>` +
+		`<Queue>` + queueARN + `</Queue>` +
+		`<Event>s3:ObjectCreated:*</Event>` +
+		`</QueueConfiguration>` +
+		`</NotificationConfiguration>`)
+}
+
+// putNotification configures a bucket's notifications from a raw XML body.
+func putNotification(t *testing.T, srv *emulator.Server, bucket string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	return s3Request(t, srv, http.MethodPut, "/"+bucket+"?notification", body,
+		map[string]string{"Content-Type": "application/xml"})
+}
+
+// getNotification reads a bucket's notification configuration and returns the raw body.
+func getNotification(t *testing.T, srv *emulator.Server, bucket string) (int, string) {
+	t.Helper()
+	w := s3Request(t, srv, http.MethodGet, "/"+bucket+"?notification", nil, nil)
+	return w.Code, w.Body.String()
+}
+
+// TestS3Notification_RealS3BodyRoundTrips is the read-back half of #542: a body
+// in the API's element names comes back as the same configuration. Before the fix
+// every element of this body matched no field, xml.Unmarshal reported no error,
+// and an empty configuration was persisted with a 200.
+func TestS3Notification_RealS3BodyRoundTrips(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/notif", nil, nil).Code)
+
+	const queueARN = "arn:aws:sqs:us-east-1:123456789012:my-queue"
+	require.Equal(t, http.StatusOK, putNotification(t, srv, "notif", notificationXML(queueARN)).Code)
+
+	code, body := getNotification(t, srv, "notif")
+	require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+	// The wire names, not substrate's field names. Asserting on the raw body is
+	// the point: a projection through the state struct would agree with itself.
+	assert.Contains(t, body, "<QueueConfiguration>",
+		"the configuration element is singular on the wire")
+	assert.NotContains(t, body, "<QueueConfigurations>",
+		"a plural element is substrate's field name leaking onto the wire")
+	assert.Contains(t, body, "<Queue>"+queueARN+"</Queue>",
+		"the destination element is Queue, not QueueArn")
+	assert.NotContains(t, body, "QueueArn")
+	assert.Contains(t, body, "<Event>s3:ObjectCreated:*</Event>",
+		"events repeat as bare Event elements")
+	assert.NotContains(t, body, "<Events>")
+	assert.Contains(t, body, "<Id>toSQS</Id>")
+}
+
+// TestS3Notification_AllThreeDestinations covers each configuration element
+// separately, so a single passing assertion cannot stand in for all three. Each
+// destination has its own element name and its own differently-named target.
+func TestS3Notification_AllThreeDestinations(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantsXML []string
+	}{
+		{
+			name: "topic",
+			body: `<NotificationConfiguration><TopicConfiguration>` +
+				`<Id>t1</Id>` +
+				`<Topic>arn:aws:sns:us-east-1:123456789012:topic-a</Topic>` +
+				`<Event>s3:ObjectCreated:Put</Event>` +
+				`</TopicConfiguration></NotificationConfiguration>`,
+			wantsXML: []string{
+				"<TopicConfiguration>",
+				"<Topic>arn:aws:sns:us-east-1:123456789012:topic-a</Topic>",
+				"<Event>s3:ObjectCreated:Put</Event>",
+			},
+		},
+		{
+			name: "queue",
+			body: `<NotificationConfiguration><QueueConfiguration>` +
+				`<Id>q1</Id>` +
+				`<Queue>arn:aws:sqs:us-east-1:123456789012:queue-a</Queue>` +
+				`<Event>s3:ObjectRemoved:*</Event>` +
+				`</QueueConfiguration></NotificationConfiguration>`,
+			wantsXML: []string{
+				"<QueueConfiguration>",
+				"<Queue>arn:aws:sqs:us-east-1:123456789012:queue-a</Queue>",
+				"<Event>s3:ObjectRemoved:*</Event>",
+			},
+		},
+		{
+			// The SDKs call this member LambdaFunctionConfigurations; the XML kept
+			// the original CloudFunctionConfiguration/CloudFunction names, so
+			// matching on the SDK's spelling finds nothing.
+			name: "lambda",
+			body: `<NotificationConfiguration><CloudFunctionConfiguration>` +
+				`<Id>l1</Id>` +
+				`<CloudFunction>arn:aws:lambda:us-east-1:123456789012:function:f</CloudFunction>` +
+				`<Event>s3:ObjectCreated:*</Event>` +
+				`</CloudFunctionConfiguration></NotificationConfiguration>`,
+			wantsXML: []string{
+				"<CloudFunctionConfiguration>",
+				"<CloudFunction>arn:aws:lambda:us-east-1:123456789012:function:f</CloudFunction>",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/dests", nil, nil).Code)
+			require.Equal(t, http.StatusOK, putNotification(t, srv, "dests", []byte(tt.body)).Code)
+
+			code, body := getNotification(t, srv, "dests")
+			require.Equal(t, http.StatusOK, code, "body: %s", body)
+			for _, want := range tt.wantsXML {
+				assert.Contains(t, body, want)
+			}
+		})
+	}
+}
+
+// TestS3Notification_KeyFilterRoundTrips covers the Filter/S3Key/FilterRule
+// nesting, whose inner element is S3Key on the wire and Key in state, and whose
+// rules repeat as FilterRule rather than nesting under FilterRules.
+func TestS3Notification_KeyFilterRoundTrips(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/filt", nil, nil).Code)
+
+	body := `<NotificationConfiguration><QueueConfiguration>` +
+		`<Queue>arn:aws:sqs:us-east-1:123456789012:filtered</Queue>` +
+		`<Event>s3:ObjectCreated:Put</Event>` +
+		`<Filter><S3Key>` +
+		`<FilterRule><Name>prefix</Name><Value>images/</Value></FilterRule>` +
+		`<FilterRule><Name>suffix</Name><Value>.jpg</Value></FilterRule>` +
+		`</S3Key></Filter>` +
+		`</QueueConfiguration></NotificationConfiguration>`
+	require.Equal(t, http.StatusOK, putNotification(t, srv, "filt", []byte(body)).Code)
+
+	code, out := getNotification(t, srv, "filt")
+	require.Equal(t, http.StatusOK, code, "body: %s", out)
+	assert.Contains(t, out, "<S3Key>", "the inner filter element is S3Key on the wire, not Key")
+	assert.NotContains(t, out, "<Key>")
+	assert.Contains(t, out, "<FilterRule><Name>prefix</Name><Value>images/</Value></FilterRule>")
+	assert.Contains(t, out, "<FilterRule><Name>suffix</Name><Value>.jpg</Value></FilterRule>")
+	assert.NotContains(t, out, "<FilterRules>")
+}
+
+// TestS3Notification_EmptyConfigurationDisables covers the documented way to turn
+// notifications off, and is the case a MalformedXML refusal must not swallow.
+func TestS3Notification_EmptyConfigurationDisables(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/off", nil, nil).Code)
+
+	const queueARN = "arn:aws:sqs:us-east-1:123456789012:disable-me"
+	require.Equal(t, http.StatusOK, putNotification(t, srv, "off", notificationXML(queueARN)).Code)
+	_, configured := getNotification(t, srv, "off")
+	require.Contains(t, configured, queueARN, "the configuration must be stored first")
+
+	require.Equal(t, http.StatusOK,
+		putNotification(t, srv, "off", []byte(`<NotificationConfiguration></NotificationConfiguration>`)).Code,
+		"an empty configuration is the documented way to disable notifications")
+
+	code, body := getNotification(t, srv, "off")
+	require.Equal(t, http.StatusOK, code)
+	assert.NotContains(t, body, queueARN, "the destination must be gone")
+	assert.Contains(t, body, "NotificationConfiguration",
+		"a bucket with no configuration still returns an empty NotificationConfiguration")
+}
+
+// TestS3Notification_UnrecognizedBodyIsMalformedXML covers the refusal that keeps
+// #542 from recurring silently. xml.Unmarshal reports no error for a body none of
+// whose elements it recognizes, so without this check a body full of wrong
+// element names is indistinguishable from a deliberate disable — which is exactly
+// how a real-S3 body used to turn every notification on the bucket off.
+func TestS3Notification_UnrecognizedBodyIsMalformedXML(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/bad", nil, nil).Code)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			// The shape substrate used to require. It is no longer accepted, and
+			// accepting it quietly is what the bug was.
+			name: "substrate's old field names",
+			body: `<NotificationConfiguration><QueueConfigurations>` +
+				`<QueueArn>arn:aws:sqs:us-east-1:123456789012:q</QueueArn>` +
+				`<Events>s3:ObjectCreated:*</Events>` +
+				`</QueueConfigurations></NotificationConfiguration>`,
+		},
+		{
+			name: "an element from no schema at all",
+			body: `<NotificationConfiguration><Nonsense>x</Nonsense></NotificationConfiguration>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := putNotification(t, srv, "bad", []byte(tt.body))
+			require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.Bytes())
+			assert.Equal(t, "MalformedXML", parseS3Error(t, w.Body.Bytes()).Code)
+		})
+	}
+
+	// The refusal must not have stored anything.
+	code, body := getNotification(t, srv, "bad")
+	require.Equal(t, http.StatusOK, code)
+	assert.NotContains(t, body, "QueueConfiguration",
+		"a refused body must leave the bucket unconfigured")
+}
+
+// TestS3Notification_EventBridgeConfiguration covers the element that carries no
+// members, so "was it present" is the only thing to record.
+func TestS3Notification_EventBridgeConfiguration(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/eventbridge", nil, nil).Code)
+
+	require.Equal(t, http.StatusOK, putNotification(t, srv, "eventbridge",
+		[]byte(`<NotificationConfiguration><EventBridgeConfiguration></EventBridgeConfiguration></NotificationConfiguration>`)).Code,
+		"an EventBridge-only configuration names a destination, so it is not an empty body")
+
+	code, body := getNotification(t, srv, "eventbridge")
+	require.Equal(t, http.StatusOK, code, "body: %s", body)
+	assert.Contains(t, body, "EventBridgeConfiguration")
+}
+
+// TestS3Notification_FiresSQSFromRealS3Body is #542's substantive half. The
+// read-back being wrong was the filed symptom; fireNotifications reads the same
+// record, so a configuration submitted the AWS way meant no notification was ever
+// dispatched. A test asserting a message arrives failed far from its assertion,
+// and one asserting none arrives passed vacuously.
+func TestS3Notification_FiresSQSFromRealS3Body(t *testing.T) {
+	srv := newS3SQSTestServer(t)
+
+	sqsFormRequest(t, srv, map[string]string{
+		"Action":    "CreateQueue",
+		"QueueName": "wire-notify-queue",
+	})
+	const queueARN = "arn:aws:sqs:us-east-1:000000000000:wire-notify-queue"
+	const queueURL = "http://sqs.us-east-1.localhost/000000000000/wire-notify-queue"
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/fire-wire", nil, nil).Code)
+	require.Equal(t, http.StatusOK, putNotification(t, srv, "fire-wire", notificationXML(queueARN)).Code)
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/fire-wire/k.txt",
+		[]byte("hello"), map[string]string{"Content-Type": "text/plain"}).Code)
+
+	w := sqsFormRequest(t, srv, map[string]string{
+		"Action":              "ReceiveMessage",
+		"QueueUrl":            queueURL,
+		"MaxNumberOfMessages": "1",
+		"VisibilityTimeout":   "0",
+	})
+	body := w.Body.String()
+	require.Contains(t, body, "s3:ObjectCreated",
+		"a configuration written the AWS way must actually dispatch: %s", body)
+	assert.Contains(t, body, "fire-wire", "the event names the bucket")
+	assert.Contains(t, body, "k.txt", "the event names the key")
+}
+
+// TestS3Notification_KeyFilterAppliesOnDispatch proves the filter survives the
+// round trip into state where fireNotifications reads it — the wire's S3Key
+// nesting reaching s3KeyFilterMatches, not just reaching the read-back.
+func TestS3Notification_KeyFilterAppliesOnDispatch(t *testing.T) {
+	srv := newS3SQSTestServer(t)
+
+	sqsFormRequest(t, srv, map[string]string{
+		"Action":    "CreateQueue",
+		"QueueName": "filtered-queue",
+	})
+	const queueARN = "arn:aws:sqs:us-east-1:000000000000:filtered-queue"
+	const queueURL = "http://sqs.us-east-1.localhost/000000000000/filtered-queue"
+
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/filter-fire", nil, nil).Code)
+	cfg := `<NotificationConfiguration><QueueConfiguration>` +
+		`<Queue>` + queueARN + `</Queue>` +
+		`<Event>s3:ObjectCreated:*</Event>` +
+		`<Filter><S3Key><FilterRule><Name>prefix</Name><Value>images/</Value></FilterRule></S3Key></Filter>` +
+		`</QueueConfiguration></NotificationConfiguration>`
+	require.Equal(t, http.StatusOK, putNotification(t, srv, "filter-fire", []byte(cfg)).Code)
+
+	// A key outside the prefix must not dispatch.
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/filter-fire/docs/a.txt", []byte("x"), nil).Code)
+	w := sqsFormRequest(t, srv, map[string]string{
+		"Action":              "ReceiveMessage",
+		"QueueUrl":            queueURL,
+		"MaxNumberOfMessages": "1",
+		"VisibilityTimeout":   "0",
+	})
+	assert.NotContains(t, w.Body.String(), "s3:ObjectCreated",
+		"a key outside the filter's prefix must not dispatch")
+
+	// A key inside it must.
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/filter-fire/images/a.jpg", []byte("x"), nil).Code)
+	w2 := sqsFormRequest(t, srv, map[string]string{
+		"Action":              "ReceiveMessage",
+		"QueueUrl":            queueURL,
+		"MaxNumberOfMessages": "1",
+		"VisibilityTimeout":   "0",
+	})
+	assert.Contains(t, w2.Body.String(), "s3:ObjectCreated",
+		"a key inside the filter's prefix must dispatch: %s", w2.Body.String())
+}
+
+// TestS3Notification_JSONBodyStillAccepted pins substrate's own convenience path,
+// which predates the XML one and is keyed on the state shape's json tags. It is
+// what the existing FireSQS test uses, so the XML fix must not break it.
+func TestS3Notification_JSONBodyStillAccepted(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/jsonb", nil, nil).Code)
+
+	const queueARN = "arn:aws:sqs:us-east-1:123456789012:json-queue"
+	body := `{"QueueConfigurations":[{"Id":"j1","QueueArn":"` + queueARN +
+		`","Events":["s3:ObjectCreated:*"]}]}`
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/jsonb?notification", []byte(body),
+			map[string]string{"Content-Type": "application/json"}).Code)
+
+	code, out := getNotification(t, srv, "jsonb")
+	require.Equal(t, http.StatusOK, code, "body: %s", out)
+	// Read back on the wire, in the API's names, whatever shape went in.
+	assert.Contains(t, out, "<Queue>"+queueARN+"</Queue>")
+}
+
+// TestS3Notification_UnconfiguredBucketReturnsEmptyElement pins the shape of the
+// read for a bucket that has never been configured, which must parse as a
+// NotificationConfiguration rather than 404 or an empty body.
+func TestS3Notification_UnconfiguredBucketReturnsEmptyElement(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/fresh", nil, nil).Code)
+
+	code, body := getNotification(t, srv, "fresh")
+	require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+	var parsed struct {
+		XMLName xml.Name `xml:"NotificationConfiguration"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &parsed), "body: %s", body)
+	for _, dest := range []string{"TopicConfiguration", "QueueConfiguration",
+		"CloudFunctionConfiguration", "EventBridgeConfiguration"} {
+		assert.NotContains(t, body, "<"+dest+">", "no destination is configured")
+	}
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -1,6 +1,7 @@
 package emulator
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5" //nolint:gosec // S3 ETag is defined as MD5; not used for security.
 	"encoding/base64"
@@ -3344,30 +3345,14 @@ func (p *S3Plugin) getBucketNotificationConfiguration(_ *RequestContext, req *AW
 	parts := strings.SplitN(strings.TrimPrefix(req.Path, "/"), "/", 2)
 	bucket := parts[0]
 
-	data, err := p.state.Get(context.Background(), s3Namespace, "notification:"+bucket)
+	cfg, err := p.loadNotificationConfiguration(bucket)
 	if err != nil {
 		return nil, fmt.Errorf("s3 getBucketNotificationConfiguration: %w", err)
 	}
-	if data == nil {
-		// Return empty configuration.
-		empty := S3NotificationConfiguration{}
-		body, marshalErr := xml.Marshal(empty)
-		if marshalErr != nil {
-			return nil, fmt.Errorf("s3 getBucketNotificationConfiguration marshal: %w", marshalErr)
-		}
-		return &AWSResponse{
-			StatusCode: http.StatusOK,
-			Headers:    map[string]string{"Content-Type": "application/xml"},
-			Body:       body,
-		}, nil
-	}
 
-	var cfg S3NotificationConfiguration
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("s3 getBucketNotificationConfiguration unmarshal: %w", err)
-	}
-
-	body, marshalErr := xml.Marshal(cfg)
+	// A bucket with no configuration returns an empty NotificationConfiguration
+	// element, not a 404 — the same body a caller PUTs to turn notifications off.
+	body, marshalErr := xml.Marshal(s3NotificationConfigurationWireOf(cfg))
 	if marshalErr != nil {
 		return nil, fmt.Errorf("s3 getBucketNotificationConfiguration xml marshal: %w", marshalErr)
 	}
@@ -3378,17 +3363,35 @@ func (p *S3Plugin) getBucketNotificationConfiguration(_ *RequestContext, req *AW
 	}, nil
 }
 
+// loadNotificationConfiguration reads a bucket's stored notification
+// configuration, returning a zero configuration when the bucket has none.
+//
+// One reader for both the API read and fireNotifications, so the two cannot end
+// up keyed or decoded differently — a read-back that passes while delivery stays
+// broken is precisely the failure #542 was.
+func (p *S3Plugin) loadNotificationConfiguration(bucket string) (S3NotificationConfiguration, error) {
+	var cfg S3NotificationConfiguration
+	data, err := p.state.Get(context.Background(), s3Namespace, "notification:"+bucket)
+	if err != nil {
+		return cfg, fmt.Errorf("state.Get notification:%s: %w", bucket, err)
+	}
+	if data == nil {
+		return cfg, nil
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("unmarshal notification:%s: %w", bucket, err)
+	}
+	return cfg, nil
+}
+
 // putBucketNotificationConfiguration handles PUT /<bucket>?notification.
 func (p *S3Plugin) putBucketNotificationConfiguration(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	parts := strings.SplitN(strings.TrimPrefix(req.Path, "/"), "/", 2)
 	bucket := parts[0]
 
-	var cfg S3NotificationConfiguration
-	if err := xml.Unmarshal(req.Body, &cfg); err != nil {
-		// Try JSON fallback.
-		if jsonErr := json.Unmarshal(req.Body, &cfg); jsonErr != nil {
-			return nil, &AWSError{Code: "MalformedXML", Message: "invalid notification configuration", HTTPStatus: http.StatusBadRequest}
-		}
+	cfg, errResp := s3ParseNotificationConfiguration(req.Body)
+	if errResp != nil {
+		return nil, errResp
 	}
 
 	data, marshalErr := json.Marshal(cfg)
@@ -3402,6 +3405,72 @@ func (p *S3Plugin) putBucketNotificationConfiguration(_ *RequestContext, req *AW
 	return &AWSResponse{StatusCode: http.StatusOK, Headers: map[string]string{}, Body: nil}, nil
 }
 
+// s3ParseNotificationConfiguration decodes a PutBucketNotificationConfiguration
+// body into the persisted shape, refusing a body it recognized nothing in.
+//
+// That refusal is the substantive part. xml.Unmarshal reports no error for a body
+// whose elements match no field, so before #542 a real-S3 body — every element of
+// which the state struct's field names failed to match — was accepted as "an
+// empty configuration was submitted", stored, and silently disabled every
+// notification on the bucket. An empty configuration *is* the documented way to
+// turn notifications off, so the two cases can only be told apart by whether the
+// body named anything at all; a body that did and still parsed to nothing is
+// MalformedXML rather than a quiet no-op.
+func s3ParseNotificationConfiguration(body []byte) (S3NotificationConfiguration, *AWSError) {
+	var cfg S3NotificationConfiguration
+	if len(bytes.TrimSpace(body)) == 0 {
+		// No body at all is the same instruction as an empty configuration.
+		return cfg, nil
+	}
+
+	var wire s3NotificationConfigurationWire
+	if err := xml.Unmarshal(body, &wire); err != nil {
+		// A JSON body is substrate's own convenience, predating the XML path and
+		// keyed on the state shape's json tags, so it decodes straight to state.
+		if jsonErr := json.Unmarshal(body, &cfg); jsonErr != nil {
+			return S3NotificationConfiguration{}, &AWSError{
+				Code:       "MalformedXML",
+				Message:    "The XML you provided was not well-formed or did not validate against our published schema",
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+		return cfg, nil
+	}
+
+	if wire.isEmpty() && s3XMLHasChildElement(body) {
+		return S3NotificationConfiguration{}, &AWSError{
+			Code:       "MalformedXML",
+			Message:    "The XML you provided was not well-formed or did not validate against our published schema",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	return s3NotificationState(wire), nil
+}
+
+// s3XMLHasChildElement reports whether an XML document's root element contains
+// at least one child element. It is how a genuinely empty
+// <NotificationConfiguration/> is distinguished from one full of elements none of
+// which were recognized.
+func s3XMLHasChildElement(body []byte) bool {
+	dec := xml.NewDecoder(bytes.NewReader(body))
+	depth := 0
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		switch tok.(type) {
+		case xml.StartElement:
+			depth++
+			if depth > 1 {
+				return true
+			}
+		case xml.EndElement:
+			depth--
+		}
+	}
+}
+
 // fireNotifications dispatches S3 event notifications to configured Lambda
 // functions and SQS queues. It is a best-effort operation: errors are logged
 // but never returned to the caller.
@@ -3410,14 +3479,9 @@ func (p *S3Plugin) fireNotifications(ctx *RequestContext, bucket, key, eventName
 		return
 	}
 
-	data, err := p.state.Get(context.Background(), s3Namespace, "notification:"+bucket)
-	if err != nil || data == nil {
-		return
-	}
-
-	var notifCfg S3NotificationConfiguration
-	if err := json.Unmarshal(data, &notifCfg); err != nil {
-		p.logger.Warn("s3 fireNotifications: unmarshal error", "err", err)
+	notifCfg, err := p.loadNotificationConfiguration(bucket)
+	if err != nil {
+		p.logger.Warn("s3 fireNotifications: load error", "bucket", bucket, "err", err)
 		return
 	}
 

--- a/emulator/s3_types.go
+++ b/emulator/s3_types.go
@@ -310,7 +310,24 @@ type S3Grantee struct {
 	DisplayName string `xml:"DisplayName,omitempty" json:"DisplayName,omitempty"`
 }
 
-// S3NotificationConfiguration holds event notification configurations for an S3 bucket.
+// S3NotificationConfiguration holds event notification configurations for an S3
+// bucket. This is the *state* encoding: it is what S3Plugin persists under
+// "notification:<bucket>" and what fireNotifications reads back to decide where
+// an event goes.
+//
+// It deliberately carries no xml tags. The wire encoding is a different shape —
+// S3 names each configuration element in the singular (TopicConfiguration, not
+// TopicConfigurations), names the destination after the service rather than the
+// field (Topic, Queue, CloudFunction rather than TopicArn, QueueArn,
+// LambdaFunctionArn) and repeats a bare Event element per event — so it lives in
+// the s3Notification*Wire types below with projections both ways, following the
+// remedy #528 established for CloudWatch Logs.
+//
+// Retagging this struct instead would have re-created the conflation that made
+// #542 invisible: xml.Unmarshal falls back to matching Go field *names*, so a
+// real-S3 body matched nothing here, returned no error, and persisted an empty
+// configuration. A round-trip test could not see it, because a struct
+// marshaled and unmarshaled by its own definition agrees with itself.
 type S3NotificationConfiguration struct {
 	// LambdaFunctionConfigurations lists Lambda invocation notification configs.
 	LambdaFunctionConfigurations []S3LambdaFunctionConfiguration `json:"LambdaFunctionConfigurations,omitempty"`
@@ -318,8 +335,14 @@ type S3NotificationConfiguration struct {
 	// QueueConfigurations lists SQS queue notification configs.
 	QueueConfigurations []S3QueueConfiguration `json:"QueueConfigurations,omitempty"`
 
-	// TopicConfigurations lists SNS topic notification configs (stored but not dispatched).
+	// TopicConfigurations lists SNS topic notification configs.
 	TopicConfigurations []S3TopicConfiguration `json:"TopicConfigurations,omitempty"`
+
+	// EventBridgeEnabled records that the bucket asked for delivery to
+	// EventBridge. Substrate stores and reports the choice so a caller can read
+	// back what it configured, but does not dispatch to EventBridge; see
+	// docs/services.md.
+	EventBridgeEnabled bool `json:"EventBridgeEnabled,omitempty"`
 }
 
 // S3LambdaFunctionConfiguration configures event notifications to a Lambda function.
@@ -353,7 +376,6 @@ type S3QueueConfiguration struct {
 }
 
 // S3TopicConfiguration configures event notifications to an SNS topic.
-// The topic is stored but notifications are not dispatched in this emulator.
 type S3TopicConfiguration struct {
 	// ID is the optional unique identifier for this configuration.
 	ID string `json:"Id,omitempty"`
@@ -387,4 +409,192 @@ type S3FilterRule struct {
 
 	// Value is the prefix or suffix string to match against.
 	Value string `json:"Value"`
+}
+
+// The wire encoding of a bucket notification configuration, per the
+// Put/GetBucketNotificationConfiguration references. These types exist only to
+// be marshaled and unmarshaled; the persisted shape is
+// [S3NotificationConfiguration], and the projections below are the one place the
+// two are allowed to meet.
+//
+// Three differences from the state shape are what #542 turned on, and each is a
+// silent failure rather than a parse error:
+//
+//   - Every configuration element is singular. A body carrying
+//     <QueueConfiguration> does not populate a field named QueueConfigurations.
+//   - The destination element is named for the service — <Topic>, <Queue>,
+//     <CloudFunction> — not for the ARN it holds.
+//   - Events repeat as bare <Event> elements rather than nesting under an
+//     <Events> parent.
+//
+// xml.Unmarshal reports no error for a body none of whose elements it
+// recognizes, so all three read as "an empty configuration was submitted".
+
+// s3NotificationConfigurationWire is the wire form of a bucket's notification
+// configuration.
+type s3NotificationConfigurationWire struct {
+	XMLName xml.Name `xml:"NotificationConfiguration"`
+
+	// Xmlns is the S3 namespace, emitted on responses. It is omitted when empty
+	// so an unmarshaled request does not have to carry it.
+	Xmlns string `xml:"xmlns,attr,omitempty"`
+
+	TopicConfigurations  []s3TopicConfigurationWire  `xml:"TopicConfiguration"`
+	QueueConfigurations  []s3QueueConfigurationWire  `xml:"QueueConfiguration"`
+	LambdaConfigurations []s3LambdaConfigurationWire `xml:"CloudFunctionConfiguration"`
+
+	// EventBridge is present-but-empty when the bucket enables EventBridge
+	// delivery, so a pointer distinguishes "the element was there" from "it was
+	// not" — there is no field inside it to test.
+	EventBridge *s3EventBridgeConfigurationWire `xml:"EventBridgeConfiguration"`
+}
+
+// s3TopicConfigurationWire is the wire form of an SNS topic notification config.
+type s3TopicConfigurationWire struct {
+	ID     string                    `xml:"Id,omitempty"`
+	Topic  string                    `xml:"Topic"`
+	Events []string                  `xml:"Event"`
+	Filter *s3NotificationFilterWire `xml:"Filter,omitempty"`
+}
+
+// s3QueueConfigurationWire is the wire form of an SQS queue notification config.
+type s3QueueConfigurationWire struct {
+	ID     string                    `xml:"Id,omitempty"`
+	Queue  string                    `xml:"Queue"`
+	Events []string                  `xml:"Event"`
+	Filter *s3NotificationFilterWire `xml:"Filter,omitempty"`
+}
+
+// s3LambdaConfigurationWire is the wire form of a Lambda notification config.
+// Its element is CloudFunctionConfiguration and its destination CloudFunction:
+// the SDKs call the member LambdaFunctionConfigurations, but the XML kept the
+// original names.
+type s3LambdaConfigurationWire struct {
+	ID            string                    `xml:"Id,omitempty"`
+	CloudFunction string                    `xml:"CloudFunction"`
+	Events        []string                  `xml:"Event"`
+	Filter        *s3NotificationFilterWire `xml:"Filter,omitempty"`
+}
+
+// s3EventBridgeConfigurationWire is the wire form of the EventBridge element,
+// which the reference documents as carrying no members.
+type s3EventBridgeConfigurationWire struct{}
+
+// s3NotificationFilterWire is the wire form of a notification's key filter. The
+// state shape names the inner element Key; the wire names it S3Key.
+type s3NotificationFilterWire struct {
+	Key s3KeyFilterWire `xml:"S3Key"`
+}
+
+// s3KeyFilterWire is the wire form of the key filter's rule list, which is a
+// repeated FilterRule rather than a FilterRules parent.
+type s3KeyFilterWire struct {
+	FilterRules []s3FilterRuleWire `xml:"FilterRule"`
+}
+
+// s3FilterRuleWire is the wire form of one prefix or suffix rule.
+type s3FilterRuleWire struct {
+	Name  string `xml:"Name"`
+	Value string `xml:"Value"`
+}
+
+// isEmpty reports whether the wire configuration named no destination at all.
+// An empty NotificationConfiguration is how the API documents "disable
+// notifications", so it is a legitimate body — but it is also what a body whose
+// elements were all unrecognized parses to, which is why the handler needs to
+// tell the two apart by looking at whether the body was empty to begin with.
+func (w s3NotificationConfigurationWire) isEmpty() bool {
+	return len(w.TopicConfigurations) == 0 && len(w.QueueConfigurations) == 0 &&
+		len(w.LambdaConfigurations) == 0 && w.EventBridge == nil
+}
+
+// s3NotificationState projects a wire configuration onto the persisted shape.
+func s3NotificationState(w s3NotificationConfigurationWire) S3NotificationConfiguration {
+	cfg := S3NotificationConfiguration{EventBridgeEnabled: w.EventBridge != nil}
+	for _, t := range w.TopicConfigurations {
+		cfg.TopicConfigurations = append(cfg.TopicConfigurations, S3TopicConfiguration{
+			ID:       t.ID,
+			TopicArn: t.Topic,
+			Events:   t.Events,
+			Filter:   s3NotificationFilterState(t.Filter),
+		})
+	}
+	for _, q := range w.QueueConfigurations {
+		cfg.QueueConfigurations = append(cfg.QueueConfigurations, S3QueueConfiguration{
+			ID:       q.ID,
+			QueueArn: q.Queue,
+			Events:   q.Events,
+			Filter:   s3NotificationFilterState(q.Filter),
+		})
+	}
+	for _, l := range w.LambdaConfigurations {
+		cfg.LambdaFunctionConfigurations = append(cfg.LambdaFunctionConfigurations, S3LambdaFunctionConfiguration{
+			ID:                l.ID,
+			LambdaFunctionArn: l.CloudFunction,
+			Events:            l.Events,
+			Filter:            s3NotificationFilterState(l.Filter),
+		})
+	}
+	return cfg
+}
+
+// s3NotificationConfigurationWireOf projects a persisted configuration onto its
+// wire form.
+func s3NotificationConfigurationWireOf(cfg S3NotificationConfiguration) s3NotificationConfigurationWire {
+	w := s3NotificationConfigurationWire{Xmlns: s3XMLNamespace}
+	if cfg.EventBridgeEnabled {
+		w.EventBridge = &s3EventBridgeConfigurationWire{}
+	}
+	for _, t := range cfg.TopicConfigurations {
+		w.TopicConfigurations = append(w.TopicConfigurations, s3TopicConfigurationWire{
+			ID:     t.ID,
+			Topic:  t.TopicArn,
+			Events: t.Events,
+			Filter: s3NotificationFilterWireOf(t.Filter),
+		})
+	}
+	for _, q := range cfg.QueueConfigurations {
+		w.QueueConfigurations = append(w.QueueConfigurations, s3QueueConfigurationWire{
+			ID:     q.ID,
+			Queue:  q.QueueArn,
+			Events: q.Events,
+			Filter: s3NotificationFilterWireOf(q.Filter),
+		})
+	}
+	for _, l := range cfg.LambdaFunctionConfigurations {
+		w.LambdaConfigurations = append(w.LambdaConfigurations, s3LambdaConfigurationWire{
+			ID:            l.ID,
+			CloudFunction: l.LambdaFunctionArn,
+			Events:        l.Events,
+			Filter:        s3NotificationFilterWireOf(l.Filter),
+		})
+	}
+	return w
+}
+
+// s3NotificationFilterState projects a wire key filter onto the persisted shape.
+// A nil filter stays nil: "no filter" and "a filter with no rules" mean the same
+// thing to s3KeyFilterMatches, and preserving the distinction would only invite
+// an empty <Filter/> onto the response.
+func s3NotificationFilterState(f *s3NotificationFilterWire) *S3NotificationFilter {
+	if f == nil || len(f.Key.FilterRules) == 0 {
+		return nil
+	}
+	out := &S3NotificationFilter{}
+	for _, r := range f.Key.FilterRules {
+		out.Key.FilterRules = append(out.Key.FilterRules, S3FilterRule(r))
+	}
+	return out
+}
+
+// s3NotificationFilterWireOf projects a persisted key filter onto its wire form.
+func s3NotificationFilterWireOf(f *S3NotificationFilter) *s3NotificationFilterWire {
+	if f == nil || len(f.Key.FilterRules) == 0 {
+		return nil
+	}
+	out := &s3NotificationFilterWire{}
+	for _, r := range f.Key.FilterRules {
+		out.Key.FilterRules = append(out.Key.FilterRules, s3FilterRuleWire(r))
+	}
+	return out
 }


### PR DESCRIPTION
Closes #542

**This is not a lost-configuration bug. It is a working feature that could not be turned on** — every S3 event notification configured through the real API was silently off.

## The cause

`PutBucketNotificationConfiguration` unmarshalled its request body into `S3NotificationConfiguration`, a struct carrying only `json` tags. Go's XML decoder falls back to matching Go field *names* when a field has no `xml` tag, and none of the API's element names are substrate's field names:

| The API writes | Substrate's field was |
|---|---|
| `<TopicConfiguration>` (singular) | `TopicConfigurations` |
| `<QueueConfiguration>` | `QueueConfigurations` |
| `<CloudFunctionConfiguration>` | `LambdaFunctionConfigurations` |
| `<Topic>`, `<Queue>`, `<CloudFunction>` | `TopicArn`, `QueueArn`, `LambdaFunctionArn` |
| repeated `<Event>` | `Events` |
| `<S3Key>` | `Key` |

So a real-S3 body matched **nothing**.

What made it invisible: **`xml.Unmarshal` reports no error for a body whose elements match no field.** The handler's JSON fallback therefore never ran, an empty configuration was persisted, and the request answered `200`. Since an empty configuration is also the documented way to *disable* notifications, the effect of configuring a notification the AWS way was to turn notifications off.

## The half that isn't in the report

`fireNotifications` reads that same record. With an empty configuration stored, **no event was ever dispatched** — a test asserting a message arrives failed far from its assertion, and one asserting no message arrives passed vacuously. That is the more serious half, and it is fixed by the same change.

## The remedy

Follows the one #528 established for CloudWatch Logs, because the struct is dual-role: it is also the persisted encoding, so retagging it would have fixed the wire and changed the stored format in the same edit, stranding existing records. The state struct and its `json` tags are untouched; wire types with the correct `xml` element names sit beside them with projections both ways.

`EventBridgeConfiguration` is now recognized, stored and reported. Delivery to EventBridge is still not dispatched — substrate has no bus-to-target path for S3 events — and `docs/services.md` says so rather than leaving it to be discovered.

`fireNotifications` and the API read now share one loader, so a read-back that passes while delivery stays broken is no longer reachable. The mutation run below confirms that: pointing the loader at a different key takes down both the new dispatch tests and the pre-existing one.

## Provenance

**A non-empty body naming no recognized element is now `400 MalformedXML`.** Substrate's own choice, not the API model's. Without it, a body with the wrong element names stays indistinguishable from a deliberate disable — which is exactly how this defect stayed invisible for as long as it did. A genuinely empty `<NotificationConfiguration/>` still disables notifications, since that is documented; the two are told apart by whether the body named anything at all. Substrate's pre-existing JSON body form, keyed on the state shape's `json` tags, is still accepted.

## Two existing tests worth naming

- **The round-trip test passed throughout.** A struct marshalled and unmarshalled by its own definition agrees with itself whatever its tags say — the lesson #528/#529 already paid for, and why every assertion in the new file is against **raw wire bytes**.
- **A delete-bucket sub-test had a comment explaining that it wrote a substrate-shaped body** *because* the AWS-shaped one stored nothing, which would have made it pass whether or not the delete cleared the key. It now writes the AWS shape, so what it pins is again the delete.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test -C test/e2e ./...` — all clean.

**All 13 new gates fail before the fix** (reverting `s3_types.go` + `s3_plugin.go`, leaving the tests).

Byte-for-byte round-trip against a live server — this body in, this body out:

```
$ curl -X PUT 'localhost:4621/notifbkt?notification' -d '<NotificationConfiguration>...'
200
$ curl 'localhost:4621/notifbkt?notification'
<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TopicConfiguration><Id>t1</Id>
<Topic>arn:aws:sns:us-east-1:123456789012:tp</Topic><Event>s3:ObjectCreated:Put</Event></TopicConfiguration>
<QueueConfiguration><Queue>...:notif-q</Queue><Event>s3:ObjectRemoved:*</Event><Filter><S3Key><FilterRule>
<Name>suffix</Name><Value>.log</Value></FilterRule></S3Key></Filter></QueueConfiguration>
<CloudFunctionConfiguration><CloudFunction>...:function:f</CloudFunction><Event>s3:ObjectCreated:*</Event>
</CloudFunctionConfiguration></NotificationConfiguration>
```

And the dispatch half, with the key filter applied:

```
$ aws s3api put-bucket-notification-configuration --bucket notifbkt \
    --notification-configuration '{"QueueConfigurations":[{...,"Filter":{"Key":{"FilterRules":[{"Name":"prefix","Value":"images/"}]}}}]}'
$ aws s3api put-object --bucket notifbkt --key docs/a.txt   --body f
$ aws sqs receive-message ...                       # {"Messages": []} — outside the prefix
$ aws s3api put-object --bucket notifbkt --key images/a.jpg --body f
$ aws sqs receive-message ...                       # s3:ObjectCreated:Put, images/a.jpg — was silence
$ curl -X PUT '...?notification' -d '<NotificationConfiguration><QueueConfigurations>...'   # 400 MalformedXML
$ curl '.../badbkt?notification'                    # empty NotificationConfiguration
```

## Mutation testing

Nine mutants, all **CAUGHT**, none survived — anchor-count asserted before applying, `gofmt -w && go vet` gated, run under `-race`:

| Mutant | Caught by |
|---|---|
| `TopicConfiguration` reverted to plural — **only that one** | `AllThreeDestinations/topic` |
| `QueueConfiguration` reverted to plural | `AllThreeDestinations/queue` + 4 more |
| lambda element uses the SDK's `LambdaFunctionConfigurations` | `AllThreeDestinations/lambda` |
| `Event` nests under a plural `Events` | `RealS3BodyRoundTrips`, both dispatch tests |
| the wire filter's inner element named `Key` | `KeyFilterRoundTrips`, `KeyFilterAppliesOnDispatch` |
| the `MalformedXML` refusal removed | both `UnrecognizedBodyIsMalformedXML` subtests |
| `fireNotifications` reads a differently-keyed record | both new dispatch tests **and the pre-existing `FireSQS`** |
| `EventBridgeConfiguration` never reported | `EventBridgeConfiguration` |
| a queue's key filter dropped going into state | `KeyFilterRoundTrips`, `KeyFilterAppliesOnDispatch` |

The first three are the plan's requirement that one element reverted at a time still goes red — a single test catching all five would not prove per-element coverage.

## Compatibility

**Substrate's old XML shape is no longer accepted**: a body with `<QueueConfigurations>`/`<QueueArn>`/`<Events>` is now `400 MalformedXML` instead of a `200` that stored nothing. A test that submits that shape and asserts `200` will go red; it was never storing a configuration. Rewrite it in the API's element names, or use the JSON form, which is unchanged.

A test that asserted no notification arrives after configuring one the AWS way **will also go red** — the notification now arrives. That is the fix.

The persisted format is unchanged, so existing state records still load. `S3NotificationConfiguration` gains one field, `EventBridgeEnabled`.
