### PR TITLE
feat(iam): a managed policy's document is readable over the wire (#498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one. Both refusals exist for the same reason: a delete that skipped them would leave one
   side of the membership index naming an entity that no longer exists, and that dangling
   membership is read by `loadPoliciesForPrincipal` on every request.
+- **A managed policy's document is readable over the wire: `GetPolicyVersion` and
+  `ListPolicyVersions`** (#498). `GetPolicy` returns metadata only — which matches AWS,
+  where the document lives behind `GetPolicyVersion` — and substrate routed no version
+  operation at all. So the 52 bundled documents, several transcribed from their AWS
+  reference pages, were readable by a Go caller through `GetManagedPolicy` and by no
+  consumer over HTTP: a test could attach `AmazonS3ReadOnlyAccess` and never see what it
+  granted. This is also what makes a simulated decision checkable — a caller who gets an
+  `implicitDeny` can now read the policy that failed to grant it.
+
+  The document is percent-encoded to **RFC 3986**, which the reference specifies and which
+  neither stdlib escaper produces. `url.QueryEscape` encodes a space as `+`, and a decoder
+  that follows RFC 3986 reads that back as a literal plus — silently corrupting any
+  document containing a space, which is most of them. `url.PathEscape` leaves `:` and
+  several sub-delimiters bare, so an ARN in a `Resource` comes back differently from what
+  AWS sends. Substrate escapes byte-at-a-time to the unreserved set per §2.5. Most SDKs
+  decode this automatically, so getting it wrong breaks the raw HTTP client and nobody
+  else, which is exactly the kind of gap that only surfaces in production; a test asserts
+  the value round-trips through a strict decoder.
+
+  Substrate models **one version per policy**: `IAMPolicy` holds a single document and a
+  `DefaultVersionID`, and no `CreatePolicyVersion`/`SetDefaultPolicyVersion` exists. So a
+  `VersionId` that is not the policy's default answers `NoSuchEntity` rather than being
+  served the default's document under the requested name — a consumer pinning a version
+  would otherwise be told a document is `v1` that AWS reports as something else. The
+  bundled catalog makes this immediately reachable rather than hypothetical:
+  `AmazonSSMManagedInstanceCore` reports `v2` and `AWSLambdaVPCAccessExecutionRole`
+  reports `v3`, because AWS has edited them since publication. `ListPolicyVersions`
+  therefore returns exactly one member, and both facts are stated in `docs/services.md`.
+
+  `ListPolicyVersions` **omits** `Document`, per the model, which documents that member as
+  returned by `GetPolicyVersion` and `GetAccountAuthorizationDetails` and not by the list
+  or create calls. Sending it would hand a caller a member AWS does not, which is the kind
+  of difference that makes a consumer work against substrate and fail against AWS. A
+  malformed `VersionId` is `InvalidInput` and is refused *before* the policy is resolved,
+  because the parameter is wrong whether or not the policy exists — answering
+  `NoSuchEntity` would send the caller looking for a policy that is right there.
 
 ### Changed
 - **A group's policies now apply to its members' requests** through `CheckAccess`. AWS

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -126,6 +126,10 @@ func (p *IAMPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.deletePolicy(ctx, req)
 	case "ListPolicies":
 		return p.listPolicies(ctx, req)
+	case "GetPolicyVersion":
+		return p.getPolicyVersion(ctx, req)
+	case "ListPolicyVersions":
+		return p.listPolicyVersions(ctx, req)
 
 	case "CreateAccessKey":
 		return p.createAccessKey(ctx, req)

--- a/emulator/iam_policy_versions.go
+++ b/emulator/iam_policy_versions.go
@@ -1,0 +1,267 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// Managed-policy versions: GetPolicyVersion and ListPolicyVersions (#498).
+//
+// Before these, a managed policy's *document* was not observable over the wire at all.
+// GetPolicy returns metadata only — PolicyId, PolicyName, Arn, Path, DefaultVersionId,
+// AttachmentCount, CreateDate, UpdateDate — which matches AWS, and the document lives
+// behind GetPolicyVersion. So the 52 bundled documents, several copied verbatim from
+// their AWS reference pages, were readable by a Go consumer through GetManagedPolicy and
+// by no consumer over HTTP.
+//
+// Substrate models exactly one version per policy: IAMPolicy holds a single Document and
+// a DefaultVersionID, and CreatePolicyVersion/SetDefaultPolicyVersion/
+// DeletePolicyVersion do not exist. That shapes both operations, and the shape is stated
+// rather than papered over — see iamPolicyVersionFor.
+
+// iamPolicyVersionIDPattern is policyVersionIdType from the API model:
+// "v[1-9][0-9]*(\.[A-Za-z0-9-]*)?".
+//
+// Anchored, because the model's pattern constrains the whole value — an unanchored match
+// would accept "xxv1yy", which no client sends and which would then be compared against
+// a real version ID and reported as NoSuchEntity rather than as the malformed input it
+// is.
+var iamPolicyVersionIDPattern = regexp.MustCompile(`^v[1-9][0-9]*(\.[A-Za-z0-9-]*)?$`)
+
+// getPolicyVersion returns one version of a managed policy, including its document.
+func (p *IAMPlugin) getPolicyVersion(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		PolicyArn string `json:"PolicyArn"`
+		VersionId string `json:"VersionId"` //nolint:revive,staticcheck // matches the API member name.
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", iamParamMessage(err), http.StatusBadRequest), nil
+	}
+	if params.PolicyArn == "" || params.VersionId == "" {
+		return iamErrorResponse("ValidationError",
+			"PolicyArn and VersionId are required", http.StatusBadRequest), nil
+	}
+	// The pattern is checked before the policy is looked up, because a malformed version
+	// ID is InvalidInput whether or not the policy exists: reporting NoSuchEntity for it
+	// would tell the caller to go looking for a policy when the parameter is the problem.
+	if !iamPolicyVersionIDPattern.MatchString(params.VersionId) {
+		return iamErrorResponse("InvalidInput",
+			fmt.Sprintf("The specified value for versionId is invalid. It must match the pattern %s.",
+				iamPolicyVersionIDPattern.String()),
+			http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:GetPolicyVersion", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	policy, errResp, err := p.resolveManagedPolicy(goCtx, params.PolicyArn)
+	if err != nil {
+		return nil, err
+	}
+	if errResp != nil {
+		return errResp, nil
+	}
+
+	version, ok := iamPolicyVersionFor(policy, params.VersionId)
+	if !ok {
+		return iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("Policy %s version %s does not exist or is not attachable.",
+				params.PolicyArn, params.VersionId),
+			http.StatusNotFound), nil
+	}
+
+	body, err := iamPolicyVersionXML(version, true)
+	if err != nil {
+		return nil, err
+	}
+	return iamXMLResponse(http.StatusOK, "GetPolicyVersion", "<PolicyVersion>"+body+"</PolicyVersion>")
+}
+
+// listPolicyVersions lists a managed policy's versions, without their documents.
+//
+// The document is deliberately absent: the model documents PolicyVersion.Document as
+// returned by GetPolicyVersion and GetAccountAuthorizationDetails and *not* by
+// ListPolicyVersions or CreatePolicyVersion. Emitting it here would hand a caller a
+// member AWS does not send, which is the kind of difference that makes a consumer work
+// against substrate and fail against AWS.
+func (p *IAMPlugin) listPolicyVersions(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var params struct {
+		PolicyArn string `json:"PolicyArn"`
+		Marker    string `json:"Marker"`
+		MaxItems  iamInt `json:"MaxItems"`
+	}
+	if err := parseIAMBody(req.Body, &params); err != nil {
+		return iamErrorResponse("ValidationError", iamParamMessage(err), http.StatusBadRequest), nil
+	}
+	if params.PolicyArn == "" {
+		return iamErrorResponse("ValidationError", "PolicyArn is required", http.StatusBadRequest), nil
+	}
+
+	goCtx := context.Background()
+	if err := p.authorize(goCtx, ctx, "iam:ListPolicyVersions", "*"); err != nil {
+		return iamErrorResponse(iamAccessDeniedCode, err.Error(), http.StatusForbidden), nil
+	}
+
+	policy, errResp, err := p.resolveManagedPolicy(goCtx, params.PolicyArn)
+	if err != nil {
+		return nil, err
+	}
+	if errResp != nil {
+		return errResp, nil
+	}
+
+	// One version, so Marker and MaxItems cannot truncate anything. They are still
+	// accepted and reported: a caller that pages this operation must see IsTruncated
+	// false rather than a missing element, and MaxItems must not fail the request the
+	// way it did before #642.
+	//
+	// The default version is taken directly rather than looked up by ID: passing
+	// policy.DefaultVersionID back through iamPolicyVersionFor would find nothing for a
+	// policy whose stored ID is empty, and the nil result would be encoded.
+	body, err := iamPolicyVersionXML(iamPolicyDefaultVersion(policy), false)
+	if err != nil {
+		return nil, err
+	}
+	return iamXMLResponse(http.StatusOK, "ListPolicyVersions",
+		"<Versions><member>"+body+"</member></Versions>"+
+			"<IsTruncated>"+iamBoolXML(false)+"</IsTruncated>")
+}
+
+// resolveManagedPolicy resolves a policy ARN to its entity, catalog before state — the
+// same order every other IAM caller uses, so a bundled and a customer-managed policy
+// behave alike.
+//
+// A returned errResp is an answer for the caller (NoSuchEntity); a returned error is
+// substrate's own failure.
+func (p *IAMPlugin) resolveManagedPolicy(goCtx context.Context, arn string) (*IAMPolicy, *AWSResponse, error) {
+	if mp, ok := GetManagedPolicy(arn); ok {
+		return mp, nil, nil
+	}
+	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get policy: %w", err)
+	}
+	if raw == nil {
+		return nil, iamErrorResponse("NoSuchEntity",
+			fmt.Sprintf("Policy %s was not found.", arn), http.StatusNotFound), nil
+	}
+	var policy IAMPolicy
+	if err := json.Unmarshal(raw, &policy); err != nil {
+		return nil, nil, fmt.Errorf("unmarshal policy: %w", err)
+	}
+	return &policy, nil, nil
+}
+
+// iamPolicyVersion is one row of a policy's version list.
+type iamPolicyVersion struct {
+	// policy is the policy the version belongs to, for its document and dates.
+	policy *IAMPolicy
+
+	// versionID is the version's own ID.
+	versionID string
+
+	// isDefault reports whether this is the policy's default version.
+	isDefault bool
+}
+
+// iamPolicyVersionFor returns the named version of policy, reporting whether it exists.
+//
+// Substrate stores one document per policy, so the only version that exists is the one
+// the policy names as its default. A request for any other version is NoSuchEntity, which
+// is the honest answer: claiming v1 exists when the policy reports v3 as its default
+// would hand back v3's document under v1's name, and a consumer pinning a version would
+// be told a document is v1 that AWS would report as something else. The bundled catalog
+// makes this immediately reachable — AmazonSSMManagedInstanceCore reports v2 and
+// AWSLambdaVPCAccessExecutionRole reports v3 — rather than hypothetical.
+func iamPolicyVersionFor(policy *IAMPolicy, versionID string) (iamPolicyVersion, bool) {
+	version := iamPolicyDefaultVersion(policy)
+	if version.policy == nil || versionID != version.versionID {
+		return iamPolicyVersion{}, false
+	}
+	return version, true
+}
+
+// iamPolicyDefaultVersion returns policy's default version — the only one substrate
+// stores.
+//
+// An empty DefaultVersionID falls back to "v1", which is what CreatePolicy assigns, so a
+// policy written by an older release still reports a version ID rather than an empty
+// element.
+func iamPolicyDefaultVersion(policy *IAMPolicy) iamPolicyVersion {
+	if policy == nil {
+		return iamPolicyVersion{}
+	}
+	versionID := policy.DefaultVersionID
+	if versionID == "" {
+		versionID = "v1"
+	}
+	return iamPolicyVersion{policy: policy, versionID: versionID, isDefault: true}
+}
+
+// iamPolicyVersionXML encodes a PolicyVersion, including the document only when
+// includeDocument is set.
+func iamPolicyVersionXML(version iamPolicyVersion, includeDocument bool) (string, error) {
+	var b strings.Builder
+	b.WriteString("<VersionId>")
+	b.WriteString(xmlEsc(version.versionID))
+	b.WriteString("</VersionId><IsDefaultVersion>")
+	b.WriteString(iamBoolXML(version.isDefault))
+	b.WriteString("</IsDefaultVersion><CreateDate>")
+	b.WriteString(version.policy.CreateDate.UTC().Format("2006-01-02T15:04:05Z"))
+	b.WriteString("</CreateDate>")
+
+	if includeDocument {
+		raw, err := json.Marshal(version.policy.Document)
+		if err != nil {
+			return "", fmt.Errorf("marshal policy document: %w", err)
+		}
+		b.WriteString("<Document>")
+		b.WriteString(xmlEsc(iamEscapeRFC3986(string(raw))))
+		b.WriteString("</Document>")
+	}
+	return b.String(), nil
+}
+
+// iamEscapeRFC3986 percent-encodes s, leaving only RFC 3986's unreserved characters
+// (ALPHA / DIGIT / "-" / "." / "_" / "~") as themselves.
+//
+// Neither stdlib escaper is this. url.QueryEscape encodes a space as "+", which a
+// URL-decoder that follows RFC 3986 reads back as a literal plus, silently corrupting a
+// document containing a space. url.PathEscape leaves ":" and several sub-delimiters bare,
+// so its output differs from what AWS sends. GetPolicyVersion's contract is specifically
+// "URL-encoded compliant with RFC 3986", and a consumer decoding the value with a strict
+// decoder is the case that has to work — most SDKs decode automatically, so a difference
+// here breaks the raw HTTP client and no one else, which is exactly the sort of gap that
+// only shows up in production.
+func iamEscapeRFC3986(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isRFC3986Unreserved(c) {
+			b.WriteByte(c)
+			continue
+		}
+		// Byte-at-a-time, so a multi-byte UTF-8 rune is encoded as its bytes, which is
+		// what RFC 3986 §2.5 requires.
+		fmt.Fprintf(&b, "%%%02X", c)
+	}
+	return b.String()
+}
+
+// isRFC3986Unreserved reports whether c is in RFC 3986's unreserved set.
+func isRFC3986Unreserved(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		return true
+	case c == '-', c == '.', c == '_', c == '~':
+		return true
+	}
+	return false
+}

