### PR TITLE
fix(cfn,iam): a stack holding an instance profile can be deleted (#581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unaffected and still gets that name verbatim, and `Ref`/`GetAtt` resolve to
   whichever name was used.
 
+- **A stack holding an IAM instance profile can be deleted** (#581). `DeleteStack` on
+  a stack with an `AWS::IAM::Role` and an `AWS::IAM::InstanceProfile` that references
+  it could never converge, and failed *inverted from both directions*: the role
+  reached `DELETE_COMPLETE` while still attached, and the profile that referenced it
+  failed with `DeleteConflict`. So the failure landed on the resource that was still
+  **present**, a retry failed identically, and there was no `RetainResources` escape —
+  retaining the profile leaves it behind for good. Two independent defects:
+
+  - **`DeleteRole` now enforces the instance-profile constraint.** It previously
+    succeeded on a role an instance profile held, leaving the profile listing a role
+    that no longer existed. The `DeleteRole` reference requires the instance profile be
+    removed first (`RemoveRoleFromInstanceProfile`), so substrate now refuses with
+    `DeleteConflict` / **409** — the code, status and shape it already used for the
+    attached-policies case — and the message names the profiles holding the role, as
+    the reference specifies ("The error message describes these entities"). A role held
+    by two profiles is refused until both release it.
+  - **The CloudFormation delete of an instance profile detaches its roles first.** The
+    sweep dispatches one `RemoveRoleFromInstanceProfile` per role in the profile's
+    declared `Roles` before `DeleteInstanceProfile`, resolving each `!Ref` through the
+    deploy's own context so a role whose name was generated is detached by that name.
+    It lands as a pre-step hook rather than by weakening the one-request-per-resource
+    deleter contract, which is what keeps each entry in that table a data declaration.
+
+  Fixing either alone flips the symptom rather than fixing it, so both are here.
+
+  **Compatibility:** a test asserting that `DeleteRole` succeeds on a role held by an
+  instance profile will now see `DeleteConflict`/409. That refusal is real IAM
+  behavior, and the permissive success was the defect.
+
 ## [v0.93.0] - 2026-08-06
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -362,6 +362,26 @@ aws cloudformation describe-stacks --stack-name stuck \
   --query 'Stacks[0].StackStatus'                           # DELETE_FAILED
 ```
 
+#### A resource whose delete needs a detach first gets one
+
+Some deletes are refused while a subordinate entity still references the resource.
+`AWS::IAM::InstanceProfile` is the case substrate models: the sweep dispatches one
+`RemoveRoleFromInstanceProfile` for each role in the profile's declared `Roles`
+before `DeleteInstanceProfile`, resolving each `!Ref` through the same context the
+deploy used — so a role whose name was generated is detached by its generated name.
+
+Without it the stack could not converge from either side
+([#581](https://github.com/scttfrdmn/substrate/issues/581)): `DeleteRole` succeeded
+while the profile still held the role, leaving the profile listing a role that no
+longer existed, and `DeleteInstanceProfile` then refused with `DeleteConflict`. The
+failure therefore landed on the resource that was still *present*, and a retry failed
+identically — with no `RetainResources` escape, since retaining the profile leaves it
+behind for good.
+
+A pre-step failure fails that resource: a delete dispatched after a failed detach
+would be refused anyway, and reporting the detach's own error names what went wrong.
+A profile declaring no roles dispatches only its own delete.
+
 Coverage is stated rather than implied. Of the 109 resource types the deployer
 dispatches, 89 have a delete request and 11 are state-only types whose stub record
 is removed. The remaining 9 sweep to a no-op and are reported as `DELETE_SKIPPED`
@@ -744,7 +764,7 @@ by their own plugins, so a stack's cost shows up under S3, EC2 and so on.
 | ListUsers | |
 | CreateRole | Supports trust policy document |
 | GetRole | |
-| DeleteRole | |
+| DeleteRole | Refuses with `DeleteConflict`/409 while a policy is attached **or** an instance profile holds the role; the message names the profiles |
 | ListRoles | |
 | CreateGroup | |
 | GetGroup | |

--- a/emulator/cfn_delete.go
+++ b/emulator/cfn_delete.go
@@ -424,6 +424,53 @@ var cfnResourceDeleters = map[string]cfnDeleteRequestFunc{
 	"AWS::SES::EmailIdentity": pathDeleter("sesv2", "/v2/email/identities/"),
 }
 
+// cfnDeletePreStepFunc builds the requests that must succeed before a resource's own
+// delete is dispatched, in the order they are returned. An empty or nil return means
+// there is nothing to do, which is the common case.
+type cfnDeletePreStepFunc func(d *StackDeployer, dr DeployedResource,
+	props map[string]interface{}, cctx *cfnContext) []*AWSRequest
+
+// cfnDeletePreSteps holds the detach-before-delete calls a resource needs, for the
+// types whose delete is refused while a subordinate entity still references them.
+//
+// This is a separate hook rather than a change to [cfnDeleteRequestFunc] because that
+// contract is deliberately one request per resource — that is what keeps every entry
+// in [cfnResourceDeleters] a data declaration the sweep can inspect without
+// dispatching. A pre-step keeps that property: the main request is still the one the
+// table declares, and the steps run through [StackDeployer.dispatchResourceDelete] so
+// absent-resource tolerance and event recording are identical for both.
+//
+// A pre-step failure fails the resource. That is the right outcome — a delete
+// dispatched after a failed detach would be refused anyway, and reporting the detach's
+// own error names what actually went wrong.
+var cfnDeletePreSteps = map[string]cfnDeletePreStepFunc{
+	// DeleteInstanceProfile is refused while the profile holds a role, and DeleteRole
+	// is now refused while a profile holds it — correctly, per both references. So the
+	// stack could not converge from either side until something made the detach call
+	// (#581). The roles come from the template's Roles list, the same list
+	// deployIAMInstanceProfile attached, resolved through the same context so a
+	// !Ref to a role in the stack yields the role's generated physical name.
+	"AWS::IAM::InstanceProfile": func(_ *StackDeployer, dr DeployedResource,
+		props map[string]interface{}, cctx *cfnContext,
+	) []*AWSRequest {
+		roles := resolveStringList(props["Roles"], cctx)
+		steps := make([]*AWSRequest, 0, len(roles))
+		for _, roleName := range roles {
+			body, err := json.Marshal(map[string]string{
+				"InstanceProfileName": dr.PhysicalID,
+				"RoleName":            roleName,
+			})
+			if err != nil {
+				continue
+			}
+			steps = append(steps, &AWSRequest{Service: "iam",
+				Operation: "RemoveRoleFromInstanceProfile", Body: body,
+				Headers: map[string]string{}, Params: map[string]string{}})
+		}
+		return steps
+	},
+}
+
 // cfnStubDeleteTypes are the resource types whose deploy writes properties into
 // cfnStubNamespace and dispatches no API call.
 //
@@ -773,6 +820,13 @@ func (d *StackDeployer) deleteViaTable(
 		result.Status = cfnDeleteSkipped
 		result.Reason = "the delete request for " + dr.Type + " could not be built"
 		return result
+	}
+	if pre, ok := cfnDeletePreSteps[dr.Type]; ok {
+		for _, step := range pre(d, dr, props, cctx) {
+			if failure := d.dispatchResourceDelete(ctx, dr, step, streamID); failure != nil {
+				return *failure
+			}
+		}
 	}
 	if failure := d.dispatchResourceDelete(ctx, dr, req, streamID); failure != nil {
 		return *failure

--- a/emulator/cfn_instance_profile_delete_test.go
+++ b/emulator/cfn_instance_profile_delete_test.go
@@ -1,0 +1,264 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// profileStackTemplate is #581's reproducer: a role, and an instance profile that
+// references it. This is the shape every "EC2 instance with a role" template has, so
+// the stack that could not be deleted was a very ordinary one.
+const profileStackTemplate = `{
+	"Resources": {
+		"ProbeRole": {
+			"Type": "AWS::IAM::Role",
+			"Properties": {
+				"RoleName": "probe-role-1",
+				"AssumeRolePolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [{
+						"Effect": "Allow",
+						"Principal": {"Service": "ec2.amazonaws.com"},
+						"Action": "sts:AssumeRole"
+					}]
+				}
+			}
+		},
+		"ProbeProfile": {
+			"Type": "AWS::IAM::InstanceProfile",
+			"Properties": {
+				"InstanceProfileName": "probe-profile-1",
+				"Roles": [{"Ref": "ProbeRole"}]
+			}
+		}
+	}
+}`
+
+// iamCall dispatches one IAM operation with a JSON body and returns the response,
+// which is how these tests observe IAM directly rather than through the stack.
+//
+// The returned error is deliberately ignored: the deployer's dispatch renders any
+// status of 400 or above as a Go error, and half of these calls are asserting exactly
+// such a refusal. A non-nil response is required instead, which is what separates a
+// modeled refusal from the request never reaching the plugin at all — a routing
+// failure returns no response.
+func iamCall(t *testing.T, d *emulator.StackDeployer, streamID, op string,
+	body map[string]string) *emulator.AWSResponse {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	resp, _ := d.DispatchForTest(context.Background(), &emulator.AWSRequest{
+		Service: "iam", Operation: op, Body: raw,
+		Headers: map[string]string{}, Params: map[string]string{},
+	}, streamID)
+	require.NotNil(t, resp, "%s did not reach the IAM plugin", op)
+	return resp
+}
+
+// TestCFN_AStackHoldingAnInstanceProfileDeletes is #581. The stack could not
+// converge: DeleteRole succeeded while the profile still held the role, and
+// DeleteInstanceProfile then refused with DeleteConflict — so the failure landed on
+// the resource that was still *present*, and there was no RetainResources escape
+// because retaining the profile would leave it behind forever. A second DeleteStack
+// failed identically.
+func TestCFN_AStackHoldingAnInstanceProfileDeletes(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	result, err := d.Deploy(ctx, profileStackTemplate, "pstack", nil)
+	require.NoError(t, err)
+	for _, res := range result.Resources {
+		require.Empty(t, res.Error, "%s must deploy, or the delete proves nothing", res.LogicalID)
+	}
+	// Not vacuous: the profile really does hold the role, which is the condition
+	// that made the delete fail.
+	require.Contains(t, string(iamCall(t, d, "pstack", "GetInstanceProfile",
+		map[string]string{"InstanceProfileName": "probe-profile-1"}).Body), "probe-role-1")
+
+	require.NoError(t, d.DeleteStack(ctx, "pstack"),
+		"a stack holding an instance profile must reach DELETE_COMPLETE")
+
+	// Both are gone from IAM, not merely dropped from the stack record.
+	assert.Equal(t, http.StatusNotFound, iamCall(t, d, "pstack", "GetRole",
+		map[string]string{"RoleName": "probe-role-1"}).StatusCode)
+	assert.Equal(t, http.StatusNotFound, iamCall(t, d, "pstack", "GetInstanceProfile",
+		map[string]string{"InstanceProfileName": "probe-profile-1"}).StatusCode)
+
+	stacks, err := d.ListStacks(ctx)
+	require.NoError(t, err)
+	for _, s := range stacks {
+		assert.NotEqual(t, "pstack", s.StackName, "the stack record must be gone too")
+	}
+}
+
+// TestCFN_TheProfileDetachIsDispatchedBeforeEitherDelete asserts the call order in
+// the recorded events rather than trusting the priority table. The table already put
+// the profile's delete before the role's — priority 2 before 1, swept descending —
+// and the stack still failed, so the order is what has to be observed.
+func TestCFN_TheProfileDetachIsDispatchedBeforeEitherDelete(t *testing.T) {
+	d, _, _, store := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, profileStackTemplate, "porder", nil)
+	require.NoError(t, err)
+	created := sweepOperations(t, store, "porder")
+
+	require.NoError(t, d.DeleteStack(ctx, "porder"))
+
+	deleted := sweepOperations(t, store, "porder")[len(created):]
+	assert.Equal(t, []string{
+		"RemoveRoleFromInstanceProfile", // the pre-step
+		"DeleteInstanceProfile",         // priority 2, swept first
+		"DeleteRole",                    // priority 1, and now unheld
+	}, deleted, "the detach must precede both deletes")
+}
+
+// TestIAM_DeleteRoleRefusesARoleHeldByAnInstanceProfile is #581's first defect with
+// no CloudFormation involved. DeleteRole succeeded on a role an instance profile
+// held, which left the profile listing a role that no longer existed — the dangling
+// reference that made the stack unfixable. The DeleteRole reference requires the
+// instance profile be removed first, and DeleteConflict is 409.
+func TestIAM_DeleteRoleRefusesARoleHeldByAnInstanceProfile(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	const stream = "direct"
+
+	require.Equal(t, http.StatusOK, iamCall(t, d, stream, "CreateRole", map[string]string{
+		"RoleName":                 "direct-role",
+		"AssumeRolePolicyDocument": `{"Statement":[]}`,
+	}).StatusCode)
+	require.Equal(t, http.StatusOK, iamCall(t, d, stream, "CreateInstanceProfile",
+		map[string]string{"InstanceProfileName": "direct-profile"}).StatusCode)
+	require.Equal(t, http.StatusOK, iamCall(t, d, stream, "AddRoleToInstanceProfile",
+		map[string]string{
+			"InstanceProfileName": "direct-profile", "RoleName": "direct-role",
+		}).StatusCode)
+
+	refusal := iamCall(t, d, stream, "DeleteRole", map[string]string{"RoleName": "direct-role"})
+	assert.Equal(t, http.StatusConflict, refusal.StatusCode, "DeleteConflict is 409")
+	body := string(refusal.Body)
+	assert.Contains(t, body, "DeleteConflict")
+	// "The error message describes these entities" — so the profile must be named, or
+	// a caller cannot tell what to detach from.
+	assert.Contains(t, body, "direct-profile")
+
+	// The role is still there: a refused delete must not have deleted anything.
+	assert.Equal(t, http.StatusOK, iamCall(t, d, stream, "GetRole",
+		map[string]string{"RoleName": "direct-role"}).StatusCode)
+
+	// And it deletes once detached, which is the documented remedy.
+	require.Equal(t, http.StatusOK, iamCall(t, d, stream, "RemoveRoleFromInstanceProfile",
+		map[string]string{
+			"InstanceProfileName": "direct-profile", "RoleName": "direct-role",
+		}).StatusCode)
+	assert.Equal(t, http.StatusOK, iamCall(t, d, stream, "DeleteRole",
+		map[string]string{"RoleName": "direct-role"}).StatusCode)
+}
+
+// TestIAM_DeleteRoleRefusesUntilEveryProfileReleasesIt covers the case the sweep's
+// one-profile shape hides: IAM allows a role in more than one instance profile, so a
+// check that stopped at the first holder — or one that deleted after any single
+// detach — would still leave a dangling reference.
+func TestIAM_DeleteRoleRefusesUntilEveryProfileReleasesIt(t *testing.T) {
+	d, _, _, _ := newSweepDeployer(t)
+	const stream = "twoprofiles"
+
+	require.Equal(t, http.StatusOK, iamCall(t, d, stream, "CreateRole", map[string]string{
+		"RoleName":                 "shared-role",
+		"AssumeRolePolicyDocument": `{"Statement":[]}`,
+	}).StatusCode)
+	for _, name := range []string{"holder-a", "holder-b"} {
+		require.Equal(t, http.StatusOK, iamCall(t, d, stream, "CreateInstanceProfile",
+			map[string]string{"InstanceProfileName": name}).StatusCode)
+		require.Equal(t, http.StatusOK, iamCall(t, d, stream, "AddRoleToInstanceProfile",
+			map[string]string{
+				"InstanceProfileName": name, "RoleName": "shared-role",
+			}).StatusCode)
+	}
+
+	both := iamCall(t, d, stream, "DeleteRole", map[string]string{"RoleName": "shared-role"})
+	require.Equal(t, http.StatusConflict, both.StatusCode)
+	assert.Contains(t, string(both.Body), "holder-a")
+	assert.Contains(t, string(both.Body), "holder-b", "every holder must be named")
+
+	require.Equal(t, http.StatusOK, iamCall(t, d, stream, "RemoveRoleFromInstanceProfile",
+		map[string]string{
+			"InstanceProfileName": "holder-a", "RoleName": "shared-role",
+		}).StatusCode)
+
+	one := iamCall(t, d, stream, "DeleteRole", map[string]string{"RoleName": "shared-role"})
+	assert.Equal(t, http.StatusConflict, one.StatusCode,
+		"one profile still holds it, so the delete is still refused")
+	assert.Contains(t, string(one.Body), "holder-b")
+	assert.NotContains(t, string(one.Body), "holder-a",
+		"a released profile must not still be named")
+
+	require.Equal(t, http.StatusOK, iamCall(t, d, stream, "RemoveRoleFromInstanceProfile",
+		map[string]string{
+			"InstanceProfileName": "holder-b", "RoleName": "shared-role",
+		}).StatusCode)
+	assert.Equal(t, http.StatusOK, iamCall(t, d, stream, "DeleteRole",
+		map[string]string{"RoleName": "shared-role"}).StatusCode)
+}
+
+// TestCFN_AProfileWithNoRolesStillDeletes pins that the pre-step is empty rather
+// than absent-safe by accident: a profile declaring no Roles emits no
+// RemoveRoleFromInstanceProfile at all, so the hook adds no dispatch for the common
+// case and cannot fail one.
+func TestCFN_AProfileWithNoRolesStillDeletes(t *testing.T) {
+	tmpl := `{"Resources":{"Bare":{"Type":"AWS::IAM::InstanceProfile",` +
+		`"Properties":{"InstanceProfileName":"bare-profile"}}}}`
+
+	d, _, _, store := newSweepDeployer(t)
+	ctx := context.Background()
+
+	_, err := d.Deploy(ctx, tmpl, "bare", nil)
+	require.NoError(t, err)
+	created := sweepOperations(t, store, "bare")
+
+	require.NoError(t, d.DeleteStack(ctx, "bare"))
+
+	deleted := sweepOperations(t, store, "bare")[len(created):]
+	assert.Equal(t, []string{"DeleteInstanceProfile"}, deleted,
+		"a profile with no roles must dispatch only its own delete")
+	assert.Equal(t, http.StatusNotFound, iamCall(t, d, "bare", "GetInstanceProfile",
+		map[string]string{"InstanceProfileName": "bare-profile"}).StatusCode)
+}
+
+// TestCFN_AGeneratedProfileNameDetachesItsGeneratedRole is the interaction with
+// #560, and the reason PR A landed first. Neither name is in the template, so the
+// pre-step's !Ref must resolve to the role's *generated* physical name — a detach
+// naming the logical ID would silently do nothing and the delete would fail again.
+func TestCFN_AGeneratedProfileNameDetachesItsGeneratedRole(t *testing.T) {
+	tmpl := `{
+		"Resources": {
+			"GenRole": {
+				"Type": "AWS::IAM::Role",
+				"Properties": {"AssumeRolePolicyDocument": {"Statement": []}}
+			},
+			"GenProfile": {
+				"Type": "AWS::IAM::InstanceProfile",
+				"Properties": {"Roles": [{"Ref": "GenRole"}]}
+			}
+		}
+	}`
+
+	d, _, _, _ := newSweepDeployer(t)
+	ctx := context.Background()
+
+	result, err := d.Deploy(ctx, tmpl, "genboth", nil)
+	require.NoError(t, err)
+	role := resourceByLogicalID(t, result, "GenRole").PhysicalID
+	require.NotEqual(t, "GenRole", role, "the role's name must be generated, per #560")
+
+	require.NoError(t, d.DeleteStack(ctx, "genboth"),
+		"the detach must name the generated role, not the logical ID")
+	assert.Equal(t, http.StatusNotFound, iamCall(t, d, "genboth", "GetRole",
+		map[string]string{"RoleName": role}).StatusCode)
+}

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -493,6 +493,27 @@ func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 			http.StatusConflict), nil
 	}
 
+	// An instance profile holding the role is the other subordinate entity the
+	// DeleteRole reference requires be removed first — "Before attempting to delete a
+	// role, remove the following attached items: … Instance profile
+	// (RemoveRoleFromInstanceProfile)". Without this the delete succeeded and left the
+	// profile listing a role that no longer exists, and DeleteInstanceProfile then
+	// refused with DeleteConflict — so the failure surfaced on the resource that was
+	// still present rather than on the one that broke the invariant (#581).
+	holders, err := p.instanceProfilesHoldingRole(goCtx, params.RoleName)
+	if err != nil {
+		return nil, err
+	}
+	if len(holders) > 0 {
+		// The reference says "The error message describes these entities", so name
+		// them: a caller has to know which profiles to detach from, and a stack that
+		// wedges here needs the reason to say what held it.
+		return iamErrorResponse("DeleteConflict",
+			fmt.Sprintf("Cannot delete entity, must remove roles from instance profile first. "+
+				"Instance profiles holding %s: %s", params.RoleName, strings.Join(holders, ", ")),
+			http.StatusConflict), nil
+	}
+
 	if err := p.state.Delete(goCtx, iamNamespace, "role:"+params.RoleName); err != nil {
 		return nil, fmt.Errorf("delete role: %w", err)
 	}
@@ -2620,6 +2641,43 @@ func (p *IAMPlugin) removeRoleFromInstanceProfile(_ *RequestContext, req *AWSReq
 		return nil, fmt.Errorf("put instance profile: %w", err)
 	}
 	return iamXMLEmptyResponse("RemoveRoleFromInstanceProfile"), nil
+}
+
+// instanceProfilesHoldingRole returns the names of the instance profiles that list
+// roleName, in state order, so [IAMPlugin.deleteRole] can refuse and name them.
+//
+// It sweeps the instance_profile: prefix the same way listInstanceProfiles does,
+// rather than maintaining a reverse index: a profile's roles are already stored on
+// the profile, and a second index would be a consistency problem of its own for a
+// read that happens once per role delete. An unreadable or unparsable profile is
+// skipped, matching listInstanceProfiles — one corrupt record must not make a role
+// undeletable.
+func (p *IAMPlugin) instanceProfilesHoldingRole(
+	ctx context.Context, roleName string,
+) ([]string, error) {
+	keys, err := p.state.List(ctx, iamNamespace, "instance_profile:")
+	if err != nil {
+		return nil, fmt.Errorf("list instance profiles: %w", err)
+	}
+
+	var holders []string
+	for _, k := range keys {
+		data, getErr := p.state.Get(ctx, iamNamespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var profile IAMInstanceProfile
+		if err := json.Unmarshal(data, &profile); err != nil {
+			continue
+		}
+		for _, r := range profile.Roles {
+			if r.RoleName == roleName {
+				holders = append(holders, profile.InstanceProfileName)
+				break
+			}
+		}
+	}
+	return holders, nil
 }
 
 // listInstanceProfiles returns persisted IAM instance profiles.


### PR DESCRIPTION
A stack holding an `AWS::IAM::Role` and an `AWS::IAM::InstanceProfile` that
references it — the shape of every "EC2 instance with a role" template — could not be
deleted, and failed **inverted from both directions**:

```
delete: DELETE_FAILED
  ProbeRole     DELETE_COMPLETE
  ProbeProfile  DELETE_FAILED  DeleteConflict
