### PR TITLE
feat(config): configuration recorder and delivery channel (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **An account can be asked whether it is being recorded: AWS Config's recorder and
+  delivery channel** (#580). Substrate emulated 66 services and not one of them could
+  answer "is this account under configuration recording, and is delivery working?" — the
+  detective half of the control loop a consumer builds after its stacks deploy. There was
+  no Config plugin at all.
+
+  The headline behaviour is that **two operations that look like they answer the same
+  question must disagree**. `DescribeConfigurationRecorders` reporting a recorder says
+  nothing about whether it is recording; that is
+  `DescribeConfigurationRecorderStatus.recording`. A recorder created and never started is
+  the single most common real Config misconfiguration, and a consumer that checks only the
+  first call reports an account as covered when nothing is being recorded. Substrate now
+  distinguishes them: `PutConfigurationRecorder` leaves `recording: false`, and only
+  `StartConfigurationRecorder` flips it.
+
+  The ordering refusals are the other half, and they make a consumer's sequencing bug
+  observable instead of silently tolerated. `StartConfigurationRecorder` without a delivery
+  channel is `NoAvailableDeliveryChannelException`; `PutDeliveryChannel` without a recorder
+  is `NoAvailableConfigurationRecorderException`, checked **before** the bucket so a
+  consumer with neither is told to fix the recorder first; `DeleteDeliveryChannel` while the
+  recorder runs is `LastDeliveryChannelDeleteFailedException`, which is what makes a
+  teardown-and-rebuild fixture — the same test run twice — express an ordering requirement
+  rather than pass on a sequence AWS rejects.
+
+  **`PutDeliveryChannel` computes its S3 refusals from real S3 state**, which makes it the
+  one Config operation whose success depends on another service. A missing bucket is
+  `NoSuchBucketException`; a bucket with no policy at all is
+  `InsufficientDeliveryPolicyException`. Where a policy exists, the matcher is deliberately
+  **permissive**: it passes if any `Allow` statement's principal covers
+  `config.amazonaws.com` or `*` and its action covers `s3:PutObject` — including `s3:Put*`,
+  `s3:*` and `*` — and it does not match the resource ARN. A policy shape substrate's parser
+  cannot decode passes too, because refusing there would be substrate blaming the consumer
+  for its own limitation. The two failure directions are not symmetric: always accepting
+  would make a bucket-policy bug invisible here and fatal at AWS, while demanding the exact
+  documented policy would refuse policies AWS accepts, and a wrong refusal breaks working
+  code.
+
+  Both `Put`s are idempotent per the reference — a second call with the same name updates the
+  role and recording group but **does not** replace creation-time tags — and a second
+  *distinct* name is `MaxNumberOf{ConfigurationRecorders,DeliveryChannels}ExceededException`,
+  there being one of each per account per Region. Both names default to `default`. An empty
+  `roleARN` is `InvalidRoleException`: the reference's own message makes this a null/empty
+  check, **not** an assumability check, so a role that was never created is accepted, as AWS
+  accepts it. A name prefixed `AWSConfigurationRecorderFor` is
+  `InvalidConfigurationRecorderNameException`, and `InvalidRecordingGroupException`
+  implements the reference's enumerated cases. The default recording group records all
+  supported types **excluding** the four global IAM types. Every state key carries the
+  Region, so a recorder put in `us-east-1` is absent in `eu-west-1` — "recording in one
+  Region only" being another misconfiguration that looks like success.
+
+- **Control-plane seeds for the statuses no API call can reach** (#580):
+  `POST`/`DELETE /v1/config/recorder-status`, `/v1/config/delivery-status` and
+  `/v1/config/delivery-policy`. Substrate delivers nothing to S3, so no sequence of calls
+  can produce a failed delivery — and a consumer's delivery-failure branch is code that
+  exists precisely for one. Each is scoped by account and Region with `*` wildcards, is
+  applied at read time so clearing restores the real status, and validates against the API
+  model's own enum: a near-miss such as `NotApplicable` for the `DeliveryStatus` member AWS
+  spells `Not_Applicable` is refused rather than stored as a value no SDK enum matches, and
+  an error code on a non-`Failure` status is refused rather than half-applied. Delivery
+  status reports `Not_Applicable` until the recorder first starts and `Success` after, per
+  stream, because reporting `Success` before anything was delivered would tell a consumer
+  its pipeline works when nothing has gone through it.
+
+### Fixed
+- **Every AWS Config request was unroutable** (#580). Config's `X-Amz-Target` prefix is
+  `StarlingDoveService` — an internal code name bearing no resemblance to the `config`
+  endpoint prefix, the way `TrentService` is KMS's — and `starlingdoveservice` was absent
+  from `targetServiceAliases`, so it reduced to nothing and every SDK call fell through to
+  "service not emulated: starlingdoveservice". The target path is the one every
+  aws-sdk-go-v2 and boto3 Config call takes, so without the alias the plugin would have been
+  registered and unit-tested green while unreachable — exactly what #561, #610 and #636 were.
+  A unit test now asserts resolution by target prefix, host **and** SigV4 signing name, so
+  the gap cannot reopen silently.
+
 ## [v0.100.0] - 2026-08-14
 
 ### Added

--- a/cmd/gen-service-reference/main.go
+++ b/cmd/gen-service-reference/main.go
@@ -69,6 +69,7 @@ var meta = map[string]pluginMeta{
 	"codepipeline":         {"CodePipeline", "JSON"},
 	"cognito-identity":     {"Cognito Identity", "JSON"},
 	"cognito-idp":          {"Cognito Identity Provider", "JSON"},
+	"config":               {"Config", "JSON"},
 	"dynamodb":             {"DynamoDB", "JSON"},
 	"ec2":                  {"EC2 / VPC", "Query"},
 	"ecr":                  {"ECR", "JSON"},

--- a/docs/services.md
+++ b/docs/services.md
@@ -3,7 +3,7 @@
 ## Coverage matrix
 
 <!-- BEGIN GENERATED COVERAGE MATRIX -->
-Substrate ships **66 built-in service plugins**. This section is generated
+Substrate ships **67 built-in service plugins**. This section is generated
 from the plugin registry (`make docs-reference`), so the count and plugin list
 cannot drift from the implementation. The live count is also available from the
 `/ready` endpoint (`curl http://localhost:4566/ready`). Per-service operation,
@@ -30,53 +30,54 @@ CloudFormation, and cost detail follows below the matrix.
 | 17 | CodePipeline | `codepipeline` | JSON |
 | 18 | Cognito Identity | `cognito-identity` | JSON |
 | 19 | Cognito Identity Provider | `cognito-idp` | JSON |
-| 20 | DynamoDB | `dynamodb` | JSON |
-| 21 | EC2 / VPC | `ec2` | Query |
-| 22 | ECR | `ecr` | JSON |
-| 23 | ECS | `ecs` | JSON |
-| 24 | EFS | `efs` | REST/JSON |
-| 25 | ElastiCache | `elasticache` | Query |
-| 26 | ELBv2 | `elasticloadbalancing` | Query |
-| 27 | EMR Serverless | `emrserverless` | REST/JSON |
-| 28 | EventBridge | `eventbridge` | JSON |
-| 29 | API Gateway (execute-api) | `execute-api` | REST/JSON |
-| 30 | Kinesis Data Firehose | `firehose` | JSON |
-| 31 | FSx | `fsx` | JSON |
-| 32 | Glue | `glue` | JSON |
-| 33 | Health | `health` | JSON |
-| 34 | IAM | `iam` | Query |
-| 35 | Kinesis Data Streams | `kinesis` | JSON |
-| 36 | KMS | `kms` | JSON |
-| 37 | Lambda | `lambda` | REST/JSON |
-| 38 | CloudWatch Logs | `logs` | JSON |
-| 39 | CloudWatch | `monitoring` | Query |
-| 40 | MSK | `msk` | REST/JSON |
-| 41 | HealthOmics | `omics` | REST/JSON |
-| 42 | OpenSearch | `opensearch` | REST/JSON |
-| 43 | Organizations | `organizations` | JSON |
-| 44 | Price List Query API | `pricing` | JSON |
-| 45 | QuickSight | `quicksight` | REST/JSON |
-| 46 | RAM | `ram` | REST/JSON |
-| 47 | RDS | `rds` | Query |
-| 48 | Redshift | `redshift` | Query |
-| 49 | Redshift Data API | `redshift-data` | JSON |
-| 50 | Route 53 | `route53` | REST/XML |
-| 51 | S3 | `s3` | REST/XML |
-| 52 | SageMaker | `sagemaker` | JSON |
-| 53 | EventBridge Scheduler | `scheduler` | REST/JSON |
-| 54 | Secrets Manager | `secretsmanager` | JSON |
-| 55 | Service Quotas | `servicequotas` | JSON |
-| 56 | SES v2 | `sesv2` | REST/JSON |
-| 57 | SNS | `sns` | Query |
-| 58 | SQS | `sqs` | JSON |
-| 59 | SSM | `ssm` | JSON |
-| 60 | SSO / Identity Store | `sso` | REST/JSON |
-| 61 | Step Functions | `states` | JSON |
-| 62 | STS | `sts` | Query |
-| 63 | Resource Groups Tagging | `tagging` | JSON |
-| 64 | Timestream | `timestream` | JSON |
-| 65 | Transfer Family | `transfer` | JSON |
-| 66 | WAFv2 | `wafv2` | JSON |
+| 20 | Config | `config` | JSON |
+| 21 | DynamoDB | `dynamodb` | JSON |
+| 22 | EC2 / VPC | `ec2` | Query |
+| 23 | ECR | `ecr` | JSON |
+| 24 | ECS | `ecs` | JSON |
+| 25 | EFS | `efs` | REST/JSON |
+| 26 | ElastiCache | `elasticache` | Query |
+| 27 | ELBv2 | `elasticloadbalancing` | Query |
+| 28 | EMR Serverless | `emrserverless` | REST/JSON |
+| 29 | EventBridge | `eventbridge` | JSON |
+| 30 | API Gateway (execute-api) | `execute-api` | REST/JSON |
+| 31 | Kinesis Data Firehose | `firehose` | JSON |
+| 32 | FSx | `fsx` | JSON |
+| 33 | Glue | `glue` | JSON |
+| 34 | Health | `health` | JSON |
+| 35 | IAM | `iam` | Query |
+| 36 | Kinesis Data Streams | `kinesis` | JSON |
+| 37 | KMS | `kms` | JSON |
+| 38 | Lambda | `lambda` | REST/JSON |
+| 39 | CloudWatch Logs | `logs` | JSON |
+| 40 | CloudWatch | `monitoring` | Query |
+| 41 | MSK | `msk` | REST/JSON |
+| 42 | HealthOmics | `omics` | REST/JSON |
+| 43 | OpenSearch | `opensearch` | REST/JSON |
+| 44 | Organizations | `organizations` | JSON |
+| 45 | Price List Query API | `pricing` | JSON |
+| 46 | QuickSight | `quicksight` | REST/JSON |
+| 47 | RAM | `ram` | REST/JSON |
+| 48 | RDS | `rds` | Query |
+| 49 | Redshift | `redshift` | Query |
+| 50 | Redshift Data API | `redshift-data` | JSON |
+| 51 | Route 53 | `route53` | REST/XML |
+| 52 | S3 | `s3` | REST/XML |
+| 53 | SageMaker | `sagemaker` | JSON |
+| 54 | EventBridge Scheduler | `scheduler` | REST/JSON |
+| 55 | Secrets Manager | `secretsmanager` | JSON |
+| 56 | Service Quotas | `servicequotas` | JSON |
+| 57 | SES v2 | `sesv2` | REST/JSON |
+| 58 | SNS | `sns` | Query |
+| 59 | SQS | `sqs` | JSON |
+| 60 | SSM | `ssm` | JSON |
+| 61 | SSO / Identity Store | `sso` | REST/JSON |
+| 62 | Step Functions | `states` | JSON |
+| 63 | STS | `sts` | Query |
+| 64 | Resource Groups Tagging | `tagging` | JSON |
+| 65 | Timestream | `timestream` | JSON |
+| 66 | Transfer Family | `transfer` | JSON |
+| 67 | WAFv2 | `wafv2` | JSON |
 <!-- END GENERATED COVERAGE MATRIX -->
 
 ---

--- a/emulator/configservice_channel.go
+++ b/emulator/configservice_channel.go
@@ -1,0 +1,543 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// The delivery-channel cluster, and the S3 bucket-policy check (#580).
+//
+// The channel ships alongside the recorder rather than after it, because
+// StartConfigurationRecorder refuses without a channel: a recorder-only release
+// could never reach `recording: true`, which is the behavior the whole cluster
+// exists to make observable.
+//
+// # The delivery-policy check
+//
+// PutDeliveryChannel is the one Config operation whose success depends on state in
+// *another* service: the bucket must exist and its policy must let Config write.
+// AWS reports the two failures separately, as NoSuchBucketException and
+// InsufficientDeliveryPolicyException, and substrate computes both from real S3
+// state rather than accepting unconditionally.
+//
+// The matcher is deliberately **permissive**. The two ways to get this wrong are not
+// symmetric:
+//
+//   - Always accepting would make a consumer's bucket-policy bug invisible here and
+//     fatal at AWS — the emulator would have said yes to the one thing it was asked
+//     to check.
+//   - Demanding the exact policy from the AWS documentation would refuse policies
+//     AWS accepts, and a wrong refusal breaks working consumer code. That is the
+//     worse failure, and it is the one a strict matcher produces every time a
+//     consumer writes a correct policy in a form substrate's parser did not expect.
+//
+// So: a bucket with no policy at all is refused, since that is unambiguous and is
+// the mistake consumers actually make. A bucket *with* a policy passes if any Allow
+// statement plausibly admits Config — and an unparseable policy passes too, because
+// refusing on substrate's own parser would be substrate blaming the consumer for its
+// own limitation. Resource ARNs are not matched at all; getting the prefix wrong is
+// a real bug, but it is not one this check can distinguish from a valid variant.
+//
+// A consumer that has no S3 fixture, or that needs the refusal on demand, seeds the
+// outcome instead — see configservice_control.go.
+
+// cfgsvcMaxChannels is the number of delivery channels AWS permits per account per
+// Region, from PutDeliveryChannel's own "you can have only one" note rather than
+// from the service-limits page, which lists no channel maximum.
+const cfgsvcMaxChannels = 1
+
+// cfgsvcConfigServicePrincipal is the service principal a bucket policy must admit
+// for Config to deliver to it.
+const cfgsvcConfigServicePrincipal = "config.amazonaws.com"
+
+// ConfigDeliveryChannel is a stored delivery channel — the DeliveryChannel shape.
+// Its members are lowerCamel on the wire, like ConfigurationRecorder's.
+type ConfigDeliveryChannel struct {
+	// Name is the channel name, "default" when the request omitted one.
+	Name string `json:"name"`
+
+	// S3BucketName is the bucket configuration snapshots are delivered to.
+	S3BucketName string `json:"s3BucketName,omitempty"`
+
+	// S3KeyPrefix is the prefix within that bucket.
+	S3KeyPrefix string `json:"s3KeyPrefix,omitempty"`
+
+	// S3KmsKeyArn is the KMS key used to encrypt delivered objects.
+	S3KmsKeyArn string `json:"s3KmsKeyArn,omitempty"`
+
+	// SnsTopicARN is the topic configuration change notifications go to.
+	SnsTopicARN string `json:"snsTopicARN,omitempty"`
+
+	// ConfigSnapshotDeliveryProperties is the snapshot delivery frequency.
+	ConfigSnapshotDeliveryProperties json.RawMessage `json:"configSnapshotDeliveryProperties,omitempty"`
+}
+
+// cfgsvcPutChannelRequest is PutDeliveryChannelRequest.
+type cfgsvcPutChannelRequest struct {
+	// DeliveryChannel is the channel to create or update, required.
+	DeliveryChannel *ConfigDeliveryChannel `json:"DeliveryChannel"`
+}
+
+// cfgsvcDescribeChannelsRequest is the input shared by DescribeDeliveryChannels and
+// DescribeDeliveryChannelStatus: a name list, and no pagination.
+type cfgsvcDescribeChannelsRequest struct {
+	// DeliveryChannelNames selects channels by name.
+	DeliveryChannelNames []string `json:"DeliveryChannelNames"`
+}
+
+// cfgsvcChannelNameRequest is the input to DeleteDeliveryChannel.
+type cfgsvcChannelNameRequest struct {
+	// DeliveryChannelName names the channel, required.
+	DeliveryChannelName string `json:"DeliveryChannelName"`
+}
+
+// channelOperation claims the delivery-channel operations.
+func (p *ConfigServicePlugin) channelOperation(op string) (cfgsvcHandler, bool) {
+	switch op {
+	case "PutDeliveryChannel":
+		return p.putDeliveryChannel, true
+	case "DescribeDeliveryChannels":
+		return p.describeDeliveryChannels, true
+	case "DescribeDeliveryChannelStatus":
+		return p.describeDeliveryChannelStatus, true
+	case "DeleteDeliveryChannel":
+		return p.deleteDeliveryChannel, true
+	}
+	return nil, false
+}
+
+// putDeliveryChannel creates or updates the account's delivery channel.
+//
+// The checks run in the order AWS documents them, and the order is observable: a
+// consumer with neither a recorder nor a bucket gets
+// NoAvailableConfigurationRecorderException, not NoSuchBucketException, so the first
+// thing it is told to fix is the first thing it must fix.
+func (p *ConfigServicePlugin) putDeliveryChannel(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcPutChannelRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	if in.DeliveryChannel == nil {
+		return nil, cfgsvcValidation("DeliveryChannel is required.")
+	}
+
+	channel := *in.DeliveryChannel
+	if channel.Name == "" {
+		channel.Name = cfgsvcDefaultName
+	}
+	if len(channel.Name) > cfgsvcMaxNameLen {
+		return nil, cfgsvcValidation("The delivery channel name must be between 1 and 256 characters long.")
+	}
+
+	goCtx := context.Background()
+	var recorder ConfigRecorder
+	hasRecorder, err := p.cfgsvcGetJSON(goCtx, cfgsvcRecorderKey(ctx.AccountID, ctx.Region), &recorder)
+	if err != nil {
+		return nil, err
+	}
+	if !hasRecorder {
+		return nil, cfgsvcNoAvailableRecorder()
+	}
+
+	if err := p.cfgsvcCheckDeliveryBucket(goCtx, channel.S3BucketName); err != nil {
+		return nil, err
+	}
+
+	key := cfgsvcChannelKey(ctx.AccountID, ctx.Region)
+	var existing ConfigDeliveryChannel
+	found, err := p.cfgsvcGetJSON(goCtx, key, &existing)
+	if err != nil {
+		return nil, err
+	}
+	if found && existing.Name != channel.Name {
+		return nil, cfgsvcErr("MaxNumberOfDeliveryChannelsExceededException",
+			"You have reached the limit of the number of delivery channels you can create.")
+	}
+	if err := p.cfgsvcPutJSON(goCtx, key, channel); err != nil {
+		return nil, err
+	}
+	return cfgsvcEmptyResponse(), nil
+}
+
+// cfgsvcNoAvailableRecorder is NoAvailableConfigurationRecorderException, which both
+// PutDeliveryChannel and PutConfigRule report. #580 omitted it; the model and the
+// reference both carry it, and it is what makes a consumer's ordering bug visible.
+func cfgsvcNoAvailableRecorder() *AWSError {
+	return cfgsvcErr("NoAvailableConfigurationRecorderException",
+		"There are no customer managed configuration recorders available to record your "+
+			"resources. Use the PutConfigurationRecorder operation to create the customer "+
+			"managed configuration recorder.")
+}
+
+// cfgsvcCheckDeliveryBucket checks the delivery bucket against real S3 state, or
+// against a seeded outcome if one is set.
+//
+// A channel with no bucket at all is accepted: DeliveryS3Bucket is min-length 0 in
+// the model and the operation does not require it, so refusing one would refuse a
+// request AWS accepts.
+func (p *ConfigServicePlugin) cfgsvcCheckDeliveryBucket(goCtx context.Context, bucket string) error {
+	if bucket == "" {
+		return nil
+	}
+
+	// The seed is consulted first and is absolute in both directions: a consumer with
+	// no S3 fixture needs "insufficient" without a bucket, and a consumer whose policy
+	// substrate's matcher cannot read needs "ok" without arguing with it.
+	outcome, seeded, err := p.seededDeliveryPolicy(goCtx, bucket)
+	if err != nil {
+		return err
+	}
+	if seeded {
+		if outcome == cfgsvcDeliveryOutcomeInsufficient {
+			return cfgsvcInsufficientDeliveryPolicy()
+		}
+		return nil
+	}
+
+	// S3 state is read straight out of the s3 namespace. authz.go already reads five
+	// namespaces from one controller, so a plugin reading another service's state is
+	// established practice rather than a new coupling — and the alternative, an
+	// internal S3 API call, would put an authorization decision in the middle of a
+	// validity check.
+	bucketData, err := p.state.Get(goCtx, s3Namespace, "bucket:"+bucket)
+	if err != nil {
+		return cfgsvcValidation("could not read bucket state: " + err.Error())
+	}
+	if bucketData == nil {
+		return cfgsvcErr("NoSuchBucketException", "The specified Amazon S3 bucket does not exist.")
+	}
+
+	policyData, err := p.state.Get(goCtx, s3Namespace, "bucket_policy:"+bucket)
+	if err != nil {
+		return cfgsvcValidation("could not read bucket policy: " + err.Error())
+	}
+	if policyData == nil {
+		return cfgsvcInsufficientDeliveryPolicy()
+	}
+	if !cfgsvcPolicyAdmitsConfig(policyData) {
+		return cfgsvcInsufficientDeliveryPolicy()
+	}
+	return nil
+}
+
+// cfgsvcInsufficientDeliveryPolicy is InsufficientDeliveryPolicyException.
+func cfgsvcInsufficientDeliveryPolicy() *AWSError {
+	return cfgsvcErr("InsufficientDeliveryPolicyException",
+		"Your Amazon S3 bucket policy does not allow Config to write to it.")
+}
+
+// cfgsvcPolicyAdmitsConfig reports whether a bucket policy plausibly lets Config
+// deliver to the bucket.
+//
+// Permissive by design, per the file header. Anything it cannot read passes, because
+// a refusal traceable to substrate's parser rather than to the policy would be
+// substrate blaming the consumer for its own limitation. What it does check is the
+// pairing a broken policy actually gets wrong: an Allow whose principal covers
+// Config and whose action covers PutObject.
+func cfgsvcPolicyAdmitsConfig(raw []byte) bool {
+	// The stored value is an S3BucketPolicy wrapper holding the document as a string;
+	// a document written directly into state is accepted too, so a fixture that seeded
+	// one form does not silently fail the check.
+	document := raw
+	var wrapper S3BucketPolicy
+	if err := json.Unmarshal(raw, &wrapper); err == nil && wrapper.Policy != "" {
+		document = []byte(wrapper.Policy)
+	}
+
+	var policy struct {
+		Statement []struct {
+			Effect    string          `json:"Effect"`
+			Principal json.RawMessage `json:"Principal"`
+			Action    json.RawMessage `json:"Action"`
+		} `json:"Statement"`
+	}
+	if err := json.Unmarshal(document, &policy); err != nil {
+		return true
+	}
+	// A document that parsed but carries no statements is not a policy that admits
+	// anything, and an empty Statement array is a mistake rather than a parser
+	// limitation — so unlike an unreadable document, this one is refused.
+	if len(policy.Statement) == 0 {
+		return false
+	}
+
+	for _, stmt := range policy.Statement {
+		if !strings.EqualFold(stmt.Effect, "Allow") {
+			continue
+		}
+		if cfgsvcPrincipalCoversConfig(stmt.Principal) && cfgsvcActionCoversPutObject(stmt.Action) {
+			return true
+		}
+	}
+	return false
+}
+
+// cfgsvcPrincipalCoversConfig reports whether a statement's Principal covers the
+// Config service principal.
+//
+// A Principal is "*", a map of principal types to one-or-many values, or (in a
+// hand-written fixture) a bare string. All three are accepted; anything unreadable
+// is treated as covering, per the permissive rule.
+func cfgsvcPrincipalCoversConfig(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		return str == "*" || strings.Contains(str, cfgsvcConfigServicePrincipal)
+	}
+	var typed map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &typed); err != nil {
+		return true
+	}
+	for _, value := range typed {
+		for _, entry := range cfgsvcStringOrSlice(value) {
+			if entry == "*" || strings.Contains(entry, cfgsvcConfigServicePrincipal) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// cfgsvcActionCoversPutObject reports whether a statement's Action covers writing an
+// object: s3:PutObject exactly, or any of the wildcards that subsume it.
+func cfgsvcActionCoversPutObject(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	for _, action := range cfgsvcStringOrSlice(raw) {
+		lower := strings.ToLower(strings.TrimSpace(action))
+		if lower == "*" || lower == "s3:*" || lower == "s3:putobject" {
+			return true
+		}
+		// A prefix wildcard such as s3:Put* covers PutObject. Matching the prefix rather
+		// than expanding the wildcard keeps this readable and errs toward accepting.
+		if strings.HasSuffix(lower, "*") && strings.HasPrefix("s3:putobject", strings.TrimSuffix(lower, "*")) {
+			return true
+		}
+	}
+	return false
+}
+
+// cfgsvcStringOrSlice decodes an IAM policy field that may be a single string or a
+// list of them, which is the shape of nearly every member of a policy document.
+func cfgsvcStringOrSlice(raw json.RawMessage) []string {
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return []string{single}
+	}
+	var many []string
+	if err := json.Unmarshal(raw, &many); err == nil {
+		return many
+	}
+	return nil
+}
+
+// describeDeliveryChannels reports the account's delivery channel.
+func (p *ConfigServicePlugin) describeDeliveryChannels(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	channel, found, err := p.cfgsvcResolveDescribedChannel(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	channels := []ConfigDeliveryChannel{}
+	if found {
+		channels = append(channels, *channel)
+	}
+	return cfgsvcJSONResponse(map[string]interface{}{"DeliveryChannels": channels},
+		"describeDeliveryChannels")
+}
+
+// describeDeliveryChannelStatus reports how delivery is going.
+//
+// Before the recorder has ever started there is nothing to deliver, so every stream
+// reports Not_Applicable — note the underscore and the capital A, which is how the
+// DeliveryStatus enum spells this member and only this member. After a start they
+// report Success, and a seed can pin Failure with an error code and message so a
+// consumer's delivery-failure branch is reachable.
+func (p *ConfigServicePlugin) describeDeliveryChannelStatus(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	channel, found, err := p.cfgsvcResolveDescribedChannel(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	statuses := []map[string]interface{}{}
+	if found {
+		status, err := p.cfgsvcChannelStatus(ctx, channel)
+		if err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, status)
+	}
+	return cfgsvcJSONResponse(map[string]interface{}{"DeliveryChannelsStatus": statuses},
+		"describeDeliveryChannelStatus")
+}
+
+// cfgsvcChannelStatus builds one DeliveryChannelStatus.
+//
+// The three streams are reported separately rather than folded into one, and they do
+// not carry the same members. The two S3 deliveries — configuration history and
+// configuration snapshot — are ConfigExportDeliveryInfo, which has lastAttemptTime,
+// lastSuccessfulTime and nextDeliveryTime; the SNS notification is
+// ConfigStreamDeliveryInfo, which has none of those and carries lastStatusChangeTime
+// instead. Emitting one shape for all three would put members in a response the
+// caller's own SDK cannot decode, so each is built by its own function.
+func (p *ConfigServicePlugin) cfgsvcChannelStatus(ctx *RequestContext, channel *ConfigDeliveryChannel) (
+	map[string]interface{}, error) {
+	goCtx := context.Background()
+	var recorderStatus ConfigRecorderStatus
+	if _, err := p.cfgsvcGetJSON(goCtx,
+		cfgsvcRecorderStatusKey(ctx.AccountID, ctx.Region), &recorderStatus); err != nil {
+		return nil, err
+	}
+
+	// Not_Applicable until the recorder has started at least once: nothing has been
+	// delivered, and reporting Success would tell a consumer its pipeline works when
+	// nothing has gone through it.
+	status := cfgsvcDeliveryNotApplicable
+	if !recorderStatus.LastStartTime.IsZero() {
+		status = cfgsvcDeliverySuccess
+	}
+	var errorCode, errorMessage string
+
+	seed, seeded, err := p.seededDeliveryStatus(goCtx, ctx.AccountID, ctx.Region)
+	if err != nil {
+		return nil, err
+	}
+	if seeded {
+		status = seed.Status
+		errorCode = seed.LastErrorCode
+		errorMessage = seed.LastErrorMessage
+	}
+
+	return map[string]interface{}{
+		"name":                       channel.Name,
+		"configHistoryDeliveryInfo":  p.cfgsvcExportDeliveryInfo(status, errorCode, errorMessage),
+		"configSnapshotDeliveryInfo": p.cfgsvcExportDeliveryInfo(status, errorCode, errorMessage),
+		"configStreamDeliveryInfo":   p.cfgsvcStreamDeliveryInfo(channel, status, errorCode, errorMessage),
+	}, nil
+}
+
+// cfgsvcExportDeliveryInfo builds a ConfigExportDeliveryInfo — the shape both S3
+// deliveries use.
+//
+// A time member is emitted only where it describes something that happened:
+// lastSuccessfulTime on a Success and lastAttemptTime on a Failure. nextDeliveryTime
+// is left out entirely, because substrate schedules no delivery and a timestamp
+// naming one would be a promise nothing keeps.
+func (p *ConfigServicePlugin) cfgsvcExportDeliveryInfo(status, errorCode, errorMessage string) map[string]interface{} {
+	info := cfgsvcDeliveryInfoBase(status, errorCode, errorMessage)
+	switch status {
+	case cfgsvcDeliverySuccess:
+		info["lastSuccessfulTime"] = EpochSeconds(p.tc.Now())
+	case cfgsvcDeliveryFailure:
+		info["lastAttemptTime"] = EpochSeconds(p.tc.Now())
+	}
+	return info
+}
+
+// cfgsvcStreamDeliveryInfo builds a ConfigStreamDeliveryInfo — the SNS notification
+// stream.
+//
+// A channel with no SNS topic reports Not_Applicable regardless of the S3 streams,
+// and a seed does not override it: the shape's own documentation says "Providing an
+// SNS topic on a DeliveryChannel for Config is optional. If the SNS delivery is
+// turned off, the last status will be Not_Applicable." Reporting Success for a
+// notification stream that was never configured would tell a consumer its alerting
+// works when no topic exists to alert on, which is a misconfiguration this operation
+// is one of the few places to observe.
+func (p *ConfigServicePlugin) cfgsvcStreamDeliveryInfo(channel *ConfigDeliveryChannel,
+	status, errorCode, errorMessage string) map[string]interface{} {
+	if channel.SnsTopicARN == "" {
+		return map[string]interface{}{"lastStatus": cfgsvcDeliveryNotApplicable}
+	}
+	info := cfgsvcDeliveryInfoBase(status, errorCode, errorMessage)
+	// lastStatusChangeTime, not lastSuccessfulTime: this shape carries neither of the
+	// export shape's time members.
+	info["lastStatusChangeTime"] = EpochSeconds(p.tc.Now())
+	return info
+}
+
+// cfgsvcDeliveryInfoBase builds the three members both delivery-info shapes share,
+// omitting an empty error code or message rather than emitting a blank one.
+func cfgsvcDeliveryInfoBase(status, errorCode, errorMessage string) map[string]interface{} {
+	info := map[string]interface{}{"lastStatus": status}
+	if errorCode != "" {
+		info["lastErrorCode"] = errorCode
+	}
+	if errorMessage != "" {
+		info["lastErrorMessage"] = errorMessage
+	}
+	return info
+}
+
+// cfgsvcResolveDescribedChannel decodes and applies the name filter both channel
+// describe operations share.
+func (p *ConfigServicePlugin) cfgsvcResolveDescribedChannel(ctx *RequestContext, req *AWSRequest) (
+	*ConfigDeliveryChannel, bool, error) {
+	var in cfgsvcDescribeChannelsRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, false, err
+	}
+	if len(in.DeliveryChannelNames) > cfgsvcMaxChannels {
+		return nil, false, cfgsvcValidation("You have specified more than one delivery channel.")
+	}
+
+	var channel ConfigDeliveryChannel
+	found, err := p.cfgsvcGetJSON(context.Background(),
+		cfgsvcChannelKey(ctx.AccountID, ctx.Region), &channel)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(in.DeliveryChannelNames) == 1 {
+		if !found || channel.Name != in.DeliveryChannelNames[0] {
+			return nil, false, cfgsvcNoSuchChannel()
+		}
+	}
+	return &channel, found, nil
+}
+
+// cfgsvcNoSuchChannel is NoSuchDeliveryChannelException.
+func cfgsvcNoSuchChannel() *AWSError {
+	return cfgsvcErr("NoSuchDeliveryChannelException",
+		"You have specified a delivery channel that does not exist.")
+}
+
+// deleteDeliveryChannel deletes the account's delivery channel.
+//
+// It refuses while the recorder is recording: "Before you can delete the delivery
+// channel, you must stop the customer managed configuration recorder." That refusal
+// is the reason the deletes are in scope at all — it is what makes a
+// teardown-and-rebuild fixture, i.e. the same test run twice, express an ordering
+// requirement rather than silently succeed on a sequence AWS would reject.
+func (p *ConfigServicePlugin) deleteDeliveryChannel(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcChannelNameRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	goCtx := context.Background()
+	var channel ConfigDeliveryChannel
+	found, err := p.cfgsvcGetJSON(goCtx, cfgsvcChannelKey(ctx.AccountID, ctx.Region), &channel)
+	if err != nil {
+		return nil, err
+	}
+	if !found || channel.Name != in.DeliveryChannelName {
+		return nil, cfgsvcNoSuchChannel()
+	}
+
+	var recorderStatus ConfigRecorderStatus
+	if _, err := p.cfgsvcGetJSON(goCtx,
+		cfgsvcRecorderStatusKey(ctx.AccountID, ctx.Region), &recorderStatus); err != nil {
+		return nil, err
+	}
+	if recorderStatus.Recording {
+		return nil, cfgsvcErr("LastDeliveryChannelDeleteFailedException",
+			"You cannot delete the delivery channel you specified because the customer "+
+				"managed configuration recorder is running.")
+	}
+
+	if err := p.cfgsvcDeleteKey(goCtx, cfgsvcChannelKey(ctx.AccountID, ctx.Region)); err != nil {
+		return nil, err
+	}
+	return cfgsvcEmptyResponse(), nil
+}

--- a/emulator/configservice_channel_test.go
+++ b/emulator/configservice_channel_test.go
@@ -1,0 +1,742 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The delivery-channel cluster, the S3 bucket-policy check, and the seeds (#580).
+//
+// The bucket-policy cases are the interesting ones. PutDeliveryChannel is the only
+// Config operation whose success depends on another service's state, and the check
+// is deliberately permissive: the tests below assert both halves of that decision —
+// what is refused (no bucket, no policy at all, a policy that admits nothing) and
+// what is accepted (every plausible variant, and anything substrate cannot parse).
+// A test suite that only asserted the refusals would pass with a matcher that
+// refuses everything, which is the failure direction that breaks working consumers.
+
+// configSeedDeliveryPolicy pins the delivery-policy outcome for a bucket.
+func configSeedDeliveryPolicy(t *testing.T, ts *emulator.TestServer, bucket, outcome string) {
+	t.Helper()
+	configSeed(t, ts, "/v1/config/delivery-policy", map[string]any{
+		"bucket": bucket, "outcome": outcome,
+	})
+}
+
+// configSeed posts a control-plane seed and requires that it be accepted.
+func configSeed(t *testing.T, ts *emulator.TestServer, path string, body any) {
+	t.Helper()
+	status, response := configSeedRaw(t, ts, path, body)
+	require.Equal(t, http.StatusOK, status, "seed %s: %s", path, response)
+}
+
+// configSeedRaw posts a control-plane seed and returns the status and body, for the
+// cases whose subject is the refusal.
+func configSeedRaw(t *testing.T, ts *emulator.TestServer, path string, body any) (int, string) {
+	t.Helper()
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+path, bytes.NewReader(data))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(raw)
+}
+
+// configClearSeed deletes a control-plane seed.
+func configClearSeed(t *testing.T, ts *emulator.TestServer, path string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete, ts.URL+path, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// configPutBucket creates an S3 bucket through the S3 plugin, so the delivery check
+// reads real state rather than state a test wrote by hand.
+func configPutBucket(t *testing.T, ts *emulator.TestServer, bucket string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, ts.URL+"/"+bucket, nil)
+	require.NoError(t, err)
+	req.Host = "s3.us-east-1.amazonaws.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "create bucket %s", bucket)
+}
+
+// configPutBucketPolicy sets a bucket policy through the S3 plugin.
+func configPutBucketPolicy(t *testing.T, ts *emulator.TestServer, bucket, policy string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut,
+		ts.URL+"/"+bucket+"?policy", bytes.NewReader([]byte(policy)))
+	require.NoError(t, err)
+	req.Host = "s3.us-east-1.amazonaws.com"
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	// PutBucketPolicy answers 204, as real S3 does.
+	require.Equal(t, http.StatusNoContent, resp.StatusCode, "put policy on %s", bucket)
+}
+
+// configPutChannelWithTopic updates the channel to carry an SNS topic, which is what
+// switches the notification stream's status on.
+func configPutChannelWithTopic(t *testing.T, ts *emulator.TestServer, name, bucket, topic string) {
+	t.Helper()
+	status, code, message := configPutChannelRaw(t, ts, map[string]any{
+		"name": name, "s3BucketName": bucket, "snsTopicARN": topic,
+	})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+}
+
+// configDeliveryPolicyAdmittingConfig is the policy the AWS documentation gives for
+// a Config delivery bucket, trimmed to the statement the check is about.
+const configDeliveryPolicyAdmittingConfig = `{"Version":"2012-10-17","Statement":[{
+	"Sid":"AWSConfigBucketDelivery","Effect":"Allow",
+	"Principal":{"Service":"config.amazonaws.com"},
+	"Action":"s3:PutObject","Resource":"arn:aws:s3:::cfg-logs/*"}]}`
+
+// configPutChannelRaw posts a PutDeliveryChannel and returns the refusal, if any.
+func configPutChannelRaw(t *testing.T, ts *emulator.TestServer, channel map[string]any) (int, string, string) {
+	t.Helper()
+	resp := configRequest(t, ts, "PutDeliveryChannel", map[string]any{"DeliveryChannel": channel})
+	return decodeConfigResponse(t, resp, nil)
+}
+
+// configDescribeChannels returns the channels DescribeDeliveryChannels reports.
+func configDescribeChannels(t *testing.T, ts *emulator.TestServer) []map[string]any {
+	t.Helper()
+	resp := configRequest(t, ts, "DescribeDeliveryChannels", map[string]any{})
+	var out struct {
+		DeliveryChannels []map[string]any `json:"DeliveryChannels"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	return out.DeliveryChannels
+}
+
+// configDescribeChannelStatus returns the statuses DescribeDeliveryChannelStatus
+// reports.
+func configDescribeChannelStatus(t *testing.T, ts *emulator.TestServer) []map[string]any {
+	t.Helper()
+	resp := configRequest(t, ts, "DescribeDeliveryChannelStatus", map[string]any{})
+	var out struct {
+		DeliveryChannelsStatus []map[string]any `json:"DeliveryChannelsStatus"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	return out.DeliveryChannelsStatus
+}
+
+func TestConfigChannel_RefusesWithoutARecorder(t *testing.T) {
+	// "There are no customer managed configuration recorders available to record your
+	// resources. Use the PutConfigurationRecorder operation…" — checked before the
+	// bucket, per the operation's own ordering, so a consumer with neither is told to
+	// fix the recorder first, which is the thing it must fix first.
+	ts := emulator.StartTestServer(t)
+
+	status, code, message := configPutChannelRaw(t, ts, map[string]any{
+		"name": "default", "s3BucketName": "does-not-exist-either",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "NoAvailableConfigurationRecorderException", code)
+	assert.Contains(t, message, "PutConfigurationRecorder")
+}
+
+func TestConfigChannel_TheBucketCheckReadsRealS3State(t *testing.T) {
+	// The whole progression, in the order a consumer hits it: no bucket, then a bucket
+	// with no policy, then a bucket with the documented policy. Each step is a distinct
+	// refusal, and only the last succeeds.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	status, code, message := configPutChannelRaw(t, ts, map[string]any{
+		"name": "default", "s3BucketName": "cfg-logs",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "NoSuchBucketException", code)
+	assert.Contains(t, message, "does not exist")
+
+	configPutBucket(t, ts, "cfg-logs")
+	status, code, message = configPutChannelRaw(t, ts, map[string]any{
+		"name": "default", "s3BucketName": "cfg-logs",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InsufficientDeliveryPolicyException", code,
+		"a bucket with no policy at all cannot admit Config, and that is unambiguous")
+	assert.Contains(t, message, "does not allow Config to write")
+
+	configPutBucketPolicy(t, ts, "cfg-logs", configDeliveryPolicyAdmittingConfig)
+	status, code, message = configPutChannelRaw(t, ts, map[string]any{
+		"name": "default", "s3BucketName": "cfg-logs",
+	})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	channels := configDescribeChannels(t, ts)
+	require.Len(t, channels, 1)
+	assert.Equal(t, "cfg-logs", channels[0]["s3BucketName"])
+}
+
+func TestConfigChannel_ThePolicyMatcherAcceptsWhatAWSAccepts(t *testing.T) {
+	// The permissive half of the decision, and the one that matters more: a refusal
+	// here would fail a consumer whose policy is perfectly valid. Every case is a form
+	// a real bucket policy takes.
+	cases := []struct {
+		name   string
+		policy string
+	}{
+		{"the documented policy", configDeliveryPolicyAdmittingConfig},
+		{
+			"a wildcard action",
+			`{"Statement":[{"Effect":"Allow","Principal":{"Service":"config.amazonaws.com"},
+			  "Action":"s3:*","Resource":"*"}]}`,
+		},
+		{
+			"a prefix wildcard action",
+			`{"Statement":[{"Effect":"Allow","Principal":{"Service":"config.amazonaws.com"},
+			  "Action":"s3:Put*","Resource":"*"}]}`,
+		},
+		{
+			"a bare wildcard action",
+			`{"Statement":[{"Effect":"Allow","Principal":{"Service":"config.amazonaws.com"},
+			  "Action":"*","Resource":"*"}]}`,
+		},
+		{
+			"a wildcard principal",
+			`{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:PutObject","Resource":"*"}]}`,
+		},
+		{
+			"a list of service principals",
+			`{"Statement":[{"Effect":"Allow",
+			  "Principal":{"Service":["cloudtrail.amazonaws.com","config.amazonaws.com"]},
+			  "Action":["s3:GetBucketAcl","s3:PutObject"],"Resource":"*"}]}`,
+		},
+		{
+			"a lowercase effect",
+			`{"Statement":[{"Effect":"allow","Principal":{"Service":"config.amazonaws.com"},
+			  "Action":"s3:PutObject","Resource":"*"}]}`,
+		},
+		{
+			"a deny statement alongside the allow",
+			`{"Statement":[
+			  {"Effect":"Deny","Principal":"*","Action":"s3:DeleteObject","Resource":"*"},
+			  {"Effect":"Allow","Principal":{"Service":"config.amazonaws.com"},
+			   "Action":"s3:PutObject","Resource":"*"}]}`,
+		},
+		{
+			"a resource ARN naming a different bucket",
+			// Resource is deliberately not matched: getting the prefix wrong is a real bug,
+			// but it is not one this check can tell apart from a valid variant, and guessing
+			// would refuse working policies.
+			`{"Statement":[{"Effect":"Allow","Principal":{"Service":"config.amazonaws.com"},
+			  "Action":"s3:PutObject","Resource":"arn:aws:s3:::some-other-bucket/*"}]}`,
+		},
+		{
+			"a shape substrate's parser cannot decode",
+			// IAM grammar permits a single Statement as an object rather than a one-element
+			// array, and S3 stores it, but substrate decodes Statement into a slice and so
+			// cannot read this one. It passes: refusing here would be substrate blaming the
+			// consumer for its own parser's narrowness, which is the failure direction that
+			// breaks working code. This is the case the permissive rule exists for.
+			`{"Version":"2012-10-17","Statement":{"Effect":"Allow",
+			  "Principal":{"Service":"config.amazonaws.com"},
+			  "Action":"s3:PutObject","Resource":"*"}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			configPutRecorder(t, ts, "default")
+			configPutBucket(t, ts, "cfg-logs")
+			configPutBucketPolicy(t, ts, "cfg-logs", tc.policy)
+
+			status, code, message := configPutChannelRaw(t, ts, map[string]any{
+				"name": "default", "s3BucketName": "cfg-logs",
+			})
+			assert.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+		})
+	}
+}
+
+func TestConfigChannel_ThePolicyMatcherRefusesWhatAdmitsNothing(t *testing.T) {
+	// The other half. A policy that parses and plainly does not let Config write is
+	// refused, because accepting it would make the consumer's bucket-policy bug
+	// invisible here and fatal at AWS.
+	cases := []struct {
+		name   string
+		policy string
+	}{
+		{
+			"a policy with no statements",
+			`{"Version":"2012-10-17","Statement":[]}`,
+		},
+		{
+			"another service's principal",
+			`{"Statement":[{"Effect":"Allow","Principal":{"Service":"cloudtrail.amazonaws.com"},
+			  "Action":"s3:PutObject","Resource":"*"}]}`,
+		},
+		{
+			"a read-only action",
+			`{"Statement":[{"Effect":"Allow","Principal":{"Service":"config.amazonaws.com"},
+			  "Action":["s3:GetObject","s3:GetBucketAcl"],"Resource":"*"}]}`,
+		},
+		{
+			"an action for another service",
+			`{"Statement":[{"Effect":"Allow","Principal":{"Service":"config.amazonaws.com"},
+			  "Action":"sns:Publish","Resource":"*"}]}`,
+		},
+		{
+			"the right pairing under a Deny",
+			`{"Statement":[{"Effect":"Deny","Principal":{"Service":"config.amazonaws.com"},
+			  "Action":"s3:PutObject","Resource":"*"}]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			configPutRecorder(t, ts, "default")
+			configPutBucket(t, ts, "cfg-logs")
+			configPutBucketPolicy(t, ts, "cfg-logs", tc.policy)
+
+			status, code, _ := configPutChannelRaw(t, ts, map[string]any{
+				"name": "default", "s3BucketName": "cfg-logs",
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InsufficientDeliveryPolicyException", code)
+		})
+	}
+}
+
+func TestConfigChannel_TheDeliveryPolicySeedWorksBothWays(t *testing.T) {
+	// The seed exists in both directions on purpose: "insufficient" for a consumer with
+	// no S3 fixture at all, and "ok" for one whose valid policy the permissive matcher
+	// still cannot read. Both override real S3 state, and clearing restores it.
+	t.Run("insufficient without any bucket", func(t *testing.T) {
+		ts := emulator.StartTestServer(t)
+		configPutRecorder(t, ts, "default")
+		configSeedDeliveryPolicy(t, ts, "no-such-bucket", "insufficient")
+
+		status, code, _ := configPutChannelRaw(t, ts, map[string]any{
+			"name": "default", "s3BucketName": "no-such-bucket",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InsufficientDeliveryPolicyException", code,
+			"the seed outranks the missing bucket, which would otherwise be NoSuchBucket")
+	})
+
+	t.Run("ok despite a policy that admits nothing", func(t *testing.T) {
+		ts := emulator.StartTestServer(t)
+		configPutRecorder(t, ts, "default")
+		configPutBucket(t, ts, "cfg-logs")
+		configPutBucketPolicy(t, ts, "cfg-logs",
+			`{"Statement":[{"Effect":"Deny","Principal":"*","Action":"*","Resource":"*"}]}`)
+		configSeedDeliveryPolicy(t, ts, "cfg-logs", "ok")
+
+		status, code, message := configPutChannelRaw(t, ts, map[string]any{
+			"name": "default", "s3BucketName": "cfg-logs",
+		})
+		require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	})
+
+	t.Run("the wildcard bucket applies to any bucket", func(t *testing.T) {
+		ts := emulator.StartTestServer(t)
+		configPutRecorder(t, ts, "default")
+		configSeed(t, ts, "/v1/config/delivery-policy", map[string]any{"outcome": "insufficient"})
+
+		status, code, _ := configPutChannelRaw(t, ts, map[string]any{
+			"name": "default", "s3BucketName": "any-bucket-at-all",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InsufficientDeliveryPolicyException", code)
+	})
+
+	t.Run("clearing restores the computed check", func(t *testing.T) {
+		ts := emulator.StartTestServer(t)
+		configPutRecorder(t, ts, "default")
+		configPutBucket(t, ts, "cfg-logs")
+		configPutBucketPolicy(t, ts, "cfg-logs", configDeliveryPolicyAdmittingConfig)
+		configSeedDeliveryPolicy(t, ts, "cfg-logs", "insufficient")
+
+		status, _, _ := configPutChannelRaw(t, ts, map[string]any{
+			"name": "default", "s3BucketName": "cfg-logs",
+		})
+		require.Equal(t, http.StatusBadRequest, status)
+
+		configClearSeed(t, ts, "/v1/config/delivery-policy?bucket=cfg-logs")
+		status, code, message := configPutChannelRaw(t, ts, map[string]any{
+			"name": "default", "s3BucketName": "cfg-logs",
+		})
+		assert.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	})
+}
+
+func TestConfigChannel_TheDeliveryPolicySeedRefusesAnUnknownOutcome(t *testing.T) {
+	// A seed value the reader will not recognize would be silently ignored, and the
+	// test that set it would pass while asserting nothing.
+	ts := emulator.StartTestServer(t)
+
+	status, body := configSeedRaw(t, ts, "/v1/config/delivery-policy",
+		map[string]any{"bucket": "cfg-logs", "outcome": "maybe"})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body, "insufficient")
+
+	status, body = configSeedRaw(t, ts, "/v1/config/delivery-policy",
+		map[string]any{"bucket": "cfg-logs"})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body, "outcome is required")
+}
+
+func TestConfigChannel_AChannelWithNoBucketIsAccepted(t *testing.T) {
+	// DeliveryS3Bucket is min-length 0 and the operation does not require it, so
+	// refusing a channel without one would refuse a request AWS accepts.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	status, code, message := configPutChannelRaw(t, ts, map[string]any{"name": "default"})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Len(t, configDescribeChannels(t, ts), 1)
+}
+
+func TestConfigChannel_PutIsIdempotentAndASecondNameIsRefused(t *testing.T) {
+	// One channel per account per Region, same as the recorder, and from the same kind
+	// of per-operation note rather than from the limits page.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configSeedDeliveryPolicy(t, ts, "*", "ok")
+
+	for _, prefix := range []string{"first", "second"} {
+		status, code, message := configPutChannelRaw(t, ts, map[string]any{
+			"name": "default", "s3BucketName": "cfg-logs", "s3KeyPrefix": prefix,
+		})
+		require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	}
+	channels := configDescribeChannels(t, ts)
+	require.Len(t, channels, 1, "a second Put with the same name updates rather than duplicates")
+	assert.Equal(t, "second", channels[0]["s3KeyPrefix"], "and the update took effect")
+
+	status, code, message := configPutChannelRaw(t, ts, map[string]any{
+		"name": "other", "s3BucketName": "cfg-logs",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "MaxNumberOfDeliveryChannelsExceededException", code)
+	assert.Contains(t, message, "reached the limit")
+}
+
+func TestConfigChannel_NameDefaultsToDefault(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	status, code, message := configPutChannelRaw(t, ts, map[string]any{})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	channels := configDescribeChannels(t, ts)
+	require.Len(t, channels, 1)
+	assert.Equal(t, "default", channels[0]["name"])
+}
+
+func TestConfigChannel_StatusIsNotApplicableUntilTheRecorderStarts(t *testing.T) {
+	// Nothing has been delivered before the first start, and reporting Success would
+	// tell a consumer its pipeline works when nothing has gone through it. Note the
+	// spelling: the DeliveryStatus enum writes this member Not_Applicable, with an
+	// underscore, unlike RecorderStatus's NotApplicable.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+
+	statuses := configDescribeChannelStatus(t, ts)
+	require.Len(t, statuses, 1)
+	for _, stream := range []string{
+		"configHistoryDeliveryInfo", "configSnapshotDeliveryInfo", "configStreamDeliveryInfo",
+	} {
+		info, ok := statuses[0][stream].(map[string]any)
+		require.True(t, ok, "%s is reported", stream)
+		assert.Equal(t, "Not_Applicable", info["lastStatus"])
+	}
+
+	configStartRecorder(t, ts, "default")
+	statuses = configDescribeChannelStatus(t, ts)
+	require.Len(t, statuses, 1)
+	for _, stream := range []string{"configHistoryDeliveryInfo", "configSnapshotDeliveryInfo"} {
+		info, ok := statuses[0][stream].(map[string]any)
+		require.True(t, ok, "%s is reported", stream)
+		assert.Equal(t, "Success", info["lastStatus"])
+		assert.NotNil(t, info["lastSuccessfulTime"], "%s carries the export shape's time member", stream)
+	}
+}
+
+func TestConfigChannel_TheThreeStreamsAreNotTheSameShape(t *testing.T) {
+	// The two S3 deliveries are ConfigExportDeliveryInfo and the SNS notification is
+	// ConfigStreamDeliveryInfo: the first has lastSuccessfulTime/lastAttemptTime and no
+	// lastStatusChangeTime, the second the reverse. Emitting one shape for all three
+	// would put members in the response an SDK decoding the stream shape cannot read,
+	// and this is the case that catches it.
+	//
+	// The stream status is also independent of the S3 ones: with no SNS topic on the
+	// channel it stays Not_Applicable, per the shape's own note that "If the SNS
+	// delivery is turned off, the last status will be Not_Applicable" — reporting
+	// Success would tell a consumer its alerting works when no topic exists.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+
+	statuses := configDescribeChannelStatus(t, ts)
+	require.Len(t, statuses, 1)
+
+	export, ok := statuses[0]["configSnapshotDeliveryInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Success", export["lastStatus"])
+	assert.NotContains(t, export, "lastStatusChangeTime",
+		"ConfigExportDeliveryInfo has no lastStatusChangeTime member")
+	assert.NotContains(t, export, "nextDeliveryTime",
+		"substrate schedules no delivery, so it promises no next one")
+
+	stream, ok := statuses[0]["configStreamDeliveryInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Not_Applicable", stream["lastStatus"], "no SNS topic is configured")
+	assert.NotContains(t, stream, "lastSuccessfulTime",
+		"ConfigStreamDeliveryInfo has no lastSuccessfulTime member")
+
+	// Give the channel a topic and the stream joins the other two, carrying its own
+	// time member rather than theirs.
+	configPutChannelWithTopic(t, ts, "default", "cfg-logs",
+		"arn:aws:sns:us-east-1:123456789012:config-changes")
+	statuses = configDescribeChannelStatus(t, ts)
+	require.Len(t, statuses, 1)
+	stream, ok = statuses[0]["configStreamDeliveryInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Success", stream["lastStatus"])
+	assert.NotNil(t, stream["lastStatusChangeTime"])
+	assert.NotContains(t, stream, "lastSuccessfulTime")
+}
+
+func TestConfigChannel_TheDeliveryStatusSeedReachesFailure(t *testing.T) {
+	// Substrate delivers nothing to S3, so no sequence of API calls can produce a
+	// failed delivery — and a consumer's delivery-failure branch is code that exists
+	// precisely for it. The seed is the only way in.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+
+	configSeed(t, ts, "/v1/config/delivery-status", map[string]any{
+		"status":           "Failure",
+		"lastErrorCode":    "AccessDenied",
+		"lastErrorMessage": "Insufficient delivery policy to s3 bucket",
+	})
+
+	statuses := configDescribeChannelStatus(t, ts)
+	require.Len(t, statuses, 1)
+	info, ok := statuses[0]["configHistoryDeliveryInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Failure", info["lastStatus"])
+	assert.Equal(t, "AccessDenied", info["lastErrorCode"])
+	assert.Equal(t, "Insufficient delivery policy to s3 bucket", info["lastErrorMessage"])
+
+	configClearSeed(t, ts, "/v1/config/delivery-status")
+	statuses = configDescribeChannelStatus(t, ts)
+	require.Len(t, statuses, 1)
+	info, ok = statuses[0]["configHistoryDeliveryInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Success", info["lastStatus"], "clearing the seed restores the real status")
+}
+
+func TestConfigChannel_TheDeliveryStatusSeedIsValidated(t *testing.T) {
+	// Not_Applicable carries an underscore in this enum and NotApplicable does not
+	// exist in it, so the near-miss spelling is refused rather than stored as a value
+	// no SDK enum member matches.
+	ts := emulator.StartTestServer(t)
+
+	status, body := configSeedRaw(t, ts, "/v1/config/delivery-status",
+		map[string]any{"status": "NotApplicable"})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body, "underscore")
+
+	// An error code on a non-Failure status would be dropped by every consumer that
+	// reads it only on failure, so the seed is refused rather than half-applied.
+	status, body = configSeedRaw(t, ts, "/v1/config/delivery-status",
+		map[string]any{"status": "Success", "lastErrorCode": "AccessDenied"})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body, "only to status Failure")
+}
+
+func TestConfigRecorder_TheStatusSeedReachesFailure(t *testing.T) {
+	// The recorder's own lastStatus, for the same reason: substrate delivers nothing,
+	// so a recorder it started always reports Success and the Failure branch is
+	// otherwise unreachable.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+
+	configSeed(t, ts, "/v1/config/recorder-status", map[string]any{
+		"lastStatus":       "Failure",
+		"lastErrorCode":    "InsufficientDeliveryPolicy",
+		"lastErrorMessage": "Config cannot write to the bucket",
+	})
+
+	statuses := configDescribeRecorderStatus(t, ts)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, "Failure", statuses[0]["lastStatus"])
+	assert.Equal(t, "InsufficientDeliveryPolicy", statuses[0]["lastErrorCode"])
+	assert.Equal(t, true, statuses[0]["recording"],
+		"the seed pins the delivery status, not whether the recorder is on")
+
+	configClearSeed(t, ts, "/v1/config/recorder-status")
+	statuses = configDescribeRecorderStatus(t, ts)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, "Success", statuses[0]["lastStatus"])
+	assert.Empty(t, statuses[0]["lastErrorCode"], "clearing the seed leaves nothing behind")
+}
+
+func TestConfigRecorder_TheStatusSeedIsValidated(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	status, body := configSeedRaw(t, ts, "/v1/config/recorder-status",
+		map[string]any{"lastStatus": "Broken"})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body, "RecorderStatus")
+
+	status, body = configSeedRaw(t, ts, "/v1/config/recorder-status", map[string]any{})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Contains(t, body, "lastStatus is required")
+}
+
+func TestConfigChannel_SeedsAreScopedByAccountAndRegion(t *testing.T) {
+	// A seed for one Region must not answer for another, or a multi-Region fixture
+	// could not distinguish a healthy Region from a failing one — which is the whole
+	// reason to run one.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+
+	configSeed(t, ts, "/v1/config/recorder-status", map[string]any{
+		"region": "eu-west-1", "lastStatus": "Failure",
+	})
+
+	statuses := configDescribeRecorderStatus(t, ts)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, "Success", statuses[0]["lastStatus"],
+		"a seed scoped to eu-west-1 does not answer for us-east-1")
+}
+
+func TestConfigChannel_DeleteRefusesWhileTheRecorderRuns(t *testing.T) {
+	// "Before you can delete the delivery channel, you must stop the customer managed
+	// configuration recorder." This is the refusal that justifies the deletes being in
+	// scope at all: it is what makes a teardown-and-rebuild fixture — the same test run
+	// twice — express an ordering requirement rather than silently succeed on a sequence
+	// AWS rejects. Asserted as a sequence rather than as an isolated refusal, because
+	// the ordering is the behavior.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+
+	resp := configRequest(t, ts, "DeleteDeliveryChannel", map[string]any{
+		"DeliveryChannelName": "default",
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "LastDeliveryChannelDeleteFailedException", code)
+	assert.Contains(t, message, "is running")
+	assert.Len(t, configDescribeChannels(t, ts), 1, "the refusal deleted nothing")
+
+	// Stop, and the same call succeeds.
+	resp = configRequest(t, ts, "StopConfigurationRecorder", map[string]any{
+		"ConfigurationRecorderName": "default",
+	})
+	status, code, message = decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	resp = configRequest(t, ts, "DeleteDeliveryChannel", map[string]any{
+		"DeliveryChannelName": "default",
+	})
+	status, code, message = decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Empty(t, configDescribeChannels(t, ts))
+
+	// And the recorder cannot be restarted with the channel gone, which closes the loop:
+	// the state after a correct teardown is the state before a correct setup.
+	resp = configRequest(t, ts, "StartConfigurationRecorder", map[string]any{
+		"ConfigurationRecorderName": "default",
+	})
+	status, code, _ = decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "NoAvailableDeliveryChannelException", code)
+}
+
+func TestConfigChannel_DeleteRefusesAnUnknownName(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	resp := configRequest(t, ts, "DeleteDeliveryChannel", map[string]any{
+		"DeliveryChannelName": "ghost",
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "NoSuchDeliveryChannelException", code)
+	assert.Contains(t, message, "does not exist")
+}
+
+func TestConfigChannel_DescribeRefusesAnUnknownNameAndMoreThanOne(t *testing.T) {
+	for _, op := range []string{"DescribeDeliveryChannels", "DescribeDeliveryChannelStatus"} {
+		t.Run(op+"/unknown name", func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			resp := configRequest(t, ts, op, map[string]any{"DeliveryChannelNames": []string{"ghost"}})
+			status, code, _ := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "NoSuchDeliveryChannelException", code)
+		})
+
+		t.Run(op+"/more than one", func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			resp := configRequest(t, ts, op, map[string]any{
+				"DeliveryChannelNames": []string{"default", "other"},
+			})
+			status, code, message := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "ValidationException", code)
+			assert.Contains(t, message, "more than one delivery channel")
+		})
+	}
+}
+
+func TestConfigChannel_DescribeIsEmptyBeforeAnyPut(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	assert.Empty(t, configDescribeChannels(t, ts))
+	assert.Empty(t, configDescribeChannelStatus(t, ts))
+}
+
+func TestConfigChannel_RefusesAMissingChannelMember(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	resp := configRequest(t, ts, "PutDeliveryChannel", map[string]any{})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "ValidationException", code)
+	assert.Contains(t, message, "DeliveryChannel is required")
+}

