### PR TITLE
feat(organizations): persist the root and add the shared storage layer (#577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The organization root now has one stable identity** (#577). `ListRoots` minted
+  a fresh `r-` ID on every call and never persisted it, so two calls disagreed and
+  the ARN built from it moved with them. Nothing could reference the root: a caller
+  that attached a policy to it, re-read, and saw a different ID would conclude the
+  attachment had vanished — a determinism defect in the one property substrate
+  exists to provide, and not one that surfaces as an error. The root is now created
+  once alongside the organization and the management account, persisted under
+  `root:<account>`, and returned unchanged for the life of the state store.
+
+- **Every Organizations exception is now HTTP 400.** `DescribeAccount` answered
+  `AccountNotFoundException` at 404. The API model declares no 404 for any
+  Organizations error, `AccountNotFoundException` included, so the status was one a
+  caller could not reproduce against AWS — and a consumer that branched on the
+  status rather than the code took a path AWS never sends it down.
+
+- **An unparseable Organizations request body is now `InvalidInputException`**,
+  not the `MalformedData` code substrate shares with twenty other plugins.
+  `MalformedData` is not in the Organizations model, so an SDK caller's catch
+  branch — written against `InvalidInputException` — never matched it. The reason
+  from the model's `InvalidInputExceptionReason` enum is carried in the message,
+  since the JSON-RPC error document has nowhere else to put it.
+
+### Added
+- **The Organizations plugin's shared storage layer, and two control-plane seed
+  endpoints** (#578, foundation). The plugin now persists the hierarchy (each
+  entity's parent and children), organizational units, policies, policy
+  attachments in both directions, tags, and `CreateAccount` request statuses; the
+  operations over them land per cluster. New accounts and the management account
+  are placed in the root, so a `ListParents` walk has somewhere to start.
+
+  `p-FullAWSAccess`, the AWS-managed SCP that allows everything, is synthesized
+  rather than stored — so it cannot be updated or deleted — and attached to the
+  root and to every account and OU while the SCP type is enabled, as AWS does.
+  Without it a fresh organization reports no attached policies, which is wrong, and
+  the minimum-one-SCP rule has nothing to hold.
+
+  `POST`/`DELETE /v1/organizations/feature-set` sets the organization's feature
+  set, making a `CONSOLIDATED_BILLING` organization — one in which no service
+  control policy can exist at all — reachable. `POST`/`DELETE
+  /v1/organizations/create-account-failure` seeds the *asynchronous* outcome of
+  `CreateAccount`, keyed by account name or `"*"`. An unknown `failureReason` is
+  refused with a 400: a typo'd value would seed a `FAILED` status carrying
+  something no SDK catch branch matches, so the caller's fallback path would go
+  untested while the test still passed.
+
+  Paginated Organizations listings now honor `MaxResults` (clamped to the model's
+  1–20) and `NextToken`, and an unreadable token is
+  `InvalidInputException`/`INVALID_NEXT_TOKEN` rather than a silent restart from
+  the beginning — a paginating caller that restarts sees duplicates instead of an
+  error, which is the harder failure to notice.
+
 ## [v0.96.0] - 2026-08-08
 
 ### Added

--- a/emulator/organizations_account.go
+++ b/emulator/organizations_account.go
@@ -1,0 +1,72 @@
+package emulator
+
+import (
+	"context"
+	"fmt"
+)
+
+// accountOperation claims the account vending and placement operations.
+func (p *OrganizationsPlugin) accountOperation(op string) (orgHandler, bool) {
+	switch op {
+	case "CreateAccount":
+		return p.createAccount, true
+	default:
+		return nil, false
+	}
+}
+
+func (p *OrganizationsPlugin) createAccount(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		AccountName string `json:"AccountName"`
+		Email       string `json:"Email"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+
+	org, err := p.ensureOrganization(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("createAccount ensure org: %w", err)
+	}
+	root, err := p.loadRoot(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("createAccount load root: %w", err)
+	}
+
+	newAcctID := generateOrganizationAccountID()
+	a := OrgAccount{
+		ID:           newAcctID,
+		Arn:          fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", reqCtx.AccountID, org.ID, newAcctID),
+		Name:         input.AccountName,
+		Email:        input.Email,
+		Status:       "ACTIVE",
+		JoinedMethod: "CREATED",
+		JoinedAt:     p.tc.Now(),
+	}
+	if err := p.saveAccount(goCtx, reqCtx.AccountID, a); err != nil {
+		return nil, fmt.Errorf("createAccount save: %w", err)
+	}
+	// A new account lands in the root; MoveAccount is the only way into an OU.
+	if err := p.placeChild(goCtx, root.ID, a.ID); err != nil {
+		return nil, fmt.Errorf("createAccount place: %w", err)
+	}
+	if err := p.attachFullAWSAccess(goCtx, reqCtx.AccountID, a.ID); err != nil {
+		return nil, fmt.Errorf("createAccount attach FullAWSAccess: %w", err)
+	}
+
+	status := OrgCreateAccountStatus{
+		ID:                 "car-" + randomLowerAlphanum(8),
+		AccountName:        a.Name,
+		State:              "SUCCEEDED",
+		RequestedTimestamp: p.tc.Now(),
+		AccountID:          a.ID,
+	}
+	completed := p.tc.Now()
+	status.CompletedTimestamp = &completed
+	if err := p.saveCreateAccountStatus(goCtx, reqCtx.AccountID, status); err != nil {
+		return nil, fmt.Errorf("createAccount save status: %w", err)
+	}
+
+	return orgJSONResponse(map[string]interface{}{"CreateAccountStatus": status}, "createAccount")
+}

--- a/emulator/organizations_control.go
+++ b/emulator/organizations_control.go
@@ -1,0 +1,222 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+)
+
+// orgCtrlNamespace is the state namespace for Organizations control-plane (seed)
+// data. It is separate from the organizations namespace so a seed is not
+// mistaken for organization state during replay or a state dump.
+const orgCtrlNamespace = "organizations-ctrl"
+
+// orgCtrlFeatureSetKey holds the seeded organization feature set.
+const orgCtrlFeatureSetKey = "feature-set"
+
+// orgCtrlCreateFailureKey returns the state key for a seeded CreateAccount
+// failure. Name-scoped seeds use "create-account-failure:{name}"; the wildcard
+// uses "create-account-failure:*".
+func orgCtrlCreateFailureKey(accountName string) string {
+	if accountName == "" {
+		accountName = "*"
+	}
+	return "create-account-failure:" + accountName
+}
+
+// orgCreateAccountFailureReasons is the CreateAccountFailureReason enum from the
+// Organizations API model. A seed is checked against it because a typo'd reason
+// would produce a FAILED status carrying a value no SDK catch branch matches,
+// so the caller's fallback path would go untested while the test still passed.
+var orgCreateAccountFailureReasons = []string{
+	"ACCOUNT_LIMIT_EXCEEDED",
+	"EMAIL_ALREADY_EXISTS",
+	"INVALID_ADDRESS",
+	"INVALID_EMAIL",
+	"CONCURRENT_ACCOUNT_MODIFICATION",
+	"INTERNAL_FAILURE",
+	"GOVCLOUD_ACCOUNT_ALREADY_EXISTS",
+	"MISSING_BUSINESS_VALIDATION",
+	"FAILED_BUSINESS_VALIDATION",
+	"PENDING_BUSINESS_VALIDATION",
+	"INVALID_IDENTITY_FOR_BUSINESS_VALIDATION",
+	"UNKNOWN_BUSINESS_VALIDATION",
+	"MISSING_PAYMENT_INSTRUMENT",
+	"INVALID_PAYMENT_INSTRUMENT",
+	"UPDATE_EXISTING_RESOURCE_POLICY_WITH_TAGS_NOT_SUPPORTED",
+}
+
+// orgSeededFeatureSet is a seeded organization feature set.
+type orgSeededFeatureSet struct {
+	// FeatureSet is "ALL" or "CONSOLIDATED_BILLING".
+	FeatureSet string `json:"featureSet"`
+}
+
+// orgSeededCreateFailure is a seeded asynchronous CreateAccount outcome.
+// Substrate does not create anything; the seed sets the terminal state that
+// DescribeCreateAccountStatus reports, which is the only place a real
+// CreateAccount failure is observable — the call itself still returns 200.
+type orgSeededCreateFailure struct {
+	// AccountName the seed applies to, or "*" for any account name.
+	AccountName string `json:"accountName"`
+
+	// FailureReason is the CreateAccountFailureReason the status reports.
+	FailureReason string `json:"failureReason"`
+}
+
+// effectiveFeatureSet returns the organization's feature set: the seeded value
+// when one is set, the stored value for an existing organization, and "ALL"
+// otherwise. The seed wins over the stored value so a test can flip an already
+// observed organization into CONSOLIDATED_BILLING without recreating it.
+func (p *OrganizationsPlugin) effectiveFeatureSet(ctx context.Context, acct string) (string, error) {
+	var seed orgSeededFeatureSet
+	found, err := p.orgCtrlGetJSON(ctx, orgCtrlFeatureSetKey, &seed)
+	if err != nil {
+		return "", err
+	}
+	if found && seed.FeatureSet != "" {
+		return seed.FeatureSet, nil
+	}
+
+	var org Organization
+	found, err = p.orgGetJSON(ctx, orgKey(acct), &org)
+	if err != nil {
+		return "", err
+	}
+	if found && org.FeatureSet != "" {
+		return org.FeatureSet, nil
+	}
+	return orgFeatureSetAll, nil
+}
+
+// resolveSeededCreateFailure returns the seeded failure for an account name, if
+// any, matching the exact name first then the "*" wildcard. It returns
+// (nil, nil) when no seed applies, so the caller falls back to the nominal
+// SUCCEEDED outcome.
+func (p *OrganizationsPlugin) resolveSeededCreateFailure(ctx context.Context, accountName string) (*orgSeededCreateFailure, error) {
+	for _, key := range []string{orgCtrlCreateFailureKey(accountName), orgCtrlCreateFailureKey("*")} {
+		var seed orgSeededCreateFailure
+		found, err := p.orgCtrlGetJSON(ctx, key, &seed)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			return &seed, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // (nil, nil) = "no seed applies", handled by caller.
+}
+
+// orgCtrlGetJSON loads and decodes a control-plane value, reporting found=false
+// when the key is absent.
+func (p *OrganizationsPlugin) orgCtrlGetJSON(ctx context.Context, key string, out interface{}) (bool, error) {
+	data, err := p.state.Get(ctx, orgCtrlNamespace, key)
+	if err != nil {
+		return false, fmt.Errorf("get %s: %w", key, err)
+	}
+	if data == nil {
+		return false, nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return false, fmt.Errorf("unmarshal %s: %w", key, err)
+	}
+	return true, nil
+}
+
+// handleOrganizationsSeedFeatureSet handles POST /v1/organizations/feature-set.
+// It sets the feature set DescribeOrganization reports, which decides whether
+// service control policies exist at all: under CONSOLIDATED_BILLING the root
+// has no policy types and every policy operation is refused with
+// PolicyTypeNotAvailableForOrganizationException.
+// Body: {"featureSet":"ALL"|"CONSOLIDATED_BILLING"}.
+func (s *Server) handleOrganizationsSeedFeatureSet(w http.ResponseWriter, r *http.Request) {
+	var seed orgSeededFeatureSet
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.FeatureSet != orgFeatureSetAll && seed.FeatureSet != orgFeatureSetConsolidatedBilling {
+		http.Error(w, `{"error":"featureSet must be ALL or CONSOLIDATED_BILLING"}`, http.StatusBadRequest)
+		return
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), orgCtrlNamespace, orgCtrlFeatureSetKey, data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true, "featureSet": seed.FeatureSet})
+}
+
+// handleOrganizationsClearFeatureSet handles DELETE /v1/organizations/feature-set,
+// restoring the organization's stored feature set.
+func (s *Server) handleOrganizationsClearFeatureSet(w http.ResponseWriter, r *http.Request) {
+	if err := s.state.Delete(r.Context(), orgCtrlNamespace, orgCtrlFeatureSetKey); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}
+
+// handleOrganizationsSeedCreateAccountFailure handles
+// POST /v1/organizations/create-account-failure. It seeds the terminal state of
+// the asynchronous CreateAccount request for a given account name (default "*"):
+// the call still returns 200 with IN_PROGRESS, and DescribeCreateAccountStatus
+// then reports FAILED with the seeded reason and no AccountId.
+// Body: {"accountName","failureReason"}.
+func (s *Server) handleOrganizationsSeedCreateAccountFailure(w http.ResponseWriter, r *http.Request) {
+	var seed orgSeededCreateFailure
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.FailureReason == "" {
+		http.Error(w, `{"error":"failureReason is required"}`, http.StatusBadRequest)
+		return
+	}
+	if !slices.Contains(orgCreateAccountFailureReasons, seed.FailureReason) {
+		http.Error(w, fmt.Sprintf(`{"error":"failureReason %q is not a CreateAccountFailureReason"}`, seed.FailureReason), http.StatusBadRequest)
+		return
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), orgCtrlNamespace, orgCtrlCreateFailureKey(seed.AccountName), data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true, "accountName": orgCtrlCreateFailureKey(seed.AccountName)})
+}
+
+// handleOrganizationsClearCreateAccountFailure handles
+// DELETE /v1/organizations/create-account-failure. With ?accountName=... it
+// removes that seed; without it removes all.
+func (s *Server) handleOrganizationsClearCreateAccountFailure(w http.ResponseWriter, r *http.Request) {
+	if name := r.URL.Query().Get("accountName"); name != "" {
+		if err := s.state.Delete(r.Context(), orgCtrlNamespace, orgCtrlCreateFailureKey(name)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), orgCtrlNamespace, "create-account-failure:")
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), orgCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}

--- a/emulator/organizations_control_test.go
+++ b/emulator/organizations_control_test.go
@@ -1,0 +1,181 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// newOrganizationsServerForSeeds returns a server and the plugin sharing its
+// state, so a test can post a seed over HTTP and then read what the plugin
+// resolves from it.
+func newOrganizationsServerForSeeds(t *testing.T) (*emulator.Server, *emulator.OrganizationsPlugin) {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false})
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.OrganizationsPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}); err != nil {
+		t.Fatalf("initialize organizations plugin: %v", err)
+	}
+	registry.Register(p)
+
+	cfg := emulator.DefaultConfig()
+	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger)
+	return srv, p
+}
+
+// orgSeedRequest posts or deletes a control-plane seed and returns the status.
+func orgSeedRequest(t *testing.T, srv *emulator.Server, method, path string, body map[string]any) int {
+	t.Helper()
+	var reader *bytes.Reader
+	if body == nil {
+		reader = bytes.NewReader(nil)
+	} else {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal seed: %v", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+	r := httptest.NewRequest(method, path, reader)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Result().StatusCode //nolint:bodyclose // httptest.Recorder result needs no close.
+}
+
+// TestOrganizations_SeedFeatureSet covers the round trip through the endpoint:
+// seeding CONSOLIDATED_BILLING makes the organization one in which no service
+// control policy can exist, and clearing restores the stored value.
+func TestOrganizations_SeedFeatureSet(t *testing.T) {
+	srv, p := newOrganizationsServerForSeeds(t)
+
+	if got := orgSeedRequest(t, srv, http.MethodPost, "/v1/organizations/feature-set",
+		map[string]any{"featureSet": "CONSOLIDATED_BILLING"}); got != http.StatusOK {
+		t.Fatalf("seed feature set: expected 200, got %d", got)
+	}
+	featureSet, err := p.EffectiveFeatureSetForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("effective feature set: %v", err)
+	}
+	if featureSet != "CONSOLIDATED_BILLING" {
+		t.Errorf("expected CONSOLIDATED_BILLING, got %q", featureSet)
+	}
+
+	if got := orgSeedRequest(t, srv, http.MethodDelete, "/v1/organizations/feature-set", nil); got != http.StatusOK {
+		t.Fatalf("clear feature set: expected 200, got %d", got)
+	}
+	featureSet, err = p.EffectiveFeatureSetForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("effective feature set after clear: %v", err)
+	}
+	if featureSet != "ALL" {
+		t.Errorf("expected ALL after clearing the seed, got %q", featureSet)
+	}
+}
+
+// TestOrganizations_SeedFeatureSet_Rejects checks a value outside the enum is
+// refused rather than stored: a seeded "all" would leave the organization in a
+// mode no branch handles, and every assertion downstream would be meaningless.
+func TestOrganizations_SeedFeatureSet_Rejects(t *testing.T) {
+	srv, _ := newOrganizationsServerForSeeds(t)
+
+	for _, body := range []map[string]any{
+		{"featureSet": "all"},
+		{"featureSet": "BILLING"},
+		{},
+	} {
+		if got := orgSeedRequest(t, srv, http.MethodPost, "/v1/organizations/feature-set", body); got != http.StatusBadRequest {
+			t.Errorf("seed %v: expected 400, got %d", body, got)
+		}
+	}
+}
+
+// TestOrganizations_SeedCreateAccountFailure covers exact-name and wildcard
+// resolution, and the clear paths.
+func TestOrganizations_SeedCreateAccountFailure(t *testing.T) {
+	srv, p := newOrganizationsServerForSeeds(t)
+	ctx := t.Context()
+
+	if _, seeded, err := p.ResolveSeededCreateFailureForTest(ctx, "dev"); err != nil || seeded {
+		t.Fatalf("expected no seed to apply initially (seeded=%v, err=%v)", seeded, err)
+	}
+
+	if got := orgSeedRequest(t, srv, http.MethodPost, "/v1/organizations/create-account-failure",
+		map[string]any{"accountName": "dev", "failureReason": "EMAIL_ALREADY_EXISTS"}); got != http.StatusOK {
+		t.Fatalf("seed named failure: expected 200, got %d", got)
+	}
+	reason, seeded, err := p.ResolveSeededCreateFailureForTest(ctx, "dev")
+	if err != nil || !seeded || reason != "EMAIL_ALREADY_EXISTS" {
+		t.Fatalf("expected the named seed to apply, got (%q, %v, %v)", reason, seeded, err)
+	}
+	// A different name does not match a name-scoped seed.
+	if _, seeded, err = p.ResolveSeededCreateFailureForTest(ctx, "prod"); err != nil || seeded {
+		t.Errorf("expected the named seed not to apply to another name (seeded=%v, err=%v)", seeded, err)
+	}
+
+	// The wildcard applies to any name.
+	if got := orgSeedRequest(t, srv, http.MethodPost, "/v1/organizations/create-account-failure",
+		map[string]any{"accountName": "*", "failureReason": "INTERNAL_FAILURE"}); got != http.StatusOK {
+		t.Fatalf("seed wildcard failure: expected 200, got %d", got)
+	}
+	reason, seeded, err = p.ResolveSeededCreateFailureForTest(ctx, "prod")
+	if err != nil || !seeded || reason != "INTERNAL_FAILURE" {
+		t.Fatalf("expected the wildcard seed to apply, got (%q, %v, %v)", reason, seeded, err)
+	}
+	// The exact name still wins over the wildcard.
+	reason, _, err = p.ResolveSeededCreateFailureForTest(ctx, "dev")
+	if err != nil || reason != "EMAIL_ALREADY_EXISTS" {
+		t.Errorf("expected the exact name to win over the wildcard, got %q (err %v)", reason, err)
+	}
+
+	// A scoped delete removes only that seed.
+	if got := orgSeedRequest(t, srv, http.MethodDelete,
+		"/v1/organizations/create-account-failure?accountName=dev", nil); got != http.StatusOK {
+		t.Fatalf("clear named seed: expected 200, got %d", got)
+	}
+	reason, _, err = p.ResolveSeededCreateFailureForTest(ctx, "dev")
+	if err != nil || reason != "INTERNAL_FAILURE" {
+		t.Errorf("expected the wildcard to remain, got %q (err %v)", reason, err)
+	}
+
+	// An unscoped delete removes everything.
+	if got := orgSeedRequest(t, srv, http.MethodDelete,
+		"/v1/organizations/create-account-failure", nil); got != http.StatusOK {
+		t.Fatalf("clear all seeds: expected 200, got %d", got)
+	}
+	if _, seeded, err = p.ResolveSeededCreateFailureForTest(ctx, "dev"); err != nil || seeded {
+		t.Errorf("expected every seed cleared (seeded=%v, err=%v)", seeded, err)
+	}
+}
+
+// TestOrganizations_SeedCreateAccountFailure_RejectsUnknownReason is the reason
+// the endpoint validates at all: a typo'd reason would seed a FAILED status
+// carrying a value no SDK catch branch matches, so the caller's fallback path
+// would go untested while the test still passed.
+func TestOrganizations_SeedCreateAccountFailure_RejectsUnknownReason(t *testing.T) {
+	srv, _ := newOrganizationsServerForSeeds(t)
+
+	for _, body := range []map[string]any{
+		{"accountName": "*", "failureReason": "EMAIL_EXISTS"},
+		{"accountName": "*", "failureReason": "email_already_exists"},
+		{"accountName": "*"},
+	} {
+		if got := orgSeedRequest(t, srv, http.MethodPost,
+			"/v1/organizations/create-account-failure", body); got != http.StatusBadRequest {
+			t.Errorf("seed %v: expected 400, got %d", body, got)
+		}
+	}
+}

--- a/emulator/organizations_export_test.go
+++ b/emulator/organizations_export_test.go
@@ -105,6 +105,21 @@ func (p *OrganizationsPlugin) ResolveSeededCreateFailureForTest(ctx context.Cont
 	return seed.FailureReason, true, nil
 }
 
+// SaveAccountForTest wraps saveAccount for external tests.
+func (p *OrganizationsPlugin) SaveAccountForTest(ctx context.Context, acct string, a OrgAccount) error {
+	return p.saveAccount(ctx, acct, a)
+}
+
+// LoadAccountForTest wraps loadAccount for external tests.
+func (p *OrganizationsPlugin) LoadAccountForTest(ctx context.Context, accountID string) (*OrgAccount, error) {
+	return p.loadAccount(ctx, accountID)
+}
+
+// LoadAccountIDsForTest wraps loadAccountIDs for external tests.
+func (p *OrganizationsPlugin) LoadAccountIDsForTest(ctx context.Context, acct string) ([]string, error) {
+	return p.loadAccountIDs(ctx, acct)
+}
+
 // PlaceChildForTest wraps placeChild for external tests.
 func (p *OrganizationsPlugin) PlaceChildForTest(ctx context.Context, parent, child string) error {
 	return p.placeChild(ctx, parent, child)

--- a/emulator/organizations_export_test.go
+++ b/emulator/organizations_export_test.go
@@ -1,0 +1,212 @@
+package emulator
+
+import "context"
+
+// This file exports the Organizations storage layer for the external test
+// package. It lives apart from export_test.go so the per-cluster Organizations
+// files can each add what they need without contending for one file, and it is
+// compiled only when running tests.
+
+// Organizations quotas, exported so a test can pin each against its documented
+// value. The depth and attachment limits in particular are boundary conditions:
+// an off-by-one in either is invisible in a nominal run.
+const (
+	OrgMaxAccountsForTest        = orgMaxAccounts
+	OrgMaxOUsPerOrgForTest       = orgMaxOUsPerOrg
+	OrgMaxOUDepthForTest         = orgMaxOUDepth
+	OrgMaxSCPsPerOrgForTest      = orgMaxSCPsPerOrg
+	OrgMaxSCPsPerTargetForTest   = orgMaxSCPsPerTarget
+	OrgMinSCPsPerTargetForTest   = orgMinSCPsPerTarget
+	OrgMaxSCPBytesForTest        = orgMaxSCPBytes
+	OrgMaxTagsPerResourceForTest = orgMaxTagsPerResource
+	OrgMaxResultsForTest         = orgMaxResults
+)
+
+// Organizations entity kinds, exported for resolveOrgTarget assertions.
+const (
+	OrgKindRootForTest    = orgKindRoot
+	OrgKindOUForTest      = orgKindOU
+	OrgKindAccountForTest = orgKindAccount
+	OrgKindPolicyForTest  = orgKindPolicy
+)
+
+// OrgFullAWSAccessIDForTest is the AWS-managed SCP's policy ID.
+const OrgFullAWSAccessIDForTest = orgFullAWSAccessID
+
+// OrgPolicyTypeSCPForTest is the one policy type substrate models.
+const OrgPolicyTypeSCPForTest = orgPolicyTypeSCP
+
+// OrgPaginateForTest wraps orgPaginate for external tests.
+func OrgPaginateForTest(ids []string, nextToken string, maxResults int) (page []string, next string, err error) {
+	return orgPaginate(ids, nextToken, maxResults)
+}
+
+// OrgConstraintViolationForTest wraps orgConstraintViolation for external tests.
+func OrgConstraintViolationForTest(reason, message string) *AWSError {
+	return orgConstraintViolation(reason, message)
+}
+
+// IsOrgOUIDForTest wraps isOrgOUID for external tests.
+func IsOrgOUIDForTest(id string) bool { return isOrgOUID(id) }
+
+// IsOrgRootIDForTest wraps isOrgRootID for external tests.
+func IsOrgRootIDForTest(id string) bool { return isOrgRootID(id) }
+
+// FullAWSAccessPolicyForTest wraps fullAWSAccessPolicy for external tests.
+func FullAWSAccessPolicyForTest() OrgPolicy { return fullAWSAccessPolicy() }
+
+// OrgEmptyResponseForTest wraps orgEmptyResponse for external tests.
+func OrgEmptyResponseForTest() *AWSResponse { return orgEmptyResponse() }
+
+// NewOrganizationsPluginForTest constructs a bare OrganizationsPlugin wired to
+// the given state and clock, so a test can drive the storage layer without going
+// through the HTTP surface.
+func NewOrganizationsPluginForTest(state StateManager, tc *TimeController) *OrganizationsPlugin {
+	return &OrganizationsPlugin{state: state, tc: tc, logger: NewDefaultLogger(0, false)}
+}
+
+// EnsureOrganizationForTest wraps ensureOrganization for external tests.
+func (p *OrganizationsPlugin) EnsureOrganizationForTest(ctx context.Context, acct string) (*Organization, error) {
+	return p.ensureOrganization(ctx, acct)
+}
+
+// LoadRootForTest wraps loadRoot for external tests.
+func (p *OrganizationsPlugin) LoadRootForTest(ctx context.Context, acct string) (*OrgRoot, error) {
+	return p.loadRoot(ctx, acct)
+}
+
+// LoadStoredRootForTest wraps loadStoredRoot for external tests.
+func (p *OrganizationsPlugin) LoadStoredRootForTest(ctx context.Context, acct string) (*OrgRoot, error) {
+	return p.loadStoredRoot(ctx, acct)
+}
+
+// SaveRootForTest wraps saveRoot for external tests.
+func (p *OrganizationsPlugin) SaveRootForTest(ctx context.Context, acct string, root OrgRoot) error {
+	return p.saveRoot(ctx, acct, root)
+}
+
+// SCPEnabledForTest wraps scpEnabled for external tests.
+func (p *OrganizationsPlugin) SCPEnabledForTest(ctx context.Context, acct string) (bool, error) {
+	return p.scpEnabled(ctx, acct)
+}
+
+// EffectiveFeatureSetForTest wraps effectiveFeatureSet for external tests.
+func (p *OrganizationsPlugin) EffectiveFeatureSetForTest(ctx context.Context, acct string) (string, error) {
+	return p.effectiveFeatureSet(ctx, acct)
+}
+
+// ResolveSeededCreateFailureForTest wraps resolveSeededCreateFailure for external
+// tests, returning the reason and whether a seed applied.
+func (p *OrganizationsPlugin) ResolveSeededCreateFailureForTest(ctx context.Context, accountName string) (reason string, seeded bool, err error) {
+	seed, err := p.resolveSeededCreateFailure(ctx, accountName)
+	if err != nil || seed == nil {
+		return "", false, err
+	}
+	return seed.FailureReason, true, nil
+}
+
+// PlaceChildForTest wraps placeChild for external tests.
+func (p *OrganizationsPlugin) PlaceChildForTest(ctx context.Context, parent, child string) error {
+	return p.placeChild(ctx, parent, child)
+}
+
+// LoadParentForTest wraps loadParent for external tests.
+func (p *OrganizationsPlugin) LoadParentForTest(ctx context.Context, child string) (string, error) {
+	return p.loadParent(ctx, child)
+}
+
+// LoadChildrenForTest wraps loadChildren for external tests.
+func (p *OrganizationsPlugin) LoadChildrenForTest(ctx context.Context, parent string) ([]string, error) {
+	return p.loadChildren(ctx, parent)
+}
+
+// OUDepthForTest wraps ouDepth for external tests.
+func (p *OrganizationsPlugin) OUDepthForTest(ctx context.Context, ouID string) (int, error) {
+	return p.ouDepth(ctx, ouID)
+}
+
+// SaveOUForTest wraps saveOU for external tests.
+func (p *OrganizationsPlugin) SaveOUForTest(ctx context.Context, acct string, ou OrgOrganizationalUnit) error {
+	return p.saveOU(ctx, acct, ou)
+}
+
+// LoadOUForTest wraps loadOU for external tests.
+func (p *OrganizationsPlugin) LoadOUForTest(ctx context.Context, ouID string) (*OrgOrganizationalUnit, error) {
+	return p.loadOU(ctx, ouID)
+}
+
+// LoadOUIDsForTest wraps loadOUIDs for external tests.
+func (p *OrganizationsPlugin) LoadOUIDsForTest(ctx context.Context, acct string) ([]string, error) {
+	return p.loadOUIDs(ctx, acct)
+}
+
+// SavePolicyForTest wraps savePolicy for external tests.
+func (p *OrganizationsPlugin) SavePolicyForTest(ctx context.Context, acct string, pol OrgPolicy) error {
+	return p.savePolicy(ctx, acct, pol)
+}
+
+// LoadPolicyForTest wraps loadPolicy for external tests.
+func (p *OrganizationsPlugin) LoadPolicyForTest(ctx context.Context, policyID string) (*OrgPolicy, error) {
+	return p.loadPolicy(ctx, policyID)
+}
+
+// LoadPolicyIDsForTest wraps loadPolicyIDs for external tests.
+func (p *OrganizationsPlugin) LoadPolicyIDsForTest(ctx context.Context, acct string) ([]string, error) {
+	return p.loadPolicyIDs(ctx, acct)
+}
+
+// AttachPolicyToForTest wraps attachPolicyTo for external tests.
+func (p *OrganizationsPlugin) AttachPolicyToForTest(ctx context.Context, policyID, targetID string) (bool, error) {
+	return p.attachPolicyTo(ctx, policyID, targetID)
+}
+
+// DetachPolicyFromForTest wraps detachPolicyFrom for external tests.
+func (p *OrganizationsPlugin) DetachPolicyFromForTest(ctx context.Context, policyID, targetID string) (bool, error) {
+	return p.detachPolicyFrom(ctx, policyID, targetID)
+}
+
+// AttachFullAWSAccessForTest wraps attachFullAWSAccess for external tests.
+func (p *OrganizationsPlugin) AttachFullAWSAccessForTest(ctx context.Context, acct, targetID string) error {
+	return p.attachFullAWSAccess(ctx, acct, targetID)
+}
+
+// LoadAttachmentsForTest wraps loadAttachments for external tests.
+func (p *OrganizationsPlugin) LoadAttachmentsForTest(ctx context.Context, target string) ([]string, error) {
+	return p.loadAttachments(ctx, target)
+}
+
+// LoadPolicyTargetsForTest wraps loadPolicyTargets for external tests.
+func (p *OrganizationsPlugin) LoadPolicyTargetsForTest(ctx context.Context, policyID string) ([]string, error) {
+	return p.loadPolicyTargets(ctx, policyID)
+}
+
+// LoadTagsForTest wraps loadTags for external tests.
+func (p *OrganizationsPlugin) LoadTagsForTest(ctx context.Context, resourceID string) ([]OrgTag, error) {
+	return p.loadTags(ctx, resourceID)
+}
+
+// SaveTagsForTest wraps saveTags for external tests.
+func (p *OrganizationsPlugin) SaveTagsForTest(ctx context.Context, resourceID string, tags []OrgTag) error {
+	return p.saveTags(ctx, resourceID, tags)
+}
+
+// ResolveOrgTargetForTest wraps resolveOrgTarget for external tests.
+func (p *OrganizationsPlugin) ResolveOrgTargetForTest(ctx context.Context, acct, id string) (string, error) {
+	return p.resolveOrgTarget(ctx, acct, id)
+}
+
+// SaveCreateAccountStatusForTest wraps saveCreateAccountStatus for external tests.
+func (p *OrganizationsPlugin) SaveCreateAccountStatusForTest(ctx context.Context, acct string, st OrgCreateAccountStatus) error {
+	return p.saveCreateAccountStatus(ctx, acct, st)
+}
+
+// LoadCreateAccountStatusForTest wraps loadCreateAccountStatus for external tests.
+func (p *OrganizationsPlugin) LoadCreateAccountStatusForTest(ctx context.Context, id string) (*OrgCreateAccountStatus, error) {
+	return p.loadCreateAccountStatus(ctx, id)
+}
+
+// LoadCreateAccountStatusIDsForTest wraps loadCreateAccountStatusIDs for external
+// tests.
+func (p *OrganizationsPlugin) LoadCreateAccountStatusIDsForTest(ctx context.Context, acct string) ([]string, error) {
+	return p.loadCreateAccountStatusIDs(ctx, acct)
+}

--- a/emulator/organizations_faults_test.go
+++ b/emulator/organizations_faults_test.go
@@ -1,0 +1,929 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// errOrgState fails one kind of state operation for keys under a prefix once
+// armed, leaving everything else working. Arming is deferred because setting the
+// organization up touches the same keys: a store that fails from construction
+// never gets an organization to read.
+type errOrgState struct {
+	inner    emulator.StateManager
+	prefix   string
+	err      error
+	armed    bool
+	onGet    bool
+	onPut    bool
+	onDelete bool
+	onList   bool
+}
+
+func (m *errOrgState) fails(key string, op bool) bool {
+	return m.armed && op && strings.HasPrefix(key, m.prefix)
+}
+
+func (m *errOrgState) Get(ctx context.Context, namespace, key string) ([]byte, error) {
+	if m.fails(key, m.onGet) {
+		return nil, m.err
+	}
+	return m.inner.Get(ctx, namespace, key)
+}
+
+func (m *errOrgState) Put(ctx context.Context, namespace, key string, value []byte) error {
+	if m.fails(key, m.onPut) {
+		return m.err
+	}
+	return m.inner.Put(ctx, namespace, key, value)
+}
+
+func (m *errOrgState) Delete(ctx context.Context, namespace, key string) error {
+	if m.fails(key, m.onDelete) {
+		return m.err
+	}
+	return m.inner.Delete(ctx, namespace, key)
+}
+
+func (m *errOrgState) List(ctx context.Context, namespace, prefix string) ([]string, error) {
+	if m.fails(prefix, m.onList) {
+		return nil, m.err
+	}
+	return m.inner.List(ctx, namespace, prefix)
+}
+
+// corruptOrgState returns a value that is not valid JSON for keys under a prefix,
+// which is how a record written by a different schema reads back. A consistent
+// store cannot produce it, so it is the only way to reach the unmarshal branch
+// that separates "the record is unreadable" from "there is no record".
+type corruptOrgState struct {
+	emulator.StateManager
+	prefix string
+	armed  bool
+}
+
+func (m *corruptOrgState) Get(ctx context.Context, namespace, key string) ([]byte, error) {
+	if m.armed && strings.HasPrefix(key, m.prefix) {
+		return []byte("{not json"), nil
+	}
+	return m.StateManager.Get(ctx, namespace, key)
+}
+
+// newOrgFaultFixture returns a plugin over the supplied state manager.
+func newOrgFaultFixture(t *testing.T, state emulator.StateManager) *emulator.OrganizationsPlugin {
+	t.Helper()
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	return emulator.NewOrganizationsPluginForTest(state, tc)
+}
+
+// TestOrganizations_StateReadFailurePropagates asserts a store read failure is
+// reported as a failure rather than as an absent entity. The two are opposite
+// signals to a caller: "no such organization" is terminal and it should stop,
+// while a store failure is transient and it should retry. Collapsing the latter
+// into the former would send a consumer down a permanent-failure path over a
+// blip, and would also make an auto-created organization appear to spring into
+// existence a second time with a different ID.
+func TestOrganizations_StateReadFailurePropagates(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "org:", err: errors.New("store unavailable"), onGet: true}
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	if _, err := p.EnsureOrganizationForTest(ctx, orgTestAccount); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	state.armed = true
+
+	if _, err := p.EnsureOrganizationForTest(ctx, orgTestAccount); err == nil {
+		t.Error("expected the read failure to propagate, got an organization")
+	}
+}
+
+// TestOrganizations_RootReadFailurePropagates covers the same boundary for the
+// root. A swallowed failure here is worse than elsewhere: loadRoot returning no
+// root would have the caller mint a new one, which is exactly the unstable
+// identity #577 was about.
+func TestOrganizations_RootReadFailurePropagates(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "root:", err: errors.New("store unavailable"), onGet: true}
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	if _, err := p.LoadRootForTest(ctx, orgTestAccount); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	state.armed = true
+
+	if _, err := p.LoadRootForTest(ctx, orgTestAccount); err == nil {
+		t.Error("expected the root read failure to propagate")
+	}
+	if _, err := p.LoadStoredRootForTest(ctx, orgTestAccount); err == nil {
+		t.Error("expected the stored-root read failure to propagate")
+	}
+	if _, err := p.SCPEnabledForTest(ctx, orgTestAccount); err == nil {
+		t.Error("expected scpEnabled to report the read failure rather than 'not enabled'")
+	}
+}
+
+// TestOrganizations_MissingRootIsAnError pins what happens when the organization
+// record exists but its root does not. That pairing is unreachable through the
+// API — ensureOrganization writes both — so it means the store lost a record,
+// and answering with a freshly minted root would hand back an identity nothing
+// else agrees with.
+func TestOrganizations_MissingRootIsAnError(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	if _, err := p.EnsureOrganizationForTest(ctx, orgTestAccount); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := state.Delete(ctx, "organizations", "root:"+orgTestAccount); err != nil {
+		t.Fatalf("delete root: %v", err)
+	}
+
+	if _, err := p.LoadRootForTest(ctx, orgTestAccount); err == nil {
+		t.Error("expected an error for an organization with no root")
+	}
+	if _, err := p.LoadStoredRootForTest(ctx, orgTestAccount); err == nil {
+		t.Error("expected an error from loadStoredRoot for an organization with no root")
+	}
+}
+
+// TestOrganizations_StateWriteFailurePropagates asserts a failed write is not
+// reported as a successful create. A CreateAccount that answers 200 while the
+// account record never landed is the worst outcome available: the caller records
+// an account ID that no subsequent call can find.
+func TestOrganizations_StateWriteFailurePropagates(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "account:", err: errors.New("store unavailable"), onPut: true}
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	if _, err := p.EnsureOrganizationForTest(ctx, orgTestAccount); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	state.armed = true
+
+	err := p.SaveAccountForTest(ctx, orgTestAccount, emulator.OrgAccount{ID: "111111111111", Name: "dev"})
+	if err == nil {
+		t.Error("expected the write failure to propagate")
+	}
+}
+
+// TestOrganizations_IndexWriteFailurePropagates covers the index half of a save.
+// The record and its index are two writes, and a caller told the save succeeded
+// when only the record landed would find the entity through Describe but never
+// through a List — the split that reads as a pagination bug.
+func TestOrganizations_IndexWriteFailurePropagates(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "policy_ids:", err: errors.New("store unavailable"), onPut: true}
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	if _, err := p.EnsureOrganizationForTest(ctx, orgTestAccount); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	state.armed = true
+
+	pol := emulator.OrgPolicy{
+		PolicySummary: emulator.OrgPolicySummary{ID: "p-11112222", Name: "deny", Type: emulator.OrgPolicyTypeSCPForTest},
+		Content:       `{"Version":"2012-10-17"}`,
+	}
+	if err := p.SavePolicyForTest(ctx, orgTestAccount, pol); err == nil {
+		t.Error("expected the index write failure to propagate")
+	}
+}
+
+// TestOrganizations_CorruptRecordIsAnError asserts an unreadable record is
+// reported rather than treated as absent. Treating it as absent would silently
+// resurrect a fresh entity over the top of one that still exists in the store.
+func TestOrganizations_CorruptRecordIsAnError(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &corruptOrgState{StateManager: inner, prefix: "org:"}
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	if _, err := p.EnsureOrganizationForTest(ctx, orgTestAccount); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	state.armed = true
+
+	if _, err := p.EnsureOrganizationForTest(ctx, orgTestAccount); err == nil {
+		t.Error("expected an unreadable organization record to be an error, not an absent one")
+	}
+}
+
+// TestOrganizations_CorruptIndexIsAnError covers the same for an ID index, which
+// every listing and every attachment lookup reads.
+func TestOrganizations_CorruptIndexIsAnError(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &corruptOrgState{StateManager: inner, prefix: "attachments:"}
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	root, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	state.armed = true
+
+	if _, err := p.LoadAttachmentsForTest(ctx, root.ID); err == nil {
+		t.Error("expected an unreadable attachment index to be an error")
+	}
+	if _, err := p.AttachPolicyToForTest(ctx, "p-11112222", root.ID); err == nil {
+		t.Error("expected an attach over an unreadable index to fail rather than overwrite it")
+	}
+	if _, err := p.DetachPolicyFromForTest(ctx, emulator.OrgFullAWSAccessIDForTest, root.ID); err == nil {
+		t.Error("expected a detach over an unreadable index to fail rather than overwrite it")
+	}
+}
+
+// TestOrganizations_HierarchyReadFailurePropagates covers the placement index.
+// ouDepth walks it, so a swallowed failure there would report a shallower depth
+// than the tree really has and let a handler create a level past the limit.
+func TestOrganizations_HierarchyReadFailurePropagates(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "parent:", err: errors.New("store unavailable"), onGet: true}
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	root, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	ouID := "ou-" + root.ID[2:] + "-11112222"
+	if err := p.PlaceChildForTest(ctx, root.ID, ouID); err != nil {
+		t.Fatalf("place OU: %v", err)
+	}
+	state.armed = true
+
+	if _, err := p.LoadParentForTest(ctx, ouID); err == nil {
+		t.Error("expected the parent read failure to propagate")
+	}
+	if _, err := p.OUDepthForTest(ctx, ouID); err == nil {
+		t.Error("expected ouDepth to report the read failure rather than a shallower depth")
+	}
+	if err := p.PlaceChildForTest(ctx, root.ID, ouID); err == nil {
+		t.Error("expected a placement that cannot read the current parent to fail")
+	}
+}
+
+// TestOrganizations_TargetResolutionFailurePropagates covers resolveOrgTarget,
+// which every attachment and every tag operation consults. A swallowed failure
+// resolves to "" and the caller turns that into a not-found refusal, telling the
+// consumer its resource does not exist when the store merely could not be read.
+func TestOrganizations_TargetResolutionFailurePropagates(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "ou:", err: errors.New("store unavailable"), onGet: true}
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	root, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	state.armed = true
+
+	if _, err := p.ResolveOrgTargetForTest(ctx, orgTestAccount, "ou-"+root.ID[2:]+"-11112222"); err == nil {
+		t.Error("expected the OU read failure to propagate rather than resolve to 'no such target'")
+	}
+}
+
+// TestOrganizations_SeedReadFailurePropagates covers the control-plane reads. A
+// swallowed failure would silently fall back to the nominal path: the test would
+// pass while exercising SUCCEEDED, which is precisely the path the seed exists
+// to avoid.
+func TestOrganizations_SeedReadFailurePropagates(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "create-account-failure:", err: errors.New("store unavailable"), onGet: true, armed: true}
+	p := newOrgFaultFixture(t, state)
+
+	if _, _, err := p.ResolveSeededCreateFailureForTest(t.Context(), "dev"); err == nil {
+		t.Error("expected the seed read failure to propagate rather than resolve to 'no seed'")
+	}
+}
+
+// TestOrganizations_FeatureSetReadFailurePropagates covers the other seed read.
+// Falling back to ALL on a failure would report policy types on a root that may
+// not have them.
+func TestOrganizations_FeatureSetReadFailurePropagates(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "feature-set", err: errors.New("store unavailable"), onGet: true, armed: true}
+	p := newOrgFaultFixture(t, state)
+
+	if _, err := p.EffectiveFeatureSetForTest(t.Context(), orgTestAccount); err == nil {
+		t.Error("expected the feature-set read failure to propagate rather than default to ALL")
+	}
+}
+
+// TestOrganizations_StoreFailureIsInternalFailure pins the wire result: a store
+// failure reaching an operation is a 500 InternalFailure, which an SDK retries,
+// rather than a 400 the SDK treats as terminal.
+func TestOrganizations_StoreFailureIsInternalFailure(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "org:", err: errors.New("store unavailable"), onGet: true}
+
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false})
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.OrganizationsPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	registry.Register(p)
+
+	cfg := emulator.DefaultConfig()
+	ts := httptest.NewServer(emulator.NewServer(*cfg, registry, store, state, tc, logger))
+	t.Cleanup(ts.Close)
+
+	// Unarmed, the organization is created and read normally.
+	warm := orgsRequest(t, ts, "DescribeOrganization", map[string]interface{}{})
+	warm.Body.Close() //nolint:errcheck
+	state.armed = true
+
+	for _, op := range []string{"DescribeOrganization", "ListAccounts", "DescribeAccount", "ListRoots", "CreateAccount"} {
+		body := map[string]interface{}{}
+		switch op {
+		case "DescribeAccount":
+			body["AccountId"] = orgTestAccount
+		case "CreateAccount":
+			body["AccountName"] = "dev"
+			body["Email"] = "dev@example.com"
+		}
+		resp := orgsRequest(t, ts, op, body)
+		gotStatus := resp.StatusCode
+		resp.Body.Close() //nolint:errcheck
+		if gotStatus != http.StatusInternalServerError {
+			t.Errorf("%s: expected 500 for a store failure, got %d", op, gotStatus)
+		}
+	}
+}
+
+// TestOrganizations_SeedEndpointStoreFailures asserts the seed endpoints report a
+// store failure as a 500 rather than answering ok. A seed silently not stored
+// makes the test that depends on it exercise the nominal path while passing.
+func TestOrganizations_SeedEndpointStoreFailures(t *testing.T) {
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false})
+	inner := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(0, false)
+
+	state := &errOrgState{
+		inner: inner, prefix: "", err: errors.New("store unavailable"),
+		armed: true, onPut: true, onDelete: true, onList: true,
+	}
+	cfg := emulator.DefaultConfig()
+	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   map[string]any
+	}{
+		{"seed feature set", http.MethodPost, "/v1/organizations/feature-set", map[string]any{"featureSet": "ALL"}},
+		{"clear feature set", http.MethodDelete, "/v1/organizations/feature-set", nil},
+		{
+			"seed create failure", http.MethodPost, "/v1/organizations/create-account-failure",
+			map[string]any{"accountName": "*", "failureReason": "INTERNAL_FAILURE"},
+		},
+		{"clear one create failure", http.MethodDelete, "/v1/organizations/create-account-failure?accountName=dev", nil},
+		{"clear all create failures", http.MethodDelete, "/v1/organizations/create-account-failure", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := orgSeedRequest(t, srv, tc.method, tc.path, tc.body); got != http.StatusInternalServerError {
+				t.Errorf("expected 500 for a store failure, got %d", got)
+			}
+		})
+	}
+}
+
+// TestOrganizations_SeedEndpointRejectsUnparseableBody covers the decode branch
+// on both seed endpoints, which is the one a hand-written curl reaches first.
+func TestOrganizations_SeedEndpointRejectsUnparseableBody(t *testing.T) {
+	srv, _ := newOrganizationsServerForSeeds(t)
+
+	for _, path := range []string{"/v1/organizations/feature-set", "/v1/organizations/create-account-failure"} {
+		r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"featureSet":`))
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, r)
+		if got := w.Result().StatusCode; got != http.StatusBadRequest { //nolint:bodyclose // httptest.Recorder result needs no close.
+			t.Errorf("%s: expected 400 for an unparseable body, got %d", path, got)
+		}
+	}
+}
+
+// TestOrganizations_ClearAllCreateFailuresDeletesEveryKey pins that the unscoped
+// clear removes every seed rather than the first. A leftover wildcard seed would
+// fail an unrelated later CreateAccount in the same run.
+func TestOrganizations_ClearAllCreateFailuresDeletesEveryKey(t *testing.T) {
+	srv, p := newOrganizationsServerForSeeds(t)
+	ctx := t.Context()
+
+	for _, name := range []string{"dev", "prod", "*"} {
+		if got := orgSeedRequest(t, srv, http.MethodPost, "/v1/organizations/create-account-failure",
+			map[string]any{"accountName": name, "failureReason": "INTERNAL_FAILURE"}); got != http.StatusOK {
+			t.Fatalf("seed %s: expected 200, got %d", name, got)
+		}
+	}
+	if got := orgSeedRequest(t, srv, http.MethodDelete, "/v1/organizations/create-account-failure", nil); got != http.StatusOK {
+		t.Fatalf("clear all: expected 200, got %d", got)
+	}
+	for _, name := range []string{"dev", "prod", "other"} {
+		if _, seeded, err := p.ResolveSeededCreateFailureForTest(ctx, name); err != nil || seeded {
+			t.Errorf("%s: expected every seed cleared (seeded=%v, err=%v)", name, seeded, err)
+		}
+	}
+}
+
+// TestOrganizations_OmittedSeedNameIsTheWildcard pins the documented default: a
+// seed posted with no accountName applies to every name. A caller who omitted it
+// expecting a no-op would otherwise fail an unrelated CreateAccount later in the
+// run and have nothing to trace it to.
+func TestOrganizations_OmittedSeedNameIsTheWildcard(t *testing.T) {
+	srv, p := newOrganizationsServerForSeeds(t)
+
+	if got := orgSeedRequest(t, srv, http.MethodPost, "/v1/organizations/create-account-failure",
+		map[string]any{"failureReason": "INVALID_EMAIL"}); got != http.StatusOK {
+		t.Fatalf("seed with no accountName: expected 200, got %d", got)
+	}
+	reason, seeded, err := p.ResolveSeededCreateFailureForTest(t.Context(), "anything")
+	if err != nil || !seeded || reason != "INVALID_EMAIL" {
+		t.Errorf("expected the omitted name to seed the wildcard, got (%q, %v, %v)", reason, seeded, err)
+	}
+}
+
+// TestOrganizations_StaleNextTokenIsRefused asserts a token from a different
+// listing is refused rather than silently treated as "start over". Restarting is
+// the worst answer available to a paging loop: it never terminates, and the
+// caller sees the first page forever without an error to explain it.
+func TestOrganizations_StaleNextTokenIsRefused(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	for _, op := range []string{"ListAccounts", "ListRoots"} {
+		resp := orgsRequest(t, ts, op, map[string]interface{}{"NextToken": "bm90LWEtcmVhbC1pZA=="})
+		gotStatus := resp.StatusCode
+		resp.Body.Close() //nolint:errcheck
+		if gotStatus != http.StatusBadRequest {
+			t.Errorf("%s: expected 400 for a token naming no known ID, got %d", op, gotStatus)
+		}
+	}
+}
+
+// TestOrganizations_MalformedBodyPerOperation covers the decode guard on every
+// operation the foundation claims, not just one. An operation that skipped the
+// guard would decode into a zero-valued input and answer as though the caller had
+// asked for the empty account, which is a wrong answer rather than an error.
+func TestOrganizations_MalformedBodyPerOperation(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	for _, op := range []string{"ListAccounts", "DescribeAccount", "ListRoots", "CreateAccount"} {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", newOrgBadBody())
+		if err != nil {
+			t.Fatalf("%s: build request: %v", op, err)
+		}
+		req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+		req.Header.Set("X-Amz-Target", "Organizations_20161128."+op)
+		req.Host = "organizations.us-east-1.amazonaws.com"
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", op, err)
+		}
+		gotStatus := resp.StatusCode
+		resp.Body.Close() //nolint:errcheck
+		if gotStatus != http.StatusBadRequest {
+			t.Errorf("%s: expected 400 for an unparseable body, got %d", op, gotStatus)
+		}
+	}
+}
+
+// TestOrganizations_ListAccountsSkipsVanishedRecords asserts a listing tolerates
+// an index entry whose record is gone rather than reporting a zero-valued account.
+// An account with an empty Id in a listing is worse than a short page: a consumer
+// iterating it would call DescribeAccount with "" and get a not-found it cannot
+// explain.
+func TestOrganizations_ListAccountsSkipsVanishedRecords(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false})
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.OrganizationsPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	registry.Register(p)
+	cfg := emulator.DefaultConfig()
+	ts := httptest.NewServer(emulator.NewServer(*cfg, registry, store, state, tc, logger))
+	t.Cleanup(ts.Close)
+
+	warm := orgsRequest(t, ts, "ListAccounts", map[string]interface{}{})
+	warm.Body.Close() //nolint:errcheck
+
+	// The index still names the management account; its record does not exist.
+	if err := state.Delete(t.Context(), "organizations", "account:"+orgTestAccount); err != nil {
+		t.Fatalf("delete account record: %v", err)
+	}
+
+	resp := orgsRequest(t, ts, "ListAccounts", map[string]interface{}{})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var out struct {
+		Accounts []struct {
+			ID string `json:"Id"`
+		} `json:"Accounts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Accounts) != 0 {
+		t.Errorf("expected the vanished record skipped rather than listed empty, got %+v", out.Accounts)
+	}
+}
+
+// TestOrganizations_OUAndStatusIndexWriteFailures covers the remaining index
+// halves, for the same reason the policy index is covered: a save reported
+// successful with only the record written is invisible to every listing.
+func TestOrganizations_OUAndStatusIndexWriteFailures(t *testing.T) {
+	t.Run("OU index", func(t *testing.T) {
+		inner := emulator.NewMemoryStateManager()
+		state := &errOrgState{inner: inner, prefix: "ou_ids:", err: errors.New("store unavailable"), onPut: true, armed: true}
+		p := newOrgFaultFixture(t, state)
+		ou := emulator.OrgOrganizationalUnit{ID: "ou-abcd-11112222", Name: "prod"}
+		if err := p.SaveOUForTest(t.Context(), orgTestAccount, ou); err == nil {
+			t.Error("expected the OU index write failure to propagate")
+		}
+	})
+	t.Run("create-account-status index", func(t *testing.T) {
+		inner := emulator.NewMemoryStateManager()
+		state := &errOrgState{inner: inner, prefix: "car_ids:", err: errors.New("store unavailable"), onPut: true, armed: true}
+		p := newOrgFaultFixture(t, state)
+		st := emulator.OrgCreateAccountStatus{ID: "car-11112222", AccountName: "dev", State: "IN_PROGRESS"}
+		if err := p.SaveCreateAccountStatusForTest(t.Context(), orgTestAccount, st); err == nil {
+			t.Error("expected the request index write failure to propagate")
+		}
+	})
+	t.Run("account index", func(t *testing.T) {
+		inner := emulator.NewMemoryStateManager()
+		state := &errOrgState{inner: inner, prefix: "account_ids:", err: errors.New("store unavailable"), onPut: true, armed: true}
+		p := newOrgFaultFixture(t, state)
+		a := emulator.OrgAccount{ID: "111111111111", Name: "dev"}
+		if err := p.SaveAccountForTest(t.Context(), orgTestAccount, a); err == nil {
+			t.Error("expected the account index write failure to propagate")
+		}
+	})
+}
+
+// TestOrganizations_ReverseIndexFailurePropagates covers the second half of an
+// attachment write. An attachment is two writes, one per direction, and reporting
+// success when only the forward one landed leaves ListPoliciesForTarget and
+// ListTargetsForPolicy contradicting each other — a state no sequence of API calls
+// can produce, so nothing downstream is prepared for it.
+func TestOrganizations_ReverseIndexFailurePropagates(t *testing.T) {
+	root := ""
+	setup := func(t *testing.T, onPut bool) *emulator.OrganizationsPlugin {
+		t.Helper()
+		inner := emulator.NewMemoryStateManager()
+		state := &errOrgState{inner: inner, prefix: "policy_targets:", err: errors.New("store unavailable"), onPut: onPut, onGet: !onPut}
+		p := newOrgFaultFixture(t, state)
+		r, err := p.LoadRootForTest(t.Context(), orgTestAccount)
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		root = r.ID
+		state.armed = true
+		return p
+	}
+
+	t.Run("attach", func(t *testing.T) {
+		p := setup(t, true)
+		if _, err := p.AttachPolicyToForTest(t.Context(), "p-11112222", root); err == nil {
+			t.Error("expected the reverse-index write failure to propagate")
+		}
+	})
+	t.Run("detach", func(t *testing.T) {
+		p := setup(t, true)
+		if _, err := p.DetachPolicyFromForTest(t.Context(), emulator.OrgFullAWSAccessIDForTest, root); err == nil {
+			t.Error("expected the reverse-index write failure to propagate")
+		}
+	})
+	t.Run("read", func(t *testing.T) {
+		p := setup(t, false)
+		if _, err := p.LoadPolicyTargetsForTest(t.Context(), emulator.OrgFullAWSAccessIDForTest); err == nil {
+			t.Error("expected the reverse-index read failure to propagate")
+		}
+	})
+}
+
+// TestOrganizations_FullAWSAccessAttachFailurePropagates covers the guard that
+// decides whether to attach at all. Reading it as "not enabled" on a failure would
+// create an account with no SCP attached, which then makes the minimum-attachment
+// rule unenforceable for that account.
+func TestOrganizations_FullAWSAccessAttachFailurePropagates(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &errOrgState{inner: inner, prefix: "root:", err: errors.New("store unavailable"), onGet: true}
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	if _, err := p.LoadRootForTest(ctx, orgTestAccount); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	state.armed = true
+
+	if err := p.AttachFullAWSAccessForTest(ctx, orgTestAccount, "111111111111"); err == nil {
+		t.Error("expected the enablement read failure to propagate rather than skip the attachment")
+	}
+}
+
+// TestOrganizations_CorruptTagsAreAnError asserts unreadable tags are reported.
+// Reading them as "no tags" would answer an authorization decision with an empty
+// tag set, which fails open on a tag-gated policy.
+func TestOrganizations_CorruptTagsAreAnError(t *testing.T) {
+	inner := emulator.NewMemoryStateManager()
+	state := &corruptOrgState{StateManager: inner, prefix: "tags:", armed: true}
+	p := newOrgFaultFixture(t, state)
+
+	if _, err := p.LoadTagsForTest(t.Context(), orgTestAccount); err == nil {
+		t.Error("expected unreadable tags to be an error, not an empty tag set")
+	}
+}
+
+// TestOrganizations_PartialAutoCreateIsRefused walks every write auto-creation
+// performs and asserts a failure at each one is reported rather than swallowed.
+// Auto-creation is six writes — the organization, the root, the root's
+// FullAWSAccess attachment, the management account, its placement, and its own
+// attachment — and a caller told the organization exists when only some landed
+// would go on to reference a root or a management account that is not there. The
+// prefixes are named individually so a reordering of the writes cannot quietly
+// stop covering one.
+func TestOrganizations_PartialAutoCreateIsRefused(t *testing.T) {
+	for _, prefix := range []string{
+		"org:", "root:", "attachments:", "policy_targets:",
+		"account:", "account_ids:", "children:", "parent:",
+	} {
+		t.Run(prefix, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			state := &errOrgState{
+				inner: inner, prefix: prefix, err: errors.New("store unavailable"),
+				onPut: true, armed: true,
+			}
+			p := newOrgFaultFixture(t, state)
+			if _, err := p.EnsureOrganizationForTest(t.Context(), orgTestAccount); err == nil {
+				t.Errorf("expected a failed %s write to refuse auto-creation, got an organization", prefix)
+			}
+		})
+	}
+}
+
+// TestOrganizations_RecordWriteFailuresPropagate covers the record half of each
+// save, the counterpart to the index half. Reporting a save successful when the
+// record never landed is the worse direction: the listing names an ID that no
+// Describe can resolve.
+func TestOrganizations_RecordWriteFailuresPropagate(t *testing.T) {
+	newFixture := func(t *testing.T, prefix string) *emulator.OrganizationsPlugin {
+		t.Helper()
+		inner := emulator.NewMemoryStateManager()
+		state := &errOrgState{
+			inner: inner, prefix: prefix, err: errors.New("store unavailable"),
+			onPut: true, armed: true,
+		}
+		return newOrgFaultFixture(t, state)
+	}
+	ctx := t.Context()
+
+	t.Run("OU record", func(t *testing.T) {
+		p := newFixture(t, "ou:")
+		ou := emulator.OrgOrganizationalUnit{ID: "ou-abcd-11112222", Name: "prod"}
+		if err := p.SaveOUForTest(ctx, orgTestAccount, ou); err == nil {
+			t.Error("expected the OU record write failure to propagate")
+		}
+	})
+	t.Run("policy record", func(t *testing.T) {
+		p := newFixture(t, "policy:")
+		pol := emulator.OrgPolicy{
+			PolicySummary: emulator.OrgPolicySummary{ID: "p-11112222", Name: "deny", Type: emulator.OrgPolicyTypeSCPForTest},
+		}
+		if err := p.SavePolicyForTest(ctx, orgTestAccount, pol); err == nil {
+			t.Error("expected the policy record write failure to propagate")
+		}
+	})
+	t.Run("create-account-status record", func(t *testing.T) {
+		p := newFixture(t, "car:")
+		st := emulator.OrgCreateAccountStatus{ID: "car-11112222", AccountName: "dev", State: "IN_PROGRESS"}
+		if err := p.SaveCreateAccountStatusForTest(ctx, orgTestAccount, st); err == nil {
+			t.Error("expected the request record write failure to propagate")
+		}
+	})
+	t.Run("tags", func(t *testing.T) {
+		p := newFixture(t, "tags:")
+		if err := p.SaveTagsForTest(ctx, orgTestAccount, []emulator.OrgTag{{Key: "Owner", Value: "x"}}); err == nil {
+			t.Error("expected the tag write failure to propagate")
+		}
+	})
+	t.Run("placement", func(t *testing.T) {
+		p := newFixture(t, "children:")
+		if err := p.PlaceChildForTest(ctx, "r-abcd", "ou-abcd-11112222"); err == nil {
+			t.Error("expected the placement write failure to propagate")
+		}
+	})
+}
+
+// TestOrganizations_CorruptRecordsAreErrors asserts every record loader reports an
+// unreadable record rather than reporting the entity absent. Reporting absent is
+// the dangerous direction: the caller's next step is to create the entity again,
+// on top of one that is still in the store.
+func TestOrganizations_CorruptRecordsAreErrors(t *testing.T) {
+	newFixture := func(t *testing.T, prefix string) *emulator.OrganizationsPlugin {
+		t.Helper()
+		inner := emulator.NewMemoryStateManager()
+		return newOrgFaultFixture(t, &corruptOrgState{StateManager: inner, prefix: prefix, armed: true})
+	}
+	ctx := t.Context()
+
+	t.Run("account", func(t *testing.T) {
+		if _, err := newFixture(t, "account:").LoadAccountForTest(ctx, orgTestAccount); err == nil {
+			t.Error("expected an unreadable account record to be an error")
+		}
+	})
+	t.Run("policy", func(t *testing.T) {
+		if _, err := newFixture(t, "policy:").LoadPolicyForTest(ctx, "p-11112222"); err == nil {
+			t.Error("expected an unreadable policy record to be an error")
+		}
+	})
+	t.Run("OU", func(t *testing.T) {
+		if _, err := newFixture(t, "ou:").LoadOUForTest(ctx, "ou-abcd-11112222"); err == nil {
+			t.Error("expected an unreadable OU record to be an error")
+		}
+	})
+	t.Run("create-account-status", func(t *testing.T) {
+		if _, err := newFixture(t, "car:").LoadCreateAccountStatusForTest(ctx, "car-11112222"); err == nil {
+			t.Error("expected an unreadable request record to be an error")
+		}
+	})
+	t.Run("parent", func(t *testing.T) {
+		if _, err := newFixture(t, "parent:").LoadParentForTest(ctx, orgTestAccount); err == nil {
+			t.Error("expected an unreadable placement record to be an error")
+		}
+	})
+}
+
+// TestOrganizations_ResolveTargetReadFailures covers the remaining lookups
+// resolveOrgTarget performs. It answers one of four kinds or "no such entity", and
+// every caller turns "" into a not-found refusal, so a swallowed failure anywhere
+// in the chain tells the consumer its resource does not exist.
+func TestOrganizations_ResolveTargetReadFailures(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		id     string
+	}{
+		{"root", "root:", ""},
+		{"policy", "policy:", "p-11112222"},
+		{"account", "account:", "111111111111"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			state := &errOrgState{inner: inner, prefix: c.prefix, err: errors.New("store unavailable"), onGet: true}
+			p := newOrgFaultFixture(t, state)
+			root, err := p.LoadRootForTest(t.Context(), orgTestAccount)
+			if err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+			id := c.id
+			if id == "" {
+				id = root.ID
+			}
+			state.armed = true
+			if _, err := p.ResolveOrgTargetForTest(t.Context(), orgTestAccount, id); err == nil {
+				t.Errorf("expected the %s read failure to propagate rather than resolve to 'no such target'", c.name)
+			}
+		})
+	}
+}
+
+// TestOrganizations_InitializeDefaultsTheClock covers the branch taken when no
+// time controller is supplied. Leaving p.tc nil there would panic on the first
+// timestamped write rather than fall back, so the fallback is what keeps a plugin
+// constructed outside the server usable.
+func TestOrganizations_InitializeDefaultsTheClock(t *testing.T) {
+	p := &emulator.OrganizationsPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:  emulator.NewMemoryStateManager(),
+		Logger: emulator.NewDefaultLogger(0, false),
+	}); err != nil {
+		t.Fatalf("initialize with no time controller: %v", err)
+	}
+	// The management account carries a JoinedAt from the clock, so auto-creation
+	// is what would panic on a nil controller.
+	if _, err := p.EnsureOrganizationForTest(t.Context(), orgTestAccount); err != nil {
+		t.Errorf("expected auto-creation to work on the default clock: %v", err)
+	}
+}
+
+// TestOrganizations_EmptyBodyIsNotAnError pins that an operation with no body at
+// all is treated as an empty request rather than a parse failure. The AWS CLI
+// sends no body for a no-argument call like ListRoots, so refusing it would make
+// every such call fail.
+func TestOrganizations_EmptyBodyIsNotAnError(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	for _, op := range []string{"ListRoots", "ListAccounts", "DescribeOrganization"} {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", http.NoBody)
+		if err != nil {
+			t.Fatalf("%s: build request: %v", op, err)
+		}
+		req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+		req.Header.Set("X-Amz-Target", "Organizations_20161128."+op)
+		req.Host = "organizations.us-east-1.amazonaws.com"
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", op, err)
+		}
+		gotStatus := resp.StatusCode
+		resp.Body.Close() //nolint:errcheck
+		if gotStatus != http.StatusOK {
+			t.Errorf("%s: expected 200 for an empty body, got %d", op, gotStatus)
+		}
+	}
+}
+
+// TestOrganizations_OUDepthTerminatesOnACycle asserts the depth walk is bounded.
+// A cycle in the placement index is unreachable through the API, but an unbounded
+// walk over one would hang the server rather than fail a request, and a hang is
+// the one failure a deterministic emulator cannot let a test observe.
+func TestOrganizations_OUDepthTerminatesOnACycle(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	root, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	a := "ou-" + root.ID[2:] + "-aaaaaaaa"
+	b := "ou-" + root.ID[2:] + "-bbbbbbbb"
+	if err := p.PlaceChildForTest(ctx, a, b); err != nil {
+		t.Fatalf("place b under a: %v", err)
+	}
+	// Closing the loop by hand; placeChild would not produce this.
+	if err := p.PlaceChildForTest(ctx, b, a); err != nil {
+		t.Fatalf("place a under b: %v", err)
+	}
+
+	depth, err := p.OUDepthForTest(ctx, a)
+	if err != nil {
+		t.Fatalf("ou depth over a cycle: %v", err)
+	}
+	if depth <= 0 {
+		t.Errorf("expected a bounded positive depth, got %d", depth)
+	}
+}
+
+// TestOrganizations_ShutdownIsANoOp pins that shutting the plugin down neither
+// errors nor discards state, which is what the registry's shutdown sweep relies
+// on when a run ends mid-journey.
+func TestOrganizations_ShutdownIsANoOp(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	p := newOrgFaultFixture(t, state)
+	ctx := t.Context()
+
+	before, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	if err := p.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	after, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root after shutdown: %v", err)
+	}
+	if after.ID != before.ID {
+		t.Errorf("the root changed identity across shutdown: %q became %q", before.ID, after.ID)
+	}
+}

--- a/emulator/organizations_ou.go
+++ b/emulator/organizations_ou.go
@@ -1,0 +1,8 @@
+package emulator
+
+// ouOperation claims the organizational-unit and hierarchy operations. The
+// hierarchy itself lives in organizations_state.go; this file owns only the
+// operations that read and build it.
+func (p *OrganizationsPlugin) ouOperation(_ string) (orgHandler, bool) {
+	return nil, false
+}

--- a/emulator/organizations_plugin.go
+++ b/emulator/organizations_plugin.go
@@ -6,18 +6,33 @@ import (
 	"fmt"
 	"math/rand" // nosemgrep
 	"net/http"
-	"sort"
 	"time"
 )
 
 // OrganizationsPlugin emulates the AWS Organizations service.
-// It supports CRUD operations on organizations and accounts using the
-// Organizations JSON-target protocol (X-Amz-Target: Organizations_20161128.{Op}).
+// It supports the organization, root, OU, policy, account and tagging
+// operations using the Organizations JSON-target protocol
+// (X-Amz-Target: Organizations_20161128.{Op}).
+//
+// The organization, its root, and its management account are auto-created on
+// first observation, and all three keep one identity for the life of the state
+// store — a caller can attach a policy to the root, re-read it, and find the
+// same root (#577).
+//
+// Asynchronous CreateAccount requests resolve on first observation rather than
+// after an interval of the simulated clock: DescribeCreateAccountStatus reports
+// IN_PROGRESS at most once and then a terminal state, so a waiter converges in
+// one poll with no dependence on wall-clock or simulated time. Transitions
+// driven by the simulated clock are the subject of #514, which is still open;
+// picking a shape for them here would front-run that design.
 type OrganizationsPlugin struct {
 	state  StateManager
 	logger Logger
 	tc     *TimeController
 }
+
+// orgHandler handles one Organizations operation.
+type orgHandler func(*RequestContext, *AWSRequest) (*AWSResponse, error)
 
 // Name returns the service name "organizations".
 func (p *OrganizationsPlugin) Name() string { return organizationsNamespace }
@@ -37,289 +52,169 @@ func (p *OrganizationsPlugin) Initialize(_ context.Context, cfg PluginConfig) er
 // Shutdown is a no-op for OrganizationsPlugin.
 func (p *OrganizationsPlugin) Shutdown(_ context.Context) error { return nil }
 
-// HandleRequest dispatches an Organizations JSON-target request to the appropriate handler.
+// HandleRequest dispatches an Organizations JSON-target request to the first
+// operation cluster that claims it. The clusters live in separate files
+// (organizations_ou.go, organizations_policy.go, and so on) and each owns its own
+// claim function, so adding an operation touches one file rather than a shared
+// switch.
 func (p *OrganizationsPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	switch req.Operation {
+	for _, claim := range []func(string) (orgHandler, bool){
+		p.coreOperation,
+		p.ouOperation,
+		p.policyOperation,
+		p.accountOperation,
+		p.tagOperation,
+	} {
+		if h, ok := claim(req.Operation); ok {
+			return h(ctx, req)
+		}
+	}
+	return nil, orgInvalidAction(req.Operation)
+}
+
+// coreOperation claims the organization- and root-level reads.
+func (p *OrganizationsPlugin) coreOperation(op string) (orgHandler, bool) {
+	switch op {
 	case "DescribeOrganization":
-		return p.describeOrganization(ctx, req)
+		return p.describeOrganization, true
 	case "ListAccounts":
-		return p.listAccounts(ctx, req)
+		return p.listAccounts, true
 	case "DescribeAccount":
-		return p.describeAccount(ctx, req)
+		return p.describeAccount, true
 	case "ListRoots":
-		return p.listRoots(ctx, req)
-	case "CreateAccount":
-		return p.createAccount(ctx, req)
+		return p.listRoots, true
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "OrganizationsPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, false
 	}
-}
-
-// --- state keys ---
-
-func orgKey(acct string) string           { return "org:" + acct }
-func orgAccountKey(id string) string      { return "account:" + id }
-func orgAccountIDsKey(acct string) string { return "account_ids:" + acct }
-
-// --- auto-create helpers ---
-
-// ensureOrganization returns the organization for acct, creating it on first call.
-func (p *OrganizationsPlugin) ensureOrganization(ctx context.Context, acct string) (*Organization, error) {
-	data, err := p.state.Get(ctx, organizationsNamespace, orgKey(acct))
-	if err != nil {
-		return nil, fmt.Errorf("get org: %w", err)
-	}
-	if data != nil {
-		var org Organization
-		if unmarshalErr := json.Unmarshal(data, &org); unmarshalErr != nil {
-			return nil, fmt.Errorf("unmarshal org: %w", unmarshalErr)
-		}
-		return &org, nil
-	}
-
-	// Auto-create.
-	orgID := "o-" + randomLowerAlphanum(10)
-	org := Organization{
-		ID:                 orgID,
-		Arn:                fmt.Sprintf("arn:aws:organizations::%s:organization/%s", acct, orgID),
-		FeatureSet:         "ALL",
-		MasterAccountID:    acct,
-		MasterAccountArn:   fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", acct, orgID, acct),
-		MasterAccountEmail: "master@example.com",
-	}
-	if saveErr := p.saveOrg(ctx, acct, org); saveErr != nil {
-		return nil, saveErr
-	}
-
-	// Auto-create the master account entry.
-	masterAccount := OrgAccount{
-		ID:       acct,
-		Arn:      org.MasterAccountArn,
-		Name:     "master",
-		Email:    "master@example.com",
-		Status:   "ACTIVE",
-		JoinedAt: p.tc.Now(),
-	}
-	if saveErr := p.saveAccount(ctx, acct, masterAccount); saveErr != nil {
-		return nil, saveErr
-	}
-
-	return &org, nil
-}
-
-func (p *OrganizationsPlugin) saveOrg(ctx context.Context, acct string, org Organization) error {
-	data, err := json.Marshal(org)
-	if err != nil {
-		return fmt.Errorf("marshal org: %w", err)
-	}
-	return p.state.Put(ctx, organizationsNamespace, orgKey(acct), data)
-}
-
-func (p *OrganizationsPlugin) saveAccount(ctx context.Context, masterAcct string, a OrgAccount) error {
-	data, err := json.Marshal(a)
-	if err != nil {
-		return fmt.Errorf("marshal account: %w", err)
-	}
-	if err := p.state.Put(ctx, organizationsNamespace, orgAccountKey(a.ID), data); err != nil {
-		return fmt.Errorf("put account: %w", err)
-	}
-	// Update account IDs index.
-	ids, _ := p.loadAccountIDs(ctx, masterAcct)
-	for _, id := range ids {
-		if id == a.ID {
-			return nil
-		}
-	}
-	ids = append(ids, a.ID)
-	sort.Strings(ids)
-	return p.saveAccountIDs(ctx, masterAcct, ids)
-}
-
-func (p *OrganizationsPlugin) loadAccount(ctx context.Context, accountID string) (*OrgAccount, error) {
-	data, err := p.state.Get(ctx, organizationsNamespace, orgAccountKey(accountID))
-	if err != nil {
-		return nil, fmt.Errorf("get account: %w", err)
-	}
-	if data == nil {
-		return nil, nil
-	}
-	var a OrgAccount
-	if err := json.Unmarshal(data, &a); err != nil {
-		return nil, fmt.Errorf("unmarshal account: %w", err)
-	}
-	return &a, nil
-}
-
-func (p *OrganizationsPlugin) loadAccountIDs(ctx context.Context, masterAcct string) ([]string, error) {
-	data, err := p.state.Get(ctx, organizationsNamespace, orgAccountIDsKey(masterAcct))
-	if err != nil {
-		return nil, fmt.Errorf("get account ids: %w", err)
-	}
-	if data == nil {
-		return nil, nil
-	}
-	var ids []string
-	if err := json.Unmarshal(data, &ids); err != nil {
-		return nil, fmt.Errorf("unmarshal account ids: %w", err)
-	}
-	return ids, nil
-}
-
-func (p *OrganizationsPlugin) saveAccountIDs(ctx context.Context, masterAcct string, ids []string) error {
-	data, err := json.Marshal(ids)
-	if err != nil {
-		return fmt.Errorf("marshal account ids: %w", err)
-	}
-	return p.state.Put(ctx, organizationsNamespace, orgAccountIDsKey(masterAcct), data)
 }
 
 // --- operations ---
 
 func (p *OrganizationsPlugin) describeOrganization(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
-	org, err := p.ensureOrganization(context.Background(), reqCtx.AccountID)
+	goCtx := context.Background()
+	org, err := p.ensureOrganization(goCtx, reqCtx.AccountID)
 	if err != nil {
 		return nil, fmt.Errorf("describeOrganization: %w", err)
 	}
-	out := map[string]interface{}{"Organization": org}
-	body, err := json.Marshal(out)
+	// The feature set is read through the control plane so a seed set after the
+	// organization was created still governs what the caller observes.
+	featureSet, err := p.effectiveFeatureSet(goCtx, reqCtx.AccountID)
 	if err != nil {
-		return nil, fmt.Errorf("describeOrganization marshal: %w", err)
+		return nil, fmt.Errorf("describeOrganization feature set: %w", err)
 	}
-	return &AWSResponse{Body: body, StatusCode: http.StatusOK}, nil
+	org.FeatureSet = featureSet
+	if featureSet == orgFeatureSetAll {
+		org.AvailablePolicyTypes = []OrgPolicyTypeSummary{{Type: orgPolicyTypeSCP, Status: "ENABLED"}}
+	}
+	return orgJSONResponse(map[string]interface{}{"Organization": org}, "describeOrganization")
 }
 
-func (p *OrganizationsPlugin) listAccounts(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
-	// Ensure org exists so master account is always present.
-	if _, err := p.ensureOrganization(context.Background(), reqCtx.AccountID); err != nil {
+func (p *OrganizationsPlugin) listAccounts(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	// Ensure org exists so the management account is always present.
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
 		return nil, fmt.Errorf("listAccounts ensure org: %w", err)
 	}
 
-	ids, err := p.loadAccountIDs(context.Background(), reqCtx.AccountID)
+	var input struct {
+		NextToken  string `json:"NextToken"`
+		MaxResults int    `json:"MaxResults"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+
+	ids, err := p.loadAccountIDs(goCtx, reqCtx.AccountID)
 	if err != nil {
 		return nil, fmt.Errorf("listAccounts load ids: %w", err)
 	}
+	page, next, err := orgPaginate(ids, input.NextToken, input.MaxResults)
+	if err != nil {
+		return nil, err
+	}
 
-	accounts := make([]OrgAccount, 0, len(ids))
-	for _, id := range ids {
-		a, loadErr := p.loadAccount(context.Background(), id)
-		if loadErr != nil || a == nil {
+	accounts := make([]OrgAccount, 0, len(page))
+	for _, id := range page {
+		a, loadErr := p.loadAccount(goCtx, id)
+		if loadErr != nil {
+			return nil, fmt.Errorf("listAccounts load account: %w", loadErr)
+		}
+		if a == nil {
 			continue
 		}
 		accounts = append(accounts, *a)
 	}
 
-	out := map[string]interface{}{
-		"Accounts":  accounts,
-		"NextToken": "",
+	out := map[string]interface{}{"Accounts": accounts}
+	if next != "" {
+		out["NextToken"] = next
 	}
-	body, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("listAccounts marshal: %w", err)
-	}
-	return &AWSResponse{Body: body, StatusCode: http.StatusOK}, nil
+	return orgJSONResponse(out, "listAccounts")
 }
 
-func (p *OrganizationsPlugin) describeAccount(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) describeAccount(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("describeAccount ensure org: %w", err)
+	}
+
 	var input struct {
 		AccountID string `json:"AccountId"`
 	}
-	if err := json.Unmarshal(req.Body, &input); err != nil {
-		return nil, &AWSError{Code: "MalformedData", Message: "invalid JSON: " + err.Error(), HTTPStatus: http.StatusBadRequest}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
 	}
 
-	a, err := p.loadAccount(context.Background(), input.AccountID)
+	a, err := p.loadAccount(goCtx, input.AccountID)
 	if err != nil {
 		return nil, fmt.Errorf("describeAccount load: %w", err)
 	}
 	if a == nil {
-		return nil, &AWSError{
-			Code:       "AccountNotFoundException",
-			Message:    "Account not found: " + input.AccountID,
-			HTTPStatus: http.StatusNotFound,
-		}
+		return nil, orgErr("AccountNotFoundException",
+			"We can't find an Amazon Web Services account with the AccountId "+input.AccountID)
 	}
-
-	out := map[string]interface{}{"Account": a}
-	body, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("describeAccount marshal: %w", err)
-	}
-	return &AWSResponse{Body: body, StatusCode: http.StatusOK}, nil
+	return orgJSONResponse(map[string]interface{}{"Account": a}, "describeAccount")
 }
 
