### PR TITLE
fix(sts,iam): AssumeRole evaluates the role's trust policy (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`AssumeRole` evaluates the role's trust policy, so `sts:ExternalId` is enforced**
+  (#593). `AssumeRole` loaded the role only to read its `RoleID` for the
+  `AssumedRoleUser` ARN and never read `AssumeRolePolicyDocument` at all, so a trust
+  policy was inert: a caller presenting no `ExternalId`, a wrong one, a policy naming a
+  different account, and an outright `{"Effect":"Deny","Principal":"*"}` all minted
+  working `ASIA` credentials. The consequence was that the confused-deputy defense — the
+  entire purpose of `sts:ExternalId` — could not be tested. A consumer's "a caller
+  without the secret cannot assume this role" test passed while verifying nothing, and
+  passed identically with the trust policy deleted.
+
+  Two gates now apply to `AssumeRole`, answering different questions: the caller's own
+  policies must allow `sts:AssumeRole` (already the case, #411), and the role's trust
+  policy must admit the caller. A refusal is `AccessDenied` (403), with AWS's two
+  messages distinguishing no matching statement ("because no role trust policy allows
+  the sts:AssumeRole action") from an explicit `Deny` ("with an explicit deny in the role
+  trust policy"). `ExternalId` is parsed for the first time and validated at 2–1224
+  characters.
+
+  **The evaluator had to learn about principals to do this.** `Evaluate` accepted an
+  `EvaluationRequest.Principal` that every call site populated and nothing read, and no
+  principal matcher existed anywhere — a trust policy naming one account admitted every
+  caller because the `Principal` element was never consulted. `Principal`/`NotPrincipal`
+  are now matched, covering `"*"`, an exact ARN, and the account-delegating forms (a bare
+  account ID and an `…:root` ARN, which IAM treats as equivalent). A statement carrying
+  *neither* element still matches every caller: that is what an identity policy looks
+  like, so reading its absence as "matches nobody" would have denied every user, role and
+  permission-boundary evaluation in the codebase.
+
+  **Writing a trust policy is the opt-in.** A role created without one — which substrate
+  permits, though AWS's `CreateRole` does not — is unenforced rather than denied, so a
+  test that never wrote a trust policy is unaffected. Enforcement is likewise skipped for
+  an unauthenticated caller, who resolves to no principal for a `Principal` element to be
+  true of; this mirrors the rule `CheckAccess` already followed. Anyone whose role *does*
+  carry a trust policy that does not admit the caller will see a call that previously
+  succeeded now fail — which is the fix, and the escape hatch is above.
+
 - **An EC2 error reaches an AWS SDK caller with the code substrate sent** (#591). EC2 is
   the only service on the `ec2` protocol, whose error document wraps the error in a
   **plural** `<Errors>` element and spells the request id `<RequestID>` with a capital D.

--- a/docs/services.md
+++ b/docs/services.md
@@ -877,8 +877,44 @@ IAM operations are free.
 | Operation | Notes |
 |-----------|-------|
 | GetCallerIdentity | Returns account 123456789012 by default |
-| AssumeRole | Returns stub temporary credentials |
+| AssumeRole | Evaluates the role's trust policy, then returns temporary credentials |
 | GetSessionToken | Returns stub temporary credentials |
+
+### A role's trust policy is enforced, and `sts:ExternalId` with it
+
+`AssumeRole` evaluates the role's `AssumeRolePolicyDocument` before minting a
+session, so a caller the trust policy does not admit is refused with
+`AccessDenied` (403). Two gates apply, and they answer different questions: the
+caller's own policies must allow `sts:AssumeRole` ("what may this caller do"), and
+the role's trust policy must admit the caller ("who may become this role").
+
+That makes the confused-deputy pattern testable. A trust policy conditioning on
+`sts:ExternalId` refuses a caller who cannot present the secret:
+
+```json
+{"Version": "2012-10-17", "Statement": [{
+  "Effect": "Allow",
+  "Principal": {"AWS": "123456789012"},
+  "Action": "sts:AssumeRole",
+  "Condition": {"StringEquals": {"sts:ExternalId": "secret-123"}}
+}]}
+```
+
+A `Principal` naming a bare account ID or an account-root ARN
+(`arn:aws:iam::123456789012:root`) admits any principal in that account; an exact
+ARN admits only that entity. `ExternalId` is validated at 2–1224 characters.
+
+AWS distinguishes the two refusals only in the message, and substrate matches:
+"because no role trust policy allows the sts:AssumeRole action" for no matching
+statement, and "with an explicit deny in the role trust policy" for an explicit
+`Deny`.
+
+**Writing a trust policy is the opt-in.** A role created without one — which
+substrate permits, though AWS's `CreateRole` does not — is not enforced, so a test
+that never wrote a trust policy is unaffected. Enforcement is also skipped for an
+unauthenticated caller, who resolves to no principal for a `Principal` element to
+be true of; this is the same rule described in
+[Testing IAM permissions](./testing-guide.md#testing-iam-permissions).
 
 ### Cost
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -497,6 +497,46 @@ STS session credentials work the same way. `AssumeRole` mints an `ASIA` key whos
 calls are evaluated against the **role**, as real IAM resolves a session, so
 `assume-role` then call is how a test exercises a role's policy.
 
+### The assumption itself is gated, by the role's trust policy
+
+Two policies decide an `AssumeRole` call, and they answer different questions. The
+caller's own policies answer "what may this caller do" — that is the check above,
+and it is why `alice` needs `sts:AssumeRole`. The role's **trust policy**
+(`AssumeRolePolicyDocument`) answers "who may become this role", and it is a
+*resource* policy: it names principals.
+
+Both must hold, so a test can pin the confused-deputy defense — a role shared with
+a third party that only admits a caller presenting a shared secret:
+
+```bash
+aws iam create-role --role-name broker --assume-role-policy-document \
+  '{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+    "Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole",
+    "Condition":{"StringEquals":{"sts:ExternalId":"secret-123"}}}]}'
+
+# as alice, who is allowed to call sts:AssumeRole:
+aws sts assume-role --role-arn arn:aws:iam::123456789012:role/broker \
+  --role-session-name s1
+# AccessDenied: User: arn:aws:iam::123456789012:user/alice is not authorized to
+# perform: sts:AssumeRole because no role trust policy allows the
+# sts:AssumeRole action
+
+aws sts assume-role --role-arn arn:aws:iam::123456789012:role/broker \
+  --role-session-name s1 --external-id secret-123
+# 200 — an ASIA session key
+```
+
+The code is `AccessDenied`, where the identity-policy denial above reports
+`AccessDeniedException`; both match what AWS returns. An explicit `Deny` in the
+trust policy is reported with a different message ("with an explicit deny in the
+role trust policy") under the same code.
+
+**Writing a trust policy is the opt-in**, the same shape as the rule below one
+level down. A role created without one is not enforced, so every test that never
+wrote a trust policy keeps working — see
+[the STS service reference](services.md#a-role-s-trust-policy-is-enforced-and-sts-externalid-with-it)
+for the `Principal` forms that match.
+
 ### A principal that does not exist is not enforced
 
 This is the one thing to know before writing such a test. **Existence in state is
@@ -517,7 +557,9 @@ role named by a session but absent from state is not enforced, so `assume-role`
 against a role substrate does not hold proves nothing.
 
 In-process `emulator.Client` callers never sign a request, so they carry no principal
-and are never authorized. Enforcement is reached over the wire.
+and are never authorized. Enforcement is reached over the wire. A trust policy is
+skipped for the same caller and the same reason: with no principal there is nothing
+for its `Principal` element to be true of.
 
 ### CloudFormation stacks
 

--- a/emulator/iam_eval.go
+++ b/emulator/iam_eval.go
@@ -29,6 +29,12 @@ type EvaluationResult struct {
 // EvaluationRequest contains the inputs for an IAM policy evaluation.
 type EvaluationRequest struct {
 	// Principal is the ARN of the caller.
+	//
+	// It is matched against a statement's Principal/NotPrincipal element, so it
+	// only affects the outcome for a *resource* policy — an identity policy has
+	// no Principal element and matches any caller. Before #593 this field was
+	// populated by every call site and read by none, which is why a role's trust
+	// policy could name one account and still admit every caller.
 	Principal string
 
 	// Action is the AWS API action being requested (e.g., "s3:GetObject").
@@ -89,9 +95,12 @@ func Evaluate(documents []PolicyDocument, req EvaluationRequest) EvaluationResul
 	}
 }
 
-// statementMatches returns true if stmt covers the action, resource, and
-// conditions specified in req.
+// statementMatches returns true if stmt covers the principal, action, resource,
+// and conditions specified in req.
 func statementMatches(stmt PolicyStatement, req EvaluationRequest) bool {
+	if !principalMatches(stmt, req.Principal) {
+		return false
+	}
 	if !actionMatches(stmt, req.Action) {
 		return false
 	}
@@ -102,6 +111,107 @@ func statementMatches(stmt PolicyStatement, req EvaluationRequest) bool {
 		return false
 	}
 	return true
+}
+
+// principalMatches reports whether principal is covered by stmt's Principal
+// element, or for a NotPrincipal statement, whether it is NOT covered.
+//
+// A statement carrying neither element always matches. That is what makes this
+// safe to run over an *identity* policy: Principal is meaningless in one — the
+// principal is whoever the policy is attached to — and IAM rejects the element
+// there, so an absent element cannot mean "matches nobody" without breaking every
+// user, role and boundary evaluation. The element only appears in a *resource*
+// policy, which is the case #593 needed: a role's trust policy answers "who may
+// become this role", and until now nothing read the answer.
+//
+// A caller with no ARN never matches a statement that does name principals. An
+// unauthenticated request resolves to no identity, so there is nothing for
+// "Principal: {AWS: …}" to be true of; callers that must stay unenforced are
+// skipped before evaluation rather than admitted here (see STSPlugin.assumeRole).
+func principalMatches(stmt PolicyStatement, principal string) bool {
+	// NotPrincipal is authoritative when both appear. IAM forbids the
+	// combination, so there is no correct reading of it; taking the exclusion is
+	// the direction that cannot widen access.
+	if stmt.NotPrincipal != nil {
+		return !principalCovered(stmt.NotPrincipal, principal)
+	}
+	if stmt.Principal == nil {
+		return true
+	}
+	return principalCovered(stmt.Principal, principal)
+}
+
+// principalCovered reports whether p names principal.
+func principalCovered(p *PolicyPrincipal, principal string) bool {
+	if principal == "" {
+		return false
+	}
+	if p.All {
+		return true
+	}
+	for _, want := range p.AWS {
+		if awsPrincipalCovers(want, principal) {
+			return true
+		}
+	}
+	// Service and Federated principals match literally. Substrate mints no
+	// service-principal caller — a service ARN never appears as reqCtx.Principal
+	// — so these entries can only be satisfied by a caller naming one exactly,
+	// and pretending otherwise would let "Service: lambda.amazonaws.com" admit an
+	// IAM user.
+	for _, want := range p.Service {
+		if want == principal {
+			return true
+		}
+	}
+	for _, want := range p.Federated {
+		if want == principal {
+			return true
+		}
+	}
+	return false
+}
+
+// awsPrincipalCovers reports whether one "AWS" principal entry names principal.
+//
+// Three forms are accepted, all documented by IAM. An exact ARN matches itself. A
+// bare 12-digit account ID and the equivalent root ARN
+// ("arn:aws:iam::<account>:root") both delegate to the whole account: IAM treats
+// them as identical, and "the account ID" form is what the ExternalId guide uses
+// for a third-party trust policy.
+func awsPrincipalCovers(want, principal string) bool {
+	if want == principal {
+		return true
+	}
+	account := want
+	if strings.HasPrefix(want, "arn:") {
+		if entityType, _ := parsePrincipalARN(want); entityType != "root" {
+			// Any other ARN form is a specific entity, already handled by the
+			// exact match above.
+			return false
+		}
+		account = arnAccountID(want)
+	} else if strings.ContainsAny(want, ":/") {
+		// Not an ARN and not a bare account ID.
+		return false
+	}
+	if account == "" {
+		return false
+	}
+	return arnAccountID(principal) == account
+}
+
+// arnAccountID returns the account field of an ARN, or "" if arn is not one.
+//
+// The field is empty for the ARNs of account-less services (S3 buckets, for
+// one), and an empty account must never be read as "same account" — every such
+// ARN would then match every other.
+func arnAccountID(arn string) string {
+	parts := strings.SplitN(arn, ":", 6)
+	if len(parts) < 6 || parts[0] != "arn" {
+		return ""
+	}
+	return parts[4]
 }
 
 // actionMatches returns true when req.Action is covered by stmt.Action or,

--- a/emulator/iam_eval_test.go
+++ b/emulator/iam_eval_test.go
@@ -522,3 +522,216 @@ func TestEvaluate_MatchedStatements(t *testing.T) {
 	assert.Equal(t, emulator.DecisionAllow, result.Decision)
 	assert.Contains(t, result.MatchedStatements, "AllowS3")
 }
+
+// --- Principal matching (#593) ---------------------------------------------
+
+// TestEvaluate_PrincipalMatching covers the Principal element, which the evaluator
+// accepted and ignored until #593: EvaluationRequest.Principal was populated by
+// every call site and read by none, so a role's trust policy could name one
+// account and still admit every caller.
+//
+// Every case here uses a resource-policy shape — a trust policy's, with no
+// Resource element — because that is the only shape where Principal is legal.
+// The identity-policy direction is covered by every other test in this file: they
+// pass no Principal at all and must keep matching, which is what the nil case
+// below asserts deliberately rather than incidentally.
+func TestEvaluate_PrincipalMatching(t *testing.T) {
+	const caller = "arn:aws:iam::123456789012:user/alice"
+
+	tests := []struct {
+		name      string
+		principal *emulator.PolicyPrincipal
+		// notPrincipal is set instead of principal for the exclusion cases.
+		notPrincipal *emulator.PolicyPrincipal
+		caller       string
+		want         string
+	}{
+		{
+			// The load-bearing case: an identity policy has no Principal element,
+			// and reading its absence as "matches nobody" would deny every user,
+			// role and permission-boundary evaluation in the codebase.
+			name:   "absent principal matches any caller",
+			caller: caller,
+			want:   emulator.DecisionAllow,
+		},
+		{
+			name:      "wildcard matches any caller",
+			principal: &emulator.PolicyPrincipal{All: true},
+			caller:    caller,
+			want:      emulator.DecisionAllow,
+		},
+		{
+			name:      "exact ARN matches",
+			principal: &emulator.PolicyPrincipal{AWS: []string{caller}},
+			caller:    caller,
+			want:      emulator.DecisionAllow,
+		},
+		{
+			name:      "a different user in the same account does not match",
+			principal: &emulator.PolicyPrincipal{AWS: []string{"arn:aws:iam::123456789012:user/bob"}},
+			caller:    caller,
+			want:      emulator.DecisionImplicitDeny,
+		},
+		{
+			// The form AWS's own ExternalId guide uses for a third-party trust
+			// policy: a bare account ID delegates to the whole account.
+			name:      "bare account ID matches any principal in that account",
+			principal: &emulator.PolicyPrincipal{AWS: []string{"123456789012"}},
+			caller:    caller,
+			want:      emulator.DecisionAllow,
+		},
+		{
+			name:      "root ARN matches any principal in that account",
+			principal: &emulator.PolicyPrincipal{AWS: []string{"arn:aws:iam::123456789012:root"}},
+			caller:    caller,
+			want:      emulator.DecisionAllow,
+		},
+		{
+			// #593's cross-account case: the confused-deputy scenario is a policy
+			// naming the *partner's* account, which must not admit the local caller.
+			name:      "another account does not match",
+			principal: &emulator.PolicyPrincipal{AWS: []string{"111111111111"}},
+			caller:    caller,
+			want:      emulator.DecisionImplicitDeny,
+		},
+		{
+			name:      "root ARN of another account does not match",
+			principal: &emulator.PolicyPrincipal{AWS: []string{"arn:aws:iam::111111111111:root"}},
+			caller:    caller,
+			want:      emulator.DecisionImplicitDeny,
+		},
+		{
+			name:      "an assumed-role session matches its account",
+			principal: &emulator.PolicyPrincipal{AWS: []string{"123456789012"}},
+			caller:    "arn:aws:sts::123456789012:assumed-role/worker/sess1",
+			want:      emulator.DecisionAllow,
+		},
+		{
+			// A service principal is never a caller substrate mints, so it can only
+			// be satisfied literally. It must not admit an IAM user.
+			name:      "service principal does not match an IAM user",
+			principal: &emulator.PolicyPrincipal{Service: []string{"lambda.amazonaws.com"}},
+			caller:    caller,
+			want:      emulator.DecisionImplicitDeny,
+		},
+		{
+			name:      "service principal matches itself",
+			principal: &emulator.PolicyPrincipal{Service: []string{"lambda.amazonaws.com"}},
+			caller:    "lambda.amazonaws.com",
+			want:      emulator.DecisionAllow,
+		},
+		{
+			name:      "federated principal matches itself",
+			principal: &emulator.PolicyPrincipal{Federated: []string{"cognito-identity.amazonaws.com"}},
+			caller:    "cognito-identity.amazonaws.com",
+			want:      emulator.DecisionAllow,
+		},
+		{
+			// An unauthenticated caller resolves to no ARN, so there is nothing for
+			// a named principal to be true of. Callers that must stay unenforced are
+			// skipped before evaluation, not admitted by the matcher.
+			name:      "an empty caller never matches a named principal",
+			principal: &emulator.PolicyPrincipal{AWS: []string{caller}},
+			caller:    "",
+			want:      emulator.DecisionImplicitDeny,
+		},
+		{
+			name:      "an empty caller does not match the wildcard either",
+			principal: &emulator.PolicyPrincipal{All: true},
+			caller:    "",
+			want:      emulator.DecisionImplicitDeny,
+		},
+		{
+			name:         "NotPrincipal excludes the named caller",
+			notPrincipal: &emulator.PolicyPrincipal{AWS: []string{caller}},
+			caller:       caller,
+			want:         emulator.DecisionImplicitDeny,
+		},
+		{
+			name:         "NotPrincipal admits everyone else",
+			notPrincipal: &emulator.PolicyPrincipal{AWS: []string{"arn:aws:iam::123456789012:user/bob"}},
+			caller:       caller,
+			want:         emulator.DecisionAllow,
+		},
+		{
+			name:         "NotPrincipal on an account excludes the whole account",
+			notPrincipal: &emulator.PolicyPrincipal{AWS: []string{"123456789012"}},
+			caller:       caller,
+			want:         emulator.DecisionImplicitDeny,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := emulator.PolicyDocument{
+				Version: "2012-10-17",
+				Statement: []emulator.PolicyStatement{{
+					Effect:       emulator.IAMEffectAllow,
+					Principal:    tt.principal,
+					NotPrincipal: tt.notPrincipal,
+					Action:       emulator.StringOrSlice{"sts:AssumeRole"},
+				}},
+			}
+			result := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+				Principal: tt.caller,
+				Action:    "sts:AssumeRole",
+			})
+			assert.Equal(t, tt.want, result.Decision)
+		})
+	}
+}
+
+// TestEvaluate_PrincipalNotPrincipalWinsOverPrincipal pins the reading of a
+// statement carrying both elements. IAM forbids the combination, so there is no
+// correct answer; taking the exclusion is the direction that cannot widen access,
+// and leaving it untested would make it an accident.
+func TestEvaluate_PrincipalNotPrincipalWinsOverPrincipal(t *testing.T) {
+	const caller = "arn:aws:iam::123456789012:user/alice"
+	doc := emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:       emulator.IAMEffectAllow,
+			Principal:    &emulator.PolicyPrincipal{All: true},
+			NotPrincipal: &emulator.PolicyPrincipal{AWS: []string{caller}},
+			Action:       emulator.StringOrSlice{"sts:AssumeRole"},
+		}},
+	}
+	result := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+		Principal: caller,
+		Action:    "sts:AssumeRole",
+	})
+	assert.Equal(t, emulator.DecisionImplicitDeny, result.Decision)
+}
+
+// TestEvaluate_PrincipalDenyStatement checks that the principal gate applies to a
+// Deny statement too. A Deny whose Principal does not name the caller must not
+// fire — otherwise "Deny everyone else" would deny everyone.
+func TestEvaluate_PrincipalDenyStatement(t *testing.T) {
+	doc := emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{
+			{
+				Effect:    emulator.IAMEffectAllow,
+				Principal: &emulator.PolicyPrincipal{All: true},
+				Action:    emulator.StringOrSlice{"sts:AssumeRole"},
+			},
+			{
+				Effect:    emulator.IAMEffectDeny,
+				Principal: &emulator.PolicyPrincipal{AWS: []string{"arn:aws:iam::123456789012:user/bob"}},
+				Action:    emulator.StringOrSlice{"sts:AssumeRole"},
+			},
+		},
+	}
+
+	alice := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+		Principal: "arn:aws:iam::123456789012:user/alice",
+		Action:    "sts:AssumeRole",
+	})
+	assert.Equal(t, emulator.DecisionAllow, alice.Decision, "the Deny names bob, so alice is still allowed")
+
+	bob := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+		Principal: "arn:aws:iam::123456789012:user/bob",
+		Action:    "sts:AssumeRole",
+	})
+	assert.Equal(t, emulator.DecisionDeny, bob.Decision)
+}