--- a/emulator/configservice_control.go
+++ b/emulator/configservice_control.go
@@ -1,0 +1,415 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+// AWS Config control-plane seeds (#580).
+//
+// Substrate delivers nothing to S3 and evaluates no rules, so the outcomes a
+// consumer's error handling exists for — a recorder reporting Failure, a delivery
+// stream that cannot write, a bucket policy substrate cannot judge — cannot be
+// produced by any sequence of API calls. Seeding is how a deterministic emulator
+// reaches them: the value is pinned here, read at request time, and the same on
+// every replay.
+//
+// Two seeds ship with the recorder and channel clusters:
+//
+//	POST/DELETE /v1/config/recorder-status    lastStatus + error code/message
+//	POST/DELETE /v1/config/delivery-policy    force or suppress the bucket-policy refusal
+//	POST/DELETE /v1/config/delivery-status    the DeliveryStatus a channel reports
+//
+// Seeds live in their own namespace so a seeded status is never mistaken for a real
+// one in a state dump or during replay, and each is applied at *read* time rather
+// than written into the resource — so clearing a seed restores the real state
+// instead of leaving the seeded value behind.
+
+// configServiceCtrlNamespace is the state namespace for AWS Config control-plane
+// (seed) data, separate from configServiceNamespace so a seed is not mistaken for
+// real recorder or channel state.
+const configServiceCtrlNamespace = "config-ctrl"
+
+// Delivery statuses, the DeliveryStatus enum. Note the spelling of the third:
+// Not_Applicable, with an underscore and a capital A, which is how the model spells
+// this member and not how it spells the RecorderStatus member NotApplicable.
+const (
+	// cfgsvcDeliverySuccess is a stream whose last delivery succeeded.
+	cfgsvcDeliverySuccess = "Success"
+
+	// cfgsvcDeliveryFailure is a stream whose last delivery failed.
+	cfgsvcDeliveryFailure = "Failure"
+
+	// cfgsvcDeliveryNotApplicable is a stream that has never delivered.
+	cfgsvcDeliveryNotApplicable = "Not_Applicable"
+)
+
+// cfgsvcDeliveryStatuses is the DeliveryStatus enum, used to validate a seed.
+var cfgsvcDeliveryStatuses = []string{
+	cfgsvcDeliverySuccess,
+	cfgsvcDeliveryFailure,
+	cfgsvcDeliveryNotApplicable,
+}
+
+// Delivery-policy seed outcomes.
+const (
+	// cfgsvcDeliveryOutcomeOK suppresses the bucket-policy refusal.
+	cfgsvcDeliveryOutcomeOK = "ok"
+
+	// cfgsvcDeliveryOutcomeInsufficient forces InsufficientDeliveryPolicyException.
+	cfgsvcDeliveryOutcomeInsufficient = "insufficient"
+)
+
+// cfgsvcDeliveryOutcomes is the set of values the delivery-policy seed accepts.
+var cfgsvcDeliveryOutcomes = []string{cfgsvcDeliveryOutcomeOK, cfgsvcDeliveryOutcomeInsufficient}
+
+// cfgsvcCtrlRecorderStatusKey returns the state key for a seeded recorder status,
+// scoped by account and Region like the recorder it describes. The wildcard forms
+// are "*" in either position, so a single-account fixture can seed without knowing
+// its own account ID.
+func cfgsvcCtrlRecorderStatusKey(accountID, region string) string {
+	return "recorder_status:" + cfgsvcCtrlScope(accountID, region)
+}
+
+// cfgsvcCtrlDeliveryStatusKey returns the state key for a seeded delivery status.
+func cfgsvcCtrlDeliveryStatusKey(accountID, region string) string {
+	return "delivery_status:" + cfgsvcCtrlScope(accountID, region)
+}
+
+// cfgsvcCtrlDeliveryPolicyKey returns the state key for a seeded delivery-policy
+// outcome, keyed by bucket name because that is what the check is about — a fixture
+// with two buckets needs to seed them separately.
+func cfgsvcCtrlDeliveryPolicyKey(bucket string) string {
+	if bucket == "" {
+		bucket = "*"
+	}
+	return "delivery_policy:" + bucket
+}
+
+// cfgsvcCtrlScope builds the account/region component of a seed key, defaulting
+// either half to the "*" wildcard.
+func cfgsvcCtrlScope(accountID, region string) string {
+	if accountID == "" {
+		accountID = "*"
+	}
+	if region == "" {
+		region = "*"
+	}
+	return accountID + "/" + region
+}
+
+// cfgsvcSeededRecorderStatus is a pinned configuration-recorder status.
+//
+// Substrate delivers nothing, so a recorder it started reports Success and can never
+// report Failure on its own. A consumer whose code branches on lastStatus — the
+// branch that pages someone — needs this to reach that branch at all.
+type cfgsvcSeededRecorderStatus struct {
+	// AccountID the seed applies to, or "*" for any account.
+	AccountID string `json:"accountId"`
+
+	// Region the seed applies to, or "*" for any Region.
+	Region string `json:"region"`
+
+	// LastStatus is the RecorderStatus every observation reports.
+	LastStatus string `json:"lastStatus"`
+
+	// LastErrorCode is reported alongside it, for a Failure.
+	LastErrorCode string `json:"lastErrorCode,omitempty"`
+
+	// LastErrorMessage is reported alongside it, for a Failure.
+	LastErrorMessage string `json:"lastErrorMessage,omitempty"`
+}
+
+// cfgsvcSeededDeliveryStatus is a pinned delivery-channel status, for the same
+// reason: nothing here can fail a delivery.
+type cfgsvcSeededDeliveryStatus struct {
+	// AccountID the seed applies to, or "*" for any account.
+	AccountID string `json:"accountId"`
+
+	// Region the seed applies to, or "*" for any Region.
+	Region string `json:"region"`
+
+	// Status is the DeliveryStatus every stream reports.
+	Status string `json:"status"`
+
+	// LastErrorCode is reported alongside it, for a Failure.
+	LastErrorCode string `json:"lastErrorCode,omitempty"`
+
+	// LastErrorMessage is reported alongside it, for a Failure.
+	LastErrorMessage string `json:"lastErrorMessage,omitempty"`
+}
+
+// cfgsvcSeededDeliveryPolicy forces or suppresses the bucket-policy refusal.
+//
+// It exists in both directions on purpose. A consumer with no S3 fixture needs
+// "insufficient" without creating a bucket at all; a consumer whose policy is valid
+// in a form substrate's permissive matcher still cannot read needs "ok" without
+// having to argue with the matcher.
+type cfgsvcSeededDeliveryPolicy struct {
+	// Bucket the seed applies to, or "*" for any bucket.
+	Bucket string `json:"bucket"`
+
+	// Outcome is "ok" or "insufficient".
+	Outcome string `json:"outcome"`
+}
+
+// seededRecorderStatus returns the pinned recorder status, matching the exact
+// account and Region first, then the wildcards. found=false leaves the caller on the
+// stored record.
+func (p *ConfigServicePlugin) seededRecorderStatus(ctx context.Context, accountID, region string) (
+	seed cfgsvcSeededRecorderStatus, found bool, err error) {
+	for _, key := range cfgsvcCtrlKeyCandidates(cfgsvcCtrlRecorderStatusKey, accountID, region) {
+		data, getErr := p.state.Get(ctx, configServiceCtrlNamespace, key)
+		if getErr != nil {
+			return seed, false, fmt.Errorf("config seededRecorderStatus %s: %w", key, getErr)
+		}
+		if data == nil {
+			continue
+		}
+		if err := json.Unmarshal(data, &seed); err != nil {
+			return seed, false, fmt.Errorf("config seededRecorderStatus %s unmarshal: %w", key, err)
+		}
+		if seed.LastStatus != "" {
+			return seed, true, nil
+		}
+	}
+	return cfgsvcSeededRecorderStatus{}, false, nil
+}
+
+// seededDeliveryStatus returns the pinned delivery status, resolved the same way.
+func (p *ConfigServicePlugin) seededDeliveryStatus(ctx context.Context, accountID, region string) (
+	seed cfgsvcSeededDeliveryStatus, found bool, err error) {
+	for _, key := range cfgsvcCtrlKeyCandidates(cfgsvcCtrlDeliveryStatusKey, accountID, region) {
+		data, getErr := p.state.Get(ctx, configServiceCtrlNamespace, key)
+		if getErr != nil {
+			return seed, false, fmt.Errorf("config seededDeliveryStatus %s: %w", key, getErr)
+		}
+		if data == nil {
+			continue
+		}
+		if err := json.Unmarshal(data, &seed); err != nil {
+			return seed, false, fmt.Errorf("config seededDeliveryStatus %s unmarshal: %w", key, err)
+		}
+		if seed.Status != "" {
+			return seed, true, nil
+		}
+	}
+	return cfgsvcSeededDeliveryStatus{}, false, nil
+}
+
+// seededDeliveryPolicy returns the pinned delivery-policy outcome for a bucket.
+func (p *ConfigServicePlugin) seededDeliveryPolicy(ctx context.Context, bucket string) (
+	outcome string, found bool, err error) {
+	for _, key := range []string{cfgsvcCtrlDeliveryPolicyKey(bucket), cfgsvcCtrlDeliveryPolicyKey("*")} {
+		data, getErr := p.state.Get(ctx, configServiceCtrlNamespace, key)
+		if getErr != nil {
+			return "", false, fmt.Errorf("config seededDeliveryPolicy %s: %w", key, getErr)
+		}
+		if data == nil {
+			continue
+		}
+		var seed cfgsvcSeededDeliveryPolicy
+		if err := json.Unmarshal(data, &seed); err != nil {
+			return "", false, fmt.Errorf("config seededDeliveryPolicy %s unmarshal: %w", key, err)
+		}
+		if seed.Outcome != "" {
+			return seed.Outcome, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// cfgsvcCtrlKeyCandidates returns the four keys an account+region seed lookup tries,
+// most specific first: the exact pair, either half wildcarded, then both.
+//
+// All four are tried rather than only exact-then-both, so a fixture can seed "every
+// account in eu-west-1" or "this account in every Region" — the two scopes a
+// multi-Region test actually needs.
+func cfgsvcCtrlKeyCandidates(build func(string, string) string, accountID, region string) []string {
+	return []string{
+		build(accountID, region),
+		build(accountID, "*"),
+		build("*", region),
+		build("*", "*"),
+	}
+}
+
+// handleConfigSeedRecorderStatus handles POST /v1/config/recorder-status. It pins
+// the lastStatus every DescribeConfigurationRecorderStatus reports, which is the
+// only way to reach a recorder reporting Failure: substrate delivers nothing, so a
+// recorder it started always succeeds.
+// Body: {"accountId":"123456789012","region":"us-east-1","lastStatus":"Failure",
+// "lastErrorCode":"NoAvailableDeliveryChannel","lastErrorMessage":"..."}.
+func (s *Server) handleConfigSeedRecorderStatus(w http.ResponseWriter, r *http.Request) {
+	var seed cfgsvcSeededRecorderStatus
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.LastStatus == "" {
+		http.Error(w, `{"error":"lastStatus is required"}`, http.StatusBadRequest)
+		return
+	}
+	// A status outside the enum would be reported as a string no SDK enum member
+	// matches, so the caller's switch would fall through to its default and the test
+	// would pass while asserting nothing.
+	if !slices.Contains(cfgsvcRecorderStatuses, seed.LastStatus) {
+		http.Error(w, fmt.Sprintf(`{"error":"lastStatus %q is not a RecorderStatus"}`, seed.LastStatus),
+			http.StatusBadRequest)
+		return
+	}
+	// An error code or message on a non-Failure status would be silently dropped by
+	// every consumer that reads them only on failure, so the seed is refused rather
+	// than half-applied.
+	if seed.LastStatus != cfgsvcRecorderStatusFailure && (seed.LastErrorCode != "" || seed.LastErrorMessage != "") {
+		http.Error(w, `{"error":"lastErrorCode and lastErrorMessage apply only to lastStatus Failure"}`,
+			http.StatusBadRequest)
+		return
+	}
+	s.configSeedPut(w, r, cfgsvcCtrlRecorderStatusKey(seed.AccountID, seed.Region), seed,
+		map[string]any{"lastStatus": seed.LastStatus})
+}
+
+// handleConfigClearRecorderStatus handles DELETE /v1/config/recorder-status. With
+// ?accountId= and/or ?region= it removes that seed; without either it removes all of
+// them, restoring each recorder to its stored status.
+func (s *Server) handleConfigClearRecorderStatus(w http.ResponseWriter, r *http.Request) {
+	s.configSeedClear(w, r, "recorder_status:", func() (string, bool) {
+		accountID := r.URL.Query().Get("accountId")
+		region := r.URL.Query().Get("region")
+		if accountID == "" && region == "" {
+			return "", false
+		}
+		return cfgsvcCtrlRecorderStatusKey(accountID, region), true
+	})
+}
+
+// handleConfigSeedDeliveryStatus handles POST /v1/config/delivery-status. It pins
+// the DeliveryStatus every stream of DescribeDeliveryChannelStatus reports, which is
+// how a consumer reaches its delivery-failure branch — nothing substrate does can
+// fail a delivery.
+// Body: {"region":"us-east-1","status":"Failure","lastErrorCode":"AccessDenied"}.
+func (s *Server) handleConfigSeedDeliveryStatus(w http.ResponseWriter, r *http.Request) {
+	var seed cfgsvcSeededDeliveryStatus
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.Status == "" {
+		http.Error(w, `{"error":"status is required"}`, http.StatusBadRequest)
+		return
+	}
+	if !slices.Contains(cfgsvcDeliveryStatuses, seed.Status) {
+		http.Error(w, fmt.Sprintf(`{"error":"status %q is not a DeliveryStatus (note Not_Applicable`+
+			` carries an underscore)"}`, seed.Status), http.StatusBadRequest)
+		return
+	}
+	if seed.Status != cfgsvcDeliveryFailure && (seed.LastErrorCode != "" || seed.LastErrorMessage != "") {
+		http.Error(w, `{"error":"lastErrorCode and lastErrorMessage apply only to status Failure"}`,
+			http.StatusBadRequest)
+		return
+	}
+	s.configSeedPut(w, r, cfgsvcCtrlDeliveryStatusKey(seed.AccountID, seed.Region), seed,
+		map[string]any{"status": seed.Status})
+}
+
+// handleConfigClearDeliveryStatus handles DELETE /v1/config/delivery-status.
+func (s *Server) handleConfigClearDeliveryStatus(w http.ResponseWriter, r *http.Request) {
+	s.configSeedClear(w, r, "delivery_status:", func() (string, bool) {
+		accountID := r.URL.Query().Get("accountId")
+		region := r.URL.Query().Get("region")
+		if accountID == "" && region == "" {
+			return "", false
+		}
+		return cfgsvcCtrlDeliveryStatusKey(accountID, region), true
+	})
+}
+
+// handleConfigSeedDeliveryPolicy handles POST /v1/config/delivery-policy. It forces
+// or suppresses InsufficientDeliveryPolicyException for a bucket regardless of that
+// bucket's real S3 state — "insufficient" for a consumer with no S3 fixture, "ok"
+// for one whose valid policy substrate's permissive matcher still cannot read.
+// Body: {"bucket":"cfg-logs","outcome":"insufficient"}.
+func (s *Server) handleConfigSeedDeliveryPolicy(w http.ResponseWriter, r *http.Request) {
+	var seed cfgsvcSeededDeliveryPolicy
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	seed.Outcome = strings.ToLower(strings.TrimSpace(seed.Outcome))
+	if seed.Outcome == "" {
+		http.Error(w, `{"error":"outcome is required"}`, http.StatusBadRequest)
+		return
+	}
+	if !slices.Contains(cfgsvcDeliveryOutcomes, seed.Outcome) {
+		http.Error(w, fmt.Sprintf(`{"error":"outcome %q is not one of \"ok\" or \"insufficient\""}`,
+			seed.Outcome), http.StatusBadRequest)
+		return
+	}
+	s.configSeedPut(w, r, cfgsvcCtrlDeliveryPolicyKey(seed.Bucket), seed,
+		map[string]any{"outcome": seed.Outcome})
+}
+
+// handleConfigClearDeliveryPolicy handles DELETE /v1/config/delivery-policy. With
+// ?bucket= it removes that seed; without it removes all of them, restoring the
+// computed check.
+func (s *Server) handleConfigClearDeliveryPolicy(w http.ResponseWriter, r *http.Request) {
+	s.configSeedClear(w, r, "delivery_policy:", func() (string, bool) {
+		bucket := r.URL.Query().Get("bucket")
+		if bucket == "" {
+			return "", false
+		}
+		return cfgsvcCtrlDeliveryPolicyKey(bucket), true
+	})
+}
+
+// configSeedPut stores one Config seed and reports what it stored.
+//
+// The stored key is echoed back because the wildcard defaulting is invisible from
+// the request: a caller that omitted the Region gets "*" and should be able to see
+// that it did.
+func (s *Server) configSeedPut(w http.ResponseWriter, r *http.Request, key string, seed any, extra map[string]any) {
+	data, err := json.Marshal(seed)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), configServiceCtrlNamespace, key, data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	out := map[string]any{"ok": true, "key": key}
+	for k, v := range extra {
+		out[k] = v
+	}
+	writeJSONDebug(w, s.logger, out)
+}
+
+// configSeedClear removes one Config seed or, when the request names none, every
+// seed under prefix.
+func (s *Server) configSeedClear(w http.ResponseWriter, r *http.Request, prefix string, specific func() (string, bool)) {
+	if key, ok := specific(); ok {
+		if err := s.state.Delete(r.Context(), configServiceCtrlNamespace, key); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+		return
+	}
+	keys, err := s.state.List(r.Context(), configServiceCtrlNamespace, prefix)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), configServiceCtrlNamespace, k); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}

