### PR TITLE
feat(iam): a tool can ask before it acts (#579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **A tool can ask before it acts: `SimulatePrincipalPolicy` and `SimulateCustomPolicy`**
+  (#579). These are the only AWS APIs that decide whether a principal may do X to Y
+  *without* doing X to Y, and neither existed — so the one code path in a consumer that
+  decides whether to proceed at all was the one path with no emulator coverage. Worse,
+  `iam_managed.go` already granted `iam:SimulatePrincipalPolicy` and
+  `iam:SimulateCustomPolicy` in its bundled policies: substrate advertised permission for
+  operations that answered `InvalidAction`.
+
+  Both operations run the **same evaluator the request gate enforces with**. `Evaluate`
+  already implemented the IAM algorithm and already produced exactly the three outcomes
+  the API reports, so this exposes existing evaluation over the wire rather than writing a
+  second one. That is the property worth having: a simulated decision that could disagree
+  with an enforced one would be worse than no simulator at all, because a consumer would
+  trust the preflight and then be refused. A test drives one user, one policy and two
+  actions through both paths and asserts they agree.
+
+  The three-way distinction is the feature. `allowed`, `explicitDeny` and `implicitDeny`
+  are reported separately, because collapsing them would look like coverage while telling
+  a consumer the wrong thing: an assertion that "the policy explicitly forbids this" would
+  pass on what is really a missing grant. The decisive test asserts all three in a single
+  response, so a handler returning a uniform answer fails.
+
+  `MatchedStatements` gained the AWS `Statement` shape — `SourcePolicyId` and
+  `SourcePolicyType` — so a caller learns *which* policy decided, which is the whole
+  output of a simulation. `Evaluate` therefore had to learn where a document came from:
+  `SourcedPolicyDocument` and `EvaluateSourced` carry the provenance, and `Evaluate`
+  delegates to them with its signature untouched for its existing callers.
+  `MissingContextValues` reports every condition key a matching-but-for-the-condition
+  statement tested and the request supplied no value for — without it a conditional grant
+  reads as a clean `implicitDeny` with no indication that the answer would change given a
+  context value. A key present with an *empty* value is set, not missing, because the
+  `Null` operator exists precisely to test for absence.
+
+  A permissions boundary that does not allow the action turns an `allowed` into an
+  **implicit** deny and reports
+  `PermissionsBoundaryDecisionDetail.AllowedByPermissionsBoundary=false`: a boundary caps
+  what is reachable rather than denying an action by name, and an identity policy's
+  explicit deny stays explicit. A boundary supplied through
+  `PermissionsBoundaryPolicyInputList` replaces the entity's stored one, per the
+  reference. `CallerArn` defaults to `PolicySourceArn` and populates `aws:PrincipalArn`;
+  `ResourceOwner` populates `aws:ResourceAccount`; an explicit `ContextEntry` wins over
+  both, because a caller who names a key is stating what to simulate with.
+  `ResourceArns` defaults to `["*"]` and every action is evaluated against every
+  resource. `MaxItems` defaults to 100, valid 1–1000.
+
+  Deliberately **not** evaluated, and stated in `docs/services.md` rather than faked:
+  **SCPs** — Organizations stores them and `CheckAccess` never consults them either, so
+  simulating them would report a bound substrate does not enforce, and
+  `OrganizationsDecisionDetail` is therefore *absent* rather than present-and-false;
+  `StartPosition`/`EndPosition`, which are offsets into the policy document as submitted,
+  and substrate stores a parsed document, so any offset would be fabricated; and
+  `ResourceHandlingOption`, `PolicyExclusionList`, `EvalDecisionDetails` and
+  `ResourceSpecificResults`, which are cross-account constructs. An attached AWS managed
+  policy substrate does not bundle contributes no statements rather than a guess.
+
+  Note the correction to the issue: **there is no 25-action cap.** #579 asserted one;
+  neither the API reference nor the model has any action-count limit, and modelling it
+  would refuse requests AWS accepts.
 - **IAM groups have an observable effect** (#579 prerequisite). Substrate routed
   `CreateGroup`, `GetGroup`, `DeleteGroup` and `ListGroups` and nothing else, so a group
   could be created and then did nothing: no user could join it, no policy could be put on

--- a/emulator/iam_eval.go
+++ b/emulator/iam_eval.go
@@ -1,6 +1,9 @@
 package emulator
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // Decision constants for IAM policy evaluation results.
 const (
@@ -14,6 +17,52 @@ const (
 	DecisionImplicitDeny = "ImplicitDeny"
 )
 
+// Policy source types, as reported in a simulation's MatchedStatements.
+//
+// These are the values the SimulatePrincipalPolicy reference's sample responses
+// emit — `<SourcePolicyType>IAM Policy</SourcePolicyType>` and `Resource Policy` —
+// which **diverge from the `PolicySourceType` enum** in the API model
+// (`user`/`group`/`role`/`aws-managed`/`user-managed`/`resource`/`none`). The doc
+// values are what an SDK actually receives from the service, so those are what
+// substrate emits.
+const (
+	// PolicySourceIAMPolicy marks a statement that came from an identity policy —
+	// managed, inline, or supplied through PolicyInputList.
+	PolicySourceIAMPolicy = "IAM Policy"
+
+	// PolicySourceResourcePolicy marks a statement that came from a resource-based
+	// policy.
+	PolicySourceResourcePolicy = "Resource Policy"
+)
+
+// MatchedStatement identifies a policy statement that determined a decision.
+//
+// It mirrors the API model's Statement type, minus StartPosition/EndPosition:
+// those are row/column offsets into the policy document *as submitted*, and
+// substrate stores a parsed PolicyDocument, so the original text is gone and any
+// offset would be fabricated. Omitting the members is honest — the reference's own
+// sample response shows `<MatchedStatements/>` empty for an implicitDeny, so
+// absence is a shape callers already handle.
+type MatchedStatement struct {
+	// SourcePolicyID identifies the policy the statement came from.
+	//
+	// It is the policy *name* rather than its ARN — `AmazonS3ReadOnlyAccess`, or
+	// `PolicyInputList.1` for a document supplied as a string — per the reference's
+	// sample responses.
+	SourcePolicyID string
+
+	// SourcePolicyType is PolicySourceIAMPolicy or PolicySourceResourcePolicy.
+	SourcePolicyType string
+
+	// Sid is the statement's own Sid, which AWS does not report.
+	//
+	// It is carried because substrate's own callers had it before MatchedStatements
+	// grew a shape, and because a Sid names the statement far more usefully than a
+	// policy name does when several statements in one document match. It is never
+	// emitted over the wire.
+	Sid string
+}
+
 // EvaluationResult holds the outcome of an IAM policy evaluation.
 type EvaluationResult struct {
 	// Decision is one of DecisionAllow, DecisionDeny, or DecisionImplicitDeny.
@@ -22,8 +71,34 @@ type EvaluationResult struct {
 	// Reason is a human-readable explanation of the decision.
 	Reason string
 
-	// MatchedStatements is the list of statement Sid values that matched.
-	MatchedStatements []string
+	// MatchedStatements identifies the statements that matched.
+	MatchedStatements []MatchedStatement
+
+	// MissingContextValues names the condition keys a matching statement tested
+	// for which the request supplied no value.
+	//
+	// This is what stops a conditional grant reading as a clean allow: a statement
+	// whose Condition names an unset key cannot match, so without this the caller
+	// sees an implicitDeny with no indication that the answer would change given a
+	// context value. AWS reports the same list for the same reason.
+	MissingContextValues []string
+}
+
+// SourcedPolicyDocument is a policy document tagged with where it came from, so a
+// matched statement can name its policy.
+//
+// It exists because Evaluate takes bare documents and therefore cannot report
+// which one decided — enough for CheckAccess, which only needs allow-or-not, but
+// not for a simulation, whose whole output is "which policy said so".
+type SourcedPolicyDocument struct {
+	// Document is the policy being evaluated.
+	Document PolicyDocument
+
+	// SourceID is the policy name reported as MatchedStatement.SourcePolicyID.
+	SourceID string
+
+	// SourceType is PolicySourceIAMPolicy or PolicySourceResourcePolicy.
+	SourceType string
 }
 
 // EvaluationRequest contains the inputs for an IAM policy evaluation.
@@ -57,42 +132,135 @@ type EvaluationRequest struct {
 //
 // Allow matching never short-circuits — the full statement list is scanned
 // to ensure no explicit Deny is present before returning Allow.
+//
+// Documents passed here carry no source identity, so the returned
+// MatchedStatements name only a Sid. A caller that must report which policy
+// decided — the policy simulator — uses [EvaluateSourced] instead.
 func Evaluate(documents []PolicyDocument, req EvaluationRequest) EvaluationResult {
+	sourced := make([]SourcedPolicyDocument, 0, len(documents))
+	for _, doc := range documents {
+		sourced = append(sourced, SourcedPolicyDocument{Document: doc, SourceType: PolicySourceIAMPolicy})
+	}
+	return EvaluateSourced(sourced, req)
+}
+
+// EvaluateSourced is [Evaluate] over documents that know where they came from, so
+// each matched statement names its policy.
+//
+// The evaluation itself is identical — one implementation, so a simulated decision
+// and an enforced one cannot disagree, which is the whole reason
+// SimulatePrincipalPolicy is worth having.
+//
+// It also reports MissingContextValues: every condition key a matching-but-for-the-
+// condition statement tested and the request had no value for. That is computed
+// only for statements whose action and resource match, because a key named by a
+// statement about some other action tells the caller nothing about this one.
+func EvaluateSourced(documents []SourcedPolicyDocument, req EvaluationRequest) EvaluationResult {
 	var allowed bool
-	var allowedSids []string
+	var allowedStatements []MatchedStatement
+	missing := make(map[string]struct{})
 
 	for _, doc := range documents {
-		for _, stmt := range doc.Statement {
+		for _, stmt := range doc.Document.Statement {
 			if !statementMatches(stmt, req) {
+				// A statement that covers the action and resource but was ruled out by a
+				// condition on an unset key is the reportable case: the answer would
+				// change given a value.
+				if actionResourcePrincipalMatch(stmt, req) {
+					for _, key := range unsetConditionKeys(stmt.Condition, req.Context) {
+						missing[key] = struct{}{}
+					}
+				}
 				continue
+			}
+			matched := MatchedStatement{
+				SourcePolicyID:   doc.SourceID,
+				SourcePolicyType: sourceTypeOrDefault(doc.SourceType),
+				Sid:              stmt.Sid,
 			}
 			if stmt.Effect == IAMEffectDeny {
 				// Explicit deny always wins — return immediately.
 				return EvaluationResult{
-					Decision:          DecisionDeny,
-					Reason:            "explicit deny in policy statement",
-					MatchedStatements: []string{stmt.Sid},
+					Decision:             DecisionDeny,
+					Reason:               "explicit deny in policy statement",
+					MatchedStatements:    []MatchedStatement{matched},
+					MissingContextValues: sortedKeys(missing),
 				}
 			}
 			if stmt.Effect == IAMEffectAllow {
 				allowed = true
-				allowedSids = append(allowedSids, stmt.Sid)
+				allowedStatements = append(allowedStatements, matched)
 			}
 		}
 	}
 
 	if allowed {
 		return EvaluationResult{
-			Decision:          DecisionAllow,
-			Reason:            "allowed by policy statement",
-			MatchedStatements: allowedSids,
+			Decision:             DecisionAllow,
+			Reason:               "allowed by policy statement",
+			MatchedStatements:    allowedStatements,
+			MissingContextValues: sortedKeys(missing),
 		}
 	}
 
 	return EvaluationResult{
-		Decision: DecisionImplicitDeny,
-		Reason:   "no matching allow statement",
+		Decision:             DecisionImplicitDeny,
+		Reason:               "no matching allow statement",
+		MissingContextValues: sortedKeys(missing),
 	}
+}
+
+// sourceTypeOrDefault fills in the identity-policy type for a document that named
+// none, so a MatchedStatement always carries a type an SDK can enum-decode.
+func sourceTypeOrDefault(sourceType string) string {
+	if sourceType == "" {
+		return PolicySourceIAMPolicy
+	}
+	return sourceType
+}
+
+// sortedKeys returns set's keys in order, or nil when it is empty.
+//
+// Sorted because the map iteration order is randomized and a response a caller
+// asserts on must not vary between two identical requests — the determinism
+// substrate exists for.
+func sortedKeys(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// actionResourcePrincipalMatch reports whether stmt covers req apart from its
+// conditions. It is the "would this statement apply, given the right context"
+// question MissingContextValues answers.
+func actionResourcePrincipalMatch(stmt PolicyStatement, req EvaluationRequest) bool {
+	return principalMatches(stmt, req.Principal) &&
+		actionMatches(stmt, req.Action) &&
+		resourceMatches(stmt, req.Resource)
+}
+
+// unsetConditionKeys returns the condition keys stmt tests that ctx has no value
+// for.
+//
+// A key present with an empty value is *set*: the Null operator exists precisely to
+// test for absence, and treating "" as missing would report every Null condition as
+// an incomplete simulation.
+func unsetConditionKeys(conditions map[string]map[string]StringOrSlice, ctx map[string]string) []string {
+	var out []string
+	for _, keyValues := range conditions {
+		for condKey := range keyValues {
+			if _, ok := ctx[condKey]; !ok {
+				out = append(out, condKey)
+			}
+		}
+	}
+	return out
 }
 
 // statementMatches returns true if stmt covers the principal, action, resource,

--- a/emulator/iam_eval_test.go
+++ b/emulator/iam_eval_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scttfrdmn/substrate/emulator"
 )
@@ -520,7 +521,12 @@ func TestEvaluate_MatchedStatements(t *testing.T) {
 		Action: "s3:GetObject", Resource: "*",
 	})
 	assert.Equal(t, emulator.DecisionAllow, result.Decision)
-	assert.Contains(t, result.MatchedStatements, "AllowS3")
+	require.Len(t, result.MatchedStatements, 1)
+	assert.Equal(t, "AllowS3", result.MatchedStatements[0].Sid)
+	// Evaluate's documents carry no source, so the identity-policy type is filled in
+	// and SourcePolicyID stays empty. EvaluateSourced is the call that names a policy.
+	assert.Equal(t, emulator.PolicySourceIAMPolicy, result.MatchedStatements[0].SourcePolicyType)
+	assert.Empty(t, result.MatchedStatements[0].SourcePolicyID)
 }
 
 // --- Principal matching (#593) ---------------------------------------------

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -187,6 +187,11 @@ func (p *IAMPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "ListInstanceProfiles":
 		return p.listInstanceProfiles(ctx, req)
 
+	case "SimulatePrincipalPolicy":
+		return p.simulatePrincipalPolicy(ctx, req)
+	case "SimulateCustomPolicy":
+		return p.simulateCustomPolicy(ctx, req)
+
 	default:
 		return iamErrorResponse("InvalidAction",
 			fmt.Sprintf("Could not find operation %s", req.Operation),

--- a/emulator/iam_simulate.go
+++ b/emulator/iam_simulate.go
@@ -1,0 +1,708 @@
+package emulator
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// The IAM policy simulator: SimulatePrincipalPolicy and SimulateCustomPolicy.
+//
+// These are the only AWS APIs that answer "may I?" without doing the thing. Every
+// other operation substrate emulates answers "here is what happened", so the one
+// code path in a consumer that decides whether to proceed at all was the one path
+// with no emulator coverage (#579) — a preflight built on SimulatePrincipalPolicy
+// could not be tested against substrate at all, and iam_managed.go had been
+// granting iam:Simulate* in its bundled policies the whole time, advertising
+// permission for an operation that answered InvalidAction.
+//
+// Both operations run the *same* evaluator substrate enforces with, EvaluateSourced
+// (iam_eval.go), and differ only in where the policy set comes from. That is the
+// point: a simulated decision that could disagree with an enforced one would be
+// worse than no simulator, because a consumer would trust it. The three decisions
+// the API reports map 1:1 to substrate's — allowed/explicitDeny/implicitDeny
+// against DecisionAllow/DecisionDeny/DecisionImplicitDeny — so nothing is
+// collapsed. #579 is explicit that collapsing them "would be worse than none,
+// because it would look like coverage".
+//
+// Deliberately not evaluated, and stated in docs/services.md rather than answered
+// wrongly:
+//
+//   - Service control policies. Organizations stores them and CheckAccess never
+//     consults them either, so reporting an SCP bound here would report a limit
+//     substrate does not enforce. OrganizationsDecisionDetail is therefore absent
+//     rather than present-and-false.
+//   - StartPosition/EndPosition on a matched statement: offsets into the document
+//     as submitted, and substrate stores a parsed PolicyDocument.
+//   - ResourceHandlingOption, PolicyExclusionList, EvalDecisionDetails and
+//     ResourceSpecificResults — cross-account and EC2-scenario constructs whose
+//     inputs substrate has nothing to resolve against.
+
+// iamSimulateDefaultMaxItems is the page size the reference specifies: "If you do
+// not include this parameter, the number of items defaults to 100".
+const iamSimulateDefaultMaxItems = 100
+
+// iamSimulateMaxMaxItems is the reference's "Valid Range: Minimum value of 1.
+// Maximum value of 1000". There is no cap on the number of *actions* a call may
+// name — #579 asserted one at 25, and no such limit appears anywhere in the API
+// reference, so modeling it would refuse requests AWS accepts.
+const iamSimulateMaxMaxItems = 1000
+
+// iamSimulateRequest is the union of both operations' inputs. They differ only in
+// which member is required, so one parser serves both.
+type iamSimulateRequest struct {
+	PolicySourceArn                    string   `json:"PolicySourceArn"`
+	PolicyInputList                    []string `json:"PolicyInputList"`
+	PermissionsBoundaryPolicyInputList []string `json:"PermissionsBoundaryPolicyInputList"`
+	ActionNames                        []string `json:"ActionNames"`
+	ResourceArns                       []string `json:"ResourceArns"`
+	ResourcePolicy                     string   `json:"ResourcePolicy"`
+	ResourceOwner                      string   `json:"ResourceOwner"`
+	CallerArn                          string   `json:"CallerArn"`
+	Marker                             string   `json:"Marker"`
+	MaxItems                           iamInt   `json:"MaxItems"`
+
+	// context holds the condition keys decoded from ContextEntries. It is not a
+	// request member, so it carries no JSON tag: only parseSimulateRequest fills it,
+	// from req.Params, because a nested member list has no JSON-body form at all.
+	context map[string]string
+}
+
+// iamSimulationResult is one (action, resource) outcome, in the terms the response
+// reports rather than the terms the evaluator answers in.
+type iamSimulationResult struct {
+	ActionName           string
+	ResourceName         string
+	Decision             string
+	MatchedStatements    []MatchedStatement
+	MissingContextValues []string
+
+	// BoundaryChecked records whether a permissions boundary applied at all.
+	// PermissionsBoundaryDecisionDetail is emitted only when one did — a `false`
+	// there means "the boundary blocked this", so emitting it for an entity with no
+	// boundary would report a block that never happened.
+	BoundaryChecked bool
+
+	// AllowedByBoundary is the boundary's answer when BoundaryChecked is true.
+	AllowedByBoundary bool
+}
+
+// simulatePrincipalPolicy implements the SimulatePrincipalPolicy operation.
+func (p *IAMPlugin) simulatePrincipalPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	params, errResp := p.parseSimulateRequest(req)
+	if errResp != nil {
+		return errResp, nil
+	}
+	if params.PolicySourceArn == "" {
+		return iamErrorResponse("InvalidInput", "PolicySourceArn is required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:SimulatePrincipalPolicy", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	docs, boundaryDocs, errResp, err := p.simulationPolicySet(goCtx, params)
+	if err != nil {
+		// The model's PolicyEvaluation 500: "The request failed because a provided
+		// policy could not be successfully evaluated." A state read that fails is
+		// substrate's fault, not the caller's, so it must not be reported as
+		// InvalidInput — and it must not be reported as an *answer*, because an
+		// evaluation over a policy set that failed to load would silently be an
+		// implicitDeny the caller would read as a real decision.
+		return iamErrorResponse("PolicyEvaluation", err.Error(), http.StatusInternalServerError), nil
+	}
+	if errResp != nil {
+		return errResp, nil
+	}
+
+	// "If you do not specify a CallerArn, it defaults to the ARN of the user, group,
+	// or role that you specify in PolicySourceArn."
+	callerArn := params.CallerArn
+	if callerArn == "" {
+		callerArn = params.PolicySourceArn
+	}
+
+	return p.simulateResponse("SimulatePrincipalPolicy", params, docs, boundaryDocs, callerArn)
+}
+
+// simulateCustomPolicy implements the SimulateCustomPolicy operation.
+//
+// It resolves no entity, which is why the model declares NoSuchEntity for
+// SimulatePrincipalPolicy and not for this one: there is nothing to fail to find.
+func (p *IAMPlugin) simulateCustomPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	params, errResp := p.parseSimulateRequest(req)
+	if errResp != nil {
+		return errResp, nil
+	}
+	if len(params.PolicyInputList) == 0 {
+		return iamErrorResponse("InvalidInput", "PolicyInputList is required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:SimulateCustomPolicy", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	docs, errResp := parseSimulationPolicyInputs(params.PolicyInputList, "PolicyInputList")
+	if errResp != nil {
+		return errResp, nil
+	}
+	resourceDocs, errResp := simulationResourcePolicyDocs(params.ResourcePolicy)
+	if errResp != nil {
+		return errResp, nil
+	}
+	docs = append(docs, resourceDocs...)
+
+	boundaryDocs, errResp := parseSimulationPolicyInputs(
+		params.PermissionsBoundaryPolicyInputList, "PermissionsBoundaryPolicyInputList")
+	if errResp != nil {
+		return errResp, nil
+	}
+
+	return p.simulateResponse("SimulateCustomPolicy", params, docs, boundaryDocs, params.CallerArn)
+}
+
+// parseSimulateRequest decodes the members shared by both operations, reading the
+// query-protocol lists through iam_query.go's decoders and falling back to a JSON
+// body for the tests that drive the plugin directly (#639).
+func (p *IAMPlugin) parseSimulateRequest(req *AWSRequest) (*iamSimulateRequest, *AWSResponse) {
+	var params iamSimulateRequest
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return nil, iamErrorResponse("InvalidInput", err.Error(), http.StatusBadRequest)
+	}
+
+	// Every list this operation takes arrives as prefix.member.N over the wire, which
+	// is why #639 had to land first: without its decoder ActionNames — a *required*
+	// member — was nil on every real request.
+	if list := iamMemberList(req.Params, "ActionNames"); list != nil {
+		params.ActionNames = list
+	}
+	if list := iamMemberList(req.Params, "ResourceArns"); list != nil {
+		params.ResourceArns = list
+	}
+	if list := iamMemberList(req.Params, "PolicyInputList"); list != nil {
+		params.PolicyInputList = list
+	}
+	if list := iamMemberList(req.Params, "PermissionsBoundaryPolicyInputList"); list != nil {
+		params.PermissionsBoundaryPolicyInputList = list
+	}
+
+	if len(params.ActionNames) == 0 {
+		return nil, iamErrorResponse("InvalidInput", "ActionNames is required", http.StatusBadRequest)
+	}
+	for _, action := range params.ActionNames {
+		// "Each operation must include the service identifier, such as
+		// iam:CreateUser." An action with no service prefix can never match a
+		// statement, so accepting it would answer implicitDeny for what is really a
+		// malformed request.
+		if !strings.Contains(action, ":") {
+			return nil, iamErrorResponse("InvalidInput",
+				fmt.Sprintf("Invalid Action name: %s; an action must name its service, as in iam:CreateUser", action),
+				http.StatusBadRequest)
+		}
+	}
+
+	// The model's maxItemsType is min 1 / max 1000. Zero means absent, which the
+	// reference gives a default for. #579 asserted a 25-action cap; no action-count
+	// limit appears anywhere in the reference or the model, so none is modeled —
+	// refusing requests AWS accepts would be worse than accepting a large one.
+	if params.MaxItems != 0 &&
+		(params.MaxItems < 1 || params.MaxItems > iamSimulateMaxMaxItems) {
+		return nil, iamErrorResponse("InvalidInput",
+			fmt.Sprintf("MaxItems must be between 1 and %d", iamSimulateMaxMaxItems),
+			http.StatusBadRequest)
+	}
+
+	// "If this parameter is not provided, then the value defaults to * (all
+	// resources)."
+	if len(params.ResourceArns) == 0 {
+		params.ResourceArns = []string{"*"}
+	}
+
+	params.context = simulationContextEntries(req.Params)
+	return &params, nil
+}
+
+// simulationContextEntries decodes ContextEntries into the condition-key map the
+// evaluator takes.
+//
+// The wire shape is a list *of structures containing a list*:
+//
+//	ContextEntries.member.1.ContextKeyName=aws:SourceIp
+//	ContextEntries.member.1.ContextKeyValues.member.1=10.0.0.1
+//	ContextEntries.member.1.ContextKeyType=ip
+//
+// which is the case iamMemberStructs keeps its suffixes verbatim for — the member
+// map holds "ContextKeyValues.member.1", so iamMemberList applies to it directly.
+// There is no JSON-body form of this at all, so unlike every other member it is read
+// only from req.Params.
+//
+// Only the first value of a multi-valued key is used, because substrate's condition
+// context is a map[string]string. A set-valued key needs ForAllValues/ForAnyValue,
+// which conditionMatches does not implement, so silently keeping one of several
+// values is the honest limit: the alternative is pretending to evaluate a
+// multi-valued condition. ContextKeyType is recorded by AWS but not consulted here —
+// every condition operator substrate implements compares strings.
+func simulationContextEntries(params map[string]string) map[string]string {
+	entries := iamMemberStructs(params, "ContextEntries")
+	if len(entries) == 0 {
+		return nil
+	}
+	ctx := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		name := entry["ContextKeyName"]
+		if name == "" {
+			continue
+		}
+		values := iamMemberList(entry, "ContextKeyValues")
+		if len(values) == 0 {
+			// A key named with no value is still *set* as far as the Null operator is
+			// concerned, and it must not be reported as a missing context value: the
+			// caller supplied it.
+			ctx[name] = ""
+			continue
+		}
+		ctx[name] = values[0]
+	}
+	return ctx
+}
+
+// simulationPolicySet assembles the documents SimulatePrincipalPolicy evaluates:
+// the entity's own identity policies, its groups' when it is a user, anything
+// supplied through PolicyInputList, and the boundary.
+//
+// The boundary follows the reference: "if a permissions boundary is attached to an
+// entity and you pass in a different permissions boundary policy using this
+// parameter, then the new permissions boundary policy is used for the simulation."
+//
+// A returned errResp is an answer for the caller (InvalidInput, NoSuchEntity); a
+// returned error is substrate's own failure, which the caller reports as
+// PolicyEvaluation 500. The two are kept apart deliberately: a state read that failed
+// must not degrade into an evaluation over a partial policy set, because the result
+// would be an implicitDeny indistinguishable from a real one.
+func (p *IAMPlugin) simulationPolicySet(goCtx context.Context, params *iamSimulateRequest) (
+	docs, boundaryDocs []SourcedPolicyDocument, errResp *AWSResponse, err error,
+) {
+	entityType, entityName := parsePrincipalARN(params.PolicySourceArn)
+	switch entityType {
+	case "user", "group", "role":
+		// "The entity can be an IAM user, group, or role."
+	default:
+		return nil, nil, iamErrorResponse("InvalidInput",
+			fmt.Sprintf("Invalid Entity Arn: %s must be a user, group or role ARN", params.PolicySourceArn),
+			http.StatusBadRequest), nil
+	}
+	if entityName == "" {
+		return nil, nil, iamErrorResponse("InvalidInput",
+			fmt.Sprintf("Invalid Entity Arn: %s names no entity", params.PolicySourceArn),
+			http.StatusBadRequest), nil
+	}
+
+	raw, err := p.state.Get(goCtx, iamNamespace, entityType+":"+entityName)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("load %s %s: %w", entityType, entityName, err)
+	}
+	if raw == nil {
+		return nil, nil, iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("The %s with name %s cannot be found.", entityType, entityName),
+			http.StatusNotFound), nil
+	}
+
+	docs, err = p.simulationIdentityDocs(goCtx, iamEntity{Kind: entityType, Name: entityName})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	inputDocs, errResp := parseSimulationPolicyInputs(params.PolicyInputList, "PolicyInputList")
+	if errResp != nil {
+		return nil, nil, errResp, nil
+	}
+	docs = append(docs, inputDocs...)
+
+	resourceDocs, errResp := simulationResourcePolicyDocs(params.ResourcePolicy)
+	if errResp != nil {
+		return nil, nil, errResp, nil
+	}
+	docs = append(docs, resourceDocs...)
+
+	if len(params.PermissionsBoundaryPolicyInputList) > 0 {
+		boundaryDocs, errResp = parseSimulationPolicyInputs(
+			params.PermissionsBoundaryPolicyInputList, "PermissionsBoundaryPolicyInputList")
+		if errResp != nil {
+			return nil, nil, errResp, nil
+		}
+		return docs, boundaryDocs, nil, nil
+	}
+
+	// No boundary was supplied, so the entity's own applies. A group holds none —
+	// IAM has no PutGroupPermissionsBoundary — so for a group this finds nothing,
+	// which is correct rather than a gap.
+	var stored struct {
+		PermissionsBoundary *IAMAttachedPolicy `json:"PermissionsBoundary,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		return nil, nil, nil, fmt.Errorf("unmarshal %s %s: %w", entityType, entityName, err)
+	}
+	if stored.PermissionsBoundary != nil {
+		for _, doc := range p.loadBoundaryPolicyDocs(goCtx, stored.PermissionsBoundary.PolicyARN) {
+			boundaryDocs = append(boundaryDocs, SourcedPolicyDocument{
+				Document:   doc,
+				SourceID:   stored.PermissionsBoundary.PolicyName,
+				SourceType: PolicySourceIAMPolicy,
+			})
+		}
+	}
+	return docs, boundaryDocs, nil, nil
+}
+
+// simulationResourcePolicyDocs parses the optional ResourcePolicy into a document
+// tagged as a resource policy, which is what makes a matched statement report
+// "Resource Policy" rather than "IAM Policy".
+//
+// It is folded into the identity set rather than evaluated separately because
+// substrate's evaluator makes one same-account decision: the reference's separate
+// EvalDecisionDetails breakdown is a cross-account construct, and it is documented as
+// out of scope in this file's header.
+func simulationResourcePolicyDocs(resourcePolicy string) ([]SourcedPolicyDocument, *AWSResponse) {
+	if resourcePolicy == "" {
+		return nil, nil
+	}
+	docs, errResp := parseSimulationPolicyInputs([]string{resourcePolicy}, "ResourcePolicy")
+	if errResp != nil {
+		return nil, errResp
+	}
+	docs[0].SourceID = "ResourcePolicy"
+	docs[0].SourceType = PolicySourceResourcePolicy
+	return docs, nil
+}
+
+// simulationIdentityDocs loads an entity's managed and inline policy documents,
+// including those of every group a user belongs to.
+//
+// AWS: "If you specify a user, then the simulation also includes all of the
+// policies that are attached to groups that the user belongs to." The group arm is
+// the reason Lane B had to land first — there was no group state to read.
+//
+// Unlike loadPoliciesForPrincipal, AdministratorAccess is not short-circuited into
+// a synthetic allow-all: the simulation must report *which* policy decided, and a
+// synthesized document has no name to report.
+func (p *IAMPlugin) simulationIdentityDocs(goCtx context.Context, entity iamEntity) ([]SourcedPolicyDocument, error) {
+	sources := []iamEntity{entity}
+	if entity.Kind == "user" {
+		groups, err := p.loadStringList(goCtx, iamUserGroupsKey(entity.Name))
+		if err != nil {
+			return nil, fmt.Errorf("load group memberships for simulation: %w", err)
+		}
+		for _, name := range groups {
+			sources = append(sources, iamEntity{Kind: "group", Name: name})
+		}
+	}
+
+	var docs []SourcedPolicyDocument
+	for _, source := range sources {
+		arns, err := p.loadPolicyList(goCtx, source.Kind+"_policies:"+source.Name)
+		if err != nil {
+			return nil, fmt.Errorf("load attached policies for simulation: %w", err)
+		}
+		for _, arn := range arns {
+			doc, ok := p.resolveSimulationManagedDoc(goCtx, arn)
+			if !ok {
+				// One of the ~1,150 AWS managed policies substrate does not bundle. Its
+				// statements are unknown, so it contributes nothing rather than a guess.
+				continue
+			}
+			docs = append(docs, SourcedPolicyDocument{
+				Document: doc,
+				// The sample response reports a managed policy by name
+				// ("AmazonS3ReadOnlyAccess"), not by ARN.
+				SourceID:   arnPolicyName(arn),
+				SourceType: PolicySourceIAMPolicy,
+			})
+		}
+
+		names, err := p.loadInlinePolicyNames(goCtx, source.Kind, source.Name)
+		if err != nil {
+			return nil, fmt.Errorf("load inline policy names for simulation: %w", err)
+		}
+		for _, name := range names {
+			doc, err := p.loadInlinePolicyDoc(goCtx, source.Kind, source.Name, name)
+			if err != nil {
+				return nil, fmt.Errorf("load inline policy for simulation: %w", err)
+			}
+			if doc == nil {
+				continue
+			}
+			docs = append(docs, SourcedPolicyDocument{
+				Document:   *doc,
+				SourceID:   name,
+				SourceType: PolicySourceIAMPolicy,
+			})
+		}
+	}
+	return docs, nil
+}
+
+// resolveSimulationManagedDoc resolves a managed policy ARN to its document,
+// catalog before state — the same order every other IAM caller uses, so a bundled
+// and a customer-managed policy behave alike.
+func (p *IAMPlugin) resolveSimulationManagedDoc(goCtx context.Context, arn string) (PolicyDocument, bool) {
+	if mp, ok := GetManagedPolicy(arn); ok {
+		return mp.Document, true
+	}
+	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	if err != nil || raw == nil {
+		return PolicyDocument{}, false
+	}
+	var pol IAMPolicy
+	if err := json.Unmarshal(raw, &pol); err != nil {
+		return PolicyDocument{}, false
+	}
+	return pol.Document, true
+}
+
+// parseSimulationPolicyInputs parses each policy string into a document, naming it
+// "<prefix>.N" as the sample response does for PolicyInputList.
+//
+// A document that will not parse is InvalidInput 400 rather than PolicyEvaluation
+// 500: the input is malformed, which is the caller's error, and the reference
+// reserves PolicyEvaluation for a policy that "could not be successfully
+// evaluated".
+func parseSimulationPolicyInputs(inputs []string, prefix string) ([]SourcedPolicyDocument, *AWSResponse) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	docs := make([]SourcedPolicyDocument, 0, len(inputs))
+	for i, input := range inputs {
+		var doc PolicyDocument
+		if err := json.Unmarshal([]byte(input), &doc); err != nil {
+			return nil, iamErrorResponse("InvalidInput",
+				fmt.Sprintf("Syntax errors in policy: %s", err.Error()),
+				http.StatusBadRequest)
+		}
+		docs = append(docs, SourcedPolicyDocument{
+			Document:   doc,
+			SourceID:   prefix + "." + strconv.Itoa(i+1),
+			SourceType: PolicySourceIAMPolicy,
+		})
+	}
+	return docs, nil
+}
+
+// simulateResponse evaluates every (action, resource) pair and encodes the page.
+//
+// Every action is evaluated against every resource, per the reference: "Each API in
+// the ActionNames parameter is evaluated for each resource in this list".
+func (p *IAMPlugin) simulateResponse(op string, params *iamSimulateRequest,
+	docs, boundaryDocs []SourcedPolicyDocument, callerArn string,
+) (*AWSResponse, error) {
+	condCtx := simulationConditionContext(params, callerArn)
+
+	results := make([]iamSimulationResult, 0, len(params.ActionNames)*len(params.ResourceArns))
+	for _, action := range params.ActionNames {
+		for _, resource := range params.ResourceArns {
+			results = append(results, simulateOne(docs, boundaryDocs, EvaluationRequest{
+				Principal: callerArn,
+				Action:    action,
+				Resource:  resource,
+				Context:   condCtx,
+			}))
+		}
+	}
+
+	page, nextMarker, isTruncated := paginateSimulationResults(results, params.Marker, params.MaxItems.Int())
+
+	xmlStr := iamEvaluationResultsXML(page) + "<IsTruncated>" + iamBoolXML(isTruncated) + "</IsTruncated>"
+	if nextMarker != "" {
+		xmlStr += "<Marker>" + xmlEsc(nextMarker) + "</Marker>"
+	}
+	return iamXMLResponse(http.StatusOK, op, xmlStr)
+}
+
+// simulateOne evaluates one (action, resource) pair, applying the boundary.
+//
+// The boundary arm mirrors CheckAccess's second Evaluate call rather than
+// reimplementing the rule: a boundary that does not allow turns an allow into an
+// implicit deny. The reference states the same in reverse — AllowedByPermissionsBoundary
+// false "means that either the requested action is not allowed (implicitly denied)
+// or that the action is explicitly denied by the permissions boundary. In both of
+// these cases, the action is not allowed, regardless of the identity-based policy".
+func simulateOne(docs, boundaryDocs []SourcedPolicyDocument, req EvaluationRequest) iamSimulationResult {
+	result := EvaluateSourced(docs, req)
+	out := iamSimulationResult{
+		ActionName:           req.Action,
+		ResourceName:         req.Resource,
+		Decision:             simulationDecision(result.Decision),
+		MatchedStatements:    result.MatchedStatements,
+		MissingContextValues: result.MissingContextValues,
+	}
+
+	if len(boundaryDocs) == 0 {
+		return out
+	}
+	boundaryResult := EvaluateSourced(boundaryDocs, req)
+	out.BoundaryChecked = true
+	out.AllowedByBoundary = boundaryResult.Decision == DecisionAllow
+	if !out.AllowedByBoundary && out.Decision == iamEvalDecisionAllowed {
+		// An identity allow the boundary does not permit is an implicit deny, not an
+		// explicit one: the boundary caps what is reachable rather than denying the
+		// action by name.
+		out.Decision = iamEvalDecisionImplicitDeny
+		out.MatchedStatements = nil
+	}
+	return out
+}
+
+// EvalDecision values, per the model's PolicyEvaluationDecisionType enum.
+const (
+	iamEvalDecisionAllowed      = "allowed"
+	iamEvalDecisionExplicitDeny = "explicitDeny"
+	iamEvalDecisionImplicitDeny = "implicitDeny"
+)
+
+// simulationDecision maps substrate's decision onto the API's enum.
+//
+// The three-way distinction is the feature. An emulator that answered a bare
+// allow/deny would let a consumer's "the policy explicitly forbids this" assertion
+// pass on what is really a missing grant, and #579 is explicit that such coverage
+// "would be worse than none, because it would look like coverage".
+func simulationDecision(decision string) string {
+	switch decision {
+	case DecisionAllow:
+		return iamEvalDecisionAllowed
+	case DecisionDeny:
+		return iamEvalDecisionExplicitDeny
+	default:
+		return iamEvalDecisionImplicitDeny
+	}
+}
+
+// simulationConditionContext builds the condition-key context for the evaluation:
+// the keys the caller supplied through ContextEntries, plus the two the simulation
+// itself determines.
+//
+// aws:PrincipalArn and aws:ResourceAccount are filled in from CallerArn and
+// ResourceOwner because the simulation *knows* them — a policy conditioned on either
+// would otherwise report the key as a missing context value when the caller had in
+// fact told substrate what it is, through a differently-named parameter.
+//
+// An explicit ContextEntry wins over both. A caller who names a key is stating what
+// to simulate with, and overriding that with a derived value would make the
+// parameter unusable.
+func simulationConditionContext(params *iamSimulateRequest, callerArn string) map[string]string {
+	ctx := make(map[string]string, len(params.context)+2)
+	if callerArn != "" {
+		ctx["aws:PrincipalArn"] = callerArn
+	}
+	if params.ResourceOwner != "" {
+		ctx["aws:ResourceAccount"] = params.ResourceOwner
+	}
+	for key, value := range params.context {
+		ctx[key] = value
+	}
+	return ctx
+}
+
+// paginateSimulationResults applies the Marker cursor and MaxItems to the flattened
+// result list.
+//
+// The cursor is the index of the last item returned rather than a key, because two
+// results can name the same (action, resource) pair only if the caller listed a
+// duplicate — and a key-based cursor would then skip or repeat. It follows
+// paginateIAMKeys' base64 convention so a caller cannot tell the two apart.
+func paginateSimulationResults(results []iamSimulationResult, marker string, maxItems int) (
+	page []iamSimulationResult, nextMarker string, isTruncated bool,
+) {
+	start := decodeSimulationMarker(marker)
+	if start > len(results) {
+		start = len(results)
+	}
+	if maxItems <= 0 || maxItems > iamSimulateMaxMaxItems {
+		maxItems = iamSimulateDefaultMaxItems
+	}
+	end := start + maxItems
+	if end >= len(results) {
+		return results[start:], "", false
+	}
+	return results[start:end], encodeSimulationMarker(end), true
+}
+
+// encodeSimulationMarker encodes a result index as an opaque page cursor, base64 as
+// paginateIAMKeys does so a caller cannot tell substrate's two cursor kinds apart.
+func encodeSimulationMarker(index int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(index)))
+}
+
+// decodeSimulationMarker returns the index a cursor names, or 0 for anything it
+// cannot read.
+//
+// A marker substrate did not mint is treated as the start of the list rather than
+// as an error: paginateIAMKeys does the same with an undecodable marker, and the
+// alternative — InvalidInput on a cursor a caller round-tripped — would be worse
+// than restarting a page.
+func decodeSimulationMarker(marker string) int {
+	if marker == "" {
+		return 0
+	}
+	raw, err := base64.StdEncoding.DecodeString(marker)
+	if err != nil {
+		return 0
+	}
+	index, err := strconv.Atoi(string(raw))
+	if err != nil || index < 0 {
+		return 0
+	}
+	return index
+}
+
+// iamEvaluationResultsXML encodes <EvaluationResults> for a page.
+//
+// MatchedStatements and MissingContextValues are always emitted, empty when there
+// is nothing to report — the reference's sample response shows
+// `<MatchedStatements/>` and `<MissingContextValues/>` on an implicitDeny result,
+// so a caller reading them unconditionally is following the documented shape.
+func iamEvaluationResultsXML(results []iamSimulationResult) string {
+	var b strings.Builder
+	b.WriteString("<EvaluationResults>")
+	for _, r := range results {
+		b.WriteString("<member><EvalActionName>")
+		b.WriteString(xmlEsc(r.ActionName))
+		b.WriteString("</EvalActionName><EvalResourceName>")
+		b.WriteString(xmlEsc(r.ResourceName))
+		b.WriteString("</EvalResourceName><EvalDecision>")
+		b.WriteString(xmlEsc(r.Decision))
+		b.WriteString("</EvalDecision>")
+		b.WriteString(iamMatchedStatementsXML(r.MatchedStatements))
+		b.WriteString(iamStringListXML("MissingContextValues", r.MissingContextValues))
+		if r.BoundaryChecked {
+			b.WriteString("<PermissionsBoundaryDecisionDetail><AllowedByPermissionsBoundary>")
+			b.WriteString(iamBoolXML(r.AllowedByBoundary))
+			b.WriteString("</AllowedByPermissionsBoundary></PermissionsBoundaryDecisionDetail>")
+		}
+		b.WriteString("</member>")
+	}
+	b.WriteString("</EvaluationResults>")
+	return b.String()
+}
+
+// iamMatchedStatementsXML encodes <MatchedStatements>.
+//
+// StartPosition/EndPosition are omitted: they are offsets into the submitted
+// document text, which substrate does not keep (see this file's header).
+func iamMatchedStatementsXML(statements []MatchedStatement) string {
+	var b strings.Builder
+	b.WriteString("<MatchedStatements>")
+	for _, s := range statements {
+		b.WriteString("<member><SourcePolicyId>")
+		b.WriteString(xmlEsc(s.SourcePolicyID))
+		b.WriteString("</SourcePolicyId><SourcePolicyType>")
+		b.WriteString(xmlEsc(s.SourcePolicyType))
+		b.WriteString("</SourcePolicyType></member>")
+	}
+	b.WriteString("</MatchedStatements>")
+	return b.String()
+}

--- a/emulator/iam_simulate_test.go
+++ b/emulator/iam_simulate_test.go
@@ -1,0 +1,1309 @@
+package emulator_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The IAM policy simulator (#579): SimulatePrincipalPolicy and SimulateCustomPolicy.
+//
+// The responses here are decoded into a typed struct rather than through decodeIAMXML,
+// because the members that matter most are the ones that are legitimately *empty*.
+// "MatchedStatements is empty" is a real assertion: a handler reporting a matched
+// statement for an implicitDeny would be wrong, and so would one that never reported
+// any. A pointer member likewise makes *absence* observable, which is the whole point
+// of PermissionsBoundaryDecisionDetail and OrganizationsDecisionDetail below.
+
+// simulateXMLStatement mirrors one MatchedStatements member.
+type simulateXMLStatement struct {
+	SourcePolicyID   string `xml:"SourcePolicyId"`
+	SourcePolicyType string `xml:"SourcePolicyType"`
+}
+
+// simulateXMLResult mirrors one EvaluationResult member.
+type simulateXMLResult struct {
+	ActionName           string                 `xml:"EvalActionName"`
+	ResourceName         string                 `xml:"EvalResourceName"`
+	Decision             string                 `xml:"EvalDecision"`
+	MatchedStatements    []simulateXMLStatement `xml:"MatchedStatements>member"`
+	MissingContextValues []string               `xml:"MissingContextValues>member"`
+
+	// BoundaryDetail is a pointer so its absence is observable: the API's
+	// AllowedByPermissionsBoundary=false means "the boundary blocked this", so an
+	// entity with no boundary must not report the element at all.
+	BoundaryDetail *struct {
+		Allowed bool `xml:"AllowedByPermissionsBoundary"`
+	} `xml:"PermissionsBoundaryDecisionDetail"`
+
+	// OrganizationsDetail must stay absent: substrate never evaluates an SCP, so
+	// reporting the element would report a bound it does not enforce.
+	OrganizationsDetail *struct {
+		Allowed bool `xml:"AllowedByOrganizations"`
+	} `xml:"OrganizationsDecisionDetail"`
+}
+
+// simulateXMLResponse mirrors a SimulatePolicyResponse from either operation, so one
+// decoder serves both.
+type simulateXMLResponse struct {
+	PrincipalResults []simulateXMLResult `xml:"SimulatePrincipalPolicyResult>EvaluationResults>member"`
+	CustomResults    []simulateXMLResult `xml:"SimulateCustomPolicyResult>EvaluationResults>member"`
+	PrincipalTrunc   bool                `xml:"SimulatePrincipalPolicyResult>IsTruncated"`
+	CustomTrunc      bool                `xml:"SimulateCustomPolicyResult>IsTruncated"`
+	PrincipalMarker  string              `xml:"SimulatePrincipalPolicyResult>Marker"`
+	CustomMarker     string              `xml:"SimulateCustomPolicyResult>Marker"`
+}
+
+// results returns whichever operation's results the response carried.
+func (r simulateXMLResponse) results() []simulateXMLResult {
+	if len(r.PrincipalResults) > 0 {
+		return r.PrincipalResults
+	}
+	return r.CustomResults
+}
+
+// page returns whichever operation's IsTruncated and Marker the response carried.
+func (r simulateXMLResponse) page() (bool, string) {
+	if r.PrincipalTrunc || r.PrincipalMarker != "" {
+		return r.PrincipalTrunc, r.PrincipalMarker
+	}
+	return r.CustomTrunc, r.CustomMarker
+}
+
+// byAction indexes the results by action name, for the single-resource cases.
+func (r simulateXMLResponse) byAction() map[string]simulateXMLResult {
+	results := r.results()
+	out := make(map[string]simulateXMLResult, len(results))
+	for _, result := range results {
+		out[result.ActionName] = result
+	}
+	return out
+}
+
+// decisions maps each result's action to its decision, which is the shape most
+// assertions here want: one call, several actions, several answers.
+func (r simulateXMLResponse) decisions() map[string]string {
+	results := r.results()
+	out := make(map[string]string, len(results))
+	for _, result := range results {
+		out[result.ActionName] = result.Decision
+	}
+	return out
+}
+
+// iamRequireOK runs an IAM setup call and fails the test unless it succeeded, so a
+// simulation never asserts against state that was never written.
+func iamRequireOK(t *testing.T, srv *emulator.Server, operation string, body any) {
+	t.Helper()
+	resp := iamRequest(t, srv, operation, body)
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "%s: %s", operation, raw)
+}
+
+// iamDecodeSimulation reads a simulation response body, requiring 200.
+func iamDecodeSimulation(t *testing.T, resp *http.Response) simulateXMLResponse {
+	t.Helper()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
+
+	// An unrouted operation answers InvalidAction, which the status check above already
+	// catches — but name it, because an InvalidAction that ever came back 200 would
+	// decode to zero results and read as an empty page rather than a routing failure.
+	// That is #636 exactly.
+	require.NotContains(t, string(raw), "InvalidAction")
+
+	var decoded simulateXMLResponse
+	require.NoError(t, xml.Unmarshal(raw, &decoded), "body: %s", raw)
+	return decoded
+}
+
+// iamSimulate posts a simulation through the JSON-body path and decodes it.
+func iamSimulate(t *testing.T, srv *emulator.Server, operation string, body map[string]any) simulateXMLResponse {
+	t.Helper()
+	return iamDecodeSimulation(t, iamRequest(t, srv, operation, body))
+}
+
+// iamPolicyJSON marshals a one-statement policy document to the string form the
+// PolicyInputList members take.
+func iamPolicyJSON(t *testing.T, effect string, actions []string, resource string) string {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"Version": "2012-10-17",
+		"Statement": []map[string]any{{
+			"Effect":   effect,
+			"Action":   actions,
+			"Resource": resource,
+		}},
+	})
+	require.NoError(t, err)
+	return string(raw)
+}
+
+// TestSimulatePrincipalPolicy_ThreeDecisionsInOneResponse is the decisive test.
+//
+// One user carries a managed allow (through a group), an inline deny, and nothing at
+// all for a third action. All three actions are simulated in a single call, so a
+// handler that returns a uniform answer — or that collapses explicitDeny and
+// implicitDeny into one "denied" — fails here. #579 is explicit that collapsing them
+// "would be worse than none, because it would look like coverage": a consumer
+// asserting "the policy explicitly forbids this" would pass on what is really a
+// missing grant.
+func TestSimulatePrincipalPolicy_ThreeDecisionsInOneResponse(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	iamCreateGroupAndUser(t, srv, "devs", "jill")
+	iamRequireOK(t, srv, "AddUserToGroup", map[string]any{"GroupName": "devs", "UserName": "jill"})
+	// The allow arrives through the *group*, which is why the group operations had to
+	// land first: AWS includes a user's group policies in the simulation, and before
+	// this release no operation could put a policy on a group at all.
+	iamRequireOK(t, srv, "AttachGroupPolicy", map[string]any{
+		"GroupName": "devs",
+		"PolicyArn": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+	})
+	iamRequireOK(t, srv, "PutUserPolicy", map[string]any{
+		"UserName":       "jill",
+		"PolicyName":     "nodelete",
+		"PolicyDocument": iamPolicyJSON(t, "Deny", []string{"s3:DeleteObject"}, "*"),
+	})
+
+	got := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+		"ActionNames":     []string{"s3:GetObject", "s3:DeleteObject", "s3:PutObject"},
+		"ResourceArns":    []string{"arn:aws:s3:::my-bucket/key"},
+	})
+
+	require.Len(t, got.results(), 3)
+	assert.Equal(t, map[string]string{
+		"s3:GetObject":    "allowed",
+		"s3:DeleteObject": "explicitDeny",
+		"s3:PutObject":    "implicitDeny",
+	}, got.decisions())
+
+	byAction := got.byAction()
+
+	// The allow must name the group's managed policy by *name*, per the reference's
+	// sample response — not by ARN.
+	allow := byAction["s3:GetObject"]
+	require.Len(t, allow.MatchedStatements, 1)
+	assert.Equal(t, "AmazonS3ReadOnlyAccess", allow.MatchedStatements[0].SourcePolicyID)
+	assert.Equal(t, "IAM Policy", allow.MatchedStatements[0].SourcePolicyType)
+
+	// "the deny statement is the only entry included in the result" — one statement,
+	// and it is the inline one.
+	deny := byAction["s3:DeleteObject"]
+	require.Len(t, deny.MatchedStatements, 1)
+	assert.Equal(t, "nodelete", deny.MatchedStatements[0].SourcePolicyID)
+
+	// An implicit deny matched nothing, so it reports nothing. A statement here would
+	// name a policy that did not decide.
+	assert.Empty(t, byAction["s3:PutObject"].MatchedStatements)
+
+	// No boundary is attached and no SCP is evaluated, so neither detail element may
+	// appear on any result: a present-and-false boundary detail claims a block that
+	// never happened.
+	for _, r := range got.results() {
+		assert.Nil(t, r.BoundaryDetail, r.ActionName)
+		assert.Nil(t, r.OrganizationsDetail, r.ActionName)
+	}
+
+	// The resource is reported back on each result, which is what lets a caller
+	// correlate an answer when several resources were named.
+	assert.Equal(t, "arn:aws:s3:::my-bucket/key", allow.ResourceName)
+}
+
+// TestSimulatePrincipalPolicy_AgreesWithTheEnforcedDecision pins the property that
+// makes the simulator worth having: it runs the same evaluator the request gate
+// enforces with.
+//
+// A simulated decision that could disagree with an enforced one would be worse than no
+// simulator at all, because a consumer would trust the preflight and then be refused —
+// or the reverse. Here the same user, the same policy and the same two actions go
+// through both paths, so a second evaluator drifting from the first fails.
+func TestSimulatePrincipalPolicy_AgreesWithTheEnforcedDecision(t *testing.T) {
+	t.Parallel()
+	srv := newTrustPolicyTestServer(t)
+
+	// The caller is granted iam:ListUsers and the simulate operation but nothing else,
+	// so the enforced answer for iam:DeleteUser is a real denial rather than the
+	// not-enforced fallback resolveIAMEntity takes for an unknown principal.
+	require.Equal(t, http.StatusOK,
+		trustIAMCall(t, srv, "CreateUser", map[string]any{"UserName": "jill"}).StatusCode)
+	require.Equal(t, http.StatusOK, trustIAMCall(t, srv, "PutUserPolicy", map[string]any{
+		"UserName":   "jill",
+		"PolicyName": "listonly",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Action":["iam:ListUsers","iam:SimulatePrincipalPolicy"],"Resource":"*"}]}`,
+	}).StatusCode)
+
+	resp := trustIAMCall(t, srv, "CreateAccessKey", map[string]any{"UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	var created struct {
+		AccessKeyID string `xml:"CreateAccessKeyResult>AccessKey>AccessKeyId"`
+	}
+	require.NoError(t, xml.Unmarshal(raw, &created))
+	accessKeyID := created.AccessKeyID
+	require.NotEmpty(t, accessKeyID)
+
+	simulated := iamDecodeSimulation(t, iamCallAs(t, srv, accessKeyID, "SimulatePrincipalPolicy",
+		map[string]any{
+			"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+			"ActionNames":     []string{"iam:ListUsers", "iam:DeleteUser"},
+		}))
+	assert.Equal(t, map[string]string{
+		"iam:ListUsers":  "allowed",
+		"iam:DeleteUser": "implicitDeny",
+	}, simulated.decisions())
+
+	// And the enforced path agrees, action for action.
+	listed := iamCallAs(t, srv, accessKeyID, "ListUsers", map[string]any{})
+	require.NoError(t, listed.Body.Close())
+	assert.Equal(t, http.StatusOK, listed.StatusCode, "the simulation answered allowed")
+
+	deleted := iamCallAs(t, srv, accessKeyID, "DeleteUser", map[string]any{"UserName": "jill"})
+	require.NoError(t, deleted.Body.Close())
+	assert.Equal(t, http.StatusForbidden, deleted.StatusCode, "the simulation answered implicitDeny")
+}
+
+// TestSimulateCustomPolicy_NeedsNoEntity covers the operation's defining difference:
+// it resolves no principal, which is why the model declares NoSuchEntity for
+// SimulatePrincipalPolicy and not for this one.
+func TestSimulateCustomPolicy_NeedsNoEntity(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames": []string{"s3:GetObject", "s3:PutObject"},
+		"PolicyInputList": []string{
+			iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "*"),
+		},
+	})
+
+	assert.Equal(t, map[string]string{
+		"s3:GetObject": "allowed",
+		"s3:PutObject": "implicitDeny",
+	}, got.decisions())
+
+	// A policy supplied as a string is named by its position, per the sample
+	// response: "PolicyInputList.1".
+	allow := got.byAction()["s3:GetObject"]
+	require.Len(t, allow.MatchedStatements, 1)
+	assert.Equal(t, "PolicyInputList.1", allow.MatchedStatements[0].SourcePolicyID)
+	assert.Equal(t, "IAM Policy", allow.MatchedStatements[0].SourcePolicyType)
+}
+
+// TestSimulateCustomPolicy_PolicyInputsAreNamedByPosition pins that the position is
+// the input's own index, so a caller can tell which of several documents decided.
+func TestSimulateCustomPolicy_PolicyInputsAreNamedByPosition(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames": []string{"s3:PutObject"},
+		"PolicyInputList": []string{
+			iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "*"),
+			iamPolicyJSON(t, "Allow", []string{"s3:PutObject"}, "*"),
+		},
+	})
+
+	require.Len(t, got.results(), 1)
+	require.Len(t, got.results()[0].MatchedStatements, 1)
+	assert.Equal(t, "PolicyInputList.2", got.results()[0].MatchedStatements[0].SourcePolicyID)
+}
+
+// TestSimulate_ResourcePolicyIsReportedAsSuch covers the second SourcePolicyType
+// value: a statement from a resource-based policy reports "Resource Policy", which is
+// how a caller tells a bucket policy's grant from an identity policy's.
+func TestSimulate_ResourcePolicyIsReportedAsSuch(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{iamPolicyJSON(t, "Allow", []string{"s3:ListBucket"}, "*")},
+		"ResourcePolicy":  iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "*"),
+	})
+
+	require.Len(t, got.results(), 1)
+	require.Len(t, got.results()[0].MatchedStatements, 1)
+	assert.Equal(t, "ResourcePolicy", got.results()[0].MatchedStatements[0].SourcePolicyID)
+	assert.Equal(t, "Resource Policy", got.results()[0].MatchedStatements[0].SourcePolicyType)
+}
+
+// TestSimulate_BoundaryFlipsAllowedToImplicitDeny covers the permissions boundary.
+//
+// A boundary that does not allow turns an allow into an *implicit* deny, not an
+// explicit one — the boundary caps what is reachable rather than denying the action by
+// name — and the detail element must then report false so a caller can tell why.
+func TestSimulate_BoundaryFlipsAllowedToImplicitDeny(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// boundaryAllows is the action the supplied boundary permits; empty means no
+		// boundary was supplied at all.
+		boundaryAllows string
+		wantDecision   string
+		wantDetail     bool
+		wantAllowed    bool
+		wantMatched    bool
+	}{
+		{
+			name:         "no boundary supplied leaves the identity decision alone",
+			wantDecision: "allowed",
+			wantDetail:   false,
+			wantMatched:  true,
+		},
+		{
+			name:           "a boundary that allows the action leaves it allowed",
+			boundaryAllows: "s3:*",
+			wantDecision:   "allowed",
+			wantDetail:     true,
+			wantAllowed:    true,
+			wantMatched:    true,
+		},
+		{
+			// The boundary allows something else entirely, so the requested action is
+			// outside it.
+			name:           "a boundary that does not allow the action denies it implicitly",
+			boundaryAllows: "ec2:DescribeInstances",
+			wantDecision:   "implicitDeny",
+			wantDetail:     true,
+			wantAllowed:    false,
+			wantMatched:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newIAMTestServer(t)
+
+			body := map[string]any{
+				"ActionNames":     []string{"s3:GetObject"},
+				"PolicyInputList": []string{iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "*")},
+			}
+			if tc.boundaryAllows != "" {
+				body["PermissionsBoundaryPolicyInputList"] = []string{
+					iamPolicyJSON(t, "Allow", []string{tc.boundaryAllows}, "*"),
+				}
+			}
+
+			got := iamSimulate(t, srv, "SimulateCustomPolicy", body)
+			require.Len(t, got.results(), 1)
+			result := got.results()[0]
+
+			assert.Equal(t, tc.wantDecision, result.Decision)
+			if tc.wantDetail {
+				require.NotNil(t, result.BoundaryDetail)
+				assert.Equal(t, tc.wantAllowed, result.BoundaryDetail.Allowed)
+			} else {
+				assert.Nil(t, result.BoundaryDetail,
+					"no boundary applied, so the detail element must be absent")
+			}
+
+			if tc.wantMatched {
+				assert.NotEmpty(t, result.MatchedStatements)
+			} else {
+				// The identity statement did not decide the outcome, so reporting it
+				// would tell the caller the request was allowed by it.
+				assert.Empty(t, result.MatchedStatements)
+			}
+		})
+	}
+}
+
+// TestSimulate_BoundaryLeavesAnExplicitDenyExplicit pins that the boundary arm only
+// touches an *allow*.
+//
+// An identity policy's explicit deny is already the final answer, and downgrading it
+// to implicitDeny would lose the distinction the operation exists to report.
+func TestSimulate_BoundaryLeavesAnExplicitDenyExplicit(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{iamPolicyJSON(t, "Deny", []string{"s3:GetObject"}, "*")},
+		"PermissionsBoundaryPolicyInputList": []string{
+			iamPolicyJSON(t, "Allow", []string{"s3:*"}, "*"),
+		},
+	})
+
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "explicitDeny", got.results()[0].Decision)
+	require.NotNil(t, got.results()[0].BoundaryDetail)
+	assert.True(t, got.results()[0].BoundaryDetail.Allowed)
+	assert.NotEmpty(t, got.results()[0].MatchedStatements,
+		"the deny statement decided, so it must still be named")
+}
+
+// TestSimulatePrincipalPolicy_UsesTheEntitysStoredBoundary covers the other half of
+// the boundary rule.
+//
+// AWS: "if a permissions boundary is attached to an entity and you pass in a different
+// permissions boundary policy using this parameter, then the new permissions boundary
+// policy is used for the simulation." So with no PermissionsBoundaryPolicyInputList the
+// entity's own attached boundary applies, and with one it does not.
+func TestSimulatePrincipalPolicy_UsesTheEntitysStoredBoundary(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	iamRequireOK(t, srv, "CreateUser", map[string]any{"UserName": "jill"})
+	iamRequireOK(t, srv, "PutUserPolicy", map[string]any{
+		"UserName":       "jill",
+		"PolicyName":     "s3full",
+		"PolicyDocument": iamPolicyJSON(t, "Allow", []string{"s3:*"}, "*"),
+	})
+	// AmazonS3ReadOnlyAccess as a boundary permits s3:Get*/List*/Describe* but not a
+	// write, so it caps the s3:* grant above.
+	iamRequireOK(t, srv, "PutUserPermissionsBoundary", map[string]any{
+		"UserName":            "jill",
+		"PermissionsBoundary": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+	})
+
+	got := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+		"ActionNames":     []string{"s3:GetObject", "s3:PutObject"},
+	})
+
+	assert.Equal(t, map[string]string{
+		"s3:GetObject": "allowed",
+		"s3:PutObject": "implicitDeny",
+	}, got.decisions())
+	for _, r := range got.results() {
+		require.NotNil(t, r.BoundaryDetail, r.ActionName)
+		assert.Equal(t, r.ActionName == "s3:GetObject", r.BoundaryDetail.Allowed, r.ActionName)
+	}
+
+	// A supplied boundary overrides the stored one, so the same call with a permissive
+	// boundary allows the write.
+	overridden := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+		"ActionNames":     []string{"s3:PutObject"},
+		"PermissionsBoundaryPolicyInputList": []string{
+			iamPolicyJSON(t, "Allow", []string{"s3:*"}, "*"),
+		},
+	})
+	require.Len(t, overridden.results(), 1)
+	assert.Equal(t, "allowed", overridden.results()[0].Decision)
+}
+
+// TestSimulate_MissingContextValues covers #579's fourth point: a conditional grant
+// must not read as a clean answer.
+//
+// A statement ruled out only by a condition on a key the request supplied no value for
+// is the reportable case — the answer would change given a value — and without the list
+// a caller sees an implicitDeny with no indication of that.
+func TestSimulate_MissingContextValues(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	conditional := `{"Version":"2012-10-17","Statement":[{"Sid":"MFAOnly",` +
+		`"Effect":"Allow","Action":"s3:GetObject","Resource":"*",` +
+		`"Condition":{"Bool":{"aws:MultiFactorAuthPresent":"true"}}}]}`
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{conditional},
+	})
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "implicitDeny", got.results()[0].Decision)
+	assert.Equal(t, []string{"aws:MultiFactorAuthPresent"}, got.results()[0].MissingContextValues)
+
+	// A statement about a *different* action names keys that tell this caller nothing,
+	// so they must not be reported.
+	unrelated := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"ec2:RunInstances","Resource":"*",` +
+		`"Condition":{"StringEquals":{"ec2:InstanceType":"t3.micro"}}}]}`
+	quiet := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{unrelated},
+	})
+	require.Len(t, quiet.results(), 1)
+	assert.Empty(t, quiet.results()[0].MissingContextValues)
+}
+
+// TestSimulate_ContextEntriesSatisfyACondition is the other side of the same rule:
+// once the caller supplies the key, the conditional grant decides and the key is no
+// longer missing.
+//
+// It is also the only test of the nested query-protocol shape
+// ContextEntries.member.1.ContextKeyValues.member.1, which is why iamMemberStructs
+// keeps its suffixes verbatim (#639). There is no JSON-body form of a nested member
+// list at all, so this member can only be driven through a form body.
+func TestSimulate_ContextEntriesSatisfyACondition(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	conditional := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"s3:GetObject","Resource":"*",` +
+		`"Condition":{"Bool":{"aws:MultiFactorAuthPresent":"true"}}}]}`
+
+	got := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulateCustomPolicy", map[string]string{
+		"ActionNames.member.1":                              "s3:GetObject",
+		"PolicyInputList.member.1":                          conditional,
+		"ContextEntries.member.1.ContextKeyName":            "aws:MultiFactorAuthPresent",
+		"ContextEntries.member.1.ContextKeyValues.member.1": "true",
+		"ContextEntries.member.1.ContextKeyType":            "boolean",
+	}))
+
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "allowed", got.results()[0].Decision)
+	assert.Empty(t, got.results()[0].MissingContextValues,
+		"the caller supplied the key, so it is not missing")
+}
+
+// TestSimulate_CallerArnPopulatesPrincipalArn covers a condition key the simulation
+// determines for itself.
+//
+// A policy conditioned on aws:PrincipalArn would otherwise report the key as missing
+// when the caller had in fact told substrate what it is — through CallerArn, or through
+// PolicySourceArn, which CallerArn defaults to.
+func TestSimulate_CallerArnPopulatesPrincipalArn(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	iamRequireOK(t, srv, "CreateUser", map[string]any{"UserName": "jill"})
+	iamRequireOK(t, srv, "PutUserPolicy", map[string]any{
+		"UserName":   "jill",
+		"PolicyName": "selfonly",
+		"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Action":"s3:GetObject","Resource":"*","Condition":{"ArnEquals":` +
+			`{"aws:PrincipalArn":"arn:aws:iam::123456789012:user/jill"}}}]}`,
+	})
+
+	// CallerArn defaults to PolicySourceArn, so the condition is satisfied without the
+	// caller naming the key at all.
+	got := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+		"ActionNames":     []string{"s3:GetObject"},
+	})
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "allowed", got.results()[0].Decision)
+	assert.Empty(t, got.results()[0].MissingContextValues,
+		"the simulation knows the principal, so the key is not missing")
+
+	// A different CallerArn is a different principal, so the same policy no longer
+	// matches — which proves the value came from CallerArn rather than the key being
+	// ignored outright.
+	other := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+		"CallerArn":       "arn:aws:iam::123456789012:user/bob",
+		"ActionNames":     []string{"s3:GetObject"},
+	})
+	require.Len(t, other.results(), 1)
+	assert.Equal(t, "implicitDeny", other.results()[0].Decision)
+}
+
+// TestSimulate_ResourceArnsDefaultToStar covers the documented default: "If this
+// parameter is not provided, then the value defaults to * (all resources)."
+//
+// A default of "" instead would silently match every statement regardless of its
+// Resource element, because resourceMatches treats an empty resource as a match — so
+// the decision, not just the reported EvalResourceName, is asserted here.
+func TestSimulate_ResourceArnsDefaultToStar(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames": []string{"s3:GetObject"},
+		"PolicyInputList": []string{
+			iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "arn:aws:s3:::other/*"),
+		},
+	})
+
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "*", got.results()[0].ResourceName)
+	// The policy grants the action only on some *other* bucket, so a simulation
+	// against "*" is not allowed. Were the default "", it would be.
+	assert.Equal(t, "implicitDeny", got.results()[0].Decision)
+}
+
+// TestSimulate_EveryActionAgainstEveryResource covers the cross product the reference
+// describes: each API in ActionNames is evaluated against each resource in
+// ResourceArns.
+func TestSimulate_EveryActionAgainstEveryResource(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames": []string{"s3:GetObject", "s3:PutObject"},
+		"ResourceArns": []string{
+			"arn:aws:s3:::allowed/key",
+			"arn:aws:s3:::denied/key",
+		},
+		"PolicyInputList": []string{
+			iamPolicyJSON(t, "Allow", []string{"s3:*"}, "arn:aws:s3:::allowed/*"),
+		},
+	})
+
+	require.Len(t, got.results(), 4, "two actions × two resources")
+	type pair struct{ action, resource string }
+	decisions := make(map[pair]string, 4)
+	for _, r := range got.results() {
+		decisions[pair{r.ActionName, r.ResourceName}] = r.Decision
+	}
+	assert.Equal(t, map[pair]string{
+		{"s3:GetObject", "arn:aws:s3:::allowed/key"}: "allowed",
+		{"s3:GetObject", "arn:aws:s3:::denied/key"}:  "implicitDeny",
+		{"s3:PutObject", "arn:aws:s3:::allowed/key"}: "allowed",
+		{"s3:PutObject", "arn:aws:s3:::denied/key"}:  "implicitDeny",
+	}, decisions)
+}
+
+// TestSimulate_Pagination covers MaxItems and the Marker cursor over the flattened
+// result list.
+//
+// MaxItems defaults to 100 and is valid 1–1000, from the model's maxItemsType and the
+// reference's "the number of items defaults to 100".
+func TestSimulate_Pagination(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	body := map[string]any{
+		"ActionNames":     []string{"s3:GetObject", "s3:PutObject", "s3:DeleteObject"},
+		"PolicyInputList": []string{iamPolicyJSON(t, "Allow", []string{"s3:*"}, "*")},
+		"MaxItems":        2,
+	}
+	first := iamSimulate(t, srv, "SimulateCustomPolicy", body)
+	require.Len(t, first.results(), 2)
+	truncated, marker := first.page()
+	assert.True(t, truncated)
+	require.NotEmpty(t, marker)
+
+	body["Marker"] = marker
+	second := iamSimulate(t, srv, "SimulateCustomPolicy", body)
+	require.Len(t, second.results(), 1)
+	secondTruncated, secondMarker := second.page()
+	assert.False(t, secondTruncated)
+	assert.Empty(t, secondMarker)
+
+	// The pages must be disjoint and cover every action — a cursor that silently
+	// restarted would still produce the counts above.
+	seen := map[string]bool{}
+	for _, r := range append(first.results(), second.results()...) {
+		assert.False(t, seen[r.ActionName], "%s appeared twice", r.ActionName)
+		seen[r.ActionName] = true
+	}
+	assert.Len(t, seen, 3)
+
+	// With no MaxItems every result fits on one page, because the default is 100.
+	delete(body, "MaxItems")
+	delete(body, "Marker")
+	all := iamSimulate(t, srv, "SimulateCustomPolicy", body)
+	assert.Len(t, all.results(), 3)
+	allTruncated, _ := all.page()
+	assert.False(t, allTruncated)
+}
+
+// TestSimulate_ActionsAreNotCappedAt25 is the direct form of the correction #579
+// needs.
+//
+// #579 asserted that a call "caps at 25 actions"; no action-count limit appears in the
+// API reference or the model, so modeling one would refuse requests AWS accepts. Thirty
+// actions in one call therefore get thirty answers on one page — which also pins
+// MaxItems' default at 100 rather than 25, since a default of 25 would truncate here.
+func TestSimulate_ActionsAreNotCappedAt25(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	actions := make([]string, 0, 30)
+	for i := 0; i < 30; i++ {
+		actions = append(actions, fmt.Sprintf("s3:GetObjectVersion%d", i))
+	}
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     actions,
+		"PolicyInputList": []string{iamPolicyJSON(t, "Allow", []string{"s3:*"}, "*")},
+	})
+	require.Len(t, got.results(), 30)
+	truncated, _ := got.page()
+	assert.False(t, truncated)
+}
+
+// TestSimulate_RefusesBadInput covers the InvalidInput arms and the one NoSuchEntity.
+//
+// The NoSuchEntity case is asymmetric on purpose: SimulateCustomPolicy resolves no
+// entity, so the model does not declare the error for it, and answering it there would
+// report a failure to find something the operation never looks for.
+func TestSimulate_RefusesBadInput(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	iamRequireOK(t, srv, "CreateUser", map[string]any{"UserName": "jill"})
+
+	allowAll := iamPolicyJSON(t, "Allow", []string{"s3:*"}, "*")
+
+	tests := []struct {
+		name      string
+		operation string
+		body      map[string]any
+		wantCode  string
+		wantHTTP  int
+	}{
+		{
+			name:      "the principal form requires PolicySourceArn",
+			operation: "SimulatePrincipalPolicy",
+			body:      map[string]any{"ActionNames": []string{"s3:GetObject"}},
+			wantCode:  "InvalidInput",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			name:      "the principal form requires ActionNames",
+			operation: "SimulatePrincipalPolicy",
+			body: map[string]any{
+				"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:      "the custom form requires PolicyInputList",
+			operation: "SimulateCustomPolicy",
+			body:      map[string]any{"ActionNames": []string{"s3:GetObject"}},
+			wantCode:  "InvalidInput",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			name:      "the custom form requires ActionNames",
+			operation: "SimulateCustomPolicy",
+			body:      map[string]any{"PolicyInputList": []string{allowAll}},
+			wantCode:  "InvalidInput",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			// "Each operation must include the service identifier, such as
+			// iam:CreateUser." An unprefixed action can never match a statement, so
+			// answering implicitDeny would report a decision about a malformed request.
+			name:      "an action with no service prefix is refused",
+			operation: "SimulateCustomPolicy",
+			body: map[string]any{
+				"ActionNames":     []string{"GetObject"},
+				"PolicyInputList": []string{allowAll},
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			// The reference reserves PolicyEvaluation 500 for a policy that "could not
+			// be successfully evaluated"; a document that will not parse is the
+			// caller's error.
+			name:      "an unparseable policy is the caller's error, not PolicyEvaluation",
+			operation: "SimulateCustomPolicy",
+			body: map[string]any{
+				"ActionNames":     []string{"s3:GetObject"},
+				"PolicyInputList": []string{"{not json"},
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:      "MaxItems above the range is refused",
+			operation: "SimulateCustomPolicy",
+			body: map[string]any{
+				"ActionNames":     []string{"s3:GetObject"},
+				"PolicyInputList": []string{allowAll},
+				"MaxItems":        1001,
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:      "MaxItems below the range is refused",
+			operation: "SimulateCustomPolicy",
+			body: map[string]any{
+				"ActionNames":     []string{"s3:GetObject"},
+				"PolicyInputList": []string{allowAll},
+				"MaxItems":        -1,
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:      "an ARN that names no IAM entity type is refused",
+			operation: "SimulatePrincipalPolicy",
+			body: map[string]any{
+				"PolicySourceArn": "arn:aws:s3:::my-bucket",
+				"ActionNames":     []string{"s3:GetObject"},
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:      "an entity ARN with no name is refused",
+			operation: "SimulatePrincipalPolicy",
+			body: map[string]any{
+				"PolicySourceArn": "arn:aws:iam::123456789012:user",
+				"ActionNames":     []string{"s3:GetObject"},
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:      "an unknown principal is NoSuchEntity",
+			operation: "SimulatePrincipalPolicy",
+			body: map[string]any{
+				"PolicySourceArn": "arn:aws:iam::123456789012:user/ghost",
+				"ActionNames":     []string{"s3:GetObject"},
+			},
+			wantCode: "NoSuchEntity",
+			wantHTTP: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := iamRequest(t, srv, tc.operation, tc.body)
+			require.Equal(t, tc.wantHTTP, resp.StatusCode)
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, tc.wantCode, result["__type"])
+		})
+	}
+}
+
+// TestSimulateCustomPolicy_HasNoNoSuchEntityPath pins the asymmetry directly: the
+// custom form ignores PolicySourceArn entirely, so naming a nonexistent entity cannot
+// produce NoSuchEntity.
+func TestSimulateCustomPolicy_HasNoNoSuchEntityPath(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/ghost",
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "*")},
+	})
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "allowed", got.results()[0].Decision)
+}
+
+// TestSimulatePrincipalPolicy_RoleAndGroupSources covers the other two entity types
+// the reference names: "The entity can be an IAM user, group, or role."
+//
+// A role must ignore group memberships — nothing calls AWS *as* a group, so a role's
+// permissions never include one — and a group simulated directly reports its own
+// policies.
+func TestSimulatePrincipalPolicy_RoleAndGroupSources(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	iamRequireOK(t, srv, "CreateRole", map[string]any{
+		"RoleName":                 "worker",
+		"AssumeRolePolicyDocument": `{"Version":"2012-10-17","Statement":[]}`,
+	})
+	iamRequireOK(t, srv, "PutRolePolicy", map[string]any{
+		"RoleName":       "worker",
+		"PolicyName":     "readonly",
+		"PolicyDocument": iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "*"),
+	})
+	iamRequireOK(t, srv, "CreateGroup", map[string]any{"GroupName": "devs"})
+	iamRequireOK(t, srv, "PutGroupPolicy", map[string]any{
+		"GroupName":      "devs",
+		"PolicyName":     "listers",
+		"PolicyDocument": iamPolicyJSON(t, "Allow", []string{"s3:ListBucket"}, "*"),
+	})
+
+	role := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:role/worker",
+		"ActionNames":     []string{"s3:GetObject", "s3:ListBucket"},
+	})
+	assert.Equal(t, map[string]string{
+		"s3:GetObject":  "allowed",
+		"s3:ListBucket": "implicitDeny",
+	}, role.decisions())
+
+	group := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:group/devs",
+		"ActionNames":     []string{"s3:GetObject", "s3:ListBucket"},
+	})
+	assert.Equal(t, map[string]string{
+		"s3:GetObject":  "implicitDeny",
+		"s3:ListBucket": "allowed",
+	}, group.decisions())
+	listed := group.byAction()["s3:ListBucket"]
+	require.Len(t, listed.MatchedStatements, 1)
+	assert.Equal(t, "listers", listed.MatchedStatements[0].SourcePolicyID)
+}
+
+// TestSimulatePrincipalPolicy_AdministratorAccessNamesItself pins that the simulator
+// does *not* take loadPoliciesForPrincipal's AdministratorAccess shortcut.
+//
+// That fast path synthesizes an allow-all document, which has no name — and the whole
+// output of a simulation is which policy decided. The catalog document is evaluated
+// instead, so the answer is the same and the report is usable.
+func TestSimulatePrincipalPolicy_AdministratorAccessNamesItself(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	iamRequireOK(t, srv, "CreateUser", map[string]any{"UserName": "admin"})
+	iamRequireOK(t, srv, "AttachUserPolicy", map[string]any{
+		"UserName":  "admin",
+		"PolicyArn": "arn:aws:iam::aws:policy/AdministratorAccess",
+	})
+
+	got := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/admin",
+		"ActionNames":     []string{"ec2:TerminateInstances"},
+	})
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "allowed", got.results()[0].Decision)
+	require.Len(t, got.results()[0].MatchedStatements, 1)
+	assert.Equal(t, "AdministratorAccess", got.results()[0].MatchedStatements[0].SourcePolicyID)
+}
+
+// TestSimulatePrincipalPolicy_UnbundledManagedPolicyContributesNothing covers the
+// catalog gap honestly.
+//
+// Substrate bundles 52 of the ~1,200 AWS managed policies, so an attachment naming an
+// unbundled one has an unknown document. It must contribute no statements rather than a
+// guess, and it must not fail the simulation: an attach of an unbundled-but-real ARN
+// succeeds, so a simulation of the resulting user has to answer something.
+func TestSimulatePrincipalPolicy_UnbundledManagedPolicyContributesNothing(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	// AmazonAthenaFullAccess is a real AWS managed policy the catalog does not carry,
+	// so nothing resolves its document. Asserted rather than assumed, because a later
+	// release adding it to the catalog would otherwise turn this test green for the
+	// wrong reason.
+	const unbundled = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
+	_, bundled := emulator.GetManagedPolicy(unbundled)
+	require.False(t, bundled, "this test needs a policy the catalog does not carry")
+
+	iamRequireOK(t, srv, "CreateUser", map[string]any{"UserName": "jill"})
+	iamRequireOK(t, srv, "AttachUserPolicy", map[string]any{
+		"UserName":  "jill",
+		"PolicyArn": unbundled,
+	})
+
+	got := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+		"ActionNames":     []string{"athena:StartQueryExecution"},
+	})
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "implicitDeny", got.results()[0].Decision)
+	assert.Empty(t, got.results()[0].MatchedStatements)
+}
+
+// TestSimulatePrincipalPolicy_CustomerManagedPolicyIsResolved covers the other half of
+// the resolution order: a policy created through CreatePolicy resolves from state, with
+// its own name reported.
+func TestSimulatePrincipalPolicy_CustomerManagedPolicyIsResolved(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	iamRequireOK(t, srv, "CreateUser", map[string]any{"UserName": "jill"})
+
+	// The ARN is read back rather than constructed: an unsigned request resolves to
+	// the fallback account, so a hardcoded 123456789012 ARN would attach an
+	// unresolvable policy and the test would pass for the wrong reason — an attach of
+	// an unknown ARN succeeds by design.
+	created := iamRequest(t, srv, "CreatePolicy", map[string]any{
+		"PolicyName":     "listbuckets",
+		"PolicyDocument": iamPolicyJSON(t, "Allow", []string{"s3:ListAllMyBuckets"}, "*"),
+	})
+	raw, err := io.ReadAll(created.Body)
+	require.NoError(t, err)
+	require.NoError(t, created.Body.Close())
+	require.Equal(t, http.StatusOK, created.StatusCode, "body: %s", raw)
+	var policy struct {
+		ARN string `xml:"CreatePolicyResult>Policy>Arn"`
+	}
+	require.NoError(t, xml.Unmarshal(raw, &policy))
+	require.NotEmpty(t, policy.ARN)
+
+	iamRequireOK(t, srv, "AttachUserPolicy", map[string]any{
+		"UserName":  "jill",
+		"PolicyArn": policy.ARN,
+	})
+
+	got := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+		"ActionNames":     []string{"s3:ListAllMyBuckets"},
+	})
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "allowed", got.results()[0].Decision)
+	require.Len(t, got.results()[0].MatchedStatements, 1)
+	assert.Equal(t, "listbuckets", got.results()[0].MatchedStatements[0].SourcePolicyID)
+}
+
+// TestSimulatePrincipalPolicy_PolicyInputListAddsToTheEntitys covers the combination:
+// the principal form takes PolicyInputList too, and those documents are evaluated
+// *alongside* the entity's own rather than replacing them.
+//
+// This is how a consumer asks "what would happen if I also attached this?", which is
+// why the member exists on both operations.
+func TestSimulatePrincipalPolicy_PolicyInputListAddsToTheEntitys(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	iamRequireOK(t, srv, "CreateUser", map[string]any{"UserName": "jill"})
+	iamRequireOK(t, srv, "PutUserPolicy", map[string]any{
+		"UserName":       "jill",
+		"PolicyName":     "getter",
+		"PolicyDocument": iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "*"),
+	})
+
+	got := iamSimulate(t, srv, "SimulatePrincipalPolicy", map[string]any{
+		"PolicySourceArn": "arn:aws:iam::123456789012:user/jill",
+		"ActionNames":     []string{"s3:GetObject", "s3:PutObject"},
+		"PolicyInputList": []string{
+			iamPolicyJSON(t, "Allow", []string{"s3:PutObject"}, "*"),
+		},
+	})
+	assert.Equal(t, map[string]string{
+		"s3:GetObject": "allowed",
+		"s3:PutObject": "allowed",
+	}, got.decisions())
+
+	// Each grant is still attributed to the document it came from, which is what makes
+	// the "if I also attached this" answer readable.
+	byAction := got.byAction()
+	require.Len(t, byAction["s3:GetObject"].MatchedStatements, 1)
+	assert.Equal(t, "getter", byAction["s3:GetObject"].MatchedStatements[0].SourcePolicyID)
+	require.Len(t, byAction["s3:PutObject"].MatchedStatements, 1)
+	assert.Equal(t, "PolicyInputList.1", byAction["s3:PutObject"].MatchedStatements[0].SourcePolicyID)
+}
+
+// TestSimulate_OperationsAreAuthorized covers the authorization arm on both
+// operations.
+//
+// iam_managed.go grants iam:SimulateCustomPolicy and iam:SimulatePrincipalPolicy in
+// its bundled policies, so a caller without them must be refused — otherwise the grant
+// means nothing.
+func TestSimulate_OperationsAreAuthorized(t *testing.T) {
+	t.Parallel()
+
+	for _, op := range []string{"SimulatePrincipalPolicy", "SimulateCustomPolicy"} {
+		t.Run(op, func(t *testing.T) {
+			t.Parallel()
+			srv := newTrustPolicyTestServer(t)
+			accessKey := trustSetupCallerWithoutAssume(t, srv, "ungranted")
+
+			resp := iamCallAs(t, srv, accessKey, op, map[string]any{
+				"PolicySourceArn": "arn:aws:iam::123456789012:user/ungranted",
+				"ActionNames":     []string{"s3:GetObject"},
+				"PolicyInputList": []string{`{"Version":"2012-10-17","Statement":[]}`},
+			})
+			require.Equal(t, http.StatusForbidden, resp.StatusCode)
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, emulator.IAMAccessDeniedCodeForTest, result["__type"])
+		})
+	}
+}
+
+// TestSimulate_MarkerEdges covers the cursor's tolerant arms.
+//
+// paginateIAMKeys treats an undecodable Marker as the start of the list rather than
+// as an error, and the simulator matches it: refusing a cursor a caller
+// round-tripped would be worse than restarting a page. A cursor past the end
+// likewise returns an empty final page rather than indexing out of range.
+func TestSimulate_MarkerEdges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		marker     string
+		wantCount  int
+		wantAction string
+	}{
+		{
+			name:       "a marker substrate did not mint restarts the list",
+			marker:     "not-base64!!",
+			wantCount:  1,
+			wantAction: "s3:GetObject",
+		},
+		{
+			name:       "base64 of a non-number restarts the list",
+			marker:     base64.StdEncoding.EncodeToString([]byte("ninety")),
+			wantCount:  1,
+			wantAction: "s3:GetObject",
+		},
+		{
+			name:      "a marker past the end is an empty final page",
+			marker:    base64.StdEncoding.EncodeToString([]byte("99")),
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newIAMTestServer(t)
+
+			got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+				"ActionNames":     []string{"s3:GetObject", "s3:PutObject"},
+				"PolicyInputList": []string{iamPolicyJSON(t, "Allow", []string{"s3:*"}, "*")},
+				"MaxItems":        1,
+				"Marker":          tc.marker,
+			})
+			require.Len(t, got.results(), tc.wantCount)
+			if tc.wantAction != "" {
+				assert.Equal(t, tc.wantAction, got.results()[0].ActionName)
+			}
+			if tc.wantCount == 0 {
+				truncated, marker := got.page()
+				assert.False(t, truncated)
+				assert.Empty(t, marker)
+			}
+		})
+	}
+}
+
+// TestSimulate_ContextEntryWithNoValueIsStillSet pins the present-vs-absent
+// distinction on a context key, the same one iamMemberList is careful about.
+//
+// A key named with no ContextKeyValues was supplied by the caller, so it must not be
+// reported as missing — the Null operator exists precisely to test for an empty
+// value, and reporting it as missing would tell the caller to supply what they
+// already did.
+func TestSimulate_ContextEntryWithNoValueIsStillSet(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	nullConditioned := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"s3:GetObject","Resource":"*",` +
+		`"Condition":{"Null":{"aws:TokenIssueTime":"true"}}}]}`
+
+	got := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulateCustomPolicy", map[string]string{
+		"ActionNames.member.1":                   "s3:GetObject",
+		"PolicyInputList.member.1":               nullConditioned,
+		"ContextEntries.member.1.ContextKeyName": "aws:TokenIssueTime",
+	}))
+
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "allowed", got.results()[0].Decision,
+		"the key is set to the empty string, which is what Null:true tests for")
+	assert.Empty(t, got.results()[0].MissingContextValues)
+
+	// An entry with no ContextKeyName names nothing, so it contributes nothing rather
+	// than a key called "".
+	unnamed := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulateCustomPolicy", map[string]string{
+		"ActionNames.member.1":                              "s3:GetObject",
+		"PolicyInputList.member.1":                          nullConditioned,
+		"ContextEntries.member.1.ContextKeyValues.member.1": "whatever",
+		"ContextEntries.member.1.ContextKeyType":            "string",
+		"ContextEntries.member.2.ContextKeyName":            "aws:TokenIssueTime",
+		"ContextEntries.member.2.ContextKeyValues.member.1": "2026-01-01T00:00:00Z",
+		"ContextEntries.member.2.ContextKeyType":            "date",
+	}))
+	require.Len(t, unnamed.results(), 1)
+	assert.Equal(t, "implicitDeny", unnamed.results()[0].Decision,
+		"the named key now holds a value, so Null:true is false")
+}
+
+// TestSimulate_ResourceOwnerPopulatesResourceAccount covers the second condition key
+// the simulation derives, for the same reason as aws:PrincipalArn: the caller told
+// substrate the account through ResourceOwner, so reporting the key as missing would
+// be wrong.
+func TestSimulate_ResourceOwnerPopulatesResourceAccount(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	sameAccount := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"s3:GetObject","Resource":"*","Condition":{"StringEquals":` +
+		`{"aws:ResourceAccount":"123456789012"}}}]}`
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{sameAccount},
+		"ResourceOwner":   "123456789012",
+	})
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "allowed", got.results()[0].Decision)
+	assert.Empty(t, got.results()[0].MissingContextValues)
+
+	// Without it the key is genuinely unknown, so it is reported rather than guessed
+	// from the request's own account.
+	absent := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{sameAccount},
+	})
+	require.Len(t, absent.results(), 1)
+	assert.Equal(t, "implicitDeny", absent.results()[0].Decision)
+	assert.Equal(t, []string{"aws:ResourceAccount"}, absent.results()[0].MissingContextValues)
+}
+
+// TestSimulateWire_OverTheQueryProtocol drives both operations the way a client does.
+//
+// Every list parameter these operations take arrives as prefix.member.N, so before
+// #639 nothing reached the handler at all — ActionNames, a *required* member, was nil
+// on every real request. And an operation that is implemented but unroutable answers
+// InvalidAction with a fully green unit suite, which was #636. This test is the one
+// that catches either without leaving the package.
+func TestSimulateWire_OverTheQueryProtocol(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	for _, setup := range []struct {
+		operation string
+		params    map[string]string
+	}{
+		{"CreateUser", map[string]string{"UserName": "jill"}},
+		{"PutUserPolicy", map[string]string{
+			"UserName":   "jill",
+			"PolicyName": "nodelete",
+			"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Deny",` +
+				`"Action":"s3:DeleteObject","Resource":"*"}]}`,
+		}},
+	} {
+		resp := iamFormRequest(t, srv, setup.operation, setup.params)
+		require.Equal(t, http.StatusOK, resp.StatusCode, setup.operation)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	principal := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulatePrincipalPolicy",
+		map[string]string{
+			"PolicySourceArn":       "arn:aws:iam::123456789012:user/jill",
+			"ActionNames.member.1":  "s3:DeleteObject",
+			"ActionNames.member.2":  "s3:GetObject",
+			"ResourceArns.member.1": "arn:aws:s3:::my-bucket/key",
+		}))
+	assert.Equal(t, map[string]string{
+		"s3:DeleteObject": "explicitDeny",
+		"s3:GetObject":    "implicitDeny",
+	}, principal.decisions())
+
+	custom := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulateCustomPolicy",
+		map[string]string{
+			"ActionNames.member.1": "s3:GetObject",
+			"PolicyInputList.member.1": `{"Version":"2012-10-17","Statement":` +
+				`[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`,
+		}))
+	require.Len(t, custom.results(), 1)
+	assert.Equal(t, "allowed", custom.results()[0].Decision)
+
+	// MaxItems is a scalar over the same wire, so it arrives as a *string* — the #642
+	// half of the same defect. A page of one out of two proves it was read.
+	paged := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulateCustomPolicy",
+		map[string]string{
+			"ActionNames.member.1": "s3:GetObject",
+			"ActionNames.member.2": "s3:PutObject",
+			"PolicyInputList.member.1": `{"Version":"2012-10-17","Statement":` +
+				`[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`,
+			"MaxItems": "1",
+		}))
+	require.Len(t, paged.results(), 1)
+	truncated, marker := paged.page()
+	assert.True(t, truncated)
+	assert.NotEmpty(t, marker)
+}


