### PR TITLE
feat(config): conformance packs with advance-on-observation status (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   evaluations *and* its compliance seed, so a rebuilt rule of the same name starts at
   `INSUFFICIENT_DATA` rather than inheriting its predecessor's verdict — which is what makes
   a teardown-and-rebuild fixture honest.
+- **A conformance pack's deployment converges in one poll: the conformance-pack cluster**
+  (#580). `PutConformancePack`, `DescribeConformancePacks`, `DescribeConformancePackStatus`,
+  `DescribeConformancePackCompliance`, `GetConformancePackComplianceSummary` and
+  `DeleteConformancePack`.
+
+  A pack is the only Config resource whose creation is **asynchronous**: `Put` returns an ARN
+  and nothing else, and a consumer learns whether its pack deployed by polling
+  `DescribeConformancePackStatus`. Substrate resolves `CREATE_IN_PROGRESS → CREATE_COMPLETE`
+  **on the first observation and then persists it**, following `resolveCreateAccountStatus`
+  from the Organizations plugin. Both halves matter and in opposite directions: a status that
+  never advanced would hang a waiter forever, while one that re-resolved on every poll would
+  move `LastUpdateCompletedTime` under a waiter comparing successive polls, which would also
+  never converge. Advancing on observation instead of on a duration is what keeps the
+  transition free of wall-clock dependence — #514 remains the home for clock-driven
+  transitions, and inventing a duration here would have pre-empted it.
+
+  The in-progress window is therefore real but narrow, which is what makes
+  `ResourceInUseException` reachable: a second `Put`, or a `Delete`, issued before anything
+  observed the first transition is refused with that operation's own bullet from the
+  exception's shared documentation list. Because the enum has **no `UPDATE_` state**, an
+  update re-enters `CREATE_IN_PROGRESS`, so a consumer that updates and immediately waits
+  does not get its predecessor's `CREATE_COMPLETE` back.
+
+  `PutConformancePack` enforces "you must specify only one of the follow parameters:
+  `TemplateS3Uri`, `TemplateBody` or `TemplateSSMDocumentDetails`" — AWS's own sentence, its
+  typo included, so a consumer matching on message text matches. Substrate does not deploy the
+  template and never judges its content: a template is recorded intent, and neither response
+  shape has a member to read it back, so emitting one would be an invention no SDK field would
+  receive. `ConformancePackId` and the required `StackArn` are minted deterministically from
+  the account, Region and name, so a replayed event stream produces the same identifiers and an
+  update keeps them. All six required members of `ConformancePackStatusDetail` are always
+  emitted, because a consumer decoding a required member into a non-pointer field reads an
+  omission as an empty string rather than as an error.
+
+  Pack compliance is **seeded, never computed**, like a rule's, and an unseeded pack reports no
+  rules and summarizes as `INSUFFICIENT_DATA`. The cumulative verdict
+  `GetConformancePackComplianceSummary` reports is *derived* from the same per-rule seeds
+  rather than seeded separately, so the summary and the drill-down cannot disagree, and a known
+  `NON_COMPLIANT` outranks an unevaluated rule — a pack with something wrong in it is not "we
+  don't know yet", and reporting the unknown would let a consumer treating it as "wait and
+  retry" loop past a real failure.
+
+  Two model asymmetries are honoured rather than smoothed over, because collapsing either
+  would answer where AWS refuses or refuse where AWS answers.
+  `ConformancePackComplianceType` has **no `NOT_APPLICABLE`** even though a rule's verdict
+  does, so the seed endpoint refuses that value. And the compliance *filter* — "the allowed
+  values are `COMPLIANT` and `NON_COMPLIANT`; `INSUFFICIENT_DATA` is not supported" — excludes
+  a value the response itself carries, so filtering on it is an error rather than an empty
+  list. A filter naming a rule the pack does not report is
+  `NoSuchConfigRuleInConformancePackException`, per "you must provide exact rule names", so a
+  typo in a fixture is caught instead of passing as "nothing matched". These four operations
+  answer `InvalidLimitException` for an out-of-range `Limit` where the rule cluster answers
+  `InvalidParameterValueException` — each cluster uses the codes its own operations declare —
+  and the caps differ per operation (20 for the two describes and the summary, 1000 for
+  compliance), each enforced at the model's own maximum so substrate never refuses a page size
+  AWS serves.
 - **Control-plane seeds for the statuses no API call can reach** (#580):
   `POST`/`DELETE /v1/config/recorder-status`, `/v1/config/delivery-status` and
   `/v1/config/delivery-policy`. Substrate delivers nothing to S3, so no sequence of calls
@@ -115,6 +171,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   status reports `Not_Applicable` until the recorder first starts and `Success` after, per
   stream, because reporting `Success` before anything was delivered would tell a consumer
   its pipeline works when nothing has gone through it.
+
+  `POST`/`DELETE /v1/config/pack-status/{name}` and `/v1/config/pack-compliance/{name}` do the
+  same for a conformance pack, scoped by account, Region and pack name with a `*` wildcard on
+  each. A pack substrate created always completes — it deploys no stack — so `CREATE_FAILED`,
+  the state that reports a bad template to its author, and `DELETE_IN_PROGRESS`, which
+  substrate's synchronous delete never occupies, are reachable only by seed. Because a status
+  seed is applied when the status is read rather than written into the record, clearing it
+  restores the real state, and a pack seeded `CREATE_FAILED` is *deletable* — the state a
+  consumer most needs to clean up — even though the stored record still says
+  `CREATE_IN_PROGRESS`. A seeded status reports its completion time as the request time rather
+  than the current clock, so successive polls cannot move it. Deleting a pack clears that
+  pack's own seeds but leaves a `*` seed alone, since a wildcard is a fixture-wide default
+  rather than one pack's state.
 
 ### Fixed
 - **Every AWS Config request was unroutable** (#580). Config's `X-Amz-Target` prefix is

--- a/emulator/configservice_control.go
+++ b/emulator/configservice_control.go
@@ -548,6 +548,307 @@ func (s *Server) handleConfigClearRuleCompliance(w http.ResponseWriter, r *http.
 	})
 }
 
+// --- conformance-pack seeds ---
+
+// cfgsvcCtrlPackStatusKey returns the state key for a seeded conformance-pack
+// deployment state, keyed by pack name within an account and Region. The pack name
+// takes the "*" wildcard, so a fixture can fail every pack at once.
+func cfgsvcCtrlPackStatusKey(accountID, region, pack string) string {
+	if pack == "" {
+		pack = "*"
+	}
+	return "pack_status:" + cfgsvcCtrlScope(accountID, region) + "/" + pack
+}
+
+// cfgsvcCtrlPackComplianceKey returns the state key for a seeded pack verdict,
+// keyed the same way.
+func cfgsvcCtrlPackComplianceKey(accountID, region, pack string) string {
+	if pack == "" {
+		pack = "*"
+	}
+	return "pack_compliance:" + cfgsvcCtrlScope(accountID, region) + "/" + pack
+}
+
+// cfgsvcSeededPackStatus pins a conformance pack's deployment state.
+//
+// Substrate deploys no CloudFormation stack, so a pack it created always reaches
+// CREATE_COMPLETE and can never fail on its own. A consumer whose waiter has a
+// CREATE_FAILED branch — the branch that reports a bad template to whoever wrote it —
+// needs this to reach that branch at all.
+type cfgsvcSeededPackStatus struct {
+	// AccountID the seed applies to, or "*" for any account.
+	AccountID string `json:"accountId"`
+
+	// Region the seed applies to, or "*" for any Region.
+	Region string `json:"region"`
+
+	// ConformancePackName the seed applies to, or "*" for any pack.
+	ConformancePackName string `json:"conformancePackName"`
+
+	// State is the ConformancePackState every observation reports.
+	State string `json:"state"`
+
+	// StatusReason explains a CREATE_FAILED or DELETE_FAILED state.
+	StatusReason string `json:"statusReason,omitempty"`
+}
+
+// cfgsvcSeededPackCompliance pins the per-rule verdicts within a conformance pack.
+//
+// The rules are named here rather than read from the pack's template because
+// substrate does not deploy the template: on AWS, CloudFormation creates a pack's
+// rules as service-linked rules, and inferring them would mean parsing arbitrary
+// CloudFormation to produce a listing a consumer would then assert against. See
+// configservice_packs.go's header comment.
+type cfgsvcSeededPackCompliance struct {
+	// AccountID the seed applies to, or "*" for any account.
+	AccountID string `json:"accountId"`
+
+	// Region the seed applies to, or "*" for any Region.
+	Region string `json:"region"`
+
+	// ConformancePackName the seed applies to, or "*" for any pack.
+	ConformancePackName string `json:"conformancePackName"`
+
+	// Rules are the pack's rules and their verdicts, and may be empty — a pack with no
+	// seeded rules reports INSUFFICIENT_DATA, the "has not evaluated" default.
+	Rules []cfgsvcSeededPackRule `json:"rules"`
+}
+
+// cfgsvcSeededPackRule is one rule's verdict within a seeded pack.
+type cfgsvcSeededPackRule struct {
+	// ConfigRuleName is the rule the verdict belongs to.
+	ConfigRuleName string `json:"configRuleName"`
+
+	// ComplianceType is a ConformancePackComplianceType member — which, unlike the
+	// rule-level ComplianceType, has no NOT_APPLICABLE.
+	ComplianceType string `json:"complianceType"`
+
+	// Controls are the controls the rule addresses, up to 20 of them. The shape
+	// documents a control as "a process to prevent or detect problems while meeting
+	// objectives"; substrate carries whatever the seed names and derives nothing from it.
+	Controls []string `json:"controls,omitempty"`
+}
+
+// seededPackStatus returns the pinned deployment state for a pack, trying the pack's
+// own name before the "*" wildcard and, within each, the account/Region candidates
+// most specific first — the resolution order seededRuleCompliance uses, and for the
+// same reason: a fixture that fails one pack and completes the rest means the named
+// seed to win.
+func (p *ConfigServicePlugin) seededPackStatus(ctx context.Context, accountID, region, pack string) (
+	seed cfgsvcSeededPackStatus, found bool, err error) {
+	for _, name := range []string{pack, "*"} {
+		build := func(a, r string) string { return cfgsvcCtrlPackStatusKey(a, r, name) }
+		for _, key := range cfgsvcCtrlKeyCandidates(build, accountID, region) {
+			data, getErr := p.state.Get(ctx, configServiceCtrlNamespace, key)
+			if getErr != nil {
+				return seed, false, fmt.Errorf("config seededPackStatus %s: %w", key, getErr)
+			}
+			if data == nil {
+				continue
+			}
+			if err := json.Unmarshal(data, &seed); err != nil {
+				return seed, false, fmt.Errorf("config seededPackStatus %s unmarshal: %w", key, err)
+			}
+			if seed.State != "" {
+				return seed, true, nil
+			}
+		}
+		if pack == "*" {
+			break
+		}
+	}
+	return cfgsvcSeededPackStatus{}, false, nil
+}
+
+// seededPackCompliance returns the pinned verdicts for a pack, resolved the same way.
+//
+// A seed naming an empty rule list counts as found: "this pack has no rules" is a
+// distinct assertion from "this pack has not been seeded", and both report
+// INSUFFICIENT_DATA in the summary but only the first is deliberate.
+func (p *ConfigServicePlugin) seededPackCompliance(ctx context.Context, accountID, region, pack string) (
+	seed cfgsvcSeededPackCompliance, found bool, err error) {
+	for _, name := range []string{pack, "*"} {
+		build := func(a, r string) string { return cfgsvcCtrlPackComplianceKey(a, r, name) }
+		for _, key := range cfgsvcCtrlKeyCandidates(build, accountID, region) {
+			data, getErr := p.state.Get(ctx, configServiceCtrlNamespace, key)
+			if getErr != nil {
+				return seed, false, fmt.Errorf("config seededPackCompliance %s: %w", key, getErr)
+			}
+			if data == nil {
+				continue
+			}
+			if err := json.Unmarshal(data, &seed); err != nil {
+				return seed, false, fmt.Errorf("config seededPackCompliance %s unmarshal: %w", key, err)
+			}
+			return seed, true, nil
+		}
+		if pack == "*" {
+			break
+		}
+	}
+	return cfgsvcSeededPackCompliance{}, false, nil
+}
+
+// cfgsvcClearPackSeeds removes every status and compliance seed naming one pack,
+// which DeleteConformancePack does so a rebuilt pack of the same name does not
+// inherit its predecessor's state or verdict.
+//
+// The "*" seeds are deliberately left alone, for the reason cfgsvcClearRuleCompliance
+// leaves them: a wildcard is a fixture-wide default rather than this pack's state,
+// and deleting one pack should not silently change what every other pack reports.
+func (p *ConfigServicePlugin) cfgsvcClearPackSeeds(ctx context.Context, reqCtx *RequestContext,
+	pack string) error {
+	builders := []func(string, string) string{
+		func(a, r string) string { return cfgsvcCtrlPackStatusKey(a, r, pack) },
+		func(a, r string) string { return cfgsvcCtrlPackComplianceKey(a, r, pack) },
+	}
+	for _, build := range builders {
+		for _, key := range cfgsvcCtrlKeyCandidates(build, reqCtx.AccountID, reqCtx.Region) {
+			if err := p.state.Delete(ctx, configServiceCtrlNamespace, key); err != nil {
+				return fmt.Errorf("config clear pack seed %s: %w", key, err)
+			}
+		}
+	}
+	return nil
+}
+
+// handleConfigSeedPackStatus handles POST /v1/config/pack-status/{name}. It pins the
+// ConformancePackState every DescribeConformancePackStatus reports, which is the only
+// way to reach CREATE_FAILED or DELETE_FAILED: substrate deploys no stack, so a pack
+// it created always completes.
+// Body: {"state":"CREATE_FAILED","statusReason":"template validation failed"}.
+// A {name} of "*" seeds every pack.
+func (s *Server) handleConfigSeedPackStatus(w http.ResponseWriter, r *http.Request) {
+	var seed cfgsvcSeededPackStatus
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		writeJSONErrorDebug(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
+	if name := chi.URLParam(r, "name"); name != "" {
+		if seed.ConformancePackName != "" && seed.ConformancePackName != name {
+			writeJSONErrorDebug(w, http.StatusBadRequest,
+				"conformancePackName %q in the body contradicts %q in the path",
+				seed.ConformancePackName, name)
+			return
+		}
+		seed.ConformancePackName = name
+	}
+	if seed.State == "" {
+		writeJSONErrorDebug(w, http.StatusBadRequest, "state is required")
+		return
+	}
+	if !slices.Contains(cfgsvcPackStates, seed.State) {
+		writeJSONErrorDebug(w, http.StatusBadRequest, "state %q is not a ConformancePackState (the "+
+			"enum has no UPDATE_ state and no DELETE_COMPLETE)", seed.State)
+		return
+	}
+	// A status reason on a state that is not one of the two failures would be silently
+	// dropped by every consumer that reads it only on failure, so the seed is refused
+	// rather than half-applied — the same rule the recorder-status seed follows for its
+	// error code and message.
+	if seed.StatusReason != "" && !slices.Contains(cfgsvcPackFailedStates, seed.State) {
+		writeJSONErrorDebug(w, http.StatusBadRequest,
+			"statusReason applies only to state CREATE_FAILED or DELETE_FAILED")
+		return
+	}
+	s.configSeedPut(w, r, cfgsvcCtrlPackStatusKey(seed.AccountID, seed.Region, seed.ConformancePackName),
+		seed, map[string]any{"state": seed.State})
+}
+
+// handleConfigClearPackStatus handles DELETE /v1/config/pack-status/{name}. A {name}
+// of "*" clears the every-pack seed; omitting the segment clears all of them,
+// returning every pack to advance-on-observation.
+func (s *Server) handleConfigClearPackStatus(w http.ResponseWriter, r *http.Request) {
+	s.configSeedClear(w, r, "pack_status:", func() (string, bool) {
+		name := chi.URLParam(r, "name")
+		if name == "" {
+			return "", false
+		}
+		return cfgsvcCtrlPackStatusKey(r.URL.Query().Get("accountId"), r.URL.Query().Get("region"),
+			name), true
+	})
+}
+
+// handleConfigSeedPackCompliance handles POST /v1/config/pack-compliance/{name}. It
+// pins the per-rule verdicts a conformance pack reports, which is the only way one
+// reports anything: substrate evaluates no rules and does not deploy the template
+// that would declare them.
+// Body: {"rules":[{"configRuleName":"iam-password-policy","complianceType":"NON_COMPLIANT",
+// "controls":["CIS 1.5"]}]}. A {name} of "*" seeds every pack.
+func (s *Server) handleConfigSeedPackCompliance(w http.ResponseWriter, r *http.Request) {
+	var seed cfgsvcSeededPackCompliance
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		writeJSONErrorDebug(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
+	if name := chi.URLParam(r, "name"); name != "" {
+		if seed.ConformancePackName != "" && seed.ConformancePackName != name {
+			writeJSONErrorDebug(w, http.StatusBadRequest,
+				"conformancePackName %q in the body contradicts %q in the path",
+				seed.ConformancePackName, name)
+			return
+		}
+		seed.ConformancePackName = name
+	}
+	seen := make(map[string]bool, len(seed.Rules))
+	for _, rule := range seed.Rules {
+		if rule.ConfigRuleName == "" || len(rule.ConfigRuleName) > cfgsvcMaxRuleNameLen {
+			writeJSONErrorDebug(w, http.StatusBadRequest,
+				"each rule requires a configRuleName of up to %d characters", cfgsvcMaxRuleNameLen)
+			return
+		}
+		// Two verdicts for one rule name would make the reported one depend on map
+		// iteration order, which is exactly the nondeterminism this emulator exists to
+		// remove.
+		if seen[rule.ConfigRuleName] {
+			writeJSONErrorDebug(w, http.StatusBadRequest,
+				"configRuleName %q appears twice; a rule has one verdict", rule.ConfigRuleName)
+			return
+		}
+		seen[rule.ConfigRuleName] = true
+		// NOT_APPLICABLE is in the rule-level ComplianceType enum but not in
+		// ConformancePackComplianceType, so storing one would make this cluster report a
+		// value no SDK enum member matches and a caller's switch would fall through to its
+		// default while the test passed asserting nothing.
+		if !slices.Contains(cfgsvcPackComplianceTypes, rule.ComplianceType) {
+			writeJSONErrorDebug(w, http.StatusBadRequest, "complianceType %q is not a "+
+				"ConformancePackComplianceType; the allowed values are COMPLIANT, NON_COMPLIANT "+
+				"and INSUFFICIENT_DATA (unlike a Config rule's verdict, a pack's has no "+
+				"NOT_APPLICABLE)", rule.ComplianceType)
+			return
+		}
+		if len(rule.Controls) > cfgsvcMaxPackControls {
+			writeJSONErrorDebug(w, http.StatusBadRequest, "a rule accepts up to %d controls",
+				cfgsvcMaxPackControls)
+			return
+		}
+		for _, control := range rule.Controls {
+			if control == "" || len(control) > 128 {
+				writeJSONErrorDebug(w, http.StatusBadRequest,
+					"each control must be between 1 and 128 characters long")
+				return
+			}
+		}
+	}
+	s.configSeedPut(w, r,
+		cfgsvcCtrlPackComplianceKey(seed.AccountID, seed.Region, seed.ConformancePackName), seed,
+		map[string]any{"rules": len(seed.Rules)})
+}
+
+// handleConfigClearPackCompliance handles DELETE /v1/config/pack-compliance/{name}.
+// A {name} of "*" clears the every-pack seed; omitting the segment clears all of
+// them, returning every pack to INSUFFICIENT_DATA.
+func (s *Server) handleConfigClearPackCompliance(w http.ResponseWriter, r *http.Request) {
+	s.configSeedClear(w, r, "pack_compliance:", func() (string, bool) {
+		name := chi.URLParam(r, "name")
+		if name == "" {
+			return "", false
+		}
+		return cfgsvcCtrlPackComplianceKey(r.URL.Query().Get("accountId"),
+			r.URL.Query().Get("region"), name), true
+	})
+}
+
 // configSeedPut stores one Config seed and reports what it stored.
 //
 // The stored key is echoed back because the wildcard defaulting is invisible from

--- a/emulator/configservice_packs.go
+++ b/emulator/configservice_packs.go
@@ -1,0 +1,1162 @@
+package emulator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+// The AWS Config conformance-pack cluster (#580).
+//
+// A conformance pack deploys asynchronously: PutConformancePack returns an ARN
+// immediately and the pack sits in CREATE_IN_PROGRESS until the CloudFormation stack
+// behind it finishes, so the consumer code worth testing here is a *waiter* — a loop
+// polling DescribeConformancePackStatus until the state is terminal. Substrate
+// resolves that transition on first observation and persists the result, following
+// resolveCreateAccountStatus (organizations_account.go): a waiter converges in one
+// poll with no dependence on wall-clock or simulated time, and a status that
+// re-resolved — flipping back to CREATE_IN_PROGRESS, or moving its
+// LastUpdateCompletedTime — would make a waiter comparing successive polls loop
+// forever. Clock-driven transitions are the subject of #514; choosing a duration
+// here would front-run that design.
+//
+// Substrate does not deploy the template. The rules a pack declares are therefore
+// not created, and DescribeConformancePackCompliance reports the rules a *seed*
+// names — because inferring them would mean parsing arbitrary CloudFormation to
+// guess at a listing a consumer would then assert against. Compliance is seeded for
+// the reason the rule cluster's is: evaluating a rule against resource state is
+// workload-internal, not an API observation.
+//
+// Two enum asymmetries have to be respected here, and neither is guessable from the
+// rule cluster:
+//
+//   - ConformancePackComplianceType has **no NOT_APPLICABLE**, so a seed carrying
+//     one is refused rather than stored as a value no response shape can hold.
+//   - the *filter* narrows further still — "The allowed values are COMPLIANT and
+//     NON_COMPLIANT. INSUFFICIENT_DATA is not supported" — so INSUFFICIENT_DATA is a
+//     verdict a pack can report but not a value a caller may filter on.
+
+// --- limits, all from the vendored model's own bounds ---
+
+const (
+	// cfgsvcMaxConformancePacks is the conformance-pack ceiling. The Developer Guide's
+	// Service Limits page gives 50 and marks it not adjustable.
+	//
+	// The page says "per account", not per account per Region, and substrate counts per
+	// account *and* Region because every key in this service is regional. That is the
+	// permissive direction — 50 packs in each of two Regions is accepted where AWS might
+	// refuse the 51st overall — and permissive is the right way to be wrong: a wrong
+	// refusal breaks working consumer code, while a wrong acceptance only fails to
+	// reproduce a limit no test fixture approaches.
+	cfgsvcMaxConformancePacks = 50
+
+	// cfgsvcMaxPackInputParameters is ConformancePackInputParameters' max (0-60).
+	cfgsvcMaxPackInputParameters = 60
+
+	// cfgsvcMaxPackNamesFilter is ConformancePackNamesList's max (0-25), the optional
+	// filter the two describe operations take.
+	cfgsvcMaxPackNamesFilter = 25
+
+	// cfgsvcMaxPackNamesToSummarize is ConformancePackNamesToSummarizeList's max. Its
+	// min is 1, and the member is required — the summary is the one operation in this
+	// cluster that cannot be asked for "every pack".
+	cfgsvcMaxPackNamesToSummarize = 5
+
+	// cfgsvcPageSizeLimit is PageSizeLimit's max (0-20), shared by
+	// DescribeConformancePacks, DescribeConformancePackStatus and
+	// GetConformancePackComplianceSummary.
+	//
+	// It is deliberately not the rule cluster's 100. The caps differ per operation in
+	// the model, and collapsing them onto one number would let a fixture page in units
+	// AWS would refuse.
+	cfgsvcPageSizeLimit = 20
+
+	// cfgsvcPackComplianceLimit is DescribeConformancePackComplianceLimit's max
+	// (0-1000) — a third ceiling on the same service.
+	cfgsvcPackComplianceLimit = 1000
+
+	// cfgsvcMaxPackFilterRuleNames is ConformancePackConfigRuleNames' max (0-10).
+	cfgsvcMaxPackFilterRuleNames = 10
+
+	// cfgsvcMaxPackFilterRuleNameLen is the length ceiling on a *filtered* rule name,
+	// which is StringWithCharLimit64 — 64, not the 128 that ConfigRuleName carries in
+	// DescribeConfigRules and in ConformancePackRuleCompliance. The asymmetry is the
+	// model's; a rule whose name is 65-128 characters long can be reported by this
+	// operation but not filtered for by it.
+	cfgsvcMaxPackFilterRuleNameLen = 64
+
+	// cfgsvcMaxPackControls is ControlsList's max (0-20), each member 1-128 characters.
+	// A control is "a process to prevent or detect problems while meeting objectives" —
+	// substrate carries whatever a seed names and derives nothing from it.
+	cfgsvcMaxPackControls = 20
+)
+
+// Conformance-pack deployment states, the ConformancePackState enum.
+//
+// There is no UPDATE_ state and no DELETE_COMPLETE, even though PutConformancePack
+// is documented as "Creates or updates": an update re-enters CREATE_IN_PROGRESS, and
+// a completed delete is reported by the pack's absence rather than by a state.
+const (
+	cfgsvcPackCreateInProgress = "CREATE_IN_PROGRESS"
+	cfgsvcPackCreateComplete   = "CREATE_COMPLETE"
+	cfgsvcPackCreateFailed     = "CREATE_FAILED"
+	cfgsvcPackDeleteInProgress = "DELETE_IN_PROGRESS"
+	cfgsvcPackDeleteFailed     = "DELETE_FAILED"
+)
+
+// cfgsvcPackStates is the ConformancePackState enum, which the status seed validates
+// against so a fixture cannot pin a state no SDK enum member matches.
+var cfgsvcPackStates = []string{
+	cfgsvcPackCreateInProgress,
+	cfgsvcPackCreateComplete,
+	cfgsvcPackCreateFailed,
+	cfgsvcPackDeleteInProgress,
+	cfgsvcPackDeleteFailed,
+}
+
+// cfgsvcPackFailedStates are the two states that carry a status reason.
+var cfgsvcPackFailedStates = []string{cfgsvcPackCreateFailed, cfgsvcPackDeleteFailed}
+
+// cfgsvcPackComplianceTypes is the ConformancePackComplianceType enum, which has no
+// NOT_APPLICABLE member; see this file's header comment.
+var cfgsvcPackComplianceTypes = []string{
+	cfgsvcCompliant,
+	cfgsvcNonCompliant,
+	cfgsvcInsufficientData,
+}
+
+// cfgsvcPackComplianceFilterTypes is the narrower subset ConformancePackComplianceFilters
+// accepts, again per this file's header comment.
+var cfgsvcPackComplianceFilterTypes = []string{cfgsvcCompliant, cfgsvcNonCompliant}
+
+// cfgsvcPackNamePattern is ConformancePackName's pattern, [a-zA-Z][-a-zA-Z0-9]*: a
+// letter, then letters, digits and hyphens. Note it admits neither an underscore nor
+// a leading digit, unlike ConfigRuleName's near-anything .*\S.*.
+var cfgsvcPackNamePattern = regexp.MustCompile(`^[a-zA-Z][-a-zA-Z0-9]*$`)
+
+// cfgsvcSSMDocumentNamePattern is SSMDocumentName's pattern, which bounds the length
+// itself.
+var cfgsvcSSMDocumentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_\-.:/]{3,200}$`)
+
+// cfgsvcSSMDocumentVersionPattern is SSMDocumentVersion's pattern: $LATEST, $DEFAULT
+// or a positive integer.
+var cfgsvcSSMDocumentVersionPattern = regexp.MustCompile(`^([$]LATEST|[$]DEFAULT|[1-9][0-9]*)$`)
+
+// --- shapes ---
+
+// ConfigConformancePackInputParameter is a ConformancePackInputParameter: one
+// key-value pair passed to the pack's template. Both members are required.
+type ConfigConformancePackInputParameter struct {
+	// ParameterName is one half of the pair, up to 255 characters.
+	ParameterName string `json:"ParameterName"`
+
+	// ParameterValue is the other half, up to 4096 characters.
+	ParameterValue string `json:"ParameterValue"`
+}
+
+// ConfigTemplateSSMDocumentDetails names the SSM document a pack template lives in.
+type ConfigTemplateSSMDocumentDetails struct {
+	// DocumentName is the name or ARN of the SSM document. Required.
+	DocumentName string `json:"DocumentName"`
+
+	// DocumentVersion is the document version; AWS uses the latest when it is empty.
+	DocumentVersion string `json:"DocumentVersion,omitempty"`
+}
+
+// ConfigConformancePack is a conformance pack as substrate stores it.
+//
+// It carries the union of ConformancePackDetail and ConformancePackStatusDetail,
+// because both operations describe the same pack and splitting the record would let
+// the two disagree about its ID or ARN. Which members each operation emits is
+// decided when its response is built, not by what is stored.
+type ConfigConformancePack struct {
+	// ConformancePackName is the pack's unique name within an account and Region.
+	ConformancePackName string `json:"ConformancePackName"`
+
+	// ConformancePackArn is the ARN substrate mints, conformance-pack/<name>/<id>.
+	ConformancePackArn string `json:"ConformancePackArn"`
+
+	// ConformancePackId is the deterministically minted pack ID.
+	ConformancePackId string `json:"ConformancePackId"` //nolint:revive // wire name.
+
+	// DeliveryS3Bucket is the optional bucket Config stores pack templates in.
+	DeliveryS3Bucket string `json:"DeliveryS3Bucket,omitempty"`
+
+	// DeliveryS3KeyPrefix is the optional prefix within that bucket.
+	DeliveryS3KeyPrefix string `json:"DeliveryS3KeyPrefix,omitempty"`
+
+	// ConformancePackInputParameters are the template's parameters.
+	ConformancePackInputParameters []ConfigConformancePackInputParameter `json:"ConformancePackInputParameters,omitempty"`
+
+	// TemplateSSMDocumentDetails names the SSM document the pack was built from, when
+	// it was built from one.
+	TemplateSSMDocumentDetails *ConfigTemplateSSMDocumentDetails `json:"TemplateSSMDocumentDetails,omitempty"`
+
+	// LastUpdateRequestedTime is when the create or update was requested. It is a
+	// required member of the status shape, so it is always set.
+	LastUpdateRequestedTime EpochSeconds `json:"LastUpdateRequestedTime,omitempty"`
+
+	// LastUpdateCompletedTime is when the deployment completed, and is unset while the
+	// pack is still in progress.
+	LastUpdateCompletedTime EpochSeconds `json:"LastUpdateCompletedTime,omitempty"`
+
+	// ConformancePackState is the stored deployment state. What an observation reports
+	// may differ from it, because a seed is applied at read time — see
+	// cfgsvcPackStateView.
+	ConformancePackState string `json:"ConformancePackState"`
+
+	// ConformancePackStatusReason explains a CREATE_FAILED or DELETE_FAILED state. It is
+	// never stored, only filled in from a seed as a response is built.
+	ConformancePackStatusReason string `json:"ConformancePackStatusReason,omitempty"`
+
+	// StackArn is the ARN of the CloudFormation stack Config deploys the pack through,
+	// synthesized because the status shape requires it.
+	StackArn string `json:"StackArn"`
+
+	// TemplateBody is the template the caller submitted, held as recorded intent:
+	// substrate never deploys it, and no response in this cluster emits it — neither
+	// ConformancePackDetail nor ConformancePackStatusDetail has a template member.
+	TemplateBody string `json:"TemplateBody,omitempty"`
+
+	// TemplateS3Uri is the S3 location a template was named at, likewise recorded and
+	// never fetched.
+	TemplateS3Uri string `json:"TemplateS3Uri,omitempty"`
+}
+
+// cfgsvcPutPackRequest is PutConformancePackRequest.
+//
+// It has no Tags member in the vendored model, though the API reference's
+// idempotency note discusses what a second Put does to a pack's tags. Substrate
+// models the vendored shape: there is no tag input here to preserve or ignore.
+type cfgsvcPutPackRequest struct {
+	ConformancePackName            string                                `json:"ConformancePackName"`
+	TemplateS3Uri                  string                                `json:"TemplateS3Uri"`
+	TemplateBody                   string                                `json:"TemplateBody"`
+	DeliveryS3Bucket               string                                `json:"DeliveryS3Bucket"`
+	DeliveryS3KeyPrefix            string                                `json:"DeliveryS3KeyPrefix"`
+	ConformancePackInputParameters []ConfigConformancePackInputParameter `json:"ConformancePackInputParameters"`
+	TemplateSSMDocumentDetails     *ConfigTemplateSSMDocumentDetails     `json:"TemplateSSMDocumentDetails"`
+}
+
+// cfgsvcDescribePacksRequest is shared by DescribeConformancePacks and
+// DescribeConformancePackStatus, whose inputs are member-for-member identical.
+type cfgsvcDescribePacksRequest struct {
+	ConformancePackNames []string `json:"ConformancePackNames"`
+	Limit                int      `json:"Limit"`
+	NextToken            string   `json:"NextToken"`
+}
+
+// cfgsvcDeletePackRequest is DeleteConformancePackRequest.
+type cfgsvcDeletePackRequest struct {
+	ConformancePackName string `json:"ConformancePackName"`
+}
+
+// cfgsvcPackComplianceFilters is ConformancePackComplianceFilters.
+type cfgsvcPackComplianceFilters struct {
+	ConfigRuleNames []string `json:"ConfigRuleNames"`
+	ComplianceType  string   `json:"ComplianceType"`
+}
+
+// cfgsvcPackComplianceRequest is DescribeConformancePackComplianceRequest.
+type cfgsvcPackComplianceRequest struct {
+	ConformancePackName string                       `json:"ConformancePackName"`
+	Filters             *cfgsvcPackComplianceFilters `json:"Filters"`
+	Limit               int                          `json:"Limit"`
+	NextToken           string                       `json:"NextToken"`
+}
+
+// cfgsvcPackSummaryRequest is GetConformancePackComplianceSummaryRequest.
+type cfgsvcPackSummaryRequest struct {
+	ConformancePackNames []string `json:"ConformancePackNames"`
+	Limit                int      `json:"Limit"`
+	NextToken            string   `json:"NextToken"`
+}
+
+// --- state keys and ARNs ---
+
+// cfgsvcPackKey holds one conformance pack, by account, Region and name.
+func cfgsvcPackKey(accountID, region, name string) string {
+	return "pack:" + accountID + "/" + region + "/" + name
+}
+
+// cfgsvcPackNamesKey holds the index of pack names for an account and Region.
+func cfgsvcPackNamesKey(accountID, region string) string {
+	return "pack_names:" + accountID + "/" + region
+}
+
+// cfgsvcPackARN builds a conformance pack's ARN, conformance-pack/<Name>/<Id>, per
+// the Service Authorization Reference. Both components appear, which is why the ID
+// alone does not identify a pack.
+func cfgsvcPackARN(ctx *RequestContext, name, packID string) string {
+	return cfgsvcARN(ctx, "conformance-pack", name+"/"+packID)
+}
+
+// cfgsvcMintPackID derives a pack's ConformancePackId deterministically, for the
+// reason cfgsvcMintRuleID does: a random or clock-derived ID would make every replay
+// of the same event stream mint different ARNs, and replay equality is the property
+// the whole emulator rests on.
+//
+// AWS's form is conformance-pack-<opaque>, which this reproduces so a consumer that
+// parses or asserts on the shape of an ID behaves the same way.
+func cfgsvcMintPackID(accountID, region, name string) string {
+	sum := sha256.Sum256([]byte("conformance-pack/" + accountID + "/" + region + "/" + name))
+	return "conformance-pack-" + strings.ToLower(base64.RawURLEncoding.EncodeToString(sum[:6]))[:8]
+}
+
+// cfgsvcPackStackARN synthesizes the ARN of the CloudFormation stack Config deploys
+// a pack through.
+//
+// StackArn is a *required* member of ConformancePackStatusDetail, so it cannot be
+// omitted: a consumer decoding a required member into a non-pointer field would get
+// an empty string rather than an error. Substrate creates no stack — no
+// CloudFormation state backs this ARN — so it is a well-formed identifier for a
+// stack that does not exist, which is the honest alternative to leaving a required
+// member blank.
+//
+// The awsconfigconforms-<pack name>-<pack id> stack-name form is provenance-worthy:
+// it appears only in the Developer Guide's sample CLI output, never in normative
+// prose, and matches the AWSServiceRoleForConfigConforms service-linked role's
+// naming. The trailing component is a stack ID, which AWS gives as a UUID; substrate
+// derives a UUID-shaped value from the same hash so it is stable across replays.
+func cfgsvcPackStackARN(ctx *RequestContext, name, packID string) string {
+	stackName := "awsconfigconforms-" + name + "-" + strings.TrimPrefix(packID, "conformance-pack-")
+	return "arn:aws:cloudformation:" + ctx.Region + ":" + ctx.AccountID + ":stack/" + stackName + "/" +
+		cfgsvcMintStackID(ctx.AccountID, ctx.Region, name)
+}
+
+// cfgsvcMintStackID derives a UUID-shaped CloudFormation stack ID deterministically,
+// so the synthesized StackArn has the shape a consumer's parsing expects.
+func cfgsvcMintStackID(accountID, region, name string) string {
+	sum := sha256.Sum256([]byte("awsconfigconforms/" + accountID + "/" + region + "/" + name))
+	hexed := hex.EncodeToString(sum[:16])
+	return hexed[0:8] + "-" + hexed[8:12] + "-" + hexed[12:16] + "-" + hexed[16:20] + "-" + hexed[20:32]
+}
+
+// --- errors ---
+
+// cfgsvcNoSuchPack is NoSuchConformancePackException.
+func cfgsvcNoSuchPack() *AWSError {
+	return cfgsvcErr("NoSuchConformancePackException",
+		"You specified one or more conformance packs that do not exist.")
+}
+
+// cfgsvcInvalidLimit is InvalidLimitException, which every paginated operation in
+// this cluster declares for an out-of-range Limit.
+//
+// The rule cluster answers InvalidParameterValueException for the same complaint,
+// because none of its operations declares InvalidLimitException while all four
+// paginated pack operations do. A caller's error handling is written against the
+// codes the operation it called declares, so borrowing one cluster's code for the
+// other would send it down a branch it has not got.
+func cfgsvcInvalidLimit() *AWSError {
+	return cfgsvcErr("InvalidLimitException", "The specified limit is outside the allowable range.")
+}
+
+// cfgsvcPackTemplateValidation is ConformancePackTemplateValidationException, whose
+// own message is "You have specified a template that is not valid or supported." The
+// caller-facing detail is appended, because that sentence alone does not say which
+// bound the template broke.
+func cfgsvcPackTemplateValidation(detail string) *AWSError {
+	return cfgsvcErr("ConformancePackTemplateValidationException",
+		"You have specified a template that is not valid or supported. "+detail)
+}
+
+// cfgsvcPackResourceInUse is ResourceInUseException for a pack whose deployment has
+// not reached a terminal state.
+//
+// The exception's own documentation is a bulleted list covering seven unrelated
+// cases, so the message is the bullet belonging to the operation that raised it,
+// verbatim. A caller reading the message gets the one sentence that applies rather
+// than a list it has to filter.
+func cfgsvcPackResourceInUse(operation string) *AWSError {
+	message := "For PutConformancePack and PutOrganizationConformancePack, a conformance pack " +
+		"creation, update, and deletion is in progress. Try your request again later."
+	if operation == "DeleteConformancePack" {
+		message = "For DeleteConformancePack, a conformance pack creation, update, and deletion " +
+			"is in progress. Try your request again later."
+	}
+	return cfgsvcErr("ResourceInUseException", "You see this exception in the following cases: "+message)
+}
+
+// packOperation claims the conformance-pack operations.
+func (p *ConfigServicePlugin) packOperation(op string) (cfgsvcHandler, bool) {
+	switch op {
+	case "PutConformancePack":
+		return p.putConformancePack, true
+	case "DescribeConformancePacks":
+		return p.describeConformancePacks, true
+	case "DescribeConformancePackStatus":
+		return p.describeConformancePackStatus, true
+	case "DescribeConformancePackCompliance":
+		return p.describeConformancePackCompliance, true
+	case "GetConformancePackComplianceSummary":
+		return p.getConformancePackComplianceSummary, true
+	case "DeleteConformancePack":
+		return p.deleteConformancePack, true
+	}
+	return nil, false
+}
+
+// putConformancePack creates or updates a conformance pack.
+//
+// The response carries the ARN and nothing else, so a caller learns the pack's state
+// only by polling DescribeConformancePackStatus — which is the waiter this cluster
+// exists to make testable.
+//
+// A Put arriving before the pack's deployment reaches a terminal state is
+// ResourceInUseException. That window is reachable in substrate precisely because
+// the state resolves on *observation*: a pack created and immediately Put again has
+// never been observed, so it is still CREATE_IN_PROGRESS and the second Put is
+// refused, exactly as AWS refuses it.
+func (p *ConfigServicePlugin) putConformancePack(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcPutPackRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	if err := cfgsvcCheckPackName(in.ConformancePackName); err != nil {
+		return nil, err
+	}
+	if err := cfgsvcCheckPackTemplate(&in); err != nil {
+		return nil, err
+	}
+	if err := cfgsvcCheckPackDelivery(&in); err != nil {
+		return nil, err
+	}
+	if err := cfgsvcCheckPackInputParameters(in.ConformancePackInputParameters); err != nil {
+		return nil, err
+	}
+
+	goCtx := context.Background()
+	var existing ConfigConformancePack
+	found, err := p.cfgsvcGetJSON(goCtx,
+		cfgsvcPackKey(ctx.AccountID, ctx.Region, in.ConformancePackName), &existing)
+	if err != nil {
+		return nil, err
+	}
+	if found {
+		state, _, stateErr := p.cfgsvcPackStateView(goCtx, ctx, &existing)
+		if stateErr != nil {
+			return nil, stateErr
+		}
+		if !cfgsvcPackIsTerminal(state) {
+			return nil, cfgsvcPackResourceInUse(req.Operation)
+		}
+	}
+
+	names, err := p.cfgsvcPackNames(goCtx, ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !found && len(names) >= cfgsvcMaxConformancePacks {
+		return nil, cfgsvcErr("MaxNumberOfConformancePacksExceededException",
+			"You have reached the limit of the number of conformance packs you can create in an "+
+				"account. For more information, see Service Limits in the Config Developer Guide.")
+	}
+
+	packID := cfgsvcMintPackID(ctx.AccountID, ctx.Region, in.ConformancePackName)
+	pack := ConfigConformancePack{
+		ConformancePackName:            in.ConformancePackName,
+		ConformancePackId:              packID,
+		ConformancePackArn:             cfgsvcPackARN(ctx, in.ConformancePackName, packID),
+		DeliveryS3Bucket:               in.DeliveryS3Bucket,
+		DeliveryS3KeyPrefix:            in.DeliveryS3KeyPrefix,
+		ConformancePackInputParameters: in.ConformancePackInputParameters,
+		TemplateSSMDocumentDetails:     in.TemplateSSMDocumentDetails,
+		TemplateBody:                   in.TemplateBody,
+		TemplateS3Uri:                  in.TemplateS3Uri,
+		StackArn:                       cfgsvcPackStackARN(ctx, in.ConformancePackName, packID),
+		// An update re-enters CREATE_IN_PROGRESS — there is no UPDATE_ state in the enum —
+		// and its LastUpdateCompletedTime is left cleared. Carrying the previous completion
+		// forward would let a waiter return before the update it just requested was
+		// observed at all, which is the bug a waiter exists to prevent.
+		ConformancePackState:    cfgsvcPackCreateInProgress,
+		LastUpdateRequestedTime: EpochSeconds(p.tc.Now()),
+	}
+	if err := p.cfgsvcSavePack(goCtx, ctx, &pack); err != nil {
+		return nil, err
+	}
+	return cfgsvcJSONResponse(map[string]interface{}{
+		"ConformancePackArn": pack.ConformancePackArn,
+	}, "PutConformancePack")
+}
+
+// cfgsvcCheckPackName validates ConformancePackName's bounds and pattern.
+func cfgsvcCheckPackName(name string) error {
+	if name == "" {
+		return cfgsvcInvalidParameter("ConformancePackName is required.")
+	}
+	if len(name) > cfgsvcMaxNameLen {
+		return cfgsvcInvalidParameter("The conformance pack name must be between 1 and 256 " +
+			"characters long.")
+	}
+	if !cfgsvcPackNamePattern.MatchString(name) {
+		return cfgsvcInvalidParameter("The conformance pack name must match the pattern " +
+			"[a-zA-Z][-a-zA-Z0-9]*: it must begin with a letter and may contain only letters, " +
+			"numbers and hyphens.")
+	}
+	return nil
+}
+
+// cfgsvcCheckPackTemplate enforces "You must specify only one of the follow
+// parameters: TemplateS3Uri, TemplateBody or TemplateSSMDocumentDetails" — AWS's
+// own sentence, its "the follow" typo included, so a consumer matching on message
+// text matches.
+//
+// Two is refused because the reference says so. **Zero is also refused, and that
+// part is substrate's reading rather than a documented rule**: all three members are
+// individually optional and no sentence says one is required, but a pack with no
+// template declares no rules, so accepting one would report CREATE_COMPLETE for a
+// deployment that could not have happened.
+//
+// The template's *content* is never judged beyond its bounds. Substrate does not
+// deploy it, and refusing a template AWS would accept would break working consumer
+// code — the worse of the two failures.
+func cfgsvcCheckPackTemplate(in *cfgsvcPutPackRequest) error {
+	supplied := 0
+	if in.TemplateS3Uri != "" {
+		supplied++
+	}
+	if in.TemplateBody != "" {
+		supplied++
+	}
+	if in.TemplateSSMDocumentDetails != nil {
+		supplied++
+	}
+	if supplied != 1 {
+		return cfgsvcInvalidParameter("You must specify only one of the follow parameters: " +
+			"TemplateS3Uri, TemplateBody or TemplateSSMDocumentDetails.")
+	}
+
+	switch {
+	case in.TemplateS3Uri != "":
+		if len(in.TemplateS3Uri) > 1024 {
+			return cfgsvcInvalidParameter("The TemplateS3Uri may be up to 1024 characters long.")
+		}
+		if !strings.HasPrefix(in.TemplateS3Uri, "s3://") {
+			return cfgsvcPackTemplateValidation("The TemplateS3Uri must match the pattern s3://.*, " +
+				"naming an Amazon S3 bucket and key.")
+		}
+	case in.TemplateBody != "":
+		if len(in.TemplateBody) > 51200 {
+			return cfgsvcPackTemplateValidation("The TemplateBody has a minimum length of 1 byte " +
+				"and a maximum length of 51,200 bytes.")
+		}
+	case in.TemplateSSMDocumentDetails != nil:
+		ssm := in.TemplateSSMDocumentDetails
+		if !cfgsvcSSMDocumentNamePattern.MatchString(ssm.DocumentName) {
+			return cfgsvcInvalidParameter("The DocumentName is required and must match the " +
+				`pattern ^[a-zA-Z0-9_\-.:/]{3,200}$.`)
+		}
+		if ssm.DocumentVersion != "" && !cfgsvcSSMDocumentVersionPattern.MatchString(ssm.DocumentVersion) {
+			return cfgsvcInvalidParameter("The DocumentVersion must be $LATEST, $DEFAULT or a " +
+				"positive version number.")
+		}
+	}
+	return nil
+}
+
+// cfgsvcCheckPackDelivery validates the optional delivery bucket and prefix against
+// DeliveryS3Bucket (0-63) and DeliveryS3KeyPrefix (0-1024). Both have a minimum of
+// zero, so an empty value is accepted rather than treated as a missing one.
+func cfgsvcCheckPackDelivery(in *cfgsvcPutPackRequest) error {
+	if len(in.DeliveryS3Bucket) > 63 {
+		return cfgsvcInvalidParameter("The DeliveryS3Bucket may be up to 63 characters long.")
+	}
+	if len(in.DeliveryS3KeyPrefix) > 1024 {
+		return cfgsvcInvalidParameter("The DeliveryS3KeyPrefix may be up to 1024 characters long.")
+	}
+	return nil
+}
+
+// cfgsvcCheckPackInputParameters validates the parameter list's length and each
+// pair's bounds. Both members are required, so an empty ParameterName is refused
+// rather than stored as a nameless parameter the template could never resolve.
+func cfgsvcCheckPackInputParameters(params []ConfigConformancePackInputParameter) error {
+	if len(params) > cfgsvcMaxPackInputParameters {
+		return cfgsvcInvalidParameter("ConformancePackInputParameters accepts up to 60 parameters.")
+	}
+	for _, param := range params {
+		if param.ParameterName == "" || len(param.ParameterName) > 255 {
+			return cfgsvcInvalidParameter("The ParameterName is required and may be up to 255 " +
+				"characters long.")
+		}
+		if len(param.ParameterValue) > 4096 {
+			return cfgsvcInvalidParameter("The ParameterValue may be up to 4096 characters long.")
+		}
+	}
+	return nil
+}
+
+// cfgsvcPackIsTerminal reports whether a pack's state is one a Put or a Delete may
+// act on. The two in-progress states are not: "You cannot update a conformance pack
+// while it is in this state".
+func cfgsvcPackIsTerminal(state string) bool {
+	return state != cfgsvcPackCreateInProgress && state != cfgsvcPackDeleteInProgress
+}
+
+// cfgsvcSavePack stores a pack and its name index through one function, so the index
+// cannot exist on one side only — the v0.99.0 saveAccount lesson.
+func (p *ConfigServicePlugin) cfgsvcSavePack(goCtx context.Context, ctx *RequestContext,
+	pack *ConfigConformancePack) error {
+	if err := p.cfgsvcPutJSON(goCtx,
+		cfgsvcPackKey(ctx.AccountID, ctx.Region, pack.ConformancePackName), pack); err != nil {
+		return err
+	}
+	names, err := p.cfgsvcPackNames(goCtx, ctx)
+	if err != nil {
+		return err
+	}
+	if slices.Contains(names, pack.ConformancePackName) {
+		return nil
+	}
+	names = append(names, pack.ConformancePackName)
+	return p.cfgsvcPutJSON(goCtx, cfgsvcPackNamesKey(ctx.AccountID, ctx.Region), names)
+}
+
+// cfgsvcDeletePackRecord removes a pack and its index entry, the counterpart to
+// cfgsvcSavePack.
+func (p *ConfigServicePlugin) cfgsvcDeletePackRecord(goCtx context.Context, ctx *RequestContext,
+	name string) error {
+	if err := p.cfgsvcDeleteKey(goCtx, cfgsvcPackKey(ctx.AccountID, ctx.Region, name)); err != nil {
+		return err
+	}
+	names, err := p.cfgsvcPackNames(goCtx, ctx)
+	if err != nil {
+		return err
+	}
+	remaining := make([]string, 0, len(names))
+	for _, existing := range names {
+		if existing != name {
+			remaining = append(remaining, existing)
+		}
+	}
+	return p.cfgsvcPutJSON(goCtx, cfgsvcPackNamesKey(ctx.AccountID, ctx.Region), remaining)
+}
+
+// cfgsvcPackNames reads the pack-name index for an account and Region.
+func (p *ConfigServicePlugin) cfgsvcPackNames(goCtx context.Context, ctx *RequestContext) ([]string, error) {
+	var names []string
+	if _, err := p.cfgsvcGetJSON(goCtx, cfgsvcPackNamesKey(ctx.AccountID, ctx.Region), &names); err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+// describeConformancePacks reports the packs' configuration — not their deployment
+// state, which is DescribeConformancePackStatus's job.
+//
+// The split matters for the same reason the recorder's does: a pack in this listing
+// may have failed to deploy, and a consumer that reads presence as success has the
+// bug this cluster makes visible.
+func (p *ConfigServicePlugin) describeConformancePacks(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	packs, next, err := p.cfgsvcPagePacks(ctx, req, true)
+	if err != nil {
+		return nil, err
+	}
+	details := make([]map[string]interface{}, 0, len(packs))
+	for i := range packs {
+		details = append(details, cfgsvcPackDetailShape(&packs[i]))
+	}
+	body := map[string]interface{}{"ConformancePackDetails": details}
+	if next != "" {
+		body["NextToken"] = next
+	}
+	return cfgsvcJSONResponse(body, "DescribeConformancePacks")
+}
+
+// describeConformancePackStatus reports each pack's deployment state, resolving
+// CREATE_IN_PROGRESS to its terminal state on this observation.
+//
+// "If there are no conformance packs then you will see an empty result", and this
+// operation does not declare NoSuchConformancePackException at all, so a name
+// matching nothing contributes nothing to the list rather than refusing the call.
+// DescribeConformancePacks does declare it, and does refuse.
+func (p *ConfigServicePlugin) describeConformancePackStatus(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	packs, next, err := p.cfgsvcPagePacks(ctx, req, false)
+	if err != nil {
+		return nil, err
+	}
+	details := make([]map[string]interface{}, 0, len(packs))
+	for i := range packs {
+		if err := p.cfgsvcResolvePackState(ctx, &packs[i]); err != nil {
+			return nil, err
+		}
+		details = append(details, cfgsvcPackStatusShape(&packs[i]))
+	}
+	body := map[string]interface{}{"ConformancePackStatusDetails": details}
+	if next != "" {
+		body["NextToken"] = next
+	}
+	return cfgsvcJSONResponse(body, "DescribeConformancePackStatus")
+}
+
+// cfgsvcPagePacks decodes the input the two describe operations share, selects the
+// named packs and paginates them at PageSizeLimit's ceiling of 20.
+//
+// refuseUnknown says whether a named pack that does not exist refuses the whole
+// call, which differs between the two callers: only DescribeConformancePacks
+// declares NoSuchConformancePackException.
+func (p *ConfigServicePlugin) cfgsvcPagePacks(ctx *RequestContext, req *AWSRequest, refuseUnknown bool) (
+	[]ConfigConformancePack, string, error) {
+	var in cfgsvcDescribePacksRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, "", err
+	}
+	if len(in.ConformancePackNames) > cfgsvcMaxPackNamesFilter {
+		return nil, "", cfgsvcInvalidParameter("ConformancePackNames accepts up to 25 pack names.")
+	}
+	if in.Limit < 0 || in.Limit > cfgsvcPageSizeLimit {
+		return nil, "", cfgsvcInvalidLimit()
+	}
+	for _, name := range in.ConformancePackNames {
+		if err := cfgsvcCheckPackName(name); err != nil {
+			return nil, "", err
+		}
+	}
+
+	goCtx := context.Background()
+	names := in.ConformancePackNames
+	named := len(names) > 0
+	if !named {
+		var err error
+		names, err = p.cfgsvcPackNames(goCtx, ctx)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	page, next, err := cfgsvcPaginate(names, in.NextToken, in.Limit, cfgsvcPageSizeLimit)
+	if err != nil {
+		return nil, "", err
+	}
+	packs := make([]ConfigConformancePack, 0, len(page))
+	for _, name := range page {
+		var pack ConfigConformancePack
+		found, getErr := p.cfgsvcGetJSON(goCtx, cfgsvcPackKey(ctx.AccountID, ctx.Region, name), &pack)
+		if getErr != nil {
+			return nil, "", getErr
+		}
+		if !found {
+			// Only a *named* pack can be missing here — an unnamed listing comes from the
+			// index, so a gap would mean the index and the records had diverged.
+			if named && refuseUnknown {
+				return nil, "", cfgsvcNoSuchPack()
+			}
+			continue
+		}
+		packs = append(packs, pack)
+	}
+	return packs, next, nil
+}
+
+// cfgsvcPackStateView returns the state and status reason an observation reports,
+// applying a seed at read time and never writing it.
+//
+// Reading rather than writing is what makes a seed reversible: clearing it restores
+// the pack's real state instead of leaving the seeded value baked into the record.
+// That is why Put and Delete consult this rather than the stored field — a pack
+// seeded CREATE_FAILED is terminal and must be deletable, even though what is stored
+// still says CREATE_IN_PROGRESS.
+func (p *ConfigServicePlugin) cfgsvcPackStateView(goCtx context.Context, ctx *RequestContext,
+	pack *ConfigConformancePack) (state, reason string, err error) {
+	seed, seeded, err := p.seededPackStatus(goCtx, ctx.AccountID, ctx.Region, pack.ConformancePackName)
+	if err != nil {
+		return "", "", err
+	}
+	if seeded {
+		return seed.State, seed.StatusReason, nil
+	}
+	return pack.ConformancePackState, "", nil
+}
+
+// cfgsvcResolvePackState settles a pack's reported state for one observation of
+// DescribeConformancePackStatus, mutating the in-memory copy the response is built
+// from.
+//
+// Advance-on-observation, following resolveCreateAccountStatus
+// (organizations_account.go), and for its reasons: resolving on observation rather
+// than after an interval of the simulated clock lets a waiter converge in one poll
+// with no dependence on wall-clock or simulated time, and *persisting* the resolved
+// state means every later observation reports the same state and the same
+// LastUpdateCompletedTime. A status that re-resolved would move that timestamp under
+// a waiter comparing successive polls, which would loop forever. Clock-driven
+// transitions are #514's subject; picking a duration here would front-run it.
+//
+// A seeded state short-circuits the advance and is *not* persisted, per
+// cfgsvcPackStateView. Its completion time is reported as the pack's requested time
+// rather than the clock's current value: an unwritten seed cannot remember when it
+// "completed", and drawing a fresh timestamp on every poll would move it under the
+// same waiter this design protects.
+func (p *ConfigServicePlugin) cfgsvcResolvePackState(ctx *RequestContext, pack *ConfigConformancePack) error {
+	goCtx := context.Background()
+	state, reason, err := p.cfgsvcPackStateView(goCtx, ctx, pack)
+	if err != nil {
+		return err
+	}
+	if state != pack.ConformancePackState || reason != "" {
+		pack.ConformancePackState = state
+		pack.ConformancePackStatusReason = reason
+		if cfgsvcPackIsTerminal(state) && time.Time(pack.LastUpdateCompletedTime).IsZero() {
+			pack.LastUpdateCompletedTime = pack.LastUpdateRequestedTime
+		}
+		return nil
+	}
+	if cfgsvcPackIsTerminal(pack.ConformancePackState) {
+		return nil
+	}
+	// DELETE_IN_PROGRESS is unreachable for a stored pack: deleteConformancePack removes
+	// the record within the call rather than leaving one behind to converge, so the only
+	// unresolved state a stored pack can hold is CREATE_IN_PROGRESS.
+	pack.ConformancePackState = cfgsvcPackCreateComplete
+	pack.LastUpdateCompletedTime = EpochSeconds(p.tc.Now())
+	return p.cfgsvcSavePack(goCtx, ctx, pack)
+}
+
+// cfgsvcPackDetailShape builds a ConformancePackDetail.
+//
+// No template member appears, because the shape has none: a caller cannot read back
+// the template it submitted, and emitting one would be an invention.
+//
+// CreatedBy is likewise absent. It names the Amazon Web Services service that
+// created a service-managed pack, and substrate models none, so reporting a value
+// would claim a caller's pack was service-created.
+func cfgsvcPackDetailShape(pack *ConfigConformancePack) map[string]interface{} {
+	out := map[string]interface{}{
+		"ConformancePackName": pack.ConformancePackName,
+		"ConformancePackArn":  pack.ConformancePackArn,
+		"ConformancePackId":   pack.ConformancePackId,
+	}
+	if pack.DeliveryS3Bucket != "" {
+		out["DeliveryS3Bucket"] = pack.DeliveryS3Bucket
+	}
+	if pack.DeliveryS3KeyPrefix != "" {
+		out["DeliveryS3KeyPrefix"] = pack.DeliveryS3KeyPrefix
+	}
+	if len(pack.ConformancePackInputParameters) > 0 {
+		out["ConformancePackInputParameters"] = pack.ConformancePackInputParameters
+	}
+	if pack.TemplateSSMDocumentDetails != nil {
+		out["TemplateSSMDocumentDetails"] = pack.TemplateSSMDocumentDetails
+	}
+	if !time.Time(pack.LastUpdateRequestedTime).IsZero() {
+		out["LastUpdateRequestedTime"] = pack.LastUpdateRequestedTime
+	}
+	return out
+}
+
+// cfgsvcPackStatusShape builds a ConformancePackStatusDetail.
+//
+// All six required members are always present — ConformancePackName, Id, Arn, State,
+// StackArn and LastUpdateRequestedTime — the synthesized StackArn included, because
+// a consumer decoding a required member into a non-pointer field gets a zero value
+// rather than an error when one is missing, and a silently empty field is worse than
+// an obviously synthetic one.
+func cfgsvcPackStatusShape(pack *ConfigConformancePack) map[string]interface{} {
+	out := map[string]interface{}{
+		"ConformancePackName":     pack.ConformancePackName,
+		"ConformancePackId":       pack.ConformancePackId,
+		"ConformancePackArn":      pack.ConformancePackArn,
+		"ConformancePackState":    pack.ConformancePackState,
+		"StackArn":                pack.StackArn,
+		"LastUpdateRequestedTime": pack.LastUpdateRequestedTime,
+	}
+	if pack.ConformancePackStatusReason != "" {
+		out["ConformancePackStatusReason"] = pack.ConformancePackStatusReason
+	}
+	if !time.Time(pack.LastUpdateCompletedTime).IsZero() {
+		out["LastUpdateCompletedTime"] = pack.LastUpdateCompletedTime
+	}
+	return out
+}
+
+// describeConformancePackCompliance reports the per-rule verdicts within a pack.
+//
+// The rules are the pack's *seeded* rules. Substrate does not deploy a pack's
+// template, so it does not know which rules that template declares — on real AWS
+// CloudFormation creates them as service-linked rules — and inferring them would mean
+// parsing arbitrary CloudFormation to produce a listing a consumer would assert
+// against. Naming the rules in the seed is the honest version of the same fixture.
+func (p *ConfigServicePlugin) describeConformancePackCompliance(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcPackComplianceRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	if err := cfgsvcCheckPackName(in.ConformancePackName); err != nil {
+		return nil, err
+	}
+	if in.Limit < 0 || in.Limit > cfgsvcPackComplianceLimit {
+		return nil, cfgsvcInvalidLimit()
+	}
+	if err := cfgsvcCheckPackComplianceFilters(in.Filters); err != nil {
+		return nil, err
+	}
+
+	goCtx := context.Background()
+	found, err := p.cfgsvcGetJSON(goCtx,
+		cfgsvcPackKey(ctx.AccountID, ctx.Region, in.ConformancePackName), &ConfigConformancePack{})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, cfgsvcNoSuchPack()
+	}
+
+	rules, err := p.cfgsvcPackRuleCompliance(goCtx, ctx, in.ConformancePackName)
+	if err != nil {
+		return nil, err
+	}
+
+	// "You must provide exact rule names." A filter naming a rule the pack does not
+	// report is NoSuchConfigRuleInConformancePackException rather than an empty list, so
+	// a typo in a fixture's rule name is a refusal instead of a silent pass — which is
+	// the whole value of that sentence.
+	for _, name := range cfgsvcPackFilterNames(in.Filters) {
+		if _, ok := rules[name]; !ok {
+			return nil, cfgsvcErr("NoSuchConfigRuleInConformancePackException",
+				"Config rule that you passed in the filter does not exist.")
+		}
+	}
+
+	names := make([]string, 0, len(rules))
+	for name, rule := range rules {
+		if filters := in.Filters; filters != nil {
+			if len(filters.ConfigRuleNames) > 0 && !slices.Contains(filters.ConfigRuleNames, name) {
+				continue
+			}
+			if filters.ComplianceType != "" && rule.ComplianceType != filters.ComplianceType {
+				continue
+			}
+		}
+		names = append(names, name)
+	}
+
+	page, next, err := cfgsvcPaginate(names, in.NextToken, in.Limit, cfgsvcPackComplianceLimit)
+	if err != nil {
+		return nil, err
+	}
+	list := make([]map[string]interface{}, 0, len(page))
+	for _, name := range page {
+		entry := map[string]interface{}{
+			"ConfigRuleName": name,
+			"ComplianceType": rules[name].ComplianceType,
+		}
+		if controls := rules[name].Controls; len(controls) > 0 {
+			entry["Controls"] = controls
+		}
+		list = append(list, entry)
+	}
+	body := map[string]interface{}{
+		"ConformancePackName":               in.ConformancePackName,
+		"ConformancePackRuleComplianceList": list,
+	}
+	if next != "" {
+		body["NextToken"] = next
+	}
+	return cfgsvcJSONResponse(body, "DescribeConformancePackCompliance")
+}
+
+// cfgsvcPackFilterNames returns the rule names a compliance filter names, or none.
+func cfgsvcPackFilterNames(filters *cfgsvcPackComplianceFilters) []string {
+	if filters == nil {
+		return nil
+	}
+	return filters.ConfigRuleNames
+}
+
+// cfgsvcPackRuleCompliance reads the seeded per-rule verdicts for a pack, keyed by
+// rule name.
+func (p *ConfigServicePlugin) cfgsvcPackRuleCompliance(goCtx context.Context, ctx *RequestContext,
+	name string) (map[string]cfgsvcSeededPackRule, error) {
+	seed, seeded, err := p.seededPackCompliance(goCtx, ctx.AccountID, ctx.Region, name)
+	if err != nil {
+		return nil, err
+	}
+	rules := make(map[string]cfgsvcSeededPackRule, len(seed.Rules))
+	if !seeded {
+		return rules, nil
+	}
+	for _, rule := range seed.Rules {
+		rules[rule.ConfigRuleName] = rule
+	}
+	return rules, nil
+}
+
+// cfgsvcCheckPackComplianceFilters validates ConformancePackComplianceFilters.
+//
+// The ComplianceType filter admits only COMPLIANT and NON_COMPLIANT —
+// "INSUFFICIENT_DATA is not supported" — even though INSUFFICIENT_DATA is in the enum
+// the shape declares and is a value the *response* carries. Accepting it as a filter
+// would return an empty list where AWS returns an error, so a fixture would read "no
+// rules match" instead of "you cannot ask that".
+func cfgsvcCheckPackComplianceFilters(filters *cfgsvcPackComplianceFilters) error {
+	if filters == nil {
+		return nil
+	}
+	if len(filters.ConfigRuleNames) > cfgsvcMaxPackFilterRuleNames {
+		return cfgsvcInvalidParameter("The ConfigRuleNames filter accepts up to 10 rule names.")
+	}
+	for _, name := range filters.ConfigRuleNames {
+		if name == "" || len(name) > cfgsvcMaxPackFilterRuleNameLen {
+			return cfgsvcInvalidParameter("A filtered Config rule name is required and may be up " +
+				"to 64 characters long.")
+		}
+	}
+	if filters.ComplianceType != "" &&
+		!slices.Contains(cfgsvcPackComplianceFilterTypes, filters.ComplianceType) {
+		return cfgsvcInvalidParameter("The ComplianceType filter allows only COMPLIANT and " +
+			"NON_COMPLIANT. INSUFFICIENT_DATA is not supported.")
+	}
+	return nil
+}
+
+// getConformancePackComplianceSummary reports one cumulative verdict per pack.
+//
+// ConformancePackNames is *required* here and accepts 1-5 names, unlike the describe
+// operations' optional 0-25.
+//
+// The cumulative verdict is derived from the seeded per-rule verdicts rather than
+// seeded separately, so the summary and the per-rule listing cannot disagree: any
+// NON_COMPLIANT rule makes the pack NON_COMPLIANT, all-COMPLIANT makes it COMPLIANT,
+// and a pack with no seeded rules is INSUFFICIENT_DATA — the same "has not evaluated"
+// default the rule cluster reports, for the same reason.
+func (p *ConfigServicePlugin) getConformancePackComplianceSummary(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcPackSummaryRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	// This operation declares only InvalidLimitException, InvalidNextTokenException and
+	// NoSuchConformancePackException — it does not declare InvalidParameterValueException,
+	// which every other paginated operation here does. An SDK caller never reaches the
+	// two refusals below, because a required member and an array's 1-5 bounds are checked
+	// client-side; a raw caller does, and serving a request outside the model's own
+	// bounds would be worse than answering with the code its sibling operations use.
+	if len(in.ConformancePackNames) == 0 {
+		return nil, cfgsvcInvalidParameter("ConformancePackNames is required and accepts between " +
+			"1 and 5 conformance pack names.")
+	}
+	if len(in.ConformancePackNames) > cfgsvcMaxPackNamesToSummarize {
+		return nil, cfgsvcInvalidParameter("ConformancePackNames accepts up to 5 conformance pack " +
+			"names.")
+	}
+	if in.Limit < 0 || in.Limit > cfgsvcPageSizeLimit {
+		return nil, cfgsvcInvalidLimit()
+	}
+
+	goCtx := context.Background()
+	for _, name := range in.ConformancePackNames {
+		if err := cfgsvcCheckPackName(name); err != nil {
+			return nil, err
+		}
+		found, getErr := p.cfgsvcGetJSON(goCtx, cfgsvcPackKey(ctx.AccountID, ctx.Region, name),
+			&ConfigConformancePack{})
+		if getErr != nil {
+			return nil, getErr
+		}
+		if !found {
+			return nil, cfgsvcNoSuchPack()
+		}
+	}
+
+	page, next, err := cfgsvcPaginate(in.ConformancePackNames, in.NextToken, in.Limit, cfgsvcPageSizeLimit)
+	if err != nil {
+		return nil, err
+	}
+	summaries := make([]map[string]interface{}, 0, len(page))
+	for _, name := range page {
+		verdict, verdictErr := p.cfgsvcPackVerdict(goCtx, ctx, name)
+		if verdictErr != nil {
+			return nil, verdictErr
+		}
+		summaries = append(summaries, map[string]interface{}{
+			"ConformancePackName":             name,
+			"ConformancePackComplianceStatus": verdict,
+		})
+	}
+	body := map[string]interface{}{"ConformancePackComplianceSummaryList": summaries}
+	if next != "" {
+		body["NextToken"] = next
+	}
+	return cfgsvcJSONResponse(body, "GetConformancePackComplianceSummary")
+}
+
+// cfgsvcPackVerdict computes a pack's cumulative verdict from its seeded rules; see
+// getConformancePackComplianceSummary for why it is derived rather than seeded.
+func (p *ConfigServicePlugin) cfgsvcPackVerdict(goCtx context.Context, ctx *RequestContext,
+	name string) (string, error) {
+	rules, err := p.cfgsvcPackRuleCompliance(goCtx, ctx, name)
+	if err != nil {
+		return "", err
+	}
+	if len(rules) == 0 {
+		return cfgsvcInsufficientData, nil
+	}
+	verdict := cfgsvcCompliant
+	for _, rule := range rules {
+		switch rule.ComplianceType {
+		case cfgsvcNonCompliant:
+			// One non-compliant rule makes the pack non-compliant, and it outranks
+			// INSUFFICIENT_DATA: a pack with a known failure is not "unknown".
+			return cfgsvcNonCompliant, nil
+		case cfgsvcInsufficientData:
+			verdict = cfgsvcInsufficientData
+		}
+	}
+	return verdict, nil
+}
+
+// deleteConformancePack deletes a pack "and all the Config rules, remediation
+// actions, and all evaluation results within that conformance pack".
+//
+// AWS sets the pack to DELETE_IN_PROGRESS and completes asynchronously. Substrate's
+// delete completes within the call, so no stored pack is ever DELETE_IN_PROGRESS and
+// a consumer polling until the pack disappears converges on its first poll. What is
+// preserved is the refusal a real ordering bug produces: a delete arriving before the
+// create was ever observed is ResourceInUseException, exactly as on AWS.
+//
+// The pack's status and compliance seeds go with it, so a rebuilt pack of the same
+// name starts at CREATE_IN_PROGRESS and INSUFFICIENT_DATA rather than inheriting its
+// predecessor's. The "*" wildcard seeds are left alone: those are fixture-wide
+// defaults rather than one pack's state, and deleting a pack should not silently
+// change what every other pack reports.
+func (p *ConfigServicePlugin) deleteConformancePack(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcDeletePackRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	if err := cfgsvcCheckPackName(in.ConformancePackName); err != nil {
+		return nil, err
+	}
+
+	goCtx := context.Background()
+	var pack ConfigConformancePack
+	found, err := p.cfgsvcGetJSON(goCtx,
+		cfgsvcPackKey(ctx.AccountID, ctx.Region, in.ConformancePackName), &pack)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, cfgsvcNoSuchPack()
+	}
+	state, _, err := p.cfgsvcPackStateView(goCtx, ctx, &pack)
+	if err != nil {
+		return nil, err
+	}
+	if !cfgsvcPackIsTerminal(state) {
+		return nil, cfgsvcPackResourceInUse(req.Operation)
+	}
+
+	if err := p.cfgsvcDeletePackRecord(goCtx, ctx, in.ConformancePackName); err != nil {
+		return nil, err
+	}
+	if err := p.cfgsvcClearPackSeeds(goCtx, ctx, in.ConformancePackName); err != nil {
+		return nil, err
+	}
+	// DeleteConformancePack has no output shape at all: "the service sends back an HTTP
+	// 200 response with an empty HTTP body."
+	return cfgsvcEmptyResponse(), nil
+}

--- a/emulator/configservice_packs_test.go
+++ b/emulator/configservice_packs_test.go
@@ -1,0 +1,1395 @@
+package emulator_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+	"github.com/stretchr/testify/require"
+)
+
+// AWS Config conformance-pack tests (#580).
+//
+// The behavior worth defending here is the waiter: a pack is CREATE_IN_PROGRESS
+// until something observes it, then CREATE_COMPLETE forever. Both halves are
+// asserted, because a status that never advanced and a status that re-resolved on
+// every poll each break a consumer's waiter, in opposite directions.
+
+// configPutPack creates a pack with a template body and returns its ARN.
+func configPutPack(t *testing.T, ts *emulator.TestServer, name string) string {
+	t.Helper()
+	resp := configRequest(t, ts, "PutConformancePack", map[string]any{
+		"ConformancePackName": name,
+		"TemplateBody":        `{"Resources":{}}`,
+	})
+	var out struct {
+		ConformancePackArn string `json:"ConformancePackArn"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	return out.ConformancePackArn
+}
+
+// configPutPackRaw sends a PutConformancePack and returns the status and error code,
+// for the cases whose subject is the refusal.
+func configPutPackRaw(t *testing.T, ts *emulator.TestServer, body map[string]any) (int, string, string) {
+	t.Helper()
+	resp := configRequest(t, ts, "PutConformancePack", body)
+	return decodeConfigResponse(t, resp, nil)
+}
+
+// configDescribePacks returns the ConformancePackDetails.
+func configDescribePacks(t *testing.T, ts *emulator.TestServer, body map[string]any) []map[string]any {
+	t.Helper()
+	resp := configRequest(t, ts, "DescribeConformancePacks", body)
+	var out struct {
+		ConformancePackDetails []map[string]any `json:"ConformancePackDetails"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	return out.ConformancePackDetails
+}
+
+// configPackStatus returns the ConformancePackStatusDetails.
+func configPackStatus(t *testing.T, ts *emulator.TestServer, body map[string]any) []map[string]any {
+	t.Helper()
+	return configPackStatusIn(t, ts, "us-east-1", body)
+}
+
+// configPackStatusIn returns the ConformancePackStatusDetails from a named Region.
+func configPackStatusIn(t *testing.T, ts *emulator.TestServer, region string,
+	body map[string]any) []map[string]any {
+	t.Helper()
+	resp := configRequestIn(t, ts, region, "DescribeConformancePackStatus", body)
+	var out struct {
+		ConformancePackStatusDetails []map[string]any `json:"ConformancePackStatusDetails"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	return out.ConformancePackStatusDetails
+}
+
+// configPackStateOf reports the state of one named pack, requiring it be present.
+func configPackStateOf(t *testing.T, ts *emulator.TestServer, name string) map[string]any {
+	t.Helper()
+	details := configPackStatus(t, ts, map[string]any{"ConformancePackNames": []string{name}})
+	require.Len(t, details, 1, "the pack has a status")
+	return details[0]
+}
+
+// configPackCompliance returns the ConformancePackRuleComplianceList.
+func configPackCompliance(t *testing.T, ts *emulator.TestServer, body map[string]any) []map[string]any {
+	t.Helper()
+	resp := configRequest(t, ts, "DescribeConformancePackCompliance", body)
+	var out struct {
+		ConformancePackRuleComplianceList []map[string]any `json:"ConformancePackRuleComplianceList"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	return out.ConformancePackRuleComplianceList
+}
+
+// configPackSummary returns the ConformancePackComplianceSummaryList.
+func configPackSummary(t *testing.T, ts *emulator.TestServer, names []string) []map[string]any {
+	t.Helper()
+	resp := configRequest(t, ts, "GetConformancePackComplianceSummary", map[string]any{
+		"ConformancePackNames": names,
+	})
+	var out struct {
+		ConformancePackComplianceSummaryList []map[string]any `json:"ConformancePackComplianceSummaryList"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	return out.ConformancePackComplianceSummaryList
+}
+
+// configDeletePack sends a DeleteConformancePack and returns the refusal, if any.
+func configDeletePack(t *testing.T, ts *emulator.TestServer, name string) (int, string, string) {
+	t.Helper()
+	resp := configRequest(t, ts, "DeleteConformancePack", map[string]any{"ConformancePackName": name})
+	return decodeConfigResponse(t, resp, nil)
+}
+
+// configSeedPackCompliance pins a pack's per-rule verdicts and requires the seed be
+// accepted.
+func configSeedPackCompliance(t *testing.T, ts *emulator.TestServer, pack string, rules []map[string]any) {
+	t.Helper()
+	configSeed(t, ts, "/v1/config/pack-compliance/"+pack, map[string]any{"rules": rules})
+}
+
+func TestConformancePacks_PutReturnsOnlyTheARN(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	resp := configRequest(t, ts, "PutConformancePack", map[string]any{
+		"ConformancePackName": "ops",
+		"TemplateBody":        `{"Resources":{}}`,
+	})
+	var out map[string]any
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	// The response shape carries one member and no state, which is why a consumer has to
+	// poll the status operation to learn whether its pack deployed at all.
+	require.Equal(t, []string{"ConformancePackArn"}, mapKeys(out))
+	arn, ok := out["ConformancePackArn"].(string)
+	require.True(t, ok)
+	require.Regexp(t,
+		`^arn:aws:config:us-east-1:123456789012:conformance-pack/ops/conformance-pack-[a-z0-9_-]{8}$`, arn)
+}
+
+func TestConformancePacks_APutDoesNotRequireARecorder(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	// PutConfigRule and PutDeliveryChannel both refuse without a recorder and declare
+	// NoAvailableConfigurationRecorderException for it. PutConformancePack declares no
+	// such error, so a pack can be created in an account that records nothing — the
+	// asymmetry a fixture would otherwise have to discover by being refused.
+	status, code, message := configPutPackRaw(t, ts, map[string]any{
+		"ConformancePackName": "ops",
+		"TemplateBody":        `{"Resources":{}}`,
+	})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+}
+
+func TestConformancePacks_StatusResolvesOnObservationAndThenStaysPut(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	// The first observation both reports and settles the transition, so a waiter
+	// converges in one poll without waiting on any clock.
+	first := configPackStateOf(t, ts, "ops")
+	require.Equal(t, "CREATE_COMPLETE", first["ConformancePackState"])
+	require.NotNil(t, first["LastUpdateCompletedTime"], "a completed pack carries a completion time")
+
+	// The second is the half that matters more: a status that re-resolved would move
+	// LastUpdateCompletedTime under a waiter comparing successive polls, and such a
+	// waiter would never converge.
+	second := configPackStateOf(t, ts, "ops")
+	require.Equal(t, first, second, "a resolved status is identical on every later observation")
+
+	third := configPackStateOf(t, ts, "ops")
+	require.Equal(t, first, third)
+}
+
+func TestConformancePacks_AnUnobservedPackIsStillInProgress(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	// DescribeConformancePacks reports configuration, not state, so it must not resolve
+	// the transition: if it did, a consumer that listed its packs before polling would
+	// never see CREATE_IN_PROGRESS and the in-progress refusals below would be
+	// unreachable.
+	details := configDescribePacks(t, ts, nil)
+	require.Len(t, details, 1)
+	require.NotContains(t, details[0], "ConformancePackState",
+		"ConformancePackDetail has no state member — state lives only on the status shape")
+
+	// A second Put before anything observed the first is ResourceInUseException, which is
+	// the ordering bug a consumer that creates and immediately updates actually hits.
+	status, code, message := configPutPackRaw(t, ts, map[string]any{
+		"ConformancePackName": "ops",
+		"TemplateBody":        `{"Resources":{}}`,
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "ResourceInUseException", code)
+	require.Contains(t, message, "For PutConformancePack and PutOrganizationConformancePack")
+
+	// So is a delete, and its message is the bullet for *its* operation rather than the
+	// Put's — the exception's documentation is a list covering seven unrelated cases.
+	status, code, message = configDeletePack(t, ts, "ops")
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "ResourceInUseException", code)
+	require.Contains(t, message, "For DeleteConformancePack")
+}
+
+func TestConformancePacks_AnUpdateReentersCreateInProgress(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	require.Equal(t, "CREATE_COMPLETE", configPackStateOf(t, ts, "ops")["ConformancePackState"])
+
+	// The enum has no UPDATE_ state, so an update re-enters CREATE_IN_PROGRESS. Reporting
+	// CREATE_COMPLETE straight away would let a waiter return before the update it just
+	// requested had been deployed at all.
+	status, code, message := configPutPackRaw(t, ts, map[string]any{
+		"ConformancePackName": "ops",
+		"TemplateBody":        `{"Resources":{"Updated":{}}}`,
+	})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	details := configDescribePacks(t, ts, nil)
+	require.Len(t, details, 1, "an update does not create a second pack")
+
+	// And the update's own transition resolves on observation, like the create's.
+	require.Equal(t, "CREATE_COMPLETE", configPackStateOf(t, ts, "ops")["ConformancePackState"])
+}
+
+func TestConformancePacks_StatusCarriesEveryRequiredMember(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	detail := configPackStateOf(t, ts, "ops")
+	// All six are Required: Yes on ConformancePackStatusDetail. A consumer decoding a
+	// required member into a non-pointer field gets a zero value rather than an error
+	// when one is missing, so an omission would surface as an empty string in its logs
+	// rather than as a failure.
+	for _, member := range []string{
+		"ConformancePackName", "ConformancePackId", "ConformancePackArn",
+		"ConformancePackState", "StackArn", "LastUpdateRequestedTime",
+	} {
+		require.NotEmpty(t, detail[member], "%s is a required member of ConformancePackStatusDetail", member)
+	}
+
+	// StackArn names a CloudFormation stack substrate does not create — nothing backs it
+	// — but it is required, so a well-formed synthetic ARN is the honest answer. The
+	// awsconfigconforms- prefix is the convention Config uses for pack stacks.
+	stackARN, ok := detail["StackArn"].(string)
+	require.True(t, ok)
+	require.Regexp(t,
+		`^arn:aws:cloudformation:us-east-1:123456789012:stack/awsconfigconforms-ops-[a-z0-9_-]{8}/`+
+			`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`, stackARN)
+}
+
+func TestConformancePacks_IdentifiersAreStableAcrossPuts(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	first := configPutPack(t, ts, "ops")
+	configPackStateOf(t, ts, "ops")
+	second := configPutPack(t, ts, "ops")
+
+	// The ID is derived from account, Region and name rather than drawn from a clock or
+	// a random source, so replaying the same event stream mints the same ARN. An update
+	// keeps it, which is what lets a fixture assert an ARN it captured earlier.
+	require.Equal(t, first, second, "an update does not re-mint the pack's ARN")
+}
+
+func TestConformancePacks_DescribeRefusesAnUnknownNameButStatusDoesNot(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	// DescribeConformancePacks declares NoSuchConformancePackException; a name matching
+	// nothing refuses the whole call.
+	resp := configRequest(t, ts, "DescribeConformancePacks", map[string]any{
+		"ConformancePackNames": []string{"absent"},
+	})
+	status, code, _ := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "NoSuchConformancePackException", code)
+
+	// DescribeConformancePackStatus does not declare it at all — "If there are no
+	// conformance packs then you will see an empty result" — so the same name is an
+	// empty list. Answering the two the same way would send a consumer down a branch
+	// one of them has not got.
+	require.Empty(t, configPackStatus(t, ts, map[string]any{
+		"ConformancePackNames": []string{"absent"},
+	}))
+
+	// A mixed request refuses on the missing one rather than silently returning the
+	// packs that do exist.
+	resp = configRequest(t, ts, "DescribeConformancePacks", map[string]any{
+		"ConformancePackNames": []string{"ops", "absent"},
+	})
+	status, code, _ = decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "NoSuchConformancePackException", code)
+}
+
+func TestConformancePacks_ExactlyOneTemplateSourceIsRequired(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	cases := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "none",
+			body: map[string]any{"ConformancePackName": "ops"},
+		},
+		{
+			name: "body and s3 uri",
+			body: map[string]any{
+				"ConformancePackName": "ops",
+				"TemplateBody":        `{"Resources":{}}`,
+				"TemplateS3Uri":       "s3://templates/ops.yaml",
+			},
+		},
+		{
+			name: "body and ssm document",
+			body: map[string]any{
+				"ConformancePackName":        "ops",
+				"TemplateBody":               `{"Resources":{}}`,
+				"TemplateSSMDocumentDetails": map[string]any{"DocumentName": "ops-pack"},
+			},
+		},
+		{
+			name: "all three",
+			body: map[string]any{
+				"ConformancePackName":        "ops",
+				"TemplateBody":               `{"Resources":{}}`,
+				"TemplateS3Uri":              "s3://templates/ops.yaml",
+				"TemplateSSMDocumentDetails": map[string]any{"DocumentName": "ops-pack"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			status, code, message := configPutPackRaw(t, ts, tc.body)
+			require.Equal(t, http.StatusBadRequest, status)
+			require.Equal(t, "InvalidParameterValueException", code)
+			// AWS's own sentence, its "the follow" typo included, so a consumer matching on
+			// message text matches.
+			require.Contains(t, message, "You must specify only one of the follow parameters")
+		})
+	}
+}
+
+func TestConformancePacks_EachTemplateSourceIsAcceptedOnItsOwn(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "template body",
+			body: map[string]any{"TemplateBody": `{"Resources":{}}`},
+		},
+		{
+			name: "s3 uri",
+			body: map[string]any{"TemplateS3Uri": "s3://templates/ops.yaml"},
+		},
+		{
+			name: "ssm document",
+			body: map[string]any{
+				"TemplateSSMDocumentDetails": map[string]any{
+					"DocumentName":    "ops-pack",
+					"DocumentVersion": "$LATEST",
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := emulator.StartTestServer(t)
+			body := map[string]any{"ConformancePackName": "ops"}
+			for k, v := range tc.body {
+				body[k] = v
+			}
+			// Accepting each source is worth asserting on its own: refusing one AWS permits
+			// would break a working template, which is the worse failure of the two.
+			status, code, message := configPutPackRaw(t, ts, body)
+			require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+		})
+	}
+}
+
+func TestConformancePacks_PutRefusals(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		body    map[string]any
+		code    string
+		message string
+	}{
+		{
+			name: "no name",
+			body: map[string]any{"TemplateBody": `{"Resources":{}}`},
+			code: "InvalidParameterValueException",
+		},
+		{
+			name: "name starting with a digit",
+			body: map[string]any{"ConformancePackName": "1ops", "TemplateBody": `{"Resources":{}}`},
+			code: "InvalidParameterValueException",
+		},
+		{
+			name: "name with an underscore",
+			body: map[string]any{"ConformancePackName": "ops_pack", "TemplateBody": `{"Resources":{}}`},
+			code: "InvalidParameterValueException",
+		},
+		{
+			name: "name over 256 characters",
+			body: map[string]any{
+				"ConformancePackName": "o" + strings.Repeat("p", 256),
+				"TemplateBody":        `{"Resources":{}}`,
+			},
+			code: "InvalidParameterValueException",
+		},
+		{
+			name: "a template s3 uri that is not an s3 uri",
+			body: map[string]any{
+				"ConformancePackName": "ops",
+				"TemplateS3Uri":       "https://templates.example/ops.yaml",
+			},
+			// The pattern is the *template's* problem, so the model's own template exception
+			// answers rather than the generic input one.
+			code:    "ConformancePackTemplateValidationException",
+			message: "You have specified a template that is not valid or supported.",
+		},
+		{
+			name: "a template body over 51200 bytes",
+			body: map[string]any{
+				"ConformancePackName": "ops",
+				"TemplateBody":        strings.Repeat("x", 51201),
+			},
+			code: "ConformancePackTemplateValidationException",
+		},
+		{
+			name: "an ssm document name too short for the pattern",
+			body: map[string]any{
+				"ConformancePackName":        "ops",
+				"TemplateSSMDocumentDetails": map[string]any{"DocumentName": "op"},
+			},
+			code: "InvalidParameterValueException",
+		},
+		{
+			name: "an ssm document version that is neither a keyword nor a number",
+			body: map[string]any{
+				"ConformancePackName": "ops",
+				"TemplateSSMDocumentDetails": map[string]any{
+					"DocumentName":    "ops-pack",
+					"DocumentVersion": "latest",
+				},
+			},
+			code: "InvalidParameterValueException",
+		},
+		{
+			name: "a delivery bucket over 63 characters",
+			body: map[string]any{
+				"ConformancePackName": "ops",
+				"TemplateBody":        `{"Resources":{}}`,
+				"DeliveryS3Bucket":    strings.Repeat("b", 64),
+			},
+			code: "InvalidParameterValueException",
+		},
+		{
+			name: "a delivery key prefix over 1024 characters",
+			body: map[string]any{
+				"ConformancePackName": "ops",
+				"TemplateBody":        `{"Resources":{}}`,
+				"DeliveryS3KeyPrefix": strings.Repeat("p", 1025),
+			},
+			code: "InvalidParameterValueException",
+		},
+		{
+			name: "an input parameter with no name",
+			body: map[string]any{
+				"ConformancePackName": "ops",
+				"TemplateBody":        `{"Resources":{}}`,
+				"ConformancePackInputParameters": []map[string]any{
+					{"ParameterValue": "v"},
+				},
+			},
+			code: "InvalidParameterValueException",
+		},
+		{
+			name: "an input parameter value over 4096 characters",
+			body: map[string]any{
+				"ConformancePackName": "ops",
+				"TemplateBody":        `{"Resources":{}}`,
+				"ConformancePackInputParameters": []map[string]any{
+					{"ParameterName": "n", "ParameterValue": strings.Repeat("v", 4097)},
+				},
+			},
+			code: "InvalidParameterValueException",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := emulator.StartTestServer(t)
+			status, code, message := configPutPackRaw(t, ts, tc.body)
+			// Every AWS Config exception is HTTP 400, the not-found ones included, so a
+			// consumer matches on the code rather than the status.
+			require.Equal(t, http.StatusBadRequest, status)
+			require.Equal(t, tc.code, code, message)
+			if tc.message != "" {
+				require.Contains(t, message, tc.message)
+			}
+		})
+	}
+}
+
+func TestConformancePacks_InputParametersAreAcceptedUpToSixty(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	params := make([]map[string]any, 0, 61)
+	for i := range 60 {
+		params = append(params, map[string]any{
+			"ParameterName":  fmt.Sprintf("p%02d", i),
+			"ParameterValue": "v",
+		})
+	}
+	// Accepting the model's own maximum matters as much as refusing 61: a narrower cap
+	// would refuse a request AWS permits, and a fixture with a large parameterised pack
+	// would fail for a reason that is substrate's alone.
+	status, code, message := configPutPackRaw(t, ts, map[string]any{
+		"ConformancePackName":            "ops",
+		"TemplateBody":                   `{"Resources":{}}`,
+		"ConformancePackInputParameters": params,
+	})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	status, code, _ = configPutPackRaw(t, ts, map[string]any{
+		"ConformancePackName": "big",
+		"TemplateBody":        `{"Resources":{}}`,
+		"ConformancePackInputParameters": append(params, map[string]any{
+			"ParameterName": "p60", "ParameterValue": "v",
+		}),
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValueException", code)
+}
+
+func TestConformancePacks_DetailReportsWhatWasSubmittedAndNoTemplate(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	status, code, message := configPutPackRaw(t, ts, map[string]any{
+		"ConformancePackName": "ops",
+		"TemplateBody":        `{"Resources":{"Rule":{}}}`,
+		"DeliveryS3Bucket":    "cfg-packs",
+		"DeliveryS3KeyPrefix": "ops/",
+		"ConformancePackInputParameters": []map[string]any{
+			{"ParameterName": "MaxAge", "ParameterValue": "90"},
+		},
+	})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	details := configDescribePacks(t, ts, nil)
+	require.Len(t, details, 1)
+	detail := details[0]
+	require.Equal(t, "ops", detail["ConformancePackName"])
+	require.Equal(t, "cfg-packs", detail["DeliveryS3Bucket"])
+	require.Equal(t, "ops/", detail["DeliveryS3KeyPrefix"])
+	require.Len(t, detail["ConformancePackInputParameters"], 1)
+
+	// Neither ConformancePackDetail nor the status shape has a template member, so the
+	// template a caller submitted is recorded intent it cannot read back. Emitting it
+	// would be an invention no SDK field would receive.
+	require.NotContains(t, detail, "TemplateBody")
+	require.NotContains(t, detail, "TemplateS3Uri")
+	// CreatedBy names the AWS service that created a service-managed pack; substrate
+	// models none, so reporting a value would claim a caller's pack was service-created.
+	require.NotContains(t, detail, "CreatedBy")
+}
+
+func TestConformancePacks_LimitIsBoundedAtTwentyWithInvalidLimitException(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	cases := []struct {
+		operation string
+		limit     int
+		code      string
+	}{
+		// PageSizeLimit's Valid Range is 0-20 for these three, so 20 must be accepted: a
+		// narrower ceiling would refuse a page size AWS serves.
+		{"DescribeConformancePacks", 20, ""},
+		{"DescribeConformancePacks", 21, "InvalidLimitException"},
+		{"DescribeConformancePacks", -1, "InvalidLimitException"},
+		{"DescribeConformancePackStatus", 20, ""},
+		{"DescribeConformancePackStatus", 21, "InvalidLimitException"},
+		// DescribeConformancePackCompliance's own ceiling is 1000, a different bound on the
+		// same service — collapsing the two onto one number would let a fixture page in
+		// units one of the operations refuses.
+		{"DescribeConformancePackCompliance", 1000, ""},
+		{"DescribeConformancePackCompliance", 1001, "InvalidLimitException"},
+		{"GetConformancePackComplianceSummary", 20, ""},
+		{"GetConformancePackComplianceSummary", 21, "InvalidLimitException"},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s/%d", tc.operation, tc.limit), func(t *testing.T) {
+			t.Parallel()
+			body := map[string]any{"Limit": tc.limit}
+			switch tc.operation {
+			case "DescribeConformancePackCompliance":
+				body["ConformancePackName"] = "ops"
+			case "GetConformancePackComplianceSummary":
+				body["ConformancePackNames"] = []string{"ops"}
+			}
+			resp := configRequest(t, ts, tc.operation, body)
+			status, code, message := decodeConfigResponse(t, resp, nil)
+			if tc.code == "" {
+				require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+				return
+			}
+			// The rule cluster answers InvalidParameterValueException for the same complaint
+			// because none of its operations declares InvalidLimitException, while all four
+			// here do. A caller's handling is written against the codes its operation declares.
+			require.Equal(t, http.StatusBadRequest, status)
+			require.Equal(t, tc.code, code)
+			require.Equal(t, "The specified limit is outside the allowable range.", message)
+		})
+	}
+}
+
+func TestConformancePacks_PaginationWalksEveryPack(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	for i := range 25 {
+		configPutPack(t, ts, fmt.Sprintf("pack-%02d", i))
+	}
+
+	seen := map[string]bool{}
+	token := ""
+	for pages := 0; pages < 10; pages++ {
+		body := map[string]any{"Limit": 20}
+		if token != "" {
+			body["NextToken"] = token
+		}
+		resp := configRequest(t, ts, "DescribeConformancePacks", body)
+		var out struct {
+			ConformancePackDetails []map[string]any `json:"ConformancePackDetails"`
+			NextToken              string           `json:"NextToken"`
+		}
+		status, code, message := decodeConfigResponse(t, resp, &out)
+		require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+		require.LessOrEqual(t, len(out.ConformancePackDetails), 20, "a page never exceeds the cap")
+		for _, detail := range out.ConformancePackDetails {
+			name, ok := detail["ConformancePackName"].(string)
+			require.True(t, ok)
+			require.False(t, seen[name], "%s appears on two pages", name)
+			seen[name] = true
+		}
+		token = out.NextToken
+		if token == "" {
+			break
+		}
+	}
+	require.Equal(t, "", token, "the walk terminates")
+	require.Len(t, seen, 25, "every pack is reported exactly once across the pages")
+}
+
+func TestConformancePacks_ABadNextTokenIsRefused(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	for _, operation := range []string{"DescribeConformancePacks", "DescribeConformancePackStatus"} {
+		t.Run(operation, func(t *testing.T) {
+			t.Parallel()
+			resp := configRequest(t, ts, operation, map[string]any{"NextToken": "not-a-token!!"})
+			status, code, _ := decodeConfigResponse(t, resp, nil)
+			require.Equal(t, http.StatusBadRequest, status)
+			require.Equal(t, "InvalidNextTokenException", code)
+		})
+	}
+}
+
+func TestConformancePacks_NameFiltersAreBounded(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	names := make([]string, 0, 26)
+	for i := range 26 {
+		names = append(names, fmt.Sprintf("pack-%02d", i))
+	}
+	resp := configRequest(t, ts, "DescribeConformancePacks", map[string]any{
+		"ConformancePackNames": names,
+	})
+	status, code, _ := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValueException", code)
+}
+
+func TestConformancePacks_TheSummaryRequiresBetweenOneAndFiveNames(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	for i := range 6 {
+		configPutPack(t, ts, fmt.Sprintf("pack-%d", i))
+	}
+
+	// ConformancePackNames is Required: Yes with Array Members 1-5 here, unlike the
+	// describe operations' optional 0-25 — the summary cannot be asked for every pack.
+	resp := configRequest(t, ts, "GetConformancePackComplianceSummary", map[string]any{})
+	status, code, _ := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValueException", code)
+
+	resp = configRequest(t, ts, "GetConformancePackComplianceSummary", map[string]any{
+		"ConformancePackNames": []string{"pack-0", "pack-1", "pack-2", "pack-3", "pack-4", "pack-5"},
+	})
+	status, code, _ = decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValueException", code)
+
+	// Five is the model's own maximum and must be served.
+	summaries := configPackSummary(t, ts, []string{"pack-0", "pack-1", "pack-2", "pack-3", "pack-4"})
+	require.Len(t, summaries, 5)
+}
+
+func TestConformancePacks_TheSummaryRefusesAnUnknownPack(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	resp := configRequest(t, ts, "GetConformancePackComplianceSummary", map[string]any{
+		"ConformancePackNames": []string{"ops", "absent"},
+	})
+	status, code, _ := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "NoSuchConformancePackException", code)
+}
+
+func TestConformancePacks_ComplianceDefaultsToInsufficientData(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	// Substrate deploys no template and evaluates no rules, so an unseeded pack reports
+	// nothing and summarizes as INSUFFICIENT_DATA — the verdict AWS gives a pack that has
+	// not evaluated. A fabricated COMPLIANT would make every compliance assertion in
+	// every consumer's suite pass for free.
+	require.Empty(t, configPackCompliance(t, ts, map[string]any{"ConformancePackName": "ops"}))
+
+	summaries := configPackSummary(t, ts, []string{"ops"})
+	require.Len(t, summaries, 1)
+	require.Equal(t, "INSUFFICIENT_DATA", summaries[0]["ConformancePackComplianceStatus"])
+}
+
+func TestConformancePacks_SeededComplianceIsReportedAndSummarized(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	configSeedPackCompliance(t, ts, "ops", []map[string]any{
+		{"configRuleName": "iam-password-policy", "complianceType": "COMPLIANT",
+			"controls": []string{"CIS 1.5"}},
+		{"configRuleName": "s3-encrypted", "complianceType": "NON_COMPLIANT"},
+	})
+
+	list := configPackCompliance(t, ts, map[string]any{"ConformancePackName": "ops"})
+	require.Len(t, list, 2)
+	byName := map[string]map[string]any{}
+	for _, entry := range list {
+		name, ok := entry["ConfigRuleName"].(string)
+		require.True(t, ok)
+		byName[name] = entry
+	}
+	require.Equal(t, "COMPLIANT", byName["iam-password-policy"]["ComplianceType"])
+	require.Equal(t, []any{"CIS 1.5"}, byName["iam-password-policy"]["Controls"])
+	require.Equal(t, "NON_COMPLIANT", byName["s3-encrypted"]["ComplianceType"])
+	require.NotContains(t, byName["s3-encrypted"], "Controls", "Controls is optional")
+
+	// The summary is derived from these same verdicts rather than seeded separately, so
+	// the two cannot disagree — a consumer that reads the summary and then drills into
+	// the rules gets one story.
+	summaries := configPackSummary(t, ts, []string{"ops"})
+	require.Equal(t, "NON_COMPLIANT", summaries[0]["ConformancePackComplianceStatus"])
+}
+
+func TestConformancePacks_TheCumulativeVerdictRanksNonCompliantHighest(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		rules   []map[string]any
+		verdict string
+	}{
+		{
+			name:    "no rules",
+			rules:   []map[string]any{},
+			verdict: "INSUFFICIENT_DATA",
+		},
+		{
+			name: "all compliant",
+			rules: []map[string]any{
+				{"configRuleName": "a", "complianceType": "COMPLIANT"},
+				{"configRuleName": "b", "complianceType": "COMPLIANT"},
+			},
+			verdict: "COMPLIANT",
+		},
+		{
+			name: "one unevaluated",
+			rules: []map[string]any{
+				{"configRuleName": "a", "complianceType": "COMPLIANT"},
+				{"configRuleName": "b", "complianceType": "INSUFFICIENT_DATA"},
+			},
+			verdict: "INSUFFICIENT_DATA",
+		},
+		{
+			name: "one failure alongside an unevaluated rule",
+			rules: []map[string]any{
+				{"configRuleName": "a", "complianceType": "INSUFFICIENT_DATA"},
+				{"configRuleName": "b", "complianceType": "NON_COMPLIANT"},
+			},
+			// A known failure outranks an unknown: a pack with something wrong in it is not
+			// "we don't know yet", and reporting INSUFFICIENT_DATA would let a consumer
+			// treating unknown as "wait and retry" loop past a real problem.
+			verdict: "NON_COMPLIANT",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := emulator.StartTestServer(t)
+			configPutPack(t, ts, "ops")
+			configSeedPackCompliance(t, ts, "ops", tc.rules)
+			summaries := configPackSummary(t, ts, []string{"ops"})
+			require.Len(t, summaries, 1)
+			require.Equal(t, tc.verdict, summaries[0]["ConformancePackComplianceStatus"])
+		})
+	}
+}
+
+func TestConformancePacks_TheComplianceSeedRefusesNotApplicable(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	// NOT_APPLICABLE is a rule-level ComplianceType but is absent from
+	// ConformancePackComplianceType, so storing one would make this cluster report a
+	// value no SDK enum member matches — a caller's switch would fall through to its
+	// default and the test would pass while asserting nothing.
+	status, body := configSeedRaw(t, ts, "/v1/config/pack-compliance/ops", map[string]any{
+		"rules": []map[string]any{
+			{"configRuleName": "a", "complianceType": "NOT_APPLICABLE"},
+		},
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "NOT_APPLICABLE")
+}
+
+func TestConformancePacks_TheComplianceSeedRefusesADuplicateRule(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	// Two verdicts for one rule name would make the reported one depend on map iteration
+	// order, which is precisely the nondeterminism this emulator exists to remove.
+	status, body := configSeedRaw(t, ts, "/v1/config/pack-compliance/ops", map[string]any{
+		"rules": []map[string]any{
+			{"configRuleName": "a", "complianceType": "COMPLIANT"},
+			{"configRuleName": "a", "complianceType": "NON_COMPLIANT"},
+		},
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "appears twice")
+}
+
+func TestConformancePacks_TheComplianceSeedRefusalsAreReadable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body map[string]any
+		want string
+	}{
+		{
+			name: "a rule with no name",
+			body: map[string]any{"rules": []map[string]any{{"complianceType": "COMPLIANT"}}},
+			want: "configRuleName",
+		},
+		{
+			name: "a rule name over 128 characters",
+			body: map[string]any{"rules": []map[string]any{
+				{"configRuleName": strings.Repeat("r", 129), "complianceType": "COMPLIANT"},
+			}},
+			want: "configRuleName",
+		},
+		{
+			name: "no compliance type",
+			body: map[string]any{"rules": []map[string]any{{"configRuleName": "a"}}},
+			want: "ConformancePackComplianceType",
+		},
+		{
+			name: "more than twenty controls",
+			body: map[string]any{"rules": []map[string]any{
+				{"configRuleName": "a", "complianceType": "COMPLIANT",
+					"controls": sliceOfN("c", 21)},
+			}},
+			want: "controls",
+		},
+		{
+			name: "an empty control",
+			body: map[string]any{"rules": []map[string]any{
+				{"configRuleName": "a", "complianceType": "COMPLIANT", "controls": []string{""}},
+			}},
+			want: "control",
+		},
+		{
+			name: "a body that is not an object",
+			body: nil,
+			want: "cannot unmarshal",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := emulator.StartTestServer(t)
+			var body any = tc.body
+			if tc.body == nil {
+				body = "not-a-seed-object"
+			}
+			status, response := configSeedRaw(t, ts, "/v1/config/pack-compliance/ops", body)
+			require.Equal(t, http.StatusBadRequest, status)
+			// A refusal a fixture author cannot read is a refusal they will work around by
+			// guessing, so the message names what was wrong and the body is valid JSON.
+			require.Contains(t, response, tc.want)
+			require.Contains(t, response, `"error"`)
+		})
+	}
+}
+
+func TestConformancePacks_ASeedContradictingItsPathIsRefused(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	for _, path := range []string{"/v1/config/pack-status/ops", "/v1/config/pack-compliance/ops"} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			// The path names the pack, so a body naming a different one is a contradiction
+			// rather than an override: honoring either would leave the caller unable to tell
+			// which pack it seeded.
+			status, response := configSeedRaw(t, ts, path, map[string]any{
+				"conformancePackName": "other",
+				"state":               "CREATE_FAILED",
+				"rules":               []map[string]any{},
+			})
+			require.Equal(t, http.StatusBadRequest, status)
+			require.Contains(t, response, "contradicts")
+		})
+	}
+}
+
+func TestConformancePacks_ExactRuleNamesAreRequiredInAFilter(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	configSeedPackCompliance(t, ts, "ops", []map[string]any{
+		{"configRuleName": "s3-encrypted", "complianceType": "NON_COMPLIANT"},
+		{"configRuleName": "iam-password-policy", "complianceType": "COMPLIANT"},
+	})
+
+	// "You must provide exact rule names." A filter naming a rule the pack does not
+	// report is a refusal rather than an empty list, so a typo in a fixture is caught
+	// instead of silently passing as "nothing matched".
+	resp := configRequest(t, ts, "DescribeConformancePackCompliance", map[string]any{
+		"ConformancePackName": "ops",
+		"Filters":             map[string]any{"ConfigRuleNames": []string{"s3-encrypted", "typo"}},
+	})
+	status, code, _ := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "NoSuchConfigRuleInConformancePackException", code)
+
+	// An exact name filters as expected.
+	list := configPackCompliance(t, ts, map[string]any{
+		"ConformancePackName": "ops",
+		"Filters":             map[string]any{"ConfigRuleNames": []string{"s3-encrypted"}},
+	})
+	require.Len(t, list, 1)
+	require.Equal(t, "s3-encrypted", list[0]["ConfigRuleName"])
+}
+
+func TestConformancePacks_TheComplianceFilterExcludesInsufficientData(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	configSeedPackCompliance(t, ts, "ops", []map[string]any{
+		{"configRuleName": "a", "complianceType": "COMPLIANT"},
+		{"configRuleName": "b", "complianceType": "NON_COMPLIANT"},
+		{"configRuleName": "c", "complianceType": "INSUFFICIENT_DATA"},
+	})
+
+	// The response carries INSUFFICIENT_DATA — it is in the enum the shape declares.
+	list := configPackCompliance(t, ts, map[string]any{"ConformancePackName": "ops"})
+	require.Len(t, list, 3)
+
+	// But the *filter* does not: "The allowed values are COMPLIANT and NON_COMPLIANT.
+	// INSUFFICIENT_DATA is not supported." Accepting it would answer with an empty list
+	// where AWS answers with an error, so a fixture would read "no rules match" instead
+	// of "you cannot ask that".
+	resp := configRequest(t, ts, "DescribeConformancePackCompliance", map[string]any{
+		"ConformancePackName": "ops",
+		"Filters":             map[string]any{"ComplianceType": "INSUFFICIENT_DATA"},
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValueException", code)
+	require.Contains(t, message, "INSUFFICIENT_DATA is not supported")
+
+	// NOT_APPLICABLE is not in the pack enum at all, so it is refused for that reason
+	// rather than as an unsupported filter.
+	resp = configRequest(t, ts, "DescribeConformancePackCompliance", map[string]any{
+		"ConformancePackName": "ops",
+		"Filters":             map[string]any{"ComplianceType": "NOT_APPLICABLE"},
+	})
+	status, code, _ = decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValueException", code)
+
+	// The two values the filter does accept work.
+	for _, verdict := range []string{"COMPLIANT", "NON_COMPLIANT"} {
+		list = configPackCompliance(t, ts, map[string]any{
+			"ConformancePackName": "ops",
+			"Filters":             map[string]any{"ComplianceType": verdict},
+		})
+		require.Len(t, list, 1)
+		require.Equal(t, verdict, list[0]["ComplianceType"])
+	}
+}
+
+func TestConformancePacks_TheRuleNameFilterIsBoundedAtTenAndSixtyFour(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	cases := []struct {
+		name  string
+		names []string
+	}{
+		{name: "eleven rule names", names: sliceOfN("rule-", 11)},
+		{name: "a name over 64 characters", names: []string{strings.Repeat("r", 65)}},
+		{name: "an empty name", names: []string{""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := configRequest(t, ts, "DescribeConformancePackCompliance", map[string]any{
+				"ConformancePackName": "ops",
+				"Filters":             map[string]any{"ConfigRuleNames": tc.names},
+			})
+			status, code, _ := decodeConfigResponse(t, resp, nil)
+			// The filter's per-name ceiling is 64, not the 128 a ConfigRuleName carries
+			// elsewhere: a rule named longer than 64 can be reported by this operation but
+			// not filtered for by it. The asymmetry is the model's.
+			require.Equal(t, http.StatusBadRequest, status)
+			require.Equal(t, "InvalidParameterValueException", code)
+		})
+	}
+}
+
+func TestConformancePacks_ComplianceRefusesAnUnknownPack(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	resp := configRequest(t, ts, "DescribeConformancePackCompliance", map[string]any{
+		"ConformancePackName": "absent",
+	})
+	status, code, _ := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "NoSuchConformancePackException", code)
+}
+
+func TestConformancePacks_ASeededFailureStatePersistsAndIsClearable(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	configSeed(t, ts, "/v1/config/pack-status/ops", map[string]any{
+		"state":        "CREATE_FAILED",
+		"statusReason": "the template declares an unsupported resource",
+	})
+
+	// Substrate deploys no stack, so a pack it created always completes and a consumer's
+	// CREATE_FAILED branch — the branch that reports a bad template to its author — is
+	// unreachable without this seed.
+	first := configPackStateOf(t, ts, "ops")
+	require.Equal(t, "CREATE_FAILED", first["ConformancePackState"])
+	require.Equal(t, "the template declares an unsupported resource", first["ConformancePackStatusReason"])
+
+	// A seeded state is stable across polls for the same reason a resolved one is.
+	require.Equal(t, first, configPackStateOf(t, ts, "ops"))
+
+	// Clearing restores the real state, because the seed is applied when the status is
+	// read rather than written into the record. A seed that baked itself in would leave a
+	// fixture unable to get back to the nominal path without deleting the pack.
+	configClearSeed(t, ts, "/v1/config/pack-status/ops")
+	require.Equal(t, "CREATE_COMPLETE", configPackStateOf(t, ts, "ops")["ConformancePackState"])
+}
+
+func TestConformancePacks_ASeededFailureIsStillDeletable(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	configSeed(t, ts, "/v1/config/pack-status/ops", map[string]any{"state": "CREATE_FAILED"})
+
+	// CREATE_FAILED is terminal, so the delete goes through even though what is *stored*
+	// still says CREATE_IN_PROGRESS — the record was never rewritten. A delete that read
+	// the stored field instead would leave a failed pack undeletable, which is the state
+	// a consumer most needs to clean up.
+	status, code, message := configDeletePack(t, ts, "ops")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	require.Empty(t, configDescribePacks(t, ts, nil))
+}
+
+func TestConformancePacks_ASeededInProgressStateBlocksAPut(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	require.Equal(t, "CREATE_COMPLETE", configPackStateOf(t, ts, "ops")["ConformancePackState"])
+	configSeed(t, ts, "/v1/config/pack-status/ops", map[string]any{"state": "DELETE_IN_PROGRESS"})
+
+	// The seed is what makes DELETE_IN_PROGRESS observable at all: substrate's delete
+	// completes within the call, so no stored pack ever holds that state. A consumer whose
+	// teardown races its rebuild needs the refusal to be reachable.
+	status, code, _ := configPutPackRaw(t, ts, map[string]any{
+		"ConformancePackName": "ops",
+		"TemplateBody":        `{"Resources":{}}`,
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "ResourceInUseException", code)
+
+	status, code, _ = configDeletePack(t, ts, "ops")
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "ResourceInUseException", code)
+}
+
+func TestConformancePacks_TheStatusSeedRefusalsAreReadable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body map[string]any
+		want string
+	}{
+		{
+			name: "no state",
+			body: map[string]any{},
+			want: "state is required",
+		},
+		{
+			name: "a state outside the enum",
+			body: map[string]any{"state": "UPDATE_COMPLETE"},
+			want: "ConformancePackState",
+		},
+		{
+			name: "delete complete, which the enum does not carry",
+			body: map[string]any{"state": "DELETE_COMPLETE"},
+			want: "ConformancePackState",
+		},
+		{
+			name: "a status reason on a state that is not a failure",
+			body: map[string]any{"state": "CREATE_COMPLETE", "statusReason": "all good"},
+			// A reason on a non-failure state would be dropped by every consumer that reads it
+			// only on failure, so the seed is refused rather than half-applied.
+			want: "CREATE_FAILED or DELETE_FAILED",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := emulator.StartTestServer(t)
+			status, response := configSeedRaw(t, ts, "/v1/config/pack-status/ops", tc.body)
+			require.Equal(t, http.StatusBadRequest, status)
+			require.Contains(t, response, tc.want)
+			require.Contains(t, response, `"error"`)
+		})
+	}
+}
+
+func TestConformancePacks_AWildcardSeedCoversEveryPack(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	configPutPack(t, ts, "security")
+	configSeed(t, ts, "/v1/config/pack-status/*", map[string]any{"state": "CREATE_FAILED"})
+
+	// A fixture that does not enumerate its pack names — because a stack chose them —
+	// still needs to assert "nothing deployed", which is what the wildcard is for.
+	for _, name := range []string{"ops", "security"} {
+		require.Equal(t, "CREATE_FAILED", configPackStateOf(t, ts, name)["ConformancePackState"])
+	}
+
+	// A named seed beats the wildcard: pack name is the more specific axis, so a fixture
+	// that fails everything but completes one pack gets what it asked for.
+	configSeed(t, ts, "/v1/config/pack-status/ops", map[string]any{"state": "CREATE_COMPLETE"})
+	require.Equal(t, "CREATE_COMPLETE", configPackStateOf(t, ts, "ops")["ConformancePackState"])
+	require.Equal(t, "CREATE_FAILED", configPackStateOf(t, ts, "security")["ConformancePackState"])
+}
+
+func TestConformancePacks_DeleteRemovesThePackAndItsSeeds(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	configPackStateOf(t, ts, "ops")
+	configSeedPackCompliance(t, ts, "ops", []map[string]any{
+		{"configRuleName": "s3-encrypted", "complianceType": "NON_COMPLIANT"},
+	})
+	configSeed(t, ts, "/v1/config/pack-status/ops", map[string]any{"state": "CREATE_FAILED"})
+
+	status, code, message := configDeletePack(t, ts, "ops")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	require.Empty(t, configDescribePacks(t, ts, nil))
+	require.Empty(t, configPackStatus(t, ts, nil))
+
+	// A rebuilt pack of the same name starts clean. Inheriting its predecessor's verdict
+	// would make a teardown-and-rebuild fixture — a test run repeated twice — report the
+	// first run's compliance on the second.
+	configPutPack(t, ts, "ops")
+	require.Equal(t, "CREATE_COMPLETE", configPackStateOf(t, ts, "ops")["ConformancePackState"])
+	require.Empty(t, configPackCompliance(t, ts, map[string]any{"ConformancePackName": "ops"}))
+	summaries := configPackSummary(t, ts, []string{"ops"})
+	require.Equal(t, "INSUFFICIENT_DATA", summaries[0]["ConformancePackComplianceStatus"])
+}
+
+func TestConformancePacks_DeleteLeavesTheWildcardSeedsAlone(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	configPutPack(t, ts, "security")
+	configSeed(t, ts, "/v1/config/pack-status/*", map[string]any{"state": "CREATE_FAILED"})
+
+	status, code, message := configDeletePack(t, ts, "ops")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	// A wildcard is a fixture-wide default rather than one pack's state, so deleting a
+	// pack must not silently change what every other pack reports.
+	require.Equal(t, "CREATE_FAILED", configPackStateOf(t, ts, "security")["ConformancePackState"])
+}
+
+func TestConformancePacks_DeleteAnswersAnEmptyBody(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+	configPackStateOf(t, ts, "ops")
+
+	resp := configRequest(t, ts, "DeleteConformancePack", map[string]any{"ConformancePackName": "ops"})
+	var out map[string]any
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	// DeleteConformancePack has no output shape at all: "the service sends back an HTTP
+	// 200 response with an empty HTTP body." Inventing a member would give a consumer
+	// something to read that AWS never sends.
+	require.Empty(t, out)
+}
+
+func TestConformancePacks_DeleteRefusesAnUnknownPack(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	status, code, _ := configDeletePack(t, ts, "absent")
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "NoSuchConformancePackException", code)
+}
+
+func TestConformancePacks_TheAccountCapIsFifty(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	for i := range 50 {
+		configPutPack(t, ts, fmt.Sprintf("pack-%02d", i))
+	}
+
+	// The Service Limits page gives 50 and marks it not adjustable, so the fiftieth must
+	// be accepted and the fifty-first refused.
+	status, code, message := configPutPackRaw(t, ts, map[string]any{
+		"ConformancePackName": "one-too-many",
+		"TemplateBody":        `{"Resources":{}}`,
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "MaxNumberOfConformancePacksExceededException", code)
+	require.Contains(t, message, "Service Limits")
+
+	// An update of an existing pack is not a new pack, so it is not refused at the cap —
+	// a consumer at its limit can still change what it has.
+	configPackStateOf(t, ts, "pack-00")
+	status, code, message = configPutPackRaw(t, ts, map[string]any{
+		"ConformancePackName": "pack-00",
+		"TemplateBody":        `{"Resources":{"Updated":{}}}`,
+	})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+}
+
+func TestConformancePacks_AreIsolatedByRegion(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+	configPutPack(t, ts, "ops")
+
+	// "Recording in one Region only" is the misconfiguration this service exists to make
+	// visible, so every key here is regional and a pack created in one Region must be
+	// absent from another.
+	require.Empty(t, configPackStatusIn(t, ts, "eu-west-1", nil))
+
+	// An empty listing is not on its own proof of isolation: the name index could be
+	// regional while the records it points at are not, and the assertion above would
+	// still pass. So put a pack of the *same name* in the second Region and require each
+	// to report its own — with a shared record the second Put would silently edit the
+	// first Region's pack, and its ARN would name the wrong Region.
+	resp := configRequestIn(t, ts, "eu-west-1", "PutConformancePack", map[string]any{
+		"ConformancePackName": "ops",
+		"TemplateBody":        `{"Resources":{}}`,
+	})
+	var out struct {
+		ConformancePackArn string `json:"ConformancePackArn"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	require.Contains(t, out.ConformancePackArn, ":eu-west-1:")
+
+	east := configPackStateOf(t, ts, "ops")
+	require.Contains(t, east["ConformancePackArn"], ":us-east-1:")
+	west := configPackStatusIn(t, ts, "eu-west-1", map[string]any{
+		"ConformancePackNames": []string{"ops"},
+	})
+	require.Len(t, west, 1)
+	require.Contains(t, west[0]["ConformancePackArn"], ":eu-west-1:")
+	require.NotEqual(t, east["ConformancePackId"], west[0]["ConformancePackId"],
+		"the minted ID is derived from the Region, so the two packs are distinct")
+
+	// Seed keys carry the Region too, so a seed scoped to one Region must not report its
+	// verdict as the other's. (An unscoped seed is the "*"/"*" wildcard and would reach
+	// both by design, which is what the wildcard test asserts.)
+	configSeed(t, ts, "/v1/config/pack-compliance/ops", map[string]any{
+		"accountId": "123456789012",
+		"region":    "us-east-1",
+		"rules": []map[string]any{
+			{"configRuleName": "s3-encrypted", "complianceType": "NON_COMPLIANT"},
+		},
+	})
+	require.Len(t, configPackCompliance(t, ts, map[string]any{"ConformancePackName": "ops"}), 1,
+		"the seed reaches the Region it names")
+	resp = configRequestIn(t, ts, "eu-west-1", "DescribeConformancePackCompliance", map[string]any{
+		"ConformancePackName": "ops",
+	})
+	var westCompliance struct {
+		ConformancePackRuleComplianceList []map[string]any `json:"ConformancePackRuleComplianceList"`
+	}
+	status, code, message = decodeConfigResponse(t, resp, &westCompliance)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	require.Empty(t, westCompliance.ConformancePackRuleComplianceList,
+		"a seed written for us-east-1 does not reach eu-west-1")
+}
+
+func TestConformancePacks_AnUnsupportedPackOperationIsRefusedByName(t *testing.T) {
+	t.Parallel()
+	ts := emulator.StartTestServer(t)
+
+	// Config has 97 operations and substrate implements the detective-controls subset, so
+	// the organization-level pack operations are not claimed. Naming the operation is
+	// what lets a consumer discover which call is missing rather than reading a bare
+	// refusal.
+	resp := configRequest(t, ts, "PutOrganizationConformancePack", map[string]any{})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidAction", code)
+	require.Contains(t, message, "PutOrganizationConformancePack")
+}
+
+// sliceOfN builds n values with a numbered prefix, for the bound cases.
+func sliceOfN(prefix string, n int) []string {
+	out := make([]string, 0, n)
+	for i := range n {
+		out = append(out, fmt.Sprintf("%s%02d", prefix, i))
+	}
+	return out
+}
+
+// mapKeys returns a map's keys, for asserting a response carries exactly one member.
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/emulator/configservice_plugin.go
+++ b/emulator/configservice_plugin.go
@@ -87,6 +87,7 @@ func (p *ConfigServicePlugin) HandleRequest(ctx *RequestContext, req *AWSRequest
 		p.recorderOperation,
 		p.channelOperation,
 		p.ruleOperation,
+		p.packOperation,
 	} {
 		if h, ok := claim(req.Operation); ok {
 			return h(ctx, req)

--- a/emulator/configservice_rules.go
+++ b/emulator/configservice_rules.go
@@ -50,6 +50,12 @@ const cfgsvcMaxConfigRules = 1000
 // DescribeConfigRules and DescribeComplianceByConfigRule.
 const cfgsvcMaxRuleNamesFilter = 25
 
+// cfgsvcMaxRuleNameLen is the ConfigRuleName ceiling (1-128). The conformance-pack
+// cluster shares it, because ConformancePackRuleCompliance.ConfigRuleName is the same
+// shape — though the *filter* that selects those rules is a narrower 64, which is why
+// that bound is its own constant.
+const cfgsvcMaxRuleNameLen = 128
+
 // cfgsvcMaxComplianceTypesFilter is the ComplianceTypes list bound (0-3).
 const cfgsvcMaxComplianceTypesFilter = 3
 
@@ -666,7 +672,7 @@ func (p *ConfigServicePlugin) cfgsvcResolveRuleForPut(ctx *RequestContext, rule 
 // cfgsvcCheckRuleName validates a rule name against ConfigRuleName's bounds and
 // pattern (1-128, .*\S.*).
 func cfgsvcCheckRuleName(name string) error {
-	if len(name) > 128 {
+	if len(name) > cfgsvcMaxRuleNameLen {
 		return cfgsvcInvalidParameter("The Config rule name must be between 1 and 128 characters long.")
 	}
 	if !cfgsvcRuleNamePattern.MatchString(name) {

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -350,6 +350,12 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/config/rule-compliance/{name}", s.handleConfigSeedRuleCompliance)
 	r.Delete("/v1/config/rule-compliance/{name}", s.handleConfigClearRuleCompliance)
 	r.Delete("/v1/config/rule-compliance", s.handleConfigClearRuleCompliance)
+	r.Post("/v1/config/pack-status/{name}", s.handleConfigSeedPackStatus)
+	r.Delete("/v1/config/pack-status/{name}", s.handleConfigClearPackStatus)
+	r.Delete("/v1/config/pack-status", s.handleConfigClearPackStatus)
+	r.Post("/v1/config/pack-compliance/{name}", s.handleConfigSeedPackCompliance)
+	r.Delete("/v1/config/pack-compliance/{name}", s.handleConfigClearPackCompliance)
+	r.Delete("/v1/config/pack-compliance", s.handleConfigClearPackCompliance)
 
 	// Lambda control-plane endpoints (#393).
 	r.Post("/v1/lambda/invoke-error", s.handleLambdaSeedInvokeError)


### PR DESCRIPTION
Lane 4 of the v0.101.0 plan: the conformance-pack cluster. `Refs #580`.

Six operations — `PutConformancePack`, `DescribeConformancePacks`,
`DescribeConformancePackStatus`, `DescribeConformancePackCompliance`,
`GetConformancePackComplianceSummary`, `DeleteConformancePack` — plus two seed families.

## The point of this PR

A pack is the only Config resource whose creation is **asynchronous**: `Put` returns an ARN and
nothing else, so a consumer learns whether its pack deployed by polling. The transition
`CREATE_IN_PROGRESS → CREATE_COMPLETE` resolves **on the first observation and is then
persisted**, following `resolveCreateAccountStatus` (`organizations_account.go:335`). Both halves
are load-bearing in opposite directions: a status that never advanced hangs a waiter forever, and
one that re-resolved on every poll would move `LastUpdateCompletedTime` under a waiter comparing
successive polls — which also never converges. Advancing on observation rather than on a duration
keeps the transition free of wall-clock dependence; #514 stays the home for clock-driven
transitions.

That narrow in-progress window is what makes `ResourceInUseException` reachable at all: a second
`Put`, or a `Delete`, issued before anything observed the first transition. Because the enum has
no `UPDATE_` state, an update re-enters `CREATE_IN_PROGRESS`.

Compliance is **seed-only**, as for rules, and the summary's cumulative verdict is *derived* from
the same per-rule seeds rather than seeded separately, so the summary and the drill-down cannot
disagree. A known `NON_COMPLIANT` outranks an unevaluated rule.

## Divergences from the plan, all doc-verified

Five corrections and flags against the plan's framing, each now in a code comment and queued for
the release's `## Provenance`:

1. **The pack limit is documented "per account", not per account per Region.** Substrate counts
   per account **and** Region, which is the permissive direction — it never refuses a create AWS
   would allow.
2. **The 50-pack figure and the `awsconfigconforms-` stack-name prefix come from sample CLI
   output, not from normative prose.** The prefix is synthesized for the required `StackArn`.
3. **`GetConformancePackComplianceSummary` does not declare `InvalidParameterValueException`,**
   yet substrate uses it for an out-of-bounds `ConformancePackNames` — there is no better-fitting
   declared code.
4. **No documented rule requires *at least one* template source.** All three are `Required: No`;
   only "you must specify only one of the follow parameters" is documented. Refusing a
   template-less `Put` is substrate's own reading and is flagged as such in the code.
5. **The filtered rule-name bound is 64 where the reported one is 128** — a rule named longer than
   64 can be reported by `DescribeConformancePackCompliance` but not filtered for by it. The
   asymmetry is the model's.

Two divergences the plan already anticipated are confirmed: these operations answer
**`InvalidLimitException`** for an out-of-range `Limit` (the rule cluster answers
`InvalidParameterValueException`, because none of *its* operations declares the former), and the
compliance **filter excludes `INSUFFICIENT_DATA`** ("the allowed values are `COMPLIANT` and
`NON_COMPLIANT`") even though the response shape carries it.

## Verification

- `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — **0 issues**
- `make test` (race) green; `make coverage` **82.6%** for `emulator`, 81.9% total; no
  zero-coverage function in the new file
- `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`,
  `go vet -C test/e2e ./... && go test -C test/e2e ./...` all green
- **Live CLI gate** on `:4678` with `AWS_MAX_ATTEMPTS=1`: `put-conformance-pack` →
  `describe-conformance-pack-status` twice (`CREATE_COMPLETE` with an unmoved
  `LastUpdateCompletedTime`), the seeded `CREATE_FAILED` and `DELETE_IN_PROGRESS` paths, the
  `ResourceInUseException` on delete, the empty delete body, and the four refusals
  (`InvalidLimitException`, `NoSuchConfigRuleInConformancePackException`, the
  `INSUFFICIENT_DATA` filter, the two-template-source `Put`)
- **Mutation testing: 14 mutants, 14 CAUGHT, 0 survivors.** Including the plan's named targets —
  the pack status re-resolved instead of persisted (5 tests), a pagination cap moved 20→100 and
  1000→20, the Region dropped from a state key — plus: the status never advancing at all, an
  unseeded pack summarizing `COMPLIANT`, `INSUFFICIENT_DATA` outranking `NON_COMPLIANT`, the
  template-source rule dropped, the filter widened to the response enum, the `Put` in-progress
  guard dropped, the delete leaving seeds behind, the exact-rule-name refusal dropped, the pack cap
  raised, and the seed accepting `NOT_APPLICABLE`.
