### PR TITLE
fix(cfn): generate a per-stack physical name when a template omits one (#560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A stack whose template omits a resource's physical name can be deployed twice**
+  (#560). A resource with no explicit name got the **logical ID verbatim** as its
+  physical name. A logical ID is unique only *within* a stack, while an IAM role
+  name, bucket, table or log group is unique across an account or a Region — so any
+  second stack from the same template collided (`EntityAlreadyExists`,
+  `BucketAlreadyExists`, `ResourceAlreadyExistsException`, `ResourceInUseException`).
+  Omitting the name is the *recommended* practice, so the templates most likely
+  written correctly were exactly the ones that could not deploy twice.
+
+  `AWS::SQS::Queue` and `AWS::SNS::Topic` failed worse, and silently: their creates
+  are idempotent, so two stacks both reported `CREATE_COMPLETE` while pointing at
+  **one** resource. Deleting either stack then destroyed the other's queue —
+  measured as `QueueDoesNotExist` while the surviving stack still reported
+  `CREATE_COMPLETE`. No error was reported to anyone.
+
+  An omitted name now becomes `{stack}-{logical ID}-{suffix}`, the shape
+  CloudFormation documents for its own generated physical IDs, fitted to each
+  service's length and case constraints. The suffix is **derived** — FNV-64a over
+  the account, Region, stack name and logical ID — where AWS randomizes. That
+  divergence is deliberate: `UpdateStack` in substrate re-deploys the whole
+  template, so a per-deploy random name would mint a fresh resource on every update
+  and leak the one it replaced; deriving it keeps an unchanged update a no-op and
+  every name reproducible from its inputs.
+
+  The fix is a **table of nine resource types** whose names are account- or
+  Region-unique, not a blanket rewrite of every property that falls back to the
+  logical ID. `PathPart`, `Domain`, `SecretId`, `ClusterId` and `ReplicationGroupId`
+  are deliberately excluded — they are not account-unique names, and generating them
+  would change URLs and identifiers a template legitimately controls.
+
+  **Compatibility:** every stack whose template omits a physical name now gets a
+  different physical name, so a fixture asserting a resource name equal to its
+  logical ID must be re-recorded. A template that sets the name explicitly is
+  unaffected and still gets that name verbatim, and `Ref`/`GetAtt` resolve to
+  whichever name was used.
+
 ## [v0.93.0] - 2026-08-06
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -254,6 +254,65 @@ that resolves to no IAM user or role in state is not authorized at all, which is
 every in-process `emulator.Client` caller and every credential that never touched
 IAM. See the testing guide's "Testing IAM permissions".
 
+### A resource with no name in the template gets a per-stack name
+
+Omitting a resource's physical name is the **recommended** practice — it is what
+makes a template deployable more than once, and AWS documents that naming a
+resource explicitly costs you replacement updates. So substrate generates a name
+for the omitted case, in the shape CloudFormation documents for its own generated
+physical IDs (`MyStack-MyBucket-abcdefghijk1`):
+
+```
+{stack name}-{logical ID}-{12-character suffix}
+```
+
+The omitted case previously used the **logical ID verbatim**, which is unique
+only *within* a stack. Every name below is unique across an account or a Region, so
+a second stack from the same template either collided outright or — for `SQS::Queue`
+and `SNS::Topic`, whose creates are idempotent — silently shared one resource with
+the first, and deleting either stack destroyed the other's resource with no error
+reported to anyone ([#560](https://github.com/scttfrdmn/substrate/issues/560)).
+
+- **An explicit name still wins, verbatim.** A template that sets `BucketName` gets
+  exactly that bucket, un-repeatability included, because that is what it asked for.
+- **The suffix is derived, not random** — FNV-64a over the account, Region, stack
+  name and logical ID, base36. This is substrate's own divergence: AWS randomizes.
+  `UpdateStack` here re-deploys the whole template, so a name regenerated per deploy
+  would mint a fresh resource on every update and leak the one it replaced. Deriving
+  it keeps an unchanged update a no-op and every name reproducible from its inputs.
+  The account and Region are in the hash because two same-named stacks in different
+  Regions are different stacks.
+- **The name fits the service.** The stack and logical-ID segments are truncated
+  proportionally to fit the service's limit and lowercased where the service demands
+  it; the suffix is never truncated, since it is the only part that makes the name
+  unique. A generated name always begins with a letter and holds only ASCII letters,
+  digits and hyphens, with no trailing or doubled hyphen.
+
+The types that get a generated name, with the limit each is fitted to:
+
+| Resource type | Name property | Limit |
+|---|---|---|
+| `AWS::IAM::Role` | `RoleName` | 64 |
+| `AWS::IAM::InstanceProfile` | `InstanceProfileName` | 128 |
+| `AWS::IAM::Policy` | `PolicyName` | 128 |
+| `AWS::S3::Bucket` | `BucketName` | 63, lowercase |
+| `AWS::DynamoDB::Table` | `TableName` | 255 |
+| `AWS::SQS::Queue` | `QueueName` | 80 |
+| `AWS::SNS::Topic` | `TopicName` | 256 |
+| `AWS::Logs::LogGroup` | `LogGroupName` | 512 |
+| `AWS::Lambda::Function` | `FunctionName` | 64 |
+
+**A type absent from that table still uses its logical ID.** The list is names that
+are account- or Region-unique, not every property that falls back to the logical ID:
+an `AWS::ApiGateway::Resource`'s `PathPart` is a URL segment unique only within its
+parent, and `Domain`, `SecretId`, `ClusterId` and `ReplicationGroupId` are
+identifiers a template legitimately controls. Generating those would change the URLs
+and identifiers a consumer wrote the template to get.
+
+`Ref` and `GetAtt` resolve to the generated name and ARN, and the delete sweep
+deletes by it, so a template that wires its resources together needs no change —
+and two stacks from one template can now be torn down independently.
+
 ### DeleteStack deletes the stack's resources
 
 `DeleteStack` sweeps the resources the stack deployed before removing the stack

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -2647,7 +2647,8 @@ func (d *StackDeployer) deployS3Bucket(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	bucketName := strings.ToLower(resolveStringProp(props, "BucketName", logicalID, cctx))
+	bucketName := strings.ToLower(resolveStringProp(props, "BucketName",
+		cfnGeneratedName(cctx, "AWS::S3::Bucket", logicalID), cctx))
 
 	req := &AWSRequest{
 		Service:   "s3",
@@ -2700,7 +2701,8 @@ func (d *StackDeployer) deployIAMRole(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	roleName := resolveStringProp(props, "RoleName", logicalID, cctx)
+	roleName := resolveStringProp(props, "RoleName",
+		cfnGeneratedName(cctx, "AWS::IAM::Role", logicalID), cctx)
 
 	body := map[string]string{
 		"RoleName":                 roleName,
@@ -2750,7 +2752,8 @@ func (d *StackDeployer) deployIAMPolicy(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	policyName := resolveStringProp(props, "PolicyName", logicalID, cctx)
+	policyName := resolveStringProp(props, "PolicyName",
+		cfnGeneratedName(cctx, "AWS::IAM::Policy", logicalID), cctx)
 
 	body := map[string]string{
 		"PolicyName":     policyName,
@@ -2800,7 +2803,8 @@ func (d *StackDeployer) deployLambdaFunction(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	fnName := resolveStringProp(props, "FunctionName", logicalID, cctx)
+	fnName := resolveStringProp(props, "FunctionName",
+		cfnGeneratedName(cctx, "AWS::Lambda::Function", logicalID), cctx)
 
 	body := map[string]interface{}{
 		"FunctionName": fnName,
@@ -2965,7 +2969,8 @@ func (d *StackDeployer) deploySQSQueue(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	queueName := resolveStringProp(props, "QueueName", logicalID, cctx)
+	queueName := resolveStringProp(props, "QueueName",
+		cfnGeneratedName(cctx, "AWS::SQS::Queue", logicalID), cctx)
 
 	params := map[string]string{
 		"Action":    "CreateQueue",
@@ -3018,7 +3023,8 @@ func (d *StackDeployer) deployDynamoDBTable(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	tableName := resolveStringProp(props, "TableName", logicalID, cctx)
+	tableName := resolveStringProp(props, "TableName",
+		cfnGeneratedName(cctx, "AWS::DynamoDB::Table", logicalID), cctx)
 
 	// Build the CreateTable body from CFN properties.
 	body := map[string]interface{}{
@@ -3771,7 +3777,8 @@ func (d *StackDeployer) deploySNSTopic(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	topicName := resolveStringProp(props, "TopicName", logicalID, cctx)
+	topicName := resolveStringProp(props, "TopicName",
+		cfnGeneratedName(cctx, "AWS::SNS::Topic", logicalID), cctx)
 	params := map[string]string{
 		"Action": "CreateTopic",
 		"Name":   topicName,
@@ -3884,7 +3891,8 @@ func (d *StackDeployer) deployLogsLogGroup(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	lgName := resolveStringProp(props, "LogGroupName", logicalID, cctx)
+	lgName := resolveStringProp(props, "LogGroupName",
+		cfnGeneratedName(cctx, "AWS::Logs::LogGroup", logicalID), cctx)
 	body := map[string]interface{}{
 		"logGroupName": lgName,
 	}

--- a/emulator/cfn_observability_test.go
+++ b/emulator/cfn_observability_test.go
@@ -88,8 +88,12 @@ func TestCFN_LogGroupDefaultName(t *testing.T) {
 	result, err := d.Deploy(context.Background(), tmpl, "test-lg-default", nil)
 	require.NoError(t, err)
 	require.Len(t, result.Resources, 1)
-	// Falls back to logicalID when LogGroupName not specified.
-	assert.Equal(t, "LogGroupResource", result.Resources[0].PhysicalID)
+	// A log group name is unique within a Region, so an omitted LogGroupName gets
+	// a generated per-stack name rather than the logical ID — before #560 two
+	// stacks from this template could not coexist.
+	got := result.Resources[0].PhysicalID
+	assert.NotEqual(t, "LogGroupResource", got)
+	assert.Equal(t, "test-lg-default-LogGroupResource-", got[:len(got)-emulator.CFNGeneratedNameSuffixLenForTest])
 }
 
 func TestCFN_EventsRuleDeployment(t *testing.T) {

--- a/emulator/cfn_physical_name.go
+++ b/emulator/cfn_physical_name.go
@@ -1,0 +1,215 @@
+package emulator
+
+import (
+	"hash/fnv"
+	"strconv"
+	"strings"
+)
+
+// cfnNameConstraint describes what a service will accept as a physical name, so
+// a generated one can be trimmed to fit before the create call is made rather
+// than failing validation at the plugin. Only two things vary between the
+// services in cfnGeneratedNameTypes: how long the name may be, and whether it
+// must be lowercase. The character set does not vary, because the set
+// CloudFormation documents for a generated name — "must begin with a letter;
+// contain only ASCII letters, digits, and hyphens; and not end with a hyphen or
+// contain two consecutive hyphens" — is a subset of what every one of those
+// services allows.
+type cfnNameConstraint struct {
+	// maxLen is the longest name the service accepts, from that service's own
+	// API reference rather than from CloudFormation's.
+	maxLen int
+
+	// lower forces the whole name to lowercase, for a service whose names are
+	// case-sensitive and lowercase-only (S3).
+	lower bool
+}
+
+// cfnGeneratedNameTypes maps a resource type to the constraint on the physical
+// name substrate generates for it when the template does not supply one.
+//
+// A type belongs here only when its physical name is unique across an account
+// (or an account and Region) and the service invents one when the template
+// omits it. That is deliberately narrower than "every property that falls back
+// to the logical ID": most such properties are not account-unique names at all.
+// AWS::ApiGateway::Resource's PathPart is a URL segment unique only within its
+// parent, and Domain, SecretId, ClusterId and ReplicationGroupId are
+// identifiers a template legitimately controls — generating those would change
+// the URLs and identifiers a consumer wrote the template to get. A type absent
+// from this table keeps the older behavior of using the logical ID verbatim.
+var cfnGeneratedNameTypes = map[string]cfnNameConstraint{
+	// IAM names: "[\w+=,.@-]+", 64 for a role, 128 for a policy or an instance
+	// profile (CreateRole, CreatePolicy, CreateInstanceProfile).
+	"AWS::IAM::Role":            {maxLen: 64},
+	"AWS::IAM::InstanceProfile": {maxLen: 128},
+	// AWS::IAM::Policy declares PolicyName as required, so a template that omits
+	// it is already invalid — but substrate deploys the type through CreatePolicy,
+	// which mints an account-unique managed policy, so the omitted case still has
+	// to generate rather than collide.
+	"AWS::IAM::Policy": {maxLen: 128},
+
+	// A bucket name is globally unique, lowercase, and 3–63 characters
+	// (validateBucketName enforces the same range).
+	"AWS::S3::Bucket": {maxLen: 63, lower: true},
+
+	// A DynamoDB table name is unique within a Region. CreateTable's own limit is
+	// 1–1024 characters because the parameter also accepts a table ARN; the
+	// name-only limit is the 3–255 in the DynamoDB service quotas, which is the
+	// tighter of the two and so the one to fit.
+	"AWS::DynamoDB::Table": {maxLen: 255},
+
+	// A queue name may be up to 80 characters (CreateQueue); a topic name up to
+	// 256 (CreateTopic). Both creates are idempotent, so without a generated
+	// name two stacks silently share one resource rather than colliding — see
+	// #560.
+	"AWS::SQS::Queue": {maxLen: 80},
+	"AWS::SNS::Topic": {maxLen: 256},
+
+	// A log group name is unique within a Region and may be up to 512
+	// characters (CreateLogGroup).
+	"AWS::Logs::LogGroup": {maxLen: 512},
+
+	// A bare Lambda function name "is limited to 64 characters in length"
+	// (CreateFunction).
+	"AWS::Lambda::Function": {maxLen: 64},
+}
+
+// cfnGeneratedNameSuffixLen is the length of the derived suffix, matching the
+// twelve characters in CloudFormation's own documented example of a generated
+// physical ID (MyStack-MyBucket-abcdefghijk1).
+const cfnGeneratedNameSuffixLen = 12
+
+// cfnGeneratedName returns the physical name to use for a resource of resType
+// whose template omitted its name property, or logicalID unchanged when resType
+// has no entry in cfnGeneratedNameTypes.
+//
+// The name is {stackName}-{logicalID}-{suffix}, the shape CloudFormation
+// documents. The suffix is *derived* — FNV-64a over the account, Region, stack
+// name and logical ID — where CloudFormation uses a random one. That divergence
+// is deliberate and load-bearing: UpdateStack in substrate is a re-Deploy of the
+// whole template (see clearUnchangedRedeploys), so a name regenerated per
+// deploy would mint a fresh resource on every update and leak the one it
+// replaced. Deriving it makes the name stable for a given (account, Region,
+// stack, logical ID) while still differing between stacks, which is the property
+// #560 needs, and keeps the emulator deterministic by construction.
+//
+// The account and Region are in the hash because two same-named stacks in
+// different Regions are different stacks, which sameScope already treats them
+// as.
+func cfnGeneratedName(cctx *cfnContext, resType, logicalID string) string {
+	c, ok := cfnGeneratedNameTypes[resType]
+	if !ok {
+		return logicalID
+	}
+
+	stackName, region, accountID := "", "", ""
+	if cctx != nil {
+		stackName, region, accountID = cctx.stackName, cctx.region, cctx.accountID
+	}
+
+	suffix := cfnNameSuffix(accountID, region, stackName, logicalID)
+
+	// A generated name must begin with a letter. The stack segment leads, so the
+	// guarantee is applied there, before the length budget is spent — prefixing
+	// afterwards would either overrun maxLen or eat into the suffix.
+	stack := cfnNameSegment(stackName)
+	if stack == "" || !isASCIILetter(stack[0]) {
+		stack = "s" + stack
+	}
+	logical := cfnNameSegment(logicalID)
+	if logical == "" {
+		logical = "r"
+	}
+
+	// Two hyphens plus the suffix are reserved, and the suffix is never
+	// truncated: it is the only part of the name that makes it unique.
+	budget := c.maxLen - len(suffix) - 2
+	if budget < 2 {
+		// No service in the table is this tight; keep the suffix rather than the
+		// segments if one ever is, because uniqueness matters more than legibility.
+		return maybeLower(suffix[:min(len(suffix), c.maxLen)], c.lower)
+	}
+	stack, logical = fitSegments(stack, logical, budget)
+
+	return maybeLower(stack+"-"+logical+"-"+suffix, c.lower)
+}
+
+// cfnNameSuffix derives the opaque, stable tail of a generated physical name.
+// The value is taken modulo 36^cfnGeneratedNameSuffixLen and zero-padded so
+// every suffix is the same width, which keeps the length budget in
+// cfnGeneratedName exact rather than approximate.
+func cfnNameSuffix(accountID, region, stackName, logicalID string) string {
+	h := fnv.New64a()
+	// Errors are impossible: hash.Hash.Write never returns one.
+	_, _ = h.Write([]byte(accountID + "/" + region + "/" + stackName + "/" + logicalID))
+
+	mod := uint64(1)
+	for i := 0; i < cfnGeneratedNameSuffixLen; i++ {
+		mod *= 36
+	}
+	s := strconv.FormatUint(h.Sum64()%mod, 36)
+	if pad := cfnGeneratedNameSuffixLen - len(s); pad > 0 {
+		s = strings.Repeat("0", pad) + s
+	}
+	return s
+}
+
+// cfnNameSegment reduces one component of a generated name to the documented
+// character set: ASCII letters, digits and hyphens, with no leading, trailing or
+// doubled hyphen. Every other byte becomes a hyphen, so a logical ID and a stack
+// name remain recognizable in the result.
+func cfnNameSegment(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case isASCIILetter(ch) || (ch >= '0' && ch <= '9'):
+			b.WriteByte(ch)
+		default:
+			// Collapse a run of unusable bytes into a single hyphen.
+			if cur := b.String(); cur != "" && !strings.HasSuffix(cur, "-") {
+				b.WriteByte('-')
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// fitSegments shrinks stack and logical so their combined length is at most
+// budget, dividing the cut between them in proportion to their lengths rather
+// than sacrificing one entirely — both are what makes a generated name
+// recognizable. Each keeps at least one character.
+func fitSegments(stack, logical string, budget int) (string, string) {
+	total := len(stack) + len(logical)
+	if total <= budget {
+		return stack, logical
+	}
+
+	stackWidth := budget * len(stack) / total
+	stackWidth = max(1, min(stackWidth, budget-1))
+	logicalWidth := budget - stackWidth
+
+	stack = strings.Trim(stack[:min(stackWidth, len(stack))], "-")
+	logical = strings.Trim(logical[:min(logicalWidth, len(logical))], "-")
+	if stack == "" {
+		stack = "s"
+	}
+	if logical == "" {
+		logical = "r"
+	}
+	return stack, logical
+}
+
+// isASCIILetter reports whether ch is an unaccented A–Z or a–z.
+func isASCIILetter(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+}
+
+// maybeLower lowercases s when the constraint demands it.
+func maybeLower(s string, lower bool) string {
+	if lower {
+		return strings.ToLower(s)
+	}
+	return s
+}

--- a/emulator/cfn_physical_name_test.go
+++ b/emulator/cfn_physical_name_test.go
@@ -1,0 +1,300 @@
+package emulator_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// repeatableTemplate is #560's reproducer: every resource omits its physical
+// name, which is the recommended practice precisely because it is what makes a
+// template deployable more than once.
+const repeatableTemplate = `{
+	"AWSTemplateFormatVersion": "2010-09-09",
+	"Resources": {
+		"MyRole": {
+			"Type": "AWS::IAM::Role",
+			"Properties": {
+				"AssumeRolePolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [{
+						"Effect": "Allow",
+						"Principal": {"Service": "ec2.amazonaws.com"},
+						"Action": "sts:AssumeRole"
+					}]
+				}
+			}
+		},
+		"MyQueue": {"Type": "AWS::SQS::Queue", "Properties": {}},
+		"MyTopic": {"Type": "AWS::SNS::Topic", "Properties": {}}
+	},
+	"Outputs": {
+		"RoleRef":  {"Value": {"Ref": "MyRole"}},
+		"RoleArn":  {"Value": {"Fn::GetAtt": ["MyRole", "Arn"]}},
+		"QueueRef": {"Value": {"Ref": "MyQueue"}}
+	}
+}`
+
+// resourceByLogicalID returns the deployed resource with the given logical ID.
+func resourceByLogicalID(t *testing.T, r *emulator.DeployResult, id string) emulator.DeployedResource {
+	t.Helper()
+	for _, res := range r.Resources {
+		if res.LogicalID == id {
+			return res
+		}
+	}
+	t.Fatalf("no resource %q in %+v", id, r.Resources)
+	return emulator.DeployedResource{}
+}
+
+// TestCFNGeneratedName_SameTemplateDeploysTwice is #560. A logical ID is unique
+// only within a stack, but an IAM role name is unique across the account, so
+// using the logical ID verbatim meant the second stack from any template that
+// omits its names could never be created. It failed with EntityAlreadyExists.
+func TestCFNGeneratedName_SameTemplateDeploysTwice(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	first, err := d.Deploy(ctx, repeatableTemplate, "repro-a", nil)
+	require.NoError(t, err)
+	second, err := d.Deploy(ctx, repeatableTemplate, "repro-b", nil)
+	require.NoError(t, err)
+
+	for _, res := range append(append([]emulator.DeployedResource{}, first.Resources...),
+		second.Resources...) {
+		assert.Empty(t, res.Error, "%s must deploy cleanly in both stacks", res.LogicalID)
+	}
+
+	for _, id := range []string{"MyRole", "MyQueue", "MyTopic"} {
+		a := resourceByLogicalID(t, first, id).PhysicalID
+		b := resourceByLogicalID(t, second, id).PhysicalID
+		assert.NotEqual(t, id, a, "%s must not use the logical ID as its physical name", id)
+		assert.NotEqual(t, a, b, "%s must differ between the two stacks", id)
+		// Contains, not HasPrefix: an SNS topic's physical ID is its ARN — Ref on
+		// AWS::SNS::Topic returns the topic ARN — so the generated name is embedded
+		// in it rather than leading it.
+		assert.Contains(t, a, "repro-a-"+id+"-", "unexpected name %q", a)
+		assert.Contains(t, b, "repro-b-"+id+"-", "unexpected name %q", b)
+	}
+}
+
+// TestCFNGeneratedName_TwoStacksDoNotShareAQueue is the failure mode #560 does
+// not name, and the worse of the two. CreateQueue and CreateTopic are idempotent,
+// so two stacks from one template did not collide — they both reported
+// CREATE_COMPLETE while pointing at a single queue. Deleting either stack then
+// destroyed the other's resource, and nothing reported an error to anyone.
+func TestCFNGeneratedName_TwoStacksDoNotShareAQueue(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	keep, err := d.Deploy(ctx, repeatableTemplate, "share-a", nil)
+	require.NoError(t, err)
+	_, err = d.Deploy(ctx, repeatableTemplate, "share-b", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, d.DeleteStack(ctx, "share-b"))
+
+	// The surviving stack's queue must still resolve. Before the fix this
+	// returned QueueDoesNotExist while share-a still reported CREATE_COMPLETE.
+	kept := resourceByLogicalID(t, keep, "MyQueue").PhysicalID
+	resp, err := d.DispatchForTest(ctx, &emulator.AWSRequest{
+		Service:   "sqs",
+		Operation: "GetQueueUrl",
+		Headers:   map[string]string{},
+		Params:    map[string]string{"Action": "GetQueueUrl", "QueueName": kept},
+	}, "share-a")
+	require.NoError(t, err, "deleting share-b must not destroy share-a's queue")
+	require.NotNil(t, resp)
+	assert.Contains(t, string(resp.Body), kept)
+}
+
+// TestCFNGeneratedName_ExplicitNameStillWins asserts the generated name is only
+// a fallback. A template that names a resource is asking for AWS's own
+// un-repeatable behavior and must get exactly the name it wrote.
+func TestCFNGeneratedName_ExplicitNameStillWins(t *testing.T) {
+	tmpl := `{
+		"Resources": {
+			"MyQueue": {
+				"Type": "AWS::SQS::Queue",
+				"Properties": {"QueueName": "explicitly-named"}
+			}
+		}
+	}`
+
+	d, _, _, _ := newSweepDeployer(t)
+	result, err := d.Deploy(context.Background(), tmpl, "explicit", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "explicitly-named",
+		resourceByLogicalID(t, result, "MyQueue").PhysicalID)
+}
+
+// TestCFNGeneratedName_RefAndGetAttResolveToIt asserts the intrinsics follow the
+// generated name. They read DeployedResource.PhysicalID and .ARN, so a template
+// that wires resources together with Ref and GetAtt keeps working — a fix that
+// left Ref returning the logical ID would produce a stack whose resources point
+// at names that do not exist.
+func TestCFNGeneratedName_RefAndGetAttResolveToIt(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	result, err := d.Deploy(context.Background(), repeatableTemplate, "refs", nil)
+	require.NoError(t, err)
+
+	role := resourceByLogicalID(t, result, "MyRole")
+	assert.Equal(t, role.PhysicalID, result.Outputs["RoleRef"])
+	assert.Equal(t, role.ARN, result.Outputs["RoleArn"])
+	assert.Contains(t, result.Outputs["RoleArn"], role.PhysicalID)
+	assert.Equal(t, resourceByLogicalID(t, result, "MyQueue").PhysicalID,
+		result.Outputs["QueueRef"])
+}
+
+// TestCFNGeneratedName_UpdateDoesNotMoveAPhysicalID is why the suffix is derived
+// rather than random. UpdateStack in substrate is a re-Deploy of the whole
+// template (clearUnchangedRedeploys exists for that reason), so a name
+// regenerated per deploy would mint a new resource on every update and leak the
+// one it replaced. This is the gate a crypto/rand suffix fails.
+func TestCFNGeneratedName_UpdateDoesNotMoveAPhysicalID(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	before, err := d.Deploy(ctx, repeatableTemplate, "stable", nil)
+	require.NoError(t, err)
+	after, err := d.UpdateStack(ctx, repeatableTemplate, "stable", nil)
+	require.NoError(t, err)
+
+	for _, id := range []string{"MyRole", "MyQueue", "MyTopic"} {
+		assert.Equal(t, resourceByLogicalID(t, before, id).PhysicalID,
+			resourceByLogicalID(t, after, id).PhysicalID,
+			"%s: an unchanged update must not move a physical ID", id)
+	}
+}
+
+// TestCFNGeneratedName_Constraints covers the name arithmetic directly, because
+// the shortest limit in the table (63, for a bucket) is under the 94 characters
+// an untruncated {40-char stack}-{40-char logical}-{12} would need. Substrate
+// validates bucket names but not IAM role-name length, so without truncation an
+// over-long name would fail for some types and silently pass for others.
+func TestCFNGeneratedName_Constraints(t *testing.T) {
+	const (
+		acct   = "000000000000"
+		region = "us-east-1"
+		long40 = "abcdefghijabcdefghijabcdefghijabcdefghij"
+	)
+
+	tests := []struct {
+		name      string
+		stackName string
+		resType   string
+		logicalID string
+		maxLen    int
+		lower     bool
+	}{
+		{"role fits 64", long40, "AWS::IAM::Role", long40, 64, false},
+		{"bucket fits 63 and lowercases", long40, "AWS::S3::Bucket", "MyBucket", 63, true},
+		{"queue fits 80", long40, "AWS::SQS::Queue", long40, 80, false},
+		{"short names are not truncated", "st", "AWS::IAM::Role", "Res", 64, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := emulator.CFNGeneratedNameForTest(acct, region, tt.stackName,
+				tt.resType, tt.logicalID)
+
+			assert.LessOrEqual(t, len(got), tt.maxLen, "name %q exceeds the limit", got)
+			if tt.lower {
+				assert.Equal(t, strings.ToLower(got), got, "name must be lowercase")
+			}
+
+			// The documented charset for a generated name: begins with a letter,
+			// ASCII letters/digits/hyphens only, no trailing or doubled hyphen.
+			require.NotEmpty(t, got)
+			assert.Regexp(t, `^[A-Za-z]`, got)
+			assert.Regexp(t, `^[A-Za-z0-9-]+$`, got)
+			assert.NotContains(t, got, "--")
+			assert.False(t, strings.HasSuffix(got, "-"))
+
+			// The suffix is never sacrificed to truncation: it is the only part of
+			// the name that makes it unique.
+			parts := strings.Split(got, "-")
+			assert.Len(t, parts[len(parts)-1], emulator.CFNGeneratedNameSuffixLenForTest)
+		})
+	}
+}
+
+// TestCFNGeneratedName_ScopeChangesTheName pins the hash inputs. Each is here
+// for a reason: dropping the stack name reinstates #560, and dropping the
+// account or Region makes two same-named stacks in different Regions collide —
+// which sameScope already treats as different stacks.
+func TestCFNGeneratedName_ScopeChangesTheName(t *testing.T) {
+	base := emulator.CFNGeneratedNameForTest("000000000000", "us-east-1", "stk",
+		"AWS::IAM::Role", "MyRole")
+
+	tests := []struct {
+		name                           string
+		acct, region, stack, logicalID string
+	}{
+		{"a different stack", "000000000000", "us-east-1", "other", "MyRole"},
+		{"a different Region", "000000000000", "eu-west-1", "stk", "MyRole"},
+		{"a different account", "111111111111", "us-east-1", "stk", "MyRole"},
+		{"a different logical ID", "000000000000", "us-east-1", "stk", "OtherRole"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := emulator.CFNGeneratedNameForTest(tt.acct, tt.region, tt.stack,
+				"AWS::IAM::Role", tt.logicalID)
+			assert.NotEqual(t, base, got, "%s must produce a different name", tt.name)
+		})
+	}
+}
+
+// TestCFNGeneratedName_UntabledTypeKeepsItsLogicalID asserts the fix is a table
+// of account-unique names rather than a blanket rewrite. An API Gateway
+// resource's PathPart is a URL segment unique only within its parent, so
+// generating it would change the URL a template was written to produce.
+func TestCFNGeneratedName_UntabledTypeKeepsItsLogicalID(t *testing.T) {
+	for _, resType := range []string{
+		"AWS::ApiGateway::Resource",
+		"AWS::ElastiCache::ReplicationGroup",
+		"AWS::SecretsManager::Secret",
+		"AWS::Unknown::Thing",
+	} {
+		assert.Equal(t, "Widget", emulator.CFNGeneratedNameForTest("000000000000",
+			"us-east-1", "stk", resType, "Widget"),
+			"%s is not in the generated-name table and must keep its logical ID", resType)
+	}
+}
+
+// TestCFNGeneratedName_LongStackNamesStillDiffer is why the stack name is in the
+// *hash* and not only in the visible segment. Two stack names long enough to be
+// truncated to the same prefix produce the same segments, so the suffix is the
+// only thing left distinguishing them — and if the suffix did not depend on the
+// full stack name, two real stacks would collide exactly as they did in #560.
+// Measured: dropping stackName from cfnNameSuffix passes every other test here.
+func TestCFNGeneratedName_LongStackNamesStillDiffer(t *testing.T) {
+	const (
+		acct   = "000000000000"
+		region = "us-east-1"
+		prefix = "a-very-long-stack-name-that-will-be-truncated"
+	)
+
+	for _, resType := range []string{"AWS::S3::Bucket", "AWS::IAM::Role"} {
+		t.Run(resType, func(t *testing.T) {
+			first := emulator.CFNGeneratedNameForTest(acct, region, prefix+"-one",
+				resType, "MyResource")
+			second := emulator.CFNGeneratedNameForTest(acct, region, prefix+"-two",
+				resType, "MyResource")
+
+			// Not vacuous: the segments really are truncated to the same text, so the
+			// suffix is carrying the whole distinction.
+			cut := len(first) - emulator.CFNGeneratedNameSuffixLenForTest
+			assert.Equal(t, first[:cut], second[:cut],
+				"the test needs two names whose segments truncate identically")
+			assert.NotEqual(t, first, second,
+				"two stacks truncating to the same segments must still get different names")
+		})
+	}
+}

--- a/emulator/cfn_resources_v77.go
+++ b/emulator/cfn_resources_v77.go
@@ -84,7 +84,8 @@ func (d *StackDeployer) deployIAMInstanceProfile(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	name := resolveStringProp(props, "InstanceProfileName", logicalID, cctx)
+	name := resolveStringProp(props, "InstanceProfileName",
+		cfnGeneratedName(cctx, "AWS::IAM::InstanceProfile", logicalID), cctx)
 	path := resolveStringProp(props, "Path", "/", cctx)
 
 	bodyBytes, err := json.Marshal(map[string]string{

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -593,3 +593,19 @@ func (d *StackDeployer) DeleteStackResourcesForTest(
 	}
 	return d.deleteStackResources(ctx, stack, stackName, cfnDeleteStackOp)
 }
+
+// CFNGeneratedNameSuffixLenForTest is the width of the derived suffix on a
+// generated physical name, so an external test can split a name into its
+// {stack}-{logical} prefix and its suffix without hard-coding the width.
+const CFNGeneratedNameSuffixLenForTest = cfnGeneratedNameSuffixLen
+
+// CFNGeneratedNameForTest exposes cfnGeneratedName so the constraint arithmetic
+// (truncation, charset, lowercasing) can be asserted directly, rather than only
+// through the resource types that happen to reach it from a template.
+func CFNGeneratedNameForTest(accountID, region, stackName, resType, logicalID string) string {
+	return cfnGeneratedName(&cfnContext{
+		accountID: accountID,
+		region:    region,
+		stackName: stackName,
+	}, resType, logicalID)
+}


### PR DESCRIPTION
A CloudFormation stack in substrate could not be deployed twice. A resource whose
template omits its physical name got the **logical ID verbatim** — unique only
*within* a stack, while an IAM role name, bucket, table or log group is unique
across an account or a Region. Omitting the name is the *recommended* practice, so
the templates most likely written correctly were exactly the ones that collided.

Measured on `main`, deploying one 7-type template as two stacks:

| Type | Second stack |
|---|---|
| `IAM::Role` | `EntityAlreadyExists` |
| `IAM::InstanceProfile` | `EntityAlreadyExists` |
| `S3::Bucket` | `BucketAlreadyExists` |
| `Logs::LogGroup` | `ResourceAlreadyExistsException` |
| `DynamoDB::Table` | `ResourceInUseException` |
| `SQS::Queue` | **`CREATE_COMPLETE`** — sharing the first stack's queue |
| `SNS::Topic` | **`CREATE_COMPLETE`** — sharing the first stack's topic |

The last two are the worse half, and the issue does not name them: those creates are
idempotent, so both stacks reported success while pointing at **one** resource.
Deleting either then destroyed the other's — measured `QueueDoesNotExist` while the
surviving stack still reported `CREATE_COMPLETE`. No error was reported to anyone.

## The fix

An omitted name becomes `{stack}-{logicalID}-{suffix}`, the shape CloudFormation
documents for its own generated physical IDs (`MyStack-MyBucket-abcdefghijk1`),
fitted to each service's own length and case limits. Explicit names are untouched:
that is the existing `resolveStringProp` contract, and a template that sets a name is
asking for the un-repeatable behavior AWS also gives it.

**The suffix is derived, not random, and that is the load-bearing decision.**
`UpdateStack` in substrate is a re-`Deploy` of the whole template —
`clearUnchangedRedeploys` exists precisely because every unchanged resource is
created again. A name regenerated per deploy would mint a fresh resource on every
update and leak the one it replaced. So it is `FNV-64a(account/region/stack/logicalID)`
in base36: unique per stack, opaque, and **stable**, which keeps an unchanged update a
no-op and the emulator deterministic by construction. `TestCFNGeneratedName_UpdateDoesNotMoveAPhysicalID`
is that gate; a `crypto/rand` suffix fails it (verified as a mutant).

**A table of nine types, not a blanket rewrite.** Only 9 of the 68
`resolveStringProp(…, logicalID, …)` sites are account/Region-unique names.
`PathPart` (an API Gateway URL segment unique only within its parent), `Domain`,
`SecretId`, `ClusterId` and `ReplicationGroupId` are deliberately excluded, with a
comment saying why: generating those would change URLs and identifiers a template
legitimately controls.

## Verification

Full gate green: `gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues),
`make test` (race), `make docs-reference-check docs-versions`, the docs site build,
and `test/e2e` vet + test.

Live against `substrate server --address :4671` with the real AWS CLI
(`AWS_MAX_ATTEMPTS=1`), the same template as two stacks:

```
repro-a: CREATE_COMPLETE          repro-b: CREATE_COMPLETE
roles     repro-a-MyRole-4ucgrorqmrlq      repro-b-MyRole-qsvc60t041v1
profiles  repro-a-MyProfile-f78mredbfz7f   repro-b-MyProfile-1r5g9bx3l07m
buckets   repro-a-mybucket-z3ipqnirsdqo    repro-b-mybucket-csh3kxpt1awb
queues    repro-a-MyQueue-1fw0qedi4hv5     repro-b-MyQueue-ixrjtu8232wc
```

- **Cross-resource `!Ref`**: each stack's instance profile holds *its own* role.
- **Update gate**: `update-stack` on an unchanged template → `UPDATE_COMPLETE`, and
  every `PhysicalResourceId` byte-identical.
- **Silent-sharing gate**: deleting `repro-b` left `repro-a`'s queue, bucket and role
  all intact. (`repro-b` itself reports `DELETE_FAILED` — that is #581, whose
  signature `MyRole DELETE_COMPLETE` / `MyProfile DeleteConflict` is unchanged by this
  PR and is the next one in this milestone.)
- **Explicit names** still land verbatim.

## Mutation testing

Six mutants, `-race`, anchor-count asserted before applying, `gofmt`+`vet` gated:

| Mutant | Verdict |
|---|---|
| Drop the stack name from the hash | **CAUGHT** — after it found a real gap, see below |
| Drop account+Region from the hash | CAUGHT (`ScopeChangesTheName`) |
| Clamp the assembled name, sacrificing the suffix | CAUGHT (`Constraints`) |
| Untabled type gets a generated name anyway | CAUGHT (`UntabledTypeKeepsItsLogicalID`) |
| `crypto/rand` suffix per call | CAUGHT (`UpdateDoesNotMoveAPhysicalID`) |
| Explicit-name branch bypassed | CAUGHT (3 existing update/redeploy tests) |

The first **survived** on the first pass, and for a real reason: the stack name is
also a visible segment, so two stacks differ even with it absent from the hash — until
truncation, where two long stack names sharing a truncated prefix would produce
identical segments and, without the stack name in the suffix, identical names. That is
#560 again for exactly the templates whose names are long.
`TestCFNGeneratedName_LongStackNamesStillDiffer` closes it and asserts non-vacuously
that the segments really do truncate to the same text, so the suffix is carrying the
whole distinction. The mutant is caught on re-run.

## Compatibility

**Every stack whose template omits a physical name now gets a different physical
name**, so any fixture asserting a resource name equal to its logical ID must be
re-recorded — one test in this repo did (`TestCFN_LogGroupDefaultName`) and is updated
here. A template that sets the name explicitly is unaffected, and `Ref`/`GetAtt`
resolve to whichever name was used.

Closes #560
