### PR TITLE
fix(iam): resolve a signed request to the principal it actually is (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A signed request now resolves to the principal it actually is** (#411). The
+  server derived a caller's principal ARN from its *access key ID*, yielding
+  `arn:aws:iam::123456789012:user/AKIATEST12345678901` — a name nothing is ever
+  stored under. So a user `alice` holding an inline `sqs:*` Allow was allowed when
+  evaluated as `user/alice` and denied when evaluated as `user/AKIATEST…`:
+  authorization could not find any real principal's policies even where it ran, and
+  #411's own acceptance ("create a role with a scoped policy, make a call as that
+  role") was unreachable in principle rather than merely unwired.
+
+  A caller is now resolved from **state**: `iam:accesskey:<id>` names the user whose
+  policies apply, which is the record `CreateAccessKey` has always written, and
+  `sts:session:<id>` names the assumed-role ARN `AssumeRole` mints — a key substrate
+  wrote from the beginning and nothing had ever read, which is why STS session
+  credentials authorized as nothing in particular.
+
+  Resolution is deliberately independent of `ServerOptions.Credentials`. That
+  registry also gates SigV4 verification, and an access key absent from it is
+  rejected with `InvalidClientTokenId`; identifying callers through it would
+  therefore have 403'd every credential substrate documents, `AKIAIOSFODNN7EXAMPLE`
+  included. Reading state instead costs one `Get` on a request that carries an
+  `Authorization` header, and refuses nothing.
+
+  A key that belongs to no IAM entity — an unregistered key, the built-in test key,
+  a deleted key — resolves to **no principal** and is therefore still enforced
+  against nothing. Existence in state is the opt-in, so no configuration flag turns
+  this on and every caller that never touched IAM is unaffected, including
+  `AKIAIOSFODNN7EXAMPLE` and `test`/`test`. `Credentials`-wired servers keep
+  reporting the access-key ARN for a key with no IAM entity behind it, which is what
+  `GetCallerIdentity` has always shown.
+
+  An STS session also now carries the account it was issued for. Account resolution
+  recognises only an `AKIA` prefix as substrate's test account, so an `ASIA` session
+  key was filed under `000000000000` — a different partition from the resources the
+  caller who assumed the role had just created.
+
+- **`sts:GetCallerIdentity` and `sts:GetSessionToken` no longer require
+  permissions** (#411). AWS documents both as needing none — `GetCallerIdentity`
+  answers "even if an administrator attaches a policy to your identity that
+  explicitly denies access", because a denial would return the same information, and
+  `GetSessionToken`'s purpose is to authenticate a user via MFA, which "you cannot
+  use policies to control". Substrate evaluated both like any other action.
+
+  This was unreachable until the fix above: with every caller resolving to no
+  principal, the evaluator never ran. The first credential that named a real IAM user
+  had `aws sts get-caller-identity` answer `AccessDeniedException`. A sweep of every
+  botocore service model finds the phrase on these two operations and nothing else,
+  so the exemption is that pair rather than a general carve-out.
+
+### Changed
+- **A call made as an IAM user that exists is now authorized against that user's
+  policies** (#411). This follows from principal resolution above and is the point of
+  the release: a key minted by `CreateAccessKey` for a user with no policy, or with a
+  policy that does not allow the call, now returns `AccessDeniedException` where it
+  previously succeeded — which is real IAM behaviour, and the failure class
+  ("forgot a permission / policy too narrow") that composition tests could not catch.
+
+  Nothing else changes. A nil principal still passes, so every in-process `Client`
+  call, every unregistered access key, and every test that does not create an IAM
+  principal behaves exactly as before. An `assumed-role` principal is not yet
+  enforced either; that fail-open is tracked in #411's remaining work.
+
 ## [v0.91.0] - 2026-08-04
 
 ### Fixed

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -32,6 +32,9 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	}
 
 	action := serviceToAction(req.Service, req.Operation)
+	if authzNoPermissionsRequired[action] {
+		return nil
+	}
 	resource := buildResourceARN(reqCtx, req)
 
 	docs, err := a.loadPoliciesForPrincipal(reqCtx)
@@ -220,6 +223,29 @@ func (a *AuthController) loadPermissionBoundary(reqCtx *RequestContext) (*Policy
 		return nil, fmt.Errorf("unmarshal boundary policy: %w", err)
 	}
 	return &pol.Document, nil
+}
+
+// authzNoPermissionsRequired holds the actions AWS documents as requiring no
+// permissions at all, so a policy — including an explicit Deny — cannot block
+// them.
+//
+// These two are the whole set: a sweep of every botocore service model finds the
+// phrase "no permissions are required" on nothing else. Both are STS operations
+// whose purpose is to answer a question about the caller itself.
+// GetCallerIdentity is the stronger case — "if an administrator attaches a policy
+// to your identity that explicitly denies access to the sts:GetCallerIdentity
+// action, you can still perform this operation", because the same information is
+// returned when access is denied — and GetSessionToken's purpose is to
+// authenticate a user via MFA, which a policy cannot gate ("you cannot use
+// policies to control authentication operations").
+//
+// This matters here because it is only reachable now. Before principal
+// resolution (#411) a caller identified as nobody and the evaluator never ran, so
+// substrate denied neither; the first credential that resolved to a real IAM user
+// was denied `aws sts get-caller-identity`, which on AWS always answers.
+var authzNoPermissionsRequired = map[string]bool{
+	"sts:GetCallerIdentity": true,
+	"sts:GetSessionToken":   true,
 }
 
 // serviceToAction maps (service, operation) to an IAM action string,

--- a/emulator/credentials.go
+++ b/emulator/credentials.go
@@ -1,9 +1,11 @@
 package emulator
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -85,8 +87,77 @@ func extractAccessKeyFromAuth(authHeader string) string {
 
 // buildCallerARN derives a principal ARN from an account ID and access key ID.
 // AKIA-prefixed keys are treated as long-term IAM user credentials.
+//
+// This names the *access key*, not the IAM user holding it, so the ARN it
+// produces resolves to no policies: nothing is stored under
+// user_policies:AKIA…. That makes it the right answer only for a credential the
+// registry knows and IAM does not — a caller who has an account but no IAM
+// identity, who is therefore not authorized against anything. Use
+// [resolvePrincipal] for a credential that may have an IAM entity behind it;
+// see #411 for the enforcement that could not work while this was the only
+// answer.
 func buildCallerARN(accountID, accessKeyID string) string {
 	return fmt.Sprintf("arn:aws:iam::%s:user/%s", accountID, accessKeyID)
+}
+
+// resolvePrincipal returns the principal an access key identifies, or nil when
+// the key belongs to no IAM entity or STS session.
+//
+// Resolution is from *state*, not from a [CredentialRegistry], and that
+// separation is the point. A registry entry answers "which account, and is this
+// signature valid"; only IAM's own records answer "which principal", because the
+// access key ID and the user's name are different strings. Deriving the ARN from
+// the key (see [buildCallerARN]) yielded arn:aws:iam::123456789012:user/AKIA…,
+// which matches no user_policies key, so a user with a perfectly good inline
+// policy evaluated as though it had none.
+//
+// Keeping this independent of ServerOptions.Credentials is deliberate: the
+// registry also gates SigV4 verification, and an access key it does not hold is
+// rejected with InvalidClientTokenId. Wiring a registry in order to identify
+// callers would therefore 403 every credential substrate documents
+// (AKIAIOSFODNN7EXAMPLE, test/test). Reading state instead costs one Get on a
+// request that carries an Authorization header and refuses nothing.
+//
+// A nil principal means "no IAM identity", which [AuthController.CheckAccess]
+// treats as unenforced rather than denied — enforcement is opt-in by creating
+// the principal, so a caller who never touched IAM is unaffected.
+//
+// The second return is an account ID to adopt, or "" to keep the one already
+// resolved. Only an STS session supplies one: extractAccount recognizes AKIA as
+// substrate's test account and maps everything else — ASIA session keys
+// included — to the fallback account, so a caller using AssumeRole credentials
+// was placed in a different partition from the resources it went on to create.
+// The session record names the account it was issued for, which is the one the
+// role's caller was in.
+func resolvePrincipal(ctx context.Context, state StateManager, accountID, accessKeyID string) (*Principal, string) {
+	if state == nil || accessKeyID == "" {
+		return nil, ""
+	}
+
+	// A long-term key: IAMPlugin.CreateAccessKey stores the owning user's name
+	// beside it, which is the link from a signed request to a set of policies.
+	if raw, err := state.Get(ctx, iamNamespace, "accesskey:"+accessKeyID); err == nil && raw != nil {
+		var key IAMAccessKey
+		if unmarshalErr := json.Unmarshal(raw, &key); unmarshalErr == nil && key.UserName != "" {
+			return &Principal{
+				ARN:  fmt.Sprintf("arn:aws:iam::%s:user/%s", accountID, key.UserName),
+				Type: "IAMUser",
+			}, ""
+		}
+	}
+
+	// A temporary key: STSPlugin.assumeRole records the session under its own
+	// access key ID, already carrying the assumed-role ARN it minted. Substrate
+	// wrote that record from the beginning and nothing read it until #411, which
+	// is why STS credentials authorized as nothing in particular.
+	if raw, err := state.Get(ctx, stsNamespace, "session:"+accessKeyID); err == nil && raw != nil {
+		var sess STSSessionCredentials
+		if unmarshalErr := json.Unmarshal(raw, &sess); unmarshalErr == nil && sess.PrincipalARN != "" {
+			return &Principal{ARN: sess.PrincipalARN, Type: "AssumedRole"}, sess.AccountID
+		}
+	}
+
+	return nil, ""
 }
 
 // VerifySigV4 validates the SigV4 signature on r using secret keys from reg.

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -57,6 +57,17 @@ func BuildCallerARNForTest(accountID, accessKeyID string) string {
 	return buildCallerARN(accountID, accessKeyID)
 }
 
+// ResolvePrincipalForTest wraps resolvePrincipal for external tests.
+//
+// The HTTP path can only reach the records IAM and STS themselves write, so the
+// arms that matter most are unreachable from it: a nil state manager, a stored
+// record that fails to unmarshal, and a session record carrying no PrincipalArn.
+// Each must resolve to no principal rather than to a partly-built one — an ARN
+// assembled from a corrupt record would name some *other* entity's policies.
+func ResolvePrincipalForTest(state StateManager, accountID, accessKeyID string) (*Principal, string) {
+	return resolvePrincipal(context.Background(), state, accountID, accessKeyID)
+}
+
 // VerifySigV4ForTest wraps VerifySigV4 for external tests.
 func VerifySigV4ForTest(r *http.Request, body []byte, reg *CredentialRegistry) error {
 	return VerifySigV4(r, body, reg)

--- a/emulator/principal_resolution_test.go
+++ b/emulator/principal_resolution_test.go
@@ -1,0 +1,369 @@
+package emulator_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// A signed request has always carried an access key; until #411 the server only
+// looked one up when a CredentialRegistry was wired, and then named the *key*
+// rather than the IAM user holding it. The tests below assert on the resolved
+// principal ARN, because that string is what the policy loader looks up — a test
+// that only checked for a non-nil principal passed before the fix.
+
+// principalCapturePlugin records the RequestContext it was dispatched with, so a
+// test can assert on what the server resolved rather than on a side effect of it.
+type principalCapturePlugin struct {
+	principal *emulator.Principal
+	accountID string
+	called    bool
+}
+
+func (p *principalCapturePlugin) Name() string { return "dynamodb" }
+
+func (p *principalCapturePlugin) Initialize(_ context.Context, _ emulator.PluginConfig) error {
+	return nil
+}
+
+func (p *principalCapturePlugin) HandleRequest(ctx *emulator.RequestContext, _ *emulator.AWSRequest) (*emulator.AWSResponse, error) {
+	p.called = true
+	p.accountID = ctx.AccountID
+	if ctx.Principal != nil {
+		copied := *ctx.Principal
+		p.principal = &copied
+	}
+	return &emulator.AWSResponse{
+		StatusCode: http.StatusOK,
+		Headers:    map[string]string{"Content-Type": "application/x-amz-json-1.0"},
+		Body:       []byte(`{}`),
+	}, nil
+}
+
+func (p *principalCapturePlugin) Shutdown(_ context.Context) error { return nil }
+
+// newPrincipalTestServer returns a server with IAM, STS and a capture plugin
+// registered, and no CredentialRegistry — which is how the CLI server runs.
+func newPrincipalTestServer(t *testing.T) (*emulator.Server, *principalCapturePlugin) {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC))
+
+	iamPlugin := &emulator.IAMPlugin{}
+	require.NoError(t, iamPlugin.Initialize(context.TODO(), emulator.PluginConfig{State: state, Logger: logger}))
+	registry.Register(iamPlugin)
+
+	stsPlugin := &emulator.STSPlugin{}
+	require.NoError(t, stsPlugin.Initialize(context.TODO(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(stsPlugin)
+
+	capture := &principalCapturePlugin{}
+	registry.Register(capture)
+
+	return emulator.NewServer(*cfg, registry, store, state, tc, logger), capture
+}
+
+// principalIAMCall issues an IAM request as an unidentified caller. The AKIA
+// header is what puts the setup calls in the test account; it resolves to no IAM
+// entity, so the calls themselves stay unauthorized.
+func principalIAMCall(t *testing.T, srv *emulator.Server, operation string, body any) *http.Response {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	r.Host = "iam.amazonaws.com"
+	r.Header.Set("X-Amz-Target", "AmazonIdentityManagementService."+operation)
+	r.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	r.Header.Set("Authorization", principalAuthHeader("AKIAIOSFODNN7EXAMPLE", "iam"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Result()
+}
+
+// principalAuthHeader builds a SigV4 Authorization header. The signature is not
+// verified: without a CredentialRegistry the server skips VerifySigV4, which is
+// the configuration under test.
+func principalAuthHeader(accessKeyID, service string) string {
+	return "AWS4-HMAC-SHA256 Credential=" + accessKeyID +
+		"/20250101/us-east-1/" + service +
+		"/aws4_request, SignedHeaders=host, Signature=unverified"
+}
+
+// principalDynamoCall issues a request to the capture plugin signed with the
+// given access key.
+func principalDynamoCall(t *testing.T, srv *emulator.Server, accessKeyID string) *http.Response {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{}`)))
+	r.Header.Set("X-Amz-Target", "DynamoDB_20120810.GetItem")
+	if accessKeyID != "" {
+		r.Header.Set("Authorization", principalAuthHeader(accessKeyID, "dynamodb"))
+	}
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Result()
+}
+
+// principalCreateAccessKey creates an IAM user and one access key for it,
+// returning the key ID.
+func principalCreateAccessKey(t *testing.T, srv *emulator.Server, userName string) string {
+	t.Helper()
+	require.Equal(t, http.StatusOK,
+		principalIAMCall(t, srv, "CreateUser", map[string]any{"UserName": userName}).StatusCode)
+
+	resp := principalIAMCall(t, srv, "CreateAccessKey", map[string]any{"UserName": userName})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	var parsed struct {
+		AccessKey struct {
+			AccessKeyID string `xml:"AccessKeyId"`
+		} `xml:"CreateAccessKeyResult>AccessKey"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed))
+	require.NotEmpty(t, parsed.AccessKey.AccessKeyID)
+	return parsed.AccessKey.AccessKeyID
+}
+
+func TestServer_ResolvePrincipal_IAMAccessKeyNamesTheUser(t *testing.T) {
+	srv, capture := newPrincipalTestServer(t)
+	keyID := principalCreateAccessKey(t, srv, "alice")
+
+	resp := principalDynamoCall(t, srv, keyID)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.True(t, capture.called)
+	require.NotNil(t, capture.principal)
+	// The user's name, not the access key ID: the policy loader looks up
+	// user_policies:alice, and nothing is ever stored under the key.
+	assert.Equal(t, "arn:aws:iam::123456789012:user/alice", capture.principal.ARN)
+	assert.Equal(t, "IAMUser", capture.principal.Type)
+}
+
+func TestServer_ResolvePrincipal_STSSessionNamesTheAssumedRole(t *testing.T) {
+	srv, capture := newPrincipalTestServer(t)
+
+	require.Equal(t, http.StatusOK,
+		principalIAMCall(t, srv, "CreateRole", map[string]any{"RoleName": "worker"}).StatusCode)
+
+	// AssumeRole as a caller in the test account, so the session records that
+	// account rather than the fallback.
+	r := httptest.NewRequest(http.MethodPost,
+		"/?Action=AssumeRole&RoleArn=arn:aws:iam::123456789012:role/worker&RoleSessionName=sess1", nil)
+	r.Host = "sts.amazonaws.com"
+	r.Header.Set("Authorization", principalAuthHeader("AKIAIOSFODNN7EXAMPLE", "sts"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var assumed struct {
+		Credentials struct {
+			AccessKeyID string `xml:"AccessKeyId"`
+		} `xml:"AssumeRoleResult>Credentials"`
+	}
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &assumed))
+	sessionKey := assumed.Credentials.AccessKeyID
+	require.NotEmpty(t, sessionKey)
+
+	resp := principalDynamoCall(t, srv, sessionKey)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NotNil(t, capture.principal)
+	assert.Equal(t, "arn:aws:sts::123456789012:assumed-role/worker/sess1", capture.principal.ARN)
+	assert.Equal(t, "AssumedRole", capture.principal.Type)
+	// The session's own account, not the one an ASIA prefix would have implied:
+	// extractAccount recognizes only AKIA, so this call would otherwise have run
+	// in account 000000000000 — a different partition from the resources the
+	// caller who assumed the role had just created.
+	assert.Equal(t, "123456789012", capture.accountID)
+}
+
+func TestServer_ResolvePrincipal_UnknownKeyStaysUnidentified(t *testing.T) {
+	tests := []struct {
+		name      string
+		accessKey string
+	}{
+		// The credential the README, the testing guide and every e2e check use.
+		// It belongs to no IAM entity, so it identifies nobody and — by the
+		// existence-is-the-opt-in rule — is enforced against nothing. This is the
+		// case that wiring a CredentialRegistry into the server would have turned
+		// into an InvalidClientTokenId 403.
+		{name: "documented example key", accessKey: "AKIAIOSFODNN7EXAMPLE"},
+		{name: "built-in test key", accessKey: "AKIATEST12345678901"},
+		{name: "never-minted key", accessKey: "AKIANEVERMINTED00001"},
+		{name: "no authorization header", accessKey: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, capture := newPrincipalTestServer(t)
+
+			resp := principalDynamoCall(t, srv, tt.accessKey)
+			require.NoError(t, resp.Body.Close())
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.True(t, capture.called)
+			assert.Nil(t, capture.principal)
+		})
+	}
+}
+
+func TestCheckAccess_NoPermissionsRequiredActions(t *testing.T) {
+	// AWS documents both of these as requiring no permissions — GetCallerIdentity
+	// answers even against an explicit Deny, because a denial would return the
+	// same information. Only reachable once a caller resolves to a real principal
+	// at all, which is what made a policy-less IAM user's `aws sts
+	// get-caller-identity` start returning AccessDeniedException.
+	tests := []struct {
+		name      string
+		operation string
+		allowed   bool
+	}{
+		{name: "GetCallerIdentity", operation: "GetCallerIdentity", allowed: true},
+		{name: "GetSessionToken", operation: "GetSessionToken", allowed: true},
+		// Not on the list: an ordinary STS call is evaluated, and a principal that
+		// exists with no policies is an implicit deny.
+		{name: "AssumeRole", operation: "AssumeRole", allowed: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := emulator.NewMemoryStateManager()
+			auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
+
+			reqCtx := &emulator.RequestContext{
+				RequestID: "req-1",
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+				Principal: &emulator.Principal{
+					ARN:  "arn:aws:iam::123456789012:user/alice",
+					Type: "IAMUser",
+				},
+			}
+			req := &emulator.AWSRequest{
+				Service:   "sts",
+				Operation: tt.operation,
+				Params:    map[string]string{},
+			}
+
+			err := auth.CheckAccess(reqCtx, req)
+			if tt.allowed {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var awsErr *emulator.AWSError
+			require.ErrorAs(t, err, &awsErr)
+			assert.Equal(t, "AccessDeniedException", awsErr.Code)
+		})
+	}
+}
+
+func TestResolvePrincipal_UnreachableOverHTTP(t *testing.T) {
+	// Arms an HTTP request cannot produce: resolution has to yield no principal
+	// rather than one built from half a record.
+	tests := []struct {
+		name      string
+		namespace string
+		key       string
+		raw       string
+		nilState  bool
+		accessKey string
+	}{
+		{
+			name:      "no state manager",
+			nilState:  true,
+			accessKey: "AKIAANYTHING00000001",
+		},
+		{
+			name:      "empty access key",
+			accessKey: "",
+		},
+		{
+			name:      "access key record is not JSON",
+			namespace: "iam",
+			key:       "accesskey:AKIACORRUPT000000001",
+			raw:       "{not json",
+			accessKey: "AKIACORRUPT000000001",
+		},
+		{
+			// A record written before CreateAccessKey stored the owner. Deriving a
+			// user ARN from it would name the account's root path with an empty
+			// name, which matches no policy key.
+			name:      "access key record names no user",
+			namespace: "iam",
+			key:       "accesskey:AKIAORPHAN0000000001",
+			raw:       `{"AccessKeyId":"AKIAORPHAN0000000001","Status":"Active"}`,
+			accessKey: "AKIAORPHAN0000000001",
+		},
+		{
+			name:      "session record is not JSON",
+			namespace: "sts",
+			key:       "session:ASIACORRUPT000000001",
+			raw:       "{not json",
+			accessKey: "ASIACORRUPT000000001",
+		},
+		{
+			// GetSessionToken writes a session with no PrincipalArn when the caller
+			// had no principal — an unidentified caller's session identifies nobody
+			// in turn, rather than inheriting the account's root.
+			name:      "session record names no principal",
+			namespace: "sts",
+			key:       "session:ASIANOPRINCIPAL00001",
+			raw:       `{"AccessKeyId":"ASIANOPRINCIPAL00001","AccountId":"123456789012"}`,
+			accessKey: "ASIANOPRINCIPAL00001",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var state emulator.StateManager
+			if !tt.nilState {
+				mem := emulator.NewMemoryStateManager()
+				if tt.key != "" {
+					require.NoError(t, mem.Put(context.Background(), tt.namespace, tt.key, []byte(tt.raw)))
+				}
+				state = mem
+			}
+
+			principal, sessionAccount := emulator.ResolvePrincipalForTest(state, "123456789012", tt.accessKey)
+			assert.Nil(t, principal)
+			assert.Empty(t, sessionAccount)
+		})
+	}
+}
+
+func TestServer_ResolvePrincipal_DeletedAccessKeyStopsResolving(t *testing.T) {
+	srv, capture := newPrincipalTestServer(t)
+	keyID := principalCreateAccessKey(t, srv, "alice")
+
+	require.Equal(t, http.StatusOK, principalIAMCall(t, srv, "DeleteAccessKey", map[string]any{
+		"UserName":    "alice",
+		"AccessKeyId": keyID,
+	}).StatusCode)
+
+	resp := principalDynamoCall(t, srv, keyID)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Nil(t, capture.principal)
+}

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -457,7 +457,8 @@ func (s *Server) handleReady(w http.ResponseWriter, _ *http.Request) {
 // handleAWSRequest is the single catch-all handler for all AWS API requests.
 // Pipeline:
 //  1. Parse → AWSRequest + RequestContext
-//     1.5. Credential resolution (when Credentials != nil)
+//     1.5. Credential resolution — account from Credentials (when non-nil),
+//     principal from state (always; see [resolvePrincipal])
 //     1.6. SigV4 signature verification (when Credentials != nil)
 //  2. auth.CheckAccess()        → 403 AccessDeniedException
 //  3. quota.CheckQuota()        → 429 ThrottlingException
@@ -531,14 +532,40 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Step 1.5: credential resolution — enrich RequestContext with account and
-	// principal derived from the registry.
-	if s.opts.Credentials != nil {
-		accessKey := extractAccessKeyFromAuth(r.Header.Get("Authorization"))
-		if entry, ok := s.opts.Credentials.Lookup(accessKey); ok {
-			reqCtx.AccountID = entry.AccountID
+	// Step 1.5: credential resolution — enrich RequestContext with the caller's
+	// account and principal.
+	//
+	// The two are resolved from different places on purpose. The account comes
+	// from the registry, which is also what gates SigV4 below. The *principal*
+	// comes from state, because only IAM's own records map an access key to the
+	// entity holding it — and because coupling identity to the registry would mean
+	// a server that identifies callers is a server that rejects every access key
+	// it was not pre-loaded with. See [resolvePrincipal] and #411.
+	if accessKey := extractAccessKeyFromAuth(r.Header.Get("Authorization")); accessKey != "" {
+		registryHit := false
+		if s.opts.Credentials != nil {
+			if entry, ok := s.opts.Credentials.Lookup(accessKey); ok {
+				reqCtx.AccountID = entry.AccountID
+				registryHit = true
+			}
+		}
+		if principal, sessionAccount := resolvePrincipal(ctx, s.state, reqCtx.AccountID, accessKey); principal != nil {
+			reqCtx.Principal = principal
+			// An STS session names the account it was issued for. Adopt it unless
+			// the registry already spoke: parser.extractAccount recognizes only an
+			// AKIA prefix as substrate's test account, so an ASIA session key was
+			// otherwise filed under the fallback account — a different partition
+			// from the resources the role's caller had just created.
+			if sessionAccount != "" && !registryHit {
+				reqCtx.AccountID = sessionAccount
+			}
+		} else if registryHit {
+			// A registered key with no IAM entity behind it. The ARN names the key
+			// rather than a user, so it resolves to no policies and authorizes
+			// nothing — which is the pre-#411 behavior every existing caller of a
+			// credential-wired server relies on, and what GetCallerIdentity reports.
 			reqCtx.Principal = &Principal{
-				ARN:  buildCallerARN(entry.AccountID, accessKey),
+				ARN:  buildCallerARN(reqCtx.AccountID, accessKey),
 				Type: "IAMUser",
 			}
 		}


### PR DESCRIPTION
First of four PRs for v0.92.0. This one makes a signed request resolve to the principal it actually is; the evaluator fixes, CloudFormation's service role, and the docs follow in B, C and D.

Refs #411.

## The defect

`buildCallerARN` derived a principal ARN from the **access key ID**, producing `arn:aws:iam::123456789012:user/AKIATEST12345678901`. Nothing is ever stored under that name — IAM writes policies under `user_policies:<UserName>` — so a user `alice` holding an inline `sqs:*` Allow was:

- **allowed** when evaluated as `arn:aws:iam::123456789012:user/alice`
- **denied** when evaluated as `arn:aws:iam::123456789012:user/AKIATEST…`

Authorization therefore could not find any real principal's policies even on the one path where it ran. #411 has been deferred six times as "wire a principal into a test"; it was not reachable in principle.

## The fix

A caller is resolved from **state**, in `resolvePrincipal`:

1. `iam:accesskey:<id>` → `IAMAccessKey.UserName` → `arn:aws:iam::<acct>:user/<UserName>`. This is the record `CreateAccessKey` has always written.
2. `sts:session:<id>` → `STSSessionCredentials.PrincipalARN`, the `assumed-role` ARN `AssumeRole` mints. Substrate wrote that key from the beginning and **nothing had ever read it**, which is why STS session credentials authorized as nothing in particular.
3. Otherwise no principal.

### Why this is decoupled from `CredentialRegistry`

The obvious fix — wire `Credentials` into the server so it can identify callers — is the trap. `VerifySigV4` runs whenever `Credentials != nil`, and an access key the registry does not hold is rejected with `InvalidClientTokenId` (403). `AKIAIOSFODNN7EXAMPLE` is not registered, so a server that identifies callers that way is a server that 403s the README, the testing guide and every e2e check.

So the two jobs stay split, the same separation as #529's state-vs-wire types: the registry answers *"which account, and is this signature valid"*; **state** answers *"which principal"*. Reading state costs one `Get` on a request that carries an `Authorization` header, and refuses nothing.

### An STS session's account

`extractAccount` recognizes only an `AKIA` prefix as substrate's test account, so an `ASIA` session key was filed under `000000000000` — a different partition from the resources the caller who assumed the role had just created. The session record names the account it was issued for; that is now adopted, unless a wired registry already spoke.

## `sts:GetCallerIdentity` and `sts:GetSessionToken` need no permissions

Found by running this change, not by reading a reference. With a real principal resolving for the first time, `aws sts get-caller-identity` as a policy-less IAM user returned `AccessDeniedException`. AWS documents both operations as requiring none:

> **GetCallerIdentity** — "No permissions are required to perform this operation. If an administrator attaches a policy to your identity that explicitly denies access to the `sts:GetCallerIdentity` action, you can still perform this operation. Permissions are not required because the same information is returned when access is denied."

> **GetSessionToken** — "No permissions are required for users to perform this operation… You cannot use policies to control authentication operations."

A sweep of **every** botocore service model finds the phrase "no permissions are required" on these two operations and nothing else, so the exemption is that pair rather than a general carve-out. It was unreachable before this PR: with every caller resolving to no principal, the evaluator never ran.

## What changes for a consumer

A call made with an access key minted by `CreateAccessKey` is now authorized against that user's policies, and can return `AccessDeniedException` where it previously succeeded. That is real IAM behaviour and the point of the release — the "forgot a permission / policy too narrow" class that spore-host/spawn#70 needed a paid real-AWS smoke to catch.

Everything else is unchanged. **Existence in state is the opt-in**, so there is no configuration flag: a key belonging to no IAM entity resolves to no principal and is enforced against nothing. That covers `AKIAIOSFODNN7EXAMPLE`, `test`/`test`, the built-in test key, a deleted key, every in-process `Client` call, and every test that does not create an IAM principal. An `assumed-role` principal is also not yet enforced — that fail-open is PR B.

## Tests

`emulator/principal_resolution_test.go`, table-driven, no wall-clock or network dependency. The two positive gates were **run against unmodified `main` in a worktree and both fail there**:

- an access key minted by `CreateAccessKey` reaches the plugin as `arn:aws:iam::123456789012:user/alice` — asserted on the ARN, because a test that only checked non-nil passed before the fix;
- an `ASIA` key from `AssumeRole` reaches it as `arn:aws:sts::123456789012:assumed-role/worker/sess1`, **in account `123456789012`**;
- four unenforced-caller regression gates (`AKIAIOSFODNN7EXAMPLE`, the built-in test key, a never-minted key, no header) resolve to no principal and still succeed — these pass on `main` too, which is what makes them regression gates;
- a deleted access key stops resolving;
- six arms an HTTP request cannot produce (nil state, corrupt records, a record naming no owner, a session naming no principal) each resolve to **no** principal rather than one built from half a record;
- the no-permissions-required pair is allowed for a policy-less user while `sts:AssumeRole` is denied, so the exemption is that pair and not all of STS.

### Mutation testing

Ten mutants, all **CAUGHT**. Two earlier attempts were BROKEN (a `perl s///` that choked on slashes in the pattern, and a `grep -c` that counted lines rather than occurrences) and were rewritten before being counted — a BROKEN mutant measures nothing.

| Mutant | Verdict |
|---|---|
| IAM branch returns `buildCallerARN` (the fixed bug, restored) | CAUGHT |
| IAM branch skipped entirely | CAUGHT |
| STS branch dropped | CAUGHT |
| session account not adopted | CAUGHT |
| owner-less key record still resolves | CAUGHT |
| resolution recoupled to `registryHit` | CAUGHT |
| registry fallback applied unconditionally | CAUGHT |
| no-permissions exemption removed | CAUGHT |
| exemption keyed on `req.Operation` instead of the action | CAUGHT |
| exemption widened to all of `sts` | CAUGHT |

The unconditional-fallback mutant fails at the *setup* call with a 403, which is the mechanism worth naming: it makes `AKIAIOSFODNN7EXAMPLE` an enforced principal with no policies, so it denies everything. That is exactly the hazard the registry-hit gate exists for.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**; `make test` (race) green; `make docs-reference docs-reference-check docs-versions` clean (65 plugins, no change); `go vet -C test/e2e ./...` and `go test -C test/e2e ./...` green.

Live against `substrate server`, with the AWS CLI:

```
$ AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE aws s3 mb s3://plain
make_bucket: plain                                    # non-breaking gate

$ aws iam create-user --user-name alice
$ aws iam create-access-key --user-name alice          # AKIADBUC6X6PVEACB4H1H
$ AWS_ACCESS_KEY_ID=AKIADBUC… aws sts get-caller-identity
{ "UserId": "alice", "Arn": "arn:aws:iam::123456789012:user/alice" }

$ AWS_ACCESS_KEY_ID=AKIADBUC… aws sqs list-queues
AccessDeniedException: User: arn:aws:iam::123456789012:user/alice is not
authorized to perform: sqs:ListQueues on resource: *

$ aws iam put-user-policy --user-name alice --policy-name ro \
    --policy-document '{"Statement":[{"Effect":"Allow","Action":"sqs:ListQueues","Resource":"*"}]}'
$ AWS_ACCESS_KEY_ID=<new key> aws sqs list-queues
{ "QueueUrls": [] }                                   # #411's acceptance, over HTTP
$ AWS_ACCESS_KEY_ID=<new key> aws sqs create-queue --queue-name q
AccessDeniedException: … not authorized to perform: sqs:CreateQueue

$ aws sts assume-role --role-arn arn:aws:iam::123456789012:role/worker \
    --role-session-name s1
$ AWS_ACCESS_KEY_ID=ASIA… aws sts get-caller-identity
{ "Arn": "arn:aws:sts::123456789012:assumed-role/worker/s1" }   # right account

$ AWS_ACCESS_KEY_ID=ASIA… aws sqs list-queues
{ "QueueUrls": [] }         # still fails open — PR B
```

The last one is the fail-open this release's PR B closes: `loadPoliciesForPrincipal` errors on any entity type outside `user`/`role` and `CheckAccess` fails open on that error, so an assumed-role is allowed with no policies at all — while `IAMPlugin.authorize` **denies** in the same case. Two loaders, two opposite answers, one ARN.

## Not in this PR

`PluginRegistry.RouteRequest` still never calls `CheckAccess`, so a CloudFormation stack's resource calls remain unauthorized. That is PR C, together with #562's `RoleARN`.