--- a/emulator/sts_plugin.go
+++ b/emulator/sts_plugin.go
@@ -114,6 +114,7 @@ func (p *STSPlugin) assumeRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	roleARN := req.Params["RoleArn"]
 	sessionName := req.Params["RoleSessionName"]
 	durationStr := req.Params["DurationSeconds"]
+	externalID := req.Params["ExternalId"]
 
 	if roleARN == "" {
 		return nil, &AWSError{
@@ -149,6 +150,15 @@ func (p *STSPlugin) assumeRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 			HTTPStatus: http.StatusBadRequest,
 		}
 	}
+	// ExternalId's documented bounds. An absent one is legal — it is only required
+	// when a trust policy conditions on it, which the evaluation below decides.
+	if externalID != "" && (len(externalID) < 2 || len(externalID) > 1224) {
+		return nil, &AWSError{
+			Code:       "ValidationError",
+			Message:    "ExternalId must be between 2 and 1224 characters",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
 
 	// Look up the role in IAM state.
 	_, roleName := parsePrincipalARN(roleARN)
@@ -176,6 +186,12 @@ func (p *STSPlugin) assumeRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	var role IAMRole
 	if err := json.Unmarshal(raw, &role); err != nil {
 		return nil, fmt.Errorf("unmarshal role: %w", err)
+	}
+
+	// The trust policy decides *before* a credential exists. Minting first and
+	// checking after would leave a usable session in state behind a 403.
+	if err := p.checkTrustPolicy(ctx, role, roleARN, externalID); err != nil {
+		return nil, err
 	}
 
 	now := p.now()
@@ -240,6 +256,79 @@ func (p *STSPlugin) assumeRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	}
 
 	return stsXMLResponse(http.StatusOK, resp)
+}
+
+// checkTrustPolicy evaluates a role's trust policy against the caller, returning
+// an *AWSError when the policy refuses them and nil when it admits them or is not
+// enforced.
+//
+// A trust policy is a *resource* policy: it answers "who may become this role",
+// which is a different question from the permissions policy [AuthController.CheckAccess]
+// already evaluates ("what may the role do"). Both gates apply to AssumeRole, and
+// this is the second one — a caller must be allowed to call sts:AssumeRole *and*
+// be admitted by the role they name. Without this, sts:ExternalId — the
+// confused-deputy defense, whose whole purpose is refusing a caller who cannot
+// present a shared secret — did nothing at all (#593).
+//
+// Enforcement is opt-in by writing a trust policy, mirroring the rule authz
+// already follows for principals: a role with no statements is "not configured"
+// rather than "trusts nobody". Real IAM requires a trust policy at CreateRole and
+// would read an empty document as an implicit deny, but substrate permits creating
+// a role without one, so denying here would refuse roles that cannot exist on AWS
+// and would break every caller who never wrote a policy. A nil principal is
+// skipped for the same reason CheckAccess skips one: an unauthenticated request
+// resolves to no ARN, so there is nothing for a Principal element to be true of.
+func (p *STSPlugin) checkTrustPolicy(ctx *RequestContext, role IAMRole, roleARN, externalID string) error {
+	if len(role.AssumeRolePolicyDocument.Statement) == 0 {
+		p.logger.Debug("sts: role has no trust policy, not enforced", "role", roleARN)
+		return nil
+	}
+	if ctx.Principal == nil {
+		p.logger.Debug("sts: unauthenticated caller, trust policy not enforced", "role", roleARN)
+		return nil
+	}
+
+	// A condition key absent from the context is not the same as one set to "":
+	// conditionMatches reads a missing key as the empty string, so a policy
+	// requiring StringEquals sts:ExternalId correctly fails when none was sent.
+	condCtx := make(map[string]string, 1)
+	if externalID != "" {
+		condCtx["sts:ExternalId"] = externalID
+	}
+
+	// Resource is empty because a trust policy carries no Resource element — the
+	// role it is attached to *is* the resource. resourceMatches treats an empty
+	// resource as a match, so a statement stands or falls on its principal,
+	// action and conditions.
+	result := Evaluate([]PolicyDocument{role.AssumeRolePolicyDocument}, EvaluationRequest{
+		Principal: ctx.Principal.ARN,
+		Action:    "sts:AssumeRole",
+		Resource:  "",
+		Context:   condCtx,
+	})
+	if result.Decision == DecisionAllow {
+		return nil
+	}
+
+	// AWS reports both refusals under the same code and distinguishes them only in
+	// the message, which is the distinction substrate's two deny decisions already
+	// draw. The code is AccessDenied — observed from the API, which documents no
+	// access-denied error for AssumeRole at all.
+	msg := fmt.Sprintf(
+		"User: %s is not authorized to perform: sts:AssumeRole because no role trust policy allows the sts:AssumeRole action",
+		ctx.Principal.ARN)
+	if result.Decision == DecisionDeny {
+		msg = fmt.Sprintf(
+			"User: %s is not authorized to perform: sts:AssumeRole with an explicit deny in the role trust policy",
+			ctx.Principal.ARN)
+	}
+	p.logger.Debug("sts: trust policy denied AssumeRole",
+		"role", roleARN, "principal", ctx.Principal.ARN, "decision", result.Decision)
+	return &AWSError{
+		Code:       "AccessDenied",
+		Message:    msg,
+		HTTPStatus: http.StatusForbidden,
+	}
 }
 
 func (p *STSPlugin) getSessionToken(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {

--- a/emulator/sts_trust_policy_test.go
+++ b/emulator/sts_trust_policy_test.go
@@ -1,0 +1,419 @@
+package emulator_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// #593: AssumeRole never read the role's AssumeRolePolicyDocument, so a trust
+// policy was inert and sts:ExternalId — the confused-deputy defense — did nothing.
+// Four refusals were verified minting credentials against a live server: a caller
+// presenting no ExternalId, a wrong one, an explicit Deny, and a policy naming a
+// different account. The tests here are those four plus the negative control, and
+// each asserts the *message* as well as the code because AWS reports an implicit
+// and an explicit denial under one code and distinguishes them only in prose.
+//
+// The identity-policy gate is a separate, already-working check
+// (see TestCheckAccess_NoPermissionsRequiredActions): the caller must be allowed
+// to call sts:AssumeRole *and* be admitted by the role. Both are wired here, so a
+// denial from the wrong gate would show up as the wrong code.
+
+// newTrustPolicyTestServer returns a server with IAM and STS registered and an
+// AuthController wired, which is what makes ctx.Principal reach the STS plugin.
+func newTrustPolicyTestServer(t *testing.T) *emulator.Server {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC))
+
+	iamPlugin := &emulator.IAMPlugin{}
+	require.NoError(t, iamPlugin.Initialize(context.TODO(), emulator.PluginConfig{State: state, Logger: logger}))
+	registry.Register(iamPlugin)
+
+	stsPlugin := &emulator.STSPlugin{}
+	require.NoError(t, stsPlugin.Initialize(context.TODO(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(stsPlugin)
+
+	return emulator.NewServer(*cfg, registry, store, state, tc, logger, emulator.ServerOptions{
+		Auth: emulator.NewAuthController(state, logger),
+	})
+}
+
+// trustIAMCall issues an IAM setup request. The AKIA header is what puts the
+// created entities in the test account rather than the unauthenticated fallback;
+// it resolves to no IAM entity, so the setup calls are themselves unenforced and
+// cannot be blocked by the policies they are creating.
+func trustIAMCall(t *testing.T, srv *emulator.Server, operation string, body any) *http.Response {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	r.Host = "iam.amazonaws.com"
+	r.Header.Set("X-Amz-Target", "AmazonIdentityManagementService."+operation)
+	r.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	r.Header.Set("Authorization", trustAuthHeader("AKIAIOSFODNN7EXAMPLE", "iam"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Result()
+}
+
+// trustAuthHeader builds a SigV4 header. The signature is unverified — no
+// CredentialRegistry is wired — so the key ID alone selects the caller.
+func trustAuthHeader(accessKeyID, service string) string {
+	return "AWS4-HMAC-SHA256 Credential=" + accessKeyID +
+		"/20250101/us-east-1/" + service +
+		"/aws4_request, SignedHeaders=host, Signature=unverified"
+}
+
+// trustAssumeRole calls AssumeRole as accessKeyID, optionally with an ExternalId.
+func trustAssumeRole(t *testing.T, srv *emulator.Server, accessKeyID, roleARN, sessionName, externalID string) *http.Response {
+	t.Helper()
+	q := url.Values{}
+	q.Set("Action", "AssumeRole")
+	q.Set("Version", "2011-06-15")
+	q.Set("RoleArn", roleARN)
+	q.Set("RoleSessionName", sessionName)
+	if externalID != "" {
+		q.Set("ExternalId", externalID)
+	}
+	r := httptest.NewRequest(http.MethodPost, "/?"+q.Encode(), nil)
+	r.Host = "sts.amazonaws.com"
+	if accessKeyID != "" {
+		r.Header.Set("Authorization", trustAuthHeader(accessKeyID, "sts"))
+	}
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Result()
+}
+
+// trustSetupCaller creates an IAM user, grants it sts:AssumeRole so the identity
+// gate passes, and returns its access key ID.
+//
+// The grant matters: without it every case below would fail at the *identity*
+// gate with AccessDeniedException, and a test asserting only "denied" would pass
+// while the trust policy stayed unread — which is exactly the #593 defect.
+func trustSetupCaller(t *testing.T, srv *emulator.Server, userName string) string {
+	t.Helper()
+	require.Equal(t, http.StatusOK,
+		trustIAMCall(t, srv, "CreateUser", map[string]any{"UserName": userName}).StatusCode)
+
+	policy := `{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"sts:AssumeRole","Resource":"*"}]}`
+	require.Equal(t, http.StatusOK, trustIAMCall(t, srv, "PutUserPolicy", map[string]any{
+		"UserName":       userName,
+		"PolicyName":     "assume",
+		"PolicyDocument": policy,
+	}).StatusCode)
+
+	resp := trustIAMCall(t, srv, "CreateAccessKey", map[string]any{"UserName": userName})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	// IAM answers XML on every path, whatever the request's content type.
+	var parsed struct {
+		AccessKey struct {
+			AccessKeyID string `xml:"AccessKeyId"`
+		} `xml:"CreateAccessKeyResult>AccessKey"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed))
+	require.NotEmpty(t, parsed.AccessKey.AccessKeyID)
+	return parsed.AccessKey.AccessKeyID
+}
+
+// trustCreateRole creates a role with the given trust policy document.
+func trustCreateRole(t *testing.T, srv *emulator.Server, roleName, trustPolicy string) {
+	t.Helper()
+	require.Equal(t, http.StatusOK, trustIAMCall(t, srv, "CreateRole", map[string]any{
+		"RoleName":                 roleName,
+		"AssumeRolePolicyDocument": trustPolicy,
+	}).StatusCode)
+}
+
+// trustErrorFrom decodes the query-protocol error document.
+func trustErrorFrom(t *testing.T, resp *http.Response) (code, message string) {
+	t.Helper()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	var parsed struct {
+		XMLName xml.Name `xml:"ErrorResponse"`
+		Error   struct {
+			Code    string `xml:"Code"`
+			Message string `xml:"Message"`
+		} `xml:"Error"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), "body: %s", body)
+	return parsed.Error.Code, parsed.Error.Message
+}
+
+// The two message forms AWS uses. One code, two messages, mapping onto
+// substrate's DecisionImplicitDeny and DecisionDeny.
+const (
+	trustMsgImplicit = "User: arn:aws:iam::123456789012:user/alice is not authorized to perform: " +
+		"sts:AssumeRole because no role trust policy allows the sts:AssumeRole action"
+	trustMsgExplicit = "User: arn:aws:iam::123456789012:user/alice is not authorized to perform: " +
+		"sts:AssumeRole with an explicit deny in the role trust policy"
+)
+
+// TestSTSAssumeRole_TrustPolicyEnforced is #593's gate: each of these
+// combinations minted credentials before the fix.
+func TestSTSAssumeRole_TrustPolicyEnforced(t *testing.T) {
+	// A third-party trust policy in the shape AWS's ExternalId guide documents.
+	const externalIDPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole",` +
+		`"Condition":{"StringEquals":{"sts:ExternalId":"secret-123"}}}]}`
+
+	tests := []struct {
+		name        string
+		trustPolicy string
+		externalID  string
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			// The confused-deputy case. A caller who cannot present the shared
+			// secret must be refused; before the fix this returned an ASIA key,
+			// which made every ExternalId test in every consumer vacuous.
+			name:        "no ExternalId is denied when the policy requires one",
+			trustPolicy: externalIDPolicy,
+			wantStatus:  http.StatusForbidden,
+			wantCode:    "AccessDenied",
+			wantMessage: trustMsgImplicit,
+		},
+		{
+			name:        "a wrong ExternalId is denied",
+			trustPolicy: externalIDPolicy,
+			externalID:  "wrong-secret",
+			wantStatus:  http.StatusForbidden,
+			wantCode:    "AccessDenied",
+			wantMessage: trustMsgImplicit,
+		},
+		{
+			// The negative control. Without it every case above would also pass
+			// for a gate that denied unconditionally, which is a different bug
+			// with identical test output.
+			name:        "the correct ExternalId is allowed",
+			trustPolicy: externalIDPolicy,
+			externalID:  "secret-123",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name: "an explicit Deny is denied, with the explicit-deny message",
+			trustPolicy: `{"Version":"2012-10-17","Statement":[{"Effect":"Deny",` +
+				`"Principal":"*","Action":"sts:AssumeRole"}]}`,
+			wantStatus:  http.StatusForbidden,
+			wantCode:    "AccessDenied",
+			wantMessage: trustMsgExplicit,
+		},
+		{
+			// A policy naming the partner account must not admit a local caller,
+			// even when the secret is right: the principal and the condition are
+			// independent gates and both have to hold.
+			name: "a policy naming another account is denied even with the right ExternalId",
+			trustPolicy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+				`"Principal":{"AWS":"111111111111"},"Action":"sts:AssumeRole",` +
+				`"Condition":{"StringEquals":{"sts:ExternalId":"secret-123"}}}]}`,
+			externalID:  "secret-123",
+			wantStatus:  http.StatusForbidden,
+			wantCode:    "AccessDenied",
+			wantMessage: trustMsgImplicit,
+		},
+		{
+			// A trust policy that admits the caller outright still works: the gate
+			// must not have become "deny unless an ExternalId was sent".
+			name: "a policy allowing the caller's account with no condition is allowed",
+			trustPolicy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+				`"Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole"}]}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			// A trust policy naming an action other than sts:AssumeRole does not
+			// permit assumption — the action is matched, not assumed.
+			name: "a policy allowing only TagSession does not permit assumption",
+			trustPolicy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+				`"Principal":"*","Action":"sts:TagSession"}]}`,
+			wantStatus:  http.StatusForbidden,
+			wantCode:    "AccessDenied",
+			wantMessage: trustMsgImplicit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTrustPolicyTestServer(t)
+			accessKey := trustSetupCaller(t, srv, "alice")
+			trustCreateRole(t, srv, "broker", tt.trustPolicy)
+
+			resp := trustAssumeRole(t, srv, accessKey,
+				"arn:aws:iam::123456789012:role/broker", "session1", tt.externalID)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			if tt.wantStatus == http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				require.NoError(t, resp.Body.Close())
+				assert.Contains(t, string(body), "<AccessKeyId>ASIA",
+					"an allowed assumption must still mint a session credential")
+				return
+			}
+
+			code, message := trustErrorFrom(t, resp)
+			assert.Equal(t, tt.wantCode, code)
+			assert.Equal(t, tt.wantMessage, message)
+		})
+	}
+}
+
+// TestSTSAssumeRole_TrustPolicyNotEnforcedWithoutOne pins the opt-in: a role with
+// no trust policy is "not configured", not "trusts nobody".
+//
+// Real IAM requires a trust policy at CreateRole and would read an empty document
+// as an implicit deny, but substrate permits creating a role without one, so
+// denying here would refuse roles that cannot exist on AWS — and would break every
+// existing caller who never wrote one. This is the same rule authz already follows
+// for principals, one level down.
+func TestSTSAssumeRole_TrustPolicyNotEnforcedWithoutOne(t *testing.T) {
+	tests := []struct {
+		name        string
+		trustPolicy string
+	}{
+		{name: "no trust policy at all", trustPolicy: ""},
+		{name: "an empty JSON document", trustPolicy: "{}"},
+		{name: "a document with no statements", trustPolicy: `{"Version":"2012-10-17","Statement":[]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTrustPolicyTestServer(t)
+			accessKey := trustSetupCaller(t, srv, "alice")
+			trustCreateRole(t, srv, "legacy", tt.trustPolicy)
+
+			resp := trustAssumeRole(t, srv, accessKey,
+				"arn:aws:iam::123456789012:role/legacy", "session1", "")
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}
+
+// TestSTSAssumeRole_TrustPolicyNotEnforcedForNilPrincipal pins the second opt-out.
+// An unauthenticated caller resolves to no ARN, so there is nothing for a
+// Principal element to be true of; denying would break every in-process and
+// httptest caller, which is the same reason CheckAccess returns nil on one.
+func TestSTSAssumeRole_TrustPolicyNotEnforcedForNilPrincipal(t *testing.T) {
+	srv := newTrustPolicyTestServer(t)
+	trustCreateRole(t, srv, "broker", `{"Version":"2012-10-17","Statement":[{"Effect":"Deny",`+
+		`"Principal":"*","Action":"sts:AssumeRole"}]}`)
+
+	// No Authorization header: the request carries no principal at all. Even an
+	// explicit Deny does not apply, because enforcement never runs.
+	resp := trustAssumeRole(t, srv, "",
+		"arn:aws:iam::123456789012:role/broker", "session1", "")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestSTSAssumeRole_NoCredentialLeaksOnDenial asserts the ordering. Minting first
+// and checking after would leave a usable session in state behind a 403, and no
+// assertion on the response body can see that.
+func TestSTSAssumeRole_NoCredentialLeaksOnDenial(t *testing.T) {
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC))
+
+	iamPlugin := &emulator.IAMPlugin{}
+	require.NoError(t, iamPlugin.Initialize(context.TODO(), emulator.PluginConfig{State: state, Logger: logger}))
+	registry.Register(iamPlugin)
+
+	stsPlugin := &emulator.STSPlugin{}
+	require.NoError(t, stsPlugin.Initialize(context.TODO(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(stsPlugin)
+
+	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger, emulator.ServerOptions{
+		Auth: emulator.NewAuthController(state, logger),
+	})
+
+	accessKey := trustSetupCaller(t, srv, "alice")
+	trustCreateRole(t, srv, "broker", `{"Version":"2012-10-17","Statement":[{"Effect":"Deny",`+
+		`"Principal":"*","Action":"sts:AssumeRole"}]}`)
+
+	resp := trustAssumeRole(t, srv, accessKey,
+		"arn:aws:iam::123456789012:role/broker", "session1", "")
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	keys, err := state.List(context.TODO(), "sts", "session:")
+	require.NoError(t, err)
+	assert.Empty(t, keys, "a denied assumption must not have stored a session credential")
+}
+
+// TestSTSAssumeRole_ExternalIDValidation covers AssumeRole's documented bounds on
+// ExternalId, which substrate did not parse at all before #593.
+func TestSTSAssumeRole_ExternalIDValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		externalID string
+		wantStatus int
+	}{
+		{name: "one character is too short", externalID: "x", wantStatus: http.StatusBadRequest},
+		{name: "two characters is the minimum", externalID: "xy", wantStatus: http.StatusOK},
+		{name: "1224 characters is the maximum", externalID: trustRepeat("a", 1224), wantStatus: http.StatusOK},
+		{name: "1225 characters is too long", externalID: trustRepeat("a", 1225), wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTrustPolicyTestServer(t)
+			accessKey := trustSetupCaller(t, srv, "alice")
+			// No trust policy: the ExternalId is validated regardless of whether
+			// any policy conditions on it, so this isolates the length check.
+			trustCreateRole(t, srv, "broker", "")
+
+			resp := trustAssumeRole(t, srv, accessKey,
+				"arn:aws:iam::123456789012:role/broker", "session1", tt.externalID)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+			if tt.wantStatus == http.StatusBadRequest {
+				code, _ := trustErrorFrom(t, resp)
+				assert.Equal(t, "ValidationError", code)
+			}
+		})
+	}
+}
+
+// trustRepeat returns s repeated n times.
+func trustRepeat(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for range n {
+		out = append(out, s...)
+	}
+	return string(out)
+}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.3
+	github.com/aws/aws-sdk-go-v2/service/sts v1.45.3
 	github.com/aws/smithy-go v1.27.6
 	github.com/scttfrdmn/substrate v0.0.0
 	github.com/spf13/afero v1.15.0
@@ -30,7 +31,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.5.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.45.3 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/test/e2e/journey_sts_trust_policy_test.go
+++ b/test/e2e/journey_sts_trust_policy_test.go
@@ -1,0 +1,173 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_AssumeRoleHonoursTheTrustPolicy is #593's gate at the SDK level.
+//
+// The confused-deputy defense is the whole reason sts:ExternalId exists: a role
+// shared with a third party names their account and conditions on a secret only
+// the real partner knows. Substrate never read AssumeRolePolicyDocument, so that
+// condition was inert — a consumer's "a caller without the secret cannot assume
+// this role" test passed while verifying nothing, and passed identically with the
+// trust policy deleted.
+//
+// This journey is at the SDK level rather than in emulator/ because it is the
+// shape a consumer actually writes: assume a role, get credentials, use them. The
+// negative and the positive are both here, because a gate that denies
+// unconditionally produces the same output as a working one for the denial half
+// alone.
+func TestJourney_AssumeRoleHonoursTheTrustPolicy(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	iamClient := iam.NewFromConfig(cfg)
+
+	const (
+		roleName   = "partner-broker"
+		externalID = "secret-123"
+	)
+	// The trust policy AWS's own ExternalId guide documents: the account may
+	// assume the role, but only when it presents the shared secret.
+	trustPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"AWS":"` + journeyAccountID + `"},"Action":"sts:AssumeRole",` +
+		`"Condition":{"StringEquals":{"sts:ExternalId":"` + externalID + `"}}}]}`
+
+	if _, err := iamClient.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	roleARN := "arn:aws:iam::" + journeyAccountID + ":role/" + roleName
+
+	// The caller has to be a real IAM user for a trust policy to have anyone to
+	// be true of. The journey's built-in AKIA key belongs to no IAM entity, so it
+	// resolves to no principal and is unenforced — the documented opt-in — which
+	// would make every assertion below pass for the wrong reason. Minting a key is
+	// also what a consumer does when testing a cross-account integration.
+	user, err := iamClient.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("partner")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	// sts:AssumeRole on the identity side, so a denial below can only have come
+	// from the trust policy. Without this the caller fails the *identity* gate with
+	// AccessDeniedException and the trust policy is never consulted.
+	if _, err := iamClient.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:   user.User.UserName,
+		PolicyName: aws.String("assume"),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[` +
+			`{"Effect":"Allow","Action":"sts:AssumeRole","Resource":"*"}]}`),
+	}); err != nil {
+		t.Fatalf("PutUserPolicy: %v", err)
+	}
+	key, err := iamClient.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{
+		UserName: user.User.UserName,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+
+	partnerCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithBaseEndpoint(ts.URL),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			aws.ToString(key.AccessKey.AccessKeyId),
+			aws.ToString(key.AccessKey.SecretAccessKey), "")),
+		config.WithHTTPClient(&http.Client{}),
+	)
+	if err != nil {
+		t.Fatalf("partner config: %v", err)
+	}
+	// Retries off: a retried call would obscure which attempt produced the denial,
+	// and the assertion is about the code on the response the caller sees.
+	stsClient := sts.NewFromConfig(partnerCfg, func(o *sts.Options) { o.RetryMaxAttempts = 1 })
+
+	// Without the ExternalId the trust policy's condition cannot be satisfied. This
+	// returned working ASIA credentials before the fix.
+	_, err = stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String("no-secret"),
+	})
+	if err == nil {
+		t.Fatal("AssumeRole without the ExternalId: expected a denial, got credentials")
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected a smithy.APIError, got %T: %v", err, err)
+	}
+	// AccessDenied, not AccessDeniedException: AWS's own CLI output for this
+	// operation reads "An error occurred (AccessDenied) when calling the AssumeRole
+	// operation". The STS API model documents no access-denied error at all, so
+	// this code comes from observed behavior.
+	if apiErr.ErrorCode() != "AccessDenied" {
+		t.Fatalf("no ExternalId: ErrorCode() = %q, want AccessDenied", apiErr.ErrorCode())
+	}
+
+	// A wrong secret is refused the same way — the condition is compared, not
+	// merely required to be present.
+	if _, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String("wrong-secret"),
+		ExternalId:      aws.String("not-the-secret"),
+	}); err == nil {
+		t.Fatal("AssumeRole with a wrong ExternalId: expected a denial, got credentials")
+	} else if !errors.As(err, &apiErr) {
+		t.Fatalf("expected a smithy.APIError, got %T: %v", err, err)
+	} else if apiErr.ErrorCode() != "AccessDenied" {
+		t.Fatalf("wrong ExternalId: ErrorCode() = %q, want AccessDenied", apiErr.ErrorCode())
+	}
+
+	// The negative control, and the half that makes the assertions above mean
+	// something: the real partner still gets a session.
+	out, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String("real-partner"),
+		ExternalId:      aws.String(externalID),
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole with the correct ExternalId: %v", err)
+	}
+	if out.Credentials == nil || aws.ToString(out.Credentials.AccessKeyId) == "" {
+		t.Fatal("expected session credentials for the admitted caller")
+	}
+	if got := aws.ToString(out.Credentials.AccessKeyId); got[:4] != "ASIA" {
+		t.Fatalf("AccessKeyId = %q, want an ASIA session key", got)
+	}
+	if arn := aws.ToString(out.AssumedRoleUser.Arn); arn == "" {
+		t.Fatal("expected an AssumedRoleUser ARN")
+	}
+
+	// A role with no trust policy stays unenforced: writing one is the opt-in, so
+	// every test that never wrote one keeps working.
+	if _, err := iamClient.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("legacy"),
+		AssumeRolePolicyDocument: aws.String(""),
+	}); err != nil {
+		t.Fatalf("CreateRole legacy: %v", err)
+	}
+	if _, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::" + journeyAccountID + ":role/legacy"),
+		RoleSessionName: aws.String("unenforced"),
+	}); err != nil {
+		t.Fatalf("a role with no trust policy must stay assumable: %v", err)
+	}
+}


