### PR TITLE
feat(config): tagging, the authorization hook, and the teardown ordering (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pack's own seeds but leaves a `*` seed alone, since a wildcard is a fixture-wide default
   rather than one pack's state.
 
+- **A policy scoped to one Config rule now applies to one Config rule: tagging and the
+  authorization hook** (#580). `TagResource`, `UntagResource` and `ListTagsForResource`,
+  plus the three `authz.go` arms that make a Config tag mean something to a policy.
+
+  The tag trio is the smaller half. Tags matter here because **they are how a Config
+  resource is authorized**: the Service Authorization Reference supports
+  `aws:ResourceTag/${TagKey}` on nine of Config's ten resource types, so a tag is a
+  privilege boundary and not decoration. (The developer guide's tagging page claims only
+  three types support it; the SAR is authoritative for authorization and is what substrate
+  implements.) `TagResource` merges rather than replaces, per "if existing tags on a
+  resource are not specified in the request parameters, they are not changed";
+  `UntagResource` treats a key that is not there as a no-op at 200, which is undocumented
+  either way and is the reading that keeps a teardown idempotent; and
+  `ListTagsForResource` emits an **empty** `Tags` list for an untagged resource rather than
+  omitting the member, since `TagList`'s min-1 bound cannot hold for a resource with no
+  tags and an omitted member reads as a decode failure to a consumer.
+
+  **`buildResourceARN` now resolves a Config request to the resource it names**, which is
+  the substantive half. Without it every Config request authorized against `*`, so a policy
+  written to admit one rule admitted every rule — a **false allow**, the one direction a
+  privilege boundary must never fail in, and a silent one: the policy looks right and a test
+  asserting the denial passes for the wrong reason. Resolution is per-operation because the
+  member naming the resource differs per operation and is nested and lowerCamel for the
+  recorder `Put` (`ConfigurationRecorder.name`) and nested and UpperCamel for the rule
+  `Put` (`ConfigRule.ConfigRuleName`).
+
+  An operation that names a *list* of resources, or none, resolves to `*` deliberately
+  rather than to one arbitrary member of the list — picking one would be the false-allow
+  direction again. So do all four delivery-channel operations, because **there is no
+  `delivery-channel` resource type**: the SAR gives them an empty resource list, `Delivery
+  Channel` has no `arn` member in the API model, and `TagResource`'s own documentation does
+  not name a channel among the taggable types, so a channel is neither taggable nor
+  nameable in a policy. `PutEvaluations` resolves to `*` too, since its `ResultToken` is the
+  only thing naming a rule and decoding it to authorize would hand a caller control over
+  the resource its own request is checked against. A rule `Put` naming its rule by ID or ARN
+  resolves to `*` for the same class of reason: converting it needs a state lookup that can
+  miss, and a miss would authorize against a *different* rule's ARN.
+
+  The tag-injection arms complete it: `aws:ResourceTag/*` is populated from the tags of the
+  resource **the request names** — resolved by the same function `buildResourceARN` uses, so
+  the two cannot disagree about whose tags these are — and `aws:RequestTag/*` from the
+  request's own `Tags` list, which is what makes "every Config rule must carry an Owner tag"
+  expressible at creation time. A tag store that will not decode leaves the condition key
+  absent, which denies; an absent key is the safe direction.
+
 ### Fixed
+- **A conformance pack's tags outlived the pack** (#580, unreleased). `DeleteConformancePack`
+  removed the pack and its index entry but not its tags, and a pack's ARN is deterministic —
+  so a pack rebuilt under the same name read back its predecessor's tags, which no AWS
+  account does ("if you delete a resource, any tags for the resource are also deleted"). It
+  was unreachable until this release's tag operations existed, because
+  `PutConformancePackRequest` has **no `Tags` member**: a pack can only be tagged through
+  `TagResource`, so the conformance-pack tests could not have caught it. Found by the test
+  asserting a rebuilt pack starts untagged.
+- **A Config recorder's ARN named a resource type that does not exist** (#580, unreleased).
+  Substrate minted `configuration-recorder/<name>`; the SAR's template is
+  `configuration-recorder/${RecorderName}/${RecorderId}`, two segments. A one-segment ARN
+  matches no policy written against the real template, which matters now that a Config
+  request authorizes against its own ARN. `RecorderId` has no member anywhere in the API
+  model, so substrate mints it deterministically from the account, Region and name.
+- **An authorization denial from AWS Config reported the wrong error code** (#580,
+  unreleased). `AuthController.CheckAccess` calls `accessDeniedCodeFor(service, "")` with no
+  Content-Type, so a service absent from `serviceErrorProtocols` takes `errorProtocolFor`'s
+  XML default and is refused with the bare `AccessDenied`. Config is `protocol: json`, so
+  its callers need `AccessDeniedException` — the #595 failure mode, in the opposite
+  direction. `config` is now classified. `pricing` is in the same state for the same reason
+  and is tracked separately in #653, since it changes an existing service's wire behaviour.
 - **Every AWS Config request was unroutable** (#580). Config's `X-Amz-Target` prefix is
   `StarlingDoveService` — an internal code name bearing no resemblance to the `config`
   endpoint prefix, the way `TrentService` is KMS's — and `starlingdoveservice` was absent

--- a/emulator/access_denied_code_test.go
+++ b/emulator/access_denied_code_test.go
@@ -57,6 +57,14 @@ func TestAccessDeniedCodeFor_TracksTheWireProtocol(t *testing.T) {
 		{"dynamodb is json rpc", "dynamodb", "application/x-amz-json-1.0", "AccessDeniedException"},
 		{"ssm is json rpc", "ssm", "application/x-amz-json-1.1", "AccessDeniedException"},
 		{"sqs is json rpc", "sqs", "", "AccessDeniedException"},
+
+		// Config, whose Content-Type-free case is the one that matters: the
+		// AuthController calls accessDeniedCodeFor(service, "") with no Content-Type
+		// at all, so a service missing from serviceErrorProtocols falls through to
+		// the XML default and refuses a JSON caller with a code its SDK cannot
+		// match. Config was in exactly that state when its plugin landed (#580).
+		{"config is json rpc", "config", "", "AccessDeniedException"},
+		{"config is json rpc with a body", "config", "application/x-amz-json-1.1", "AccessDeniedException"},
 		{"lambda is rest json", "lambda", "application/json", "AccessDeniedException"},
 		{"apigateway is rest json", "apigateway", "application/json", "AccessDeniedException"},
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -577,6 +577,12 @@ func (a *AuthController) buildResourceARN(reqCtx *RequestContext, req *AWSReques
 		// orgAuthzResourceARN. Falling through to "*" would make a policy scoped to
 		// one OU or policy apply to every one of them.
 		return orgAuthzResourceARN(a.state, reqCtx, req)
+	case configServiceNamespace:
+		// A Config request's resource is resolved from the operation, because the
+		// member naming it differs per operation and is nested for the two Puts. See
+		// cfgsvcAuthzResourceARN for why an operation naming a *list* of resources
+		// resolves to "*" rather than to one arbitrary member of the list.
+		return cfgsvcAuthzResourceARN(reqCtx, req)
 	default:
 		return "*"
 	}
@@ -738,6 +744,12 @@ func (a *AuthController) addResourceTags(condCtx map[string]string, reqCtx *Requ
 		// would be a false allow rather than a convenience.
 		tags = orgAuthzResourceTags(a.state, req)
 
+	case configServiceNamespace:
+		// Config tags are keyed by the resource's ARN, so the same resolution
+		// buildResourceARN performs decides whose tags these are — the two cannot
+		// disagree about which resource a request names.
+		tags = cfgsvcAuthzResourceTags(a.state, reqCtx, req)
+
 	default:
 		return
 	}
@@ -804,6 +816,16 @@ func addRequestTags(condCtx map[string]string, req *AWSRequest) {
 		// TagResource or a tagged CreatePolicy on the tag the caller is trying to
 		// apply, rather than only on tags already stored.
 		for k, v := range orgAuthzRequestTags(req) {
+			condCtx["aws:RequestTag/"+k] = v
+		}
+
+	case configServiceNamespace:
+		// Config tags arrive as "Tags": [{"Key":…,"Value":…}] on TagResource and on all
+		// four creating Puts, so one reader serves them. aws:RequestTag/${TagKey} is a
+		// condition key on TagResource specifically, per the Service Authorization
+		// Reference, which is what makes a "may only apply approved tags" policy
+		// expressible here.
+		for k, v := range cfgsvcAuthzRequestTags(req) {
 			condCtx["aws:RequestTag/"+k] = v
 		}
 

--- a/emulator/configservice_authz_test.go
+++ b/emulator/configservice_authz_test.go
@@ -1,0 +1,500 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AWS Config authorization (#580).
+//
+// Without a Config arm in buildResourceARN every Config request authorizes against
+// "*", so a policy scoped to one rule admits an operation on every rule and a test
+// asserting a denial passes for the wrong reason. That is a **false allow**, the one
+// direction a privilege boundary must never fail in, and it is silent: the policy looks
+// right, the test goes green, and the scoping does nothing.
+//
+// So the cases below pin two things. First, that a resource-scoped statement narrows —
+// naming one rule in a policy's Resource element must not admit an operation against
+// another. Second, that the tags a decision reads come from the resource the request
+// names, so an ABAC policy over Config is enforceable at all.
+//
+// Operations that name a *list* of resources, and the delivery-channel operations that
+// have no resource type, resolve to "*" deliberately, and that is asserted too: an
+// arbitrary member of a list would be the false-allow direction again, and inventing a
+// delivery-channel ARN would name a resource no real policy could.
+
+// configAuthzFixture is a state store plus an AuthController over it, which is what
+// makes a tag-gated boundary testable: the tag must travel out of the Config namespace
+// into the condition context.
+type configAuthzFixture struct {
+	state emulator.StateManager
+	auth  *emulator.AuthController
+	ctx   *emulator.RequestContext
+}
+
+// newConfigAuthzFixture builds a user carrying one policy and an AuthController reading
+// the same store.
+func newConfigAuthzFixture(t *testing.T, user string, doc emulator.PolicyDocument) *configAuthzFixture {
+	t.Helper()
+	state := newAuthTestState(t, user, "arn:aws:iam::123456789012:policy/ConfigGate-"+user, doc)
+	return &configAuthzFixture{
+		state: state,
+		auth:  emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false)),
+		ctx:   newAuthTestReqCtx("arn:aws:iam::123456789012:user/" + user),
+	}
+}
+
+// check runs one Config request through the authorization decision.
+func (f *configAuthzFixture) check(t *testing.T, operation string, body map[string]any) error {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	return f.auth.CheckAccess(f.ctx, &emulator.AWSRequest{
+		Service:   "config",
+		Operation: operation,
+		Path:      "/",
+		Body:      raw,
+	})
+}
+
+// tag stores tags under a resource ARN, as a Put or a TagResource would.
+func (f *configAuthzFixture) tag(t *testing.T, arn string, tags map[string]string) {
+	t.Helper()
+	raw, err := json.Marshal(tags)
+	require.NoError(t, err)
+	require.NoError(t, f.state.Put(t.Context(), emulator.ConfigServiceNamespaceForTest,
+		emulator.CfgsvcTagsKeyForTest(arn), raw))
+}
+
+// configAuthzDenied reports whether err is the denial a Config caller sees. Config
+// speaks JSON 1.1, so the code carries the "Exception" suffix.
+func configAuthzDenied(t *testing.T, err error) bool {
+	t.Helper()
+	if err == nil {
+		return false
+	}
+	var awsErr *emulator.AWSError
+	require.ErrorAs(t, err, &awsErr)
+	assert.Equal(t, "AccessDeniedException", awsErr.Code)
+	assert.Equal(t, http.StatusForbidden, awsErr.HTTPStatus)
+	return true
+}
+
+// configAuthzCtx is the request context the ARN builders are called with, matching the
+// one the fixture authorizes under.
+func configAuthzCtx() *emulator.RequestContext {
+	return newAuthTestReqCtx("arn:aws:iam::123456789012:user/anyone")
+}
+
+func TestConfigAuthz_AResourceScopedStatementNarrows(t *testing.T) {
+	// The decisive case. A policy allowing DeleteConfigRule on one rule must deny it on
+	// another — which requires the request to resolve to *that rule's* ARN. Falling
+	// through to "*" makes both requests match, so the second assertion is the one that
+	// fails without the Config arm in buildResourceARN.
+	ctx := configAuthzCtx()
+	mine := emulator.CfgsvcRuleARNForTest(ctx, "s3-encrypted")
+
+	f := newConfigAuthzFixture(t, "cfgdeleter", emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"config:DeleteConfigRule"},
+			Resource: emulator.StringOrSlice{mine},
+		}},
+	})
+
+	assert.NoError(t, f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "s3-encrypted"}),
+		"the rule the policy names is allowed")
+	assert.True(t, configAuthzDenied(t,
+		f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "ebs-encrypted"})),
+		"a rule the policy does not name is denied")
+}
+
+func TestConfigAuthz_EachResourceKindResolvesToItsOwnARN(t *testing.T) {
+	// The three ARN shapes, each resolved from the member its operation uses. The
+	// recorder's and the pack's names are nested or differently spelled, so a single
+	// "look for a name-shaped member" implementation would get at least one wrong.
+	ctx := configAuthzCtx()
+
+	for _, tc := range []struct {
+		name, operation string
+		body            map[string]any
+		want            string
+	}{
+		{
+			name:      "a recorder Put, whose name is nested and lowerCamel",
+			operation: "PutConfigurationRecorder",
+			body: map[string]any{"ConfigurationRecorder": map[string]any{
+				"name": "main", "roleARN": "arn:aws:iam::123456789012:role/config",
+			}},
+			want: emulator.CfgsvcRecorderARNForTest(ctx, "main"),
+		},
+		{
+			name:      "a recorder Put omitting the name, which defaults to default",
+			operation: "PutConfigurationRecorder",
+			body: map[string]any{"ConfigurationRecorder": map[string]any{
+				"roleARN": "arn:aws:iam::123456789012:role/config",
+			}},
+			want: emulator.CfgsvcRecorderARNForTest(ctx, "default"),
+		},
+		{
+			name:      "a Start, whose name is top-level",
+			operation: "StartConfigurationRecorder",
+			body:      map[string]any{"ConfigurationRecorderName": "main"},
+			want:      emulator.CfgsvcRecorderARNForTest(ctx, "main"),
+		},
+		{
+			name:      "a Stop",
+			operation: "StopConfigurationRecorder",
+			body:      map[string]any{"ConfigurationRecorderName": "main"},
+			want:      emulator.CfgsvcRecorderARNForTest(ctx, "main"),
+		},
+		{
+			name:      "a recorder Delete",
+			operation: "DeleteConfigurationRecorder",
+			body:      map[string]any{"ConfigurationRecorderName": "main"},
+			want:      emulator.CfgsvcRecorderARNForTest(ctx, "main"),
+		},
+		{
+			name:      "a rule Put, whose name is nested and UpperCamel",
+			operation: "PutConfigRule",
+			body:      map[string]any{"ConfigRule": map[string]any{"ConfigRuleName": "s3-encrypted"}},
+			want:      emulator.CfgsvcRuleARNForTest(ctx, "s3-encrypted"),
+		},
+		{
+			name:      "a rule Delete",
+			operation: "DeleteConfigRule",
+			body:      map[string]any{"ConfigRuleName": "s3-encrypted"},
+			want:      emulator.CfgsvcRuleARNForTest(ctx, "s3-encrypted"),
+		},
+		{
+			name:      "a per-rule compliance read",
+			operation: "GetComplianceDetailsByConfigRule",
+			body:      map[string]any{"ConfigRuleName": "s3-encrypted"},
+			want:      emulator.CfgsvcRuleARNForTest(ctx, "s3-encrypted"),
+		},
+		{
+			name:      "a pack Put",
+			operation: "PutConformancePack",
+			body:      map[string]any{"ConformancePackName": "ops", "TemplateBody": "{}"},
+			want:      emulator.CfgsvcPackARNForTest(ctx, "ops"),
+		},
+		{
+			name:      "a pack Delete",
+			operation: "DeleteConformancePack",
+			body:      map[string]any{"ConformancePackName": "ops"},
+			want:      emulator.CfgsvcPackARNForTest(ctx, "ops"),
+		},
+		{
+			name:      "a pack compliance read",
+			operation: "DescribeConformancePackCompliance",
+			body:      map[string]any{"ConformancePackName": "ops"},
+			want:      emulator.CfgsvcPackARNForTest(ctx, "ops"),
+		},
+		{
+			name:      "a tag operation, which names its resource outright",
+			operation: "TagResource",
+			body: map[string]any{
+				"ResourceArn": emulator.CfgsvcRuleARNForTest(ctx, "s3-encrypted"),
+				"Tags":        []map[string]any{{"Key": "env", "Value": "prod"}},
+			},
+			want: emulator.CfgsvcRuleARNForTest(ctx, "s3-encrypted"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+			got := emulator.CfgsvcAuthzResourceARNForTest(ctx, &emulator.AWSRequest{
+				Service: "config", Operation: tc.operation, Path: "/", Body: raw,
+			})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestConfigAuthz_AnOperationNamingNoSingleResourceIsStar(t *testing.T) {
+	// "*" is the honest answer for a request whose resource cannot be named, and each of
+	// these has a reason.
+	ctx := configAuthzCtx()
+
+	for _, tc := range []struct {
+		name, operation string
+		body            map[string]any
+	}{
+		{
+			// The describes take name *lists*. Resolving to one member's ARN would let a
+			// policy scoped to that member admit a call about all of them.
+			name: "a describe over a list of rules", operation: "DescribeConfigRules",
+			body: map[string]any{"ConfigRuleNames": []string{"a", "b"}},
+		},
+		{
+			name: "a describe over a list of packs", operation: "DescribeConformancePacks",
+			body: map[string]any{"ConformancePackNames": []string{"a", "b"}},
+		},
+		{
+			name: "a describe of every recorder", operation: "DescribeConfigurationRecorders",
+			body: map[string]any{},
+		},
+		{
+			// **There is no delivery-channel resource type.** The Service Authorization
+			// Reference gives all four channel operations an empty resource list, which is
+			// how it spells "authorizes against * only". Synthesizing an ARN would name a
+			// resource no real policy could match.
+			name: "a channel Put", operation: "PutDeliveryChannel",
+			body: map[string]any{"DeliveryChannel": map[string]any{
+				"name": "default", "s3BucketName": "cfg-logs",
+			}},
+		},
+		{
+			name: "a channel Delete", operation: "DeleteDeliveryChannel",
+			body: map[string]any{"DeliveryChannelName": "default"},
+		},
+		{
+			name: "a channel describe", operation: "DescribeDeliveryChannels", body: map[string]any{},
+		},
+		{
+			name: "a channel status describe", operation: "DescribeDeliveryChannelStatus",
+			body: map[string]any{},
+		},
+		{
+			// PutEvaluations carries no rule name at all — its ResultToken is the only
+			// thing that says which rule. Decoding a token to authorize would hand a
+			// caller control over the resource its own request is checked against.
+			name: "PutEvaluations, which carries no rule name", operation: "PutEvaluations",
+			body: map[string]any{"ResultToken": "substrate-config-rule:czMtZW5jcnlwdGVk"},
+		},
+		{
+			// A rule update may name its rule by Id or Arn. Converting either would need a
+			// state lookup that can miss — and a miss would authorize against a
+			// *different* rule's ARN.
+			name: "a rule Put naming its rule by ID", operation: "PutConfigRule",
+			body: map[string]any{"ConfigRule": map[string]any{"ConfigRuleId": "config-rule-abc123"}},
+		},
+		{
+			name: "an operation with an unparseable body", operation: "DeleteConfigRule",
+			body: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := []byte("not json")
+			if tc.body != nil {
+				var err error
+				raw, err = json.Marshal(tc.body)
+				require.NoError(t, err)
+			}
+			got := emulator.CfgsvcAuthzResourceARNForTest(ctx, &emulator.AWSRequest{
+				Service: "config", Operation: tc.operation, Path: "/", Body: raw,
+			})
+			assert.Equal(t, "*", got)
+		})
+	}
+}
+
+func TestConfigAuthz_ResourceTagGatesTheResourceNamed(t *testing.T) {
+	// The aws:ResourceTag half. A policy allowing DeleteConfigRule only on a rule
+	// already tagged Owner=platform must allow it for that rule and deny it for another
+	// — which requires the tags to be loaded from the Config namespace at decision time.
+	// Without the addResourceTags arm the condition key is never populated, the Allow
+	// never matches, and the *first* assertion fails: a boundary that denies everything
+	// looks correct until someone legitimate is blocked.
+	ctx := configAuthzCtx()
+	f := newConfigAuthzFixture(t, "cfgabac",
+		newABACPolicy("Allow", "config:DeleteConfigRule", "*", "aws:ResourceTag/Owner", "platform"))
+
+	f.tag(t, emulator.CfgsvcRuleARNForTest(ctx, "mine"), map[string]string{"Owner": "platform"})
+	f.tag(t, emulator.CfgsvcRuleARNForTest(ctx, "theirs"), map[string]string{"Owner": "security"})
+
+	assert.NoError(t, f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "mine"}),
+		"the matching resource tag is allowed")
+	assert.True(t, configAuthzDenied(t,
+		f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "theirs"})),
+		"a rule tagged with a different Owner is denied")
+	assert.True(t, configAuthzDenied(t,
+		f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "untagged"})),
+		"an untagged rule has no Owner at all, which cannot satisfy the condition")
+}
+
+func TestConfigAuthz_ResourceTagsComeFromTheResourceTheOperationNames(t *testing.T) {
+	// The tags must come from the resource *this* operation names, not from whichever
+	// Config resource happens to be tagged. A recorder and a rule tagged differently
+	// must decide their own operations — merging them, or reading the wrong one, would
+	// let a tag on one satisfy a condition written about the other.
+	ctx := configAuthzCtx()
+	f := newConfigAuthzFixture(t, "cfgmixed", emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"config:*"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				"StringEquals": {"aws:ResourceTag/Owner": {"platform"}},
+			},
+		}},
+	})
+
+	f.tag(t, emulator.CfgsvcRecorderARNForTest(ctx, "default"), map[string]string{"Owner": "platform"})
+	f.tag(t, emulator.CfgsvcRuleARNForTest(ctx, "s3-encrypted"), map[string]string{"Owner": "security"})
+
+	assert.NoError(t, f.check(t, "StopConfigurationRecorder",
+		map[string]any{"ConfigurationRecorderName": "default"}),
+		"the recorder's own tag decides the recorder's operation")
+	assert.True(t, configAuthzDenied(t,
+		f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "s3-encrypted"})),
+		"the recorder's tag does not satisfy a condition about the rule")
+}
+
+func TestConfigAuthz_RequestTagGatesTagResource(t *testing.T) {
+	// The aws:RequestTag half: a policy permitting tagging only with an approved tag.
+	// This is about what the request *asks for* rather than what is stored, so it is the
+	// arm addRequestTags populates.
+	ctx := configAuthzCtx()
+	f := newConfigAuthzFixture(t, "cfgtagger",
+		newABACPolicy("Allow", "config:TagResource", "*", "aws:RequestTag/Owner", "platform"))
+	arn := emulator.CfgsvcRuleARNForTest(ctx, "s3-encrypted")
+
+	body := func(tags []map[string]any) map[string]any {
+		return map[string]any{"ResourceArn": arn, "Tags": tags}
+	}
+
+	assert.NoError(t, f.check(t, "TagResource",
+		body([]map[string]any{{"Key": "Owner", "Value": "platform"}})),
+		"the approved tag is allowed")
+	assert.True(t, configAuthzDenied(t, f.check(t, "TagResource",
+		body([]map[string]any{{"Key": "Owner", "Value": "security"}}))),
+		"a request carrying the wrong Owner is denied")
+	assert.True(t, configAuthzDenied(t, f.check(t, "TagResource",
+		map[string]any{"ResourceArn": arn})),
+		"no tag at all leaves the condition key absent, which also fails to match")
+}
+
+func TestConfigAuthz_RequestTagGatesACreationTimeTagsList(t *testing.T) {
+	// The same reader serves the creating Puts, whose Tags list has the same shape. A
+	// policy requiring an approved tag on creation is a real control — "every Config
+	// rule must name its owner" — and it is only expressible if the Put's own Tags list
+	// reaches the condition context.
+	f := newConfigAuthzFixture(t, "cfgcreator",
+		newABACPolicy("Allow", "config:PutConfigRule", "*", "aws:RequestTag/Owner", "platform"))
+
+	body := func(owner string) map[string]any {
+		return map[string]any{
+			"ConfigRule": map[string]any{"ConfigRuleName": "s3-encrypted"},
+			"Tags":       []map[string]any{{"Key": "Owner", "Value": owner}},
+		}
+	}
+
+	assert.NoError(t, f.check(t, "PutConfigRule", body("platform")))
+	assert.True(t, configAuthzDenied(t, f.check(t, "PutConfigRule", body("security"))))
+}
+
+func TestConfigAuthz_AnUnreadableTagStoreDenies(t *testing.T) {
+	// Tags that will not decode leave the condition key absent, so a policy requiring it
+	// does not match and the request is denied — the failure mode a corrupted or
+	// hand-edited state file produces.
+	//
+	// The **partially** decodable store is the case that matters, and it is not the
+	// obvious one. `encoding/json` populates a map as it goes and returns its type error
+	// at the member that failed, so a document whose first tag is a string and whose
+	// second is an object yields *both* an error and a map containing the first tag. A
+	// reader that ignored the error would hand the decision a map carrying
+	// Owner=platform read out of a store it could not decode — an Allow granted from
+	// corrupted state, which is the false-allow direction. Whole-file garbage does not
+	// discriminate: both readings return an empty map for that, so only this input
+	// distinguishes checking the error from ignoring it.
+	ctx := configAuthzCtx()
+	f := newConfigAuthzFixture(t, "cfgcorrupt",
+		newABACPolicy("Allow", "config:DeleteConfigRule", "*", "aws:ResourceTag/Owner", "platform"))
+
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{
+			// The discriminating case: Owner decodes, Team does not.
+			name: "a store whose first tag decodes and whose second does not",
+			raw:  `{"Owner":"platform","Team":{"nested":"object"}}`,
+		},
+		{
+			name: "a store that is not a JSON object at all",
+			raw:  `["Owner","platform"]`,
+		},
+		{
+			name: "a store that is not JSON",
+			raw:  `not json at all`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			arn := emulator.CfgsvcRuleARNForTest(ctx, "s3-encrypted")
+			require.NoError(t, f.state.Put(t.Context(), emulator.ConfigServiceNamespaceForTest,
+				emulator.CfgsvcTagsKeyForTest(arn), []byte(tc.raw)))
+
+			assert.True(t, configAuthzDenied(t,
+				f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "s3-encrypted"})))
+		})
+	}
+}
+
+func TestConfigAuthz_AnExplicitDenyOnOneRuleStillNarrows(t *testing.T) {
+	// The other polarity: a broad Allow with a Deny scoped to one rule. If the request
+	// resolved to "*", the Deny's Resource element would match every request and the
+	// broad Allow would be useless — the failure that *looks* safe and is just as wrong,
+	// because it blocks work that should proceed.
+	ctx := configAuthzCtx()
+	protected := emulator.CfgsvcRuleARNForTest(ctx, "do-not-touch")
+
+	f := newConfigAuthzFixture(t, "cfgdenied", emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{
+			{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice{"config:*"},
+				Resource: emulator.StringOrSlice{"*"},
+			},
+			{
+				Effect:   "Deny",
+				Action:   emulator.StringOrSlice{"config:DeleteConfigRule"},
+				Resource: emulator.StringOrSlice{protected},
+			},
+		},
+	})
+
+	assert.True(t, configAuthzDenied(t,
+		f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "do-not-touch"})))
+	assert.NoError(t, f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "anything-else"}),
+		"the Deny is scoped to one rule and must not reach another")
+}
+
+func TestConfigAuthz_TheARNIsMintedWhetherOrNotTheResourceExists(t *testing.T) {
+	// Authorization runs before the handler, so a policy denying an operation on a rule
+	// must deny it whether or not the rule is there. Reading state to build the ARN
+	// would make a denial depend on the resource existing — so a caller could probe a
+	// policy's shape by deleting, and an operation on an absent resource would authorize
+	// against "*" and be allowed by a broad statement it should not match.
+	//
+	// The fixture's store holds no Config resources at all, and the decision still lands
+	// on the right ARN.
+	ctx := configAuthzCtx()
+	f := newConfigAuthzFixture(t, "cfgghost", emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   "Deny",
+			Action:   emulator.StringOrSlice{"config:DeleteConfigRule"},
+			Resource: emulator.StringOrSlice{emulator.CfgsvcRuleARNForTest(ctx, "ghost")},
+		}, {
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"config:*"},
+			Resource: emulator.StringOrSlice{"*"},
+		}},
+	})
+
+	err := f.check(t, "DeleteConfigRule", map[string]any{"ConfigRuleName": "ghost"})
+	assert.True(t, configAuthzDenied(t, err), "a rule that does not exist is still named")
+	var awsErr *emulator.AWSError
+	require.True(t, errors.As(err, &awsErr))
+}

