### PR TITLE
fix(msk): return the response shape a Kafka SDK parses (#529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **MSK responses are the shape a Kafka SDK parses** (#529). Every `kafka` response
+  substrate sent used PascalCase keys, and botocore matches a response key against
+  the model's `locationName` **case-sensitively** — so `aws kafka list-clusters`
+  returned HTTP 200 with an empty result and no error at all, and
+  `--query 'length(ClusterInfoList)'` failed on a null. The kafka model spells all
+  579 of its response members in lowerCamel, with no exceptions, so nothing
+  substrate returned parsed: not a missing field here and there, nothing.
+
+  This was invisible from every direction. The request side works, because Go's
+  `json.Unmarshal` matches keys case-insensitively and so accepts the lowerCamel
+  body a real SDK sends into a PascalCase-tagged struct. The state was written
+  correctly. And the Go round-trip tests passed, because a struct marshalled and
+  unmarshalled by its own definition agrees with itself whatever its tags say — the
+  reason the new tests decode into `map[string]any` and assert on literal wire keys
+  instead.
+
+  Fixed as #528 fixed CloudWatch Logs: the state types keep their PascalCase tags,
+  and response-only element types tagged from the model are projected from them.
+  `MSKCluster` and its six sibling state types are **untouched**, so **state
+  encoding is unchanged and recorded runs replay** — the wire types are a separate
+  thing from the persisted format, and a comment in `msk_types.go` says so, because
+  the tempting "fix" for a future casing bug is to retag the state struct and
+  silently change the format of every recorded run.
+
+  Corrected envelopes and members: `clusterInfoList`, `clusterInfo`,
+  `bootstrapBrokerString`, `nodeInfoList`, and `CreateCluster`'s
+  `clusterArn`/`clusterName`/`state`. `NodeInfo`'s ARN member is `nodeARN` — the one
+  kafka response member that is not the plain lowerCamel of its name, transcribed
+  from the model rather than lowercased. `DeleteCluster` no longer reports
+  `clusterName`, which is not a member of `DeleteClusterResponse`. `ListClustersV2`
+  no longer sends an empty `nextToken`, which invited a caller to page on nothing.
+  `DescribeClusterV2`/`ListClustersV2` built a hand-written PascalCase map, which was
+  wrong for the same reason the struct path was; both now use the same projection as
+  v1, so the two cannot drift.
+
+  Three consequences worth stating. Substrate's internal `AccountID` and `Region`
+  are gone from every kafka response, and structurally so: no wire type has such a
+  member, so a field added later cannot reintroduce the leak. An unset optional —
+  `securityGroups`, `storageInfo`, `tags` — is now **omitted** rather than sent as
+  `null` or as `volumeSize: 0`, matching real MSK, since a caller distinguishing
+  absent from null is reading a real observable. And an empty `ListClusters` returns
+  `[]`, not `null`.
 - **API Gateway v2 and SSO Admin are reachable from an SDK at all** (#561, #529).
   Both plugins were registered, had test files, and could not be reached by any
   client — every unit test green, the feature absent from a caller's point of view,

--- a/emulator/cfn_resources_v34.go
+++ b/emulator/cfn_resources_v34.go
@@ -87,8 +87,10 @@ func (d *StackDeployer) deployMSKCluster(
 	if bi, ok := props["BrokerNodeGroupInfo"].(map[string]interface{}); ok {
 		// Resolved rather than asserted on string: a template names its subnets
 		// with a Ref far more often than as literals, and a string assertion
-		// dropped every one of them (#526). MSK's API is natively PascalCase, so
-		// only the values need attention.
+		// dropped every one of them (#526). The keys here are a CloudFormation
+		// template's property names, which are PascalCase; the kafka API's own wire
+		// members are lowerCamel (#529), so do not read these as evidence of the
+		// wire shape.
 		if it := resolveValue(bi["InstanceType"], cctx); it != "" {
 			brokerInfo["InstanceType"] = it
 		}
@@ -130,8 +132,8 @@ func (d *StackDeployer) deployMSKCluster(
 		dr.PhysicalID = name
 	} else if resp != nil {
 		var result struct {
-			ClusterARN  string `json:"ClusterArn"`
-			ClusterName string `json:"ClusterName"`
+			ClusterARN  string `json:"clusterArn"`
+			ClusterName string `json:"clusterName"`
 		}
 		if json.Unmarshal(resp.Body, &result) == nil {
 			dr.PhysicalID = result.ClusterARN

--- a/emulator/msk_plugin.go
+++ b/emulator/msk_plugin.go
@@ -162,9 +162,9 @@ func (p *MSKPlugin) createCluster(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	updateStringIndex(context.Background(), p.state, mskNamespace, indexKey, input.ClusterName)
 
 	return mskJSONResponse(http.StatusOK, map[string]interface{}{
-		"ClusterArn":  clusterARN,
-		"ClusterName": cluster.ClusterName,
-		"State":       cluster.State,
+		"clusterArn":  clusterARN,
+		"clusterName": cluster.ClusterName,
+		"state":       cluster.State,
 	})
 }
 
@@ -177,7 +177,7 @@ func (p *MSKPlugin) describeCluster(_ *RequestContext, _ *AWSRequest, clusterARN
 		return nil, err
 	}
 	return mskJSONResponse(http.StatusOK, map[string]interface{}{
-		"ClusterInfo": cluster,
+		"clusterInfo": mskClusterInfoWire(cluster),
 	})
 }
 
@@ -196,7 +196,7 @@ func (p *MSKPlugin) getBootstrapBrokers(_ *RequestContext, _ *AWSRequest, cluste
 		name, region, name, region,
 	)
 	return mskJSONResponse(http.StatusOK, map[string]string{
-		"BootstrapBrokerString": brokers,
+		"bootstrapBrokerString": brokers,
 	})
 }
 
@@ -207,7 +207,7 @@ func (p *MSKPlugin) listClusters(reqCtx *RequestContext, _ *AWSRequest) (*AWSRes
 		return nil, fmt.Errorf("msk listClusters load index: %w", err)
 	}
 
-	var clusters []MSKCluster
+	infos := make([]mskClusterInfoOut, 0, len(names))
 	for _, name := range names {
 		data, getErr := p.state.Get(context.Background(), mskNamespace, "cluster:"+scope+"/"+name)
 		if getErr != nil || data == nil {
@@ -217,14 +217,11 @@ func (p *MSKPlugin) listClusters(reqCtx *RequestContext, _ *AWSRequest) (*AWSRes
 		if json.Unmarshal(data, &c) != nil {
 			continue
 		}
-		clusters = append(clusters, c)
-	}
-	if clusters == nil {
-		clusters = []MSKCluster{}
+		infos = append(infos, mskClusterInfoWire(&c))
 	}
 
 	return mskJSONResponse(http.StatusOK, map[string]interface{}{
-		"ClusterInfoList": clusters,
+		"clusterInfoList": infos,
 	})
 }
 
@@ -244,10 +241,11 @@ func (p *MSKPlugin) deleteCluster(reqCtx *RequestContext, _ *AWSRequest, cluster
 	}
 	removeFromStringIndex(context.Background(), p.state, mskNamespace, "cluster_ids:"+scope, cluster.ClusterName)
 
+	// DeleteClusterResponse declares only clusterArn and state; clusterName is not
+	// a member of it, so it is not reported here.
 	return mskJSONResponse(http.StatusOK, map[string]interface{}{
-		"ClusterArn":  cluster.ClusterARN,
-		"ClusterName": cluster.ClusterName,
-		"State":       "DELETING",
+		"clusterArn": cluster.ClusterARN,
+		"state":      "DELETING",
 	})
 }
 
@@ -346,7 +344,7 @@ func (p *MSKPlugin) describeClusterV2(_ *RequestContext, _ *AWSRequest, clusterA
 		return nil, err
 	}
 	return mskJSONResponse(http.StatusOK, map[string]interface{}{
-		"ClusterInfo": mskV2ClusterInfo(cluster),
+		"clusterInfo": mskClusterWire(cluster),
 	})
 }
 
@@ -358,7 +356,7 @@ func (p *MSKPlugin) listClustersV2(reqCtx *RequestContext, req *AWSRequest) (*AW
 		return nil, fmt.Errorf("msk listClustersV2 load index: %w", err)
 	}
 
-	infos := make([]map[string]interface{}, 0, len(names))
+	infos := make([]mskClusterOut, 0, len(names))
 	for _, name := range names {
 		data, getErr := p.state.Get(context.Background(), mskNamespace, "cluster:"+scope+"/"+name)
 		if getErr != nil || data == nil {
@@ -368,12 +366,13 @@ func (p *MSKPlugin) listClustersV2(reqCtx *RequestContext, req *AWSRequest) (*AW
 		if json.Unmarshal(data, &c) != nil {
 			continue
 		}
-		infos = append(infos, mskV2ClusterInfo(&c))
+		infos = append(infos, mskClusterWire(&c))
 	}
 	_ = req
+	// nextToken is omitted rather than sent empty: substrate returns every cluster
+	// in one page, and an empty token would invite a caller to page on it.
 	return mskJSONResponse(http.StatusOK, map[string]interface{}{
-		"ClusterInfoList": infos,
-		"NextToken":       "",
+		"clusterInfoList": infos,
 	})
 }
 
@@ -421,27 +420,13 @@ func (p *MSKPlugin) listNodes(_ *RequestContext, _ *AWSRequest, clusterARN strin
 			NodeType:     "BROKER",
 		}
 	}
-	return mskJSONResponse(http.StatusOK, map[string]interface{}{
-		"NodeInfoList": nodes,
-	})
-}
-
-// mskV2ClusterInfo converts an MSKCluster to the V2 ClusterInfo wire shape.
-func mskV2ClusterInfo(c *MSKCluster) map[string]interface{} {
-	return map[string]interface{}{
-		"ClusterArn":   c.ClusterARN,
-		"ClusterName":  c.ClusterName,
-		"ClusterType":  "PROVISIONED",
-		"State":        c.State,
-		"CreationTime": c.CreatedAt,
-		"Provisioned": map[string]interface{}{
-			"BrokerNodeGroupInfo": c.BrokerNodeGroupInfo,
-			"CurrentBrokerSoftwareInfo": MSKBrokerSoftwareInfo{
-				KafkaVersion: c.KafkaVersion,
-			},
-			"NumberOfBrokerNodes": c.NumberOfBrokerNodes,
-		},
+	out := make([]mskNodeInfoOut, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, mskNodeInfoWire(n))
 	}
+	return mskJSONResponse(http.StatusOK, map[string]interface{}{
+		"nodeInfoList": out,
+	})
 }
 
 // mskGenerateUUID produces a short deterministic hex string for cluster ARNs.

--- a/emulator/msk_plugin_test.go
+++ b/emulator/msk_plugin_test.go
@@ -65,21 +65,21 @@ func TestMSKPlugin_CreateListDescribeDeleteCluster(t *testing.T) {
 		t.Fatalf("want 200, got %d", resp.StatusCode)
 	}
 	var created struct {
-		ClusterARN  string `json:"ClusterArn"`
-		ClusterName string `json:"ClusterName"`
-		State       string `json:"State"`
+		ClusterARN  string `json:"clusterArn"`
+		ClusterName string `json:"clusterName"`
+		State       string `json:"state"`
 	}
 	if err := json.Unmarshal(resp.Body, &created); err != nil {
 		t.Fatalf("unmarshal create response: %v", err)
 	}
 	if created.ClusterARN == "" {
-		t.Error("want non-empty ClusterArn")
+		t.Error("want non-empty clusterArn")
 	}
 	if created.ClusterName != "my-kafka" {
-		t.Errorf("want ClusterName=my-kafka, got %q", created.ClusterName)
+		t.Errorf("want clusterName=my-kafka, got %q", created.ClusterName)
 	}
 	if created.State != "ACTIVE" {
-		t.Errorf("want State=ACTIVE, got %q", created.State)
+		t.Errorf("want state=ACTIVE, got %q", created.State)
 	}
 
 	// CreateCluster — duplicate
@@ -108,7 +108,9 @@ func TestMSKPlugin_CreateListDescribeDeleteCluster(t *testing.T) {
 		t.Fatalf("ListClusters: %v", err)
 	}
 	var listed struct {
-		ClusterInfoList []emulator.MSKCluster `json:"ClusterInfoList"`
+		ClusterInfoList []struct {
+			ClusterName string `json:"clusterName"`
+		} `json:"clusterInfoList"`
 	}
 	if err := json.Unmarshal(resp.Body, &listed); err != nil {
 		t.Fatalf("unmarshal list: %v", err)
@@ -117,7 +119,7 @@ func TestMSKPlugin_CreateListDescribeDeleteCluster(t *testing.T) {
 		t.Errorf("want 1 cluster, got %d", len(listed.ClusterInfoList))
 	}
 	if listed.ClusterInfoList[0].ClusterName != "my-kafka" {
-		t.Errorf("want ClusterName=my-kafka, got %q", listed.ClusterInfoList[0].ClusterName)
+		t.Errorf("want clusterName=my-kafka, got %q", listed.ClusterInfoList[0].ClusterName)
 	}
 
 	// DescribeCluster
@@ -126,13 +128,15 @@ func TestMSKPlugin_CreateListDescribeDeleteCluster(t *testing.T) {
 		t.Fatalf("DescribeCluster: %v", err)
 	}
 	var described struct {
-		ClusterInfo emulator.MSKCluster `json:"ClusterInfo"`
+		ClusterInfo struct {
+			ClusterName string `json:"clusterName"`
+		} `json:"clusterInfo"`
 	}
 	if err := json.Unmarshal(resp.Body, &described); err != nil {
 		t.Fatalf("unmarshal describe: %v", err)
 	}
 	if described.ClusterInfo.ClusterName != "my-kafka" {
-		t.Errorf("want ClusterName=my-kafka, got %q", described.ClusterInfo.ClusterName)
+		t.Errorf("want clusterName=my-kafka, got %q", described.ClusterInfo.ClusterName)
 	}
 
 	// DescribeCluster — not found
@@ -154,13 +158,13 @@ func TestMSKPlugin_CreateListDescribeDeleteCluster(t *testing.T) {
 		t.Fatalf("GetBootstrapBrokers: %v", err)
 	}
 	var brokers struct {
-		BootstrapBrokerString string `json:"BootstrapBrokerString"`
+		BootstrapBrokerString string `json:"bootstrapBrokerString"`
 	}
 	if err := json.Unmarshal(resp.Body, &brokers); err != nil {
 		t.Fatalf("unmarshal brokers: %v", err)
 	}
 	if brokers.BootstrapBrokerString == "" {
-		t.Error("want non-empty BootstrapBrokerString")
+		t.Error("want non-empty bootstrapBrokerString")
 	}
 
 	// DeleteCluster
@@ -172,13 +176,13 @@ func TestMSKPlugin_CreateListDescribeDeleteCluster(t *testing.T) {
 		t.Fatalf("want 200, got %d", resp.StatusCode)
 	}
 	var deleted struct {
-		State string `json:"State"`
+		State string `json:"state"`
 	}
 	if err := json.Unmarshal(resp.Body, &deleted); err != nil {
 		t.Fatalf("unmarshal delete: %v", err)
 	}
 	if deleted.State != "DELETING" {
-		t.Errorf("want State=DELETING, got %q", deleted.State)
+		t.Errorf("want state=DELETING, got %q", deleted.State)
 	}
 
 	// DescribeCluster — not found after delete
@@ -235,21 +239,21 @@ func TestMSKPlugin_CreateClusterV2_DescribeListV2(t *testing.T) {
 		t.Fatalf("want 200, got %d", resp.StatusCode)
 	}
 	var created struct {
-		ClusterARN  string `json:"ClusterArn"`
-		ClusterName string `json:"ClusterName"`
-		State       string `json:"State"`
+		ClusterARN  string `json:"clusterArn"`
+		ClusterName string `json:"clusterName"`
+		State       string `json:"state"`
 	}
 	if err := json.Unmarshal(resp.Body, &created); err != nil {
 		t.Fatalf("unmarshal create v2 response: %v", err)
 	}
 	if created.ClusterARN == "" {
-		t.Error("want non-empty ClusterArn")
+		t.Error("want non-empty clusterArn")
 	}
 	if created.ClusterName != "v2-kafka" {
-		t.Errorf("want ClusterName=v2-kafka, got %q", created.ClusterName)
+		t.Errorf("want clusterName=v2-kafka, got %q", created.ClusterName)
 	}
 	if created.State != "ACTIVE" {
-		t.Errorf("want State=ACTIVE, got %q", created.State)
+		t.Errorf("want state=ACTIVE, got %q", created.State)
 	}
 
 	// DescribeClusterV2
@@ -259,26 +263,26 @@ func TestMSKPlugin_CreateClusterV2_DescribeListV2(t *testing.T) {
 	}
 	var described struct {
 		ClusterInfo struct {
-			ClusterARN  string `json:"ClusterArn"`
-			ClusterName string `json:"ClusterName"`
-			ClusterType string `json:"ClusterType"`
-			State       string `json:"State"`
+			ClusterARN  string `json:"clusterArn"`
+			ClusterName string `json:"clusterName"`
+			ClusterType string `json:"clusterType"`
+			State       string `json:"state"`
 			Provisioned struct {
-				NumberOfBrokerNodes int `json:"NumberOfBrokerNodes"`
-			} `json:"Provisioned"`
-		} `json:"ClusterInfo"`
+				NumberOfBrokerNodes int `json:"numberOfBrokerNodes"`
+			} `json:"provisioned"`
+		} `json:"clusterInfo"`
 	}
 	if err := json.Unmarshal(resp.Body, &described); err != nil {
 		t.Fatalf("unmarshal describe v2: %v", err)
 	}
 	if described.ClusterInfo.ClusterType != "PROVISIONED" {
-		t.Errorf("want ClusterType=PROVISIONED, got %q", described.ClusterInfo.ClusterType)
+		t.Errorf("want clusterType=PROVISIONED, got %q", described.ClusterInfo.ClusterType)
 	}
 	if described.ClusterInfo.ClusterName != "v2-kafka" {
-		t.Errorf("want ClusterName=v2-kafka, got %q", described.ClusterInfo.ClusterName)
+		t.Errorf("want clusterName=v2-kafka, got %q", described.ClusterInfo.ClusterName)
 	}
 	if described.ClusterInfo.Provisioned.NumberOfBrokerNodes != 2 {
-		t.Errorf("want NumberOfBrokerNodes=2, got %d", described.ClusterInfo.Provisioned.NumberOfBrokerNodes)
+		t.Errorf("want numberOfBrokerNodes=2, got %d", described.ClusterInfo.Provisioned.NumberOfBrokerNodes)
 	}
 
 	// ListClustersV2
@@ -288,9 +292,9 @@ func TestMSKPlugin_CreateClusterV2_DescribeListV2(t *testing.T) {
 	}
 	var listed struct {
 		ClusterInfoList []struct {
-			ClusterName string `json:"ClusterName"`
-			ClusterType string `json:"ClusterType"`
-		} `json:"ClusterInfoList"`
+			ClusterName string `json:"clusterName"`
+			ClusterType string `json:"clusterType"`
+		} `json:"clusterInfoList"`
 	}
 	if err := json.Unmarshal(resp.Body, &listed); err != nil {
 		t.Fatalf("unmarshal list v2: %v", err)
@@ -299,7 +303,7 @@ func TestMSKPlugin_CreateClusterV2_DescribeListV2(t *testing.T) {
 		t.Errorf("want 1 cluster, got %d", len(listed.ClusterInfoList))
 	}
 	if listed.ClusterInfoList[0].ClusterType != "PROVISIONED" {
-		t.Errorf("want ClusterType=PROVISIONED, got %q", listed.ClusterInfoList[0].ClusterType)
+		t.Errorf("want clusterType=PROVISIONED, got %q", listed.ClusterInfoList[0].ClusterType)
 	}
 }
 
