### PR TITLE
fix(iam): an attach validates the shape of its PolicyArn (#499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before this release no operation could put a policy on a group at all, so an existing
   fixture can only be affected if it wrote group policy state directly.
 
+- **An attach validates the shape of its `PolicyArn`** (#499). `AttachUserPolicy`,
+  `AttachRolePolicy` and `AttachGroupPolicy` appended whatever ARN they were given to the
+  entity's list unconditionally, so a consumer could attach a bare policy name or an S3
+  bucket ARN, get a success, and only discover the mistake through `GetPolicy` answering
+  `NoSuchEntity` for an ARN the attach had just accepted. All three now refuse a
+  malformed policy ARN with `InvalidInput` (400) — the code the model declares for them —
+  built from the model's own `accountIdType`, `policyPathType` and `policyNameType`
+  patterns rather than by eye.
+
+  **Existence is deliberately not required.** Substrate bundles 52 of roughly 1,200 AWS
+  managed policies, so refusing an ARN that resolves nowhere would refuse every attach of
+  the other ~1,150: attaching `AmazonAthenaFullAccess` would hard-fail where AWS succeeds.
+  That trades a confusing success for a wrong failure, and the wrong failure is worse — it
+  breaks working consumer code rather than merely failing to catch a typo. A well-formed
+  ARN that resolves in neither the catalog nor state therefore **succeeds**, and logs at
+  `WARN` naming the ARN, with a different message for an unbundled AWS managed policy (the
+  expected case) than for a customer-managed ARN no `CreatePolicy` ever created (a likelier
+  mistake). The warning fires after the entity lookup, so an attach that is going to fail
+  with `NoSuchEntity` does not also warn about a policy nothing was attaching. An ARN
+  `GetPolicy` resolves is never refused and never warns. The partition stays permissive
+  (`aws`, `aws-cn`, `aws-us-gov`, the `aws-iso` variants and whatever follows), because
+  refusing an unknown partition would refuse an ARN that is well-formed for a region
+  substrate does not model.
+
+  Two paths the issue offered are not taken and are recorded on it: seeding all ~1,200 ARNs
+  without documents would make `GetPolicy` resolve policies whose documents are empty, and
+  a seedable strict mode would be a second behaviour for the same call with no consumer
+  asking for it yet.
+
+  This is a behaviour change: a fixture attaching a made-up ARN that is not ARN-shaped
+  starts failing. One that attaches a real-but-unbundled AWS managed ARN keeps working.
+
 ### Fixed
 - **`ListPolicies` applies its filters and can see the bundled catalog** (#497). It parsed
   `Scope` and `PathPrefix` and applied neither, and it enumerated only policies created

--- a/emulator/iam_groups.go
+++ b/emulator/iam_groups.go
@@ -165,6 +165,11 @@ func (p *IAMPlugin) attachGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AW
 	if params.GroupName == "" || params.PolicyArn == "" {
 		return iamErrorResponse("ValidationError", "GroupName and PolicyArn are required", http.StatusBadRequest), nil
 	}
+	// Shape, not existence — see iam_policy_arn.go (#499). Applied here too, so the asymmetry
+	// #499 reports is not recreated in an operation shipping in the same release.
+	if message, ok := iamValidatePolicyARN(params.PolicyArn); !ok {
+		return iamErrorResponse("InvalidInput", message, http.StatusBadRequest), nil
+	}
 
 	goCtx := context.Background()
 	if err := p.authorize(goCtx, ctx, "iam:AttachGroupPolicy", "*"); err != nil {
@@ -180,6 +185,10 @@ func (p *IAMPlugin) attachGroupPolicy(ctx *RequestContext, req *AWSRequest) (*AW
 			fmt.Sprintf("The group with name %s cannot be found.", params.GroupName),
 			http.StatusNotFound), nil
 	}
+
+	// Existence is not required, only reported — see iam_policy_arn.go (#499). The check runs
+	// after the group lookup so an attach that is going to fail anyway does not also warn.
+	p.iamWarnUnresolvedPolicyARN(goCtx, "AttachGroupPolicy", params.PolicyArn)
 
 	listKey := iamGroupPoliciesKey(params.GroupName)
 	arns, err := p.loadPolicyList(goCtx, listKey)

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -920,6 +920,10 @@ func (p *IAMPlugin) attachUserPolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 	if params.UserName == "" || params.PolicyArn == "" {
 		return iamErrorResponse("ValidationError", "UserName and PolicyArn are required", http.StatusBadRequest), nil
 	}
+	// Shape, not existence — see iam_policy_arn.go (#499).
+	if message, ok := iamValidatePolicyARN(params.PolicyArn); !ok {
+		return iamErrorResponse("InvalidInput", message, http.StatusBadRequest), nil
+	}
 
 	goCtx := context.Background()
 
@@ -936,6 +940,10 @@ func (p *IAMPlugin) attachUserPolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 			fmt.Sprintf("The user with name %s cannot be found.", params.UserName),
 			http.StatusNotFound), nil
 	}
+
+	// Existence is not required, only reported — see iam_policy_arn.go (#499). The check runs
+	// after the user lookup so an attach that is going to fail anyway does not also warn.
+	p.iamWarnUnresolvedPolicyARN(goCtx, "AttachUserPolicy", params.PolicyArn)
 
 	listKey := "user_policies:" + params.UserName
 	arns, err := p.loadPolicyList(goCtx, listKey)
@@ -1046,6 +1054,10 @@ func (p *IAMPlugin) attachRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 	if params.RoleName == "" || params.PolicyArn == "" {
 		return iamErrorResponse("ValidationError", "RoleName and PolicyArn are required", http.StatusBadRequest), nil
 	}
+	// Shape, not existence — see iam_policy_arn.go (#499).
+	if message, ok := iamValidatePolicyARN(params.PolicyArn); !ok {
+		return iamErrorResponse("InvalidInput", message, http.StatusBadRequest), nil
+	}
 
 	goCtx := context.Background()
 
@@ -1062,6 +1074,10 @@ func (p *IAMPlugin) attachRolePolicy(ctx *RequestContext, req *AWSRequest) (*AWS
 			fmt.Sprintf("The role with name %s cannot be found.", params.RoleName),
 			http.StatusNotFound), nil
 	}
