### PR TITLE
fix(iam): decode query-protocol list parameters (#639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **IAM list parameters sent by a real client now reach the handler** (#639). IAM speaks
+  the AWS query protocol, in which a list travels as numbered form parameters —
+  `Tags.member.1.Key=env&Tags.member.1.Value=prod`. Nothing decoded that encoding.
+  `ParseAWSRequest` flattens a form body into `AWSRequest.Params`, a
+  `map[string]string`, and the server rebuilds `req.Body` for the query-protocol
+  services as `json.Marshal(req.Params)` — so a handler field declared `Tags []IAMTag`
+  was matched by a JSON key *literally named* `"Tags.member.1.Key"` and unmarshaled to
+  nil. `TagUser`, `UntagUser`, `TagRole`, `UntagRole` and the create-time `Tags` on
+  `CreateUser`/`CreateRole` all answered `200 OK` and stored nothing: a tag call that
+  reported success and did not happen, which is worse than a refusal, because a
+  consumer's assertion on its own tagging silently became an assertion about an empty
+  set.
+
+  The decoder is new (`emulator/iam_query.go`) and follows the pattern CloudWatch's
+  `parseMemberList` already established, with two rules made explicit. Indices are
+  walked from 1 and the first gap ends the list — AWS numbers members contiguously, and
+  guessing at the intended length would invent members a client never sent. A
+  present-but-empty value is a member holding `""` rather than the end of the list, the
+  same present-vs-absent distinction the parser is careful about for `ImageId` (#412),
+  because a required-member check has to be able to see what was sent. A member map
+  keeps its suffix verbatim, so a list nested inside a struct member —
+  `ContextEntries.member.1.ContextKeyValues.member.1`, which
+  `SimulatePrincipalPolicy` needs — decodes by applying the flat decoder to the map.
+
+  Each affected handler reads `req.Params` and falls back to its JSON body when no
+  member list was sent. That dual read is deliberate: the JSON path is how a unit test
+  drives the plugin, the params path is how every real client does, and **only the first
+  was ever exercised** — which is why a fully green suite shipped four broken
+  operations. `iamRequest` hand-marshals real JSON arrays, a shape no AWS client
+  produces, and no e2e journey drove a list-valued IAM parameter. This is the #561 /
+  #610 / #636 blind spot again: an operation no client can reach, with passing tests
+  over it. Both new test files close it — `journey_iam_tags_test.go` at the SDK level and
+  `iam_query_wire_test.go` posting a genuine urlencoded form body one layer down.
+
 ## [v0.99.0] - 2026-08-14
 
 ### Added

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -667,3 +667,16 @@ func CFNGeneratedNameForTest(accountID, region, stackName, resType, logicalID st
 		stackName: stackName,
 	}, resType, logicalID)
 }
+
+// IAMMemberListForTest wraps iamMemberList for external tests.
+func IAMMemberListForTest(params map[string]string, prefix string) []string {
+	return iamMemberList(params, prefix)
+}
+
+// IAMMemberStructsForTest wraps iamMemberStructs for external tests.
+func IAMMemberStructsForTest(params map[string]string, prefix string) []map[string]string {
+	return iamMemberStructs(params, prefix)
+}
+
+// IAMMemberTagsForTest wraps iamMemberTags for external tests.
+func IAMMemberTagsForTest(params map[string]string) []IAMTag { return iamMemberTags(params) }

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -186,6 +186,11 @@ func (p *IAMPlugin) createUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	if params.UserName == "" {
 		return iamErrorResponse("ValidationError", "UserName is required", http.StatusBadRequest), nil
 	}
+	// Tags is a query-protocol list; see tagUser and iam_query.go (#639). A user
+	// created with tags kept none of them.
+	if tags := iamMemberTags(req.Params); tags != nil {
+		params.Tags = tags
+	}
 
 	goCtx := context.Background()
 
@@ -372,6 +377,11 @@ func (p *IAMPlugin) createRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	}
 	if params.RoleName == "" {
 		return iamErrorResponse("ValidationError", "RoleName is required", http.StatusBadRequest), nil
+	}
+	// Tags is a query-protocol list; see tagUser and iam_query.go (#639). A role
+	// created with tags kept none of them.
+	if tags := iamMemberTags(req.Params); tags != nil {
+		params.Tags = tags
 	}
 
 	goCtx := context.Background()