@@ -320,7 +324,7 @@ func TestMSKPlugin_ListNodes(t *testing.T) {
 		t.Fatalf("CreateCluster: %v", err)
 	}
 	var created struct {
-		ClusterARN string `json:"ClusterArn"`
+		ClusterARN string `json:"clusterArn"`
 	}
 	if err := json.Unmarshal(resp.Body, &created); err != nil {
 		t.Fatalf("unmarshal create: %v", err)
@@ -331,8 +335,22 @@ func TestMSKPlugin_ListNodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListNodes: %v", err)
 	}
+	// nodeARN, not nodeArn: the model spells this member with the acronym
+	// capitalised, and it is the one MSK response member that is not the plain
+	// lowerCamel of its name.
 	var nodes struct {
-		NodeInfoList []emulator.MSKNodeInfo `json:"NodeInfoList"`
+		NodeInfoList []struct {
+			NodeARN        string `json:"nodeARN"`
+			NodeType       string `json:"nodeType"`
+			InstanceType   string `json:"instanceType"`
+			BrokerNodeInfo struct {
+				BrokerID                  float64 `json:"brokerId"`
+				ClientSubnet              string  `json:"clientSubnet"`
+				CurrentBrokerSoftwareInfo struct {
+					KafkaVersion string `json:"kafkaVersion"`
+				} `json:"currentBrokerSoftwareInfo"`
+			} `json:"brokerNodeInfo"`
+		} `json:"nodeInfoList"`
 	}
 	if err := json.Unmarshal(resp.Body, &nodes); err != nil {
 		t.Fatalf("unmarshal nodes: %v", err)
@@ -342,16 +360,16 @@ func TestMSKPlugin_ListNodes(t *testing.T) {
 	}
 	for i, n := range nodes.NodeInfoList {
 		if n.NodeType != "BROKER" {
-			t.Errorf("node[%d] want NodeType=BROKER, got %q", i, n.NodeType)
+			t.Errorf("node[%d] want nodeType=BROKER, got %q", i, n.NodeType)
 		}
 		if n.NodeARN == "" {
-			t.Errorf("node[%d] want non-empty NodeArn", i)
+			t.Errorf("node[%d] want non-empty nodeARN", i)
 		}
 		if n.BrokerNodeInfo.BrokerID == 0 {
-			t.Errorf("node[%d] want non-zero BrokerID", i)
+			t.Errorf("node[%d] want non-zero brokerId", i)
 		}
 		if n.BrokerNodeInfo.CurrentBrokerSoftwareInfo.KafkaVersion == "" {
-			t.Errorf("node[%d] want non-empty KafkaVersion", i)
+			t.Errorf("node[%d] want non-empty kafkaVersion", i)
 		}
 	}
 }

