### PR TITLE
fix(cfn): accept a stack ARN wherever StackName is taken (#544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one stored nothing; it now writes the AWS shape, so what it pins is again the
   delete clearing the key.
 
+- **The stack ARN `CreateStack` returns is now an identifier every stack-scoped
+  operation accepts** (#544). Substrate looked a caller's `StackName` up verbatim, so
+  the `StackId` it had just handed back resolved to no stack — even though the
+  reference documents both forms for each of these operations: "The name or the unique
+  stack ID that's associated with the stack, which aren't always interchangeable."
+
+  `DeleteStack` is the case worth stating plainly, and the reason this is a
+  silent-success bug rather than a lookup gap. It documents no not-found error, so
+  substrate treats an unresolvable name as a stack already gone and succeeds. Handed
+  an ARN, it swept nothing, answered `200`, and left the stack standing — and v0.89.0
+  *widened* the gap by shipping #518's sweep, so a delete by name now really tears
+  resources down while a delete by ARN did nothing. A caller had no error to catch and
+  no status to poll; the next `CreateStack` answering `AlreadyExists` was the only
+  symptom.
+
+  One resolver runs at the plugin boundary, modelled on the `cfnChangeSetName` this
+  repository already had, so the deployer keeps taking a name and its nine
+  `"stack:"`-keyed lookups are untouched. It is applied to every operation that takes
+  a `StackName` — thirteen call sites, not the two the report named, since fixing
+  describe and delete alone would leave the same trap in `GetTemplate`, the change-set
+  family and the drift pair, which are exactly the operations a caller reaches holding
+  a `StackId`. In `DeleteStack` it runs **ahead** of the absent-stack tolerance; that
+  ordering is the fix. `CreateStack` deliberately does not use it: its `StackName` has
+  no unique-stack-ID alternative, because the ID does not exist until that call mints
+  it.
+
+  **The ARN is verified, not merely parsed.** Substrate builds a stack ARN from the
+  caller's partition, Region and account plus a digest over those and the name, so the
+  whole string is recomputable — and it is compared whole, which checks every
+  component at once rather than field by field. Lifting the name out without that
+  check would have let a caller reach, and `DeleteStack` tear down, a stack in another
+  account, Region or partition by hand-writing an ARN: a defect worse than the silent
+  no-op being fixed. An out-of-scope ARN reports the same `ValidationError` an absent
+  stack does, deliberately — a stack outside the caller's scope is one the caller
+  cannot observe, so a distinct error would disclose whether another scope holds a
+  stack by that name.
+
 ## [v0.89.0] - 2026-08-03
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -99,7 +99,7 @@ here.
 |-----------|-------|
 | CreateStack | Deploys every resource in `TemplateBody` and returns the stack ARN |
 | UpdateStack | Re-deploys the template; an omitted `TemplateBody` re-uses the stored one |
-| DeleteStack | Deletes the stack **record only**, not the resources it deployed (see below); deleting an absent stack succeeds |
+| DeleteStack | Sweeps the resources the stack deployed, then removes the stack record (see below); deleting an absent stack succeeds |
 | DescribeStacks | One stack by `StackName`, or every stack when omitted |
 | ListStacks | Summary shape; honours `StackStatusFilter.member.N` |
 | DescribeStackResources | By `StackName` + optional `LogicalResourceId`, or by `PhysicalResourceId` |
@@ -126,6 +126,33 @@ to deploy after the template parsed is an `InternalFailure` at 500, because the
 request was well-formed and the failure is substrate's. That distinction is drawn
 from the classification the stack model attaches to a failure, not from its
 message, so a message may be reworded without moving any consumer's error code.
+
+### A stack ARN is accepted wherever `StackName` is
+
+`CreateStack` reports the stack's ARN as its `StackId`, and every stack-scoped
+operation takes that identifier in place of the name — "The name or the unique
+stack ID that's associated with the stack", as the reference puts it. That covers
+`UpdateStack`, `DeleteStack`, `DescribeStacks`, `DescribeStackResources`,
+`GetTemplate`, the four change-set operations that take a `StackName`, and both
+drift operations. `CreateStack` is the exception, and the API's: the ID does not
+exist until that call mints it.
+
+```
+ARN=$(aws cloudformation create-stack --stack-name probe \
+        --template-body file:///tmp/probe.json --query StackId --output text)
+aws cloudformation describe-stacks --stack-name "$ARN"   # the stack
+aws cloudformation delete-stack   --stack-name "$ARN"    # sweeps its resources
+```
+
+The ARN is **verified**, not merely parsed for the name inside it. Substrate builds
+a stack ARN from the caller's partition, Region and account plus a digest over
+those and the stack name, so an ARN naming another account, another Region, another
+partition, or a digest that does not belong to the name attached to it is not an
+identifier substrate would have issued — and is refused with the same
+`ValidationError` an absent stack reports. Reporting the two cases identically is
+deliberate: a stack outside the caller's account and Region is one the caller
+cannot observe, so a distinct error would disclose whether some other scope holds a
+stack by that name.
 
 ### Stacks share state with every other plugin
 

--- a/emulator/cfn_stack_arn_test.go
+++ b/emulator/cfn_stack_arn_test.go
@@ -1,0 +1,381 @@
+package emulator_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file are #544's gate.
+//
+// CreateStack answers with a StackId — the stack's ARN — and every stack-scoped
+// operation documents that identifier as an alternative to the name: "The name or
+// the unique stack ID that's associated with the stack". Substrate looked the
+// caller's string up verbatim, so the ARN it had just minted resolved to no stack.
+//
+// The delete is the case worth stating plainly, and it is why this is filed as a
+// silent-success bug rather than a lookup gap. DeleteStack documents no not-found
+// error, so the deployer treats an unresolvable name as a stack already gone and
+// succeeds. Handed an ARN, it swept nothing, answered 200, and left the stack
+// standing — and since v0.89.0 shipped #518's sweep, a by-name delete really does
+// tear resources down, so the two paths disagreed about what a successful delete
+// means.
+//
+// A caller could not tell: no error to catch, no status to poll. The next
+// CreateStack answering AlreadyExists was the only symptom.
+
+// cfnTestAccount and cfnTestRegion are the identity cfnRequest's signed
+// Authorization header resolves to. The ARN assertions below are built from them
+// rather than from a pasted string, so a change to either shows up as a failure
+// here rather than as a test that no longer exercises the scope check.
+const (
+	cfnTestAccount = "123456789012"
+	cfnTestRegion  = "us-east-1"
+)
+
+// cfnCreateStackARN creates a stack and returns the StackId it reported, which is
+// the identifier a caller holds and the one these tests hand back.
+func cfnCreateStackARN(t *testing.T, ts *cfnTestServer, name, template string) string {
+	t.Helper()
+	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    name,
+		"TemplateBody": template,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	arn := cfnXMLValue(t, body, "StackId")
+	require.Contains(t, arn, ":stack/"+name+"/", "StackId was %q", arn)
+	return arn
+}
+
+// TestCFNStackARN_DescribeByReturnedID is the smallest statement of the defect:
+// the identifier substrate handed the caller is one substrate accepts.
+func TestCFNStackARN_DescribeByReturnedID(t *testing.T) {
+	ts := newCFNTestServer(t)
+	arn := cfnCreateStackARN(t, ts, "by-id", cfnEmptyTemplate)
+
+	code, body := cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": arn})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<StackName>by-id</StackName>")
+	assert.Contains(t, body, "<StackStatus>CREATE_COMPLETE</StackStatus>")
+
+	// And the ARN is exactly the one the create reported, so a caller comparing the
+	// two identifiers sees them agree.
+	assert.Equal(t, arn, cfnXMLValue(t, body, "StackId"))
+}
+
+// TestCFNStackARN_DeleteByARNSweepsResources is the half a caller could not
+// observe. Before the fix the delete answered 200, the bucket survived, the stack
+// stayed CREATE_COMPLETE, and the next create by name answered AlreadyExists.
+func TestCFNStackARN_DeleteByARNSweepsResources(t *testing.T) {
+	ts := newCFNTestServer(t)
+	arn := cfnCreateStackARN(t, ts, "swept-by-arn", cfnBucketTemplate)
+	require.Equal(t, http.StatusOK, cfnHeadBucket(t, ts, "cfn-wire-bucket"),
+		"the stack's bucket exists before the delete")
+
+	code, body := cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": arn})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	assert.Equal(t, http.StatusNotFound, cfnHeadBucket(t, ts, "cfn-wire-bucket"),
+		"a delete by ARN sweeps the stack's resources, as a delete by name does")
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "swept-by-arn"})
+	require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+	assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+
+	// The symptom the issue was filed from: the name is free again.
+	code, body = cfnAction(t, ts, "CreateStack", map[string]string{
+		"StackName":    "swept-by-arn",
+		"TemplateBody": cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.NotContains(t, body, "AlreadyExists")
+}
+
+// TestCFNStackARN_DeleteAbsentByARNSucceeds keeps the tolerance the resolver runs
+// ahead of. A well-formed in-scope ARN for a stack that is genuinely gone is still
+// a successful delete — DeleteStack documents no not-found error — and the fix must
+// not turn that into a refusal.
+func TestCFNStackARN_DeleteAbsentByARNSucceeds(t *testing.T) {
+	ts := newCFNTestServer(t)
+	arn := cfnCreateStackARN(t, ts, "twice-deleted", cfnEmptyTemplate)
+
+	for _, pass := range []string{"first", "second"} {
+		code, body := cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": arn})
+		require.Equal(t, http.StatusOK, code, "%s delete: body was %s", pass, body)
+	}
+}
+
+// TestCFNStackARN_StackScopedOperations covers the whole set rather than the two
+// the report named. Fixing describe and delete alone would leave the same trap in
+// GetTemplate, the change-set family and the drift pair — and those are exactly the
+// operations a caller reaches holding a StackId rather than a name.
+func TestCFNStackARN_StackScopedOperations(t *testing.T) {
+	ts := newCFNTestServer(t)
+	arn := cfnCreateStackARN(t, ts, "every-op", cfnEmptyTemplate)
+
+	// A change set to address, so the change-set operations have a subject.
+	code, body := cfnAction(t, ts, "CreateChangeSet", map[string]string{
+		"StackName":     arn,
+		"ChangeSetName": "cs-by-arn",
+		"TemplateBody":  cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "CreateChangeSet by ARN: body was %s", body)
+
+	cases := []struct {
+		action  string
+		params  map[string]string
+		expects string
+	}{
+		{action: "DescribeStacks", expects: "<StackName>every-op</StackName>"},
+		{action: "DescribeStackResources", expects: "<DescribeStackResourcesResult>"},
+		{action: "GetTemplate", expects: "Resources"},
+		{action: "ListChangeSets", expects: "<ChangeSetName>cs-by-arn</ChangeSetName>"},
+		{
+			action:  "DescribeChangeSet",
+			params:  map[string]string{"ChangeSetName": "cs-by-arn"},
+			expects: "<StackName>every-op</StackName>",
+		},
+		{action: "DetectStackDrift", expects: "<StackDriftDetectionId>"},
+		{action: "DescribeStackResourceDrifts", expects: "<DescribeStackResourceDriftsResult>"},
+		{
+			action:  "UpdateStack",
+			params:  map[string]string{"TemplateBody": cfnBucketTemplate},
+			expects: ":stack/every-op/",
+		},
+		{
+			action:  "ExecuteChangeSet",
+			params:  map[string]string{"ChangeSetName": "cs-by-arn"},
+			expects: "<ExecuteChangeSetResponse",
+		},
+		{
+			action:  "DeleteChangeSet",
+			params:  map[string]string{"ChangeSetName": "cs-by-arn"},
+			expects: "<DeleteChangeSetResponse",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.action, func(t *testing.T) {
+			params := map[string]string{"StackName": arn}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			code, body := cfnAction(t, ts, tc.action, params)
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+			assert.Contains(t, body, tc.expects)
+		})
+	}
+}
+
+// TestCFNStackARN_OutOfScopeARNIsRefused is the check that keeps this fix from
+// being worse than the bug it closes.
+//
+// Lifting the name out of an ARN without verifying the rest of it would let a
+// caller reach — and DeleteStack tear down — a stack in another account, Region or
+// partition, or bind a UUID to a name it was never derived from, simply by writing
+// the ARN by hand. Each case below is a string a caller can compose; none of them
+// is an identifier substrate would have minted for this caller.
+func TestCFNStackARN_OutOfScopeARNIsRefused(t *testing.T) {
+	ts := newCFNTestServer(t)
+	arn := cfnCreateStackARN(t, ts, "in-scope", cfnBucketTemplate)
+	// A second stack, so the name-swap case below names something that really
+	// exists: the refusal must come from the UUID, not from the stack being absent.
+	_ = cfnCreateStackARN(t, ts, "other", cfnEmptyTemplate)
+
+	uuid := arn[strings.LastIndexByte(arn, '/')+1:]
+	require.NotEmpty(t, uuid)
+
+	cases := []struct {
+		name string
+		arn  string
+	}{
+		{
+			name: "a foreign account",
+			arn:  strings.Replace(arn, cfnTestAccount, "999999999999", 1),
+		},
+		{
+			name: "a foreign Region",
+			arn:  strings.Replace(arn, cfnTestRegion, "eu-west-1", 1),
+		},
+		{
+			name: "a foreign partition",
+			arn:  strings.Replace(arn, "arn:aws:", "arn:aws-cn:", 1),
+		},
+		{
+			name: "a UUID belonging to another stack's name",
+			arn:  "arn:aws:cloudformation:" + cfnTestRegion + ":" + cfnTestAccount + ":stack/other/" + uuid,
+		},
+		{
+			name: "a UUID that matches nothing",
+			arn: "arn:aws:cloudformation:" + cfnTestRegion + ":" + cfnTestAccount +
+				":stack/in-scope/00000000-0000-0000-0000-000000000000",
+		},
+		{
+			name: "no UUID at all",
+			arn:  "arn:aws:cloudformation:" + cfnTestRegion + ":" + cfnTestAccount + ":stack/in-scope",
+		},
+		{
+			name: "an empty name segment",
+			arn:  "arn:aws:cloudformation:" + cfnTestRegion + ":" + cfnTestAccount + ":stack//" + uuid,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotEqual(t, arn, tc.arn, "the case must differ from the real ARN")
+
+			code, body := cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": tc.arn})
+			require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+			assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+
+			// The delete is the case that matters: an out-of-scope ARN must be
+			// refused outright, not absorbed by the absent-stack-is-success
+			// tolerance, or the refusal would read to a caller as a completed
+			// teardown.
+			code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": tc.arn})
+			require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+			assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+		})
+	}
+
+	// Nothing above touched the stack it was aimed at.
+	assert.Equal(t, http.StatusOK, cfnHeadBucket(t, ts, "cfn-wire-bucket"),
+		"a refused ARN must not have swept the in-scope stack's resources")
+	code, body := cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "in-scope"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<StackStatus>CREATE_COMPLETE</StackStatus>")
+}
+
+// TestCFNStackARN_AnotherCallersARNIsRefused is the scope check's sharpest case,
+// and the one that needs two callers to state.
+//
+// The cases in TestCFNStackARN_OutOfScopeARNIsRefused edit one field of a real ARN,
+// which leaves the digest disagreeing with the rest — so a check that verified only
+// the digest would refuse them all and look sufficient. This test hands over an ARN
+// that is *internally consistent* and belongs to a different caller: substrate minted
+// it, every field agrees, and it is still not this caller's to use. Only comparing
+// the ARN against the one substrate would mint for **this** caller refuses it.
+//
+// It is not a hypothetical. One substrate process serves every account and Region a
+// test suite uses, and a stack ARN is something a caller passes around; #517 is what
+// happened the last time a stack's identity and its caller's were allowed to drift
+// apart.
+func TestCFNStackARN_AnotherCallersARNIsRefused(t *testing.T) {
+	ts := newCFNIdentityTestServer(t)
+
+	// Two callers on one server: unsigned resolves to 000000000000, an AKIA-signed
+	// request to 123456789012.
+	const unsigned = ""
+	signed := signedAuthHeader("cloudformation", cfnTestRegion)
+
+	create := func(auth, region, name string) string {
+		t.Helper()
+		code, body := cfnIdentityRequest(t, ts, "cloudformation", region, auth, map[string]string{
+			"Action":       "CreateStack",
+			"Version":      "2010-05-15",
+			"StackName":    name,
+			"TemplateBody": cfnEmptyTemplate,
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		return cfnXMLValue(t, body, "StackId")
+	}
+
+	zeroARN := create(unsigned, cfnTestRegion, "zero-owned")
+	testARN := create(signed, cfnTestRegion, "test-owned")
+	westARN := create(signed, "eu-west-1", "west-owned")
+
+	require.Contains(t, zeroARN, ":000000000000:stack/zero-owned/")
+	require.Contains(t, testARN, ":"+cfnTestAccount+":stack/test-owned/")
+	require.Contains(t, westARN, ":eu-west-1:")
+
+	cases := []struct {
+		name   string
+		auth   string
+		region string
+		arn    string
+	}{
+		{
+			name: "the unsigned caller's own ARN, offered by the signed caller",
+			auth: signed, region: cfnTestRegion, arn: zeroARN,
+		},
+		{
+			name: "the signed caller's own ARN, offered by the unsigned caller",
+			auth: unsigned, region: cfnTestRegion, arn: testARN,
+		},
+		{
+			name: "a us-east-1 ARN offered to the eu-west-1 endpoint",
+			auth: signedAuthHeader("cloudformation", "eu-west-1"), region: "eu-west-1", arn: testARN,
+		},
+		{
+			name: "an eu-west-1 ARN offered to the us-east-1 endpoint",
+			auth: signed, region: cfnTestRegion, arn: westARN,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, body := cfnIdentityRequest(t, ts, "cloudformation", tc.region, tc.auth,
+				map[string]string{
+					"Action": "DescribeStacks", "Version": "2010-05-15", "StackName": tc.arn,
+				})
+			require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+			assert.Contains(t, body, "<Code>ValidationError</Code>")
+
+			code, body = cfnIdentityRequest(t, ts, "cloudformation", tc.region, tc.auth,
+				map[string]string{
+					"Action": "DeleteStack", "Version": "2010-05-15", "StackName": tc.arn,
+				})
+			require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+			assert.Contains(t, body, "<Code>ValidationError</Code>")
+		})
+	}
+
+	// Each owner still reaches its own stack by its own ARN, which is what keeps the
+	// refusals above from being a blanket "no ARNs across identities".
+	for _, own := range []struct {
+		auth, region, arn, name string
+	}{
+		{unsigned, cfnTestRegion, zeroARN, "zero-owned"},
+		{signed, cfnTestRegion, testARN, "test-owned"},
+		{signedAuthHeader("cloudformation", "eu-west-1"), "eu-west-1", westARN, "west-owned"},
+	} {
+		code, body := cfnIdentityRequest(t, ts, "cloudformation", own.region, own.auth,
+			map[string]string{
+				"Action": "DescribeStacks", "Version": "2010-05-15", "StackName": own.arn,
+			})
+		require.Equal(t, http.StatusOK, code, "%s: body was %s", own.name, body)
+		assert.Contains(t, body, "<StackName>"+own.name+"</StackName>")
+	}
+}
+
+// TestCFNStackARN_BareNamesUnchanged is the regression half. A name is not an ARN,
+// an absent name still answers ValidationError, and an absent name still deletes
+// successfully — the resolver sits in front of all three and must pass them
+// through untouched.
+func TestCFNStackARN_BareNamesUnchanged(t *testing.T) {
+	ts := newCFNTestServer(t)
+	_ = cfnCreateStackARN(t, ts, "plain", cfnEmptyTemplate)
+
+	code, body := cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "plain"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<StackName>plain</StackName>")
+
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "absent"})
+	require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+	assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+
+	code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "absent"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	// An absent StackName is still absent: DescribeStacks with none reports every
+	// stack, and the resolver must not turn "" into a refusal.
+	code, body = cfnAction(t, ts, "DescribeStacks", nil)
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<StackName>plain</StackName>")
+
+	// DeleteStack with no StackName is still the missing-parameter case, not the
+	// out-of-scope one.
+	code, body = cfnAction(t, ts, "DeleteStack", nil)
+	require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+	assert.Equal(t, "MissingParameter", cfnErrorCode(t, body))
+}

