### PR TITLE
feat(iam): implement UpdateAssumeRolePolicy (#594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`iam:UpdateAssumeRolePolicy`, so a role's trust policy can be changed after
+  `CreateRole`** (#594). The operation was absent from the IAM switch, making
+  `CreateRole` the only way to set an `AssumeRolePolicyDocument`. That cost nothing
+  while nothing read the document; #593 made it load-bearing, and from then on IaC
+  that creates a role and narrows its trust policy in a second pass — the
+  update-in-place shape CDK and Terraform both emit — silently kept the original
+  policy, so the tightening a test was written to verify was unobservable. The
+  replacement takes effect on the **next** `AssumeRole` and does not revoke sessions
+  already minted under the old policy, matching AWS: the gate runs at assumption
+  time, so a credential in hand keeps working. `PolicyDocument` is **required**,
+  unlike `CreateRole`'s optional `AssumeRolePolicyDocument` — the API model lists it
+  under `required`, so there is no "clear the trust policy" form of this call and an
+  absent one is a `ValidationError` rather than a silently unenforced role.
+  Errors are the model's: `NoSuchEntity` (404) for an unknown role,
+  `MalformedPolicyDocument` (400) for a document that does not parse.
+
+  **`GetRole` and `ListRoles` now report `AssumeRolePolicyDocument`**, which they
+  did not before — substrate's `Role` rendering omitted the member entirely, so a
+  caller had no way to confirm what it had just set, and #594's read-back criterion
+  could not be met without it. The document is emitted as plain JSON rather than
+  URL-encoded JSON: botocore's `after-call.iam` handler unquotes and then
+  `json.loads` every `policyDocumentType` member, and unquoting plain JSON is a
+  no-op, so both botocore and aws-sdk-go-v2 hand a consumer valid JSON. It is
+  re-marshaled from the stored parsed form rather than returned verbatim, the same
+  normalization `GetRolePolicy` and `GetUserPolicy` already apply to inline
+  policies, so a semantically equivalent form can come back — a `Principal`
+  submitted as `{"AWS":"123456789012"}` reads back as `"123456789012"`, the bare
+  string AWS also accepts for the same meaning. Real IAM stores the text and returns
+  the submitted bytes, so a consumer comparing the read-back byte-for-byte against
+  what it sent sees a difference; one parsing the document does not. A role created
+  without a trust policy reports no member at all rather than an empty document,
+  which is the same emptiness test the STS gate uses to decide a role is unenforced.
+
 ## [v0.95.0] - 2026-08-08
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -793,7 +793,8 @@ by their own plugins, so a stack's cost shows up under S3, EC2 and so on.
 | DeleteUser | |
 | ListUsers | |
 | CreateRole | Supports trust policy document |
-| GetRole | |
+| GetRole | Reports `AssumeRolePolicyDocument`, re-marshalled from the stored document rather than returned verbatim, so an equivalent form can come back (a `{"AWS":"1234"}` principal reads back as `"1234"`) |
+| UpdateAssumeRolePolicy | Replaces the trust policy in place; takes effect on the next `AssumeRole` and does not revoke existing sessions. `PolicyDocument` is required |
 | DeleteRole | Refuses with `DeleteConflict`/409 while a policy is attached **or** an instance profile holds the role; the message names the profiles |
 | ListRoles | |
 | CreateGroup | |
@@ -945,6 +946,12 @@ that never wrote a trust policy is unaffected. Enforcement is also skipped for a
 unauthenticated caller, who resolves to no principal for a `Principal` element to
 be true of; this is the same rule described in
 [Testing IAM permissions](./testing-guide.md#testing-iam-permissions).
+
+`iam:UpdateAssumeRolePolicy` replaces the document in place, which is how a test
+exercises the update-in-place shape IaC emits: assume, tighten, and be refused on
+the same role. The replacement takes effect on the **next** `AssumeRole`; sessions
+already minted under the old policy stay valid, as on AWS. `GetRole` reports the
+stored document, so a test can assert what it set.
 
 ### Cost
 

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -66,6 +66,8 @@ func (p *IAMPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.createRole(ctx, req)
 	case "GetRole":
 		return p.getRole(ctx, req)
+	case "UpdateAssumeRolePolicy":
+		return p.updateAssumeRolePolicy(ctx, req)
 	case "DeleteRole":
 		return p.deleteRole(ctx, req)
 	case "ListRoles":
@@ -454,6 +456,66 @@ func (p *IAMPlugin) getRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 	}
 
 	return iamXMLResponse(http.StatusOK, "GetRole", iamSingleRoleXML(role))
+}
+
+// updateAssumeRolePolicy replaces a role's trust policy in place.
+//
+// The document is stored the same way createRole stores it — unmarshalled into a
+// [PolicyDocument] — so the trust-policy gate STS applies (#593) and GetRole's
+// read-back both see the new document with no further plumbing. That gate reads
+// the stored policy at AssumeRole time, which is what makes the replacement take
+// effect on the *next* assume and leave already-minted sessions alone: AWS does
+// not revoke them either.
+//
+// PolicyDocument is required here, unlike CreateRole's AssumeRolePolicyDocument —
+// the UpdateAssumeRolePolicy model lists both RoleName and PolicyDocument under
+// "required", so there is no "clear the policy" form of this call. An absent one
+// is a validation error rather than an unenforced role.
+func (p *IAMPlugin) updateAssumeRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		RoleName       string `json:"RoleName"`
+		PolicyDocument string `json:"PolicyDocument"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.RoleName == "" || params.PolicyDocument == "" {
+		return iamErrorResponse("ValidationError",
+			"RoleName and PolicyDocument are required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+
+	if err := p.authorize(goCtx, ctx, "iam:UpdateAssumeRolePolicy", "*"); err != nil {
+		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+	}
+
+	role, err := p.loadRole(goCtx, params.RoleName)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
+			http.StatusNotFound), nil
+	}
+
+	var trustPolicy PolicyDocument
+	if err := json.Unmarshal([]byte(params.PolicyDocument), &trustPolicy); err != nil {
+		return iamErrorResponse("MalformedPolicyDocument", //nolint:nilerr
+			"PolicyDocument is not valid JSON.", http.StatusBadRequest), nil
+	}
+	role.AssumeRolePolicyDocument = trustPolicy
+
+	raw, err := json.Marshal(role)
+	if err != nil {
+		return nil, fmt.Errorf("marshal role: %w", err)
+	}
+	if err := p.state.Put(goCtx, iamNamespace, "role:"+params.RoleName, raw); err != nil {
+		return nil, fmt.Errorf("put role: %w", err)
+	}
+
+	return iamXMLEmptyResponse("UpdateAssumeRolePolicy"), nil
 }
 
 func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {

--- a/emulator/iam_update_assume_role_policy_test.go
+++ b/emulator/iam_update_assume_role_policy_test.go
@@ -1,0 +1,316 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// #594: UpdateAssumeRolePolicy was absent from the IAM operation switch, so a
+// role's trust policy could only ever be set by CreateRole. That was invisible
+// until #593 made the document load-bearing; now a consumer that creates a role
+// and narrows its trust policy in a second pass — the update-in-place shape CDK
+// and Terraform both emit — silently kept the original policy, so the tightening
+// the test existed to verify was unobservable.
+//
+// The decisive test is TestIAMPlugin_UpdateAssumeRolePolicy_TakesEffectOnNextAssume:
+// the others pin the operation's own contract, but only that one proves the
+// replacement reaches the gate that reads it.
+
+func TestIAMPlugin_UpdateAssumeRolePolicy_ReplacesTheDocument(t *testing.T) {
+	srv := newIAMTestServer(t)
+
+	const original = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+	const replacement = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateRole", map[string]any{
+		"RoleName":                 "worker",
+		"AssumeRolePolicyDocument": original,
+	}).StatusCode)
+
+	resp := iamRequest(t, srv, "UpdateAssumeRolePolicy", map[string]any{
+		"RoleName":       "worker",
+		"PolicyDocument": replacement,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The response shape carries only ResponseMetadata — the model declares no
+	// output shape at all — so there is no Result element to decode.
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Contains(t, string(body), "<UpdateAssumeRolePolicyResponse")
+	assert.Contains(t, string(body), "<ResponseMetadata>")
+
+	// Read back through GetRole. Substrate stores the document parsed, so the
+	// round trip is by principal rather than by byte: the replacement's Service
+	// principal must be there and the original's must be gone.
+	var result map[string]any
+	get := iamRequest(t, srv, "GetRole", map[string]any{"RoleName": "worker"})
+	require.Equal(t, http.StatusOK, get.StatusCode)
+	decodeIAMXML(t, get, &result)
+	role, ok := result["Role"].(map[string]any)
+	require.True(t, ok, "GetRole must report a Role element: %v", result)
+
+	doc, ok := role["AssumeRolePolicyDocument"].(string)
+	require.True(t, ok, "GetRole must report the trust policy: %v", role)
+	assert.Contains(t, doc, "ecs-tasks.amazonaws.com")
+	assert.NotContains(t, doc, "lambda.amazonaws.com",
+		"the replacement must displace the original, not merge with it")
+
+	// And it must still parse as a policy document, so a consumer reading it back
+	// can act on it. botocore url-decodes then json.loads every policyDocumentType
+	// member, and unquoting plain JSON is a no-op, so this is what a real SDK sees.
+	var parsed emulator.PolicyDocument
+	require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+	require.Len(t, parsed.Statement, 1)
+	assert.Equal(t, "Allow", parsed.Statement[0].Effect)
+}
+
+// TestIAMPlugin_UpdateAssumeRolePolicy_SetsAPolicyOnARoleCreatedWithout pins the
+// other direction of the same call: substrate permits creating a role with no
+// trust policy (real IAM requires one), and such a role is unenforced. An update
+// is how a test opts that role into enforcement without recreating it.
+func TestIAMPlugin_UpdateAssumeRolePolicy_SetsAPolicyOnARoleCreatedWithout(t *testing.T) {
+	srv := newIAMTestServer(t)
+	require.Equal(t, http.StatusOK,
+		iamRequest(t, srv, "CreateRole", map[string]any{"RoleName": "bare"}).StatusCode)
+
+	// GetRole reports no document at all before the update — not an empty one,
+	// which would be a document AWS never sends.
+	var before map[string]any
+	decodeIAMXML(t, iamRequest(t, srv, "GetRole", map[string]any{"RoleName": "bare"}), &before)
+	role, ok := before["Role"].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, role, "AssumeRolePolicyDocument")
+
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "UpdateAssumeRolePolicy", map[string]any{
+		"RoleName": "bare",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole"}]}`,
+	}).StatusCode)
+
+	var after map[string]any
+	decodeIAMXML(t, iamRequest(t, srv, "GetRole", map[string]any{"RoleName": "bare"}), &after)
+	role, ok = after["Role"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, role["AssumeRolePolicyDocument"], "123456789012")
+}
+
+// TestIAMPlugin_UpdateAssumeRolePolicy_ReadBackIsNormalized pins the shape of the
+// read-back, so the normalization is a documented property rather than a surprise.
+//
+// Substrate stores the parsed document and re-marshals it, which is what
+// GetRolePolicy and GetUserPolicy already do for inline policies. AWS stores the
+// text and returns the submitted bytes, so a consumer comparing the read-back
+// byte-for-byte against what it sent sees a difference here. Both forms are legal
+// AWS input for the same meaning and unmarshal identically, so a consumer that
+// parses the document is unaffected — which is the case worth pinning, because a
+// change that broke it would look like a passing test.
+func TestIAMPlugin_UpdateAssumeRolePolicy_ReadBackIsNormalized(t *testing.T) {
+	srv := newIAMTestServer(t)
+	require.Equal(t, http.StatusOK,
+		iamRequest(t, srv, "CreateRole", map[string]any{"RoleName": "worker"}).StatusCode)
+
+	// A lone AWS principal in map form. PolicyPrincipal marshals this back as the
+	// bare string AWS also accepts.
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "UpdateAssumeRolePolicy", map[string]any{
+		"RoleName": "worker",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole"}]}`,
+	}).StatusCode)
+
+	var result map[string]any
+	decodeIAMXML(t, iamRequest(t, srv, "GetRole", map[string]any{"RoleName": "worker"}), &result)
+	role, ok := result["Role"].(map[string]any)
+	require.True(t, ok)
+	doc, ok := role["AssumeRolePolicyDocument"].(string)
+	require.True(t, ok)
+
+	assert.Contains(t, doc, `"Principal":"123456789012"`,
+		"a lone AWS principal round-trips through the bare-string form")
+
+	// The meaning survives, which is what the STS gate reads.
+	var parsed emulator.PolicyDocument
+	require.NoError(t, json.Unmarshal([]byte(doc), &parsed))
+	require.Len(t, parsed.Statement, 1)
+	require.NotNil(t, parsed.Statement[0].Principal)
+	assert.Equal(t, []string{"123456789012"}, parsed.Statement[0].Principal.AWS)
+	assert.False(t, parsed.Statement[0].Principal.All,
+		"a named account must not normalize into the wildcard form")
+}
+
+// TestIAMPlugin_UpdateAssumeRolePolicy_Errors covers the operation's documented
+// error shapes. The codes and statuses are the botocore IAM model's:
+// NoSuchEntity/404 and MalformedPolicyDocument/400.
+func TestIAMPlugin_UpdateAssumeRolePolicy_Errors(t *testing.T) {
+	const validPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":"*","Action":"sts:AssumeRole"}]}`
+
+	tests := []struct {
+		name       string
+		body       map[string]any
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "an unknown role is NoSuchEntity",
+			body:       map[string]any{"RoleName": "nobody", "PolicyDocument": validPolicy},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "NoSuchEntity",
+		},
+		{
+			name:       "a document that does not parse is MalformedPolicyDocument",
+			body:       map[string]any{"RoleName": "worker", "PolicyDocument": "not json"},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "MalformedPolicyDocument",
+		},
+		{
+			// PolicyDocument is required by the model, unlike CreateRole's optional
+			// AssumeRolePolicyDocument — there is no "clear the trust policy" form of
+			// this call, so an absent document is a validation error rather than a
+			// silent unenforcing of the role.
+			name:       "an absent PolicyDocument is a validation error",
+			body:       map[string]any{"RoleName": "worker"},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "ValidationError",
+		},
+		{
+			name:       "an absent RoleName is a validation error",
+			body:       map[string]any{"PolicyDocument": validPolicy},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "ValidationError",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newIAMTestServer(t)
+			require.Equal(t, http.StatusOK,
+				iamRequest(t, srv, "CreateRole", map[string]any{"RoleName": "worker"}).StatusCode)
+
+			resp := iamRequest(t, srv, "UpdateAssumeRolePolicy", tt.body)
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, tt.wantCode, result["__type"])
+		})
+	}
+}
+
+// TestIAMPlugin_UpdateAssumeRolePolicy_LeavesTheRoleOtherwiseIntact pins that the
+// update is a replacement of one field, not of the role. The handler re-marshals
+// the whole record, so a dropped field would be silent — GetRole would simply
+// stop reporting it.
+func TestIAMPlugin_UpdateAssumeRolePolicy_LeavesTheRoleOtherwiseIntact(t *testing.T) {
+	srv := newIAMTestServer(t)
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "CreateRole", map[string]any{
+		"RoleName":           "worker",
+		"Path":               "/service-role/",
+		"Description":        "A role whose trust policy gets tightened.",
+		"MaxSessionDuration": 7200,
+	}).StatusCode)
+
+	var before map[string]any
+	decodeIAMXML(t, iamRequest(t, srv, "GetRole", map[string]any{"RoleName": "worker"}), &before)
+	original, ok := before["Role"].(map[string]any)
+	require.True(t, ok)
+
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "UpdateAssumeRolePolicy", map[string]any{
+		"RoleName": "worker",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Principal":"*","Action":"sts:AssumeRole"}]}`,
+	}).StatusCode)
+
+	var after map[string]any
+	decodeIAMXML(t, iamRequest(t, srv, "GetRole", map[string]any{"RoleName": "worker"}), &after)
+	updated, ok := after["Role"].(map[string]any)
+	require.True(t, ok)
+
+	for _, field := range []string{"RoleId", "RoleName", "Arn", "Path", "CreateDate", "Description", "MaxSessionDuration"} {
+		assert.Equal(t, original[field], updated[field], "%s must survive the update", field)
+	}
+}
+
+// TestIAMPlugin_UpdateAssumeRolePolicy_TakesEffectOnNextAssume is #594's point:
+// the same role, assumed successfully, tightened to another account, then refused.
+// Before this operation existed a test had to create two roles to express that,
+// which is not what the code under test does.
+func TestIAMPlugin_UpdateAssumeRolePolicy_TakesEffectOnNextAssume(t *testing.T) {
+	srv := newTrustPolicyTestServer(t)
+	accessKey := trustSetupCaller(t, srv, "alice")
+	trustCreateRole(t, srv, "broker", `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",`+
+		`"Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole"}]}`)
+
+	const roleARN = "arn:aws:iam::123456789012:role/broker"
+
+	allowed := trustAssumeRole(t, srv, accessKey, roleARN, "session1", "")
+	require.Equal(t, http.StatusOK, allowed.StatusCode,
+		"the caller's own account is trusted, so this must mint a session")
+	require.NoError(t, allowed.Body.Close())
+
+	// Tighten to a partner account the caller is not in.
+	require.Equal(t, http.StatusOK, trustIAMCall(t, srv, "UpdateAssumeRolePolicy", map[string]any{
+		"RoleName": "broker",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Principal":{"AWS":"999999999999"},"Action":"sts:AssumeRole"}]}`,
+	}).StatusCode)
+
+	denied := trustAssumeRole(t, srv, accessKey, roleARN, "session2", "")
+	require.Equal(t, http.StatusForbidden, denied.StatusCode,
+		"the tightened policy must be the one the gate reads")
+	code, message := trustErrorFrom(t, denied)
+	assert.Equal(t, "AccessDenied", code)
+	assert.Equal(t, trustMsgImplicit, message)
+}
+
+// TestIAMPlugin_UpdateAssumeRolePolicy_DoesNotRevokeExistingSessions pins the
+// other half of "takes effect on the next assume". AWS does not revoke sessions
+// minted under a policy it later replaces, and substrate should not either: the
+// gate runs at AssumeRole time, so a session already in state stays valid.
+//
+// Asserted through GetCallerIdentity rather than by reading state, because the
+// question is whether the *credential still works*, and only a request answers
+// that.
+func TestIAMPlugin_UpdateAssumeRolePolicy_DoesNotRevokeExistingSessions(t *testing.T) {
+	srv := newTrustPolicyTestServer(t)
+	accessKey := trustSetupCaller(t, srv, "alice")
+	trustCreateRole(t, srv, "broker", `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",`+
+		`"Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole"}]}`)
+
+	resp := trustAssumeRole(t, srv, accessKey,
+		"arn:aws:iam::123456789012:role/broker", "session1", "")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	sessionKey := trustSessionKeyFrom(t, resp)
+
+	// Replace the policy with one that would refuse a fresh assumption outright.
+	require.Equal(t, http.StatusOK, trustIAMCall(t, srv, "UpdateAssumeRolePolicy", map[string]any{
+		"RoleName": "broker",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Deny",` +
+			`"Principal":"*","Action":"sts:AssumeRole"}]}`,
+	}).StatusCode)
+
+	identity := trustGetCallerIdentity(t, srv, sessionKey)
+	require.Equal(t, http.StatusOK, identity.StatusCode,
+		"a session minted under the old policy must keep working")
+	body, err := io.ReadAll(identity.Body)
+	require.NoError(t, err)
+	require.NoError(t, identity.Body.Close())
+	assert.Contains(t, string(body), "assumed-role/broker/session1",
+		"and must still identify as the role it assumed")
+
+	// The control: a *new* assumption is now refused, so the replacement did land.
+	fresh := trustAssumeRole(t, srv, accessKey,
+		"arn:aws:iam::123456789012:role/broker", "session2", "")
+	assert.Equal(t, http.StatusForbidden, fresh.StatusCode)
+	require.NoError(t, fresh.Body.Close())
+}

