### PR TITLE
docs: document testing IAM permissions and a stack's service role (#411, #562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Documentation for testing IAM permissions** (#411, #562). A "Testing IAM
+  Permissions" section in the testing guide — create a principal, attach a scoped
+  policy, mint an access key, assert the denial — and the one rule a reader would
+  otherwise get wrong: **existence in state is the opt-in**, so a policy attached to
+  a user that was never created denies nothing, while a principal that *does* exist
+  with no policy is denied. The CloudFormation service reference gains `RoleARN` on
+  the three operations and on `DescribeStacks`, the lifetime rules that differ per
+  operation, and a note that a denied resource call surfaces as `CREATE_FAILED` with
+  the denial as `ResourceStatusReason` rather than as a `StackEvent` (#501).
+
 - **A CloudFormation stack's service role** (#562). `RoleARN` is now accepted on
   `CreateStack`, `UpdateStack` and `DeleteStack`, stored on the stack, and reported
   by `DescribeStacks` — the four places the API model carries it. A stack's resource

--- a/docs/services.md
+++ b/docs/services.md
@@ -97,10 +97,10 @@ here.
 
 | Operation | Notes |
 |-----------|-------|
-| CreateStack | Deploys every resource in `TemplateBody` and returns the stack ARN |
-| UpdateStack | Re-deploys the template; an omitted `TemplateBody` re-uses the stored one |
-| DeleteStack | Sweeps the resources the stack deployed, then removes the stack record (see below); deleting an absent stack succeeds |
-| DescribeStacks | One stack by `StackName`, or every stack when omitted |
+| CreateStack | Deploys every resource in `TemplateBody` and returns the stack ARN; honours `RoleARN` |
+| UpdateStack | Re-deploys the template; an omitted `TemplateBody` re-uses the stored one, and an omitted `RoleARN` the stored role |
+| DeleteStack | Sweeps the resources the stack deployed, then removes the stack record (see below); deleting an absent stack succeeds; `RoleARN` applies to this operation only |
+| DescribeStacks | One stack by `StackName`, or every stack when omitted; reports `RoleARN` when the stack has one |
 | ListStacks | Summary shape; honours `StackStatusFilter.member.N` |
 | DescribeStackResources | By `StackName` + optional `LogicalResourceId`, or by `PhysicalResourceId` |
 | GetTemplate | Returns the stored `TemplateBody` byte-for-byte |
@@ -200,6 +200,59 @@ The in-process `emulator.Client` deploys into substrate's default partition
 (`123456789012` / `us-east-1`). Its callers never sign a request, so there is no
 caller identity to take; an in-process caller that needs another partition can set
 one on the deployer with `emulator.WithDeployerIdentity`.
+
+### A stack's resource calls are authorized
+
+CloudFormation does not create resources as itself. With a service role it "always
+uses this role for all future operations on the stack"; without one it uses "a
+temporary session that's generated from your user credentials". Substrate models
+both, so a template asking for a permission the deploying identity does not have
+fails the way it fails on AWS instead of deploying cleanly.
+
+`RoleARN` is accepted on `CreateStack`, `UpdateStack` and `DeleteStack` and reported
+by `DescribeStacks`. Its lifetime differs by operation, following the reference
+rather than convenience:
+
+- `UpdateStack` **without** `RoleARN` keeps the role the stack already has, and one
+  that supplies it replaces the role for that update and every operation after.
+- `DeleteStack`'s `RoleARN` applies to **that delete only** and is not persisted, so
+  a delete refused by its override leaves the stack's own role intact and a retry
+  runs as the identity the stack was created with.
+- A stack with no service role reports no `RoleARN` at all rather than an empty
+  string.
+
+Absent a service role, the calls are attributed to the principal that created the
+stack — so `CreateStack` cannot be used to obtain a permission the caller does not
+have. The same resolution covers teardown: a resource created by a role is deleted
+by that role, not by whoever asks for the delete, and a rollback's sweep runs as the
+identity that created what it is tearing down.
+
+A refused resource call surfaces as `CREATE_FAILED` with the denial —
+`AccessDeniedException`, naming the action and the resource ARN — as that resource's
+`ResourceStatusReason` in `DescribeStackResources`, and the stack rolls back:
+
+```
+aws cloudformation create-stack --stack-name s --template-body file://bucket.json \
+  --role-arn arn:aws:iam::123456789012:role/narrow
+aws cloudformation describe-stacks --stack-name s \
+  --query 'Stacks[0].[StackStatus,RoleARN]'
+# ROLLBACK_COMPLETE   arn:aws:iam::123456789012:role/narrow
+aws cloudformation describe-stack-resources --stack-name s \
+  --query 'StackResources[0].ResourceStatusReason'
+# AccessDeniedException: User: arn:aws:iam::123456789012:role/narrow is not
+# authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::...
+```
+
+The denial is **not** reported as a `StackEvent`: `DescribeStackEvents` is still
+refused with `UnsupportedOperation`, because substrate models stack status rather
+than per-resource stack events. Deriving events from the event log is tracked in
+[#501](https://github.com/scttfrdmn/substrate/issues/501); until then
+`DescribeStackResources` is where a per-resource reason is observable.
+
+Enforcement is opt-in by creating the principal: a stack deployed with a credential
+that resolves to no IAM user or role in state is not authorized at all, which is
+every in-process `emulator.Client` caller and every credential that never touched
+IAM. See the testing guide's "Testing IAM permissions".
 
 ### DeleteStack deletes the stack's resources
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -450,6 +450,63 @@ errors use, so an SDK recovers the code rather than falling back to the HTTP sta
 
 <!-- TODO(#178): document server.WithFaultController option once stabilised -->
 
+## Testing IAM Permissions
+
+Substrate evaluates IAM policies, so "the policy is too narrow" and "we forgot a
+permission" are failures a test can catch instead of a real deployment finding them.
+The class is worth naming: a worker launched with an instance profile granting no SQS
+permissions passes every mocked test, and then never drains a queue.
+
+Create a principal, attach a scoped policy, mint an access key, and call as it:
+
+```bash
+aws iam create-user --user-name alice
+aws iam put-user-policy --user-name alice --policy-name ro --policy-document \
+  '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:ListBucket","Resource":"*"}]}'
+aws iam create-access-key --user-name alice   # returns the ID and secret
+
+AWS_ACCESS_KEY_ID=<id> AWS_SECRET_ACCESS_KEY=<secret> aws sqs list-queues
+# AccessDeniedException: User: arn:aws:iam::123456789012:user/alice is not
+# authorized to perform: sqs:ListQueues on resource: *
+
+AWS_ACCESS_KEY_ID=<id> AWS_SECRET_ACCESS_KEY=<secret> aws s3api list-objects --bucket b
+# 200 — s3:ListBucket is what a listing authorizes against
+```
+
+STS session credentials work the same way. `AssumeRole` mints an `ASIA` key whose
+calls are evaluated against the **role**, as real IAM resolves a session, so
+`assume-role` then call is how a test exercises a role's policy.
+
+### A principal that does not exist is not enforced
+
+This is the one thing to know before writing such a test. **Existence in state is
+the opt-in**: enforcement runs only when the access key resolves to an IAM user or
+role substrate actually holds. An unregistered key, a key whose user was deleted, and
+the credentials this guide uses elsewhere (`test`/`test`, `AKIAIOSFODNN7EXAMPLE`) all
+resolve to no principal and are authorized against nothing.
+
+There is no configuration flag. A test that never touches IAM is unaffected, and a
+test that asserts a denial must create the principal first — a `put-user-policy`
+against a user that was never created denies nothing, because there is no user to
+evaluate.
+
+Two consequences follow from the same rule. A principal that exists with **no**
+policy is **denied** (an implicit deny, as on AWS), so a freshly created role with
+nothing attached is the "forgot to attach the policy" case rather than a pass. And a
+role named by a session but absent from state is not enforced, so `assume-role`
+against a role substrate does not hold proves nothing.
+
+In-process `emulator.Client` callers never sign a request, so they carry no principal
+and are never authorized. Enforcement is reached over the wire.
+
+### CloudFormation stacks
+
+A stack's resource calls are authorized too, as the stack's service role when it has
+one and as the creating principal otherwise. A refused resource call rolls the stack
+back and names the denial in `DescribeStackResources`' `ResourceStatusReason` — not
+as a `StackEvent`. See the CloudFormation section of
+[the service reference](services.md) for the `RoleARN` semantics.
+
 ## Multi-Region
 
 Substrate supports multiple regions. Resources are scoped by `(account, region)`


### PR DESCRIPTION
The docs half of v0.92.0. #570, #571 and #574 made IAM enforcement reachable and
correct; this makes it discoverable, and states the one rule that would otherwise
have readers writing tests that silently prove nothing.

## `docs/testing-guide.md` — "Testing IAM Permissions"

Create a principal, attach a scoped policy, mint an access key, assert the denial —
with the denial and the allow side by side, since a test that only asserts the
denial passes for the wrong reason. It leads with the failure class rather than the
API, because that is why a reader would write such a test: a worker launched with an
instance profile granting no SQS permissions passes every mocked test and then never
drains a queue.

**Existence in state is the opt-in** gets its own subsection. Both halves are
stated, because each is a different way to be wrong:

- a policy attached to a user that was **never created** denies nothing — there is
  no user to evaluate, so the test proves nothing while passing;
- a principal that **does** exist with **no** policy is **denied** (an implicit deny,
  as on AWS) — which is the "forgot to attach the policy" case, not a pass.

Plus: STS session credentials evaluate against the role, a role named by a session
but absent from state is not enforced, and in-process `emulator.Client` callers never
sign a request so they carry no principal and are never authorized.

## `docs/services.md` — CloudFormation

`RoleARN` on the three operations that take it and on `DescribeStacks`, in the
operation table and in a new "A stack's resource calls are authorized" section: the
per-operation lifetime rules (an update keeps the stored role; a delete's override
applies to that delete only and is not persisted, so a retry runs as the identity the
stack was created with), attribution to the creating principal absent a role, and a
worked example of the denial as it actually appears.

And the boundary, named rather than left to be discovered: the denial is **not** a
`StackEvent`. `DescribeStackEvents` is still refused with `UnsupportedOperation`,
`DescribeStackResources`' `ResourceStatusReason` is where a per-resource reason is
observable, and #501 is linked as where that changes.

## Verification

`make docs-reference-check` (no plugin added or removed — the generated matrix is
untouched; all edits are in hand-written prose), `make docs-versions`
(`scripts/check-doc-versions.sh` — no pinned version in prose), and
`npm --prefix docs run build`. Every command shown was run live against
`substrate server` while verifying #574, so the outputs are transcripts rather than
constructions.

Part of #411 and #562; no `Closes` keyword — #411 is closed by #574, and #562
deliberately stays open for its `StackEvent` criterion (#501).
