### PR TITLE
feat(cfn): DescribeStackEvents answers, derived from the stack record (#501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`DescribeStackEvents` answers, derived from the stack record** (#501, #562).
+  The operation returned `UnsupportedOperation` (400), so a consumer's deployment
+  wrapper — which polls events, because that is where a CloudFormation failure is
+  conventionally read from — could not run against substrate at all. Events are now
+  reported for every stack, newest first, paginated at 100 with a `NextToken`.
+
+  **The events are derived from the stack record, not from the event log**, which
+  is a departure from the route #501 filed as its preferred one. Two measurements
+  ruled the event log out. A recorded `Event` carries no `LogicalResourceId` —
+  `EventStore.RecordRequest` builds one from the request context and operation and
+  never copies the per-resource metadata across — and every `StackEvent` requires
+  one, so the log knows `s3:CreateBucket at T` but not which logical resource that
+  was. And the event store is disabled for in-process `emulator.Client` callers, who
+  would have seen an empty list for a stack that plainly deployed. The stack record
+  carries the logical ID, physical ID, type and error for each resource, so deriving
+  from it invents strictly less. `emulator/cfn_events_test.go` pins the second
+  reason: a plugin initialized with no event store still reports events.
+
+  **Resource events are terminal only, and a deploy's events share one timestamp.**
+  Substrate deploys synchronously, so it never observed a resource mid-create and
+  holds no record that one existed; a per-resource `CREATE_IN_PROGRESS` would be
+  fabricated. The stack's own bracketing events are different — the record's status
+  names the operation that ran and its timestamps say when — so those are reported.
+  Spacing the events apart was considered and rejected for a reason already recorded
+  in `emulator/sqs_control.go`: simulated time advances with wall time, so any
+  interval substrate manufactured would make a consumer's assertions wall-clock
+  dependent. Order is carried by position instead, reverse-deployment within an
+  instant, which is what real CloudFormation shows. `EventId` is deterministic in
+  the form AWS's own sample response returns
+  (`{LogicalId}-{ResourceStatus}-{Timestamp}`), so a replayed stack reports
+  byte-identical events.
+
+  **This closes #562's fifth acceptance criterion**, which had deferred that issue
+  across four releases: a stack whose service role is missing one permission reaches
+  `ROLLBACK_COMPLETE` **and** reports a `StackEvent` whose `ResourceStatusReason`
+  names the `AccessDeniedException` and the action refused. `DescribeStackResources`
+  already reported the same fact, and the two now share one derivation
+  (`cfnResourceStatus`) so they cannot disagree about whether a resource failed.
+
+  A stack deleted successfully is removed from the record, so `DescribeStackEvents`
+  on it reports `ValidationError` — the same answer `DescribeStacks` gives. A stack
+  whose delete *failed* remains, and its events name the resource holding it.
+
 ### Fixed
 - **`AssumeRole` evaluates the role's trust policy, so `sts:ExternalId` is enforced**
   (#593). `AssumeRole` loaded the role only to read its `RoleID` for the

--- a/docs/services.md
+++ b/docs/services.md
@@ -243,11 +243,19 @@ aws cloudformation describe-stack-resources --stack-name s \
 # authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::...
 ```
 
-The denial is **not** reported as a `StackEvent`: `DescribeStackEvents` is still
-refused with `UnsupportedOperation`, because substrate models stack status rather
-than per-resource stack events. Deriving events from the event log is tracked in
-[#501](https://github.com/scttfrdmn/substrate/issues/501); until then
-`DescribeStackResources` is where a per-resource reason is observable.
+The denial is also reported as a `StackEvent`, which is where a deployment wrapper
+conventionally reads a CloudFormation failure from:
+
+```bash
+aws cloudformation describe-stack-events --stack-name s \
+  --query 'StackEvents[?ResourceStatus==`CREATE_FAILED`].ResourceStatusReason'
+# AccessDeniedException: User: arn:aws:iam::123456789012:role/narrow is not
+# authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::...
+```
+
+Both views share one derivation, so they cannot disagree about whether a resource
+failed. See "Stack events are derived from the stack record" below for what the
+event model does and does not contain.
 
 Enforcement is opt-in by creating the principal: a stack deployed with a credential
 that resolves to no IAM user or role in state is not authorized at all, which is
@@ -712,20 +720,42 @@ the stack family, which reports `ValidationError` at 400).
 `REVIEW_IN_PROGRESS`, a state the stack model has no representation for. Create
 the stack, then change-set the update.
 
-### DescribeStackEvents is not supported
+### Stack events are derived from the stack record
 
-`DescribeStackEvents` returns `UnsupportedOperation` (400). This is deliberate,
-and `UnsupportedOperation` is substrate's own signal rather than a documented
-CloudFormation code — real CloudFormation has no error for an operation it
-implements.
+`DescribeStackEvents` answers from the stack's recorded state rather than from a
+separately maintained event stream, which is what keeps every value in it a real
+observation. Four consequences are worth knowing before writing an assertion.
 
-A stack carries one status string; there is no per-resource event model behind
-it. Answering the call would mean synthesizing a plausible
-`CREATE_IN_PROGRESS → CREATE_COMPLETE` pair per resource with invented
-timestamps, which is inventing observations — the opposite of what an emulator
-that exists to be trusted should do. A consumer polling events for completion
-should poll `DescribeStacks` for `StackStatus` instead. Tracked in
-[#501](https://github.com/scttfrdmn/substrate/issues/501).
+**Resource events are terminal only.** A stack's own events bracket the operation
+— an opening `CREATE_IN_PROGRESS` / `UPDATE_IN_PROGRESS` / `DELETE_IN_PROGRESS`
+and the terminal status — because the record says the deploy started and how it
+finished. Its *resources* get one event each, the terminal one. Substrate deploys
+synchronously and never observed a resource mid-create, so emitting a per-resource
+`CREATE_IN_PROGRESS` would be inventing an observation. A consumer counting two
+events per resource will find one.
+
+**A deploy's events share one timestamp.** They come from the record's creation
+and update times, and a synchronous deploy is one instant. Manufacturing an
+interval is not available: simulated time advances with wall time, so any spacing
+substrate invented would make a test's assertions wall-clock dependent. Order is
+carried by position instead — newest first, as the API documents, with the
+last-deployed resource above the one before it.
+
+**`EventId` is deterministic.** A resource event's is
+`{LogicalId}-{ResourceStatus}-{Timestamp}`, the form real CloudFormation is
+observed to return; a stack event's is a UUID derived from the stack ARN, status
+and timestamp. So a replayed stack reports byte-identical events.
+
+**Only the most recent operation is reported.** An update overwrites the record's
+status and time, so the create that preceded it left nothing to report. And a
+stack deleted successfully is removed from the record entirely, so
+`DescribeStackEvents` on it reports `ValidationError` — the same answer
+`DescribeStacks` gives. A stack whose *delete failed* remains, and its events name
+the resource holding it.
+
+Responses paginate at 100 events with a `NextToken`. `DescribeStackEvents` has no
+`MaxResults` parameter (the CLI's `--max-items` is applied client-side), so a
+`NextToken` loop is the only way to page.
 
 ### Stack status is terminal on return
 

--- a/emulator/cfn_events.go
+++ b/emulator/cfn_events.go
@@ -1,0 +1,221 @@
+package emulator
+
+import (
+	"encoding/base64"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// cfnStackEvent is one member of a DescribeStackEvents response.
+//
+// The XML member names are the StackEvent shape's. EventId, StackId, StackName and
+// Timestamp are the shape's only required members; the resource fields are all
+// documented "Required: No", which is what lets a stack-level event carry no
+// physical ID and a resource event carry no reason.
+type cfnStackEvent struct {
+	EventID              string `xml:"EventId"`
+	StackID              string `xml:"StackId"`
+	StackName            string `xml:"StackName"`
+	LogicalResourceID    string `xml:"LogicalResourceId,omitempty"`
+	PhysicalResourceID   string `xml:"PhysicalResourceId,omitempty"`
+	ResourceType         string `xml:"ResourceType,omitempty"`
+	Timestamp            string `xml:"Timestamp"`
+	ResourceStatus       string `xml:"ResourceStatus,omitempty"`
+	ResourceStatusReason string `xml:"ResourceStatusReason,omitempty"`
+}
+
+// cfnStackEventResourceType is the ResourceType a stack's own events carry, as
+// AWS's own DescribeStackEvents sample response shows.
+const cfnStackEventResourceType = "AWS::CloudFormation::Stack"
+
+// cfnStackEventsPageSize is how many events one page carries.
+//
+// DescribeStackEvents takes no MaxResults parameter — only StackName and
+// NextToken — so the page size is the service's to choose, and 100 is the size
+// real CloudFormation is observed to return (the CLI's --max-items is applied
+// client-side over the same token loop). Paging at all is what makes a consumer's
+// NextToken loop testable; a substrate stack small enough to fit in one page
+// simply gets no token, which is also what AWS does.
+const cfnStackEventsPageSize = 100
+
+// cfnResourceStatus derives one resource's status and reason from the stack
+// record.
+//
+// Nothing here is invented: DeployedResource.Error is set when a resource failed
+// and empty when it succeeded, and a rollback's sweep records per-resource
+// deletion outcomes of its own. It is shared by DescribeStackResources and
+// DescribeStackEvents so the two views cannot disagree about whether a resource
+// failed — they are two renderings of one fact, not two derivations.
+func cfnResourceStatus(s CFNStackState, r DeployedResource) (status, reason string) {
+	status, reason = "CREATE_COMPLETE", ""
+	if r.Error != "" {
+		status, reason = "CREATE_FAILED", r.Error
+	}
+	// A rollback swept the resources the failed create had created, so reporting
+	// CREATE_COMPLETE for one would claim a resource that is gone. The sweep's own
+	// record is what says which, and why.
+	if del := cfnDeletionFor(s.ResourceDeletions, r.LogicalID); del != nil && r.Error == "" {
+		status = del.Status
+		reason = del.Reason
+	}
+	return status, reason
+}
+
+// cfnDeriveStackEvents renders a stack's recorded state as the events
+// DescribeStackEvents reports, newest first.
+//
+// This operation was refused outright until #501, and the refusal's reasoning is
+// why the model looks like this. Substrate carries no per-resource event log, so
+// synthesizing a plausible CREATE_IN_PROGRESS/CREATE_COMPLETE pair per resource
+// would invent observations a real stack never produced — the opposite of the
+// provenance rule in docs/fidelity.md. Three decisions keep that rule intact:
+//
+// Derived from the stack record, not the event store. Every StackEvent needs a
+// LogicalResourceId, and a recorded [Event] has none: [EventStore.RecordRequest]
+// builds an event from the request context and operation only, and never copies
+// reqCtx.Metadata onto it, so the log knows "s3:CreateBucket at T" but not which
+// logical resource that was. The record knows. The store is also disabled for
+// [Client] callers, who would otherwise see no events at all.
+//
+// Terminal resource states only. A deploy is synchronous, so no caller ever
+// observed a resource mid-create and substrate holds no record that one existed.
+// The stack's own bracketing events are different: the record's Status names the
+// operation that ran, and CreatedAt/UpdatedAt say when, so an opening
+// *_IN_PROGRESS is a fact rather than a guess.
+//
+// No invented timestamps. Timestamps come from the record's CreatedAt/UpdatedAt,
+// which are [TimeController]-sourced. A synchronous deploy's events therefore
+// share one instant. Spreading them apart is not available: [TimeController.Now]
+// advances with wall time, so any interval substrate manufactured would make a
+// consumer's assertions wall-clock dependent — the same finding sqs_control.go
+// already records, and its reason for counting observations rather than measuring
+// durations. Ordering is carried by position instead: stack.Resources is in
+// deployment order, so reversing it puts the last-deployed resource first, which is
+// what real CloudFormation shows.
+//
+// Only the most recent operation is derivable. An update overwrites the record's
+// Status and UpdatedAt, so the create that preceded it left nothing behind to
+// report.
+func cfnDeriveStackEvents(s CFNStackState, stackID string) []cfnStackEvent {
+	// Built oldest-first, because that is the order the record describes, then
+	// reversed at the end.
+	events := make([]cfnStackEvent, 0, len(s.Resources)+2)
+
+	// The opening event. Its status names the operation the terminal status
+	// reports on, and "User Initiated" is the reason real CloudFormation puts on a
+	// caller-initiated stack's first event — every substrate stack is one.
+	opening, openingAt := cfnStackOpeningEvent(s)
+	if opening != "" {
+		events = append(events, cfnStackLevelEvent(s, stackID, opening, "User Initiated", openingAt))
+	}
+
+	for _, r := range s.Resources {
+		status, reason := cfnResourceStatus(s, r)
+		events = append(events, cfnStackEvent{
+			EventID:              cfnResourceEventID(r.LogicalID, status, cfnTime(s.UpdatedAt)),
+			StackID:              stackID,
+			StackName:            s.StackName,
+			LogicalResourceID:    r.LogicalID,
+			PhysicalResourceID:   r.PhysicalID,
+			ResourceType:         r.Type,
+			Timestamp:            cfnTime(s.UpdatedAt),
+			ResourceStatus:       status,
+			ResourceStatusReason: reason,
+		})
+	}
+
+	if s.Status != "" {
+		events = append(events, cfnStackLevelEvent(s, stackID, s.Status, s.StatusReason, s.UpdatedAt))
+	}
+
+	// Newest first, as the API documents. Reversing the record's order *is* the whole
+	// ordering, with no timestamp sort behind it, because the list is already
+	// non-decreasing in time when built: the opening event is at CreatedAt (or at
+	// UpdatedAt for a later operation) and everything after it is at UpdatedAt, which
+	// is always tc.Now() at or after CreatedAt. A sort was written here first and
+	// found to be unreachable — it could never reorder anything — so it is gone
+	// rather than left as a branch no test can reach.
+	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+		events[i], events[j] = events[j], events[i]
+	}
+	return events
+}
+
+// cfnStackLevelEvent builds one event about the stack itself.
+//
+// AWS's sample response is the shape being matched: the stack's LogicalResourceId
+// is its name, its PhysicalResourceId is its ARN, and its EventId is UUID-shaped
+// rather than the resource events' composite form.
+func cfnStackLevelEvent(s CFNStackState, stackID, status, reason string, at time.Time) cfnStackEvent {
+	return cfnStackEvent{
+		EventID:              cfnDeterministicUUID(stackID, status, cfnTime(at)),
+		StackID:              stackID,
+		StackName:            s.StackName,
+		LogicalResourceID:    s.StackName,
+		PhysicalResourceID:   stackID,
+		ResourceType:         cfnStackEventResourceType,
+		Timestamp:            cfnTime(at),
+		ResourceStatus:       status,
+		ResourceStatusReason: reason,
+	}
+}
+
+// cfnStackOpeningEvent derives the *_IN_PROGRESS status a stack's first event
+// carries, and when it happened, from the status the record ended on.
+//
+// The terminal status names which operation ran, so this is read off the record
+// rather than tracked separately. A create's opening event is at CreatedAt; any
+// later operation's is at UpdatedAt, because CreatedAt belongs to the create that
+// the record no longer describes. An unrecognized or empty status yields no
+// opening event rather than a guessed one.
+func cfnStackOpeningEvent(s CFNStackState) (status string, at time.Time) {
+	switch {
+	case strings.HasPrefix(s.Status, "CREATE_"), strings.HasPrefix(s.Status, "ROLLBACK_"):
+		// A rollback is the tail of a create that failed, so the operation the
+		// caller started was still CreateStack.
+		return "CREATE_IN_PROGRESS", s.CreatedAt
+	case strings.HasPrefix(s.Status, "UPDATE_"):
+		return "UPDATE_IN_PROGRESS", s.UpdatedAt
+	case strings.HasPrefix(s.Status, "DELETE_"):
+		return "DELETE_IN_PROGRESS", s.UpdatedAt
+	}
+	return "", s.UpdatedAt
+}
+
+// cfnResourceEventID builds a resource event's EventId.
+//
+// The format is the one AWS's own DescribeStackEvents sample returns —
+// "MyEC2Instance-CREATE_COMPLETE-2016-03-15T20:54:30.174Z" — which is already
+// deterministic, so a replay of the same deploy reports byte-identical event IDs.
+// A random UUID would satisfy the API's uniqueness requirement and break that.
+func cfnResourceEventID(logicalID, status, timestamp string) string {
+	return logicalID + "-" + status + "-" + timestamp
+}
+
+// cfnPaginateEvents applies a NextToken cursor to events and returns the page
+// plus the token for the next one, empty when the page is the last.
+//
+// The token is a base64-encoded offset, following the base64-marker shape
+// paginateIAMKeys established. An offset rather than an event ID because the
+// derivation is a pure function of the record: the same call produces the same
+// list in the same order, so position is stable, and an unparseable or
+// out-of-range token starts from the beginning rather than erroring —
+// DescribeStackEvents documents no service-specific errors.
+func cfnPaginateEvents(events []cfnStackEvent, token string) (page []cfnStackEvent, nextToken string) {
+	start := 0
+	if token != "" {
+		if decoded, err := base64.StdEncoding.DecodeString(token); err == nil {
+			if offset, convErr := strconv.Atoi(string(decoded)); convErr == nil && offset > 0 && offset < len(events) {
+				start = offset
+			}
+		}
+	}
+	end := start + cfnStackEventsPageSize
+	if end < len(events) {
+		nextToken = base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(end)))
+	} else {
+		end = len(events)
+	}
+	return events[start:end], nextToken
+}

--- a/emulator/cfn_events_test.go
+++ b/emulator/cfn_events_test.go
@@ -1,0 +1,418 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The derivation under test is #501's answer to a question it filed open: whether
+// stack events are read out of the event store or recorded separately. Neither, as
+// it turns out. A recorded [emulator.Event] carries no LogicalResourceId — the
+// store builds one from the request context and operation and never copies the
+// per-resource metadata across — and every StackEvent needs one. The stack record
+// has it, so the events are derived from the record, which also means an
+// in-process [emulator.Client] caller (whose event store is disabled) gets events
+// at all. TestCFNEvents_DerivesWithoutAnEventStore is the guard on that.
+
+// cfnEventsAt is the instant the fixtures below use, so a test asserting a
+// timestamp reads the same value the fixture wrote rather than a literal.
+var cfnEventsAt = time.Date(2026, 3, 15, 20, 54, 30, 0, time.UTC)
+
+// cfnEventsStackID is a stack ARN of the shape cfnStackID builds. The derivation
+// takes it as an argument rather than building it, because only the wire boundary
+// knows the requesting caller's partition.
+const cfnEventsStackID = "arn:aws:cloudformation:us-east-1:123456789012:stack/demo/" +
+	"11111111-2222-3333-4444-555555555555"
+
+// cfnCleanStack is a two-resource stack that deployed cleanly. Resources are in
+// deployment order, which is what cfnDeriveStackEvents reverses.
+func cfnCleanStack() emulator.CFNStackState {
+	return emulator.CFNStackState{
+		StackName: "demo",
+		Status:    "CREATE_COMPLETE",
+		CreatedAt: cfnEventsAt,
+		UpdatedAt: cfnEventsAt,
+		Resources: []emulator.DeployedResource{
+			{LogicalID: "Role", Type: "AWS::IAM::Role", PhysicalID: "demo-role"},
+			{LogicalID: "Bucket", Type: "AWS::S3::Bucket", PhysicalID: "demo-bucket"},
+		},
+	}
+}
+
+// TestCFNEvents_DeriveShape asserts the whole event list a stack record produces,
+// for the record shapes the wire cannot easily reach.
+//
+// Asserted as a full ordered list rather than a set of spot checks, because
+// ordering *is* the contract: DescribeStackEvents documents "reverse chronological
+// order", and a deploy's events share one instant (see the derivation's doc
+// comment), so nothing but position can order them.
+func TestCFNEvents_DeriveShape(t *testing.T) {
+	type want struct {
+		logicalID string
+		status    string
+		reason    string
+	}
+	tests := []struct {
+		name  string
+		stack emulator.CFNStackState
+		want  []want
+	}{
+		{
+			// Newest first: the stack's terminal event, then the resources in the
+			// reverse of the order they deployed in, then the stack's opening event.
+			// Real CloudFormation shows the last-deployed resource nearest the top.
+			name:  "a clean create brackets its resources newest-first",
+			stack: cfnCleanStack(),
+			want: []want{
+				{"demo", "CREATE_COMPLETE", ""},
+				{"Bucket", "CREATE_COMPLETE", ""},
+				{"Role", "CREATE_COMPLETE", ""},
+				{"demo", "CREATE_IN_PROGRESS", "User Initiated"},
+			},
+		},
+		{
+			// #562's criterion in its purest form: the resource's recorded Error
+			// becomes the event's ResourceStatusReason, so a caller polling events
+			// learns which resource was refused and why. A stack left CREATE_FAILED
+			// rather than rolled back is what OnFailure DO_NOTHING asks for.
+			name: "a failed resource carries its error as the reason",
+			stack: emulator.CFNStackState{
+				StackName:    "demo",
+				Status:       "CREATE_FAILED",
+				StatusReason: "resource Bucket failed",
+				CreatedAt:    cfnEventsAt,
+				UpdatedAt:    cfnEventsAt,
+				Resources: []emulator.DeployedResource{
+					{LogicalID: "Role", Type: "AWS::IAM::Role", PhysicalID: "demo-role"},
+					{LogicalID: "Bucket", Type: "AWS::S3::Bucket",
+						Error: "AccessDeniedException: not authorized to perform: s3:CreateBucket"},
+				},
+			},
+			want: []want{
+				{"demo", "CREATE_FAILED", "resource Bucket failed"},
+				{"Bucket", "CREATE_FAILED",
+					"AccessDeniedException: not authorized to perform: s3:CreateBucket"},
+				{"Role", "CREATE_COMPLETE", ""},
+				{"demo", "CREATE_IN_PROGRESS", "User Initiated"},
+			},
+		},
+		{
+			// The sweep's record overlays the resources it removed. Reporting
+			// CREATE_COMPLETE for Role here would claim a resource the rollback
+			// deleted — the failed one keeps its own reason, because the rollback
+			// never created it to delete.
+			name: "a rollback reports the sweep's outcome, not CREATE_COMPLETE",
+			stack: emulator.CFNStackState{
+				StackName:    "demo",
+				Status:       "ROLLBACK_COMPLETE",
+				StatusReason: "AccessDeniedException on Bucket",
+				CreatedAt:    cfnEventsAt,
+				UpdatedAt:    cfnEventsAt,
+				Resources: []emulator.DeployedResource{
+					{LogicalID: "Role", Type: "AWS::IAM::Role", PhysicalID: "demo-role"},
+					{LogicalID: "Bucket", Type: "AWS::S3::Bucket",
+						Error: "AccessDeniedException on s3:CreateBucket"},
+				},
+				ResourceDeletions: []emulator.CFNResourceDeletion{
+					{LogicalID: "Role", Type: "AWS::IAM::Role", Status: "DELETE_COMPLETE"},
+				},
+			},
+			want: []want{
+				{"demo", "ROLLBACK_COMPLETE", "AccessDeniedException on Bucket"},
+				{"Bucket", "CREATE_FAILED", "AccessDeniedException on s3:CreateBucket"},
+				{"Role", "DELETE_COMPLETE", ""},
+				// A rollback is the tail of the CreateStack the caller made, so the
+				// opening event is still CREATE_IN_PROGRESS.
+				{"demo", "CREATE_IN_PROGRESS", "User Initiated"},
+			},
+		},
+		{
+			// A sweep that could not remove a resource says which and why. This is
+			// the state that wedges a stack, so it is the one a consumer most needs
+			// to be able to read out of events.
+			name: "a failed sweep names the resource holding the stack",
+			stack: emulator.CFNStackState{
+				StackName:    "demo",
+				Status:       "DELETE_FAILED",
+				StatusReason: "resource Bucket could not be deleted",
+				CreatedAt:    cfnEventsAt,
+				UpdatedAt:    cfnEventsAt,
+				Resources: []emulator.DeployedResource{
+					{LogicalID: "Bucket", Type: "AWS::S3::Bucket", PhysicalID: "demo-bucket"},
+				},
+				ResourceDeletions: []emulator.CFNResourceDeletion{
+					{LogicalID: "Bucket", Type: "AWS::S3::Bucket",
+						Status: "DELETE_FAILED", Reason: "BucketNotEmpty"},
+				},
+			},
+			want: []want{
+				{"demo", "DELETE_FAILED", "resource Bucket could not be deleted"},
+				{"Bucket", "DELETE_FAILED", "BucketNotEmpty"},
+				{"demo", "DELETE_IN_PROGRESS", "User Initiated"},
+			},
+		},
+		{
+			// An update's opening event is UPDATE_IN_PROGRESS, and dated UpdatedAt:
+			// CreatedAt belongs to the create the record no longer describes, so
+			// using it would date this operation before it happened.
+			name: "an update opens with UPDATE_IN_PROGRESS at UpdatedAt",
+			stack: emulator.CFNStackState{
+				StackName: "demo",
+				Status:    "UPDATE_COMPLETE",
+				CreatedAt: cfnEventsAt.Add(-time.Hour),
+				UpdatedAt: cfnEventsAt,
+				Resources: []emulator.DeployedResource{
+					{LogicalID: "Bucket", Type: "AWS::S3::Bucket", PhysicalID: "demo-bucket"},
+				},
+			},
+			want: []want{
+				{"demo", "UPDATE_COMPLETE", ""},
+				{"Bucket", "CREATE_COMPLETE", ""},
+				{"demo", "UPDATE_IN_PROGRESS", "User Initiated"},
+			},
+		},
+		{
+			// A record restored from a snapshot written before Status existed gets
+			// no invented opening event. Guessing one would be the fabrication the
+			// whole model exists to avoid.
+			name: "a record with no status yields only its resources",
+			stack: emulator.CFNStackState{
+				StackName: "demo",
+				UpdatedAt: cfnEventsAt,
+				Resources: []emulator.DeployedResource{
+					{LogicalID: "Bucket", Type: "AWS::S3::Bucket", PhysicalID: "demo-bucket"},
+				},
+			},
+			want: []want{{"Bucket", "CREATE_COMPLETE", ""}},
+		},
+		{
+			// A stack with no resources still reports its own two events: the
+			// deploy did start and did finish, both recorded.
+			name: "an empty stack still brackets itself",
+			stack: emulator.CFNStackState{
+				StackName: "demo",
+				Status:    "CREATE_COMPLETE",
+				CreatedAt: cfnEventsAt,
+				UpdatedAt: cfnEventsAt,
+			},
+			want: []want{
+				{"demo", "CREATE_COMPLETE", ""},
+				{"demo", "CREATE_IN_PROGRESS", "User Initiated"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := emulator.CFNDeriveStackEventsForTest(tt.stack, cfnEventsStackID)
+			require.Len(t, events, len(tt.want))
+			for i, w := range tt.want {
+				assert.Equal(t, w.logicalID, events[i].LogicalResourceID, "event %d logical ID", i)
+				assert.Equal(t, w.status, events[i].ResourceStatus, "event %d status", i)
+				assert.Equal(t, w.reason, events[i].ResourceStatusReason, "event %d reason", i)
+			}
+		})
+	}
+}
+
+// TestCFNEvents_MemberShapes asserts the members each kind of event carries.
+//
+// The StackEvent shape requires only EventId, StackId, StackName and Timestamp,
+// which is what lets the two kinds differ: a stack-level event's
+// PhysicalResourceId is the stack ARN and its type is AWS::CloudFormation::Stack,
+// while a resource event's are the resource's own.
+func TestCFNEvents_MemberShapes(t *testing.T) {
+	events := emulator.CFNDeriveStackEventsForTest(cfnCleanStack(), cfnEventsStackID)
+	require.Len(t, events, 4)
+
+	wantTime := cfnEventsAt.Format(time.RFC3339)
+	for i, e := range events {
+		assert.Equal(t, cfnEventsStackID, e.StackID, "event %d", i)
+		assert.Equal(t, "demo", e.StackName, "event %d", i)
+		assert.Equal(t, wantTime, e.Timestamp, "event %d", i)
+		assert.NotEmpty(t, e.EventID, "event %d: EventId is a required member", i)
+	}
+
+	stackEvent := events[0]
+	assert.Equal(t, "AWS::CloudFormation::Stack", stackEvent.ResourceType)
+	assert.Equal(t, "demo", stackEvent.LogicalResourceID,
+		"a stack's own event names the stack as its logical resource")
+	assert.Equal(t, cfnEventsStackID, stackEvent.PhysicalResourceID,
+		"and the stack ARN as its physical one")
+
+	resourceEvent := events[1]
+	assert.Equal(t, "AWS::S3::Bucket", resourceEvent.ResourceType)
+	assert.Equal(t, "Bucket", resourceEvent.LogicalResourceID)
+	assert.Equal(t, "demo-bucket", resourceEvent.PhysicalResourceID)
+}
+
+// TestCFNEvents_EventIDsAreDeterministicAndUnique is the replay criterion.
+//
+// #501 asks that a replayed stack report identical events, so a random UUID is
+// disqualified however well it satisfies the API's uniqueness requirement. The
+// resource form is the one AWS's own sample response returns —
+// "MyEC2Instance-CREATE_COMPLETE-2016-03-15T20:54:30.174Z" — which is both
+// deterministic and observed rather than invented.
+func TestCFNEvents_EventIDsAreDeterministicAndUnique(t *testing.T) {
+	first := emulator.CFNDeriveStackEventsForTest(cfnCleanStack(), cfnEventsStackID)
+	second := emulator.CFNDeriveStackEventsForTest(cfnCleanStack(), cfnEventsStackID)
+	require.Equal(t, first, second, "the same record must derive byte-identical events")
+
+	seen := map[string]bool{}
+	for _, e := range first {
+		assert.False(t, seen[e.EventID], "EventId %q repeated", e.EventID)
+		seen[e.EventID] = true
+	}
+
+	assert.Equal(t, "Bucket-CREATE_COMPLETE-"+cfnEventsAt.Format(time.RFC3339), first[1].EventID,
+		"a resource EventId follows AWS's observed logicalID-status-timestamp form")
+
+	// Two stacks are not allowed to collide: the stack-level ID is derived from the
+	// stack ARN, which carries the name, region and account.
+	other := cfnCleanStack()
+	other.StackName = "other"
+	otherEvents := emulator.CFNDeriveStackEventsForTest(other, cfnEventsStackID+"-other")
+	assert.NotEqual(t, first[0].EventID, otherEvents[0].EventID)
+}
+
+// TestCFNEvents_Paginate round-trips a NextToken.
+//
+// DescribeStackEvents takes no MaxResults, so the page size is substrate's, and the
+// only way a consumer's token loop is testable is if a large enough stack actually
+// truncates. The page boundary is built from the exported constant rather than a
+// second copy of the number.
+func TestCFNEvents_Paginate(t *testing.T) {
+	// One resource past a full page, so exactly one event spills: the stack's
+	// bracketing pair plus the resources is pageSize+1 events.
+	stack := emulator.CFNStackState{
+		StackName: "demo",
+		Status:    "CREATE_COMPLETE",
+		CreatedAt: cfnEventsAt,
+		UpdatedAt: cfnEventsAt,
+	}
+	for i := range emulator.CFNStackEventsPageSizeForTest - 1 {
+		stack.Resources = append(stack.Resources, emulator.DeployedResource{
+			LogicalID:  fmt.Sprintf("R%03d", i),
+			Type:       "AWS::S3::Bucket",
+			PhysicalID: fmt.Sprintf("bucket-%03d", i),
+		})
+	}
+	events := emulator.CFNDeriveStackEventsForTest(stack, cfnEventsStackID)
+	require.Len(t, events, emulator.CFNStackEventsPageSizeForTest+1)
+
+	page, token := emulator.CFNPaginateEventsForTest(events, "")
+	assert.Len(t, page, emulator.CFNStackEventsPageSizeForTest)
+	require.NotEmpty(t, token, "a truncated page must hand back a NextToken")
+	assert.Equal(t, events[:emulator.CFNStackEventsPageSizeForTest], page)
+
+	rest, nextToken := emulator.CFNPaginateEventsForTest(events, token)
+	assert.Empty(t, nextToken, "the last page carries no token")
+	require.Len(t, rest, 1)
+	assert.Equal(t, events[len(events)-1], rest[0],
+		"the second page resumes where the first stopped, losing nothing")
+
+	// A complete list is one page and no token — the case a substrate-sized stack
+	// almost always hits, and the one a consumer's loop must terminate on.
+	page, token = emulator.CFNPaginateEventsForTest(events[:3], "")
+	assert.Len(t, page, 3)
+	assert.Empty(t, token)
+
+	// A token substrate did not mint restarts from the beginning rather than
+	// erroring: DescribeStackEvents documents no service-specific errors, so there
+	// is no code to return, and dropping the whole list would be worse.
+	page, _ = emulator.CFNPaginateEventsForTest(events, "not-base64-at-all")
+	assert.Equal(t, events[0], page[0])
+}
+
+// TestCFNEvents_DerivesWithoutAnEventStore is the guard on #501's design decision.
+//
+// The issue's own preferred route was to derive events from the recorded event
+// stream. That route is unavailable for two measured reasons, and this test pins
+// the second: an in-process caller's plugin has no event store — the CFN plugin
+// substitutes a disabled one when none is passed — so a derivation that read the
+// log would report an empty list here while the stack plainly deployed. If this
+// test starts failing, the derivation has been pointed at the event store.
+//
+// The first reason has no test because it is a property of the [emulator.Event]
+// type: it carries no LogicalResourceId, and every StackEvent needs one.
+func TestCFNEvents_DerivesWithoutAnEventStore(t *testing.T) {
+	ctx := context.Background()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	tc := emulator.NewTimeController(cfnEventsAt)
+
+	s3p := &emulator.S3Plugin{}
+	require.NoError(t, s3p.Initialize(ctx, emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"filesystem":      afero.NewMemMapFs(),
+		},
+	}))
+	registry := emulator.NewPluginRegistry()
+	registry.Register(s3p)
+
+	// No "event_store" option, which is the whole point: this is the configuration
+	// an emulator.Client caller's plugin runs in.
+	cfnp := &emulator.CloudFormationPlugin{}
+	require.NoError(t, cfnp.Initialize(ctx, emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc, "registry": registry},
+	}))
+	registry.Register(cfnp)
+
+	reqCtx := &emulator.RequestContext{
+		RequestID: "req-1",
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		Timestamp: cfnEventsAt,
+	}
+	create := &emulator.AWSRequest{
+		Service:   "cloudformation",
+		Operation: "CreateStack",
+		Params: map[string]string{
+			"StackName": "storeless",
+			"TemplateBody": `{"Resources":{"Bucket":{"Type":"AWS::S3::Bucket",` +
+				`"Properties":{"BucketName":"storeless-bucket"}}}}`,
+		},
+		Headers: map[string]string{},
+	}
+	_, err := cfnp.HandleRequest(reqCtx, create)
+	require.NoError(t, err)
+
+	resp, err := cfnp.HandleRequest(reqCtx, &emulator.AWSRequest{
+		Service:   "cloudformation",
+		Operation: "DescribeStackEvents",
+		Params:    map[string]string{"StackName": "storeless"},
+		Headers:   map[string]string{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var parsed struct {
+		Events []struct {
+			LogicalResourceID string `xml:"LogicalResourceId"`
+			ResourceStatus    string `xml:"ResourceStatus"`
+		} `xml:"DescribeStackEventsResult>StackEvents>member"`
+	}
+	require.NoError(t, xml.Unmarshal(resp.Body, &parsed), "body was %s", resp.Body)
+	require.Len(t, parsed.Events, 3, "body was %s", resp.Body)
+	assert.Equal(t, "storeless", parsed.Events[0].LogicalResourceID)
+	assert.Equal(t, "CREATE_COMPLETE", parsed.Events[0].ResourceStatus)
+	assert.Equal(t, "Bucket", parsed.Events[1].LogicalResourceID,
+		"the resource event names the logical resource, which the event log cannot")
+	assert.Equal(t, "CREATE_COMPLETE", parsed.Events[1].ResourceStatus)
+}

--- a/emulator/cfn_service_role_test.go
+++ b/emulator/cfn_service_role_test.go
@@ -190,11 +190,76 @@ func TestCFN_ServiceRoleAuthorizesResourceCalls(t *testing.T) {
 	}
 }
 
+func TestCFN_DeniedResourceNamesTheDenialInStackEvents(t *testing.T) {
+	// #562's fifth criterion, which was blocked on #501 for four releases: "a stack
+	// whose role is missing one permission reaches ROLLBACK_COMPLETE with a
+	// StackEvent reason naming the denial". DescribeStackEvents was refused with
+	// UnsupportedOperation until #501, so this could not be written at all.
+	//
+	// It is a distinct assertion from the DescribeStackResources one below, not a
+	// duplicate of it: polling events is what a consumer's deployment wrapper
+	// actually does, and it is where a CloudFormation failure is conventionally read
+	// from. Both views share one derivation (cfnResourceStatus) so they cannot
+	// disagree, which is exactly why the second assertion is cheap to keep.
+	ts := emulator.StartTestServer(t)
+	cfnSeedRole(t, ts.StateManager(), "narrow", []string{"s3:ListBucket"})
+	client := &cfnRoleTestClient{t: t, baseURL: ts.URL}
+
+	code, body := client.call("CreateStack", map[string]string{
+		"StackName":    "eventstack",
+		"TemplateBody": cfnRoleBucketTemplate,
+		"RoleARN":      "arn:aws:iam::123456789012:role/narrow",
+	})
+	require.Equal(t, http.StatusOK, code, "body: %s", body)
+
+	_, body = client.call("DescribeStacks", map[string]string{"StackName": "eventstack"})
+	status, _, _ := cfnStackStatus(t, body)
+	require.Equal(t, "ROLLBACK_COMPLETE", status, "the criterion's premise")
+
+	_, body = client.call("DescribeStackEvents", map[string]string{"StackName": "eventstack"})
+	var parsed struct {
+		Events []struct {
+			LogicalResourceID    string `xml:"LogicalResourceId"`
+			ResourceType         string `xml:"ResourceType"`
+			ResourceStatus       string `xml:"ResourceStatus"`
+			ResourceStatusReason string `xml:"ResourceStatusReason"`
+		} `xml:"DescribeStackEventsResult>StackEvents>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &parsed), "body: %s", body)
+	require.NotEmpty(t, parsed.Events, "body: %s", body)
+
+	// Newest first: the stack's own ROLLBACK_COMPLETE heads the list, which is what
+	// a consumer polling for a terminal status reads.
+	assert.Equal(t, "ROLLBACK_COMPLETE", parsed.Events[0].ResourceStatus)
+	assert.Equal(t, "AWS::CloudFormation::Stack", parsed.Events[0].ResourceType)
+
+	// The criterion itself: some event names the denial, and names the action, so a
+	// consumer learns which permission to add rather than only that something failed.
+	var denial string
+	for _, e := range parsed.Events {
+		if e.LogicalResourceID == "Data" && e.ResourceStatus == "CREATE_FAILED" {
+			denial = e.ResourceStatusReason
+		}
+	}
+	require.NotEmpty(t, denial, "no CREATE_FAILED event for the refused resource: %s", body)
+	assert.Contains(t, denial, "AccessDeniedException")
+	assert.Contains(t, denial, "s3:CreateBucket",
+		"the event names the action that was refused")
+
+	// And the opening event is a real observation, not a fabricated per-resource
+	// one: the deploy did start, at the time the stack records.
+	last := parsed.Events[len(parsed.Events)-1]
+	assert.Equal(t, "CREATE_IN_PROGRESS", last.ResourceStatus,
+		"a rollback is the tail of the CreateStack the caller made")
+	assert.Equal(t, "AWS::CloudFormation::Stack", last.ResourceType,
+		"substrate emits no per-resource CREATE_IN_PROGRESS — it never observed one")
+}
+
 func TestCFN_DeniedResourceNamesTheDenialInStackResources(t *testing.T) {
-	// #562's reporting criterion, minus the StackEvent one that is blocked by #501.
-	// A caller has to be able to learn *which* resource was refused and *why*, not
-	// only that the stack rolled back — that is the difference between a test
-	// failure a consumer can act on and one that sends them to real AWS to find out.
+	// The same fact through DescribeStackResources. A caller has to be able to learn
+	// *which* resource was refused and *why*, not only that the stack rolled back —
+	// that is the difference between a test failure a consumer can act on and one
+	// that sends them to real AWS to find out.
 	ts := emulator.StartTestServer(t)
 	cfnSeedRole(t, ts.StateManager(), "narrow", []string{"s3:ListBucket"})
 	client := &cfnRoleTestClient{t: t, baseURL: ts.URL}

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -178,21 +178,7 @@ func (p *CloudFormationPlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 	case "DescribeStackDriftDetectionStatus":
 		return p.describeStackDriftDetectionStatus(ctx, req)
 	case "DescribeStackEvents":
-		// Scoped out deliberately rather than fabricated. CFNStackState carries a
-		// single Status string; there is no per-resource event model behind it, so
-		// synthesizing a plausible CREATE_IN_PROGRESS/CREATE_COMPLETE pair per
-		// resource would invent observations a real stack never produced — the
-		// opposite of the provenance rule in docs/fidelity.md. A caller polling
-		// events gets a clear refusal instead and can poll DescribeStacks. See #501.
-		//
-		// UnsupportedOperation is not a documented CloudFormation error code; it is
-		// substrate's own signal that the operation exists but is unmodelled, chosen
-		// over inventing a stack-event stream.
-		return nil, &AWSError{
-			Code:       "UnsupportedOperation",
-			Message:    "CloudFormation DescribeStackEvents is not emulated: substrate models stack status, not per-resource stack events",
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return p.describeStackEvents(ctx, req)
 	default:
 		return nil, &AWSError{
 			Code:       "InvalidAction",
@@ -550,6 +536,53 @@ func (p *CloudFormationPlugin) listStacks(reqCtx *RequestContext, req *AWSReques
 	return cfnXMLResponse(http.StatusOK, resp)
 }
 
+// describeStackEvents reports a stack's events, newest first (#501).
+//
+// StackName is the operation's only required parameter and takes a name or a
+// stack ID, so an unknown one is the ValidationError DescribeStacks already
+// gives. A stack deleted successfully is gone from the record, so it answers that
+// way too: the API's note that a deleted stack must be addressed by ID is about
+// name reuse, and substrate keeps no events past the record they were derived
+// from. A stack whose delete *failed* remains, and reports its sweep's outcome.
+//
+// [cfnDeriveStackEvents] holds the model and the reasoning behind it.
+func (p *CloudFormationPlugin) describeStackEvents(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	name, arnErr := cfnStackName(reqCtx, req.Params["StackName"])
+	if arnErr != nil {
+		return nil, arnErr
+	}
+	if name == "" {
+		return nil, cfnMissingParameter("StackName")
+	}
+	stack, err := p.findStack(name)
+	if err != nil {
+		return nil, err
+	}
+	if stack == nil {
+		return nil, cfnStackNotFound(name)
+	}
+
+	page, nextToken := cfnPaginateEvents(
+		cfnDeriveStackEvents(*stack, cfnStackID(reqCtx, stack.StackName)),
+		req.Params["NextToken"])
+
+	type result struct {
+		Events    []cfnStackEvent `xml:"StackEvents>member"`
+		NextToken string          `xml:"NextToken,omitempty"`
+	}
+	type response struct {
+		XMLName  xml.Name            `xml:"DescribeStackEventsResponse"`
+		XMLNS    string              `xml:"xmlns,attr"`
+		Result   result              `xml:"DescribeStackEventsResult"`
+		Metadata cfnResponseMetadata `xml:"ResponseMetadata"`
+	}
+	return cfnXMLResponse(http.StatusOK, response{
+		XMLNS:    cfnXMLNS,
+		Result:   result{Events: page, NextToken: nextToken},
+		Metadata: cfnMetadata(reqCtx),
+	})
+}
+
 func (p *CloudFormationPlugin) describeStackResources(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	name := req.Params["StackName"]
 	physicalID := req.Params["PhysicalResourceId"]
@@ -622,19 +655,10 @@ func (p *CloudFormationPlugin) describeStackResources(reqCtx *RequestContext, re
 				continue
 			}
 			// The per-resource status is derived from whether the resource actually
-			// deployed, not invented: DeployedResource.Error is set when a resource
-			// failed, and empty when it succeeded.
-			status, reason := "CREATE_COMPLETE", ""
-			if r.Error != "" {
-				status, reason = "CREATE_FAILED", r.Error
-			}
-			// A rollback swept the resources the failed create had created, so
-			// reporting CREATE_COMPLETE for one would claim a resource that is gone.
-			// The sweep's own record is what says which, and why.
-			if del := cfnDeletionFor(s.ResourceDeletions, r.LogicalID); del != nil && r.Error == "" {
-				status = del.Status
-				reason = del.Reason
-			}
+			// deployed, not invented. DescribeStackEvents renders the same derivation
+			// as an event (#501), so it lives in cfnResourceStatus: the two views must
+			// not be able to disagree about whether a resource failed.
+			status, reason := cfnResourceStatus(s, r)
 			resp.Result.Resources = append(resp.Result.Resources, resourceItem{
 				StackID:              cfnStackID(reqCtx, s.StackName),
 				StackName:            s.StackName,

--- a/emulator/cloudformation_plugin_test.go
+++ b/emulator/cloudformation_plugin_test.go
@@ -1259,13 +1259,14 @@ func TestCFNPlugin_DescribeStackResources(t *testing.T) {
 	})
 }
 
-// TestCFNPlugin_DescribeStackEvents pins the scope decision deliberately rather
-// than leaving it incidental.
+// TestCFNPlugin_DescribeStackEvents asserts the operation answers on the wire.
 //
-// CFNStackState carries one Status string; there is no per-resource event model,
-// so a plausible CREATE_IN_PROGRESS/CREATE_COMPLETE sequence would be invented
-// observations. A caller gets a refusal they can see instead. If someone later
-// adds a real event model, this test is the one that must be changed knowingly.
+// It used to assert the opposite. Until #501 this pinned a deliberate refusal —
+// UnsupportedOperation, on the grounds that substrate had no per-resource event
+// model and a synthesized CREATE_IN_PROGRESS/CREATE_COMPLETE pair would be
+// invented observations. The events are now derived from the stack record, which
+// invents nothing, so the refusal is gone and this is the knowing change the old
+// test asked for.
 func TestCFNPlugin_DescribeStackEvents(t *testing.T) {
 	ts := newCFNTestServer(t)
 	code, body := cfnAction(t, ts, "CreateStack", map[string]string{
@@ -1275,8 +1276,93 @@ func TestCFNPlugin_DescribeStackEvents(t *testing.T) {
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 
 	code, body = cfnAction(t, ts, "DescribeStackEvents", map[string]string{"StackName": "eventful"})
-	assert.Equal(t, http.StatusBadRequest, code)
-	assert.Equal(t, "UnsupportedOperation", cfnErrorCode(t, body))
+	require.Equal(t, http.StatusOK, code, "body was %s", body)
+
+	events := cfnStackEvents(t, body)
+	// An empty template still brackets itself: the deploy started and finished,
+	// both recorded on the stack. Newest first, as the API documents.
+	require.Len(t, events, 2, "body was %s", body)
+	assert.Equal(t, "CREATE_COMPLETE", events[0].ResourceStatus)
+	assert.Equal(t, "CREATE_IN_PROGRESS", events[1].ResourceStatus)
+	assert.Equal(t, "eventful", events[0].StackName)
+	assert.Equal(t, "AWS::CloudFormation::Stack", events[0].ResourceType)
+	assert.NotEmpty(t, events[0].EventID, "EventId is a required member")
+	assert.Empty(t, cfnNextToken(t, body), "two events do not fill a page")
+
+	t.Run("the stack ID is accepted in place of the name", func(t *testing.T) {
+		// Every stack-scoped operation documents both forms, and DescribeStackEvents
+		// spells the ARN out as the way to address a deleted stack.
+		_, describeBody := cfnAction(t, ts, "DescribeStacks", map[string]string{"StackName": "eventful"})
+		stackID := cfnStackIDOf(t, describeBody)
+		require.NotEmpty(t, stackID)
+
+		code, byIDBody := cfnAction(t, ts, "DescribeStackEvents", map[string]string{"StackName": stackID})
+		require.Equal(t, http.StatusOK, code, "body was %s", byIDBody)
+		assert.Len(t, cfnStackEvents(t, byIDBody), 2)
+	})
+
+	t.Run("an unknown stack is a ValidationError", func(t *testing.T) {
+		// The same answer DescribeStacks gives, which is also the answer for a stack
+		// deleted successfully: the record is gone, and the events were derived from
+		// it.
+		code, notFoundBody := cfnAction(t, ts, "DescribeStackEvents", map[string]string{"StackName": "nope"})
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "ValidationError", cfnErrorCode(t, notFoundBody))
+	})
+
+	t.Run("no StackName is a MissingParameter", func(t *testing.T) {
+		// StackName is the operation's only required parameter.
+		code, missingBody := cfnAction(t, ts, "DescribeStackEvents", nil)
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.Equal(t, "MissingParameter", cfnErrorCode(t, missingBody))
+	})
+}
+
+// cfnEventMember is the subset of a StackEvent the wire tests assert over.
+type cfnEventMember struct {
+	EventID              string `xml:"EventId"`
+	StackID              string `xml:"StackId"`
+	StackName            string `xml:"StackName"`
+	LogicalResourceID    string `xml:"LogicalResourceId"`
+	PhysicalResourceID   string `xml:"PhysicalResourceId"`
+	ResourceType         string `xml:"ResourceType"`
+	Timestamp            string `xml:"Timestamp"`
+	ResourceStatus       string `xml:"ResourceStatus"`
+	ResourceStatusReason string `xml:"ResourceStatusReason"`
+}
+
+// cfnStackEvents parses a DescribeStackEvents body's members, in order.
+func cfnStackEvents(t *testing.T, body string) []cfnEventMember {
+	t.Helper()
+	var parsed struct {
+		Events []cfnEventMember `xml:"DescribeStackEventsResult>StackEvents>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &parsed), "body was %s", body)
+	return parsed.Events
+}
+
+// cfnNextToken reads a DescribeStackEvents body's pagination token, empty when the
+// page was the last.
+func cfnNextToken(t *testing.T, body string) string {
+	t.Helper()
+	var parsed struct {
+		NextToken string `xml:"DescribeStackEventsResult>NextToken"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &parsed), "body was %s", body)
+	return parsed.NextToken
+}
+
+// cfnStackIDOf reads the StackId off a DescribeStacks body.
+func cfnStackIDOf(t *testing.T, body string) string {
+	t.Helper()
+	var parsed struct {
+		Stacks []struct {
+			StackID string `xml:"StackId"`
+		} `xml:"DescribeStacksResult>Stacks>member"`
+	}
+	require.NoError(t, xml.Unmarshal([]byte(body), &parsed), "body was %s", body)
+	require.Len(t, parsed.Stacks, 1, "body was %s", body)
+	return parsed.Stacks[0].StackID
 }
 
 // TestCFNPlugin_UnknownAction asserts an unmodelled action is InvalidAction, not

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -599,6 +599,34 @@ func (d *StackDeployer) DeleteStackResourcesForTest(
 	return d.deleteStackResources(ctx, stack, stackName, cfnDeleteStackOp)
 }
 
+// CFNStackEventForTest is the derived stack event, aliased so an external test can
+// read its members. The type stays unexported in the package proper: it is a wire
+// shape, and the only supported way to reach one is DescribeStackEvents.
+type CFNStackEventForTest = cfnStackEvent
+
+// CFNDeriveStackEventsForTest wraps cfnDeriveStackEvents (#501).
+//
+// The derivation is a pure function of a stack record, and exercising it directly
+// is what pins the parts the wire cannot vary: a rollback whose sweep left some
+// resources deleted and others failed, an UPDATE_ROLLBACK_FAILED stack, and a
+// record restored from a snapshot that has no Status at all. Reaching those
+// through CreateStack would mean engineering a failure for each.
+func CFNDeriveStackEventsForTest(s CFNStackState, stackID string) []CFNStackEventForTest {
+	return cfnDeriveStackEvents(s, stackID)
+}
+
+// CFNPaginateEventsForTest wraps cfnPaginateEvents, so the page boundary can be
+// asserted without deploying a template of more than CFNStackEventsPageSizeForTest
+// resources.
+func CFNPaginateEventsForTest(events []CFNStackEventForTest, token string) ([]CFNStackEventForTest, string) {
+	return cfnPaginateEvents(events, token)
+}
+
+// CFNStackEventsPageSizeForTest is the DescribeStackEvents page size, so a test
+// builds a page boundary from the value the code uses rather than a second copy of
+// it.
+const CFNStackEventsPageSizeForTest = cfnStackEventsPageSize
+
 // CFNGeneratedNameSuffixLenForTest is the width of the derived suffix on a
 // generated physical name, so an external test can split a name into its
 // {stack}-{logical} prefix and its suffix without hard-coding the width.

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.34
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.33
+	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.3

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -14,6 +14,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.35 h1:WK6CjihTuLisCjSKKb
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.35/go.mod h1:KYleN57luLoe97R7vTnx8PMcVrr9gAcRECtOjl91DNg=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.35 h1:Oe8gMKJLO5awqpa5EhAGKVnBv1s+brdWVuxM2mDa7zA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.35/go.mod h1:FZevcG9cOST/FWAAUhHIchjR9fXFXFRCWodOhx+PDLA=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1 h1:UDQGJ9AuLcf4yiDKyHPGN4EirOLo/E8+Zfoii8FhyZs=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1/go.mod h1:tCsJEKr4HMFIZSnXLx6rU2HlptPtLhWWfw2V2j9p7lE=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0 h1:XxzwotCCRk2Un1OWcJujk4vAC2OZkGh5l816W1w+Fd8=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0/go.mod h1:Gi5mEHpABbT34fHwafgyxqrIte9oHUEHscusPBYEdHA=
 github.com/aws/aws-sdk-go-v2/service/iam v1.57.1 h1:frtNexXj45Ko7pFfBKLyxObvNHefmL7vBeZid9uJCfU=

--- a/test/e2e/journey_cfn_events_test.go
+++ b/test/e2e/journey_cfn_events_test.go
@@ -1,0 +1,175 @@
+package e2e_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_DescribeStackEvents is #501's and #562's gate at the SDK level.
+//
+// DescribeStackEvents returned UnsupportedOperation (400) until #501, so a
+// consumer's deployment wrapper — which polls events, because that is where a
+// CloudFormation failure is conventionally read from — could not run against
+// substrate at all. It is a journey rather than a plugin test because the SDK is
+// what turns the XML into a []types.StackEvent: an element name substrate got wrong
+// would deserialize to a zero value here while a hand-written XPath assertion in
+// emulator/ still passed. That is the failure mode #591 shipped for EC2 errors.
+func TestJourney_DescribeStackEvents(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	// Retries off: a retried call would obscure which attempt produced a result.
+	cfn := cloudformation.NewFromConfig(cfg, func(o *cloudformation.Options) { o.RetryMaxAttempts = 1 })
+
+	const template = `{"Resources":{
+		"Bucket":{"Type":"AWS::S3::Bucket","Properties":{"BucketName":"journey-events-bucket"}}}}`
+
+	if _, err := cfn.CreateStack(ctx, &cloudformation.CreateStackInput{
+		StackName:    aws.String("journey-events"),
+		TemplateBody: aws.String(template),
+	}); err != nil {
+		t.Fatalf("CreateStack: %v", err)
+	}
+
+	out, err := cfn.DescribeStackEvents(ctx, &cloudformation.DescribeStackEventsInput{
+		StackName: aws.String("journey-events"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeStackEvents: %v", err)
+	}
+	// The stack's terminal event, the resource, then the stack's opening event.
+	// Newest first, as the API documents.
+	if len(out.StackEvents) != 3 {
+		t.Fatalf("StackEvents: got %d events, want 3: %+v", len(out.StackEvents), out.StackEvents)
+	}
+	wantStatuses := []cfntypes.ResourceStatus{"CREATE_COMPLETE", "CREATE_COMPLETE", "CREATE_IN_PROGRESS"}
+	for i, want := range wantStatuses {
+		if got := out.StackEvents[i].ResourceStatus; got != want {
+			t.Errorf("event %d: ResourceStatus = %q, want %q", i, got, want)
+		}
+	}
+	// Every required member deserialized. A missing one would be the zero value
+	// here and invisible to an XPath assertion over the raw body.
+	for i, e := range out.StackEvents {
+		if aws.ToString(e.EventId) == "" {
+			t.Errorf("event %d: EventId is empty", i)
+		}
+		if aws.ToString(e.StackName) != "journey-events" {
+			t.Errorf("event %d: StackName = %q", i, aws.ToString(e.StackName))
+		}
+		if aws.ToString(e.StackId) == "" {
+			t.Errorf("event %d: StackId is empty", i)
+		}
+		if e.Timestamp == nil {
+			t.Errorf("event %d: Timestamp is nil", i)
+		}
+	}
+	if got := aws.ToString(out.StackEvents[1].LogicalResourceId); got != "Bucket" {
+		t.Errorf("the resource event's LogicalResourceId = %q, want Bucket", got)
+	}
+	if got := aws.ToString(out.StackEvents[1].ResourceType); got != "AWS::S3::Bucket" {
+		t.Errorf("the resource event's ResourceType = %q", got)
+	}
+	if got := aws.ToString(out.StackEvents[0].ResourceType); got != "AWS::CloudFormation::Stack" {
+		t.Errorf("the stack event's ResourceType = %q", got)
+	}
+	if out.NextToken != nil {
+		t.Errorf("NextToken = %q, want none for a three-event stack", aws.ToString(out.NextToken))
+	}
+}
+
+// TestJourney_StackEventsNameARoleDenial is #562's fifth acceptance criterion
+// through the SDK: "a stack whose role is missing one permission reaches
+// ROLLBACK_COMPLETE with a StackEvent reason naming the denial".
+//
+// The criterion blocked #562 across four releases because DescribeStackEvents was
+// refused. The role is built through the IAM SDK rather than seeded into state, so
+// the whole chain a consumer writes is exercised: create a role, give it too little,
+// deploy under it, then read why from events.
+func TestJourney_StackEventsNameARoleDenial(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	iamClient := iam.NewFromConfig(cfg)
+	cfn := cloudformation.NewFromConfig(cfg, func(o *cloudformation.Options) { o.RetryMaxAttempts = 1 })
+
+	const roleName = "cfn-narrow"
+	if _, err := iamClient.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName: aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Principal":{"Service":"cloudformation.amazonaws.com"},"Action":"sts:AssumeRole"}]}`),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	// s3:ListBucket and not s3:CreateBucket: one missing permission, which is the
+	// criterion's shape — a role that is plausible rather than empty.
+	if _, err := iamClient.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		RoleName:   aws.String(roleName),
+		PolicyName: aws.String("too-narrow"),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[` +
+			`{"Effect":"Allow","Action":"s3:ListBucket","Resource":"*"}]}`),
+	}); err != nil {
+		t.Fatalf("PutRolePolicy: %v", err)
+	}
+
+	// A rolled-back stack is still a successful CreateStack: the API returns the
+	// StackId before any rollback happens, and the outcome is the stack's status.
+	if _, err := cfn.CreateStack(ctx, &cloudformation.CreateStackInput{
+		StackName: aws.String("journey-denied"),
+		RoleARN:   aws.String("arn:aws:iam::" + journeyAccountID + ":role/" + roleName),
+		TemplateBody: aws.String(`{"Resources":{"Bucket":{"Type":"AWS::S3::Bucket",` +
+			`"Properties":{"BucketName":"journey-denied-bucket"}}}}`),
+	}); err != nil {
+		t.Fatalf("CreateStack: %v", err)
+	}
+
+	stacks, err := cfn.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+		StackName: aws.String("journey-denied"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeStacks: %v", err)
+	}
+	if len(stacks.Stacks) != 1 {
+		t.Fatalf("DescribeStacks returned %d stacks", len(stacks.Stacks))
+	}
+	if got := stacks.Stacks[0].StackStatus; got != cfntypes.StackStatusRollbackComplete {
+		t.Fatalf("StackStatus = %q, want ROLLBACK_COMPLETE", got)
+	}
+
+	out, err := cfn.DescribeStackEvents(ctx, &cloudformation.DescribeStackEventsInput{
+		StackName: aws.String("journey-denied"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeStackEvents: %v", err)
+	}
+	var denial string
+	for _, e := range out.StackEvents {
+		if e.ResourceStatus == cfntypes.ResourceStatusCreateFailed {
+			denial = aws.ToString(e.ResourceStatusReason)
+		}
+	}
+	if denial == "" {
+		t.Fatalf("no CREATE_FAILED event carrying a reason: %+v", out.StackEvents)
+	}
+	// Naming the action is what makes the event actionable: a consumer learns which
+	// permission to add, rather than only that something failed.
+	for _, want := range []string{"AccessDeniedException", "s3:CreateBucket"} {
+		if !strings.Contains(denial, want) {
+			t.Errorf("ResourceStatusReason = %q, want it to name %q", denial, want)
+		}
+	}
+}


### PR DESCRIPTION
`DescribeStackEvents` returned `UnsupportedOperation` (400), so a consumer's deployment
wrapper — which polls events, because that is where a CloudFormation failure is
conventionally read from — could not run against substrate at all. That refusal also
blocked #562's fifth acceptance criterion, which deferred that issue across four
releases.

Closes #501
Closes #562

## The events are derived from the stack record, not the event log

This is a departure from the route #501 filed as its preferred one, and two
measurements are why.

**A recorded `Event` cannot name a resource.** `EventStore.RecordRequest`
(`emulator/eventstore.go:310-319`) builds an event from the request context and the
operation and never copies `reqCtx.Metadata` onto it, so the log knows
`s3:CreateBucket at T` but not which logical resource that was — and every useful
`StackEvent` carries a `LogicalResourceId`. Deriving from the log would mean guessing
which recorded call belonged to which resource, which invents *more* than reading the
record does.

**The event store is disabled for in-process callers.** The CFN plugin substitutes a
disabled store when none is passed (`cloudformation_plugin.go:114-117`), so an
`emulator.Client` test would have seen an empty list for a stack that plainly deployed.
`TestCFNEvents_DerivesWithoutAnEventStore` is the regression guard.

`cfnResourceStatus` is factored out of `describeStackResources` and shared, so the two
views cannot disagree about whether a resource failed.

## Terminal states only, and one instant per deploy

Substrate deploys synchronously, so it never observed a resource mid-create and holds no
record that one existed — a per-resource `CREATE_IN_PROGRESS` would be fabricated. The
stack's *own* bracketing events are different: the record's status names the operation
that ran and its timestamps say when.

Spacing the events apart was considered and rejected for a reason already recorded in
`emulator/sqs_control.go:20-27`: `TimeController.Now()` advances with wall time, so any
interval substrate manufactured would make a consumer's assertions wall-clock dependent.
Order is carried by position instead — reverse deployment order within an instant, which
is what real CloudFormation shows. This also settles the clock question #501 and #514
were both waiting on; #514 is not a blocker and stays open on its own EC2 merits.

`EventId` is deterministic: `{LogicalId}-{ResourceStatus}-{Timestamp}` for a resource,
which is the form AWS's own sample response returns, and a UUID derived from the stack
ARN, status and timestamp for a stack event. A replayed stack reports byte-identical
events.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run ./...` → **0 issues**, `make test`
(race), `make coverage` (81.5% emulator / 80.8% total), `make docs-reference
docs-reference-check docs-versions`, the docs site build, and `test/e2e` all green.

Verified live through the AWS CLI, including #562's criterion:

```
$ aws cloudformation describe-stack-events --stack-name ok \
    --query 'StackEvents[].[ResourceStatus,LogicalResourceId]' --output text
CREATE_COMPLETE     ok
CREATE_COMPLETE     B
CREATE_IN_PROGRESS  ok

$ aws cloudformation describe-stack-events --stack-name denied \
    --query 'StackEvents[?ResourceStatus==`CREATE_FAILED`].ResourceStatusReason' --output text
AccessDeniedException: User: arn:aws:iam::123456789012:role/narrow is not authorized to
perform: s3:CreateBucket on resource: arn:aws:s3:::denied-demo-bucket
```

An unknown stack, and a stack deleted successfully, both report `ValidationError` —
matching `DescribeStacks`, and #501 point 6's honest answer.

**Mutation testing: 12 mutants, 11 caught.** The survivor was a real defect rather than a
test gap: a `sort.SliceStable` by timestamp that could never reorder anything, because
the list is already non-decreasing in time when built. It was removed rather than covered
by a test for an unreachable branch. Mutants included ordering reversed, the
reverse-deployment tiebreak dropped, `ResourceStatusReason` dropped for a failed
resource, the sweep's deletion overlay skipped, both `EventId` forms made
non-deterministic, `NextToken` emitted on a complete page, the cursor ignored, the
opening event fabricated for a status-less record, an update reporting a create's
opening event, the derivation gated on the event store, the shared derivation split, and
a per-resource `CREATE_IN_PROGRESS` fabricated.

## Compatibility

`DescribeStackEvents` previously returned `UnsupportedOperation` (400) and now returns
200. A test asserting the refusal will fail —
`TestCFNPlugin_DescribeStackEvents` was such a test and is replaced knowingly, which is
what #501's own acceptance criteria asked for.

The `docs/services.md` "DescribeStackEvents is not supported" section is deleted and
replaced with what the model does and does not contain, and the paragraph claiming a
role denial is "**not** reported as a `StackEvent`" is now false and rewritten.
