### PR TITLE
chore(release): v0.92.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.92.0] - 2026-08-05
+
 ### Added
 - **Documentation for testing IAM permissions** (#411, #562). A "Testing IAM
   Permissions" section in the testing guide — create a principal, attach a scoped
@@ -5342,7 +5344,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.91.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.92.0...HEAD
+[v0.92.0]: https://github.com/scttfrdmn/substrate/compare/v0.91.0...v0.92.0
 [v0.91.0]: https://github.com/scttfrdmn/substrate/compare/v0.90.0...v0.91.0
 [v0.90.0]: https://github.com/scttfrdmn/substrate/compare/v0.89.0...v0.90.0
 [v0.89.0]: https://github.com/scttfrdmn/substrate/compare/v0.88.0...v0.89.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.92.0] - 2026-08-05` and adds the comparison link. The empty `## [Unreleased]` heading stays.

Version derived from `git tag --sort=-v:refname | head -1` → `v0.91.0`, so this is v0.92.0. Date is UTC.

The release: **the permission a caller actually has** — #411 (four PRs' worth: principal resolution, the evaluator, the CloudFormation half) and #562 minus its `StackEvent` criterion, plus #572, the operation-naming defect that would have inverted the release's headline claim.

No code changes. The tag is cut on this PR's merge commit and the GitHub Release published against it in the same sitting.