### PR TITLE
chore(release): v0.96.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.96.0] - 2026-08-08
+
 ### Added
 - **`iam:UpdateAssumeRolePolicy`, so a role's trust policy can be changed after
   `CreateRole`** (#594). The operation was absent from the IAM switch, making
@@ -5724,7 +5726,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.95.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.96.0...HEAD
+[v0.96.0]: https://github.com/scttfrdmn/substrate/compare/v0.95.0...v0.96.0
 [v0.95.0]: https://github.com/scttfrdmn/substrate/compare/v0.94.0...v0.95.0
 [v0.94.0]: https://github.com/scttfrdmn/substrate/compare/v0.93.0...v0.94.0
 [v0.93.0]: https://github.com/scttfrdmn/substrate/compare/v0.92.0...v0.93.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.96.0] - 2026-08-08` and adds the comparison link, per the release steps in `CLAUDE.md`. No code changes.

v0.96.0 finishes what v0.95.0 started. #593 made a role's trust policy load-bearing, and making that surface real exposed two gaps that were invisible while nothing read the document — both filed the same day. The third is unrelated and was found while implementing #501.

- **#594** — `iam:UpdateAssumeRolePolicy`, so a trust policy can be changed after `CreateRole` (#600)
- **#595** — an authorization denial reports the code the service's wire protocol uses, instead of one outcome answering with two codes (#601)
- **#599** — a configured event-store backend actually persists: `max_in_memory` triggers a flush, and the server flushes on shutdown (#602)

Also carries an unparseable-`shutdown_timeout` hang that was found while testing #599 and is pre-existing on `main`, attributed as such rather than folded into the issue.

The milestone is empty — all three issues closed via `Closes #N`. The tag and GitHub Release follow once this merges.