--- a/emulator/iam_policy_versions_test.go
+++ b/emulator/iam_policy_versions_test.go
@@ -1,0 +1,470 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// GetPolicyVersion and ListPolicyVersions (#498).
+//
+// The point of these operations is that a managed policy's *document* becomes observable
+// over the wire. GetPolicy returns metadata only, matching AWS, so before this the 52
+// bundled documents — several copied verbatim from their AWS reference pages — were
+// readable by a Go consumer through GetManagedPolicy and by no consumer over HTTP.
+
+// policyVersionXML mirrors a PolicyVersion element. Document is a pointer so its
+// *absence* is observable: ListPolicyVersions must not send it.
+type policyVersionXML struct {
+	VersionID        string  `xml:"VersionId"`
+	IsDefaultVersion bool    `xml:"IsDefaultVersion"`
+	CreateDate       string  `xml:"CreateDate"`
+	Document         *string `xml:"Document"`
+}
+
+// policyVersionResponse decodes either operation's response, so one decoder serves both.
+type policyVersionResponse struct {
+	Version   *policyVersionXML  `xml:"GetPolicyVersionResult>PolicyVersion"`
+	Versions  []policyVersionXML `xml:"ListPolicyVersionsResult>Versions>member"`
+	Truncated bool               `xml:"ListPolicyVersionsResult>IsTruncated"`
+}
+
+// iamDecodePolicyVersion posts an IAM request, requires 200, and decodes it.
+func iamDecodePolicyVersion(t *testing.T, resp *http.Response) policyVersionResponse {
+	t.Helper()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
+	require.NotContains(t, string(raw), "InvalidAction")
+
+	var decoded policyVersionResponse
+	require.NoError(t, xml.Unmarshal(raw, &decoded), "body: %s", raw)
+	return decoded
+}
+
+// iamPolicyDocumentFor fetches a policy version's document and URL-decodes it, which is
+// how a consumer reads it: the response carries it RFC 3986 percent-encoded.
+func iamPolicyDocumentFor(t *testing.T, srv *emulator.Server, arn, versionID string) string {
+	t.Helper()
+	got := iamDecodePolicyVersion(t, iamRequest(t, srv, "GetPolicyVersion", map[string]any{
+		"PolicyArn": arn,
+		"VersionId": versionID,
+	}))
+	require.NotNil(t, got.Version)
+	require.NotNil(t, got.Version.Document, "GetPolicyVersion must return the document")
+
+	decoded, err := url.QueryUnescape(*got.Version.Document)
+	require.NoError(t, err, "the document must decode as a URL-encoded value")
+	return decoded
+}
+
+// TestGetPolicyVersion_ReturnsABundledDocument is the reason the operation exists: a
+// document that only a Go caller could read is now readable over the wire, and it decodes
+// to the JSON the catalog holds.
+func TestGetPolicyVersion_ReturnsABundledDocument(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	const arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+	catalog, ok := emulator.GetManagedPolicy(arn)
+	require.True(t, ok, "the catalog must carry the policy this test reads")
+
+	document := iamPolicyDocumentFor(t, srv, arn, catalog.DefaultVersionID)
+
+	// Compared as parsed documents rather than as bytes: the assertion is about the
+	// policy's content, and pinning substrate's own marshaling order would fail on a
+	// harmless field reordering while saying nothing about fidelity.
+	var got, want emulator.PolicyDocument
+	require.NoError(t, json.Unmarshal([]byte(document), &got))
+	wantRaw, err := json.Marshal(catalog.Document)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(wantRaw, &want))
+	assert.Equal(t, want, got)
+
+	// And the document actually says what AmazonS3ReadOnlyAccess says, so a test that
+	// round-tripped an empty document would not pass.
+	assert.Contains(t, document, "s3:Get*")
+	assert.Equal(t, "2012-10-17", got.Version)
+}
+
+// TestGetPolicyVersion_DocumentIsRFC3986Encoded pins the encoding, which the reference
+// specifies and which no stdlib escaper produces.
+//
+// url.QueryEscape encodes a space as "+", which a strict RFC 3986 decoder reads back as a
+// literal plus — silently corrupting any document containing a space. url.PathEscape
+// leaves ":" bare. Most SDKs decode automatically, so getting this wrong breaks the raw
+// HTTP client and nobody else, which is the kind of gap that only shows up in production.
+func TestGetPolicyVersion_DocumentIsRFC3986Encoded(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	// A Sid holding a space and a tilde: the space distinguishes RFC 3986 from
+	// QueryEscape, and the tilde is unreserved so it must survive un-encoded.
+	document := `{"Version":"2012-10-17","Statement":[{"Sid":"needs escaping~","Effect":"Allow",` +
+		`"Action":"s3:GetObject","Resource":"*"}]}`
+	arn := iamCreatePolicyForVersions(t, srv, "spacey", document)
+
+	got := iamDecodePolicyVersion(t, iamRequest(t, srv, "GetPolicyVersion", map[string]any{
+		"PolicyArn": arn,
+		"VersionId": "v1",
+	}))
+	require.NotNil(t, got.Version)
+	require.NotNil(t, got.Version.Document)
+	encoded := *got.Version.Document
+
+	assert.NotContains(t, encoded, "+", "a space must be %20, not +, per RFC 3986")
+	assert.Contains(t, encoded, "%20")
+	assert.Contains(t, encoded, "~", "a tilde is unreserved and must not be encoded")
+	assert.Contains(t, encoded, "%3A", "a colon is reserved and must be encoded")
+	assert.NotContains(t, encoded, `"`, "every reserved character must be encoded")
+
+	// The decisive property: it round-trips through a strict decoder.
+	decoded, err := url.PathUnescape(encoded)
+	require.NoError(t, err)
+	var parsed emulator.PolicyDocument
+	require.NoError(t, json.Unmarshal([]byte(decoded), &parsed))
+	require.Len(t, parsed.Statement, 1)
+	assert.Equal(t, "needs escaping~", parsed.Statement[0].Sid)
+}
+
+// TestGetPolicyVersion_ReturnsACustomerManagedDocument covers the other resolution arm:
+// a policy created through CreatePolicy behaves the same as a bundled one.
+func TestGetPolicyVersion_ReturnsACustomerManagedDocument(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	document := iamPolicyJSON(t, "Allow", []string{"s3:ListAllMyBuckets"}, "*")
+	arn := iamCreatePolicyForVersions(t, srv, "listbuckets", document)
+
+	got := iamPolicyDocumentFor(t, srv, arn, "v1")
+	var parsed emulator.PolicyDocument
+	require.NoError(t, json.Unmarshal([]byte(got), &parsed))
+	require.Len(t, parsed.Statement, 1)
+	assert.Equal(t, emulator.StringOrSlice{"s3:ListAllMyBuckets"}, parsed.Statement[0].Action)
+}
+
+// TestGetPolicyVersion_IsDefaultVersionTracksThePolicy pins IsDefaultVersion against the
+// two bundled policies whose default is not v1.
+//
+// AWS has edited these policies since publication, and their reference pages report v2 and
+// v3; substrate's catalog carries those values. So a caller asking for the default gets
+// IsDefaultVersion true under the version ID the policy actually names — and asking for
+// v1 is refused, which is what makes this pair worth asserting rather than assuming.
+func TestGetPolicyVersion_IsDefaultVersionTracksThePolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		arn         string
+		wantVersion string
+	}{
+		{
+			name:        "a policy AWS reports at v2",
+			arn:         "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+			wantVersion: "v2",
+		},
+		{
+			name:        "a policy AWS reports at v3",
+			arn:         "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+			wantVersion: "v3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newIAMTestServer(t)
+
+			catalog, ok := emulator.GetManagedPolicy(tc.arn)
+			require.True(t, ok)
+			require.Equal(t, tc.wantVersion, catalog.DefaultVersionID,
+				"the catalog's default version is the premise of this test")
+
+			got := iamDecodePolicyVersion(t, iamRequest(t, srv, "GetPolicyVersion", map[string]any{
+				"PolicyArn": tc.arn,
+				"VersionId": tc.wantVersion,
+			}))
+			require.NotNil(t, got.Version)
+			assert.Equal(t, tc.wantVersion, got.Version.VersionID)
+			assert.True(t, got.Version.IsDefaultVersion)
+
+			// v1 is a version AWS *has* and substrate does not store, so it is refused
+			// rather than served with the default's document under the wrong name.
+			resp := iamRequest(t, srv, "GetPolicyVersion", map[string]any{
+				"PolicyArn": tc.arn,
+				"VersionId": "v1",
+			})
+			require.Equal(t, http.StatusNotFound, resp.StatusCode)
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, "NoSuchEntity", result["__type"])
+		})
+	}
+}
+
+// TestListPolicyVersions_OmitsTheDocument pins the member the model says this operation
+// does not send.
+//
+// PolicyVersion.Document is documented as returned by GetPolicyVersion and
+// GetAccountAuthorizationDetails, and *not* by ListPolicyVersions or CreatePolicyVersion.
+// Sending it would hand a caller a member AWS omits — the kind of difference that makes a
+// consumer work against substrate and fail against AWS.
+func TestListPolicyVersions_OmitsTheDocument(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	const arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+	got := iamDecodePolicyVersion(t, iamRequest(t, srv, "ListPolicyVersions", map[string]any{
+		"PolicyArn": arn,
+	}))
+
+	require.Len(t, got.Versions, 1, "substrate models exactly one version per policy")
+	assert.Nil(t, got.Versions[0].Document,
+		"ListPolicyVersions must not send the document")
+	assert.Equal(t, "v1", got.Versions[0].VersionID)
+	assert.True(t, got.Versions[0].IsDefaultVersion)
+	assert.NotEmpty(t, got.Versions[0].CreateDate)
+	assert.False(t, got.Truncated)
+}
+
+// TestListPolicyVersions_ReportsOneVersionForACreatedPolicy covers the state arm and the
+// pagination members.
+//
+// One version cannot truncate, but IsTruncated must still be present and MaxItems must not
+// fail the request — which it did for every paginated IAM operation before #642, because
+// the query protocol sends it as a string.
+func TestListPolicyVersions_ReportsOneVersionForACreatedPolicy(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	arn := iamCreatePolicyForVersions(t, srv, "listable",
+		iamPolicyJSON(t, "Allow", []string{"s3:GetObject"}, "*"))
+
+	got := iamDecodePolicyVersion(t, iamRequest(t, srv, "ListPolicyVersions", map[string]any{
+		"PolicyArn": arn,
+		"MaxItems":  10,
+	}))
+	require.Len(t, got.Versions, 1)
+	assert.Equal(t, "v1", got.Versions[0].VersionID)
+	assert.False(t, got.Truncated)
+}
+
+// TestPolicyVersions_RefuseBadInput covers the InvalidInput and NoSuchEntity arms of both
+// operations.
+//
+// The malformed-VersionId case is checked before the policy is resolved on purpose: a
+// version ID that cannot match the model's pattern is the caller's error whether or not
+// the policy exists, and answering NoSuchEntity would send them looking for a policy that
+// is right there.
+func TestPolicyVersions_RefuseBadInput(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	const real = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+
+	tests := []struct {
+		name      string
+		operation string
+		body      map[string]any
+		wantCode  string
+		wantHTTP  int
+	}{
+		{
+			name:      "GetPolicyVersion requires PolicyArn",
+			operation: "GetPolicyVersion",
+			body:      map[string]any{"VersionId": "v1"},
+			wantCode:  "ValidationError",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			name:      "GetPolicyVersion requires VersionId",
+			operation: "GetPolicyVersion",
+			body:      map[string]any{"PolicyArn": real},
+			wantCode:  "ValidationError",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			name:      "ListPolicyVersions requires PolicyArn",
+			operation: "ListPolicyVersions",
+			body:      map[string]any{},
+			wantCode:  "ValidationError",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			name:      "a VersionId with no v prefix is InvalidInput",
+			operation: "GetPolicyVersion",
+			body:      map[string]any{"PolicyArn": real, "VersionId": "1"},
+			wantCode:  "InvalidInput",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			// The model's pattern is v[1-9]…, so a zero first digit cannot occur.
+			name:      "v0 is InvalidInput",
+			operation: "GetPolicyVersion",
+			body:      map[string]any{"PolicyArn": real, "VersionId": "v0"},
+			wantCode:  "InvalidInput",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			name:      "a non-numeric VersionId is InvalidInput",
+			operation: "GetPolicyVersion",
+			body:      map[string]any{"PolicyArn": real, "VersionId": "latest"},
+			wantCode:  "InvalidInput",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			// The pattern is anchored, so a well-formed ID embedded in other text is
+			// refused rather than matched loosely.
+			name:      "a VersionId with trailing junk is InvalidInput",
+			operation: "GetPolicyVersion",
+			body:      map[string]any{"PolicyArn": real, "VersionId": "v1 or so"},
+			wantCode:  "InvalidInput",
+			wantHTTP:  http.StatusBadRequest,
+		},
+		{
+			// Checked before resolution: the parameter is wrong, not the policy.
+			name:      "a malformed VersionId is refused even for an unknown policy",
+			operation: "GetPolicyVersion",
+			body: map[string]any{
+				"PolicyArn": "arn:aws:iam::123456789012:policy/ghost",
+				"VersionId": "nope",
+			},
+			wantCode: "InvalidInput",
+			wantHTTP: http.StatusBadRequest,
+		},
+		{
+			name:      "an unknown PolicyArn is NoSuchEntity for GetPolicyVersion",
+			operation: "GetPolicyVersion",
+			body: map[string]any{
+				"PolicyArn": "arn:aws:iam::123456789012:policy/ghost",
+				"VersionId": "v1",
+			},
+			wantCode: "NoSuchEntity",
+			wantHTTP: http.StatusNotFound,
+		},
+		{
+			name:      "an unknown PolicyArn is NoSuchEntity for ListPolicyVersions",
+			operation: "ListPolicyVersions",
+			body:      map[string]any{"PolicyArn": "arn:aws:iam::123456789012:policy/ghost"},
+			wantCode:  "NoSuchEntity",
+			wantHTTP:  http.StatusNotFound,
+		},
+		{
+			// A version substrate does not store, on a policy it does.
+			name:      "a non-default VersionId is NoSuchEntity",
+			operation: "GetPolicyVersion",
+			body:      map[string]any{"PolicyArn": real, "VersionId": "v9"},
+			wantCode:  "NoSuchEntity",
+			wantHTTP:  http.StatusNotFound,
+		},
+		{
+			// A dotted suffix is legal per the pattern, so it passes the shape check and
+			// is then refused as a version substrate does not hold — which proves the two
+			// checks are distinct.
+			name:      "a legal dotted VersionId that does not exist is NoSuchEntity",
+			operation: "GetPolicyVersion",
+			body:      map[string]any{"PolicyArn": real, "VersionId": "v2.abc-1"},
+			wantCode:  "NoSuchEntity",
+			wantHTTP:  http.StatusNotFound,
+		},
+		{
+			name:      "MaxItems that is not a number is refused by name",
+			operation: "ListPolicyVersions",
+			body:      map[string]any{"PolicyArn": real, "MaxItems": "abc"},
+			wantCode:  "ValidationError",
+			wantHTTP:  http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := iamRequest(t, srv, tc.operation, tc.body)
+			require.Equal(t, tc.wantHTTP, resp.StatusCode)
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, tc.wantCode, result["__type"])
+		})
+	}
+}
+
+// TestPolicyVersions_AreAuthorized covers the authorization arm on both operations, so the
+// iam:GetPolicyVersion and iam:ListPolicyVersions grants in the bundled policies mean
+// something.
+func TestPolicyVersions_AreAuthorized(t *testing.T) {
+	t.Parallel()
+
+	for _, op := range []string{"GetPolicyVersion", "ListPolicyVersions"} {
+		t.Run(op, func(t *testing.T) {
+			t.Parallel()
+			srv := newTrustPolicyTestServer(t)
+			accessKey := trustSetupCallerWithoutAssume(t, srv, "ungranted")
+
+			resp := iamCallAs(t, srv, accessKey, op, map[string]any{
+				"PolicyArn": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+				"VersionId": "v1",
+			})
+			require.Equal(t, http.StatusForbidden, resp.StatusCode)
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, emulator.IAMAccessDeniedCodeForTest, result["__type"])
+		})
+	}
+}
+
+// TestPolicyVersionsWire_OverTheQueryProtocol drives both operations the way a client
+// does. An operation that is implemented but unroutable answers InvalidAction with a fully
+// green unit suite, which is what #636 was.
+func TestPolicyVersionsWire_OverTheQueryProtocol(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	const arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+
+	got := iamDecodePolicyVersion(t, iamFormRequest(t, srv, "GetPolicyVersion",
+		map[string]string{"PolicyArn": arn, "VersionId": "v1"}))
+	require.NotNil(t, got.Version)
+	require.NotNil(t, got.Version.Document)
+	decoded, err := url.PathUnescape(*got.Version.Document)
+	require.NoError(t, err)
+	assert.Contains(t, decoded, "logs:PutLogEvents")
+
+	// MaxItems arrives as a string over this wire — the #642 shape.
+	listed := iamDecodePolicyVersion(t, iamFormRequest(t, srv, "ListPolicyVersions",
+		map[string]string{"PolicyArn": arn, "MaxItems": "5"}))
+	require.Len(t, listed.Versions, 1)
+	assert.Nil(t, listed.Versions[0].Document)
+}
+
+// iamCreatePolicyForVersions creates a customer-managed policy and returns its ARN.
+//
+// The ARN is read back rather than constructed: an unsigned test request resolves to the
+// fallback account, so a hardcoded 123456789012 ARN would name a policy that does not
+// exist and the test would assert against a NoSuchEntity it never expected.
+func iamCreatePolicyForVersions(t *testing.T, srv *emulator.Server, name, document string) string {
+	t.Helper()
+	resp := iamRequest(t, srv, "CreatePolicy", map[string]any{
+		"PolicyName":     name,
+		"PolicyDocument": document,
+	})
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
+
+	var created struct {
+		ARN string `xml:"CreatePolicyResult>Policy>Arn"`
+	}
+	require.NoError(t, xml.Unmarshal(raw, &created))
+	require.NotEmpty(t, created.ARN)
+	return created.ARN
+}


