### PR TITLE
feat(quotas): seed the organizations service quotas (#620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for a caller outside the organization. Both need a member→organization reverse
   index that does not exist yet.
 
+- **`organizations` quotas are now readable through Service Quotas** (#620). The
+  service was in neither seed table, so `L-E619E033` — the accounts-per-organization
+  ceiling — answered `NoSuchResourceException`: `CreateAccount` worked, but nothing
+  could read the limit it runs into. Also found by driving a consumer against
+  v0.97.0 rather than by reading the API model.
+
+  | Quota code | Name | Value | Adjustable |
+  |---|---|---|---|
+  | `L-E619E033` | Maximum number of accounts | 10 | **yes** |
+  | `L-29A0C5DF` | Service control policies in an organization | 10,000 | no |
+  | `L-0F0F51F4` | Organizational units in an organization | 2,000 | no |
+
+  The values are the ones substrate's Organizations plugin actually enforces
+  (`orgMaxAccounts`, `orgMaxSCPsPerOrg`, `orgMaxOUsPerOrg`), asserted against those
+  constants directly. A quota table that disagreed with its own emulator would be
+  worse than a missing one: a test written against the published number would fail
+  for a reason unrelated to the code under test. #620 reported the last two as 1,000
+  each; both AWS pages and substrate's own constants say **10,000** and **2,000**,
+  the same class of error as #578's RCP-for-SCP mixup. All three are
+  `GlobalQuota: true`, Organizations being global.
+
+  The two seed tables — `defaultServiceQuotas`, which `ListServiceQuotas` reads, and
+  `defaultServiceList`, which `ListServices` reads — are maintained by hand, so a
+  service added to one and not the other is either undiscoverable or discoverable
+  with no quotas, and neither is visible in any single response. A test now asserts
+  the two agree on every service code and name, which closes that drift for the
+  existing ten as well.
+
+### Fixed
+- **`ListServiceQuotas` for an unknown service is a refusal, not an empty list**
+  (#620). It answered HTTP 200 with `{"Quotas": []}`, which claims *this service
+  exists and publishes no quotas* — a different statement from *there is no such
+  service*, and only the second is true of a code substrate does not carry. The
+  first sends a caller to audit a quota code when the service name was wrong, which
+  is what happened here. It now answers `NoSuchResourceException`, the error the API
+  model declares for the operation.
+
+  `GetServiceQuota` and `GetAWSDefaultServiceQuota` now distinguish their two
+  refusals in the **message**: an unknown service names the service and points at
+  `ListServices`, an unknown quota code on a known service names the code and points
+  at `ListServiceQuotas`. The code stays `NoSuchResourceException` for both because
+  that is the only one the model declares, so the message is the sole place they can
+  differ. A missing required member is now `IllegalArgumentException` — also from the
+  model's error list — rather than a not-found for a resource the request never
+  named.
+
 ### Security
 - Bumped the `toolchain` directive in both modules from `go1.26.5` to `go1.26.6`,
   clearing seven standard-library vulnerabilities `govulncheck` reports as reachable

--- a/docs/services.md
+++ b/docs/services.md
@@ -4686,6 +4686,11 @@ and each is enforced rather than merely documented.
 The 5-per-target and 5,120-character figures often quoted are the **RCP** values,
 not the SCP ones.
 
+Three of these are also readable through Service Quotas — accounts, OUs and SCPs
+per organization — at the same values, so a consumer that reads a ceiling and a
+consumer that runs into one get the same number. See
+[Service Quotas](#service-quotas).
+
 ### Pagination
 
 Paginated listings honor `MaxResults` — clamped to the model's 1–20, so a caller
@@ -4724,6 +4729,86 @@ testing: `CreateAccount` still returns **200**, and only
 ### Cost
 
 Organizations API calls are free.
+
+---
+
+## Service Quotas
+
+**Endpoint:** `servicequotas.{region}.amazonaws.com`
+**Protocol:** JSON (`X-Amz-Target: ServiceQuotasV20190624.{Op}`)
+
+Service Quotas answers from a **built-in table of representative default quotas**,
+not from the plugins that enforce them. It covers eleven services rather than
+AWS's full catalog, which is why an unrecognised service code is an error rather
+than an empty result — see below.
+
+### Supported operations
+
+| Operation | Notes |
+|-----------|-------|
+| ListServices | The service codes substrate publishes quotas for |
+| ListServiceQuotas | `ServiceCode` required; `NoSuchResourceException` for a service not in the table |
+| GetServiceQuota | `ServiceCode` **and** `QuotaCode` required |
+| GetAWSDefaultServiceQuota | The same answer as `GetServiceQuota` — nothing here mutates a quota, so the applied value and the AWS default never diverge |
+| RequestServiceQuotaIncrease | Records a `PENDING` request; the published value does not move |
+| ListRequestedServiceQuotaChangesByService | Filterable by `ServiceCode` |
+| GetRequestedServiceQuotaChange | `NoSuchResourceException` for an unknown request ID |
+
+### An unknown service is a refusal, not an empty list
+
+`ListServiceQuotas` for a service code that is not in the table answers
+`NoSuchResourceException`, which the API model declares for this operation. It
+previously answered HTTP 200 with `{"Quotas": []}`, and that is a different claim:
+*this service exists and publishes no quotas*, rather than *there is no such
+service*. Only the second is true of a code substrate does not carry, and the
+first sends a caller looking for a missing quota rather than a wrong service name.
+
+`GetServiceQuota` distinguishes the two cases it can refuse for. Both are
+`NoSuchResourceException` — the only code the model declares — so the **message**
+is the only place they differ: an unknown service names the service and points at
+`ListServices`, while a known service with an unknown quota code names the code
+and points at `ListServiceQuotas`. Conflating them is what makes a missing service
+look like a bad quota code.
+
+A missing required member is `IllegalArgumentException` rather than
+`NoSuchResourceException`: the request never named a resource, so reporting one as
+absent would be misleading.
+
+### An increase request does not grant anything
+
+`RequestServiceQuotaIncrease` stores a `PENDING` record and returns it. The quota
+keeps reading its old value, because AWS grants nothing synchronously — a consumer
+that read the quota back expecting its `DesiredValue` would be asserting on a
+state real Service Quotas never reaches on that call.
+
+### Organizations quotas
+
+The three ceilings the Organizations plugin enforces are readable here at the
+values it enforces them at. A quota table that disagreed with its own emulator
+would be worse than a missing one: a test written against the published number
+would fail for a reason that has nothing to do with the code under test.
+
+| Quota code | Name | Value | Adjustable |
+|---|---|---|---|
+| `L-E619E033` | Maximum number of accounts | 10 | **yes** |
+| `L-29A0C5DF` | Service control policies in an organization | 10,000 | no |
+| `L-0F0F51F4` | Organizational units in an organization | 2,000 | no |
+
+All three are `GlobalQuota: true` — Organizations is a global service hosted in
+`us-east-1`, so its quotas are not per-region.
+
+Only `L-E619E033`'s code is confirmable from AWS documentation:
+[Endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/ao.html)
+publishes a quota code only for the **adjustable** quotas, and that is the
+adjustable one. The other two codes are best-effort, and the User Guide notes that
+quota codes may change — use `ListServiceQuotas` to discover them rather than
+hard-coding. The *values* are documented in
+[Quotas for AWS Organizations](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html)
+and match the [Organizations quotas](#quotas) above.
+
+### Cost
+
+Service Quotas API calls are free.
 
 ---
 

--- a/emulator/servicequotas_export_test.go
+++ b/emulator/servicequotas_export_test.go
@@ -1,0 +1,39 @@
+package emulator
+
+// This file exports the Service Quotas seed tables for the external test package,
+// so their consistency can be asserted directly rather than inferred from the API
+// responses they feed. It is compiled only when running tests.
+
+// ServiceQuotaCodesForTest returns the service codes keyed in
+// defaultServiceQuotas — the table ListServiceQuotas and GetServiceQuota read.
+func ServiceQuotaCodesForTest() []string {
+	codes := make([]string, 0, len(defaultServiceQuotas))
+	for code := range defaultServiceQuotas {
+		codes = append(codes, code)
+	}
+	return codes
+}
+
+// ServiceQuotaRowsForTest returns every quota in defaultServiceQuotas for one
+// service code, and whether the service is in the table at all.
+func ServiceQuotaRowsForTest(serviceCode string) ([]ServiceQuota, bool) {
+	quotas, ok := defaultServiceQuotas[serviceCode]
+	return quotas, ok
+}
+
+// ServiceListForTest returns the service codes and names in defaultServiceList —
+// the table ListServices reads.
+func ServiceListForTest() map[string]string {
+	names := make(map[string]string, len(defaultServiceList))
+	for _, entry := range defaultServiceList {
+		names[entry["ServiceCode"]] = entry["ServiceName"]
+	}
+	return names
+}
+
+// ServiceListLenForTest is the number of entries in defaultServiceList, exported
+// so a duplicate code can be told apart from a missing one.
+//
+// The Organizations ceilings this package's tests compare the seeded values
+// against are already exported by organizations_export_test.go.
+func ServiceListLenForTest() int { return len(defaultServiceList) }

--- a/emulator/servicequotas_organizations_test.go
+++ b/emulator/servicequotas_organizations_test.go
@@ -1,0 +1,406 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// This file covers #620: `organizations` was in neither Service Quotas seed table,
+// so a consumer could vend accounts with CreateAccount but could not read the
+// ceiling those calls run into. It also covers the two refusals that made the gap
+// hard to diagnose — an unknown service answering 200 with an empty list, and an
+// unknown service being indistinguishable from an unknown quota code.
+
+// sqQuota reads one quota through GetServiceQuota and returns it decoded.
+func sqQuota(t *testing.T, srv *emulator.TestServer, serviceCode, quotaCode string) map[string]interface{} {
+	t.Helper()
+	resp := makeServiceQuotasRequest(t, srv, "GetServiceQuota", map[string]interface{}{
+		"ServiceCode": serviceCode,
+		"QuotaCode":   quotaCode,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		body, _ := json.Marshal(sqDecode(t, resp))
+		t.Fatalf("GetServiceQuota(%s, %s): status %d: %s", serviceCode, quotaCode, resp.StatusCode, body)
+	}
+	quota, ok := sqDecode(t, resp)["Quota"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("GetServiceQuota(%s, %s) carried no Quota", serviceCode, quotaCode)
+	}
+	return quota
+}
+
+// sqDecode decodes a Service Quotas response body into a map.
+func sqDecode(t *testing.T, resp *http.Response) map[string]interface{} {
+	t.Helper()
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out
+}
+
+// sqRefusal issues a request expected to be refused and returns the error code and
+// message. The __type member carries the code, prefixed with the protocol's
+// namespace on some paths, so only the suffix is compared.
+func sqRefusal(t *testing.T, srv *emulator.TestServer, op string, body map[string]interface{}) (int, string, string) {
+	t.Helper()
+	resp := makeServiceQuotasRequest(t, srv, op, body)
+	defer resp.Body.Close() //nolint:errcheck
+	decoded := sqDecode(t, resp)
+	code, _ := decoded["__type"].(string)
+	if i := strings.LastIndex(code, "#"); i >= 0 {
+		code = code[i+1:]
+	}
+	message, _ := decoded["message"].(string)
+	if message == "" {
+		message, _ = decoded["Message"].(string)
+	}
+	return resp.StatusCode, code, message
+}
+
+// TestServiceQuotas_OrganizationsQuotasAreReadable is #620's repro verbatim:
+// L-E619E033 read through GetServiceQuota. It is the call that answered
+// NoSuchResourceException before the service was seeded.
+func TestServiceQuotas_OrganizationsQuotasAreReadable(t *testing.T) {
+	srv := emulator.StartTestServer(t)
+
+	tests := []struct {
+		quotaCode  string
+		name       string
+		value      float64
+		adjustable bool
+	}{
+		{"L-E619E033", "Maximum number of accounts", 10, true},
+		{"L-29A0C5DF", "Service control policies in an organization", 10000, false},
+		{"L-0F0F51F4", "Organizational units in an organization", 2000, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.quotaCode, func(t *testing.T) {
+			quota := sqQuota(t, srv, "organizations", tt.quotaCode)
+			if got := quota["QuotaName"]; got != tt.name {
+				t.Errorf("QuotaName = %v, want %q", got, tt.name)
+			}
+			if got, _ := quota["Value"].(float64); got != tt.value {
+				t.Errorf("Value = %v, want %v", got, tt.value)
+			}
+			if got, _ := quota["Adjustable"].(bool); got != tt.adjustable {
+				t.Errorf("Adjustable = %v, want %v", got, tt.adjustable)
+			}
+			// Organizations is a global service, so none of its quotas are
+			// per-region. A consumer that reads GlobalQuota to decide whether to
+			// enumerate regions would enumerate them for nothing.
+			if got, _ := quota["GlobalQuota"].(bool); !got {
+				t.Error("GlobalQuota = false, want true for a global service")
+			}
+			if got := quota["ServiceName"]; got != "AWS Organizations" {
+				t.Errorf("ServiceName = %v, want \"AWS Organizations\"", got)
+			}
+		})
+	}
+}
+
+// TestServiceQuotas_OrganizationsIsDiscoverable pins the discovery path a consumer
+// actually walks: ListServices to find the code, ListServiceQuotas to find the
+// quota codes, GetServiceQuota to read one. A service missing from any step is
+// unreachable through the step before it.
+func TestServiceQuotas_OrganizationsIsDiscoverable(t *testing.T) {
+	srv := emulator.StartTestServer(t)
+
+	listed := makeServiceQuotasRequest(t, srv, "ListServices", nil)
+	defer listed.Body.Close() //nolint:errcheck
+	services, _ := sqDecode(t, listed)["Services"].([]interface{})
+	found := 0
+	for _, svc := range services {
+		entry, _ := svc.(map[string]interface{})
+		if entry["ServiceCode"] == "organizations" {
+			found++
+			if entry["ServiceName"] != "AWS Organizations" {
+				t.Errorf("ListServices names organizations %v", entry["ServiceName"])
+			}
+		}
+	}
+	if found != 1 {
+		t.Fatalf("ListServices reported organizations %d times, want exactly 1", found)
+	}
+
+	quotasResp := makeServiceQuotasRequest(t, srv, "ListServiceQuotas", map[string]interface{}{
+		"ServiceCode": "organizations",
+	})
+	defer quotasResp.Body.Close() //nolint:errcheck
+	if quotasResp.StatusCode != http.StatusOK {
+		t.Fatalf("ListServiceQuotas(organizations): status %d", quotasResp.StatusCode)
+	}
+	quotas, _ := sqDecode(t, quotasResp)["Quotas"].([]interface{})
+	codes := make(map[string]bool, len(quotas))
+	for _, q := range quotas {
+		entry, _ := q.(map[string]interface{})
+		code, _ := entry["QuotaCode"].(string)
+		codes[code] = true
+	}
+	for _, want := range []string{"L-E619E033", "L-29A0C5DF", "L-0F0F51F4"} {
+		if !codes[want] {
+			t.Errorf("ListServiceQuotas(organizations) omitted %s; got %v", want, codes)
+		}
+	}
+	if len(quotas) != 3 {
+		t.Errorf("ListServiceQuotas(organizations) returned %d quotas, want 3", len(quotas))
+	}
+}
+
+// TestServiceQuotas_OrganizationsValuesMatchTheEnforcedLimits is the property that
+// makes the seeded values worth having: the ceiling a consumer reads and the
+// ceiling the Organizations plugin refuses at are the same number. A quota table
+// that disagrees with its own emulator is worse than a missing one, because a test
+// written against the published value would then fail for the wrong reason.
+func TestServiceQuotas_OrganizationsValuesMatchTheEnforcedLimits(t *testing.T) {
+	quotas, ok := emulator.ServiceQuotaRowsForTest("organizations")
+	if !ok {
+		t.Fatal("organizations is not in defaultServiceQuotas")
+	}
+
+	want := map[string]float64{
+		"L-E619E033": emulator.OrgMaxAccountsForTest,
+		"L-29A0C5DF": emulator.OrgMaxSCPsPerOrgForTest,
+		"L-0F0F51F4": emulator.OrgMaxOUsPerOrgForTest,
+	}
+	for _, quota := range quotas {
+		expected, known := want[quota.QuotaCode]
+		if !known {
+			t.Errorf("unexpected quota %s in the organizations table", quota.QuotaCode)
+			continue
+		}
+		if quota.Value != expected {
+			t.Errorf("%s (%s) publishes %v but the plugin enforces %v",
+				quota.QuotaCode, quota.QuotaName, quota.Value, expected)
+		}
+		delete(want, quota.QuotaCode)
+	}
+	for code := range want {
+		t.Errorf("the organizations table is missing %s", code)
+	}
+}
+
+// TestServiceQuotas_TheTwoTablesAgree closes the drift the plan named: the two seed
+// tables are maintained by hand, ListServices reads only defaultServiceList and
+// ListServiceQuotas only defaultServiceQuotas, so a service added to one and not
+// the other is either undiscoverable or discoverable with no quotas. Neither is
+// visible from any single response, which is why this asserts on the tables.
+func TestServiceQuotas_TheTwoTablesAgree(t *testing.T) {
+	listed := emulator.ServiceListForTest()
+	if got := emulator.ServiceListLenForTest(); got != len(listed) {
+		t.Errorf("defaultServiceList has %d entries but %d distinct service codes — a duplicate",
+			got, len(listed))
+	}
+
+	for _, code := range emulator.ServiceQuotaCodesForTest() {
+		name, ok := listed[code]
+		if !ok {
+			t.Errorf("%q has quotas but is absent from defaultServiceList, so ListServices cannot find it", code)
+			continue
+		}
+		// Every row of a service's quotas repeats the service's name, so a
+		// mismatch means the same service answers to two names depending on
+		// which operation asked.
+		quotas, _ := emulator.ServiceQuotaRowsForTest(code)
+		for _, quota := range quotas {
+			if quota.ServiceName != name {
+				t.Errorf("%q is %q in defaultServiceList but %q on quota %s",
+					code, name, quota.ServiceName, quota.QuotaCode)
+			}
+			if quota.ServiceCode != code {
+				t.Errorf("quota %s is keyed under %q but carries ServiceCode %q",
+					quota.QuotaCode, code, quota.ServiceCode)
+			}
+		}
+		delete(listed, code)
+	}
+	for code := range listed {
+		t.Errorf("%q is in defaultServiceList but has no quotas, so ListServiceQuotas refuses it", code)
+	}
+}
+
+// TestServiceQuotas_UnknownServiceIsARefusal is the behavior change #620's
+// "Related" note asks for. An empty Quotas list says the service exists and
+// publishes no quotas; only NoSuchResourceException says it does not exist, and
+// that is the error the model declares for ListServiceQuotas.
+func TestServiceQuotas_UnknownServiceIsARefusal(t *testing.T) {
+	srv := emulator.StartTestServer(t)
+
+	for _, op := range []string{"ListServiceQuotas", "GetServiceQuota", "GetAWSDefaultServiceQuota"} {
+		t.Run(op, func(t *testing.T) {
+			status, code, message := sqRefusal(t, srv, op, map[string]interface{}{
+				"ServiceCode": "nosuchsvc",
+				"QuotaCode":   "L-E619E033",
+			})
+			if status != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", status)
+			}
+			if code != "NoSuchResourceException" {
+				t.Errorf("code = %q, want NoSuchResourceException", code)
+			}
+			// The message has to name the service, since that is the input that
+			// was wrong. Naming only the quota code sends a caller to audit a
+			// code that was fine.
+			if !strings.Contains(message, `"nosuchsvc"`) {
+				t.Errorf("message does not name the service: %q", message)
+			}
+			if !strings.Contains(message, "ListServices") {
+				t.Errorf("message does not point at ListServices: %q", message)
+			}
+		})
+	}
+}
+
+// TestServiceQuotas_UnknownQuotaCodeSaysSo is the other half of the same defect:
+// a known service with an unknown quota code must not read as an unknown service.
+// Both are NoSuchResourceException — the only code the model declares — so the
+// message is the only place they differ.
+func TestServiceQuotas_UnknownQuotaCodeSaysSo(t *testing.T) {
+	srv := emulator.StartTestServer(t)
+
+	status, code, message := sqRefusal(t, srv, "GetServiceQuota", map[string]interface{}{
+		"ServiceCode": "organizations",
+		"QuotaCode":   "L-NOTAQUOTA",
+	})
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", status)
+	}
+	if code != "NoSuchResourceException" {
+		t.Errorf("code = %q, want NoSuchResourceException", code)
+	}
+	if !strings.Contains(message, `"L-NOTAQUOTA"`) {
+		t.Errorf("message does not name the quota code: %q", message)
+	}
+	if !strings.Contains(message, "ListServiceQuotas") {
+		t.Errorf("message does not point at ListServiceQuotas: %q", message)
+	}
+	// The distinguishing assertion: this must not read as "no such service".
+	if strings.Contains(message, "No such service") {
+		t.Errorf("a known service with a bad quota code reported an unknown service: %q", message)
+	}
+}
+
+// TestServiceQuotas_RequiredMembersAreEnforced pins the model's required members.
+// Both operations declare ServiceCode required (GetServiceQuota also QuotaCode),
+// and IllegalArgumentException is the error the model declares for bad input —
+// answering NoSuchResourceException for an absent member would tell a caller the
+// resource is missing when the request never named one.
+func TestServiceQuotas_RequiredMembersAreEnforced(t *testing.T) {
+	srv := emulator.StartTestServer(t)
+
+	tests := []struct {
+		name string
+		op   string
+		body map[string]interface{}
+	}{
+		{"ListServiceQuotas without a service", "ListServiceQuotas", map[string]interface{}{}},
+		{"ListServiceQuotas with no body at all", "ListServiceQuotas", nil},
+		{"GetServiceQuota without a service", "GetServiceQuota", map[string]interface{}{"QuotaCode": "L-E619E033"}},
+		{"GetServiceQuota without a quota code", "GetServiceQuota", map[string]interface{}{"ServiceCode": "organizations"}},
+		{"GetAWSDefaultServiceQuota without a quota code", "GetAWSDefaultServiceQuota", map[string]interface{}{"ServiceCode": "organizations"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, code, _ := sqRefusal(t, srv, tt.op, tt.body)
+			if status != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", status)
+			}
+			if code != "IllegalArgumentException" {
+				t.Errorf("code = %q, want IllegalArgumentException", code)
+			}
+		})
+	}
+}
+
+// TestServiceQuotas_BodyDecodeFailures covers the decode path with bodies the
+// shared helper cannot produce, since it substitutes "{}" for an absent one.
+//
+// A body that is not JSON is a serialization failure. A body that is *absent*
+// is not: it carries no members, so the useful answer is the missing required
+// member rather than a decode error about the empty string — which is why the
+// zero-length case is handled before the unmarshal rather than by it.
+func TestServiceQuotas_BodyDecodeFailures(t *testing.T) {
+	srv := emulator.StartTestServer(t)
+
+	tests := []struct {
+		name string
+		op   string
+		body string
+		code string
+	}{
+		{"unparseable on list", "ListServiceQuotas", "{not json", "SerializationException"},
+		{"unparseable on get", "GetServiceQuota", "{not json", "SerializationException"},
+		{"empty on list", "ListServiceQuotas", "", "IllegalArgumentException"},
+		{"empty on get", "GetServiceQuota", "", "IllegalArgumentException"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Host = "servicequotas.us-east-1.amazonaws.com"
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Amz-Target", "ServiceQuotas."+tt.op)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("do request: %v", err)
+			}
+			defer resp.Body.Close() //nolint:errcheck
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", resp.StatusCode)
+			}
+			code, _ := sqDecode(t, resp)["__type"].(string)
+			if i := strings.LastIndex(code, "#"); i >= 0 {
+				code = code[i+1:]
+			}
+			if code != tt.code {
+				t.Errorf("code = %q, want %q", code, tt.code)
+			}
+		})
+	}
+}
+
+// TestServiceQuotas_OrganizationsIncreaseIsRequestable is the rest of #620's story:
+// the accounts quota is the adjustable one, so a consumer that reads 10 and wants
+// more files an increase against it. The request is what a tool does next, and it
+// has to reach a PENDING record rather than a refusal.
+func TestServiceQuotas_OrganizationsIncreaseIsRequestable(t *testing.T) {
+	srv := emulator.StartTestServer(t)
+
+	resp := makeServiceQuotasRequest(t, srv, "RequestServiceQuotaIncrease", map[string]interface{}{
+		"ServiceCode":  "organizations",
+		"QuotaCode":    "L-E619E033",
+		"DesiredValue": 50.0,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("RequestServiceQuotaIncrease: status %d", resp.StatusCode)
+	}
+	requested, ok := sqDecode(t, resp)["RequestedQuota"].(map[string]interface{})
+	if !ok {
+		t.Fatal("RequestServiceQuotaIncrease carried no RequestedQuota")
+	}
+	if requested["Status"] != "PENDING" {
+		t.Errorf("Status = %v, want PENDING", requested["Status"])
+	}
+	if requested["QuotaCode"] != "L-E619E033" {
+		t.Errorf("QuotaCode = %v, want L-E619E033", requested["QuotaCode"])
+	}
+	if got, _ := requested["DesiredValue"].(float64); got != 50 {
+		t.Errorf("DesiredValue = %v, want 50", got)
+	}
+	// The increase does not move the published value. Service Quotas records the
+	// request; nothing is granted until it is approved, and a consumer that read
+	// the quota back expecting 50 would be reading a state AWS never reaches
+	// synchronously.
+	quota := sqQuota(t, srv, "organizations", "L-E619E033")
+	if got, _ := quota["Value"].(float64); got != 10 {
+		t.Errorf("after a pending increase the quota reads %v, want the unchanged 10", got)
+	}
+}

--- a/emulator/servicequotas_plugin.go
+++ b/emulator/servicequotas_plugin.go
@@ -132,13 +132,19 @@ func (p *ServiceQuotasPlugin) listServiceQuotas(req *AWSRequest) (*AWSResponse, 
 	var input struct {
 		ServiceCode string `json:"ServiceCode"`
 	}
-	if len(req.Body) > 0 {
-		_ = json.Unmarshal(req.Body, &input)
+	if err := sqUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if input.ServiceCode == "" {
+		return nil, sqIllegalArgument("ServiceCode is required")
 	}
 
+	// An unrecognized service is NoSuchResourceException, which the model declares
+	// for this operation. Answering 200 with an empty list instead claims the
+	// service exists and has no quotas — a different, and false, statement.
 	quotas, ok := defaultServiceQuotas[input.ServiceCode]
 	if !ok {
-		quotas = []ServiceQuota{}
+		return nil, sqNoSuchService(input.ServiceCode)
 	}
 
 	return sqJSONResponse(http.StatusOK, map[string]interface{}{
@@ -151,17 +157,16 @@ func (p *ServiceQuotasPlugin) getServiceQuota(req *AWSRequest) (*AWSResponse, er
 		ServiceCode string `json:"ServiceCode"`
 		QuotaCode   string `json:"QuotaCode"`
 	}
-	if len(req.Body) > 0 {
-		_ = json.Unmarshal(req.Body, &input)
+	if err := sqUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if input.ServiceCode == "" || input.QuotaCode == "" {
+		return nil, sqIllegalArgument("ServiceCode and QuotaCode are required")
 	}
 
-	quota := p.findQuota(input.ServiceCode, input.QuotaCode)
-	if quota == nil {
-		return nil, &AWSError{
-			Code:       "NoSuchResourceException",
-			Message:    fmt.Sprintf("No quota found for service %q quota %q", input.ServiceCode, input.QuotaCode),
-			HTTPStatus: http.StatusBadRequest,
-		}
+	quota, awsErr := p.findQuota(input.ServiceCode, input.QuotaCode)
+	if awsErr != nil {
+		return nil, awsErr
 	}
 	return sqJSONResponse(http.StatusOK, map[string]interface{}{
 		"Quota": quota,
@@ -283,15 +288,65 @@ func (p *ServiceQuotasPlugin) getRequestedServiceQuotaChange(req *AWSRequest) (*
 // --- Helpers -----------------------------------------------------------------
 
 // findQuota returns the quota matching serviceCode and quotaCode from the
-// built-in table, or nil if not found.
-func (p *ServiceQuotasPlugin) findQuota(serviceCode, quotaCode string) *ServiceQuota {
+// built-in table.
+//
+// The refusal distinguishes an unknown service from an unknown quota code on a
+// known service. Both are NoSuchResourceException — that is the only code the
+// model declares — so the message is the only place the two can be told apart,
+// and a caller that cannot tell them apart goes looking for a wrong quota code
+// when the service name is what was wrong.
+func (p *ServiceQuotasPlugin) findQuota(serviceCode, quotaCode string) (*ServiceQuota, *AWSError) {
 	quotas, ok := defaultServiceQuotas[serviceCode]
 	if !ok {
-		return nil
+		return nil, sqNoSuchService(serviceCode)
 	}
 	for i := range quotas {
 		if quotas[i].QuotaCode == quotaCode {
-			return &quotas[i]
+			return &quotas[i], nil
+		}
+	}
+	return nil, &AWSError{
+		Code: "NoSuchResourceException",
+		Message: fmt.Sprintf("No quota code %q for service %q. Use ListServiceQuotas to find the quota codes "+
+			"a service publishes.", quotaCode, serviceCode),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// sqNoSuchService is the refusal for a service code that is not in the built-in
+// table. It names the service so a caller does not read it as a bad quota code.
+func sqNoSuchService(serviceCode string) *AWSError {
+	return &AWSError{
+		Code: "NoSuchResourceException",
+		Message: fmt.Sprintf("No such service %q. Use ListServices to find the service codes substrate emulates "+
+			"quotas for.", serviceCode),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// sqIllegalArgument is the refusal for a missing or malformed request member.
+// IllegalArgumentException is the code the model declares for it on every
+// Service Quotas operation.
+func sqIllegalArgument(message string) *AWSError {
+	return &AWSError{
+		Code:       "IllegalArgumentException",
+		Message:    message,
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// sqUnmarshal decodes a request body, treating an absent body as an empty one so
+// the required-member check below reports the missing member rather than a
+// serialization failure.
+func sqUnmarshal(body []byte, out interface{}) *AWSError {
+	if len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return &AWSError{
+			Code:       "SerializationException",
+			Message:    err.Error(),
+			HTTPStatus: http.StatusBadRequest,
 		}
 	}
 	return nil

--- a/emulator/servicequotas_types.go
+++ b/emulator/servicequotas_types.go
@@ -201,9 +201,57 @@ var defaultServiceQuotas = map[string][]ServiceQuota{
 			Unit:        "None",
 		},
 	},
+	// Organizations quotas. Each value is the one substrate's Organizations plugin
+	// actually enforces, so a consumer that reads the ceiling here and a consumer
+	// that runs into it get the same number — a quota table disagreeing with the
+	// limit it describes is worse than a missing one, because the disagreement is
+	// silent.
+	//
+	// GlobalQuota is true for all three: Organizations is a global service hosted in
+	// us-east-1, so its quotas are not per-region.
+	"organizations": {
+		{
+			ServiceCode: "organizations",
+			ServiceName: "AWS Organizations",
+			// The only one of the three whose code is confirmable from AWS docs. The
+			// endpoints-and-quotas page publishes a quota code only for adjustable
+			// quotas, and this is the adjustable one.
+			QuotaCode:   "L-E619E033",
+			QuotaName:   "Maximum number of accounts",
+			Value:       10, // Matches orgMaxAccounts.
+			Adjustable:  true,
+			GlobalQuota: true,
+			Unit:        "None",
+		},
+		{
+			ServiceCode: "organizations",
+			ServiceName: "AWS Organizations",
+			QuotaCode:   "L-29A0C5DF",
+			QuotaName:   "Service control policies in an organization",
+			Value:       10000, // Matches orgMaxSCPsPerOrg.
+			Adjustable:  false,
+			GlobalQuota: true,
+			Unit:        "None",
+		},
+		{
+			ServiceCode: "organizations",
+			ServiceName: "AWS Organizations",
+			QuotaCode:   "L-0F0F51F4",
+			QuotaName:   "Organizational units in an organization",
+			Value:       2000, // Matches orgMaxOUsPerOrg.
+			Adjustable:  false,
+			GlobalQuota: true,
+			Unit:        "None",
+		},
+	},
 }
 
 // defaultServiceList is the list of services returned by ListServices.
+//
+// It must name exactly the services keyed in defaultServiceQuotas: ListServices
+// reads only this table and ListServiceQuotas only the other, so a service present
+// in one and absent from the other is discoverable but has no quotas, or has quotas
+// nothing can discover. TestServiceQuotas_TheTwoTablesAgree pins the two together.
 var defaultServiceList = []map[string]string{
 	{"ServiceCode": "lambda", "ServiceName": "AWS Lambda"},
 	{"ServiceCode": "s3", "ServiceName": "Amazon S3"},
@@ -215,4 +263,5 @@ var defaultServiceList = []map[string]string{
 	{"ServiceCode": "cloudwatch", "ServiceName": "Amazon CloudWatch"},
 	{"ServiceCode": "sns", "ServiceName": "Amazon Simple Notification Service"},
 	{"ServiceCode": "rds", "ServiceName": "Amazon Relational Database Service"},
+	{"ServiceCode": "organizations", "ServiceName": "AWS Organizations"},
 }

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.26
 toolchain go1.26.6
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.43.4
+	github.com/aws/aws-sdk-go-v2 v1.43.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.35
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.34
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.58.1
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.53.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.0
+	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.37.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.4
 	github.com/aws/smithy-go v1.27.7
 	github.com/scttfrdmn/substrate v0.0.0
@@ -23,8 +24,8 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.35 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.35 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.35 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.36 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.36 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.28 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go-v2 v1.43.4 h1:b9FTvbRwy+JCsfp2Wp6wV/KbOx3Aj7nkoFb2cRX0IhE=
-github.com/aws/aws-sdk-go-v2 v1.43.4/go.mod h1:70vwSy16txshwG+g55WkpgPKDIByzHI8ccBsOteo3bQ=
+github.com/aws/aws-sdk-go-v2 v1.43.5 h1:yKT5GYnFWhuDo+DqKvE5ZPwVn3RjC4MAeBtZGlh6AVM=
+github.com/aws/aws-sdk-go-v2 v1.43.5/go.mod h1:wZjAJppCntyOGgVSmgVTfDyRJK5PHOasO6Wsy8U7Axk=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.16 h1:aiuaKlDweRC5qExJondpWjOgyzMHpofpwspGXUtwn4c=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.16/go.mod h1:nG/LOlmox9BDe9HvQnXWzgcK8uKbgBMZ/Hp5pVt/21I=
 github.com/aws/aws-sdk-go-v2/config v1.32.35 h1:UEzXuET8E42lxBPijuACu/tEK7v5lFPlk0Q+GT5WD9E=
@@ -8,10 +8,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.34 h1:y6GkSmcv5myd1ngrYbGmiLlwQqB
 github.com/aws/aws-sdk-go-v2/credentials v1.19.34/go.mod h1:w3dTcnDVoQIewjo7JG45hduAToikiIFLC4FIO7fndvw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.35 h1:+S7kbJoLDDQ5tE+lHrUBgMkzC8NLgsaioS2F3dVoFAE=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.35/go.mod h1:Ak7xXviIARfFdNUJ9Etb0bdVDt/KAvKjMGJVLWXDzik=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.35 h1:kzVuGlatQtYinwBJEEyLAbggepCoavosiaHHX9+fD+c=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.35/go.mod h1:0yLx0yEI+SfqeJMPvOtIEFoZbiQYXMGszBueiutQyaI=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.35 h1:WK6CjihTuLisCjSKKbildJ79sGZZgbBz3iNa7VsKIhU=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.35/go.mod h1:KYleN57luLoe97R7vTnx8PMcVrr9gAcRECtOjl91DNg=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.36 h1:5CrzwxDqf4w3x1Vs3/NiZ0nsC34Hbm3pIDMWbsLebOE=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.36/go.mod h1:A3gHdKZIvG/QXERzZwcxNS3RNDFcRCuhhTFBYp+V/nw=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36 h1:A4N2f4YPcST0v+dWtX+xrpPPCL9VTBhoIFFUWYqbacE=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36/go.mod h1:B/Qr859uxWUEfZeGotK5KAEoof4Q9YWgNtPSwV6jcyk=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.36 h1:jbGY4CXLzZElOXgGsexlC3Hi+3YM0rSmk4opFXKqg/k=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.36/go.mod h1:uBu/9aKsS/UQGc72RAt3y54kjgYQxmhut8ZD2dXCDNE=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1 h1:UDQGJ9AuLcf4yiDKyHPGN4EirOLo/E8+Zfoii8FhyZs=
@@ -32,6 +32,8 @@ github.com/aws/aws-sdk-go-v2/service/organizations v1.53.5 h1:K0Ayr+MNVSkEVbD/dn
 github.com/aws/aws-sdk-go-v2/service/organizations v1.53.5/go.mod h1:mJSUa59X8tlEX0DVvxdHZvMMrll/65omXLuwk2FCRDw=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.107.0 h1:OkYV+1171za+ab9otU1tGxMXhx6uZvwVEtVddjLuYTg=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.107.0/go.mod h1:5FTZoQxhmLEiCAtYVk6V+t0iS/B5yGZVLZ3Wq5FDJZI=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.37.5 h1:D5ReWQnjE6GCrjtvu5qmbFJx9HCk/RqTHzJeV2gaFxA=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.37.5/go.mod h1:C7EOgH7vtwuQRwtzfWx3mzekFyeWcUxiiF0hUr7EWug=
 github.com/aws/aws-sdk-go-v2/service/signin v1.5.4 h1:cOJELVNrq5Q3Udry2GLuHUM7MhwpeaQRdYaoa6GI/yI=
 github.com/aws/aws-sdk-go-v2/service/signin v1.5.4/go.mod h1:f4LxzKBtaTxD7xh3PiVg3CE1tchQemfmghaJr+NbK2c=
 github.com/aws/aws-sdk-go-v2/service/sso v1.33.4 h1:AMW7a7S8iQaHjBYZdU3PCq4GKRPijTPRAc7e6XtEThY=

--- a/test/e2e/journey_servicequotas_test.go
+++ b/test/e2e/journey_servicequotas_test.go
@@ -1,0 +1,145 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	sqtypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_ServiceQuotasOrganizations is #620 at the SDK level: the
+// Organizations account ceiling read through the real Service Quotas client.
+//
+// The unit tests cover the table and each refusal. What only this level catches is
+// routing — the Service Quotas SigV4 name is `servicequotasv20190624` and its
+// X-Amz-Target prefix is `ServiceQuotasV20190624`, neither of which is the plugin
+// name, so a mapping that stops matching sends every SDK call to "service not
+// emulated" while the unit tests, which drive the plugin through a hand-built
+// target header, stay green. That is #610's failure mode exactly.
+func TestJourney_ServiceQuotasOrganizations(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	// Retries off, so each assertion is about the first response rather than
+	// whatever the retry loop settled on.
+	quotas := servicequotas.NewFromConfig(cfg, func(o *servicequotas.Options) { o.RetryMaxAttempts = 1 })
+
+	// --- the discovery path a tool actually walks ---
+	services, err := quotas.ListServices(ctx, &servicequotas.ListServicesInput{})
+	if err != nil {
+		t.Fatalf("ListServices: %v", err)
+	}
+	found := false
+	for _, svc := range services.Services {
+		if aws.ToString(svc.ServiceCode) == "organizations" {
+			found = true
+			if got := aws.ToString(svc.ServiceName); got != "AWS Organizations" {
+				t.Errorf("ListServices names organizations %q", got)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("ListServices did not report organizations, so nothing can discover its quotas")
+	}
+
+	listed, err := quotas.ListServiceQuotas(ctx, &servicequotas.ListServiceQuotasInput{
+		ServiceCode: aws.String("organizations"),
+	})
+	if err != nil {
+		t.Fatalf("ListServiceQuotas(organizations): %v", err)
+	}
+	if len(listed.Quotas) != 3 {
+		t.Fatalf("ListServiceQuotas(organizations) returned %d quotas, want 3", len(listed.Quotas))
+	}
+
+	// --- #620's repro verbatim ---
+	got, err := quotas.GetServiceQuota(ctx, &servicequotas.GetServiceQuotaInput{
+		ServiceCode: aws.String("organizations"),
+		QuotaCode:   aws.String("L-E619E033"),
+	})
+	if err != nil {
+		t.Fatalf("GetServiceQuota(organizations, L-E619E033): %v", err)
+	}
+	if v := aws.ToFloat64(got.Quota.Value); v != 10 {
+		t.Errorf("the accounts quota reads %v, want 10 — the value CreateAccount enforces", v)
+	}
+	if !got.Quota.Adjustable {
+		t.Error("the accounts quota reports Adjustable=false; it is the adjustable one")
+	}
+	if !got.Quota.GlobalQuota {
+		t.Error("the accounts quota reports GlobalQuota=false; Organizations is a global service")
+	}
+
+	// GetAWSDefaultServiceQuota agrees, because nothing here mutates a quota: the
+	// applied value and the AWS default cannot diverge.
+	def, err := quotas.GetAWSDefaultServiceQuota(ctx, &servicequotas.GetAWSDefaultServiceQuotaInput{
+		ServiceCode: aws.String("organizations"),
+		QuotaCode:   aws.String("L-E619E033"),
+	})
+	if err != nil {
+		t.Fatalf("GetAWSDefaultServiceQuota: %v", err)
+	}
+	if aws.ToFloat64(def.Quota.Value) != aws.ToFloat64(got.Quota.Value) {
+		t.Errorf("the applied value %v and the AWS default %v disagree",
+			aws.ToFloat64(got.Quota.Value), aws.ToFloat64(def.Quota.Value))
+	}
+
+	// --- the refusals, through the typed exception a consumer branches on ---
+	//
+	// errors.As is the branch a caller's error handling actually takes. Both cases
+	// are NoSuchResourceException, so the type alone cannot tell them apart — which
+	// is why the plugin distinguishes them in the message.
+	var noSuch *sqtypes.NoSuchResourceException
+	if _, err := quotas.ListServiceQuotas(ctx, &servicequotas.ListServiceQuotasInput{
+		ServiceCode: aws.String("nosuchsvc"),
+	}); err == nil {
+		t.Fatal("an unknown service code: expected NoSuchResourceException, not an empty list")
+	} else if !errors.As(err, &noSuch) {
+		t.Fatalf("expected *NoSuchResourceException, got %T: %v", err, err)
+	}
+
+	if _, err := quotas.GetServiceQuota(ctx, &servicequotas.GetServiceQuotaInput{
+		ServiceCode: aws.String("organizations"),
+		QuotaCode:   aws.String("L-NOTAQUOTA"),
+	}); err == nil {
+		t.Fatal("an unknown quota code: expected NoSuchResourceException")
+	} else if !errors.As(err, &noSuch) {
+		t.Fatalf("expected *NoSuchResourceException, got %T: %v", err, err)
+	}
+
+	// --- the increase a consumer files after reading the ceiling ---
+	//
+	// It records a request and grants nothing. A tool that read the quota back
+	// expecting its DesiredValue would be asserting on a state real Service Quotas
+	// never reaches on this call.
+	requested, err := quotas.RequestServiceQuotaIncrease(ctx, &servicequotas.RequestServiceQuotaIncreaseInput{
+		ServiceCode:  aws.String("organizations"),
+		QuotaCode:    aws.String("L-E619E033"),
+		DesiredValue: aws.Float64(50),
+	})
+	if err != nil {
+		t.Fatalf("RequestServiceQuotaIncrease: %v", err)
+	}
+	if requested.RequestedQuota.Status != sqtypes.RequestStatusPending {
+		t.Errorf("Status = %q, want PENDING", requested.RequestedQuota.Status)
+	}
+	after, err := quotas.GetServiceQuota(ctx, &servicequotas.GetServiceQuotaInput{
+		ServiceCode: aws.String("organizations"),
+		QuotaCode:   aws.String("L-E619E033"),
+	})
+	if err != nil {
+		t.Fatalf("GetServiceQuota after the increase: %v", err)
+	}
+	if v := aws.ToFloat64(after.Quota.Value); v != 10 {
+		t.Errorf("a pending increase moved the quota to %v; it must still read 10", v)
+	}
+}


### PR DESCRIPTION
`organizations` was in neither Service Quotas seed table, so `L-E619E033` — the accounts-per-organization ceiling — answered `NoSuchResourceException`. `CreateAccount` worked but nothing could read the limit it runs into. Like #619, this was found by driving a consumer against `substrate server` at v0.97.0 rather than by reading the API model.

## The quotas

| Quota code | Name | Value | Adjustable |
|---|---|---|---|
| `L-E619E033` | Maximum number of accounts | 10 | **yes** |
| `L-29A0C5DF` | Service control policies in an organization | 10,000 | no |
| `L-0F0F51F4` | Organizational units in an organization | 2,000 | no |

Each value is the one substrate's Organizations plugin actually enforces, and a test asserts that against `orgMaxAccounts`/`orgMaxSCPsPerOrg`/`orgMaxOUsPerOrg` directly rather than against a copied literal. A quota table that disagreed with its own emulator would be worse than a missing one: a test written against the published number would fail for a reason unrelated to the code under test.

All three are `GlobalQuota: true` — Organizations is a global service hosted in `us-east-1`.

## A correction to the issue

#620 gives SCPs-per-organization and OUs-per-organization as 1,000 each. Both [Endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/ao.html) and the [User Guide](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html) say **10,000** and **2,000**, matching substrate's own constants. Same class of error as #578's RCP-for-SCP mixup, so the corrected values ship.

## Provenance of the quota codes

Only `L-E619E033`'s code is confirmable from AWS documentation: the endpoints page publishes a quota code only for the **adjustable** quotas, and that is the adjustable one. `L-29A0C5DF` and `L-0F0F51F4` come from #620's report; the User Guide warns that quota codes may change and says to use `ListServiceQuotas` to discover them. Their *values* are documented and cited. This will be repeated in the release notes' `## Provenance` section.

## The two-table drift

`defaultServiceQuotas` is read only by `ListServiceQuotas`/`GetServiceQuota`, `defaultServiceList` only by `ListServices`, and both are maintained by hand. A service added to one and not the other is either undiscoverable or discoverable with no quotas, and neither state is visible in any single response. `TestServiceQuotas_TheTwoTablesAgree` now pins the two together on every service code and name, which closes that drift for the existing ten services as well.

## The refusals that made this hard to diagnose

- **`ListServiceQuotas` for an unknown service** was HTTP 200 with `{"Quotas": []}`. That claims *this service exists and publishes no quotas* — a different statement from *there is no such service*, and only the second is true of a code substrate does not carry. It now answers `NoSuchResourceException`, which the model declares for this operation.
- **`GetServiceQuota`/`GetAWSDefaultServiceQuota`** could not distinguish an unknown service from an unknown quota code. Both are `NoSuchResourceException` — the only code the model declares — so the message is the sole place they can differ: an unknown service names the service and points at `ListServices`, an unknown quota code names the code and points at `ListServiceQuotas`. Conflating them is what sends a caller to audit a quota code when the service name was wrong.
- **A missing required member** is now `IllegalArgumentException`, also from the model's error list, rather than a not-found for a resource the request never named.

## Verification

- `gofmt`, `go build`, `go vet`, `golangci-lint run ./...` — 0 issues
- `make test` (race detector) green; `make coverage` at 81.5% total, 82.2% for `emulator`. Every function touched here is at **100%** statement coverage.
- `make docs-reference docs-reference-check docs-versions`; `npm --prefix docs run build`
- `go vet -C test/e2e ./...` and `go test -C test/e2e ./...` green, including the new `TestJourney_ServiceQuotasOrganizations` — the level that catches an unrouted operation, since the SDK's SigV4 name (`servicequotasv20190624`) and target prefix are neither of them the plugin name.
- Live against `substrate server --address :4678` with `AWS_MAX_ATTEMPTS=1`, running #620's repro verbatim: `get-service-quota organizations L-E619E033` reads 10 / adjustable, `list-service-quotas` returns all three, `list-services` names it once, both unknown-service refusals arrive with distinguishable messages, and a pending increase leaves the quota reading 10.
- **Mutation testing**, five mutants aimed at this change: the `defaultServiceList` entry removed (caught by 2 tests), the unknown-service check reverted to the empty list, the two refusals conflated, the accounts value drifted off the enforced limit (caught by 3 tests), and the required-member check dropped (caught by 2). **All caught, no survivors.** Three more against #619's merged code — re-minting the resource-policy ID on replacement, the 40,000-character bound off by one, and delete made a silent no-op — were also all caught.

## Out of scope

The hardcoded `accountID := "000000000000"` in `requestServiceQuotaIncrease` and friends, filed as #624: `HandleRequest` discards the `RequestContext`, so increases are recorded under a placeholder account rather than the caller's. A real defect, but a separate concern from #620.

Closes #620