### PR TITLE
fix(ec2): parse every network interface a launch declares (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   does not describe the extent of a part.
 
 ### Fixed
+- **Every network interface a launch declares is parsed and reported** (#455).
+  `NetworkInterface.N.*` was read for **N=1 only**, in both `runInstances` and
+  `createLaunchTemplate`, and `EC2Instance` had no interface list to hold a second
+  one — so a launch or a template declaring two interfaces was answered `200` and
+  quietly became a one-interface instance, with no error and nothing in the response
+  to reveal the loss.
+
+  Both sites now parse all N, following the same convention every other indexed list
+  in the plugin follows: contiguously from 1, stopping at the first missing index.
+  **Identity is keyed on `DeviceIndex`, not the parameter index** — the reference
+  defines `DeviceIndex` as the position in the attachment order and does not require
+  it to agree with the position the request writes the interface at, so
+  `NetworkInterface.1.DeviceIndex=3` with `NetworkInterface.2.DeviceIndex=0` makes the
+  *second* one primary. An implementation that used the parameter index would name the
+  wrong interface primary and put the wrong subnet on the instance.
+
+  `RunInstances` and `DescribeInstances` now both report `networkInterfaceSet>item` —
+  emitted because the `RunInstances` reference's own sample response carries it, so a
+  caller parsing the documented shape found a member missing. The instance's flat
+  `subnetId`, `privateIpAddress` and `groupSet` continue to describe the **primary**
+  interface, which is what real EC2 puts at the top level; they are not superseded by
+  the new set, and `AssociatePublicIpAddress` is still honored only on the primary, as
+  the reference requires ("can only be assigned to a network interface for eth0").
+
+  `DeleteOnTermination` defaults per the reference's reasoning rather than to a single
+  value: `true` for an interface the launch creates, `false` for an existing one it
+  attaches by `NetworkInterfaceId`, since deleting an interface the caller brought
+  would destroy something the launch did not make. An explicit value wins over either.
+
+  The state and template shapes both grew a slice, so both keep their flat fields as
+  the primary's values: an instance or a launch-template version stored by an earlier
+  substrate reads back with an empty slice, and the single-interface synthesis from
+  the flat fields still runs for it, so a replayed event log still describes
+  correctly. `docs/services.md` loses its "only interface index 1 is modeled" limit
+  and gains a section stating what substrate decides where the API model does not —
+  how a secondary interface's address is assigned, that there are no standalone ENI
+  resources so a launch declaring none reports an empty set rather than a phantom
+  interface, and that interfaces report `in-use`/`attached` immediately because
+  substrate's instances are already `running` when `RunInstances` answers.
 - **A Lambda function reports the size and digest of the package it was deployed
   from** (#545). `CodeSize` was `0` and `CodeSha256` empty for every function whose
   code did not arrive as an inline base64 `ZipFile` on a direct `CreateFunction` — so

--- a/docs/services.md
+++ b/docs/services.md
@@ -2254,7 +2254,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids) |
-| CreateLaunchTemplate | Creates version 1. Networking is read from `NetworkInterface.1.*` — see [Launch template networking](#launch-template-networking) |
+| CreateLaunchTemplate | Creates version 1. Networking is read from every `NetworkInterface.N.*` — see [Launch template networking](#launch-template-networking) |
 | DescribeLaunchTemplates | Summary only — no `launchTemplateData`, matching AWS. Use `DescribeLaunchTemplateVersions` to read a template's parameters |
 | DeleteLaunchTemplate | |
 | CreateLaunchTemplateVersion | `SourceVersion` inheritance — see [Launch template versions](#launch-template-versions) |
@@ -2442,12 +2442,12 @@ and still describes correctly. No event rewriting is involved.
 ### Launch template networking
 
 A launch template's subnet, security groups and public-IP preference are read from
-its **first network interface**:
+its **primary network interface** — the one whose `DeviceIndex` is lowest:
 
 ```
-LaunchTemplateData.NetworkInterface.1.SubnetId
-LaunchTemplateData.NetworkInterface.1.SecurityGroupId.N
-LaunchTemplateData.NetworkInterface.1.AssociatePublicIpAddress
+LaunchTemplateData.NetworkInterface.N.SubnetId
+LaunchTemplateData.NetworkInterface.N.SecurityGroupId.N
+LaunchTemplateData.NetworkInterface.N.AssociatePublicIpAddress
 ```
 
 That is not a stylistic choice. AWS's `RequestLaunchTemplateData` has **no
@@ -2464,7 +2464,7 @@ Precedence when the same value is available from several sources, matching AWS:
 
 | Source | Wins over |
 |---|---|
-| The request itself — `SubnetId`, or `NetworkInterface.1.SubnetId` | everything below |
+| The request itself — `SubnetId`, or the primary `NetworkInterface.N.SubnetId` | everything below |
 | A `CreateFleet` override's `SubnetId` | the template (it reaches `RunInstances` as a request-level value) |
 | The launch template's network interface | the default VPC |
 | The auto-created default VPC | — |
@@ -2473,8 +2473,10 @@ Precedence when the same value is available from several sources, matching AWS:
 `MapPublicIPOnLaunch` distinguishes them: **absent** uses the subnet's own
 behavior, **`true`** forces a public IP anyway, and **`false`** suppresses one.
 
-Only interface index **1** is modeled, on both `RunInstances` and launch templates.
-A template declaring a second interface loses it silently.
+Every declared interface is parsed, on both `RunInstances` and launch templates — see
+[Multiple network interfaces](#multiple-network-interfaces). The flat fields above
+describe the **primary** interface, which is what a launch from a multi-interface
+template resolves its subnet and groups from.
 
 ### Security groups on an instance
 
@@ -2484,7 +2486,8 @@ Both `RunInstances` and `DescribeInstances` report an instance's security groups
 source supplied them:
 
 - `SecurityGroupId.N` (or `SecurityGroupIds.N`) on the request, or the nested
-  `NetworkInterface.1.SecurityGroupId.N` / `NetworkInterface.1.Groups.N`.
+  `NetworkInterface.N.SecurityGroupId.N` / `NetworkInterface.N.Groups.N` of the
+  **primary** interface.
 - The launch template's [network interface](#launch-template-networking).
 - The auto-created default VPC's `default` group, when the launch names none.
 
@@ -2492,6 +2495,69 @@ source supplied them:
 the group is deleted while the instance it was launched with still exists. The
 `groupId` is still reported, because that is what the launch actually recorded; a
 name is not invented to fill the field.
+
+The top-level `groupSet` reports the **primary** interface's groups, matching AWS.
+A secondary interface's own groups appear on that interface inside
+[`networkInterfaceSet`](#multiple-network-interfaces).
+
+### Multiple network interfaces
+
+`RunInstances` and `CreateLaunchTemplate` parse **every** declared
+`NetworkInterface.N.*`, contiguously from 1 and stopping at the first missing
+index — the same convention every other indexed list follows. Both `RunInstances`
+and `DescribeInstances` report them as `networkInterfaceSet>item`, which is what
+the `RunInstances` reference's own sample response shows:
+
+```xml
+<networkInterfaceSet>
+  <item>
+    <networkInterfaceId>eni-1a2b3c4d</networkInterfaceId>
+    <subnetId>subnet-0123456789abcdef0</subnetId>
+    <status>in-use</status>
+    <privateIpAddress>172.31.1.10</privateIpAddress>
+    <groupSet><item><groupId>sg-…</groupId><groupName>default</groupName></item></groupSet>
+    <attachment>
+      <deviceIndex>0</deviceIndex>
+      <status>attached</status>
+      <deleteOnTermination>true</deleteOnTermination>
+    </attachment>
+  </item>
+</networkInterfaceSet>
+```
+
+**Identity is `DeviceIndex`, not the parameter index.** AWS documents
+`DeviceIndex` as "the position of the network interface in the attachment order",
+and it is not required to agree with the position the request happens to write it
+at, so `NetworkInterface.1.DeviceIndex=3` and `NetworkInterface.2.DeviceIndex=0`
+makes the *second* one primary. Interfaces are reported in `DeviceIndex` order.
+
+The instance's flat `subnetId`, `privateIpAddress` and `groupSet` describe the
+**primary** interface, as real EC2 does — they are not superseded by the set.
+`AssociatePublicIpAddress` is honored **only on the primary**, which is what the
+reference requires: it "can only be assigned to a network interface for eth0".
+
+`DeleteOnTermination` defaults to `true` for an interface the launch creates and
+`false` for an existing one it attaches by `NetworkInterfaceId` — deleting an
+interface the caller brought would destroy something the launch did not make. An
+explicit value wins over either default.
+
+Substrate's own choices, where the API model does not decide:
+
+- A **secondary** interface that names no `PrivateIpAddress` is given one derived
+  from its instance index and device index, so every interface of every instance
+  in a multi-`Count` launch has a distinct address a test can assert on. The
+  primary's address is the instance's own.
+- There are **no standalone ENI resources** — `CreateNetworkInterface` is not
+  modeled, so an interface exists only as part of the instance that declared it,
+  and an `eni-` ID is minted for one the request did not name. A launch declaring
+  no interface reports an empty `networkInterfaceSet` rather than a synthesized
+  phantom interface.
+- Interfaces report `status: in-use` and attachment `status: attached`
+  immediately, because substrate's instances are already `running` by the time
+  `RunInstances` answers; an `attaching` attachment would contradict the instance
+  state reported beside it.
+- `InterfaceType` defaults to `interface`; `efa` and `efa-only` are recorded as
+  given. `NetworkCardIndex` is recorded as given and defaults to 0.
 
 ### Instance attributes
 

--- a/emulator/ec2_launchtemplate_versions.go
+++ b/emulator/ec2_launchtemplate_versions.go
@@ -142,6 +142,12 @@ type ec2LTVersionNetIfcXML struct {
 	SubnetID                 string   `xml:"subnetId,omitempty"`
 	AssociatePublicIPAddress string   `xml:"associatePublicIpAddress,omitempty"`
 	Groups                   []string `xml:"groupSet>item,omitempty"`
+	NetworkInterfaceID       string   `xml:"networkInterfaceId,omitempty"`
+	PrivateIPAddress         string   `xml:"privateIpAddress,omitempty"`
+	Description              string   `xml:"description,omitempty"`
+	InterfaceType            string   `xml:"interfaceType,omitempty"`
+	NetworkCardIndex         int      `xml:"networkCardIndex,omitempty"`
+	DeleteOnTermination      bool     `xml:"deleteOnTermination"`
 }
 
 // ec2LTVersionProfileXML is a version's LaunchTemplateIamInstanceProfileSpecification,
@@ -188,14 +194,35 @@ func ec2LTVersionData(d EC2LaunchTemplateData) ec2LTVersionDataXML {
 		}
 		out.TagSpecifications = []ec2LTVersionTagSpecXML{spec}
 	}
-	// Emit an interface only when the template actually named one, so a template
-	// carrying no networking does not read back with a phantom eth0.
-	if d.SubnetID != "" || d.AssociatePublicIPAddress != "" || len(d.NetworkInterfaceGroups) > 0 {
+	// Every interface the template declared reads back, not just the primary (#455).
+	//
+	// The flat-field fallback below is what a template stored before the slice existed
+	// carries, so a replayed event log still reports its networking rather than
+	// nothing. Either way an interface is emitted only when the template actually
+	// named one, so a template carrying no networking does not read back with a
+	// phantom eth0.
+	for _, ifc := range d.NetworkInterfaces {
+		out.NetworkInterfaces = append(out.NetworkInterfaces, ec2LTVersionNetIfcXML{
+			DeviceIndex:              ifc.DeviceIndex,
+			SubnetID:                 ifc.SubnetID,
+			AssociatePublicIPAddress: ifc.AssociatePublicIPAddress,
+			Groups:                   ifc.SecurityGroupIDs,
+			NetworkInterfaceID:       ifc.NetworkInterfaceID,
+			PrivateIPAddress:         ifc.PrivateIPAddress,
+			Description:              ifc.Description,
+			InterfaceType:            ifc.InterfaceType,
+			NetworkCardIndex:         ifc.NetworkCardIndex,
+			DeleteOnTermination:      ifc.DeleteOnTermination,
+		})
+	}
+	if len(out.NetworkInterfaces) == 0 &&
+		(d.SubnetID != "" || d.AssociatePublicIPAddress != "" || len(d.NetworkInterfaceGroups) > 0) {
 		out.NetworkInterfaces = []ec2LTVersionNetIfcXML{{
 			DeviceIndex:              0,
 			SubnetID:                 d.SubnetID,
 			AssociatePublicIPAddress: d.AssociatePublicIPAddress,
 			Groups:                   d.NetworkInterfaceGroups,
+			DeleteOnTermination:      true,
 		}}
 	}
 	return out

--- a/emulator/ec2_network_interfaces.go
+++ b/emulator/ec2_network_interfaces.go
@@ -1,0 +1,164 @@
+package emulator
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ec2ParseNetworkInterfaces collects every NetworkInterface.N specification under
+// prefix, contiguously from N=1 and stopping at the first index that names nothing.
+//
+// prefix is "" for a RunInstances request and "LaunchTemplateData." for a template's,
+// so both paths parse the same shape by the same rules rather than by two hand-rolled
+// readers that can drift — which is how index 1 came to be the only one either of
+// them read (#455).
+//
+// The contiguous-from-1 rule is [indexedParams]' convention, extended from a string
+// per index to a struct per index. An index is "present" when *any* of its members
+// is, not when a particular one is: a specification naming only DeviceIndex and
+// SubnetId is as real as one naming ten members, and requiring a chosen member would
+// silently drop an interface for spelling reasons.
+func ec2ParseNetworkInterfaces(params map[string]string, prefix string) []EC2NetworkInterface {
+	var out []EC2NetworkInterface
+	for n := 1; ; n++ {
+		p := fmt.Sprintf("%sNetworkInterface.%d.", prefix, n)
+		ifc, present := ec2ParseNetworkInterface(params, p)
+		if !present {
+			return out
+		}
+		out = append(out, ifc)
+	}
+}
+
+// ec2ParseNetworkInterface reads one interface's members from the parameters under
+// p, reporting whether the index was present at all.
+//
+// DeviceIndex is parsed rather than taken from the parameter index. AWS documents it
+// as "the position of the network interface in the attachment order", and the two
+// indices need not agree — NetworkInterface.1 may declare DeviceIndex 3. Using the
+// parameter index would make a launch whose interfaces are listed out of order
+// report the wrong primary, and the primary is what an instance's top-level
+// subnetId, privateIpAddress and groupSet describe.
+//
+// An unparseable or absent DeviceIndex reads as 0. AWS documents it as required when
+// a network interface is specified, but substrate does not refuse the launch: a
+// specification naming a subnet and no device index is unambiguous about the subnet,
+// and failing it would reject a hand-built request over a value substrate can infer.
+func ec2ParseNetworkInterface(params map[string]string, p string) (EC2NetworkInterface, bool) {
+	groups := indexedParams(params, p+"SecurityGroupId.%d", p+"Groups.%d")
+	ifc := EC2NetworkInterface{
+		NetworkInterfaceID:       params[p+"NetworkInterfaceId"],
+		SubnetID:                 params[p+"SubnetId"],
+		PrivateIPAddress:         params[p+"PrivateIpAddress"],
+		SecurityGroupIDs:         groups,
+		AssociatePublicIPAddress: params[p+"AssociatePublicIpAddress"],
+		Description:              params[p+"Description"],
+		InterfaceType:            params[p+"InterfaceType"],
+	}
+	deviceIndex, hasDeviceIndex := params[p+"DeviceIndex"]
+	if n, err := strconv.Atoi(strings.TrimSpace(deviceIndex)); err == nil {
+		ifc.DeviceIndex = n
+	}
+	if n, err := strconv.Atoi(strings.TrimSpace(params[p+"NetworkCardIndex"])); err == nil {
+		ifc.NetworkCardIndex = n
+	}
+	// AWS defaults DeleteOnTermination to true for an interface the launch creates
+	// and false for an existing one it attaches, since deleting an interface the
+	// caller brought would destroy something the launch did not make. An explicit
+	// value wins over both.
+	ifc.DeleteOnTermination = ifc.NetworkInterfaceID == ""
+	if v, ok := params[p+"DeleteOnTermination"]; ok && v != "" {
+		ifc.DeleteOnTermination = strings.EqualFold(v, "true")
+	}
+
+	present := hasDeviceIndex || ifc.NetworkInterfaceID != "" || ifc.SubnetID != "" ||
+		ifc.PrivateIPAddress != "" || len(groups) > 0 ||
+		ifc.AssociatePublicIPAddress != "" || ifc.Description != "" ||
+		ifc.InterfaceType != "" || params[p+"NetworkCardIndex"] != "" ||
+		params[p+"DeleteOnTermination"] != ""
+	return ifc, present
+}
+
+// ec2PrimaryInterface reports the interface an instance's top-level networking
+// describes: the one at DeviceIndex 0, or the lowest device index when a launch
+// declared no interface at index 0.
+//
+// The fallback matters because DeviceIndex defaults to 0 here rather than being
+// required, so "no interface at 0" means the caller numbered them from 1 — in which
+// case the lowest is the one attached first, which is what "primary" means.
+func ec2PrimaryInterface(interfaces []EC2NetworkInterface) *EC2NetworkInterface {
+	var primary *EC2NetworkInterface
+	for i := range interfaces {
+		if primary == nil || interfaces[i].DeviceIndex < primary.DeviceIndex {
+			primary = &interfaces[i]
+		}
+	}
+	return primary
+}
+
+// ec2AttachInterfaces records the launch's interfaces on inst, filling in what the
+// request left to EC2: an interface ID, a private address, and a private DNS name.
+//
+// instanceIndex distinguishes the instances of a multi-count launch, so two instances
+// from one RunInstances call do not report the same secondary addresses. AWS refuses a
+// launch that names a PrivateIpAddress with a count above one for exactly this
+// reason; substrate does not refuse it, so it has to make the addresses differ.
+//
+// The primary interface takes the instance's own address and DNS name rather than a
+// separately generated one: they describe the same interface, and letting them differ
+// would mean an instance whose top-level privateIpAddress is not the address of any
+// interface it has.
+func (p *EC2Plugin) ec2AttachInterfaces(inst *EC2Instance, declared []EC2NetworkInterface, instanceIndex int, region string) {
+	if len(declared) == 0 {
+		return
+	}
+	interfaces := make([]EC2NetworkInterface, 0, len(declared))
+	primary := ec2PrimaryInterface(declared)
+	for n := range declared {
+		ifc := declared[n]
+		ifc.SecurityGroupIDs = filterEmpty(ifc.SecurityGroupIDs)
+		if ifc.NetworkInterfaceID == "" {
+			ifc.NetworkInterfaceID = generateENIID()
+		}
+		if ifc.InterfaceType == "" {
+			ifc.InterfaceType = "interface"
+		}
+		switch {
+		case primary != nil && ifc.DeviceIndex == primary.DeviceIndex:
+			ifc.SubnetID = inst.SubnetID
+			ifc.PrivateIPAddress = inst.PrivateIPAddress
+			ifc.PrivateDNSName = inst.PrivateDNSName
+			if len(ifc.SecurityGroupIDs) == 0 {
+				ifc.SecurityGroupIDs = inst.SecurityGroupIDs
+			}
+		case ifc.PrivateIPAddress == "":
+			// A secondary interface's address comes from the same 172.31.0.0/16 space
+			// the instance's does, offset by its device index so the addresses within
+			// one instance are distinct and stable across a replay.
+			ifc.PrivateIPAddress = fmt.Sprintf("172.31.%d.%d",
+				instanceIndex+1, 10+instanceIndex+ifc.DeviceIndex*10)
+		}
+		if ifc.PrivateDNSName == "" && ifc.PrivateIPAddress != "" {
+			ifc.PrivateDNSName = ec2PrivateDNSName(ifc.PrivateIPAddress, region)
+		}
+		interfaces = append(interfaces, ifc)
+	}
+	inst.NetworkInterfaces = interfaces
+}
+
+// ec2SortInterfacesByDeviceIndex orders interfaces by device index, which is the
+// order AWS reports them in and the order that puts the primary first.
+//
+// An insertion sort rather than sort.Slice: the list is at most a handful of entries,
+// and this keeps two interfaces declaring the same device index in the order the
+// request listed them. AWS rejects that duplicate; substrate does not, and a stable
+// order means a caller reading such a launch back sees something reproducible rather
+// than whichever order the sort happened to produce.
+func ec2SortInterfacesByDeviceIndex(interfaces []EC2NetworkInterface) {
+	for i := 1; i < len(interfaces); i++ {
+		for j := i; j > 0 && interfaces[j].DeviceIndex < interfaces[j-1].DeviceIndex; j-- {
+			interfaces[j], interfaces[j-1] = interfaces[j-1], interfaces[j]
+		}
+	}
+}

--- a/emulator/ec2_network_interfaces_test.go
+++ b/emulator/ec2_network_interfaces_test.go
@@ -1,0 +1,728 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests below cover #455: every NetworkInterface.N a launch declares is parsed,
+// not only index 1.
+//
+// They assert on the wire XML rather than on the stored record. An interface substrate
+// parses and stores but does not report is a write with no observable, which is the
+// defect shape this release is about — and `networkInterfaceSet` is the observation
+// AWS's own RunInstances sample response carries.
+
+// niInstance is the part of an instance item these tests read.
+type niInstance struct {
+	InstanceID       string `xml:"instanceId"`
+	SubnetID         string `xml:"subnetId"`
+	PrivateIPAddress string `xml:"privateIpAddress"`
+	PublicIPAddress  string `xml:"publicIpAddress"`
+	Groups           []struct {
+		GroupID string `xml:"groupId"`
+	} `xml:"groupSet>item"`
+	Interfaces []niInterface `xml:"networkInterfaceSet>item"`
+}
+
+// niInterface is one networkInterfaceSet>item.
+type niInterface struct {
+	NetworkInterfaceID string `xml:"networkInterfaceId"`
+	SubnetID           string `xml:"subnetId"`
+	VpcID              string `xml:"vpcId"`
+	Description        string `xml:"description"`
+	OwnerID            string `xml:"ownerId"`
+	Status             string `xml:"status"`
+	PrivateIPAddress   string `xml:"privateIpAddress"`
+	PrivateDNSName     string `xml:"privateDnsName"`
+	InterfaceType      string `xml:"interfaceType"`
+	Groups             []struct {
+		GroupID string `xml:"groupId"`
+	} `xml:"groupSet>item"`
+	Attachment struct {
+		DeviceIndex         int    `xml:"deviceIndex"`
+		Status              string `xml:"status"`
+		DeleteOnTermination bool   `xml:"deleteOnTermination"`
+		NetworkCardIndex    int    `xml:"networkCardIndex"`
+	} `xml:"attachment"`
+	PrivateIPAddresses []struct {
+		PrivateIPAddress string `xml:"privateIpAddress"`
+		Primary          bool   `xml:"primary"`
+	} `xml:"privateIpAddressesSet>item"`
+}
+
+// niRun launches instances and returns the RunInstances response's instance items.
+func niRun(t *testing.T, ts *httptest.Server, params map[string]string) []niInstance {
+	t.Helper()
+	full := map[string]string{
+		"Action":   "RunInstances",
+		"ImageId":  "ami-12345678",
+		"MinCount": "1",
+		"MaxCount": "1",
+	}
+	for k, v := range params {
+		full[k] = v
+	}
+	resp := ec2Request(t, ts, full)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "RunInstances")
+	var out struct {
+		XMLName   xml.Name     `xml:"RunInstancesResponse"`
+		Instances []niInstance `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	return out.Instances
+}
+
+// niDescribe reads one instance back through DescribeInstances.
+func niDescribe(t *testing.T, ts *httptest.Server, instanceID string) niInstance {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":       "DescribeInstances",
+		"InstanceId.1": instanceID,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, "DescribeInstances")
+	var out struct {
+		XMLName      xml.Name `xml:"DescribeInstancesResponse"`
+		Reservations []struct {
+			Instances []niInstance `xml:"instancesSet>item"`
+		} `xml:"reservationSet>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&out))
+	require.Len(t, out.Reservations, 1)
+	require.Len(t, out.Reservations[0].Instances, 1)
+	return out.Reservations[0].Instances[0]
+}
+
+// niSubnets creates a VPC with two subnets and a security group in each, so a
+// two-interface launch has somewhere real to attach.
+//
+// Security groups are validated against the target subnet's VPC, so both subnets
+// share one VPC: a launch whose interfaces name subnets in different VPCs is not
+// something AWS allows either.
+func niSubnets(t *testing.T, ts *httptest.Server) (subnetA, subnetB, groupA, groupB string) {
+	t.Helper()
+	vpc := niCreate(t, ts, map[string]string{
+		"Action": "CreateVpc", "CidrBlock": "10.0.0.0/16",
+	}, "CreateVpcResponse", "vpc>vpcId")
+	subnetA = niCreate(t, ts, map[string]string{
+		"Action": "CreateSubnet", "VpcId": vpc, "CidrBlock": "10.0.1.0/24",
+	}, "CreateSubnetResponse", "subnet>subnetId")
+	subnetB = niCreate(t, ts, map[string]string{
+		"Action": "CreateSubnet", "VpcId": vpc, "CidrBlock": "10.0.2.0/24",
+	}, "CreateSubnetResponse", "subnet>subnetId")
+	groupA = niCreate(t, ts, map[string]string{
+		"Action": "CreateSecurityGroup", "VpcId": vpc,
+		"GroupName": "sg-a", "GroupDescription": "a",
+	}, "CreateSecurityGroupResponse", "groupId")
+	groupB = niCreate(t, ts, map[string]string{
+		"Action": "CreateSecurityGroup", "VpcId": vpc,
+		"GroupName": "sg-b", "GroupDescription": "b",
+	}, "CreateSecurityGroupResponse", "groupId")
+	return subnetA, subnetB, groupA, groupB
+}
+
+// niCreate sends a create request and pulls one element out of its response.
+func niCreate(t *testing.T, ts *httptest.Server, params map[string]string, root, path string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode, params["Action"])
+	var id string
+	require.NoError(t, niDecodePath(xml.NewDecoder(resp.Body), root, path, &id))
+	require.NotEmpty(t, id, "%s returned no id at %s", params["Action"], path)
+	return id
+}
+
+// niDecodePath walks an XML document to a slash-separated element path and returns
+// that element's character data.
+//
+// Hand-written rather than done with struct tags because the path differs per action
+// and a tag cannot be built at run time. It is deliberately shallow: it matches the
+// first element at each level, which is all these single-resource create responses
+// contain.
+func niDecodePath(dec *xml.Decoder, root, path string, out *string) error {
+	want := append([]string{root}, niSplit(path)...)
+	depth := 0
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if depth < len(want) && start.Name.Local == want[depth] {
+			depth++
+			if depth == len(want) {
+				return dec.DecodeElement(out, &start)
+			}
+		}
+	}
+}
+
+// niSplit splits a slash-separated element path.
+func niSplit(path string) []string {
+	var out []string
+	current := ""
+	for _, r := range path {
+		if r == '>' {
+			out = append(out, current)
+			current = ""
+			continue
+		}
+		current += string(r)
+	}
+	return append(out, current)
+}
+
+// TestEC2NetworkInterfaces_TwoInterfacesBothReported is #455's headline: a launch
+// declaring two interfaces reports two, where it reported one.
+func TestEC2NetworkInterfaces_TwoInterfacesBothReported(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, groupA, groupB := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex":         "0",
+		"NetworkInterface.1.SubnetId":            subnetA,
+		"NetworkInterface.1.SecurityGroupId.1":   groupA,
+		"NetworkInterface.2.DeviceIndex":         "1",
+		"NetworkInterface.2.SubnetId":            subnetB,
+		"NetworkInterface.2.SecurityGroupId.1":   groupB,
+		"NetworkInterface.2.Description":         "secondary",
+		"NetworkInterface.2.DeleteOnTermination": "false",
+	})
+	require.Len(t, instances, 1)
+	inst := instances[0]
+
+	require.Len(t, inst.Interfaces, 2,
+		"both declared interfaces are reported; one is the pre-fix behavior")
+
+	// The primary's values are the instance's top-level ones, which is what real EC2
+	// puts there — the secondary must not displace them.
+	assert.Equal(t, subnetA, inst.SubnetID,
+		"the instance's subnetId is the primary interface's")
+	require.Len(t, inst.Groups, 1)
+	assert.Equal(t, groupA, inst.Groups[0].GroupID,
+		"the instance's groupSet is the primary interface's")
+
+	primary, secondary := inst.Interfaces[0], inst.Interfaces[1]
+	assert.Equal(t, 0, primary.Attachment.DeviceIndex)
+	assert.Equal(t, subnetA, primary.SubnetID)
+	assert.Equal(t, inst.PrivateIPAddress, primary.PrivateIPAddress,
+		"the primary interface's address is the instance's, not a second one")
+	require.Len(t, primary.Groups, 1)
+	assert.Equal(t, groupA, primary.Groups[0].GroupID)
+	assert.True(t, primary.Attachment.DeleteOnTermination,
+		"an interface the launch creates defaults to delete-on-termination")
+
+	assert.Equal(t, 1, secondary.Attachment.DeviceIndex)
+	assert.Equal(t, subnetB, secondary.SubnetID)
+	require.Len(t, secondary.Groups, 1)
+	assert.Equal(t, groupB, secondary.Groups[0].GroupID,
+		"the secondary keeps its own groups rather than inheriting the primary's")
+	assert.Equal(t, "secondary", secondary.Description)
+	assert.False(t, secondary.Attachment.DeleteOnTermination,
+		"an explicit DeleteOnTermination=false wins over the default")
+	assert.NotEqual(t, primary.PrivateIPAddress, secondary.PrivateIPAddress,
+		"two interfaces on one instance have distinct addresses")
+	assert.NotEqual(t, primary.NetworkInterfaceID, secondary.NetworkInterfaceID,
+		"two interfaces have distinct IDs")
+
+	for _, ifc := range inst.Interfaces {
+		assert.Regexp(t, `^eni-[0-9a-f]+$`, ifc.NetworkInterfaceID)
+		assert.Equal(t, "in-use", ifc.Status)
+		assert.Equal(t, "attached", ifc.Attachment.Status)
+		assert.Equal(t, "interface", ifc.InterfaceType,
+			"an absent InterfaceType reads back as the documented default")
+		assert.NotEmpty(t, ifc.VpcID, "an interface reports the VPC it is in")
+		assert.NotEmpty(t, ifc.OwnerID)
+		assert.NotEmpty(t, ifc.PrivateDNSName)
+		require.Len(t, ifc.PrivateIPAddresses, 1)
+		assert.Equal(t, ifc.PrivateIPAddress, ifc.PrivateIPAddresses[0].PrivateIPAddress)
+		assert.True(t, ifc.PrivateIPAddresses[0].Primary)
+	}
+}
+
+// TestEC2NetworkInterfaces_DescribeInstancesReportsThem checks the interfaces survive
+// the state round-trip, since RunInstances answers from the in-memory instance while
+// DescribeInstances answers from what was persisted.
+func TestEC2NetworkInterfaces_DescribeInstancesReportsThem(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, groupA, _ := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex":       "0",
+		"NetworkInterface.1.SubnetId":          subnetA,
+		"NetworkInterface.1.SecurityGroupId.1": groupA,
+		"NetworkInterface.2.DeviceIndex":       "1",
+		"NetworkInterface.2.SubnetId":          subnetB,
+	})
+	require.Len(t, instances, 1)
+
+	described := niDescribe(t, ts, instances[0].InstanceID)
+	require.Len(t, described.Interfaces, 2,
+		"the interfaces were persisted, not only echoed")
+	assert.Equal(t, instances[0].Interfaces[0].NetworkInterfaceID,
+		described.Interfaces[0].NetworkInterfaceID,
+		"the same interface IDs read back; a describe does not mint new ones")
+	assert.Equal(t, subnetB, described.Interfaces[1].SubnetID)
+}
+
+// TestEC2NetworkInterfaces_DeviceIndexKeysIdentity is the plan's named mutant made a
+// test: identity is DeviceIndex, not the parameter index.
+//
+// The interfaces are declared in the reverse of their attachment order, so a
+// parameter-index implementation names subnetB the primary and puts the instance's
+// top-level subnetId in the wrong place. AWS documents DeviceIndex as "the position of
+// the network interface in the attachment order", which the parameter index does not
+// have to agree with.
+func TestEC2NetworkInterfaces_DeviceIndexKeysIdentity(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, groupA, groupB := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex":       "3",
+		"NetworkInterface.1.SubnetId":          subnetB,
+		"NetworkInterface.1.SecurityGroupId.1": groupB,
+		"NetworkInterface.2.DeviceIndex":       "0",
+		"NetworkInterface.2.SubnetId":          subnetA,
+		"NetworkInterface.2.SecurityGroupId.1": groupA,
+	})
+	require.Len(t, instances, 1)
+	inst := instances[0]
+
+	assert.Equal(t, subnetA, inst.SubnetID,
+		"the primary is DeviceIndex 0, whichever parameter index declared it")
+	require.Len(t, inst.Groups, 1)
+	assert.Equal(t, groupA, inst.Groups[0].GroupID,
+		"the instance's groups are the primary's, keyed on DeviceIndex")
+
+	require.Len(t, inst.Interfaces, 2)
+	assert.Equal(t, 0, inst.Interfaces[0].Attachment.DeviceIndex,
+		"interfaces are reported in attachment order, primary first")
+	assert.Equal(t, 3, inst.Interfaces[1].Attachment.DeviceIndex,
+		"a device index need not be contiguous; 3 is reported as 3")
+	assert.Equal(t, subnetB, inst.Interfaces[1].SubnetID)
+}
+
+// TestEC2NetworkInterfaces_GapStopsTheParse checks the contiguous-from-1 rule
+// [indexedParams] already used for string lists: index 3 without index 2 is not read.
+//
+// This is not pedantry about a malformed request. Stopping at the gap is what bounds
+// the loop — an implementation that scanned for some maximum index instead would have
+// to choose one, and would silently drop anything above it.
+func TestEC2NetworkInterfaces_GapStopsTheParse(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, _, _ := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex": "0",
+		"NetworkInterface.1.SubnetId":    subnetA,
+		"NetworkInterface.3.DeviceIndex": "2",
+		"NetworkInterface.3.SubnetId":    subnetB,
+	})
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Interfaces, 1,
+		"the parse stops at the missing index 2, so index 3 is not read")
+	assert.Equal(t, subnetA, instances[0].Interfaces[0].SubnetID)
+}
+
+// TestEC2NetworkInterfaces_SingleInterfaceUnchanged is the no-regression guard: the
+// index-1-only launch that worked before must behave identically.
+//
+// It is the case every existing launch-template and spawn test exercises, and the one
+// a parse-all-N change is most likely to break.
+func TestEC2NetworkInterfaces_SingleInterfaceUnchanged(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, _, groupA, _ := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex":              "0",
+		"NetworkInterface.1.SubnetId":                 subnetA,
+		"NetworkInterface.1.SecurityGroupId.1":        groupA,
+		"NetworkInterface.1.AssociatePublicIpAddress": "true",
+	})
+	require.Len(t, instances, 1)
+	inst := instances[0]
+
+	assert.Equal(t, subnetA, inst.SubnetID)
+	require.Len(t, inst.Groups, 1)
+	assert.Equal(t, groupA, inst.Groups[0].GroupID)
+	require.Len(t, inst.Interfaces, 1)
+	assert.Equal(t, 0, inst.Interfaces[0].Attachment.DeviceIndex)
+
+	described := niDescribe(t, ts, inst.InstanceID)
+	assert.NotEmpty(t, described.PrivateIPAddress)
+}
+
+// TestEC2NetworkInterfaces_NoInterfaceDeclared checks that a launch naming no
+// interface reports no interface set rather than a phantom one.
+//
+// Substrate does not create an ENI record for the interface every real instance has,
+// because it does not model ENIs as resources; reporting one here would be an
+// observation with nothing behind it.
+func TestEC2NetworkInterfaces_NoInterfaceDeclared(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	instances := niRun(t, ts, map[string]string{"InstanceType": "t3.micro"})
+	require.Len(t, instances, 1)
+	assert.Empty(t, instances[0].Interfaces,
+		"a launch declaring no interface reports none")
+	assert.NotEmpty(t, instances[0].SubnetID,
+		"the default-VPC subnet still applies")
+}
+
+// TestEC2NetworkInterfaces_MultiCountDistinctAddresses checks that two instances from
+// one launch do not report the same secondary address.
+func TestEC2NetworkInterfaces_MultiCountDistinctAddresses(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, _, _ := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"MaxCount":                       "2",
+		"NetworkInterface.1.DeviceIndex": "0",
+		"NetworkInterface.1.SubnetId":    subnetA,
+		"NetworkInterface.2.DeviceIndex": "1",
+		"NetworkInterface.2.SubnetId":    subnetB,
+	})
+	require.Len(t, instances, 2)
+
+	seen := map[string]string{}
+	for _, inst := range instances {
+		require.Len(t, inst.Interfaces, 2)
+		for _, ifc := range inst.Interfaces {
+			require.NotEmpty(t, ifc.PrivateIPAddress)
+			prior, dup := seen[ifc.PrivateIPAddress]
+			assert.False(t, dup,
+				"address %s is on both %s and %s", ifc.PrivateIPAddress, prior, inst.InstanceID)
+			seen[ifc.PrivateIPAddress] = inst.InstanceID
+		}
+	}
+}
+
+// TestEC2NetworkInterfaces_ExistingInterfaceAttached checks the two things that change
+// when a launch attaches an interface it did not create: the ID is the caller's, and
+// DeleteOnTermination defaults to false rather than true.
+//
+// The default is not arbitrary. Deleting an interface the caller brought would destroy
+// something the launch did not make, which is why AWS defaults it the other way for an
+// attached interface than for a created one.
+func TestEC2NetworkInterfaces_ExistingInterfaceAttached(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, _, _, _ := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex":        "0",
+		"NetworkInterface.1.NetworkInterfaceId": "eni-0abcdef01234567",
+		"NetworkInterface.2.DeviceIndex":        "1",
+		"NetworkInterface.2.SubnetId":           subnetA,
+	})
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Interfaces, 2)
+
+	attached := instances[0].Interfaces[0]
+	assert.Equal(t, "eni-0abcdef01234567", attached.NetworkInterfaceID,
+		"an attached interface keeps the ID the caller named")
+	assert.False(t, attached.Attachment.DeleteOnTermination,
+		"an interface the launch did not create is not deleted with the instance")
+	assert.True(t, instances[0].Interfaces[1].Attachment.DeleteOnTermination,
+		"one the launch did create is")
+}
+
+// TestEC2NetworkInterfaces_InterfaceTypeAndNetworkCard checks two members that only
+// matter for reading back what was declared: an EFA interface and a non-zero network
+// card.
+func TestEC2NetworkInterfaces_InterfaceTypeAndNetworkCard(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, _, _ := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex":      "0",
+		"NetworkInterface.1.SubnetId":         subnetA,
+		"NetworkInterface.2.DeviceIndex":      "1",
+		"NetworkInterface.2.SubnetId":         subnetB,
+		"NetworkInterface.2.InterfaceType":    "efa",
+		"NetworkInterface.2.NetworkCardIndex": "1",
+	})
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Interfaces, 2)
+
+	assert.Equal(t, 0, instances[0].Interfaces[0].Attachment.NetworkCardIndex,
+		"the primary must be on network card 0")
+	assert.Equal(t, "efa", instances[0].Interfaces[1].InterfaceType)
+	assert.Equal(t, 1, instances[0].Interfaces[1].Attachment.NetworkCardIndex)
+}
+
+// TestEC2NetworkInterfaces_PrivateIPAddressHonored checks that an address the request
+// names on a secondary interface is the one reported, rather than a substrate-assigned
+// one.
+func TestEC2NetworkInterfaces_PrivateIPAddressHonored(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, _, _ := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex":      "0",
+		"NetworkInterface.1.SubnetId":         subnetA,
+		"NetworkInterface.2.DeviceIndex":      "1",
+		"NetworkInterface.2.SubnetId":         subnetB,
+		"NetworkInterface.2.PrivateIpAddress": "10.0.2.77",
+	})
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Interfaces, 2)
+
+	secondary := instances[0].Interfaces[1]
+	assert.Equal(t, "10.0.2.77", secondary.PrivateIPAddress)
+	assert.Equal(t, "ip-10-0-2-77.us-east-1.compute.internal", secondary.PrivateDNSName,
+		"the DNS name is derived from the address the caller named")
+}
+
+// TestEC2NetworkInterfaces_LaunchTemplateAllInterfaces is the launch-template half:
+// LaunchTemplateData.NetworkInterface.N is parsed for all N too.
+func TestEC2NetworkInterfaces_LaunchTemplateAllInterfaces(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, groupA, groupB := niSubnets(t, ts)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "two-nics",
+		"LaunchTemplateData.ImageId": "ami-12345678",
+		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":       "0",
+		"LaunchTemplateData.NetworkInterface.1.SubnetId":          subnetA,
+		"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1": groupA,
+		"LaunchTemplateData.NetworkInterface.2.DeviceIndex":       "1",
+		"LaunchTemplateData.NetworkInterface.2.SubnetId":          subnetB,
+		"LaunchTemplateData.NetworkInterface.2.SecurityGroupId.1": groupB,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// The template reads back with both interfaces.
+	versions, _ := describeLTVersions(t, ts, map[string]string{"LaunchTemplateName": "two-nics"})
+	require.Len(t, versions, 1)
+	require.Len(t, versions[0].Data.Interfaces, 2,
+		"a template's second interface reads back; losing it was the pre-fix behavior")
+	assert.Equal(t, subnetA, versions[0].Data.Interfaces[0].SubnetID)
+	assert.Equal(t, subnetB, versions[0].Data.Interfaces[1].SubnetID)
+
+	// And a launch from it gets both.
+	instances := niRun(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateName": "two-nics",
+	})
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Interfaces, 2,
+		"a launch from the template attaches both interfaces")
+	assert.Equal(t, subnetA, instances[0].SubnetID,
+		"the instance's subnet is the template's primary interface's")
+	assert.Equal(t, subnetB, instances[0].Interfaces[1].SubnetID)
+}
+
+// TestEC2NetworkInterfaces_RequestInterfacesBeatTemplate checks the precedence rule:
+// a request declaring its own interfaces does not inherit the template's.
+//
+// All-or-nothing rather than per-device-index, because the reference's rule is that
+// "any additional parameters that you specify for the new instance overwrite the
+// corresponding parameters included in the launch template" — merging per index would
+// let a request naming one interface silently acquire a second.
+func TestEC2NetworkInterfaces_RequestInterfacesBeatTemplate(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, _, _ := niSubnets(t, ts)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "tmpl-two",
+		"LaunchTemplateData.ImageId": "ami-12345678",
+		"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
+		"LaunchTemplateData.NetworkInterface.1.SubnetId":    subnetB,
+		"LaunchTemplateData.NetworkInterface.2.DeviceIndex": "1",
+		"LaunchTemplateData.NetworkInterface.2.SubnetId":    subnetB,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	instances := niRun(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateName": "tmpl-two",
+		"NetworkInterface.1.DeviceIndex":    "0",
+		"NetworkInterface.1.SubnetId":       subnetA,
+	})
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Interfaces, 1,
+		"the request's one interface replaces the template's two rather than merging")
+	assert.Equal(t, subnetA, instances[0].Interfaces[0].SubnetID)
+}
+
+// TestEC2NetworkInterfaces_TemplateFlatFieldsStillLaunch checks that a template
+// whose one interface names no DeviceIndex is still read — the shape every template
+// created before #455 was created as.
+func TestEC2NetworkInterfaces_TemplateFlatFieldsStillLaunch(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, _, groupA, _ := niSubnets(t, ts)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "flat",
+		"LaunchTemplateData.ImageId": "ami-12345678",
+		"LaunchTemplateData.NetworkInterface.1.SubnetId":          subnetA,
+		"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1": groupA,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	instances := niRun(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateName": "flat",
+	})
+	require.Len(t, instances, 1)
+	assert.Equal(t, subnetA, instances[0].SubnetID,
+		"an interface naming a subnet but no DeviceIndex is still read")
+	require.Len(t, instances[0].Groups, 1)
+	assert.Equal(t, groupA, instances[0].Groups[0].GroupID)
+}
+
+// TestEC2NetworkInterfaces_PreSliceTemplateStateStillWorks is the replay gate: a
+// template stored before the interface slice existed carries its networking in the
+// flat fields alone, and must still launch and still read back.
+//
+// The stored JSON is written by hand because CreateLaunchTemplate can no longer
+// produce it — it now always writes the slice too — and that is exactly what makes
+// this a migration rather than a round-trip. Without the flat-field fallback in
+// ec2LTVersionData, such a template would describe with an empty
+// networkInterfaceSet, so a replayed event log would report a template with no
+// networking at all while the record plainly holds a subnet.
+func TestEC2NetworkInterfaces_PreSliceTemplateStateStillWorks(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	ts := newEC2TestServerWithState(t, state)
+	subnetA, _, groupA, _ := niSubnets(t, ts)
+
+	// The shape createLaunchTemplate wrote before #455: subnetId,
+	// associatePublicIpAddress and networkInterfaceGroups, no networkInterfaces key.
+	const acct, region, ltID = "000000000000", "us-east-1", "lt-0preslice00001"
+	stored := map[string]any{
+		"launchTemplateId":     ltID,
+		"launchTemplateName":   "preslice",
+		"defaultVersionNumber": 1,
+		"latestVersionNumber":  1,
+		"createdBy":            acct,
+		"createTime":           "2026-01-01T00:00:00Z",
+		"latestData": map[string]any{
+			"imageId":                  "ami-12345678",
+			"instanceType":             "t3.small",
+			"subnetId":                 subnetA,
+			"associatePublicIpAddress": "true",
+			"networkInterfaceGroups":   []string{groupA},
+		},
+		"accountID": acct,
+		"region":    region,
+	}
+	raw, err := json.Marshal(stored)
+	require.NoError(t, err)
+	ctx := t.Context()
+	require.NoError(t, state.Put(ctx, "ec2", "lt:"+acct+"/"+region+"/"+ltID, raw))
+	require.NoError(t, state.Put(ctx, "ec2", "lt_by_name:"+acct+"/"+region+"/preslice", []byte(ltID)))
+	idsRaw, err := json.Marshal([]string{ltID})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "ec2", "lt_ids:"+acct+"/"+region, idsRaw))
+
+	instances := niRun(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
+	require.Len(t, instances, 1)
+	assert.Equal(t, subnetA, instances[0].SubnetID, "the stored subnet still launches")
+	require.Len(t, instances[0].Groups, 1)
+	assert.Equal(t, groupA, instances[0].Groups[0].GroupID)
+	assert.NotEmpty(t, niDescribe(t, ts, instances[0].InstanceID).PublicIPAddress,
+		"the stored public-IP preference still applies")
+
+	// And it describes as the one interface it holds, synthesized from those fields.
+	versions, _ := describeLTVersions(t, ts, map[string]string{"LaunchTemplateId": ltID})
+	require.Len(t, versions, 1)
+	require.Len(t, versions[0].Data.Interfaces, 1,
+		"a pre-slice template describes its interface, not an empty set")
+	assert.Equal(t, subnetA, versions[0].Data.Interfaces[0].SubnetID)
+	assert.Equal(t, "true", versions[0].Data.Interfaces[0].AssociatePublicIPAddress)
+	assert.Equal(t, []string{groupA}, versions[0].Data.Interfaces[0].Groups)
+}
+
+// TestEC2NetworkInterfaces_PublicIPFromPrimaryOnly checks that the public-IP
+// preference is read from the primary interface alone.
+//
+// AWS documents the public IP as assignable "to a network interface for eth0" only, so
+// a secondary interface asking for one is not a statement about the instance's public
+// IP. Reading it from any interface would let a secondary silently turn on a public
+// address the caller asked for somewhere it does not apply.
+func TestEC2NetworkInterfaces_PublicIPFromPrimaryOnly(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, subnetB, _, _ := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex":              "0",
+		"NetworkInterface.1.SubnetId":                 subnetA,
+		"NetworkInterface.2.DeviceIndex":              "1",
+		"NetworkInterface.2.SubnetId":                 subnetB,
+		"NetworkInterface.2.AssociatePublicIpAddress": "true",
+	})
+	require.Len(t, instances, 1)
+
+	described := niDescribe(t, ts, instances[0].InstanceID)
+	assert.Empty(t, described.PublicIPAddress,
+		"a secondary interface's public-IP preference does not apply to the instance")
+
+	// The same preference on the primary does apply, which is what makes the
+	// assertion above about *which* interface rather than about the feature.
+	onPrimary := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex":              "0",
+		"NetworkInterface.1.SubnetId":                 subnetA,
+		"NetworkInterface.1.AssociatePublicIpAddress": "true",
+	})
+	require.Len(t, onPrimary, 1)
+	assert.NotEmpty(t, niDescribe(t, ts, onPrimary[0].InstanceID).PublicIPAddress)
+}
+
+// TestEC2NetworkInterfaces_DeviceIndexUnparseable checks that a non-numeric device
+// index does not fail the launch or make the interface vanish.
+//
+// It reads as 0, the documented primary. A launch is not rejected over a member
+// substrate can infer, and the interface's subnet is unambiguous whatever the index
+// says.
+func TestEC2NetworkInterfaces_DeviceIndexUnparseable(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, _, _, _ := niSubnets(t, ts)
+
+	instances := niRun(t, ts, map[string]string{
+		"NetworkInterface.1.DeviceIndex": "primary",
+		"NetworkInterface.1.SubnetId":    subnetA,
+	})
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Interfaces, 1,
+		"an unparseable device index does not drop the interface")
+	assert.Equal(t, 0, instances[0].Interfaces[0].Attachment.DeviceIndex)
+	assert.Equal(t, subnetA, instances[0].SubnetID)
+}
+
+// TestEC2NetworkInterfaces_ManyInterfaces checks the loop is bounded by the request
+// rather than by a hard-coded ceiling, which is the failure mode a "scan up to N"
+// implementation has.
+func TestEC2NetworkInterfaces_ManyInterfaces(t *testing.T) {
+	ts := newEC2TestServer(t)
+	subnetA, _, _, _ := niSubnets(t, ts)
+
+	params := map[string]string{}
+	const count = 8
+	for n := 1; n <= count; n++ {
+		params["NetworkInterface."+strconv.Itoa(n)+".DeviceIndex"] = strconv.Itoa(n - 1)
+		params["NetworkInterface."+strconv.Itoa(n)+".SubnetId"] = subnetA
+	}
+	instances := niRun(t, ts, params)
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Interfaces, count)
+	for n, ifc := range instances[0].Interfaces {
+		assert.Equal(t, n, ifc.Attachment.DeviceIndex)
+	}
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -340,25 +340,39 @@ func (p *EC2Plugin) runInstancesWithTags(
 	}
 
 	// Networking can be specified either at the top level (above) or nested in a
