### PR TITLE
docs: specify the PR merge command and delete the branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `CLAUDE.md` now specifies the merge command, `gh pr merge <N> --squash
+  --delete-branch`, and forbids `--delete-branch=false`. The repository's
+  `delete_branch_on_merge` is `false`, so the flag is the only thing that removes a
+  merged branch; 45 of them had accumulated by v0.97.0, none deliberately kept.
+  Contributor process only — no emulator behaviour changes.
+
 ## [v0.97.0] - 2026-08-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,14 @@ https://github.com/scttfrdmn/substrate/issues.
 Milestones map directly to semver releases:
 https://github.com/scttfrdmn/substrate/milestones
 
+Merge with `gh pr merge <N> --squash --delete-branch`. **Do not pass
+`--delete-branch=false`** — the repository's `delete_branch_on_merge` is `false`, so
+the flag is the only thing that removes the branch, and omitting it leaves the merged
+branch on the remote indefinitely. That is how 45 merged branches accumulated through
+v0.97.0 before being swept; none of them had been kept for a reason. A branch is
+recoverable from its PR page after deletion, so keeping it buys nothing that a squash
+merge has not already recorded on `main`.
+
 ## Code conventions
 
 - Idiomatic Go 1.26; target A+ on https://goreportcard.com/report/github.com/scttfrdmn/substrate


### PR DESCRIPTION
`CLAUDE.md` documented the release process in detail but never specified how a PR
gets merged. The repository's `delete_branch_on_merge` is `false`, so
`--delete-branch` is the only thing that removes a merged branch — and with no
documented command, every merge left one behind.

45 merged branches had accumulated on the remote by v0.97.0. All were swept after
verifying each one: every branch had a MERGED PR, none had a commit dated after its
merge, and no file existed only on a branch — every branch-side line was a stale
copy of a file `main` had since moved past. None had been kept for a reason.

This adds the command to the Work tracking section, where the PR lifecycle belongs,
and states why `--delete-branch=false` is wrong here rather than just banning it: a
branch is recoverable from its PR page after deletion, so keeping it buys nothing a
squash merge has not already recorded on `main`.

Contributor process only — no emulator behaviour changes, so the compatibility
surface is untouched.

Setting the repository's `delete_branch_on_merge` to `true` would make this
structural rather than procedural. That is a repo-settings change rather than a code
one, so it is left to the maintainer.