### PR TITLE
feat(iam): groups have an observable effect (#579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **IAM groups have an observable effect** (#579 prerequisite). Substrate routed
+  `CreateGroup`, `GetGroup`, `DeleteGroup` and `ListGroups` and nothing else, so a group
+  could be created and then did nothing: no user could join it, no policy could be put on
+  it, and `GetGroup` passed `iamUserListXML(nil)` unconditionally — a group was
+  observably always empty no matter what state held. Eleven operations close that gap:
+  `AddUserToGroup`, `RemoveUserFromGroup`, `ListGroupsForUser`, `AttachGroupPolicy`,
+  `DetachGroupPolicy`, `ListAttachedGroupPolicies`, `PutGroupPolicy`, `GetGroupPolicy`,
+  `DeleteGroupPolicy` and `ListGroupPolicies`.
+
+  Membership is stored on **both** sides of the index — `group_users:<group>` and
+  `user_groups:<user>` — because both directions are read by an API: `GetGroup` lists a
+  group's users and `ListGroupsForUser` lists a user's groups. Every write goes through
+  one pair of functions so the two sides cannot come to disagree, which is the v0.99.0
+  `saveAccount` lesson applied before it could bite: a membership visible to one call and
+  denied by the other is a state invariant broken by a missing line. Both writes are
+  idempotent, matching the reference, which declares `NoSuchEntity` for the group and the
+  user but nothing for the membership itself.
+
+  Group policies reuse the existing storage exactly. Managed attachments land in
+  `group_policies:<name>` through the same `loadPolicyList`/`savePolicyList` pair the user
+  and role handlers use, and inline documents go through the already entity-type
+  parameterized `putInlinePolicy` family. Nothing here invents a second way to store a
+  policy — that is what lets `loadPoliciesForPrincipal` read a group's policies with the
+  code it already had for a user's.
+
+  `DeleteGroup` now refuses with `DeleteConflict` 409 while the group holds members or
+  attached policies ("The group must not contain any users or have any attached
+  policies"), and `DeleteUser` refuses while the user belongs to a group, naming which
+  one. Both refusals exist for the same reason: a delete that skipped them would leave one
+  side of the membership index naming an entity that no longer exists, and that dangling
+  membership is read by `loadPoliciesForPrincipal` on every request.
+
+### Changed
+- **A group's policies now apply to its members' requests** through `CheckAccess`. AWS
+  applies group policies to every request a member makes; substrate evaluated none of
+  them, and the word "group" did not appear in `authz.go`. Both policy loaders learned
+  this arm — `AuthController.loadPoliciesForPrincipal` *and* `IAMPlugin.authorize`, which
+  loads its own document set independently. Teaching only one would have recreated #411
+  exactly: one ARN, two loaders, two opposite answers. A test asserts the two agree on the
+  same input, so the arms cannot drift apart later.
+
+  This is a behaviour change for any fixture whose user belongs to a group carrying a
+  policy: that user starts being allowed — or denied — by it. Nothing else moves, because
+  before this release no operation could put a policy on a group at all, so an existing
+  fixture can only be affected if it wrote group policy state directly.
+
 ### Fixed
+- **`GetGroup` reports its actual members**, paginated by `Marker`/`MaxItems` and sorted,
+  instead of an empty list. A group-based simulation is untestable through the API that
+  reports it if that API always answers "empty".
+- **The inline-policy handlers no longer treat an unknown entity type as a user.** All
+  four of `putInlinePolicy`/`getInlinePolicy`/`deleteInlinePolicy`/`listInlinePolicies`
+  branched on `entityType == "role"` with a `default:` arm that read `role:` state for the
+  existence check while reporting `UserName` in the response — so a third entity type
+  would have looked itself up under the wrong prefix and answered with the wrong element
+  name. One helper now maps the type to its entity name and operation suffix, and an
+  unrecognized type yields an empty name, which every caller already refuses with
+  `ValidationError`.
 - **IAM list parameters sent by a real client now reach the handler** (#639). IAM speaks
   the AWS query protocol, in which a list travels as numbered form parameters —
   `Tags.member.1.Key=env&Tags.member.1.Value=prod`. Nothing decoded that encoding.

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -182,80 +182,142 @@ func resolveIAMEntity(ctx context.Context, state StateManager, principalARN stri
 	return entity, raw != nil, nil
 }
 
+// authzAdministratorAccessARN is the managed policy whose presence short-circuits
+// evaluation, since it allows every action on every resource.
+const authzAdministratorAccessARN = "arn:aws:iam::aws:policy/AdministratorAccess"
+
 // loadPoliciesForPrincipal loads attached managed + inline policies for the
 // entity resolved from reqCtx.Principal.ARN.
+//
+// For a user this includes the policies of every group the user belongs to, which
+// is how IAM works — "a group's permissions apply to all of its users" — and what
+// makes group membership have any effect at all. Before this, authz.go read only
+// the entity's own "<kind>_policies:" and "<kind>_inline*:" keys, so a user whose
+// sole grant came from a group was implicitly denied.
+//
+// A group is never itself a principal: nothing can call AWS *as* a group, so the
+// group arm is reached only through a user.
 func (a *AuthController) loadPoliciesForPrincipal(entity iamEntity) ([]PolicyDocument, error) {
-	entityType, entityName := entity.Kind, entity.Name
-	listKey := entityType + "_policies:" + entityName
-
 	goCtx := context.Background()
 
-	// Load attached managed policy ARNs.
-	raw, err := a.state.Get(goCtx, iamNamespace, listKey)
-	if err != nil {
-		return nil, fmt.Errorf("load policy list: %w", err)
-	}
-
-	var arns []string
-	if raw != nil {
-		if err := json.Unmarshal(raw, &arns); err != nil {
-			return nil, fmt.Errorf("unmarshal policy list: %w", err)
+	// The entity's own policies come first, then each group's, so the order a
+	// document appears in is stable — Evaluate is order-independent (an explicit Deny
+	// wins wherever it sits), but a stable order keeps MatchedStatements reproducible
+	// for the callers that report them.
+	sources := []iamEntity{entity}
+	if entity.Kind == "user" {
+		groups, err := a.loadAuthzStringList(goCtx, iamUserGroupsKey(entity.Name))
+		if err != nil {
+			return nil, fmt.Errorf("load group memberships: %w", err)
+		}
+		for _, name := range groups {
+			sources = append(sources, iamEntity{Kind: "group", Name: name})
 		}
 	}
 
-	// Fast path: AdministratorAccess grants all actions.
-	for _, arn := range arns {
-		if arn == "arn:aws:iam::aws:policy/AdministratorAccess" {
-			return []PolicyDocument{{
-				Version: "2012-10-17",
-				Statement: []PolicyStatement{{
-					Effect:   IAMEffectAllow,
-					Action:   StringOrSlice{"*"},
-					Resource: StringOrSlice{"*"},
-				}},
-			}}, nil
+	arnsBySource := make([][]string, 0, len(sources))
+	for _, source := range sources {
+		arns, err := a.loadAuthzStringList(goCtx, source.Kind+"_policies:"+source.Name)
+		if err != nil {
+			return nil, fmt.Errorf("load policy list: %w", err)
 		}
-	}
+		arnsBySource = append(arnsBySource, arns)
 
-	var docs []PolicyDocument
-
-	// Load managed policy documents.
-	for _, arn := range arns {
-		if mp, ok := GetManagedPolicy(arn); ok {
-			docs = append(docs, mp.Document)
-			continue
-		}
-		polRaw, err := a.state.Get(goCtx, iamNamespace, "policy:"+arn)
-		if err != nil || polRaw == nil {
-			continue
-		}
-		var pol IAMPolicy
-		if err := json.Unmarshal(polRaw, &pol); err != nil {
-			continue
-		}
-		docs = append(docs, pol.Document)
-	}
-
-	// Load inline policies.
-	namesRaw, err := a.state.Get(goCtx, iamNamespace, entityType+"_inline_names:"+entityName)
-	if err == nil && namesRaw != nil {
-		var names []string
-		if err := json.Unmarshal(namesRaw, &names); err == nil {
-			for _, name := range names {
-				docRaw, err := a.state.Get(goCtx, iamNamespace, entityType+"_inline:"+entityName+":"+name)
-				if err != nil || docRaw == nil {
-					continue
-				}
-				var doc PolicyDocument
-				if err := json.Unmarshal(docRaw, &doc); err != nil {
-					continue
-				}
-				docs = append(docs, doc)
+		// Fast path: AdministratorAccess grants all actions, from whichever source it
+		// is attached to.
+		for _, arn := range arns {
+			if arn == authzAdministratorAccessARN {
+				return []PolicyDocument{{
+					Version: "2012-10-17",
+					Statement: []PolicyStatement{{
+						Effect:   IAMEffectAllow,
+						Action:   StringOrSlice{"*"},
+						Resource: StringOrSlice{"*"},
+					}},
+				}}, nil
 			}
 		}
 	}
 
+	var docs []PolicyDocument
+	for i, source := range sources {
+		for _, arn := range arnsBySource[i] {
+			if doc, ok := a.resolveManagedPolicyDoc(goCtx, arn); ok {
+				docs = append(docs, doc)
+			}
+		}
+		docs = append(docs, a.loadInlinePolicyDocs(goCtx, source)...)
+	}
+
 	return docs, nil
+}
+
+// loadAuthzStringList reads a JSON string list from IAM state, treating an absent
+// key as an empty list.
+func (a *AuthController) loadAuthzStringList(goCtx context.Context, key string) ([]string, error) {
+	raw, err := a.state.Get(goCtx, iamNamespace, key)
+	if err != nil {
+		return nil, fmt.Errorf("get %s: %w", key, err)
+	}
+	if raw == nil {
+		return nil, nil
+	}
+	var list []string
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("unmarshal %s: %w", key, err)
+	}
+	return list, nil
+}
+
+// resolveManagedPolicyDoc resolves a managed policy ARN to its document, checking
+// the bundled catalog before state — the same order every other IAM caller uses, so
+// a bundled and a customer-managed policy behave alike.
+//
+// An ARN that resolves to neither is reported as not found rather than as an
+// error: substrate bundles 52 of the ~1,200 AWS managed policies, so an attachment
+// naming an unbundled one is expected and must not fail the whole load.
+func (a *AuthController) resolveManagedPolicyDoc(goCtx context.Context, arn string) (PolicyDocument, bool) {
+	if mp, ok := GetManagedPolicy(arn); ok {
+		return mp.Document, true
+	}
+	polRaw, err := a.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	if err != nil || polRaw == nil {
+		return PolicyDocument{}, false
+	}
+	var pol IAMPolicy
+	if err := json.Unmarshal(polRaw, &pol); err != nil {
+		return PolicyDocument{}, false
+	}
+	return pol.Document, true
+}
+
+// loadInlinePolicyDocs returns the inline policy documents embedded in an entity.
+//
+// A read that fails yields no document rather than an error, matching the
+// behavior this replaced: an unreadable inline policy must not turn into a
+// blanket deny, and CheckAccess already fails open on the errors it does see.
+func (a *AuthController) loadInlinePolicyDocs(goCtx context.Context, entity iamEntity) []PolicyDocument {
+	namesRaw, err := a.state.Get(goCtx, iamNamespace, entity.Kind+"_inline_names:"+entity.Name)
+	if err != nil || namesRaw == nil {
+		return nil
+	}
+	var names []string
+	if err := json.Unmarshal(namesRaw, &names); err != nil {
+		return nil
+	}
+	var docs []PolicyDocument
+	for _, name := range names {
+		docRaw, err := a.state.Get(goCtx, iamNamespace, entity.Kind+"_inline:"+entity.Name+":"+name)
+		if err != nil || docRaw == nil {
+			continue
+		}
+		var doc PolicyDocument
+		if err := json.Unmarshal(docRaw, &doc); err != nil {
+			continue
+		}
+		docs = append(docs, doc)
+	}
+	return docs
 }
 
 // loadPermissionBoundary loads the permission boundary PolicyDocument for the

--- a/emulator/authz_groups_test.go
+++ b/emulator/authz_groups_test.go
@@ -1,0 +1,302 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// A group's policies apply to its members' requests. AWS: "a group's permissions
+// apply to all of its users", and the SimulatePrincipalPolicy reference says the
+// simulation "also includes all of the policies that are attached to groups that
+// the user belongs to".
+//
+// Before this, authz.go read only "<kind>_policies:" and "<kind>_inline*:" for the
+// resolved entity, so a user whose sole grant came from a group was implicitly
+// denied. Nothing caught it because no operation could put a policy on a group.
+//
+// The same widening is applied to IAMPlugin.authorize, so both loaders answer the
+// same for one ARN — the #411 split.
+
+// authzGroupState builds state with one user, one group, the user in the group, and
+// whichever grants the caller asks for. Membership is written on both sides, the
+// way addGroupMembership does, because a test writing only one side would pass
+// against a loader reading only the other.
+type authzGroupState struct {
+	// GroupManaged is a managed policy ARN attached to the group.
+	GroupManaged string
+
+	// GroupManagedDoc is the document stored for GroupManaged, when it is not a
+	// bundled ARN.
+	GroupManagedDoc *emulator.PolicyDocument
+
+	// GroupInline is an inline document embedded in the group.
+	GroupInline *emulator.PolicyDocument
+
+	// UserInline is an inline document embedded in the user.
+	UserInline *emulator.PolicyDocument
+
+	// OmitMembership skips the membership write, so the same grants can be checked
+	// with and without the user being a member.
+	OmitMembership bool
+}
+
+func newAuthzGroupState(t *testing.T, userName, groupName string, spec authzGroupState) emulator.StateManager {
+	t.Helper()
+	state := emulator.NewMemoryStateManager()
+	ctx := context.Background()
+
+	put := func(key string, value any) {
+		t.Helper()
+		raw, err := json.Marshal(value)
+		require.NoError(t, err)
+		require.NoError(t, state.Put(ctx, "iam", key, raw))
+	}
+
+	put("user:"+userName, emulator.IAMUser{
+		UserName: userName,
+		UserID:   "AIDATEST",
+		ARN:      "arn:aws:iam::123456789012:user/" + userName,
+		Path:     "/",
+	})
+	put("group:"+groupName, emulator.IAMGroup{
+		GroupName: groupName,
+		GroupID:   "AGPATEST",
+		ARN:       "arn:aws:iam::123456789012:group/" + groupName,
+		Path:      "/",
+	})
+	if !spec.OmitMembership {
+		put("group_users:"+groupName, []string{userName})
+		put("user_groups:"+userName, []string{groupName})
+	}
+	if spec.GroupManaged != "" {
+		put("group_policies:"+groupName, []string{spec.GroupManaged})
+		if spec.GroupManagedDoc != nil {
+			put("policy:"+spec.GroupManaged, emulator.IAMPolicy{
+				PolicyName:       "grouppolicy",
+				ARN:              spec.GroupManaged,
+				Path:             "/",
+				DefaultVersionID: "v1",
+				IsAttachable:     true,
+				Document:         *spec.GroupManagedDoc,
+			})
+		}
+	}
+	if spec.GroupInline != nil {
+		put("group_inline:"+groupName+":inline", *spec.GroupInline)
+		put("group_inline_names:"+groupName, []string{"inline"})
+	}
+	if spec.UserInline != nil {
+		put("user_inline:"+userName+":inline", *spec.UserInline)
+		put("user_inline_names:"+userName, []string{"inline"})
+	}
+	return state
+}
+
+func authzDoc(effect, action, resource string) *emulator.PolicyDocument {
+	return &emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   effect,
+			Action:   emulator.StringOrSlice{action},
+			Resource: emulator.StringOrSlice{resource},
+		}},
+	}
+}
+
+// TestAuthController_GroupPolicyGrantsMember is the decisive test for the lane: a
+// user with no policies of their own, in a group whose managed policy is the only
+// grant, is allowed — and the identical state minus the membership is denied. The
+// second half is what makes the first half about groups rather than about the
+// policy simply being found somewhere.
+func TestAuthController_GroupPolicyGrantsMember(t *testing.T) {
+	t.Parallel()
+
+	const groupPolicyARN = "arn:aws:iam::123456789012:policy/GroupS3Read"
+	grant := authzDoc(emulator.IAMEffectAllow, "s3:GetObject", "*")
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	req := &emulator.AWSRequest{Service: "s3", Operation: "GetObject", Path: "/bucket/key"}
+	reqCtx := newAuthTestReqCtx("arn:aws:iam::123456789012:user/jill")
+
+	member := emulator.NewAuthController(newAuthzGroupState(t, "jill", "devs", authzGroupState{
+		GroupManaged: groupPolicyARN, GroupManagedDoc: grant,
+	}), logger)
+	assert.NoError(t, member.CheckAccess(reqCtx, req),
+		"the group's policy is the user's only grant, so a denial means groups are not read")
+
+	nonMember := emulator.NewAuthController(newAuthzGroupState(t, "jill", "devs", authzGroupState{
+		GroupManaged: groupPolicyARN, GroupManagedDoc: grant, OmitMembership: true,
+	}), logger)
+	err := nonMember.CheckAccess(reqCtx, req)
+	require.Error(t, err, "a user not in the group must not receive its policy")
+	var awsErr *emulator.AWSError
+	require.ErrorAs(t, err, &awsErr)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
+}
+
+// TestAuthController_GroupInlinePolicyGrantsMember covers the other storage a group
+// policy can live in. Managed and inline are separate reads, so one working proves
+// nothing about the other.
+func TestAuthController_GroupInlinePolicyGrantsMember(t *testing.T) {
+	t.Parallel()
+
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	state := newAuthzGroupState(t, "jill", "devs", authzGroupState{
+		GroupInline: authzDoc(emulator.IAMEffectAllow, "s3:PutObject", "*"),
+	})
+	auth := emulator.NewAuthController(state, logger)
+
+	assert.NoError(t, auth.CheckAccess(
+		newAuthTestReqCtx("arn:aws:iam::123456789012:user/jill"),
+		&emulator.AWSRequest{Service: "s3", Operation: "PutObject", Path: "/bucket/key"}))
+}
+
+// TestAuthController_GroupDenyBeatsUserAllow is IAM's rule that an explicit Deny
+// wins from wherever it comes. A group Deny overriding a user Allow proves the two
+// document sets are evaluated together rather than the group's being consulted only
+// when the user's produces no answer.
+func TestAuthController_GroupDenyBeatsUserAllow(t *testing.T) {
+	t.Parallel()
+
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	state := newAuthzGroupState(t, "jill", "devs", authzGroupState{
+		UserInline:  authzDoc(emulator.IAMEffectAllow, "s3:DeleteObject", "*"),
+		GroupInline: authzDoc(emulator.IAMEffectDeny, "s3:DeleteObject", "*"),
+	})
+	auth := emulator.NewAuthController(state, logger)
+
+	err := auth.CheckAccess(
+		newAuthTestReqCtx("arn:aws:iam::123456789012:user/jill"),
+		&emulator.AWSRequest{Service: "s3", Operation: "DeleteObject", Path: "/bucket/key"})
+	require.Error(t, err)
+	var awsErr *emulator.AWSError
+	require.ErrorAs(t, err, &awsErr)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
+}
+
+// TestAuthController_GroupAdministratorAccessFastPath covers the short-circuit:
+// AdministratorAccess allows everything from whichever source it is attached to, and
+// the fast path returned before any group was read.
+func TestAuthController_GroupAdministratorAccessFastPath(t *testing.T) {
+	t.Parallel()
+
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	state := newAuthzGroupState(t, "jill", "admins", authzGroupState{
+		GroupManaged: "arn:aws:iam::aws:policy/AdministratorAccess",
+	})
+	auth := emulator.NewAuthController(state, logger)
+
+	assert.NoError(t, auth.CheckAccess(
+		newAuthTestReqCtx("arn:aws:iam::123456789012:user/jill"),
+		&emulator.AWSRequest{Service: "dynamodb", Operation: "PutItem", Path: "/"}))
+}
+
+// TestAuthController_RoleIgnoresGroupMemberships pins the shape of the widening: a
+// role cannot belong to a group, so a stray user_groups entry under a role's name
+// must not grant it anything. Reading "<kind>_groups:" unconditionally would.
+func TestAuthController_RoleIgnoresGroupMemberships(t *testing.T) {
+	t.Parallel()
+
+	state := emulator.NewMemoryStateManager()
+	ctx := context.Background()
+	put := func(key string, value any) {
+		raw, err := json.Marshal(value)
+		require.NoError(t, err)
+		require.NoError(t, state.Put(ctx, "iam", key, raw))
+	}
+	put("role:worker", emulator.IAMRole{
+		RoleName: "worker",
+		RoleID:   "AROATEST",
+		ARN:      "arn:aws:iam::123456789012:role/worker",
+		Path:     "/",
+	})
+	put("group:devs", emulator.IAMGroup{GroupName: "devs", ARN: "arn:aws:iam::123456789012:group/devs", Path: "/"})
+	put("group_inline:devs:inline", *authzDoc(emulator.IAMEffectAllow, "s3:GetObject", "*"))
+	put("group_inline_names:devs", []string{"inline"})
+	// A membership keyed by the role's name, which nothing writes but state could hold.
+	put("user_groups:worker", []string{"devs"})
+
+	auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
+	err := auth.CheckAccess(
+		newAuthTestReqCtx("arn:aws:iam::123456789012:role/worker"),
+		&emulator.AWSRequest{Service: "s3", Operation: "GetObject", Path: "/bucket/key"})
+	require.Error(t, err, "a role must not pick up a group's policies")
+	var awsErr *emulator.AWSError
+	require.ErrorAs(t, err, &awsErr)
+	assert.Equal(t, "AccessDenied", awsErr.Code)
+}
+
+// TestGroupPolicy_BothLoadersAgree checks the same grant through both gates at
+// once. IAMPlugin.authorize loads its documents independently of AuthController, so
+// both had to learn about groups: teaching only one would refuse an IAM call granted
+// through a group on one path and allow it on the other — the #411 split, one ARN
+// with two answers, which is the failure mode a second loader always risks.
+func TestGroupPolicy_BothLoadersAgree(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		spec       authzGroupState
+		wantDenied bool
+	}{
+		{
+			name: "group inline policy allows the action",
+			spec: authzGroupState{GroupInline: authzDoc(emulator.IAMEffectAllow, "iam:ListUsers", "*")},
+		},
+		{
+			name: "group managed policy allows the action",
+			spec: authzGroupState{
+				GroupManaged:    "arn:aws:iam::123456789012:policy/GroupIAMRead",
+				GroupManagedDoc: authzDoc(emulator.IAMEffectAllow, "iam:ListUsers", "*"),
+			},
+		},
+		{
+			name: "the same grant on a group the user has left",
+			spec: authzGroupState{
+				GroupInline:    authzDoc(emulator.IAMEffectAllow, "iam:ListUsers", "*"),
+				OmitMembership: true,
+			},
+			wantDenied: true,
+		},
+		{
+			name: "a group deny overrides the user's own allow",
+			spec: authzGroupState{
+				UserInline:  authzDoc(emulator.IAMEffectAllow, "iam:ListUsers", "*"),
+				GroupInline: authzDoc(emulator.IAMEffectDeny, "iam:ListUsers", "*"),
+			},
+			wantDenied: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			state := newAuthzGroupState(t, "jill", "iamadmins", tt.spec)
+			logger := emulator.NewDefaultLogger(slog.LevelError, false)
+
+			plugin := &emulator.IAMPlugin{}
+			require.NoError(t, plugin.Initialize(context.Background(),
+				emulator.PluginConfig{State: state, Logger: logger}))
+			auth := emulator.NewAuthController(state, logger)
+
+			reqCtx := newAuthTestReqCtx("arn:aws:iam::123456789012:user/jill")
+			pluginErr := emulator.IAMAuthorizeForTest(plugin, reqCtx, "iam:ListUsers", "*")
+			controllerErr := auth.CheckAccess(reqCtx,
+				&emulator.AWSRequest{Service: "iam", Operation: "ListUsers", Params: map[string]string{}})
+
+			if tt.wantDenied {
+				assert.Error(t, pluginErr, "IAMPlugin.authorize should deny")
+				assert.Error(t, controllerErr, "CheckAccess should deny")
+				return
+			}
+			assert.NoError(t, pluginErr, "IAMPlugin.authorize should allow")
+			assert.NoError(t, controllerErr, "CheckAccess should allow")
+		})
+	}
+}

--- a/emulator/iam_groups.go
+++ b/emulator/iam_groups.go
@@ -1,0 +1,413 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+)
+
+// IAM groups: membership and the policy operations that make a group worth
+// belonging to.
+//
+// Before this file, substrate routed CreateGroup/GetGroup/DeleteGroup/ListGroups
+// and nothing else — a group could be created, but no user could join it and no
+// policy could be put on it, so GetGroup answered with an empty member list
+// unconditionally and a group had no observable effect on any request. That is
+// also why no evaluation consulted group policies: there were none to consult.
+//
+// Membership is stored on *both* sides, "group_users:<group>" and
+// "user_groups:<user>", because both directions are read by an API: GetGroup
+// lists a group's users and ListGroupsForUser lists a user's groups. Every write
+// goes through addGroupMembership/removeGroupMembership so an index cannot come
+// to exist on one side only — the v0.99.0 saveAccount lesson.
+//
+// Group policies reuse the existing storage exactly: managed attachments land in
+// "group_policies:<name>" through loadPolicyList/savePolicyList, and inline
+// documents go through the putInlinePolicy family, which is entity-type
+// parameterized. Nothing here invents a second way to store a policy, which is
+// what lets loadPoliciesForPrincipal (authz.go) read a group's policies with the
+// same code it already uses for a user's.
+
+// --- Membership ------------------------------------------------------------
+
+// addUserToGroup implements the AddUserToGroup operation.
+func (p *IAMPlugin) addUserToGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		GroupName string `json:"GroupName"`
+		UserName  string `json:"UserName"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.GroupName == "" || params.UserName == "" {
+		return iamErrorResponse("ValidationError", "GroupName and UserName are required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:AddUserToGroup", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	if resp, err := p.requireGroupAndUser(goCtx, params.GroupName, params.UserName); resp != nil || err != nil {
+		return resp, err
+	}
+
+	if err := p.addGroupMembership(goCtx, params.GroupName, params.UserName); err != nil {
+		return nil, err
+	}
+
+	return iamXMLEmptyResponse("AddUserToGroup"), nil
+}
+
+// removeUserFromGroup implements the RemoveUserFromGroup operation.
+func (p *IAMPlugin) removeUserFromGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		GroupName string `json:"GroupName"`
+		UserName  string `json:"UserName"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.GroupName == "" || params.UserName == "" {
+		return iamErrorResponse("ValidationError", "GroupName and UserName are required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:RemoveUserFromGroup", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	if resp, err := p.requireGroupAndUser(goCtx, params.GroupName, params.UserName); resp != nil || err != nil {
+		return resp, err
+	}
+
+	// AWS declares only NoSuchEntity for the group and the user, not for the
+	// membership: removing a user who is not a member is not an error, so the write
+	// is idempotent in both directions.
+	if err := p.removeGroupMembership(goCtx, params.GroupName, params.UserName); err != nil {
+		return nil, err
+	}
+
+	return iamXMLEmptyResponse("RemoveUserFromGroup"), nil
+}
+
+// listGroupsForUser implements the ListGroupsForUser operation.
+func (p *IAMPlugin) listGroupsForUser(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		UserName string `json:"UserName"`
+		Marker   string `json:"Marker"`
+		MaxItems int    `json:"MaxItems"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.UserName == "" {
+		return iamErrorResponse("ValidationError", "UserName is required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:ListGroupsForUser", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	user, err := p.loadUser(goCtx, params.UserName)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("The user with name %s cannot be found.", params.UserName),
+			http.StatusNotFound), nil
+	}
+
+	names, err := p.loadStringList(goCtx, iamUserGroupsKey(params.UserName))
+	if err != nil {
+		return nil, err
+	}
+
+	page, nextMarker, isTruncated := paginateIAMKeys(names, params.Marker, params.MaxItems)
+
+	groups := make([]*IAMGroup, 0, len(page))
+	for _, name := range page {
+		group, err := p.loadGroup(goCtx, name)
+		if err != nil {
+			return nil, err
+		}
+		// A membership naming a group that no longer exists is skipped rather than
+		// reported: DeleteGroup refuses while the group has members, so this can only
+		// arise from a state edit outside the API.
+		if group == nil {
+			continue
+		}
+		groups = append(groups, group)
+	}
+
+	xmlStr := iamGroupListXML(groups) + "<IsTruncated>" + iamBoolXML(isTruncated) + "</IsTruncated>"
+	if nextMarker != "" {
+		xmlStr += "<Marker>" + xmlEsc(nextMarker) + "</Marker>"
+	}
+	return iamXMLResponse(http.StatusOK, "ListGroupsForUser", xmlStr)
+}
+
+// --- Managed policy attachment (group) -------------------------------------
+
+// attachGroupPolicy implements the AttachGroupPolicy operation.
+func (p *IAMPlugin) attachGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		GroupName string `json:"GroupName"`
+		PolicyArn string `json:"PolicyArn"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.GroupName == "" || params.PolicyArn == "" {
+		return iamErrorResponse("ValidationError", "GroupName and PolicyArn are required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:AttachGroupPolicy", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	group, err := p.loadGroup(goCtx, params.GroupName)
+	if err != nil {
+		return nil, err
+	}
+	if group == nil {
+		return iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("The group with name %s cannot be found.", params.GroupName),
+			http.StatusNotFound), nil
+	}
+
+	listKey := iamGroupPoliciesKey(params.GroupName)
+	arns, err := p.loadPolicyList(goCtx, listKey)
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range arns {
+		if a == params.PolicyArn {
+			return iamXMLEmptyResponse("AttachGroupPolicy"), nil
+		}
+	}
+	arns = append(arns, params.PolicyArn)
+	if err := p.savePolicyList(goCtx, listKey, arns); err != nil {
+		return nil, err
+	}
+
+	return iamXMLEmptyResponse("AttachGroupPolicy"), nil
+}
+
+// detachGroupPolicy implements the DetachGroupPolicy operation.
+func (p *IAMPlugin) detachGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		GroupName string `json:"GroupName"`
+		PolicyArn string `json:"PolicyArn"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.GroupName == "" || params.PolicyArn == "" {
+		return iamErrorResponse("ValidationError", "GroupName and PolicyArn are required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:DetachGroupPolicy", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	listKey := iamGroupPoliciesKey(params.GroupName)
+	arns, err := p.loadPolicyList(goCtx, listKey)
+	if err != nil {
+		return nil, err
+	}
+
+	newARNs := arns[:0]
+	found := false
+	for _, a := range arns {
+		if a == params.PolicyArn {
+			found = true
+			continue
+		}
+		newARNs = append(newARNs, a)
+	}
+	if !found {
+		return iamErrorResponse("NoSuchEntity",
+			"The policy is not attached to the specified entity.",
+			http.StatusNotFound), nil
+	}
+	if err := p.savePolicyList(goCtx, listKey, newARNs); err != nil {
+		return nil, err
+	}
+
+	return iamXMLEmptyResponse("DetachGroupPolicy"), nil
+}
+
+// listAttachedGroupPolicies implements the ListAttachedGroupPolicies operation.
+func (p *IAMPlugin) listAttachedGroupPolicies(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		GroupName string `json:"GroupName"`
+		Marker    string `json:"Marker"`
+		MaxItems  int    `json:"MaxItems"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
+	}
+	if params.GroupName == "" {
+		return iamErrorResponse("ValidationError", "GroupName is required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:ListAttachedGroupPolicies", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	arns, err := p.loadPolicyList(goCtx, iamGroupPoliciesKey(params.GroupName))
+	if err != nil {
+		return nil, err
+	}
+
+	policies := make([]IAMAttachedPolicy, 0, len(arns))
+	for _, arn := range arns {
+		policies = append(policies, IAMAttachedPolicy{PolicyName: arnPolicyName(arn), PolicyARN: arn})
+	}
+
+	return iamXMLResponse(http.StatusOK, "ListAttachedGroupPolicies",
+		iamAttachedPoliciesXML(policies)+"<IsTruncated>false</IsTruncated>")
+}
+
+// --- Inline policies (group) -----------------------------------------------
+
+func (p *IAMPlugin) putGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	return p.putInlinePolicy(ctx, req, "group")
+}
+
+func (p *IAMPlugin) getGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	return p.getInlinePolicy(ctx, req, "group")
+}
+
+func (p *IAMPlugin) deleteGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	return p.deleteInlinePolicy(ctx, req, "group")
+}
+
+func (p *IAMPlugin) listGroupPolicies(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	return p.listInlinePolicies(ctx, req, "group")
+}
+
+// --- State helpers ---------------------------------------------------------
+
+// iamGroupUsersKey is the state key holding a group's member user names.
+func iamGroupUsersKey(groupName string) string { return "group_users:" + groupName }
+
+// iamUserGroupsKey is the state key holding the group names a user belongs to.
+func iamUserGroupsKey(userName string) string { return "user_groups:" + userName }
+
+// iamGroupPoliciesKey is the state key holding a group's attached managed policy
+// ARNs. It follows the "<kind>_policies:<name>" form the user and role keys use,
+// which is what lets loadPoliciesForPrincipal read it with the same code.
+func iamGroupPoliciesKey(groupName string) string { return "group_policies:" + groupName }
+
+// loadGroup returns the stored group, or nil when it does not exist.
+func (p *IAMPlugin) loadGroup(goCtx context.Context, name string) (*IAMGroup, error) {
+	raw, err := p.state.Get(goCtx, iamNamespace, "group:"+name)
+	if err != nil {
+		return nil, fmt.Errorf("load group %s: %w", name, err)
+	}
+	if raw == nil {
+		return nil, nil
+	}
+	var g IAMGroup
+	if err := json.Unmarshal(raw, &g); err != nil {
+		return nil, fmt.Errorf("unmarshal group %s: %w", name, err)
+	}
+	return &g, nil
+}
+
+// requireGroupAndUser returns a NoSuchEntity response when either entity is
+// missing, or (nil, nil) when both exist.
+//
+// The group is checked first because it is the operation's first parameter, so a
+// call naming two unknown entities reports the one a caller reads first.
+func (p *IAMPlugin) requireGroupAndUser(goCtx context.Context, groupName, userName string) (*AWSResponse, error) {
+	group, err := p.loadGroup(goCtx, groupName)
+	if err != nil {
+		return nil, err
+	}
+	if group == nil {
+		return iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("The group with name %s cannot be found.", groupName),
+			http.StatusNotFound), nil
+	}
+	user, err := p.loadUser(goCtx, userName)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("The user with name %s cannot be found.", userName),
+			http.StatusNotFound), nil
+	}
+	return nil, nil
+}
+
+// addGroupMembership records the membership on both sides of the index. It is
+// idempotent: adding a user who is already a member changes nothing.
+//
+// Both writes live here, and nowhere else, so the two directions cannot disagree.
+// A membership visible to GetGroup but not to ListGroupsForUser — or worse, one
+// that grants the group's policies through CheckAccess while the API reports the
+// user as not a member — would be a state invariant broken by a missing line.
+func (p *IAMPlugin) addGroupMembership(goCtx context.Context, groupName, userName string) error {
+	if err := p.addToSortedList(goCtx, iamGroupUsersKey(groupName), userName); err != nil {
+		return err
+	}
+	return p.addToSortedList(goCtx, iamUserGroupsKey(userName), groupName)
+}
+
+// removeGroupMembership drops the membership from both sides of the index. It is
+// idempotent: removing a non-member changes nothing.
+func (p *IAMPlugin) removeGroupMembership(goCtx context.Context, groupName, userName string) error {
+	if err := p.removeFromList(goCtx, iamGroupUsersKey(groupName), userName); err != nil {
+		return err
+	}
+	return p.removeFromList(goCtx, iamUserGroupsKey(userName), groupName)
+}
+
+// addToSortedList adds value to the string list at key, keeping it sorted and
+// free of duplicates. Sorting is what makes the paginated reads stable.
+func (p *IAMPlugin) addToSortedList(goCtx context.Context, key, value string) error {
+	list, err := p.loadStringList(goCtx, key)
+	if err != nil {
+		return err
+	}
+	for _, v := range list {
+		if v == value {
+			return nil
+		}
+	}
+	list = append(list, value)
+	sort.Strings(list)
+	return p.saveStringList(goCtx, key, list)
+}
+
+// removeFromList drops value from the string list at key.
+func (p *IAMPlugin) removeFromList(goCtx context.Context, key, value string) error {
+	list, err := p.loadStringList(goCtx, key)
+	if err != nil {
+		return err
+	}
+	out := list[:0]
+	found := false
+	for _, v := range list {
+		if v == value {
+			found = true
+			continue
+		}
+		out = append(out, v)
+	}
+	if !found {
+		return nil
+	}
+	return p.saveStringList(goCtx, key, out)
+}