### PR DESCRIPTION
Closes #579

`SimulatePrincipalPolicy` and `SimulateCustomPolicy` are the only AWS APIs that decide
whether a principal may do X to Y *without* doing X to Y, and neither was implemented. So
the one code path in a consumer that decides whether to proceed at all was the one path
with no emulator coverage. `iam_managed.go` already granted `iam:SimulatePrincipalPolicy`
and `iam:SimulateCustomPolicy` in its bundled policies, so substrate advertised permission
for operations that answered `InvalidAction`.

## One evaluator, not two

Both operations run **the same evaluator the request gate enforces with**. `Evaluate`
already implemented the IAM algorithm and already produced exactly the three outcomes the
API reports, so this exposes existing evaluation over the wire rather than writing a second
one. That is the property worth having, and it is tested directly: one user, one policy and
two actions go through the simulator *and* through the enforced path, and the decisions must
agree. A simulated decision that could disagree with an enforced one would be worse than no
simulator at all, because a consumer would trust the preflight and then be refused.

## The three-way distinction is the feature

`allowed`, `explicitDeny` and `implicitDeny` are reported separately. Collapsing them would
look like coverage while telling a consumer the wrong thing: an assertion that "the policy
explicitly forbids this" would pass on what is really a missing grant. The decisive test
puts a group managed allow, an inline deny and an ungranted action in **one response**, so
a handler returning a uniform answer fails.

