### PR TITLE
fix(routing): reach API Gateway v2 and SSO Admin from an SDK (#561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **API Gateway v2 and SSO Admin are reachable from an SDK at all** (#561, #529).
+  Both plugins were registered, had test files, and could not be reached by any
+  client — every unit test green, the feature absent from a caller's point of view,
+  because both test files call `HandleRequest` directly and so never exercise the
+  router.
+
+  `APIGatewayV2Plugin` was unreachable because no routing signal distinguishes API
+  Gateway v1 from v2: the v2 client's SigV4 signing name **is** `apigateway`, its
+  hostname is the same `apigateway.<region>.amazonaws.com`, and neither client sends
+  `X-Amz-Target`. So every v2 request landed on `APIGatewayPlugin` and came back
+  `NotFoundException: unknown operation for POST /v2/apis`. `extractService` now
+  refines a resolved `apigateway` to `apigatewayv2` when the path begins with
+  `/v2/`. The two URI spaces make that exact rather than heuristic — all 103
+  requestUris in the apigatewayv2 model are under `/v2/`, and none of v1's are — and
+  the refinement is confined to requests that already resolved to `apigateway`, so
+  another service's `/v2/` endpoint cannot be captured by it.
+
+  `SSOPlugin` was unreachable because `targetServiceAliases` mapped
+  `AWSSSOAdminService`, a prefix derived by guesswork that no client sends. The real
+  `sso-admin` `targetPrefix` is `SWBExternalService`, so `aws sso-admin
+  list-instances` failed with `ServiceNotAvailable: service not emulated:
+  swbexternalservice`. The real prefix is now mapped **alongside** the guessed one,
+  which is retained so any caller that does send it keeps working.
+
+  API Gateway v2 responses are still PascalCase and so still parse to nothing in a
+  real SDK; that is #529's separate defect and is fixed in this release's later
+  changes. This change is what makes it observable.
+
 ## [v0.90.0] - 2026-08-04
 
 ### Deprecated

--- a/docs/services.md
+++ b/docs/services.md
@@ -3582,6 +3582,14 @@ API Gateway REST API calls: $3.50 per million calls.
 **Endpoint:** `apigateway.{region}.amazonaws.com`
 **Protocol:** REST/JSON (`/v2/` prefix)
 
+**Routing:** v1 and v2 are one endpoint and one SigV4 signing name — an
+apigatewayv2 client signs as `apigateway`, uses the same hostname, and sends no
+`X-Amz-Target` — so Substrate discriminates them by **path**: a request under
+`/v2/` that would otherwise resolve to `apigateway` is routed to the v2 plugin.
+Every requestUri in the apigatewayv2 API is under `/v2/` and none of v1's is, so
+the split is exact. A consumer pointing an `apigatewayv2` client at Substrate needs
+no special configuration.
+
 ### Supported operations
 
 | Operation | Notes |
@@ -4297,6 +4305,35 @@ revision 1.
 ### Cost
 
 Batch itself is free; the compute it launches is not, and substrate launches none.
+
+---
+
+## SSO / Identity Store
+
+**Endpoint:** `sso.{region}.amazonaws.com`
+**Protocol:** JSON (`X-Amz-Target: SWBExternalService.{Op}`)
+
+`SWBExternalService` is the `sso-admin` API's target prefix — not a name that appears
+in any published SDK surface, but what every client sends. Substrate accepts the
+plausible-looking `AWSSSOAdminService` as well, so a caller that constructs the target
+header by hand from the service name also reaches this plugin.
+
+### Supported operations
+
+| Operation | Notes |
+|-----------|-------|
+| ListInstances | One instance per account, created on first read |
+| CreatePermissionSet | |
+| DescribePermissionSet | |
+| UpdatePermissionSet | |
+| DeletePermissionSet | |
+| ListPermissionSets | |
+| AttachManagedPolicyToPermissionSet | |
+| DetachManagedPolicyFromPermissionSet | |
+| ListManagedPoliciesInPermissionSet | |
+| CreateAccountAssignment | |
+| DeleteAccountAssignment | |
+| ListAccountAssignments | |
 
 ---
 

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -146,8 +146,39 @@ func ParseAWSRequest(r *http.Request) (*AWSRequest, *RequestContext, error) {
 
 // extractService determines the AWS service name from available signals, in
 // priority order: X-Amz-Target header, Host header, URL path prefix, SigV4
-// credential scope.
+// credential scope. A resolved "apigateway" is then refined by path, because API
+// Gateway v1 and v2 are indistinguishable by every other signal.
 func extractService(target, host, urlPath, authHeader string) string {
+	return refineAPIGatewayVersion(extractServiceSignals(target, host, urlPath, authHeader), urlPath)
+}
+
+// refineAPIGatewayVersion resolves API Gateway v1 versus v2, which no other
+// routing signal can distinguish: an apigatewayv2 client's SigV4 signing name
+// *is* "apigateway", its Host is the same "apigateway.<region>.amazonaws.com",
+// and neither client sends X-Amz-Target. Every v2 request therefore reached
+// APIGatewayPlugin, which answered NotFoundException for all of them — the v2
+// plugin was registered, tested in-process, and unreachable from any SDK (#529).
+//
+// The path is unambiguous. Every one of the 103 requestUris in the apigatewayv2
+// model lives under "/v2/", and none of the v1 model's URI space does — v1's
+// roots are /account, /apikeys, /clientcertificates, /domainnames,
+// /domainnameaccessassociations, /rejectdomainnameaccessassociations, /restapis,
+// /sdktypes, /tags, /usageplans and /vpclinks. So a "/v2/" path cannot be a v1
+// call, and this cannot misroute one.
+//
+// The check is deliberately confined to requests that already resolved to
+// "apigateway": a bare "/v2/..." path is not evidence of API Gateway by itself,
+// and some other service's endpoint is free to use one.
+func refineAPIGatewayVersion(service, urlPath string) string {
+	if service == "apigateway" && strings.HasPrefix(urlPath, "/v2/") {
+		return "apigatewayv2"
+	}
+	return service
+}
+
+// extractServiceSignals applies the four routing signals in priority order and
+// returns the service they name, or "unknown".
+func extractServiceSignals(target, host, urlPath, authHeader string) string {
 	// 1. X-Amz-Target: "AmazonDynamoDB.GetItem" → "dynamodb"
 	//    or "DynamoDB_20120810.GetItem" → "dynamodb"
 	if target != "" {
@@ -257,8 +288,15 @@ var targetServiceAliases = map[string]string{
 	// "TransferService" → lowercase → "transferservice" → "transfer".
 	// aws-sdk-go-v2 Transfer Family uses X-Amz-Target: TransferService.{Op}.
 	"transferservice": "transfer",
-	// "AWSSSOAdminService" → strip "AWS" → "ssoadminservice" → "sso".
-	// aws-sdk-go-v2 SSO Admin client uses X-Amz-Target: AWSSSOAdminService.{Op}.
+	// "SWBExternalService" → no strip → "swbexternalservice" → "sso".
+	// This is the sso-admin model's targetPrefix, and what both boto3 and
+	// aws-sdk-go-v2 actually send. The "AWSSSOAdminService" prefix below was
+	// derived by guesswork and matches no client, so SSOPlugin was registered,
+	// tested in-process, and unreachable from any SDK — every call fell through
+	// to "service not emulated: swbexternalservice" (#561). Kept alongside the
+	// real prefix rather than replacing it: it costs nothing, and it keeps
+	// working for any caller that does send it.
+	"swbexternalservice": "sso",
 	"awsssoadminservice": "sso",
 	// "RedshiftData_20191217" → strip version → "RedshiftData" → lowercase → "redshiftdata".
 	// Both aws-sdk-go-v2 and boto3 use this X-Amz-Target namespace for the Data API.

--- a/emulator/parser_test.go
+++ b/emulator/parser_test.go
@@ -752,6 +752,87 @@ func TestParseAWSRequest_ServiceFromSigV4Auth(t *testing.T) {
 	}
 }
 
+// TestParseAWSRequest_APIGatewayVersionRouting pins the path discriminator that
+// makes APIGatewayV2Plugin reachable. Both clients sign as "apigateway" and use
+// the same hostname, so before #529 every v2 request landed on the v1 plugin and
+// came back NotFoundException. The v2 model's URI space is entirely under "/v2/"
+// and the v1 model's contains no "/v2/" path, so the split is exact — these cases
+// cover both directions plus the guard that keeps an unrelated service's "/v2/"
+// endpoint out of it.
+func TestParseAWSRequest_APIGatewayVersionRouting(t *testing.T) {
+	t.Parallel()
+	const apigwScope = "AKIATEST12345678901/20240101/us-east-1/apigateway/aws4_request"
+	tests := []struct {
+		name        string
+		authScope   string
+		host        string
+		path        string
+		wantService string
+	}{
+		{"v2 CreateApi by auth scope", apigwScope, "", "/v2/apis", "apigatewayv2"},
+		{"v2 GetRoutes by auth scope", apigwScope, "", "/v2/apis/abc123/routes", "apigatewayv2"},
+		{"v2 by host", "", "apigateway.us-east-1.amazonaws.com", "/v2/apis", "apigatewayv2"},
+		{"v1 restapis stays v1", apigwScope, "", "/restapis", "apigateway"},
+		{"v1 nested path stays v1", apigwScope, "", "/restapis/abc123/resources", "apigateway"},
+		{"v1 usageplans stays v1", apigwScope, "", "/usageplans", "apigateway"},
+		{"v1 root stays v1", apigwScope, "", "/account", "apigateway"},
+		// A v1 rest-api id is ten lowercase alphanumerics and a stage name is
+		// caller-chosen, so either can contain "v2". Only the "/v2/" *prefix*
+		// selects the v2 plugin.
+		{"v1 id containing v2 stays v1", apigwScope, "", "/restapis/abcv2ghijk", "apigateway"},
+		{"v1 stage named v2 stays v1", apigwScope, "", "/restapis/abc123defg/stages/v2", "apigateway"},
+		// The refinement is scoped to apigateway: another service is free to use a
+		// "/v2/" path and must not be captured.
+		{"other service with /v2/ path", "AKIATEST12345678901/20240101/us-east-1/kafka/aws4_request", "", "/v2/clusters", "msk"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodPost, "http://localhost:4566"+tt.path, nil)
+			r.Host = "localhost:4566"
+			if tt.host != "" {
+				r.Host = tt.host
+			}
+			if tt.authScope != "" {
+				r.Header.Set("Authorization",
+					"AWS4-HMAC-SHA256 Credential="+tt.authScope+", SignedHeaders=host, Signature=abc123")
+			}
+
+			req, _, err := emulator.ParseAWSRequest(r)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantService, req.Service)
+		})
+	}
+}
+
+// TestParseAWSRequest_SSOAdminTargetPrefix pins the real sso-admin target prefix.
+// "SWBExternalService" is the sso-admin model's targetPrefix and what clients
+// actually send; the previously-mapped "AWSSSOAdminService" was a guess that
+// matched nothing, so every call fell through to "service not emulated" (#561).
+// The guessed prefix is retained deliberately, so both are asserted.
+func TestParseAWSRequest_SSOAdminTargetPrefix(t *testing.T) {
+	t.Parallel()
+	for _, target := range []string{
+		"SWBExternalService.ListInstances",
+		"SWBExternalService.CreatePermissionSet",
+		"AWSSSOAdminService.ListInstances",
+	} {
+		target := target
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodPost, "http://localhost:4566/", nil)
+			r.Host = "localhost:4566"
+			r.Header.Set("X-Amz-Target", target)
+
+			req, _, err := emulator.ParseAWSRequest(r)
+			require.NoError(t, err)
+			assert.Equal(t, "sso", req.Service)
+		})
+	}
+}
+
 func TestNormalizeS3VirtualHost(t *testing.T) {
 	tests := []struct {
 		host       string


### PR DESCRIPTION
Two plugins were registered, had test files, and could not be reached by any SDK.
Both test files call `HandleRequest` directly, so every unit test was green while
the feature did not exist from a caller's point of view — the same shape twice, so
they are fixed together.

Closes #561.

Part of #529: its third acceptance criterion ("same check applied to API Gateway
v2") is unverifiable end to end while `aws apigatewayv2 create-api` 404s, so this
is a prerequisite of the response-shape work rather than drive-by cleanup. #529
itself stays open for that work.

## API Gateway v2 was unreachable

No routing signal distinguishes v1 from v2. The apigatewayv2 client's SigV4
signing name **is** `apigateway`, its hostname is the same
`apigateway.{region}.amazonaws.com`, and neither client sends `X-Amz-Target`. So
every v2 request resolved to `apigateway`, landed on `APIGatewayPlugin`, and came
back:

```
$ aws apigatewayv2 create-api --name p --protocol-type HTTP
NotFoundException … APIGatewayPlugin: unknown operation for POST /v2/apis
```

`extractService` now refines a resolved `apigateway` to `apigatewayv2` when the
path begins with `/v2/`. That is exact rather than heuristic: **all 103 requestUris
in the apigatewayv2 model are under `/v2/`**, and none of the v1 model's URI space
is — v1's roots are `/account`, `/apikeys`, `/clientcertificates`, `/domainnames`,
`/domainnameaccessassociations`, `/rejectdomainnameaccessassociations`,
`/restapis`, `/sdktypes`, `/tags`, `/usageplans`, `/vpclinks`. So a `/v2/` path
cannot be a v1 call.

The refinement is confined to requests that **already** resolved to `apigateway`.
A bare `/v2/…` path is not evidence of API Gateway by itself, and another service's
endpoint is free to use one — MSK's `/v2/clusters` is exactly that case, and it is
in the test table.

## SSO Admin was unreachable

`targetServiceAliases` mapped `AWSSSOAdminService`, a prefix derived by guesswork
that no client sends. The real `sso-admin` `targetPrefix` is `SWBExternalService`:

```
$ aws sso-admin list-instances
ServiceNotAvailable … service not emulated: swbexternalservice
```

The real prefix is now mapped **alongside** the guessed one rather than replacing
it — retaining it costs nothing and keeps working for a caller that builds the
target header by hand from the service name. The comment records the correction,
since the existing one stated the wrong derivation with some confidence.

## Verified

End to end against `substrate server --address :4620`, both previously impossible:

```
$ aws apigatewayv2 create-api --name pra-v2 --protocol-type HTTP     # 201, was NotFoundException
$ aws sso-admin list-instances
{"Instances": [{"InstanceArn": "arn:aws:sso:::instance/13b848…", "IdentityStoreId": "d-2670d174b0", …}]}
$ aws sso-admin create-permission-set --instance-arn "$ARN" --name ps1   # parses
$ aws sso-admin list-permission-sets --instance-arn "$ARN"              # parses
```

`create-api` returns 201 and the response body is populated, but the CLI still
prints nothing for it — its members are PascalCase, which is #529's separate defect
and is fixed later in this milestone. Reachability is what this PR delivers; it is
also what makes that defect observable at all.

v1 regressions checked in the same session: `create-rest-api`, `/restapis`,
`/usageplans` and `/account` all still reach `APIGatewayPlugin`, and MSK's
`/v1/clusters` is unaffected.

## Tests

Two table-driven cases in `parser_test.go`, both red before the fix:
`TestParseAWSRequest_APIGatewayVersionRouting` (v2 by auth scope and by host; four
v1 paths staying v1; MSK's `/v2/clusters` staying MSK) and
`TestParseAWSRequest_SSOAdminTargetPrefix` (both target prefixes resolving to
`sso`).

**Mutation testing** found a real gap rather than confirming what was already
there. Six mutants: the `apigateway`-only guard dropped, the refinement removed,
the refinement inverted, the real SSO prefix reverted, the legacy SSO prefix
dropped — five caught — and `HasPrefix` loosened to `Contains`, which **survived**.
A v1 rest-api id is ten lowercase alphanumerics and a stage name is caller-chosen,
so either can contain `v2`; `/restapis/abcv2ghijk` would have been routed to the v2
plugin by that mutant with nothing to catch it. Two cases were added for it and the
mutant is now caught, 6/6.

## Docs

`docs/services.md`: the API Gateway v2 section states how v1 and v2 are
discriminated and that a consumer needs no special client configuration, and SSO /
Identity Store gains a section — it was in the coverage matrix with no detail,
which is consistent with having been unreachable. `make docs-reference` reports no
change to the generated matrix; no plugin is added or removed.