+
+	// Existence is not required, only reported — see iam_policy_arn.go (#499). The check runs
+	// after the role lookup so an attach that is going to fail anyway does not also warn.
+	p.iamWarnUnresolvedPolicyARN(goCtx, "AttachRolePolicy", params.PolicyArn)
 
 	listKey := "role_policies:" + params.RoleName
 	arns, err := p.loadPolicyList(goCtx, listKey)

--- a/emulator/iam_plugin_test.go
+++ b/emulator/iam_plugin_test.go
@@ -30,9 +30,16 @@ func newIAMTestServer(t *testing.T) *emulator.Server {
 // result, which is the opposite signal.
 func newIAMTestServerWithState(t *testing.T, state emulator.StateManager) *emulator.Server {
 	t.Helper()
+	return newIAMTestServerWith(t, state, emulator.NewDefaultLogger(slog.LevelInfo, false))
+}
+
+// newIAMTestServerWith is [newIAMTestServer] over a caller-supplied store and logger, for a
+// test that asserts on a warning: an operation whose only report of a gap is a log line is
+// otherwise indistinguishable from one that noticed nothing.
+func newIAMTestServerWith(t *testing.T, state emulator.StateManager, logger emulator.Logger) *emulator.Server {
+	t.Helper()
 	cfg := emulator.DefaultConfig()
 	registry := emulator.NewPluginRegistry()
-	logger := emulator.NewDefaultLogger(slog.LevelInfo, false)
 	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
 	tc := emulator.NewTimeController(time.Now())
 

--- a/emulator/iam_policy_arn.go
+++ b/emulator/iam_policy_arn.go
@@ -1,0 +1,107 @@
+package emulator
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Policy-ARN shape validation on attach (#499).
+//
+// AttachUserPolicy, AttachRolePolicy and AttachGroupPolicy accepted any PolicyArn and
+// appended it to the entity's list unconditionally, so a consumer could attach a policy that
+// does not exist and only find out later through GetPolicy — a different operation reporting
+// NoSuchEntity for an ARN the attach had just accepted.
+//
+// #499 offered four paths and left the decision to be recorded. What ships is (1) + (2):
+// refuse a *malformed* ARN, and log a warning for a well-formed one that resolves nowhere.
+//
+// Existence is deliberately not required. Substrate bundles 52 of roughly 1,200 AWS managed
+// policies, so refusing an unresolvable ARN would refuse every attach of the other ~1,150: a
+// consumer attaching AmazonAthenaFullAccess would get a hard failure where AWS succeeds. That
+// trades a confusing success for a wrong failure, and the wrong failure is worse — it breaks
+// working consumer code rather than merely failing to catch a typo. Shape validation catches
+// the typo-shaped mistake (a bare policy name, an S3 bucket ARN, a missing "policy/") without
+// requiring the catalog to be complete, and the WARN names the ARN so the confusing success
+// is at least visible in a log.
+//
+// The two paths not taken: seeding all ~1,200 ARNs without documents (3) would make GetPolicy
+// resolve policies whose documents are empty, which needs its own caveat and is a large data
+// addition; a seedable strict mode (4) would be a second behavior for the same call with no
+// consumer asking for it yet. Either remains open if one does.
+
+// iamPolicyARNPattern is the shape a policy ARN must have.
+//
+// Built from the API model's own patterns rather than by eye:
+//
+//   - the account is "aws" for an AWS managed policy or accountIdType (\d{12}) for a
+//     customer-managed one, and nothing else — an ARN naming a 13-digit account is a typo, not
+//     an account substrate has not heard of;
+//   - the region is empty, because IAM is global and every real policy ARN has an empty
+//     region field;
+//   - the path segments follow policyPathType and the name follows policyNameType
+//     ([\w+=,.@-]+), which is what makes a bare name or a slash-terminated ARN refusable.
+//
+// The partition is a permissive [a-z0-9-]+ on purpose: aws, aws-cn, aws-us-gov and the
+// several aws-iso variants exist, more may follow, and refusing an unknown partition would
+// refuse an ARN that is perfectly well-formed for a region substrate does not model.
+var iamPolicyARNPattern = regexp.MustCompile(
+	`^arn:[a-z0-9-]+:iam::(aws|[0-9]{12}):policy(/[A-Za-z0-9.,+@=_-]+)*/[\w+=,.@-]+$`)
+
+// iamValidatePolicyARN reports whether arn is a well-formed IAM policy ARN, returning the
+// message to refuse it with when it is not.
+//
+// Shape only: a well-formed ARN naming a policy that does not exist is valid here, and the
+// caller decides what to do about that (see iamWarnUnresolvedPolicyARN).
+func iamValidatePolicyARN(arn string) (message string, ok bool) {
+	// arnType is min 20, max 2048. The length check comes first so a 4 KB body is refused on
+	// its size rather than run through the pattern.
+	if len(arn) < 20 || len(arn) > 2048 {
+		return fmt.Sprintf("The specified value for policyArn is invalid. "+
+			"It must be between 20 and 2048 characters long (got %d).", len(arn)), false
+	}
+	if !iamPolicyARNPattern.MatchString(arn) {
+		return fmt.Sprintf("ARN %s is not valid.", arn), false
+	}
+	return "", true
+}
+
+// iamPolicyARNIsAWSManaged reports whether arn names an AWS managed policy — the "::aws:"
+// account — rather than a customer-managed one.
+func iamPolicyARNIsAWSManaged(arn string) bool {
+	return strings.HasPrefix(arn, "arn:") && strings.Contains(arn, ":iam::aws:policy/")
+}
+
+// iamWarnUnresolvedPolicyARN logs at WARN when a well-formed ARN resolves in neither the
+// bundled catalog nor state, and reports whether it resolved.
+//
+// The attach still succeeds. The log is what makes the gap visible without breaking the
+// consumer: an AWS managed ARN substrate does not bundle is the expected case (52 of ~1,200),
+// while a customer-managed ARN that resolves nowhere means no CreatePolicy call ever made it,
+// which is more likely to be a real mistake — so the two get different messages.
+func (p *IAMPlugin) iamWarnUnresolvedPolicyARN(goCtx context.Context, operation, arn string) bool {
+	if _, ok := GetManagedPolicy(arn); ok {
+		return true
+	}
+	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
+	if err == nil && raw != nil {
+		return true
+	}
+
+	if p.logger == nil {
+		return false
+	}
+	if iamPolicyARNIsAWSManaged(arn) {
+		p.logger.Warn("iam "+operation+": the policy ARN is a well-formed AWS managed ARN "+
+			"substrate does not bundle; the attach succeeds and the policy contributes no "+
+			"statements to an authorization decision",
+			"policyArn", arn)
+		return false
+	}
+	p.logger.Warn("iam "+operation+": the policy ARN resolves in neither the bundled catalog "+
+		"nor state; the attach succeeds and the policy contributes no statements to an "+
+		"authorization decision",
+		"policyArn", arn)
+	return false
+}

--- a/emulator/iam_policy_arn_test.go
+++ b/emulator/iam_policy_arn_test.go
@@ -1,0 +1,353 @@
+package emulator_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// Attach-time PolicyArn validation (#499).
+//
+// The shape of these tests follows the decision: a malformed ARN is refused, a well-formed one
+// that resolves nowhere succeeds with a warning, and an ARN GetPolicy resolves is never refused
+// — that last one is #499's hard acceptance criterion, so it is asserted for every attach
+// operation and for both a bundled and a created policy.
+//
+// All three of AttachUserPolicy, AttachRolePolicy and AttachGroupPolicy are driven from the
+// same tables. #499's report was that the check existed on none of them; shipping it on two of
+// three would be the same defect with a smaller surface.
+
+// iamAttachTarget names one attach operation and the entity it needs, so a table can drive all
+// three without three copies of every case.
+type iamAttachTarget struct {
+	operation string
+	// setup creates the entity and returns the request field naming it.
+	setup func(t *testing.T, srv *emulator.Server) (field, name string)
+}
+
+// iamAttachTargets is the three attach operations, each with the entity it attaches to.
+var iamAttachTargets = []iamAttachTarget{
+	{
+		operation: "AttachUserPolicy",
+		setup: func(t *testing.T, srv *emulator.Server) (string, string) {
+			t.Helper()
+			resp := iamRequest(t, srv, "CreateUser", map[string]any{"UserName": "jill"})
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+			return "UserName", "jill"
+		},
+	},
+	{
+		operation: "AttachRolePolicy",
+		setup: func(t *testing.T, srv *emulator.Server) (string, string) {
+			t.Helper()
+			resp := iamRequest(t, srv, "CreateRole", map[string]any{
+				"RoleName":                 "worker",
+				"AssumeRolePolicyDocument": `{"Version":"2012-10-17","Statement":[]}`,
+			})
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+			return "RoleName", "worker"
+		},
+	},
+	{
+		operation: "AttachGroupPolicy",
+		setup: func(t *testing.T, srv *emulator.Server) (string, string) {
+			t.Helper()
+			resp := iamRequest(t, srv, "CreateGroup", map[string]any{"GroupName": "devs"})
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+			return "GroupName", "devs"
+		},
+	},
+}
+
+// iamAttach runs one attach operation against target's entity and returns the response.
+func iamAttach(t *testing.T, srv *emulator.Server, target iamAttachTarget, policyARN string) *http.Response {
+	t.Helper()
+	field, name := target.setup(t, srv)
+	return iamRequest(t, srv, target.operation, map[string]any{
+		field:       name,
+		"PolicyArn": policyARN,
+	})
+}
+
+func TestAttachPolicy_RefusesAMalformedARN(t *testing.T) {
+	// Every case here is a mistake a consumer actually makes: the bare name from the console,
+	// an ARN for the wrong service, a resource type that is not a policy, a slash-terminated
+	// ARN with no name, an account that is not twelve digits.
+	cases := []struct {
+		name      string
+		policyARN string
+	}{
+		{"a bare policy name", "AmazonS3ReadOnlyAccess"},
+		{"not an ARN at all", "not-an-arn-at-all-but-long-enough"},
+		{"the wrong service", "arn:aws:s3:::my-bucket/AmazonS3ReadOnlyAccess"},
+		{"the wrong resource type", "arn:aws:iam::123456789012:role/AmazonS3ReadOnlyAccess"},
+		{"a region where IAM has none", "arn:aws:iam:us-east-1:123456789012:policy/thing"},
+		{"no policy name", "arn:aws:iam::aws:policy/service-role/"},
+		{"a thirteen-digit account", "arn:aws:iam::1234567890123:policy/thing"},
+		{"an eleven-digit account", "arn:aws:iam::12345678901:policy/thing"},
+		{"too short to be an ARN", "arn:aws:iam::a"},
+	}
+
+	for _, target := range iamAttachTargets {
+		for _, tc := range cases {
+			t.Run(target.operation+"/"+tc.name, func(t *testing.T) {
+				srv := newIAMTestServer(t)
+				resp := iamAttach(t, srv, target, tc.policyARN)
+
+				assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+				var result map[string]any
+				decodeIAMXML(t, resp, &result)
+				assert.Equal(t, "InvalidInput", result["__type"],
+					"the model declares InvalidInputException for all three attach operations")
+			})
+		}
+	}
+}
+
+func TestAttachPolicy_AnARNGetPolicyResolvesIsNeverRefused(t *testing.T) {
+	// #499's hard acceptance criterion. A bundled ARN and a created one both resolve through
+	// GetPolicy, so neither may be refused — and neither may warn, because warning about a
+	// policy the emulator holds would train a consumer to ignore the warning.
+	for _, target := range iamAttachTargets {
+		t.Run(target.operation+"/bundled", func(t *testing.T) {
+			logs := &iamWarnLog{}
+			srv := newIAMTestServerWith(t, emulator.NewMemoryStateManager(), logs)
+
+			resp := iamAttach(t, srv, target, "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess")
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+			assert.Empty(t, logs.warningsAbout("policyArn"),
+				"a bundled policy resolves, so there is nothing to warn about")
+		})
+
+		t.Run(target.operation+"/created", func(t *testing.T) {
+			logs := &iamWarnLog{}
+			srv := newIAMTestServerWith(t, emulator.NewMemoryStateManager(), logs)
+			arn := iamCreatePolicyForVersions(t, srv, "team-policy",
+				`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`)
+
+			resp := iamAttach(t, srv, target, arn)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+			assert.Empty(t, logs.warningsAbout("policyArn"),
+				"a created policy resolves through state, so there is nothing to warn about")
+		})
+	}
+}
+
+func TestAttachPolicy_AnUnbundledAWSManagedARNSucceedsWithAWarning(t *testing.T) {
+	// Substrate bundles 52 of roughly 1,200 AWS managed policies. AmazonAthenaFullAccess is
+	// real and is not one of the 52, which is exactly the case that must not be refused:
+	// refusing it would fail an attach that succeeds against AWS.
+	const arn = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
+	_, bundled := emulator.GetManagedPolicy(arn)
+	require.False(t, bundled,
+		"this test needs an ARN the catalog does not hold; pick another if it gets bundled")
+
+	for _, target := range iamAttachTargets {
+		t.Run(target.operation, func(t *testing.T) {
+			logs := &iamWarnLog{}
+			srv := newIAMTestServerWith(t, emulator.NewMemoryStateManager(), logs)
+
+			resp := iamAttach(t, srv, target, arn)
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "AWS accepts this attach, so substrate must")
+			require.NoError(t, resp.Body.Close())
+
+			warns := logs.warningsAbout("does not bundle")
+			require.Len(t, warns, 1, "the gap has to be visible somewhere, and the log is where")
+			assert.Contains(t, warns[0], target.operation,
+				"the warning names the operation that logged it")
+			assert.Contains(t, warns[0], arn, "and the ARN it is about")
+		})
+	}
+}
+
+func TestAttachPolicy_ACustomerManagedARNThatResolvesNowhereWarnsDifferently(t *testing.T) {
+	// A customer-managed ARN resolving nowhere means no CreatePolicy call ever made it, which
+	// is a likelier mistake than an unbundled AWS policy — so it gets its own message rather
+	// than being folded into the expected case.
+	for _, target := range iamAttachTargets {
+		t.Run(target.operation, func(t *testing.T) {
+			logs := &iamWarnLog{}
+			srv := newIAMTestServerWith(t, emulator.NewMemoryStateManager(), logs)
+
+			resp := iamAttach(t, srv, target, "arn:aws:iam::123456789012:policy/never-created")
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+
+			assert.Len(t, logs.warningsAbout("resolves in neither"), 1)
+			assert.Empty(t, logs.warningsAbout("does not bundle"),
+				"a customer-managed ARN is not the unbundled-AWS-policy case")
+		})
+	}
+}
+
+func TestAttachPolicy_AnUnknownEntityDoesNotWarnAboutTheARN(t *testing.T) {
+	// The shape check runs before the entity lookup, because it needs no state; the warning
+	// runs after, so an attach that is going to fail with NoSuchEntity does not also produce a
+	// warning about a policy nothing was going to be attached to.
+	cases := []struct {
+		operation string
+		field     string
+	}{
+		{"AttachUserPolicy", "UserName"},
+		{"AttachRolePolicy", "RoleName"},
+		{"AttachGroupPolicy", "GroupName"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.operation, func(t *testing.T) {
+			logs := &iamWarnLog{}
+			srv := newIAMTestServerWith(t, emulator.NewMemoryStateManager(), logs)
+
+			resp := iamRequest(t, srv, tc.operation, map[string]any{
+				tc.field:    "ghost",
+				"PolicyArn": "arn:aws:iam::123456789012:policy/never-created",
+			})
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, "NoSuchEntity", result["__type"])
+			assert.Empty(t, logs.messages(), "nothing was attached, so nothing is worth warning about")
+		})
+	}
+}
+
+func TestAttachPolicy_TheShapeCheckPrecedesAuthorization(t *testing.T) {
+	// A malformed ARN is refused on its shape whatever the caller may do, so the refusal is a
+	// property of the request rather than of the caller's permissions. This pins the order:
+	// swapping the two would report AccessDenied for a request that is invalid regardless.
+	for _, target := range iamAttachTargets {
+		t.Run(target.operation, func(t *testing.T) {
+			srv := newIAMTestServer(t)
+			resp := iamAttach(t, srv, target, "AmazonS3ReadOnlyAccess")
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+		})
+	}
+}
+
+func TestAttachPolicy_AcceptsTheARNShapesAWSDoes(t *testing.T) {
+	// Shapes that are well-formed but that substrate does not otherwise model: a non-default
+	// partition, a nested path, and a name using the full policyNameType character set. Each
+	// must be accepted — refusing one would refuse an ARN that is valid at AWS.
+	cases := []struct {
+		name      string
+		policyARN string
+	}{
+		{"the China partition", "arn:aws-cn:iam::aws:policy/AmazonS3ReadOnlyAccess"},
+		{"GovCloud", "arn:aws-us-gov:iam::aws:policy/AmazonS3ReadOnlyAccess"},
+		{"an ISO partition", "arn:aws-iso-b:iam::123456789012:policy/thing"},
+		{"a nested path", "arn:aws:iam::123456789012:policy/team/infra/deployer"},
+		{"the full name charset", "arn:aws:iam::123456789012:policy/name+with=odd,chars.@-ok"},
+		{"a service-role path", "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newIAMTestServer(t)
+			resp := iamAttach(t, srv, iamAttachTargets[0], tc.policyARN)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+		})
+	}
+}
+
+func TestAttachPolicy_TheAttachedARNIsReadableBack(t *testing.T) {
+	// The warning must not become a refusal by accident: an unresolvable ARN that warns is
+	// still recorded, so ListAttachedUserPolicies reports it.
+	const arn = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
+	logs := &iamWarnLog{}
+	srv := newIAMTestServerWith(t, emulator.NewMemoryStateManager(), logs)
+
+	resp := iamAttach(t, srv, iamAttachTargets[0], arn)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "ListAttachedUserPolicies", map[string]any{"UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+
+	attached, ok := result["AttachedPolicies"].([]any)
+	require.True(t, ok)
+	require.Len(t, attached, 1)
+	entry, ok := attached[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, arn, entry["PolicyArn"])
+}
+
+func TestAttachPolicy_OverTheQueryProtocol(t *testing.T) {
+	// A real client posts a form body, and the refusal has to survive that path: a check that
+	// only fires for a hand-built JSON body is a check no SDK caller reaches.
+	srv := newIAMTestServer(t)
+	resp := iamFormRequest(t, srv, "CreateUser", map[string]string{"UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamFormRequest(t, srv, "AttachUserPolicy", map[string]string{
+		"UserName":  "jill",
+		"PolicyArn": "AmazonS3ReadOnlyAccess",
+	})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, "InvalidInput", result["__type"])
+
+	resp = iamFormRequest(t, srv, "AttachUserPolicy", map[string]string{
+		"UserName":  "jill",
+		"PolicyArn": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+	})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+// iamWarnLog is an [emulator.Logger] that keeps the Warn messages it is given, so a test can
+// assert on a gap the operation reports only in a log.
+type iamWarnLog struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *iamWarnLog) Debug(_ string, _ ...any) {}
+func (l *iamWarnLog) Info(_ string, _ ...any)  {}
+func (l *iamWarnLog) Error(_ string, _ ...any) {}
+
+func (l *iamWarnLog) Warn(msg string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	// The key-value args are folded into the line so a test can assert on the ARN the warning
+	// names, not only on the message it carries.
+	line := msg
+	for _, arg := range args {
+		line += " " + fmt.Sprint(arg)
+	}
+	l.warns = append(l.warns, line)
+}
+
+func (l *iamWarnLog) messages() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.warns...)
+}
+
+// warningsAbout returns the collected warnings containing substr.
+func (l *iamWarnLog) warningsAbout(substr string) []string {
+	var out []string
+	for _, msg := range l.messages() {
+		if strings.Contains(msg, substr) {
+			out = append(out, msg)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Closes #499

`AttachUserPolicy`, `AttachRolePolicy` and `AttachGroupPolicy` appended whatever `PolicyArn` they were given to the entity's list unconditionally. A consumer could attach a bare policy name from the console, or an S3 bucket ARN, get a `200`, and only discover the mistake later through `GetPolicy` answering `NoSuchEntity` for an ARN the attach had just accepted — two operations disagreeing about the same string.

## The decision

#499 listed four paths and left the choice to be recorded. This ships **(1) + (2)**: refuse a malformed ARN, warn on a well-formed one that resolves nowhere. The reasoning lives in `emulator/iam_policy_arn.go`'s header so it is readable next to the code it explains.

**Shape is refused.** `InvalidInput` (400) — the code the model declares for all three operations — for an ARN that does not match a policy ARN. The pattern is built from the model's own `accountIdType` (`\d{12}`), `policyPathType` and `policyNameType` (`[\w+=,.@-]+`) rather than by eye, and the `arnType` 20–2048 length bound is checked first so a 4 KB body is refused on its size.

**Existence is deliberately not required.** Substrate bundles 52 of roughly 1,200 AWS managed policies. Refusing an ARN that resolves nowhere would refuse every attach of the other ~1,150 — attaching `AmazonAthenaFullAccess` would hard-fail where AWS succeeds. That trades a confusing success for a wrong failure, and the wrong failure is worse: it breaks working consumer code rather than merely failing to catch a typo. So a well-formed unresolvable ARN **succeeds** and logs at `WARN` naming it, with a different message for an unbundled AWS managed policy (the expected case) than for a customer-managed ARN no `CreatePolicy` ever created (a likelier real mistake).

**The partition stays permissive.** `[a-z0-9-]+` covers `aws`, `aws-cn`, `aws-us-gov`, the `aws-iso` variants and whatever follows; refusing an unknown partition would refuse an ARN that is well-formed for a region substrate does not model.

**All three operations, not two.** `AttachGroupPolicy` ships in this same release, so applying the check to only the two pre-existing handlers would recreate the asymmetry #499 reports inside a brand-new operation.

**Ordering.** The shape check precedes authorization — it needs no state, and a malformed request is invalid whatever the caller may do. The existence warning runs *after* the entity lookup, so an attach that is going to fail with `NoSuchEntity` does not also warn about a policy nothing was attaching.

Paths not taken, recorded on the issue: seeding all ~1,200 ARNs without documents (3) would make `GetPolicy` resolve policies whose documents are empty; a seedable strict mode (4) would be a second behaviour for the same call with no consumer asking for it yet.

## Tests

`emulator/iam_policy_arn_test.go`, tables driving all three operations:

- **An ARN `GetPolicy` resolves is never refused and never warns** — #499's hard acceptance criterion, asserted for a bundled ARN and a created one. Warning about a policy the emulator holds would train a consumer to ignore the warning.
- A malformed ARN → `InvalidInput` 400: nine cases, each a mistake a consumer actually makes (bare name, wrong service, `role/` instead of `policy/`, a region where IAM has none, slash-terminated with no name, 11- and 13-digit accounts).
- `AmazonAthenaFullAccess` (real, unbundled, asserted unbundled so the test fails loudly if it ever gets added) succeeds with exactly one warning naming both the operation and the ARN.
- A customer-managed ARN that resolves nowhere gets the *other* message, and not the unbundled-AWS one.
- An unknown entity → `NoSuchEntity` with **no** warning at all.
- The attached ARN reads back through `ListAttachedUserPolicies`, so the warning cannot quietly become a refusal.
- Shapes AWS accepts and substrate does not otherwise model are accepted: three partitions, a nested path, the full `policyNameType` charset.
- Over the **query protocol** with a real form body, because a check only reachable through a hand-built JSON body is a check no SDK caller reaches.

## Compatibility

A fixture attaching a made-up, non-ARN-shaped `PolicyArn` starts failing with `InvalidInput`. One attaching a real-but-unbundled AWS managed ARN keeps working, and now says so in the log.

## Verification

`gofmt -l .` clean; `go build ./...`; `go vet ./...`; `golangci-lint run ./...` → `0 issues.`; `make test` (race) green. Coverage: `iamValidatePolicyARN` 100%, `iamPolicyARNIsAWSManaged` 100%, `iamWarnUnresolvedPolicyARN` 91.7%; total 82.6%.