### PR TITLE
chore(release): v0.100.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.100.0] - 2026-08-14
+
 ### Added
 - **A tool can ask before it acts: `SimulatePrincipalPolicy` and `SimulateCustomPolicy`**
   (#579). These are the only AWS APIs that decide whether a principal may do X to Y
@@ -6563,7 +6565,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.98.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.100.0...HEAD
+[v0.100.0]: https://github.com/scttfrdmn/substrate/compare/v0.99.0...v0.100.0
 [v0.99.0]: https://github.com/scttfrdmn/substrate/compare/v0.98.0...v0.99.0
 [v0.98.0]: https://github.com/scttfrdmn/substrate/compare/v0.97.0...v0.98.0
 [v0.97.0]: https://github.com/scttfrdmn/substrate/compare/v0.96.0...v0.97.0


### PR DESCRIPTION
Moves the `## [Unreleased]` entries into `## [v0.100.0] - 2026-08-14` and adds the
comparison link, per the release procedure in `CLAUDE.md`. No code changes.

The release is IAM only, themed on a tool being able to ask before it acts:
`SimulatePrincipalPolicy`/`SimulateCustomPolicy` (#579) plus the group support they
require, and the three fidelity issues that make a simulated answer checkable
(#497, #498, #499) alongside the two query-protocol decoding defects found while
building them (#639, #642).

Closes #579
Closes #497
Closes #498
Closes #499
Closes #639
Closes #642