--- a/emulator/msk_types.go
+++ b/emulator/msk_types.go
@@ -80,3 +80,166 @@ type MSKBrokerSoftwareInfo struct {
 	// KafkaVersion is the Apache Kafka version running on the broker.
 	KafkaVersion string `json:"KafkaVersion"`
 }
+
+// The wire is a different thing from the state, and the types below exist to keep
+// them apart.
+//
+// The state types above are a persisted format: MemoryStateManager snapshots them
+// and recorded runs replay from those bytes, so their PascalCase tags must not
+// change. The kafka API's wire members are lowerCamel — every response member in
+// the model carries a lowerCamel locationName, 579 of them, with no exceptions —
+// and botocore matches a response key against that name case-sensitively. A
+// PascalCase key therefore matches nothing and parses to nothing: `aws kafka
+// list-clusters` returned HTTP 200 with an empty result and no error, because the
+// state struct was marshaled straight onto the wire (#529).
+//
+// So each response gets its own element type, tagged from the model, projected
+// from the state by a Wire function. Two consequences are deliberate: substrate's
+// own AccountID and Region are simply absent from these types, so the leak cannot
+// come back through a field someone adds later; and `omitempty` follows the model's
+// optionality, because real MSK omits an unset member rather than sending null, and
+// a caller distinguishing absent from null is reading a real observable.
+//
+// Do not "fix" a casing bug here by retagging a state type above. That conflates
+// the two jobs again, and it silently changes the format of every recorded run.
+
+// mskClusterInfoOut is the ClusterInfo element of the v1 DescribeCluster and
+// ListClusters responses.
+type mskClusterInfoOut struct {
+	ClusterARN                string                    `json:"clusterArn"`
+	ClusterName               string                    `json:"clusterName"`
+	State                     string                    `json:"state"`
+	BrokerNodeGroupInfo       mskBrokerNodeGroupInfoOut `json:"brokerNodeGroupInfo"`
+	CurrentBrokerSoftwareInfo mskBrokerSoftwareInfoOut  `json:"currentBrokerSoftwareInfo"`
+	NumberOfBrokerNodes       int                       `json:"numberOfBrokerNodes"`
+	Tags                      map[string]string         `json:"tags,omitempty"`
+	CreationTime              time.Time                 `json:"creationTime"`
+}
+
+// mskClusterOut is the Cluster element of the v2 DescribeClusterV2 and
+// ListClustersV2 responses, which wraps the provisioned detail in a sub-object.
+type mskClusterOut struct {
+	ClusterARN   string            `json:"clusterArn"`
+	ClusterName  string            `json:"clusterName"`
+	ClusterType  string            `json:"clusterType"`
+	State        string            `json:"state"`
+	CreationTime time.Time         `json:"creationTime"`
+	Tags         map[string]string `json:"tags,omitempty"`
+	Provisioned  mskProvisionedOut `json:"provisioned"`
+}
+
+// mskProvisionedOut is the Provisioned member of a v2 Cluster.
+type mskProvisionedOut struct {
+	BrokerNodeGroupInfo       mskBrokerNodeGroupInfoOut `json:"brokerNodeGroupInfo"`
+	CurrentBrokerSoftwareInfo mskBrokerSoftwareInfoOut  `json:"currentBrokerSoftwareInfo"`
+	NumberOfBrokerNodes       int                       `json:"numberOfBrokerNodes"`
+}
+
+// mskBrokerNodeGroupInfoOut is the brokerNodeGroupInfo member of a cluster.
+// clientSubnets and instanceType are required in the model and so are always
+// present; the rest are optional and omitted when unset.
+type mskBrokerNodeGroupInfoOut struct {
+	InstanceType   string             `json:"instanceType"`
+	ClientSubnets  []string           `json:"clientSubnets"`
+	SecurityGroups []string           `json:"securityGroups,omitempty"`
+	StorageInfo    *mskStorageInfoOut `json:"storageInfo,omitempty"`
+}
+
+// mskStorageInfoOut is the storageInfo member of a broker node group.
+type mskStorageInfoOut struct {
+	EBSStorageInfo mskEBSStorageInfoOut `json:"ebsStorageInfo"`
+}
+
+// mskEBSStorageInfoOut is the ebsStorageInfo member of a storage configuration.
+type mskEBSStorageInfoOut struct {
+	VolumeSize int `json:"volumeSize,omitempty"`
+}
+
+// mskBrokerSoftwareInfoOut is the currentBrokerSoftwareInfo member of a cluster
+// or a broker node.
+type mskBrokerSoftwareInfoOut struct {
+	KafkaVersion string `json:"kafkaVersion,omitempty"`
+}
+
+// mskNodeInfoOut is the nodeInfoList element of a ListNodes response. The model
+// spells this member nodeARN, not nodeArn — the one MSK response member that is
+// not the plain lowerCamel of its name.
+type mskNodeInfoOut struct {
+	BrokerNodeInfo mskBrokerNodeInfoOut `json:"brokerNodeInfo"`
+	InstanceType   string               `json:"instanceType,omitempty"`
+	NodeARN        string               `json:"nodeARN"`
+	NodeType       string               `json:"nodeType"`
+}
+
+// mskBrokerNodeInfoOut is the brokerNodeInfo member of a node.
+type mskBrokerNodeInfoOut struct {
+	BrokerID                  float64                  `json:"brokerId"`
+	ClientSubnet              string                   `json:"clientSubnet,omitempty"`
+	CurrentBrokerSoftwareInfo mskBrokerSoftwareInfoOut `json:"currentBrokerSoftwareInfo"`
+}
+
+// mskClusterInfoWire projects a stored cluster onto the v1 ClusterInfo wire shape.
+func mskClusterInfoWire(c *MSKCluster) mskClusterInfoOut {
+	return mskClusterInfoOut{
+		ClusterARN:                c.ClusterARN,
+		ClusterName:               c.ClusterName,
+		State:                     c.State,
+		BrokerNodeGroupInfo:       mskBrokerNodeGroupInfoWire(c.BrokerNodeGroupInfo),
+		CurrentBrokerSoftwareInfo: mskBrokerSoftwareInfoOut{KafkaVersion: c.KafkaVersion},
+		NumberOfBrokerNodes:       c.NumberOfBrokerNodes,
+		Tags:                      c.Tags,
+		CreationTime:              c.CreatedAt,
+	}
+}
+
+// mskClusterWire projects a stored cluster onto the v2 Cluster wire shape. Every
+// cluster substrate creates is provisioned; serverless is not modeled, so
+// clusterType is constant rather than derived.
+func mskClusterWire(c *MSKCluster) mskClusterOut {
+	return mskClusterOut{
+		ClusterARN:   c.ClusterARN,
+		ClusterName:  c.ClusterName,
+		ClusterType:  "PROVISIONED",
+		State:        c.State,
+		CreationTime: c.CreatedAt,
+		Tags:         c.Tags,
+		Provisioned: mskProvisionedOut{
+			BrokerNodeGroupInfo:       mskBrokerNodeGroupInfoWire(c.BrokerNodeGroupInfo),
+			CurrentBrokerSoftwareInfo: mskBrokerSoftwareInfoOut{KafkaVersion: c.KafkaVersion},
+			NumberOfBrokerNodes:       c.NumberOfBrokerNodes,
+		},
+	}
+}
+
+// mskBrokerNodeGroupInfoWire projects broker node configuration onto the wire.
+// An unset storage size is omitted rather than reported as 0, which is a size the
+// API rejects and real MSK never returns.
+func mskBrokerNodeGroupInfoWire(b MSKBrokerNodeGroupInfo) mskBrokerNodeGroupInfoOut {
+	out := mskBrokerNodeGroupInfoOut{
+		InstanceType:   b.InstanceType,
+		ClientSubnets:  b.ClientSubnets,
+		SecurityGroups: b.SecurityGroups,
+	}
+	if b.StorageInfo.EbsStorageInfo.VolumeSize != 0 {
+		out.StorageInfo = &mskStorageInfoOut{
+			EBSStorageInfo: mskEBSStorageInfoOut{VolumeSize: b.StorageInfo.EbsStorageInfo.VolumeSize},
+		}
+	}
+	return out
+}
+
+// mskNodeInfoWire projects a broker node onto the wire.
+func mskNodeInfoWire(n MSKNodeInfo) mskNodeInfoOut {
+	return mskNodeInfoOut{
+		BrokerNodeInfo: mskBrokerNodeInfoOut{
+			BrokerID:     n.BrokerNodeInfo.BrokerID,
+			ClientSubnet: n.BrokerNodeInfo.ClientSubnet,
+			CurrentBrokerSoftwareInfo: mskBrokerSoftwareInfoOut{
+				KafkaVersion: n.BrokerNodeInfo.CurrentBrokerSoftwareInfo.KafkaVersion,
+			},
+		},
+		InstanceType: n.InstanceType,
+		NodeARN:      n.NodeARN,
+		NodeType:     n.NodeType,
+	}
+}