--- a/emulator/configservice_plugin.go
+++ b/emulator/configservice_plugin.go
@@ -1,0 +1,111 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// ConfigServicePlugin emulates AWS Config — the detective half of the control
+// loop (#580).
+//
+// Every other AWS API substrate models answers "make this so". Config answers a
+// different question: *is anything watching, and is anything compliant?* No
+// service here could answer it before this plugin, so the one path in a consumer
+// that checks whether its own controls are in place was the one path with no
+// emulator coverage.
+//
+// The fidelity that matters is a real misconfiguration rather than a CRUD surface.
+// DescribeConfigurationRecorders returning a recorder says **nothing** about
+// whether that recorder is recording — that is
+// DescribeConfigurationRecorderStatus.recording. Two states look identical to the
+// operation most consumers call, and telling them apart is what this plugin is
+// for. The same shape recurs in the ordering refusals: a recorder cannot start
+// without a delivery channel, a channel cannot be created without a recorder, and
+// a channel cannot be deleted while the recorder runs. A consumer's ordering bug
+// becomes an observable refusal rather than a silent success.
+//
+// Rule and conformance-pack compliance is **seeded, never computed**. Evaluating a
+// rule against resource state is workload-internal rather than an API observation,
+// so per the scope boundary in CLAUDE.md it is exposed as a seedable value read
+// from a control-plane endpoint at request time. Computing it would require
+// hundreds of AWS-managed rule implementations, and — worse — would make a
+// consumer's compliance assertion silently change meaning as unrelated plugins
+// gained fidelity. PutEvaluations is the exception that proves the rule: a custom
+// rule reporting its own result *is* an API observation, so what a caller submits
+// is recorded and reported back.
+//
+// Requests reach here over the JSON 1.1 target protocol
+// (X-Amz-Target: StarlingDoveService.{Op}); see the targetServiceAliases entry
+// that maps that prefix, without which the plugin would be registered,
+// unit-tested and unreachable.
+type ConfigServicePlugin struct {
+	state  StateManager
+	logger Logger
+	tc     *TimeController
+}
+
+// cfgsvcHandler handles one AWS Config operation.
+type cfgsvcHandler func(*RequestContext, *AWSRequest) (*AWSResponse, error)
+
+// Name returns the service name "config".
+//
+// This is the value the request parser resolves a Config request to — from the
+// endpoint prefix, the host and the SigV4 signing name alike — and it is
+// deliberately not the "configservice" file prefix, which exists only because
+// emulator/config.go already owns substrate's own Config type.
+func (p *ConfigServicePlugin) Name() string { return configServiceNamespace }
+
+// Initialize configures the ConfigServicePlugin with the provided configuration.
+func (p *ConfigServicePlugin) Initialize(_ context.Context, cfg PluginConfig) error {
+	p.state = cfg.State
+	p.logger = cfg.Logger
+	if tc, ok := cfg.Options["time_controller"].(*TimeController); ok {
+		p.tc = tc
+	} else {
+		p.tc = NewTimeController(time.Now())
+	}
+	return nil
+}
+
+// Shutdown is a no-op for ConfigServicePlugin.
+func (p *ConfigServicePlugin) Shutdown(_ context.Context) error { return nil }
+
+// HandleRequest dispatches an AWS Config request to the first operation cluster
+// that claims it.
+//
+// Each cluster lives in its own file (configservice_recorder.go and the rest) and
+// owns its claim function, following OrganizationsPlugin: adding an operation
+// touches one file rather than a switch every cluster shares. AWS Config has 97
+// operations and substrate implements the detective-controls subset, so an
+// unclaimed operation is answered with InvalidAction naming itself rather than
+// with a bare refusal.
+func (p *ConfigServicePlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	for _, claim := range []func(string) (cfgsvcHandler, bool){
+		p.recorderOperation,
+		p.channelOperation,
+	} {
+		if h, ok := claim(req.Operation); ok {
+			return h(ctx, req)
+		}
+	}
+	return nil, cfgsvcInvalidAction(req.Operation)
+}
+
+// cfgsvcJSONResponse marshals an AWS Config response body.
+func cfgsvcJSONResponse(out interface{}, op string) (*AWSResponse, error) {
+	body, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("%s marshal: %w", op, err)
+	}
+	return &AWSResponse{Body: body, StatusCode: http.StatusOK}, nil
+}
+
+// cfgsvcEmptyResponse is the body for an operation the API model gives no output
+// shape — PutConfigurationRecorder, Start/Stop, the deletes and the tag
+// operations all answer 200 with an empty JSON object.
+func cfgsvcEmptyResponse() *AWSResponse {
+	return &AWSResponse{Body: []byte(`{}`), StatusCode: http.StatusOK}
+}

