### PR TITLE
feat(organizations): emulate CloseAccount, record the email decision, hoist the shared helpers (#625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contract is opt-in. Decoupling the two is #630. Each account's access key and
   secret are **derived from the account ID** rather than generated, so a recorded run
   replays with the same credentials in it.
+- **`CloseAccount` is now emulated** (#625), completing the account lifecycle v0.97.0
+  began with vending, placement and governance. A success is an empty 200 — the model
+  gives the operation no output shape — and the closure is read through
+  `DescribeAccount`, which AWS documents as the way to watch it: `PENDING_CLOSURE`
+  while in flight, `SUSPENDED` when done.
+
+  **A closed account does not leave the organization**, which is the reason this is
+  worth modelling rather than a detail of it. It keeps its place in the hierarchy,
+  stays in `ListAccounts` and `ListAccountsForParent`, and keeps counting against
+  `L-E619E033` — "when an account is closed it does not stop counting against this
+  quota until it is permanently closed". So a cleanup path that closes accounts to
+  make room for new ones gets no room, and `CreateAccount` still refuses. Removing the
+  account instead would make that broken script pass.
+
+  The transition **resolves on observation**, not off the clock (#514 remains the
+  subject of clock-driven transitions), and reports `PENDING_CLOSURE` on the *first*
+  observation for the same reason `EnableRegion` does: with no output shape, a poll is
+  the only place the in-flight status is ever visible. Only the three operations that
+  put an account's `Status` on the wire advance it. The concurrency count deliberately
+  does **not** — counting through an observation would let closing a fourth account
+  converge the first three, and the quota below could then never be reached.
+
+  Refusals come from the model's declared list and are each distinguishable, because
+  the JSON-RPC error document carries only a code and a message: the management
+  account is `ConstraintViolationException` / `CANNOT_CLOSE_MANAGEMENT_ACCOUNT` ("you
+  can't close the management account with this API"); an account of another
+  organization is `AccountNotFoundException`, and a malformed ID is
+  `InvalidInputException` / `INVALID_PATTERN` rather than the same not-found, so a
+  caller that passed a name where an ID belongs is not sent looking for an account it
+  never named; a `CONSOLIDATED_BILLING` organization is
+  `ORGANIZATION_NOT_IN_ALL_FEATURES_MODE` ("you can close an account when all features
+  are enabled"), and the account is left untouched so a retry after enabling all
+  features does not start from half-applied state. A member account calling it at all
+  is `AccessDeniedException` (403), checked before any state read so a member cannot
+  use the other refusals to probe the organization it belongs to.
+
+  The model declares both `ConflictException` and `AccountAlreadyClosedException` and
+  does not say which applies to a closure already in flight. Substrate reads "already
+  closed" as the terminal state and answers the conflict for `PENDING_CLOSURE`, so a
+  re-run of a teardown script can tell "this is finishing" from "this was done" — one
+  code for both collapses that distinction.
+
+  One of the three published closure quotas is modelled: **3 concurrent closures**
+  (`CLOSE_ACCOUNT_REQUESTS_LIMIT_EXCEEDED`), which is a count of accounts currently in
+  `PENDING_CLOSURE` and therefore exact. The rolling-30-day allowance (250 or 20% of
+  member accounts, capped at 1,000) and the four-day minimum age for removing a created
+  account are not, and the docs say why: both are bounded by a wall-clock window, and
+  substrate's clock is simulated and freely advanced, so such a refusal would fire or
+  not depending on unrelated `AdvanceTime` calls elsewhere in a test.
+
+### Changed
+- **Organization-wide email uniqueness stays reachable only through a seed** (#625),
+  now recorded as a decision rather than left as an open question. AWS surfaces a
+  collision asynchronously, as `CreateAccount` answering 200 and
+  `DescribeCreateAccountStatus` later reporting `FAILED` / `EMAIL_ALREADY_EXISTS`;
+  substrate models that shape but does not infer the collision from stored accounts.
+  Inferring it would *remove* a path rather than add one — every existing fixture that
+  vends two accounts with one email would start failing without asking to — and the
+  named cost is that a consumer wanting the collision must seed it. The stale
+  `TODO(#578)` pointing at a closed issue is gone.
+- The shared Organizations helpers now live in `organizations_state.go` beside the rest
+  of the foundation, rather than in whichever of v0.97.0's five per-lane files happened
+  to need them first (#625): `orgDeleteKey`, `isOrgAccountID`, `isOrgParentID`,
+  `orgOUNamesRoot`, `policyTypeAvailable`, `loadVisiblePolicy`, `rootSubtree` and the
+  `orgCheck*` validators. Behaviour-preserving — no test changed — and the point is the
+  next Organizations feature not reimplementing a near-duplicate because the original
+  was not where it looked.
 
 ### Fixed
 - **A Service Quotas increase is now filed under the account that requested it**

--- a/emulator/organizations_account.go
+++ b/emulator/organizations_account.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 )
 
 // CreateAccountState values, the model's CreateAccountState enum in full.
@@ -49,11 +48,13 @@ type orgPendingAccountOutcome struct {
 	FailureReason string `json:"failureReason,omitempty"`
 }
 
-// accountOperation claims the account vending and placement operations.
+// accountOperation claims the account vending, placement and closure operations.
 func (p *OrganizationsPlugin) accountOperation(op string) (orgHandler, bool) {
 	switch op {
 	case "CreateAccount":
 		return p.createAccount, true
+	case "CloseAccount":
+		return p.closeAccount, true
 	case "DescribeCreateAccountStatus":
 		return p.describeCreateAccountStatus, true
 	case "ListCreateAccountStatus":
@@ -172,7 +173,7 @@ func (p *OrganizationsPlugin) vendAccount(ctx context.Context, masterAcct, orgID
 		Arn:          fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", masterAcct, orgID, newAcctID),
 		Name:         name,
 		Email:        email,
-		Status:       "ACTIVE",
+		Status:       orgAccountStatusActive,
 		JoinedMethod: "CREATED",
 		JoinedAt:     EpochSeconds(p.tc.Now()),
 	}
@@ -201,11 +202,22 @@ func (p *OrganizationsPlugin) vendAccount(ctx context.Context, masterAcct, orgID
 // succeeds, which is the nominal path a new operation defaults to.
 //
 // The organization-wide email uniqueness AWS enforces — surfaced asynchronously
-// as EMAIL_ALREADY_EXISTS, not as an error from CreateAccount — is deliberately
-// not inferred from the stored accounts here. It stays reachable only through the
-// seed (TODO(#578)): inferring it would make a duplicate email fail whether the
-// test asked for it or not, which changes the outcome of an existing fixture
-// rather than adding a path a test can opt into.
+// as EMAIL_ALREADY_EXISTS, not as an error from CreateAccount — is **not**
+// inferred from the stored accounts, and that is a settled decision rather than a
+// pending one (#625). The seed is the only route to it.
+//
+// Inferring it would remove a path rather than add one: a fixture that vends two
+// accounts under one email succeeds today, and every such fixture would start
+// failing at a point it never asked to test. Seeding keeps the failure opt-in,
+// which is what CLAUDE.md's seeding rule asks for — a new operation defaults to
+// its nominal path and the alternate outcome is something a test reaches for
+// deliberately.
+//
+// The cost is real and worth naming: a consumer whose own logic depends on the
+// uniqueness constraint has to seed the collision rather than provoke it, so
+// substrate will not catch a caller that reuses an email by accident. That is the
+// trade — a false negative a test can opt out of, against a false positive it
+// cannot.
 func (p *OrganizationsPlugin) pendingCreateOutcome(ctx context.Context, accountName string) (orgPendingAccountOutcome, error) {
 	seed, err := p.resolveSeededCreateFailure(ctx, accountName)
 	if err != nil {
@@ -455,23 +467,4 @@ func (p *OrganizationsPlugin) moveAccount(reqCtx *orgCaller, req *AWSRequest) (*
 		return nil, fmt.Errorf("moveAccount place: %w", err)
 	}
 	return orgEmptyResponse(), nil
-}
-
-// isOrgParentID reports whether id has the shape of a ParentId — a root or an OU
-// — which is the pattern the model puts on both of MoveAccount's parent members.
-func isOrgParentID(id string) bool { return isOrgRootID(id) || isOrgOUID(id) }
-
-// orgOUNamesRoot reports whether an OU ID's embedded root segment is rootID. An
-// OU ID is "ou-" plus the containing root's suffix, a dash, and the OU's own
-// suffix, so the root an OU belongs to is readable from its ID alone.
-func orgOUNamesRoot(ouID, rootID string) bool {
-	if !isOrgOUID(ouID) || !isOrgRootID(rootID) {
-		return false
-	}
-	rest := ouID[len("ou-"):]
-	dash := strings.Index(rest, "-")
-	if dash <= 0 {
-		return false
-	}
-	return rest[:dash] == rootID[len("r-"):]
 }

--- a/emulator/organizations_close.go
+++ b/emulator/organizations_close.go
@@ -1,0 +1,245 @@
+package emulator
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// orgMaxConcurrentClosures is the number of member-account closures that may be
+// in progress at once: "Number of member accounts you can close concurrently: 3
+// — Only three account closures can be in progress at the same time. As soon as
+// one finishes, you can close another account", from "Quotas and service limits
+// for AWS Organizations" in the Organizations User Guide:
+// https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html
+//
+// This is the only closure quota substrate models, because it is the only one
+// countable from state. See the closeAccount doc comment for the two that are
+// deliberately left out.
+const orgMaxConcurrentClosures = 3
+
+// closeAccount closes a member account.
+//
+// The model gives CloseAccount no output shape — a success is an empty 200 — and
+// AWS documents it as "an asynchronous request that Amazon Web Services performs
+// in the background" whose progress is read through DescribeAccount: "While the
+// close account request is in progress, Account status will indicate
+// PENDING_CLOSURE. When the close account request completes, the status will
+// change to SUSPENDED."
+//
+// The account is *not* removed from the organization. It keeps its place in the
+// hierarchy, stays in ListAccounts, and keeps counting against the account quota,
+// which is what the User Guide means by "When an account is closed it does not
+// stop counting against this quota until it is permanently closed" — the
+// interaction with L-E619E033 that makes this worth modeling at all. A consumer
+// whose cleanup path closes accounts to make room does not get room, and that is
+// the observation substrate has to reproduce.
+//
+// Two of the three published closure quotas are deliberately not modeled: the
+// rolling-30-day allowance (the higher of 250 or 20% of member accounts, capped
+// at 1,000) and the four-day minimum age for removing a created account. Both are
+// bounded by a wall-clock window, and substrate's clock is simulated and freely
+// advanced — a refusal tied to such a window would fire or not depending on
+// unrelated AdvanceTime calls elsewhere in a test, which is the opposite of a
+// reproducible outcome. The concurrent-closure limit has no window: it is a count
+// of accounts currently in PENDING_CLOSURE, so it is exact.
+func (p *OrganizationsPlugin) closeAccount(reqCtx *orgCaller, req *AWSRequest) (*AWSResponse, error) {
+	goCtx := context.Background()
+	var input struct {
+		AccountID string `json:"AccountId"`
+	}
+	if err := orgUnmarshal(req.Body, &input); err != nil {
+		return nil, err
+	}
+	if input.AccountID == "" {
+		return nil, orgInvalidInput("INPUT_REQUIRED", "you must specify an AccountId")
+	}
+	// Shape before existence, the order AWS validates in: the member's pattern is
+	// ^\d{12}$, so anything else is a malformed request rather than a missing
+	// account. Answering AccountNotFoundException for "not-an-id" would send a
+	// caller looking for an account it never named.
+	if !isOrgAccountID(input.AccountID) {
+		return nil, orgInvalidInput("INVALID_PATTERN",
+			"an account ID must be 12 digits, got "+input.AccountID)
+	}
+
+	// Management-only, per the User Guide: "When you sign in to the organization's
+	// management account, you can close member accounts that are part of your
+	// organization." The guard is before any state read so a member cannot use the
+	// refusals below to probe the organization it belongs to.
+	if reqCtx.isMember() {
+		return nil, orgCloseAccountAccessDenied()
+	}
+
+	if _, err := p.ensureOrganization(goCtx, reqCtx.AccountID); err != nil {
+		return nil, fmt.Errorf("closeAccount ensure org: %w", err)
+	}
+	// "You can close an account when all features are enabled." Under
+	// CONSOLIDATED_BILLING the console hides the button entirely and directs the
+	// caller to close the account as its own root user, which is not this API.
+	featureSet, err := p.effectiveFeatureSet(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("closeAccount feature set: %w", err)
+	}
+	if featureSet != orgFeatureSetAll {
+		return nil, orgConstraintViolation("ORGANIZATION_NOT_IN_ALL_FEATURES_MODE",
+			"you can close an account only in an organization with all features enabled")
+	}
+
+	// The management account is refused on its identity rather than its state, so
+	// the check does not depend on a lookup. AWS is explicit that the API cannot do
+	// it at all: "You can't close the management account with this API."
+	if input.AccountID == reqCtx.AccountID {
+		return nil, orgConstraintViolation("CANNOT_CLOSE_MANAGEMENT_ACCOUNT",
+			"you attempted to close the management account; to close it you must first remove or close all member accounts in the organization")
+	}
+
+	// An account of another organization is reported as not found rather than
+	// denied, which is what the model's own message describes: "We can't find an
+	// Amazon Web Services account with the AccountId that you specified, or the
+	// account whose credentials you used to make this request isn't a member of an
+	// organization." Distinguishing the two would tell the caller that an account
+	// it cannot manage exists.
+	owner, err := p.organizationOwner(goCtx, input.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("closeAccount resolve owner: %w", err)
+	}
+	a, err := p.loadAccount(goCtx, input.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("closeAccount load account: %w", err)
+	}
+	if a == nil || owner != reqCtx.AccountID {
+		return nil, orgErr("AccountNotFoundException",
+			"We can't find an Amazon Web Services account with the AccountId "+input.AccountID)
+	}
+
+	// A closure already in flight and one already finished are different refusals.
+	// AWS declares both AccountAlreadyClosedException ("You attempted to close an
+	// account that is already closed") and ConflictException ("The request failed
+	// because it conflicts with the current state of the specified resource") for
+	// this operation but does not say which applies to a PENDING_CLOSURE target;
+	// substrate reads the "already closed" wording as the terminal state and
+	// answers the conflict for the in-flight one. A re-run of a teardown script can
+	// then tell "this is finishing" from "this was done", which one code for both
+	// cases would collapse.
+	switch a.Status {
+	case orgAccountStatusSuspended:
+		return nil, orgErr("AccountAlreadyClosedException",
+			"You attempted to close an account that is already closed")
+	case orgAccountStatusPendingClosure:
+		return nil, orgErr("ConflictException",
+			"The request failed because it conflicts with the current state of account "+a.ID)
+	}
+
+	inFlight, err := p.pendingClosureCount(goCtx, reqCtx.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("closeAccount count closures: %w", err)
+	}
+	if inFlight >= orgMaxConcurrentClosures {
+		return nil, orgConstraintViolation("CLOSE_ACCOUNT_REQUESTS_LIMIT_EXCEEDED",
+			fmt.Sprintf("you attempted to exceed the number of accounts that you can close at a time (%d)",
+				orgMaxConcurrentClosures))
+	}
+
+	a.Status = orgAccountStatusPendingClosure
+	if err := p.saveAccount(goCtx, reqCtx.AccountID, *a); err != nil {
+		return nil, fmt.Errorf("closeAccount save account: %w", err)
+	}
+	return orgEmptyResponse(), nil
+}
+
+// pendingClosureCount counts the accounts of an organization whose closure is in
+// flight, which is what the concurrent-closure quota is measured against.
+//
+// It reads through loadAccount rather than observeAccount on purpose: counting is
+// not an observation of any one account's status, and letting it advance would
+// mean that closing a fourth account converged the first three — so the quota
+// could never be reached, and a seeded or unobserved closure would silently
+// resolve behind a caller that never polled it.
+func (p *OrganizationsPlugin) pendingClosureCount(ctx context.Context, masterAcct string) (int, error) {
+	ids, err := p.loadAccountIDs(ctx, masterAcct)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, id := range ids {
+		a, err := p.loadAccount(ctx, id)
+		if err != nil {
+			return 0, err
+		}
+		if a != nil && a.Status == orgAccountStatusPendingClosure {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// observeAccount loads an account for an operation that reports its status,
+// advancing an in-flight closure as a side effect of the observation.
+//
+// Only the three operations that put an account's Status on the wire —
+// DescribeAccount, ListAccounts, ListAccountsForParent — read through this. Every
+// other loadAccount caller resolves an account as a policy target or a hierarchy
+// child and reports no status, so advancing there would move a closure a caller
+// never looked at.
+func (p *OrganizationsPlugin) observeAccount(ctx context.Context, id string) (*OrgAccount, error) {
+	a, err := p.loadAccount(ctx, id)
+	if err != nil || a == nil {
+		return a, err
+	}
+	if err := p.resolveAccountClosure(ctx, *a); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// resolveAccountClosure persists the terminal status of an in-flight closure,
+// leaving the status the caller is handed at PENDING_CLOSURE.
+//
+// So the first observation reports PENDING_CLOSURE and every later one reports
+// SUSPENDED. That is the same departure from resolveCreateAccountStatus the
+// Account Management Region opts make, and for the same reason: CloseAccount has
+// no output shape, so a poll is the only place PENDING_CLOSURE is ever
+// observable. Resolving on the first read instead would make a consumer's
+// in-flight branch unexecutable — it would see nothing but SUSPENDED, and the
+// wait loop AWS's documented status sequence exists to justify would never be
+// exercised.
+//
+// Resolving on observation rather than after an interval of the simulated clock
+// is the same choice resolveCreateAccountStatus makes: a waiter converges in two
+// polls with no dependence on wall-clock or simulated time, and clock-driven
+// transitions are the subject of #514.
+//
+// The record is written through orgPutJSON rather than saveAccount because a
+// status transition changes no membership: the account keeps its place in the
+// management account's member list, which is exactly what makes a closed account
+// still count against the account quota.
+func (p *OrganizationsPlugin) resolveAccountClosure(ctx context.Context, a OrgAccount) error {
+	if a.Status != orgAccountStatusPendingClosure {
+		return nil
+	}
+	a.Status = orgAccountStatusSuspended
+	if err := p.orgPutJSON(ctx, orgAccountKey(a.ID), a); err != nil {
+		return fmt.Errorf("resolve closure of %s: %w", a.ID, err)
+	}
+	return nil
+}
+
+// orgCloseAccountAccessDenied returns AccessDeniedException for a member account
+// calling CloseAccount, which the User Guide reserves to the management account.
+//
+// HTTP 403, matching orgResourcePolicyAccessDenied: the Organizations API
+// reference gives this code 400 on each operation page, while the service's
+// Common Errors page — where AccessDeniedException actually belongs, since it is
+// a common error rather than one the model declares — gives it 403. Whichever
+// reading is right, one service must answer one status for one code, or a
+// consumer's classifier would branch differently depending on which operation
+// denied it.
+func orgCloseAccountAccessDenied() *AWSError {
+	return &AWSError{
+		Code: "AccessDeniedException",
+		Message: "You don't have permissions to perform the requested operation. " +
+			"CloseAccount can be called only from the management account of the organization",
+		HTTPStatus: http.StatusForbidden,
+	}
+}

--- a/emulator/organizations_close_test.go
+++ b/emulator/organizations_close_test.go
@@ -1,0 +1,386 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// This file covers CloseAccount (#625). The interesting properties are all about
+// what a closure does *not* do: the account does not leave ListAccounts, does not
+// stop counting against the account quota, and does not reach SUSPENDED before a
+// caller has had one chance to observe PENDING_CLOSURE.
+
+// orgCloseAccount posts CloseAccount and returns the HTTP status and the error
+// code a refusal carries. A success has no output shape, so there is nothing else
+// to read.
+func orgCloseAccount(t *testing.T, ts *httptest.Server, accountID string) (int, string) {
+	t.Helper()
+	return orgErrorCodeOrEmpty(t, ts, "CloseAccount", map[string]interface{}{"AccountId": accountID})
+}
+
+// orgErrorCodeOrEmpty posts an operation whose success has no output shape,
+// returning the status and, for a refusal, the JSON-RPC error code.
+func orgErrorCodeOrEmpty(t *testing.T, ts *httptest.Server, op string, body map[string]interface{}) (int, string) {
+	t.Helper()
+	resp := orgsRequest(t, ts, op, body)
+	defer resp.Body.Close() //nolint:errcheck
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("%s decode body: %v", op, err)
+	}
+	if resp.StatusCode == http.StatusOK {
+		// The model gives CloseAccount no output shape, so an empty object is the
+		// whole success. A body carrying members would be a shape no SDK can decode
+		// into the operation's output struct.
+		if len(out) != 0 {
+			t.Errorf("%s answered 200 with %v, want an empty object — the model gives it no output shape", op, out)
+		}
+		return resp.StatusCode, ""
+	}
+	code, _ := out["__type"].(string)
+	return resp.StatusCode, code
+}
+
+// orgAccountStatus reads one account's Status through DescribeAccount, which is
+// the operation AWS documents as the way to watch a closure.
+func orgAccountStatus(t *testing.T, ts *httptest.Server, accountID string) string {
+	t.Helper()
+	resp := orgsRequest(t, ts, "DescribeAccount", map[string]interface{}{"AccountId": accountID})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DescribeAccount(%s): expected 200, got %d", accountID, resp.StatusCode)
+	}
+	var out struct {
+		Account struct {
+			Status string `json:"Status"`
+		} `json:"Account"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("DescribeAccount decode: %v", err)
+	}
+	return out.Account.Status
+}
+
+// orgListAccountStatuses reads every account's status out of ListAccounts, keyed
+// by ID.
+func orgListAccountStatuses(t *testing.T, ts *httptest.Server) map[string]string {
+	t.Helper()
+	resp := orgsRequest(t, ts, "ListAccounts", map[string]interface{}{})
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ListAccounts: expected 200, got %d", resp.StatusCode)
+	}
+	var out struct {
+		Accounts []struct {
+			ID     string `json:"Id"`
+			Status string `json:"Status"`
+		} `json:"Accounts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("ListAccounts decode: %v", err)
+	}
+	byID := make(map[string]string, len(out.Accounts))
+	for _, a := range out.Accounts {
+		byID[a.ID] = a.Status
+	}
+	return byID
+}
+
+// TestOrganizations_CloseAccountResolvesOnObservation is the nominal journey: an
+// empty 200, then PENDING_CLOSURE, then SUSPENDED, and stable after that.
+//
+// The two-step sequence is the point. CloseAccount has no output shape, so a poll
+// is the only place PENDING_CLOSURE is observable at all — resolving on the first
+// read would leave a consumer's in-flight branch unexecutable, and a status that
+// moved back would make a waiter comparing successive polls loop forever.
+func TestOrganizations_CloseAccountResolvesOnObservation(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	member := orgVendAccount(t, ts, "doomed", "doomed@example.com")
+
+	if status, code := orgCloseAccount(t, ts, member); status != http.StatusOK {
+		t.Fatalf("CloseAccount: %d %s", status, code)
+	}
+
+	if got := orgAccountStatus(t, ts, member); got != "PENDING_CLOSURE" {
+		t.Errorf("the first observation reads %q, want PENDING_CLOSURE — CloseAccount has no output, so this is the only place the in-flight status appears", got)
+	}
+	for i := range 3 {
+		if got := orgAccountStatus(t, ts, member); got != "SUSPENDED" {
+			t.Fatalf("observation %d reads %q, want SUSPENDED", i+2, got)
+		}
+	}
+}
+
+// TestOrganizations_CloseAccountKeepsTheAccountInTheOrganization is the
+// interaction with L-E619E033 that makes this worth modeling.
+//
+// The User Guide is explicit: "When an account is closed it does not stop counting
+// against this quota until it is permanently closed." So a consumer whose cleanup
+// path closes accounts to make room does not get room, and the account stays
+// visible in every listing. Removing it would make a broken cleanup script look
+// correct.
+func TestOrganizations_CloseAccountKeepsTheAccountInTheOrganization(t *testing.T) {
+	ts, _ := newOrgVendingFixture(t)
+
+	// Nine vended accounts plus the management account fills the default quota.
+	var members []string
+	for i := range 9 {
+		members = append(members, orgVendAccount(t, ts,
+			"member-"+string(rune('a'+i)), "member-"+string(rune('a'+i))+"@example.com"))
+	}
+	if status, code := orgErrorCode(t, ts, "CreateAccount", map[string]interface{}{
+		"AccountName": "one-too-many", "Email": "one-too-many@example.com",
+	}); status != http.StatusBadRequest || code != "ConstraintViolationException" {
+		t.Fatalf("the tenth vend answered %d %q, want 400/ConstraintViolationException", status, code)
+	}
+
+	if status, code := orgCloseAccount(t, ts, members[0]); status != http.StatusOK {
+		t.Fatalf("CloseAccount: %d %s", status, code)
+	}
+
+	// Still listed, and listed with its in-flight status: ListAccounts reports the
+	// same status DescribeAccount would, or a caller polling through the listing
+	// would disagree with one polling the Describe.
+	listed := orgListAccountStatuses(t, ts)
+	if got, ok := listed[members[0]]; !ok {
+		t.Errorf("ListAccounts dropped the closed account %s; a closed account stays in the organization until it is permanently closed", members[0])
+	} else if got != "PENDING_CLOSURE" {
+		t.Errorf("ListAccounts reports the closing account as %q, want PENDING_CLOSURE", got)
+	}
+	if len(listed) != 10 {
+		t.Errorf("ListAccounts returned %d accounts after a closure, want 10", len(listed))
+	}
+
+	// And the quota still refuses, which is the observation a cleanup script's
+	// author would otherwise get wrong.
+	if status, code := orgErrorCode(t, ts, "CreateAccount", map[string]interface{}{
+		"AccountName": "after-close", "Email": "after-close@example.com",
+	}); status != http.StatusBadRequest || code != "ConstraintViolationException" {
+		t.Errorf("vending after a closure answered %d %q, want 400/ConstraintViolationException — a closed account keeps counting against the quota",
+			status, code)
+	}
+}
+
+// TestOrganizations_CloseAccountRefusals covers every refusal that is about which
+// account was named, each one distinguishable from the others.
+func TestOrganizations_CloseAccountRefusals(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	member := orgVendAccount(t, ts, "doomed", "doomed@example.com")
+
+	tests := []struct {
+		name      string
+		accountID string
+		status    int
+		code      string
+		// wants is a fragment the message must carry. Two of these share a code, so
+		// the code alone does not identify which limit or reason was violated — the
+		// JSON-RPC error document has no reason member to read.
+		wants string
+	}{
+		{
+			name: "the management account cannot be closed through this API",
+			// orgTestAccount, because an unsigned request is account 000000000000 and
+			// therefore the management account of the organization this fixture
+			// auto-creates.
+			accountID: orgTestAccount,
+			status:    http.StatusBadRequest,
+			code:      "ConstraintViolationException",
+			wants:     "CANNOT_CLOSE_MANAGEMENT_ACCOUNT",
+		},
+		{
+			name:      "an account of another organization is not found",
+			accountID: "999988887777",
+			status:    http.StatusBadRequest,
+			code:      "AccountNotFoundException",
+		},
+		{
+			name:      "a malformed ID is a pattern violation, not a missing account",
+			accountID: "not-an-account",
+			status:    http.StatusBadRequest,
+			code:      "InvalidInputException",
+			wants:     "INVALID_PATTERN",
+		},
+		{
+			name:      "an absent AccountId is a missing required member",
+			accountID: "",
+			status:    http.StatusBadRequest,
+			code:      "InvalidInputException",
+			wants:     "INPUT_REQUIRED",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := orgsRequest(t, ts, "CloseAccount", map[string]interface{}{"AccountId": tc.accountID})
+			defer resp.Body.Close() //nolint:errcheck
+			var out struct {
+				Type    string `json:"__type"`
+				Message string `json:"message"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp.StatusCode != tc.status || out.Type != tc.code {
+				t.Fatalf("CloseAccount(%q) answered %d %q, want %d %q",
+					tc.accountID, resp.StatusCode, out.Type, tc.status, tc.code)
+			}
+			if tc.wants != "" && !strings.Contains(out.Message, tc.wants) {
+				t.Errorf("the refusal message is %q; it must name %q, since the error document has no reason member",
+					out.Message, tc.wants)
+			}
+		})
+	}
+
+	// The member itself is closable, which is what makes the refusals above about
+	// the target rather than the operation being broken.
+	if status, code := orgCloseAccount(t, ts, member); status != http.StatusOK {
+		t.Fatalf("CloseAccount on a member: %d %s", status, code)
+	}
+}
+
+// TestOrganizations_CloseAccountTwiceIsDistinguishable separates the two states a
+// second close can find: a closure still in flight, and one already finished.
+//
+// The model declares both ConflictException and AccountAlreadyClosedException for
+// this operation and does not say which applies to a PENDING_CLOSURE target.
+// Substrate reads "already closed" as the terminal state, so a teardown script
+// re-run can tell "this is finishing" from "this was done" — one code for both
+// would collapse that.
+func TestOrganizations_CloseAccountTwiceIsDistinguishable(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	member := orgVendAccount(t, ts, "doomed", "doomed@example.com")
+
+	if status, code := orgCloseAccount(t, ts, member); status != http.StatusOK {
+		t.Fatalf("CloseAccount: %d %s", status, code)
+	}
+	// No observation between the two closes, so the account is still
+	// PENDING_CLOSURE.
+	if status, code := orgCloseAccount(t, ts, member); status != http.StatusBadRequest ||
+		code != "ConflictException" {
+		t.Errorf("closing an in-flight closure answered %d %q, want 400/ConflictException", status, code)
+	}
+
+	// Two observations take it to SUSPENDED, and then the refusal changes.
+	orgAccountStatus(t, ts, member)
+	if got := orgAccountStatus(t, ts, member); got != "SUSPENDED" {
+		t.Fatalf("the account is %q after two observations, want SUSPENDED", got)
+	}
+	if status, code := orgCloseAccount(t, ts, member); status != http.StatusBadRequest ||
+		code != "AccountAlreadyClosedException" {
+		t.Errorf("closing a SUSPENDED account answered %d %q, want 400/AccountAlreadyClosedException", status, code)
+	}
+}
+
+// TestOrganizations_CloseAccountConcurrencyLimit pins the one closure quota
+// substrate models: three closures in flight at once.
+//
+// It is countable from state — the number of accounts currently in
+// PENDING_CLOSURE — with no wall-clock window, which is exactly why it is modeled
+// and the rolling-30-day allowance is not. Counting must also not advance the
+// closures it counts: if it did, closing a fourth account would converge the first
+// three and the limit could never be reached.
+func TestOrganizations_CloseAccountConcurrencyLimit(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+
+	var members []string
+	for i := range 4 {
+		name := "member-" + string(rune('a'+i))
+		members = append(members, orgVendAccount(t, ts, name, name+"@example.com"))
+	}
+
+	for i, member := range members[:3] {
+		if status, code := orgCloseAccount(t, ts, member); status != http.StatusOK {
+			t.Fatalf("CloseAccount %d: %d %s", i+1, status, code)
+		}
+	}
+	status, code := orgCloseAccount(t, ts, members[3])
+	if status != http.StatusBadRequest || code != "ConstraintViolationException" {
+		t.Fatalf("the fourth concurrent closure answered %d %q, want 400/ConstraintViolationException", status, code)
+	}
+
+	// Observing all three to their terminal status frees the slots, so the fourth
+	// then succeeds. That is the "as soon as one finishes, you can close another"
+	// half of the quota, and it is what proves the count is of in-flight closures
+	// rather than of closures ever made.
+	for range 2 {
+		for _, member := range members[:3] {
+			orgAccountStatus(t, ts, member)
+		}
+	}
+	if status, code := orgCloseAccount(t, ts, members[3]); status != http.StatusOK {
+		t.Errorf("CloseAccount after the three in-flight closures finished: %d %s", status, code)
+	}
+}
+
+// TestOrganizations_CloseAccountRequiresAllFeatures gates the operation on the
+// feature set, per "You can close an account when all features are enabled".
+//
+// Under CONSOLIDATED_BILLING the console hides the button entirely and directs the
+// caller to close the account as its own root user, which is not this API.
+func TestOrganizations_CloseAccountRequiresAllFeatures(t *testing.T) {
+	ts := newOrganizationsTestServer(t)
+	member := orgVendAccount(t, ts, "doomed", "doomed@example.com")
+
+	orgSeedFeatureSet(t, ts, "CONSOLIDATED_BILLING")
+	resp := orgsRequest(t, ts, "CloseAccount", map[string]interface{}{"AccountId": member})
+	defer resp.Body.Close() //nolint:errcheck
+	var out struct {
+		Type    string `json:"__type"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest || out.Type != "ConstraintViolationException" {
+		t.Fatalf("CloseAccount under CONSOLIDATED_BILLING answered %d %q, want 400/ConstraintViolationException",
+			resp.StatusCode, out.Type)
+	}
+	if !strings.Contains(out.Message, "ORGANIZATION_NOT_IN_ALL_FEATURES_MODE") {
+		t.Errorf("the refusal message is %q; it must name the reason", out.Message)
+	}
+
+	// The account is untouched, so a caller that retries after enabling all
+	// features is not starting from a half-applied state.
+	if got := orgAccountStatus(t, ts, member); got != "ACTIVE" {
+		t.Errorf("the account is %q after a refused close, want ACTIVE", got)
+	}
+}
+
+// TestOrganizations_CloseAccountIsManagementOnly is the member half of the
+// asymmetry, through a signed request.
+//
+// The User Guide reserves closing a member account to the management account:
+// "When you sign in to the organization's management account, you can close member
+// accounts that are part of your organization." A member that could close its
+// siblings would let a compromised member account dismantle the organization.
+func TestOrganizations_CloseAccountIsManagementOnly(t *testing.T) {
+	ts := emulator.StartTestServerWithAccounts(t)
+
+	victim := orgVendMember(t, ts, "victim", "victim@example.com")
+	attacker := orgVendMember(t, ts, "attacker", "attacker@example.com")
+
+	status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, attacker, "CloseAccount",
+		map[string]any{"AccountId": victim}), nil)
+	if status != http.StatusForbidden || code != "AccessDeniedException" {
+		t.Fatalf("CloseAccount as a member answered %d %q, want 403/AccessDeniedException", status, code)
+	}
+
+	// A member cannot close itself either: the guard is on the caller, not on the
+	// relationship between caller and target.
+	status, code = decodeAWSResponse(t, orgSignedRequest(t, ts, attacker, "CloseAccount",
+		map[string]any{"AccountId": attacker}), nil)
+	if status != http.StatusForbidden || code != "AccessDeniedException" {
+		t.Errorf("a member closing itself answered %d %q, want 403/AccessDeniedException", status, code)
+	}
+
+	// Management closes the same account the member could not, so the refusals are
+	// about the caller.
+	if status, code := decodeAWSResponse(t, orgSignedRequest(t, ts, orgManagementAccount, "CloseAccount",
+		map[string]any{"AccountId": victim}), nil); status != http.StatusOK {
+		t.Errorf("CloseAccount as management: %d %s", status, code)
+	}
+}

--- a/emulator/organizations_ou.go
+++ b/emulator/organizations_ou.go
@@ -439,9 +439,11 @@ func (p *OrganizationsPlugin) listAccountsForParent(reqCtx *orgCaller, req *AWSR
 		return nil, err
 	}
 
+	// observeAccount, like ListAccounts: this operation reports Status too, and two
+	// listings of one account must not disagree about whether its closure finished.
 	accounts := make([]OrgAccount, 0, len(page))
 	for _, id := range page {
-		a, loadErr := p.loadAccount(goCtx, id)
+		a, loadErr := p.observeAccount(goCtx, id)
 		if loadErr != nil {
 			return nil, fmt.Errorf("listAccountsForParent load account: %w", loadErr)
 		}
@@ -587,28 +589,4 @@ func (p *OrganizationsPlugin) forgetOU(ctx context.Context, acct, ouID string) e
 		}
 	}
 	return nil
-}
-
-// orgDeleteKey removes a state key outright. Deletion is the one thing the
-// foundation's storage helpers do not cover, and an emptied-but-present index key
-// would keep a deleted entity's shadow in a state dump.
-func (p *OrganizationsPlugin) orgDeleteKey(ctx context.Context, key string) error {
-	if err := p.state.Delete(ctx, organizationsNamespace, key); err != nil {
-		return fmt.Errorf("delete %s: %w", key, err)
-	}
-	return nil
-}
-
-// isOrgAccountID reports whether id has the exactly-12-digits shape the model's
-// AccountId pattern requires.
-func isOrgAccountID(id string) bool {
-	if len(id) != 12 {
-		return false
-	}
-	for i := 0; i < len(id); i++ {
-		if id[i] < '0' || id[i] > '9' {
-			return false
-		}
-	}
-	return true
 }

--- a/emulator/organizations_plugin.go
+++ b/emulator/organizations_plugin.go
@@ -186,9 +186,12 @@ func (p *OrganizationsPlugin) listAccounts(reqCtx *orgCaller, req *AWSRequest) (
 		return nil, err
 	}
 
+	// Each account is read the way DescribeAccount reads it, so a caller polling
+	// through the listing sees a closure converge rather than watching
+	// PENDING_CLOSURE forever while a Describe of the same account reports SUSPENDED.
 	accounts := make([]OrgAccount, 0, len(page))
 	for _, id := range page {
-		a, loadErr := p.loadAccount(goCtx, id)
+		a, loadErr := p.observeAccount(goCtx, id)
 		if loadErr != nil {
 			return nil, fmt.Errorf("listAccounts load account: %w", loadErr)
 		}
@@ -218,7 +221,10 @@ func (p *OrganizationsPlugin) describeAccount(reqCtx *orgCaller, req *AWSRequest
 		return nil, err
 	}
 
-	a, err := p.loadAccount(goCtx, input.AccountID)
+	// observeAccount rather than loadAccount: DescribeAccount is the operation AWS
+	// documents as the way to watch a closure finish, so it is one of the reads that
+	// advances PENDING_CLOSURE to SUSPENDED.
+	a, err := p.observeAccount(goCtx, input.AccountID)
 	if err != nil {
 		return nil, fmt.Errorf("describeAccount load: %w", err)
 	}

--- a/emulator/organizations_policy.go
+++ b/emulator/organizations_policy.go
@@ -2,11 +2,9 @@ package emulator
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
-	"unicode/utf8"
 )
 
 // orgPolicyTypes is the PolicyType enum from the Organizations API model. A value
@@ -67,53 +65,6 @@ func (p *OrganizationsPlugin) policyOperation(op string) (orgHandler, bool) {
 	default:
 		return nil, false
 	}
-}
-
-// --- availability, the outermost gate ---
-//
-// Two different conditions stop an SCP being useful, and they are not the same
-// refusal:
-//
-//   - Not *available*: the organization is in CONSOLIDATED_BILLING mode, where the
-//     policy type does not exist at all. Nothing can create, read, attach or enable
-//     one, and the fix is a migration to all features.
-//   - Available but not *enabled*: an all-features organization whose root has had
-//     DisablePolicyType called on it. Policies still exist and can be created; only
-//     attachment is refused, and the fix is one EnablePolicyType call.
-//
-// The second is the dangerous state issue #578 point 6 is about, and it is only
-// distinguishable from the first if the two report differently. Availability is
-// modeled as visibility: while SCPs are unavailable no policy is visible, so every
-// operation that names one answers with its own documented not-found code. Only
-// CreatePolicy and EnablePolicyType name the feature set as the reason, because
-// those are the two operations whose error list in the API model declares
-// PolicyTypeNotAvailableForOrganizationException — emitting it from an operation
-// that does not declare it would hand a caller an exception its SDK cannot catch
-// by type, which is worse than a truthful "no such policy".
-
-// policyTypeAvailable reports whether service control policies exist at all for
-// the organization, which is true only under the ALL feature set.
-func (p *OrganizationsPlugin) policyTypeAvailable(ctx context.Context, acct string) (bool, error) {
-	featureSet, err := p.effectiveFeatureSet(ctx, acct)
-	if err != nil {
-		return false, err
-	}
-	return featureSet == orgFeatureSetAll, nil
-}
-
-// loadVisiblePolicy returns the policy only when service control policies are
-// available to the organization, and (nil, nil) otherwise. p-FullAWSAccess is
-// synthesized by loadPolicy rather than stored, so without this gate it would stay
-// readable in a CONSOLIDATED_BILLING organization that can hold no SCP at all.
-func (p *OrganizationsPlugin) loadVisiblePolicy(ctx context.Context, acct, policyID string) (*OrgPolicy, error) {
-	available, err := p.policyTypeAvailable(ctx, acct)
-	if err != nil {
-		return nil, err
-	}
-	if !available {
-		return nil, nil //nolint:nilnil // (nil, nil) = "no visible policy", handled by caller.
-	}
-	return p.loadPolicy(ctx, policyID)
 }
 
 // --- CreatePolicy ---
@@ -929,26 +880,6 @@ func scpEnabledOnStoredRoot(root OrgRoot) bool {
 	})
 }
 
-// rootSubtree returns every entity a policy can be attached to: the root, every
-// OU, and every account. DisablePolicyType clears the attachments of all of them
-// and EnablePolicyType restores FullAWSAccess to all of them, which is what AWS
-// does — an OU or account created while the type was off would otherwise come back
-// with no SCP at all, and the minimum-attachment rule would then be unenforceable
-// for it.
-func (p *OrganizationsPlugin) rootSubtree(ctx context.Context, acct, rootID string) ([]string, error) {
-	entities := []string{rootID}
-	ouIDs, err := p.loadOUIDs(ctx, acct)
-	if err != nil {
-		return nil, err
-	}
-	entities = append(entities, ouIDs...)
-	accountIDs, err := p.loadAccountIDs(ctx, acct)
-	if err != nil {
-		return nil, err
-	}
-	return append(entities, accountIDs...), nil
-}
-
 // orgRootWithPolicyTypes returns the root with PolicyTypes as an empty list rather
 // than null when nothing is enabled. The model's member is a list, and a caller
 // ranging over a null gets a nil-pointer panic in a typed SDK rather than an empty
@@ -1003,94 +934,6 @@ func orgPolicyNumberLimitExceeded(count int) bool { return count >= orgMaxSCPsPe
 // account; see orgFullAWSAccessArn.
 func orgPolicyArn(acct, orgID, policyID string) string {
 	return fmt.Sprintf("arn:aws:organizations::%s:policy/%s/service_control_policy/%s", acct, orgID, policyID)
-}
-
-// orgCheckPolicyType validates a PolicyType or a ListPolicies Filter against the
-// model's enum. A value outside the enum is a caller typo and gets
-// INVALID_ENUM_POLICY_TYPE; a valid value substrate does not model is refused
-// separately by each operation, because what the caller should do about it differs.
-func orgCheckPolicyType(policyType string) error {
-	if !slices.Contains(orgPolicyTypes, policyType) {
-		return orgInvalidInput("INVALID_ENUM_POLICY_TYPE", "You specified an invalid policy type string: "+policyType)
-	}
-	return nil
-}
-
-// orgCheckPolicyID validates a PolicyId against the model's pattern. A malformed ID
-// is INVALID_SYNTAX_POLICY_ID rather than PolicyNotFoundException, so a caller that
-// passed a policy name where an ID belongs learns that instead of concluding the
-// policy was deleted.
-func orgCheckPolicyID(policyID string) error {
-	if policyID == "" {
-		return orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter PolicyId.")
-	}
-	if !isOrgPolicyIDSyntax(policyID) {
-		return orgInvalidInput("INVALID_SYNTAX_POLICY_ID", "You specified an invalid policy ID: "+policyID)
-	}
-	return nil
-}
-
-// orgCheckTargetID validates a TargetId against the model's pattern, which admits
-// a root, a 12-digit account, or an OU — and not a policy ID.
-func orgCheckTargetID(targetID string) error {
-	if targetID == "" {
-		return orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter TargetId.")
-	}
-	if !isOrgTargetIDSyntax(targetID) {
-		return orgInvalidInput("INVALID_PATTERN_TARGET_ID", "You specified a target that doesn't match the required pattern: "+targetID)
-	}
-	return nil
-}
-
-// orgCheckPolicyName validates a policy name against the model's PolicyName shape
-// (1 to 128 characters).
-func orgCheckPolicyName(name string) error {
-	switch {
-	case name == "":
-		return orgInvalidInput("MIN_LENGTH_EXCEEDED", "You provided a name that is shorter than the minimum of 1 character")
-	case utf8.RuneCountInString(name) > orgMaxPolicyNameChars:
-		return orgInvalidInput("MAX_LENGTH_EXCEEDED",
-			fmt.Sprintf("You provided a name longer than the maximum of %d characters", orgMaxPolicyNameChars))
-	default:
-		return nil
-	}
-}
-
-// orgCheckPolicyDescription validates a description against the model's
-// PolicyDescription shape (up to 512 characters; empty is permitted).
-func orgCheckPolicyDescription(description string) error {
-	if utf8.RuneCountInString(description) > orgMaxPolicyDescriptionChars {
-		return orgInvalidInput("MAX_LENGTH_EXCEEDED",
-			fmt.Sprintf("You provided a description longer than the maximum of %d characters", orgMaxPolicyDescriptionChars))
-	}
-	return nil
-}
-
-// orgCheckPolicyContent validates an SCP document: the size quota first, then
-// whether it parses at all. The two are different refusals because they call for
-// different fixes — a document over the limit has to be split across policies,
-// while an unparseable one has to be corrected — and a caller cannot tell them
-// apart from one code.
-func orgCheckPolicyContent(content string) error {
-	if content == "" {
-		return orgInvalidInput("MIN_LENGTH_EXCEEDED", "You provided a policy document that is shorter than the minimum of 1 character")
-	}
-	// The quota is stated in characters, so a multi-byte document is measured in
-	// runes: counting bytes would refuse a document AWS accepts.
-	if utf8.RuneCountInString(content) > orgMaxSCPBytes {
-		return orgConstraintViolation("POLICY_CONTENT_LIMIT_EXCEEDED",
-			fmt.Sprintf("You have exceeded the maximum size of a policy document (%d characters)", orgMaxSCPBytes))
-	}
-	// Substrate does not evaluate an SCP, so it checks only that the document is a
-	// JSON object — the boundary between "the caller sent something a policy engine
-	// could read" and "the caller sent a string it never templated". Judging the
-	// statement semantics would be modeling the authorization engine, not the API.
-	var doc map[string]interface{}
-	if err := json.Unmarshal([]byte(content), &doc); err != nil {
-		return orgErr("MalformedPolicyDocumentException",
-			"The provided policy document doesn't meet the requirements of the specified policy type: "+err.Error())
-	}
-	return nil
 }
 
 // Policy string-length quotas, from the model's PolicyName and PolicyDescription

--- a/emulator/organizations_state.go
+++ b/emulator/organizations_state.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
+	"strings"
+	"unicode/utf8"
 )
 
 // Organizations quotas. Every value below is from "Quotas for AWS Organizations"
@@ -79,6 +82,15 @@ const orgPolicyTypeSCP = "SERVICE_CONTROL_POLICY"
 const (
 	orgFeatureSetAll                 = "ALL"
 	orgFeatureSetConsolidatedBilling = "CONSOLIDATED_BILLING"
+)
+
+// Account statuses, the model's AccountStatus enum in full. There is no CLOSED
+// member: a closed account reports SUSPENDED, and PENDING_CLOSURE is the
+// in-flight status CloseAccount's asynchronous request passes through.
+const (
+	orgAccountStatusActive         = "ACTIVE"
+	orgAccountStatusSuspended      = "SUSPENDED"
+	orgAccountStatusPendingClosure = "PENDING_CLOSURE"
 )
 
 // p-FullAWSAccess, the AWS-managed SCP that permits everything. AWS attaches it
@@ -275,6 +287,16 @@ func (p *OrganizationsPlugin) orgRemoveID(ctx context.Context, key, id string) (
 	return true, nil
 }
 
+// orgDeleteKey removes a state key outright. Deletion is the one thing the
+// foundation's storage helpers do not cover, and an emptied-but-present index key
+// would keep a deleted entity's shadow in a state dump.
+func (p *OrganizationsPlugin) orgDeleteKey(ctx context.Context, key string) error {
+	if err := p.state.Delete(ctx, organizationsNamespace, key); err != nil {
+		return fmt.Errorf("delete %s: %w", key, err)
+	}
+	return nil
+}
+
 // --- pagination ---
 
 // orgPaginate returns one page of ids and the token for the next, honoring the
@@ -421,7 +443,7 @@ func (p *OrganizationsPlugin) ensureOrganization(ctx context.Context, acct strin
 		Arn:          org.MasterAccountArn,
 		Name:         "master",
 		Email:        "master@example.com",
-		Status:       "ACTIVE",
+		Status:       orgAccountStatusActive,
 		JoinedMethod: "INVITED",
 		JoinedAt:     EpochSeconds(p.tc.Now()),
 	}
@@ -617,6 +639,39 @@ func isOrgOUID(id string) bool { return len(id) > 3 && id[:3] == "ou-" }
 // isOrgRootID reports whether id has the "r-" prefix of a root.
 func isOrgRootID(id string) bool { return len(id) > 2 && id[:2] == "r-" }
 
+// isOrgAccountID reports whether id has the exactly-12-digits shape the model's
+// AccountId pattern requires.
+func isOrgAccountID(id string) bool {
+	if len(id) != 12 {
+		return false
+	}
+	for i := 0; i < len(id); i++ {
+		if id[i] < '0' || id[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// isOrgParentID reports whether id has the shape of a ParentId — a root or an OU
+// — which is the pattern the model puts on both of MoveAccount's parent members.
+func isOrgParentID(id string) bool { return isOrgRootID(id) || isOrgOUID(id) }
+
+// orgOUNamesRoot reports whether an OU ID's embedded root segment is rootID. An
+// OU ID is "ou-" plus the containing root's suffix, a dash, and the OU's own
+// suffix, so the root an OU belongs to is readable from its ID alone.
+func orgOUNamesRoot(ouID, rootID string) bool {
+	if !isOrgOUID(ouID) || !isOrgRootID(rootID) {
+		return false
+	}
+	rest := ouID[len("ou-"):]
+	dash := strings.Index(rest, "-")
+	if dash <= 0 {
+		return false
+	}
+	return rest[:dash] == rootID[len("r-"):]
+}
+
 // --- organizational units ---
 
 func (p *OrganizationsPlugin) saveOU(ctx context.Context, acct string, ou OrgOrganizationalUnit) error {
@@ -694,6 +749,163 @@ func fullAWSAccessPolicy() OrgPolicy {
 		},
 		Content: orgFullAWSAccessContent,
 	}
+}
+
+// --- availability, the outermost gate ---
+//
+// Two different conditions stop an SCP being useful, and they are not the same
+// refusal:
+//
+//   - Not *available*: the organization is in CONSOLIDATED_BILLING mode, where the
+//     policy type does not exist at all. Nothing can create, read, attach or enable
+//     one, and the fix is a migration to all features.
+//   - Available but not *enabled*: an all-features organization whose root has had
+//     DisablePolicyType called on it. Policies still exist and can be created; only
+//     attachment is refused, and the fix is one EnablePolicyType call.
+//
+// The second is the dangerous state issue #578 point 6 is about, and it is only
+// distinguishable from the first if the two report differently. Availability is
+// modeled as visibility: while SCPs are unavailable no policy is visible, so every
+// operation that names one answers with its own documented not-found code. Only
+// CreatePolicy and EnablePolicyType name the feature set as the reason, because
+// those are the two operations whose error list in the API model declares
+// PolicyTypeNotAvailableForOrganizationException — emitting it from an operation
+// that does not declare it would hand a caller an exception its SDK cannot catch
+// by type, which is worse than a truthful "no such policy".
+
+// policyTypeAvailable reports whether service control policies exist at all for
+// the organization, which is true only under the ALL feature set.
+func (p *OrganizationsPlugin) policyTypeAvailable(ctx context.Context, acct string) (bool, error) {
+	featureSet, err := p.effectiveFeatureSet(ctx, acct)
+	if err != nil {
+		return false, err
+	}
+	return featureSet == orgFeatureSetAll, nil
+}
+
+// loadVisiblePolicy returns the policy only when service control policies are
+// available to the organization, and (nil, nil) otherwise. p-FullAWSAccess is
+// synthesized by loadPolicy rather than stored, so without this gate it would stay
+// readable in a CONSOLIDATED_BILLING organization that can hold no SCP at all.
+func (p *OrganizationsPlugin) loadVisiblePolicy(ctx context.Context, acct, policyID string) (*OrgPolicy, error) {
+	available, err := p.policyTypeAvailable(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	if !available {
+		return nil, nil //nolint:nilnil // (nil, nil) = "no visible policy", handled by caller.
+	}
+	return p.loadPolicy(ctx, policyID)
+}
+
+// rootSubtree returns every entity a policy can be attached to: the root, every
+// OU, and every account. DisablePolicyType clears the attachments of all of them
+// and EnablePolicyType restores FullAWSAccess to all of them, which is what AWS
+// does — an OU or account created while the type was off would otherwise come back
+// with no SCP at all, and the minimum-attachment rule would then be unenforceable
+// for it.
+func (p *OrganizationsPlugin) rootSubtree(ctx context.Context, acct, rootID string) ([]string, error) {
+	entities := []string{rootID}
+	ouIDs, err := p.loadOUIDs(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	entities = append(entities, ouIDs...)
+	accountIDs, err := p.loadAccountIDs(ctx, acct)
+	if err != nil {
+		return nil, err
+	}
+	return append(entities, accountIDs...), nil
+}
+
+// --- policy input validation ---
+
+// orgCheckPolicyType validates a PolicyType or a ListPolicies Filter against the
+// model's enum. A value outside the enum is a caller typo and gets
+// INVALID_ENUM_POLICY_TYPE; a valid value substrate does not model is refused
+// separately by each operation, because what the caller should do about it differs.
+func orgCheckPolicyType(policyType string) error {
+	if !slices.Contains(orgPolicyTypes, policyType) {
+		return orgInvalidInput("INVALID_ENUM_POLICY_TYPE", "You specified an invalid policy type string: "+policyType)
+	}
+	return nil
+}
+
+// orgCheckPolicyID validates a PolicyId against the model's pattern. A malformed ID
+// is INVALID_SYNTAX_POLICY_ID rather than PolicyNotFoundException, so a caller that
+// passed a policy name where an ID belongs learns that instead of concluding the
+// policy was deleted.
+func orgCheckPolicyID(policyID string) error {
+	if policyID == "" {
+		return orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter PolicyId.")
+	}
+	if !isOrgPolicyIDSyntax(policyID) {
+		return orgInvalidInput("INVALID_SYNTAX_POLICY_ID", "You specified an invalid policy ID: "+policyID)
+	}
+	return nil
+}
+
+// orgCheckTargetID validates a TargetId against the model's pattern, which admits
+// a root, a 12-digit account, or an OU — and not a policy ID.
+func orgCheckTargetID(targetID string) error {
+	if targetID == "" {
+		return orgInvalidInput("INPUT_REQUIRED", "You must specify a value for the parameter TargetId.")
+	}
+	if !isOrgTargetIDSyntax(targetID) {
+		return orgInvalidInput("INVALID_PATTERN_TARGET_ID", "You specified a target that doesn't match the required pattern: "+targetID)
+	}
+	return nil
+}
+
+// orgCheckPolicyName validates a policy name against the model's PolicyName shape
+// (1 to 128 characters).
+func orgCheckPolicyName(name string) error {
+	switch {
+	case name == "":
+		return orgInvalidInput("MIN_LENGTH_EXCEEDED", "You provided a name that is shorter than the minimum of 1 character")
+	case utf8.RuneCountInString(name) > orgMaxPolicyNameChars:
+		return orgInvalidInput("MAX_LENGTH_EXCEEDED",
+			fmt.Sprintf("You provided a name longer than the maximum of %d characters", orgMaxPolicyNameChars))
+	default:
+		return nil
+	}
+}
+
+// orgCheckPolicyDescription validates a description against the model's
+// PolicyDescription shape (up to 512 characters; empty is permitted).
+func orgCheckPolicyDescription(description string) error {
+	if utf8.RuneCountInString(description) > orgMaxPolicyDescriptionChars {
+		return orgInvalidInput("MAX_LENGTH_EXCEEDED",
+			fmt.Sprintf("You provided a description longer than the maximum of %d characters", orgMaxPolicyDescriptionChars))
+	}
+	return nil
+}
+
+// orgCheckPolicyContent validates an SCP document: the size quota first, then
+// whether it parses at all. The two are different refusals because they call for
+// different fixes — a document over the limit has to be split across policies,
+// while an unparseable one has to be corrected — and a caller cannot tell them
+// apart from one code.
+func orgCheckPolicyContent(content string) error {
+	if content == "" {
+		return orgInvalidInput("MIN_LENGTH_EXCEEDED", "You provided a policy document that is shorter than the minimum of 1 character")
+	}
+	// The quota is stated in characters, so a multi-byte document is measured in
+	// runes: counting bytes would refuse a document AWS accepts.
+	if utf8.RuneCountInString(content) > orgMaxSCPBytes {
+		return orgConstraintViolation("POLICY_CONTENT_LIMIT_EXCEEDED",
+			fmt.Sprintf("You have exceeded the maximum size of a policy document (%d characters)", orgMaxSCPBytes))
+	}
+	// Substrate does not evaluate an SCP, so it checks only that the document is a
+	// JSON object — the boundary between "the caller sent something a policy engine
+	// could read" and "the caller sent a string it never templated". Judging the
+	// statement semantics would be modeling the authorization engine, not the API.
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &doc); err != nil {
+		return orgErr("MalformedPolicyDocumentException",
+			"The provided policy document doesn't meet the requirements of the specified policy type: "+err.Error())
+	}
+	return nil
 }
 
 // --- policy attachments ---


### PR DESCRIPTION
Closes #625

The three items v0.97.0 deferred and #625 grouped. Each is small; none blocked a consumer on its own.

## `CloseAccount`

Completes the account lifecycle v0.97.0 began with vending, placement and governance. A success is an empty 200 — the model gives the operation no output shape — and the closure is read through `DescribeAccount`, which AWS documents as the way to watch it: `PENDING_CLOSURE` while in flight, `SUSPENDED` when done.

**A closed account does not leave the organization.** That is the reason this is worth modeling rather than a detail of it. It keeps its place in the hierarchy, stays in `ListAccounts` and `ListAccountsForParent`, and keeps counting against `L-E619E033` — "when an account is closed it does not stop counting against this quota until it is permanently closed". A cleanup path that closes accounts to make room for new ones gets no room, and `CreateAccount` still refuses. Removing the account instead would make that broken script pass, which is the interaction v0.98.0 made readable.

The transition **resolves on observation**, not off the clock (#514 remains the subject of clock-driven transitions), and reports the in-flight status on the *first* observation for the same reason `EnableRegion` does: with no output shape, a poll is the only place `PENDING_CLOSURE` is ever visible, so resolving sooner leaves a consumer's in-flight branch unexecutable. Only the three operations that put an account's `Status` on the wire advance it, through a new `observeAccount` seam. The concurrency count deliberately reads through `loadAccount` instead — counting through an observation would let closing a fourth account converge the first three, and the quota could then never be reached.

Refusals are each distinguishable, because the JSON-RPC error document carries only a code and a message, so the reason rides at the front of the message:

| Case | Answer |
|---|---|
| The management account | `ConstraintViolationException` / `CANNOT_CLOSE_MANAGEMENT_ACCOUNT` |
| An account of another organization | `AccountNotFoundException` |
| A malformed ID | `InvalidInputException` / `INVALID_PATTERN` — shape before existence |
| A `CONSOLIDATED_BILLING` organization | `ConstraintViolationException` / `ORGANIZATION_NOT_IN_ALL_FEATURES_MODE`, account untouched |
| A closure already in flight | `ConflictException` |
| A closure already finished | `AccountAlreadyClosedException` |
| A member account calling it at all | `AccessDeniedException`, 403 |

Two of those deserve a note. The model declares both `ConflictException` and `AccountAlreadyClosedException` and does not say which applies to a `PENDING_CLOSURE` target; substrate reads "already closed" as the terminal state and answers the conflict for the in-flight one, so a re-run of a teardown script can tell "this is finishing" from "this was done". And the member guard runs before any state read, so a member cannot use the other refusals to probe the organization it belongs to — it is 403 rather than 400 to match `orgResourcePolicyAccessDenied` and the Common Errors page, since one service must answer one status per code or a consumer's classifier branches inconsistently.

One of the three published closure quotas is modeled: **3 concurrent closures**, a count of accounts currently in `PENDING_CLOSURE` and therefore exact. The rolling-30-day allowance (250 / 20% / 1,000) and the four-day minimum age are not, and the code and docs say why: both are bounded by a wall-clock window, and substrate's clock is simulated and freely advanced, so such a refusal would fire or not depending on unrelated `AdvanceTime` calls elsewhere in a test.

## The email-uniqueness decision

Recorded rather than left open. AWS surfaces a collision asynchronously — `CreateAccount` answers 200, `DescribeCreateAccountStatus` later reports `FAILED` / `EMAIL_ALREADY_EXISTS` — and substrate models that shape without inferring the collision from stored accounts. Inferring it *removes* a path rather than adding one: every existing fixture vending two accounts with one email would start failing without asking to. The named cost is that a consumer wanting the collision must seed it. The stale `TODO(#578)`, pointing at a closed issue, is gone.

## The helper hoist

`orgDeleteKey`, `isOrgAccountID`, `isOrgParentID`, `orgOUNamesRoot`, `policyTypeAvailable`, `loadVisiblePolicy`, `rootSubtree` and the `orgCheck*` validators move to `organizations_state.go` beside the rest of the foundation, out of whichever of v0.97.0's five per-lane files needed them first. Behaviour-preserving: **no test file changed**, and the `organizations_account_export_test.go` seam still compiles. Done last so it did not turn the other lanes into merge puzzles.

## Verification

- `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**
- `make test` (race detector) green; `make coverage` at emulator **82.2%**, total **81.5%**
- `make docs-reference-check docs-versions` clean; `go vet -C test/e2e ./... && go test -C test/e2e ./...` green
- Live against `substrate server --address :4678` with `AWS_MAX_ATTEMPTS=1`, the plan's repro verbatim: close → empty 200; `describe-account` → `PENDING_CLOSURE` then `SUSPENDED` and stable; `list-accounts` → still present as `SUSPENDED`; re-close → `AccountAlreadyClosedException`; close management → `CANNOT_CLOSE_MANAGEMENT_ACCOUNT`

Mutation testing, full-package `-race` runs, restored from saved `.orig`:

| Mutant | Verdict |
|---|---|
| `CloseAccount` removes the account from the member index | **CAUGHT** (2 tests) |
| The closure resolves on the first observation | **CAUGHT** (2 tests) |
| `pendingClosureCount` counts through `observeAccount` | **CAUGHT** |
| The member guard dropped from `closeAccount` | **CAUGHT** |
| The hoisted `orgOUNamesRoot` body stubbed to `true` | **CAUGHT** (2 tests) |

No survivors. One unrelated flake surfaced while running these and is filed separately as **#634**: `startFakeRIE` re-binds a `FindFreePort` result, so `TestInvokePOST_*` fail intermittently under `-count>1`. Reproduced on unmodified `main` in a clean worktree; not touched here.