--- a/emulator/msk_wire_test.go
+++ b/emulator/msk_wire_test.go
@@ -1,0 +1,483 @@
+package emulator_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// These tests assert on the raw response bytes rather than round-tripping through
+// a Go struct. That distinction is the whole point: a struct marshaled and
+// unmarshaled by its own definition agrees with itself whatever its tags say, and
+// Go's json.Unmarshal matches keys case-insensitively on top of that — so the
+// pre-#529 tests were green while `aws kafka list-clusters` returned nothing at
+// all. Only a literal-key assertion sees the difference.
+
+// mskWireBody sends one request and decodes the response into a generic map, so
+// every assertion is against the key a real SDK would look for.
+func mskWireBody(t *testing.T, p *emulator.MSKPlugin, ctx *emulator.RequestContext,
+	method, path string, body map[string]any,
+) (map[string]any, []byte) {
+	t.Helper()
+	resp, err := p.HandleRequest(ctx, mskRequest(method, path, body))
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s %s: want 200, got %d", method, path, resp.StatusCode)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(resp.Body, &m); err != nil {
+		t.Fatalf("%s %s: unmarshal body: %v", method, path, err)
+	}
+	return m, resp.Body
+}
+
+// mskWireCreate creates one cluster and returns the decoded create response plus
+// its raw bytes.
+func mskWireCreate(t *testing.T, p *emulator.MSKPlugin, ctx *emulator.RequestContext, name string) (map[string]any, []byte) {
+	t.Helper()
+	return mskWireBody(t, p, ctx, "POST", "/v1/clusters", map[string]any{
+		"clusterName":         name,
+		"kafkaVersion":        "3.5.1",
+		"numberOfBrokerNodes": 3,
+		"brokerNodeGroupInfo": map[string]any{
+			"instanceType":  "kafka.m5.large",
+			"clientSubnets": []string{"subnet-1", "subnet-2"},
+			"storageInfo": map[string]any{
+				"ebsStorageInfo": map[string]any{"volumeSize": 100},
+			},
+		},
+		"tags": map[string]string{"env": "test"},
+	})
+}
+
+// mskWireCluster creates one cluster and returns its ARN.
+func mskWireCluster(t *testing.T, p *emulator.MSKPlugin, ctx *emulator.RequestContext, name string) string {
+	t.Helper()
+	m, _ := mskWireCreate(t, p, ctx, name)
+	arn, ok := m["clusterArn"].(string)
+	if !ok || arn == "" {
+		t.Fatalf("create: want a clusterArn, got %v", m)
+	}
+	return arn
+}
+
+// requireKeys fails unless every named key is present in m.
+func requireKeys(t *testing.T, what string, m map[string]any, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		if _, ok := m[k]; !ok {
+			present := make([]string, 0, len(m))
+			for kk := range m {
+				present = append(present, kk)
+			}
+			t.Errorf("%s: missing wire key %q; present keys: %v", what, k, present)
+		}
+	}
+}
+
+// requireValues asserts each key's value, not merely its presence. Presence alone
+// does not prove a projection carried a member: a Wire function that forgets a
+// field still emits its key, holding Go's zero value, because the wire type's tag
+// has no omitempty. A dropped numberOfBrokerNodes reads as a cluster with no
+// brokers — so every member a projection copies is checked by value here.
+func requireValues(t *testing.T, what string, m map[string]any, want map[string]any) {
+	t.Helper()
+	for k, w := range want {
+		got, ok := m[k]
+		if !ok {
+			t.Errorf("%s: missing wire key %q", what, k)
+			continue
+		}
+		if got != w {
+			t.Errorf("%s: %s = %#v, want %#v", what, k, got, w)
+		}
+	}
+}
+
+func TestMSKWire_CreateCluster(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	m, raw := mskWireCreate(t, p, ctx, "wire-create")
+
+	// CreateClusterResponse declares exactly these three members.
+	requireKeys(t, "CreateCluster", m, "clusterArn", "clusterName", "state")
+	if got := m["clusterName"]; got != "wire-create" {
+		t.Errorf("clusterName: want wire-create, got %v", got)
+	}
+	if got := m["state"]; got != "ACTIVE" {
+		t.Errorf("state: want ACTIVE, got %v", got)
+	}
+	mskAssertNoInternalFields(t, "CreateCluster", raw)
+}
+
+func TestMSKWire_DescribeCluster(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	arn := mskWireCluster(t, p, ctx, "wire-describe")
+
+	m, raw := mskWireBody(t, p, ctx, "GET", "/v1/clusters/"+arn, nil)
+	requireKeys(t, "DescribeCluster", m, "clusterInfo")
+	info, ok := m["clusterInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("clusterInfo: want an object, got %T", m["clusterInfo"])
+	}
+	requireKeys(t, "ClusterInfo", info,
+		"clusterArn", "clusterName", "state", "brokerNodeGroupInfo",
+		"currentBrokerSoftwareInfo", "numberOfBrokerNodes", "tags", "creationTime")
+	requireValues(t, "ClusterInfo", info, map[string]any{
+		"clusterArn":          arn,
+		"clusterName":         "wire-describe",
+		"state":               "ACTIVE",
+		"numberOfBrokerNodes": float64(3),
+	})
+	if tags, ok := info["tags"].(map[string]any); !ok || tags["env"] != "test" {
+		t.Errorf("tags: want env=test, got %#v", info["tags"])
+	}
+	if ct, ok := info["creationTime"].(string); !ok || ct == "" {
+		t.Errorf("creationTime: want a timestamp, got %#v", info["creationTime"])
+	}
+	mskAssertNoInternalFields(t, "DescribeCluster", raw)
+}
+
+func TestMSKWire_ListClusters(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	mskWireCluster(t, p, ctx, "wire-list")
+
+	m, raw := mskWireBody(t, p, ctx, "GET", "/v1/clusters", nil)
+	// The envelope is clusterInfoList, not ClusterInfoList: botocore parses
+	// {"ClusterInfoList": […]} to an empty result with no error.
+	requireKeys(t, "ListClusters", m, "clusterInfoList")
+	list, ok := m["clusterInfoList"].([]any)
+	if !ok || len(list) != 1 {
+		t.Fatalf("clusterInfoList: want one element, got %v", m["clusterInfoList"])
+	}
+	elem, ok := list[0].(map[string]any)
+	if !ok {
+		t.Fatalf("clusterInfoList[0]: want an object, got %T", list[0])
+	}
+	requireKeys(t, "ListClusters element", elem,
+		"clusterArn", "clusterName", "state", "numberOfBrokerNodes", "creationTime")
+	requireValues(t, "ListClusters element", elem, map[string]any{
+		"clusterName":         "wire-list",
+		"state":               "ACTIVE",
+		"numberOfBrokerNodes": float64(3),
+	})
+	mskAssertNoInternalFields(t, "ListClusters", raw)
+}
+
+// TestMSKWire_ListClustersEmpty pins the empty case as a list rather than null: a
+// caller iterating the result must not have to handle a JSON null.
+func TestMSKWire_ListClustersEmpty(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	m, _ := mskWireBody(t, p, ctx, "GET", "/v1/clusters", nil)
+	list, ok := m["clusterInfoList"].([]any)
+	if !ok {
+		t.Fatalf("clusterInfoList: want an empty list, got %#v", m["clusterInfoList"])
+	}
+	if len(list) != 0 {
+		t.Errorf("clusterInfoList: want 0 elements, got %d", len(list))
+	}
+}
+
+func TestMSKWire_DeleteCluster(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	arn := mskWireCluster(t, p, ctx, "wire-delete")
+
+	m, raw := mskWireBody(t, p, ctx, "DELETE", "/v1/clusters/"+arn, nil)
+	requireKeys(t, "DeleteCluster", m, "clusterArn", "state")
+	if got := m["state"]; got != "DELETING" {
+		t.Errorf("state: want DELETING, got %v", got)
+	}
+	// DeleteClusterResponse declares only clusterArn and state.
+	if _, ok := m["clusterName"]; ok {
+		t.Error("DeleteCluster: clusterName is not a member of DeleteClusterResponse")
+	}
+	mskAssertNoInternalFields(t, "DeleteCluster", raw)
+}
+
+func TestMSKWire_GetBootstrapBrokers(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	arn := mskWireCluster(t, p, ctx, "wire-brokers")
+
+	m, raw := mskWireBody(t, p, ctx, "GET", "/v1/clusters/"+arn+"/bootstrap-brokers", nil)
+	requireKeys(t, "GetBootstrapBrokers", m, "bootstrapBrokerString")
+	mskAssertNoInternalFields(t, "GetBootstrapBrokers", raw)
+}
+
+func TestMSKWire_ListNodes(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	arn := mskWireCluster(t, p, ctx, "wire-nodes")
+
+	m, raw := mskWireBody(t, p, ctx, "GET", "/v1/clusters/"+arn+"/nodes", nil)
+	requireKeys(t, "ListNodes", m, "nodeInfoList")
+	list, ok := m["nodeInfoList"].([]any)
+	if !ok || len(list) != 3 {
+		t.Fatalf("nodeInfoList: want three elements, got %v", m["nodeInfoList"])
+	}
+	node, ok := list[0].(map[string]any)
+	if !ok {
+		t.Fatalf("nodeInfoList[0]: want an object, got %T", list[0])
+	}
+	// nodeARN: the acronym stays capitalised in this one member.
+	requireKeys(t, "NodeInfo", node, "nodeARN", "nodeType", "instanceType", "brokerNodeInfo")
+	requireValues(t, "NodeInfo", node, map[string]any{
+		"nodeType":     "BROKER",
+		"instanceType": "kafka.m5.large",
+	})
+	if s, ok := node["nodeARN"].(string); !ok || s == "" {
+		t.Errorf("nodeARN: want a non-empty ARN, got %#v", node["nodeARN"])
+	}
+	if _, ok := node["nodeArn"]; ok {
+		t.Error("NodeInfo: the member is nodeARN, not nodeArn")
+	}
+	bni, ok := node["brokerNodeInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("brokerNodeInfo: want an object, got %T", node["brokerNodeInfo"])
+	}
+	requireKeys(t, "BrokerNodeInfo", bni, "brokerId", "clientSubnet", "currentBrokerSoftwareInfo")
+	requireValues(t, "BrokerNodeInfo", bni, map[string]any{
+		"brokerId":     float64(1),
+		"clientSubnet": "subnet-1",
+	})
+	sw, ok := bni["currentBrokerSoftwareInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("currentBrokerSoftwareInfo: want an object, got %T", bni["currentBrokerSoftwareInfo"])
+	}
+	requireValues(t, "BrokerSoftwareInfo", sw, map[string]any{"kafkaVersion": "3.5.1"})
+	mskAssertNoInternalFields(t, "ListNodes", raw)
+}
+
+// TestMSKWire_NestedProjection walks the deepest nesting a cluster response has —
+// clusterInfo → brokerNodeGroupInfo → storageInfo → ebsStorageInfo — because a
+// projection that converts only the top level leaves the nested value PascalCase
+// and a caller parses a cluster whose broker configuration is empty.
+func TestMSKWire_NestedProjection(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	arn := mskWireCluster(t, p, ctx, "wire-nested")
+
+	m, _ := mskWireBody(t, p, ctx, "GET", "/v1/clusters/"+arn, nil)
+	info := m["clusterInfo"].(map[string]any)
+
+	bng, ok := info["brokerNodeGroupInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("brokerNodeGroupInfo: want an object, got %T", info["brokerNodeGroupInfo"])
+	}
+	requireKeys(t, "BrokerNodeGroupInfo", bng, "instanceType", "clientSubnets", "storageInfo")
+	requireValues(t, "BrokerNodeGroupInfo", bng, map[string]any{"instanceType": "kafka.m5.large"})
+	subnets, ok := bng["clientSubnets"].([]any)
+	if !ok || len(subnets) != 2 || subnets[0] != "subnet-1" || subnets[1] != "subnet-2" {
+		t.Errorf("clientSubnets: want [subnet-1 subnet-2], got %#v", bng["clientSubnets"])
+	}
+
+	si, ok := bng["storageInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("storageInfo: want an object, got %T", bng["storageInfo"])
+	}
+	requireKeys(t, "StorageInfo", si, "ebsStorageInfo")
+
+	ebs, ok := si["ebsStorageInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("ebsStorageInfo: want an object, got %T", si["ebsStorageInfo"])
+	}
+	requireKeys(t, "EBSStorageInfo", ebs, "volumeSize")
+	if got := ebs["volumeSize"]; got != float64(100) {
+		t.Errorf("volumeSize: want 100, got %v", got)
+	}
+
+	sw, ok := info["currentBrokerSoftwareInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("currentBrokerSoftwareInfo: want an object, got %T", info["currentBrokerSoftwareInfo"])
+	}
+	requireKeys(t, "BrokerSoftwareInfo", sw, "kafkaVersion")
+	if got := sw["kafkaVersion"]; got != "3.5.1" {
+		t.Errorf("kafkaVersion: want 3.5.1, got %v", got)
+	}
+}
+
+// TestMSKWire_UnsetOptionalsAreOmitted pins absent-versus-null. Real MSK omits an
+// unset member; substrate used to send "securityGroups": null and
+// "volumeSize": 0 because the state struct it marshaled had no omitempty, and a
+// caller distinguishing the two reads a real observable.
+func TestMSKWire_UnsetOptionalsAreOmitted(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	// No securityGroups, no storageInfo, no tags.
+	m, _ := mskWireBody(t, p, ctx, "POST", "/v1/clusters", map[string]any{
+		"clusterName":         "wire-sparse",
+		"numberOfBrokerNodes": 2,
+		"brokerNodeGroupInfo": map[string]any{
+			"instanceType":  "kafka.m5.large",
+			"clientSubnets": []string{"subnet-1"},
+		},
+	})
+	arn := m["clusterArn"].(string)
+
+	body, raw := mskWireBody(t, p, ctx, "GET", "/v1/clusters/"+arn, nil)
+	info := body["clusterInfo"].(map[string]any)
+	if _, ok := info["tags"]; ok {
+		t.Error("tags: an unset map must be omitted, not sent empty")
+	}
+	bng := info["brokerNodeGroupInfo"].(map[string]any)
+	if _, ok := bng["securityGroups"]; ok {
+		t.Error("securityGroups: an unset list must be omitted, not sent as null")
+	}
+	if _, ok := bng["storageInfo"]; ok {
+		t.Error("storageInfo: unset storage must be omitted rather than reporting volumeSize 0")
+	}
+	if bytes.Contains(raw, []byte("null")) {
+		t.Errorf("response contains a JSON null: %s", raw)
+	}
+}
+
+func TestMSKWire_DescribeClusterV2(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	m, _ := mskWireBody(t, p, ctx, "POST", "/api/v2/clusters", map[string]any{
+		"clusterName": "wire-v2",
+		"provisioned": map[string]any{
+			"kafkaVersion":        "3.6.0",
+			"numberOfBrokerNodes": 2,
+			"brokerNodeGroupInfo": map[string]any{
+				"instanceType":  "kafka.m5.xlarge",
+				"clientSubnets": []string{"subnet-a"},
+			},
+		},
+	})
+	arn := m["clusterArn"].(string)
+
+	body, raw := mskWireBody(t, p, ctx, "GET", "/api/v2/clusters/"+arn, nil)
+	requireKeys(t, "DescribeClusterV2", body, "clusterInfo")
+	info, ok := body["clusterInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("clusterInfo: want an object, got %T", body["clusterInfo"])
+	}
+	requireKeys(t, "Cluster", info,
+		"clusterArn", "clusterName", "clusterType", "state", "creationTime", "provisioned")
+	requireValues(t, "Cluster", info, map[string]any{
+		"clusterArn":  arn,
+		"clusterName": "wire-v2",
+		"clusterType": "PROVISIONED",
+		"state":       "ACTIVE",
+	})
+	prov, ok := info["provisioned"].(map[string]any)
+	if !ok {
+		t.Fatalf("provisioned: want an object, got %T", info["provisioned"])
+	}
+	requireKeys(t, "Provisioned", prov,
+		"brokerNodeGroupInfo", "currentBrokerSoftwareInfo", "numberOfBrokerNodes")
+	requireValues(t, "Provisioned", prov, map[string]any{"numberOfBrokerNodes": float64(2)})
+	if sw, ok := prov["currentBrokerSoftwareInfo"].(map[string]any); !ok || sw["kafkaVersion"] != "3.6.0" {
+		t.Errorf("provisioned.currentBrokerSoftwareInfo: want kafkaVersion 3.6.0, got %#v", prov["currentBrokerSoftwareInfo"])
+	}
+	// The v2 projection must reach the same depth as v1's, not stop at Provisioned.
+	bng, ok := prov["brokerNodeGroupInfo"].(map[string]any)
+	if !ok {
+		t.Fatalf("provisioned.brokerNodeGroupInfo: want an object, got %T", prov["brokerNodeGroupInfo"])
+	}
+	requireKeys(t, "Provisioned.BrokerNodeGroupInfo", bng, "instanceType", "clientSubnets")
+	requireValues(t, "Provisioned.BrokerNodeGroupInfo", bng, map[string]any{"instanceType": "kafka.m5.xlarge"})
+	mskAssertNoInternalFields(t, "DescribeClusterV2", raw)
+}
+
+func TestMSKWire_ListClustersV2(t *testing.T) {
+	p, ctx := setupMSKPlugin(t)
+	mskWireBody(t, p, ctx, "POST", "/api/v2/clusters", map[string]any{
+		"clusterName": "wire-v2-list",
+		"provisioned": map[string]any{
+			"kafkaVersion":        "3.6.0",
+			"numberOfBrokerNodes": 2,
+			"brokerNodeGroupInfo": map[string]any{
+				"instanceType":  "kafka.m5.xlarge",
+				"clientSubnets": []string{"subnet-a"},
+			},
+		},
+	})
+
+	m, raw := mskWireBody(t, p, ctx, "GET", "/api/v2/clusters", nil)
+	requireKeys(t, "ListClustersV2", m, "clusterInfoList")
+	list, ok := m["clusterInfoList"].([]any)
+	if !ok || len(list) != 1 {
+		t.Fatalf("clusterInfoList: want one element, got %v", m["clusterInfoList"])
+	}
+	elem, ok := list[0].(map[string]any)
+	if !ok {
+		t.Fatalf("clusterInfoList[0]: want an object, got %T", list[0])
+	}
+	requireKeys(t, "ListClustersV2 element", elem,
+		"clusterArn", "clusterName", "clusterType", "state", "provisioned")
+	requireValues(t, "ListClustersV2 element", elem, map[string]any{
+		"clusterName": "wire-v2-list",
+		"clusterType": "PROVISIONED",
+		"state":       "ACTIVE",
+	})
+	if prov, ok := elem["provisioned"].(map[string]any); !ok || prov["numberOfBrokerNodes"] != float64(2) {
+		t.Errorf("provisioned: want numberOfBrokerNodes 2, got %#v", elem["provisioned"])
+	}
+	// An empty nextToken would invite a caller to page on nothing.
+	if _, ok := m["nextToken"]; ok {
+		t.Error("nextToken: substrate returns one page, so the token must be omitted")
+	}
+	mskAssertNoInternalFields(t, "ListClustersV2", raw)
+}
+
+// mskAssertNoInternalFields checks the raw bytes, not a decoded top-level map: a
+// nested occurrence of AccountID or Region would pass a top-level key check while
+// still reaching the caller. #529 requires no response carry either.
+func mskAssertNoInternalFields(t *testing.T, what string, raw []byte) {
+	t.Helper()
+	for _, bad := range []string{`"AccountID"`, `"Region"`, `"accountId"`, `"region"`} {
+		if bytes.Contains(raw, []byte(bad)) {
+			t.Errorf("%s: response carries substrate's internal %s: %s", what, bad, raw)
+		}
+	}
+}
+
+// TestMSKWire_StateEncodingUnchanged makes "state encoding is unchanged" a fact
+// rather than a claim. The stored bytes are a persisted format that recorded runs
+// replay from, so they must keep their PascalCase keys even though the wire is
+// lowerCamel. This is the test that fails if someone later fixes a casing bug by
+// retagging the state struct instead of the wire type.
+func TestMSKWire_StateEncodingUnchanged(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	p := &emulator.MSKPlugin{}
+	if err := p.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: emulator.NewDefaultLogger(0, false),
+	}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	ctx := &emulator.RequestContext{AccountID: "123456789012", Region: "us-east-1", RequestID: "req-1"}
+	if _, err := p.HandleRequest(ctx, mskRequest("POST", "/v1/clusters", map[string]any{
+		"clusterName":         "state-shape",
+		"numberOfBrokerNodes": 2,
+		"brokerNodeGroupInfo": map[string]any{
+			"instanceType":  "kafka.m5.large",
+			"clientSubnets": []string{"subnet-1"},
+		},
+	})); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	data, err := state.Get(context.Background(), "msk", "cluster:123456789012/us-east-1/state-shape")
+	if err != nil || data == nil {
+		t.Fatalf("state.Get: %v (data=%v)", err, data)
+	}
+	var stored map[string]any
+	if err := json.Unmarshal(data, &stored); err != nil {
+		t.Fatalf("unmarshal stored cluster: %v", err)
+	}
+	for _, k := range []string{
+		"ClusterName", "ClusterArn", "State", "BrokerNodeGroupInfo",
+		"NumberOfBrokerNodes", "KafkaVersion", "AccountID", "Region", "CreatedAt",
+	} {
+		if _, ok := stored[k]; !ok {
+			t.Errorf("stored cluster: key %q is missing; the persisted format must not change", k)
+		}
+	}
+	// And the wire spelling must NOT appear in state, or the two have been conflated.
+	if _, ok := stored["clusterArn"]; ok {
+		t.Error("stored cluster: wire spelling clusterArn found in the persisted format")
+	}
+}