-func (p *OrganizationsPlugin) listRoots(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
-	// Ensure org is initialized.
-	org, err := p.ensureOrganization(context.Background(), reqCtx.AccountID)
-	if err != nil {
-		return nil, fmt.Errorf("listRoots ensure org: %w", err)
-	}
-
-	rootID := "r-" + randomLowerHex(4)
-	root := OrgRoot{
-		ID:   rootID,
-		Arn:  fmt.Sprintf("arn:aws:organizations::%s:root/%s/%s", reqCtx.AccountID, org.ID, rootID),
-		Name: "Root",
-		PolicyTypes: []OrgPolicyTypeSummary{
-			{Type: "SERVICE_CONTROL_POLICY", Status: "ENABLED"},
-		},
-	}
-
-	out := map[string]interface{}{
-		"Roots":     []OrgRoot{root},
-		"NextToken": "",
-	}
-	body, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("listRoots marshal: %w", err)
-	}
-	return &AWSResponse{Body: body, StatusCode: http.StatusOK}, nil
-}
-
-func (p *OrganizationsPlugin) createAccount(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listRoots(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
 	var input struct {
-		AccountName string `json:"AccountName"`
-		Email       string `json:"Email"`
+		NextToken  string `json:"NextToken"`
+		MaxResults int    `json:"MaxResults"`
 	}
-	if err := json.Unmarshal(req.Body, &input); err != nil {
-		return nil, &AWSError{Code: "MalformedData", Message: "invalid JSON: " + err.Error(), HTTPStatus: http.StatusBadRequest}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	// The token is validated even though an organization has exactly one root, so
+	// a caller passing a stale token learns it rather than silently restarting.
+	if _, _, err := orgPaginate([]string{"root"}, input.NextToken, input.MaxResults); err != nil {
+		return nil, err
 	}
 
-	// Ensure org exists.
-	org, err := p.ensureOrganization(context.Background(), reqCtx.AccountID)
+	root, err := p.loadRoot(goCtx, reqCtx.AccountID)
 	if err != nil {
-		return nil, fmt.Errorf("createAccount ensure org: %w", err)
+		return nil, fmt.Errorf("listRoots: %w", err)
 	}
+	if root.PolicyTypes == nil {
+		root.PolicyTypes = []OrgPolicyTypeSummary{}
+	}
+	return orgJSONResponse(map[string]interface{}{"Roots": []OrgRoot{*root}}, "listRoots")
+}
 
-	newAcctID := generateOrganizationAccountID()
-	a := OrgAccount{
-		ID:       newAcctID,
-		Arn:      fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", reqCtx.AccountID, org.ID, newAcctID),
-		Name:     input.AccountName,
-		Email:    input.Email,
-		Status:   "ACTIVE",
-		JoinedAt: p.tc.Now(),
-	}
-	if saveErr := p.saveAccount(context.Background(), reqCtx.AccountID, a); saveErr != nil {
-		return nil, fmt.Errorf("createAccount save: %w", saveErr)
-	}
-
-	out := map[string]interface{}{
-		"CreateAccountStatus": map[string]interface{}{
-			"Id":          "car-" + randomLowerAlphanum(8),
-			"AccountName": a.Name,
-			"AccountId":   a.ID,
-			"State":       "SUCCEEDED",
-		},
-	}
+// orgJSONResponse marshals an Organizations response body.
+func orgJSONResponse(out interface{}, op string) (*AWSResponse, error) {
 	body, err := json.Marshal(out)
 	if err != nil {
-		return nil, fmt.Errorf("createAccount marshal: %w", err)
+		return nil, fmt.Errorf("%s marshal: %w", op, err)
 	}
 	return &AWSResponse{Body: body, StatusCode: http.StatusOK}, nil
+}
+
+// orgEmptyResponse is the body of an operation the API model gives no output
+// shape — AttachPolicy, MoveAccount, TagResource and the like answer 200 with an
+// empty JSON object.
+func orgEmptyResponse() *AWSResponse {
+	return &AWSResponse{Body: []byte(`{}`), StatusCode: http.StatusOK}
 }
 
 // --- ID generation helpers ---

--- a/emulator/organizations_plugin_test.go
+++ b/emulator/organizations_plugin_test.go
@@ -163,6 +163,10 @@ func TestOrganizations_CreateAccount_DescribeAccount(t *testing.T) {
 	}
 }
 
+// TestOrganizations_DescribeAccount_NotFound pins the status at 400. Every
+// Organizations exception is 400 — the API model declares no 404 for any of
+// them, AccountNotFoundException included — so the 404 this returned before
+// v0.97.0 was a response a caller could not reproduce against AWS.
 func TestOrganizations_DescribeAccount_NotFound(t *testing.T) {
 	ts := newOrganizationsTestServer(t)
 
@@ -170,8 +174,15 @@ func TestOrganizations_DescribeAccount_NotFound(t *testing.T) {
 		"AccountId": "999999999999",
 	})
 	defer resp.Body.Close() //nolint:errcheck
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if code, _ := out["__type"].(string); code != "AccountNotFoundException" {
+		t.Errorf("expected __type=AccountNotFoundException, got %q", code)
 	}
 }
 