## What the response reports

- `MatchedStatements` gained the AWS `Statement` shape (`SourcePolicyId`,
  `SourcePolicyType`), so a caller learns *which* policy decided — the whole output of a
  simulation. `Evaluate` therefore had to learn a document's provenance:
  `SourcedPolicyDocument` + `EvaluateSourced` carry it, and `Evaluate` delegates with its
  signature untouched for `authz.go`, `sts_plugin.go` and 737 lines of existing tests.
- `MissingContextValues` names every condition key a matching-but-for-the-condition
  statement tested and the request had no value for. Without it a conditional grant reads
  as a clean `implicitDeny` with no indication the answer would change. A key present with
  an empty value is *set*, not missing — the `Null` operator exists to test absence.
- A permissions boundary that does not allow flips an `allowed` to an **implicit** deny and
  reports `AllowedByPermissionsBoundary=false`; a boundary caps what is reachable rather
  than denying by name, and an identity policy's explicit deny stays explicit. A supplied
  boundary replaces the entity's stored one, per the reference.
- `CallerArn` defaults to `PolicySourceArn` and populates `aws:PrincipalArn`;
  `ResourceOwner` populates `aws:ResourceAccount`; an explicit `ContextEntry` wins over
  both. `ResourceArns` defaults to `["*"]`, every action is evaluated against every
  resource, `MaxItems` defaults to 100 (valid 1–1000).

