### PR TITLE
fix(batch): read a compute environment, job queue and job definition back (#530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   does not describe the extent of a part.
 
 ### Fixed
+- **A Batch compute environment, job queue and job definition can be read back after
+  it is created** (#530). `DescribeComputeEnvironments`, `DescribeJobQueues` and
+  `DescribeJobDefinitions` were unrouted, so each answered an unknown-operation error
+  while `DescribeJobs` — the one read that was routed — worked. A test could perform
+  the write and had no way to verify it.
+
+  **The issue's premise was wrong, and correcting it made the change larger than
+  filed.** It reported these as read handlers over state the creates already
+  persisted. None of the three creates persisted anything: each unmarshalled only the
+  name out of the body, echoed it back, and never touched the state manager. So the
+  whole request body — `type`, `state`, `priority`, `computeEnvironmentOrder`,
+  `containerProperties`, every member a describe has to report — was not merely unread
+  but never stored, and the creates had to start recording before there was anything
+  to answer from.
+
+  Two consequences of that came with it. All three creates took `_ *RequestContext`
+  and minted a hardcoded `arn:aws:batch:us-east-1:000000000000:…` for every caller,
+  which is wrong for any caller outside that account and Region and propagates,
+  because that ARN is the identifier `computeEnvironmentOrder` and `SubmitJob` take;
+  resources are now recorded against and reported to the caller's own account and
+  Region, like every other partitioned plugin. And `RegisterJobDefinition` answered
+  `"revision": 1` unconditionally, so registering one name twice was
+  indistinguishable — each registration is now its own revision and its own record,
+  which is what makes `${name}:${revision}` addressable at all.
+
+  The reads honour the documented filters (`computeEnvironments`/`jobQueues` as names
+  or full ARNs, `jobDefinitions` as `${name}:${revision}` or an ARN,
+  `jobDefinitionName` for every revision of a definition, `status`) and paginate on
+  `maxResults`/`nextToken`, omitting the token once the results are exhausted. An
+  absent filter reports every resource in scope; a filter entry naming something that
+  does not exist is skipped rather than refused, since the operations document no
+  not-found error. `jobDefinitions` wins outright over `jobDefinitionName` when both
+  are sent, per the reference's "can't be used with other parameters". A bad request
+  is a `ClientException` at HTTP 400, the only 400-class error any Batch operation
+  declares.
+
+  A registered definition is `ACTIVE` and the `status` filter selects on it. Nothing
+  yet reports one `INACTIVE`, because `DeregisterJobDefinition` is not routed either
+  — filed separately as #555 rather than widening this — but the status is stored on
+  the resource rather than synthesised at read time, so a deregistration can set it.
 - **An S3 bucket notification configuration submitted the way the API documents it
   is now parsed, stored, reported back — and dispatched** (#542). This is not a
   lost-configuration bug. It is a working feature that could not be turned on: every

--- a/docs/services.md
+++ b/docs/services.md
@@ -4091,6 +4091,78 @@ Firehose data ingestion: $0.029 per GB.
 
 ---
 
+## Batch
+
+**Endpoint:** `batch.{region}.amazonaws.com`
+**Protocol:** REST/JSON (`POST /v1/{operation}`)
+
+### Supported operations
+
+| Operation | Notes |
+|-----------|-------|
+| CreateComputeEnvironment | `computeEnvironmentName` and `type` required; an omitted `state` is `ENABLED` |
+| DescribeComputeEnvironments | `computeEnvironments` filter takes [names or full ARNs](#a-describe-filter-takes-a-name-or-an-arn); reports `ecsClusterArn` |
+| CreateJobQueue | `jobQueueName` required; an omitted `state` is `ENABLED` |
+| DescribeJobQueues | `jobQueues` filter takes names or full ARNs |
+| RegisterJobDefinition | `jobDefinitionName` and `type` required; each registration is [the next revision](#a-job-definition-is-versioned) |
+| DescribeJobDefinitions | `jobDefinitions` (`${name}:${revision}` or full ARN), `jobDefinitionName` (every revision), and `status` |
+| SubmitJob | Returns `jobId`; the job is immediately `SUCCEEDED` |
+| DescribeJobs | |
+| TerminateJob | Reports the job `FAILED` with the supplied `reason` |
+
+Every operation reports a bad request as **`ClientException`** at HTTP 400. The API
+reference declares exactly two errors for each Batch operation, `ClientException` and
+`ServerException`, so substrate does not use the `MissingParameter` or
+`InvalidParameterValue` codes other services return for the same shape of complaint.
+
+### A describe filter takes a name or an ARN
+
+All three resource describes document their filter as "a list of up to 100 … names or
+full Amazon Resource Name (ARN) entries", and both forms resolve. An **absent** filter
+reports every resource of that type in the caller's account and Region.
+
+A filter entry naming a resource that does not exist is **skipped, not refused**: the
+operations describe "one or more of your compute environments" and document no
+not-found error, so an absent name yields an absent result rather than an error. A
+filter in which nothing matches is an empty list at HTTP 200.
+
+`maxResults` and `nextToken` paginate. An absent or out-of-range `maxResults` reports up
+to 100 results, per the reference's "if this parameter isn't used, then Describe…
+returns up to 100 results". `nextToken` is **omitted** once the results are exhausted —
+"this value is null when there are no more results to return" — including when the last
+page is exactly full.
+
+### A job definition is versioned
+
+Each `RegisterJobDefinition` of a name is a distinct revision, numbered from 1, and each
+revision is its own record. `DescribeJobDefinitions` addresses one revision through
+`jobDefinitions` (`${name}:${revision}` or the full ARN) and every revision of a
+definition through `jobDefinitionName`.
+
+`jobDefinitions` **wins outright** when both are sent, rather than being intersected or
+unioned: the reference states it "can't be used with other parameters".
+
+A newly registered definition is `ACTIVE`, and the `status` filter selects on that.
+Nothing yet reports a definition `INACTIVE` — `DeregisterJobDefinition` is not
+implemented (tracked as issue #555) — but the status is recorded on the resource rather
+than synthesised at read time, so a deregistration can set it.
+
+### Resources are scoped to the caller
+
+A compute environment, job queue and job definition is recorded against the account and
+Region of the request that created it, and reported only to a caller in that scope, as
+every other partitioned plugin does. The ARN a create returns therefore names the
+caller's own account and Region, and is an identifier that caller's `SubmitJob` and
+`computeEnvironmentOrder` can use. A job definition's revision counter is scoped the
+same way, so two accounts each registering one definition of the same name both see
+revision 1.
+
+### Cost
+
+Batch itself is free; the compute it launches is not, and substrate launches none.
+
+---
+
 ## Fault injection
 
 Fault injection is cross-service rather than a plugin, so it lives here rather than in a

--- a/emulator/batch_describe_test.go
+++ b/emulator/batch_describe_test.go
@@ -1,0 +1,606 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file are #530's gate.
+//
+// Batch could create a compute environment, a job queue and a job definition and
+// read none of them back: DescribeComputeEnvironments, DescribeJobQueues and
+// DescribeJobDefinitions were unrouted, so each answered an unknown-operation error
+// while DescribeJobs — the one read that was routed — worked. A test could perform
+// the write and never verify it.
+//
+// The issue said the state was already there to answer from. It was not: all three
+// creates unmarshaled only the name, echoed it back with a hardcoded
+// us-east-1:000000000000 ARN, and never touched the state manager. So the creates
+// had to start recording first, which is why these tests assert on the whole record
+// rather than just the name — the request body was previously discarded in full.
+//
+// The assertions are on raw wire bytes rather than a Go round-trip. A struct
+// marshaled and unmarshaled by its own definition agrees with itself whatever its
+// tags say, which is exactly how #528 and #542 stayed green in tests while broken on
+// the wire. Batch's API is camelCase throughout and the create responses were
+// already correct, so they are the local reference.
+
+// batchPost posts to a Batch path and returns the status code together with the raw
+// response body, so an assertion can name the bytes a caller's SDK parses.
+func batchPost(t *testing.T, ts *httptest.Server, path string, body interface{}) (int, string) {
+	t.Helper()
+	resp := batchRequest(t, ts, http.MethodPost, path, body)
+	return resp.StatusCode, string(batchBody(t, resp))
+}
+
+// batchIdentityRequest posts to a Batch path as a particular caller: the Region comes
+// from the host the request is addressed to and the account from the Authorization
+// header, which is how the server resolves both. An empty authHeader is an unsigned
+// caller.
+func batchIdentityRequest(
+	t *testing.T, ts *httptest.Server, region, authHeader, path string, body interface{},
+) (int, string) {
+	t.Helper()
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+path, bytes.NewReader(data))
+	require.NoError(t, err)
+	req.Host = "batch." + region + ".amazonaws.com"
+	req.Header.Set("Content-Type", "application/json")
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(raw)
+}
+
+// batchMembers decodes a describe response and returns the named member, for the
+// assertions that need a count rather than a substring.
+func batchMembers(t *testing.T, body, member string) []map[string]interface{} {
+	t.Helper()
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(body), &decoded), "body was %s", body)
+	raw, ok := decoded[member]
+	require.True(t, ok, "no %s member in %s", member, body)
+	var members []map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &members), "body was %s", body)
+	return members
+}
+
+// TestBatchDescribe_ComputeEnvironmentIsReadableBack is the smallest statement of
+// the defect, for the first of the three resources.
+func TestBatchDescribe_ComputeEnvironmentIsReadableBack(t *testing.T) {
+	ts := newBatchTestServer(t)
+
+	code, body := batchPost(t, ts, "/v1/createcomputeenvironment", map[string]interface{}{
+		"computeEnvironmentName": "ce1",
+		"type":                   "MANAGED",
+		"serviceRole":            "arn:aws:iam::000000000000:role/AWSBatchServiceRole",
+		"computeResources": map[string]interface{}{
+			"type":     "EC2",
+			"maxvCpus": 128,
+			"minvCpus": 0,
+			"subnets":  []string{"subnet-a"},
+		},
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, `"computeEnvironmentName":"ce1"`)
+
+	code, body = batchPost(t, ts, "/v1/describecomputeenvironments", map[string]interface{}{})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	// Each member is asserted as a wire-name/value pair, because the whole request
+	// body used to be discarded — a describe reporting only the name would look like
+	// a fix while every other field stayed lost.
+	assert.Contains(t, body, `"computeEnvironments":[`)
+	assert.Contains(t, body, `"computeEnvironmentName":"ce1"`)
+	assert.Contains(t, body, `"computeEnvironmentArn":"arn:aws:batch:us-east-1:`)
+	assert.Contains(t, body, `"type":"MANAGED"`)
+	assert.Contains(t, body, `"status":"VALID"`)
+	assert.Contains(t, body, `"serviceRole":"arn:aws:iam::000000000000:role/AWSBatchServiceRole"`)
+	assert.Contains(t, body, `"maxvCpus":128`)
+	assert.Contains(t, body, `"subnets":["subnet-a"]`)
+	// "A compute environment must be created in the ENABLED state", so an omitted
+	// state is ENABLED rather than absent.
+	assert.Contains(t, body, `"state":"ENABLED"`)
+	// The operation's own preamble is that an unmanaged caller reads it to find the
+	// ECS cluster, so the member has to be there.
+	assert.Contains(t, body, `"ecsClusterArn":"arn:aws:ecs:us-east-1:`)
+}
+
+// TestBatchDescribe_JobQueueIsReadableBack covers the second resource, including the
+// members a compute-environment cross-reference depends on.
+func TestBatchDescribe_JobQueueIsReadableBack(t *testing.T) {
+	ts := newBatchTestServer(t)
+
+	code, body := batchPost(t, ts, "/v1/createjobqueue", map[string]interface{}{
+		"jobQueueName": "q1",
+		"priority":     10,
+		"state":        "ENABLED",
+		"computeEnvironmentOrder": []map[string]interface{}{
+			{"order": 1, "computeEnvironment": "ce1"},
+		},
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = batchPost(t, ts, "/v1/describejobqueues", map[string]interface{}{})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Contains(t, body, `"jobQueues":[`)
+	assert.Contains(t, body, `"jobQueueName":"q1"`)
+	assert.Contains(t, body, `"jobQueueArn":"arn:aws:batch:us-east-1:`)
+	assert.Contains(t, body, `"priority":10`)
+	assert.Contains(t, body, `"state":"ENABLED"`)
+	assert.Contains(t, body, `"status":"VALID"`)
+	assert.Contains(t, body, `"computeEnvironment":"ce1"`)
+	assert.Contains(t, body, `"order":1`)
+}
+
+// TestBatchDescribe_JobDefinitionRevisions is the versioning half.
+//
+// registerJobDefinition used to answer "revision":1 unconditionally, so two
+// registrations of one name were indistinguishable. Each is now its own revision and
+// its own record, which is what makes ${name}:${revision} addressable at all.
+func TestBatchDescribe_JobDefinitionRevisions(t *testing.T) {
+	ts := newBatchTestServer(t)
+
+	register := func(image string) string {
+		t.Helper()
+		code, body := batchPost(t, ts, "/v1/registerjobdefinition", map[string]interface{}{
+			"jobDefinitionName":   "jd1",
+			"type":                "container",
+			"containerProperties": map[string]interface{}{"image": image},
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		return body
+	}
+
+	first := register("busybox")
+	assert.Contains(t, first, `"revision":1`)
+	assert.Contains(t, first, `:job-definition/jd1:1"`)
+
+	second := register("amazonlinux")
+	assert.Contains(t, second, `"revision":2`, "a second registration of one name is revision 2")
+	assert.Contains(t, second, `:job-definition/jd1:2"`)
+
+	// A bare jobDefinitionName names every revision of that definition.
+	code, body := batchPost(t, ts, "/v1/describejobdefinitions", map[string]interface{}{
+		"jobDefinitionName": "jd1",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	require.Len(t, batchMembers(t, body, "jobDefinitions"), 2)
+	assert.Contains(t, body, `"revision":1`)
+	assert.Contains(t, body, `"revision":2`)
+	// Each revision carries its own properties, so the two are really distinct
+	// records rather than one record described twice.
+	assert.Contains(t, body, `"image":"busybox"`)
+	assert.Contains(t, body, `"image":"amazonlinux"`)
+	assert.Contains(t, body, `"status":"ACTIVE"`)
+	assert.Contains(t, body, `"type":"container"`)
+
+	// And one revision is addressable on its own, in both documented forms.
+	for _, identifier := range []string{
+		"jd1:2",
+		"arn:aws:batch:us-east-1:000000000000:job-definition/jd1:2",
+	} {
+		t.Run(identifier, func(t *testing.T) {
+			code, body := batchPost(t, ts, "/v1/describejobdefinitions", map[string]interface{}{
+				"jobDefinitions": []string{identifier},
+			})
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+			require.Len(t, batchMembers(t, body, "jobDefinitions"), 1)
+			assert.Contains(t, body, `"revision":2`)
+			assert.Contains(t, body, `"image":"amazonlinux"`)
+			assert.NotContains(t, body, `"image":"busybox"`,
+				"a revision-scoped filter reports that revision and no other")
+		})
+	}
+}
+
+// TestBatchDescribe_Filters covers the name-or-ARN filter each describe documents,
+// and the absent-filter case the reference specifies as every resource.
+func TestBatchDescribe_Filters(t *testing.T) {
+	ts := newBatchTestServer(t)
+
+	for _, name := range []string{"ce1", "ce2", "ce3"} {
+		code, body := batchPost(t, ts, "/v1/createcomputeenvironment", map[string]interface{}{
+			"computeEnvironmentName": name,
+			"type":                   "MANAGED",
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+	}
+
+	const arnPrefix = "arn:aws:batch:us-east-1:000000000000:compute-environment/"
+
+	cases := []struct {
+		name    string
+		filter  []string
+		wantLen int
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "an absent filter reports every environment",
+			wantLen: 3,
+			want:    []string{`"ce1"`, `"ce2"`, `"ce3"`},
+		},
+		{
+			name:    "a name",
+			filter:  []string{"ce2"},
+			wantLen: 1,
+			want:    []string{`"ce2"`},
+			notWant: []string{`"ce1"`, `"ce3"`},
+		},
+		{
+			name:    "a full ARN",
+			filter:  []string{arnPrefix + "ce3"},
+			wantLen: 1,
+			want:    []string{`"ce3"`},
+			notWant: []string{`"ce1"`, `"ce2"`},
+		},
+		{
+			// The parameter is documented as "a list of up to 100 compute environment
+			// names or full ARN entries", so the two forms mix freely.
+			name:    "names and ARNs mixed",
+			filter:  []string{"ce1", arnPrefix + "ce3"},
+			wantLen: 2,
+			want:    []string{`"ce1"`, `"ce3"`},
+			notWant: []string{`"ce2"`},
+		},
+		{
+			// The operation describes "one or more of your compute environments" and
+			// documents no not-found error, so an absent name is an absent result
+			// rather than a refusal.
+			name:    "an absent name is skipped, not refused",
+			filter:  []string{"ce1", "nope"},
+			wantLen: 1,
+			want:    []string{`"ce1"`},
+		},
+		{
+			name:    "a filter matching nothing",
+			filter:  []string{"nope"},
+			wantLen: 0,
+			notWant: []string{`"ce1"`, `"ce2"`, `"ce3"`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := map[string]interface{}{}
+			if tc.filter != nil {
+				body["computeEnvironments"] = tc.filter
+			}
+			code, got := batchPost(t, ts, "/v1/describecomputeenvironments", body)
+			require.Equal(t, http.StatusOK, code, "body was %s", got)
+			assert.Len(t, batchMembers(t, got, "computeEnvironments"), tc.wantLen)
+			for _, want := range tc.want {
+				assert.Contains(t, got, want)
+			}
+			for _, notWant := range tc.notWant {
+				assert.NotContains(t, got, notWant)
+			}
+		})
+	}
+}
+
+// TestBatchDescribe_JobDefinitionStatusFilter covers the documented status filter and
+// the name-matches-nothing case.
+//
+// Nothing in substrate can yet make a job definition INACTIVE — DeregisterJobDefinition
+// is unrouted, filed as #555 — so ACTIVE is the case with records in it. The INACTIVE
+// case still earns its place: it proves the filter is applied rather than accepted and
+// ignored, which is how a status parameter usually rots.
+func TestBatchDescribe_JobDefinitionStatusFilter(t *testing.T) {
+	ts := newBatchTestServer(t)
+
+	code, body := batchPost(t, ts, "/v1/registerjobdefinition", map[string]interface{}{
+		"jobDefinitionName":   "jd1",
+		"type":                "container",
+		"containerProperties": map[string]interface{}{"image": "busybox"},
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = batchPost(t, ts, "/v1/describejobdefinitions", map[string]interface{}{"status": "ACTIVE"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Len(t, batchMembers(t, body, "jobDefinitions"), 1)
+	assert.Contains(t, body, `"status":"ACTIVE"`)
+
+	code, body = batchPost(t, ts, "/v1/describejobdefinitions", map[string]interface{}{"status": "INACTIVE"})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Empty(t, batchMembers(t, body, "jobDefinitions"),
+		"the status filter is applied, so an ACTIVE definition is not reported as INACTIVE")
+
+	// A jobDefinitionName matching nothing must not fall through to the unfiltered
+	// branch and report every definition in the account.
+	code, body = batchPost(t, ts, "/v1/describejobdefinitions", map[string]interface{}{
+		"jobDefinitionName": "absent",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Empty(t, batchMembers(t, body, "jobDefinitions"))
+	assert.NotContains(t, body, "jd1")
+
+	// jobDefinitions "can't be used with other parameters", so it wins outright when
+	// both are sent. The second definition below is what makes that a real
+	// statement: a jobDefinitionName naming something absent would leave a
+	// jobDefinitions filter alone under either reading, so it cannot tell
+	// precedence from a union.
+	code, body = batchPost(t, ts, "/v1/registerjobdefinition", map[string]interface{}{
+		"jobDefinitionName":   "jd2",
+		"type":                "container",
+		"containerProperties": map[string]interface{}{"image": "alpine"},
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	code, body = batchPost(t, ts, "/v1/describejobdefinitions", map[string]interface{}{
+		"jobDefinitions":    []string{"jd1:1"},
+		"jobDefinitionName": "jd2",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Len(t, batchMembers(t, body, "jobDefinitions"), 1)
+	assert.Contains(t, body, `"image":"busybox"`)
+	assert.NotContains(t, body, `"image":"alpine"`,
+		"jobDefinitions wins outright; jobDefinitionName does not widen it")
+
+	// And the same pair with a jobDefinitionName that names nothing.
+	code, body = batchPost(t, ts, "/v1/describejobdefinitions", map[string]interface{}{
+		"jobDefinitions":    []string{"jd1:1"},
+		"jobDefinitionName": "absent",
+	})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Len(t, batchMembers(t, body, "jobDefinitions"), 1)
+	assert.Contains(t, body, `"revision":1`)
+}
+
+// TestBatchDescribe_Pagination covers maxResults and nextToken, which all three
+// operations document identically.
+func TestBatchDescribe_Pagination(t *testing.T) {
+	ts := newBatchTestServer(t)
+
+	for _, name := range []string{"q1", "q2", "q3", "q4", "q5"} {
+		code, body := batchPost(t, ts, "/v1/createjobqueue", map[string]interface{}{
+			"jobQueueName": name,
+			"priority":     1,
+		})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+	}
+
+	seen := map[string]bool{}
+	token := ""
+	pages := 0
+	for pages < 5 {
+		body := map[string]interface{}{"maxResults": 2}
+		if token != "" {
+			body["nextToken"] = token
+		}
+		code, got := batchPost(t, ts, "/v1/describejobqueues", body)
+		require.Equal(t, http.StatusOK, code, "body was %s", got)
+		pages++
+
+		queues := batchMembers(t, got, "jobQueues")
+		require.LessOrEqual(t, len(queues), 2, "a page must not exceed maxResults")
+		for _, q := range queues {
+			name, _ := q["jobQueueName"].(string)
+			require.False(t, seen[name], "%s appeared on two pages", name)
+			seen[name] = true
+		}
+
+		var decoded struct {
+			NextToken string `json:"nextToken"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(got), &decoded))
+		token = decoded.NextToken
+		if token == "" {
+			break
+		}
+	}
+	assert.Len(t, seen, 5, "paging through reports every queue exactly once")
+	assert.Empty(t, token,
+		"the last page omits nextToken, which is the only way a caller's paginator stops")
+	assert.Equal(t, 3, pages, "five queues at two per page is three pages")
+
+	// An absent maxResults means up to 100 in one page, so five queues arrive
+	// together with no token at all.
+	code, got := batchPost(t, ts, "/v1/describejobqueues", map[string]interface{}{})
+	require.Equal(t, http.StatusOK, code, "body was %s", got)
+	assert.Len(t, batchMembers(t, got, "jobQueues"), 5)
+	assert.NotContains(t, got, `"nextToken"`,
+		`"This value is null when there are no more results to return"`)
+
+	// The boundary worth stating separately: a maxResults that exactly exhausts the
+	// results is still exhausted. A token here would send a caller's paginator round
+	// again for an empty page — harmless against real AWS, but it means the token is
+	// being derived from the page size rather than from whether anything is left.
+	code, got = batchPost(t, ts, "/v1/describejobqueues", map[string]interface{}{"maxResults": 5})
+	require.Equal(t, http.StatusOK, code, "body was %s", got)
+	assert.Len(t, batchMembers(t, got, "jobQueues"), 5)
+	assert.NotContains(t, got, `"nextToken"`)
+}
+
+// TestBatchDescribe_ScopedToTheCaller is why the creates had to stop minting a
+// hardcoded ARN.
+//
+// The old creates took `_ *RequestContext` and answered
+// arn:aws:batch:us-east-1:000000000000:… for every caller. One substrate process
+// serves every account and Region a test suite uses, so a resource has to be
+// reported to its own caller and not to another — and the ARN it reports has to be
+// one that caller's own SubmitJob and computeEnvironmentOrder can name.
+func TestBatchDescribe_ScopedToTheCaller(t *testing.T) {
+	ts := newBatchTestServer(t)
+
+	// Unsigned resolves to 000000000000; an AKIA-signed request to 123456789012.
+	const unsigned = ""
+	signed := signedAuthHeader("batch", "us-east-1")
+	signedWest := signedAuthHeader("batch", "eu-west-1")
+
+	create := func(auth, region, name string) string {
+		t.Helper()
+		code, body := batchIdentityRequest(t, ts, region, auth, "/v1/createcomputeenvironment",
+			map[string]interface{}{"computeEnvironmentName": name, "type": "MANAGED"})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		return body
+	}
+
+	zero := create(unsigned, "us-east-1", "zero-owned")
+	test := create(signed, "us-east-1", "test-owned")
+	west := create(signedWest, "eu-west-1", "west-owned")
+
+	assert.Contains(t, zero, `"computeEnvironmentArn":"arn:aws:batch:us-east-1:000000000000:compute-environment/zero-owned"`)
+	assert.Contains(t, test, `:123456789012:compute-environment/test-owned"`,
+		"the ARN carries the caller's account, not a hardcoded 000000000000")
+	assert.Contains(t, west, `"computeEnvironmentArn":"arn:aws:batch:eu-west-1:`,
+		"the ARN carries the caller's Region, not a hardcoded us-east-1")
+
+	// Each caller's unfiltered describe reports its own environment and no other's.
+	cases := []struct {
+		auth    string
+		region  string
+		want    string
+		notWant []string
+	}{
+		{unsigned, "us-east-1", "zero-owned", []string{"test-owned", "west-owned"}},
+		{signed, "us-east-1", "test-owned", []string{"zero-owned", "west-owned"}},
+		{signedWest, "eu-west-1", "west-owned", []string{"zero-owned", "test-owned"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			code, body := batchIdentityRequest(t, ts, tc.region, tc.auth,
+				"/v1/describecomputeenvironments", map[string]interface{}{})
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+			assert.Contains(t, body, `"computeEnvironmentName":"`+tc.want+`"`)
+			for _, other := range tc.notWant {
+				assert.NotContains(t, body, other)
+			}
+
+			// And a name filter cannot cross the scope either: naming another
+			// caller's environment reports nothing, not that caller's record.
+			for _, other := range tc.notWant {
+				code, body := batchIdentityRequest(t, ts, tc.region, tc.auth,
+					"/v1/describecomputeenvironments",
+					map[string]interface{}{"computeEnvironments": []string{other}})
+				require.Equal(t, http.StatusOK, code, "body was %s", body)
+				assert.Empty(t, batchMembers(t, body, "computeEnvironments"),
+					"%s must not be readable by this caller", other)
+			}
+		})
+	}
+
+	// A job definition's revision counter is scoped the same way: two callers each
+	// registering one definition of the same name both get revision 1.
+	for _, auth := range []string{unsigned, signed} {
+		code, body := batchIdentityRequest(t, ts, "us-east-1", auth, "/v1/registerjobdefinition",
+			map[string]interface{}{"jobDefinitionName": "shared", "type": "container"})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		assert.Contains(t, body, `"revision":1`,
+			"one caller's registrations do not advance another's revision counter")
+	}
+
+	// The name *index* has to be scoped too, not only the records.
+	//
+	// This is worth its own assertion because an unscoped index is invisible to the
+	// checks above: a foreign name would resolve to no record for this caller and be
+	// skipped, so the result set still looks right. What leaks is the enumeration —
+	// pagination runs over the index before the records are loaded, so another
+	// caller's names consume this caller's page and the count and token come out
+	// wrong. The result would be a caller paging forever through pages that are
+	// mysteriously short.
+	code, body := batchIdentityRequest(t, ts, "us-east-1", signed,
+		"/v1/describecomputeenvironments", map[string]interface{}{"maxResults": 1})
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+	assert.Len(t, batchMembers(t, body, "computeEnvironments"), 1,
+		"the caller's one environment fills its one-result page")
+	assert.NotContains(t, body, `"nextToken"`,
+		"the caller has one environment, so the first page is the last — "+
+			"another caller's names must not be counted into the enumeration")
+}
+
+// TestBatchDescribe_MissingRequiredParameters covers the validation the persistence
+// made necessary: a record keyed by an empty name is unreachable, so an omitted name
+// has to be refused rather than stored.
+//
+// Batch documents exactly two errors for every operation, ClientException (400) and
+// ServerException (500), so a parameter complaint is a ClientException — not the
+// MissingParameter or InvalidParameterValue other services use.
+func TestBatchDescribe_MissingRequiredParameters(t *testing.T) {
+	ts := newBatchTestServer(t)
+
+	cases := []struct {
+		name string
+		path string
+		body map[string]interface{}
+	}{
+		{
+			"a compute environment with no name", "/v1/createcomputeenvironment",
+			map[string]interface{}{"type": "MANAGED"},
+		},
+		{
+			"a compute environment with no type", "/v1/createcomputeenvironment",
+			map[string]interface{}{"computeEnvironmentName": "ce1"},
+		},
+		{
+			"a job queue with no name", "/v1/createjobqueue",
+			map[string]interface{}{"priority": 1},
+		},
+		{
+			"a job definition with no name", "/v1/registerjobdefinition",
+			map[string]interface{}{"type": "container"},
+		},
+		{
+			"a job definition with no type", "/v1/registerjobdefinition",
+			map[string]interface{}{"jobDefinitionName": "jd1"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, body := batchPost(t, ts, tc.path, tc.body)
+			require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
+			assert.Contains(t, body, "ClientException")
+		})
+	}
+
+	// And none of the refused creates recorded anything, which is the point of
+	// refusing them: a half-created resource would be worse than none.
+	for member, path := range map[string]string{
+		"computeEnvironments": "/v1/describecomputeenvironments",
+		"jobQueues":           "/v1/describejobqueues",
+		"jobDefinitions":      "/v1/describejobdefinitions",
+	} {
+		code, body := batchPost(t, ts, path, map[string]interface{}{})
+		require.Equal(t, http.StatusOK, code, "body was %s", body)
+		assert.Empty(t, batchMembers(t, body, member))
+	}
+}
+
+// TestBatchDescribe_EmptyBeforeAnyCreate is the case that used to be an
+// unknown-operation error: a describe with nothing created is a 200 and an empty
+// list.
+func TestBatchDescribe_EmptyBeforeAnyCreate(t *testing.T) {
+	for member, path := range map[string]string{
+		"computeEnvironments": "/v1/describecomputeenvironments",
+		"jobQueues":           "/v1/describejobqueues",
+		"jobDefinitions":      "/v1/describejobdefinitions",
+	} {
+		t.Run(strings.TrimPrefix(path, "/v1/"), func(t *testing.T) {
+			ts := newBatchTestServer(t)
+			code, body := batchPost(t, ts, path, map[string]interface{}{})
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+			assert.Contains(t, body, `"`+member+`":[]`,
+				"an empty result is an empty list, not a null and not a missing member")
+
+			// An empty body at all is the other way an SDK sends this, and it is not
+			// a malformed request.
+			code, body = batchPost(t, ts, path, nil)
+			require.Equal(t, http.StatusOK, code, "body was %s", body)
+			assert.Contains(t, body, `"`+member+`":[]`)
+		})
+	}
+}

--- a/emulator/batch_plugin.go
+++ b/emulator/batch_plugin.go
@@ -3,9 +3,12 @@ package emulator
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -59,6 +62,12 @@ func (p *BatchPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSR
 		return p.createJobQueue(ctx, req)
 	case "RegisterJobDefinition":
 		return p.registerJobDefinition(ctx, req)
+	case "DescribeComputeEnvironments":
+		return p.describeComputeEnvironments(ctx, req)
+	case "DescribeJobQueues":
+		return p.describeJobQueues(ctx, req)
+	case "DescribeJobDefinitions":
+		return p.describeJobDefinitions(ctx, req)
 	default:
 		return nil, &AWSError{
 			Code:       "InvalidAction",
@@ -89,6 +98,14 @@ func parseBatchOperation(method, path string) (op, jobID string) {
 		return "CreateJobQueue", ""
 	case rest == "v1/registerjobdefinition" && method == "POST":
 		return "RegisterJobDefinition", ""
+	// Each create's describe counterpart. Their absence, alongside routed creates,
+	// is what #530 reported: a resource could be created and not read back.
+	case rest == "v1/describecomputeenvironments" && method == "POST":
+		return "DescribeComputeEnvironments", ""
+	case rest == "v1/describejobqueues" && method == "POST":
+		return "DescribeJobQueues", ""
+	case rest == "v1/describejobdefinitions" && method == "POST":
+		return "DescribeJobDefinitions", ""
 	// Legacy REST-style paths retained for backwards compatibility.
 	case rest == "v1/jobs" && method == "POST":
 		return "DescribeJobs", ""
@@ -134,6 +151,403 @@ type BatchJob struct {
 
 	// Region is the AWS region in which the job runs.
 	Region string `json:"region"`
+}
+
+// BatchComputeEnvironment holds persisted state for an AWS Batch compute
+// environment.
+//
+// The json tags are the wire names, which for Batch are the same in both
+// directions: the API is camelCase and ComputeEnvironmentDetail's members are the
+// ones a create accepts. Fields substrate does not interpret are carried as
+// map[string]interface{} so a describe reports back what the caller sent rather
+// than a lossy projection of it.
+type BatchComputeEnvironment struct {
+	// ComputeEnvironmentName is the caller-supplied name.
+	ComputeEnvironmentName string `json:"computeEnvironmentName"`
+
+	// ComputeEnvironmentARN is the environment's ARN, in the caller's partition,
+	// Region and account.
+	ComputeEnvironmentARN string `json:"computeEnvironmentArn"`
+
+	// Type is MANAGED or UNMANAGED.
+	Type string `json:"type"`
+
+	// State is ENABLED or DISABLED.
+	State string `json:"state"`
+
+	// Status is the environment's status; substrate reports VALID.
+	Status string `json:"status"`
+
+	// StatusReason is the human-readable reason accompanying Status.
+	StatusReason string `json:"statusReason,omitempty"`
+
+	// ServiceRole is the IAM role Batch assumes, when the caller supplied one.
+	ServiceRole string `json:"serviceRole,omitempty"`
+
+	// UnmanagedvCPUs is the vCPU reservation for an unmanaged environment.
+	UnmanagedvCPUs int `json:"unmanagedvCpus,omitempty"`
+
+	// ECSClusterARN is the ECS cluster the environment reports, which is what an
+	// unmanaged caller reads this operation to discover.
+	ECSClusterARN string `json:"ecsClusterArn,omitempty"`
+
+	// ComputeResources is the compute resource specification as sent.
+	ComputeResources map[string]interface{} `json:"computeResources,omitempty"`
+
+	// Tags are the environment's tags.
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
+// BatchJobQueue holds persisted state for an AWS Batch job queue.
+type BatchJobQueue struct {
+	// JobQueueName is the caller-supplied name.
+	JobQueueName string `json:"jobQueueName"`
+
+	// JobQueueARN is the queue's ARN, in the caller's partition, Region and account.
+	JobQueueARN string `json:"jobQueueArn"`
+
+	// State is ENABLED or DISABLED.
+	State string `json:"state"`
+
+	// Status is the queue's status; substrate reports VALID.
+	Status string `json:"status"`
+
+	// StatusReason is the human-readable reason accompanying Status.
+	StatusReason string `json:"statusReason,omitempty"`
+
+	// Priority is the queue's scheduling priority.
+	Priority int `json:"priority"`
+
+	// JobQueueType is EKS, ECS, ECS_FARGATE or SAGEMAKER_TRAINING.
+	JobQueueType string `json:"jobQueueType,omitempty"`
+
+	// SchedulingPolicyARN is the fair-share scheduling policy, when set.
+	SchedulingPolicyARN string `json:"schedulingPolicyArn,omitempty"`
+
+	// ComputeEnvironmentOrder is the ordered compute environment list as sent.
+	ComputeEnvironmentOrder []map[string]interface{} `json:"computeEnvironmentOrder,omitempty"`
+
+	// Tags are the queue's tags.
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
+// BatchJobDefinition holds persisted state for one revision of an AWS Batch job
+// definition.
+//
+// Each registration of a name is a separate record: a job definition is versioned,
+// and DescribeJobDefinitions addresses a revision as ${name}:${revision}.
+type BatchJobDefinition struct {
+	// JobDefinitionName is the caller-supplied name, without the revision suffix.
+	JobDefinitionName string `json:"jobDefinitionName"`
+
+	// JobDefinitionARN is this revision's ARN, ending in :${revision}.
+	JobDefinitionARN string `json:"jobDefinitionArn"`
+
+	// Revision is this registration's revision number, starting at 1.
+	Revision int `json:"revision"`
+
+	// Status is ACTIVE or INACTIVE.
+	Status string `json:"status"`
+
+	// Type is container or multinode.
+	Type string `json:"type"`
+
+	// ContainerProperties is the single-node container specification as sent.
+	ContainerProperties map[string]interface{} `json:"containerProperties,omitempty"`
+
+	// NodeProperties is the multi-node parallel specification as sent.
+	NodeProperties map[string]interface{} `json:"nodeProperties,omitempty"`
+
+	// ECSProperties is the ECS-specific specification as sent.
+	ECSProperties map[string]interface{} `json:"ecsProperties,omitempty"`
+
+	// EKSProperties is the EKS-specific specification as sent.
+	EKSProperties map[string]interface{} `json:"eksProperties,omitempty"`
+
+	// Parameters are the default parameter substitutions.
+	Parameters map[string]string `json:"parameters,omitempty"`
+
+	// RetryStrategy is the retry strategy as sent.
+	RetryStrategy map[string]interface{} `json:"retryStrategy,omitempty"`
+
+	// Timeout is the timeout configuration as sent.
+	Timeout map[string]interface{} `json:"timeout,omitempty"`
+
+	// PlatformCapabilities is EC2 or FARGATE.
+	PlatformCapabilities []string `json:"platformCapabilities,omitempty"`
+
+	// PropagateTags reports whether tags propagate to the ECS task.
+	PropagateTags bool `json:"propagateTags,omitempty"`
+
+	// SchedulingPriority is the fair-share scheduling priority.
+	SchedulingPriority int `json:"schedulingPriority,omitempty"`
+
+	// Tags are the job definition's tags.
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
+// batchARN builds a Batch ARN for a resource in the caller's Region and account.
+//
+// The ARN is what a caller passes to computeEnvironmentOrder, SubmitJob and the
+// describe filters, so building it from the RequestContext rather than a fixed
+// us-east-1/000000000000 is what makes those cross-references resolve for any other
+// caller (#530). The partition is aws, matching submitJob's jobArn below and every
+// other plugin's ARNs.
+func batchARN(ctx *RequestContext, resource, name string) string {
+	return fmt.Sprintf("arn:aws:batch:%s:%s:%s/%s", ctx.Region, ctx.AccountID, resource, name)
+}
+
+// batchDeterministicUUID derives a stable UUID-shaped suffix for a resource, so a
+// synthesized ARN is the same on every read of the same resource and differs
+// between resources.
+func batchDeterministicUUID(ctx *RequestContext, resource, name string) string {
+	sum := sha256.Sum256([]byte(ctx.AccountID + "/" + ctx.Region + "/" + resource + "/" + name))
+	return fmt.Sprintf("%x-%x-%x-%x-%x", sum[0:4], sum[4:6], sum[6:8], sum[8:10], sum[10:16])
+}
+
+// batchClientError returns the ClientException Batch reports for a bad request.
+// Every Batch operation documents exactly two errors, ClientException (400) and
+// ServerException (500), so a parameter complaint is a ClientException.
+func batchClientError(message string) *AWSError {
+	return &AWSError{Code: "ClientException", Message: message, HTTPStatus: http.StatusBadRequest}
+}
+
+// putBatchRecord persists a Batch resource and adds its name to the per-account,
+// per-Region index the describe operations enumerate when no filter is given.
+func (p *BatchPlugin) putBatchRecord(ctx *RequestContext, resource, name string, record interface{}) error {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("batch %s marshal: %w", resource, err)
+	}
+	goCtx := context.Background()
+	if err := p.state.Put(goCtx, batchNamespace, batchRecordKey(ctx, resource, name), data); err != nil {
+		return fmt.Errorf("batch %s put: %w", resource, err)
+	}
+	updateStringIndex(goCtx, p.state, batchNamespace, batchIndexKey(ctx, resource), name)
+	return nil
+}
+
+// batchRecordKey is the state key for one Batch resource.
+func batchRecordKey(ctx *RequestContext, resource, name string) string {
+	return resource + ":" + ctx.AccountID + "/" + ctx.Region + "/" + name
+}
+
+// batchIndexKey is the state key for a resource type's name index, scoped to the
+// caller's account and Region so one substrate process serving several identities
+// does not report another caller's resources.
+func batchIndexKey(ctx *RequestContext, resource string) string {
+	return resource + "_names:" + ctx.AccountID + "/" + ctx.Region
+}
+
+// batchNameFromIdentifier reduces a describe filter entry to the name the records
+// are keyed by.
+//
+// Every describe takes "names or full Amazon Resource Name (ARN) entries", so an
+// ARN is reduced to its resource segment. A job definition keeps its :revision
+// suffix, because that suffix is part of what identifies the record.
+func batchNameFromIdentifier(identifier string) string {
+	if slash := strings.LastIndexByte(identifier, '/'); slash >= 0 {
+		return identifier[slash+1:]
+	}
+	return identifier
+}
+
+// batchPage applies the maxResults/nextToken pagination every Batch describe
+// documents to an already-filtered list of names, returning the page and the token
+// to report.
+//
+// "If this parameter isn't used, then Describe… returns up to 100 results", so an
+// absent or out-of-range maxResults is 100 rather than unbounded.
+func batchPage(names []string, maxResults int, nextToken string) ([]string, string) {
+	if maxResults < 1 || maxResults > 100 {
+		maxResults = 100
+	}
+	offset := 0
+	if nextToken != "" {
+		if decoded, err := base64.StdEncoding.DecodeString(nextToken); err == nil {
+			if n, err := strconv.Atoi(string(decoded)); err == nil && n > 0 {
+				offset = n
+			}
+		}
+	}
+	if offset > len(names) {
+		offset = len(names)
+	}
+	page := names[offset:]
+	var out string
+	if len(page) > maxResults {
+		page = page[:maxResults]
+		out = base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset + maxResults)))
+	}
+	return page, out
+}
+
+// batchDescribeRequest is the request body shape shared by the three resource
+// describes. jobDefinitionName and status are only meaningful to
+// DescribeJobDefinitions; the others ignore them.
+type batchDescribeRequest struct {
+	ComputeEnvironments []string `json:"computeEnvironments"`
+	JobQueues           []string `json:"jobQueues"`
+	JobDefinitions      []string `json:"jobDefinitions"`
+	JobDefinitionName   string   `json:"jobDefinitionName"`
+	Status              string   `json:"status"`
+	MaxResults          int      `json:"maxResults"`
+	NextToken           string   `json:"nextToken"`
+}
+
+// describeBatchResources is the body of all three resource describes: resolve the
+// filter to a list of names, page it, and load each record.
+//
+// filter is the caller's list of names or ARNs; an empty filter means every
+// resource of this type in the caller's account and Region, which is what each
+// operation's reference specifies for the absent-filter case.
+//
+// A filter entry naming a resource that does not exist is skipped rather than
+// refused: the operations describe "one or more of your compute environments" and
+// document no not-found error, so an absent name yields an absent result.
+func (p *BatchPlugin) describeBatchResources(
+	ctx *RequestContext, resource string, filter []string, maxResults int, nextToken string,
+) ([]json.RawMessage, string, error) {
+	goCtx := context.Background()
+
+	names := make([]string, 0, len(filter))
+	if len(filter) > 0 {
+		for _, entry := range filter {
+			if name := batchNameFromIdentifier(entry); name != "" {
+				names = append(names, name)
+			}
+		}
+	} else {
+		indexed, err := loadStringIndex(goCtx, p.state, batchNamespace, batchIndexKey(ctx, resource))
+		if err != nil {
+			return nil, "", fmt.Errorf("describe %s index: %w", resource, err)
+		}
+		names = indexed
+	}
+
+	page, out := batchPage(names, maxResults, nextToken)
+	records := make([]json.RawMessage, 0, len(page))
+	for _, name := range page {
+		data, err := p.state.Get(goCtx, batchNamespace, batchRecordKey(ctx, resource, name))
+		if err != nil {
+			return nil, "", fmt.Errorf("describe %s get: %w", resource, err)
+		}
+		if data == nil {
+			continue
+		}
+		records = append(records, data)
+	}
+	return records, out, nil
+}
+
+// batchDescribeResponse assembles a describe response, omitting nextToken when
+// there are no further results. "This value is null when there are no more results
+// to return", and a caller's paginator stops on its absence.
+func batchDescribeResponse(member string, records []json.RawMessage, nextToken string) (*AWSResponse, error) {
+	resp := map[string]interface{}{member: records}
+	if nextToken != "" {
+		resp["nextToken"] = nextToken
+	}
+	return batchJSONResponse(http.StatusOK, resp)
+}
+
+func (p *BatchPlugin) describeComputeEnvironments(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var body batchDescribeRequest
+	if len(req.Body) > 0 {
+		if err := json.Unmarshal(req.Body, &body); err != nil {
+			return nil, batchClientError("invalid request body")
+		}
+	}
+	records, nextToken, err := p.describeBatchResources(
+		ctx, "compute-environment", body.ComputeEnvironments, body.MaxResults, body.NextToken)
+	if err != nil {
+		return nil, err
+	}
+	return batchDescribeResponse("computeEnvironments", records, nextToken)
+}
+
+func (p *BatchPlugin) describeJobQueues(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var body batchDescribeRequest
+	if len(req.Body) > 0 {
+		if err := json.Unmarshal(req.Body, &body); err != nil {
+			return nil, batchClientError("invalid request body")
+		}
+	}
+	records, nextToken, err := p.describeBatchResources(
+		ctx, "job-queue", body.JobQueues, body.MaxResults, body.NextToken)
+	if err != nil {
+		return nil, err
+	}
+	return batchDescribeResponse("jobQueues", records, nextToken)
+}
+
+// describeJobDefinitions describes job definitions, which are versioned and so
+// filter differently from the other two resources.
+//
+// jobDefinitions entries address a specific revision — "an ARN … :${Revision} or a
+// short version using the form ${JobDefinitionName}:${Revision}" — while
+// jobDefinitionName names every revision of one definition. status filters the
+// result either way. The reference states jobDefinitions "can't be used with other
+// parameters", so it wins outright when both are sent rather than being intersected.
+func (p *BatchPlugin) describeJobDefinitions(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var body batchDescribeRequest
+	if len(req.Body) > 0 {
+		if err := json.Unmarshal(req.Body, &body); err != nil {
+			return nil, batchClientError("invalid request body")
+		}
+	}
+
+	goCtx := context.Background()
+	filter := body.JobDefinitions
+	if len(filter) == 0 && body.JobDefinitionName != "" {
+		// Every revision of the named definition, in registration order.
+		indexed, err := loadStringIndex(goCtx, p.state, batchNamespace, batchIndexKey(ctx, "job-definition"))
+		if err != nil {
+			return nil, fmt.Errorf("describe job-definition index: %w", err)
+		}
+		for _, name := range indexed {
+			if colon := strings.LastIndexByte(name, ':'); colon >= 0 && name[:colon] == body.JobDefinitionName {
+				filter = append(filter, name)
+			}
+		}
+		if filter == nil {
+			// A name matching nothing must not fall through to the unfiltered branch,
+			// which would report every definition in the account.
+			return batchDescribeResponse("jobDefinitions", []json.RawMessage{}, "")
+		}
+	}
+
+	records, nextToken, err := p.describeBatchResources(
+		ctx, "job-definition", filter, body.MaxResults, body.NextToken)
+	if err != nil {
+		return nil, err
+	}
+	if body.Status != "" {
+		records = batchFilterByStatus(records, body.Status)
+	}
+	return batchDescribeResponse("jobDefinitions", records, nextToken)
+}
+
+// batchFilterByStatus keeps the records whose status field equals status, which is
+// how DescribeJobDefinitions' documented ACTIVE/INACTIVE filter selects revisions.
+//
+// It filters after pagination rather than before, so a page's size reflects the
+// filter — matching the reference's ordering, in which status narrows the results a
+// page describes.
+func batchFilterByStatus(records []json.RawMessage, status string) []json.RawMessage {
+	kept := make([]json.RawMessage, 0, len(records))
+	for _, record := range records {
+		var probe struct {
+			Status string `json:"status"`
+		}
+		if json.Unmarshal(record, &probe) != nil {
+			continue
+		}
+		if probe.Status == status {
+			kept = append(kept, record)
+		}
+	}
+	return kept
 }
 
 func (p *BatchPlugin) submitJob(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -269,38 +683,205 @@ func (p *BatchPlugin) listJobs(ctx *RequestContext, _ *AWSRequest) (*AWSResponse
 	return batchJSONResponse(http.StatusOK, map[string]interface{}{"jobSummaryList": summaries})
 }
 
-func (p *BatchPlugin) createComputeEnvironment(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *BatchPlugin) createComputeEnvironment(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	var body struct {
-		ComputeEnvironmentName string `json:"computeEnvironmentName"`
+		ComputeEnvironmentName string                 `json:"computeEnvironmentName"`
+		Type                   string                 `json:"type"`
+		State                  string                 `json:"state"`
+		ServiceRole            string                 `json:"serviceRole"`
+		UnmanagedvCPUs         int                    `json:"unmanagedvCpus"`
+		ComputeResources       map[string]interface{} `json:"computeResources"`
+		Tags                   map[string]string      `json:"tags"`
 	}
-	_ = json.Unmarshal(req.Body, &body)
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return nil, batchClientError("invalid request body")
+	}
+	if body.ComputeEnvironmentName == "" {
+		return nil, batchClientError("computeEnvironmentName is required")
+	}
+	// computeEnvironmentName and type are the two required parameters.
+	if body.Type == "" {
+		return nil, batchClientError("type is required")
+	}
+
+	env := BatchComputeEnvironment{
+		ComputeEnvironmentName: body.ComputeEnvironmentName,
+		ComputeEnvironmentARN:  batchARN(ctx, "compute-environment", body.ComputeEnvironmentName),
+		Type:                   body.Type,
+		// "A compute environment must be created in the ENABLED state", so an
+		// omitted state is ENABLED rather than empty.
+		State: body.State,
+		// A substrate compute environment has no instances to bring up, so it is
+		// immediately VALID — the state a caller's wait loop polls for.
+		Status:           "VALID",
+		StatusReason:     "ComputeEnvironment Healthy",
+		ServiceRole:      body.ServiceRole,
+		UnmanagedvCPUs:   body.UnmanagedvCPUs,
+		ComputeResources: body.ComputeResources,
+		Tags:             body.Tags,
+		// ecsClusterArn is what DescribeComputeEnvironments exists to report for an
+		// unmanaged environment, per the operation's own preamble.
+		ECSClusterARN: fmt.Sprintf("arn:aws:ecs:%s:%s:cluster/%s_Batch_%s",
+			ctx.Region, ctx.AccountID, body.ComputeEnvironmentName,
+			batchDeterministicUUID(ctx, "compute-environment", body.ComputeEnvironmentName)),
+	}
+	if env.State == "" {
+		env.State = "ENABLED"
+	}
+
+	if err := p.putBatchRecord(ctx, "compute-environment", body.ComputeEnvironmentName, env); err != nil {
+		return nil, err
+	}
 	return batchJSONResponse(http.StatusOK, map[string]string{
-		"computeEnvironmentArn":  "arn:aws:batch:us-east-1:000000000000:compute-environment/" + body.ComputeEnvironmentName,
-		"computeEnvironmentName": body.ComputeEnvironmentName,
+		"computeEnvironmentArn":  env.ComputeEnvironmentARN,
+		"computeEnvironmentName": env.ComputeEnvironmentName,
 	})
 }
 
-func (p *BatchPlugin) createJobQueue(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *BatchPlugin) createJobQueue(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	var body struct {
-		JobQueueName string `json:"jobQueueName"`
+		JobQueueName            string                   `json:"jobQueueName"`
+		State                   string                   `json:"state"`
+		Priority                int                      `json:"priority"`
+		JobQueueType            string                   `json:"jobQueueType"`
+		SchedulingPolicyARN     string                   `json:"schedulingPolicyArn"`
+		ComputeEnvironmentOrder []map[string]interface{} `json:"computeEnvironmentOrder"`
+		Tags                    map[string]string        `json:"tags"`
 	}
-	_ = json.Unmarshal(req.Body, &body)
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return nil, batchClientError("invalid request body")
+	}
+	if body.JobQueueName == "" {
+		return nil, batchClientError("jobQueueName is required")
+	}
+
+	queue := BatchJobQueue{
+		JobQueueName:            body.JobQueueName,
+		JobQueueARN:             batchARN(ctx, "job-queue", body.JobQueueName),
+		State:                   body.State,
+		Status:                  "VALID",
+		StatusReason:            "JobQueue Healthy",
+		Priority:                body.Priority,
+		JobQueueType:            body.JobQueueType,
+		SchedulingPolicyARN:     body.SchedulingPolicyARN,
+		ComputeEnvironmentOrder: body.ComputeEnvironmentOrder,
+		Tags:                    body.Tags,
+	}
+	if queue.State == "" {
+		queue.State = "ENABLED"
+	}
+
+	if err := p.putBatchRecord(ctx, "job-queue", body.JobQueueName, queue); err != nil {
+		return nil, err
+	}
 	return batchJSONResponse(http.StatusOK, map[string]string{
-		"jobQueueArn":  "arn:aws:batch:us-east-1:000000000000:job-queue/" + body.JobQueueName,
-		"jobQueueName": body.JobQueueName,
+		"jobQueueArn":  queue.JobQueueARN,
+		"jobQueueName": queue.JobQueueName,
 	})
 }
 
-func (p *BatchPlugin) registerJobDefinition(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+// registerJobDefinition registers a job definition, assigning it the next
+// revision for its name.
+//
+// A job definition is versioned: "each entry in the list can either be an ARN in
+// the format arn:aws:batch:${Region}:${Account}:job-definition/${JobDefinitionName}:${Revision}
+// or a short version using the form ${JobDefinitionName}:${Revision}". So every
+// registration of a name is a distinct record keyed by name and revision, and the
+// name's revisions are indexed together — a describe by bare name reports all of
+// them, which is what makes the revision observable.
+func (p *BatchPlugin) registerJobDefinition(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	var body struct {
-		JobDefinitionName string `json:"jobDefinitionName"`
+		JobDefinitionName    string                 `json:"jobDefinitionName"`
+		Type                 string                 `json:"type"`
+		ContainerProperties  map[string]interface{} `json:"containerProperties"`
+		NodeProperties       map[string]interface{} `json:"nodeProperties"`
+		ECSProperties        map[string]interface{} `json:"ecsProperties"`
+		EKSProperties        map[string]interface{} `json:"eksProperties"`
+		Parameters           map[string]string      `json:"parameters"`
+		RetryStrategy        map[string]interface{} `json:"retryStrategy"`
+		Timeout              map[string]interface{} `json:"timeout"`
+		PlatformCapabilities []string               `json:"platformCapabilities"`
+		PropagateTags        bool                   `json:"propagateTags"`
+		SchedulingPriority   int                    `json:"schedulingPriority"`
+		Tags                 map[string]string      `json:"tags"`
 	}
-	_ = json.Unmarshal(req.Body, &body)
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return nil, batchClientError("invalid request body")
+	}
+	if body.JobDefinitionName == "" {
+		return nil, batchClientError("jobDefinitionName is required")
+	}
+	// jobDefinitionName and type are the two required parameters.
+	if body.Type == "" {
+		return nil, batchClientError("type is required")
+	}
+
+	goCtx := context.Background()
+	revision, err := p.nextJobDefinitionRevision(goCtx, ctx, body.JobDefinitionName)
+	if err != nil {
+		return nil, err
+	}
+	name := fmt.Sprintf("%s:%d", body.JobDefinitionName, revision)
+
+	def := BatchJobDefinition{
+		JobDefinitionName: body.JobDefinitionName,
+		JobDefinitionARN:  batchARN(ctx, "job-definition", name),
+		Revision:          revision,
+		// A newly registered job definition is ACTIVE. Nothing in substrate makes one
+		// INACTIVE yet — DeregisterJobDefinition is not routed (#555) — but the status
+		// is recorded rather than synthesized at read time so that it can be.
+		Status:               "ACTIVE",
+		Type:                 body.Type,
+		ContainerProperties:  body.ContainerProperties,
+		NodeProperties:       body.NodeProperties,
+		ECSProperties:        body.ECSProperties,
+		EKSProperties:        body.EKSProperties,
+		Parameters:           body.Parameters,
+		RetryStrategy:        body.RetryStrategy,
+		Timeout:              body.Timeout,
+		PlatformCapabilities: body.PlatformCapabilities,
+		PropagateTags:        body.PropagateTags,
+		SchedulingPriority:   body.SchedulingPriority,
+		Tags:                 body.Tags,
+	}
+
+	if err := p.putBatchRecord(ctx, "job-definition", name, def); err != nil {
+		return nil, err
+	}
 	return batchJSONResponse(http.StatusOK, map[string]interface{}{
-		"jobDefinitionArn":  "arn:aws:batch:us-east-1:000000000000:job-definition/" + body.JobDefinitionName + ":1",
-		"jobDefinitionName": body.JobDefinitionName,
-		"revision":          1,
+		"jobDefinitionArn":  def.JobDefinitionARN,
+		"jobDefinitionName": def.JobDefinitionName,
+		"revision":          revision,
 	})
+}
+
+// nextJobDefinitionRevision reports the revision to assign to a new registration
+// of name: one past the highest already recorded, starting at 1.
+//
+// It reads the name's own revision index rather than counting records, so a
+// revision number is never reused even if an intermediate revision is one day
+// removed.
+func (p *BatchPlugin) nextJobDefinitionRevision(goCtx context.Context, ctx *RequestContext, name string) (int, error) {
+	key := "job-definition_revisions:" + ctx.AccountID + "/" + ctx.Region + "/" + name
+	data, err := p.state.Get(goCtx, batchNamespace, key)
+	if err != nil {
+		return 0, fmt.Errorf("nextJobDefinitionRevision get: %w", err)
+	}
+	highest := 0
+	if data != nil {
+		if err := json.Unmarshal(data, &highest); err != nil {
+			return 0, fmt.Errorf("nextJobDefinitionRevision unmarshal: %w", err)
+		}
+	}
+	highest++
+	next, err := json.Marshal(highest)
+	if err != nil {
+		return 0, fmt.Errorf("nextJobDefinitionRevision marshal: %w", err)
+	}
+	if err := p.state.Put(goCtx, batchNamespace, key, next); err != nil {
+		return 0, fmt.Errorf("nextJobDefinitionRevision put: %w", err)
+	}
+	return highest, nil
 }
 
 // generateBatchJobID generates a random UUID-formatted job ID.


### PR DESCRIPTION
Closes #530.

`DescribeComputeEnvironments`, `DescribeJobQueues` and `DescribeJobDefinitions` were unrouted, so each answered an unknown-operation error while `DescribeJobs` — the one read that *was* routed — worked. A test could create a Batch resource and had no way to verify it. Same shape as the rest of this release: the write is accepted and produces nothing a caller can observe.

## The issue's premise was wrong, and the correction makes this larger than filed

The issue said *"the state is there to answer from — `createComputeEnvironment`, `createJobQueue` and `registerJobDefinition` all persist, so these are read handlers over existing state rather than new modelling."*

**None of the three persisted anything.** Each unmarshaled only the name out of the body, echoed it back, and never touched the state manager (`grep -c 'p.state'` inside each was `0`). So `type`, `state`, `priority`, `computeEnvironmentOrder`, `containerProperties` — everything a describe has to report — was not merely unread but never stored. The creates had to start recording before there was anything for the reads to answer from. Posted as a correction on the issue before starting.

Two consequences came with it, both now fixed:

- **The ARN was hardcoded.** All three creates took `_ *RequestContext` and minted `arn:aws:batch:us-east-1:000000000000:…` for every caller. That is wrong for any caller outside that account and Region, and it propagates, because that ARN is the identifier `computeEnvironmentOrder` and `SubmitJob` take. Resources are now recorded against and reported to the caller's own scope, like every other partitioned plugin.
- **`revision` was a constant.** `RegisterJobDefinition` answered `"revision": 1` unconditionally, so registering one name twice was indistinguishable. Each registration is now its own revision and its own record, which is what makes `${name}:${revision}` addressable at all.

## The reads

Filters follow the reference: `computeEnvironments`/`jobQueues` take "names or full ARN entries" and both forms resolve; `jobDefinitions` takes `${name}:${revision}` or a full ARN; `jobDefinitionName` names every revision of one definition; `status` selects on `ACTIVE`/`INACTIVE`. An **absent** filter reports every resource in scope.

Three decisions worth naming, each from the reference rather than from taste:

- **An absent name is skipped, not refused.** The operations describe "one or more of your compute environments" and document no not-found error, so a filter entry matching nothing yields an absent result. A filter in which nothing matches is an empty list at `200`.
- **`jobDefinitions` wins outright** over `jobDefinitionName` when both are sent — it "can't be used with other parameters" — rather than being intersected or unioned. A `jobDefinitionName` matching nothing returns an empty list rather than falling through to the unfiltered branch and reporting the whole account.
- **`ClientException` at 400.** Every Batch operation declares exactly two errors, `ClientException` and `ServerException`, so a parameter complaint is a `ClientException` — not the `MissingParameter`/`InvalidParameterValue` other plugins use. Verified on the wire: `{"Code":"ClientException","Message":"type is required"}`.

`maxResults`/`nextToken` paginate, with the token **omitted** once results are exhausted ("this value is null when there are no more results to return"), including when the last page is exactly full — a token there would send a caller's paginator round again for an empty page, which is the tell that the token was derived from page size rather than from what remains.

`DeregisterJobDefinition` is still unrouted, so nothing yet reports a definition `INACTIVE`. Filed separately as **#555** rather than widening this. The status is stored on the resource rather than synthesized at read time, so a deregistration can set it.

## Tests

`emulator/batch_describe_test.go`, nine tests. **Every one fails before the fix** — confirmed by stashing only `batch_plugin.go` and keeping the tests: 9 top-level failures, 21 including subtests.

Assertions are on **raw wire bytes**, not a Go round-trip. A struct marshaled and unmarshaled by its own definition agrees with itself whatever its tags say — which is exactly how #528 and #542 stayed green in tests while broken on the wire.

**Mutation testing**, established harness (anchor-count assert before applying, `gofmt -w && go vet` gate, `-race`): **15 mutants, 15 CAUGHT, 0 survivors.** Two survived the first round and both were real gaps, not equivalents:

- *The name index unscoped by account and Region* survived because it leaks no data on its own — a foreign name still resolves to no record for this caller and is skipped, so the result set looks right. What it corrupts is the **enumeration**: pagination runs over the index before records are loaded, so another caller's names consume this caller's page. Caught by adding a `maxResults: 1` assertion that the caller's single environment fills its page with no token. A third mutant, scoped by account but not Region, is caught by the same assertion.
- *`jobDefinitions` intersected with `jobDefinitionName`* survived because my precedence case used a `jobDefinitionName` naming something **absent**, which leaves a `jobDefinitions` filter alone under either reading. Caught by registering a second definition so the name refers to something real.

The other twelve: both key builders unscoped, `jobDefinitionName` falling through to the unfiltered branch, `revision` pinned at 1, the token emitted on a full page, `maxResults: 0` paging nothing, the `status` filter ignored, an ARN filter entry used verbatim, `state` not defaulting to `ENABLED`, a record written but never indexed, the ARN hardcoded as it was before, and a job definition keyed by bare name so revision 2 overwrites 1.

## Verified live

Fresh server on `:4603`, real AWS CLI. `create-compute-environment ce1` then `describe-compute-environments` reports it in full — `type`, `state: ENABLED`, `status: VALID`, `ecsClusterArn`, `computeResources`, `serviceRole` — where it was previously an unknown operation. Describe by name and by ARN both resolve; an absent name is an empty list. Two registrations of `jd1` report revisions 1 and 2 with their own `containerProperties`; `--job-definition-name jd1` reports both, `--job-definitions jd1:2` reports one. `--status ACTIVE` → 2, `INACTIVE` → 0. The SDK's own paginator at `--page-size 1` terminates and collects both. `eu-west-1` sees none of the `us-east-1` resources. The created queue and definition are usable by `submit-job`.

## Compatibility

A test asserting that a Batch describe fails, or that a second `RegisterJobDefinition` of one name reports revision 1, will go red — that is the fix. The ARN a create returns now carries the caller's real account and Region instead of `us-east-1:000000000000`, so a test that pinned the hardcoded string will need updating; a test that uses the returned ARN is unaffected. `SubmitJob`, `DescribeJobs` and `TerminateJob` are untouched.

Docs: `docs/services.md` gains a Batch section — the operation table, the filter and pagination rules, the revision semantics, and the caller-scoping. `make docs-reference` shows no plugin change.
