### PR TITLE
chore(release): v0.94.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.94.0] - 2026-08-06
+
 ### Fixed
 - **A stack whose template omits a resource's physical name can be deployed twice**
   (#560). A resource with no explicit name got the **logical ID verbatim** as its
@@ -5501,7 +5503,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.93.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.94.0...HEAD
+[v0.94.0]: https://github.com/scttfrdmn/substrate/compare/v0.93.0...v0.94.0
 [v0.93.0]: https://github.com/scttfrdmn/substrate/compare/v0.92.0...v0.93.0
 [v0.92.0]: https://github.com/scttfrdmn/substrate/compare/v0.91.0...v0.92.0
 [v0.91.0]: https://github.com/scttfrdmn/substrate/compare/v0.90.0...v0.91.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.94.0] - 2026-08-06` and adds the
compare link. No behaviour change; the three fixes it records landed in #587, #588
and #589.

Version derived from `git tag --sort=-v:refname | head -1` (`v0.93.0`) at release
time, per the release steps.