### PR TITLE
fix(sqs): the wildcard consistency seed cannot be double-consumed (#582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance profile will now see `DeleteConflict`/409. That refusal is real IAM
   behavior, and the permissive success was the defect.
 
+- **The SQS wildcard consistency seed cannot be double-consumed** (#582). Consuming a
+  seeded miss is a read-modify-write and `StateManager` has no compare-and-swap, so
+  the decrement was serialized under a mutex striped by *queue name*. That covered a
+  name-scoped seed and left the `"*"` wildcard unguarded: the wildcard is shared
+  across every queue, so two lookups on different names took different stripes and
+  raced on the one budget they were both spending. A seed of 16 misses driven from 32
+  concurrent lookups on distinct queues was measured reporting 27 and then 32 misses
+  — a harness seeding "the next N lookups miss" saw more than N, and only sometimes.
+
+  Consumption now takes one dedicated mutex covering the whole read-decrement-write.
+  The striped type is **replaced** rather than supplemented, since its only caller was
+  the seed path itself; one lock also means there is no lock order to get wrong. This
+  is the shape the S3 conditional-conflict seed already uses, for the same reason. The
+  guarantee remains process-local, which covers substrate's single-process topology.
+
 ## [v0.93.0] - 2026-08-06
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -2031,6 +2031,15 @@ A name-scoped seed is consulted before the wildcard. When a name-scoped seed is
 exhausted the lookup falls through to the wildcard, so an empty named seed does not
 mask a wildcard that still has budget.
 
+**A budget is consumed exactly once per miss, including under concurrency.** That
+matters most for a wildcard seed, which is shared across every queue: seeding
+`{"getUrlMisses":16}` and then driving concurrent lookups on sixteen *different*
+queues reports exactly sixteen misses, not more. Substrate serializes the
+read-decrement-write on one lock, the same way it does for the
+[S3 conditional-conflict seed](#seeding-conditionalrequestconflict). The guarantee
+is process-local, so it covers a single `substrate server` and not two of them
+sharing one state backend.
+
 **The window is counted in misses, not measured as a duration.** Substrate's
 simulated clock advances with wall time from its baseline, so a duration-based
 window would expire partway through a test and make "still missing" assertions

--- a/emulator/sqs_consistency_test.go
+++ b/emulator/sqs_consistency_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -323,10 +324,13 @@ func TestSQS_Consistency_RejectsNegative(t *testing.T) {
 	}
 }
 
-// TestSQS_Consistency_ConcurrentGetQueueUrl is the test that fails without the
-// striped mutex in sqsQueueMutex. Consuming a miss is a read-modify-write and
-// StateManager has no compare-and-swap, so concurrent lookups could each read the
-// same count and each write count-1, consuming one miss where several were seeded.
+// TestSQS_Consistency_ConcurrentGetQueueUrl is the test that fails without the seed
+// mutex. Consuming a miss is a read-modify-write and StateManager has no
+// compare-and-swap, so concurrent lookups could each read the same count and each
+// write count-1, consuming one miss where several were seeded.
+//
+// It drives one queue name, which the per-queue stripe this once used also covered;
+// TestSQS_Consistency_ConcurrentWildcardAcrossQueues is the case it did not.
 //
 // Run with -race. If this ever passes with the lock removed, it is not driving
 // enough concurrency — check that before trusting it.
@@ -368,6 +372,63 @@ func TestSQS_Consistency_ConcurrentGetQueueUrl(t *testing.T) {
 	// The budget is now spent, so the next lookup resolves.
 	status, _ := getQueueURL(t, srv, "conc-q", false)
 	assert.Equal(t, http.StatusOK, status)
+}
+
+// TestSQS_Consistency_ConcurrentWildcardAcrossQueues is #582. Seed consumption used
+// to take a mutex striped by queue name, which serialized the name-scoped seed
+// correctly and left the "*" wildcard unguarded: the wildcard is shared across every
+// queue, so lookups on *different* names hashed to different stripes and raced on the
+// one budget they were both spending. A double-spend decrements once for two
+// consumed misses, so the count observed here comes out *above* the seeded budget —
+// a harness seeding "the next 16 lookups in this suite miss" would see 17 or more,
+// and only sometimes.
+//
+// More queues than budget on purpose: the overspend has to be observable as a count,
+// which needs lookups left over to be refused. Run with -race.
+func TestSQS_Consistency_ConcurrentWildcardAcrossQueues(t *testing.T) {
+	const (
+		queues = 32
+		budget = 16
+	)
+
+	srv, _ := newSQSTestServer(t)
+	names := make([]string, queues)
+	for i := range queues {
+		names[i] = fmt.Sprintf("wild-conc-%d", i)
+		createSQSQueue(t, srv, names[i])
+	}
+	// No queueName: one wildcard seed every one of those queues consumes from.
+	seedSQSConsistency(t, srv, map[string]any{"getUrlMisses": budget})
+
+	var (
+		mu     sync.Mutex
+		misses int
+		start  = make(chan struct{})
+		wg     sync.WaitGroup
+	)
+	for _, name := range names {
+		wg.Add(1)
+		go func(queue string) {
+			defer wg.Done()
+			<-start // maximize the overlap on the read-modify-write
+			status, _ := getQueueURL(t, srv, queue, false)
+			if status == http.StatusBadRequest {
+				mu.Lock()
+				misses++
+				mu.Unlock()
+			}
+		}(name)
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, budget, misses,
+		"a wildcard seed shared across queues must be consumed exactly once per miss")
+
+	// And the budget really is spent, rather than the count having come out right
+	// because misses were lost instead of double-spent.
+	status, _ := getQueueURL(t, srv, names[0], false)
+	assert.Equal(t, http.StatusOK, status, "the wildcard budget must be exhausted")
 }
 
 // TestSQS_Consistency_ResetClearsSeeds pins that seeds live in the state store and

--- a/emulator/sqs_control.go
+++ b/emulator/sqs_control.go
@@ -4,51 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"net/http"
 	"strings"
-	"sync"
 )
 
 // sqsCtrlNamespace is the state namespace for SQS control-plane (seed) data.
 const sqsCtrlNamespace = "sqs-ctrl"
-
-// sqsQueueLockStripes is the number of mutexes in [SQSPlugin]'s per-queue stripe
-// set. A power of two well above the concurrency any test drives, so distinct
-// queues almost never contend.
-const sqsQueueLockStripes = 64
-
-// sqsQueueMutex is a striped mutex set serializing seed consumption per queue.
-//
-// It deliberately mirrors [s3KeyMutex] rather than reusing it: that type's API is
-// two-part (bucket, key) and its documentation is written entirely in S3 terms, so
-// sharing would mean either changing a signature used at every S3
-// conditional-write call site or adding a joined-string API that reads worse at
-// both. Roughly twenty lines of FNV striping is the cheaper duplication; extract a
-// common type on the third caller.
-//
-// The hazard is the same one s3KeyMutex exists for. Consuming a seeded miss is a
-// read-modify-write, and [StateManager] offers no compare-and-swap — Get/Put/
-// Delete/List only, with [MemoryStateManager] last-write-wins. Two concurrent
-// lookups could both read misses=1 and both write 0, consuming one miss where two
-// were seeded, so a test asserting "exactly N calls fail" would flake. Holding a
-// per-queue lock across read→decrement→Put closes that window.
-//
-// The guarantee is bounded the same way, and for the same reason: it is
-// process-local. That is airtight for substrate's single-process topology and
-// would not hold across two emulator processes sharing one state backend.
-type sqsQueueMutex struct {
-	stripes [sqsQueueLockStripes]sync.Mutex
-}
-
-// lock acquires the stripe guarding a queue name and returns its unlock function.
-func (m *sqsQueueMutex) lock(queueName string) func() {
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(queueName))
-	mu := &m.stripes[h.Sum32()%sqsQueueLockStripes]
-	mu.Lock()
-	return mu.Unlock
-}
 
 // sqsConsistencySeed is a seeded create→lookup eventual-consistency window. AWS
 // documents that a caller "must wait at least one second after the queue is
