### PR TITLE
feat(account): emulate the Account Management Region opt-in API (#629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **The Account Management Region opt-in API is now emulated** (#629): `ListRegions`,
+  `GetRegionOptStatus`, `EnableRegion` and `DisableRegion`. There was no `account`
+  namespace at all, so every one of them fell through to "service not emulated" and a
+  consumer that baselines an account's usable Regions before deploying anything could
+  not be tested against substrate. Found by driving a shipped consumer against
+  `substrate server`, not by reading the API model.
+
+  `ListRegions` reports all 34 Regions: 17 `ENABLED_BY_DEFAULT` and 17 `DISABLED`
+  until enabled, with `RegionOptStatusContains` filtering and `MaxResults`/`NextToken`
+  paging (bounds 1–50, from the model's own shape). `AccountId` targets a member
+  account of the caller's organization, resolved through the **same** member→management
+  index #623 added rather than a second copy of it — two answers to "who manages this
+  account" is one too many.
+
+  An opt is asynchronous and **resolves on observation**, following
+  `resolveCreateAccountStatus`: the first `GetRegionOptStatus` reports `ENABLING`, the
+  next reports `ENABLED`, and it never moves again. `ListRegions` resolves identically,
+  so a caller polling the listing and one polling a single Region cannot contradict
+  each other. Reporting the in-flight status on the *first* observation is deliberate
+  and differs from `CreateAccount`: `EnableRegion` has no output shape, so a poll is
+  the only place `ENABLING` is ever visible, and resolving sooner would leave a
+  consumer's in-flight branch — the branch that exists because AWS takes "a few
+  minutes to several hours" here — unexecutable. Clock-driven transitions remain #514's
+  subject.
+
+  An opt is **not** an observation. Enabling a Region that is already `ENABLED` or
+  `ENABLING` succeeds silently and rewrites nothing, which is what makes an "ensure
+  these Regions are on" routine safe to re-run; writing `ENABLING` over `ENABLED` would
+  make the Region go backwards for a waiter that had already finished.
+
+  One correction to the issue's own framing: disabling a default Region is
+  `ValidationException` with reason `invalidRegionOptTarget`, **not** the
+  `ConstraintViolationException` #629 named — the `account/2021-02-01` model declares
+  no such error for any operation, so a consumer catching one could never match. The
+  reason rides at the front of the message, because the REST-JSON error document has
+  no `reason` member to put it in, and the message also distinguishes a default Region
+  from an unknown one: the code and the reason are identical for both, so the message
+  is the only thing that tells them apart.
+
+  A control-plane seed (`POST`/`DELETE /v1/account/region-opt-status`, Region code or
+  `"*"`) pins what an observation reports. It is the only route to a status a sequence
+  of API calls cannot produce — a Region held in `ENABLING`, and with it a waiter's
+  timeout branch and the `ConflictException` (409) an opposite opt gets mid-flight. A
+  seed naming a **default** Region is refused rather than ignored: that status is fixed
+  before a seed is consulted, so an accepted seed would leave the test asserting
+  nothing.
+
+  Two published limits are deliberately not modelled and the docs say why: the 6
+  in-progress requests per account, and a per-organization limit the same guide gives
+  as 50 in one section and 20 in another. A guessed `TooManyRequestsException` boundary
+  refuses requests AWS accepts, and there is no way to choose between two published
+  numbers without making one wrong. The remaining eleven operations in the model —
+  alternate contacts, the primary contact, the account name, the primary email — are
+  out of scope.
+
+  `ec2SeededRegions` stays a separate, smaller list. It answers a different question —
+  which Regions EC2 reports, not which ones an account has opted into — and unifying
+  them would make every EC2 fixture's Region list depend on this table.
 - **A test server can now be called as more than one account**
   (`StartTestServerWithAccounts`, `TestServer.RegisterAccount`,
   `TestServer.CredentialsFor`) (#623). No in-repo test could authenticate as a

--- a/cmd/gen-service-reference/main.go
+++ b/cmd/gen-service-reference/main.go
@@ -50,6 +50,7 @@ type pluginMeta struct {
 // meta maps each registered plugin name to its documentation metadata. Adding a
 // plugin to the registry without a matching entry here fails generation (and CI).
 var meta = map[string]pluginMeta{
+	"account":              {"Account Management", "REST/JSON"},
 	"acm":                  {"ACM", "JSON"},
 	"apigateway":           {"API Gateway (REST)", "REST/JSON"},
 	"apigatewayv2":         {"API Gateway (HTTP)", "REST/JSON"},

--- a/docs/services.md
+++ b/docs/services.md
@@ -3,7 +3,7 @@
 ## Coverage matrix
 
 <!-- BEGIN GENERATED COVERAGE MATRIX -->
-Substrate ships **65 built-in service plugins**. This section is generated
+Substrate ships **66 built-in service plugins**. This section is generated
 from the plugin registry (`make docs-reference`), so the count and plugin list
 cannot drift from the implementation. The live count is also available from the
 `/ready` endpoint (`curl http://localhost:4566/ready`). Per-service operation,
@@ -11,71 +11,72 @@ CloudFormation, and cost detail follows below the matrix.
 
 | # | Service | Plugin name | Protocol |
 |---|---------|-------------|----------|
-| 1 | ACM | `acm` | JSON |
-| 2 | API Gateway (REST) | `apigateway` | REST/JSON |
-| 3 | API Gateway (HTTP) | `apigatewayv2` | REST/JSON |
-| 4 | AppSync | `appsync` | REST/JSON |
-| 5 | Athena | `athena` | JSON |
-| 6 | Backup | `backup` | REST/JSON |
-| 7 | Batch | `batch` | REST/JSON |
-| 8 | Bedrock Runtime | `bedrock-runtime` | REST/JSON |
-| 9 | Budgets | `budgets` | JSON |
-| 10 | Cost Explorer | `ce` | JSON |
-| 11 | CloudFormation | `cloudformation` | Query |
-| 12 | CloudFront | `cloudfront` | REST/XML |
-| 13 | CloudTrail | `cloudtrail` | JSON |
-| 14 | CodeBuild | `codebuild` | JSON |
-| 15 | CodeDeploy | `codedeploy` | JSON |
-| 16 | CodePipeline | `codepipeline` | JSON |
-| 17 | Cognito Identity | `cognito-identity` | JSON |
-| 18 | Cognito Identity Provider | `cognito-idp` | JSON |
-| 19 | DynamoDB | `dynamodb` | JSON |
-| 20 | EC2 / VPC | `ec2` | Query |
-| 21 | ECR | `ecr` | JSON |
-| 22 | ECS | `ecs` | JSON |
-| 23 | EFS | `efs` | REST/JSON |
-| 24 | ElastiCache | `elasticache` | Query |
-| 25 | ELBv2 | `elasticloadbalancing` | Query |
-| 26 | EMR Serverless | `emrserverless` | REST/JSON |
-| 27 | EventBridge | `eventbridge` | JSON |
-| 28 | API Gateway (execute-api) | `execute-api` | REST/JSON |
-| 29 | Kinesis Data Firehose | `firehose` | JSON |
-| 30 | FSx | `fsx` | JSON |
-| 31 | Glue | `glue` | JSON |
-| 32 | Health | `health` | JSON |
-| 33 | IAM | `iam` | Query |
-| 34 | Kinesis Data Streams | `kinesis` | JSON |
-| 35 | KMS | `kms` | JSON |
-| 36 | Lambda | `lambda` | REST/JSON |
-| 37 | CloudWatch Logs | `logs` | JSON |
-| 38 | CloudWatch | `monitoring` | Query |
-| 39 | MSK | `msk` | REST/JSON |
-| 40 | HealthOmics | `omics` | REST/JSON |
-| 41 | OpenSearch | `opensearch` | REST/JSON |
-| 42 | Organizations | `organizations` | JSON |
-| 43 | Price List Query API | `pricing` | JSON |
-| 44 | QuickSight | `quicksight` | REST/JSON |
-| 45 | RAM | `ram` | REST/JSON |
-| 46 | RDS | `rds` | Query |
-| 47 | Redshift | `redshift` | Query |
-| 48 | Redshift Data API | `redshift-data` | JSON |
-| 49 | Route 53 | `route53` | REST/XML |
-| 50 | S3 | `s3` | REST/XML |
-| 51 | SageMaker | `sagemaker` | JSON |
-| 52 | EventBridge Scheduler | `scheduler` | REST/JSON |
-| 53 | Secrets Manager | `secretsmanager` | JSON |
-| 54 | Service Quotas | `servicequotas` | JSON |
-| 55 | SES v2 | `sesv2` | REST/JSON |
-| 56 | SNS | `sns` | Query |
-| 57 | SQS | `sqs` | JSON |
-| 58 | SSM | `ssm` | JSON |
-| 59 | SSO / Identity Store | `sso` | REST/JSON |
-| 60 | Step Functions | `states` | JSON |
-| 61 | STS | `sts` | Query |
-| 62 | Resource Groups Tagging | `tagging` | JSON |
-| 63 | Timestream | `timestream` | JSON |
-| 64 | Transfer Family | `transfer` | JSON |
-| 65 | WAFv2 | `wafv2` | JSON |
+| 1 | Account Management | `account` | REST/JSON |
+| 2 | ACM | `acm` | JSON |
+| 3 | API Gateway (REST) | `apigateway` | REST/JSON |
+| 4 | API Gateway (HTTP) | `apigatewayv2` | REST/JSON |
+| 5 | AppSync | `appsync` | REST/JSON |
+| 6 | Athena | `athena` | JSON |
+| 7 | Backup | `backup` | REST/JSON |
+| 8 | Batch | `batch` | REST/JSON |
+| 9 | Bedrock Runtime | `bedrock-runtime` | REST/JSON |
+| 10 | Budgets | `budgets` | JSON |
+| 11 | Cost Explorer | `ce` | JSON |
+| 12 | CloudFormation | `cloudformation` | Query |
+| 13 | CloudFront | `cloudfront` | REST/XML |
+| 14 | CloudTrail | `cloudtrail` | JSON |
+| 15 | CodeBuild | `codebuild` | JSON |
+| 16 | CodeDeploy | `codedeploy` | JSON |
+| 17 | CodePipeline | `codepipeline` | JSON |
+| 18 | Cognito Identity | `cognito-identity` | JSON |
+| 19 | Cognito Identity Provider | `cognito-idp` | JSON |
+| 20 | DynamoDB | `dynamodb` | JSON |
+| 21 | EC2 / VPC | `ec2` | Query |
+| 22 | ECR | `ecr` | JSON |
+| 23 | ECS | `ecs` | JSON |
+| 24 | EFS | `efs` | REST/JSON |
+| 25 | ElastiCache | `elasticache` | Query |
+| 26 | ELBv2 | `elasticloadbalancing` | Query |
+| 27 | EMR Serverless | `emrserverless` | REST/JSON |
+| 28 | EventBridge | `eventbridge` | JSON |
+| 29 | API Gateway (execute-api) | `execute-api` | REST/JSON |
+| 30 | Kinesis Data Firehose | `firehose` | JSON |
+| 31 | FSx | `fsx` | JSON |
+| 32 | Glue | `glue` | JSON |
+| 33 | Health | `health` | JSON |
+| 34 | IAM | `iam` | Query |
+| 35 | Kinesis Data Streams | `kinesis` | JSON |
+| 36 | KMS | `kms` | JSON |
+| 37 | Lambda | `lambda` | REST/JSON |
+| 38 | CloudWatch Logs | `logs` | JSON |
+| 39 | CloudWatch | `monitoring` | Query |
+| 40 | MSK | `msk` | REST/JSON |
+| 41 | HealthOmics | `omics` | REST/JSON |
+| 42 | OpenSearch | `opensearch` | REST/JSON |
+| 43 | Organizations | `organizations` | JSON |
+| 44 | Price List Query API | `pricing` | JSON |
+| 45 | QuickSight | `quicksight` | REST/JSON |
+| 46 | RAM | `ram` | REST/JSON |
+| 47 | RDS | `rds` | Query |
+| 48 | Redshift | `redshift` | Query |
+| 49 | Redshift Data API | `redshift-data` | JSON |
+| 50 | Route 53 | `route53` | REST/XML |
+| 51 | S3 | `s3` | REST/XML |
+| 52 | SageMaker | `sagemaker` | JSON |
+| 53 | EventBridge Scheduler | `scheduler` | REST/JSON |
+| 54 | Secrets Manager | `secretsmanager` | JSON |
+| 55 | Service Quotas | `servicequotas` | JSON |
+| 56 | SES v2 | `sesv2` | REST/JSON |
+| 57 | SNS | `sns` | Query |
+| 58 | SQS | `sqs` | JSON |
+| 59 | SSM | `ssm` | JSON |
+| 60 | SSO / Identity Store | `sso` | REST/JSON |
+| 61 | Step Functions | `states` | JSON |
+| 62 | STS | `sts` | Query |
+| 63 | Resource Groups Tagging | `tagging` | JSON |
+| 64 | Timestream | `timestream` | JSON |
+| 65 | Transfer Family | `transfer` | JSON |
+| 66 | WAFv2 | `wafv2` | JSON |
 <!-- END GENERATED COVERAGE MATRIX -->
 
 ---
@@ -4729,6 +4730,131 @@ testing: `CreateAccount` still returns **200**, and only
 ### Cost
 
 Organizations API calls are free.
+
+---
+
+## Account Management
+
+**Endpoint:** `account.{region}.amazonaws.com`
+**Protocol:** REST/JSON (`POST /listRegions`, `/enableRegion`, `/disableRegion`,
+`/getRegionOptStatus` — the operation is in the URL; there is no `X-Amz-Target`)
+
+Substrate emulates the **Region opt-in** half of the Account Management API: which
+Regions an account may use, and the asynchronous opt in and out of the ones that
+are off by default. The other eleven operations in the model — alternate contacts,
+the primary contact, the account name and the primary email — are not emulated.
+
+### Supported operations
+
+| Operation | Notes |
+|-----------|-------|
+| ListRegions | All 34 Regions with their opt status; `RegionOptStatusContains` filters, `MaxResults` 1–50 |
+| GetRegionOptStatus | The poll target; reports the Region name back alongside the status |
+| EnableRegion | **Asynchronous**, empty 200, no output shape; idempotent against the target state |
+| DisableRegion | The same, and refused for a Region that is enabled by default |
+
+### The two Region tables
+
+The 17 **default** Regions — those launched before 2019-03-20 — report
+`ENABLED_BY_DEFAULT` and can be neither enabled nor disabled. The 17 **opt-in**
+Regions report `DISABLED` until an account enables them.
+
+| | Regions |
+|---|---|
+| Default (`ENABLED_BY_DEFAULT`) | `ap-northeast-1`, `ap-northeast-2`, `ap-northeast-3`, `ap-south-1`, `ap-southeast-1`, `ap-southeast-2`, `ca-central-1`, `eu-central-1`, `eu-north-1`, `eu-west-1`, `eu-west-2`, `eu-west-3`, `sa-east-1`, `us-east-1`, `us-east-2`, `us-west-1`, `us-west-2` |
+| Opt-in (`DISABLED` until enabled) | `af-south-1`, `ap-east-1`, `ap-east-2`, `ap-south-2`, `ap-southeast-3`, `ap-southeast-4`, `ap-southeast-5`, `ap-southeast-6`, `ap-southeast-7`, `ca-west-1`, `eu-central-2`, `eu-south-1`, `eu-south-2`, `il-central-1`, `me-central-1`, `me-south-1`, `mx-central-1` |
+
+Both tables come from the
+[Account Management Reference Guide](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-regions.html)
+rather than from the API model, which publishes the `RegionOptStatus` enum but no
+Region list.
+
+**`ec2SeededRegions` is a separate, smaller list** and stays that way. EC2's
+`DescribeRegions` seeds three Regions and answers a different question — which
+Regions EC2 reports, not which ones an account has opted into. Unifying them would
+make every EC2 fixture's Region list depend on this table.
+
+### An opt resolves on observation
+
+`EnableRegion` answers an empty 200 and moves the Region to `ENABLING`. The **first**
+`GetRegionOptStatus` reports `ENABLING`; the next reports `ENABLED`, and it never
+moves again. `DisableRegion` behaves the same way through `DISABLING` to `DISABLED`.
+`ListRegions` resolves identically, so a caller polling through the listing and one
+polling a single Region cannot contradict each other.
+
+Advancing on observation rather than after an interval of the simulated clock is
+what makes the wait testable: enabling a Region takes "a few minutes to several
+hours" in AWS, and a waiter here converges in two polls with no dependence on
+wall-clock or simulated time. The first observation reports the in-flight status
+deliberately — `EnableRegion` has no output shape, so a poll is the only place
+`ENABLING` is ever visible, and resolving before the first report would leave a
+consumer's in-flight branch unexecutable.
+
+An opt is **not** an observation: a redundant `EnableRegion` neither advances the
+record nor rewrites it. Enabling a Region that is already `ENABLED` or `ENABLING`
+succeeds silently, which is what makes an "ensure these Regions are on" routine
+safe to re-run.
+
+### Refusals
+
+Every 400 is `ValidationException`, the only one these operations declare, with the
+reason at the front of the message (`"invalidRegionOptTarget: …"`) — the REST-JSON
+error document has no `reason` member to put it in. `ValidationExceptionReason` has
+exactly two members, and both are used:
+
+| Case | Code | Reason |
+|---|---|---|
+| Enabling or disabling a default Region | `ValidationException` (400) | `invalidRegionOptTarget` |
+| A Region code in neither table | `ValidationException` (400) | `invalidRegionOptTarget` |
+| An `AccountId` that is not a member of the caller's organization, or is the caller itself | `ValidationException` (400) | `invalidRegionOptTarget` / `fieldValidationFailed` |
+| `MaxResults` outside 1–50, a bad `RegionOptStatusContains` member, a missing `RegionName`, an unreadable `NextToken` | `ValidationException` (400) | `fieldValidationFailed` |
+| The opposite opt is still in flight | `ConflictException` (409) | — |
+
+Disabling a default Region is **`ValidationException`, not
+`ConstraintViolationException`** — the `account/2021-02-01` model declares no such
+error for any operation, so a consumer catching one would never match.
+
+### Targeting a member account
+
+`AccountId` names a member account of the caller's organization, resolved through
+the same member→management index Organizations uses; there is no second copy of it.
+The management account cannot specify its own `AccountId` — omit the parameter to
+operate in standalone context — and an account outside the caller's organization is
+refused. Trusted access and a delegated administrator for Account Management are
+not modelled, so the caller must be the management account itself.
+
+### Two limits are deliberately not modelled
+
+AWS documents a limit of **6** region-opt requests in progress per account, and a
+per-organization limit that the same guide gives as **50** in one section and **20**
+in another. Neither is enforced here. A guessed `TooManyRequestsException` boundary
+would refuse requests AWS accepts, and there is no way to pick between two
+published numbers without making one of them wrong.
+
+### Seeding
+
+```bash
+# Pin what every observation of a Region reports, by Region code or "*".
+curl -X POST http://localhost:4566/v1/account/region-opt-status \
+  -d '{"regionName":"af-south-1","status":"ENABLING"}'
+curl -X DELETE 'http://localhost:4566/v1/account/region-opt-status?regionName=af-south-1'
+curl -X DELETE http://localhost:4566/v1/account/region-opt-status
+```
+
+A Region-scoped seed takes precedence over the wildcard, and a seeded status does
+not resolve — that is the point of it. Because an in-flight opt otherwise advances
+on the first observation, the seed is the only way to hold a Region *stuck* in
+`ENABLING`, which is what a waiter's timeout branch and the `ConflictException` an
+opposite opt gets mid-flight both need.
+
+`status` must be a member of the `RegionOptStatus` enum, and a **default** Region
+cannot be seeded: its status is fixed before a seed is ever consulted, so the seed
+would be silently ignored and the test using it would pass while asserting nothing.
+Both are a 400.
+
+### Cost
+
+Account Management API calls are free.
 
 ---
 

--- a/emulator/account_control.go
+++ b/emulator/account_control.go
@@ -1,0 +1,141 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+)
+
+// accountCtrlNamespace is the state namespace for Account Management
+// control-plane (seed) data. It is separate from the account namespace so a seed
+// is not mistaken for an account's real opt state during replay or a state dump.
+const accountCtrlNamespace = "account-ctrl"
+
+// accountCtrlRegionOptStatusKey returns the state key for a seeded Region opt
+// status. Region-scoped seeds use "region_opt_status:{region}"; the wildcard uses
+// "region_opt_status:*".
+func accountCtrlRegionOptStatusKey(region string) string {
+	if region == "" {
+		region = "*"
+	}
+	return "region_opt_status:" + region
+}
+
+// accountSeededRegionOptStatus is a pinned Region opt status.
+//
+// Substrate does not enable anything, so the seed sets what an observation
+// reports. It is the only way to reach a status a sequence of API calls cannot
+// produce: an in-flight ENABLING resolves on first observation, so a test that
+// needs a Region *stuck* mid-flight — to exercise a waiter's timeout, or the
+// ConflictException an opposite opt gets while one is in progress — has to pin it.
+type accountSeededRegionOptStatus struct {
+	// RegionName the seed applies to, or "*" for any Region.
+	RegionName string `json:"regionName"`
+
+	// Status is the RegionOptStatus every observation reports.
+	Status string `json:"status"`
+}
+
+// seededRegionOptStatus returns the pinned status for a Region, if any, matching
+// the exact Region first and then the "*" wildcard. It reports found=false when
+// no seed applies, so the caller falls back to the stored record.
+func (p *AccountPlugin) seededRegionOptStatus(ctx context.Context, region string) (status string, found bool, err error) {
+	for _, key := range []string{accountCtrlRegionOptStatusKey(region), accountCtrlRegionOptStatusKey("*")} {
+		data, getErr := p.state.Get(ctx, accountCtrlNamespace, key)
+		if getErr != nil {
+			return "", false, fmt.Errorf("account seededRegionOptStatus %s: %w", key, getErr)
+		}
+		if data == nil {
+			continue
+		}
+		var seed accountSeededRegionOptStatus
+		if err := json.Unmarshal(data, &seed); err != nil {
+			return "", false, fmt.Errorf("account seededRegionOptStatus %s unmarshal: %w", key, err)
+		}
+		if seed.Status != "" {
+			return seed.Status, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// handleAccountSeedRegionOptStatus handles POST /v1/account/region-opt-status.
+// It pins the status every observation of a Region reports, for a given Region
+// code (default "*"), which is how a test reaches a Region held in ENABLING or
+// DISABLING — a status an unseeded emulator resolves away on first observation.
+// Body: {"regionName":"af-south-1","status":"ENABLING"}.
+func (s *Server) handleAccountSeedRegionOptStatus(w http.ResponseWriter, r *http.Request) {
+	var seed accountSeededRegionOptStatus
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.Status == "" {
+		http.Error(w, `{"error":"status is required"}`, http.StatusBadRequest)
+		return
+	}
+	// A status outside the enum would be reported by GetRegionOptStatus as a value
+	// no SDK enum member matches, so the caller's switch would fall through to its
+	// default and the test would pass without exercising anything.
+	if !slices.Contains(accountRegionOptStatuses, seed.Status) {
+		http.Error(w, fmt.Sprintf(`{"error":"status %q is not a RegionOptStatus"}`, seed.Status), http.StatusBadRequest)
+		return
+	}
+	// A default Region is always ENABLED_BY_DEFAULT, and a seed naming one would be
+	// silently ignored: regionStatus answers for a default Region before it ever
+	// consults a seed. Refusing is the difference between a test that fails and one
+	// that passes while asserting nothing.
+	if seed.RegionName != "" && seed.RegionName != "*" {
+		isDefault, isOptIn := accountRegionKind(seed.RegionName)
+		if isDefault {
+			http.Error(w, fmt.Sprintf(`{"error":"%s is enabled by default; its status cannot be seeded"}`, seed.RegionName), http.StatusBadRequest)
+			return
+		}
+		if !isOptIn {
+			http.Error(w, fmt.Sprintf(`{"error":"%q is not an AWS Region code substrate knows"}`, seed.RegionName), http.StatusBadRequest)
+			return
+		}
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), accountCtrlNamespace, accountCtrlRegionOptStatusKey(seed.RegionName), data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{
+		"ok":         true,
+		"regionName": accountCtrlRegionOptStatusKey(seed.RegionName),
+		"status":     seed.Status,
+	})
+}
+
+// handleAccountClearRegionOptStatus handles DELETE /v1/account/region-opt-status.
+// With ?regionName=... it removes that seed; without it removes all of them,
+// restoring each Region to its stored opt record.
+func (s *Server) handleAccountClearRegionOptStatus(w http.ResponseWriter, r *http.Request) {
+	if region := r.URL.Query().Get("regionName"); region != "" {
+		if err := s.state.Delete(r.Context(), accountCtrlNamespace, accountCtrlRegionOptStatusKey(region)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), accountCtrlNamespace, "region_opt_status:")
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), accountCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}

--- a/emulator/account_plugin.go
+++ b/emulator/account_plugin.go
@@ -1,0 +1,756 @@
+package emulator
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+)
+
+// accountNamespace is the state namespace used by AccountPlugin.
+const accountNamespace = "account"
+
+// Region opt statuses, the RegionOptStatus enum from the account/2021-02-01 API
+// model. A Region is in exactly one of them, and only the middle three are ever
+// stored: a default Region is always ENABLED_BY_DEFAULT and an opt-in Region
+// substrate has never been asked about is DISABLED, so neither needs a record.
+const (
+	// accountRegionEnabled is an opt-in Region whose enable has completed.
+	accountRegionEnabled = "ENABLED"
+
+	// accountRegionEnabling is an opt-in Region with an enable in flight.
+	accountRegionEnabling = "ENABLING"
+
+	// accountRegionDisabling is an opt-in Region with a disable in flight.
+	accountRegionDisabling = "DISABLING"
+
+	// accountRegionDisabled is an opt-in Region that has not been enabled.
+	accountRegionDisabled = "DISABLED"
+
+	// accountRegionEnabledByDefault is a Region launched before 2019-03-20, which
+	// can be neither enabled nor disabled.
+	accountRegionEnabledByDefault = "ENABLED_BY_DEFAULT"
+)
+
+// accountRegionOptStatuses is the RegionOptStatus enum, used to validate a
+// RegionOptStatusContains filter and a seeded status. A value outside it would
+// filter every Region out of a listing, or pin a status no SDK enum member
+// matches, and the caller would read an empty list rather than a refusal.
+var accountRegionOptStatuses = []string{
+	accountRegionEnabled,
+	accountRegionEnabling,
+	accountRegionDisabling,
+	accountRegionDisabled,
+	accountRegionEnabledByDefault,
+}
+
+// accountDefaultRegions are the Regions enabled by default — those launched
+// before 2019-03-20 — which "cannot be enabled or disabled".
+//
+// The API model publishes the RegionOptStatus enum but no Region list, so this
+// table and the opt-in one below come from the AWS Account Management Reference
+// Guide's "Regional availability reference":
+// https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-regions.html
+//
+// This is deliberately not unified with ec2SeededRegions, which seeds three
+// Regions for DescribeRegions and answers a different question — which Regions
+// EC2 reports, not which ones an account has opted into. Merging them would make
+// every EC2 fixture's Region list depend on this table.
+var accountDefaultRegions = []string{
+	"ap-northeast-1",
+	"ap-northeast-2",
+	"ap-northeast-3",
+	"ap-south-1",
+	"ap-southeast-1",
+	"ap-southeast-2",
+	"ca-central-1",
+	"eu-central-1",
+	"eu-north-1",
+	"eu-west-1",
+	"eu-west-2",
+	"eu-west-3",
+	"sa-east-1",
+	"us-east-1",
+	"us-east-2",
+	"us-west-1",
+	"us-west-2",
+}
+
+// accountOptInRegions are the Regions disabled by default — those launched after
+// 2019-03-20 — which must be enabled before use. Same source as
+// accountDefaultRegions.
+var accountOptInRegions = []string{
+	"af-south-1",
+	"ap-east-1",
+	"ap-east-2",
+	"ap-south-2",
+	"ap-southeast-3",
+	"ap-southeast-4",
+	"ap-southeast-5",
+	"ap-southeast-6",
+	"ap-southeast-7",
+	"ca-west-1",
+	"eu-central-2",
+	"eu-south-1",
+	"eu-south-2",
+	"il-central-1",
+	"me-central-1",
+	"me-south-1",
+	"mx-central-1",
+}
+
+// accountMaxResults is the ListRegions MaxResults ceiling, from the model's
+// ListRegionsRequestMaxResultsInteger shape (min 1, max 50).
+const accountMaxResults = 50
+
+// accountMinResults is the ListRegions MaxResults floor, from the same shape.
+const accountMinResults = 1
+
+// AccountRegion is the Region structure ListRegions returns: a Region code and
+// its opt status.
+type AccountRegion struct {
+	// RegionName is the Region code, e.g. "af-south-1".
+	RegionName string `json:"RegionName"`
+
+	// RegionOptStatus is the Region's opt status, a RegionOptStatus enum member.
+	RegionOptStatus string `json:"RegionOptStatus"`
+}
+
+// accountRegionOpt is the stored opt record for one account and one opt-in
+// Region. Only a Region an account has acted on has a record; the absence of one
+// means DISABLED, which is what makes a fresh account's listing correct with no
+// setup at all.
+type accountRegionOpt struct {
+	// Status is the RegionOptStatus the last operation moved the Region to.
+	Status string `json:"status"`
+
+	// UpdatedAt is the simulated instant the status was last written, recorded so
+	// a state dump is readable. Nothing reads it back: the ENABLING → ENABLED
+	// transition is advance-on-observation, not clock-driven.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// AccountPlugin emulates the AWS Account Management API's Region opt-in
+// operations: ListRegions, EnableRegion, DisableRegion and GetRegionOptStatus.
+//
+// The service is rest-json with no X-Amz-Target, so the operation lives in the
+// URL and nothing else; parseAccountOperation is what recovers it, both here and
+// for the pipeline via operationResolvers.
+//
+// The other eleven operations in the account/2021-02-01 model — alternate
+// contacts, the primary contact, the account name and the primary email — are not
+// emulated. #629 asked for the four Region operations, which are what a consumer
+// baselining an account's enabled Regions calls.
+type AccountPlugin struct {
+	state  StateManager
+	logger Logger
+	tc     *TimeController
+}
+
+// Name returns the service name "account".
+func (p *AccountPlugin) Name() string { return accountNamespace }
+
+// Initialize sets up the AccountPlugin with the provided configuration.
+func (p *AccountPlugin) Initialize(_ context.Context, cfg PluginConfig) error {
+	p.state = cfg.State
+	p.logger = cfg.Logger
+	if tc, ok := cfg.Options["time_controller"].(*TimeController); ok {
+		p.tc = tc
+	} else {
+		p.tc = NewTimeController(time.Now())
+	}
+	return nil
+}
+
+// Shutdown is a no-op for AccountPlugin.
+func (p *AccountPlugin) Shutdown(_ context.Context) error { return nil }
+
+// HandleRequest dispatches an Account Management rest-json request.
+func (p *AccountPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	op := parseAccountOperation(requestMethod(req), req.Path)
+	switch op {
+	case "ListRegions":
+		return p.listRegions(reqCtx, req)
+	case "EnableRegion":
+		return p.enableRegion(reqCtx, req)
+	case "DisableRegion":
+		return p.disableRegion(reqCtx, req)
+	case "GetRegionOptStatus":
+		return p.getRegionOptStatus(reqCtx, req)
+	default:
+		return nil, &AWSError{
+			Code:       "InvalidAction",
+			Message:    fmt.Sprintf("AccountPlugin: unsupported operation %q", op),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+}
+
+// parseAccountOperation maps an HTTP method and path to an Account Management
+// operation name, and returns "" for a path that is not one of the four Region
+// routes.
+//
+// Every requestUri in the model is a single flat segment and every method is
+// POST, so this is an exact match on the path rather than a prefix walk. It is
+// idempotent: an already-resolved operation name is not a path, so it falls
+// through to "" and resolveOperationName leaves req.Operation alone.
+func parseAccountOperation(method, path string) string {
+	if method != http.MethodPost {
+		return ""
+	}
+	switch strings.TrimSuffix(path, "/") {
+	case "/listRegions":
+		return "ListRegions"
+	case "/enableRegion":
+		return "EnableRegion"
+	case "/disableRegion":
+		return "DisableRegion"
+	case "/getRegionOptStatus":
+		return "GetRegionOptStatus"
+	default:
+		return ""
+	}
+}
+
+// --- errors ------------------------------------------------------------------
+
+// accountValidation returns ValidationException with a reason from the model's
+// ValidationExceptionReason enum, which has exactly two members:
+// invalidRegionOptTarget and fieldValidationFailed.
+//
+// The reason is carried in the message as well as in the "reason" member, because
+// substrate's rest-json error document is {message, Message, Code} plus the
+// x-amzn-errortype header — there is no place for a modeled member, so a caller
+// that needs to tell the two apart has only the message to read.
+func accountValidation(reason, message string) *AWSError {
+	return &AWSError{
+		Code:       "ValidationException",
+		Message:    fmt.Sprintf("%s: %s", reason, message),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// accountConflict returns ConflictException, which the model declares for
+// EnableRegion and DisableRegion at HTTP 409. It is the answer to an opt whose
+// opposite is still in flight — "this happens if you try to enable a Region that
+// is currently being disabled (in a status of DISABLING)".
+func accountConflict(message string) *AWSError {
+	return &AWSError{
+		Code:       "ConflictException",
+		Message:    message,
+		HTTPStatus: http.StatusConflict,
+	}
+}
+
+// --- state -------------------------------------------------------------------
+
+// accountRegionOptKey is the state key for one account's record of one Region.
+func accountRegionOptKey(acct, region string) string {
+	return "region_opt:" + acct + "/" + region
+}
+
+// loadRegionOpt returns the stored opt record for a Region, or nil when the
+// account has never acted on it.
+func (p *AccountPlugin) loadRegionOpt(ctx context.Context, acct, region string) (*accountRegionOpt, error) {
+	data, err := p.state.Get(ctx, accountNamespace, accountRegionOptKey(acct, region))
+	if err != nil {
+		return nil, fmt.Errorf("account loadRegionOpt %s/%s: %w", acct, region, err)
+	}
+	if data == nil {
+		return nil, nil //nolint:nilnil // (nil, nil) = "never acted on", which means DISABLED.
+	}
+	var opt accountRegionOpt
+	if err := json.Unmarshal(data, &opt); err != nil {
+		return nil, fmt.Errorf("account loadRegionOpt %s/%s unmarshal: %w", acct, region, err)
+	}
+	return &opt, nil
+}
+
+// saveRegionOpt writes the opt record for a Region.
+func (p *AccountPlugin) saveRegionOpt(ctx context.Context, acct, region, status string) error {
+	data, err := json.Marshal(accountRegionOpt{Status: status, UpdatedAt: p.tc.Now()})
+	if err != nil {
+		return fmt.Errorf("account saveRegionOpt marshal: %w", err)
+	}
+	if err := p.state.Put(ctx, accountNamespace, accountRegionOptKey(acct, region), data); err != nil {
+		return fmt.Errorf("account saveRegionOpt %s/%s: %w", acct, region, err)
+	}
+	return nil
+}
+
+// --- Region classification ---------------------------------------------------
+
+// accountRegionKind reports whether a Region code is a default Region, an opt-in
+// Region, or neither.
+func accountRegionKind(region string) (isDefault, isOptIn bool) {
+	return slices.Contains(accountDefaultRegions, region), slices.Contains(accountOptInRegions, region)
+}
+
+// accountUnknownRegion is the refusal for a Region code in neither table. The
+// model's only fitting reason is invalidRegionOptTarget — there is no
+// "no such Region" error and no ResourceNotFoundException in this model at all.
+func accountUnknownRegion(region string) *AWSError {
+	return accountValidation("invalidRegionOptTarget",
+		fmt.Sprintf("%q is not an AWS Region code substrate knows", region))
+}
+
+// regionStatus returns the opt status of a Region for an account, advancing an
+// in-flight opt towards its terminal status as a side effect of the observation.
+//
+// Only ListRegions and GetRegionOptStatus call this. EnableRegion and
+// DisableRegion read through peekRegionStatus instead, because an opt is not an
+// observation: letting a redundant EnableRegion advance the record would make a
+// consumer's "ensure" pass converge a Region a poller had not yet seen finish.
+func (p *AccountPlugin) regionStatus(ctx context.Context, acct, region string) (status string, err error) {
+	status, stored, err := p.peekRegionStatus(ctx, acct, region)
+	if err != nil || !stored {
+		return status, err
+	}
+	return p.resolveRegionOpt(ctx, acct, region, status)
+}
+
+// peekRegionStatus returns the opt status of a Region without advancing anything.
+//
+// stored reports whether the status came from the account's own record, which is
+// the only case an observation may advance: a default Region's status is fixed, an
+// unopted Region has no record to move, and a seeded status is pinned precisely so
+// that it does not move.
+func (p *AccountPlugin) peekRegionStatus(ctx context.Context, acct, region string) (status string, stored bool, err error) {
+	if isDefault, isOptIn := accountRegionKind(region); isDefault {
+		return accountRegionEnabledByDefault, false, nil
+	} else if !isOptIn {
+		return "", false, accountUnknownRegion(region)
+	}
+
+	if seeded, found, seedErr := p.seededRegionOptStatus(ctx, region); seedErr != nil {
+		return "", false, seedErr
+	} else if found {
+		return seeded, false, nil
+	}
+
+	opt, err := p.loadRegionOpt(ctx, acct, region)
+	if err != nil {
+		return "", false, err
+	}
+	if opt == nil {
+		return accountRegionDisabled, false, nil
+	}
+	return opt.Status, true, nil
+}
+
+// resolveRegionOpt reports an in-flight opt's current status and advances the
+// stored record to its terminal one, so the observation after this one reports
+// ENABLED or DISABLED and every observation after that reports the same thing.
+//
+// Advancing on observation rather than after an interval of the simulated clock
+// follows resolveCreateAccountStatus, and for the same reason: a waiter converges
+// in a bounded number of polls with no dependence on wall-clock or simulated
+// time, and a terminal status that flipped back to in-flight would make a waiter
+// comparing successive polls loop forever. Enabling a Region takes "a few minutes
+// to several hours" in AWS, which is exactly the wait a test must not have to
+// actually spend. Clock-driven transitions are #514's subject; choosing a duration
+// here would front-run that design.
+//
+// It differs from resolveCreateAccountStatus in one way that matters: the *first*
+// observation reports the in-flight status, and the second reports the terminal
+// one. CreateAccount hands back an IN_PROGRESS CreateAccountStatus in its own
+// response, so a consumer sees the in-flight state without polling at all;
+// EnableRegion has no output shape, so a poll is the only place ENABLING is ever
+// observable. Resolving before the first report would make ENABLING and DISABLING
+// unreachable, and a waiter's in-flight branch — the branch that exists precisely
+// because AWS takes hours here — would never execute in a test.
+func (p *AccountPlugin) resolveRegionOpt(ctx context.Context, acct, region, status string) (string, error) {
+	var terminal string
+	switch status {
+	case accountRegionEnabling:
+		terminal = accountRegionEnabled
+	case accountRegionDisabling:
+		terminal = accountRegionDisabled
+	default:
+		return status, nil
+	}
+	if err := p.saveRegionOpt(ctx, acct, region, terminal); err != nil {
+		return "", err
+	}
+	return status, nil
+}
+
+// --- Operations --------------------------------------------------------------
+
+// listRegions reports every Region substrate knows with its opt status for the
+// caller's account: the 17 default Regions as ENABLED_BY_DEFAULT and the 17
+// opt-in Regions as their stored status, defaulting to DISABLED.
+//
+// An in-flight opt resolves here as well as in GetRegionOptStatus. If it did not,
+// a caller polling through the listing would read ENABLING forever while a
+// GetRegionOptStatus of the same Region reported ENABLED — two observations of
+// one Region contradicting each other.
+func (p *AccountPlugin) listRegions(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var input struct {
+		AccountID               string   `json:"AccountId"`
+		MaxResults              *int     `json:"MaxResults"`
+		NextToken               string   `json:"NextToken"`
+		RegionOptStatusContains []string `json:"RegionOptStatusContains"`
+	}
+	if err := accountUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	for _, status := range input.RegionOptStatusContains {
+		if !slices.Contains(accountRegionOptStatuses, status) {
+			return nil, accountValidation("fieldValidationFailed",
+				fmt.Sprintf("RegionOptStatusContains member %q is not a RegionOptStatus", status))
+		}
+	}
+	if input.MaxResults != nil && (*input.MaxResults < accountMinResults || *input.MaxResults > accountMaxResults) {
+		return nil, accountValidation("fieldValidationFailed",
+			fmt.Sprintf("MaxResults must be between %d and %d, got %d",
+				accountMinResults, accountMaxResults, *input.MaxResults))
+	}
+
+	goCtx := context.Background()
+	target, err := p.targetAccount(reqCtx, input.AccountID)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]string, 0, len(accountDefaultRegions)+len(accountOptInRegions))
+	all = append(all, accountDefaultRegions...)
+	all = append(all, accountOptInRegions...)
+	sort.Strings(all)
+
+	matched := make([]AccountRegion, 0, len(all))
+	for _, region := range all {
+		status, statusErr := p.regionStatus(goCtx, target, region)
+		if statusErr != nil {
+			return nil, statusErr
+		}
+		if len(input.RegionOptStatusContains) > 0 &&
+			!slices.Contains(input.RegionOptStatusContains, status) {
+			continue
+		}
+		matched = append(matched, AccountRegion{RegionName: region, RegionOptStatus: status})
+	}
+
+	limit := accountMaxResults
+	if input.MaxResults != nil {
+		limit = *input.MaxResults
+	}
+	page, next, err := accountPaginate(matched, input.NextToken, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	out := map[string]any{"Regions": page}
+	if next != "" {
+		out["NextToken"] = next
+	}
+	return accountJSONResponse(out, "listRegions")
+}
+
+// getRegionOptStatus is the poll target for an enable or a disable. It reports
+// the Region code back alongside the status, which is what lets a caller confirm
+// it is reading the Region it asked about.
+func (p *AccountPlugin) getRegionOptStatus(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	input, err := p.regionInput(req)
+	if err != nil {
+		return nil, err
+	}
+	target, err := p.targetAccount(reqCtx, input.AccountID)
+	if err != nil {
+		return nil, err
+	}
+	status, err := p.regionStatus(context.Background(), target, input.RegionName)
+	if err != nil {
+		return nil, err
+	}
+	return accountJSONResponse(map[string]any{
+		"RegionName":      input.RegionName,
+		"RegionOptStatus": status,
+	}, "getRegionOptStatus")
+}
+
+// enableRegion opts an account into a Region. It answers an empty 200: the model
+// gives EnableRegion no output shape, and the status is observed through
+// GetRegionOptStatus.
+//
+// It is idempotent against the target state rather than the call: enabling a
+// Region already ENABLED or ENABLING succeeds silently and changes nothing. That
+// is what makes an "ensure these Regions are on" routine safe to re-run, which is
+// the shape of the consumer #629 came from.
+func (p *AccountPlugin) enableRegion(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	return p.opt(reqCtx, req, accountRegionEnabling)
+}
+
+// disableRegion opts an account out of a Region, with the same empty 200 and the
+// same idempotence as enableRegion.
+//
+// A default Region is refused: "Default Regions cannot be enabled or disabled".
+// The refusal is ValidationException with reason invalidRegionOptTarget, not the
+// ConstraintViolationException #629 named — the account/2021-02-01 model declares
+// no such error for this operation, and invalidRegionOptTarget is the enum member
+// that exists for a target that cannot be opted.
+func (p *AccountPlugin) disableRegion(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	return p.opt(reqCtx, req, accountRegionDisabling)
+}
+
+// opt is the shared body of enableRegion and disableRegion. want is the in-flight
+// status the call moves the Region to.
+func (p *AccountPlugin) opt(reqCtx *RequestContext, req *AWSRequest, want string) (*AWSResponse, error) {
+	input, err := p.regionInput(req)
+	if err != nil {
+		return nil, err
+	}
+	target, err := p.targetAccount(reqCtx, input.AccountID)
+	if err != nil {
+		return nil, err
+	}
+
+	isDefault, isOptIn := accountRegionKind(input.RegionName)
+	switch {
+	case isDefault:
+		return nil, accountValidation("invalidRegionOptTarget",
+			fmt.Sprintf("%s is enabled by default and can be neither enabled nor disabled", input.RegionName))
+	case !isOptIn:
+		return nil, accountUnknownRegion(input.RegionName)
+	}
+
+	goCtx := context.Background()
+	// peekRegionStatus, not regionStatus: an opt is not an observation. If this read
+	// advanced the record, an "ensure these Regions are on" pass would converge a
+	// Region the consumer's own poller had not yet seen reach ENABLED, and the
+	// ConflictException below would then be unreachable even with a seed in place.
+	current, _, err := p.peekRegionStatus(goCtx, target, input.RegionName)
+	if err != nil {
+		return nil, err
+	}
+
+	// The opposite opt is still in flight. AWS refuses rather than queueing, and
+	// the model declares ConflictException for exactly this: "you cannot use the
+	// Region until this process is complete … you cannot disable the Region until
+	// the enabling process is fully completed".
+	opposite := accountRegionDisabling
+	if want == accountRegionDisabling {
+		opposite = accountRegionEnabling
+	}
+	if current == opposite {
+		return nil, accountConflict(fmt.Sprintf(
+			"%s is in status %s for account %s; wait for it to complete before opting the other way",
+			input.RegionName, current, target))
+	}
+
+	// Already where the call wants it, or already on the way there. Writing
+	// ENABLING over ENABLED would be worse than a no-op: a waiter that had already
+	// observed ENABLED would see the Region go backwards.
+	settled := accountRegionEnabled
+	if want == accountRegionDisabling {
+		settled = accountRegionDisabled
+	}
+	if current == want || current == settled {
+		return accountEmptyResponse(), nil
+	}
+
+	if err := p.saveRegionOpt(goCtx, target, input.RegionName, want); err != nil {
+		return nil, err
+	}
+	return accountEmptyResponse(), nil
+}
+
+// --- input -------------------------------------------------------------------
+
+// accountRegionRequest is the input shape the three Region-named operations
+// share: a required RegionName and an optional AccountId.
+type accountRegionRequest struct {
+	// AccountID is the member account the operation targets, or "" for the caller.
+	AccountID string `json:"AccountId"`
+
+	// RegionName is the Region code the operation acts on.
+	RegionName string `json:"RegionName"`
+}
+
+// regionInput decodes and validates the shared input. RegionName is required by
+// the model, and its shape bounds the length at 1-50 characters.
+func (p *AccountPlugin) regionInput(req *AWSRequest) (*accountRegionRequest, error) {
+	var input accountRegionRequest
+	if err := accountUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if input.RegionName == "" {
+		return nil, accountValidation("fieldValidationFailed", "RegionName is required")
+	}
+	if len(input.RegionName) > 50 {
+		return nil, accountValidation("fieldValidationFailed", "RegionName must be at most 50 characters")
+	}
+	return &input, nil
+}
+
+// targetAccount resolves which account an operation reads or writes: the caller's
+// own when AccountId is absent, or the named member account when it is present.
+//
+// The model's rules are specific and all three refusals below are
+// ValidationException, the only 400 these operations declare:
+//
+//   - "The management account can't specify its own AccountId. It must call the
+//     operation in standalone context by not including the AccountId parameter."
+//   - "The specified account ID must be a member account in the same
+//     organization."
+//   - The organization "must have all features enabled".
+//
+// Membership is read through the Organizations reverse index #623 added, which is
+// the one place that knows who manages whom. Substrate does not model Account
+// Management trusted access or a delegated administrator for it, so the caller
+// must be the management account itself; a member naming another member is
+// refused.
+func (p *AccountPlugin) targetAccount(reqCtx *RequestContext, accountID string) (string, error) {
+	caller := fallbackAccountID
+	if reqCtx != nil && reqCtx.AccountID != "" {
+		caller = reqCtx.AccountID
+	}
+	if accountID == "" {
+		return caller, nil
+	}
+	if !isAccountIDPattern(accountID) {
+		return "", accountValidation("fieldValidationFailed",
+			fmt.Sprintf("AccountId %q must be 12 digits", accountID))
+	}
+	if accountID == caller {
+		return "", accountValidation("fieldValidationFailed",
+			"the calling account can't specify its own AccountId; omit the parameter to operate in standalone context")
+	}
+
+	owner, err := p.organizationOwner(context.Background(), accountID)
+	if err != nil {
+		return "", err
+	}
+	if owner != caller {
+		return "", accountValidation("invalidRegionOptTarget",
+			fmt.Sprintf("account %s is not a member account of the organization managed by %s", accountID, caller))
+	}
+	return accountID, nil
+}
+
+// organizationOwner reads the Organizations member→management index directly out
+// of state, returning "" when the account is not a recorded member.
+//
+// Reading another plugin's namespace is deliberate and is what the API models:
+// ListRegions with an AccountId is only valid "if the caller is an identity in
+// the organization's management account", so the answer depends on Organizations
+// state and nothing else. The alternative — a second copy of the membership index
+// under this namespace — could disagree with Organizations', and the whole point
+// of #623 was that two answers to "who manages this account" is one too many.
+func (p *AccountPlugin) organizationOwner(ctx context.Context, acct string) (string, error) {
+	data, err := p.state.Get(ctx, organizationsNamespace, orgMemberOwnerKey(acct))
+	if err != nil {
+		return "", fmt.Errorf("account organizationOwner %s: %w", acct, err)
+	}
+	if data == nil {
+		return "", nil
+	}
+	var owner string
+	if err := json.Unmarshal(data, &owner); err != nil {
+		return "", fmt.Errorf("account organizationOwner %s unmarshal: %w", acct, err)
+	}
+	return owner, nil
+}
+
+// isAccountIDPattern reports whether s matches the model's AccountId pattern,
+// ^\d{12}$.
+func isAccountIDPattern(s string) bool {
+	if len(s) != 12 {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// --- helpers -----------------------------------------------------------------
+
+// accountUnmarshal decodes a request body, treating an absent one as empty so a
+// required-member check reports the missing member rather than a parse failure.
+// A body that will not parse is ValidationException/fieldValidationFailed: it is
+// the only 400 these operations declare, so any other code is one no caller's
+// catch branch can match.
+func accountUnmarshal(body []byte, out any) error {
+	if len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return accountValidation("fieldValidationFailed", "could not parse request body: "+err.Error())
+	}
+	return nil
+}
+
+// accountJSONResponse marshals an Account Management response body.
+func accountJSONResponse(out any, op string) (*AWSResponse, error) {
+	body, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("account %s marshal: %w", op, err)
+	}
+	return &AWSResponse{
+		StatusCode: http.StatusOK,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       body,
+	}, nil
+}
+
+// accountEmptyResponse is the answer to an operation the model gives no output
+// shape. EnableRegion and DisableRegion both declare responseCode 200 and no
+// output, and the AWS CLI documents it as "This command produces no output if
+// it's successful".
+func accountEmptyResponse() *AWSResponse {
+	return &AWSResponse{
+		StatusCode: http.StatusOK,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       []byte(`{}`),
+	}
+}
+
+// accountPaginate returns one page of Regions and the token for the next.
+//
+// The token encodes the last Region code returned rather than an offset, so a
+// listing whose contents changed between pages cannot silently skip an entry. An
+// unreadable token is a refusal rather than a silent restart from the beginning:
+// a paginating caller that restarts sees duplicates instead of an error, which is
+// the failure mode hardest to notice.
+func accountPaginate(regions []AccountRegion, nextToken string, maxResults int) (page []AccountRegion, next string, err error) {
+	start := 0
+	if nextToken != "" {
+		decoded, decodeErr := base64.StdEncoding.DecodeString(nextToken)
+		if decodeErr != nil {
+			return nil, "", accountValidation("fieldValidationFailed", "the NextToken value is not valid")
+		}
+		found := false
+		for i, r := range regions {
+			if r.RegionName == string(decoded) {
+				start = i + 1
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, "", accountValidation("fieldValidationFailed", "the NextToken value is not valid")
+		}
+	}
+
+	limit := maxResults
+	if limit <= 0 || limit > accountMaxResults {
+		limit = accountMaxResults
+	}
+	end := min(start+limit, len(regions))
+	page = regions[start:end]
+	if end < len(regions) {
+		next = base64.StdEncoding.EncodeToString([]byte(regions[end-1].RegionName))
+	}
+	if page == nil {
+		page = []AccountRegion{}
+	}
+	return page, next, nil
+}

--- a/emulator/account_plugin_test.go
+++ b/emulator/account_plugin_test.go
@@ -1,0 +1,826 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// This file covers #629: the account service namespace, and specifically the four
+// Region opt-in operations a consumer calls to baseline which Regions an account
+// can use.
+//
+// Every case here goes through the full server rather than calling the plugin
+// directly. That is deliberate: the account model is rest-json with no
+// X-Amz-Target, so the operation is carried by the URL and nothing else, and a
+// plugin driven in-process would never exercise the routing. #561 and #610 were
+// both "registered, unit-tested, and unreachable from any SDK", which is a defect
+// no in-process test can see.
+
+// accountRegionOptStatus is the GetRegionOptStatus response shape.
+type accountRegionOptStatus struct {
+	RegionName      string `json:"RegionName"`
+	RegionOptStatus string `json:"RegionOptStatus"`
+}
+
+// accountListRegions is the ListRegions response shape.
+type accountListRegions struct {
+	Regions   []emulator.AccountRegion `json:"Regions"`
+	NextToken string                   `json:"NextToken"`
+}
+
+// accountRequest posts an Account Management operation the way the SDK does: a
+// bare POST to the operation's own path, with no X-Amz-Target, routed by the Host
+// header and the credential scope.
+func accountRequest(t *testing.T, ts *emulator.TestServer, path string, body any) *http.Response {
+	t.Helper()
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+path, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("build %s request: %v", path, err)
+	}
+	req.Host = "account.us-east-1.amazonaws.com"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization",
+		"AWS4-HMAC-SHA256 Credential=AKIATEST12345678901/20260101/us-east-1/account/aws4_request, "+
+			"SignedHeaders=host, Signature=fake")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	return resp
+}
+
+// decodeAccountResponse decodes a rest-json response into out, returning the
+// status and the error code a refusal carries.
+//
+// The code comes from the x-amzn-errortype header, which is where the rest-json
+// protocol puts it and what botocore's RestJSONParser prefers — not from
+// "__type", which is the JSON-RPC spelling and which these responses do not
+// carry. The message is returned too, because a ValidationException's reason is
+// the only thing distinguishing invalidRegionOptTarget from
+// fieldValidationFailed and substrate's error document has no modeled member to
+// put it in.
+func decodeAccountResponse(t *testing.T, resp *http.Response, out any) (status int, code, message string) {
+	t.Helper()
+	defer resp.Body.Close() //nolint:errcheck
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if errType := resp.Header.Get("x-amzn-errortype"); errType != "" {
+		var errShape struct {
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(raw, &errShape)
+		return resp.StatusCode, errType, errShape.Message
+	}
+	if out != nil {
+		if err := json.Unmarshal(raw, out); err != nil {
+			t.Fatalf("decode %s: %v", raw, err)
+		}
+	}
+	return resp.StatusCode, "", ""
+}
+
+// accountOptStatus reads one Region's status, failing the test on any refusal.
+func accountOptStatus(t *testing.T, ts *emulator.TestServer, region string) string {
+	t.Helper()
+	var got accountRegionOptStatus
+	status, code, msg := decodeAccountResponse(t,
+		accountRequest(t, ts, "/getRegionOptStatus", map[string]any{"RegionName": region}), &got)
+	if status != http.StatusOK {
+		t.Fatalf("GetRegionOptStatus(%s): %d %s %s", region, status, code, msg)
+	}
+	if got.RegionName != region {
+		t.Errorf("GetRegionOptStatus(%s) answered for %q; a caller reads this field to confirm it got the Region it asked about",
+			region, got.RegionName)
+	}
+	return got.RegionOptStatus
+}
+
+// --- routing --------------------------------------------------------------
+
+// TestAccount_IsReachableFromAnSDKShapedRequest is the routing guard.
+//
+// The account service supplies no X-Amz-Target, so a request only reaches this
+// plugin if the Host header or the SigV4 credential scope resolves "account" and
+// the URL path resolves the operation. #561 (SSO) and #610 were both a plugin that
+// was registered, unit-tested and unreachable: every call fell through to
+// "service not emulated". So this asserts the two things an in-process test cannot
+// — that the request routes, and that the pipeline sees "ListRegions" rather than
+// the bare verb "POST" it would otherwise be named (#480/#572).
+func TestAccount_IsReachableFromAnSDKShapedRequest(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	var listed accountListRegions
+	status, code, msg := decodeAccountResponse(t,
+		accountRequest(t, ts, "/listRegions", map[string]any{}), &listed)
+	if status != http.StatusOK {
+		t.Fatalf("ListRegions: %d %s %s — the account service did not route", status, code, msg)
+	}
+	if len(listed.Regions) == 0 {
+		t.Fatal("ListRegions routed but reported no Regions")
+	}
+
+	// The recorded operation name is what authorization, fault injection and cost
+	// all read, and they read it before any plugin runs.
+	events, err := ts.Store().GetEvents(t.Context(), emulator.EventFilter{Service: "account"})
+	if err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("no account events were recorded, so nothing can confirm the operation name")
+	}
+	for _, ev := range events {
+		if ev.Operation != "ListRegions" {
+			t.Errorf("recorded operation %q, want ListRegions — a bare verb here is the #572 defect", ev.Operation)
+		}
+	}
+}
+
+// TestAccount_UnknownPathIsRefused pins the default arm. A path that is not one
+// of the four Region routes must not be answered as though it were: the eleven
+// contact and account-name operations are deliberately not emulated, and a
+// consumer calling one needs to see that rather than a plausible empty success.
+func TestAccount_UnknownPathIsRefused(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	status, code, _ := decodeAccountResponse(t,
+		accountRequest(t, ts, "/putAlternateContact", map[string]any{}), nil)
+	if status != http.StatusBadRequest || code != "InvalidAction" {
+		t.Errorf("POST /putAlternateContact: %d %q, want 400/InvalidAction", status, code)
+	}
+}
+
+// --- ListRegions ----------------------------------------------------------
+
+// TestAccount_ListRegionsReportsBothTables is #629's first observation: the two
+// Region tables and their statuses.
+//
+// The counts are pinned because they are the whole content of the answer — a
+// consumer deciding which Regions to enable reads this list and nothing else, and
+// a table that silently lost an entry would make it skip a Region without
+// reporting anything. The API model publishes the RegionOptStatus enum but no
+// Region list, so both tables come from the Account Management Reference Guide.
+func TestAccount_ListRegionsReportsBothTables(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	var listed accountListRegions
+	if status, code, msg := decodeAccountResponse(t,
+		accountRequest(t, ts, "/listRegions", map[string]any{}), &listed); status != http.StatusOK {
+		t.Fatalf("ListRegions: %d %s %s", status, code, msg)
+	}
+
+	byName := make(map[string]string, len(listed.Regions))
+	for _, r := range listed.Regions {
+		if prior, dup := byName[r.RegionName]; dup {
+			t.Errorf("%s appears twice, as %s and %s", r.RegionName, prior, r.RegionOptStatus)
+		}
+		byName[r.RegionName] = r.RegionOptStatus
+	}
+	if len(byName) != 34 {
+		t.Errorf("ListRegions reported %d Regions, want 34 (17 default + 17 opt-in)", len(byName))
+	}
+
+	// A default Region is ENABLED_BY_DEFAULT and can never be anything else; an
+	// unopted opt-in Region is DISABLED. Spot-checking one of each in every
+	// partition-adjacent shape the guide lists would just restate the table, so
+	// these are the two the repro in #629 names plus the boundary cases: the
+	// Regions whose names look like the other table's.
+	wantDefault := []string{"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-2", "ap-northeast-3"}
+	for _, region := range wantDefault {
+		if got := byName[region]; got != "ENABLED_BY_DEFAULT" {
+			t.Errorf("%s is %q, want ENABLED_BY_DEFAULT", region, got)
+		}
+	}
+	// ap-southeast-3 and ap-south-2 are one digit from a default Region, which is
+	// exactly the kind of entry a hand-copied table gets wrong.
+	wantOptIn := []string{"af-south-1", "ap-east-1", "ap-southeast-3", "ap-south-2", "mx-central-1", "il-central-1"}
+	for _, region := range wantOptIn {
+		if got := byName[region]; got != "DISABLED" {
+			t.Errorf("%s is %q, want DISABLED", region, got)
+		}
+	}
+}
+
+// TestAccount_ListRegionsFiltersAndPaginates covers the two ListRegions inputs a
+// caller actually drives: the status filter and the page size.
+func TestAccount_ListRegionsFiltersAndPaginates(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	// The filter is how a consumer asks "which Regions are already on", and it must
+	// not answer with the opt-in Regions that are merely available.
+	var defaults accountListRegions
+	if status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/listRegions",
+		map[string]any{"RegionOptStatusContains": []string{"ENABLED_BY_DEFAULT"}}),
+		&defaults); status != http.StatusOK {
+		t.Fatalf("ListRegions filtered: %d %s %s", status, code, msg)
+	}
+	if len(defaults.Regions) != 17 {
+		t.Errorf("the ENABLED_BY_DEFAULT filter returned %d Regions, want 17", len(defaults.Regions))
+	}
+	for _, r := range defaults.Regions {
+		if r.RegionOptStatus != "ENABLED_BY_DEFAULT" {
+			t.Errorf("the filter let %s through with status %s", r.RegionName, r.RegionOptStatus)
+		}
+	}
+
+	// Enabling one Region then filtering on ENABLED is the check the plan's repro
+	// ends on: the filter reads live state, not the static table.
+	if status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/enableRegion",
+		map[string]any{"RegionName": "af-south-1"}), nil); status != http.StatusOK {
+		t.Fatalf("EnableRegion(af-south-1): %d %s %s", status, code, msg)
+	}
+	if got := accountOptStatus(t, ts, "af-south-1"); got != "ENABLING" {
+		t.Fatalf("af-south-1 is %s on the first poll, want ENABLING", got)
+	}
+	if got := accountOptStatus(t, ts, "af-south-1"); got != "ENABLED" {
+		t.Fatalf("af-south-1 is %s on the second poll, want ENABLED", got)
+	}
+	var enabled accountListRegions
+	if status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/listRegions",
+		map[string]any{"RegionOptStatusContains": []string{"ENABLED"}}), &enabled); status != http.StatusOK {
+		t.Fatalf("ListRegions ENABLED: %d %s %s", status, code, msg)
+	}
+	if len(enabled.Regions) != 1 || enabled.Regions[0].RegionName != "af-south-1" {
+		t.Errorf("the ENABLED filter returned %+v, want af-south-1 alone", enabled.Regions)
+	}
+
+	// Pagination: a caller looping until NextToken is empty must see all 34 exactly
+	// once. A token that restarted from the beginning would loop forever, which is
+	// why the token encodes the last Region rather than an offset.
+	seen := make(map[string]bool, 34)
+	token := ""
+	for pages := 0; ; pages++ {
+		if pages > 34 {
+			t.Fatal("ListRegions paginated past 34 pages, so the NextToken never emptied")
+		}
+		body := map[string]any{"MaxResults": 5}
+		if token != "" {
+			body["NextToken"] = token
+		}
+		var page accountListRegions
+		if status, code, msg := decodeAccountResponse(t,
+			accountRequest(t, ts, "/listRegions", body), &page); status != http.StatusOK {
+			t.Fatalf("ListRegions page %d: %d %s %s", pages, status, code, msg)
+		}
+		if len(page.Regions) > 5 {
+			t.Fatalf("page %d holds %d Regions, over the MaxResults of 5", pages, len(page.Regions))
+		}
+		for _, r := range page.Regions {
+			if seen[r.RegionName] {
+				t.Errorf("%s appeared on two pages", r.RegionName)
+			}
+			seen[r.RegionName] = true
+		}
+		token = page.NextToken
+		if token == "" {
+			break
+		}
+	}
+	if len(seen) != 34 {
+		t.Errorf("paging through saw %d Regions, want 34", len(seen))
+	}
+}
+
+// TestAccount_ListRegionsRefusesBadInput covers the two ValidationException
+// reasons a bad ListRegions input gets, both fieldValidationFailed: the model's
+// MaxResults shape bounds it at 1-50, and RegionOptStatusContains takes enum
+// members.
+//
+// A status outside the enum is refused rather than filtering everything out. That
+// distinction is the point: a caller that typo'd "Enabled" would otherwise read an
+// empty list and conclude no Region was enabled.
+func TestAccount_ListRegionsRefusesBadInput(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	for _, tc := range []struct {
+		name string
+		body map[string]any
+	}{
+		{"MaxResults below the floor", map[string]any{"MaxResults": 0}},
+		{"MaxResults above the ceiling", map[string]any{"MaxResults": 51}},
+		{"MaxResults negative", map[string]any{"MaxResults": -1}},
+		{"a status outside the enum", map[string]any{"RegionOptStatusContains": []string{"Enabled"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/listRegions", tc.body), nil)
+			if status != http.StatusBadRequest || code != "ValidationException" {
+				t.Fatalf("ListRegions %s: %d %q, want 400/ValidationException", tc.name, status, code)
+			}
+			if !strings.Contains(msg, "fieldValidationFailed") {
+				t.Errorf("the message is %q; it must name the reason, since the error document has nowhere else to carry it", msg)
+			}
+		})
+	}
+
+	// MaxResults at both bounds is accepted. An off-by-one in the check would be
+	// invisible in a nominal run, and it refuses a request AWS accepts.
+	for _, maxResults := range []int{1, 50} {
+		var page accountListRegions
+		if status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/listRegions",
+			map[string]any{"MaxResults": maxResults}), &page); status != http.StatusOK {
+			t.Errorf("ListRegions MaxResults=%d: %d %s %s, want 200", maxResults, status, code, msg)
+		}
+	}
+
+	// An unreadable NextToken is a refusal rather than a silent restart: a
+	// paginating caller that restarts sees duplicates instead of an error.
+	status, code, _ := decodeAccountResponse(t, accountRequest(t, ts, "/listRegions",
+		map[string]any{"NextToken": "not-base64-!!"}), nil)
+	if status != http.StatusBadRequest || code != "ValidationException" {
+		t.Errorf("ListRegions with a corrupt NextToken: %d %q, want 400/ValidationException", status, code)
+	}
+	// A well-formed token naming no Region is equally a refusal.
+	status, code, _ = decodeAccountResponse(t, accountRequest(t, ts, "/listRegions",
+		map[string]any{"NextToken": base64.StdEncoding.EncodeToString([]byte("nosuch-region-9"))}), nil)
+	if status != http.StatusBadRequest || code != "ValidationException" {
+		t.Errorf("ListRegions with a stale NextToken: %d %q, want 400/ValidationException", status, code)
+	}
+}
+
+// --- Enable / Disable / GetRegionOptStatus --------------------------------
+
+// TestAccount_EnableRegionResolvesOnObservation is the core of #629: the
+// asynchronous enable, and the fact that a waiter converges.
+//
+// Enabling a Region in AWS takes "a few minutes to several hours". Substrate
+// resolves ENABLING to ENABLED on first observation instead, which is what makes
+// that wait testable at all — and the terminal status then never moves, because a
+// status that flipped back would make a waiter comparing successive polls loop
+// forever.
+func TestAccount_EnableRegionResolvesOnObservation(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	if got := accountOptStatus(t, ts, "af-south-1"); got != "DISABLED" {
+		t.Fatalf("af-south-1 starts at %s, want DISABLED", got)
+	}
+
+	// EnableRegion has no output shape: an empty 200 is the whole answer, and the
+	// status is observed separately.
+	resp := accountRequest(t, ts, "/enableRegion", map[string]any{"RegionName": "af-south-1"})
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read EnableRegion body: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("EnableRegion: %d %s", resp.StatusCode, raw)
+	}
+	if got := strings.TrimSpace(string(raw)); got != "{}" {
+		t.Errorf("EnableRegion answered %q; the model gives it no output shape", got)
+	}
+
+	if got := accountOptStatus(t, ts, "af-south-1"); got != "ENABLING" {
+		t.Errorf("the first poll reads %s, want ENABLING — the enable is asynchronous", got)
+	}
+	if got := accountOptStatus(t, ts, "af-south-1"); got != "ENABLED" {
+		t.Errorf("the second poll reads %s, want ENABLED", got)
+	}
+	// And it stays. This is the assertion a clock-driven transition would fail.
+	for i := range 3 {
+		if got := accountOptStatus(t, ts, "af-south-1"); got != "ENABLED" {
+			t.Fatalf("poll %d reads %s, want ENABLED — a terminal status must not move", i+3, got)
+		}
+	}
+
+	// Re-enabling is idempotent against the target state, not the call. This is what
+	// makes an "ensure these Regions are on" routine safe to re-run, which is the
+	// shape of the consumer #629 came from; writing ENABLING over ENABLED would make
+	// the Region go backwards for a waiter that had already finished.
+	if status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/enableRegion",
+		map[string]any{"RegionName": "af-south-1"}), nil); status != http.StatusOK {
+		t.Fatalf("re-enabling an ENABLED Region: %d %s %s, want an empty 200", status, code, msg)
+	}
+	if got := accountOptStatus(t, ts, "af-south-1"); got != "ENABLED" {
+		t.Errorf("af-south-1 is %s after a redundant enable, want ENABLED", got)
+	}
+
+	// ListRegions must agree with GetRegionOptStatus. If it resolved separately, a
+	// caller polling through the listing would read ENABLING forever while a
+	// GetRegionOptStatus of the same Region said ENABLED.
+	var listed accountListRegions
+	if status, code, msg := decodeAccountResponse(t,
+		accountRequest(t, ts, "/listRegions", map[string]any{}), &listed); status != http.StatusOK {
+		t.Fatalf("ListRegions: %d %s %s", status, code, msg)
+	}
+	for _, r := range listed.Regions {
+		if r.RegionName == "af-south-1" && r.RegionOptStatus != "ENABLED" {
+			t.Errorf("ListRegions reports af-south-1 as %s while GetRegionOptStatus says ENABLED", r.RegionOptStatus)
+		}
+	}
+}
+
+// TestAccount_DisableRegionResolvesOnObservation is the mirror of the enable, plus
+// the round trip: a Region can be turned off again and lands back where it began.
+func TestAccount_DisableRegionResolvesOnObservation(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	if status, _, _ := decodeAccountResponse(t, accountRequest(t, ts, "/enableRegion",
+		map[string]any{"RegionName": "eu-south-1"}), nil); status != http.StatusOK {
+		t.Fatalf("EnableRegion(eu-south-1): %d", status)
+	}
+	if got := accountOptStatus(t, ts, "eu-south-1"); got != "ENABLING" {
+		t.Fatalf("eu-south-1 is %s, want ENABLING", got)
+	}
+	if got := accountOptStatus(t, ts, "eu-south-1"); got != "ENABLED" {
+		t.Fatalf("eu-south-1 is %s, want ENABLED", got)
+	}
+
+	if status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/disableRegion",
+		map[string]any{"RegionName": "eu-south-1"}), nil); status != http.StatusOK {
+		t.Fatalf("DisableRegion(eu-south-1): %d %s %s", status, code, msg)
+	}
+	if got := accountOptStatus(t, ts, "eu-south-1"); got != "DISABLING" {
+		t.Errorf("the first poll after the disable reads %s, want DISABLING", got)
+	}
+	if got := accountOptStatus(t, ts, "eu-south-1"); got != "DISABLED" {
+		t.Errorf("the second poll reads %s, want DISABLED", got)
+	}
+
+	// A redundant disable is a no-op success, same as the redundant enable.
+	if status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/disableRegion",
+		map[string]any{"RegionName": "eu-south-1"}), nil); status != http.StatusOK {
+		t.Errorf("re-disabling a DISABLED Region: %d %s %s, want an empty 200", status, code, msg)
+	}
+	if got := accountOptStatus(t, ts, "eu-south-1"); got != "DISABLED" {
+		t.Errorf("eu-south-1 is %s after a redundant disable, want DISABLED", got)
+	}
+}
+
+// TestAccount_OptTargetRefusals covers the invalidRegionOptTarget cases.
+//
+// A default Region cannot be disabled — "Default Regions cannot be enabled or
+// disabled" — and this is where #629's own framing was wrong: it named
+// ConstraintViolationException, which the account/2021-02-01 model declares for
+// no operation at all. ValidationException with reason invalidRegionOptTarget is
+// the shape that exists, and the reason distinguishes it from a malformed field.
+func TestAccount_OptTargetRefusals(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	// Both cases are ValidationException/invalidRegionOptTarget — the model gives
+	// them no separate code and no separate reason — so the message is the only thing
+	// that distinguishes them, and `wants` pins the distinguishing word. Without it,
+	// deleting the default-Region check entirely leaves every assertion here passing:
+	// the fall-through arm answers the same code and the same reason, and a caller
+	// would be told us-east-1 is not a Region.
+	for _, tc := range []struct {
+		name, path, region, wants string
+	}{
+		{"disabling a default Region", "/disableRegion", "us-east-1", "enabled by default"},
+		{"enabling a default Region", "/enableRegion", "us-east-1", "enabled by default"},
+		{"disabling an unknown Region", "/disableRegion", "nosuch-region-9", "not an AWS Region code"},
+		{"enabling an unknown Region", "/enableRegion", "nosuch-region-9", "not an AWS Region code"},
+		{"reading an unknown Region", "/getRegionOptStatus", "nosuch-region-9", "not an AWS Region code"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code, msg := decodeAccountResponse(t,
+				accountRequest(t, ts, tc.path, map[string]any{"RegionName": tc.region}), nil)
+			if status != http.StatusBadRequest || code != "ValidationException" {
+				t.Fatalf("%s: %d %q, want 400/ValidationException — not ConstraintViolationException, which this model does not declare",
+					tc.name, status, code)
+			}
+			if !strings.Contains(msg, "invalidRegionOptTarget") {
+				t.Errorf("the message is %q; it must name the reason, since the error document has nowhere else to carry it", msg)
+			}
+			if !strings.Contains(msg, tc.wants) {
+				t.Errorf("the message is %q, want it to say %q — the reason alone does not tell a default Region from an unknown one",
+					msg, tc.wants)
+			}
+		})
+	}
+
+	// A default Region still reads back through GetRegionOptStatus: it is only the
+	// opt that is refused, not the observation.
+	if got := accountOptStatus(t, ts, "us-east-1"); got != "ENABLED_BY_DEFAULT" {
+		t.Errorf("us-east-1 reads %s, want ENABLED_BY_DEFAULT", got)
+	}
+
+	// RegionName is required by the model on all three Region-named operations.
+	for _, path := range []string{"/enableRegion", "/disableRegion", "/getRegionOptStatus"} {
+		status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, path, map[string]any{}), nil)
+		if status != http.StatusBadRequest || code != "ValidationException" {
+			t.Errorf("POST %s with no RegionName: %d %q, want 400/ValidationException", path, status, code)
+		}
+		if !strings.Contains(msg, "fieldValidationFailed") {
+			t.Errorf("POST %s with no RegionName: message %q, want fieldValidationFailed", path, msg)
+		}
+	}
+}
+
+// --- the seed -------------------------------------------------------------
+
+// TestAccount_SeededStatusPinsTheObservation covers the control-plane seed, which
+// is the only route to a status a sequence of API calls cannot produce.
+//
+// Because an in-flight opt resolves on first observation, an unseeded emulator can
+// never hold a Region in ENABLING across two polls — so a waiter's timeout branch,
+// and the ConflictException an opposite opt gets mid-flight, are unreachable
+// without this. That is what CLAUDE.md's seeding rule is for: the rare path made
+// instant and reproducible rather than nondeterministic.
+func TestAccount_SeededStatusPinsTheObservation(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	accountSeedStatus(t, ts, "af-south-1", "ENABLING")
+
+	// Pinned means pinned: repeated polls do not resolve it away.
+	for i := range 3 {
+		if got := accountOptStatus(t, ts, "af-south-1"); got != "ENABLING" {
+			t.Fatalf("poll %d reads %s, want the seeded ENABLING", i+1, got)
+		}
+	}
+
+	// And the ConflictException the User Guide describes verbatim — "this happens if
+	// you try to enable a Region that is currently being disabled (in a status of
+	// DISABLING)" — which is 409, not 400.
+	accountSeedStatus(t, ts, "af-south-1", "DISABLING")
+	status, code, _ := decodeAccountResponse(t, accountRequest(t, ts, "/enableRegion",
+		map[string]any{"RegionName": "af-south-1"}), nil)
+	if status != http.StatusConflict || code != "ConflictException" {
+		t.Errorf("enabling a DISABLING Region: %d %q, want 409/ConflictException", status, code)
+	}
+
+	accountSeedStatus(t, ts, "af-south-1", "ENABLING")
+	status, code, _ = decodeAccountResponse(t, accountRequest(t, ts, "/disableRegion",
+		map[string]any{"RegionName": "af-south-1"}), nil)
+	if status != http.StatusConflict || code != "ConflictException" {
+		t.Errorf("disabling an ENABLING Region: %d %q, want 409/ConflictException", status, code)
+	}
+
+	// The seed also drives the listing, so a consumer that reads state through
+	// ListRegions rather than a per-Region poll sees the same thing.
+	var listed accountListRegions
+	if status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/listRegions",
+		map[string]any{"RegionOptStatusContains": []string{"ENABLING"}}), &listed); status != http.StatusOK {
+		t.Fatalf("ListRegions ENABLING: %d %s %s", status, code, msg)
+	}
+	if len(listed.Regions) != 1 || listed.Regions[0].RegionName != "af-south-1" {
+		t.Errorf("the ENABLING filter returned %+v, want af-south-1 alone", listed.Regions)
+	}
+
+	// Clearing restores the stored record, which for a Region never opted is
+	// DISABLED.
+	accountClearStatus(t, ts, "af-south-1")
+	if got := accountOptStatus(t, ts, "af-south-1"); got != "DISABLED" {
+		t.Errorf("af-south-1 reads %s after the seed was cleared, want DISABLED", got)
+	}
+}
+
+// TestAccount_SeedRefusesWhatItCannotAffect pins the seed endpoint's own
+// refusals. A seed that is silently ignored is worse than one that is refused: the
+// test using it passes while asserting nothing.
+func TestAccount_SeedRefusesWhatItCannotAffect(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	for _, tc := range []struct {
+		name, region, status string
+	}{
+		{"a status outside the enum", "af-south-1", "Enabling"},
+		{"a default Region, whose status is fixed", "us-east-1", "DISABLED"},
+		{"a Region in neither table", "nosuch-region-9", "ENABLED"},
+		{"an empty status", "af-south-1", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(map[string]any{"regionName": tc.region, "status": tc.status})
+			if err != nil {
+				t.Fatalf("marshal seed: %v", err)
+			}
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+				ts.URL+"/v1/account/region-opt-status", bytes.NewReader(body))
+			if err != nil {
+				t.Fatalf("build seed request: %v", err)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			defer resp.Body.Close() //nolint:errcheck
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("seeding %s: %d, want 400", tc.name, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// --- AccountId targeting --------------------------------------------------
+
+// TestAccount_AccountIDTargetsAMemberAccount covers the AccountId parameter,
+// which is where #623's reverse index pays off a second time.
+//
+// The model's rules are narrow and each refusal below is one of them: the caller
+// may name a member of its own organization, may not name itself ("The management
+// account can't specify its own AccountId"), and may not name an account it does
+// not manage. Getting this wrong in the permissive direction would let a test
+// read or opt another organization's account and see a plausible answer.
+func TestAccount_AccountIDTargetsAMemberAccount(t *testing.T) {
+	ts := emulator.StartTestServerWithAccounts(t)
+	member := orgVendMember(t, ts, "regions-member", "regions-member@example.com")
+
+	// Management enables a Region *in the member account*. The member's own view is
+	// what must change — that is the whole point of the parameter.
+	if status, code, msg := decodeAccountResponse(t, accountSignedRequest(t, ts, orgManagementAccount,
+		"/enableRegion", map[string]any{"AccountId": member, "RegionName": "ap-east-1"}),
+		nil); status != http.StatusOK {
+		t.Fatalf("EnableRegion for member %s: %d %s %s", member, status, code, msg)
+	}
+
+	var got accountRegionOptStatus
+	if status, code, msg := decodeAccountResponse(t, accountSignedRequest(t, ts, orgManagementAccount,
+		"/getRegionOptStatus", map[string]any{"AccountId": member, "RegionName": "ap-east-1"}),
+		&got); status != http.StatusOK {
+		t.Fatalf("GetRegionOptStatus for member: %d %s %s", status, code, msg)
+	}
+	if got.RegionOptStatus != "ENABLING" {
+		t.Errorf("the member's ap-east-1 is %s, want ENABLING", got.RegionOptStatus)
+	}
+
+	// Management's own account is untouched: the opt was filed under the member, not
+	// under whoever happened to make the call. That is #624's defect in another
+	// service, and the reason this assertion is here rather than assumed.
+	var mgmt accountRegionOptStatus
+	if status, code, msg := decodeAccountResponse(t, accountSignedRequest(t, ts, orgManagementAccount,
+		"/getRegionOptStatus", map[string]any{"RegionName": "ap-east-1"}), &mgmt); status != http.StatusOK {
+		t.Fatalf("GetRegionOptStatus for management: %d %s %s", status, code, msg)
+	}
+	if mgmt.RegionOptStatus != "DISABLED" {
+		t.Errorf("management's own ap-east-1 is %s, want DISABLED", mgmt.RegionOptStatus)
+	}
+
+	for _, tc := range []struct {
+		name, caller, accountID string
+	}{
+		{"the caller names itself", orgManagementAccount, orgManagementAccount},
+		{"an account in no organization", orgManagementAccount, "222233334444"},
+		{"a malformed account ID", orgManagementAccount, "12345"},
+		{"a member names its management account", member, orgManagementAccount},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code, _ := decodeAccountResponse(t, accountSignedRequest(t, ts, tc.caller,
+				"/getRegionOptStatus", map[string]any{"AccountId": tc.accountID, "RegionName": "ap-east-1"}), nil)
+			if status != http.StatusBadRequest || code != "ValidationException" {
+				t.Errorf("%s: %d %q, want 400/ValidationException — the only 400 this operation declares",
+					tc.name, status, code)
+			}
+		})
+	}
+}
+
+// accountSignedRequest posts an Account Management operation signed as the given
+// account, so a test can be a caller other than the default one.
+//
+// The rest-json path is part of the canonical request, so the signature covers it;
+// signing "/" here would produce a header the server refuses before any plugin
+// runs, which is why sigV4Header takes the path.
+func accountSignedRequest(t *testing.T, ts *emulator.TestServer, account, path string, body any) *http.Response {
+	t.Helper()
+
+	creds, ok := ts.CredentialsFor(account)
+	if !ok {
+		t.Fatalf("no credential registered for account %s", account)
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+
+	const (
+		host     = "account.us-east-1.amazonaws.com"
+		dateTime = "20260101T120000Z"
+	)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+path, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("build %s request: %v", path, err)
+	}
+	req.Host = host
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Amz-Date", dateTime)
+	req.Header.Set("Authorization", sigV4Header(path, host, "account", dateTime, data,
+		creds.AccessKeyID, creds.SecretAccessKey))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s as %s: %v", path, account, err)
+	}
+	return resp
+}
+
+// TestAccount_ClearAllSeedsRestoresEveryRegion covers the no-argument clear, which
+// is what a test fixture calls between cases. A clear that missed a Region would
+// leak a pinned status into the next case and produce a failure with no visible
+// cause in the test that fails.
+func TestAccount_ClearAllSeedsRestoresEveryRegion(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	accountSeedStatus(t, ts, "af-south-1", "ENABLING")
+	accountSeedStatus(t, ts, "ap-east-1", "ENABLED")
+	if got := accountOptStatus(t, ts, "af-south-1"); got != "ENABLING" {
+		t.Fatalf("af-south-1 is %s, want the seeded ENABLING", got)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete,
+		ts.URL+"/v1/account/region-opt-status", nil)
+	if err != nil {
+		t.Fatalf("build clear-all request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("clear all: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("clear all: %d", resp.StatusCode)
+	}
+
+	for _, region := range []string{"af-south-1", "ap-east-1"} {
+		if got := accountOptStatus(t, ts, region); got != "DISABLED" {
+			t.Errorf("%s is %s after clearing every seed, want DISABLED", region, got)
+		}
+	}
+}
+
+// TestAccount_MalformedInputIsRefused covers the two input failures that are not
+// about a Region: a body that is not JSON, and a RegionName past the model's
+// 50-character bound. Both are ValidationException, the only 400 these operations
+// declare, so a caller's catch branch matches either.
+func TestAccount_MalformedInputIsRefused(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		ts.URL+"/getRegionOptStatus", strings.NewReader("{not json"))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Host = "account.us-east-1.amazonaws.com"
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /getRegionOptStatus: %v", err)
+	}
+	status, code, _ := decodeAccountResponse(t, resp, nil)
+	if status != http.StatusBadRequest || code != "ValidationException" {
+		t.Errorf("an unparseable body: %d %q, want 400/ValidationException", status, code)
+	}
+
+	status, code, msg := decodeAccountResponse(t, accountRequest(t, ts, "/getRegionOptStatus",
+		map[string]any{"RegionName": strings.Repeat("z", 51)}), nil)
+	if status != http.StatusBadRequest || code != "ValidationException" {
+		t.Errorf("a 51-character RegionName: %d %q, want 400/ValidationException", status, code)
+	}
+	if !strings.Contains(msg, "fieldValidationFailed") {
+		t.Errorf("the message is %q, want fieldValidationFailed — the length bound is a field failure, not a bad target", msg)
+	}
+}
+
+// accountSeedStatus pins a Region's opt status through the control plane.
+func accountSeedStatus(t *testing.T, ts *emulator.TestServer, region, status string) {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"regionName": region, "status": status})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		ts.URL+"/v1/account/region-opt-status", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build seed request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("seed %s=%s: %v", region, status, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("seed %s=%s: %d %s", region, status, resp.StatusCode, raw)
+	}
+}
+
+// accountClearStatus removes the seed for one Region.
+func accountClearStatus(t *testing.T, ts *emulator.TestServer, region string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete,
+		ts.URL+"/v1/account/region-opt-status?regionName="+region, nil)
+	if err != nil {
+		t.Fatalf("build clear request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("clear %s: %v", region, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("clear %s: %d", region, resp.StatusCode)
+	}
+}