--- a/emulator/configservice_export_test.go
+++ b/emulator/configservice_export_test.go
@@ -1,0 +1,38 @@
+package emulator
+
+// This file exports the AWS Config authorization helpers for the external test
+// package, following organizations_export_test.go. It is compiled only under test.
+//
+// The ARN builders are exported because their identifier components are minted by
+// hash: a test cannot spell one out without asserting the hash, and cannot store a
+// tag under a resource's ARN without knowing it. Exporting the builder rather than
+// the hash keeps the test asserting the *resolution* — which operation names which
+// resource — rather than the digest.
+
+// CfgsvcAuthzResourceARNForTest wraps cfgsvcAuthzResourceARN for external tests.
+func CfgsvcAuthzResourceARNForTest(reqCtx *RequestContext, req *AWSRequest) string {
+	return cfgsvcAuthzResourceARN(reqCtx, req)
+}
+
+// CfgsvcRecorderARNForTest wraps cfgsvcRecorderARN for external tests.
+func CfgsvcRecorderARNForTest(ctx *RequestContext, name string) string {
+	return cfgsvcRecorderARN(ctx, name)
+}
+
+// CfgsvcRuleARNForTest builds a Config rule's ARN from its name, minting the rule ID
+// the way the handlers do.
+func CfgsvcRuleARNForTest(ctx *RequestContext, name string) string {
+	return cfgsvcRuleARN(ctx, cfgsvcMintRuleID(ctx.AccountID, ctx.Region, name))
+}
+
+// CfgsvcPackARNForTest builds a conformance pack's ARN from its name, minting the pack
+// ID the way the handlers do.
+func CfgsvcPackARNForTest(ctx *RequestContext, name string) string {
+	return cfgsvcPackARN(ctx, name, cfgsvcMintPackID(ctx.AccountID, ctx.Region, name))
+}
+
+// CfgsvcTagsKeyForTest wraps cfgsvcTagsKey for external tests.
+func CfgsvcTagsKeyForTest(arn string) string { return cfgsvcTagsKey(arn) }
+
+// ConfigServiceNamespaceForTest is the state namespace AWS Config stores under.
+const ConfigServiceNamespaceForTest = configServiceNamespace