-	// NetworkInterface spec (NetworkInterface.1.*). The AWS SDK puts SubnetId,
-	// security groups, and AssociatePublicIpAddress inside the network interface
-	// whenever a public-IP preference is set — which spawn always does. Fall back
-	// to the nested form so that subnet/SG/public-IP aren't silently dropped.
-	if subnetID == "" {
-		subnetID = req.Params["NetworkInterface.1.SubnetId"]
+	// NetworkInterface.N spec. The AWS SDK puts SubnetId, security groups, and
+	// AssociatePublicIpAddress inside the network interface whenever a public-IP
+	// preference is set — which spawn always does. Read the nested form so that
+	// subnet/SG/public-IP aren't silently dropped.
+	//
+	// Every declared interface is parsed, not just index 1 (#455). The top-level
+	// fallbacks below read the *primary* interface, which is the one whose values
+	// real EC2 reports at the top level of an instance — see [ec2PrimaryInterface]
+	// for why that is the lowest device index rather than the first parameter index.
+	networkInterfaces := ec2ParseNetworkInterfaces(req.Params, "")
+	ec2SortInterfacesByDeviceIndex(networkInterfaces)
+	primaryIfc := ec2PrimaryInterface(networkInterfaces)
+	if subnetID == "" && primaryIfc != nil {
+		subnetID = primaryIfc.SubnetID
 	}
 	// AssociatePublicIpAddress=true forces a public IP even on a non-default
 	// subnet; "" means "use the subnet default". A launch template can also carry
 	// this preference, so the call-level value is kept as the raw string and only
 	// resolved to a bool once the template has had its chance to supply one.
-	publicIPPref := req.Params["NetworkInterface.1.AssociatePublicIpAddress"]
+	//
+	// Read from the primary alone: AWS documents the public IP as assignable "to a
+	// network interface for eth0" only, so a secondary interface's preference is not
+	// a statement about the instance's public IP.
+	var publicIPPref string
+	if primaryIfc != nil {
+		publicIPPref = primaryIfc.AssociatePublicIPAddress
+	}
 
 	// Security groups named at call level, from either the top-level params or the
-	// nested NetworkInterface.1.* form (SecurityGroupId.M or Groups.M).
+	// primary interface's nested form (SecurityGroupId.M or Groups.M).
 	securityGroupIDs := indexedParams(req.Params, "SecurityGroupId.%d", "SecurityGroupIds.%d")
-	if len(securityGroupIDs) == 0 {
-		securityGroupIDs = indexedParams(req.Params,
-			"NetworkInterface.1.SecurityGroupId.%d", "NetworkInterface.1.Groups.%d")
+	if len(securityGroupIDs) == 0 && primaryIfc != nil {
+		securityGroupIDs = primaryIfc.SecurityGroupIDs
 	}
 
 	// Merge a named launch template into the request, per field.
@@ -409,6 +423,14 @@ func (p *EC2Plugin) runInstancesWithTags(
 		}
 		if len(securityGroupIDs) == 0 {
 			securityGroupIDs = ltData.NetworkSecurityGroupIDs()
+		}
+		// The template's interfaces apply only when the request declared none, the
+		// same all-or-nothing rule the reference's "any additional parameters that you
+		// specify for the new instance overwrite the corresponding parameters included
+		// in the launch template" gives every other field. Merging per device index
+		// would let a request that named one interface silently inherit a second.
+		if len(networkInterfaces) == 0 {
+			networkInterfaces = ltData.NetworkInterfaces
 		}
 		if sgID == "" && len(securityGroupIDs) > 0 {
 			sgID = securityGroupIDs[0]
@@ -582,6 +604,10 @@ func (p *EC2Plugin) runInstancesWithTags(
 			inst.AvailabilityZone = reqCtx.Region + "a"
 		}
 
+		// Record the interfaces last, since the primary's address and DNS name are
+		// the instance's own and those were only just resolved.
+		p.ec2AttachInterfaces(&inst, networkInterfaces, i, reqCtx.Region)
+
 		data, err := json.Marshal(inst)
 		if err != nil {
 			return nil, fmt.Errorf("ec2 runInstances marshal: %w", err)
@@ -614,6 +640,90 @@ type ec2GroupItem struct {
 
 	// GroupName is the group's name, omitted when it cannot be resolved.
 	GroupName string `xml:"groupName,omitempty"`
+}
+
+// ec2NetworkInterfaceItem is one networkInterfaceSet>item, the shape both
+// RunInstances and DescribeInstances report an instance's interfaces in.
+//
+// Declared once at package level for the reason [ec2GroupItem] is: the two responses
+// carrying their own copies is what let their instance items drift apart before.
+// Only the members substrate records are emitted — see [EC2NetworkInterface].
+type ec2NetworkInterfaceItem struct {
+	NetworkInterfaceID string                    `xml:"networkInterfaceId"`
+	SubnetID           string                    `xml:"subnetId,omitempty"`
+	VpcID              string                    `xml:"vpcId,omitempty"`
+	Description        string                    `xml:"description,omitempty"`
+	OwnerID            string                    `xml:"ownerId"`
+	Status             string                    `xml:"status"`
+	PrivateIPAddress   string                    `xml:"privateIpAddress,omitempty"`
+	PrivateDNSName     string                    `xml:"privateDnsName,omitempty"`
+	Groups             []ec2GroupItem            `xml:"groupSet>item,omitempty"`
+	Attachment         ec2NetworkAttachmentItem  `xml:"attachment"`
+	InterfaceType      string                    `xml:"interfaceType,omitempty"`
+	PrivateIPAddresses []ec2NetworkPrivateIPItem `xml:"privateIpAddressesSet>item,omitempty"`
+}
+
+// ec2NetworkAttachmentItem is an interface's attachment element, which is where AWS
+// reports the device index rather than on the interface itself.
+type ec2NetworkAttachmentItem struct {
+	DeviceIndex         int    `xml:"deviceIndex"`
+	Status              string `xml:"status"`
+	DeleteOnTermination bool   `xml:"deleteOnTermination"`
+	NetworkCardIndex    int    `xml:"networkCardIndex"`
+}
+
+// ec2NetworkPrivateIPItem is one entry in an interface's privateIpAddressesSet.
+//
+// Substrate records a single address per interface, so exactly one entry is emitted
+// and it is always primary. The set is still reported rather than omitted, because a
+// caller reading privateIpAddressesSet to find the primary address should find it
+// there rather than have to know substrate models no secondary addresses.
+type ec2NetworkPrivateIPItem struct {
+	PrivateIPAddress string `xml:"privateIpAddress"`
+	PrivateDNSName   string `xml:"privateDnsName,omitempty"`
+	Primary          bool   `xml:"primary"`
+}
+
+// ec2NetworkInterfaceItems builds the networkInterfaceSet entries for an instance.
+//
+// status is "in-use" and the attachment's is "attached" rather than the "attaching"
+// a real launch reports mid-attachment: substrate's instances are running by the time
+// RunInstances answers, so an interface still attaching would contradict the instance
+// state alongside it.
+func (p *EC2Plugin) ec2NetworkInterfaceItems(reqCtx *RequestContext, inst EC2Instance) []ec2NetworkInterfaceItem {
+	if len(inst.NetworkInterfaces) == 0 {
+		return nil
+	}
+	items := make([]ec2NetworkInterfaceItem, 0, len(inst.NetworkInterfaces))
+	for _, ifc := range inst.NetworkInterfaces {
+		item := ec2NetworkInterfaceItem{
+			NetworkInterfaceID: ifc.NetworkInterfaceID,
+			SubnetID:           ifc.SubnetID,
+			VpcID:              inst.VPCID,
+			Description:        ifc.Description,
+			OwnerID:            reqCtx.AccountID,
+			Status:             "in-use",
+			PrivateIPAddress:   ifc.PrivateIPAddress,
+			PrivateDNSName:     ifc.PrivateDNSName,
+			Groups:             p.ec2GroupItems(reqCtx, ifc.SecurityGroupIDs),
+			Attachment: ec2NetworkAttachmentItem{
+				DeviceIndex:         ifc.DeviceIndex,
+				Status:              "attached",
+				DeleteOnTermination: ifc.DeleteOnTermination,
+				NetworkCardIndex:    ifc.NetworkCardIndex,
+			},
+			InterfaceType: ifc.InterfaceType,
+		}
+		if ifc.PrivateIPAddress != "" {
+			item.PrivateIPAddresses = []ec2NetworkPrivateIPItem{{
+				PrivateIPAddress: ifc.PrivateIPAddress,
+				PrivateDNSName:   ifc.PrivateDNSName,
+				Primary:          true,
+			}}
+		}
+		items = append(items, item)
+	}
+	return items
 }
 
 // ec2GroupItems builds the groupSet entries for an instance's security groups.
@@ -668,8 +778,9 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 			Code int    `xml:"code"`
 			Name string `xml:"name"`
 		} `xml:"instanceState"`
-		Groups []ec2GroupItem `xml:"groupSet>item"`
-		Tags   []tagItem      `xml:"tagSet>item"`
+		Groups            []ec2GroupItem            `xml:"groupSet>item"`
+		Tags              []tagItem                 `xml:"tagSet>item"`
+		NetworkInterfaces []ec2NetworkInterfaceItem `xml:"networkInterfaceSet>item,omitempty"`
 	}
 	type response struct {
 		XMLName       xml.Name          `xml:"RunInstancesResponse"`
@@ -702,6 +813,10 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 		item.State.Code = inst.State.Code
 		item.State.Name = inst.State.Name
 		item.Groups = p.ec2GroupItems(reqCtx, inst.SecurityGroupIDs)
+		// RunInstances reports networkInterfaceSet, not only DescribeInstances — the
+		// reference's own sample response carries it — so a caller can read back the
+		// interfaces it declared without a follow-up describe (#455).
+		item.NetworkInterfaces = p.ec2NetworkInterfaceItems(reqCtx, inst)
 		// Echo launch-time tags (from TagSpecifications) — real EC2 populates
 		// tagSet in the RunInstances response, not just DescribeInstances (#351).
 		for _, t := range inst.Tags {
@@ -822,6 +937,8 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		Placement          placementItem   `xml:"placement"`
 		Groups             []ec2GroupItem  `xml:"groupSet>item"`
 		Tags               []tagItem       `xml:"tagSet>item"`
+
+		NetworkInterfaces []ec2NetworkInterfaceItem `xml:"networkInterfaceSet>item,omitempty"`
 	}
 	type reservationItem struct {
 		ReservationID string            `xml:"reservationId"`
@@ -872,6 +989,7 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		item.State.Code = inst.State.Code
 		item.State.Name = inst.State.Name
 		item.Groups = p.ec2GroupItems(reqCtx, inst.SecurityGroupIDs)
+		item.NetworkInterfaces = p.ec2NetworkInterfaceItems(reqCtx, inst)
 		// Echo the IAM instance profile set at launch (#331). The stored value is
 		// the name or ARN supplied; surface it as the ARN and derive an id so a
 		// caller can read back the profile it attached.
@@ -4275,8 +4393,11 @@ func (p *EC2Plugin) resolveLaunchTemplate(goCtx context.Context, ctx *RequestCon
 // params and stored none of them, so an instance launched from a template
 // configured the way AWS requires landed in a substrate-chosen subnet (#444).
 //
-// Only interface index 1 is modeled, matching runInstances' own NetworkInterface.1
-// handling: a template declaring a second interface silently loses it.
+// Every declared interface is parsed (#455). The flat SubnetID,
+// AssociatePublicIPAddress and NetworkInterfaceGroups fields hold the primary
+// interface's values, so a launch from this template lands where it did before and a
+// template stored before the slice existed still reads correctly; the slice carries
+// the rest, which used to be silently dropped.
 //
 // The interface's security groups are read from SecurityGroupId.N first, which is
 // what real SDKs send — the AWS model gives that member the locationName
@@ -4289,16 +4410,24 @@ func (p *EC2Plugin) resolveLaunchTemplate(goCtx context.Context, ctx *RequestCon
 // say so, and a tag: filter simply returning nothing (#471).
 func parseLaunchTemplateData(params map[string]string) EC2LaunchTemplateData {
 	const ltPrefix = "LaunchTemplateData."
-	const niPrefix = ltPrefix + "NetworkInterface.1."
+
+	interfaces := ec2ParseNetworkInterfaces(params, ltPrefix)
+	ec2SortInterfacesByDeviceIndex(interfaces)
 
 	data := EC2LaunchTemplateData{
-		ImageID:                  params[ltPrefix+"ImageId"],
-		InstanceType:             params[ltPrefix+"InstanceType"],
-		KeyName:                  params[ltPrefix+"KeyName"],
-		UserData:                 params[ltPrefix+"UserData"],
-		SubnetID:                 params[niPrefix+"SubnetId"],
-		AssociatePublicIPAddress: params[niPrefix+"AssociatePublicIpAddress"],
-		TagSpecifications:        ec2TagSpecificationTags(params, ltPrefix, "instance"),
+		ImageID:           params[ltPrefix+"ImageId"],
+		InstanceType:      params[ltPrefix+"InstanceType"],
+		KeyName:           params[ltPrefix+"KeyName"],
+		UserData:          params[ltPrefix+"UserData"],
+		TagSpecifications: ec2TagSpecificationTags(params, ltPrefix, "instance"),
+		NetworkInterfaces: interfaces,
+	}
+	// The flat fields hold the primary interface's values; see
+	// [EC2LaunchTemplateData.NetworkInterfaces].
+	if primary := ec2PrimaryInterface(interfaces); primary != nil {
+		data.SubnetID = primary.SubnetID
+		data.AssociatePublicIPAddress = primary.AssociatePublicIPAddress
+		data.NetworkInterfaceGroups = primary.SecurityGroupIDs
 	}
 	// Name before Arn, mirroring runInstances' own precedence for the call-level
 	// pair; see [EC2LaunchTemplateData.IamInstanceProfile].
@@ -4309,8 +4438,6 @@ func parseLaunchTemplateData(params map[string]string) EC2LaunchTemplateData {
 	if sg1 := params[ltPrefix+"SecurityGroupId.1"]; sg1 != "" {
 		data.SecurityGroupIDs = []string{sg1}
 	}
-	data.NetworkInterfaceGroups = indexedParams(params,
-		niPrefix+"SecurityGroupId.%d", niPrefix+"Groups.%d")
 	return data
 }
 

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -112,6 +112,75 @@ type EC2Instance struct {
 	// zone — the conservative reading, since it is what a single-zone account
 	// looks like.
 	AvailabilityZone string `json:"availability_zone,omitempty"`
+
+	// NetworkInterfaces holds every interface the launch declared, in DeviceIndex
+	// order, with the primary (DeviceIndex 0) first.
+	//
+	// The flat SubnetID/PrivateIPAddress/SecurityGroupIDs fields above continue to
+	// report the *primary* interface's values, which is what real EC2 puts at the
+	// top level of an instance — they are not superseded by this slice. An instance
+	// unmarshalled from an event log predating this field reads back with an empty
+	// slice, and its flat fields still describe its one interface, so a replayed log
+	// still describes correctly (#455).
+	NetworkInterfaces []EC2NetworkInterface `json:"network_interfaces,omitempty"`
+}
+
+// EC2NetworkInterface is one interface attached to an instance at launch, from a
+// RunInstances NetworkInterface.N specification or a launch template's.
+//
+// Only the members substrate can observe something about are held. AWS's
+// InstanceNetworkInterfaceSpecification has some forty members; recording a value
+// substrate never reports would be a write with no observable, and reporting one it
+// never received would be a claim nothing backs.
+type EC2NetworkInterface struct {
+	// NetworkInterfaceID is the interface's ID, either the one the request attached
+	// by NetworkInterfaceId or one substrate minted for an interface the launch
+	// created.
+	NetworkInterfaceID string `json:"network_interface_id"`
+
+	// DeviceIndex is "the position of the network interface in the attachment
+	// order. A primary network interface has a device index of 0."
+	//
+	// This is the interface's identity, not its position in the request: AWS keys on
+	// DeviceIndex and the two need not agree, so NetworkInterface.1 may perfectly
+	// well declare DeviceIndex 3.
+	DeviceIndex int `json:"device_index"`
+
+	// SubnetID is the subnet the interface is in.
+	SubnetID string `json:"subnet_id,omitempty"`
+
+	// PrivateIPAddress is the interface's primary private IPv4 address, either the
+	// one the request named or one substrate assigned from the subnet's range.
+	PrivateIPAddress string `json:"private_ip_address,omitempty"`
+
+	// PrivateDNSName is the interface's private DNS hostname.
+	PrivateDNSName string `json:"private_dns_name,omitempty"`
+
+	// SecurityGroupIDs holds the interface's security groups.
+	SecurityGroupIDs []string `json:"security_group_ids,omitempty"`
+
+	// AssociatePublicIPAddress is the interface's public-IP preference, stored
+	// verbatim as a string for the same three-state reason
+	// [EC2LaunchTemplateData.AssociatePublicIPAddress] gives: absent, "true" and
+	// "false" are three distinguishable requests and a bool collapses two of them.
+	AssociatePublicIPAddress string `json:"associate_public_ip_address,omitempty"`
+
+	// Description is the interface's description, which "applies only if creating a
+	// network interface when launching an instance".
+	Description string `json:"description,omitempty"`
+
+	// DeleteOnTermination reports whether the interface is deleted with the
+	// instance. AWS defaults a launch-created interface to true; an attached
+	// existing one to false.
+	DeleteOnTermination bool `json:"delete_on_termination"`
+
+	// InterfaceType is "the type of network interface": interface, efa or efa-only.
+	// Absent reads back as "interface", the documented default.
+	InterfaceType string `json:"interface_type,omitempty"`
+
+	// NetworkCardIndex is "the index of the network card", which defaults to 0 and
+	// which "the primary network interface must be assigned to".
+	NetworkCardIndex int `json:"network_card_index,omitempty"`
 }
 
 // EC2KeyPair represents an EC2 key pair (public/private key used for SSH access).
@@ -353,6 +422,12 @@ type EC2RouteTable struct {
 // "i-" followed by 17 hex characters.
 func generateEC2InstanceID() string {
 	return "i-" + randomHex(8)
+}
+
+// generateENIID generates a random elastic network interface ID in the format
+// "eni-" followed by 8 hex characters.
+func generateENIID() string {
+	return "eni-" + randomHex(8)
 }
 
 // generateVPCID generates a random VPC ID in the format "vpc-" followed by
@@ -636,8 +711,8 @@ type EC2LaunchTemplateData struct {
 	// UserData is the base64-encoded user data script.
 	UserData string `json:"userData,omitempty"`
 
-	// SubnetID is the subnet named in the template's first network interface
-	// (LaunchTemplateData.NetworkInterface.1.SubnetId).
+	// SubnetID is the subnet named in the template's primary network interface —
+	// the one whose LaunchTemplateData.NetworkInterface.N.DeviceIndex is lowest.
 	//
 	// This is not a mirror of RunInstances' top-level SubnetId: AWS's
 	// RequestLaunchTemplateData has no top-level SubnetId member at all, so a
@@ -645,19 +720,29 @@ type EC2LaunchTemplateData struct {
 	// only place AssociatePublicIpAddress exists (#444).
 	SubnetID string `json:"subnetId,omitempty"`
 
-	// AssociatePublicIPAddress is the first network interface's public-IP
+	// AssociatePublicIPAddress is the primary network interface's public-IP
 	// preference, stored verbatim as a string rather than a bool because three
 	// states are observable: absent (use the subnet's own default), "true" (force
 	// a public IP even on a non-default subnet), and "false" (suppress one). A
 	// bool would collapse the first two.
 	AssociatePublicIPAddress string `json:"associatePublicIpAddress,omitempty"`
 
-	// NetworkInterfaceGroups is the security groups named in the template's first
+	// NetworkInterfaceGroups is the security groups named in the template's primary
 	// network interface, kept separate from SecurityGroupIDs so a template
 	// carrying both is not silently merged. AWS rejects that combination; see
 	// [EC2LaunchTemplateData.NetworkSecurityGroupIDs] for how substrate resolves
 	// which list applies.
 	NetworkInterfaceGroups []string `json:"networkInterfaceGroups,omitempty"`
+
+	// NetworkInterfaces holds every interface the template declares, in DeviceIndex
+	// order (#455).
+	//
+	// SubnetID, AssociatePublicIPAddress and NetworkInterfaceGroups above hold the
+	// *primary* interface's values and are not superseded by this slice: they are
+	// what a template stored before this field existed carries, so a replayed event
+	// log still launches into the right subnet with the right groups. A launch reads
+	// this slice when it has one and those fields otherwise.
+	NetworkInterfaces []EC2NetworkInterface `json:"networkInterfaces,omitempty"`
 
 	// TagSpecifications is the template's instance-scoped tag-on-create tags, from
 	// LaunchTemplateData.TagSpecification.N with ResourceType=instance.


### PR DESCRIPTION
Closes #455.

`NetworkInterface.N.*` was parsed for **N=1 only**, at both sites that read it —
`runInstances` and `createLaunchTemplate` — and `EC2Instance` had no interface list to
hold a second one. So a launch or a template declaring two interfaces was accepted,
answered `200`, and quietly became a one-interface instance: no error, and nothing in
the response to reveal the loss. That is this release's shape, reached by a sixth
route.

## What changed

Both sites parse **all N**, by the convention every other indexed list in the plugin
follows — contiguously from 1, stopping at the first missing index (`indexedParams`),
extended from a string per index to a struct per index. An index counts as present
when *any* of its members is, since a specification naming only `DeviceIndex` and
`SubnetId` is as real as one naming ten, and requiring a chosen member would drop an
interface for spelling reasons.

**Identity is keyed on `DeviceIndex`, not the parameter index.** The reference defines
`DeviceIndex` as "the position of the network interface in the attachment order" and
does not require it to agree with the position the request writes the interface at, so
`NetworkInterface.1.DeviceIndex=3` with `NetworkInterface.2.DeviceIndex=0` makes the
*second* one primary. An implementation using the parameter index would name the wrong
interface primary and put the wrong subnet on the instance — verified live:

```
$ aws ec2 run-instances … --network-interfaces 'DeviceIndex=3,SubnetId=$SB' 'DeviceIndex=0,SubnetId=$SA'
{"TopLevelSubnet": "subnet-…A", "DevOrder": [0, 3]}
```

`RunInstances` **and** `DescribeInstances` now report `networkInterfaceSet>item`.
That was decided from the reference rather than assumed: the `RunInstances` sample
response carries the member, so a caller parsing the documented shape found it
missing. Reporting it on both means the interfaces a launch declared are readable back
without a follow-up describe.

The instance's flat `subnetId`, `privateIpAddress` and `groupSet` continue to describe
the **primary** interface, which is what real EC2 puts at the top level — they are not
superseded by the new set. `AssociatePublicIpAddress` is still honored only on the
primary, as the reference requires ("can only be assigned to a network interface for
eth0"); a secondary interface asking for a public IP is not a statement about the
instance's.

`DeleteOnTermination` defaults per the reference's reasoning rather than to one value:
`true` for an interface the launch creates, `false` for an existing one it attaches by
`NetworkInterfaceId`, since deleting an interface the caller brought would destroy
something the launch did not make. An explicit value wins over either.

## Replay

Both the instance and the launch-template shapes grew a slice, so both keep their flat
fields as the primary's values. An instance or a template version stored by an earlier
substrate reads back with an empty slice, and `ec2LTVersionData`'s single-interface
synthesis from the flat fields still runs for it — so a replayed event log still
launches into the right subnet with the right groups and still *describes* its
networking rather than reporting an empty set over a record that plainly holds a
subnet. `TestEC2NetworkInterfaces_PreSliceTemplateStateStillWorks` writes that stored
shape by hand, because `CreateLaunchTemplate` can no longer produce it — which is what
makes it a migration gate rather than a round-trip.

## Substrate's own choices

Recorded in `docs/services.md`, since the API model does not decide them:

- A **secondary** interface naming no `PrivateIpAddress` is given one derived from its
  instance index and device index, so every interface of every instance in a
  multi-`Count` launch has a distinct, replay-stable address a test can assert on. AWS
  refuses a launch that names an address with a count above one; substrate does not,
  so it has to make them differ.
- There are **no standalone ENI resources** — `CreateNetworkInterface` is not modeled,
  so an interface exists only as part of the instance that declared it and an `eni-`
  ID is minted for one the request did not name. A launch declaring no interface
  reports an **empty** set rather than a synthesized phantom eth0.
- Interfaces report `status: in-use` and attachment `status: attached` immediately,
  because substrate's instances are already `running` when `RunInstances` answers; an
  `attaching` attachment would contradict the instance state reported beside it.

## Tests

16 tests in `emulator/ec2_network_interfaces_test.go`, asserting on the **wire XML**
rather than the stored record — an interface substrate parses and stores but does not
report is a write with no observable, which is the defect shape this release is about.
The gate was proven both ways: with the four source files at `HEAD`, **13 of 16 fail**;
the 3 that pass are the deliberate no-regression guards. The whole existing EC2 suite
passes unedited, which is what proves the index-1 path is unchanged.

**Mutation testing: 24 mutants, 23 CAUGHT, 1 EQUIVALENT with a written proof, 0
survivors.** Both mutants the plan named by name are caught by a single test each — the
parse loop not stopping at the first gap (`_GapStopsTheParse`) and `DeviceIndex`
ignored in favour of the parameter index (`_DeviceIndexKeysIdentity`). The equivalent
one replaces `ec2PrimaryInterface`'s lowest-device-index comparison with "first entry":
all three call sites sort ascending immediately before calling it, so `interfaces[0]`
*is* the lowest at every call and no observable distinguishes them. The comparison is
defense in depth against a future caller that does not sort, and the sort it leans on
is itself covered by a mutant that reverses it, caught by 8 tests.

`networkInterfaceSet` was mutated out of each response builder **separately**, since a
test that only reads one of them would not prove the other.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0
issues**, `make test` (race) green, `make docs-reference docs-reference-check
docs-versions` clean (no plugin added, so the generated tables are unchanged),
`npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test -C test/e2e ./...`.

Live against `substrate server`: a two-interface `run-instances` reports **2**
interfaces in both the `RunInstances` response and `describe-instances` (was 1), a
two-interface template describes both versions' interfaces and launches with both, a
brought ENI reports `DeleteOnTermination: false` beside a created one's `true`, and a
launch declaring none reports **0**.

## Compatibility

A test asserting that a multi-interface launch yields one interface, or that an
instance item has no `networkInterfaceSet`, **will go red** — that is the fix.
