### PR TITLE
fix(organizations,server): route the AWSOrganizationsV20161128 target prefix (#610)

### DIFF
--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -304,6 +304,15 @@ var targetServiceAliases = map[string]string{
 	// Both aws-sdk-go-v2 and boto3 use X-Amz-Target: AWSPriceListService.{Op}
 	// for the Price List Query API, whose SigV4 signing name is "pricing".
 	"awspricelistservice": "pricing",
+	// "AWSOrganizationsV20161128" → no "Amazon" to strip, no "_" version suffix
+	// → lowercase → "awsorganizationsv20161128" → "organizations". The version
+	// rides in the prefix itself rather than after an underscore, so the generic
+	// suffix strip above never fires and the name never reduces on its own.
+	// Without this alias OrganizationsPlugin was registered and unit-tested but
+	// unreachable from any SDK, exactly as SSOPlugin was in #561: every
+	// aws-sdk-go-v2 and boto3 call fell through to
+	// "service not emulated: awsorganizationsv20161128".
+	"awsorganizationsv20161128": "organizations",
 }
 
 // extractServiceFromTarget parses an X-Amz-Target value such as

--- a/emulator/parser_test.go
+++ b/emulator/parser_test.go
@@ -833,6 +833,33 @@ func TestParseAWSRequest_SSOAdminTargetPrefix(t *testing.T) {
 	}
 }
 
+// TestParseAWSRequest_OrganizationsTargetPrefix pins the Organizations target
+// prefix. "AWSOrganizationsV20161128" carries its API version inside the prefix
+// rather than after an underscore, so the generic version-suffix strip never
+// fires and the name never reduces to "organizations" on its own. Without the
+// alias the plugin was registered and unit-tested but unreachable from any SDK,
+// the same failure #561 found in sso-admin: every call answered
+// "service not emulated: awsorganizationsv20161128".
+func TestParseAWSRequest_OrganizationsTargetPrefix(t *testing.T) {
+	t.Parallel()
+	for _, target := range []string{
+		"AWSOrganizationsV20161128.ListRoots",
+		"AWSOrganizationsV20161128.CreateAccount",
+		"AWSOrganizationsV20161128.MoveAccount",
+	} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodPost, "http://localhost:4566/", nil)
+			r.Host = "localhost:4566"
+			r.Header.Set("X-Amz-Target", target)
+
+			req, _, err := emulator.ParseAWSRequest(r)
+			require.NoError(t, err)
+			assert.Equal(t, "organizations", req.Service)
+		})
+	}
+}
+
 func TestNormalizeS3VirtualHost(t *testing.T) {
 	tests := []struct {
 		host       string


### PR DESCRIPTION
Found by the live-server gate: `aws organizations list-roots` against
`substrate server` answered `service not emulated: awsorganizationsv20161128`,
so the whole plugin was unreachable from any SDK despite being registered and
unit-tested.

`extractServiceFromTarget` strips a leading `Amazon` and a version suffix that
follows an underscore. `AWSOrganizationsV20161128` has neither, so the name
never reduces and no registry entry matches. One alias fixes it.

The regression test goes through `ParseAWSRequest` rather than constructing an
`AWSRequest` — that is exactly why the existing Organizations tests could not
catch this, and it mirrors the #561 test for the same reason.

Verified against a live server with `AWS_MAX_ATTEMPTS=1`: the full vending
journey (stable root, OU create, async create → poll → move, the duplicate-move
refusal, `ListParents`, the seeded async failure, the depth limit) now works
through the AWS CLI.

Closes #610