### PR TITLE
feat(cloudformation): authorize a stack's resource calls and model its service role (#411, #562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A CloudFormation stack's service role** (#562). `RoleARN` is now accepted on
+  `CreateStack`, `UpdateStack` and `DeleteStack`, stored on the stack, and reported
+  by `DescribeStacks` — the four places the API model carries it. A stack's resource
+  calls are made as that role, which is what makes "the deploy role is missing a
+  permission" a failure a composition test can observe rather than something a real
+  deployment discovers.
+
+  The documented lifetime rules are modelled rather than the convenient ones. A
+  service role governs "all future operations on the stack", so an `UpdateStack`
+  that omits `RoleARN` keeps the stored role instead of clearing it. A
+  `DeleteStack`'s `RoleARN` applies to **that operation only** and is not persisted
+  — otherwise a delete refused by its override would silently re-attribute the
+  stack, and a retried delete would run as a different identity than the first
+  attempt. A stack with no role reports none at all (`omitempty`, per the model),
+  and `RoleARN` is length-validated as the model specifies.
+
+  Absent a service role, CloudFormation uses "a temporary session that's generated
+  from your user credentials", so the creating principal is recorded on the stack
+  and its resource calls are attributed to it. Without that, `CreateStack` would be
+  a way to launder a permission the caller does not have. Resolution order is
+  service role → creating principal → nothing, in one place, so create, update,
+  rollback and delete cannot disagree: a resource created by a role is deleted by
+  that role, and a rollback's sweep runs as the identity that created what it is
+  tearing down.
+
+  Both new fields are `omitempty`, so recorded runs replay.
+
 ### Fixed
 - **A REST service is no longer named after its HTTP method, so a correct policy
   is no longer denied** (#572). A REST-JSON or REST-XML service carries its
@@ -149,6 +177,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A role that the session names but that does not exist in state is still not
   enforced, so this reaches only sessions minted against a role substrate actually
   holds.
+
+- **A CloudFormation stack's resource calls are now authorized** (#411, #562). They
+  were dispatched with no principal at all, and `PluginRegistry.RouteRequest` — the
+  path every in-process deploy routes through — never authorized anything. So a
+  template asking for a permission the deploying identity did not have deployed
+  cleanly. This is the release's other half, and no amount of principal resolution
+  reached it: authorization now happens in the deployer, which every create, update,
+  rollback and delete sweep passes through, so there is no second path to keep in
+  step.
+
+  A denial is reported through the existing machinery with no new model: the
+  resource records the error, `DescribeStackResources` renders it as `CREATE_FAILED`
+  with the denial — naming the action that was refused — as
+  `ResourceStatusReason`, and the stack rolls back. It is **not** yet a
+  `StackEvent`; `DescribeStackEvents` is still refused with `UnsupportedOperation`,
+  and deriving events from the event store is #501's question.
+
+  A stack with no service role and no resolvable creating principal deploys exactly
+  as before, which is every existing test and every in-process `Client` caller.
 
 ## [v0.91.0] - 2026-08-04
 

--- a/cmd/substrate/main.go
+++ b/cmd/substrate/main.go
@@ -107,7 +107,14 @@ configured address will have their requests emulated and recorded.`,
 
 			initCtx := context.Background()
 
-			if err := substrate.RegisterDefaultPlugins(initCtx, registry, state, tc, logger, store, cfg); err != nil {
+			// Built before the plugins because CloudFormation takes it: a stack's
+			// resource calls are dispatched in process rather than through the server,
+			// so they are authorized by the controller the plugin holds rather than by
+			// the one ServerOptions.Auth names. It is the same controller either way.
+			authCtrl := substrate.NewAuthController(state, logger)
+
+			if err := substrate.RegisterDefaultPlugins(initCtx, registry, state, tc, logger, store, cfg,
+				substrate.WithPluginAuth(authCtrl)); err != nil {
 				return err
 			}
 
@@ -147,8 +154,6 @@ configured address will have their requests emulated and recorded.`,
 			if cfg.Fault.Enabled || len(cfg.Fault.Rules) > 0 {
 				faultCtrl = substrate.NewFaultController(cfg.Fault.ToFaultConfig(), time.Now().UnixNano())
 			}
-
-			authCtrl := substrate.NewAuthController(state, logger)
 
 			var metricsCollector *substrate.MetricsCollector
 			if cfg.Metrics.Enabled {

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -298,6 +298,79 @@ type CFNStackState struct {
 	// ROLLBACK_FAILED with the resources gone. So its presence does not by itself
 	// mean failure — the Status says which.
 	ResourceDeletions []CFNResourceDeletion `json:"ResourceDeletions,omitempty"`
+
+	// RoleARN is the IAM service role CloudFormation assumes to make the stack's
+	// resource calls, empty when the stack has none.
+	//
+	// Persisted because it outlives the operation that set it: CloudFormation
+	// "always uses this role for all future operations on the stack", and an
+	// UpdateStack that omits RoleARN "uses the role that was previously associated
+	// with the stack" rather than reverting to the caller's own permissions. A
+	// DeleteStack's RoleARN is the exception and is deliberately not written here —
+	// it applies to that operation only.
+	RoleARN string `json:"RoleARN,omitempty"`
+
+	// CreatorPrincipalARN is the principal that created the stack, empty when the
+	// creating call had none.
+	//
+	// This is the principal a resource call runs as when the stack has no service
+	// role, which is CloudFormation's own model: absent a role it uses "a temporary
+	// session that's generated from your user credentials". Recording it is what
+	// makes a rollback's deletes run as the identity that created the stack rather
+	// than unauthorized — the alternative, an exempt service principal, would
+	// reintroduce exactly the blind spot #411 exists to remove, since a rollback
+	// would then be able to delete what the creator could not.
+	CreatorPrincipalARN string `json:"CreatorPrincipalARN,omitempty"`
+}
+
+// attribution returns who the stack's resource calls are made as, from what was
+// persisted about the stack.
+//
+// This is the reader that makes a later operation on a stack — an update that omits
+// RoleARN, a delete, a rollback's sweep — run as whatever the stack was created
+// with rather than as whoever happens to be asking now.
+func (s CFNStackState) attribution() cfnAttribution {
+	att := cfnAttribution{roleARN: s.RoleARN}
+	if s.CreatorPrincipalARN != "" {
+		att.creator = &Principal{
+			ARN:  s.CreatorPrincipalARN,
+			Type: cfnPrincipalType(s.CreatorPrincipalARN),
+		}
+	}
+	return att
+}
+
+// setAttribution records the attribution a deployment ran under, so a later
+// operation on the stack resolves the same one.
+//
+// The inverse of [CFNStackState.attribution], and paired with it so the two fields
+// are written in one place: a stack whose RoleARN was persisted but whose creator
+// was not would silently fall back to unauthorized the moment its role was removed.
+func (s *CFNStackState) setAttribution(att cfnAttribution) {
+	s.RoleARN = att.roleARN
+	if att.creator != nil {
+		s.CreatorPrincipalARN = att.creator.ARN
+	}
+}
+
+// cfnPrincipalType labels an ARN with the Principal.Type it describes.
+//
+// Nothing evaluates Type — authorization resolves the ARN — so this exists to keep
+// a recorded event readable rather than to decide anything. Deriving it beats
+// storing it: the type is a property of the ARN, and a stored one could disagree
+// with the ARN it sits beside after a replay of a run recorded by an older build.
+func cfnPrincipalType(arn string) string {
+	entityType, _ := parsePrincipalARN(arn)
+	switch entityType {
+	case "role":
+		return "Role"
+	case "assumed-role":
+		return "AssumedRole"
+	case "user":
+		return "User"
+	default:
+		return "Service"
+	}
 }
 
 // exports returns the stack's export name → resolved value map, joining
@@ -801,9 +874,12 @@ var typePriority = map[string]int{
 //
 // Two strings rather than a whole *RequestContext: a deployer that carried one
 // would carry a single request's ID and timestamp across every resource it
-// deploys, which is wrong — each dispatch generates its own — and would invite a
-// future reader to propagate Principal, which is a separate decision about how
-// stack-deployed requests are authorized.
+// deploys, which is wrong — each dispatch generates its own. The separate
+// decision this comment used to defer — how a stack-deployed request is
+// authorized — is now [WithDeployerPrincipal], which is deliberately its own
+// option: identity says which partition a resource is written into, the principal
+// says whose permissions creating it required, and a stack can change the second
+// per operation (a service role) without touching the first.
 type cfnIdentity struct {
 	accountID string
 	region    string
@@ -824,6 +900,16 @@ type StackDeployer struct {
 	// pseudo-parameters resolve to. It defaults to substrate's own defaults; see
 	// WithDeployerIdentity for why a caller would set it.
 	identity cfnIdentity
+
+	// attribution is who every request this deployer dispatches is made as. Zero
+	// means unauthorized, which is what every in-process caller was before it
+	// existed. See WithDeployerAttribution.
+	attribution cfnAttribution
+
+	// auth evaluates each dispatched request against principal's policies, or is
+	// nil to authorize nothing. Taken from PluginConfig.Options["auth_controller"]
+	// the same way event_store and cost_controller are.
+	auth *AuthController
 }
 
 // StackDeployerOption configures optional behavior of a [StackDeployer].
@@ -849,10 +935,76 @@ func WithDeployerIdentity(accountID, region string) StackDeployerOption {
 	}
 }
 
+// cfnAttribution is who a stack's resource calls are made as: a service role if
+// the stack has one, otherwise the identity that created it.
+//
+// Both are carried rather than one resolved principal because they are not
+// interchangeable and the difference is observable. A roleARN is the answer for
+// every future operation on the stack whoever asks for it, while creator is only
+// the answer while the stack has no role — so an update that attaches a role must
+// change what the stack's calls are attributed to, and one that omits it must not.
+// Resolving in one place ([cfnAttribution.resolve]) is what keeps that rule from
+// being restated at each call site.
+type cfnAttribution struct {
+	roleARN string
+	creator *Principal
+}
+
+// resolve returns the principal to dispatch as, or nil for unauthorized.
+//
+// The service role wins, because that is what a service role is: CloudFormation
+// "always uses this role for all future operations on the stack". A roleARN is used
+// directly as a role principal — the evaluator's role path resolves it — rather
+// than run through AssumeRole, since the observation being modeled is that a call
+// was denied, not role-assumption machinery.
+func (a cfnAttribution) resolve() *Principal {
+	if a.roleARN != "" {
+		return &Principal{ARN: a.roleARN, Type: cfnPrincipalType(a.roleARN)}
+	}
+	return a.creator
+}
+
+// WithDeployerAttribution sets who the deployer's resource calls are made as, and
+// therefore whose policies they are authorized against.
+//
+// CloudFormation does not create resources as itself: absent a service role it uses
+// "a temporary session that's generated from your user credentials", and with one it
+// "always uses this role for all future operations on the stack". So a stack's
+// resource calls have an answerable principal, and modeling it is what makes a
+// template asking for something the deploying identity cannot do fail the way it
+// fails on AWS — the failure class ("forgot a permission / policy too narrow") that
+// a green composition test could not catch, because a stack's calls carried no
+// principal at all and PluginRegistry.RouteRequest never authorizes.
+//
+// Both zero, the default, dispatches unauthorized, which is what every in-process
+// caller did before this option existed. That default is deliberate rather than
+// conservative: authorization only means something once a caller has said which
+// identity a deployment is on behalf of, and a deployer a test constructs directly
+// has not.
+func WithDeployerAttribution(roleARN string, creator *Principal) StackDeployerOption {
+	return func(d *StackDeployer) {
+		d.attribution = cfnAttribution{roleARN: roleARN, creator: creator}
+	}
+}
+
+// WithDeployerAuth sets the controller that authorizes each dispatched request.
+//
+// Separate from [WithDeployerAttribution] because the two arrive from different
+// places: attribution is a property of one stack operation, while the controller is
+// a server-lifetime dependency the CloudFormation plugin receives in its
+// PluginConfig. Nil authorizes nothing, so a deployer given an attribution and no
+// controller records who deployed a stack without enforcing it.
+func WithDeployerAuth(auth *AuthController) StackDeployerOption {
+	return func(d *StackDeployer) {
+		d.auth = auth
+	}
+}
+
 // NewStackDeployer creates a StackDeployer wired to the provided dependencies.
 //
 // The deployer deploys into substrate's default account and region unless
-// [WithDeployerIdentity] says otherwise.
+// [WithDeployerIdentity] says otherwise, and dispatches unauthorized unless both
+// [WithDeployerPrincipal] and [WithDeployerAuth] say otherwise.
 func NewStackDeployer(registry *PluginRegistry, store *EventStore, state StateManager, tc *TimeController, logger Logger, costs *CostController, opts ...StackDeployerOption) *StackDeployer {
 	d := &StackDeployer{
 		registry: registry,
@@ -1040,6 +1192,7 @@ func (d *StackDeployer) DeployWithOptions(
 			CreatedAt:    start,
 			UpdatedAt:    d.tc.Now(),
 		}
+		state.setAttribution(d.attribution)
 		d.persistStack(ctx, state)
 	}
 
@@ -3927,6 +4080,7 @@ func (d *StackDeployer) dispatch(
 		AccountID: d.identity.accountID,
 		Region:    d.identity.region,
 		Timestamp: d.tc.Now(),
+		Principal: d.attribution.resolve(),
 		Metadata:  map[string]interface{}{"stream_id": streamID},
 	}
 
@@ -3938,7 +4092,32 @@ func (d *StackDeployer) dispatch(
 	// which no policy granting s3:CreateBucket matches. Resolving here reaches
 	// every dispatch site at once, and is a no-op for a request that already
 	// carries a real operation name.
+	//
+	// This must precede the authorization below: the action a policy is evaluated
+	// against is derived from req.Operation, so authorizing first would ask whether
+	// the stack's role may perform "s3:PUT" — a question no correct policy answers
+	// yes to.
 	resolveOperationName(req)
+
+	// Authorize here rather than in RouteRequest, which no caller's requests pass
+	// an authorization check through. Doing it at the deployer covers create,
+	// update, rollback and delete at once: every one of those sweeps reaches a
+	// resource through this function, so there is no second path to keep in step.
+	//
+	// A denial is returned as the dispatch error, which is exactly what a refused
+	// call from the resource's own service would have produced. The existing
+	// machinery then reports it with no new model: the resource records the error,
+	// DescribeStackResources renders it as CREATE_FAILED with the denial as
+	// ResourceStatusReason, and the stack rolls back.
+	if d.auth != nil && reqCtx.Principal != nil {
+		if err := d.auth.CheckAccess(reqCtx, req); err != nil {
+			// Record the refusal before returning it, so a denied call is in the
+			// event log beside the ones that succeeded and a replay shows where the
+			// deployment stopped and why.
+			_ = d.store.RecordRequest(ctx, reqCtx, req, nil, 0, 0, err)
+			return nil, 0, err
+		}
+	}
 
 	start := d.tc.Now()
 	resp, routeErr := d.registry.RouteRequest(reqCtx, req)

--- a/emulator/cfn_rollback.go
+++ b/emulator/cfn_rollback.go
@@ -337,6 +337,12 @@ func (d *StackDeployer) handleFailedCreate(ctx context.Context, fc cfnFailedCrea
 		CreatedAt:    fc.start,
 		UpdatedAt:    d.tc.Now(),
 	}
+	// A stack that failed to create still records who created it. Its rollback's
+	// deletes are dispatched by this same deployer, so they already run as the right
+	// principal; persisting matters for what comes after — a caller that inspects a
+	// ROLLBACK_FAILED stack and then deletes it gets a sweep attributed to the same
+	// identity as the one that could not finish.
+	state.setAttribution(d.attribution)
 
 	if fc.onFailure == CFNOnFailureDoNothing {
 		// The resources stay, including the ones deployed after the failure.

--- a/emulator/cfn_service_role_test.go
+++ b/emulator/cfn_service_role_test.go
@@ -1,0 +1,536 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// A stack's resource calls were dispatched with no principal at all, and
+// PluginRegistry.RouteRequest — which is what an in-process deploy routes through —
+// never authorizes. So a template asking for a permission the deploying identity
+// did not have deployed cleanly, which is the failure class #411 exists to catch:
+// in spore-host/spawn#70 a worker launched with an instance profile granting no SQS
+// permissions passed every composition test and then never drained a queue on real
+// AWS.
+
+// cfnRoleTestClient drives a TestServer over HTTP with the CloudFormation query
+// protocol, signed as the given access key.
+type cfnRoleTestClient struct {
+	t         *testing.T
+	baseURL   string
+	accessKey string
+}
+
+// call issues a CloudFormation query request and returns the status and body.
+func (c *cfnRoleTestClient) call(action string, params map[string]string) (int, string) {
+	c.t.Helper()
+	form := url.Values{"Action": {action}, "Version": {"2010-05-15"}}
+	for k, v := range params {
+		form.Set(k, v)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		c.baseURL+"/", strings.NewReader(form.Encode()))
+	require.NoError(c.t, err)
+	req.Host = "cloudformation.us-east-1.amazonaws.com"
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if c.accessKey != "" {
+		req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+c.accessKey+
+			"/20250101/us-east-1/cloudformation/aws4_request, SignedHeaders=host, Signature=unverified")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(c.t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(c.t, err)
+	require.NoError(c.t, resp.Body.Close())
+	return resp.StatusCode, string(body)
+}
+
+// cfnRoleBucketTemplate is a template declaring one bucket, which is enough: the
+// question under test is whose permissions the CreateBucket call is made with.
+const cfnRoleBucketTemplate = `{
+  "Resources": {
+    "Data": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {"BucketName": "role-test-bucket"}
+    }
+  }
+}`
+
+// cfnSeedRole writes an IAM role and, when doc is non-empty, an inline policy
+// granting it. Written straight to state rather than through the IAM API because
+// what is under test is the deployment, not IAM's own request handling.
+func cfnSeedRole(t *testing.T, state emulator.StateManager, roleName string, actions []string) {
+	t.Helper()
+	ctx := context.Background()
+
+	roleRaw, err := json.Marshal(emulator.IAMRole{
+		RoleName: roleName,
+		RoleID:   "AROATEST" + roleName,
+		ARN:      "arn:aws:iam::123456789012:role/" + roleName,
+		Path:     "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "role:"+roleName, roleRaw))
+
+	if len(actions) == 0 {
+		return
+	}
+	policyARN := "arn:aws:iam::123456789012:policy/" + roleName + "Policy"
+	arnsRaw, err := json.Marshal([]string{policyARN})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "role_policies:"+roleName, arnsRaw))
+
+	polRaw, err := json.Marshal(emulator.IAMPolicy{
+		PolicyName: roleName + "Policy",
+		ARN:        policyARN,
+		Document: emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice(actions),
+				Resource: emulator.StringOrSlice{"*"},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+}
+
+// cfnStackStatus reads a stack's status and RoleARN out of a DescribeStacks body.
+func cfnStackStatus(t *testing.T, body string) (status, roleARN, reason string) {
+	t.Helper()
+	var parsed struct {
+		Stacks []struct {
+			StackStatus       string `xml:"StackStatus"`
+			StackStatusReason string `xml:"StackStatusReason"`
+			RoleARN           string `xml:"RoleARN"`
+		} `xml:"DescribeStacksResult>Stacks>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &parsed), "body: %s", body)
+	require.Len(t, parsed.Stacks, 1, "body: %s", body)
+	return parsed.Stacks[0].StackStatus, parsed.Stacks[0].RoleARN, parsed.Stacks[0].StackStatusReason
+}
+
+func TestCFN_ServiceRoleAuthorizesResourceCalls(t *testing.T) {
+	// #411's acceptance and #562's, end to end over HTTP: a stack deployed under a
+	// service role that cannot create the resource fails, and the same template
+	// under a role that can succeeds. Nothing about the template differs — only the
+	// permissions of the identity CloudFormation makes the calls with.
+	tests := []struct {
+		name       string
+		roleName   string
+		actions    []string
+		wantStatus string
+		wantReason string
+	}{
+		{
+			// The point of the release. Before this, a role granting nothing
+			// deployed the bucket without complaint.
+			name:       "a role that cannot create the bucket rolls the stack back",
+			roleName:   "narrow",
+			actions:    []string{"s3:ListBucket"},
+			wantStatus: "ROLLBACK_COMPLETE",
+			wantReason: "AccessDeniedException",
+		},
+		{
+			name:       "a role that can create the bucket deploys",
+			roleName:   "wide",
+			actions:    []string{"s3:*"},
+			wantStatus: "CREATE_COMPLETE",
+		},
+		{
+			// A role that grants nothing at all is an implicit deny, which is what
+			// a freshly created role with no policy attached is on AWS. This is the
+			// "forgot to attach the policy" case, distinct from "the policy is too
+			// narrow" above.
+			name:       "a role with no policy at all rolls the stack back",
+			roleName:   "empty",
+			wantStatus: "ROLLBACK_COMPLETE",
+			wantReason: "AccessDeniedException",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			cfnSeedRole(t, ts.StateManager(), tt.roleName, tt.actions)
+			client := &cfnRoleTestClient{t: t, baseURL: ts.URL}
+
+			code, body := client.call("CreateStack", map[string]string{
+				"StackName":    "rolestack",
+				"TemplateBody": cfnRoleBucketTemplate,
+				"RoleARN":      "arn:aws:iam::123456789012:role/" + tt.roleName,
+			})
+			// A rolled-back stack is still a successful CreateStack call: the API
+			// returns its StackId before any rollback happens, and the outcome is
+			// the stack's status.
+			require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+			_, body = client.call("DescribeStacks", map[string]string{"StackName": "rolestack"})
+			status, roleARN, reason := cfnStackStatus(t, body)
+			assert.Equal(t, tt.wantStatus, status)
+			assert.Equal(t, "arn:aws:iam::123456789012:role/"+tt.roleName, roleARN,
+				"the service role round-trips through DescribeStacks")
+			if tt.wantReason != "" {
+				assert.Contains(t, reason, tt.wantReason,
+					"the denial must name itself, not just a status")
+			}
+		})
+	}
+}
+
+func TestCFN_DeniedResourceNamesTheDenialInStackResources(t *testing.T) {
+	// #562's reporting criterion, minus the StackEvent one that is blocked by #501.
+	// A caller has to be able to learn *which* resource was refused and *why*, not
+	// only that the stack rolled back — that is the difference between a test
+	// failure a consumer can act on and one that sends them to real AWS to find out.
+	ts := emulator.StartTestServer(t)
+	cfnSeedRole(t, ts.StateManager(), "narrow", []string{"s3:ListBucket"})
+	client := &cfnRoleTestClient{t: t, baseURL: ts.URL}
+
+	code, body := client.call("CreateStack", map[string]string{
+		"StackName":    "reasonstack",
+		"TemplateBody": cfnRoleBucketTemplate,
+		"RoleARN":      "arn:aws:iam::123456789012:role/narrow",
+	})
+	require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+	_, body = client.call("DescribeStackResources", map[string]string{"StackName": "reasonstack"})
+	var parsed struct {
+		Resources []struct {
+			LogicalResourceID    string `xml:"LogicalResourceId"`
+			ResourceStatus       string `xml:"ResourceStatus"`
+			ResourceStatusReason string `xml:"ResourceStatusReason"`
+		} `xml:"DescribeStackResourcesResult>StackResources>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &parsed), "body: %s", body)
+	require.NotEmpty(t, parsed.Resources, "body: %s", body)
+
+	res := parsed.Resources[0]
+	assert.Equal(t, "Data", res.LogicalResourceID)
+	assert.Contains(t, res.ResourceStatusReason, "AccessDeniedException")
+	assert.Contains(t, res.ResourceStatusReason, "s3:CreateBucket",
+		"the reason names the action that was refused")
+}
+
+func TestCFN_RoleARNSemantics(t *testing.T) {
+	// The documented lifetime rules, which are not the convenient ones: a service
+	// role governs "all future operations on the stack", so an UpdateStack that
+	// omits RoleARN keeps it, while a DeleteStack's applies to that one operation
+	// and is not persisted.
+	t.Run("a stack without a role reports none", func(t *testing.T) {
+		ts := emulator.StartTestServer(t)
+		client := &cfnRoleTestClient{t: t, baseURL: ts.URL}
+
+		code, body := client.call("CreateStack", map[string]string{
+			"StackName":    "noroles",
+			"TemplateBody": cfnRoleBucketTemplate,
+		})
+		require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+		_, body = client.call("DescribeStacks", map[string]string{"StackName": "noroles"})
+		status, roleARN, _ := cfnStackStatus(t, body)
+		// The non-breaking gate: no role and no resolvable caller means nothing is
+		// enforced, exactly as before this existed.
+		assert.Equal(t, "CREATE_COMPLETE", status)
+		assert.Empty(t, roleARN, "a stack with no service role reports no RoleARN at all")
+	})
+
+	t.Run("an update that omits RoleARN keeps the stored one", func(t *testing.T) {
+		ts := emulator.StartTestServer(t)
+		cfnSeedRole(t, ts.StateManager(), "wide", []string{"s3:*"})
+		client := &cfnRoleTestClient{t: t, baseURL: ts.URL}
+
+		code, body := client.call("CreateStack", map[string]string{
+			"StackName":    "keeprole",
+			"TemplateBody": cfnRoleBucketTemplate,
+			"RoleARN":      "arn:aws:iam::123456789012:role/wide",
+		})
+		require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+		code, body = client.call("UpdateStack", map[string]string{
+			"StackName":    "keeprole",
+			"TemplateBody": cfnRoleBucketTemplate,
+		})
+		require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+		_, body = client.call("DescribeStacks", map[string]string{"StackName": "keeprole"})
+		_, roleARN, _ := cfnStackStatus(t, body)
+		assert.Equal(t, "arn:aws:iam::123456789012:role/wide", roleARN,
+			"an omitted RoleARN uses the role previously associated with the stack")
+	})
+
+	t.Run("an update that supplies RoleARN replaces the stored one", func(t *testing.T) {
+		ts := emulator.StartTestServer(t)
+		cfnSeedRole(t, ts.StateManager(), "wide", []string{"s3:*"})
+		cfnSeedRole(t, ts.StateManager(), "wider", []string{"s3:*", "sqs:*"})
+		client := &cfnRoleTestClient{t: t, baseURL: ts.URL}
+
+		code, body := client.call("CreateStack", map[string]string{
+			"StackName":    "swaprole",
+			"TemplateBody": cfnRoleBucketTemplate,
+			"RoleARN":      "arn:aws:iam::123456789012:role/wide",
+		})
+		require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+		code, body = client.call("UpdateStack", map[string]string{
+			"StackName":    "swaprole",
+			"TemplateBody": cfnRoleBucketTemplate,
+			"RoleARN":      "arn:aws:iam::123456789012:role/wider",
+		})
+		require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+		_, body = client.call("DescribeStacks", map[string]string{"StackName": "swaprole"})
+		_, roleARN, _ := cfnStackStatus(t, body)
+		assert.Equal(t, "arn:aws:iam::123456789012:role/wider", roleARN)
+	})
+
+	t.Run("a delete's RoleARN applies to that operation only", func(t *testing.T) {
+		// The asymmetry worth testing: CreateStack and UpdateStack document "always
+		// uses this role for all future operations", and DeleteStack does not. A
+		// delete refused by its override must leave the stack's own role intact, or
+		// a retried delete would silently run as a different identity than the
+		// first attempt.
+		ts := emulator.StartTestServer(t)
+		cfnSeedRole(t, ts.StateManager(), "wide", []string{"s3:*"})
+		cfnSeedRole(t, ts.StateManager(), "cannotdelete", []string{"s3:CreateBucket"})
+		client := &cfnRoleTestClient{t: t, baseURL: ts.URL}
+
+		code, body := client.call("CreateStack", map[string]string{
+			"StackName":    "delrole",
+			"TemplateBody": cfnRoleBucketTemplate,
+			"RoleARN":      "arn:aws:iam::123456789012:role/wide",
+		})
+		require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+		// DeleteStack answers 200 even when the sweep fails: the outcome is the
+		// stack's status, which the caller polls for.
+		code, body = client.call("DeleteStack", map[string]string{
+			"StackName": "delrole",
+			"RoleARN":   "arn:aws:iam::123456789012:role/cannotdelete",
+		})
+		require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+		_, body = client.call("DescribeStacks", map[string]string{"StackName": "delrole"})
+		status, roleARN, _ := cfnStackStatus(t, body)
+		assert.Equal(t, "DELETE_FAILED", status,
+			"the override's role cannot delete the bucket, so the sweep fails")
+		assert.Equal(t, "arn:aws:iam::123456789012:role/wide", roleARN,
+			"a delete's RoleARN is not persisted onto the stack")
+	})
+
+	t.Run("a RoleARN shorter than the model allows is refused", func(t *testing.T) {
+		ts := emulator.StartTestServer(t)
+		client := &cfnRoleTestClient{t: t, baseURL: ts.URL}
+
+		code, body := client.call("CreateStack", map[string]string{
+			"StackName":    "badrole",
+			"TemplateBody": cfnRoleBucketTemplate,
+			"RoleARN":      "arn:aws:iam::1:r",
+		})
+		assert.Equal(t, http.StatusBadRequest, code, "body: %s", body)
+		assert.Contains(t, body, "ValidationError")
+	})
+}
+
+func TestCFN_DeleteRunsAsTheStacksRole(t *testing.T) {
+	// A resource created by a role is deleted by that role, not by whoever happens
+	// to ask for the delete. Without this a stack deployed under a narrow role could
+	// be swept by an unauthorized delete, which would make the enforcement decorative:
+	// the permissions that gated creation would not gate teardown.
+	ts := emulator.StartTestServer(t)
+	cfnSeedRole(t, ts.StateManager(), "createonly", []string{"s3:CreateBucket"})
+	client := &cfnRoleTestClient{t: t, baseURL: ts.URL}
+
+	code, body := client.call("CreateStack", map[string]string{
+		"StackName":    "sweepstack",
+		"TemplateBody": cfnRoleBucketTemplate,
+		"RoleARN":      "arn:aws:iam::123456789012:role/createonly",
+	})
+	require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+	_, body = client.call("DescribeStacks", map[string]string{"StackName": "sweepstack"})
+	status, _, reason := cfnStackStatus(t, body)
+	require.Equal(t, "CREATE_COMPLETE", status, "reason: %s", reason)
+
+	// The same role cannot delete a bucket, so the sweep fails and says so.
+	code, body = client.call("DeleteStack", map[string]string{"StackName": "sweepstack"})
+	require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+	_, body = client.call("DescribeStacks", map[string]string{"StackName": "sweepstack"})
+	status, _, _ = cfnStackStatus(t, body)
+	assert.Equal(t, "DELETE_FAILED", status,
+		"the delete is attributed to the stack's role, which cannot delete")
+}
+
+// cfnSeedUserWithKey writes an IAM user, an access key for it, and a policy
+// allowing actions on every resource, returning the access key ID to sign with.
+func cfnSeedUserWithKey(t *testing.T, state emulator.StateManager, user, keyID string, actions []string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	userRaw, err := json.Marshal(emulator.IAMUser{
+		UserName: user,
+		UserID:   "AIDA" + user,
+		ARN:      "arn:aws:iam::123456789012:user/" + user,
+		Path:     "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "user:"+user, userRaw))
+
+	policyARN := "arn:aws:iam::123456789012:policy/" + user + "Policy"
+	arnsRaw, err := json.Marshal([]string{policyARN})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "user_policies:"+user, arnsRaw))
+
+	polRaw, err := json.Marshal(emulator.IAMPolicy{
+		PolicyName: user + "Policy",
+		ARN:        policyARN,
+		Document: emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice(actions),
+				Resource: emulator.StringOrSlice{"*"},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+
+	keyRaw, err := json.Marshal(emulator.IAMAccessKey{
+		AccessKeyID: keyID,
+		UserName:    user,
+		Status:      "Active",
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "accesskey:"+keyID, keyRaw))
+	return keyID
+}
+
+func TestCFN_ServiceRoleWinsOverTheCreatingPrincipal(t *testing.T) {
+	// The one case where the resolution *order* is observable, and therefore the
+	// only thing that measures it: both a service role and a creating principal
+	// exist, and they disagree. A service role is what CloudFormation "always uses
+	// for all future operations on the stack", so it wins — which means a caller
+	// cannot widen a narrow deploy role by holding a broader policy of their own,
+	// and cannot be blamed for a role's refusal either.
+	tests := []struct {
+		name        string
+		roleActions []string
+		userActions []string
+		wantStatus  string
+	}{
+		{
+			// If the creator won, this would deploy — the caller can create buckets.
+			// It must not: the stack's role cannot.
+			name:        "a narrow role refuses what the broad creator could do",
+			roleActions: []string{"s3:ListBucket"},
+			userActions: []string{"cloudformation:*", "s3:*"},
+			wantStatus:  "ROLLBACK_COMPLETE",
+		},
+		{
+			// The converse, which pins the order rather than merely "the role is
+			// consulted": if the creator won, this would roll back.
+			name:        "a broad role deploys what the narrow creator could not",
+			roleActions: []string{"s3:*"},
+			userActions: []string{"cloudformation:*"},
+			wantStatus:  "CREATE_COMPLETE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			state := ts.StateManager()
+			cfnSeedRole(t, state, "deployrole", tt.roleActions)
+			keyID := cfnSeedUserWithKey(t, state, "caller", "AKIACALLER0000000001", tt.userActions)
+			client := &cfnRoleTestClient{t: t, baseURL: ts.URL, accessKey: keyID}
+
+			code, body := client.call("CreateStack", map[string]string{
+				"StackName":    "orderstack",
+				"TemplateBody": cfnRoleBucketTemplate,
+				"RoleARN":      "arn:aws:iam::123456789012:role/deployrole",
+			})
+			require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+			_, body = client.call("DescribeStacks", map[string]string{"StackName": "orderstack"})
+			status, roleARN, reason := cfnStackStatus(t, body)
+			assert.Equal(t, tt.wantStatus, status, "reason: %s", reason)
+			assert.Equal(t, "arn:aws:iam::123456789012:role/deployrole", roleARN)
+		})
+	}
+}
+
+func TestCFN_CreatorPrincipalDeploysWhenThereIsNoRole(t *testing.T) {
+	// CloudFormation's no-service-role case: absent a role it uses "a temporary
+	// session that's generated from your user credentials", so a stack created by a
+	// caller whose policy does not allow the resource must fail — otherwise
+	// CreateStack would be a way to launder a permission the caller does not have.
+	ts := emulator.StartTestServer(t)
+	state := ts.StateManager()
+	ctx := context.Background()
+
+	// A user with an access key, and a policy that allows CloudFormation but not S3.
+	userRaw, err := json.Marshal(emulator.IAMUser{
+		UserName: "deployer",
+		UserID:   "AIDATEST",
+		ARN:      "arn:aws:iam::123456789012:user/deployer",
+		Path:     "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "user:deployer", userRaw))
+
+	policyARN := "arn:aws:iam::123456789012:policy/CFNOnly"
+	arnsRaw, err := json.Marshal([]string{policyARN})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "user_policies:deployer", arnsRaw))
+	polRaw, err := json.Marshal(emulator.IAMPolicy{
+		PolicyName: "CFNOnly",
+		ARN:        policyARN,
+		Document: emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice{"cloudformation:*"},
+				Resource: emulator.StringOrSlice{"*"},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "policy:"+policyARN, polRaw))
+
+	const keyID = "AKIADEPLOYER00000001"
+	keyRaw, err := json.Marshal(emulator.IAMAccessKey{
+		AccessKeyID: keyID,
+		UserName:    "deployer",
+		Status:      "Active",
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.Put(ctx, "iam", "accesskey:"+keyID, keyRaw))
+
+	client := &cfnRoleTestClient{t: t, baseURL: ts.URL, accessKey: keyID}
+
+	code, body := client.call("CreateStack", map[string]string{
+		"StackName":    "creatorstack",
+		"TemplateBody": cfnRoleBucketTemplate,
+	})
+	require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+	_, body = client.call("DescribeStacks", map[string]string{"StackName": "creatorstack"})
+	status, roleARN, reason := cfnStackStatus(t, body)
+	assert.Equal(t, "ROLLBACK_COMPLETE", status)
+	assert.Empty(t, roleARN, "the stack has no service role; the creator is not one")
+	assert.Contains(t, reason, "AccessDeniedException")
+}

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -51,18 +51,31 @@ type CloudFormationPlugin struct {
 	registry *PluginRegistry
 	store    *EventStore
 	costs    *CostController
+
+	// auth authorizes each resource call a deployment dispatches, or is nil to
+	// authorize nothing. Held at the plugin because it is a server-lifetime
+	// dependency, unlike the per-request identity and per-stack attribution beside
+	// it in deployerFor.
+	auth *AuthController
 }
 
 // deployerFor returns a [StackDeployer] that deploys into the requesting
-// caller's account and region.
+// caller's account and region, attributing its resource calls to att.
 //
 // Identity is a property of the request, not of the plugin, so it cannot be fixed
 // at Initialize time. A caller signing for another account used to get a stack
 // whose ARN named that account while the resources inside it were written into
 // substrate's defaults, which put them in a partition that caller could not read.
-func (p *CloudFormationPlugin) deployerFor(reqCtx *RequestContext) *StackDeployer {
+//
+// Attribution is a property of the request *and* of the stack — a service role
+// outlives the operation that set it — so every caller passes it explicitly rather
+// than having one derived here. A zero cfnAttribution dispatches unauthorized,
+// which is right for the paths that touch no resource of the stack's own.
+func (p *CloudFormationPlugin) deployerFor(reqCtx *RequestContext, att cfnAttribution) *StackDeployer {
 	return NewStackDeployer(p.registry, p.store, p.state, p.tc, p.logger, p.costs,
-		WithDeployerIdentity(reqCtx.AccountID, reqCtx.Region))
+		WithDeployerIdentity(reqCtx.AccountID, reqCtx.Region),
+		WithDeployerAttribution(att.roleARN, att.creator),
+		WithDeployerAuth(p.auth))
 }
 
 // Name returns the service name "cloudformation".
@@ -80,6 +93,10 @@ func (p *CloudFormationPlugin) Name() string { return "cloudformation" }
 // substituted with disabled instances when absent, never left nil:
 // [StackDeployer.dispatch] dereferences both on every resource it deploys, and
 // callers of [RegisterDefaultPlugins] are permitted to pass a nil *EventStore.
+//
+// Options["auth_controller"] is optional and, unlike those two, is left nil when
+// absent: a nil controller authorizes nothing, which is what every caller that does
+// not pass one got before a stack's resource calls carried a principal at all.
 func (p *CloudFormationPlugin) Initialize(_ context.Context, cfg PluginConfig) error {
 	p.state = cfg.State
 	p.logger = cfg.Logger
@@ -103,9 +120,14 @@ func (p *CloudFormationPlugin) Initialize(_ context.Context, cfg PluginConfig) e
 		costs = NewCostController(CostConfig{Enabled: false})
 	}
 
+	// Not substituted when absent: nil is the "authorize nothing" case, and there is
+	// no disabled AuthController to stand in for it.
+	auth, _ := cfg.Options["auth_controller"].(*AuthController)
+
 	p.registry = registry
 	p.store = store
 	p.costs = costs
+	p.auth = auth
 	p.deployer = NewStackDeployer(registry, store, cfg.State, p.tc, cfg.Logger, costs)
 	return nil
 }
@@ -233,7 +255,15 @@ func (p *CloudFormationPlugin) createStack(reqCtx *RequestContext, req *AWSReque
 	// status, which is where the API puts it — real CreateStack has returned its
 	// StackId before any rollback happens — so a rolled-back stack answers 200 and
 	// says ROLLBACK_COMPLETE through DescribeStacks.
-	if _, err := p.deployerFor(reqCtx).DeployWithOptions(context.Background(), body, name,
+	// The stack's resource calls are attributed to its service role if it has one
+	// and to the creating caller otherwise, which is CloudFormation's own rule.
+	// Both are persisted by the deployer, so every later operation on this stack
+	// resolves the same identity — see [cfnAttribution].
+	if roleErr := cfnValidateRoleARN(req.Params["RoleARN"]); roleErr != nil {
+		return nil, roleErr
+	}
+	att := cfnAttribution{roleARN: req.Params["RoleARN"], creator: reqCtx.Principal}
+	if _, err := p.deployerFor(reqCtx, att).DeployWithOptions(context.Background(), body, name,
 		cfnRequestParameters(req.Params, nil), opts); err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -280,7 +310,19 @@ func (p *CloudFormationPlugin) updateStack(reqCtx *RequestContext, req *AWSReque
 		// UsePreviousTemplate is the documented way to change only parameters.
 		body = stack.TemplateBody
 	}
-	if _, err := p.deployerFor(reqCtx).UpdateStack(context.Background(), body, name,
+	// "If you don't specify a value, CloudFormation uses the role that was
+	// previously associated with the stack." So an omitted RoleARN keeps the stored
+	// one rather than reverting the stack to the caller's own permissions, and a
+	// supplied one replaces it for this update and every operation after it. The
+	// creator is not reassigned: an update does not change who created the stack.
+	att := stack.attribution()
+	if roleARN := req.Params["RoleARN"]; roleARN != "" {
+		if roleErr := cfnValidateRoleARN(roleARN); roleErr != nil {
+			return nil, roleErr
+		}
+		att.roleARN = roleARN
+	}
+	if _, err := p.deployerFor(reqCtx, att).UpdateStack(context.Background(), body, name,
 		cfnRequestParameters(req.Params, stack.Parameters)); err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -323,7 +365,26 @@ func (p *CloudFormationPlugin) deleteStack(reqCtx *RequestContext, req *AWSReque
 	// unpartitioned: the delete is refused when another stack imports one of this
 	// stack's exports, and export visibility is scoped per account and Region, so
 	// the default identity would consult the wrong namespace.
-	if err := p.deployerFor(reqCtx).DeleteStack(context.Background(), name); err != nil {
+	//
+	// The sweep is attributed to the stack's own service role or creator, not to
+	// whoever asked for the delete: a resource created by a role is deleted by that
+	// role. DeleteStack's RoleARN overrides for this operation only — "CloudFormation
+	// uses the role's credentials to make calls on your behalf" for this delete —
+	// and is deliberately not persisted, which is the one place a stack's stored role
+	// is not updated by an operation that names one. A stack the lookup cannot find
+	// contributes no attribution and still succeeds, since deleting an absent stack
+	// is a success.
+	att := cfnAttribution{}
+	if stack, findErr := p.findStack(name); findErr == nil && stack != nil {
+		att = stack.attribution()
+	}
+	if roleARN := req.Params["RoleARN"]; roleARN != "" {
+		if roleErr := cfnValidateRoleARN(roleARN); roleErr != nil {
+			return nil, roleErr
+		}
+		att.roleARN = roleARN
+	}
+	if err := p.deployerFor(reqCtx, att).DeleteStack(context.Background(), name); err != nil {
 		// A sweep that could not remove a resource is reported the way the API
 		// reports it: DeleteStack "returns success" and the stack reaches
 		// DELETE_FAILED, which the caller learns by polling DescribeStacks. Raising
@@ -369,6 +430,13 @@ type cfnStackItem struct {
 	DisableRollback bool              `xml:"DisableRollback"`
 	Parameters      []cfnParameterXML `xml:"Parameters>member,omitempty"`
 	Outputs         []cfnOutputXML    `xml:"Outputs>member,omitempty"`
+
+	// RoleARN is "the ARN of an IAM role that's associated with the stack", omitted
+	// for a stack with none. Omitted rather than empty because the member is not
+	// required and a stack without a service role has no role to report: an empty
+	// string would have a caller checking `Stacks[0].RoleARN` read "" where AWS
+	// gives it nothing at all.
+	RoleARN string `xml:"RoleARN,omitempty"`
 }
 
 // cfnParameterXML is a resolved template parameter as DescribeStacks reports it.
@@ -437,6 +505,7 @@ func (p *CloudFormationPlugin) describeStacks(reqCtx *RequestContext, req *AWSRe
 			DisableRollback:   cfnStackDisablesRollback(s.OnFailure),
 			Parameters:        cfnParametersXML(s.Parameters),
 			Outputs:           cfnOutputsXML(s.Outputs, s.ExportNames),
+			RoleARN:           s.RoleARN,
 		})
 	}
 	return cfnXMLResponse(http.StatusOK, resp)
@@ -809,7 +878,17 @@ func (p *CloudFormationPlugin) executeChangeSet(reqCtx *RequestContext, req *AWS
 	}
 	// ExecuteChangeSet routes through UpdateStack to Deploy, so it deploys
 	// resources and takes the executing caller's identity like the other two.
-	if _, err := p.deployerFor(reqCtx).ExecuteChangeSet(context.Background(), cs.StackName, cs.ChangeSetName); err != nil {
+	//
+	// Attribution comes from the stack, for the same reason UpdateStack's does: the
+	// stack's service role governs "all future operations on the stack", and
+	// executing a change set is one. A change set against a stack that does not yet
+	// exist has none to inherit, so its resource calls are attributed to the caller
+	// executing it — which is CloudFormation's no-service-role case.
+	att := cfnAttribution{creator: reqCtx.Principal}
+	if stack, findErr := p.findStack(cs.StackName); findErr == nil && stack != nil {
+		att = stack.attribution()
+	}
+	if _, err := p.deployerFor(reqCtx, att).ExecuteChangeSet(context.Background(), cs.StackName, cs.ChangeSetName); err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
 
@@ -918,7 +997,7 @@ func (p *CloudFormationPlugin) deleteChangeSet(reqCtx *RequestContext, req *AWSR
 // exports; substrate returns them all in one page and emits no NextToken, which is
 // the documented answer for a result that fits.
 func (p *CloudFormationPlugin) listExports(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
-	exports, err := p.deployerFor(reqCtx).Exports(context.Background())
+	exports, err := p.deployerFor(reqCtx, cfnAttribution{}).Exports(context.Background())
 	if err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -962,7 +1041,7 @@ func (p *CloudFormationPlugin) listImports(reqCtx *RequestContext, req *AWSReque
 	if exportName == "" {
 		return nil, cfnMissingParameter("ExportName")
 	}
-	importers, err := p.deployerFor(reqCtx).Imports(context.Background(), exportName)
+	importers, err := p.deployerFor(reqCtx, cfnAttribution{}).Imports(context.Background(), exportName)
 	if err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -1001,7 +1080,7 @@ func (p *CloudFormationPlugin) detectStackDrift(reqCtx *RequestContext, req *AWS
 	// region, so detection has to look where the resources were actually
 	// deployed. On the default identity it would report every resource of another
 	// caller's stack as DELETED.
-	detectionID, err := p.deployerFor(reqCtx).StartStackDriftDetection(context.Background(), stackName)
+	detectionID, err := p.deployerFor(reqCtx, cfnAttribution{}).StartStackDriftDetection(context.Background(), stackName)
 	if err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -1035,7 +1114,7 @@ func (p *CloudFormationPlugin) describeStackResourceDrifts(reqCtx *RequestContex
 	filters := extractIndexedParams(req.Params, "StackResourceDriftStatusFilters.member")
 	// Recomputes drift, so it needs the caller's identity for the same reason
 	// detectStackDrift does.
-	drifts, err := p.deployerFor(reqCtx).DescribeStackResourceDrifts(context.Background(), stackName, filters)
+	drifts, err := p.deployerFor(reqCtx, cfnAttribution{}).DescribeStackResourceDrifts(context.Background(), stackName, filters)
 	if err != nil {
 		return nil, cfnMapDeployerError(err)
 	}
@@ -1192,6 +1271,39 @@ func cfnMissingParameter(name string) *AWSError {
 		Message:    "Missing required parameter " + name,
 		HTTPStatus: http.StatusBadRequest,
 	}
+}
+
+// cfnRoleARNLimits are the RoleARN shape's documented bounds: "min": 20,
+// "max": 2048.
+const (
+	cfnRoleARNMinLen = 20
+	cfnRoleARNMaxLen = 2048
+)
+
+// cfnValidateRoleARN reports a RoleARN outside the length the model constrains it
+// to, or nil when there is none to check.
+//
+// Only the length is checked, which is all the model constrains: the shape is a
+// bare string with min and max, so refusing anything else here would invent a
+// validation AWS does not document. A role that does not exist is deliberately not
+// an error either — CloudFormation "uses this role even if the users don't have
+// permission to pass it", and a nonexistent role resolves to no policies, which the
+// evaluator already treats as unenforced.
+func cfnValidateRoleARN(roleARN string) *AWSError {
+	if roleARN == "" {
+		return nil
+	}
+	if n := len(roleARN); n < cfnRoleARNMinLen || n > cfnRoleARNMaxLen {
+		return &AWSError{
+			Code: "ValidationError",
+			Message: fmt.Sprintf(
+				"1 validation error detected: Value '%s' at 'roleARN' failed to satisfy constraint: "+
+					"Member must have length greater than or equal to %d and less than or equal to %d",
+				roleARN, cfnRoleARNMinLen, cfnRoleARNMaxLen),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	return nil
 }
 
 // cfnStackNotFound reports an unknown stack. DescribeStacks and GetTemplate both

--- a/emulator/plugins.go
+++ b/emulator/plugins.go
@@ -8,6 +8,33 @@ import (
 
 //go:generate go run ../cmd/gen-service-reference -out ../docs/services.md
 
+// RegisterPluginsOption configures optional dependencies passed to the plugins
+// [RegisterDefaultPlugins] registers.
+//
+// Variadic rather than another positional parameter because the function is
+// exported and called from six places, most of which have nothing to pass: a new
+// parameter would make every one of them say so explicitly.
+type RegisterPluginsOption func(*registerPluginsSettings)
+
+// registerPluginsSettings accumulates what the options set.
+type registerPluginsSettings struct {
+	auth *AuthController
+}
+
+// WithPluginAuth gives the CloudFormation plugin the controller that authorizes the
+// resource calls a stack deployment makes.
+//
+// Only CloudFormation takes it, and only because it is the one plugin that
+// dispatches requests of its own: every other plugin's calls arrive through the
+// server, which authorizes them before routing. Without this a stack's resource
+// calls are dispatched unauthorized, which is what they always were — the gap that
+// made a template asking for a permission it did not have deploy cleanly.
+func WithPluginAuth(auth *AuthController) RegisterPluginsOption {
+	return func(s *registerPluginsSettings) {
+		s.auth = auth
+	}
+}
+
 // RegisterDefaultPlugins initializes and registers all built-in service plugins
 // into registry. This function is called by both the server binary and
 // [StartTestServer] so the same plugin set is always available.
@@ -17,6 +44,8 @@ import (
 // Docker execution, RDS container engine).
 // Adding a plugin here also requires a metadata entry in cmd/gen-service-reference
 // (enforced by `make docs-reference-check` in CI).
+//
+// opts carry the dependencies only some callers have; see [WithPluginAuth].
 func RegisterDefaultPlugins(
 	ctx context.Context,
 	registry *PluginRegistry,
@@ -25,7 +54,12 @@ func RegisterDefaultPlugins(
 	logger Logger,
 	store *EventStore,
 	cfg *Config,
+	opts ...RegisterPluginsOption,
 ) error {
+	var settings registerPluginsSettings
+	for _, opt := range opts {
+		opt(&settings)
+	}
 	// Resolve optional Docker-backed executors from cfg.
 	var lambdaExec *LambdaExecutor
 	var rdsExec *RDSExecutor
@@ -134,6 +168,9 @@ func RegisterDefaultPlugins(
 	}
 	if store != nil {
 		cfnOpts["event_store"] = store
+	}
+	if settings.auth != nil {
+		cfnOpts["auth_controller"] = settings.auth
 	}
 	if err := cfnPlugin.Initialize(ctx, PluginConfig{
 		State:   state,

--- a/emulator/testing.go
+++ b/emulator/testing.go
@@ -65,8 +65,21 @@ func StartTestServer(t *testing.T) *TestServer {
 
 	store := NewEventStore(cfg.EventStore.ToEventStoreConfig(), WithTimeController(tc))
 
+	// An IAM-enforcing composition test is the reason the authorization chain
+	// exists, and TestServer is how a consumer writes one, so a test server
+	// authorizes: a call made with a key minted by CreateAccessKey, or with STS
+	// session credentials, is evaluated against that principal's policies, and a
+	// stack's resource calls are evaluated against its service role or its creator.
+	//
+	// This changes nothing for a test that does not create an IAM principal.
+	// Enforcement keys off whether the caller resolves to an IAM entity present in
+	// state, so an unsigned request, substrate's documented credentials, and any
+	// key that was never minted here are all unenforced.
+	auth := NewAuthController(state, logger)
+
 	ctx := context.Background()
-	if err := RegisterDefaultPlugins(ctx, registry, state, tc, logger, store, nil); err != nil {
+	if err := RegisterDefaultPlugins(ctx, registry, state, tc, logger, store, nil,
+		WithPluginAuth(auth)); err != nil {
 		t.Fatalf("StartTestServer: register plugins: %v", err)
 	}
 
@@ -87,7 +100,8 @@ func StartTestServer(t *testing.T) *TestServer {
 	// ts.Store().GetCostSummary returns non-zero costs out of the box.
 	costs := NewCostController(CostConfig{Enabled: true})
 
-	srv := NewServer(*cfg, registry, store, state, tc, logger, ServerOptions{Fault: fault, Costs: costs})
+	srv := NewServer(*cfg, registry, store, state, tc, logger,
+		ServerOptions{Fault: fault, Costs: costs, Auth: auth})
 
 	srvCtx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})


### PR DESCRIPTION
A stack's resource calls were dispatched with **no principal at all**, and
`PluginRegistry.RouteRequest` — the path every in-process deploy routes through —
never authorizes. So a template asking for a permission the deploying identity did
not have deployed cleanly.

This is the failure class #411 exists to catch, and it has a concrete consumer
story: in spore-host/spawn#70 a worker instance was launched with an instance
profile granting no SQS permissions. Every substrate-backed composition test was
green; on real AWS its `GetQueueUrl` returned `NonExistentQueue` and the pool never
drained. A paid real-AWS smoke found it.

This is the half of #411 that no amount of principal resolution reaches (#570,
#571 did that half), plus #562.

## Authorization happens in the deployer

Not in `RouteRequest`, which authorizes nothing for anyone. Every create, update,
rollback and delete sweep reaches a resource through `StackDeployer.dispatch`, so
authorizing there covers all four at once and there is no second path to keep in
step.

A denial is returned as the dispatch error — exactly what a refused call from the
resource's own service would have produced — so the existing machinery reports it
with **no new model**: the resource records the error, `DescribeStackResources`
renders it as `CREATE_FAILED` with the denial as `ResourceStatusReason`, and the
stack rolls back through `cfn_rollback.go` untouched. The refusal is recorded in
the event log beside the calls that succeeded, so a replay shows where the
deployment stopped and why.

It is **not** yet a `StackEvent`. `DescribeStackEvents` is still refused with
`UnsupportedOperation`, and deriving events from the event store — with its
ordering, pagination and clock decisions — is #501's own design question. This is
why **#562 is not closed by this PR**: four of its five criteria ship here, and
the `StackEvent` criterion stays open against #501.

## The service role (#562)

`RoleARN` is accepted on `CreateStack`, `UpdateStack` and `DeleteStack`, stored on
the stack, and reported by `DescribeStacks` — the four places the API model carries
it, `omitempty` so a stack without one reports nothing, and length-validated as the
model specifies.

The **documented** lifetime rules, which are not the convenient ones:

| Operation | Behaviour | Source |
|---|---|---|
| `CreateStack` | sets the role | — |
| `UpdateStack` omitting `RoleARN` | **keeps** the stored role | "CloudFormation uses the role that was previously associated with the stack" |
| `UpdateStack` supplying one | replaces it for this and every later operation | "always uses this role for all future operations on the stack" |
| `DeleteStack` supplying one | applies to **that operation only**, not persisted | the phrase is absent from `DeleteStack` |

The delete asymmetry is worth the care: a delete refused by its override must leave
the stack's own role intact, or a retried delete silently runs as a different
identity than the first attempt. Verified live below.

## Which principal, and why

Absent a service role, CloudFormation uses "a temporary session that's generated
from your user credentials", so the **creating principal** is recorded on the stack
and its resource calls are attributed to it. Without that, `CreateStack` would be a
way to launder a permission the caller does not have.

Resolution is **service role → creating principal → nil**, in one place
(`cfnAttribution.resolve`), so create, update, rollback and delete cannot disagree.
Two consequences that follow from putting it in one place rather than restating it:
a resource created by a role is **deleted by that role**, not by whoever asks for
the delete (otherwise the permissions that gated creation would not gate teardown,
making enforcement decorative); and a **rollback's sweep** runs as the identity
that created what it is tearing down. An exempt service principal would have
reintroduced exactly the blind spot #411 exists to remove.

A `RoleARN` is used directly as a role principal — the evaluator's role path
resolves it — rather than run through `AssumeRole`, keeping this inside the scope
boundary: the observation being modelled is that a call was denied, not
role-assumption machinery.

## Compatibility

A stack deployed under a service role, or by a caller whose access key resolves to
an IAM user or role that **exists in state**, is now authorized and can reach
`ROLLBACK_COMPLETE` where it previously reached `CREATE_COMPLETE`. That is the
point of the release.

A stack with no service role and no resolvable creating principal deploys exactly
as before — every existing test, every in-process `Client` caller,
`AKIAIOSFODNN7EXAMPLE`. State encoding gains `CFNStackState.RoleARN` and
`CreatorPrincipalARN`, both `omitempty`, so recorded runs replay.

## Verification

**Mutation testing** — 8 mutants, each reversing one load-bearing decision:
**8 CAUGHT, 0 survivors, 0 broken.** Two rounds. The first found a real gap that
the plan had predicted: `attribution-order-inverted` (creator wins over `RoleARN`)
**SURVIVED**, because every existing test had either a role or a creator, never
both disagreeing — so nothing measured the *order*, only that something was
consulted. Added `TestCFN_ServiceRoleWinsOverTheCreatingPrincipal`: a caller whose
own policy allows the bucket deploying under a role that refuses it (must roll
back), and the converse (must succeed). Both directions are needed; either alone is
satisfiable by the wrong order.

The other seven: `dispatch`'s `CheckAccess` removed while the principal is still
carried; `DeleteStack`'s `RoleARN` persisted; `UpdateStack`'s omitted `RoleARN`
cleared; the delete sweep not attributed to the stack; the rollback's attribution
not persisted; the creating principal not carried; and `resolveOperationName` moved
after authorization (the new coupling with #572 — without it the action evaluated
for a stack's bucket is `s3:PUT` again).

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0
issues**, `make test` (race), `make docs-reference docs-reference-check
docs-versions` (65 plugins, no change), `go vet -C test/e2e ./...`,
`go test -C test/e2e ./...` — all green.

### Live end to end, `substrate server --address :4655`

```
# the non-breaking gate first, with the credential everything documents
AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE aws s3 mb s3://plain
  → make_bucket: plain

# a role that cannot create the bucket
aws cloudformation create-stack --stack-name narrowstack --role-arn .../role/narrow
aws cloudformation describe-stacks  --query 'Stacks[0].[StackStatus,RoleARN]'
  → ROLLBACK_COMPLETE   arn:aws:iam::123456789012:role/narrow
aws cloudformation describe-stack-resources --query 'StackResources[0].ResourceStatusReason'
  → AccessDeniedException: User: arn:aws:iam::123456789012:role/narrow is not
    authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::e2e-role-bucket

# a role that can
  → CREATE_COMPLETE   arn:aws:iam::123456789012:role/wide     (bucket present in s3 ls)

# UpdateStack omitting RoleARN keeps it
  → arn:aws:iam::123456789012:role/wide

# DeleteStack --role-arn narrow: refused, and the stack's own role is untouched
  → DELETE_FAILED   arn:aws:iam::123456789012:role/wide
# retried with the stack's own role: gone
  → ValidationError: Stack with id widestack does not exist

# no service role: the creator's own policy governs (cloudformation:* + s3:ListBucket)
  → ROLLBACK_COMPLETE   None
  → AccessDeniedException: User: arn:aws:iam::123456789012:user/alice is not
    authorized to perform: s3:CreateBucket ...

# #411's acceptance, same credential
aws sqs list-queues        → AccessDeniedException ... sqs:ListQueues on resource: *
aws s3api list-objects --bucket plain  → 0        (allowed: s3:ListBucket)
```

That last pair also exercises #572's action renames — a `list-objects` authorizing
against `s3:ListBucket`.

## Provenance

That `RouteRequest` never authorizes, and that a stack's `dispatch` carried no
principal, were **measured** with throwaway in-package probes rather than read off
a reference. The `RoleARN` shapes and lifetime semantics are from the
CloudFormation botocore model (`CreateStack`/`UpdateStack`/`DeleteStack` inputs and
the `Stack` output shape) and the CloudFormation API reference.

Closes #411
