### PR TITLE
fix(organizations): a member account sees the organization it belongs to (#623, #619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A test server can now be called as more than one account**
+  (`StartTestServerWithAccounts`, `TestServer.RegisterAccount`,
+  `TestServer.CredentialsFor`) (#623). No in-repo test could authenticate as a
+  second account before this: `StartTestServer` wires no `CredentialRegistry`, and
+  `extractAccount` maps every `AKIA…` key to `123456789012`. That is why #623
+  survived every Organizations test — all of them are one caller by construction.
+
+  It is a **separate entry point** rather than an option on `StartTestServer`,
+  because wiring a registry also switches SigV4 verification on: the server
+  verifies signatures exactly when `ServerOptions.Credentials` is non-nil, and a key
+  the registry does not hold is `InvalidClientTokenId` 403. Turning that on
+  repository-wide inside a feature change is not a trade worth making, so the strict
+  contract is opt-in. Decoupling the two is #630. Each account's access key and
+  secret are **derived from the account ID** rather than generated, so a recorded run
+  replays with the same credentials in it.
+
+### Fixed
+- **A member account now sees the organization it belongs to** (#623). All
+  Organizations state is keyed by the caller's account, and `ensureOrganization`
+  auto-created an entire organization — root, management account, `FullAWSAccess` —
+  for any account it had not seen. So a member account calling *any* Organizations
+  operation was silently handed a private organization of its own: a different `o-`
+  ID, a different `r-` root, and a member list holding only itself. A consumer
+  walking the hierarchy from a member credential saw an organization management had
+  never created, and nothing in the response said so.
+
+  `saveAccount` now writes a member→management reverse index, and the caller's
+  organization is resolved **once at dispatch** rather than per read. Resolving per
+  read would let two reads in one request disagree about which organization they
+  concern — a member's `ListRoots` would hard-error on a root that resolution had
+  not reached — and would leave every future handler having to remember to do it.
+  Both directions of the index are written in the one function every create-or-join
+  path already goes through, so an index written by one operation and not another is
+  not a reachable state.
+
+  An account the index does not name still auto-creates its own organization. That
+  is not a fallback: it is what keeps a fresh emulator usable with no
+  `CreateOrganization` call, and the distinction the index preserves is "a member of
+  that organization" versus "a member of nothing" — not "known" versus "unknown".
+- **`DescribeResourcePolicy` now answers a member account, and the writes refuse
+  one** (#619). The two bullets v0.98.0 left open. The AWS reference is specific
+  that this asymmetry is real: `DescribeResourcePolicy` is callable "from the
+  management account or a member account that is a delegated administrator", while
+  `Put`/`DeleteResourcePolicy` are callable "only from the management account" —
+  whereas `DescribeOrganization` is callable "from any account in a organization", so
+  the two reads must not be made uniform.
+
+  Three answers, all distinguishable, which is the whole point of #619 — a tool has
+  to tell "nothing was delegated to me" from "something was, and I cannot read it":
+  - management: the policy, or `ResourcePolicyNotFoundException` (400)
+  - a member the policy names: the **identical** `Content`, `Id` and `Arn`
+  - a member it does not name: `AccessDeniedException` (**403**)
+
+  Delegation is decided by the `Principal`, not the `Action`. Every delegation policy
+  AWS documents names the member as `arn:aws:iam::<account>:root`, and
+  `organizations:DescribeResourcePolicy` appears in **none** of their `Action` lists —
+  the delegated actions are the policy-management ones a delegated administrator goes
+  on to call. Requiring an `Allow` for the read itself would deny every member AWS's
+  own examples intend to admit, and a guessed denial fails a request AWS accepts.
+
+  A member is refused **before** the absence is reported, so it cannot use the
+  operation to learn whether the organization has a policy at all. And the refusal is
+  403 rather than the 400 every other Organizations error carries:
+  `AccessDeniedException` is a *common* error the service model does not declare, and
+  the API Reference's Common Errors page gives it 403 — which is what an SDK's retry
+  classifier reads.
+
+  One correction to the issue's own framing: none of the three operations takes an
+  input naming an organization, so "a caller outside the organization" is **not
+  reachable** through this API — there is nowhere to put another organization's ID. The
+  reachable third case is a member the policy does not name, which is what is
+  modelled.
+
 ## [v0.98.0] - 2026-08-14
 
 ### Added

--- a/emulator/organizations_account.go
+++ b/emulator/organizations_account.go
@@ -73,7 +73,7 @@ func (p *OrganizationsPlugin) accountOperation(op string) (orgHandler, bool) {
 // consumer with no poll loop pass its tests, and the poll loop is the part that
 // has to survive being interrupted: the request ID is the only handle a resumed
 // run has on an account that may or may not exist yet.
-func (p *OrganizationsPlugin) createAccount(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) createAccount(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		AccountName string        `json:"AccountName"`
@@ -219,7 +219,7 @@ func (p *OrganizationsPlugin) pendingCreateOutcome(ctx context.Context, accountN
 
 // describeCreateAccountStatus reports the current state of a vending request,
 // resolving it on first observation.
-func (p *OrganizationsPlugin) describeCreateAccountStatus(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) describeCreateAccountStatus(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
 		return nil, fmt.Errorf("describeCreateAccountStatus ensure org: %w", err)
@@ -253,7 +253,7 @@ func (p *OrganizationsPlugin) describeCreateAccountStatus(reqCtx *RequestContext
 }
 
 // listCreateAccountStatus lists vending requests, optionally filtered by state.
-func (p *OrganizationsPlugin) listCreateAccountStatus(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listCreateAccountStatus(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
 		return nil, fmt.Errorf("listCreateAccountStatus ensure org: %w", err)
@@ -367,7 +367,7 @@ func (p *OrganizationsPlugin) resolveCreateAccountStatus(ctx context.Context, ac
 // in MoveAccount's declared errors list, and each one distinguishes a case a
 // re-run of a governance script hits: nothing here is idempotent, which is the
 // property such a script has to be built on.
-func (p *OrganizationsPlugin) moveAccount(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) moveAccount(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		AccountID           string `json:"AccountId"`

--- a/emulator/organizations_export_test.go
+++ b/emulator/organizations_export_test.go
@@ -70,6 +70,13 @@ func (p *OrganizationsPlugin) EnsureOrganizationForTest(ctx context.Context, acc
 	return p.ensureOrganization(ctx, acct)
 }
 
+// OrganizationOwnerForTest wraps organizationOwner for external tests, so the
+// reverse index #623 added can be asserted directly rather than only through the
+// organization a handler happens to answer with.
+func (p *OrganizationsPlugin) OrganizationOwnerForTest(ctx context.Context, acct string) (string, error) {
+	return p.organizationOwner(ctx, acct)
+}
+
 // LoadRootForTest wraps loadRoot for external tests.
 func (p *OrganizationsPlugin) LoadRootForTest(ctx context.Context, acct string) (*OrgRoot, error) {
 	return p.loadRoot(ctx, acct)

--- a/emulator/organizations_member_test.go
+++ b/emulator/organizations_member_test.go
@@ -1,0 +1,497 @@
+package emulator_test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// This file covers #623 and the remainder of #619: an Organizations caller that
+// is a *member* of an organization rather than its management account.
+//
+// It is the only Organizations test file that signs its requests. The rest drive
+// a bare plugin through a hand-built X-Amz-Target header and are all account
+// 123456789012 by construction, so nothing in them can observe a second caller —
+// which is why #623 survived every one of them. Reaching a member identity means
+// a credential registry, and a registry is also what switches SigV4 verification
+// on, so every request here carries a real signature.
+
+// orgManagementAccount is the account the built-in test credential belongs to,
+// and therefore the management account of the organization these tests build.
+const orgManagementAccount = "123456789012"
+
+// orgOutsiderAccount is an account that joins no organization. It is used for the
+// auto-create regression guard: #623's fix must not turn an unknown caller's
+// first request into a refusal, because a fresh emulator with no
+// CreateOrganization call is substrate's documented starting point.
+const orgOutsiderAccount = "222233334444"
+
+// --- helpers --------------------------------------------------------------
+
+// orgTestNow is a fixed instant for the storage-layer test's clock. A literal
+// rather than time.Now, so nothing here can depend on when it runs.
+func orgTestNow() time.Time {
+	return time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+}
+
+// orgSignedRequest posts an Organizations operation signed as the given account.
+//
+// The account must have been registered with the server, either by
+// StartTestServerWithAccounts or by RegisterAccount; an unregistered key is
+// InvalidClientTokenId 403 before any plugin sees it.
+func orgSignedRequest(t *testing.T, ts *emulator.TestServer, account, op string, body any) *http.Response {
+	t.Helper()
+
+	creds, ok := ts.CredentialsFor(account)
+	if !ok {
+		t.Fatalf("no credential registered for account %s", account)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", op, err)
+	}
+
+	const dateTime = "20260101T120000Z"
+	host := "organizations.us-east-1.amazonaws.com"
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("build %s request: %v", op, err)
+	}
+	req.Host = host
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "Organizations_20161128."+op)
+	req.Header.Set("X-Amz-Date", dateTime)
+	req.Header.Set("Authorization", orgSigV4Header(
+		host, dateTime, data, creds.AccessKeyID, creds.SecretAccessKey))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("orgs request %s as %s: %v", op, account, err)
+	}
+	return resp
+}
+
+// orgSigV4Header computes a valid SigV4 Authorization header for a POST to "/"
+// with the host and x-amz-date headers signed.
+//
+// This duplicates the algorithm rather than calling into the emulator, so a
+// mistake in the emulator's own signing cannot make these tests pass by agreeing
+// with it.
+func orgSigV4Header(host, dateTime string, body []byte, accessKey, secretKey string) string {
+	const (
+		region        = "us-east-1"
+		service       = "organizations"
+		signedHeaders = "host;x-amz-date"
+	)
+	date := dateTime[:8]
+
+	bodyHash := sha256.Sum256(body)
+	canonicalReq := strings.Join([]string{
+		http.MethodPost,
+		"/",
+		"",
+		"host:" + host + "\n" + "x-amz-date:" + dateTime + "\n",
+		signedHeaders,
+		hex.EncodeToString(bodyHash[:]),
+	}, "\n")
+
+	canonicalHash := sha256.Sum256([]byte(canonicalReq))
+	credScope := date + "/" + region + "/" + service + "/aws4_request"
+	stringToSign := "AWS4-HMAC-SHA256\n" + dateTime + "\n" + credScope + "\n" +
+		hex.EncodeToString(canonicalHash[:])
+
+	mac := func(key, data []byte) []byte {
+		h := hmac.New(sha256.New, key)
+		h.Write(data)
+		return h.Sum(nil)
+	}
+	signing := mac(mac(mac(mac([]byte("AWS4"+secretKey), []byte(date)), []byte(region)),
+		[]byte(service)), []byte("aws4_request"))
+
+	return fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		accessKey, credScope, signedHeaders, hex.EncodeToString(mac(signing, []byte(stringToSign))))
+}
+
+// orgDecode decodes an Organizations response into out, returning the status and
+// the error code a refusal carries.
+func orgDecode(t *testing.T, resp *http.Response, out any) (int, string) {
+	t.Helper()
+	defer resp.Body.Close() //nolint:errcheck
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var errShape struct {
+		Type    string `json:"__type"`
+		Message string `json:"message"`
+	}
+	if unmarshalErr := json.Unmarshal(raw, &errShape); unmarshalErr == nil && errShape.Type != "" {
+		return resp.StatusCode, errShape.Type
+	}
+	if out != nil {
+		if unmarshalErr := json.Unmarshal(raw, out); unmarshalErr != nil {
+			t.Fatalf("decode %s: %v", raw, unmarshalErr)
+		}
+	}
+	return resp.StatusCode, ""
+}
+
+// orgVendMember creates an account through CreateAccount, polls the request to
+// SUCCEEDED, registers a signing credential for the vended account, and returns
+// its ID.
+//
+// The poll is what makes the account ID available at all: CreateAccount answers
+// IN_PROGRESS with no AccountId, so a test that skipped the poll would have
+// nothing to sign as.
+func orgVendMember(t *testing.T, ts *emulator.TestServer, name, email string) string {
+	t.Helper()
+
+	var created struct {
+		CreateAccountStatus emulator.OrgCreateAccountStatus `json:"CreateAccountStatus"`
+	}
+	status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount, "CreateAccount",
+		map[string]any{"AccountName": name, "Email": email}), &created)
+	if status != http.StatusOK {
+		t.Fatalf("CreateAccount: %d %s", status, code)
+	}
+	requestID := created.CreateAccountStatus.ID
+
+	var describe struct {
+		CreateAccountStatus emulator.OrgCreateAccountStatus `json:"CreateAccountStatus"`
+	}
+	status, code = orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount, "DescribeCreateAccountStatus",
+		map[string]any{"CreateAccountRequestId": requestID}), &describe)
+	if status != http.StatusOK {
+		t.Fatalf("DescribeCreateAccountStatus: %d %s", status, code)
+	}
+	if describe.CreateAccountStatus.State != "SUCCEEDED" {
+		t.Fatalf("CreateAccount resolved to %q, want SUCCEEDED", describe.CreateAccountStatus.State)
+	}
+	member := describe.CreateAccountStatus.AccountID
+	if member == "" {
+		t.Fatal("a SUCCEEDED CreateAccount reported no AccountId, so nothing can sign as the member")
+	}
+
+	ts.RegisterAccount(t, member)
+	return member
+}
+
+// --- #623: a member sees the organization it belongs to -------------------
+
+// TestOrganizations_MemberSeesManagementsOrganization is #623's repro.
+//
+// Before the reverse index, every Organizations record was keyed by the account
+// that signed the request and ensureOrganization auto-created a whole
+// organization — root, management account, FullAWSAccess — for any account it had
+// not seen. So a member account calling DescribeOrganization was handed a private
+// organization of its own, with a different o- ID and a different root, and a
+// consumer walking the hierarchy from a member credential saw an organization of
+// exactly one account that management had never created.
+func TestOrganizations_MemberSeesManagementsOrganization(t *testing.T) {
+	ts := emulator.StartTestServerWithAccounts(t)
+
+	var mgmt struct {
+		Organization emulator.Organization `json:"Organization"`
+	}
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+		"DescribeOrganization", map[string]any{}), &mgmt); status != http.StatusOK {
+		t.Fatalf("DescribeOrganization as management: %d %s", status, code)
+	}
+
+	member := orgVendMember(t, ts, "member", "member@example.com")
+
+	var got struct {
+		Organization emulator.Organization `json:"Organization"`
+	}
+	status, code := orgDecode(t, orgSignedRequest(t, ts, member,
+		"DescribeOrganization", map[string]any{}), &got)
+	if status != http.StatusOK {
+		t.Fatalf("DescribeOrganization as the member: %d %s", status, code)
+	}
+	if got.Organization.ID != mgmt.Organization.ID {
+		t.Errorf("the member sees organization %s, management sees %s — the member was given one of its own",
+			got.Organization.ID, mgmt.Organization.ID)
+	}
+	// MasterAccountId is the field a consumer reads to find out who manages it, so
+	// a member that saw itself there would conclude it was the management account.
+	if got.Organization.MasterAccountID != orgManagementAccount {
+		t.Errorf("the member reads MasterAccountId %q, want %s",
+			got.Organization.MasterAccountID, orgManagementAccount)
+	}
+
+	// The root has to agree too. ListRoots is where a hierarchy walk starts, and
+	// the pre-#623 behavior gave the member a second r- ID with nothing under it.
+	var mgmtRoots, memberRoots struct {
+		Roots []emulator.OrgRoot `json:"Roots"`
+	}
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+		"ListRoots", map[string]any{}), &mgmtRoots); status != http.StatusOK {
+		t.Fatalf("ListRoots as management: %d %s", status, code)
+	}
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, member,
+		"ListRoots", map[string]any{}), &memberRoots); status != http.StatusOK {
+		t.Fatalf("ListRoots as the member: %d %s", status, code)
+	}
+	if len(mgmtRoots.Roots) != 1 || len(memberRoots.Roots) != 1 {
+		t.Fatalf("ListRoots returned %d/%d roots, want 1 each",
+			len(mgmtRoots.Roots), len(memberRoots.Roots))
+	}
+	if memberRoots.Roots[0].ID != mgmtRoots.Roots[0].ID {
+		t.Errorf("the member's root is %s, management's is %s",
+			memberRoots.Roots[0].ID, mgmtRoots.Roots[0].ID)
+	}
+
+	// ListAccounts from the member reports the organization's accounts, which is
+	// the observation that proves the member is reading management's member list
+	// rather than a fresh one holding only itself.
+	var listed struct {
+		Accounts []emulator.OrgAccount `json:"Accounts"`
+	}
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, member,
+		"ListAccounts", map[string]any{}), &listed); status != http.StatusOK {
+		t.Fatalf("ListAccounts as the member: %d %s", status, code)
+	}
+	ids := make(map[string]bool, len(listed.Accounts))
+	for _, a := range listed.Accounts {
+		ids[a.ID] = true
+	}
+	if !ids[orgManagementAccount] || !ids[member] {
+		t.Errorf("ListAccounts as the member returned %v, want both %s and %s",
+			ids, orgManagementAccount, member)
+	}
+}
+
+// TestOrganizations_UnknownAccountStillAutoCreates is the regression guard on the
+// no-setup path.
+//
+// #623's fix consults a reverse index before auto-creating, and an account the
+// index does not name must still get an organization rather than a refusal: a
+// fresh emulator has no CreateOrganization call in it, and every existing
+// Organizations fixture depends on the first observation creating one. The
+// distinction the index has to preserve is "not a member of anything" versus "a
+// member of that organization", not "known" versus "unknown".
+func TestOrganizations_UnknownAccountStillAutoCreates(t *testing.T) {
+	ts := emulator.StartTestServerWithAccounts(t, orgOutsiderAccount)
+
+	var mgmt, outsider struct {
+		Organization emulator.Organization `json:"Organization"`
+	}
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+		"DescribeOrganization", map[string]any{}), &mgmt); status != http.StatusOK {
+		t.Fatalf("DescribeOrganization as management: %d %s", status, code)
+	}
+	status, code := orgDecode(t, orgSignedRequest(t, ts, orgOutsiderAccount,
+		"DescribeOrganization", map[string]any{}), &outsider)
+	if status != http.StatusOK {
+		t.Fatalf("DescribeOrganization as an account in no organization: %d %s — the auto-create path must still work",
+			status, code)
+	}
+	if outsider.Organization.ID == mgmt.Organization.ID {
+		t.Error("an account in no organization was placed in management's; only a recorded member resolves there")
+	}
+	if outsider.Organization.MasterAccountID != orgOutsiderAccount {
+		t.Errorf("the outsider's organization reports MasterAccountId %q, want itself (%s)",
+			outsider.Organization.MasterAccountID, orgOutsiderAccount)
+	}
+}
+
+// TestOrganizations_MemberOwnerIndexIsWrittenBySaveAccount pins the index at the
+// storage layer, below the HTTP surface.
+//
+// saveAccount is the single write point — every path that creates or joins an
+// account goes through it — so this asserts the property the handlers rely on
+// rather than one handler's answer: the management account indexes to itself, a
+// member indexes to management, and an account substrate has never seen indexes
+// to "". That third case is not a default; it is what tells the auto-create path
+// apart from a resolution, and collapsing it would make a member of a deleted
+// organization look like a management account.
+func TestOrganizations_MemberOwnerIndexIsWrittenBySaveAccount(t *testing.T) {
+	state := emulator.NewMemoryStateManager()
+	p := emulator.NewOrganizationsPluginForTest(state, emulator.NewTimeController(orgTestNow()))
+	ctx := t.Context()
+
+	if _, err := p.EnsureOrganizationForTest(ctx, orgManagementAccount); err != nil {
+		t.Fatalf("ensure organization: %v", err)
+	}
+	owner, err := p.OrganizationOwnerForTest(ctx, orgManagementAccount)
+	if err != nil {
+		t.Fatalf("organizationOwner(management): %v", err)
+	}
+	if owner != orgManagementAccount {
+		t.Errorf("the management account indexes to %q, want itself — one lookup must answer for every account substrate knows", owner)
+	}
+
+	const member = "555566667777"
+	if err := p.SaveAccountForTest(ctx, orgManagementAccount, emulator.OrgAccount{
+		ID: member, Name: "member", Email: "member@example.com", Status: "ACTIVE",
+	}); err != nil {
+		t.Fatalf("save member account: %v", err)
+	}
+	owner, err = p.OrganizationOwnerForTest(ctx, member)
+	if err != nil {
+		t.Fatalf("organizationOwner(member): %v", err)
+	}
+	if owner != orgManagementAccount {
+		t.Errorf("the member indexes to %q, want %s", owner, orgManagementAccount)
+	}
+
+	owner, err = p.OrganizationOwnerForTest(ctx, orgOutsiderAccount)
+	if err != nil {
+		t.Fatalf("organizationOwner(unknown): %v", err)
+	}
+	if owner != "" {
+		t.Errorf("an account substrate has never seen indexes to %q, want \"\"", owner)
+	}
+
+	// ensureOrganization resolves through the index, so the member gets
+	// management's organization rather than one of its own.
+	mgmtOrg, err := p.EnsureOrganizationForTest(ctx, orgManagementAccount)
+	if err != nil {
+		t.Fatalf("ensure organization (management): %v", err)
+	}
+	memberOrg, err := p.EnsureOrganizationForTest(ctx, member)
+	if err != nil {
+		t.Fatalf("ensure organization (member): %v", err)
+	}
+	if memberOrg.ID != mgmtOrg.ID {
+		t.Errorf("ensureOrganization gave the member %s, management has %s", memberOrg.ID, mgmtOrg.ID)
+	}
+}
+
+// --- #619: the resource-policy asymmetry ---------------------------------
+
+// orgDelegationPolicy is a resource policy that names one account as a delegated
+// administrator, in the form every delegation example in the Organizations User
+// Guide uses: the member appears as "arn:aws:iam::<account>:root" in Principal.
+func orgDelegationPolicy(account string) string {
+	return `{"Version":"2012-10-17","Statement":[{"Sid":"Delegate","Effect":"Allow",` +
+		`"Principal":{"AWS":"arn:aws:iam::` + account + `:root"},` +
+		`"Action":["organizations:DescribeOrganization","organizations:ListAccounts"],` +
+		`"Resource":"*"}]}`
+}
+
+// TestOrganizations_ResourcePolicy_MemberAsymmetry is the remainder of #619: the
+// three answers DescribeResourcePolicy gives, and the fact that they are
+// distinguishable.
+//
+// A tool checking whether management delegated anything to it must be able to
+// tell "nothing is delegated" from "something is, and I cannot read it". Those
+// are ResourcePolicyNotFoundException and AccessDeniedException respectively, and
+// they differ in HTTP status too — 400 against 403 — because AccessDeniedException
+// is a common error rather than one the Organizations model declares.
+func TestOrganizations_ResourcePolicy_MemberAsymmetry(t *testing.T) {
+	ts := emulator.StartTestServerWithAccounts(t)
+
+	delegated := orgVendMember(t, ts, "delegated", "delegated@example.com")
+	plain := orgVendMember(t, ts, "plain", "plain@example.com")
+
+	// Before any policy exists, management gets the absence — the ordinary answer,
+	// since most organizations have no resource policy.
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+		"DescribeResourcePolicy", map[string]any{}), nil); status != http.StatusBadRequest ||
+		code != "ResourcePolicyNotFoundException" {
+		t.Fatalf("DescribeResourcePolicy with no policy set: %d %q, want 400/ResourcePolicyNotFoundException", status, code)
+	}
+
+	// A member gets denied rather than the absence, so it cannot use this
+	// operation to learn whether the organization has a policy at all.
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, plain,
+		"DescribeResourcePolicy", map[string]any{}), nil); status != http.StatusForbidden ||
+		code != "AccessDeniedException" {
+		t.Fatalf("DescribeResourcePolicy as a member with no policy set: %d %q, want 403/AccessDeniedException", status, code)
+	}
+
+	var put struct {
+		ResourcePolicy emulator.OrgResourcePolicy `json:"ResourcePolicy"`
+	}
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+		"PutResourcePolicy", map[string]any{"Content": orgDelegationPolicy(delegated)}),
+		&put); status != http.StatusOK {
+		t.Fatalf("PutResourcePolicy as management: %d %s", status, code)
+	}
+
+	// The delegated member reads exactly what management wrote. Identical Content,
+	// Id and Arn is the point: a delegated administrator that saw a different ARN
+	// would conclude it was looking at a different policy.
+	var got struct {
+		ResourcePolicy emulator.OrgResourcePolicy `json:"ResourcePolicy"`
+	}
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, delegated,
+		"DescribeResourcePolicy", map[string]any{}), &got); status != http.StatusOK {
+		t.Fatalf("DescribeResourcePolicy as the delegated member: %d %s", status, code)
+	}
+	if got.ResourcePolicy != put.ResourcePolicy {
+		t.Errorf("the delegated member reads %+v, management wrote %+v",
+			got.ResourcePolicy, put.ResourcePolicy)
+	}
+
+	// A member the policy does not name is still denied, with the policy now in
+	// place. This is the case the API can actually reach: none of the three
+	// operations takes an input naming an organization, so a caller can only ever
+	// ask about its own and "an account in no relationship to this organization"
+	// has no way to pose the question.
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, plain,
+		"DescribeResourcePolicy", map[string]any{}), nil); status != http.StatusForbidden ||
+		code != "AccessDeniedException" {
+		t.Fatalf("DescribeResourcePolicy as an undelegated member: %d %q, want 403/AccessDeniedException", status, code)
+	}
+
+	// Management still reads it, which is what makes the member's denial an
+	// asymmetry rather than the policy having gone missing.
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+		"DescribeResourcePolicy", map[string]any{}), &got); status != http.StatusOK {
+		t.Fatalf("DescribeResourcePolicy as management after the put: %d %s", status, code)
+	}
+	if got.ResourcePolicy != put.ResourcePolicy {
+		t.Errorf("management reads back %+v, want %+v", got.ResourcePolicy, put.ResourcePolicy)
+	}
+}
+
+// TestOrganizations_ResourcePolicy_WritesAreManagementOnly covers the other half
+// of the asymmetry: the writes admit no member, delegated or not.
+//
+// The AWS reference is explicit that PutResourcePolicy and DeleteResourcePolicy
+// "can be called only from the organization's management account", while
+// DescribeResourcePolicy also admits a delegated administrator. Letting a
+// delegated member write would let it widen its own delegation, which is why the
+// guard here does not consult the policy document at all.
+func TestOrganizations_ResourcePolicy_WritesAreManagementOnly(t *testing.T) {
+	ts := emulator.StartTestServerWithAccounts(t)
+
+	delegated := orgVendMember(t, ts, "delegated", "delegated@example.com")
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+		"PutResourcePolicy", map[string]any{"Content": orgDelegationPolicy(delegated)}),
+		nil); status != http.StatusOK {
+		t.Fatalf("PutResourcePolicy as management: %d %s", status, code)
+	}
+
+	for _, op := range []string{"PutResourcePolicy", "DeleteResourcePolicy"} {
+		body := map[string]any{}
+		if op == "PutResourcePolicy" {
+			body["Content"] = orgDelegationPolicy(delegated)
+		}
+		status, code := orgDecode(t, orgSignedRequest(t, ts, delegated, op, body), nil)
+		if status != http.StatusForbidden || code != "AccessDeniedException" {
+			t.Errorf("%s as a delegated member: %d %q, want 403/AccessDeniedException", op, status, code)
+		}
+	}
+
+	// And management's own delete still works, so the refusals above are about the
+	// caller rather than the operation being broken.
+	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+		"DeleteResourcePolicy", map[string]any{}), nil); status != http.StatusOK {
+		t.Fatalf("DeleteResourcePolicy as management: %d %s", status, code)
+	}
+}

