### PR TITLE
fix(servicequotas): file a quota increase under the account that requested it (#624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   replays with the same credentials in it.
 
 ### Fixed
+- **A Service Quotas increase is now filed under the account that requested it**
+  (#624). `ServiceQuotasPlugin.HandleRequest` discarded its `*RequestContext` and
+  the three quota-increase operations hardcoded the literal `000000000000`, so two
+  accounts sharing one emulator shared one pile of requests. A consumer reading
+  `ListRequestedServiceQuotaChangesByService` to decide whether it had already asked
+  for a raise would find *another* account's request and skip filing its own, and
+  `GetRequestedServiceQuotaChange` would hand over a request by ID to any caller.
+
+  The four read-only operations still take no account, deliberately: the quota table
+  is per-service and identical for every caller, so threading one through them would
+  imply a per-account value substrate does not model and nothing can set.
+
+  An unattributed request — no `Authorization` header — still lands under
+  `000000000000`, because that is what substrate's own parser answers for one. The
+  placeholder is the fallback rather than the default, so existing fixtures that
+  file an increase without signing keep working.
 - **A member account now sees the organization it belongs to** (#623). All
   Organizations state is keyed by the caller's account, and `ensureOrganization`
   auto-created an entire organization — root, management account, `FullAWSAccess` —

--- a/emulator/organizations_member_test.go
+++ b/emulator/organizations_member_test.go
@@ -1,15 +1,7 @@
 package emulator_test
 
 import (
-	"bytes"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -44,108 +36,18 @@ func orgTestNow() time.Time {
 	return time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 }
 
+// orgsTarget is the Organizations JSON-target endpoint. The signing name and the
+// host label are both the plain service name here, unlike Service Quotas.
+var orgsTarget = signedRequestTarget{
+	host:        "organizations.us-east-1.amazonaws.com",
+	target:      "Organizations_20161128",
+	signingName: "organizations",
+}
+
 // orgSignedRequest posts an Organizations operation signed as the given account.
-//
-// The account must have been registered with the server, either by
-// StartTestServerWithAccounts or by RegisterAccount; an unregistered key is
-// InvalidClientTokenId 403 before any plugin sees it.
 func orgSignedRequest(t *testing.T, ts *emulator.TestServer, account, op string, body any) *http.Response {
 	t.Helper()
-
-	creds, ok := ts.CredentialsFor(account)
-	if !ok {
-		t.Fatalf("no credential registered for account %s", account)
-	}
-
-	data, err := json.Marshal(body)
-	if err != nil {
-		t.Fatalf("marshal %s: %v", op, err)
-	}
-
-	const dateTime = "20260101T120000Z"
-	host := "organizations.us-east-1.amazonaws.com"
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", bytes.NewReader(data))
-	if err != nil {
-		t.Fatalf("build %s request: %v", op, err)
-	}
-	req.Host = host
-	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
-	req.Header.Set("X-Amz-Target", "Organizations_20161128."+op)
-	req.Header.Set("X-Amz-Date", dateTime)
-	req.Header.Set("Authorization", orgSigV4Header(
-		host, dateTime, data, creds.AccessKeyID, creds.SecretAccessKey))
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("orgs request %s as %s: %v", op, account, err)
-	}
-	return resp
-}
-
-// orgSigV4Header computes a valid SigV4 Authorization header for a POST to "/"
-// with the host and x-amz-date headers signed.
-//
-// This duplicates the algorithm rather than calling into the emulator, so a
-// mistake in the emulator's own signing cannot make these tests pass by agreeing
-// with it.
-func orgSigV4Header(host, dateTime string, body []byte, accessKey, secretKey string) string {
-	const (
-		region        = "us-east-1"
-		service       = "organizations"
-		signedHeaders = "host;x-amz-date"
-	)
-	date := dateTime[:8]
-
-	bodyHash := sha256.Sum256(body)
-	canonicalReq := strings.Join([]string{
-		http.MethodPost,
-		"/",
-		"",
-		"host:" + host + "\n" + "x-amz-date:" + dateTime + "\n",
-		signedHeaders,
-		hex.EncodeToString(bodyHash[:]),
-	}, "\n")
-
-	canonicalHash := sha256.Sum256([]byte(canonicalReq))
-	credScope := date + "/" + region + "/" + service + "/aws4_request"
-	stringToSign := "AWS4-HMAC-SHA256\n" + dateTime + "\n" + credScope + "\n" +
-		hex.EncodeToString(canonicalHash[:])
-
-	mac := func(key, data []byte) []byte {
-		h := hmac.New(sha256.New, key)
-		h.Write(data)
-		return h.Sum(nil)
-	}
-	signing := mac(mac(mac(mac([]byte("AWS4"+secretKey), []byte(date)), []byte(region)),
-		[]byte(service)), []byte("aws4_request"))
-
-	return fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
-		accessKey, credScope, signedHeaders, hex.EncodeToString(mac(signing, []byte(stringToSign))))
-}
-
-// orgDecode decodes an Organizations response into out, returning the status and
-// the error code a refusal carries.
-func orgDecode(t *testing.T, resp *http.Response, out any) (int, string) {
-	t.Helper()
-	defer resp.Body.Close() //nolint:errcheck
-
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read body: %v", err)
-	}
-	var errShape struct {
-		Type    string `json:"__type"`
-		Message string `json:"message"`
-	}
-	if unmarshalErr := json.Unmarshal(raw, &errShape); unmarshalErr == nil && errShape.Type != "" {
-		return resp.StatusCode, errShape.Type
-	}
-	if out != nil {
-		if unmarshalErr := json.Unmarshal(raw, out); unmarshalErr != nil {
-			t.Fatalf("decode %s: %v", raw, unmarshalErr)
-		}
-	}
-	return resp.StatusCode, ""
+	return signedRequest(t, ts, orgsTarget, account, op, body)
 }
 
 // orgVendMember creates an account through CreateAccount, polls the request to
@@ -161,7 +63,7 @@ func orgVendMember(t *testing.T, ts *emulator.TestServer, name, email string) st
 	var created struct {
 		CreateAccountStatus emulator.OrgCreateAccountStatus `json:"CreateAccountStatus"`
 	}
-	status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount, "CreateAccount",
+	status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount, "CreateAccount",
 		map[string]any{"AccountName": name, "Email": email}), &created)
 	if status != http.StatusOK {
 		t.Fatalf("CreateAccount: %d %s", status, code)
@@ -171,7 +73,7 @@ func orgVendMember(t *testing.T, ts *emulator.TestServer, name, email string) st
 	var describe struct {
 		CreateAccountStatus emulator.OrgCreateAccountStatus `json:"CreateAccountStatus"`
 	}
-	status, code = orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount, "DescribeCreateAccountStatus",
+	status, code = decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount, "DescribeCreateAccountStatus",
 		map[string]any{"CreateAccountRequestId": requestID}), &describe)
 	if status != http.StatusOK {
 		t.Fatalf("DescribeCreateAccountStatus: %d %s", status, code)
@@ -205,7 +107,7 @@ func TestOrganizations_MemberSeesManagementsOrganization(t *testing.T) {
 	var mgmt struct {
 		Organization emulator.Organization `json:"Organization"`
 	}
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount,
 		"DescribeOrganization", map[string]any{}), &mgmt); status != http.StatusOK {
 		t.Fatalf("DescribeOrganization as management: %d %s", status, code)
 	}