@@ -1981,6 +1991,14 @@ func (p *IAMPlugin) tagUser(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 	if params.UserName == "" {
 		return iamErrorResponse("ValidationError", "UserName is required", http.StatusBadRequest), nil
 	}
+	// Tags is a query-protocol list, so it arrives as Tags.member.N.Key/Value and
+	// the JSON unmarshal above leaves it nil. Reading req.Params is how every real
+	// client's tags reach this handler; the JSON path is how a unit test drives it.
+	// Only the second was ever exercised, which is why this shipped storing nothing
+	// (#639). See iam_query.go.
+	if tags := iamMemberTags(req.Params); tags != nil {
+		params.Tags = tags
+	}
 
 	goCtx := context.Background()
 
@@ -2034,6 +2052,10 @@ func (p *IAMPlugin) untagUser(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	}
 	if params.UserName == "" {
 		return iamErrorResponse("ValidationError", "UserName is required", http.StatusBadRequest), nil
+	}
+	// TagKeys is a flat query-protocol list; see tagUser above and iam_query.go (#639).
+	if keys := iamMemberList(req.Params, "TagKeys"); keys != nil {
+		params.TagKeys = keys
 	}
 
 	goCtx := context.Background()
@@ -2152,6 +2174,10 @@ func (p *IAMPlugin) tagRole(ctx *RequestContext, req *AWSRequest) (*AWSResponse,
 	if params.RoleName == "" {
 		return iamErrorResponse("ValidationError", "RoleName is required", http.StatusBadRequest), nil
 	}
+	// Tags is a query-protocol list; see tagUser and iam_query.go (#639).
+	if tags := iamMemberTags(req.Params); tags != nil {
+		params.Tags = tags
+	}
 
 	goCtx := context.Background()
 
@@ -2205,6 +2231,10 @@ func (p *IAMPlugin) untagRole(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	}
 	if params.RoleName == "" {
 		return iamErrorResponse("ValidationError", "RoleName is required", http.StatusBadRequest), nil
+	}
+	// TagKeys is a flat query-protocol list; see tagUser and iam_query.go (#639).
+	if keys := iamMemberList(req.Params, "TagKeys"); keys != nil {
+		params.TagKeys = keys
 	}
 
 	goCtx := context.Background()

--- a/emulator/iam_query.go
+++ b/emulator/iam_query.go
@@ -1,0 +1,146 @@
+package emulator
+
+import (
+	"strconv"
+	"strings"
+)
+
+// IAM speaks the AWS query protocol, which has no JSON: a list is sent as
+// numbered form parameters and a struct member as a dotted suffix on one. This
+// file decodes that encoding, mirroring iam_xml.go, which encodes the responses.
+//
+// It exists because nothing decoded it. ParseAWSRequest flattens a form body into
+// AWSRequest.Params, a map[string]string (parser.go), and server.go rebuilds
+// req.Body for the query-protocol services as json.Marshal(req.Params). A client
+// sending
+//
+//	ActionNames.member.1=s3:GetObject&ActionNames.member.2=s3:PutObject
+//
+// therefore produces a JSON body whose keys are *literally* "ActionNames.member.1"
+// and "ActionNames.member.2", so a handler field declared `ActionNames []string`
+// matched nothing and unmarshaled to nil. TagUser, UntagUser, TagRole and UntagRole
+// shipped that way: 200 OK, nothing stored (#639).
+//
+// The unit suite could not see it, because iam_plugin_test.go's iamRequest
+// hand-marshals a body containing real JSON arrays and never traverses the
+// query → params → JSON path a real client takes. Only an SDK-level journey does
+// (test/e2e/journey_iam_tags_test.go).
+//
+// The precedent for the walk itself is parseMemberList (cloudwatch_plugin.go); IAM
+// gets its own so an IAM-shaped refusal never depends on CloudWatch's file, and so
+// the empty-value rule below can differ.
+
+// iamMemberSep is the infix the query protocol puts between a list parameter's
+// name and its 1-based index.
+const iamMemberSep = ".member."
+
+// iamMemberList decodes a flat query-protocol list: prefix.member.1,
+// prefix.member.2, and so on. It returns nil when the list is absent.
+//
+// Indices are walked from 1 — AWS numbers members from 1, contiguously — and the
+// first absent index ends the list. A gap therefore truncates rather than being
+// skipped over, which is deliberate: a client that produced one is not speaking the
+// protocol, and guessing at the intended length would invent members.
+//
+// Unlike parseMemberList, a present-but-empty value is a member holding the empty
+// string rather than the end of the list. That is the same present-vs-absent
+// distinction parser.go is careful about (#412): a client that sent an empty value
+// sent something, and a required-member check must be able to see it.
+func iamMemberList(params map[string]string, prefix string) []string {
+	if params == nil {
+		return nil
+	}
+	var out []string
+	for i := 1; ; i++ {
+		v, ok := params[prefix+iamMemberSep+strconv.Itoa(i)]
+		if !ok {
+			return out
+		}
+		out = append(out, v)
+	}
+}
+
+// iamMemberStructs decodes a query-protocol list of structures: for each index it
+// collects every parameter under prefix.member.N. into one map, keyed by the
+// remaining suffix. It returns nil when the list is absent.
+//
+// So Tags.member.1.Key=env&Tags.member.1.Value=prod yields
+// [{"Key": "env", "Value": "prod"}].
+//
+// The suffix is kept verbatim rather than split further, which is what makes a
+// nested list work: ContextEntries.member.1.ContextKeyValues.member.1=arn yields a
+// member map holding "ContextKeyValues.member.1", so iamMemberList can be applied
+// to that map directly with prefix "ContextKeyValues". SimulatePrincipalPolicy's
+// ContextEntries is exactly that shape (#579).
+//
+// An index exists if any parameter sits under it; as in iamMemberList, the first
+// absent index ends the list.
+func iamMemberStructs(params map[string]string, prefix string) []map[string]string {
+	if params == nil {
+		return nil
+	}
+	// One pass over params per index would be O(n·len), so group by index first.
+	byIndex := make(map[int]map[string]string)
+	root := prefix + iamMemberSep
+	for k, v := range params {
+		if !strings.HasPrefix(k, root) {
+			continue
+		}
+		rest := k[len(root):]
+		dot := strings.IndexByte(rest, '.')
+		if dot <= 0 {
+			// prefix.member.N with no suffix: a flat member, not a struct one. It
+			// belongs to iamMemberList, so leave it out rather than recording an
+			// index with no fields.
+			continue
+		}
+		idx, err := strconv.Atoi(rest[:dot])
+		if err != nil || idx < 1 {
+			continue
+		}
+		fields, ok := byIndex[idx]
+		if !ok {
+			fields = make(map[string]string)
+			byIndex[idx] = fields
+		}
+		fields[rest[dot+1:]] = v
+	}
+	if len(byIndex) == 0 {
+		return nil
+	}
+	var out []map[string]string
+	for i := 1; ; i++ {
+		fields, ok := byIndex[i]
+		if !ok {
+			return out
+		}
+		out = append(out, fields)
+	}
+}
+
+// iamMemberTags decodes a Tags list from query parameters into the shape the
+// tagging handlers store. It returns nil when no Tags list was sent, which is what
+// lets a caller fall back to a JSON body.
+//
+// A member with neither Key nor Value is dropped: an empty tag would otherwise
+// merge into an entity's tag set under the key "", which no client asked for. An
+// empty *Value* under a real Key is kept, because AWS accepts a tag with an empty
+// value.
+func iamMemberTags(params map[string]string) []IAMTag {
+	members := iamMemberStructs(params, "Tags")
+	if members == nil {
+		return nil
+	}
+	out := make([]IAMTag, 0, len(members))
+	for _, m := range members {
+		key, value := m["Key"], m["Value"]
+		if key == "" && value == "" {
+			continue
+		}
+		out = append(out, IAMTag{Key: key, Value: value})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/emulator/iam_query_test.go
+++ b/emulator/iam_query_test.go
@@ -1,0 +1,284 @@
+package emulator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestIAMMemberList covers the flat query-protocol list decoder (#639). The
+// numbering rules are the point: AWS numbers members from 1 contiguously, so index
+// 0 is not a member and a gap ends the list rather than being skipped.
+func TestIAMMemberList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		prefix string
+		want   []string
+	}{
+		{
+			name:   "nil params",
+			params: nil,
+			prefix: "ActionNames",
+			want:   nil,
+		},
+		{
+			name:   "absent list",
+			params: map[string]string{"UserName": "jill"},
+			prefix: "ActionNames",
+			want:   nil,
+		},
+		{
+			name:   "single member",
+			params: map[string]string{"ActionNames.member.1": "s3:GetObject"},
+			prefix: "ActionNames",
+			want:   []string{"s3:GetObject"},
+		},
+		{
+			name: "three members in order",
+			params: map[string]string{
+				"ActionNames.member.3": "s3:PutObject",
+				"ActionNames.member.1": "s3:GetObject",
+				"ActionNames.member.2": "s3:DeleteObject",
+			},
+			prefix: "ActionNames",
+			want:   []string{"s3:GetObject", "s3:DeleteObject", "s3:PutObject"},
+		},
+		{
+			// The walk starts at 1. A member numbered 0 is not something AWS sends, and
+			// treating it as one would shift every index.
+			name: "index zero is not a member",
+			params: map[string]string{
+				"ActionNames.member.0": "ignored",
+				"ActionNames.member.1": "s3:GetObject",
+			},
+			prefix: "ActionNames",
+			want:   []string{"s3:GetObject"},
+		},
+		{
+			// A gap truncates. Guessing at the intended length would invent members a
+			// client did not send.
+			name: "a gap ends the list",
+			params: map[string]string{
+				"ActionNames.member.1": "s3:GetObject",
+				"ActionNames.member.3": "s3:PutObject",
+			},
+			prefix: "ActionNames",
+			want:   []string{"s3:GetObject"},
+		},
+		{
+			// Present-but-empty is a member, unlike parseMemberList's rule. A client
+			// that sent an empty value sent something, and a required-member check has
+			// to be able to see it (the #412 distinction).
+			name: "an empty value is a present member",
+			params: map[string]string{
+				"ActionNames.member.1": "",
+				"ActionNames.member.2": "s3:PutObject",
+			},
+			prefix: "ActionNames",
+			want:   []string{"", "s3:PutObject"},
+		},
+		{
+			// A prefix must not match a longer sibling parameter name.
+			name: "a longer sibling prefix does not leak in",
+			params: map[string]string{
+				"Tags.member.1":    "a",
+				"TagKeys.member.1": "env",
+			},
+			prefix: "TagKeys",
+			want:   []string{"env"},
+		},
+		{
+			// Struct members belong to iamMemberStructs; the flat decoder must not
+			// mistake the dotted suffix for a value.
+			name:   "struct members are not flat members",
+			params: map[string]string{"Tags.member.1.Key": "env"},
+			prefix: "Tags",
+			want:   nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, emulator.IAMMemberListForTest(tc.params, tc.prefix))
+		})
+	}
+}
+
+// TestIAMMemberStructs covers the struct-list decoder, including the nested-list
+// case SimulatePrincipalPolicy's ContextEntries needs (#579): a member map keeps its
+// suffix verbatim, so iamMemberList applies to it directly.
+func TestIAMMemberStructs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		prefix string
+		want   []map[string]string
+	}{
+		{
+			name:   "nil params",
+			params: nil,
+			prefix: "Tags",
+			want:   nil,
+		},
+		{
+			name:   "absent list",
+			params: map[string]string{"UserName": "jill"},
+			prefix: "Tags",
+			want:   nil,
+		},
+		{
+			name: "two members, fields grouped by index",
+			params: map[string]string{
+				"Tags.member.1.Key":   "env",
+				"Tags.member.1.Value": "prod",
+				"Tags.member.2.Key":   "team",
+				"Tags.member.2.Value": "infra",
+			},
+			prefix: "Tags",
+			want: []map[string]string{
+				{"Key": "env", "Value": "prod"},
+				{"Key": "team", "Value": "infra"},
+			},
+		},
+		{
+			name: "a gap ends the list",
+			params: map[string]string{
+				"Tags.member.1.Key": "env",
+				"Tags.member.3.Key": "team",
+			},
+			prefix: "Tags",
+			want:   []map[string]string{{"Key": "env"}},
+		},
+		{
+			name:   "index zero is not a member",
+			params: map[string]string{"Tags.member.0.Key": "env"},
+			prefix: "Tags",
+			want:   nil,
+		},
+		{
+			// The suffix is kept whole, which is what makes a list inside a struct
+			// member decodable by a second iamMemberList call.
+			name: "a nested member list keeps its suffix",
+			params: map[string]string{
+				"ContextEntries.member.1.ContextKeyName":            "aws:username",
+				"ContextEntries.member.1.ContextKeyType":            "string",
+				"ContextEntries.member.1.ContextKeyValues.member.1": "jill",
+				"ContextEntries.member.1.ContextKeyValues.member.2": "jack",
+			},
+			prefix: "ContextEntries",
+			want: []map[string]string{{
+				"ContextKeyName":            "aws:username",
+				"ContextKeyType":            "string",
+				"ContextKeyValues.member.1": "jill",
+				"ContextKeyValues.member.2": "jack",
+			}},
+		},
+		{
+			// A flat member under the same prefix records no index, so the two
+			// decoders cannot corrupt each other's view of the same parameter set.
+			name:   "a flat member is not a struct member",
+			params: map[string]string{"Tags.member.1": "env"},
+			prefix: "Tags",
+			want:   nil,
+		},
+		{
+			name:   "a non-numeric index is skipped",
+			params: map[string]string{"Tags.member.x.Key": "env"},
+			prefix: "Tags",
+			want:   nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := emulator.IAMMemberStructsForTest(tc.params, tc.prefix)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestIAMMemberStructs_NestedListDecodesWithMemberList closes the loop on the
+// nested case: the member map iamMemberStructs returns must be usable as input to
+// iamMemberList, since that is how ContextKeyValues is read.
+func TestIAMMemberStructs_NestedListDecodesWithMemberList(t *testing.T) {
+	t.Parallel()
+
+	members := emulator.IAMMemberStructsForTest(map[string]string{
+		"ContextEntries.member.1.ContextKeyName":            "aws:PrincipalTag/team",
+		"ContextEntries.member.1.ContextKeyValues.member.1": "infra",
+		"ContextEntries.member.1.ContextKeyValues.member.2": "platform",
+	}, "ContextEntries")
+	assert.Len(t, members, 1)
+	assert.Equal(t, []string{"infra", "platform"},
+		emulator.IAMMemberListForTest(members[0], "ContextKeyValues"))
+}
+
+// TestIAMMemberTags covers the tagging shim, whose job is to answer nil when no
+// Tags list was sent so a handler can fall back to its JSON body.
+func TestIAMMemberTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		want   []emulator.IAMTag
+	}{
+		{
+			name:   "no tags sent",
+			params: map[string]string{"UserName": "jill"},
+			want:   nil,
+		},
+		{
+			name: "two tags",
+			params: map[string]string{
+				"Tags.member.1.Key":   "env",
+				"Tags.member.1.Value": "prod",
+				"Tags.member.2.Key":   "team",
+				"Tags.member.2.Value": "infra",
+			},
+			want: []emulator.IAMTag{{Key: "env", Value: "prod"}, {Key: "team", Value: "infra"}},
+		},
+		{
+			// AWS accepts a tag with an empty value, so the key alone is enough to
+			// make a member real.
+			name:   "an empty value under a real key is kept",
+			params: map[string]string{"Tags.member.1.Key": "env", "Tags.member.1.Value": ""},
+			want:   []emulator.IAMTag{{Key: "env", Value: ""}},
+		},
+		{
+			// A wholly empty member would otherwise merge into the tag set under the
+			// key "", which no client asked for.
+			name: "a wholly empty member is dropped",
+			params: map[string]string{
+				"Tags.member.1.Key":   "",
+				"Tags.member.1.Value": "",
+				"Tags.member.2.Key":   "team",
+				"Tags.member.2.Value": "infra",
+			},
+			want: []emulator.IAMTag{{Key: "team", Value: "infra"}},
+		},
+		{
+			// Every member empty means nothing to apply, and nil is what lets the
+			// handler fall through to its JSON body rather than clearing the field.
+			name:   "all members empty answers nil",
+			params: map[string]string{"Tags.member.1.Key": "", "Tags.member.1.Value": ""},
+			want:   nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, emulator.IAMMemberTagsForTest(tc.params))
+		})
+	}
+}

