### PR TITLE
feat(s3): a seedable 409 ConditionalRequestConflict on conditional writes (#540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A seedable `409 ConditionalRequestConflict` on S3 conditional writes** (#540).
+  `PutObject`, `CopyObject` and `CompleteMultipartUpload` could reach two of the
+  three outcomes AWS documents for a conditional write — `412 PreconditionFailed`
+  and `404 NoSuchKey` — but never the `409` S3 returns when a concurrent operation
+  interferes. The three are not interchangeable: a `412` means re-read, recompute
+  and retry the compare-and-swap, a `409` on `PutObject` means retry the request
+  as-is, and a `409` on `CompleteMultipartUpload` means the upload ID is finished
+  and the caller must re-do `CreateMultipartUpload` and every `UploadPart`. A CAS
+  loop that answers the third case like the first spins until it gives up, and
+  against substrate that loop looked correct.
+
+  `POST /v1/s3/conditional-conflict` seeds how many subsequent conditional writes
+  to a key report the code, keyed by `bucket`/`key` or the `*` wildcard, with
+  independent counters per operation (`putConflicts`, `copyConflicts`,
+  `completeConflicts`); `DELETE` clears one or all. A key-scoped seed is consulted
+  before the wildcard and falls through when exhausted, and conflicts are counted
+  in occurrences rather than measured as a duration, so a test is never wall-clock
+  dependent.
+
+  **Consuming a seeded multipart conflict invalidates the upload**, so a same-ID
+  retry gets `404 NoSuchUpload` and `ListParts` on that ID is gone — which is the
+  asymmetry that makes the broken loop fail. Reaching that required a plugin-level
+  seed rather than a fault-injection rule: faults are evaluated before a request
+  reaches its plugin, so a faulted `Complete` writes no state and its upload ID
+  stays completable.
+
+  Nothing changes for an unseeded caller. A conflict is consumed only *after* the
+  preconditions pass, so a `412` or `404` is still reported as itself and does not
+  spend the budget, and an unconditional write to a seeded key is untouched — AWS
+  documents the code only on the two conditional headers.
+
 ## [v0.92.0] - 2026-08-05
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -820,18 +820,18 @@ STS operations are free.
 | HeadBucket | |
 | DeleteBucket | |
 | ListBuckets | |
-| PutObject | Supports Content-Type, metadata headers; `Cache-Control`, `Content-Disposition`, `Content-Language`, `Expires` — see [Object system metadata](#object-system-metadata); `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums); records the `x-amz-server-side-encryption` family — see [Server-side encryption](#server-side-encryption); stores an ACL named by `x-amz-acl` / `x-amz-grant-*` — see [Access control lists](#access-control-lists) |
+| PutObject | Supports Content-Type, metadata headers; `Cache-Control`, `Content-Disposition`, `Content-Language`, `Expires` — see [Object system metadata](#object-system-metadata); `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-storage-class` — see [Storage classes](#storage-classes); conditional writes, including a seedable `409 ConditionalRequestConflict` — see [Conditional requests](#conditional-requests); verifies `x-amz-checksum-*` — see [Additional checksums](#additional-checksums); records the `x-amz-server-side-encryption` family — see [Server-side encryption](#server-side-encryption); stores an ACL named by `x-amz-acl` / `x-amz-grant-*` — see [Access control lists](#access-control-lists) |
 | GetObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); `403 InvalidObjectState` on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); synthesizes a seedable task-completion record — see [Task-completion records](#task-completion-records); echoes recorded encryption — see [Server-side encryption](#server-side-encryption) |
 | HeadObject | Echoes recorded system metadata — see [Object system metadata](#object-system-metadata); supports Range header — see [Ranged reads](#ranged-reads); preconditions — see [Conditional requests](#conditional-requests); succeeds on archived objects — see [Storage classes](#storage-classes); `x-amz-checksum-mode` — see [Additional checksums](#additional-checksums); resolves a synthesized task-completion record exactly as `GetObject` does — see [Task-completion records](#task-completion-records); echoes recorded encryption — see [Server-side encryption](#server-side-encryption) |
 | DeleteObject | Fires S3 notifications if configured |
-| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums); records **no** encryption, deliberately — see [Server-side encryption](#server-side-encryption); takes its ACL from the copy request and never from the source — see [Access control lists](#access-control-lists) |
+| CopyObject | Honors both destination and `x-amz-copy-source-if-*` preconditions, including a seedable `409 ConditionalRequestConflict` on the destination — see [Conditional requests](#conditional-requests); `x-amz-metadata-directive` / `x-amz-tagging-directive` and storage-class transitions — see [Copying objects](#copying-objects); recomputes the checksum — see [Additional checksums](#additional-checksums); records **no** encryption, deliberately — see [Server-side encryption](#server-side-encryption); takes its ACL from the copy request and never from the source — see [Access control lists](#access-control-lists) |
 | ListObjects | Emits `<StorageClass>` per object |
 | ListObjectsV2 | Supports Prefix, Delimiter, MaxKeys, ContinuationToken; emits `<StorageClass>` per object |
 | CreateMultipartUpload | Accepts `x-amz-storage-class` and the [system-metadata family](#object-system-metadata), applied to the assembled object; `Content-Encoding` less any `aws-chunked` — see [Content-Encoding and aws-chunked](#content-encoding-and-aws-chunked); `x-amz-checksum-algorithm` / `x-amz-checksum-type` — see [Additional checksums](#additional-checksums); records the encryption for the whole upload — see [Server-side encryption](#server-side-encryption); records the ACL for the whole upload — see [Access control lists](#access-control-lists) |
 | UploadPart | Verifies the part checksum, including a trailing one — see [Additional checksums](#additional-checksums) |
 | UploadPartCopy | Copies an existing object, or a byte range of one, into a part — see [Copying into a part](#copying-into-a-part) |
 | ListParts | Lists an upload's stored parts, with `max-parts` / `part-number-marker` paging; an upload with no parts is `200` with an empty list |
-| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums); reports the upload's recorded encryption — see [Server-side encryption](#server-side-encryption); applies the upload's recorded ACL — see [Access control lists](#access-control-lists) |
+| CompleteMultipartUpload | Validates part order, ETags, and part sizes — see [Multipart upload validation](#multipart-upload-validation); conditional writes, including a seedable `409 ConditionalRequestConflict` that invalidates the upload — see [Conditional requests](#conditional-requests); assembles the object checksum — see [Additional checksums](#additional-checksums); reports the upload's recorded encryption — see [Server-side encryption](#server-side-encryption); applies the upload's recorded ACL — see [Access control lists](#access-control-lists) |
 | AbortMultipartUpload | |
 | ListMultipartUploads | Emits `<StorageClass>` per in-progress upload |
 | GetBucketPolicy | |
@@ -1117,11 +1117,12 @@ Retrieving a specific part by `?partNumber=N` is not implemented.
 | `If-Match: "<etag>"` | ETag matches | `200` — the write proceeds |
 | `If-Match: "<etag>"` | ETag differs | `412 PreconditionFailed` |
 | `If-Match: "<etag>"` | Key absent, or the current version is a delete marker | `404 NoSuchKey` |
+| either header | A conflict is [seeded](#seeding-conditionalrequestconflict) on the key | `409 ConditionalRequestConflict` |
 
 A rejected conditional write is a no-op: the stored object is byte-identical
 afterwards — body, ETag, size, `Content-Type` and user metadata all unchanged — and
-a rejected `CompleteMultipartUpload` additionally leaves its upload open to be
-retried or aborted.
+a `412`-rejected `CompleteMultipartUpload` additionally leaves its upload open to be
+retried or aborted. A `409`-rejected one does not; see below.
 
 **Concurrency.** N concurrent `If-None-Match: *` writes to one key yield exactly one
 `200` and N-1 `412`s; the same holds for N concurrent `If-Match` writes asserting
@@ -1132,12 +1133,83 @@ compare-and-swap; it therefore holds for any number of goroutines or HTTP client
 against one emulator process, but would not hold across two emulator processes
 sharing one state backend.
 
-Two outcomes real S3 documents are deliberately not emulated: the `409
-ConditionalRequestConflict` returned when a concurrent operation interferes, and the
-`404` returned when a concurrent delete lands mid-write. Both are races against
-wall-clock timing rather than states a deterministic emulator can reach, so
-substrate resolves every conditional write to one of the rows above. A consumer
-that must exercise its 409 handler needs a fault-injection tier, not this one.
+#### Seeding `ConditionalRequestConflict`
+
+S3 returns `409 ConditionalRequestConflict` when a concurrent operation — in the
+documented case, a delete — interferes with a conditional write between its
+evaluation and its completion. It is a timing accident rather than a state a
+request can assert, so substrate cannot derive it the way it derives a `412` from
+the current object. Seeding is what makes the branch reachable.
+
+**The branch matters because the three outcomes select different recovery paths,
+and they are not interchangeable:**
+
+| Outcome | What it means | The recovery AWS documents |
+|---|---|---|
+| `412 PreconditionFailed` | Another writer won the race | Re-read, recompute, retry the compare-and-swap |
+| `404 NoSuchKey` on `If-Match` | The object is gone | Re-upload rather than retry the CAS |
+| `409` on `PutObject` / `CopyObject` | A delete interleaved | Retry the request as-is (for `If-Match`, fetch the current ETag first) |
+| `409` on `CompleteMultipartUpload` | A delete interleaved | **Abandon the upload ID** — re-do `CreateMultipartUpload` and re-upload every part |
+
+A compare-and-swap loop that answers the last case like the first re-sends
+`CompleteMultipartUpload` with an upload ID that can never complete again, and
+spins until it gives up. **Substrate models that consequence: consuming a seeded
+multipart conflict invalidates the upload, so a same-ID retry gets
+`404 NoSuchUpload` and `ListParts` on it is gone too.** That inference is
+substrate's — AWS documents the recovery advice, not the ID's fate — but without it
+the broken loop passes.
+
+```bash
+# The next conditional PutObject on cond/k reports ConditionalRequestConflict.
+curl -X POST http://localhost:4566/v1/s3/conditional-conflict \
+  -d '{"bucket":"cond","key":"k","putConflicts":1}'
+
+# CopyObject (evaluated against the destination key) and
+# CompleteMultipartUpload have their own independent counters.
+curl -X POST http://localhost:4566/v1/s3/conditional-conflict \
+  -d '{"bucket":"cond","key":"dst","copyConflicts":1}'
+curl -X POST http://localhost:4566/v1/s3/conditional-conflict \
+  -d '{"bucket":"cond","key":"big","completeConflicts":1}'
+
+# Apply to any key (wildcard).
+curl -X POST http://localhost:4566/v1/s3/conditional-conflict -d '{"putConflicts":3}'
+
+# Clear one, or all.
+curl -X DELETE 'http://localhost:4566/v1/s3/conditional-conflict?bucket=cond&key=k'
+curl -X DELETE http://localhost:4566/v1/s3/conditional-conflict
+```
+
+`bucket` and `key` must be given together; supplying one alone is a `400`, because
+such a seed would be stored under a key no write can match — it would look armed
+and never fire. A key-scoped seed is consulted before the wildcard, and when it is
+exhausted the write falls through to the wildcard, so a spent key-scoped seed does
+not mask a wildcard that still has budget.
+
+**Conflicts are counted in occurrences, not measured as a duration**, for the same
+reason as [the SQS consistency window](#seeding-the-create-then-lookup-consistency-window):
+substrate's simulated clock advances with wall time from its baseline, so a
+duration-based window would expire partway through a test and make assertions
+wall-clock dependent. A counter is exactly reproducible.
+
+Two ordering rules make the seed usable from a harness:
+
+- A conflict is consumed **only after the preconditions pass**. A `412` or `404` is
+  a determinate observation of the destination's current state and is reported as
+  itself rather than replaced by a seeded race — and it does not spend the budget,
+  so a request that was going to fail anyway cannot silently consume what the test
+  armed for the conflict.
+- An **unconditional** write to a seeded key is untouched and spends nothing. AWS
+  documents this code only on the `If-Match` and `If-None-Match` members, so a
+  plain `PutObject` never reports it.
+
+The code and the `409` status are documented in those member docs and in the S3
+user guide's conditional-writes page; **no message text is documented anywhere**,
+and the API model carries no `ConditionalRequestConflict` shape, so substrate's
+message is its own. Assert on the code and the status.
+
+The `404` real S3 can return when a concurrent delete lands mid-write is still not
+modeled as a race: substrate reaches that outcome deterministically, from an
+`If-Match` against a key that is genuinely absent (the row above).
 
 #### Conditional reads
 

--- a/emulator/s3_conditional_conflict_test.go
+++ b/emulator/s3_conditional_conflict_test.go
@@ -1,0 +1,380 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// seedConflict arms a conditional-conflict seed over the control plane. An empty
+// bucket and key seed the wildcard.
+func seedConflict(t *testing.T, srv *emulator.Server, body map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	w := ctrlRequest(t, srv, http.MethodPost, "/v1/s3/conditional-conflict", raw)
+	require.Equal(t, http.StatusOK, w.Code, "seed conflict: %s", w.Body)
+}
+
+// ctrlRequest issues a control-plane request and returns the recorder. The S3
+// helpers all address s3.amazonaws.com, which the control plane is not served
+// under, so this uses a plain localhost target.
+func ctrlRequest(t *testing.T, srv *emulator.Server, method, path string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body != nil {
+		r = httptest.NewRequest(method, "http://localhost"+path, bytes.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, "http://localhost"+path, nil)
+	}
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w
+}
+
+// TestS3_SeededConditionalConflict_PutObject is the acceptance test for #540's
+// PutObject arm: a seeded conflict makes a conditional write that would otherwise
+// succeed report 409 ConditionalRequestConflict, and the budget is spent, so the
+// caller's documented recovery — retry the PUT as-is — then works.
+func TestS3_SeededConditionalConflict_PutObject(t *testing.T) {
+	const bucket, key = "conflict-put", "obj"
+	srv := condFixture(t, bucket)
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": key, "putConflicts": 1})
+
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("first"),
+		map[string]string{"If-None-Match": "*"})
+	require.Equal(t, http.StatusConflict, w.Code, "body: %s", w.Body)
+	assert.Equal(t, "ConditionalRequestConflict", parseS3Error(t, w.Body.Bytes()).Code)
+
+	// The refused write is a no-op: the key must still be absent, or a consumer
+	// retrying would find state the 409 said was not applied.
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodGet, "/"+bucket+"/"+key, nil, nil).Code,
+		"a 409 must leave the key untouched")
+
+	// The budget was one, so the retry AWS documents for this arm succeeds.
+	w = s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("first"),
+		map[string]string{"If-None-Match": "*"})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body)
+	assert.Equal(t, "first", getCondBody(t, srv, bucket, key))
+}
+
+// TestS3_SeededConditionalConflict_IfMatchLeavesObjectIntact covers the other
+// header on the same arm. AWS documents 409 for If-Match as well as If-None-Match
+// — the recovery differs (fetch the ETag first) but the outcome is the same — and
+// the existing object must survive a refused overwrite.
+func TestS3_SeededConditionalConflict_IfMatchLeavesObjectIntact(t *testing.T) {
+	const bucket, key = "conflict-ifmatch", "obj"
+	srv := condFixture(t, bucket)
+	etag := putCondObject(t, srv, bucket, key, "original")
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": key, "putConflicts": 1})
+
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("overwrite"),
+		map[string]string{"If-Match": etag})
+	require.Equal(t, http.StatusConflict, w.Code, "body: %s", w.Body)
+	assert.Equal(t, "ConditionalRequestConflict", parseS3Error(t, w.Body.Bytes()).Code)
+	assert.Equal(t, "original", getCondBody(t, srv, bucket, key),
+		"a 409 must leave the stored object byte-identical")
+}
+
+// TestS3_SeededConditionalConflict_UnconditionalWriteUnaffected is the gate on the
+// seed's scope. AWS documents ConditionalRequestConflict only on the If-Match and
+// If-None-Match members, so a plain PUT to a seeded key must be untouched — and
+// must not spend the budget the test armed for a conditional write.
+func TestS3_SeededConditionalConflict_UnconditionalWriteUnaffected(t *testing.T) {
+	const bucket, key = "conflict-uncond", "obj"
+	srv := condFixture(t, bucket)
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": key, "putConflicts": 1})
+
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("plain"), nil).Code,
+		"an unconditional write must ignore a seeded conflict")
+
+	// The budget is intact, so the next conditional write — one whose precondition
+	// holds, so the seed is the only reason it can fail — still gets its 409.
+	etag := s3Request(t, srv, http.MethodHead, "/"+bucket+"/"+key, nil, nil).Header().Get("ETag")
+	require.NotEmpty(t, etag)
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("cas"),
+		map[string]string{"If-Match": etag})
+	assert.Equal(t, http.StatusConflict, w.Code,
+		"an unconditional write must not consume the budget: %s", w.Body)
+}
+
+// TestS3_SeededConditionalConflict_FailedPreconditionKeepsBudget is the ordering
+// gate. A 412 is a determinate observation of the destination's current state and
+// must be reported as itself rather than replaced by a seeded race — and must not
+// spend the budget, or the conflict the test armed would silently never fire.
+func TestS3_SeededConditionalConflict_FailedPreconditionKeepsBudget(t *testing.T) {
+	const bucket, key = "conflict-order", "obj"
+	srv := condFixture(t, bucket)
+	putCondObject(t, srv, bucket, key, "original")
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": key, "putConflicts": 1})
+
+	// If-None-Match: * against a key that exists is a 412 on its own terms.
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("overwrite"),
+		map[string]string{"If-None-Match": "*"})
+	require.Equal(t, http.StatusPreconditionFailed, w.Code, "body: %s", w.Body)
+	assert.Equal(t, "PreconditionFailed", parseS3Error(t, w.Body.Bytes()).Code)
+
+	// An If-Match against an absent key is the 404 arm, likewise unmasked.
+	w = s3Request(t, srv, http.MethodPut, "/"+bucket+"/absent", []byte("x"),
+		map[string]string{"If-Match": `"whatever"`})
+	require.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body)
+	assert.Equal(t, "NoSuchKey", parseS3Error(t, w.Body.Bytes()).Code)
+
+	// Neither spent the budget, so a write whose preconditions do hold gets the 409.
+	w = s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("cas"),
+		map[string]string{"If-Match": `"nomatch"`})
+	require.Equal(t, http.StatusPreconditionFailed, w.Code,
+		"sanity: a stale ETag is still a 412")
+
+	etag := s3Request(t, srv, http.MethodHead, "/"+bucket+"/"+key, nil, nil).Header().Get("ETag")
+	w = s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("cas"),
+		map[string]string{"If-Match": etag})
+	assert.Equal(t, http.StatusConflict, w.Code,
+		"the budget must survive a request that failed its preconditions: %s", w.Body)
+}
+
+// TestS3_SeededConditionalConflict_CompleteMultipartUpload is the headline gate for
+// #540. AWS documents the recovery from a 409 on Complete as re-initiating with
+// CreateMultipartUpload and re-uploading every part, which is only meaningful if
+// the old upload ID can no longer complete. A CAS loop that instead re-sends
+// Complete with the same ID spins until it gives up, and that bug is invisible
+// unless the ID really dies.
+//
+// This is also the case a FaultController rule cannot express: faults are
+// evaluated before a request reaches its plugin, so a faulted Complete writes no
+// state and its upload ID stays completable.
+func TestS3_SeededConditionalConflict_CompleteMultipartUpload(t *testing.T) {
+	const bucket, key = "conflict-mpu", "obj.bin"
+	srv, uploadID := multipartFixture(t, bucket, key)
+	etag := uploadPart(t, srv, bucket, key, uploadID, 1, []byte("payload"))
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": key, "completeConflicts": 1})
+
+	w := s3Request(t, srv, http.MethodPost, "/"+bucket+"/"+key+"?uploadId="+uploadID,
+		completeBody(etag), map[string]string{"If-None-Match": "*"})
+	require.Equal(t, http.StatusConflict, w.Code, "body: %s", w.Body)
+	assert.Equal(t, "ConditionalRequestConflict", parseS3Error(t, w.Body.Bytes()).Code)
+
+	// The object was not written: a 409 says the write did not happen.
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodGet, "/"+bucket+"/"+key, nil, nil).Code)
+
+	// The upload ID is dead. This is the assertion the issue exists for.
+	w = s3Request(t, srv, http.MethodPost, "/"+bucket+"/"+key+"?uploadId="+uploadID,
+		completeBody(etag), map[string]string{"If-None-Match": "*"})
+	require.Equal(t, http.StatusNotFound, w.Code,
+		"retrying Complete with the same upload ID must not succeed: %s", w.Body)
+	assert.Equal(t, "NoSuchUpload", parseS3Error(t, w.Body.Bytes()).Code)
+
+	assert.Empty(t, openUploadIDs(t, srv, bucket),
+		"a conflicted upload must be gone from the listing")
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodGet, "/"+bucket+"/"+key+"?uploadId="+uploadID, nil, nil).Code,
+		"ListParts on a conflicted upload must be NoSuchUpload")
+
+	// And the documented recovery works: a fresh upload completes.
+	iw := s3Request(t, srv, http.MethodPost, "/"+bucket+"/"+key+"?uploads", nil, nil)
+	require.Equal(t, http.StatusOK, iw.Code)
+	var ir struct {
+		UploadID string `xml:"UploadId"`
+	}
+	require.NoError(t, xml.Unmarshal(iw.Body.Bytes(), &ir))
+	fresh := uploadPart(t, srv, bucket, key, ir.UploadID, 1, []byte("payload"))
+	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPost,
+		"/"+bucket+"/"+key+"?uploadId="+ir.UploadID, completeBody(fresh),
+		map[string]string{"If-None-Match": "*"}).Code)
+}
+
+// TestS3_SeededConditionalConflict_MPU412LeavesUploadOpen is the control for the
+// test above: the 412 arm keeps its documented behavior, so the difference
+// between the two really is the seeded conflict and not multipart Complete having
+// become fragile.
+func TestS3_SeededConditionalConflict_MPU412LeavesUploadOpen(t *testing.T) {
+	const bucket, key = "conflict-mpu-412", "obj.bin"
+	srv, uploadID := multipartFixture(t, bucket, key)
+	etag := uploadPart(t, srv, bucket, key, uploadID, 1, []byte("payload"))
+	putCondObject(t, srv, bucket, key, "existing")
+
+	w := s3Request(t, srv, http.MethodPost, "/"+bucket+"/"+key+"?uploadId="+uploadID,
+		completeBody(etag), map[string]string{"If-None-Match": "*"})
+	require.Equal(t, http.StatusPreconditionFailed, w.Code, "body: %s", w.Body)
+
+	assert.Equal(t, []string{uploadID}, openUploadIDs(t, srv, bucket),
+		"a 412'd Complete must leave the upload open, unlike a 409")
+}
+
+// TestS3_SeededConditionalConflict_CopyObject covers the third arm. CopyObject's
+// preconditions are evaluated against the destination, so the seed is keyed by the
+// destination too.
+func TestS3_SeededConditionalConflict_CopyObject(t *testing.T) {
+	const bucket = "conflict-copy"
+	srv := condFixture(t, bucket)
+	putCondObject(t, srv, bucket, "src", "payload")
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": "dst", "copyConflicts": 1})
+
+	headers := map[string]string{
+		"x-amz-copy-source": "/" + bucket + "/src",
+		"If-None-Match":     "*",
+	}
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/dst", nil, headers)
+	require.Equal(t, http.StatusConflict, w.Code, "body: %s", w.Body)
+	assert.Equal(t, "ConditionalRequestConflict", parseS3Error(t, w.Body.Bytes()).Code)
+	assert.Equal(t, http.StatusNotFound,
+		s3Request(t, srv, http.MethodGet, "/"+bucket+"/dst", nil, nil).Code,
+		"a refused copy must not create the destination")
+
+	w = s3Request(t, srv, http.MethodPut, "/"+bucket+"/dst", nil, headers)
+	require.Equal(t, http.StatusOK, w.Code, "the retry must succeed: %s", w.Body)
+	assert.Equal(t, "payload", getCondBody(t, srv, bucket, "dst"))
+}
+
+// TestS3_SeededConditionalConflict_CountersAreIndependent asserts the three
+// counters do not share a budget: a fixture seeding the multipart arm — the one
+// with the expensive recovery — must be able to do so without perturbing plain
+// writes to the same key.
+func TestS3_SeededConditionalConflict_CountersAreIndependent(t *testing.T) {
+	const bucket, key = "conflict-independent", "obj.bin"
+	srv, uploadID := multipartFixture(t, bucket, key)
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": key, "completeConflicts": 1})
+
+	// A conditional PutObject has no budget of its own and is unaffected.
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("plain"),
+			map[string]string{"If-None-Match": "*"}).Code,
+		"a Put must not consume the Complete counter")
+
+	// The Complete budget is intact. Delete the object first so the precondition
+	// holds and the seed is the reason for the failure.
+	require.Equal(t, http.StatusNoContent,
+		s3Request(t, srv, http.MethodDelete, "/"+bucket+"/"+key, nil, nil).Code)
+	etag := uploadPart(t, srv, bucket, key, uploadID, 1, []byte("payload"))
+	w := s3Request(t, srv, http.MethodPost, "/"+bucket+"/"+key+"?uploadId="+uploadID,
+		completeBody(etag), map[string]string{"If-None-Match": "*"})
+	assert.Equal(t, http.StatusConflict, w.Code, "body: %s", w.Body)
+}
+
+// TestS3_SeededConditionalConflict_WildcardAndPrecedence covers the two ordering
+// rules the seed shares with every other seeded window: a key-scoped seed is
+// consulted before the wildcard, and an **exhausted** key-scoped seed falls
+// through rather than masking a wildcard that still has budget.
+func TestS3_SeededConditionalConflict_WildcardAndPrecedence(t *testing.T) {
+	const bucket = "conflict-wildcard"
+	srv := condFixture(t, bucket)
+	seedConflict(t, srv, map[string]any{"putConflicts": 2})
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": "scoped", "putConflicts": 1})
+
+	put := func(key string) int {
+		return s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("v"),
+			map[string]string{"If-None-Match": "*"}).Code
+	}
+
+	// An unseeded key draws on the wildcard.
+	assert.Equal(t, http.StatusConflict, put("other"), "wildcard applies to any key")
+
+	// The key-scoped seed is consulted first and spends its own budget.
+	assert.Equal(t, http.StatusConflict, put("scoped"), "key-scoped seed fires")
+
+	// Now exhausted, it falls through to the wildcard's remaining budget rather
+	// than masking it.
+	assert.Equal(t, http.StatusConflict, put("scoped"),
+		"an exhausted key-scoped seed must fall through to a funded wildcard")
+
+	// Both are spent.
+	assert.Equal(t, http.StatusOK, put("third"), "no budget left anywhere")
+}
+
+// TestS3_SeededConditionalConflict_ClearAndReseed covers the DELETE arm: clearing
+// one seed leaves the others, and a bare DELETE clears everything including the
+// wildcard.
+func TestS3_SeededConditionalConflict_ClearAndReseed(t *testing.T) {
+	const bucket = "conflict-clear"
+	srv := condFixture(t, bucket)
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": "a", "putConflicts": 1})
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": "b", "putConflicts": 1})
+	seedConflict(t, srv, map[string]any{"putConflicts": 1})
+
+	put := func(key string) int {
+		return s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("v"),
+			map[string]string{"If-None-Match": "*"}).Code
+	}
+
+	w := ctrlRequest(t, srv, http.MethodDelete,
+		fmt.Sprintf("/v1/s3/conditional-conflict?bucket=%s&key=a", bucket), nil)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body)
+
+	// "a" was cleared, so it falls through to the wildcard rather than being
+	// unseeded outright — which is the behavior that would hide a clear that did
+	// nothing, so "b" is the assertion that the clear was targeted.
+	assert.Equal(t, http.StatusConflict, put("a"), "falls through to the wildcard")
+	assert.Equal(t, http.StatusConflict, put("b"), "an untargeted seed survives")
+
+	require.Equal(t, http.StatusOK,
+		ctrlRequest(t, srv, http.MethodDelete, "/v1/s3/conditional-conflict", nil).Code)
+	assert.Equal(t, http.StatusOK, put("c"), "a bare DELETE clears the wildcard too")
+}
+
+// TestS3_SeededConditionalConflict_Endpoint_Rejects covers the request validation.
+// The bucket-without-key case matters most: such a seed would be stored under a
+// key no write can match, so it would look armed and never fire, and the fixture
+// would pass vacuously.
+func TestS3_SeededConditionalConflict_Endpoint_Rejects(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "malformed json", body: `{`},
+		{name: "negative put count", body: `{"bucket":"b","key":"k","putConflicts":-1}`},
+		{name: "negative copy count", body: `{"bucket":"b","key":"k","copyConflicts":-1}`},
+		{name: "negative complete count", body: `{"bucket":"b","key":"k","completeConflicts":-1}`},
+		{name: "bucket without key", body: `{"bucket":"b","putConflicts":1}`},
+		{name: "key without bucket", body: `{"key":"k","putConflicts":1}`},
+	}
+
+	srv := condFixture(t, "conflict-reject")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := ctrlRequest(t, srv, http.MethodPost, "/v1/s3/conditional-conflict", []byte(tt.body))
+			assert.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body)
+		})
+	}
+
+	// The DELETE arm rejects a half-specified target for the same reason: it would
+	// silently clear nothing.
+	w := ctrlRequest(t, srv, http.MethodDelete, "/v1/s3/conditional-conflict?bucket=b", nil)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body)
+}
+
+// TestS3_SeededConditionalConflict_ErrorDocumentShape asserts the wire form. An
+// SDK dispatches on Error.Code, and S3's document is a bare <Error> rather than
+// the wrapped <ErrorResponse> the Query protocol uses — a wrapped body would
+// arrive at the client as a bare "Conflict" from the HTTP status, and a consumer
+// matching on ConditionalRequestConflict would never see their own seed.
+func TestS3_SeededConditionalConflict_ErrorDocumentShape(t *testing.T) {
+	const bucket, key = "conflict-shape", "obj"
+	srv := condFixture(t, bucket)
+	seedConflict(t, srv, map[string]any{"bucket": bucket, "key": key, "putConflicts": 1})
+
+	w := s3Request(t, srv, http.MethodPut, "/"+bucket+"/"+key, []byte("v"),
+		map[string]string{"If-None-Match": "*"})
+	require.Equal(t, http.StatusConflict, w.Code)
+
+	body := w.Body.String()
+	assert.True(t, strings.Contains(body, "<Error>"), "want a bare <Error> document: %s", body)
+	assert.False(t, strings.Contains(body, "<ErrorResponse"),
+		"the Query wrapper would hide the code from an SDK: %s", body)
+
+	parsed := parseS3Error(t, w.Body.Bytes())
+	assert.Equal(t, "ConditionalRequestConflict", parsed.Code)
+	assert.NotEmpty(t, parsed.Message)
+}