--- a/emulator/configservice_recorder.go
+++ b/emulator/configservice_recorder.go
@@ -1,0 +1,558 @@
+package emulator
+
+import (
+	"context"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// The configuration-recorder cluster (#580).
+//
+// This is the point of the release. AWS Config has two operations that look like
+// they answer the same question and do not:
+//
+//	DescribeConfigurationRecorders       — does a recorder exist?
+//	DescribeConfigurationRecorderStatus  — is it recording?
+//
+// A recorder created and never started exists, is returned by the first call in
+// full, and records nothing. That is a real and common misconfiguration, and a
+// consumer that checks only the first call reports an account as covered when it is
+// not. Substrate stores the two answers separately so the difference is observable:
+// PutConfigurationRecorder always leaves Recording false, and only
+// StartConfigurationRecorder sets it true.
+//
+// One recorder per account per Region. AWS documents this per operation rather than
+// on the service-limits page — there is no recorder maximum listed there — and the
+// note is what makes MaxNumberOfConfigurationRecordersExceededException reachable
+// at a count of two. State is therefore keyed by account and Region with no name
+// component: a second recorder under a different name is refused rather than
+// stored.
+
+// cfgsvcMaxRecorders is the number of configuration recorders AWS permits per
+// account per Region. See the cluster comment: this comes from
+// PutConfigurationRecorder's own "you can have only one" note, not from the
+// service-limits page.
+const cfgsvcMaxRecorders = 1
+
+// cfgsvcResourceTypePattern is the shape a RecordingGroup resource type must have.
+//
+// The API model's ResourceType enum has 533 members and grows with every AWS
+// service launch. Substrate checks the *shape* rather than membership, on the same
+// reasoning as the attach-time policy-ARN check (#499): a vendored enum goes stale,
+// and refusing a resource type that AWS has since added would fail a request that
+// succeeds against AWS — a wrong refusal breaks working consumer code, which is
+// worse than accepting a typo. A value that is not AWS::Service::Type shaped is a
+// typo in any vintage of the enum, and that is what this catches.
+var cfgsvcResourceTypePattern = regexp.MustCompile(`^AWS::[A-Za-z0-9]+::[A-Za-z0-9]+$`)
+
+// cfgsvcServicePrincipalPattern is the ServicePrincipal shape, from the model
+// (1-128 characters of [\w+=,.@-]).
+var cfgsvcServicePrincipalPattern = regexp.MustCompile(`^[\w+=,.@-]+$`)
+
+// ConfigTag is the Tag shape AWS Config uses in a Put's TagsList.
+type ConfigTag struct {
+	// Key is the tag key.
+	Key string `json:"Key"`
+
+	// Value is the tag value, which may be empty but not null.
+	Value string `json:"Value"`
+}
+
+// cfgsvcPutRecorderRequest is PutConfigurationRecorderRequest.
+//
+// Note the case asymmetry: the request's own members are UpperCamel while the
+// nested ConfigurationRecorder's are lowerCamel (name, roleARN, recordingGroup).
+// That is the API model's, and a shape that "corrected" it would not decode what an
+// SDK sends.
+type cfgsvcPutRecorderRequest struct {
+	// ConfigurationRecorder is the recorder to create or update, required.
+	ConfigurationRecorder *ConfigRecorder `json:"ConfigurationRecorder"`
+
+	// Tags are applied at creation only, per the operation's own note.
+	Tags []ConfigTag `json:"Tags"`
+}
+
+// cfgsvcDescribeRecordersRequest is the input shared by
+// DescribeConfigurationRecorders and DescribeConfigurationRecorderStatus: both take
+// the same three filters and neither paginates.
+type cfgsvcDescribeRecordersRequest struct {
+	// ConfigurationRecorderNames selects recorders by name. More than one is a
+	// ValidationException, because an account has at most one recorder.
+	ConfigurationRecorderNames []string `json:"ConfigurationRecorderNames"`
+
+	// ServicePrincipal selects the service-linked recorder for a service.
+	ServicePrincipal string `json:"ServicePrincipal"`
+
+	// Arn selects a recorder by ARN.
+	Arn string `json:"Arn"`
+}
+
+// cfgsvcRecorderNameRequest is the input to StartConfigurationRecorder,
+// StopConfigurationRecorder and DeleteConfigurationRecorder, all of which take only
+// the name.
+type cfgsvcRecorderNameRequest struct {
+	// ConfigurationRecorderName names the recorder, required.
+	ConfigurationRecorderName string `json:"ConfigurationRecorderName"`
+}
+
+// recorderOperation claims the configuration-recorder operations.
+func (p *ConfigServicePlugin) recorderOperation(op string) (cfgsvcHandler, bool) {
+	switch op {
+	case "PutConfigurationRecorder":
+		return p.putConfigurationRecorder, true
+	case "DescribeConfigurationRecorders":
+		return p.describeConfigurationRecorders, true
+	case "DescribeConfigurationRecorderStatus":
+		return p.describeConfigurationRecorderStatus, true
+	case "StartConfigurationRecorder":
+		return p.startConfigurationRecorder, true
+	case "StopConfigurationRecorder":
+		return p.stopConfigurationRecorder, true
+	case "DeleteConfigurationRecorder":
+		return p.deleteConfigurationRecorder, true
+	}
+	return nil, false
+}
+
+// putConfigurationRecorder creates or updates the account's configuration
+// recorder.
+//
+// The operation is idempotent by name: a second call with the same name updates
+// the role and recording group and does **not** create a second recorder. A second
+// call with a *different* name is refused, because that would be a second recorder.
+// Tags are not touched by an update — "the tags for a configuration recorder are
+// added at creation and are not updated with configuration recorder updates" — so a
+// consumer that expects a Put to retag has a bug substrate reports rather than
+// hides.
+func (p *ConfigServicePlugin) putConfigurationRecorder(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcPutRecorderRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	if in.ConfigurationRecorder == nil {
+		return nil, cfgsvcValidation("ConfigurationRecorder is required.")
+	}
+
+	recorder := *in.ConfigurationRecorder
+	if recorder.Name == "" {
+		recorder.Name = cfgsvcDefaultName
+	}
+	if err := cfgsvcCheckRecorderName(recorder.Name); err != nil {
+		return nil, err
+	}
+	// A null or empty roleARN is InvalidRoleException, which is a *presence* check
+	// and nothing more: the exception's own text is "You have provided a null or
+	// empty Amazon Resource Name (ARN) for the IAM role assumed by Config". Substrate
+	// deliberately does not check that the role exists or is assumable — #580
+	// described this exception as an assumability check, and modeling it that way
+	// would refuse requests AWS accepts. The requirement itself is a documented
+	// divergence from the model, which marks roleARN optional: "While the API model
+	// does not require this field, the server will reject a request without a defined
+	// roleARN."
+	if strings.TrimSpace(recorder.RoleARN) == "" {
+		return nil, cfgsvcErr("InvalidRoleException",
+			"You have provided a null or empty Amazon Resource Name (ARN) for the IAM role "+
+				"assumed by Config and used by the customer managed configuration recorder.")
+	}
+	if err := cfgsvcCheckRecordingGroup(recorder.RecordingGroup); err != nil {
+		return nil, err
+	}
+	if recorder.RecordingGroup == nil {
+		recorder.RecordingGroup = cfgsvcDefaultRecordingGroup()
+	}
+
+	goCtx := context.Background()
+	key := cfgsvcRecorderKey(ctx.AccountID, ctx.Region)
+	var existing ConfigRecorder
+	found, err := p.cfgsvcGetJSON(goCtx, key, &existing)
+	if err != nil {
+		return nil, err
+	}
+	if found && existing.Name != recorder.Name {
+		return nil, cfgsvcErr("MaxNumberOfConfigurationRecordersExceededException",
+			"You have reached the limit of the number of configuration recorders you can create.")
+	}
+
+	recorder.ARN = cfgsvcRecorderARN(ctx, recorder.Name)
+	if err := p.cfgsvcPutJSON(goCtx, key, recorder); err != nil {
+		return nil, err
+	}
+
+	// The status record is created alongside a new recorder with Recording false —
+	// the whole point of the cluster — and left alone on an update, so a Put against a
+	// running recorder does not silently stop it.
+	if !found {
+		status := ConfigRecorderStatus{ARN: recorder.ARN, Name: recorder.Name, Recording: false}
+		if err := p.cfgsvcPutJSON(goCtx, cfgsvcRecorderStatusKey(ctx.AccountID, ctx.Region), status); err != nil {
+			return nil, err
+		}
+		tags, err := cfgsvcTagsToMap(in.Tags)
+		if err != nil {
+			return nil, err
+		}
+		if err := p.cfgsvcSaveTags(goCtx, recorder.ARN, tags); err != nil {
+			return nil, err
+		}
+	}
+
+	return cfgsvcEmptyResponse(), nil
+}
+
+// cfgsvcCheckRecorderName validates a recorder name against RecorderName's bounds
+// and the reserved service-linked prefix.
+func cfgsvcCheckRecorderName(name string) error {
+	if len(name) > cfgsvcMaxNameLen {
+		return cfgsvcValidation("The configuration recorder name must be between 1 and 256 characters long.")
+	}
+	// AWS reserves this prefix for recorders created through
+	// PutServiceLinkedConfigurationRecorder, which substrate does not model. The
+	// refusal still matters: a consumer that picks the prefix by accident gets the
+	// same error it would from AWS rather than a recorder AWS would not have made.
+	if strings.HasPrefix(name, cfgsvcServiceLinkedNamePrefix) {
+		return cfgsvcErr("InvalidConfigurationRecorderNameException",
+			"The configuration recorder name is not valid. The prefix "+
+				`"AWSConfigurationRecorderFor" is reserved for service-linked configuration recorders.`)
+	}
+	return nil
+}
+
+// cfgsvcDefaultRecordingGroup is the group a Put gets when it specifies none: all
+// supported resource types, excluding the global IAM types.
+//
+// The exclusion is expressed the way AWS expresses it — allSupported true with
+// includeGlobalResourceTypes false, that field being "a bundle which only applies to
+// the global IAM resource types: IAM users, groups, roles, and customer managed
+// policies". It is deliberately *not* expressed by synthesizing an
+// exclusionByResourceTypes list naming the four types: AWS does not return one for an
+// allSupported group, and an exclusion list paired with ALL_SUPPORTED_RESOURCE_TYPES
+// is the combination the recordingStrategy documentation treats as contradictory —
+// exclusionByResourceTypes is what EXCLUSION_BY_RESOURCE_TYPES reads. Emitting it
+// would be substrate inventing a response member, and a consumer asserting against
+// its own recorder would be asserting against substrate rather than against AWS.
+func cfgsvcDefaultRecordingGroup() *ConfigRecordingGroup {
+	return &ConfigRecordingGroup{
+		AllSupported:               true,
+		IncludeGlobalResourceTypes: false,
+		RecordingStrategy:          &ConfigRecordingStrategy{UseOnly: cfgsvcStrategyAllSupported},
+	}
+}
+
+// cfgsvcCheckRecordingGroup implements InvalidRecordingGroupException.
+//
+// The reference enumerates the cases, and these are them in order. A nil group is
+// valid — it means "use the default" — so only a group that was supplied is checked.
+//
+// The one enumerated case not implemented is "you have provided too many resource
+// types": no ceiling is documented anywhere, and inventing a number would refuse a
+// request AWS accepts.
+func cfgsvcCheckRecordingGroup(g *ConfigRecordingGroup) error {
+	if g == nil {
+		return nil
+	}
+	const invalid = "InvalidRecordingGroupException"
+
+	strategy := ""
+	if g.RecordingStrategy != nil {
+		strategy = g.RecordingStrategy.UseOnly
+	}
+	var excluded []string
+	if g.ExclusionByResourceTypes != nil {
+		excluded = g.ExclusionByResourceTypes.ResourceTypes
+	}
+
+	if g.AllSupported && len(g.ResourceTypes) > 0 {
+		return cfgsvcErr(invalid, "You have provided a configuration recorder that is not valid: "+
+			"allSupported is set to true and resourceTypes is not empty. If allSupported is set to "+
+			"true, do not provide a list of resource types.")
+	}
+	if g.AllSupported && strategy == cfgsvcStrategyExclusion {
+		return cfgsvcErr(invalid, "You have provided a configuration recorder that is not valid: "+
+			"allSupported is set to true and recordingStrategy is set to "+
+			"EXCLUSION_BY_RESOURCE_TYPES. These settings conflict.")
+	}
+	if !g.AllSupported && !g.IncludeGlobalResourceTypes &&
+		len(g.ResourceTypes) == 0 && len(excluded) == 0 && strategy == "" {
+		return cfgsvcErr(invalid, "You have provided a configuration recorder that is not valid: "+
+			"all of the recording group parameters are either null, false, or empty.")
+	}
+	if strategy != "" && !slices.Contains(cfgsvcRecordingStrategies, strategy) {
+		return cfgsvcErr(invalid, "You have provided a configuration recorder that is not valid: "+
+			"the recording strategy "+strategy+" is not a valid recording strategy.")
+	}
+	for _, list := range [][]string{g.ResourceTypes, excluded} {
+		for _, rt := range list {
+			if !cfgsvcResourceTypePattern.MatchString(rt) {
+				return cfgsvcErr(invalid, "You have provided a configuration recorder that is not "+
+					"valid: the resource type "+rt+" is not a valid resource type.")
+			}
+		}
+	}
+	return nil
+}
+
+// cfgsvcTagsToMap folds a TagsList into the map substrate stores, refusing a list
+// longer than the documented 50.
+func cfgsvcTagsToMap(tags []ConfigTag) (map[string]string, error) {
+	if len(tags) > cfgsvcMaxTags {
+		return nil, cfgsvcValidation("You can associate up to 50 tags with a resource.")
+	}
+	out := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		if err := cfgsvcCheckTag(tag.Key, tag.Value); err != nil {
+			return nil, err
+		}
+		out[tag.Key] = tag.Value
+	}
+	return out, nil
+}
+
+// describeConfigurationRecorders reports the account's recorder — whether or not it
+// is recording, which is what makes DescribeConfigurationRecorderStatus a separate
+// call and not a redundant one.
+func (p *ConfigServicePlugin) describeConfigurationRecorders(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	in, recorder, found, err := p.cfgsvcResolveDescribed(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	recorders := []ConfigRecorder{}
+	if found {
+		// A service-principal filter selects a service-linked recorder, and substrate
+		// models none — so a syntactically valid principal matches nothing rather than
+		// matching the customer managed recorder, which is not what the caller asked for.
+		if in.ServicePrincipal == "" {
+			recorders = append(recorders, *recorder)
+		}
+	}
+	return cfgsvcJSONResponse(map[string]interface{}{
+		"ConfigurationRecorders": recorders,
+	}, "describeConfigurationRecorders")
+}
+
+// describeConfigurationRecorderStatus reports whether the recorder is recording.
+//
+// This is the only operation that can answer that question, and a consumer reading
+// only DescribeConfigurationRecorders has not asked it.
+func (p *ConfigServicePlugin) describeConfigurationRecorderStatus(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	in, _, found, err := p.cfgsvcResolveDescribed(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	statuses := []ConfigRecorderStatus{}
+	if found && in.ServicePrincipal == "" {
+		status, err := p.cfgsvcRecorderStatus(ctx)
+		if err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, *status)
+	}
+	return cfgsvcJSONResponse(map[string]interface{}{
+		"ConfigurationRecordersStatus": statuses,
+	}, "describeConfigurationRecorderStatus")
+}
+
+// cfgsvcResolveDescribed decodes and applies the filters both describe operations
+// share, so the two cannot disagree about which recorder a request names.
+//
+// An absent recorder is reported as found=false rather than as an error when the
+// request carries no name: "no recorder yet" is the state a fresh account is in, and
+// an empty list is what AWS returns for it. A request that *names* a recorder that
+// does not exist is NoSuchConfigurationRecorderException, because the caller
+// asserted the name.
+func (p *ConfigServicePlugin) cfgsvcResolveDescribed(ctx *RequestContext, req *AWSRequest) (
+	*cfgsvcDescribeRecordersRequest, *ConfigRecorder, bool, error) {
+	var in cfgsvcDescribeRecordersRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, nil, false, err
+	}
+	if len(in.ConfigurationRecorderNames) > cfgsvcMaxRecorders {
+		return nil, nil, false, cfgsvcValidation("You have specified more than one configuration recorder.")
+	}
+	if in.ServicePrincipal != "" &&
+		(len(in.ServicePrincipal) > 128 || !cfgsvcServicePrincipalPattern.MatchString(in.ServicePrincipal)) {
+		return nil, nil, false, cfgsvcValidation(
+			"You have provided a service principal for service-linked configuration recorder that is not valid.")
+	}
+
+	var recorder ConfigRecorder
+	found, err := p.cfgsvcGetJSON(context.Background(), cfgsvcRecorderKey(ctx.AccountID, ctx.Region), &recorder)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	if len(in.ConfigurationRecorderNames) == 1 {
+		if !found || recorder.Name != in.ConfigurationRecorderNames[0] {
+			return nil, nil, false, cfgsvcNoSuchRecorder()
+		}
+	}
+	if in.Arn != "" {
+		if !found || recorder.ARN != in.Arn {
+			return nil, nil, false, cfgsvcNoSuchRecorder()
+		}
+	}
+	return &in, &recorder, found, nil
+}
+
+// cfgsvcNoSuchRecorder is NoSuchConfigurationRecorderException, at 400 like every
+// other Config exception — including this one, whose reference page says 400 even
+// though it reports a missing entity.
+func cfgsvcNoSuchRecorder() *AWSError {
+	return cfgsvcErr("NoSuchConfigurationRecorderException",
+		"You have specified a configuration recorder that does not exist.")
+}
+
+// startConfigurationRecorder starts recording.
+//
+// The delivery-channel guard is the interesting part: "You must have created a
+// delivery channel to successfully start the customer managed configuration
+// recorder." A consumer that creates a recorder and starts it without a channel has
+// an ordering bug, and without this refusal the emulator would report a recording
+// recorder that AWS would not have started.
+//
+// Starting an already-recording recorder is a no-op at 200. No refusal is
+// documented for it, and inventing one would fail a retry that AWS accepts.
+func (p *ConfigServicePlugin) startConfigurationRecorder(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	status, err := p.cfgsvcNamedRecorderStatus(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	goCtx := context.Background()
+	var channel ConfigDeliveryChannel
+	hasChannel, err := p.cfgsvcGetJSON(goCtx, cfgsvcChannelKey(ctx.AccountID, ctx.Region), &channel)
+	if err != nil {
+		return nil, err
+	}
+	if !hasChannel {
+		return nil, cfgsvcErr("NoAvailableDeliveryChannelException",
+			"There is no delivery channel available to record configurations.")
+	}
+
+	if !status.Recording {
+		now := EpochSeconds(p.tc.Now())
+		status.Recording = true
+		status.LastStartTime = now
+		status.LastStatusChangeTime = now
+		// Substrate has nothing that can fail a delivery, so a started recorder reports
+		// Success. A consumer that needs to exercise a failing recorder seeds it; see
+		// configservice_control.go.
+		status.LastStatus = cfgsvcRecorderStatusSuccess
+		if err := p.cfgsvcPutJSON(goCtx, cfgsvcRecorderStatusKey(ctx.AccountID, ctx.Region), *status); err != nil {
+			return nil, err
+		}
+	}
+	return cfgsvcEmptyResponse(), nil
+}
+
+// stopConfigurationRecorder stops recording. Stopping an already-stopped recorder
+// is a no-op at 200, for the same reason starting a running one is.
+func (p *ConfigServicePlugin) stopConfigurationRecorder(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	status, err := p.cfgsvcNamedRecorderStatus(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if status.Recording {
+		now := EpochSeconds(p.tc.Now())
+		status.Recording = false
+		status.LastStopTime = now
+		status.LastStatusChangeTime = now
+		if err := p.cfgsvcPutJSON(context.Background(),
+			cfgsvcRecorderStatusKey(ctx.AccountID, ctx.Region), *status); err != nil {
+			return nil, err
+		}
+	}
+	return cfgsvcEmptyResponse(), nil
+}
+
+// deleteConfigurationRecorder deletes the recorder and its status and tags.
+//
+// Deleting a recorder while it is recording is permitted — no refusal is documented
+// — and it does not delete the delivery channel, so a fixture that tears down and
+// rebuilds must delete both.
+func (p *ConfigServicePlugin) deleteConfigurationRecorder(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcRecorderNameRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	goCtx := context.Background()
+	var recorder ConfigRecorder
+	found, err := p.cfgsvcGetJSON(goCtx, cfgsvcRecorderKey(ctx.AccountID, ctx.Region), &recorder)
+	if err != nil {
+		return nil, err
+	}
+	if !found || recorder.Name != in.ConfigurationRecorderName {
+		return nil, cfgsvcNoSuchRecorder()
+	}
+
+	// Tags go with the resource: "if you delete a resource, tags for the resource are
+	// deleted as well". Leaving them would make a rebuilt recorder inherit the tags of
+	// its predecessor, which no AWS account does.
+	for _, key := range []string{
+		cfgsvcRecorderKey(ctx.AccountID, ctx.Region),
+		cfgsvcRecorderStatusKey(ctx.AccountID, ctx.Region),
+		cfgsvcTagsKey(recorder.ARN),
+	} {
+		if err := p.cfgsvcDeleteKey(goCtx, key); err != nil {
+			return nil, err
+		}
+	}
+	return cfgsvcEmptyResponse(), nil
+}
+
+// cfgsvcNamedRecorderStatus resolves the status record for a name-only request,
+// refusing a name that is not the account's recorder.
+func (p *ConfigServicePlugin) cfgsvcNamedRecorderStatus(ctx *RequestContext, req *AWSRequest) (
+	*ConfigRecorderStatus, error) {
+	var in cfgsvcRecorderNameRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	var recorder ConfigRecorder
+	found, err := p.cfgsvcGetJSON(context.Background(),
+		cfgsvcRecorderKey(ctx.AccountID, ctx.Region), &recorder)
+	if err != nil {
+		return nil, err
+	}
+	if !found || recorder.Name != in.ConfigurationRecorderName {
+		return nil, cfgsvcNoSuchRecorder()
+	}
+	return p.cfgsvcRecorderStatus(ctx)
+}
+
+// cfgsvcRecorderStatus loads the recorder's status with any seeded values applied.
+//
+// The seed is applied at read time rather than written into state, so clearing it
+// restores the real status rather than leaving a seeded value behind — the same
+// reasoning as the account Region-opt seed.
+func (p *ConfigServicePlugin) cfgsvcRecorderStatus(ctx *RequestContext) (*ConfigRecorderStatus, error) {
+	goCtx := context.Background()
+	var status ConfigRecorderStatus
+	found, err := p.cfgsvcGetJSON(goCtx, cfgsvcRecorderStatusKey(ctx.AccountID, ctx.Region), &status)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		// A recorder with no status record predates the status write or was written
+		// directly into state; report it as existing and not recording rather than
+		// failing, because "exists but not recording" is a real state and an error is not.
+		var recorder ConfigRecorder
+		if _, err := p.cfgsvcGetJSON(goCtx, cfgsvcRecorderKey(ctx.AccountID, ctx.Region), &recorder); err != nil {
+			return nil, err
+		}
+		status = ConfigRecorderStatus{ARN: recorder.ARN, Name: recorder.Name}
+	}
+
+	seed, seeded, err := p.seededRecorderStatus(goCtx, ctx.AccountID, ctx.Region)
+	if err != nil {
+		return nil, err
+	}
+	if seeded {
+		status.LastStatus = seed.LastStatus
+		status.LastErrorCode = seed.LastErrorCode
+		status.LastErrorMessage = seed.LastErrorMessage
+		if status.LastStatusChangeTime.IsZero() {
+			status.LastStatusChangeTime = EpochSeconds(p.tc.Now())
+		}
+	}
+	return &status, nil
+}

--- a/emulator/configservice_recorder_test.go
+++ b/emulator/configservice_recorder_test.go
@@ -1,0 +1,828 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The configuration-recorder cluster (#580).
+//
+// Every case here goes through the full server rather than calling the plugin
+// directly, because the thing most likely to be wrong about a new JSON-target
+// service is whether a request reaches it at all — that is what #561 and #580's
+// own routing gap were, and a direct plugin call cannot see it.
+//
+// The headline assertion is TestConfigRecorder_ExistsButIsNotRecording: a recorder
+// that exists and is not recording is the misconfiguration the whole plugin is for,
+// and the two operations that look like they answer the same question must disagree
+// about it.
+
+// configRequest posts an AWS Config JSON-target request in us-east-1 and returns the
+// response.
+func configRequest(t *testing.T, ts *emulator.TestServer, operation string, body any) *http.Response {
+	t.Helper()
+	return configRequestIn(t, ts, "us-east-1", operation, body)
+}
+
+// configRequestIn posts an AWS Config JSON-target request against a named Region.
+//
+// The request is signed with the built-in test key, which resolves the caller to
+// account 123456789012; an unsigned one would land in 000000000000 and the ARNs
+// these cases assert would silently be a different account's. The Region rides in
+// both the host and the credential scope, as it does from a real client, so the
+// regional-isolation cases exercise the same resolution path as the rest.
+func configRequestIn(t *testing.T, ts *emulator.TestServer, region, operation string, body any) *http.Response {
+	t.Helper()
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", operation, err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("build %s request: %v", operation, err)
+	}
+	req.Host = "config." + region + ".amazonaws.com"
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "StarlingDoveService."+operation)
+	req.Header.Set("Authorization",
+		"AWS4-HMAC-SHA256 Credential=AKIATEST12345678901/20260101/"+region+
+			"/config/aws4_request, SignedHeaders=host, Signature=fake")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", operation, err)
+	}
+	return resp
+}
+
+// decodeConfigResponse decodes a JSON 1.1 response into out and returns the status
+// and the error code a refusal carries.
+//
+// The code comes from "__type", which is where the JSON-RPC protocols put it and
+// what an SDK matches on. Every Config exception is HTTP 400 — including the
+// not-found ones — so the status alone distinguishes nothing and the code is what
+// every refusal case asserts.
+func decodeConfigResponse(t *testing.T, resp *http.Response, out any) (status int, code, message string) {
+	t.Helper()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("close body: %v", err)
+		}
+	}()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		var errBody struct {
+			Type    string `json:"__type"`
+			Message string `json:"message"`
+			Msg     string `json:"Message"`
+		}
+		if err := json.Unmarshal(raw, &errBody); err != nil {
+			t.Fatalf("unmarshal error body %q: %v", raw, err)
+		}
+		msg := errBody.Message
+		if msg == "" {
+			msg = errBody.Msg
+		}
+		return resp.StatusCode, errBody.Type, msg
+	}
+	if out != nil {
+		if err := json.Unmarshal(raw, out); err != nil {
+			t.Fatalf("unmarshal body %q: %v", raw, err)
+		}
+	}
+	return resp.StatusCode, "", ""
+}
+
+// configRecorderPayload is the ConfigurationRecorder a Put sends. Its members are
+// lowerCamel because that is what the API model declares for this shape, unlike the
+// request that wraps it.
+func configRecorderPayload(name string) map[string]any {
+	return map[string]any{
+		"name":    name,
+		"roleARN": "arn:aws:iam::123456789012:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig",
+	}
+}
+
+// configPutRecorder creates a recorder and requires that it succeed, for the many
+// cases whose subject is something else.
+func configPutRecorder(t *testing.T, ts *emulator.TestServer, name string) {
+	t.Helper()
+	resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+		"ConfigurationRecorder": configRecorderPayload(name),
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+}
+
+// configDescribeRecorders returns the recorders DescribeConfigurationRecorders
+// reports.
+func configDescribeRecorders(t *testing.T, ts *emulator.TestServer) []map[string]any {
+	t.Helper()
+	resp := configRequest(t, ts, "DescribeConfigurationRecorders", map[string]any{})
+	var out struct {
+		ConfigurationRecorders []map[string]any `json:"ConfigurationRecorders"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	return out.ConfigurationRecorders
+}
+
+// configDescribeRecorderStatus returns the statuses
+// DescribeConfigurationRecorderStatus reports.
+func configDescribeRecorderStatus(t *testing.T, ts *emulator.TestServer) []map[string]any {
+	t.Helper()
+	resp := configRequest(t, ts, "DescribeConfigurationRecorderStatus", map[string]any{})
+	var out struct {
+		ConfigurationRecordersStatus []map[string]any `json:"ConfigurationRecordersStatus"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	return out.ConfigurationRecordersStatus
+}
+
+// configStartRecorder starts the named recorder, requiring success.
+func configStartRecorder(t *testing.T, ts *emulator.TestServer, name string) {
+	t.Helper()
+	resp := configRequest(t, ts, "StartConfigurationRecorder", map[string]any{
+		"ConfigurationRecorderName": name,
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+}
+
+// configPutChannel creates a delivery channel with a bucket whose policy admits
+// Config, which is the setup StartConfigurationRecorder needs.
+func configPutChannel(t *testing.T, ts *emulator.TestServer, name, bucket string) {
+	t.Helper()
+	if bucket != "" {
+		configSeedDeliveryPolicy(t, ts, bucket, "ok")
+	}
+	channel := map[string]any{"name": name}
+	if bucket != "" {
+		channel["s3BucketName"] = bucket
+	}
+	resp := configRequest(t, ts, "PutDeliveryChannel", map[string]any{"DeliveryChannel": channel})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+}
+
+func TestConfigRecorder_ExistsButIsNotRecording(t *testing.T) {
+	// The release's headline behavior. DescribeConfigurationRecorders reporting a
+	// recorder says nothing about whether it is recording, and a consumer that checks
+	// only that call reports an account as covered when it is not. The two operations
+	// must disagree here, and after a Start they must agree.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	recorders := configDescribeRecorders(t, ts)
+	require.Len(t, recorders, 1, "the recorder exists and Describe reports it in full")
+	assert.Equal(t, "default", recorders[0]["name"])
+
+	statuses := configDescribeRecorderStatus(t, ts)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, false, statuses[0]["recording"],
+		"a recorder that was created and never started records nothing — this is the whole point")
+
+	// And only Start changes it, which is what makes the first assertion a behavior
+	// rather than an omission.
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+
+	statuses = configDescribeRecorderStatus(t, ts)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, true, statuses[0]["recording"])
+	assert.Equal(t, "Success", statuses[0]["lastStatus"])
+	assert.NotNil(t, statuses[0]["lastStartTime"], "a started recorder reports when it started")
+}
+
+func TestConfigRecorder_DescribeIsEmptyBeforeAnyPut(t *testing.T) {
+	// A fresh account has no recorder, and that is an empty list rather than a
+	// refusal: an emulator answering NoSuchConfigurationRecorder to an unfiltered
+	// Describe would make a consumer's "am I set up?" check fail where AWS answers it.
+	ts := emulator.StartTestServer(t)
+
+	assert.Empty(t, configDescribeRecorders(t, ts))
+	assert.Empty(t, configDescribeRecorderStatus(t, ts))
+}
+
+func TestConfigRecorder_PutIsIdempotentAndDoesNotRetag(t *testing.T) {
+	// "Subsequent requests won't create a duplicate resource" — and the tags "are
+	// added at creation and are not updated with configuration recorder updates". The
+	// second half is the surprising one, so a consumer that expects a Put to retag has
+	// a bug substrate must report rather than hide.
+	ts := emulator.StartTestServer(t)
+
+	resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+		"ConfigurationRecorder": configRecorderPayload("default"),
+		"Tags":                  []map[string]string{{"Key": "env", "Value": "prod"}},
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	// A second Put updates the role, and must neither create a second recorder nor
+	// replace the tags.
+	updated := configRecorderPayload("default")
+	updated["roleARN"] = "arn:aws:iam::123456789012:role/second"
+	resp = configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+		"ConfigurationRecorder": updated,
+		"Tags":                  []map[string]string{{"Key": "env", "Value": "dev"}},
+	})
+	status, code, message = decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	recorders := configDescribeRecorders(t, ts)
+	require.Len(t, recorders, 1, "a second Put with the same name updates rather than duplicates")
+	assert.Equal(t, "arn:aws:iam::123456789012:role/second", recorders[0]["roleARN"],
+		"the role is updated")
+
+	tags := configStoredTags(t, ts, "arn:aws:config:us-east-1:123456789012:config-recorder/default")
+	assert.Equal(t, map[string]string{"env": "prod"}, tags,
+		"tags are set at creation and a later Put does not update them")
+}
+
+// configStoredTags reads the tags substrate stored for a resource ARN. The tag
+// operations that read them over the wire arrive in a later PR; until then the state
+// is the only place the creation-time behavior is observable, and it is the
+// behavior that matters.
+func configStoredTags(t *testing.T, ts *emulator.TestServer, arn string) map[string]string {
+	t.Helper()
+	raw, err := ts.StateManager().Get(t.Context(), "config", "tags:"+arn)
+	require.NoError(t, err)
+	if raw == nil {
+		return nil
+	}
+	var tags map[string]string
+	require.NoError(t, json.Unmarshal(raw, &tags))
+	return tags
+}
+
+func TestConfigRecorder_ASecondNameIsRefused(t *testing.T) {
+	// One recorder per account per Region. AWS documents this on the operation rather
+	// than on the service-limits page, and it is what makes the exception reachable at
+	// a count of two rather than at some larger ceiling.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+		"ConfigurationRecorder": configRecorderPayload("second"),
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "MaxNumberOfConfigurationRecordersExceededException", code)
+	assert.Contains(t, message, "reached the limit")
+
+	assert.Len(t, configDescribeRecorders(t, ts), 1, "the refusal stored nothing")
+}
+
+func TestConfigRecorder_NameDefaultsToDefault(t *testing.T) {
+	// "If you do not specify a name, the default is used." A consumer that omits the
+	// name and then starts "default" — which is what every console-derived script does
+	// — must find a recorder there.
+	ts := emulator.StartTestServer(t)
+
+	resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+		"ConfigurationRecorder": map[string]any{
+			"roleARN": "arn:aws:iam::123456789012:role/config",
+		},
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	recorders := configDescribeRecorders(t, ts)
+	require.Len(t, recorders, 1)
+	assert.Equal(t, "default", recorders[0]["name"])
+	assert.Equal(t, "arn:aws:config:us-east-1:123456789012:config-recorder/default", recorders[0]["arn"],
+		"the ARN resource type is config-recorder, per the Service Authorization Reference")
+}
+
+func TestConfigRecorder_RefusesAnEmptyRoleARN(t *testing.T) {
+	// InvalidRoleException is a presence check and nothing more — "You have provided a
+	// null or empty Amazon Resource Name (ARN)". #580 described it as an assumability
+	// check; modeling it that way would refuse requests AWS accepts, so a role that
+	// does not exist is deliberately fine here and only an absent one is refused.
+	cases := []struct {
+		name     string
+		recorder map[string]any
+	}{
+		{"omitted", map[string]any{"name": "default"}},
+		{"empty", map[string]any{"name": "default", "roleARN": ""}},
+		{"whitespace", map[string]any{"name": "default", "roleARN": "   "}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+				"ConfigurationRecorder": tc.recorder,
+			})
+			status, code, message := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidRoleException", code)
+			assert.Contains(t, message, "null or empty")
+		})
+	}
+
+	t.Run("a role that does not exist is accepted", func(t *testing.T) {
+		ts := emulator.StartTestServer(t)
+		resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+			"ConfigurationRecorder": map[string]any{
+				"name":    "default",
+				"roleARN": "arn:aws:iam::123456789012:role/never-created",
+			},
+		})
+		status, code, message := decodeConfigResponse(t, resp, nil)
+		assert.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	})
+}
+
+func TestConfigRecorder_RefusesTheReservedNamePrefix(t *testing.T) {
+	// AWS reserves AWSConfigurationRecorderFor for service-linked recorders, which are
+	// created through PutServiceLinkedConfigurationRecorder and which substrate does
+	// not model. The refusal still matters: a consumer that picks the prefix gets the
+	// error AWS gives rather than a recorder AWS would not have made.
+	ts := emulator.StartTestServer(t)
+
+	resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+		"ConfigurationRecorder": configRecorderPayload("AWSConfigurationRecorderForSecurityHub"),
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidConfigurationRecorderNameException", code)
+	assert.Contains(t, message, "AWSConfigurationRecorderFor")
+}
+
+func TestConfigRecorder_RefusesAnInvalidRecordingGroup(t *testing.T) {
+	// The five cases the reference enumerates, minus "too many resource types", for
+	// which no ceiling is documented anywhere — inventing one would refuse a request
+	// AWS accepts. wantMessage is asserted rather than only the code, because all of
+	// these share one exception and a test checking only the code would pass with any
+	// single arm deleted.
+	cases := []struct {
+		name        string
+		group       map[string]any
+		wantMessage string
+	}{
+		{
+			"allSupported with resourceTypes",
+			map[string]any{"allSupported": true, "resourceTypes": []string{"AWS::S3::Bucket"}},
+			"resourceTypes is not empty",
+		},
+		{
+			"allSupported with an exclusion strategy",
+			map[string]any{
+				"allSupported":      true,
+				"recordingStrategy": map[string]any{"useOnly": "EXCLUSION_BY_RESOURCE_TYPES"},
+			},
+			"These settings conflict",
+		},
+		{
+			"every parameter null false or empty",
+			map[string]any{"allSupported": false},
+			"null, false, or empty",
+		},
+		{
+			"an invalid strategy",
+			map[string]any{
+				"resourceTypes":     []string{"AWS::S3::Bucket"},
+				"recordingStrategy": map[string]any{"useOnly": "SOME_OTHER_STRATEGY"},
+			},
+			"not a valid recording strategy",
+		},
+		{
+			"an invalid resource type",
+			map[string]any{"resourceTypes": []string{"S3Bucket"}},
+			"not a valid resource type",
+		},
+		{
+			"an invalid excluded resource type",
+			map[string]any{
+				"exclusionByResourceTypes": map[string]any{"resourceTypes": []string{"nonsense"}},
+				"recordingStrategy":        map[string]any{"useOnly": "EXCLUSION_BY_RESOURCE_TYPES"},
+			},
+			"not a valid resource type",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			recorder := configRecorderPayload("default")
+			recorder["recordingGroup"] = tc.group
+
+			resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+				"ConfigurationRecorder": recorder,
+			})
+			status, code, message := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidRecordingGroupException", code)
+			assert.Contains(t, message, tc.wantMessage)
+		})
+	}
+}
+
+func TestConfigRecorder_AcceptsTheRecordingGroupsAWSDoes(t *testing.T) {
+	// The shapes a real template sends. Each must be accepted: a group refused here
+	// that AWS accepts would fail a working stack, which is the worse of the two
+	// failure directions.
+	cases := []struct {
+		name  string
+		group map[string]any
+	}{
+		{"allSupported alone", map[string]any{"allSupported": true}},
+		{
+			"allSupported with global types",
+			map[string]any{"allSupported": true, "includeGlobalResourceTypes": true},
+		},
+		{
+			"an inclusion list",
+			map[string]any{
+				"resourceTypes":     []string{"AWS::S3::Bucket", "AWS::EC2::Instance"},
+				"recordingStrategy": map[string]any{"useOnly": "INCLUSION_BY_RESOURCE_TYPES"},
+			},
+		},
+		{
+			"an exclusion list",
+			map[string]any{
+				"exclusionByResourceTypes": map[string]any{"resourceTypes": []string{"AWS::IAM::Role"}},
+				"recordingStrategy":        map[string]any{"useOnly": "EXCLUSION_BY_RESOURCE_TYPES"},
+			},
+		},
+		{
+			"a resource type from a service substrate does not emulate",
+			map[string]any{
+				"resourceTypes": []string{"AWS::Panorama::Package"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			recorder := configRecorderPayload("default")
+			recorder["recordingGroup"] = tc.group
+
+			resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+				"ConfigurationRecorder": recorder,
+			})
+			status, code, message := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+		})
+	}
+}
+
+func TestConfigRecorder_TheDefaultGroupExcludesGlobalIAMTypes(t *testing.T) {
+	// "All supported resource types, excluding the global IAM resource types" — and the
+	// way AWS says so is includeGlobalResourceTypes false, that field being "a bundle
+	// which only applies to the global IAM resource types: IAM users, groups, roles, and
+	// customer managed policies".
+	//
+	// It is specifically not said by synthesizing an exclusionByResourceTypes list of
+	// those four types. AWS returns no such list for an allSupported group, and an
+	// exclusion list alongside ALL_SUPPORTED_RESOURCE_TYPES is the combination
+	// InvalidRecordingGroupException exists to refuse — so emitting one would have
+	// substrate answering with a group it would itself reject on input.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	recorders := configDescribeRecorders(t, ts)
+	require.Len(t, recorders, 1)
+	group, ok := recorders[0]["recordingGroup"].(map[string]any)
+	require.True(t, ok, "a Put with no group is reported with the default one")
+	assert.Equal(t, true, group["allSupported"])
+	assert.Equal(t, false, group["includeGlobalResourceTypes"],
+		"the global IAM types are the bundle this field turns off")
+	assert.NotContains(t, group, "exclusionByResourceTypes",
+		"an allSupported group carries no exclusion list")
+
+	strategy, ok := group["recordingStrategy"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "ALL_SUPPORTED_RESOURCE_TYPES", strategy["useOnly"])
+}
+
+func TestConfigRecorder_StartRefusesWithoutADeliveryChannel(t *testing.T) {
+	// "You must have created a delivery channel to successfully start the customer
+	// managed configuration recorder." #580 omitted this refusal; without it the
+	// emulator would report a recording recorder that AWS would not have started,
+	// which is precisely the wrong answer to give a consumer with an ordering bug.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	resp := configRequest(t, ts, "StartConfigurationRecorder", map[string]any{
+		"ConfigurationRecorderName": "default",
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "NoAvailableDeliveryChannelException", code)
+	assert.Contains(t, message, "no delivery channel available")
+
+	statuses := configDescribeRecorderStatus(t, ts)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, false, statuses[0]["recording"], "the refusal did not start anything")
+}
+
+func TestConfigRecorder_StartAndStopAreIdempotent(t *testing.T) {
+	// No refusal is documented for starting a running recorder or stopping a stopped
+	// one, so both are no-ops at 200. Inventing a refusal would fail a retry that AWS
+	// accepts — and a retry is exactly what a consumer whose first call timed out
+	// sends.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+
+	configStartRecorder(t, ts, "default")
+	configStartRecorder(t, ts, "default")
+	statuses := configDescribeRecorderStatus(t, ts)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, true, statuses[0]["recording"])
+
+	for range 2 {
+		resp := configRequest(t, ts, "StopConfigurationRecorder", map[string]any{
+			"ConfigurationRecorderName": "default",
+		})
+		status, code, message := decodeConfigResponse(t, resp, nil)
+		require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	}
+	statuses = configDescribeRecorderStatus(t, ts)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, false, statuses[0]["recording"])
+	assert.NotNil(t, statuses[0]["lastStopTime"])
+}
+
+func TestConfigRecorder_AnUnknownNameIsRefused(t *testing.T) {
+	// Every operation that names a recorder refuses a name that is not the account's,
+	// and every one of them does so at HTTP 400 — this exception reports a missing
+	// entity and its reference page still says 400, so a 404 here would be a shape a
+	// consumer cannot reproduce against AWS.
+	operations := []string{
+		"StartConfigurationRecorder",
+		"StopConfigurationRecorder",
+		"DeleteConfigurationRecorder",
+	}
+	for _, op := range operations {
+		t.Run(op+"/no recorder at all", func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			resp := configRequest(t, ts, op, map[string]any{"ConfigurationRecorderName": "ghost"})
+			status, code, message := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status,
+				"every Config exception is 400, including the not-found ones")
+			assert.Equal(t, "NoSuchConfigurationRecorderException", code)
+			assert.Contains(t, message, "does not exist")
+		})
+
+		t.Run(op+"/a different recorder exists", func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			configPutRecorder(t, ts, "default")
+			resp := configRequest(t, ts, op, map[string]any{"ConfigurationRecorderName": "ghost"})
+			status, code, _ := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "NoSuchConfigurationRecorderException", code)
+		})
+	}
+
+	// The describe operations refuse a named recorder that does not exist too — the
+	// caller asserted the name — while an *unfiltered* describe answers with an empty
+	// list, which the fresh-account test pins.
+	for _, op := range []string{"DescribeConfigurationRecorders", "DescribeConfigurationRecorderStatus"} {
+		t.Run(op+"/by name", func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			resp := configRequest(t, ts, op, map[string]any{
+				"ConfigurationRecorderNames": []string{"ghost"},
+			})
+			status, code, _ := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "NoSuchConfigurationRecorderException", code)
+		})
+
+		t.Run(op+"/by arn", func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			configPutRecorder(t, ts, "default")
+			resp := configRequest(t, ts, op, map[string]any{
+				"Arn": "arn:aws:config:us-east-1:123456789012:config-recorder/ghost",
+			})
+			status, code, _ := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "NoSuchConfigurationRecorderException", code)
+		})
+	}
+}
+
+func TestConfigRecorder_DescribeAcceptsTheRecordersOwnNameAndARN(t *testing.T) {
+	// The filters must select as well as refuse: a describe naming the recorder that
+	// does exist has to find it, or the refusal above would be indistinguishable from
+	// a filter that matches nothing.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	const arn = "arn:aws:config:us-east-1:123456789012:config-recorder/default"
+
+	for _, body := range []map[string]any{
+		{"ConfigurationRecorderNames": []string{"default"}},
+		{"Arn": arn},
+		{"ConfigurationRecorderNames": []string{"default"}, "Arn": arn},
+	} {
+		resp := configRequest(t, ts, "DescribeConfigurationRecorders", body)
+		var out struct {
+			ConfigurationRecorders []map[string]any `json:"ConfigurationRecorders"`
+		}
+		status, code, message := decodeConfigResponse(t, resp, &out)
+		require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+		require.Len(t, out.ConfigurationRecorders, 1)
+		assert.Equal(t, "default", out.ConfigurationRecorders[0]["name"])
+	}
+}
+
+func TestConfigRecorder_MoreThanOneNameIsAValidationException(t *testing.T) {
+	// "You have specified more than one configuration recorder." An account has at
+	// most one, so a list of two is a request that cannot be satisfied — and reporting
+	// an empty list instead would leave a consumer to conclude it has no recorder.
+	for _, op := range []string{"DescribeConfigurationRecorders", "DescribeConfigurationRecorderStatus"} {
+		t.Run(op, func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			configPutRecorder(t, ts, "default")
+
+			resp := configRequest(t, ts, op, map[string]any{
+				"ConfigurationRecorderNames": []string{"default", "other"},
+			})
+			status, code, message := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "ValidationException", code)
+			assert.Contains(t, message, "more than one configuration recorder")
+		})
+	}
+}
+
+func TestConfigRecorder_AServicePrincipalFilterMatchesNothing(t *testing.T) {
+	// A service principal selects a service-linked recorder, and substrate models
+	// none. Reporting the customer managed recorder for such a filter would answer a
+	// question the caller did not ask; an invalid principal is refused with the
+	// exception's own wording.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	resp := configRequest(t, ts, "DescribeConfigurationRecorders", map[string]any{
+		"ServicePrincipal": "securityhub.amazonaws.com",
+	})
+	var out struct {
+		ConfigurationRecorders []map[string]any `json:"ConfigurationRecorders"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Empty(t, out.ConfigurationRecorders,
+		"substrate models no service-linked recorders, so this filter selects nothing")
+
+	resp = configRequest(t, ts, "DescribeConfigurationRecorders", map[string]any{
+		"ServicePrincipal": "not a principal!",
+	})
+	status, code, message = decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "ValidationException", code)
+	assert.Contains(t, message, "service principal")
+}
+
+func TestConfigRecorder_IsIsolatedByRegion(t *testing.T) {
+	// "Recording in one Region only" is a real and common misconfiguration, and a
+	// state key that dropped the Region would make it unreachable: the recorder created
+	// in us-east-1 would appear in eu-west-1 and the consumer's multi-Region check
+	// would pass everywhere.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+
+	resp := configRequestIn(t, ts, "eu-west-1", "DescribeConfigurationRecorders", map[string]any{})
+	var out struct {
+		ConfigurationRecorders []map[string]any `json:"ConfigurationRecorders"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Empty(t, out.ConfigurationRecorders, "a recorder in us-east-1 is not in eu-west-1")
+
+	// And a recorder can be created there without colliding with the first, which the
+	// max-recorders refusal would otherwise prevent.
+	resp = configRequestIn(t, ts, "eu-west-1", "PutConfigurationRecorder", map[string]any{
+		"ConfigurationRecorder": configRecorderPayload("default"),
+	})
+	status, code, message = decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	resp = configRequestIn(t, ts, "eu-west-1", "DescribeConfigurationRecorders", map[string]any{})
+	status, code, message = decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	require.Len(t, out.ConfigurationRecorders, 1)
+	assert.Equal(t, "arn:aws:config:eu-west-1:123456789012:config-recorder/default",
+		out.ConfigurationRecorders[0]["arn"], "the ARN carries the Region it was created in")
+}
+
+func TestConfigRecorder_DeleteRemovesEverythingAboutIt(t *testing.T) {
+	// A rebuilt recorder must not inherit its predecessor's tags or status: "if you
+	// delete a resource, tags for the resource are deleted as well", and a fixture that
+	// tears down and rebuilds is just the same test run twice.
+	ts := emulator.StartTestServer(t)
+	const arn = "arn:aws:config:us-east-1:123456789012:config-recorder/default"
+
+	resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+		"ConfigurationRecorder": configRecorderPayload("default"),
+		"Tags":                  []map[string]string{{"Key": "env", "Value": "prod"}},
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+
+	resp = configRequest(t, ts, "DeleteConfigurationRecorder", map[string]any{
+		"ConfigurationRecorderName": "default",
+	})
+	status, code, message = decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	assert.Empty(t, configDescribeRecorders(t, ts))
+	assert.Empty(t, configDescribeRecorderStatus(t, ts))
+	assert.Nil(t, configStoredTags(t, ts, arn), "tags go with the resource")
+
+	// A rebuilt recorder starts from nothing: not recording, and untagged.
+	configPutRecorder(t, ts, "default")
+	statuses := configDescribeRecorderStatus(t, ts)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, false, statuses[0]["recording"],
+		"a rebuilt recorder is not recording, whatever its predecessor was doing")
+	assert.Nil(t, configStoredTags(t, ts, arn))
+}
+
+func TestConfigRecorder_RefusesTagsAWSWouldRefuse(t *testing.T) {
+	// Creation-time tags go through the same validation the tag operations will, so a
+	// tag AWS refuses cannot enter through the Put and be refused at TagResource.
+	cases := []struct {
+		name        string
+		tags        []map[string]string
+		wantMessage string
+	}{
+		{"the reserved prefix", []map[string]string{{"Key": "aws:internal", "Value": "x"}}, "reserved"},
+		{"an empty key", []map[string]string{{"Key": "", "Value": "x"}}, "cannot be empty"},
+		{
+			"a key outside the charset",
+			[]map[string]string{{"Key": "bad!key", "Value": "x"}},
+			"Unicode letters",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := emulator.StartTestServer(t)
+			resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+				"ConfigurationRecorder": configRecorderPayload("default"),
+				"Tags":                  tc.tags,
+			})
+			status, code, message := decodeConfigResponse(t, resp, nil)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "ValidationException", code)
+			assert.Contains(t, message, tc.wantMessage)
+		})
+	}
+
+	t.Run("an empty value is accepted", func(t *testing.T) {
+		// "You can set the value of a tag to an empty string, but you can't set the value
+		// of a tag to null."
+		ts := emulator.StartTestServer(t)
+		resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+			"ConfigurationRecorder": configRecorderPayload("default"),
+			"Tags":                  []map[string]string{{"Key": "env", "Value": ""}},
+		})
+		status, code, message := decodeConfigResponse(t, resp, nil)
+		require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+		assert.Equal(t, map[string]string{"env": ""},
+			configStoredTags(t, ts, "arn:aws:config:us-east-1:123456789012:config-recorder/default"))
+	})
+}
+
+func TestConfigRecorder_RefusesAMissingRecorderMember(t *testing.T) {
+	// ConfigurationRecorder is the one required member, and a request without it is a
+	// ValidationException rather than a recorder named "default" conjured from nothing.
+	ts := emulator.StartTestServer(t)
+
+	resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "ValidationException", code)
+	assert.Contains(t, message, "ConfigurationRecorder is required")
+}
+
+func TestConfigService_AnUnimplementedOperationNamesItself(t *testing.T) {
+	// AWS Config has 97 operations and substrate implements the detective-controls
+	// subset. An unimplemented one must say which, so a consumer discovers the gap from
+	// the response rather than by reading the plugin.
+	ts := emulator.StartTestServer(t)
+
+	resp := configRequest(t, ts, "SelectResourceConfig", map[string]any{})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidAction", code)
+	assert.Contains(t, message, "SelectResourceConfig")
+}