### PR DESCRIPTION
Second of four PRs for #529 (v0.91.0). [PR A](https://github.com/scttfrdmn/substrate/pull/563) made API Gateway v2 and SSO Admin reachable from an SDK at all; this one fixes MSK's wire shape. API Gateway v1 and v2 follow.

## The defect

`aws kafka list-clusters` returned HTTP 200 with an empty result and no error. So did every other kafka call. Not "some fields missing" — nothing parsed.

botocore's rest-json parser matches a response key against the model's `locationName` **case-sensitively**. The kafka model spells all 579 of its response members in lowerCamel, with no exceptions. Substrate marshaled its PascalCase state struct straight onto the wire, so `{"ClusterInfoList":[…]}` matched nothing and parsed to `{}`.

This corrects #529 as filed, which says MSK's *"API is natively PascalCase, so its casing is correct"* and flags only the `AccountID`/`Region` leak. Both are wrong: the casing is broken exactly as API Gateway's is, and the leak is the smaller half. (Posted as a correction on the issue before starting.)

## Why nothing caught it

Three independent reasons, and they are the reason this defect class is worth a release:

- **The request side works.** Go's `json.Unmarshal` matches keys case-insensitively, so the lowerCamel body a real SDK sends parses into a PascalCase-tagged struct without complaint. Verified live.
- **The state was written correctly.** Nothing was corrupted; only the response was unreadable.
- **The Go tests passed.** A struct marshaled and unmarshaled by its own definition agrees with itself whatever its tags say — and on top of that, the case-insensitive match means even a hand-written assertion struct with the wrong tags stays green. `msk_plugin_test.go` was green while the CLI returned nothing.

