### PR TITLE
chore(release): v0.91.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.91.0] - 2026-08-04
+
 ### Fixed
 - **API Gateway v2 responses are the shape an SDK parses** (#529). Every
   `apigatewayv2` response used PascalCase members under an `Items` envelope, so
@@ -5140,7 +5142,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.90.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.91.0...HEAD
+[v0.91.0]: https://github.com/scttfrdmn/substrate/compare/v0.90.0...v0.91.0
 [v0.90.0]: https://github.com/scttfrdmn/substrate/compare/v0.89.0...v0.90.0
 [v0.89.0]: https://github.com/scttfrdmn/substrate/compare/v0.88.0...v0.89.0
 [v0.88.0]: https://github.com/scttfrdmn/substrate/compare/v0.87.1...v0.88.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.91.0] - 2026-08-04` and adds the
compare link. No code changes.

v0.91.0 is one theme: **a response substrate answered 200 to, that no AWS SDK could
parse.** Three plugins marshaled their PascalCase state structs straight onto a
lowercase JSON wire, and botocore matches a response key against the model's
`locationName` case-sensitively — so the caller got an empty parse with no error.
Two more plugins were registered, tested, and unreachable by any client at all.

- #561 / #529 — API Gateway v2 and SSO Admin are reachable from an SDK
- #529 — MSK, API Gateway v1, and API Gateway v2 response shapes

Both milestone issues are closed. #411 moved to v0.92.0 with its blocking design
question answered rather than restated; #566 (`GetApiMappings` unrouted) was filed
during verification and is a missing operation rather than a wrong shape.

Version derived from `git tag --sort=-v:refname | head -1` → `v0.90.0`.