--- a/emulator/configservice_types.go
+++ b/emulator/configservice_types.go
@@ -1,0 +1,386 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// AWS Config state, keys, ARNs and error helpers (#580).
+//
+// Everything here is prefixed cfgsvc/configService rather than config, because
+// emulator/config.go already owns Config, ServerConfig, DefaultConfig and
+// LoadConfig — substrate's own configuration, unrelated to the AWS service. Only
+// the namespace *value* and ConfigServicePlugin.Name() are "config", because those
+// are what the request parser resolves a Config request to.
+
+// configServiceNamespace is the state namespace for AWS Config.
+const configServiceNamespace = "config"
+
+// Recorder status values, the RecorderStatus enum from the config/2014-11-12 API
+// model. A recorder's lastStatus is one of these; substrate reports Pending for a
+// recorder that has never been started and Success once it has, and a seed can pin
+// any of the four.
+const (
+	// cfgsvcRecorderStatusPending is a recorder that has not yet delivered anything.
+	cfgsvcRecorderStatusPending = "Pending"
+
+	// cfgsvcRecorderStatusSuccess is a recorder whose last delivery succeeded.
+	cfgsvcRecorderStatusSuccess = "Success"
+
+	// cfgsvcRecorderStatusFailure is a recorder whose last delivery failed.
+	cfgsvcRecorderStatusFailure = "Failure"
+
+	// cfgsvcRecorderStatusNotApplicable is a recorder for which delivery does not apply.
+	cfgsvcRecorderStatusNotApplicable = "NotApplicable"
+)
+
+// cfgsvcRecorderStatuses is the RecorderStatus enum, used to validate a seeded
+// status. A value outside it would be reported as a string no SDK enum member
+// matches, so a caller's switch would fall through to its default and the test
+// would pass while asserting nothing.
+var cfgsvcRecorderStatuses = []string{
+	cfgsvcRecorderStatusPending,
+	cfgsvcRecorderStatusSuccess,
+	cfgsvcRecorderStatusFailure,
+	cfgsvcRecorderStatusNotApplicable,
+}
+
+// Recording strategies, the RecordingStrategyType enum.
+const (
+	// cfgsvcStrategyAllSupported records every supported resource type.
+	cfgsvcStrategyAllSupported = "ALL_SUPPORTED_RESOURCE_TYPES"
+
+	// cfgsvcStrategyInclusion records only the types in resourceTypes.
+	cfgsvcStrategyInclusion = "INCLUSION_BY_RESOURCE_TYPES"
+
+	// cfgsvcStrategyExclusion records every supported type except those excluded.
+	cfgsvcStrategyExclusion = "EXCLUSION_BY_RESOURCE_TYPES"
+)
+
+// cfgsvcRecordingStrategies is the RecordingStrategyType enum, used to refuse a
+// useOnly value the service would not accept.
+var cfgsvcRecordingStrategies = []string{
+	cfgsvcStrategyAllSupported,
+	cfgsvcStrategyInclusion,
+	cfgsvcStrategyExclusion,
+}
+
+// cfgsvcServiceLinkedNamePrefix is the recorder-name prefix AWS reserves for
+// service-linked configuration recorders. PutConfigurationRecorder refuses a name
+// carrying it with InvalidConfigurationRecorderNameException.
+const cfgsvcServiceLinkedNamePrefix = "AWSConfigurationRecorderFor"
+
+// cfgsvcDefaultName is the name both PutConfigurationRecorder and
+// PutDeliveryChannel use when the request omits one — the API reference states for
+// each that "If you do not specify a name, the default is used".
+const cfgsvcDefaultName = "default"
+
+// cfgsvcMaxNameLen is the RecorderName/ChannelName ceiling (both 1-256).
+const cfgsvcMaxNameLen = 256
+
+// ConfigRecorder is a stored configuration recorder — the ConfigurationRecorder
+// shape, plus the tags a Put set at creation.
+//
+// The JSON tags are the wire names, which are lowerCamelCase for this shape
+// (name, roleARN, recordingGroup) while every other Config shape is UpperCamel.
+// That asymmetry is the API model's, not substrate's.
+type ConfigRecorder struct {
+	// ARN is the recorder's Amazon Resource Name.
+	ARN string `json:"arn,omitempty"`
+
+	// Name is the recorder name, "default" when the request omitted one.
+	Name string `json:"name"`
+
+	// RoleARN is the IAM role Config assumes. Required in practice — see
+	// cfgsvcCheckRoleARN.
+	RoleARN string `json:"roleARN,omitempty"`
+
+	// RecordingGroup is the set of resource types being recorded.
+	RecordingGroup *ConfigRecordingGroup `json:"recordingGroup,omitempty"`
+
+	// RecordingMode is the recording frequency and its per-type overrides.
+	RecordingMode json.RawMessage `json:"recordingMode,omitempty"`
+
+	// RecordingScope is INTERNAL or PAID.
+	RecordingScope string `json:"recordingScope,omitempty"`
+
+	// Tags are the tags set when the recorder was created. A later Put does not
+	// replace them: the API reference states tags "are added at creation and are not
+	// updated with configuration recorder updates".
+	Tags map[string]string `json:"-"`
+}
+
+// ConfigRecordingGroup is the RecordingGroup shape: which resource types a
+// recorder records.
+type ConfigRecordingGroup struct {
+	// AllSupported records every supported type except the global IAM ones.
+	AllSupported bool `json:"allSupported"`
+
+	// IncludeGlobalResourceTypes adds the global IAM types back in.
+	IncludeGlobalResourceTypes bool `json:"includeGlobalResourceTypes"`
+
+	// ResourceTypes is the explicit inclusion list.
+	ResourceTypes []string `json:"resourceTypes,omitempty"`
+
+	// ExclusionByResourceTypes is the exclusion list.
+	ExclusionByResourceTypes *ConfigExclusionByResourceTypes `json:"exclusionByResourceTypes,omitempty"`
+
+	// RecordingStrategy names which of the three strategies is in force.
+	RecordingStrategy *ConfigRecordingStrategy `json:"recordingStrategy,omitempty"`
+}
+
+// ConfigExclusionByResourceTypes is the ExclusionByResourceTypes shape.
+type ConfigExclusionByResourceTypes struct {
+	// ResourceTypes are the types excluded from recording.
+	ResourceTypes []string `json:"resourceTypes,omitempty"`
+}
+
+// ConfigRecordingStrategy is the RecordingStrategy shape.
+type ConfigRecordingStrategy struct {
+	// UseOnly is a RecordingStrategyType enum member.
+	UseOnly string `json:"useOnly,omitempty"`
+}
+
+// ConfigRecorderStatus is the ConfigurationRecorderStatus shape: whether a
+// recorder is recording, and how its last delivery went.
+//
+// It is stored separately from ConfigRecorder because the two answer different
+// questions and only the second is what "is this account covered" turns on. A
+// recorder can exist with Recording false, which is the misconfiguration #580's
+// behavior #1 exists to make testable.
+type ConfigRecorderStatus struct {
+	// ARN is the recorder's ARN, repeated here because the status shape carries it.
+	ARN string `json:"arn,omitempty"`
+
+	// Name is the recorder name.
+	Name string `json:"name"`
+
+	// LastStartTime is when the recorder was last started, zero if never.
+	LastStartTime EpochSeconds `json:"lastStartTime,omitempty"`
+
+	// LastStopTime is when the recorder was last stopped, zero if never.
+	LastStopTime EpochSeconds `json:"lastStopTime,omitempty"`
+
+	// Recording reports whether the recorder is recording. This is the field
+	// DescribeConfigurationRecorders cannot answer.
+	Recording bool `json:"recording"`
+
+	// LastStatus is a RecorderStatus enum member.
+	LastStatus string `json:"lastStatus,omitempty"`
+
+	// LastErrorCode is the code of the last delivery failure, if any.
+	LastErrorCode string `json:"lastErrorCode,omitempty"`
+
+	// LastErrorMessage is the message of the last delivery failure, if any.
+	LastErrorMessage string `json:"lastErrorMessage,omitempty"`
+
+	// LastStatusChangeTime is when LastStatus last changed.
+	LastStatusChangeTime EpochSeconds `json:"lastStatusChangeTime,omitempty"`
+}
+
+// --- state keys ---
+//
+// Every key is scoped by account *and* Region, because Config is regional and
+// "recording in one Region only" is a common real misconfiguration (#580 behavior
+// #7). A key that dropped the Region would make a recorder created in us-east-1
+// visible in eu-west-1, which is the opposite of the thing under test.
+
+// cfgsvcRecorderKey holds the single configuration recorder for an account and
+// Region. AWS permits one per account per Region, so this is keyed by neither a
+// name nor an ID: a second recorder under a different name is refused rather than
+// stored.
+func cfgsvcRecorderKey(accountID, region string) string {
+	return "recorder:" + accountID + "/" + region
+}
+
+// cfgsvcRecorderStatusKey holds that recorder's status.
+func cfgsvcRecorderStatusKey(accountID, region string) string {
+	return "recorder_status:" + accountID + "/" + region
+}
+
+// cfgsvcChannelKey holds the single delivery channel for an account and Region,
+// keyed for the same reason cfgsvcRecorderKey is.
+func cfgsvcChannelKey(accountID, region string) string {
+	return "channel:" + accountID + "/" + region
+}
+
+// cfgsvcTagsKey holds the tags on a Config resource, keyed by its ARN. Tags are
+// keyed by ARN rather than by name so one map serves recorders, rules and packs,
+// which is also the shape TagResource's own input has.
+func cfgsvcTagsKey(arn string) string { return "tags:" + arn }
+
+// --- ARNs ---
+//
+// The ARN formats come from the Service Authorization Reference's "Resource types
+// defined by AWS Config" table, not from the API reference, which gives none:
+//
+//	arn:${Partition}:config:${Region}:${Account}:config-recorder/${Name}
+//	arn:${Partition}:config:${Region}:${Account}:delivery-channel/${Name}
+//	arn:${Partition}:config:${Region}:${Account}:config-rule/${ConfigRuleId}
+//	arn:${Partition}:config:${Region}:${Account}:conformance-pack/${Name}/${Id}
+//
+// The recorder form is "config-recorder", not "recorder". Substrate's own
+// CloudFormation stub emitted the latter (#580); it is corrected where that stub
+// becomes a real dispatch.
+
+// cfgsvcARN builds a Config ARN for a resource type and identifier.
+func cfgsvcARN(ctx *RequestContext, resourceType, id string) string {
+	return fmt.Sprintf("arn:aws:config:%s:%s:%s/%s", ctx.Region, ctx.AccountID, resourceType, id)
+}
+
+// cfgsvcRecorderARN builds the ARN of a configuration recorder.
+func cfgsvcRecorderARN(ctx *RequestContext, name string) string {
+	return cfgsvcARN(ctx, "config-recorder", name)
+}
+
+// A delivery-channel ARN is deliberately absent here: the DeliveryChannel shape
+// carries no arn member, so nothing in this cluster has one to emit. The
+// delivery-channel form above is recorded because the tag operations address a
+// channel by ARN, and it arrives with them.
+
+// --- errors ---
+//
+// Every AWS Config exception is HTTP 400. Each exception shape in the API model
+// carries "exception": true with no "error" member giving a status, and every
+// exception's reference page states "HTTP Status Code: 400" — including the
+// not-found ones such as NoSuchConfigurationRecorderException. The SDKs match on
+// the error code rather than the status, so a 404 here would be a shape a caller
+// cannot reproduce against AWS. Organizations is in the same position, and orgErr
+// hard-codes 400 for the same reason.
+
+// cfgsvcErr returns an AWS Config error with the given code at HTTP 400.
+func cfgsvcErr(code, message string) *AWSError {
+	return &AWSError{Code: code, Message: message, HTTPStatus: http.StatusBadRequest}
+}
+
+// cfgsvcValidation returns ValidationException, which the model documents for
+// "missing required fields or if the input value fails the validation".
+func cfgsvcValidation(message string) *AWSError {
+	return cfgsvcErr("ValidationException", message)
+}
+
+// cfgsvcInvalidAction reports an operation the plugin does not implement.
+//
+// AWS Config has 97 operations and substrate implements the detective-controls
+// subset, so this is the answer for the rest. It names the operation so a consumer
+// discovers which call is missing rather than a bare refusal.
+func cfgsvcInvalidAction(op string) *AWSError {
+	return cfgsvcErr("InvalidAction", "ConfigServicePlugin: unsupported operation "+op)
+}
+
+// cfgsvcUnmarshal decodes a request body, answering ValidationException rather
+// than a generic malformed-data code: ValidationException is the input exception
+// every Config operation declares, so it is the branch a caller's error handling
+// is written against.
+func cfgsvcUnmarshal(body []byte, out interface{}) error {
+	if len(body) == 0 {
+		body = []byte("{}")
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return cfgsvcValidation("could not parse request body: " + err.Error())
+	}
+	return nil
+}
+
+// --- generic state helpers ---
+
+// cfgsvcGetJSON loads and decodes the value at key, reporting found=false when the
+// key is absent so a caller can tell "no such entity" from a read error.
+func (p *ConfigServicePlugin) cfgsvcGetJSON(ctx context.Context, key string, out interface{}) (bool, error) {
+	data, err := p.state.Get(ctx, configServiceNamespace, key)
+	if err != nil {
+		return false, fmt.Errorf("config get %s: %w", key, err)
+	}
+	if data == nil {
+		return false, nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return false, fmt.Errorf("config unmarshal %s: %w", key, err)
+	}
+	return true, nil
+}
+
+// cfgsvcPutJSON encodes and stores v at key.
+func (p *ConfigServicePlugin) cfgsvcPutJSON(ctx context.Context, key string, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("config marshal %s: %w", key, err)
+	}
+	if err := p.state.Put(ctx, configServiceNamespace, key, data); err != nil {
+		return fmt.Errorf("config put %s: %w", key, err)
+	}
+	return nil
+}
+
+// cfgsvcDeleteKey removes a state key outright, so a deleted resource leaves no
+// shadow in a state dump.
+func (p *ConfigServicePlugin) cfgsvcDeleteKey(ctx context.Context, key string) error {
+	if err := p.state.Delete(ctx, configServiceNamespace, key); err != nil {
+		return fmt.Errorf("config delete %s: %w", key, err)
+	}
+	return nil
+}
+
+// cfgsvcSaveTags stores the tags on a resource ARN, deleting the key when the map
+// is empty rather than storing "{}".
+func (p *ConfigServicePlugin) cfgsvcSaveTags(ctx context.Context, arn string, tags map[string]string) error {
+	if len(tags) == 0 {
+		return p.cfgsvcDeleteKey(ctx, cfgsvcTagsKey(arn))
+	}
+	return p.cfgsvcPutJSON(ctx, cfgsvcTagsKey(arn), tags)
+}
+
+// --- tag validation ---
+//
+// The restrictions come from the developer guide's "Tagging AWS Config resources"
+// page rather than from the API model, which bounds only the key and value lengths.
+// The tag trio (TagResource/UntagResource/ListTagsForResource) validates through the
+// same helpers a Put's creation-time TagsList does, so a tag AWS would refuse cannot
+// enter through one door and be refused at the other.
+
+// cfgsvcMaxTags is the number of tags AWS Config permits per resource, from both the
+// service-limits page ("Maximum number of tags per resource: 50") and TagsList's own
+// bound.
+const cfgsvcMaxTags = 50
+
+// cfgsvcReservedTagPrefix is the prefix AWS reserves for its own tags. The guide
+// states "you can't edit or delete a tag with this prefix" and that such tags "do not
+// count against your tags per resource limit" — so a caller-supplied one is refused
+// rather than stored and counted.
+const cfgsvcReservedTagPrefix = "aws:"
+
+// cfgsvcTagCharset is the character set a tag key or value may use: "Unicode letters,
+// digits, whitespace, or these symbols: _ . : / = + - @".
+//
+// Unicode letters and digits are matched by class rather than enumerated, so a tag in
+// a non-Latin script is accepted as AWS accepts it.
+var cfgsvcTagCharset = regexp.MustCompile(`^[\p{L}\p{N}\p{Z}_.:/=+\-@]*$`)
+
+// cfgsvcCheckTag validates one tag key and value.
+//
+// An empty value is permitted — "you can set the value of a tag to an empty string,
+// but you can't set the value of a tag to null" — and an empty *key* is not, because a
+// key is what identifies the tag.
+func cfgsvcCheckTag(key, value string) error {
+	if key == "" {
+		return cfgsvcValidation("A tag key cannot be empty.")
+	}
+	if len([]rune(key)) > 128 {
+		return cfgsvcValidation("A tag key may be up to 128 Unicode characters long.")
+	}
+	if len([]rune(value)) > 256 {
+		return cfgsvcValidation("A tag value may be up to 256 Unicode characters long.")
+	}
+	if strings.HasPrefix(strings.ToLower(key), cfgsvcReservedTagPrefix) {
+		return cfgsvcValidation(`The "aws:" prefix is reserved for AWS use and cannot be used in a tag key.`)
+	}
+	if !cfgsvcTagCharset.MatchString(key) || !cfgsvcTagCharset.MatchString(value) {
+		return cfgsvcValidation("A tag key or value may contain Unicode letters, digits, whitespace, " +
+			"or these symbols: _ . : / = + - @")
+	}
+	return nil
+}

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -313,6 +313,19 @@ var targetServiceAliases = map[string]string{
 	// aws-sdk-go-v2 and boto3 call fell through to
 	// "service not emulated: awsorganizationsv20161128".
 	"awsorganizationsv20161128": "organizations",
+	// "StarlingDoveService" → no "Amazon" to strip, no "_" version suffix →
+	// lowercase → "starlingdoveservice" → "config". StarlingDove is the internal
+	// code-name for AWS Config, the way TrentService is for KMS, so the target
+	// prefix bears no resemblance to the endpoint prefix and reduces to nothing on
+	// its own. The host "config.*" and the SigV4 signing name already yield
+	// "config", so only the target path needed this — and the target path is the
+	// one every aws-sdk-go-v2 and boto3 Config call takes.
+	//
+	// Without the alias ConfigServicePlugin would be registered and unit-tested
+	// green while unreachable from any SDK, exactly as SSOPlugin was in #561 and
+	// OrganizationsPlugin above: every call would fall through to "service not
+	// emulated: starlingdoveservice" (#580).
+	"starlingdoveservice": "config",
 }
 
 // extractServiceFromTarget parses an X-Amz-Target value such as

