### PR TITLE
feat(organizations): implement the service control policy lifecycle (#578)

### DIFF
--- a/emulator/organizations_policy.go
+++ b/emulator/organizations_policy.go
@@ -1,8 +1,1165 @@
 package emulator
 
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"unicode/utf8"
+)
+
+// orgPolicyTypes is the PolicyType enum from the Organizations API model. A value
+// outside it is a syntax error the caller can fix by correcting a string; a value
+// inside it that substrate does not model is a different problem entirely, and
+// the two get different codes so a caller can tell a typo from an unsupported
+// feature.
+var orgPolicyTypes = []string{
+	"SERVICE_CONTROL_POLICY",
+	"RESOURCE_CONTROL_POLICY",
+	"TAG_POLICY",
+	"BACKUP_POLICY",
+	"AISERVICES_OPT_OUT_POLICY",
+	"CHATBOT_POLICY",
+	"DECLARATIVE_POLICY_EC2",
+	"SECURITYHUB_POLICY",
+	"INSPECTOR_POLICY",
+	"UPGRADE_ROLLOUT_POLICY",
+	"BEDROCK_POLICY",
+	"S3_POLICY",
+	"NETWORK_SECURITY_DIRECTOR_POLICY",
+}
+
+// orgPolicyTypeStatusEnabled is the PolicyTypeStatus a root reports for a policy
+// type EnablePolicyType has turned on. The model also declares PENDING_ENABLE and
+// PENDING_DISABLE; substrate does not use them, because a transition no caller can
+// observe the end of would make a poll loop wait for a state change that never
+// arrives.
+const orgPolicyTypeStatusEnabled = "ENABLED"
+
 // policyOperation claims the service control policy lifecycle operations. The
 // policy, attachment and FullAWSAccess stores live in organizations_state.go;
 // this file owns only the operations over them.