## Deliberately not evaluated

Stated in the code and owed to `docs/services.md` in the docs PR, rather than faked:

- **SCPs.** Organizations stores them and `CheckAccess` never consults them either, so
  simulating them would report a bound substrate does not enforce.
  `OrganizationsDecisionDetail` is therefore **absent** rather than present-and-false — a
  test asserts its absence, because present-and-false is a claim.
- **`StartPosition`/`EndPosition`.** Offsets into the document *as submitted*; substrate
  stores a parsed `PolicyDocument`, so any offset would be fabricated.
- **`ResourceHandlingOption`, `PolicyExclusionList`, `EvalDecisionDetails`,
  `ResourceSpecificResults`** — cross-account constructs.
- An attached AWS managed policy substrate does not bundle contributes no statements rather
  than a guess, and does not fail the simulation.

## Correction to the issue

**There is no 25-action cap.** #579 asserted one; no action-count limit appears in the API
reference or the model, and modelling it would refuse requests AWS accepts. A test drives
30 actions through one call and expects 30 answers on one page — which also pins `MaxItems`'
default at 100 rather than 25.

## Provenance

`SourcePolicyType` emits `IAM Policy` / `Resource Policy`, from the reference's **sample
responses**, which diverge from the model's `PolicySourceType` enum
(`user`/`group`/`role`/`aws-managed`/`user-managed`/`resource`/`none`). The doc values are
what an SDK actually receives, so those are what substrate emits; the divergence is
commented at the constants. `SourcePolicyId` being a policy *name* rather than an ARN comes
from the same samples.

## Verification

- `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — 0 issues
- `make test` (race) green; `emulator` coverage 82.5%, every function in
  `iam_simulate.go` ≥81%
- `TestSimulateWire_OverTheQueryProtocol` posts a genuine urlencoded form body, since every
  parameter these operations take is a `.member.N` list and `MaxItems` arrives as a
  *string* — the #639/#642 shapes. An unroutable operation (#636) is caught here too.
- `ContextEntries.member.1.ContextKeyValues.member.1` has no JSON-body form at all, so the
  nested-member tests are form-body only.