### PR TITLE
fix(cfn,config): the three AWS::Config resource types really deploy (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   absent, which denies; an absent key is the safe direction.
 
 ### Fixed
+- **Three `AWS::Config::*` CloudFormation resources reported `CREATE_COMPLETE` while creating
+  nothing** (#97). `AWS::Config::ConfigRule` and `AWS::Config::ConfigurationRecorder` were stubs
+  that stored a synthetic ARN and dispatched no API call; `AWS::Config::DeliveryChannel` fell
+  through to the generic stub and did the same. All three now dispatch the real operations, so a
+  deployed recorder is visible to `DescribeConfigurationRecorders` and a deployed rule to
+  `DescribeConfigRules`. The delivery channel was scoped out of the plan for this release and is
+  included anyway: it was *already* a de-facto stub, so excluding it would have preserved the
+  defect for one of three siblings, and it is the only route to the recorder's documented
+  CloudFormation behaviour — "AWS CloudFormation starts the recorder as soon as the delivery
+  channel is available", which a recorder cannot reach without a channel. A template carrying both
+  now ends with `recording: true` no matter which order the two are declared in, because ordering
+  is carried by `typePriority` rather than by `DependsOn`.
+  - **The recorder's ARN named a resource type that does not exist.** The stub minted
+    `recorder/<name>`; the ARN is now read back from the service, which mints the Service
+    Authorization Reference's two-segment `configuration-recorder/${RecorderName}/${RecorderId}`.
+    A delivery channel's `ARN` is deliberately **empty**: no `delivery-channel` resource type
+    exists in the reference at all, so any ARN substrate invented would match no policy.
+  - **CloudFormation and the Config API disagree about capitalisation, and a pass-through would
+    lose the whole recording group against real AWS.** CloudFormation spells the recorder's and
+    channel's nested members UpperCamel (`RecordingGroup.AllSupported`,
+    `RecordingMode.RecordingFrequency`, `DeliveryChannel.S3BucketName`) where the API spells them
+    lowerCamel. Real Config is case-sensitive and would ignore the UpperCamel members — the deploy
+    succeeding, the recorder recording AWS's *default* group, and nothing reporting that the
+    template's group had been discarded. Substrate would not have shown that, because its handlers
+    decode with `encoding/json`, whose field matching is case-insensitive; the request body
+    substrate records is nevertheless what an exported event log replays against AWS, so a body
+    that only works against a lenient decoder is a fixture that passes here and fails there. Every
+    nested member is now translated, and a test asserts the emitted wire keys directly rather than
+    through the decoder that hides the difference. `ConfigRule` is
+    UpperCamel on both sides and instead takes a whitelist, because CloudFormation defines a
+    `Compliance` property `PutConfigRule` has no member for and the model refuses `ConfigRuleArn`
+    and `ConfigRuleId` on a create.
+  - **`Fn::GetAtt` on a rule returned the rule's name for every attribute.** The
+    `AWS::Config::ConfigRule` page documents three — `Arn`, `ConfigRuleId` and `Compliance.Type` —
+    and the last two now resolve from the values the service reports rather than falling through
+    to the physical ID, which would have answered a plausible-looking wrong value that a stack
+    `Output` asserts against happily. The recorder and channel expose no attributes, matching
+    their pages' empty `Fn::GetAtt` sections.
+  - **A stack holding Config resources could not be torn down and rebuilt.** All three types were
+    in `cfnStubDeleteTypes`, so `DeleteStack` forgot them without calling Config — leaving the
+    account's one recorder and one channel behind, and the next deploy refusing. They now delete
+    through `DeleteConfigRule`, `DeleteConfigurationRecorder` and `DeleteDeliveryChannel`, with a
+    `StopConfigurationRecorder` pre-step so the channel's own
+    `LastDeliveryChannelDeleteFailedException` ordering refusal does not block teardown, and the
+    three `NoSuch…Exception` codes registered as already-absent so a resource deleted out of band
+    still reaches `DELETE_COMPLETE`. Every Config exception is HTTP 400, so the code is the only
+    thing that can carry that distinction.
+  - **An omitted `ConfigRuleName` reused the logical ID across stacks.** `AWS::Config::ConfigRule`
+    joins `cfnGeneratedNameTypes` (max 128), producing CloudFormation's documented
+    `mystack-MyConfigRule-12ABCFPXHV4OV` shape. Its two siblings stay out: AWS itself names a
+    recorder and a channel `"default"`, and only one of each exists per account per Region.
+  - Known gap: `AWS::S3::BucketPolicy` is not a supported resource type anywhere in substrate, so
+    a template cannot yet express the bucket policy `PutDeliveryChannel` requires. A fixture needs
+    either the `/v1/config/delivery-policy/{bucket}` seed or an out-of-band `PutBucketPolicy`.
 - **A conformance pack's tags outlived the pack** (#580, unreleased). `DeleteConformancePack`
   removed the pack and its index entry but not its tags, and a pack's ARN is deterministic —
   so a pack rebuilt under the same name read back its predecessor's tags, which no AWS

--- a/emulator/cfn_delete.go
+++ b/emulator/cfn_delete.go
@@ -422,6 +422,20 @@ var cfnResourceDeleters = map[string]cfnDeleteRequestFunc{
 			Headers: map[string]string{}, Params: map[string]string{}}
 	},
 	"AWS::SES::EmailIdentity": pathDeleter("sesv2", "/v2/email/identities/"),
+
+	// AWS Config's three types were stub-deleted until their API handlers existed
+	// (#580): the sweep removed a cfnStubNamespace key and reported DELETE_COMPLETE
+	// while the recorder, channel and rule the deploy had created stayed behind. A
+	// second deploy of the same template then met
+	// MaxNumberOfConfigurationRecordersExceededException from a stack that had
+	// reported itself fully deleted, which is the teardown-and-rebuild case — a test
+	// run repeated twice — that Lane 6 of #580 exists to make work.
+	"AWS::Config::ConfigRule": jsonBodyDeleter("config", "DeleteConfigRule",
+		"ConfigRuleName"),
+	"AWS::Config::ConfigurationRecorder": jsonBodyDeleter("config",
+		"DeleteConfigurationRecorder", "ConfigurationRecorderName"),
+	"AWS::Config::DeliveryChannel": jsonBodyDeleter("config", "DeleteDeliveryChannel",
+		"DeliveryChannelName"),
 }
 
 // cfnDeletePreStepFunc builds the requests that must succeed before a resource's own
@@ -469,6 +483,34 @@ var cfnDeletePreSteps = map[string]cfnDeletePreStepFunc{
 		}
 		return steps
 	},
+
+	// "Before you can delete the delivery channel, you must stop the configuration
+	// recorder", else DeleteDeliveryChannel answers
+	// LastDeliveryChannelDeleteFailedException — and the deploy started the recorder
+	// precisely because the channel exists, so a stack carrying both would otherwise
+	// wedge on teardown at the very ordering the release added.
+	//
+	// Only the stack's own recorder is stopped, for the reason
+	// cfgsvcCFNStartRecorder only starts the stack's own: the deploy's start was
+	// scoped to a sibling, so the teardown's stop must be too, or a sweep would
+	// silently switch off a recorder the stack does not own and could not restore.
+	// A stack with a channel but no recorder of its own contributes no step, and its
+	// channel delete is then refused if some other recorder is running — which is the
+	// service's own answer, reported rather than worked around.
+	"AWS::Config::DeliveryChannel": func(_ *StackDeployer, _ DeployedResource,
+		_ map[string]interface{}, cctx *cfnContext,
+	) []*AWSRequest {
+		name, ok := cfgsvcCFNRecorderSibling(cctx)
+		if !ok {
+			return nil
+		}
+		body, err := json.Marshal(map[string]string{"ConfigurationRecorderName": name})
+		if err != nil {
+			return nil
+		}
+		return []*AWSRequest{{Service: "config", Operation: "StopConfigurationRecorder",
+			Body: body, Headers: map[string]string{}, Params: map[string]string{}}}
+	},
 }
 
 // cfnStubDeleteTypes are the resource types whose deploy writes properties into
