### PR TITLE
feat(organizations): validate inline tags on every create path (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the beginning — a paginating caller that restarts sees duplicates instead of an
   error, which is the harder failure to notice.
 
+- **Organizations resource tagging, and the condition keys that read those tags**
+  (#578). `TagResource`, `UntagResource` and `ListTagsForResource` work on all four
+  taggable kinds — the root, an OU, an account and a policy — and the tags they
+  write now reach the authorization decision: `aws:ResourceTag/*` resolves against
+  the tagged entity and `aws:RequestTag/*` against a request's inline `Tags`, so a
+  tag-gated privilege boundary (`CreatePolicy` only when `aws:RequestTag/Owner`
+  matches, `UpdatePolicy` only when `aws:ResourceTag/Owner` does) is actually
+  enforceable rather than silently open. An Organizations resource ARN is now built
+  from state instead of falling through to `"*"`, since the ARN embeds the
+  organization ID.
+
+  The tag shapes are refused exactly where AWS refuses them: an unknown resource is
+  `TargetNotFoundException`, a malformed ID is
+  `InvalidInputException`/`INVALID_PATTERN`, a repeated key in one request is
+  `DUPLICATE_TAG_KEY`, the 51st key on a resource is
+  `ConstraintViolationException`/`MAX_TAG_LIMIT_EXCEEDED`, and an `aws:`-prefixed
+  key is `INVALID_SYSTEM_TAGS_PARAMETER`. The same validation gates the inline
+  `Tags` of `CreateOrganizationalUnit`, `CreatePolicy` and `CreateAccount`, so a key
+  `TagResource` refuses cannot be planted through a create instead — an
+  `aws:`-prefixed one would otherwise be readable as `aws:ResourceTag` by a policy
+  condition, letting a boundary be crossed with a key AWS never lets a caller write.
+  An invalid tag fails the whole create and leaves nothing behind, so a retry does
+  not collide with a duplicate-name refusal for a resource the caller does not
+  believe it created. `CreateAccount`'s refusal is synchronous even though its
+  success is not: the request is malformed, so there is nothing to vend.
+
+  Tags go with the resource they are on: deleting an OU or a policy deletes its
+  tags, so a later entity that reused the ID cannot inherit them and answer a
+  tag-gated decision with someone else's tag set. `p-FullAWSAccess` cannot be
+  tagged — its ARN is owned by `aws`, not by the organization — though reading its
+  tags answers empty rather than failing. A store fault on a tag read is a 500, not
+  an empty tag set: answering "no tags" would fail open on every tag-gated policy.
+
 ## [v0.96.0] - 2026-08-08
 
 ### Added

--- a/emulator/organizations_account.go
+++ b/emulator/organizations_account.go
@@ -76,9 +76,9 @@ func (p *OrganizationsPlugin) accountOperation(op string) (orgHandler, bool) {
 func (p *OrganizationsPlugin) createAccount(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
-		AccountName string   `json:"AccountName"`
-		Email       string   `json:"Email"`
-		Tags        []OrgTag `json:"Tags"`
+		AccountName string        `json:"AccountName"`
+		Email       string        `json:"Email"`
+		Tags        []orgTagInput `json:"Tags"`
 
 		// RoleName and IamUserAccessToBilling are accepted and recorded nowhere:
 		// no Organizations API observation exposes either, so modeling them would
@@ -92,6 +92,14 @@ func (p *OrganizationsPlugin) createAccount(reqCtx *RequestContext, req *AWSRequ
 	if input.AccountName == "" || input.Email == "" {
 		return nil, orgInvalidInput("INPUT_REQUIRED",
 			"you must specify both AccountName and Email to create an account")
+	}
+	// Tags go through the same validation TagResource applies, so a key that
+	// operation refuses cannot be planted through a create instead. The refusal is
+	// synchronous — it is the request that is malformed, not the vend that failed,
+	// so it must not arrive later as a FAILED status the caller has to poll for.
+	tags, err := validateOrgCreateTags(input.Tags)
+	if err != nil {
+		return nil, err
 	}
 
 	org, err := p.ensureOrganization(goCtx, reqCtx.AccountID)
@@ -126,7 +134,7 @@ func (p *OrganizationsPlugin) createAccount(reqCtx *RequestContext, req *AWSRequ
 	// is the state most likely to make a consumer's cleanup path look correct
 	// while it deletes nothing.
 	if outcome.AccountID != "" {
-		if err := p.vendAccount(goCtx, reqCtx.AccountID, org.ID, root.ID, outcome.AccountID, input.AccountName, input.Email, input.Tags); err != nil {
+		if err := p.vendAccount(goCtx, reqCtx.AccountID, org.ID, root.ID, outcome.AccountID, input.AccountName, input.Email, tags); err != nil {
 			return nil, err
 		}
 	}

--- a/emulator/organizations_ou.go
+++ b/emulator/organizations_ou.go
@@ -50,9 +50,9 @@ const orgMaxOUNameChars = 128
 func (p *OrganizationsPlugin) createOrganizationalUnit(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
-		ParentID string   `json:"ParentId"`
-		Name     string   `json:"Name"`
-		Tags     []OrgTag `json:"Tags"`
+		ParentID string        `json:"ParentId"`
+		Name     string        `json:"Name"`
+		Tags     []orgTagInput `json:"Tags"`
 	}
 	if err := orgUnmarshal(req.Body, &input); err != nil {
 		return nil, err
@@ -64,12 +64,12 @@ func (p *OrganizationsPlugin) createOrganizationalUnit(reqCtx *RequestContext, r
 		return nil, orgInvalidInput("MAX_LENGTH_EXCEEDED",
 			fmt.Sprintf("the Name value must be at most %d characters", orgMaxOUNameChars))
 	}
-	// Tags are validated before anything is written, because the operation
-	// documents that an invalid tag fails the whole request and leaves no OU
-	// behind. A partially created OU would be worse than the refusal: the caller's
-	// retry would then hit DuplicateOrganizationalUnitException for an OU it does
-	// not believe it created.
-	if err := orgValidateOUTags(input.Tags); err != nil {
+	// Tags go through the same validation TagResource applies, so a key that
+	// operation refuses cannot be planted through a create instead. A partially
+	// created OU would be worse than the refusal: the caller's retry would then hit
+	// DuplicateOrganizationalUnitException for an OU it does not believe it created.
+	tags, err := validateOrgCreateTags(input.Tags)
+	if err != nil {
 		return nil, err
 	}
 
@@ -136,8 +136,8 @@ func (p *OrganizationsPlugin) createOrganizationalUnit(reqCtx *RequestContext, r
 	if err := p.attachFullAWSAccess(goCtx, reqCtx.AccountID, ouID); err != nil {
 		return nil, fmt.Errorf("createOrganizationalUnit attach FullAWSAccess: %w", err)
 	}
-	if len(input.Tags) > 0 {
-		if err := p.saveTags(goCtx, ouID, input.Tags); err != nil {
+	if len(tags) > 0 {
+		if err := p.saveTags(goCtx, ouID, tags); err != nil {
 			return nil, fmt.Errorf("createOrganizationalUnit save tags: %w", err)
 		}
 	}
@@ -611,28 +611,4 @@ func isOrgAccountID(id string) bool {
 		}
 	}
 	return true
-}
-
-// orgValidateOUTags checks the tags on CreateOrganizationalUnit against the two
-// limits the model documents for them. Both refusals are in the operation's
-// declared error list, and both have to fire before the OU is written: the
-// operation documents that an invalid tag fails the entire request.
-func orgValidateOUTags(tags []OrgTag) error {
-	if len(tags) > orgMaxTagsPerResource {
-		return orgConstraintViolation("MAX_TAG_LIMIT_EXCEEDED",
-			fmt.Sprintf("you have exceeded the number of tags you can attach to a resource (%d)", orgMaxTagsPerResource))
-	}
-	seen := make(map[string]bool, len(tags))
-	for _, tag := range tags {
-		if tag.Key == "" {
-			return orgInvalidInput("INPUT_REQUIRED", "every tag must specify a Key")
-		}
-		// A repeated key would otherwise silently keep whichever value sorted last,
-		// so the caller's second value would win with nothing to say it had.
-		if seen[tag.Key] {
-			return orgInvalidInput("DUPLICATE_TAG_KEY", "the tag key "+tag.Key+" appears more than once")
-		}
-		seen[tag.Key] = true
-	}
-	return nil
 }

--- a/emulator/organizations_policy.go
+++ b/emulator/organizations_policy.go
@@ -121,13 +121,21 @@ func (p *OrganizationsPlugin) loadVisiblePolicy(ctx context.Context, acct, polic
 func (p *OrganizationsPlugin) createPolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
-		Content     string   `json:"Content"`
-		Description *string  `json:"Description"`
-		Name        string   `json:"Name"`
-		Type        string   `json:"Type"`
-		Tags        []OrgTag `json:"Tags"`
+		Content     string        `json:"Content"`
+		Description *string       `json:"Description"`
+		Name        string        `json:"Name"`
+		Type        string        `json:"Type"`
+		Tags        []orgTagInput `json:"Tags"`
 	}
 	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	// Tags go through the same validation TagResource applies, before anything is
+	// written: a key that operation refuses must not be plantable through a create,
+	// and a half-created policy would make the caller's retry collide with a
+	// DuplicatePolicyException for a policy it does not believe it created.
+	tags, err := validateOrgCreateTags(input.Tags)
+	if err != nil {
 		return nil, err
 	}
 
@@ -215,10 +223,9 @@ func (p *OrganizationsPlugin) createPolicy(reqCtx *RequestContext, req *AWSReque
 		return nil, fmt.Errorf("createPolicy save: %w", err)
 	}
 	// Tags supplied at creation are stored so ListTagsForResource can read them
-	// back; their validation and their part in the authorization decision belong to
-	// the tagging operations.
-	if len(input.Tags) > 0 {
-		if err := p.saveTags(goCtx, policyID, input.Tags); err != nil {
+	// back, and so a policy condition on aws:ResourceTag sees them.
+	if len(tags) > 0 {
+		if err := p.saveTags(goCtx, policyID, tags); err != nil {
 			return nil, fmt.Errorf("createPolicy save tags: %w", err)
 		}
 	}

--- a/emulator/organizations_tags.go
+++ b/emulator/organizations_tags.go
@@ -367,6 +367,28 @@ func validateOrgTags(inputs []orgTagInput) ([]OrgTag, error) {
 	return tags, nil
 }
 
+// validateOrgCreateTags checks the inline Tags of a create operation —
+// CreateOrganizationalUnit, CreatePolicy, CreateAccount — and returns them.
+//
+// It is the same validation TagResource applies, plus the count quota, because
+// the tags are the same tags: a key TagResource refuses has to be refused here
+// too, or a caller can plant a tag through a create that it could never set
+// afterwards, and an "aws:"-prefixed one would then be readable as
+// aws:ResourceTag by a policy condition. The count is checked against the request
+// alone rather than a merge, since a resource being created carries no tags yet.
+//
+// Every refusal fires before the resource is written: each of these operations
+// documents that an invalid tag fails the whole request, and a partially created
+// resource would make the caller's retry collide with something it does not
+// believe it created.
+func validateOrgCreateTags(inputs []orgTagInput) ([]OrgTag, error) {
+	if len(inputs) > orgMaxTagsPerResource {
+		return nil, orgConstraintViolation("MAX_TAG_LIMIT_EXCEEDED",
+			fmt.Sprintf("you have exceeded the number of tags allowed on this resource (%d)", orgMaxTagsPerResource))
+	}
+	return validateOrgTags(inputs)
+}
+
 // validateOrgTagKey enforces the TagKey shape and the reservation of the "aws:"
 // prefix.
 func validateOrgTagKey(key string) error {

--- a/emulator/organizations_tags_test.go
+++ b/emulator/organizations_tags_test.go
@@ -698,6 +698,115 @@ func TestOrganizations_TagResource_MaxTagLimit(t *testing.T) {
 	}
 }
 
+// TestOrganizations_CreateOperationsShareTagValidation asserts the three
+// operations that accept inline Tags — CreateOrganizationalUnit, CreatePolicy and
+// CreateAccount — refuse exactly what TagResource refuses. A create that is more
+// permissive than TagResource lets a caller plant a tag it could never set
+// afterwards, and an "aws:"-prefixed one is the case that matters: it would then
+// be readable as aws:ResourceTag by a policy condition, so a tag-gated boundary
+// could be crossed by a key AWS reserves for itself and never lets a caller write.
+// The refusal has to be synchronous even for CreateAccount, whose success is
+// asynchronous — the request is malformed, so there is nothing to vend.
+func TestOrganizations_CreateOperationsShareTagValidation(t *testing.T) {
+	// Each entry names a create and a body builder taking the tag list, so the same
+	// refusal table runs against all three without a per-operation copy of it.
+	creates := []struct {
+		op   string
+		body func(root string, tags []map[string]any) map[string]any
+	}{
+		{
+			op: "CreateOrganizationalUnit",
+			body: func(root string, tags []map[string]any) map[string]any {
+				return map[string]any{"ParentId": root, "Name": "Rejected", "Tags": tags}
+			},
+		},
+		{
+			op: "CreatePolicy",
+			body: func(_ string, tags []map[string]any) map[string]any {
+				return map[string]any{
+					"Name": "rejected", "Description": "d", "Type": emulator.OrgPolicyTypeSCPForTest,
+					"Content": orgPolicyDoc, "Tags": tags,
+				}
+			},
+		},
+		{
+			op: "CreateAccount",
+			body: func(_ string, tags []map[string]any) map[string]any {
+				return map[string]any{"AccountName": "rejected", "Email": "rejected@example.com", "Tags": tags}
+			},
+		},
+	}
+	refusals := []struct {
+		name   string
+		tags   []map[string]any
+		code   string
+		reason string
+	}{
+		{
+			"a system tag key", []map[string]any{orgTag("aws:cloudformation:stack-name", "x")},
+			"InvalidInputException", "INVALID_SYSTEM_TAGS_PARAMETER",
+		},
+		{
+			"a duplicate tag key", []map[string]any{orgTag("Owner", "a"), orgTag("Owner", "b")},
+			"InvalidInputException", "DUPLICATE_TAG_KEY",
+		},
+		{"an empty tag key", []map[string]any{orgTag("", "a")}, "InvalidInputException", "MIN_LENGTH_EXCEEDED"},
+		{
+			"a key past the length limit", []map[string]any{orgTag(strings.Repeat("k", 129), "a")},
+			"InvalidInputException", "MAX_LENGTH_EXCEEDED",
+		},
+		{
+			"a key outside the allowed pattern", []map[string]any{orgTag("Own%er", "a")},
+			"InvalidInputException", "INVALID_PATTERN",
+		},
+		{
+			"a value past the length limit", []map[string]any{orgTag("Owner", strings.Repeat("v", 257))},
+			"InvalidInputException", "MAX_LENGTH_EXCEEDED",
+		},
+	}
+
+	for _, c := range creates {
+		t.Run(c.op, func(t *testing.T) {
+			for _, r := range refusals {
+				t.Run(r.name, func(t *testing.T) {
+					// A fresh fixture per case, so a refusal that wrongly created something
+					// cannot be mistaken for a name collision with an earlier subtest.
+					f := newOrgTagsFixture(t)
+					status, code := orgTagCall(t, f.ts, c.op, c.body(f.root, r.tags))
+					if status != http.StatusBadRequest ||
+						!strings.Contains(code, r.code) || !strings.Contains(code, r.reason) {
+						t.Fatalf("expected %s/%s, got %d (%s)", r.code, r.reason, status, code)
+					}
+				})
+			}
+
+			t.Run("more tags than the quota allows", func(t *testing.T) {
+				f := newOrgTagsFixture(t)
+				tags := make([]map[string]any, 0, emulator.OrgMaxTagsPerResourceForTest+1)
+				for i := range emulator.OrgMaxTagsPerResourceForTest + 1 {
+					tags = append(tags, orgTag(fmt.Sprintf("Key%02d", i), "v"))
+				}
+				status, code := orgTagCall(t, f.ts, c.op, c.body(f.root, tags))
+				if status != http.StatusBadRequest ||
+					!strings.Contains(code, "ConstraintViolationException") ||
+					!strings.Contains(code, "MAX_TAG_LIMIT_EXCEEDED") {
+					t.Errorf("expected ConstraintViolationException/MAX_TAG_LIMIT_EXCEEDED, got %d (%s)", status, code)
+				}
+			})
+
+			// The same tag list TagResource accepts has to be accepted here, or the
+			// shared validation would be refusing more than it should.
+			t.Run("a legal tag is accepted", func(t *testing.T) {
+				f := newOrgTagsFixture(t)
+				status, code := orgTagCall(t, f.ts, c.op, c.body(f.root, []map[string]any{orgTag("Owner", "platform")}))
+				if status != http.StatusOK {
+					t.Errorf("expected 200, got %d (%s)", status, code)
+				}
+			})
+		})
+	}
+}
+
 // TestOrganizations_Tagging_FullAWSAccessIsImmutable asserts the AWS-managed SCP
 // cannot be tagged. Its ARN is owned by the "aws" account, not by the
 // organization, so a tag stored against it would be visible in one organization


### PR DESCRIPTION
`CreateOrganizationalUnit`, `CreatePolicy` and `CreateAccount` all accept an inline
`Tags` list, and each stored it without running it through the validation
`TagResource` applies. A key `TagResource` refuses could therefore be planted
through a create instead — and an `aws:`-prefixed one would then be readable as
`aws:ResourceTag` by a policy condition, so a tag-gated privilege boundary could be
crossed with a key AWS reserves for itself and never lets a caller write.

This was the one genuine gap the tagging lane disclosed when it landed: the three
create handlers belong to other clusters, and the validation helpers were written to
be called from them but were not wired up.

## What changed

- `validateOrgCreateTags` in `organizations_tags.go` — the shared entry point. Same
  key/value shapes as `TagResource` plus the per-resource count quota. The count is
  checked against the request alone rather than a merge, since a resource being
  created carries no tags yet.
- All three creates call it before writing anything, so a refusal leaves nothing
  behind and a retry does not collide with a duplicate-name exception for a resource
  the caller does not believe it created. For `CreateAccount` the refusal is
  synchronous even though the success is not — a malformed request has nothing to
  vend.
- Each `Tags` field moves from `[]OrgTag` to `[]orgTagInput`, so an absent value is
  distinguishable from an empty string (the first is refused, the second is legal).
- `orgValidateOUTags`, which duplicated a weaker subset of the checks, is deleted.

## Testing

`TestOrganizations_CreateOperationsShareTagValidation` runs one refusal table across
all three operations rather than a per-operation copy, so a create that drifts more
permissive than `TagResource` fails rather than being asserted only where someone
remembered to: system tag key, duplicate key, empty key, over-length key, key
outside the pattern, over-length value, over-quota count, plus a legal tag that must
still be accepted.

Mutation check: dropping the `MAX_TAG_LIMIT_EXCEEDED` guard from
`validateOrgCreateTags` fails the new test on all three operations — CAUGHT.

Gate: `gofmt -l .` clean, `go build ./...`, `go vet ./...`,
`golangci-lint run ./...` (0 issues), `make test` (race detector) all green.

Verified against the botocore Organizations model at
`organizations/2016-11-28/service-2.json`: the `Tags` member of all three create
shapes is the same `Tags` list `TagResource` takes.

Part of #578.