### PR TITLE
fix(authz): name a REST request by its operation, not its HTTP method (#572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A REST service is no longer named after its HTTP method, so a correct policy
+  is no longer denied** (#572). A REST-JSON or REST-XML service carries its
+  operation in the shape of its URL and nowhere else, so request parsing fell
+  through to its last-resort fallback and the request entered the pipeline named
+  `POST`. Authorization, fault injection, cost and consistency all read the
+  operation before any plugin runs, so every one of them saw the verb. Measured on
+  the parent commit: **17 of 18 REST services** were affected — S3 was the only
+  exception, because #480 had wired its resolver in for exactly this reason.
+
+  This was inert while the evaluator was unreachable and stopped being inert with
+  #411. A user holding `lambda:InvokeFunction` was refused an invoke, because the
+  action evaluated was `lambda:POST`; a wildcard masked it, so precisely the
+  scoped policy #411 exists to let a consumer test got a false
+  `AccessDeniedException`. Left unfixed, the release would have reported denials
+  for policies that are correct — the inverse of its claim.
+
+  The operation name is now resolved once, before the pipeline reads it,
+  generalising #480 instead of repeating it 17 times. Each service's resolver
+  already existed and is reused rather than reimplemented, so the name that is
+  authorized, metered and recorded cannot drift from the name its plugin routes
+  on. `AWSRequest` gains `HTTPMethod`: the verb and the operation had been sharing
+  one field, and resolving the operation destroyed the verb a REST resolver needs
+  — `POST` and `DELETE` on the same path are different operations.
+
+  **The IAM action is not always the operation name**, and treating it as such
+  denies a caller whose policy is right, so the mapping is now explicit and
+  sourced per operation. Lambda's `Invoke` requires `lambda:InvokeFunction`. S3's
+  listings authorize against the bucket: `ListObjects`/`ListObjectsV2` and
+  `HeadBucket` require `s3:ListBucket`, `ListBuckets` requires
+  `s3:ListAllMyBuckets`, and the versioned and multipart listings have their own
+  bucket-scoped actions. API Gateway v1 is the sharper case: its IAM actions
+  genuinely *are* HTTP verbs (`apigateway:POST`, and no `apigateway:CreateRestApi`
+  exists), so for that service the verb remains the action — while `apigatewayv2`
+  is a separate prefix that does use operation names. Conflating them would have
+  broken v1 in the act of fixing the others.
+
+  Two consequences beyond authorization, both pre-existing and now fixed: a fault
+  rule can name a REST operation, closing #480's gap for the 17 services its
+  S3-only fix never reached (a rule naming `POST` used to take out every call to
+  the service at once); and a recorded event carries its operation, so an event log
+  is greppable by operation. CloudFormation's resource calls are built in-process
+  and never parsed off the wire, so they are resolved at dispatch too — a stack's
+  bucket is recorded and authorized as `CreateBucket`, not `PUT`.
 - **A signed request now resolves to the principal it actually is** (#411). The
   server derived a caller's principal ARN from its *access key ID*, yielding
   `arn:aws:iam::123456789012:user/AKIATEST12345678901` — a name nothing is ever

--- a/emulator/apigateway_plugin.go
+++ b/emulator/apigateway_plugin.go
@@ -40,7 +40,7 @@ func (p *APIGatewayPlugin) Shutdown(_ context.Context) error { return nil }
 // HandleRequest dispatches an API Gateway v1 request to the appropriate handler
 // using path-based operation routing.
 func (p *APIGatewayPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, params := parseAPIGatewayOperation(req.Operation, req.Path)
+	op, params := parseAPIGatewayOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateRestApi":
 		return p.createRestAPI(ctx, req)

--- a/emulator/apigatewayv2_plugin.go
+++ b/emulator/apigatewayv2_plugin.go
@@ -38,7 +38,7 @@ func (p *APIGatewayV2Plugin) Shutdown(_ context.Context) error { return nil }
 // HandleRequest dispatches an API Gateway v2 request to the appropriate handler
 // using path-based operation routing.
 func (p *APIGatewayV2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, params := parseAPIGatewayV2Operation(req.Operation, req.Path)
+	op, params := parseAPIGatewayV2Operation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateApi":
 		return p.createAPI(ctx, req)

--- a/emulator/appsync_plugin.go
+++ b/emulator/appsync_plugin.go
@@ -38,7 +38,7 @@ func (p *AppSyncPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches an AppSync REST/JSON request to the appropriate handler.
 func (p *AppSyncPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, apiID, segment, resourceID := parseAppSyncOperation(req.Operation, req.Path)
+	op, apiID, segment, resourceID := parseAppSyncOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateGraphqlApi":
 		return p.createGraphqlAPI(ctx, req)

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -31,7 +31,7 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		return nil
 	}
 
-	action := serviceToAction(req.Service, req.Operation)
+	action := serviceToAction(req, req.Service, req.Operation)
 	if authzNoPermissionsRequired[action] {
 		return nil
 	}
@@ -316,10 +316,78 @@ var authzNoPermissionsRequired = map[string]bool{
 	"sts:GetSessionToken":   true,
 }
 
-// serviceToAction maps (service, operation) to an IAM action string,
+// verbActionServices are the services whose IAM actions are HTTP verbs rather
+// than operation names.
+//
+// API Gateway v1 is the case that matters: its Service Authorization Reference
+// defines apigateway:GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS and no
+// apigateway:CreateRestApi, because permissions map to the HTTP method used
+// against a management resource. API Gateway v2 is a different service prefix
+// (apigatewayv2) and does use operation names, so it is deliberately absent.
+//
+// For these services the verb ParseAWSRequest started with is the correct action,
+// which is why authorization reads HTTPMethod rather than the resolved
+// Operation. See serviceToAction.
+var verbActionServices = map[string]bool{
+	"apigateway": true,
+}
+
+// operationActionOverrides maps a (service, operation) pair whose IAM action is
+// not its operation name to the action a policy must actually name.
+//
+// The IAM action is usually the operation name, but "usually" is not "always",
+// and a wrong action string denies a caller whose policy is correct. Every entry
+// is from the operation's own API reference or its Service Authorization
+// Reference:
+//
+//   - Lambda's Invoke requires lambda:InvokeFunction — the one rename in Lambda's
+//     otherwise identical mapping.
+//   - S3's list operations authorize against the bucket, not the listing:
+//     ListObjects/ListObjectsV2 and HeadBucket require s3:ListBucket ("You must
+//     have permission to perform the s3:ListBucket action"), ListBuckets requires
+//     s3:ListAllMyBuckets, and the versioned and multipart listings have their own
+//     bucket-scoped actions.
+//   - DeleteObjects is the batch form of DeleteObject and requires that action.
+//
+// Keyed by "service:operation" so the lookup is one map access on the string
+// serviceToAction was going to build anyway.
+var operationActionOverrides = map[string]string{
+	"lambda:Invoke": "lambda:InvokeFunction",
+
+	"s3:ListObjects":          "s3:ListBucket",
+	"s3:ListObjectsV2":        "s3:ListBucket",
+	"s3:HeadBucket":           "s3:ListBucket",
+	"s3:ListBuckets":          "s3:ListAllMyBuckets",
+	"s3:ListObjectVersions":   "s3:ListBucketVersions",
+	"s3:ListMultipartUploads": "s3:ListBucketMultipartUploads",
+	"s3:DeleteObjects":        "s3:DeleteObject",
+}
+
+// serviceToAction maps a request to the IAM action a policy must allow,
 // e.g. ("s3", "PutObject") → "s3:PutObject".
-func serviceToAction(service, operation string) string {
-	return service + ":" + operation
+//
+// It is not simply service + ":" + operation. Two things break that identity, and
+// both produce a denial for a caller whose policy is right:
+//
+//   - a handful of operations authorize under a different action name
+//     (operationActionOverrides);
+//   - a few services authorize by HTTP verb instead of operation name
+//     (verbActionServices), so for those the resolved operation name must be
+//     ignored in favor of the verb.
+//
+// req carries the HTTP verb a verb-action service needs; a nil req falls back to
+// the operation name, which is what an in-process caller that never set one has.
+func serviceToAction(req *AWSRequest, service, operation string) string {
+	if verbActionServices[service] {
+		if method := requestMethod(req); method != "" {
+			return service + ":" + method
+		}
+	}
+	action := service + ":" + operation
+	if override, ok := operationActionOverrides[action]; ok {
+		return override
+	}
+	return action
 }
 
 // buildResourceARN constructs a best-effort IAM resource ARN for the request.

--- a/emulator/backup_plugin.go
+++ b/emulator/backup_plugin.go
@@ -39,7 +39,7 @@ func (p *BackupPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches an AWS Backup REST/JSON request to the appropriate handler.
 func (p *BackupPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, vaultName, planID, selectionID := parseBackupOperation(req.Operation, req.Path)
+	op, vaultName, planID, selectionID := parseBackupOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateBackupVault":
 		return p.createBackupVault(reqCtx, req, vaultName)

--- a/emulator/batch_plugin.go
+++ b/emulator/batch_plugin.go
@@ -46,7 +46,7 @@ func (p *BatchPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches a Batch REST/JSON request to the appropriate handler.
 func (p *BatchPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, jobID := parseBatchOperation(req.Operation, req.Path)
+	op, jobID := parseBatchOperation(requestMethod(req), req.Path)
 	switch op {
 	case "SubmitJob":
 		return p.submitJob(ctx, req)

--- a/emulator/bedrock_runtime_plugin.go
+++ b/emulator/bedrock_runtime_plugin.go
@@ -57,7 +57,7 @@ func (p *BedrockRuntimePlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches a Bedrock Runtime request to the appropriate handler.
 func (p *BedrockRuntimePlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, resourceID, version := parseBedrockRuntimeOperation(req.Operation, req.Path)
+	op, resourceID, version := parseBedrockRuntimeOperation(requestMethod(req), req.Path)
 	switch op {
 	case "ApplyGuardrail":
 		return p.applyGuardrail(ctx, req, resourceID, version)

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -3930,6 +3930,16 @@ func (d *StackDeployer) dispatch(
 		Metadata:  map[string]interface{}{"stream_id": streamID},
 	}
 
+	// A template's resource calls are built in this package rather than parsed off
+	// the wire, and 40 of those construction sites name a bare HTTP method ("PUT"
+	// for a bucket, "POST" for a function). ParseAWSRequest resolves the semantic
+	// name for everything arriving over HTTP (#480, #572), but these never pass
+	// through it, so they would be metered, recorded and authorized as "s3:PUT" —
+	// which no policy granting s3:CreateBucket matches. Resolving here reaches
+	// every dispatch site at once, and is a no-op for a request that already
+	// carries a real operation name.
+	resolveOperationName(req)
+
 	start := d.tc.Now()
 	resp, routeErr := d.registry.RouteRequest(reqCtx, req)
 	duration := time.Since(start)

--- a/emulator/cfn_nested_test.go
+++ b/emulator/cfn_nested_test.go
@@ -61,6 +61,11 @@ func newECSDynamoTestDeployer(t *testing.T) (*emulator.StackDeployer, *emulator.
 // read-back through the plugin cannot substitute for it when the question is a
 // member's *name*, because the plugin unmarshals the name it was sent and
 // re-marshals the name its own struct is tagged with.
+//
+// operation is the semantic API operation ("CreateCluster"), not the HTTP verb.
+// A recorded REST event was named after its method until #572 resolved the name
+// before the pipeline read it, which is what made an event log greppable by
+// operation at all.
 func dispatchedBody(t *testing.T, store *emulator.EventStore, service, operation string) []byte {
 	t.Helper()
 	events, err := store.GetEvents(context.Background(), emulator.EventFilter{
@@ -821,7 +826,7 @@ func TestCFN_MSKClientSubnets_Resolved(t *testing.T) {
 			ClientSubnets []string `json:"ClientSubnets"`
 		} `json:"BrokerNodeGroupInfo"`
 	}
-	require.NoError(t, json.Unmarshal(dispatchedBody(t, store, "msk", "POST"), &sent))
+	require.NoError(t, json.Unmarshal(dispatchedBody(t, store, "msk", "CreateCluster"), &sent))
 	assert.Equal(t, "kafka.m5.xlarge", sent.BrokerNodeGroupInfo.InstanceType)
 	assert.Equal(t, []string{"subnet-a", "subnet-b"}, sent.BrokerNodeGroupInfo.ClientSubnets)
 }
@@ -850,7 +855,7 @@ func TestCFN_MSKClientSubnets_AbsentStaysEmptyList(t *testing.T) {
 	_, err := d.Deploy(context.Background(), tmpl, "msk-bare", nil)
 	require.NoError(t, err)
 
-	sent := string(dispatchedBody(t, store, "msk", "POST"))
+	sent := string(dispatchedBody(t, store, "msk", "CreateCluster"))
 	assert.Contains(t, sent, `"ClientSubnets":[]`)
 	assert.NotContains(t, sent, `"ClientSubnets":null`)
 }

--- a/emulator/cloudfront_plugin.go
+++ b/emulator/cloudfront_plugin.go
@@ -43,7 +43,7 @@ func (p *CloudFrontPlugin) Shutdown(_ context.Context) error { return nil }
 // HandleRequest dispatches a CloudFront REST/XML request to the appropriate handler.
 // The operation is derived from the HTTP method and URL path.
 func (p *CloudFrontPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, distID := parseCloudFrontOperation(req.Operation, req.Path, req.Params)
+	op, distID := parseCloudFrontOperation(requestMethod(req), req.Path, req.Params)
 	// Handle GetInvalidation (op includes invID after colon).
 	if strings.HasPrefix(op, "GetInvalidation:") {
 		invID := strings.TrimPrefix(op, "GetInvalidation:")

--- a/emulator/efs_plugin.go
+++ b/emulator/efs_plugin.go
@@ -38,7 +38,7 @@ func (p *EFSPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches an EFS REST/JSON request to the appropriate handler.
 func (p *EFSPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, resourceID := parseEFSOperation(req.Operation, req.Path)
+	op, resourceID := parseEFSOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateFileSystem":
 		return p.createFileSystem(ctx, req)

--- a/emulator/emrserverless_plugin.go
+++ b/emulator/emrserverless_plugin.go
@@ -42,7 +42,7 @@ func (p *EMRServerlessPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches an EMR Serverless REST/JSON request to the appropriate handler.
 func (p *EMRServerlessPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, appID, runID := parseEMRServerlessOperation(req.Operation, req.Path)
+	op, appID, runID := parseEMRServerlessOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateApplication":
 		return p.createApplication(ctx, req)

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -47,6 +47,9 @@ func S3PersistedContentEncodingForTest(headers map[string]string) string {
 // ExtractRegionFromHostForTest wraps extractRegionFromHost for external tests.
 func ExtractRegionFromHostForTest(host string) string { return extractRegionFromHost(host) }
 
+// ResolveOperationNameForTest wraps resolveOperationName for external tests.
+func ResolveOperationNameForTest(req *AWSRequest) { resolveOperationName(req) }
+
 // ExtractAccessKeyFromAuthForTest wraps extractAccessKeyFromAuth for external tests.
 func ExtractAccessKeyFromAuthForTest(authHeader string) string {
 	return extractAccessKeyFromAuth(authHeader)

--- a/emulator/lambda_plugin.go
+++ b/emulator/lambda_plugin.go
@@ -71,7 +71,7 @@ func (p *LambdaPlugin) Shutdown(_ context.Context) error {
 
 // HandleRequest dispatches a Lambda REST API request to the appropriate handler.
 func (p *LambdaPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, name, subResource := parseLambdaOperation(req.Operation, req.Path)
+	op, name, subResource := parseLambdaOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateFunction":
 		return p.createFunction(ctx, req)

--- a/emulator/msk_plugin.go
+++ b/emulator/msk_plugin.go
@@ -37,7 +37,7 @@ func (p *MSKPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches an MSK REST/JSON request to the appropriate handler.
 func (p *MSKPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, clusterARN := parseKafkaOperation(req.Operation, req.Path)
+	op, clusterARN := parseKafkaOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateCluster":
 		return p.createCluster(ctx, req)

--- a/emulator/omics_plugin.go
+++ b/emulator/omics_plugin.go
@@ -44,7 +44,7 @@ func (p *OmicsPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches a HealthOmics REST/JSON request to the appropriate handler.
 func (p *OmicsPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, runID := parseOmicsOperation(req.Operation, req.Path)
+	op, runID := parseOmicsOperation(requestMethod(req), req.Path)
 	switch op {
 	case "StartRun":
 		return p.startRun(ctx, req)

--- a/emulator/operation_names.go
+++ b/emulator/operation_names.go
@@ -1,0 +1,167 @@
+package emulator
+
+import "net/http"
+
+// httpMethodOperations is the set of bare HTTP methods that stand in for an
+// unresolved operation name. A request whose Operation is one of these was named
+// by extractOperation's last-resort fallback, because the service supplied none
+// of the three signals that carry an operation name (X-Amz-Target, an Action
+// parameter, a Smithy RPC v2 path).
+//
+// This is the same set as s3HTTPMethods, kept separate because that one is part
+// of parseS3Operation's idempotence contract and is consulted for a different
+// question — whether the plugin was handed a verb — whereas this one gates the
+// pipeline-wide resolution below.
+var httpMethodOperations = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPut:    true,
+	http.MethodPost:   true,
+	http.MethodDelete: true,
+	http.MethodHead:   true,
+	http.MethodPatch:  true,
+}
+
+// requestMethod returns the HTTP verb of a request.
+//
+// AWSRequest.HTTPMethod carries it for anything that came off the wire. An
+// in-process caller that builds an AWSRequest by hand sets only Operation, and
+// by convention sets it to the verb — so fall back to it, but only when it holds
+// a verb, never when it holds an already-resolved operation name.
+func requestMethod(req *AWSRequest) string {
+	if req.HTTPMethod != "" {
+		return req.HTTPMethod
+	}
+	if httpMethodOperations[req.Operation] {
+		return req.Operation
+	}
+	return ""
+}
+
+// operationResolvers maps a service name to the function that derives its
+// semantic operation name from an AWSRequest.
+//
+// Every entry wraps a resolver the service's plugin already owns and already
+// calls at the top of its HandleRequest. Wrapping rather than reimplementing is
+// the point: there is one definition of "what operation is this", so the name
+// the pipeline authorizes, meters and records cannot drift from the name the
+// plugin routes on.
+//
+// The resolvers are pure functions of the method, path and params — the fields
+// ParseAWSRequest has populated by the time it consults this table — which is
+// what makes resolving there safe. See resolveOperationName.
+var operationResolvers = map[string]func(req *AWSRequest) string{
+	"s3": func(req *AWSRequest) string {
+		_, _, op := parseS3Operation(req)
+		return op
+	},
+	"lambda": func(req *AWSRequest) string {
+		op, _, _ := parseLambdaOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"apigateway": func(req *AWSRequest) string {
+		op, _ := parseAPIGatewayOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"apigatewayv2": func(req *AWSRequest) string {
+		op, _ := parseAPIGatewayV2Operation(requestMethod(req), req.Path)
+		return op
+	},
+	"appsync": func(req *AWSRequest) string {
+		op, _, _, _ := parseAppSyncOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"backup": func(req *AWSRequest) string {
+		op, _, _, _ := parseBackupOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"batch": func(req *AWSRequest) string {
+		op, _ := parseBatchOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"bedrock-runtime": func(req *AWSRequest) string {
+		op, _, _ := parseBedrockRuntimeOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"cloudfront": func(req *AWSRequest) string {
+		op, _ := parseCloudFrontOperation(requestMethod(req), req.Path, req.Params)
+		return op
+	},
+	"efs": func(req *AWSRequest) string {
+		op, _ := parseEFSOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"emrserverless": func(req *AWSRequest) string {
+		op, _, _ := parseEMRServerlessOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"msk": func(req *AWSRequest) string {
+		op, _ := parseKafkaOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"omics": func(req *AWSRequest) string {
+		op, _ := parseOmicsOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"quicksight": func(req *AWSRequest) string {
+		op, _, _, _ := parseQuickSightOperation(requestMethod(req), req.Path)
+		return op
+	},
+	"ram": func(req *AWSRequest) string {
+		return parseRAMOperation(requestMethod(req), req.Path)
+	},
+	"route53": func(req *AWSRequest) string {
+		op, _ := parseRoute53Operation(requestMethod(req), req.Path)
+		return op
+	},
+	"scheduler": func(req *AWSRequest) string {
+		return parseSchedulerOperation(requestMethod(req), req.Path)
+	},
+	"sesv2": func(req *AWSRequest) string {
+		op, _ := parseSESv2Operation(requestMethod(req), req.Path)
+		return op
+	},
+}
+
+// resolveOperationName replaces a bare HTTP method in req.Operation with the
+// service's semantic operation name.
+//
+// A REST-JSON or REST-XML service carries its operation in the shape of its URL
+// and nothing else, so extractOperation falls through to the HTTP method and the
+// request enters the pipeline named "POST". Authorization, fault injection, cost
+// and consistency all read req.Operation before any plugin runs, so each of them
+// saw the verb: a policy granting lambda:InvokeFunction was refused because the
+// action evaluated was lambda:POST (#572), and a fault rule could not name an
+// operation (#480, fixed for S3 alone at the time).
+//
+// Resolving here rather than in each plugin is what keeps the pipeline and the
+// plugin in agreement. It is safe to call more than once: a resolver is only
+// consulted when the operation is still a bare verb, and every resolver returns
+// an already-resolved name unchanged.
+//
+// A resolver that cannot name the request leaves the verb in place, because a
+// verb is a more honest answer than a wrong operation name — an unroutable path
+// must reach the plugin and be refused there, not be authorized as something
+// else. A resolver signals that by returning either "" or the verb it was handed,
+// and both are treated the same way: leave req alone.
+func resolveOperationName(req *AWSRequest) {
+	if req == nil || !httpMethodOperations[req.Operation] {
+		return
+	}
+	resolve := operationResolvers[req.Service]
+	if resolve == nil {
+		return
+	}
+	op := resolve(req)
+	if op == "" || httpMethodOperations[op] {
+		return
+	}
+	// Preserve the verb before overwriting it. An in-process caller — every
+	// CloudFormation resource call — sets only Operation, so the verb lives there
+	// and resolving would consume the one signal the plugin's own resolver needs:
+	// it would then see no method at all and fail to route a request that used to
+	// work.
+	if req.HTTPMethod == "" {
+		req.HTTPMethod = req.Operation
+	}
+	req.Operation = op
+}

--- a/emulator/operation_names_test.go
+++ b/emulator/operation_names_test.go
@@ -1,0 +1,410 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// A REST service names its operation with nothing but the shape of its URL, so
+// extractOperation's last-resort fallback named every such request after its HTTP
+// method. That was inert until #411 made the evaluator reachable; then a policy
+// granting lambda:InvokeFunction was refused, because the action evaluated was
+// lambda:POST (#572). #480 had already fixed this for S3 alone.
+
+// httpVerbs is the set a resolved operation name must not be a member of.
+var httpVerbs = map[string]bool{
+	http.MethodGet: true, http.MethodPut: true, http.MethodPost: true,
+	http.MethodDelete: true, http.MethodHead: true, http.MethodPatch: true,
+}
+
+// parseWire runs a request through the wire parser the way the server does and
+// returns the operation the pipeline sees.
+func parseWire(t *testing.T, method, host, path, body string) *emulator.AWSRequest {
+	t.Helper()
+	r := httptest.NewRequest(method, path, strings.NewReader(body))
+	r.Host = host
+	req, _, err := emulator.ParseAWSRequest(r)
+	require.NoError(t, err)
+	return req
+}
+
+func TestParseAWSRequest_ResolvesRESTOperationNames(t *testing.T) {
+	// One representative operation per REST service. Each of these entered the
+	// pipeline named "POST"/"PUT" before #572, so every row fails on the parent
+	// commit — that is what makes this a gate rather than a description.
+	tests := []struct {
+		name, method, host, path, wantOp string
+	}{
+		{"lambda CreateFunction", "POST", "lambda.us-east-1.amazonaws.com",
+			"/2015-03-31/functions", "CreateFunction"},
+		{"lambda Invoke", "POST", "lambda.us-east-1.amazonaws.com",
+			"/2015-03-31/functions/fn/invocations", "Invoke"},
+		{"lambda DeleteFunction", "DELETE", "lambda.us-east-1.amazonaws.com",
+			"/2015-03-31/functions/fn", "DeleteFunction"},
+		{"apigateway CreateRestApi", "POST", "apigateway.us-east-1.amazonaws.com",
+			"/restapis", "CreateRestApi"},
+		{"apigateway UpdateRestApi", "PATCH", "apigateway.us-east-1.amazonaws.com",
+			"/restapis/abc", "UpdateRestApi"},
+		{"apigatewayv2 CreateApi", "POST", "apigateway.us-east-1.amazonaws.com",
+			"/v2/apis", "CreateApi"},
+		{"appsync CreateGraphqlApi", "POST", "appsync.us-east-1.amazonaws.com",
+			"/v1/apis", "CreateGraphqlApi"},
+		{"efs CreateFileSystem", "POST", "elasticfilesystem.us-east-1.amazonaws.com",
+			"/2015-02-01/file-systems", "CreateFileSystem"},
+		{"route53 CreateHostedZone", "POST", "route53.amazonaws.com",
+			"/2013-04-01/hostedzone", "CreateHostedZone"},
+		{"sesv2 CreateEmailIdentity", "POST", "email.us-east-1.amazonaws.com",
+			"/v2/email/identities", "CreateEmailIdentity"},
+		{"cloudfront CreateDistribution", "POST", "cloudfront.amazonaws.com",
+			"/2020-05-31/distribution", "CreateDistribution"},
+		{"msk CreateCluster", "POST", "kafka.us-east-1.amazonaws.com",
+			"/v1/clusters", "CreateCluster"},
+		{"omics StartRun", "POST", "omics.us-east-1.amazonaws.com",
+			"/run", "StartRun"},
+		{"scheduler CreateSchedule", "POST", "scheduler.us-east-1.amazonaws.com",
+			"/schedules/nightly", "CreateSchedule"},
+		{"emrserverless CreateApplication", "POST", "emr-serverless.us-east-1.amazonaws.com",
+			"/applications", "CreateApplication"},
+		{"bedrock-runtime InvokeModel", "POST", "bedrock-runtime.us-east-1.amazonaws.com",
+			"/model/anthropic.claude-v2/invoke", "InvokeModel"},
+		// S3 is the precedent (#480) and must keep working.
+		{"s3 CreateBucket", "PUT", "s3.us-east-1.amazonaws.com",
+			"/mybucket", "CreateBucket"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := parseWire(t, tt.method, tt.host, tt.path, "{}")
+			assert.Equal(t, tt.wantOp, req.Operation,
+				"the pipeline must see the API operation, not the HTTP verb")
+			assert.Equal(t, tt.method, req.HTTPMethod,
+				"the verb is preserved separately, because a REST resolver keys on verb and path")
+		})
+	}
+}
+
+func TestParseAWSRequest_LeavesUnresolvableOperationsAlone(t *testing.T) {
+	// A verb is a more honest answer than a wrong operation name: an unroutable
+	// path must reach the plugin and be refused there, not be authorized as
+	// something else.
+	tests := []struct {
+		name, method, host, path string
+	}{
+		{"a lambda path no resolver claims", "POST",
+			"lambda.us-east-1.amazonaws.com", "/2015-03-31/no-such-collection"},
+		{"a service with no resolver at all", "POST",
+			"unknownservice.us-east-1.amazonaws.com", "/whatever"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := parseWire(t, tt.method, tt.host, tt.path, "{}")
+			assert.NotEmpty(t, req.Operation, "an unresolved operation is still named")
+			// HTTPMethod is the verb of the request unconditionally, whether or not
+			// the name resolved. resolveOperationName also backfills it, which makes
+			// this incidentally true for the 18 services that have a resolver — so
+			// assert it where nothing backfills, or the field's contract holds only
+			// by accident and the next REST service added without a table entry
+			// reaches its plugin with no verb at all.
+			assert.Equal(t, tt.method, req.HTTPMethod,
+				"the verb is recorded off the wire, not derived from resolution")
+			if !httpVerbs[req.Operation] {
+				// A resolver that answers UnknownOperation is also acceptable — what
+				// must not happen is a *different* real operation's name.
+				assert.NotContains(t, []string{"CreateFunction", "Invoke", "DeleteFunction"},
+					req.Operation, "an unroutable path must not borrow another operation's name")
+			}
+		})
+	}
+}
+
+func TestParseAWSRequest_OperationResolutionIsIdempotent(t *testing.T) {
+	// The load-bearing property. Each plugin still resolves at the top of its own
+	// HandleRequest, so resolution happens twice for every wire request; if the
+	// second pass did not agree with the first, routing would break. That is why
+	// the verb lives in HTTPMethod rather than being overwritten in Operation.
+	tests := []struct {
+		name, method, host, path string
+	}{
+		{"lambda", "POST", "lambda.us-east-1.amazonaws.com", "/2015-03-31/functions/fn/invocations"},
+		{"apigateway", "POST", "apigateway.us-east-1.amazonaws.com", "/restapis"},
+		{"appsync", "POST", "appsync.us-east-1.amazonaws.com", "/v1/apis"},
+		{"route53", "POST", "route53.amazonaws.com", "/2013-04-01/hostedzone"},
+		{"s3", "PUT", "s3.us-east-1.amazonaws.com", "/mybucket"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := parseWire(t, tt.method, tt.host, tt.path, "{}")
+			first := req.Operation
+			require.False(t, httpVerbs[first], "precondition: the name resolved")
+
+			// Resolving again must be a no-op, however many times it runs.
+			for range 3 {
+				emulator.ResolveOperationNameForTest(req)
+				assert.Equal(t, first, req.Operation, "resolution must be idempotent")
+			}
+		})
+	}
+}
+
+func TestCheckAccess_EvaluatesTheRealActionName(t *testing.T) {
+	// #572's consequence, and the reason it blocks the release: with the evaluator
+	// now reachable, a scoped policy naming the real action was denied because the
+	// action evaluated was <service>:POST. A wildcard policy masked it, so only a
+	// scoped one measures anything.
+	tests := []struct {
+		name      string
+		allow     []string
+		method    string
+		host      string
+		path      string
+		wantAllow bool
+		wantInMsg string
+	}{
+		{
+			// The headline case. Before #572 this was denied.
+			name:      "a policy naming Invoke allows an invoke",
+			allow:     []string{"lambda:InvokeFunction"},
+			method:    "POST",
+			host:      "lambda.us-east-1.amazonaws.com",
+			path:      "/2015-03-31/functions/fn/invocations",
+			wantAllow: true,
+		},
+		{
+			// The denial must still happen, and must name the action a reader can
+			// act on — a message saying "lambda:POST" tells them nothing to fix.
+			name:      "a policy without Invoke denies it by its real name",
+			allow:     []string{"lambda:GetFunction"},
+			method:    "POST",
+			host:      "lambda.us-east-1.amazonaws.com",
+			path:      "/2015-03-31/functions/fn/invocations",
+			wantAllow: false,
+			wantInMsg: "lambda:InvokeFunction",
+		},
+		{
+			// Two operations that share a verb and differ only by path must be
+			// separately grantable, which is the whole point of resolving the name.
+			name:      "CreateFunction and Invoke are distinct grants",
+			allow:     []string{"lambda:CreateFunction"},
+			method:    "POST",
+			host:      "lambda.us-east-1.amazonaws.com",
+			path:      "/2015-03-31/functions/fn/invocations",
+			wantAllow: false,
+			wantInMsg: "lambda:InvokeFunction",
+		},
+		{
+			// API Gateway v1 is the exception that makes this service-specific: its
+			// Service Authorization Reference defines apigateway:GET/POST/PUT/…
+			// and no apigateway:CreateRestApi at all, because permissions map to the
+			// HTTP method used against a management resource. So resolving the
+			// operation name must not change the action here.
+			name:      "an apigateway policy naming the verb allows it",
+			allow:     []string{"apigateway:POST"},
+			method:    "POST",
+			host:      "apigateway.us-east-1.amazonaws.com",
+			path:      "/restapis",
+			wantAllow: true,
+		},
+		{
+			name:      "an apigateway policy naming an operation does not grant it",
+			allow:     []string{"apigateway:CreateRestApi"},
+			method:    "POST",
+			host:      "apigateway.us-east-1.amazonaws.com",
+			path:      "/restapis",
+			wantAllow: false,
+			wantInMsg: "apigateway:POST",
+		},
+		{
+			// apigatewayv2 is a different service prefix and does use operation
+			// names, so the two must not be conflated.
+			name:      "an apigatewayv2 policy naming CreateApi allows it",
+			allow:     []string{"apigatewayv2:CreateApi"},
+			method:    "POST",
+			host:      "apigateway.us-east-1.amazonaws.com",
+			path:      "/v2/apis",
+			wantAllow: true,
+		},
+		{
+			// S3's list operations authorize against the bucket, not the listing:
+			// "You must have permission to perform the s3:ListBucket action".
+			name:      "s3:ListBucket allows a ListObjectsV2",
+			allow:     []string{"s3:ListBucket"},
+			method:    "GET",
+			host:      "mybucket.s3.us-east-1.amazonaws.com",
+			path:      "/?list-type=2",
+			wantAllow: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := emulator.NewMemoryStateManager()
+			seedUserWithPolicy(t, state, "alice", tt.allow)
+
+			auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(0, false))
+			req := parseWire(t, tt.method, tt.host, tt.path, "{}")
+			reqCtx := &emulator.RequestContext{
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+				Principal: &emulator.Principal{
+					ARN:  "arn:aws:iam::123456789012:user/alice",
+					Type: "User",
+				},
+			}
+
+			err := auth.CheckAccess(reqCtx, req)
+			if tt.wantAllow {
+				assert.NoError(t, err, "a policy naming the real action must allow it")
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantInMsg,
+				"the denial must name the action a caller has to grant")
+		})
+	}
+}
+
+// seedUserWithPolicy writes an IAM user and an attached policy allowing actions
+// on every resource. Written straight to state because what is under test is the
+// evaluation, not IAM's own request handling.
+func seedUserWithPolicy(t *testing.T, state emulator.StateManager, user string, actions []string) {
+	t.Helper()
+	ctx := t.Context()
+
+	userRaw, err := json.Marshal(emulator.IAMUser{
+		UserName: user,
+		ARN:      "arn:aws:iam::123456789012:user/" + user,
+		Path:     "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "user:"+user, userRaw))
+
+	policyARN := "arn:aws:iam::123456789012:policy/" + user + "Policy"
+	arnsRaw, err := json.Marshal([]string{policyARN})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "user_policies:"+user, arnsRaw))
+
+	polRaw, err := json.Marshal(emulator.IAMPolicy{
+		PolicyName: user + "Policy",
+		ARN:        policyARN,
+		Document: emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice(actions),
+				Resource: emulator.StringOrSlice{"*"},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+}
+
+func TestFaultRule_CanNameARESTOperation(t *testing.T) {
+	// #480's complaint, for the 17 services its S3-only fix did not reach: a rule
+	// naming an operation matched nothing, because the request was named after its
+	// HTTP method — while a rule naming "POST" took out every call to the service
+	// at once.
+	ts := emulator.StartTestServer(t)
+
+	cfg := `{"enabled":true,"rules":[{"service":"lambda","operation":"CreateFunction",` +
+		`"fault_type":"error","error_code":"ServiceException","http_status":500}]}`
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		ts.URL+"/v1/fault/rules", strings.NewReader(cfg))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The operation the rule names must be hit...
+	create := lambdaCall(t, ts, http.MethodPost, "/2015-03-31/functions",
+		`{"FunctionName":"fn","Runtime":"python3.12","Handler":"h",`+
+			`"Role":"arn:aws:iam::123456789012:role/r","Code":{"ZipFile":"eA=="}}`)
+	assert.Equal(t, http.StatusInternalServerError, create,
+		"a rule naming CreateFunction must match the create")
+
+	// ...and an operation it does not name, on the same service, must not be. Before
+	// #572 both were named "POST", so no rule could tell them apart.
+	list := lambdaCall(t, ts, http.MethodGet, "/2015-03-31/functions", "")
+	assert.NotEqual(t, http.StatusInternalServerError, list,
+		"the rule must not take out every call to the service")
+}
+
+// lambdaCall issues a Lambda REST request with the Host header the parser needs
+// to resolve the service, and returns the status code.
+func lambdaCall(t *testing.T, ts *emulator.TestServer, method, path, body string) int {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), method, ts.URL+path, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Host = "lambda.us-east-1.amazonaws.com"
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	return resp.StatusCode
+}
+
+func TestCFNDispatch_RecordsRealOperationNames(t *testing.T) {
+	// A template's resource calls are built in-process, so they never pass through
+	// ParseAWSRequest: a bucket was dispatched as "PUT" and a function as "POST".
+	// That is what made a CloudFormation stack's calls unauthorizable against a
+	// real policy — s3:PUT matches no grant a consumer would write — and it is why
+	// the deployer resolves the name too.
+	d, store := newS3TestDeployer(t)
+
+	const template = `{"Resources":{"Data":{"Type":"AWS::S3::Bucket",` +
+		`"Properties":{"BucketName":"opname-bucket"}}}}`
+	result, err := d.Deploy(t.Context(), template, "opnames", nil)
+	require.NoError(t, err)
+	require.Empty(t, findResource(t, result, "Data").Error)
+
+	events, err := store.GetEvents(t.Context(), emulator.EventFilter{Service: "s3"})
+	require.NoError(t, err)
+	require.NotEmpty(t, events, "the deploy must have dispatched an S3 call")
+
+	var names []string
+	for _, ev := range events {
+		if ev.Request != nil {
+			names = append(names, ev.Request.Operation)
+		}
+	}
+	assert.Contains(t, names, "CreateBucket",
+		"a stack's bucket creation is recorded and authorized as CreateBucket, not PUT")
+	assert.NotContains(t, names, "PUT",
+		"no dispatched call may reach the pipeline named after its HTTP verb")
+}
+
+// newS3TestDeployer builds a StackDeployer with only the S3 plugin registered and
+// an in-memory event store, which is the view of what a deploy actually dispatched.
+func newS3TestDeployer(t *testing.T) (*emulator.StackDeployer, *emulator.EventStore) {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled: true, Backend: "memory", IncludeBodies: true,
+	})
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+
+	p := &emulator.S3Plugin{}
+	require.NoError(t, p.Initialize(t.Context(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(p)
+
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs), store
+}

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -111,27 +111,26 @@ func ParseAWSRequest(r *http.Request) (*AWSRequest, *RequestContext, error) {
 	account := extractAccount(authHeader)
 
 	req := &AWSRequest{
-		Service:   service,
-		Operation: operation,
-		Headers:   headers,
-		Params:    params,
-		Path:      effectivePath,
+		Service:    service,
+		Operation:  operation,
+		HTTPMethod: r.Method,
+		Headers:    headers,
+		Params:     params,
+		Path:       effectivePath,
 	}
 
-	// S3 supplies none of extractOperation's first three signals, so it fell
-	// through to the HTTP-method fallback and every S3 request entered the
-	// pipeline named "PUT"/"GET"/"POST"/"DELETE"/"HEAD". The plugin resolved the
-	// semantic name, but not until it handled the request — one step after fault
-	// injection, cost and consistency had already read req.Operation. A fault
-	// rule naming PutObject therefore matched nothing while a rule naming PUT
-	// took out UploadPart too (#480). parseS3Operation is pure and depends only
-	// on fields already populated above, so resolving here makes the canonical
-	// name available to every step.
-	if service == "s3" {
-		if _, _, op := parseS3Operation(req); op != "" {
-			req.Operation = op
-		}
-	}
+	// A REST service supplies none of extractOperation's first three signals, so
+	// it fell through to the HTTP-method fallback and every request entered the
+	// pipeline named "PUT"/"GET"/"POST"/"DELETE"/"HEAD"/"PATCH". The plugin
+	// resolved the semantic name, but not until it handled the request — one step
+	// after authorization, fault injection, cost and consistency had already read
+	// req.Operation. A fault rule naming PutObject therefore matched nothing while
+	// a rule naming PUT took out UploadPart too (#480), and a policy granting
+	// lambda:InvokeFunction was refused because the action evaluated was
+	// lambda:POST (#572). The resolvers are pure and depend only on the fields
+	// populated above, so resolving here makes the canonical name available to
+	// every step. #480 did this for S3 alone; #572 generalized it to the rest.
+	resolveOperationName(req)
 
 	reqCtx := &RequestContext{
 		RequestID: generateRequestID(),

--- a/emulator/quicksight_plugin.go
+++ b/emulator/quicksight_plugin.go
@@ -43,7 +43,7 @@ func (p *QuickSightPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches a QuickSight REST/JSON request to the appropriate handler.
 func (p *QuickSightPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, accountID, resourceID, secondaryID := parseQuickSightOperation(req.Operation, req.Path)
+	op, accountID, resourceID, secondaryID := parseQuickSightOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateDataSource":
 		return p.createDataSource(ctx, req, accountID)

--- a/emulator/ram_plugin.go
+++ b/emulator/ram_plugin.go
@@ -38,7 +38,7 @@ func (p *RAMPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches a RAM REST/JSON request to the appropriate handler.
 func (p *RAMPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op := parseRAMOperation(req.Operation, req.Path)
+	op := parseRAMOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateResourceShare":
 		return p.createResourceShare(reqCtx, req)

--- a/emulator/route53_plugin.go
+++ b/emulator/route53_plugin.go
@@ -51,7 +51,7 @@ func (p *Route53Plugin) Shutdown(_ context.Context) error { return nil }
 // HandleRequest dispatches a Route 53 REST/XML request to the appropriate handler.
 // The operation is derived from the HTTP method and URL path.
 func (p *Route53Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, zoneID := parseRoute53Operation(req.Operation, req.Path)
+	op, zoneID := parseRoute53Operation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateHostedZone":
 		return p.createHostedZone(ctx, req)

--- a/emulator/scheduler_plugin.go
+++ b/emulator/scheduler_plugin.go
@@ -105,7 +105,7 @@ func (p *SchedulerPlugin) Shutdown(_ context.Context) error { return nil }
 // HandleRequest dispatches an EventBridge Scheduler REST/JSON request to the
 // appropriate handler using path-based operation routing.
 func (p *SchedulerPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op := parseSchedulerOperation(req.Operation, req.Path)
+	op := parseSchedulerOperation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateSchedule":
 		return p.createSchedule(ctx, req)

--- a/emulator/sesv2_plugin.go
+++ b/emulator/sesv2_plugin.go
@@ -40,7 +40,7 @@ func (p *SESv2Plugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches an SES v2 REST/JSON request to the appropriate handler.
 func (p *SESv2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	op, identityName := parseSESv2Operation(req.Operation, req.Path)
+	op, identityName := parseSESv2Operation(requestMethod(req), req.Path)
 	switch op {
 	case "CreateEmailIdentity":
 		return p.createEmailIdentity(ctx, req)

--- a/emulator/types.go
+++ b/emulator/types.go
@@ -14,7 +14,23 @@ type AWSRequest struct {
 	Service string
 
 	// Operation is the API operation name (e.g., "PutObject", "CreateUser").
+	//
+	// For a REST service the operation is carried by the shape of the URL and
+	// nothing else, so ParseAWSRequest derives it from Method and Path (#480,
+	// #572). Until that resolution succeeds — and for an in-process caller that
+	// builds an AWSRequest by hand — this may still hold a bare HTTP method, which
+	// is why HTTPMethod exists separately: resolving Operation must not destroy the
+	// verb the resolvers need.
 	Operation string
+
+	// HTTPMethod is the verb of the underlying HTTP request ("GET", "PUT", …).
+	//
+	// It is set by ParseAWSRequest and is what a REST plugin's path resolver keys
+	// on, because a REST operation is identified by verb *and* path: POST and
+	// DELETE on /v1/apis/{id} are different operations. Empty for an in-process
+	// AWSRequest built by hand, in which case Operation carries the verb; use
+	// requestMethod to read whichever holds it.
+	HTTPMethod string
 
 	// Headers contains HTTP request headers, including AWS authentication headers.
 	Headers map[string]string


### PR DESCRIPTION
A REST-JSON or REST-XML service carries its operation in the shape of its URL and
nowhere else, so `extractOperation` fell through to its last-resort HTTP-method
fallback and the request entered the pipeline named `POST`. Authorization, fault
injection, cost and consistency all read `req.Operation` **before any plugin
runs**, while each plugin resolved the real name only at the top of its own
`HandleRequest` — one step too late.

Measured on the parent commit (`87a966f`), **17 of 18 REST services** were
affected. S3 was the only exception, because #480 had wired its resolver in for
exactly this reason.

## Why this blocks the release

The defect was inert while the evaluator was unreachable, and stopped being inert
with #411 (merged, unreleased). A user holding `lambda:InvokeFunction` was refused
an invoke, because the action evaluated was `lambda:POST`. A wildcard policy masks
it, so it is precisely the *scoped* policy #411 exists to let a consumer test that
gets a false `AccessDeniedException` — the inverse of the release's headline claim.
Transcript from a throwaway probe at `87a966f`:

```
policy: Allow lambda:InvokeFunction on *
POST /2015-03-31/functions/fn/invocations
  → AccessDeniedException: not authorized to perform: lambda:POST
```

## The fix

Resolve the operation name **once, before the pipeline reads it** — generalizing
#480 instead of repeating it 17 times. Every entry in the new
`operationResolvers` table wraps a resolver the service's plugin already owns and
already calls, rather than reimplementing it, so there is one definition of "what
operation is this" and the name the pipeline authorizes, meters and records cannot
drift from the name the plugin routes on.

`AWSRequest` gains `HTTPMethod`. This is the root modeling error: the verb and the
operation had been sharing one field, so resolving the operation *destroyed* the
verb that all 17 REST resolvers key on — `POST` and `DELETE` on the same path are
different operations. The alternative was 17 defensive guards; splitting the field
is the fix that leaves each resolver's contract intact, and the whole existing
suite went green with no test edits beyond the one intentional behaviour change
noted below.

CloudFormation's resource calls are built in-process and never pass through
`ParseAWSRequest`, so `dispatch` resolves too — otherwise a stack's bucket is
authorized as `s3:PUT`, which matches no policy a consumer would write.

## The IAM action is not always the operation name

Treating it as such denies a caller whose policy is right, so the mapping is
explicit and each entry was checked against the AWS documentation rather than
assumed:

| Operation | Action a policy must name |
|---|---|
| `lambda:Invoke` | `lambda:InvokeFunction` |
| `s3:ListObjects` / `ListObjectsV2` / `HeadBucket` | `s3:ListBucket` |
| `s3:ListBuckets` | `s3:ListAllMyBuckets` |
| `s3:ListObjectVersions` | `s3:ListBucketVersions` |
| `s3:ListMultipartUploads` | `s3:ListBucketMultipartUploads` |
| `s3:DeleteObjects` | `s3:DeleteObject` |

**API Gateway v1 is the sharp case.** Its Service Authorization Reference defines
`apigateway:GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS` and **no**
`apigateway:CreateRestApi` — its IAM actions genuinely *are* HTTP verbs. So for
that service the verb remains the action, while `apigatewayv2` is a separate
prefix that does use operation names. Blind resolution would have broken v1 in the
act of fixing the other 16; I had this wrong in a first draft of the tests and the
docs caught it.

## Two pre-existing consequences, also fixed

- **Fault rules.** A rule can now name a REST operation, closing #480's gap for
  the 17 services its S3-only fix never reached. Before this, a rule naming `POST`
  took out every call to the service at once.
- **The event log.** A recorded event now carries its operation, so a log is
  greppable by operation. This is the one intentional behaviour change to an
  existing test: `dispatchedBody(t, store, "msk", "POST")` became
  `"CreateCluster"`, and the helper's doc comment says why.

## Compatibility

**The action strings a policy must name have changed.** A REST call is now
authorized as its real operation rather than as its HTTP verb, and the renames in
the table above apply. A caller whose policy named `lambda:POST` (which no AWS
policy would) is now denied; a caller whose policy named `lambda:InvokeFunction`
(which every real policy does) is now correctly allowed. A recorded event's
operation for a REST service changes accordingly. Anything with a wildcard policy,
a nil principal, or a credential that resolves to no IAM entity is unaffected.

## Verification

- **Baseline:** 28 subtests fail at `87a966f` and pass here.
- **Mutation testing** — 8 mutants, each reversing one load-bearing decision:
  **8 CAUGHT, 0 survivors, 0 broken.** Two rounds were needed. The first found a
  real gap: `HTTPMethod`'s contract held only *incidentally*, because
  `resolveOperationName` backfills the field, so a REST service added later
  without a table entry would have reached its plugin with no verb at all. Now
  asserted where nothing backfills. One mutant (`resolveOperationName`'s
  resolved-name guard) was provably equivalent — every resolver echoes back the
  verb it was handed, never a different one — so rather than leave an unmeasurable
  branch, the now-unused `bool` return was dropped and the `""`-or-verb contract
  documented.
- `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0
  issues**, `make test` (race), `make docs-reference docs-reference-check
  docs-versions` (65 plugins, no change), `go vet -C test/e2e ./...`,
  `go test -C test/e2e ./...` — all green.

## Provenance

The 17-service list and the false-denial transcript above were **measured** with
throwaway in-package probes against `87a966f`, not read off a reference. The
action-name mappings and the API Gateway v1 verb-action behaviour are from the AWS
API and Service Authorization references.

Closes #572