### PR DESCRIPTION
`sts:AssumeRole` never read `AssumeRolePolicyDocument`. `assumeRole` loaded the role only to get `RoleID` for the `AssumedRoleUser` ARN, so every caller who could reach the operation got credentials for every role, and **`sts:ExternalId` did nothing at all** — the parameter was not even parsed. A consumer writing a cross-account integration pins access with a trust policy naming the partner account plus a `StringEquals` on `sts:ExternalId`; against substrate that pin was inert, so the test proving "a caller without the secret cannot assume this role" passed while verifying nothing, and passed identically with the policy deleted.

Closes #593.

## The evaluator this needed did not exist

The issue suggested reusing the evaluator the IAM paths already use. `Evaluate` **never read `req.Principal`** — `statementMatches` consulted action ∧ resource ∧ condition only, and `EvaluationRequest.Principal` was populated by all four call sites and read by none. That is precisely why a trust policy could name one account and still admit every caller. No principal matcher existed anywhere, so building one is the bulk of this change rather than a wiring exercise.

`principalMatches` in `emulator/iam_eval.go` covers the forms IAM documents: `"*"`, an exact ARN, a bare 12-digit account ID and the equivalent `arn:aws:iam::<acct>:root` (IAM treats them as identical, and the account-ID form is what the ExternalId guide uses), `Service` and `Federated` matched literally, and `NotPrincipal` inverted — authoritative when both appear, since IAM forbids the combination and the exclusion is the reading that cannot widen access.

