### PR TITLE
chore(release): v0.95.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.95.0] - 2026-08-08
+
 ### Added
 - **`DescribeStackEvents` answers, derived from the stack record** (#501, #562).
   The operation returned `UnsupportedOperation` (400), so a consumer's deployment
@@ -5612,7 +5614,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.94.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.95.0...HEAD
+[v0.95.0]: https://github.com/scttfrdmn/substrate/compare/v0.94.0...v0.95.0
 [v0.94.0]: https://github.com/scttfrdmn/substrate/compare/v0.93.0...v0.94.0
 [v0.93.0]: https://github.com/scttfrdmn/substrate/compare/v0.92.0...v0.93.0
 [v0.92.0]: https://github.com/scttfrdmn/substrate/compare/v0.91.0...v0.92.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.95.0] - 2026-08-08` and adds the
comparison link. No code changes — the release's work is already on `main`.

## What v0.95.0 carries

- **#593** — `AssumeRole` evaluates the role's trust policy, so `sts:ExternalId` and
  `Principal` conditions are enforced. The IAM evaluator learned principal matching to
  do it.
- **#591** — an EC2 error reaches an AWS SDK caller with the code substrate sent, via the
  `ec2` protocol's own `<Errors><Error>` document.
- **#501** — `DescribeStackEvents` answers, derived from the stack record.
- **#562** — the CloudFormation service role's fifth acceptance criterion, met by #501:
  a denial is now visible in a `StackEvent`.

The v0.95.0 milestone is empty of open issues; it is closed once this merges and the
release is published.