--- a/emulator/iam_xml.go
+++ b/emulator/iam_xml.go
@@ -2,6 +2,7 @@ package emulator
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -135,6 +136,34 @@ func iamRoleXMLFields(r *IAMRole) string {
 		b.WriteString("<Description>")
 		b.WriteString(xmlEsc(r.Description))
 		b.WriteString("</Description>")
+	}
+	// The Role shape carries AssumeRolePolicyDocument, so a role's trust policy is
+	// readable through GetRole/ListRoles — which is the only way a caller can
+	// confirm what UpdateAssumeRolePolicy stored (#594). Emitted as JSON rather
+	// than URL-encoded JSON, matching how GetRolePolicy already returns an inline
+	// document: botocore's after-call.iam handler unquotes then json.loads every
+	// policyDocumentType member, and unquoting plain JSON is a no-op.
+	//
+	// The document is *re-marshaled from the parsed form*, not returned verbatim,
+	// because that is what substrate stores — the same normalization GetRolePolicy
+	// and GetUserPolicy already apply to inline policies. So a semantically
+	// equivalent form can come back: a Principal submitted as {"AWS":"1234"}
+	// reports as "1234", since PolicyPrincipal marshals a lone AWS entry as the
+	// bare string AWS also accepts. Real IAM stores the document as text and
+	// returns the submitted bytes, so a consumer comparing byte-for-byte sees a
+	// difference; one parsing the document does not.
+	//
+	// Omitted when there are no statements, because a role created without a trust
+	// policy has a zero PolicyDocument, and marshaling that would report a
+	// document ({"Version":"","Statement":null}) where AWS reports none. The
+	// emptiness test is the same one the STS gate uses to decide the role is
+	// unenforced.
+	if len(r.AssumeRolePolicyDocument.Statement) > 0 {
+		if doc, err := json.Marshal(r.AssumeRolePolicyDocument); err == nil {
+			b.WriteString("<AssumeRolePolicyDocument>")
+			b.WriteString(xmlEsc(string(doc)))
+			b.WriteString("</AssumeRolePolicyDocument>")
+		}
 	}
 	if r.PermissionsBoundary != nil {
 		b.WriteString("<PermissionsBoundary><PolicyArn>")

--- a/emulator/sts_trust_policy_test.go
+++ b/emulator/sts_trust_policy_test.go
@@ -152,6 +152,38 @@ func trustCreateRole(t *testing.T, srv *emulator.Server, roleName, trustPolicy s
 	}).StatusCode)
 }
 