That last point is why the new tests decode into `map[string]any` and assert on **literal wire keys**. It is the only assertion that can see the difference.

## The fix

#528's remedy at `cloudwatchlogs_types.go:59-121`, followed exactly:

- **`MSKCluster` and its six sibling state types are untouched.** Their PascalCase tags are a persisted format that `MemoryStateManager` snapshots and recorded runs replay from. **State encoding is unchanged.** A comment block in `msk_types.go` says why, because the tempting fix for a future casing bug is to retag the state struct — which conflates the two jobs again and silently changes the format of every recorded run. `TestMSKWire_StateEncodingUnchanged` makes that a fact rather than a claim.
- Response-only element types (`mskClusterInfoOut`, `mskClusterOut`, `mskProvisionedOut`, `mskBrokerNodeGroupInfoOut`, `mskStorageInfoOut`, `mskEBSStorageInfoOut`, `mskBrokerSoftwareInfoOut`, `mskNodeInfoOut`, `mskBrokerNodeInfoOut`), each tagged from the model, each projected by a `…Wire()` function.
- **No wire type has an `AccountID` or `Region` member at all.** The leak is fixed structurally, not by an `omitempty` that a field added later could defeat.

### Judgement calls, from the model rather than the current code

- **`nodeARN`, not `nodeArn`.** The one kafka response member that is not the plain lowerCamel of its name. Transcribed from the model; a mechanical lowercasing would have got exactly this wrong.
- **`DeleteCluster` no longer reports `clusterName`.** It is not a member of `DeleteClusterResponse`.
- **`ListClustersV2` no longer sends an empty `nextToken`.** Substrate returns every cluster in one page, and an empty token invites a caller to page on nothing.
- **Unset optionals are omitted, not nulled.** `securityGroups: null` and `volumeSize: 0` appeared on the wire because the state struct has no `omitempty`; real MSK omits an unset member, and `volumeSize: 0` is a size the API rejects. A caller distinguishing absent from null is reading a real observable, so this is a behaviour change on purpose.
- **An empty `ListClusters` returns `[]`, not `null`.**
- **`mskV2ClusterInfo` is deleted.** The v2 handlers built a hand-written PascalCase map — wrong for the same reason the struct path was, not right for being hand-written. v1 and v2 now share one projection and cannot drift.