--- a/emulator/cfn_stack_arn_test.go
+++ b/emulator/cfn_stack_arn_test.go
@@ -247,6 +247,74 @@ func TestCFNStackARN_OutOfScopeARNIsRefused(t *testing.T) {
 	assert.Contains(t, body, "<StackStatus>CREATE_COMPLETE</StackStatus>")
 }
 
+// TestCFNStackARN_EveryOperationRefusesAnOutOfScopeARN is the mirror of
+// TestCFNStackARN_StackScopedOperations: the same twelve operations, offered an ARN
+// that is not this caller's.
+//
+// Resolving is only half of what each handler has to do — it also has to *return*
+// the refusal rather than ignore it and carry on with an empty name, which in
+// DeleteStack's case would land straight back in the absent-is-success tolerance.
+// TestCFNStackARN_OutOfScopeARNIsRefused proves the resolver refuses; this proves
+// every call site propagates.
+func TestCFNStackARN_EveryOperationRefusesAnOutOfScopeARN(t *testing.T) {
+	ts := newCFNTestServer(t)
+	arn := cfnCreateStackARN(t, ts, "propagates", cfnBucketTemplate)
+
+	// A real change set, so a refusal cannot be the change set merely being absent.
+	code, body := cfnAction(t, ts, "CreateChangeSet", map[string]string{
+		"StackName":     "propagates",
+		"ChangeSetName": "cs-propagates",
+		"TemplateBody":  cfnBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	// Another account's ARN for a stack that really exists here under that name.
+	foreign := strings.Replace(arn, cfnTestAccount, "999999999999", 1)
+	require.NotEqual(t, arn, foreign)
+
+	cases := []struct {
+		action string
+		params map[string]string
+	}{
+		{action: "DescribeStacks"},
+		{action: "DescribeStackResources"},
+		{action: "GetTemplate"},
+		{action: "ListChangeSets"},
+		{action: "DetectStackDrift"},
+		{action: "DescribeStackResourceDrifts"},
+		{action: "UpdateStack", params: map[string]string{"TemplateBody": cfnBucketTemplate}},
+		{
+			action: "CreateChangeSet",
+			params: map[string]string{"ChangeSetName": "cs-new", "TemplateBody": cfnBucketTemplate},
+		},
+		{action: "DescribeChangeSet", params: map[string]string{"ChangeSetName": "cs-propagates"}},
+		{action: "ExecuteChangeSet", params: map[string]string{"ChangeSetName": "cs-propagates"}},
+		{action: "DeleteChangeSet", params: map[string]string{"ChangeSetName": "cs-propagates"}},
+		{action: "DeleteStack"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.action, func(t *testing.T) {
+			params := map[string]string{"StackName": foreign}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			code, body := cfnAction(t, ts, tc.action, params)
+			require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+			assert.Equal(t, "ValidationError", cfnErrorCode(t, body))
+		})
+	}
+
+	// Twelve refused operations later, the stack, its change set and its resources
+	// are all exactly as they were.
+	assert.Equal(t, http.StatusOK, cfnHeadBucket(t, ts, "cfn-wire-bucket"))
+	code, body = cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "propagates"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<StackStatus>CREATE_COMPLETE</StackStatus>")
+	code, body = cfnAction(t, ts, "ListChangeSets", map[string]string{"StackName": "propagates"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, "<ChangeSetName>cs-propagates</ChangeSetName>")
+}
+
 // TestCFNStackARN_AnotherCallersARNIsRefused is the scope check's sharpest case,
 // and the one that needs two callers to state.
 //

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -183,6 +183,9 @@ func (p *CloudFormationPlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 // --- Stack operations ---
 
 func (p *CloudFormationPlugin) createStack(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	// Not run through [cfnStackName], and deliberately: CreateStack's StackName is
+	// "the name that's associated with the stack" with no unique-stack-ID
+	// alternative, because the ID does not exist until this call mints it.
 	name := req.Params["StackName"]
 	if name == "" {
 		return nil, cfnMissingParameter("StackName")
@@ -252,7 +255,11 @@ func (p *CloudFormationPlugin) createStack(reqCtx *RequestContext, req *AWSReque
 }
 
 func (p *CloudFormationPlugin) updateStack(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	name := req.Params["StackName"]
+	// "The name or unique stack ID of the stack to update."
+	name, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
 	if name == "" {
 		return nil, cfnMissingParameter("StackName")
 	}
@@ -295,7 +302,17 @@ func (p *CloudFormationPlugin) updateStack(reqCtx *RequestContext, req *AWSReque
 }
 
 func (p *CloudFormationPlugin) deleteStack(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	name := req.Params["StackName"]
+	// "The name or the unique stack ID that's associated with the stack."
+	//
+	// Resolving here, ahead of the deployer, is the whole fix for #544's silent
+	// success: DeleteStack's absent-stack tolerance below is right for a stack that
+	// is genuinely gone and wrong for an identifier the lookup merely failed to
+	// parse, and an ARN reaching the deployer verbatim matches no record, sweeps
+	// nothing, and answers 200.
+	name, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
 	if name == "" {
 		return nil, cfnMissingParameter("StackName")
 	}
@@ -373,7 +390,13 @@ type cfnOutputXML struct {
 }
 
 func (p *CloudFormationPlugin) describeStacks(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	name := req.Params["StackName"]
+	// "Running stacks: You can specify either the stack's name or its unique stack
+	// ID." Substrate keeps no record of a deleted stack, so the deleted-stack case —
+	// where the API requires the ID — reports the same not-found either way.
+	name, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
 
 	var stacks []CFNStackState
 	if name == "" {
@@ -475,6 +498,13 @@ func (p *CloudFormationPlugin) describeStackResources(reqCtx *RequestContext, re
 	if name == "" && physicalID == "" {
 		return nil, cfnMissingParameter("StackName")
 	}
+	// "Running stacks: You can specify either the stack's name or its unique stack
+	// ID." Resolved after the two parameter-shape checks above, which are about
+	// which parameters were sent rather than what they contain.
+	name, arnErr := cfnStackName(reqCtx, name)
+	if arnErr != nil {
+		return nil, arnErr
+	}
 
 	var stacks []CFNStackState
 	if name != "" {
@@ -552,7 +582,13 @@ func (p *CloudFormationPlugin) describeStackResources(reqCtx *RequestContext, re
 }
 
 func (p *CloudFormationPlugin) getTemplate(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	stackName := req.Params["StackName"]
+	// "Running stacks: You can specify either the stack's name or its unique stack
+	// ID." The change-set branch takes a name or ARN too, which cfnChangeSetName
+	// already handled; this is the stack half of the same courtesy.
+	stackName, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
 	changeSetName := cfnChangeSetName(req.Params["ChangeSetName"])
 
 	var body string
@@ -601,7 +637,12 @@ func (p *CloudFormationPlugin) getTemplate(reqCtx *RequestContext, req *AWSReque
 // --- Change-set operations ---
 
 func (p *CloudFormationPlugin) createChangeSet(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	stackName := req.Params["StackName"]
+	// "The name or the unique ID of the stack for which you are creating a change
+	// set", and the parameter's own pattern admits an arn: form.
+	stackName, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
 	changeSetName := req.Params["ChangeSetName"]
 	if changeSetName == "" {
 		return nil, cfnMissingParameter("ChangeSetName")
@@ -675,7 +716,14 @@ func (p *CloudFormationPlugin) describeChangeSet(reqCtx *RequestContext, req *AW
 	if changeSetName == "" {
 		return nil, cfnMissingParameter("ChangeSetName")
 	}
-	cs, err := p.findChangeSet(req.Params["StackName"], changeSetName)
+	// "If you specified the name of a change set, specify the stack name or Amazon
+	// Resource Name (ARN)". An empty StackName searches every stack, which
+	// findChangeSet already supports.
+	stackName, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
+	cs, err := p.findChangeSet(stackName, changeSetName)
 	if err != nil {
 		return nil, err
 	}
@@ -746,7 +794,13 @@ func (p *CloudFormationPlugin) executeChangeSet(reqCtx *RequestContext, req *AWS
 	if changeSetName == "" {
 		return nil, cfnMissingParameter("ChangeSetName")
 	}
-	cs, err := p.findChangeSet(req.Params["StackName"], changeSetName)
+	// "If you specified the name of a change set, specify the stack name or Amazon
+	// Resource Name (ARN) that's associated with the change set you want to execute."
+	stackName, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
+	cs, err := p.findChangeSet(stackName, changeSetName)
 	if err != nil {
 		return nil, err
 	}
@@ -769,7 +823,12 @@ func (p *CloudFormationPlugin) executeChangeSet(reqCtx *RequestContext, req *AWS
 }
 
 func (p *CloudFormationPlugin) listChangeSets(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	stackName := req.Params["StackName"]
+	// "The name or the Amazon Resource Name (ARN) of the stack for which you want to
+	// list change sets."
+	stackName, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
 	if stackName == "" {
 		return nil, cfnMissingParameter("StackName")
 	}
@@ -821,10 +880,16 @@ func (p *CloudFormationPlugin) deleteChangeSet(reqCtx *RequestContext, req *AWSR
 	if changeSetName == "" {
 		return nil, cfnMissingParameter("ChangeSetName")
 	}
+	// "If you specified the name of a change set to delete, specify the stack name or
+	// ID (ARN) that's associated with it."
+	stackName, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
 	// DeleteChangeSet documents no not-found error, so deleting an absent change
 	// set succeeds; only a wrong-status change set is refused, and substrate has
 	// no in-progress status to refuse.
-	if cs, err := p.findChangeSet(req.Params["StackName"], changeSetName); err != nil {
+	if cs, err := p.findChangeSet(stackName, changeSetName); err != nil {
 		return nil, err
 	} else if cs != nil {
 		if err := p.deployer.DeleteChangeSet(context.Background(), cs.StackName, cs.ChangeSetName); err != nil {
@@ -923,7 +988,12 @@ func (p *CloudFormationPlugin) listImports(reqCtx *RequestContext, req *AWSReque
 // --- Drift operations ---
 
 func (p *CloudFormationPlugin) detectStackDrift(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	stackName := req.Params["StackName"]
+	// The parameter's pattern admits an arn: form even though its prose says only
+	// "the name of the stack for which you want to detect drift".
+	stackName, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
 	if stackName == "" {
 		return nil, cfnMissingParameter("StackName")
 	}
@@ -953,7 +1023,12 @@ func (p *CloudFormationPlugin) detectStackDrift(reqCtx *RequestContext, req *AWS
 }
 
 func (p *CloudFormationPlugin) describeStackResourceDrifts(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	stackName := req.Params["StackName"]
+	// Same pattern as DetectStackDrift, and the pair is usually called together with
+	// whichever identifier the caller already has.
+	stackName, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
 	if stackName == "" {
 		return nil, cfnMissingParameter("StackName")
 	}
@@ -1129,6 +1204,19 @@ func cfnStackNotFound(name string) *AWSError {
 	}
 }
 
+// cfnStackARNNotInScope refuses a stack ARN that is not one substrate would have
+// minted for this caller — a foreign account or Region, a foreign partition, or a
+// UUID that does not match the name it is attached to.
+//
+// It reports exactly what an absent stack reports, and deliberately so: a stack
+// outside the caller's account and Region is a stack the caller cannot observe, so
+// telling the two cases apart would disclose whether some other scope holds a
+// stack by that name. Real CloudFormation answers a cross-account stack ID the
+// same way, since credentials scope the request before the identifier is read.
+func cfnStackARNNotInScope(nameOrARN string) *AWSError {
+	return cfnStackNotFound(nameOrARN)
+}
+
 // cfnChangeSetNotFound reports an unknown change set. ChangeSetNotFound is
 // documented at HTTP 404, unlike the stack case.
 func cfnChangeSetNotFound(name string) *AWSError {
@@ -1266,6 +1354,49 @@ func cfnDeterministicUUID(parts ...string) string {
 	sum := sha256.Sum256([]byte(strings.Join(parts, "/")))
 	h := hex.EncodeToString(sum[:])
 	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}
+
+// cfnStackName resolves the StackName a caller sent — a bare stack name, or the
+// stack ARN CreateStack handed back as its StackId — to the name StackDeployer
+// keys stacks by.
+//
+// Every stack-scoped operation documents both forms: "The name or the unique
+// stack ID that's associated with the stack", and CreateChangeSet, ExecuteChangeSet,
+// ListChangeSets, DetectStackDrift and DescribeStackResourceDrifts spell the ARN
+// alternative out in the parameter's own pattern,
+// ([a-zA-Z][-a-zA-Z0-9]*)|(arn:\b(aws|aws-us-gov|aws-cn)\b:[-a-zA-Z0-9:/._+]*).
+// Until #544 substrate looked the caller's string up verbatim, so the identifier
+// it had just minted resolved to nothing.
+//
+// The ARN is verified, not merely parsed. [cfnStackARN] builds it from the
+// partition, Region, account and a [cfnDeterministicUUID] over those plus the
+// name, so all of it is recomputable here — and comparing the whole string
+// against the one substrate would have minted checks every component at once,
+// with no way for a later field to be forgotten. Lifting the name out without
+// that check would let a caller reach, and DeleteStack tear down, a stack in
+// another account or Region by hand-writing an ARN: a worse defect than the
+// silent no-op #544 reported.
+//
+// CreateStack deliberately does not use this. Its StackName is documented as "The
+// name that's associated with the stack", with no ARN alternative — a stack ID
+// does not exist yet at the moment the stack is created.
+func cfnStackName(reqCtx *RequestContext, nameOrARN string) (string, *AWSError) {
+	const token = ":stack/"
+	idx := strings.Index(nameOrARN, token)
+	if idx < 0 {
+		// A stack name is "only alphanumeric characters (case sensitive) and
+		// hyphens", so no name can be mistaken for an ARN. An empty StackName stays
+		// empty: whether it is required is each operation's business, not this one.
+		return nameOrARN, nil
+	}
+	name := nameOrARN[idx+len(token):]
+	if slash := strings.IndexByte(name, '/'); slash >= 0 {
+		name = name[:slash]
+	}
+	if name == "" || nameOrARN != cfnStackARN(reqCtx.Region, reqCtx.AccountID, name) {
+		return "", cfnStackARNNotInScope(nameOrARN)
+	}
+	return name, nil
 }
 
 // cfnChangeSetName accepts either a bare change-set name or a change-set ARN and


### PR DESCRIPTION
Closes #544.

`CreateStack` answers with a `StackId` — the stack's ARN — and every stack-scoped operation documents that identifier as an alternative to the name: *"The name or the unique stack ID that's associated with the stack"*. `CreateChangeSet`, `ExecuteChangeSet`, `ListChangeSets`, `DetectStackDrift` and `DescribeStackResourceDrifts` spell the alternative out in the parameter's own pattern, `([a-zA-Z][-a-zA-Z0-9]*)|(arn:\b(aws|aws-us-gov|aws-cn)\b:[-a-zA-Z0-9:/._+]*)`. Substrate looked the caller's string up verbatim, so the identifier it had just minted resolved to no stack.

## Why this is a silent-success bug, not a lookup gap

`DeleteStack` documents no not-found error, so the deployer deliberately treats an unresolvable name as a stack already gone and succeeds (`cfn_deployer.go:1131`) — right for a stack that is genuinely absent, wrong for an identifier the lookup merely failed to parse. Handed an ARN it swept nothing, answered `200`, and left the stack standing. A caller had no error to catch and no status to poll; the next `CreateStack` answering `AlreadyExists` was the only symptom.

Measured against v0.89.0 before planning, the gap had **widened**: v0.89.0 shipped #518's resource sweep, so a by-**name** delete now really does tear resources down while a by-**ARN** delete still answered `200` and did nothing. The two paths disagreed about what a successful delete means.

## The change

- **One resolver at the plugin boundary.** `cfnStackName` is modelled on the existing `cfnChangeSetName` precedent — find `:stack/`, take the segment before the next `/` — so normalisation happens once where the caller's string arrives and the deployer's nine `d.state.Get(ctx, cfnNamespace, "stack:"+stackName)` sites keep taking a name and stay untouched. Normalising inside `loadStack` instead would leave `ListStacks`'s index-driven reads and `persistStack` keyed differently from the lookups.
- **Thirteen call sites, not the two the report named.** Every routed operation that takes `StackName` resolves: `UpdateStack`, `DeleteStack`, `DescribeStacks`, `DescribeStackResources`, `GetTemplate`, `CreateChangeSet`, `DescribeChangeSet`, `ExecuteChangeSet`, `DeleteChangeSet`, `ListChangeSets`, `DetectStackDrift`, `DescribeStackResourceDrifts`. Fixing describe and delete alone would leave the same trap in exactly the operations a caller reaches holding a `StackId`.
- **Ordering.** In `DeleteStack` the resolver runs *ahead* of the absent-is-success tolerance. That ordering is the whole fix for the silent `200`.
- **`CreateStack` is the deliberate exception**, documented at the call site: its `StackName` is "the name that's associated with the stack" with no unique-stack-ID alternative, because the ID does not exist until that call mints it.

## The ARN is verified, not merely parsed

This is the one way the fix could have been worse than the bug. `cfnStackARN` builds the ARN from the partition, Region, account and a `cfnDeterministicUUID` over those plus the name, so all of it is recomputable at request time — and comparing the **whole string** against the one substrate would have minted for **this** caller checks every component at once, with no way for a later field to be forgotten. Lifting the name out unverified would let a caller reach, and `DeleteStack` tear down, a stack in another account or Region by hand-writing an ARN.

An out-of-scope ARN reports the same `ValidationError` an absent stack does, deliberately: a stack outside the caller's account and Region is a stack the caller cannot observe, so a distinct error would disclose whether some other scope holds a stack by that name. Real CloudFormation answers the same way, since credentials scope the request before the identifier is read.

## Tests

`emulator/cfn_stack_arn_test.go`, seven tests. Confirmed to fail before the fix: with the plugin change stashed and the tests kept, `DescribeByReturnedID`, `DeleteByARNSweepsResources`, `StackScopedOperations` and all seven `OutOfScopeARNIsRefused` subtests go red. `DeleteAbsentByARNSucceeds` and `BareNamesUnchanged` are the regression halves and pass either way, which is the point of them.

`AnotherCallersARNIsRefused` is the sharpest case and needs two callers to state: every case in `OutOfScopeARNIsRefused` edits one field of a real ARN, which leaves the digest disagreeing with the rest — so a check that verified only the digest would refuse them all and look sufficient. That test hands one caller an ARN that is internally consistent and belongs to a *different* caller, across both identity and Region.

**Mutation testing**, established harness (anchor-count assert before applying, `gofmt -w && go vet` gate, `-race`): **10 mutants, 10 CAUGHT, 0 survivors.** Including the plan's two named ones — the scope check dropped (all seven out-of-scope subtests), and the resolver called after the absent-is-success tolerance (`DeleteByARNSweepsResources` plus every out-of-scope subtest) — as well as the report's narrow describe-only fix, `GetTemplate` left verbatim, a prefix-only check that skips the UUID, the caller's account or Region replaced by the ARN's own, an empty name segment resolving, the name not truncated at the next slash, and a bare name put through the ARN check.

Verified live on a fresh server: `describe-stacks` and `get-template` by the returned `StackId` behave as by-name; `delete-stack` by ARN sweeps `pc-data` (`head-bucket` → 404) and frees the name; the foreign-account, foreign-Region and tampered-UUID ARNs are each refused with `ValidationError` on **both** describe and delete, and leave the in-scope stack `CREATE_COMPLETE` with its bucket intact.

## Compatibility

A test that asserts a stack ARN in `StackName` reports `ValidationError`, or that `delete-stack` by ARN leaves resources standing, will go red. That is the fix. Bare names are unchanged, including the absent-name tolerances.

Docs: `docs/services.md` gains a *"A stack ARN is accepted wherever `StackName` is"* section, and a stale `DeleteStack` row claiming it deletes "the stack record only" is corrected — it has swept resources since v0.89.0.