### PR DESCRIPTION
`GetPolicy` returns metadata only — which matches AWS, where the document lives behind
`GetPolicyVersion` — and substrate routed no version operation at all. So the 52 bundled
documents, several transcribed from their AWS reference pages, were readable by a Go caller
through `GetManagedPolicy` and by no consumer over HTTP: a test could attach
`AmazonS3ReadOnlyAccess` and never see what it granted. This is also what makes a simulated
decision checkable — a caller who gets an `implicitDeny` can now read the policy that failed
to grant it.

## RFC 3986, not either stdlib escaper

The reference specifies the document is "URL-encoded compliant with RFC 3986", and neither
stdlib escaper is that:

- `url.QueryEscape` encodes a space as `+`. A decoder following RFC 3986 reads that back as a
  literal plus, silently corrupting any document containing a space — which is most of them.
- `url.PathEscape` leaves `:` and several sub-delimiters bare, so an ARN in a `Resource` comes
  back differently from what AWS sends.

`iamEscapeRFC3986` escapes byte-at-a-time to the unreserved set (`ALPHA / DIGIT / - . _ ~`)
per §2.5. Most SDKs decode this automatically, so getting it wrong breaks the raw HTTP client
and nobody else — exactly the kind of gap that only surfaces in production. The test asserts
no `+`, a `%20` present, `~` untouched, `:` encoded, and that the value round-trips through
`url.PathUnescape` into the document the catalog holds.