### `cfn_resources_v34.go`

Two changes, neither behavioural. The comment claimed *"MSK's API is natively PascalCase, so only the values need attention"* — the PascalCase keys there are CloudFormation **template property** names and are no evidence of the wire shape; corrected with a pointer to #529. And the create-response struct is retagged `clusterArn`/`clusterName` to document the real wire shape.

That retag is provably a no-op: `deployMSKCluster` unmarshals with `encoding/json`, which matches case-insensitively, so both spellings recover `PhysicalID`/`ARN` from the lowerCamel body. Confirmed by mutation — reverting the tag leaves `TestCFN_MSKCluster` green, verdict **EQUIVALENT** with that proof. It is the same mechanism that hid #529, benign here because both ends are Go.

## Tests

`emulator/msk_wire_test.go`, new — 12 tests asserting the raw wire:

- One envelope-and-element test per operation (create, describe, list, delete, bootstrap-brokers, list-nodes, describe-v2, list-v2), each on literal keys. One test covering all eight would pass while seven were wrong.
- **Byte-level leak assertions** via `bytes.Contains` on every response, per #529's criterion — a nested `AccountID` would hide from a top-level map check.
- A nested-projection test walking `clusterInfo` → `brokerNodeGroupInfo` → `storageInfo` → `ebsStorageInfo`, and the v2 equivalent through `provisioned`. A projection that converts only the top level leaves the nested value PascalCase and a caller parses a cluster with no broker configuration.
- Absent-versus-null, and empty-list-versus-null.
- The state-encoding invariance test described above.
- **Value assertions, not just key presence** (`requireValues`). Mutation testing found this gap: a `Wire()` that forgets a member still emits its key holding Go's zero value, so `numberOfBrokerNodes` silently became 0 and a presence check saw nothing wrong. That is the likeliest real-world slip in a transcription like this, so every member a projection copies is now checked by value.