-func (p *OrganizationsPlugin) policyOperation(_ string) (orgHandler, bool) {
-	return nil, false
+func (p *OrganizationsPlugin) policyOperation(op string) (orgHandler, bool) {
+	switch op {
+	case "CreatePolicy":
+		return p.createPolicy, true
+	case "UpdatePolicy":
+		return p.updatePolicy, true
+	case "DeletePolicy":
+		return p.deletePolicy, true
+	case "DescribePolicy":
+		return p.describePolicy, true
+	case "ListPolicies":
+		return p.listPolicies, true
+	case "AttachPolicy":
+		return p.attachPolicy, true
+	case "DetachPolicy":
+		return p.detachPolicy, true
+	case "ListPoliciesForTarget":
+		return p.listPoliciesForTarget, true
+	case "ListTargetsForPolicy":
+		return p.listTargetsForPolicy, true
+	case "EnablePolicyType":
+		return p.enablePolicyType, true
+	case "DisablePolicyType":
+		return p.disablePolicyType, true
+	default:
+		return nil, false
+	}
+}
+
+// --- availability, the outermost gate ---
+//
+// Two different conditions stop an SCP being useful, and they are not the same
+// refusal:
+//
+//   - Not *available*: the organization is in CONSOLIDATED_BILLING mode, where the
+//     policy type does not exist at all. Nothing can create, read, attach or enable
+//     one, and the fix is a migration to all features.
+//   - Available but not *enabled*: an all-features organization whose root has had
+//     DisablePolicyType called on it. Policies still exist and can be created; only
+//     attachment is refused, and the fix is one EnablePolicyType call.
+//
+// The second is the dangerous state issue #578 point 6 is about, and it is only
+// distinguishable from the first if the two report differently. Availability is
+// modeled as visibility: while SCPs are unavailable no policy is visible, so every
+// operation that names one answers with its own documented not-found code. Only
+// CreatePolicy and EnablePolicyType name the feature set as the reason, because
+// those are the two operations whose error list in the API model declares
+// PolicyTypeNotAvailableForOrganizationException — emitting it from an operation
+// that does not declare it would hand a caller an exception its SDK cannot catch
+// by type, which is worse than a truthful "no such policy".
+
+// policyTypeAvailable reports whether service control policies exist at all for
+// the organization, which is true only under the ALL feature set.
+func (p *OrganizationsPlugin) policyTypeAvailable(ctx context.Context, acct string) (bool, error) {
+	featureSet, err := p.effectiveFeatureSet(ctx, acct)
+	if err != nil {
+		return false, err
+	}
+	return featureSet == orgFeatureSetAll, nil
+}
+
+// loadVisiblePolicy returns the policy only when service control policies are
+// available to the organization, and (nil, nil) otherwise. p-FullAWSAccess is
+// synthesized by loadPolicy rather than stored, so without this gate it would stay
+// readable in a CONSOLIDATED_BILLING organization that can hold no SCP at all.
+func (p *OrganizationsPlugin) loadVisiblePolicy(ctx context.Context, acct, policyID string) (*OrgPolicy, error) {
+	available, err := p.policyTypeAvailable(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	if !available {
+		return nil, nil //nolint:nilnil // (nil, nil) = "no visible policy", handled by caller.
+	}
+	return p.loadPolicy(ctx, policyID)
+}
+
+// --- CreatePolicy ---
+
+func (p *OrganizationsPlugin) createPolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		Content     string   `json:"Content"`
+		Description *string  `json:"Description"`
+		Name        string   `json:"Name"`
+		Type        string   `json:"Type"`
+		Tags        []OrgTag `json:"Tags"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+
+	// Content, Description, Name and Type are all required in the model — including
+	// Description, which reads as optional but is not.
+	if input.Name == "" {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter Name.")
+	}
+	if input.Content == "" {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter Content.")
+	}
+	if input.Description == nil {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter Description.")
+	}
+	if input.Type == "" {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter Type.")
+	}
+	if err := orgCheckPolicyType(input.Type); err != nil {
+		return nil, err
+	}
+
+	org, err := p.ensureOrganization(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("createPolicy ensure org: %w", err)
+	}
+	available, err := p.policyTypeAvailable(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("createPolicy availability: %w", err)
+	}
+	// A type that is valid in the enum but not SERVICE_CONTROL_POLICY gets the same
+	// refusal as an unavailable one: substrate models no other policy type, so from
+	// the caller's side the type is not usable in this organization. Under
+	// CONSOLIDATED_BILLING even SCPs are refused here, and this is deliberately the
+	// one place the feature set is named — it is the first call a governance tool
+	// makes, so it is where the diagnosis has to be legible.
+	if !available || input.Type != orgPolicyTypeSCP {
+		return nil, orgErr("PolicyTypeNotAvailableForOrganizationException",
+			"You can't use the specified policy type with the feature set currently enabled for this organization")
+	}
+
+	if err := orgCheckPolicyName(input.Name); err != nil {
+		return nil, err
+	}
+	if err := orgCheckPolicyDescription(*input.Description); err != nil {
+		return nil, err
+	}
+	if err := orgCheckPolicyContent(input.Content); err != nil {
+		return nil, err
+	}
+
+	ids, err := p.loadPolicyIDs(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("createPolicy load ids: %w", err)
+	}
+	// The quota counts the policies the organization owns; p-FullAWSAccess is
+	// AWS-managed and is not stored, so it is not one of them.
+	if orgPolicyNumberLimitExceeded(len(ids)) {
+		return nil, orgConstraintViolation("POLICY_NUMBER_LIMIT_EXCEEDED",
+			fmt.Sprintf("You have exceeded the number of policies allowed in an organization (%d)", orgMaxSCPsPerOrg))
+	}
+	taken, err := p.policyNameTaken(goCtx, ids, input.Name, "")
+	if err != nil {
+		return nil, fmt.Errorf("createPolicy name check: %w", err)
+	}
+	// Creating is not idempotent: a re-run of a governance script has to be able to
+	// tell "I already made this" from "I made it now", and the name is the only
+	// handle it has before it knows the ID.
+	if taken {
+		return nil, orgErr("DuplicatePolicyException", "A policy with the same name already exists")
+	}
+
+	policyID := "p-" + randomLowerAlphanum(orgPolicyIDSuffixLen)
+	pol := OrgPolicy{
+		PolicySummary: OrgPolicySummary{
+			ID:          policyID,
+			Arn:         orgPolicyArn(reqCtx.AccountID, org.ID, policyID),
+			Name:        input.Name,
+			Description: *input.Description,
+			Type:        orgPolicyTypeSCP,
+			AwsManaged:  false,
+		},
+		Content: input.Content,
+	}
+	if err := p.savePolicy(goCtx, reqCtx.AccountID, pol); err != nil {
+		return nil, fmt.Errorf("createPolicy save: %w", err)
+	}
+	// Tags supplied at creation are stored so ListTagsForResource can read them
+	// back; their validation and their part in the authorization decision belong to
+	// the tagging operations.
+	if len(input.Tags) > 0 {
+		if err := p.saveTags(goCtx, policyID, input.Tags); err != nil {
+			return nil, fmt.Errorf("createPolicy save tags: %w", err)
+		}
+	}
+	return orgJSONResponse(map[string]interface{}{"Policy": pol}, "createPolicy")
+}
+
+// --- UpdatePolicy ---
+
+func (p *OrganizationsPlugin) updatePolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	// Name, Description and Content are pointers because UpdatePolicy is a partial
+	// update: an omitted member leaves the stored value alone, while an empty string
+	// is a value the caller asked for. Collapsing the two would silently blank a
+	// description on every rename.
+	var input struct {
+		PolicyID    string  `json:"PolicyId"`
+		Name        *string `json:"Name"`
+		Description *string `json:"Description"`
+		Content     *string `json:"Content"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := orgCheckPolicyID(input.PolicyID); err != nil {
+		return nil, err
+	}
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("updatePolicy ensure org: %w", err)
+	}
+	if input.PolicyID == orgFullAWSAccessID {
+		return nil, orgImmutablePolicy()
+	}
+
+	pol, err := p.loadVisiblePolicy(goCtx, reqCtx.AccountID, input.PolicyID)
+	if err != nil {
+		return nil, fmt.Errorf("updatePolicy load: %w", err)
+	}
+	if pol == nil {
+		return nil, orgPolicyNotFound()
+	}
+
+	if input.Name != nil && *input.Name != pol.PolicySummary.Name {
+		if err := orgCheckPolicyName(*input.Name); err != nil {
+			return nil, err
+		}
+		ids, idErr := p.loadPolicyIDs(goCtx, reqCtx.AccountID)
+		if idErr != nil {
+			return nil, fmt.Errorf("updatePolicy load ids: %w", idErr)
+		}
+		taken, takenErr := p.policyNameTaken(goCtx, ids, *input.Name, input.PolicyID)
+		if takenErr != nil {
+			return nil, fmt.Errorf("updatePolicy name check: %w", takenErr)
+		}
+		if taken {
+			return nil, orgErr("DuplicatePolicyException", "A policy with the same name already exists")
+		}
+		pol.PolicySummary.Name = *input.Name
+	}
+	if input.Description != nil {
+		if err := orgCheckPolicyDescription(*input.Description); err != nil {
+			return nil, err
+		}
+		pol.PolicySummary.Description = *input.Description
+	}
+	if input.Content != nil {
+		if err := orgCheckPolicyContent(*input.Content); err != nil {
+			return nil, err
+		}
+		pol.Content = *input.Content
+	}
+
+	if err := p.savePolicy(goCtx, reqCtx.AccountID, *pol); err != nil {
+		return nil, fmt.Errorf("updatePolicy save: %w", err)
+	}
+	return orgJSONResponse(map[string]interface{}{"Policy": *pol}, "updatePolicy")
+}
+
+// --- DeletePolicy ---
+
+func (p *OrganizationsPlugin) deletePolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		PolicyID string `json:"PolicyId"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := orgCheckPolicyID(input.PolicyID); err != nil {
+		return nil, err
+	}
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("deletePolicy ensure org: %w", err)
+	}
+	if input.PolicyID == orgFullAWSAccessID {
+		return nil, orgImmutablePolicy()
+	}
+
+	pol, err := p.loadVisiblePolicy(goCtx, reqCtx.AccountID, input.PolicyID)
+	if err != nil {
+		return nil, fmt.Errorf("deletePolicy load: %w", err)
+	}
+	if pol == nil {
+		return nil, orgPolicyNotFound()
+	}
+
+	targets, err := p.loadPolicyTargets(goCtx, input.PolicyID)
+	if err != nil {
+		return nil, fmt.Errorf("deletePolicy load targets: %w", err)
+	}
+	// Deleting an attached policy is refused rather than cascading. A cascade would
+	// silently remove a guardrail from every entity it was attached to, and a
+	// teardown script that deletes in the wrong order would look like it worked.
+	if len(targets) > 0 {
+		return nil, orgErr("PolicyInUseException",
+			"The policy is attached to one or more entities. You must detach it from all roots, OUs, and accounts before performing this operation")
+	}
+
+	if err := p.deletePolicyRecord(goCtx, reqCtx.AccountID, input.PolicyID); err != nil {
+		return nil, fmt.Errorf("deletePolicy delete: %w", err)
+	}
+	return orgEmptyResponse(), nil
+}
+
+// deletePolicyRecord removes a policy, its index entry, its (empty) target index
+// and its tags. The tags go with it so a later resource never inherits the tags of
+// a policy that no longer exists — which would fail open on a tag-gated policy.
+func (p *OrganizationsPlugin) deletePolicyRecord(ctx context.Context, acct, policyID string) error {
+	if _, err := p.orgRemoveID(ctx, orgPolicyIDsKey(acct), policyID); err != nil {
+		return err
+	}
+	for _, key := range []string{orgPolicyKey(policyID), orgPolicyTargetsKey(policyID), orgTagsKey(policyID)} {
+		if err := p.state.Delete(ctx, organizationsNamespace, key); err != nil {
+			return fmt.Errorf("delete %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// --- DescribePolicy ---
+
+func (p *OrganizationsPlugin) describePolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		PolicyID string `json:"PolicyId"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := orgCheckPolicyID(input.PolicyID); err != nil {
+		return nil, err
+	}
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("describePolicy ensure org: %w", err)
+	}
+
+	pol, err := p.loadVisiblePolicy(goCtx, reqCtx.AccountID, input.PolicyID)
+	if err != nil {
+		return nil, fmt.Errorf("describePolicy load: %w", err)
+	}
+	if pol == nil {
+		return nil, orgPolicyNotFound()
+	}
+	return orgJSONResponse(map[string]interface{}{"Policy": *pol}, "describePolicy")
+}
+
+// --- ListPolicies ---
+
+func (p *OrganizationsPlugin) listPolicies(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		Filter     string `json:"Filter"`
+		NextToken  string `json:"NextToken"`
+		MaxResults int    `json:"MaxResults"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	// Filter is required in the model, and defaulting it would be the wrong kindness:
+	// a caller that meant to list tag policies and got SCPs would draw the opposite
+	// conclusion about what governs its accounts.
+	if input.Filter == "" {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter Filter.")
+	}
+	if err := orgCheckPolicyType(input.Filter); err != nil {
+		return nil, err
+	}
+
+	ids, err := p.visiblePolicyIDs(goCtx, reqCtx.AccountID, input.Filter)
+	if err != nil {
+		return nil, fmt.Errorf("listPolicies load ids: %w", err)
+	}
+	page, next, err := orgPaginate(ids, input.NextToken, input.MaxResults)
+	if err != nil {
+		return nil, err
+	}
+	summaries, err := p.policySummaries(goCtx, page)
+	if err != nil {
+		return nil, fmt.Errorf("listPolicies load policies: %w", err)
+	}
+
+	out := map[string]interface{}{"Policies": summaries}
+	if next != "" {
+		out["NextToken"] = next
+	}
+	return orgJSONResponse(out, "listPolicies")
+}
+
+// visiblePolicyIDs returns the policy IDs a listing filtered by policyType should
+// report. Only SERVICE_CONTROL_POLICY has any members: substrate models no other
+// type, so a valid filter naming one answers with an empty page rather than a
+// refusal — an organization with no tag policies is exactly what AWS reports as an
+// empty list, and the API model offers no code to refuse with here.
+func (p *OrganizationsPlugin) visiblePolicyIDs(ctx context.Context, acct, policyType string) ([]string, error) {
+	if policyType != orgPolicyTypeSCP {
+		return nil, nil
+	}
+	available, err := p.policyTypeAvailable(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	if !available {
+		return nil, nil
+	}
+	ids, err := p.loadPolicyIDs(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	// FullAWSAccess is not in the stored index because it is synthesized, but it is
+	// a policy of the organization and every listing has to show it — a caller that
+	// concludes a fresh organization has no SCPs would also conclude nothing is
+	// allowed, which is the reverse of the truth.
+	return append(ids, orgFullAWSAccessID), nil
+}
+
+// policySummaries loads a page of policies as summaries, skipping an ID whose
+// record has gone. A zero-valued summary in a listing is worse than a short page:
+// a caller iterating it would call DescribePolicy with "" and get a refusal it has
+// nothing to trace to.
+func (p *OrganizationsPlugin) policySummaries(ctx context.Context, ids []string) ([]OrgPolicySummary, error) {
+	summaries := make([]OrgPolicySummary, 0, len(ids))
+	for _, id := range ids {
+		pol, err := p.loadPolicy(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if pol == nil {
+			continue
+		}
+		summaries = append(summaries, pol.PolicySummary)
+	}
+	return summaries, nil
+}
+
+// --- AttachPolicy ---
+
+func (p *OrganizationsPlugin) attachPolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		PolicyID string `json:"PolicyId"`
+		TargetID string `json:"TargetId"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := orgCheckPolicyID(input.PolicyID); err != nil {
+		return nil, err
+	}
+	if err := orgCheckTargetID(input.TargetID); err != nil {
+		return nil, err
+	}
+
+	pol, kind, err := p.resolveAttachment(goCtx, reqCtx.AccountID, input.PolicyID, input.TargetID)
+	if err != nil {
+		return nil, fmt.Errorf("attachPolicy resolve: %w", err)
+	}
+	if pol == nil {
+		return nil, orgPolicyNotFound()
+	}
+	if kind == "" {
+		return nil, orgTargetNotFound()
+	}
+
+	enabled, err := p.scpEnabled(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("attachPolicy enablement: %w", err)
+	}
+	// This is issue #578's point 6. The policy exists and the target exists, and a
+	// caller that treats create-then-attach as one step has already recorded the
+	// policy as applied. Refusing here — rather than attaching something the root
+	// would not evaluate — is what makes the unenforced-guardrail state observable.
+	if !enabled {
+		return nil, orgErr("PolicyTypeNotEnabledException",
+			"The specified policy type isn't currently enabled in this root. You can't attach policies of the specified type to entities in a root until you enable that type in the root")
+	}
+
+	attached, err := p.loadAttachments(goCtx, input.TargetID)
+	if err != nil {
+		return nil, fmt.Errorf("attachPolicy load attachments: %w", err)
+	}
+	if slices.Contains(attached, input.PolicyID) {
+		return nil, orgErr("DuplicatePolicyAttachmentException", "The selected policy is already attached to the specified target")
+	}
+	if len(attached) >= orgMaxSCPsPerTarget {
+		return nil, orgConstraintViolation("MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED",
+			fmt.Sprintf("You have exceeded the number of policies of type SERVICE_CONTROL_POLICY that can be attached to one entity (%d)", orgMaxSCPsPerTarget))
+	}
+
+	if _, err := p.attachPolicyTo(goCtx, input.PolicyID, input.TargetID); err != nil {
+		return nil, fmt.Errorf("attachPolicy attach: %w", err)
+	}
+	return orgEmptyResponse(), nil
+}
+
+// --- DetachPolicy ---
+
+func (p *OrganizationsPlugin) detachPolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		PolicyID string `json:"PolicyId"`
+		TargetID string `json:"TargetId"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := orgCheckPolicyID(input.PolicyID); err != nil {
+		return nil, err
+	}
+	if err := orgCheckTargetID(input.TargetID); err != nil {
+		return nil, err
+	}
+
+	pol, kind, err := p.resolveAttachment(goCtx, reqCtx.AccountID, input.PolicyID, input.TargetID)
+	if err != nil {
+		return nil, fmt.Errorf("detachPolicy resolve: %w", err)
+	}
+	if pol == nil {
+		return nil, orgPolicyNotFound()
+	}
+	if kind == "" {
+		return nil, orgTargetNotFound()
+	}
+
+	attached, err := p.loadAttachments(goCtx, input.TargetID)
+	if err != nil {
+		return nil, fmt.Errorf("detachPolicy load attachments: %w", err)
+	}
+	if !slices.Contains(attached, input.PolicyID) {
+		return nil, orgErr("PolicyNotAttachedException", "The policy isn't attached to the specified target in the specified root")
+	}
+
+	enabled, err := p.scpEnabled(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("detachPolicy enablement: %w", err)
+	}
+	// The floor is why FullAWSAccess can be detached from a target that has another
+	// SCP but not from one that has only FullAWSAccess. An entity with the type
+	// enabled and no SCP attached denies everything in real AWS, so a detach that
+	// took the last one would produce the opposite of what the caller intended, and
+	// would produce it silently. The floor does not apply while the type is
+	// disabled: nothing is attached then, and nothing is evaluated either.
+	if enabled && len(attached) <= orgMinSCPsPerTarget {
+		return nil, orgConstraintViolation("MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED",
+			fmt.Sprintf("You must have at least %d policy of type SERVICE_CONTROL_POLICY attached to this entity", orgMinSCPsPerTarget))
+	}
+
+	if _, err := p.detachPolicyFrom(goCtx, input.PolicyID, input.TargetID); err != nil {
+		return nil, fmt.Errorf("detachPolicy detach: %w", err)
+	}
+	return orgEmptyResponse(), nil
+}
+
+// resolveAttachment loads the policy and resolves the target for an attach or a
+// detach. It returns a nil policy for "no such policy" and an empty kind for "no
+// such target", so the caller can pick the code its operation documents.
+func (p *OrganizationsPlugin) resolveAttachment(ctx context.Context, acct, policyID, targetID string) (*OrgPolicy, string, error) {
+	if _, err := p.ensureOrganization(ctx, acct); err != nil {
+		return nil, "", err
+	}
+	pol, err := p.loadVisiblePolicy(ctx, acct, policyID)
+	if err != nil {
+		return nil, "", err
+	}
+	if pol == nil {
+		return nil, "", nil
+	}
+	kind, err := p.resolveOrgTarget(ctx, acct, targetID)
+	if err != nil {
+		return nil, "", err
+	}
+	// A policy is a valid tag target but not a valid attachment target; the syntax
+	// check upstream already rules its ID out, so anything else is not attachable.
+	if kind == orgKindPolicy {
+		kind = ""
+	}
+	return pol, kind, nil
+}
+
+// --- ListPoliciesForTarget ---
+
+func (p *OrganizationsPlugin) listPoliciesForTarget(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		TargetID   string `json:"TargetId"`
+		Filter     string `json:"Filter"`
+		NextToken  string `json:"NextToken"`
+		MaxResults int    `json:"MaxResults"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := orgCheckTargetID(input.TargetID); err != nil {
+		return nil, err
+	}
+	if input.Filter == "" {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter Filter.")
+	}
+	if err := orgCheckPolicyType(input.Filter); err != nil {
+		return nil, err
+	}
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("listPoliciesForTarget ensure org: %w", err)
+	}
+
+	kind, err := p.resolveOrgTarget(goCtx, reqCtx.AccountID, input.TargetID)
+	if err != nil {
+		return nil, fmt.Errorf("listPoliciesForTarget resolve target: %w", err)
+	}
+	if kind == "" || kind == orgKindPolicy {
+		return nil, orgTargetNotFound()
+	}
+
+	available, err := p.policyTypeAvailable(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("listPoliciesForTarget availability: %w", err)
+	}
+	// An empty page, not a refusal, for a type substrate does not model or an
+	// organization that can hold none: that is what AWS reports for a target with no
+	// policies of the filtered type, and the model gives this operation no code to
+	// refuse with. The listing reports only *directly* attached policies, never
+	// inherited ones — which is why a caller checking whether an account is governed
+	// has to walk the hierarchy itself rather than trusting one call.
+	var ids []string
+	if available && input.Filter == orgPolicyTypeSCP {
+		ids, err = p.loadAttachments(goCtx, input.TargetID)
+		if err != nil {
+			return nil, fmt.Errorf("listPoliciesForTarget load attachments: %w", err)
+		}
+	}
+
+	page, next, err := orgPaginate(ids, input.NextToken, input.MaxResults)
+	if err != nil {
+		return nil, err
+	}
+	summaries, err := p.policySummaries(goCtx, page)
+	if err != nil {
+		return nil, fmt.Errorf("listPoliciesForTarget load policies: %w", err)
+	}
+
+	out := map[string]interface{}{"Policies": summaries}
+	if next != "" {
+		out["NextToken"] = next
+	}
+	return orgJSONResponse(out, "listPoliciesForTarget")
+}
+
+// --- ListTargetsForPolicy ---
+
+func (p *OrganizationsPlugin) listTargetsForPolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		PolicyID   string `json:"PolicyId"`
+		NextToken  string `json:"NextToken"`
+		MaxResults int    `json:"MaxResults"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if err := orgCheckPolicyID(input.PolicyID); err != nil {
+		return nil, err
+	}
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("listTargetsForPolicy ensure org: %w", err)
+	}
+
+	pol, err := p.loadVisiblePolicy(goCtx, reqCtx.AccountID, input.PolicyID)
+	if err != nil {
+		return nil, fmt.Errorf("listTargetsForPolicy load: %w", err)
+	}
+	if pol == nil {
+		return nil, orgPolicyNotFound()
+	}
+
+	ids, err := p.loadPolicyTargets(goCtx, input.PolicyID)
+	if err != nil {
+		return nil, fmt.Errorf("listTargetsForPolicy load targets: %w", err)
+	}
+	page, next, err := orgPaginate(ids, input.NextToken, input.MaxResults)
+	if err != nil {
+		return nil, err
+	}
+
+	targets := make([]OrgPolicyTargetSummary, 0, len(page))
+	for _, id := range page {
+		summary, sumErr := p.policyTargetSummary(goCtx, reqCtx.AccountID, id)
+		if sumErr != nil {
+			return nil, fmt.Errorf("listTargetsForPolicy load target: %w", sumErr)
+		}
+		if summary == nil {
+			continue
+		}
+		targets = append(targets, *summary)
+	}
+
+	out := map[string]interface{}{"Targets": targets}
+	if next != "" {
+		out["NextToken"] = next
+	}
+	return orgJSONResponse(out, "listTargetsForPolicy")
+}
+
+// policyTargetSummary describes an attachment target, or returns (nil, nil) when
+// the entity behind the index entry has gone.
+func (p *OrganizationsPlugin) policyTargetSummary(ctx context.Context, acct, targetID string) (*OrgPolicyTargetSummary, error) {
+	switch {
+	case isOrgRootID(targetID):
+		root, err := p.loadRoot(ctx, acct)
+		if err != nil {
+			return nil, err
+		}
+		if root.ID != targetID {
+			return nil, nil //nolint:nilnil // (nil, nil) = "the entity has gone", skipped by caller.
+		}
+		return &OrgPolicyTargetSummary{TargetID: root.ID, Arn: root.Arn, Name: root.Name, Type: orgKindRoot}, nil
+	case isOrgOUID(targetID):
+		ou, err := p.loadOU(ctx, targetID)
+		if err != nil {
+			return nil, err
+		}
+		if ou == nil {
+			return nil, nil //nolint:nilnil // (nil, nil) = "the entity has gone", skipped by caller.
+		}
+		return &OrgPolicyTargetSummary{TargetID: ou.ID, Arn: ou.Arn, Name: ou.Name, Type: orgKindOU}, nil
+	default:
+		a, err := p.loadAccount(ctx, targetID)
+		if err != nil {
+			return nil, err
+		}
+		if a == nil {
+			return nil, nil //nolint:nilnil // (nil, nil) = "the entity has gone", skipped by caller.
+		}
+		return &OrgPolicyTargetSummary{TargetID: a.ID, Arn: a.Arn, Name: a.Name, Type: orgKindAccount}, nil
+	}
+}
+
+// --- EnablePolicyType ---
+
+func (p *OrganizationsPlugin) enablePolicyType(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	input, root, err := p.policyTypeRequest(goCtx, reqCtx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	available, err := p.policyTypeAvailable(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("enablePolicyType availability: %w", err)
+	}
+	// EnablePolicyType is the second operation whose model error list declares the
+	// feature-set refusal, and it is the natural place a caller lands after
+	// CreatePolicy told it the type is unavailable. Answering anything else here
+	// would send it round the same loop.
+	if !available || input.PolicyType != orgPolicyTypeSCP {
+		return nil, orgErr("PolicyTypeNotAvailableForOrganizationException",
+			"You can't use the specified policy type with the feature set currently enabled for this organization")
+	}
+	if scpEnabledOnStoredRoot(*root) {
+		return nil, orgErr("PolicyTypeAlreadyEnabledException", "The specified policy type is already enabled in the specified root")
+	}
+
+	root.PolicyTypes = append(root.PolicyTypes, OrgPolicyTypeSummary{Type: orgPolicyTypeSCP, Status: orgPolicyTypeStatusEnabled})
+	// The root is written before the attachments, because attachFullAWSAccess reads
+	// the root to decide whether the type is enabled at all.
+	if err := p.saveRoot(goCtx, reqCtx.AccountID, *root); err != nil {
+		return nil, fmt.Errorf("enablePolicyType save root: %w", err)
+	}
+
+	// Re-enabling restores only FullAWSAccess. The attachments a previous
+	// DisablePolicyType removed are gone, which is what the User Guide documents and
+	// what makes disable-then-enable a destructive round trip rather than a toggle:
+	// a caller that expected its SCPs back has to reattach them, and this is where
+	// it finds out.
+	entities, err := p.rootSubtree(goCtx, reqCtx.AccountID, root.ID)
+	if err != nil {
+		return nil, fmt.Errorf("enablePolicyType load entities: %w", err)
+	}
+	for _, id := range entities {
+		if _, err := p.attachPolicyTo(goCtx, orgFullAWSAccessID, id); err != nil {
+			return nil, fmt.Errorf("enablePolicyType attach FullAWSAccess: %w", err)
+		}
+	}
+	return orgJSONResponse(map[string]interface{}{"Root": orgRootWithPolicyTypes(*root)}, "enablePolicyType")
+}
+
+// --- DisablePolicyType ---
+
+func (p *OrganizationsPlugin) disablePolicyType(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	input, root, err := p.policyTypeRequest(goCtx, reqCtx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	available, err := p.policyTypeAvailable(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("disablePolicyType availability: %w", err)
+	}
+	// One code covers "never available", "not the type substrate models" and
+	// "already disabled", because PolicyTypeNotEnabledException is the only refusal
+	// DisablePolicyType's error list declares — the model gives it no feature-set
+	// code — and all three mean the same thing to the caller: there is nothing here
+	// to turn off.
+	if !available || input.PolicyType != orgPolicyTypeSCP || !scpEnabledOnStoredRoot(*root) {
+		return nil, orgErr("PolicyTypeNotEnabledException",
+			"The specified policy type isn't currently enabled in this root")
+	}
+
+	// Every SCP is detached from every entity in the root, and the attachments are
+	// not remembered. This is the User Guide's behavior, and it is the whole reason
+	// this operation exists in substrate: it is the only route to an all-features
+	// organization with SCPs off, the state where CreatePolicy still succeeds and
+	// nothing is enforced.
+	entities, err := p.rootSubtree(goCtx, reqCtx.AccountID, root.ID)
+	if err != nil {
+		return nil, fmt.Errorf("disablePolicyType load entities: %w", err)
+	}
+	for _, id := range entities {
+		attached, attErr := p.loadAttachments(goCtx, id)
+		if attErr != nil {
+			return nil, fmt.Errorf("disablePolicyType load attachments: %w", attErr)
+		}
+		for _, policyID := range attached {
+			if _, detErr := p.detachPolicyFrom(goCtx, policyID, id); detErr != nil {
+				return nil, fmt.Errorf("disablePolicyType detach: %w", detErr)
+			}
+		}
+	}
+
+	root.PolicyTypes = slices.DeleteFunc(root.PolicyTypes, func(pt OrgPolicyTypeSummary) bool {
+		return pt.Type == orgPolicyTypeSCP
+	})
+	if err := p.saveRoot(goCtx, reqCtx.AccountID, *root); err != nil {
+		return nil, fmt.Errorf("disablePolicyType save root: %w", err)
+	}
+	return orgJSONResponse(map[string]interface{}{"Root": orgRootWithPolicyTypes(*root)}, "disablePolicyType")
+}
+
+// orgPolicyTypeInput is the input EnablePolicyType and DisablePolicyType share.
+type orgPolicyTypeInput struct {
+	RootID     string `json:"RootId"`
+	PolicyType string `json:"PolicyType"`
+}
+
+// policyTypeRequest decodes and validates the input EnablePolicyType and
+// DisablePolicyType share, and returns the stored root. The stored root is
+// deliberately not the one loadRoot returns: loadRoot masks PolicyTypes under
+// CONSOLIDATED_BILLING, so writing it back would erase an enablement the
+// organization would get back if the feature-set seed were cleared.
+func (p *OrganizationsPlugin) policyTypeRequest(ctx context.Context, reqCtx *RequestContext, req *AWSRequest) (orgPolicyTypeInput, *OrgRoot, error) {
+	var input orgPolicyTypeInput
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return input, nil, err
+	}
+	if input.RootID == "" {
+		return input, nil, orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter RootId.")
+	}
+	if input.PolicyType == "" {
+		return input, nil, orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter PolicyType.")
+	}
+	if err := orgCheckPolicyType(input.PolicyType); err != nil {
+		return input, nil, err
+	}
+
+	root, err := p.loadStoredRoot(ctx, reqCtx.AccountID)
+	if err != nil {
+		return input, nil, fmt.Errorf("policy type request load root: %w", err)
+	}
+	// The root ID is checked before the feature set: a caller that named the wrong
+	// root has a different bug from one whose organization cannot hold the type, and
+	// telling it about the feature set would send it to fix the wrong thing.
+	if root.ID != input.RootID {
+		return input, nil, orgErr("RootNotFoundException", "We can't find a root with the RootId that you specified")
+	}
+	return input, root, nil
+}
+
+// scpEnabledOnStoredRoot reports whether root carries SERVICE_CONTROL_POLICY as
+// ENABLED.
+func scpEnabledOnStoredRoot(root OrgRoot) bool {
+	return slices.ContainsFunc(root.PolicyTypes, func(pt OrgPolicyTypeSummary) bool {
+		return pt.Type == orgPolicyTypeSCP && pt.Status == orgPolicyTypeStatusEnabled
+	})
+}
+
+// rootSubtree returns every entity a policy can be attached to: the root, every
+// OU, and every account. DisablePolicyType clears the attachments of all of them
+// and EnablePolicyType restores FullAWSAccess to all of them, which is what AWS
+// does — an OU or account created while the type was off would otherwise come back
+// with no SCP at all, and the minimum-attachment rule would then be unenforceable
+// for it.
+func (p *OrganizationsPlugin) rootSubtree(ctx context.Context, acct, rootID string) ([]string, error) {
+	entities := []string{rootID}
+	ouIDs, err := p.loadOUIDs(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	entities = append(entities, ouIDs...)
+	accountIDs, err := p.loadAccountIDs(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	return append(entities, accountIDs...), nil
+}
+
+// orgRootWithPolicyTypes returns the root with PolicyTypes as an empty list rather
+// than null when nothing is enabled. The model's member is a list, and a caller
+// ranging over a null gets a nil-pointer panic in a typed SDK rather than an empty
+// loop.
+func orgRootWithPolicyTypes(root OrgRoot) OrgRoot {
+	if root.PolicyTypes == nil {
+		root.PolicyTypes = []OrgPolicyTypeSummary{}
+	}
+	return root
+}
+
+// --- shared refusals ---
+
+// orgPolicyNotFound reports a policy the organization does not contain.
+func orgPolicyNotFound() *AWSError {
+	return orgErr("PolicyNotFoundException", "We can't find a policy with the PolicyId that you specified")
+}
+
+// orgTargetNotFound reports an attachment target the organization does not
+// contain.
+func orgTargetNotFound() *AWSError {
+	return orgErr("TargetNotFoundException",
+		"We can't find a root, OU, account, or policy with the TargetId that you specified")
+}
+
+// orgImmutablePolicy refuses a write to an AWS-managed policy. p-FullAWSAccess is
+// the only one substrate has, and the refusal matters because a teardown that
+// deletes every policy it can list would otherwise remove the policy the
+// minimum-attachment rule depends on.
+func orgImmutablePolicy() *AWSError {
+	return orgInvalidInput("IMMUTABLE_POLICY",
+		"You specified a policy that is managed by Amazon Web Services and can't be modified")
+}
+
+// --- input validation ---
+
+// orgPolicyIDSuffixLen is the length of the generated part of a policy ID. The
+// model gives two patterns for the same identity: PolicyId admits 8 to 128
+// characters, while PolicyArn requires 10 to 32 in the ARN it embeds. Ten
+// satisfies both, so a generated policy's ID and ARN are each valid against the
+// model's own pattern.
+const orgPolicyIDSuffixLen = 10
+
+// orgPolicyNumberLimitExceeded reports whether an organization already holding
+// count policies is at the quota. It is a function rather than an inline
+// comparison so the boundary can be pinned without creating orgMaxSCPsPerOrg
+// policies: an off-by-one here is invisible in every ordinary run.
+func orgPolicyNumberLimitExceeded(count int) bool { return count >= orgMaxSCPsPerOrg }
+
+// orgPolicyArn returns the ARN of an organization-owned policy. AWS-managed
+// policies use a different form, owned by "aws" rather than by the management
+// account; see orgFullAWSAccessArn.
+func orgPolicyArn(acct, orgID, policyID string) string {
+	return fmt.Sprintf("arn:aws:organizations::%s:policy/%s/service_control_policy/%s", acct, orgID, policyID)
+}
+
+// orgCheckPolicyType validates a PolicyType or a ListPolicies Filter against the
+// model's enum. A value outside the enum is a caller typo and gets
+// INVALID_ENUM_POLICY_TYPE; a valid value substrate does not model is refused
+// separately by each operation, because what the caller should do about it differs.
+func orgCheckPolicyType(policyType string) error {
+	if !slices.Contains(orgPolicyTypes, policyType) {
+		return orgInvalidInput("INVALID_ENUM_POLICY_TYPE", "You specified an invalid policy type string: "+policyType)
+	}
+	return nil
+}
+
+// orgCheckPolicyID validates a PolicyId against the model's pattern. A malformed ID
+// is INVALID_SYNTAX_POLICY_ID rather than PolicyNotFoundException, so a caller that
+// passed a policy name where an ID belongs learns that instead of concluding the
+// policy was deleted.
+func orgCheckPolicyID(policyID string) error {
+	if policyID == "" {
+		return orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter PolicyId.")
+	}
+	if !isOrgPolicyIDSyntax(policyID) {
+		return orgInvalidInput("INVALID_SYNTAX_POLICY_ID", "You specified an invalid policy ID: "+policyID)
+	}
+	return nil
+}
+
+// orgCheckTargetID validates a TargetId against the model's pattern, which admits
+// a root, a 12-digit account, or an OU — and not a policy ID.
+func orgCheckTargetID(targetID string) error {
+	if targetID == "" {
+		return orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter TargetId.")
+	}
+	if !isOrgTargetIDSyntax(targetID) {
+		return orgInvalidInput("INVALID_PATTERN_TARGET_ID", "You specified a target that doesn't match the required pattern: "+targetID)
+	}
+	return nil
+}
+
+// orgCheckPolicyName validates a policy name against the model's PolicyName shape
+// (1 to 128 characters).
+func orgCheckPolicyName(name string) error {
+	switch {
+	case name == "":
+		return orgInvalidInput("MIN_LENGTH_EXCEEDED", "You provided a name that is shorter than the minimum of 1 character")
+	case utf8.RuneCountInString(name) > orgMaxPolicyNameChars:
+		return orgInvalidInput("MAX_LENGTH_EXCEEDED",
+			fmt.Sprintf("You provided a name longer than the maximum of %d characters", orgMaxPolicyNameChars))
+	default:
+		return nil
+	}
+}
+
+// orgCheckPolicyDescription validates a description against the model's
+// PolicyDescription shape (up to 512 characters; empty is permitted).
+func orgCheckPolicyDescription(description string) error {
+	if utf8.RuneCountInString(description) > orgMaxPolicyDescriptionChars {
+		return orgInvalidInput("MAX_LENGTH_EXCEEDED",
+			fmt.Sprintf("You provided a description longer than the maximum of %d characters", orgMaxPolicyDescriptionChars))
+	}
+	return nil
+}
+
+// orgCheckPolicyContent validates an SCP document: the size quota first, then
+// whether it parses at all. The two are different refusals because they call for
+// different fixes — a document over the limit has to be split across policies,
+// while an unparseable one has to be corrected — and a caller cannot tell them
+// apart from one code.
+func orgCheckPolicyContent(content string) error {
+	if content == "" {
+		return orgInvalidInput("MIN_LENGTH_EXCEEDED", "You provided a policy document that is shorter than the minimum of 1 character")
+	}
+	// The quota is stated in characters, so a multi-byte document is measured in
+	// runes: counting bytes would refuse a document AWS accepts.
+	if utf8.RuneCountInString(content) > orgMaxSCPBytes {
+		return orgConstraintViolation("POLICY_CONTENT_LIMIT_EXCEEDED",
+			fmt.Sprintf("You have exceeded the maximum size of a policy document (%d characters)", orgMaxSCPBytes))
+	}
+	// Substrate does not evaluate an SCP, so it checks only that the document is a
+	// JSON object — the boundary between "the caller sent something a policy engine
+	// could read" and "the caller sent a string it never templated". Judging the
+	// statement semantics would be modeling the authorization engine, not the API.
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &doc); err != nil {
+		return orgErr("MalformedPolicyDocumentException",
+			"The provided policy document doesn't meet the requirements of the specified policy type: "+err.Error())
+	}
+	return nil
+}
+
+// Policy string-length quotas, from the model's PolicyName and PolicyDescription
+// shapes.
+const (
+	orgMaxPolicyNameChars        = 128
+	orgMaxPolicyDescriptionChars = 512
+)
+
+// policyNameTaken reports whether any policy other than exceptID already carries
+// name. FullAWSAccess is included: it is a policy of the organization, so a
+// caller cannot shadow its name either.
+func (p *OrganizationsPlugin) policyNameTaken(ctx context.Context, ids []string, name, exceptID string) (bool, error) {
+	if name == orgFullAWSAccessName && exceptID != orgFullAWSAccessID {
+		return true, nil
+	}
+	for _, id := range ids {
+		if id == exceptID {
+			continue
+		}
+		pol, err := p.loadPolicy(ctx, id)
+		if err != nil {
+			return false, err
+		}
+		if pol != nil && pol.PolicySummary.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// isOrgPolicyIDSyntax reports whether id matches the model's PolicyId pattern,
+// ^p-[0-9a-zA-Z_]{8,128}$.
+func isOrgPolicyIDSyntax(id string) bool {
+	rest, ok := strings.CutPrefix(id, "p-")
+	if !ok {
+		return false
+	}
+	return orgIDSegmentOK(rest, 8, 128, true)
+}
+
+// isOrgTargetIDSyntax reports whether id matches the model's PolicyTargetId
+// pattern: a root, a 12-digit account ID, or an OU.
+func isOrgTargetIDSyntax(id string) bool {
+	if len(id) == 12 && orgIDSegmentOK(id, 12, 12, false) && !strings.ContainsFunc(id, func(r rune) bool {
+		return r < '0' || r > '9'
+	}) {
+		return true
+	}
+	if rest, ok := strings.CutPrefix(id, "r-"); ok {
+		return orgIDSegmentOK(rest, 4, 32, false)
+	}
+	if rest, ok := strings.CutPrefix(id, "ou-"); ok {
+		parts := strings.Split(rest, "-")
+		if len(parts) != 2 {
+			return false
+		}
+		return orgIDSegmentOK(parts[0], 4, 32, false) && orgIDSegmentOK(parts[1], 8, 32, false)
+	}
+	return false
+}
+
+// orgIDSegmentOK reports whether s is minLen to maxLen characters drawn from
+// lowercase letters and digits, widening to uppercase letters and "_" when wide is
+// set — the two character classes the model's identifier patterns use.
+func orgIDSegmentOK(s string, minLen, maxLen int, wide bool) bool {
+	if len(s) < minLen || len(s) > maxLen {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+		case wide && (r >= 'A' && r <= 'Z' || r == '_'):
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/emulator/organizations_policy_export_test.go
+++ b/emulator/organizations_policy_export_test.go
@@ -1,0 +1,27 @@
+package emulator
+
+// This file exports the policy lifecycle's internals for the external test
+// package. It is separate from organizations_export_test.go so the policy cluster
+// can add what it needs without contending for a shared file, and it is compiled
+// only when running tests.
+
+// IsOrgPolicyIDSyntaxForTest wraps isOrgPolicyIDSyntax for external tests.
+func IsOrgPolicyIDSyntaxForTest(id string) bool { return isOrgPolicyIDSyntax(id) }
+
+// IsOrgTargetIDSyntaxForTest wraps isOrgTargetIDSyntax for external tests.
+func IsOrgTargetIDSyntaxForTest(id string) bool { return isOrgTargetIDSyntax(id) }
+
+// OrgPolicyNumberLimitExceededForTest wraps orgPolicyNumberLimitExceeded for
+// external tests, so the quota boundary can be pinned without creating
+// orgMaxSCPsPerOrg policies.
+func OrgPolicyNumberLimitExceededForTest(count int) bool { return orgPolicyNumberLimitExceeded(count) }
+
+// OrgMaxPolicyNameCharsForTest is the PolicyName shape's maximum length.
+const OrgMaxPolicyNameCharsForTest = orgMaxPolicyNameChars
+
+// OrgMaxPolicyDescriptionCharsForTest is the PolicyDescription shape's maximum
+// length.
+const OrgMaxPolicyDescriptionCharsForTest = orgMaxPolicyDescriptionChars
+
+// OrgPolicyIDSuffixLenForTest is the length of the generated part of a policy ID.
+const OrgPolicyIDSuffixLenForTest = orgPolicyIDSuffixLen

--- a/emulator/organizations_policy_test.go
+++ b/emulator/organizations_policy_test.go
@@ -1,0 +1,1738 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// --- helpers ---
+
+// orgPolicyDoc is a minimal well-formed SCP document, used wherever the content
+// itself is not what the test is about.
+const orgPolicyDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"iam:*","Resource":"*"}]}`
+
+// orgPolicyOK posts an operation, asserts 200, and decodes the body.
+func orgPolicyOK(t *testing.T, ts *httptest.Server, op string, body, out interface{}) {
+	t.Helper()
+	resp := orgsRequest(t, ts, op, body)
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		var errBody map[string]interface{}
+		_ = json.NewDecoder(resp.Body).Decode(&errBody) //nolint:errcheck
+		t.Fatalf("%s: expected 200, got %d (%v)", op, resp.StatusCode, errBody)
+	}
+	if out == nil {
+		return
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		t.Fatalf("%s decode: %v", op, err)
+	}
+}
+
+// orgPolicyRefused posts an operation and asserts it is refused at 400 with the
+// given error code, returning the message so a test can pin a reason. Every
+// Organizations exception is 400, so the status is pinned as well as the code.
+func orgPolicyRefused(t *testing.T, ts *httptest.Server, op string, body interface{}, wantCode string) string {
+	t.Helper()
+	resp := orgsRequest(t, ts, op, body)
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("%s: expected 400, got %d", op, resp.StatusCode)
+	}
+	var out struct {
+		Type    string `json:"__type"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("%s decode: %v", op, err)
+	}
+	if out.Type != wantCode {
+		t.Errorf("%s: expected __type=%s, got %q (%q)", op, wantCode, out.Type, out.Message)
+	}
+	return out.Message
+}
+
+// orgCreatePolicy creates an SCP and returns its ID.
+func orgCreatePolicy(t *testing.T, ts *httptest.Server, name string) string {
+	t.Helper()
+	var out struct {
+		Policy emulator.OrgPolicy `json:"Policy"`
+	}
+	orgPolicyOK(t, ts, "CreatePolicy", map[string]interface{}{
+		"Name":        name,
+		"Description": "created by " + t.Name(),
+		"Type":        emulator.OrgPolicyTypeSCPForTest,
+		"Content":     orgPolicyDoc,
+	}, &out)
+	if out.Policy.PolicySummary.ID == "" {
+		t.Fatalf("CreatePolicy %s: no policy ID in the response", name)
+	}
+	return out.Policy.PolicySummary.ID
+}
+
+// orgAttachedPolicies returns the policy IDs ListPoliciesForTarget reports for a
+// target, following NextToken so a paginated answer is not mistaken for a short one.
+func orgAttachedPolicies(t *testing.T, ts *httptest.Server, targetID string) []string {
+	t.Helper()
+	ids := []string{}
+	token := ""
+	for {
+		body := map[string]interface{}{"TargetId": targetID, "Filter": emulator.OrgPolicyTypeSCPForTest}
+		if token != "" {
+			body["NextToken"] = token
+		}
+		var out struct {
+			Policies  []emulator.OrgPolicySummary `json:"Policies"`
+			NextToken string                      `json:"NextToken"`
+		}
+		orgPolicyOK(t, ts, "ListPoliciesForTarget", body, &out)
+		for _, s := range out.Policies {
+			ids = append(ids, s.ID)
+		}
+		if out.NextToken == "" {
+			break
+		}
+		token = out.NextToken
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// orgSeedFeatureSet points the plugin's control plane at a feature set. The seed
+// wins over the stored value, so a CONSOLIDATED_BILLING organization is reachable
+// without recreating one.
+func orgSeedFeatureSet(t *testing.T, ts *httptest.Server, featureSet string) {
+	t.Helper()
+	body := strings.NewReader(`{"featureSet":"` + featureSet + `"}`)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/v1/organizations/feature-set", body)
+	if err != nil {
+		t.Fatalf("build feature-set seed: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("seed feature set: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed feature set: expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// --- the decisive tests ---
+
+// TestOrganizations_SCPDisabledCreateSucceedsAttachRefused is issue #578's point 6,
+// end to end. An all-features organization has SCPs enabled from creation, so the
+// unenforced state is only reachable by disabling — and once there, CreatePolicy
+// still succeeds while AttachPolicy refuses. A caller that treats create-then-attach
+// as one atomic step breaks exactly here, and would otherwise record a guardrail as
+// applied when nothing is evaluating it.
+func TestOrganizations_SCPDisabledCreateSucceedsAttachRefused(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+
+	var disabled struct {
+		Root emulator.OrgRoot `json:"Root"`
+	}
+	orgPolicyOK(t, ts, "DisablePolicyType", map[string]interface{}{
+		"RootId": rootID, "PolicyType": emulator.OrgPolicyTypeSCPForTest,
+	}, &disabled)
+	if len(disabled.Root.PolicyTypes) != 0 {
+		t.Errorf("expected no policy types on the root after disabling, got %+v", disabled.Root.PolicyTypes)
+	}
+
+	// Creating a policy is legal with the type off; only attaching is not.
+	policyID := orgCreatePolicy(t, ts, "deny-iam")
+
+	msg := orgPolicyRefused(t, ts, "AttachPolicy", map[string]interface{}{
+		"PolicyId": policyID, "TargetId": rootID,
+	}, "PolicyTypeNotEnabledException")
+	if msg == "" {
+		t.Error("expected the refusal to carry a message a caller can log")
+	}
+
+	// Nothing is attached anywhere while the type is off, including FullAWSAccess.
+	if got := orgAttachedPolicies(t, ts, rootID); len(got) != 0 {
+		t.Errorf("expected no attachments while the type is disabled, got %v", got)
+	}
+
+	// Re-enabling restores FullAWSAccess only. The policy created in between still
+	// exists, but it is not attached: disable-then-enable is a destructive round
+	// trip, not a toggle.
+	var reenabled struct {
+		Root emulator.OrgRoot `json:"Root"`
+	}
+	orgPolicyOK(t, ts, "EnablePolicyType", map[string]interface{}{
+		"RootId": rootID, "PolicyType": emulator.OrgPolicyTypeSCPForTest,
+	}, &reenabled)
+	if len(reenabled.Root.PolicyTypes) != 1 || reenabled.Root.PolicyTypes[0].Status != "ENABLED" {
+		t.Fatalf("expected SCP ENABLED on the root after re-enabling, got %+v", reenabled.Root.PolicyTypes)
+	}
+	want := []string{emulator.OrgFullAWSAccessIDForTest}
+	if got := orgAttachedPolicies(t, ts, rootID); !slices.Equal(got, want) {
+		t.Errorf("expected re-enabling to restore only FullAWSAccess, got %v", got)
+	}
+	var described struct {
+		Policy emulator.OrgPolicy `json:"Policy"`
+	}
+	orgPolicyOK(t, ts, "DescribePolicy", map[string]interface{}{"PolicyId": policyID}, &described)
+	if described.Policy.PolicySummary.ID != policyID {
+		t.Errorf("expected the policy created while disabled to survive, got %+v", described.Policy.PolicySummary)
+	}
+}
+
+// TestOrganizations_DisablePolicyTypeLosesPriorAttachments pins that the
+// attachments are *lost*, not remembered. The User Guide says so, and the
+// difference matters: a caller that disables the type to make a change and
+// re-enables it afterwards has silently removed every guardrail it had attached, and
+// only finds out if the emulator does not helpfully restore them.
+func TestOrganizations_DisablePolicyTypeLosesPriorAttachments(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+
+	policyID := orgCreatePolicy(t, ts, "deny-iam")
+	orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": policyID, "TargetId": rootID}, nil)
+	before := orgAttachedPolicies(t, ts, rootID)
+	if !slices.Contains(before, policyID) {
+		t.Fatalf("setup: expected the policy attached, got %v", before)
+	}
+
+	orgPolicyOK(t, ts, "DisablePolicyType", map[string]interface{}{
+		"RootId": rootID, "PolicyType": emulator.OrgPolicyTypeSCPForTest,
+	}, nil)
+	orgPolicyOK(t, ts, "EnablePolicyType", map[string]interface{}{
+		"RootId": rootID, "PolicyType": emulator.OrgPolicyTypeSCPForTest,
+	}, nil)
+
+	after := orgAttachedPolicies(t, ts, rootID)
+	if slices.Contains(after, policyID) {
+		t.Errorf("expected the prior attachment to be lost across a disable/enable round trip, got %v", after)
+	}
+	if !slices.Contains(after, emulator.OrgFullAWSAccessIDForTest) {
+		t.Errorf("expected FullAWSAccess restored on re-enable, got %v", after)
+	}
+
+	// Both directions of the index agree: the policy no longer names the root as a
+	// target either. A one-sided detach would have ListTargetsForPolicy contradict
+	// ListPoliciesForTarget, a state no sequence of API calls can produce.
+	var targets struct {
+		Targets []emulator.OrgPolicyTargetSummary `json:"Targets"`
+	}
+	orgPolicyOK(t, ts, "ListTargetsForPolicy", map[string]interface{}{"PolicyId": policyID}, &targets)
+	if len(targets.Targets) != 0 {
+		t.Errorf("expected the policy to name no targets after the round trip, got %+v", targets.Targets)
+	}
+}
+
+// TestOrganizations_DisablePolicyTypeClearsTheWholeSubtree asserts the clearing
+// reaches OUs and accounts, not just the root. AWS detaches from every entity in
+// the root; an emulator that cleared only the root would leave an account still
+// carrying an SCP that the root no longer evaluates, which is a state a caller
+// cannot reach through the API and so has no handling for.
+func TestOrganizations_DisablePolicyTypeClearsTheWholeSubtree(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+
+	// The management account exists from auto-creation and carries FullAWSAccess.
+	var accounts struct {
+		Accounts []emulator.OrgAccount `json:"Accounts"`
+	}
+	orgPolicyOK(t, ts, "ListAccounts", map[string]interface{}{}, &accounts)
+	if len(accounts.Accounts) == 0 {
+		t.Fatal("setup: expected the management account to exist")
+	}
+	acctID := accounts.Accounts[0].ID
+	if got := orgAttachedPolicies(t, ts, acctID); !slices.Contains(got, emulator.OrgFullAWSAccessIDForTest) {
+		t.Fatalf("setup: expected the account to carry FullAWSAccess, got %v", got)
+	}
+
+	orgPolicyOK(t, ts, "DisablePolicyType", map[string]interface{}{
+		"RootId": rootID, "PolicyType": emulator.OrgPolicyTypeSCPForTest,
+	}, nil)
+
+	for _, id := range []string{rootID, acctID} {
+		if got := orgAttachedPolicies(t, ts, id); len(got) != 0 {
+			t.Errorf("%s: expected every attachment cleared, got %v", id, got)
+		}
+	}
+
+	orgPolicyOK(t, ts, "EnablePolicyType", map[string]interface{}{
+		"RootId": rootID, "PolicyType": emulator.OrgPolicyTypeSCPForTest,
+	}, nil)
+	for _, id := range []string{rootID, acctID} {
+		want := []string{emulator.OrgFullAWSAccessIDForTest}
+		if got := orgAttachedPolicies(t, ts, id); !slices.Equal(got, want) {
+			t.Errorf("%s: expected FullAWSAccess restored, got %v", id, got)
+		}
+	}
+}
+
+// TestOrganizations_MinAttachmentFloor is the second decisive case. FullAWSAccess
+// can be detached from a target that has another SCP, but the last SCP cannot be
+// detached at all: in real AWS an entity with the type enabled and no SCP attached
+// denies everything, so a detach that emptied the set would produce the exact
+// opposite of what the caller intended, and produce it silently.
+func TestOrganizations_MinAttachmentFloor(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+	policyID := orgCreatePolicy(t, ts, "deny-iam")
+	orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": policyID, "TargetId": rootID}, nil)
+
+	// Two attached, so detaching FullAWSAccess is allowed — this is the documented
+	// way to replace the allow-everything default with a real guardrail.
+	orgPolicyOK(t, ts, "DetachPolicy", map[string]interface{}{
+		"PolicyId": emulator.OrgFullAWSAccessIDForTest, "TargetId": rootID,
+	}, nil)
+	want := []string{policyID}
+	if got := orgAttachedPolicies(t, ts, rootID); !slices.Equal(got, want) {
+		t.Fatalf("expected only the new policy attached, got %v", got)
+	}
+
+	// One left, so the floor fires.
+	msg := orgPolicyRefused(t, ts, "DetachPolicy", map[string]interface{}{
+		"PolicyId": policyID, "TargetId": rootID,
+	}, "ConstraintViolationException")
+	if !strings.HasPrefix(msg, "MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED:") {
+		t.Errorf("expected MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED, got %q", msg)
+	}
+	if got := orgAttachedPolicies(t, ts, rootID); !slices.Equal(got, want) {
+		t.Errorf("expected the refused detach to change nothing, got %v", got)
+	}
+	if emulator.OrgMinSCPsPerTargetForTest != 1 {
+		t.Errorf("expected the documented floor of 1 SCP per target, got %d", emulator.OrgMinSCPsPerTargetForTest)
+	}
+}
+
+// TestOrganizations_ConsolidatedBillingRefusesEveryPolicyOperation is the third.
+// Under CONSOLIDATED_BILLING the policy type does not exist at all, which is a
+// different problem from an all-features organization that has it switched off: the
+// first needs a migration, the second needs one API call. A caller branches on the
+// distinction, so the two must not collapse into one code.
+func TestOrganizations_ConsolidatedBillingRefusesEveryPolicyOperation(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+	// A policy created before the switch, so the refusals are about the feature set
+	// rather than about a policy that never existed.
+	policyID := orgCreatePolicy(t, ts, "deny-iam")
+	orgSeedFeatureSet(t, ts, "CONSOLIDATED_BILLING")
+
+	scp := emulator.OrgPolicyTypeSCPForTest
+	cases := []struct {
+		op       string
+		body     map[string]interface{}
+		wantCode string
+	}{
+		// These two declare PolicyTypeNotAvailableForOrganizationException in the
+		// model, and they are where a caller learns the feature set is the problem.
+		{"CreatePolicy", map[string]interface{}{
+			"Name": "another", "Description": "d", "Type": scp, "Content": orgPolicyDoc,
+		}, "PolicyTypeNotAvailableForOrganizationException"},
+		{"EnablePolicyType", map[string]interface{}{"RootId": rootID, "PolicyType": scp},
+			"PolicyTypeNotAvailableForOrganizationException"},
+
+		// The rest do not declare it, so they answer with the code their own error
+		// list carries. Emitting an undeclared exception would hand a caller
+		// something its SDK cannot catch by type.
+		{"DescribePolicy", map[string]interface{}{"PolicyId": policyID}, "PolicyNotFoundException"},
+		{"UpdatePolicy", map[string]interface{}{"PolicyId": policyID, "Name": "x"}, "PolicyNotFoundException"},
+		{"DeletePolicy", map[string]interface{}{"PolicyId": policyID}, "PolicyNotFoundException"},
+		{"AttachPolicy", map[string]interface{}{"PolicyId": policyID, "TargetId": rootID}, "PolicyNotFoundException"},
+		{"DetachPolicy", map[string]interface{}{"PolicyId": policyID, "TargetId": rootID}, "PolicyNotFoundException"},
+		{"ListTargetsForPolicy", map[string]interface{}{"PolicyId": policyID}, "PolicyNotFoundException"},
+		{"DisablePolicyType", map[string]interface{}{"RootId": rootID, "PolicyType": scp}, "PolicyTypeNotEnabledException"},
+	}
+	for _, c := range cases {
+		t.Run(c.op, func(t *testing.T) {
+			orgPolicyRefused(t, ts, c.op, c.body, c.wantCode)
+		})
+	}
+
+	// Even FullAWSAccess is invisible: it is an SCP, and no SCP exists in this mode.
+	t.Run("FullAWSAccess is invisible", func(t *testing.T) {
+		orgPolicyRefused(t, ts, "DescribePolicy",
+			map[string]interface{}{"PolicyId": emulator.OrgFullAWSAccessIDForTest}, "PolicyNotFoundException")
+	})
+
+	// The listings answer empty rather than refusing: the model gives them no code
+	// for this, and "no policies" is a truthful answer for an organization that can
+	// hold none.
+	t.Run("ListPolicies is empty", func(t *testing.T) {
+		var out struct {
+			Policies []emulator.OrgPolicySummary `json:"Policies"`
+		}
+		orgPolicyOK(t, ts, "ListPolicies", map[string]interface{}{"Filter": scp}, &out)
+		if len(out.Policies) != 0 {
+			t.Errorf("expected no policies under CONSOLIDATED_BILLING, got %+v", out.Policies)
+		}
+	})
+	t.Run("ListPoliciesForTarget is empty", func(t *testing.T) {
+		if got := orgAttachedPolicies(t, ts, rootID); len(got) != 0 {
+			t.Errorf("expected no attachments under CONSOLIDATED_BILLING, got %v", got)
+		}
+	})
+}
+
+// TestOrganizations_FullAWSAccessIsImmutable is the fourth. A teardown that deletes
+// every policy it can list must not be able to delete the one the minimum-
+// attachment rule depends on, and a caller that tries gets IMMUTABLE_POLICY rather
+// than a not-found it would read as "already cleaned up".
+func TestOrganizations_FullAWSAccessIsImmutable(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	full := emulator.OrgFullAWSAccessIDForTest
+
+	for _, c := range []struct {
+		op   string
+		body map[string]interface{}
+	}{
+		{"UpdatePolicy", map[string]interface{}{"PolicyId": full, "Name": "NotFullAccess"}},
+		{"UpdatePolicy", map[string]interface{}{"PolicyId": full, "Content": orgPolicyDoc}},
+		{"DeletePolicy", map[string]interface{}{"PolicyId": full}},
+	} {
+		t.Run(c.op, func(t *testing.T) {
+			msg := orgPolicyRefused(t, ts, c.op, c.body, "InvalidInputException")
+			if !strings.HasPrefix(msg, "IMMUTABLE_POLICY:") {
+				t.Errorf("expected IMMUTABLE_POLICY, got %q", msg)
+			}
+		})
+	}
+
+	// It is still there, still AWS-managed, and still owned by the "aws" account
+	// rather than by the management account.
+	var described struct {
+		Policy emulator.OrgPolicy `json:"Policy"`
+	}
+	orgPolicyOK(t, ts, "DescribePolicy", map[string]interface{}{"PolicyId": full}, &described)
+	wantSummary := emulator.FullAWSAccessPolicyForTest()
+	if described.Policy.PolicySummary != wantSummary.PolicySummary {
+		t.Errorf("expected FullAWSAccess unchanged, got %+v", described.Policy.PolicySummary)
+	}
+	if !strings.HasPrefix(described.Policy.PolicySummary.Arn, "arn:aws:organizations::aws:policy/") {
+		t.Errorf("expected the AWS-owned ARN form, got %q", described.Policy.PolicySummary.Arn)
+	}
+
+	var listed struct {
+		Policies []emulator.OrgPolicySummary `json:"Policies"`
+	}
+	orgPolicyOK(t, ts, "ListPolicies", map[string]interface{}{"Filter": emulator.OrgPolicyTypeSCPForTest}, &listed)
+	found := false
+	for _, s := range listed.Policies {
+		if s.ID == full {
+			found = true
+			if !s.AwsManaged {
+				t.Error("expected FullAWSAccess to report AwsManaged=true")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected FullAWSAccess in ListPolicies after the refused writes, got %+v", listed.Policies)
+	}
+}
+
+// TestOrganizations_AttachmentCapFiresOnTheEleventh is the fifth. The SCP quota is
+// 10 per target, not the 5 that belongs to resource control policies, so the cap
+// must fire on the 11th attachment — the 10th succeeding is as much the assertion
+// as the 11th failing.
+func TestOrganizations_AttachmentCapFiresOnTheEleventh(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+
+	if emulator.OrgMaxSCPsPerTargetForTest != 10 {
+		t.Fatalf("expected the documented SCP cap of 10 per target, got %d", emulator.OrgMaxSCPsPerTargetForTest)
+	}
+
+	// FullAWSAccess already occupies one slot, so nine more reach the cap.
+	created := make([]string, 0, emulator.OrgMaxSCPsPerTargetForTest)
+	for i := 1; i < emulator.OrgMaxSCPsPerTargetForTest; i++ {
+		id := orgCreatePolicy(t, ts, "deny-"+string(rune('a'+i)))
+		created = append(created, id)
+		orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": id, "TargetId": rootID}, nil)
+	}
+	if got := orgAttachedPolicies(t, ts, rootID); len(got) != emulator.OrgMaxSCPsPerTargetForTest {
+		t.Fatalf("expected exactly %d attachments at the cap, got %d (%v)",
+			emulator.OrgMaxSCPsPerTargetForTest, len(got), got)
+	}
+
+	overflow := orgCreatePolicy(t, ts, "deny-overflow")
+	msg := orgPolicyRefused(t, ts, "AttachPolicy", map[string]interface{}{
+		"PolicyId": overflow, "TargetId": rootID,
+	}, "ConstraintViolationException")
+	if !strings.HasPrefix(msg, "MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED:") {
+		t.Errorf("expected MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED, got %q", msg)
+	}
+
+	// Detaching one makes room again, so the cap is a live count rather than a
+	// high-water mark a caller can never recover from.
+	orgPolicyOK(t, ts, "DetachPolicy", map[string]interface{}{
+		"PolicyId": created[0], "TargetId": rootID,
+	}, nil)
+	orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": overflow, "TargetId": rootID}, nil)
+}
+
+// --- refusals ---
+
+// TestOrganizations_PolicyRefusals covers the remaining documented refusals, each
+// against the code its operation's error list in the API model declares. They are
+// the point of the lane: they are what a re-runnable governance script is built on,
+// and each one distinguishes a case a caller must handle differently.
+func TestOrganizations_PolicyRefusals(t *testing.T) {
+	scp := emulator.OrgPolicyTypeSCPForTest
+
+	t.Run("duplicate policy name", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		orgCreatePolicy(t, ts, "deny-iam")
+		// A re-run has to be able to tell "I already made this" from "I made it now",
+		// and the name is the only handle it has before it knows the ID.
+		orgPolicyRefused(t, ts, "CreatePolicy", map[string]interface{}{
+			"Name": "deny-iam", "Description": "d", "Type": scp, "Content": orgPolicyDoc,
+		}, "DuplicatePolicyException")
+	})
+
+	t.Run("duplicate name shadowing FullAWSAccess", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		// FullAWSAccess is a policy of the organization even though it is synthesized,
+		// so its name is taken too — a caller that shadowed it would get two policies
+		// answering to one name in its own bookkeeping.
+		orgPolicyRefused(t, ts, "CreatePolicy", map[string]interface{}{
+			"Name": "FullAWSAccess", "Description": "d", "Type": scp, "Content": orgPolicyDoc,
+		}, "DuplicatePolicyException")
+	})
+
+	t.Run("rename onto an existing name", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		orgCreatePolicy(t, ts, "deny-iam")
+		second := orgCreatePolicy(t, ts, "deny-s3")
+		orgPolicyRefused(t, ts, "UpdatePolicy", map[string]interface{}{
+			"PolicyId": second, "Name": "deny-iam",
+		}, "DuplicatePolicyException")
+	})
+
+	t.Run("rename to its own name", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		id := orgCreatePolicy(t, ts, "deny-iam")
+		// Not a duplicate: a re-applied update that sets the same name is the shape a
+		// declarative tool sends every run, and refusing it would make the tool
+		// non-convergent.
+		orgPolicyOK(t, ts, "UpdatePolicy", map[string]interface{}{"PolicyId": id, "Name": "deny-iam"}, nil)
+	})
+
+	t.Run("already attached", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		rootID := orgListRootsID(t, ts)
+		id := orgCreatePolicy(t, ts, "deny-iam")
+		orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": id, "TargetId": rootID}, nil)
+		// Attaching is not idempotent, which is the whole reason a re-run needs a
+		// distinguishable refusal rather than a silent success.
+		orgPolicyRefused(t, ts, "AttachPolicy", map[string]interface{}{
+			"PolicyId": id, "TargetId": rootID,
+		}, "DuplicatePolicyAttachmentException")
+	})
+
+	t.Run("detaching a policy that is not attached", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		rootID := orgListRootsID(t, ts)
+		id := orgCreatePolicy(t, ts, "deny-iam")
+		// Distinct from the min-attachment floor: nothing was there to remove, so a
+		// caller reconciling its own record of the attachment learns its record is
+		// stale rather than that it hit a quota.
+		orgPolicyRefused(t, ts, "DetachPolicy", map[string]interface{}{
+			"PolicyId": id, "TargetId": rootID,
+		}, "PolicyNotAttachedException")
+	})
+
+	t.Run("unknown policy", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		rootID := orgListRootsID(t, ts)
+		unknown := "p-99998888"
+		for _, c := range []struct {
+			op   string
+			body map[string]interface{}
+		}{
+			{"DescribePolicy", map[string]interface{}{"PolicyId": unknown}},
+			{"UpdatePolicy", map[string]interface{}{"PolicyId": unknown, "Name": "x"}},
+			{"DeletePolicy", map[string]interface{}{"PolicyId": unknown}},
+			{"AttachPolicy", map[string]interface{}{"PolicyId": unknown, "TargetId": rootID}},
+			{"DetachPolicy", map[string]interface{}{"PolicyId": unknown, "TargetId": rootID}},
+			{"ListTargetsForPolicy", map[string]interface{}{"PolicyId": unknown}},
+		} {
+			orgPolicyRefused(t, ts, c.op, c.body, "PolicyNotFoundException")
+		}
+	})
+
+	t.Run("unknown target", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		id := orgCreatePolicy(t, ts, "deny-iam")
+		// The policy is checked before the target on attach and detach, so an unknown
+		// target is only reachable with a real policy.
+		for _, op := range []string{"AttachPolicy", "DetachPolicy"} {
+			orgPolicyRefused(t, ts, op, map[string]interface{}{
+				"PolicyId": id, "TargetId": "999999999999",
+			}, "TargetNotFoundException")
+		}
+		orgPolicyRefused(t, ts, "ListPoliciesForTarget", map[string]interface{}{
+			"TargetId": "999999999999", "Filter": scp,
+		}, "TargetNotFoundException")
+	})
+
+	t.Run("a policy is not an attachment target", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		id := orgCreatePolicy(t, ts, "deny-iam")
+		// A policy ID resolves as an entity — it is taggable — but it is not
+		// attachable, and the TargetId pattern in the model does not admit one.
+		orgPolicyRefused(t, ts, "AttachPolicy", map[string]interface{}{
+			"PolicyId": id, "TargetId": id,
+		}, "InvalidInputException")
+	})
+
+	t.Run("deleting an attached policy", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		rootID := orgListRootsID(t, ts)
+		id := orgCreatePolicy(t, ts, "deny-iam")
+		orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": id, "TargetId": rootID}, nil)
+		// Refused rather than cascaded: a cascade would remove a guardrail from every
+		// entity it was attached to, and a teardown running in the wrong order would
+		// look like it worked.
+		orgPolicyRefused(t, ts, "DeletePolicy", map[string]interface{}{"PolicyId": id}, "PolicyInUseException")
+
+		// Detaching first makes the delete legal, and the policy is then gone from
+		// every listing.
+		orgPolicyOK(t, ts, "DetachPolicy", map[string]interface{}{"PolicyId": id, "TargetId": rootID}, nil)
+		orgPolicyOK(t, ts, "DeletePolicy", map[string]interface{}{"PolicyId": id}, nil)
+		orgPolicyRefused(t, ts, "DescribePolicy", map[string]interface{}{"PolicyId": id}, "PolicyNotFoundException")
+		var listed struct {
+			Policies []emulator.OrgPolicySummary `json:"Policies"`
+		}
+		orgPolicyOK(t, ts, "ListPolicies", map[string]interface{}{"Filter": scp}, &listed)
+		for _, s := range listed.Policies {
+			if s.ID == id {
+				t.Error("expected the deleted policy gone from ListPolicies")
+			}
+		}
+	})
+
+	t.Run("unparseable policy content", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		// A caller that shipped an untemplated string learns the document is the
+		// problem, not the request. Both create and update check it: an update that
+		// accepted garbage would leave a stored policy nothing could evaluate.
+		orgPolicyRefused(t, ts, "CreatePolicy", map[string]interface{}{
+			"Name": "broken", "Description": "d", "Type": scp, "Content": "not a policy",
+		}, "MalformedPolicyDocumentException")
+
+		id := orgCreatePolicy(t, ts, "deny-iam")
+		orgPolicyRefused(t, ts, "UpdatePolicy", map[string]interface{}{
+			"PolicyId": id, "Content": `{"Version":`,
+		}, "MalformedPolicyDocumentException")
+	})
+
+	t.Run("content over the character limit", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		if emulator.OrgMaxSCPBytesForTest != 10240 {
+			t.Fatalf("expected the documented SCP limit of 10240 characters, got %d", emulator.OrgMaxSCPBytesForTest)
+		}
+		// A well-formed document one character over the limit, so the refusal is about
+		// the size and not about the syntax — the two need different fixes (split the
+		// policy vs. correct it), so they must not share a code.
+		prefix := `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"iam:*","Resource":"`
+		suffix := `"}]}`
+		pad := emulator.OrgMaxSCPBytesForTest + 1 - len(prefix) - len(suffix)
+		oversize := prefix + strings.Repeat("x", pad) + suffix
+		if len(oversize) != emulator.OrgMaxSCPBytesForTest+1 {
+			t.Fatalf("test bug: built a %d-character document", len(oversize))
+		}
+		msg := orgPolicyRefused(t, ts, "CreatePolicy", map[string]interface{}{
+			"Name": "big", "Description": "d", "Type": scp, "Content": oversize,
+		}, "ConstraintViolationException")
+		if !strings.HasPrefix(msg, "POLICY_CONTENT_LIMIT_EXCEEDED:") {
+			t.Errorf("expected POLICY_CONTENT_LIMIT_EXCEEDED, got %q", msg)
+		}
+
+		// Exactly at the limit is accepted; the boundary is inclusive.
+		atLimit := prefix + strings.Repeat("x", pad-1) + suffix
+		orgPolicyOK(t, ts, "CreatePolicy", map[string]interface{}{
+			"Name": "at-limit", "Description": "d", "Type": scp, "Content": atLimit,
+		}, nil)
+	})
+
+	t.Run("policy type already enabled", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		rootID := orgListRootsID(t, ts)
+		// An all-features organization has SCPs on from creation, so the first
+		// EnablePolicyType a caller makes is already the second.
+		orgPolicyRefused(t, ts, "EnablePolicyType", map[string]interface{}{
+			"RootId": rootID, "PolicyType": scp,
+		}, "PolicyTypeAlreadyEnabledException")
+	})
+
+	t.Run("policy type not enabled", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		rootID := orgListRootsID(t, ts)
+		orgPolicyOK(t, ts, "DisablePolicyType", map[string]interface{}{"RootId": rootID, "PolicyType": scp}, nil)
+		orgPolicyRefused(t, ts, "DisablePolicyType", map[string]interface{}{
+			"RootId": rootID, "PolicyType": scp,
+		}, "PolicyTypeNotEnabledException")
+	})
+
+	t.Run("unknown root", func(t *testing.T) {
+		ts := newOrganizationsTestServer(t)
+		// Checked before the feature set: a caller that named the wrong root has a
+		// different bug from one whose organization cannot hold the type, and being
+		// told about the feature set would send it to fix the wrong thing.
+		for _, op := range []string{"EnablePolicyType", "DisablePolicyType"} {
+			orgPolicyRefused(t, ts, op, map[string]interface{}{
+				"RootId": "r-9999", "PolicyType": scp,
+			}, "RootNotFoundException")
+		}
+	})
+
+	t.Run("policy number limit", func(t *testing.T) {
+		// Asserted against the constant and the comparison rather than by creating
+		// 10,000 policies: the boundary is what an off-by-one would move, and the
+		// count is not reachable in a test that has to run in milliseconds.
+		if emulator.OrgMaxSCPsPerOrgForTest != 10000 {
+			t.Errorf("expected the documented limit of 10000 SCPs per organization, got %d",
+				emulator.OrgMaxSCPsPerOrgForTest)
+		}
+		for _, c := range []struct {
+			count int
+			want  bool
+		}{
+			{0, false},
+			{emulator.OrgMaxSCPsPerOrgForTest - 1, false},
+			{emulator.OrgMaxSCPsPerOrgForTest, true},
+			{emulator.OrgMaxSCPsPerOrgForTest + 1, true},
+		} {
+			if got := emulator.OrgPolicyNumberLimitExceededForTest(c.count); got != c.want {
+				t.Errorf("with %d policies stored: expected exceeded=%v, got %v", c.count, c.want, got)
+			}
+		}
+	})
+}
+
+// TestOrganizations_UnsupportedPolicyTypesAreRefused pins the distinction between a
+// policy type string the caller typo'd and one that is valid in the API model but
+// that substrate does not model. They call for different responses from the caller —
+// fix the string, versus do not expect this type here — so they get different codes.
+func TestOrganizations_UnsupportedPolicyTypesAreRefused(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+
+	t.Run("outside the enum", func(t *testing.T) {
+		for _, c := range []struct {
+			op   string
+			body map[string]interface{}
+		}{
+			{"CreatePolicy", map[string]interface{}{
+				"Name": "x", "Description": "d", "Type": "NOT_A_POLICY_TYPE", "Content": orgPolicyDoc,
+			}},
+			{"ListPolicies", map[string]interface{}{"Filter": "NOT_A_POLICY_TYPE"}},
+			{"ListPoliciesForTarget", map[string]interface{}{"TargetId": rootID, "Filter": "NOT_A_POLICY_TYPE"}},
+			{"EnablePolicyType", map[string]interface{}{"RootId": rootID, "PolicyType": "NOT_A_POLICY_TYPE"}},
+			{"DisablePolicyType", map[string]interface{}{"RootId": rootID, "PolicyType": "NOT_A_POLICY_TYPE"}},
+		} {
+			msg := orgPolicyRefused(t, ts, c.op, c.body, "InvalidInputException")
+			if !strings.HasPrefix(msg, "INVALID_ENUM_POLICY_TYPE:") {
+				t.Errorf("%s: expected INVALID_ENUM_POLICY_TYPE, got %q", c.op, msg)
+			}
+		}
+	})
+
+	t.Run("valid in the enum but not modeled", func(t *testing.T) {
+		// TAG_POLICY is a real AWS policy type. Substrate models only SCPs, so it is
+		// unavailable for this organization rather than an invalid string.
+		orgPolicyRefused(t, ts, "CreatePolicy", map[string]interface{}{
+			"Name": "tags", "Description": "d", "Type": "TAG_POLICY", "Content": orgPolicyDoc,
+		}, "PolicyTypeNotAvailableForOrganizationException")
+		orgPolicyRefused(t, ts, "EnablePolicyType", map[string]interface{}{
+			"RootId": rootID, "PolicyType": "TAG_POLICY",
+		}, "PolicyTypeNotAvailableForOrganizationException")
+		orgPolicyRefused(t, ts, "DisablePolicyType", map[string]interface{}{
+			"RootId": rootID, "PolicyType": "TAG_POLICY",
+		}, "PolicyTypeNotEnabledException")
+	})
+
+	t.Run("listings filtered to an unmodeled type are empty", func(t *testing.T) {
+		// An empty page rather than a refusal: an organization with no tag policies is
+		// exactly what AWS reports as an empty list, and these operations declare no
+		// code to refuse with.
+		var out struct {
+			Policies []emulator.OrgPolicySummary `json:"Policies"`
+		}
+		orgPolicyOK(t, ts, "ListPolicies", map[string]interface{}{"Filter": "TAG_POLICY"}, &out)
+		if len(out.Policies) != 0 {
+			t.Errorf("expected no TAG_POLICY policies, got %+v", out.Policies)
+		}
+		orgPolicyOK(t, ts, "ListPoliciesForTarget",
+			map[string]interface{}{"TargetId": rootID, "Filter": "TAG_POLICY"}, &out)
+		if len(out.Policies) != 0 {
+			t.Errorf("expected no TAG_POLICY attachments, got %+v", out.Policies)
+		}
+	})
+}
+
+// TestOrganizations_PolicyInputValidation covers the required-member and
+// syntax refusals. A malformed policy ID is a syntax error rather than a
+// not-found: a caller that passed a policy *name* where an ID belongs would
+// otherwise conclude the policy had been deleted and go on to recreate it.
+func TestOrganizations_PolicyInputValidation(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+	scp := emulator.OrgPolicyTypeSCPForTest
+
+	t.Run("required members", func(t *testing.T) {
+		cases := []struct {
+			name string
+			op   string
+			body map[string]interface{}
+		}{
+			// Description is required in the model even though it reads as optional.
+			{"CreatePolicy without Name", "CreatePolicy", map[string]interface{}{
+				"Description": "d", "Type": scp, "Content": orgPolicyDoc,
+			}},
+			{"CreatePolicy without Content", "CreatePolicy", map[string]interface{}{
+				"Name": "x", "Description": "d", "Type": scp,
+			}},
+			{"CreatePolicy without Description", "CreatePolicy", map[string]interface{}{
+				"Name": "x", "Type": scp, "Content": orgPolicyDoc,
+			}},
+			{"CreatePolicy without Type", "CreatePolicy", map[string]interface{}{
+				"Name": "x", "Description": "d", "Content": orgPolicyDoc,
+			}},
+			{"DescribePolicy without PolicyId", "DescribePolicy", map[string]interface{}{}},
+			{"UpdatePolicy without PolicyId", "UpdatePolicy", map[string]interface{}{"Name": "x"}},
+			{"DeletePolicy without PolicyId", "DeletePolicy", map[string]interface{}{}},
+			{"AttachPolicy without PolicyId", "AttachPolicy", map[string]interface{}{"TargetId": rootID}},
+			{"AttachPolicy without TargetId", "AttachPolicy", map[string]interface{}{"PolicyId": "p-11112222"}},
+			{"DetachPolicy without TargetId", "DetachPolicy", map[string]interface{}{"PolicyId": "p-11112222"}},
+			{"ListPolicies without Filter", "ListPolicies", map[string]interface{}{}},
+			{"ListPoliciesForTarget without Filter", "ListPoliciesForTarget",
+				map[string]interface{}{"TargetId": rootID}},
+			{"ListPoliciesForTarget without TargetId", "ListPoliciesForTarget",
+				map[string]interface{}{"Filter": scp}},
+			{"ListTargetsForPolicy without PolicyId", "ListTargetsForPolicy", map[string]interface{}{}},
+			{"EnablePolicyType without RootId", "EnablePolicyType", map[string]interface{}{"PolicyType": scp}},
+			{"EnablePolicyType without PolicyType", "EnablePolicyType", map[string]interface{}{"RootId": rootID}},
+			{"DisablePolicyType without RootId", "DisablePolicyType", map[string]interface{}{"PolicyType": scp}},
+			{"DisablePolicyType without PolicyType", "DisablePolicyType", map[string]interface{}{"RootId": rootID}},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				msg := orgPolicyRefused(t, ts, c.op, c.body, "InvalidInputException")
+				if !strings.HasPrefix(msg, "INPUT_REQUIRED:") {
+					t.Errorf("expected INPUT_REQUIRED, got %q", msg)
+				}
+			})
+		}
+	})
+
+	t.Run("malformed policy ID", func(t *testing.T) {
+		for _, id := range []string{"deny-iam", "p-short", "p-has!bang", "policy-11112222", "p-"} {
+			msg := orgPolicyRefused(t, ts, "DescribePolicy", map[string]interface{}{"PolicyId": id}, "InvalidInputException")
+			if !strings.HasPrefix(msg, "INVALID_SYNTAX_POLICY_ID:") {
+				t.Errorf("%q: expected INVALID_SYNTAX_POLICY_ID, got %q", id, msg)
+			}
+		}
+	})
+
+	t.Run("malformed target ID", func(t *testing.T) {
+		id := orgCreatePolicy(t, ts, "deny-target-syntax")
+		for _, target := range []string{"root", "12345", "00000000000a", "ou-abcd", "ou-ab-11112222"} {
+			msg := orgPolicyRefused(t, ts, "AttachPolicy",
+				map[string]interface{}{"PolicyId": id, "TargetId": target}, "InvalidInputException")
+			if !strings.HasPrefix(msg, "INVALID_PATTERN_TARGET_ID:") {
+				t.Errorf("%q: expected INVALID_PATTERN_TARGET_ID, got %q", target, msg)
+			}
+		}
+	})
+
+	t.Run("name and description lengths", func(t *testing.T) {
+		msg := orgPolicyRefused(t, ts, "CreatePolicy", map[string]interface{}{
+			"Name": strings.Repeat("n", 129), "Description": "d", "Type": scp, "Content": orgPolicyDoc,
+		}, "InvalidInputException")
+		if !strings.HasPrefix(msg, "MAX_LENGTH_EXCEEDED:") {
+			t.Errorf("expected MAX_LENGTH_EXCEEDED for a 129-character name, got %q", msg)
+		}
+		msg = orgPolicyRefused(t, ts, "CreatePolicy", map[string]interface{}{
+			"Name": "long-description", "Description": strings.Repeat("d", 513), "Type": scp, "Content": orgPolicyDoc,
+		}, "InvalidInputException")
+		if !strings.HasPrefix(msg, "MAX_LENGTH_EXCEEDED:") {
+			t.Errorf("expected MAX_LENGTH_EXCEEDED for a 513-character description, got %q", msg)
+		}
+		// An empty description is permitted; an empty *name* is not, and each is
+		// reachable only through UpdatePolicy, where an empty string is a value rather
+		// than an omission.
+		id := orgCreatePolicy(t, ts, "deny-lengths")
+		orgPolicyOK(t, ts, "UpdatePolicy", map[string]interface{}{"PolicyId": id, "Description": ""}, nil)
+		msg = orgPolicyRefused(t, ts, "UpdatePolicy",
+			map[string]interface{}{"PolicyId": id, "Name": ""}, "InvalidInputException")
+		if !strings.HasPrefix(msg, "MIN_LENGTH_EXCEEDED:") {
+			t.Errorf("expected MIN_LENGTH_EXCEEDED for an empty name, got %q", msg)
+		}
+		msg = orgPolicyRefused(t, ts, "UpdatePolicy",
+			map[string]interface{}{"PolicyId": id, "Content": ""}, "InvalidInputException")
+		if !strings.HasPrefix(msg, "MIN_LENGTH_EXCEEDED:") {
+			t.Errorf("expected MIN_LENGTH_EXCEEDED for empty content, got %q", msg)
+		}
+	})
+
+	t.Run("unparseable body", func(t *testing.T) {
+		// Every handler decodes before it does anything else, so a body no decoder can
+		// read is InvalidInputException rather than an answer computed from a
+		// zero-valued input.
+		for _, op := range []string{
+			"CreatePolicy", "UpdatePolicy", "DeletePolicy", "DescribePolicy", "ListPolicies",
+			"AttachPolicy", "DetachPolicy", "ListPoliciesForTarget", "ListTargetsForPolicy",
+			"EnablePolicyType", "DisablePolicyType",
+		} {
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", newOrgBadBody())
+			if err != nil {
+				t.Fatalf("%s: build request: %v", op, err)
+			}
+			req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+			req.Header.Set("X-Amz-Target", "Organizations_20161128."+op)
+			req.Host = "organizations.us-east-1.amazonaws.com"
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("%s: %v", op, err)
+			}
+			gotStatus := resp.StatusCode
+			resp.Body.Close() //nolint:errcheck
+			if gotStatus != http.StatusBadRequest {
+				t.Errorf("%s: expected 400 for an unparseable body, got %d", op, gotStatus)
+			}
+		}
+	})
+}
+
+// --- nominal shapes ---
+
+// TestOrganizations_PolicyLifecycleShapes pins the response shapes against the API
+// model: a wrong member name is invisible to a test that only checks the status, and
+// is exactly what breaks a typed SDK.
+func TestOrganizations_PolicyLifecycleShapes(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	scp := emulator.OrgPolicyTypeSCPForTest
+
+	var created struct {
+		Policy emulator.OrgPolicy `json:"Policy"`
+	}
+	orgPolicyOK(t, ts, "CreatePolicy", map[string]interface{}{
+		"Name": "deny-iam", "Description": "blocks IAM", "Type": scp, "Content": orgPolicyDoc,
+	}, &created)
+
+	summary := created.Policy.PolicySummary
+	if summary.Name != "deny-iam" || summary.Description != "blocks IAM" || summary.Type != scp {
+		t.Errorf("unexpected summary: %+v", summary)
+	}
+	if summary.AwsManaged {
+		t.Error("expected a caller-created policy to report AwsManaged=false")
+	}
+	if created.Policy.Content != orgPolicyDoc {
+		t.Errorf("expected the content echoed verbatim, got %q", created.Policy.Content)
+	}
+	// The ID and the ARN each have to satisfy the model's own pattern. PolicyId
+	// admits 8-128 characters after "p-" while the ARN pattern requires 10-32, so a
+	// generated suffix has to satisfy both.
+	if !emulator.IsOrgPolicyIDSyntaxForTest(summary.ID) {
+		t.Errorf("policy ID %q does not match the model's PolicyId pattern", summary.ID)
+	}
+	if len(strings.TrimPrefix(summary.ID, "p-")) < 10 {
+		t.Errorf("policy ID %q is too short for the ARN pattern's 10-character minimum", summary.ID)
+	}
+	var org struct {
+		Organization emulator.Organization `json:"Organization"`
+	}
+	orgPolicyOK(t, ts, "DescribeOrganization", map[string]interface{}{}, &org)
+	wantArn := "arn:aws:organizations::" + orgTestAccount + ":policy/" + org.Organization.ID +
+		"/service_control_policy/" + summary.ID
+	if summary.Arn != wantArn {
+		t.Errorf("expected ARN %q, got %q", wantArn, summary.Arn)
+	}
+
+	// DescribePolicy returns the same nested Policy{PolicySummary, Content}.
+	var described struct {
+		Policy emulator.OrgPolicy `json:"Policy"`
+	}
+	orgPolicyOK(t, ts, "DescribePolicy", map[string]interface{}{"PolicyId": summary.ID}, &described)
+	if described.Policy != created.Policy {
+		t.Errorf("expected DescribePolicy to match CreatePolicy, got %+v", described.Policy)
+	}
+
+	// UpdatePolicy is a partial update: an omitted member leaves the stored value
+	// alone. Collapsing omitted with empty would blank the description on a rename.
+	var updated struct {
+		Policy emulator.OrgPolicy `json:"Policy"`
+	}
+	orgPolicyOK(t, ts, "UpdatePolicy", map[string]interface{}{
+		"PolicyId": summary.ID, "Name": "deny-iam-v2",
+	}, &updated)
+	if updated.Policy.PolicySummary.Name != "deny-iam-v2" {
+		t.Errorf("expected the rename applied, got %q", updated.Policy.PolicySummary.Name)
+	}
+	if updated.Policy.PolicySummary.Description != "blocks IAM" {
+		t.Errorf("expected an omitted Description to be left alone, got %q", updated.Policy.PolicySummary.Description)
+	}
+	if updated.Policy.Content != orgPolicyDoc {
+		t.Errorf("expected an omitted Content to be left alone, got %q", updated.Policy.Content)
+	}
+	if updated.Policy.PolicySummary.ID != summary.ID || updated.Policy.PolicySummary.Arn != summary.Arn {
+		t.Error("expected an update to preserve the policy's identity")
+	}
+
+	// AttachPolicy, DetachPolicy and DeletePolicy have no output shape in the model,
+	// so they answer with an empty JSON object.
+	rootID := orgListRootsID(t, ts)
+	for _, c := range []struct {
+		op   string
+		body map[string]interface{}
+	}{
+		{"AttachPolicy", map[string]interface{}{"PolicyId": summary.ID, "TargetId": rootID}},
+		{"DetachPolicy", map[string]interface{}{"PolicyId": summary.ID, "TargetId": rootID}},
+		{"DeletePolicy", map[string]interface{}{"PolicyId": summary.ID}},
+	} {
+		resp := orgsRequest(t, ts, c.op, c.body)
+		body := make([]byte, 64)
+		n, _ := resp.Body.Read(body) //nolint:errcheck
+		gotStatus := resp.StatusCode
+		resp.Body.Close() //nolint:errcheck
+		if gotStatus != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d", c.op, gotStatus)
+		}
+		if got := string(body[:n]); got != "{}" {
+			t.Errorf("%s: expected an empty JSON object, got %q", c.op, got)
+		}
+	}
+}
+
+// TestOrganizations_ListTargetsForPolicyShapes pins the target summaries. Each of
+// the three kinds carries its own Type, ARN and Name, and a caller uses Type to
+// decide whether the attachment governs one account or a whole subtree.
+func TestOrganizations_ListTargetsForPolicyShapes(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+
+	var accounts struct {
+		Accounts []emulator.OrgAccount `json:"Accounts"`
+	}
+	orgPolicyOK(t, ts, "ListAccounts", map[string]interface{}{}, &accounts)
+	if len(accounts.Accounts) == 0 {
+		t.Fatal("setup: expected the management account")
+	}
+	acct := accounts.Accounts[0]
+
+	policyID := orgCreatePolicy(t, ts, "deny-iam")
+	for _, target := range []string{rootID, acct.ID} {
+		orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": policyID, "TargetId": target}, nil)
+	}
+
+	var out struct {
+		Targets []emulator.OrgPolicyTargetSummary `json:"Targets"`
+	}
+	orgPolicyOK(t, ts, "ListTargetsForPolicy", map[string]interface{}{"PolicyId": policyID}, &out)
+	byID := map[string]emulator.OrgPolicyTargetSummary{}
+	for _, s := range out.Targets {
+		byID[s.TargetID] = s
+	}
+	if len(byID) != 2 {
+		t.Fatalf("expected 2 targets, got %+v", out.Targets)
+	}
+	if got := byID[rootID]; got.Type != emulator.OrgKindRootForTest || got.Name != "Root" || got.Arn == "" {
+		t.Errorf("unexpected root target summary: %+v", got)
+	}
+	if got := byID[acct.ID]; got.Type != emulator.OrgKindAccountForTest || got.Name != acct.Name || got.Arn != acct.Arn {
+		t.Errorf("unexpected account target summary: %+v", got)
+	}
+
+	// FullAWSAccess reports its targets too, which is how a caller confirms a fresh
+	// organization is governed by the allow-everything default rather than by nothing.
+	orgPolicyOK(t, ts, "ListTargetsForPolicy",
+		map[string]interface{}{"PolicyId": emulator.OrgFullAWSAccessIDForTest}, &out)
+	if len(out.Targets) < 2 {
+		t.Errorf("expected FullAWSAccess attached to at least the root and the management account, got %+v", out.Targets)
+	}
+}
+
+// TestOrganizations_PolicyListPagination asserts every List* in the lane honors
+// MaxResults and NextToken. A caller that ignores NextToken gets a truncated answer
+// with no error, and for attachments that means concluding a policy is not attached
+// when it is — so the truncation has to be observable for the caller's paging loop
+// to be testable at all.
+func TestOrganizations_PolicyListPagination(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	rootID := orgListRootsID(t, ts)
+
+	ids := []string{emulator.OrgFullAWSAccessIDForTest}
+	for i := range 3 {
+		id := orgCreatePolicy(t, ts, "deny-"+string(rune('a'+i)))
+		ids = append(ids, id)
+		orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": id, "TargetId": rootID}, nil)
+	}
+	slices.Sort(ids)
+
+	t.Run("ListPolicies", func(t *testing.T) {
+		seen := []string{}
+		token := ""
+		for range len(ids) + 1 {
+			body := map[string]interface{}{"Filter": emulator.OrgPolicyTypeSCPForTest, "MaxResults": 2}
+			if token != "" {
+				body["NextToken"] = token
+			}
+			var out struct {
+				Policies  []emulator.OrgPolicySummary `json:"Policies"`
+				NextToken string                      `json:"NextToken"`
+			}
+			orgPolicyOK(t, ts, "ListPolicies", body, &out)
+			if len(out.Policies) > 2 {
+				t.Fatalf("expected MaxResults=2 honored, got %d", len(out.Policies))
+			}
+			for _, s := range out.Policies {
+				seen = append(seen, s.ID)
+			}
+			if out.NextToken == "" {
+				break
+			}
+			token = out.NextToken
+		}
+		slices.Sort(seen)
+		if !slices.Equal(seen, ids) {
+			t.Errorf("expected paging to see every policy exactly once: want %v, got %v", ids, seen)
+		}
+	})
+
+	t.Run("ListPoliciesForTarget", func(t *testing.T) {
+		var out struct {
+			Policies  []emulator.OrgPolicySummary `json:"Policies"`
+			NextToken string                      `json:"NextToken"`
+		}
+		orgPolicyOK(t, ts, "ListPoliciesForTarget", map[string]interface{}{
+			"TargetId": rootID, "Filter": emulator.OrgPolicyTypeSCPForTest, "MaxResults": 1,
+		}, &out)
+		if len(out.Policies) != 1 || out.NextToken == "" {
+			t.Fatalf("expected a truncated first page with a token, got %d policies and token %q",
+				len(out.Policies), out.NextToken)
+		}
+		// The full walk agrees with the truncated one, so the token is a cursor rather
+		// than a restart.
+		if got := orgAttachedPolicies(t, ts, rootID); !slices.Equal(got, ids) {
+			t.Errorf("expected paging to see every attachment: want %v, got %v", ids, got)
+		}
+	})
+
+	t.Run("ListTargetsForPolicy", func(t *testing.T) {
+		full := emulator.OrgFullAWSAccessIDForTest
+		var out struct {
+			Targets   []emulator.OrgPolicyTargetSummary `json:"Targets"`
+			NextToken string                            `json:"NextToken"`
+		}
+		orgPolicyOK(t, ts, "ListTargetsForPolicy",
+			map[string]interface{}{"PolicyId": full, "MaxResults": 1}, &out)
+		if len(out.Targets) != 1 || out.NextToken == "" {
+			t.Fatalf("expected a truncated first page with a token, got %d targets and token %q",
+				len(out.Targets), out.NextToken)
+		}
+	})
+
+	t.Run("stale token", func(t *testing.T) {
+		// A token naming no known ID is refused rather than silently restarting.
+		// Restarting is the worst answer available to a paging loop: it never
+		// terminates and there is no error to explain why.
+		for _, c := range []struct {
+			op   string
+			body map[string]interface{}
+		}{
+			{"ListPolicies", map[string]interface{}{
+				"Filter": emulator.OrgPolicyTypeSCPForTest, "NextToken": "bm90LWEtcmVhbC1pZA==",
+			}},
+			{"ListPoliciesForTarget", map[string]interface{}{
+				"TargetId": rootID, "Filter": emulator.OrgPolicyTypeSCPForTest, "NextToken": "bm90LWEtcmVhbC1pZA==",
+			}},
+			{"ListTargetsForPolicy", map[string]interface{}{
+				"PolicyId": emulator.OrgFullAWSAccessIDForTest, "NextToken": "bm90LWEtcmVhbC1pZA==",
+			}},
+		} {
+			msg := orgPolicyRefused(t, ts, c.op, c.body, "InvalidInputException")
+			if !strings.HasPrefix(msg, "INVALID_NEXT_TOKEN:") {
+				t.Errorf("%s: expected INVALID_NEXT_TOKEN, got %q", c.op, msg)
+			}
+		}
+	})
+}
+
+// TestOrganizations_ListPoliciesIncludesFullAWSAccessOnAFreshOrganization pins the
+// state of an organization nobody has touched. FullAWSAccess is synthesized rather
+// than stored, so a listing that read only the stored index would report no policies
+// at all — and a caller that concluded a fresh organization has no SCPs would also
+// conclude nothing is allowed, the reverse of the truth.
+func TestOrganizations_ListPoliciesIncludesFullAWSAccessOnAFreshOrganization(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	var out struct {
+		Policies  []emulator.OrgPolicySummary `json:"Policies"`
+		NextToken string                      `json:"NextToken"`
+	}
+	orgPolicyOK(t, ts, "ListPolicies", map[string]interface{}{"Filter": emulator.OrgPolicyTypeSCPForTest}, &out)
+	if len(out.Policies) != 1 {
+		t.Fatalf("expected exactly FullAWSAccess on a fresh organization, got %+v", out.Policies)
+	}
+	if out.NextToken != "" {
+		t.Errorf("expected no NextToken for a single-page listing, got %q", out.NextToken)
+	}
+	want := emulator.FullAWSAccessPolicyForTest().PolicySummary
+	if out.Policies[0] != want {
+		t.Errorf("expected %+v, got %+v", want, out.Policies[0])
+	}
+
+	// And it is attached to the root, which is what makes the min-attachment floor
+	// enforceable from the first request.
+	got := orgAttachedPolicies(t, ts, orgListRootsID(t, ts))
+	if !slices.Equal(got, []string{emulator.OrgFullAWSAccessIDForTest}) {
+		t.Errorf("expected FullAWSAccess attached to the root, got %v", got)
+	}
+}
+
+// TestOrganizations_PolicyDeleteRemovesTags asserts a deleted policy's tags go with
+// it. A later policy that reused the ID would otherwise inherit them, and since tags
+// reach the authorization decision that would fail open on a tag-gated policy.
+func TestOrganizations_PolicyDeleteRemovesTags(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	ts := newOrgPolicyServer(t, state)
+	p := emulator.NewOrganizationsPluginForTest(state, emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)))
+
+	var created struct {
+		Policy emulator.OrgPolicy `json:"Policy"`
+	}
+	orgPolicyOK(t, ts, "CreatePolicy", map[string]interface{}{
+		"Name": "deny-iam", "Description": "d", "Type": emulator.OrgPolicyTypeSCPForTest,
+		"Content": orgPolicyDoc,
+		"Tags":    []emulator.OrgTag{{Key: "Owner", Value: "platform"}},
+	}, &created)
+	id := created.Policy.PolicySummary.ID
+
+	orgPolicyOK(t, ts, "DeletePolicy", map[string]interface{}{"PolicyId": id}, nil)
+	orgPolicyRefused(t, ts, "DescribePolicy", map[string]interface{}{"PolicyId": id}, "PolicyNotFoundException")
+
+	tags, err := p.LoadTagsForTest(t.Context(), id)
+	if err != nil {
+		t.Fatalf("load tags: %v", err)
+	}
+	if len(tags) != 0 {
+		t.Errorf("expected the deleted policy's tags removed, got %+v", tags)
+	}
+}
+
+// TestOrganizations_PolicyAttachmentToAnOU covers the OU branch of the attachment
+// path. An OU is where a governance script actually attaches an SCP — attaching per
+// account is the thing OUs exist to avoid — and its summary carries a different Type
+// from a root's, which is how a caller tells "this governs one account" from "this
+// governs a subtree". The OU is created through the storage layer because the OU
+// operations belong to a different cluster; the attachment path being exercised is
+// the same one AttachPolicy takes for any target.
+func TestOrganizations_PolicyAttachmentToAnOU(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	ts := newOrgPolicyServer(t, state)
+	p := emulator.NewOrganizationsPluginForTest(state, emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)))
+	ctx := t.Context()
+
+	rootID := orgListRootsID(t, ts)
+	ouID := "ou-" + rootID[2:] + "-11112222"
+	ou := emulator.OrgOrganizationalUnit{
+		ID:   ouID,
+		Arn:  "arn:aws:organizations::" + orgTestAccount + ":ou/o-test/" + ouID,
+		Name: "prod",
+	}
+	if err := p.SaveOUForTest(ctx, orgTestAccount, ou); err != nil {
+		t.Fatalf("save OU: %v", err)
+	}
+	if err := p.PlaceChildForTest(ctx, rootID, ouID); err != nil {
+		t.Fatalf("place OU: %v", err)
+	}
+	if err := p.AttachFullAWSAccessForTest(ctx, orgTestAccount, ouID); err != nil {
+		t.Fatalf("attach FullAWSAccess to the OU: %v", err)
+	}
+
+	policyID := orgCreatePolicy(t, ts, "deny-iam")
+	orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": policyID, "TargetId": ouID}, nil)
+
+	var targets struct {
+		Targets []emulator.OrgPolicyTargetSummary `json:"Targets"`
+	}
+	orgPolicyOK(t, ts, "ListTargetsForPolicy", map[string]interface{}{"PolicyId": policyID}, &targets)
+	if len(targets.Targets) != 1 {
+		t.Fatalf("expected the OU as the only target, got %+v", targets.Targets)
+	}
+	got := targets.Targets[0]
+	if got.TargetID != ouID || got.Type != emulator.OrgKindOUForTest || got.Name != "prod" || got.Arn != ou.Arn {
+		t.Errorf("unexpected OU target summary: %+v", got)
+	}
+
+	// Disabling the type clears the OU's attachments too, and re-enabling restores
+	// FullAWSAccess to it. An OU left carrying an SCP the root no longer evaluates is
+	// a state no sequence of API calls can reach.
+	orgPolicyOK(t, ts, "DisablePolicyType",
+		map[string]interface{}{"RootId": rootID, "PolicyType": emulator.OrgPolicyTypeSCPForTest}, nil)
+	if attached := orgAttachedPolicies(t, ts, ouID); len(attached) != 0 {
+		t.Errorf("expected the OU's attachments cleared, got %v", attached)
+	}
+	orgPolicyOK(t, ts, "EnablePolicyType",
+		map[string]interface{}{"RootId": rootID, "PolicyType": emulator.OrgPolicyTypeSCPForTest}, nil)
+	want := []string{emulator.OrgFullAWSAccessIDForTest}
+	if attached := orgAttachedPolicies(t, ts, ouID); !slices.Equal(attached, want) {
+		t.Errorf("expected FullAWSAccess restored to the OU, got %v", attached)
+	}
+
+	// A target whose OU record has gone is skipped rather than summarized empty.
+	orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": policyID, "TargetId": ouID}, nil)
+	if err := state.Delete(ctx, "organizations", "ou:"+ouID); err != nil {
+		t.Fatalf("delete OU record: %v", err)
+	}
+	orgPolicyOK(t, ts, "ListTargetsForPolicy", map[string]interface{}{"PolicyId": policyID}, &targets)
+	if len(targets.Targets) != 0 {
+		t.Errorf("expected the vanished OU skipped, got %+v", targets.Targets)
+	}
+}
+
+// TestOrganizations_TargetSummarySkipsAVanishedRoot covers the root branch of the
+// same skip. The root ID is stable for the life of the state store, so the only way
+// its record disagrees with an attachment index is a store written by something
+// else — and answering with a half-filled summary would put an empty Id in front of
+// a caller that has no way to trace it.
+func TestOrganizations_TargetSummarySkipsAVanishedRoot(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	ts := newOrgPolicyServer(t, state)
+	rootID := orgListRootsID(t, ts)
+	policyID := orgCreatePolicy(t, ts, "deny-iam")
+	orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": policyID, "TargetId": rootID}, nil)
+
+	// A stale root ID in the attachment index, as a store rewritten under the
+	// emulator would leave it.
+	stale := "r-999a"
+	if err := state.Put(t.Context(), "organizations", "policy_targets:"+policyID,
+		[]byte(`["`+stale+`"]`)); err != nil {
+		t.Fatalf("rewrite the target index: %v", err)
+	}
+
+	var targets struct {
+		Targets []emulator.OrgPolicyTargetSummary `json:"Targets"`
+	}
+	orgPolicyOK(t, ts, "ListTargetsForPolicy", map[string]interface{}{"PolicyId": policyID}, &targets)
+	if len(targets.Targets) != 0 {
+		t.Errorf("expected a root ID that is not this organization's root to be skipped, got %+v", targets.Targets)
+	}
+}
+
+// --- store failures and corrupt records ---
+
+// newOrgPolicyServer wires a plugin over the supplied state manager onto an HTTP
+// server, so the policy operations can be driven while the store misbehaves.
+func newOrgPolicyServer(t *testing.T, state emulator.StateManager) *httptest.Server {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: false})
+	tc := emulator.NewTimeController(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	logger := emulator.NewDefaultLogger(0, false)
+
+	p := &emulator.OrganizationsPlugin{}
+	if err := p.Initialize(t.Context(), emulator.PluginConfig{ //nolint:contextcheck
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	registry.Register(p)
+
+	cfg := emulator.DefaultConfig()
+	ts := httptest.NewServer(emulator.NewServer(*cfg, registry, store, state, tc, logger))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// orgPolicyStoreGroup is a set of operations that all read one state-key prefix
+// and all need the same warm-up. The mapping is spelled out rather than asserted
+// loosely ("some error happened") because a loose assertion passes when an
+// operation stops reading a store it needs — and an operation answering from a
+// store it never consulted is exactly the bug this covers.
+type orgPolicyStoreGroup struct {
+	// name is the subtest name; two groups can share a prefix with different
+	// warm-ups.
+	name string
+
+	// prefix is the state-key prefix the fault applies to.
+	prefix string
+
+	// ops are the operations expected to read it.
+	ops []string
+
+	// disableSCP turns the policy type off before the fault is armed. It is the
+	// only way to reach EnablePolicyType's body: an all-features organization starts
+	// enabled, so the request would otherwise stop at
+	// PolicyTypeAlreadyEnabledException and the test would pass having exercised
+	// nothing.
+	disableSCP bool
+
+	// useFullAWSAccess drives the operation against p-FullAWSAccess, which is the
+	// only policy attached to anything after warm-up and so the only one whose
+	// target summaries are built at all.
+	useFullAWSAccess bool
+}
+
+// orgPolicyStoreReads is the prefix-to-operation map the store-fault and
+// corrupt-record tests share.
+var orgPolicyStoreReads = []orgPolicyStoreGroup{
+	{name: "policy", prefix: "policy:", ops: []string{
+		"CreatePolicy", "UpdatePolicy", "DeletePolicy", "DescribePolicy", "ListPolicies",
+		"AttachPolicy", "DetachPolicy", "ListTargetsForPolicy",
+	}},
+	{name: "policy_ids", prefix: "policy_ids:", ops: []string{
+		"CreatePolicy", "UpdatePolicy", "DeletePolicy", "ListPolicies",
+	}},
+	{name: "attachments", prefix: "attachments:", ops: []string{
+		"AttachPolicy", "DetachPolicy", "ListPoliciesForTarget", "DisablePolicyType",
+	}},
+	{name: "attachments on enable", prefix: "attachments:", disableSCP: true,
+		ops: []string{"EnablePolicyType"}},
+	{name: "policy_targets", prefix: "policy_targets:", ops: []string{
+		"DeletePolicy", "ListTargetsForPolicy", "DisablePolicyType",
+	}},
+	{name: "policy_targets on enable", prefix: "policy_targets:", disableSCP: true,
+		ops: []string{"EnablePolicyType"}},
+	{name: "root", prefix: "root:", ops: []string{
+		"AttachPolicy", "DetachPolicy", "ListPoliciesForTarget", "EnablePolicyType", "DisablePolicyType",
+	}},
+	// The feature-set seed decides whether SCPs exist at all, so every operation in
+	// the lane consults it. A failure to read it must not default to "available":
+	// that would have the emulator answer as though the organization were
+	// all-features when it cannot tell, and a consolidated-billing test would then
+	// silently exercise the wrong path while passing.
+	{name: "feature-set seed", prefix: "feature-set", ops: []string{
+		"CreatePolicy", "UpdatePolicy", "DeletePolicy", "DescribePolicy", "ListPolicies",
+		"AttachPolicy", "DetachPolicy", "ListPoliciesForTarget", "ListTargetsForPolicy",
+		"EnablePolicyType", "DisablePolicyType",
+	}},
+	// EnablePolicyType and DisablePolicyType walk every entity in the root, so they
+	// depend on the OU and account indexes. A partial walk is the dangerous outcome:
+	// some entities cleared and others not is a state no sequence of API calls can
+	// produce, and no caller has handling for it.
+	{name: "ou_ids on enable", prefix: "ou_ids:", disableSCP: true, ops: []string{"EnablePolicyType"}},
+	{name: "ou_ids on disable", prefix: "ou_ids:", ops: []string{"DisablePolicyType"}},
+	{name: "account_ids on enable", prefix: "account_ids:", disableSCP: true, ops: []string{"EnablePolicyType"}},
+	{name: "account_ids on disable", prefix: "account_ids:", ops: []string{"DisablePolicyType"}},
+	// ListTargetsForPolicy summarizes each target from its own record.
+	{name: "account", prefix: "account:", useFullAWSAccess: true, ops: []string{"ListTargetsForPolicy"}},
+}
+
+// orgPolicyOpBody returns a well-formed request body for op, so a fault-injection
+// test reaches the store rather than stopping at validation.
+func orgPolicyOpBody(op, rootID, policyID string) map[string]interface{} {
+	scp := emulator.OrgPolicyTypeSCPForTest
+	switch op {
+	case "CreatePolicy":
+		return map[string]interface{}{"Name": "another", "Description": "d", "Type": scp, "Content": orgPolicyDoc}
+	case "UpdatePolicy":
+		return map[string]interface{}{"PolicyId": policyID, "Name": "renamed"}
+	case "DeletePolicy", "DescribePolicy", "ListTargetsForPolicy":
+		return map[string]interface{}{"PolicyId": policyID}
+	case "ListPolicies":
+		return map[string]interface{}{"Filter": scp}
+	case "AttachPolicy", "DetachPolicy":
+		return map[string]interface{}{"PolicyId": policyID, "TargetId": rootID}
+	case "ListPoliciesForTarget":
+		return map[string]interface{}{"TargetId": rootID, "Filter": scp}
+	case "EnablePolicyType", "DisablePolicyType":
+		return map[string]interface{}{"RootId": rootID, "PolicyType": scp}
+	default:
+		return map[string]interface{}{}
+	}
+}
+
+// orgPolicyFaultWarmUp brings an organization, a root and a policy into existence
+// before a fault is armed, and returns the root and policy IDs the group's
+// operations should name. Warming up first is what makes the fault reach the
+// operation rather than the setup.
+func orgPolicyFaultWarmUp(t *testing.T, ts *httptest.Server, group orgPolicyStoreGroup) (rootID, policyID string) {
+	t.Helper()
+	rootID = orgListRootsID(t, ts)
+	policyID = orgCreatePolicy(t, ts, "deny-iam")
+	if group.useFullAWSAccess {
+		policyID = emulator.OrgFullAWSAccessIDForTest
+	}
+	if group.disableSCP {
+		orgPolicyOK(t, ts, "DisablePolicyType", map[string]interface{}{
+			"RootId": rootID, "PolicyType": emulator.OrgPolicyTypeSCPForTest,
+		}, nil)
+	}
+	return rootID, policyID
+}
+
+// TestOrganizations_PolicyStoreFailureIsInternalFailure asserts a store failure
+// reaching a policy operation is a 500 InternalFailure, which an SDK retries, rather
+// than a 400 it treats as terminal. Collapsing a transient store failure into a
+// refusal would send a consumer down a permanent-failure path over a blip — and for
+// AttachPolicy specifically, a 400 would read as "the guardrail cannot be applied"
+// when the truth is "we could not tell".
+func TestOrganizations_PolicyStoreFailureIsInternalFailure(t *testing.T) {
+	for _, group := range orgPolicyStoreReads {
+		t.Run(group.name, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			state := &errOrgState{inner: inner, prefix: group.prefix, err: errors.New("store unavailable"), onGet: true}
+			ts := newOrgPolicyServer(t, state)
+			rootID, policyID := orgPolicyFaultWarmUp(t, ts, group)
+			state.armed = true
+
+			for _, op := range group.ops {
+				resp := orgsRequest(t, ts, op, orgPolicyOpBody(op, rootID, policyID))
+				gotStatus := resp.StatusCode
+				resp.Body.Close() //nolint:errcheck
+				if gotStatus != http.StatusInternalServerError {
+					t.Errorf("%s: expected 500 while %s reads were failing, got %d", op, group.prefix, gotStatus)
+				}
+			}
+		})
+	}
+}
+
+// TestOrganizations_PolicyWriteFailureIsNotASuccess asserts a failed write is never
+// reported as a completed change. A CreatePolicy that answers 200 while the record
+// never landed is the worst outcome available: the caller records a policy ID that
+// no subsequent call can find, and a governance script believes a guardrail exists.
+func TestOrganizations_PolicyWriteFailureIsNotASuccess(t *testing.T) {
+	scp := emulator.OrgPolicyTypeSCPForTest
+	cases := []struct {
+		name   string
+		prefix string
+		op     string
+		// disableFirst turns the policy type off during warm-up, which is the only
+		// way to reach EnablePolicyType's write path — an all-features organization
+		// starts enabled, so an armed store would otherwise be masked by
+		// PolicyTypeAlreadyEnabledException and the test would pass having exercised
+		// nothing.
+		disableFirst bool
+	}{
+		{name: "create record", prefix: "policy:", op: "CreatePolicy"},
+		{name: "create index", prefix: "policy_ids:", op: "CreatePolicy"},
+		{name: "attach", prefix: "attachments:", op: "AttachPolicy"},
+		{name: "attach reverse index", prefix: "policy_targets:", op: "AttachPolicy"},
+		{name: "enable", prefix: "root:", op: "EnablePolicyType", disableFirst: true},
+		{name: "disable", prefix: "root:", op: "DisablePolicyType"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			state := &errOrgState{inner: inner, prefix: c.prefix, err: errors.New("store unavailable"), onPut: true}
+			ts := newOrgPolicyServer(t, state)
+			rootID := orgListRootsID(t, ts)
+			policyID := orgCreatePolicy(t, ts, "deny-iam")
+			if c.disableFirst {
+				orgPolicyOK(t, ts, "DisablePolicyType",
+					map[string]interface{}{"RootId": rootID, "PolicyType": scp}, nil)
+			}
+			state.armed = true
+
+			resp := orgsRequest(t, ts, c.op, orgPolicyOpBody(c.op, rootID, policyID))
+			gotStatus := resp.StatusCode
+			resp.Body.Close() //nolint:errcheck
+			if gotStatus != http.StatusInternalServerError {
+				t.Errorf("%s: expected 500 while %s writes were failing, got %d", c.op, c.prefix, gotStatus)
+			}
+		})
+	}
+}
+
+// TestOrganizations_PolicyDeleteFailureIsNotASuccess covers the delete path's
+// writes. A delete reported successful with the record still in the store leaves a
+// policy a listing still shows, which a teardown script reads as a leak it cannot
+// clean up.
+func TestOrganizations_PolicyDeleteFailureIsNotASuccess(t *testing.T) {
+	for _, prefix := range []string{"policy:", "policy_ids:"} {
+		t.Run(prefix, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			state := &errOrgState{
+				inner: inner, prefix: prefix, err: errors.New("store unavailable"),
+				onDelete: true, onPut: true,
+			}
+			ts := newOrgPolicyServer(t, state)
+			policyID := orgCreatePolicy(t, ts, "deny-iam")
+			state.armed = true
+
+			resp := orgsRequest(t, ts, "DeletePolicy", map[string]interface{}{"PolicyId": policyID})
+			gotStatus := resp.StatusCode
+			resp.Body.Close() //nolint:errcheck
+			if gotStatus == http.StatusOK {
+				t.Errorf("DeletePolicy answered 200 while %s writes were failing", prefix)
+			}
+		})
+	}
+}
+
+// TestOrganizations_CorruptPolicyRecordIsAnError asserts an unreadable policy is
+// reported rather than treated as absent. Absent is the dangerous direction: the
+// caller's next step is to create the policy again, on top of one that is still in
+// the store, and it would then hold two IDs for one guardrail.
+func TestOrganizations_CorruptPolicyRecordIsAnError(t *testing.T) {
+	for _, group := range orgPolicyStoreReads {
+		t.Run(group.name, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			state := &corruptOrgState{StateManager: inner, prefix: group.prefix}
+			ts := newOrgPolicyServer(t, state)
+			rootID, policyID := orgPolicyFaultWarmUp(t, ts, group)
+			state.armed = true
+
+			for _, op := range group.ops {
+				resp := orgsRequest(t, ts, op, orgPolicyOpBody(op, rootID, policyID))
+				gotStatus := resp.StatusCode
+				resp.Body.Close() //nolint:errcheck
+				if gotStatus != http.StatusInternalServerError {
+					t.Errorf("%s: expected 500 over an unreadable %s record, got %d", op, group.prefix, gotStatus)
+				}
+			}
+		})
+	}
+}
+
+// TestOrganizations_ListingsSkipVanishedRecords asserts a listing tolerates an index
+// entry whose record is gone rather than reporting a zero-valued member. A summary
+// with an empty Id is worse than a short page: a consumer iterating it calls
+// DescribePolicy with "" and gets a refusal it has nothing to trace to.
+func TestOrganizations_ListingsSkipVanishedRecords(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	ts := newOrgPolicyServer(t, state)
+	rootID := orgListRootsID(t, ts)
+	policyID := orgCreatePolicy(t, ts, "deny-iam")
+	orgPolicyOK(t, ts, "AttachPolicy", map[string]interface{}{"PolicyId": policyID, "TargetId": rootID}, nil)
+
+	// The indexes still name the policy; its record does not exist.
+	if err := state.Delete(t.Context(), "organizations", "policy:"+policyID); err != nil {
+		t.Fatalf("delete policy record: %v", err)
+	}
+
+	var out struct {
+		Policies []emulator.OrgPolicySummary `json:"Policies"`
+	}
+	orgPolicyOK(t, ts, "ListPolicies", map[string]interface{}{"Filter": emulator.OrgPolicyTypeSCPForTest}, &out)
+	for _, s := range out.Policies {
+		if s.ID == "" || s.ID == policyID {
+			t.Errorf("expected the vanished policy skipped rather than listed empty, got %+v", out.Policies)
+		}
+	}
+	if got := orgAttachedPolicies(t, ts, rootID); slices.Contains(got, policyID) {
+		t.Errorf("expected the vanished policy skipped in the target listing, got %v", got)
+	}
+
+	// The same for a target whose entity has gone.
+	var accounts struct {
+		Accounts []emulator.OrgAccount `json:"Accounts"`
+	}
+	orgPolicyOK(t, ts, "ListAccounts", map[string]interface{}{}, &accounts)
+	if len(accounts.Accounts) == 0 {
+		t.Fatal("setup: expected the management account")
+	}
+	if err := state.Delete(t.Context(), "organizations", "account:"+accounts.Accounts[0].ID); err != nil {
+		t.Fatalf("delete account record: %v", err)
+	}
+	var targets struct {
+		Targets []emulator.OrgPolicyTargetSummary `json:"Targets"`
+	}
+	orgPolicyOK(t, ts, "ListTargetsForPolicy",
+		map[string]interface{}{"PolicyId": emulator.OrgFullAWSAccessIDForTest}, &targets)
+	for _, s := range targets.Targets {
+		if s.TargetID == "" {
+			t.Errorf("expected the vanished target skipped rather than summarized empty, got %+v", targets.Targets)
+		}
+	}
+}
+
+// TestOrganizations_PolicyIDSyntaxUnits exercises the identifier matchers directly.
+// They stand in for the model's regexes, and a matcher that is too permissive turns
+// a caller's typo into a not-found — a wrong diagnosis rather than a refused
+// request — so the boundary lengths are worth pinning without an HTTP round trip.
+func TestOrganizations_PolicyIDSyntaxUnits(t *testing.T) {
+	t.Run("policy ID", func(t *testing.T) {
+		cases := map[string]bool{
+			"p-11112222":                       true,
+			"p-Full_AWSAccess":                 true,
+			emulator.OrgFullAWSAccessIDForTest: true,
+			"p-" + strings.Repeat("a", 8):      true,
+			"p-" + strings.Repeat("a", 128):    true,
+			"p-" + strings.Repeat("a", 7):      false,
+			"p-" + strings.Repeat("a", 129):    false,
+			"p-with-dash":                      false,
+			"p-":                               false,
+			"":                                 false,
+			"r-abcd":                           false,
+			"11112222":                         false,
+		}
+		for id, want := range cases {
+			if got := emulator.IsOrgPolicyIDSyntaxForTest(id); got != want {
+				t.Errorf("%q: expected %v, got %v", id, want, got)
+			}
+		}
+	})
+
+	t.Run("target ID", func(t *testing.T) {
+		cases := map[string]bool{
+			"r-abcd":                             true,
+			"r-" + strings.Repeat("a", 32):       true,
+			"000000000000":                       true,
+			"ou-abcd-11112222":                   true,
+			"ou-abcd-" + strings.Repeat("a", 32): true,
+			"r-abc":                              false,
+			"r-ABCD":                             false,
+			"00000000000":                        false,
+			"0000000000000":                      false,
+			"00000000000a":                       false,
+			"ou-abcd":                            false,
+			"ou-abc-11112222":                    false,
+			"ou-abcd-1111222":                    false,
+			"ou-abcd-11112222-extra":             false,
+			"p-11112222":                         false,
+			"":                                   false,
+		}
+		for id, want := range cases {
+			if got := emulator.IsOrgTargetIDSyntaxForTest(id); got != want {
+				t.Errorf("%q: expected %v, got %v", id, want, got)
+			}
+		}
+	})
+}
+
+// TestOrganizations_PolicyOperationsAreClaimed pins that every operation in the lane
+// is dispatched, and that an operation outside it still falls through to
+// InvalidAction. A silently unclaimed operation would answer InvalidAction, which a
+// caller reads as "this API does not exist" rather than "substrate has not
+// implemented it".
+func TestOrganizations_PolicyOperationsAreClaimed(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	for _, op := range []string{
+		"CreatePolicy", "UpdatePolicy", "DeletePolicy", "DescribePolicy", "ListPolicies",
+		"AttachPolicy", "DetachPolicy", "ListPoliciesForTarget", "ListTargetsForPolicy",
+		"EnablePolicyType", "DisablePolicyType",
+	} {
+		resp := orgsRequest(t, ts, op, map[string]interface{}{})
+		var out struct {
+			Type string `json:"__type"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&out) //nolint:errcheck
+		resp.Body.Close()                           //nolint:errcheck
+		if out.Type == "InvalidAction" {
+			t.Errorf("%s: expected the operation to be claimed, got InvalidAction", op)
+		}
+	}
+
+	resp := orgsRequest(t, ts, "DescribeResourcePolicy", map[string]interface{}{})
+	var out struct {
+		Type string `json:"__type"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&out) //nolint:errcheck
+	resp.Body.Close()                           //nolint:errcheck
+	if out.Type != "InvalidAction" {
+		t.Errorf("expected an unimplemented operation to answer InvalidAction, got %q", out.Type)
+	}
+}


### PR DESCRIPTION
Part of #578. This is the service control policy lane of the v0.97.0
Organizations work; the OU, account and tagging clusters land separately, so
`Closes` is deliberately not used.

## What this covers

Points **2** (SCP CRUD), **3** (attach/detach with the quotas), **5**
(`ListPoliciesForTarget` / `ListTargetsForPolicy`) and **6**
(`EnablePolicyType` / `DisablePolicyType`, and the unenforced state between
them) of #578, plus the parts of point **9** that belong to policies —
`PolicyInUseException`, `IMMUTABLE_POLICY`, the min/max attachment limits and
the content limit.

Eleven operations: `CreatePolicy`, `UpdatePolicy`, `DeletePolicy`,
`DescribePolicy`, `ListPolicies`, `AttachPolicy`, `DetachPolicy`,
`ListPoliciesForTarget`, `ListTargetsForPolicy`, `EnablePolicyType`,
`DisablePolicyType`.

## Why the refusals are the point

A governance script's real behaviour is what it does when a call is refused,
and each of these distinguishes a case the caller must handle differently:

| Refusal | Code | Why a caller needs it |
|---|---|---|
| Attach while the type is disabled | `PolicyTypeNotEnabledException` | #578 point 6. `CreatePolicy` still succeeds, so a caller treating create-then-attach as atomic would record a guardrail as applied while nothing evaluates it. |
| Detach the last SCP | `ConstraintViolationException` / `MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED` | An entity with the type enabled and no SCP denies everything, so an emptying detach produces the reverse of the intent, silently. |
| Eleventh attachment | `ConstraintViolationException` / `MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED` | The SCP quota is 10 per target, not the 5 that belongs to RCPs. |
| Write to `p-FullAWSAccess` | `InvalidInputException` / `IMMUTABLE_POLICY` | A teardown deleting every listed policy must not remove the one the min-attachment rule depends on, and must not get a not-found it reads as "already gone". |
| Delete an attached policy | `PolicyInUseException` | Refused rather than cascaded: a cascade would strip a guardrail from every target, and a teardown in the wrong order would look like it worked. |
| Duplicate name (create, or rename onto one) | `DuplicatePolicyException` | A re-run needs to tell "already made this" from "made it now", and the name is its only handle before it knows the ID. |
| Re-attach | `DuplicatePolicyAttachmentException` | Attaching is not idempotent; a silent success would hide the double-apply. |
| Detach something not attached | `PolicyNotAttachedException` | Distinct from the min-attachment floor: the caller's own record is stale, not a quota. |
| Unknown policy / target | `PolicyNotFoundException` / `TargetNotFoundException` | Both are 400 — the model declares no 404 for any Organizations exception. |
| Content over 10,240 characters | `ConstraintViolationException` / `POLICY_CONTENT_LIMIT_EXCEEDED` | Split the policy. Measured in runes, since the quota is stated in characters. |
| Unparseable content | `MalformedPolicyDocumentException` | Correct the document. Separate from the size limit because the fixes differ. |
| Enable an already-enabled type | `PolicyTypeAlreadyEnabledException` | An all-features organization starts enabled, so a caller's first enable is already its second. |
| Disable a type that is off, never available, or unmodeled | `PolicyTypeNotEnabledException` | The only refusal `DisablePolicyType`'s error list declares; all three mean "nothing here to turn off". |
| Wrong root | `RootNotFoundException` | Checked *before* the feature set, so a caller that named the wrong root is not sent to fix the feature set. |
| Feature set has no SCPs | `PolicyTypeNotAvailableForOrganizationException` | Only on `CreatePolicy` and `EnablePolicyType` — see below. |
| Malformed identifiers | `InvalidInputException` / `INVALID_SYNTAX_POLICY_ID`, `INVALID_PATTERN_TARGET_ID`, `INVALID_ENUM_POLICY_TYPE` | A typo'd ID is a syntax error, not a not-found: a caller told "not found" would go on to recreate a policy that exists. |
| Quota on policies per organization | `ConstraintViolationException` / `POLICY_NUMBER_LIMIT_EXCEEDED` | Boundary pinned through the exported comparison rather than by creating 10,000 policies. |

## Two model-vs-brief discrepancies, resolved toward the model

1. **`PolicyTypeNotAvailableForOrganizationException` is narrower than the
   lane brief said.** The brief called for it on any policy operation under
   `CONSOLIDATED_BILLING`. The API model declares it on **`CreatePolicy` and
   `EnablePolicyType` only**. Availability is therefore modeled as
   *visibility*: while SCPs are unavailable no policy is visible, so each
   other operation answers with the not-found code its own error list carries
   (`PolicyNotFoundException`, `TargetNotFoundException`) and the two listings
   answer an empty page, which they declare no code to refuse with. Emitting
   an undeclared exception would hand a caller something its SDK cannot catch
   by type — worse than a truthful "no such policy".

2. **Generated policy IDs use a ten-character suffix, not eight.** The model
   gives two patterns for one identity: `PolicyId` admits `p-[0-9a-zA-Z_]{8,128}`,
   while `PolicyArn` requires `p-[0-9a-z]{10,32}` in the org-owned ARN form.
   Eight would emit an ARN invalid against the model's own pattern, so ten
   satisfies both.

Also wired `PolicyNotAttachedException` on `DetachPolicy`, which the model
declares and the brief's refusal list omitted.

## The disable/enable round trip

`DisablePolicyType` detaches every SCP from **every entity in the root** — the
root, every OU and every account — and does not remember them.
`EnablePolicyType` restores `p-FullAWSAccess` and nothing else. That is what
the User Guide documents, and helpfully restoring the prior attachments would
hide a destructive round trip from a caller that disabled the type to make a
change. Clearing only the root would leave an account carrying an SCP the root
no longer evaluates — a state no sequence of API calls can reach, so no caller
has handling for it.

## Deliberate omissions

- **No `ListPolicies` / `ListPoliciesForTarget` filters beyond the required
  `Filter`**; the model has no others.
- **Only `SERVICE_CONTROL_POLICY` is modeled.** Other enum members
  (`TAG_POLICY`, `BACKUP_POLICY`, …) are refused on create/enable with
  `PolicyTypeNotAvailableForOrganizationException` and return an empty page
  from the listings, which declare no refusal for it. A value outside the enum
  is `INVALID_ENUM_POLICY_TYPE` — a typo and an unsupported feature call for
  different action from the caller.
- **No `PENDING_ENABLE` / `PENDING_DISABLE` policy-type status.** The model
  declares them, but a transition whose end no caller can observe would make a
  poll loop wait for a state change that never arrives. Clock-driven
  transitions are #514.
- **SCP content is not evaluated**, only checked to be a JSON object. Judging
  statement semantics is modeling the authorization engine, not the API.
- `CHANGELOG.md` is untouched — PR 6 of this series owns it.

## New unexported helpers, for later hoisting

All live in `emulator/organizations_policy.go` so the parallel lanes do not
conflict; several are candidates to move into `organizations_state.go` once
the lanes have merged: `policyTypeAvailable`, `loadVisiblePolicy`,
`scpEnabledOnStoredRoot`, `rootSubtree`, `orgRootWithPolicyTypes`,
`orgPolicyNotFound`, `orgTargetNotFound`, `orgPolicyArn`, `orgPolicyTypes`
and the `orgCheck*` validators.

## Verification

`gofmt -l emulator/`, `go build ./...`, `go vet ./...`,
`golangci-lint run ./emulator/` (0 issues), and `make test` (race detector)
are all clean. Per-function statement coverage of
`emulator/organizations_policy.go` averages 97%.
