### PR TITLE
docs(organizations): document the service, and add the SDK-level journey (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the model's `InvalidInputExceptionReason` enum is carried in the message,
   since the JSON-RPC error document has nowhere else to put it.
 
+- **Organizations calls reach the plugin at all** (#610). Every `aws-sdk-go-v2`
+  and `boto3` Organizations call fell through to
+  `ServiceNotAvailable: service not emulated: awsorganizationsv20161128`, while
+  the plugin sat registered and fully unit-tested behind it — the unit tests build
+  an `AWSRequest` directly and so never exercised the routing. The SDKs send
+  `X-Amz-Target: AWSOrganizationsV20161128.{Op}`, and that prefix reduces through
+  neither of `extractServiceFromTarget`'s rules: there is no leading `Amazon` to
+  strip, and the version rides inside the prefix rather than after an underscore,
+  so nothing shortened it. An explicit alias now maps it, and the new parser test
+  goes through `ParseAWSRequest` rather than around it. Same class of bug as #561.
+
+- **Organizations timestamps are JSON numbers, as the wire protocol requires.**
+  `JoinedTimestamp`, `RequestedTimestamp` and `CompletedTimestamp` were RFC3339
+  strings. The JSON 1.1 protocol carries a timestamp as epoch seconds, and
+  aws-sdk-go-v2 calls `ParseEpochSeconds` on the member: a string failed the whole
+  response, so `ListAccounts`, `CreateAccount` and `DescribeCreateAccountStatus`
+  raised `deserialization failed` at every SDK caller — the operations were correct
+  and unreachable. Found by the new SDK-level journey; the unit tests decoded the
+  timestamps as strings and so asserted the broken form. They now assert the
+  number.
+
 ### Added
 - **The Organizations plugin's shared storage layer, and two control-plane seed
   endpoints** (#578, foundation). The plugin now persists the hierarchy (each
@@ -58,6 +79,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InvalidInputException`/`INVALID_NEXT_TOKEN` rather than a silent restart from
   the beginning — a paginating caller that restarts sees duplicates instead of an
   error, which is the harder failure to notice.
+
+- **The Organizations organizational-unit tree** (#578).
+  `CreateOrganizationalUnit`, `DescribeOrganizationalUnit`,
+  `UpdateOrganizationalUnit`, `DeleteOrganizationalUnit`,
+  `ListOrganizationalUnitsForParent`, `ListChildren`, `ListParents` and
+  `ListAccountsForParent`, so an organization can be *built* rather than only read.
+  An OU ID is `ou-{root suffix}-{8}`, and the middle segment is the containing
+  root's suffix whatever the immediate parent is — nesting does not extend the ID.
+  `UpdateOrganizationalUnit` renames in place: the ID, ARN, children and attached
+  policies all survive, so a caller holding any of them keeps a valid handle.
+
+  The refusals are what a landing-zone tool's re-run actually hits: a name already
+  used among a parent's children is `DuplicateOrganizationalUnitException` (scoped
+  to the parent, so "Sandbox" under two business units is legal), a sixth nesting
+  level is `OU_DEPTH_LIMIT_EXCEEDED`, and an OU still holding anything is
+  `OrganizationalUnitNotEmptyException` rather than a delete that orphans its
+  children. Deleting an OU deletes its tags with it.
+
+  `OrganizationalUnit` carries no `Path` member — the API model does not declare
+  one, though the reference's prose mentions a path — so substrate does not invent
+  it. A caller needing the path walks `ListParents`.
+
+- **Asynchronous Organizations account vending** (#578). `CreateAccount` now
+  returns HTTP 200 with `State: IN_PROGRESS` and a `car-` request ID, as AWS does,
+  and `DescribeCreateAccountStatus`/`ListCreateAccountStatus`/`MoveAccount` are
+  implemented. A synchronous `SUCCEEDED` let a consumer with no poll loop pass its
+  tests — and the poll loop is the part that has to survive an interruption.
+
+  The status resolves on the **first** `DescribeCreateAccountStatus`, so a waiter
+  converges in one observation with no wall-clock dependence, and the terminal
+  status never moves afterwards: a re-minted `AccountId` or a fresh
+  `CompletedTimestamp` would make a waiter comparing successive polls loop forever.
+  This is advance-on-observation rather than clock-driven deliberately — #514 is the
+  open design issue for transitions over the simulated clock, and choosing a shape
+  here would front-run it. `ListAccounts` reports the account while its request is
+  still `IN_PROGRESS`, matching AWS.
+
+  New accounts land in the **root**; `MoveAccount` is the only way into an OU, which
+  is where policies attach, so a tool that assumes otherwise leaves accounts
+  ungoverned. A move to the account's current parent is `DuplicateAccountException`,
+  not a no-op — that is what makes a vending run re-runnable: the second pass fails
+  loudly and distinguishably instead of appearing to succeed while doing nothing.
+  The destination is validated before the source on purpose, so a re-run hears
+  "already present in the destination" rather than "your source does not exist".
+
+- **The Organizations service control policy lifecycle** (#578). `CreatePolicy`,
+  `UpdatePolicy`, `DeletePolicy`, `DescribePolicy`, `ListPolicies`, `AttachPolicy`,
+  `DetachPolicy`, `ListPoliciesForTarget`, `ListTargetsForPolicy`,
+  `EnablePolicyType` and `DisablePolicyType`.
+
+  `DisablePolicyType` detaches every SCP from every entity in the root, and
+  `EnablePolicyType` restores only `p-FullAWSAccess` — attachments from before the
+  disable are lost, per the User Guide. That round trip is the state #578's point 6
+  is about, and it is only reachable because `DisablePolicyType` exists: AWS creates
+  an all-features organization with SCPs already enabled. The state is dangerous
+  precisely because it does not look like a failure — `CreatePolicy` **succeeds**
+  and only `AttachPolicy` is refused, with `PolicyTypeNotEnabledException`.
+
+  That is distinct from SCPs not being *available*, which is what a
+  `CONSOLIDATED_BILLING` organization has. Availability is modeled as visibility:
+  while SCPs are unavailable no policy is visible, so each operation answers with
+  its own documented not-found code, and only `CreatePolicy` and `EnablePolicyType`
+  name the feature set as the reason
+  (`PolicyTypeNotAvailableForOrganizationException`) — they are the two operations
+  whose model error list declares it, and emitting it elsewhere would hand a caller
+  an exception its SDK cannot catch by type.
+
+  Quotas are enforced with the User Guide's values, not the frequently misquoted
+  ones: **10** SCPs per root/OU/account and **10,240** characters per policy (5 and
+  5,120 are the *RCP* numbers), 10,000 policies per organization. The minimum of one
+  SCP per target is enforced too, so the last policy on a target cannot be detached
+  — which is what makes `p-FullAWSAccess` load-bearing rather than decorative.
+  `p-FullAWSAccess` itself is `IMMUTABLE_POLICY` on any modification, an attached
+  policy is `PolicyInUseException` on delete, and detaching something not attached
+  is `PolicyNotAttachedException`.
 
 - **Organizations resource tagging, and the condition keys that read those tags**
   (#578). `TagResource`, `UntagResource` and `ListTagsForResource` work on all four

--- a/docs/services.md
+++ b/docs/services.md
@@ -4476,19 +4476,204 @@ Price List API calls are free.
 **Endpoint:** `organizations.us-east-1.amazonaws.com`
 **Protocol:** JSON (`X-Amz-Target: Organizations_20161128.{Op}`)
 
-On the first `DescribeOrganization` call, the plugin auto-creates an
-organization and master account.
+On the first call, the plugin auto-creates an organization, its management
+account, and its root. All three are persisted, so the root's ID and ARN are
+stable for the life of the state store — an organization whose root ID moved
+between calls could not be governed at all, since nothing could reference the
+thing policies attach to.
+
+**Every Organizations exception is HTTP 400.** The API model declares no 404 for
+any of them, `AccountNotFoundException` included, so a consumer that branches on
+the status rather than the code takes a path AWS never sends it down. The
+`InvalidInputException` and `ConstraintViolationException` reasons ride at the
+front of the message (`"OU_DEPTH_LIMIT_EXCEEDED: …"`), because the JSON-RPC error
+document has no `Reason` member to put them in.
 
 ### Supported operations
 
 | Operation | Notes |
 |-----------|-------|
-| CreateOrganization | |
-| DescribeOrganization | Auto-creates org on first call |
-| ListRoots | |
-| CreateAccount | |
-| DescribeAccount | `AccountNotFoundException` if missing |
-| ListAccounts | |
+| DescribeOrganization | Auto-creates the organization, its management account and its root on first call |
+| ListRoots | The same root ID on every call; `PolicyTypes` is empty under `CONSOLIDATED_BILLING` |
+| ListAccounts | Reports a vending account immediately, before its status resolves |
+| DescribeAccount | `AccountNotFoundException` |
+| CreateAccount | **Asynchronous** — returns `IN_PROGRESS` and a `car-` request ID |
+| DescribeCreateAccountStatus | Resolves the request on first observation; `CreateAccountStatusNotFoundException` |
+| ListCreateAccountStatus | Filterable by `States` |
+| MoveAccount | The only way an account leaves the root |
+| CreateOrganizationalUnit | `Name` 1–128 characters; accepts inline `Tags` |
+| DescribeOrganizationalUnit | `OrganizationalUnitNotFoundException` |
+| UpdateOrganizationalUnit | Renames in place — ID, ARN, children and attachments all survive |
+| DeleteOrganizationalUnit | `OrganizationalUnitNotEmptyException` while it holds anything; deletes its tags |
+| ListOrganizationalUnitsForParent | |
+| ListChildren | `ChildType` is required |
+| ListParents | Walks up to the root `ListRoots` reports |
+| ListAccountsForParent | |
+| CreatePolicy | `Content`, `Description`, `Name` and `Type` are **all** required; accepts inline `Tags` |
+| UpdatePolicy | Any of `Name`/`Description`/`Content`; `IMMUTABLE_POLICY` on `p-FullAWSAccess` |
+| DeletePolicy | `PolicyInUseException` while attached; deletes its tags |
+| DescribePolicy | `PolicyNotFoundException` |
+| ListPolicies | `Filter` is required; includes `p-FullAWSAccess` |
+| AttachPolicy | `DuplicatePolicyAttachmentException`; refused while the type is disabled |
+| DetachPolicy | `PolicyNotAttachedException`; the last SCP on a target cannot be detached |
+| ListPoliciesForTarget | `Filter` is required |
+| ListTargetsForPolicy | Reports the root, OU and account targets of one policy |
+| EnablePolicyType | `PolicyTypeAlreadyEnabledException`; restores only `p-FullAWSAccess` |
+| DisablePolicyType | Detaches every SCP from every entity in the root |
+| TagResource | Roots, OUs, accounts and policies |
+| UntagResource | Validates key shape on the removal path too |
+| ListTagsForResource | Paginated by `NextToken`; no `MaxResults` |
+
+`CreateOrganization` is not implemented: the organization already exists on first
+contact, so there is nothing for it to create.
+
+### `p-FullAWSAccess`
+
+AWS attaches the managed allow-everything SCP to the root, every OU and every
+account while the SCP type is enabled, and substrate does the same. It is
+**synthesized rather than stored**, so it cannot be updated or deleted, and its
+ARN is owned by `aws` (`arn:aws:organizations::aws:policy/service_control_policy/p-FullAWSAccess`)
+rather than by the organization — which is also why it cannot be tagged, though
+reading its tags answers empty.
+
+Without it a fresh organization reports no attached policies, which is wrong, and
+the minimum-one-SCP rule below has nothing to hold.
+
+### Account vending is asynchronous
+
+`CreateAccount` returns HTTP 200 with `State: IN_PROGRESS` and a `car-` request
+ID, as AWS does. The status resolves — to `SUCCEEDED` with an `AccountId` and a
+`CompletedTimestamp`, or to the seeded `FAILED` — on the **first**
+`DescribeCreateAccountStatus`, so a waiter converges in one poll with no
+wall-clock dependence. `ListAccounts` reports the account immediately, before the
+status resolves, matching AWS.
+
+This is advance-on-observation rather than clock-driven on purpose: transitions
+over the simulated clock are the open design question in #514, and picking a shape
+here would front-run it.
+
+New accounts land in the **root**. `MoveAccount` is the only way into an OU, and
+a move to the account's current parent is `DuplicateAccountException`, not a
+no-op — which is what makes a vending script's re-run testable: the second run
+hits the refusal rather than silently duplicating.
+
+### The disabled-SCP state
+
+An all-features organization whose root has had `DisablePolicyType` called on it
+is the state a governance tool is most likely to get wrong, because it looks
+nothing like a failure:
+
+- `CreatePolicy` **succeeds**.
+- `AttachPolicy` is refused with `PolicyTypeNotEnabledException`.
+- `EnablePolicyType` restores **only** `p-FullAWSAccess`. Attachments from before
+  the disable are lost, per the User Guide.
+
+That is different from SCPs not being *available* at all, which is what a
+`CONSOLIDATED_BILLING` organization has: there no SCP exists, no policy is
+visible, and every operation naming one answers with its own documented not-found
+code. Only `CreatePolicy` and `EnablePolicyType` name the feature set as the
+reason (`PolicyTypeNotAvailableForOrganizationException`), because those are the
+two operations whose model error list declares it — emitting it elsewhere would
+hand a caller an exception its SDK cannot catch by type.
+
+### Tags reach the authorization decision
+
+Tags written through `TagResource` resolve as `aws:ResourceTag/*` on the tagged
+entity, and a request's inline `Tags` as `aws:RequestTag/*`, so a tag-gated
+privilege boundary — `CreatePolicy` only when `aws:RequestTag/Owner` matches,
+`UpdatePolicy` on that policy only when `aws:ResourceTag/Owner` does — is
+actually enforced rather than silently open.
+
+The inline `Tags` of `CreateOrganizationalUnit`, `CreatePolicy` and
+`CreateAccount` go through the same validation `TagResource` applies, so a key
+that operation refuses cannot be planted through a create instead; an
+`aws:`-prefixed one would otherwise be readable as `aws:ResourceTag` by a policy
+condition. An invalid tag fails the whole create and leaves nothing behind, and
+`CreateAccount`'s refusal is synchronous even though its success is not — the
+request is malformed, so there is nothing to vend. Deleting an OU or a policy
+deletes its tags, so an entity that reused the ID cannot inherit them.
+
+### Refusals
+
+| Condition | Answer |
+|---|---|
+| Unknown account | `AccountNotFoundException` |
+| Unknown OU | `OrganizationalUnitNotFoundException` |
+| Unknown parent / child / root | `ParentNotFoundException` / `ChildNotFoundException` / `RootNotFoundException` |
+| Unknown policy / attachment target | `PolicyNotFoundException` / `TargetNotFoundException` |
+| Duplicate OU name under one parent | `DuplicateOrganizationalUnitException` |
+| Duplicate policy name | `DuplicatePolicyException` |
+| Already attached | `DuplicatePolicyAttachmentException` |
+| Detaching something not attached | `PolicyNotAttachedException` |
+| Deleting an attached policy | `PolicyInUseException` |
+| Deleting a non-empty OU | `OrganizationalUnitNotEmptyException` |
+| Enabling an enabled policy type | `PolicyTypeAlreadyEnabledException` |
+| Attaching while the type is disabled | `PolicyTypeNotEnabledException` |
+| `CreatePolicy`/`EnablePolicyType` under `CONSOLIDATED_BILLING` | `PolicyTypeNotAvailableForOrganizationException` |
+| Unparseable policy content | `MalformedPolicyDocumentException` |
+| Modifying `p-FullAWSAccess` | `InvalidInputException`/`IMMUTABLE_POLICY` |
+| Moving to the current parent | `DuplicateAccountException` |
+| A source that is not the account's parent | `SourceParentNotFoundException` |
+| Unknown move destination | `DestinationParentNotFoundException` |
+| A move across roots | `InvalidInputException`/`MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS` |
+| A repeated tag key in one request | `InvalidInputException`/`DUPLICATE_TAG_KEY` |
+| An `aws:`-prefixed tag key | `InvalidInputException`/`INVALID_SYSTEM_TAGS_PARAMETER` |
+| An unreadable pagination token | `InvalidInputException`/`INVALID_NEXT_TOKEN` |
+| An unparseable request body | `InvalidInputException` |
+| An unimplemented operation | `InvalidAction` |
+
+### Quotas
+
+Each is the value in [Quotas for AWS Organizations](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html),
+and each is enforced rather than merely documented.
+
+| Quota | Value | Refusal reason |
+|---|---|---|
+| Accounts in an organization | 10 | `ACCOUNT_NUMBER_LIMIT_EXCEEDED` |
+| OU nesting levels below the root | 5 | `OU_DEPTH_LIMIT_EXCEEDED` |
+| OUs in an organization | 2,000 | `OU_NUMBER_LIMIT_EXCEEDED` |
+| SCPs in an organization | 10,000 | `POLICY_NUMBER_LIMIT_EXCEEDED` |
+| SCPs attached to one root, OU or account | 10 max, **1 min** | `MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED` / `MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED` |
+| Characters in an SCP | 10,240 | `POLICY_CONTENT_LIMIT_EXCEEDED` |
+| Tags on one resource | 50 | `MAX_TAG_LIMIT_EXCEEDED` |
+
+The 5-per-target and 5,120-character figures often quoted are the **RCP** values,
+not the SCP ones.
+
+### Pagination
+
+Paginated listings honor `MaxResults` — clamped to the model's 1–20, so a caller
+asking for more gets a truncated page and a token rather than everything — and
+`NextToken`. An unreadable token is `InvalidInputException`/`INVALID_NEXT_TOKEN`
+rather than a silent restart from the beginning: a paginating caller that restarts
+sees duplicates instead of an error, which is the harder failure to notice.
+
+### Seeding
+
+```bash
+# An organization in which no service control policy can exist at all.
+curl -X POST http://localhost:4566/v1/organizations/feature-set \
+  -d '{"featureSet":"CONSOLIDATED_BILLING"}'
+curl -X DELETE http://localhost:4566/v1/organizations/feature-set
+
+# The asynchronous outcome of CreateAccount, by account name or "*".
+curl -X POST http://localhost:4566/v1/organizations/create-account-failure \
+  -d '{"accountName":"dev","failureReason":"EMAIL_ALREADY_EXISTS"}'
+curl -X DELETE 'http://localhost:4566/v1/organizations/create-account-failure?accountName=dev'
+curl -X DELETE http://localhost:4566/v1/organizations/create-account-failure
+```
+
+A name-scoped seed takes precedence over the wildcard. The feature-set seed wins
+over the stored value, so an already observed organization can be flipped without
+recreating it.
+
+`failureReason` must be a member of the model's `CreateAccountFailureReason`
+enum; anything else is a 400. A typo'd reason would seed a `FAILED` status
+carrying a value no SDK catch branch matches, so the caller's fallback path would
+go untested while the seed appeared to work. The seeded failure is the case worth
+testing: `CreateAccount` still returns **200**, and only
+`DescribeCreateAccountStatus` reveals `FAILED`, the reason, and the absence of an
+`AccountId`.
 
 ### Cost
 

--- a/emulator/organizations_account.go
+++ b/emulator/organizations_account.go
@@ -143,7 +143,7 @@ func (p *OrganizationsPlugin) createAccount(reqCtx *RequestContext, req *AWSRequ
 		ID:                 "car-" + randomLowerAlphanum(8),
 		AccountName:        input.AccountName,
 		State:              orgCreateStateInProgress,
-		RequestedTimestamp: p.tc.Now(),
+		RequestedTimestamp: EpochSeconds(p.tc.Now()),
 	}
 	if err := p.orgPutJSON(goCtx, orgCreatePendingKey(status.ID), outcome); err != nil {
 		return nil, fmt.Errorf("createAccount save outcome: %w", err)
@@ -174,7 +174,7 @@ func (p *OrganizationsPlugin) vendAccount(ctx context.Context, masterAcct, orgID
 		Email:        email,
 		Status:       "ACTIVE",
 		JoinedMethod: "CREATED",
-		JoinedAt:     p.tc.Now(),
+		JoinedAt:     EpochSeconds(p.tc.Now()),
 	}
 	if err := p.saveAccount(ctx, masterAcct, a); err != nil {
 		return fmt.Errorf("createAccount save account: %w", err)
@@ -347,7 +347,7 @@ func (p *OrganizationsPlugin) resolveCreateAccountStatus(ctx context.Context, ac
 		return fmt.Errorf("organizations: create-account request %s has no recorded outcome", st.ID)
 	}
 
-	completed := p.tc.Now()
+	completed := EpochSeconds(p.tc.Now())
 	st.CompletedTimestamp = &completed
 	if pending.FailureReason != "" {
 		st.State = orgCreateStateFailed

--- a/emulator/organizations_account_test.go
+++ b/emulator/organizations_account_test.go
@@ -17,14 +17,18 @@ import (
 // orgCreateStatus is the CreateAccountStatus shape, named exactly as the model
 // spells its members so a rename in the plugin fails the decode rather than
 // silently reading back a zero value.
+// The timestamps decode as numbers, not strings: the JSON 1.1 protocol carries a
+// timestamp as epoch seconds, and aws-sdk-go-v2 fails the whole response on an
+// RFC3339 string. Decoding them as float64 here is what makes this test able to
+// catch that — a string field would accept the wire form the SDK rejects.
 type orgCreateStatus struct {
-	ID                 string  `json:"Id"`
-	AccountName        string  `json:"AccountName"`
-	State              string  `json:"State"`
-	RequestedTimestamp string  `json:"RequestedTimestamp"`
-	CompletedTimestamp *string `json:"CompletedTimestamp"`
-	AccountID          string  `json:"AccountId"`
-	FailureReason      string  `json:"FailureReason"`
+	ID                 string   `json:"Id"`
+	AccountName        string   `json:"AccountName"`
+	State              string   `json:"State"`
+	RequestedTimestamp *float64 `json:"RequestedTimestamp"`
+	CompletedTimestamp *float64 `json:"CompletedTimestamp"`
+	AccountID          string   `json:"AccountId"`
+	FailureReason      string   `json:"FailureReason"`
 }
 
 // orgCreateAccount posts CreateAccount and returns the status and the HTTP code.
@@ -342,8 +346,8 @@ func TestOrganizations_CreateAccountIsAsynchronous(t *testing.T) {
 	if status.AccountName != "dev-account" {
 		t.Errorf("expected AccountName=dev-account, got %q", status.AccountName)
 	}
-	if status.RequestedTimestamp == "" {
-		t.Error("expected a RequestedTimestamp on the in-progress request")
+	if status.RequestedTimestamp == nil || *status.RequestedTimestamp <= 0 {
+		t.Errorf("expected a RequestedTimestamp in epoch seconds, got %v", status.RequestedTimestamp)
 	}
 	// The model's CreateAccountRequestId pattern is ^car-[a-z0-9]{8,32}$.
 	if !orgMatchesCreateRequestID(status.ID) {

--- a/emulator/organizations_plugin_test.go
+++ b/emulator/organizations_plugin_test.go
@@ -112,6 +112,24 @@ func TestOrganizations_ListAccounts(t *testing.T) {
 	if !ok || len(accounts) == 0 {
 		t.Fatalf("expected at least 1 account, got %v", out["Accounts"])
 	}
+
+	// JoinedTimestamp is a JSON number, not a string. The JSON 1.1 protocol carries
+	// a timestamp as epoch seconds, and aws-sdk-go-v2's decoder calls
+	// ParseEpochSeconds on the member: an RFC3339 string fails the whole response,
+	// so an SDK caller gets a deserialization error instead of an account list. This
+	// is asserted on the raw decode rather than through a typed struct, because a
+	// struct field would coerce and hide the wire form.
+	account, ok := accounts[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected an account object, got %v", accounts[0])
+	}
+	joined, ok := account["JoinedTimestamp"].(float64)
+	if !ok {
+		t.Fatalf("JoinedTimestamp = %#v, want a JSON number of epoch seconds", account["JoinedTimestamp"])
+	}
+	if joined <= 0 {
+		t.Errorf("JoinedTimestamp = %v, want a positive epoch-seconds value", joined)
+	}
 }
 
 func TestOrganizations_CreateAccount_DescribeAccount(t *testing.T) {

--- a/emulator/organizations_state.go
+++ b/emulator/organizations_state.go
@@ -368,7 +368,7 @@ func (p *OrganizationsPlugin) ensureOrganization(ctx context.Context, acct strin
 		Email:        "master@example.com",
 		Status:       "ACTIVE",
 		JoinedMethod: "INVITED",
-		JoinedAt:     p.tc.Now(),
+		JoinedAt:     EpochSeconds(p.tc.Now()),
 	}
 	if err := p.saveAccount(ctx, acct, masterAccount); err != nil {
 		return nil, err

--- a/emulator/organizations_store_test.go
+++ b/emulator/organizations_store_test.go
@@ -267,8 +267,10 @@ func TestOrganizations_CreateAccountStatusStore(t *testing.T) {
 		t.Fatalf("expected no requests in a fresh organization, got %v", ids)
 	}
 
-	requested := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	completed := requested.Add(time.Minute)
+	// EpochSeconds, because that is what the wire form of a JSON 1.1 timestamp
+	// requires; the store round-trips whatever the API shape carries.
+	requested := emulator.EpochSeconds(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	completed := emulator.EpochSeconds(requested.Time().Add(time.Minute))
 	for _, st := range []emulator.OrgCreateAccountStatus{
 		{ID: "car-bbbbbbbb", AccountName: "prod", State: "IN_PROGRESS", RequestedTimestamp: requested},
 		{
@@ -299,7 +301,7 @@ func TestOrganizations_CreateAccountStatusStore(t *testing.T) {
 	if failed.State != "FAILED" || failed.FailureReason != "EMAIL_ALREADY_EXISTS" || failed.AccountID != "" {
 		t.Errorf("expected a FAILED status carrying no AccountId, got %+v", failed)
 	}
-	if failed.CompletedTimestamp == nil || !failed.CompletedTimestamp.Equal(completed) {
+	if failed.CompletedTimestamp == nil || !failed.CompletedTimestamp.Time().Equal(completed.Time()) {
 		t.Errorf("expected the completion timestamp preserved, got %v", failed.CompletedTimestamp)
 	}
 

--- a/emulator/organizations_types.go
+++ b/emulator/organizations_types.go
@@ -1,7 +1,5 @@
 package emulator
 
-import "time"
-
 // organizationsNamespace is the service name used by OrganizationsPlugin.
 const organizationsNamespace = "organizations"
 
@@ -56,8 +54,12 @@ type OrgAccount struct {
 	// values, and the management account is not created by Organizations.
 	JoinedMethod string `json:"JoinedMethod"`
 
-	// JoinedAt is the time the account joined the organization.
-	JoinedAt time.Time `json:"JoinedTimestamp"`
+	// JoinedAt is the time the account joined the organization. It is an
+	// EpochSeconds rather than a time.Time because the JSON 1.1 protocol carries a
+	// timestamp as a JSON number: aws-sdk-go-v2's decoder calls ParseEpochSeconds
+	// on the member and fails the whole response on an RFC3339 string, so an
+	// SDK caller would get a deserialization error instead of an account.
+	JoinedAt EpochSeconds `json:"JoinedTimestamp"`
 }
 
 // OrgRoot is the root container of the organization hierarchy.
@@ -175,11 +177,14 @@ type OrgCreateAccountStatus struct {
 	State string `json:"State"`
 
 	// RequestedTimestamp is when CreateAccount was called, on the simulated clock.
-	RequestedTimestamp time.Time `json:"RequestedTimestamp"`
+	// EpochSeconds for the same reason Account.JoinedAt is: the JSON 1.1 wire form
+	// of a timestamp is a number, and the SDK refuses a string.
+	RequestedTimestamp EpochSeconds `json:"RequestedTimestamp"`
 
-	// CompletedTimestamp is when the request reached a terminal state; the zero
-	// value while IN_PROGRESS.
-	CompletedTimestamp *time.Time `json:"CompletedTimestamp,omitempty"`
+	// CompletedTimestamp is when the request reached a terminal state, and is
+	// omitted entirely while IN_PROGRESS — a waiter reads State, and a completion
+	// time on a request that has not completed would contradict it.
+	CompletedTimestamp *EpochSeconds `json:"CompletedTimestamp,omitempty"`
 
 	// AccountID is the created account, set only when State is SUCCEEDED.
 	AccountID string `json:"AccountId,omitempty"`

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.57.1
+	github.com/aws/aws-sdk-go-v2/service/organizations v1.53.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.3
 	github.com/aws/smithy-go v1.27.6

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -28,6 +28,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.35 h1:BBEElKh4
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.35/go.mod h1:zaZk983w//8beSruBVec/mr4CmDwgZitW/qzGhAAX0g=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.35 h1:ohfdSAm4TA6nryIY7mLqe4mnSIAnAreoAPBM81ZVoIM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.35/go.mod h1:uUjphnxMb3HH3vIiOHl4dH0fGNKL+csjqRQEabbfw5k=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.53.5 h1:K0Ayr+MNVSkEVbD/dnQ1/bVDcFqKl2CNoF/ZfMUoSDI=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.53.5/go.mod h1:mJSUa59X8tlEX0DVvxdHZvMMrll/65omXLuwk2FCRDw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.106.3 h1:oSfubHEP3a0nTRAtm99IDaws0f15qwf+fOwS1Esh5jI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.106.3/go.mod h1:lWk6L5Q3YkaC7so1bQUJkvF7hj2KUFzdZ4w15wc2GHY=
 github.com/aws/aws-sdk-go-v2/service/signin v1.5.3 h1:togAtAmgV5IGMnQDuBDJeM8z5Y5RN6G7xeOgphWz+Yc=

--- a/test/e2e/journey_organizations_test.go
+++ b/test/e2e/journey_organizations_test.go
@@ -1,0 +1,466 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_OrganizationsAccountVending is #577 and #578 at the SDK level: the
+// account-vending run a landing-zone tool actually performs, through the real
+// Organizations client rather than a hand-built request.
+//
+// The unit tests cover each operation. What only this level can catch is the join
+// between them — #610 was exactly that: OrganizationsPlugin was registered and
+// fully unit-tested while every SDK call fell through to "service not emulated",
+// because the target prefix never routed. A journey through the SDK is the cheapest
+// thing that fails when the plugin is unreachable.
+//
+// The journey is also the property #578 is really about: a vending run must be
+// *re-runnable*. The second pass has to hit refusals rather than silently
+// duplicating, and that is asserted here through the SDK's typed errors, because
+// errors.As on the typed exception is the branch a consumer's error handling
+// actually takes.
+func TestJourney_OrganizationsAccountVending(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	// Retries off, so every assertion below is about the first response rather than
+	// whatever the SDK's retry loop eventually settled on.
+	orgs := organizations.NewFromConfig(cfg, func(o *organizations.Options) { o.RetryMaxAttempts = 1 })
+
+	// --- #577: the root has one identity ---
+	//
+	// Two ListRoots calls, because that is the issue's repro verbatim. Everything
+	// after this references the root, so an ID that moved between calls would make
+	// the rest of the journey meaningless rather than failing loudly.
+	first, err := orgs.ListRoots(ctx, &organizations.ListRootsInput{})
+	if err != nil {
+		t.Fatalf("ListRoots: %v", err)
+	}
+	if len(first.Roots) != 1 {
+		t.Fatalf("ListRoots returned %d roots, want exactly 1", len(first.Roots))
+	}
+	rootID := aws.ToString(first.Roots[0].Id)
+	rootARN := aws.ToString(first.Roots[0].Arn)
+
+	second, err := orgs.ListRoots(ctx, &organizations.ListRootsInput{})
+	if err != nil {
+		t.Fatalf("ListRoots again: %v", err)
+	}
+	if got := aws.ToString(second.Roots[0].Id); got != rootID {
+		t.Fatalf("the root ID moved between calls: %q then %q", rootID, got)
+	}
+	if got := aws.ToString(second.Roots[0].Arn); got != rootARN {
+		t.Fatalf("the root ARN moved between calls: %q then %q", rootARN, got)
+	}
+
+	// --- the governed OU the account will land in ---
+	ou, err := orgs.CreateOrganizationalUnit(ctx, &organizations.CreateOrganizationalUnitInput{
+		ParentId: aws.String(rootID),
+		Name:     aws.String("prod"),
+		Tags:     []orgtypes.Tag{{Key: aws.String("Owner"), Value: aws.String("platform")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateOrganizationalUnit: %v", err)
+	}
+	ouID := aws.ToString(ou.OrganizationalUnit.Id)
+
+	// The tag has to be readable back, or nothing downstream can gate on it.
+	tags, err := orgs.ListTagsForResource(ctx, &organizations.ListTagsForResourceInput{
+		ResourceId: aws.String(ouID),
+	})
+	if err != nil {
+		t.Fatalf("ListTagsForResource on the OU: %v", err)
+	}
+	if len(tags.Tags) != 1 || aws.ToString(tags.Tags[0].Key) != "Owner" {
+		t.Fatalf("expected the OU's create-time tag readable, got %+v", tags.Tags)
+	}
+
+	// A second OU of the same name under the same parent is refused. A landing-zone
+	// tool's re-run does exactly this.
+	var dupOU *orgtypes.DuplicateOrganizationalUnitException
+	if _, err := orgs.CreateOrganizationalUnit(ctx, &organizations.CreateOrganizationalUnitInput{
+		ParentId: aws.String(rootID),
+		Name:     aws.String("prod"),
+	}); err == nil {
+		t.Fatal("a duplicate OU name: expected DuplicateOrganizationalUnitException")
+	} else if !errors.As(err, &dupOU) {
+		t.Fatalf("expected *DuplicateOrganizationalUnitException, got %T: %v", err, err)
+	}
+
+	// --- #578: vending is asynchronous ---
+	//
+	// The call returns IN_PROGRESS with a request ID, as AWS does. A caller that
+	// read State without polling would see a state that is not terminal.
+	created, err := orgs.CreateAccount(ctx, &organizations.CreateAccountInput{
+		AccountName: aws.String("dev"),
+		Email:       aws.String("dev@example.com"),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	if created.CreateAccountStatus.State != orgtypes.CreateAccountStateInProgress {
+		t.Fatalf("CreateAccount State = %q, want IN_PROGRESS", created.CreateAccountStatus.State)
+	}
+	if aws.ToString(created.CreateAccountStatus.AccountId) != "" {
+		t.Fatal("CreateAccount reported an AccountId before the request resolved")
+	}
+	requestID := aws.ToString(created.CreateAccountStatus.Id)
+
+	// The poll a waiter performs. It converges in one observation, with no
+	// wall-clock dependence — the property that makes this test not flake.
+	status, err := orgs.DescribeCreateAccountStatus(ctx, &organizations.DescribeCreateAccountStatusInput{
+		CreateAccountRequestId: aws.String(requestID),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCreateAccountStatus: %v", err)
+	}
+	if status.CreateAccountStatus.State != orgtypes.CreateAccountStateSucceeded {
+		t.Fatalf("status State = %q, want SUCCEEDED", status.CreateAccountStatus.State)
+	}
+	accountID := aws.ToString(status.CreateAccountStatus.AccountId)
+	if accountID == "" {
+		t.Fatal("a SUCCEEDED status carried no AccountId")
+	}
+
+	// --- placement: the account starts in the root and MoveAccount is the only
+	// way out of it ---
+	if parents := journeyOrgParents(t, ctx, orgs, accountID); len(parents) != 1 || parents[0] != rootID {
+		t.Fatalf("a new account's parents = %v, want just the root %s", parents, rootID)
+	}
+	if _, err := orgs.MoveAccount(ctx, &organizations.MoveAccountInput{
+		AccountId:           aws.String(accountID),
+		SourceParentId:      aws.String(rootID),
+		DestinationParentId: aws.String(ouID),
+	}); err != nil {
+		t.Fatalf("MoveAccount: %v", err)
+	}
+	if parents := journeyOrgParents(t, ctx, orgs, accountID); len(parents) != 1 || parents[0] != ouID {
+		t.Fatalf("after the move, parents = %v, want just the OU %s", parents, ouID)
+	}
+
+	// Both listings have to agree about where the account is, since a tool reads
+	// placement from one and asserts on the other.
+	if got := journeyOrgAccountsForParent(t, ctx, orgs, ouID); len(got) != 1 || got[0] != accountID {
+		t.Fatalf("ListAccountsForParent(%s) = %v, want just %s", ouID, got, accountID)
+	}
+	for _, id := range journeyOrgAccountsForParent(t, ctx, orgs, rootID) {
+		if id == accountID {
+			t.Fatalf("the moved account is still reported under the root %s", rootID)
+		}
+	}
+
+	// --- the re-run: the same move is a refusal, not a no-op ---
+	//
+	// This is the re-runnability property. A no-op here would let a tool's second
+	// pass appear to succeed while doing nothing, and a duplicate would corrupt the
+	// hierarchy; the API's answer is DuplicateAccountException, which the source
+	// parent no longer matching is *not* — so both refusals are asserted.
+	var dupAccount *orgtypes.DuplicateAccountException
+	if _, err := orgs.MoveAccount(ctx, &organizations.MoveAccountInput{
+		AccountId:           aws.String(accountID),
+		SourceParentId:      aws.String(ouID),
+		DestinationParentId: aws.String(ouID),
+	}); err == nil {
+		t.Fatal("moving to the current parent: expected DuplicateAccountException")
+	} else if !errors.As(err, &dupAccount) {
+		t.Fatalf("expected *DuplicateAccountException, got %T: %v", err, err)
+	}
+
+	// A source that is not the account's actual parent is its own refusal. It needs a
+	// destination that is not the current parent, because the destination is checked
+	// first: on a governance re-run the useful answer is "already in the destination",
+	// not "your source does not exist", so the order matters and is asserted by these
+	// two cases together.
+	var srcNotFound *orgtypes.SourceParentNotFoundException
+	if _, err := orgs.MoveAccount(ctx, &organizations.MoveAccountInput{
+		AccountId:           aws.String(accountID),
+		SourceParentId:      aws.String(rootID), // no longer the parent
+		DestinationParentId: aws.String(rootID),
+	}); err == nil {
+		t.Fatal("a stale source parent: expected SourceParentNotFoundException")
+	} else if !errors.As(err, &srcNotFound) {
+		t.Fatalf("expected *SourceParentNotFoundException, got %T: %v", err, err)
+	}
+
+	// An unknown account is AccountNotFoundException at HTTP 400 — the model
+	// declares no 404 for it, so a consumer branching on the status must not see one.
+	var acctNotFound *orgtypes.AccountNotFoundException
+	if _, err := orgs.DescribeAccount(ctx, &organizations.DescribeAccountInput{
+		AccountId: aws.String("999999999999"),
+	}); err == nil {
+		t.Fatal("an unknown account: expected AccountNotFoundException")
+	} else if !errors.As(err, &acctNotFound) {
+		t.Fatalf("expected *AccountNotFoundException, got %T: %v", err, err)
+	}
+}
+
+// TestJourney_OrganizationsSeededVendingFailure covers the case a vending tool's
+// error path exists for and that no nominal run reaches: the account never gets
+// created.
+//
+// The shape is what makes it worth a journey. CreateAccount still answers HTTP
+// 200 with IN_PROGRESS — the SDK raises nothing at all — and the failure is
+// observable only through DescribeCreateAccountStatus. A consumer that treats a
+// successful CreateAccount as a vended account never notices, which is precisely
+// the bug this seed lets a test catch.
+func TestJourney_OrganizationsSeededVendingFailure(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	orgs := organizations.NewFromConfig(cfg, func(o *organizations.Options) { o.RetryMaxAttempts = 1 })
+
+	journeySeedOrgCreateFailure(t, ts, "dup", "EMAIL_ALREADY_EXISTS")
+
+	created, err := orgs.CreateAccount(ctx, &organizations.CreateAccountInput{
+		AccountName: aws.String("dup"),
+		Email:       aws.String("taken@example.com"),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount under a seeded failure must still succeed: %v", err)
+	}
+	if created.CreateAccountStatus.State != orgtypes.CreateAccountStateInProgress {
+		t.Fatalf("CreateAccount State = %q, want IN_PROGRESS", created.CreateAccountStatus.State)
+	}
+
+	status, err := orgs.DescribeCreateAccountStatus(ctx, &organizations.DescribeCreateAccountStatusInput{
+		CreateAccountRequestId: created.CreateAccountStatus.Id,
+	})
+	if err != nil {
+		t.Fatalf("DescribeCreateAccountStatus: %v", err)
+	}
+	if status.CreateAccountStatus.State != orgtypes.CreateAccountStateFailed {
+		t.Fatalf("status State = %q, want FAILED", status.CreateAccountStatus.State)
+	}
+	if status.CreateAccountStatus.FailureReason != orgtypes.CreateAccountFailureReasonEmailAlreadyExists {
+		t.Fatalf("FailureReason = %q, want EMAIL_ALREADY_EXISTS", status.CreateAccountStatus.FailureReason)
+	}
+	// No AccountId, because nothing was vended. A tool that read the ID off a
+	// FAILED status would carry an empty string into every call after it.
+	if got := aws.ToString(status.CreateAccountStatus.AccountId); got != "" {
+		t.Fatalf("a FAILED status carried AccountId %q", got)
+	}
+}
+
+// TestJourney_OrganizationsDisabledSCPState is #578 point 6 through the SDK: an
+// all-features organization whose root has had the SCP type disabled.
+//
+// It is the state a governance tool is most likely to get wrong, because it does
+// not look like a failure — CreatePolicy succeeds, and only the attach is refused.
+// Re-enabling then restores p-FullAWSAccess alone: the earlier attachments are
+// gone, so a tool that disabled and re-enabled a root has lost its governance and
+// gets no error saying so.
+func TestJourney_OrganizationsDisabledSCPState(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	orgs := organizations.NewFromConfig(cfg, func(o *organizations.Options) { o.RetryMaxAttempts = 1 })
+
+	roots, err := orgs.ListRoots(ctx, &organizations.ListRootsInput{})
+	if err != nil {
+		t.Fatalf("ListRoots: %v", err)
+	}
+	rootID := aws.ToString(roots.Roots[0].Id)
+
+	// A fresh organization already has the managed SCP attached to its root. A
+	// caller asserting an empty list here would be asserting against AWS's actual
+	// behaviour, which is why this is called out in the release's compatibility note.
+	attached := journeyOrgPoliciesForTarget(t, ctx, orgs, rootID)
+	if len(attached) != 1 || attached[0] != "p-FullAWSAccess" {
+		t.Fatalf("a fresh root's policies = %v, want just p-FullAWSAccess", attached)
+	}
+
+	const scpDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"iam:*","Resource":"*"}]}`
+	governing, err := orgs.CreatePolicy(ctx, &organizations.CreatePolicyInput{
+		Name:        aws.String("deny-iam"),
+		Description: aws.String("no IAM in prod"),
+		Type:        orgtypes.PolicyTypeServiceControlPolicy,
+		Content:     aws.String(scpDoc),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+	policyID := aws.ToString(governing.Policy.PolicySummary.Id)
+	if _, err := orgs.AttachPolicy(ctx, &organizations.AttachPolicyInput{
+		PolicyId: aws.String(policyID),
+		TargetId: aws.String(rootID),
+	}); err != nil {
+		t.Fatalf("AttachPolicy: %v", err)
+	}
+
+	// The last SCP on a target cannot be detached, so p-FullAWSAccess is load-bearing
+	// rather than decorative: a tool that detached it to "clean up" would be refused.
+	if _, err := orgs.DetachPolicy(ctx, &organizations.DetachPolicyInput{
+		PolicyId: aws.String(policyID),
+		TargetId: aws.String(rootID),
+	}); err != nil {
+		t.Fatalf("detaching one of two SCPs: %v", err)
+	}
+	var constraint *orgtypes.ConstraintViolationException
+	if _, err := orgs.DetachPolicy(ctx, &organizations.DetachPolicyInput{
+		PolicyId: aws.String("p-FullAWSAccess"),
+		TargetId: aws.String(rootID),
+	}); err == nil {
+		t.Fatal("detaching the last SCP: expected ConstraintViolationException")
+	} else if !errors.As(err, &constraint) {
+		t.Fatalf("expected *ConstraintViolationException, got %T: %v", err, err)
+	}
+
+	// Re-attach, so the disable below has an attachment to lose.
+	if _, err := orgs.AttachPolicy(ctx, &organizations.AttachPolicyInput{
+		PolicyId: aws.String(policyID),
+		TargetId: aws.String(rootID),
+	}); err != nil {
+		t.Fatalf("re-AttachPolicy: %v", err)
+	}
+
+	// --- the dangerous state ---
+	if _, err := orgs.DisablePolicyType(ctx, &organizations.DisablePolicyTypeInput{
+		RootId:     aws.String(rootID),
+		PolicyType: orgtypes.PolicyTypeServiceControlPolicy,
+	}); err != nil {
+		t.Fatalf("DisablePolicyType: %v", err)
+	}
+
+	// CreatePolicy still succeeds — the trap. Nothing in this response tells a
+	// caller its policy can never take effect.
+	quarantine, err := orgs.CreatePolicy(ctx, &organizations.CreatePolicyInput{
+		Name:        aws.String("deny-all"),
+		Description: aws.String("quarantine"),
+		Type:        orgtypes.PolicyTypeServiceControlPolicy,
+		Content:     aws.String(`{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"*","Resource":"*"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy while the type is disabled must still succeed: %v", err)
+	}
+	var notEnabled *orgtypes.PolicyTypeNotEnabledException
+	if _, err := orgs.AttachPolicy(ctx, &organizations.AttachPolicyInput{
+		PolicyId: quarantine.Policy.PolicySummary.Id,
+		TargetId: aws.String(rootID),
+	}); err == nil {
+		t.Fatal("attaching while the type is disabled: expected PolicyTypeNotEnabledException")
+	} else if !errors.As(err, &notEnabled) {
+		t.Fatalf("expected *PolicyTypeNotEnabledException, got %T: %v", err, err)
+	}
+
+	// Re-enabling restores only the managed SCP. The deny-iam attachment is gone,
+	// and nothing reports that it went.
+	if _, err := orgs.EnablePolicyType(ctx, &organizations.EnablePolicyTypeInput{
+		RootId:     aws.String(rootID),
+		PolicyType: orgtypes.PolicyTypeServiceControlPolicy,
+	}); err != nil {
+		t.Fatalf("EnablePolicyType: %v", err)
+	}
+	restored := journeyOrgPoliciesForTarget(t, ctx, orgs, rootID)
+	if len(restored) != 1 || restored[0] != "p-FullAWSAccess" {
+		t.Fatalf("after re-enabling, the root's policies = %v, want just p-FullAWSAccess "+
+			"(attachments from before a disable are lost)", restored)
+	}
+}
+
+// journeyOrgParents walks every page of ListParents and returns the parent IDs.
+func journeyOrgParents(t *testing.T, ctx context.Context, orgs *organizations.Client, childID string) []string {
+	t.Helper()
+	var ids []string
+	pager := organizations.NewListParentsPaginator(orgs, &organizations.ListParentsInput{
+		ChildId: aws.String(childID),
+	})
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListParents(%s): %v", childID, err)
+		}
+		for _, parent := range page.Parents {
+			ids = append(ids, aws.ToString(parent.Id))
+		}
+	}
+	return ids
+}
+
+// journeyOrgAccountsForParent walks every page of ListAccountsForParent. The
+// paginator is used rather than a single call because MaxResults clamps to 20:
+// reading only the first page would make this assertion silently partial.
+func journeyOrgAccountsForParent(t *testing.T, ctx context.Context, orgs *organizations.Client, parentID string) []string {
+	t.Helper()
+	var ids []string
+	pager := organizations.NewListAccountsForParentPaginator(orgs, &organizations.ListAccountsForParentInput{
+		ParentId: aws.String(parentID),
+	})
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListAccountsForParent(%s): %v", parentID, err)
+		}
+		for _, account := range page.Accounts {
+			ids = append(ids, aws.ToString(account.Id))
+		}
+	}
+	return ids
+}
+
+// journeyOrgPoliciesForTarget walks every page of ListPoliciesForTarget for the
+// SCP type and returns the policy IDs.
+func journeyOrgPoliciesForTarget(t *testing.T, ctx context.Context, orgs *organizations.Client, targetID string) []string {
+	t.Helper()
+	var ids []string
+	pager := organizations.NewListPoliciesForTargetPaginator(orgs, &organizations.ListPoliciesForTargetInput{
+		TargetId: aws.String(targetID),
+		Filter:   orgtypes.PolicyTypeServiceControlPolicy,
+	})
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListPoliciesForTarget(%s): %v", targetID, err)
+		}
+		for _, policy := range page.Policies {
+			ids = append(ids, aws.ToString(policy.Id))
+		}
+	}
+	return ids
+}
+
+// journeySeedOrgCreateFailure seeds the asynchronous outcome of CreateAccount for
+// one account name. The seed is a plain HTTP POST rather than an SDK call: it is
+// substrate's control plane, not part of the AWS API, which is what keeps the
+// journey above it identical to the code a consumer runs against real AWS.
+func journeySeedOrgCreateFailure(t *testing.T, ts *emulator.TestServer, accountName, reason string) {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{
+		"accountName":   accountName,
+		"failureReason": reason,
+	})
+	if err != nil {
+		t.Fatalf("marshal the create-account-failure seed: %v", err)
+	}
+	resp, err := http.Post(ts.URL+"/v1/organizations/create-account-failure", //nolint:noctx
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /v1/organizations/create-account-failure: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /v1/organizations/create-account-failure: status %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Closes #578.

The last piece of the v0.97.0 Organizations milestone: the service reference, the
SDK-level journey, and the changelog for the four lanes that landed without one.

## A bug the journey found

Organizations timestamps were RFC3339 strings. The JSON 1.1 protocol carries a
timestamp as **epoch seconds**, and aws-sdk-go-v2 calls `ParseEpochSeconds` on the
member — so a string failed the whole response and every SDK caller got
`deserialization failed` from `ListAccounts`, `CreateAccount` and
`DescribeCreateAccountStatus`, while the operations behind them were correct.

`JoinedAt`, `RequestedTimestamp` and `CompletedTimestamp` now use the existing
`EpochSeconds` type. The unit tests had decoded those members as `string` and so
asserted the broken form; they now assert the number, and `ListAccounts` gained the
`JoinedTimestamp` assertion it never had.

This is the second bug of #610's class in this milestone — correct, unit-tested,
and unreachable from any SDK. That is what the journey level exists for.

## What changed

- **`docs/services.md`** — the section covered the five operations that predated
  this milestone. It now covers all thirty, plus `p-FullAWSAccess`, asynchronous
  vending, the disabled-SCP state, how tags reach the authorization decision, the
  refusal table, the quotas with their User Guide values, pagination, and both seed
  endpoints. Notes that `CreateOrganization` is deliberately absent: the
  organization already exists on first contact.
- **`test/e2e/journey_organizations_test.go`** — three journeys through the real
  `organizations` client, all asserting via typed exceptions since `errors.As` on
  the typed error is the branch a consumer's handling actually takes:
  1. the vending run — stable root across two `ListRoots`, OU with a create-time
     tag read back, create → poll → move, both listings agreeing on placement, then
     the **re-run** hitting `DuplicateAccountException` and
     `SourceParentNotFoundException` rather than silently duplicating;
  2. the seeded async failure — `CreateAccount` still answers 200, and only
     `DescribeCreateAccountStatus` reveals `FAILED`/`EMAIL_ALREADY_EXISTS`/no
     `AccountId`;
  3. the disabled-SCP state — a fresh root carries only `p-FullAWSAccess`, the last
     SCP cannot be detached, `CreatePolicy` **succeeds** while the type is disabled,
     `AttachPolicy` is refused, and re-enabling restores `p-FullAWSAccess` alone.
- **`CHANGELOG.md`** — the OU tree, the policy lifecycle, and asynchronous vending
  (the three lanes that landed without an entry), plus #610 and the timestamp fix.

## Verification

`gofmt -l .` clean; `go build ./...`; `go vet ./...`; `golangci-lint run ./...`
(0 issues); `make test` (race detector); `make docs-reference docs-reference-check
docs-versions`; `npm --prefix docs run build`; `go vet -C test/e2e ./...` and
`go test -C test/e2e ./...`.

**Mutation testing**, the five targets the plan named, all **CAUGHT** on a
full-package `-race` run with a verified-green baseline before and after:

| Mutation | Caught by |
|---|---|
| The persisted root reverted to per-call generation (the #577 bug) | 10+ tests, incl. the whole OU and vending suites |
| The OU depth boundary off by one | `TestOrganizations_OUDepthLimit` |
| The minimum-one-SCP guard dropped | `TestOrganizations_MinAttachmentFloor` |
| `MoveAccount`'s destination-equals-parent check removed | `TestOrganizations_FullVend`, `TestOrganizations_VendingRefusals` |
| The `MaxResults` upper clamp dropped | `TestOrganizations_Paginate` |

**Live server** (`:4678`, `AWS_MAX_ATTEMPTS=1`, scratch dir since removed): stable
root across two `ListRoots`; `JoinedTimestamp` now parsing into a datetime instead
of failing; OU tree with the 6th level refused as `OU_DEPTH_LIMIT_EXCEEDED`; vend →
poll → move → `DuplicateAccountException` on the re-run; `ListParents` reporting the
OU; an `aws:`-prefixed tag refused on create with `INVALID_SYSTEM_TAGS_PARAMETER`;
the full disabled-SCP journey; the seeded failure answering 200 with only the status
revealing `FAILED`; and `AccountNotFoundException` at HTTP 400.