@@ -215,7 +117,7 @@ func TestOrganizations_MemberSeesManagementsOrganization(t *testing.T) {
 	var got struct {
 		Organization emulator.Organization `json:"Organization"`
 	}
-	status, code := orgDecode(t, orgSignedRequest(t, ts, member,
+	status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, member,
 		"DescribeOrganization", map[string]any{}), &got)
 	if status != http.StatusOK {
 		t.Fatalf("DescribeOrganization as the member: %d %s", status, code)
@@ -236,11 +138,11 @@ func TestOrganizations_MemberSeesManagementsOrganization(t *testing.T) {
 	var mgmtRoots, memberRoots struct {
 		Roots []emulator.OrgRoot `json:"Roots"`
 	}
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount,
 		"ListRoots", map[string]any{}), &mgmtRoots); status != http.StatusOK {
 		t.Fatalf("ListRoots as management: %d %s", status, code)
 	}
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, member,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, member,
 		"ListRoots", map[string]any{}), &memberRoots); status != http.StatusOK {
 		t.Fatalf("ListRoots as the member: %d %s", status, code)
 	}
@@ -259,7 +161,7 @@ func TestOrganizations_MemberSeesManagementsOrganization(t *testing.T) {
 	var listed struct {
 		Accounts []emulator.OrgAccount `json:"Accounts"`
 	}
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, member,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, member,
 		"ListAccounts", map[string]any{}), &listed); status != http.StatusOK {
 		t.Fatalf("ListAccounts as the member: %d %s", status, code)
 	}