--- a/emulator/iam_groups_test.go
+++ b/emulator/iam_groups_test.go
@@ -1,7 +1,12 @@
 package emulator_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -167,6 +172,43 @@ func TestIAMGroups_MembersAreSortedAndPaginated(t *testing.T) {
 	assert.Equal(t, false, page["IsTruncated"])
 }
 
+// TestIAMGroups_GroupsForUserArePaginated is the same cursor on the other side of
+// the index. Both directions page, so both need the assertion — a user in many
+// groups is the realistic shape, and a caller that follows the Marker must see each
+// group exactly once.
+func TestIAMGroups_GroupsForUserArePaginated(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	resp := iamRequest(t, srv, "CreateUser", map[string]any{"UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	for _, name := range []string{"sre", "devs", "oncall"} {
+		resp = iamRequest(t, srv, "CreateGroup", map[string]any{"GroupName": name})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+		resp = iamRequest(t, srv, "AddUserToGroup", map[string]any{"GroupName": name, "UserName": "jill"})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	}
+	assert.Equal(t, []string{"devs", "oncall", "sre"}, iamGroupNamesForUser(t, srv, "jill"))
+
+	resp = iamRequest(t, srv, "ListGroupsForUser", map[string]any{"UserName": "jill", "MaxItems": 2})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var page map[string]any
+	decodeIAMXML(t, resp, &page)
+	require.Len(t, page["Groups"], 2)
+	assert.Equal(t, true, page["IsTruncated"])
+	marker, ok := page["Marker"].(string)
+	require.True(t, ok, "a truncated page must carry a Marker")
+
+	resp = iamRequest(t, srv, "ListGroupsForUser", map[string]any{"UserName": "jill", "Marker": marker})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	decodeIAMXML(t, resp, &page)
+	require.Len(t, page["Groups"], 1, "the second page holds the remaining group")
+	assert.Equal(t, false, page["IsTruncated"])
+}
+
 // TestIAMGroups_MembershipRefusesUnknownEntities covers the two NoSuchEntity arms
 // the model declares for both membership operations.
 func TestIAMGroups_MembershipRefusesUnknownEntities(t *testing.T) {
@@ -290,6 +332,88 @@ func TestIAMGroups_ManagedPolicyAttachment(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	decodeIAMXML(t, resp, &result)
 	assert.Equal(t, "NoSuchEntity", result["__type"])
+}
+
+// TestIAMGroups_DetachKeepsTheOtherPolicies pins that a detach removes one entry
+// rather than rewriting the list: the filter reuses the backing array, so an
+// off-by-one there would drop a policy the caller never named.
+func TestIAMGroups_DetachKeepsTheOtherPolicies(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	resp := iamRequest(t, srv, "CreateGroup", map[string]any{"GroupName": "devs"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	const (
+		s3ARN  = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+		ec2ARN = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+	)
+	for _, arn := range []string{s3ARN, ec2ARN} {
+		resp = iamRequest(t, srv, "AttachGroupPolicy", map[string]any{"GroupName": "devs", "PolicyArn": arn})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	resp = iamRequest(t, srv, "DetachGroupPolicy", map[string]any{"GroupName": "devs", "PolicyArn": s3ARN})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "ListAttachedGroupPolicies", map[string]any{"GroupName": "devs"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	attached, ok := result["AttachedPolicies"].([]any)
+	require.True(t, ok)
+	require.Len(t, attached, 1, "detaching one policy must leave the other attached")
+	entry, ok := attached[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, ec2ARN, entry["PolicyArn"])
+}
+
+// TestIAMGroups_RequiredParameters covers the ValidationError arm of every new
+// operation. AWS refuses a missing required member before it looks anything up, so
+// a handler that skipped the check would report NoSuchEntity for a call that named
+// no entity at all.
+func TestIAMGroups_RequiredParameters(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	tests := []struct {
+		operation string
+		body      map[string]any
+	}{
+		{"RemoveUserFromGroup", map[string]any{"GroupName": "devs"}},
+		{"RemoveUserFromGroup", map[string]any{"UserName": "jill"}},
+		{"ListGroupsForUser", map[string]any{}},
+		{"AttachGroupPolicy", map[string]any{"GroupName": "devs"}},
+		{"AttachGroupPolicy", map[string]any{"PolicyArn": "arn:aws:iam::aws:policy/ReadOnlyAccess"}},
+		{"DetachGroupPolicy", map[string]any{"GroupName": "devs"}},
+		{"DetachGroupPolicy", map[string]any{"PolicyArn": "arn:aws:iam::aws:policy/ReadOnlyAccess"}},
+		{"ListAttachedGroupPolicies", map[string]any{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.operation+"/"+iamMissingParamName(tt.body), func(t *testing.T) {
+			resp := iamRequest(t, srv, tt.operation, tt.body)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, "ValidationError", result["__type"])
+		})
+	}
+}
+
+// iamMissingParamName names a subtest by what the body does carry, since what it
+// omits is the point and listing every present key keeps the names unique.
+func iamMissingParamName(body map[string]any) string {
+	if len(body) == 0 {
+		return "empty"
+	}
+	keys := make([]string, 0, len(body))
+	for k := range body {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return "only" + strings.Join(keys, "+")
 }
 
 // TestIAMGroups_InlinePolicyRoundTrip drives the inline family with entityType
@@ -428,6 +552,64 @@ func TestIAMGroups_DeleteRefusesWhileSubordinatesExist(t *testing.T) {
 	resp = iamRequest(t, srv, "DeleteGroup", map[string]any{"GroupName": "devs"})
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
+}
+
+// TestIAMGroups_OperationsAreAuthorized covers the gate on every new operation. A
+// group is where permissions come from, so an operation that mutates one must be
+// refused to a caller who was not granted it — an unauthorized AddUserToGroup would
+// be a privilege escalation, not just a fidelity gap.
+//
+// The caller here is a real IAM user holding a policy that grants something else, so
+// every group action lands on the implicit-deny arm.
+func TestIAMGroups_OperationsAreAuthorized(t *testing.T) {
+	t.Parallel()
+	srv := newTrustPolicyTestServer(t)
+	accessKey := trustSetupCallerWithoutAssume(t, srv, "ungranted")
+
+	// Setup runs unenforced through the AKIA header, so the entities exist before the
+	// gate is exercised.
+	iamCreateGroupAndUser(t, srv, "devs", "jill")
+
+	operations := []struct {
+		operation string
+		body      map[string]any
+	}{
+		{"AddUserToGroup", map[string]any{"GroupName": "devs", "UserName": "jill"}},
+		{"RemoveUserFromGroup", map[string]any{"GroupName": "devs", "UserName": "jill"}},
+		{"ListGroupsForUser", map[string]any{"UserName": "jill"}},
+		{"AttachGroupPolicy", map[string]any{
+			"GroupName": "devs", "PolicyArn": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+		}},
+		{"DetachGroupPolicy", map[string]any{
+			"GroupName": "devs", "PolicyArn": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+		}},
+		{"ListAttachedGroupPolicies", map[string]any{"GroupName": "devs"}},
+	}
+	for _, op := range operations {
+		t.Run(op.operation, func(t *testing.T) {
+			resp := iamCallAs(t, srv, accessKey, op.operation, op.body)
+			assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, "AccessDenied", result["__type"])
+		})
+	}
+}
+
+// iamCallAs issues an IAM request signed with accessKeyID, so the gate resolves a
+// real principal rather than the unenforced fallback trustIAMCall relies on.
+func iamCallAs(t *testing.T, srv *emulator.Server, accessKeyID, operation string, body any) *http.Response {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	r.Host = "iam.amazonaws.com"
+	r.Header.Set("X-Amz-Target", "AmazonIdentityManagementService."+operation)
+	r.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	r.Header.Set("Authorization", trustAuthHeader(accessKeyID, "iam"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+	return w.Result()
 }
 
 // TestIAMGroupsWire_MembershipOverTheQueryProtocol drives the new operations the

--- a/emulator/iam_groups_test.go
+++ b/emulator/iam_groups_test.go
@@ -1,0 +1,468 @@
+package emulator_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// Group membership and group policies. The point of the whole set is that a group
+// now has an observable effect: before this, CreateGroup/GetGroup/DeleteGroup/
+// ListGroups were routed and nothing else, so GetGroup reported every group as
+// empty and no policy could be put on a group at all.
+//
+// The authorization half — a group's policy applying to its members' requests —
+// lives in authz_groups_test.go, because that is a CheckAccess behavior rather
+// than an API-shape one.
+
+// iamCreateGroupAndUser creates a group and a user, failing the test if either
+// setup call does not succeed.
+func iamCreateGroupAndUser(t *testing.T, srv *emulator.Server, groupName, userName string) {
+	t.Helper()
+	resp := iamRequest(t, srv, "CreateGroup", map[string]any{"GroupName": groupName})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	resp = iamRequest(t, srv, "CreateUser", map[string]any{"UserName": userName})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+// iamGroupMemberNames returns the user names a GetGroup response lists.
+func iamGroupMemberNames(t *testing.T, srv *emulator.Server, groupName string) []string {
+	t.Helper()
+	resp := iamRequest(t, srv, "GetGroup", map[string]any{"GroupName": groupName})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	raw, ok := result["Users"].([]any)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		user, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := user["UserName"].(string)
+		names = append(names, name)
+	}
+	return names
+}
+
+// iamGroupNamesForUser returns the group names a ListGroupsForUser response lists.
+func iamGroupNamesForUser(t *testing.T, srv *emulator.Server, userName string) []string {
+	t.Helper()
+	resp := iamRequest(t, srv, "ListGroupsForUser", map[string]any{"UserName": userName})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	raw, ok := result["Groups"].([]any)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		group, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := group["GroupName"].(string)
+		names = append(names, name)
+	}
+	return names
+}
+
+// TestIAMGroups_MembershipIsVisibleFromBothSides is the reason membership is
+// stored twice. Two APIs read it in opposite directions, so a single-sided write
+// would leave one of them reporting a membership the other denies.
+func TestIAMGroups_MembershipIsVisibleFromBothSides(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	iamCreateGroupAndUser(t, srv, "devs", "jill")
+
+	// GetGroup passed iamUserListXML(nil) unconditionally, so this was [] no matter
+	// what state held.
+	assert.Empty(t, iamGroupMemberNames(t, srv, "devs"), "a new group has no members")
+	assert.Empty(t, iamGroupNamesForUser(t, srv, "jill"), "a new user belongs to no group")
+
+	resp := iamRequest(t, srv, "AddUserToGroup", map[string]any{"GroupName": "devs", "UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, []string{"jill"}, iamGroupMemberNames(t, srv, "devs"))
+	assert.Equal(t, []string{"devs"}, iamGroupNamesForUser(t, srv, "jill"))
+
+	resp = iamRequest(t, srv, "RemoveUserFromGroup", map[string]any{"GroupName": "devs", "UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	assert.Empty(t, iamGroupMemberNames(t, srv, "devs"), "GetGroup still lists a removed member")
+	assert.Empty(t, iamGroupNamesForUser(t, srv, "jill"), "ListGroupsForUser still lists a left group")
+}
+
+// TestIAMGroups_MembershipWritesAreIdempotent covers both directions: AWS declares
+// NoSuchEntity for the group and the user but nothing for the membership itself, so
+// neither a repeated add nor a remove of a non-member is an error.
+func TestIAMGroups_MembershipWritesAreIdempotent(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	iamCreateGroupAndUser(t, srv, "devs", "jill")
+
+	for range 2 {
+		resp := iamRequest(t, srv, "AddUserToGroup", map[string]any{"GroupName": "devs", "UserName": "jill"})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	}
+	assert.Equal(t, []string{"jill"}, iamGroupMemberNames(t, srv, "devs"),
+		"adding a member twice must not duplicate it")
+
+	// Never a member.
+	resp := iamRequest(t, srv, "CreateUser", map[string]any{"UserName": "outsider"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	resp = iamRequest(t, srv, "RemoveUserFromGroup", map[string]any{"GroupName": "devs", "UserName": "outsider"})
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "removing a non-member is not an error")
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, []string{"jill"}, iamGroupMemberNames(t, srv, "devs"))
+}
+
+// TestIAMGroups_MembersAreSortedAndPaginated pins the member order and the Marker
+// cursor, so a caller paging a large group sees each member exactly once.
+func TestIAMGroups_MembersAreSortedAndPaginated(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	resp := iamRequest(t, srv, "CreateGroup", map[string]any{"GroupName": "devs"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Added out of order, so the sort is doing the work rather than the insertion.
+	for _, name := range []string{"carol", "alice", "bob"} {
+		resp = iamRequest(t, srv, "CreateUser", map[string]any{"UserName": name})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+		resp = iamRequest(t, srv, "AddUserToGroup", map[string]any{"GroupName": "devs", "UserName": name})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+	}
+	assert.Equal(t, []string{"alice", "bob", "carol"}, iamGroupMemberNames(t, srv, "devs"))
+
+	resp = iamRequest(t, srv, "GetGroup", map[string]any{"GroupName": "devs", "MaxItems": 2})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var page map[string]any
+	decodeIAMXML(t, resp, &page)
+	require.Len(t, page["Users"], 2)
+	assert.Equal(t, true, page["IsTruncated"])
+	marker, ok := page["Marker"].(string)
+	require.True(t, ok, "a truncated page must carry a Marker")
+
+	resp = iamRequest(t, srv, "GetGroup", map[string]any{"GroupName": "devs", "Marker": marker})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	decodeIAMXML(t, resp, &page)
+	require.Len(t, page["Users"], 1, "the second page holds the remaining member")
+	assert.Equal(t, false, page["IsTruncated"])
+}
+
+// TestIAMGroups_MembershipRefusesUnknownEntities covers the two NoSuchEntity arms
+// the model declares for both membership operations.
+func TestIAMGroups_MembershipRefusesUnknownEntities(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	iamCreateGroupAndUser(t, srv, "devs", "jill")
+
+	tests := []struct {
+		name      string
+		operation string
+		body      map[string]any
+		wantCode  string
+		wantHTTP  int
+	}{
+		{
+			name: "add to unknown group", operation: "AddUserToGroup",
+			body:     map[string]any{"GroupName": "ghosts", "UserName": "jill"},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name: "add unknown user", operation: "AddUserToGroup",
+			body:     map[string]any{"GroupName": "devs", "UserName": "ghost"},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name: "remove from unknown group", operation: "RemoveUserFromGroup",
+			body:     map[string]any{"GroupName": "ghosts", "UserName": "jill"},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name: "remove unknown user", operation: "RemoveUserFromGroup",
+			body:     map[string]any{"GroupName": "devs", "UserName": "ghost"},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name: "list groups for unknown user", operation: "ListGroupsForUser",
+			body:     map[string]any{"UserName": "ghost"},
+			wantCode: "NoSuchEntity", wantHTTP: http.StatusNotFound,
+		},
+		{
+			name: "add with no user name", operation: "AddUserToGroup",
+			body:     map[string]any{"GroupName": "devs"},
+			wantCode: "ValidationError", wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name: "add with no group name", operation: "AddUserToGroup",
+			body:     map[string]any{"UserName": "jill"},
+			wantCode: "ValidationError", wantHTTP: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := iamRequest(t, srv, tt.operation, tt.body)
+			assert.Equal(t, tt.wantHTTP, resp.StatusCode)
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, tt.wantCode, result["__type"])
+		})
+	}
+}
+
+// TestIAMGroups_ManagedPolicyAttachment mirrors the user and role attach handlers:
+// attach, list, detach, and the NoSuchEntity a detach of an unattached policy gets.
+func TestIAMGroups_ManagedPolicyAttachment(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	resp := iamRequest(t, srv, "CreateGroup", map[string]any{"GroupName": "devs"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	const policyARN = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+
+	resp = iamRequest(t, srv, "AttachGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyArn": policyARN,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Attaching twice must not duplicate the entry.
+	resp = iamRequest(t, srv, "AttachGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyArn": policyARN,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "ListAttachedGroupPolicies", map[string]any{"GroupName": "devs"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	attached, ok := result["AttachedPolicies"].([]any)
+	require.True(t, ok)
+	require.Len(t, attached, 1)
+	entry, ok := attached[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AmazonS3ReadOnlyAccess", entry["PolicyName"])
+	assert.Equal(t, policyARN, entry["PolicyArn"])
+
+	resp = iamRequest(t, srv, "DetachGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyArn": policyARN,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "ListAttachedGroupPolicies", map[string]any{"GroupName": "devs"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	decodeIAMXML(t, resp, &result)
+	assert.Empty(t, result["AttachedPolicies"])
+
+	// Detaching what is not attached is NoSuchEntity, as for a user.
+	resp = iamRequest(t, srv, "DetachGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyArn": policyARN,
+	})
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, "NoSuchEntity", result["__type"])
+
+	// An unknown group is NoSuchEntity, matching AttachUserPolicy.
+	resp = iamRequest(t, srv, "AttachGroupPolicy", map[string]any{
+		"GroupName": "ghosts", "PolicyArn": policyARN,
+	})
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, "NoSuchEntity", result["__type"])
+}
+
+// TestIAMGroups_InlinePolicyRoundTrip drives the inline family with entityType
+// "group". The four handlers previously branched on "role" with a default arm
+// treating everything else as a user, so a group policy would have been stored and
+// reported under the wrong entity name element and operation name.
+func TestIAMGroups_InlinePolicyRoundTrip(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	resp := iamRequest(t, srv, "CreateGroup", map[string]any{"GroupName": "devs"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	const doc = `{"Version":"2012-10-17","Statement":[{"Sid":"ReadBuckets","Effect":"Allow",` +
+		`"Action":"s3:ListAllMyBuckets","Resource":"*"}]}`
+
+	resp = iamRequest(t, srv, "PutGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyName": "readbuckets", "PolicyDocument": doc,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "GetGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyName": "readbuckets",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	// GroupName, not UserName: the entity-name element follows the entity type.
+	assert.Equal(t, "devs", result["GroupName"])
+	assert.Equal(t, "readbuckets", result["PolicyName"])
+	assert.Contains(t, result["PolicyDocument"], "ListAllMyBuckets")
+
+	resp = iamRequest(t, srv, "ListGroupPolicies", map[string]any{"GroupName": "devs"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, []any{"readbuckets"}, result["PolicyNames"])
+
+	resp = iamRequest(t, srv, "DeleteGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyName": "readbuckets",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "GetGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyName": "readbuckets",
+	})
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, "NoSuchEntity", result["__type"])
+}
+
+// TestIAMGroups_PutGroupPolicyRefusesUnknownGroup proves the existence check reads
+// group state rather than role state — the default arm it replaced looked every
+// non-user type up under "role:", so a group named like an existing role would have
+// been accepted.
+func TestIAMGroups_PutGroupPolicyRefusesUnknownGroup(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	trustDoc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+	resp := iamRequest(t, srv, "CreateRole", map[string]any{
+		"RoleName": "devs", "AssumeRolePolicyDocument": trustDoc,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A role called "devs" exists; a group called "devs" does not.
+	resp = iamRequest(t, srv, "PutGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyName": "p",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[]}`,
+	})
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, "NoSuchEntity", result["__type"])
+}
+
+// TestIAMGroups_DeleteRefusesWhileSubordinatesExist covers the DeleteGroup
+// reference's requirement — "The group must not contain any users or have any
+// attached policies" — and the DeleteUser one, "remove … Group memberships".
+//
+// Both matter for the same reason: a delete that skipped the check would leave one
+// side of the membership index naming an entity that no longer exists, and that
+// dangling membership is read by loadPoliciesForPrincipal on every request.
+func TestIAMGroups_DeleteRefusesWhileSubordinatesExist(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	iamCreateGroupAndUser(t, srv, "devs", "jill")
+	resp := iamRequest(t, srv, "AddUserToGroup", map[string]any{"GroupName": "devs", "UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	var result map[string]any
+
+	resp = iamRequest(t, srv, "DeleteGroup", map[string]any{"GroupName": "devs"})
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, "DeleteConflict", result["__type"])
+	assert.Contains(t, result["message"], "jill", "the message names who to remove")
+
+	resp = iamRequest(t, srv, "DeleteUser", map[string]any{"UserName": "jill"})
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, "DeleteConflict", result["__type"])
+	assert.Contains(t, result["message"], "devs", "the message names which group holds the user")
+
+	// Removing the membership clears both refusals.
+	resp = iamRequest(t, srv, "RemoveUserFromGroup", map[string]any{"GroupName": "devs", "UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "DeleteUser", map[string]any{"UserName": "jill"})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// An attached policy is the other subordinate DeleteGroup refuses on.
+	resp = iamRequest(t, srv, "AttachGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyArn": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "DeleteGroup", map[string]any{"GroupName": "devs"})
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, "DeleteConflict", result["__type"])
+
+	resp = iamRequest(t, srv, "DetachGroupPolicy", map[string]any{
+		"GroupName": "devs", "PolicyArn": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "DeleteGroup", map[string]any{"GroupName": "devs"})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+// TestIAMGroupsWire_MembershipOverTheQueryProtocol drives the new operations the
+// way a client does, so an operation that is implemented but unroutable — #636 —
+// or a parameter that never reaches the handler — #639 — is caught by this package
+// rather than only by the e2e module.
+func TestIAMGroupsWire_MembershipOverTheQueryProtocol(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	for _, op := range []struct {
+		operation string
+		params    map[string]string
+	}{
+		{"CreateGroup", map[string]string{"GroupName": "devs"}},
+		{"CreateUser", map[string]string{"UserName": "jill"}},
+		{"AddUserToGroup", map[string]string{"GroupName": "devs", "UserName": "jill"}},
+	} {
+		resp := iamFormRequest(t, srv, op.operation, op.params)
+		require.Equal(t, http.StatusOK, resp.StatusCode, op.operation)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	resp := iamFormRequest(t, srv, "GetGroup", map[string]string{"GroupName": "devs"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	users, ok := result["Users"].([]any)
+	require.True(t, ok, "GetGroup must report a Users list")
+	require.Len(t, users, 1)
+
+	resp = iamFormRequest(t, srv, "ListGroupsForUser", map[string]string{"UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	decodeIAMXML(t, resp, &result)
+	groups, ok := result["Groups"].([]any)
+	require.True(t, ok, "ListGroupsForUser must report a Groups list")
+	require.Len(t, groups, 1)
+}

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -81,6 +81,28 @@ func (p *IAMPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.deleteGroup(ctx, req)
 	case "ListGroups":
 		return p.listGroups(ctx, req)
+	case "AddUserToGroup":
+		return p.addUserToGroup(ctx, req)
+	case "RemoveUserFromGroup":
+		return p.removeUserFromGroup(ctx, req)
+	case "ListGroupsForUser":
+		return p.listGroupsForUser(ctx, req)
+
+	case "AttachGroupPolicy":
+		return p.attachGroupPolicy(ctx, req)
+	case "DetachGroupPolicy":
+		return p.detachGroupPolicy(ctx, req)
+	case "ListAttachedGroupPolicies":
+		return p.listAttachedGroupPolicies(ctx, req)
+
+	case "PutGroupPolicy":
+		return p.putGroupPolicy(ctx, req)
+	case "GetGroupPolicy":
+		return p.getGroupPolicy(ctx, req)
+	case "DeleteGroupPolicy":
+		return p.deleteGroupPolicy(ctx, req)
+	case "ListGroupPolicies":
+		return p.listGroupPolicies(ctx, req)
 
 	case "AttachUserPolicy":
 		return p.attachUserPolicy(ctx, req)
@@ -305,6 +327,23 @@ func (p *IAMPlugin) deleteUser(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	if len(arns) > 0 {
 		return iamErrorResponse("DeleteConflict",
 			"Cannot delete entity, must detach all policies first.",
+			http.StatusConflict), nil
+	}
+
+	// "Before attempting to delete a user, remove the following items: … Group
+	// memberships (RemoveUserFromGroup)" — the DeleteUser reference. Deleting a
+	// member would otherwise leave the group's side of the index naming a user that
+	// no longer exists, and GetGroup would silently skip it.
+	groups, err := p.loadStringList(goCtx, iamUserGroupsKey(params.UserName))
+	if err != nil {
+		return nil, err
+	}
+	if len(groups) > 0 {
+		// Name them, for the same reason DeleteRole names the instance profiles: a
+		// caller that wedges here needs to know what to detach from.
+		return iamErrorResponse("DeleteConflict",
+			fmt.Sprintf("Cannot delete entity, must remove user from all groups first. "+
+				"Groups containing %s: %s", params.UserName, strings.Join(groups, ", ")),
 			http.StatusConflict), nil
 	}
 
@@ -725,7 +764,36 @@ func (p *IAMPlugin) getGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse
 		return nil, fmt.Errorf("unmarshal group: %w", err)
 	}
 
-	return iamXMLResponse(http.StatusOK, "GetGroup", iamSingleGroupXML(&group)+iamUserListXML(nil)+"<IsTruncated>false</IsTruncated>")
+	// GetGroup's whole purpose is the member list — "Returns a list of IAM users
+	// that are in the specified IAM group" — and this passed iamUserListXML(nil)
+	// unconditionally, so every group was observably empty. Nothing noticed because
+	// no operation could add a member until now.
+	memberNames, err := p.loadStringList(goCtx, iamGroupUsersKey(params.GroupName))
+	if err != nil {
+		return nil, err
+	}
+	page, nextMarker, isTruncated := paginateIAMKeys(memberNames, params.Marker, params.MaxItems)
+
+	users := make([]*IAMUser, 0, len(page))
+	for _, name := range page {
+		user, err := p.loadUser(goCtx, name)
+		if err != nil {
+			return nil, err
+		}
+		// A member naming no stored user can only come from a state edit outside the
+		// API: DeleteUser refuses while the user is in a group.
+		if user == nil {
+			continue
+		}
+		users = append(users, user)
+	}
+
+	xmlStr := iamSingleGroupXML(&group) + iamUserListXML(users) +
+		"<IsTruncated>" + iamBoolXML(isTruncated) + "</IsTruncated>"
+	if nextMarker != "" {
+		xmlStr += "<Marker>" + xmlEsc(nextMarker) + "</Marker>"
+	}
+	return iamXMLResponse(http.StatusOK, "GetGroup", xmlStr)
 }
 
 func (p *IAMPlugin) deleteGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -753,6 +821,31 @@ func (p *IAMPlugin) deleteGroup(ctx *RequestContext, req *AWSRequest) (*AWSRespo
 		return iamErrorResponse("NoSuchEntity",
 			fmt.Sprintf("The group with name %s cannot be found.", params.GroupName),
 			http.StatusNotFound), nil
+	}
+
+	// "The group must not contain any users or have any attached policies" — the
+	// DeleteGroup reference. Both refusals are DeleteConflict, matching DeleteUser
+	// and DeleteRole. Without them a delete would leave a user_groups entry naming a
+	// group that no longer exists, and that membership would still be read by
+	// loadPoliciesForPrincipal.
+	members, err := p.loadStringList(goCtx, iamGroupUsersKey(params.GroupName))
+	if err != nil {
+		return nil, err
+	}
+	if len(members) > 0 {
+		return iamErrorResponse("DeleteConflict",
+			fmt.Sprintf("Cannot delete entity, must remove users from group first. "+
+				"Users in %s: %s", params.GroupName, strings.Join(members, ", ")),
+			http.StatusConflict), nil
+	}
+	arns, err := p.loadPolicyList(goCtx, iamGroupPoliciesKey(params.GroupName))
+	if err != nil {
+		return nil, err
+	}
+	if len(arns) > 0 {
+		return iamErrorResponse("DeleteConflict",
+			"Cannot delete entity, must detach all policies first.",
+			http.StatusConflict), nil
 	}
 
 	if err := p.state.Delete(goCtx, iamNamespace, "group:"+params.GroupName); err != nil {
@@ -1454,18 +1547,36 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 	}
 	entityType, entityName := entity.Kind, entity.Name
 
-	arns, err := p.loadPolicyList(goCtx, entityType+"_policies:"+entityName)
-	if err != nil {
-		return fmt.Errorf("load policies for authorization: %w", err)
+	// A user's groups carry policies too, and this gate loads its own documents
+	// rather than calling AuthController — so the group arm has to exist on both
+	// paths or an IAM call granted through a group would be refused here and allowed
+	// there. That is the #411 split exactly: one ARN, two loaders, two answers.
+	sources := []iamEntity{entity}
+	if entityType == "user" {
+		groups, err := p.loadStringList(goCtx, iamUserGroupsKey(entityName))
+		if err != nil {
+			return fmt.Errorf("load group memberships for authorization: %w", err)
+		}
+		for _, name := range groups {
+			sources = append(sources, iamEntity{Kind: "group", Name: name})
+		}
 	}
 
 	// Check for AdministratorAccess: substitute a synthetic allow-all document
 	// so that permission boundary evaluation still runs below.
+	arnsBySource := make([][]string, 0, len(sources))
 	hasAdminAccess := false
-	for _, arn := range arns {
-		if arn == "arn:aws:iam::aws:policy/AdministratorAccess" {
-			hasAdminAccess = true
-			break
+	for _, source := range sources {
+		arns, err := p.loadPolicyList(goCtx, source.Kind+"_policies:"+source.Name)
+		if err != nil {
+			return fmt.Errorf("load policies for authorization: %w", err)
+		}
+		arnsBySource = append(arnsBySource, arns)
+		for _, arn := range arns {
+			if arn == authzAdministratorAccessARN {
+				hasAdminAccess = true
+				break
+			}
 		}
 	}
 
@@ -1480,28 +1591,30 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 			}},
 		}}
 	}
-	for _, arn := range arns {
-		if mp, ok := GetManagedPolicy(arn); ok {
-			docs = append(docs, mp.Document)
-			continue
+	for i, source := range sources {
+		for _, arn := range arnsBySource[i] {
+			if mp, ok := GetManagedPolicy(arn); ok {
+				docs = append(docs, mp.Document)
+				continue
+			}
+			raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+			if err != nil || raw == nil {
+				continue
+			}
+			var pol IAMPolicy
+			if err := json.Unmarshal(raw, &pol); err != nil {
+				continue
+			}
+			docs = append(docs, pol.Document)
 		}
-		raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
-		if err != nil || raw == nil {
-			continue
-		}
-		var pol IAMPolicy
-		if err := json.Unmarshal(raw, &pol); err != nil {
-			continue
-		}
-		docs = append(docs, pol.Document)
-	}
 
-	// Also load inline policies for the entity.
-	inlineNames, _ := p.loadInlinePolicyNames(goCtx, entityType, entityName)
-	for _, name := range inlineNames {
-		doc, _ := p.loadInlinePolicyDoc(goCtx, entityType, entityName, name)
-		if doc != nil {
-			docs = append(docs, *doc)
+		// Also load inline policies for the entity.
+		inlineNames, _ := p.loadInlinePolicyNames(goCtx, source.Kind, source.Name)
+		for _, name := range inlineNames {
+			doc, _ := p.loadInlinePolicyDoc(goCtx, source.Kind, source.Name, name)
+			if doc != nil {
+				docs = append(docs, *doc)
+			}
 		}
 	}
 
@@ -1586,11 +1699,34 @@ func (p *IAMPlugin) listRolePolicies(ctx *RequestContext, req *AWSRequest) (*AWS
 	return p.listInlinePolicies(ctx, req, "role")
 }
 
-// putInlinePolicy stores an inline policy document for a user or role.
+// iamInlineEntity selects which of an inline-policy request's mutually exclusive
+// name parameters applies, and returns the operation-name suffix for the entity
+// type: Put*Policy, Get*Policy, Delete*Policy and List*Policies all differ only in
+// that word, as does the entity-name element in a Get response.
+//
+// The four inline handlers previously each carried a two-arm branch defaulting to
+// role, so an unrecognized entity type read a role's state and reported a role's
+// operation name. One helper means a type is either known here or produces an
+// empty name, which every caller already refuses with ValidationError.
+func iamInlineEntity(entityType, userName, roleName, groupName string) (entityName, actionSuffix string) {
+	switch entityType {
+	case "role":
+		return roleName, "Role"
+	case "group":
+		return groupName, "Group"
+	case "user":
+		return userName, "User"
+	default:
+		return "", ""
+	}
+}
+
+// putInlinePolicy stores an inline policy document for a user, role or group.
 func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entityType string) (*AWSResponse, error) {
 	var params struct {
 		UserName       string `json:"UserName"`
 		RoleName       string `json:"RoleName"`
+		GroupName      string `json:"GroupName"`
 		PolicyName     string `json:"PolicyName"`
 		PolicyDocument string `json:"PolicyDocument"`
 	}
@@ -1598,12 +1734,7 @@ func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
 	}
 
-	entityName := params.UserName
-	actionSuffix := "User"
-	if entityType == "role" {
-		entityName = params.RoleName
-		actionSuffix = "Role"
-	}
+	entityName, actionSuffix := iamInlineEntity(entityType, params.UserName, params.RoleName, params.GroupName)
 	if entityName == "" || params.PolicyName == "" || params.PolicyDocument == "" {
 		return iamErrorResponse("ValidationError",
 			"EntityName, PolicyName, and PolicyDocument are required", http.StatusBadRequest), nil
@@ -1614,15 +1745,10 @@ func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
 	}
 
-	// Verify the entity exists.
-	var entityRaw []byte
-	var getErr error
-	switch entityType {
-	case "user":
-		entityRaw, getErr = p.state.Get(goCtx, iamNamespace, "user:"+entityName)
-	default:
-		entityRaw, getErr = p.state.Get(goCtx, iamNamespace, "role:"+entityName)
-	}
+	// Verify the entity exists. The key prefix is the entity type itself, so a new
+	// type needs no arm here — the previous form branched on "user" with a default
+	// arm reading "role:", which would have silently looked a group up as a role.
+	entityRaw, getErr := p.state.Get(goCtx, iamNamespace, entityType+":"+entityName)
 	if getErr != nil {
 		return nil, fmt.Errorf("get %s: %w", entityType, getErr)
 	}
@@ -1672,23 +1798,19 @@ func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 	return iamXMLEmptyResponse("Put" + actionSuffix + "Policy"), nil
 }
 
-// getInlinePolicy retrieves an inline policy document for a user or role.
+// getInlinePolicy retrieves an inline policy document for a user, role or group.
 func (p *IAMPlugin) getInlinePolicy(ctx *RequestContext, req *AWSRequest, entityType string) (*AWSResponse, error) {
 	var params struct {
 		UserName   string `json:"UserName"`
 		RoleName   string `json:"RoleName"`
+		GroupName  string `json:"GroupName"`
 		PolicyName string `json:"PolicyName"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
 	}
 
-	entityName := params.UserName
-	actionSuffix := "User"
-	if entityType == "role" {
-		entityName = params.RoleName
-		actionSuffix = "Role"
-	}
+	entityName, actionSuffix := iamInlineEntity(entityType, params.UserName, params.RoleName, params.GroupName)
 	if entityName == "" || params.PolicyName == "" {
 		return iamErrorResponse("ValidationError",
 			"EntityName and PolicyName are required", http.StatusBadRequest), nil
@@ -1709,30 +1831,27 @@ func (p *IAMPlugin) getInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 			http.StatusNotFound), nil
 	}
 
-	entityKey := entityName
-	if entityType == "role" {
-		return iamXMLResponse(http.StatusOK, "GetRolePolicy", "<RoleName>"+xmlEsc(entityKey)+"</RoleName><PolicyName>"+xmlEsc(params.PolicyName)+"</PolicyName><PolicyDocument>"+xmlEsc(string(raw))+"</PolicyDocument>")
-	}
-	return iamXMLResponse(http.StatusOK, "GetUserPolicy", "<UserName>"+xmlEsc(entityKey)+"</UserName><PolicyName>"+xmlEsc(params.PolicyName)+"</PolicyName><PolicyDocument>"+xmlEsc(string(raw))+"</PolicyDocument>")
+	// The entity-name element is named for the entity type, and the operation name is
+	// the same suffix, so both come from one place rather than a branch per type.
+	return iamXMLResponse(http.StatusOK, "Get"+actionSuffix+"Policy",
+		"<"+actionSuffix+"Name>"+xmlEsc(entityName)+"</"+actionSuffix+"Name>"+
+			"<PolicyName>"+xmlEsc(params.PolicyName)+"</PolicyName>"+
+			"<PolicyDocument>"+xmlEsc(string(raw))+"</PolicyDocument>")
 }
 
-// deleteInlinePolicy removes an inline policy from a user or role.
+// deleteInlinePolicy removes an inline policy from a user, role or group.
 func (p *IAMPlugin) deleteInlinePolicy(ctx *RequestContext, req *AWSRequest, entityType string) (*AWSResponse, error) {
 	var params struct {
 		UserName   string `json:"UserName"`
 		RoleName   string `json:"RoleName"`
+		GroupName  string `json:"GroupName"`
 		PolicyName string `json:"PolicyName"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
 	}
 
-	entityName := params.UserName
-	actionSuffix := "User"
-	if entityType == "role" {
-		entityName = params.RoleName
-		actionSuffix = "Role"
-	}
+	entityName, actionSuffix := iamInlineEntity(entityType, params.UserName, params.RoleName, params.GroupName)
 	if entityName == "" || params.PolicyName == "" {
 		return iamErrorResponse("ValidationError",
 			"EntityName and PolicyName are required", http.StatusBadRequest), nil
@@ -1776,24 +1895,21 @@ func (p *IAMPlugin) deleteInlinePolicy(ctx *RequestContext, req *AWSRequest, ent
 	return iamXMLEmptyResponse("Delete" + actionSuffix + "Policy"), nil
 }
 
-// listInlinePolicies returns the names of all inline policies for a user or role.
+// listInlinePolicies returns the names of all inline policies for a user, role or
+// group.
 func (p *IAMPlugin) listInlinePolicies(ctx *RequestContext, req *AWSRequest, entityType string) (*AWSResponse, error) {
 	var params struct {
-		UserName string `json:"UserName"`
-		RoleName string `json:"RoleName"`
-		Marker   string `json:"Marker"`
-		MaxItems int    `json:"MaxItems"`
+		UserName  string `json:"UserName"`
+		RoleName  string `json:"RoleName"`
+		GroupName string `json:"GroupName"`
+		Marker    string `json:"Marker"`
+		MaxItems  int    `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
 	}
 
-	entityName := params.UserName
-	actionSuffix := "User"
-	if entityType == "role" {
-		entityName = params.RoleName
-		actionSuffix = "Role"
-	}
+	entityName, actionSuffix := iamInlineEntity(entityType, params.UserName, params.RoleName, params.GroupName)
 	if entityName == "" {
 		return iamErrorResponse("ValidationError", "EntityName is required", http.StatusBadRequest), nil
 	}

--- a/test/e2e/journey_iam_groups_test.go
+++ b/test/e2e/journey_iam_groups_test.go
@@ -1,0 +1,169 @@
+package e2e_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_IAMGroupMembership drives the group operations through the real SDK.
+//
+// This level catches what the unit suite structurally cannot: an operation that is
+// implemented but not routed answers InvalidAction, and a unit test that calls the
+// handler directly never finds out. That was #636, and every one of these
+// operations is new routing.
+func TestJourney_IAMGroupMembership(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	// Retries off, so every assertion is about the first response.
+	client := iam.NewFromConfig(cfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	const groupName, userName = "devs", "jill"
+
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{
+		GroupName: aws.String(groupName),
+	}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{
+		UserName: aws.String(userName),
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.AddUserToGroup(ctx, &iam.AddUserToGroupInput{
+		GroupName: aws.String(groupName),
+		UserName:  aws.String(userName),
+	}); err != nil {
+		t.Fatalf("AddUserToGroup: %v", err)
+	}
+
+	// GetGroup's member list was hardcoded empty before this release, so this is the
+	// assertion that would have failed on the shipped code even with membership
+	// stored correctly.
+	group, err := client.GetGroup(ctx, &iam.GetGroupInput{GroupName: aws.String(groupName)})
+	if err != nil {
+		t.Fatalf("GetGroup: %v", err)
+	}
+	if len(group.Users) != 1 || aws.ToString(group.Users[0].UserName) != userName {
+		t.Fatalf("GetGroup listed %d users, want exactly %s", len(group.Users), userName)
+	}
+	if aws.ToString(group.Group.GroupName) != groupName {
+		t.Errorf("GetGroup returned group %q, want %q", aws.ToString(group.Group.GroupName), groupName)
+	}
+
+	// The other direction of the same membership. Both are read by an API, so a
+	// single-sided write would satisfy one of these two calls and not the other.
+	forUser, err := client.ListGroupsForUser(ctx, &iam.ListGroupsForUserInput{
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		t.Fatalf("ListGroupsForUser: %v", err)
+	}
+	if len(forUser.Groups) != 1 || aws.ToString(forUser.Groups[0].GroupName) != groupName {
+		t.Fatalf("ListGroupsForUser returned %d groups, want exactly %s", len(forUser.Groups), groupName)
+	}
+
+	// Group policies: a managed attachment and an inline document, each read back
+	// through the operation that reports it.
+	const policyARN = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+	if _, err := client.AttachGroupPolicy(ctx, &iam.AttachGroupPolicyInput{
+		GroupName: aws.String(groupName),
+		PolicyArn: aws.String(policyARN),
+	}); err != nil {
+		t.Fatalf("AttachGroupPolicy: %v", err)
+	}
+	attached, err := client.ListAttachedGroupPolicies(ctx, &iam.ListAttachedGroupPoliciesInput{
+		GroupName: aws.String(groupName),
+	})
+	if err != nil {
+		t.Fatalf("ListAttachedGroupPolicies: %v", err)
+	}
+	if len(attached.AttachedPolicies) != 1 ||
+		aws.ToString(attached.AttachedPolicies[0].PolicyArn) != policyARN {
+		t.Fatalf("ListAttachedGroupPolicies returned %v, want %s", attached.AttachedPolicies, policyARN)
+	}
+
+	const inlineDoc = `{"Version":"2012-10-17","Statement":[{"Sid":"ListBuckets",` +
+		`"Effect":"Allow","Action":"s3:ListAllMyBuckets","Resource":"*"}]}`
+	if _, err := client.PutGroupPolicy(ctx, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String(groupName),
+		PolicyName:     aws.String("listbuckets"),
+		PolicyDocument: aws.String(inlineDoc),
+	}); err != nil {
+		t.Fatalf("PutGroupPolicy: %v", err)
+	}
+	inline, err := client.GetGroupPolicy(ctx, &iam.GetGroupPolicyInput{
+		GroupName:  aws.String(groupName),
+		PolicyName: aws.String("listbuckets"),
+	})
+	if err != nil {
+		t.Fatalf("GetGroupPolicy: %v", err)
+	}
+	// The SDK models GroupName as required on the response, so a handler emitting
+	// <UserName> — which the inline family's default arm did for every non-role type
+	// — leaves this empty.
+	if aws.ToString(inline.GroupName) != groupName {
+		t.Errorf("GetGroupPolicy reported GroupName %q, want %q", aws.ToString(inline.GroupName), groupName)
+	}
+	names, err := client.ListGroupPolicies(ctx, &iam.ListGroupPoliciesInput{
+		GroupName: aws.String(groupName),
+	})
+	if err != nil {
+		t.Fatalf("ListGroupPolicies: %v", err)
+	}
+	if len(names.PolicyNames) != 1 || names.PolicyNames[0] != "listbuckets" {
+		t.Fatalf("ListGroupPolicies returned %v, want [listbuckets]", names.PolicyNames)
+	}
+
+	// Removal clears both sides.
+	if _, err := client.RemoveUserFromGroup(ctx, &iam.RemoveUserFromGroupInput{
+		GroupName: aws.String(groupName),
+		UserName:  aws.String(userName),
+	}); err != nil {
+		t.Fatalf("RemoveUserFromGroup: %v", err)
+	}
+	group, err = client.GetGroup(ctx, &iam.GetGroupInput{GroupName: aws.String(groupName)})
+	if err != nil {
+		t.Fatalf("GetGroup after removal: %v", err)
+	}
+	if len(group.Users) != 0 {
+		t.Errorf("GetGroup still lists %d users after RemoveUserFromGroup", len(group.Users))
+	}
+	forUser, err = client.ListGroupsForUser(ctx, &iam.ListGroupsForUserInput{
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		t.Fatalf("ListGroupsForUser after removal: %v", err)
+	}
+	if len(forUser.Groups) != 0 {
+		t.Errorf("ListGroupsForUser still lists %d groups after RemoveUserFromGroup", len(forUser.Groups))
+	}
+
+	if _, err := client.DetachGroupPolicy(ctx, &iam.DetachGroupPolicyInput{
+		GroupName: aws.String(groupName),
+		PolicyArn: aws.String(policyARN),
+	}); err != nil {
+		t.Fatalf("DetachGroupPolicy: %v", err)
+	}
+	if _, err := client.DeleteGroupPolicy(ctx, &iam.DeleteGroupPolicyInput{
+		GroupName:  aws.String(groupName),
+		PolicyName: aws.String("listbuckets"),
+	}); err != nil {
+		t.Fatalf("DeleteGroupPolicy: %v", err)
+	}
+	if _, err := client.DeleteGroup(ctx, &iam.DeleteGroupInput{
+		GroupName: aws.String(groupName),
+	}); err != nil {
+		t.Fatalf("DeleteGroup after clearing members and policies: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

`SimulatePrincipalPolicy` (#579) cannot be built without this. AWS is explicit: "If you
specify a user, then the simulation also includes all of the policies that are attached to
groups that the user belongs to." Substrate had no way to attach a policy to a group, no
way to put a user in one, and no evaluation that read group state — so a user simulation
without this would be *wrong* rather than partial.

The gap was wider than #579 needed. Only `CreateGroup`, `GetGroup`, `DeleteGroup` and
`ListGroups` were routed, and `GetGroup` passed `iamUserListXML(nil)` unconditionally: a
group was observably always empty no matter what state held.

## What ships

Eleven operations, each mirroring the user/role handler that already existed:
`AddUserToGroup`, `RemoveUserFromGroup`, `ListGroupsForUser`, `AttachGroupPolicy`,
`DetachGroupPolicy`, `ListAttachedGroupPolicies`, `PutGroupPolicy`, `GetGroupPolicy`,
`DeleteGroupPolicy`, `ListGroupPolicies`. `GetGroup` reports real members, sorted and
paginated by `Marker`/`MaxItems`.

**Membership is stored on both sides** — `group_users:<group>` and `user_groups:<user>` —
because both directions are read by an API. Every write goes through one pair of functions
so the two sides cannot come to disagree; that is the v0.99.0 `saveAccount` lesson applied
before it could bite. Both writes are idempotent, matching the reference, which declares
`NoSuchEntity` for the group and the user but nothing for the membership itself.

**Group policies reuse the existing storage exactly.** Managed attachments go to
`group_policies:<name>` through the same `loadPolicyList`/`savePolicyList` pair; inline
documents go through the already entity-type-parameterized `putInlinePolicy` family.
Nothing invents a second way to store a policy — that is what lets
`loadPoliciesForPrincipal` read a group's policies with the code it already had.

**Referential integrity on both sides of the index.** `DeleteGroup` refuses with
`DeleteConflict` 409 while members or attached policies remain ("The group must not contain
any users or have any attached policies"); `DeleteUser` refuses while the user belongs to a
group, naming which one. A delete that skipped either check would leave one side of the
index naming an entity that no longer exists, and that dangling membership is read on
every request.

## The two-loader trap

`IAMPlugin.authorize` loads its own document set independently of
`AuthController.loadPoliciesForPrincipal`. Teaching only one about groups would have
recreated #411 exactly: one ARN, two loaders, two opposite answers. Both learned the arm,
and `TestGroupPolicy_BothLoadersAgree` asserts they answer the same on the same input, so
they cannot drift apart later.

## Fixed as fallout

All four inline-policy handlers branched on `entityType == "role"` with a `default:` arm
that read `role:` state for the existence check while emitting `UserName` in the response.
Any third entity type would have looked itself up under the wrong prefix and answered with
the wrong element name. One helper now maps type → (entity name, operation suffix), and an
unrecognized type yields an empty name, which every caller already refuses with
`ValidationError`. `TestIAMGroups_PutGroupPolicyRefusesUnknownGroup` pins it by creating a
*role* named `devs` and asserting a group policy on `devs` is still `NoSuchEntity`.

## Verification

- `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → 0 issues
- `make test` (race) green; `make coverage` — emulator 82.3%, total 81.6%
- `go vet -C test/e2e ./... && go test -C test/e2e ./...` green
- 16 new tests: `emulator/iam_groups_test.go` (API shapes + a query-protocol wire test),
  `emulator/authz_groups_test.go` (the authorization half), and
  `test/e2e/journey_iam_groups_test.go` driving the whole sequence through the real SDK —
  the level that catches an unroutable operation, which is what #636 was.
- Mutation testing, 6 applied / 6 caught / no survivors: the group arm removed from each
  loader in turn, a one-sided membership write, the `"group"` arm dropped from the inline
  entity helper, the `DeleteGroup` member check disabled, and `GetGroup`'s pagination
  bypassed.

## Compatibility

A group's policies now apply to its members' requests through `CheckAccess`, so a fixture
whose user belongs to a group carrying a policy starts being allowed — or denied — by it.
In practice nothing existing moves: before this release no operation could put a policy on
a group, so a fixture can only be affected if it wrote group policy state directly.

Prerequisite for #579; does not close it — the simulator itself lands next.