### PR TITLE
fix(eventstore): make a configured backend actually persist (#599)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #501 renders that as a `StackEvent` `ResourceStatusReason`, the denial text in
   stack events and `DescribeStackResources` changes with it.
 
+- **A configured event-store backend actually persists: `max_in_memory` triggers a
+  flush, and the server flushes on shutdown** (#599). `MaxEventsInMemory` was
+  declared, documented as *"the maximum number of events held in memory before the
+  store flushes"*, plumbed through config and pinned by a config test — and read
+  nowhere. `EventStore.Flush` had **zero callers** anywhere in the repo, tests and
+  CLI included: the two halves of one unfinished feature. So a run configured with
+  `backend: file` or `backend: sqlite` wrote nothing at all, and because the setting
+  parsed and round-tripped cleanly there was no signal short of grepping for readers.
+  The file and sqlite write paths were, correspondingly, unexercised.
+
+  `RecordEvent` now flushes each time the recorded count crosses a multiple of
+  `max_in_memory`, guarded the same way the adjacent `SnapshotInterval` hint is.
+  **It is a flush threshold, not a cap**: events are never dropped from memory, so
+  replay, `GetStream` and time-travel debugging still see the full history — the
+  distinction #599 flagged as the one that had to be got right, since "flush" meaning
+  *discard* would have broken the derivations that read back over a stream. A flush
+  failure is logged rather than returned, so a disk problem does not turn into an
+  AWS-level error on a caller's request; `substrate server` passes a logger in for
+  exactly that, via the new `WithEventStoreLogger`.
+
+  **`Server.Stop` flushes too**, which the threshold alone does not cover: everything
+  recorded since the last crossing sits in memory until something writes it, and with
+  the default `max_in_memory` of 1000 a short run crossed nothing, so a cleanly
+  terminated server still persisted zero events. `Start` and `Serve` now wait for
+  that flush before returning — `http.Server.Shutdown` releases the serve loop as
+  soon as the listener closes, so without the wait `main` returned and the process
+  exited while the flush was still running. A live `SIGTERM` is what caught this; a
+  test calling `Stop` directly cannot see it, so there is now one that goes through
+  cancellation and asserts the ordering.
+
+- **The event-store flush no longer races its own cursor** (#599). Both persisting
+  backends track how far they have written — `fileBackend` a per-stream map,
+  `sqliteBackend` a single counter — and both wrote it while holding only the event
+  store's **read** lock, which permits concurrent holders and so serializes nothing.
+  `fileBackend`'s struct comment asserted the opposite ("*flush is called while the
+  EventStore read-lock is held so flushCursors can be accessed without a separate
+  lock*"). It was unreachable while `Flush` had no callers; wiring the automatic
+  flush made it live, and `Flush` is exported, so a consumer calling it while
+  requests are still recording hits it too. Each backend now guards its cursor with
+  its own mutex, and the race detector reproduces the old behavior in a few hundred
+  iterations against the tests added with the fix.
+
 ## [v0.95.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test calling `Stop` directly cannot see it, so there is now one that goes through
   cancellation and asserts the ordering.
 
+- **An unparseable `server.shutdown_timeout` fails at startup instead of hanging the
+  process** (found while testing #599). The value was parsed only inside `Stop`, and a
+  `Stop` that failed on it returned **before** closing the listener — so `Start`/`Serve`
+  never unblocked and a `SIGTERM`'d server hung rather than exiting. `read_timeout` and
+  `write_timeout` were already validated up front; `shutdown_timeout` now is too, so an
+  unusable duration is reported where it is visible. Pre-existing, and independent of
+  the flush work, but the shutdown flush waits on `Stop` and would have compounded it.
+
 - **The event-store flush no longer races its own cursor** (#599). Both persisting
   backends track how far they have written — `fileBackend` a per-stream map,
   `sqliteBackend` a single counter — and both wrote it while holding only the event

--- a/cmd/substrate/main.go
+++ b/cmd/substrate/main.go
@@ -121,7 +121,11 @@ configured address will have their requests emulated and recorded.`,
 
 			registry := substrate.NewPluginRegistry()
 			tc := substrate.NewTimeController(time.Now())
-			store := substrate.NewEventStore(cfg.EventStore.ToEventStoreConfig(), substrate.WithTimeController(tc))
+			// The logger is what makes an automatic flush failure visible: the store
+			// records the event either way and does not fail the caller's request, so
+			// without it a persistence problem would be silent (#599).
+			store := substrate.NewEventStore(cfg.EventStore.ToEventStoreConfig(),
+				substrate.WithTimeController(tc), substrate.WithEventStoreLogger(logger))
 			state := substrate.NewMemoryStateManager()
 
 			initCtx := context.Background()

--- a/emulator/eventstore.go
+++ b/emulator/eventstore.go
@@ -34,6 +34,8 @@ type EventStore struct {
 	fileBE       *fileBackend    // file NDJSON backend, non-nil when backend=="file"
 	sqliteBE     *sqliteBackend  // SQLite backend, lazily initialized
 	sqliteInitMu sync.Mutex      // guards lazy sqliteBE init
+	logger       Logger          // reports an automatic flush failure; nil means silent
+	flushMu      sync.Mutex      // serializes automatic flushes; see maybeFlush
 }
 
 // EventStoreConfig controls the behavior of an [EventStore].
@@ -45,8 +47,24 @@ type EventStoreConfig struct {
 	// Zero disables automatic snapshots.
 	SnapshotInterval int
 
-	// MaxEventsInMemory is the maximum number of events held in memory before
-	// the store flushes to the configured backend. Zero means unlimited.
+	// MaxEventsInMemory is the event count at which [EventStore.RecordEvent]
+	// automatically flushes to the configured backend. Zero disables the trigger.
+	//
+	// It is a *flush* threshold, not a cap: events are never dropped from memory,
+	// so replay, [EventStore.GetStream] and time-travel debugging see the full
+	// history whether a flush has happened or not. Flushing only makes the events
+	// durable earlier than an explicit [EventStore.Flush] would. That is the point
+	// — a run that ends without one (a crash, a killed process, a test binary that
+	// never calls it) still has its events on disk up to the last threshold
+	// crossing.
+	//
+	// The flush fires each time the count crosses a multiple of the value, the same
+	// shape as SnapshotInterval, so a long run flushes repeatedly rather than once.
+	// A flush error does not fail the caller's API call — a recorded observation
+	// must not turn a persistence hiccup into a request failure — so it is reported
+	// through the logger given to [WithEventStoreLogger] and otherwise silent.
+	//
+	// A no-op for Backend "memory", which has nowhere to flush to.
 	MaxEventsInMemory int
 
 	// Backend selects the storage driver: "memory", "sqlite", or "file".
@@ -87,6 +105,13 @@ func WithStateManager(sm StateManager) EventStoreOption {
 // event timestamps use the controlled clock rather than time.Now().
 func WithTimeController(tc *TimeController) EventStoreOption {
 	return func(e *EventStore) { e.tc = tc }
+}
+
+// WithEventStoreLogger attaches a [Logger] the store uses to report a failure it
+// deliberately does not propagate — an automatic flush that could not write (see
+// [EventStoreConfig.MaxEventsInMemory]). Without one such a failure is silent.
+func WithEventStoreLogger(l Logger) EventStoreOption {
+	return func(e *EventStore) { e.logger = l }
 }
 
 // now returns the current time from the controlled clock, or time.Now() when
@@ -293,7 +318,42 @@ func (e *EventStore) RecordEvent(_ context.Context, event *Event) error {
 		}
 	}
 
+	e.maybeFlush(n)
+
 	return nil
+}
+
+// maybeFlush persists to the backend when the recorded count n has crossed a
+// multiple of [EventStoreConfig.MaxEventsInMemory] (#599). n is read under the
+// write lock by the caller and passed in, so two concurrent recorders cannot both
+// compute the same n and flush twice.
+//
+// Called after RecordEvent releases e.mu, because Flush takes e.mu.RLock() and Go's
+// RWMutex is not upgradable — the same reason the SnapshotInterval hint above is
+// sent outside the lock.
+//
+// A flush error is logged, not returned. RecordEvent's contract is that the
+// observation was recorded, and it was: the events are in memory and a later flush
+// will still write them. Failing the caller's API call because the disk hiccuped
+// would report an infrastructure fault as an AWS-level error, which is the same
+// reasoning AuthController applies to a failed state read.
+func (e *EventStore) maybeFlush(n int) {
+	threshold := e.config.MaxEventsInMemory
+	if threshold <= 0 || n%threshold != 0 {
+		return
+	}
+
+	// Serialized so two crossings cannot interleave inside the backends. Both track
+	// a flush cursor they advance after writing, and Flush holds only a read lock,
+	// which permits concurrent holders — so without this two flushes could read the
+	// same cursor and write the same events twice.
+	e.flushMu.Lock()
+	defer e.flushMu.Unlock()
+
+	if err := e.Flush(context.Background()); err != nil && e.logger != nil {
+		e.logger.Warn("eventstore: automatic flush failed",
+			"backend", e.config.Backend, "events", n, "err", err)
+	}
 }
 
 // RecordRequest is a convenience wrapper that builds an [Event] from a
@@ -601,8 +661,19 @@ func (i *ReplayIterator) Reset() {
 	i.position = 0
 }
 
-// Flush persists in-memory events to the configured backend.
-// It is a no-op for the "memory" backend.
+// Flush persists in-memory events to the configured backend, appending only those
+// written since the last flush.
+//
+// It never discards anything: the store keeps every event in memory afterwards, so
+// replay, [EventStore.GetStream] and time-travel debugging are unaffected by
+// whether a flush has run. Calling it repeatedly is safe and does not duplicate
+// events — each backend tracks how far it has written.
+//
+// A no-op for the "memory" backend, which has nowhere to persist to. Since #599 it
+// is also called automatically by [EventStore.RecordEvent] when
+// [EventStoreConfig.MaxEventsInMemory] is set, so an explicit call is only needed
+// to force a flush at a point of the caller's choosing (before reading the files,
+// or at shutdown).
 func (e *EventStore) Flush(ctx context.Context) error {
 	switch e.config.Backend {
 	case "memory":

--- a/emulator/eventstore_file.go
+++ b/emulator/eventstore_file.go
@@ -7,18 +7,27 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // fileBackend persists events as NDJSON files under a directory tree.
 // Each stream is stored in its own file: <persistPath>/events/<stream_id>.ndjson
 // Files are rotated to <stream_id>.ndjson.1, .2, … when they exceed
-// maxFileSizeMB. flush is called while the EventStore read-lock is held so
-// flushCursors can be accessed without a separate lock.
+// maxFileSizeMB.
+//
+// flush and load both write flushCursors, and both run while the EventStore holds
+// only its *read* lock — which permits concurrent holders, so that lock does not
+// serialize them. This struct's comment previously claimed it did. That was
+// harmless while Flush had no callers; wiring the automatic flush (#599) made it a
+// live data race, so the map has its own mutex.
 type fileBackend struct {
 	persistPath   string
 	maxFileSizeMB int
 	serializer    Serializer
-	flushCursors  map[string]int64 // stream_id → count already flushed
+
+	// mu guards flushCursors, which flush advances and load rebuilds.
+	mu           sync.Mutex
+	flushCursors map[string]int64 // stream_id → count already flushed
 }
 
 // newFileBackend creates a fileBackend that stores events under path.
@@ -32,9 +41,14 @@ func newFileBackend(path string, maxMB int, s Serializer) *fileBackend {
 }
 
 // flush appends any events not yet persisted to their respective NDJSON files.
-// streams is the EventStore's stream map; it is accessed under the store's
-// read-lock so this method needs no additional locking.
+// streams is the EventStore's stream map, read under the store's read-lock by the
+// caller. f.mu guards this backend's own cursor map for the whole write, so a
+// concurrent flush cannot read a cursor this one is about to advance and write the
+// same events a second time.
 func (f *fileBackend) flush(streams map[string][]*Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	eventsDir := filepath.Join(f.persistPath, "events")
 	if err := os.MkdirAll(eventsDir, 0o750); err != nil {
 		return fmt.Errorf("create events dir: %w", err)
@@ -119,12 +133,16 @@ func (f *fileBackend) load() ([]*Event, error) {
 		events = append(events, evs...)
 	}
 
-	// Update flush cursors so a subsequent flush only appends new events.
+	// Update flush cursors so a subsequent flush only appends new events. Under the
+	// same lock flush takes, because a load concurrent with a flush would otherwise
+	// write this map while flush was reading it.
+	f.mu.Lock()
 	for _, ev := range events {
 		if ev.StreamID != "" {
 			f.flushCursors[ev.StreamID]++
 		}
 	}
+	f.mu.Unlock()
 
 	return events, nil
 }

--- a/emulator/eventstore_maxinmemory_test.go
+++ b/emulator/eventstore_maxinmemory_test.go
@@ -372,6 +372,168 @@ func TestEventStore_MaxEventsInMemory_SQLiteFlushesToo(t *testing.T) {
 		"the automatic flush must reach sqlite, and four crossings must not duplicate")
 }
 
+// warnCollector is a [emulator.Logger] that keeps the Warn messages it is given, so
+// a test can assert on a failure the store deliberately does not return.
+type warnCollector struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *warnCollector) Debug(_ string, _ ...any) {}
+func (l *warnCollector) Info(_ string, _ ...any)  {}
+func (l *warnCollector) Error(_ string, _ ...any) {}
+
+func (l *warnCollector) Warn(msg string, _ ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, msg)
+}
+
+func (l *warnCollector) messages() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.warns...)
+}
+
+// TestEventStore_MaxEventsInMemory_FlushFailureIsLoggedNotReturned pins the contract
+// that decides where a persistence failure surfaces. RecordEvent promises the
+// observation was recorded, and it was — the events are in memory and a later flush
+// still writes them — so failing the caller's API call because the disk hiccuped
+// would report an infrastructure fault as an AWS-level error. It is reported through
+// the logger instead, which is what [emulator.WithEventStoreLogger] exists for:
+// without one the failure is silent, and that silence is what #599 was.
+func TestEventStore_MaxEventsInMemory_FlushFailureIsLoggedNotReturned(t *testing.T) {
+	// A regular file where the store expects to create its directory, so the flush
+	// fails on every attempt for a reason that has nothing to do with the caller.
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocked")
+	require.NoError(t, os.WriteFile(blocked, []byte("not a directory"), 0o600))
+
+	logger := &warnCollector{}
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "file",
+		PersistPath:       blocked,
+		MaxEventsInMemory: 2,
+	}, emulator.WithEventStoreLogger(logger))
+	ctx := context.Background()
+
+	// The record itself must succeed even though its flush cannot.
+	for range 4 {
+		require.NoError(t, store.RecordEvent(ctx, &emulator.Event{
+			StreamID: "blocked", Service: "s3", Operation: "Put", Timestamp: time.Now(),
+		}))
+	}
+
+	assert.NotEmpty(t, logger.messages(),
+		"a flush that could not write must be reported through the logger")
+
+	// And the events are still there to be flushed later, which is why failing the
+	// caller would have been the wrong trade.
+	events, err := store.GetEvents(ctx, emulator.EventFilter{})
+	require.NoError(t, err)
+	assert.Len(t, events, 4)
+
+	// An explicit Flush, by contrast, does return the error — its caller asked for
+	// the write and can act on it.
+	require.Error(t, store.Flush(ctx))
+}
+
+// TestEventStore_MaxEventsInMemory_FlushFailureWithoutALoggerIsSilent is the other
+// half: the logger is optional, so a store built without one must degrade to silence
+// rather than panicking on a nil interface.
+func TestEventStore_MaxEventsInMemory_FlushFailureWithoutALoggerIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocked")
+	require.NoError(t, os.WriteFile(blocked, []byte("not a directory"), 0o600))
+
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "file",
+		PersistPath:       blocked,
+		MaxEventsInMemory: 2,
+	})
+
+	recordN(t, store, "blocked", 4)
+
+	events, err := store.GetEvents(context.Background(), emulator.EventFilter{})
+	require.NoError(t, err)
+	assert.Len(t, events, 4)
+}
+
+// TestServer_Stop_ReportsAFailedFlush pins the opposite choice at shutdown. An
+// automatic flush failure is logged because a request is waiting on it; at shutdown
+// nothing is, and the events are about to be lost with the process, so the error goes
+// to Stop's caller.
+func TestServer_Stop_ReportsAFailedFlush(t *testing.T) {
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocked")
+	require.NoError(t, os.WriteFile(blocked, []byte("not a directory"), 0o600))
+
+	cfg := emulator.DefaultConfig()
+	cfg.EventStore.Enabled = true
+	cfg.EventStore.Backend = "file"
+	cfg.EventStore.PersistPath = blocked
+
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	srv := emulator.NewServer(*cfg, emulator.NewPluginRegistry(), store,
+		emulator.NewMemoryStateManager(), emulator.NewTimeController(time.Now()),
+		emulator.NewDefaultLogger(slog.LevelError, false))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	baseURL := fmt.Sprintf("http://%s", ln.Addr().String())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	served := make(chan error, 1)
+	go func() { served <- srv.Serve(ctx, ln) }()
+
+	waitForHealth(t, baseURL)
+	recordN(t, store, "blocked", 1)
+
+	err = srv.Stop(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "flush event store")
+
+	cancel()
+	require.NoError(t, <-served)
+}
+
+// TestServer_UnparseableShutdownTimeoutIsAStartupError covers a hang found while
+// testing the shutdown flush, and present on main before this change: shutdown_timeout
+// was parsed only inside Stop, and a Stop that failed on it returned *before* closing
+// the listener — so Serve never unblocked and the process hung on SIGTERM instead of
+// exiting. Adding the flush wait would have compounded it.
+//
+// Start and Serve already parse read_timeout and write_timeout up front; this one is
+// now parsed with them, so an unusable value fails at startup where it is visible.
+func TestServer_UnparseableShutdownTimeoutIsAStartupError(t *testing.T) {
+	cfg := emulator.DefaultConfig()
+	cfg.Server.ShutdownTimeout = "not-a-duration"
+
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	srv := emulator.NewServer(*cfg, emulator.NewPluginRegistry(), store,
+		emulator.NewMemoryStateManager(), emulator.NewTimeController(time.Now()),
+		emulator.NewDefaultLogger(slog.LevelError, false))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	// Returns immediately rather than serving, so there is no hang to wait out.
+	served := make(chan error, 1)
+	go func() { served <- srv.Serve(context.Background(), ln) }()
+
+	select {
+	case serveErr := <-served:
+		require.Error(t, serveErr)
+		assert.Contains(t, serveErr.Error(), "parse shutdown_timeout")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Serve neither served nor reported the bad shutdown_timeout")
+	}
+}
+
 // TestEventStore_MaxEventsInMemory_ConcurrentRecordersDoNotRace is why the file and
 // sqlite backends gained their own mutexes. Their flush methods advance a cursor
 // while the EventStore holds only its *read* lock, which permits concurrent

--- a/emulator/eventstore_maxinmemory_test.go
+++ b/emulator/eventstore_maxinmemory_test.go
@@ -1,0 +1,516 @@
+package emulator_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// #599: MaxEventsInMemory was declared, plumbed through the config and asserted by
+// a config test, but read nowhere — and EventStore.Flush had zero callers. Two
+// halves of one unfinished feature: a run configured with a cap persisted nothing
+// unless the consumer knew to call Flush itself, so a crash or a test binary that
+// simply exited lost every event, with the setting reporting otherwise.
+
+// recordN records n events on one stream, so a test reads as "the count crossed the
+// threshold" rather than as a loop.
+func recordN(t *testing.T, store *emulator.EventStore, streamID string, n int) {
+	t.Helper()
+	ctx := context.Background()
+	for range n {
+		require.NoError(t, store.RecordEvent(ctx, &emulator.Event{
+			StreamID: streamID, Service: "s3", Operation: "Put", Timestamp: time.Now(),
+		}))
+	}
+}
+
+// ndjsonLines counts persisted events across every NDJSON file, rotations included.
+// The backend writes one event per line with a trailing newline, so newlines are the
+// event count. Counting bytes on disk rather than loading through a second store
+// keeps the assertion on what was actually persisted — and is what distinguishes an
+// append from a re-write of the whole stream.
+func ndjsonLines(t *testing.T, dir string) int {
+	t.Helper()
+	eventsDir := filepath.Join(dir, "events")
+	entries, err := os.ReadDir(eventsDir)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	require.NoError(t, err)
+
+	total := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join(eventsDir, entry.Name())) //nolint:gosec // test-owned temp dir
+		require.NoError(t, readErr)
+		total += strings.Count(string(data), "\n")
+	}
+	return total
+}
+
+// TestEventStore_MaxEventsInMemory_FlushesWithoutAnExplicitCall is #599's point.
+// Nothing here calls Flush.
+func TestEventStore_MaxEventsInMemory_FlushesWithoutAnExplicitCall(t *testing.T) {
+	dir := t.TempDir()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "file",
+		PersistPath:       dir,
+		MaxEventsInMemory: 5,
+	})
+
+	// Below the threshold: nothing is written yet, so the test cannot pass by the
+	// store having flushed on every single event.
+	recordN(t, store, "auto", 4)
+	assert.Equal(t, 0, ndjsonLines(t, dir),
+		"a flush before the threshold would make the threshold meaningless")
+
+	// The crossing.
+	recordN(t, store, "auto", 1)
+	assert.Equal(t, 5, ndjsonLines(t, dir), "crossing the threshold must flush")
+}
+
+// TestEventStore_MaxEventsInMemory_FlushesRepeatedly pins that the trigger fires on
+// every crossing rather than once. A long-running server is the case that matters:
+// flushing only at the first threshold would persist the first N events and then
+// silently stop.
+func TestEventStore_MaxEventsInMemory_FlushesRepeatedly(t *testing.T) {
+	dir := t.TempDir()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "file",
+		PersistPath:       dir,
+		MaxEventsInMemory: 10,
+	})
+
+	recordN(t, store, "repeat", 10)
+	require.Equal(t, 10, ndjsonLines(t, dir))
+
+	recordN(t, store, "repeat", 10)
+	assert.Equal(t, 20, ndjsonLines(t, dir), "the second crossing must flush too")
+
+	// And the events between crossings are not lost — they are in memory, and the
+	// next crossing writes them.
+	recordN(t, store, "repeat", 7)
+	assert.Equal(t, 20, ndjsonLines(t, dir), "no crossing yet")
+	recordN(t, store, "repeat", 3)
+	assert.Equal(t, 30, ndjsonLines(t, dir),
+		"the crossing writes everything recorded since the last one")
+}
+
+// TestEventStore_MaxEventsInMemory_AppendsRatherThanDuplicating pins the cursor
+// contract the repeated trigger now depends on. The backend writes events[cursor:]
+// and advances the cursor, so a flush that re-wrote from zero would multiply every
+// event by the number of crossings — and the count is the only thing that shows it.
+func TestEventStore_MaxEventsInMemory_AppendsRatherThanDuplicating(t *testing.T) {
+	dir := t.TempDir()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "file",
+		PersistPath:       dir,
+		MaxEventsInMemory: 5,
+	})
+
+	recordN(t, store, "dup", 25)
+	assert.Equal(t, 25, ndjsonLines(t, dir),
+		"five crossings must produce 25 lines, not 75")
+
+	// An explicit Flush after the automatic ones must also add nothing.
+	require.NoError(t, store.Flush(context.Background()))
+	assert.Equal(t, 25, ndjsonLines(t, dir), "a redundant flush must be a no-op")
+}
+
+// TestEventStore_MaxEventsInMemory_KeepsTheFullHistoryInMemory is the property that
+// makes this safe for replay. MaxEventsInMemory is a *flush* threshold, not a cap:
+// the events stay in memory, so replay and time-travel debugging see the whole run.
+// If it ever became an eviction bound, this is the test that would fail.
+func TestEventStore_MaxEventsInMemory_KeepsTheFullHistoryInMemory(t *testing.T) {
+	dir := t.TempDir()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "file",
+		PersistPath:       dir,
+		MaxEventsInMemory: 5,
+	})
+	ctx := context.Background()
+
+	recordN(t, store, "history", 23)
+
+	events, err := store.GetEvents(ctx, emulator.EventFilter{})
+	require.NoError(t, err)
+	assert.Len(t, events, 23, "flushing must not discard events from memory")
+
+	stream, err := store.GetStream(ctx, "history")
+	require.NoError(t, err)
+	assert.Len(t, stream, 23, "the stream must still replay in full")
+
+	// Sequence numbers are unbroken, which is what a replay walks.
+	for i, ev := range stream {
+		require.Equal(t, int64(i), ev.Sequence)
+	}
+}
+
+// TestEventStore_MaxEventsInMemory_MemoryBackendIsANoOp pins that a cap set on the
+// memory backend records normally and does not error. There is nowhere to flush to,
+// and the default test server runs on this backend — a trigger that failed here
+// would break every consumer's test rather than only a persistence one.
+func TestEventStore_MaxEventsInMemory_MemoryBackendIsANoOp(t *testing.T) {
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "memory",
+		MaxEventsInMemory: 3,
+	})
+
+	recordN(t, store, "mem", 10)
+
+	events, err := store.GetEvents(context.Background(), emulator.EventFilter{})
+	require.NoError(t, err)
+	assert.Len(t, events, 10)
+}
+
+// TestEventStore_MaxEventsInMemory_ZeroDisablesTheTrigger is the control for the
+// tests above: with no threshold set, nothing is written until Flush is called, so
+// the existing explicit-flush behavior is unchanged for every consumer that does
+// not set the value.
+func TestEventStore_MaxEventsInMemory_ZeroDisablesTheTrigger(t *testing.T) {
+	dir := t.TempDir()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:     true,
+		Backend:     "file",
+		PersistPath: dir,
+	})
+
+	recordN(t, store, "off", 50)
+	assert.Equal(t, 0, ndjsonLines(t, dir), "zero must disable the trigger")
+
+	require.NoError(t, store.Flush(context.Background()))
+	assert.Equal(t, 50, ndjsonLines(t, dir))
+}
+
+// TestServer_Stop_FlushesTheEventStore covers the threshold's blind spot, which is
+// the other half of #599: the trigger only fires on a crossing, so everything
+// recorded after the last one lives in memory until something flushes. Nothing did
+// — Flush had zero callers — so a server exiting cleanly dropped them, and with the
+// default max_in_memory of 1000 a short recorded run persisted nothing at all
+// despite a file backend being configured. Server.Stop now flushes.
+//
+// The threshold is left at zero here deliberately: the events reach disk because of
+// the shutdown flush and nothing else.
+func TestServer_Stop_FlushesTheEventStore(t *testing.T) {
+	dir := t.TempDir()
+	cfg := emulator.DefaultConfig()
+	cfg.EventStore.Enabled = true
+	cfg.EventStore.Backend = "file"
+	cfg.EventStore.PersistPath = dir
+	cfg.EventStore.MaxInMemory = 0
+
+	registry := emulator.NewPluginRegistry()
+	registry.Register(&serverPlugin{
+		serviceName: "dynamodb",
+		resp: &emulator.AWSResponse{
+			StatusCode: 200, Headers: map[string]string{}, Body: []byte(`{}`),
+		},
+	})
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	srv := emulator.NewServer(*cfg, registry, store,
+		emulator.NewMemoryStateManager(), emulator.NewTimeController(time.Now()),
+		emulator.NewDefaultLogger(slog.LevelInfo, false))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	baseURL := fmt.Sprintf("http://%s", ln.Addr().String())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = srv.Serve(ctx, ln)
+	}()
+
+	waitForHealth(t, baseURL)
+
+	const requests = 3
+	for range requests {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/",
+			strings.NewReader("{}"))
+		require.NoError(t, reqErr)
+		req.Header.Set("X-Amz-Target", "DynamoDB_20120810.GetItem")
+		resp, doErr := http.DefaultClient.Do(req)
+		require.NoError(t, doErr)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	require.Equal(t, 0, ndjsonLines(t, dir),
+		"with no threshold set nothing should be persisted before shutdown")
+
+	require.NoError(t, srv.Stop(context.Background()))
+	<-done
+
+	assert.Equal(t, requests, ndjsonLines(t, dir),
+		"shutdown must persist the events recorded since the last flush")
+}
+
+// TestServer_Serve_WaitsForTheShutdownFlush is the regression test for what the
+// test above could not see. Stop's flush is correct, but on the path a real server
+// takes — SIGTERM cancels the context, a goroutine calls Stop — http.Server.Shutdown
+// makes Serve return the moment the listener closes, while the flush is still
+// running. main then returned and the process exited, so a SIGTERM'd server still
+// dropped everything since the last crossing. A live SIGTERM found it; calling Stop
+// directly never could.
+//
+// The assertion is therefore about ordering, not about flushing: by the time Serve
+// has returned, the events must already be on disk.
+func TestServer_Serve_WaitsForTheShutdownFlush(t *testing.T) {
+	dir := t.TempDir()
+	cfg := emulator.DefaultConfig()
+	cfg.EventStore.Enabled = true
+	cfg.EventStore.Backend = "file"
+	cfg.EventStore.PersistPath = dir
+	cfg.EventStore.MaxInMemory = 0
+
+	registry := emulator.NewPluginRegistry()
+	registry.Register(&serverPlugin{
+		serviceName: "dynamodb",
+		resp: &emulator.AWSResponse{
+			StatusCode: 200, Headers: map[string]string{}, Body: []byte(`{}`),
+		},
+	})
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	srv := emulator.NewServer(*cfg, registry, store,
+		emulator.NewMemoryStateManager(), emulator.NewTimeController(time.Now()),
+		emulator.NewDefaultLogger(slog.LevelInfo, false))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	baseURL := fmt.Sprintf("http://%s", ln.Addr().String())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	served := make(chan error, 1)
+	go func() { served <- srv.Serve(ctx, ln) }()
+
+	waitForHealth(t, baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/",
+		strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.GetItem")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	// What a SIGTERM does.
+	cancel()
+	require.NoError(t, <-served)
+
+	// Read immediately, with no sleep and no wait for the Stop goroutine: Serve
+	// returning must already imply the flush completed. Before the awaitStop fix
+	// this read won the race and saw an empty directory.
+	assert.Positive(t, ndjsonLines(t, dir),
+		"Serve must not return until the shutdown flush has persisted its events")
+}
+
+// waitForHealth blocks until the server answers, so a test does not race the bind.
+func waitForHealth(t *testing.T, baseURL string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/health") //nolint:noctx // liveness probe, no ctx to thread
+		if err == nil {
+			require.NoError(t, resp.Body.Close())
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("server at %s did not become healthy", baseURL)
+}
+
+// TestEventStore_MaxEventsInMemory_SQLiteFlushesToo covers the other persisting
+// backend. It matters on its own because sqlite tracks a single flushCursor rather
+// than a per-stream map, and because its flush runs inside a transaction — a
+// threshold trigger that worked for NDJSON files but not here would leave the
+// documented setting half-true.
+func TestEventStore_MaxEventsInMemory_SQLiteFlushesToo(t *testing.T) {
+	dir := t.TempDir()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "sqlite",
+		PersistPath:       dir,
+		DSN:               "auto.db",
+		MaxEventsInMemory: 5,
+	})
+	ctx := context.Background()
+
+	// No explicit Flush anywhere in this test — only Close, which does not flush.
+	recordN(t, store, "sqlite-auto", 20)
+	require.NoError(t, store.Close())
+
+	store2 := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled: true, Backend: "sqlite", PersistPath: dir, DSN: "auto.db",
+	})
+	require.NoError(t, store2.Load(ctx))
+	t.Cleanup(func() { require.NoError(t, store2.Close()) })
+
+	events, err := store2.GetEvents(ctx, emulator.EventFilter{Service: "s3"})
+	require.NoError(t, err)
+	assert.Len(t, events, 20,
+		"the automatic flush must reach sqlite, and four crossings must not duplicate")
+}
+
+// TestEventStore_MaxEventsInMemory_ConcurrentRecordersDoNotRace is why the file and
+// sqlite backends gained their own mutexes. Their flush methods advance a cursor
+// while the EventStore holds only its *read* lock, which permits concurrent
+// holders — so the struct comment claiming that lock serialized them was wrong. It
+// was harmless while Flush had no callers; the automatic trigger made it live.
+//
+// Worth running under -race specifically, which is what make test does. Without the
+// backend mutex the detector reports a write/write on flushCursors here.
+func TestEventStore_MaxEventsInMemory_ConcurrentRecordersDoNotRace(t *testing.T) {
+	dir := t.TempDir()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "file",
+		PersistPath:       dir,
+		MaxEventsInMemory: 2,
+	})
+	ctx := context.Background()
+
+	const writers, each = 8, 25
+
+	var wg sync.WaitGroup
+	for w := range writers {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			// A stream per writer, so the flushes contend over several cursor
+			// entries rather than one — a single key would still race, but the map
+			// itself is what the detector reports on.
+			streamID := fmt.Sprintf("racer-%d", w)
+			for range each {
+				require.NoError(t, store.RecordEvent(ctx, &emulator.Event{
+					StreamID: streamID, Service: "s3", Operation: "Put", Timestamp: time.Now(),
+				}))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Every event is in memory regardless of how the flushes interleaved.
+	events, err := store.GetEvents(ctx, emulator.EventFilter{})
+	require.NoError(t, err)
+	assert.Len(t, events, writers*each)
+
+	// And a final flush leaves exactly one line per event: no crossing wrote a
+	// range another had already written.
+	require.NoError(t, store.Flush(ctx))
+	assert.Equal(t, writers*each, ndjsonLines(t, dir),
+		"interleaved flushes must not duplicate events")
+}
+
+// TestEventStore_ExplicitFlushConcurrentWithRecording is the test that actually
+// reaches the backend cursor mutex, and it exists because the concurrency test above
+// does not: the automatic path is serialized by the store's own flushMu, so removing
+// the backend lock leaves that test passing. Flush is exported, though, and a
+// consumer calling it while requests are still being recorded takes only the store's
+// *read* lock — which permits concurrent holders. That is the live race (#599), and
+// under -race this reproduces it in a few hundred iterations.
+func TestEventStore_ExplicitFlushConcurrentWithRecording(t *testing.T) {
+	dir := t.TempDir()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "file",
+		PersistPath:       dir,
+		MaxEventsInMemory: 2,
+	})
+	ctx := context.Background()
+
+	const events = 200
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range events {
+			require.NoError(t, store.RecordEvent(ctx, &emulator.Event{
+				StreamID: "concurrent", Service: "s3", Operation: "Put", Timestamp: time.Now(),
+			}))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range events {
+			require.NoError(t, store.Flush(ctx))
+		}
+	}()
+	wg.Wait()
+
+	require.NoError(t, store.Flush(ctx))
+	assert.Equal(t, events, ndjsonLines(t, dir),
+		"a flush racing a recorder must still write each event exactly once")
+}
+
+// TestEventStore_SQLite_ExplicitFlushConcurrentWithRecording is the sqlite half of
+// the test above. It needs its own case because the backends guard different things:
+// the file backend a per-stream map, sqlite a single int64 cursor. Both were written
+// under the store's read lock alone, and a test covering one leaves the other's lock
+// removable without failing anything.
+func TestEventStore_SQLite_ExplicitFlushConcurrentWithRecording(t *testing.T) {
+	dir := t.TempDir()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled:           true,
+		Backend:           "sqlite",
+		PersistPath:       dir,
+		DSN:               "concurrent.db",
+		MaxEventsInMemory: 2,
+	})
+	ctx := context.Background()
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	const events = 200
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range events {
+			require.NoError(t, store.RecordEvent(ctx, &emulator.Event{
+				StreamID: "concurrent", Service: "s3", Operation: "Put", Timestamp: time.Now(),
+			}))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range events {
+			require.NoError(t, store.Flush(ctx))
+		}
+	}()
+	wg.Wait()
+
+	require.NoError(t, store.Flush(ctx))
+
+	store2 := emulator.NewEventStore(emulator.EventStoreConfig{
+		Enabled: true, Backend: "sqlite", PersistPath: dir, DSN: "concurrent.db",
+	})
+	require.NoError(t, store2.Load(ctx))
+	t.Cleanup(func() { require.NoError(t, store2.Close()) })
+
+	persisted, err := store2.GetEvents(ctx, emulator.EventFilter{Service: "s3"})
+	require.NoError(t, err)
+	assert.Len(t, persisted, events,
+		"a flush racing a recorder must persist each event exactly once")
+}

--- a/emulator/eventstore_sqlite.go
+++ b/emulator/eventstore_sqlite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sync"
 	"time"
 
 	_ "modernc.org/sqlite" // register the sqlite3 driver
@@ -37,9 +38,17 @@ CREATE INDEX IF NOT EXISTS idx_events_operation ON events(operation);
 `
 
 // sqliteBackend persists events and snapshots to a SQLite database.
+//
+// flush and load both write flushCursor while the EventStore holds only its read
+// lock, which permits concurrent holders and so does not serialize them — the same
+// hazard fileBackend has, and it became live for the same reason (#599). mu guards
+// the cursor and the write it decides.
 type sqliteBackend struct {
-	db          *sql.DB
-	serializer  Serializer
+	db         *sql.DB
+	serializer Serializer
+
+	// mu guards flushCursor, which flush advances and load rebuilds.
+	mu          sync.Mutex
 	flushCursor int64 // count of events already flushed
 }
 
@@ -61,7 +70,14 @@ func newSQLiteBackend(dsn string, s Serializer) (*sqliteBackend, error) {
 
 // flush writes events and snapshots that have not yet been persisted.
 // INSERT OR IGNORE ensures idempotency.
+//
+// Held under sb.mu for the whole transaction, so a concurrent flush cannot read
+// the cursor this one is about to advance. INSERT OR IGNORE would absorb the
+// duplicate rows, but the cursor write itself is still a race.
 func (sb *sqliteBackend) flush(ctx context.Context, events []*Event, snapshots map[string]*Snapshot) error {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+
 	tx, err := sb.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -177,7 +193,12 @@ func (sb *sqliteBackend) load(ctx context.Context) ([]*Event, map[string]*Snapsh
 		return nil, nil, fmt.Errorf("close snapshot rows: %w", closeErr)
 	}
 
+	// Under the same lock flush takes, so a load concurrent with a flush cannot
+	// write the cursor while flush is reading it.
+	sb.mu.Lock()
 	sb.flushCursor = int64(len(events))
+	sb.mu.Unlock()
+
 	return events, snapshots, nil
 }
 

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -123,17 +123,12 @@ func (s *Server) Start(ctx context.Context) error {
 
 	s.logger.Info("substrate server starting", "address", s.config.Server.Address)
 
-	// Shutdown when context is canceled.
-	go func() {
-		<-ctx.Done()
-		if stopErr := s.Stop(context.Background()); stopErr != nil {
-			s.logger.Error("graceful shutdown error", "err", stopErr)
-		}
-	}()
+	done := s.stopOnCancel(ctx)
 
 	if err := s.httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("listen and serve: %w", err)
 	}
+	s.awaitStop(ctx, done)
 	return nil
 }
 
@@ -159,21 +154,64 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 
 	s.logger.Info("substrate server starting", "address", ln.Addr().String())
 
+	done := s.stopOnCancel(ctx)
+
+	if err := s.httpSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("serve: %w", err)
+	}
+	s.awaitStop(ctx, done)
+	return nil
+}
+
+// stopOnCancel calls [Server.Stop] when ctx is canceled, returning a channel closed
+// once that Stop has returned. Pass it to [Server.awaitStop].
+func (s *Server) stopOnCancel(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		<-ctx.Done()
 		if stopErr := s.Stop(context.Background()); stopErr != nil {
 			s.logger.Error("graceful shutdown error", "err", stopErr)
 		}
 	}()
+	return done
+}
 
-	if err := s.httpSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("serve: %w", err)
+// awaitStop waits for a cancellation-triggered [Server.Stop] to finish before Start
+// or Serve returns.
+//
+// Necessary because http.Server.Shutdown makes Serve return as soon as the listener
+// closes, while the rest of Stop — notably the event-store flush (#599) — is still
+// running on the goroutine. Without this wait, main returns and the process exits
+// first, so a SIGTERM'd server dropped everything recorded since the last automatic
+// flush. The unit test for Stop could not catch that: it calls Stop directly.
+//
+// Bounded by the same ShutdownTimeout Stop honors, so a wedged flush delays exit
+// rather than hanging it. Only waits when ctx is what ended the serve loop; a Stop
+// called directly by the caller has already completed by the time it returns.
+func (s *Server) awaitStop(ctx context.Context, done <-chan struct{}) {
+	if ctx.Err() == nil {
+		return
 	}
-	return nil
+	timeout, err := time.ParseDuration(s.config.Server.ShutdownTimeout)
+	if err != nil {
+		// Unparseable: Stop will have failed on the same value and logged it, so
+		// there is nothing left to wait for. Bound the wait anyway rather than
+		// blocking forever on a channel that will not close.
+		timeout = time.Second
+	}
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		s.logger.Warn("shutdown did not finish within shutdown_timeout",
+			"timeout", timeout)
+	}
 }
 
 // Stop initiates graceful shutdown, waiting up to the configured
-// ShutdownTimeout for active connections to finish.
+// ShutdownTimeout for active connections to finish, then flushing the event store
+// so events recorded since the last automatic flush are persisted rather than lost
+// on exit.
 func (s *Server) Stop(ctx context.Context) error {
 	if s.httpSrv == nil {
 		return nil
@@ -186,7 +224,30 @@ func (s *Server) Stop(ctx context.Context) error {
 	defer cancel()
 
 	s.logger.Info("substrate server shutting down")
-	return s.httpSrv.Shutdown(shutCtx)
+	if err := s.httpSrv.Shutdown(shutCtx); err != nil {
+		return fmt.Errorf("shutdown: %w", err)
+	}
+
+	// Persist what the automatic threshold has not reached yet (#599). Without this
+	// the events recorded since the last crossing are lost on exit, and with the
+	// default max_in_memory of 1000 a short run would persist nothing at all despite
+	// a file or sqlite backend being configured. Run after Shutdown returns, so no
+	// request is still recording. A failure here loses recorded history rather than
+	// breaking a request, so unlike an automatic flush it is reported to the caller.
+	//
+	// On its own deadline rather than shutCtx, which Shutdown may have already
+	// consumed — a flush that inherited an expired context would fail every time the
+	// drain used its full budget, which is exactly when there is most to write. And
+	// detached from ctx's cancellation, because the usual caller is the signal
+	// handler, whose ctx is canceled by definition.
+	if s.store != nil {
+		flushCtx, flushCancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownTimeout)
+		defer flushCancel()
+		if err := s.store.Flush(flushCtx); err != nil {
+			return fmt.Errorf("flush event store: %w", err)
+		}
+	}
+	return nil
 }
 
 // ServeHTTP implements [http.Handler], allowing the server to be used directly

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -104,6 +104,12 @@ func NewServer(
 // Start binds the listener and begins accepting requests. It blocks until ctx
 // is canceled or an unrecoverable error occurs. A nil error is returned only
 // when shutdown is initiated via ctx cancellation or [Server.Stop].
+//
+// All three server timeouts are parsed up front, so an unusable duration is a
+// startup error rather than a surprise later. shutdown_timeout in particular is only
+// read by Stop, and a Stop that failed on it returned before closing the listener —
+// which left Start blocked forever on a canceled context, and now with the flush wait
+// would have blocked there too.
 func (s *Server) Start(ctx context.Context) error {
 	readTimeout, err := time.ParseDuration(s.config.Server.ReadTimeout)
 	if err != nil {
@@ -112,6 +118,9 @@ func (s *Server) Start(ctx context.Context) error {
 	writeTimeout, err := time.ParseDuration(s.config.Server.WriteTimeout)
 	if err != nil {
 		return fmt.Errorf("parse write_timeout: %w", err)
+	}
+	if _, err := time.ParseDuration(s.config.Server.ShutdownTimeout); err != nil {
+		return fmt.Errorf("parse shutdown_timeout: %w", err)
 	}
 
 	s.httpSrv = &http.Server{
@@ -144,6 +153,9 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	writeTimeout, err := time.ParseDuration(s.config.Server.WriteTimeout)
 	if err != nil {
 		return fmt.Errorf("parse write_timeout: %w", err)
+	}
+	if _, err := time.ParseDuration(s.config.Server.ShutdownTimeout); err != nil {
+		return fmt.Errorf("parse shutdown_timeout: %w", err)
 	}
 
 	s.httpSrv = &http.Server{
@@ -193,12 +205,12 @@ func (s *Server) awaitStop(ctx context.Context, done <-chan struct{}) {
 	if ctx.Err() == nil {
 		return
 	}
+	// Start and Serve both parse this before reaching here, so the error cannot
+	// happen; the fallback keeps a wedge from becoming an unbounded wait if that ever
+	// stops being true.
 	timeout, err := time.ParseDuration(s.config.Server.ShutdownTimeout)
 	if err != nil {
-		// Unparseable: Stop will have failed on the same value and logged it, so
-		// there is nothing left to wait for. Bound the wait anyway rather than
-		// blocking forever on a channel that will not close.
-		timeout = time.Second
+		timeout = 30 * time.Second
 	}
 	select {
 	case <-done:


### PR DESCRIPTION
Closes #599

## What was wrong

`MaxEventsInMemory` was declared, documented as *"the maximum number of events held in memory before the store flushes"*, plumbed through config and pinned by `config_test.go` — and **read nowhere**. `EventStore.Flush` had **zero callers** anywhere in the repo, tests and CLI included. Two halves of one unfinished feature, so a run configured with `backend: file` or `backend: sqlite` wrote nothing at all. Because the setting parsed, validated and round-tripped through a passing test, there was no signal short of grepping for readers — the config test looked like coverage of the feature while covering only the plumbing.

## The fix

**The threshold fires.** `RecordEvent` flushes each time the recorded count crosses a multiple of `max_in_memory`, guarded the same way the adjacent `SnapshotInterval` hint is, and called after `e.mu` is released because `Flush` takes `RLock()` and Go's RWMutex is not upgradable.

**It is a flush threshold, not a cap.** Events are never dropped from memory, so replay, `GetStream` and time-travel debugging still see the full history. #599 flagged this as the distinction that had to be got right — "flush" meaning *discard* would break every derivation that reads back over a stream. There is a test that fails if it ever becomes an eviction bound.

**A flush failure is logged, not returned.** `RecordEvent`'s contract is that the observation was recorded, and it was — the events are in memory and a later flush still writes them. Failing the caller's API call because the disk hiccuped would report an infrastructure fault as an AWS error, the same reasoning `AuthController` applies to a failed state read. `WithEventStoreLogger` is new and is how `substrate server` makes such a failure visible instead of silent.

## Two things found while implementing, beyond the issue

**1. The threshold alone does not make a backend persist.** Everything recorded since the last crossing sits in memory until something writes it, and with the **default `max_in_memory` of 1000** a short recorded run crosses nothing — so a cleanly terminated server still persisted zero events despite a file backend being configured. `Server.Stop` now flushes after the connection drain.

That exposed an ordering bug: `http.Server.Shutdown` releases the serve loop as soon as the listener closes, so `Start`/`Serve` returned and `main` exited while the flush was still running on the shutdown goroutine. A **live `SIGTERM` is what caught this** — the unit test for `Stop` calls it directly and structurally cannot see it. `Start` and `Serve` now wait (bounded by the same `shutdown_timeout`), and `TestServer_Serve_WaitsForTheShutdownFlush` goes through the cancellation path and asserts the ordering: by the time `Serve` has returned, the events are on disk.

**2. Both backends raced their own flush cursor.** `fileBackend` tracks a per-stream map, `sqliteBackend` a single counter, and both wrote it holding only the event store's **read** lock — which permits concurrent holders and so serializes nothing. `fileBackend`'s struct comment asserted the opposite:

> *flush is called while the EventStore read-lock is held so flushCursors can be accessed without a separate lock*

Unreachable while `Flush` had no callers; live once triggered automatically. The planning note anticipated the file backend — **sqlite had the identical defect and was not anticipated**. Each now guards its cursor with its own mutex. Note this is reachable independent of the new trigger: `Flush` is exported, so a consumer calling it while requests are still recording hit it before this PR too.

## Verification

`gofmt` clean, `go build`, `go vet`, `golangci-lint run ./...` → **0 issues**. `make test` (race detector) green; `make coverage` → **81.5%** on `emulator`, 80.8% total. `test/e2e` module green. `make docs-reference-check`, `docs-versions`, VitePress build all pass.

End-to-end against a live server with `AWS_MAX_ATTEMPTS=1`, `max_in_memory: 5`:

| step | observed |
|---|---|
| 4 requests | no `events/` directory — the threshold is not "flush every event" |
| 5th request | `default.ndjson`, **5 lines**, no explicit `Flush` anywhere |
| through 10 | **10 lines**, not 15 — the second crossing appends rather than re-writing |
| 11–12 | still 10 on disk; no crossing yet |
| `SIGTERM` | **12 lines** — the shutdown flush persists the remainder |

That last row is the one that failed before the `awaitStop` fix, and is why it exists.

## Mutation testing

Seven mutations, each applied to a green baseline, `gofmt`/`vet` gated, run against the **full package** rather than a `-run` filter (the lesson from #601's M2), restored from a saved copy.

| # | mutation | verdict |
|---|---|---|
| M1 | threshold guard dropped — flush on every event | **CAUGHT** (4 tests) |
| M2 | `n%threshold != 0` → `n < threshold` | **CAUGHT** (`FlushesRepeatedly`) |
| M3 | `threshold <= 0` → `< 0`, so zero no longer disables | **CAUGHT** — divide by zero across the suite |
| M4 | `maybeFlush` call removed from `RecordEvent` | **CAUGHT** (4 tests) |
| M5 | `fileBackend` cursor mutex removed | **CAUGHT** — *after a fix, see below* |
| M6 | `sqliteBackend` cursor mutex removed | **CAUGHT** — *after a fix, see below* |
| M7 | shutdown flush removed from `Stop` | **CAUGHT** (2 tests) |

**M5 and M6 initially SURVIVED, and that was a real coverage gap, not a filter artifact.** My concurrency test drove the *automatic* path, which `EventStore.flushMu` already serializes — so the backend mutexes were never reached and could be deleted with everything still passing. A throwaway probe confirmed the race is genuinely reachable through **exported `Flush` called concurrently with recording**, which nothing covered. I added `TestEventStore_ExplicitFlushConcurrentWithRecording` and a sqlite counterpart (needed separately: a test covering one backend leaves the other's lock removable), then re-ran both mutations — the file one reports `WARNING: DATA RACE`, the sqlite one fails the exactly-once assertion. Disclosing rather than reporting a clean 7/7, because the first pass of those two tests was decoration.

## Compatibility

Additive for anyone who leaves `max_in_memory` at its default and does not configure a persisting backend; `TestEventStore_MaxEventsInMemory_ZeroDisablesTheTrigger` pins that zero keeps the previous explicit-flush-only behavior. Two changes a consumer could notice:

- With `backend: file`/`sqlite` **and** `max_in_memory` set, writes now happen during the run rather than only on an explicit `Flush`. A test asserting an empty `events/` directory mid-run would need to stop setting the threshold.
- `Server.Stop` can now return a `flush event store:` error it previously could not, and `Start`/`Serve` return slightly later — after the flush rather than at listener close.

[CHANGELOG](https://github.com/scttfrdmn/substrate/blob/main/CHANGELOG.md#unreleased) · [compare](https://github.com/scttfrdmn/substrate/compare/main...fix/599-flush-max-events)