### PR TITLE
fix(cli): always build the fault controller, and seed it from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A default server can arm fault rules, and its PRNG seed is pinnable.** `substrate
+  server` built a `FaultController` only when the config file had `fault.enabled` or
+  at least one rule, so on a default server all three `/v1/fault/rules` endpoints
+  answered `501 fault injection not enabled on this server` — a harness could not
+  arm a rule at all, which is the remedy the docs point at. The controller is now
+  always constructed; a disabled one makes injection a no-op, so behavior is
+  unchanged for a run that never touches the endpoint. A `Server` constructed
+  in-process with no controller still answers `501`.
+
+  The seed came from `time.Now().UnixNano()`, so a probabilistic rule loaded from a
+  config file produced a different run every time. `fault.seed` now supplies it,
+  defaulting to `0` — deterministic, which is what this emulator is for.
+
+- **The testing guide's fault example compiles.** It called
+  `substrate.WithFaultController(fc)`, a symbol that exists nowhere in the repo; the
+  option is `substrate.ServerOptions{Fault: fc}`. The guide also gains a section on
+  arming rules over the wire and on `fault.seed`, replacing a `TODO` that pointed at
+  a closed issue and at that same non-existent symbol.
+
 ### Changed
 - **Each fault rule draws from its own PRNG** (#510). `FaultController` rolled
   `probability` from one PRNG shared by every rule, so a rule's outcomes depended on

--- a/cmd/substrate/main.go
+++ b/cmd/substrate/main.go
@@ -76,6 +76,25 @@ of CDK, CloudFormation, and Terraform infrastructure code.`,
 	return root
 }
 
+// newFaultController builds the server's fault controller from configuration.
+//
+// It is always non-nil, even with no fault: block in the config. A disabled
+// controller makes InjectFault a no-op, so behavior is unchanged for every run
+// that never arms a rule — but the /v1/fault/rules endpoints answered 501 without
+// a controller, so a harness could not arm one on a default server at all, which
+// is the remedy the docs point at. Only a Server constructed in-process without
+// one still answers 501.
+//
+// The seed comes from configuration rather than time.Now().UnixNano(): a
+// wall-clock seed makes a probabilistic rule irreproducible between runs, which is
+// the one thing this emulator exists to avoid.
+//
+// This is a function rather than three inline lines so a test can assert both
+// halves without starting a server.
+func newFaultController(cfg substrate.FaultCfg) *substrate.FaultController {
+	return substrate.NewFaultController(cfg.ToFaultConfig(), cfg.Seed)
+}
+
 func newServerCmd() *cobra.Command {
 	var configPath string
 	var address string
@@ -150,10 +169,7 @@ configured address will have their requests emulated and recorded.`,
 			costCtrl := substrate.NewCostController(cfg.Costs.ToCostConfig(),
 				substrate.WithPricingProvider(pricingProvider))
 
-			var faultCtrl *substrate.FaultController
-			if cfg.Fault.Enabled || len(cfg.Fault.Rules) > 0 {
-				faultCtrl = substrate.NewFaultController(cfg.Fault.ToFaultConfig(), time.Now().UnixNano())
-			}
+			faultCtrl := newFaultController(cfg.Fault)
 
 			var metricsCollector *substrate.MetricsCollector
 			if cfg.Metrics.Enabled {

--- a/cmd/substrate/main_test.go
+++ b/cmd/substrate/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"slices"
 	"strings"
 	"testing"
+
+	substrate "github.com/scttfrdmn/substrate/emulator"
 )
 
 // TestBuildRootCmd verifies the root command is constructed without panic.
@@ -59,5 +62,78 @@ func TestNewDebugCmd(t *testing.T) {
 	}
 	if cmd.Use != "debug <stream>" {
 		t.Errorf("unexpected Use: %q", cmd.Use)
+	}
+}
+
+// TestNewFaultController_AlwaysBuiltAndSeeded covers the two wiring properties a
+// default `substrate server` depends on. The controller used to be built only when
+// the config named faults, so /v1/fault/rules answered 501 on a default server and
+// a harness could not arm a rule at all; and its seed came from
+// time.Now().UnixNano(), so a probabilistic rule was irreproducible between runs.
+func TestNewFaultController_AlwaysBuiltAndSeeded(t *testing.T) {
+	defaults := substrate.DefaultConfig()
+	if defaults.Fault.Enabled {
+		t.Fatal("precondition: the default config must not enable fault injection")
+	}
+	if len(defaults.Fault.Rules) != 0 {
+		t.Fatal("precondition: the default config must carry no rules")
+	}
+	if defaults.Fault.Seed != 0 {
+		t.Errorf("default seed = %d, want 0 — a wall-clock seed is not reproducible",
+			defaults.Fault.Seed)
+	}
+
+	// Built even though nothing in the config asked for faults.
+	fc := newFaultController(defaults.Fault)
+	if fc == nil {
+		t.Fatal("newFaultController returned nil for a default config; /v1/fault/rules would 501")
+	}
+
+	// Disabled until something arms it, so behavior is unchanged for such a run.
+	req := &substrate.AWSRequest{Service: "s3", Operation: "PutObject"}
+	if awsErr, delay := fc.InjectFault(&substrate.RequestContext{}, req); awsErr != nil || delay != 0 {
+		t.Errorf("a controller from a default config injected %v/%v, want nothing", awsErr, delay)
+	}
+
+	// Arming it makes the configured rule fire, which is what the endpoint does.
+	fc.UpdateConfig(substrate.FaultConfig{
+		Enabled: true,
+		Rules: []substrate.FaultRule{{
+			Service: "s3", Operation: "PutObject",
+			FaultType: "error", ErrorCode: "InternalError", Times: 1,
+		}},
+	})
+	awsErr, _ := fc.InjectFault(&substrate.RequestContext{}, req)
+	if awsErr == nil || awsErr.Code != "InternalError" {
+		t.Errorf("armed rule did not fire: %v", awsErr)
+	}
+
+	// The configured seed reaches the controller: the same seed traces identically
+	// and a different one does not.
+	trace := func(seed int64) []bool {
+		c := newFaultController(substrate.FaultCfg{
+			Enabled: true,
+			Seed:    seed,
+			Rules: []substrate.FaultRuleCfg{{
+				Service: "s3", FaultType: "error", ErrorCode: "InternalError",
+				Probability: 0.5, Times: -1,
+			}},
+		})
+		got := make([]bool, 24)
+		for i := range got {
+			e, _ := c.InjectFault(&substrate.RequestContext{}, req)
+			got[i] = e != nil
+		}
+		return got
+	}
+	want := trace(77)
+	if !slices.Equal(want, trace(77)) {
+		t.Error("the configured seed must reproduce a run exactly")
+	}
+	if slices.Equal(want, trace(78)) {
+		t.Error("a different configured seed must produce a different run")
+	}
+	if !slices.Contains(want, true) || !slices.Contains(want, false) {
+		t.Error("the probe must both fire and decline, or reproducibility is vacuous")
 	}
 }