--- a/emulator/s3_conditional_control.go
+++ b/emulator/s3_conditional_control.go
@@ -1,0 +1,260 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// s3CtrlNamespace is the state namespace for S3 control-plane (seed) data.
+const s3CtrlNamespace = "s3-ctrl"
+
+// s3CtrlConflictPrefix is the key prefix for every conditional-conflict seed, used
+// to clear all of them.
+const s3CtrlConflictPrefix = "conflict:"
+
+// s3ConditionalConflictMessage accompanies ConditionalRequestConflict.
+//
+// This wording is Substrate's own. The code and the 409 status are documented —
+// they appear in the If-Match and If-None-Match member documentation for
+// PutObject, CopyObject and CompleteMultipartUpload, and in the "Conditional
+// write behavior" section of the S3 user guide — but no message string is
+// documented anywhere, and the API model carries no ConditionalRequestConflict
+// shape and does not list the code in any operation's errors. Per
+// docs/fidelity.md, a message with no corroborating source is Substrate's own
+// and says so here rather than being written to look authoritative. Assert on
+// the code and the status.
+const s3ConditionalConflictMessage = "A conflicting operation occurred during this conditional write. " +
+	"The request was not applied."
+
+// s3ConflictSeed is a seeded 409 ConditionalRequestConflict on a conditional
+// write. S3 returns that code when a concurrent operation — in the documented
+// case, a delete — interferes with a conditional write between its evaluation and
+// its completion. It is a timing accident rather than a state a request can
+// assert, so it cannot be derived by inspecting the current object the way a 412
+// is; seeding is what makes the branch reachable.
+//
+// The branch matters because the three outcomes of a conditional write select
+// different recovery paths in the caller, and only two of them were reachable
+// before this seed existed. A 412 means another writer won: re-read, recompute,
+// retry the compare-and-swap. A 409 on PutObject means retry the PUT as-is. A 409
+// on CompleteMultipartUpload means the upload ID is finished: re-do
+// CreateMultipartUpload and every UploadPart. A CAS loop that answers the third
+// case like the first spins until it gives up, and without this seed that loop
+// looks correct (#540).
+//
+// Fault injection cannot substitute for this. [FaultController] rules are
+// evaluated before a request reaches its plugin, so a faulted Complete writes no
+// state and leaves its upload ID completable — the retry a consumer must not
+// perform still succeeds, which is the defect the seed exists to expose.
+//
+// The budget is counted in occurrences rather than measured as a duration, for
+// the reason recorded on [sqsConsistencySeed]: [TimeController.Now] advances with
+// wall time from its baseline, so a duration-based window would expire partway
+// through a test and make assertions wall-clock dependent, which no test here may
+// be. A counter is exactly reproducible.
+//
+// Keyed by "bucket/key" or the "*" wildcard. The three counters are independent so
+// a fixture can seed the multipart arm — the one with the expensive recovery —
+// without perturbing plain writes; all three default to 0, so an unseeded key
+// behaves exactly as before.
+type s3ConflictSeed struct {
+	// Bucket the seed applies to. Empty, together with an empty Key, seeds the
+	// "*" wildcard.
+	Bucket string `json:"bucket"`
+
+	// Key the seed applies to, within Bucket.
+	Key string `json:"key"`
+
+	// PutConflicts is the number of subsequent conditional PutObject calls on
+	// this key that report ConditionalRequestConflict.
+	PutConflicts int `json:"putConflicts"`
+
+	// CopyConflicts is the same count for CopyObject, evaluated against the
+	// destination key.
+	CopyConflicts int `json:"copyConflicts"`
+
+	// CompleteConflicts is the same count for CompleteMultipartUpload. Consuming
+	// one also invalidates the upload, so the caller's only recovery is the one
+	// AWS documents; see [S3Plugin.consumeConditionalConflict].
+	CompleteConflicts int `json:"completeConflicts"`
+}
+
+// s3ConflictOp names which counter on a seed a conditional write consumes.
+type s3ConflictOp int
+
+const (
+	// s3ConflictPut selects the PutObject counter.
+	s3ConflictPut s3ConflictOp = iota
+
+	// s3ConflictCopy selects the CopyObject counter.
+	s3ConflictCopy
+
+	// s3ConflictComplete selects the CompleteMultipartUpload counter.
+	s3ConflictComplete
+)
+
+// counter returns a pointer to the seed field this operation consumes, so
+// consumeConditionalConflict decrements the right one without duplicating the
+// switch.
+func (op s3ConflictOp) counter(seed *s3ConflictSeed) *int {
+	switch op {
+	case s3ConflictCopy:
+		return &seed.CopyConflicts
+	case s3ConflictComplete:
+		return &seed.CompleteConflicts
+	default:
+		return &seed.PutConflicts
+	}
+}
+
+// s3ConflictKey returns the state key for a conditional-conflict seed. Key-scoped
+// seeds use "conflict:{bucket}/{key}"; the wildcard uses "conflict:*".
+func s3ConflictKey(bucket, key string) string {
+	if bucket == "" && key == "" {
+		return s3CtrlConflictPrefix + "*"
+	}
+	return s3CtrlConflictPrefix + bucket + "/" + key
+}
+
+// consumeConditionalConflict reports whether this conditional write should report
+// a seeded 409 ConditionalRequestConflict instead of proceeding, decrementing the
+// budget when it does. It matches bucket/key exactly first, then the "*" wildcard,
+// and returns false when no seed applies.
+//
+// Callers must consult this only *after* [evaluateWritePreconditions] has passed,
+// and only for a request that actually carries a precondition. Both halves matter.
+// A 412 or a 404 is a determinate observation of the destination's current state
+// and must not be masked by a seeded race — and consuming budget on a request that
+// was going to fail anyway silently spends what the test meant to spend on the
+// conflict, leaving the later assertion meaningless. That is the hazard
+// [SQSPlugin.consumeQueueMiss] names for the same reason. An unconditional write
+// never reports this code at all, because AWS documents it only on the two
+// conditional headers.
+//
+// Consumption takes one dedicated mutex rather than the per-key stripe the caller
+// already holds. The stripe is chosen by hashing bucket/key, but the wildcard seed
+// is shared across every key, so two concurrent writes to *different* keys hold
+// different stripes and could both read a budget of 1, both decrement to 0 and
+// both Put — consuming one seeded conflict twice, exactly the read-modify-write
+// hazard [s3KeyMutex] exists to close (there is no compare-and-swap on
+// [StateManager]). Seed consumption is a harness-frequency operation, so a single
+// mutex costs nothing here. The lock order is always key-stripe → seed mutex and
+// never the reverse, so the two cannot deadlock.
+func (p *S3Plugin) consumeConditionalConflict(ctx context.Context, bucket, key string, op s3ConflictOp) (bool, error) {
+	p.seedMu.Lock()
+	defer p.seedMu.Unlock()
+
+	for _, stateKey := range []string{s3ConflictKey(bucket, key), s3ConflictKey("", "")} {
+		data, err := p.state.Get(ctx, s3CtrlNamespace, stateKey)
+		if err != nil {
+			return false, fmt.Errorf("s3 consumeConditionalConflict get: %w", err)
+		}
+		if data == nil {
+			continue
+		}
+		var seed s3ConflictSeed
+		if err := json.Unmarshal(data, &seed); err != nil {
+			return false, fmt.Errorf("s3 consumeConditionalConflict unmarshal: %w", err)
+		}
+
+		counter := op.counter(&seed)
+		if *counter <= 0 {
+			// This seed exists but has nothing left for this operation. Fall
+			// through to the wildcard: an exhausted key-scoped seed must not mask
+			// a wildcard seed that still has budget.
+			continue
+		}
+
+		*counter--
+		updated, err := json.Marshal(seed)
+		if err != nil {
+			return false, fmt.Errorf("s3 consumeConditionalConflict marshal: %w", err)
+		}
+		if err := p.state.Put(ctx, s3CtrlNamespace, stateKey, updated); err != nil {
+			return false, fmt.Errorf("s3 consumeConditionalConflict put: %w", err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// s3ConditionalConflictResponse returns the 409 ConditionalRequestConflict a
+// seeded conflict serves. It goes through [s3ErrorResponse] so the document is
+// byte-identical to the one a genuine S3 error would produce — a bare <Error>
+// rather than the wrapped <ErrorResponse> the Query protocol uses — which is what
+// lets an SDK recover the code instead of falling back to the HTTP status.
+func s3ConditionalConflictResponse() *AWSResponse {
+	return s3ErrorResponse("ConditionalRequestConflict", s3ConditionalConflictMessage, http.StatusConflict)
+}
+
+// handleS3SeedConditionalConflict handles POST /v1/s3/conditional-conflict. It
+// seeds how many subsequent conditional writes to a key report
+// 409 ConditionalRequestConflict, modeling the concurrent-delete race AWS
+// documents. Body:
+// {"bucket","key","putConflicts","copyConflicts","completeConflicts"}; an empty
+// bucket and key seed the "*" wildcard.
+func (s *Server) handleS3SeedConditionalConflict(w http.ResponseWriter, r *http.Request) {
+	var seed s3ConflictSeed
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.PutConflicts < 0 || seed.CopyConflicts < 0 || seed.CompleteConflicts < 0 {
+		http.Error(w, `{"error":"conflict counts must not be negative"}`, http.StatusBadRequest)
+		return
+	}
+	// A bucket without a key (or the reverse) would be stored under a key no write
+	// can ever match, so it would look armed and never fire. Refusing it is the
+	// difference between a fixture that fails and one that passes vacuously.
+	if (seed.Bucket == "") != (seed.Key == "") {
+		http.Error(w, `{"error":"bucket and key must be given together, or both omitted for the wildcard"}`,
+			http.StatusBadRequest)
+		return
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	stateKey := s3ConflictKey(seed.Bucket, seed.Key)
+	if err := s.state.Put(r.Context(), s3CtrlNamespace, stateKey, data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true, "key": strings.TrimPrefix(stateKey, s3CtrlConflictPrefix)})
+}
+
+// handleS3ClearConditionalConflict handles DELETE /v1/s3/conditional-conflict.
+// With ?bucket=&key= it removes that seed; without either it removes all,
+// including the wildcard.
+func (s *Server) handleS3ClearConditionalConflict(w http.ResponseWriter, r *http.Request) {
+	bucket := r.URL.Query().Get("bucket")
+	key := r.URL.Query().Get("key")
+	if bucket != "" || key != "" {
+		if bucket == "" || key == "" {
+			http.Error(w, `{"error":"bucket and key must be given together"}`, http.StatusBadRequest)
+			return
+		}
+		if err := s.state.Delete(r.Context(), s3CtrlNamespace, s3ConflictKey(bucket, key)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), s3CtrlNamespace, s3CtrlConflictPrefix)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), s3CtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -52,6 +53,12 @@ type S3Plugin struct {
 	registry   *PluginRegistry // nil = notifications disabled
 	versionSeq int64           // monotonic counter for unique version IDs
 	keyLocks   s3KeyMutex      // serializes conditional writes per object key
+
+	// seedMu serializes consumption of a seeded conditional conflict. It is
+	// deliberately not the per-key stripe set above; see
+	// [S3Plugin.consumeConditionalConflict] for why the wildcard seed needs a
+	// lock that is not keyed by the object it applies to.
+	seedMu sync.Mutex
 }
 
 // Name returns the service name "s3".
@@ -815,6 +822,19 @@ func (p *S3Plugin) putObject(reqCtx *RequestContext, req *AWSRequest, bucket, ke
 			// stored object byte-identical.
 			return resp, nil
 		}
+
+		// The preconditions hold, so this write would succeed — which is the only
+		// point at which a seeded conflict is the right answer. A 412 or 404 above
+		// is a determinate observation of state and must not be masked, and a
+		// budget spent on a request that was going to fail anyway is a budget the
+		// test cannot spend on the conflict (#540).
+		conflict, cfErr := p.consumeConditionalConflict(ctx, bucket, key, s3ConflictPut)
+		if cfErr != nil {
+			return nil, cfErr
+		}
+		if conflict {
+			return s3ConditionalConflictResponse(), nil
+		}
 	}
 
 	body, trailers := decodeAWSChunkedWithTrailers(req.Headers, req.Body)
@@ -1400,6 +1420,17 @@ func (p *S3Plugin) copyObject(_ *RequestContext, req *AWSRequest, dstBucket, dst
 		}
 		if resp := evaluateWritePreconditions(cond, current); resp != nil {
 			return resp, nil
+		}
+
+		// Seeded conflicts are consumed after the preconditions pass, for the
+		// reasons on [S3Plugin.consumeConditionalConflict]. CopyObject has its own
+		// counter, so seeding a copy conflict does not perturb plain writes.
+		conflict, cfErr := p.consumeConditionalConflict(ctx, dstBucket, dstKey, s3ConflictCopy)
+		if cfErr != nil {
+			return nil, cfErr
+		}
+		if conflict {
+			return s3ConditionalConflictResponse(), nil
 		}
 	}
 
@@ -2264,6 +2295,35 @@ func (p *S3Plugin) completeMultipartUpload(_ *RequestContext, req *AWSRequest, b
 		if resp := evaluateWritePreconditions(cond, current); resp != nil {
 			// The upload stays open: a caller that lost the race can abort it.
 			return resp, nil
+		}
+
+		// A seeded conflict on Complete additionally *invalidates the upload*, which
+		// the 412 above deliberately does not. That asymmetry is the whole reason
+		// this arm is seedable separately: AWS documents the recovery from a 412 as
+		// retrying the compare-and-swap, and the recovery from a 409 as
+		// re-initiating with CreateMultipartUpload and re-uploading every part —
+		// advice that is only meaningful if the old upload ID can no longer
+		// complete. A CAS loop that answers a 409 by re-sending Complete with the
+		// same ID spins until it gives up, and that bug is invisible unless the ID
+		// really dies here (#540).
+		//
+		// The inference from that documented advice to "the ID is dead" is
+		// Substrate's; AWS documents the recovery, not the state of the upload.
+		//
+		// This is also why the seed lives here rather than in a FaultController
+		// rule, which is what #540 originally proposed: faults are evaluated before
+		// a request reaches its plugin, so a faulted Complete writes no state and
+		// its upload ID stays completable — reproducing the code but not the
+		// consequence, and passing the very loop the code exists to catch.
+		conflict, cfErr := p.consumeConditionalConflict(ctx, bucket, key, s3ConflictComplete)
+		if cfErr != nil {
+			return nil, cfErr
+		}
+		if conflict {
+			if abortErr := p.abortUploadState(ctx, uploadID); abortErr != nil {
+				return nil, fmt.Errorf("invalidate upload after seeded conflict: %w", abortErr)
+			}
+			return s3ConditionalConflictResponse(), nil
 		}
 	}
 

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -303,6 +303,8 @@ func (s *Server) buildRouter() *chi.Mux {
 
 	// S3 control-plane endpoints.
 	r.Post("/v1/s3/presign", s.handleS3Presign)
+	r.Post("/v1/s3/conditional-conflict", s.handleS3SeedConditionalConflict)
+	r.Delete("/v1/s3/conditional-conflict", s.handleS3ClearConditionalConflict)
 
 	r.Get("/ui", s.handleDebugUI)
 	r.Get("/v1/debug/events", s.handleDebugEvents)


### PR DESCRIPTION
## The gap

S3 conditional writes in Substrate could produce two of the three outcomes AWS
documents — `412 PreconditionFailed` and `404 NoSuchKey` — but never the `409
ConditionalRequestConflict` S3 returns when a concurrent operation interferes with
a conditional write between its evaluation and its completion.

The three are not interchangeable, and the recovery each demands differs:

| Outcome | Meaning | Documented recovery |
|---|---|---|
| `412 PreconditionFailed` | another writer won | re-read, recompute, retry the CAS |
| `404 NoSuchKey` on `If-Match` | the object is gone | re-upload rather than retry the CAS |
| `409` on `PutObject` / `CopyObject` | a delete interleaved | retry as-is (for `If-Match`, fetch the current ETag first) |
| `409` on `CompleteMultipartUpload` | a delete interleaved | **abandon the upload ID** — re-do `CreateMultipartUpload` and every `UploadPart` |

A CAS loop that answers the last case like the first re-sends Complete with an
upload ID that can never complete again and spins until it gives up. Against
Substrate that loop looked correct, because only 412 was reachable.

## Why a seed, and not the fault rule the issue proposed

#540 prefers making the code fault-injectable. **Measured: that produces the code
but not its consequence.** `InjectFault` runs at step 4.5 (`server.go:636`),
*before* `registry.RouteRequest`, so a fault never reaches the plugin and writes no
state. With a rule armed on `CompleteMultipartUpload`, the first Complete returned
the injected 409 and **the immediate retry with the same upload ID returned 200**
with `ETag "0b5160c2adf21a2967b0bb17bb704b12-1"` — passing the exact loop the code
exists to catch. (Control: a genuinely-successful Complete retried gives
`NoSuchUpload`.) Full evidence in
https://github.com/scttfrdmn/substrate/issues/540#issuecomment-5208109275.

So this is a plugin-level seed, which reaches the plugin and can therefore call
`abortUploadState`. The issue's option 1 (a per-key recently-deleted window) is
rejected for the reason the issue itself gives: it makes Substrate keep state to
model a timing accident.

## What this adds

`POST /v1/s3/conditional-conflict` seeds how many subsequent conditional writes to
a key report the code; `DELETE` clears one (`?bucket=&key=`) or all.

```bash
curl -X POST localhost:4566/v1/s3/conditional-conflict \
  -d '{"bucket":"cond","key":"big","completeConflicts":1}'
```

Keyed `bucket/key` or by the `*` wildcard, with independent counters per operation
(`putConflicts`, `copyConflicts`, `completeConflicts`) so a fixture can seed the
multipart arm — the one with the expensive recovery — without perturbing plain
writes. It follows the established seed pattern (`sqs_control.go`) down to its
reasoning: key-scoped consulted before the wildcard, **falling through when
exhausted** so a spent key-scoped seed cannot mask a funded wildcard, and counted
in **occurrences rather than measured as a duration**, because `TimeController.Now`
advances with wall time and a duration window would make assertions wall-clock
dependent.

**Consuming a seeded multipart conflict invalidates the upload.** A same-ID retry
gets `NoSuchUpload`, and `ListParts` on that ID is gone. This deliberately
contradicts the 412 arm, which leaves the upload open, and the comment at the call
site explains why: AWS documents the 409 recovery as re-initiating and re-uploading
every part, advice only meaningful if the old ID cannot complete. The inference from
that advice to "the ID is dead" is Substrate's, and the comment says so.

## Nothing changes for an unseeded caller

- A conflict is consumed **only after `evaluateWritePreconditions` passes**. A 412
  or 404 is a determinate observation of the destination's current state, is still
  reported as itself, and **does not spend the budget** — otherwise a request that
  was going to fail anyway silently consumes what the test armed for the conflict.
- An **unconditional** write to a seeded key is untouched and spends nothing; AWS
  documents this code only on the two conditional headers.
- `bucket` and `key` must be given together (a `400` otherwise), because such a
  seed would be stored under a key no write can match: it would look armed, never
  fire, and the fixture would pass vacuously.

## Provenance

The code and the `409` status are documented — they appear in the `IfMatch` and
`IfNoneMatch` member docs for all three operations, and in the user guide's
conditional-writes page. **No message text is documented anywhere**: the model
carries no `ConditionalRequestConflict` shape and lists the code in no operation's
`errors`. Per `docs/fidelity.md` the message is Substrate's own and the comment
beside the literal says so. Assert on the code and the status.

## Concurrency

Consumption takes a dedicated mutex rather than the per-key stripe the caller
already holds. The stripe is chosen by hashing bucket/key, but the wildcard seed is
shared across every key, so two concurrent writes to *different* keys hold
different stripes and could both read a budget of 1 and both decrement — the
read-modify-write hazard `s3KeyMutex` exists to close, since `StateManager` has no
compare-and-swap. Lock order is always key-stripe → seed mutex.

The same window exists in `consumeQueueMiss` on the SQS side; filed separately as
#582 rather than fixed here.

## Tests

Twelve tests in `emulator/s3_conditional_conflict_test.go`. The headline gate seeds
the multipart arm, asserts 409, then asserts the same-ID retry is `NoSuchUpload`
with `ListParts` and the upload listing gone — plus its control, that a 412'd
Complete still leaves the upload open. Also: both headers on the Put arm, Copy, the
counters' independence, key-scoped-beats-wildcard and the fall-through, an
unconditional write untouched, a failed precondition keeping its budget, a refused
write leaving the object byte-identical, the bare `<Error>` wire shape (a wrapped
document would hide the code from an SDK), and the endpoint's validation.

**Mutation tested**, 7 mutants, all CAUGHT: `abortUploadState` dropped from the
Complete arm; the seed consulted before the preconditions; `continue` → `return` on
an exhausted counter; the `cond.any()` gate removed; the decrement dropped;
`StatusConflict` → `StatusPreconditionFailed`; the bucket-XOR-key validation
dropped.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0
issues), `make test` (race), `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test
-C test/e2e ./...` — all clean.

End to end against `substrate server --address :4621` with the real AWS CLI:

```
$ aws s3api complete-multipart-upload --bucket cond --key big --upload-id "$UP" --if-none-match '*' ...
An error occurred (ConditionalRequestConflict) when calling the CompleteMultipartUpload operation: ...
$ aws s3api complete-multipart-upload --bucket cond --key big --upload-id "$UP" --if-none-match '*' ...
An error occurred (NoSuchUpload) when calling the CompleteMultipartUpload operation: ...
$ aws s3api list-parts --bucket cond --key big --upload-id "$UP"
An error occurred (NoSuchUpload) when calling the ListParts operation: ...
```

The plain arm (409 then 200), the copy arm, an unconditional write to a seeded key
(200, budget unspent), and both `400` validations were checked the same way.

## Docs

`docs/services.md`'s "Conditional writes" section gains the outcome, the recovery
table, the endpoint with `curl` examples, the precedence and
counted-in-occurrences rules, and the upload-invalidation asymmetry. The paragraph
claiming 409 is "deliberately not emulated" is gone — it is now false. The three
operation rows cross-reference it.

Closes #540