## One version per policy, said rather than faked

`IAMPolicy` holds a single `Document` and a `DefaultVersionID`; no `CreatePolicyVersion` or
`SetDefaultPolicyVersion` exists. So a `VersionId` that is not the policy's default answers
`NoSuchEntity` rather than being served the default's document under the requested name — a
consumer pinning a version would otherwise be told a document is `v1` that AWS reports as
something else. The catalog makes this immediately reachable rather than hypothetical, because
AWS has edited these policies since publication: `AmazonSSMManagedInstanceCore` reports `v2`
and `AWSLambdaVPCAccessExecutionRole` reports `v3`. `ListPolicyVersions` therefore returns
exactly one member.

`ListPolicyVersions` **omits** `Document`. The model documents that member as returned by
`GetPolicyVersion` and `GetAccountAuthorizationDetails` and *not* by `ListPolicyVersions` or
`CreatePolicyVersion` — sending it would hand a caller a member AWS does not, which is the
kind of difference that makes a consumer work against substrate and fail against AWS. This is
a correction to the plan, which did not state it.

A malformed `VersionId` is `InvalidInput` and is refused **before** the policy is resolved:
the parameter is wrong whether or not the policy exists, and answering `NoSuchEntity` would
send the caller looking for a policy that is right there. The pattern is anchored, because an
unanchored match would accept `xxv1yy` and then misreport it as a missing version.

## Verification

- `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → 0 issues
- `make test` (race) green; coverage 82.6%
- A wire test drives both operations over the query protocol, so an implemented-but-unroutable
  operation cannot pass with a green unit suite — which is what #636 was. It also sends
  `MaxItems` as a string, the #642 shape.

Closes #498