@@ -489,17 +531,15 @@ var cfnDeletePreSteps = map[string]cfnDeletePreStepFunc{
 // resources of their own, so the record sets it wrote outlive the sweep. That gap
 // is reported rather than hidden; see cfnDeleteInertTypes.
 var cfnStubDeleteTypes = map[string]bool{
-	"AWS::Athena::WorkGroup":             true,
-	"AWS::Backup::BackupPlan":            true,
-	"AWS::CloudTrail::Trail":             true,
-	"AWS::CodeBuild::Project":            true,
-	"AWS::CodeDeploy::DeploymentGroup":   true,
-	"AWS::CodePipeline::Pipeline":        true,
-	"AWS::Config::ConfigRule":            true,
-	"AWS::Config::ConfigurationRecorder": true,
-	"AWS::OpenSearchService::Domain":     true,
-	"AWS::Transfer::Server":              true,
-	"AWS::WAFv2::WebACL":                 true,
+	"AWS::Athena::WorkGroup":           true,
+	"AWS::Backup::BackupPlan":          true,
+	"AWS::CloudTrail::Trail":           true,
+	"AWS::CodeBuild::Project":          true,
+	"AWS::CodeDeploy::DeploymentGroup": true,
+	"AWS::CodePipeline::Pipeline":      true,
+	"AWS::OpenSearchService::Domain":   true,
+	"AWS::Transfer::Server":            true,
+	"AWS::WAFv2::WebACL":               true,
 }
 
 // cfnDeleteInertTypes maps a type whose sweep is a no-op to why, so the reason a
@@ -898,18 +938,23 @@ var cfnDeleteAbsentCodes = map[string]bool{
 	"InvalidVpcID.NotFound":             true,
 	"NatGatewayNotFound":                true,
 	"NoSuchBucket":                      true,
-	"NoSuchDistribution":                true,
-	"NoSuchEntity":                      true,
-	"NoSuchHostedZone":                  true,
-	"NotFound":                          true, // SNS DeleteTopic.
-	"NotFoundException":                 true,
-	"ParameterNotFound":                 true,
-	"QueueDoesNotExist":                 true,
-	"ReplicationGroupNotFoundFault":     true,
-	"RepositoryNotFoundException":       true,
-	"ResourceNotFoundException":         true,
-	"ServiceNotFoundException":          true,
-	"StateMachineDoesNotExist":          true,
+	// AWS Config's three not-found codes. Each is HTTP 400 rather than 404 — every
+	// Config exception is — so nothing but the code identifies them as an absence.
+	"NoSuchConfigRuleException":            true,
+	"NoSuchConfigurationRecorderException": true,
+	"NoSuchDeliveryChannelException":       true,
+	"NoSuchDistribution":                   true,
+	"NoSuchEntity":                         true,
+	"NoSuchHostedZone":                     true,
+	"NotFound":                             true, // SNS DeleteTopic.
+	"NotFoundException":                    true,
+	"ParameterNotFound":                    true,
+	"QueueDoesNotExist":                    true,
+	"ReplicationGroupNotFoundFault":        true,
+	"RepositoryNotFoundException":          true,
+	"ResourceNotFoundException":            true,
+	"ServiceNotFoundException":             true,
+	"StateMachineDoesNotExist":             true,
 }
 
 // cfnDeleteIsAbsent reports whether a delete failed because the resource was

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -857,15 +857,23 @@ var typePriority = map[string]int{
 	// v0.34.0 — RDS Aurora cluster and MSK.
 	"AWS::MSK::Cluster": 3,
 	// v0.32.0 — extended CFN stubs.
-	"AWS::OpenSearchService::Domain":     2,
-	"AWS::WAFv2::WebACL":                 2,
-	"AWS::Backup::BackupPlan":            2,
-	"AWS::CodeBuild::Project":            2,
-	"AWS::CodePipeline::Pipeline":        3,
-	"AWS::CodeDeploy::DeploymentGroup":   3,
-	"AWS::CloudTrail::Trail":             2,
-	"AWS::Config::ConfigRule":            3,
+	"AWS::OpenSearchService::Domain":   2,
+	"AWS::WAFv2::WebACL":               2,
+	"AWS::Backup::BackupPlan":          2,
+	"AWS::CodeBuild::Project":          2,
+	"AWS::CodePipeline::Pipeline":      3,
+	"AWS::CodeDeploy::DeploymentGroup": 3,
+	"AWS::CloudTrail::Trail":           2,
+	// AWS Config's three types carry an ordering the service enforces, and a
+	// template need not declare it with DependsOn — which substrate parses and does
+	// not act on — because the priorities alone produce it. "Before you can create a
+	// delivery channel, you must create a configuration recorder", so the channel
+	// follows the recorder; it also follows the S3 bucket it delivers to, which is
+	// itself a 2. PutConfigRule refuses without a recorder, and the rule's own page
+	// says the recorder must be running first, so the rule is last of the three.
 	"AWS::Config::ConfigurationRecorder": 2,
+	"AWS::Config::DeliveryChannel":       3,
+	"AWS::Config::ConfigRule":            4,
 	"AWS::Transfer::Server":              2,
 	"AWS::Athena::WorkGroup":             2,
 }
@@ -2612,6 +2620,8 @@ func (d *StackDeployer) dispatchResource(
 		return d.deployConfigConfigRule(ctx, logicalID, res.Properties, streamID, cctx)
 	case "AWS::Config::ConfigurationRecorder":
 		return d.deployConfigConfigurationRecorder(ctx, logicalID, res.Properties, streamID, cctx)
+	case "AWS::Config::DeliveryChannel":
+		return d.deployConfigDeliveryChannel(ctx, logicalID, res.Properties, streamID, cctx)
 	case "AWS::Transfer::Server":
 		return d.deployTransferServer(ctx, logicalID, res.Properties, streamID, cctx)
 	case "AWS::Athena::WorkGroup":
@@ -5362,6 +5372,17 @@ func resolveFnGetAtt(args interface{}, cctx *cfnContext) string {
 				return dr.ARN
 			}
 			return dr.PhysicalID
+		case "ConfigRuleId", "Compliance.Type":
+			// AWS::Config::ConfigRule GetAtt ConfigRuleId and Compliance.Type, both
+			// read back from the service at deploy time. Falling through to the
+			// default here would return the rule *name* for either one, which is a
+			// plausible-looking wrong answer: a stack Output carrying it would be
+			// asserted against happily. An unset attribute resolves to empty instead,
+			// which a test can tell apart from an ID.
+			if v, ok := dr.Metadata[attr]; ok {
+				return fmt.Sprintf("%v", v)
+			}
+			return ""
 		case "Endpoint.Address", "Endpoint.Port",
 			"ConfigurationEndpoint.Address", "ConfigurationEndpoint.Port",
 			"RedisEndPoint.Address", "RedisEndPoint.Port",

--- a/emulator/cfn_physical_name.go
+++ b/emulator/cfn_physical_name.go
@@ -72,6 +72,15 @@ var cfnGeneratedNameTypes = map[string]cfnNameConstraint{
 	// A bare Lambda function name "is limited to 64 characters in length"
 	// (CreateFunction).
 	"AWS::Lambda::Function": {maxLen: 64},
+
+	// A Config rule name is unique within a Region and may be up to 128 characters
+	// (ConfigRuleName, 1-128). CloudFormation documents generating one — the page's
+	// own example is mystack-MyConfigRule-12ABCFPXHV4OV, the shape this table
+	// produces. Its two sibling types are deliberately absent: AWS itself names a
+	// configuration recorder and a delivery channel "default", and only one of each
+	// may exist per account per Region, so a generated stack-scoped name would
+	// replace a name the service assigns and could not collide with anything anyway.
+	"AWS::Config::ConfigRule": {maxLen: 128},
 }
 
 // cfnGeneratedNameSuffixLen is the length of the derived suffix, matching the

--- a/emulator/cfn_resources_v101.go
+++ b/emulator/cfn_resources_v101.go
@@ -1,0 +1,587 @@
+package emulator
+
+// cfn_resources_v101.go holds the StackDeployer.deployResource helpers for AWS
+// Config. The name records the substrate release that added them (v0.101.0) rather
+// than the service, because several releases touched overlapping services; the
+// helpers here follow the same pattern as those in cfn_resources_v77.go.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+// This file replaces the AWS::Config::ConfigRule and
+// AWS::Config::ConfigurationRecorder stubs that shipped in v0.32.0, and wires
+// AWS::Config::DeliveryChannel, which fell through to deployGenericStub. All three
+// reported CREATE_COMPLETE while creating nothing, and nothing observable
+// contradicted them — the #388 class, fixable only now that the Config API handlers
+// exist (#580).
+//
+// AWS::Config::DeliveryChannel is here despite the release plan scoping it out. The
+// plan's reason for excluding it — "a stub is the defect this lane exists to remove"
+// — is exactly the argument for including it: the type was *already* a de-facto stub
+// through deployGenericStub, so leaving it out would have preserved the defect for
+// one of the three siblings. It is also the only way the recorder's documented
+// CloudFormation behavior is reachable at all: "AWS CloudFormation starts the
+// recorder as soon as the delivery channel is available", and a recorder cannot be
+// started without a channel.
+//
+// Two divergences from the Config API model are deliberate and load-bearing:
+//
+//   - **CloudFormation requires properties the API model marks optional.** RoleARN on
+//     the recorder and S3BucketName on the channel are *Required: Yes* on their
+//     CloudFormation pages while the API model requires neither. Real CloudFormation
+//     refuses such a template before it calls Config at all, so substrate refuses at
+//     the CloudFormation layer too rather than letting the plugin answer
+//     InvalidRoleException — the caller's stack event then names the property
+//     CloudFormation would have named.
+//   - **CloudFormation spells the recorder's and channel's nested members
+//     UpperCamel; the API spells them lowerCamel.** RecordingGroup.AllSupported is
+//     recordingGroup.allSupported on the wire, and so on through RecordingMode and
+//     the whole DeliveryChannel shape. Real Config is case-sensitive and would
+//     silently ignore the UpperCamel members: the deploy would succeed, the recorder
+//     would record AWS's default group, and nothing would report that the template's
+//     group had been discarded. Substrate itself would *not* show that, because its
+//     handlers decode with encoding/json, whose field matching is case-insensitive —
+//     which is precisely why the keys are translated here rather than forwarded. The
+//     request body substrate records is what an exported event log replays against
+//     AWS, so a body that only works against a lenient decoder is a fixture that
+//     passes here and fails there. Pinned by
+//     TestCFN_ConfigRecorderWireKeysAreLowerCamel, which asserts the emitted keys
+//     directly for that reason. The ConfigRule shape is UpperCamel in both and needs
+//     no translation — only a whitelist, because CloudFormation defines a Compliance
+//     property that PutConfigRule's input does not have.
+
+// cfgsvcJSONContentType is the content type Config's JSON 1.1 protocol uses. It is
+// set on every dispatched request so a refusal is encoded the way the service would
+// encode it rather than falling back to a protocol default.
+const cfgsvcJSONContentType = "application/x-amz-json-1.1"
+
+// deployConfigConfigurationRecorder creates the account's AWS Config configuration
+// recorder.
+//
+// Ref returns the recorder name — "the configuration recorder name, such as
+// default" — and the Fn::GetAtt section of the resource's page is empty, so no
+// attributes are exposed. Name is optional because "AWS Config automatically assigns
+// the name of 'default'", which is also why the type is absent from
+// cfnGeneratedNameTypes: a generated stack-scoped name would replace a name AWS
+// itself assigns, and only one recorder may exist per account per Region anyway.
+//
+// The recorder is created stopped. Starting it is the delivery channel's job, per
+// the page's own "AWS CloudFormation starts the recorder as soon as the delivery
+// channel is available" — see deployConfigDeliveryChannel.
+func (d *StackDeployer) deployConfigConfigurationRecorder(
+	ctx context.Context,
+	logicalID string,
+	props map[string]interface{},
+	streamID string,
+	cctx *cfnContext,
+) (DeployedResource, float64, error) {
+	const resType = "AWS::Config::ConfigurationRecorder"
+	name := resolveStringProp(props, "Name", cfgsvcDefaultName, cctx)
+	dr := DeployedResource{LogicalID: logicalID, Type: resType, PhysicalID: name}
+
+	roleARN := resolveStringProp(props, "RoleARN", "", cctx)
+	if roleARN == "" {
+		// CloudFormation's own requirement, not Config's — see the file header.
+		dr.Error = "RoleARN is required by AWS::Config::ConfigurationRecorder"
+		return dr, 0, nil
+	}
+
+	recorder := map[string]interface{}{"name": name, "roleARN": roleARN}
+	if group := cfgsvcCFNRecordingGroup(props["RecordingGroup"], cctx); group != nil {
+		recorder["recordingGroup"] = group
+	}
+	if mode := cfgsvcCFNRecordingMode(props["RecordingMode"], cctx); mode != nil {
+		recorder["recordingMode"] = mode
+	}
+
+	body, err := json.Marshal(map[string]interface{}{"ConfigurationRecorder": recorder})
+	if err != nil {
+		return dr, 0, fmt.Errorf("marshal configuration recorder body: %w", err)
+	}
+
+	_, cost, routeErr := d.dispatch(ctx, cfgsvcCFNRequest("PutConfigurationRecorder", body), streamID)
+	if routeErr != nil {
+		// Recorded on the resource, not returned — a returned error aborts the stack.
+		dr.Error = routeErr.Error()
+		return dr, cost, nil //nolint:nilerr
+	}
+
+	// The ARN is read back rather than rebuilt here. Its second component is a
+	// RecorderId that no member of the API model carries, so substrate mints it
+	// (cfgsvcMintRecorderID); recomputing that in the CloudFormation layer would give
+	// the derivation two homes that could drift apart. The v0.32.0 stub's
+	// recorder/<name> was wrong on both counts — the segment is
+	// configuration-recorder and it takes a name *and* an ID.
+	arnCost, arn := d.cfgsvcCFNRecorderARN(ctx, name, streamID)
+	dr.ARN = arn
+	return dr, cost + arnCost, nil
+}
+
+// cfgsvcCFNRecorderARN reads the recorder's ARN back through
+// DescribeConfigurationRecorders. An unreadable response leaves the ARN empty rather
+// than synthesizing one, because an ARN substrate guessed is worse than none: a
+// policy written against the real form would not match it, so a test asserting a
+// denial would pass for the wrong reason.
+func (d *StackDeployer) cfgsvcCFNRecorderARN(
+	ctx context.Context, name, streamID string,
+) (float64, string) {
+	body, err := json.Marshal(map[string]interface{}{"ConfigurationRecorderNames": []string{name}})
+	if err != nil {
+		return 0, ""
+	}
+	resp, cost, routeErr := d.dispatch(ctx,
+		cfgsvcCFNRequest("DescribeConfigurationRecorders", body), streamID)
+	if routeErr != nil || resp == nil {
+		return cost, ""
+	}
+	var out struct {
+		ConfigurationRecorders []struct {
+			ARN string `json:"arn"`
+		} `json:"ConfigurationRecorders"`
+	}
+	if jsonErr := json.Unmarshal(resp.Body, &out); jsonErr != nil || len(out.ConfigurationRecorders) == 0 {
+		return cost, ""
+	}
+	return cost, out.ConfigurationRecorders[0].ARN
+}
+
+// deployConfigDeliveryChannel creates the account's AWS Config delivery channel, and
+// starts the stack's configuration recorder once it exists.
+//
+// Ref returns the channel name and the Fn::GetAtt section of the page is empty, so
+// no attributes are exposed. The resource's ARN is left **empty**, which is not an
+// omission: the Service Authorization Reference defines ten Config resource types and
+// none is a delivery channel, the DeliveryChannel shape has no arn member to carry
+// one, and TagResource does not accept a channel. Synthesizing one would be an
+// invention with nothing behind it.
+//
+// Two ordering facts from the page are modeled by typePriority rather than by
+// DependsOn — which substrate parses and does not act on — so a template need not
+// declare them: "Before you can create a delivery channel, you must create a
+// configuration recorder" (recorder 2, channel 3), and the channel must exist before
+// a rule is put (rule 4).
+//
+// A caveat a fixture author needs: a real PutDeliveryChannel refuses a bucket whose
+// policy does not admit Config (InsufficientDeliveryPolicyException), and substrate
+// has no AWS::S3::BucketPolicy resource type, so a template *cannot* express the
+// policy the check wants. Seeding the outcome — POST /v1/config/delivery-policy/{bucket}
+// with {"outcome":"ok"} — is the only way a CloudFormation fixture passes it.
+func (d *StackDeployer) deployConfigDeliveryChannel(
+	ctx context.Context,
+	logicalID string,
+	props map[string]interface{},
+	streamID string,
+	cctx *cfnContext,
+) (DeployedResource, float64, error) {
+	const resType = "AWS::Config::DeliveryChannel"
+	name := resolveStringProp(props, "Name", cfgsvcDefaultName, cctx)
+	dr := DeployedResource{LogicalID: logicalID, Type: resType, PhysicalID: name}
+
+	bucket := resolveStringProp(props, "S3BucketName", "", cctx)
+	if bucket == "" {
+		// CloudFormation's own requirement, not Config's — see the file header.
+		dr.Error = "S3BucketName is required by AWS::Config::DeliveryChannel"
+		return dr, 0, nil
+	}
+
+	channel := map[string]interface{}{"name": name, "s3BucketName": bucket}
+	for cfnKey, wireKey := range map[string]string{
+		"S3KeyPrefix": "s3KeyPrefix",
+		"S3KmsKeyArn": "s3KmsKeyArn",
+		"SnsTopicARN": "snsTopicARN",
+	} {
+		if v := resolveStringProp(props, cfnKey, "", cctx); v != "" {
+			channel[wireKey] = v
+		}
+	}
+	if snapshot, ok := resolveNested(props["ConfigSnapshotDeliveryProperties"], cctx).(map[string]interface{}); ok {
+		if freq := cfgsvcCFNString(snapshot, "DeliveryFrequency"); freq != "" {
+			channel["configSnapshotDeliveryProperties"] = map[string]interface{}{"deliveryFrequency": freq}
+		}
+	}
+
+	body, err := json.Marshal(map[string]interface{}{"DeliveryChannel": channel})
+	if err != nil {
+		return dr, 0, fmt.Errorf("marshal delivery channel body: %w", err)
+	}
+
+	_, cost, routeErr := d.dispatch(ctx, cfgsvcCFNRequest("PutDeliveryChannel", body), streamID)
+	if routeErr != nil {
+		dr.Error = routeErr.Error()
+		return dr, cost, nil //nolint:nilerr
+	}
+
+	startCost, startErr := d.cfgsvcCFNStartRecorder(ctx, cctx, streamID)
+	if startErr != "" && dr.Error == "" {
+		dr.Error = startErr
+	}
+	return dr, cost + startCost, nil
+}
+
+// cfgsvcCFNStartRecorder starts the recorder declared in the same stack, which is
+// what makes DescribeConfigurationRecorderStatus report recording: true for a
+// template carrying both a recorder and a channel, and false for one carrying only a
+// recorder.
+//
+// Only a *sibling* recorder is started. A recorder that some other stack or a direct
+// API call created is deliberately left alone: real CloudFormation starts the
+// recorder it manages, and reaching outside the stack to change the state of a
+// resource this stack does not own would make a delivery channel a covert switch on
+// somebody else's recorder — and the teardown could not undo it, since the sweep
+// finds the recorder to stop the same way.
+func (d *StackDeployer) cfgsvcCFNStartRecorder(
+	ctx context.Context, cctx *cfnContext, streamID string,
+) (float64, string) {
+	name, ok := cfgsvcCFNRecorderSibling(cctx)
+	if !ok {
+		return 0, ""
+	}
+	body, err := json.Marshal(map[string]interface{}{"ConfigurationRecorderName": name})
+	if err != nil {
+		return 0, ""
+	}
+	_, cost, routeErr := d.dispatch(ctx,
+		cfgsvcCFNRequest("StartConfigurationRecorder", body), streamID)
+	if routeErr != nil {
+		return cost, routeErr.Error()
+	}
+	return cost, ""
+}
+
+// cfgsvcCFNRecorderSibling returns the physical name of the configuration recorder
+// deployed by the same stack, if it deployed successfully.
+//
+// The logical IDs are sorted before the scan so the answer does not depend on Go's
+// map iteration order. Only one recorder can exist per account and Region, so a
+// second one in the same template was refused and carries an Error — but sorting
+// costs nothing and keeps a replay identical to the run it replays, which is the
+// property the whole emulator rests on.
+func cfgsvcCFNRecorderSibling(cctx *cfnContext) (string, bool) {
+	if cctx == nil {
+		return "", false
+	}
+	ids := make([]string, 0, len(cctx.resources))
+	for id := range cctx.resources {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		dr := cctx.resources[id]
+		if dr.Type == "AWS::Config::ConfigurationRecorder" && dr.Error == "" && dr.PhysicalID != "" {
+			return dr.PhysicalID, true
+		}
+	}
+	return "", false
+}
+
+// deployConfigConfigRule creates an AWS Config rule.
+//
+// Ref returns the rule name, "such as mystack-MyConfigRule-12ABCFPXHV4OV" — the
+// shape cfnGeneratedName produces — because "if you don't specify a name,
+// CloudFormation generates a unique physical ID and uses that ID for the rule name".
+// That is why AWS::Config::ConfigRule is in cfnGeneratedNameTypes where the recorder
+// and the channel are not: those two are named "default" by AWS itself.
+//
+// Unlike the recorder and the channel, this type does expose Fn::GetAtt attributes —
+// Arn, ConfigRuleId and Compliance.Type — and all three are read back from the
+// service rather than derived here, so the ARN and the ID cannot disagree with what
+// DescribeConfigRules reports.
+func (d *StackDeployer) deployConfigConfigRule(
+	ctx context.Context,
+	logicalID string,
+	props map[string]interface{},
+	streamID string,
+	cctx *cfnContext,
+) (DeployedResource, float64, error) {
+	const resType = "AWS::Config::ConfigRule"
+	name := resolveStringProp(props, "ConfigRuleName",
+		cfnGeneratedName(cctx, resType, logicalID), cctx)
+	dr := DeployedResource{LogicalID: logicalID, Type: resType, PhysicalID: name}
+
+	rule := map[string]interface{}{"ConfigRuleName": name}
+	// Source is the only Required: Yes property on the resource's page, and it is the
+	// only required member of the API model's ConfigRule shape too — the one place the
+	// two agree on a requirement.
+	source, ok := resolveNested(props["Source"], cctx).(map[string]interface{})
+	if !ok || len(source) == 0 {
+		dr.Error = "Source is required by AWS::Config::ConfigRule"
+		return dr, 0, nil
+	}
+	rule["Source"] = source
+
+	// A whitelist rather than a pass-through. The ConfigRule shape's members are
+	// UpperCamel in both the template and the API, so forwarding *looks* safe — but
+	// CloudFormation defines a Compliance property that PutConfigRule's input has no
+	// member for, and the model's ConfigRuleArn/ConfigRuleId are refused outright on a
+	// create ("These values are generated by Config for new rules"), so a template
+	// echoing a described rule back would be refused rather than deployed.
+	for _, key := range []string{"Description", "MaximumExecutionFrequency"} {
+		if v := resolveStringProp(props, key, "", cctx); v != "" {
+			rule[key] = v
+		}
+	}
+	for _, key := range []string{"Scope", "EvaluationModes"} {
+		if v := resolveNested(props[key], cctx); v != nil {
+			rule[key] = v
+		}
+	}
+	if params := cfgsvcCFNInputParameters(props["InputParameters"], cctx); params != "" {
+		rule["InputParameters"] = params
+	}
+
+	body, err := json.Marshal(map[string]interface{}{"ConfigRule": rule})
+	if err != nil {
+		return dr, 0, fmt.Errorf("marshal config rule body: %w", err)
+	}
+
+	_, cost, routeErr := d.dispatch(ctx, cfgsvcCFNRequest("PutConfigRule", body), streamID)
+	if routeErr != nil {
+		dr.Error = routeErr.Error()
+		return dr, cost, nil //nolint:nilerr
+	}
+
+	attrCost := d.cfgsvcCFNRuleAttributes(ctx, &dr, name, streamID)
+	return dr, cost + attrCost, nil
+}
+
+// cfgsvcCFNInputParameters renders the rule's InputParameters as the JSON *string*
+// the API model wants.
+//
+// The resource's page shows both spellings: its JSON example supplies a JSON object
+// and its YAML example a string. Both are accepted here, because a template author
+// following either example is following the documentation.
+func cfgsvcCFNInputParameters(v interface{}, cctx *cfnContext) string {
+	resolved := resolveNested(v, cctx)
+	switch typed := resolved.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	default:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return ""
+		}
+		return string(encoded)
+	}
+}
+
+// cfgsvcCFNRuleAttributes fills in the rule's ARN and its two Metadata-borne GetAtt
+// attributes from the service's own answers.
+//
+// Compliance.Type comes from DescribeComplianceByConfigRule, so a compliance value
+// seeded before the deploy is what an Output reading it reports — which is the point:
+// compliance is seed-only, and a stack whose Output asserts a rule's compliance is
+// asserting against the seed the fixture set. An unreadable answer leaves the
+// attribute unset rather than defaulting to a verdict, because INSUFFICIENT_DATA
+// invented here would be indistinguishable from INSUFFICIENT_DATA observed.
+func (d *StackDeployer) cfgsvcCFNRuleAttributes(
+	ctx context.Context, dr *DeployedResource, name, streamID string,
+) float64 {
+	var total float64
+
+	if body, err := json.Marshal(map[string]interface{}{"ConfigRuleNames": []string{name}}); err == nil {
+		resp, cost, routeErr := d.dispatch(ctx, cfgsvcCFNRequest("DescribeConfigRules", body), streamID)
+		total += cost
+		if routeErr == nil && resp != nil {
+			var out struct {
+				ConfigRules []struct {
+					ConfigRuleArn string `json:"ConfigRuleArn"`
+					ConfigRuleID  string `json:"ConfigRuleId"`
+				} `json:"ConfigRules"`
+			}
+			if json.Unmarshal(resp.Body, &out) == nil && len(out.ConfigRules) > 0 {
+				dr.ARN = out.ConfigRules[0].ConfigRuleArn
+				cfnSetMetadata(dr, "ConfigRuleId", out.ConfigRules[0].ConfigRuleID)
+			}
+		}
+	}
+
+	if body, err := json.Marshal(map[string]interface{}{"ConfigRuleNames": []string{name}}); err == nil {
+		resp, cost, routeErr := d.dispatch(ctx,
+			cfgsvcCFNRequest("DescribeComplianceByConfigRule", body), streamID)
+		total += cost
+		if routeErr == nil && resp != nil {
+			var out struct {
+				ComplianceByConfigRules []struct {
+					Compliance struct {
+						ComplianceType string `json:"ComplianceType"`
+					} `json:"Compliance"`
+				} `json:"ComplianceByConfigRules"`
+			}
+			if json.Unmarshal(resp.Body, &out) == nil && len(out.ComplianceByConfigRules) > 0 {
+				cfnSetMetadata(dr, "Compliance.Type",
+					out.ComplianceByConfigRules[0].Compliance.ComplianceType)
+			}
+		}
+	}
+
+	return total
+}
+
+// cfnSetMetadata records a GetAtt-resolvable attribute on a resource, allocating the
+// map on first use and ignoring an empty value so an absent attribute stays absent
+// rather than resolving to "".
+func cfnSetMetadata(dr *DeployedResource, key, value string) {
+	if value == "" {
+		return
+	}
+	if dr.Metadata == nil {
+		dr.Metadata = map[string]interface{}{}
+	}
+	dr.Metadata[key] = value
+}
+
+// cfgsvcCFNRequest builds a Config API request for a dispatched CloudFormation
+// resource.
+func cfgsvcCFNRequest(operation string, body []byte) *AWSRequest {
+	return &AWSRequest{
+		Service:   configServiceNamespace,
+		Operation: operation,
+		Body:      body,
+		Headers:   map[string]string{"Content-Type": cfgsvcJSONContentType},
+		Params:    map[string]string{},
+	}
+}
+
+// cfgsvcCFNRecordingGroup translates a template's RecordingGroup into the API
+// model's recordingGroup.
+//
+// Every member is renamed, and that is the whole reason this function exists — see
+// the file header on the case asymmetry. A nil result means the template supplied no
+// group, which PutConfigurationRecorder answers with AWS's default group; an empty
+// map would instead be a group with every parameter unset, which the reference
+// enumerates as an InvalidRecordingGroupException case.
+func cfgsvcCFNRecordingGroup(v interface{}, cctx *cfnContext) map[string]interface{} {
+	src, ok := resolveNested(v, cctx).(map[string]interface{})
+	if !ok || len(src) == 0 {
+		return nil
+	}
+	group := map[string]interface{}{}
+	for cfnKey, wireKey := range map[string]string{
+		"AllSupported":               "allSupported",
+		"IncludeGlobalResourceTypes": "includeGlobalResourceTypes",
+	} {
+		if b, set := cfgsvcCFNBool(src, cfnKey); set {
+			group[wireKey] = b
+		}
+	}
+	if types := cfgsvcCFNStringList(src["ResourceTypes"]); len(types) > 0 {
+		group["resourceTypes"] = types
+	}
+	if excl, isMap := src["ExclusionByResourceTypes"].(map[string]interface{}); isMap {
+		if types := cfgsvcCFNStringList(excl["ResourceTypes"]); len(types) > 0 {
+			group["exclusionByResourceTypes"] = map[string]interface{}{"resourceTypes": types}
+		}
+	}
+	if strategy, isMap := src["RecordingStrategy"].(map[string]interface{}); isMap {
+		if useOnly := cfgsvcCFNString(strategy, "UseOnly"); useOnly != "" {
+			group["recordingStrategy"] = map[string]interface{}{"useOnly": useOnly}
+		}
+	}
+	if len(group) == 0 {
+		return nil
+	}
+	return group
+}
+
+// cfgsvcCFNRecordingMode translates a template's RecordingMode into the API model's
+// recordingMode.
+//
+// RecordingFrequency is Required: Yes within RecordingMode, so a mode without one is
+// dropped rather than sent: the request would be refused, and dropping it leaves the
+// recorder on the default frequency, which is what a template that failed to say
+// otherwise asked for. RecordingModeOverrides accepts at most one member, and each
+// override requires both ResourceTypes and RecordingFrequency.
+func cfgsvcCFNRecordingMode(v interface{}, cctx *cfnContext) map[string]interface{} {
+	src, ok := resolveNested(v, cctx).(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	frequency := cfgsvcCFNString(src, "RecordingFrequency")
+	if frequency == "" {
+		return nil
+	}
+	mode := map[string]interface{}{"recordingFrequency": frequency}
+
+	rawOverrides, isList := src["RecordingModeOverrides"].([]interface{})
+	if !isList {
+		return mode
+	}
+	overrides := make([]map[string]interface{}, 0, len(rawOverrides))
+	for _, raw := range rawOverrides {
+		item, isMap := raw.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		types := cfgsvcCFNStringList(item["ResourceTypes"])
+		itemFrequency := cfgsvcCFNString(item, "RecordingFrequency")
+		if len(types) == 0 || itemFrequency == "" {
+			continue
+		}
+		override := map[string]interface{}{
+			"resourceTypes":      types,
+			"recordingFrequency": itemFrequency,
+		}
+		if desc := cfgsvcCFNString(item, "Description"); desc != "" {
+			override["description"] = desc
+		}
+		overrides = append(overrides, override)
+	}
+	if len(overrides) > 0 {
+		mode["recordingModeOverrides"] = overrides
+	}
+	return mode
+}
+
+// cfgsvcCFNString reads a string member out of an already-resolved property map.
+func cfgsvcCFNString(src map[string]interface{}, key string) string {
+	s, _ := src[key].(string)
+	return s
+}
+
+// cfgsvcCFNStringList reads a list-of-strings member out of an already-resolved
+// property map, dropping non-string and empty members.
+func cfgsvcCFNStringList(v interface{}) []string {
+	items, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, isString := item.(string); isString && s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// cfgsvcCFNBool reads a boolean member out of an already-resolved property map,
+// reporting whether the template set it at all.
+//
+// Both spellings are accepted because both reach here: a JSON template's `true` is a
+// Go bool, while a YAML template's and an Fn::If's or Ref's resolution is the string
+// "true". Sending allSupported: false for a member the template never mentioned would
+// be substrate asserting a choice the author did not make, which the recording-group
+// validation treats as a distinct — and refusable — configuration.
+func cfgsvcCFNBool(src map[string]interface{}, key string) (value, set bool) {
+	switch typed := src[key].(type) {
+	case bool:
+		return typed, true
+	case string:
+		parsed, err := strconv.ParseBool(typed)
+		if err != nil {
+			return false, false
+		}
+		return parsed, true
+	}
+	return false, false
+}

--- a/emulator/cfn_resources_v101_test.go
+++ b/emulator/cfn_resources_v101_test.go
@@ -1,0 +1,807 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// CloudFormation's three AWS Config resource types, which stopped being stubs in
+// this release (#580, the #388 class).
+//
+// Every assertion here observes the *service* after the deploy rather than only the
+// DeployedResource the deployer returned, because the defect being fixed was
+// precisely a deployer returning a well-formed resource for a service call that never
+// happened. A test that asserted only on the returned PhysicalID and ARN would have
+// passed against the stub, which is how the stub survived from v0.32.0.
+
+// newConfigTestDeployer creates a StackDeployer with the Config and S3 plugins and
+// returns the registry, so a test can observe deployed resources through the same API
+// a consumer would call.
+//
+// S3 is here because PutDeliveryChannel reads real bucket state; the shared state
+// manager is what lets it. Config's requests carry a JSON body rather than query
+// parameters, so routeQuery does not fit and configOp below is used instead.
+func newConfigTestDeployer(t *testing.T) (*emulator.StackDeployer, *emulator.PluginRegistry) {
+	t.Helper()
+	cfg := emulator.DefaultConfig()
+	registry := emulator.NewPluginRegistry()
+	state := emulator.NewMemoryStateManager()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(cfg.EventStore.ToEventStoreConfig())
+	tc := emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	costs := emulator.NewCostController(emulator.CostConfig{Enabled: true})
+
+	configPlugin := &emulator.ConfigServicePlugin{}
+	require.NoError(t, configPlugin.Initialize(context.Background(), emulator.PluginConfig{
+		State:   state,
+		Logger:  logger,
+		Options: map[string]any{"time_controller": tc},
+	}))
+	registry.Register(configPlugin)
+
+	s3Plugin := &emulator.S3Plugin{}
+	require.NoError(t, s3Plugin.Initialize(context.Background(), emulator.PluginConfig{
+		State:  state,
+		Logger: logger,
+		Options: map[string]any{
+			"time_controller": tc,
+			"filesystem":      afero.NewMemMapFs(),
+		},
+	}))
+	registry.Register(s3Plugin)
+
+	return emulator.NewStackDeployer(registry, store, state, tc, logger, costs), registry
+}
+
+// configOp sends one Config operation through the registry and decodes its JSON
+// response into out. It requires success: a test asserting a refusal names the
+// operation itself rather than going through here.
+func configOp(t *testing.T, registry *emulator.PluginRegistry, operation string, input, out any) {
+	t.Helper()
+	body, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	resp, err := registry.RouteRequest(&emulator.RequestContext{
+		RequestID: "test-request",
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		Timestamp: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+	}, &emulator.AWSRequest{
+		Service:   "config",
+		Operation: operation,
+		Body:      body,
+		Headers:   map[string]string{"Content-Type": "application/x-amz-json-1.1"},
+		Params:    map[string]string{},
+	})
+	require.NoError(t, err, "%s was refused", operation)
+	require.NotNil(t, resp)
+	if out != nil {
+		require.NoError(t, json.Unmarshal(resp.Body, out))
+	}
+}
+
+// cfnConfigRecorders returns what DescribeConfigurationRecorders reports.
+func cfnConfigRecorders(t *testing.T, registry *emulator.PluginRegistry) []map[string]any {
+	t.Helper()
+	var out struct {
+		ConfigurationRecorders []map[string]any `json:"ConfigurationRecorders"`
+	}
+	configOp(t, registry, "DescribeConfigurationRecorders", map[string]any{}, &out)
+	return out.ConfigurationRecorders
+}
+
+// cfnConfigRecorderStatus returns what DescribeConfigurationRecorderStatus reports —
+// the operation that answers whether the recorder is actually recording.
+func cfnConfigRecorderStatus(t *testing.T, registry *emulator.PluginRegistry) []map[string]any {
+	t.Helper()
+	var out struct {
+		ConfigurationRecordersStatus []map[string]any `json:"ConfigurationRecordersStatus"`
+	}
+	configOp(t, registry, "DescribeConfigurationRecorderStatus", map[string]any{}, &out)
+	return out.ConfigurationRecordersStatus
+}
+
+// cfnConfigChannels returns what DescribeDeliveryChannels reports.
+func cfnConfigChannels(t *testing.T, registry *emulator.PluginRegistry) []map[string]any {
+	t.Helper()
+	var out struct {
+		DeliveryChannels []map[string]any `json:"DeliveryChannels"`
+	}
+	configOp(t, registry, "DescribeDeliveryChannels", map[string]any{}, &out)
+	return out.DeliveryChannels
+}
+
+// cfnConfigRules returns what DescribeConfigRules reports.
+func cfnConfigRules(t *testing.T, registry *emulator.PluginRegistry) []map[string]any {
+	t.Helper()
+	var out struct {
+		ConfigRules []map[string]any `json:"ConfigRules"`
+	}
+	configOp(t, registry, "DescribeConfigRules", map[string]any{}, &out)
+	return out.ConfigRules
+}
+
+// cfnConfigDeliveryBucket creates a delivery bucket carrying a policy that admits
+// Config, through the S3 plugin, so PutDeliveryChannel's check reads real state.
+//
+// The bucket and the policy are set up outside the template rather than in it because
+// substrate has no AWS::S3::BucketPolicy resource type: a template can create the
+// bucket but cannot express the policy the check wants, so a stack carrying a channel
+// needs the policy — or the delivery-policy seed — from somewhere else. That gap is
+// stated in cfn_resources_v101.go's doc comment, and this helper is the fixture form
+// of it.
+func cfnConfigDeliveryBucket(t *testing.T, registry *emulator.PluginRegistry, bucket string) {
+	t.Helper()
+	reqCtx := &emulator.RequestContext{
+		RequestID: "fixture-request",
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		Timestamp: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	_, err := registry.RouteRequest(reqCtx, &emulator.AWSRequest{
+		Service: "s3", Operation: "PUT", Path: "/" + bucket,
+		Headers: map[string]string{}, Params: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	policy := `{"Version":"2012-10-17","Statement":[{` +
+		`"Sid":"AWSConfigBucketDelivery","Effect":"Allow",` +
+		`"Principal":{"Service":"config.amazonaws.com"},` +
+		`"Action":"s3:PutObject","Resource":"arn:aws:s3:::` + bucket + `/*"}]}`
+	_, err = registry.RouteRequest(reqCtx, &emulator.AWSRequest{
+		Service: "s3", Operation: "PUT", Path: "/" + bucket,
+		Body:    []byte(policy),
+		Headers: map[string]string{}, Params: map[string]string{"policy": "1"},
+	})
+	require.NoError(t, err)
+}
+
+// TestCFN_ConfigConfigurationRecorder verifies a recorder declared in a template is
+// afterwards visible to DescribeConfigurationRecorders — and, because the template
+// carries no delivery channel, that it is **not recording**.
+//
+// That second assertion is the release's headline behavior seen from
+// CloudFormation: the two states a consumer confuses are "the recorder exists" and
+// "the recorder is recording", and a template with a recorder alone produces only the
+// first. Real CloudFormation is explicit that the start waits on the channel.
+func TestCFN_ConfigConfigurationRecorder(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyRecorder": {
+				"Type": "AWS::Config::ConfigurationRecorder",
+				"Properties": {
+					"Name": "default",
+					"RoleARN": "arn:aws:iam::123456789012:role/config-role"
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "config-recorder-stack", nil)
+	require.NoError(t, err)
+
+	r := findResource(t, result, "MyRecorder")
+	require.Empty(t, r.Error)
+	assert.Equal(t, "AWS::Config::ConfigurationRecorder", r.Type)
+	// Ref returns the recorder name, "such as default".
+	assert.Equal(t, "default", r.PhysicalID)
+	// The stub's ARN was recorder/default. The Service Authorization Reference gives
+	// configuration-recorder/${RecorderName}/${RecorderId}, and the ID has no member
+	// in the API model, so the deployer reads the ARN back rather than rebuilding it.
+	assert.Contains(t, r.ARN, "arn:aws:config:us-east-1:123456789012:configuration-recorder/default/")
+	assert.NotContains(t, r.ARN, ":recorder/")
+
+	recorders := cfnConfigRecorders(t, registry)
+	require.Len(t, recorders, 1, "the recorder the stub never created")
+	assert.Equal(t, "default", recorders[0]["name"])
+	assert.Equal(t, "arn:aws:iam::123456789012:role/config-role", recorders[0]["roleARN"])
+
+	status := cfnConfigRecorderStatus(t, registry)
+	require.Len(t, status, 1)
+	assert.Equal(t, false, status[0]["recording"],
+		"with no delivery channel in the template there is nothing to start the recorder")
+}
+
+// TestCFN_ConfigRecorderRequiresRoleARN verifies a template omitting RoleARN is
+// refused at the CloudFormation layer.
+//
+// The divergence is deliberate: the resource's page marks RoleARN Required: Yes while
+// the API model marks roleARN optional. Refusing here rather than letting the plugin
+// answer InvalidRoleException means the stack event names the property real
+// CloudFormation would have named. The refusal must also be *recorded* rather than
+// returned — a returned error aborts the whole stack.
+func TestCFN_ConfigRecorderRequiresRoleARN(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyRecorder": {
+				"Type": "AWS::Config::ConfigurationRecorder",
+				"Properties": { "Name": "default" }
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "config-no-role-stack", nil)
+	require.NoError(t, err, "the resource fails; the deploy call does not")
+
+	r := findResource(t, result, "MyRecorder")
+	assert.Contains(t, r.Error, "RoleARN is required")
+	assert.Empty(t, cfnConfigRecorders(t, registry),
+		"a refused resource dispatched nothing")
+}
+
+// TestCFN_ConfigRecordingGroupIsTranslated verifies the template's RecordingGroup
+// reaches the service.
+//
+// This is the case a pass-through of the properties would fail *silently*:
+// CloudFormation spells the nested members UpperCamel (RecordingGroup.ResourceTypes)
+// and the API spells them lowerCamel (recordingGroup.resourceTypes), so forwarding
+// the map verbatim decodes to an empty group. The deploy would still succeed, the
+// recorder would record AWS's default group, and nothing would report that the
+// template's group had been dropped — so the assertion is on the recorded group's
+// contents, not on the deploy's success.
+//
+// Both booleans are asserted true in at least one case, which is the only way the
+// assertion can fail when a member is dropped: allSupported and
+// includeGlobalResourceTypes decode to false when absent, so a case that expects
+// false cannot tell a translated member from a discarded one. That is not
+// hypothetical — a mutant renaming both wire keys survived a version of this test
+// that only exercised the false shape.
+func TestCFN_ConfigRecordingGroupIsTranslated(t *testing.T) {
+	tests := []struct {
+		name   string
+		group  string
+		assert func(t *testing.T, group map[string]any)
+	}{
+		{
+			// The inclusion shape: allSupported false, an explicit type list, and
+			// INCLUSION_BY_RESOURCE_TYPES — the group a template most often writes.
+			name: "inclusion by resource types",
+			group: `{
+				"AllSupported": false,
+				"IncludeGlobalResourceTypes": false,
+				"ResourceTypes": ["AWS::S3::Bucket", "AWS::EC2::Instance"],
+				"RecordingStrategy": { "UseOnly": "INCLUSION_BY_RESOURCE_TYPES" }
+			}`,
+			assert: func(t *testing.T, group map[string]any) {
+				assert.Equal(t, []any{"AWS::S3::Bucket", "AWS::EC2::Instance"}, group["resourceTypes"])
+				assert.Equal(t, false, group["allSupported"])
+				assert.Equal(t, false, group["includeGlobalResourceTypes"])
+				strategy, ok := group["recordingStrategy"].(map[string]any)
+				require.True(t, ok, "the nested strategy survived too: %v", group)
+				assert.Equal(t, "INCLUSION_BY_RESOURCE_TYPES", strategy["useOnly"])
+			},
+		},
+		{
+			// Both booleans true. A dropped member reports false here, so this is the
+			// case that distinguishes a translation from a pass-through. The strategy
+			// must be ALL_SUPPORTED_RESOURCE_TYPES: allSupported paired with either a
+			// type list or EXCLUSION_BY_RESOURCE_TYPES is an
+			// InvalidRecordingGroupException case, so those combinations cannot be
+			// used to make the point.
+			name: "all supported with global types",
+			group: `{
+				"AllSupported": true,
+				"IncludeGlobalResourceTypes": true,
+				"RecordingStrategy": { "UseOnly": "ALL_SUPPORTED_RESOURCE_TYPES" }
+			}`,
+			assert: func(t *testing.T, group map[string]any) {
+				assert.Equal(t, true, group["allSupported"])
+				assert.Equal(t, true, group["includeGlobalResourceTypes"])
+			},
+		},
+		{
+			// The exclusion shape, whose resource-type list is nested one level deeper
+			// than the inclusion one and so is renamed at two levels.
+			name: "exclusion by resource types",
+			group: `{
+				"AllSupported": false,
+				"IncludeGlobalResourceTypes": true,
+				"ExclusionByResourceTypes": { "ResourceTypes": ["AWS::EC2::Instance"] },
+				"RecordingStrategy": { "UseOnly": "EXCLUSION_BY_RESOURCE_TYPES" }
+			}`,
+			assert: func(t *testing.T, group map[string]any) {
+				assert.Equal(t, true, group["includeGlobalResourceTypes"])
+				exclusion, ok := group["exclusionByResourceTypes"].(map[string]any)
+				require.True(t, ok, "the nested exclusion survived: %v", group)
+				assert.Equal(t, []any{"AWS::EC2::Instance"}, exclusion["resourceTypes"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, registry := newConfigTestDeployer(t)
+			tmpl := `{
+				"AWSTemplateFormatVersion": "2010-09-09",
+				"Resources": {
+					"MyRecorder": {
+						"Type": "AWS::Config::ConfigurationRecorder",
+						"Properties": {
+							"RoleARN": "arn:aws:iam::123456789012:role/config-role",
+							"RecordingGroup": ` + tt.group + `,
+							"RecordingMode": { "RecordingFrequency": "DAILY" }
+						}
+					}
+				}
+			}`
+			result, err := d.Deploy(context.Background(), tmpl, "config-group-stack", nil)
+			require.NoError(t, err)
+			require.Empty(t, findResource(t, result, "MyRecorder").Error)
+
+			recorders := cfnConfigRecorders(t, registry)
+			require.Len(t, recorders, 1)
+
+			group, ok := recorders[0]["recordingGroup"].(map[string]any)
+			require.True(t, ok, "the recording group survived the case translation: %v", recorders[0])
+			tt.assert(t, group)
+
+			mode, ok := recorders[0]["recordingMode"].(map[string]any)
+			require.True(t, ok, "the recording mode survived: %v", recorders[0])
+			assert.Equal(t, "DAILY", mode["recordingFrequency"])
+		})
+	}
+}
+
+// TestCFN_ConfigDeliveryChannelStartsTheRecorder verifies the behavior the resource's
+// own page states: "AWS CloudFormation starts the recorder as soon as the delivery
+// channel is available."
+//
+// It also asserts the ordering comes from typePriority alone. The template declares
+// the channel before the recorder and uses no DependsOn — which substrate parses and
+// does not act on — so if the priorities were wrong the channel's Put would meet
+// NoAvailableConfigurationRecorderException.
+func TestCFN_ConfigDeliveryChannelStartsTheRecorder(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	cfnConfigDeliveryBucket(t, registry, "cfg-logs")
+
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyChannel": {
+				"Type": "AWS::Config::DeliveryChannel",
+				"Properties": {
+					"Name": "default",
+					"S3BucketName": "cfg-logs",
+					"S3KeyPrefix": "config",
+					"ConfigSnapshotDeliveryProperties": { "DeliveryFrequency": "TwentyFour_Hours" }
+				}
+			},
+			"MyRecorder": {
+				"Type": "AWS::Config::ConfigurationRecorder",
+				"Properties": {
+					"Name": "default",
+					"RoleARN": "arn:aws:iam::123456789012:role/config-role"
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "config-channel-stack", nil)
+	require.NoError(t, err)
+
+	channel := findResource(t, result, "MyChannel")
+	require.Empty(t, channel.Error)
+	// Ref returns the channel name, and there is deliberately no ARN: the Service
+	// Authorization Reference defines no delivery-channel resource type at all.
+	assert.Equal(t, "default", channel.PhysicalID)
+	assert.Empty(t, channel.ARN)
+
+	channels := cfnConfigChannels(t, registry)
+	require.Len(t, channels, 1)
+	assert.Equal(t, "cfg-logs", channels[0]["s3BucketName"])
+	assert.Equal(t, "config", channels[0]["s3KeyPrefix"])
+	snapshot, ok := channels[0]["configSnapshotDeliveryProperties"].(map[string]any)
+	require.True(t, ok, "the snapshot properties survived the case translation: %v", channels[0])
+	assert.Equal(t, "TwentyFour_Hours", snapshot["deliveryFrequency"])
+
+	status := cfnConfigRecorderStatus(t, registry)
+	require.Len(t, status, 1)
+	assert.Equal(t, true, status[0]["recording"],
+		"the channel's deploy started the stack's recorder")
+}
+
+// TestCFN_ConfigDeliveryChannelRequiresBucket verifies the second
+// CloudFormation-only requirement: S3BucketName is Required: Yes on the page while
+// the API model bounds it 0-63 and requires nothing.
+func TestCFN_ConfigDeliveryChannelRequiresBucket(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyRecorder": {
+				"Type": "AWS::Config::ConfigurationRecorder",
+				"Properties": {
+					"RoleARN": "arn:aws:iam::123456789012:role/config-role"
+				}
+			},
+			"MyChannel": {
+				"Type": "AWS::Config::DeliveryChannel",
+				"Properties": { "Name": "default" }
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "config-no-bucket-stack", nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, findResource(t, result, "MyChannel").Error, "S3BucketName is required")
+	assert.Empty(t, cfnConfigChannels(t, registry))
+
+	// The failed resource rolled the whole stack back, and the rollback's sweep took
+	// the recorder with it — which is only true because the recorder's delete is a real
+	// DeleteConfigurationRecorder now. Under the stub the rollback removed a state key
+	// and left the recorder behind, so a consumer whose stack failed on the channel was
+	// left with a recorder no stack owned and a second attempt meeting
+	// MaxNumberOfConfigurationRecordersExceededException.
+	assert.Equal(t, "ROLLBACK_COMPLETE", result.Status)
+	assert.Empty(t, cfnConfigRecorders(t, registry),
+		"the rollback deleted the recorder the failed stack had created")
+}
+
+// TestCFN_ConfigConfigRule verifies a rule declared in a template is afterwards
+// visible to DescribeConfigRules, and that its three documented GetAtt attributes
+// resolve.
+func TestCFN_ConfigConfigRule(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	cfnConfigDeliveryBucket(t, registry, "cfg-logs")
+
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyRecorder": {
+				"Type": "AWS::Config::ConfigurationRecorder",
+				"Properties": {
+					"RoleARN": "arn:aws:iam::123456789012:role/config-role"
+				}
+			},
+			"MyChannel": {
+				"Type": "AWS::Config::DeliveryChannel",
+				"Properties": { "S3BucketName": "cfg-logs" }
+			},
+			"MyRule": {
+				"Type": "AWS::Config::ConfigRule",
+				"Properties": {
+					"ConfigRuleName": "s3-encrypted",
+					"Description": "buckets must be encrypted",
+					"Source": {
+						"Owner": "AWS",
+						"SourceIdentifier": "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
+					},
+					"Scope": { "ComplianceResourceTypes": ["AWS::S3::Bucket"] },
+					"InputParameters": { "minimumCount": "1" }
+				}
+			}
+		},
+		"Outputs": {
+			"RuleArn":        { "Value": { "Fn::GetAtt": ["MyRule", "Arn"] } },
+			"RuleId":         { "Value": { "Fn::GetAtt": ["MyRule", "ConfigRuleId"] } },
+			"RuleCompliance": { "Value": { "Fn::GetAtt": ["MyRule", "Compliance.Type"] } },
+			"RuleRef":        { "Value": { "Ref": "MyRule" } }
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "config-rule-stack", nil)
+	require.NoError(t, err)
+
+	r := findResource(t, result, "MyRule")
+	require.Empty(t, r.Error)
+	assert.Equal(t, "s3-encrypted", r.PhysicalID)
+	// The stub built the ARN's ID component from the *logical* ID. The real ID is
+	// minted from the rule name, and the deployer reads it back rather than
+	// recomputing it, so the ARN cannot disagree with DescribeConfigRules.
+	assert.Contains(t, r.ARN, "arn:aws:config:us-east-1:123456789012:config-rule/config-rule-")
+	assert.NotContains(t, r.ARN, "config-rule-MyRule")
+
+	rules := cfnConfigRules(t, registry)
+	require.Len(t, rules, 1, "the rule the stub never created")
+	assert.Equal(t, "s3-encrypted", rules[0]["ConfigRuleName"])
+	assert.Equal(t, "buckets must be encrypted", rules[0]["Description"])
+	source, ok := rules[0]["Source"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AWS", source["Owner"])
+	// InputParameters is a JSON *string* in the API model; the resource's JSON example
+	// supplies an object, so the deployer encodes one.
+	assert.Equal(t, `{"minimumCount":"1"}`, rules[0]["InputParameters"])
+
+	assert.Equal(t, r.ARN, result.Outputs["RuleArn"])
+	assert.Equal(t, "s3-encrypted", result.Outputs["RuleRef"])
+	assert.NotEmpty(t, result.Outputs["RuleId"], "ConfigRuleId resolves from Metadata")
+	assert.NotEqual(t, "s3-encrypted", result.Outputs["RuleId"],
+		"the ID is not the name; falling through to the physical ID would return the name")
+	// Compliance is seed-only and nothing was seeded, so the value is what AWS reports
+	// for a rule that has not evaluated — not a fabricated COMPLIANT.
+	assert.Equal(t, "INSUFFICIENT_DATA", result.Outputs["RuleCompliance"])
+}
+
+// TestCFN_ConfigRuleRequiresSource verifies the one requirement the resource's page
+// and the API model agree on. The template the stub test used carried no Source at
+// all and passed, which is how invalid fixtures went green for nine releases.
+func TestCFN_ConfigRuleRequiresSource(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyRule": {
+				"Type": "AWS::Config::ConfigRule",
+				"Properties": { "ConfigRuleName": "my-config-rule" }
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "config-no-source-stack", nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, findResource(t, result, "MyRule").Error, "Source is required")
+	assert.Empty(t, cfnConfigRules(t, registry))
+}
+
+// TestCFN_ConfigRuleWithoutARecorder verifies the service's own precondition surfaces
+// as a resource failure rather than as a false success. The resource's own page says
+// "You must first create and start the AWS Config configuration recorder in order to
+// create AWS Config managed rules with AWS CloudFormation".
+func TestCFN_ConfigRuleWithoutARecorder(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyRule": {
+				"Type": "AWS::Config::ConfigRule",
+				"Properties": {
+					"ConfigRuleName": "s3-encrypted",
+					"Source": { "Owner": "AWS", "SourceIdentifier": "S3_BUCKET_VERSIONING_ENABLED" }
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "config-orphan-rule-stack", nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, findResource(t, result, "MyRule").Error,
+		"NoAvailableConfigurationRecorderException")
+	assert.Empty(t, cfnConfigRules(t, registry))
+}
+
+// TestCFN_ConfigRuleNameIsGenerated verifies a template omitting ConfigRuleName gets a
+// generated stack-scoped name, the shape the page documents
+// (mystack-MyConfigRule-12ABCFPXHV4OV), rather than the bare logical ID the stub used.
+//
+// The bare logical ID is not a harmless simplification: PutConfigRule is idempotent on
+// the name, so two stacks each declaring "MyRule" would silently share one rule and
+// the first stack's teardown would delete the second's (#560, the reason
+// cfnGeneratedNameTypes exists).
+func TestCFN_ConfigRuleNameIsGenerated(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	cfnConfigDeliveryBucket(t, registry, "cfg-logs")
+
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyRecorder": {
+				"Type": "AWS::Config::ConfigurationRecorder",
+				"Properties": { "RoleARN": "arn:aws:iam::123456789012:role/config-role" }
+			},
+			"MyChannel": {
+				"Type": "AWS::Config::DeliveryChannel",
+				"Properties": { "S3BucketName": "cfg-logs" }
+			},
+			"MyRule": {
+				"Type": "AWS::Config::ConfigRule",
+				"Properties": {
+					"Source": { "Owner": "AWS", "SourceIdentifier": "S3_BUCKET_VERSIONING_ENABLED" }
+				}
+			}
+		}
+	}`
+	result, err := d.Deploy(context.Background(), tmpl, "cfgstack", nil)
+	require.NoError(t, err)
+
+	r := findResource(t, result, "MyRule")
+	require.Empty(t, r.Error)
+	assert.NotEqual(t, "MyRule", r.PhysicalID)
+	assert.Regexp(t, `^cfgstack-MyRule-[0-9a-z]{12}$`, r.PhysicalID)
+	assert.LessOrEqual(t, len(r.PhysicalID), 128, "ConfigRuleName is bounded at 128")
+
+	rules := cfnConfigRules(t, registry)
+	require.Len(t, rules, 1)
+	assert.Equal(t, r.PhysicalID, rules[0]["ConfigRuleName"])
+}
+
+// TestCFN_ConfigTeardownDeletesTheRealResources verifies the sweep removes what the
+// deploy created, in an order the service accepts.
+//
+// Until this release all three types were stub-deletes: the sweep dropped a
+// cfnStubNamespace key and reported DELETE_COMPLETE while the recorder, channel and
+// rule stayed behind. The rebuild at the end is the assertion that matters — a second
+// deploy of the same template met
+// MaxNumberOfConfigurationRecordersExceededException from a stack that had reported
+// itself fully deleted.
+//
+// The ordering is doubly load-bearing here. The reverse sweep tears down by descending
+// priority, so the rule goes first and the recorder last; but DeleteDeliveryChannel is
+// refused while the recorder is recording, and the deploy started it. The channel's
+// pre-step stops the recorder, and the recorder's own delete has no precondition at
+// all.
+func TestCFN_ConfigTeardownDeletesTheRealResources(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	cfnConfigDeliveryBucket(t, registry, "cfg-logs")
+
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyRecorder": {
+				"Type": "AWS::Config::ConfigurationRecorder",
+				"Properties": { "RoleARN": "arn:aws:iam::123456789012:role/config-role" }
+			},
+			"MyChannel": {
+				"Type": "AWS::Config::DeliveryChannel",
+				"Properties": { "S3BucketName": "cfg-logs" }
+			},
+			"MyRule": {
+				"Type": "AWS::Config::ConfigRule",
+				"Properties": {
+					"ConfigRuleName": "s3-encrypted",
+					"Source": { "Owner": "AWS", "SourceIdentifier": "S3_BUCKET_VERSIONING_ENABLED" }
+				}
+			}
+		}
+	}`
+	_, err := d.Deploy(context.Background(), tmpl, "config-teardown-stack", nil)
+	require.NoError(t, err)
+	require.Len(t, cfnConfigRecorders(t, registry), 1)
+	require.Len(t, cfnConfigChannels(t, registry), 1)
+	require.Len(t, cfnConfigRules(t, registry), 1)
+	require.Equal(t, true, cfnConfigRecorderStatus(t, registry)[0]["recording"])
+
+	// DeleteStack reports an error naming every resource whose delete failed, so a
+	// clean return is the assertion that all three deletes were accepted.
+	require.NoError(t, d.DeleteStack(context.Background(), "config-teardown-stack"))
+
+	assert.Empty(t, cfnConfigRecorders(t, registry), "the recorder is really gone")
+	assert.Empty(t, cfnConfigChannels(t, registry), "the channel is really gone")
+	assert.Empty(t, cfnConfigRules(t, registry), "the rule is really gone")
+
+	// The rebuild: the same template deploys clean a second time, which is what the
+	// stub delete made impossible.
+	rebuilt, err := d.Deploy(context.Background(), tmpl, "config-teardown-stack", nil)
+	require.NoError(t, err)
+	for _, res := range rebuilt.Resources {
+		assert.Empty(t, res.Error, "%s (%s)", res.LogicalID, res.Type)
+	}
+	assert.Len(t, cfnConfigRecorders(t, registry), 1)
+	assert.Equal(t, true, cfnConfigRecorderStatus(t, registry)[0]["recording"])
+}
+
+// TestCFN_ConfigTeardownToleratesAnAlreadyAbsentResource verifies a resource deleted
+// out of band does not wedge the sweep.
+//
+// Config's not-found exceptions are HTTP 400 like every other Config exception, so
+// nothing but the error code distinguishes an absence from a real failure — which is
+// why the three NoSuch codes had to be added to cfnDeleteAbsentCodes. Without them a
+// stack whose rule someone deleted by hand sits in DELETE_FAILED on a condition the
+// caller cannot fix.
+func TestCFN_ConfigTeardownToleratesAnAlreadyAbsentResource(t *testing.T) {
+	d, registry := newConfigTestDeployer(t)
+	cfnConfigDeliveryBucket(t, registry, "cfg-logs")
+
+	tmpl := `{
+		"AWSTemplateFormatVersion": "2010-09-09",
+		"Resources": {
+			"MyRecorder": {
+				"Type": "AWS::Config::ConfigurationRecorder",
+				"Properties": { "RoleARN": "arn:aws:iam::123456789012:role/config-role" }
+			},
+			"MyChannel": {
+				"Type": "AWS::Config::DeliveryChannel",
+				"Properties": { "S3BucketName": "cfg-logs" }
+			},
+			"MyRule": {
+				"Type": "AWS::Config::ConfigRule",
+				"Properties": {
+					"ConfigRuleName": "s3-encrypted",
+					"Source": { "Owner": "AWS", "SourceIdentifier": "S3_BUCKET_VERSIONING_ENABLED" }
+				}
+			}
+		}
+	}`
+	_, err := d.Deploy(context.Background(), tmpl, "config-absent-stack", nil)
+	require.NoError(t, err)
+
+	// Out of band, as a consumer's console click would.
+	configOp(t, registry, "DeleteConfigRule", map[string]any{"ConfigRuleName": "s3-encrypted"}, nil)
+
+	// The sweep is run directly rather than through DeleteStack so the per-resource
+	// statuses are visible: a tolerated absence must be a completion rather than a
+	// skip, because the sweep's goal is that the resource not exist and it does not.
+	deletions := d.DeleteStackResourcesForTest(context.Background(), "config-absent-stack")
+	require.Len(t, deletions, 3)
+	for _, res := range deletions {
+		assert.Equal(t, "DELETE_COMPLETE", res.Status,
+			"%s (%s): %s", res.LogicalID, res.Type, res.Reason)
+	}
+
+	require.NoError(t, d.DeleteStack(context.Background(), "config-absent-stack"),
+		"and the sweep is idempotent: every resource is now absent")
+}
+
+// TestCFN_ConfigRecorderWireKeysAreLowerCamel asserts the exact keys the recorder
+// translation emits.
+//
+// Every other test here observes the service, which is the right instinct and cannot
+// make this point: substrate decodes a request with encoding/json, whose field
+// matching is case-insensitive, so an UpperCamel body decodes into the same struct as
+// a lowerCamel one and DescribeConfigurationRecorders reports the same group either
+// way. Real Config is case-sensitive and would ignore the UpperCamel members, and the
+// recorded request body is what an exported event log replays against AWS — so the
+// emitted keys are asserted where they are produced. Mutants renaming
+// allSupported/includeGlobalResourceTypes and nesting ResourceTypes under
+// exclusionByResourceTypes both survived the service-level tests for exactly this
+// reason.
+func TestCFN_ConfigRecorderWireKeysAreLowerCamel(t *testing.T) {
+	group := emulator.CFGSvcCFNRecordingGroupForTest(map[string]interface{}{
+		"AllSupported":               true,
+		"IncludeGlobalResourceTypes": true,
+		"RecordingStrategy":          map[string]interface{}{"UseOnly": "ALL_SUPPORTED_RESOURCE_TYPES"},
+	})
+	assert.Equal(t, map[string]interface{}{
+		"allSupported":               true,
+		"includeGlobalResourceTypes": true,
+		"recordingStrategy":          map[string]interface{}{"useOnly": "ALL_SUPPORTED_RESOURCE_TYPES"},
+	}, group)
+
+	exclusion := emulator.CFGSvcCFNRecordingGroupForTest(map[string]interface{}{
+		"AllSupported": false,
+		"ExclusionByResourceTypes": map[string]interface{}{
+			"ResourceTypes": []interface{}{"AWS::EC2::Instance"},
+		},
+		"RecordingStrategy": map[string]interface{}{"UseOnly": "EXCLUSION_BY_RESOURCE_TYPES"},
+	})
+	assert.Equal(t, map[string]interface{}{
+		"allSupported": false,
+		"exclusionByResourceTypes": map[string]interface{}{
+			"resourceTypes": []string{"AWS::EC2::Instance"},
+		},
+		"recordingStrategy": map[string]interface{}{"useOnly": "EXCLUSION_BY_RESOURCE_TYPES"},
+	}, exclusion)
+
+	inclusion := emulator.CFGSvcCFNRecordingGroupForTest(map[string]interface{}{
+		"ResourceTypes":     []interface{}{"AWS::S3::Bucket"},
+		"RecordingStrategy": map[string]interface{}{"UseOnly": "INCLUSION_BY_RESOURCE_TYPES"},
+	})
+	assert.Equal(t, map[string]interface{}{
+		"resourceTypes":     []string{"AWS::S3::Bucket"},
+		"recordingStrategy": map[string]interface{}{"useOnly": "INCLUSION_BY_RESOURCE_TYPES"},
+	}, inclusion, "an unmentioned boolean is absent rather than sent as false")
+
+	mode := emulator.CFGSvcCFNRecordingModeForTest(map[string]interface{}{
+		"RecordingFrequency": "CONTINUOUS",
+		"RecordingModeOverrides": []interface{}{
+			map[string]interface{}{
+				"ResourceTypes":      []interface{}{"AWS::S3::Bucket"},
+				"RecordingFrequency": "DAILY",
+				"Description":        "buckets daily",
+			},
+		},
+	})
+	assert.Equal(t, map[string]interface{}{
+		"recordingFrequency": "CONTINUOUS",
+		"recordingModeOverrides": []map[string]interface{}{{
+			"resourceTypes":      []string{"AWS::S3::Bucket"},
+			"recordingFrequency": "DAILY",
+			"description":        "buckets daily",
+		}},
+	}, mode)
+
+	assert.Nil(t, emulator.CFGSvcCFNRecordingGroupForTest(map[string]interface{}{}),
+		"an empty group is nil, not a group with every parameter unset — which is an "+
+			"InvalidRecordingGroupException case")
+	assert.Nil(t, emulator.CFGSvcCFNRecordingModeForTest(map[string]interface{}{}),
+		"a mode without the required RecordingFrequency is dropped rather than refused")
+}

