### PR TITLE
chore(release): v0.98.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.98.0] - 2026-08-14
+
 ### Added
 - **The organization's resource policy is now readable, writable and deletable**
   (#619). `PutResourcePolicy`, `DescribeResourcePolicy` and `DeleteResourcePolicy`
@@ -6035,7 +6037,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.97.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.98.0...HEAD
+[v0.98.0]: https://github.com/scttfrdmn/substrate/compare/v0.97.0...v0.98.0
 [v0.97.0]: https://github.com/scttfrdmn/substrate/compare/v0.96.0...v0.97.0
 [v0.96.0]: https://github.com/scttfrdmn/substrate/compare/v0.95.0...v0.96.0
 [v0.95.0]: https://github.com/scttfrdmn/substrate/compare/v0.94.0...v0.95.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.98.0] - 2026-08-14` and adds the comparison link. No code changes.

v0.98.0 is themed on **consumer observability**: both features in it were found by driving a real read-only Organizations tool against `substrate server` at v0.97.0, not by reading the API model.

- **#619** — the organization resource policy (`PutResourcePolicy`, `DescribeResourcePolicy`, `DeleteResourcePolicy`), which fell through to `InvalidAction`. Merged in #626.
- **#620** — the `organizations` Service Quotas entries, so `L-E619E033` reads the ceiling `CreateAccount` enforces, plus the two refusals that made the gap read as a bad quota code. Merged in #627.

The release notes will carry a `## Provenance` section for the two quota codes AWS does not publish, and a `## Compatibility` note for `list-service-quotas`'s behaviour change on an unrecognised service.