### PR TITLE
fix(iam): evaluate the principals that exist, and stop guessing at the rest (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   key was filed under `000000000000` — a different partition from the resources the
   caller who assumed the role had just created.
 
+- **An `assumed-role` principal is no longer allowed with no policies at all**
+  (#411). `arn:aws:sts::123456789012:assumed-role/worker/sess1` — the principal shape
+  STS itself mints, and therefore what every "call as a role" reduces to — was
+  **allowed unconditionally**. The policy loader treated any entity type outside
+  `user`/`role` as an error, and the evaluator failed open on an error, so the safe
+  default inverted for exactly the callers a scoped role is meant to constrain. A
+  session is now resolved to its **role**, as real IAM resolves one: the session name
+  is split off (`assumed-role/worker/sess1` → role `worker`) so managed and inline
+  role policies are found under the keys IAM writes, rather than under a per-session
+  name nothing is stored beneath.
+
+  A permission boundary resolves through the same path, else switching enforcement on
+  for these principals would have switched their boundaries off.
+
+- **The two policy loaders no longer disagree about one ARN** (#411).
+  `IAMPlugin.authorize` **denied** an entity type it did not handle where
+  `AuthController.CheckAccess` **allowed** it, so the same caller's permission
+  depended on which service it happened to call. Both now resolve through one
+  function, and an entity type neither models — an account root, a service
+  principal, a federated user — is consistently *not enforced* rather than denied by
+  one and allowed by the other.
+
+  This distinguishes two cases the loader had conflated: an entity that resolves and
+  exists is evaluated (no policies is an implicit deny, as on AWS) and one that
+  resolves to nothing is unenforced and logged at debug, while a state read that
+  genuinely *fails* still fails open with a warning. That last case is a broken
+  backend, not an unknown caller, and it is the only one that should be loud.
+
 - **`sts:GetCallerIdentity` and `sts:GetSessionToken` no longer require
   permissions** (#411). AWS documents both as needing none — `GetCallerIdentity`
   answers "even if an administrator attaches a policy to your identity that
@@ -66,8 +94,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Nothing else changes. A nil principal still passes, so every in-process `Client`
   call, every unregistered access key, and every test that does not create an IAM
-  principal behaves exactly as before. An `assumed-role` principal is not yet
-  enforced either; that fail-open is tracked in #411's remaining work.
+  principal behaves exactly as before.
+
+- **A call made with STS session credentials is now authorized against the assumed
+  role's policies** (#411). Same consequence as above, for the principal shape
+  `AssumeRole` mints: a session of a role holding no policy, or a policy that does
+  not allow the call, now returns `AccessDeniedException` where it previously
+  succeeded — see the fail-open under **Fixed** for why "previously succeeded" meant
+  *unconditionally*.
+
+  A role that the session names but that does not exist in state is still not
+  enforced, so this reaches only sessions minted against a role substrate actually
+  holds.
 
 ## [v0.91.0] - 2026-08-04
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -37,7 +37,27 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	}
 	resource := buildResourceARN(reqCtx, req)
 
-	docs, err := a.loadPoliciesForPrincipal(reqCtx)
+	goCtx := context.Background()
+	entity, exists, err := resolveIAMEntity(goCtx, a.state, reqCtx.Principal.ARN)
+	if err != nil {
+		// A state read that actually failed — a broken backend, not an unknown
+		// caller. Fail open and say so loudly: substrate cannot decide, and denying
+		// on a storage error would turn an infrastructure fault into a
+		// misleading AccessDeniedException.
+		a.logger.Warn("authz: failed to resolve principal", "principal", reqCtx.Principal.ARN, "err", err)
+		return nil
+	}
+	if !exists {
+		// Enforcement is opt-in by creating the principal. A credential that
+		// resolves to no IAM entity is not enforced — Debug rather than Warn,
+		// because this is the normal case for every caller that never touched IAM
+		// and warning on each would bury the signal it is meant to carry.
+		a.logger.Debug("authz: principal has no IAM entity, not enforced",
+			"principal", reqCtx.Principal.ARN, "action", action)
+		return nil
+	}
+
+	docs, err := a.loadPoliciesForPrincipal(entity)
 	if err != nil {
 		// Fail open: if we cannot load policies we cannot block the caller.
 		a.logger.Warn("authz: failed to load policies", "principal", reqCtx.Principal.ARN, "err", err)
@@ -63,7 +83,7 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	}
 
 	// If a permission boundary is set it must also allow the action.
-	boundary, err := a.loadPermissionBoundary(reqCtx)
+	boundary, err := a.loadPermissionBoundary(entity)
 	if err != nil {
 		a.logger.Warn("authz: failed to load permission boundary", "principal", reqCtx.Principal.ARN, "err", err)
 	}
@@ -87,23 +107,80 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	return nil
 }
 
-// loadPoliciesForPrincipal loads attached managed + inline policies for the
-// principal identified by reqCtx.Principal.ARN.
-func (a *AuthController) loadPoliciesForPrincipal(reqCtx *RequestContext) ([]PolicyDocument, error) {
-	entityType, entityName := parsePrincipalARN(reqCtx.Principal.ARN)
+// iamEntity is the IAM entity a principal ARN names, in the terms the policy
+// keys are written under.
+//
+// Kind is "user" or "role" — never "assumed-role", because a session holds no
+// policies of its own: IAM resolves an assumed-role's permissions against the
+// role it assumed, so a session's Kind is "role" and its Name is the role's.
+type iamEntity struct {
+	// Kind is the entity type, matching the prefix IAM stores policies under.
+	Kind string
+
+	// Name is the entity name, which is the policy-key suffix.
+	Name string
+}
+
+// resolveIAMEntity maps a principal ARN onto the IAM entity whose policies apply,
+// reporting separately whether that entity exists in state.
+//
+// Splitting "which entity" from "does it exist" is the point. Before #411 both
+// loaders folded them into one error and then disagreed about what to do with it:
+// [AuthController.loadPoliciesForPrincipal] returned "unsupported entity type"
+// for anything outside user/role and [AuthController.CheckAccess] failed *open*
+// on that error, so an arn:aws:sts::…:assumed-role/worker/sess1 — the exact shape
+// STS mints — was allowed with no policies at all, while IAMPlugin.authorize
+// *denied* it. One ARN, two loaders, two opposite answers.
+//
+// Existence is what makes enforcement opt-in. An entity present in state is
+// evaluated, and having no policies is an implicit deny, which is real IAM
+// behavior. An ARN that names nothing in state is not enforced at all, so the
+// thousands of calls made with a credential that never touched IAM are
+// unaffected. A read that genuinely *fails* is neither: see the error return.
+func resolveIAMEntity(ctx context.Context, state StateManager, principalARN string) (entity iamEntity, exists bool, err error) {
+	entityType, entityName := parsePrincipalARN(principalARN)
 	if entityName == "" {
-		return nil, fmt.Errorf("cannot parse principal ARN %q", reqCtx.Principal.ARN)
+		return iamEntity{}, false, nil
 	}
 
-	var listKey string
 	switch entityType {
-	case "user":
-		listKey = "user_policies:" + entityName
-	case "role":
-		listKey = "role_policies:" + entityName
+	case "user", "role":
+		entity = iamEntity{Kind: entityType, Name: entityName}
+	case "assumed-role":
+		// arn:aws:sts::<acct>:assumed-role/<RoleName>/<SessionName>. Only the role
+		// carries policies, and parsePrincipalARN splits on the first slash — so
+		// without dropping the session the lookup would be
+		// role_policies:worker/sess1, a key nothing is ever stored under. Every
+		// session of the same role would then evaluate as a distinct nameless
+		// entity.
+		roleName := entityName
+		if slash := strings.IndexByte(roleName, '/'); slash >= 0 {
+			roleName = roleName[:slash]
+		}
+		if roleName == "" {
+			return iamEntity{}, false, nil
+		}
+		entity = iamEntity{Kind: "role", Name: roleName}
 	default:
-		return nil, fmt.Errorf("unsupported entity type %q in ARN", entityType)
+		// A principal substrate does not model as a policy-holding entity — a
+		// service principal, a federated user, the account root. Not enforced,
+		// rather than denied: refusing a caller whose policies cannot be looked up
+		// would deny requests that pass today for a reason no test could fix.
+		return iamEntity{}, false, nil
 	}
+
+	raw, err := state.Get(ctx, iamNamespace, entity.Kind+":"+entity.Name)
+	if err != nil {
+		return entity, false, fmt.Errorf("load %s %q: %w", entity.Kind, entity.Name, err)
+	}
+	return entity, raw != nil, nil
+}
+
+// loadPoliciesForPrincipal loads attached managed + inline policies for the
+// entity resolved from reqCtx.Principal.ARN.
+func (a *AuthController) loadPoliciesForPrincipal(entity iamEntity) ([]PolicyDocument, error) {
+	entityType, entityName := entity.Kind, entity.Name
+	listKey := entityType + "_policies:" + entityName
 
 	goCtx := context.Background()
 
@@ -176,41 +253,32 @@ func (a *AuthController) loadPoliciesForPrincipal(reqCtx *RequestContext) ([]Pol
 }
 
 // loadPermissionBoundary loads the permission boundary PolicyDocument for the
-// principal, or nil if none is set.
-func (a *AuthController) loadPermissionBoundary(reqCtx *RequestContext) (*PolicyDocument, error) {
-	entityType, entityName := parsePrincipalARN(reqCtx.Principal.ARN)
-	if entityName == "" {
-		return nil, nil
-	}
-
+// resolved entity, or nil if none is set.
+//
+// It takes the same resolved entity the policy load did, so a boundary applies to
+// an assumed-role session through the role it assumed. Reading the ARN again here
+// is what silently stopped boundaries applying to exactly the principals #411
+// made enforceable.
+func (a *AuthController) loadPermissionBoundary(entity iamEntity) (*PolicyDocument, error) {
 	goCtx := context.Background()
 
-	var entityRaw []byte
-	var err error
-	switch entityType {
-	case "user":
-		entityRaw, err = a.state.Get(goCtx, iamNamespace, "user:"+entityName)
-	case "role":
-		entityRaw, err = a.state.Get(goCtx, iamNamespace, "role:"+entityName)
-	default:
-		return nil, nil
-	}
+	entityRaw, err := a.state.Get(goCtx, iamNamespace, entity.Kind+":"+entity.Name)
 	if err != nil || entityRaw == nil {
 		return nil, err
 	}
 
-	var entity struct {
+	var stored struct {
 		PermissionsBoundary *IAMAttachedPolicy `json:"PermissionsBoundary,omitempty"`
 	}
-	if err := json.Unmarshal(entityRaw, &entity); err != nil {
+	if err := json.Unmarshal(entityRaw, &stored); err != nil {
 		return nil, fmt.Errorf("unmarshal entity for boundary: %w", err)
 	}
-	if entity.PermissionsBoundary == nil {
+	if stored.PermissionsBoundary == nil {
 		return nil, nil
 	}
 
 	// Resolve the boundary policy document.
-	arn := entity.PermissionsBoundary.PolicyARN
+	arn := stored.PermissionsBoundary.PolicyARN
 	if mp, ok := GetManagedPolicy(arn); ok {
 		return &mp.Document, nil
 	}

--- a/emulator/authz_assumed_role_test.go
+++ b/emulator/authz_assumed_role_test.go
@@ -1,0 +1,330 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// An assumed-role principal used to be allowed with no policies at all:
+// loadPoliciesForPrincipal errored on any entity type outside user/role and
+// CheckAccess failed open on that error. IAMPlugin.authorize denied in the same
+// case. One ARN, two loaders, two opposite answers — and the shape STS itself
+// mints, so every "call as a role" test was unenforced while looking enforced.
+
+// newRoleAuthState builds a state manager holding a role, optionally with an
+// attached policy and a permissions boundary.
+func newRoleAuthState(t *testing.T, roleName string, doc *emulator.PolicyDocument, boundary *emulator.PolicyDocument) emulator.StateManager {
+	t.Helper()
+	state := emulator.NewMemoryStateManager()
+	ctx := context.Background()
+
+	role := emulator.IAMRole{
+		RoleName: roleName,
+		RoleID:   "AROATEST",
+		ARN:      "arn:aws:iam::123456789012:role/" + roleName,
+		Path:     "/",
+	}
+	if boundary != nil {
+		boundaryARN := "arn:aws:iam::123456789012:policy/Boundary"
+		role.PermissionsBoundary = &emulator.IAMAttachedPolicy{
+			PolicyARN:  boundaryARN,
+			PolicyName: "Boundary",
+		}
+		polRaw, err := json.Marshal(emulator.IAMPolicy{
+			PolicyName: "Boundary",
+			ARN:        boundaryARN,
+			Document:   *boundary,
+		})
+		require.NoError(t, err)
+		require.NoError(t, state.Put(ctx, "iam", "policy:"+boundaryARN, polRaw))
+	}
+
+	roleRaw, err := json.Marshal(role)
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "role:"+roleName, roleRaw))
+
+	if doc != nil {
+		policyARN := "arn:aws:iam::123456789012:policy/RolePolicy"
+		arnsRaw, marshalErr := json.Marshal([]string{policyARN})
+		require.NoError(t, marshalErr)
+		require.NoError(t, state.Put(ctx, "iam", "role_policies:"+roleName, arnsRaw))
+		polRaw, marshalErr := json.Marshal(emulator.IAMPolicy{
+			PolicyName: "RolePolicy",
+			ARN:        policyARN,
+			Document:   *doc,
+		})
+		require.NoError(t, marshalErr)
+		require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+	}
+
+	return state
+}
+
+// allowSQSListQueues is a policy allowing exactly one action.
+func allowSQSListQueues() *emulator.PolicyDocument {
+	return &emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"sqs:ListQueues"},
+			Resource: emulator.StringOrSlice{"*"},
+		}},
+	}
+}
+
+func TestAuthController_AssumedRole(t *testing.T) {
+	const sessionARN = "arn:aws:sts::123456789012:assumed-role/worker/sess1"
+
+	tests := []struct {
+		name        string
+		principal   string
+		roleName    string
+		policy      *emulator.PolicyDocument
+		boundary    *emulator.PolicyDocument
+		operation   string
+		wantDenied  bool
+		wantMessage string
+	}{
+		{
+			// The fail-open that started this. The role exists and holds no policy,
+			// so the session is an implicit deny — as it is on AWS.
+			name:       "role with no policy is denied",
+			principal:  sessionARN,
+			roleName:   "worker",
+			operation:  "ListQueues",
+			wantDenied: true,
+		},
+		{
+			// Resolution has to drop the session name: parsePrincipalARN splits on
+			// the first slash, so without that the lookup is
+			// role_policies:worker/sess1 and every session of the same role is a
+			// distinct nameless entity.
+			name:      "role policy applies to the session",
+			principal: sessionARN,
+			roleName:  "worker",
+			policy:    allowSQSListQueues(),
+			operation: "ListQueues",
+		},
+		{
+			name:       "role policy does not cover another action",
+			principal:  sessionARN,
+			roleName:   "worker",
+			policy:     allowSQSListQueues(),
+			operation:  "CreateQueue",
+			wantDenied: true,
+		},
+		{
+			// A session name may itself contain slashes or dots; only the first
+			// segment is the role.
+			name:      "a dotted session name still resolves to the role",
+			principal: "arn:aws:sts::123456789012:assumed-role/worker/i-0abc.session",
+			roleName:  "worker",
+			policy:    allowSQSListQueues(),
+			operation: "ListQueues",
+		},
+		{
+			// A boundary must keep applying to exactly the principals that now
+			// enforce, else switching enforcement on switches boundaries off.
+			name:        "a permission boundary applies through the role",
+			principal:   sessionARN,
+			roleName:    "worker",
+			policy:      allowSQSListQueues(),
+			boundary:    &emulator.PolicyDocument{Version: "2012-10-17"},
+			operation:   "ListQueues",
+			wantDenied:  true,
+			wantMessage: "blocked by permission boundary",
+		},
+		{
+			// The opt-in: the session names a role that was never created, so
+			// nothing is enforced. This is what keeps every existing caller green.
+			name:      "a session whose role does not exist is not enforced",
+			principal: "arn:aws:sts::123456789012:assumed-role/ghost/sess1",
+			roleName:  "worker",
+			operation: "ListQueues",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newRoleAuthState(t, tt.roleName, tt.policy, tt.boundary)
+			auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
+
+			reqCtx := &emulator.RequestContext{
+				RequestID: "req-1",
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+				Principal: &emulator.Principal{ARN: tt.principal, Type: "AssumedRole"},
+				Metadata:  make(map[string]interface{}),
+			}
+			req := &emulator.AWSRequest{Service: "sqs", Operation: tt.operation, Params: map[string]string{}}
+
+			err := auth.CheckAccess(reqCtx, req)
+			if !tt.wantDenied {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var awsErr *emulator.AWSError
+			require.ErrorAs(t, err, &awsErr)
+			assert.Equal(t, "AccessDeniedException", awsErr.Code)
+			assert.Equal(t, 403, awsErr.HTTPStatus)
+			if tt.wantMessage != "" {
+				assert.Contains(t, awsErr.Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestAuthController_ExistenceIsTheOptIn(t *testing.T) {
+	// Enforcement keys off whether the principal resolves to an IAM entity that
+	// exists. A user that does exist and holds no policies is an implicit deny —
+	// real IAM behavior, and the whole point. A principal naming nothing in state
+	// is not enforced, which is what keeps the thousands of existing calls made
+	// with a credential that never touched IAM passing.
+	tests := []struct {
+		name       string
+		principal  string
+		wantDenied bool
+	}{
+		{name: "user that exists", principal: "arn:aws:iam::123456789012:user/alice", wantDenied: true},
+		{name: "user that does not exist", principal: "arn:aws:iam::123456789012:user/nobody"},
+		{name: "role that does not exist", principal: "arn:aws:iam::123456789012:role/nosuchrole"},
+		// A service principal, the account root, and a federated user hold no
+		// policies substrate models. Each was previously an "unsupported entity
+		// type" error that CheckAccess failed open on and IAMPlugin.authorize
+		// denied; both now agree they are simply not enforced.
+		{name: "account root", principal: "arn:aws:iam::123456789012:root"},
+		{name: "service principal", principal: "cloudformation.amazonaws.com"},
+		{name: "federated user", principal: "arn:aws:sts::123456789012:federated-user/dave"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newAuthTestState(t, "alice", "", emulator.PolicyDocument{})
+			auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
+
+			reqCtx := &emulator.RequestContext{
+				RequestID: "req-1",
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+				Principal: &emulator.Principal{ARN: tt.principal, Type: "IAMUser"},
+				Metadata:  make(map[string]interface{}),
+			}
+			req := &emulator.AWSRequest{Service: "sqs", Operation: "ListQueues", Params: map[string]string{}}
+
+			err := auth.CheckAccess(reqCtx, req)
+			if tt.wantDenied {
+				require.Error(t, err)
+				var awsErr *emulator.AWSError
+				require.ErrorAs(t, err, &awsErr)
+				assert.Equal(t, "AccessDeniedException", awsErr.Code)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestAuthController_StateFailureFailsOpen(t *testing.T) {
+	// The one case that must stay loud and permissive. "I cannot reach the store"
+	// and "this caller is nobody" both used to be the same error, and both allowed;
+	// they are now distinguished, and the distinction is only worth anything if the
+	// I/O arm keeps failing open. Denying on a storage blip would report a broken
+	// backend as AccessDeniedException — a permanent-looking signal for a transient
+	// fault, which is the wrong path to send a consumer's retry loop down.
+	state := &errAfterGetsStateManager{
+		inner:  newRoleAuthState(t, "worker", allowSQSListQueues(), nil),
+		getErr: errors.New("state store unavailable"),
+		allow:  0, // every Get fails, so entity resolution itself errors
+	}
+	auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
+
+	reqCtx := &emulator.RequestContext{
+		RequestID: "req-1",
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		Principal: &emulator.Principal{
+			ARN:  "arn:aws:sts::123456789012:assumed-role/worker/sess1",
+			Type: "AssumedRole",
+		},
+		Metadata: make(map[string]interface{}),
+	}
+	req := &emulator.AWSRequest{Service: "sqs", Operation: "ListQueues", Params: map[string]string{}}
+
+	assert.NoError(t, auth.CheckAccess(reqCtx, req),
+		"a state-store failure must fail open, not deny")
+}
+
+func TestIAMAuthorize_AgreesWithCheckAccess(t *testing.T) {
+	// The asymmetry this closes: IAMPlugin.authorize denied an entity type it did
+	// not handle where CheckAccess allowed it, so the same ARN got opposite answers
+	// depending on which service it called. Both now route through one resolver.
+	tests := []struct {
+		name       string
+		principal  string
+		policy     *emulator.PolicyDocument
+		wantDenied bool
+	}{
+		{
+			name:       "assumed-role with no role policy",
+			principal:  "arn:aws:sts::123456789012:assumed-role/worker/sess1",
+			wantDenied: true,
+		},
+		{
+			name:      "assumed-role with a role policy allowing the action",
+			principal: "arn:aws:sts::123456789012:assumed-role/worker/sess1",
+			policy: &emulator.PolicyDocument{
+				Version: "2012-10-17",
+				Statement: []emulator.PolicyStatement{{
+					Effect:   "Allow",
+					Action:   emulator.StringOrSlice{"iam:ListUsers"},
+					Resource: emulator.StringOrSlice{"*"},
+				}},
+			},
+		},
+		{
+			name:      "a principal that resolves to nothing is not enforced",
+			principal: "arn:aws:iam::123456789012:root",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newRoleAuthState(t, "worker", tt.policy, nil)
+			logger := emulator.NewDefaultLogger(slog.LevelError, false)
+
+			plugin := &emulator.IAMPlugin{}
+			require.NoError(t, plugin.Initialize(context.Background(),
+				emulator.PluginConfig{State: state, Logger: logger}))
+			auth := emulator.NewAuthController(state, logger)
+
+			reqCtx := &emulator.RequestContext{
+				RequestID: "req-1",
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+				Principal: &emulator.Principal{ARN: tt.principal, Type: "AssumedRole"},
+				Metadata:  make(map[string]interface{}),
+			}
+
+			pluginErr := emulator.IAMAuthorizeForTest(plugin, reqCtx, "iam:ListUsers", "*")
+			controllerErr := auth.CheckAccess(reqCtx,
+				&emulator.AWSRequest{Service: "iam", Operation: "ListUsers", Params: map[string]string{}})
+
+			if tt.wantDenied {
+				assert.Error(t, pluginErr, "IAMPlugin.authorize should deny")
+				assert.Error(t, controllerErr, "CheckAccess should deny")
+				return
+			}
+			assert.NoError(t, pluginErr, "IAMPlugin.authorize should allow")
+			assert.NoError(t, controllerErr, "CheckAccess should allow")
+		})
+	}
+}

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -1334,22 +1334,25 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 		return nil
 	}
 
-	entityType, entityName := parsePrincipalARN(reqCtx.Principal.ARN)
-	if entityName == "" {
-		return &AWSError{Code: "AccessDeniedException", Message: "access denied", HTTPStatus: 403}
+	// The same resolver AuthController.CheckAccess uses, so one ARN gets one
+	// answer. These two disagreed: an entity type outside user/role was denied
+	// here and allowed there, and an assumed-role session — the shape STS mints —
+	// hit that arm on both paths. An IAM call by such a session now evaluates
+	// against the role it assumed instead of being refused outright.
+	entity, exists, err := resolveIAMEntity(goCtx, p.state, reqCtx.Principal.ARN)
+	if err != nil {
+		return fmt.Errorf("resolve principal for authorization: %w", err)
 	}
-
-	var listKey string
-	switch entityType {
-	case "user":
-		listKey = "user_policies:" + entityName
-	case "role":
-		listKey = "role_policies:" + entityName
-	default:
-		return &AWSError{Code: "AccessDeniedException", Message: "access denied", HTTPStatus: 403}
+	if !exists {
+		// Not enforced, matching CheckAccess: enforcement is opt-in by creating the
+		// principal. Denying here instead would refuse every IAM call made with a
+		// credential that has no IAM entity behind it — which is how substrate's own
+		// documented credentials bootstrap the users these policies are attached to.
+		return nil
 	}
+	entityType, entityName := entity.Kind, entity.Name
 
-	arns, err := p.loadPolicyList(goCtx, listKey)
+	arns, err := p.loadPolicyList(goCtx, entityType+"_policies:"+entityName)
 	if err != nil {
 		return fmt.Errorf("load policies for authorization: %w", err)
 	}
@@ -1415,20 +1418,17 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 		}
 	}
 
-	// If a permission boundary is set it must also allow the action.
-	var entityRaw []byte
-	switch entityType {
-	case "user":
-		entityRaw, _ = p.state.Get(goCtx, iamNamespace, "user:"+entityName)
-	case "role":
-		entityRaw, _ = p.state.Get(goCtx, iamNamespace, "role:"+entityName)
-	}
+	// If a permission boundary is set it must also allow the action. The resolver
+	// above guarantees Kind is "user" or "role" and that the record exists, so this
+	// is one read rather than a switch that had to repeat the same entity-type
+	// decision a third time.
+	entityRaw, _ := p.state.Get(goCtx, iamNamespace, entityType+":"+entityName)
 	if entityRaw != nil {
-		var entity struct {
+		var stored struct {
 			PermissionsBoundary *IAMAttachedPolicy `json:"PermissionsBoundary,omitempty"`
 		}
-		if unmarshalErr := json.Unmarshal(entityRaw, &entity); unmarshalErr == nil && entity.PermissionsBoundary != nil {
-			boundaryDocs := p.loadBoundaryPolicyDocs(goCtx, entity.PermissionsBoundary.PolicyARN)
+		if unmarshalErr := json.Unmarshal(entityRaw, &stored); unmarshalErr == nil && stored.PermissionsBoundary != nil {
+			boundaryDocs := p.loadBoundaryPolicyDocs(goCtx, stored.PermissionsBoundary.PolicyARN)
 			if len(boundaryDocs) > 0 {
 				boundaryResult := Evaluate(boundaryDocs, EvaluationRequest{
 					Principal: reqCtx.Principal.ARN,

--- a/emulator/principal_resolution_test.go
+++ b/emulator/principal_resolution_test.go
@@ -249,7 +249,10 @@ func TestCheckAccess_NoPermissionsRequiredActions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			state := emulator.NewMemoryStateManager()
+			// alice has to exist for anything to be evaluated at all: a principal
+			// absent from state is unenforced, so a jointly-empty state manager
+			// would make every case pass for the wrong reason.
+			state := newAuthTestState(t, "alice", "", emulator.PolicyDocument{})
 			auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
 
 			reqCtx := &emulator.RequestContext{


### PR DESCRIPTION
Second of four PRs for v0.92.0. PR A (#570) made a signed request resolve to the
principal it actually is; this makes the evaluator answer correctly for the
principals that resolve, and refuse to guess about the rest.

Does **not** close #411 — the CloudFormation half (`RouteRequest` never calls
`CheckAccess`, so the whole IaC path is unauthorized) lands in PR C.

## The fail-open

`arn:aws:sts::123456789012:assumed-role/worker/sess1` was **allowed with no
policies at all**. `loadPoliciesForPrincipal` returned an error for any entity
type outside `user`/`role`, and `CheckAccess` fails open on an error, so the two
lines conspired to invert the safe default for exactly the callers a scoped role
exists to constrain. This is not an obscure shape: it is what `AssumeRole` mints,
so *every* "call as a role" reduced to it — and PR A, by making STS session
credentials resolve at all, turned it from unreachable into live. Measured against
`main` after PR A: `AWS_ACCESS_KEY_ID=ASIA… aws sqs list-queues` with no role
policy returned `{"QueueUrls": []}`.

A session now resolves to its **role**, as IAM does. The session name has to be
split off: `parsePrincipalARN` splits on the first slash, so without that the
lookup is `role_policies:worker/sess1` — a key nothing is ever stored under, which
would have made every session of a role a distinct nameless entity. A permission
boundary resolves through the same path, because otherwise switching enforcement
on for these principals would have switched their boundaries off.

## One ARN, one answer

`IAMPlugin.authorize` **denied** an entity type it did not handle where
`AuthController.CheckAccess` **allowed** it, so a caller's permission depended on
which service it happened to call. Both now route through one `resolveIAMEntity`,
which separates three cases the old single error had conflated:

| case | before | after |
|---|---|---|
| entity resolves and exists in state | evaluated | evaluated (no policies → implicit deny, as on AWS) |
| entity resolves to nothing in state | `CheckAccess` allowed, `authorize` denied | not enforced, `Debug` |
| a state read genuinely fails (I/O) | fails open, `Warn` | fails open, `Warn` — unchanged |

The last row is the one worth being deliberate about. It stays permissive and
loud: a storage fault is not an unknown caller, and reporting it as
`AccessDeniedException` would hand a consumer's retry loop a permanent-looking
answer to a transient problem. That distinction is only worth anything if it is
tested, so it is — see M5 below, which survived the first mutation run and is why
`TestAuthController_StateFailureFailsOpen` exists.

Existence in state remains the opt-in, so a session naming a role substrate does
not hold is unenforced, and every caller that never touched IAM is unaffected.

## Tests

`emulator/authz_assumed_role_test.go`, table-driven, no clock or network.

- an assumed-role whose role holds no policy is **denied**; with an `sqs:ListQueues`
  role policy it is **allowed**; and it is denied `sqs:CreateQueue`
- a dotted/slashed session name still resolves to the role
- a permission boundary applies through the role
- a session whose role does not exist is **not enforced** (the opt-in)
- a `user` that exists with no policies is denied; `user`/`role` that do not
  exist, an account root, a service principal and a federated user are all
  unenforced
- `IAMPlugin.authorize` and `CheckAccess` agree on the same ARN in all three cases
- a state-store failure fails open

**Baselined at PR A's merge commit (`3916ef6`) in a throwaway worktree: 9 of 14
subtests fail there.** The five that pass at baseline pass *vacuously* — the
fail-open allowed them — which is what the mutation set below is for.

One existing test changed: `TestCheckAccess_NoPermissionsRequiredActions` now
builds state where `alice` exists, because a jointly-empty state manager would
make every case pass for the wrong reason once absence means unenforced.

## Mutation testing — 8/8 caught

Occurrence-count asserted before applying, `gofmt`+`go vet` gate, `-race`,
green-baseline pre-flight.

| # | mutant | verdict |
|---|---|---|
| 1 | the `assumed-role` case removed (fail-open restored) | CAUGHT |
| 2 | session **not** split off the name → loads `role_policies:worker/sess1` | CAUGHT |
| 3 | "entity does not exist" denies instead of not enforcing | CAUGHT |
| 4 | the existence check dropped entirely | CAUGHT |
| 5 | a state-read failure denies instead of failing open | CAUGHT (after a rewrite — see below) |
| 6 | boundary loaded under the wrong entity kind | CAUGHT |
| 7 | `IAMPlugin.authorize` denies where `CheckAccess` allows | CAUGHT (after a rewrite) |
| 8 | the policy-list key drops the entity kind | CAUGHT |

Two needed a second pass, both worth recording. **M5 SURVIVED** the first run:
nothing covered the I/O fail-open, so the arm this PR deliberately preserves was
untested — the test above was written in response. **M7 was BROKEN**, not caught:
`go vet` rejected it as unreachable code, and a mutant that does not build measures
nothing, so it was rewritten to mutate the condition rather than insert a return.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0
issues**, `make test` (race) green, `make docs-reference docs-reference-check
docs-versions` (no plugin added or removed), `go vet -C test/e2e ./...`,
`go test -C test/e2e ./...`.

Live against `substrate server --address :4655`, one server, both callers:

```
AKIAIOSFODNN7EXAMPLE      sqs create-queue plain     → 200          (unenforced, unchanged)
assumed-role/worker/sess1 sqs list-queues            → AccessDeniedException   (was 200)
assumed-role/reader/sess2 sqs list-queues            → 200          (inline role policy allows)
assumed-role/reader/sess2 sqs create-queue           → AccessDeniedException
assumed-role/worker/sess1 sts get-caller-identity    → 200          (no permissions required)
```

Refs #411.