--- a/emulator/cfn_resources_v32.go
+++ b/emulator/cfn_resources_v32.go
@@ -1,7 +1,7 @@
 package emulator
 
 // cfn_resources_v32.go holds the StackDeployer.deployResource helpers for
-// Athena, Backup, CloudTrail, the CodeSuite, Config, OpenSearch, Transfer and WAFv2.
+// Athena, Backup, CloudTrail, the CodeSuite, OpenSearch, Transfer and WAFv2.
 // The name records the substrate release that added them (v0.32.0) rather than the
 // services, because several releases touched overlapping services; the helpers here
 // follow the same pattern as those in cfn_deployer.go.
@@ -170,46 +170,10 @@ func (d *StackDeployer) deployCloudTrailTrail(
 	}, 0, nil
 }
 
-// deployConfigConfigRule creates an AWS Config rule stub.
-// The Ref value is the config rule name.
-func (d *StackDeployer) deployConfigConfigRule(
-	ctx context.Context,
-	logicalID string,
-	props map[string]interface{},
-	_ string,
-	cctx *cfnContext,
-) (DeployedResource, float64, error) {
-	name := resolveStringProp(props, "ConfigRuleName", logicalID, cctx)
-	// Config rule ARN suffix is "config-rule-{logicalID}".
-	arn := fmt.Sprintf("arn:aws:config:%s:%s:config-rule/config-rule-%s", cctx.region, cctx.accountID, logicalID)
-	d.stubStore(ctx, cctx.accountID, cctx.region, logicalID, props)
-	return DeployedResource{
-		LogicalID:  logicalID,
-		Type:       "AWS::Config::ConfigRule",
-		PhysicalID: name,
-		ARN:        arn,
-	}, 0, nil
-}
-
-// deployConfigConfigurationRecorder creates an AWS Config recorder stub.
-// The Ref value is the recorder name.
-func (d *StackDeployer) deployConfigConfigurationRecorder(
-	ctx context.Context,
-	logicalID string,
-	props map[string]interface{},
-	_ string,
-	cctx *cfnContext,
-) (DeployedResource, float64, error) {
-	name := resolveStringProp(props, "Name", logicalID, cctx)
-	arn := fmt.Sprintf("arn:aws:config:%s:%s:recorder/%s", cctx.region, cctx.accountID, name)
-	d.stubStore(ctx, cctx.accountID, cctx.region, logicalID, props)
-	return DeployedResource{
-		LogicalID:  logicalID,
-		Type:       "AWS::Config::ConfigurationRecorder",
-		PhysicalID: name,
-		ARN:        arn,
-	}, 0, nil
-}
+// The AWS::Config::ConfigRule and AWS::Config::ConfigurationRecorder stubs that
+// shipped here in v0.32.0 are gone: they now dispatch real Config operations from
+// cfn_resources_v101.go, which became possible once the service's handlers existed
+// (#580).
 
 // deployTransferServer creates an AWS Transfer Family server stub.
 // The Ref value is the server ID.

