### PR TITLE
feat(organizations): tag roots, OUs, accounts and policies, and let a policy read those tags (#578)

### DIFF
--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -36,7 +36,7 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	if authzNoPermissionsRequired[action] {
 		return nil
 	}
-	resource := buildResourceARN(reqCtx, req)
+	resource := a.buildResourceARN(reqCtx, req)
 
 	goCtx := context.Background()
 	entity, exists, err := resolveIAMEntity(goCtx, a.state, reqCtx.Principal.ARN)
@@ -397,7 +397,11 @@ func serviceToAction(req *AWSRequest, service, operation string) string {
 }
 
 // buildResourceARN constructs a best-effort IAM resource ARN for the request.
-func buildResourceARN(reqCtx *RequestContext, req *AWSRequest) string {
+//
+// It is a method rather than a free function because some services cannot name
+// their resources without reading them: an Organizations ARN embeds the
+// organization's own ID, which only the stored record knows.
+func (a *AuthController) buildResourceARN(reqCtx *RequestContext, req *AWSRequest) string {
 	acct := reqCtx.AccountID
 	region := reqCtx.Region
 	switch req.Service {
@@ -505,6 +509,12 @@ func buildResourceARN(reqCtx *RequestContext, req *AWSRequest) string {
 			return "arn:aws:glue:" + region + ":" + acct + ":database/" + name
 		}
 		return "*"
+	case organizationsNamespace:
+		// Organizations ARNs carry the organization's own ID as a segment, so the
+		// real ARN is read from the stored record rather than reassembled here; see
+		// orgAuthzResourceARN. Falling through to "*" would make a policy scoped to
+		// one OU or policy apply to every one of them.
+		return orgAuthzResourceARN(a.state, reqCtx, req)
 	default:
 		return "*"
 	}
@@ -659,6 +669,13 @@ func (a *AuthController) addResourceTags(condCtx map[string]string, reqCtx *Requ
 		}
 		tags = t.Tags
 
+	case organizationsNamespace:
+		// The request names one Organizations resource — an account, root, OU, or
+		// policy — under whichever member the operation uses. Only that one is read;
+		// see orgAuthzResourceID for why merging the tags of two named resources
+		// would be a false allow rather than a convenience.
+		tags = orgAuthzResourceTags(a.state, req)
+
 	default:
 		return
 	}
@@ -717,6 +734,15 @@ func addRequestTags(condCtx map[string]string, req *AWSRequest) {
 			for k, v := range body.Tags {
 				condCtx["aws:RequestTag/"+k] = v
 			}
+		}
+
+	case organizationsNamespace:
+		// Organizations tags arrive in the JSON body as "Tags": [{"Key":…,"Value":…}],
+		// the same shape IAM uses. Reading them here is what lets a policy gate
+		// TagResource or a tagged CreatePolicy on the tag the caller is trying to
+		// apply, rather than only on tags already stored.
+		for k, v := range orgAuthzRequestTags(req) {
+			condCtx["aws:RequestTag/"+k] = v
 		}
 
 	case "s3":

--- a/emulator/organizations_tags.go
+++ b/emulator/organizations_tags.go
@@ -1,8 +1,606 @@
 package emulator
 
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Tag shape bounds, from the Organizations API model's TagKey and TagValue
+// shapes. Lengths are in characters rather than bytes, which is what the model's
+// min/max mean and what a caller tagging with non-ASCII depends on.
+const (
+	// orgMinTagKeyChars is TagKey's minimum length. An empty key is refused
+	// rather than stored, because a tag with no key can never be matched by an
+	// aws:ResourceTag condition and so would silently never gate anything.
+	orgMinTagKeyChars = 1
+
+	// orgMaxTagKeyChars is TagKey's maximum length.
+	orgMaxTagKeyChars = 128
+
+	// orgMaxTagValueChars is TagValue's maximum length. TagValue's minimum is 0:
+	// the empty string is a legal value, and only a null one is refused.
+	orgMaxTagValueChars = 256
+
+	// orgSystemTagPrefix marks the tag keys AWS reserves for itself. The model's
+	// INVALID_SYSTEM_TAGS_PARAMETER reason exists for a caller that tries to
+	// write one: a caller cannot add, edit, or delete a system tag key, because
+	// those keys are reserved for AWS's own use.
+	orgSystemTagPrefix = "aws:"
+)
+
+// orgTagInput is one tag as the wire sends it. Key and Value are pointers so an
+// absent or null member can be told apart from an empty string: TagValue's
+// minimum length is 0, so "" is a legal value the caller may have meant, while
+// null is not a value at all. Collapsing the two would store an empty-valued tag
+// for a request AWS refuses.
+type orgTagInput struct {
+	Key   *string `json:"Key"`
+	Value *string `json:"Value"`
+}
+
 // tagOperation claims the resource tagging operations. Tags reach the
-// authorization decision through the organizations arms of addRequestTags and
-// addResourceTags in authz.go.
-func (p *OrganizationsPlugin) tagOperation(_ string) (orgHandler, bool) {
-	return nil, false
+// authorization decision through the organizations arms of buildResourceARN,
+// addResourceTags and addRequestTags in authz.go — tagging that no policy can
+// read is bookkeeping, not a privilege boundary.
+func (p *OrganizationsPlugin) tagOperation(op string) (orgHandler, bool) {
+	switch op {
+	case "TagResource":
+		return p.tagResource, true
+	case "UntagResource":
+		return p.untagResource, true
+	case "ListTagsForResource":
+		return p.listTagsForResource, true
+	default:
+		return nil, false
+	}
+}
+
+// --- operations ---
+
+// tagResource adds or overwrites tags on an account, root, OU, or policy.
+//
+// Every input is validated before anything is written, which is what TagResource
+// documents: "If any one of the tags is not valid or if you exceed the maximum
+// allowed number of tags for a resource, then the entire request fails." A
+// partially applied batch would leave the caller unable to tell which tags
+// landed, and a retry of the same request would then behave differently from the
+// first attempt.
+func (p *OrganizationsPlugin) tagResource(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		ResourceID string        `json:"ResourceId"`
+		Tags       []orgTagInput `json:"Tags"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := validateOrgTaggableResourceID(input.ResourceID); err != nil {
+		return nil, err
+	}
+	// A nil slice is an absent required member; an empty one is a request that
+	// asked for no tags, which the model permits (Tags carries no minimum length)
+	// and which is a no-op.
+	if input.Tags == nil {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "you must specify Tags")
+	}
+	tags, err := validateOrgTags(input.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.requireWritableOrgResource(goCtx, reqCtx.AccountID, input.ResourceID); err != nil {
+		return nil, err
+	}
+
+	existing, err := p.loadTags(goCtx, input.ResourceID)
+	if err != nil {
+		return nil, fmt.Errorf("tagResource load tags: %w", err)
+	}
+	merged := mergeOrgTags(existing, tags)
+	// The limit is on the resulting tag set, not on the request: re-tagging an
+	// existing key overwrites it, so a resource already at the limit can still be
+	// retagged. Counting the request instead would refuse a governance script that
+	// only ever rewrites the tags it owns.
+	if len(merged) > orgMaxTagsPerResource {
+		return nil, orgConstraintViolation("MAX_TAG_LIMIT_EXCEEDED",
+			fmt.Sprintf("you have exceeded the number of tags allowed on this resource (%d)", orgMaxTagsPerResource))
+	}
+	if err := p.saveTags(goCtx, input.ResourceID, merged); err != nil {
+		return nil, fmt.Errorf("tagResource save tags: %w", err)
+	}
+	return orgEmptyResponse(), nil
+}
+
+// untagResource removes the named tag keys from a resource.
+//
+// A key that is not on the resource is not an error: UntagResource "removes any
+// tags with the specified keys", so the operation is idempotent, and a cleanup
+// path that runs twice must not fail the second time.
+func (p *OrganizationsPlugin) untagResource(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		ResourceID string   `json:"ResourceId"`
+		TagKeys    []string `json:"TagKeys"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := validateOrgTaggableResourceID(input.ResourceID); err != nil {
+		return nil, err
+	}
+	if input.TagKeys == nil {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "you must specify TagKeys")
+	}
+	for _, key := range input.TagKeys {
+		if err := validateOrgTagKey(key); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := p.requireWritableOrgResource(goCtx, reqCtx.AccountID, input.ResourceID); err != nil {
+		return nil, err
+	}
+
+	existing, err := p.loadTags(goCtx, input.ResourceID)
+	if err != nil {
+		return nil, fmt.Errorf("untagResource load tags: %w", err)
+	}
+	remove := make(map[string]bool, len(input.TagKeys))
+	for _, key := range input.TagKeys {
+		remove[key] = true
+	}
+	kept := make([]OrgTag, 0, len(existing))
+	for _, t := range existing {
+		if !remove[t.Key] {
+			kept = append(kept, t)
+		}
+	}
+	// Nothing matched, so nothing is written: an untag of keys a resource never
+	// had leaves no record behind, and a resource that was never tagged stays
+	// untagged rather than acquiring an empty tag set.
+	if len(kept) == len(existing) {
+		return orgEmptyResponse(), nil
+	}
+	if err := p.saveTags(goCtx, input.ResourceID, kept); err != nil {
+		return nil, fmt.Errorf("untagResource save tags: %w", err)
+	}
+	return orgEmptyResponse(), nil
+}
+
+// listTagsForResource returns a resource's tags, one page at a time.
+//
+// The model gives this operation a NextToken but no MaxResults, so the page size
+// is the ceiling orgPaginate applies to every Organizations listing. That is
+// below the 50-tag limit, so a heavily tagged resource really does page, and a
+// consumer that reads only the first page is caught here rather than against AWS.
+func (p *OrganizationsPlugin) listTagsForResource(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		ResourceID string `json:"ResourceId"`
+		NextToken  string `json:"NextToken"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := validateOrgTaggableResourceID(input.ResourceID); err != nil {
+		return nil, err
+	}
+	// Listing is a read, so it does not care whether the resource is writable —
+	// an AWS-managed policy has no tags and answers with an empty list.
+	if err := p.requireOrgResource(goCtx, reqCtx.AccountID, input.ResourceID); err != nil {
+		return nil, err
+	}
+
+	tags, err := p.loadTags(goCtx, input.ResourceID)
+	if err != nil {
+		return nil, fmt.Errorf("listTagsForResource load tags: %w", err)
+	}
+	byKey := make(map[string]string, len(tags))
+	keys := make([]string, 0, len(tags))
+	for _, t := range tags {
+		byKey[t.Key] = t.Value
+		keys = append(keys, t.Key)
+	}
+	// MaxResults is 0 because the operation has none; orgPaginate reads that as
+	// "the maximum" and still validates the token.
+	page, next, err := orgPaginate(keys, input.NextToken, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	out := map[string]interface{}{"Tags": orgTagsFromKeys(page, byKey)}
+	if next != "" {
+		out["NextToken"] = next
+	}
+	return orgJSONResponse(out, "listTagsForResource")
+}
+
+// --- resource resolution ---
+
+// requireOrgResource refuses a resource the organization does not contain.
+//
+// TargetNotFoundException rather than a silent success: a tag written against an
+// ID that resolves to nothing would be unreadable by every later call, and a
+// caller that mistyped a resource ID would discover it only when the tag-gated
+// policy it wrote failed to gate anything.
+func (p *OrganizationsPlugin) requireOrgResource(ctx context.Context, acct, resourceID string) error {
+	if _, err := p.ensureOrganization(ctx, acct); err != nil {
+		return fmt.Errorf("organizations tagging ensure org: %w", err)
+	}
+	kind, err := p.resolveOrgTarget(ctx, acct, resourceID)
+	if err != nil {
+		return fmt.Errorf("organizations tagging resolve %s: %w", resourceID, err)
+	}
+	if kind == "" {
+		return orgErr("TargetNotFoundException",
+			"We can't find a root, OU, account, or policy with the ResourceId "+resourceID)
+	}
+	return nil
+}
+
+// requireWritableOrgResource additionally refuses a resource whose tags cannot
+// be changed.
+//
+// p-FullAWSAccess is owned by AWS, not by the organization — its ARN names the
+// "aws" account — so a tag written against it would be visible in one
+// organization and nowhere else, a state no sequence of AWS calls can produce.
+// IMMUTABLE_POLICY is the model's reason for "a policy that is managed by Amazon
+// Web Services and can't be modified".
+func (p *OrganizationsPlugin) requireWritableOrgResource(ctx context.Context, acct, resourceID string) error {
+	if err := p.requireOrgResource(ctx, acct, resourceID); err != nil {
+		return err
+	}
+	// p-FullAWSAccess is the only AWS-managed policy substrate synthesizes; every
+	// other policy ID resolves to a record the organization owns.
+	if resourceID == orgFullAWSAccessID {
+		return orgInvalidInput("IMMUTABLE_POLICY",
+			"you specified a policy that is managed by Amazon Web Services and can't be modified: "+resourceID)
+	}
+	return nil
+}
+
+// --- validation ---
+
+// validateOrgTaggableResourceID refuses a ResourceId the model's
+// TaggableResourceId pattern does not admit.
+//
+// A malformed ID and an absent resource are different answers to different
+// mistakes: "ou-oops" is a typo the caller can fix from the error, while a
+// well-formed ID that names nothing means the resource is gone. Answering
+// TargetNotFoundException for both would send a caller looking for a deleted OU
+// that never existed.
+func validateOrgTaggableResourceID(id string) error {
+	if id == "" {
+		return orgInvalidInput("INPUT_REQUIRED", "you must specify ResourceId")
+	}
+	if !isOrgTaggableResourceID(id) {
+		return orgInvalidInput("INVALID_PATTERN",
+			"the ResourceId "+id+" does not match the required pattern for a root, account, OU, or policy")
+	}
+	return nil
+}
+
+// isOrgTaggableResourceID reports whether id has one of the six forms the
+// model's TaggableResourceId pattern accepts. Two of them — rp- (resource
+// policy) and rt- (responsibility transfer) — are well-formed but name resources
+// substrate does not model, so they are admitted here and refused as absent by
+// resolveOrgTarget, which is the same answer AWS gives for an ID in an
+// organization that has no such resource.
+func isOrgTaggableResourceID(id string) bool {
+	switch {
+	case strings.HasPrefix(id, "rp-"):
+		return orgIDBodyMatches(id[3:], 4, 128, isOrgPolicyIDRune)
+	case strings.HasPrefix(id, "rt-"):
+		return orgIDBodyMatches(id[3:], 8, 32, isOrgPolicyIDRune)
+	case strings.HasPrefix(id, "r-"):
+		return orgIDBodyMatches(id[2:], 4, 32, isOrgLowerAlphanumRune)
+	case strings.HasPrefix(id, "ou-"):
+		root, child, ok := strings.Cut(id[3:], "-")
+		return ok && orgIDBodyMatches(root, 4, 32, isOrgLowerAlphanumRune) &&
+			orgIDBodyMatches(child, 8, 32, isOrgLowerAlphanumRune)
+	case strings.HasPrefix(id, "p-"):
+		return orgIDBodyMatches(id[2:], 8, 128, isOrgPolicyIDRune)
+	default:
+		return orgIDBodyMatches(id, 12, 12, func(r rune) bool { return r >= '0' && r <= '9' })
+	}
+}
+
+// orgIDBodyMatches reports whether body has between minLen and maxLen characters
+// and every one of them satisfies allowed.
+func orgIDBodyMatches(body string, minLen, maxLen int, allowed func(rune) bool) bool {
+	n := 0
+	for _, r := range body {
+		if !allowed(r) {
+			return false
+		}
+		n++
+	}
+	return n >= minLen && n <= maxLen
+}
+
+// isOrgLowerAlphanumRune matches the [0-9a-z] class the root and OU ID patterns
+// use.
+func isOrgLowerAlphanumRune(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z')
+}
+
+// isOrgPolicyIDRune matches the [0-9a-zA-Z_] class the policy ID pattern uses;
+// p-FullAWSAccess is why the class is mixed case.
+func isOrgPolicyIDRune(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_'
+}
+
+// validateOrgTags checks a whole request's tags and returns them, refusing the
+// first problem it finds.
+//
+// The duplicate-key check is over the request rather than over the stored tags:
+// two entries for one key in one call leave the result dependent on which one
+// wins, so DUPLICATE_TAG_KEY refuses the ambiguity instead of silently picking.
+func validateOrgTags(inputs []orgTagInput) ([]OrgTag, error) {
+	tags := make([]OrgTag, 0, len(inputs))
+	seen := make(map[string]bool, len(inputs))
+	for _, in := range inputs {
+		if in.Key == nil {
+			return nil, orgInvalidInput("INPUT_REQUIRED", "every tag must specify a Key")
+		}
+		if in.Value == nil {
+			return nil, orgInvalidInput("INPUT_REQUIRED",
+				"the tag "+*in.Key+" must specify a Value; the value may be an empty string but not null")
+		}
+		if err := validateOrgTagKey(*in.Key); err != nil {
+			return nil, err
+		}
+		if err := validateOrgTagValue(*in.Key, *in.Value); err != nil {
+			return nil, err
+		}
+		if seen[*in.Key] {
+			return nil, orgInvalidInput("DUPLICATE_TAG_KEY",
+				"tag keys must be unique among the tags attached to the same entity: "+*in.Key)
+		}
+		seen[*in.Key] = true
+		tags = append(tags, OrgTag{Key: *in.Key, Value: *in.Value})
+	}
+	return tags, nil
+}
+
+// validateOrgTagKey enforces the TagKey shape and the reservation of the "aws:"
+// prefix.
+func validateOrgTagKey(key string) error {
+	n := utf8.RuneCountInString(key)
+	switch {
+	case n < orgMinTagKeyChars:
+		return orgInvalidInput("MIN_LENGTH_EXCEEDED",
+			fmt.Sprintf("a tag key must be at least %d character long", orgMinTagKeyChars))
+	case n > orgMaxTagKeyChars:
+		return orgInvalidInput("MAX_LENGTH_EXCEEDED",
+			fmt.Sprintf("the tag key %q is longer than the %d-character maximum", key, orgMaxTagKeyChars))
+	case !isOrgTagText(key):
+		return orgInvalidInput("INVALID_PATTERN",
+			fmt.Sprintf("the tag key %q contains a character tag keys do not allow", key))
+	case strings.HasPrefix(key, orgSystemTagPrefix):
+		return orgInvalidInput("INVALID_SYSTEM_TAGS_PARAMETER",
+			fmt.Sprintf("the tag key %q is a system tag; system tag keys are reserved for Amazon Web Services use", key))
+	}
+	return nil
+}
+
+// validateOrgTagValue enforces the TagValue shape. The empty string passes: the
+// shape's minimum length is 0, and a caller that tags with an empty value is
+// recording the key's presence.
+func validateOrgTagValue(key, value string) error {
+	if utf8.RuneCountInString(value) > orgMaxTagValueChars {
+		return orgInvalidInput("MAX_LENGTH_EXCEEDED",
+			fmt.Sprintf("the value of tag %q is longer than the %d-character maximum", key, orgMaxTagValueChars))
+	}
+	if !isOrgTagText(value) {
+		return orgInvalidInput("INVALID_PATTERN",
+			fmt.Sprintf("the value of tag %q contains a character tag values do not allow", key))
+	}
+	return nil
+}
+
+// isOrgTagText reports whether every character of s is in the class the model's
+// TagKey and TagValue patterns share: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$.
+func isOrgTagText(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.Is(unicode.Z, r) {
+			continue
+		}
+		switch r {
+		case '_', '.', ':', '/', '=', '+', '-', '@':
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// --- tag set arithmetic ---
+
+// mergeOrgTags applies added over existing, overwriting a key rather than
+// duplicating it. A resource carrying one key twice would make an
+// aws:ResourceTag condition depend on read order, which is the one thing a
+// deterministic emulator must not allow.
+func mergeOrgTags(existing, added []OrgTag) []OrgTag {
+	merged := make([]OrgTag, 0, len(existing)+len(added))
+	replaced := make(map[string]string, len(added))
+	for _, t := range added {
+		replaced[t.Key] = t.Value
+	}
+	for _, t := range existing {
+		if v, ok := replaced[t.Key]; ok {
+			merged = append(merged, OrgTag{Key: t.Key, Value: v})
+			delete(replaced, t.Key)
+			continue
+		}
+		merged = append(merged, t)
+	}
+	for _, t := range added {
+		if _, ok := replaced[t.Key]; ok {
+			merged = append(merged, t)
+			delete(replaced, t.Key)
+		}
+	}
+	return merged
+}
+
+// orgTagsFromKeys rebuilds the tags for one page of keys.
+func orgTagsFromKeys(keys []string, byKey map[string]string) []OrgTag {
+	tags := make([]OrgTag, 0, len(keys))
+	for _, k := range keys {
+		tags = append(tags, OrgTag{Key: k, Value: byKey[k]})
+	}
+	return tags
+}
+
+// --- authorization support ---
+//
+// These three feed the organizations arms of buildResourceARN, addResourceTags
+// and addRequestTags in authz.go. They read through the raw StateManager rather
+// than through the plugin because authorization runs before dispatch, so no
+// plugin instance is in hand — and they run on every request, so each reads at
+// most the one resource the request names.
+
+// orgAuthzResourceID returns the ID of the Organizations resource a request
+// names, or "" when it names none.
+//
+// One resource, not several: AttachPolicy names both a policy and a target, and
+// merging both tag sets into aws:ResourceTag would let a tag on the policy
+// satisfy a condition written about the target — a false allow, which is the
+// failure a tag-gated boundary exists to prevent. The order below prefers the
+// member that names the operation's own subject.
+func orgAuthzResourceID(req *AWSRequest) string {
+	var body struct {
+		ResourceID           string `json:"ResourceId"`
+		PolicyID             string `json:"PolicyId"`
+		TargetID             string `json:"TargetId"`
+		AccountID            string `json:"AccountId"`
+		OrganizationalUnitID string `json:"OrganizationalUnitId"`
+		RootID               string `json:"RootId"`
+		ParentID             string `json:"ParentId"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return ""
+	}
+	for _, id := range []string{
+		body.ResourceID, body.PolicyID, body.TargetID, body.AccountID,
+		body.OrganizationalUnitID, body.RootID, body.ParentID,
+	} {
+		if id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+// orgAuthzResourceARN returns the ARN of the Organizations resource a request
+// names, for the Resource element of a policy statement to be matched against.
+//
+// It returns the ARN the API itself reports for the resource, read from the
+// stored record, rather than one reassembled here: the organization ID is a
+// segment of every one of them, and a synthesized ARN that disagreed with what
+// DescribeOrganizationalUnit returns would make a policy written from an
+// observed ARN fail to match the resource it names.
+//
+// "*" is the answer when the request names no resource, or names one that is not
+// there. It is deliberately not "" — resourceMatches treats the empty string as
+// "matches every statement", so an unreadable record would widen a
+// resource-scoped policy instead of narrowing it.
+func orgAuthzResourceARN(state StateManager, reqCtx *RequestContext, req *AWSRequest) string {
+	id := orgAuthzResourceID(req)
+	if id == "" {
+		return "*"
+	}
+	goCtx := context.Background()
+	arn := ""
+	switch {
+	case isOrgRootID(id):
+		var root OrgRoot
+		if orgAuthzGetJSON(goCtx, state, orgRootKey(reqCtx.AccountID), &root) && root.ID == id {
+			arn = root.Arn
+		}
+	case isOrgOUID(id):
+		var ou OrgOrganizationalUnit
+		if orgAuthzGetJSON(goCtx, state, orgOUKey(id), &ou) {
+			arn = ou.Arn
+		}
+	case strings.HasPrefix(id, "p-"):
+		if id == orgFullAWSAccessID {
+			// Synthesized rather than stored, so there is no record to read.
+			return orgFullAWSAccessArn
+		}
+		var pol OrgPolicy
+		if orgAuthzGetJSON(goCtx, state, orgPolicyKey(id), &pol) {
+			arn = pol.PolicySummary.Arn
+		}
+	default:
+		var a OrgAccount
+		if orgAuthzGetJSON(goCtx, state, orgAccountKey(id), &a) {
+			arn = a.Arn
+		}
+	}
+	if arn == "" {
+		return "*"
+	}
+	return arn
+}
+
+// orgAuthzResourceTags returns the tags on the Organizations resource a request
+// names, as an aws:ResourceTag-shaped map.
+func orgAuthzResourceTags(state StateManager, req *AWSRequest) map[string]string {
+	id := orgAuthzResourceID(req)
+	if id == "" {
+		return nil
+	}
+	var tags []OrgTag
+	if !orgAuthzGetJSON(context.Background(), state, orgTagsKey(id), &tags) {
+		return nil
+	}
+	return orgTagsToMap(tags)
+}
+
+// orgAuthzRequestTags returns the tags a request asks to set, as an
+// aws:RequestTag-shaped map. Organizations sends them in the JSON body as
+// "Tags": [{"Key":…,"Value":…}], the same shape IAM uses.
+func orgAuthzRequestTags(req *AWSRequest) map[string]string {
+	var body struct {
+		Tags []OrgTag `json:"Tags"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return nil
+	}
+	return orgTagsToMap(body.Tags)
+}
+
+// orgTagsToMap converts a tag list to the key-value map the condition context
+// wants.
+func orgTagsToMap(tags []OrgTag) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(tags))
+	for _, t := range tags {
+		m[t.Key] = t.Value
+	}
+	return m
+}
+
+// orgAuthzGetJSON decodes the value at key, reporting false when it is absent or
+// cannot be read.
+//
+// Failing quietly is the established behavior of every other arm of
+// addResourceTags, and it is the safe direction here: an unread tag leaves the
+// condition key absent, so an Allow that requires it does not match and the
+// caller is denied. The opposite — assuming a tag matched — would let a storage
+// fault grant access.
+func orgAuthzGetJSON(ctx context.Context, state StateManager, key string, out interface{}) bool {
+	raw, err := state.Get(ctx, organizationsNamespace, key)
+	if err != nil || raw == nil {
+		return false
+	}
+	return json.Unmarshal(raw, out) == nil
 }

--- a/emulator/organizations_tags_test.go
+++ b/emulator/organizations_tags_test.go
@@ -1,0 +1,1289 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// --- fixtures -------------------------------------------------------------
+
+// orgTagsFixture is a running Organizations surface plus the state and plugin
+// behind it, so a test can both call the API and reach past it to create the
+// entities the other lanes' operations would create.
+type orgTagsFixture struct {
+	ts     *httptest.Server
+	state  emulator.StateManager
+	plugin *emulator.OrganizationsPlugin
+	root   string
+}
+
+// newOrgTagsFixture returns a server whose state is also directly reachable.
+// Tagging spans all four entity kinds, and only the account and the root exist
+// without the OU and policy lifecycle operations that other lanes own, so OUs and
+// policies are written through the storage layer instead.
+func newOrgTagsFixture(t *testing.T) *orgTagsFixture {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false})
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.OrganizationsPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}); err != nil {
+		t.Fatalf("initialize organizations plugin: %v", err)
+	}
+	registry.Register(p)
+
+	cfg := emulator.DefaultConfig()
+	ts := httptest.NewServer(emulator.NewServer(*cfg, registry, store, state, tc, logger))
+	t.Cleanup(ts.Close)
+
+	root, err := p.LoadRootForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	return &orgTagsFixture{ts: ts, state: state, plugin: p, root: root.ID}
+}
+
+// putOU writes an OU through the storage layer, placed in the root, with the ARN
+// the API would report.
+func (f *orgTagsFixture) putOU(t *testing.T, suffix string) string {
+	t.Helper()
+	id := "ou-" + f.root[2:] + "-" + suffix
+	ou := emulator.OrgOrganizationalUnit{
+		ID:   id,
+		Arn:  "arn:aws:organizations::" + orgTestAccount + ":ou/o-tagtest/" + id,
+		Name: "ou-" + suffix,
+	}
+	if err := f.plugin.SaveOUForTest(t.Context(), orgTestAccount, ou); err != nil {
+		t.Fatalf("save OU: %v", err)
+	}
+	if err := f.plugin.PlaceChildForTest(t.Context(), f.root, id); err != nil {
+		t.Fatalf("place OU: %v", err)
+	}
+	return id
+}
+
+// putPolicy writes an SCP through the storage layer.
+func (f *orgTagsFixture) putPolicy(t *testing.T, id string) string {
+	t.Helper()
+	pol := emulator.OrgPolicy{
+		PolicySummary: emulator.OrgPolicySummary{
+			ID:   id,
+			Arn:  "arn:aws:organizations::" + orgTestAccount + ":policy/o-tagtest/service_control_policy/" + id,
+			Name: "policy-" + id,
+			Type: emulator.OrgPolicyTypeSCPForTest,
+		},
+		Content: `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"*","Resource":"*"}]}`,
+	}
+	if err := f.plugin.SavePolicyForTest(t.Context(), orgTestAccount, pol); err != nil {
+		t.Fatalf("save policy: %v", err)
+	}
+	return id
+}
+
+// tagResource posts TagResource and returns the response status.
+func (f *orgTagsFixture) tagResource(t *testing.T, resourceID string, tags []map[string]any) (int, string) {
+	t.Helper()
+	return orgTagCall(t, f.ts, "TagResource", map[string]any{"ResourceId": resourceID, "Tags": tags})
+}
+
+// untagResource posts UntagResource and returns the response status.
+func (f *orgTagsFixture) untagResource(t *testing.T, resourceID string, keys []string) (int, string) {
+	t.Helper()
+	return orgTagCall(t, f.ts, "UntagResource", map[string]any{"ResourceId": resourceID, "TagKeys": keys})
+}
+
+// listTags posts ListTagsForResource and returns the decoded tags and token.
+func (f *orgTagsFixture) listTags(t *testing.T, resourceID, nextToken string) (map[string]string, string) {
+	t.Helper()
+	body := map[string]any{"ResourceId": resourceID}
+	if nextToken != "" {
+		body["NextToken"] = nextToken
+	}
+	resp := orgsRequest(t, f.ts, "ListTagsForResource", body)
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ListTagsForResource %s: expected 200, got %d", resourceID, resp.StatusCode)
+	}
+	var out struct {
+		Tags []struct {
+			Key   string `json:"Key"`
+			Value string `json:"Value"`
+		} `json:"Tags"`
+		NextToken string `json:"NextToken"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode ListTagsForResource: %v", err)
+	}
+	tags := make(map[string]string, len(out.Tags))
+	for _, tag := range out.Tags {
+		tags[tag.Key] = tag.Value
+	}
+	return tags, out.NextToken
+}
+
+// listAllTags walks every page of ListTagsForResource, which is what a test
+// asserting on a whole tag set has to do: the operation has no MaxResults, and
+// its page ceiling is below the per-resource tag limit, so one page is not the
+// whole set.
+func (f *orgTagsFixture) listAllTags(t *testing.T, resourceID string) map[string]string {
+	t.Helper()
+	all := make(map[string]string)
+	token := ""
+	for pages := 0; ; pages++ {
+		if pages > emulator.OrgMaxTagsPerResourceForTest {
+			t.Fatal("pagination did not terminate")
+		}
+		page, next := f.listTags(t, resourceID, token)
+		for k, v := range page {
+			all[k] = v
+		}
+		if next == "" {
+			return all
+		}
+		token = next
+	}
+}
+
+// orgTagCall posts one operation and returns the status and the error code the
+// body carries, so a refusal can be asserted by code rather than by status alone
+// — every Organizations exception shares HTTP 400.
+func orgTagCall(t *testing.T, ts *httptest.Server, op string, body map[string]any) (int, string) {
+	t.Helper()
+	resp := orgsRequest(t, ts, op, body)
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		Type    string `json:"__type"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return resp.StatusCode, ""
+	}
+	if out.Type != "" {
+		// The reason travels in the message, since the JSON-RPC error document has
+		// no Reason member; return both joined so a test can assert on either.
+		return resp.StatusCode, out.Type + "/" + out.Message
+	}
+	return resp.StatusCode, ""
+}
+
+// orgTag is shorthand for one tag in a TagResource body.
+func orgTag(key, value string) map[string]any {
+	return map[string]any{"Key": key, "Value": value}
+}
+
+// --- happy paths ----------------------------------------------------------
+
+// TestOrganizations_TagResource_AllFourKinds asserts every resource AWS lists as
+// taggable can actually be tagged. The four kinds resolve through four different
+// stores, so one of them silently answering TargetNotFoundException is invisible
+// until a consumer tags that kind — and a tag that will not attach cannot gate
+// anything.
+func TestOrganizations_TagResource_AllFourKinds(t *testing.T) {
+	f := newOrgTagsFixture(t)
+	ouID := f.putOU(t, "11112222")
+	policyID := f.putPolicy(t, "p-tagtest1")
+
+	cases := []struct {
+		kind string
+		id   string
+	}{
+		{"account", orgTestAccount},
+		{"root", f.root},
+		{"organizational unit", ouID},
+		{"policy", policyID},
+	}
+	for _, c := range cases {
+		t.Run(c.kind, func(t *testing.T) {
+			status, code := f.tagResource(t, c.id, []map[string]any{orgTag("Owner", "platform")})
+			if status != http.StatusOK {
+				t.Fatalf("TagResource on a %s: expected 200, got %d (%s)", c.kind, status, code)
+			}
+			tags, next := f.listTags(t, c.id, "")
+			if tags["Owner"] != "platform" {
+				t.Errorf("expected Owner=platform on the %s, got %v", c.kind, tags)
+			}
+			if next != "" {
+				t.Errorf("expected no NextToken for a single tag, got %q", next)
+			}
+		})
+	}
+}
+
+// TestOrganizations_TagResource_OverwritesRatherThanDuplicates pins that
+// re-tagging an existing key replaces its value. Two entries for one key would
+// make an aws:ResourceTag condition depend on which one is read first, so a
+// tag-gated policy would allow or deny the same request depending on nothing the
+// caller can see.
+func TestOrganizations_TagResource_OverwritesRatherThanDuplicates(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	if status, code := f.tagResource(t, orgTestAccount, []map[string]any{
+		orgTag("Owner", "platform"), orgTag("Env", "dev"),
+	}); status != http.StatusOK {
+		t.Fatalf("first tag: expected 200, got %d (%s)", status, code)
+	}
+	if status, code := f.tagResource(t, orgTestAccount, []map[string]any{
+		orgTag("Owner", "security"),
+	}); status != http.StatusOK {
+		t.Fatalf("retag: expected 200, got %d (%s)", status, code)
+	}
+
+	tags, _ := f.listTags(t, orgTestAccount, "")
+	if len(tags) != 2 {
+		t.Errorf("expected the key replaced rather than added, got %v", tags)
+	}
+	if tags["Owner"] != "security" {
+		t.Errorf("expected Owner=security after the retag, got %q", tags["Owner"])
+	}
+	if tags["Env"] != "dev" {
+		t.Errorf("expected the untouched tag preserved, got %v", tags)
+	}
+}
+
+// TestOrganizations_TagResource_EmptyValueIsLegal covers the one length boundary
+// the model states explicitly: TagValue's minimum is 0, so "" is a value, and
+// only null is refused. A caller using an empty value to record a key's presence
+// would otherwise be refused for a request AWS accepts.
+func TestOrganizations_TagResource_EmptyValueIsLegal(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	if status, code := f.tagResource(t, orgTestAccount, []map[string]any{orgTag("Reviewed", "")}); status != http.StatusOK {
+		t.Fatalf("expected an empty value accepted, got %d (%s)", status, code)
+	}
+	tags, _ := f.listTags(t, orgTestAccount, "")
+	value, ok := tags["Reviewed"]
+	if !ok || value != "" {
+		t.Errorf("expected the empty-valued tag stored, got %v", tags)
+	}
+}
+
+// TestOrganizations_UntagResource_AbsentKeyIsNotAnError pins UntagResource as
+// idempotent: it "removes any tags with the specified keys", so a key that is not
+// there is nothing to remove. Refusing would break a cleanup path that runs
+// twice, which is exactly what a re-run of a governance script does.
+func TestOrganizations_UntagResource_AbsentKeyIsNotAnError(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	if status, code := f.untagResource(t, orgTestAccount, []string{"NeverSet"}); status != http.StatusOK {
+		t.Fatalf("untag of an absent key on an untagged resource: expected 200, got %d (%s)", status, code)
+	}
+
+	if status, _ := f.tagResource(t, orgTestAccount, []map[string]any{
+		orgTag("Owner", "platform"), orgTag("Env", "dev"),
+	}); status != http.StatusOK {
+		t.Fatalf("tag: expected 200, got %d", status)
+	}
+	if status, code := f.untagResource(t, orgTestAccount, []string{"Owner", "NeverSet"}); status != http.StatusOK {
+		t.Fatalf("mixed untag: expected 200, got %d (%s)", status, code)
+	}
+	tags, _ := f.listTags(t, orgTestAccount, "")
+	if _, ok := tags["Owner"]; ok {
+		t.Errorf("expected Owner removed, got %v", tags)
+	}
+	if tags["Env"] != "dev" {
+		t.Errorf("expected Env untouched by the untag, got %v", tags)
+	}
+
+	// Repeating the same untag is still a success.
+	if status, code := f.untagResource(t, orgTestAccount, []string{"Owner"}); status != http.StatusOK {
+		t.Fatalf("repeated untag: expected 200, got %d (%s)", status, code)
+	}
+}
+
+// TestOrganizations_ListTagsForResource_Paginates asserts a heavily tagged
+// resource pages. The model gives ListTagsForResource a NextToken and no
+// MaxResults, and the per-listing ceiling is below the 50-tag limit, so a
+// resource can carry more tags than one page holds. A consumer that reads only
+// the first page would silently miss the tag its condition is about.
+func TestOrganizations_ListTagsForResource_Paginates(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	const total = emulator.OrgMaxTagsPerResourceForTest
+	tags := make([]map[string]any, 0, total)
+	for i := range total {
+		tags = append(tags, orgTag(fmt.Sprintf("Key%02d", i), fmt.Sprintf("v%02d", i)))
+	}
+	if status, code := f.tagResource(t, orgTestAccount, tags); status != http.StatusOK {
+		t.Fatalf("tag %d keys: expected 200, got %d (%s)", total, status, code)
+	}
+
+	seen := make(map[string]string, total)
+	token := ""
+	for pages := 0; ; pages++ {
+		if pages > total {
+			t.Fatal("pagination did not terminate")
+		}
+		page, next := f.listTags(t, orgTestAccount, token)
+		if len(page) > emulator.OrgMaxResultsForTest {
+			t.Fatalf("page %d holds %d tags, above the %d ceiling", pages, len(page), emulator.OrgMaxResultsForTest)
+		}
+		for k, v := range page {
+			if _, dup := seen[k]; dup {
+				t.Errorf("tag %q appeared on two pages", k)
+			}
+			seen[k] = v
+		}
+		if next == "" {
+			if pages == 0 {
+				t.Error("expected more than one page for a resource at the tag limit")
+			}
+			break
+		}
+		token = next
+	}
+	if len(seen) != total {
+		t.Errorf("expected %d tags across every page, got %d", total, len(seen))
+	}
+	for i := range total {
+		key := fmt.Sprintf("Key%02d", i)
+		if seen[key] != fmt.Sprintf("v%02d", i) {
+			t.Errorf("tag %q: expected v%02d, got %q", key, i, seen[key])
+		}
+	}
+}
+
+// TestOrganizations_ListTagsForResource_StaleTokenIsRefused asserts a token
+// naming no known tag key is refused rather than restarting the listing. A silent
+// restart never terminates, and the caller sees the first page forever with no
+// error to explain it.
+func TestOrganizations_ListTagsForResource_StaleTokenIsRefused(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	status, code := orgTagCall(t, f.ts, "ListTagsForResource", map[string]any{
+		"ResourceId": orgTestAccount,
+		"NextToken":  "bm90LWEtcmVhbC1rZXk=",
+	})
+	if status != http.StatusBadRequest || !strings.Contains(code, "INVALID_NEXT_TOKEN") {
+		t.Errorf("expected InvalidInputException/INVALID_NEXT_TOKEN, got %d (%s)", status, code)
+	}
+}
+
+// TestOrganizations_TagsAreNotSharedBetweenResources pins that two resources have
+// independent tag sets. A shared one would let a tag-gated policy written about a
+// production OU be satisfied by a tag on a sandbox account.
+func TestOrganizations_TagsAreNotSharedBetweenResources(t *testing.T) {
+	f := newOrgTagsFixture(t)
+	ouA := f.putOU(t, "aaaa1111")
+	ouB := f.putOU(t, "bbbb2222")
+
+	if status, _ := f.tagResource(t, ouA, []map[string]any{orgTag("Owner", "platform")}); status != http.StatusOK {
+		t.Fatalf("tag ouA: got %d", status)
+	}
+	if status, _ := f.tagResource(t, ouB, []map[string]any{orgTag("Owner", "security")}); status != http.StatusOK {
+		t.Fatalf("tag ouB: got %d", status)
+	}
+	if status, _ := f.tagResource(t, orgTestAccount, []map[string]any{orgTag("Tier", "management")}); status != http.StatusOK {
+		t.Fatalf("tag account: got %d", status)
+	}
+
+	if got, _ := f.listTags(t, ouA, ""); len(got) != 1 || got["Owner"] != "platform" {
+		t.Errorf("ouA: expected only Owner=platform, got %v", got)
+	}
+	if got, _ := f.listTags(t, ouB, ""); len(got) != 1 || got["Owner"] != "security" {
+		t.Errorf("ouB: expected only Owner=security, got %v", got)
+	}
+	if got, _ := f.listTags(t, orgTestAccount, ""); len(got) != 1 || got["Tier"] != "management" {
+		t.Errorf("account: expected only Tier=management, got %v", got)
+	}
+
+	// Untagging one resource leaves the other alone.
+	if status, _ := f.untagResource(t, ouA, []string{"Owner"}); status != http.StatusOK {
+		t.Fatalf("untag ouA: got %d", status)
+	}
+	if got, _ := f.listTags(t, ouB, ""); got["Owner"] != "security" {
+		t.Errorf("expected ouB's tag untouched by ouA's untag, got %v", got)
+	}
+}
+
+// TestOrganizations_TagsSurviveReplacement asserts moving an account between
+// parents does not disturb its tags. Tags are the input to an ABAC decision, so
+// an account silently losing them on a MoveAccount would turn a tag-gated Allow
+// into a denial the caller cannot trace to the move.
+func TestOrganizations_TagsSurviveReplacement(t *testing.T) {
+	f := newOrgTagsFixture(t)
+	ouID := f.putOU(t, "cccc3333")
+
+	if status, _ := f.tagResource(t, orgTestAccount, []map[string]any{orgTag("Owner", "platform")}); status != http.StatusOK {
+		t.Fatalf("tag account: got %d", status)
+	}
+	if err := f.plugin.PlaceChildForTest(t.Context(), ouID, orgTestAccount); err != nil {
+		t.Fatalf("move account into the OU: %v", err)
+	}
+
+	parent, err := f.plugin.LoadParentForTest(t.Context(), orgTestAccount)
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	if parent != ouID {
+		t.Fatalf("expected the account under %s, got %s", ouID, parent)
+	}
+	if got, _ := f.listTags(t, orgTestAccount, ""); got["Owner"] != "platform" {
+		t.Errorf("expected the tag to survive the re-placement, got %v", got)
+	}
+}
+
+// --- refusals -------------------------------------------------------------
+
+// TestOrganizations_Tagging_UnknownResourceIsTargetNotFound asserts a well-formed
+// ID naming nothing is TargetNotFoundException on all three operations. A silent
+// success would store a tag no later call can read, and a caller who mistyped a
+// resource ID would find out only when the policy it wrote gated nothing.
+func TestOrganizations_Tagging_UnknownResourceIsTargetNotFound(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	// Each of these is well-formed for its kind and absent from the organization.
+	absent := []string{
+		"999999999999",
+		"r-9999",
+		"ou-" + f.root[2:] + "-99999999",
+		"p-99999999",
+	}
+	for _, id := range absent {
+		t.Run(id, func(t *testing.T) {
+			status, code := f.tagResource(t, id, []map[string]any{orgTag("Owner", "platform")})
+			if status != http.StatusBadRequest || !strings.Contains(code, "TargetNotFoundException") {
+				t.Errorf("TagResource: expected TargetNotFoundException, got %d (%s)", status, code)
+			}
+			status, code = f.untagResource(t, id, []string{"Owner"})
+			if status != http.StatusBadRequest || !strings.Contains(code, "TargetNotFoundException") {
+				t.Errorf("UntagResource: expected TargetNotFoundException, got %d (%s)", status, code)
+			}
+			status, code = orgTagCall(t, f.ts, "ListTagsForResource", map[string]any{"ResourceId": id})
+			if status != http.StatusBadRequest || !strings.Contains(code, "TargetNotFoundException") {
+				t.Errorf("ListTagsForResource: expected TargetNotFoundException, got %d (%s)", status, code)
+			}
+		})
+	}
+}
+
+// TestOrganizations_Tagging_UnmodelledResourceKindsAreAbsentNotMalformed covers
+// the two ID forms the model's TaggableResourceId pattern admits for resources
+// substrate does not model — rp- (resource policy) and rt- (responsibility
+// transfer). They are well-formed, so INVALID_PATTERN would be the wrong answer;
+// they name nothing, so TargetNotFoundException is the same answer AWS gives for
+// an organization that has no such resource.
+func TestOrganizations_Tagging_UnmodelledResourceKindsAreAbsentNotMalformed(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	for _, id := range []string{"rp-abcd1234", "rt-abcd1234"} {
+		status, code := f.tagResource(t, id, []map[string]any{orgTag("Owner", "platform")})
+		if status != http.StatusBadRequest || !strings.Contains(code, "TargetNotFoundException") {
+			t.Errorf("%s: expected TargetNotFoundException, got %d (%s)", id, status, code)
+		}
+		// A malformed one of the same kind is still a pattern error.
+		status, code = f.tagResource(t, id[:3]+"x", []map[string]any{orgTag("Owner", "platform")})
+		if status != http.StatusBadRequest || !strings.Contains(code, "INVALID_PATTERN") {
+			t.Errorf("%sx: expected INVALID_PATTERN, got %d (%s)", id[:3], status, code)
+		}
+	}
+}
+
+// TestOrganizations_Tagging_MalformedResourceIDIsInvalidInput separates a typo
+// from a deletion. The model's TaggableResourceId pattern admits six ID forms;
+// something that matches none of them is INVALID_PATTERN, which tells the caller
+// to fix the string, while TargetNotFoundException would send it looking for a
+// resource that never existed.
+func TestOrganizations_Tagging_MalformedResourceIDIsInvalidInput(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	cases := map[string]string{
+		"not an ID at all":     "my-account",
+		"account too short":    "12345",
+		"root suffix too long": "r-" + strings.Repeat("a", 33),
+		"OU with no child":     "ou-abcd",
+		"OU child too short":   "ou-abcd-1234",
+		"policy too short":     "p-1234",
+		"uppercase root":       "r-ABCD",
+	}
+	for name, id := range cases {
+		t.Run(name, func(t *testing.T) {
+			status, code := f.tagResource(t, id, []map[string]any{orgTag("Owner", "platform")})
+			if status != http.StatusBadRequest || !strings.Contains(code, "INVALID_PATTERN") {
+				t.Errorf("expected InvalidInputException/INVALID_PATTERN, got %d (%s)", status, code)
+			}
+		})
+	}
+}
+
+// TestOrganizations_Tagging_MissingRequiredMemberIsRefused covers the required
+// members. A zero-valued ResourceId would otherwise be treated as a request about
+// the empty resource, which is a wrong answer rather than an error.
+func TestOrganizations_Tagging_MissingRequiredMemberIsRefused(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	cases := []struct {
+		name string
+		op   string
+		body map[string]any
+	}{
+		{"TagResource with no ResourceId", "TagResource", map[string]any{"Tags": []map[string]any{orgTag("Owner", "x")}}},
+		{"TagResource with no Tags", "TagResource", map[string]any{"ResourceId": orgTestAccount}},
+		{"UntagResource with no ResourceId", "UntagResource", map[string]any{"TagKeys": []string{"Owner"}}},
+		{"UntagResource with no TagKeys", "UntagResource", map[string]any{"ResourceId": orgTestAccount}},
+		{"ListTagsForResource with no ResourceId", "ListTagsForResource", map[string]any{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			status, code := orgTagCall(t, f.ts, c.op, c.body)
+			if status != http.StatusBadRequest || !strings.Contains(code, "INPUT_REQUIRED") {
+				t.Errorf("expected InvalidInputException/INPUT_REQUIRED, got %d (%s)", status, code)
+			}
+		})
+	}
+}
+
+// TestOrganizations_TagResource_DuplicateKeyIsRefused asserts one request naming
+// a key twice is refused rather than resolved. Picking a winner would make the
+// stored value depend on list order, so the same request could leave two
+// different tag sets behind.
+func TestOrganizations_TagResource_DuplicateKeyIsRefused(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	status, code := f.tagResource(t, orgTestAccount, []map[string]any{
+		orgTag("Owner", "platform"), orgTag("Owner", "security"),
+	})
+	if status != http.StatusBadRequest || !strings.Contains(code, "DUPLICATE_TAG_KEY") {
+		t.Errorf("expected InvalidInputException/DUPLICATE_TAG_KEY, got %d (%s)", status, code)
+	}
+	// The refusal is total: nothing from the batch landed.
+	if got, _ := f.listTags(t, orgTestAccount, ""); len(got) != 0 {
+		t.Errorf("expected the whole request refused, got %v", got)
+	}
+}
+
+// TestOrganizations_TagResource_NullValueIsRefused pins the distinction the model
+// draws: "The value can be an empty string, but you can't set it to null." A null
+// read as "" would store a tag for a request AWS refuses, so the caller's error
+// path would never be exercised.
+func TestOrganizations_TagResource_NullValueIsRefused(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	cases := []struct {
+		name string
+		tag  map[string]any
+	}{
+		{"null value", map[string]any{"Key": "Owner", "Value": nil}},
+		{"absent value", map[string]any{"Key": "Owner"}},
+		{"null key", map[string]any{"Key": nil, "Value": "platform"}},
+		{"absent key", map[string]any{"Value": "platform"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			status, code := f.tagResource(t, orgTestAccount, []map[string]any{c.tag})
+			if status != http.StatusBadRequest || !strings.Contains(code, "INPUT_REQUIRED") {
+				t.Errorf("expected InvalidInputException/INPUT_REQUIRED, got %d (%s)", status, code)
+			}
+		})
+	}
+}
+
+// TestOrganizations_TagResource_KeyAndValueConstraints covers the TagKey and
+// TagValue shapes. Each bound is a boundary an off-by-one hides: a key one
+// character over the limit is accepted by substrate and refused by AWS, so the
+// consumer's validation never gets tested.
+func TestOrganizations_TagResource_KeyAndValueConstraints(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	cases := []struct {
+		name   string
+		key    string
+		value  string
+		reason string
+	}{
+		{"empty key", "", "x", "MIN_LENGTH_EXCEEDED"},
+		{"key at the limit", strings.Repeat("k", 128), "x", ""},
+		{"key over the limit", strings.Repeat("k", 129), "x", "MAX_LENGTH_EXCEEDED"},
+		{"value at the limit", "AtLimit", strings.Repeat("v", 256), ""},
+		{"value over the limit", "OverLimit", strings.Repeat("v", 257), "MAX_LENGTH_EXCEEDED"},
+		{"key with a disallowed character", "Own%er", "x", "INVALID_PATTERN"},
+		{"value with a disallowed character", "Owner", "plat*form", "INVALID_PATTERN"},
+		{"key in the allowed punctuation class", "cost:center/v1_2=a+b-c@d.e", "x", ""},
+		{"non-ASCII letters are allowed", "Propriétaire", "équipe", ""},
+		{"system tag key", "aws:cloudformation:stack-name", "x", "INVALID_SYSTEM_TAGS_PARAMETER"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			status, code := f.tagResource(t, orgTestAccount, []map[string]any{orgTag(c.key, c.value)})
+			if c.reason == "" {
+				if status != http.StatusOK {
+					t.Errorf("expected the tag accepted, got %d (%s)", status, code)
+				}
+				return
+			}
+			if status != http.StatusBadRequest || !strings.Contains(code, c.reason) {
+				t.Errorf("expected InvalidInputException/%s, got %d (%s)", c.reason, status, code)
+			}
+		})
+	}
+}
+
+// TestOrganizations_UntagResource_ValidatesKeys asserts the key shape is enforced
+// on the removal path too. A key that could never have been stored names nothing
+// to remove, and answering 200 would tell a caller its cleanup succeeded.
+func TestOrganizations_UntagResource_ValidatesKeys(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	for _, key := range []string{"", strings.Repeat("k", 129), "bad%key"} {
+		status, code := f.untagResource(t, orgTestAccount, []string{"Owner", key})
+		if status != http.StatusBadRequest || !strings.Contains(code, "InvalidInputException") {
+			t.Errorf("key %q: expected InvalidInputException, got %d (%s)", key, status, code)
+		}
+	}
+}
+
+// TestOrganizations_TagResource_MaxTagLimit asserts the 51st tag on one resource
+// is refused with the documented reason. The limit is on the resulting set, not
+// on the request, so a resource already at the limit can still have an existing
+// key rewritten — refusing that would break a governance script that only ever
+// rewrites the tags it owns.
+func TestOrganizations_TagResource_MaxTagLimit(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	const limit = emulator.OrgMaxTagsPerResourceForTest
+	tags := make([]map[string]any, 0, limit)
+	for i := range limit {
+		tags = append(tags, orgTag(fmt.Sprintf("Key%02d", i), "v"))
+	}
+	if status, code := f.tagResource(t, orgTestAccount, tags); status != http.StatusOK {
+		t.Fatalf("tagging exactly %d keys: expected 200, got %d (%s)", limit, status, code)
+	}
+
+	// One more distinct key crosses the limit.
+	status, code := f.tagResource(t, orgTestAccount, []map[string]any{orgTag("OneTooMany", "v")})
+	if status != http.StatusBadRequest || !strings.Contains(code, "MAX_TAG_LIMIT_EXCEEDED") {
+		t.Errorf("expected ConstraintViolationException/MAX_TAG_LIMIT_EXCEEDED, got %d (%s)", status, code)
+	}
+	if got := f.listAllTags(t, orgTestAccount); len(got) != limit {
+		t.Errorf("expected the refused tag not to land, got %d tags", len(got))
+	}
+
+	// Rewriting a key that is already there does not grow the set, so it is allowed.
+	if status, code := f.tagResource(t, orgTestAccount, []map[string]any{orgTag("Key00", "rewritten")}); status != http.StatusOK {
+		t.Errorf("expected a rewrite at the limit to be allowed, got %d (%s)", status, code)
+	}
+	got := f.listAllTags(t, orgTestAccount)
+	if got["Key00"] != "rewritten" {
+		t.Errorf("expected the rewrite applied, got %q", got["Key00"])
+	}
+
+	// A single request whose own tags would cross the limit is refused whole.
+	fresh := newOrgTagsFixture(t)
+	tooMany := make([]map[string]any, 0, limit+1)
+	for i := range limit + 1 {
+		tooMany = append(tooMany, orgTag(fmt.Sprintf("Key%02d", i), "v"))
+	}
+	status, code = fresh.tagResource(t, orgTestAccount, tooMany)
+	if status != http.StatusBadRequest || !strings.Contains(code, "MAX_TAG_LIMIT_EXCEEDED") {
+		t.Errorf("expected one oversized request refused, got %d (%s)", status, code)
+	}
+	if got, _ := fresh.listTags(t, orgTestAccount, ""); len(got) != 0 {
+		t.Errorf("expected none of an oversized request to land, got %d tags", len(got))
+	}
+}
+
+// TestOrganizations_Tagging_FullAWSAccessIsImmutable asserts the AWS-managed SCP
+// cannot be tagged. Its ARN is owned by the "aws" account, not by the
+// organization, so a tag stored against it would be visible in one organization
+// and nowhere else — a state no sequence of AWS calls can produce, which means
+// nothing downstream is prepared for it. Reading its tags is still fine and
+// answers empty.
+func TestOrganizations_Tagging_FullAWSAccessIsImmutable(t *testing.T) {
+	f := newOrgTagsFixture(t)
+	managed := emulator.OrgFullAWSAccessIDForTest
+
+	status, code := f.tagResource(t, managed, []map[string]any{orgTag("Owner", "platform")})
+	if status != http.StatusBadRequest || !strings.Contains(code, "IMMUTABLE_POLICY") {
+		t.Errorf("TagResource: expected InvalidInputException/IMMUTABLE_POLICY, got %d (%s)", status, code)
+	}
+	status, code = f.untagResource(t, managed, []string{"Owner"})
+	if status != http.StatusBadRequest || !strings.Contains(code, "IMMUTABLE_POLICY") {
+		t.Errorf("UntagResource: expected InvalidInputException/IMMUTABLE_POLICY, got %d (%s)", status, code)
+	}
+	if got, _ := f.listTags(t, managed, ""); len(got) != 0 {
+		t.Errorf("expected the managed policy to list no tags, got %v", got)
+	}
+}
+
+// TestOrganizations_Tagging_MalformedBodyIsRefused covers the decode guard on
+// each operation, which is the branch a hand-written curl reaches first.
+func TestOrganizations_Tagging_MalformedBodyIsRefused(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	for _, op := range []string{"TagResource", "UntagResource", "ListTagsForResource"} {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, f.ts.URL+"/", newOrgBadBody())
+		if err != nil {
+			t.Fatalf("%s: build request: %v", op, err)
+		}
+		req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+		req.Header.Set("X-Amz-Target", "Organizations_20161128."+op)
+		req.Host = "organizations.us-east-1.amazonaws.com"
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", op, err)
+		}
+		gotStatus := resp.StatusCode
+		resp.Body.Close() //nolint:errcheck
+		if gotStatus != http.StatusBadRequest {
+			t.Errorf("%s: expected 400 for an unparseable body, got %d", op, gotStatus)
+		}
+	}
+}
+
+// TestOrganizations_Tagging_UnknownOperationIsRefused pins that the tag cluster
+// claims only its three operations. Claiming a fourth would shadow whichever lane
+// owns it.
+func TestOrganizations_Tagging_UnknownOperationIsRefused(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	status, code := orgTagCall(t, f.ts, "TagResourceButNotReally", map[string]any{"ResourceId": orgTestAccount})
+	if status == http.StatusOK {
+		t.Errorf("expected an unimplemented operation to be refused, got 200 (%s)", code)
+	}
+}
+
+// --- store failures -------------------------------------------------------
+
+// TestOrganizations_Tagging_StoreFailuresAreInternalFailure asserts a store fault
+// reaching a tag operation is a 500 an SDK retries rather than a 400 it treats as
+// terminal. The tag read is worse than most: answering "no tags" on a failure
+// would hand an authorization decision an empty tag set, which fails open on
+// every tag-gated policy.
+func TestOrganizations_Tagging_StoreFailuresAreInternalFailure(t *testing.T) {
+	cases := []struct {
+		name  string
+		state func(inner emulator.StateManager) emulator.StateManager
+	}{
+		{
+			name: "tag read fails",
+			state: func(inner emulator.StateManager) emulator.StateManager {
+				return &errOrgState{inner: inner, prefix: "tags:", err: errors.New("store unavailable"), onGet: true}
+			},
+		},
+		{
+			name: "tag write fails",
+			state: func(inner emulator.StateManager) emulator.StateManager {
+				return &errOrgState{inner: inner, prefix: "tags:", err: errors.New("store unavailable"), onPut: true}
+			},
+		},
+		{
+			name: "resource resolution fails",
+			state: func(inner emulator.StateManager) emulator.StateManager {
+				return &errOrgState{inner: inner, prefix: "account:", err: errors.New("store unavailable"), onGet: true}
+			},
+		},
+		{
+			name: "the organization itself is unreadable",
+			state: func(inner emulator.StateManager) emulator.StateManager {
+				return &errOrgState{inner: inner, prefix: "org:", err: errors.New("store unavailable"), onGet: true}
+			},
+		},
+		{
+			name: "tags are unreadable",
+			state: func(inner emulator.StateManager) emulator.StateManager {
+				return &corruptOrgState{StateManager: inner, prefix: "tags:"}
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			wrapped := c.state(inner)
+			ts := newOrgTagsServerOver(t, wrapped)
+
+			// Warm the organization up and store one tag before arming, so neither
+			// auto-creation nor an empty tag set is what the fault lands on: an
+			// UntagResource with nothing to remove legitimately performs no write.
+			warm := orgsRequest(t, ts, "DescribeOrganization", map[string]any{})
+			warm.Body.Close() //nolint:errcheck
+			if status, code := orgTagCall(t, ts, "TagResource", map[string]any{
+				"ResourceId": orgTestAccount, "Tags": []map[string]any{orgTag("Owner", "x")},
+			}); status != http.StatusOK {
+				t.Fatalf("seed tag before arming: got %d (%s)", status, code)
+			}
+			armOrgFaultState(wrapped)
+
+			bodies := map[string]map[string]any{
+				"TagResource":         {"ResourceId": orgTestAccount, "Tags": []map[string]any{orgTag("Team", "y")}},
+				"UntagResource":       {"ResourceId": orgTestAccount, "TagKeys": []string{"Owner"}},
+				"ListTagsForResource": {"ResourceId": orgTestAccount},
+			}
+			for op, body := range bodies {
+				if op == "ListTagsForResource" && c.name == "tag write fails" {
+					continue // A listing performs no write, so no write can fail it.
+				}
+				status, _ := orgTagCall(t, ts, op, body)
+				if status != http.StatusInternalServerError {
+					t.Errorf("%s: expected 500 for a store fault, got %d", op, status)
+				}
+			}
+		})
+	}
+}
+
+// newOrgTagsServerOver starts an Organizations server over an arbitrary state
+// manager, so a fault-injecting wrapper can sit under the HTTP surface.
+func newOrgTagsServerOver(t *testing.T, state emulator.StateManager) *httptest.Server {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false})
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.OrganizationsPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}); err != nil {
+		t.Fatalf("initialize organizations plugin: %v", err)
+	}
+	registry.Register(p)
+
+	cfg := emulator.DefaultConfig()
+	ts := httptest.NewServer(emulator.NewServer(*cfg, registry, store, state, tc, logger))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// armOrgFaultState turns on whichever fault wrapper state is.
+func armOrgFaultState(state emulator.StateManager) {
+	switch s := state.(type) {
+	case *errOrgState:
+		s.armed = true
+	case *corruptOrgState:
+		s.armed = true
+	}
+}
+
+// --- the authorization decision -------------------------------------------
+
+// orgAuthzFixture is an Organizations state store plus an AuthController over the
+// same store, which is what makes the tag-gated boundary testable: the tag has to
+// travel from the Organizations namespace into the condition context.
+type orgAuthzFixture struct {
+	state  emulator.StateManager
+	auth   *emulator.AuthController
+	plugin *emulator.OrganizationsPlugin
+	root   string
+}
+
+// newOrgAuthzFixture builds a user carrying one policy, an organization, and an
+// AuthController reading both.
+func newOrgAuthzFixture(t *testing.T, user string, doc emulator.PolicyDocument) *orgAuthzFixture {
+	t.Helper()
+	policyARN := "arn:aws:iam::123456789012:policy/OrgTagGate-" + user
+	state := newAuthTestState(t, user, policyARN, doc)
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	p := emulator.NewOrganizationsPluginForTest(state, tc)
+	root, err := p.LoadRootForTest(t.Context(), "123456789012")
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	return &orgAuthzFixture{
+		state:  state,
+		auth:   emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false)),
+		plugin: p,
+		root:   root.ID,
+	}
+}
+
+// check runs one Organizations request through the authorization decision.
+func (f *orgAuthzFixture) check(t *testing.T, user, operation string, body map[string]any) error {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	reqCtx := newAuthTestReqCtx("arn:aws:iam::123456789012:user/" + user)
+	return f.auth.CheckAccess(reqCtx, &emulator.AWSRequest{
+		Service:   "organizations",
+		Operation: operation,
+		Path:      "/",
+		Body:      raw,
+	})
+}
+
+// orgAuthzDenied reports whether err is the denial an Organizations caller sees.
+// Organizations speaks JSON-RPC, so the code carries the "Exception" suffix.
+func orgAuthzDenied(t *testing.T, err error) bool {
+	t.Helper()
+	if err == nil {
+		return false
+	}
+	var awsErr *emulator.AWSError
+	if !errors.As(err, &awsErr) {
+		t.Fatalf("expected an *AWSError, got %T: %v", err, err)
+	}
+	if awsErr.Code != "AccessDeniedException" {
+		t.Errorf("expected AccessDeniedException, got %q", awsErr.Code)
+	}
+	if awsErr.HTTPStatus != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", awsErr.HTTPStatus)
+	}
+	return true
+}
+
+// TestOrganizations_Authz_RequestTagGatesTagResource is the decisive test for the
+// aws:RequestTag half of #578's point 9: a policy that allows tagging only when
+// the request carries Owner=platform must allow that request and deny one
+// carrying a different owner. Without the organizations arm of addRequestTags the
+// condition key is never populated, so the Allow never matches and the *first*
+// case fails — a boundary that denies everything looks like it works until
+// someone legitimate is blocked by it.
+func TestOrganizations_Authz_RequestTagGatesTagResource(t *testing.T) {
+	doc := newABACPolicy("Allow", "organizations:TagResource", "*", "aws:RequestTag/Owner", "platform")
+	f := newOrgAuthzFixture(t, "orgtagger", doc)
+
+	body := func(owner string) map[string]any {
+		return map[string]any{
+			"ResourceId": f.root,
+			"Tags":       []map[string]any{{"Key": "Owner", "Value": owner}},
+		}
+	}
+
+	if err := f.check(t, "orgtagger", "TagResource", body("platform")); err != nil {
+		t.Errorf("expected the matching request tag to be allowed: %v", err)
+	}
+	if err := f.check(t, "orgtagger", "TagResource", body("security")); !orgAuthzDenied(t, err) {
+		t.Error("expected a request carrying the wrong Owner tag to be denied")
+	}
+	// No tag at all leaves the condition key absent, which also fails to match.
+	if err := f.check(t, "orgtagger", "TagResource", map[string]any{"ResourceId": f.root}); !orgAuthzDenied(t, err) {
+		t.Error("expected a request carrying no Owner tag to be denied")
+	}
+}
+
+// TestOrganizations_Authz_ResourceTagGatesTheResourceNamed is the other half: a
+// policy allowing an operation only when the resource already carries
+// Owner=platform. This is the test that fails without the organizations arm of
+// addResourceTags, and the one that proves the tags a TagResource call stored are
+// the tags the next decision reads.
+func TestOrganizations_Authz_ResourceTagGatesTheResourceNamed(t *testing.T) {
+	doc := newABACPolicy("Allow", "organizations:UntagResource", "*", "aws:ResourceTag/Owner", "platform")
+	f := newOrgAuthzFixture(t, "orguntagger", doc)
+	ctx := t.Context()
+
+	mine := "ou-" + f.root[2:] + "-11112222"
+	theirs := "ou-" + f.root[2:] + "-33334444"
+	if err := f.plugin.SaveTagsForTest(ctx, mine, []emulator.OrgTag{{Key: "Owner", Value: "platform"}}); err != nil {
+		t.Fatalf("tag mine: %v", err)
+	}
+	if err := f.plugin.SaveTagsForTest(ctx, theirs, []emulator.OrgTag{{Key: "Owner", Value: "security"}}); err != nil {
+		t.Fatalf("tag theirs: %v", err)
+	}
+
+	body := func(id string) map[string]any {
+		return map[string]any{"ResourceId": id, "TagKeys": []string{"Owner"}}
+	}
+	if err := f.check(t, "orguntagger", "UntagResource", body(mine)); err != nil {
+		t.Errorf("expected the matching resource tag to be allowed: %v", err)
+	}
+	if err := f.check(t, "orguntagger", "UntagResource", body(theirs)); !orgAuthzDenied(t, err) {
+		t.Error("expected a resource tagged with a different Owner to be denied")
+	}
+	// An untagged resource has no Owner at all, which cannot satisfy the condition.
+	untagged := "ou-" + f.root[2:] + "-55556666"
+	if err := f.check(t, "orguntagger", "UntagResource", body(untagged)); !orgAuthzDenied(t, err) {
+		t.Error("expected an untagged resource to be denied")
+	}
+}
+
+// TestOrganizations_Authz_ResourceTagsComeFromTheNamedResourceOnly asserts the
+// decision reads the tags of one resource, not of every ID the body mentions.
+// AttachPolicy names both a policy and a target; merging both tag sets would let
+// a tag on the policy satisfy a condition written about the target, which is a
+// false allow — the one direction a privilege boundary must never fail in.
+func TestOrganizations_Authz_ResourceTagsComeFromTheNamedResourceOnly(t *testing.T) {
+	doc := newABACPolicy("Allow", "organizations:AttachPolicy", "*", "aws:ResourceTag/Owner", "platform")
+	f := newOrgAuthzFixture(t, "orgattacher", doc)
+	ctx := t.Context()
+
+	policyID := "p-authztest"
+	targetID := "ou-" + f.root[2:] + "-77778888"
+	// The policy carries the tag the condition wants; the target does not.
+	if err := f.plugin.SaveTagsForTest(ctx, policyID, []emulator.OrgTag{{Key: "Owner", Value: "platform"}}); err != nil {
+		t.Fatalf("tag policy: %v", err)
+	}
+	if err := f.plugin.SaveTagsForTest(ctx, targetID, []emulator.OrgTag{{Key: "Owner", Value: "security"}}); err != nil {
+		t.Fatalf("tag target: %v", err)
+	}
+
+	// PolicyId is the subject of AttachPolicy, so its tags are the ones read.
+	if err := f.check(t, "orgattacher", "AttachPolicy", map[string]any{
+		"PolicyId": policyID, "TargetId": targetID,
+	}); err != nil {
+		t.Errorf("expected the named policy's tag to decide the request: %v", err)
+	}
+	// Reversing which resource carries the tag must reverse the decision; if both
+	// were merged, this would still be allowed.
+	if err := f.plugin.SaveTagsForTest(ctx, policyID, []emulator.OrgTag{{Key: "Owner", Value: "security"}}); err != nil {
+		t.Fatalf("retag policy: %v", err)
+	}
+	if err := f.plugin.SaveTagsForTest(ctx, targetID, []emulator.OrgTag{{Key: "Owner", Value: "platform"}}); err != nil {
+		t.Fatalf("retag target: %v", err)
+	}
+	if err := f.check(t, "orgattacher", "AttachPolicy", map[string]any{
+		"PolicyId": policyID, "TargetId": targetID,
+	}); !orgAuthzDenied(t, err) {
+		t.Error("expected a tag on the target not to satisfy a condition about the policy")
+	}
+}
+
+// TestOrganizations_Authz_ResourceScopedStatementNarrows covers buildResourceARN.
+// A policy whose Resource element names one OU must not admit an operation
+// against another: falling through to "*" would make every resource-scoped
+// Organizations statement match everything, which is a silent grant rather than a
+// visible failure.
+func TestOrganizations_Authz_ResourceScopedStatementNarrows(t *testing.T) {
+	f := newOrgAuthzFixture(t, "orgscoped", emulator.PolicyDocument{})
+	ctx := t.Context()
+
+	mine := "ou-" + f.root[2:] + "-aaaa1111"
+	theirs := "ou-" + f.root[2:] + "-bbbb2222"
+	mineArn := "arn:aws:organizations::123456789012:ou/o-scoped/" + mine
+	theirsArn := "arn:aws:organizations::123456789012:ou/o-scoped/" + theirs
+	for id, arn := range map[string]string{mine: mineArn, theirs: theirsArn} {
+		if err := f.plugin.SaveOUForTest(ctx, "123456789012", emulator.OrgOrganizationalUnit{
+			ID: id, Arn: arn, Name: id,
+		}); err != nil {
+			t.Fatalf("save OU %s: %v", id, err)
+		}
+	}
+
+	// Rewrite the user's policy so its Resource names only one of the two OUs.
+	doc := emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"organizations:TagResource"},
+			Resource: emulator.StringOrSlice{mineArn},
+		}},
+	}
+	pol := emulator.IAMPolicy{
+		PolicyName:       "testpolicy",
+		PolicyID:         "ANPATEST",
+		ARN:              "arn:aws:iam::123456789012:policy/OrgTagGate-orgscoped",
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document:         doc,
+	}
+	raw, err := json.Marshal(pol)
+	if err != nil {
+		t.Fatalf("marshal policy: %v", err)
+	}
+	if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store policy: %v", err)
+	}
+
+	body := func(id string) map[string]any {
+		return map[string]any{"ResourceId": id, "Tags": []map[string]any{{"Key": "Owner", "Value": "platform"}}}
+	}
+	if err := f.check(t, "orgscoped", "TagResource", body(mine)); err != nil {
+		t.Errorf("expected the OU the statement names to be allowed: %v", err)
+	}
+	if err := f.check(t, "orgscoped", "TagResource", body(theirs)); !orgAuthzDenied(t, err) {
+		t.Error("expected an OU the statement does not name to be denied")
+	}
+}
+
+// TestOrganizations_Authz_ARNsMatchWhatTheAPIReports pins that the ARN
+// authorization builds is the ARN the API itself reports for each kind. A policy
+// is written by pasting an ARN out of a Describe response, so an ARN assembled
+// differently here would fail to match the resource it names — and the caller
+// would have no way to see why.
+func TestOrganizations_Authz_ARNsMatchWhatTheAPIReports(t *testing.T) {
+	f := newOrgAuthzFixture(t, "orgarns", emulator.PolicyDocument{})
+	ctx := t.Context()
+
+	root, err := f.plugin.LoadRootForTest(ctx, "123456789012")
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	account, err := f.plugin.LoadAccountForTest(ctx, "123456789012")
+	if err != nil || account == nil {
+		t.Fatalf("load management account: %v", err)
+	}
+	ouID := "ou-" + root.ID[2:] + "-cccc3333"
+	ouArn := "arn:aws:organizations::123456789012:ou/o-arns/" + ouID
+	if err := f.plugin.SaveOUForTest(ctx, "123456789012", emulator.OrgOrganizationalUnit{
+		ID: ouID, Arn: ouArn, Name: "prod",
+	}); err != nil {
+		t.Fatalf("save OU: %v", err)
+	}
+	policyID := "p-arntest1"
+	policyArn := "arn:aws:organizations::123456789012:policy/o-arns/service_control_policy/" + policyID
+	if err := f.plugin.SavePolicyForTest(ctx, "123456789012", emulator.OrgPolicy{
+		PolicySummary: emulator.OrgPolicySummary{
+			ID: policyID, Arn: policyArn, Name: "deny", Type: emulator.OrgPolicyTypeSCPForTest,
+		},
+		Content: `{"Version":"2012-10-17"}`,
+	}); err != nil {
+		t.Fatalf("save policy: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		body map[string]any
+		want string
+	}{
+		{"root", map[string]any{"ResourceId": root.ID}, root.Arn},
+		{"account", map[string]any{"ResourceId": "123456789012"}, account.Arn},
+		{"organizational unit", map[string]any{"ResourceId": ouID}, ouArn},
+		{"policy", map[string]any{"ResourceId": policyID}, policyArn},
+		{"AWS-managed policy", map[string]any{"PolicyId": emulator.OrgFullAWSAccessIDForTest},
+			emulator.FullAWSAccessPolicyForTest().PolicySummary.Arn},
+		// A resource the organization does not contain, and a request naming none at
+		// all, both fall back to "*" rather than to the empty string: an empty
+		// resource matches every statement, which would widen a scoped policy.
+		{"absent OU", map[string]any{"ResourceId": "ou-" + root.ID[2:] + "-99999999"}, "*"},
+		{"no resource named", map[string]any{}, "*"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raw, err := json.Marshal(c.body)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			// The Resource element names exactly the ARN under test, so an Allow that
+			// matches proves buildResourceARN produced it.
+			doc := emulator.PolicyDocument{
+				Version: "2012-10-17",
+				Statement: []emulator.PolicyStatement{{
+					Effect:   "Allow",
+					Action:   emulator.StringOrSlice{"organizations:TagResource"},
+					Resource: emulator.StringOrSlice{c.want},
+				}},
+			}
+			pol := emulator.IAMPolicy{
+				PolicyName:       "arncheck",
+				PolicyID:         "ANPAARN",
+				ARN:              "arn:aws:iam::123456789012:policy/OrgTagGate-orgarns",
+				Path:             "/",
+				DefaultVersionID: "v1",
+				IsAttachable:     true,
+				Document:         doc,
+			}
+			polRaw, err := json.Marshal(pol)
+			if err != nil {
+				t.Fatalf("marshal policy: %v", err)
+			}
+			if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, polRaw); err != nil { //nolint:contextcheck
+				t.Fatalf("store policy: %v", err)
+			}
+			reqCtx := newAuthTestReqCtx("arn:aws:iam::123456789012:user/orgarns")
+			err = f.auth.CheckAccess(reqCtx, &emulator.AWSRequest{
+				Service: "organizations", Operation: "TagResource", Path: "/", Body: raw,
+			})
+			if err != nil {
+				t.Errorf("expected the request to match a statement naming %s: %v", c.want, err)
+			}
+		})
+	}
+}
+
+// TestOrganizations_Authz_UnreadableTagsDenyRatherThanAllow pins the direction
+// the tag lookup fails in. An unreadable tag record leaves the condition key
+// absent, so an Allow that requires it does not match and the caller is denied.
+// The opposite — assuming the tag matched — would let a storage fault grant
+// access, which is the one failure mode a privilege boundary cannot have.
+func TestOrganizations_Authz_UnreadableTagsDenyRatherThanAllow(t *testing.T) {
+	doc := newABACPolicy("Allow", "organizations:UntagResource", "*", "aws:ResourceTag/Owner", "platform")
+	f := newOrgAuthzFixture(t, "orgfaulty", doc)
+	ctx := t.Context()
+
+	ouID := "ou-" + f.root[2:] + "-dddd4444"
+	if err := f.plugin.SaveTagsForTest(ctx, ouID, []emulator.OrgTag{{Key: "Owner", Value: "platform"}}); err != nil {
+		t.Fatalf("tag OU: %v", err)
+	}
+	// Sanity: the tag decides the request while it is readable.
+	if err := f.check(t, "orgfaulty", "UntagResource", map[string]any{
+		"ResourceId": ouID, "TagKeys": []string{"Owner"},
+	}); err != nil {
+		t.Fatalf("expected the readable tag to allow the request: %v", err)
+	}
+
+	// Now make the tag record unreadable and re-decide over the same state.
+	broken := &corruptOrgState{StateManager: f.state, prefix: "tags:", armed: true}
+	auth := emulator.NewAuthController(broken, emulator.NewDefaultLogger(slog.LevelError, false))
+	reqCtx := newAuthTestReqCtx("arn:aws:iam::123456789012:user/orgfaulty")
+	raw, err := json.Marshal(map[string]any{"ResourceId": ouID, "TagKeys": []string{"Owner"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	err = auth.CheckAccess(reqCtx, &emulator.AWSRequest{
+		Service: "organizations", Operation: "UntagResource", Path: "/", Body: raw,
+	})
+	if !orgAuthzDenied(t, err) {
+		t.Error("expected an unreadable tag record to deny rather than allow")
+	}
+}
+
+// TestOrganizations_Authz_UnparseableBodyDeniesRatherThanAllows asserts a body
+// authorization cannot decode names no resource and carries no request tags, so
+// a tag-gated Allow does not match it. Authorization runs before the handler, so
+// it sees the malformed body first: treating an undecodable body as "no
+// conditions to check" would let a caller bypass an ABAC gate by sending
+// garbage — and the handler's own 400 would never be reached to catch it.
+func TestOrganizations_Authz_UnparseableBodyDeniesRatherThanAllows(t *testing.T) {
+	doc := newABACPolicy("Allow", "organizations:TagResource", "*", "aws:RequestTag/Owner", "platform")
+	f := newOrgAuthzFixture(t, "orggarbage", doc)
+
+	reqCtx := newAuthTestReqCtx("arn:aws:iam::123456789012:user/orggarbage")
+	err := f.auth.CheckAccess(reqCtx, &emulator.AWSRequest{
+		Service: "organizations", Operation: "TagResource", Path: "/",
+		Body: []byte(`{"ResourceId":`),
+	})
+	if !orgAuthzDenied(t, err) {
+		t.Error("expected an unparseable body to be denied by a tag-gated policy")
+	}
+}
+
+// TestOrganizations_Authz_NonOrganizationsRequestsAreUnaffected asserts the new
+// arms are scoped to the organizations service. A condition context leaking
+// Organizations tags into another service's decision would change that service's
+// answers, and every one of those decisions is already covered elsewhere.
+func TestOrganizations_Authz_NonOrganizationsRequestsAreUnaffected(t *testing.T) {
+	doc := newABACPolicy("Allow", "s3:PutObject", "*", "aws:ResourceTag/Owner", "platform")
+	f := newOrgAuthzFixture(t, "orgunrelated", doc)
+
+	// An Organizations resource carrying the tag the S3 condition wants must not
+	// satisfy it.
+	if err := f.plugin.SaveTagsForTest(t.Context(), "my-bucket",
+		[]emulator.OrgTag{{Key: "Owner", Value: "platform"}}); err != nil {
+		t.Fatalf("tag: %v", err)
+	}
+	reqCtx := newAuthTestReqCtx("arn:aws:iam::123456789012:user/orgunrelated")
+	err := f.auth.CheckAccess(reqCtx, &emulator.AWSRequest{
+		Service: "s3", Operation: "PutObject", Path: "/my-bucket/key",
+	})
+	if err == nil {
+		t.Fatal("expected an Organizations tag not to satisfy an S3 resource-tag condition")
+	}
+	// S3 speaks its own XML dialect, so its denial is the bare code; asserting it
+	// here also pins that the new arms did not change another protocol's error.
+	var awsErr *emulator.AWSError
+	if !errors.As(err, &awsErr) {
+		t.Fatalf("expected an *AWSError, got %T: %v", err, err)
+	}
+	if awsErr.Code != "AccessDenied" {
+		t.Errorf("expected AccessDenied for an S3 request, got %q", awsErr.Code)
+	}
+}


### PR DESCRIPTION
Part of #578.

Adds Organizations resource tagging and wires the stored tags into the IAM
authorization decision, so a tag on a root, OU, account or policy can actually
gate a request. The two halves ship together on purpose: tagging that no policy
can read is bookkeeping, not a privilege boundary.

## What this covers of #578

- **Point 8 — resource tagging.** `TagResource`, `UntagResource` and
  `ListTagsForResource`, over all four resource kinds the model's
  `TaggableResourceId` marks taggable.
- **Point 9 — tags in the authorization decision.** `aws:ResourceTag/{Key}` and
  `aws:RequestTag/{Key}` are populated for the `organizations` namespace, and a
  resource-scoped `Resource` element now narrows an Organizations statement
  instead of matching everything.

Nothing else in #578 is touched — organization/root lifecycle landed in #606, and
the OU, policy and account operations belong to the other lanes on this
milestone.

## The authorization wiring

Three arms in `emulator/authz.go`:

| site | what it does |
|---|---|
| `buildResourceARN` | returns the ARN the API itself reports for the named resource, read from the stored record |
| `addResourceTags` | populates `aws:ResourceTag/{Key}` from the one resource the request names |
| `addRequestTags` | populates `aws:RequestTag/{Key}` from the body's `Tags` member |

`buildResourceARN` becomes a method on `*AuthController`. An Organizations ARN
embeds the organization's own ID, so it cannot be reassembled from the request —
it has to be read, and the free function had no state access. The one call site
moves with it; no other service's behaviour changes, and the existing `authz`
tests pass unchanged.

Two decisions worth flagging for review:

- **One resource per request, never a merge.** `AttachPolicy` names both a policy
  and a target. Merging both tag sets into `aws:ResourceTag` would let a tag on
  the policy satisfy a condition written about the target — a false allow, which
  is the one direction a privilege boundary must not fail in. There is a test
  that reverses which of the two carries the tag and asserts the decision
  reverses with it.
- **`"*"` on a miss, never `""`.** `resourceMatches` treats an empty resource as
  matching every statement, so returning `""` for an absent or unreadable record
  would *widen* a resource-scoped policy. A store fault likewise leaves the tag
  condition key absent, so a tag-gated Allow fails to match and the caller is
  denied — the safe direction.

## Which operations the authz test exercises

Lane B's `CreatePolicy`/`UpdatePolicy` had not merged when this was written, so
the decisive test uses the operations that exist rather than implementing any:

- `aws:RequestTag/Owner` gates **`organizations:TagResource`** — allowed with the
  matching tag, denied with a different one, denied with none.
- `aws:ResourceTag/Owner` gates **`organizations:UntagResource`** — allowed on a
  resource tagged `Owner=platform`, denied on one tagged `Owner=security`, denied
  on an untagged one.
- The one-resource rule is exercised through **`organizations:AttachPolicy`**,
  whose body names two resources.
- ARN scoping is exercised through **`organizations:TagResource`** against a
  statement naming a single OU's ARN, plus a table asserting the ARN built for
  each kind is the ARN the API reports for it.

Denials assert code **`AccessDeniedException`**, not `AccessDenied`:
Organizations speaks JSON-RPC, so `accessDeniedCodeFor` returns the suffixed
form. One test pins that an S3 decision still gets the bare `AccessDenied`, so
the new arms did not disturb another protocol's error.

## Refusals wired

| condition | code / reason |
|---|---|
| well-formed ID naming nothing | `TargetNotFoundException` |
| ID the `TaggableResourceId` pattern rejects | `InvalidInputException` / `INVALID_PATTERN` |
| missing `ResourceId`, `Tags`, `TagKeys`; null tag key or value | `InvalidInputException` / `INPUT_REQUIRED` |
| one request naming a key twice | `InvalidInputException` / `DUPLICATE_TAG_KEY` |
| empty tag key | `InvalidInputException` / `MIN_LENGTH_EXCEEDED` |
| key over 128 or value over 256 characters | `InvalidInputException` / `MAX_LENGTH_EXCEEDED` |
| key or value outside the `TagKey`/`TagValue` character class | `InvalidInputException` / `INVALID_PATTERN` |
| `aws:`-prefixed key | `InvalidInputException` / `INVALID_SYSTEM_TAGS_PARAMETER` |
| tagging or untagging `p-FullAWSAccess` | `InvalidInputException` / `IMMUTABLE_POLICY` |
| past 50 tags on one resource | `ConstraintViolationException` / `MAX_TAG_LIMIT_EXCEEDED` |
| stale or unparseable `NextToken` | `InvalidInputException` / `INVALID_NEXT_TOKEN` |
| store fault or unreadable record | HTTP 500 |

Every reason string comes from the botocore model
(`organizations/2016-11-28/service-2.json`), not from recall. Every Organizations
exception is HTTP **400** — the model declares no 404 — so the tests assert on
the error code, never on the status alone.

## Notes from checking the model

- `ListTagsForResource` genuinely has **no `MaxResults`** member, only
  `NextToken`. It still pages, at the shared `orgMaxResults` ceiling of 20, which
  is *below* the 50-tag limit — so a heavily tagged resource really does page, and
  a consumer reading only the first page would miss the tag its condition is
  about. A stale token is refused rather than silently restarting the listing,
  which would never terminate.
- `UntagResource` is **idempotent**: "Removes any tags with the specified keys."
  An absent key is not an error, and nothing is written when nothing matched.
  Refusing would break a cleanup path that runs twice.
- `TagValue`'s minimum length is **0**, so `""` is a legal value and only `null`
  is refused. `Key` and `Value` are decoded as pointers to keep the two apart.
- The 50-tag limit is checked on the **resulting** set, not on the request, so a
  resource already at the limit can still have an existing key rewritten. A
  single request whose own tags would cross the limit is refused whole.
- `TaggableResourceId` admits two forms substrate does not model — `rp-`
  (resource policy) and `rt-` (responsibility transfer). They are admitted as
  well-formed and then refused as absent, which is what AWS answers for an
  organization with no such resource; `INVALID_PATTERN` would be wrong for a
  syntactically valid ID.

Nothing in the model contradicted the brief.

## Deliberate omissions

- **No tag-on-create.** `CreateOrganizationalUnit`, `CreatePolicy` and
  `CreateAccount` all accept a `Tags` member; those operations belong to the other
  lanes, so their handlers must call into this file's validation. The validation
  and merge helpers are written to be called that way, but nothing here wires
  them up. The `aws:RequestTag` arm already covers a tagged create once the
  operation exists.
- **No tag cleanup on delete.** Deleting an OU or policy should drop its tags;
  the delete operations are another lane's.
- **No resource-policy or responsibility-transfer tagging** (`rp-`/`rt-`), since
  substrate models neither resource.
- **`CHANGELOG.md` untouched**, per the lane split — PR 6 owns it.

## Verification

```
gofmt -l emulator/          # clean
go build ./... && go vet ./...
golangci-lint run ./emulator/   # 0 issues.
go test ./emulator/ -run TestOrganizations -count=1   # ok
make test                       # ok, race detector, whole repo
```

`emulator/organizations_tags.go` is at **100% statement coverage**.
