### PR TITLE
chore(deps): move the toolchain to go1.26.6 for seven stdlib CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Bumped the `toolchain` directive in both modules from `go1.26.5` to `go1.26.6`,
+  clearing seven standard-library vulnerabilities `govulncheck` reports as reachable
+  from substrate's own call paths — among them recursion-depth guards in
+  `encoding/xml` (reached from `putBucketVersioning` and CloudFront's `tagResource`)
+  and `encoding/asn1`, and the `net/http` Punycode-label rejection failure. CI
+  resolves its Go version from `go.mod` via `setup-go`'s `go-version-file`, so the
+  directive is what pinned the vulnerable toolchain. No code changes; the daily
+  Security workflow first caught this on 2026-08-14 when the advisories were
+  published against go1.26.5.
+
 ### Changed
 - `CLAUDE.md` now specifies the merge command, `gh pr merge <N> --squash
   --delete-branch`, and forbids `--delete-branch=false`. The repository's

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/scttfrdmn/substrate
 
 go 1.26
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/go-chi/chi/v5 v5.3.1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/scttfrdmn/substrate/test/e2e
 
 go 1.26
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4


### PR DESCRIPTION
The daily Security workflow went red on `main` at 735ce57 — not from any code change,
but because seven Go standard-library advisories were published against **go1.26.5**,
all fixed in **go1.26.6**. `govulncheck` reports each as reachable from substrate's
own call paths, not merely present in the module graph:

| Advisory | Package | Reached from |
|---|---|---|
| GO-2026-6088 | `encoding/xml` | `S3Plugin.putBucketVersioning`, `CloudFrontPlugin.tagResource`, `s3XMLHasChildElement` |
| GO-2026-5972 | `encoding/asn1` | `GetManagedPolicy` |
| GO-2026-5026 | `net/http` (idna) | `AWSPricingProvider.fetchServicePrices`, `StartTestServer`, `TestServer.ResetState` |

(plus four more; full list in the workflow log.)

CI resolves its Go version from `go.mod` through `setup-go`'s `go-version-file`, so
the `toolchain` directive is the thing that pinned the vulnerable version — bumping it
is the whole fix. Both modules move together because `test/e2e` consumes the root
through a `replace` directive.

No code changes. `govulncheck ./...` reports **"No vulnerabilities found"** locally on
go1.26.6, down from seven.

This is independent of #621 (otel SDK) — that PR's own red `Go Vulnerability Check` is
this same pre-existing failure, not anything it introduced, and will clear once this
lands and it rebases.

## Verification

`gofmt -l`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues),
`make test` (race detector), `go test -C test/e2e ./...`, `make docs-versions` and
`make version-check` all pass.