--- a/emulator/error_protocol.go
+++ b/emulator/error_protocol.go
@@ -153,6 +153,7 @@ var serviceErrorProtocols = map[string]awsErrorProtocol{
 	"wafv2":            errProtoJSONRPC,
 
 	// REST-JSON.
+	"account":         errProtoRESTJSON,
 	"apigateway":      errProtoRESTJSON,
 	"apigatewayv2":    errProtoRESTJSON,
 	"appsync":         errProtoRESTJSON,

--- a/emulator/operation_names.go
+++ b/emulator/operation_names.go
@@ -50,6 +50,9 @@ func requestMethod(req *AWSRequest) string {
 // ParseAWSRequest has populated by the time it consults this table — which is
 // what makes resolving there safe. See resolveOperationName.
 var operationResolvers = map[string]func(req *AWSRequest) string{
+	"account": func(req *AWSRequest) string {
+		return parseAccountOperation(requestMethod(req), req.Path)
+	},
 	"s3": func(req *AWSRequest) string {
 		_, _, op := parseS3Operation(req)
 		return op

--- a/emulator/plugins.go
+++ b/emulator/plugins.go
@@ -273,6 +273,16 @@ func RegisterDefaultPlugins(
 	}
 	registry.Register(ebPlugin)
 
+	accountPlugin := &AccountPlugin{}
+	if err := accountPlugin.Initialize(ctx, PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}); err != nil {
+		return fmt.Errorf("initialize account plugin: %w", err)
+	}
+	registry.Register(accountPlugin)
+
 	schedulerPlugin := &SchedulerPlugin{}
 	if err := schedulerPlugin.Initialize(ctx, PluginConfig{
 		State:   state,

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -336,6 +336,10 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/organizations/create-account-failure", s.handleOrganizationsSeedCreateAccountFailure)
 	r.Delete("/v1/organizations/create-account-failure", s.handleOrganizationsClearCreateAccountFailure)
 
+	// Account Management control-plane endpoints (#629).
+	r.Post("/v1/account/region-opt-status", s.handleAccountSeedRegionOptStatus)
+	r.Delete("/v1/account/region-opt-status", s.handleAccountClearRegionOptStatus)
+
 	// Lambda control-plane endpoints (#393).
 	r.Post("/v1/lambda/invoke-error", s.handleLambdaSeedInvokeError)
 	r.Delete("/v1/lambda/invoke-error", s.handleLambdaClearInvokeError)

--- a/emulator/signed_request_test.go
+++ b/emulator/signed_request_test.go
@@ -78,7 +78,7 @@ func signedRequest(t *testing.T, ts *emulator.TestServer, tgt signedRequestTarge
 	req.Header.Set("X-Amz-Target", tgt.target+"."+op)
 	req.Header.Set("X-Amz-Date", dateTime)
 	req.Header.Set("Authorization", sigV4Header(
-		tgt.host, tgt.signingName, dateTime, data, creds.AccessKeyID, creds.SecretAccessKey))
+		"/", tgt.host, tgt.signingName, dateTime, data, creds.AccessKeyID, creds.SecretAccessKey))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -87,9 +87,14 @@ func signedRequest(t *testing.T, ts *emulator.TestServer, tgt signedRequestTarge
 	return resp
 }
 
-// sigV4Header computes a valid SigV4 Authorization header for a POST to "/" with
+// sigV4Header computes a valid SigV4 Authorization header for a POST to path with
 // the host and x-amz-date headers signed.
-func sigV4Header(host, signingName, dateTime string, body []byte, accessKey, secretKey string) string {
+//
+// path is a parameter because a rest-json service carries its operation in the URL
+// — the account service posts to /listRegions and the like — and the canonical
+// request covers the path, so signing "/" for a request sent elsewhere produces a
+// signature the server correctly refuses.
+func sigV4Header(path, host, signingName, dateTime string, body []byte, accessKey, secretKey string) string {
 	const (
 		region        = "us-east-1"
 		signedHeaders = "host;x-amz-date"
@@ -99,7 +104,7 @@ func sigV4Header(host, signingName, dateTime string, body []byte, accessKey, sec
 	bodyHash := sha256.Sum256(body)
 	canonicalReq := strings.Join([]string{
 		http.MethodPost,
-		"/",
+		path,
 		"",
 		"host:" + host + "\n" + "x-amz-date:" + dateTime + "\n",
 		signedHeaders,

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -5,9 +5,10 @@ go 1.26
 toolchain go1.26.6
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.43.5
+	github.com/aws/aws-sdk-go-v2 v1.43.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.35
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.34
+	github.com/aws/aws-sdk-go-v2/service/account v1.35.6
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.58.1
@@ -15,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.37.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.4
-	github.com/aws/smithy-go v1.27.7
+	github.com/aws/smithy-go v1.27.8
 	github.com/scttfrdmn/substrate v0.0.0
 	github.com/spf13/afero v1.15.0
 	github.com/stretchr/testify v1.11.1
@@ -24,8 +25,8 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.35 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.36 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.36 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.28 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go-v2 v1.43.5 h1:yKT5GYnFWhuDo+DqKvE5ZPwVn3RjC4MAeBtZGlh6AVM=
-github.com/aws/aws-sdk-go-v2 v1.43.5/go.mod h1:wZjAJppCntyOGgVSmgVTfDyRJK5PHOasO6Wsy8U7Axk=
+github.com/aws/aws-sdk-go-v2 v1.43.6 h1:RrmFcqCBxkJuf7g1axVo5krB4jM/AO8r5e5oujrgdoQ=
+github.com/aws/aws-sdk-go-v2 v1.43.6/go.mod h1:tXpPM+v0D1lndmga+HqqLDIzUFJlEeR21aspVklHF00=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.16 h1:aiuaKlDweRC5qExJondpWjOgyzMHpofpwspGXUtwn4c=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.16/go.mod h1:nG/LOlmox9BDe9HvQnXWzgcK8uKbgBMZ/Hp5pVt/21I=
 github.com/aws/aws-sdk-go-v2/config v1.32.35 h1:UEzXuET8E42lxBPijuACu/tEK7v5lFPlk0Q+GT5WD9E=
@@ -8,12 +8,14 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.34 h1:y6GkSmcv5myd1ngrYbGmiLlwQqB
 github.com/aws/aws-sdk-go-v2/credentials v1.19.34/go.mod h1:w3dTcnDVoQIewjo7JG45hduAToikiIFLC4FIO7fndvw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.35 h1:+S7kbJoLDDQ5tE+lHrUBgMkzC8NLgsaioS2F3dVoFAE=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.35/go.mod h1:Ak7xXviIARfFdNUJ9Etb0bdVDt/KAvKjMGJVLWXDzik=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.36 h1:5CrzwxDqf4w3x1Vs3/NiZ0nsC34Hbm3pIDMWbsLebOE=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.36/go.mod h1:A3gHdKZIvG/QXERzZwcxNS3RNDFcRCuhhTFBYp+V/nw=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36 h1:A4N2f4YPcST0v+dWtX+xrpPPCL9VTBhoIFFUWYqbacE=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.36/go.mod h1:B/Qr859uxWUEfZeGotK5KAEoof4Q9YWgNtPSwV6jcyk=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37 h1:lznzIOvvbqjfe8UAaciCRJgBgJsxuTROKlhZuXQWfv8=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37/go.mod h1:otfkzyfQeMMLZAqX59GSXTL3o22BR/l6HFaRzzbWSqA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.37 h1:zCEORWo0eU0gDjG+IyApE/2B+ZGG1m+GU7B263XV8ds=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.37/go.mod h1:i6c0PEl3TNOWxRbQ++KQcVenPWS/GoQeiklKhNuqzJ8=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.36 h1:jbGY4CXLzZElOXgGsexlC3Hi+3YM0rSmk4opFXKqg/k=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.36/go.mod h1:uBu/9aKsS/UQGc72RAt3y54kjgYQxmhut8ZD2dXCDNE=
+github.com/aws/aws-sdk-go-v2/service/account v1.35.6 h1:mObt+amlHneRU0jyyCIRb6vyV3kjLqhUMKbFveX365g=
+github.com/aws/aws-sdk-go-v2/service/account v1.35.6/go.mod h1:N2v9jPq9iN8zqp2/IzP44Y6hShrwn8Q7IJGiBHCc184=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1 h1:UDQGJ9AuLcf4yiDKyHPGN4EirOLo/E8+Zfoii8FhyZs=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1/go.mod h1:tCsJEKr4HMFIZSnXLx6rU2HlptPtLhWWfw2V2j9p7lE=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0 h1:XxzwotCCRk2Un1OWcJujk4vAC2OZkGh5l816W1w+Fd8=
@@ -42,8 +44,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.4 h1:AsbZcJAQPRmHDJG8K1N0pof/
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.4/go.mod h1:6imqztH0//t0mKbl6yWl7swSEl7F/w32oAmqB3vP1ag=
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.4 h1:w/AryDYMjSUANSQ2uoZxJovUsMTwWJNTv3IMex30Y+4=
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.4/go.mod h1:WeBiAa67azG7Su9Vf+ChGDBLiAozJCXzdjXiPBUwtbc=
-github.com/aws/smithy-go v1.27.7 h1:Zgj5z4LfcDYoQIVk+n/yGdTkP/2y6ZT5vYxe0fp7bqE=
-github.com/aws/smithy-go v1.27.7/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.8 h1:FR0dxZfIlV7Z8eh2iHfIofdunw382XsDV3Mxt9nUvRY=
+github.com/aws/smithy-go v1.27.8/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/test/e2e/journey_account_regions_test.go
+++ b/test/e2e/journey_account_regions_test.go
@@ -1,0 +1,222 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/account"
+	accounttypes "github.com/aws/aws-sdk-go-v2/service/account/types"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_AccountRegionOptIn is #629 at the SDK level: the Region opt-in
+// baseline a consumer walks before it deploys anything.
+//
+// This level is the one that matters most for a brand-new namespace. The account
+// service sends no X-Amz-Target and carries its operation entirely in the URL, so
+// routing depends on the Host header, the SigV4 credential scope and an exact path
+// match — none of which a unit test driving the plugin through a hand-built request
+// exercises. #561 and #610 were both a plugin that was registered, fully
+// unit-tested, and unreachable from every SDK.
+func TestJourney_AccountRegionOptIn(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	// Retries off, so each assertion is about the first response rather than
+	// whatever the retry loop settled on.
+	acct := account.NewFromConfig(cfg, func(o *account.Options) { o.RetryMaxAttempts = 1 })
+
+	// --- the baseline a consumer reads first ---
+	listed, err := acct.ListRegions(ctx, &account.ListRegionsInput{})
+	if err != nil {
+		t.Fatalf("ListRegions: %v", err)
+	}
+	byName := make(map[string]accounttypes.RegionOptStatus, len(listed.Regions))
+	for _, r := range listed.Regions {
+		byName[aws.ToString(r.RegionName)] = r.RegionOptStatus
+	}
+	if len(byName) != 34 {
+		t.Fatalf("ListRegions reported %d Regions, want 34 (17 default + 17 opt-in)", len(byName))
+	}
+	// The statuses come back as SDK enum members rather than strings, which is what
+	// a consumer switches on. A value outside the enum would deserialize into
+	// something no case matches.
+	if got := byName["us-east-1"]; got != accounttypes.RegionOptStatusEnabledByDefault {
+		t.Errorf("us-east-1 is %q, want ENABLED_BY_DEFAULT", got)
+	}
+	if got := byName["af-south-1"]; got != accounttypes.RegionOptStatusDisabled {
+		t.Errorf("af-south-1 is %q, want DISABLED", got)
+	}
+
+	// --- the asynchronous enable, polled the way a waiter does ---
+	// EnableRegion has no output shape in the model, so the SDK's output struct
+	// carries only ResultMetadata; the absence of an error is the whole answer.
+	if _, err := acct.EnableRegion(ctx, &account.EnableRegionInput{
+		RegionName: aws.String("af-south-1"),
+	}); err != nil {
+		t.Fatalf("EnableRegion(af-south-1): %v", err)
+	}
+
+	first, err := acct.GetRegionOptStatus(ctx, &account.GetRegionOptStatusInput{
+		RegionName: aws.String("af-south-1"),
+	})
+	if err != nil {
+		t.Fatalf("GetRegionOptStatus: %v", err)
+	}
+	if first.RegionOptStatus != accounttypes.RegionOptStatusEnabling {
+		t.Errorf("the first poll reads %q, want ENABLING — the in-flight status is only observable here, since EnableRegion has no output", first.RegionOptStatus)
+	}
+	if got := aws.ToString(first.RegionName); got != "af-south-1" {
+		t.Errorf("GetRegionOptStatus answered for %q, want af-south-1", got)
+	}
+
+	// Two more polls: the second converges, and the terminal status then holds. A
+	// status that flipped back would make a waiter comparing successive polls loop
+	// forever, which is the failure this asserts against.
+	for i := range 3 {
+		got, pollErr := acct.GetRegionOptStatus(ctx, &account.GetRegionOptStatusInput{
+			RegionName: aws.String("af-south-1"),
+		})
+		if pollErr != nil {
+			t.Fatalf("GetRegionOptStatus poll %d: %v", i+2, pollErr)
+		}
+		if got.RegionOptStatus != accounttypes.RegionOptStatusEnabled {
+			t.Fatalf("poll %d reads %q, want ENABLED", i+2, got.RegionOptStatus)
+		}
+	}
+
+	// --- idempotence: the "ensure" semantics #629 came from ---
+	if _, err := acct.EnableRegion(ctx, &account.EnableRegionInput{
+		RegionName: aws.String("af-south-1"),
+	}); err != nil {
+		t.Fatalf("re-enabling an ENABLED Region: %v — an ensure pass must be safe to re-run", err)
+	}
+	after, err := acct.GetRegionOptStatus(ctx, &account.GetRegionOptStatusInput{
+		RegionName: aws.String("af-south-1"),
+	})
+	if err != nil {
+		t.Fatalf("GetRegionOptStatus after the redundant enable: %v", err)
+	}
+	if after.RegionOptStatus != accounttypes.RegionOptStatusEnabled {
+		t.Errorf("af-south-1 is %q after a redundant enable, want ENABLED — the Region must not go backwards", after.RegionOptStatus)
+	}
+
+	// The filter reads live state, not the static table.
+	enabled, err := acct.ListRegions(ctx, &account.ListRegionsInput{
+		RegionOptStatusContains: []accounttypes.RegionOptStatus{accounttypes.RegionOptStatusEnabled},
+	})
+	if err != nil {
+		t.Fatalf("ListRegions(ENABLED): %v", err)
+	}
+	if len(enabled.Regions) != 1 || aws.ToString(enabled.Regions[0].RegionName) != "af-south-1" {
+		t.Errorf("the ENABLED filter returned %d Regions, want af-south-1 alone", len(enabled.Regions))
+	}
+
+	// --- the refusals, through the SDK's own error types ---
+	// errors.As is the assertion that matters: it is what a consumer's catch branch
+	// does, and it only succeeds if the code reached the client in the place the
+	// REST-JSON parser looks for it — the x-amzn-errortype header. A code left in the
+	// body alone deserializes to a bare *smithy.GenericAPIError and no branch matches.
+	var validation *accounttypes.ValidationException
+	_, err = acct.DisableRegion(ctx, &account.DisableRegionInput{RegionName: aws.String("us-east-1")})
+	if !errors.As(err, &validation) {
+		t.Fatalf("DisableRegion(us-east-1) answered %v, want *ValidationException — not the ConstraintViolationException #629 named, which this model declares nowhere", err)
+	}
+	if msg := aws.ToString(validation.Message); !strings.Contains(msg, "invalidRegionOptTarget") {
+		t.Errorf("the refusal message is %q; it must name the reason, since the REST-JSON error document has no reason member", msg)
+	}
+	if msg := aws.ToString(validation.Message); !strings.Contains(msg, "enabled by default") {
+		t.Errorf("the refusal message is %q; the reason alone does not tell a default Region from an unknown one", msg)
+	}
+
+	validation = nil
+	_, err = acct.DisableRegion(ctx, &account.DisableRegionInput{RegionName: aws.String("nosuch-region-9")})
+	if !errors.As(err, &validation) {
+		t.Fatalf("DisableRegion(nosuch-region-9) answered %v, want *ValidationException", err)
+	}
+
+	// --- the round trip ---
+	if _, err := acct.DisableRegion(ctx, &account.DisableRegionInput{
+		RegionName: aws.String("af-south-1"),
+	}); err != nil {
+		t.Fatalf("DisableRegion(af-south-1): %v", err)
+	}
+	disabling, err := acct.GetRegionOptStatus(ctx, &account.GetRegionOptStatusInput{
+		RegionName: aws.String("af-south-1"),
+	})
+	if err != nil {
+		t.Fatalf("GetRegionOptStatus after the disable: %v", err)
+	}
+	if disabling.RegionOptStatus != accounttypes.RegionOptStatusDisabling {
+		t.Errorf("the first poll after the disable reads %q, want DISABLING", disabling.RegionOptStatus)
+	}
+}
+
+// TestJourney_AccountSeededRegionStatus covers the seed through the SDK, and with
+// it the one status an unseeded emulator cannot hold: a Region stuck mid-flight.
+//
+// Because an in-flight opt advances on observation, a consumer's timeout branch and
+// the ConflictException an opposite opt gets while one is in progress are both
+// unreachable without the seed. That is what CLAUDE.md's seeding rule buys — the
+// rare path made instant and reproducible instead of nondeterministic.
+func TestJourney_AccountSeededRegionStatus(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	acct := account.NewFromConfig(cfg, func(o *account.Options) { o.RetryMaxAttempts = 1 })
+
+	seedRegionOptStatus(t, ts, `{"regionName":"ap-east-1","status":"DISABLING"}`)
+
+	// Pinned means pinned: the status does not resolve away under repeated polls,
+	// which is what lets a waiter's timeout branch actually run.
+	for i := range 3 {
+		got, pollErr := acct.GetRegionOptStatus(ctx, &account.GetRegionOptStatusInput{
+			RegionName: aws.String("ap-east-1"),
+		})
+		if pollErr != nil {
+			t.Fatalf("GetRegionOptStatus poll %d: %v", i+1, pollErr)
+		}
+		if got.RegionOptStatus != accounttypes.RegionOptStatusDisabling {
+			t.Fatalf("poll %d reads %q, want the seeded DISABLING", i+1, got.RegionOptStatus)
+		}
+	}
+
+	// And the ConflictException the User Guide describes verbatim: "this happens if
+	// you try to enable a Region that is currently being disabled". 409, not 400.
+	var conflict *accounttypes.ConflictException
+	_, err = acct.EnableRegion(ctx, &account.EnableRegionInput{RegionName: aws.String("ap-east-1")})
+	if !errors.As(err, &conflict) {
+		t.Fatalf("enabling a DISABLING Region answered %v, want *ConflictException", err)
+	}
+}
+
+// seedRegionOptStatus posts a Region opt-status seed to the control plane.
+func seedRegionOptStatus(t *testing.T, ts *emulator.TestServer, body string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		ts.URL+"/v1/account/region-opt-status", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build seed request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("seed %s: %v", body, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed %s: %d", body, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Closes #629.

Substrate had no `account` service namespace, so `ListRegions`,
`GetRegionOptStatus`, `EnableRegion` and `DisableRegion` all fell through to
"service not emulated". A consumer that baselines an account's usable Regions
before it deploys anything therefore could not be tested against substrate —
which is how this was found: by driving a shipped consumer against
`substrate server`, not by reading the API model.

## What's here

`ListRegions` reports all 34 Regions — 17 `ENABLED_BY_DEFAULT` and 17 `DISABLED`
until enabled — with `RegionOptStatusContains` filtering and
`MaxResults`/`NextToken` paging (bounds 1–50, from the model's own shape).
`AccountId` targets a member account of the caller's organization, resolved
through the **same** member→management index #623 added rather than a second copy
of it: two answers to "who manages this account" is one too many.

An opt is asynchronous and **resolves on observation**, following
`resolveCreateAccountStatus`. The first `GetRegionOptStatus` reports `ENABLING`,
the next reports `ENABLED`, and it never moves again; `ListRegions` resolves
identically, so a caller polling the listing and one polling a single Region
cannot contradict each other.

Two deliberate departures, both with the reasoning in the code:

- **The first observation reports the in-flight status**, unlike
  `CreateAccount`. `CreateAccount` hands back an `IN_PROGRESS` status in its own
  response, so a consumer sees the in-flight state without polling.
  `EnableRegion` has no output shape at all, so a poll is the only place
  `ENABLING` is ever observable — resolving sooner would leave a consumer's
  in-flight branch, the branch that exists because AWS takes "a few minutes to
  several hours" here, unexecutable in a test.
- **An opt is not an observation.** `EnableRegion` reads through
  `peekRegionStatus`, which advances nothing. A redundant enable of an `ENABLED`
  or `ENABLING` Region succeeds silently and rewrites nothing, which is what
  makes an "ensure these Regions are on" routine safe to re-run; writing
  `ENABLING` over `ENABLED` would make the Region go backwards for a waiter that
  had already finished.

## A correction to the issue

Disabling a default Region is **`ValidationException` with reason
`invalidRegionOptTarget`**, not the `ConstraintViolationException` the issue
names — the `account/2021-02-01` model declares no such error for *any*
operation, so a consumer catching one could never match. The reason rides at the
front of the message, because the REST-JSON error document is `{message, Message,
Code}` plus `x-amzn-errortype` and has no `reason` member. The message also
distinguishes a default Region from an unknown one: the code *and* the reason are
identical for both cases, so the message is the only thing that tells them apart
— a mutation deleting the default-Region check proved this, surviving until the
test asserted on the message.

## Seeding

`POST`/`DELETE /v1/account/region-opt-status` (Region code or `"*"`) pins what an
observation reports. It is the only route to a status a sequence of API calls
cannot produce — a Region held in `ENABLING`, and with it a waiter's timeout
branch and the `ConflictException` (409) an opposite opt gets mid-flight. A seed
naming a **default** Region is refused rather than ignored: that status is fixed
before a seed is consulted, so an accepted seed would leave the test asserting
nothing.

## Not modelled

Two published limits, and the docs say why: 6 in-progress requests per account,
and a per-organization limit the same guide gives as **50** in one section and
**20** in another. A guessed `TooManyRequestsException` boundary refuses requests
AWS accepts, and there is no way to choose between two published numbers without
making one wrong. The other eleven operations in the model — alternate contacts,
the primary contact, the account name, the primary email — are out of scope;
#629 asked for the four Region operations.

`ec2SeededRegions` stays a separate, smaller list: it answers which Regions EC2
reports, not which ones an account has opted into, and unifying them would make
every EC2 fixture's Region list depend on this table.

## Provenance

Both Region tables come from the [Account Management Reference
Guide](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-regions.html)
rather than from the API model, which publishes the `RegionOptStatus` enum but no
Region list. Every status, error code, HTTP status, required member and numeric
bound is from `account/2021-02-01/service-2.json`.

## Verification

- `gofmt`, `go build`, `go vet`, `golangci-lint run ./...` — **0 issues**
- `make test` (race detector) green; coverage 82.2%
- `make docs-reference-check docs-versions`, `npm --prefix docs run build` green
- `go vet -C test/e2e ./...` and `go test -C test/e2e ./...` green
- **Live run** against `substrate server --address :4678` with
  `AWS_MAX_ATTEMPTS=1`: every line of the issue's repro matches, including the
  409 wire shape (`x-amzn-errortype: ConflictException`)
- **New e2e journeys** through the real `aws-sdk-go-v2/service/account` client
  (added to `test/e2e/go.mod`). This is the level that catches an unrouted
  service: the account API sends no `X-Amz-Target` and carries its operation
  entirely in the URL, and #561/#610 were both a plugin that was registered,
  fully unit-tested, and unreachable from every SDK. `errors.As` on
  `*types.ValidationException` and `*types.ConflictException` is what asserts the
  code reached the client where the REST-JSON parser looks for it.
- **Mutation testing**, five mutants, all **CAUGHT**: the default-Region check
  dropped from the opt path; `GetRegionOptStatus` never resolving; it resolving
  too early; `EnableRegion` made non-idempotent; the `operationResolvers` entry
  removed (the #480/#572 defect — the plugin still works while the pipeline
  authorizes, meters and records every call as `POST`).