--- a/emulator/cfn_resources_v32_test.go
+++ b/emulator/cfn_resources_v32_test.go
@@ -195,49 +195,13 @@ func TestCFN_CloudTrailTrail(t *testing.T) {
 	assert.Contains(t, r.ARN, "trail/my-trail")
 }
 
-// TestCFN_ConfigConfigRule verifies the Config rule stub.
-func TestCFN_ConfigConfigRule(t *testing.T) {
-	d := newTestDeployer(t)
-	tmpl := `{
-		"AWSTemplateFormatVersion": "2010-09-09",
-		"Resources": {
-			"MyRule": {
-				"Type": "AWS::Config::ConfigRule",
-				"Properties": { "ConfigRuleName": "my-config-rule" }
-			}
-		}
-	}`
-	result, err := d.Deploy(context.Background(), tmpl, "config-rule-stack", nil)
-	require.NoError(t, err)
-	require.Len(t, result.Resources, 1)
-	r := result.Resources[0]
-	assert.Equal(t, "AWS::Config::ConfigRule", r.Type)
-	assert.Empty(t, r.Error)
-	assert.Equal(t, "my-config-rule", r.PhysicalID)
-	assert.Contains(t, r.ARN, "config-rule/config-rule-MyRule")
-}
-
-// TestCFN_ConfigConfigurationRecorder verifies the Config recorder stub.
-func TestCFN_ConfigConfigurationRecorder(t *testing.T) {
-	d := newTestDeployer(t)
-	tmpl := `{
-		"AWSTemplateFormatVersion": "2010-09-09",
-		"Resources": {
-			"MyRecorder": {
-				"Type": "AWS::Config::ConfigurationRecorder",
-				"Properties": { "Name": "default" }
-			}
-		}
-	}`
-	result, err := d.Deploy(context.Background(), tmpl, "config-recorder-stack", nil)
-	require.NoError(t, err)
-	require.Len(t, result.Resources, 1)
-	r := result.Resources[0]
-	assert.Equal(t, "AWS::Config::ConfigurationRecorder", r.Type)
-	assert.Empty(t, r.Error)
-	assert.Equal(t, "default", r.PhysicalID)
-	assert.Contains(t, r.ARN, "recorder/default")
-}
+// The Config rule and recorder tests that lived here asserted the stub behavior
+// this release removed, and could not be carried over by adjusting their
+// expectations: each template was invalid against the real API — the rule's carried
+// no Source, the recorder's no RoleARN — and newTestDeployer registers no Config
+// plugin, so both went green while creating nothing. That is the defect, not the
+// baseline. Their replacements are in cfn_resources_v101_test.go, against a deployer
+// that registers Config.
 
 // TestCFN_TransferServer verifies the Transfer Family server stub.
 func TestCFN_TransferServer(t *testing.T) {

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -668,6 +668,26 @@ func CFNGeneratedNameForTest(accountID, region, stackName, resType, logicalID st
 	}, resType, logicalID)
 }
 