--- a/configs/substrate-local.yaml
+++ b/configs/substrate-local.yaml
@@ -44,7 +44,12 @@ tracing:
   enabled: false
 
 fault:
+  # A fault controller is always constructed, so POST /v1/fault/rules works even
+  # with this false; disabling only makes injection a no-op until a rule is armed.
   enabled: false
+  # Seeds the per-rule PRNGs behind a rule's `probability`. Default 0 —
+  # deterministic, so the same config produces the same run every time.
+  seed: 0
 
 region:
   default: "us-east-1"

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -393,7 +393,7 @@ func TestRetryOnS3Error(t *testing.T) {
     _ = substrate.RegisterDefaultPlugins(ctx, registry, state, tc, logger, store)
 
     srv := substrate.NewServer(*cfg, registry, store, state, tc, logger,
-        substrate.WithFaultController(fc),
+        substrate.ServerOptions{Fault: fc},
     )
 
     // Start and test...
@@ -449,7 +449,26 @@ An injected error is serialized in the same wire shape the target service's own
 errors use, so an SDK recovers the code rather than falling back to the HTTP status
 (an injected S3 `SlowDown` used to arrive as `ServiceUnavailable`).
 
-<!-- TODO(#178): document server.WithFaultController option once stabilised -->
+### Arming rules over the wire
+
+A server started with `substrate server` always has a fault controller, whether or
+not the config file has a `fault:` block, so a harness can arm rules through
+`POST /v1/fault/rules` without restarting anything. A controller with `enabled:
+false` makes injection a no-op until a rule is armed; only a `Server` constructed
+in-process with no controller at all answers `501`.
+
+```yaml
+fault:
+  enabled: false
+  # Seeds the per-rule PRNGs behind `probability`. Default 0 — deterministic, so
+  # the same config produces the same run every time. Set it to vary
+  # probabilistic outcomes between runs deliberately.
+  seed: 0
+```
+
+Rules armed over the wire replace the configured set and reset each rule's `fired`
+count and PRNG stream, so a fixture that re-arms between phases starts each phase
+from the same place.
 
 ## Testing IAM Permissions
 

--- a/emulator/config.go
+++ b/emulator/config.go
@@ -325,7 +325,17 @@ type PricingCfg struct {
 // Use [FaultCfg.ToFaultConfig] to convert it for use with [NewFaultController].
 type FaultCfg struct {
 	// Enabled gates fault injection. Default false.
+	//
+	// A disabled controller is still constructed, so the /v1/fault/rules
+	// endpoints work and a harness can arm rules over the wire on a server whose
+	// config file says nothing about faults.
 	Enabled bool `mapstructure:"enabled"`
+
+	// Seed controls the per-rule PRNGs behind [FaultRule.Probability]. Default 0,
+	// which is deterministic — the same config produces the same run every time,
+	// which is what Substrate is for. Set it to vary probabilistic outcomes
+	// between runs deliberately.
+	Seed int64 `mapstructure:"seed"`
 
 	// Rules is the ordered list of fault injection rules.
 	Rules []FaultRuleCfg `mapstructure:"rules"`
@@ -563,6 +573,7 @@ func LoadConfig(path string) (*Config, error) {
 	v.SetDefault("tracing.exporter", defaults.Tracing.Exporter)
 	v.SetDefault("tracing.service_name", defaults.Tracing.ServiceName)
 	v.SetDefault("fault.enabled", defaults.Fault.Enabled)
+	v.SetDefault("fault.seed", defaults.Fault.Seed)
 	v.SetDefault("region.default", defaults.Region.Default)
 	v.SetDefault("lambda.docker_enabled", defaults.Lambda.DockerEnabled)
 	v.SetDefault("lambda.replay_mode", defaults.Lambda.ReplayMode)

--- a/emulator/fault_wiring_test.go
+++ b/emulator/fault_wiring_test.go
@@ -1,0 +1,103 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// postRules arms a fault config over the wire.
+func postRules(t *testing.T, ts *httptest.Server, cfg emulator.FaultConfig) {
+	t.Helper()
+	body, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	resp, err := http.Post(ts.URL+"/v1/fault/rules", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	raw, _ := io.ReadAll(resp.Body)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "POST /v1/fault/rules: %s", raw)
+}
+
+// TestFaultCfg_SeedRoundTrips asserts a config file can pin the PRNG seed. Before
+// this field existed, the CLI seeded from time.Now().UnixNano(), so a probabilistic
+// rule from a config file produced a different run every time — the one property
+// this emulator exists to avoid.
+func TestFaultCfg_SeedRoundTrips(t *testing.T) {
+	cfg := emulator.DefaultConfig()
+	assert.Equal(t, int64(0), cfg.Fault.Seed,
+		"the default must be deterministic, not wall-clock")
+
+	// The seed reaches the controller, and the same seed produces the same run.
+	rules := []emulator.FaultRule{{
+		Service:     "s3",
+		FaultType:   "error",
+		ErrorCode:   "ServiceUnavailable",
+		HTTPStatus:  503,
+		Probability: 0.5,
+		Times:       -1,
+	}}
+	fcfg := emulator.FaultCfg{Enabled: true, Seed: 1234}
+	converted := fcfg.ToFaultConfig()
+	converted.Rules = rules
+
+	trace := func(seed int64) []bool {
+		fc := emulator.NewFaultController(converted, seed)
+		got := make([]bool, 20)
+		for i := range got {
+			awsErr, _ := fc.InjectFault(&emulator.RequestContext{},
+				&emulator.AWSRequest{Service: "s3", Operation: "PutObject"})
+			got[i] = awsErr != nil
+		}
+		return got
+	}
+	want := trace(fcfg.Seed)
+	assert.Equal(t, want, trace(fcfg.Seed), "a pinned seed must reproduce a run")
+	assert.NotEqual(t, want, trace(fcfg.Seed+1), "a different seed must differ")
+
+	// Not vacuous: the probe must actually vary, or "reproducible" is trivial.
+	assert.Contains(t, want, true)
+	assert.Contains(t, want, false)
+}
+
+// TestFaultControl_DisabledControllerAcceptsRules is the wiring gate. A server
+// started with no fault: block in its config now still has a controller, so a
+// harness can arm a rule over the wire — the remedy the docs point at, which
+// answered 501 before. The controller is disabled until something arms it, so
+// behavior is unchanged for a run that never touches the endpoint.
+func TestFaultControl_DisabledControllerAcceptsRules(t *testing.T) {
+	ts, fc := newFaultTestServer(t)
+	require.NotNil(t, fc)
+
+	// Nothing is injected before a rule is armed.
+	awsErr, delay := fc.InjectFault(&emulator.RequestContext{},
+		&emulator.AWSRequest{Service: "s3", Operation: "PutObject"})
+	assert.Nil(t, awsErr, "a disabled controller must inject nothing")
+	assert.Zero(t, delay)
+
+	// Arming over the wire works and the rule then fires.
+	postRules(t, ts, emulator.FaultConfig{
+		Enabled: true,
+		Rules: []emulator.FaultRule{{
+			Service:    "s3",
+			Operation:  "PutObject",
+			FaultType:  "error",
+			ErrorCode:  "InternalError",
+			HTTPStatus: 500,
+			Times:      1,
+		}},
+	})
+
+	awsErr, _ = fc.InjectFault(&emulator.RequestContext{},
+		&emulator.AWSRequest{Service: "s3", Operation: "PutObject"})
+	require.NotNil(t, awsErr, "a rule armed over the wire must fire")
+	assert.Equal(t, "InternalError", awsErr.Code)
+	assert.Equal(t, 1, fc.GetConfig().Rules[0].Fired)
+}


### PR DESCRIPTION
## Two gaps that made the fault tier unreachable from a config file

**A default server answered 501.** `substrate server` built a `FaultController`
only when the config file had `fault.enabled` or at least one rule
(`main.go:153-156`). Without one, all three `/v1/fault/rules` endpoints returned
`501 fault injection not enabled on this server`, so a harness could not arm a rule
on a default server at all — which is precisely the remedy `docs/testing-guide.md`
points a reader at. This is not hypothetical: it silently swallowed the first probe
of the #540 investigation.

**Its seed was the wall clock.** When the controller *was* built, it came up with
`time.Now().UnixNano()`, and `FaultCfg` had no seed field, so a config file could
not pin it. A probabilistic rule from a config file therefore produced a different
run every time — the one property this emulator exists to avoid.
`StartTestServer` already did the right thing in-process (`NewFaultController(...,
1)`); only the CLI path was affected.

## The fix

The controller is **always constructed**. A disabled one makes `InjectFault` a
no-op, so behavior is unchanged for every run that never arms a rule; only a
`Server` constructed in-process with no controller still answers 501, which
`TestFaultControl_NilController_Returns501` asserts and which still passes.

**`fault.seed`** (`int64`, `mapstructure:"seed"`) supplies the seed, defaulting to
`0` — deterministic, which is what Substrate is for. Documented in
`configs/substrate-local.yaml` and the testing guide.

Construction moved into a `newFaultController` function so a test can assert both
halves without starting a server. That seam exists because it was needed: the first
run of the mutation pass had the mutant restoring conditional construction
**SURVIVE**, since every existing test built its server in-process and none
exercised the CLI's construction path at all.

## Also: the testing guide's fault example did not compile

It called `substrate.WithFaultController(fc)` — a symbol that exists nowhere in the
repo. The option is `substrate.ServerOptions{Fault: fc}`. Found by grep while
scoping this.

The `<!-- TODO(#178): document server.WithFaultController option once stabilised
-->` beneath it is replaced with the documentation it was deferring: #178 is closed,
and the symbol it names never existed. In its place, a short section on arming rules
over the wire and on `fault.seed`.

## Tests

- `cmd/substrate/main_test.go` — `TestNewFaultController_AlwaysBuiltAndSeeded`: a
  default config yields a non-nil controller (with preconditions asserting the
  default config really does not enable faults, so the test cannot pass vacuously);
  it injects nothing until armed; arming makes a rule fire; and the configured seed
  reaches the controller — the same seed traces identically over 24 requests, a
  different seed does not, and the trace contains both outcomes so "reproducible"
  is not trivially true.
- `emulator/fault_wiring_test.go` — `fault.seed` round-trips through
  `ToFaultConfig` with the default asserted as `0`, and a disabled controller
  accepts rules over the wire and then fires them with `fired` incremented.

**Mutation tested**, 2 mutants, both **CAUGHT** after the seam was added:
restoring the conditional construction, and restoring `time.Now().UnixNano()`.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0
issues), `make test` (race), `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...`, `go test
-C test/e2e ./...` — all clean.

End to end against a **default** `substrate server` with no `fault:` block:

```
$ curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:4623/v1/fault/rules -d '{...}'
200                                     # was 501
$ AWS_MAX_ATTEMPTS=1 aws s3api put-object --bucket faultwire --key k --body /tmp/v
An error occurred (InternalError) when calling the PutObject operation: injected fault
$ AWS_MAX_ATTEMPTS=1 aws s3api put-object --bucket faultwire --key k --body /tmp/v
{ ... }                                 # times: 1, so the retry succeeds
$ curl -s localhost:4623/v1/fault/rules | jq '.rules[0].fired'
1
```