--- a/emulator/configservice_packs.go
+++ b/emulator/configservice_packs.go
@@ -618,12 +618,25 @@ func (p *ConfigServicePlugin) cfgsvcSavePack(goCtx context.Context, ctx *Request
 	return p.cfgsvcPutJSON(goCtx, cfgsvcPackNamesKey(ctx.AccountID, ctx.Region), names)
 }
 
-// cfgsvcDeletePackRecord removes a pack and its index entry, the counterpart to
-// cfgsvcSavePack.
+// cfgsvcDeletePackRecord removes a pack, its index entry and its tags, the counterpart
+// to cfgsvcSavePack.
+//
+// The tags go with it because "if you delete a resource, any tags for the resource are
+// also deleted". That matters here specifically because a pack's ARN is deterministic:
+// a rebuilt pack of the same name has the same ARN, so tags left behind would be read
+// back as tags on the new pack, which no AWS account does. PutConformancePack has no
+// Tags member of its own — a pack can only be tagged through TagResource — so this is
+// the only place a pack's tags are ever removed.
 func (p *ConfigServicePlugin) cfgsvcDeletePackRecord(goCtx context.Context, ctx *RequestContext,
-	name string) error {
-	if err := p.cfgsvcDeleteKey(goCtx, cfgsvcPackKey(ctx.AccountID, ctx.Region, name)); err != nil {
-		return err
+	pack *ConfigConformancePack) error {
+	name := pack.ConformancePackName
+	for _, key := range []string{
+		cfgsvcPackKey(ctx.AccountID, ctx.Region, name),
+		cfgsvcTagsKey(pack.ConformancePackArn),
+	} {
+		if err := p.cfgsvcDeleteKey(goCtx, key); err != nil {
+			return err
+		}
 	}
 	names, err := p.cfgsvcPackNames(goCtx, ctx)
 	if err != nil {
@@ -1150,7 +1163,7 @@ func (p *ConfigServicePlugin) deleteConformancePack(ctx *RequestContext, req *AW
 		return nil, cfgsvcPackResourceInUse(req.Operation)
 	}
 
-	if err := p.cfgsvcDeletePackRecord(goCtx, ctx, in.ConformancePackName); err != nil {
+	if err := p.cfgsvcDeletePackRecord(goCtx, ctx, &pack); err != nil {
 		return nil, err
 	}
 	if err := p.cfgsvcClearPackSeeds(goCtx, ctx, in.ConformancePackName); err != nil {

--- a/emulator/configservice_plugin.go
+++ b/emulator/configservice_plugin.go
@@ -88,6 +88,7 @@ func (p *ConfigServicePlugin) HandleRequest(ctx *RequestContext, req *AWSRequest
 		p.channelOperation,
 		p.ruleOperation,
 		p.packOperation,
+		p.tagOperation,
 	} {
 		if h, ok := claim(req.Operation); ok {
 			return h(ctx, req)

--- a/emulator/configservice_recorder.go
+++ b/emulator/configservice_recorder.go
@@ -466,9 +466,17 @@ func (p *ConfigServicePlugin) stopConfigurationRecorder(ctx *RequestContext, req
 
 // deleteConfigurationRecorder deletes the recorder and its status and tags.
 //
-// Deleting a recorder while it is recording is permitted — no refusal is documented
-// — and it does not delete the delivery channel, so a fixture that tears down and
-// rebuilds must delete both.
+// **It has no ordering precondition at all**, which is worth stating plainly because
+// the asymmetry with DeleteDeliveryChannel invites the opposite assumption. That
+// operation refuses while the recorder runs, and its prose says so; this one declares
+// exactly two exceptions — NoSuchConfigurationRecorderException and
+// UnmodifiableEntityException, the latter for service-linked recorders only — and no
+// exception exists that could express "stop it first" or "delete the channel first".
+// Inferring a precondition from the *channel* delete's prose would make substrate
+// refuse a sequence AWS accepts, and a wrong refusal breaks working code.
+//
+// So deleting a recorder while it is recording succeeds, and it does not delete the
+// delivery channel: a fixture that tears down and rebuilds must delete both.
 func (p *ConfigServicePlugin) deleteConfigurationRecorder(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	var in cfgsvcRecorderNameRequest
 	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {

--- a/emulator/configservice_recorder_test.go
+++ b/emulator/configservice_recorder_test.go
@@ -147,6 +147,28 @@ func configDescribeRecorders(t *testing.T, ts *emulator.TestServer) []map[string
 	return out.ConfigurationRecorders
 }
 
+// configRecorderARN returns the ARN of the account's recorder in a Region, read back
+// from the API rather than assembled in the test.
+//
+// The ARN's trailing RecorderId component is minted from a hash — the API model has
+// no member that carries it, yet the Service Authorization Reference's template
+// requires it — so a test that spelled the whole ARN out would be asserting the hash
+// rather than the behavior it cares about. TestConfigRecorder_NameDefaultsToDefault is
+// the one place the ARN's documented *shape* is asserted.
+func configRecorderARN(t *testing.T, ts *emulator.TestServer, region string) string {
+	t.Helper()
+	resp := configRequestIn(t, ts, region, "DescribeConfigurationRecorders", map[string]any{})
+	var out struct {
+		ConfigurationRecorders []map[string]any `json:"ConfigurationRecorders"`
+	}
+	status, code, message := decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	require.Len(t, out.ConfigurationRecorders, 1)
+	arn, ok := out.ConfigurationRecorders[0]["arn"].(string)
+	require.True(t, ok, "the recorder reports an arn")
+	return arn
+}
+
 // configDescribeRecorderStatus returns the statuses
 // DescribeConfigurationRecorderStatus reports.
 func configDescribeRecorderStatus(t *testing.T, ts *emulator.TestServer) []map[string]any {
@@ -255,15 +277,18 @@ func TestConfigRecorder_PutIsIdempotentAndDoesNotRetag(t *testing.T) {
 	assert.Equal(t, "arn:aws:iam::123456789012:role/second", recorders[0]["roleARN"],
 		"the role is updated")
 
-	tags := configStoredTags(t, ts, "arn:aws:config:us-east-1:123456789012:config-recorder/default")
+	tags := configStoredTags(t, ts, configRecorderARN(t, ts, "us-east-1"))
 	assert.Equal(t, map[string]string{"env": "prod"}, tags,
 		"tags are set at creation and a later Put does not update them")
 }
 
-// configStoredTags reads the tags substrate stored for a resource ARN. The tag
-// operations that read them over the wire arrive in a later PR; until then the state
-// is the only place the creation-time behavior is observable, and it is the
-// behavior that matters.
+// configStoredTags reads the tags substrate stored for a resource ARN.
+//
+// ListTagsForResource reads the same tags over the wire, and
+// TestConfigTags_CreationTimeTagsAreVisibleToTheTagAPI asserts the two agree. This
+// helper stays because a creation-time tag is stored before any tag operation is
+// called, so the state read is what tells a Put's own behavior apart from the tag
+// cluster's.
 func configStoredTags(t *testing.T, ts *emulator.TestServer, arn string) map[string]string {
 	t.Helper()
 	raw, err := ts.StateManager().Get(t.Context(), "config", "tags:"+arn)
@@ -311,8 +336,14 @@ func TestConfigRecorder_NameDefaultsToDefault(t *testing.T) {
 	recorders := configDescribeRecorders(t, ts)
 	require.Len(t, recorders, 1)
 	assert.Equal(t, "default", recorders[0]["name"])
-	assert.Equal(t, "arn:aws:config:us-east-1:123456789012:config-recorder/default", recorders[0]["arn"],
-		"the ARN resource type is config-recorder, per the Service Authorization Reference")
+	// The Service Authorization Reference's template is
+	// configuration-recorder/${RecorderName}/${RecorderId} — the segment is
+	// "configuration-recorder", not "config-recorder" or "recorder", and it carries two
+	// components. RecorderId has no member anywhere in the API model, so substrate mints
+	// it; only its shape is asserted.
+	assert.Regexp(t,
+		`^arn:aws:config:us-east-1:123456789012:configuration-recorder/default/[a-z0-9_-]{8}$`,
+		recorders[0]["arn"])
 }
 
 func TestConfigRecorder_RefusesAnEmptyRoleARN(t *testing.T) {
@@ -616,7 +647,7 @@ func TestConfigRecorder_AnUnknownNameIsRefused(t *testing.T) {
 			ts := emulator.StartTestServer(t)
 			configPutRecorder(t, ts, "default")
 			resp := configRequest(t, ts, op, map[string]any{
-				"Arn": "arn:aws:config:us-east-1:123456789012:config-recorder/ghost",
+				"Arn": "arn:aws:config:us-east-1:123456789012:configuration-recorder/ghost/deadbeef",
 			})
 			status, code, _ := decodeConfigResponse(t, resp, nil)
 			assert.Equal(t, http.StatusBadRequest, status)
@@ -631,7 +662,7 @@ func TestConfigRecorder_DescribeAcceptsTheRecordersOwnNameAndARN(t *testing.T) {
 	// a filter that matches nothing.
 	ts := emulator.StartTestServer(t)
 	configPutRecorder(t, ts, "default")
-	const arn = "arn:aws:config:us-east-1:123456789012:config-recorder/default"
+	arn := configRecorderARN(t, ts, "us-east-1")
 
 	for _, body := range []map[string]any{
 		{"ConfigurationRecorderNames": []string{"default"}},
@@ -725,8 +756,12 @@ func TestConfigRecorder_IsIsolatedByRegion(t *testing.T) {
 	status, code, message = decodeConfigResponse(t, resp, &out)
 	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
 	require.Len(t, out.ConfigurationRecorders, 1)
-	assert.Equal(t, "arn:aws:config:eu-west-1:123456789012:config-recorder/default",
+	assert.Regexp(t, `^arn:aws:config:eu-west-1:123456789012:configuration-recorder/default/`,
 		out.ConfigurationRecorders[0]["arn"], "the ARN carries the Region it was created in")
+	assert.NotEqual(t, configRecorderARN(t, ts, "us-east-1"),
+		out.ConfigurationRecorders[0]["arn"],
+		"the minted RecorderId is derived from the Region, so the two recorders differ by more "+
+			"than the ARN's region field")
 }
 
 func TestConfigRecorder_DeleteRemovesEverythingAboutIt(t *testing.T) {
@@ -734,7 +769,6 @@ func TestConfigRecorder_DeleteRemovesEverythingAboutIt(t *testing.T) {
 	// delete a resource, tags for the resource are deleted as well", and a fixture that
 	// tears down and rebuilds is just the same test run twice.
 	ts := emulator.StartTestServer(t)
-	const arn = "arn:aws:config:us-east-1:123456789012:config-recorder/default"
 
 	resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
 		"ConfigurationRecorder": configRecorderPayload("default"),
@@ -742,6 +776,7 @@ func TestConfigRecorder_DeleteRemovesEverythingAboutIt(t *testing.T) {
 	})
 	status, code, message := decodeConfigResponse(t, resp, nil)
 	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	arn := configRecorderARN(t, ts, "us-east-1")
 	configPutChannel(t, ts, "default", "cfg-logs")
 	configStartRecorder(t, ts, "default")
 
@@ -805,7 +840,7 @@ func TestConfigRecorder_RefusesTagsAWSWouldRefuse(t *testing.T) {
 		status, code, message := decodeConfigResponse(t, resp, nil)
 		require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
 		assert.Equal(t, map[string]string{"env": ""},
-			configStoredTags(t, ts, "arn:aws:config:us-east-1:123456789012:config-recorder/default"))
+			configStoredTags(t, ts, configRecorderARN(t, ts, "us-east-1")))
 	})
 }
 

--- a/emulator/configservice_tags.go
+++ b/emulator/configservice_tags.go
@@ -1,0 +1,572 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// AWS Config resource tagging: TagResource, UntagResource and ListTagsForResource
+// (#580).
+//
+// Tags matter here for a reason beyond bookkeeping: an IAM policy conditioned on
+// aws:ResourceTag is how a consumer expresses "only the compliance team may delete a
+// Config rule", and that condition cannot be evaluated unless the tags on the named
+// resource are readable at authorization time. The authz hooks at the bottom of this
+// file are what make such a policy enforceable; without them a policy scoped to one
+// rule would apply to every one.
+//
+// The three operations validate through the same cfgsvcCheckTag the Puts' creation-time
+// TagsList does, so a tag AWS would refuse cannot enter through one door having been
+// refused at the other.
+//
+// **Which resources are taggable is documented, and a delivery channel is not among
+// them.** TagResource's own ResourceArn documentation enumerates the supported types,
+// and the Service Authorization Reference's resource table — the authoritative,
+// machine-readable copy at
+// servicereference.us-east-1.amazonaws.com/v1/config/config.json — defines ten
+// resource types, none of them a delivery channel. So a channel cannot be tagged, has
+// no ARN member in its own shape to be named by, and is not policy-addressable. Of the
+// taggable types, substrate models three: the configuration recorder, the Config rule
+// and the conformance pack. An ARN naming one of the other six (an aggregator, an
+// aggregation authorization, an organization rule or pack, a remediation configuration,
+// or a stored query) is answered ResourceNotFoundException, which is also what AWS
+// answers for a type that exists but has no such instance — the same observation a
+// caller gets either way.
+//
+// One further note on the documentation: the developer guide's "Tagging AWS Config
+// resources" page claims only three types support the aws:ResourceTag condition key.
+// The Service Authorization Reference lists it on nine of the ten, and the SAR is the
+// authoritative source for authorization behavior, so that is what is implemented here.
+
+// cfgsvcMaxTagKeys is the TagKeyList bound on UntagResource, and the TagList bound on
+// TagResource: both are min 1, max 50 in the API model. The per-resource ceiling is the
+// same number (cfgsvcMaxTags) but a different rule — see untagResource for why the two
+// are answered with different exceptions.
+const cfgsvcMaxTagKeys = 50
+
+// cfgsvcMaxTagsLimit is the ceiling ListTagsForResource's Limit accepts.
+//
+// **The API reference documents this two ways.** The Limit member's own prose says
+// "The limit maximum is 50. You cannot specify a number greater than 50", while the
+// shape it points at is {"type":"integer","max":100,"min":0} — and the contradiction is
+// present in both the rendered page and the vendored model, so it is AWS's, not a
+// stale copy. Which bound the real service enforces is not documented.
+//
+// Substrate takes 100, the model's. An SDK generated from that model will not
+// client-side-reject a Limit of 60, so a request carrying one reaches the service; if
+// substrate refused it, substrate would be refusing a request the SDK was built to
+// send. Taking the wider bound means substrate never refuses what the model permits,
+// and the narrower prose is recorded as provenance rather than enforced.
+const cfgsvcMaxTagsLimit = 100
+
+// cfgsvcTagResourceRequest is TagResourceRequest; both members are required.
+type cfgsvcTagResourceRequest struct {
+	// ResourceArn names the resource to tag.
+	ResourceArn string `json:"ResourceArn"`
+
+	// Tags are the tags to apply.
+	Tags []ConfigTag `json:"Tags"`
+}
+
+// cfgsvcUntagResourceRequest is UntagResourceRequest; both members are required.
+type cfgsvcUntagResourceRequest struct {
+	// ResourceArn names the resource to untag.
+	ResourceArn string `json:"ResourceArn"`
+
+	// TagKeys are the keys of the tags to remove.
+	TagKeys []string `json:"TagKeys"`
+}
+
+// cfgsvcListTagsRequest is ListTagsForResourceRequest; only ResourceArn is required.
+type cfgsvcListTagsRequest struct {
+	// ResourceArn names the resource whose tags to list.
+	ResourceArn string `json:"ResourceArn"`
+
+	// Limit is the page size, 0-100 — see cfgsvcMaxTagsLimit for the documented
+	// contradiction in that bound.
+	Limit int `json:"Limit"`
+
+	// NextToken continues a previous page.
+	NextToken string `json:"NextToken"`
+}
+
+// --- errors ---
+
+// cfgsvcResourceNotFound is ResourceNotFoundException, carrying the model's own message
+// verbatim: "You have specified a resource that does not exist".
+func cfgsvcResourceNotFound() *AWSError {
+	return cfgsvcErr("ResourceNotFoundException", "You have specified a resource that does not exist.")
+}
+
+// cfgsvcTooManyTags is TooManyTagsException, declared by TagResource alone of the three.
+//
+// The model's message points at the Service Limits page rather than naming a number,
+// so the number is added here: a caller reading only the message otherwise cannot tell
+// what it exceeded.
+func cfgsvcTooManyTags() *AWSError {
+	return cfgsvcErr("TooManyTagsException",
+		"You have reached the limit of the number of tags you can use. You can use up to "+
+			"50 tags per resource.")
+}
+
+// tagOperation claims the three tagging operations.
+func (p *ConfigServicePlugin) tagOperation(op string) (cfgsvcHandler, bool) {
+	switch op {
+	case "TagResource":
+		return p.tagResource, true
+	case "UntagResource":
+		return p.untagResource, true
+	case "ListTagsForResource":
+		return p.listTagsForResource, true
+	}
+	return nil, false
+}
+
+// tagResource adds or updates tags on a Config resource.
+//
+// It merges rather than replaces, per the operation's own prose: "If existing tags on a
+// resource are not specified in the request parameters, they are not changed. If
+// existing tags are specified, however, then their values will be updated." So a same-key
+// tag overwrites and every other tag survives — a replace-everything implementation
+// would silently drop tags a caller never mentioned, which is the failure a consumer
+// would only notice much later.
+//
+// The two size rules are answered with different exceptions on purpose. A Tags list
+// longer than 50 violates TagList's own model bound, which ValidationException covers
+// ("missing required fields or if the input value fails the validation"). A merge that
+// would leave the *resource* holding more than 50 violates the service limit, which is
+// what TooManyTagsException is for and is the only one of the two a caller can hit with
+// a well-formed request. Both are declared by this operation.
+func (p *ConfigServicePlugin) tagResource(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcTagResourceRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	if len(in.Tags) == 0 {
+		return nil, cfgsvcValidation("Tags is required and must contain at least one tag.")
+	}
+	if len(in.Tags) > cfgsvcMaxTagKeys {
+		return nil, cfgsvcValidation("Tags accepts up to 50 tags.")
+	}
+	added, err := cfgsvcTagsToMap(in.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	goCtx := context.Background()
+	arn, err := p.cfgsvcResolveTaggable(goCtx, ctx, in.ResourceArn)
+	if err != nil {
+		return nil, err
+	}
+	tags, err := p.cfgsvcLoadTags(goCtx, arn)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range added {
+		tags[key] = value
+	}
+	if len(tags) > cfgsvcMaxTags {
+		return nil, cfgsvcTooManyTags()
+	}
+	if err := p.cfgsvcSaveTags(goCtx, arn, tags); err != nil {
+		return nil, err
+	}
+	p.logger.Debug("config: tagged resource",
+		"arn", arn, "added", len(added), "total", len(tags))
+	// TagResource has no output shape.
+	return cfgsvcEmptyResponse(), nil
+}
+
+// untagResource removes tags from a Config resource by key.
+//
+// **Removing a key the resource does not carry is a no-op at 200.** Neither the
+// operation's prose nor its error list says what happens, and the two candidate
+// exceptions it declares are for a malformed request and a missing resource — neither
+// describes an absent key. The no-op is the reading that keeps a teardown idempotent:
+// a fixture that untags before deleting, and runs twice, must not fail the second time
+// on a tag the first run already removed. Refusing would make substrate stricter than
+// anything documented, and a wrong refusal breaks working code.
+//
+// Note also that UntagResource does *not* declare TooManyTagsException — only
+// TagResource does — so a TagKeys list over the model's 50 is ValidationException here,
+// which is one of the two exceptions this operation declares.
+func (p *ConfigServicePlugin) untagResource(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	var in cfgsvcUntagResourceRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	if len(in.TagKeys) == 0 {
+		return nil, cfgsvcValidation("TagKeys is required and must contain at least one key.")
+	}
+	if len(in.TagKeys) > cfgsvcMaxTagKeys {
+		return nil, cfgsvcValidation("TagKeys accepts up to 50 tag keys.")
+	}
+	for _, key := range in.TagKeys {
+		// Only the key bounds apply: TagKey is 1-128 and there is no value to check.
+		// cfgsvcCheckTag is reused with an empty value, which it permits, so an untag
+		// and a tag agree on what a valid key is.
+		if err := cfgsvcCheckTag(key, ""); err != nil {
+			return nil, err
+		}
+	}
+
+	goCtx := context.Background()
+	arn, err := p.cfgsvcResolveTaggable(goCtx, ctx, in.ResourceArn)
+	if err != nil {
+		return nil, err
+	}
+	tags, err := p.cfgsvcLoadTags(goCtx, arn)
+	if err != nil {
+		return nil, err
+	}
+	for _, key := range in.TagKeys {
+		delete(tags, key)
+	}
+	if err := p.cfgsvcSaveTags(goCtx, arn, tags); err != nil {
+		return nil, err
+	}
+	p.logger.Debug("config: untagged resource",
+		"arn", arn, "removed", len(in.TagKeys), "remaining", len(tags))
+	// UntagResource has no output shape.
+	return cfgsvcEmptyResponse(), nil
+}
+
+// listTagsForResource reports a resource's tags, paginated.
+//
+// This is the only one of the three with an output shape. Its Tags member points at
+// TagList, whose model bound is min 1 — which cannot hold for an untagged resource, so
+// an empty list is emitted rather than an omitted member: a consumer taking len() of
+// the result gets 0 instead of a nil-pointer path, and output bounds are not something
+// an SDK enforces on the way in.
+//
+// Pagination walks the keys in sorted order so a page boundary falls in the same place
+// on every replay of the same event stream. Both InvalidLimitException and
+// InvalidNextTokenException are declared by this operation — unusually, since most
+// paginated Config operations declare one or the other — so each complaint is answered
+// with the code that describes it.
+func (p *ConfigServicePlugin) listTagsForResource(ctx *RequestContext, req *AWSRequest) (
+	*AWSResponse, error) {
+	var in cfgsvcListTagsRequest
+	if err := cfgsvcUnmarshal(req.Body, &in); err != nil {
+		return nil, err
+	}
+	if in.Limit < 0 || in.Limit > cfgsvcMaxTagsLimit {
+		return nil, cfgsvcInvalidLimit()
+	}
+
+	goCtx := context.Background()
+	arn, err := p.cfgsvcResolveTaggable(goCtx, ctx, in.ResourceArn)
+	if err != nil {
+		return nil, err
+	}
+	tags, err := p.cfgsvcLoadTags(goCtx, arn)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(tags))
+	for key := range tags {
+		keys = append(keys, key)
+	}
+	page, next, err := cfgsvcPaginate(keys, in.NextToken, in.Limit, cfgsvcMaxTagsLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	out := struct {
+		Tags      []ConfigTag `json:"Tags"`
+		NextToken string      `json:"NextToken,omitempty"`
+	}{Tags: make([]ConfigTag, 0, len(page)), NextToken: next}
+	for _, key := range page {
+		out.Tags = append(out.Tags, ConfigTag{Key: key, Value: tags[key]})
+	}
+	return cfgsvcJSONResponse(out, req.Operation)
+}
+
+// --- resolving an ARN to a resource that exists ---
+
+// cfgsvcLoadTags reads a resource's tags, returning an empty map rather than nil so a
+// caller can add to it without a nil check.
+func (p *ConfigServicePlugin) cfgsvcLoadTags(goCtx context.Context, arn string) (
+	map[string]string, error) {
+	var tags map[string]string
+	if _, err := p.cfgsvcGetJSON(goCtx, cfgsvcTagsKey(arn), &tags); err != nil {
+		return nil, err
+	}
+	if tags == nil {
+		tags = map[string]string{}
+	}
+	return tags, nil
+}
+
+// cfgsvcResolveTaggable checks that an ARN names a Config resource that exists in the
+// caller's own account and Region, returning the ARN the tags are keyed by.
+//
+// The returned ARN is the resource's *stored* ARN rather than the one the request sent.
+// For a recorder and a pack those are the same string, but reading it back from the
+// record is what keeps the tag key aligned with the key the Put wrote — the alternative
+// is two spellings of one resource's tags, one of which no operation would ever find.
+//
+// An ARN from another account or Region is ResourceNotFoundException, not a validation
+// complaint: Config is regional and per-account, so from the caller's position the
+// resource genuinely does not exist. That is also the answer for a well-formed ARN
+// naming one of the six taggable types substrate does not model.
+func (p *ConfigServicePlugin) cfgsvcResolveTaggable(goCtx context.Context, ctx *RequestContext,
+	arn string) (string, error) {
+	if arn == "" {
+		return "", cfgsvcValidation("ResourceArn is required.")
+	}
+	if len([]rune(arn)) > 1000 {
+		// AmazonResourceName is 1-1000 in the model.
+		return "", cfgsvcValidation("ResourceArn may be up to 1000 characters long.")
+	}
+
+	prefix := "arn:aws:config:" + ctx.Region + ":" + ctx.AccountID + ":"
+	if !strings.HasPrefix(arn, prefix) {
+		return "", cfgsvcResourceNotFound()
+	}
+	resource := strings.TrimPrefix(arn, prefix)
+	kind, rest, ok := strings.Cut(resource, "/")
+	if !ok || rest == "" {
+		return "", cfgsvcResourceNotFound()
+	}
+
+	switch kind {
+	case "configuration-recorder":
+		return p.cfgsvcResolveRecorderARN(goCtx, ctx, arn)
+	case "config-rule":
+		return p.cfgsvcResolveRuleARN(goCtx, ctx, rest)
+	case "conformance-pack":
+		return p.cfgsvcResolvePackARN(goCtx, ctx, arn, rest)
+	default:
+		return "", cfgsvcResourceNotFound()
+	}
+}
+
+// cfgsvcResolveRecorderARN matches an ARN against the account's recorder.
+//
+// The whole ARN is compared rather than just the name, because the template carries a
+// name *and* an ID (configuration-recorder/${RecorderName}/${RecorderId}) and the ID is
+// derived from the name — so an ARN pairing a real name with a wrong ID names no
+// resource and must not tag the real one.
+func (p *ConfigServicePlugin) cfgsvcResolveRecorderARN(goCtx context.Context, ctx *RequestContext,
+	arn string) (string, error) {
+	var recorder ConfigRecorder
+	found, err := p.cfgsvcGetJSON(goCtx, cfgsvcRecorderKey(ctx.AccountID, ctx.Region), &recorder)
+	if err != nil {
+		return "", err
+	}
+	if !found || recorder.ARN != arn {
+		return "", cfgsvcResourceNotFound()
+	}
+	return recorder.ARN, nil
+}
+
+// cfgsvcResolveRuleARN matches a config-rule/${ConfigRuleId} ARN against the account's
+// rules.
+//
+// A rule's ARN names it by ID and not by name, so the index is walked to find the rule
+// holding that ID. The alternative — deriving the name back from the ID — is impossible
+// by construction: the ID is a hash.
+func (p *ConfigServicePlugin) cfgsvcResolveRuleARN(goCtx context.Context, ctx *RequestContext,
+	ruleID string) (string, error) {
+	names, err := p.cfgsvcRuleNames(goCtx, ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, name := range names {
+		var rule ConfigRule
+		found, err := p.cfgsvcGetJSON(goCtx, cfgsvcRuleKey(ctx.AccountID, ctx.Region, name), &rule)
+		if err != nil {
+			return "", err
+		}
+		if found && rule.ConfigRuleId == ruleID {
+			return rule.ConfigRuleArn, nil
+		}
+	}
+	return "", cfgsvcResourceNotFound()
+}
+
+// cfgsvcResolvePackARN matches a conformance-pack/${Name}/${Id} ARN against the
+// account's packs, comparing the whole ARN for the reason the recorder's does.
+func (p *ConfigServicePlugin) cfgsvcResolvePackARN(goCtx context.Context, ctx *RequestContext,
+	arn, rest string) (string, error) {
+	name, _, ok := strings.Cut(rest, "/")
+	if !ok || name == "" {
+		return "", cfgsvcResourceNotFound()
+	}
+	var pack ConfigConformancePack
+	found, err := p.cfgsvcGetJSON(goCtx, cfgsvcPackKey(ctx.AccountID, ctx.Region, name), &pack)
+	if err != nil {
+		return "", err
+	}
+	if !found || pack.ConformancePackArn != arn {
+		return "", cfgsvcResourceNotFound()
+	}
+	return pack.ConformancePackArn, nil
+}
+
+// --- authorization hooks ---
+//
+// These are what buildResourceARN and the two tag-injection arms in authz.go call, and
+// they exist for the same reason the Organizations ones do: without a service-specific
+// ARN, every Config request authorizes against "*", so a policy scoped to one rule
+// applies to all of them and a test asserting a denial passes for the wrong reason.
+//
+// The resource is resolved from the operation rather than by scanning the body for any
+// name-shaped member. **One resource, not several**: an operation naming zero resources,
+// or a list of them, resolves to "*" rather than to one arbitrary member of the list.
+// Merging two named resources' tags into one condition context would let a caller
+// authorized for one resource act on the other — a false allow, which is the failure
+// direction that matters.
+
+// cfgsvcAuthzResourceARN builds the IAM resource ARN a Config request authorizes
+// against.
+//
+// Identifiers are minted rather than read from state, so an operation naming a resource
+// that does not exist still authorizes against the ARN it would have: authorization
+// runs before the handler, and a policy denying DeleteConfigRule on one rule should
+// deny it whether or not the rule is there. The mint is the same deterministic function
+// the handlers use, so the two agree.
+//
+// The delivery-channel operations resolve to "*" because **there is no delivery-channel
+// resource type**: the Service Authorization Reference gives PutDeliveryChannel,
+// DescribeDeliveryChannels, DescribeDeliveryChannelStatus and DeleteDeliveryChannel an
+// empty resource list, which is how it spells "this action authorizes against * only".
+// Synthesizing an ARN for them would invent a resource a real policy could never name.
+func cfgsvcAuthzResourceARN(reqCtx *RequestContext, req *AWSRequest) string {
+	switch req.Operation {
+	case "TagResource", "UntagResource", "ListTagsForResource":
+		// The request names the resource outright, so no minting is needed — and using
+		// the caller's own string is right even when it names nothing, because that is
+		// the resource the request asked to act on.
+		if arn := cfgsvcAuthzBodyString(req, "ResourceArn"); arn != "" {
+			return arn
+		}
+	case "PutConfigurationRecorder":
+		if name := cfgsvcAuthzRecorderPutName(req); name != "" {
+			return cfgsvcRecorderARN(reqCtx, name)
+		}
+	case "StartConfigurationRecorder", "StopConfigurationRecorder", "DeleteConfigurationRecorder":
+		if name := cfgsvcAuthzBodyString(req, "ConfigurationRecorderName"); name != "" {
+			return cfgsvcRecorderARN(reqCtx, name)
+		}
+	case "PutConfigRule":
+		if name := cfgsvcAuthzRulePutName(req); name != "" {
+			return cfgsvcRuleARN(reqCtx, cfgsvcMintRuleID(reqCtx.AccountID, reqCtx.Region, name))
+		}
+	case "DeleteConfigRule", "GetComplianceDetailsByConfigRule":
+		if name := cfgsvcAuthzBodyString(req, "ConfigRuleName"); name != "" {
+			return cfgsvcRuleARN(reqCtx, cfgsvcMintRuleID(reqCtx.AccountID, reqCtx.Region, name))
+		}
+	case "PutConformancePack", "DeleteConformancePack", "DescribeConformancePackCompliance":
+		if name := cfgsvcAuthzBodyString(req, "ConformancePackName"); name != "" {
+			return cfgsvcPackARN(reqCtx, name, cfgsvcMintPackID(reqCtx.AccountID, reqCtx.Region, name))
+		}
+	}
+	// Everything else names no single resource: the describes take name *lists*, the
+	// delivery-channel operations have no resource type, and PutEvaluations carries no
+	// rule name at all (its ResultToken is the only thing that says which rule, and
+	// decoding a token to authorize would give a caller control over the resource its
+	// own request is checked against).
+	return "*"
+}
+
+// cfgsvcAuthzResourceTags reads the tags on the resource a Config request names, for
+// aws:ResourceTag conditions.
+//
+// A read failure returns no tags rather than an error, deliberately: an absent
+// condition key makes a policy requiring it *not* match, so an unreadable resource
+// denies. Returning a partial map would be the false-allow direction.
+func cfgsvcAuthzResourceTags(state StateManager, reqCtx *RequestContext, req *AWSRequest) map[string]string {
+	arn := cfgsvcAuthzResourceARN(reqCtx, req)
+	if arn == "" || arn == "*" {
+		return nil
+	}
+	raw, err := state.Get(context.Background(), configServiceNamespace, cfgsvcTagsKey(arn))
+	if err != nil || raw == nil {
+		return nil
+	}
+	var tags map[string]string
+	if err := json.Unmarshal(raw, &tags); err != nil {
+		return nil
+	}
+	return tags
+}
+
+// cfgsvcAuthzRequestTags reads the tags a Config request is trying to apply, for
+// aws:RequestTag conditions.
+//
+// All four creating operations and TagResource carry the same [{Key,Value}] list, under
+// "Tags" — so one reader serves them all, and a policy can gate a tagged
+// PutConfigurationRecorder on the tag being applied rather than only on tags already
+// stored.
+func cfgsvcAuthzRequestTags(req *AWSRequest) map[string]string {
+	var body struct {
+		Tags []ConfigTag `json:"Tags"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil || len(body.Tags) == 0 {
+		return nil
+	}
+	tags := make(map[string]string, len(body.Tags))
+	for _, tag := range body.Tags {
+		tags[tag.Key] = tag.Value
+	}
+	return tags
+}
+
+// cfgsvcAuthzBodyString reads one top-level string member from a request body, quietly
+// reporting "" for a body that will not parse: the handler answers that with the
+// service's own validation exception, and authorization is not the place to decide a
+// request is malformed.
+func cfgsvcAuthzBodyString(req *AWSRequest, member string) string {
+	var body map[string]interface{}
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return ""
+	}
+	value, _ := body[member].(string)
+	return value
+}
+
+// cfgsvcAuthzRecorderPutName reads the recorder name out of a PutConfigurationRecorder
+// body, where it is nested under ConfigurationRecorder and spelled lowerCamel ("name")
+// unlike every other member — the API model's asymmetry, not substrate's.
+//
+// An omitted name defaults to "default", the same default the handler applies, so the
+// policy and the handler are talking about the same recorder.
+func cfgsvcAuthzRecorderPutName(req *AWSRequest) string {
+	var body struct {
+		ConfigurationRecorder struct {
+			Name string `json:"name"`
+		} `json:"ConfigurationRecorder"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return ""
+	}
+	if body.ConfigurationRecorder.Name == "" {
+		return cfgsvcDefaultName
+	}
+	return body.ConfigurationRecorder.Name
+}
+
+// cfgsvcAuthzRulePutName reads the rule name out of a PutConfigRule body, where it is
+// nested under ConfigRule.
+//
+// An update may name its rule by Id or Arn instead of by Name. Those resolve to "*"
+// rather than being converted, because converting would require reading state to find
+// which rule an ID belongs to and then authorizing against a resource the request did
+// not name — and if the lookup missed, the request would authorize against a
+// *different* rule's ARN. "*" is the honest answer for a request whose resource cannot
+// be named without a lookup that can be wrong.
+func cfgsvcAuthzRulePutName(req *AWSRequest) string {
+	var body struct {
+		ConfigRule struct {
+			ConfigRuleName string `json:"ConfigRuleName"`
+		} `json:"ConfigRule"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return ""
+	}
+	return body.ConfigRule.ConfigRuleName
+}

--- a/emulator/configservice_tags_test.go
+++ b/emulator/configservice_tags_test.go
@@ -1,0 +1,624 @@
+package emulator_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AWS Config resource tagging (#580).
+//
+// Two behaviors carry the weight here. The first is that TagResource *merges*: a tag
+// the request did not mention survives, per "if existing tags on a resource are not
+// specified in the request parameters, they are not changed". A replace-everything
+// implementation passes a naive round-trip test and silently drops tags a consumer set
+// earlier, so the merge is asserted in both directions — the new tag arrives and the
+// old one is still there.
+//
+// The second is which ARNs name a taggable resource. Substrate models three of the ten
+// types the Service Authorization Reference defines, and **a delivery channel is not one
+// of the ten at all** — so an ARN naming one is refused rather than accepted into a
+// namespace no operation would ever read back. The cases below also pin that an ARN
+// pairing a real name with a wrong ID is refused, because a recorder's and a pack's ARN
+// each carry two components and matching only the first would tag the real resource from
+// a bogus ARN.
+
+// configTagServer starts a server holding one of each taggable resource, and returns
+// their ARNs read back from the API rather than assembled here.
+func configTagServer(t *testing.T) (ts *emulator.TestServer, recorderARN, ruleARN, packARN string) {
+	t.Helper()
+	ts = emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutRule(t, ts, "s3-encrypted")
+	packARN = configPutPack(t, ts, "ops")
+	recorderARN = configRecorderARN(t, ts, "us-east-1")
+
+	rules := configDescribeRules(t, ts, map[string]any{})
+	require.Len(t, rules, 1)
+	arn, ok := rules[0]["ConfigRuleArn"].(string)
+	require.True(t, ok, "the rule reports a ConfigRuleArn")
+	return ts, recorderARN, arn, packARN
+}
+
+// configTagResource sends a TagResource and returns the status and error code.
+func configTagResource(t *testing.T, ts *emulator.TestServer, arn string,
+	tags []map[string]any) (int, string, string) {
+	t.Helper()
+	resp := configRequest(t, ts, "TagResource", map[string]any{"ResourceArn": arn, "Tags": tags})
+	return decodeConfigResponse(t, resp, nil)
+}
+
+// configTag builds one Tag member.
+func configTag(key, value string) map[string]any {
+	return map[string]any{"Key": key, "Value": value}
+}
+
+// configTagOK tags a resource and requires that it succeed.
+func configTagOK(t *testing.T, ts *emulator.TestServer, arn string, tags ...map[string]any) {
+	t.Helper()
+	status, code, message := configTagResource(t, ts, arn, tags)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+}
+
+// configUntagResource sends an UntagResource and returns the status and error code.
+func configUntagResource(t *testing.T, ts *emulator.TestServer, arn string,
+	keys []string) (int, string, string) {
+	t.Helper()
+	resp := configRequest(t, ts, "UntagResource", map[string]any{"ResourceArn": arn, "TagKeys": keys})
+	return decodeConfigResponse(t, resp, nil)
+}
+
+// configListTagsRaw sends a ListTagsForResource and returns the whole response.
+func configListTagsRaw(t *testing.T, ts *emulator.TestServer, body map[string]any) (
+	tags []map[string]any, next string, status int, code, message string) {
+	t.Helper()
+	resp := configRequest(t, ts, "ListTagsForResource", body)
+	var out struct {
+		Tags      []map[string]any `json:"Tags"`
+		NextToken string           `json:"NextToken"`
+	}
+	status, code, message = decodeConfigResponse(t, resp, &out)
+	return out.Tags, out.NextToken, status, code, message
+}
+
+// configListTags reads a resource's tags as a map, requiring success.
+func configListTags(t *testing.T, ts *emulator.TestServer, arn string) map[string]string {
+	t.Helper()
+	tags, next, status, code, message := configListTagsRaw(t, ts, map[string]any{"ResourceArn": arn})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	require.Empty(t, next, "a resource under the page size reports no NextToken")
+	return configTagsToMap(t, tags)
+}
+
+// configTagsToMap folds a reported TagList into a map, asserting each member's shape on
+// the way through.
+func configTagsToMap(t *testing.T, tags []map[string]any) map[string]string {
+	t.Helper()
+	out := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		key, ok := tag["Key"].(string)
+		require.True(t, ok, "each tag reports a Key: %v", tag)
+		value, ok := tag["Value"].(string)
+		require.True(t, ok, "each tag reports a Value: %v", tag)
+		out[key] = value
+	}
+	return out
+}
+
+func TestConfigTags_MergeRatherThanReplace(t *testing.T) {
+	// The behavior the operation's own prose specifies: "If existing tags on a resource
+	// are not specified in the request parameters, they are not changed. If existing
+	// tags are specified, however, then their values will be updated."
+	//
+	// Both halves matter and they fail in opposite directions. An implementation that
+	// replaced would drop `owner`, and one that refused to overwrite would leave `env`
+	// at its first value — each passes a test that checks only the other.
+	ts, _, ruleARN, _ := configTagServer(t)
+
+	configTagOK(t, ts, ruleARN, configTag("env", "dev"), configTag("owner", "platform"))
+	configTagOK(t, ts, ruleARN, configTag("env", "prod"))
+
+	assert.Equal(t, map[string]string{"env": "prod", "owner": "platform"},
+		configListTags(t, ts, ruleARN),
+		"the named tag is updated and the unnamed one survives")
+}
+
+func TestConfigTags_EachTaggableTypeIsReachable(t *testing.T) {
+	// The three types substrate models, each tagged and read back through its own ARN.
+	// A recorder's and a pack's ARN carry two components while a rule's carries one, so
+	// this is also where the three resolution paths are exercised at all.
+	ts, recorderARN, ruleARN, packARN := configTagServer(t)
+
+	for _, tc := range []struct{ name, arn string }{
+		{"recorder", recorderARN},
+		{"rule", ruleARN},
+		{"pack", packARN},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configTagOK(t, ts, tc.arn, configTag("kind", tc.name))
+			assert.Equal(t, map[string]string{"kind": tc.name}, configListTags(t, ts, tc.arn))
+		})
+	}
+}
+
+func TestConfigTags_AreNotSharedBetweenResources(t *testing.T) {
+	// Tags are keyed by ARN, so tagging one resource must not be visible on another.
+	// A key that dropped the ARN would make every Config resource in the account share
+	// one tag set, which is the shape a policy conditioned on aws:ResourceTag would then
+	// match far too widely.
+	ts, recorderARN, ruleARN, packARN := configTagServer(t)
+
+	configTagOK(t, ts, ruleARN, configTag("env", "prod"))
+
+	assert.Empty(t, configListTags(t, ts, recorderARN))
+	assert.Empty(t, configListTags(t, ts, packARN))
+}
+
+func TestConfigTags_CreationTimeTagsAreVisibleToTheTagAPI(t *testing.T) {
+	// A Put's Tags list and ListTagsForResource must agree: the Put writes tags keyed by
+	// the resource's stored ARN and the tag cluster resolves the caller's ARN back to
+	// that same key. Two spellings of one resource's tags would each be invisible to the
+	// other, and the Put's would be the copy no operation ever read.
+	ts := emulator.StartTestServer(t)
+	resp := configRequest(t, ts, "PutConfigurationRecorder", map[string]any{
+		"ConfigurationRecorder": configRecorderPayload("default"),
+		"Tags":                  []map[string]any{configTag("team", "compliance")},
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	arn := configRecorderARN(t, ts, "us-east-1")
+	assert.Equal(t, map[string]string{"team": "compliance"}, configListTags(t, ts, arn),
+		"the tag API reads what the Put wrote")
+	assert.Equal(t, configStoredTags(t, ts, arn), configListTags(t, ts, arn),
+		"the wire response and the stored state agree")
+}
+
+func TestConfigTags_ATagAddedByTheAPIIsNotErasedByAnUpdatingPut(t *testing.T) {
+	// A second Put does not touch tags — "the tags for a configuration recorder are
+	// added at creation and are not updated with configuration recorder updates" — and
+	// that has to hold for tags the *tag API* added too, not only for creation-time
+	// ones. Otherwise an unrelated recording-group update would silently delete a
+	// consumer's tags.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	arn := configRecorderARN(t, ts, "us-east-1")
+	configTagOK(t, ts, arn, configTag("env", "prod"))
+
+	configPutRecorder(t, ts, "default")
+
+	assert.Equal(t, map[string]string{"env": "prod"}, configListTags(t, ts, arn))
+}
+
+func TestConfigTags_UntagRemovesOnlyTheNamedKeys(t *testing.T) {
+	ts, _, ruleARN, _ := configTagServer(t)
+	configTagOK(t, ts, ruleARN,
+		configTag("env", "prod"), configTag("owner", "platform"), configTag("tier", "1"))
+
+	status, code, message := configUntagResource(t, ts, ruleARN, []string{"env", "tier"})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	assert.Equal(t, map[string]string{"owner": "platform"}, configListTags(t, ts, ruleARN))
+}
+
+func TestConfigTags_UntaggingAnAbsentKeyIsANoOp(t *testing.T) {
+	// Undocumented either way: the operation's prose does not say, and neither of the
+	// two exceptions it declares (ValidationException, ResourceNotFoundException)
+	// describes an absent key.
+	//
+	// Substrate answers 200. The no-op is what keeps a teardown idempotent — a fixture
+	// that untags before deleting, run twice, must not fail the second time on a tag the
+	// first run already removed — and refusing would make substrate stricter than
+	// anything documented, which breaks working code.
+	ts, _, ruleARN, _ := configTagServer(t)
+	configTagOK(t, ts, ruleARN, configTag("env", "prod"))
+
+	status, code, message := configUntagResource(t, ts, ruleARN, []string{"nosuchkey"})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	status, code, message = configUntagResource(t, ts, ruleARN, []string{"env"})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	status, code, message = configUntagResource(t, ts, ruleARN, []string{"env"})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	assert.Empty(t, configListTags(t, ts, ruleARN))
+}
+
+func TestConfigTags_AnUntaggedResourceReportsAnEmptyList(t *testing.T) {
+	// TagList's model bound is min 1, which cannot hold for a resource with no tags, so
+	// the member is emitted empty rather than omitted: a consumer taking len() of the
+	// result gets 0 rather than following a nil path. Output bounds are not something an
+	// SDK enforces on the way in.
+	ts, recorderARN, _, _ := configTagServer(t)
+
+	tags, next, status, code, message := configListTagsRaw(t, ts,
+		map[string]any{"ResourceArn": recorderARN})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Empty(t, tags)
+	assert.Empty(t, next)
+}
+
+func TestConfigTags_TheDeliveryChannelIsNotTaggable(t *testing.T) {
+	// **There is no delivery-channel resource type.** The Service Authorization
+	// Reference defines ten Config resource types and none is a delivery channel;
+	// PutDeliveryChannel and its three siblings authorize against an empty resource
+	// list, i.e. "*". TagResource's own ResourceArn documentation likewise does not list
+	// a delivery channel among the taggable types, and the DeliveryChannel shape has no
+	// arn member to be named by.
+	//
+	// So an ARN in the shape one might guess is refused. Accepting it would write tags
+	// into a key no operation reads back, and a consumer's test asserting the tag "took"
+	// would pass while nothing had happened.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+
+	for _, arn := range []string{
+		"arn:aws:config:us-east-1:123456789012:delivery-channel/default",
+		"arn:aws:config:us-east-1:123456789012:deliverychannel/default",
+	} {
+		status, code, _ := configTagResource(t, ts, arn, []map[string]any{configTag("env", "prod")})
+		assert.Equal(t, http.StatusBadRequest, status, arn)
+		assert.Equal(t, "ResourceNotFoundException", code, arn)
+	}
+}
+
+func TestConfigTags_ARefusedARNRefusesAllThreeOperations(t *testing.T) {
+	// The three operations resolve the ARN through one function, so an ARN that names
+	// nothing must be refused by all three. A read path that resolved more loosely than
+	// the write path would report tags for a resource a tag could not be written to.
+	ts, _, ruleARN, _ := configTagServer(t)
+
+	for _, tc := range []struct{ name, arn string }{
+		{"an empty ARN", ""},
+		{"not an ARN at all", "s3-encrypted"},
+		{"another service's ARN", "arn:aws:s3:::cfg-logs"},
+		{"a resource type substrate does not model",
+			"arn:aws:config:us-east-1:123456789012:config-aggregator/agg"},
+		{"a resource type that does not exist",
+			"arn:aws:config:us-east-1:123456789012:nosuchtype/thing"},
+		{"a type with no identifier", "arn:aws:config:us-east-1:123456789012:config-rule/"},
+		{"another account's rule",
+			strings.Replace(ruleARN, "123456789012", "210987654321", 1)},
+		{"another Region's rule", strings.Replace(ruleARN, "us-east-1", "eu-west-1", 1)},
+		{"an unknown rule ID", "arn:aws:config:us-east-1:123456789012:config-rule/config-rule-nope00"},
+		{"a recorder ARN with the wrong ID",
+			"arn:aws:config:us-east-1:123456789012:configuration-recorder/default/deadbeef"},
+		{"a recorder ARN with no ID component",
+			"arn:aws:config:us-east-1:123456789012:configuration-recorder/default"},
+		{"a pack ARN with the wrong ID",
+			"arn:aws:config:us-east-1:123456789012:conformance-pack/ops/conformance-pack-xxxxxxxx"},
+		{"an unknown pack", "arn:aws:config:us-east-1:123456789012:conformance-pack/ghost/x"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// An empty ARN is a missing required member, which is ValidationException;
+			// every other case names a resource that does not exist from the caller's
+			// position, which is ResourceNotFoundException.
+			want := "ResourceNotFoundException"
+			if tc.arn == "" {
+				want = "ValidationException"
+			}
+
+			status, code, _ := configTagResource(t, ts, tc.arn, []map[string]any{configTag("k", "v")})
+			assert.Equal(t, http.StatusBadRequest, status, "TagResource")
+			assert.Equal(t, want, code, "TagResource")
+
+			status, code, _ = configUntagResource(t, ts, tc.arn, []string{"k"})
+			assert.Equal(t, http.StatusBadRequest, status, "UntagResource")
+			assert.Equal(t, want, code, "UntagResource")
+
+			_, _, status, code, _ = configListTagsRaw(t, ts, map[string]any{"ResourceArn": tc.arn})
+			assert.Equal(t, http.StatusBadRequest, status, "ListTagsForResource")
+			assert.Equal(t, want, code, "ListTagsForResource")
+		})
+	}
+}
+
+func TestConfigTags_AreIsolatedByRegion(t *testing.T) {
+	// Config is regional and every state key carries the Region, so a rule tagged in one
+	// Region is not tagged in the other — and a rule of the same name in the other
+	// Region has a different ARN, because the minted ID is Region-derived.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutRecorderIn(t, ts, "eu-west-1", "default")
+	configPutRule(t, ts, "s3-encrypted")
+
+	resp := configRequestIn(t, ts, "eu-west-1", "PutConfigRule", map[string]any{
+		"ConfigRule": configRulePayload("s3-encrypted"),
+	})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	east := configDescribeRules(t, ts, map[string]any{})
+	require.Len(t, east, 1)
+	eastARN, ok := east[0]["ConfigRuleArn"].(string)
+	require.True(t, ok)
+
+	resp = configRequestIn(t, ts, "eu-west-1", "DescribeConfigRules", map[string]any{})
+	var out struct {
+		ConfigRules []map[string]any `json:"ConfigRules"`
+	}
+	status, code, message = decodeConfigResponse(t, resp, &out)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	require.Len(t, out.ConfigRules, 1)
+	westARN, ok := out.ConfigRules[0]["ConfigRuleArn"].(string)
+	require.True(t, ok)
+	require.NotEqual(t, eastARN, westARN, "the same rule name in two Regions has two ARNs")
+
+	configTagOK(t, ts, eastARN, configTag("env", "prod"))
+
+	// The west ARN is refused in us-east-1 outright: it names a resource that does not
+	// exist from this Region's position.
+	_, _, status, code, _ = configListTagsRaw(t, ts, map[string]any{"ResourceArn": westARN})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "ResourceNotFoundException", code)
+
+	// And read from its own Region, the west rule carries no tags.
+	resp = configRequestIn(t, ts, "eu-west-1", "ListTagsForResource",
+		map[string]any{"ResourceArn": westARN})
+	var west struct {
+		Tags []map[string]any `json:"Tags"`
+	}
+	status, code, message = decodeConfigResponse(t, resp, &west)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Empty(t, west.Tags, "the tag was applied in us-east-1 only")
+}
+
+func TestConfigTags_RefusesTagsAWSWouldRefuse(t *testing.T) {
+	// The same restrictions the creation-time TagsList enforces, through the same
+	// helper: a tag AWS would refuse must not enter through one door having been refused
+	// at the other.
+	ts, _, ruleARN, _ := configTagServer(t)
+
+	for _, tc := range []struct {
+		name string
+		tags []map[string]any
+		want string
+	}{
+		{"no Tags member at all", nil, "ValidationException"},
+		{"an empty list", []map[string]any{}, "ValidationException"},
+		{"an empty key", []map[string]any{configTag("", "v")}, "ValidationException"},
+		{"a key over 128 characters",
+			[]map[string]any{configTag(strings.Repeat("k", 129), "v")}, "ValidationException"},
+		{"a value over 256 characters",
+			[]map[string]any{configTag("k", strings.Repeat("v", 257))}, "ValidationException"},
+		{"the reserved aws: prefix", []map[string]any{configTag("aws:x", "v")}, "ValidationException"},
+		{"the reserved prefix in any case",
+			[]map[string]any{configTag("AWS:x", "v")}, "ValidationException"},
+		{"a character outside the documented set",
+			[]map[string]any{configTag("k$", "v")}, "ValidationException"},
+		{"more than 50 tags in one request", configTagsOfN(51), "ValidationException"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code, _ := configTagResource(t, ts, ruleARN, tc.tags)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tc.want, code)
+		})
+	}
+
+	// The boundaries themselves are accepted, so the bounds are off-by-one-proof.
+	configTagOK(t, ts, ruleARN,
+		configTag(strings.Repeat("k", 128), strings.Repeat("v", 256)),
+		configTag("empty-value-is-allowed", ""),
+		configTag("unicode-and-symbols_.:/=+-@", "καλημέρα 1"))
+}
+
+func TestConfigTags_TheResourceCeilingIsFiftyAndIsTooManyTags(t *testing.T) {
+	// Two size rules, two exceptions, and only one of them is reachable with a
+	// well-formed request.
+	//
+	// A Tags *list* longer than 50 breaks TagList's own model bound, which is
+	// ValidationException. A merge that would leave the *resource* holding more than 50
+	// breaks the service limit, which is what TooManyTagsException exists for — and it
+	// is reachable only across two calls, because no single request may carry 51 tags.
+	// TagResource is the one of the three operations that declares it.
+	ts, _, ruleARN, _ := configTagServer(t)
+
+	configTagOK(t, ts, ruleARN, configTagsOfN(50)...)
+	assert.Len(t, configListTags(t, ts, ruleARN), 50, "the fiftieth tag is accepted")
+
+	// Re-tagging an existing key does not grow the resource, so it still succeeds at the
+	// ceiling — otherwise a consumer could never correct a tag's value on a full
+	// resource.
+	configTagOK(t, ts, ruleARN, configTag("tag-00", "changed"))
+	assert.Equal(t, "changed", configListTags(t, ts, ruleARN)["tag-00"])
+
+	status, code, message := configTagResource(t, ts, ruleARN,
+		[]map[string]any{configTag("one-too-many", "v")})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "TooManyTagsException", code)
+	assert.Contains(t, message, "50", "the message names the limit the model's own does not")
+
+	assert.Len(t, configListTags(t, ts, ruleARN), 50, "the refused tag was not stored")
+}
+
+func TestConfigTags_UntagRefusesKeysAWSWouldRefuse(t *testing.T) {
+	// UntagResource declares ValidationException and ResourceNotFoundException and
+	// **not** TooManyTagsException — only TagResource declares that — so an over-long
+	// TagKeys list is answered here with the code this operation actually declares.
+	ts, _, ruleARN, _ := configTagServer(t)
+
+	tooMany := make([]string, 51)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("tag-%02d", i)
+	}
+
+	for _, tc := range []struct {
+		name string
+		keys []string
+	}{
+		{"no TagKeys member at all", nil},
+		{"an empty list", []string{}},
+		{"an empty key", []string{""}},
+		{"a key over 128 characters", []string{strings.Repeat("k", 129)}},
+		{"more than 50 keys", tooMany},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code, _ := configUntagResource(t, ts, ruleARN, tc.keys)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "ValidationException", code)
+		})
+	}
+
+	// Exactly 50 keys is the bound and is accepted.
+	status, code, message := configUntagResource(t, ts, ruleARN, tooMany[:50])
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+}
+
+func TestConfigTags_ListPaginatesAtTheModelsHundred(t *testing.T) {
+	// **The Limit is documented two ways** — the member's prose says "The limit maximum
+	// is 50. You cannot specify a number greater than 50", the shape it points at is
+	// max 100 — and the contradiction is in both the rendered page and the vendored
+	// model, so it is AWS's rather than a stale copy.
+	//
+	// Substrate takes 100, the model's bound, because an SDK generated from that model
+	// will not client-side-reject a Limit of 60: refusing one would mean refusing a
+	// request the SDK was built to send. So 60 is accepted here, which is exactly the
+	// value that tells the two readings apart.
+	ts, _, ruleARN, _ := configTagServer(t)
+	configTagOK(t, ts, ruleARN, configTagsOfN(50)...)
+
+	for _, limit := range []int{1, 50, 51, 60, 100} {
+		tags, _, status, code, message := configListTagsRaw(t, ts,
+			map[string]any{"ResourceArn": ruleARN, "Limit": limit})
+		require.Equal(t, http.StatusOK, status, "Limit %d: %s: %s", limit, code, message)
+		assert.LessOrEqual(t, len(tags), limit, "Limit %d bounds the page", limit)
+	}
+
+	for _, limit := range []int{-1, 101} {
+		_, _, status, code, _ := configListTagsRaw(t, ts,
+			map[string]any{"ResourceArn": ruleARN, "Limit": limit})
+		assert.Equal(t, http.StatusBadRequest, status, "Limit %d", limit)
+		assert.Equal(t, "InvalidLimitException", code, "Limit %d", limit)
+	}
+}
+
+func TestConfigTags_PaginationWalksEveryTag(t *testing.T) {
+	// Pagination walks the keys in sorted order, so a page boundary falls in the same
+	// place on every replay. Every tag must appear exactly once across the pages: a
+	// token that re-served a page would loop a consumer's walk, and one that skipped
+	// would silently lose tags.
+	ts, _, ruleARN, _ := configTagServer(t)
+	configTagOK(t, ts, ruleARN, configTagsOfN(50)...)
+
+	seen := map[string]string{}
+	body := map[string]any{"ResourceArn": ruleARN, "Limit": 7}
+	for pages := 0; ; pages++ {
+		require.Less(t, pages, 20, "pagination terminates")
+		tags, next, status, code, message := configListTagsRaw(t, ts, body)
+		require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+		require.LessOrEqual(t, len(tags), 7)
+		for key, value := range configTagsToMap(t, tags) {
+			_, dup := seen[key]
+			require.False(t, dup, "%s appears on two pages", key)
+			seen[key] = value
+		}
+		if next == "" {
+			break
+		}
+		body["NextToken"] = next
+	}
+	assert.Len(t, seen, 50, "every tag appeared exactly once")
+}
+
+func TestConfigTags_ABadNextTokenIsRefused(t *testing.T) {
+	// ListTagsForResource declares **both** InvalidLimitException and
+	// InvalidNextTokenException, which is unusual — most paginated Config operations
+	// declare one or the other — so each complaint is answered with the code that
+	// describes it rather than with whichever one the cluster happens to share.
+	ts, _, ruleARN, _ := configTagServer(t)
+	configTagOK(t, ts, ruleARN, configTag("env", "prod"))
+
+	for _, token := range []string{"not-base64!!", "bm9zdWNoa2V5"} {
+		_, _, status, code, _ := configListTagsRaw(t, ts,
+			map[string]any{"ResourceArn": ruleARN, "NextToken": token})
+		assert.Equal(t, http.StatusBadRequest, status, token)
+		assert.Equal(t, "InvalidNextTokenException", code, token)
+	}
+}
+
+func TestConfigTags_GoWithTheResourceOnDelete(t *testing.T) {
+	// "If you delete a resource, any tags for the resource are also deleted." Leaving
+	// them would make a rebuilt resource of the same name inherit its predecessor's
+	// tags — which no AWS account does, and which a fixture that tears down and rebuilds
+	// would see as a tag it never set.
+	//
+	// The ARN is deterministic, so a rebuilt resource has the same ARN and would read
+	// the stale tags back if the delete had not removed them. That is what makes this
+	// assertable at all.
+	ts, _, ruleARN, packARN := configTagServer(t)
+	configTagOK(t, ts, ruleARN, configTag("env", "prod"))
+	configTagOK(t, ts, packARN, configTag("env", "prod"))
+
+	status, code, message := decodeConfigResponse(t,
+		configRequest(t, ts, "DeleteConfigRule", map[string]any{"ConfigRuleName": "s3-encrypted"}), nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	// A pack must be observed before it is deletable: its state advances to
+	// CREATE_COMPLETE on the first observation, and a delete arriving while it is still
+	// CREATE_IN_PROGRESS is ResourceInUseException.
+	require.Equal(t, "CREATE_COMPLETE", configPackStateOf(t, ts, "ops")["ConformancePackState"])
+	status, code, message = configDeletePack(t, ts, "ops")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	configPutRule(t, ts, "s3-encrypted")
+	rebuilt := configPutPack(t, ts, "ops")
+	require.Equal(t, packARN, rebuilt, "the rebuilt pack has the same ARN")
+
+	assert.Empty(t, configListTags(t, ts, ruleARN), "the rebuilt rule carries no stale tags")
+	assert.Empty(t, configListTags(t, ts, packARN), "the rebuilt pack carries no stale tags")
+}
+
+func TestConfigTags_RecorderTagsGoWithTheRecorder(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	arn := configRecorderARN(t, ts, "us-east-1")
+	configTagOK(t, ts, arn, configTag("env", "prod"))
+
+	status, code, message := decodeConfigResponse(t, configRequest(t, ts,
+		"DeleteConfigurationRecorder", map[string]any{"ConfigurationRecorderName": "default"}), nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	configPutRecorder(t, ts, "default")
+	require.Equal(t, arn, configRecorderARN(t, ts, "us-east-1"),
+		"the rebuilt recorder has the same ARN")
+	assert.Empty(t, configListTags(t, ts, arn))
+}
+
+func TestConfigTags_AreClearedRatherThanStoredEmpty(t *testing.T) {
+	// Removing the last tag deletes the state key rather than storing "{}", so a state
+	// dump of a fully-untagged resource carries no shadow of the tags it once had.
+	ts, _, ruleARN, _ := configTagServer(t)
+	configTagOK(t, ts, ruleARN, configTag("env", "prod"))
+
+	status, code, message := configUntagResource(t, ts, ruleARN, []string{"env"})
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	assert.Nil(t, configStoredTags(t, ts, ruleARN), "the key is gone, not an empty map")
+}
+
+func TestConfigTags_AnUnsupportedTagOperationIsRefusedByName(t *testing.T) {
+	// AWS Config has 97 operations; substrate implements the detective-controls subset.
+	// An unclaimed one names itself so a consumer discovers which call is missing.
+	ts := emulator.StartTestServer(t)
+
+	status, code, message := decodeConfigResponse(t,
+		configRequest(t, ts, "ListResourceEvaluations", map[string]any{}), nil)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidAction", code)
+	assert.Contains(t, message, "ListResourceEvaluations")
+}
+
+// configTagsOfN builds n distinct tags, named so their sort order is stable.
+func configTagsOfN(n int) []map[string]any {
+	tags := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		tags = append(tags, configTag(fmt.Sprintf("tag-%02d", i), fmt.Sprintf("value-%02d", i)))
+	}
+	return tags
+}

--- a/emulator/configservice_teardown_test.go
+++ b/emulator/configservice_teardown_test.go
@@ -1,0 +1,241 @@
+package emulator_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AWS Config teardown ordering (#580).
+//
+// The four deletes live in their own clusters' files, but their *combined* behavior is
+// what justifies including them in scope, so it is asserted here as a sequence rather
+// than as four isolated refusals. The sequence is the one a repeated test run performs:
+// tear the account's Config setup down and build it again.
+//
+// The load-bearing fact is an **asymmetry between the two deletes**, and it is easy to
+// get wrong in the tidy direction:
+//
+//   - DeleteDeliveryChannel refuses while the recorder is recording, with
+//     LastDeliveryChannelDeleteFailedException. Its prose says so outright: "Before you
+//     can delete the delivery channel, you must stop the customer managed configuration
+//     recorder."
+//   - DeleteConfigurationRecorder has **no documented precondition whatsoever**. It
+//     declares two exceptions — NoSuchConfigurationRecorderException and
+//     UnmodifiableEntityException — and neither could express "stop it first" or "delete
+//     the channel first". So substrate permits both.
+//
+// An emulator that "helpfully" required the recorder to be stopped before deleting it
+// would refuse a sequence AWS accepts, and a consumer whose teardown works against AWS
+// would fail here. That is the worse failure of the two directions, so the permissive
+// reading is asserted deliberately below rather than left to chance.
+
+func TestConfigTeardown_TheOrderingSequence(t *testing.T) {
+	// The whole story in one test, in order, because the ordering is the behavior — the
+	// refusal only means something in the context of the steps around it.
+	ts := emulator.StartTestServer(t)
+
+	// --- build ---
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+	require.Equal(t, true, configDescribeRecorderStatus(t, ts)[0]["recording"],
+		"the recorder is recording before the teardown starts")
+
+	// --- the refusal: the channel cannot go while the recorder runs ---
+	status, code, message := configDeleteChannel(t, ts, "default")
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "LastDeliveryChannelDeleteFailedException", code)
+	assert.Contains(t, message, "configuration recorder is running",
+		"the message names the reason, which is what a consumer's log will show")
+
+	// The refusal changed nothing: the channel is still there. A refusal that had
+	// deleted anyway would leave a consumer's retry acting on state it cannot see.
+	require.Len(t, configDescribeChannels(t, ts), 1, "the refused delete removed nothing")
+
+	// --- stop, then the same delete succeeds ---
+	configStopRecorder(t, ts, "default")
+	status, code, message = configDeleteChannel(t, ts, "default")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Empty(t, configDescribeChannels(t, ts))
+
+	// --- the recorder goes next, and the recorder's delete does not touch a channel ---
+	status, code, message = configDeleteRecorder(t, ts, "default")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Empty(t, configDescribeRecorders(t, ts))
+	assert.Empty(t, configDescribeRecorderStatus(t, ts),
+		"the status goes with the recorder, so a rebuilt one does not inherit recording:true")
+
+	// --- rebuild: the same sequence runs clean a second time ---
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	require.Equal(t, false, configDescribeRecorderStatus(t, ts)[0]["recording"],
+		"a rebuilt recorder starts not recording, whatever its predecessor was doing")
+	configStartRecorder(t, ts, "default")
+	assert.Equal(t, true, configDescribeRecorderStatus(t, ts)[0]["recording"])
+}
+
+func TestConfigTeardown_TheRecorderCanBeDeletedWhileRecording(t *testing.T) {
+	// The asymmetry, asserted on its own so it cannot be lost in the sequence above.
+	//
+	// DeleteConfigurationRecorder declares only NoSuchConfigurationRecorderException and
+	// UnmodifiableEntityException. There is no exception it could answer for "the
+	// recorder is running" or "the channel still exists", and no prose requiring either,
+	// so both succeed. Requiring a Stop first would be substrate inventing a rule.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+
+	status, code, message := configDeleteRecorder(t, ts, "default")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Empty(t, configDescribeRecorders(t, ts))
+
+	// And the channel outlived it — deleting a recorder does not cascade. A fixture that
+	// tears down must delete both, which is exactly why the sequence above deletes the
+	// channel first.
+	assert.Len(t, configDescribeChannels(t, ts), 1,
+		"the channel is not deleted with the recorder")
+}
+
+func TestConfigTeardown_AnOrphanedChannelIsDeletableWithNoRecorder(t *testing.T) {
+	// The state the previous case leaves behind: a channel whose recorder is gone. The
+	// delete's guard reads the recorder's *status*, and with no recorder there is no
+	// status, so the guard must treat an absent status as "not recording" rather than
+	// failing to read it. Otherwise a teardown that deleted the recorder first would
+	// wedge, with no documented way out.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+
+	status, code, message := configDeleteRecorder(t, ts, "default")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	status, code, message = configDeleteChannel(t, ts, "default")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	assert.Empty(t, configDescribeChannels(t, ts))
+}
+
+func TestConfigTeardown_TheStoppedRecorderRefusalIsNotResurrectedByARestart(t *testing.T) {
+	// Stop then Start then Delete-channel must refuse again. A guard that read a
+	// one-shot "has been stopped" flag rather than the current recording state would
+	// permit the delete after the restart, which is the mutation this case exists to
+	// catch.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+	configStartRecorder(t, ts, "default")
+	configStopRecorder(t, ts, "default")
+	configStartRecorder(t, ts, "default")
+
+	status, code, _ := configDeleteChannel(t, ts, "default")
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "LastDeliveryChannelDeleteFailedException", code)
+}
+
+func TestConfigTeardown_ADeleteOfSomethingAbsentIsRefusedNotIgnored(t *testing.T) {
+	// Each delete refuses an entity that is not there, with the exception its own model
+	// declares. A delete that silently succeeded would make a teardown-then-rebuild
+	// fixture pass while asserting nothing about the teardown having happened.
+	ts := emulator.StartTestServer(t)
+
+	status, code, _ := configDeleteRecorder(t, ts, "default")
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "NoSuchConfigurationRecorderException", code)
+
+	status, code, _ = configDeleteChannel(t, ts, "default")
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "NoSuchDeliveryChannelException", code)
+
+	// And a delete naming something other than the one that exists is refused too: the
+	// account holds one recorder and one channel, so a wrong name names nothing.
+	configPutRecorder(t, ts, "default")
+	configPutChannel(t, ts, "default", "cfg-logs")
+
+	status, code, _ = configDeleteRecorder(t, ts, "other")
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "NoSuchConfigurationRecorderException", code)
+
+	status, code, _ = configDeleteChannel(t, ts, "other")
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "NoSuchDeliveryChannelException", code)
+}
+
+func TestConfigTeardown_ARebuildDoesNotInheritTheOldRulesOrPacks(t *testing.T) {
+	// The full teardown a repeated run performs: rules and packs go too, and a rebuilt
+	// account starts from the documented defaults rather than from its predecessor's
+	// verdicts. Both identifiers are deterministic, so a rebuilt rule and pack have the
+	// same ARNs — which is what makes an inherited verdict observable at all.
+	ts := emulator.StartTestServer(t)
+	configPutRecorder(t, ts, "default")
+	configPutRule(t, ts, "s3-encrypted")
+	configSeedRuleCompliance(t, ts, "s3-encrypted", map[string]any{"complianceType": "NON_COMPLIANT"})
+	packARN := configPutPack(t, ts, "ops")
+	configSeedPackCompliance(t, ts, "ops", []map[string]any{
+		{"configRuleName": "s3-encrypted", "complianceType": "NON_COMPLIANT"},
+	})
+	require.Equal(t, "CREATE_COMPLETE", configPackStateOf(t, ts, "ops")["ConformancePackState"])
+
+	status, code, message := decodeConfigResponse(t,
+		configRequest(t, ts, "DeleteConfigRule", map[string]any{"ConfigRuleName": "s3-encrypted"}), nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	status, code, message = configDeletePack(t, ts, "ops")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+	status, code, message = configDeleteRecorder(t, ts, "default")
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+
+	// Rebuild.
+	configPutRecorder(t, ts, "default")
+	configPutRule(t, ts, "s3-encrypted")
+	require.Equal(t, packARN, configPutPack(t, ts, "ops"),
+		"the rebuilt pack's ARN is the same, so a stale verdict would be visible")
+
+	// The rebuilt pack is CREATE_IN_PROGRESS, not the CREATE_COMPLETE its predecessor
+	// reached. That cannot be asserted by reading the state — the first observation is
+	// what *advances* it — so it is asserted through the refusal only an unresolved pack
+	// gives: a delete arriving before anything has observed the pack.
+	status, code, _ = configDeletePack(t, ts, "ops")
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "ResourceInUseException", code,
+		"the rebuilt pack starts unobserved rather than inheriting its predecessor's completion")
+	require.Equal(t, "CREATE_COMPLETE", configPackStateOf(t, ts, "ops")["ConformancePackState"],
+		"...and one observation settles it, as it did the first time")
+
+	compliance := configDescribeCompliance(t, ts, map[string]any{})
+	require.Len(t, compliance, 1)
+	assert.Equal(t, "INSUFFICIENT_DATA", configComplianceTypeOf(t, compliance[0]),
+		"the rebuilt rule starts at the documented default, not its predecessor's verdict")
+
+	assert.Empty(t, configPackCompliance(t, ts, map[string]any{"ConformancePackName": "ops"}),
+		"the rebuilt pack carries no rule verdicts")
+}
+
+// configDeleteChannel sends a DeleteDeliveryChannel and returns the status and error
+// code, since every case here is about which of those two it is.
+func configDeleteChannel(t *testing.T, ts *emulator.TestServer, name string) (int, string, string) {
+	t.Helper()
+	resp := configRequest(t, ts, "DeleteDeliveryChannel", map[string]any{"DeliveryChannelName": name})
+	return decodeConfigResponse(t, resp, nil)
+}
+
+// configDeleteRecorder sends a DeleteConfigurationRecorder and returns the status and
+// error code.
+func configDeleteRecorder(t *testing.T, ts *emulator.TestServer, name string) (int, string, string) {
+	t.Helper()
+	resp := configRequest(t, ts, "DeleteConfigurationRecorder",
+		map[string]any{"ConfigurationRecorderName": name})
+	return decodeConfigResponse(t, resp, nil)
+}
+
+// configStopRecorder stops the named recorder, requiring success.
+func configStopRecorder(t *testing.T, ts *emulator.TestServer, name string) {
+	t.Helper()
+	resp := configRequest(t, ts, "StopConfigurationRecorder",
+		map[string]any{"ConfigurationRecorderName": name})
+	status, code, message := decodeConfigResponse(t, resp, nil)
+	require.Equal(t, http.StatusOK, status, "%s: %s", code, message)
+}

--- a/emulator/configservice_types.go
+++ b/emulator/configservice_types.go
@@ -2,6 +2,8 @@ package emulator
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -216,31 +218,56 @@ func cfgsvcTagsKey(arn string) string { return "tags:" + arn }
 // --- ARNs ---
 //
 // The ARN formats come from the Service Authorization Reference's "Resource types
-// defined by AWS Config" table, not from the API reference, which gives none:
+// defined by AWS Config" table, not from the API reference, which gives none. The
+// authoritative form is the machine-readable service reference at
+// servicereference.us-east-1.amazonaws.com/v1/config/config.json (Version v1.4),
+// which agrees with the rendered page:
 //
-//	arn:${Partition}:config:${Region}:${Account}:config-recorder/${Name}
-//	arn:${Partition}:config:${Region}:${Account}:delivery-channel/${Name}
+//	arn:${Partition}:config:${Region}:${Account}:configuration-recorder/${RecorderName}/${RecorderId}
 //	arn:${Partition}:config:${Region}:${Account}:config-rule/${ConfigRuleId}
-//	arn:${Partition}:config:${Region}:${Account}:conformance-pack/${Name}/${Id}
+//	arn:${Partition}:config:${Region}:${Account}:conformance-pack/${ConformancePackName}/${ConformancePackId}
 //
-// The recorder form is "config-recorder", not "recorder". Substrate's own
-// CloudFormation stub emitted the latter (#580); it is corrected where that stub
-// becomes a real dispatch.
+// Two of those corrected an earlier reading of this table (#580), and both are worth
+// recording because a wrong ARN is a silent failure: a policy written against the
+// real form would not match substrate's resource, so a test asserting a denial would
+// pass for the wrong reason.
+//
+//   - The recorder segment is "configuration-recorder", not "config-recorder" or
+//     "recorder", and it is *two* components — a name and an ID. RecorderId has no
+//     member in the API model at all, so it is minted here the way a pack's ID is.
+//   - There is **no delivery-channel resource type**. The table defines ten types and
+//     none is a delivery channel; PutDeliveryChannel, DescribeDeliveryChannels,
+//     DescribeDeliveryChannelStatus and DeleteDeliveryChannel authorize against an
+//     empty resource list, i.e. "*". Synthesizing a delivery-channel ARN would be an
+//     invention with no documentation behind it, and the DeliveryChannel shape has no
+//     arn member to carry one anyway — which is consistent: a channel is not a
+//     taggable, policy-addressable resource. TagResource's own ResourceArn
+//     documentation enumerates the supported types and a delivery channel is not
+//     among them.
 
 // cfgsvcARN builds a Config ARN for a resource type and identifier.
 func cfgsvcARN(ctx *RequestContext, resourceType, id string) string {
 	return fmt.Sprintf("arn:aws:config:%s:%s:%s/%s", ctx.Region, ctx.AccountID, resourceType, id)
 }
 
-// cfgsvcRecorderARN builds the ARN of a configuration recorder.
+// cfgsvcRecorderARN builds the ARN of a configuration recorder,
+// configuration-recorder/<RecorderName>/<RecorderId>.
+//
+// The ID component is minted deterministically because the API model has no member
+// that carries it: nothing a caller sends or reads names it, yet the ARN template
+// requires it. Deriving it by hash keeps a replayed event stream producing the same
+// ARN, which is the property the whole emulator rests on.
 func cfgsvcRecorderARN(ctx *RequestContext, name string) string {
-	return cfgsvcARN(ctx, "config-recorder", name)
+	return cfgsvcARN(ctx, "configuration-recorder",
+		name+"/"+cfgsvcMintRecorderID(ctx.AccountID, ctx.Region, name))
 }
 
-// A delivery-channel ARN is deliberately absent here: the DeliveryChannel shape
-// carries no arn member, so nothing in this cluster has one to emit. The
-// delivery-channel form above is recorded because the tag operations address a
-// channel by ARN, and it arrives with them.
+// cfgsvcMintRecorderID derives a recorder's ID component, for the reason
+// cfgsvcMintRuleID does.
+func cfgsvcMintRecorderID(accountID, region, name string) string {
+	sum := sha256.Sum256([]byte("configuration-recorder/" + accountID + "/" + region + "/" + name))
+	return strings.ToLower(base64.RawURLEncoding.EncodeToString(sum[:6]))[:8]
+}
 
 // --- errors ---
 //

--- a/emulator/error_protocol.go
+++ b/emulator/error_protocol.go
@@ -128,6 +128,7 @@ var serviceErrorProtocols = map[string]awsErrorProtocol{
 	"codepipeline":     errProtoJSONRPC,
 	"cognito-identity": errProtoJSONRPC,
 	"cognito-idp":      errProtoJSONRPC,
+	"config":           errProtoJSONRPC,
 	"dynamodb":         errProtoJSONRPC,
 	"ecr":              errProtoJSONRPC,
 	"ecs":              errProtoJSONRPC,


### PR DESCRIPTION
Lanes 5 and 6 of the v0.101.0 plan: the tag trio, the authorization hook, and the
teardown-and-rebuild ordering asserted as a sequence. PR 5 of 7 for #580.

## The authorization hook is the substantive half

`TagResource`/`UntagResource`/`ListTagsForResource` matter here because **tags are how a
Config resource is authorized** — the Service Authorization Reference supports
`aws:ResourceTag/${TagKey}` on nine of Config's ten resource types, so a Config tag is a
privilege boundary, not decoration. (The developer guide's tagging page claims only
three types; the SAR is authoritative for authorization and is what this implements.)

Without a Config case in `buildResourceARN` every Config request authorized against
`*`, so a policy written to admit one rule admitted every rule. That is a **false
allow** — the one direction a privilege boundary must never fail in — and it is silent:
the policy looks right and a test asserting the denial passes for the wrong reason.

Resolution is per-operation, because the member naming the resource differs per
operation and is nested and lowerCamel for the recorder `Put`
(`ConfigurationRecorder.name`) versus nested and UpperCamel for the rule `Put`
(`ConfigRule.ConfigRuleName`). Three cases resolve to `*` **deliberately**, each for its
own reason:

- an operation naming a *list* of resources, or none — picking one arbitrary member
  would be the false-allow direction again;
- all four delivery-channel operations, because **there is no `delivery-channel`
  resource type**: the SAR gives them an empty resource list, `DeliveryChannel` has no
  `arn` member in the API model, and `TagResource`'s own docs do not name a channel among
  the taggable types. A channel is neither taggable nor nameable in a policy;
- `PutEvaluations`, whose `ResultToken` is the only thing naming a rule — decoding it to
  authorize would hand a caller control over the resource its own request is checked
  against. A rule `Put` naming its rule by ID or ARN is the same class: converting it
  needs a lookup that can miss, and a miss would authorize against a *different* rule.

## Three defects in unreleased merged code

1. **A deleted conformance pack's tags survived it.** A pack's ARN is deterministic, so a
   pack rebuilt under the same name read back its predecessor's tags — which no AWS
   account does. Unreachable until this PR because `PutConformancePackRequest` has **no
   `Tags` member**: a pack can only be tagged through `TagResource`, so PR 4's tests could
   not have caught it. Found by the test asserting a rebuilt pack starts untagged.
2. **The recorder ARN was one segment where the SAR's template is two** —
   `configuration-recorder/${RecorderName}/${RecorderId}`. A one-segment ARN matches no
   policy written against the real template, which now matters because a Config request
   authorizes against its own ARN. `RecorderId` has no member anywhere in the API model,
   so substrate mints it deterministically.
3. **`config` was absent from `serviceErrorProtocols`**, so an authorization denial took
   `errorProtocolFor`'s XML default and reported the bare `AccessDenied` to a JSON caller
   — the #595 failure mode in the opposite direction. `pricing` is in the same state for
   the same reason and is tracked in #653, since fixing it changes an existing service's
   wire behaviour.

## The teardown asymmetry, asserted deliberately

`DeleteDeliveryChannel` refuses while the recorder records
(`LastDeliveryChannelDeleteFailedException`, and its prose says so). `DeleteConfigurationRecorder`
has **no documented precondition whatsoever** — it declares exactly two exceptions and
neither could express "stop it first" or "delete the channel first". An emulator that
"helpfully" required a Stop would refuse a sequence AWS accepts, and a wrong refusal
breaks working code, so the permissive reading is asserted on its own rather than left to
chance.

## Verification

All gates green: `gofmt`/`go build`/`go vet`/`golangci-lint` (0 issues), `make test`
(race), `make coverage` at **82.0%**, `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e && go test -C test/e2e`.

**Live server** on `:4678` with `AWS_MAX_ATTEMPTS=1` — a resource-scoped policy narrows
(the named rule allowed, another denied); an `aws:ResourceTag/Owner` policy admits the
tagged rule and denies the differently-tagged one; an `aws:RequestTag/Owner` policy gates
`TagResource`; a rebuilt pack and recorder both come back with identical ARNs and **no
tags**; `Limit=60` is accepted (the value that tells the model's 100 from the prose's 50);
a `delivery-channel/...` ARN is `ResourceNotFoundException`; and the teardown refusal
fires and then clears after a `Stop`. Every denial reported `AccessDeniedException`,
confirming the protocol fix end to end.

**Mutation pass: 10 targets, 10 caught.** One initially survived and is worth recording:
ignoring the tag store's decode error. The test used whole-file garbage, where both
readings return nil — but `encoding/json` *partially populates* a map before returning its
type error, so a store whose first tag decodes and whose second does not yields
`Owner=platform` **plus** an error. Ignoring the error there would grant an Allow from
corrupted state, which is precisely the false allow the check exists to prevent. The test
now uses that input and the mutant dies.

Refs #580