--- a/emulator/organizations_policy.go
+++ b/emulator/organizations_policy.go
@@ -1,0 +1,8 @@
+package emulator
+
+// policyOperation claims the service control policy lifecycle operations. The
+// policy, attachment and FullAWSAccess stores live in organizations_state.go;
+// this file owns only the operations over them.
+func (p *OrganizationsPlugin) policyOperation(_ string) (orgHandler, bool) {
+	return nil, false
+}

--- a/emulator/organizations_state.go
+++ b/emulator/organizations_state.go
@@ -1,0 +1,789 @@
+package emulator
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+)
+
+// Organizations quotas. Every value below is from "Quotas for AWS Organizations"
+// in the Organizations User Guide:
+// https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html
+const (
+	// orgMaxAccounts is the default number of accounts in an organization. AWS
+	// raises this on request; the default is what an untouched account gets, and
+	// it is the value a vending tool's quota handling has to survive.
+	orgMaxAccounts = 10
+
+	// orgMaxOUsPerOrg is the number of OUs an organization may contain.
+	orgMaxOUsPerOrg = 2000
+
+	// orgMaxOUDepth is the number of OU levels below the root. A sixth level is
+	// refused with ConstraintViolationException/OU_DEPTH_LIMIT_EXCEEDED.
+	orgMaxOUDepth = 5
+
+	// orgMaxSCPsPerOrg is the number of service control policies an organization
+	// may contain.
+	orgMaxSCPsPerOrg = 10000
+
+	// orgMaxSCPsPerTarget is the number of SCPs attachable to one root, OU, or
+	// account. Note this is the SCP number: the 5-per-target figure belongs to
+	// resource control policies, which substrate does not model.
+	orgMaxSCPsPerTarget = 10
+
+	// orgMinSCPsPerTarget is the number of SCPs that must remain attached to an
+	// entity while the SCP type is enabled — which is why p-FullAWSAccess exists
+	// and why detaching the last policy is refused.
+	orgMinSCPsPerTarget = 1
+
+	// orgMaxSCPBytes is the maximum size of an SCP document, in characters.
+	// Again the SCP number: 5120 is the RCP limit.
+	orgMaxSCPBytes = 10240
+
+	// orgMaxTagsPerResource is the number of tags attachable to one account, OU,
+	// root, or policy.
+	orgMaxTagsPerResource = 50
+
+	// orgMaxResults is the ceiling the API model puts on MaxResults for every
+	// paginated Organizations operation.
+	orgMaxResults = 20
+)
+
+// Organizations entity kinds, as ParentType, ChildType and the TargetType of a
+// PolicyTargetSummary spell them.
+const (
+	orgKindRoot    = "ROOT"
+	orgKindOU      = "ORGANIZATIONAL_UNIT"
+	orgKindAccount = "ACCOUNT"
+
+	// orgKindPolicy is not a ParentType or ChildType — it exists because a policy
+	// is taggable, so resolveOrgTarget has to be able to name one.
+	orgKindPolicy = "POLICY"
+)
+
+// Organizations policy types substrate models.
+const orgPolicyTypeSCP = "SERVICE_CONTROL_POLICY"
+
+// Organization feature sets.
+const (
+	orgFeatureSetAll                 = "ALL"
+	orgFeatureSetConsolidatedBilling = "CONSOLIDATED_BILLING"
+)
+
+// p-FullAWSAccess, the AWS-managed SCP that permits everything. AWS attaches it
+// to the root, to every OU, and to every account when the SCP type is enabled,
+// and the minimum-attachment rule then prevents it being detached without
+// another SCP in its place. Substrate synthesizes it rather than storing it, so
+// it cannot be updated or deleted, and its ARN is owned by "aws" rather than by
+// the organization's management account.
+const (
+	orgFullAWSAccessID      = "p-FullAWSAccess"
+	orgFullAWSAccessName    = "FullAWSAccess"
+	orgFullAWSAccessArn     = "arn:aws:organizations::aws:policy/service_control_policy/p-FullAWSAccess"
+	orgFullAWSAccessContent = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`
+)
+
+// --- state keys ---
+
+func orgKey(acct string) string           { return "org:" + acct }
+func orgRootKey(acct string) string       { return "root:" + acct }
+func orgAccountKey(id string) string      { return "account:" + id }
+func orgAccountIDsKey(acct string) string { return "account_ids:" + acct }
+
+// orgParentKey holds the ID of the root or OU that directly contains child.
+func orgParentKey(child string) string { return "parent:" + child }
+
+// orgChildrenKey holds the sorted IDs of the accounts and OUs directly inside
+// parent. The two directions are stored separately so ListParents and
+// ListChildren are both single reads.
+func orgChildrenKey(parent string) string { return "children:" + parent }
+
+func orgOUKey(id string) string      { return "ou:" + id }
+func orgOUIDsKey(acct string) string { return "ou_ids:" + acct }
+
+func orgPolicyKey(id string) string      { return "policy:" + id }
+func orgPolicyIDsKey(acct string) string { return "policy_ids:" + acct }
+
+// orgAttachmentsKey holds the sorted policy IDs attached to a target.
+func orgAttachmentsKey(target string) string { return "attachments:" + target }
+
+// orgPolicyTargetsKey holds the sorted target IDs a policy is attached to.
+func orgPolicyTargetsKey(policy string) string { return "policy_targets:" + policy }
+
+// orgTagsKey holds the tags on an account, OU, root, or policy.
+func orgTagsKey(resource string) string { return "tags:" + resource }
+
+func orgCreateStatusKey(id string) string      { return "car:" + id }
+func orgCreateStatusIDsKey(acct string) string { return "car_ids:" + acct }
+
+// --- errors ---
+//
+// Every Organizations exception is HTTP 400. The API model declares no 404 for
+// any of them, including AccountNotFoundException, and the SDKs match on the
+// error code rather than the status — so a 404 here is a shape a caller cannot
+// reproduce against AWS.
+
+// orgErr returns an Organizations error with the given code at HTTP 400.
+func orgErr(code, message string) *AWSError {
+	return &AWSError{Code: code, Message: message, HTTPStatus: http.StatusBadRequest}
+}
+
+// orgInvalidInput returns InvalidInputException. reason is a member of the
+// model's InvalidInputExceptionReason enum and is included in the message,
+// because the JSON-RPC error document substrate emits carries only a code and a
+// message — a caller that needs to distinguish two InvalidInputExceptions has
+// nothing else to read.
+func orgInvalidInput(reason, message string) *AWSError {
+	return orgErr("InvalidInputException", fmt.Sprintf("%s: %s", reason, message))
+}
+
+// orgConstraintViolation returns ConstraintViolationException with a reason from
+// the model's ConstraintViolationExceptionReason enum, carried in the message
+// for the same reason orgInvalidInput carries its own.
+func orgConstraintViolation(reason, message string) *AWSError {
+	return orgErr("ConstraintViolationException", fmt.Sprintf("%s: %s", reason, message))
+}
+
+// orgInvalidAction reports an operation the plugin does not implement.
+func orgInvalidAction(op string) *AWSError {
+	return orgErr("InvalidAction", "OrganizationsPlugin: unsupported operation "+op)
+}
+
+// orgUnmarshal decodes a request body, answering InvalidInputException rather
+// than a generic malformed-data code: the caller's catch branch is written
+// against the Organizations exception, and no Organizations operation can return
+// anything else for a body it cannot parse.
+func orgUnmarshal(body []byte, out interface{}) error {
+	if len(body) == 0 {
+		body = []byte("{}")
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return orgInvalidInput("INVALID_PATTERN", "could not parse request body: "+err.Error())
+	}
+	return nil
+}
+
+// --- generic state helpers ---
+
+// orgGetJSON loads and decodes the value at key. It reports found=false when the
+// key is absent, so callers can distinguish "no such entity" from a read error.
+func (p *OrganizationsPlugin) orgGetJSON(ctx context.Context, key string, out interface{}) (bool, error) {
+	data, err := p.state.Get(ctx, organizationsNamespace, key)
+	if err != nil {
+		return false, fmt.Errorf("get %s: %w", key, err)
+	}
+	if data == nil {
+		return false, nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return false, fmt.Errorf("unmarshal %s: %w", key, err)
+	}
+	return true, nil
+}
+
+// orgPutJSON encodes and stores v at key.
+func (p *OrganizationsPlugin) orgPutJSON(ctx context.Context, key string, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", key, err)
+	}
+	if err := p.state.Put(ctx, organizationsNamespace, key, data); err != nil {
+		return fmt.Errorf("put %s: %w", key, err)
+	}
+	return nil
+}
+
+// orgLoadIDs loads a sorted ID index, returning an empty slice when absent.
+func (p *OrganizationsPlugin) orgLoadIDs(ctx context.Context, key string) ([]string, error) {
+	var ids []string
+	if _, err := p.orgGetJSON(ctx, key, &ids); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+// orgAddID adds id to the sorted index at key if it is not already there, and
+// reports whether it added it.
+func (p *OrganizationsPlugin) orgAddID(ctx context.Context, key, id string) (bool, error) {
+	ids, err := p.orgLoadIDs(ctx, key)
+	if err != nil {
+		return false, err
+	}
+	for _, existing := range ids {
+		if existing == id {
+			return false, nil
+		}
+	}
+	ids = append(ids, id)
+	sort.Strings(ids)
+	if err := p.orgPutJSON(ctx, key, ids); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// orgRemoveID removes id from the sorted index at key and reports whether it was
+// present.
+func (p *OrganizationsPlugin) orgRemoveID(ctx context.Context, key, id string) (bool, error) {
+	ids, err := p.orgLoadIDs(ctx, key)
+	if err != nil {
+		return false, err
+	}
+	kept := make([]string, 0, len(ids))
+	found := false
+	for _, existing := range ids {
+		if existing == id {
+			found = true
+			continue
+		}
+		kept = append(kept, existing)
+	}
+	if !found {
+		return false, nil
+	}
+	if err := p.orgPutJSON(ctx, key, kept); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// --- pagination ---
+
+// orgPaginate returns one page of ids and the token for the next, honoring the
+// MaxResults ceiling the API model declares (1-20; 0 means "unset", which AWS
+// treats as the maximum). The token is the opaque encoding of the last ID
+// returned, and is empty when the listing is exhausted — a caller looping until
+// NextToken is empty terminates.
+//
+// An unreadable token is InvalidInputException/INVALID_NEXT_TOKEN rather than a
+// silent restart from the beginning: a paginating caller that restarts sees
+// duplicates instead of an error, which is the failure mode hardest to notice.
+func orgPaginate(ids []string, nextToken string, maxResults int) (page []string, next string, err error) {
+	sorted := make([]string, len(ids))
+	copy(sorted, ids)
+	sort.Strings(sorted)
+
+	start := 0
+	if nextToken != "" {
+		decoded, decodeErr := base64.StdEncoding.DecodeString(nextToken)
+		if decodeErr != nil {
+			return nil, "", orgInvalidInput("INVALID_NEXT_TOKEN", "the NextToken value is not valid")
+		}
+		found := false
+		for i, id := range sorted {
+			if id == string(decoded) {
+				start = i + 1
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, "", orgInvalidInput("INVALID_NEXT_TOKEN", "the NextToken value is not valid")
+		}
+	}
+
+	limit := maxResults
+	if limit <= 0 || limit > orgMaxResults {
+		limit = orgMaxResults
+	}
+
+	end := start + limit
+	if end > len(sorted) {
+		end = len(sorted)
+	}
+	page = sorted[start:end]
+	if end < len(sorted) && len(page) > 0 {
+		next = base64.StdEncoding.EncodeToString([]byte(page[len(page)-1]))
+	}
+	return page, next, nil
+}
+
+// --- organization, root and feature set ---
+
+// ensureOrganization returns the organization for acct, creating it — along with
+// its root, its management account, and the FullAWSAccess attachments AWS makes
+// — on first call.
+func (p *OrganizationsPlugin) ensureOrganization(ctx context.Context, acct string) (*Organization, error) {
+	var org Organization
+	found, err := p.orgGetJSON(ctx, orgKey(acct), &org)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		return &org, nil
+	}
+
+	// Auto-create. The feature set comes from the control-plane seed when one is
+	// set, so a test can have the organization exist in CONSOLIDATED_BILLING mode
+	// from its very first observation rather than being switched afterwards.
+	featureSet, err := p.effectiveFeatureSet(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	orgID := "o-" + randomLowerAlphanum(10)
+	org = Organization{
+		ID:                 orgID,
+		Arn:                fmt.Sprintf("arn:aws:organizations::%s:organization/%s", acct, orgID),
+		FeatureSet:         featureSet,
+		MasterAccountID:    acct,
+		MasterAccountArn:   fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", acct, orgID, acct),
+		MasterAccountEmail: "master@example.com",
+	}
+	if err := p.orgPutJSON(ctx, orgKey(acct), org); err != nil {
+		return nil, err
+	}
+
+	// The root is created once, with the organization, and persisted. Minting it
+	// per request left it with no stable identity, so nothing could reference it
+	// (#577).
+	rootID := "r-" + randomLowerHex(4)
+	root := OrgRoot{
+		ID:   rootID,
+		Arn:  fmt.Sprintf("arn:aws:organizations::%s:root/%s/%s", acct, orgID, rootID),
+		Name: "Root",
+	}
+	// An ALL-features organization has SERVICE_CONTROL_POLICY enabled from the
+	// start; under CONSOLIDATED_BILLING no policy type is available at all, which
+	// is what CreateOrganization documents for that mode.
+	if featureSet == orgFeatureSetAll {
+		root.PolicyTypes = []OrgPolicyTypeSummary{{Type: orgPolicyTypeSCP, Status: "ENABLED"}}
+	}
+	if err := p.orgPutJSON(ctx, orgRootKey(acct), root); err != nil {
+		return nil, err
+	}
+	if featureSet == orgFeatureSetAll {
+		if _, err := p.attachPolicyTo(ctx, orgFullAWSAccessID, rootID); err != nil {
+			return nil, err
+		}
+	}
+
+	// Auto-create the management account, placed in the root.
+	masterAccount := OrgAccount{
+		ID:           acct,
+		Arn:          org.MasterAccountArn,
+		Name:         "master",
+		Email:        "master@example.com",
+		Status:       "ACTIVE",
+		JoinedMethod: "INVITED",
+		JoinedAt:     p.tc.Now(),
+	}
+	if err := p.saveAccount(ctx, acct, masterAccount); err != nil {
+		return nil, err
+	}
+	if err := p.placeChild(ctx, rootID, acct); err != nil {
+		return nil, err
+	}
+	if err := p.attachFullAWSAccess(ctx, acct, acct); err != nil {
+		return nil, err
+	}
+
+	return &org, nil
+}
+
+// loadRoot returns the organization's root, creating the organization if needed.
+// The returned root's PolicyTypes reflect the effective feature set: under
+// CONSOLIDATED_BILLING no policy type is available, which is what
+// CreateOrganization documents for that mode.
+func (p *OrganizationsPlugin) loadRoot(ctx context.Context, acct string) (*OrgRoot, error) {
+	if _, err := p.ensureOrganization(ctx, acct); err != nil {
+		return nil, err
+	}
+	var root OrgRoot
+	found, err := p.orgGetJSON(ctx, orgRootKey(acct), &root)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("organizations: root missing for account %s", acct)
+	}
+	featureSet, err := p.effectiveFeatureSet(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	if featureSet != orgFeatureSetAll {
+		root.PolicyTypes = nil
+	}
+	return &root, nil
+}
+
+// saveRoot persists the root as-is. Callers that mutate PolicyTypes must read
+// the stored root rather than the one loadRoot returns, since loadRoot masks
+// PolicyTypes under CONSOLIDATED_BILLING.
+func (p *OrganizationsPlugin) saveRoot(ctx context.Context, acct string, root OrgRoot) error {
+	return p.orgPutJSON(ctx, orgRootKey(acct), root)
+}
+
+// loadStoredRoot returns the root exactly as persisted, without the feature-set
+// masking loadRoot applies.
+func (p *OrganizationsPlugin) loadStoredRoot(ctx context.Context, acct string) (*OrgRoot, error) {
+	if _, err := p.ensureOrganization(ctx, acct); err != nil {
+		return nil, err
+	}
+	var root OrgRoot
+	found, err := p.orgGetJSON(ctx, orgRootKey(acct), &root)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("organizations: root missing for account %s", acct)
+	}
+	return &root, nil
+}
+
+// scpEnabled reports whether SERVICE_CONTROL_POLICY is available and enabled for
+// the organization's root. Two separate conditions collapse into one answer: the
+// type is unavailable under CONSOLIDATED_BILLING, and available-but-disabled
+// after DisablePolicyType. Attaching is refused either way, but with different
+// codes, so callers that need to tell them apart consult effectiveFeatureSet.
+func (p *OrganizationsPlugin) scpEnabled(ctx context.Context, acct string) (bool, error) {
+	root, err := p.loadRoot(ctx, acct)
+	if err != nil {
+		return false, err
+	}
+	for _, pt := range root.PolicyTypes {
+		if pt.Type == orgPolicyTypeSCP && pt.Status == "ENABLED" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// --- accounts ---
+
+func (p *OrganizationsPlugin) saveAccount(ctx context.Context, masterAcct string, a OrgAccount) error {
+	if err := p.orgPutJSON(ctx, orgAccountKey(a.ID), a); err != nil {
+		return err
+	}
+	if _, err := p.orgAddID(ctx, orgAccountIDsKey(masterAcct), a.ID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadAccount returns the account, or (nil, nil) when there is no such account.
+func (p *OrganizationsPlugin) loadAccount(ctx context.Context, accountID string) (*OrgAccount, error) {
+	var a OrgAccount
+	found, err := p.orgGetJSON(ctx, orgAccountKey(accountID), &a)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil //nolint:nilnil // (nil, nil) = "no such account", handled by caller.
+	}
+	return &a, nil
+}
+
+func (p *OrganizationsPlugin) loadAccountIDs(ctx context.Context, masterAcct string) ([]string, error) {
+	return p.orgLoadIDs(ctx, orgAccountIDsKey(masterAcct))
+}
+
+// --- hierarchy ---
+
+// placeChild makes parent the direct container of child, removing child from any
+// previous parent. Both directions of the index are updated together so a move
+// cannot leave a child reachable from two parents.
+func (p *OrganizationsPlugin) placeChild(ctx context.Context, parent, child string) error {
+	prev, err := p.loadParent(ctx, child)
+	if err != nil {
+		return err
+	}
+	if prev == parent {
+		return nil
+	}
+	if prev != "" {
+		if _, err := p.orgRemoveID(ctx, orgChildrenKey(prev), child); err != nil {
+			return err
+		}
+	}
+	if _, err := p.orgAddID(ctx, orgChildrenKey(parent), child); err != nil {
+		return err
+	}
+	return p.orgPutJSON(ctx, orgParentKey(child), parent)
+}
+
+// loadParent returns the ID of the entity directly containing child, or "" when
+// child has no recorded parent.
+func (p *OrganizationsPlugin) loadParent(ctx context.Context, child string) (string, error) {
+	var parent string
+	if _, err := p.orgGetJSON(ctx, orgParentKey(child), &parent); err != nil {
+		return "", err
+	}
+	return parent, nil
+}
+
+// loadChildren returns the sorted IDs directly inside parent.
+func (p *OrganizationsPlugin) loadChildren(ctx context.Context, parent string) ([]string, error) {
+	return p.orgLoadIDs(ctx, orgChildrenKey(parent))
+}
+
+// ouDepth returns how many OU levels separate ouID from the root: 1 for an OU
+// directly in the root, 2 for one nested inside that, and so on. It returns 0
+// for a root. The walk is bounded by orgMaxOUDepth+2 so a corrupt index cannot
+// loop forever.
+func (p *OrganizationsPlugin) ouDepth(ctx context.Context, ouID string) (int, error) {
+	if !isOrgOUID(ouID) {
+		return 0, nil
+	}
+	depth := 0
+	current := ouID
+	for i := 0; i <= orgMaxOUDepth+2; i++ {
+		if !isOrgOUID(current) {
+			return depth, nil
+		}
+		depth++
+		parent, err := p.loadParent(ctx, current)
+		if err != nil {
+			return 0, err
+		}
+		if parent == "" {
+			return depth, nil
+		}
+		current = parent
+	}
+	return depth, nil
+}
+
+// isOrgOUID reports whether id has the "ou-" prefix that distinguishes an OU
+// from a root or an account in a ParentId or ChildId.
+func isOrgOUID(id string) bool { return len(id) > 3 && id[:3] == "ou-" }
+
+// isOrgRootID reports whether id has the "r-" prefix of a root.
+func isOrgRootID(id string) bool { return len(id) > 2 && id[:2] == "r-" }
+
+// --- organizational units ---
+
+func (p *OrganizationsPlugin) saveOU(ctx context.Context, acct string, ou OrgOrganizationalUnit) error {
+	if err := p.orgPutJSON(ctx, orgOUKey(ou.ID), ou); err != nil {
+		return err
+	}
+	if _, err := p.orgAddID(ctx, orgOUIDsKey(acct), ou.ID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadOU returns the OU, or (nil, nil) when there is no such OU.
+func (p *OrganizationsPlugin) loadOU(ctx context.Context, ouID string) (*OrgOrganizationalUnit, error) {
+	var ou OrgOrganizationalUnit
+	found, err := p.orgGetJSON(ctx, orgOUKey(ouID), &ou)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil //nolint:nilnil // (nil, nil) = "no such OU", handled by caller.
+	}
+	return &ou, nil
+}
+
+func (p *OrganizationsPlugin) loadOUIDs(ctx context.Context, acct string) ([]string, error) {
+	return p.orgLoadIDs(ctx, orgOUIDsKey(acct))
+}
+
+// --- policies ---
+
+func (p *OrganizationsPlugin) savePolicy(ctx context.Context, acct string, pol OrgPolicy) error {
+	if err := p.orgPutJSON(ctx, orgPolicyKey(pol.PolicySummary.ID), pol); err != nil {
+		return err
+	}
+	if _, err := p.orgAddID(ctx, orgPolicyIDsKey(acct), pol.PolicySummary.ID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadPolicy returns the policy, or (nil, nil) when there is no such policy.
+// p-FullAWSAccess is synthesized rather than read, so it exists in every
+// organization and cannot be written to.
+func (p *OrganizationsPlugin) loadPolicy(ctx context.Context, policyID string) (*OrgPolicy, error) {
+	if policyID == orgFullAWSAccessID {
+		full := fullAWSAccessPolicy()
+		return &full, nil
+	}
+	var pol OrgPolicy
+	found, err := p.orgGetJSON(ctx, orgPolicyKey(policyID), &pol)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil //nolint:nilnil // (nil, nil) = "no such policy", handled by caller.
+	}
+	return &pol, nil
+}
+
+func (p *OrganizationsPlugin) loadPolicyIDs(ctx context.Context, acct string) ([]string, error) {
+	return p.orgLoadIDs(ctx, orgPolicyIDsKey(acct))
+}
+
+// fullAWSAccessPolicy returns the AWS-managed SCP that allows everything.
+func fullAWSAccessPolicy() OrgPolicy {
+	return OrgPolicy{
+		PolicySummary: OrgPolicySummary{
+			ID:          orgFullAWSAccessID,
+			Arn:         orgFullAWSAccessArn,
+			Name:        orgFullAWSAccessName,
+			Description: "Allows access to every operation",
+			Type:        orgPolicyTypeSCP,
+			AwsManaged:  true,
+		},
+		Content: orgFullAWSAccessContent,
+	}
+}
+
+// --- policy attachments ---
+
+// attachPolicyTo records an attachment in both directions and reports whether it
+// was new.
+func (p *OrganizationsPlugin) attachPolicyTo(ctx context.Context, policyID, targetID string) (bool, error) {
+	added, err := p.orgAddID(ctx, orgAttachmentsKey(targetID), policyID)
+	if err != nil {
+		return false, err
+	}
+	if _, err := p.orgAddID(ctx, orgPolicyTargetsKey(policyID), targetID); err != nil {
+		return false, err
+	}
+	return added, nil
+}
+
+// detachPolicyFrom removes an attachment in both directions and reports whether
+// it was there.
+func (p *OrganizationsPlugin) detachPolicyFrom(ctx context.Context, policyID, targetID string) (bool, error) {
+	removed, err := p.orgRemoveID(ctx, orgAttachmentsKey(targetID), policyID)
+	if err != nil {
+		return false, err
+	}
+	if _, err := p.orgRemoveID(ctx, orgPolicyTargetsKey(policyID), targetID); err != nil {
+		return false, err
+	}
+	return removed, nil
+}
+
+// attachFullAWSAccess attaches p-FullAWSAccess to a newly created OU or account,
+// which is what AWS does while the SCP type is enabled. It is a no-op when the
+// type is not enabled, matching an organization whose entities never carried an
+// SCP. The root's own attachment is made inline by ensureOrganization, before
+// the root record is readable.
+func (p *OrganizationsPlugin) attachFullAWSAccess(ctx context.Context, acct, targetID string) error {
+	enabled, err := p.scpEnabled(ctx, acct)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		return nil
+	}
+	if _, err := p.attachPolicyTo(ctx, orgFullAWSAccessID, targetID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadAttachments returns the sorted policy IDs attached to target.
+func (p *OrganizationsPlugin) loadAttachments(ctx context.Context, target string) ([]string, error) {
+	return p.orgLoadIDs(ctx, orgAttachmentsKey(target))
+}
+
+// loadPolicyTargets returns the sorted target IDs a policy is attached to.
+func (p *OrganizationsPlugin) loadPolicyTargets(ctx context.Context, policyID string) ([]string, error) {
+	return p.orgLoadIDs(ctx, orgPolicyTargetsKey(policyID))
+}
+
+// --- tags ---
+
+// loadTags returns the tags on a resource, in key order.
+func (p *OrganizationsPlugin) loadTags(ctx context.Context, resourceID string) ([]OrgTag, error) {
+	var tags []OrgTag
+	if _, err := p.orgGetJSON(ctx, orgTagsKey(resourceID), &tags); err != nil {
+		return nil, err
+	}
+	sort.Slice(tags, func(i, j int) bool { return tags[i].Key < tags[j].Key })
+	return tags, nil
+}
+
+// saveTags replaces the tags on a resource.
+func (p *OrganizationsPlugin) saveTags(ctx context.Context, resourceID string, tags []OrgTag) error {
+	sort.Slice(tags, func(i, j int) bool { return tags[i].Key < tags[j].Key })
+	return p.orgPutJSON(ctx, orgTagsKey(resourceID), tags)
+}
+
+// --- target resolution ---
+
+// resolveOrgTarget names what id refers to — a root, OU, account, or policy —
+// or returns "" when the organization contains no such entity. Callers turn ""
+// into whichever not-found code their operation documents, which differs per
+// operation: TargetNotFoundException for an attachment or a tag,
+// ParentNotFoundException for a listing, AccountNotFoundException for a move.
+func (p *OrganizationsPlugin) resolveOrgTarget(ctx context.Context, acct, id string) (string, error) {
+	if id == "" {
+		return "", nil
+	}
+	switch {
+	case isOrgRootID(id):
+		root, err := p.loadRoot(ctx, acct)
+		if err != nil {
+			return "", err
+		}
+		if root.ID == id {
+			return orgKindRoot, nil
+		}
+		return "", nil
+	case isOrgOUID(id):
+		ou, err := p.loadOU(ctx, id)
+		if err != nil {
+			return "", err
+		}
+		if ou != nil {
+			return orgKindOU, nil
+		}
+		return "", nil
+	case len(id) > 2 && id[:2] == "p-":
+		pol, err := p.loadPolicy(ctx, id)
+		if err != nil {
+			return "", err
+		}
+		if pol != nil {
+			return orgKindPolicy, nil
+		}
+		return "", nil
+	default:
+		a, err := p.loadAccount(ctx, id)
+		if err != nil {
+			return "", err
+		}
+		if a != nil {
+			return orgKindAccount, nil
+		}
+		return "", nil
+	}
+}
+
+// --- create-account status ---
+
+func (p *OrganizationsPlugin) saveCreateAccountStatus(ctx context.Context, acct string, st OrgCreateAccountStatus) error {
+	if err := p.orgPutJSON(ctx, orgCreateStatusKey(st.ID), st); err != nil {
+		return err
+	}
+	if _, err := p.orgAddID(ctx, orgCreateStatusIDsKey(acct), st.ID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadCreateAccountStatus returns the status, or (nil, nil) when there is no
+// request with that ID.
+func (p *OrganizationsPlugin) loadCreateAccountStatus(ctx context.Context, id string) (*OrgCreateAccountStatus, error) {
+	var st OrgCreateAccountStatus
+	found, err := p.orgGetJSON(ctx, orgCreateStatusKey(id), &st)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil //nolint:nilnil // (nil, nil) = "no such request", handled by caller.
+	}
+	return &st, nil
+}
+
+func (p *OrganizationsPlugin) loadCreateAccountStatusIDs(ctx context.Context, acct string) ([]string, error) {
+	return p.orgLoadIDs(ctx, orgCreateStatusIDsKey(acct))
+}

--- a/emulator/organizations_state_test.go
+++ b/emulator/organizations_state_test.go
@@ -1,0 +1,604 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// newOrganizationsStateFixture returns a plugin wired straight to a memory state
+// manager, for exercising the storage layer without the HTTP surface.
+func newOrganizationsStateFixture(t *testing.T) *emulator.OrganizationsPlugin {
+	t.Helper()
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	return emulator.NewOrganizationsPluginForTest(state, tc)
+}
+
+const orgTestAccount = "000000000000"
+
+// newOrgBadBody returns a body no JSON decoder can parse.
+func newOrgBadBody() io.Reader { return strings.NewReader(`{"AccountId":`) }
+
+// orgListRootsID posts ListRoots and returns the single root's ID.
+func orgListRootsID(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	resp := orgsRequest(t, ts, "ListRoots", map[string]interface{}{})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ListRoots: expected 200, got %d", resp.StatusCode)
+	}
+	var out struct {
+		Roots []struct {
+			ID string `json:"Id"`
+		} `json:"Roots"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("ListRoots decode: %v", err)
+	}
+	if len(out.Roots) != 1 {
+		t.Fatalf("expected exactly 1 root, got %d", len(out.Roots))
+	}
+	return out.Roots[0].ID
+}
+
+// TestOrganizations_ListRoots_StableID is #577's repro: two ListRoots calls
+// disagreeing about the root's identity meant nothing could reference the root,
+// and a caller that attached a policy to it and re-read would conclude the
+// attachment had vanished.
+func TestOrganizations_ListRoots_StableID(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	first := orgListRootsID(t, ts)
+	second := orgListRootsID(t, ts)
+	if first != second {
+		t.Fatalf("root ID changed between ListRoots calls: %q vs %q", first, second)
+	}
+
+	// An unrelated write must not disturb it either.
+	createResp := orgsRequest(t, ts, "CreateAccount", map[string]interface{}{
+		"AccountName": "dev",
+		"Email":       "dev@example.com",
+	})
+	createResp.Body.Close() //nolint:errcheck
+
+	third := orgListRootsID(t, ts)
+	if third != first {
+		t.Fatalf("root ID changed after an unrelated write: %q vs %q", first, third)
+	}
+}
+
+// TestOrganizations_ListRoots_ARNMatchesID checks the ARN is built from the
+// persisted root rather than a freshly minted one, since an unstable ARN is the
+// form of #577 a caller storing the ARN would hit.
+func TestOrganizations_ListRoots_ARNMatchesID(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	resp := orgsRequest(t, ts, "ListRoots", map[string]interface{}{})
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		Roots []struct {
+			ID          string `json:"Id"`
+			Arn         string `json:"Arn"`
+			Name        string `json:"Name"`
+			PolicyTypes []struct {
+				Type   string `json:"Type"`
+				Status string `json:"Status"`
+			} `json:"PolicyTypes"`
+		} `json:"Roots"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Roots) != 1 {
+		t.Fatalf("expected 1 root, got %d", len(out.Roots))
+	}
+	root := out.Roots[0]
+	if root.Name != "Root" {
+		t.Errorf("expected Name=Root, got %q", root.Name)
+	}
+	if suffix := "/" + root.ID; len(root.Arn) < len(suffix) || root.Arn[len(root.Arn)-len(suffix):] != suffix {
+		t.Errorf("ARN %q does not end with the root ID %q", root.Arn, root.ID)
+	}
+	if len(root.PolicyTypes) != 1 || root.PolicyTypes[0].Type != emulator.OrgPolicyTypeSCPForTest ||
+		root.PolicyTypes[0].Status != "ENABLED" {
+		t.Errorf("expected SERVICE_CONTROL_POLICY ENABLED, got %+v", root.PolicyTypes)
+	}
+}
+
+// TestOrganizations_RootPersistsAcrossPlugins checks the root survives a fresh
+// plugin over the same state, which is what a replayed run does.
+func TestOrganizations_RootPersistsAcrossPlugins(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	first := emulator.NewOrganizationsPluginForTest(state, tc)
+	rootA, err := first.LoadRootForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+
+	second := emulator.NewOrganizationsPluginForTest(state, tc)
+	rootB, err := second.LoadRootForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("reload root: %v", err)
+	}
+	if rootA.ID != rootB.ID {
+		t.Fatalf("root ID changed across plugin instances: %q vs %q", rootA.ID, rootB.ID)
+	}
+}
+
+// TestOrganizations_ManagementAccountPlacedInRoot pins #578's placement rule:
+// an account has a parent from the moment it exists, so a ListParents walk has
+// somewhere to start.
+func TestOrganizations_ManagementAccountPlacedInRoot(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+
+	root, err := p.LoadRootForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	parent, err := p.LoadParentForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	if parent != root.ID {
+		t.Errorf("expected management account's parent to be the root %q, got %q", root.ID, parent)
+	}
+	children, err := p.LoadChildrenForTest(t.Context(), root.ID)
+	if err != nil {
+		t.Fatalf("load children: %v", err)
+	}
+	if len(children) != 1 || children[0] != orgTestAccount {
+		t.Errorf("expected the root to contain only the management account, got %v", children)
+	}
+}
+
+// TestOrganizations_FullAWSAccessAttachedOnCreate pins the AWS-managed SCP onto
+// the root and the management account. Without it ListPoliciesForTarget is wrong
+// on a fresh organization, and the minimum-attachment rule has nothing to hold.
+func TestOrganizations_FullAWSAccessAttachedOnCreate(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+
+	root, err := p.LoadRootForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	for _, target := range []string{root.ID, orgTestAccount} {
+		attached, attachErr := p.LoadAttachmentsForTest(t.Context(), target)
+		if attachErr != nil {
+			t.Fatalf("load attachments for %s: %v", target, attachErr)
+		}
+		if len(attached) != 1 || attached[0] != emulator.OrgFullAWSAccessIDForTest {
+			t.Errorf("expected only FullAWSAccess attached to %s, got %v", target, attached)
+		}
+	}
+
+	targets, err := p.LoadPolicyTargetsForTest(t.Context(), emulator.OrgFullAWSAccessIDForTest)
+	if err != nil {
+		t.Fatalf("load policy targets: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Errorf("expected FullAWSAccess attached to 2 targets, got %v", targets)
+	}
+}
+
+// TestOrganizations_FullAWSAccessIsSynthesized checks the AWS-managed policy is
+// readable without ever having been written, is owned by "aws", and is marked
+// AwsManaged — the three properties that make it immutable.
+func TestOrganizations_FullAWSAccessIsSynthesized(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+
+	pol, err := p.LoadPolicyForTest(t.Context(), emulator.OrgFullAWSAccessIDForTest)
+	if err != nil {
+		t.Fatalf("load FullAWSAccess: %v", err)
+	}
+	if pol == nil {
+		t.Fatal("expected FullAWSAccess to exist without being created")
+	}
+	if !pol.PolicySummary.AwsManaged {
+		t.Error("expected AwsManaged=true")
+	}
+	if pol.PolicySummary.Arn != "arn:aws:organizations::aws:policy/service_control_policy/p-FullAWSAccess" {
+		t.Errorf("expected the aws-owned ARN, got %q", pol.PolicySummary.Arn)
+	}
+	// It is not in the organization's own policy index, so it cannot be updated
+	// or deleted through the stored-policy path.
+	ids, err := p.LoadPolicyIDsForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("load policy ids: %v", err)
+	}
+	for _, id := range ids {
+		if id == emulator.OrgFullAWSAccessIDForTest {
+			t.Error("FullAWSAccess must not be in the organization's stored policy index")
+		}
+	}
+}
+
+// TestOrganizations_ConsolidatedBillingHasNoPolicyTypes pins the state where an
+// SCP cannot exist at all: CreateOrganization documents that a
+// CONSOLIDATED_BILLING organization enables no policy type, so the root reports
+// none and FullAWSAccess is not attached.
+func TestOrganizations_ConsolidatedBillingHasNoPolicyTypes(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err := state.Put(t.Context(), "organizations-ctrl", "feature-set",
+		[]byte(`{"featureSet":"CONSOLIDATED_BILLING"}`)); err != nil {
+		t.Fatalf("seed feature set: %v", err)
+	}
+	p := emulator.NewOrganizationsPluginForTest(state, tc)
+
+	root, err := p.LoadRootForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	if len(root.PolicyTypes) != 0 {
+		t.Errorf("expected no policy types under CONSOLIDATED_BILLING, got %+v", root.PolicyTypes)
+	}
+	enabled, err := p.SCPEnabledForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("scp enabled: %v", err)
+	}
+	if enabled {
+		t.Error("expected the SCP type to be unavailable under CONSOLIDATED_BILLING")
+	}
+	attached, err := p.LoadAttachmentsForTest(t.Context(), root.ID)
+	if err != nil {
+		t.Fatalf("load attachments: %v", err)
+	}
+	if len(attached) != 0 {
+		t.Errorf("expected no attachments under CONSOLIDATED_BILLING, got %v", attached)
+	}
+}
+
+// TestOrganizations_DescribeOrganization_FeatureSetSeed checks the seed governs
+// what a caller observes, including for an organization already created in ALL
+// mode — otherwise a test would have to arrange the seed before the very first
+// request, which the seed endpoint cannot guarantee.
+func TestOrganizations_DescribeOrganization_FeatureSetSeed(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	p := emulator.NewOrganizationsPluginForTest(state, tc)
+
+	if _, err := p.EnsureOrganizationForTest(t.Context(), orgTestAccount); err != nil {
+		t.Fatalf("ensure org: %v", err)
+	}
+	got, err := p.EffectiveFeatureSetForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("effective feature set: %v", err)
+	}
+	if got != "ALL" {
+		t.Fatalf("expected ALL by default, got %q", got)
+	}
+
+	if err := state.Put(t.Context(), "organizations-ctrl", "feature-set",
+		[]byte(`{"featureSet":"CONSOLIDATED_BILLING"}`)); err != nil {
+		t.Fatalf("seed feature set: %v", err)
+	}
+	got, err = p.EffectiveFeatureSetForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("effective feature set after seed: %v", err)
+	}
+	if got != "CONSOLIDATED_BILLING" {
+		t.Errorf("expected the seed to win over the stored value, got %q", got)
+	}
+}
+
+// TestOrganizations_ResolveTarget covers every entity kind resolveOrgTarget has
+// to name, since the policy and tagging operations both branch on its answer.
+func TestOrganizations_ResolveTarget(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+	ctx := t.Context()
+
+	root, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	ouID := "ou-" + root.ID[2:] + "-abcd1234"
+	if err := p.SaveOUForTest(ctx, orgTestAccount, emulator.OrgOrganizationalUnit{
+		ID: ouID, Arn: "arn:aws:organizations::" + orgTestAccount + ":ou/o-x/" + ouID, Name: "prod",
+	}); err != nil {
+		t.Fatalf("save OU: %v", err)
+	}
+	if err := p.SavePolicyForTest(ctx, orgTestAccount, emulator.OrgPolicy{
+		PolicySummary: emulator.OrgPolicySummary{ID: "p-abcdefgh", Name: "deny", Type: emulator.OrgPolicyTypeSCPForTest},
+		Content:       `{}`,
+	}); err != nil {
+		t.Fatalf("save policy: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"root", root.ID, emulator.OrgKindRootForTest},
+		{"ou", ouID, emulator.OrgKindOUForTest},
+		{"account", orgTestAccount, emulator.OrgKindAccountForTest},
+		{"policy", "p-abcdefgh", emulator.OrgKindPolicyForTest},
+		{"aws managed policy", emulator.OrgFullAWSAccessIDForTest, emulator.OrgKindPolicyForTest},
+		{"unknown root", "r-zzzz", ""},
+		{"unknown ou", "ou-zzzz-99999999", ""},
+		{"unknown account", "999999999999", ""},
+		{"unknown policy", "p-zzzzzzzz", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, resolveErr := p.ResolveOrgTargetForTest(ctx, orgTestAccount, tt.id)
+			if resolveErr != nil {
+				t.Fatalf("resolve %q: %v", tt.id, resolveErr)
+			}
+			if got != tt.want {
+				t.Errorf("resolve %q: expected %q, got %q", tt.id, tt.want, got)
+			}
+		})
+	}
+}
+
+// TestOrganizations_PlaceChildMovesExclusively checks a move leaves the child
+// reachable from exactly one parent. A stale entry in the old parent's list would
+// let ListAccountsForParent report the same account in two places.
+func TestOrganizations_PlaceChildMovesExclusively(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+	ctx := t.Context()
+
+	root, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	ouID := "ou-" + root.ID[2:] + "-11112222"
+	if err := p.PlaceChildForTest(ctx, ouID, orgTestAccount); err != nil {
+		t.Fatalf("place child: %v", err)
+	}
+
+	rootChildren, err := p.LoadChildrenForTest(ctx, root.ID)
+	if err != nil {
+		t.Fatalf("load root children: %v", err)
+	}
+	if len(rootChildren) != 0 {
+		t.Errorf("expected the account to have left the root, still there: %v", rootChildren)
+	}
+	ouChildren, err := p.LoadChildrenForTest(ctx, ouID)
+	if err != nil {
+		t.Fatalf("load OU children: %v", err)
+	}
+	if len(ouChildren) != 1 || ouChildren[0] != orgTestAccount {
+		t.Errorf("expected the account under the OU, got %v", ouChildren)
+	}
+	parent, err := p.LoadParentForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	if parent != ouID {
+		t.Errorf("expected parent %q, got %q", ouID, parent)
+	}
+
+	// Re-placing under the same parent is idempotent, not a duplicate.
+	if err := p.PlaceChildForTest(ctx, ouID, orgTestAccount); err != nil {
+		t.Fatalf("re-place child: %v", err)
+	}
+	ouChildren, err = p.LoadChildrenForTest(ctx, ouID)
+	if err != nil {
+		t.Fatalf("reload OU children: %v", err)
+	}
+	if len(ouChildren) != 1 {
+		t.Errorf("expected no duplicate child entry, got %v", ouChildren)
+	}
+}
+
+// TestOrganizations_OUDepth walks a chain to the documented maximum. The depth
+// limit is a boundary an off-by-one hides: a 5-deep tree is legal and a 6th level
+// is not, and both nominal runs look identical.
+func TestOrganizations_OUDepth(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+	ctx := t.Context()
+
+	root, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	if depth, depthErr := p.OUDepthForTest(ctx, root.ID); depthErr != nil || depth != 0 {
+		t.Fatalf("expected the root at depth 0, got %d (err %v)", depth, depthErr)
+	}
+
+	parent := root.ID
+	suffixes := []string{"aaaaaaaa", "bbbbbbbb", "cccccccc", "dddddddd", "eeeeeeee", "ffffffff"}
+	for i, suffix := range suffixes {
+		ouID := "ou-" + root.ID[2:] + "-" + suffix
+		if err := p.PlaceChildForTest(ctx, parent, ouID); err != nil {
+			t.Fatalf("place OU %d: %v", i, err)
+		}
+		depth, depthErr := p.OUDepthForTest(ctx, ouID)
+		if depthErr != nil {
+			t.Fatalf("depth of OU %d: %v", i, depthErr)
+		}
+		if depth != i+1 {
+			t.Errorf("OU %d: expected depth %d, got %d", i, i+1, depth)
+		}
+		parent = ouID
+	}
+	// The chain reached six levels, one past the documented limit, so a handler
+	// comparing against orgMaxOUDepth refuses the last one.
+	if emulator.OrgMaxOUDepthForTest != 5 {
+		t.Errorf("expected the documented OU depth limit of 5, got %d", emulator.OrgMaxOUDepthForTest)
+	}
+}
+
+// TestOrganizations_Paginate covers the clamp, termination, and the token a
+// caller loops on. A truncated listing that never terminates or silently
+// restarts is the failure mode hardest for a consumer to notice.
+func TestOrganizations_Paginate(t *testing.T) {
+	ids := []string{"e", "d", "c", "b", "a"}
+
+	t.Run("sorts and returns everything by default", func(t *testing.T) {
+		page, next, err := emulator.OrgPaginateForTest(ids, "", 0)
+		if err != nil {
+			t.Fatalf("paginate: %v", err)
+		}
+		if next != "" {
+			t.Errorf("expected no NextToken, got %q", next)
+		}
+		if got := len(page); got != 5 {
+			t.Fatalf("expected 5 items, got %d", got)
+		}
+		if page[0] != "a" || page[4] != "e" {
+			t.Errorf("expected sorted order, got %v", page)
+		}
+	})
+
+	t.Run("honors MaxResults and terminates", func(t *testing.T) {
+		var seen []string
+		token := ""
+		for i := 0; i < 10; i++ {
+			page, next, err := emulator.OrgPaginateForTest(ids, token, 2)
+			if err != nil {
+				t.Fatalf("paginate: %v", err)
+			}
+			if len(page) > 2 {
+				t.Fatalf("expected at most 2 per page, got %d", len(page))
+			}
+			seen = append(seen, page...)
+			if next == "" {
+				break
+			}
+			token = next
+		}
+		if len(seen) != 5 {
+			t.Errorf("expected to walk all 5 items, saw %v", seen)
+		}
+	})
+
+	t.Run("clamps MaxResults to the model ceiling", func(t *testing.T) {
+		many := make([]string, 40)
+		for i := range many {
+			many[i] = string(rune('a'+i/26)) + string(rune('a'+i%26))
+		}
+		page, next, err := emulator.OrgPaginateForTest(many, "", 1000)
+		if err != nil {
+			t.Fatalf("paginate: %v", err)
+		}
+		if len(page) != emulator.OrgMaxResultsForTest {
+			t.Errorf("expected the page clamped to %d, got %d", emulator.OrgMaxResultsForTest, len(page))
+		}
+		if next == "" {
+			t.Error("expected a NextToken for a truncated listing")
+		}
+	})
+
+	t.Run("rejects an unreadable token", func(t *testing.T) {
+		if _, _, err := emulator.OrgPaginateForTest(ids, "not-base64!!", 0); err == nil {
+			t.Fatal("expected an error for a malformed NextToken")
+		}
+		if _, _, err := emulator.OrgPaginateForTest(ids, "enp6eg==", 0); err == nil {
+			t.Fatal("expected an error for a token naming an unknown item")
+		}
+	})
+}
+
+// TestOrganizations_MalformedBodyIsInvalidInput pins the code for an unparseable
+// request. The Organizations model has no generic malformed-data exception, so a
+// caller's catch branch is written against InvalidInputException.
+func TestOrganizations_MalformedBodyIsInvalidInput(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/",
+		newOrgBadBody())
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "Organizations_20161128.DescribeAccount")
+	req.Host = "organizations.us-east-1.amazonaws.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if code, _ := out["__type"].(string); code != "InvalidInputException" {
+		t.Errorf("expected __type=InvalidInputException, got %q", code)
+	}
+}
+
+// TestOrganizations_UnsupportedOperation checks the claim chain's fallthrough:
+// an operation no cluster claims is InvalidAction rather than a panic or a
+// silent empty success.
+func TestOrganizations_UnsupportedOperation(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	resp := orgsRequest(t, ts, "LeaveOrganization", map[string]interface{}{})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if code, _ := out["__type"].(string); code != "InvalidAction" {
+		t.Errorf("expected __type=InvalidAction, got %q", code)
+	}
+}
+
+// TestOrganizations_ListAccountsPaginates checks the pagination wiring on a real
+// operation, not just the helper.
+func TestOrganizations_ListAccountsPaginates(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	for i := 0; i < 3; i++ {
+		resp := orgsRequest(t, ts, "CreateAccount", map[string]interface{}{
+			"AccountName": "acct",
+			"Email":       "a@example.com",
+		})
+		resp.Body.Close() //nolint:errcheck
+	}
+
+	seen := map[string]bool{}
+	token := ""
+	for i := 0; i < 10; i++ {
+		body := map[string]interface{}{"MaxResults": 2}
+		if token != "" {
+			body["NextToken"] = token
+		}
+		resp := orgsRequest(t, ts, "ListAccounts", body)
+		var out struct {
+			Accounts []struct {
+				ID string `json:"Id"`
+			} `json:"Accounts"`
+			NextToken string `json:"NextToken"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			resp.Body.Close() //nolint:errcheck
+			t.Fatalf("decode: %v", err)
+		}
+		resp.Body.Close() //nolint:errcheck
+		if len(out.Accounts) > 2 {
+			t.Fatalf("expected at most 2 accounts per page, got %d", len(out.Accounts))
+		}
+		for _, a := range out.Accounts {
+			seen[a.ID] = true
+		}
+		if out.NextToken == "" {
+			break
+		}
+		token = out.NextToken
+	}
+	// Three created plus the management account.
+	if len(seen) != 4 {
+		t.Errorf("expected to page through 4 accounts, saw %d", len(seen))
+	}
+}