+// trustSessionKeyFrom extracts the minted session's access key ID from an
+// AssumeRole response, so a later call can be made *as* that session.
+func trustSessionKeyFrom(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	var parsed struct {
+		AccessKeyID string `xml:"AssumeRoleResult>Credentials>AccessKeyId"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), "body: %s", body)
+	require.NotEmpty(t, parsed.AccessKeyID)
+	return parsed.AccessKeyID
+}
+
+// trustGetCallerIdentity calls GetCallerIdentity as accessKeyID. Whether a
+// credential still works is only answerable by making a request with it, which is
+// why this exists rather than a state read.
+func trustGetCallerIdentity(t *testing.T, srv *emulator.Server, accessKeyID string) *http.Response {
+	t.Helper()
+	q := url.Values{}
+	q.Set("Action", "GetCallerIdentity")
+	q.Set("Version", "2011-06-15")
+	r := httptest.NewRequest(http.MethodPost, "/?"+q.Encode(), nil)
+	r.Host = "sts.amazonaws.com"
+	r.Header.Set("Authorization", trustAuthHeader(accessKeyID, "sts"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Result()
+}
+
 // trustErrorFrom decodes the query-protocol error document.
 func trustErrorFrom(t *testing.T, resp *http.Response) (code, message string) {
 	t.Helper()

--- a/test/e2e/journey_iam_update_assume_role_policy_test.go
+++ b/test/e2e/journey_iam_update_assume_role_policy_test.go
@@ -1,0 +1,174 @@
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_UpdateAssumeRolePolicyTightensARoleInPlace is #594 at the SDK level.
+//
+// The shape being tested is the one CDK and Terraform emit on an update: a role
+// exists, and a second pass narrows its trust policy without recreating it.
+// UpdateAssumeRolePolicy was absent from substrate's IAM switch, so that second
+// pass had nowhere to land — and once #593 made the document load-bearing, the
+// tightening a consumer's test was written to verify became unobservable.
+//
+// Both halves are here. The tightening must deny, and the SDK's own round trip
+// through GetRole must report the new document: a caller that cannot read the
+// policy back has no way to assert what it set, and substrate did not render
+// AssumeRolePolicyDocument on the Role shape at all before this.
+func TestJourney_UpdateAssumeRolePolicyTightensARoleInPlace(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	iamClient := iam.NewFromConfig(cfg)
+
+	const roleName = "deploy-broker"
+	// The initial policy trusts the journey's own account, so the first assumption
+	// succeeds and the denial below can only be the update's doing.
+	original := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"AWS":"` + journeyAccountID + `"},"Action":"sts:AssumeRole"}]}`
+
+	if _, err := iamClient.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(original),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	roleARN := "arn:aws:iam::" + journeyAccountID + ":role/" + roleName
+
+	// A real IAM user, for the same reason the #593 journey needs one: the built-in
+	// AKIA key resolves to no principal, and an unenforced caller would make every
+	// assertion below pass regardless of what the trust policy says.
+	user, err := iamClient.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("deployer")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := iamClient.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:   user.User.UserName,
+		PolicyName: aws.String("assume"),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[` +
+			`{"Effect":"Allow","Action":"sts:AssumeRole","Resource":"*"}]}`),
+	}); err != nil {
+		t.Fatalf("PutUserPolicy: %v", err)
+	}
+	key, err := iamClient.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{
+		UserName: user.User.UserName,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+
+	callerCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithBaseEndpoint(ts.URL),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			aws.ToString(key.AccessKey.AccessKeyId),
+			aws.ToString(key.AccessKey.SecretAccessKey), "")),
+		config.WithHTTPClient(&http.Client{}),
+	)
+	if err != nil {
+		t.Fatalf("caller config: %v", err)
+	}
+	// Retries off, so the assertion is about the code on the first response.
+	stsClient := sts.NewFromConfig(callerCfg, func(o *sts.Options) { o.RetryMaxAttempts = 1 })
+
+	out, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String("before-tightening"),
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole under the original policy: %v", err)
+	}
+	if out.Credentials == nil || aws.ToString(out.Credentials.AccessKeyId) == "" {
+		t.Fatal("expected session credentials under the original policy")
+	}
+
+	// The update: narrow the role to a partner account this caller is not in.
+	const partnerAccount = "999999999999"
+	tightened := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"AWS":"` + partnerAccount + `"},"Action":"sts:AssumeRole"}]}`
+	if _, err := iamClient.UpdateAssumeRolePolicy(ctx, &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String(roleName),
+		PolicyDocument: aws.String(tightened),
+	}); err != nil {
+		t.Fatalf("UpdateAssumeRolePolicy: %v", err)
+	}
+
+	// The SDK's read-back, which is the only way a consumer can assert what it set.
+	// Substrate emits the document as plain JSON rather than URL-encoded JSON:
+	// botocore unquotes then json.loads every policyDocumentType member and
+	// aws-sdk-go-v2 hands back the raw string, and unquoting plain JSON is a no-op,
+	// so both see valid JSON.
+	//
+	// Parsed with substrate's own PolicyDocument rather than an ad-hoc struct,
+	// because the document is re-marshaled from the stored parsed form: a
+	// Principal submitted as {"AWS":"9999…"} comes back as the bare string
+	// "9999…", which is the other form AWS accepts for the same meaning. Comparing
+	// semantically is therefore the assertion that holds; a byte compare against
+	// the submitted text would fail on a normalization, not on a defect.
+	role, err := iamClient.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(roleName)})
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+	doc := aws.ToString(role.Role.AssumeRolePolicyDocument)
+	var parsed emulator.PolicyDocument
+	if err := json.Unmarshal([]byte(doc), &parsed); err != nil {
+		t.Fatalf("GetRole trust policy %q does not parse as JSON: %v", doc, err)
+	}
+	if len(parsed.Statement) != 1 {
+		t.Fatalf("GetRole trust policy = %q, want exactly one statement", doc)
+	}
+	principal := parsed.Statement[0].Principal
+	if principal == nil || len(principal.AWS) != 1 || principal.AWS[0] != partnerAccount {
+		t.Fatalf("trust policy = %q, want a lone AWS principal of %s (the update must displace, not merge)",
+			doc, partnerAccount)
+	}
+
+	// The tightened policy is the one the gate reads on the *next* assumption.
+	_, err = stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String("after-tightening"),
+	})
+	if err == nil {
+		t.Fatal("AssumeRole after tightening: expected a denial, got credentials")
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected a smithy.APIError, got %T: %v", err, err)
+	}
+	if apiErr.ErrorCode() != "AccessDenied" {
+		t.Fatalf("after tightening: ErrorCode() = %q, want AccessDenied", apiErr.ErrorCode())
+	}
+
+	// An unknown role is NoSuchEntity. Asserted through the SDK's *typed* error,
+	// because that is the branch a consumer's error handling actually takes — a code
+	// that only matches as a string would leave errors.As falling through.
+	var noSuchEntity *iamtypes.NoSuchEntityException
+	if _, err := iamClient.UpdateAssumeRolePolicy(ctx, &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String("no-such-role"),
+		PolicyDocument: aws.String(tightened),
+	}); err == nil {
+		t.Fatal("UpdateAssumeRolePolicy on an unknown role: expected NoSuchEntity")
+	} else if !errors.As(err, &noSuchEntity) {
+		t.Fatalf("expected *iamtypes.NoSuchEntityException, got %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
Closes #594

## Why

`UpdateAssumeRolePolicy` was absent from the IAM operation switch — `grep` found zero occurrences in `emulator/` — so `CreateRole` was the only way a role's trust policy could ever be set. That was harmless while the document was inert. #593 (v0.95.0) made it load-bearing at `AssumeRole` time, and after that the update-in-place shape CDK and Terraform both emit on a second pass had nowhere to land: a consumer tightening a trust policy silently kept the original, so the tightening its test existed to verify was unobservable.

## The operation

Verified against the botocore IAM model rather than recalled:

- `RoleName` and `PolicyDocument` are **both** `required`, unlike `CreateRole`'s optional `AssumeRolePolicyDocument`. There is therefore no "clear the trust policy" form of this call, and an absent document is a `ValidationError`/400 rather than a silent unenforcing of the role.
- Unknown role → `NoSuchEntity`/404, with `createRole`'s message wording.
- Unparseable document → `MalformedPolicyDocument`/400.
- The model declares **no output shape**, so success is the empty-envelope response (`iamXMLEmptyResponse`).

The document is stored unmarshalled into `PolicyDocument` exactly as `createRole` stores it, so #593's gate and `GetRole`'s read-back both see the replacement with no further plumbing. Because that gate reads the stored policy at `AssumeRole` time, the replacement takes effect on the **next** assume and leaves already-minted sessions alone — which is what AWS does too, and both halves are pinned by tests.

## `GetRole` now reports the trust policy

The issue's acceptance criterion "read-back through `GetRole` reflects the new document" was unmeetable: `iamRoleXMLFields` omitted `AssumeRolePolicyDocument` entirely. It now emits it, which affects `GetRole`, `ListRoles` and the roles embedded in instance-profile responses.

- **Plain JSON, not URL-encoded**, matching how `GetRolePolicy` already returns an inline document. botocore's `after-call.iam` handler unquotes then `json.loads` every `policyDocumentType` member, and unquoting plain JSON is a no-op, so both SDK families see valid JSON. Confirmed against a live server: `aws iam get-role --query 'Role.AssumeRolePolicyDocument'` prints a parsed object.
- **Re-marshalled from the stored parsed form**, not returned verbatim — the same normalization `GetRolePolicy`/`GetUserPolicy` already apply. A semantically equivalent form can therefore come back: a `{"AWS":"1234"}` principal reads back as `"1234"`, the other form AWS accepts for the same meaning. A consumer that parses the document is unaffected; one comparing bytes against what it submitted sees a difference. Pinned by `..._ReadBackIsNormalized` so it is a documented property rather than something rediscovered.
- **Omitted for a role with no statements**, because a role created without a trust policy has a zero `PolicyDocument` and marshalling that would report `{"Version":"","Statement":null}` where AWS reports nothing. The emptiness test is the same one the STS gate uses to decide a role is unenforced.

## Tests

Seven unit tests in `emulator/iam_update_assume_role_policy_test.go` plus one SDK-level journey. The decisive one is `..._TakesEffectOnNextAssume`: assume successfully, tighten to another account, assume again and get `AccessDenied` — #594's criterion exercised through an update rather than through a second role. `..._DoesNotRevokeExistingSessions` covers the other half, with a fresh-assume control proving the replacement did land.

## Verification

`gofmt` · `go build` · `go vet` · `golangci-lint run ./...` → 0 issues · `make test` (race) · `make docs-reference-check docs-versions` · `go test -C test/e2e ./...` · `npm --prefix docs run build`. Also end-to-end against `substrate server` with the AWS CLI (`AWS_MAX_ATTEMPTS=1`): assume succeeds, update, `get-role` shows the new document, assume is refused with `AccessDenied`, `NoSuchEntity`/`MalformedPolicyDocument` on the error paths, and `list-roles` unaffected.