### PR TITLE
chore(release): v0.93.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.93.0] - 2026-08-06
+
 ### Fixed
 - **A default server can arm fault rules, and its PRNG seed is pinnable.** `substrate
   server` built a `FaultController` only when the config file had `fault.enabled` or
@@ -5418,7 +5420,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.92.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.93.0...HEAD
+[v0.93.0]: https://github.com/scttfrdmn/substrate/compare/v0.92.0...v0.93.0
 [v0.92.0]: https://github.com/scttfrdmn/substrate/compare/v0.91.0...v0.92.0
 [v0.91.0]: https://github.com/scttfrdmn/substrate/compare/v0.90.0...v0.91.0
 [v0.90.0]: https://github.com/scttfrdmn/substrate/compare/v0.89.0...v0.90.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.93.0] - 2026-08-06` and adds the comparison link.

Ships #540 (a seedable `409 ConditionalRequestConflict` on S3 conditional writes), #510 (per-rule PRNGs in `FaultController`), and the fault-tier wiring fixes: a default `substrate server` can arm rules, `fault.seed` pins the PRNG, and the testing guide's fault example compiles.

No code changes. The tag is cut against this merge commit after it lands.