### PR TITLE
feat(organizations): make account vending asynchronous (#578)

### DIFF
--- a/emulator/organizations_account.go
+++ b/emulator/organizations_account.go
@@ -3,26 +3,95 @@ package emulator
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 )
+
+// CreateAccountState values, the model's CreateAccountState enum in full.
+const (
+	orgCreateStateInProgress = "IN_PROGRESS"
+	orgCreateStateSucceeded  = "SUCCEEDED"
+	orgCreateStateFailed     = "FAILED"
+)
+
+// orgCreateAccountStates is the CreateAccountState enum, used to validate the
+// States filter ListCreateAccountStatus takes. A value outside the enum is
+// refused rather than matching nothing: a filter that silently matches nothing
+// reads to the caller as "there are no requests", which is the same answer a
+// correctly spelled filter gives for an organization that has vended nothing.
+var orgCreateAccountStates = []string{
+	orgCreateStateInProgress,
+	orgCreateStateSucceeded,
+	orgCreateStateFailed,
+}
+
+// orgCreatePendingKey holds the outcome an IN_PROGRESS CreateAccount request will
+// resolve to. It is kept apart from the request record so the record itself is
+// always a shape AWS could return — an IN_PROGRESS status carrying the AccountId
+// it is going to get is not, and substrate's state is meant to be inspectable at
+// any point in history.
+func orgCreatePendingKey(id string) string { return "car_pending:" + id }
+
+// orgPendingAccountOutcome is the terminal outcome an asynchronous CreateAccount
+// request is already committed to. Exactly one field is set: an account ID for a
+// request that will succeed, a CreateAccountFailureReason for one that will fail.
+//
+// The outcome is decided when CreateAccount is called, not when the status is
+// first read, so that the account record and the status can never disagree.
+// Deciding it at read time would let a seed cleared between the two produce a
+// SUCCEEDED status naming an account that was never written, or a FAILED status
+// for an account that is in ListAccounts — states real AWS cannot reach.
+type orgPendingAccountOutcome struct {
+	// AccountID is the account the request will report on success.
+	AccountID string `json:"accountId,omitempty"`
+
+	// FailureReason is the CreateAccountFailureReason the request will report.
+	FailureReason string `json:"failureReason,omitempty"`
+}
 
 // accountOperation claims the account vending and placement operations.
 func (p *OrganizationsPlugin) accountOperation(op string) (orgHandler, bool) {
 	switch op {
 	case "CreateAccount":
 		return p.createAccount, true
+	case "DescribeCreateAccountStatus":
+		return p.describeCreateAccountStatus, true
+	case "ListCreateAccountStatus":
+		return p.listCreateAccountStatus, true
+	case "MoveAccount":
+		return p.moveAccount, true
 	default:
 		return nil, false
 	}
 }
 
+// createAccount starts an asynchronous account creation. AWS documents
+// CreateAccount as "an asynchronous request that Amazon Web Services performs in
+// the background", so the call answers IN_PROGRESS with a car- request ID and no
+// AccountId, and the caller polls DescribeCreateAccountStatus with that ID. A
+// synchronous SUCCEEDED — what substrate returned before v0.97.0 — lets a
+// consumer with no poll loop pass its tests, and the poll loop is the part that
+// has to survive being interrupted: the request ID is the only handle a resumed
+// run has on an account that may or may not exist yet.
 func (p *OrganizationsPlugin) createAccount(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
-		AccountName string `json:"AccountName"`
-		Email       string `json:"Email"`
+		AccountName string   `json:"AccountName"`
+		Email       string   `json:"Email"`
+		Tags        []OrgTag `json:"Tags"`
+
+		// RoleName and IamUserAccessToBilling are accepted and recorded nowhere:
+		// no Organizations API observation exposes either, so modeling them would
+		// be modeling the inside of the new account rather than the API surface.
+		RoleName               string `json:"RoleName"`
+		IamUserAccessToBilling string `json:"IamUserAccessToBilling"`
 	}
 	if err := orgUnmarshal(req.Body, &input); err != nil {
 		return nil, err
+	}
+	if input.AccountName == "" || input.Email == "" {
+		return nil, orgInvalidInput("INPUT_REQUIRED",
+			"you must specify both AccountName and Email to create an account")
 	}
 
 	org, err := p.ensureOrganization(goCtx, reqCtx.AccountID)
@@ -34,39 +103,367 @@ func (p *OrganizationsPlugin) createAccount(reqCtx *RequestContext, req *AWSRequ
 		return nil, fmt.Errorf("createAccount load root: %w", err)
 	}
 
