### PR TITLE
fix(authz): report the denial code the service's wire protocol uses (#595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without a trust policy reports no member at all rather than an empty document,
   which is the same emptiness test the STS gate uses to decide a role is unenforced.
 
+### Fixed
+- **An authorization denial reports the code the service's wire protocol uses, so
+  substrate no longer answers one outcome with two codes** (#595). The generic
+  authorization gate returned `AccessDeniedException` for every service, while
+  #593's trust-policy gate returned the bare `AccessDenied` AWS actually sends for
+  STS. Two gates therefore reported different codes for one conceptual outcome, and
+  a consumer matching on the code got a denial it could not identify — the case IaC
+  error handling is most likely to branch on. The code now follows the requested
+  service's error protocol: `AccessDenied` for the XML protocols (Query, REST-XML
+  and EC2 — STS, IAM, CloudFormation, SNS, S3, EC2) and `AccessDeniedException` for
+  the JSON ones (SQS, DynamoDB, Lambda, SSM and the rest), which is the split every
+  AWS service model shows. Keying on protocol rather than on a per-service table
+  means a newly registered plugin gets the right code from its existing
+  classification, with no second table to keep in step; a test asserts the property
+  over every registered service rather than over a sample.
+
+  The IAM plugin's own gate is fixed with it. It runs a separate `authorize()` and
+  built its ~40 denials from a hardcoded `AccessDeniedException`, so fixing only the
+  generic controller would have left substrate reporting two codes for **one
+  service** — #595's complaint restated one level down. IAM speaks the Query
+  protocol, so its denials are now `AccessDenied` too.
+
+  Because the CloudFormation deployer surfaces a denial as a resource's error, and
+  #501 renders that as a `StackEvent` `ResourceStatusReason`, the denial text in
+  stack events and `DescribeStackResources` changes with it.
+
 ## [v0.95.0] - 2026-08-08
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -228,7 +228,7 @@ by that role, not by whoever asks for the delete, and a rollback's sweep runs as
 identity that created what it is tearing down.
 
 A refused resource call surfaces as `CREATE_FAILED` with the denial —
-`AccessDeniedException`, naming the action and the resource ARN — as that resource's
+`AccessDenied`, naming the action and the resource ARN — as that resource's
 `ResourceStatusReason` in `DescribeStackResources`, and the stack rolls back:
 
 ```
@@ -239,7 +239,7 @@ aws cloudformation describe-stacks --stack-name s \
 # ROLLBACK_COMPLETE   arn:aws:iam::123456789012:role/narrow
 aws cloudformation describe-stack-resources --stack-name s \
   --query 'StackResources[0].ResourceStatusReason'
-# AccessDeniedException: User: arn:aws:iam::123456789012:role/narrow is not
+# AccessDenied: User: arn:aws:iam::123456789012:role/narrow is not
 # authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::...
 ```
 
@@ -249,7 +249,7 @@ conventionally reads a CloudFormation failure from:
 ```bash
 aws cloudformation describe-stack-events --stack-name s \
   --query 'StackEvents[?ResourceStatus==`CREATE_FAILED`].ResourceStatusReason'
-# AccessDeniedException: User: arn:aws:iam::123456789012:role/narrow is not
+# AccessDenied: User: arn:aws:iam::123456789012:role/narrow is not
 # authorized to perform: s3:CreateBucket on resource: arn:aws:s3:::...
 ```
 
@@ -917,7 +917,15 @@ IAM operations are free.
 session, so a caller the trust policy does not admit is refused with
 `AccessDenied` (403). Two gates apply, and they answer different questions: the
 caller's own policies must allow `sts:AssumeRole` ("what may this caller do"), and