One line is load-bearing: **an absent `Principal` element matches**. All four pre-existing `Evaluate` call sites are identity/permission-boundary paths whose documents carry no `Principal` element — IAM rejects it there — so reading absence as "matches nobody" would break every user, role and boundary evaluation. A mutant flipping that guard turns `TestAuthController_AssumedRole` and `TestIAMAuthorize_AgreesWithCheckAccess` red, which is the proof it's tested rather than incidental. `resourceMatches` already returned `true` for an empty resource, so a trust policy (which has no `Resource`) evaluates through `Evaluate` unchanged once the matcher is in place.

## The gate

In `assumeRole`, the trust policy is evaluated **before any credential is minted** — checking after would leave a usable session in state behind a 403, and `TestSTSAssumeRole_NoCredentialLeaksOnDenial` asserts the session store is empty after a denial. `ExternalId` is parsed and bounds-checked at 2–1224 characters, returning `ValidationError` like `DurationSeconds` already does. On a non-Allow decision the response is `AccessDenied` / 403 with AWS's own two messages, selected on the decision:

- `DecisionImplicitDeny` → `…is not authorized to perform: sts:AssumeRole because no role trust policy allows the sts:AssumeRole action`
- `DecisionDeny` → `…is not authorized to perform: sts:AssumeRole with an explicit deny in the role trust policy`

