### PR TITLE
fix(apigateway): return the v1 response shape an SDK parses (#529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **API Gateway v1 responses are the shape an SDK parses** (#529). Every `apigateway`
+  response substrate sent used PascalCase members under an `items` envelope, and
+  botocore matches a response key against the model's `locationName`
+  **case-sensitively** — so `aws apigateway create-rest-api --query id` printed
+  nothing and `get-rest-apis --query 'length(items)'` failed on a null. Not a field
+  missing here and there: nothing substrate returned parsed.
+
+  Both halves were wrong, and this corrects #529 as filed, which says the envelope
+  key `items` is *"already correct"*. Every v1 collection member is spelled `items`
+  in the model but carries `locationName: "item"` — singular — so `{"items": […]}`
+  parses to nothing and `{"item": […]}` parses. Seven of substrate's eight list
+  handlers sent the plural and now send `item`. `GetStages` is the exception: its
+  model member is literally named `item`, substrate already emitted `item`, and it
+  is deliberately **unchanged** — a blanket rename would have broken the only v1
+  list an SDK could already read. `TestAPIGatewayWire_GetStagesEnvelope` is the
+  regression gate for exactly that.
+
+  Fixed as #528 fixed CloudWatch Logs and as MSK is fixed below: the eleven state
+  types keep their PascalCase tags and are **untouched**, so **state encoding is
+  unchanged and recorded runs replay**; eleven response-only element types tagged
+  from the model are projected from them by a `Wire` function, and none of those
+  types has an `AccountID`, `Region` or `APIId` member at all, so substrate's
+  internal fields cannot leak back through a field someone adds later.
+
+  The projection recurses, which needed a second fix to be observable: `Resource`
+  declares a `resourceMethods` map and `Method` a `methodIntegration`, but substrate
+  stored methods and integrations under their own state keys and never joined them,
+  so both members were permanently absent from every response. `GetResource` and
+  `GetMethod` now report them, projected at all three depths.
+
+  Judgement calls taken from the model rather than the previous code: `providerARNs`
+  keeps its capitalised acronym, the one v1 member that is not the plain lowerCamel
+  of its name; `UsagePlan` reports no `createdDate` and `BasePathMapping` no
+  `domainName`, neither being a member of its shape; unset optionals are omitted
+  rather than sent as `""` or `null`, because real API Gateway omits them and a
+  caller distinguishing absent from null is reading a real observable; and no
+  response carries a `position` token, since substrate returns every element in one
+  page and honours none — an empty token would invite a caller to page on nothing.
+  `GetStage`'s `invokeUrl` is substrate's own convenience that no model declares; it
+  is kept, respelled from `InvokeUrl`, and cannot confuse an SDK because botocore
+  drops a key the model does not declare.
+
+  Existing assertions in `apigateway_plugin_test.go` and `apigateway_proxy_test.go`
+  are updated to the real wire keys. Worth saying plainly: those assertions were
+  **wrong today and passed anyway**, for the same case-insensitivity reason, and one
+  even carried a comment documenting the broken spelling as intended.
+
 - **MSK responses are the shape a Kafka SDK parses** (#529). Every `kafka` response
   substrate sent used PascalCase keys, and botocore matches a response key against
   the model's `locationName` **case-sensitively** — so `aws kafka list-clusters`

--- a/docs/services.md
+++ b/docs/services.md
@@ -3539,6 +3539,15 @@ ACM certificates are free.
 **Endpoint:** `apigateway.{region}.amazonaws.com`
 **Protocol:** REST/JSON
 
+**Response shape:** every member is lowerCamel as the service model spells it
+(`id`, `name`, `rootResourceId`, `resourceMethods`, `methodIntegration`, …), and
+collection responses nest their elements under **`item`** — singular, because that
+is the `locationName` of the `items` member. `GetUsage` uses a third spelling,
+`values`, and is not routed. Responses carry no pagination `position`: Substrate
+returns every element in one page and honours no token. Earlier releases sent
+PascalCase members under an `items` envelope, which an AWS SDK parsed to an empty
+result with no error (#529).
+
 ### Supported operations
 
 | Operation | Notes |

--- a/emulator/apigateway_plugin.go
+++ b/emulator/apigateway_plugin.go
@@ -438,7 +438,7 @@ func (p *APIGatewayPlugin) createRestAPI(ctx *RequestContext, req *AWSRequest) (
 	}
 	updateStringIndex(goCtx, p.state, apigatewayNamespace, apigwResourceIDsKey(ctx.AccountID, ctx.Region, apiID), rootResID)
 
-	return apigwJSONResponse(http.StatusCreated, api)
+	return apigwJSONResponse(http.StatusCreated, restAPIWire(api))
 }
 
 func (p *APIGatewayPlugin) getRestAPI(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -454,7 +454,7 @@ func (p *APIGatewayPlugin) getRestAPI(ctx *RequestContext, apiID string) (*AWSRe
 	if err := json.Unmarshal(data, &api); err != nil {
 		return nil, fmt.Errorf("apigateway getRestAPI unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, api)
+	return apigwJSONResponse(http.StatusOK, restAPIWire(api))
 }
 
 func (p *APIGatewayPlugin) getRestAPIs(ctx *RequestContext) (*AWSResponse, error) {
@@ -464,7 +464,7 @@ func (p *APIGatewayPlugin) getRestAPIs(ctx *RequestContext) (*AWSResponse, error
 		return nil, fmt.Errorf("apigateway getRestApis loadIndex: %w", err)
 	}
 
-	items := make([]RestAPIState, 0, len(ids))
+	items := make([]restAPIOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayNamespace, apigwAPIKey(ctx.AccountID, ctx.Region, id))
 		if getErr != nil || data == nil {
@@ -472,14 +472,11 @@ func (p *APIGatewayPlugin) getRestAPIs(ctx *RequestContext) (*AWSResponse, error
 		}
 		var api RestAPIState
 		if json.Unmarshal(data, &api) == nil {
-			items = append(items, api)
+			items = append(items, restAPIWire(api))
 		}
 	}
 
-	type response struct {
-		Items []RestAPIState `json:"items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwItemsOut[restAPIOut]{Item: items})
 }
 
 func (p *APIGatewayPlugin) deleteRestAPI(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -519,7 +516,7 @@ func (p *APIGatewayPlugin) updateRestAPI(ctx *RequestContext, _ *AWSRequest, api
 	if err := p.state.Put(goCtx, apigatewayNamespace, apigwAPIKey(ctx.AccountID, ctx.Region, apiID), updated); err != nil {
 		return nil, fmt.Errorf("apigateway updateRestApi state.Put: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, api)
+	return apigwJSONResponse(http.StatusOK, restAPIWire(api))
 }
 
 // --- Resource operations -----------------------------------------------------
@@ -572,7 +569,7 @@ func (p *APIGatewayPlugin) createResource(ctx *RequestContext, req *AWSRequest, 
 	}
 	updateStringIndex(goCtx, p.state, apigatewayNamespace, apigwResourceIDsKey(ctx.AccountID, ctx.Region, apiID), resID)
 
-	return apigwJSONResponse(http.StatusCreated, res)
+	return apigwJSONResponse(http.StatusCreated, resourceWire(res))
 }
 
 func (p *APIGatewayPlugin) getResource(ctx *RequestContext, apiID, resID string) (*AWSResponse, error) {
@@ -588,7 +585,10 @@ func (p *APIGatewayPlugin) getResource(ctx *RequestContext, apiID, resID string)
 	if err := json.Unmarshal(data, &res); err != nil {
 		return nil, fmt.Errorf("apigateway getResource unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, res)
+	if res.ResourceMethods, err = p.loadResourceMethods(goCtx, ctx, apiID, resID); err != nil {
+		return nil, err
+	}
+	return apigwJSONResponse(http.StatusOK, resourceWire(res))
 }
 
 func (p *APIGatewayPlugin) getResources(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -598,22 +598,23 @@ func (p *APIGatewayPlugin) getResources(ctx *RequestContext, apiID string) (*AWS
 		return nil, fmt.Errorf("apigateway getResources loadIndex: %w", err)
 	}
 
-	items := make([]ResourceState, 0, len(ids))
+	items := make([]resourceOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayNamespace, apigwResourceKey(ctx.AccountID, ctx.Region, apiID, id))
 		if getErr != nil || data == nil {
 			continue
 		}
 		var res ResourceState
-		if json.Unmarshal(data, &res) == nil {
-			items = append(items, res)
+		if json.Unmarshal(data, &res) != nil {
+			continue
 		}
+		if res.ResourceMethods, err = p.loadResourceMethods(goCtx, ctx, apiID, id); err != nil {
+			return nil, err
+		}
+		items = append(items, resourceWire(res))
 	}
 
-	type response struct {
-		Items []ResourceState `json:"items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwItemsOut[resourceOut]{Item: items})
 }
 
 func (p *APIGatewayPlugin) deleteResource(ctx *RequestContext, apiID, resID string) (*AWSResponse, error) {
@@ -652,7 +653,7 @@ func (p *APIGatewayPlugin) putMethod(ctx *RequestContext, req *AWSRequest, apiID
 	if err := p.state.Put(goCtx, apigatewayNamespace, apigwMethodKey(ctx.AccountID, ctx.Region, apiID, resID, verb), data); err != nil {
 		return nil, fmt.Errorf("apigateway putMethod state.Put: %w", err)
 	}
-	return apigwJSONResponse(http.StatusCreated, method)
+	return apigwJSONResponse(http.StatusCreated, methodWire(method))
 }
 
 func (p *APIGatewayPlugin) getMethod(ctx *RequestContext, apiID, resID, verb string) (*AWSResponse, error) {
@@ -668,7 +669,66 @@ func (p *APIGatewayPlugin) getMethod(ctx *RequestContext, apiID, resID, verb str
 	if err := json.Unmarshal(data, &method); err != nil {
 		return nil, fmt.Errorf("apigateway getMethod unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, method)
+	if err := p.attachIntegration(goCtx, ctx, &method, apiID, resID, verb); err != nil {
+		return nil, err
+	}
+	return apigwJSONResponse(http.StatusOK, methodWire(method))
+}
+
+// attachIntegration joins a method's stored integration onto it. PutIntegration
+// writes the integration under its own state key, so a method read back from state
+// alone has none — and methodIntegration is a member of the Method a real
+// GetMethod reports. A method with no integration is left with a nil one, which the
+// wire type omits.
+func (p *APIGatewayPlugin) attachIntegration(goCtx context.Context, ctx *RequestContext, method *MethodState, apiID, resID, verb string) error {
+	data, err := p.state.Get(goCtx, apigatewayNamespace, apigwIntegrationKey(ctx.AccountID, ctx.Region, apiID, resID, verb))
+	if err != nil {
+		return fmt.Errorf("apigateway attachIntegration state.Get: %w", err)
+	}
+	if data == nil {
+		return nil
+	}
+	var integration IntegrationState
+	if err := json.Unmarshal(data, &integration); err != nil {
+		return fmt.Errorf("apigateway attachIntegration unmarshal: %w", err)
+	}
+	method.Integration = &integration
+	return nil
+}
+
+// loadResourceMethods collects the methods declared on one resource, each with its
+// integration attached. Methods are stored under their own keys, so a resource read
+// back from state alone reports no methods at all — and resourceMethods is a member
+// of the Resource a real GetResource reports. Returns nil when the resource has no
+// methods, which the wire type omits rather than sending an empty object.
+func (p *APIGatewayPlugin) loadResourceMethods(goCtx context.Context, ctx *RequestContext, apiID, resID string) (map[string]MethodState, error) {
+	prefix := "method:" + ctx.AccountID + "/" + ctx.Region + "/" + apiID + "/" + resID + "/"
+	keys, err := p.state.List(goCtx, apigatewayNamespace, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("apigateway loadResourceMethods state.List: %w", err)
+	}
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	methods := make(map[string]MethodState, len(keys))
+	for _, k := range keys {
+		data, getErr := p.state.Get(goCtx, apigatewayNamespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var method MethodState
+		if json.Unmarshal(data, &method) != nil || method.HTTPMethod == "" {
+			continue
+		}
+		if err := p.attachIntegration(goCtx, ctx, &method, apiID, resID, method.HTTPMethod); err != nil {
+			return nil, err
+		}
+		methods[method.HTTPMethod] = method
+	}
+	if len(methods) == 0 {
+		return nil, nil
+	}
+	return methods, nil
 }
 
 func (p *APIGatewayPlugin) deleteMethod(ctx *RequestContext, apiID, resID, verb string) (*AWSResponse, error) {
@@ -695,7 +755,7 @@ func (p *APIGatewayPlugin) putIntegration(ctx *RequestContext, req *AWSRequest, 
 	if err := p.state.Put(goCtx, apigatewayNamespace, apigwIntegrationKey(ctx.AccountID, ctx.Region, apiID, resID, verb), data); err != nil {
 		return nil, fmt.Errorf("apigateway putIntegration state.Put: %w", err)
 	}
-	return apigwJSONResponse(http.StatusCreated, integration)
+	return apigwJSONResponse(http.StatusCreated, integrationWire(integration))
 }
 
 func (p *APIGatewayPlugin) putIntegrationResponse(_ *RequestContext, req *AWSRequest, _, _, _, _ string) (*AWSResponse, error) {
@@ -743,7 +803,7 @@ func (p *APIGatewayPlugin) createDeployment(ctx *RequestContext, req *AWSRequest
 	}
 	updateStringIndex(goCtx, p.state, apigatewayNamespace, apigwDeploymentIDsKey(ctx.AccountID, ctx.Region, apiID), dep.ID)
 
-	return apigwJSONResponse(http.StatusCreated, dep)
+	return apigwJSONResponse(http.StatusCreated, deploymentWire(dep))
 }
 
 func (p *APIGatewayPlugin) getDeployment(ctx *RequestContext, apiID, deployID string) (*AWSResponse, error) {
@@ -759,7 +819,7 @@ func (p *APIGatewayPlugin) getDeployment(ctx *RequestContext, apiID, deployID st
 	if err := json.Unmarshal(data, &dep); err != nil {
 		return nil, fmt.Errorf("apigateway getDeployment unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, dep)
+	return apigwJSONResponse(http.StatusOK, deploymentWire(dep))
 }
 
 func (p *APIGatewayPlugin) getDeployments(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -769,7 +829,7 @@ func (p *APIGatewayPlugin) getDeployments(ctx *RequestContext, apiID string) (*A
 		return nil, fmt.Errorf("apigateway getDeployments loadIndex: %w", err)
 	}
 
-	items := make([]DeploymentState, 0, len(ids))
+	items := make([]deploymentOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayNamespace, apigwDeploymentKey(ctx.AccountID, ctx.Region, apiID, id))
 		if getErr != nil || data == nil {
@@ -777,14 +837,11 @@ func (p *APIGatewayPlugin) getDeployments(ctx *RequestContext, apiID string) (*A
 		}
 		var dep DeploymentState
 		if json.Unmarshal(data, &dep) == nil {
-			items = append(items, dep)
+			items = append(items, deploymentWire(dep))
 		}
 	}
 
-	type response struct {
-		Items []DeploymentState `json:"items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwItemsOut[deploymentOut]{Item: items})
 }
 
 func (p *APIGatewayPlugin) deleteDeployment(ctx *RequestContext, apiID, deployID string) (*AWSResponse, error) {
@@ -835,7 +892,7 @@ func (p *APIGatewayPlugin) createStage(ctx *RequestContext, req *AWSRequest, api
 	}
 	updateStringIndex(goCtx, p.state, apigatewayNamespace, apigwStageNamesKey(ctx.AccountID, ctx.Region, apiID), stage.StageName)
 
-	return apigwJSONResponse(http.StatusCreated, stage)
+	return apigwJSONResponse(http.StatusCreated, stageWire(stage, apigwInvokeURL(apiID, ctx.Region, stage.StageName)))
 }
 
 func (p *APIGatewayPlugin) getStage(ctx *RequestContext, apiID, stageName string) (*AWSResponse, error) {
@@ -852,16 +909,15 @@ func (p *APIGatewayPlugin) getStage(ctx *RequestContext, apiID, stageName string
 		return nil, fmt.Errorf("apigateway getStage unmarshal: %w", err)
 	}
 
-	// Augment with computed InvokeURL.
-	type stageWithURL struct {
-		StageState
-		InvokeURL string `json:"InvokeUrl"`
-	}
-	sw := stageWithURL{
-		StageState: stage,
-		InvokeURL:  fmt.Sprintf("https://%s.execute-api.%s.amazonaws.com/%s", apiID, ctx.Region, stageName),
-	}
-	return apigwJSONResponse(http.StatusOK, sw)
+	return apigwJSONResponse(http.StatusOK, stageWire(stage, apigwInvokeURL(apiID, ctx.Region, stageName)))
+}
+
+// apigwInvokeURL builds the execute-api endpoint a caller invokes a stage through.
+// No model declares an invokeUrl member on a Stage, so this is substrate's own
+// convenience; see apigateway_wire.go for why it is kept and why it cannot confuse
+// an SDK.
+func apigwInvokeURL(apiID, region, stageName string) string {
+	return fmt.Sprintf("https://%s.execute-api.%s.amazonaws.com/%s", apiID, region, stageName)
 }
 
 func (p *APIGatewayPlugin) getStages(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -871,7 +927,7 @@ func (p *APIGatewayPlugin) getStages(ctx *RequestContext, apiID string) (*AWSRes
 		return nil, fmt.Errorf("apigateway getStages loadIndex: %w", err)
 	}
 
-	items := make([]StageState, 0, len(names))
+	items := make([]stageOut, 0, len(names))
 	for _, name := range names {
 		data, getErr := p.state.Get(goCtx, apigatewayNamespace, apigwStageKey(ctx.AccountID, ctx.Region, apiID, name))
 		if getErr != nil || data == nil {
@@ -879,14 +935,15 @@ func (p *APIGatewayPlugin) getStages(ctx *RequestContext, apiID string) (*AWSRes
 		}
 		var stage StageState
 		if json.Unmarshal(data, &stage) == nil {
-			items = append(items, stage)
+			items = append(items, stageWire(stage, apigwInvokeURL(apiID, ctx.Region, stage.StageName)))
 		}
 	}
 
-	type response struct {
-		Item []StageState `json:"item"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Item: items})
+	// The envelope here was already "item" before #529, and stays "item": GetStages
+	// is the one v1 collection whose model member is named "item" rather than
+	// "items". Renaming it to match the other seven would break the only list
+	// handler that a real SDK could already parse.
+	return apigwJSONResponse(http.StatusOK, apigwItemsOut[stageOut]{Item: items})
 }
 
 func (p *APIGatewayPlugin) deleteStage(ctx *RequestContext, apiID, stageName string) (*AWSResponse, error) {
@@ -918,7 +975,7 @@ func (p *APIGatewayPlugin) updateStage(ctx *RequestContext, _ *AWSRequest, apiID
 	if err := p.state.Put(goCtx, apigatewayNamespace, apigwStageKey(ctx.AccountID, ctx.Region, apiID, stageName), updated); err != nil {
 		return nil, fmt.Errorf("apigateway updateStage state.Put: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, stage)
+	return apigwJSONResponse(http.StatusOK, stageWire(stage, apigwInvokeURL(apiID, ctx.Region, stage.StageName)))
 }
 
 // --- Authorizer operations ---------------------------------------------------
@@ -957,7 +1014,7 @@ func (p *APIGatewayPlugin) createAuthorizer(ctx *RequestContext, req *AWSRequest
 	}
 	updateStringIndex(goCtx, p.state, apigatewayNamespace, apigwAuthorizerIDsKey(ctx.AccountID, ctx.Region, apiID), auth.ID)
 
-	return apigwJSONResponse(http.StatusCreated, auth)
+	return apigwJSONResponse(http.StatusCreated, authorizerWire(auth))
 }
 
 func (p *APIGatewayPlugin) getAuthorizer(ctx *RequestContext, apiID, authID string) (*AWSResponse, error) {
@@ -973,7 +1030,7 @@ func (p *APIGatewayPlugin) getAuthorizer(ctx *RequestContext, apiID, authID stri
 	if err := json.Unmarshal(data, &auth); err != nil {
 		return nil, fmt.Errorf("apigateway getAuthorizer unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, auth)
+	return apigwJSONResponse(http.StatusOK, authorizerWire(auth))
 }
 
 func (p *APIGatewayPlugin) getAuthorizers(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -983,7 +1040,7 @@ func (p *APIGatewayPlugin) getAuthorizers(ctx *RequestContext, apiID string) (*A
 		return nil, fmt.Errorf("apigateway getAuthorizers loadIndex: %w", err)
 	}
 
-	items := make([]AuthorizerState, 0, len(ids))
+	items := make([]authorizerOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayNamespace, apigwAuthorizerKey(ctx.AccountID, ctx.Region, apiID, id))
 		if getErr != nil || data == nil {
@@ -991,14 +1048,11 @@ func (p *APIGatewayPlugin) getAuthorizers(ctx *RequestContext, apiID string) (*A
 		}
 		var auth AuthorizerState
 		if json.Unmarshal(data, &auth) == nil {
-			items = append(items, auth)
+			items = append(items, authorizerWire(auth))
 		}
 	}
 
-	type response struct {
-		Items []AuthorizerState `json:"items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwItemsOut[authorizerOut]{Item: items})
 }
 
 func (p *APIGatewayPlugin) deleteAuthorizer(ctx *RequestContext, apiID, authID string) (*AWSResponse, error) {
@@ -1052,7 +1106,7 @@ func (p *APIGatewayPlugin) createAPIKey(ctx *RequestContext, req *AWSRequest) (*
 	}
 	updateStringIndex(goCtx, p.state, apigatewayNamespace, apigwAPIKeyIDsKey(ctx.AccountID, ctx.Region), key.ID)
 
-	return apigwJSONResponse(http.StatusCreated, key)
+	return apigwJSONResponse(http.StatusCreated, apiKeyWire(key))
 }
 
 func (p *APIGatewayPlugin) getAPIKey(ctx *RequestContext, keyID string) (*AWSResponse, error) {
@@ -1068,7 +1122,7 @@ func (p *APIGatewayPlugin) getAPIKey(ctx *RequestContext, keyID string) (*AWSRes
 	if err := json.Unmarshal(data, &key); err != nil {
 		return nil, fmt.Errorf("apigateway getAPIKey unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, key)
+	return apigwJSONResponse(http.StatusOK, apiKeyWire(key))
 }
 
 func (p *APIGatewayPlugin) getAPIKeys(ctx *RequestContext) (*AWSResponse, error) {
@@ -1078,7 +1132,7 @@ func (p *APIGatewayPlugin) getAPIKeys(ctx *RequestContext) (*AWSResponse, error)
 		return nil, fmt.Errorf("apigateway getApiKeys loadIndex: %w", err)
 	}
 
-	items := make([]APIKeyState, 0, len(ids))
+	items := make([]apiKeyOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayNamespace, apigwAPIKeyKey(ctx.AccountID, ctx.Region, id))
 		if getErr != nil || data == nil {
@@ -1086,14 +1140,11 @@ func (p *APIGatewayPlugin) getAPIKeys(ctx *RequestContext) (*AWSResponse, error)
 		}
 		var key APIKeyState
 		if json.Unmarshal(data, &key) == nil {
-			items = append(items, key)
+			items = append(items, apiKeyWire(key))
 		}
 	}
 
-	type response struct {
-		Items []APIKeyState `json:"items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwItemsOut[apiKeyOut]{Item: items})
 }
 
 func (p *APIGatewayPlugin) deleteAPIKey(ctx *RequestContext, keyID string) (*AWSResponse, error) {
@@ -1139,7 +1190,7 @@ func (p *APIGatewayPlugin) createUsagePlan(ctx *RequestContext, req *AWSRequest)
 	}
 	updateStringIndex(goCtx, p.state, apigatewayNamespace, apigwUsagePlanIDsKey(ctx.AccountID, ctx.Region), plan.ID)
 
-	return apigwJSONResponse(http.StatusCreated, plan)
+	return apigwJSONResponse(http.StatusCreated, usagePlanWire(plan))
 }
 
 func (p *APIGatewayPlugin) getUsagePlan(ctx *RequestContext, planID string) (*AWSResponse, error) {
@@ -1155,7 +1206,7 @@ func (p *APIGatewayPlugin) getUsagePlan(ctx *RequestContext, planID string) (*AW
 	if err := json.Unmarshal(data, &plan); err != nil {
 		return nil, fmt.Errorf("apigateway getUsagePlan unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, plan)
+	return apigwJSONResponse(http.StatusOK, usagePlanWire(plan))
 }
 
 func (p *APIGatewayPlugin) getUsagePlans(ctx *RequestContext) (*AWSResponse, error) {
@@ -1165,7 +1216,7 @@ func (p *APIGatewayPlugin) getUsagePlans(ctx *RequestContext) (*AWSResponse, err
 		return nil, fmt.Errorf("apigateway getUsagePlans loadIndex: %w", err)
 	}
 
-	items := make([]UsagePlanState, 0, len(ids))
+	items := make([]usagePlanOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayNamespace, apigwUsagePlanKey(ctx.AccountID, ctx.Region, id))
 		if getErr != nil || data == nil {
@@ -1173,14 +1224,11 @@ func (p *APIGatewayPlugin) getUsagePlans(ctx *RequestContext) (*AWSResponse, err
 		}
 		var plan UsagePlanState
 		if json.Unmarshal(data, &plan) == nil {
-			items = append(items, plan)
+			items = append(items, usagePlanWire(plan))
 		}
 	}
 
-	type response struct {
-		Items []UsagePlanState `json:"items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwItemsOut[usagePlanOut]{Item: items})
 }
 
 func (p *APIGatewayPlugin) deleteUsagePlan(ctx *RequestContext, planID string) (*AWSResponse, error) {
@@ -1220,7 +1268,7 @@ func (p *APIGatewayPlugin) createDomainName(ctx *RequestContext, req *AWSRequest
 		return nil, fmt.Errorf("apigateway createDomainName state.Put: %w", err)
 	}
 
-	return apigwJSONResponse(http.StatusCreated, dn)
+	return apigwJSONResponse(http.StatusCreated, domainNameWire(dn))
 }
 
 func (p *APIGatewayPlugin) getDomainName(ctx *RequestContext, name string) (*AWSResponse, error) {
@@ -1236,7 +1284,7 @@ func (p *APIGatewayPlugin) getDomainName(ctx *RequestContext, name string) (*AWS
 	if err := json.Unmarshal(data, &dn); err != nil {
 		return nil, fmt.Errorf("apigateway getDomainName unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, dn)
+	return apigwJSONResponse(http.StatusOK, domainNameWire(dn))
 }
 
 func (p *APIGatewayPlugin) createBasePathMapping(ctx *RequestContext, req *AWSRequest, domainName string) (*AWSResponse, error) {
@@ -1268,7 +1316,7 @@ func (p *APIGatewayPlugin) createBasePathMapping(ctx *RequestContext, req *AWSRe
 		return nil, fmt.Errorf("apigateway createBasePathMapping state.Put: %w", err)
 	}
 
-	return apigwJSONResponse(http.StatusCreated, mapping)
+	return apigwJSONResponse(http.StatusCreated, basePathMappingWire(mapping))
 }
 
 func (p *APIGatewayPlugin) getBasePathMappings(ctx *RequestContext, domainName string) (*AWSResponse, error) {
@@ -1279,7 +1327,7 @@ func (p *APIGatewayPlugin) getBasePathMappings(ctx *RequestContext, domainName s
 		return nil, fmt.Errorf("apigateway getBasePathMappings state.List: %w", err)
 	}
 
-	items := make([]BasePathMappingState, 0, len(keys))
+	items := make([]basePathMappingOut, 0, len(keys))
 	for _, k := range keys {
 		data, getErr := p.state.Get(goCtx, apigatewayNamespace, k)
 		if getErr != nil || data == nil {
@@ -1287,14 +1335,11 @@ func (p *APIGatewayPlugin) getBasePathMappings(ctx *RequestContext, domainName s
 		}
 		var m BasePathMappingState
 		if json.Unmarshal(data, &m) == nil {
-			items = append(items, m)
+			items = append(items, basePathMappingWire(m))
 		}
 	}
 
-	type response struct {
-		Items []BasePathMappingState `json:"items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwItemsOut[basePathMappingOut]{Item: items})
 }
 
 // --- ID generation -----------------------------------------------------------

--- a/emulator/apigateway_plugin_test.go
+++ b/emulator/apigateway_plugin_test.go
@@ -175,13 +175,14 @@ func TestAPIGatewayPlugin_CreateDeploymentAndStage(t *testing.T) {
 	if err := json.Unmarshal(getStageResp.Body, &stageOut); err != nil {
 		t.Fatalf("unmarshal stage: %v", err)
 	}
-	invokeURL, _ := stageOut["InvokeUrl"].(string)
+	// The key is invokeUrl, lowerCamel like every other member (#529).
+	invokeURL, _ := stageOut["invokeUrl"].(string)
 	if invokeURL == "" {
-		t.Error("InvokeUrl is empty")
+		t.Error("invokeUrl is empty")
 	}
 	expectedURL := "https://" + api.ID + ".execute-api.us-east-1.amazonaws.com/prod"
 	if invokeURL != expectedURL {
-		t.Errorf("want InvokeUrl %q, got %q", expectedURL, invokeURL)
+		t.Errorf("want invokeUrl %q, got %q", expectedURL, invokeURL)
 	}
 }
 
@@ -200,14 +201,25 @@ func TestAPIGatewayPlugin_GetRestApis(t *testing.T) {
 		t.Fatalf("GetRestApis: %v", err)
 	}
 
+	// The envelope is "item" and the members are lowerCamel, so this decodes into
+	// a map rather than a state struct: RestAPIState would silently match nothing
+	// useful, which is how #529 stayed hidden.
 	var out struct {
-		Items []emulator.RestAPIState `json:"items"`
+		Item []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"item"`
 	}
 	if err := json.Unmarshal(listResp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(out.Items) != 2 {
-		t.Errorf("want 2 APIs, got %d", len(out.Items))
+	if len(out.Item) != 2 {
+		t.Errorf("want 2 APIs, got %d", len(out.Item))
+	}
+	for _, api := range out.Item {
+		if api.ID == "" || api.Name == "" {
+			t.Errorf("listed API is empty: %+v", api)
+		}
 	}
 }
 
@@ -330,7 +342,7 @@ func TestAPIGatewayPlugin_GetResources(t *testing.T) {
 	if err := json.Unmarshal(listResp.Body, &out); err != nil {
 		t.Fatalf("unmarshal GetResources: %v", err)
 	}
-	items, _ := out["items"].([]any)
+	items, _ := out["item"].([]any)
 	if len(items) < 2 {
 		t.Errorf("want at least 2 resources (root + child), got %d", len(items))
 	}
@@ -599,7 +611,7 @@ func TestAPIGatewayPlugin_Authorizer(t *testing.T) {
 	if err := json.Unmarshal(createResp.Body, &authOut); err != nil {
 		t.Fatalf("unmarshal authorizer: %v", err)
 	}
-	authID, _ := authOut["Id"].(string)
+	authID, _ := authOut["id"].(string)
 	if authID == "" {
 		t.Fatal("authorizer id is empty")
 	}
@@ -627,7 +639,7 @@ func TestAPIGatewayPlugin_Authorizer(t *testing.T) {
 	if err := json.Unmarshal(listResp.Body, &listOut); err != nil {
 		t.Fatalf("unmarshal authorizers: %v", err)
 	}
-	authItems, _ := listOut["items"].([]any)
+	authItems, _ := listOut["item"].([]any)
 	if len(authItems) != 1 {
 		t.Errorf("want 1 authorizer, got %d", len(authItems))
 	}
@@ -660,7 +672,7 @@ func TestAPIGatewayPlugin_APIKey(t *testing.T) {
 	if err := json.Unmarshal(createResp.Body, &keyOut); err != nil {
 		t.Fatalf("unmarshal api key: %v", err)
 	}
-	keyID, _ := keyOut["Id"].(string)
+	keyID, _ := keyOut["id"].(string)
 	if keyID == "" {
 		t.Fatal("api key id is empty")
 	}
@@ -686,7 +698,7 @@ func TestAPIGatewayPlugin_APIKey(t *testing.T) {
 	if err := json.Unmarshal(listResp.Body, &listOut); err != nil {
 		t.Fatalf("unmarshal api keys: %v", err)
 	}
-	keyItems, _ := listOut["items"].([]any)
+	keyItems, _ := listOut["item"].([]any)
 	if len(keyItems) != 1 {
 		t.Errorf("want 1 api key, got %d", len(keyItems))
 	}
@@ -723,7 +735,7 @@ func TestAPIGatewayPlugin_UsagePlan(t *testing.T) {
 	if err := json.Unmarshal(createResp.Body, &planOut); err != nil {
 		t.Fatalf("unmarshal usage plan: %v", err)
 	}
-	planID, _ := planOut["Id"].(string)
+	planID, _ := planOut["id"].(string)
 	if planID == "" {
 		t.Fatal("usage plan id is empty")
 	}
@@ -749,7 +761,7 @@ func TestAPIGatewayPlugin_UsagePlan(t *testing.T) {
 	if err := json.Unmarshal(listResp.Body, &listOut); err != nil {
 		t.Fatalf("unmarshal usage plans: %v", err)
 	}
-	planItems, _ := listOut["items"].([]any)
+	planItems, _ := listOut["item"].([]any)
 	if len(planItems) != 1 {
 		t.Errorf("want 1 usage plan, got %d", len(planItems))
 	}
@@ -821,7 +833,7 @@ func TestAPIGatewayPlugin_DomainNameAndBasePathMapping(t *testing.T) {
 	if err := json.Unmarshal(listResp.Body, &listOut); err != nil {
 		t.Fatalf("unmarshal base path mappings: %v", err)
 	}
-	bpmItems, _ := listOut["items"].([]any)
+	bpmItems, _ := listOut["item"].([]any)
 	if len(bpmItems) != 1 {
 		t.Errorf("want 1 base path mapping, got %d", len(bpmItems))
 	}

--- a/emulator/apigateway_proxy_test.go
+++ b/emulator/apigateway_proxy_test.go
@@ -453,8 +453,9 @@ func proxyCreateRESTAPI(t *testing.T, ts *emulator.TestServer) string {
 	if err := json.Unmarshal(b, &result); err != nil {
 		t.Fatalf("decode restapi: %v — body: %s", err, b)
 	}
-	// RestAPIState uses json tag "Id" (capital I).
-	id, _ := result["Id"].(string)
+	// The wire member is "id", lowercase, as the model spells it (#529). It read
+	// "Id" here before, matching the state struct substrate used to marshal.
+	id, _ := result["id"].(string)
 	return id
 }
 
@@ -468,16 +469,17 @@ func proxyGetRootResourceID(t *testing.T, ts *emulator.TestServer, apiID string)
 	if resp.StatusCode >= 400 {
 		t.Fatalf("GetResources status %d: %s", resp.StatusCode, b)
 	}
+	// The collection envelope is "item", singular — the member's locationName (#529).
 	var result struct {
-		Items []struct {
+		Item []struct {
 			ID   string `json:"id"`
 			Path string `json:"path"`
-		} `json:"items"`
+		} `json:"item"`
 	}
 	if err := json.Unmarshal(b, &result); err != nil {
 		t.Fatalf("decode resources (status %d): %v — body: %s", resp.StatusCode, err, b)
 	}
-	for _, item := range result.Items {
+	for _, item := range result.Item {
 		if item.Path == "/" {
 			return item.ID
 		}

--- a/emulator/apigateway_wire.go
+++ b/emulator/apigateway_wire.go
@@ -1,0 +1,286 @@
+package emulator
+
+import "time"
+
+// The wire is a different thing from the state, and the types below exist to keep
+// them apart.
+//
+// The state types in apigateway_types.go are a persisted format: MemoryStateManager
+// snapshots them and recorded runs replay from those bytes, so their PascalCase tags
+// must not change. API Gateway v1's wire members are lowerCamel, and botocore
+// matches a response key against the model's locationName case-sensitively — so a
+// PascalCase key matches nothing and parses to nothing. `aws apigateway
+// get-rest-apis` returned HTTP 200 with an empty result and no error, because the
+// state struct was marshaled straight onto the wire (#529).
+//
+// So each response gets its own element type, tagged from the model, projected from
+// the state by a Wire function. Two consequences are deliberate: substrate's own
+// AccountID and Region are simply absent from these types, so the leak cannot come
+// back through a field someone adds later; and `omitempty` follows the model's
+// optionality, because real API Gateway omits an unset member rather than sending
+// null.
+//
+// Do not "fix" a casing bug here by retagging a state type. That conflates the two
+// jobs again, and it silently changes the format of every recorded run.
+//
+// One member is substrate's own and no model declares it: stageOut.InvokeURL. It is
+// retained because a consumer reading the raw response uses it, and because botocore
+// drops a key the model does not declare, so it cannot break an SDK caller. It is
+// spelled lowerCamel for consistency with everything around it, not because the
+// model says so.
+
+// restAPIOut is the RestApi element of the v1 REST API responses.
+type restAPIOut struct {
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	Description    string            `json:"description,omitempty"`
+	RootResourceID string            `json:"rootResourceId"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	CreatedDate    time.Time         `json:"createdDate"`
+}
+
+// resourceOut is the Resource element of the v1 resource responses. resourceMethods
+// is a map of Method, so a projection that stops here would leave every method
+// PascalCase and a caller would parse a resource whose methods are empty.
+type resourceOut struct {
+	ID              string               `json:"id"`
+	ParentID        string               `json:"parentId,omitempty"`
+	PathPart        string               `json:"pathPart,omitempty"`
+	Path            string               `json:"path"`
+	ResourceMethods map[string]methodOut `json:"resourceMethods,omitempty"`
+}
+
+// methodOut is the Method element, and the methodIntegration member of a resource's
+// method map.
+type methodOut struct {
+	HTTPMethod        string                 `json:"httpMethod"`
+	AuthorizationType string                 `json:"authorizationType"`
+	AuthorizerID      string                 `json:"authorizerId,omitempty"`
+	APIKeyRequired    bool                   `json:"apiKeyRequired"`
+	MethodIntegration *integrationOut        `json:"methodIntegration,omitempty"`
+	MethodResponses   map[string]interface{} `json:"methodResponses,omitempty"`
+}
+
+// integrationOut is the Integration element. Its integrationResponses hold whatever
+// the caller PUT, so they are passed through unchanged — those are the caller's own
+// keys, not substrate's to rename.
+type integrationOut struct {
+	Type                 string                 `json:"type"`
+	URI                  string                 `json:"uri,omitempty"`
+	HTTPMethod           string                 `json:"httpMethod,omitempty"`
+	IntegrationResponses map[string]interface{} `json:"integrationResponses,omitempty"`
+}
+
+// stageOut is the Stage element. invokeUrl is substrate's own addition; see the
+// comment at the top of this file.
+type stageOut struct {
+	StageName    string            `json:"stageName"`
+	DeploymentID string            `json:"deploymentId,omitempty"`
+	Description  string            `json:"description,omitempty"`
+	Variables    map[string]string `json:"variables,omitempty"`
+	Tags         map[string]string `json:"tags,omitempty"`
+	CreatedDate  time.Time         `json:"createdDate"`
+	InvokeURL    string            `json:"invokeUrl,omitempty"`
+}
+
+// deploymentOut is the Deployment element.
+type deploymentOut struct {
+	ID          string    `json:"id"`
+	Description string    `json:"description,omitempty"`
+	CreatedDate time.Time `json:"createdDate"`
+}
+
+// authorizerOut is the Authorizer element. providerARNs keeps its capitalised
+// acronym, which is what the model spells.
+type authorizerOut struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Type           string   `json:"type"`
+	ProviderARNs   []string `json:"providerARNs,omitempty"`
+	AuthorizerURI  string   `json:"authorizerUri,omitempty"`
+	IdentitySource string   `json:"identitySource,omitempty"`
+}
+
+// apiKeyOut is the ApiKey element.
+type apiKeyOut struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Value       string            `json:"value"`
+	Enabled     bool              `json:"enabled"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	CreatedDate time.Time         `json:"createdDate"`
+}
+
+// usagePlanOut is the UsagePlan element. The model declares no createdDate on a
+// usage plan, so substrate does not report one even though it stores one.
+type usagePlanOut struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	APIStages   []interface{}     `json:"apiStages,omitempty"`
+	Tags        map[string]string `json:"tags,omitempty"`
+}
+
+// domainNameOut is the DomainName element.
+type domainNameOut struct {
+	DomainName         string `json:"domainName"`
+	CertificateArn     string `json:"certificateArn,omitempty"`
+	RegionalDomainName string `json:"regionalDomainName"`
+}
+
+// basePathMappingOut is the BasePathMapping element. The model declares no
+// domainName on a mapping — the domain is a path parameter of the request, not a
+// member of the response — so substrate no longer reports one.
+type basePathMappingOut struct {
+	BasePath  string `json:"basePath"`
+	RestAPIID string `json:"restApiId"`
+	Stage     string `json:"stage,omitempty"`
+}
+
+// --- Projections -------------------------------------------------------------
+
+// restAPIWire projects a stored REST API onto the wire.
+func restAPIWire(a RestAPIState) restAPIOut {
+	return restAPIOut{
+		ID:             a.ID,
+		Name:           a.Name,
+		Description:    a.Description,
+		RootResourceID: a.RootResourceID,
+		Tags:           a.Tags,
+		CreatedDate:    a.CreatedDate,
+	}
+}
+
+// resourceWire projects a stored resource onto the wire, recursing through its
+// method map and each method's integration.
+func resourceWire(r ResourceState) resourceOut {
+	out := resourceOut{
+		ID:       r.ID,
+		ParentID: r.ParentID,
+		PathPart: r.PathPart,
+		Path:     r.Path,
+	}
+	if len(r.ResourceMethods) > 0 {
+		out.ResourceMethods = make(map[string]methodOut, len(r.ResourceMethods))
+		for verb, m := range r.ResourceMethods {
+			out.ResourceMethods[verb] = methodWire(m)
+		}
+	}
+	return out
+}
+
+// methodWire projects a stored method onto the wire, including its integration.
+func methodWire(m MethodState) methodOut {
+	out := methodOut{
+		HTTPMethod:        m.HTTPMethod,
+		AuthorizationType: m.AuthorizationType,
+		AuthorizerID:      m.AuthorizerID,
+		APIKeyRequired:    m.APIKeyRequired,
+		MethodResponses:   m.MethodResponses,
+	}
+	if m.Integration != nil {
+		i := integrationWire(*m.Integration)
+		out.MethodIntegration = &i
+	}
+	return out
+}
+
+// integrationWire projects a stored integration onto the wire.
+//
+// The two types happen to have identical field sets today, so a conversion would
+// compile — but that is incidental, and writing the members out keeps this
+// projection readable the same way as the ten around it, and keeps adding a
+// state-only field (an AccountID, say) a local edit here rather than a compile
+// error in an unrelated line.
+func integrationWire(i IntegrationState) integrationOut {
+	return integrationOut{ //nolint:staticcheck // S1016: an explicit projection, not a coincidental conversion.
+		Type:                 i.Type,
+		URI:                  i.URI,
+		HTTPMethod:           i.HTTPMethod,
+		IntegrationResponses: i.IntegrationResponses,
+	}
+}
+
+// stageWire projects a stored stage onto the wire. invokeURL is passed in rather
+// than derived here, because it depends on the request's region and API id.
+func stageWire(s StageState, invokeURL string) stageOut {
+	return stageOut{
+		StageName:    s.StageName,
+		DeploymentID: s.DeploymentID,
+		Description:  s.Description,
+		Variables:    s.Variables,
+		Tags:         s.Tags,
+		CreatedDate:  s.CreatedDate,
+		InvokeURL:    invokeURL,
+	}
+}
+
+// deploymentWire projects a stored deployment onto the wire.
+func deploymentWire(d DeploymentState) deploymentOut {
+	return deploymentOut{ID: d.ID, Description: d.Description, CreatedDate: d.CreatedDate}
+}
+
+// authorizerWire projects a stored authorizer onto the wire.
+func authorizerWire(a AuthorizerState) authorizerOut {
+	return authorizerOut{
+		ID:             a.ID,
+		Name:           a.Name,
+		Type:           a.Type,
+		ProviderARNs:   a.ProviderARNs,
+		AuthorizerURI:  a.AuthorizerURI,
+		IdentitySource: a.IdentitySource,
+	}
+}
+
+// apiKeyWire projects a stored API key onto the wire.
+func apiKeyWire(k APIKeyState) apiKeyOut {
+	return apiKeyOut{
+		ID:          k.ID,
+		Name:        k.Name,
+		Value:       k.Value,
+		Enabled:     k.Enabled,
+		Tags:        k.Tags,
+		CreatedDate: k.CreatedDate,
+	}
+}
+
+// usagePlanWire projects a stored usage plan onto the wire.
+func usagePlanWire(u UsagePlanState) usagePlanOut {
+	return usagePlanOut{
+		ID:          u.ID,
+		Name:        u.Name,
+		Description: u.Description,
+		APIStages:   u.APIStages,
+		Tags:        u.Tags,
+	}
+}
+
+// domainNameWire projects a stored domain name onto the wire.
+func domainNameWire(d DomainNameState) domainNameOut {
+	return domainNameOut{
+		DomainName:         d.DomainName,
+		CertificateArn:     d.CertificateArn,
+		RegionalDomainName: d.RegionalDomainName,
+	}
+}
+
+// basePathMappingWire projects a stored base path mapping onto the wire.
+func basePathMappingWire(m BasePathMappingState) basePathMappingOut {
+	return basePathMappingOut{BasePath: m.BasePath, RestAPIID: m.RestAPIID, Stage: m.Stage}
+}
+
+// --- List envelopes ----------------------------------------------------------
+
+// Every v1 collection response nests its elements under the member named "items"
+// — whose locationName is "item", singular. GetStages is the one exception, and only
+// in the model's member name: its member is literally called "item", and its
+// locationName is "item" too. So on the wire all twenty collections agree, and
+// substrate emits "item" for every one of them. Emitting "items" parses to nothing.
+//
+// No collection carries a "position" token, because substrate returns every element
+// in one page and does not honor one; inventing a token would invite a caller to
+// page on nothing. GetUsage's member is a third spelling, "values", but substrate
+// does not route GetUsage.
+type apigwItemsOut[T any] struct {
+	Item []T `json:"item"`
+}

--- a/emulator/apigateway_wire_test.go
+++ b/emulator/apigateway_wire_test.go
@@ -1,0 +1,641 @@
+package emulator_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// These tests assert on the raw response bytes rather than round-tripping through a
+// Go struct, for the reason #529 exists: a struct marshaled and unmarshaled by its
+// own definition agrees with itself whatever its tags say, and Go's json.Unmarshal
+// matches keys case-insensitively on top of that. So apigateway_plugin_test.go was
+// green while `aws apigateway get-rest-apis` returned an empty result and no error.
+// Only a literal-key assertion sees the difference.
+
+// agwWire sends one request and decodes the response into a generic map, so every
+// assertion is against the key a real SDK would look for.
+func agwWire(t *testing.T, p *emulator.APIGatewayPlugin, ctx *emulator.RequestContext,
+	method, path string, body map[string]any,
+) (map[string]any, []byte) {
+	t.Helper()
+	resp, err := p.HandleRequest(ctx, apigwRequest(t, method, path, body))
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		t.Fatalf("%s %s: want 200 or 201, got %d: %s", method, path, resp.StatusCode, resp.Body)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(resp.Body, &m); err != nil {
+		t.Fatalf("%s %s: unmarshal body: %v", method, path, err)
+	}
+	return m, resp.Body
+}
+
+// agwAPI creates one REST API and returns its id.
+func agwAPI(t *testing.T, p *emulator.APIGatewayPlugin, ctx *emulator.RequestContext, name string) string {
+	t.Helper()
+	m, _ := agwWire(t, p, ctx, "POST", "/restapis", map[string]any{
+		"name":        name,
+		"description": "d-" + name,
+		"tags":        map[string]string{"env": "test"},
+	})
+	id, ok := m["id"].(string)
+	if !ok || id == "" {
+		t.Fatalf("CreateRestApi: want an id, got %#v", m)
+	}
+	return id
+}
+
+// agwItem pulls the single element out of a v1 collection response. Every v1
+// collection nests under "item", singular — "items" parses to nothing.
+func agwItem(t *testing.T, what string, m map[string]any) map[string]any {
+	t.Helper()
+	if _, wrong := m["items"]; wrong {
+		t.Fatalf("%s: the envelope is %q, not %q — botocore parses the plural to nothing", what, "item", "items")
+	}
+	list, ok := m["item"].([]any)
+	if !ok {
+		t.Fatalf("%s: want an %q list, got %#v", what, "item", m)
+	}
+	if len(list) != 1 {
+		t.Fatalf("%s: want one element, got %d: %#v", what, len(list), list)
+	}
+	elem, ok := list[0].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: want an object element, got %T", what, list[0])
+	}
+	return elem
+}
+
+// agwNoInternalFields checks the raw bytes, not a decoded top-level map: substrate's
+// AccountID or Region nested inside a resourceMethods map would pass a top-level key
+// check while still reaching the caller. #529 requires no response carry either.
+func agwNoInternalFields(t *testing.T, what string, raw []byte) {
+	t.Helper()
+	for _, bad := range []string{`"AccountID"`, `"Region"`, `"accountId"`, `"region"`, `"APIId"`, `"apiId"`} {
+		if bytes.Contains(raw, []byte(bad)) {
+			t.Errorf("%s: response carries substrate's internal %s: %s", what, bad, raw)
+		}
+	}
+}
+
+// --- Elements ----------------------------------------------------------------
+
+func TestAPIGatewayWire_RestAPI(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+
+	created, raw := agwWire(t, p, ctx, "POST", "/restapis", map[string]any{
+		"name":        "wire-api",
+		"description": "a description",
+		"tags":        map[string]string{"env": "test"},
+	})
+	requireValues(t, "CreateRestApi", created, map[string]any{
+		"name":        "wire-api",
+		"description": "a description",
+	})
+	requireKeys(t, "CreateRestApi", created, "id", "rootResourceId", "createdDate", "tags")
+	agwNoInternalFields(t, "CreateRestApi", raw)
+	id := created["id"].(string)
+
+	got, raw := agwWire(t, p, ctx, "GET", "/restapis/"+id, nil)
+	requireValues(t, "GetRestApi", got, map[string]any{
+		"id":             id,
+		"name":           "wire-api",
+		"description":    "a description",
+		"rootResourceId": created["rootResourceId"],
+	})
+	if tags, ok := got["tags"].(map[string]any); !ok || tags["env"] != "test" {
+		t.Errorf("GetRestApi tags: want env=test, got %#v", got["tags"])
+	}
+	agwNoInternalFields(t, "GetRestApi", raw)
+
+	patched, raw := agwWire(t, p, ctx, "PATCH", "/restapis/"+id, map[string]any{})
+	requireValues(t, "UpdateRestApi", patched, map[string]any{"id": id, "name": "wire-api"})
+	agwNoInternalFields(t, "UpdateRestApi", raw)
+}
+
+func TestAPIGatewayWire_Resource(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-res")
+	root, _ := agwWire(t, p, ctx, "GET", "/restapis/"+apiID, nil)
+	rootID := root["rootResourceId"].(string)
+
+	created, raw := agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/resources/"+rootID,
+		map[string]any{"pathPart": "widgets"})
+	requireValues(t, "CreateResource", created, map[string]any{
+		"parentId": rootID,
+		"pathPart": "widgets",
+		"path":     "/widgets",
+	})
+	requireKeys(t, "CreateResource", created, "id")
+	agwNoInternalFields(t, "CreateResource", raw)
+	resID := created["id"].(string)
+
+	got, raw := agwWire(t, p, ctx, "GET", "/restapis/"+apiID+"/resources/"+resID, nil)
+	requireValues(t, "GetResource", got, map[string]any{
+		"id":       resID,
+		"parentId": rootID,
+		"pathPart": "widgets",
+		"path":     "/widgets",
+	})
+	agwNoInternalFields(t, "GetResource", raw)
+}
+
+// TestAPIGatewayWire_NestedProjection walks the deepest nesting a v1 response has:
+// resource → resourceMethods[verb] → methodIntegration. A projection that converts
+// only the top level leaves the nested values PascalCase, and a caller parses a
+// resource whose method map is populated with empty methods.
+func TestAPIGatewayWire_NestedProjection(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-nested")
+	root, _ := agwWire(t, p, ctx, "GET", "/restapis/"+apiID, nil)
+	rootID := root["rootResourceId"].(string)
+	res, _ := agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/resources/"+rootID,
+		map[string]any{"pathPart": "things"})
+	resID := res["id"].(string)
+
+	base := "/restapis/" + apiID + "/resources/" + resID + "/methods/GET"
+	method, raw := agwWire(t, p, ctx, "PUT", base, map[string]any{
+		"authorizationType": "NONE",
+		"apiKeyRequired":    true,
+	})
+	requireValues(t, "PutMethod", method, map[string]any{
+		"httpMethod":        "GET",
+		"authorizationType": "NONE",
+		"apiKeyRequired":    true,
+	})
+	agwNoInternalFields(t, "PutMethod", raw)
+
+	integration, raw := agwWire(t, p, ctx, "PUT", base+"/integration", map[string]any{
+		"type":       "AWS_PROXY",
+		"uri":        "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/f/invocations",
+		"httpMethod": "POST",
+	})
+	requireValues(t, "PutIntegration", integration, map[string]any{
+		"type":       "AWS_PROXY",
+		"uri":        "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/f/invocations",
+		"httpMethod": "POST",
+	})
+	agwNoInternalFields(t, "PutIntegration", raw)
+
+	// Depth 1: the method, fetched on its own, carries its integration.
+	got, raw := agwWire(t, p, ctx, "GET", base, nil)
+	mi, ok := got["methodIntegration"].(map[string]any)
+	if !ok {
+		t.Fatalf("GetMethod: want a methodIntegration object, got %#v", got["methodIntegration"])
+	}
+	requireValues(t, "GetMethod.methodIntegration", mi, map[string]any{
+		"type":       "AWS_PROXY",
+		"httpMethod": "POST",
+	})
+	agwNoInternalFields(t, "GetMethod", raw)
+
+	// Depth 2 and 3: the resource carries the method map, and each method carries
+	// its integration.
+	gotRes, raw := agwWire(t, p, ctx, "GET", "/restapis/"+apiID+"/resources/"+resID, nil)
+	rm, ok := gotRes["resourceMethods"].(map[string]any)
+	if !ok {
+		t.Fatalf("GetResource: want a resourceMethods map, got %#v", gotRes["resourceMethods"])
+	}
+	nested, ok := rm["GET"].(map[string]any)
+	if !ok {
+		t.Fatalf("resourceMethods[GET]: want an object, got %T", rm["GET"])
+	}
+	requireValues(t, "resourceMethods[GET]", nested, map[string]any{
+		"httpMethod":        "GET",
+		"authorizationType": "NONE",
+		"apiKeyRequired":    true,
+	})
+	deep, ok := nested["methodIntegration"].(map[string]any)
+	if !ok {
+		t.Fatalf("resourceMethods[GET].methodIntegration: want an object, got %#v", nested["methodIntegration"])
+	}
+	requireValues(t, "resourceMethods[GET].methodIntegration", deep, map[string]any{
+		"type": "AWS_PROXY",
+		"uri":  "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/f/invocations",
+	})
+	agwNoInternalFields(t, "GetResource nested", raw)
+}
+
+// TestAPIGatewayWire_CallerSuppliedResponsesPassThrough pins that a method
+// response's and integration response's contents are the caller's own keys, echoed
+// back rather than renamed. Substrate does not model their shape.
+func TestAPIGatewayWire_CallerSuppliedResponsesPassThrough(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-resp")
+	root, _ := agwWire(t, p, ctx, "GET", "/restapis/"+apiID, nil)
+	rootID := root["rootResourceId"].(string)
+	base := "/restapis/" + apiID + "/resources/" + rootID + "/methods/GET"
+	agwWire(t, p, ctx, "PUT", base, map[string]any{"authorizationType": "NONE"})
+
+	got, _ := agwWire(t, p, ctx, "PUT", base+"/responses/200", map[string]any{
+		"statusCode":     "200",
+		"responseModels": map[string]any{"application/json": "Empty"},
+	})
+	requireValues(t, "PutMethodResponse", got, map[string]any{"statusCode": "200"})
+	if rm, ok := got["responseModels"].(map[string]any); !ok || rm["application/json"] != "Empty" {
+		t.Errorf("PutMethodResponse: caller's responseModels must echo back, got %#v", got["responseModels"])
+	}
+}
+
+func TestAPIGatewayWire_Deployment(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-dep")
+
+	created, raw := agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/deployments",
+		map[string]any{"description": "first"})
+	requireValues(t, "CreateDeployment", created, map[string]any{"description": "first"})
+	requireKeys(t, "CreateDeployment", created, "id", "createdDate")
+	agwNoInternalFields(t, "CreateDeployment", raw)
+	depID := created["id"].(string)
+
+	got, raw := agwWire(t, p, ctx, "GET", "/restapis/"+apiID+"/deployments/"+depID, nil)
+	requireValues(t, "GetDeployment", got, map[string]any{"id": depID, "description": "first"})
+	agwNoInternalFields(t, "GetDeployment", raw)
+}
+
+func TestAPIGatewayWire_Stage(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-stage")
+	dep, _ := agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/deployments", map[string]any{})
+	depID := dep["id"].(string)
+
+	created, raw := agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/stages", map[string]any{
+		"stageName":    "prod",
+		"deploymentId": depID,
+		"description":  "production",
+		"variables":    map[string]string{"k": "v"},
+	})
+	requireValues(t, "CreateStage", created, map[string]any{
+		"stageName":    "prod",
+		"deploymentId": depID,
+		"description":  "production",
+	})
+	requireKeys(t, "CreateStage", created, "createdDate", "variables")
+	agwNoInternalFields(t, "CreateStage", raw)
+
+	got, raw := agwWire(t, p, ctx, "GET", "/restapis/"+apiID+"/stages/prod", nil)
+	requireValues(t, "GetStage", got, map[string]any{
+		"stageName":    "prod",
+		"deploymentId": depID,
+		"invokeUrl":    "https://" + apiID + ".execute-api.us-east-1.amazonaws.com/prod",
+	})
+	// The old spelling was InvokeUrl, PascalCase like everything else here.
+	if _, ok := got["InvokeUrl"]; ok {
+		t.Error("GetStage: the key is invokeUrl, not InvokeUrl")
+	}
+	agwNoInternalFields(t, "GetStage", raw)
+
+	patched, raw := agwWire(t, p, ctx, "PATCH", "/restapis/"+apiID+"/stages/prod", map[string]any{})
+	requireValues(t, "UpdateStage", patched, map[string]any{"stageName": "prod"})
+	agwNoInternalFields(t, "UpdateStage", raw)
+}
+
+func TestAPIGatewayWire_Authorizer(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-auth")
+
+	created, raw := agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/authorizers", map[string]any{
+		"name":           "my-auth",
+		"type":           "TOKEN",
+		"authorizerUri":  "arn:aws:apigateway:us-east-1:lambda:path/f",
+		"identitySource": "method.request.header.Authorization",
+		"providerARNs":   []string{"arn:aws:cognito-idp:us-east-1:123456789012:userpool/p"},
+	})
+	requireValues(t, "CreateAuthorizer", created, map[string]any{
+		"name":           "my-auth",
+		"type":           "TOKEN",
+		"authorizerUri":  "arn:aws:apigateway:us-east-1:lambda:path/f",
+		"identitySource": "method.request.header.Authorization",
+	})
+	requireKeys(t, "CreateAuthorizer", created, "id", "providerARNs")
+	// providerARNs keeps its capitalised acronym; providerArns is not the member.
+	if _, ok := created["providerArns"]; ok {
+		t.Error("CreateAuthorizer: the member is providerARNs, not providerArns")
+	}
+	agwNoInternalFields(t, "CreateAuthorizer", raw)
+	authID := created["id"].(string)
+
+	got, raw := agwWire(t, p, ctx, "GET", "/restapis/"+apiID+"/authorizers/"+authID, nil)
+	requireValues(t, "GetAuthorizer", got, map[string]any{"id": authID, "name": "my-auth", "type": "TOKEN"})
+	agwNoInternalFields(t, "GetAuthorizer", raw)
+}
+
+func TestAPIGatewayWire_APIKey(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+
+	created, raw := agwWire(t, p, ctx, "POST", "/apikeys", map[string]any{
+		"name":    "my-key",
+		"enabled": true,
+		"tags":    map[string]string{"env": "test"},
+	})
+	requireValues(t, "CreateApiKey", created, map[string]any{"name": "my-key", "enabled": true})
+	requireKeys(t, "CreateApiKey", created, "id", "value", "createdDate", "tags")
+	// Assert the value is non-empty, not merely equal to itself on both reads: a
+	// projection that drops it still emits the key holding "", and comparing the two
+	// responses' values would then compare "" with "" and pass.
+	value, _ := created["value"].(string)
+	if value == "" {
+		t.Error("CreateApiKey: value must be a non-empty key material")
+	}
+	agwNoInternalFields(t, "CreateApiKey", raw)
+	keyID := created["id"].(string)
+
+	got, raw := agwWire(t, p, ctx, "GET", "/apikeys/"+keyID, nil)
+	requireValues(t, "GetApiKey", got, map[string]any{
+		"id":      keyID,
+		"name":    "my-key",
+		"enabled": true,
+		"value":   value,
+	})
+	agwNoInternalFields(t, "GetApiKey", raw)
+}
+
+func TestAPIGatewayWire_UsagePlan(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+
+	created, raw := agwWire(t, p, ctx, "POST", "/usageplans", map[string]any{
+		"name":        "my-plan",
+		"description": "a plan",
+		"tags":        map[string]string{"env": "test"},
+	})
+	requireValues(t, "CreateUsagePlan", created, map[string]any{
+		"name":        "my-plan",
+		"description": "a plan",
+	})
+	requireKeys(t, "CreateUsagePlan", created, "id", "tags")
+	// UsagePlan declares no createdDate, so substrate must not report one even
+	// though it stores one.
+	if _, ok := created["createdDate"]; ok {
+		t.Error("CreateUsagePlan: createdDate is not a member of UsagePlan")
+	}
+	agwNoInternalFields(t, "CreateUsagePlan", raw)
+	planID := created["id"].(string)
+
+	got, raw := agwWire(t, p, ctx, "GET", "/usageplans/"+planID, nil)
+	requireValues(t, "GetUsagePlan", got, map[string]any{"id": planID, "name": "my-plan"})
+	agwNoInternalFields(t, "GetUsagePlan", raw)
+}
+
+func TestAPIGatewayWire_DomainNameAndBasePathMapping(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-domain")
+
+	created, raw := agwWire(t, p, ctx, "POST", "/domainnames", map[string]any{
+		"domainName":     "api.example.com",
+		"certificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/c",
+	})
+	requireValues(t, "CreateDomainName", created, map[string]any{
+		"domainName":         "api.example.com",
+		"certificateArn":     "arn:aws:acm:us-east-1:123456789012:certificate/c",
+		"regionalDomainName": "api.example.com.regional.execute-api.us-east-1.amazonaws.com",
+	})
+	agwNoInternalFields(t, "CreateDomainName", raw)
+
+	got, raw := agwWire(t, p, ctx, "GET", "/domainnames/api.example.com", nil)
+	requireValues(t, "GetDomainName", got, map[string]any{"domainName": "api.example.com"})
+	agwNoInternalFields(t, "GetDomainName", raw)
+
+	mapping, raw := agwWire(t, p, ctx, "POST", "/domainnames/api.example.com/basepathmappings",
+		map[string]any{"basePath": "v1", "restApiId": apiID, "stage": "prod"})
+	requireValues(t, "CreateBasePathMapping", mapping, map[string]any{
+		"basePath":  "v1",
+		"restApiId": apiID,
+		"stage":     "prod",
+	})
+	// BasePathMapping declares no domainName: the domain is a path parameter of the
+	// request, not a member of the response.
+	if _, ok := mapping["domainName"]; ok {
+		t.Error("CreateBasePathMapping: domainName is not a member of BasePathMapping")
+	}
+	agwNoInternalFields(t, "CreateBasePathMapping", raw)
+}
+
+// --- Envelopes ---------------------------------------------------------------
+//
+// One test per list operation. A single test covering all eight would pass while
+// seven of them were wrong.
+
+func TestAPIGatewayWire_GetRestAPIsEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	id := agwAPI(t, p, ctx, "wire-list-api")
+
+	m, raw := agwWire(t, p, ctx, "GET", "/restapis", nil)
+	elem := agwItem(t, "GetRestApis", m)
+	requireValues(t, "GetRestApis element", elem, map[string]any{"id": id, "name": "wire-list-api"})
+	agwNoInternalFields(t, "GetRestApis", raw)
+}
+
+func TestAPIGatewayWire_GetResourcesEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-list-res")
+
+	m, raw := agwWire(t, p, ctx, "GET", "/restapis/"+apiID+"/resources", nil)
+	elem := agwItem(t, "GetResources", m)
+	requireValues(t, "GetResources element", elem, map[string]any{"path": "/"})
+	agwNoInternalFields(t, "GetResources", raw)
+}
+
+func TestAPIGatewayWire_GetDeploymentsEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-list-dep")
+	dep, _ := agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/deployments", map[string]any{"description": "d"})
+
+	m, raw := agwWire(t, p, ctx, "GET", "/restapis/"+apiID+"/deployments", nil)
+	elem := agwItem(t, "GetDeployments", m)
+	requireValues(t, "GetDeployments element", elem, map[string]any{"id": dep["id"], "description": "d"})
+	agwNoInternalFields(t, "GetDeployments", raw)
+}
+
+// TestAPIGatewayWire_GetStagesEnvelope is the regression gate for the one handler
+// that was already right. GetStages' model member is named "item" where the other
+// nineteen collections are named "items" with locationName "item" — so a blanket
+// rename to match the others breaks the only v1 list an SDK could already parse.
+func TestAPIGatewayWire_GetStagesEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-list-stage")
+	agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/stages", map[string]any{"stageName": "prod"})
+
+	m, raw := agwWire(t, p, ctx, "GET", "/restapis/"+apiID+"/stages", nil)
+	elem := agwItem(t, "GetStages", m)
+	requireValues(t, "GetStages element", elem, map[string]any{"stageName": "prod"})
+	agwNoInternalFields(t, "GetStages", raw)
+}
+
+func TestAPIGatewayWire_GetAuthorizersEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-list-auth")
+	agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/authorizers",
+		map[string]any{"name": "a", "type": "TOKEN"})
+
+	m, raw := agwWire(t, p, ctx, "GET", "/restapis/"+apiID+"/authorizers", nil)
+	elem := agwItem(t, "GetAuthorizers", m)
+	requireValues(t, "GetAuthorizers element", elem, map[string]any{"name": "a", "type": "TOKEN"})
+	agwNoInternalFields(t, "GetAuthorizers", raw)
+}
+
+func TestAPIGatewayWire_GetAPIKeysEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	agwWire(t, p, ctx, "POST", "/apikeys", map[string]any{"name": "k", "enabled": true})
+
+	m, raw := agwWire(t, p, ctx, "GET", "/apikeys", nil)
+	elem := agwItem(t, "GetApiKeys", m)
+	requireValues(t, "GetApiKeys element", elem, map[string]any{"name": "k", "enabled": true})
+	agwNoInternalFields(t, "GetApiKeys", raw)
+}
+
+func TestAPIGatewayWire_GetUsagePlansEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	agwWire(t, p, ctx, "POST", "/usageplans", map[string]any{"name": "p"})
+
+	m, raw := agwWire(t, p, ctx, "GET", "/usageplans", nil)
+	elem := agwItem(t, "GetUsagePlans", m)
+	requireValues(t, "GetUsagePlans element", elem, map[string]any{"name": "p"})
+	agwNoInternalFields(t, "GetUsagePlans", raw)
+}
+
+func TestAPIGatewayWire_GetBasePathMappingsEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-list-bpm")
+	agwWire(t, p, ctx, "POST", "/domainnames", map[string]any{"domainName": "api.example.com"})
+	agwWire(t, p, ctx, "POST", "/domainnames/api.example.com/basepathmappings",
+		map[string]any{"basePath": "v1", "restApiId": apiID, "stage": "prod"})
+
+	m, raw := agwWire(t, p, ctx, "GET", "/domainnames/api.example.com/basepathmappings", nil)
+	elem := agwItem(t, "GetBasePathMappings", m)
+	requireValues(t, "GetBasePathMappings element", elem, map[string]any{"basePath": "v1", "restApiId": apiID})
+	agwNoInternalFields(t, "GetBasePathMappings", raw)
+}
+
+// TestAPIGatewayWire_EmptyListsAreLists pins the empty case across every collection
+// as a list rather than null: a caller iterating the result must not have to handle
+// a JSON null. It also asserts no "position" token is invented — substrate returns
+// every element in one page and honors no token, and an empty one would invite a
+// caller to page on nothing.
+func TestAPIGatewayWire_EmptyListsAreLists(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+	apiID := agwAPI(t, p, ctx, "wire-empty")
+	agwWire(t, p, ctx, "POST", "/domainnames", map[string]any{"domainName": "api.example.com"})
+
+	for _, tc := range []struct{ name, path string }{
+		{"GetDeployments", "/restapis/" + apiID + "/deployments"},
+		{"GetStages", "/restapis/" + apiID + "/stages"},
+		{"GetAuthorizers", "/restapis/" + apiID + "/authorizers"},
+		{"GetApiKeys", "/apikeys"},
+		{"GetUsagePlans", "/usageplans"},
+		{"GetBasePathMappings", "/domainnames/api.example.com/basepathmappings"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, raw := agwWire(t, p, ctx, "GET", tc.path, nil)
+			list, ok := m["item"].([]any)
+			if !ok {
+				t.Fatalf("%s: want an empty %q list, got %#v", tc.name, "item", m)
+			}
+			if len(list) != 0 {
+				t.Errorf("%s: want 0 elements, got %d", tc.name, len(list))
+			}
+			if _, ok := m["position"]; ok {
+				t.Errorf("%s: substrate returns one page, so no position token must be sent", tc.name)
+			}
+			if bytes.Contains(raw, []byte("null")) {
+				t.Errorf("%s: response contains a JSON null: %s", tc.name, raw)
+			}
+		})
+	}
+}
+
+// TestAPIGatewayWire_UnsetOptionalsAreOmitted pins absent-versus-null. Real API
+// Gateway omits an unset member; substrate used to send "description": "" and
+// "tags": null because it marshaled a state struct whose optional members lacked
+// omitempty, and a caller distinguishing the two reads a real observable.
+func TestAPIGatewayWire_UnsetOptionalsAreOmitted(t *testing.T) {
+	p, ctx := setupAPIGatewayPlugin(t)
+
+	// No description, no tags.
+	created, raw := agwWire(t, p, ctx, "POST", "/restapis", map[string]any{"name": "sparse"})
+	if _, ok := created["description"]; ok {
+		t.Error("description: an unset optional must be omitted, not sent empty")
+	}
+	if _, ok := created["tags"]; ok {
+		t.Error("tags: an unset map must be omitted, not sent as null")
+	}
+	if bytes.Contains(raw, []byte("null")) {
+		t.Errorf("response contains a JSON null: %s", raw)
+	}
+
+	apiID := created["id"].(string)
+	root, _ := agwWire(t, p, ctx, "GET", "/restapis/"+apiID, nil)
+	rootID := root["rootResourceId"].(string)
+
+	// A method with no integration must omit methodIntegration rather than nulling it.
+	base := "/restapis/" + apiID + "/resources/" + rootID + "/methods/GET"
+	agwWire(t, p, ctx, "PUT", base, map[string]any{"authorizationType": "NONE"})
+	method, raw := agwWire(t, p, ctx, "GET", base, nil)
+	if _, ok := method["methodIntegration"]; ok {
+		t.Error("methodIntegration: a method with no integration must omit it, not send null")
+	}
+	if bytes.Contains(raw, []byte("null")) {
+		t.Errorf("GetMethod response contains a JSON null: %s", raw)
+	}
+
+	// A resource with no methods must omit resourceMethods rather than sending {}.
+	res, _ := agwWire(t, p, ctx, "POST", "/restapis/"+apiID+"/resources/"+rootID,
+		map[string]any{"pathPart": "bare"})
+	if _, ok := res["resourceMethods"]; ok {
+		t.Error("resourceMethods: a resource with no methods must omit the map")
+	}
+}
+
+// TestAPIGatewayWire_StateEncodingUnchanged makes "state encoding is unchanged" a
+// fact rather than a claim. The stored bytes are a persisted format that recorded
+// runs replay from, so they keep their PascalCase keys even though the wire is
+// lowerCamel — including the AccountID and Region that must never reach a caller.
+// This is the test that fails if someone later fixes a casing bug by retagging the
+// state struct instead of the wire type.
+func TestAPIGatewayWire_StateEncodingUnchanged(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	p := &emulator.APIGatewayPlugin{}
+	if err := p.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: emulator.NewDefaultLogger(0, false),
+	}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	ctx := &emulator.RequestContext{AccountID: "123456789012", Region: "us-east-1", RequestID: "req-1"}
+
+	resp, err := p.HandleRequest(ctx, apigwRequest(t, "POST", "/restapis", map[string]any{"name": "state-shape"}))
+	if err != nil {
+		t.Fatalf("CreateRestApi: %v", err)
+	}
+	var created map[string]any
+	if err := json.Unmarshal(resp.Body, &created); err != nil {
+		t.Fatalf("unmarshal create response: %v", err)
+	}
+	apiID := created["id"].(string)
+
+	data, err := state.Get(context.Background(), "apigateway", "api:123456789012/us-east-1/"+apiID)
+	if err != nil || data == nil {
+		t.Fatalf("state.Get: %v (data=%v)", err, data)
+	}
+	var stored map[string]any
+	if err := json.Unmarshal(data, &stored); err != nil {
+		t.Fatalf("unmarshal stored api: %v", err)
+	}
+	for _, k := range []string{"Id", "Name", "RootResourceId", "CreatedDate", "AccountID", "Region"} {
+		if _, ok := stored[k]; !ok {
+			t.Errorf("stored api: key %q is missing; the persisted format must not change", k)
+		}
+	}
+	// And the wire spelling must NOT appear in state, or the two have been conflated.
+	for _, k := range []string{"id", "name", "rootResourceId"} {
+		if _, ok := stored[k]; ok {
+			t.Errorf("stored api: wire spelling %q found in the persisted format", k)
+		}
+	}
+}


### PR DESCRIPTION
Every API Gateway v1 response substrate sent was unparseable by an AWS SDK, and
nothing reported it. `aws apigateway create-rest-api --query id` printed an empty
line; `get-rest-apis --query 'length(items)'` failed on a null. Both at HTTP 200
with a well-formed body and no error.

The mechanism is #528's: the plugin marshaled its **state** struct onto the wire,
and botocore's rest-json parser matches a response key against the model's
`locationName` (falling back to the member name) **case-sensitively**. A
PascalCase key matches nothing, so the parse produces an empty result rather than
a failure. Feeding substrate's actual body to `create_parser('rest-json')` turns
`{"Id":"a1","Name":"n1",…}` into `{}` — not "some fields missing", nothing at all.

It hid because Go's `json.Unmarshal` matches keys **case-insensitively**. The
request side therefore works, every Go round-trip test passes, and a hand-written
assertion struct with the wrong tags stays green. Response-only fix.

## Three corrections to #529 as filed

**The `items` envelope was not already correct.** The issue says it is. Every v1
collection member is *named* `items` but carries `locationName: "item"`, singular,
so `{"items":[…]}` parses to `{}` and `{"item":[…]}` parses. Seven of the eight
list handlers sent the plural; they now send `item`.

**`GetStages` is the exception and is deliberately unchanged.** Its model member is
literally named `item`, and substrate already emitted `item`. A blanket rename
would have broken the only v1 list an SDK could already read. It keeps its key,
with a comment saying why and a regression test that goes red if someone
"corrects" it.

**`resourceMethods` and `methodIntegration` were never populated at all.** Not a
casing problem — methods and integrations were stored under separate state keys and
never joined, so both members were structurally absent from every response no
matter how they were spelled. The recursive projection is only observable once that
join exists, so this PR adds it: `GetResource`, `GetResources` and `GetMethod` now
report all three depths.

## The fix

The eleven state types in `apigateway_types.go` are **untouched**. Their PascalCase
tags are a persisted format that `MemoryStateManager.Snapshot` round-trips and
recorded runs replay from — retagging them would silently change the format of
every recording. **State encoding is unchanged**, and a test asserts it by checking
the stored bytes still carry `Id`/`Name`/`RootResourceId`/`AccountID`/`Region` and
that the wire spellings do *not* appear there.

`apigateway_wire.go` adds eleven response-only element types tagged from the
botocore model, each with a `…Wire()` projection, plus a generic `apigwItemsOut[T]`
envelope. None of the wire types has an `AccountID`, `Region` or `APIId` member at
all — the leak is closed structurally, not by an `omitempty` a future field could
step around. `resourceWire` recurses into `methodWire` which recurses into
`integrationWire`.

`MethodResponses` and `IntegrationResponses` hold whatever the caller PUT. They pass
through unchanged: those are the caller's own keys, not substrate's to rename.

## Judgement calls, made from the model rather than the previous code

- `providerARNs` keeps its capitalised acronym — that is what the model spells, and
  a mechanical lowerCamel transform would get it wrong.
- `UsagePlan` reports no `createdDate` and `BasePathMapping` no `domainName`.
  Neither is a member of its shape; substrate stores both, and a mapping's domain
  is a path parameter of the request.
- Unset optionals are **omitted** rather than sent as `""` or `null`, following each
  model member's optionality. A caller distinguishing absent from null is making a
  real observation.
- No response invents a `position` token. Substrate returns every element in one
  page and honors no token; emitting one would invite a caller to page on nothing.
- `GetStage`'s `invokeUrl` is substrate's own member that no model declares. It is
  kept (a consumer reading the raw response uses it) and respelled from `InvokeUrl`.
  It cannot break an SDK caller, because botocore drops a key the model does not
  declare.

## The updated existing assertions were wrong today and passed anyway

Ten sites in `apigateway_plugin_test.go` and two in `apigateway_proxy_test.go`
assert on PascalCase members and `items` envelopes. They passed because of the
case-insensitive `Unmarshal` above, not because the wire was right — one carried a
comment documenting the broken spelling as intended (*"RestAPIState uses json tag
`Id` (capital I)"*). Updating them is part of the fix, not a weakening of the
tests. The `GetRestApis` decode could not simply be retagged: it decoded into
`[]emulator.RestAPIState`, which is the state type this PR is specifically keeping
off the wire, so it now decodes into a local struct with wire tags.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → 0
issues, `make test` (race), `make docs-reference docs-reference-check docs-versions`,
`npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test -C test/e2e ./...`.

`apigateway_wire_test.go` adds 18 tests that decode into `map[string]any` and assert
**literal wire keys** — including one envelope test per list operation (a single
test over all eight would pass while seven were wrong), the `GetStages` regression
gate, the three-depth nested-projection test, byte-level negative assertions on
`AccountID`/`Region`/`APIId`, empty-list-is-a-list-not-null, and the
state-encoding-invariance test. Value assertions throughout, not key presence: a
`Wire()` that drops a member still emits its key holding Go's zero value.

**Mutation testing: 30 mutants, 30 CAUGHT.** Including `getStages` "fixed" to
`items`, two different list operations reverted independently, per-type tag
reversions, `AccountID` and `APIId` added back to a wire type, the nested projection
skipped at each of two levels, both joins removed, eight separate single-member
`Wire()` drops, two `omitempty` drops, the two non-model members added back, an
invented `position`, and the state struct retagged. One survivor was found and
fixed on the way: the API-key test compared `got["value"]` against
`created["value"]`, so dropping the member compared `""` with `""` — it now asserts
non-empty before comparing.

Live against `substrate server --address :4621`, every call parsing a non-empty
result where it returned empty before:

```
create-rest-api --query id                → ojkaahjfpk
get-rest-apis --query 'length(items)'     → 1
get-resources items[0].path               → /
get-method                                → GET  True  AWS_PROXY  arn:…
get-resource resourceMethods.GET.methodIntegration.type  → AWS_PROXY   # all three depths
get-stages item[0].[stageName,deploymentId]              → prod  mbbmfpmbli   # regression gate
authorizer / api-key / usage-plan / domain-name / base-path-mapping → all parse
AccountID|Region|APIId grep on every response            → 0
```

Raw body: `{"item":[{"id":"ojkaahjfpk","name":"prod-api","description":"a
description","rootResourceId":"pnmjfhiipp","createdDate":"…"}]}`.

No other consumer of the v1 wire shape exists: `tagging_plugin.go` reads state
directly, and `cfn_resources_v19.go` already decodes lowerCamel and computes the
stage invoke URL locally rather than reading it from the response.

## Scope

v1 only. API Gateway v2 is the same defect and is the next PR — `aws apigatewayv2
create-api --query ApiId` still returns `None` today. #529 covers v1, v2 and MSK, so
it stays open until v2 lands; MSK was #564.

Refs #529
