### PR TITLE
chore(release): v0.90.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.90.0] - 2026-08-04
+
 ### Deprecated
 - **`emulator.BettyClient` and `emulator.NewBettyClient`, in favour of
   `emulator.Client` and `emulator.NewClient`** (#549). The name referred to an
@@ -4972,7 +4974,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.89.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.90.0...HEAD
+[v0.90.0]: https://github.com/scttfrdmn/substrate/compare/v0.89.0...v0.90.0
 [v0.89.0]: https://github.com/scttfrdmn/substrate/compare/v0.88.0...v0.89.0
 [v0.88.0]: https://github.com/scttfrdmn/substrate/compare/v0.87.1...v0.88.0
 [v0.87.1]: https://github.com/scttfrdmn/substrate/compare/v0.87.0...v0.87.1


### PR DESCRIPTION
Moves `## [Unreleased]` into `## [v0.90.0] - 2026-08-04` and adds the compare link. No code changes.

Eight issues: #532, #551, #542, #544, #530, #545, #455 and #549. The seven bug fixes share one shape — a request accepted, answered `200`, and producing no effect a caller can observe — reached by seven different routes.