-the role's trust policy must admit the caller ("who may become this role").
+the role's trust policy must admit the caller ("who may become this role"). Both
+report the same code, so a consumer cannot tell them apart by code alone — the
+message says which one refused.
+
+That code follows the service's **wire protocol** rather than which gate refused or
+which service was called: `AccessDenied` on the XML protocols (Query, REST-XML and
+EC2 — so STS, IAM, CloudFormation, SNS, S3, EC2) and `AccessDeniedException` on the
+JSON ones (so SQS, DynamoDB, Lambda, SSM). That is what AWS does, and it is the
+same split every AWS service model shows.
 
 That makes the confused-deputy pattern testable. A trust policy conditioning on
 `sts:ExternalId` refuses a caller who cannot present the secret:

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -526,10 +526,14 @@ aws sts assume-role --role-arn arn:aws:iam::123456789012:role/broker \
 # 200 — an ASIA session key
 ```
 
-The code is `AccessDenied`, where the identity-policy denial above reports
-`AccessDeniedException`; both match what AWS returns. An explicit `Deny` in the
-trust policy is reported with a different message ("with an explicit deny in the
-role trust policy") under the same code.
+The code is `AccessDenied`, and so is an identity-policy denial *on the same
+service* — the two gates agree. The `sqs list-queues` denial above reports
+`AccessDeniedException` because the code follows the service's **wire protocol**,
+not which gate refused: AWS sends the bare form on the XML protocols (Query,
+REST-XML, EC2 — so STS, IAM, CloudFormation, S3) and the suffixed form on the JSON
+ones (so SQS, DynamoDB, Lambda). An explicit `Deny` in the trust policy is
+reported with a different message ("with an explicit deny in the role trust
+policy") under the same code.
 
 **Writing a trust policy is the opt-in**, the same shape as the rule below one
 level down. A role created without one is not enforced, so every test that never

--- a/emulator/access_denied_code_test.go
+++ b/emulator/access_denied_code_test.go
@@ -1,0 +1,183 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// #595: the generic authorization gate returned AccessDeniedException for every
+// service, but AWS only uses the suffixed form on the JSON protocols. On the XML
+// ones it sends the bare AccessDenied — which is what #593's trust-policy gate
+// already emitted, so substrate reported *two different codes for one conceptual
+// outcome* depending on which gate refused. A consumer matching on the code saw a
+// denial it could not identify.
+
+// TestAccessDeniedCodeFor_TracksTheWireProtocol pins the mapping the fix rests
+// on. Audited across every botocore model, deduplicated by service and restricted
+// to shapes carrying "exception": true:
+//
+//	family                                  bare AccessDenied  AccessDeniedException
+//	XML   (query 17, rest-xml 4, ec2 1)     1 (cloudfront)     0
+//	JSON  (json 149, rest-json 242, cbor 2) 0                  233
+//
+// The JSON arm is settled by the models: all 233 that declare the shape use the
+// suffixed form. The XML arm is not — only CloudFront declares it at all, so what
+// decides it is that no query-protocol service models an access-denied shape
+// (all 17, STS and IAM and CloudFormation among them), nor do S3 or EC2. Every
+// service where this code is observable in substrate is in that set, so the value
+// is observed AWS behavior rather than modeled. See accessDeniedCodeFor.
+func TestAccessDeniedCodeFor_TracksTheWireProtocol(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		service     string
+		contentType string
+		want        string
+	}{
+		// The services #595 names. STS is the one whose real code is quoted in the
+		// issue from AWS's own CLI output.
+		{"sts is query xml", "sts", "", "AccessDenied"},
+		{"iam is query xml", "iam", "application/x-amz-json-1.1", "AccessDenied"},
+		{"cloudformation is query xml", "cloudformation", "", "AccessDenied"},
+		{"sns is query xml", "sns", "", "AccessDenied"},
+
+		// S3 and EC2 have their own error documents but are still XML-family, and
+		// s3_publicaccess.go already documents the bare code for S3.
+		{"s3 is bare", "s3", "", "AccessDenied"},
+		{"ec2 is bare", "ec2", "", "AccessDenied"},
+
+		// The JSON side, where the models are unanimous.
+		{"dynamodb is json rpc", "dynamodb", "application/x-amz-json-1.0", "AccessDeniedException"},
+		{"ssm is json rpc", "ssm", "application/x-amz-json-1.1", "AccessDeniedException"},
+		{"sqs is json rpc", "sqs", "", "AccessDeniedException"},
+		{"lambda is rest json", "lambda", "application/json", "AccessDeniedException"},
+		{"apigateway is rest json", "apigateway", "application/json", "AccessDeniedException"},
+
+		// An unregistered service falls through errorProtocolFor's Content-Type
+		// sniff, so it inherits that fallback rather than a code of its own.
+		{"unknown with a json body", "notaservice", "application/x-amz-json-1.1", "AccessDeniedException"},
+		{"unknown with no content type", "notaservice", "", "AccessDenied"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want,
+				emulator.AccessDeniedCodeForTest(tt.service, tt.contentType))
+		})
+	}
+}
+
+// TestAccessDeniedCode_MatchesTheServiceErrorProtocol is the property behind the
+// table above, asserted over every registered service rather than a sample: a
+// service's denial code is the suffixed form exactly when its error protocol is
+// one of the JSON ones. A new plugin added to serviceErrorProtocols is covered by
+// this without anyone remembering to extend the table.
+func TestAccessDeniedCode_MatchesTheServiceErrorProtocol(t *testing.T) {
+	t.Parallel()
+	for _, svc := range emulator.RegisteredErrorProtocolServicesForTest() {
+		proto := emulator.ErrorProtocolForTest(svc, "")
+		wantSuffixed := proto == emulator.ErrProtoJSONRPCForTest ||
+			proto == emulator.ErrProtoRESTJSONForTest
+
+		want := "AccessDenied"
+		if wantSuffixed {
+			want = "AccessDeniedException"
+		}
+		assert.Equal(t, want, emulator.AccessDeniedCodeForTest(svc, ""),
+			"service %q classified as %s", svc, proto)
+	}
+}
+
+// TestAccessDenied_IAMPluginAgreesWithTheGenericGate closes the other half of the
+// drift. IAM's plugin runs its own authorize() and built its denials from a
+// hardcoded literal, so fixing only AuthController would have left substrate
+// reporting two codes for the *same service* — which is #595's complaint restated
+// one level down.
+func TestAccessDenied_IAMPluginAgreesWithTheGenericGate(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, emulator.AccessDeniedCodeForTest("iam", ""),
+		emulator.IAMAccessDeniedCodeForTest,
+		"the IAM plugin's denial code must be the one its protocol implies")
+}
+
+// TestAccessDenied_BothGatesAgree is the test #595 asks for by name: an identity
+// denial and a trust-policy denial on the same role must report the same code, so
+// the two cannot drift apart again.
+//
+// It is a live-server test rather than a unit assertion because the two codes are
+// produced in different places — AuthController.CheckAccess for the identity gate
+// and the STS plugin's trust-policy evaluation for the other — and only a request
+// through the whole pipeline shows what a caller actually receives from each.
+func TestAccessDenied_BothGatesAgree(t *testing.T) {
+	const roleARN = "arn:aws:iam::123456789012:role/broker"
+	trustPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole"}]}`
+
+	// The identity gate: a caller with no sts:AssumeRole grant. The trust policy
+	// here *would* allow it, so the refusal can only come from the identity gate.
+	identitySrv := newTrustPolicyTestServer(t)
+	identityKey := trustSetupCallerWithoutAssume(t, identitySrv, "ungranted")
+	trustCreateRole(t, identitySrv, "broker", trustPolicy)
+
+	identityDenied := trustAssumeRole(t, identitySrv, identityKey, roleARN, "session", "")
+	require.Equal(t, http.StatusForbidden, identityDenied.StatusCode)
+	identityCode, _ := trustErrorFrom(t, identityDenied)
+
+	// The trust-policy gate: a caller that *is* granted sts:AssumeRole, refused by
+	// a role that trusts only another account.
+	trustSrv := newTrustPolicyTestServer(t)
+	trustKey := trustSetupCaller(t, trustSrv, "granted")
+	trustCreateRole(t, trustSrv, "broker", `{"Version":"2012-10-17","Statement":[`+
+		`{"Effect":"Allow","Principal":{"AWS":"999999999999"},"Action":"sts:AssumeRole"}]}`)
+
+	trustDenied := trustAssumeRole(t, trustSrv, trustKey, roleARN, "session", "")
+	require.Equal(t, http.StatusForbidden, trustDenied.StatusCode)
+	trustCode, _ := trustErrorFrom(t, trustDenied)
+
+	assert.Equal(t, trustCode, identityCode,
+		"the two gates must report one code for one outcome")
+	// And that shared code is the one AWS sends for STS, so agreeing on the wrong
+	// value would not satisfy this test.
+	assert.Equal(t, "AccessDenied", identityCode)
+}
+
+// trustSetupCallerWithoutAssume creates an IAM user with a policy that grants
+// something unrelated, and returns its access key ID.
+//
+// A policy is still attached, deliberately. A user with no policy at all is an
+// implicit deny too, but resolveIAMEntity's not-enforced arm and an empty policy
+// list are different paths; granting an unrelated action puts the request on the
+// evaluated-and-refused path, which is the one that produces a denial code.
+func trustSetupCallerWithoutAssume(t *testing.T, srv *emulator.Server, userName string) string {
+	t.Helper()
+	require.Equal(t, http.StatusOK,
+		trustIAMCall(t, srv, "CreateUser", map[string]any{"UserName": userName}).StatusCode)
+	require.Equal(t, http.StatusOK, trustIAMCall(t, srv, "PutUserPolicy", map[string]any{
+		"UserName":   userName,
+		"PolicyName": "unrelated",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[` +
+			`{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`,
+	}).StatusCode)
+
+	resp := trustIAMCall(t, srv, "CreateAccessKey", map[string]any{"UserName": userName})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	var parsed struct {
+		AccessKey struct {
+			AccessKeyID string `xml:"AccessKeyId"`
+		} `xml:"CreateAccessKeyResult>AccessKey"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed))
+	require.NotEmpty(t, parsed.AccessKey.AccessKeyID)
+	return parsed.AccessKey.AccessKeyID
+}

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -24,8 +24,9 @@ func NewAuthController(state StateManager, logger Logger) *AuthController {
 }
 
 // CheckAccess returns nil when the caller is allowed or when reqCtx.Principal
-// is nil. Returns an *AWSError with code "AccessDeniedException" (HTTP 403)
-// when access is denied.
+// is nil. Returns an *AWSError with HTTP 403 and the denial code the requested
+// service's wire protocol uses — "AccessDenied" for the XML protocols,
+// "AccessDeniedException" for the JSON ones; see [accessDeniedCodeFor] (#595).
 func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) error {
 	if reqCtx.Principal == nil {
 		return nil
@@ -73,9 +74,14 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		Context:   condCtx,
 	})
 
+	// Both denial arms take their code from the same helper, so an identity-policy
+	// refusal and a boundary refusal cannot drift apart — and neither can drift from
+	// the trust-policy gate #593 added, which resolves the same way for STS.
+	deniedCode := accessDeniedCodeFor(req.Service, "")
+
 	if result.Decision != DecisionAllow {
 		return &AWSError{
-			Code: "AccessDeniedException",
+			Code: deniedCode,
 			Message: fmt.Sprintf("User: %s is not authorized to perform: %s on resource: %s",
 				reqCtx.Principal.ARN, action, resource),
 			HTTPStatus: http.StatusForbidden,
@@ -96,7 +102,7 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		})
 		if boundaryResult.Decision != DecisionAllow {
 			return &AWSError{
-				Code: "AccessDeniedException",
+				Code: deniedCode,
 				Message: fmt.Sprintf("User: %s is not authorized to perform: %s (blocked by permission boundary)",
 					reqCtx.Principal.ARN, action),
 				HTTPStatus: http.StatusForbidden,

--- a/emulator/authz_test.go
+++ b/emulator/authz_test.go
@@ -117,7 +117,7 @@ func TestAuthController_Deny(t *testing.T) {
 	require.Error(t, err)
 	var awsErr *emulator.AWSError
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, "AccessDeniedException", awsErr.Code)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
 	assert.Equal(t, 403, awsErr.HTTPStatus)
 }
 
@@ -134,7 +134,7 @@ func TestAuthController_ImplicitDeny(t *testing.T) {
 	require.Error(t, err)
 	var awsErr *emulator.AWSError
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, "AccessDeniedException", awsErr.Code)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
 }
 
 func TestAuthController_CrossService_S3Deny(t *testing.T) {
@@ -159,7 +159,7 @@ func TestAuthController_CrossService_S3Deny(t *testing.T) {
 	require.Error(t, err)
 	var awsErr *emulator.AWSError
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, "AccessDeniedException", awsErr.Code)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
 }
 
 func TestAuthController_InlinePolicy_Allow(t *testing.T) {
@@ -254,7 +254,7 @@ func TestAuthController_PermissionBoundary_Deny(t *testing.T) {
 	require.Error(t, err)
 	var awsErr *emulator.AWSError
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, "AccessDeniedException", awsErr.Code)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
 	assert.Contains(t, awsErr.Message, "permission boundary")
 }
 
@@ -322,7 +322,7 @@ func TestABAC_ResourceTag_Deny(t *testing.T) {
 	require.Error(t, err)
 	var awsErr *emulator.AWSError
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, "AccessDeniedException", awsErr.Code)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
 }
 
 func TestABAC_ResourceTag_Missing(t *testing.T) {
@@ -343,7 +343,7 @@ func TestABAC_ResourceTag_Missing(t *testing.T) {
 	require.Error(t, err)
 	var awsErr *emulator.AWSError
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, "AccessDeniedException", awsErr.Code)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
 }
 
 func TestABAC_RequestTag_Allow(t *testing.T) {
@@ -386,7 +386,7 @@ func TestABAC_RequestTag_Deny(t *testing.T) {
 	require.Error(t, err)
 	var awsErr *emulator.AWSError
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, "AccessDeniedException", awsErr.Code)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
 }
 
 func TestABAC_IAMRole_ResourceTag(t *testing.T) {

--- a/emulator/cfn_events_test.go
+++ b/emulator/cfn_events_test.go
@@ -96,13 +96,13 @@ func TestCFNEvents_DeriveShape(t *testing.T) {
 				Resources: []emulator.DeployedResource{
 					{LogicalID: "Role", Type: "AWS::IAM::Role", PhysicalID: "demo-role"},
 					{LogicalID: "Bucket", Type: "AWS::S3::Bucket",
-						Error: "AccessDeniedException: not authorized to perform: s3:CreateBucket"},
+						Error: "AccessDenied: not authorized to perform: s3:CreateBucket"},
 				},
 			},
 			want: []want{
 				{"demo", "CREATE_FAILED", "resource Bucket failed"},
 				{"Bucket", "CREATE_FAILED",
-					"AccessDeniedException: not authorized to perform: s3:CreateBucket"},
+					"AccessDenied: not authorized to perform: s3:CreateBucket"},
 				{"Role", "CREATE_COMPLETE", ""},
 				{"demo", "CREATE_IN_PROGRESS", "User Initiated"},
 			},
