### PR TITLE
fix(apigatewayv2): return the v2 response shape an SDK parses (#529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **API Gateway v2 responses are the shape an SDK parses** (#529). Every
+  `apigatewayv2` response used PascalCase members under an `Items` envelope, so
+  `aws apigatewayv2 create-api --query ApiId` printed `None` and
+  `get-apis --query 'length(Items)'` failed on a null — the same
+  case-sensitive-`locationName` mechanism as v1 and MSK below, and the same total
+  parse failure rather than a member missing here and there. This was invisible over
+  the wire until the routing fix below made v2 reachable by an SDK at all.
+
+  Same remedy: the seven state types keep their PascalCase tags and are
+  **untouched**, so **state encoding is unchanged and recorded runs replay**; nine
+  response-only element types tagged from the model are projected from them, and none
+  carries an `AccountID` or `Region` member at all. The five list envelopes now emit
+  `items` — lowercase, unlike v1's singular `item`; the two spellings differ and both
+  are transcribed from their own model.
+
+  v2 is far more regular than v1: all 1,545 members of its response shapes are the
+  plain lowerCamel of their member names, the only irregular spellings in the whole
+  model (`ResourceArn -> "resource-arn"`) being on the three tag *request* shapes
+  that substrate does not route. Each tag was still transcribed from the model rather
+  than lowercased programmatically, because a mechanical transform is exactly what
+  gets an exception wrong.
+
+  Three members are now absent, from the model rather than the previous code. A
+  route, integration, stage and API mapping report no `apiId`: the API is a path
+  parameter of the request and not a member of any of those shapes, so botocore
+  discarded the key regardless. A domain name reports no `regionalDomainName` — that
+  spelling is v1's, and v2 has no top-level equivalent; substrate now reports the
+  same hostname where the v2 model puts it, as
+  `domainNameConfigurations[].apiGatewayDomainName`, which is what makes it visible
+  to an SDK instead of silently dropped. And no response carries a `nextToken`, since
+  substrate returns every element in one page and honours no token. Unset optionals
+  are omitted rather than sent as `""` or `null`.
+
+  The CloudFormation v2 deploy handlers read `ApiId`, `RouteId`, `IntegrationId` and
+  `AuthorizerId` out of these responses to set a resource's physical ID; they now read
+  the wire spellings. They worked before only because Go's `json.Unmarshal` is
+  case-insensitive, which is the same reason ~10 assertions in
+  `apigatewayv2_plugin_test.go` and `apigateway_proxy_test.go` were **wrong today and
+  passed anyway**. Updating them is part of the fix. Those CloudFormation tests
+  asserted only a resource count, so a physical ID silently falling back to a logical
+  ID or a route key would not have failed one; they now assert the ID itself, which is
+  what makes every `Ref` in a stack verifiable.
+
+  `GetApiMappings` turns out to be unrouted (`POST` on that path is the only mapping
+  operation implemented). That is a missing operation rather than a wrong response
+  shape, so it is filed as #566 rather than folded in here; `create-api-mapping`
+  itself parses correctly.
+
 - **API Gateway v1 responses are the shape an SDK parses** (#529). Every `apigateway`
   response substrate sent used PascalCase members under an `items` envelope, and
   botocore matches a response key against the model's `locationName`

--- a/docs/services.md
+++ b/docs/services.md
@@ -3599,6 +3599,18 @@ Every requestUri in the apigatewayv2 API is under `/v2/` and none of v1's is, so
 the split is exact. A consumer pointing an `apigatewayv2` client at Substrate needs
 no special configuration.
 
+**Response shape:** every member is lowerCamel as the service model spells it
+(`apiId`, `routeId`, `integrationId`, `apiEndpoint`, `protocolType`, …), and
+collection responses nest their elements under **`items`** — lowercase, unlike v1's
+singular `item`. Substrate returns every element in one page and honours no
+pagination token, so no response carries a `nextToken`. Two members v1 has are
+absent here because the v2 model does not declare them: a route, integration, stage
+or API mapping reports no `apiId` (the API is a path parameter of the request), and
+a domain name reports no `regionalDomainName` — v2 nests that hostname as
+`domainNameConfigurations[].apiGatewayDomainName`. Earlier releases sent PascalCase
+members under an `Items` envelope, which an AWS SDK parsed to an empty result with
+no error (#529).
+
 ### Supported operations
 
 | Operation | Notes |

--- a/emulator/apigateway_proxy_test.go
+++ b/emulator/apigateway_proxy_test.go
@@ -342,9 +342,11 @@ func TestAPIGatewayProxy_V2EndToEnd(t *testing.T) {
 	if err := json.Unmarshal(apiBody, &apiResult); err != nil {
 		t.Fatalf("decode v2 api: %v", err)
 	}
-	apiID, _ := apiResult["ApiId"].(string)
+	// The wire key is "apiId", lowercase — the PascalCase spelling this read
+	// before #529 is what no SDK could parse.
+	apiID, _ := apiResult["apiId"].(string)
 	if apiID == "" {
-		t.Fatalf("no ApiId in response: %s", apiBody)
+		t.Fatalf("no apiId in response: %s", apiBody)
 	}
 
 	// Create integration.
@@ -365,7 +367,7 @@ func TestAPIGatewayProxy_V2EndToEnd(t *testing.T) {
 	if err := json.Unmarshal(intBody, &intResult); err != nil {
 		t.Fatalf("decode integration: %v", err)
 	}
-	intID, _ := intResult["IntegrationId"].(string)
+	intID, _ := intResult["integrationId"].(string)
 
 	// Create a $default route.
 	routePayload, _ := json.Marshal(map[string]interface{}{

--- a/emulator/apigatewayv2_plugin.go
+++ b/emulator/apigatewayv2_plugin.go
@@ -301,7 +301,7 @@ func (p *APIGatewayV2Plugin) createAPI(ctx *RequestContext, req *AWSRequest) (*A
 	}
 	updateStringIndex(goCtx, p.state, apigatewayv2Namespace, apigwv2APIIDsKey(ctx.AccountID, ctx.Region), apiID)
 
-	return apigwJSONResponse(http.StatusCreated, api)
+	return apigwJSONResponse(http.StatusCreated, v2APIWire(api))
 }
 
 func (p *APIGatewayV2Plugin) getAPI(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -317,7 +317,7 @@ func (p *APIGatewayV2Plugin) getAPI(ctx *RequestContext, apiID string) (*AWSResp
 	if err := json.Unmarshal(data, &api); err != nil {
 		return nil, fmt.Errorf("apigatewayv2 getApi unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, api)
+	return apigwJSONResponse(http.StatusOK, v2APIWire(api))
 }
 
 func (p *APIGatewayV2Plugin) getAPIs(ctx *RequestContext) (*AWSResponse, error) {
@@ -327,7 +327,7 @@ func (p *APIGatewayV2Plugin) getAPIs(ctx *RequestContext) (*AWSResponse, error) 
 		return nil, fmt.Errorf("apigatewayv2 getApis loadIndex: %w", err)
 	}
 
-	items := make([]V2ApiState, 0, len(ids))
+	items := make([]v2APIOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayv2Namespace, apigwv2APIKey(ctx.AccountID, ctx.Region, id))
 		if getErr != nil || data == nil {
@@ -335,14 +335,11 @@ func (p *APIGatewayV2Plugin) getAPIs(ctx *RequestContext) (*AWSResponse, error) 
 		}
 		var api V2ApiState
 		if json.Unmarshal(data, &api) == nil {
-			items = append(items, api)
+			items = append(items, v2APIWire(api))
 		}
 	}
 
-	type response struct {
-		Items []V2ApiState `json:"Items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwV2ItemsOut[v2APIOut]{Items: items})
 }
 
 func (p *APIGatewayV2Plugin) deleteAPI(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -396,7 +393,7 @@ func (p *APIGatewayV2Plugin) updateAPI(ctx *RequestContext, req *AWSRequest, api
 	if err := p.state.Put(goCtx, apigatewayv2Namespace, apigwv2APIKey(ctx.AccountID, ctx.Region, apiID), updated); err != nil {
 		return nil, fmt.Errorf("apigatewayv2 updateApi state.Put: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, api)
+	return apigwJSONResponse(http.StatusOK, v2APIWire(api))
 }
 
 // --- Route operations --------------------------------------------------------
@@ -433,7 +430,7 @@ func (p *APIGatewayV2Plugin) createRoute(ctx *RequestContext, req *AWSRequest, a
 	}
 	updateStringIndex(goCtx, p.state, apigatewayv2Namespace, apigwv2RouteIDsKey(ctx.AccountID, ctx.Region, apiID), route.RouteID)
 
-	return apigwJSONResponse(http.StatusCreated, route)
+	return apigwJSONResponse(http.StatusCreated, v2RouteWire(route))
 }
 
 func (p *APIGatewayV2Plugin) getRoute(ctx *RequestContext, apiID, routeID string) (*AWSResponse, error) {
@@ -449,7 +446,7 @@ func (p *APIGatewayV2Plugin) getRoute(ctx *RequestContext, apiID, routeID string
 	if err := json.Unmarshal(data, &route); err != nil {
 		return nil, fmt.Errorf("apigatewayv2 getRoute unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, route)
+	return apigwJSONResponse(http.StatusOK, v2RouteWire(route))
 }
 
 func (p *APIGatewayV2Plugin) getRoutes(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -459,7 +456,7 @@ func (p *APIGatewayV2Plugin) getRoutes(ctx *RequestContext, apiID string) (*AWSR
 		return nil, fmt.Errorf("apigatewayv2 getRoutes loadIndex: %w", err)
 	}
 
-	items := make([]V2RouteState, 0, len(ids))
+	items := make([]v2RouteOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayv2Namespace, apigwv2RouteKey(ctx.AccountID, ctx.Region, apiID, id))
 		if getErr != nil || data == nil {
@@ -467,14 +464,11 @@ func (p *APIGatewayV2Plugin) getRoutes(ctx *RequestContext, apiID string) (*AWSR
 		}
 		var route V2RouteState
 		if json.Unmarshal(data, &route) == nil {
-			items = append(items, route)
+			items = append(items, v2RouteWire(route))
 		}
 	}
 
-	type response struct {
-		Items []V2RouteState `json:"Items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwV2ItemsOut[v2RouteOut]{Items: items})
 }
 
 func (p *APIGatewayV2Plugin) deleteRoute(ctx *RequestContext, apiID, routeID string) (*AWSResponse, error) {
@@ -518,7 +512,7 @@ func (p *APIGatewayV2Plugin) createIntegration(ctx *RequestContext, req *AWSRequ
 	}
 	updateStringIndex(goCtx, p.state, apigatewayv2Namespace, apigwv2IntegrationIDsKey(ctx.AccountID, ctx.Region, apiID), integ.IntegrationID)
 
-	return apigwJSONResponse(http.StatusCreated, integ)
+	return apigwJSONResponse(http.StatusCreated, v2IntegrationWire(integ))
 }
 
 func (p *APIGatewayV2Plugin) getIntegration(ctx *RequestContext, apiID, intID string) (*AWSResponse, error) {
@@ -534,7 +528,7 @@ func (p *APIGatewayV2Plugin) getIntegration(ctx *RequestContext, apiID, intID st
 	if err := json.Unmarshal(data, &integ); err != nil {
 		return nil, fmt.Errorf("apigatewayv2 getIntegration unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, integ)
+	return apigwJSONResponse(http.StatusOK, v2IntegrationWire(integ))
 }
 
 func (p *APIGatewayV2Plugin) getIntegrations(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -544,7 +538,7 @@ func (p *APIGatewayV2Plugin) getIntegrations(ctx *RequestContext, apiID string) 
 		return nil, fmt.Errorf("apigatewayv2 getIntegrations loadIndex: %w", err)
 	}
 
-	items := make([]V2IntegrationState, 0, len(ids))
+	items := make([]v2IntegrationOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayv2Namespace, apigwv2IntegrationKey(ctx.AccountID, ctx.Region, apiID, id))
 		if getErr != nil || data == nil {
@@ -552,14 +546,11 @@ func (p *APIGatewayV2Plugin) getIntegrations(ctx *RequestContext, apiID string) 
 		}
 		var integ V2IntegrationState
 		if json.Unmarshal(data, &integ) == nil {
-			items = append(items, integ)
+			items = append(items, v2IntegrationWire(integ))
 		}
 	}
 
-	type response struct {
-		Items []V2IntegrationState `json:"Items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwV2ItemsOut[v2IntegrationOut]{Items: items})
 }
 
 func (p *APIGatewayV2Plugin) deleteIntegration(ctx *RequestContext, apiID, intID string) (*AWSResponse, error) {
@@ -610,7 +601,7 @@ func (p *APIGatewayV2Plugin) createStageV2(ctx *RequestContext, req *AWSRequest,
 	}
 	updateStringIndex(goCtx, p.state, apigatewayv2Namespace, apigwv2StageNamesKey(ctx.AccountID, ctx.Region, apiID), stage.StageName)
 
-	return apigwJSONResponse(http.StatusCreated, stage)
+	return apigwJSONResponse(http.StatusCreated, v2StageWire(stage))
 }
 
 func (p *APIGatewayV2Plugin) getStageV2(ctx *RequestContext, apiID, stageName string) (*AWSResponse, error) {
@@ -626,7 +617,7 @@ func (p *APIGatewayV2Plugin) getStageV2(ctx *RequestContext, apiID, stageName st
 	if err := json.Unmarshal(data, &stage); err != nil {
 		return nil, fmt.Errorf("apigatewayv2 getStage unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, stage)
+	return apigwJSONResponse(http.StatusOK, v2StageWire(stage))
 }
 
 func (p *APIGatewayV2Plugin) getStagesV2(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -636,7 +627,7 @@ func (p *APIGatewayV2Plugin) getStagesV2(ctx *RequestContext, apiID string) (*AW
 		return nil, fmt.Errorf("apigatewayv2 getStages loadIndex: %w", err)
 	}
 
-	items := make([]V2StageState, 0, len(names))
+	items := make([]v2StageOut, 0, len(names))
 	for _, name := range names {
 		data, getErr := p.state.Get(goCtx, apigatewayv2Namespace, apigwv2StageKey(ctx.AccountID, ctx.Region, apiID, name))
 		if getErr != nil || data == nil {
@@ -644,14 +635,11 @@ func (p *APIGatewayV2Plugin) getStagesV2(ctx *RequestContext, apiID string) (*AW
 		}
 		var stage V2StageState
 		if json.Unmarshal(data, &stage) == nil {
-			items = append(items, stage)
+			items = append(items, v2StageWire(stage))
 		}
 	}
 
-	type response struct {
-		Items []V2StageState `json:"Items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwV2ItemsOut[v2StageOut]{Items: items})
 }
 
 func (p *APIGatewayV2Plugin) deleteStageV2(ctx *RequestContext, apiID, stageName string) (*AWSResponse, error) {
@@ -697,7 +685,7 @@ func (p *APIGatewayV2Plugin) createAuthorizerV2(ctx *RequestContext, req *AWSReq
 	}
 	updateStringIndex(goCtx, p.state, apigatewayv2Namespace, apigwv2AuthorizerIDsKey(ctx.AccountID, ctx.Region, apiID), auth.AuthorizerID)
 
-	return apigwJSONResponse(http.StatusCreated, auth)
+	return apigwJSONResponse(http.StatusCreated, v2AuthorizerWire(auth))
 }
 
 func (p *APIGatewayV2Plugin) getAuthorizerV2(ctx *RequestContext, apiID, authID string) (*AWSResponse, error) {
@@ -713,7 +701,7 @@ func (p *APIGatewayV2Plugin) getAuthorizerV2(ctx *RequestContext, apiID, authID 
 	if err := json.Unmarshal(data, &auth); err != nil {
 		return nil, fmt.Errorf("apigatewayv2 getAuthorizer unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, auth)
+	return apigwJSONResponse(http.StatusOK, v2AuthorizerWire(auth))
 }
 
 func (p *APIGatewayV2Plugin) getAuthorizersV2(ctx *RequestContext, apiID string) (*AWSResponse, error) {
@@ -723,7 +711,7 @@ func (p *APIGatewayV2Plugin) getAuthorizersV2(ctx *RequestContext, apiID string)
 		return nil, fmt.Errorf("apigatewayv2 getAuthorizers loadIndex: %w", err)
 	}
 
-	items := make([]V2AuthorizerState, 0, len(ids))
+	items := make([]v2AuthorizerOut, 0, len(ids))
 	for _, id := range ids {
 		data, getErr := p.state.Get(goCtx, apigatewayv2Namespace, apigwv2AuthorizerKey(ctx.AccountID, ctx.Region, apiID, id))
 		if getErr != nil || data == nil {
@@ -731,14 +719,11 @@ func (p *APIGatewayV2Plugin) getAuthorizersV2(ctx *RequestContext, apiID string)
 		}
 		var auth V2AuthorizerState
 		if json.Unmarshal(data, &auth) == nil {
-			items = append(items, auth)
+			items = append(items, v2AuthorizerWire(auth))
 		}
 	}
 
-	type response struct {
-		Items []V2AuthorizerState `json:"Items"`
-	}
-	return apigwJSONResponse(http.StatusOK, response{Items: items})
+	return apigwJSONResponse(http.StatusOK, apigwV2ItemsOut[v2AuthorizerOut]{Items: items})
 }
 
 func (p *APIGatewayV2Plugin) deleteAuthorizerV2(ctx *RequestContext, apiID, authID string) (*AWSResponse, error) {
@@ -780,7 +765,7 @@ func (p *APIGatewayV2Plugin) createDeploymentV2(ctx *RequestContext, req *AWSReq
 	}
 	updateStringIndex(goCtx, p.state, apigatewayv2Namespace, apigwv2DeploymentIDsKey(ctx.AccountID, ctx.Region, apiID), dep.DeploymentID)
 
-	return apigwJSONResponse(http.StatusCreated, dep)
+	return apigwJSONResponse(http.StatusCreated, v2DeploymentWire(dep))
 }
 
 func (p *APIGatewayV2Plugin) getDeploymentV2(ctx *RequestContext, apiID, depID string) (*AWSResponse, error) {
@@ -796,7 +781,7 @@ func (p *APIGatewayV2Plugin) getDeploymentV2(ctx *RequestContext, apiID, depID s
 	if err := json.Unmarshal(data, &dep); err != nil {
 		return nil, fmt.Errorf("apigatewayv2 getDeployment unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, dep)
+	return apigwJSONResponse(http.StatusOK, v2DeploymentWire(dep))
 }
 
 // --- Domain name and API mapping operations ----------------------------------
@@ -825,7 +810,7 @@ func (p *APIGatewayV2Plugin) createDomainNameV2(ctx *RequestContext, req *AWSReq
 		return nil, fmt.Errorf("apigatewayv2 createDomainName state.Put: %w", err)
 	}
 
-	return apigwJSONResponse(http.StatusCreated, dn)
+	return apigwJSONResponse(http.StatusCreated, v2DomainNameWire(dn))
 }
 
 func (p *APIGatewayV2Plugin) getDomainNameV2(ctx *RequestContext, name string) (*AWSResponse, error) {
@@ -841,7 +826,7 @@ func (p *APIGatewayV2Plugin) getDomainNameV2(ctx *RequestContext, name string) (
 	if err := json.Unmarshal(data, &dn); err != nil {
 		return nil, fmt.Errorf("apigatewayv2 getDomainName unmarshal: %w", err)
 	}
-	return apigwJSONResponse(http.StatusOK, dn)
+	return apigwJSONResponse(http.StatusOK, v2DomainNameWire(dn))
 }
 
 func (p *APIGatewayV2Plugin) createAPIMapping(ctx *RequestContext, req *AWSRequest, domainName string) (*AWSResponse, error) {
@@ -855,14 +840,7 @@ func (p *APIGatewayV2Plugin) createAPIMapping(ctx *RequestContext, req *AWSReque
 	}
 
 	mappingID := generateAPIGatewayID()
-	type apiMappingState struct {
-		APIMappingID  string `json:"ApiMappingId"`
-		APIID         string `json:"ApiId"`
-		Stage         string `json:"Stage"`
-		APIMappingKey string `json:"ApiMappingKey,omitempty"`
-		DomainName    string `json:"DomainName"`
-	}
-	mapping := apiMappingState{
+	mapping := v2APIMappingState{
 		APIMappingID:  mappingID,
 		APIID:         body.APIID,
 		Stage:         body.Stage,
@@ -879,5 +857,5 @@ func (p *APIGatewayV2Plugin) createAPIMapping(ctx *RequestContext, req *AWSReque
 		return nil, fmt.Errorf("apigatewayv2 createAPIMapping state.Put: %w", err)
 	}
 
-	return apigwJSONResponse(http.StatusCreated, mapping)
+	return apigwJSONResponse(http.StatusCreated, v2APIMappingWire(mapping))
 }

--- a/emulator/apigatewayv2_plugin_test.go
+++ b/emulator/apigatewayv2_plugin_test.go
@@ -67,27 +67,31 @@ func TestAPIGatewayV2Plugin_CreateApi(t *testing.T) {
 		t.Fatalf("want status 201, got %d", resp.StatusCode)
 	}
 
-	var out emulator.V2ApiState
+	// Decoded into a map with the wire keys, not into V2ApiState: the state
+	// struct's PascalCase tags are what an SDK cannot parse (#529), so an
+	// assertion made through it would pass whatever the wire said.
+	var out map[string]any
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.APIID == "" {
-		t.Error("ApiId is empty")
+	if id, _ := out["apiId"].(string); id == "" {
+		t.Error("apiId is empty")
 	}
-	if out.APIEndpoint == "" {
-		t.Error("ApiEndpoint is empty")
+	endpoint, _ := out["apiEndpoint"].(string)
+	if endpoint == "" {
+		t.Error("apiEndpoint is empty")
 	}
-	if !strings.HasPrefix(out.APIEndpoint, "https://") {
-		t.Errorf("ApiEndpoint should start with https://, got %q", out.APIEndpoint)
+	if !strings.HasPrefix(endpoint, "https://") {
+		t.Errorf("apiEndpoint should start with https://, got %q", endpoint)
 	}
-	if !strings.Contains(out.APIEndpoint, "execute-api") {
-		t.Errorf("ApiEndpoint should contain execute-api, got %q", out.APIEndpoint)
+	if !strings.Contains(endpoint, "execute-api") {
+		t.Errorf("apiEndpoint should contain execute-api, got %q", endpoint)
 	}
-	if out.Name != "my-http-api" {
-		t.Errorf("want name my-http-api, got %q", out.Name)
+	if out["name"] != "my-http-api" {
+		t.Errorf("want name my-http-api, got %v", out["name"])
 	}
-	if out.ProtocolType != "HTTP" {
-		t.Errorf("want ProtocolType HTTP, got %q", out.ProtocolType)
+	if out["protocolType"] != "HTTP" {
+		t.Errorf("want protocolType HTTP, got %v", out["protocolType"])
 	}
 }
 
@@ -102,14 +106,11 @@ func TestAPIGatewayV2Plugin_CreateRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateApi: %v", err)
 	}
-	var api emulator.V2ApiState
-	if err := json.Unmarshal(createResp.Body, &api); err != nil {
-		t.Fatalf("unmarshal api: %v", err)
-	}
+	apiID := apigwv2APIID(t, createResp.Body)
 
 	// Create a route.
 	routeResp, err := p.HandleRequest(ctx, apigwv2Request(t, "POST",
-		"/v2/apis/"+api.APIID+"/routes",
+		"/v2/apis/"+apiID+"/routes",
 		map[string]any{
 			"RouteKey": "GET /users",
 		},
@@ -121,15 +122,15 @@ func TestAPIGatewayV2Plugin_CreateRoute(t *testing.T) {
 		t.Fatalf("want 201, got %d", routeResp.StatusCode)
 	}
 
-	var route emulator.V2RouteState
+	var route map[string]any
 	if err := json.Unmarshal(routeResp.Body, &route); err != nil {
 		t.Fatalf("unmarshal route: %v", err)
 	}
-	if route.RouteID == "" {
-		t.Error("RouteId is empty")
+	if id, _ := route["routeId"].(string); id == "" {
+		t.Error("routeId is empty")
 	}
-	if route.RouteKey != "GET /users" {
-		t.Errorf("want RouteKey 'GET /users', got %q", route.RouteKey)
+	if route["routeKey"] != "GET /users" {
+		t.Errorf("want routeKey 'GET /users', got %v", route["routeKey"])
 	}
 }
 
@@ -144,14 +145,11 @@ func TestAPIGatewayV2Plugin_CreateStage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateApi: %v", err)
 	}
-	var api emulator.V2ApiState
-	if err := json.Unmarshal(createResp.Body, &api); err != nil {
-		t.Fatalf("unmarshal api: %v", err)
-	}
+	apiID := apigwv2APIID(t, createResp.Body)
 
 	// Create a stage.
 	stageResp, err := p.HandleRequest(ctx, apigwv2Request(t, "POST",
-		"/v2/apis/"+api.APIID+"/stages",
+		"/v2/apis/"+apiID+"/stages",
 		map[string]any{
 			"StageName": "$default",
 		},
@@ -163,17 +161,17 @@ func TestAPIGatewayV2Plugin_CreateStage(t *testing.T) {
 		t.Fatalf("want 201, got %d", stageResp.StatusCode)
 	}
 
-	var stage emulator.V2StageState
+	var stage map[string]any
 	if err := json.Unmarshal(stageResp.Body, &stage); err != nil {
 		t.Fatalf("unmarshal stage: %v", err)
 	}
-	if stage.StageName != "$default" {
-		t.Errorf("want StageName $default, got %q", stage.StageName)
+	if stage["stageName"] != "$default" {
+		t.Errorf("want stageName $default, got %v", stage["stageName"])
 	}
 
 	// GetStage should return it.
 	getResp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET",
-		"/v2/apis/"+api.APIID+"/stages/$default",
+		"/v2/apis/"+apiID+"/stages/$default",
 		nil,
 	))
 	if err != nil {
@@ -205,19 +203,45 @@ func TestAPIGatewayV2Plugin_GetApis(t *testing.T) {
 		t.Fatalf("want 200, got %d", listResp.StatusCode)
 	}
 
+	// The envelope is "items", lowercase — "Items" parses to nothing (#529).
 	var out struct {
-		Items []emulator.V2ApiState `json:"Items"`
+		Items []struct {
+			APIID string `json:"apiId"`
+			Name  string `json:"name"`
+		} `json:"items"`
 	}
 	if err := json.Unmarshal(listResp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if len(out.Items) != 2 {
-		t.Errorf("want 2 APIs, got %d", len(out.Items))
+		t.Fatalf("want 2 APIs, got %d", len(out.Items))
+	}
+	for i, it := range out.Items {
+		if it.APIID == "" || it.Name == "" {
+			t.Errorf("item %d: empty apiId or name: %+v", i, it)
+		}
 	}
 }
 
-// createTestV2API creates a V2 API and returns its state.
-func createTestV2API(t *testing.T, p *emulator.APIGatewayV2Plugin, ctx *emulator.RequestContext, name string) emulator.V2ApiState {
+// apigwv2APIID pulls the apiId out of a v2 response body. It reads the wire key
+// rather than decoding into V2ApiState, which is the state type #529 keeps off the
+// wire.
+func apigwv2APIID(t *testing.T, body []byte) string {
+	t.Helper()
+	var m struct {
+		APIID string `json:"apiId"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("unmarshal apiId: %v", err)
+	}
+	if m.APIID == "" {
+		t.Fatalf("no apiId in response: %s", body)
+	}
+	return m.APIID
+}
+
+// createTestV2API creates a V2 API and returns its wire apiId.
+func createTestV2API(t *testing.T, p *emulator.APIGatewayV2Plugin, ctx *emulator.RequestContext, name string) string {
 	t.Helper()
 	resp, err := p.HandleRequest(ctx, apigwv2Request(t, "POST", "/v2/apis", map[string]any{
 		"Name":         name,
@@ -226,38 +250,30 @@ func createTestV2API(t *testing.T, p *emulator.APIGatewayV2Plugin, ctx *emulator
 	if err != nil {
 		t.Fatalf("CreateApi %q: %v", name, err)
 	}
-	var api emulator.V2ApiState
-	if err := json.Unmarshal(resp.Body, &api); err != nil {
-		t.Fatalf("unmarshal V2ApiState: %v", err)
-	}
-	return api
+	return apigwv2APIID(t, resp.Body)
 }
 
 func TestAPIGatewayV2Plugin_GetApi(t *testing.T) {
 	p, ctx := setupAPIGatewayV2Plugin(t)
-	api := createTestV2API(t, p, ctx, "get-me")
+	apiID := createTestV2API(t, p, ctx, "get-me")
 
-	resp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET", "/v2/apis/"+api.APIID, nil))
+	resp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET", "/v2/apis/"+apiID, nil))
 	if err != nil {
 		t.Fatalf("GetApi: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("want 200, got %d", resp.StatusCode)
 	}
-	var out emulator.V2ApiState
-	if err := json.Unmarshal(resp.Body, &out); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if out.APIID != api.APIID {
-		t.Errorf("want APIID %q, got %q", api.APIID, out.APIID)
+	if got := apigwv2APIID(t, resp.Body); got != apiID {
+		t.Errorf("want apiId %q, got %q", apiID, got)
 	}
 }
 
 func TestAPIGatewayV2Plugin_UpdateApi(t *testing.T) {
 	p, ctx := setupAPIGatewayV2Plugin(t)
-	api := createTestV2API(t, p, ctx, "update-me")
+	apiID := createTestV2API(t, p, ctx, "update-me")
 
-	resp, err := p.HandleRequest(ctx, apigwv2Request(t, "PATCH", "/v2/apis/"+api.APIID,
+	resp, err := p.HandleRequest(ctx, apigwv2Request(t, "PATCH", "/v2/apis/"+apiID,
 		map[string]any{"Description": "updated"},
 	))
 	if err != nil {
@@ -270,9 +286,9 @@ func TestAPIGatewayV2Plugin_UpdateApi(t *testing.T) {
 
 func TestAPIGatewayV2Plugin_DeleteApi(t *testing.T) {
 	p, ctx := setupAPIGatewayV2Plugin(t)
-	api := createTestV2API(t, p, ctx, "delete-me")
+	apiID := createTestV2API(t, p, ctx, "delete-me")
 
-	resp, err := p.HandleRequest(ctx, apigwv2Request(t, "DELETE", "/v2/apis/"+api.APIID, nil))
+	resp, err := p.HandleRequest(ctx, apigwv2Request(t, "DELETE", "/v2/apis/"+apiID, nil))
 	if err != nil {
 		t.Fatalf("DeleteApi: %v", err)
 	}
@@ -283,24 +299,29 @@ func TestAPIGatewayV2Plugin_DeleteApi(t *testing.T) {
 
 func TestAPIGatewayV2Plugin_RouteGetDelete(t *testing.T) {
 	p, ctx := setupAPIGatewayV2Plugin(t)
-	api := createTestV2API(t, p, ctx, "route-api")
+	apiID := createTestV2API(t, p, ctx, "route-api")
 
 	// Create route.
 	routeResp, err := p.HandleRequest(ctx, apigwv2Request(t, "POST",
-		"/v2/apis/"+api.APIID+"/routes",
+		"/v2/apis/"+apiID+"/routes",
 		map[string]any{"RouteKey": "POST /items"},
 	))
 	if err != nil {
 		t.Fatalf("CreateRoute: %v", err)
 	}
-	var route emulator.V2RouteState
+	var route struct {
+		RouteID string `json:"routeId"`
+	}
 	if err := json.Unmarshal(routeResp.Body, &route); err != nil {
 		t.Fatalf("unmarshal route: %v", err)
+	}
+	if route.RouteID == "" {
+		t.Fatalf("no routeId in response: %s", routeResp.Body)
 	}
 
 	// GetRoute.
 	getResp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET",
-		"/v2/apis/"+api.APIID+"/routes/"+route.RouteID, nil))
+		"/v2/apis/"+apiID+"/routes/"+route.RouteID, nil))
 	if err != nil {
 		t.Fatalf("GetRoute: %v", err)
 	}
@@ -310,7 +331,7 @@ func TestAPIGatewayV2Plugin_RouteGetDelete(t *testing.T) {
 
 	// GetRoutes.
 	listResp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET",
-		"/v2/apis/"+api.APIID+"/routes", nil))
+		"/v2/apis/"+apiID+"/routes", nil))
 	if err != nil {
 		t.Fatalf("GetRoutes: %v", err)
 	}
@@ -320,7 +341,7 @@ func TestAPIGatewayV2Plugin_RouteGetDelete(t *testing.T) {
 
 	// DeleteRoute.
 	delResp, err := p.HandleRequest(ctx, apigwv2Request(t, "DELETE",
-		"/v2/apis/"+api.APIID+"/routes/"+route.RouteID, nil))
+		"/v2/apis/"+apiID+"/routes/"+route.RouteID, nil))
 	if err != nil {
 		t.Fatalf("DeleteRoute: %v", err)
 	}
@@ -331,11 +352,11 @@ func TestAPIGatewayV2Plugin_RouteGetDelete(t *testing.T) {
 
 func TestAPIGatewayV2Plugin_Integration(t *testing.T) {
 	p, ctx := setupAPIGatewayV2Plugin(t)
-	api := createTestV2API(t, p, ctx, "int-api")
+	apiID := createTestV2API(t, p, ctx, "int-api")
 
 	// CreateIntegration.
 	createResp, err := p.HandleRequest(ctx, apigwv2Request(t, "POST",
-		"/v2/apis/"+api.APIID+"/integrations",
+		"/v2/apis/"+apiID+"/integrations",
 		map[string]any{
 			"IntegrationType":      "AWS_PROXY",
 			"IntegrationUri":       "arn:aws:lambda:us-east-1:123456789012:function:my-fn",
@@ -352,14 +373,14 @@ func TestAPIGatewayV2Plugin_Integration(t *testing.T) {
 	if err := json.Unmarshal(createResp.Body, &intOut); err != nil {
 		t.Fatalf("unmarshal integration: %v", err)
 	}
-	intID, _ := intOut["IntegrationId"].(string)
+	intID, _ := intOut["integrationId"].(string)
 	if intID == "" {
-		t.Fatal("IntegrationId is empty")
+		t.Fatal("integrationId is empty")
 	}
 
 	// GetIntegration.
 	getResp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET",
-		"/v2/apis/"+api.APIID+"/integrations/"+intID, nil))
+		"/v2/apis/"+apiID+"/integrations/"+intID, nil))
 	if err != nil {
 		t.Fatalf("GetIntegration: %v", err)
 	}
@@ -369,7 +390,7 @@ func TestAPIGatewayV2Plugin_Integration(t *testing.T) {
 
 	// GetIntegrations.
 	listResp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET",
-		"/v2/apis/"+api.APIID+"/integrations", nil))
+		"/v2/apis/"+apiID+"/integrations", nil))
 	if err != nil {
 		t.Fatalf("GetIntegrations: %v", err)
 	}
@@ -379,7 +400,7 @@ func TestAPIGatewayV2Plugin_Integration(t *testing.T) {
 
 	// DeleteIntegration.
 	delResp, err := p.HandleRequest(ctx, apigwv2Request(t, "DELETE",
-		"/v2/apis/"+api.APIID+"/integrations/"+intID, nil))
+		"/v2/apis/"+apiID+"/integrations/"+intID, nil))
 	if err != nil {
 		t.Fatalf("DeleteIntegration: %v", err)
 	}
@@ -390,11 +411,11 @@ func TestAPIGatewayV2Plugin_Integration(t *testing.T) {
 
 func TestAPIGatewayV2Plugin_GetStagesAndDeleteStage(t *testing.T) {
 	p, ctx := setupAPIGatewayV2Plugin(t)
-	api := createTestV2API(t, p, ctx, "stages-api")
+	apiID := createTestV2API(t, p, ctx, "stages-api")
 
 	// Create stage.
 	_, err := p.HandleRequest(ctx, apigwv2Request(t, "POST",
-		"/v2/apis/"+api.APIID+"/stages",
+		"/v2/apis/"+apiID+"/stages",
 		map[string]any{"StageName": "dev"},
 	))
 	if err != nil {
@@ -403,7 +424,7 @@ func TestAPIGatewayV2Plugin_GetStagesAndDeleteStage(t *testing.T) {
 
 	// GetStages.
 	listResp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET",
-		"/v2/apis/"+api.APIID+"/stages", nil))
+		"/v2/apis/"+apiID+"/stages", nil))
 	if err != nil {
 		t.Fatalf("GetStages: %v", err)
 	}
@@ -414,14 +435,14 @@ func TestAPIGatewayV2Plugin_GetStagesAndDeleteStage(t *testing.T) {
 	if err := json.Unmarshal(listResp.Body, &listOut); err != nil {
 		t.Fatalf("unmarshal stages: %v", err)
 	}
-	items, _ := listOut["Items"].([]any)
+	items, _ := listOut["items"].([]any)
 	if len(items) != 1 {
 		t.Errorf("want 1 stage, got %d", len(items))
 	}
 
 	// DeleteStage.
 	delResp, err := p.HandleRequest(ctx, apigwv2Request(t, "DELETE",
-		"/v2/apis/"+api.APIID+"/stages/dev", nil))
+		"/v2/apis/"+apiID+"/stages/dev", nil))
 	if err != nil {
 		t.Fatalf("DeleteStage: %v", err)
 	}
@@ -432,11 +453,11 @@ func TestAPIGatewayV2Plugin_GetStagesAndDeleteStage(t *testing.T) {
 
 func TestAPIGatewayV2Plugin_AuthorizerCRUD(t *testing.T) {
 	p, ctx := setupAPIGatewayV2Plugin(t)
-	api := createTestV2API(t, p, ctx, "auth-v2-api")
+	apiID := createTestV2API(t, p, ctx, "auth-v2-api")
 
 	// CreateAuthorizer.
 	createResp, err := p.HandleRequest(ctx, apigwv2Request(t, "POST",
-		"/v2/apis/"+api.APIID+"/authorizers",
+		"/v2/apis/"+apiID+"/authorizers",
 		map[string]any{
 			"Name":           "my-jwt-auth",
 			"AuthorizerType": "JWT",
@@ -457,14 +478,14 @@ func TestAPIGatewayV2Plugin_AuthorizerCRUD(t *testing.T) {
 	if err := json.Unmarshal(createResp.Body, &authOut); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	authID, _ := authOut["AuthorizerId"].(string)
+	authID, _ := authOut["authorizerId"].(string)
 	if authID == "" {
-		t.Fatal("AuthorizerId is empty")
+		t.Fatal("authorizerId is empty")
 	}
 
 	// GetAuthorizer.
 	getResp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET",
-		"/v2/apis/"+api.APIID+"/authorizers/"+authID, nil))
+		"/v2/apis/"+apiID+"/authorizers/"+authID, nil))
 	if err != nil {
 		t.Fatalf("GetAuthorizer: %v", err)
 	}
@@ -474,7 +495,7 @@ func TestAPIGatewayV2Plugin_AuthorizerCRUD(t *testing.T) {
 
 	// GetAuthorizers.
 	listResp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET",
-		"/v2/apis/"+api.APIID+"/authorizers", nil))
+		"/v2/apis/"+apiID+"/authorizers", nil))
 	if err != nil {
 		t.Fatalf("GetAuthorizers: %v", err)
 	}
@@ -484,7 +505,7 @@ func TestAPIGatewayV2Plugin_AuthorizerCRUD(t *testing.T) {
 
 	// DeleteAuthorizer.
 	delResp, err := p.HandleRequest(ctx, apigwv2Request(t, "DELETE",
-		"/v2/apis/"+api.APIID+"/authorizers/"+authID, nil))
+		"/v2/apis/"+apiID+"/authorizers/"+authID, nil))
 	if err != nil {
 		t.Fatalf("DeleteAuthorizer: %v", err)
 	}
@@ -495,11 +516,11 @@ func TestAPIGatewayV2Plugin_AuthorizerCRUD(t *testing.T) {
 
 func TestAPIGatewayV2Plugin_DeploymentCRUD(t *testing.T) {
 	p, ctx := setupAPIGatewayV2Plugin(t)
-	api := createTestV2API(t, p, ctx, "dep-v2-api")
+	apiID := createTestV2API(t, p, ctx, "dep-v2-api")
 
 	// CreateDeployment.
 	createResp, err := p.HandleRequest(ctx, apigwv2Request(t, "POST",
-		"/v2/apis/"+api.APIID+"/deployments",
+		"/v2/apis/"+apiID+"/deployments",
 		map[string]any{"Description": "initial"},
 	))
 	if err != nil {
@@ -512,14 +533,14 @@ func TestAPIGatewayV2Plugin_DeploymentCRUD(t *testing.T) {
 	if err := json.Unmarshal(createResp.Body, &depOut); err != nil {
 		t.Fatalf("unmarshal deployment: %v", err)
 	}
-	depID, _ := depOut["DeploymentId"].(string)
+	depID, _ := depOut["deploymentId"].(string)
 	if depID == "" {
-		t.Fatal("DeploymentId is empty")
+		t.Fatal("deploymentId is empty")
 	}
 
 	// GetDeployment.
 	getResp, err := p.HandleRequest(ctx, apigwv2Request(t, "GET",
-		"/v2/apis/"+api.APIID+"/deployments/"+depID, nil))
+		"/v2/apis/"+apiID+"/deployments/"+depID, nil))
 	if err != nil {
 		t.Fatalf("GetDeployment: %v", err)
 	}
@@ -530,11 +551,11 @@ func TestAPIGatewayV2Plugin_DeploymentCRUD(t *testing.T) {
 
 func TestAPIGatewayV2Plugin_DomainNameAndApiMapping(t *testing.T) {
 	p, ctx := setupAPIGatewayV2Plugin(t)
-	api := createTestV2API(t, p, ctx, "mapping-api")
+	apiID := createTestV2API(t, p, ctx, "mapping-api")
 
 	// Create stage.
 	_, err := p.HandleRequest(ctx, apigwv2Request(t, "POST",
-		"/v2/apis/"+api.APIID+"/stages",
+		"/v2/apis/"+apiID+"/stages",
 		map[string]any{"StageName": "$default"},
 	))
 	if err != nil {
@@ -570,7 +591,7 @@ func TestAPIGatewayV2Plugin_DomainNameAndApiMapping(t *testing.T) {
 	mappingResp, err := p.HandleRequest(ctx, apigwv2Request(t, "POST",
 		"/v2/domainnames/v2.example.com/apimappings",
 		map[string]any{
-			"ApiId":         api.APIID,
+			"ApiId":         apiID,
 			"Stage":         "$default",
 			"ApiMappingKey": "",
 		},
@@ -585,7 +606,7 @@ func TestAPIGatewayV2Plugin_DomainNameAndApiMapping(t *testing.T) {
 	if err := json.Unmarshal(mappingResp.Body, &mappingOut); err != nil {
 		t.Fatalf("unmarshal mapping: %v", err)
 	}
-	if _, ok := mappingOut["ApiMappingId"]; !ok {
-		t.Error("ApiMappingId is missing from response")
+	if _, ok := mappingOut["apiMappingId"]; !ok {
+		t.Error("apiMappingId is missing from response")
 	}
 }

--- a/emulator/apigatewayv2_types.go
+++ b/emulator/apigatewayv2_types.go
@@ -185,6 +185,26 @@ type V2DomainNameState struct {
 	Region string `json:"Region"`
 }
 
+// v2APIMappingState holds the state of an API Gateway v2 API mapping. It was
+// declared inside createAPIMapping until #529 needed a wire projection for it;
+// its tags are unchanged, because they are a persisted format.
+type v2APIMappingState struct {
+	// APIMappingID is the unique identifier for the mapping.
+	APIMappingID string `json:"ApiMappingId"`
+
+	// APIID is the API this mapping points at.
+	APIID string `json:"ApiId"`
+
+	// Stage is the stage this mapping points at.
+	Stage string `json:"Stage"`
+
+	// APIMappingKey is the optional path key the mapping is mounted under.
+	APIMappingKey string `json:"ApiMappingKey,omitempty"`
+
+	// DomainName is the custom domain that owns this mapping.
+	DomainName string `json:"DomainName"`
+}
+
 // --- State key helpers -------------------------------------------------------
 
 func apigwv2APIKey(accountID, region, apiID string) string {

--- a/emulator/apigatewayv2_wire.go
+++ b/emulator/apigatewayv2_wire.go
@@ -1,0 +1,225 @@
+package emulator
+
+import "time"
+
+// The wire is a different thing from the state, and the types below keep them
+// apart — the same separation as apigateway_wire.go (#529) and
+// cloudwatchlogs_types.go (#528), for the same reason.
+//
+// The state types in apigatewayv2_types.go are a persisted format:
+// MemoryStateManager snapshots them and recorded runs replay from those bytes, so
+// their PascalCase tags must not change. API Gateway v2's wire members are
+// lowerCamel, and botocore matches a response key against the model's
+// locationName case-sensitively — so a PascalCase key matches nothing and parses
+// to nothing. `aws apigatewayv2 create-api --query ApiId` printed None, because
+// the state struct was marshaled straight onto the wire.
+//
+// v2 is more regular than v1: every member of every v2 response shape is the
+// plain lowerCamel of its member name. The only irregular spellings in the whole
+// model — ResourceArn -> "resource-arn" — are on the three tag *request* shapes,
+// which substrate does not route. Each tag below is still transcribed from the
+// model rather than lowercased programmatically, because a mechanical transform
+// is exactly what would silently get an exception wrong.
+//
+// Two consequences are deliberate: substrate's own AccountID and Region are
+// simply absent from these types, so the leak cannot come back through a field
+// someone adds later; and `omitempty` follows the model's optionality, because
+// real API Gateway omits an unset member rather than sending null.
+//
+// Do not "fix" a casing bug here by retagging a state type. That conflates the
+// two jobs again, and it silently changes the format of every recorded run.
+
+// v2APIOut is the Api element of the v2 API responses.
+type v2APIOut struct {
+	APIID        string            `json:"apiId"`
+	Name         string            `json:"name"`
+	ProtocolType string            `json:"protocolType"`
+	Description  string            `json:"description,omitempty"`
+	APIEndpoint  string            `json:"apiEndpoint"`
+	Tags         map[string]string `json:"tags,omitempty"`
+	CreatedDate  time.Time         `json:"createdDate"`
+}
+
+// v2RouteOut is the Route element. The Route shape declares no apiId — the API is
+// a path parameter of the request, not a member of the response — so substrate
+// reports none, even though it stores one.
+type v2RouteOut struct {
+	RouteID           string `json:"routeId"`
+	RouteKey          string `json:"routeKey"`
+	Target            string `json:"target,omitempty"`
+	AuthorizationType string `json:"authorizationType,omitempty"`
+	AuthorizerID      string `json:"authorizerId,omitempty"`
+}
+
+// v2IntegrationOut is the Integration element. As with a route, the Integration
+// shape declares no apiId.
+type v2IntegrationOut struct {
+	IntegrationID        string `json:"integrationId"`
+	IntegrationType      string `json:"integrationType,omitempty"`
+	IntegrationURI       string `json:"integrationUri,omitempty"`
+	PayloadFormatVersion string `json:"payloadFormatVersion,omitempty"`
+}
+
+// v2StageOut is the Stage element. The Stage shape declares no apiId.
+type v2StageOut struct {
+	StageName      string            `json:"stageName"`
+	DeploymentID   string            `json:"deploymentId,omitempty"`
+	Description    string            `json:"description,omitempty"`
+	StageVariables map[string]string `json:"stageVariables,omitempty"`
+	Tags           map[string]string `json:"tags,omitempty"`
+	CreatedDate    time.Time         `json:"createdDate"`
+}
+
+// v2AuthorizerOut is the Authorizer element. The model spells the JWT member
+// jwtConfiguration, not jwtConfig — its shape is named JWTConfiguration but the
+// member's locationName is what goes on the wire.
+type v2AuthorizerOut struct {
+	AuthorizerID     string      `json:"authorizerId"`
+	Name             string      `json:"name,omitempty"`
+	AuthorizerType   string      `json:"authorizerType,omitempty"`
+	IdentitySource   []string    `json:"identitySource,omitempty"`
+	JwtConfiguration interface{} `json:"jwtConfiguration,omitempty"`
+}
+
+// v2DeploymentOut is the Deployment element.
+type v2DeploymentOut struct {
+	DeploymentID     string    `json:"deploymentId"`
+	DeploymentStatus string    `json:"deploymentStatus"`
+	Description      string    `json:"description,omitempty"`
+	CreatedDate      time.Time `json:"createdDate"`
+}
+
+// v2DomainNameConfigurationOut is one element of a domain name's
+// domainNameConfigurations list.
+//
+// This is where v2 reports the regional hostname: the DomainName shape has no
+// top-level regionalDomainName member — that spelling is v1's — and instead
+// nests apiGatewayDomainName here. Substrate computes the hostname either way, so
+// projecting it into this list is what makes it observable to an SDK rather than
+// silently dropped as an undeclared key.
+type v2DomainNameConfigurationOut struct {
+	APIGatewayDomainName string `json:"apiGatewayDomainName"`
+	EndpointType         string `json:"endpointType"`
+	DomainNameStatus     string `json:"domainNameStatus"`
+}
+
+// v2DomainNameOut is the DomainName element.
+type v2DomainNameOut struct {
+	DomainName               string                         `json:"domainName"`
+	DomainNameConfigurations []v2DomainNameConfigurationOut `json:"domainNameConfigurations"`
+}
+
+// v2APIMappingOut is the ApiMapping element. The model declares no domainName on
+// a mapping, for the same reason a route declares no apiId.
+type v2APIMappingOut struct {
+	APIMappingID  string `json:"apiMappingId"`
+	APIID         string `json:"apiId"`
+	Stage         string `json:"stage"`
+	APIMappingKey string `json:"apiMappingKey,omitempty"`
+}
+
+// --- Projections -------------------------------------------------------------
+
+// v2APIWire projects a stored API onto the wire.
+func v2APIWire(a V2ApiState) v2APIOut {
+	return v2APIOut{
+		APIID:        a.APIID,
+		Name:         a.Name,
+		ProtocolType: a.ProtocolType,
+		Description:  a.Description,
+		APIEndpoint:  a.APIEndpoint,
+		Tags:         a.Tags,
+		CreatedDate:  a.CreatedDate,
+	}
+}
+
+// v2RouteWire projects a stored route onto the wire.
+func v2RouteWire(r V2RouteState) v2RouteOut {
+	return v2RouteOut{
+		RouteID:           r.RouteID,
+		RouteKey:          r.RouteKey,
+		Target:            r.Target,
+		AuthorizationType: r.AuthorizationType,
+		AuthorizerID:      r.AuthorizerID,
+	}
+}
+
+// v2IntegrationWire projects a stored integration onto the wire.
+func v2IntegrationWire(i V2IntegrationState) v2IntegrationOut {
+	return v2IntegrationOut{
+		IntegrationID:        i.IntegrationID,
+		IntegrationType:      i.IntegrationType,
+		IntegrationURI:       i.IntegrationURI,
+		PayloadFormatVersion: i.PayloadFormatVersion,
+	}
+}
+
+// v2StageWire projects a stored stage onto the wire.
+func v2StageWire(s V2StageState) v2StageOut {
+	return v2StageOut{
+		StageName:      s.StageName,
+		DeploymentID:   s.DeploymentID,
+		Description:    s.Description,
+		StageVariables: s.StageVariables,
+		Tags:           s.Tags,
+		CreatedDate:    s.CreatedDate,
+	}
+}
+
+// v2AuthorizerWire projects a stored authorizer onto the wire.
+func v2AuthorizerWire(a V2AuthorizerState) v2AuthorizerOut {
+	return v2AuthorizerOut{
+		AuthorizerID:     a.AuthorizerID,
+		Name:             a.Name,
+		AuthorizerType:   a.AuthorizerType,
+		IdentitySource:   a.IdentitySource,
+		JwtConfiguration: a.JwtConfiguration,
+	}
+}
+
+// v2DeploymentWire projects a stored deployment onto the wire.
+func v2DeploymentWire(d V2DeploymentState) v2DeploymentOut {
+	return v2DeploymentOut{
+		DeploymentID:     d.DeploymentID,
+		DeploymentStatus: d.DeploymentStatus,
+		Description:      d.Description,
+		CreatedDate:      d.CreatedDate,
+	}
+}
+
+// v2DomainNameWire projects a stored domain name onto the wire, nesting the
+// regional hostname where the model puts it.
+func v2DomainNameWire(d V2DomainNameState) v2DomainNameOut {
+	return v2DomainNameOut{
+		DomainName: d.DomainName,
+		DomainNameConfigurations: []v2DomainNameConfigurationOut{{
+			APIGatewayDomainName: d.RegionalDomainName,
+			EndpointType:         "REGIONAL",
+			DomainNameStatus:     "AVAILABLE",
+		}},
+	}
+}
+
+// v2APIMappingWire projects a stored API mapping onto the wire.
+func v2APIMappingWire(m v2APIMappingState) v2APIMappingOut {
+	return v2APIMappingOut{
+		APIMappingID:  m.APIMappingID,
+		APIID:         m.APIID,
+		Stage:         m.Stage,
+		APIMappingKey: m.APIMappingKey,
+	}
+}
+
+// --- List envelopes ----------------------------------------------------------
+
+// Every v2 collection response nests its elements under "items" — lowercase,
+// which is what the member's locationName spells. Emitting "Items" parses to
+// nothing.
+//
+// nextToken is omitted rather than sent empty, because substrate returns every
+// element in one page and honors no token; emitting one would invite a caller to
+// page on nothing.
+type apigwV2ItemsOut[T any] struct {
+	Items     []T    `json:"items"`
+	NextToken string `json:"nextToken,omitempty"`
+}

--- a/emulator/apigatewayv2_wire_test.go
+++ b/emulator/apigatewayv2_wire_test.go
@@ -1,0 +1,520 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// These tests assert on the literal JSON keys API Gateway v2 puts on the wire,
+// which is the only thing an AWS SDK can parse (#529). A Go round-trip through
+// the plugin's own state struct agrees with itself whatever its tags say —
+// encoding/json matches keys case-insensitively — so every assertion here decodes
+// into map[string]any and names the wire key.
+//
+// requireKeys and requireValues come from msk_wire_test.go. requireValues is what
+// most of these use: a projection that forgets a member still emits its key
+// holding Go's zero value, so presence proves nothing.
+
+// agwv2Wire issues a request and decodes the response body into a map, accepting
+// either 200 or 201.
+func agwv2Wire(t *testing.T, p *emulator.APIGatewayV2Plugin, ctx *emulator.RequestContext,
+	method, path string, body map[string]any) (map[string]any, []byte) {
+	t.Helper()
+	resp, err := p.HandleRequest(ctx, apigwv2Request(t, method, path, body))
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		t.Fatalf("%s %s: want 200 or 201, got %d", method, path, resp.StatusCode)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(resp.Body, &m); err != nil {
+		t.Fatalf("%s %s: unmarshal: %v", method, path, err)
+	}
+	return m, resp.Body
+}
+
+// agwv2API creates an API and returns its wire apiId.
+func agwv2API(t *testing.T, p *emulator.APIGatewayV2Plugin, ctx *emulator.RequestContext, name string) string {
+	t.Helper()
+	m, _ := agwv2Wire(t, p, ctx, "POST", "/v2/apis", map[string]any{
+		"Name": name, "ProtocolType": "HTTP",
+	})
+	id, _ := m["apiId"].(string)
+	if id == "" {
+		t.Fatalf("CreateApi %q: no apiId on the wire; got %v", name, m)
+	}
+	return id
+}
+
+// agwv2Items pulls a collection out of a v2 list response, failing explicitly if
+// the envelope is the PascalCase "Items" that parses to nothing.
+func agwv2Items(t *testing.T, what string, m map[string]any) []any {
+	t.Helper()
+	if _, bad := m["Items"]; bad {
+		t.Fatalf("%s: envelope is %q, which an SDK parses to nothing; want %q", what, "Items", "items")
+	}
+	items, ok := m["items"].([]any)
+	if !ok {
+		t.Fatalf("%s: want a list under %q, got %#v", what, "items", m["items"])
+	}
+	return items
+}
+
+// agwv2NoInternalFields asserts substrate's own state members are nowhere in a
+// response, at the byte level so a nested occurrence cannot hide from a top-level
+// map check.
+func agwv2NoInternalFields(t *testing.T, what string, raw []byte) {
+	t.Helper()
+	for _, leak := range []string{`"AccountID"`, `"Region"`, `"accountId"`, `"region"`} {
+		if bytes.Contains(raw, []byte(leak)) {
+			t.Errorf("%s: response leaks %s: %s", what, leak, raw)
+		}
+	}
+}
+
+func TestAPIGatewayV2Wire_Api(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+
+	created, raw := agwv2Wire(t, p, ctx, "POST", "/v2/apis", map[string]any{
+		"Name": "wire-api", "ProtocolType": "HTTP", "Description": "a description",
+	})
+	requireKeys(t, "CreateApi", created, "apiId", "name", "protocolType", "apiEndpoint", "createdDate")
+	requireValues(t, "CreateApi", created, map[string]any{
+		"name":         "wire-api",
+		"protocolType": "HTTP",
+		"description":  "a description",
+	})
+	agwv2NoInternalFields(t, "CreateApi", raw)
+
+	apiID, _ := created["apiId"].(string)
+	if apiID == "" {
+		t.Fatal("CreateApi: apiId is empty")
+	}
+	endpoint, _ := created["apiEndpoint"].(string)
+	if !strings.HasPrefix(endpoint, "https://") || !strings.Contains(endpoint, "execute-api") {
+		t.Errorf("CreateApi: apiEndpoint = %q, want an https execute-api host", endpoint)
+	}
+
+	got, rawGet := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID, nil)
+	requireValues(t, "GetApi", got, map[string]any{
+		"apiId": apiID, "name": "wire-api", "protocolType": "HTTP",
+	})
+	agwv2NoInternalFields(t, "GetApi", rawGet)
+
+	patched, _ := agwv2Wire(t, p, ctx, "PATCH", "/v2/apis/"+apiID, map[string]any{
+		"Description": "updated",
+	})
+	requireValues(t, "UpdateApi", patched, map[string]any{
+		"apiId": apiID, "description": "updated",
+	})
+}
+
+func TestAPIGatewayV2Wire_Route(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "route-wire")
+
+	created, raw := agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/routes", map[string]any{
+		"RouteKey": "GET /users", "Target": "integrations/abc123",
+		"AuthorizationType": "NONE",
+	})
+	requireValues(t, "CreateRoute", created, map[string]any{
+		"routeKey":          "GET /users",
+		"target":            "integrations/abc123",
+		"authorizationType": "NONE",
+	})
+	agwv2NoInternalFields(t, "CreateRoute", raw)
+
+	// The Route shape declares no apiId — the API is a path parameter, not a
+	// response member. botocore drops the key, so reporting it is at best noise.
+	if _, ok := created["apiId"]; ok {
+		t.Error("CreateRoute: apiId is not a member of the Route shape")
+	}
+
+	routeID, _ := created["routeId"].(string)
+	if routeID == "" {
+		t.Fatalf("CreateRoute: no routeId on the wire; got %v", created)
+	}
+
+	got, _ := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID+"/routes/"+routeID, nil)
+	requireValues(t, "GetRoute", got, map[string]any{
+		"routeId": routeID, "routeKey": "GET /users",
+	})
+}
+
+func TestAPIGatewayV2Wire_Integration(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "int-wire")
+
+	created, raw := agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/integrations", map[string]any{
+		"IntegrationType":      "AWS_PROXY",
+		"IntegrationUri":       "arn:aws:lambda:us-east-1:123456789012:function:my-fn",
+		"PayloadFormatVersion": "2.0",
+	})
+	requireValues(t, "CreateIntegration", created, map[string]any{
+		"integrationType":      "AWS_PROXY",
+		"integrationUri":       "arn:aws:lambda:us-east-1:123456789012:function:my-fn",
+		"payloadFormatVersion": "2.0",
+	})
+	agwv2NoInternalFields(t, "CreateIntegration", raw)
+
+	intID, _ := created["integrationId"].(string)
+	if intID == "" {
+		t.Fatalf("CreateIntegration: no integrationId on the wire; got %v", created)
+	}
+
+	got, _ := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID+"/integrations/"+intID, nil)
+	requireValues(t, "GetIntegration", got, map[string]any{
+		"integrationId": intID, "integrationType": "AWS_PROXY",
+	})
+}
+
+func TestAPIGatewayV2Wire_Stage(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "stage-wire")
+
+	created, raw := agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/stages", map[string]any{
+		"StageName": "dev", "DeploymentId": "dep123", "Description": "development",
+		"StageVariables": map[string]any{"lang": "go"},
+	})
+	requireKeys(t, "CreateStage", created, "stageName", "createdDate", "stageVariables")
+	requireValues(t, "CreateStage", created, map[string]any{
+		"stageName":    "dev",
+		"deploymentId": "dep123",
+		"description":  "development",
+	})
+	agwv2NoInternalFields(t, "CreateStage", raw)
+
+	vars, ok := created["stageVariables"].(map[string]any)
+	if !ok || vars["lang"] != "go" {
+		t.Errorf("CreateStage: stageVariables = %#v, want {lang: go}", created["stageVariables"])
+	}
+
+	got, _ := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID+"/stages/dev", nil)
+	requireValues(t, "GetStage", got, map[string]any{
+		"stageName": "dev", "deploymentId": "dep123",
+	})
+}
+
+func TestAPIGatewayV2Wire_Authorizer(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "auth-wire")
+
+	created, raw := agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/authorizers", map[string]any{
+		"Name": "my-jwt", "AuthorizerType": "JWT",
+		"IdentitySource": []string{"$request.header.Authorization"},
+		"JwtConfiguration": map[string]any{
+			"Audience": []string{"my-client"}, "Issuer": "https://example.com",
+		},
+	})
+	requireValues(t, "CreateAuthorizer", created, map[string]any{
+		"name": "my-jwt", "authorizerType": "JWT",
+	})
+	agwv2NoInternalFields(t, "CreateAuthorizer", raw)
+
+	// The model spells the member jwtConfiguration, whatever its shape is called.
+	if _, ok := created["jwtConfiguration"]; !ok {
+		t.Errorf("CreateAuthorizer: missing jwtConfiguration; got %v", created)
+	}
+	src, ok := created["identitySource"].([]any)
+	if !ok || len(src) != 1 || src[0] != "$request.header.Authorization" {
+		t.Errorf("CreateAuthorizer: identitySource = %#v", created["identitySource"])
+	}
+
+	authID, _ := created["authorizerId"].(string)
+	if authID == "" {
+		t.Fatalf("CreateAuthorizer: no authorizerId on the wire; got %v", created)
+	}
+	got, _ := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID+"/authorizers/"+authID, nil)
+	requireValues(t, "GetAuthorizer", got, map[string]any{
+		"authorizerId": authID, "name": "my-jwt",
+	})
+}
+
+func TestAPIGatewayV2Wire_Deployment(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "dep-wire")
+
+	created, raw := agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/deployments", map[string]any{
+		"Description": "initial",
+	})
+	requireKeys(t, "CreateDeployment", created, "deploymentId", "deploymentStatus", "createdDate")
+	requireValues(t, "CreateDeployment", created, map[string]any{
+		"deploymentStatus": "DEPLOYED", "description": "initial",
+	})
+	agwv2NoInternalFields(t, "CreateDeployment", raw)
+
+	depID, _ := created["deploymentId"].(string)
+	if depID == "" {
+		t.Fatalf("CreateDeployment: no deploymentId on the wire; got %v", created)
+	}
+	got, _ := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID+"/deployments/"+depID, nil)
+	requireValues(t, "GetDeployment", got, map[string]any{
+		"deploymentId": depID, "deploymentStatus": "DEPLOYED",
+	})
+}
+
+// TestAPIGatewayV2Wire_DomainNameAndApiMapping pins where v2 reports the regional
+// hostname. v1 has a top-level regionalDomainName; v2's DomainName shape has no
+// such member and nests apiGatewayDomainName inside domainNameConfigurations, so a
+// top-level spelling would be dropped by botocore and invisible to a caller.
+func TestAPIGatewayV2Wire_DomainNameAndApiMapping(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "mapping-wire")
+
+	dn, rawDN := agwv2Wire(t, p, ctx, "POST", "/v2/domainnames", map[string]any{
+		"DomainName": "v2.example.com",
+	})
+	requireValues(t, "CreateDomainName", dn, map[string]any{"domainName": "v2.example.com"})
+	agwv2NoInternalFields(t, "CreateDomainName", rawDN)
+
+	if _, ok := dn["regionalDomainName"]; ok {
+		t.Error("CreateDomainName: regionalDomainName is v1's member, not a v2 one")
+	}
+	cfgs, ok := dn["domainNameConfigurations"].([]any)
+	if !ok || len(cfgs) != 1 {
+		t.Fatalf("CreateDomainName: domainNameConfigurations = %#v", dn["domainNameConfigurations"])
+	}
+	cfg, ok := cfgs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("CreateDomainName: configuration element = %#v", cfgs[0])
+	}
+	requireValues(t, "CreateDomainName config", cfg, map[string]any{
+		"endpointType":     "REGIONAL",
+		"domainNameStatus": "AVAILABLE",
+	})
+	host, _ := cfg["apiGatewayDomainName"].(string)
+	if !strings.Contains(host, "v2.example.com") {
+		t.Errorf("CreateDomainName: apiGatewayDomainName = %q, want the domain in it", host)
+	}
+
+	got, _ := agwv2Wire(t, p, ctx, "GET", "/v2/domainnames/v2.example.com", nil)
+	requireValues(t, "GetDomainName", got, map[string]any{"domainName": "v2.example.com"})
+
+	mapping, rawMap := agwv2Wire(t, p, ctx, "POST",
+		"/v2/domainnames/v2.example.com/apimappings", map[string]any{
+			"ApiId": apiID, "Stage": "$default", "ApiMappingKey": "v1",
+		})
+	requireValues(t, "CreateApiMapping", mapping, map[string]any{
+		"apiId": apiID, "stage": "$default", "apiMappingKey": "v1",
+	})
+	agwv2NoInternalFields(t, "CreateApiMapping", rawMap)
+	if id, _ := mapping["apiMappingId"].(string); id == "" {
+		t.Errorf("CreateApiMapping: no apiMappingId on the wire; got %v", mapping)
+	}
+	// The ApiMapping shape declares no domainName, for the same reason a route
+	// declares no apiId.
+	if _, ok := mapping["domainName"]; ok {
+		t.Error("CreateApiMapping: domainName is not a member of the ApiMapping shape")
+	}
+}
+
+// The five list operations get one test each. A single test covering all five
+// would pass while four were wrong.
+
+func TestAPIGatewayV2Wire_GetApisEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	agwv2API(t, p, ctx, "alpha")
+	agwv2API(t, p, ctx, "beta")
+
+	m, raw := agwv2Wire(t, p, ctx, "GET", "/v2/apis", nil)
+	items := agwv2Items(t, "GetApis", m)
+	if len(items) != 2 {
+		t.Fatalf("GetApis: want 2 items, got %d", len(items))
+	}
+	agwv2NoInternalFields(t, "GetApis", raw)
+	for i, it := range items {
+		el, ok := it.(map[string]any)
+		if !ok {
+			t.Fatalf("GetApis: item %d = %#v", i, it)
+		}
+		requireKeys(t, "GetApis element", el, "apiId", "name", "protocolType")
+		if el["name"] == "" {
+			t.Errorf("GetApis: item %d has an empty name", i)
+		}
+	}
+}
+
+func TestAPIGatewayV2Wire_GetRoutesEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "routes-env")
+	agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/routes", map[string]any{"RouteKey": "GET /a"})
+
+	m, raw := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID+"/routes", nil)
+	items := agwv2Items(t, "GetRoutes", m)
+	if len(items) != 1 {
+		t.Fatalf("GetRoutes: want 1 item, got %d", len(items))
+	}
+	el, _ := items[0].(map[string]any)
+	requireValues(t, "GetRoutes element", el, map[string]any{"routeKey": "GET /a"})
+	agwv2NoInternalFields(t, "GetRoutes", raw)
+}
+
+func TestAPIGatewayV2Wire_GetIntegrationsEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "ints-env")
+	agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/integrations", map[string]any{
+		"IntegrationType": "MOCK",
+	})
+
+	m, raw := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID+"/integrations", nil)
+	items := agwv2Items(t, "GetIntegrations", m)
+	if len(items) != 1 {
+		t.Fatalf("GetIntegrations: want 1 item, got %d", len(items))
+	}
+	el, _ := items[0].(map[string]any)
+	requireValues(t, "GetIntegrations element", el, map[string]any{"integrationType": "MOCK"})
+	agwv2NoInternalFields(t, "GetIntegrations", raw)
+}
+
+func TestAPIGatewayV2Wire_GetStagesEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "stages-env")
+	agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/stages", map[string]any{"StageName": "dev"})
+
+	m, raw := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID+"/stages", nil)
+	items := agwv2Items(t, "GetStages", m)
+	if len(items) != 1 {
+		t.Fatalf("GetStages: want 1 item, got %d", len(items))
+	}
+	el, _ := items[0].(map[string]any)
+	requireValues(t, "GetStages element", el, map[string]any{"stageName": "dev"})
+	agwv2NoInternalFields(t, "GetStages", raw)
+}
+
+func TestAPIGatewayV2Wire_GetAuthorizersEnvelope(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "auths-env")
+	agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/authorizers", map[string]any{
+		"Name": "a1", "AuthorizerType": "JWT",
+	})
+
+	m, raw := agwv2Wire(t, p, ctx, "GET", "/v2/apis/"+apiID+"/authorizers", nil)
+	items := agwv2Items(t, "GetAuthorizers", m)
+	if len(items) != 1 {
+		t.Fatalf("GetAuthorizers: want 1 item, got %d", len(items))
+	}
+	el, _ := items[0].(map[string]any)
+	requireValues(t, "GetAuthorizers element", el, map[string]any{"name": "a1"})
+	agwv2NoInternalFields(t, "GetAuthorizers", raw)
+}
+
+// TestAPIGatewayV2Wire_EmptyListsAreLists pins that an empty collection is a JSON
+// list rather than null. `--query 'length(items)'` errors on a null, which is how
+// the v1 defect surfaced, and it costs nothing to hold v2 to the same standard.
+// Also asserts no nextToken is invented: substrate returns one page and honors no
+// token.
+func TestAPIGatewayV2Wire_EmptyListsAreLists(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+	apiID := agwv2API(t, p, ctx, "empty-lists")
+
+	for _, tc := range []struct{ name, path string }{
+		{"GetRoutes", "/v2/apis/" + apiID + "/routes"},
+		{"GetIntegrations", "/v2/apis/" + apiID + "/integrations"},
+		{"GetStages", "/v2/apis/" + apiID + "/stages"},
+		{"GetAuthorizers", "/v2/apis/" + apiID + "/authorizers"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, raw := agwv2Wire(t, p, ctx, "GET", tc.path, nil)
+			items := agwv2Items(t, tc.name, m)
+			if len(items) != 0 {
+				t.Errorf("%s: want an empty list, got %d items", tc.name, len(items))
+			}
+			if bytes.Contains(raw, []byte("null")) {
+				t.Errorf("%s: response contains null: %s", tc.name, raw)
+			}
+			if _, ok := m["nextToken"]; ok {
+				t.Errorf("%s: emits a nextToken it does not honor: %s", tc.name, raw)
+			}
+		})
+	}
+}
+
+// TestAPIGatewayV2Wire_UnsetOptionalsAreOmitted pins absent-vs-empty. Real API
+// Gateway omits an unset member; sending "" or null is a different observation,
+// and a caller distinguishing them is making a real one.
+func TestAPIGatewayV2Wire_UnsetOptionalsAreOmitted(t *testing.T) {
+	p, ctx := setupAPIGatewayV2Plugin(t)
+
+	api, _ := agwv2Wire(t, p, ctx, "POST", "/v2/apis", map[string]any{
+		"Name": "minimal", "ProtocolType": "HTTP",
+	})
+	for _, k := range []string{"description", "tags"} {
+		if _, ok := api[k]; ok {
+			t.Errorf("CreateApi: unset %q should be omitted, got %#v", k, api[k])
+		}
+	}
+
+	apiID, _ := api["apiId"].(string)
+	route, _ := agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/routes", map[string]any{
+		"RouteKey": "GET /min",
+	})
+	for _, k := range []string{"target", "authorizationType", "authorizerId"} {
+		if _, ok := route[k]; ok {
+			t.Errorf("CreateRoute: unset %q should be omitted, got %#v", k, route[k])
+		}
+	}
+
+	stage, _ := agwv2Wire(t, p, ctx, "POST", "/v2/apis/"+apiID+"/stages", map[string]any{
+		"StageName": "bare",
+	})
+	for _, k := range []string{"deploymentId", "description", "stageVariables", "tags"} {
+		if _, ok := stage[k]; ok {
+			t.Errorf("CreateStage: unset %q should be omitted, got %#v", k, stage[k])
+		}
+	}
+}
+
+// TestAPIGatewayV2Wire_StateEncodingUnchanged is what makes "state encoding
+// unchanged" a fact rather than a claim. The state types are a persisted format
+// that recorded runs replay from, so the fix belongs entirely in the wire types.
+// This test fails if someone later retags a state struct instead.
+func TestAPIGatewayV2Wire_StateEncodingUnchanged(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	p := &emulator.APIGatewayV2Plugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{
+		State:  state,
+		Logger: emulator.NewDefaultLogger(0, false),
+	}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	ctx := &emulator.RequestContext{AccountID: "123456789012", Region: "us-east-1", RequestID: "r1"}
+
+	apiID := agwv2API(t, p, ctx, "persisted")
+
+	keys, err := state.List(t.Context(), "apigatewayv2", "apiv2:")
+	if err != nil {
+		t.Fatalf("state.List: %v", err)
+	}
+	var stored []byte
+	for _, k := range keys {
+		if strings.HasSuffix(k, apiID) {
+			stored, err = state.Get(t.Context(), "apigatewayv2", k)
+			if err != nil {
+				t.Fatalf("state.Get %s: %v", k, err)
+			}
+		}
+	}
+	if stored == nil {
+		t.Fatalf("no stored API under %v", keys)
+	}
+
+	for _, want := range []string{`"ApiId"`, `"Name"`, `"ProtocolType"`, `"ApiEndpoint"`,
+		`"CreatedDate"`, `"AccountID"`, `"Region"`} {
+		if !bytes.Contains(stored, []byte(want)) {
+			t.Errorf("state no longer carries %s: %s", want, stored)
+		}
+	}
+	// The wire spellings must not appear in state; if they do, a state struct was
+	// retagged and every recorded run's format changed with it.
+	for _, bad := range []string{`"apiId"`, `"name"`, `"protocolType"`} {
+		if bytes.Contains(stored, []byte(bad)) {
+			t.Errorf("state carries the wire spelling %s: %s", bad, stored)
+		}
+	}
+}

--- a/emulator/cfn_deployer_test.go
+++ b/emulator/cfn_deployer_test.go
@@ -1125,6 +1125,30 @@ func TestCFN_APIGatewayV2RouteAndIntegration(t *testing.T) {
 	result, err := d.Deploy(context.Background(), tmpl, "apigwv2-route-stack", nil)
 	require.NoError(t, err)
 	assert.Len(t, result.Resources, 3)
+
+	// A physical ID assertion, not just a resource count. These handlers read the
+	// created id out of the plugin's response body, so a response whose keys an SDK
+	// cannot parse leaves the physical ID as the fallback — the logical ID or the
+	// route key — and a resource count stays green while every Ref in the stack
+	// points at the wrong thing (#529).
+	byType := make(map[string]emulator.DeployedResource, len(result.Resources))
+	for _, r := range result.Resources {
+		assert.Empty(t, r.Error, "resource %s: %s", r.LogicalID, r.Error)
+		byType[r.Type] = r
+	}
+
+	api := byType["AWS::ApiGatewayV2::Api"]
+	assert.NotEqual(t, "v2-route-api", api.PhysicalID,
+		"Api physical ID is the fallback name, so apiId was not read from the response")
+	assert.NotEmpty(t, api.ARN)
+
+	route := byType["AWS::ApiGatewayV2::Route"]
+	assert.NotEqual(t, "GET /items", route.PhysicalID,
+		"Route physical ID is the fallback route key, so routeId was not read from the response")
+
+	integration := byType["AWS::ApiGatewayV2::Integration"]
+	assert.NotEqual(t, "MyIntegration", integration.PhysicalID,
+		"Integration physical ID is the fallback logical ID, so integrationId was not read")
 }
 
 func TestCFN_APIGatewayV2Authorizer(t *testing.T) {
@@ -1149,6 +1173,16 @@ func TestCFN_APIGatewayV2Authorizer(t *testing.T) {
 	result, err := d.Deploy(context.Background(), tmpl, "apigwv2-auth-stack", nil)
 	require.NoError(t, err)
 	assert.Len(t, result.Resources, 2)
+
+	for _, r := range result.Resources {
+		assert.Empty(t, r.Error, "resource %s: %s", r.LogicalID, r.Error)
+		if r.Type == "AWS::ApiGatewayV2::Authorizer" {
+			// As above: the fallback is the authorizer's name, so an unparseable
+			// response is invisible to a count assertion.
+			assert.NotEqual(t, "cfn-v2-auth", r.PhysicalID,
+				"Authorizer physical ID is the fallback name, so authorizerId was not read")
+		}
+	}
 }
 
 func TestCFN_StepFunctionsStateMachine(t *testing.T) {

--- a/emulator/cfn_resources_v19.go
+++ b/emulator/cfn_resources_v19.go
@@ -472,7 +472,7 @@ func (d *StackDeployer) deployAPIGatewayV2Api(
 		dr.Error = routeErr.Error()
 	} else if resp != nil {
 		var result struct {
-			APIID string `json:"ApiId"`
+			APIID string `json:"apiId"`
 		}
 		if jsonErr := json.Unmarshal(resp.Body, &result); jsonErr == nil && result.APIID != "" {
 			dr.PhysicalID = result.APIID
@@ -514,7 +514,7 @@ func (d *StackDeployer) deployAPIGatewayV2Route(
 		dr.Error = routeErr.Error()
 	} else if resp != nil {
 		var result struct {
-			RouteID string `json:"RouteId"`
+			RouteID string `json:"routeId"`
 		}
 		if jsonErr := json.Unmarshal(resp.Body, &result); jsonErr == nil && result.RouteID != "" {
 			dr.PhysicalID = result.RouteID
@@ -554,7 +554,7 @@ func (d *StackDeployer) deployAPIGatewayV2Integration(
 		dr.Error = routeErr.Error()
 	} else if resp != nil {
 		var result struct {
-			IntegrationID string `json:"IntegrationId"`
+			IntegrationID string `json:"integrationId"`
 		}
 		if jsonErr := json.Unmarshal(resp.Body, &result); jsonErr == nil && result.IntegrationID != "" {
 			dr.PhysicalID = result.IntegrationID
@@ -628,7 +628,7 @@ func (d *StackDeployer) deployAPIGatewayV2Authorizer(
 		dr.Error = routeErr.Error()
 	} else if resp != nil {
 		var result struct {
-			AuthorizerID string `json:"AuthorizerId"`
+			AuthorizerID string `json:"authorizerId"`
 		}
 		if jsonErr := json.Unmarshal(resp.Body, &result); jsonErr == nil && result.AuthorizerID != "" {
 			dr.PhysicalID = result.AuthorizerID


### PR DESCRIPTION
Closes #529.

The last of the three plugins. Every `apigatewayv2` response marshaled a PascalCase
state struct straight onto the wire under an `Items` envelope, and botocore matches a
response key against the model's `locationName` **case-sensitively** — so nothing
substrate returned parsed at all. Not a member missing here and there:

```
# before (main @ 4305baf), raw wire body from botocore's own debug log
b'{"ApiId":"llijecdmcl","Name":"pre3","ProtocolType":"HTTP","ApiEndpoint":"…",
   "CreatedDate":"…","AccountID":"123456789012","Region":"us-east-1"}'

$ aws apigatewayv2 create-api --name pre --protocol-type HTTP --query ApiId
None
$ aws apigatewayv2 get-apis --query 'length(Items)'
# fails on a null

# after
b'{"apiId":"eoffpmoiol","name":"post3","protocolType":"HTTP","apiEndpoint":"…",
   "createdDate":"…"}'
```

Note the two `AccountID`/`Region` keys in the before-body: substrate's own bookkeeping
went out on every v2 response.

This was invisible over the wire until PR A (`15867b6`) made v2 reachable by an SDK at
all — `create-api` used to 404 with `unknown operation for POST /v2/apis`, which is why
#529's *"same check applied to API Gateway v2"* criterion was unverifiable when it was
filed.

## Remedy — the same one as #528, v1 (#565) and MSK

- **The seven state types keep their PascalCase tags and are untouched.** They are a
  persisted format: `MemoryStateManager` snapshots them and recorded runs replay from
  those bytes. **State encoding is unchanged**, and `TestAPIGatewayV2Wire_StateEncodingUnchanged`
  asserts the stored bytes still carry `ApiId`/`Name`/`ProtocolType`/`AccountID`/`Region`
  and that no wire spelling appears in state — so that is a fact, not a claim, and it is
  the test that fails if someone later "fixes" a casing bug by retagging a state struct.
- Nine response-only element types in a new `apigatewayv2_wire.go`, each tagged from the
  model, each with a `Wire()` projection.
- **No wire type declares an `AccountID` or `Region` member at all.** The leak is fixed
  structurally rather than by an `omitempty` a future field could sidestep.
- The five list envelopes now emit **`items`** — lowercase, and note this *differs from
  v1's singular `item`*. The two spellings are not a typo in one of them; each was
  transcribed from its own model.

`v2APIMappingState` was declared inline inside `createAPIMapping` and is now a
package-level type, because a wire projection needed to name it. Its tags are unchanged.

## Why v2 was easier than v1, and why it was still done by hand

All 1,545 members of v2's response shapes are the plain lowerCamel of their member
names, against v1's ~230 irregular renames. The only irregular spellings anywhere in
the v2 model — `ResourceArn -> "resource-arn"` — are on the three tag **request** shapes,
which substrate does not route.

Each tag was still transcribed from the model rather than lowercased programmatically. A
mechanical transform is exactly what silently gets an exception wrong, and "there are no
exceptions" is a claim that has to be checked before it can be relied on — which is the
same mistake #529 as filed made about v1's envelope and about MSK.

## Three members are now absent — from the model, not from the old code

- **A route, integration, stage and API mapping report no `apiId`.** The API is a path
  parameter of the request, not a member of any of those four shapes. botocore discarded
  the key regardless, so nothing observable is lost.
- **A domain name reports no `regionalDomainName`.** That spelling is v1's; v2 has no
  top-level equivalent and nests the regional hostname as
  `domainNameConfigurations[].apiGatewayDomainName`. Substrate computes the hostname
  either way — projecting it into that list is what makes it *visible to an SDK* instead
  of being dropped as an undeclared key.
- **No response carries a `nextToken`.** Substrate returns every element in one page and
  honours no token; emitting an empty one would invite a caller to page on nothing.

Unset optionals are omitted rather than sent as `""` or `null`, following each member's
optionality in the model, because "absent" versus "null" is a real observable a caller
can branch on.

## Existing assertions that were wrong today and passed anyway

This is the part of the diff that must not read as weakening tests.

Go's `json.Unmarshal` matches an object key against a struct tag **case-insensitively**.
Measured, not assumed — a field tagged `json:"ApiId"` and one tagged `json:"apiId"` both
decode `{"apiId":"abc123"}` to `abc123`. That single fact is why this defect survived the
entire life of the plugin: the request side worked, every Go round-trip test passed, and
an assertion struct with the wrong tags stayed green.

So two groups of consumers were wrong and silent:

- **The four CloudFormation v2 deploy handlers** (`cfn_resources_v19.go`) decode `ApiId`,
  `RouteId`, `IntegrationId` and `AuthorizerId` out of these response bodies to set a
  resource's `PhysicalID` and `ARN`. Retagged to the wire spellings.
- **~10 assertions** across `apigatewayv2_plugin_test.go` and `apigateway_proxy_test.go`
  read `result["ApiId"]`, `["IntegrationId"]`, `["Items"]` and decoded response bodies
  into `emulator.V2*State` — the state type this change deliberately keeps off the wire.
  Rewritten to read literal wire keys.

And the CloudFormation v2 tests asserted only `assert.Len(t, result.Resources, N)`. A
physical ID silently falling back to a logical ID or a route key would not have failed
one, so a resource count could stay green while every `Ref` in the stack pointed at the
wrong thing. They now assert the ID itself.

## Tests

`apigatewayv2_wire_test.go`, 13 tests, all decoding into `map[string]any` and asserting
**literal wire keys** — per #528's lesson that a struct marshaled and unmarshaled by its
own definition agrees with itself whatever its tags say.

- One per element type, asserting **values** and not merely key presence: a `Wire()` that
  forgets a member still emits its key holding Go's zero value. Reuses `requireKeys`/
  `requireValues` from `msk_wire_test.go`.
- One **per list operation** — five of them, not one shared helper. A single test over all
  five would pass while four were wrong.
- Byte-level `bytes.Contains` negative assertions on `AccountID`, `Region`, `accountId`
  and `region`, so a nested occurrence cannot hide from a top-level map check.
- `_EmptyListsAreLists`: a table over four collections asserting an empty collection is
  `[]` and not `null`, and that no `nextToken` appears.
- `_StateEncodingUnchanged`, described above.
- The domain-name test asserts the hostname is reachable at
  `domainNameConfigurations[0].apiGatewayDomainName` and that no top-level
  `regionalDomainName` survives.

### Mutation testing

**38 mutants, 38 CAUGHT, 0 SURVIVED, 0 BROKEN, 0 ANCHOR-MISS**, against a green baseline,
each anchor count-asserted before applying and each mutant gated through `gofmt -w` +
`go vet` and run with `-race`.

Covered: a tag reverted to PascalCase on each of the nine element types; both envelope
reversions (`Items`, and v1's `item` — the cross-version confusion is a real hazard);
three list operations reverted independently; `AccountID`/`Region` added back to two wire
types; three single-resource returns left unprojected; nine `Wire()` projections each
dropping one member; two `omitempty` drops; the three non-model members added back; an
always-emitted `nextToken`; a state struct retagged instead of the wire type; and the
CloudFormation decode tags.

One mutant is worth recording because it was initially scored SURVIVED and is in fact
**EQUIVALENT**: reverting a CloudFormation decode tag to `json:"ApiId"` leaves the tests
green *because it changes nothing* — Go's case-insensitive decode, proven above. No test
can distinguish the two spellings. It was replaced with a mutant that does not case-fold
onto the wire key (`json:"restApiId"`), which is CAUGHT, and that is what proves the new
physical-ID assertions have teeth. The comment in the harness records the measurement so
the next reader does not mistake it for a coverage gap.

## Verified end to end through botocore's real parser

Against a live `substrate server`, and against `main @ 4305baf` on a second port for the
before-comparison quoted at the top. **28 checks that returned `None` or an empty parse
now return values; 0 leaked fields.** Every v2 resource type is covered — API, route,
integration, stage, authorizer (including `jwtConfiguration` and `identitySource`),
deployment, domain name (both nested configuration members) and API mapping.

The AWS CLI presents these responses with PascalCase *output* keys (`--query ApiId`,
`Items`) because botocore maps `locationName` back to the member name. That is expected:
the wire is `apiId`, the CLI's own view of it is `ApiId`, and the whole defect was that
the mapping between them never happened.

## One thing deliberately left out

`aws apigatewayv2 get-api-mappings` fails with `unknown operation for GET
/v2/domainnames/{name}/apimappings` — only `POST` on that path is routed. That is a
**missing operation**, not a wrong response shape, so it is filed as #566 rather than
folded into a wire-format change. The shape work it needs is already done here
(`v2APIMappingOut`, `v2APIMappingWire` and the `apigwV2ItemsOut[T]` envelope all exist and
are tested), so it becomes a routing and state-indexing change. `create-api-mapping`
itself parses correctly today.

## Verification

`gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0
issues**, `make test` (race) green, `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`,
`go test -C test/e2e ./...`.

`docs/services.md` gains a **Response shape** paragraph for the v2 section: every member
lowerCamel, collections under `items`, no `nextToken`, and the three absent members with
the reason for each. The operation table is unchanged — no plugin is added or removed.

## Compatibility

Any consumer asserting a PascalCase member, an `AccountID`/`Region` field, or an `Items`
envelope on an API Gateway v2 response will go red. That is the fix — no AWS SDK could
parse the old shape — but a consumer who pinned to the broken shape needs to be told
plainly. **State encoding is unchanged, so recorded runs replay.**
