### PR TITLE
fix(iam): decode query-protocol scalar parameters (#642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #610 / #636 blind spot again: an operation no client can reach, with passing tests
   over it. Both new test files close it — `journey_iam_tags_test.go` at the SDK level and
   `iam_query_wire_test.go` posting a genuine urlencoded form body one layer down.
+- **`MaxItems` no longer fails every paginated IAM operation** (#642). The same root
+  cause as #639, one layer along and louder. The query protocol has no types, so
+  `MaxItems=1` reaches a handler inside a JSON body as `{"MaxItems":"1"}`, and a field
+  declared `int` made `encoding/json` refuse the whole request: any caller who passed
+  `MaxItems` at all got `400 ValidationError` — "cannot unmarshal string into Go struct
+  field .MaxItems of type int" — instead of a page. `CreateRole`'s
+  `MaxSessionDuration` failed the same way, so a role could not be created with a
+  session duration through any SDK. Where #639's lists unmarshaled to nil in silence,
+  an integer took the request down with it.
+
+  Two scalar types in `emulator/iam_query.go` accept either a JSON number or a numeric
+  JSON string, and every IAM integer field now uses one. A boolean equivalent lands with
+  them, unused for now, so `ListPolicies`' `OnlyAttached` (#497) is not built with the
+  defect already in it. An empty value is the zero value rather than an error — a client
+  that sent `MaxItems=` expressed no limit, and refusing it would fail a request AWS
+  accepts. A malformed value now names its parameter (`MaxItems must be an integer, got
+  "abc"`) rather than leaking a Go struct field.
+
+  Found by probing `ListUsers(MaxItems: 1)` through the SDK while building #579 — not by
+  any test, and this is the third defect of the class. The unit suite could not see it
+  for the reason it could not see #639: `iamRequest` hand-marshals a body holding a real
+  JSON *number*, the one shape no AWS client produces, and the IAM journeys that do go
+  through the SDK never passed `MaxItems`, because pagination was asserted at the unit
+  level where the number is real. `journey_iam_numbers_test.go` drives `MaxItems` across
+  two pages and round-trips `MaxSessionDuration` through `GetRole`; it fails against the
+  code before this fix.
 
 ## [v0.99.0] - 2026-08-14
 

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -680,3 +680,23 @@ func IAMMemberStructsForTest(params map[string]string, prefix string) []map[stri
 
 // IAMMemberTagsForTest wraps iamMemberTags for external tests.
 func IAMMemberTagsForTest(params map[string]string) []IAMTag { return iamMemberTags(params) }
+
+// IAMScalarParamsForTest is a struct holding one of each string-tolerant IAM scalar,
+// for external tests of the query-protocol scalar decoding (#642).
+type IAMScalarParamsForTest struct {
+	// Count is an integer parameter, standing in for MaxItems.
+	Count iamInt `json:"Count"`
+
+	// Flag is a boolean parameter, standing in for OnlyAttached.
+	Flag iamBool `json:"Flag"`
+}
+
+// IAMScalarValuesForTest returns the decoded scalars as plain Go values.
+func (p IAMScalarParamsForTest) IAMScalarValuesForTest() (int, bool) {
+	return p.Count.Int(), p.Flag.Bool()
+}
+
+// ParseIAMBodyForTest wraps parseIAMBody for external tests, so the whole
+// body-decoding path — including the parameter-naming error message — is testable
+// from package emulator_test.
+func ParseIAMBodyForTest(body []byte, dst any) error { return parseIAMBody(body, dst) }

--- a/emulator/iam_groups.go
+++ b/emulator/iam_groups.go
@@ -98,7 +98,7 @@ func (p *IAMPlugin) listGroupsForUser(ctx *RequestContext, req *AWSRequest) (*AW
 	var params struct {
 		UserName string `json:"UserName"`
 		Marker   string `json:"Marker"`
-		MaxItems int    `json:"MaxItems"`
+		MaxItems iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -127,7 +127,7 @@ func (p *IAMPlugin) listGroupsForUser(ctx *RequestContext, req *AWSRequest) (*AW
 		return nil, err
 	}
 
-	page, nextMarker, isTruncated := paginateIAMKeys(names, params.Marker, params.MaxItems)
+	page, nextMarker, isTruncated := paginateIAMKeys(names, params.Marker, params.MaxItems.Int())
 
 	groups := make([]*IAMGroup, 0, len(page))
 	for _, name := range page {
@@ -249,7 +249,7 @@ func (p *IAMPlugin) listAttachedGroupPolicies(ctx *RequestContext, req *AWSReque
 	var params struct {
 		GroupName string `json:"GroupName"`
 		Marker    string `json:"Marker"`
-		MaxItems  int    `json:"MaxItems"`
+		MaxItems  iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -358,7 +358,7 @@ func (p *IAMPlugin) listUsers(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	var params struct {
 		PathPrefix string `json:"PathPrefix"`
 		Marker     string `json:"Marker"`
-		MaxItems   int    `json:"MaxItems"`
+		MaxItems   iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -375,7 +375,7 @@ func (p *IAMPlugin) listUsers(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return nil, fmt.Errorf("list users: %w", err)
 	}
 
-	page, nextMarker, isTruncated := paginateIAMKeys(keys, params.Marker, params.MaxItems)
+	page, nextMarker, isTruncated := paginateIAMKeys(keys, params.Marker, params.MaxItems.Int())
 
 	users := make([]*IAMUser, 0, len(page))
 	for _, k := range page {
@@ -408,7 +408,7 @@ func (p *IAMPlugin) createRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		AssumeRolePolicyDocument string   `json:"AssumeRolePolicyDocument"`
 		Path                     string   `json:"Path"`
 		Description              string   `json:"Description"`
-		MaxSessionDuration       int      `json:"MaxSessionDuration"`
+		MaxSessionDuration       iamInt   `json:"MaxSessionDuration"`
 		Tags                     []IAMTag `json:"Tags"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
@@ -460,7 +460,7 @@ func (p *IAMPlugin) createRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		ARN:                      iamRoleARN(ctx.AccountID, params.Path, params.RoleName),
 		Path:                     params.Path,
 		Description:              params.Description,
-		MaxSessionDuration:       params.MaxSessionDuration,
+		MaxSessionDuration:       params.MaxSessionDuration.Int(),
 		CreateDate:               p.now().UTC(),
 		AssumeRolePolicyDocument: trustPolicy,
 		Tags:                     params.Tags,
@@ -636,7 +636,7 @@ func (p *IAMPlugin) listRoles(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 	var params struct {
 		PathPrefix string `json:"PathPrefix"`
 		Marker     string `json:"Marker"`
-		MaxItems   int    `json:"MaxItems"`
+		MaxItems   iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -653,7 +653,7 @@ func (p *IAMPlugin) listRoles(ctx *RequestContext, req *AWSRequest) (*AWSRespons
 		return nil, fmt.Errorf("list roles: %w", err)
 	}
 
-	page, nextMarker, isTruncated := paginateIAMKeys(keys, params.Marker, params.MaxItems)
+	page, nextMarker, isTruncated := paginateIAMKeys(keys, params.Marker, params.MaxItems.Int())
 
 	roles := make([]*IAMRole, 0, len(page))
 	for _, k := range page {
@@ -735,7 +735,7 @@ func (p *IAMPlugin) getGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse
 	var params struct {
 		GroupName string `json:"GroupName"`
 		Marker    string `json:"Marker"`
-		MaxItems  int    `json:"MaxItems"`
+		MaxItems  iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -772,7 +772,7 @@ func (p *IAMPlugin) getGroup(ctx *RequestContext, req *AWSRequest) (*AWSResponse
 	if err != nil {
 		return nil, err
 	}
-	page, nextMarker, isTruncated := paginateIAMKeys(memberNames, params.Marker, params.MaxItems)
+	page, nextMarker, isTruncated := paginateIAMKeys(memberNames, params.Marker, params.MaxItems.Int())
 
 	users := make([]*IAMUser, 0, len(page))
 	for _, name := range page {
@@ -859,7 +859,7 @@ func (p *IAMPlugin) listGroups(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 	var params struct {
 		PathPrefix string `json:"PathPrefix"`
 		Marker     string `json:"Marker"`
-		MaxItems   int    `json:"MaxItems"`
+		MaxItems   iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -876,7 +876,7 @@ func (p *IAMPlugin) listGroups(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 		return nil, fmt.Errorf("list groups: %w", err)
 	}
 
-	page, nextMarker, isTruncated := paginateIAMKeys(keys, params.Marker, params.MaxItems)
+	page, nextMarker, isTruncated := paginateIAMKeys(keys, params.Marker, params.MaxItems.Int())
 
 	groups := make([]*IAMGroup, 0, len(page))
 	for _, k := range page {
@@ -995,7 +995,7 @@ func (p *IAMPlugin) listAttachedUserPolicies(ctx *RequestContext, req *AWSReques
 	var params struct {
 		UserName string `json:"UserName"`
 		Marker   string `json:"Marker"`
-		MaxItems int    `json:"MaxItems"`
+		MaxItems iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -1121,7 +1121,7 @@ func (p *IAMPlugin) listAttachedRolePolicies(ctx *RequestContext, req *AWSReques
 	var params struct {
 		RoleName string `json:"RoleName"`
 		Marker   string `json:"Marker"`
-		MaxItems int    `json:"MaxItems"`
+		MaxItems iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -1298,7 +1298,7 @@ func (p *IAMPlugin) listPolicies(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		Scope      string `json:"Scope"`
 		PathPrefix string `json:"PathPrefix"`
 		Marker     string `json:"Marker"`
-		MaxItems   int    `json:"MaxItems"`
+		MaxItems   iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -1315,7 +1315,7 @@ func (p *IAMPlugin) listPolicies(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		return nil, fmt.Errorf("list policies: %w", err)
 	}
 
-	page, nextMarker, isTruncated := paginateIAMKeys(keys, params.Marker, params.MaxItems)
+	page, nextMarker, isTruncated := paginateIAMKeys(keys, params.Marker, params.MaxItems.Int())
 
 	policies := make([]*IAMPolicy, 0, len(page))
 	for _, k := range page {
@@ -1462,7 +1462,7 @@ func (p *IAMPlugin) listAccessKeys(ctx *RequestContext, req *AWSRequest) (*AWSRe
 	var params struct {
 		UserName string `json:"UserName"`
 		Marker   string `json:"Marker"`
-		MaxItems int    `json:"MaxItems"`
+		MaxItems iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -1903,7 +1903,7 @@ func (p *IAMPlugin) listInlinePolicies(ctx *RequestContext, req *AWSRequest, ent
 		RoleName  string `json:"RoleName"`
 		GroupName string `json:"GroupName"`
 		Marker    string `json:"Marker"`
-		MaxItems  int    `json:"MaxItems"`
+		MaxItems  iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -1924,7 +1924,7 @@ func (p *IAMPlugin) listInlinePolicies(ctx *RequestContext, req *AWSRequest, ent
 		return nil, err
 	}
 
-	page, nextMarker, isTruncated := paginateIAMKeys(names, params.Marker, params.MaxItems)
+	page, nextMarker, isTruncated := paginateIAMKeys(names, params.Marker, params.MaxItems.Int())
 
 	xmlStr := iamStringListXML("PolicyNames", page) + "<IsTruncated>" + iamBoolXML(isTruncated) + "</IsTruncated>"
 	if nextMarker != "" {
@@ -2217,7 +2217,7 @@ func (p *IAMPlugin) listUserTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	var params struct {
 		UserName string `json:"UserName"`
 		Marker   string `json:"Marker"`
-		MaxItems int    `json:"MaxItems"`
+		MaxItems iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -2247,7 +2247,7 @@ func (p *IAMPlugin) listUserTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		tags = []IAMTag{}
 	}
 
-	maxItems := params.MaxItems
+	maxItems := params.MaxItems.Int()
 	if maxItems <= 0 {
 		maxItems = 100
 	}
@@ -2396,7 +2396,7 @@ func (p *IAMPlugin) listRoleTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	var params struct {
 		RoleName string `json:"RoleName"`
 		Marker   string `json:"Marker"`
-		MaxItems int    `json:"MaxItems"`
+		MaxItems iamInt `json:"MaxItems"`
 	}
 	if err := parseIAMBody(req.Body, &params); err != nil {
 		return iamErrorResponse("ValidationError", err.Error(), http.StatusBadRequest), nil
@@ -2426,7 +2426,7 @@ func (p *IAMPlugin) listRoleTags(ctx *RequestContext, req *AWSRequest) (*AWSResp
 		tags = []IAMTag{}
 	}
 
-	maxItems := params.MaxItems
+	maxItems := params.MaxItems.Int()
 	if maxItems <= 0 {
 		maxItems = 100
 	}
@@ -2569,12 +2569,18 @@ func (p *IAMPlugin) saveStringList(goCtx context.Context, key string, list []str
 
 // parseIAMBody unmarshals an IAM JSON request body into dst.
 // An empty body is treated as an empty JSON object.
+//
+// A failure is reported through iamParamMessage, so a bad scalar names its
+// parameter — "MaxItems must be an integer, got \"abc\"". Every handler surfaces
+// this as a ValidationError, and before #642 the message a caller got for a
+// perfectly valid `MaxItems=1` was an encoding/json internal about a Go struct
+// field.
 func parseIAMBody(body []byte, dst any) error {
 	if len(body) == 0 {
 		return nil
 	}
 	if err := json.Unmarshal(body, dst); err != nil {
-		return fmt.Errorf("invalid request body: %w", err)
+		return fmt.Errorf("invalid request body: %s", iamParamMessage(err))
 	}
 	return nil
 }

--- a/emulator/iam_query.go
+++ b/emulator/iam_query.go
@@ -1,6 +1,10 @@
 package emulator
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -33,6 +37,128 @@ import (
 // iamMemberSep is the infix the query protocol puts between a list parameter's
 // name and its 1-based index.
 const iamMemberSep = ".member."
+
+// iamInt is an integer parameter that decodes from either a JSON number or a JSON
+// string.
+//
+// It exists because the query protocol has no types: every value in the JSON body
+// server.go rebuilds is a string, so `MaxItems=1` arrives as `{"MaxItems":"1"}` and
+// a field declared `int` made encoding/json refuse the whole request. Every
+// paginated IAM operation answered `400 ValidationError` to a caller who passed
+// MaxItems at all, and CreateRole rejected MaxSessionDuration (#642) — the louder
+// half of the defect #639 fixed for lists, which failed silently instead.
+//
+// Both forms are accepted rather than only the string, because iam_plugin_test.go's
+// iamRequest hand-marshals a body holding a real JSON number. That is exactly the
+// asymmetry that hid this: the unit path sends a number, every real client sends a
+// string, and only the first was ever exercised.
+type iamInt int
+
+// UnmarshalJSON decodes a JSON number or a numeric JSON string.
+//
+// An empty string is zero, matching an absent parameter: a client that sent
+// `MaxItems=` expressed no limit, and refusing it would fail a request AWS accepts.
+func (v *iamInt) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	if s == "null" {
+		return nil
+	}
+	if unquoted, ok := iamUnquote(s); ok {
+		if unquoted == "" {
+			*v = 0
+			return nil
+		}
+		s = unquoted
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return iamParamError(fmt.Sprintf("must be an integer, got %q", s))
+	}
+	*v = iamInt(n)
+	return nil
+}
+
+// Int returns the value as a plain int, for handing to a helper that takes one.
+func (v iamInt) Int() int { return int(v) }
+
+// iamBool is a boolean parameter that decodes from either a JSON bool or a JSON
+// string, for the same reason as [iamInt].
+//
+// Only "true" and "false" are accepted, case-insensitively, which is what the query
+// protocol sends. A numeric 1/0 is not: no AWS client emits it, and accepting it
+// would mean guessing at a value the caller never wrote.
+type iamBool bool
+
+// UnmarshalJSON decodes a JSON bool or a "true"/"false" JSON string. An empty
+// string is false, matching an absent parameter.
+func (v *iamBool) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	if s == "null" {
+		return nil
+	}
+	if unquoted, ok := iamUnquote(s); ok {
+		if unquoted == "" {
+			*v = false
+			return nil
+		}
+		s = strings.ToLower(unquoted)
+	}
+	switch s {
+	case "true":
+		*v = true
+	case "false":
+		*v = false
+	default:
+		return iamParamError(fmt.Sprintf("must be true or false, got %q", s))
+	}
+	return nil
+}
+
+// iamParamError wraps a scalar-decoding message in a *json.UnmarshalTypeError so
+// encoding/json fills in the field name.
+//
+// Returning a plain error would lose it: json.Unmarshal reports a custom
+// unmarshaler's error verbatim, so the caller would see "must be an integer" with
+// no clue *which* parameter was wrong. UnmarshalTypeError is the one error type the
+// decoder annotates with the path it was decoding, and it nests correctly
+// ("Tags.N") for a scalar inside a list member. [iamParamMessage] reads the result
+// back out.
+func iamParamError(message string) error {
+	return &json.UnmarshalTypeError{Value: message, Type: reflect.TypeOf(0)}
+}
+
+// iamParamMessage turns a body-decoding error into a parameter-shaped message, so a
+// caller sees "MaxItems must be an integer, got \"abc\"" rather than an
+// encoding/json internal.
+//
+// An error from any other cause is returned as-is: this is presentation for the one
+// case that has a parameter name, not a general error rewrite.
+func iamParamMessage(err error) string {
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) && typeErr.Field != "" && typeErr.Value != "" {
+		return typeErr.Field + " " + typeErr.Value
+	}
+	return err.Error()
+}
+
+// Bool returns the value as a plain bool.
+func (v iamBool) Bool() bool { return bool(v) }
+
+// iamUnquote unwraps a JSON string literal, reporting whether data was one.
+//
+// json.Unmarshal is used rather than trimming quotes so an escaped value decodes
+// correctly; a value that will not decode is reported as not-a-string and falls
+// through to the numeric parse, which produces the parameter-shaped error.
+func iamUnquote(data string) (string, bool) {
+	if len(data) < 2 || data[0] != '"' {
+		return "", false
+	}
+	var s string
+	if err := json.Unmarshal([]byte(data), &s); err != nil {
+		return "", false
+	}
+	return s, true
+}
 
 // iamMemberList decodes a flat query-protocol list: prefix.member.1,
 // prefix.member.2, and so on. It returns nil when the list is absent.

--- a/emulator/iam_query_test.go
+++ b/emulator/iam_query_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scttfrdmn/substrate/emulator"
 )
@@ -281,4 +282,131 @@ func TestIAMMemberTags(t *testing.T) {
 			assert.Equal(t, tc.want, emulator.IAMMemberTagsForTest(tc.params))
 		})
 	}
+}
+
+// TestIAMScalarParams covers the string-tolerant integer and boolean decoders
+// (#642).
+//
+// Both forms must work, and the reason is the defect: the query protocol has no
+// types, so every real client sends "1", while the unit suite's iamRequest
+// hand-marshals a real JSON number. Accepting only one of the two shapes is exactly
+// how MaxItems came to answer 400 to every SDK caller while the unit tests stayed
+// green.
+func TestIAMScalarParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		body      string
+		wantCount int
+		wantFlag  bool
+		wantErr   string
+	}{
+		{
+			name:      "the wire form: every value is a string",
+			body:      `{"Count":"25","Flag":"true"}`,
+			wantCount: 25,
+			wantFlag:  true,
+		},
+		{
+			// The shape iamRequest sends. It must keep working, or every existing unit
+			// test that passes MaxItems breaks.
+			name:      "the unit-test form: real JSON scalars",
+			body:      `{"Count":25,"Flag":true}`,
+			wantCount: 25,
+			wantFlag:  true,
+		},
+		{
+			name:      "absent members stay zero",
+			body:      `{"UserName":"jill"}`,
+			wantCount: 0,
+			wantFlag:  false,
+		},
+		{
+			// A client that sent "MaxItems=" expressed no limit. Refusing it would fail
+			// a request AWS accepts.
+			name:      "an empty string is the zero value, not an error",
+			body:      `{"Count":"","Flag":""}`,
+			wantCount: 0,
+			wantFlag:  false,
+		},
+		{
+			name:      "explicit null is the zero value",
+			body:      `{"Count":null,"Flag":null}`,
+			wantCount: 0,
+			wantFlag:  false,
+		},
+		{
+			name:      "a negative integer decodes, so a range check can refuse it",
+			body:      `{"Count":"-1"}`,
+			wantCount: -1,
+		},
+		{
+			name:     "false decodes as false, not as absent",
+			body:     `{"Flag":"false"}`,
+			wantFlag: false,
+		},
+		{
+			// The query protocol lower-cases neither, and the CLI sends "true".
+			name:     "a boolean is case-insensitive",
+			body:     `{"Flag":"True"}`,
+			wantFlag: true,
+		},
+		{
+			// The message must name the parameter. Before this, a caller saw
+			// "cannot unmarshal string into Go struct field .MaxItems of type int".
+			name:    "a non-numeric integer names its parameter",
+			body:    `{"Count":"abc"}`,
+			wantErr: `invalid request body: Count must be an integer, got "abc"`,
+		},
+		{
+			name:    "a non-boolean names its parameter",
+			body:    `{"Flag":"yes"}`,
+			wantErr: `invalid request body: Flag must be true or false, got "yes"`,
+		},
+		{
+			// 1/0 is not a boolean in any AWS client, and accepting it would mean
+			// guessing at a value the caller never wrote.
+			name:    "a numeric boolean is refused",
+			body:    `{"Flag":"1"}`,
+			wantErr: `invalid request body: Flag must be true or false, got "1"`,
+		},
+		{
+			// A malformed body has no parameter to name, so it must still report
+			// something a caller can act on rather than an empty message.
+			name:    "a malformed body still reports an error",
+			body:    `{"Count":`,
+			wantErr: "invalid request body: unexpected end of JSON input",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var params emulator.IAMScalarParamsForTest
+			err := emulator.ParseIAMBodyForTest([]byte(tc.body), &params)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+				return
+			}
+			require.NoError(t, err)
+			count, flag := params.IAMScalarValuesForTest()
+			assert.Equal(t, tc.wantCount, count)
+			assert.Equal(t, tc.wantFlag, flag)
+		})
+	}
+}
+
+// TestIAMScalarParams_EmptyBodyIsNotAnError pins parseIAMBody's contract that an
+// absent body decodes to the zero value, which is what lets an operation with only
+// optional parameters be called with nothing at all.
+func TestIAMScalarParams_EmptyBodyIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	var params emulator.IAMScalarParamsForTest
+	require.NoError(t, emulator.ParseIAMBodyForTest(nil, &params))
+	count, flag := params.IAMScalarValuesForTest()
+	assert.Zero(t, count)
+	assert.False(t, flag)
 }

--- a/test/e2e/journey_iam_numbers_test.go
+++ b/test/e2e/journey_iam_numbers_test.go
@@ -1,0 +1,109 @@
+package e2e_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_IAMNumericParameters drives IAM's integer parameters through the real
+// SDK.
+//
+// It is the regression for #642, and it fails against the code before that fix:
+// IAM speaks the query protocol, so every parameter reaches a handler as a *string*,
+// and a field declared `int` made encoding/json refuse the request. `MaxItems` on
+// any paginated operation and `MaxSessionDuration` on CreateRole both answered
+// 400 ValidationError.
+//
+// It has to live at this level for the same reason #639's did. The unit suite's
+// iamRequest hand-marshals a body holding a real JSON number, so it exercises the
+// one shape no client sends; only an SDK call travels the query → params → JSON
+// path where the value is a string. Four tag operations shipped broken through that
+// gap, and this defect shipped through it too.
+func TestJourney_IAMNumericParameters(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	// Retries off, so every assertion is about the first response.
+	client := iam.NewFromConfig(cfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	for _, name := range []string{"ann", "bob", "cyd"} {
+		if _, err := client.CreateUser(ctx, &iam.CreateUserInput{
+			UserName: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateUser %s: %v", name, err)
+		}
+	}
+
+	// MaxItems is the member that failed. Two of three users, then the rest through
+	// the marker, so the page really is a page and not a rejected request.
+	first, err := client.ListUsers(ctx, &iam.ListUsersInput{MaxItems: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("ListUsers with MaxItems: %v", err)
+	}
+	if len(first.Users) != 2 {
+		t.Fatalf("MaxItems=2 returned %d users, want 2", len(first.Users))
+	}
+	if !first.IsTruncated {
+		t.Fatal("MaxItems=2 over three users reported IsTruncated=false")
+	}
+	if aws.ToString(first.Marker) == "" {
+		t.Fatal("truncated page carried no Marker")
+	}
+
+	second, err := client.ListUsers(ctx, &iam.ListUsersInput{
+		MaxItems: aws.Int32(2),
+		Marker:   first.Marker,
+	})
+	if err != nil {
+		t.Fatalf("ListUsers second page: %v", err)
+	}
+	if len(second.Users) != 1 {
+		t.Fatalf("second page returned %d users, want 1", len(second.Users))
+	}
+	if second.IsTruncated {
+		t.Fatal("final page reported IsTruncated=true")
+	}
+
+	// The two pages must be disjoint and cover everything — a Marker that silently
+	// restarted would still produce the counts above.
+	seen := map[string]bool{}
+	for _, u := range append(first.Users, second.Users...) {
+		name := aws.ToString(u.UserName)
+		if seen[name] {
+			t.Fatalf("user %s appeared on both pages", name)
+		}
+		seen[name] = true
+	}
+	if len(seen) != 3 {
+		t.Fatalf("pages covered %d users, want 3", len(seen))
+	}
+
+	// MaxSessionDuration is the same defect on a non-pagination member, and unlike
+	// MaxItems it is stored, so GetRole proves the value survived the round trip
+	// rather than merely being accepted.
+	const trust = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("worker"),
+		AssumeRolePolicyDocument: aws.String(trust),
+		MaxSessionDuration:       aws.Int32(7200),
+	}); err != nil {
+		t.Fatalf("CreateRole with MaxSessionDuration: %v", err)
+	}
+	role, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String("worker")})
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+	if got := aws.ToInt32(role.Role.MaxSessionDuration); got != 7200 {
+		t.Fatalf("MaxSessionDuration round-tripped as %d, want 7200", got)
+	}
+}


### PR DESCRIPTION
Closes #642

## What was broken

`MaxItems` failed **every** paginated IAM operation with `400 ValidationError`, and
`CreateRole` rejected `MaxSessionDuration`. Through the Go SDK:

```
operation error IAM: ListUsers, StatusCode: 400, api error ValidationError:
invalid request body: json: cannot unmarshal string into Go struct field .MaxItems of type int
```

## Why

The same root cause as #639, one layer along. IAM speaks the query protocol, so
`ParseAWSRequest` flattens the form body into `AWSRequest.Params` (`map[string]string`) and
`server.go:583-589` rebuilds `req.Body` as `json.Marshal(req.Params)` — every value in that
JSON object is a **string**. A handler field declared `int` made `encoding/json` refuse the
whole request. Where #639's lists unmarshaled to nil in silence, an integer took the request
down with it.

## The fix

`iamInt` and `iamBool` in `emulator/iam_query.go` accept either a JSON number or a numeric
JSON string. All 14 `MaxItems` declarations and `MaxSessionDuration` now use `iamInt`.
`iamBool` lands unused so #497's `OnlyAttached` is not built with the defect already in it.

Both shapes are accepted rather than only the string, because `iamRequest`
(`iam_plugin_test.go:40`) hand-marshals a real JSON number — that asymmetry is precisely what
hid this.

An empty value is the zero value rather than an error: a client that sent `MaxItems=`
expressed no limit, and refusing it would fail a request AWS accepts. A malformed value now
names its parameter — `MaxItems must be an integer, got "abc"` — carried through a
`*json.UnmarshalTypeError`, which is the one error type `encoding/json` annotates with the
field path it was decoding (and it nests correctly for a scalar inside a list member).

## How it was found, and why no test caught it

By probing `ListUsers(MaxItems: 1)` through the SDK while building #579. That makes this the
**third** defect of the #561/#610/#636/#639 class. The unit suite structurally cannot see it:
`iamRequest` sends the one shape no AWS client produces, and the IAM journeys that do go
through the SDK never passed `MaxItems`, because pagination is asserted at the unit level
where the number is real.

`test/e2e/journey_iam_numbers_test.go` closes that: `MaxItems` across two pages (asserting
the pages are disjoint and complete, so a Marker that silently restarted still fails) and
`MaxSessionDuration` round-tripped through `GetRole`. **Verified to fail against the pre-fix
code** by reverting `listUsers` and re-running — it reproduces the 400 above.

## Gates

`gofmt -l .` clean · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` → **0
issues** · `make test` (race) · `make coverage` → emulator **82.3%**, total **81.6%** ·
`go vet -C test/e2e ./... && go test -C test/e2e ./...`