@@ -116,21 +116,21 @@ func TestCFNEvents_DeriveShape(t *testing.T) {
 			stack: emulator.CFNStackState{
 				StackName:    "demo",
 				Status:       "ROLLBACK_COMPLETE",
-				StatusReason: "AccessDeniedException on Bucket",
+				StatusReason: "AccessDenied on Bucket",
 				CreatedAt:    cfnEventsAt,
 				UpdatedAt:    cfnEventsAt,
 				Resources: []emulator.DeployedResource{
 					{LogicalID: "Role", Type: "AWS::IAM::Role", PhysicalID: "demo-role"},
 					{LogicalID: "Bucket", Type: "AWS::S3::Bucket",
-						Error: "AccessDeniedException on s3:CreateBucket"},
+						Error: "AccessDenied on s3:CreateBucket"},
 				},
 				ResourceDeletions: []emulator.CFNResourceDeletion{
 					{LogicalID: "Role", Type: "AWS::IAM::Role", Status: "DELETE_COMPLETE"},
 				},
 			},
 			want: []want{
-				{"demo", "ROLLBACK_COMPLETE", "AccessDeniedException on Bucket"},
-				{"Bucket", "CREATE_FAILED", "AccessDeniedException on s3:CreateBucket"},
+				{"demo", "ROLLBACK_COMPLETE", "AccessDenied on Bucket"},
+				{"Bucket", "CREATE_FAILED", "AccessDenied on s3:CreateBucket"},
 				{"Role", "DELETE_COMPLETE", ""},
 				// A rollback is the tail of the CreateStack the caller made, so the
 				// opening event is still CREATE_IN_PROGRESS.

--- a/emulator/cfn_service_role_test.go
+++ b/emulator/cfn_service_role_test.go
@@ -141,7 +141,7 @@ func TestCFN_ServiceRoleAuthorizesResourceCalls(t *testing.T) {
 			roleName:   "narrow",
 			actions:    []string{"s3:ListBucket"},
 			wantStatus: "ROLLBACK_COMPLETE",
-			wantReason: "AccessDeniedException",
+			wantReason: "AccessDenied",
 		},
 		{
 			name:       "a role that can create the bucket deploys",
@@ -157,7 +157,7 @@ func TestCFN_ServiceRoleAuthorizesResourceCalls(t *testing.T) {
 			name:       "a role with no policy at all rolls the stack back",
 			roleName:   "empty",
 			wantStatus: "ROLLBACK_COMPLETE",
-			wantReason: "AccessDeniedException",
+			wantReason: "AccessDenied",
 		},
 	}
 
@@ -242,7 +242,7 @@ func TestCFN_DeniedResourceNamesTheDenialInStackEvents(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, denial, "no CREATE_FAILED event for the refused resource: %s", body)
-	assert.Contains(t, denial, "AccessDeniedException")
+	assert.Contains(t, denial, "AccessDenied")
 	assert.Contains(t, denial, "s3:CreateBucket",
 		"the event names the action that was refused")
 
@@ -284,7 +284,7 @@ func TestCFN_DeniedResourceNamesTheDenialInStackResources(t *testing.T) {
 
 	res := parsed.Resources[0]
 	assert.Equal(t, "Data", res.LogicalResourceID)
-	assert.Contains(t, res.ResourceStatusReason, "AccessDeniedException")
+	assert.Contains(t, res.ResourceStatusReason, "AccessDenied")
 	assert.Contains(t, res.ResourceStatusReason, "s3:CreateBucket",
 		"the reason names the action that was refused")
 }
@@ -597,5 +597,5 @@ func TestCFN_CreatorPrincipalDeploysWhenThereIsNoRole(t *testing.T) {
 	status, roleARN, reason := cfnStackStatus(t, body)
 	assert.Equal(t, "ROLLBACK_COMPLETE", status)
 	assert.Empty(t, roleARN, "the stack has no service role; the creator is not one")
-	assert.Contains(t, reason, "AccessDeniedException")
+	assert.Contains(t, reason, "AccessDenied")
 }

--- a/emulator/coverage_test.go
+++ b/emulator/coverage_test.go
@@ -705,6 +705,6 @@ func TestIAMPlugin_Authorize_WithBoundary(t *testing.T) {
 	require.Error(t, err)
 	var awsErr *emulator.AWSError
 	require.ErrorAs(t, err, &awsErr)
-	assert.Equal(t, "AccessDeniedException", awsErr.Code)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
 	assert.Contains(t, awsErr.Message, "permission boundary")
 }

--- a/emulator/error_protocol.go
+++ b/emulator/error_protocol.go
@@ -187,6 +187,49 @@ func errorProtocolFor(service, contentType string) awsErrorProtocol {
 	return errProtoQueryXML
 }
 
+// accessDeniedCodeFor returns the error code AWS uses to refuse an authorization
+// check on the given service: "AccessDenied" for the XML protocols, and
+// "AccessDeniedException" for the JSON ones.
+//
+// The suffix tracks the wire protocol rather than the individual service (#595).
+// Audited across every botocore model, deduplicated by service (botocore ships
+// many versioned models per service, so counting files inflates the XML side
+// nineteen-fold) and restricted to shapes carrying "exception": true:
+//
+//	family                                  bare AccessDenied  AccessDeniedException
+//	XML   (query 17, rest-xml 4, ec2 1)     1 (cloudfront)     0
+//	JSON  (json 149, rest-json 242, cbor 2) 0                  233
+//
+// The two halves rest on very different evidence. On the JSON side all 233
+// services that model the shape use the suffixed form and none use the bare one,
+// so that arm is settled by the models. On the XML side only CloudFront models
+// the shape at all, so n=1.
+//
+// What decides the XML arm instead is that **no query-protocol service models an
+// access-denied shape** — all 17, including STS, IAM, CloudFormation and SNS —
+// and neither do S3 (rest-xml) or EC2 (ec2), which declare no exception shapes
+// whatsoever. Every service where this code is observable in substrate is in that
+// set, so the value is *observed AWS behavior, not modeled*: AWS's own CLI
+// output for a refused sts:AssumeRole reports "AccessDenied" (quoted in #595),
+// and s3ErrorResponseWith's callers already rely on the same for S3 (see
+// s3_publicaccess.go). CloudFront and the unanimous JSON column corroborate the
+// split; they are not its basis.
+//
+// contentType is only consulted for services absent from serviceErrorProtocols,
+// via errorProtocolFor's fallback — callers that do not have it may pass "".
+func accessDeniedCodeFor(service, contentType string) string {
+	switch errorProtocolFor(service, contentType) {
+	case errProtoJSONRPC, errProtoRESTJSON:
+		return "AccessDeniedException"
+	case errProtoQueryXML, errProtoS3XML, errProtoEC2XML:
+		return "AccessDenied"
+	}
+	// Unreachable: errorProtocolFor returns one of the constants above. Defaulting
+	// to the suffixed form keeps a hypothetical new protocol on the value the
+	// overwhelming majority of AWS services use.
+	return "AccessDeniedException"
+}
+
 // marshalAWSError serializes err in the wire format the given protocol uses,
 // returning the body, the Content-Type to send, and any extra response headers.
 //

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"time"
 )
 