--- a/emulator/parser_test.go
+++ b/emulator/parser_test.go
@@ -860,6 +860,63 @@ func TestParseAWSRequest_OrganizationsTargetPrefix(t *testing.T) {
 	}
 }
 
+// TestParseAWSRequest_ConfigResolvesByEveryPath pins all three ways a Config
+// request identifies itself, because each is taken by a different caller and only
+// one of them needed an alias.
+//
+// "StarlingDoveService" is Config's target prefix — an internal code-name, like
+// TrentService for KMS — so it bears no resemblance to the endpoint prefix and
+// reduces to nothing on its own. The host and the SigV4 signing name already yield
+// "config" without help. Asserting all three together is what makes a future
+// refactor of any one path a failing test rather than a plugin that is registered,
+// green, and unreachable — the #561/#580 failure.
+func TestParseAWSRequest_ConfigResolvesByEveryPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("target prefix", func(t *testing.T) {
+		t.Parallel()
+		for _, target := range []string{
+			"StarlingDoveService.PutConfigurationRecorder",
+			"StarlingDoveService.DescribeConfigurationRecorderStatus",
+			"StarlingDoveService.PutDeliveryChannel",
+		} {
+			t.Run(target, func(t *testing.T) {
+				t.Parallel()
+				r := httptest.NewRequest(http.MethodPost, "http://localhost:4566/", nil)
+				r.Host = "localhost:4566"
+				r.Header.Set("X-Amz-Target", target)
+
+				req, _, err := emulator.ParseAWSRequest(r)
+				require.NoError(t, err)
+				assert.Equal(t, "config", req.Service)
+			})
+		}
+	})
+
+	t.Run("host", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequest(http.MethodPost, "http://config.us-east-1.amazonaws.com/", nil)
+		r.Host = "config.us-east-1.amazonaws.com"
+
+		req, _, err := emulator.ParseAWSRequest(r)
+		require.NoError(t, err)
+		assert.Equal(t, "config", req.Service)
+	})
+
+	t.Run("sigv4 signing name", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequest(http.MethodPost, "http://localhost:4566/", nil)
+		r.Host = "localhost:4566"
+		r.Header.Set("Authorization",
+			"AWS4-HMAC-SHA256 Credential=AKIATEST12345678901/20260101/us-east-1/config/aws4_request, "+
+				"SignedHeaders=host, Signature=fake")
+
+		req, _, err := emulator.ParseAWSRequest(r)
+		require.NoError(t, err)
+		assert.Equal(t, "config", req.Service)
+	})
+}
+
 func TestNormalizeS3VirtualHost(t *testing.T) {
 	tests := []struct {
 		host       string

--- a/emulator/plugins.go
+++ b/emulator/plugins.go
@@ -283,6 +283,16 @@ func RegisterDefaultPlugins(
 	}
 	registry.Register(accountPlugin)
 
+	configServicePlugin := &ConfigServicePlugin{}
+	if err := configServicePlugin.Initialize(ctx, PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}); err != nil {
+		return fmt.Errorf("initialize config plugin: %w", err)
+	}
+	registry.Register(configServicePlugin)
+
 	schedulerPlugin := &SchedulerPlugin{}
 	if err := schedulerPlugin.Initialize(ctx, PluginConfig{
 		State:   state,

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -340,6 +340,14 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/account/region-opt-status", s.handleAccountSeedRegionOptStatus)
 	r.Delete("/v1/account/region-opt-status", s.handleAccountClearRegionOptStatus)
 
+	// AWS Config control-plane endpoints (#580).
+	r.Post("/v1/config/recorder-status", s.handleConfigSeedRecorderStatus)
+	r.Delete("/v1/config/recorder-status", s.handleConfigClearRecorderStatus)
+	r.Post("/v1/config/delivery-status", s.handleConfigSeedDeliveryStatus)
+	r.Delete("/v1/config/delivery-status", s.handleConfigClearDeliveryStatus)
+	r.Post("/v1/config/delivery-policy", s.handleConfigSeedDeliveryPolicy)
+	r.Delete("/v1/config/delivery-policy", s.handleConfigClearDeliveryPolicy)
+
 	// Lambda control-plane endpoints (#393).
 	r.Post("/v1/lambda/invoke-error", s.handleLambdaSeedInvokeError)
 	r.Delete("/v1/lambda/invoke-error", s.handleLambdaClearInvokeError)


### PR DESCRIPTION
First of seven PRs for #580 (AWS Config, milestone v0.101.0 "detective controls"). This one is the plan's Lane 0 + Lane 1 + Lane 2.

## Why the channel ships with the recorder

The plan had these as PRs 1 and 2. `StartConfigurationRecorder` refuses without a delivery channel, so a recorder-only PR could never reach `recording: true` — the release's headline behaviour — leaving it untestable. They land together.

## What this does

**Two operations that look like they answer the same question now disagree.** `DescribeConfigurationRecorders` reporting a recorder says nothing about whether it is recording; that is `DescribeConfigurationRecorderStatus.recording`. A recorder created and never started is the most common real Config misconfiguration, and a consumer checking only the first call reports an account as covered when nothing is recorded. A `Put` leaves `recording: false`; only `Start` flips it.

**The ordering refusals** make a sequencing bug observable: `NoAvailableDeliveryChannelException` on `Start` without a channel, `NoAvailableConfigurationRecorderException` on `PutDeliveryChannel` without a recorder (checked **before** the bucket, per the operation's own ordering), and `LastDeliveryChannelDeleteFailedException` on a delete while recording — which is what makes a teardown-and-rebuild fixture express an ordering requirement rather than pass on a sequence AWS rejects.

**`PutDeliveryChannel` computes its S3 refusals from real S3 state**, permissively. Missing bucket → `NoSuchBucketException`; bucket with no policy at all → `InsufficientDeliveryPolicyException`; a policy passes if any `Allow` statement's principal covers `config.amazonaws.com` or `*` and its action covers `s3:PutObject` (including `s3:Put*`, `s3:*`, `*`); the resource ARN is not matched, and a shape substrate's parser cannot decode passes. The two failure directions are not symmetric: always accepting hides a bucket-policy bug that is fatal at AWS, while demanding the documented policy verbatim refuses policies AWS accepts — and a wrong refusal breaks working code.

**Three seed families** (`/v1/config/recorder-status`, `/v1/config/delivery-status`, `/v1/config/delivery-policy`) cover what no API call can reach: substrate delivers nothing to S3, so no sequence of calls produces a failed delivery, and a consumer's delivery-failure branch exists precisely for one. Applied at read time, scoped by account and Region with `*` wildcards, and validated against the model's enum — `NotApplicable` is refused in favour of the `Not_Applicable` AWS actually spells, and an error code on a non-`Failure` status is refused rather than half-applied.

## The routing alias is the hard prerequisite

Config's `X-Amz-Target` prefix is `StarlingDoveService` — an internal code name, as `TrentService` is KMS's — and `starlingdoveservice` was absent from `targetServiceAliases`, so it reduced to nothing and every SDK call fell through to `service not emulated: starlingdoveservice`. Without the alias this plugin would be registered and unit-tested green while unreachable, exactly what #561, #610 and #636 were. A unit test asserts resolution by target prefix, host **and** SigV4 signing name.

## Two defects the live CLI caught, which unit tests did not

Both were fixed against the botocore model, not recall:

1. `configStreamDeliveryInfo` is `ConfigStreamDeliveryInfo`, which carries `lastStatusChangeTime` and **neither** of the export shape's `lastSuccessfulTime`/`lastAttemptTime`. I had emitted three clones of one shape, putting members in the response an SDK decoding the stream shape cannot read. It also reports `Not_Applicable` when no SNS topic is configured, per the shape's own note — reporting `Success` would tell a consumer its alerting works when no topic exists.
2. The default recording group expressed "not the global IAM types" by synthesizing an `exclusionByResourceTypes` list of the four types. AWS returns no such list for an `allSupported` group, and an exclusion list alongside `ALL_SUPPORTED_RESOURCE_TYPES` is the combination `InvalidRecordingGroupException` refuses — substrate would have answered with a group it rejects on input. It is now `includeGlobalResourceTypes: false`, the bundle AWS uses.

## Verification

- `gofmt -l`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → **0 issues**
- `make test` (race) green; coverage **82.6%**
- `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build` green
- **Live AWS CLI** against `substrate server --address :4678` with `AWS_MAX_ATTEMPTS=1`: reachability, the full bucket-policy progression, `recording: false` → `true`, regional isolation, `InvalidRoleException`, the reserved name prefix, `InvalidRecordingGroupException`, both status seeds, and the whole teardown ordering sequence. This tier is what catches an unroutable operation.
- **Mutation testing, 10 mutants, no survivors**: alias removed (40 failures), `Recording: true` on Put (8), the `Start` channel guard dropped, the channel-delete guard dropped, the policy matcher forced permissive and forced strict, tags overwritten on a second Put, the Region dropped from a state key, the stream shape replaced with the export shape, and `Not_Applicable` collapsed to `Success`.

Not `Closes #580` — that goes on PR 7, once the rules, packs, tagging, CFN stubs and e2e journey have landed.