Two paths stay unenforced by design. **A role with no trust policy** — a zero-value document means "not configured", so `AssumeRole` behaves exactly as before; writing a policy is the opt-in. That is the documented `docs/testing-guide.md` rule, *existence in state is the opt-in*, one level down: there enforcement starts when the principal exists, here when the role carries a trust policy. Strict fidelity would treat an empty document as an implicit deny, but AWS's `CreateRole` *requires* a trust policy, a state substrate permits, so denying it would refuse roles that cannot exist on AWS. **A nil `ctx.Principal`** — for the same reason `CheckAccess` returns nil on one: an unauthenticated caller resolves to no ARN, so there is nothing for a `Principal` element to be true of, and denying would break every in-process `httptest` caller.

## Provenance

The code is `AccessDenied`, **not** the `AccessDeniedException` #593's Acceptance section names. This is **observed behaviour, not modelled**: the botocore STS model documents no access-denied error for `AssumeRole` at all (only `MalformedPolicyDocument`, `PackedPolicyTooLarge`, `RegionDisabled`, `ExpiredToken`). The code and both message strings come from AWS's own CLI output and the access-denied troubleshooting reference.

The pre-existing generic `AccessDeniedException` from `CheckAccess` is left alone — it is service-wide, and narrowing it for STS is a consumer-visible change for every service on that path. Filed as #595. #594 covers `UpdateAssumeRolePolicy`, which turned out not to exist, so `CreateRole` remains the only way to set a trust policy.