--- a/emulator/organizations_store_test.go
+++ b/emulator/organizations_store_test.go
@@ -1,0 +1,354 @@
+package emulator_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestOrganizations_SaveRootRoundTrip covers the pair a policy-type change needs:
+// saveRoot writes PolicyTypes verbatim and loadStoredRoot reads it back without
+// the feature-set masking loadRoot applies. Reading through loadRoot instead would
+// make a disable look like it worked under CONSOLIDATED_BILLING, where the mask
+// hides the field either way.
+func TestOrganizations_SaveRootRoundTrip(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+	ctx := t.Context()
+
+	root, err := p.LoadStoredRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load stored root: %v", err)
+	}
+	if len(root.PolicyTypes) != 1 || root.PolicyTypes[0].Type != emulator.OrgPolicyTypeSCPForTest {
+		t.Fatalf("expected SERVICE_CONTROL_POLICY enabled on a fresh ALL-features root, got %v", root.PolicyTypes)
+	}
+
+	// Disabling the type is a write of the stored root, so the round trip is what
+	// Lane B's DisablePolicyType stands on.
+	root.PolicyTypes = nil
+	if err := p.SaveRootForTest(ctx, orgTestAccount, *root); err != nil {
+		t.Fatalf("save root: %v", err)
+	}
+	reloaded, err := p.LoadStoredRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("reload stored root: %v", err)
+	}
+	if len(reloaded.PolicyTypes) != 0 {
+		t.Errorf("expected no policy types after the write, got %v", reloaded.PolicyTypes)
+	}
+	if reloaded.ID != root.ID {
+		t.Errorf("the write changed the root ID: %q became %q", root.ID, reloaded.ID)
+	}
+	enabled, err := p.SCPEnabledForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("scp enabled: %v", err)
+	}
+	if enabled {
+		t.Error("expected SCPs reported disabled once the root carries no policy type")
+	}
+}
+
+// TestOrganizations_OUIndex checks the per-organization OU index that
+// ListOrganizationalUnitsForParent reads. An OU written but missing from the index
+// is invisible to every listing while DescribeOrganizationalUnit still finds it —
+// a split that looks like a pagination bug.
+func TestOrganizations_OUIndex(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+	ctx := t.Context()
+
+	ids, err := p.LoadOUIDsForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load OU IDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected no OUs in a fresh organization, got %v", ids)
+	}
+
+	root, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	for _, suffix := range []string{"bbbbbbbb", "aaaaaaaa"} {
+		ou := emulator.OrgOrganizationalUnit{
+			ID:   "ou-" + root.ID[2:] + "-" + suffix,
+			Arn:  "arn:aws:organizations::" + orgTestAccount + ":ou/o-test/ou-" + suffix,
+			Name: suffix,
+		}
+		if err := p.SaveOUForTest(ctx, orgTestAccount, ou); err != nil {
+			t.Fatalf("save OU %s: %v", suffix, err)
+		}
+	}
+
+	ids, err = p.LoadOUIDsForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("reload OU IDs: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 indexed OUs, got %v", ids)
+	}
+	// The index is sorted, so a paginated listing is stable across calls.
+	if ids[0] >= ids[1] {
+		t.Errorf("expected the OU index sorted, got %v", ids)
+	}
+
+	loaded, err := p.LoadOUForTest(ctx, ids[0])
+	if err != nil {
+		t.Fatalf("load OU: %v", err)
+	}
+	if loaded == nil || loaded.ID != ids[0] {
+		t.Fatalf("expected to load %q, got %v", ids[0], loaded)
+	}
+	missing, err := p.LoadOUForTest(ctx, "ou-zzzz-99999999")
+	if err != nil {
+		t.Fatalf("load unknown OU: %v", err)
+	}
+	if missing != nil {
+		t.Errorf("expected nil for an unknown OU, got %v", missing)
+	}
+}
+
+// TestOrganizations_DetachPolicy checks a detach clears both directions of the
+// attachment index. Clearing only one leaves ListPoliciesForTarget and
+// ListTargetsForPolicy contradicting each other, which is the shape of bug that
+// makes a re-run of a governance script attach a policy it thinks is missing.
+func TestOrganizations_DetachPolicy(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+	ctx := t.Context()
+
+	root, err := p.LoadRootForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+
+	attached, err := p.LoadAttachmentsForTest(ctx, root.ID)
+	if err != nil {
+		t.Fatalf("load attachments: %v", err)
+	}
+	if len(attached) != 1 || attached[0] != emulator.OrgFullAWSAccessIDForTest {
+		t.Fatalf("expected FullAWSAccess on the root, got %v", attached)
+	}
+
+	removed, err := p.DetachPolicyFromForTest(ctx, emulator.OrgFullAWSAccessIDForTest, root.ID)
+	if err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	if !removed {
+		t.Error("expected the detach to report it removed an attachment")
+	}
+	attached, err = p.LoadAttachmentsForTest(ctx, root.ID)
+	if err != nil {
+		t.Fatalf("reload attachments: %v", err)
+	}
+	if len(attached) != 0 {
+		t.Errorf("expected no attachments on the root, got %v", attached)
+	}
+	// The reverse index loses the root but keeps the management account, which
+	// carries its own attachment.
+	targets, err := p.LoadPolicyTargetsForTest(ctx, emulator.OrgFullAWSAccessIDForTest)
+	if err != nil {
+		t.Fatalf("load policy targets: %v", err)
+	}
+	if len(targets) != 1 || targets[0] != orgTestAccount {
+		t.Errorf("expected only the management account left as a target, got %v", targets)
+	}
+
+	// Detaching what is not attached reports false rather than erroring, so a
+	// handler can turn it into PolicyNotAttachedException itself.
+	removed, err = p.DetachPolicyFromForTest(ctx, emulator.OrgFullAWSAccessIDForTest, root.ID)
+	if err != nil {
+		t.Fatalf("second detach: %v", err)
+	}
+	if removed {
+		t.Error("expected the second detach to report nothing removed")
+	}
+}
+
+// TestOrganizations_Tags covers the tag store for the four taggable kinds. Tags
+// are read back in key order because ListTagsForResource paginates: an unordered
+// store would shuffle pages between calls and lose entries.
+func TestOrganizations_Tags(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+	ctx := t.Context()
+
+	tags, err := p.LoadTagsForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load tags: %v", err)
+	}
+	if len(tags) != 0 {
+		t.Fatalf("expected an untagged account, got %v", tags)
+	}
+
+	if err := p.SaveTagsForTest(ctx, orgTestAccount, []emulator.OrgTag{
+		{Key: "Owner", Value: "platform"},
+		{Key: "CostCenter", Value: "1234"},
+		{Key: "Empty", Value: ""},
+	}); err != nil {
+		t.Fatalf("save tags: %v", err)
+	}
+
+	tags, err = p.LoadTagsForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("reload tags: %v", err)
+	}
+	if len(tags) != 3 {
+		t.Fatalf("expected 3 tags, got %v", tags)
+	}
+	want := []emulator.OrgTag{
+		{Key: "CostCenter", Value: "1234"},
+		{Key: "Empty", Value: ""},
+		{Key: "Owner", Value: "platform"},
+	}
+	for i, w := range want {
+		if tags[i] != w {
+			t.Errorf("tag %d: expected %v, got %v", i, w, tags[i])
+		}
+	}
+
+	// saveTags replaces rather than merges, which is what UntagResource needs.
+	if err := p.SaveTagsForTest(ctx, orgTestAccount, []emulator.OrgTag{{Key: "Owner", Value: "platform"}}); err != nil {
+		t.Fatalf("replace tags: %v", err)
+	}
+	tags, err = p.LoadTagsForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("reload replaced tags: %v", err)
+	}
+	if len(tags) != 1 || tags[0].Key != "Owner" {
+		t.Errorf("expected the tag set replaced, got %v", tags)
+	}
+}
+
+// TestOrganizations_TagsAreScopedPerResource pins that two resources do not share
+// a tag set. A key collision here would make an OU's tags govern an account, and
+// once tags reach the authorization decision that is a privilege boundary.
+func TestOrganizations_TagsAreScopedPerResource(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+	ctx := t.Context()
+
+	if err := p.SaveTagsForTest(ctx, "ou-abcd-11112222", []emulator.OrgTag{{Key: "Owner", Value: "ou"}}); err != nil {
+		t.Fatalf("save OU tags: %v", err)
+	}
+	if err := p.SaveTagsForTest(ctx, emulator.OrgFullAWSAccessIDForTest, []emulator.OrgTag{{Key: "Owner", Value: "policy"}}); err != nil {
+		t.Fatalf("save policy tags: %v", err)
+	}
+
+	ouTags, err := p.LoadTagsForTest(ctx, "ou-abcd-11112222")
+	if err != nil {
+		t.Fatalf("load OU tags: %v", err)
+	}
+	policyTags, err := p.LoadTagsForTest(ctx, emulator.OrgFullAWSAccessIDForTest)
+	if err != nil {
+		t.Fatalf("load policy tags: %v", err)
+	}
+	if len(ouTags) != 1 || ouTags[0].Value != "ou" {
+		t.Errorf("expected the OU's own tags, got %v", ouTags)
+	}
+	if len(policyTags) != 1 || policyTags[0].Value != "policy" {
+		t.Errorf("expected the policy's own tags, got %v", policyTags)
+	}
+	if accountTags, tagErr := p.LoadTagsForTest(ctx, orgTestAccount); tagErr != nil || len(accountTags) != 0 {
+		t.Errorf("expected the account untouched, got %v (err %v)", accountTags, tagErr)
+	}
+}
+
+// TestOrganizations_CreateAccountStatusStore covers the request store an
+// asynchronous CreateAccount is polled through, including the unknown-ID answer
+// that becomes CreateAccountStatusNotFoundException.
+func TestOrganizations_CreateAccountStatusStore(t *testing.T) {
+	p := newOrganizationsStateFixture(t)
+	ctx := t.Context()
+
+	ids, err := p.LoadCreateAccountStatusIDsForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("load status IDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected no requests in a fresh organization, got %v", ids)
+	}
+
+	requested := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	completed := requested.Add(time.Minute)
+	for _, st := range []emulator.OrgCreateAccountStatus{
+		{ID: "car-bbbbbbbb", AccountName: "prod", State: "IN_PROGRESS", RequestedTimestamp: requested},
+		{
+			ID: "car-aaaaaaaa", AccountName: "dev", State: "FAILED", RequestedTimestamp: requested,
+			CompletedTimestamp: &completed, FailureReason: "EMAIL_ALREADY_EXISTS",
+		},
+	} {
+		if err := p.SaveCreateAccountStatusForTest(ctx, orgTestAccount, st); err != nil {
+			t.Fatalf("save status %s: %v", st.ID, err)
+		}
+	}
+
+	ids, err = p.LoadCreateAccountStatusIDsForTest(ctx, orgTestAccount)
+	if err != nil {
+		t.Fatalf("reload status IDs: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "car-aaaaaaaa" {
+		t.Fatalf("expected 2 sorted request IDs, got %v", ids)
+	}
+
+	failed, err := p.LoadCreateAccountStatusForTest(ctx, "car-aaaaaaaa")
+	if err != nil {
+		t.Fatalf("load failed status: %v", err)
+	}
+	if failed == nil {
+		t.Fatal("expected to load the failed request")
+	}
+	if failed.State != "FAILED" || failed.FailureReason != "EMAIL_ALREADY_EXISTS" || failed.AccountID != "" {
+		t.Errorf("expected a FAILED status carrying no AccountId, got %+v", failed)
+	}
+	if failed.CompletedTimestamp == nil || !failed.CompletedTimestamp.Equal(completed) {
+		t.Errorf("expected the completion timestamp preserved, got %v", failed.CompletedTimestamp)
+	}
+
+	inProgress, err := p.LoadCreateAccountStatusForTest(ctx, "car-bbbbbbbb")
+	if err != nil {
+		t.Fatalf("load in-progress status: %v", err)
+	}
+	if inProgress == nil || inProgress.CompletedTimestamp != nil {
+		t.Errorf("expected an IN_PROGRESS status with no completion timestamp, got %+v", inProgress)
+	}
+
+	missing, err := p.LoadCreateAccountStatusForTest(ctx, "car-99999999")
+	if err != nil {
+		t.Fatalf("load unknown status: %v", err)
+	}
+	if missing != nil {
+		t.Errorf("expected nil for an unknown request ID, got %+v", missing)
+	}
+}
+
+// TestOrganizations_ConstraintViolationShape pins the quota-refusal constructor.
+// Every Organizations exception is HTTP 400, and the reason has to reach the
+// caller: an SDK catch branch reads ConstraintViolationException's reason to tell
+// a quota it can raise from one it cannot.
+func TestOrganizations_ConstraintViolationShape(t *testing.T) {
+	err := emulator.OrgConstraintViolationForTest("ACCOUNT_NUMBER_LIMIT_EXCEEDED", "You have exceeded the limit.")
+	if err.Code != "ConstraintViolationException" {
+		t.Errorf("expected ConstraintViolationException, got %q", err.Code)
+	}
+	if err.HTTPStatus != http.StatusBadRequest {
+		t.Errorf("expected HTTP 400, got %d", err.HTTPStatus)
+	}
+	// The JSON-RPC error shape has no Reason member, so the reason rides in the
+	// message; a caller matching on it needs it verbatim and first.
+	const want = "ACCOUNT_NUMBER_LIMIT_EXCEEDED: You have exceeded the limit."
+	if err.Message != want {
+		t.Errorf("expected message %q, got %q", want, err.Message)
+	}
+}
+
+// TestOrganizations_EmptyResponse pins the body of the operations the API model
+// gives no output shape. An empty body rather than "{}" makes an SDK fail to
+// unmarshal a call that actually succeeded.
+func TestOrganizations_EmptyResponse(t *testing.T) {
+	resp := emulator.OrgEmptyResponseForTest()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if string(resp.Body) != "{}" {
+		t.Errorf("expected an empty JSON object, got %q", resp.Body)
+	}
+}