--- a/emulator/iam_query_wire_test.go
+++ b/emulator/iam_query_wire_test.go
@@ -1,0 +1,209 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// This file drives the IAM plugin the way a real client does: an
+// application/x-www-form-urlencoded body in the AWS query protocol, with lists
+// encoded as `.member.N`. Every other IAM unit test uses iamRequest, which
+// hand-marshals a JSON body containing real arrays — a shape no AWS client
+// produces. That is why #639 shipped: TagUser answered 200 and stored nothing, and
+// the whole unit suite agreed it worked.
+//
+// The SDK-level regression lives in test/e2e/journey_iam_tags_test.go. These are
+// the same assertions one layer down, so a decode regression is reported by the
+// package that owns the decoder rather than only by the separate e2e module.
+
+// iamFormRequest executes an IAM query-protocol request against srv, encoding
+// params as a form body exactly as an AWS client would. The operation travels in
+// the Action parameter, which is the query protocol's own mechanism, rather than in
+// an X-Amz-Target header.
+func iamFormRequest(t *testing.T, srv *emulator.Server, operation string, params map[string]string) *http.Response {
+	t.Helper()
+	form := url.Values{}
+	form.Set("Action", operation)
+	form.Set("Version", "2010-05-08")
+	for k, v := range params {
+		form.Set(k, v)
+	}
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
+	r.Host = "iam.amazonaws.com"
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Result()
+}
+
+// iamFormTagNames returns the tag keys and values a Tags-bearing IAM XML response
+// reports, so an assertion can name what it expected rather than only a count.
+func iamFormTagNames(t *testing.T, resp *http.Response) map[string]string {
+	t.Helper()
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	raw, ok := result["Tags"].([]any)
+	if !ok {
+		return map[string]string{}
+	}
+	tags := make(map[string]string, len(raw))
+	for _, entry := range raw {
+		tag, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		key, _ := tag["Key"].(string)
+		value, _ := tag["Value"].(string)
+		tags[key] = value
+	}
+	return tags
+}
+
+// TestIAMWire_UserTagsFromMemberList is #639 for the user pair. Two tags, because a
+// decoder that reads only index 1 would pass a single-tag assertion.
+func TestIAMWire_UserTagsFromMemberList(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	resp := iamFormRequest(t, srv, "CreateUser", map[string]string{"UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamFormRequest(t, srv, "TagUser", map[string]string{
+		"UserName":            "jill",
+		"Tags.member.1.Key":   "env",
+		"Tags.member.1.Value": "prod",
+		"Tags.member.2.Key":   "team",
+		"Tags.member.2.Value": "infra",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamFormRequest(t, srv, "ListUserTags", map[string]string{"UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, map[string]string{"env": "prod", "team": "infra"}, iamFormTagNames(t, resp),
+		"the tags a client sent over the wire never reached tagUser")
+
+	// TagKeys is a flat member list rather than a struct one, so it exercises the
+	// other decoder. Removing one of two proves the keys are read rather than the
+	// whole set being dropped.
+	resp = iamFormRequest(t, srv, "UntagUser", map[string]string{
+		"UserName":         "jill",
+		"TagKeys.member.1": "env",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamFormRequest(t, srv, "ListUserTags", map[string]string{"UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, map[string]string{"team": "infra"}, iamFormTagNames(t, resp))
+}
+
+// TestIAMWire_RoleTagsFromMemberList is the role pair, which was broken
+// independently of the user pair: a fix applied to only one would leave these nil.
+func TestIAMWire_RoleTagsFromMemberList(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	trustDoc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+	resp := iamFormRequest(t, srv, "CreateRole", map[string]string{
+		"RoleName":                 "tagged-role",
+		"AssumeRolePolicyDocument": trustDoc,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamFormRequest(t, srv, "TagRole", map[string]string{
+		"RoleName":            "tagged-role",
+		"Tags.member.1.Key":   "owner",
+		"Tags.member.1.Value": "platform",
+		"Tags.member.2.Key":   "tier",
+		"Tags.member.2.Value": "prod",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamFormRequest(t, srv, "ListRoleTags", map[string]string{"RoleName": "tagged-role"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, map[string]string{"owner": "platform", "tier": "prod"}, iamFormTagNames(t, resp))
+
+	resp = iamFormRequest(t, srv, "UntagRole", map[string]string{
+		"RoleName":         "tagged-role",
+		"TagKeys.member.1": "owner",
+		"TagKeys.member.2": "tier",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamFormRequest(t, srv, "ListRoleTags", map[string]string{"RoleName": "tagged-role"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, iamFormTagNames(t, resp), "both keys were named, so nothing should remain")
+}
+
+// TestIAMWire_CreateWithTags covers the create-time Tags parameter, which is the
+// same encoding on a different operation: CDK and Terraform tag at creation rather
+// than in a second call, so a user or role created with tags kept none of them.
+func TestIAMWire_CreateWithTags(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	resp := iamFormRequest(t, srv, "CreateUser", map[string]string{
+		"UserName":            "born-tagged",
+		"Tags.member.1.Key":   "env",
+		"Tags.member.1.Value": "prod",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamFormRequest(t, srv, "ListUserTags", map[string]string{"UserName": "born-tagged"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, map[string]string{"env": "prod"}, iamFormTagNames(t, resp))
+
+	trustDoc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+	resp = iamFormRequest(t, srv, "CreateRole", map[string]string{
+		"RoleName":                 "born-tagged-role",
+		"AssumeRolePolicyDocument": trustDoc,
+		"Tags.member.1.Key":        "tier",
+		"Tags.member.1.Value":      "prod",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamFormRequest(t, srv, "ListRoleTags", map[string]string{"RoleName": "born-tagged-role"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, map[string]string{"tier": "prod"}, iamFormTagNames(t, resp))
+}
+
+// TestIAMWire_NoTagsLeavesJSONPathIntact guards the fallback the fix relies on: a
+// request carrying no Tags member list must not have its JSON-body tags cleared.
+// That dual read is what keeps every existing iamRequest-driven test meaningful.
+func TestIAMWire_NoTagsLeavesJSONPathIntact(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	resp := iamRequest(t, srv, "CreateUser", map[string]any{"UserName": "json-tagged"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "TagUser", map[string]any{
+		"UserName": "json-tagged",
+		"Tags":     []map[string]string{{"Key": "env", "Value": "test"}},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "ListUserTags", map[string]any{"UserName": "json-tagged"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, map[string]string{"env": "test"}, iamFormTagNames(t, resp))
+}

--- a/test/e2e/journey_iam_tags_test.go
+++ b/test/e2e/journey_iam_tags_test.go
@@ -1,0 +1,148 @@
+package e2e_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_IAMTagsSurviveTheWire is #639 at the SDK level: an IAM list
+// parameter arriving in the query protocol's `.member.N` encoding.
+//
+// This is a level the unit suite structurally cannot reach. `iamRequest`
+// (emulator/iam_plugin_test.go) hand-marshals its body, so a unit test hands
+// tagUser a real JSON array — while a real client sends
+// `Tags.member.1.Key=env&Tags.member.1.Value=prod`, which server.go turns into a
+// JSON body whose keys are *literally* "Tags.member.1.Key". Every `[]string` and
+// `[]struct` field therefore unmarshaled to nil, so TagUser answered 200 and
+// stored nothing. Same blind spot as #561/#610/#636: green tests over a shape no
+// client can produce.
+//
+// The list is two-element on purpose. A decoder that reads only index 1 would
+// pass a single-tag assertion.
+func TestJourney_IAMTagsSurviveTheWire(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	// Retries off, so every assertion is about the first response.
+	iamClient := iam.NewFromConfig(cfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	const userName = "jill"
+	if _, err := iamClient.CreateUser(ctx, &iam.CreateUserInput{
+		UserName: aws.String(userName),
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := iamClient.TagUser(ctx, &iam.TagUserInput{
+		UserName: aws.String(userName),
+		Tags: []iamtypes.Tag{
+			{Key: aws.String("env"), Value: aws.String("prod")},
+			{Key: aws.String("team"), Value: aws.String("infra")},
+		},
+	}); err != nil {
+		t.Fatalf("TagUser: %v", err)
+	}
+
+	got := listUserTags(t, ctx, iamClient, userName)
+	want := map[string]string{"env": "prod", "team": "infra"}
+	if len(got) != len(want) {
+		t.Fatalf("ListUserTags returned %v, want %v — the tags an SDK sent never reached the handler", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("tag %q = %q, want %q", k, got[k], v)
+		}
+	}
+
+	// The removal half: UntagRole/UntagUser take TagKeys, a flat member list rather
+	// than a struct one, so it exercises the other decoder. Removing one of two
+	// proves the keys are read rather than the whole tag set being dropped.
+	if _, err := iamClient.UntagUser(ctx, &iam.UntagUserInput{
+		UserName: aws.String(userName),
+		TagKeys:  []string{"env"},
+	}); err != nil {
+		t.Fatalf("UntagUser: %v", err)
+	}
+	got = listUserTags(t, ctx, iamClient, userName)
+	if len(got) != 1 || got["team"] != "infra" {
+		t.Fatalf("after untagging env, ListUserTags = %v, want only team=infra", got)
+	}
+
+	// Roles carry the same two handlers over the same encoding, and each was broken
+	// independently — a fix applied only to the user pair would leave these nil.
+	const roleName = "tagged-role"
+	if _, err := iamClient.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName: aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}`),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	if _, err := iamClient.TagRole(ctx, &iam.TagRoleInput{
+		RoleName: aws.String(roleName),
+		Tags: []iamtypes.Tag{
+			{Key: aws.String("owner"), Value: aws.String("platform")},
+			{Key: aws.String("tier"), Value: aws.String("prod")},
+		},
+	}); err != nil {
+		t.Fatalf("TagRole: %v", err)
+	}
+	roleTags, err := iamClient.ListRoleTags(ctx, &iam.ListRoleTagsInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		t.Fatalf("ListRoleTags: %v", err)
+	}
+	if len(roleTags.Tags) != 2 {
+		t.Fatalf("ListRoleTags returned %d tags, want 2", len(roleTags.Tags))
+	}
+	if _, err := iamClient.UntagRole(ctx, &iam.UntagRoleInput{
+		RoleName: aws.String(roleName),
+		TagKeys:  []string{"owner", "tier"},
+	}); err != nil {
+		t.Fatalf("UntagRole: %v", err)
+	}
+	roleTags, err = iamClient.ListRoleTags(ctx, &iam.ListRoleTagsInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		t.Fatalf("ListRoleTags after untagging: %v", err)
+	}
+	if len(roleTags.Tags) != 0 {
+		keys := make([]string, 0, len(roleTags.Tags))
+		for _, tag := range roleTags.Tags {
+			keys = append(keys, aws.ToString(tag.Key))
+		}
+		sort.Strings(keys)
+		t.Errorf("UntagRole left %v behind; both keys were named", keys)
+	}
+}
+
+// listUserTags reads a user's tags back as a map, which is what the assertions
+// above compare against — the API's order is the emulator's sort order, not
+// something a consumer should be pinned to.
+func listUserTags(t *testing.T, ctx context.Context, client *iam.Client, userName string) map[string]string {
+	t.Helper()
+	out, err := client.ListUserTags(ctx, &iam.ListUserTagsInput{
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		t.Fatalf("ListUserTags: %v", err)
+	}
+	tags := make(map[string]string, len(out.Tags))
+	for _, tag := range out.Tags {
+		tags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+	return tags
+}


### PR DESCRIPTION
Closes #639.

## The defect

IAM speaks the AWS query protocol, in which a list travels as numbered form
parameters:

```
Tags.member.1.Key=env&Tags.member.1.Value=prod&Tags.member.2.Key=team&Tags.member.2.Value=infra
```

Nothing decoded that encoding. `ParseAWSRequest` flattens a form body into
`AWSRequest.Params`, a `map[string]string` (`emulator/parser.go:44`), and
`server.go:583-589` rebuilds `req.Body` for the query-protocol services as
`json.Marshal(req.Params)` — so a handler field declared `Tags []IAMTag` was
matched by a JSON key *literally named* `"Tags.member.1.Key"` and unmarshaled to
nil.

Six operations were affected, all answering `200 OK` and storing nothing:
`TagUser`, `UntagUser`, `TagRole`, `UntagRole`, and the create-time `Tags` on
`CreateUser`/`CreateRole` (the last two are how CDK and Terraform tag, so they
matter as much as the explicit pair). A tag call that reports success and does
not happen is worse than a refusal: a consumer's assertion on its own tagging
silently becomes an assertion about an empty set.

## The fix

New `emulator/iam_query.go`, following the pattern `parseMemberList`
(`cloudwatch_plugin.go:464`) already established, with two rules made explicit:

- **Indices are walked from 1 and the first gap ends the list.** AWS numbers
  members contiguously; guessing at the intended length would invent members a
  client never sent.
- **A present-but-empty value is a member holding `""`**, not the end of the
  list — the same present-vs-absent distinction `parser.go:37-56` is careful
  about for `ImageId` (#412), because a required-member check has to be able to
  see what was sent.

A member map keeps its suffix verbatim, so a list nested inside a struct member
(`ContextEntries.member.1.ContextKeyValues.member.1`, which
`SimulatePrincipalPolicy` needs — #579) decodes by applying the flat decoder to
the map.

Each handler reads `req.Params` and falls back to its JSON body when no member
list was sent. That dual read is deliberate and commented: the JSON path is how
a unit test drives the plugin, the params path is how every real client does.

## Why the suite shipped green over it

`iamRequest` (`iam_plugin_test.go:40`) hand-marshals a body containing real JSON
arrays — a shape no AWS client produces — and no e2e journey drove a list-valued
IAM parameter. Same structural blind spot as #561 / #610 / #636: an operation no
client can reach, with passing tests over it.

Both new test files close it:

- `test/e2e/journey_iam_tags_test.go` — the SDK level, with two-element lists so
  a decoder reading only index 1 would fail. **This fails before the fix.**
- `emulator/iam_query_wire_test.go` — a genuine `application/x-www-form-urlencoded`
  body one layer down, so a decode regression is reported by the package that
  owns the decoder rather than only by the separate e2e module.

## Verification

- `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — 0 issues
- `make test` (race detector) green; `test/e2e` green
- `make coverage` — 81.6% total, 82.3% for `emulator`
- Live against `substrate server --address :4678` with `AWS_MAX_ATTEMPTS=1`:
  `tag-user` + `list-user-tags` returns both tags, `untag-user` removes the named
  one, and `create-user --tags` keeps them. This is where the defect was visible
  and every unit test was not.
- **Mutation testing, 6 applied, 6 CAUGHT**: flat walk starting at 0; empty value
  treated as end-of-list; struct walk starting at 0; nested suffix truncated at
  the first dot; a wholly-empty tag member kept rather than dropped; the params
  read removed from `tagUser` only (the asymmetric-fix case). No survivors.