### PR TITLE
test(eventstore): stop the shutdown-flush tests flaking on cleanup

### DIFF
--- a/emulator/eventstore_maxinmemory_test.go
+++ b/emulator/eventstore_maxinmemory_test.go
@@ -235,8 +235,13 @@ func TestServer_Stop_FlushesTheEventStore(t *testing.T) {
 	require.NoError(t, err)
 	baseURL := fmt.Sprintf("http://%s", ln.Addr().String())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// Served on an uncancelable context deliberately. Stop is called directly below,
+	// and a cancelable one would fire Serve's shutdown goroutine when the deferred
+	// cancel ran — a *second* Stop, whose flush re-created the events directory while
+	// t.TempDir's cleanup was removing it ("directory not empty"). That flaked in CI
+	// on the release PR. The cancellation path is covered by the test below, which
+	// waits for it to finish.
+	ctx := context.Background()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -484,10 +489,10 @@ func TestServer_Stop_ReportsAFailedFlush(t *testing.T) {
 	require.NoError(t, err)
 	baseURL := fmt.Sprintf("http://%s", ln.Addr().String())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// Uncancelable for the same reason as TestServer_Stop_FlushesTheEventStore: Stop
+	// is called directly, and a cancel would fire a second one during cleanup.
 	served := make(chan error, 1)
-	go func() { served <- srv.Serve(ctx, ln) }()
+	go func() { served <- srv.Serve(context.Background(), ln) }()
 
 	waitForHealth(t, baseURL)
 	recordN(t, store, "blocked", 1)
@@ -496,7 +501,6 @@ func TestServer_Stop_ReportsAFailedFlush(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "flush event store")
 
-	cancel()
 	require.NoError(t, <-served)
 }
 


### PR DESCRIPTION
A flake in the tests added by #602, caught by CI on the v0.96.0 release PR (#603) — which contains **no code changes at all**, so the failure could only have come from the tests themselves.

```
--- FAIL: TestServer_Stop_FlushesTheEventStore (0.00s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat /tmp/TestServer_Stop_FlushesTheEventStore2915843973: directory not empty
```

## Cause

Both tests call `Server.Stop` directly, but served on a **cancelable** context with a `defer cancel()`. The deferred cancel runs after the test body, which fires `Serve`'s shutdown goroutine and so a **second** `Stop` — whose flush re-created the `events/` directory while `t.TempDir`'s cleanup was removing it. Two `"substrate server shutting down"` lines in the CI log for one test confirm it.

Ordering, not timing, which is why it is intermittent rather than constant: `t.Cleanup` runs LIFO, so whether the flush lands before or after `RemoveAll` walks the directory depends on how the two goroutines interleave.

## Fix

Neither test needs the cancellation path — they call `Stop` explicitly — so both now serve on `context.Background()`. The cancellation path stays covered by `TestServer_Serve_WaitsForTheShutdownFlush`, which waits for `Serve` to return before asserting and therefore leaves no cleanup racing a flush.

Worth noting the flake was in the *test*, not the shutdown flush: a second `Stop` re-creating the directory is the flush working, on a directory the harness was concurrently deleting.

## Verification

`-count=30` on the affected tests, with and without `-race`, plus `-count=30` across all `TestServer_Stop`/`TestServer_Serve`/`TestEventStore_MaxEventsInMemory` cases — clean. Full `make test`, `go vet ./...` and `golangci-lint run ./...` (0 issues) green.

No CHANGELOG entry: test-only, and it fixes tests that have not appeared in a release yet.