### PR TITLE
fix(lambda): report the size and digest of the deployed package (#545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   does not describe the extent of a part.
 
 ### Fixed
+- **A Lambda function reports the size and digest of the package it was deployed
+  from** (#545). `CodeSize` was `0` and `CodeSha256` empty for every function whose
+  code did not arrive as an inline base64 `ZipFile` on a direct `CreateFunction` — so
+  a consumer polling `CodeSize` to decide whether a deploy took effect was told
+  nothing had, whatever it deployed.
+
+  **The issue's premise was confounded, and correcting it doubled the change.** It was
+  filed as a CloudFormation problem. Measuring all four combinations against v0.89.0
+  showed the axis is **inline vs. S3 source**, not CFN vs. direct:
+  direct + `ZipFile` = **156** (correct), direct + S3 = **0**, CFN + S3 = **0**, and
+  CFN + inline `ZipFile` = **0** — the row the report never tested, and the one that
+  proves there were two independent gaps rather than one.
+
+  **CloudFormation sent no `Code` at all.** `deployLambdaFunction` built a
+  `CreateFunction` body carrying `FunctionName`, `Runtime`, `Role`, `Handler`,
+  `Description`, `Timeout` and `MemorySize` and no `Code` key of any kind, so every
+  CFN-deployed function reported size 0 and an empty digest however its template
+  declared its code, a container-image function lost both its image and its
+  `PackageType`, and `UpdateFunctionCode` drift was undetectable. All of `ZipFile`,
+  `S3Bucket`, `S3Key`, `S3ObjectVersion` and `ImageUri` are now forwarded, each
+  through the template's `Ref` and pseudo-parameter resolution like any other
+  property.
+
+  **An inline template needed more than forwarding, which is why fixing it was not a
+  one-line change.** The resource type's `Code.ZipFile` is "the source code of your
+  Lambda function" — "CloudFormation places it in a file named `index` and zips it to
+  create a deployment package" — while the API's `Code.ZipFile` is "the base64-encoded
+  contents of the deployment package". Forwarding the template's string would have
+  handed Lambda something that is not a package and usually not valid base64, leaving
+  `CodeSize` at 0 exactly as before. Substrate now builds the archive CloudFormation
+  would have built: one entry named `index` with the extension the runtime reads
+  (`.js` for `nodejs*` per the reference, `.py` for `python*`, bare `index`
+  otherwise). The archive carries no timestamps, so the same template deployed twice
+  yields the same package and the same digest — a digest that moved on every deploy
+  would not be worth comparing.
+
+  **An S3-sourced package is now sized.** Both `createFunction` and
+  `updateFunctionCode` read the object's recorded length out of substrate's own S3
+  state, honouring `S3ObjectVersion`. `ZipStored` stays `false` — the bytes are still
+  not staged for execution, which is a separate and correct fact from knowing the
+  size.
+
+  **`UpdateFunctionCode` stopped randomising the digest.** It assigned `CodeSha256` a
+  fresh random value on every call, so a caller asking "did the code change?" was
+  always told yes. The digest is now derived from the package, and an update carrying
+  no package at all changes neither the size nor the digest. `RevisionId` is not a
+  digest of anything and still advances on every call. An image-packaged function's
+  digest tracks its image URI, and is now reported from creation rather than only after
+  the first update — appearing on one path and not the other was a difference a caller
+  had no way to account for.
+
+  Two decisions here are substrate's own rather than the API model's, and
+  `docs/services.md` states both. The digest of an **S3-sourced** package is the
+  object's **ETag**, not a SHA256: substrate never fetches the bytes, and for a
+  single-part upload the ETag is the MD5 of the body, so it changes exactly when the
+  package changes — the question a caller comparing digests is actually asking. And an
+  **absent** S3 object does not fail the create the way real Lambda would; substrate's
+  S3 and Lambda state are independent and a template may legitimately name an object a
+  test never uploaded, so it logs and reports size 0. A deleted object — one hidden by
+  a delete marker — counts as absent rather than as a zero-length package.
+
+  Two adjacent gaps surfaced while fixing this and are fixed with it, since leaving
+  either would have made the change a write with no observable — the shape this whole
+  release is about. `Code.ImageUri`, the documented spelling, was accepted only at the
+  top level, and now wins over the legacy field and infers `PackageType: Image`. And
+  `GetFunction` reported `RepositoryType: S3` with a stub presigned URL for an
+  image-packaged function, which is a claim a caller can act on and be wrong about; it
+  now reports `RepositoryType: ECR` with `ImageUri` and `ResolvedImageUri` and no
+  `Location`.
+
 - **A Batch compute environment, job queue and job definition can be read back after
   it is created** (#530). `DescribeComputeEnvironments`, `DescribeJobQueues` and
   `DescribeJobDefinitions` were unrouted, so each answered an unknown-operation error

--- a/docs/services.md
+++ b/docs/services.md
@@ -1656,9 +1656,9 @@ $0.005 per 1,000. GET/SELECT operations are $0.0004 per 1,000.
 
 | Operation | Notes |
 |-----------|-------|
-| CreateFunction | Stores function metadata; no actual execution |
-| GetFunction | |
-| UpdateFunctionCode | |
+| CreateFunction | Stores function metadata; no actual execution; records [`CodeSize` and `CodeSha256`](#what-codesize-and-codesha256-report) from the deployment package |
+| GetFunction | Reports `Code.ImageUri` with `RepositoryType: ECR` for an [image-packaged function](#an-image-packaged-function-reports-its-image) |
+| UpdateFunctionCode | Re-derives [`CodeSize` and `CodeSha256`](#what-codesize-and-codesha256-report) from the new package; an update carrying no package changes neither |
 | UpdateFunctionConfiguration | |
 | DeleteFunction | |
 | ListFunctions | |
@@ -1670,12 +1670,83 @@ $0.005 per 1,000. GET/SELECT operations are $0.0004 per 1,000.
 | UntagResource | |
 | ListTags | |
 
+### What CodeSize and CodeSha256 report
+
+`CodeSize` is "the size of the function's deployment package, in bytes" and
+`CodeSha256` is "the SHA256 hash of the function's deployment package". What
+substrate can report depends on whether it holds the package:
+
+| Code source | `CodeSize` | `CodeSha256` |
+|---|---|---|
+| `Code.ZipFile` (inline, base64) | the decoded package's length | the real SHA256 of those bytes |
+| `Code.S3Bucket` + `Code.S3Key` | the S3 object's recorded length | the object's **ETag**, not a SHA256 — see below |
+| `Code.S3ObjectVersion` | that version's length | that version's ETag |
+| `Code.ImageUri` | 0 — an image is not a package substrate holds | a digest of the image URI |
+| no `Code` at all | 0 | empty |
+
+Two of these are substrate's own decisions rather than the API model:
+
+**The digest of an S3-sourced package is the object's ETag.** Substrate does not
+fetch the object's bytes — nothing executes them unless they arrived inline — so it
+cannot compute the SHA256 real Lambda would report. It reports the ETag instead,
+unquoted. For a single-part upload that ETag is the MD5 of the body, so it changes
+exactly when the package changes, which is what a caller comparing digests across
+deploys is asking. Do not assert that it equals a SHA256 you computed yourself; do
+assert that it changes when you upload different bytes and does not when you do not.
+An image-packaged function's digest is likewise derived from its URI.
+
+**An absent S3 object does not fail the create.** Real Lambda refuses a
+`CreateFunction` naming an object that is not there. Substrate accepts it, logs a
+warning, and reports `CodeSize: 0` with no digest. The reason is that substrate's S3
+and Lambda state are independent and a template may legitimately name an object a
+test never uploaded; failing the create would make a stack undeployable for a reason
+unrelated to what the test is checking. A deleted object — one hidden by a delete
+marker — counts as absent, not as a zero-length package.
+
+`CodeSize` and `CodeSha256` describe the package. `RevisionId` does not: it is not a
+digest of anything and advances on every `UpdateFunctionCode`, including one that
+changes no code.
+
+### An image-packaged function reports its image
+
+`Code.ImageUri` is the documented spelling and implies `PackageType: Image`, which a
+request need not state — real Lambda rejects an `ImageUri` alongside
+`PackageType: Zip`, so inferring it cannot contradict a valid request. A top-level
+`ImageUri` is also accepted, for compatibility with what substrate took before
+`Code.ImageUri` worked; `Code.ImageUri` wins when both are sent.
+
+`GetFunction` reports such a function through `Code.RepositoryType: ECR` with
+`ImageUri` and `ResolvedImageUri`, and no `Location` — `RepositoryType` is "the
+service that's hosting the file", and reporting a presigned S3 URL for an image is a
+claim a caller can act on and be wrong about.
+
 ### CloudFormation resource types
 
 | Type | Ref | Notes |
 |------|-----|-------|
-| AWS::Lambda::Function | FunctionName | |
+| AWS::Lambda::Function | FunctionName | `Code` is deployed in every form; [inline `ZipFile` is zipped](#an-inline-zipfile-is-zipped-into-a-package) |
 | AWS::Lambda::EventSourceMapping | — | |
+
+### An inline ZipFile is zipped into a package
+
+The resource type's `Code.ZipFile` and the API's `Code.ZipFile` are not the same
+thing, which is the one place the deployer does more than forward a property.
+
+The resource type's is "the source code of your Lambda function": "CloudFormation
+places it in a file named `index` and zips it to create a deployment package". The
+API's is "the base64-encoded contents of the deployment package". So substrate builds
+the archive CloudFormation would have built — a single entry named `index` with the
+extension the runtime reads (`.js` for `nodejs*`, `.py` for `python*`, bare `index`
+otherwise) — and sends that. `CodeSize` is therefore the **archive's** length, not the
+source's, and `CodeSha256` is a digest of real bytes.
+
+The archive carries no timestamps, so the same template deployed twice produces the
+same package and the same digest. A digest that changed on every deploy would not be
+worth comparing.
+
+`Code.S3Bucket`, `Code.S3Key`, `Code.S3ObjectVersion` and `Code.ImageUri` are
+forwarded as the API spells them, and each goes through the template's `Ref` and
+pseudo-parameter resolution like every other property.
 
 ### Cost
 

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -1,6 +1,7 @@
 package emulator
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -2668,6 +2669,12 @@ func (d *StackDeployer) deployLambdaFunction(
 			body["MemorySize"] = n
 		}
 	}
+	// Code is what the function is. Omitting it — as this deployer did — meant every
+	// CloudFormation-deployed function reported CodeSize 0 and an empty CodeSha256
+	// however its template declared its code, and a container-image function lost
+	// both its image and its package type. Called after Runtime is set, because an
+	// inline package's file name depends on it.
+	cfnLambdaCode(body, props, cctx)
 
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -2702,6 +2709,99 @@ func (d *StackDeployer) deployLambdaFunction(
 	}
 
 	return dr, cost, nil
+}
+
+// cfnLambdaCode carries an AWS::Lambda::Function resource's Code property into a
+// CreateFunction request body.
+//
+// The resource type and CreateFunction spell the S3 and image forms identically, so
+// S3Bucket/S3Key/S3ObjectVersion and ImageUri are forwarded as they are. An ImageUri
+// also implies PackageType: Image, which the resource type declares separately but a
+// template need not state — real CloudFormation rejects an ImageUri alongside
+// PackageType: Zip, so inferring it cannot contradict a valid template.
+//
+// ZipFile is the one form where the two spellings differ and the difference matters.
+// The resource type's ZipFile is "the source code of your Lambda function", plain
+// text: "CloudFormation places it in a file named index and zips it to create a
+// deployment package". CreateFunction's ZipFile is "the base64-encoded contents of
+// the deployment package". Forwarding the template's string verbatim would therefore
+// hand Lambda something that is not a package and usually not even valid base64,
+// which is why this builds the archive CloudFormation would have built — one entry
+// named index plus the runtime's extension — and sends that. The consequence is
+// visible: CodeSize is the archive's byte count and CodeSha256 a digest of real
+// bytes, where an unzipped forward would have left both empty.
+//
+// A resource with no Code at all is left alone rather than sent an empty Code
+// object: substrate's CreateFunction treats an absent Code as a function with no
+// stored package, which is the same outcome and one fewer thing to explain.
+func cfnLambdaCode(body, props map[string]interface{}, cctx *cfnContext) {
+	code, ok := props["Code"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	out := map[string]interface{}{}
+	for _, key := range []string{"S3Bucket", "S3Key", "S3ObjectVersion"} {
+		if v := resolveStringProp(code, key, "", cctx); v != "" {
+			out[key] = v
+		}
+	}
+	if src := resolveStringProp(code, "ZipFile", "", cctx); src != "" {
+		runtime, _ := body["Runtime"].(string)
+		pkg, err := cfnInlineZipPackage(src, runtime)
+		if err == nil {
+			out["ZipFile"] = base64.StdEncoding.EncodeToString(pkg)
+		}
+	}
+	if uri := resolveStringProp(code, "ImageUri", "", cctx); uri != "" {
+		out["ImageUri"] = uri
+		body["PackageType"] = "Image"
+	}
+	if len(out) > 0 {
+		body["Code"] = out
+	}
+	// PackageType may also be declared outright, for a template that says Image
+	// without a Code.ImageUri or states Zip explicitly.
+	if pt := resolveStringProp(props, "PackageType", "", cctx); pt != "" {
+		body["PackageType"] = pt
+	}
+}
+
+// cfnInlineZipPackage builds the deployment package CloudFormation builds for an
+// inline Code.ZipFile: a ZIP archive holding the source as a single file named
+// index, with the extension the runtime reads.
+//
+// The reference names the extension for one runtime family only — "when you specify
+// source code inline for a Node.js function, the index file that CloudFormation
+// creates uses the extension .js" — and inline code is documented as "(Node.js and
+// Python)", so Python's .py is the only other case. An unrecognized runtime gets a
+// bare index rather than a guess; the archive's size and digest, which is what this
+// exists to make right, do not depend on the name being executable, and substrate
+// does not run an inline package unless Docker is present.
+func cfnInlineZipPackage(source, runtime string) ([]byte, error) {
+	name := "index"
+	switch {
+	case strings.HasPrefix(runtime, "nodejs"):
+		name = "index.js"
+	case strings.HasPrefix(runtime, "python"):
+		name = "index.py"
+	}
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	// A zero timestamp keeps the archive deterministic: the same template deployed
+	// twice has to produce the same CodeSize and CodeSha256, which is the whole
+	// point of reporting a digest rather than a random value.
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Deflate})
+	if err != nil {
+		return nil, fmt.Errorf("create inline lambda package entry: %w", err)
+	}
+	if _, err := w.Write([]byte(source)); err != nil {
+		return nil, fmt.Errorf("write inline lambda package entry: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("close inline lambda package: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 // deploySQSQueue creates an SQS queue for the given CFN resource.

--- a/emulator/lambda_code_size_test.go
+++ b/emulator/lambda_code_size_test.go
@@ -1,0 +1,598 @@
+package emulator_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The tests below cover #545: a function's CodeSize and CodeSha256 report the
+// deployment package it was created from, whether that package arrived inline, from
+// S3, or through a CloudFormation template.
+//
+// They assert on the JSON GetFunction returns rather than on the state record, since
+// CodeSize is only interesting as an observation a caller makes — and a caller who
+// polls a function's size to decide whether a deploy took effect is the one the bug
+// was reported by.
+
+// lambdaCodeTestWorld bundles a server carrying the Lambda, S3 and CloudFormation
+// plugins with the deployer that shares their registry.
+//
+// One world rather than three: the point of the fix is that a package uploaded to
+// substrate's S3 is the same object the Lambda plugin sizes, and a CFN-deployed
+// function is the same function GetFunction answers for. Separate servers per plugin
+// could not express either.
+type lambdaCodeTestWorld struct {
+	srv      *emulator.Server
+	deployer *emulator.StackDeployer
+	state    emulator.StateManager
+}
+
+func newLambdaCodeTestWorld(t *testing.T) *lambdaCodeTestWorld {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+
+	opts := emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"filesystem":      afero.NewMemMapFs(),
+			"registry":        registry,
+		},
+	}
+	for _, p := range []emulator.Plugin{
+		&emulator.LambdaPlugin{},
+		&emulator.S3Plugin{},
+		&emulator.IAMPlugin{},
+	} {
+		require.NoError(t, p.Initialize(context.Background(), opts))
+		registry.Register(p)
+	}
+
+	return &lambdaCodeTestWorld{
+		srv:      emulator.NewServer(*cfg, registry, store, state, tc, logger),
+		deployer: emulator.NewStackDeployer(registry, store, state, tc, logger, costs),
+		state:    state,
+	}
+}
+
+// putS3Package uploads body as an object, the way a test or a build pipeline stages a
+// deployment package before pointing a function at it.
+func (w *lambdaCodeTestWorld) putS3Package(t *testing.T, bucket, key string, body []byte) {
+	t.Helper()
+	resp := s3Request(t, w.srv, http.MethodPut, "/"+bucket, nil, nil)
+	require.Equal(t, http.StatusOK, resp.Code, "create bucket: %s", resp.Body.String())
+	resp = s3Request(t, w.srv, http.MethodPut, "/"+bucket+"/"+key, body, nil)
+	require.Equal(t, http.StatusOK, resp.Code, "put object: %s", resp.Body.String())
+}
+
+// getFunctionConfig reports the Configuration member of GetFunction's response.
+func (w *lambdaCodeTestWorld) getFunctionConfig(t *testing.T, name string) map[string]any {
+	t.Helper()
+	resp := lambdaRequest(t, w.srv, http.MethodGet, "/2015-03-31/functions/"+name, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out struct {
+		Configuration map[string]any `json:"Configuration"`
+		Code          map[string]any `json:"Code"`
+	}
+	decodeLambdaJSON(t, resp, &out)
+	require.NotNil(t, out.Configuration, "GetFunction returned no Configuration")
+	return out.Configuration
+}
+
+// getFunctionCode reports the Code member of GetFunction's response.
+func (w *lambdaCodeTestWorld) getFunctionCode(t *testing.T, name string) map[string]any {
+	t.Helper()
+	resp := lambdaRequest(t, w.srv, http.MethodGet, "/2015-03-31/functions/"+name, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out struct {
+		Code map[string]any `json:"Code"`
+	}
+	decodeLambdaJSON(t, resp, &out)
+	return out.Code
+}
+
+// codeSize reports a Configuration's CodeSize as an int64. JSON numbers decode to
+// float64, and asserting on a float64 would let a size of 156.5 pass.
+func codeSize(t *testing.T, cfg map[string]any) int64 {
+	t.Helper()
+	n, ok := cfg["CodeSize"].(float64)
+	require.True(t, ok, "CodeSize was %#v", cfg["CodeSize"])
+	return int64(n)
+}
+
+// lambdaTestPackage is a 156-byte stand-in for a deployment package, the size the
+// issue reported as 0. Its exact contents do not matter; its exact length does, since
+// that is the observation under test.
+var lambdaTestPackage = bytes.Repeat([]byte("substrate-lambda-package-0123456789abcdef\n"), 4)[:156]
+
+// TestLambdaCodeSize_DirectS3Source is the direct half of #545: a CreateFunction
+// naming an S3 object reports that object's length, where it reported 0.
+func TestLambdaCodeSize_DirectS3Source(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+	w.putS3Package(t, "pkgs", "fn.zip", lambdaTestPackage)
+
+	resp := lambdaRequest(t, w.srv, http.MethodPost, "/2015-03-31/functions", map[string]any{
+		"FunctionName": "direct-s3",
+		"Runtime":      "python3.12",
+		"Role":         "arn:aws:iam::123456789012:role/r",
+		"Handler":      "index.handler",
+		"Code":         map[string]any{"S3Bucket": "pkgs", "S3Key": "fn.zip"},
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	cfg := w.getFunctionConfig(t, "direct-s3")
+	assert.Equal(t, int64(156), codeSize(t, cfg),
+		"CodeSize is the S3 object's byte length")
+	assert.NotEmpty(t, cfg["CodeSha256"],
+		"an S3-sourced package has a digest; an empty one is the pre-fix behavior")
+	assert.Equal(t, "Zip", cfg["PackageType"])
+}
+
+// TestLambdaCodeSize_DirectS3AbsentObject records the deliberate choice that an
+// absent object still deploys.
+//
+// Real Lambda refuses the create. Substrate does not, because its S3 and Lambda
+// namespaces are independent and a template may legitimately name an object a test
+// never uploaded; failing here would make a stack undeployable for a reason unrelated
+// to what the test is checking. The observable is a size of 0, not an error.
+func TestLambdaCodeSize_DirectS3AbsentObject(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+
+	resp := lambdaRequest(t, w.srv, http.MethodPost, "/2015-03-31/functions", map[string]any{
+		"FunctionName": "missing-s3",
+		"Runtime":      "python3.12",
+		"Role":         "arn:aws:iam::123456789012:role/r",
+		"Handler":      "index.handler",
+		"Code":         map[string]any{"S3Bucket": "nowhere", "S3Key": "absent.zip"},
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode,
+		"an absent package must not fail the create")
+
+	cfg := w.getFunctionConfig(t, "missing-s3")
+	assert.Equal(t, int64(0), codeSize(t, cfg))
+	assert.Empty(t, cfg["CodeSha256"],
+		"there is no package to digest, so no digest is reported")
+}
+
+// TestLambdaCodeSize_DirectS3ObjectVersion checks that S3ObjectVersion selects the
+// version it names rather than the current one.
+//
+// The two versions have different lengths deliberately: with equal lengths the
+// assertion would hold whichever record was read, which would measure nothing.
+func TestLambdaCodeSize_DirectS3ObjectVersion(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+
+	resp := s3Request(t, w.srv, http.MethodPut, "/vpkgs", nil, nil)
+	require.Equal(t, http.StatusOK, resp.Code)
+	resp = s3Request(t, w.srv, http.MethodPut, "/vpkgs?versioning",
+		[]byte(`<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>`), nil)
+	require.Equal(t, http.StatusOK, resp.Code, "enable versioning: %s", resp.Body.String())
+
+	first := bytes.Repeat([]byte("a"), 100)
+	resp = s3Request(t, w.srv, http.MethodPut, "/vpkgs/fn.zip", first, nil)
+	require.Equal(t, http.StatusOK, resp.Code)
+	firstVersion := resp.Header().Get("x-amz-version-id")
+	require.NotEmpty(t, firstVersion, "versioned PUT must report a version id")
+
+	resp = s3Request(t, w.srv, http.MethodPut, "/vpkgs/fn.zip", bytes.Repeat([]byte("b"), 250), nil)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	createResp := lambdaRequest(t, w.srv, http.MethodPost, "/2015-03-31/functions", map[string]any{
+		"FunctionName": "versioned-s3",
+		"Runtime":      "python3.12",
+		"Role":         "arn:aws:iam::123456789012:role/r",
+		"Handler":      "index.handler",
+		"Code": map[string]any{
+			"S3Bucket":        "vpkgs",
+			"S3Key":           "fn.zip",
+			"S3ObjectVersion": firstVersion,
+		},
+	})
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	cfg := w.getFunctionConfig(t, "versioned-s3")
+	assert.Equal(t, int64(100), codeSize(t, cfg),
+		"the named version's length, not the current version's 250")
+}
+
+// TestLambdaCodeSize_InlineZipFileIsHashed checks the inline path: CodeSize was
+// already right, but CodeSha256 was empty, so a caller could not tell one package
+// from another.
+func TestLambdaCodeSize_InlineZipFileIsHashed(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+
+	create := func(name string, pkg []byte) map[string]any {
+		resp := lambdaRequest(t, w.srv, http.MethodPost, "/2015-03-31/functions", map[string]any{
+			"FunctionName": name,
+			"Runtime":      "python3.12",
+			"Role":         "arn:aws:iam::123456789012:role/r",
+			"Handler":      "index.handler",
+			"Code":         map[string]any{"ZipFile": base64.StdEncoding.EncodeToString(pkg)},
+		})
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		return w.getFunctionConfig(t, name)
+	}
+
+	one := create("inline-one", lambdaTestPackage)
+	assert.Equal(t, int64(156), codeSize(t, one))
+	assert.NotEmpty(t, one["CodeSha256"], "an inline package has a digest")
+
+	// The same bytes hash the same and different bytes hash differently — which is
+	// the only property a caller comparing digests across deploys relies on.
+	again := create("inline-again", lambdaTestPackage)
+	assert.Equal(t, one["CodeSha256"], again["CodeSha256"])
+
+	other := create("inline-other", append(bytes.Clone(lambdaTestPackage), 'x'))
+	assert.NotEqual(t, one["CodeSha256"], other["CodeSha256"])
+}
+
+// TestLambdaCodeSize_UpdateFunctionCode covers both update paths.
+//
+// The digest assertion is the substantive one: UpdateFunctionCode used to assign
+// CodeSha256 a fresh random value on every call, so a caller asking "did the code
+// change?" was always told yes.
+func TestLambdaCodeSize_UpdateFunctionCode(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+	w.putS3Package(t, "updates", "v2.zip", bytes.Repeat([]byte("z"), 4096))
+
+	resp := lambdaRequest(t, w.srv, http.MethodPost, "/2015-03-31/functions", map[string]any{
+		"FunctionName": "updated",
+		"Runtime":      "python3.12",
+		"Role":         "arn:aws:iam::123456789012:role/r",
+		"Handler":      "index.handler",
+		"Code":         map[string]any{"ZipFile": base64.StdEncoding.EncodeToString(lambdaTestPackage)},
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	before := w.getFunctionConfig(t, "updated")
+	require.Equal(t, int64(156), codeSize(t, before))
+
+	// Re-uploading the identical package leaves the digest alone: the code did not
+	// change, so the answer to "did it change?" is no.
+	resp = lambdaRequest(t, w.srv, http.MethodPut, "/2015-03-31/functions/updated/code", map[string]any{
+		"ZipFile": base64.StdEncoding.EncodeToString(lambdaTestPackage),
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	same := w.getFunctionConfig(t, "updated")
+	assert.Equal(t, before["CodeSha256"], same["CodeSha256"],
+		"an unchanged package keeps its digest")
+	assert.NotEqual(t, before["RevisionId"], same["RevisionId"],
+		"a RevisionId is not a digest and advances on every update")
+
+	// An S3-sourced update reports the new object's length, where it reported the
+	// stale size and a random digest.
+	resp = lambdaRequest(t, w.srv, http.MethodPut, "/2015-03-31/functions/updated/code", map[string]any{
+		"S3Bucket": "updates",
+		"S3Key":    "v2.zip",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	after := w.getFunctionConfig(t, "updated")
+	assert.Equal(t, int64(4096), codeSize(t, after))
+	assert.NotEqual(t, before["CodeSha256"], after["CodeSha256"],
+		"a different package has a different digest")
+
+	// An UpdateFunctionCode carrying no code at all — which the API allows, and which
+	// an SDK sends when only DryRun or Publish is set — changes no package, so it
+	// changes no digest. This is the assertion that pins the digest to the package
+	// rather than to the act of calling the operation.
+	resp = lambdaRequest(t, w.srv, http.MethodPut, "/2015-03-31/functions/updated/code",
+		map[string]any{})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	empty := w.getFunctionConfig(t, "updated")
+	assert.Equal(t, after["CodeSha256"], empty["CodeSha256"],
+		"an update with no package keeps the digest it had")
+	assert.Equal(t, int64(4096), codeSize(t, empty),
+		"and keeps the size it had")
+
+	// Pointing the function at an image does change the package, so the digest moves
+	// with the URI — and moves back if the same URI is set again.
+	const uri = "123456789012.dkr.ecr.us-east-1.amazonaws.com/updated:v1"
+	resp = lambdaRequest(t, w.srv, http.MethodPut, "/2015-03-31/functions/updated/code",
+		map[string]any{"ImageUri": uri})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	img := w.getFunctionConfig(t, "updated")
+	assert.NotEqual(t, after["CodeSha256"], img["CodeSha256"],
+		"a new image is a new package")
+
+	resp = lambdaRequest(t, w.srv, http.MethodPut, "/2015-03-31/functions/updated/code",
+		map[string]any{"ImageUri": uri})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, img["CodeSha256"], w.getFunctionConfig(t, "updated")["CodeSha256"],
+		"the same image is the same package")
+}
+
+// TestLambdaCodeSize_ImageUriInCode checks the documented spelling of an image
+// source, which substrate accepted only at the top level.
+//
+// PackageType is inferred rather than required: an ImageUri implies Image, and real
+// Lambda rejects the pair with Zip, so inferring it cannot contradict a valid
+// request. GetFunction reports the image through FunctionCodeLocation, which is what
+// makes accepting the URI observable at all.
+func TestLambdaCodeSize_ImageUriInCode(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+	const uri = "123456789012.dkr.ecr.us-east-1.amazonaws.com/fn:latest"
+
+	resp := lambdaRequest(t, w.srv, http.MethodPost, "/2015-03-31/functions", map[string]any{
+		"FunctionName": "image-fn",
+		"Role":         "arn:aws:iam::123456789012:role/r",
+		"Code":         map[string]any{"ImageUri": uri},
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	cfg := w.getFunctionConfig(t, "image-fn")
+	assert.Equal(t, "Image", cfg["PackageType"],
+		"an ImageUri implies PackageType Image")
+
+	code := w.getFunctionCode(t, "image-fn")
+	assert.Equal(t, "ECR", code["RepositoryType"],
+		"the service hosting an image is ECR, not S3")
+	assert.Equal(t, uri, code["ImageUri"])
+	assert.Empty(t, code["Location"],
+		"there is no presigned S3 URL for an image-packaged function")
+
+	// The digest is reported at create, not only after an UpdateFunctionCode. Having it
+	// appear on one path and not the other would mean a function created from an image
+	// had no digest until it happened to be updated.
+	assert.NotEmpty(t, cfg["CodeSha256"],
+		"an image-packaged function's digest tracks its URI from creation")
+
+	other := newLambdaCodeTestWorld(t)
+	resp = lambdaRequest(t, other.srv, http.MethodPost, "/2015-03-31/functions", map[string]any{
+		"FunctionName": "image-fn",
+		"Role":         "arn:aws:iam::123456789012:role/r",
+		"Code":         map[string]any{"ImageUri": uri + "-different"},
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.NotEqual(t, cfg["CodeSha256"], other.getFunctionConfig(t, "image-fn")["CodeSha256"],
+		"a different image is a different package, so it digests differently")
+}
+
+// The templates below declare the same function three ways, which is what turns
+// "CFN drops Code" into three separate observations.
+const (
+	cfnInlineLambdaTemplate = `{"Resources":{"Fn":{"Type":"AWS::Lambda::Function","Properties":{
+		"FunctionName":"cfn-inline","Runtime":"python3.12","Handler":"index.handler",
+		"Role":"arn:aws:iam::123456789012:role/r",
+		"Code":{"ZipFile":"def handler(event, context):\n    return {'ok': True}\n"}}}}}`
+
+	cfnS3LambdaTemplate = `{"Resources":{"Fn":{"Type":"AWS::Lambda::Function","Properties":{
+		"FunctionName":"cfn-s3","Runtime":"python3.12","Handler":"index.handler",
+		"Role":"arn:aws:iam::123456789012:role/r",
+		"Code":{"S3Bucket":"pkgs","S3Key":"fn.zip"}}}}}`
+
+	cfnImageLambdaTemplate = `{"Resources":{"Fn":{"Type":"AWS::Lambda::Function","Properties":{
+		"FunctionName":"cfn-image",
+		"Role":"arn:aws:iam::123456789012:role/r",
+		"Code":{"ImageUri":"123456789012.dkr.ecr.us-east-1.amazonaws.com/cfn:latest"}}}}}`
+)
+
+// TestLambdaCodeSize_CFNInlineZipFile is the half of #545 the report never tested: a
+// CloudFormation function whose template declares its code inline.
+//
+// The resource type's ZipFile is plain source — "CloudFormation places it in a file
+// named index and zips it to create a deployment package" — while CreateFunction's
+// ZipFile is "the base64-encoded contents of the deployment package". So the deployer
+// has to build the archive, not forward the string: forwarding it would hand Lambda
+// something that is not a package and usually not valid base64, leaving CodeSize 0
+// exactly as before.
+func TestLambdaCodeSize_CFNInlineZipFile(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+
+	result, err := w.deployer.Deploy(context.Background(), cfnInlineLambdaTemplate, "inline-stack", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.Empty(t, result.Resources[0].Error)
+
+	cfg := w.getFunctionConfig(t, "cfn-inline")
+	size := codeSize(t, cfg)
+	assert.Positive(t, size, "an inline template's function has a package; 0 is the bug")
+	assert.NotEmpty(t, cfg["CodeSha256"])
+
+	// The package is the archive CloudFormation would have built: one entry, named
+	// for the runtime. Asserting on the stored bytes rather than only on the size is
+	// what distinguishes a real ZIP from any string of the right length.
+	raw, err := w.state.Get(context.Background(), "lambda", "function_zip:cfn-inline")
+	require.NoError(t, err)
+	require.NotEmpty(t, raw, "an inline package is staged for execution")
+	assert.Equal(t, size, int64(len(raw)), "CodeSize is the archive's length")
+
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	require.NoError(t, err, "the stored package is a ZIP archive")
+	require.Len(t, zr.File, 1)
+	assert.Equal(t, "index.py", zr.File[0].Name,
+		"a python runtime's inline source lands in index.py")
+
+	// Deterministic by construction: the same template deployed again produces the
+	// same package, which is what makes a digest worth comparing.
+	w2 := newLambdaCodeTestWorld(t)
+	_, err = w2.deployer.Deploy(context.Background(), cfnInlineLambdaTemplate, "inline-stack", nil)
+	require.NoError(t, err)
+	assert.Equal(t, cfg["CodeSha256"], w2.getFunctionConfig(t, "cfn-inline")["CodeSha256"])
+}
+
+// TestLambdaCodeSize_CFNInlineZipFileNodeRuntime pins the one extension the reference
+// names outright, so the runtime is read rather than assumed.
+func TestLambdaCodeSize_CFNInlineZipFileNodeRuntime(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+	tmpl := `{"Resources":{"Fn":{"Type":"AWS::Lambda::Function","Properties":{
+		"FunctionName":"cfn-node","Runtime":"nodejs20.x","Handler":"index.handler",
+		"Role":"arn:aws:iam::123456789012:role/r",
+		"Code":{"ZipFile":"exports.handler = async () => ({ok: true});\n"}}}}}`
+
+	_, err := w.deployer.Deploy(context.Background(), tmpl, "node-stack", nil)
+	require.NoError(t, err)
+
+	raw, err := w.state.Get(context.Background(), "lambda", "function_zip:cfn-node")
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	require.NoError(t, err)
+	require.Len(t, zr.File, 1)
+	assert.Equal(t, "index.js", zr.File[0].Name,
+		`"the index file that CloudFormation creates uses the extension .js"`)
+}
+
+// TestLambdaCodeSize_CFNS3Source is the case the issue filed: a CFN-deployed
+// function whose package is an S3 object reports that object's length.
+func TestLambdaCodeSize_CFNS3Source(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+	w.putS3Package(t, "pkgs", "fn.zip", lambdaTestPackage)
+
+	result, err := w.deployer.Deploy(context.Background(), cfnS3LambdaTemplate, "s3-stack", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.Empty(t, result.Resources[0].Error)
+
+	cfg := w.getFunctionConfig(t, "cfn-s3")
+	assert.Equal(t, int64(156), codeSize(t, cfg), "was 0 before the fix")
+	assert.NotEmpty(t, cfg["CodeSha256"])
+
+	// Nothing is staged for execution — the bytes were never fetched — and that is a
+	// separate and correct fact from knowing the size.
+	raw, err := w.state.Get(context.Background(), "lambda", "function_zip:cfn-s3")
+	require.NoError(t, err)
+	assert.Empty(t, raw, "an S3 package is not fetched, only sized")
+}
+
+// TestLambdaCodeSize_CFNS3SourceAbsentObject checks that a template naming an object
+// no test uploaded still deploys.
+func TestLambdaCodeSize_CFNS3SourceAbsentObject(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+
+	result, err := w.deployer.Deploy(context.Background(), cfnS3LambdaTemplate, "absent-stack", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	assert.Empty(t, result.Resources[0].Error,
+		"an absent package must not fail the stack")
+
+	assert.Equal(t, int64(0), codeSize(t, w.getFunctionConfig(t, "cfn-s3")))
+}
+
+// TestLambdaCodeSize_CFNImageUri checks that a container-image template keeps both
+// its image and its package type, which the deployer dropped along with Code.
+func TestLambdaCodeSize_CFNImageUri(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+
+	_, err := w.deployer.Deploy(context.Background(), cfnImageLambdaTemplate, "image-stack", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Image", w.getFunctionConfig(t, "cfn-image")["PackageType"])
+	assert.Equal(t, "123456789012.dkr.ecr.us-east-1.amazonaws.com/cfn:latest",
+		w.getFunctionCode(t, "cfn-image")["ImageUri"])
+}
+
+// TestLambdaCodeSize_CFNCodeResolvesRefs checks that Code's members go through the
+// template's parameter and pseudo-parameter resolution like every other property.
+//
+// A template that hardcodes its bucket is the exception; one that takes it as a
+// parameter is what a pipeline generates, and forwarding the unresolved {"Ref": …}
+// would name a bucket called nothing at all.
+func TestLambdaCodeSize_CFNCodeResolvesRefs(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+	w.putS3Package(t, "param-pkgs", "fn.zip", lambdaTestPackage)
+
+	tmpl := `{"Parameters":{"Bucket":{"Type":"String"},"Key":{"Type":"String","Default":"fn.zip"}},
+		"Resources":{"Fn":{"Type":"AWS::Lambda::Function","Properties":{
+		"FunctionName":"cfn-ref","Runtime":"python3.12","Handler":"index.handler",
+		"Role":"arn:aws:iam::123456789012:role/r",
+		"Code":{"S3Bucket":{"Ref":"Bucket"},"S3Key":{"Ref":"Key"}}}}}}`
+
+	_, err := w.deployer.Deploy(context.Background(), tmpl, "ref-stack",
+		map[string]string{"Bucket": "param-pkgs"})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(156), codeSize(t, w.getFunctionConfig(t, "cfn-ref")))
+}
+
+// TestLambdaCodeSize_CFNNoCode checks that a template declaring no Code at all is
+// unchanged: it deploys, and reports no package.
+//
+// Substrate's own generated templates and many hand-written test fixtures omit Code,
+// so this is the path that must not start failing.
+func TestLambdaCodeSize_CFNNoCode(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+	tmpl := `{"Resources":{"Fn":{"Type":"AWS::Lambda::Function","Properties":{
+		"FunctionName":"cfn-bare","Runtime":"python3.12","Handler":"index.handler",
+		"Role":"arn:aws:iam::123456789012:role/r"}}}}`
+
+	result, err := w.deployer.Deploy(context.Background(), tmpl, "bare-stack", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+	require.Empty(t, result.Resources[0].Error)
+
+	cfg := w.getFunctionConfig(t, "cfn-bare")
+	assert.Equal(t, int64(0), codeSize(t, cfg))
+	assert.Equal(t, "Zip", cfg["PackageType"])
+}
+
+// TestLambdaCodeSize_CFNRequestBodyCarriesCode asserts on the CreateFunction body the
+// deployer sends, one level below the observations above.
+//
+// The gap was that this body carried no Code key at all, so asserting on its presence
+// is the most direct statement of the fix — and it holds for a resource type whose
+// Code arrives in a shape the Lambda plugin happens to tolerate as well as one it
+// does not.
+func TestLambdaCodeSize_CFNRequestBodyCarriesCode(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+	w.putS3Package(t, "pkgs", "fn.zip", lambdaTestPackage)
+	_, err := w.deployer.Deploy(context.Background(), cfnS3LambdaTemplate, "body-stack", nil)
+	require.NoError(t, err)
+
+	raw, err := w.state.Get(context.Background(), "lambda", "function:cfn-s3")
+	require.NoError(t, err) //nolint:testifylint // the deploy above is asserted separately.
+	require.NotEmpty(t, raw)
+	var fn map[string]any
+	require.NoError(t, json.Unmarshal(raw, &fn))
+	assert.Equal(t, float64(156), fn["CodeSize"],
+		"the size reached the persisted record, not just the response")
+}
+
+// TestLambdaCodeSize_S3ETagIsTheDigest documents what the digest of an S3-sourced
+// package actually is, since it is substrate's own choice rather than the API model.
+//
+// Substrate never fetches the bytes, so it cannot compute the SHA256 real Lambda
+// reports. It reports the object's ETag instead, which for a single-part upload is
+// the MD5 of the body — it changes exactly when the package changes, which is the
+// question a caller comparing digests is asking, and it is stable across reads.
+func TestLambdaCodeSize_S3ETagIsTheDigest(t *testing.T) {
+	w := newLambdaCodeTestWorld(t)
+	w.putS3Package(t, "etags", "fn.zip", lambdaTestPackage)
+
+	head := s3Request(t, w.srv, http.MethodHead, "/etags/fn.zip", nil, nil)
+	require.Equal(t, http.StatusOK, head.Code)
+	etag := head.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+
+	resp := lambdaRequest(t, w.srv, http.MethodPost, "/2015-03-31/functions", map[string]any{
+		"FunctionName": "etag-fn",
+		"Runtime":      "python3.12",
+		"Role":         "arn:aws:iam::123456789012:role/r",
+		"Handler":      "index.handler",
+		"Code":         map[string]any{"S3Bucket": "etags", "S3Key": "fn.zip"},
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	cfg := w.getFunctionConfig(t, "etag-fn")
+	assert.Equal(t, strings.Trim(etag, `"`), cfg["CodeSha256"],
+		"the digest is the object's ETag, unquoted")
+}

--- a/emulator/lambda_plugin.go
+++ b/emulator/lambda_plugin.go
@@ -3,6 +3,7 @@ package emulator
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
@@ -244,9 +245,11 @@ func (p *LambdaPlugin) createFunction(ctx *RequestContext, req *AWSRequest) (*AW
 		Tags          map[string]string `json:"Tags"`
 		ImageURI      string            `json:"ImageUri"`
 		Code          struct {
-			ZipFile  string `json:"ZipFile"`
-			S3Bucket string `json:"S3Bucket"`
-			S3Key    string `json:"S3Key"`
+			ZipFile         string `json:"ZipFile"`
+			S3Bucket        string `json:"S3Bucket"`
+			S3Key           string `json:"S3Key"`
+			S3ObjectVersion string `json:"S3ObjectVersion"`
+			ImageURI        string `json:"ImageUri"`
 		} `json:"Code"`
 		Environment struct {
 			Variables map[string]string `json:"Variables"`
@@ -280,6 +283,18 @@ func (p *LambdaPlugin) createFunction(ctx *RequestContext, req *AWSRequest) (*AW
 	if pkgType == "" {
 		pkgType = "Zip"
 	}
+	// The API declares ImageUri inside Code, not at the top level; the top-level
+	// field substrate also accepts predates this and is kept so an existing caller
+	// keeps working. Code.ImageUri wins, being the documented spelling.
+	imageURI := body.ImageURI
+	if body.Code.ImageURI != "" {
+		imageURI = body.Code.ImageURI
+	}
+	if imageURI != "" && body.PackageType == "" {
+		// "PackageType: Image" is required alongside an ImageUri, and real Lambda
+		// rejects the pair with Zip, so an unstated package type cannot conflict.
+		pkgType = "Image"
+	}
 	archs := body.Architectures
 	if len(archs) == 0 {
 		archs = []string{"x86_64"}
@@ -303,7 +318,7 @@ func (p *LambdaPlugin) createFunction(ctx *RequestContext, req *AWSRequest) (*AW
 		PackageType:   pkgType,
 		Architectures: archs,
 		Tags:          body.Tags,
-		ImageURI:      body.ImageURI,
+		ImageURI:      imageURI,
 		LastModified:  now,
 		CreateDate:    now,
 	}
@@ -313,9 +328,21 @@ func (p *LambdaPlugin) createFunction(ctx *RequestContext, req *AWSRequest) (*AW
 		decoded, decErr := base64.StdEncoding.DecodeString(body.Code.ZipFile)
 		if decErr == nil && len(decoded) > 0 {
 			fn.CodeSize = int64(len(decoded))
+			fn.CodeSha256 = lambdaCodeSha256(decoded)
 			fn.ZipStored = true
 			_ = p.state.Put(context.Background(), lambdaNamespace, "function_zip:"+body.FunctionName, decoded)
 		}
+	} else if body.Code.S3Bucket != "" {
+		// The bytes are not staged for execution — that is what ZipStored records and
+		// it stays false — but the object is usually in substrate's own S3, so its
+		// length is knowable even though the package is not fetched.
+		fn.CodeSize, fn.CodeSha256 = p.sizeS3Package(body.Code.S3Bucket, body.Code.S3Key, body.Code.S3ObjectVersion)
+	} else if imageURI != "" {
+		// The same rule UpdateFunctionCode applies: an image function's package is the
+		// image, so its digest tracks the URI. Reporting one here and only there would
+		// mean a function created from an image had no digest until it was updated,
+		// which is a difference between two paths a caller cannot see a reason for.
+		fn.CodeSha256 = lambdaCodeSha256([]byte(imageURI))
 	}
 
 	data, err := json.Marshal(fn)
@@ -341,19 +368,35 @@ func (p *LambdaPlugin) getFunction(_ *RequestContext, name string) (*AWSResponse
 	}
 
 	type codeLocation struct {
-		RepositoryType string `json:"RepositoryType"`
-		Location       string `json:"Location"`
+		RepositoryType   string `json:"RepositoryType"`
+		Location         string `json:"Location,omitempty"`
+		ImageURI         string `json:"ImageUri,omitempty"`
+		ResolvedImageURI string `json:"ResolvedImageUri,omitempty"`
 	}
 	type response struct {
 		Configuration interface{}  `json:"Configuration"`
 		Code          codeLocation `json:"Code"`
 	}
+	// FunctionCodeLocation reports "the service that's hosting the file", so an
+	// image-packaged function is hosted by ECR and reports ImageUri rather than a
+	// presigned Location — reporting an S3 URL for one is a claim a caller can act
+	// on and be wrong about. A function created with a Code.ImageUri had nowhere to
+	// surface it before, so the deployer forwarding one would otherwise have been a
+	// write with no observable.
+	loc := codeLocation{
+		RepositoryType: "S3",
+		Location:       "https://lambda-stub.localhost/code/" + name,
+	}
+	if fn.PackageType == "Image" && fn.ImageURI != "" {
+		loc = codeLocation{
+			RepositoryType:   "ECR",
+			ImageURI:         fn.ImageURI,
+			ResolvedImageURI: fn.ImageURI,
+		}
+	}
 	return lambdaJSONResponse(http.StatusOK, response{
 		Configuration: buildFunctionConfig(fn),
-		Code: codeLocation{
-			RepositoryType: "S3",
-			Location:       "https://lambda-stub.localhost/code/" + name,
-		},
+		Code:          loc,
 	})
 }
 
@@ -364,34 +407,48 @@ func (p *LambdaPlugin) updateFunctionCode(_ *RequestContext, req *AWSRequest, na
 	}
 
 	var body struct {
-		ZipFile  string `json:"ZipFile"`
-		S3Bucket string `json:"S3Bucket"`
-		S3Key    string `json:"S3Key"`
-		ImageURI string `json:"ImageUri"`
+		ZipFile         string `json:"ZipFile"`
+		S3Bucket        string `json:"S3Bucket"`
+		S3Key           string `json:"S3Key"`
+		S3ObjectVersion string `json:"S3ObjectVersion"`
+		ImageURI        string `json:"ImageUri"`
 	}
 	_ = json.Unmarshal(req.Body, &body)
 
-	fn.CodeSha256 = generateLambdaRevisionID()
+	// CodeSha256 is "the SHA256 hash of the function's deployment package", so it is
+	// derived from the package below when there are bytes to hash rather than being a
+	// fresh random value on every update — a caller comparing it across two updates
+	// is asking whether the code changed, and a random value answers "always". A
+	// RevisionID is not a digest of anything and stays random.
 	fn.RevisionID = generateLambdaRevisionID()
 	fn.LastModified = p.tc.Now()
 
-	if body.ZipFile != "" {
+	switch {
+	case body.ZipFile != "":
 		decoded, decErr := base64.StdEncoding.DecodeString(body.ZipFile)
 		if decErr == nil && len(decoded) > 0 {
 			fn.CodeSize = int64(len(decoded))
+			fn.CodeSha256 = lambdaCodeSha256(decoded)
 			fn.ZipStored = true
 			_ = p.state.Put(context.Background(), lambdaNamespace, "function_zip:"+name, decoded)
 		}
-	} else if body.S3Bucket != "" {
-		// S3-sourced ZIP — we don't have the bytes; log and continue.
-		p.logger.Warn("lambda updateFunctionCode: S3 source not fetched; Docker execution unavailable for this function",
-			"bucket", body.S3Bucket, "key", body.S3Key)
+	case body.S3Bucket != "":
+		// The bytes are not staged for execution — that is what ZipStored records and
+		// it stays false — but the object is usually in substrate's own S3, so its
+		// length is knowable even though the package is not fetched.
+		fn.CodeSize, fn.CodeSha256 = p.sizeS3Package(body.S3Bucket, body.S3Key, body.S3ObjectVersion)
 		fn.ZipStored = false
 	}
 
 	if body.ImageURI != "" {
 		fn.ImageURI = body.ImageURI
 		fn.PackageType = "Image"
+		// An image function's package is the image, so its digest tracks the URI: it
+		// changes when the function is pointed at a different image and not otherwise.
+		// Substrate never pulls the image, so this is not the digest real Lambda
+		// reports, for the same reason the S3 path reports an ETag — see
+		// docs/services.md.
+		fn.CodeSha256 = lambdaCodeSha256([]byte(body.ImageURI))
 	}
 
 	return p.saveFunctionAndRespond(fn, http.StatusOK)
@@ -965,6 +1022,60 @@ func (p *LambdaPlugin) autoCreateLambdaLogGroup(ctx *RequestContext, name string
 	}
 	idxKey := cwLogGroupNamesKey(ctx.AccountID, ctx.Region)
 	updateStringIndex(goCtx, p.state, cloudwatchLogsNamespace, idxKey, lgName)
+}
+
+// lambdaCodeSha256 reports the CodeSha256 for a deployment package: "the SHA256 hash
+// of the function's deployment package", base64-encoded as Lambda returns it.
+func lambdaCodeSha256(pkg []byte) string {
+	sum := sha256.Sum256(pkg)
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+// sizeS3Package reports the CodeSize and CodeSha256 of an S3-sourced deployment
+// package by reading the object's recorded metadata out of substrate's own S3 state.
+//
+// Lambda reports CodeSize as "the size of the function's deployment package, in
+// bytes", which for an S3 source is the length of the object — a fact substrate
+// already holds, since a template that references an object a test uploaded is the
+// ordinary case. Substrate does not fetch the bytes (nothing executes them unless
+// they arrived inline), so the digest comes from the object's own ETag rather than
+// from a hash of the package: for a single-part upload that ETag *is* the MD5 of the
+// body, which makes it change exactly when the package changes, which is the
+// question a caller comparing CodeSha256 across deploys is asking. It is not the
+// SHA256 real Lambda would report, and docs/services.md says so.
+//
+// An absent object is not an error. Real Lambda would refuse the create, but
+// substrate's S3 and Lambda namespaces are independent and a template may
+// legitimately name an object a test never uploaded — failing the create would make
+// a stack undeployable for a reason unrelated to what the test is checking. It logs
+// and reports size 0, which is what the function did for every S3 source before.
+func (p *LambdaPlugin) sizeS3Package(bucket, key, versionID string) (int64, string) {
+	stateKey := "object:" + bucket + "/" + key
+	if versionID != "" {
+		stateKey = "object_version:" + bucket + "/" + key + "/" + versionID
+	}
+	data, err := p.state.Get(context.Background(), s3Namespace, stateKey)
+	if err != nil || data == nil {
+		p.logger.Warn("lambda: S3 deployment package not found in substrate's S3 state; "+
+			"reporting CodeSize 0 and no execution package",
+			"bucket", bucket, "key", key, "versionId", versionID)
+		return 0, ""
+	}
+	var obj S3Object
+	if err := json.Unmarshal(data, &obj); err != nil {
+		p.logger.Warn("lambda: S3 deployment package metadata is unreadable; reporting CodeSize 0",
+			"bucket", bucket, "key", key, "error", err)
+		return 0, ""
+	}
+	// A delete marker lives at the same key as the object it hides, so reading the
+	// record is not the same as the object being there. A deleted package is absent,
+	// not a zero-length one.
+	if obj.IsDeleteMarker {
+		p.logger.Warn("lambda: S3 deployment package is a delete marker; reporting CodeSize 0",
+			"bucket", bucket, "key", key)
+		return 0, ""
+	}
+	return obj.Size, strings.Trim(obj.ETag, `"`)
 }
 
 // generateLambdaRevisionID generates a unique revision/code ID.


### PR DESCRIPTION
Closes #545

`CodeSize` was `0` and `CodeSha256` empty for every function whose code did not arrive as an inline base64 `ZipFile` on a direct `CreateFunction`. A consumer polling `CodeSize` to decide whether a deploy took effect was told nothing had, whatever it deployed — this release's shape: a request accepted, answered `200`, producing no effect a caller can observe.

## The issue's premise was confounded, and correcting it doubled the change

It was filed as a CloudFormation problem. Measuring all four combinations against v0.89.0 showed the axis is **inline vs. S3 source**, not CFN vs. direct:

| | inline `ZipFile` | S3 source |
|---|---|---|
| direct `CreateFunction` | **156** (correct) | **0** |
| CloudFormation | **0** | **0** |

CFN + inline is the row the report never tested, and the one that proves there were two independent gaps rather than one.

## CloudFormation sent no `Code` at all

`deployLambdaFunction` built a `CreateFunction` body carrying `FunctionName`, `Runtime`, `Role`, `Handler`, `Description`, `Timeout` and `MemorySize` and no `Code` key of any kind. So every CFN-deployed function reported size 0 and an empty digest however its template declared its code, a container-image function lost both its image and its `PackageType`, and `UpdateFunctionCode` drift was undetectable. All of `ZipFile`, `S3Bucket`, `S3Key`, `S3ObjectVersion` and `ImageUri` are now forwarded, each through the template's `Ref` and pseudo-parameter resolution like any other property.

## An inline template needed more than forwarding

The resource type's `Code.ZipFile` is "the source code of your Lambda function" — "CloudFormation places it in a file named `index` and zips it to create a deployment package" — while the API's `Code.ZipFile` is "the base64-encoded contents of the deployment package". Forwarding the template's string would have handed Lambda something that is not a package and usually not valid base64, leaving `CodeSize` at 0 exactly as before. Substrate now builds the archive CloudFormation would have built: one entry named `index` with the extension the runtime reads (`.js` for `nodejs*` per the reference, `.py` for `python*`, bare `index` otherwise), carrying no timestamps so the same template deployed twice yields the same package and the same digest. A digest that moved on every deploy would not be worth comparing.

## An S3-sourced package is sized, and the digest stopped being random

Both `createFunction` and `updateFunctionCode` read the object's recorded length out of substrate's own S3 state, honouring `S3ObjectVersion`. `ZipStored` stays `false` — the bytes are still not staged for execution, which is a separate and correct fact from knowing the size.

`UpdateFunctionCode` assigned `CodeSha256` a fresh random value on every call, so a caller asking "did the code change?" was always told yes. The digest is now derived from the package, an update carrying no package changes neither size nor digest, and an image function's digest tracks its URI from creation rather than only after the first update. `RevisionId` is not a digest of anything and still advances on every call.

## Substrate's own decisions

Two, both stated in `docs/services.md`:

- **An S3-sourced package's digest is the object's ETag**, not a SHA256. Substrate never fetches the bytes; for a single-part upload the ETag is the MD5 of the body, so it changes exactly when the package changes — the question a caller comparing digests is actually asking.
- **An absent S3 object does not fail the create** the way real Lambda would. Substrate's S3 and Lambda state are independent and a template may legitimately name an object a test never uploaded, so it logs and reports size 0. A deleted object — one hidden by a delete marker — counts as absent rather than as a zero-length package.

## Two adjacent gaps, fixed with it

Leaving either would have kept a write with no observable. `Code.ImageUri`, the documented spelling, was accepted only at the top level; it now wins over the legacy field and infers `PackageType: Image`. And `GetFunction` reported `RepositoryType: S3` with a stub presigned URL for an image-packaged function — a claim a caller can act on and be wrong about — and now reports `RepositoryType: ECR` with `ImageUri`/`ResolvedImageUri` and no `Location`.

## Tests

16 tests in `emulator/lambda_code_size_test.go`, asserting on the JSON `GetFunction` returns rather than on the state record, since `CodeSize` is only interesting as an observation a caller makes. **With the two source files stashed, 12 fail**; the 3 that pass are the deliberate no-regression guards (absent object, CFN absent object, CFN with no `Code`).

**Mutation testing: 21 mutants, 21 CAUGHT, 0 survivors**, including the plan's named mutant (`Code` forwarded for `ZipFile` but not for `S3Bucket`), the deployer not calling the `Code` helper at all (the exact pre-fix state), inline code forwarded unzipped, the entry name ignoring the runtime, a nondeterministic archive, the S3 sizing removed from create and from update, `S3ObjectVersion` ignored, an absent object reporting a size, the ETag not de-quoted, a delete marker read as an object, and four on the image path.

Three mutants were informative rather than merely caught:

- `Deflate → Store` **survived and is a genuine equivalent** — the compression method is unconstrained; only the bytes' determinism is.
- `hdr.Modified = time.Now()` **survived** because ZIP stores mtime at two-second granularity, so both deploys in a test land in the same slot. Rewritten to put the nondeterminism in the payload → CAUGHT.
- Randomising the update digest **survived and was a real gap**: it exposed that an `ImageUri` update left `CodeSha256` untouched. Fixed in the plugin; the mutant and two new ones now fail.

The image *create* path reporting no digest was found by the live e2e below, not by the tests, and is covered by a new mutant (M21).

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race) green, `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test -C test/e2e ./...` all pass.

Live, against `substrate server`:

```
cfn-s3      : 156  (was 0)
cfn-inline  : 189  (was 0)
direct-s3   : 156  63c06d925da678da514971ea76cc81a1
missing-s3  : 0    (empty digest, create still succeeds)
img-fn      : Image  Ag8hBGe6jxmsncGBq/TAoOzxwcbYdPXFmQdwPiTnB58=
              Code: {"RepositoryType":"ECR","ImageUri":…,"ResolvedImageUri":…}
```

## Compatibility

A test asserting that `CodeSize` is `0`, that `CodeSha256` is empty, or that `CodeSha256` changes on every `UpdateFunctionCode` will go red. That is the fix. A test asserting `RepositoryType: S3` for an image-packaged function will also go red.
