### PR TITLE
chore(release): v0.99.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.99.0] - 2026-08-14
+
 ### Added
 - **The Account Management Region opt-in API is now emulated** (#629): `ListRegions`,
   `GetRegionOptStatus`, `EnableRegion` and `DisableRegion`. There was no `account`
@@ -6277,6 +6279,7 @@ all changes onto the v0.44.x line.
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
 [Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.98.0...HEAD
+[v0.99.0]: https://github.com/scttfrdmn/substrate/compare/v0.98.0...v0.99.0
 [v0.98.0]: https://github.com/scttfrdmn/substrate/compare/v0.97.0...v0.98.0
 [v0.97.0]: https://github.com/scttfrdmn/substrate/compare/v0.96.0...v0.97.0
 [v0.96.0]: https://github.com/scttfrdmn/substrate/compare/v0.95.0...v0.96.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.99.0] - 2026-08-14` and adds the comparison link. No code changes.

v0.99.0's theme is that **the identity of the caller starts to matter**. v0.98.0 deferred three things and filed an issue for each; all three shared one root cause — substrate answered as if there were only ever one caller. Organizations state was keyed by the caller's account with no member→management index, Service Quotas discarded its `RequestContext`, and there was no `account` namespace at all.

Seven issues: #623, #619, #629, #624, #625, plus #636 and #634, which the end-to-end journeys written for this release exposed.

The tag will be cut against the merge commit once this lands, followed by a GitHub Release with `## Provenance` and `## Compatibility` sections.