## Compatibility

**A test whose role carries a trust policy that does not admit the caller now fails where it previously passed.** That is the fix, but it is a behaviour change: `sts:ExternalId` and `Principal` restrictions were inert and are now enforced. Two escape hatches, both intentional: a role with no trust policy stays unenforced, and an unauthenticated in-process caller is never gated. Nothing else moves — no existing test both set a trust policy and assumed that role, and CFN never runs `AssumeRole` (`cfnAttribution.resolve` uses a service role ARN directly), so no stack deploy passes the new gate.

## Verification

All five pre-existing `sts_plugin_test.go` AssumeRole tests pass **unchanged** — the opt-in decision as an executable claim. New: `TestEvaluate_PrincipalMatching` (18 cases) plus two `NotPrincipal`/Deny tests, `emulator/sts_trust_policy_test.go` (~19 subtests across the enforced paths, both opt-outs, the no-leak assertion and the ExternalId bounds), and a real-SDK e2e journey asserting `AccessDenied` without the ExternalId and `ASIA…` credentials with it on the same role.

`gofmt`, `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `make test` (race), `make coverage` (emulator 81.5%, total 80.7%), `make docs-reference-check docs-versions`, the docs site build and `go test -C test/e2e` are all green.

Replayed live against the real CLI, with a signed IAM user already granted `sts:AssumeRole` so the #411 identity gate passes first — that success was the defect, since there was no trust gate behind it. All four refusal paths returned `ASIA…` credentials before and are denied now; the negative control (a policy admitting the caller, correct ExternalId) and the no-trust-policy opt-out still return credentials. Both message forms confirmed on the wire.

Eight mutants, all **CAUGHT** — including `principalMatches` returning `true` unconditionally, which restores this bug exactly; the trust check moved after the mint; the `sts:ExternalId` condition context dropped; the two messages swapped; the empty-policy opt-out removed; and the account comparison widened.