get-role     probe-role-1     → NoSuchEntity
get-profile  probe-profile-1  → still exists
```

The failure landed on the resource that was still **present**, and a second
`DeleteStack` failed identically. There was no `RetainResources` escape either:
retaining the profile leaves it behind for good.

## Two defects, both here

Fixing either alone flips the symptom rather than fixing it, as the issue says.

**1. `DeleteRole` did not enforce the instance-profile constraint.** Reproduced with
no CloudFormation involved: `DeleteRole` on a role an instance profile held
*succeeded*, and the profile was then left listing a role that no longer existed —
the dangling reference that made the stack unfixable. The reference is explicit:
"Before attempting to delete a role, remove the following attached items: … Instance
profile (`RemoveRoleFromInstanceProfile`)", and `DeleteConflict` is **409**.
Substrate now refuses with exactly that code and status — the same shape it already
used for the attached-policies case two blocks up — and names the profiles holding
the role, since the reference specifies "The error message describes these entities"
and a caller otherwise cannot tell what to detach from. A role held by two profiles
is refused until both release it.

**2. The CFN delete of an instance profile did not detach its roles.** The sweep now
dispatches one `RemoveRoleFromInstanceProfile` per role in the profile's declared
`Roles` before `DeleteInstanceProfile`, resolved through the deploy's own context so
a role whose name was **generated** (#560) is detached by that generated name.

It lands as a `cfnDeletePreSteps` hook rather than by weakening
`cfnDeleteRequestFunc`: that contract is deliberately one request per resource, which
is what keeps every entry in `cfnResourceDeleters` a data declaration inspectable
without dispatching. The pre-steps run through the existing
`dispatchResourceDelete`, so absent-resource tolerance and event recording are
identical for both. A profile declaring no roles emits nothing.

**Ordering** was already correct in the priority table (profile 2, role 1, swept
descending) and the stack still failed — so the order is asserted from the recorded
events rather than trusted.

## Verification

Full gate green: `gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues),
`make test` (race), `make docs-reference-check docs-versions`, docs site build,
`test/e2e` vet + test.

