### PR TITLE
docs(services): caller-identity behaviour, plus two defects the e2e journeys found (#636, #634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,11 +150,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was not where it looked.
 
 ### Fixed
+- **`make test` no longer flakes on a reused Lambda port** (#634). The two
+  `TestInvokePOST` tests that stand in a fake runtime interface emulator asked
+  `findFreePort` for a number and then bound it, and `findFreePort` closes its own
+  listener before returning — so between the close and the re-bind the port belonged to
+  nobody, and a sibling `t.Parallel()` test could be handed the same one. The loser got
+  `bind: address already in use`. They now bind port 0 and read the port back off the
+  live listener, which is atomic. `findFreePort` itself is unchanged: its callers hand
+  the number to Docker's `-p`, which has to do the binding, so the gap is inherent
+  there and only a test could avoid it.
+- **The Service Quotas increase history is reachable from an SDK at all** (#636).
+  The operation was routed as `ListRequestedServiceQuotaChangesByService`, a name the
+  Service Quotas API does not have: the 2019-06-24 model declares
+  `ListRequestedServiceQuotaChangeHistory` and
+  `ListRequestedServiceQuotaChangeHistoryByQuota`, and nothing of that shape. So the
+  handler was reachable only by a hand-built `X-Amz-Target` — exactly what the plugin's
+  unit tests supply, which is why they stayed green while every real SDK and CLI call
+  answered `InvalidAction`. Found by the #624 end-to-end journey, the same class of gap
+  as #561 and #610.
+
+  The real name is now routed and the invented one kept as an alias, so a fixture that
+  already drives it does not break. The `Status` filter the model declares is honored
+  rather than ignored: a caller narrowing its history query to `DENIED` was handed the
+  `PENDING` records back, and would read an outcome the service never reported.
+  `…ChangeHistoryByQuota` remains unmodelled, and the docs say so.
 - **A Service Quotas increase is now filed under the account that requested it**
   (#624). `ServiceQuotasPlugin.HandleRequest` discarded its `*RequestContext` and
   the three quota-increase operations hardcoded the literal `000000000000`, so two
   accounts sharing one emulator shared one pile of requests. A consumer reading
-  `ListRequestedServiceQuotaChangesByService` to decide whether it had already asked
+  `ListRequestedServiceQuotaChangeHistory` to decide whether it had already asked
   for a raise would find *another* account's request and skip filing its own, and
   `GetRequestedServiceQuotaChange` would hand over a request by ID to any caller.
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -4502,6 +4502,7 @@ document has no `Reason` member to put them in.
 | DescribeCreateAccountStatus | Resolves the request on first observation; `CreateAccountStatusNotFoundException` |
 | ListCreateAccountStatus | Filterable by `States` |
 | MoveAccount | The only way an account leaves the root |
+| CloseAccount | **Asynchronous**, no output shape; management-only; the account stays in the organization |
 | CreateOrganizationalUnit | `Name` 1–128 characters; accepts inline `Tags` |
 | DescribeOrganizationalUnit | `OrganizationalUnitNotFoundException` |
 | UpdateOrganizationalUnit | Renames in place — ID, ARN, children and attachments all survive |
@@ -4563,11 +4564,45 @@ document's *meaning*, and the sets AWS accepts are not in the model, so emitting
 them would mean guessing at their boundaries. A guessed refusal is worse than a
 missing one: it fails a document AWS would have accepted.
 
-**Not modelled:** the asymmetry itself. Organizations state is keyed by the
-**calling** account, so a member account calling `DescribeResourcePolicy` reads its
-own organization rather than management's, and there is no
-`AccessDeniedException` for a caller outside the organization. Both need a
-member→organization reverse index, tracked in #623.
+### A member account sees its management account's organization
+
+Organizations state is keyed by the management account, and every account
+substrate knows is indexed to the organization it belongs to. So a **member**
+account calling any Organizations operation reads management's organization — the
+same organization ID, the same root, the same accounts — rather than a private one
+of its own. A vended account signing its own requests is a real member, which is
+what makes a two-account governance flow testable at all.
+
+An account substrate has never seen still gets an organization auto-created for
+it on first contact. That no-setup path is what makes a fresh emulator usable
+without a `CreateOrganization` call, and it is only reachable for an account that
+is not a known member of anything.
+
+The reads are **not** uniform across the three resource-policy operations, because
+AWS's own permissions are not:
+
+| Caller | `DescribeResourcePolicy` | `Put`/`DeleteResourcePolicy` |
+|---|---|---|
+| The management account | The policy, or `ResourcePolicyNotFoundException` | Allowed |
+| A member the policy names | The **same** policy management set | `AccessDeniedException` (403) |
+| A member the policy does not name | `AccessDeniedException` (403) | `AccessDeniedException` (403) |
+
+`DescribeOrganization` stays readable by every account in the organization, per
+"can be called from any account in the organization"; `DescribeResourcePolicy` is
+documented as callable from the management account *or a member account that is a
+delegated administrator*, and for Organizations itself that delegation comes from
+the resource policy substrate already stores. Making the two uniform would erase a
+distinction a governance tool depends on.
+
+`AccessDeniedException` is HTTP **403** here, not the 400 every declared
+Organizations exception uses. It is a *common* error the service model does not
+declare at all, and the API Reference's Common Errors page gives it 403 — which is
+what an SDK's retry classifier reads.
+
+A caller in **no** relationship to the organization is not reachable through this
+API: none of the three operations takes an input naming an organization, so there
+is nowhere to put another organization's ID. The reachable third case is a member
+the policy does not name.
 
 ### `p-FullAWSAccess`
 
@@ -4598,6 +4633,66 @@ New accounts land in the **root**. `MoveAccount` is the only way into an OU, and
 a move to the account's current parent is `DuplicateAccountException`, not a
 no-op — which is what makes a vending script's re-run testable: the second run
 hits the refusal rather than silently duplicating.
+
+Organization-wide **email uniqueness is reachable only through the seed**. AWS
+enforces it and surfaces a collision asynchronously — `CreateAccount` answers 200
+and `DescribeCreateAccountStatus` later reports `FAILED` /
+`EMAIL_ALREADY_EXISTS` — and substrate models that shape without inferring the
+collision from the accounts it holds. Inferring it would *remove* a path rather
+than add one: every fixture that vends two accounts with one email would start
+failing without having asked to. The cost is that a consumer wanting the collision
+must seed it, which is the trade taken deliberately.
+
+### Closing an account does not remove it
+
+`CloseAccount` has **no output shape** — a success is an empty 200 — and the
+closure is read through `DescribeAccount`, which is how AWS documents watching it:
+`PENDING_CLOSURE` while the request is in flight, `SUSPENDED` when it completes.
+There is no `CLOSED` status; the model's `AccountStatus` enum is exactly those
+three values.
+
+The closed account **stays in the organization**. It keeps its place in the
+hierarchy, still appears in `ListAccounts` and `ListAccountsForParent`, and keeps
+counting against the accounts-per-organization quota — "when an account is closed
+it does not stop counting against this quota until it is permanently closed". So a
+cleanup path that closes accounts to make room for new ones **gets no room**, and
+`CreateAccount` still answers `ACCOUNT_NUMBER_LIMIT_EXCEEDED`. Removing the
+account instead would make that broken script look correct, which is the reason
+this operation is modelled at all.
+
+The status advances **on observation**, like `DescribeCreateAccountStatus`, with
+one difference: the in-flight status is reported on the *first* observation and the
+terminal one from the second. `CloseAccount` returns no body, so a poll is the only
+place `PENDING_CLOSURE` is ever visible — resolving on the first read would leave a
+consumer's in-flight branch unexecutable. Only the operations that put an account's
+`Status` on the wire advance it; the concurrency count below deliberately does not,
+since counting through an observation would let closing a fourth account converge
+the first three.
+
+The operation is **management-only** (`AccessDeniedException`, 403), checked before
+any state is read so a member cannot use the other refusals to probe the
+organization it belongs to — and a member cannot close itself either, since the
+guard is on the caller rather than on the caller's relationship to the target. It
+also requires the **ALL** feature set, per "you can close an account when all
+features are enabled"; under `CONSOLIDATED_BILLING` the account is left untouched,
+so a retry after enabling all features does not start from half-applied state.
+
+A closure already in flight and one already finished are **different** refusals.
+The model declares both `ConflictException` and `AccountAlreadyClosedException`
+without saying which applies to a `PENDING_CLOSURE` target; substrate reads
+"already closed" as the terminal state and answers the conflict for the in-flight
+one, so a re-run of a teardown script can tell "this is finishing" from "this was
+done".
+
+Of the three published closure quotas, only **3 concurrent closures** is enforced
+— it is a count of accounts currently in `PENDING_CLOSURE`, so it is exact.
+Observing all three to `SUSPENDED` frees the slots, which is the "as soon as one
+finishes, you can close another" half of the quota. The rolling-30-day allowance
+(250 or 20% of member accounts, capped at 1,000) and the four-day minimum age
+before a created account can be removed are **not** modelled: both are bounded by a
+wall-clock window, and substrate's clock is simulated and freely advanced, so such
+a refusal would fire or not depending on unrelated `AdvanceTime` calls elsewhere in
+a test. A limit a test can skip past is not a limit.
 
 ### The disabled-SCP state
 
@@ -4659,6 +4754,14 @@ deletes its tags, so an entity that reused the ID cannot inherit them.
 | Unparseable policy content | `MalformedPolicyDocumentException` |
 | Modifying `p-FullAWSAccess` | `InvalidInputException`/`IMMUTABLE_POLICY` |
 | Moving to the current parent | `DuplicateAccountException` |
+| Closing the management account | `ConstraintViolationException`/`CANNOT_CLOSE_MANAGEMENT_ACCOUNT` |
+| Closing an account already `SUSPENDED` | `AccountAlreadyClosedException` |
+| Closing an account already `PENDING_CLOSURE` | `ConflictException` |
+| Closing a malformed account ID | `InvalidInputException`/`INVALID_PATTERN` — shape is checked before existence |
+| `CloseAccount` under `CONSOLIDATED_BILLING` | `ConstraintViolationException`/`ORGANIZATION_NOT_IN_ALL_FEATURES_MODE` |
+| A member account calling `CloseAccount` | `AccessDeniedException`, **403** |
+| A member account calling `Put`/`DeleteResourcePolicy` | `AccessDeniedException`, **403** |
+| A member the resource policy does not name calling `DescribeResourcePolicy` | `AccessDeniedException`, **403** |
 | A source that is not the account's parent | `SourceParentNotFoundException` |
 | Unknown move destination | `DestinationParentNotFoundException` |
 | A move across roots | `InvalidInputException`/`MOVING_ACCOUNT_BETWEEN_DIFFERENT_ROOTS` |
@@ -4683,9 +4786,16 @@ and each is enforced rather than merely documented.
 | Characters in an SCP | 10,240 | `POLICY_CONTENT_LIMIT_EXCEEDED` |
 | Characters in the resource policy | 40,000 | `MAX_LENGTH_EXCEEDED` |
 | Tags on one resource | 50 | `MAX_TAG_LIMIT_EXCEEDED` |
+| Member-account closures in progress at once | 3 | `CLOSE_ACCOUNT_REQUESTS_LIMIT_EXCEEDED` |
 
 The 5-per-target and 5,120-character figures often quoted are the **RCP** values,
 not the SCP ones.
+
+Two published closure quotas are deliberately **not** enforced — the rolling
+30-day allowance (250 or 20% of member accounts, capped at 1,000) and the four-day
+minimum age before a created account can be removed. Both require a wall-clock
+window, which a freely advanced simulated clock makes meaningless; see
+[Closing an account does not remove it](#closing-an-account-does-not-remove-it).
 
 Three of these are also readable through Service Quotas — accounts, OUs and SCPs
 per organization — at the same values, so a consumer that reads a ceiling and a
@@ -4877,8 +4987,17 @@ than an empty result — see below.
 | GetServiceQuota | `ServiceCode` **and** `QuotaCode` required |
 | GetAWSDefaultServiceQuota | The same answer as `GetServiceQuota` — nothing here mutates a quota, so the applied value and the AWS default never diverge |
 | RequestServiceQuotaIncrease | Records a `PENDING` request; the published value does not move |
-| ListRequestedServiceQuotaChangesByService | Filterable by `ServiceCode` |
+| ListRequestedServiceQuotaChangeHistory | The caller's own requests; filterable by `ServiceCode` and `Status` |
 | GetRequestedServiceQuotaChange | `NoSuchResourceException` for an unknown request ID |
+
+The history operation also answers to `ListRequestedServiceQuotaChangesByService`,
+which is the name it shipped under and which the Service Quotas API does not have —
+the 2019-06-24 model declares `ListRequestedServiceQuotaChangeHistory` and
+`ListRequestedServiceQuotaChangeHistoryByQuota` and nothing else of that shape. So
+for one release the handler was reachable only by a hand-built `X-Amz-Target`, and
+every SDK or CLI call answered `InvalidAction`. The invented name is kept as an
+alias so a fixture that already drives it keeps working; new code should use the
+real one. `…ChangeHistoryByQuota` is not modelled.
 
 ### An unknown service is a refusal, not an empty list
 
@@ -4906,6 +5025,14 @@ absent would be misleading.
 keeps reading its old value, because AWS grants nothing synchronously — a consumer
 that read the quota back expecting its `DesiredValue` would be asserting on a
 state real Service Quotas never reaches on that call.
+
+A request is filed under **the account that made it**, and the two history
+operations report only that account's requests. Increase requests were previously
+filed under the literal `000000000000` regardless of the caller, so two accounts
+sharing one emulator shared one pile of requests — and a consumer reading the
+history to decide whether it had already asked would see a sibling's request as its
+own. A fixture that asserted on `000000000000` will now see the caller's real
+account.
 
 ### Organizations quotas
 

--- a/emulator/lambda_invoke_test.go
+++ b/emulator/lambda_invoke_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -377,14 +376,18 @@ func startFakeRIE(t *testing.T, body, functionError string) int {
 		_, _ = w.Write([]byte(body))
 	})
 
-	port, err := emulator.FindFreePort()
-	require.NoError(t, err)
-	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	// Bind port 0 and read the port back off the live listener, rather than asking
+	// FindFreePort and re-binding what it named. FindFreePort closes its listener
+	// before returning the number, so between the close and the re-bind the port is
+	// free for anything else to take — including a sibling t.Parallel() test that
+	// FindFreePort then hands the very same number. That is the "bind: address
+	// already in use" flake these two tests hit under -race (#634).
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	go func() { _ = srv.Serve(ln) }()
 	t.Cleanup(func() { _ = srv.Close() })
-	return port
+	return ln.Addr().(*net.TCPAddr).Port
 }
 
 // TestInvokePOST_PropagatesFunctionErrorHeader asserts invokePOST surfaces the

--- a/emulator/servicequotas_account_test.go
+++ b/emulator/servicequotas_account_test.go
@@ -2,6 +2,7 @@ package emulator_test
 
 import (
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/scttfrdmn/substrate/emulator"
@@ -34,8 +35,8 @@ const sqSecondAccount = "444455556666"
 //
 // Two accounts each file one increase, and each must see only its own. Before the
 // fix both saw both, and a consumer reading
-// ListRequestedServiceQuotaChangesByService to decide whether it had already asked
-// for a raise would find another account's request and skip filing its own.
+// ListRequestedServiceQuotaChangeHistory to decide whether it had already asked for
+// a raise would find another account's request and skip filing its own.
 func TestServiceQuotas_IncreasesAreFiledUnderTheCaller(t *testing.T) {
 	ts := emulator.StartTestServerWithAccounts(t, sqSecondAccount)
 
@@ -77,11 +78,11 @@ func TestServiceQuotas_IncreasesAreFiledUnderTheCaller(t *testing.T) {
 			RequestedQuotas []requestedQuota `json:"RequestedQuotas"`
 		}
 		status, code := decodeAWSResponse(t, signedRequest(t, ts, sqTarget, account,
-			"ListRequestedServiceQuotaChangesByService", map[string]any{
+			"ListRequestedServiceQuotaChangeHistory", map[string]any{
 				"ServiceCode": "organizations",
 			}), &listed)
 		if status != http.StatusOK {
-			t.Fatalf("ListRequestedServiceQuotaChangesByService as %s: %d %s", account, status, code)
+			t.Fatalf("ListRequestedServiceQuotaChangeHistory as %s: %d %s", account, status, code)
 		}
 		if len(listed.RequestedQuotas) != 1 {
 			t.Fatalf("as %s: %d requests listed, want 1 — the other account's request leaked",
@@ -146,6 +147,9 @@ func TestServiceQuotas_UnattributedCallerKeepsThePlaceholder(t *testing.T) {
 			QuotaCode string `json:"QuotaCode"`
 		} `json:"RequestedQuotas"`
 	}
+	// Deliberately the legacy name, which is the one this handler shipped under and
+	// which no SDK can send (#636). It is kept as an alias precisely so a fixture
+	// like this one keeps working, so something has to hold it.
 	status, code := decodeAWSResponse(t,
 		makeServiceQuotasRequest(t, ts, "ListRequestedServiceQuotaChangesByService", map[string]interface{}{
 			"ServiceCode": "organizations",
@@ -155,5 +159,83 @@ func TestServiceQuotas_UnattributedCallerKeepsThePlaceholder(t *testing.T) {
 	}
 	if len(listed.RequestedQuotas) != 1 || listed.RequestedQuotas[0].QuotaCode != "L-E619E033" {
 		t.Errorf("an unsigned caller listed %+v, want the one request it just filed", listed.RequestedQuotas)
+	}
+}
+
+// TestServiceQuotas_ChangeHistoryFilters is #636: the operation an SDK can reach,
+// and the filters it accepts.
+//
+// The handler shipped as ListRequestedServiceQuotaChangesByService, which is not an
+// operation the Service Quotas API has — the 2019-06-24 model declares
+// ListRequestedServiceQuotaChangeHistory and …ChangeHistoryByQuota. So every real
+// SDK call answered InvalidAction while the unit tests, which name the operation
+// themselves, stayed green. The two names must reach the same handler, and the
+// Status filter has to narrow: a caller asking for DENIED that is handed a PENDING
+// record reads an outcome the service never reported.
+func TestServiceQuotas_ChangeHistoryFilters(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	for _, svc := range []string{"organizations", "lambda"} {
+		resp := makeServiceQuotasRequest(t, ts, "RequestServiceQuotaIncrease", map[string]interface{}{
+			"ServiceCode":  svc,
+			"QuotaCode":    map[string]string{"organizations": "L-E619E033", "lambda": "L-B99A9384"}[svc],
+			"DesiredValue": float64(50),
+		})
+		if status, code := decodeAWSResponse(t, resp, nil); status != http.StatusOK {
+			t.Fatalf("RequestServiceQuotaIncrease(%s): %d %s", svc, status, code)
+		}
+	}
+
+	list := func(t *testing.T, operation string, input map[string]interface{}) []string {
+		t.Helper()
+		var out struct {
+			RequestedQuotas []struct {
+				ServiceCode string `json:"ServiceCode"`
+			} `json:"RequestedQuotas"`
+		}
+		status, code := decodeAWSResponse(t, makeServiceQuotasRequest(t, ts, operation, input), &out)
+		if status != http.StatusOK {
+			t.Fatalf("%s%v: %d %s", operation, input, status, code)
+		}
+		codes := make([]string, 0, len(out.RequestedQuotas))
+		for _, q := range out.RequestedQuotas {
+			codes = append(codes, q.ServiceCode)
+		}
+		slices.Sort(codes)
+		return codes
+	}
+
+	tests := []struct {
+		name  string
+		input map[string]interface{}
+		want  []string
+	}{
+		{"no filter lists both", map[string]interface{}{}, []string{"lambda", "organizations"}},
+		{"service narrows", map[string]interface{}{"ServiceCode": "lambda"}, []string{"lambda"}},
+		{"status matches", map[string]interface{}{"Status": "PENDING"}, []string{"lambda", "organizations"}},
+		{"status excludes", map[string]interface{}{"Status": "DENIED"}, []string{}},
+		{
+			"service and status together",
+			map[string]interface{}{"ServiceCode": "organizations", "Status": "PENDING"},
+			[]string{"organizations"},
+		},
+		{
+			"a service with no request is empty, not everything",
+			map[string]interface{}{"ServiceCode": "s3"},
+			[]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := list(t, "ListRequestedServiceQuotaChangeHistory", tt.input)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("listed %v, want %v", got, tt.want)
+			}
+			// The legacy name is an alias, not a second implementation: whatever the
+			// real operation answers, it answers.
+			if legacy := list(t, "ListRequestedServiceQuotaChangesByService", tt.input); !slices.Equal(legacy, got) {
+				t.Errorf("the legacy name listed %v, the real one %v", legacy, got)
+			}
+		})
 	}
 }

--- a/emulator/servicequotas_plugin.go
+++ b/emulator/servicequotas_plugin.go
@@ -11,7 +11,7 @@ import (
 // ServiceQuotasPlugin emulates the AWS Service Quotas API.
 // It handles ListServices, ListServiceQuotas, GetServiceQuota,
 // GetAWSDefaultServiceQuota, RequestServiceQuotaIncrease,
-// ListRequestedServiceQuotaChangesByService, and GetRequestedServiceQuotaChange.
+// ListRequestedServiceQuotaChangeHistory, and GetRequestedServiceQuotaChange.
 // The built-in quota table provides representative default values; increases
 // are stored in state as PENDING requests. The Service Quotas API is free.
 type ServiceQuotasPlugin struct {
@@ -57,8 +57,11 @@ func (p *ServiceQuotasPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequ
 		return p.getAWSDefaultServiceQuota(req)
 	case "RequestServiceQuotaIncrease":
 		return p.requestServiceQuotaIncrease(sqAccountID(reqCtx), req)
-	case "ListRequestedServiceQuotaChangesByService":
-		return p.listRequestedServiceQuotaChangesByService(sqAccountID(reqCtx), req)
+	// The second name is not one AWS has; it is the name this handler shipped
+	// under, kept as an alias so a fixture that drives the plugin by a hand-built
+	// X-Amz-Target keeps working. See the handler's doc comment (#636).
+	case "ListRequestedServiceQuotaChangeHistory", "ListRequestedServiceQuotaChangesByService":
+		return p.listRequestedServiceQuotaChangeHistory(sqAccountID(reqCtx), req)
 	case "GetRequestedServiceQuotaChange":
 		return p.getRequestedServiceQuotaChange(sqAccountID(reqCtx), req)
 	default:
@@ -240,9 +243,25 @@ func (p *ServiceQuotasPlugin) requestServiceQuotaIncrease(accountID string, req 
 	})
 }
 
-func (p *ServiceQuotasPlugin) listRequestedServiceQuotaChangesByService(accountID string, req *AWSRequest) (*AWSResponse, error) {
+// listRequestedServiceQuotaChangeHistory reports the caller's quota-increase
+// requests, optionally filtered by service and status.
+//
+// This shipped as "ListRequestedServiceQuotaChangesByService", a name the Service
+// Quotas API does not have: the 2019-06-24 model declares
+// ListRequestedServiceQuotaChangeHistory (this operation) and
+// ListRequestedServiceQuotaChangeHistoryByQuota, and nothing resembling
+// "…ChangesByService". So the handler was reachable only by a hand-built
+// X-Amz-Target — every SDK and CLI call got InvalidAction — which is why the
+// plugin's own unit tests could not see it (#636). Both names now route here; the
+// invented one is kept because a fixture may already drive it directly.
+//
+// The Status filter is honored rather than ignored: a caller asking for
+// CASE_OPENED that was handed a PENDING record back would read an outcome the
+// service never reports.
+func (p *ServiceQuotasPlugin) listRequestedServiceQuotaChangeHistory(accountID string, req *AWSRequest) (*AWSResponse, error) {
 	var input struct {
 		ServiceCode string `json:"ServiceCode"`
+		Status      string `json:"Status"`
 	}
 	if len(req.Body) > 0 {
 		_ = json.Unmarshal(req.Body, &input)
@@ -261,9 +280,13 @@ func (p *ServiceQuotasPlugin) listRequestedServiceQuotaChangesByService(accountI
 		if err != nil || qi == nil {
 			continue
 		}
-		if input.ServiceCode == "" || qi.ServiceCode == input.ServiceCode {
-			results = append(results, *qi)
+		if input.ServiceCode != "" && qi.ServiceCode != input.ServiceCode {
+			continue
 		}
+		if input.Status != "" && qi.Status != input.Status {
+			continue
+		}
+		results = append(results, *qi)
 	}
 	if results == nil {
 		results = []QuotaIncrease{}

--- a/test/e2e/journey_organizations_test.go
+++ b/test/e2e/journey_organizations_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -567,4 +568,299 @@ func journeySeedOrgCreateFailure(t *testing.T, ts *emulator.TestServer, accountN
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("POST /v1/organizations/create-account-failure: status %d", resp.StatusCode)
 	}
+}
+
+// TestJourney_OrganizationsMemberView is #623 and #619's remainder through the
+// SDK: two accounts, two identities, and the asymmetry between them.
+//
+// It is the only level at which this can be checked. A member account is a
+// different *caller*, resolved from the signing key, so nothing that signs as one
+// account can exercise it — which is exactly why #623 survived every Organizations
+// test until now: all of them are one caller by construction.
+//
+// The journey pins the three answers a governance tool depends on being distinct.
+// A member reading management's policy and a member denied it must not look the
+// same, and neither must "no delegation" and "delegation I cannot read": those are
+// different branches in a consumer, and errors.As on the typed exception is how it
+// takes them.
+func TestJourney_OrganizationsMemberView(t *testing.T) {
+	ts := emulator.StartTestServerWithAccounts(t, journeyAccountID)
+
+	mgmtCfg, err := journeyConfigAs(ts, journeyAccountID)
+	if err != nil {
+		t.Fatalf("management config: %v", err)
+	}
+	ctx := context.Background()
+	mgmt := organizations.NewFromConfig(mgmtCfg, func(o *organizations.Options) { o.RetryMaxAttempts = 1 })
+
+	orgDesc, err := mgmt.DescribeOrganization(ctx, &organizations.DescribeOrganizationInput{})
+	if err != nil {
+		t.Fatalf("DescribeOrganization as management: %v", err)
+	}
+	orgID := aws.ToString(orgDesc.Organization.Id)
+
+	// Two members, so the delegated one and the undelegated one are both real
+	// accounts of the same organization rather than one account and one absence.
+	delegated := journeyVendAccount(t, ctx, mgmt, "delegated", "delegated@example.com")
+	outsider := journeyVendAccount(t, ctx, mgmt, "outsider", "outsider@example.com")
+
+	delegatedCfg, err := journeyConfigAs(ts, ts.RegisterAccount(t, delegated).AccountID)
+	if err != nil {
+		t.Fatalf("delegated member config: %v", err)
+	}
+	outsiderCfg, err := journeyConfigAs(ts, ts.RegisterAccount(t, outsider).AccountID)
+	if err != nil {
+		t.Fatalf("undelegated member config: %v", err)
+	}
+	memberOpts := func(o *organizations.Options) { o.RetryMaxAttempts = 1 }
+	delegatedClient := organizations.NewFromConfig(delegatedCfg, memberOpts)
+	outsiderClient := organizations.NewFromConfig(outsiderCfg, memberOpts)
+
+	// --- #623: a member is in management's organization, not one of its own ---
+	//
+	// DescribeOrganization is documented as callable "from any account in the
+	// organization", so both members get an answer — and it has to be the *same*
+	// organization, or a member's view of the hierarchy it lives in is fiction.
+	for _, tc := range []struct {
+		name   string
+		client *organizations.Client
+	}{
+		{"the delegated member", delegatedClient},
+		{"the undelegated member", outsiderClient},
+	} {
+		got, describeErr := tc.client.DescribeOrganization(ctx, &organizations.DescribeOrganizationInput{})
+		if describeErr != nil {
+			t.Fatalf("DescribeOrganization as %s: %v", tc.name, describeErr)
+		}
+		if id := aws.ToString(got.Organization.Id); id != orgID {
+			t.Errorf("%s sees organization %q, want management's %q — a member must not get a private organization",
+				tc.name, id, orgID)
+		}
+		if master := aws.ToString(got.Organization.MasterAccountId); master != journeyAccountID {
+			t.Errorf("%s reports management account %q, want %q", tc.name, master, journeyAccountID)
+		}
+	}
+
+	// A member also sees the same accounts, which is what makes the organization one
+	// organization rather than three that agree on an ID.
+	memberAccounts, err := delegatedClient.ListAccounts(ctx, &organizations.ListAccountsInput{})
+	if err != nil {
+		t.Fatalf("ListAccounts as a member: %v", err)
+	}
+	if len(memberAccounts.Accounts) != 3 {
+		t.Errorf("a member sees %d accounts, want the organization's 3", len(memberAccounts.Accounts))
+	}
+
+	// --- #619: nothing is delegated yet ---
+	//
+	// Management gets the not-found refusal — the ordinary answer, since most
+	// organizations have no resource policy. A member gets denied instead, because
+	// reporting the absence to a member would leak whether a policy exists at all.
+	var notFound *orgtypes.ResourcePolicyNotFoundException
+	if _, err := mgmt.DescribeResourcePolicy(ctx, &organizations.DescribeResourcePolicyInput{}); !errors.As(err, &notFound) {
+		t.Fatalf("DescribeResourcePolicy as management with no policy set: got %T (%v), want *ResourcePolicyNotFoundException", err, err)
+	}
+	var denied *orgtypes.AccessDeniedException
+	if _, err := delegatedClient.DescribeResourcePolicy(ctx, &organizations.DescribeResourcePolicyInput{}); !errors.As(err, &denied) {
+		t.Fatalf("DescribeResourcePolicy as a member with no policy set: got %T (%v), want *AccessDeniedException", err, err)
+	}
+
+	// --- management delegates to one of the two members ---
+	delegation := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":` +
+		`{"AWS":"arn:aws:iam::` + delegated + `:root"},"Action":"organizations:DescribePolicy","Resource":"*"}]}`
+	put, err := mgmt.PutResourcePolicy(ctx, &organizations.PutResourcePolicyInput{
+		Content: aws.String(delegation),
+	})
+	if err != nil {
+		t.Fatalf("PutResourcePolicy as management: %v", err)
+	}
+	wantID := aws.ToString(put.ResourcePolicy.ResourcePolicySummary.Id)
+	wantARN := aws.ToString(put.ResourcePolicy.ResourcePolicySummary.Arn)
+
+	// The delegated member reads the identical document. Not an equivalent one: the
+	// same Content, Id and Arn, because a tool that reads the policy to decide what
+	// it may do has to see what management actually set.
+	got, err := delegatedClient.DescribeResourcePolicy(ctx, &organizations.DescribeResourcePolicyInput{})
+	if err != nil {
+		t.Fatalf("DescribeResourcePolicy as the delegated member: %v", err)
+	}
+	if content := aws.ToString(got.ResourcePolicy.Content); content != delegation {
+		t.Errorf("the delegated member reads Content %q, want the document management put", content)
+	}
+	if id := aws.ToString(got.ResourcePolicy.ResourcePolicySummary.Id); id != wantID {
+		t.Errorf("the delegated member reads Id %q, want %q", id, wantID)
+	}
+	if arn := aws.ToString(got.ResourcePolicy.ResourcePolicySummary.Arn); arn != wantARN {
+		t.Errorf("the delegated member reads Arn %q, want %q", arn, wantARN)
+	}
+
+	// The member the policy does not name is still denied, so the delegation is what
+	// grants the read rather than membership.
+	if _, err := outsiderClient.DescribeResourcePolicy(ctx, &organizations.DescribeResourcePolicyInput{}); !errors.As(err, &denied) {
+		t.Fatalf("DescribeResourcePolicy as the undelegated member: got %T (%v), want *AccessDeniedException", err, err)
+	}
+
+	// --- the writes stay management-only ---
+	//
+	// Reading a delegation does not confer the ability to rewrite it. A member that
+	// could would be able to delegate itself anything.
+	for _, tc := range []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "PutResourcePolicy as the delegated member",
+			call: func() error {
+				_, err := delegatedClient.PutResourcePolicy(ctx, &organizations.PutResourcePolicyInput{
+					Content: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+				})
+				return err
+			},
+		},
+		{
+			name: "DeleteResourcePolicy as the delegated member",
+			call: func() error {
+				_, err := delegatedClient.DeleteResourcePolicy(ctx, &organizations.DeleteResourcePolicyInput{})
+				return err
+			},
+		},
+	} {
+		if err := tc.call(); !errors.As(err, &denied) {
+			t.Errorf("%s: got %T (%v), want *AccessDeniedException", tc.name, err, err)
+		}
+	}
+
+	// And the document management set is untouched by those attempts.
+	after, err := mgmt.DescribeResourcePolicy(ctx, &organizations.DescribeResourcePolicyInput{})
+	if err != nil {
+		t.Fatalf("DescribeResourcePolicy as management after the refused writes: %v", err)
+	}
+	if content := aws.ToString(after.ResourcePolicy.Content); content != delegation {
+		t.Errorf("the resource policy is %q after two refused member writes, want it unchanged", content)
+	}
+}
+
+// TestJourney_OrganizationsCloseAccount is #625 through the SDK: the teardown half
+// of the vending lifecycle.
+//
+// The property worth a journey is what closing does *not* do. A cleanup tool closes
+// accounts to make room and then vends again; if a closed account left the
+// organization, that tool would appear to work here and fail against AWS, where the
+// account keeps counting against the quota until it is permanently closed.
+func TestJourney_OrganizationsCloseAccount(t *testing.T) {
+	ts := emulator.StartTestServerWithAccounts(t, journeyAccountID)
+
+	cfg, err := journeyConfigAs(ts, journeyAccountID)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	orgs := organizations.NewFromConfig(cfg, func(o *organizations.Options) { o.RetryMaxAttempts = 1 })
+
+	member := journeyVendAccount(t, ctx, orgs, "doomed", "doomed@example.com")
+
+	// CloseAccount has no output shape, so the SDK's output struct carries nothing
+	// to assert on. The absence of an error is the whole success.
+	if _, err := orgs.CloseAccount(ctx, &organizations.CloseAccountInput{
+		AccountId: aws.String(member),
+	}); err != nil {
+		t.Fatalf("CloseAccount: %v", err)
+	}
+
+	// The documented sequence, read the way AWS documents reading it. The in-flight
+	// status appears on the first poll and nowhere else: with no output shape, a
+	// consumer's PENDING_CLOSURE branch has only this to observe.
+	if status := journeyOrgAccountStatus(t, ctx, orgs, member); status != orgtypes.AccountStatusPendingClosure {
+		t.Errorf("the first DescribeAccount reads %q, want PENDING_CLOSURE", status)
+	}
+	for i := range 2 {
+		if status := journeyOrgAccountStatus(t, ctx, orgs, member); status != orgtypes.AccountStatusSuspended {
+			t.Fatalf("DescribeAccount poll %d reads %q, want SUSPENDED", i+2, status)
+		}
+	}
+
+	// Still in the organization, and reported through the listing with the same
+	// status the Describe gives — a caller polling either one must not contradict a
+	// caller polling the other.
+	listed, err := orgs.ListAccounts(ctx, &organizations.ListAccountsInput{})
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	found := false
+	for _, a := range listed.Accounts {
+		if aws.ToString(a.Id) != member {
+			continue
+		}
+		found = true
+		if a.Status != orgtypes.AccountStatusSuspended {
+			t.Errorf("ListAccounts reports the closed account as %q, want SUSPENDED", a.Status)
+		}
+	}
+	if !found {
+		t.Errorf("ListAccounts dropped the closed account %s; a closed account stays in the organization", member)
+	}
+	if len(listed.Accounts) != 2 {
+		t.Errorf("ListAccounts returned %d accounts after a closure, want 2", len(listed.Accounts))
+	}
+
+	// --- the re-run a teardown script performs ---
+	var alreadyClosed *orgtypes.AccountAlreadyClosedException
+	if _, err := orgs.CloseAccount(ctx, &organizations.CloseAccountInput{
+		AccountId: aws.String(member),
+	}); !errors.As(err, &alreadyClosed) {
+		t.Errorf("closing an already-closed account: got %T (%v), want *AccountAlreadyClosedException", err, err)
+	}
+
+	// The management account cannot be closed through this API at all, which is the
+	// refusal a script that closes "every account it can list" runs into.
+	var constraint *orgtypes.ConstraintViolationException
+	if _, err := orgs.CloseAccount(ctx, &organizations.CloseAccountInput{
+		AccountId: aws.String(journeyAccountID),
+	}); !errors.As(err, &constraint) {
+		t.Fatalf("closing the management account: got %T (%v), want *ConstraintViolationException", err, err)
+	} else if msg := constraint.ErrorMessage(); !strings.Contains(msg, "CANNOT_CLOSE_MANAGEMENT_ACCOUNT") {
+		// The reason rides in the message because the JSON-RPC error document has no
+		// member for it, and this exception covers several unrelated limits.
+		t.Errorf("the refusal message is %q; it must name CANNOT_CLOSE_MANAGEMENT_ACCOUNT", msg)
+	}
+}
+
+// journeyVendAccount vends an account through CreateAccount and returns its ID,
+// polling the request to completion the way a vending tool does.
+func journeyVendAccount(t *testing.T, ctx context.Context, orgs *organizations.Client, name, email string) string {
+	t.Helper()
+	created, err := orgs.CreateAccount(ctx, &organizations.CreateAccountInput{
+		AccountName: aws.String(name),
+		Email:       aws.String(email),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount(%s): %v", name, err)
+	}
+	status, err := orgs.DescribeCreateAccountStatus(ctx, &organizations.DescribeCreateAccountStatusInput{
+		CreateAccountRequestId: created.CreateAccountStatus.Id,
+	})
+	if err != nil {
+		t.Fatalf("DescribeCreateAccountStatus(%s): %v", name, err)
+	}
+	if status.CreateAccountStatus.State != orgtypes.CreateAccountStateSucceeded {
+		t.Fatalf("vending %s settled at %q, want SUCCEEDED", name, status.CreateAccountStatus.State)
+	}
+	id := aws.ToString(status.CreateAccountStatus.AccountId)
+	if id == "" {
+		t.Fatalf("vending %s succeeded with no AccountId", name)
+	}
+	return id
+}
+
+// journeyOrgAccountStatus reads one account's status through DescribeAccount,
+// which is the operation AWS documents as the way to watch a closure.
+func journeyOrgAccountStatus(t *testing.T, ctx context.Context, orgs *organizations.Client, accountID string) orgtypes.AccountStatus {
+	t.Helper()
+	got, err := orgs.DescribeAccount(ctx, &organizations.DescribeAccountInput{
+		AccountId: aws.String(accountID),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAccount(%s): %v", accountID, err)
+	}
+	return got.Account.Status
 }

--- a/test/e2e/journey_servicequotas_test.go
+++ b/test/e2e/journey_servicequotas_test.go
@@ -143,3 +143,88 @@ func TestJourney_ServiceQuotasOrganizations(t *testing.T) {
 		t.Errorf("a pending increase moved the quota to %v; it must still read 10", v)
 	}
 }
+
+// TestJourney_ServiceQuotasCallerIsolation is #624 at the SDK level: two accounts
+// filing increases against one emulator, each seeing only its own.
+//
+// The plugin discarded its request context and filed every increase under the
+// literal 000000000000, so this is the leak that fix closed. It needs two signing
+// identities, which is why it lives here rather than in a single-caller journey: a
+// consumer that reads its request history to decide whether it has already asked
+// would otherwise see a sibling's request and skip filing its own.
+func TestJourney_ServiceQuotasCallerIsolation(t *testing.T) {
+	const otherAccount = "210987654321"
+	ts := emulator.StartTestServerWithAccounts(t, journeyAccountID, otherAccount)
+
+	ctx := context.Background()
+	clients := make(map[string]*servicequotas.Client, 2)
+	for _, account := range []string{journeyAccountID, otherAccount} {
+		cfg, err := journeyConfigAs(ts, account)
+		if err != nil {
+			t.Fatalf("config for %s: %v", account, err)
+		}
+		clients[account] = servicequotas.NewFromConfig(cfg,
+			func(o *servicequotas.Options) { o.RetryMaxAttempts = 1 })
+	}
+
+	// Each account asks for a different value, so the records are distinguishable by
+	// content and not only by count.
+	wanted := map[string]float64{journeyAccountID: 50, otherAccount: 75}
+	for account, client := range clients {
+		if _, err := client.RequestServiceQuotaIncrease(ctx, &servicequotas.RequestServiceQuotaIncreaseInput{
+			ServiceCode:  aws.String("organizations"),
+			QuotaCode:    aws.String("L-E619E033"),
+			DesiredValue: aws.Float64(wanted[account]),
+		}); err != nil {
+			t.Fatalf("RequestServiceQuotaIncrease as %s: %v", account, err)
+		}
+	}
+
+	for account, client := range clients {
+		history, err := client.ListRequestedServiceQuotaChangeHistory(ctx,
+			&servicequotas.ListRequestedServiceQuotaChangeHistoryInput{
+				ServiceCode: aws.String("organizations"),
+			})
+		if err != nil {
+			t.Fatalf("ListRequestedServiceQuotaChangeHistory as %s: %v", account, err)
+		}
+		if len(history.RequestedQuotas) != 1 {
+			t.Fatalf("%s sees %d increase requests, want only its own 1", account, len(history.RequestedQuotas))
+		}
+		got := history.RequestedQuotas[0]
+		if v := aws.ToFloat64(got.DesiredValue); v != wanted[account] {
+			t.Errorf("%s sees a request for %v, want its own %v — the requests are crossed",
+				account, v, wanted[account])
+		}
+		if got.Status != sqtypes.RequestStatusPending {
+			t.Errorf("%s's request reads Status %q, want PENDING", account, got.Status)
+		}
+	}
+
+	// The Status filter has to agree with the unfiltered read, or a consumer that
+	// narrows its history query to PENDING would conclude it had never asked.
+	pending, err := clients[journeyAccountID].ListRequestedServiceQuotaChangeHistory(ctx,
+		&servicequotas.ListRequestedServiceQuotaChangeHistoryInput{
+			Status: sqtypes.RequestStatusPending,
+		})
+	if err != nil {
+		t.Fatalf("ListRequestedServiceQuotaChangeHistory(Status=PENDING): %v", err)
+	}
+	if len(pending.RequestedQuotas) != 1 {
+		t.Errorf("filtering on PENDING returned %d requests, want the caller's 1",
+			len(pending.RequestedQuotas))
+	}
+	// A status no record holds returns nothing rather than everything, which is the
+	// difference between an honoured filter and an ignored one.
+	denied, err := clients[journeyAccountID].ListRequestedServiceQuotaChangeHistory(ctx,
+		&servicequotas.ListRequestedServiceQuotaChangeHistoryInput{
+			Status: sqtypes.RequestStatusDenied,
+		})
+	if err != nil {
+		t.Fatalf("ListRequestedServiceQuotaChangeHistory(Status=DENIED): %v", err)
+	}
+	if len(denied.RequestedQuotas) != 0 {
+		t.Errorf("filtering on DENIED returned %d requests; every record is PENDING",
+			len(denied.RequestedQuotas))
+	}
+}

--- a/test/e2e/journey_test.go
+++ b/test/e2e/journey_test.go
@@ -13,6 +13,7 @@ package e2e_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -39,3 +40,27 @@ func journeyConfig(ts *emulator.TestServer) (aws.Config, error) {
 
 // journeyAccountID is the account the built-in AKIA test credentials map to.
 const journeyAccountID = "123456789012"
+
+// journeyConfigAs builds an SDK config that signs as one specific account of a
+// server started with [emulator.StartTestServerWithAccounts].
+//
+// Such a server verifies SigV4 — it holds a credential registry, and the server
+// verifies signatures exactly when one is present — so the credentials have to be
+// the ones the registry vended rather than the built-in test key. That is what
+// makes a journey through two identities possible at all: the caller's account is
+// resolved from the signing key, so a member account is a genuinely different
+// caller rather than a parameter.
+func journeyConfigAs(ts *emulator.TestServer, accountID string) (aws.Config, error) {
+	entry, ok := ts.CredentialsFor(accountID)
+	if !ok {
+		return aws.Config{}, fmt.Errorf("account %s is not registered with this test server", accountID)
+	}
+	return config.LoadDefaultConfig(context.Background(),
+		config.WithRegion("us-east-1"),
+		config.WithBaseEndpoint(ts.URL),
+		config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(entry.AccessKeyID, entry.SecretAccessKey, ""),
+		),
+		config.WithHTTPClient(&http.Client{}),
+	)
+}


### PR DESCRIPTION
Lane F of the v0.99.0 plan: the documentation and end-to-end journeys for the caller-identity work, and the two defects writing those journeys exposed.

## The journeys

`test/e2e/journey_organizations_test.go` gains two, both driving the real `organizations` SDK client against two signing identities via the new `StartTestServerWithAccounts`:

- **`TestJourney_OrganizationsMemberView`** — two vended members both read management's org ID and master and see all three accounts (#623). The `DescribeResourcePolicy` asymmetry is exercised in full: not-found for management, `AccessDeniedException` for a member before delegation, the identical `Content`/`Id`/`Arn` for a delegated member, still denied for the undelegated one, and `Put`/`Delete` refused for the delegated member with the document unchanged afterwards (#619).
- **`TestJourney_OrganizationsCloseAccount`** — close → `PENDING_CLOSURE` → `SUSPENDED` and stable, still present in `ListAccounts` as `SUSPENDED`, then `AccountAlreadyClosedException`, and management's own closure refused with `CANNOT_CLOSE_MANAGEMENT_ACCOUNT` (#625).

`TestJourney_ServiceQuotasCallerIsolation` is #624 at SDK level: two accounts file increases of 50 and 75 and each sees only its own.

These are load-bearing, not decorative — stubbing `organizationOwner` to return `""` reproduced #623's exact symptom in both Organizations journeys (members reading private organizations instead of management's) before it was restored.

## The two defects they found

**#636 — the increase history was unreachable from any SDK.** `HandleRequest` routed `ListRequestedServiceQuotaChangesByService`, which is not a Service Quotas operation: the 2019-06-24 model declares `ListRequestedServiceQuotaChangeHistory` and `ListRequestedServiceQuotaChangeHistoryByQuota`, and nothing of that shape. The handler was therefore reachable only by a hand-built `X-Amz-Target` — precisely what the plugin's unit tests supply, which is why they stayed green while every real call answered `InvalidAction`. Same class of gap as #561 and #610, caught at the only level that can catch it.

The real name is now routed, with the invented one kept as an alias because existing fixtures drive it directly; that alias is documented as substrate-only. The `Status` filter the model declares is honored rather than ignored — a caller narrowing to `DENIED` was handed the `PENDING` records back, an outcome the service never reports. `…ChangeHistoryByQuota` stays unmodelled, and the docs say so.

**#634 — the Lambda port-reuse flake, now firing on a plain `make test`.** `startFakeRIE` asked `FindFreePort` for a number and then bound it, and `findFreePort` closes its own listener before returning — so between the close and the re-bind the port belonged to nobody, and a sibling `t.Parallel()` test could be handed the same one. They now bind port 0 and read the port back off the live listener, which is atomic. `findFreePort` itself is unchanged: its callers hand the number to Docker's `-p`, which has to do the binding, so the gap is inherent there and only a test can avoid it.

## Documentation

`docs/services.md`: a new *A member account sees its management account's organization* section with the caller×operation table and the `DescribeOrganization` vs `DescribeResourcePolicy` distinction; `CloseAccount` in the operations table plus a *Closing an account does not remove it* section; the email-uniqueness decision; nine new Refusals rows; the concurrent-closure quota and why the other two are not modelled; a note that quota increases file under the caller; and the `…ChangesByService` alias with its provenance. `make docs-reference` needed no regeneration — the matrix is registry-driven and already carries the `account` metadata.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race, clean across four consecutive runs), `make coverage` (82.2% emulator, 81.5% total), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...` and `go test -C test/e2e ./...` all pass.

The live gate was run against `substrate server --address :4678` with `AWS_MAX_ATTEMPTS=1` from a scratch directory, covering every command in the plan: 34 Regions split 17/17, the `ENABLING`→`ENABLED` poll sequence and its stability, idempotent re-enable, `ValidationException`/`invalidRegionOptTarget` for both a default and an unknown Region, the `ENABLED` filter, `PutResourcePolicy` and the member/outsider reads, `CloseAccount`'s full sequence and both refusals, and the Service Quotas attribution including `list-requested-service-quota-change-history` — the CLI call that answered `InvalidAction` before this PR.

Mutation testing: four mutants, all CAUGHT, no survivors — dropping the `Status` filter, removing the real operation name (restoring #636, caught by both the journey and the unit test), dropping the legacy alias, and reverting the port fix (reproducible under `-count=40`, the invocation that originally found #634).

Closes #636
Closes #634