-	newAcctID := generateOrganizationAccountID()
-	a := OrgAccount{
-		ID:           newAcctID,
-		Arn:          fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", reqCtx.AccountID, org.ID, newAcctID),
-		Name:         input.AccountName,
-		Email:        input.Email,
-		Status:       "ACTIVE",
-		JoinedMethod: "CREATED",
-		JoinedAt:     p.tc.Now(),
+	// The account quota is a synchronous refusal, which is what CreateAccount's
+	// declared ConstraintViolationException is for. The management account counts
+	// against it, so an organization at the default quota has room for nine
+	// vended accounts and the tenth call is refused.
+	existing, err := p.loadAccountIDs(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("createAccount load account ids: %w", err)
 	}
-	if err := p.saveAccount(goCtx, reqCtx.AccountID, a); err != nil {
-		return nil, fmt.Errorf("createAccount save: %w", err)
+	if len(existing) >= orgMaxAccounts {
+		return nil, orgConstraintViolation("ACCOUNT_NUMBER_LIMIT_EXCEEDED",
+			fmt.Sprintf("you have exceeded the number of accounts allowed in the organization (%d)", orgMaxAccounts))
 	}
-	// A new account lands in the root; MoveAccount is the only way into an OU.
-	if err := p.placeChild(goCtx, root.ID, a.ID); err != nil {
-		return nil, fmt.Errorf("createAccount place: %w", err)
+
+	outcome, err := p.pendingCreateOutcome(goCtx, input.AccountName)
+	if err != nil {
+		return nil, fmt.Errorf("createAccount resolve outcome: %w", err)
 	}
-	if err := p.attachFullAWSAccess(goCtx, reqCtx.AccountID, a.ID); err != nil {
-		return nil, fmt.Errorf("createAccount attach FullAWSAccess: %w", err)
+
+	// A request headed for FAILED writes no account. A FAILED request that left
+	// an account in ListAccounts would be a state real AWS cannot produce, and it
+	// is the state most likely to make a consumer's cleanup path look correct
+	// while it deletes nothing.
+	if outcome.AccountID != "" {
+		if err := p.vendAccount(goCtx, reqCtx.AccountID, org.ID, root.ID, outcome.AccountID, input.AccountName, input.Email, input.Tags); err != nil {
+			return nil, err
+		}
 	}
 
 	status := OrgCreateAccountStatus{
 		ID:                 "car-" + randomLowerAlphanum(8),
-		AccountName:        a.Name,
-		State:              "SUCCEEDED",
+		AccountName:        input.AccountName,
+		State:              orgCreateStateInProgress,
 		RequestedTimestamp: p.tc.Now(),
-		AccountID:          a.ID,
 	}
-	completed := p.tc.Now()
-	status.CompletedTimestamp = &completed
+	if err := p.orgPutJSON(goCtx, orgCreatePendingKey(status.ID), outcome); err != nil {
+		return nil, fmt.Errorf("createAccount save outcome: %w", err)
+	}
 	if err := p.saveCreateAccountStatus(goCtx, reqCtx.AccountID, status); err != nil {
 		return nil, fmt.Errorf("createAccount save status: %w", err)
 	}
 
+	// 200 with IN_PROGRESS even for a request that is already committed to
+	// failing. That asymmetry is the whole point of the seeded failure: a caller
+	// that checks the HTTP status and moves on never learns the account was not
+	// created, which is exactly the bug the seed exists to catch.
 	return orgJSONResponse(map[string]interface{}{"CreateAccountStatus": status}, "createAccount")
+}
+
+// vendAccount writes the account record for a request that will succeed. The
+// record is written now rather than at resolution, because AWS reports a new
+// account from ListAccounts while its creation request is still IN_PROGRESS.
+//
+// The account lands in the root: CreateAccount takes no parent, so MoveAccount is
+// the only way into an OU. A tool that assumes otherwise leaves accounts
+// unprotected, since the OU is where policies are attached.
+func (p *OrganizationsPlugin) vendAccount(ctx context.Context, masterAcct, orgID, rootID, newAcctID, name, email string, tags []OrgTag) error {
+	a := OrgAccount{
+		ID:           newAcctID,
+		Arn:          fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", masterAcct, orgID, newAcctID),
+		Name:         name,
+		Email:        email,
+		Status:       "ACTIVE",
+		JoinedMethod: "CREATED",
+		JoinedAt:     p.tc.Now(),
+	}
+	if err := p.saveAccount(ctx, masterAcct, a); err != nil {
+		return fmt.Errorf("createAccount save account: %w", err)
+	}
+	if err := p.placeChild(ctx, rootID, a.ID); err != nil {
+		return fmt.Errorf("createAccount place: %w", err)
+	}
+	if err := p.attachFullAWSAccess(ctx, masterAcct, a.ID); err != nil {
+		return fmt.Errorf("createAccount attach FullAWSAccess: %w", err)
+	}
+	// Tags given to CreateAccount are tags on the account, so they have to be
+	// readable through ListTagsForResource; dropping them would answer a tag-gated
+	// authorization decision with an empty tag set.
+	if len(tags) > 0 {
+		if err := p.saveTags(ctx, a.ID, tags); err != nil {
+			return fmt.Errorf("createAccount save tags: %w", err)
+		}
+	}
+	return nil
+}
+
+// pendingCreateOutcome decides what an asynchronous CreateAccount will resolve
+// to, at request time. A control-plane seed decides it; with no seed the request
+// succeeds, which is the nominal path a new operation defaults to.
+//
+// The organization-wide email uniqueness AWS enforces — surfaced asynchronously
+// as EMAIL_ALREADY_EXISTS, not as an error from CreateAccount — is deliberately
+// not inferred from the stored accounts here. It stays reachable only through the
+// seed (TODO(#578)): inferring it would make a duplicate email fail whether the
+// test asked for it or not, which changes the outcome of an existing fixture
+// rather than adding a path a test can opt into.
+func (p *OrganizationsPlugin) pendingCreateOutcome(ctx context.Context, accountName string) (orgPendingAccountOutcome, error) {
+	seed, err := p.resolveSeededCreateFailure(ctx, accountName)
+	if err != nil {
+		return orgPendingAccountOutcome{}, err
+	}
+	if seed != nil {
+		return orgPendingAccountOutcome{FailureReason: seed.FailureReason}, nil
+	}
+	return orgPendingAccountOutcome{AccountID: generateOrganizationAccountID()}, nil
+}
+
+// describeCreateAccountStatus reports the current state of a vending request,
+// resolving it on first observation.
+func (p *OrganizationsPlugin) describeCreateAccountStatus(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("describeCreateAccountStatus ensure org: %w", err)
+	}
+
+	var input struct {
+		CreateAccountRequestID string `json:"CreateAccountRequestId"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if input.CreateAccountRequestID == "" {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "you must specify a CreateAccountRequestId")
+	}
+
+	st, err := p.loadCreateAccountStatus(goCtx, input.CreateAccountRequestID)
+	if err != nil {
+		return nil, fmt.Errorf("describeCreateAccountStatus load: %w", err)
+	}
+	if st == nil {
+		// An unknown request ID is a refusal rather than an empty answer: a
+		// resumed run holding an ID from a discarded state store must learn the
+		// request is gone, not conclude it is still in progress and poll forever.
+		return nil, orgErr("CreateAccountStatusNotFoundException",
+			"We can't find a create account request with the CreateAccountRequestId "+input.CreateAccountRequestID)
+	}
+	if err := p.resolveCreateAccountStatus(goCtx, reqCtx.AccountID, st); err != nil {
+		return nil, fmt.Errorf("describeCreateAccountStatus resolve: %w", err)
+	}
+	return orgJSONResponse(map[string]interface{}{"CreateAccountStatus": st}, "describeCreateAccountStatus")
+}
+
+// listCreateAccountStatus lists vending requests, optionally filtered by state.
+func (p *OrganizationsPlugin) listCreateAccountStatus(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("listCreateAccountStatus ensure org: %w", err)
+	}
+
+	var input struct {
+		States     []string `json:"States"`
+		NextToken  string   `json:"NextToken"`
+		MaxResults int      `json:"MaxResults"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	for _, state := range input.States {
+		if !slices.Contains(orgCreateAccountStates, state) {
+			return nil, orgInvalidInput("INVALID_LIST_MEMBER",
+				fmt.Sprintf("%q is not a CreateAccountState", state))
+		}
+	}
+
+	ids, err := p.loadCreateAccountStatusIDs(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("listCreateAccountStatus load ids: %w", err)
+	}
+
+	// The listing resolves each request the same way a Describe does. If it did
+	// not, a caller polling through the listing would see IN_PROGRESS forever
+	// while a Describe of the same request reported SUCCEEDED — two observations
+	// of one request contradicting each other, and a waiter built on the listing
+	// that never terminates.
+	matched := make([]string, 0, len(ids))
+	byID := make(map[string]OrgCreateAccountStatus, len(ids))
+	for _, id := range ids {
+		st, loadErr := p.loadCreateAccountStatus(goCtx, id)
+		if loadErr != nil {
+			return nil, fmt.Errorf("listCreateAccountStatus load status: %w", loadErr)
+		}
+		if st == nil {
+			continue
+		}
+		if err := p.resolveCreateAccountStatus(goCtx, reqCtx.AccountID, st); err != nil {
+			return nil, fmt.Errorf("listCreateAccountStatus resolve: %w", err)
+		}
+		if len(input.States) > 0 && !slices.Contains(input.States, st.State) {
+			continue
+		}
+		matched = append(matched, id)
+		byID[id] = *st
+	}
+
+	page, next, err := orgPaginate(matched, input.NextToken, input.MaxResults)
+	if err != nil {
+		return nil, err
+	}
+	statuses := make([]OrgCreateAccountStatus, 0, len(page))
+	for _, id := range page {
+		statuses = append(statuses, byID[id])
+	}
+
+	out := map[string]interface{}{"CreateAccountStatuses": statuses}
+	if next != "" {
+		out["NextToken"] = next
+	}
+	return orgJSONResponse(out, "listCreateAccountStatus")
+}
+
+// resolveCreateAccountStatus turns an IN_PROGRESS request into its terminal state
+// on first observation and persists the result, so every later observation
+// reports the same state, the same AccountId, and the same CompletedTimestamp.
+//
+// Resolving on observation rather than after an interval of the simulated clock
+// is deliberate: a waiter converges in one poll with no dependence on wall-clock
+// or simulated time, and a status that re-resolved — moving its
+// CompletedTimestamp, or flipping back to IN_PROGRESS — would make a waiter that
+// compares successive polls loop forever. Clock-driven transitions are the
+// subject of #514, which is still open; choosing a duration here would front-run
+// that design.
+func (p *OrganizationsPlugin) resolveCreateAccountStatus(ctx context.Context, acct string, st *OrgCreateAccountStatus) error {
+	if st.State != orgCreateStateInProgress {
+		return nil
+	}
+	var pending orgPendingAccountOutcome
+	found, err := p.orgGetJSON(ctx, orgCreatePendingKey(st.ID), &pending)
+	if err != nil {
+		return err
+	}
+	if !found {
+		// Unreachable through the API — createAccount writes the outcome before
+		// the request record — so it means the store lost a record. Guessing
+		// SUCCEEDED here would report an AccountId nothing else agrees with.
+		return fmt.Errorf("organizations: create-account request %s has no recorded outcome", st.ID)
+	}
+
+	completed := p.tc.Now()
+	st.CompletedTimestamp = &completed
+	if pending.FailureReason != "" {
+		st.State = orgCreateStateFailed
+		st.FailureReason = pending.FailureReason
+		st.AccountID = ""
+	} else {
+		st.State = orgCreateStateSucceeded
+		st.AccountID = pending.AccountID
+	}
+	if err := p.saveCreateAccountStatus(ctx, acct, *st); err != nil {
+		return err
+	}
+	return nil
+}
+
+// moveAccount moves an account between the root and OUs. Every refusal below is
+// in MoveAccount's declared errors list, and each one distinguishes a case a
+// re-run of a governance script hits: nothing here is idempotent, which is the
+// property such a script has to be built on.
+func (p *OrganizationsPlugin) moveAccount(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		AccountID           string `json:"AccountId"`
+		SourceParentID      string `json:"SourceParentId"`
+		DestinationParentID string `json:"DestinationParentId"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if input.AccountID == "" || input.SourceParentID == "" || input.DestinationParentID == "" {
+		return nil, orgInvalidInput("INPUT_REQUIRED",
+			"you must specify AccountId, SourceParentId and DestinationParentId")
+	}
+	// Shape before existence, the order AWS validates in. A parent ID that is
+	// neither a root nor an OU is a malformed request, and answering
+	// DestinationParentNotFoundException for one would send a caller looking for a
+	// container it never named.
+	for _, id := range []string{input.SourceParentID, input.DestinationParentID} {
+		if !isOrgParentID(id) {
+			return nil, orgInvalidInput("INVALID_PATTERN",
+				"a parent must be a root or an organizational unit ID, got "+id)
+		}
+	}
+
+	root, err := p.loadRoot(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("moveAccount load root: %w", err)
+	}
+
+	a, err := p.loadAccount(goCtx, input.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("moveAccount load account: %w", err)
+	}
+	if a == nil {
+		return nil, orgErr("AccountNotFoundException",
+			"We can't find an Amazon Web Services account with the AccountId "+input.AccountID)
+	}
+	currentParent, err := p.loadParent(goCtx, a.ID)
+	if err != nil {
+		return nil, fmt.Errorf("moveAccount load parent: %w", err)
+	}
+
+	// An OU ID embeds the ID of the root that contains it — "ou-{root
+	// suffix}-{suffix}" — so an OU naming another root is a move across roots on
+	// its face. That is refused as a cross-root move rather than as a missing
+	// container, because the two send a caller to different places: one says
+	// "this move is not possible", the other says "create the OU first".
+	for _, id := range []string{input.SourceParentID, input.DestinationParentID} {
+		if isOrgOUID(id) && !orgOUNamesRoot(id, root.ID) {
+			return nil, orgInvalidInput("MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS",
+				"you can move an account only between entities in the same root")
+		}
+	}
+
+	destKind, err := p.resolveOrgTarget(goCtx, reqCtx.AccountID, input.DestinationParentID)
+	if err != nil {
+		return nil, fmt.Errorf("moveAccount resolve destination: %w", err)
+	}
+	if destKind != orgKindRoot && destKind != orgKindOU {
+		return nil, orgErr("DestinationParentNotFoundException",
+			"We can't find the destination container (a root or OU) with the ParentId "+input.DestinationParentID)
+	}
+
+	// The destination is checked before the source on purpose. A governance
+	// script re-run replays the move it already made — source root, destination
+	// OU — and the useful answer is "that account is already present in the
+	// specified destination", not "your source OU does not exist", which is what
+	// validating the source first would say. This is the reading #578's point 5
+	// left open: the second pass fails loudly and distinguishably rather than
+	// silently succeeding.
+	if currentParent == input.DestinationParentID {
+		return nil, orgErr("DuplicateAccountException",
+			"That account is already present in the specified destination")
+	}
+
+	// SourceParentId has to be the account's actual parent. Accepting a stale one
+	// would let a caller that has lost track of where the account is move it
+	// anyway, and the source parameter exists precisely so that cannot happen.
+	if input.SourceParentID != currentParent {
+		return nil, orgErr("SourceParentNotFoundException",
+			"We can't find a source root or OU with the ParentId "+input.SourceParentID)
+	}
+
+	if err := p.placeChild(goCtx, input.DestinationParentID, a.ID); err != nil {
+		return nil, fmt.Errorf("moveAccount place: %w", err)
+	}
+	return orgEmptyResponse(), nil
+}
+
+// isOrgParentID reports whether id has the shape of a ParentId — a root or an OU
+// — which is the pattern the model puts on both of MoveAccount's parent members.
+func isOrgParentID(id string) bool { return isOrgRootID(id) || isOrgOUID(id) }
+
+// orgOUNamesRoot reports whether an OU ID's embedded root segment is rootID. An
+// OU ID is "ou-" plus the containing root's suffix, a dash, and the OU's own
+// suffix, so the root an OU belongs to is readable from its ID alone.
+func orgOUNamesRoot(ouID, rootID string) bool {
+	if !isOrgOUID(ouID) || !isOrgRootID(rootID) {
+		return false
+	}
+	rest := ouID[len("ou-"):]
+	dash := strings.Index(rest, "-")
+	if dash <= 0 {
+		return false
+	}
+	return rest[:dash] == rootID[len("r-"):]
 }

--- a/emulator/organizations_account_export_test.go
+++ b/emulator/organizations_account_export_test.go
@@ -1,0 +1,24 @@
+package emulator
+
+// This file exports what the account-vending tests need. It is separate from
+// organizations_export_test.go so the vending lane does not contend with the
+// other operation clusters for one file.
+
+// CreateAccountState values, exported so a test pins each against the model's
+// CreateAccountState enum rather than against a string literal.
+const (
+	OrgCreateStateInProgressForTest = orgCreateStateInProgress
+	OrgCreateStateSucceededForTest  = orgCreateStateSucceeded
+	OrgCreateStateFailedForTest     = orgCreateStateFailed
+)
+
+// OrgCreatePendingPrefixForTest is the state-key prefix under which the terminal
+// outcome of an in-flight CreateAccount request is recorded, so a fault test can
+// scope a store failure to exactly that record.
+const OrgCreatePendingPrefixForTest = "car_pending:"
+
+// OrgOUNamesRootForTest wraps orgOUNamesRoot for external tests.
+func OrgOUNamesRootForTest(ouID, rootID string) bool { return orgOUNamesRoot(ouID, rootID) }
+
+// IsOrgParentIDForTest wraps isOrgParentID for external tests.
+func IsOrgParentIDForTest(id string) bool { return isOrgParentID(id) }

--- a/emulator/organizations_account_test.go
+++ b/emulator/organizations_account_test.go
@@ -1,0 +1,1085 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// orgCreateStatus is the CreateAccountStatus shape, named exactly as the model
+// spells its members so a rename in the plugin fails the decode rather than
+// silently reading back a zero value.
+type orgCreateStatus struct {
+	ID                 string  `json:"Id"`
+	AccountName        string  `json:"AccountName"`
+	State              string  `json:"State"`
+	RequestedTimestamp string  `json:"RequestedTimestamp"`
+	CompletedTimestamp *string `json:"CompletedTimestamp"`
+	AccountID          string  `json:"AccountId"`
+	FailureReason      string  `json:"FailureReason"`
+}
+
+// orgCreateAccount posts CreateAccount and returns the status and the HTTP code.
+func orgCreateAccount(t *testing.T, ts *httptest.Server, name, email string) (orgCreateStatus, int) {
+	t.Helper()
+	resp := orgsRequest(t, ts, "CreateAccount", map[string]interface{}{
+		"AccountName": name,
+		"Email":       email,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return orgCreateStatus{}, resp.StatusCode
+	}
+	var out struct {
+		CreateAccountStatus orgCreateStatus `json:"CreateAccountStatus"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("CreateAccount decode: %v", err)
+	}
+	return out.CreateAccountStatus, resp.StatusCode
+}
+
+// orgDescribeCreateStatus polls DescribeCreateAccountStatus once.
+func orgDescribeCreateStatus(t *testing.T, ts *httptest.Server, requestID string) (orgCreateStatus, int) {
+	t.Helper()
+	resp := orgsRequest(t, ts, "DescribeCreateAccountStatus", map[string]interface{}{
+		"CreateAccountRequestId": requestID,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return orgCreateStatus{}, resp.StatusCode
+	}
+	var out struct {
+		CreateAccountStatus orgCreateStatus `json:"CreateAccountStatus"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("DescribeCreateAccountStatus decode: %v", err)
+	}
+	return out.CreateAccountStatus, resp.StatusCode
+}
+
+// orgVendAccount runs the nominal vend — create, then one poll — and returns the
+// resolved account ID.
+func orgVendAccount(t *testing.T, ts *httptest.Server, name, email string) string {
+	t.Helper()
+	created, code := orgCreateAccount(t, ts, name, email)
+	if code != http.StatusOK {
+		t.Fatalf("CreateAccount %s: expected 200, got %d", name, code)
+	}
+	resolved, code := orgDescribeCreateStatus(t, ts, created.ID)
+	if code != http.StatusOK {
+		t.Fatalf("DescribeCreateAccountStatus %s: expected 200, got %d", name, code)
+	}
+	if resolved.State != emulator.OrgCreateStateSucceededForTest {
+		t.Fatalf("expected %s to vend, got State=%q reason=%q",
+			name, resolved.State, resolved.FailureReason)
+	}
+	return resolved.AccountID
+}
+
+// orgErrorCode posts an operation expected to be refused and returns the status
+// and the JSON-RPC error code.
+func orgErrorCode(t *testing.T, ts *httptest.Server, op string, body map[string]interface{}) (int, string) {
+	t.Helper()
+	resp := orgsRequest(t, ts, op, body)
+	defer resp.Body.Close() //nolint:errcheck
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("%s decode error body: %v", op, err)
+	}
+	code, _ := out["__type"].(string)
+	return resp.StatusCode, code
+}
+
+// orgSeedCreateFailureOn posts a create-account-failure seed to the same server
+// the AWS requests go to, so the seed and the operation share one state store.
+func orgSeedCreateFailureOn(t *testing.T, ts *httptest.Server, accountName, reason string) {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"accountName": accountName, "failureReason": reason})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		ts.URL+"/v1/organizations/create-account-failure", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build seed request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("seed create failure: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed create failure: expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// orgListAccountIDs returns every account ID ListAccounts reports, paging to the
+// end so the assertion is about the organization rather than about a first page.
+func orgListAccountIDs(t *testing.T, ts *httptest.Server) []string {
+	t.Helper()
+	var ids []string
+	token := ""
+	for {
+		body := map[string]interface{}{}
+		if token != "" {
+			body["NextToken"] = token
+		}
+		resp := orgsRequest(t, ts, "ListAccounts", body)
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close() //nolint:errcheck
+			t.Fatalf("ListAccounts: expected 200, got %d", resp.StatusCode)
+		}
+		var out struct {
+			Accounts []struct {
+				ID string `json:"Id"`
+			} `json:"Accounts"`
+			NextToken string `json:"NextToken"`
+		}
+		err := json.NewDecoder(resp.Body).Decode(&out)
+		resp.Body.Close() //nolint:errcheck
+		if err != nil {
+			t.Fatalf("ListAccounts decode: %v", err)
+		}
+		for _, a := range out.Accounts {
+			ids = append(ids, a.ID)
+		}
+		if out.NextToken == "" {
+			return ids
+		}
+		token = out.NextToken
+	}
+}
+
+// orgCreateOU places an OU under the root directly through the storage layer.
+// The OU operations belong to another lane, so the placement is made here rather
+// than through CreateOrganizationalUnit: this file's subject is what MoveAccount
+// does with an OU that exists, not how it came to exist.
+func orgCreateOU(t *testing.T, p *emulator.OrganizationsPlugin, rootID, suffix string) string {
+	t.Helper()
+	ouID := "ou-" + rootID[len("r-"):] + "-" + suffix
+	ou := emulator.OrgOrganizationalUnit{ID: ouID, Name: suffix}
+	if err := p.SaveOUForTest(t.Context(), orgTestAccount, ou); err != nil {
+		t.Fatalf("save OU: %v", err)
+	}
+	if err := p.PlaceChildForTest(t.Context(), rootID, ouID); err != nil {
+		t.Fatalf("place OU: %v", err)
+	}
+	return ouID
+}
+
+// orgListCreateStatuses posts ListCreateAccountStatus with an optional States
+// filter and returns one page of statuses.
+func orgListCreateStatuses(t *testing.T, ts *httptest.Server, states []string) []orgCreateStatus {
+	t.Helper()
+	body := map[string]interface{}{}
+	if states != nil {
+		body["States"] = states
+	}
+	resp := orgsRequest(t, ts, "ListCreateAccountStatus", body)
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ListCreateAccountStatus: expected 200, got %d", resp.StatusCode)
+	}
+	var out struct {
+		CreateAccountStatuses []orgCreateStatus `json:"CreateAccountStatuses"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("ListCreateAccountStatus decode: %v", err)
+	}
+	return out.CreateAccountStatuses
+}
+
+// orgMatchesCreateRequestID reports whether id matches the model's
+// CreateAccountRequestId pattern, ^car-[a-z0-9]{8,32}$.
+func orgMatchesCreateRequestID(id string) bool {
+	return regexp.MustCompile(`^car-[a-z0-9]{8,32}$`).MatchString(id)
+}
+
+// newOrgServerOverState wires a plugin and server to the supplied state manager,
+// which is what lets a fault test arm a store failure mid-journey.
+func newOrgServerOverState(t *testing.T, state emulator.StateManager) *httptest.Server {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false})
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.OrganizationsPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}); err != nil {
+		t.Fatalf("initialize organizations plugin: %v", err)
+	}
+	registry.Register(p)
+
+	cfg := emulator.DefaultConfig()
+	ts := httptest.NewServer(emulator.NewServer(*cfg, registry, store, state, tc, logger))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// newOrgVendingFixture returns a server and the plugin behind it, sharing one
+// state store, so a test can drive the wire surface and then read the hierarchy
+// the storage layer recorded.
+func newOrgVendingFixture(t *testing.T) (*httptest.Server, *emulator.OrganizationsPlugin) {
+	t.Helper()
+	state := emulator.NewMemoryStateManager()
+	ts := newOrgServerOverState(t, state)
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	return ts, emulator.NewOrganizationsPluginForTest(state, tc)
+}
+
+// TestOrganizations_FullVend is the journey #578 is really about: vend an
+// account, poll it to SUCCEEDED, move it into an OU, and re-run the same move.
+// The re-run must fail loudly — a governance script run twice that silently
+// succeeds the second time is indistinguishable from one that did nothing, and
+// the operator has no way to tell which happened.
+func TestOrganizations_FullVend(t *testing.T) {
+	ts, p := newOrgVendingFixture(t)
+	ctx := t.Context()
+
+	rootID := orgListRootsID(t, ts)
+	accountID := orgVendAccount(t, ts, "dev-account", "dev@example.com")
+
+	// A new account lands in the root, not in an OU: CreateAccount takes no
+	// parent, so a tool that assumes otherwise leaves the account outside the OU
+	// where the policies are attached.
+	parent, err := p.LoadParentForTest(ctx, accountID)
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	if parent != rootID {
+		t.Fatalf("expected the new account in the root %q, got %q", rootID, parent)
+	}
+
+	ouID := orgCreateOU(t, p, rootID, "11112222")
+
+	resp := orgsRequest(t, ts, "MoveAccount", map[string]interface{}{
+		"AccountId":           accountID,
+		"SourceParentId":      rootID,
+		"DestinationParentId": ouID,
+	})
+	gotStatus := resp.StatusCode
+	resp.Body.Close() //nolint:errcheck
+	if gotStatus != http.StatusOK {
+		t.Fatalf("MoveAccount: expected 200, got %d", gotStatus)
+	}
+
+	// Both directions of the hierarchy have to agree about where the account is.
+	// If they did not, ListAccountsForParent and ListParents would contradict each
+	// other, and the account would appear to be in two places at once.
+	ouChildren, err := p.LoadChildrenForTest(ctx, ouID)
+	if err != nil {
+		t.Fatalf("load OU children: %v", err)
+	}
+	if len(ouChildren) != 1 || ouChildren[0] != accountID {
+		t.Errorf("expected the OU to contain only %q, got %v", accountID, ouChildren)
+	}
+	rootChildren, err := p.LoadChildrenForTest(ctx, rootID)
+	if err != nil {
+		t.Fatalf("load root children: %v", err)
+	}
+	for _, id := range rootChildren {
+		if id == accountID {
+			t.Errorf("expected the account gone from the root, still found in %v", rootChildren)
+		}
+	}
+	moved, err := p.LoadParentForTest(ctx, accountID)
+	if err != nil {
+		t.Fatalf("load parent after move: %v", err)
+	}
+	if moved != ouID {
+		t.Errorf("expected the account's parent to be %q, got %q", ouID, moved)
+	}
+
+	// The re-run. The source is now the OU, but the script replays what it
+	// recorded, so it sends the root again; either way the destination is already
+	// the parent, and DuplicateAccountException is the answer that tells it so.
+	code, errCode := orgErrorCode(t, ts, "MoveAccount", map[string]interface{}{
+		"AccountId":           accountID,
+		"SourceParentId":      rootID,
+		"DestinationParentId": ouID,
+	})
+	if code != http.StatusBadRequest || errCode != "DuplicateAccountException" {
+		t.Errorf("expected 400/DuplicateAccountException on the re-run, got %d/%s", code, errCode)
+	}
+}
+
+// TestOrganizations_CreateAccountIsAsynchronous pins the response CreateAccount
+// itself gives: IN_PROGRESS, a car- request ID, a RequestedTimestamp, and no
+// AccountId. A synchronous SUCCEEDED lets a consumer with no poll loop pass, and
+// the poll loop is the part that has to survive an interruption.
+func TestOrganizations_CreateAccountIsAsynchronous(t *testing.T) {
+	ts, _ := newOrgVendingFixture(t)
+
+	status, code := orgCreateAccount(t, ts, "dev-account", "dev@example.com")
+	if code != http.StatusOK {
+		t.Fatalf("CreateAccount: expected 200, got %d", code)
+	}
+	if status.State != emulator.OrgCreateStateInProgressForTest {
+		t.Errorf("expected State=%s, got %q", emulator.OrgCreateStateInProgressForTest, status.State)
+	}
+	if status.AccountID != "" {
+		t.Errorf("expected no AccountId while IN_PROGRESS, got %q", status.AccountID)
+	}
+	if status.CompletedTimestamp != nil {
+		t.Errorf("expected no CompletedTimestamp while IN_PROGRESS, got %v", *status.CompletedTimestamp)
+	}
+	if status.FailureReason != "" {
+		t.Errorf("expected no FailureReason while IN_PROGRESS, got %q", status.FailureReason)
+	}
+	if status.AccountName != "dev-account" {
+		t.Errorf("expected AccountName=dev-account, got %q", status.AccountName)
+	}
+	if status.RequestedTimestamp == "" {
+		t.Error("expected a RequestedTimestamp on the in-progress request")
+	}
+	// The model's CreateAccountRequestId pattern is ^car-[a-z0-9]{8,32}$.
+	if !orgMatchesCreateRequestID(status.ID) {
+		t.Errorf("expected an ID matching ^car-[a-z0-9]{8,32}$, got %q", status.ID)
+	}
+
+	// The account is in ListAccounts immediately, before any poll — AWS reports a
+	// new account while its creation request is still in progress.
+	if len(orgListAccountIDs(t, ts)) != 2 {
+		t.Errorf("expected the management account and the new one, got %v", orgListAccountIDs(t, ts))
+	}
+}
+
+// TestOrganizations_SeededCreateFailureStillReturns200 is the asymmetry the seed
+// exists to expose: the call succeeds, and only the status reports the failure.
+// A caller that checks the HTTP status and moves on never learns the account was
+// not created, which is the bug this makes reachable in a test.
+func TestOrganizations_SeededCreateFailureStillReturns200(t *testing.T) {
+	ts, _ := newOrgVendingFixture(t)
+
+	before := orgListAccountIDs(t, ts)
+	orgSeedCreateFailureOn(t, ts, "*", "EMAIL_ALREADY_EXISTS")
+
+	status, code := orgCreateAccount(t, ts, "doomed", "doomed@example.com")
+	if code != http.StatusOK {
+		t.Fatalf("expected a seeded failure to still answer 200, got %d", code)
+	}
+	if status.State != emulator.OrgCreateStateInProgressForTest {
+		t.Errorf("expected the call itself to report IN_PROGRESS, got %q", status.State)
+	}
+
+	resolved, code := orgDescribeCreateStatus(t, ts, status.ID)
+	if code != http.StatusOK {
+		t.Fatalf("DescribeCreateAccountStatus: expected 200, got %d", code)
+	}
+	if resolved.State != emulator.OrgCreateStateFailedForTest {
+		t.Fatalf("expected State=%s, got %q", emulator.OrgCreateStateFailedForTest, resolved.State)
+	}
+	if resolved.FailureReason != "EMAIL_ALREADY_EXISTS" {
+		t.Errorf("expected the seeded reason, got %q", resolved.FailureReason)
+	}
+	if resolved.AccountID != "" {
+		t.Errorf("expected no AccountId on a FAILED request, got %q", resolved.AccountID)
+	}
+	if resolved.CompletedTimestamp == nil {
+		t.Error("expected a CompletedTimestamp on a terminal request")
+	}
+
+	// No account was written. A FAILED request that left an account in
+	// ListAccounts would be a state real AWS cannot produce, and it would make a
+	// consumer's cleanup path look correct while it deleted nothing.
+	after := orgListAccountIDs(t, ts)
+	if len(after) != len(before) {
+		t.Errorf("expected no new account for a failed request, %v became %v", before, after)
+	}
+}
+
+// TestOrganizations_OnePollResolvesAndTheStatusIsStable asserts a waiter
+// converges in one poll and that the terminal status never moves afterwards. A
+// status that re-resolved — a new CompletedTimestamp, or a flip back to
+// IN_PROGRESS — would make a waiter comparing successive polls loop forever, and
+// a re-minted AccountId would have the caller record an account nothing agrees
+// with.
+func TestOrganizations_OnePollResolvesAndTheStatusIsStable(t *testing.T) {
+	ts, _ := newOrgVendingFixture(t)
+
+	created, code := orgCreateAccount(t, ts, "dev-account", "dev@example.com")
+	if code != http.StatusOK {
+		t.Fatalf("CreateAccount: expected 200, got %d", code)
+	}
+
+	first, _ := orgDescribeCreateStatus(t, ts, created.ID)
+	if first.State != emulator.OrgCreateStateSucceededForTest {
+		t.Fatalf("expected the first poll to resolve to SUCCEEDED, got %q", first.State)
+	}
+	if first.AccountID == "" {
+		t.Fatal("expected an AccountId on a SUCCEEDED request")
+	}
+	if first.CompletedTimestamp == nil {
+		t.Fatal("expected a CompletedTimestamp on a SUCCEEDED request")
+	}
+
+	for i := range 3 {
+		later, _ := orgDescribeCreateStatus(t, ts, created.ID)
+		if later.State != first.State {
+			t.Errorf("poll %d: state moved from %q to %q", i+2, first.State, later.State)
+		}
+		if later.AccountID != first.AccountID {
+			t.Errorf("poll %d: AccountId moved from %q to %q", i+2, first.AccountID, later.AccountID)
+		}
+		if later.CompletedTimestamp == nil || *later.CompletedTimestamp != *first.CompletedTimestamp {
+			t.Errorf("poll %d: CompletedTimestamp moved from %v to %v",
+				i+2, *first.CompletedTimestamp, later.CompletedTimestamp)
+		}
+	}
+
+	// The account the status names is the one DescribeAccount resolves, and it is
+	// marked CREATED rather than INVITED.
+	resp := orgsRequest(t, ts, "DescribeAccount", map[string]interface{}{"AccountId": first.AccountID})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DescribeAccount: expected 200, got %d", resp.StatusCode)
+	}
+	var out struct {
+		Account struct {
+			JoinedMethod string `json:"JoinedMethod"`
+			Status       string `json:"Status"`
+			Email        string `json:"Email"`
+		} `json:"Account"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("DescribeAccount decode: %v", err)
+	}
+	if out.Account.JoinedMethod != "CREATED" {
+		t.Errorf("expected JoinedMethod=CREATED for a vended account, got %q", out.Account.JoinedMethod)
+	}
+	if out.Account.Status != "ACTIVE" {
+		t.Errorf("expected Status=ACTIVE, got %q", out.Account.Status)
+	}
+	if out.Account.Email != "dev@example.com" {
+		t.Errorf("expected the requested email, got %q", out.Account.Email)
+	}
+}
+
+// TestOrganizations_AccountCapFiresOnTheEleventh pins the boundary including the
+// management account. An off-by-one here is invisible in any nominal run and only
+// shows up as a vending tool that stops one account early or one too late.
+func TestOrganizations_AccountCapFiresOnTheEleventh(t *testing.T) {
+	ts, _ := newOrgVendingFixture(t)
+
+	// The management account already occupies one slot, so orgMaxAccounts-1 vends
+	// fill the organization.
+	for i := range emulator.OrgMaxAccountsForTest - 1 {
+		name := "acct-" + string(rune('a'+i))
+		orgVendAccount(t, ts, name, name+"@example.com")
+	}
+	if got := len(orgListAccountIDs(t, ts)); got != emulator.OrgMaxAccountsForTest {
+		t.Fatalf("expected the organization full at %d accounts, got %d",
+			emulator.OrgMaxAccountsForTest, got)
+	}
+
+	code, errCode := orgErrorCode(t, ts, "CreateAccount", map[string]interface{}{
+		"AccountName": "one-too-many",
+		"Email":       "one-too-many@example.com",
+	})
+	if code != http.StatusBadRequest || errCode != "ConstraintViolationException" {
+		t.Fatalf("expected 400/ConstraintViolationException on the 11th account, got %d/%s", code, errCode)
+	}
+	// The reason travels in the message, since the JSON-RPC error document
+	// substrate emits has no Reason member for a caller to read.
+	resp := orgsRequest(t, ts, "CreateAccount", map[string]interface{}{
+		"AccountName": "one-too-many", "Email": "one-too-many@example.com",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if msg, _ := body["message"].(string); !strings.Contains(msg, "ACCOUNT_NUMBER_LIMIT_EXCEEDED") {
+		t.Errorf("expected ACCOUNT_NUMBER_LIMIT_EXCEEDED in the message, got %q", msg)
+	}
+}
+
+// TestOrganizations_NameScopedSeedLeavesOtherVendsAlone asserts a name-scoped
+// seed fails only the account it names. A seed that leaked onto its neighbors
+// would fail an unrelated vend in the same run, and the test asserting on the
+// seeded failure would still pass — so the leak would only show up as an
+// unexplained failure somewhere else.
+func TestOrganizations_NameScopedSeedLeavesOtherVendsAlone(t *testing.T) {
+	ts, _ := newOrgVendingFixture(t)
+
+	orgSeedCreateFailureOn(t, ts, "doomed", "INVALID_EMAIL")
+
+	// The named account fails, and no record of it is left behind.
+	doomed, code := orgCreateAccount(t, ts, "doomed", "doomed@example.com")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200 for a seeded failure, got %d", code)
+	}
+	resolved, _ := orgDescribeCreateStatus(t, ts, doomed.ID)
+	if resolved.State != emulator.OrgCreateStateFailedForTest ||
+		resolved.FailureReason != "INVALID_EMAIL" {
+		t.Fatalf("expected FAILED/INVALID_EMAIL, got %q/%q", resolved.State, resolved.FailureReason)
+	}
+
+	// Its neighbor vends normally.
+	otherID := orgVendAccount(t, ts, "healthy", "healthy@example.com")
+	ids := orgListAccountIDs(t, ts)
+	if len(ids) != 2 {
+		t.Fatalf("expected only the management account and %q, got %v", otherID, ids)
+	}
+}
+
+// TestOrganizations_ListCreateAccountStatus covers the listing and its States
+// filter, which is the enum in the model. A caller that watches the listing
+// rather than one request has to see the same resolution a Describe gives, or the
+// two observations of one request contradict each other.
+func TestOrganizations_ListCreateAccountStatus(t *testing.T) {
+	ts, _ := newOrgVendingFixture(t)
+
+	orgSeedCreateFailureOn(t, ts, "doomed", "INTERNAL_FAILURE")
+	good, _ := orgCreateAccount(t, ts, "good", "good@example.com")
+	bad, _ := orgCreateAccount(t, ts, "doomed", "doomed@example.com")
+
+	// No filter: both requests, and both resolved by the listing itself.
+	all := orgListCreateStatuses(t, ts, nil)
+	if len(all) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(all))
+	}
+	for _, st := range all {
+		if st.State == emulator.OrgCreateStateInProgressForTest {
+			t.Errorf("expected the listing to resolve %s, got IN_PROGRESS", st.ID)
+		}
+	}
+
+	succeeded := orgListCreateStatuses(t, ts, []string{emulator.OrgCreateStateSucceededForTest})
+	if len(succeeded) != 1 || succeeded[0].ID != good.ID {
+		t.Errorf("expected only %s to have succeeded, got %+v", good.ID, succeeded)
+	}
+	failed := orgListCreateStatuses(t, ts, []string{emulator.OrgCreateStateFailedForTest})
+	if len(failed) != 1 || failed[0].ID != bad.ID {
+		t.Fatalf("expected only %s to have failed, got %+v", bad.ID, failed)
+	}
+	if failed[0].FailureReason != "INTERNAL_FAILURE" {
+		t.Errorf("expected the seeded reason in the listing, got %q", failed[0].FailureReason)
+	}
+	if none := orgListCreateStatuses(t, ts, []string{emulator.OrgCreateStateInProgressForTest}); len(none) != 0 {
+		t.Errorf("expected nothing still in progress after the listing resolved both, got %+v", none)
+	}
+}
+
+// TestOrganizations_ListCreateAccountStatusPaginates asserts the listing honors
+// MaxResults and that a full walk visits every request exactly once. A listing
+// that returned everything in one page makes a caller's missing NextToken loop
+// invisible.
+func TestOrganizations_ListCreateAccountStatusPaginates(t *testing.T) {
+	ts, _ := newOrgVendingFixture(t)
+
+	want := map[string]bool{}
+	for i := range 5 {
+		name := "acct-" + string(rune('a'+i))
+		st, _ := orgCreateAccount(t, ts, name, name+"@example.com")
+		want[st.ID] = false
+	}
+
+	seen := 0
+	token := ""
+	pages := 0
+	for {
+		body := map[string]interface{}{"MaxResults": 2}
+		if token != "" {
+			body["NextToken"] = token
+		}
+		resp := orgsRequest(t, ts, "ListCreateAccountStatus", body)
+		var out struct {
+			CreateAccountStatuses []orgCreateStatus `json:"CreateAccountStatuses"`
+			NextToken             string            `json:"NextToken"`
+		}
+		err := json.NewDecoder(resp.Body).Decode(&out)
+		resp.Body.Close() //nolint:errcheck
+		if err != nil {
+			t.Fatalf("decode page: %v", err)
+		}
+		if len(out.CreateAccountStatuses) > 2 {
+			t.Fatalf("expected MaxResults=2 honored, got a page of %d", len(out.CreateAccountStatuses))
+		}
+		for _, st := range out.CreateAccountStatuses {
+			already, known := want[st.ID]
+			if !known {
+				t.Errorf("page returned an unknown request %q", st.ID)
+			}
+			if already {
+				t.Errorf("request %q returned twice across pages", st.ID)
+			}
+			want[st.ID] = true
+			seen++
+		}
+		pages++
+		if out.NextToken == "" {
+			break
+		}
+		token = out.NextToken
+		if pages > 10 {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+	if seen != 5 {
+		t.Errorf("expected 5 requests across all pages, saw %d", seen)
+	}
+	if pages != 3 {
+		t.Errorf("expected 5 requests over 3 pages at MaxResults=2, got %d pages", pages)
+	}
+}
+
+// TestOrganizations_VendingRefusals walks every documented refusal on the lane's
+// operations. Each is in the operation's declared errors list in the API model,
+// and the code is what a consumer's catch branch is written against — a
+// plausible-looking substitute would send it down the wrong path.
+func TestOrganizations_VendingRefusals(t *testing.T) {
+	ts, p := newOrgVendingFixture(t)
+	rootID := orgListRootsID(t, ts)
+	accountID := orgVendAccount(t, ts, "dev-account", "dev@example.com")
+	ouID := orgCreateOU(t, p, rootID, "11112222")
+
+	cases := []struct {
+		name string
+		op   string
+		body map[string]interface{}
+		code string
+		why  string
+	}{
+		{
+			name: "unknown create request",
+			op:   "DescribeCreateAccountStatus",
+			body: map[string]interface{}{"CreateAccountRequestId": "car-99999999"},
+			code: "CreateAccountStatusNotFoundException",
+			why:  "a resumed run holding a stale ID must learn the request is gone rather than poll forever",
+		},
+		{
+			name: "missing create request id",
+			op:   "DescribeCreateAccountStatus",
+			body: map[string]interface{}{},
+			code: "InvalidInputException",
+			why:  "an omitted ID must not be read as a request named the empty string",
+		},
+		{
+			name: "unknown account",
+			op:   "MoveAccount",
+			body: map[string]interface{}{
+				"AccountId": "999999999999", "SourceParentId": rootID, "DestinationParentId": ouID,
+			},
+			code: "AccountNotFoundException",
+			why:  "moving an account that does not exist must not create a placement for it",
+		},
+		{
+			name: "wrong source parent",
+			op:   "MoveAccount",
+			body: map[string]interface{}{
+				"AccountId": accountID, "SourceParentId": "ou-" + rootID[2:] + "-99999999",
+				"DestinationParentId": ouID,
+			},
+			code: "SourceParentNotFoundException",
+			why:  "SourceParentId exists so a caller that lost track of the account cannot move it anyway",
+		},
+		{
+			name: "unknown destination",
+			op:   "MoveAccount",
+			body: map[string]interface{}{
+				"AccountId": accountID, "SourceParentId": rootID,
+				"DestinationParentId": "ou-" + rootID[2:] + "-99999999",
+			},
+			code: "DestinationParentNotFoundException",
+			why:  "a destination that does not exist must not silently leave the account where it was",
+		},
+		{
+			name: "cross-root move",
+			op:   "MoveAccount",
+			body: map[string]interface{}{
+				"AccountId": accountID, "SourceParentId": rootID,
+				"DestinationParentId": "ou-zzzz-11112222",
+			},
+			code: "InvalidInputException",
+			why:  "an OU under another root is not a container this account can reach",
+		},
+		{
+			name: "destination is already the parent",
+			op:   "MoveAccount",
+			body: map[string]interface{}{
+				"AccountId": accountID, "SourceParentId": rootID, "DestinationParentId": rootID,
+			},
+			code: "DuplicateAccountException",
+			why:  "a re-run must fail distinguishably rather than succeed silently",
+		},
+		{
+			name: "malformed parent id",
+			op:   "MoveAccount",
+			body: map[string]interface{}{
+				"AccountId": accountID, "SourceParentId": rootID, "DestinationParentId": "not-a-parent",
+			},
+			code: "InvalidInputException",
+			why:  "a malformed parent is a bad request, not a missing container to go and create",
+		},
+		{
+			name: "missing move arguments",
+			op:   "MoveAccount",
+			body: map[string]interface{}{"AccountId": accountID},
+			code: "InvalidInputException",
+			why:  "an omitted parent must not be read as a move to the empty container",
+		},
+		{
+			name: "create with no name",
+			op:   "CreateAccount",
+			body: map[string]interface{}{"Email": "x@example.com"},
+			code: "InvalidInputException",
+			why:  "both AccountName and Email are required by the model",
+		},
+		{
+			name: "create with no email",
+			op:   "CreateAccount",
+			body: map[string]interface{}{"AccountName": "x"},
+			code: "InvalidInputException",
+			why:  "an account with no email address could never be reported by DescribeAccount",
+		},
+		{
+			name: "state filter outside the enum",
+			op:   "ListCreateAccountStatus",
+			body: map[string]interface{}{"States": []string{"in_progress"}},
+			code: "InvalidInputException",
+			why:  "a filter that matched nothing would read as 'the organization vended nothing'",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotStatus, gotCode := orgErrorCode(t, ts, c.op, c.body)
+			if gotStatus != http.StatusBadRequest {
+				t.Errorf("expected 400 (%s), got %d", c.why, gotStatus)
+			}
+			if gotCode != c.code {
+				t.Errorf("expected %s (%s), got %s", c.code, c.why, gotCode)
+			}
+		})
+	}
+}
+
+// TestOrganizations_MoveAccountAcrossOUs asserts a move between two OUs leaves
+// the account in exactly one of them. Both directions of the placement index are
+// rewritten, and a move that only added to the destination would make the account
+// appear in two OUs — a state no sequence of API calls can produce, so nothing
+// downstream is prepared for it.
+func TestOrganizations_MoveAccountAcrossOUs(t *testing.T) {
+	ts, p := newOrgVendingFixture(t)
+	ctx := t.Context()
+
+	rootID := orgListRootsID(t, ts)
+	accountID := orgVendAccount(t, ts, "dev-account", "dev@example.com")
+	first := orgCreateOU(t, p, rootID, "11112222")
+	second := orgCreateOU(t, p, rootID, "33334444")
+
+	for _, move := range []struct{ src, dst string }{
+		{rootID, first},
+		{first, second},
+	} {
+		resp := orgsRequest(t, ts, "MoveAccount", map[string]interface{}{
+			"AccountId": accountID, "SourceParentId": move.src, "DestinationParentId": move.dst,
+		})
+		gotStatus := resp.StatusCode
+		resp.Body.Close() //nolint:errcheck
+		if gotStatus != http.StatusOK {
+			t.Fatalf("move %s -> %s: expected 200, got %d", move.src, move.dst, gotStatus)
+		}
+	}
+
+	if children, err := p.LoadChildrenForTest(ctx, first); err != nil {
+		t.Fatalf("load first OU children: %v", err)
+	} else if len(children) != 0 {
+		t.Errorf("expected the account gone from the first OU, got %v", children)
+	}
+	if children, err := p.LoadChildrenForTest(ctx, second); err != nil {
+		t.Fatalf("load second OU children: %v", err)
+	} else if len(children) != 1 || children[0] != accountID {
+		t.Errorf("expected the account only in the second OU, got %v", children)
+	}
+}
+
+// TestOrganizations_MoveAccountEmptyResponse pins the body shape. MoveAccount
+// declares no output shape in the model, so it answers an empty JSON object; a
+// null body would fail an SDK's response parse.
+func TestOrganizations_MoveAccountEmptyResponse(t *testing.T) {
+	ts, p := newOrgVendingFixture(t)
+	rootID := orgListRootsID(t, ts)
+	accountID := orgVendAccount(t, ts, "dev-account", "dev@example.com")
+	ouID := orgCreateOU(t, p, rootID, "11112222")
+
+	resp := orgsRequest(t, ts, "MoveAccount", map[string]interface{}{
+		"AccountId": accountID, "SourceParentId": rootID, "DestinationParentId": ouID,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("expected a decodable empty object: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected an empty object, got %v", out)
+	}
+}
+
+// TestOrganizations_CreateAccountTagsAreReadable asserts tags passed to
+// CreateAccount land on the account. Dropping them would answer a tag-gated
+// authorization decision with an empty tag set, which fails open.
+func TestOrganizations_CreateAccountTagsAreReadable(t *testing.T) {
+	ts, p := newOrgVendingFixture(t)
+
+	resp := orgsRequest(t, ts, "CreateAccount", map[string]interface{}{
+		"AccountName": "tagged",
+		"Email":       "tagged@example.com",
+		"Tags":        []map[string]string{{"Key": "Owner", "Value": "platform"}},
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CreateAccount: expected 200, got %d", resp.StatusCode)
+	}
+	var out struct {
+		CreateAccountStatus orgCreateStatus `json:"CreateAccountStatus"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	resolved, _ := orgDescribeCreateStatus(t, ts, out.CreateAccountStatus.ID)
+	if resolved.AccountID == "" {
+		t.Fatalf("expected the request to vend an account, got %q", resolved.State)
+	}
+
+	tags, err := p.LoadTagsForTest(t.Context(), resolved.AccountID)
+	if err != nil {
+		t.Fatalf("load tags: %v", err)
+	}
+	if len(tags) != 1 || tags[0].Key != "Owner" || tags[0].Value != "platform" {
+		t.Errorf("expected the request's tag on the account, got %+v", tags)
+	}
+}
+
+// TestOrganizations_VendingMalformedBody covers the decode guard on each
+// operation this lane adds. An operation that skipped it would decode into a
+// zero-valued input and answer as though the caller had asked about the empty
+// request ID, which is a wrong answer rather than an error.
+func TestOrganizations_VendingMalformedBody(t *testing.T) {
+	ts, _ := newOrgVendingFixture(t)
+
+	for _, op := range []string{"DescribeCreateAccountStatus", "ListCreateAccountStatus", "MoveAccount"} {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", newOrgBadBody())
+		if err != nil {
+			t.Fatalf("%s: build request: %v", op, err)
+		}
+		req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+		req.Header.Set("X-Amz-Target", "Organizations_20161128."+op)
+		req.Host = "organizations.us-east-1.amazonaws.com"
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", op, err)
+		}
+		gotStatus := resp.StatusCode
+		resp.Body.Close() //nolint:errcheck
+		if gotStatus != http.StatusBadRequest {
+			t.Errorf("%s: expected 400 for an unparseable body, got %d", op, gotStatus)
+		}
+	}
+}
+
+// TestOrganizations_VendingStoreFailures asserts a store failure on any of the
+// lane's operations is a 500 the SDK retries rather than a 400 it treats as
+// terminal. The vending path is the worst place to collapse the two: a
+// CreateAccount that answers 200 while nothing landed leaves the caller holding a
+// request ID no poll can resolve.
+func TestOrganizations_VendingStoreFailures(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		op     string
+		body   map[string]interface{}
+		// needsAccount builds the request body from a vended account and an OU,
+		// which MoveAccount needs before a store failure is worth arming.
+		needsAccount bool
+		onGet        bool
+		onPut        bool
+	}{
+		{
+			name: "create cannot read the account index", prefix: "account_ids:",
+			op: "CreateAccount", body: map[string]interface{}{"AccountName": "dev", "Email": "dev@example.com"},
+			onGet: true,
+		},
+		{
+			name: "create cannot write the request record", prefix: "car:",
+			op: "CreateAccount", body: map[string]interface{}{"AccountName": "dev", "Email": "dev@example.com"},
+			onPut: true,
+		},
+		{
+			name: "create cannot write the pending outcome", prefix: emulator.OrgCreatePendingPrefixForTest,
+			op: "CreateAccount", body: map[string]interface{}{"AccountName": "dev", "Email": "dev@example.com"},
+			onPut: true,
+		},
+		{
+			name: "create cannot write the account record", prefix: "account:",
+			op: "CreateAccount", body: map[string]interface{}{"AccountName": "dev", "Email": "dev@example.com"},
+			onPut: true,
+		},
+		{
+			name: "create cannot place the account", prefix: "children:",
+			op: "CreateAccount", body: map[string]interface{}{"AccountName": "dev", "Email": "dev@example.com"},
+			onPut: true,
+		},
+		{
+			name: "create cannot write the account's tags", prefix: "tags:",
+			op: "CreateAccount", body: map[string]interface{}{
+				"AccountName": "dev", "Email": "dev@example.com",
+				"Tags": []map[string]string{{"Key": "Owner", "Value": "platform"}},
+			},
+			onPut: true,
+		},
+		{
+			name: "create cannot read the failure seed", prefix: "create-account-failure:",
+			op: "CreateAccount", body: map[string]interface{}{"AccountName": "dev", "Email": "dev@example.com"},
+			onGet: true,
+		},
+		{
+			name: "describe cannot read the request", prefix: "car:",
+			op: "DescribeCreateAccountStatus", body: map[string]interface{}{"CreateAccountRequestId": "car-11112222"},
+			onGet: true,
+		},
+		{
+			name: "list cannot read the request index", prefix: "car_ids:",
+			op: "ListCreateAccountStatus", body: map[string]interface{}{},
+			onGet: true,
+		},
+		{
+			name: "move cannot read the placement", prefix: "parent:",
+			op: "MoveAccount", needsAccount: true, onGet: true,
+		},
+		{
+			name: "move cannot write the placement", prefix: "children:",
+			op: "MoveAccount", needsAccount: true, onPut: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			state := &errOrgState{
+				inner: inner, prefix: c.prefix, err: errors.New("store unavailable"),
+				onGet: c.onGet, onPut: c.onPut,
+			}
+			ts := newOrgServerOverState(t, state)
+
+			// The organization is created before the failure is armed, since
+			// arming from the start would leave nothing to operate on.
+			body := c.body
+			if c.needsAccount {
+				rootID := orgListRootsID(t, ts)
+				accountID := orgVendAccount(t, ts, "dev-account", "dev@example.com")
+				body = map[string]interface{}{
+					"AccountId":      accountID,
+					"SourceParentId": rootID,
+					// Well formed and existent, so the request reaches the store
+					// read rather than stopping at a shape or lookup refusal.
+					"DestinationParentId": orgCreateOU(t,
+						emulator.NewOrganizationsPluginForTest(state, emulator.NewTimeController(time.Now())),
+						rootID, "11112222"),
+				}
+			} else {
+				warm := orgsRequest(t, ts, "ListRoots", map[string]interface{}{})
+				warm.Body.Close() //nolint:errcheck
+			}
+			state.armed = true
+
+			resp := orgsRequest(t, ts, c.op, body)
+			gotStatus := resp.StatusCode
+			resp.Body.Close() //nolint:errcheck
+			if gotStatus != http.StatusInternalServerError {
+				t.Errorf("expected 500 for a store failure, got %d", gotStatus)
+			}
+		})
+	}
+}
+
+// TestOrganizations_MissingPendingOutcomeIsAnError pins what happens when the
+// request record exists but the outcome it was committed to does not. That
+// pairing is unreachable through the API — createAccount writes the outcome first
+// — so it means the store lost a record, and guessing SUCCEEDED would report an
+// AccountId nothing else in the organization agrees with.
+func TestOrganizations_MissingPendingOutcomeIsAnError(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	ts := newOrgServerOverState(t, state)
+
+	created, code := orgCreateAccount(t, ts, "dev-account", "dev@example.com")
+	if code != http.StatusOK {
+		t.Fatalf("CreateAccount: expected 200, got %d", code)
+	}
+	if err := state.Delete(t.Context(), "organizations",
+		emulator.OrgCreatePendingPrefixForTest+created.ID); err != nil {
+		t.Fatalf("delete pending outcome: %v", err)
+	}
+
+	resp := orgsRequest(t, ts, "DescribeCreateAccountStatus",
+		map[string]interface{}{"CreateAccountRequestId": created.ID})
+	gotStatus := resp.StatusCode
+	resp.Body.Close() //nolint:errcheck
+	if gotStatus != http.StatusInternalServerError {
+		t.Errorf("expected 500 for a request with no recorded outcome, got %d", gotStatus)
+	}
+}
+
+// TestOrganizations_ListCreateStatusSkipsVanishedRecords asserts the listing
+// tolerates an index entry whose record is gone rather than reporting a
+// zero-valued request. A status with an empty Id and an empty State is worse than
+// a short page: a waiter iterating it would never see a terminal state.
+func TestOrganizations_ListCreateStatusSkipsVanishedRecords(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	ts := newOrgServerOverState(t, state)
+
+	created, _ := orgCreateAccount(t, ts, "dev-account", "dev@example.com")
+	if err := state.Delete(t.Context(), "organizations", "car:"+created.ID); err != nil {
+		t.Fatalf("delete request record: %v", err)
+	}
+
+	if got := orgListCreateStatuses(t, ts, nil); len(got) != 0 {
+		t.Errorf("expected the vanished record skipped rather than listed empty, got %+v", got)
+	}
+}
+
+// TestOrganizations_OUNamesRoot covers the ID-shape reasoning the cross-root
+// refusal rests on. An OU ID embeds its root's suffix, so getting this wrong
+// would either refuse a legitimate move or let an account cross roots.
+func TestOrganizations_OUNamesRoot(t *testing.T) {
+	cases := []struct {
+		ou, root string
+		want     bool
+	}{
+		{"ou-abcd-11112222", "r-abcd", true},
+		{"ou-abcd-11112222", "r-zzzz", false},
+		{"ou-abcd-1111-2222", "r-abcd", true},
+		{"r-abcd", "r-abcd", false},
+		{"ou-abcd", "r-abcd", false},
+		{"ou--11112222", "r-abcd", false},
+		{"ou-abcd-11112222", "ou-abcd-11112222", false},
+	}
+	for _, c := range cases {
+		if got := emulator.OrgOUNamesRootForTest(c.ou, c.root); got != c.want {
+			t.Errorf("OrgOUNamesRoot(%q, %q) = %v, want %v", c.ou, c.root, got, c.want)
+		}
+	}
+
+	for id, want := range map[string]bool{
+		"r-abcd": true, "ou-abcd-11112222": true, "111111111111": false, "": false, "p-11112222": false,
+	} {
+		if got := emulator.IsOrgParentIDForTest(id); got != want {
+			t.Errorf("IsOrgParentID(%q) = %v, want %v", id, got, want)
+		}
+	}
+}

