### PR TITLE
feat(organizations): implement the organization resource policy (#619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **The organization's resource policy is now readable, writable and deletable**
+  (#619). `PutResourcePolicy`, `DescribeResourcePolicy` and `DeleteResourcePolicy`
+  were claimed by no operation cluster, so every one of them fell through to
+  `InvalidAction` — which a consumer reads as "no such API" rather than "substrate
+  has not implemented it", sending it to hunt a bug in its own request. Found by
+  driving a read-only Organizations consumer against `substrate server` at v0.97.0,
+  not by reading the API model.
+
+  The cluster's shape is unlike every other one in Organizations: an organization
+  holds exactly **one** resource policy, `Put` replaces it wholesale, and `Describe`
+  and `Delete` take no input at all. Three consequences a consumer depends on:
+  - The `rp-` ID and its ARN are minted once and **survive every replacement**. A
+    re-mint would tell a caller holding the ARN that its policy had been replaced by
+    a different one, when the same single policy was updated — and with one per
+    organization, a new ID distinguishes nothing.
+  - `DescribeResourcePolicy`'s `ResourcePolicyNotFoundException` is the **normal**
+    answer, since most organizations have no resource policy. Answering an empty
+    policy would collapse "nothing was delegated to me" and "something was delegated
+    that I cannot read" into one observation, and those are different branches in a
+    caller's error handling. `DeleteResourcePolicy` refuses the same way, so a second
+    teardown pass is a refusal it can branch on rather than an outcome
+    indistinguishable from the first.
+  - Inline `Tags` apply only to the initial creation, per the API model's note, and
+    go through the same `validateOrgCreateTags` every other Organizations create
+    uses — so an `aws:`-prefixed key cannot be planted here and then read as
+    `aws:ResourceTag` by a policy condition. A `Put` carrying tags against an
+    existing policy is refused rather than silently dropping them, which would leave
+    a tag-gated authorization decision reading a tag set the caller believes it just
+    wrote. Deleting the policy deletes its tags.
+
+  Content is bounded at the model's 1–40,000 characters and must parse as JSON,
+  refused as `INVALID_RESOURCE_POLICY_JSON`. That the document is parsed at all comes
+  from that member of the model's `InvalidInputExceptionReason` enum, not from the
+  shape's pattern, which is `[\s\S]*` — any text. Only parseability is checked: the
+  same enum's `INVALID_PRINCIPAL` and `UNSUPPORTED_ACTION_IN_RESOURCE_POLICY` are
+  refusals about the document's meaning, and the sets AWS accepts are not in the
+  model, so emitting them would mean guessing at their boundaries — and a guessed
+  refusal fails a document AWS would have accepted. For the same reason the
+  tags-on-update refusal carries **no** reason prefix, unlike every other
+  `InvalidInputException` here: no enum member describes it, and borrowing one would
+  read as documented behaviour while matching no branch a consumer could write.
+
+  The policy is also a tagging target, so
+  `TagResource`/`UntagResource`/`ListTagsForResource` reach it and its ARN resolves in
+  the authorization path instead of falling through to `*`.
+
+  Not modelled, and tracked in #623: the asymmetry itself. Organizations state is
+  keyed by the **calling** account, so a member account reading the policy sees its
+  own organization rather than management's, and there is no `AccessDeniedException`
+  for a caller outside the organization. Both need a member→organization reverse
+  index that does not exist yet.
+
 ### Security
 - Bumped the `toolchain` directive in both modules from `go1.26.5` to `go1.26.6`,
   clearing seven standard-library vulnerabilities `govulncheck` reports as reachable

--- a/docs/services.md
+++ b/docs/services.md
@@ -4520,12 +4520,53 @@ document has no `Reason` member to put them in.
 | ListTargetsForPolicy | Reports the root, OU and account targets of one policy |
 | EnablePolicyType | `PolicyTypeAlreadyEnabledException`; restores only `p-FullAWSAccess` |
 | DisablePolicyType | Detaches every SCP from every entity in the root |
-| TagResource | Roots, OUs, accounts and policies |
+| PutResourcePolicy | `Content` is required, 1–40,000 characters; `Tags` only on the first call |
+| DescribeResourcePolicy | `ResourcePolicyNotFoundException` when none is set — the usual case |
+| DeleteResourcePolicy | `ResourcePolicyNotFoundException` when none is set, so a re-run is a refusal |
+| TagResource | Roots, OUs, accounts, policies and the resource policy |
 | UntagResource | Validates key shape on the removal path too |
 | ListTagsForResource | Paginated by `NextToken`; no `MaxResults` |
 
 `CreateOrganization` is not implemented: the organization already exists on first
 contact, so there is nothing for it to create.
+
+### The resource policy
+
+An organization holds **exactly one** resource policy — the delegation document
+that lets a member account make a read management would otherwise have to make.
+That shape is unlike everything else here: there is no list, no per-statement
+update, and `PutResourcePolicy` replaces the document wholesale.
+
+The `rp-` ID and its ARN are minted once and **survive every replacement**. A
+re-mint would tell a caller holding the ARN that its policy had been replaced by a
+different one, when the same single policy was updated — and with only one per
+organization, there is nothing a new ID could distinguish it from.
+
+`DescribeResourcePolicy`'s refusal is the **normal** answer, not an edge case: most
+organizations have no resource policy. A caller checking whether anything was
+delegated to it has to tell `ResourcePolicyNotFoundException` apart from
+`AccessDeniedException`, so answering an empty policy would collapse "no
+delegation" and "delegation I cannot read" into one observation.
+
+`Tags` apply only to the initial creation, per the API model; a `Put` carrying
+tags against an existing policy is refused rather than silently dropping them,
+which would leave a tag-gated decision reading a tag set the caller believes it
+just wrote. Deleting the policy deletes its tags.
+
+Content must **parse as JSON**, refused as
+`InvalidInputException`/`INVALID_RESOURCE_POLICY_JSON`. The evidence is that enum
+member in the API model, not the shape's own pattern — which is `[\s\S]*`, any text
+at all. Only parseability is checked: the enum's `INVALID_PRINCIPAL`,
+`UNSUPPORTED_ACTION_IN_RESOURCE_POLICY` and the two like them are refusals about the
+document's *meaning*, and the sets AWS accepts are not in the model, so emitting
+them would mean guessing at their boundaries. A guessed refusal is worse than a
+missing one: it fails a document AWS would have accepted.
+
+**Not modelled:** the asymmetry itself. Organizations state is keyed by the
+**calling** account, so a member account calling `DescribeResourcePolicy` reads its
+own organization rather than management's, and there is no
+`AccessDeniedException` for a caller outside the organization. Both need a
+member→organization reverse index, tracked in #623.
 
 ### `p-FullAWSAccess`
 
@@ -4601,6 +4642,10 @@ deletes its tags, so an entity that reused the ID cannot inherit them.
 | Unknown OU | `OrganizationalUnitNotFoundException` |
 | Unknown parent / child / root | `ParentNotFoundException` / `ChildNotFoundException` / `RootNotFoundException` |
 | Unknown policy / attachment target | `PolicyNotFoundException` / `TargetNotFoundException` |
+| Describing or deleting an unset resource policy | `ResourcePolicyNotFoundException` |
+| Resource-policy content outside 1–40,000 characters | `InvalidInputException`/`MIN_LENGTH_EXCEEDED` or `MAX_LENGTH_EXCEEDED` |
+| Unparseable resource-policy content | `InvalidInputException`/`INVALID_RESOURCE_POLICY_JSON` |
+| `PutResourcePolicy` with `Tags` on an existing policy | `InvalidInputException`, with no reason prefix — the model's enum has no member for it |
 | Duplicate OU name under one parent | `DuplicateOrganizationalUnitException` |
 | Duplicate policy name | `DuplicatePolicyException` |
 | Already attached | `DuplicatePolicyAttachmentException` |
@@ -4635,6 +4680,7 @@ and each is enforced rather than merely documented.
 | SCPs in an organization | 10,000 | `POLICY_NUMBER_LIMIT_EXCEEDED` |
 | SCPs attached to one root, OU or account | 10 max, **1 min** | `MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED` / `MIN_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED` |
 | Characters in an SCP | 10,240 | `POLICY_CONTENT_LIMIT_EXCEEDED` |
+| Characters in the resource policy | 40,000 | `MAX_LENGTH_EXCEEDED` |
 | Tags on one resource | 50 | `MAX_TAG_LIMIT_EXCEEDED` |
 
 The 5-per-target and 5,120-character figures often quoted are the **RCP** values,

--- a/emulator/organizations_plugin.go
+++ b/emulator/organizations_plugin.go
@@ -64,6 +64,7 @@ func (p *OrganizationsPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest
 		p.policyOperation,
 		p.accountOperation,
 		p.tagOperation,
+		p.resourcePolicyOperation,
 	} {
 		if h, ok := claim(req.Operation); ok {
 			return h(ctx, req)

--- a/emulator/organizations_policy_test.go
+++ b/emulator/organizations_policy_test.go
@@ -1726,7 +1726,10 @@ func TestOrganizations_PolicyOperationsAreClaimed(t *testing.T) {
 		}
 	}
 
-	resp := orgsRequest(t, ts, "DescribeResourcePolicy", map[string]interface{}{})
+	// A policy operation substrate does not implement, so the fallthrough is
+	// asserted against this lane's own subject area rather than a distant one.
+	// DescribeResourcePolicy stood here until v0.98.0 implemented it (#619).
+	resp := orgsRequest(t, ts, "DescribeEffectivePolicy", map[string]interface{}{})
 	var out struct {
 		Type string `json:"__type"`
 	}

--- a/emulator/organizations_resourcepolicy.go
+++ b/emulator/organizations_resourcepolicy.go
@@ -1,0 +1,241 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"unicode/utf8"
+)
+
+// Resource policy bounds, from the Organizations API model's ResourcePolicyContent
+// shape. The maximum is corroborated by "Maximum size of the resource-based
+// delegation policy: 40,000 characters" in the Organizations User Guide.
+const (
+	// orgMinResourcePolicyChars is ResourcePolicyContent's minimum length. An
+	// empty document is refused rather than stored: it would delegate nothing
+	// while DescribeResourcePolicy reported a policy in place, which is the one
+	// answer a caller checking for delegation must not get wrong.
+	orgMinResourcePolicyChars = 1
+
+	// orgMaxResourcePolicyChars is ResourcePolicyContent's maximum length, in
+	// characters rather than bytes — which is what the model's max means, and what
+	// a caller with non-ASCII principals in its document depends on.
+	orgMaxResourcePolicyChars = 40000
+)
+
+// resourcePolicyOperation claims the organization resource-policy operations.
+//
+// The cluster's shape is unlike every other one here: an organization holds
+// exactly one resource policy rather than a list keyed by ID, PutResourcePolicy
+// replaces it wholesale, and there is no per-statement update. Describe and Delete
+// take no input at all, which is why neither reads req.Body.
+func (p *OrganizationsPlugin) resourcePolicyOperation(op string) (orgHandler, bool) {
+	switch op {
+	case "PutResourcePolicy":
+		return p.putResourcePolicy, true
+	case "DescribeResourcePolicy":
+		return p.describeResourcePolicy, true
+	case "DeleteResourcePolicy":
+		return p.deleteResourcePolicy, true
+	default:
+		return nil, false
+	}
+}
+
+// --- operations ---
+
+// putResourcePolicy stores the organization's resource policy, replacing any
+// existing one.
+//
+// The ID and ARN are minted once and survive every replacement. Re-minting them
+// would make a caller holding the ARN conclude its policy had been replaced by a
+// different one, when in fact the same single policy was updated — and since an
+// organization has exactly one, there is nothing the new ID could distinguish it
+// from.
+func (p *OrganizationsPlugin) putResourcePolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	org, err := p.ensureOrganization(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("putResourcePolicy ensure org: %w", err)
+	}
+
+	var input struct {
+		Content *string       `json:"Content"`
+		Tags    []orgTagInput `json:"Tags"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	// A nil Content is an absent required member, which is a different refusal
+	// from a present-but-empty one: the model marks Content required and gives it a
+	// minimum length of 1, so both are errors but a caller debugging its request
+	// needs to know which.
+	if input.Content == nil {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "you must specify Content")
+	}
+	if err := validateOrgResourcePolicyContent(*input.Content); err != nil {
+		return nil, err
+	}
+
+	existing, found, err := p.loadResourcePolicy(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("putResourcePolicy load: %w", err)
+	}
+
+	// Tags apply only to the initial creation: "Calls with tags apply to the
+	// initial creation of the resource policy, otherwise an exception is thrown."
+	// Accepting them on an update would silently drop them, leaving a tag-gated
+	// authorization decision reading a tag set the caller believes it just wrote.
+	//
+	// The refusal carries no reason prefix, unlike every other InvalidInputException
+	// here: no member of the model's InvalidInputExceptionReason enum describes it,
+	// and inventing one would hand a caller a reason AWS never sends — the same
+	// hazard as a typo'd CreateAccount failureReason, which no SDK catch branch
+	// matches.
+	if found && len(input.Tags) > 0 {
+		return nil, orgErr("InvalidInputException",
+			"tags can be attached only when the resource policy is first created")
+	}
+	tags, err := validateOrgCreateTags(input.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	policy := OrgResourcePolicy{Content: *input.Content}
+	if found {
+		policy.ResourcePolicySummary = existing.ResourcePolicySummary
+	} else {
+		id := "rp-" + randomLowerAlphanum(8)
+		policy.ResourcePolicySummary = OrgResourcePolicySummary{
+			ID:  id,
+			Arn: fmt.Sprintf("arn:aws:organizations::%s:resourcepolicy/%s/%s", reqCtx.AccountID, org.ID, id),
+		}
+	}
+
+	if err := p.orgPutJSON(goCtx, orgResourcePolicyKey(reqCtx.AccountID), policy); err != nil {
+		return nil, fmt.Errorf("putResourcePolicy save: %w", err)
+	}
+	// Tags on the resource policy are tags on a resource, so they have to be
+	// readable through ListTagsForResource like every other Organizations tag.
+	if len(tags) > 0 {
+		if err := p.saveTags(goCtx, policy.ResourcePolicySummary.ID, tags); err != nil {
+			return nil, fmt.Errorf("putResourcePolicy save tags: %w", err)
+		}
+	}
+
+	return orgJSONResponse(map[string]interface{}{"ResourcePolicy": policy}, "putResourcePolicy")
+}
+
+// describeResourcePolicy returns the organization's resource policy.
+//
+// The refusal is the normal case, not an edge case: most organizations have no
+// resource policy, and a caller checking whether management delegated anything to
+// it has to tell ResourcePolicyNotFoundException apart from AccessDeniedException.
+// Answering an empty policy instead would make "no delegation" and "delegation I
+// cannot read" the same observation.
+//
+// The operation takes no input, so req.Body is not read.
+func (p *OrganizationsPlugin) describeResourcePolicy(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("describeResourcePolicy ensure org: %w", err)
+	}
+
+	policy, found, err := p.loadResourcePolicy(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("describeResourcePolicy load: %w", err)
+	}
+	if !found {
+		return nil, orgResourcePolicyNotFound()
+	}
+	return orgJSONResponse(map[string]interface{}{"ResourcePolicy": policy}, "describeResourcePolicy")
+}
+
+// deleteResourcePolicy removes the organization's resource policy.
+//
+// Deleting when none is set is ResourcePolicyNotFoundException rather than a
+// silent success, so a second run of a teardown script is a refusal it can branch
+// on rather than an outcome indistinguishable from the first — the same
+// re-runnability property MoveAccount's DuplicateAccountException provides.
+//
+// The operation takes no input and the model gives it no output shape.
+func (p *OrganizationsPlugin) deleteResourcePolicy(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("deleteResourcePolicy ensure org: %w", err)
+	}
+
+	policy, found, err := p.loadResourcePolicy(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("deleteResourcePolicy load: %w", err)
+	}
+	if !found {
+		return nil, orgResourcePolicyNotFound()
+	}
+
+	if err := p.state.Delete(goCtx, organizationsNamespace, orgResourcePolicyKey(reqCtx.AccountID)); err != nil {
+		return nil, fmt.Errorf("deleteResourcePolicy delete: %w", err)
+	}
+	// The policy's tags go with it. Leaving them behind would let a later
+	// PutResourcePolicy that mints a fresh ID collide with a stale tag set, and
+	// would keep an aws:ResourceTag condition matching a resource that is gone.
+	if err := p.state.Delete(goCtx, organizationsNamespace, orgTagsKey(policy.ResourcePolicySummary.ID)); err != nil {
+		return nil, fmt.Errorf("deleteResourcePolicy delete tags: %w", err)
+	}
+	return orgEmptyResponse(), nil
+}
+
+// --- helpers ---
+
+// loadResourcePolicy returns the organization's resource policy and whether one
+// is set.
+func (p *OrganizationsPlugin) loadResourcePolicy(ctx context.Context, acct string) (OrgResourcePolicy, bool, error) {
+	var policy OrgResourcePolicy
+	found, err := p.orgGetJSON(ctx, orgResourcePolicyKey(acct), &policy)
+	if err != nil {
+		return OrgResourcePolicy{}, false, err
+	}
+	return policy, found, nil
+}
+
+// orgResourcePolicyNotFound returns ResourcePolicyNotFoundException.
+func orgResourcePolicyNotFound() *AWSError {
+	return orgErr("ResourcePolicyNotFoundException",
+		"we can't find a resource policy for this organization")
+}
+
+// validateOrgResourcePolicyContent enforces ResourcePolicyContent's bounds and
+// checks the document parses.
+//
+// The length bounds come first, so an empty document is MIN_LENGTH_EXCEEDED rather
+// than a JSON complaint about a document the caller never wrote.
+//
+// The JSON check is not implied by the model's pattern, which is "[\s\S]*" — any
+// text at all — but by the INVALID_RESOURCE_POLICY_JSON member of the model's
+// InvalidInputExceptionReason enum: AWS parses the document, so accepting an
+// unparseable one here would pass a test that real Organizations refuses.
+//
+// Only parseability is checked. The enum also carries INVALID_PRINCIPAL,
+// UNSUPPORTED_ACTION_IN_RESOURCE_POLICY, UNSUPPORTED_RESOURCE_IN_RESOURCE_POLICY and
+// UNSUPPORTED_POLICY_TYPE_IN_RESOURCE_POLICY, which are refusals about the
+// document's *meaning*. The sets of principals, actions and resources AWS accepts in
+// a resource policy are not in the API model, so emitting those reasons would mean
+// guessing at their boundaries — and a guessed refusal is worse than a missing one:
+// it fails a document AWS would have accepted, with a reason the caller cannot act
+// on.
+func validateOrgResourcePolicyContent(content string) error {
+	n := utf8.RuneCountInString(content)
+	switch {
+	case n < orgMinResourcePolicyChars:
+		return orgInvalidInput("MIN_LENGTH_EXCEEDED",
+			fmt.Sprintf("the resource policy content must be at least %d character long", orgMinResourcePolicyChars))
+	case n > orgMaxResourcePolicyChars:
+		return orgInvalidInput("MAX_LENGTH_EXCEEDED",
+			fmt.Sprintf("the resource policy content is longer than the %d-character maximum", orgMaxResourcePolicyChars))
+	}
+	if !json.Valid([]byte(content)) {
+		return orgInvalidInput("INVALID_RESOURCE_POLICY_JSON",
+			"the resource policy content is not valid JSON")
+	}
+	return nil
+}

--- a/emulator/organizations_resourcepolicy_export_test.go
+++ b/emulator/organizations_resourcepolicy_export_test.go
@@ -1,0 +1,16 @@
+package emulator
+
+// This file exports the resource-policy cluster for the external test package,
+// following the per-cluster convention the other Organizations lanes use.
+
+// Resource policy content bounds, exported so a test can pin each against its
+// documented value. The maximum in particular is a boundary an off-by-one hides
+// in a nominal run.
+const (
+	OrgMinResourcePolicyCharsForTest = orgMinResourcePolicyChars
+	OrgMaxResourcePolicyCharsForTest = orgMaxResourcePolicyChars
+)
+
+// OrgKindResourcePolicyForTest is the kind resolveOrgTarget names for the
+// organization's resource policy.
+const OrgKindResourcePolicyForTest = orgKindResourcePolicy

--- a/emulator/organizations_resourcepolicy_test.go
+++ b/emulator/organizations_resourcepolicy_test.go
@@ -1,0 +1,650 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// A well-formed resource policy document. The content is not parsed by
+// substrate — the model's pattern is "[\s\S]*" and the operation declares no
+// MalformedPolicyDocumentException — but a realistic one is used so a test
+// reading this file sees what the operation is for: delegating a read to a
+// member account.
+const orgResourcePolicyDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+	`"Principal":{"AWS":"111122223333"},"Action":"organizations:DescribeOrganization","Resource":"*"}]}`
+
+// --- helpers --------------------------------------------------------------
+
+// orgDescribeResourcePolicy posts DescribeResourcePolicy and returns the status,
+// the policy, and the error code a refusal carries.
+func orgDescribeResourcePolicy(t *testing.T, ts *httptest.Server) (int, emulator.OrgResourcePolicy, string) {
+	t.Helper()
+	return orgResourcePolicyCall(t, ts, "DescribeResourcePolicy", map[string]any{})
+}
+
+// orgPutResourcePolicy posts PutResourcePolicy with the given body.
+func orgPutResourcePolicy(t *testing.T, ts *httptest.Server, body map[string]any) (int, emulator.OrgResourcePolicy, string) {
+	t.Helper()
+	return orgResourcePolicyCall(t, ts, "PutResourcePolicy", body)
+}
+
+// orgResourcePolicyCall posts one operation and decodes either the ResourcePolicy
+// or the error code, so a refusal can be asserted by code rather than by status
+// alone — every Organizations exception shares HTTP 400.
+func orgResourcePolicyCall(t *testing.T, ts *httptest.Server, op string, body map[string]any) (int, emulator.OrgResourcePolicy, string) {
+	t.Helper()
+	resp := orgsRequest(t, ts, op, body)
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		ResourcePolicy emulator.OrgResourcePolicy `json:"ResourcePolicy"`
+		Type           string                     `json:"__type"`
+		Message        string                     `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode %s: %v", op, err)
+	}
+	code := out.Type
+	if code != "" {
+		code += "/" + out.Message
+	}
+	return resp.StatusCode, out.ResourcePolicy, code
+}
+
+// --- tests ----------------------------------------------------------------
+
+// TestOrganizations_ResourcePolicy_NotFoundIsTheNormalCase is #619's repro
+// verbatim, and the assertion the issue cares most about.
+//
+// Most organizations have no resource policy, so this refusal is the ordinary
+// answer rather than an edge case. A caller checking whether management delegated
+// anything to it has to tell ResourcePolicyNotFoundException apart from
+// AccessDeniedException; answering an empty policy would collapse "no delegation"
+// and "delegation I cannot read" into one observation.
+func TestOrganizations_ResourcePolicy_NotFoundIsTheNormalCase(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	status, _, code := orgDescribeResourcePolicy(t, ts)
+	if status != http.StatusBadRequest {
+		t.Fatalf("DescribeResourcePolicy on a fresh organization: expected 400, got %d", status)
+	}
+	if !strings.HasPrefix(code, "ResourcePolicyNotFoundException") {
+		t.Fatalf("expected ResourcePolicyNotFoundException, got %q", code)
+	}
+}
+
+// TestOrganizations_ResourcePolicy_RoundTrip covers the lifecycle a delegation
+// story needs: put, read back, delete, and read again.
+func TestOrganizations_ResourcePolicy_RoundTrip(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	status, put, code := orgPutResourcePolicy(t, ts, map[string]any{"Content": orgResourcePolicyDoc})
+	if status != http.StatusOK {
+		t.Fatalf("PutResourcePolicy: expected 200, got %d (%s)", status, code)
+	}
+	id := put.ResourcePolicySummary.ID
+	if !strings.HasPrefix(id, "rp-") {
+		t.Fatalf("resource policy ID %q does not have the rp- prefix the model's pattern requires", id)
+	}
+	// The ARN embeds the organization ID, so a caller that scopes a policy statement
+	// to it must see the same one DescribeOrganization reports.
+	if arn := put.ResourcePolicySummary.Arn; !strings.Contains(arn, ":resourcepolicy/") ||
+		!strings.HasSuffix(arn, "/"+id) {
+		t.Fatalf("resource policy ARN %q is not the documented resourcepolicy/{orgId}/{rpId} shape", arn)
+	}
+	if put.Content != orgResourcePolicyDoc {
+		t.Fatalf("PutResourcePolicy returned content %q, want the document that was sent", put.Content)
+	}
+
+	status, got, code := orgDescribeResourcePolicy(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("DescribeResourcePolicy after a put: expected 200, got %d (%s)", status, code)
+	}
+	if got != put {
+		t.Fatalf("DescribeResourcePolicy returned %+v, want the policy Put reported %+v", got, put)
+	}
+
+	resp := orgsRequest(t, ts, "DeleteResourcePolicy", map[string]any{})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DeleteResourcePolicy: expected 200, got %d", resp.StatusCode)
+	}
+
+	status, _, code = orgDescribeResourcePolicy(t, ts)
+	if status != http.StatusBadRequest || !strings.HasPrefix(code, "ResourcePolicyNotFoundException") {
+		t.Fatalf("after a delete: expected 400/ResourcePolicyNotFoundException, got %d/%q", status, code)
+	}
+}
+
+// TestOrganizations_ResourcePolicy_ReplacementKeepsTheID asserts the decision that
+// a Put updates the single policy in place.
+//
+// An organization holds exactly one resource policy, so a fresh ID would name
+// nothing new — it would only make a caller holding the previous ARN conclude its
+// policy had been replaced by a different one.
+func TestOrganizations_ResourcePolicy_ReplacementKeepsTheID(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	_, first, _ := orgPutResourcePolicy(t, ts, map[string]any{"Content": orgResourcePolicyDoc})
+
+	const replacement = `{"Version":"2012-10-17","Statement":[]}`
+	status, second, code := orgPutResourcePolicy(t, ts, map[string]any{"Content": replacement})
+	if status != http.StatusOK {
+		t.Fatalf("replacing the resource policy: expected 200, got %d (%s)", status, code)
+	}
+	if second.ResourcePolicySummary != first.ResourcePolicySummary {
+		t.Fatalf("a replacement re-minted the identity: %+v then %+v",
+			first.ResourcePolicySummary, second.ResourcePolicySummary)
+	}
+	if second.Content != replacement {
+		t.Fatalf("the replacement's content = %q, want the new document", second.Content)
+	}
+
+	// The stored policy has to agree, or a caller reading after the write sees the
+	// pre-replacement document.
+	_, got, _ := orgDescribeResourcePolicy(t, ts)
+	if got.Content != replacement || got.ResourcePolicySummary != first.ResourcePolicySummary {
+		t.Fatalf("DescribeResourcePolicy after a replacement = %+v, want content %q with the original identity",
+			got, replacement)
+	}
+}
+
+// TestOrganizations_ResourcePolicy_DeleteTwiceIsARefusal is the re-runnability
+// property: a second teardown pass gets an error it can branch on rather than an
+// outcome indistinguishable from having done the work.
+func TestOrganizations_ResourcePolicy_DeleteTwiceIsARefusal(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	if _, _, code := orgPutResourcePolicy(t, ts, map[string]any{"Content": orgResourcePolicyDoc}); code != "" {
+		t.Fatalf("PutResourcePolicy: %s", code)
+	}
+
+	first := orgsRequest(t, ts, "DeleteResourcePolicy", map[string]any{})
+	defer first.Body.Close() //nolint:errcheck
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("the first DeleteResourcePolicy: expected 200, got %d", first.StatusCode)
+	}
+
+	status, _, code := orgResourcePolicyCall(t, ts, "DeleteResourcePolicy", map[string]any{})
+	if status != http.StatusBadRequest || !strings.HasPrefix(code, "ResourcePolicyNotFoundException") {
+		t.Fatalf("the second DeleteResourcePolicy: expected 400/ResourcePolicyNotFoundException, got %d/%q",
+			status, code)
+	}
+}
+
+// TestOrganizations_PutResourcePolicy_ContentBounds covers ResourcePolicyContent's
+// documented 1-40,000-character range at its boundaries.
+//
+// The maximum is the interesting one: it is 40,000 rather than the 10,240 an SCP
+// gets, so a caller sizing its delegation document against the SCP limit would be
+// refused for no reason, and an off-by-one here is invisible in a nominal run.
+func TestOrganizations_PutResourcePolicy_ContentBounds(t *testing.T) {
+	// Padding goes inside a JSON string so the oversized document is still
+	// well-formed: the refusal under test is the length, and a document that also
+	// failed to parse would pass this test for the wrong reason.
+	doc := func(n int) string {
+		const wrapper = `{"Version":"2012-10-17","Statement":"%s"}`
+		fill := n - (len(wrapper) - 2)
+		if fill < 0 {
+			t.Fatalf("cannot build a %d-character document", n)
+		}
+		return strings.Replace(wrapper, "%s", strings.Repeat("x", fill), 1)
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name:    "empty content is refused",
+			content: "",
+			wantErr: "InvalidInputException",
+		},
+		{
+			// The shortest parseable document, so this pins the minimum rather than
+			// the JSON check that follows it. A single "x" is within the length bound
+			// and would be refused for the other reason, which would leave the
+			// minimum itself unexercised.
+			name:    "the documented minimum is a length, not a shape",
+			content: "0",
+			wantErr: "",
+		},
+		{
+			name:    "the maximum is accepted",
+			content: doc(emulator.OrgMaxResourcePolicyCharsForTest),
+			wantErr: "",
+		},
+		{
+			name:    "one character past the maximum is refused",
+			content: doc(emulator.OrgMaxResourcePolicyCharsForTest + 1),
+			wantErr: "InvalidInputException",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newOrganizationsTestServer(t)
+			status, _, code := orgPutResourcePolicy(t, ts, map[string]any{"Content": tc.content})
+			if tc.wantErr == "" {
+				if status != http.StatusOK {
+					t.Fatalf("expected 200, got %d (%s)", status, code)
+				}
+				return
+			}
+			if status != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", status)
+			}
+			if !strings.HasPrefix(code, tc.wantErr) {
+				t.Fatalf("expected %s, got %q", tc.wantErr, code)
+			}
+		})
+	}
+}
+
+// TestOrganizations_PutResourcePolicy_ContentRequired distinguishes an absent
+// required member from a present-but-empty one. Both are refused, but a caller
+// debugging its request needs to know which mistake it made.
+func TestOrganizations_PutResourcePolicy_ContentRequired(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	status, _, code := orgPutResourcePolicy(t, ts, map[string]any{})
+	if status != http.StatusBadRequest {
+		t.Fatalf("PutResourcePolicy with no Content: expected 400, got %d", status)
+	}
+	if !strings.Contains(code, "INPUT_REQUIRED") {
+		t.Fatalf("expected the INPUT_REQUIRED reason for an absent Content, got %q", code)
+	}
+}
+
+// TestOrganizations_PutResourcePolicy_TagsAreCreateOnly covers the model's note
+// that "Calls with tags apply to the initial creation of the resource policy,
+// otherwise an exception is thrown".
+//
+// Accepting tags on an update and silently dropping them would leave a tag-gated
+// authorization decision reading a tag set the caller believes it just wrote.
+func TestOrganizations_PutResourcePolicy_TagsAreCreateOnly(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	status, created, code := orgPutResourcePolicy(t, ts, map[string]any{
+		"Content": orgResourcePolicyDoc,
+		"Tags":    []map[string]any{{"Key": "Owner", "Value": "platform"}},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("PutResourcePolicy with create-time tags: expected 200, got %d (%s)", status, code)
+	}
+
+	// The tag has to be readable through ListTagsForResource, or nothing can gate
+	// on it — a resource policy is taggable precisely because Put accepts Tags.
+	resp := orgsRequest(t, ts, "ListTagsForResource",
+		map[string]any{"ResourceId": created.ResourcePolicySummary.ID})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ListTagsForResource on the resource policy: expected 200, got %d", resp.StatusCode)
+	}
+	var tagsOut struct {
+		Tags []emulator.OrgTag `json:"Tags"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tagsOut); err != nil {
+		t.Fatalf("decode ListTagsForResource: %v", err)
+	}
+	if len(tagsOut.Tags) != 1 || tagsOut.Tags[0].Key != "Owner" || tagsOut.Tags[0].Value != "platform" {
+		t.Fatalf("the create-time tag is not readable back: %+v", tagsOut.Tags)
+	}
+
+	// A second Put carrying tags is refused rather than silently ignoring them.
+	status, _, code = orgPutResourcePolicy(t, ts, map[string]any{
+		"Content": `{"Version":"2012-10-17","Statement":[]}`,
+		"Tags":    []map[string]any{{"Key": "Owner", "Value": "someone-else"}},
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("PutResourcePolicy with tags on an update: expected 400, got %d", status)
+	}
+	if !strings.HasPrefix(code, "InvalidInputException") {
+		t.Fatalf("expected InvalidInputException, got %q", code)
+	}
+
+	// An update without tags still succeeds, and leaves the create-time tags alone.
+	if status, _, code = orgPutResourcePolicy(t, ts,
+		map[string]any{"Content": `{"Version":"2012-10-17","Statement":[]}`}); status != http.StatusOK {
+		t.Fatalf("PutResourcePolicy without tags on an update: expected 200, got %d (%s)", status, code)
+	}
+}
+
+// TestOrganizations_PutResourcePolicy_RejectsReservedTagKeys asserts the resource
+// policy's inline tags go through the same validation every other Organizations
+// create does.
+//
+// An "aws:"-prefixed key AWS never lets a caller write could otherwise be planted
+// through this operation and then read as aws:ResourceTag by a policy condition.
+func TestOrganizations_PutResourcePolicy_RejectsReservedTagKeys(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	status, _, code := orgPutResourcePolicy(t, ts, map[string]any{
+		"Content": orgResourcePolicyDoc,
+		"Tags":    []map[string]any{{"Key": "aws:cloudformation:stack-name", "Value": "planted"}},
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("an aws:-prefixed tag key: expected 400, got %d", status)
+	}
+	if !strings.HasPrefix(code, "InvalidInputException") {
+		t.Fatalf("expected InvalidInputException, got %q", code)
+	}
+
+	// Nothing was written, so the failed Put did not leave a policy behind.
+	if status, _, _ := orgDescribeResourcePolicy(t, ts); status != http.StatusBadRequest {
+		t.Fatal("a refused PutResourcePolicy created the policy anyway")
+	}
+}
+
+// TestOrganizations_PutResourcePolicy_RejectsUnparseableContent covers the
+// INVALID_RESOURCE_POLICY_JSON member of the model's InvalidInputExceptionReason
+// enum.
+//
+// The enum member is the evidence AWS parses the document; the shape's own pattern,
+// "[\s\S]*", is not. Accepting an unparseable document would let a test go green on
+// a policy real Organizations refuses — the exact false signal the emulator exists to
+// prevent.
+func TestOrganizations_PutResourcePolicy_RejectsUnparseableContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "truncated object", content: `{"Version":`},
+		{name: "not JSON at all", content: "this is not a policy"},
+		{name: "trailing garbage after a valid document", content: `{"Version":"2012-10-17"} oops`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newOrganizationsTestServer(t)
+			status, _, code := orgPutResourcePolicy(t, ts, map[string]any{"Content": tc.content})
+			if status != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", status)
+			}
+			// The reason has to be the JSON one, not a length complaint: a caller
+			// reading MIN_LENGTH_EXCEEDED would go pad a document whose real problem
+			// is its syntax.
+			if !strings.Contains(code, "INVALID_RESOURCE_POLICY_JSON") {
+				t.Fatalf("expected the INVALID_RESOURCE_POLICY_JSON reason, got %q", code)
+			}
+		})
+	}
+}
+
+// TestOrganizations_PutResourcePolicy_TagsRefusalInventsNoReason pins that the
+// create-only tags refusal carries no reason prefix.
+//
+// Every other InvalidInputException here leads with a member of the model's
+// InvalidInputExceptionReason enum, and none of them describes this condition. A
+// borrowed reason — INVALID_PARTY_TYPE_TARGET, say, which is about handshake
+// parties — would read as documented AWS behavior while matching no branch a
+// consumer could have written.
+func TestOrganizations_PutResourcePolicy_TagsRefusalInventsNoReason(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	if _, _, code := orgPutResourcePolicy(t, ts, map[string]any{"Content": orgResourcePolicyDoc}); code != "" {
+		t.Fatalf("PutResourcePolicy: %s", code)
+	}
+	_, _, code := orgPutResourcePolicy(t, ts, map[string]any{
+		"Content": orgResourcePolicyDoc,
+		"Tags":    []map[string]any{{"Key": "Owner", "Value": "x"}},
+	})
+	message, ok := strings.CutPrefix(code, "InvalidInputException/")
+	if !ok {
+		t.Fatalf("expected InvalidInputException, got %q", code)
+	}
+	// A reason prefix is SCREAMING_SNAKE_CASE followed by ": ". Nothing in the enum
+	// fits this refusal, so the message must start with prose instead.
+	if reason, _, found := strings.Cut(message, ": "); found && reason == strings.ToUpper(reason) {
+		t.Errorf("the refusal leads with the reason %q, which is not in the model's enum", reason)
+	}
+}
+
+// TestOrganizations_ResourcePolicy_DeleteRemovesTags asserts the tags go with the
+// policy.
+//
+// Left behind, they would keep an aws:ResourceTag condition matching a resource
+// that no longer exists, and a later Put that mints a fresh ID could collide with
+// a stale tag set.
+func TestOrganizations_ResourcePolicy_DeleteRemovesTags(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	_, created, _ := orgPutResourcePolicy(t, ts, map[string]any{
+		"Content": orgResourcePolicyDoc,
+		"Tags":    []map[string]any{{"Key": "Owner", "Value": "platform"}},
+	})
+	id := created.ResourcePolicySummary.ID
+
+	resp := orgsRequest(t, ts, "DeleteResourcePolicy", map[string]any{})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DeleteResourcePolicy: expected 200, got %d", resp.StatusCode)
+	}
+
+	// The ID now names nothing, so tagging it is TargetNotFoundException — the same
+	// answer any other deleted resource gets.
+	status, _, code := orgResourcePolicyCall(t, ts, "ListTagsForResource", map[string]any{"ResourceId": id})
+	if status != http.StatusBadRequest || !strings.HasPrefix(code, "TargetNotFoundException") {
+		t.Fatalf("ListTagsForResource on the deleted policy: expected 400/TargetNotFoundException, got %d/%q",
+			status, code)
+	}
+}
+
+// TestOrganizations_ResourcePolicy_MalformedBodyIsRefused covers the decode guard
+// on the one operation of the three that reads a body.
+//
+// Skipping it would decode into a zero-valued input, where Content is nil — and the
+// refusal a caller then gets says its Content was missing when in fact its JSON was
+// unparseable, sending it to inspect the wrong part of its request.
+func TestOrganizations_ResourcePolicy_MalformedBodyIsRefused(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", newOrgBadBody())
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "Organizations_20161128.PutResourcePolicy")
+	req.Host = "organizations.us-east-1.amazonaws.com"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PutResourcePolicy: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for an unparseable body, got %d", resp.StatusCode)
+	}
+}
+
+// TestOrganizations_ResourcePolicy_StoreReadFailureIsInternalFailure asserts a store
+// read failure is a 500 an SDK retries rather than the 400 every
+// ResourcePolicyNotFoundException carries.
+//
+// This lane is the one place the distinction matters most: the not-found refusal is
+// the *normal* answer here, so collapsing a transient failure into it would tell a
+// caller "management delegated nothing" — a terminal, wrong conclusion — over a blip.
+func TestOrganizations_ResourcePolicy_StoreReadFailureIsInternalFailure(t *testing.T) {
+	// Both reads every operation performs: the organization each one ensures first,
+	// and the policy document itself.
+	for _, prefix := range []string{"org:", "resource_policy:"} {
+		for _, op := range []string{"PutResourcePolicy", "DescribeResourcePolicy", "DeleteResourcePolicy"} {
+			t.Run(prefix+op, func(t *testing.T) {
+				inner := emulator.NewMemoryStateManager()
+				state := &errOrgState{
+					inner: inner, prefix: prefix,
+					err: errors.New("store unavailable"), onGet: true,
+				}
+				ts := newOrgServerOverState(t, state)
+				if _, _, code := orgPutResourcePolicy(t, ts,
+					map[string]any{"Content": orgResourcePolicyDoc}); code != "" {
+					t.Fatalf("warm-up: %s", code)
+				}
+				state.armed = true
+
+				resp := orgsRequest(t, ts, op, map[string]any{"Content": orgResourcePolicyDoc})
+				gotStatus := resp.StatusCode
+				resp.Body.Close() //nolint:errcheck
+				if gotStatus != http.StatusInternalServerError {
+					t.Errorf("expected 500 while %s reads were failing, got %d", prefix, gotStatus)
+				}
+			})
+		}
+	}
+}
+
+// TestOrganizations_ResourcePolicy_WriteFailureIsNotASuccess asserts a failed write
+// is never reported as a completed change.
+//
+// A Put that answers 200 while the document never landed is the worst outcome
+// available: the caller records the ARN and believes it delegated a read that no
+// member account can actually make. The tags case is the same claim one level down —
+// a 200 with the tag write lost leaves a tag-gated condition reading nothing.
+func TestOrganizations_ResourcePolicy_WriteFailureIsNotASuccess(t *testing.T) {
+	cases := []struct {
+		name    string
+		prefix  string
+		op      string
+		body    map[string]any
+		warmUp  bool
+		onPut   bool
+		onDelet bool
+	}{
+		{
+			name: "the policy document", prefix: "resource_policy:", op: "PutResourcePolicy",
+			body: map[string]any{"Content": orgResourcePolicyDoc}, onPut: true,
+		},
+		{
+			name: "the create-time tags", prefix: "tags:", op: "PutResourcePolicy",
+			body: map[string]any{
+				"Content": orgResourcePolicyDoc,
+				"Tags":    []map[string]any{{"Key": "Owner", "Value": "platform"}},
+			},
+			onPut: true,
+		},
+		{
+			name: "the delete", prefix: "resource_policy:", op: "DeleteResourcePolicy",
+			body: map[string]any{}, warmUp: true, onDelet: true, onPut: true,
+		},
+		{
+			name: "the delete's tag cleanup", prefix: "tags:", op: "DeleteResourcePolicy",
+			body: map[string]any{}, warmUp: true, onDelet: true, onPut: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			state := &errOrgState{
+				inner: inner, prefix: c.prefix, err: errors.New("store unavailable"),
+				onPut: c.onPut, onDelete: c.onDelet,
+			}
+			ts := newOrgServerOverState(t, state)
+			if c.warmUp {
+				if _, _, code := orgPutResourcePolicy(t, ts, map[string]any{
+					"Content": orgResourcePolicyDoc,
+					"Tags":    []map[string]any{{"Key": "Owner", "Value": "platform"}},
+				}); code != "" {
+					t.Fatalf("warm-up: %s", code)
+				}
+			}
+			state.armed = true
+
+			resp := orgsRequest(t, ts, c.op, c.body)
+			gotStatus := resp.StatusCode
+			resp.Body.Close() //nolint:errcheck
+			if gotStatus == http.StatusOK {
+				t.Errorf("%s answered 200 while %s writes were failing", c.op, c.prefix)
+			}
+		})
+	}
+}
+
+// TestOrganizations_ResourcePolicy_CorruptRecordIsAnError asserts an unreadable
+// document is reported rather than treated as absent.
+//
+// Absent is the dangerous direction here: the caller's next step is to Put again,
+// which would mint a fresh ID over a record that is still in the store — the ID
+// stability the round-trip test pins, lost through the failure path.
+func TestOrganizations_ResourcePolicy_CorruptRecordIsAnError(t *testing.T) {
+	for _, op := range []string{"PutResourcePolicy", "DescribeResourcePolicy", "DeleteResourcePolicy"} {
+		t.Run(op, func(t *testing.T) {
+			inner := emulator.NewMemoryStateManager()
+			state := &corruptOrgState{StateManager: inner, prefix: "resource_policy:"}
+			ts := newOrgServerOverState(t, state)
+			if _, _, code := orgPutResourcePolicy(t, ts,
+				map[string]any{"Content": orgResourcePolicyDoc}); code != "" {
+				t.Fatalf("warm-up: %s", code)
+			}
+			state.armed = true
+
+			resp := orgsRequest(t, ts, op, map[string]any{"Content": orgResourcePolicyDoc})
+			gotStatus := resp.StatusCode
+			resp.Body.Close() //nolint:errcheck
+			if gotStatus != http.StatusInternalServerError {
+				t.Errorf("expected 500 over an unreadable resource-policy record, got %d", gotStatus)
+			}
+		})
+	}
+}
+
+// TestOrganizations_ResourcePolicyOperationsAreClaimed pins that all three
+// operations reach the new cluster.
+//
+// This is the failure #619 actually reported: an unclaimed operation falls through
+// to InvalidAction, which a caller reads as "no such API" rather than "substrate
+// has not implemented it", so it hunts for a bug in its own request.
+func TestOrganizations_ResourcePolicyOperationsAreClaimed(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	for _, op := range []string{"PutResourcePolicy", "DescribeResourcePolicy", "DeleteResourcePolicy"} {
+		if _, _, code := orgResourcePolicyCall(t, ts, op, map[string]any{}); strings.HasPrefix(code, "InvalidAction") {
+			t.Errorf("%s: expected the operation to be claimed, got InvalidAction", op)
+		}
+	}
+}
+
+// TestOrganizations_ResourcePolicy_ResolvesAsATarget covers resolveOrgTarget's
+// rp- arm, which is what makes the policy taggable.
+//
+// The organization holds at most one, so the ID has to match the stored one rather
+// than index into a collection: a well-formed rp- ID that is not the current
+// policy names nothing.
+func TestOrganizations_ResourcePolicy_ResolvesAsATarget(t *testing.T) {
+	f := newOrgTagsFixture(t)
+
+	kind, err := f.plugin.ResolveOrgTargetForTest(t.Context(), orgTestAccount, "rp-notthere")
+	if err != nil {
+		t.Fatalf("resolve an absent resource policy: %v", err)
+	}
+	if kind != "" {
+		t.Fatalf("a well-formed rp- ID with no policy set resolved to %q, want absent", kind)
+	}
+
+	_, created, code := orgPutResourcePolicy(t, f.ts, map[string]any{"Content": orgResourcePolicyDoc})
+	if code != "" {
+		t.Fatalf("PutResourcePolicy: %s", code)
+	}
+
+	kind, err = f.plugin.ResolveOrgTargetForTest(t.Context(), orgTestAccount, created.ResourcePolicySummary.ID)
+	if err != nil {
+		t.Fatalf("resolve the resource policy: %v", err)
+	}
+	if kind != emulator.OrgKindResourcePolicyForTest {
+		t.Fatalf("the resource policy resolved to %q, want %q", kind, emulator.OrgKindResourcePolicyForTest)
+	}
+
+	// A different well-formed rp- ID still names nothing, rather than borrowing the
+	// real policy's identity.
+	kind, err = f.plugin.ResolveOrgTargetForTest(t.Context(), orgTestAccount, "rp-someotherpolicy")
+	if err != nil {
+		t.Fatalf("resolve a non-matching resource policy ID: %v", err)
+	}
+	if kind != "" {
+		t.Fatalf("a non-matching rp- ID resolved to %q, want absent", kind)
+	}
+}

--- a/emulator/organizations_state.go
+++ b/emulator/organizations_state.go
@@ -62,6 +62,14 @@ const (
 	// orgKindPolicy is not a ParentType or ChildType — it exists because a policy
 	// is taggable, so resolveOrgTarget has to be able to name one.
 	orgKindPolicy = "POLICY"
+
+	// orgKindResourcePolicy exists for the same reason as orgKindPolicy: the
+	// organization's resource policy is taggable, because PutResourcePolicy accepts
+	// Tags. It is not a ParentType or ChildType either, and every caller that
+	// resolves a hierarchy target checks against an allowlist of ROOT/
+	// ORGANIZATIONAL_UNIT/ACCOUNT, so naming it here cannot make it attachable or
+	// movable.
+	orgKindResourcePolicy = "RESOURCE_POLICY"
 )
 
 // Organizations policy types substrate models.
@@ -118,6 +126,12 @@ func orgTagsKey(resource string) string { return "tags:" + resource }
 
 func orgCreateStatusKey(id string) string      { return "car:" + id }
 func orgCreateStatusIDsKey(acct string) string { return "car_ids:" + acct }
+
+// orgResourcePolicyKey holds the organization's single resource policy. It is
+// keyed by the management account, like orgKey, because an organization has
+// exactly one — not a list keyed by ID, which is what makes this cluster's shape
+// unlike the rest of the service.
+func orgResourcePolicyKey(acct string) string { return "resource_policy:" + acct }
 
 // --- errors ---
 //
@@ -744,6 +758,18 @@ func (p *OrganizationsPlugin) resolveOrgTarget(ctx context.Context, acct, id str
 		}
 		if pol != nil {
 			return orgKindPolicy, nil
+		}
+		return "", nil
+	case len(id) > 3 && id[:3] == "rp-":
+		// The organization holds at most one resource policy, so the ID has to match
+		// the stored one rather than index into a collection. A well-formed rp- ID
+		// that is not it names nothing, which is the same answer AWS gives.
+		policy, found, err := p.loadResourcePolicy(ctx, acct)
+		if err != nil {
+			return "", err
+		}
+		if found && policy.ResourcePolicySummary.ID == id {
+			return orgKindResourcePolicy, nil
 		}
 		return "", nil
 	default:

--- a/emulator/organizations_tags.go
+++ b/emulator/organizations_tags.go
@@ -285,9 +285,10 @@ func validateOrgTaggableResourceID(id string) error {
 }
 
 // isOrgTaggableResourceID reports whether id has one of the six forms the
-// model's TaggableResourceId pattern accepts. Two of them — rp- (resource
-// policy) and rt- (responsibility transfer) — are well-formed but name resources
-// substrate does not model, so they are admitted here and refused as absent by
+// model's TaggableResourceId pattern accepts. rp- names the organization's
+// resource policy, which is taggable because PutResourcePolicy accepts Tags.
+// rt- (responsibility transfer) is well-formed but names a resource substrate
+// does not model, so it is admitted here and refused as absent by
 // resolveOrgTarget, which is the same answer AWS gives for an ID in an
 // organization that has no such resource.
 func isOrgTaggableResourceID(id string) bool {
@@ -549,6 +550,16 @@ func orgAuthzResourceARN(state StateManager, reqCtx *RequestContext, req *AWSReq
 		var ou OrgOrganizationalUnit
 		if orgAuthzGetJSON(goCtx, state, orgOUKey(id), &ou) {
 			arn = ou.Arn
+		}
+	case strings.HasPrefix(id, "rp-"):
+		// Keyed by the management account rather than by the ID, like the root: the
+		// organization holds exactly one resource policy. The stored ID must match,
+		// so a well-formed rp- ID that is not the current policy falls through to "*"
+		// rather than borrowing the real policy's ARN.
+		var rp OrgResourcePolicy
+		if orgAuthzGetJSON(goCtx, state, orgResourcePolicyKey(reqCtx.AccountID), &rp) &&
+			rp.ResourcePolicySummary.ID == id {
+			arn = rp.ResourcePolicySummary.Arn
 		}
 	case strings.HasPrefix(id, "p-"):
 		if id == orgFullAWSAccessID {

--- a/emulator/organizations_types.go
+++ b/emulator/organizations_types.go
@@ -201,3 +201,27 @@ type OrgTag struct {
 	// Value is the tag value; the empty string is permitted, null is not.
 	Value string `json:"Value"`
 }
+
+// OrgResourcePolicySummary identifies the organization's resource policy.
+type OrgResourcePolicySummary struct {
+	// ID is the policy identifier, "rp-" followed by 4-128 alphanumerics or
+	// underscores.
+	ID string `json:"Id"`
+
+	// Arn is the ARN of the resource policy, which embeds the organization ID.
+	Arn string `json:"Arn"`
+}
+
+// OrgResourcePolicy is the organization's resource-based delegation policy, as
+// DescribeResourcePolicy and PutResourcePolicy return it.
+//
+// An organization holds exactly one, so this is not stored in a list keyed by ID
+// the way OrgPolicy is: PutResourcePolicy replaces the document wholesale and
+// there is no per-statement update.
+type OrgResourcePolicy struct {
+	// ResourcePolicySummary is the policy's identity.
+	ResourcePolicySummary OrgResourcePolicySummary `json:"ResourcePolicySummary"`
+
+	// Content is the policy document text.
+	Content string `json:"Content"`
+}

--- a/test/e2e/journey_organizations_test.go
+++ b/test/e2e/journey_organizations_test.go
@@ -380,6 +380,110 @@ func TestJourney_OrganizationsDisabledSCPState(t *testing.T) {
 	}
 }
 
+// TestJourney_OrganizationsResourcePolicy is #619 through the SDK: the delegation
+// lifecycle a tool that reads the organization's resource policy performs.
+//
+// This level is what #619 actually needed. The operation was implemented nowhere,
+// so it fell through to InvalidAction — and an unrouted operation is invisible to
+// unit tests of the operations that *are* routed. It is the same class of failure as
+// #610, and a journey through the real client is the cheapest thing that catches it.
+//
+// The journey also pins the two properties a caller depends on and no single
+// operation shows: the not-found refusal is the ordinary answer, and the policy's
+// identity survives a replacement.
+func TestJourney_OrganizationsResourcePolicy(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	orgs := organizations.NewFromConfig(cfg, func(o *organizations.Options) { o.RetryMaxAttempts = 1 })
+
+	// --- the normal case: nothing is delegated ---
+	//
+	// A caller has to reach the typed exception, not just a 400: its branch for "no
+	// delegation" and its branch for "delegation I cannot read" are different, and
+	// errors.As on the type is how it tells them apart.
+	var notFound *orgtypes.ResourcePolicyNotFoundException
+	if _, err := orgs.DescribeResourcePolicy(ctx, &organizations.DescribeResourcePolicyInput{}); err == nil {
+		t.Fatal("DescribeResourcePolicy on a fresh organization: expected ResourcePolicyNotFoundException")
+	} else if !errors.As(err, &notFound) {
+		t.Fatalf("expected *ResourcePolicyNotFoundException, got %T: %v", err, err)
+	}
+
+	const delegation = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"AWS":"111122223333"},"Action":"organizations:DescribeOrganization","Resource":"*"}]}`
+
+	put, err := orgs.PutResourcePolicy(ctx, &organizations.PutResourcePolicyInput{
+		Content: aws.String(delegation),
+		Tags:    []orgtypes.Tag{{Key: aws.String("Owner"), Value: aws.String("platform")}},
+	})
+	if err != nil {
+		t.Fatalf("PutResourcePolicy: %v", err)
+	}
+	policyID := aws.ToString(put.ResourcePolicy.ResourcePolicySummary.Id)
+	policyARN := aws.ToString(put.ResourcePolicy.ResourcePolicySummary.Arn)
+
+	got, err := orgs.DescribeResourcePolicy(ctx, &organizations.DescribeResourcePolicyInput{})
+	if err != nil {
+		t.Fatalf("DescribeResourcePolicy after a put: %v", err)
+	}
+	if content := aws.ToString(got.ResourcePolicy.Content); content != delegation {
+		t.Fatalf("DescribeResourcePolicy Content = %q, want the document that was put", content)
+	}
+	if id := aws.ToString(got.ResourcePolicy.ResourcePolicySummary.Id); id != policyID {
+		t.Fatalf("the resource policy ID moved between calls: %q then %q", policyID, id)
+	}
+
+	// The create-time tag is readable through the same operation every other
+	// Organizations resource's tags are, or nothing can gate on it.
+	tags, err := orgs.ListTagsForResource(ctx, &organizations.ListTagsForResourceInput{
+		ResourceId: aws.String(policyID),
+	})
+	if err != nil {
+		t.Fatalf("ListTagsForResource on the resource policy: %v", err)
+	}
+	if len(tags.Tags) != 1 || aws.ToString(tags.Tags[0].Key) != "Owner" {
+		t.Fatalf("expected the resource policy's create-time tag readable, got %+v", tags.Tags)
+	}
+
+	// --- a replacement updates the one policy in place ---
+	//
+	// A re-minted ID would tell a caller holding policyARN that its policy had been
+	// replaced by a different one, when the same single policy was updated.
+	replaced, err := orgs.PutResourcePolicy(ctx, &organizations.PutResourcePolicyInput{
+		Content: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	})
+	if err != nil {
+		t.Fatalf("replacing the resource policy: %v", err)
+	}
+	if id := aws.ToString(replaced.ResourcePolicy.ResourcePolicySummary.Id); id != policyID {
+		t.Fatalf("a replacement re-minted the ID: %q then %q", policyID, id)
+	}
+	if arn := aws.ToString(replaced.ResourcePolicy.ResourcePolicySummary.Arn); arn != policyARN {
+		t.Fatalf("a replacement re-minted the ARN: %q then %q", policyARN, arn)
+	}
+
+	// --- teardown, and the re-run ---
+	if _, err := orgs.DeleteResourcePolicy(ctx, &organizations.DeleteResourcePolicyInput{}); err != nil {
+		t.Fatalf("DeleteResourcePolicy: %v", err)
+	}
+	if _, err := orgs.DescribeResourcePolicy(ctx, &organizations.DescribeResourcePolicyInput{}); err == nil {
+		t.Fatal("DescribeResourcePolicy after a delete: expected ResourcePolicyNotFoundException")
+	} else if !errors.As(err, &notFound) {
+		t.Fatalf("expected *ResourcePolicyNotFoundException, got %T: %v", err, err)
+	}
+	// A second teardown pass is a refusal it can branch on rather than an outcome
+	// indistinguishable from having done the work.
+	if _, err := orgs.DeleteResourcePolicy(ctx, &organizations.DeleteResourcePolicyInput{}); err == nil {
+		t.Fatal("a second DeleteResourcePolicy: expected ResourcePolicyNotFoundException")
+	} else if !errors.As(err, &notFound) {
+		t.Fatalf("expected *ResourcePolicyNotFoundException, got %T: %v", err, err)
+	}
+}
+
 // journeyOrgParents walks every page of ListParents and returns the parent IDs.
 func journeyOrgParents(t *testing.T, ctx context.Context, orgs *organizations.Client, childID string) []string {
 	t.Helper()


### PR DESCRIPTION
Implements `PutResourcePolicy`, `DescribeResourcePolicy` and `DeleteResourcePolicy`, the operations #619 found missing by driving a read-only Organizations consumer against `substrate server` at v0.97.0. All three were claimed by no operation cluster, so each fell through to `InvalidAction` — which a consumer reads as "no such API" rather than "substrate has not implemented it", sending it to hunt a bug in its own request.

Part of #619. Two bullets of the issue's suggested behaviour are deliberately **not** implemented; see below.

## The shape

The issue calls this out and it drives the design: an organization holds exactly **one** resource policy, not a list keyed by ID. `Put` replaces it wholesale, and `Describe`/`Delete` take no input at all (the model gives `Delete` no output shape either).

- **The `rp-` ID and ARN are minted once and survive every replacement.** A re-mint would tell a caller holding the ARN that its policy had been replaced by a different one, when the same single policy was updated — and with one per organization, a new ID distinguishes nothing.
- **`ResourcePolicyNotFoundException` is the normal answer,** since most organizations have no resource policy. Answering an empty policy would collapse "nothing was delegated to me" and "something was delegated that I cannot read" into one observation, and those are different branches in a caller's error handling. `Delete` refuses the same way, so a second teardown pass is a refusal it can branch on rather than an outcome indistinguishable from the first.
- **Inline `Tags` are create-only,** per the model's note, and go through the same `validateOrgCreateTags` every other Organizations create uses — so an `aws:`-prefixed key cannot be planted here and then read as `aws:ResourceTag` by a policy condition. A `Put` carrying tags against an existing policy is refused rather than silently dropping them. The policy is also a tagging target: `resolveOrgTarget` grows an `rp-` arm and `orgAuthzResourceARN` resolves its ARN instead of falling through to `*`.

## Two corrections found against the API model

Both came from reading `InvalidInputExceptionReason`'s enum rather than the shape definitions, after the first pass was already green:

1. **Content is parsed as JSON.** The enum carries `INVALID_RESOURCE_POLICY_JSON`, which is the evidence AWS parses the document — the shape's own pattern is `[\s\S]*`, any text at all. Accepting an unparseable document would let a test go green on a policy real Organizations refuses. Only parseability is checked: the enum's `INVALID_PRINCIPAL`, `UNSUPPORTED_ACTION_IN_RESOURCE_POLICY` and the two like them are refusals about the document's *meaning*, and the sets AWS accepts are not in the model, so emitting them would mean guessing at their boundaries. A guessed refusal is worse than a missing one — it fails a document AWS would have accepted.
2. **The tags-on-update refusal carries no reason prefix.** No member of the enum describes that condition. The first pass borrowed `INVALID_PARTY_TYPE_TARGET`, which is about handshake parties; that would read as documented AWS behavior while matching no branch a consumer could have written. A test now asserts the message does not lead with a `SCREAMING_SNAKE_CASE` reason.

## Deliberately not implemented

Two of the issue's suggested-behaviour bullets — a member account reading what management set, and `AccessDeniedException` for a caller outside the organization — are **not** here, and #619 stays open against them. Organizations state is keyed by the **calling** account (`orgKey(acct)` is `"org:" + acct`, and `ensureOrganization` auto-creates a fresh organization for any unseen account), so a member account calling `DescribeResourcePolicy` today reads its own organization rather than management's. Making the asymmetry observable needs a member→organization reverse index plus a way to authenticate as a member — a foundation change, not a fourth operation. Tracked in #623.

The issue also offers a control-plane seed as an alternative; these are real API operations instead, since a consumer's own `Put` is what a delegation test needs to exercise.

## Testing

- 15 unit tests in `emulator/organizations_resourcepolicy_test.go`, including the round trip, ID stability across a replacement, the double-delete refusal, the 40,000-character boundary, the JSON refusal, the create-only tags rule, and `resolveOrgTarget`'s `rp-` arm. Store-read/write failures and an unreadable record are covered through the existing `errOrgState`/`corruptOrgState` harness, so a transient failure is a retryable 500 rather than the 400 the not-found refusal carries — the distinction matters most in this lane, because not-found is the *normal* answer here.
- **100% statement coverage** on the new file; the package total holds at 82.4%.
- An SDK journey in `test/e2e`, asserting the typed `*ResourcePolicyNotFoundException` via `errors.As`. This is the level that catches an unrouted operation, which is what #619 and #610 both were.
- The policy lane's claim test used `DescribeResourcePolicy` as its stand-in for an unimplemented operation. That claim is now false, so it uses `DescribeEffectivePolicy`, which substrate still does not implement.
- Verified live against `substrate server` with `AWS_MAX_ATTEMPTS=1` (so no CLI retry can mask a result): #619's repro, the full round trip, ID stability across a replacement, both refusals, the JSON refusal, `tag-resource`/`list-tags-for-resource` on the policy, and `TargetNotFoundException` on the ID after a delete.
- `gofmt`, `go vet`, `golangci-lint` (0 issues), `make test` with the race detector, and the e2e module all green.