+// CFGSvcCFNRecordingGroupForTest and CFGSvcCFNRecordingModeForTest expose the two
+// CloudFormation-to-API translations for AWS Config's configuration recorder, so a
+// test can assert the *emitted* wire keys.
+//
+// Asserting through the service instead would not do it: substrate decodes the
+// request with encoding/json, which matches field names case-insensitively, so an
+// UpperCamel body decodes into the same struct as a lowerCamel one and the two are
+// indistinguishable downstream. Real Config is case-sensitive, and the request body
+// is what an exported event log replays against AWS, so the keys have to be pinned
+// where they are produced.
+func CFGSvcCFNRecordingGroupForTest(v interface{}) map[string]interface{} {
+	return cfgsvcCFNRecordingGroup(v, nil)
+}
+
+// CFGSvcCFNRecordingModeForTest exposes cfgsvcCFNRecordingMode — see
+// CFGSvcCFNRecordingGroupForTest for why the emitted keys are asserted directly.
+func CFGSvcCFNRecordingModeForTest(v interface{}) map[string]interface{} {
+	return cfgsvcCFNRecordingMode(v, nil)
+}
+
 // IAMMemberListForTest wraps iamMemberList for external tests.
 func IAMMemberListForTest(params map[string]string, prefix string) []string {
 	return iamMemberList(params, prefix)


### PR DESCRIPTION
PR 6 of 7 for the v0.101.0 milestone (#580). Lane 7 of the release plan: the CloudFormation stubs become real dispatches.

## What was wrong

`AWS::Config::ConfigRule` and `AWS::Config::ConfigurationRecorder` were stubs in `cfn_resources_v32.go` — each stored a synthetic ARN and dispatched no API call. `AWS::Config::DeliveryChannel` fell through to `deployGenericStub` and did the same. All three reported `CREATE_COMPLETE` while creating nothing, and nothing observable contradicted them. That is the #388 class, and it became fixable only now that the Config handlers exist.

## A deliberate divergence from the plan

**The plan scoped `AWS::Config::DeliveryChannel` out; this PR includes it.** The plan's stated reason for excluding it — "a stub is the defect this lane exists to remove" — is the argument for including it: the type was *already* a de-facto stub through `deployGenericStub`, so leaving it out would have preserved the defect for one of the three siblings. It is also the only route to the recorder's own documented CloudFormation behaviour, "AWS CloudFormation starts the recorder as soon as the delivery channel is available" — a recorder cannot be started without a channel, so the lane's stated outcome (a template carrying both yields `recording: true`) is unreachable otherwise.

Ordering is carried entirely by `typePriority` (recorder 2, channel 3, rule 4), not by `DependsOn` — which substrate parses and does not act on. A test declares the channel *before* the recorder with no `DependsOn` and still ends `recording: true`.

## The case asymmetry, and why the test asserts wire keys

CloudFormation spells the recorder's and channel's nested members UpperCamel (`RecordingGroup.AllSupported`, `RecordingMode.RecordingFrequency`, `DeliveryChannel.S3BucketName`); the API spells them lowerCamel. Real Config is case-sensitive and would ignore the UpperCamel members: the deploy succeeds, the recorder records AWS's *default* group, nothing reports the loss.

Substrate would **not** show that, because its handlers decode with `encoding/json`, whose field matching is case-insensitive — an UpperCamel body decodes into the same struct. The recorded request body is nevertheless what an exported event log replays against AWS, so a body that only works against a lenient decoder is a fixture that passes here and fails there. `TestCFN_ConfigRecorderWireKeysAreLowerCamel` therefore asserts the *emitted* keys directly. It exists because the mutation pass found it: two mutants renaming wire keys survived the service-level tests, which is exactly the blind spot described above.

`ConfigRule` is UpperCamel on both sides and takes a whitelist instead — CloudFormation defines a `Compliance` property `PutConfigRule` has no member for, and the model refuses `ConfigRuleArn`/`ConfigRuleId` on a create.

## Also in this PR

- **The recorder ARN is corrected and read back, not rebuilt.** The Service Authorization Reference gives the two-segment `configuration-recorder/${RecorderName}/${RecorderId}`; the stub minted `recorder/<name>`. The `RecorderId` has no member in the API model, so the plugin mints it — recomputing that here would give the derivation two homes that could drift. A delivery channel's `ARN` is deliberately **empty**: no `delivery-channel` resource type exists in the reference at all.
- **Three `Fn::GetAtt` attributes on the rule.** The page documents `Arn`, `ConfigRuleId` and `Compliance.Type` (the plan's "no `Fn::GetAtt` attributes are exposed" holds only for the recorder and the channel, whose sections are empty). The latter two resolve from `dr.Metadata`; falling through to `dr.PhysicalID` would answer the rule *name* — a plausible-looking wrong value a stack `Output` asserts against happily.
- **Teardown works.** All three types leave `cfnStubDeleteTypes` for real deleters, plus a `StopConfigurationRecorder` pre-step (scoped to a *sibling* recorder, so a sweep cannot switch off a recorder the stack does not own) and the three `NoSuch…Exception` codes as already-absent. Every Config exception is HTTP 400, so the code is the only thing that can carry an absence.
- **`AWS::Config::ConfigRule` joins `cfnGeneratedNameTypes`** (max 128), producing CloudFormation's documented `mystack-MyConfigRule-12ABCFPXHV4OV` shape. Its two siblings stay out: AWS names them `"default"` itself.
- **CloudFormation-layer refusals.** `RoleARN` and `S3BucketName` are *Required: Yes* on their CloudFormation pages while the API model requires neither, so substrate refuses at the CloudFormation layer — the stack event then names the property CloudFormation would have named.

## Known gap

`AWS::S3::BucketPolicy` is not a supported resource type anywhere in substrate, so a template cannot express the bucket policy `PutDeliveryChannel` requires. A fixture needs either the `/v1/config/delivery-policy/{bucket}` seed or an out-of-band `PutBucketPolicy` — the new tests use the latter, which exercises the permissive matcher rather than bypassing it.

The two v0.32.0 stub tests were **not** carried over by adjusting expectations: each template was invalid against the real API (no `Source`, no `RoleARN`) and `newTestDeployer` registers no Config plugin, so both went green while creating nothing. That is the defect, not the baseline.

## Verification

- `gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...` → `0 issues.`
- `make test` (race detector) → every package green
- `make coverage` → `emulator 82.6%`, total 82.0%
- `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build` → green
- `go vet -C test/e2e ./... && go test -C test/e2e ./...` → green
- **Live server on `:4678` with `AWS_MAX_ATTEMPTS=1`**: deployed a recorder + channel + rule template (channel declared first), then `describe-configuration-recorders` (present, two-segment ARN), `describe-configuration-recorder-status` (`recording: true`), `describe-delivery-channels`, `describe-config-rules` (generated name `cfg-Rule-o6f9kx9mp8yv`), `describe-stack-resources` (all `CREATE_COMPLETE`), the four Outputs including `Compliance.Type` → `INSUFFICIENT_DATA`. Then `delete-stack` → all three gone → redeploy `CREATE_COMPLETE` with `recording: true`. A recorder template omitting `RoleARN` → `CREATE_FAILED` / `ROLLBACK_COMPLETE` naming the property.
- **Mutation pass, 13 mutants, 13 CAUGHT, 0 survivors** — after fixing the two genuine survivors described above rather than declaring them equivalent. Targets: the `RoleARN` and `S3BucketName` guards, the channel's recorder start, the ARN read-back, the `Fn::GetAtt` case, the generated-name entry, the three deleters, the stop pre-step, the absent codes, and three separate wire-key renames (group, nested exclusion, mode overrides).