@@ -288,11 +190,11 @@ func TestOrganizations_UnknownAccountStillAutoCreates(t *testing.T) {
 	var mgmt, outsider struct {
 		Organization emulator.Organization `json:"Organization"`
 	}
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount,
 		"DescribeOrganization", map[string]any{}), &mgmt); status != http.StatusOK {
 		t.Fatalf("DescribeOrganization as management: %d %s", status, code)
 	}
-	status, code := orgDecode(t, orgSignedRequest(t, ts, orgOutsiderAccount,
+	status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgOutsiderAccount,
 		"DescribeOrganization", map[string]any{}), &outsider)
 	if status != http.StatusOK {
 		t.Fatalf("DescribeOrganization as an account in no organization: %d %s — the auto-create path must still work",
@@ -399,7 +301,7 @@ func TestOrganizations_ResourcePolicy_MemberAsymmetry(t *testing.T) {
 
 	// Before any policy exists, management gets the absence — the ordinary answer,
 	// since most organizations have no resource policy.
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount,
 		"DescribeResourcePolicy", map[string]any{}), nil); status != http.StatusBadRequest ||
 		code != "ResourcePolicyNotFoundException" {
 		t.Fatalf("DescribeResourcePolicy with no policy set: %d %q, want 400/ResourcePolicyNotFoundException", status, code)
@@ -407,7 +309,7 @@ func TestOrganizations_ResourcePolicy_MemberAsymmetry(t *testing.T) {
 
 	// A member gets denied rather than the absence, so it cannot use this
 	// operation to learn whether the organization has a policy at all.
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, plain,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, plain,
 		"DescribeResourcePolicy", map[string]any{}), nil); status != http.StatusForbidden ||
 		code != "AccessDeniedException" {
 		t.Fatalf("DescribeResourcePolicy as a member with no policy set: %d %q, want 403/AccessDeniedException", status, code)
@@ -416,7 +318,7 @@ func TestOrganizations_ResourcePolicy_MemberAsymmetry(t *testing.T) {
 	var put struct {
 		ResourcePolicy emulator.OrgResourcePolicy `json:"ResourcePolicy"`
 	}
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount,
 		"PutResourcePolicy", map[string]any{"Content": orgDelegationPolicy(delegated)}),
 		&put); status != http.StatusOK {
 		t.Fatalf("PutResourcePolicy as management: %d %s", status, code)
@@ -428,7 +330,7 @@ func TestOrganizations_ResourcePolicy_MemberAsymmetry(t *testing.T) {
 	var got struct {
 		ResourcePolicy emulator.OrgResourcePolicy `json:"ResourcePolicy"`
 	}
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, delegated,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, delegated,
 		"DescribeResourcePolicy", map[string]any{}), &got); status != http.StatusOK {
 		t.Fatalf("DescribeResourcePolicy as the delegated member: %d %s", status, code)
 	}
@@ -442,7 +344,7 @@ func TestOrganizations_ResourcePolicy_MemberAsymmetry(t *testing.T) {
 	// operations takes an input naming an organization, so a caller can only ever
 	// ask about its own and "an account in no relationship to this organization"
 	// has no way to pose the question.
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, plain,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, plain,
 		"DescribeResourcePolicy", map[string]any{}), nil); status != http.StatusForbidden ||
 		code != "AccessDeniedException" {
 		t.Fatalf("DescribeResourcePolicy as an undelegated member: %d %q, want 403/AccessDeniedException", status, code)
@@ -450,7 +352,7 @@ func TestOrganizations_ResourcePolicy_MemberAsymmetry(t *testing.T) {
 
 	// Management still reads it, which is what makes the member's denial an
 	// asymmetry rather than the policy having gone missing.
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount,
 		"DescribeResourcePolicy", map[string]any{}), &got); status != http.StatusOK {
 		t.Fatalf("DescribeResourcePolicy as management after the put: %d %s", status, code)
 	}
