### PR TITLE
docs(iam): the simulator's scope, and an e2e journey through it

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -937,8 +937,13 @@ AWSLambdaBasicExecutionRole`, matching AWS. The full ARN includes the path compo
 `Scope=AWS` means substrate's **52-policy catalog**, not the ~1,200 AWS publishes.
 `Scope=Local` is the policies created through `CreatePolicy`; `All`, the default, is both.
 `PathPrefix` matches against the `Path` field and must begin *and* end with a slash, as
-IAM requires — `/service-role` is refused, `/service-role/` returns the five service-role
-policies. `OnlyAttached` is computed from stored attachments, so a bundled policy that has
+IAM requires — `/service-role` is refused, `/service-role/` returns the three policies AWS
+publishes under that path (`AWSLambdaBasicExecutionRole`,
+`AWSLambdaVPCAccessExecutionRole`, `AmazonECSTaskExecutionRolePolicy`). The other two
+service-role policies substrate bundles, `AmazonSSMManagedInstanceCore` and
+`AmazonEC2ContainerRegistryReadOnly`, live at `/` because that is their real path — what a
+policy is *for* and where it lives are different things, and the path reported here is
+AWS's. `OnlyAttached` is computed from stored attachments, so a bundled policy that has
 been attached to a user, group or role does appear; the catalog's own `AttachmentCount` is
 always 0 and is not used.
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -799,19 +799,33 @@ by their own plugins, so a stack's cost shows up under S3, EC2 and so on.
 | DeleteRole | Refuses with `DeleteConflict`/409 while a policy is attached **or** an instance profile holds the role; the message names the profiles |
 | ListRoles | |
 | CreateGroup | |
-| GetGroup | |
-| DeleteGroup | |
+| GetGroup | Reports the group's actual members |
+| DeleteGroup | Refuses with `DeleteConflict`/409 while the group has members or policies |
 | ListGroups | |
-| AttachUserPolicy | Does not verify the policy ARN resolves ([#499](https://github.com/scttfrdmn/substrate/issues/499)) |
+| AddUserToGroup | Writes both sides of the membership index; idempotent |
+| RemoveUserFromGroup | Idempotent — removing a non-member is not an error, per the model |
+| ListGroupsForUser | |
+| AttachUserPolicy | Refuses a malformed `PolicyArn` with `InvalidInput`; a well-formed ARN that resolves nowhere succeeds and logs at `WARN` (see below) |
 | DetachUserPolicy | |
 | ListAttachedUserPolicies | |
-| AttachRolePolicy | Does not verify the policy ARN resolves ([#499](https://github.com/scttfrdmn/substrate/issues/499)) |
+| AttachRolePolicy | Same `PolicyArn` check as `AttachUserPolicy` |
 | DetachRolePolicy | |
 | ListAttachedRolePolicies | |
+| AttachGroupPolicy | Same `PolicyArn` check as `AttachUserPolicy` |
+| DetachGroupPolicy | |
+| ListAttachedGroupPolicies | |
+| PutGroupPolicy | Inline policy |
+| GetGroupPolicy | |
+| DeleteGroupPolicy | |
+| ListGroupPolicies | |
 | CreatePolicy | |
 | GetPolicy | Resolves a bundled AWS managed policy or a `CreatePolicy` one; metadata only, as on AWS |
 | DeletePolicy | |
-| ListPolicies | Lists `CreatePolicy` policies only; `Scope` and `PathPrefix` are accepted and not applied ([#497](https://github.com/scttfrdmn/substrate/issues/497)) |
+| ListPolicies | Applies `Scope`, `PathPrefix` and `OnlyAttached`, and includes the bundled catalog. `PolicyUsageFilter` is validated and narrows nothing (see below) |
+| GetPolicyVersion | Returns the document, URL-encoded per RFC 3986. A `VersionId` other than the policy's default is `NoSuchEntity` |
+| ListPolicyVersions | Returns exactly one version — substrate stores one document per policy |
+| SimulatePrincipalPolicy | Evaluates a user's, group's or role's identity policies plus its permissions boundary. See "What the policy simulator evaluates" |
+| SimulateCustomPolicy | Evaluates `PolicyInputList` only; resolves no entity, so it declares no `NoSuchEntity` |
 | CreateAccessKey | |
 | DeleteAccessKey | |
 | ListAccessKeys | |
@@ -835,7 +849,63 @@ by their own plugins, so a stack's cost shows up under S3, EC2 and so on.
 | ListRoleTags | |
 | CreateInstanceProfile | |
 | GetInstanceProfile | |
+| DeleteInstanceProfile | |
 | AddRoleToInstanceProfile | |
+| RemoveRoleFromInstanceProfile | |
+| ListInstanceProfiles | |
+
+### What the policy simulator evaluates
+
+`SimulatePrincipalPolicy` and `SimulateCustomPolicy` answer "may this principal do X to
+Y?" without doing X to Y. Both run **the same evaluator the request gate enforces with**,
+which is the property worth relying on: a simulated decision that could disagree with an
+enforced one would be worse than no simulator, because a consumer would trust the
+preflight and then be refused.
+
+The three decisions are reported separately and mean different things:
+
+| `EvalDecision` | Meaning |
+|---|---|
+| `allowed` | A statement allows the action and nothing denies it |
+| `explicitDeny` | A statement denies the action by name |
+| `implicitDeny` | Nothing allows it — or a permissions boundary does not permit it |
+
+The distinction matters to an assertion. "The policy explicitly forbids this" and "no
+policy grants this" are different findings, and a test asserting the first must not pass
+on the second.
+
+**What is in the evaluated set.** For `SimulatePrincipalPolicy`: the entity's attached
+managed policies, its inline policies, the managed and inline policies of every group a
+user belongs to, plus any `PolicyInputList` documents supplied with the call. The boundary
+is `PermissionsBoundaryPolicyInputList` when given, otherwise the entity's stored one. For
+`SimulateCustomPolicy`: `PolicyInputList` and `PermissionsBoundaryPolicyInputList` only —
+it resolves no entity.
+
+`MatchedStatements` names *which* policy decided, as `SourcePolicyId` (the policy **name**,
+or `PolicyInputList.N` for a string input) and `SourcePolicyType`. `MissingContextValues`
+reports every condition key a statement tested that the request supplied no value for, so
+a conditional grant does not read as a clean refusal. A key present with an empty value is
+*set*, not missing — the `Null` operator exists precisely to test for absence.
+
+`CallerArn` defaults to `PolicySourceArn` and populates `aws:PrincipalArn`; `ResourceOwner`
+populates `aws:ResourceAccount`; an explicit `ContextEntry` wins over both. `ResourceArns`
+defaults to `["*"]`, and every action is evaluated against every resource. `MaxItems`
+defaults to 100, valid 1–1000 — **there is no cap on the number of actions per call**.
+
+#### What the simulator does not evaluate
+
+Each of these is absent rather than faked, because a fabricated field in a preflight
+answer is worse than a missing one:
+
+| Not evaluated | Why |
+|---|---|
+| **Service control policies** | Organizations stores SCPs and `CheckAccess` never consults them either, so simulating them would report a bound substrate does not enforce. `OrganizationsDecisionDetail` is therefore *absent* from a result rather than present and `false` |
+| `StartPosition` / `EndPosition` | They are byte offsets into the policy document *as submitted*. Substrate stores a parsed document, so the original text is gone and any offset would be invented. The AWS sample response shows an empty `<MatchedStatements/>`, so an absent member is a shape callers already handle |
+| `EvalDecisionDetails`, `ResourceSpecificResults` | Cross-account constructs. The reference states `EvalDecisionDetails` "is returned, but the response is empty" for a same-account simulation with a resource ARN, which is what substrate models |
+| `ResourceHandlingOption`, `PolicyExclusionList` | Accepted and ignored; both select alternate evaluation modes substrate does not model |
+
+A consumer whose preflight depends on an SCP boundary cannot get that answer here, and
+should not read an `allowed` as covering it.
 
 ### AWS managed policies are a seeded catalog
 
@@ -862,26 +932,57 @@ A policy under a path reports the path in `Path` and keeps it out of `PolicyName
 `service-role/AWSLambdaBasicExecutionRole` has `Path: /service-role/` and `PolicyName:
 AWSLambdaBasicExecutionRole`, matching AWS. The full ARN includes the path component.
 