@@ -282,6 +283,30 @@ func ErrorProtocolForTest(service, contentType string) string {
 		return ErrProtoUnknownForTest
 	}
 }
+
+// AccessDeniedCodeForTest wraps accessDeniedCodeFor so an external test can pin
+// the protocol-to-code mapping directly, rather than only through the two
+// AuthController denial arms that consume it.
+func AccessDeniedCodeForTest(service, contentType string) string {
+	return accessDeniedCodeFor(service, contentType)
+}
+
+// RegisteredErrorProtocolServicesForTest returns every service name in
+// serviceErrorProtocols, so a test can assert a property over the whole table
+// rather than over a sample that goes stale as plugins are added.
+func RegisteredErrorProtocolServicesForTest() []string {
+	names := make([]string, 0, len(serviceErrorProtocols))
+	for svc := range serviceErrorProtocols {
+		names = append(names, svc)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// IAMAccessDeniedCodeForTest is the code the IAM plugin's own gate reports, so a
+// test can assert it agrees with what accessDeniedCodeFor derives for "iam"
+// instead of restating the literal.
+const IAMAccessDeniedCodeForTest = iamAccessDeniedCode
 
 // MarshalAWSErrorForTest wraps marshalAWSError, selecting the protocol by one of
 // the ErrProto*ForTest names. status is the HTTP status the error carries, which

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -190,7 +190,7 @@ func (p *IAMPlugin) createUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:CreateUser", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	key := "user:" + params.UserName
@@ -238,7 +238,7 @@ func (p *IAMPlugin) getUser(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:GetUser", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	userName := params.UserName
@@ -279,7 +279,7 @@ func (p *IAMPlugin) deleteUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:DeleteUser", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	user, err := p.loadUser(goCtx, params.UserName)
@@ -323,7 +323,7 @@ func (p *IAMPlugin) listUsers(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:ListUsers", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	keys, err := p.state.List(goCtx, iamNamespace, "user:")
@@ -377,7 +377,7 @@ func (p *IAMPlugin) createRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:CreateRole", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	key := "role:" + params.RoleName
@@ -442,7 +442,7 @@ func (p *IAMPlugin) getRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:GetRole", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	role, err := p.loadRole(goCtx, params.RoleName)
@@ -487,7 +487,7 @@ func (p *IAMPlugin) updateAssumeRolePolicy(ctx *RequestContext, req *AWSRequest)
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:UpdateAssumeRolePolicy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	role, err := p.loadRole(goCtx, params.RoleName)
@@ -532,7 +532,7 @@ func (p *IAMPlugin) deleteRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:DeleteRole", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	role, err := p.loadRole(goCtx, params.RoleName)
@@ -596,7 +596,7 @@ func (p *IAMPlugin) listRoles(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:ListRoles", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	keys, err := p.state.List(goCtx, iamNamespace, "role:")
@@ -646,7 +646,7 @@ func (p *IAMPlugin) createGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:CreateGroup", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	key := "group:" + params.GroupName
@@ -698,7 +698,7 @@ func (p *IAMPlugin) getGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:GetGroup", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	raw, err := p.state.Get(goCtx, iamNamespace, "group:"+params.GroupName)
@@ -732,7 +732,7 @@ func (p *IAMPlugin) deleteGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:DeleteGroup", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	existing, err := p.state.Get(goCtx, iamNamespace, "group:"+params.GroupName)
@@ -765,7 +765,7 @@ func (p *IAMPlugin) listGroups(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:ListGroups", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	keys, err := p.state.List(goCtx, iamNamespace, "group:")
@@ -812,7 +812,7 @@ func (p *IAMPlugin) attachUserPolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:AttachUserPolicy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	user, err := p.loadUser(goCtx, params.UserName)
@@ -858,7 +858,7 @@ func (p *IAMPlugin) detachUserPolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:DetachUserPolicy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	listKey := "user_policies:" + params.UserName
@@ -904,7 +904,7 @@ func (p *IAMPlugin) listAttachedUserPolicies(ctx *RequestContext, req *AWSReques
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:ListAttachedUserPolicies", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	arns, err := p.loadPolicyList(goCtx, "user_policies:"+params.UserName)
@@ -938,7 +938,7 @@ func (p *IAMPlugin) attachRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:AttachRolePolicy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	role, err := p.loadRole(goCtx, params.RoleName)
@@ -984,7 +984,7 @@ func (p *IAMPlugin) detachRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:DetachRolePolicy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	listKey := "role_policies:" + params.RoleName
@@ -1030,7 +1030,7 @@ func (p *IAMPlugin) listAttachedRolePolicies(ctx *RequestContext, req *AWSReques
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:ListAttachedRolePolicies", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	arns, err := p.loadPolicyList(goCtx, "role_policies:"+params.RoleName)
@@ -1066,7 +1066,7 @@ func (p *IAMPlugin) createPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:CreatePolicy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	if params.Path == "" {
@@ -1131,7 +1131,7 @@ func (p *IAMPlugin) getPolicy(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:GetPolicy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	// Check managed policies first.
@@ -1170,7 +1170,7 @@ func (p *IAMPlugin) deletePolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:DeletePolicy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+params.PolicyArn)
@@ -1204,7 +1204,7 @@ func (p *IAMPlugin) listPolicies(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:ListPolicies", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	keys, err := p.state.List(goCtx, iamNamespace, "policy:")
@@ -1247,7 +1247,7 @@ func (p *IAMPlugin) createAccessKey(ctx *RequestContext, req *AWSRequest) (*AWSR
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:CreateAccessKey", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	userName := params.UserName
@@ -1315,7 +1315,7 @@ func (p *IAMPlugin) deleteAccessKey(ctx *RequestContext, req *AWSRequest) (*AWSR
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:DeleteAccessKey", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	raw, err := p.state.Get(goCtx, iamNamespace, "accesskey:"+params.AccessKeyID)
@@ -1368,7 +1368,7 @@ func (p *IAMPlugin) listAccessKeys(ctx *RequestContext, req *AWSRequest) (*AWSRe
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:ListAccessKeys", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	userName := params.UserName
@@ -1409,6 +1409,15 @@ func (p *IAMPlugin) listAccessKeys(ctx *RequestContext, req *AWSRequest) (*AWSRe
 }
 
 // --- Authorization ---------------------------------------------------------
+
+// iamAccessDeniedCode is the code every IAM denial reports.
+//
+// IAM speaks the query protocol, so this is the bare form — the same value
+// [accessDeniedCodeFor] derives for the service, and the plugin's denials must
+// agree with the generic gate's or substrate would report two codes for one
+// outcome on the same service (#595). Written as a constant rather than a call
+// because the answer is fixed for this plugin: its service is always "iam".
+const iamAccessDeniedCode = "AccessDenied"
 
 // authorize checks whether the caller (reqCtx.Principal) is allowed to perform
 // action on resource. A nil Principal always passes (bootstrap/test mode).
@@ -1495,7 +1504,7 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 
 	if result.Decision != DecisionAllow {
 		return &AWSError{
-			Code:       "AccessDeniedException",
+			Code:       iamAccessDeniedCode,
 			Message:    "User: " + reqCtx.Principal.ARN + " is not authorized to perform: " + action,
 			HTTPStatus: http.StatusForbidden,
 		}
@@ -1521,7 +1530,7 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 				})
 				if boundaryResult.Decision != DecisionAllow {
 					return &AWSError{
-						Code:       "AccessDeniedException",
+						Code:       iamAccessDeniedCode,
 						Message:    "User: " + reqCtx.Principal.ARN + " is not authorized to perform: " + action + " (blocked by permission boundary)",
 						HTTPStatus: http.StatusForbidden,
 					}
@@ -1592,7 +1601,7 @@ func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 
 	goCtx := context.Background()
 	if err := p.authorize(goCtx, ctx, "iam:Put"+actionSuffix+"Policy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	// Verify the entity exists.
@@ -1677,7 +1686,7 @@ func (p *IAMPlugin) getInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 
 	goCtx := context.Background()
 	if err := p.authorize(goCtx, ctx, "iam:Get"+actionSuffix+"Policy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	raw, err := p.state.Get(goCtx, iamNamespace, entityType+"_inline:"+entityName+":"+params.PolicyName)
@@ -1721,7 +1730,7 @@ func (p *IAMPlugin) deleteInlinePolicy(ctx *RequestContext, req *AWSRequest, ent
 
 	goCtx := context.Background()
 	if err := p.authorize(goCtx, ctx, "iam:Delete"+actionSuffix+"Policy", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	stateKey := entityType + "_inline:" + entityName + ":" + params.PolicyName
@@ -1781,7 +1790,7 @@ func (p *IAMPlugin) listInlinePolicies(ctx *RequestContext, req *AWSRequest, ent
 
 	goCtx := context.Background()
 	if err := p.authorize(goCtx, ctx, "iam:List"+actionSuffix+"Policies", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	names, err := p.loadStringList(goCtx, entityType+"_inline_names:"+entityName)
@@ -1840,7 +1849,7 @@ func (p *IAMPlugin) putPermissionsBoundary(ctx *RequestContext, req *AWSRequest,
 
 	goCtx := context.Background()
 	if err := p.authorize(goCtx, ctx, "iam:Put"+actionSuffix+"PermissionsBoundary", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	boundary := &IAMAttachedPolicy{
@@ -1913,7 +1922,7 @@ func (p *IAMPlugin) deletePermissionsBoundary(ctx *RequestContext, req *AWSReque
 
 	goCtx := context.Background()
 	if err := p.authorize(goCtx, ctx, "iam:Delete"+actionSuffix+"PermissionsBoundary", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	stateKey := entityType + ":" + entityName
@@ -1976,7 +1985,7 @@ func (p *IAMPlugin) tagUser(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:TagUser", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	user, err := p.loadUser(goCtx, params.UserName)
@@ -2030,7 +2039,7 @@ func (p *IAMPlugin) untagUser(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:UntagUser", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	user, err := p.loadUser(goCtx, params.UserName)
@@ -2082,7 +2091,7 @@ func (p *IAMPlugin) listUserTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:ListUserTags", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	user, err := p.loadUser(goCtx, params.UserName)
@@ -2147,7 +2156,7 @@ func (p *IAMPlugin) tagRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:TagRole", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	role, err := p.loadRole(goCtx, params.RoleName)
@@ -2201,7 +2210,7 @@ func (p *IAMPlugin) untagRole(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:UntagRole", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	role, err := p.loadRole(goCtx, params.RoleName)
@@ -2253,7 +2262,7 @@ func (p *IAMPlugin) listRoleTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	goCtx := context.Background()
 
 	if err := p.authorize(goCtx, ctx, "iam:ListRoleTags", "*"); err != nil {
-		return iamErrorResponse("AccessDeniedException", err.Error(), http.StatusForbidden), nil
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
 	role, err := p.loadRole(goCtx, params.RoleName)

--- a/emulator/principal_resolution_test.go
+++ b/emulator/principal_resolution_test.go
@@ -278,7 +278,7 @@ func TestCheckAccess_NoPermissionsRequiredActions(t *testing.T) {
 			require.Error(t, err)
 			var awsErr *emulator.AWSError
 			require.ErrorAs(t, err, &awsErr)
-			assert.Equal(t, "AccessDeniedException", awsErr.Code)
+			assert.Equal(t, "AccessDenied", awsErr.Code)
 		})
 	}
 }

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -462,7 +462,8 @@ func (s *Server) handleReady(w http.ResponseWriter, _ *http.Request) {
 //     1.5. Credential resolution — account from Credentials (when non-nil),
 //     principal from state (always; see [resolvePrincipal])
 //     1.6. SigV4 signature verification (when Credentials != nil)
-//  2. auth.CheckAccess()        → 403 AccessDeniedException
+//  2. auth.CheckAccess()        → 403 AccessDenied / AccessDeniedException
+//     (per the service's wire protocol; see accessDeniedCodeFor)
 //  3. quota.CheckQuota()        → 429 ThrottlingException
 //  4. consistency.CheckRead()   → 409 InconsistentStateException
 //  5. registry.RouteRequest()   (plugin dispatch)

--- a/emulator/sts_trust_policy_test.go
+++ b/emulator/sts_trust_policy_test.go
@@ -111,8 +111,10 @@ func trustAssumeRole(t *testing.T, srv *emulator.Server, accessKeyID, roleARN, s
 // gate passes, and returns its access key ID.
 //
 // The grant matters: without it every case below would fail at the *identity*
-// gate with AccessDeniedException, and a test asserting only "denied" would pass
-// while the trust policy stayed unread — which is exactly the #593 defect.
+// gate instead, and a test asserting only "denied" would pass while the trust
+// policy stayed unread — which is exactly the #593 defect. Since #595 the two
+// gates report the same code, so the assertion cannot even be told apart by code
+// alone; TestAccessDenied_BothGatesAgree pins that deliberately.
 func trustSetupCaller(t *testing.T, srv *emulator.Server, userName string) string {
 	t.Helper()
 	require.Equal(t, http.StatusOK,

--- a/test/e2e/journey_cfn_events_test.go
+++ b/test/e2e/journey_cfn_events_test.go
@@ -167,7 +167,7 @@ func TestJourney_StackEventsNameARoleDenial(t *testing.T) {
 	}
 	// Naming the action is what makes the event actionable: a consumer learns which
 	// permission to add, rather than only that something failed.
-	for _, want := range []string{"AccessDeniedException", "s3:CreateBucket"} {
+	for _, want := range []string{"AccessDenied", "s3:CreateBucket"} {
 		if !strings.Contains(denial, want) {
 			t.Errorf("ResourceStatusReason = %q, want it to name %q", denial, want)
 		}


### PR DESCRIPTION
Closes #595

## Why

The generic authorization gate returned `AccessDeniedException` for every service, while #593's trust-policy gate returned the bare `AccessDenied` AWS actually sends for STS. Substrate therefore answered **one conceptual outcome with two different codes** depending on which gate refused, and a consumer matching on the code got a denial it could not identify — the case IaC error handling is most likely to branch on.

## The audit, and what it does and does not settle

Posted in full on #595, including a correction to my first pass. Run across every botocore model, **deduplicated by service** (botocore ships many versioned models per service, so counting files inflates the XML side nineteen-fold) and restricted to shapes carrying `"exception": true`:

| family | services | bare `AccessDenied` | `AccessDeniedException` |
|---|---|---|---|
| XML (`query` 17, `rest-xml` 4, `ec2` 1) | 22 | **1** (`cloudfront`) | 0 |
| JSON (`json` 149, `rest-json` 242, `cbor` 2) | 393 | **0** | **233** |

- **The JSON arm is settled by the models**: all 233 services that declare the shape use the suffixed form, none the bare one.
- **The XML arm is not.** Only CloudFront declares it at all, so n=1. What decides it instead is that **no query-protocol service models an access-denied shape** — all 17, STS and IAM and CloudFormation among them — and neither do S3 or EC2, which declare no exception shapes whatsoever. Every service where this code is observable in substrate is in that set, so the value is **observed AWS behaviour, not modelled**: AWS's own CLI output for a refused `sts:AssumeRole` (quoted in #595), and what `s3_publicaccess.go:22-35` already documents for S3.

Keying on wire protocol rather than on a hand-maintained per-service table means a newly registered plugin inherits the right code from its existing classification, with no second table to keep in step. `TestAccessDeniedCode_MatchesTheServiceErrorProtocol` asserts that property over **every** registered service rather than over a sample, so a plugin added later is covered without anyone remembering to extend a list.

## The IAM plugin's own gate is fixed with it

`IAMPlugin.authorize` is a separate gate and built its ~40 denials from a hardcoded `AccessDeniedException`. Fixing only `AuthController` would have left substrate reporting two codes for **one service** — this issue's complaint restated one level down. IAM speaks the query protocol, so its denials are now bare too, routed through a named constant that a test pins against what `accessDeniedCodeFor` derives for `"iam"`.

## Blast radius

`cfn_deployer.go` surfaces a `CheckAccess` denial as a resource's `Error`, and #501 renders that as a `StackEvent` `ResourceStatusReason` — so the **denial text in CloudFormation stack events and `DescribeStackResources` changes**. Those 12 assertions, and the docs in `docs/services.md` and `docs/testing-guide.md` that quoted the old code (including a paragraph that explicitly documented the two-code behaviour as correct), are updated in this same commit.

## Tests

Four new, plus the two-gate agreement test #595 asks for by name: an identity denial and a trust-policy denial on the same role must report one code, so they cannot drift apart again. It asserts they are equal *and* that the shared value is `AccessDenied`, so agreeing on the wrong code would not satisfy it.

## Verification

`gofmt` · `go build` · `go vet` · `golangci-lint run ./...` → 0 issues · `make test` (race) · `make docs-reference-check docs-versions` · `go test -C test/e2e ./...` · `npm --prefix docs run build`.

Live server with the AWS CLI (`AWS_MAX_ATTEMPTS=1`), confirming the split reaches a real client: STS → `AccessDenied`, IAM → `AccessDenied`, SQS → `AccessDeniedException`, DynamoDB → `AccessDeniedException`; and all three gates (identity, trust-policy, IAM-plugin) reporting `AccessDenied` on XML services with the *message* distinguishing which one refused.

**Mutation testing** — 6 mutants, all CAUGHT, tree verified clean after each restore:

| mutation | verdict |
|---|---|
| protocol→code mapping inverted | CAUGHT |
| boundary denial site left on the old literal | CAUGHT |
| policy-decision denial site left on the old literal | CAUGHT |
| IAM plugin constant reverted to the suffixed form | CAUGHT |
| `errProtoS3XML` dropped from the XML arm | CAUGHT |
| `contentType` ignored in the fallback | CAUGHT |

One note on method: the boundary-site mutant first read SURVIVED under a `-run 'Authz|…'` filter that does not match `TestAuthController_*`. Re-run against the whole package it is caught by `TestAuthController_PermissionBoundary_Deny`. The filter was the defect, not the coverage; all six verdicts above are from full-package runs.