@@ -471,7 +373,7 @@ func TestOrganizations_ResourcePolicy_WritesAreManagementOnly(t *testing.T) {
 	ts := emulator.StartTestServerWithAccounts(t)
 
 	delegated := orgVendMember(t, ts, "delegated", "delegated@example.com")
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount,
 		"PutResourcePolicy", map[string]any{"Content": orgDelegationPolicy(delegated)}),
 		nil); status != http.StatusOK {
 		t.Fatalf("PutResourcePolicy as management: %d %s", status, code)
@@ -482,7 +384,7 @@ func TestOrganizations_ResourcePolicy_WritesAreManagementOnly(t *testing.T) {
 		if op == "PutResourcePolicy" {
 			body["Content"] = orgDelegationPolicy(delegated)
 		}
-		status, code := orgDecode(t, orgSignedRequest(t, ts, delegated, op, body), nil)
+		status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, delegated, op, body), nil)
 		if status != http.StatusForbidden || code != "AccessDeniedException" {
 			t.Errorf("%s as a delegated member: %d %q, want 403/AccessDeniedException", op, status, code)
 		}
@@ -490,7 +392,7 @@ func TestOrganizations_ResourcePolicy_WritesAreManagementOnly(t *testing.T) {
 
 	// And management's own delete still works, so the refusals above are about the
 	// caller rather than the operation being broken.
-	if status, code := orgDecode(t, orgSignedRequest(t, ts, orgManagementAccount,
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount,
 		"DeleteResourcePolicy", map[string]any{}), nil); status != http.StatusOK {
 		t.Fatalf("DeleteResourcePolicy as management: %d %s", status, code)
 	}

--- a/emulator/servicequotas_account_test.go
+++ b/emulator/servicequotas_account_test.go
@@ -1,0 +1,159 @@
+package emulator_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// This file is #624: a quota increase belongs to the account that filed it.
+//
+// ServiceQuotasPlugin.HandleRequest discarded its *RequestContext and filed every
+// increase under the literal 000000000000, so two accounts sharing one emulator
+// shared one pile of requests. The existing Service Quotas tests could not see it
+// — they are all one caller, so "everyone's requests" and "my requests" are the
+// same set.
+
+// sqTarget is the Service Quotas JSON-target endpoint.
+//
+// The signing name is servicequotasv20190624, not the plugin name: aws-sdk-go-v2
+// puts the versioned form in the credential scope, and parser.go carries an alias
+// for exactly that. Signing as "servicequotas" here would test a request no SDK
+// sends — the same class of gap #610 was.
+var sqTarget = signedRequestTarget{
+	host:        "servicequotas.us-east-1.amazonaws.com",
+	target:      "ServiceQuotas",
+	signingName: "servicequotasv20190624",
+}
+
+// sqSecondAccount is a second caller, unrelated to the built-in test account.
+const sqSecondAccount = "444455556666"
+
+// TestServiceQuotas_IncreasesAreFiledUnderTheCaller is #624's repro.
+//
+// Two accounts each file one increase, and each must see only its own. Before the
+// fix both saw both, and a consumer reading
+// ListRequestedServiceQuotaChangesByService to decide whether it had already asked
+// for a raise would find another account's request and skip filing its own.
+func TestServiceQuotas_IncreasesAreFiledUnderTheCaller(t *testing.T) {
+	ts := emulator.StartTestServerWithAccounts(t, sqSecondAccount)
+
+	type requestedQuota struct {
+		ID           string  `json:"Id"`
+		ServiceCode  string  `json:"ServiceCode"`
+		QuotaCode    string  `json:"QuotaCode"`
+		DesiredValue float64 `json:"DesiredValue"`
+		Status       string  `json:"Status"`
+	}
+
+	// The two accounts ask for different values, so a leak shows up as a wrong
+	// DesiredValue rather than only as a count.
+	filed := map[string]requestedQuota{}
+	for account, want := range map[string]float64{
+		orgManagementAccount: 50,
+		sqSecondAccount:      75,
+	} {
+		var out struct {
+			RequestedQuota requestedQuota `json:"RequestedQuota"`
+		}
+		status, code := decodeAWSResponse(t, signedRequest(t, ts, sqTarget, account,
+			"RequestServiceQuotaIncrease", map[string]any{
+				"ServiceCode":  "organizations",
+				"QuotaCode":    "L-E619E033",
+				"DesiredValue": want,
+			}), &out)
+		if status != http.StatusOK {
+			t.Fatalf("RequestServiceQuotaIncrease as %s: %d %s", account, status, code)
+		}
+		if out.RequestedQuota.Status != "PENDING" {
+			t.Errorf("as %s: Status = %q, want PENDING", account, out.RequestedQuota.Status)
+		}
+		filed[account] = out.RequestedQuota
+	}
+
+	for account, own := range filed {
+		var listed struct {
+			RequestedQuotas []requestedQuota `json:"RequestedQuotas"`
+		}
+		status, code := decodeAWSResponse(t, signedRequest(t, ts, sqTarget, account,
+			"ListRequestedServiceQuotaChangesByService", map[string]any{
+				"ServiceCode": "organizations",
+			}), &listed)
+		if status != http.StatusOK {
+			t.Fatalf("ListRequestedServiceQuotaChangesByService as %s: %d %s", account, status, code)
+		}
+		if len(listed.RequestedQuotas) != 1 {
+			t.Fatalf("as %s: %d requests listed, want 1 — the other account's request leaked",
+				account, len(listed.RequestedQuotas))
+		}
+		if got := listed.RequestedQuotas[0]; got != own {
+			t.Errorf("as %s: listed %+v, want its own %+v", account, got, own)
+		}
+	}
+
+	// GetRequestedServiceQuotaChange is keyed the same way, so one account cannot
+	// read the other's request by ID. NoSuchResourceException rather than the
+	// record is the answer that matters: an ID is guessable, and a lookup that
+	// ignored the caller would hand it over.
+	status, code := decodeAWSResponse(t, signedRequest(t, ts, sqTarget, sqSecondAccount,
+		"GetRequestedServiceQuotaChange", map[string]any{
+			"RequestId": filed[orgManagementAccount].ID,
+		}), nil)
+	if status != http.StatusBadRequest || code != "NoSuchResourceException" {
+		t.Errorf("reading another account's request by ID: %d %q, want 400/NoSuchResourceException",
+			status, code)
+	}
+
+	// And its own is readable, so the refusal above is about the caller rather
+	// than the operation being broken.
+	var got struct {
+		RequestedQuota requestedQuota `json:"RequestedQuota"`
+	}
+	status, code = decodeAWSResponse(t, signedRequest(t, ts, sqTarget, sqSecondAccount,
+		"GetRequestedServiceQuotaChange", map[string]any{
+			"RequestId": filed[sqSecondAccount].ID,
+		}), &got)
+	if status != http.StatusOK {
+		t.Fatalf("GetRequestedServiceQuotaChange for its own request: %d %s", status, code)
+	}
+	if got.RequestedQuota != filed[sqSecondAccount] {
+		t.Errorf("read back %+v, want %+v", got.RequestedQuota, filed[sqSecondAccount])
+	}
+}
+
+// TestServiceQuotas_UnattributedCallerKeepsThePlaceholder pins the fallback.
+//
+// An unsigned request carries no account, and substrate's parser answers
+// 000000000000 for it — the same literal the plugin used to hardcode. So a test
+// that files an increase without signing still finds it, which is what keeps the
+// existing Service Quotas fixtures working: #624 changes who a *signed* request is
+// attributed to, not whether an unattributed one has somewhere to live.
+func TestServiceQuotas_UnattributedCallerKeepsThePlaceholder(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	resp := makeServiceQuotasRequest(t, ts, "RequestServiceQuotaIncrease", map[string]interface{}{
+		"ServiceCode":  "organizations",
+		"QuotaCode":    "L-E619E033",
+		"DesiredValue": float64(50),
+	})
+	if status, code := decodeAWSResponse(t, resp, nil); status != http.StatusOK {
+		t.Fatalf("RequestServiceQuotaIncrease unsigned: %d %s", status, code)
+	}
+
+	var listed struct {
+		RequestedQuotas []struct {
+			QuotaCode string `json:"QuotaCode"`
+		} `json:"RequestedQuotas"`
+	}
+	status, code := decodeAWSResponse(t,
+		makeServiceQuotasRequest(t, ts, "ListRequestedServiceQuotaChangesByService", map[string]interface{}{
+			"ServiceCode": "organizations",
+		}), &listed)
+	if status != http.StatusOK {
+		t.Fatalf("ListRequestedServiceQuotaChangesByService unsigned: %d %s", status, code)
+	}
+	if len(listed.RequestedQuotas) != 1 || listed.RequestedQuotas[0].QuotaCode != "L-E619E033" {
+		t.Errorf("an unsigned caller listed %+v, want the one request it just filed", listed.RequestedQuotas)
+	}
+}

--- a/emulator/servicequotas_plugin.go
+++ b/emulator/servicequotas_plugin.go
@@ -39,7 +39,13 @@ func (p *ServiceQuotasPlugin) Initialize(_ context.Context, cfg PluginConfig) er
 func (p *ServiceQuotasPlugin) Shutdown(_ context.Context) error { return nil }
 
 // HandleRequest dispatches a Service Quotas JSON-protocol request.
-func (p *ServiceQuotasPlugin) HandleRequest(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+//
+// The three quota-increase operations take the caller's account, because a quota
+// increase belongs to the account that filed it. The four read-only ones do not:
+// the quota table is per-service and identical for every caller, so threading an
+// account into them would imply a per-account value that substrate does not model
+// and nothing can set.
+func (p *ServiceQuotasPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	switch req.Operation {
 	case "ListServices":
 		return p.listServices(req)
@@ -50,11 +56,11 @@ func (p *ServiceQuotasPlugin) HandleRequest(_ *RequestContext, req *AWSRequest) 
 	case "GetAWSDefaultServiceQuota":
 		return p.getAWSDefaultServiceQuota(req)
 	case "RequestServiceQuotaIncrease":
-		return p.requestServiceQuotaIncrease(req)
+		return p.requestServiceQuotaIncrease(sqAccountID(reqCtx), req)
 	case "ListRequestedServiceQuotaChangesByService":
-		return p.listRequestedServiceQuotaChangesByService(req)
+		return p.listRequestedServiceQuotaChangesByService(sqAccountID(reqCtx), req)
 	case "GetRequestedServiceQuotaChange":
-		return p.getRequestedServiceQuotaChange(req)
+		return p.getRequestedServiceQuotaChange(sqAccountID(reqCtx), req)
 	default:
 		return nil, &AWSError{
 			Code:       "InvalidAction",
@@ -62,6 +68,20 @@ func (p *ServiceQuotasPlugin) HandleRequest(_ *RequestContext, req *AWSRequest) 
 			HTTPStatus: http.StatusBadRequest,
 		}
 	}
+}
+
+// sqAccountID returns the account a quota-increase record belongs to.
+//
+// A nil context, or one carrying no account, falls back to the same placeholder
+// every increase used to be filed under (#624). That is not a guess about the
+// caller: it is the account substrate's own parser assigns a request it cannot
+// attribute, so a plugin driven directly by a unit test keeps landing where it
+// always did rather than under "".
+func sqAccountID(reqCtx *RequestContext) string {
+	if reqCtx == nil || reqCtx.AccountID == "" {
+		return fallbackAccountID
+	}
+	return reqCtx.AccountID
 }
 
 // --- State helpers -----------------------------------------------------------
@@ -177,7 +197,7 @@ func (p *ServiceQuotasPlugin) getAWSDefaultServiceQuota(req *AWSRequest) (*AWSRe
 	return p.getServiceQuota(req)
 }
 
-func (p *ServiceQuotasPlugin) requestServiceQuotaIncrease(req *AWSRequest) (*AWSResponse, error) {
+func (p *ServiceQuotasPlugin) requestServiceQuotaIncrease(accountID string, req *AWSRequest) (*AWSResponse, error) {
 	var input struct {
 		ServiceCode  string  `json:"ServiceCode"`
 		QuotaCode    string  `json:"QuotaCode"`
@@ -189,10 +209,6 @@ func (p *ServiceQuotasPlugin) requestServiceQuotaIncrease(req *AWSRequest) (*AWS
 	if input.ServiceCode == "" || input.QuotaCode == "" {
 		return nil, &AWSError{Code: "ValidationException", Message: "ServiceCode and QuotaCode are required", HTTPStatus: http.StatusBadRequest}
 	}
-
-	// Use a placeholder account ID since RequestContext is not passed here.
-	// The account ID will be pulled from req.AccountID if available in future.
-	accountID := "000000000000"
 
 	id := generateSQSMessageID() // reuse UUID generator
 
@@ -224,7 +240,7 @@ func (p *ServiceQuotasPlugin) requestServiceQuotaIncrease(req *AWSRequest) (*AWS
 	})
 }
 
-func (p *ServiceQuotasPlugin) listRequestedServiceQuotaChangesByService(req *AWSRequest) (*AWSResponse, error) {
+func (p *ServiceQuotasPlugin) listRequestedServiceQuotaChangesByService(accountID string, req *AWSRequest) (*AWSResponse, error) {
 	var input struct {
 		ServiceCode string `json:"ServiceCode"`
 	}
@@ -232,7 +248,6 @@ func (p *ServiceQuotasPlugin) listRequestedServiceQuotaChangesByService(req *AWS
 		_ = json.Unmarshal(req.Body, &input)
 	}
 
-	accountID := "000000000000"
 	ctx := context.Background()
 
 	ids, err := p.loadIncreaseIDs(ctx, accountID)
@@ -259,7 +274,7 @@ func (p *ServiceQuotasPlugin) listRequestedServiceQuotaChangesByService(req *AWS
 	})
 }
 
-func (p *ServiceQuotasPlugin) getRequestedServiceQuotaChange(req *AWSRequest) (*AWSResponse, error) {
+func (p *ServiceQuotasPlugin) getRequestedServiceQuotaChange(accountID string, req *AWSRequest) (*AWSResponse, error) {
 	var input struct {
 		RequestID string `json:"RequestId"`
 	}
@@ -267,7 +282,6 @@ func (p *ServiceQuotasPlugin) getRequestedServiceQuotaChange(req *AWSRequest) (*
 		return nil, &AWSError{Code: "SerializationException", Message: err.Error(), HTTPStatus: http.StatusBadRequest}
 	}
 
-	accountID := "000000000000"
 	qi, err := p.loadIncrease(context.Background(), accountID, input.RequestID)
 	if err != nil {
 		return nil, err

--- a/emulator/signed_request_test.go
+++ b/emulator/signed_request_test.go
@@ -1,0 +1,153 @@
+package emulator_test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// This file holds the shared machinery for a test that needs to be *a particular
+// account*. It exists because most of substrate's tests cannot be: they send no
+// Authorization header, and extractAccount answers 000000000000 for a request
+// without one and 123456789012 for any AKIA-prefixed key. So every caller in them
+// is the same caller, which is why both #623 and #624 — two different services
+// answering as if there were only ever one account — survived a green suite.
+//
+// Reaching a second identity means a CredentialRegistry, and a registry is also
+// what switches SigV4 verification on, so these requests carry real signatures.
+// The signing algorithm is reimplemented here rather than called into the
+// emulator, so a mistake in substrate's own signing cannot make a test pass by
+// agreeing with it.
+
+// signedRequestTarget names the wire details of one service's JSON-target
+// endpoint, so a signed request can be built for it.
+type signedRequestTarget struct {
+	// host is the Host header, which is one of the signals the parser uses to
+	// route a request to a service.
+	host string
+	// target is the X-Amz-Target prefix, "Organizations_20161128" and the like.
+	// The operation is appended to it.
+	target string
+	// signingName is the service field of the SigV4 credential scope. It is not
+	// always the service name — Service Quotas signs as servicequotasv20190624 —
+	// and VerifySigV4 derives the signing key from whatever is in the header, so
+	// this only has to be what a real SDK would send.
+	signingName string
+}
+
+// signedRequest posts an operation to a JSON-target service, signed as the given
+// account.
+//
+// The account must have been registered with the server by
+// [emulator.StartTestServerWithAccounts] or [emulator.TestServer.RegisterAccount];
+// an unregistered key is InvalidClientTokenId 403 before any plugin sees it.
+func signedRequest(t *testing.T, ts *emulator.TestServer, tgt signedRequestTarget,
+	account, op string, body any,
+) *http.Response {
+	t.Helper()
+
+	creds, ok := ts.CredentialsFor(account)
+	if !ok {
+		t.Fatalf("no credential registered for account %s", account)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", op, err)
+	}
+
+	// A fixed instant rather than time.Now: the signature covers the date, and a
+	// test that depends on the wall clock is exactly what CLAUDE.md forbids.
+	const dateTime = "20260101T120000Z"
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("build %s request: %v", op, err)
+	}
+	req.Host = tgt.host
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", tgt.target+"."+op)
+	req.Header.Set("X-Amz-Date", dateTime)
+	req.Header.Set("Authorization", sigV4Header(
+		tgt.host, tgt.signingName, dateTime, data, creds.AccessKeyID, creds.SecretAccessKey))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s as %s: %v", op, account, err)
+	}
+	return resp
+}
+
+// sigV4Header computes a valid SigV4 Authorization header for a POST to "/" with
+// the host and x-amz-date headers signed.
+func sigV4Header(host, signingName, dateTime string, body []byte, accessKey, secretKey string) string {
+	const (
+		region        = "us-east-1"
+		signedHeaders = "host;x-amz-date"
+	)
+	date := dateTime[:8]
+
+	bodyHash := sha256.Sum256(body)
+	canonicalReq := strings.Join([]string{
+		http.MethodPost,
+		"/",
+		"",
+		"host:" + host + "\n" + "x-amz-date:" + dateTime + "\n",
+		signedHeaders,
+		hex.EncodeToString(bodyHash[:]),
+	}, "\n")
+
+	canonicalHash := sha256.Sum256([]byte(canonicalReq))
+	credScope := date + "/" + region + "/" + signingName + "/aws4_request"
+	stringToSign := "AWS4-HMAC-SHA256\n" + dateTime + "\n" + credScope + "\n" +
+		hex.EncodeToString(canonicalHash[:])
+
+	mac := func(key, data []byte) []byte {
+		h := hmac.New(sha256.New, key)
+		h.Write(data)
+		return h.Sum(nil)
+	}
+	signing := mac(mac(mac(mac([]byte("AWS4"+secretKey), []byte(date)), []byte(region)),
+		[]byte(signingName)), []byte("aws4_request"))
+
+	return fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		accessKey, credScope, signedHeaders, hex.EncodeToString(mac(signing, []byte(stringToSign))))
+}
+
+// decodeAWSResponse decodes a JSON-protocol response into out, returning the
+// status and the error code a refusal carries.
+//
+// The code is returned separately rather than left in out because a refusal and a
+// success have different shapes, and a test asserting on a refusal cares about
+// which one it got — not about the message text, which is prose.
+func decodeAWSResponse(t *testing.T, resp *http.Response, out any) (int, string) {
+	t.Helper()
+	defer resp.Body.Close() //nolint:errcheck
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var errShape struct {
+		Type    string `json:"__type"`
+		Message string `json:"message"`
+	}
+	if unmarshalErr := json.Unmarshal(raw, &errShape); unmarshalErr == nil && errShape.Type != "" {
+		return resp.StatusCode, errShape.Type
+	}
+	if out != nil {
+		if unmarshalErr := json.Unmarshal(raw, out); unmarshalErr != nil {
+			t.Fatalf("decode %s: %v", raw, unmarshalErr)
+		}
+	}
+	return resp.StatusCode, ""
+}


### PR DESCRIPTION
## What

`ServiceQuotasPlugin.HandleRequest` discarded its `*RequestContext` (`_ *RequestContext`) and the three quota-increase operations each hardcoded the literal `000000000000`. So two accounts sharing one emulator shared one pile of requests:

- a consumer reading `ListRequestedServiceQuotaChangesByService` to decide whether it had already asked for a raise finds **another account's** request and skips filing its own
- `GetRequestedServiceQuotaChange` hands over a request by ID to any caller — and an ID is guessable

`increaseKey(accountID, id)` already keyed by account. It was just always handed the same one.

## How

`HandleRequest` takes a named `reqCtx` and passes `sqAccountID(reqCtx)` to the three increase handlers.

**The four read-only operations still take no account, deliberately.** The quota table is per-service and identical for every caller, so threading an account into `ListServices`/`ListServiceQuotas`/`GetServiceQuota`/`GetAWSDefaultServiceQuota` would imply a per-account value substrate does not model and nothing can set.

**An unattributed request still lands under `000000000000`.** That is not a leftover: it is what `parser.extractAccount` answers for a request with no `Authorization` header, so the placeholder is the *fallback* rather than the default. Existing fixtures that file an increase without signing keep working, and a plugin driven directly by a unit test lands where it always did rather than under `""`.

## Why the existing tests could not see this

They are all one caller. Nothing in the repository could authenticate as a second account until #623 added `StartTestServerWithAccounts`, so "everyone's requests" and "my requests" were the same set and no assertion could tell them apart. The signing helper is hoisted out of the #623 test file into `signed_request_test.go` for that reason — both defects have the same root cause, a service answering as if there were only ever one account, and both need the same seam to catch.

One detail worth naming: the test signs as `servicequotasv20190624`, not `servicequotas`. That versioned form is what aws-sdk-go-v2 puts in the credential scope, and `parser.go` carries an alias for exactly it. Signing as the plugin name would test a request no SDK sends — the same class of gap #610 was.

## Verification

- `make test` (race detector) — green; `golangci-lint run ./...` — 0 issues; `gofmt`/`go vet` clean.
- **Mutation-tested**, CAUGHT: `sqAccountID` forced to always return the placeholder → `TestServiceQuotas_IncreasesAreFiledUnderTheCaller` fails.

## Compatibility

Quota increase requests are now filed under the **caller's** account instead of `000000000000`. A fixture that signs its requests and then asserts on state under the placeholder will need updating; one that does not sign is unaffected.

Closes #624