Live against `substrate server --address :4671` with the real AWS CLI
(`AWS_MAX_ATTEMPTS=1`):

```
create: CREATE_COMPLETE        profile roles: probe-role-1
delete → stack gone (not DELETE_FAILED)
get-role     probe-role-1     → NoSuchEntity
get-profile  probe-profile-1  → NoSuchEntity

# defect 1 directly
aws iam delete-role --role-name direct-role
→ DeleteConflict: Cannot delete entity, must remove roles from instance profile
  first. Instance profiles holding direct-role: direct-profile
# the role is still there, and deletes after remove-role-from-instance-profile
```

And the two fixes together give the release its point — two stacks from one template
now deploy **and** tear down independently: `ra`/`rb` both `CREATE_COMPLETE`,
deleting `rb` leaves `ra-MyRole-czo0btk63rc9` intact.

## Tests

Six, `package emulator_test`, no wall-clock or network dependency: the #581
reproducer reaching `DELETE_COMPLETE` with both resources gone from IAM (asserting
non-vacuously that the profile really held the role first); the dispatch **order**
from recorded events (`RemoveRoleFromInstanceProfile`, `DeleteInstanceProfile`,
`DeleteRole`); the direct-IAM refusal including that the role survives it and deletes
after a detach; a role in two profiles refused until both release it, with the
released one no longer named; a profile with no roles dispatching only its own
delete; and the #560 interaction — both names generated, so the detach must resolve
`!Ref` to the role's generated name or silently do nothing.

## Mutation testing

Four mutants, anchor-count asserted, `gofmt`+`vet` gated:

| Mutant | Verdict |
|---|---|
| Drop the `instance_profile:` sweep from `DeleteRole` | CAUGHT (both direct-IAM tests) |
| Drop the profile pre-step | CAUGHT (all three CFN tests) |
| `DeleteConflict` status changed to 400 | CAUGHT (both direct-IAM tests) |
| Stop at the first holding profile | CAUGHT (the two-profile test) |

Each half of the fix is independently gated, which is what the "fixing either alone
flips the symptom" property requires.

## Compatibility

A test asserting that `DeleteRole` succeeds on a role held by an instance profile will
now see `DeleteConflict`/409. That refusal is real IAM behavior; the permissive
success was the defect.

Closes #581
