### PR TITLE
fix(fault): each rule draws from its own PRNG (#510)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Each fault rule draws from its own PRNG** (#510). `FaultController` rolled
+  `probability` from one PRNG shared by every rule, so a rule's outcomes depended on
+  how many rolls the rules before it had taken. A fixed seed therefore reproduced a
+  run only while the whole sequence of requests was unchanged: adding a request
+  upstream, or a retry, shifted every later roll — including for rules that request
+  never touched. A rule now has its own stream, so its outcome sequence depends only
+  on how many requests *that* rule matched.
+
+  Streams are seeded from the controller's seed and the rule's **index**, mixed
+  through FNV, and re-derived whenever a config is armed — so re-arming resets them
+  exactly as it resets each rule's `fired` count. Keying by index rather than by the
+  rule's matchers is deliberate: two rules with identical matchers are legitimate and
+  must not share a stream, and a matcher hash would make editing a path suffix
+  silently reshuffle outcomes. The cost is that **reordering rules changes their
+  outcomes**, which the field's documentation now states.
+
+  **Compatibility:** a consumer asserting on specific outcomes of a seeded
+  intermediate `probability` will see different results and must re-record them.
+  Nothing changes for `probability` of 0 or 1, or for a rule bounded by `times`,
+  which needs no roll at all.
+
 ### Added
 - **A seedable `409 ConditionalRequestConflict` on S3 conditional writes** (#540).
   `PutObject`, `CopyObject` and `CompleteMultipartUpload` could reach two of the

--- a/docs/services.md
+++ b/docs/services.md
@@ -4571,12 +4571,16 @@ apart can tell a fixture from production.
 `cloudfront` and `route53` are REST-XML like S3 but keep the `<ErrorResponse>` shape:
 their real error documents genuinely are wrapped, so they were already correct.
 
-### `probability` determinism depends on request ordering
+### `probability` draws from a per-rule PRNG
 
-The PRNG behind `probability` is shared by every rule in a configuration and is rolled
-once per *matching* rule per request, so a fixed seed reproduces a run only while the
-whole sequence of requests is unchanged. Adding a request upstream, or a retry, shifts
-every later roll — including for rules that request never touched. Prefer `times` for a
-bounded outcome: it needs no roll at all. Per-rule PRNGs would fix this and would change
-the outcome of existing seeded runs, so it is tracked separately as
-[#510](https://github.com/scttfrdmn/substrate/issues/510).
+Each rule draws from its own PRNG stream, seeded from the controller's seed and the
+rule's index. A rule's outcome sequence therefore depends only on how many requests
+that rule itself matched: adding an unrelated rule, or changing how often one matches,
+leaves the others' rolls unchanged. Streams are re-derived whenever a configuration is
+armed, so re-arming resets them exactly as it resets each rule's `fired` count.
+
+The stream is keyed by a rule's **index**, so reordering rules does change their
+outcomes. That is deliberate — two rules with identical matchers are legitimate and
+useful, and keying by the matchers instead would make them share a stream and would
+make editing a path suffix silently reshuffle results. Prefer `times` for a bounded
+outcome regardless: it needs no roll at all.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -438,11 +438,12 @@ Four things are worth knowing before writing a fixture (all four are #480):
   `fired` member of `GET /v1/fault/rules` over the wire, is what tells them apart.
   Arming rules again resets the counts, so a fixture that re-arms between phases
   gets its full budget back.
-- **`Probability` depends on request ordering.** The PRNG is shared by every rule in
-  a `FaultConfig` and is rolled once per matching rule per request, so a fixed seed
-  reproduces a run only while the sequence of requests is unchanged — adding a
-  request upstream, or a retry, shifts every later roll. Prefer `Times` for a
-  bounded outcome: it needs no roll at all. See #510.
+- **`Probability` draws from a per-rule PRNG.** Each rule has its own stream, so its
+  outcome sequence depends only on how many requests *that* rule matched — adding an
+  unrelated rule, or a retry that another rule handles, does not shift it. Streams
+  are keyed by a rule's index and reset when a config is armed, so reordering rules
+  does change their outcomes. Prefer `Times` for a bounded outcome regardless: it
+  needs no roll at all.
 
 An injected error is serialized in the same wire shape the target service's own
 errors use, so an SDK recovers the code rather than falling back to the HTTP status

--- a/emulator/fault.go
+++ b/emulator/fault.go
@@ -1,8 +1,10 @@
 package emulator
 
 import (
+	"hash/fnv"
 	"math/rand" // nosemgrep
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -71,11 +73,16 @@ type FaultRule struct {
 	// fault, in the range [0.0, 1.0]. A value of 1.0 (the default) fires on
 	// every matching request.
 	//
-	// The PRNG behind this is shared by every rule in a FaultConfig and is
-	// rolled once per matching rule per request, so a fixed seed reproduces a
-	// run only while the sequence of requests is unchanged. Adding a request
-	// upstream, or a retry, shifts every later roll. Prefer Times for a bounded
-	// outcome: it needs no roll at all. See #510.
+	// Each rule draws from its own PRNG stream, so a rule's outcome sequence
+	// depends only on how many requests that rule itself matched — not on what
+	// any other rule in the config matched. Adding an unrelated rule, or
+	// changing how often one matches, leaves the others' rolls unchanged.
+	// Streams are re-derived whenever the config is armed, so re-arming a config
+	// resets them exactly as it resets [FaultRule.Fired].
+	//
+	// A rule's stream is derived from its **index** in the config, so reordering
+	// rules does change their outcomes. Prefer Times for a bounded outcome: it
+	// needs no roll at all.
 	Probability float64 `json:"probability,omitempty"`
 
 	// Times bounds how many matching requests the rule fires on. Zero means
@@ -125,23 +132,70 @@ type FaultConfig struct {
 }
 
 // FaultController injects configurable faults (errors and latency) into the
-// Substrate request pipeline. It uses a seeded, non-global PRNG for
-// deterministic fault firing in tests.
+// Substrate request pipeline. It uses seeded, non-global PRNGs for deterministic
+// fault firing in tests.
 type FaultController struct {
 	mu     sync.Mutex
 	config FaultConfig
-	rng    *rand.Rand
+
+	// seed is kept so the per-rule streams can be re-derived when the config is
+	// replaced.
+	seed int64
+
+	// rngs holds one PRNG per rule in config.Rules, parallel to that slice.
+	// Per-rule streams are what make a seeded run reproducible: with one shared
+	// PRNG, rule 2's outcomes depended on how many rolls rule 1 had taken, so
+	// adding a request upstream or an unrelated rule shifted every later roll
+	// and a fixed seed reproduced a run only while request ordering was
+	// unchanged (#510).
+	rngs []*rand.Rand
 }
 
 // NewFaultController creates a FaultController with the given configuration.
-// seed controls the PRNG used for probabilistic fault firing; use a fixed seed
-// in tests for determinism, subject to the caveat on [FaultRule.Probability]
-// that makes a bounded [FaultRule.Times] the more reproducible choice.
+// seed controls the PRNGs used for probabilistic fault firing; use a fixed seed
+// in tests for determinism.
 func NewFaultController(cfg FaultConfig, seed int64) *FaultController {
+	owned := cfg.withOwnedRules()
 	return &FaultController{
-		config: cfg.withOwnedRules(),
-		rng:    rand.New(rand.NewSource(seed)), //nolint:gosec // not used for cryptography
+		config: owned,
+		seed:   seed,
+		rngs:   ruleRNGs(seed, len(owned.Rules)),
 	}
+}
+
+// ruleRNGs returns n PRNGs, one per rule, each seeded from the controller's seed
+// and the rule's index.
+//
+// The index is what identifies a stream, deliberately, rather than a hash of the
+// rule's matchers. Two rules with identical matchers are legitimate and useful —
+// fail with one error, then with another — and a matcher hash would make them
+// share a stream, which is the coupling this change exists to remove. A matcher
+// hash would also make a rule's outcomes depend on its matcher *text*, so editing
+// a path suffix would silently reshuffle results; that is a worse surprise than
+// reordering rules, which is at least visible in the config. The cost is that
+// reordering rules does change their streams, which [FaultRule.Probability]
+// documents.
+//
+// The seed and index are mixed through FNV rather than added. Measured, both
+// schemes decorrelate adjacent rules equally well on this scale — Go's source
+// scrambles nearby seeds on its own — so this buys no measurable independence.
+// It is used because that scrambling is an unspecified property of math/rand
+// rather than a documented one: mixing first means the streams do not depend on
+// it, and a rule's independence from its neighbors does not become a thing a Go
+// release can quietly change. Mixing also keeps a controller's seed from
+// colliding with an adjacent controller's, since seed+i and (seed+1)+(i-1) are
+// the same source.
+func ruleRNGs(seed int64, n int) []*rand.Rand {
+	rngs := make([]*rand.Rand, n)
+	for i := range rngs {
+		h := fnv.New64a()
+		_, _ = h.Write([]byte(strconv.FormatInt(seed, 10)))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(strconv.Itoa(i)))
+		//nolint:gosec // not used for cryptography
+		rngs[i] = rand.New(rand.NewSource(int64(h.Sum64())))
+	}
+	return rngs
 }
 
 // withOwnedRules returns cfg with a private copy of its rule slice, so the
@@ -184,7 +238,7 @@ func (f *FaultController) InjectFault(_ *RequestContext, req *AWSRequest) (*AWSE
 		if p <= 0 {
 			p = 1.0
 		}
-		if f.rng.Float64() >= p {
+		if f.ruleRNG(i).Float64() >= p {
 			continue
 		}
 		switch rule.FaultType {
@@ -215,13 +269,32 @@ func (f *FaultController) InjectFault(_ *RequestContext, req *AWSRequest) (*AWSE
 	return nil, 0
 }
 
+// ruleRNG returns the PRNG for the rule at index i, which the caller must hold
+// f.mu to use.
+//
+// rngs is built parallel to config.Rules and rebuilt with it, so the index is
+// always in range in practice. The fallback covers a FaultController that reached
+// InjectFault without going through [NewFaultController] or
+// [FaultController.UpdateConfig] — a panic there would surface as a broken
+// emulator rather than as the misconfiguration it is.
+func (f *FaultController) ruleRNG(i int) *rand.Rand {
+	if i < len(f.rngs) {
+		return f.rngs[i]
+	}
+	f.rngs = append(f.rngs, ruleRNGs(f.seed, i+1)[len(f.rngs):]...)
+	return f.rngs[i]
+}
+
 // UpdateConfig replaces the fault injection configuration. It is safe to call
 // concurrently with InjectFault. Arming a rule again starts its Times bound
-// over, because the incoming rules carry their own fired counts.
+// over, because the incoming rules carry their own fired counts — and resets the
+// per-rule PRNG streams for the same reason, so an armed config behaves
+// identically whether it is the first one or the fifth.
 func (f *FaultController) UpdateConfig(cfg FaultConfig) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.config = cfg.withOwnedRules()
+	f.rngs = ruleRNGs(f.seed, len(f.config.Rules))
 }
 
 // GetConfig returns a snapshot of the current fault injection configuration,

--- a/emulator/fault_prng_test.go
+++ b/emulator/fault_prng_test.go
@@ -1,0 +1,159 @@
+package emulator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// probeRule returns a rule that fires on one service half the time, unbounded, so
+// its outcome sequence is a PRNG trace rather than a Times bound.
+func probeRule(service string) emulator.FaultRule {
+	return emulator.FaultRule{
+		Service:     service,
+		FaultType:   "error",
+		ErrorCode:   "ServiceUnavailable",
+		HTTPStatus:  503,
+		Probability: 0.5,
+		Times:       -1,
+	}
+}
+
+// outcomes drives n requests against one service and records which fired, which is
+// the observable trace of that rule's PRNG stream.
+func outcomes(fc *emulator.FaultController, service string, n int) []bool {
+	got := make([]bool, n)
+	for i := range got {
+		awsErr, _ := fc.InjectFault(&emulator.RequestContext{},
+			&emulator.AWSRequest{Service: service, Operation: "PutObject"})
+		got[i] = awsErr != nil
+	}
+	return got
+}
+
+// TestFaultController_RuleStreamsAreIndependent is #510's acceptance property: a
+// rule's outcome sequence must not depend on how many requests *another* rule
+// matched. With one shared PRNG it did — every roll rule 1 took shifted rule 2's
+// entire sequence — so a fixed seed reproduced a run only while request ordering
+// was unchanged, which is the opposite of what a deterministic emulator is for.
+func TestFaultController_RuleStreamsAreIndependent(t *testing.T) {
+	cfg := func() emulator.FaultConfig {
+		return emulator.FaultConfig{
+			Enabled: true,
+			Rules:   []emulator.FaultRule{probeRule("sqs"), probeRule("s3")},
+		}
+	}
+
+	// Baseline: rule 1 (sqs) matches nothing, so only rule 2's stream advances.
+	baseline := outcomes(emulator.NewFaultController(cfg(), 42), "s3", 20)
+
+	// Now drive rule 1 hard first. Under a shared PRNG this consumed rolls that
+	// rule 2 would otherwise have taken, and every s3 outcome moved.
+	fc := emulator.NewFaultController(cfg(), 42)
+	outcomes(fc, "sqs", 7)
+	withNoise := outcomes(fc, "s3", 20)
+
+	assert.Equal(t, baseline, withNoise,
+		"rule 2's outcomes must not depend on how many requests rule 1 matched")
+
+	// Interleaving the two must not shift either, for the same reason.
+	fc = emulator.NewFaultController(cfg(), 42)
+	interleaved := make([]bool, 0, 20)
+	for i := 0; i < 20; i++ {
+		outcomes(fc, "sqs", 1)
+		interleaved = append(interleaved, outcomes(fc, "s3", 1)...)
+	}
+	assert.Equal(t, baseline, interleaved, "interleaving must not shift a rule's stream")
+}
+
+// TestFaultController_UnrelatedRuleDoesNotShiftOutcomes is the config-editing half
+// of the same property: adding a rule that never matches must leave the existing
+// rules' outcomes alone. Under a shared PRNG this held only because the added rule
+// never rolled; a rule added *before* another still shifts it, which is why the
+// stream is keyed by index and the docs say so.
+func TestFaultController_UnrelatedRuleDoesNotShiftOutcomes(t *testing.T) {
+	one := emulator.NewFaultController(emulator.FaultConfig{
+		Enabled: true,
+		Rules:   []emulator.FaultRule{probeRule("s3")},
+	}, 7)
+	two := emulator.NewFaultController(emulator.FaultConfig{
+		Enabled: true,
+		Rules:   []emulator.FaultRule{probeRule("s3"), probeRule("sqs")},
+	}, 7)
+
+	assert.Equal(t, outcomes(one, "s3", 15), outcomes(two, "s3", 15),
+		"appending a rule must not change an existing rule's outcomes")
+}
+
+// TestFaultController_FixedSeedStillReproduces asserts independence did not cost
+// reproducibility, which is the whole point of a seed. Two controllers built from
+// the same seed and config must trace identically, and a different seed must not.
+func TestFaultController_FixedSeedStillReproduces(t *testing.T) {
+	cfg := emulator.FaultConfig{
+		Enabled: true,
+		Rules:   []emulator.FaultRule{probeRule("s3"), probeRule("sqs")},
+	}
+
+	first := emulator.NewFaultController(cfg, 99)
+	second := emulator.NewFaultController(cfg, 99)
+	trace := func(fc *emulator.FaultController) []bool {
+		return append(outcomes(fc, "s3", 12), outcomes(fc, "sqs", 12)...)
+	}
+	want := trace(first)
+	assert.Equal(t, want, trace(second), "a fixed seed must reproduce a run exactly")
+
+	// Not vacuous: the trace must actually contain both outcomes, or "identical"
+	// would be satisfied by a rule that never fires.
+	assert.Contains(t, want, true, "the probe must fire sometimes")
+	assert.Contains(t, want, false, "the probe must decline sometimes")
+
+	assert.NotEqual(t, want, trace(emulator.NewFaultController(cfg, 100)),
+		"a different seed must produce a different run")
+}
+
+// TestFaultController_AdjacentRulesAreNotCorrelated asserts two adjacent rules
+// with the same probability do not trace identically, which is what a fixture
+// using both to model independent failures depends on. It does not distinguish
+// FNV-mixing the index from adding it — measured, both decorrelate adjacent rules
+// equally well on this scale — and it is not meant to; see [ruleRNGs] for why the
+// mixing is there anyway.
+func TestFaultController_AdjacentRulesAreNotCorrelated(t *testing.T) {
+	fc := emulator.NewFaultController(emulator.FaultConfig{
+		Enabled: true,
+		Rules:   []emulator.FaultRule{probeRule("s3"), probeRule("sqs")},
+	}, 1)
+
+	first := outcomes(fc, "s3", 30)
+	second := outcomes(fc, "sqs", 30)
+	assert.NotEqual(t, first, second,
+		"two rules with the same probability must not trace identically")
+}
+
+// TestFaultController_ReArmingResetsStreams asserts the streams are re-derived on
+// UpdateConfig, exactly as the fired counts are. A fixture that re-arms between
+// phases gets its full budget back; it must get the same rolls back too, or the
+// second phase of a two-phase test is not reproducible.
+func TestFaultController_ReArmingResetsStreams(t *testing.T) {
+	cfg := emulator.FaultConfig{
+		Enabled: true,
+		Rules:   []emulator.FaultRule{probeRule("s3")},
+	}
+	fc := emulator.NewFaultController(cfg, 5)
+	first := outcomes(fc, "s3", 15)
+
+	fc.UpdateConfig(cfg)
+	assert.Equal(t, first, outcomes(fc, "s3", 15),
+		"re-arming a config must reset the PRNG streams, as it resets fired counts")
+
+	// A config armed with more rules gets a stream for each of them.
+	fc.UpdateConfig(emulator.FaultConfig{
+		Enabled: true,
+		Rules:   []emulator.FaultRule{probeRule("s3"), probeRule("sqs")},
+	})
+	assert.Equal(t, first, outcomes(fc, "s3", 15),
+		"rule 0's stream is unchanged by a rule appended after it")
+	require.NotEmpty(t, outcomes(fc, "sqs", 5), "the appended rule must be armed")
+}


### PR DESCRIPTION
## The gap

`FaultController` rolled `probability` from **one PRNG shared by every rule**, so a
rule's outcomes depended on how many rolls the rules before it had taken. A fixed
seed reproduced a run only while the whole sequence of requests was unchanged:
adding a request upstream, or a retry, shifted every later roll — including for
rules that request never touched. That is the opposite of what a deterministic
emulator is for, and the caveat documenting it was the largest asterisk on the
fault tier.

## The fix

Each rule gets its own PRNG stream, so its outcome sequence depends only on how
many requests *that* rule matched. Streams are re-derived whenever a config is
armed, so re-arming resets them exactly as it resets each rule's `fired` count —
which matters for a fixture that re-arms between phases.

**The index identifies a stream, not a hash of the rule's matchers** — the decision
#510 asks to be made in the issue. Two rules with identical matchers are legitimate
and useful (fail with one error, then with another), and a matcher hash would make
them share a stream, which is the exact coupling this removes. A matcher hash would
also make a rule's outcomes depend on its matcher *text*, so editing a path suffix
would silently reshuffle results — a worse surprise than reordering rules, which is
at least visible in the config. The cost is that reordering rules does change their
outcomes, and `FaultRule.Probability` now says so.

## On the FNV mixing, and a correction

Seed and index are mixed through FNV rather than added. My earlier comment on #510
justified this by claiming adjacent seeds give correlated streams in Go's default
source. **That claim is wrong** and is corrected in
https://github.com/scttfrdmn/substrate/issues/510#issuecomment-5208251926. Measured
over 5000 draws per stream across 60 base seeds, worst-case |Pearson r| between
adjacent indices: `seed+i` 0.030, FNV 0.036. Neither scheme shows a correlation the
other lacks.

The mixing stays, for reasons that survive measurement: that scrambling is an
*unspecified* property of `math/rand` rather than a documented one, so mixing means
per-rule independence does not rest on it; and `seed+i` makes one controller's
streams collide with an adjacent controller's, since `seed+1` at index 0 and `seed`
at index 1 are the same source. Both the code comment and the test now say what was
actually measured rather than asserting a correlation that does not hold.

## Compatibility

A consumer asserting on specific outcomes of a seeded **intermediate** `probability`
will see different results and must re-record them. Nothing changes for
`probability` of 0 or 1, or for a rule bounded by `times`, which needs no roll at
all. **In-repo this cost is zero:** every `probability` that actually reaches
`InjectFault` in the test suite is `1.0` or `0.0`. The one `0.5` (`config_test.go`)
only asserts the field round-trips through `ToFaultConfig` and never runs a request.

## Tests

Five new tests in `emulator/fault_prng_test.go`, driving unbounded `Probability:
0.5` rules so the assertions are on PRNG traces rather than `Times` bounds:

- **#510's acceptance property**: rule 2's outcome sequence is unchanged whether
  rule 1 matched 0 or 7 requests, and unchanged when the two are interleaved.
- Appending a rule does not shift an existing rule's outcomes.
- A fixed seed still reproduces a run exactly (with non-vacuity checks that the
  trace contains both outcomes), and a different seed does not.
- Two adjacent rules with the same probability do not trace identically.
- Re-arming a config resets the streams, and rule 0's stream survives a rule
  appended after it.

**Mutation tested**, 3 mutants: `rngs[i]` → `rngs[0]` (restoring #510) **CAUGHT**;
the `rngs` rebuild dropped from `UpdateConfig` **CAUGHT**; `seed+int64(i)` in place
of the FNV mix **EQUIVALENT**, with the correlation measurement above as its written
proof — the mutant is observably indistinguishable at this scale, which is precisely
what the corrected comment now claims.

## Docs

The ordering caveat and its `#510` pointers are gone from `FaultRule.Probability`,
`docs/services.md` and `docs/testing-guide.md`, replaced by what now holds: per-rule
streams, keyed by index, reset on arming.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0
issues), `make test` (race), `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test
-C test/e2e ./...` — all clean.

Closes #510