--- a/emulator/organizations_plugin_test.go
+++ b/emulator/organizations_plugin_test.go
@@ -134,12 +134,28 @@ func TestOrganizations_CreateAccount_DescribeAccount(t *testing.T) {
 	if !ok {
 		t.Fatal("expected CreateAccountStatus")
 	}
-	if state, _ := status["State"].(string); state != "SUCCEEDED" {
-		t.Errorf("expected State=SUCCEEDED, got %q", state)
+	// CreateAccount is asynchronous, so the call itself reports IN_PROGRESS and
+	// carries no AccountId; the account ID arrives from the first
+	// DescribeCreateAccountStatus. See TestOrganizations_FullVend.
+	if state, _ := status["State"].(string); state != "IN_PROGRESS" {
+		t.Errorf("expected State=IN_PROGRESS, got %q", state)
 	}
-	newAccountID, _ := status["AccountId"].(string)
+	requestID, _ := status["Id"].(string)
+	resolved := orgsRequest(t, ts, "DescribeCreateAccountStatus", map[string]interface{}{
+		"CreateAccountRequestId": requestID,
+	})
+	defer resolved.Body.Close() //nolint:errcheck
+	var resolvedOut struct {
+		CreateAccountStatus struct {
+			AccountID string `json:"AccountId"`
+		} `json:"CreateAccountStatus"`
+	}
+	if err := json.NewDecoder(resolved.Body).Decode(&resolvedOut); err != nil {
+		t.Fatalf("DescribeCreateAccountStatus decode: %v", err)
+	}
+	newAccountID := resolvedOut.CreateAccountStatus.AccountID
 	if newAccountID == "" {
-		t.Fatal("expected non-empty AccountId in CreateAccountStatus")
+		t.Fatal("expected non-empty AccountId once the request resolved")
 	}
 
 	// DescribeAccount.


### PR DESCRIPTION
Lane C of the v0.97.0 Organizations work: asynchronous account vending.

`Part of #578` — covers **points 1, 2, 3 and 5** of the issue's nine, plus point 8 for the operations added here.

## What changed

`CreateAccount` answered `SUCCEEDED` inline with an `AccountId`. AWS documents the operation as "an asynchronous request that Amazon Web Services performs in the background", and a synchronous fake lets a consumer with no poll loop pass its tests — the poll loop being the part that has to survive an interruption, since the `car-` request ID is the only handle a resumed run has on an account that may or may not exist yet.

**Operations:** `CreateAccount` (now asynchronous), `DescribeCreateAccountStatus`, `ListCreateAccountStatus`, `MoveAccount`. Every input/output member name, error code, enum and pattern was checked against `organizations/2016-11-28/service-2.json`; the request ID matches the model's `CreateAccountRequestId` pattern `^car-[a-z0-9]{8,32}$`.

## Design decisions worth reviewing

**Resolution on first observation, not on the clock (point 1).** The status resolves when it is first read, so a waiter converges in one poll with no dependence on wall-clock or simulated time, and the terminal state never moves afterwards — a status that re-resolved (a moving `CompletedTimestamp`, a flip back to `IN_PROGRESS`) would make a waiter comparing successive polls loop forever. Clock-driven transitions are #514, still open; picking a duration here would front-run that design. The `OrganizationsPlugin` doc comment already recorded this and remains accurate.

**The outcome is decided at request time, recorded apart from the request.** A new `car_pending:` record holds the terminal outcome the request is committed to. Deciding it at read time instead would let a seed cleared between `CreateAccount` and the first poll produce a `SUCCEEDED` status naming an account that was never written, or a `FAILED` status for an account sitting in `ListAccounts` — states real AWS cannot reach. Keeping it out of the request record also means the stored `CreateAccountStatus` is always a shape AWS could return, which matters because substrate's state is meant to be inspectable at any point in history.

**A seeded failure writes no account (asked for explicitly in the lane brief).** It should not, and does not. A `FAILED` request that left an account in `ListAccounts` is a state real AWS cannot produce, and it is the one most likely to make a consumer's cleanup path look correct while it deletes nothing.

**`CreateAccount` still returns 200 for a seeded failure (point 3).** That asymmetry is the whole point of the seed: a caller that checks the HTTP status and moves on never learns the account was not created. Asserted directly.

**New accounts land in the root (point 2).** `CreateAccount` takes no parent, so `MoveAccount` is the only way into an OU, and the account is in `ListAccounts` immediately — before any poll — as AWS reports it. A tool that assumes otherwise leaves accounts outside the OU where the policies are attached.

## Refusals wired, each from the operation's declared `errors` list

| Case | Code |
| --- | --- |
| Unknown `CreateAccountRequestId` | `CreateAccountStatusNotFoundException` |
| Destination is already the account's parent | `DuplicateAccountException` |
| `SourceParentId` is not the actual parent | `SourceParentNotFoundException` |
| Unknown destination | `DestinationParentNotFoundException` |
| OU under another root | `InvalidInputException` / `MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS` |
| 11th account, management account counted | `ConstraintViolationException` / `ACCOUNT_NUMBER_LIMIT_EXCEEDED` |
| `States` filter outside the enum | `InvalidInputException` / `INVALID_LIST_MEMBER` |
| Malformed parent ID | `InvalidInputException` / `INVALID_PATTERN` |
| Missing required member | `InvalidInputException` / `INPUT_REQUIRED` |

Two orderings are deliberate and commented:

- **Destination before source.** A governance script re-run replays the move it recorded (source root, destination OU). The useful answer is "that account is already present in the specified destination", not "your source OU does not exist", which is what validating the source first would say. This settles **point 5**, which was uncertain whether the move should be a no-op: it is a refusal, and a re-run fails distinguishably instead of silently succeeding.
- **Cross-root before not-found.** An OU ID embeds its root's suffix, so an OU naming another root is a cross-root move on its face. The two refusals send a caller to different places — "this move is not possible" versus "create the OU first".

## Consumer-visible break

`CreateAccount` reports `State: "IN_PROGRESS"` and carries no `AccountId`. A caller must poll `DescribeCreateAccountStatus` with the returned `Id`. One assertion outside this lane changed for it — `emulator/organizations_plugin_test.go` now polls for the account ID instead of reading it off the create response. That is the single line the lane brief flagged.

## Deliberately left out

- **`CloseAccount`.** It did not fall out for free. AWS documents it as its own asynchronous journey observed through `DescribeAccount` (`ACTIVE` → `PENDING_CLOSURE` → `SUSPENDED`), with its own refusals (`AccountAlreadyClosedException`, `ConstraintViolationException`/`CANNOT_CLOSE_MANAGEMENT_ACCOUNT`, `CLOSE_ACCOUNT_QUOTA_EXCEEDED`) and a 30-day quota. That is a second resolution mechanism on a different observation surface, not a few lines on this one.
- **Organization-wide email uniqueness** (the `EMAIL_ALREADY_EXISTS` half of point 7). Reachable through the seed, not inferred from stored accounts. Inferring it would change the outcome of an existing fixture rather than add a path a test opts into — the foundation's `TestOrganizations_ListAccountsPaginates` vends three accounts sharing one email, and inferring uniqueness silently failed it. Left as `TODO(#578)` in `pendingCreateOutcome`; worth a follow-up decision, since making it automatic is a behaviour change for any existing fixture that reuses an address.
- **`RoleName` / `IamUserAccessToBilling`** are accepted and recorded nowhere. No Organizations API observation exposes either, so modeling them would be modeling the inside of the new account rather than the API surface.
- `GovCloudAccountId` on `CreateAccountStatus`, since GovCloud vending is not modeled.

## Nothing contradicted the brief

The model agreed with the lane brief on every point checked: the `car-` pattern, the three-value `CreateAccountState` enum, `ListCreateAccountStatus`'s `States` filter, and all six `MoveAccount` refusals. `orgMaxAccounts = 10` and the 10-per-target / 10,240-byte SCP figures from the milestone comment are what the foundation already ships.

## Files

- `emulator/organizations_account.go` — the lane's operations.
- `emulator/organizations_account_test.go`, `emulator/organizations_account_export_test.go` — new.
- `emulator/organizations_plugin_test.go` — the one-line assertion above.

No shared file was otherwise touched: `HandleRequest`, `organizations_state.go`, `organizations_types.go` and `organizations_export_test.go` are unchanged. Two helpers live in this lane's file and could be hoisted later if another lane needs them: `isOrgParentID` and `orgOUNamesRoot`.

`CHANGELOG.md` is untouched (PR 6 owns it).

## Verification

`gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run ./emulator/` (0 issues), `go test ./emulator/ -run TestOrganizations`, and `make test` (race detector, whole repo) all clean. Per-function coverage of the new code is 89–100%, including the store-failure and corrupt-record boundaries in the style of `organizations_faults_test.go`.