`msk_plugin_test.go`'s nine assertion blocks are converted to the real wire keys. Worth saying plainly: **those assertions were wrong today and passed anyway** — the case-insensitive match again. Updating them is part of the fix, not weakened testing.

## Verification

**Mutation testing, 17 mutants, 17 CAUGHT** (green baseline pre-flight; anchor-count assert before applying; `gofmt`+`go vet` gate; `-race`): an element tag reverted to PascalCase; the v1 and v2 envelopes reverted; an `AccountID` field added back to a wire type; the nested projection skipped; five separate members dropped from four different `Wire()` functions; `nodeARN` lowercased; `storageInfo` always emitted; `securityGroups`' `omitempty` dropped; `clusterName` added back to delete; `nextToken` restored; and the state struct retagged to the wire spelling. Plus one EQUIVALENT with the proof given above.

Gates: `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**, `make test` (race), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test -C test/e2e ./...` — all clean.

Live against `substrate server`, every line of which returned empty or a null-type error before:

```
create-cluster                              → ClusterArn/ClusterName/State all parse
list-clusters --query 'length(…)'           → 1
describe-cluster … ClusterInfo.ClusterName  → c1
… BrokerNodeGroupInfo.StorageInfo.EbsStorageInfo.VolumeSize → 100   (nested)
… CurrentBrokerSoftwareInfo.KafkaVersion    → 3.5.1
list-clusters-v2 … ClusterType              → PROVISIONED
describe-cluster-v2 … Provisioned.NumberOfBrokerNodes → 2
get-bootstrap-brokers                       → broker1.c1.us-east-1…:9092,…
list-nodes → 2 nodes, NodeARN and BrokerNodeInfo.BrokerId both parse
delete-cluster --query State                → DELETING
AccountID/Region in any response body       → 0
```

The raw body, from botocore's own debug log: `{"clusterInfoList":[{"clusterArn":…,"clusterName":"c2","state":"ACTIVE","brokerNodeGroupInfo":{"instanceType":…,"clientSubnets":[…]},"currentBrokerSoftwareInfo":{"kafkaVersion":"3.5.1"},"numberOfBrokerNodes":2,"creationTime":…}]}` — lowerCamel throughout, no leak, no nulls, sparse members absent.

`docs/services.md` needed no change: it documents no MSK member names, only the service-table row.

## Compatibility

A consumer asserting a PascalCase member, an `AccountID`/`Region` field, a `clusterName` on a delete response, or an empty `nextToken` from MSK will go red. That is the fix — those shapes were unparseable by a real SDK — but anyone pinned to the broken shape should know. State encoding is unchanged, so recorded runs replay.

#529 stays open until API Gateway v1 and v2 land.

Refs #529