+#### Finding a policy: `ListPolicies` scope
+
+`Scope=AWS` means substrate's **52-policy catalog**, not the ~1,200 AWS publishes.
+`Scope=Local` is the policies created through `CreatePolicy`; `All`, the default, is both.
+`PathPrefix` matches against the `Path` field and must begin *and* end with a slash, as
+IAM requires — `/service-role` is refused, `/service-role/` returns the five service-role
+policies. `OnlyAttached` is computed from stored attachments, so a bundled policy that has
+been attached to a user, group or role does appear; the catalog's own `AttachmentCount` is
+always 0 and is not used.
+
+`PolicyUsageFilter` is **validated and applies no narrowing.** The reference does not say
+which side of `PermissionsPolicy`/`PermissionsBoundary` an entirely-unused policy falls on,
+and in a fresh substrate every bundled policy is unused — so guessing would silently drop
+all 52 from a filtered listing, which is the same failure the unfiltered listing used to
+have. An invalid value is still refused with `ValidationError`.
+
 #### Attaching a policy substrate does not bundle
 
-`AttachRolePolicy` and `AttachUserPolicy` accept **any** policy ARN without checking that
-it resolves, so attaching one of the ~1,150 unbundled managed policies succeeds and
-`GetPolicy` on the same ARN then returns `NoSuchEntity`. Real IAM refuses the attach.
+`AttachUserPolicy`, `AttachRolePolicy` and `AttachGroupPolicy` check the **shape** of
+`PolicyArn`, not that it resolves. A value that is not a well-formed policy ARN — a bare
+policy name, a bucket ARN, `role/` where `policy/` belongs, an account that is not twelve
+digits — is refused with `InvalidInput` (400).
 