--- a/emulator/organizations_tags.go
+++ b/emulator/organizations_tags.go
@@ -1,0 +1,8 @@
+package emulator
+
+// tagOperation claims the resource tagging operations. Tags reach the
+// authorization decision through the organizations arms of addRequestTags and
+// addResourceTags in authz.go.
+func (p *OrganizationsPlugin) tagOperation(_ string) (orgHandler, bool) {
+	return nil, false
+}

--- a/emulator/organizations_types.go
+++ b/emulator/organizations_types.go
@@ -13,7 +13,9 @@ type Organization struct {
 	// Arn is the ARN of the organization.
 	Arn string `json:"Arn"`
 
-	// FeatureSet is the set of features enabled for the organization (e.g. "ALL").
+	// FeatureSet is the set of features enabled for the organization,
+	// either "ALL" or "CONSOLIDATED_BILLING". Service control policies exist
+	// only under "ALL"; see OrganizationsPlugin.effectiveFeatureSet.
 	FeatureSet string `json:"FeatureSet"`
 
 	// MasterAccountArn is the ARN of the master (management) account.
@@ -24,6 +26,12 @@ type Organization struct {
 
 	// MasterAccountEmail is the email address of the master account.
 	MasterAccountEmail string `json:"MasterAccountEmail"`
+
+	// AvailablePolicyTypes lists the policy types available in the organization.
+	// AWS marks this member deprecated in favor of the root's PolicyTypes and
+	// documents that it reports only SERVICE_CONTROL_POLICY, but still returns it;
+	// it is omitted under CONSOLIDATED_BILLING, where no policy type is available.
+	AvailablePolicyTypes []OrgPolicyTypeSummary `json:"AvailablePolicyTypes,omitempty"`
 }
 
 // OrgAccount represents an AWS account that is a member of an organization.
@@ -42,6 +50,11 @@ type OrgAccount struct {
 
 	// Status is the account status (e.g. "ACTIVE").
 	Status string `json:"Status"`
+
+	// JoinedMethod is how the account became a member, "CREATED" for an account
+	// CreateAccount made and "INVITED" otherwise. The enum admits only those two
+	// values, and the management account is not created by Organizations.
+	JoinedMethod string `json:"JoinedMethod"`
 
 	// JoinedAt is the time the account joined the organization.
 	JoinedAt time.Time `json:"JoinedTimestamp"`
@@ -69,4 +82,117 @@ type OrgPolicyTypeSummary struct {
 
 	// Status is the enablement status (e.g. "ENABLED").
 	Status string `json:"Status"`
+}
+
+// OrgOrganizationalUnit is a container for accounts within an organization root.
+type OrgOrganizationalUnit struct {
+	// ID is the OU identifier, "ou-{root suffix}-{8 lowercase alphanum}".
+	ID string `json:"Id"`
+
+	// Arn is the ARN of the OU.
+	Arn string `json:"Arn"`
+
+	// Name is the friendly name of the OU, unique among its siblings.
+	Name string `json:"Name"`
+}
+
+// OrgPolicySummary describes a policy without its content.
+type OrgPolicySummary struct {
+	// ID is the policy identifier, "p-" followed by 8-128 alphanumerics or "_".
+	ID string `json:"Id"`
+
+	// Arn is the ARN of the policy. AWS-managed policies are owned by the "aws"
+	// account rather than the organization's management account.
+	Arn string `json:"Arn"`
+
+	// Name is the friendly name of the policy.
+	Name string `json:"Name"`
+
+	// Description is the policy description.
+	Description string `json:"Description"`
+
+	// Type is the policy type (e.g. "SERVICE_CONTROL_POLICY").
+	Type string `json:"Type"`
+
+	// AwsManaged reports whether AWS owns the policy. An AWS-managed policy
+	// cannot be updated, deleted, or detached below the minimum attachment count.
+	AwsManaged bool `json:"AwsManaged"`
+}
+
+// OrgPolicy is a policy and its content, as DescribePolicy returns it.
+type OrgPolicy struct {
+	// PolicySummary describes the policy's identity and type.
+	PolicySummary OrgPolicySummary `json:"PolicySummary"`
+
+	// Content is the text of the policy document.
+	Content string `json:"Content"`
+}
+
+// OrgParent identifies the root or OU that directly contains an entity.
+type OrgParent struct {
+	// ID is the parent identifier (a root or OU ID).
+	ID string `json:"Id"`
+
+	// Type is "ROOT" or "ORGANIZATIONAL_UNIT".
+	Type string `json:"Type"`
+}
+
+// OrgChild identifies an account or OU directly contained by a parent.
+type OrgChild struct {
+	// ID is the child identifier (an account ID or OU ID).
+	ID string `json:"Id"`
+
+	// Type is "ACCOUNT" or "ORGANIZATIONAL_UNIT".
+	Type string `json:"Type"`
+}
+
+// OrgPolicyTargetSummary identifies an entity a policy is attached to.
+type OrgPolicyTargetSummary struct {
+	// TargetID is the root, OU, or account identifier.
+	TargetID string `json:"TargetId"`
+
+	// Arn is the ARN of the target.
+	Arn string `json:"Arn"`
+
+	// Name is the friendly name of the target.
+	Name string `json:"Name"`
+
+	// Type is "ROOT", "ORGANIZATIONAL_UNIT", or "ACCOUNT".
+	Type string `json:"Type"`
+}
+
+// OrgCreateAccountStatus is the observable state of an asynchronous CreateAccount
+// request. CreateAccount returns it as IN_PROGRESS; DescribeCreateAccountStatus
+// reports the resolved outcome.
+type OrgCreateAccountStatus struct {
+	// ID is the request identifier, "car-" followed by 8-32 lowercase alphanum.
+	ID string `json:"Id"`
+
+	// AccountName is the name given in the CreateAccount request.
+	AccountName string `json:"AccountName"`
+
+	// State is "IN_PROGRESS", "SUCCEEDED", or "FAILED".
+	State string `json:"State"`
+
+	// RequestedTimestamp is when CreateAccount was called, on the simulated clock.
+	RequestedTimestamp time.Time `json:"RequestedTimestamp"`
+
+	// CompletedTimestamp is when the request reached a terminal state; the zero
+	// value while IN_PROGRESS.
+	CompletedTimestamp *time.Time `json:"CompletedTimestamp,omitempty"`
+
+	// AccountID is the created account, set only when State is SUCCEEDED.
+	AccountID string `json:"AccountId,omitempty"`
+
+	// FailureReason is why the request failed, set only when State is FAILED.
+	FailureReason string `json:"FailureReason,omitempty"`
+}
+
+// OrgTag is a key-value pair attached to an account, OU, root, or policy.
+type OrgTag struct {
+	// Key is the tag name.
+	Key string `json:"Key"`
+
+	// Value is the tag value; the empty string is permitted, null is not.
+	Value string `json:"Value"`
 }

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -330,6 +330,12 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/ssm/command-invocation", s.handleSSMSeedCommandInvocation)
 	r.Delete("/v1/ssm/command-invocation", s.handleSSMClearCommandInvocation)
 
+	// Organizations control-plane endpoints (#578).
+	r.Post("/v1/organizations/feature-set", s.handleOrganizationsSeedFeatureSet)
+	r.Delete("/v1/organizations/feature-set", s.handleOrganizationsClearFeatureSet)
+	r.Post("/v1/organizations/create-account-failure", s.handleOrganizationsSeedCreateAccountFailure)
+	r.Delete("/v1/organizations/create-account-failure", s.handleOrganizationsClearCreateAccountFailure)
+
 	// Lambda control-plane endpoints (#393).
 	r.Post("/v1/lambda/invoke-error", s.handleLambdaSeedInvokeError)
 	r.Delete("/v1/lambda/invoke-error", s.handleLambdaClearInvokeError)


### PR DESCRIPTION
`ListRoots` minted a fresh `r-` ID on every call and never persisted it:

```go
rootID := "r-" + randomLowerHex(4)   // organizations_plugin.go:261, before
```

Two calls disagreed, the ARN built from it moved with them, and nothing could
reference the root. The failure mode is not an error — a caller attaches a policy
to the root, re-reads, sees a different ID, and concludes the attachment
vanished. That is a determinism defect in the one property substrate exists to
provide.

The root is now created once alongside the organization and the management
account, persisted under `root:<account>`, and returned unchanged for the life of
the state store.

## The storage layer

Every control #578 adds attaches to that root, so this PR also lands the shared
storage the remaining Organizations work is built on — deliberately as one
serial change, so the operation clusters that follow add operations rather than
data structures and can be written independently:

- the hierarchy in both directions (`parent:<child>`, `children:<parent>`), with
  new accounts and the management account placed in the root so a `ListParents`
  walk has somewhere to start
- OU, policy, attachment, tag and `CreateAccount`-status stores with their indices
- `resolveOrgTarget`, which names what an ID refers to — the policy and tagging
  clusters both branch on it
- `orgPaginate`, honoring the model's `MaxResults` ceiling of 20
- the quota constants, each carrying its User Guide value in a doc comment
- error constructors carrying the `Reason` the model documents

The per-operation dispatch `switch` is replaced by a chain of per-cluster claim
functions, four of them currently empty, so each cluster owns one file rather
than contending for one statement.

## `p-FullAWSAccess`

AWS attaches this AWS-managed SCP to the root, every OU and every account when
the SCP type is enabled, and the minimum-one-SCP rule then prevents detaching
it without a replacement. It had zero occurrences in `emulator/` but is
load-bearing: without it a fresh organization reports no attached policies, which
is wrong, and the minimum-attachment rule has nothing to hold. It is synthesized
rather than stored, so it cannot be updated or deleted, and its ARN is owned by
`aws` rather than by the management account.

## Seeds

- `POST`/`DELETE /v1/organizations/feature-set` — sets the feature set, making a
  `CONSOLIDATED_BILLING` organization (one in which no SCP can exist at all)
  reachable. The seed wins over the stored value, so a test can flip an
  already-observed organization rather than having to arrange the seed before the
  first request.
- `POST`/`DELETE /v1/organizations/create-account-failure` — seeds the
  *asynchronous* `CreateAccount` outcome, keyed by account name or `"*"`. An
  unknown `failureReason` is refused with a 400, for the reason the Price List
  seed already gives: a typo'd value would seed a `FAILED` status carrying
  something no SDK catch branch matches, so the caller's fallback path would go
  untested while the test still passed.

## Two fidelity fixes in the same code

- **`AccountNotFoundException` is now 400, not 404.** The API model declares no
  404 for any Organizations error, so the status was one a caller could not
  reproduce against AWS. Updates the assertion in
  `organizations_plugin_test.go`.
- **An unparseable body is `InvalidInputException`, not `MalformedData`**, which
  is not an Organizations code — so an SDK caller's catch branch never matched
  it. The `InvalidInputExceptionReason` is carried in the message, since the
  JSON-RPC error document has nowhere else to put it.

## Compatibility

A fresh organization now reports `FullAWSAccess` attached to the root and to
every account, so a test asserting an empty policy list will see one entry.
`AccountNotFoundException` is 400 rather than 404.

## Verification

```
gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...   # 0 issues
make test                                                                 # race detector on
```

All green. Sources for every code, status and quota: the botocore Organizations
model at `2016-11-28`, and [Quotas for AWS Organizations](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html).
Two figures #578 states are corrected against that page — an SCP limit is **10**
per target and **10,240** characters; 5/5120 are the *RCP* values.

Closes #577