--- a/emulator/organizations_ou.go
+++ b/emulator/organizations_ou.go
@@ -47,7 +47,7 @@ const orgMaxOUNameChars = 128
 // parent that is not there, DuplicateOrganizationalUnit for a name already used
 // among the parent's children, ConstraintViolation for the depth and count
 // quotas, and InvalidInput for a malformed request.
-func (p *OrganizationsPlugin) createOrganizationalUnit(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) createOrganizationalUnit(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		ParentID string        `json:"ParentId"`
@@ -145,7 +145,7 @@ func (p *OrganizationsPlugin) createOrganizationalUnit(reqCtx *RequestContext, r
 	return orgJSONResponse(map[string]interface{}{"OrganizationalUnit": ou}, "createOrganizationalUnit")
 }
 
-func (p *OrganizationsPlugin) describeOrganizationalUnit(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) describeOrganizationalUnit(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		OrganizationalUnitID string `json:"OrganizationalUnitId"`
@@ -163,7 +163,7 @@ func (p *OrganizationsPlugin) describeOrganizationalUnit(reqCtx *RequestContext,
 // updateOrganizationalUnit implements UpdateOrganizationalUnit, which renames an
 // OU in place: the ID, the ARN, the children, and the attached policies all
 // survive it, so a caller holding any of those keeps a valid handle.
-func (p *OrganizationsPlugin) updateOrganizationalUnit(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) updateOrganizationalUnit(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	// Name is optional in the model, and an omitted name is not the same request as
 	// an empty one: the first leaves the OU alone, the second asks for a name the
@@ -218,7 +218,7 @@ func (p *OrganizationsPlugin) updateOrganizationalUnit(reqCtx *RequestContext, r
 // OU be emptied first, and the refusal is what makes a teardown script's ordering
 // bug visible: deleting an OU that still holds accounts would otherwise orphan
 // them somewhere no listing reaches.
-func (p *OrganizationsPlugin) deleteOrganizationalUnit(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) deleteOrganizationalUnit(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		OrganizationalUnitID string `json:"OrganizationalUnitId"`
@@ -251,7 +251,7 @@ func (p *OrganizationsPlugin) deleteOrganizationalUnit(reqCtx *RequestContext, r
 	return orgEmptyResponse(), nil
 }
 
-func (p *OrganizationsPlugin) listOrganizationalUnitsForParent(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listOrganizationalUnitsForParent(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		ParentID   string `json:"ParentId"`
@@ -303,7 +303,7 @@ func (p *OrganizationsPlugin) listOrganizationalUnitsForParent(reqCtx *RequestCo
 // listParents implements ListParents. A child has exactly one parent in the
 // current API, so the list has one entry — but it is still a list, and it is the
 // step a caller walks upward with until it reaches the root ListRoots reports.
-func (p *OrganizationsPlugin) listParents(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listParents(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		ChildID    string `json:"ChildId"`
@@ -365,7 +365,7 @@ func (p *OrganizationsPlugin) listParents(reqCtx *RequestContext, req *AWSReques
 // listChildren implements ListChildren. ChildType is required by the model, so
 // the operation never mixes accounts and OUs in one answer — a caller walking the
 // tree downward asks twice.
-func (p *OrganizationsPlugin) listChildren(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listChildren(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		ParentID   string `json:"ParentId"`
@@ -413,7 +413,7 @@ func (p *OrganizationsPlugin) listChildren(reqCtx *RequestContext, req *AWSReque
 	return orgJSONResponse(out, "listChildren")
 }
 
-func (p *OrganizationsPlugin) listAccountsForParent(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listAccountsForParent(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		ParentID   string `json:"ParentId"`

--- a/emulator/organizations_plugin.go
+++ b/emulator/organizations_plugin.go
@@ -31,8 +31,34 @@ type OrganizationsPlugin struct {
 	tc     *TimeController
 }
 
+// orgCaller is the request context an Organizations handler runs against: the
+// caller's own account, and the organization that account belongs to.
+//
+// The embedded *RequestContext is a copy whose AccountID has been resolved to the
+// **management account** of the caller's organization, because that is the key
+// every Organizations record is stored under — the organization, its root, its
+// member list, its policies, its resource policy. A handler that keyed state by
+// the account that signed the request would answer a member account with a
+// private organization of its own, which is #623.
+//
+// For a management account, or for an account substrate has never seen, the
+// resolved account and the signing account are the same, so nothing changes for a
+// single-caller test. Only callerAccount tells them apart, and only the handlers
+// that model a management-versus-member asymmetry read it.
+type orgCaller struct {
+	*RequestContext
+
+	// callerAccount is the account that signed the request, which is not
+	// necessarily the one AccountID now names.
+	callerAccount string
+}
+
+// isMember reports whether the caller is a member of the organization rather than
+// its management account.
+func (c *orgCaller) isMember() bool { return c.callerAccount != c.AccountID }
+
 // orgHandler handles one Organizations operation.
-type orgHandler func(*RequestContext, *AWSRequest) (*AWSResponse, error)
+type orgHandler func(*orgCaller, *AWSRequest) (*AWSResponse, error)
 
 // Name returns the service name "organizations".
 func (p *OrganizationsPlugin) Name() string { return organizationsNamespace }
@@ -57,6 +83,10 @@ func (p *OrganizationsPlugin) Shutdown(_ context.Context) error { return nil }
 // (organizations_ou.go, organizations_policy.go, and so on) and each owns its own
 // claim function, so adding an operation touches one file rather than a shared
 // switch.
+//
+// The caller's organization is resolved once, here, rather than in each handler:
+// resolving per read would let two reads in one request disagree about which
+// organization they are about, and every handler would have to remember to do it.
 func (p *OrganizationsPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	for _, claim := range []func(string) (orgHandler, bool){
 		p.coreOperation,
@@ -67,10 +97,32 @@ func (p *OrganizationsPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest
 		p.resourcePolicyOperation,
 	} {
 		if h, ok := claim(req.Operation); ok {
-			return h(ctx, req)
+			caller, err := p.resolveOrgCaller(context.Background(), ctx)
+			if err != nil {
+				return nil, fmt.Errorf("organizations resolve caller: %w", err)
+			}
+			return h(caller, req)
 		}
 	}
 	return nil, orgInvalidAction(req.Operation)
+}
+
+// resolveOrgCaller builds the orgCaller for a request, resolving the signing
+// account to the management account of the organization it belongs to.
+//
+// An account the reverse index does not know resolves to itself, which is what
+// keeps the no-setup auto-create working: the first caller of a fresh emulator is
+// in no organization yet, and it must still get one rather than a refusal.
+func (p *OrganizationsPlugin) resolveOrgCaller(ctx context.Context, reqCtx *RequestContext) (*orgCaller, error) {
+	owner, err := p.organizationOwner(ctx, reqCtx.AccountID)
+	if err != nil {
+		return nil, err
+	}
+	resolved := *reqCtx
+	if owner != "" {
+		resolved.AccountID = owner
+	}
+	return &orgCaller{RequestContext: &resolved, callerAccount: reqCtx.AccountID}, nil
 }
 
 // coreOperation claims the organization- and root-level reads.
@@ -91,7 +143,7 @@ func (p *OrganizationsPlugin) coreOperation(op string) (orgHandler, bool) {
 
 // --- operations ---
 
-func (p *OrganizationsPlugin) describeOrganization(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) describeOrganization(reqCtx *orgCaller, _ *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	org, err := p.ensureOrganization(goCtx, reqCtx.AccountID)
 	if err != nil {
@@ -110,7 +162,7 @@ func (p *OrganizationsPlugin) describeOrganization(reqCtx *RequestContext, _ *AW
 	return orgJSONResponse(map[string]interface{}{"Organization": org}, "describeOrganization")
 }
 
-func (p *OrganizationsPlugin) listAccounts(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listAccounts(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	// Ensure org exists so the management account is always present.
 	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
@@ -153,7 +205,7 @@ func (p *OrganizationsPlugin) listAccounts(reqCtx *RequestContext, req *AWSReque
 	return orgJSONResponse(out, "listAccounts")
 }
 
-func (p *OrganizationsPlugin) describeAccount(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) describeAccount(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
 		return nil, fmt.Errorf("describeAccount ensure org: %w", err)
@@ -177,7 +229,7 @@ func (p *OrganizationsPlugin) describeAccount(reqCtx *RequestContext, req *AWSRe
 	return orgJSONResponse(map[string]interface{}{"Account": a}, "describeAccount")
 }
 
-func (p *OrganizationsPlugin) listRoots(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listRoots(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		NextToken  string `json:"NextToken"`

--- a/emulator/organizations_policy.go
+++ b/emulator/organizations_policy.go
@@ -118,7 +118,7 @@ func (p *OrganizationsPlugin) loadVisiblePolicy(ctx context.Context, acct, polic
 
 // --- CreatePolicy ---
 
-func (p *OrganizationsPlugin) createPolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) createPolicy(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		Content     string        `json:"Content"`
@@ -234,7 +234,7 @@ func (p *OrganizationsPlugin) createPolicy(reqCtx *RequestContext, req *AWSReque
 
 // --- UpdatePolicy ---
 
-func (p *OrganizationsPlugin) updatePolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) updatePolicy(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	// Name, Description and Content are pointers because UpdatePolicy is a partial
 	// update: an omitted member leaves the stored value alone, while an empty string
@@ -305,7 +305,7 @@ func (p *OrganizationsPlugin) updatePolicy(reqCtx *RequestContext, req *AWSReque
 
 // --- DeletePolicy ---
 
-func (p *OrganizationsPlugin) deletePolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) deletePolicy(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		PolicyID string `json:"PolicyId"`
@@ -366,7 +366,7 @@ func (p *OrganizationsPlugin) deletePolicyRecord(ctx context.Context, acct, poli
 
 // --- DescribePolicy ---
 
-func (p *OrganizationsPlugin) describePolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) describePolicy(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		PolicyID string `json:"PolicyId"`
@@ -393,7 +393,7 @@ func (p *OrganizationsPlugin) describePolicy(reqCtx *RequestContext, req *AWSReq
 
 // --- ListPolicies ---
 
-func (p *OrganizationsPlugin) listPolicies(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listPolicies(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		Filter     string `json:"Filter"`
@@ -481,7 +481,7 @@ func (p *OrganizationsPlugin) policySummaries(ctx context.Context, ids []string)
 
 // --- AttachPolicy ---
 
-func (p *OrganizationsPlugin) attachPolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) attachPolicy(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		PolicyID string `json:"PolicyId"`
@@ -541,7 +541,7 @@ func (p *OrganizationsPlugin) attachPolicy(reqCtx *RequestContext, req *AWSReque
 
 // --- DetachPolicy ---
 
-func (p *OrganizationsPlugin) detachPolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) detachPolicy(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		PolicyID string `json:"PolicyId"`
@@ -625,7 +625,7 @@ func (p *OrganizationsPlugin) resolveAttachment(ctx context.Context, acct, polic
 
 // --- ListPoliciesForTarget ---
 
-func (p *OrganizationsPlugin) listPoliciesForTarget(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listPoliciesForTarget(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		TargetID   string `json:"TargetId"`
@@ -693,7 +693,7 @@ func (p *OrganizationsPlugin) listPoliciesForTarget(reqCtx *RequestContext, req 
 
 // --- ListTargetsForPolicy ---
 
-func (p *OrganizationsPlugin) listTargetsForPolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listTargetsForPolicy(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		PolicyID   string `json:"PolicyId"`
@@ -782,7 +782,7 @@ func (p *OrganizationsPlugin) policyTargetSummary(ctx context.Context, acct, tar
 
 // --- EnablePolicyType ---
 
-func (p *OrganizationsPlugin) enablePolicyType(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) enablePolicyType(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	input, root, err := p.policyTypeRequest(goCtx, reqCtx, req)
 	if err != nil {
@@ -831,7 +831,7 @@ func (p *OrganizationsPlugin) enablePolicyType(reqCtx *RequestContext, req *AWSR
 
 // --- DisablePolicyType ---
 
-func (p *OrganizationsPlugin) disablePolicyType(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) disablePolicyType(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	input, root, err := p.policyTypeRequest(goCtx, reqCtx, req)
 	if err != nil {
@@ -893,7 +893,7 @@ type orgPolicyTypeInput struct {
 // deliberately not the one loadRoot returns: loadRoot masks PolicyTypes under
 // CONSOLIDATED_BILLING, so writing it back would erase an enablement the
 // organization would get back if the feature-set seed were cleared.
-func (p *OrganizationsPlugin) policyTypeRequest(ctx context.Context, reqCtx *RequestContext, req *AWSRequest) (orgPolicyTypeInput, *OrgRoot, error) {
+func (p *OrganizationsPlugin) policyTypeRequest(ctx context.Context, reqCtx *orgCaller, req *AWSRequest) (orgPolicyTypeInput, *OrgRoot, error) {
 	var input orgPolicyTypeInput
 	if err := orgUnmarshal(req.Body, &input); err != nil {
 		return input, nil, err

--- a/emulator/organizations_resourcepolicy.go
+++ b/emulator/organizations_resourcepolicy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -29,6 +31,14 @@ const (
 // exactly one resource policy rather than a list keyed by ID, PutResourcePolicy
 // replaces it wholesale, and there is no per-statement update. Describe and Delete
 // take no input at all, which is why neither reads req.Body.
+//
+// That absence of input is also what bounds the authorization model below. None of
+// the three operations names an organization, so a caller can only ever ask about
+// its own — the "caller outside the organization" case #619 and #623 both describe
+// is not reachable through this API, because there is no member to put an outside
+// organization's ID in. The asymmetry that *is* reachable is the documented one:
+// Describe is callable "from the management account or a member account that is a
+// delegated administrator", Put and Delete "only from the management account".
 func (p *OrganizationsPlugin) resourcePolicyOperation(op string) (orgHandler, bool) {
 	switch op {
 	case "PutResourcePolicy":
@@ -52,8 +62,11 @@ func (p *OrganizationsPlugin) resourcePolicyOperation(op string) (orgHandler, bo
 // different one, when in fact the same single policy was updated — and since an
 // organization has exactly one, there is nothing the new ID could distinguish it
 // from.
-func (p *OrganizationsPlugin) putResourcePolicy(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) putResourcePolicy(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
+	if reqCtx.isMember() {
+		return nil, orgResourcePolicyAccessDenied("PutResourcePolicy")
+	}
 	org, err := p.ensureOrganization(goCtx, reqCtx.AccountID)
 	if err != nil {
 		return nil, fmt.Errorf("putResourcePolicy ensure org: %w", err)
@@ -128,14 +141,23 @@ func (p *OrganizationsPlugin) putResourcePolicy(reqCtx *RequestContext, req *AWS
 
 // describeResourcePolicy returns the organization's resource policy.
 //
-// The refusal is the normal case, not an edge case: most organizations have no
-// resource policy, and a caller checking whether management delegated anything to
-// it has to tell ResourcePolicyNotFoundException apart from AccessDeniedException.
-// Answering an empty policy instead would make "no delegation" and "delegation I
-// cannot read" the same observation.
+// A member account reads the document management set, provided that document names
+// it as a principal — which is what makes it a delegated administrator. That is
+// the asymmetry #619 asked for, and the three answers it produces are all
+// distinguishable:
+//
+//   - management: the policy, or ResourcePolicyNotFoundException
+//   - a member the policy names: the identical Content, Id and Arn
+//   - a member it does not name: AccessDeniedException
+//
+// The refusal is the normal case for management, not an edge case: most
+// organizations have no resource policy, and a caller checking whether management
+// delegated anything has to tell ResourcePolicyNotFoundException apart from
+// AccessDeniedException. Answering an empty policy instead would make "no
+// delegation" and "delegation I cannot read" the same observation.
 //
 // The operation takes no input, so req.Body is not read.
-func (p *OrganizationsPlugin) describeResourcePolicy(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) describeResourcePolicy(reqCtx *orgCaller, _ *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
 		return nil, fmt.Errorf("describeResourcePolicy ensure org: %w", err)
@@ -144,6 +166,14 @@ func (p *OrganizationsPlugin) describeResourcePolicy(reqCtx *RequestContext, _ *
 	policy, found, err := p.loadResourcePolicy(goCtx, reqCtx.AccountID)
 	if err != nil {
 		return nil, fmt.Errorf("describeResourcePolicy load: %w", err)
+	}
+	// A member is refused before the absence is reported, so a member cannot use
+	// this operation to learn whether the organization has a policy at all: the two
+	// answers it can get are the document that names it and a denial. Reporting
+	// ResourcePolicyNotFoundException to a member of an organization that does have
+	// one would leak the policy's existence to a caller not permitted to read it.
+	if reqCtx.isMember() && !orgPolicyDelegatesTo(policy, found, reqCtx.callerAccount) {
+		return nil, orgResourcePolicyAccessDenied("DescribeResourcePolicy")
 	}
 	if !found {
 		return nil, orgResourcePolicyNotFound()
@@ -159,8 +189,11 @@ func (p *OrganizationsPlugin) describeResourcePolicy(reqCtx *RequestContext, _ *
 // re-runnability property MoveAccount's DuplicateAccountException provides.
 //
 // The operation takes no input and the model gives it no output shape.
-func (p *OrganizationsPlugin) deleteResourcePolicy(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) deleteResourcePolicy(reqCtx *orgCaller, _ *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
+	if reqCtx.isMember() {
+		return nil, orgResourcePolicyAccessDenied("DeleteResourcePolicy")
+	}
 	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
 		return nil, fmt.Errorf("deleteResourcePolicy ensure org: %w", err)
 	}
@@ -202,6 +235,81 @@ func (p *OrganizationsPlugin) loadResourcePolicy(ctx context.Context, acct strin
 func orgResourcePolicyNotFound() *AWSError {
 	return orgErr("ResourcePolicyNotFoundException",
 		"we can't find a resource policy for this organization")
+}
+
+// orgResourcePolicyAccessDenied returns AccessDeniedException for a member account
+// calling an operation reserved to the management account.
+//
+// This is HTTP 403, not the 400 every other Organizations error here uses:
+// AccessDeniedException is a *common* error rather than one the service's model
+// declares, and the Organizations API reference's Common Errors page gives it 403.
+// The distinction is what an SDK's retry classifier reads, so answering 400 would
+// make a denial look like a malformed request.
+//
+// The message names the operation because all three refuse in the same place: a
+// caller that logged only the message would otherwise not know which of its calls
+// was the one management reserved.
+func orgResourcePolicyAccessDenied(op string) *AWSError {
+	return &AWSError{
+		Code: "AccessDeniedException",
+		Message: fmt.Sprintf(
+			"You don't have permissions to perform the requested operation. %s can be called only from the management account%s",
+			op, orgResourcePolicyCallerScope(op)),
+		HTTPStatus: http.StatusForbidden,
+	}
+}
+
+// orgResourcePolicyCallerScope completes the denial message with the set of
+// callers the operation does admit, which differs between the read and the writes.
+func orgResourcePolicyCallerScope(op string) string {
+	if op == "DescribeResourcePolicy" {
+		return " or a member account that is a delegated administrator."
+	}
+	return "."
+}
+
+// orgPolicyDelegatesTo reports whether the organization's resource policy makes
+// account a delegated administrator.
+//
+// Naming the account as a Principal is the test, and it is the whole test. Every
+// delegation policy AWS documents names the member as
+// "arn:aws:iam::<account>:root" in the Principal of each statement, so the
+// principal is what distinguishes a delegated administrator from any other member.
+//
+// The Action element deliberately is not consulted. DescribeResourcePolicy appears
+// in none of AWS's example delegation policies — the actions delegated are the
+// *policy-management* ones a delegated administrator goes on to call — so
+// requiring an Allow for it would deny every member that AWS's own examples
+// intend to admit. Evaluating the document as an authorization decision per
+// operation is a larger design than #619 asks for and would need the
+// organizations:PolicyType condition key substrate does not model; the reason
+// it is not attempted here is that a guessed denial fails a request AWS accepts.
+//
+// An unparseable document delegates to nobody. PutResourcePolicy already refuses
+// content that is not JSON, so this is reachable only from a hand-seeded state
+// store, and treating garbage as a grant would be the wrong direction to fail.
+func orgPolicyDelegatesTo(policy OrgResourcePolicy, found bool, account string) bool {
+	if !found || account == "" {
+		return false
+	}
+	var doc PolicyDocument
+	if err := json.Unmarshal([]byte(policy.Content), &doc); err != nil {
+		return false
+	}
+	principal := fmt.Sprintf("arn:aws:iam::%s:root", account)
+	for _, stmt := range doc.Statement {
+		// Only an Allow delegates. A Deny naming the account is the opposite, and a
+		// statement with no Principal at all names nobody in a resource policy —
+		// principalMatches treats an absent Principal as matching every caller,
+		// which is right for an identity policy and wrong here.
+		if !strings.EqualFold(stmt.Effect, "Allow") || stmt.Principal == nil {
+			continue
+		}
+		if principalCovered(stmt.Principal, principal) {
+			return true
+		}
+	}
+	return false
 }
 
 // validateOrgResourcePolicyContent enforces ResourcePolicyContent's bounds and

--- a/emulator/organizations_state.go
+++ b/emulator/organizations_state.go
@@ -133,6 +133,17 @@ func orgCreateStatusIDsKey(acct string) string { return "car_ids:" + acct }
 // unlike the rest of the service.
 func orgResourcePolicyKey(acct string) string { return "resource_policy:" + acct }
 
+// orgMemberOwnerKey holds the management account of the organization an account
+// belongs to. Every other index here runs the other way — orgAccountIDsKey lists
+// the members of one management account — so before this key existed there was no
+// way to answer "whose organization is this caller in", and a member calling any
+// operation was given a private organization of its own (#623).
+//
+// The management account is indexed to itself, so the lookup has one answer for
+// every account substrate knows rather than two cases the callers have to
+// distinguish.
+func orgMemberOwnerKey(id string) string { return "member_owner:" + id }
+
 // --- errors ---
 //
 // Every Organizations exception is HTTP 400. The API model declares no 404 for
@@ -317,10 +328,40 @@ func orgPaginate(ids []string, nextToken string, maxResults int) (page []string,
 
 // --- organization, root and feature set ---
 
+// organizationOwner returns the management account of the organization acct
+// belongs to, or "" when substrate has never seen acct.
+//
+// "" is not an error and not a default: it is the answer for an account that has
+// joined no organization, and the auto-create path depends on being able to tell
+// it from a real answer. Collapsing the two — returning acct itself for an
+// unknown account — would make a member of a *deleted* organization look like a
+// management account.
+func (p *OrganizationsPlugin) organizationOwner(ctx context.Context, acct string) (string, error) {
+	var owner string
+	if _, err := p.orgGetJSON(ctx, orgMemberOwnerKey(acct), &owner); err != nil {
+		return "", err
+	}
+	return owner, nil
+}
+
 // ensureOrganization returns the organization for acct, creating it — along with
 // its root, its management account, and the FullAWSAccess attachments AWS makes
 // — on first call.
+//
+// A known member account resolves to the organization it belongs to rather than
+// getting one of its own. Handlers reach here with an already-resolved management
+// account (see orgCaller), so on the request path the reverse-index lookup below
+// is a no-op; it is what makes the function correct for any caller, including a
+// direct one, rather than only for the resolved path (#623).
 func (p *OrganizationsPlugin) ensureOrganization(ctx context.Context, acct string) (*Organization, error) {
+	owner, err := p.organizationOwner(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	if owner != "" {
+		acct = owner
+	}
+
 	var org Organization
 	found, err := p.orgGetJSON(ctx, orgKey(acct), &org)
 	if err != nil {
@@ -467,6 +508,15 @@ func (p *OrganizationsPlugin) scpEnabled(ctx context.Context, acct string) (bool
 
 // --- accounts ---
 
+// saveAccount persists an account and records both directions of its membership:
+// the management account's list of members, and the member's own pointer back at
+// the management account.
+//
+// Both writes live here rather than at the call sites because every path that
+// creates or joins an account already goes through this one function —
+// ensureOrganization's management account, vendAccount's member — so an index
+// written by one operation and not another, which is worse than no index at all,
+// is not a state this can reach.
 func (p *OrganizationsPlugin) saveAccount(ctx context.Context, masterAcct string, a OrgAccount) error {
 	if err := p.orgPutJSON(ctx, orgAccountKey(a.ID), a); err != nil {
 		return err
@@ -474,7 +524,7 @@ func (p *OrganizationsPlugin) saveAccount(ctx context.Context, masterAcct string
 	if _, err := p.orgAddID(ctx, orgAccountIDsKey(masterAcct), a.ID); err != nil {
 		return err
 	}
-	return nil
+	return p.orgPutJSON(ctx, orgMemberOwnerKey(a.ID), masterAcct)
 }
 
 // loadAccount returns the account, or (nil, nil) when there is no such account.

--- a/emulator/organizations_tags.go
+++ b/emulator/organizations_tags.go
@@ -69,7 +69,7 @@ func (p *OrganizationsPlugin) tagOperation(op string) (orgHandler, bool) {
 // partially applied batch would leave the caller unable to tell which tags
 // landed, and a retry of the same request would then behave differently from the
 // first attempt.
-func (p *OrganizationsPlugin) tagResource(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) tagResource(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		ResourceID string        `json:"ResourceId"`
@@ -120,7 +120,7 @@ func (p *OrganizationsPlugin) tagResource(reqCtx *RequestContext, req *AWSReques
 // A key that is not on the resource is not an error: UntagResource "removes any
 // tags with the specified keys", so the operation is idempotent, and a cleanup
 // path that runs twice must not fail the second time.
-func (p *OrganizationsPlugin) untagResource(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) untagResource(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		ResourceID string   `json:"ResourceId"`
@@ -177,7 +177,7 @@ func (p *OrganizationsPlugin) untagResource(reqCtx *RequestContext, req *AWSRequ
 // is the ceiling orgPaginate applies to every Organizations listing. That is
 // below the 50-tag limit, so a heavily tagged resource really does page, and a
 // consumer that reads only the first page is caught here rather than against AWS.
-func (p *OrganizationsPlugin) listTagsForResource(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+func (p *OrganizationsPlugin) listTagsForResource(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var input struct {
 		ResourceID string `json:"ResourceId"`

--- a/emulator/testing.go
+++ b/emulator/testing.go
@@ -25,6 +25,7 @@ type TestServer struct {
 	state    StateManager
 	store    *EventStore
 	registry *PluginRegistry
+	creds    map[string]CredentialEntry
 }
 
 // Store returns the [EventStore] backing the server, for cost summaries
@@ -47,7 +48,46 @@ func (ts *TestServer) Registry() *PluginRegistry { return ts.registry }
 // registers all default plugins, and schedules t.Cleanup to shut it down.
 // The returned [TestServer] is ready to accept requests when this function
 // returns.
+//
+// No [CredentialRegistry] is wired, so SigV4 signatures are not verified and any
+// access key is accepted: an AKIA-prefixed one resolves to account 123456789012
+// and everything else to 000000000000. Use [StartTestServerWithAccounts] when a
+// test needs to call as more than one account.
 func StartTestServer(t *testing.T) *TestServer {
+	t.Helper()
+	return startTestServer(t, nil)
+}
+
+// StartTestServerWithAccounts starts a test server that can be called as any of
+// the given accounts, in addition to the built-in 123456789012.
+//
+// Each account gets its own signing credential, readable with
+// [TestServer.CredentialsFor]. Because the accounts are named up front, a test
+// that needs to sign as an account Organizations vends — whose ID is not known
+// until CreateAccount returns — should call [TestServer.RegisterAccount] instead.
+//
+// This is a separate entry point from [StartTestServer] rather than an option on
+// it because wiring a registry also switches SigV4 verification on: the server
+// verifies signatures exactly when [ServerOptions.Credentials] is non-nil, and an
+// access key the registry does not hold is refused with InvalidClientTokenId 403.
+// Every request made against the returned server must therefore be signed with one
+// of these credentials, which is a stricter contract than [StartTestServer]'s and
+// is why it is opt-in. Decoupling the two is #630.
+func StartTestServerWithAccounts(t testing.TB, accounts ...string) *TestServer {
+	t.Helper()
+
+	registry := NewCredentialRegistry()
+	ts := startTestServer(t, registry)
+	for _, account := range accounts {
+		ts.RegisterAccount(t, account)
+	}
+	return ts
+}
+
+// startTestServer is the shared body of [StartTestServer] and
+// [StartTestServerWithAccounts]. A nil registry leaves SigV4 verification off,
+// which is [StartTestServer]'s documented behavior.
+func startTestServer(t testing.TB, creds *CredentialRegistry) *TestServer {
 	t.Helper()
 
 	cfg := DefaultConfig()
@@ -101,7 +141,7 @@ func StartTestServer(t *testing.T) *TestServer {
 	costs := NewCostController(CostConfig{Enabled: true})
 
 	srv := NewServer(*cfg, registry, store, state, tc, logger,
-		ServerOptions{Fault: fault, Costs: costs, Auth: auth})
+		ServerOptions{Fault: fault, Costs: costs, Auth: auth, Credentials: creds})
 
 	srvCtx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -130,7 +170,55 @@ func StartTestServer(t *testing.T) *TestServer {
 		<-done
 	})
 
-	return &TestServer{URL: baseURL, Port: port, tc: tc, srv: srv, state: state, store: store, registry: registry}
+	ts := &TestServer{URL: baseURL, Port: port, tc: tc, srv: srv, state: state, store: store, registry: registry}
+	if creds != nil {
+		ts.creds = map[string]CredentialEntry{}
+		if entry, ok := creds.Lookup(defaultTestAccessKeyID); ok {
+			ts.creds[entry.AccountID] = entry
+		}
+	}
+	return ts
+}
+
+// RegisterAccount mints a signing credential for an account and returns it, so a
+// test can call as an account whose ID it did not know at startup — an account
+// Organizations vended, for one.
+//
+// The server must have been started by [StartTestServerWithAccounts]; a server with
+// no credential registry has nowhere to put the entry, and registering one after
+// the fact could not turn signature verification on for a server already running.
+//
+// The access key and secret are derived from the account ID rather than generated,
+// so a recorded run replays with the same credentials in it. AWS access key IDs are
+// 20 characters of uppercase alphanumerics; a 12-digit account ID padded after
+// "AKIA" fits exactly, which keeps the key one that resolvePrincipal and
+// extractAccount both recognize.
+func (ts *TestServer) RegisterAccount(t testing.TB, accountID string) CredentialEntry {
+	t.Helper()
+	if ts.creds == nil {
+		t.Fatalf("RegisterAccount(%s): this server has no credential registry; start it with StartTestServerWithAccounts", accountID)
+	}
+	if existing, ok := ts.creds[accountID]; ok {
+		return existing
+	}
+	if len(accountID) != 12 {
+		t.Fatalf("RegisterAccount(%q): an AWS account ID is 12 digits", accountID)
+	}
+	entry := CredentialEntry{
+		AccessKeyID:     "AKIA" + accountID + "TEST",
+		SecretAccessKey: "substrate-secret-" + accountID,
+		AccountID:       accountID,
+	}
+	ts.srv.opts.Credentials.Register(entry)
+	ts.creds[accountID] = entry
+	return entry
+}
+
+// CredentialsFor returns the signing credential for an account registered with
+// this server, and whether one exists.
+func (ts *TestServer) CredentialsFor(accountID string) (CredentialEntry, bool) {
+	entry, ok := ts.creds[accountID]
+	return entry, ok
 }
 
 // ResetState wipes all server state. Call this between test cases that share


### PR DESCRIPTION
## What

Organizations state is keyed by the **caller's** account, and `ensureOrganization` auto-created an entire organization — root, management account, `FullAWSAccess` — for any account it had not seen. So a member account calling *any* Organizations operation was silently handed a private organization of its own: a different `o-` ID, a different `r-` root, and a member list holding only itself. A consumer walking the hierarchy from a member credential saw an organization management had never created, and nothing in the response said so.

With that fixed, #619's two remaining bullets become reachable, so both issues land together — Lane B is unreachable without Lane A's index.

## How

**The reverse index (#623).** `saveAccount` writes `member_owner:<id>` in both directions. Both writes live in that one function because every path that creates or joins an account already goes through it, so an index written by one operation and not another — worse than no index at all — is not a reachable state.

**Resolution happens once, at dispatch.** A new `orgCaller` carries a `*RequestContext` whose `AccountID` has been resolved to the management account, plus the signing account. Resolving inside `ensureOrganization` alone was not enough: a member's `ListRoots` calls `loadRoot` directly and would hard-error with `root missing for account …`, and two reads in one request could disagree about which organization they concern. Only the handlers that model a management-versus-member asymmetry read `callerAccount`.

An account the index does not name **still auto-creates its own organization**. That is not a fallback — it is what keeps a fresh emulator usable with no `CreateOrganization` call, and the distinction the index preserves is "a member of that organization" versus "a member of nothing", not "known" versus "unknown".

**The resource-policy asymmetry (#619).** Three answers, all distinguishable, which is the point of the issue — a tool must tell "nothing was delegated to me" from "something was, and I cannot read it":

| Caller | Answer |
|---|---|
| Management | the policy, or `ResourcePolicyNotFoundException` (400) |
| A member the policy names | the **identical** `Content`, `Id`, `Arn` |
| A member it does not name | `AccessDeniedException` (**403**) |

`Put`/`DeleteResourcePolicy` stay management-only. Delegation is decided by the `Principal`, **not** the `Action`: every delegation policy AWS documents names the member as `arn:aws:iam::<account>:root`, and `organizations:DescribeResourcePolicy` appears in **none** of their `Action` lists — the delegated actions are the policy-management ones a delegated administrator goes on to call. Requiring an `Allow` for the read itself would deny every member AWS's own examples intend to admit, and a guessed denial fails a request AWS accepts.

A member is refused **before** the absence is reported, so it cannot use the operation to learn whether a policy exists at all.

## Corrections to the issues' own framing

- **`AccessDeniedException` is 403, not 400.** Every other Organizations error substrate emits is 400 via `orgErr`. This one is a *common* error the service model does not declare, and the API Reference's Common Errors page gives it 403 — which is what an SDK's retry classifier reads. It builds an `*AWSError` directly rather than going through `orgErr`.
- **"A caller outside the organization" is not reachable through this API.** None of the three resource-policy operations takes an input naming an organization, so there is nowhere to put another organization's ID. The reachable third case is a member the policy does not name, which is what is modelled.

## The test seam

No in-repo test could authenticate as a second account: `StartTestServer` wires no `CredentialRegistry`, and `extractAccount` maps every `AKIA…` key to `123456789012`. That is precisely why #623 survived every Organizations test — all of them are one caller by construction.

`StartTestServerWithAccounts` is a **separate entry point** rather than an option on `StartTestServer`, because wiring a registry also switches SigV4 verification on: the server verifies signatures exactly when `ServerOptions.Credentials` is non-nil, and a key the registry does not hold is `InvalidClientTokenId` 403. Turning that on repository-wide inside a feature change is not a trade worth making. Decoupling the two is #630. It takes `testing.TB` from the outset so #605 gets smaller rather than more conflicted.

Keys and secrets are **derived from the account ID** rather than generated, so a recorded run replays with the same credentials in it.

## Verification

- `make test` (race detector) — green; `golangci-lint run ./...` — 0 issues; `gofmt`/`go vet` clean.
- Five new tests, including the storage-layer index assertions and the only Organizations test file that signs its requests (the SigV4 algorithm is reimplemented in the test rather than called into, so a mistake in substrate's own signing cannot make it pass by agreeing with itself).
- **Mutation-tested**, all CAUGHT:
  - resolution dropped from `resolveOrgCaller` → 3 tests fail
  - the index write dropped from `saveAccount` → 4 tests fail
  - `orgPolicyDelegatesTo` forced true → the asymmetry test fails

## Compatibility

A member account calling Organizations **no longer receives a private organization of its own**. A fixture that relied on that isolation will now see management's `o-`/`r-` IDs and its member list. This affects only a test that authenticates as an account Organizations vended, which was not possible before this change.

Closes #623
Closes #619