-This asymmetry is deliberate for now: refusing an ARN substrate cannot resolve would fail
-every attach of an unbundled managed policy — breaking working consumer code — where the
-current behaviour merely fails to catch a typo. Tracked in
-[#499](https://github.com/scttfrdmn/substrate/issues/499). A consumer who needs the attach
-verified should follow it with `GetPolicy`, which is exact.
+A well-formed ARN that resolves in neither the catalog nor state **succeeds**, and logs at
+`WARN` naming it. Requiring existence would refuse every attach of the ~1,150 unbundled
+managed policies: attaching `AmazonAthenaFullAccess` would hard-fail where AWS succeeds.
+That trades a confusing success for a wrong failure, and the wrong failure breaks working
+consumer code rather than merely failing to catch a typo. The warning distinguishes an
+unbundled AWS managed policy (expected) from a customer-managed ARN no `CreatePolicy` ever
+created (likelier a real mistake).
 
-#### Policy documents are not observable over the wire
+The consequence to know: an attached-but-unresolvable policy contributes **no statements**
+to any authorization decision, so `CheckAccess` and the simulator both behave as though it
+were not attached. A consumer who needs the attach verified should follow it with
+`GetPolicy`, which is exact.
 
-`GetPolicy` returns metadata only — policy ID, name, ARN, path, default version,
-attachment count and dates — which is what AWS returns. On AWS the document comes from
-`GetPolicyVersion`, which substrate does not implement
-([#498](https://github.com/scttfrdmn/substrate/issues/498)). The seeded documents are
-readable in process through `emulator.GetManagedPolicy` and are what the IAM policy
-evaluator reads.
+#### Policy documents and versions
+
+`GetPolicy` returns metadata only — policy ID, name, ARN, path, default version, attachment
+count and dates — which is what AWS returns. The document comes from `GetPolicyVersion`,
+URL-encoded per RFC 3986, for a bundled policy and a created one alike.
+
+**Substrate stores one document per policy**, so `ListPolicyVersions` returns exactly one
+version and `GetPolicyVersion` answers `NoSuchEntity` for any `VersionId` other than the
+policy's default. This is reachable immediately: the catalog reports real AWS defaults, so
+`AmazonSSMManagedInstanceCore` has `DefaultVersionId: v2` and `v1` does not exist here.
+Claiming `v1` resolves when the policy reports `v3` as its default would be a fabricated
+document. A `VersionId` that is not version-shaped at all is `InvalidInput` (400).
+
+The seeded documents are also readable in process through `emulator.GetManagedPolicy`, and
+are what the IAM policy evaluator reads.
 
 ### CloudFormation resource types
 

--- a/emulator/iam_policy_arn.go
+++ b/emulator/iam_policy_arn.go
@@ -74,34 +74,39 @@ func iamPolicyARNIsAWSManaged(arn string) bool {
 }
 
 // iamWarnUnresolvedPolicyARN logs at WARN when a well-formed ARN resolves in neither the
-// bundled catalog nor state, and reports whether it resolved.
+// bundled catalog nor state.
 //
 // The attach still succeeds. The log is what makes the gap visible without breaking the
 // consumer: an AWS managed ARN substrate does not bundle is the expected case (52 of ~1,200),
 // while a customer-managed ARN that resolves nowhere means no CreatePolicy call ever made it,
 // which is more likely to be a real mistake — so the two get different messages.
-func (p *IAMPlugin) iamWarnUnresolvedPolicyARN(goCtx context.Context, operation, arn string) bool {
-	if _, ok := GetManagedPolicy(arn); ok {
-		return true
+//
+// It returns nothing on purpose. An earlier form reported whether the ARN resolved, and no
+// caller used it — a bool no attach reads is a value a test cannot observe, so a mutation
+// flipping it survived the whole suite. The log line is the entire observable effect.
+func (p *IAMPlugin) iamWarnUnresolvedPolicyARN(goCtx context.Context, operation, arn string) {
+	if p.logger == nil {
+		return
 	}
+	if _, ok := GetManagedPolicy(arn); ok {
+		return
+	}
+	// A state failure is treated as "does not resolve": the warning is advisory and the attach
+	// proceeds either way, so a read error must not turn an accepted call into an error.
 	raw, err := p.state.Get(goCtx, iamNamespace, "policy:"+arn)
 	if err == nil && raw != nil {
-		return true
+		return
 	}
 
-	if p.logger == nil {
-		return false
-	}
 	if iamPolicyARNIsAWSManaged(arn) {
 		p.logger.Warn("iam "+operation+": the policy ARN is a well-formed AWS managed ARN "+
 			"substrate does not bundle; the attach succeeds and the policy contributes no "+
 			"statements to an authorization decision",
 			"policyArn", arn)
-		return false
+		return
 	}
 	p.logger.Warn("iam "+operation+": the policy ARN resolves in neither the bundled catalog "+
 		"nor state; the attach succeeds and the policy contributes no statements to an "+
 		"authorization decision",
 		"policyArn", arn)
-	return false
 }

--- a/emulator/iam_policy_arn_test.go
+++ b/emulator/iam_policy_arn_test.go
@@ -1,11 +1,14 @@
 package emulator_test
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -231,6 +234,38 @@ func TestAttachPolicy_AnUnknownEntityDoesNotWarnAboutTheARN(t *testing.T) {
 			assert.Empty(t, logs.messages(), "nothing was attached, so nothing is worth warning about")
 		})
 	}
+}
+
+func TestAttachPolicy_WithoutALoggerTheAttachStillSucceeds(t *testing.T) {
+	// PluginConfig.Logger is optional, so the warning path has to tolerate its absence: the
+	// warning is advisory, and an attach that panicked or failed because nothing was listening
+	// would turn a diagnostic into an outage. The plugin is initialized with a nil logger while
+	// the server keeps a real one, because it is the plugin's guard under test.
+	cfg := emulator.DefaultConfig()
+	state := emulator.NewMemoryStateManager()
+	registry := emulator.NewPluginRegistry()
+
+	plugin := &emulator.IAMPlugin{}
+	require.NoError(t, plugin.Initialize(context.Background(),
+		emulator.PluginConfig{State: state, Logger: nil}))
+	registry.Register(plugin)
+
+	srv := emulator.NewServer(*cfg, registry,
+		emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig()), state,
+		emulator.NewTimeController(time.Now()), emulator.NewDefaultLogger(slog.LevelInfo, false))
+
+	// An ARN that resolves nowhere: the case that would warn if there were anywhere to warn.
+	resp := iamAttach(t, srv, iamAttachTargets[0], "arn:aws:iam::123456789012:policy/never-created")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = iamRequest(t, srv, "ListAttachedUserPolicies", map[string]any{"UserName": "jill"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	attached, ok := result["AttachedPolicies"].([]any)
+	require.True(t, ok, "the attach is recorded whether or not anything logged")
+	assert.Len(t, attached, 1)
 }
 
 func TestAttachPolicy_TheShapeCheckPrecedesAuthorization(t *testing.T) {

--- a/emulator/iam_policy_arn_test.go
+++ b/emulator/iam_policy_arn_test.go
@@ -83,19 +83,27 @@ func TestAttachPolicy_RefusesAMalformedARN(t *testing.T) {
 	// Every case here is a mistake a consumer actually makes: the bare name from the console,
 	// an ARN for the wrong service, a resource type that is not a policy, a slash-terminated
 	// ARN with no name, an account that is not twelve digits.
+	// wantMessage is asserted, not only the code: the length bound and the pattern refuse for
+	// different reasons and say so, and a test checking only "InvalidInput" would pass with
+	// either bound removed entirely.
 	cases := []struct {
-		name      string
-		policyARN string
+		name        string
+		policyARN   string
+		wantMessage string
 	}{
-		{"a bare policy name", "AmazonS3ReadOnlyAccess"},
-		{"not an ARN at all", "not-an-arn-at-all-but-long-enough"},
-		{"the wrong service", "arn:aws:s3:::my-bucket/AmazonS3ReadOnlyAccess"},
-		{"the wrong resource type", "arn:aws:iam::123456789012:role/AmazonS3ReadOnlyAccess"},
-		{"a region where IAM has none", "arn:aws:iam:us-east-1:123456789012:policy/thing"},
-		{"no policy name", "arn:aws:iam::aws:policy/service-role/"},
-		{"a thirteen-digit account", "arn:aws:iam::1234567890123:policy/thing"},
-		{"an eleven-digit account", "arn:aws:iam::12345678901:policy/thing"},
-		{"too short to be an ARN", "arn:aws:iam::a"},
+		{"a bare policy name", "AmazonS3ReadOnlyAccess", "is not valid"},
+		{"not an ARN at all", "not-an-arn-at-all-but-long-enough", "is not valid"},
+		{"the wrong service", "arn:aws:s3:::my-bucket/AmazonS3ReadOnlyAccess", "is not valid"},
+		{"the wrong resource type", "arn:aws:iam::123456789012:role/AmazonS3ReadOnlyAccess", "is not valid"},
+		{"a region where IAM has none", "arn:aws:iam:us-east-1:123456789012:policy/thing", "is not valid"},
+		{"no policy name", "arn:aws:iam::aws:policy/service-role/", "is not valid"},
+		{"a thirteen-digit account", "arn:aws:iam::1234567890123:policy/thing", "is not valid"},
+		{"an eleven-digit account", "arn:aws:iam::12345678901:policy/thing", "is not valid"},
+		// arnType's own bounds, min 20 and max 2048. Both are refused on size rather than by
+		// the pattern, so the message names the length.
+		{"shorter than arnType allows", "arn:aws:iam::a", "between 20 and 2048"},
+		{"longer than arnType allows",
+			"arn:aws:iam::aws:policy/" + strings.Repeat("x", 2048), "between 20 and 2048"},
 	}
 
 	for _, target := range iamAttachTargets {
@@ -109,6 +117,8 @@ func TestAttachPolicy_RefusesAMalformedARN(t *testing.T) {
 				decodeIAMXML(t, resp, &result)
 				assert.Equal(t, "InvalidInput", result["__type"],
 					"the model declares InvalidInputException for all three attach operations")
+				message, _ := result["message"].(string)
+				assert.Contains(t, message, tc.wantMessage)
 			})
 		}
 	}

--- a/test/e2e/journey_iam_simulate_test.go
+++ b/test/e2e/journey_iam_simulate_test.go
@@ -1,0 +1,345 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// The point of the v0.100.0 milestone, driven through the real SDK: a tool asking
+// whether it may act, before acting.
+//
+// This level is the one that matters for these two operations. A unit test calls the
+// handler directly and so never learns whether the operation is routed at all — that
+// was #636 — and it hand-builds a JSON body with real arrays, while every parameter
+// SimulatePrincipalPolicy takes is a query-protocol `.member.N` list that arrives as
+// a flat map of strings (#639). Both failure modes are invisible below this line.
+
+// TestJourney_IAMSimulatePrincipalPolicy asserts all three decisions in a single
+// response, from three different policy sources.
+//
+// The three-way distinction is the feature. A handler that returned one uniform
+// answer — or that collapsed explicitDeny into implicitDeny — would satisfy a test
+// that checked each action separately, so they are checked together: one call, three
+// actions, three different decisions, each traced to the policy that produced it.
+func TestJourney_IAMSimulatePrincipalPolicy(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	// Retries off, so every assertion is about the first response.
+	client := iam.NewFromConfig(cfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	const (
+		userName  = "jill"
+		groupName = "devs"
+		bucketARN = "arn:aws:s3:::my-test-bucket/object"
+		// The group's grant. Bundled, so the simulation reads a real AWS document.
+		managedARN  = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+		managedName = "AmazonS3ReadOnlyAccess"
+		inlineName  = "nodelete"
+	)
+	userARN := "arn:aws:iam::" + journeyAccountID + ":user/" + userName
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{
+		UserName: aws.String(userName),
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{
+		GroupName: aws.String(groupName),
+	}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+	if _, err := client.AddUserToGroup(ctx, &iam.AddUserToGroupInput{
+		GroupName: aws.String(groupName),
+		UserName:  aws.String(userName),
+	}); err != nil {
+		t.Fatalf("AddUserToGroup: %v", err)
+	}
+	// The allow arrives through the *group*, which is why groups had to become real
+	// before the simulator could be right: AWS includes a user's group policies in the
+	// simulation, and a simulation missing them is wrong rather than partial.
+	if _, err := client.AttachGroupPolicy(ctx, &iam.AttachGroupPolicyInput{
+		GroupName: aws.String(groupName),
+		PolicyArn: aws.String(managedARN),
+	}); err != nil {
+		t.Fatalf("AttachGroupPolicy: %v", err)
+	}
+	// The deny is inline on the user, and it is explicit — the distinction the API
+	// exists to report.
+	if _, err := client.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:   aws.String(userName),
+		PolicyName: aws.String(inlineName),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[{"Sid":"NoDelete",` +
+			`"Effect":"Deny","Action":"s3:DeleteObject","Resource":"*"}]}`),
+	}); err != nil {
+		t.Fatalf("PutUserPolicy: %v", err)
+	}
+
+	out, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String(userARN),
+		// Three actions in one call: allowed by the group's managed policy, denied
+		// explicitly by the inline policy, and granted by nothing at all.
+		ActionNames:  []string{"s3:GetObject", "s3:DeleteObject", "s3:PutObject"},
+		ResourceArns: []string{bucketARN},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy: %v", err)
+	}
+	if len(out.EvaluationResults) != 3 {
+		t.Fatalf("got %d evaluation results, want 3 (one per action)", len(out.EvaluationResults))
+	}
+
+	byAction := make(map[string]iamtypes.EvaluationResult, len(out.EvaluationResults))
+	for _, result := range out.EvaluationResults {
+		byAction[aws.ToString(result.EvalActionName)] = result
+	}
+
+	want := map[string]iamtypes.PolicyEvaluationDecisionType{
+		"s3:GetObject":    iamtypes.PolicyEvaluationDecisionTypeAllowed,
+		"s3:DeleteObject": iamtypes.PolicyEvaluationDecisionTypeExplicitDeny,
+		"s3:PutObject":    iamtypes.PolicyEvaluationDecisionTypeImplicitDeny,
+	}
+	for action, wantDecision := range want {
+		result, ok := byAction[action]
+		if !ok {
+			t.Fatalf("no evaluation result for %s; got %v", action, byAction)
+		}
+		if result.EvalDecision != wantDecision {
+			t.Errorf("%s: EvalDecision = %q, want %q", action, result.EvalDecision, wantDecision)
+		}
+		if aws.ToString(result.EvalResourceName) != bucketARN {
+			t.Errorf("%s: EvalResourceName = %q, want %q",
+				action, aws.ToString(result.EvalResourceName), bucketARN)
+		}
+	}
+
+	// MatchedStatements names *which* policy decided, which is the whole output of a
+	// simulation: a decision with no source tells a caller nothing it can act on.
+	if got := matchedSourceIDs(byAction["s3:GetObject"]); !containsString(got, managedName) {
+		t.Errorf("s3:GetObject matched %v, want the group's %s among them", got, managedName)
+	}
+	if got := matchedSourceIDs(byAction["s3:DeleteObject"]); !containsString(got, inlineName) {
+		t.Errorf("s3:DeleteObject matched %v, want the inline %s among them", got, inlineName)
+	}
+	// Nothing matched the ungranted action — an implicit deny is the absence of a
+	// statement, so a source here would mean the emulator invented one.
+	if got := matchedSourceIDs(byAction["s3:PutObject"]); len(got) != 0 {
+		t.Errorf("s3:PutObject matched %v, want nothing for an implicit deny", got)
+	}
+
+	// Removing the group takes the allow with it: the grant was never on the user.
+	if _, err := client.RemoveUserFromGroup(ctx, &iam.RemoveUserFromGroupInput{
+		GroupName: aws.String(groupName),
+		UserName:  aws.String(userName),
+	}); err != nil {
+		t.Fatalf("RemoveUserFromGroup: %v", err)
+	}
+	after, err := client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String(userARN),
+		ActionNames:     []string{"s3:GetObject"},
+		ResourceArns:    []string{bucketARN},
+	})
+	if err != nil {
+		t.Fatalf("SimulatePrincipalPolicy after removal: %v", err)
+	}
+	if len(after.EvaluationResults) != 1 {
+		t.Fatalf("got %d results after removal, want 1", len(after.EvaluationResults))
+	}
+	if got := after.EvaluationResults[0].EvalDecision; got != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+		t.Errorf("s3:GetObject after leaving the group = %q, want implicitDeny", got)
+	}
+}
+
+// TestJourney_IAMSimulatePrincipalPolicy_UnknownPrincipal pins the error the
+// principal form has and the custom form does not.
+func TestJourney_IAMSimulatePrincipalPolicy_UnknownPrincipal(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	client := iam.NewFromConfig(cfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	_, err = client.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String("arn:aws:iam::" + journeyAccountID + ":user/ghost"),
+		ActionNames:     []string{"s3:GetObject"},
+	})
+	if err == nil {
+		t.Fatal("SimulatePrincipalPolicy on an unknown user succeeded, want NoSuchEntity")
+	}
+	// Asserting through the SDK's typed error is what proves the wire shape is right:
+	// a plain 404 with the wrong code does not deserialize into this type.
+	var notFound *iamtypes.NoSuchEntityException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("SimulatePrincipalPolicy error = %v, want *NoSuchEntityException", err)
+	}
+}
+
+// TestJourney_IAMSimulateCustomPolicy evaluates policies that were never stored.
+//
+// The custom form resolves no entity, so it takes documents inline and declares no
+// NoSuchEntity at all. It is also the form a tool uses to check a policy it is about
+// to write, which is the case that cannot be tested any other way.
+func TestJourney_IAMSimulateCustomPolicy(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	client := iam.NewFromConfig(cfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	out, err := client.SimulateCustomPolicy(ctx, &iam.SimulateCustomPolicyInput{
+		PolicyInputList: []string{
+			`{"Version":"2012-10-17","Statement":[{"Sid":"Read","Effect":"Allow",` +
+				`"Action":"s3:GetObject","Resource":"*"}]}`,
+		},
+		ActionNames: []string{"s3:GetObject", "s3:PutObject"},
+	})
+	if err != nil {
+		t.Fatalf("SimulateCustomPolicy: %v", err)
+	}
+	if len(out.EvaluationResults) != 2 {
+		t.Fatalf("got %d results, want 2", len(out.EvaluationResults))
+	}
+
+	byAction := make(map[string]iamtypes.EvaluationResult, len(out.EvaluationResults))
+	for _, result := range out.EvaluationResults {
+		byAction[aws.ToString(result.EvalActionName)] = result
+		// ResourceArns was not supplied, so it defaults to "*" per the reference.
+		if got := aws.ToString(result.EvalResourceName); got != "*" {
+			t.Errorf("%s: EvalResourceName = %q, want the default *",
+				aws.ToString(result.EvalActionName), got)
+		}
+	}
+	if got := byAction["s3:GetObject"].EvalDecision; got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("s3:GetObject = %q, want allowed", got)
+	}
+	if got := byAction["s3:PutObject"].EvalDecision; got != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+		t.Errorf("s3:PutObject = %q, want implicitDeny", got)
+	}
+
+	// A boundary caps what the identity policy reaches. The allow above stays an
+	// allow only while the boundary permits it, and the result is an *implicit* deny:
+	// a boundary limits reachability rather than denying an action by name.
+	bounded, err := client.SimulateCustomPolicy(ctx, &iam.SimulateCustomPolicyInput{
+		PolicyInputList: []string{
+			`{"Version":"2012-10-17","Statement":[{"Sid":"Read","Effect":"Allow",` +
+				`"Action":"s3:GetObject","Resource":"*"}]}`,
+		},
+		PermissionsBoundaryPolicyInputList: []string{
+			`{"Version":"2012-10-17","Statement":[{"Sid":"OnlyList","Effect":"Allow",` +
+				`"Action":"s3:ListBucket","Resource":"*"}]}`,
+		},
+		ActionNames: []string{"s3:GetObject"},
+	})
+	if err != nil {
+		t.Fatalf("SimulateCustomPolicy with a boundary: %v", err)
+	}
+	if len(bounded.EvaluationResults) != 1 {
+		t.Fatalf("got %d results, want 1", len(bounded.EvaluationResults))
+	}
+	result := bounded.EvaluationResults[0]
+	if result.EvalDecision != iamtypes.PolicyEvaluationDecisionTypeImplicitDeny {
+		t.Errorf("s3:GetObject under a boundary that omits it = %q, want implicitDeny",
+			result.EvalDecision)
+	}
+	if result.PermissionsBoundaryDecisionDetail == nil {
+		t.Fatal("PermissionsBoundaryDecisionDetail is absent; a caller cannot tell the " +
+			"boundary was what refused")
+	}
+	if result.PermissionsBoundaryDecisionDetail.AllowedByPermissionsBoundary {
+		t.Error("AllowedByPermissionsBoundary = true for an action the boundary omits")
+	}
+}
+
+// TestJourney_IAMSimulateCustomPolicy_MissingContextValues asserts that a
+// conditional grant does not read as a clean refusal.
+//
+// Without this, a policy allowing an action only when a condition key matches looks
+// identical to one that never granted it — so a consumer's preflight would report
+// "you cannot" where the truth is "not with what you told me".
+func TestJourney_IAMSimulateCustomPolicy_MissingContextValues(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	client := iam.NewFromConfig(cfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	const conditional = `{"Version":"2012-10-17","Statement":[{"Sid":"TaggedOnly",` +
+		`"Effect":"Allow","Action":"s3:GetObject","Resource":"*","Condition":` +
+		`{"StringEquals":{"aws:RequestTag/env":"prod"}}}]}`
+
+	out, err := client.SimulateCustomPolicy(ctx, &iam.SimulateCustomPolicyInput{
+		PolicyInputList: []string{conditional},
+		ActionNames:     []string{"s3:GetObject"},
+	})
+	if err != nil {
+		t.Fatalf("SimulateCustomPolicy: %v", err)
+	}
+	if len(out.EvaluationResults) != 1 {
+		t.Fatalf("got %d results, want 1", len(out.EvaluationResults))
+	}
+	if got := out.EvaluationResults[0].MissingContextValues; !containsString(got, "aws:RequestTag/env") {
+		t.Errorf("MissingContextValues = %v, want aws:RequestTag/env among them", got)
+	}
+
+	// Supplied, the same simulation allows — and reports nothing missing.
+	supplied, err := client.SimulateCustomPolicy(ctx, &iam.SimulateCustomPolicyInput{
+		PolicyInputList: []string{conditional},
+		ActionNames:     []string{"s3:GetObject"},
+		ContextEntries: []iamtypes.ContextEntry{{
+			ContextKeyName:   aws.String("aws:RequestTag/env"),
+			ContextKeyType:   iamtypes.ContextKeyTypeEnumString,
+			ContextKeyValues: []string{"prod"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SimulateCustomPolicy with a context entry: %v", err)
+	}
+	if len(supplied.EvaluationResults) != 1 {
+		t.Fatalf("got %d results, want 1", len(supplied.EvaluationResults))
+	}
+	if got := supplied.EvaluationResults[0].EvalDecision; got != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+		t.Errorf("s3:GetObject with the condition satisfied = %q, want allowed", got)
+	}
+	if got := supplied.EvaluationResults[0].MissingContextValues; len(got) != 0 {
+		t.Errorf("MissingContextValues = %v, want empty once the key is supplied", got)
+	}
+}
+
+// matchedSourceIDs returns the SourcePolicyId of every statement a result matched.
+func matchedSourceIDs(result iamtypes.EvaluationResult) []string {
+	ids := make([]string, 0, len(result.MatchedStatements))
+	for _, statement := range result.MatchedStatements {
+		ids = append(ids, aws.ToString(statement.SourcePolicyId))
+	}
+	return ids
+}
+
+// containsString reports whether values holds want.
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The documentation and end-to-end half of the v0.100.0 IAM work. No behaviour changes — every operation described here already merged.

## `docs/services.md` was describing the pre-release state

Three entries were actively wrong after this milestone's PRs:

- `AttachUserPolicy` / `AttachRolePolicy`: "Does not verify the policy ARN resolves (#499)" — they now refuse a malformed ARN.
- `ListPolicies`: "Lists `CreatePolicy` policies only; `Scope` and `PathPrefix` are accepted and not applied (#497)" — it now applies them and sees the catalog.
- "Policy documents are not observable over the wire… `GetPolicyVersion`, which substrate does not implement (#498)" — it is implemented.

The operation table also omitted seventeen routed operations: the eleven group operations, both `Simulate*`, both version operations, and `DeleteInstanceProfile`/`RemoveRoleFromInstanceProfile`/`ListInstanceProfiles`. All are now listed with the behaviour worth knowing before calling them.

## New prose

**"What the policy simulator evaluates"** — the three decisions and why the distinction matters to an assertion, exactly what is in the evaluated policy set for each of the two operations, `MatchedStatements`/`MissingContextValues`, and the parameter defaults (including that there is **no** cap on actions per call).

**"What the simulator does not evaluate"** — a table, one row per omission with its reason, because a fabricated field in a preflight answer is worse than a missing one: SCPs (stored by Organizations, never consulted by `CheckAccess` either, so `OrganizationsDecisionDetail` is *absent* rather than present-and-`false`), `StartPosition`/`EndPosition` (offsets into text substrate does not keep), the cross-account details, and the two ignored mode parameters. It closes by saying plainly that a consumer whose preflight depends on an SCP boundary cannot get that answer here.

**"Finding a policy: `ListPolicies` scope"** — that `Scope=AWS` means the 52-policy catalog, that `PathPrefix` must begin *and* end with a slash as IAM requires, that `OnlyAttached` is computed from stored attachments rather than the catalog's always-zero count, and that `PolicyUsageFilter` is validated and narrows nothing (with the reason: guessing which side an unused policy falls on would silently drop all 52).

**"Attaching a policy substrate does not bundle"**, rewritten for #499's shipped behaviour, including the consequence a reader actually needs: an attached-but-unresolvable policy contributes no statements, so `CheckAccess` and the simulator both behave as though it were not attached.

**"Policy documents and versions"** — the RFC 3986 encoding, and why one version per policy means `v1` does not exist for a policy whose default is `v2`.

## `test/e2e/journey_iam_simulate_test.go`

The point of the milestone, through the real SDK. Four tests:

- **All three decisions in one response.** A group's managed allow (`AmazonS3ReadOnlyAccess`), a user's inline explicit deny, and an action nothing grants — one `SimulatePrincipalPolicy` call, three actions, three different `EvalDecision` values, each traced through `MatchedStatements` to the policy that produced it. Checked together rather than separately, so a handler returning a uniform answer fails. Then `RemoveUserFromGroup` and the allow becomes an implicit deny, proving the grant was only ever on the group.
- **An unknown principal** → asserted through the SDK's typed `*NoSuchEntityException`, which is what proves the wire shape rather than just the status code.
- **`SimulateCustomPolicy`** over documents that were never stored — the form a tool uses to check a policy it is about to write — including `ResourceArns` defaulting to `*`, and a boundary flipping an allow to an **implicit** deny with `AllowedByPermissionsBoundary=false`.
- **`MissingContextValues`** on a conditional grant, and the same simulation allowing once the `ContextEntry` is supplied. Without this a conditional grant is indistinguishable from a missing one, and a preflight would report "you cannot" where the truth is "not with what you told me".

This level is the one that matters for these operations: a unit test calls the handler directly and never learns whether it is routed (#636), and hand-marshals a body with real arrays while every parameter these two take is a query-protocol `.member.N` list (#639). Both failure modes are invisible below this line.

## Verification

`gofmt -l .` clean; `go build ./...`; `go vet ./...`; `golangci-lint run ./...` → `0 issues.`; `make test` (race) green; `make docs-reference-check docs-versions` clean; `npm --prefix docs run build` clean; `go vet -C test/e2e ./...` and the full `go test -C test/e2e ./...` green.