@@ -155,9 +116,26 @@ func (op sqsConsistencyOp) counter(seed *sqsConsistencySeed) *int {
 // burn budget the test meant to spend on the window, leaving the later retry
 // assertion meaningless. [sqsConsistencyDeletedRecently] is the deliberate
 // exception — the queue is absent by definition in that case.
+//
+// Consumption takes one dedicated mutex, not a mutex keyed by the queue name.
+// Decrementing a counter is a read-modify-write and [StateManager] offers no
+// compare-and-swap — Get/Put/Delete/List only, with [MemoryStateManager]
+// last-write-wins — so two concurrent lookups could both read a budget of 1, both
+// decrement to 0 and both Put, consuming one seeded miss twice and making a test
+// that asserts "exactly N calls fail" flake. A per-queue lock closed that window
+// only for the name-scoped seed: the "*" wildcard is shared across every queue, so
+// two lookups on *different* names took different locks and raced on the one seed
+// they both consumed (#582). Seed consumption is a harness-frequency operation, so
+// a single mutex costs nothing, and having exactly one lock here means there is no
+// lock order to get wrong. [S3Plugin.consumeConditionalConflict] holds the same
+// shape for the same reason.
+//
+// The guarantee is bounded the way that one is, too: it is process-local, which
+// covers substrate's single-process topology and would not hold across two emulator
+// processes sharing one state backend.
 func (p *SQSPlugin) consumeQueueMiss(queueName string, op sqsConsistencyOp) (bool, error) {
-	unlock := p.queueMu.lock(queueName)
-	defer unlock()
+	p.seedMu.Lock()
+	defer p.seedMu.Unlock()
 
 	goCtx := context.Background()
 	for _, key := range []string{sqsCtrlKey(queueName), sqsCtrlKey("*")} {

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -27,10 +28,10 @@ type SQSPlugin struct {
 	logger Logger
 	tc     *TimeController
 
-	// queueMu serializes consumption of a seeded consistency window per queue,
-	// since decrementing the miss counter is a read-modify-write and StateManager
-	// offers no compare-and-swap. See [sqsQueueMutex].
-	queueMu sqsQueueMutex
+	// seedMu serializes consumption of a seeded consistency window. It is one lock
+	// rather than one per queue because the "*" wildcard seed is shared across every
+	// queue name; see [SQSPlugin.consumeQueueMiss].
+	seedMu sync.Mutex
 }
 
 // Name returns the service name "sqs".


### PR DESCRIPTION
Consuming a seeded consistency miss is a read-modify-write and `StateManager` has no
compare-and-swap, so the decrement was serialized under a mutex striped by **queue
name**. The `"*"` wildcard seed is shared by every queue but the lock was not: two
concurrent lookups on *different* names took different stripes, both read the same
budget, both decremented it and both `Put`. One seeded miss consumed twice.

The issue notes this would flake rather than fail reliably. It does not — with enough
concurrency it fails every time. A wildcard seed of **16** driven by **32** concurrent
`GetQueueUrl` calls on distinct queues reported **27** misses, then **32** on the next
run: a harness seeding "the next N lookups in this suite miss" saw more than N, and
inconsistently.

## The fix, and where it deviates from the issue

The issue proposes adding `seedMu` *alongside* `queueMu` and specifies a
stripe → seed-mutex lock order. Measured before writing any code: **`queueMu.lock` had
exactly one call site — `consumeQueueMiss` itself.** Nothing else used the stripe set,
so it is **replaced** rather than supplemented. That removes the lock-order rule along
with the hazard it guarded, which is strictly better than documenting an ordering
between two locks when one suffices. Seed consumption is a harness-frequency
operation, so striping buys nothing here.

The result is the shape `S3Plugin.consumeConditionalConflict` already has — the seed
this was found next to, in #540 — and the comment cross-references it so the two read
as one decision rather than two coincidences.

## Acceptance criteria

- [x] Concurrent consumption of a wildcard seed from different queue names consumes
      each seeded miss exactly once.
- [x] A test drives N concurrent lookups against a wildcard seed of M and asserts
      exactly M report the deviation, under `-race`, failing before the fix —
      measured at 27 and 32 against a seeded 16.
- [x] The name-scoped path keeps its behaviour, including fall-through to a funded
      wildcard when a name-scoped seed is exhausted (`sqs_consistency_test.go`'s
      existing cases pass unchanged).
- [x] The "airtight" doc comment is updated — it moves to `consumeQueueMiss` along
      with the reasoning, since the type it was attached to is gone. It now records
      that the guarantee was airtight for the name-scoped path and **not** for the
      wildcard one, keeping the two paragraphs that are still true: `StateManager` has
      no compare-and-swap, and the guarantee is process-local.
- [x] `CHANGELOG.md` under `### Fixed`.

## Tests

`TestSQS_Consistency_ConcurrentWildcardAcrossQueues`: 32 queues sharing one wildcard
seed of 16, released from a single `start` channel to maximize overlap. More queues
than budget on purpose — the overspend is only observable as a count if there are
lookups left over to be refused. It also asserts the budget really is spent
afterwards, so a count that comes out right because misses were *lost* rather than
double-spent still fails.

The pre-existing single-name concurrency test keeps its assertion and gains a comment
saying which case it does not cover, so the two are not mistaken for duplicates.

## Mutation testing

Three mutants, anchor-count asserted, `gofmt`+`vet` gated, `-race`, `-count=3`:

| Mutant | Verdict |
|---|---|
| Restore the pre-#582 striped `queueMu` | CAUGHT — 27 then 32 misses against 16 |
| Move the lock to *after* the `Get` (the plan's mutant) | CAUGHT — both concurrency tests |
| Remove the lock entirely | CAUGHT — both concurrency tests |

## Verification

Full gate green: `gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues),
`make test` (race), `make docs-reference-check docs-versions`, docs site build,
`test/e2e` vet + test.

Live against `substrate server --address :4673` with the real AWS CLI
(`AWS_MAX_ATTEMPTS=1`): 16 concurrent `get-queue-url` calls on 16 distinct queues
against a wildcard seed of 8 → **8 misses, 8 successes, three runs in a row**, and
`wq-0` resolving normally once the budget is spent.

Closes #582
