### PR TITLE
fix(s3): a subresource marker routes on presence, not on a sentinel value (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   absent, which denies; an absent key is the safe direction.
 
 ### Fixed
+- **`DeleteBucketPolicy` deleted the bucket, and every other S3 subresource call from a real
+  SDK was misrouted** (#656). S3 routes bucket-policy and ACL operations on a query-string
+  marker — `?policy`, `?acl` — and substrate compared that marker against the `"1"` sentinel
+  its own parser assigns to *bare* query keys. aws-sdk-go-v2 does not send a bare key: it
+  sends `?policy=`, a key with an **empty value**, which the sentinel is never applied to. So
+  the comparison failed on every request a real client made, and seven operations fell
+  through to their arm's default: `PutBucketPolicy` was handled as `CreateBucket` (answering
+  `409 BucketAlreadyExists`), `GetBucketPolicy` and `GetBucketAcl` as an object listing,
+  `PutBucketAcl` as `CreateBucket`, `PutObjectAcl` as `PutObject` — overwriting the object
+  with the ACL request's empty body — and `DeleteBucketPolicy` as **`DeleteBucket`**.
+
+  That last one is data loss, and it is why this is called out rather than filed as a routing
+  nit: a consumer clearing a bucket policy destroyed the bucket. On a bucket holding objects
+  the misroute at least surfaced as `BucketNotEmpty`; on an empty bucket it answered `204`,
+  byte for byte what a correct `DeleteBucketPolicy` returns, so nothing in the response
+  distinguished the two and only a later call revealed the bucket was gone. Anyone who ran
+  `DeleteBucketPolicy` against an affected version lost the bucket and its contents.
+
+  Every S3 unit test passed throughout. Each one hand-built `Params{"policy": "1"}` — the one
+  shape no client sends — so the suite asserted the routing worked for a request that never
+  arrives. The fix tests every subresource marker for **presence** and never for a value,
+  which is the invariant: a marker carries no information beyond being there, and its wire
+  shape is the client's choice, not substrate's. `list-type` is the sole exception and stays a
+  value test, because `2` genuinely selects `ListObjectsV2`. New coverage runs the markers
+  through `Server.ServeHTTP` in both shapes — the level at which they differ at all — asserts
+  no marker's value changes routing across five values a client would not send, and adds
+  end-to-end journeys through the real SDK, including one whose whole purpose is to reach the
+  silent case and assert that an emptied bucket is still standing after its policy is
+  cleared. This is the #446 class and the #561/#610/#636 class at once: a code path that only
+  a real client exercises cannot be pinned by a test that builds the request itself.
 - **Three `AWS::Config::*` CloudFormation resources reported `CREATE_COMPLETE` while creating
   nothing** (#97). `AWS::Config::ConfigRule` and `AWS::Config::ConfigurationRecorder` were stubs
   that stored a synthetic ARN and dispatched no API call; `AWS::Config::DeliveryChannel` fell

--- a/emulator/s3_plugin.go
+++ b/emulator/s3_plugin.go
@@ -253,14 +253,27 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 		return bucket, key, method
 	}
 
+	// Every subresource below is tested for **presence**, never for a particular
+	// value. A subresource marker carries no information beyond being there, and the
+	// shape it arrives in is not substrate's to choose: aws-sdk-go-v2 sends "?policy="
+	// — a key with an empty value — where the AWS docs write the bare "?policy", so
+	// parser.go's bare-key sentinel ("1") is never applied to it.
+	//
+	// Seven of these tests compared against that sentinel until #656, which made
+	// every SDK bucket-policy and ACL call fall through to the arm's default: a
+	// PutBucketPolicy became CreateBucket, a GetBucketPolicy became a list, and a
+	// DeleteBucketPolicy became **DeleteBucket** — a consumer clearing a policy
+	// destroyed the bucket and its contents. Unit tests could not catch it, because
+	// each built Params{"policy": "1"} by hand and so asserted the one shape no client
+	// sends; that is the #446 and #561/#610/#636 class both at once.
 	if key == "" {
 		// Bucket-level operations.
 		switch method {
 		case "PUT":
-			if req.Params["policy"] == "1" {
+			if _, ok := req.Params["policy"]; ok {
 				return bucket, "", "PutBucketPolicy"
 			}
-			if req.Params["acl"] == "1" {
+			if _, ok := req.Params["acl"]; ok {
 				return bucket, "", "PutBucketAcl"
 			}
 			if _, ok := req.Params["notification"]; ok {
@@ -282,7 +295,7 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 		case "HEAD":
 			return bucket, "", "HeadBucket"
 		case "DELETE":
-			if req.Params["policy"] == "1" {
+			if _, ok := req.Params["policy"]; ok {
 				return bucket, "", "DeleteBucketPolicy"
 			}
 			if _, ok := req.Params["tagging"]; ok {
@@ -298,10 +311,10 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 			}
 			return bucket, "", "DeleteBucket"
 		case "GET":
-			if req.Params["policy"] == "1" {
+			if _, ok := req.Params["policy"]; ok {
 				return bucket, "", "GetBucketPolicy"
 			}
-			if req.Params["acl"] == "1" {
+			if _, ok := req.Params["acl"]; ok {
 				return bucket, "", "GetBucketAcl"
 			}
 			if _, ok := req.Params["notification"]; ok {
@@ -348,7 +361,7 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 		// GetObject, whose arm tested no uploadId at all).
 		switch method {
 		case "PUT":
-			if req.Params["acl"] == "1" {
+			if _, ok := req.Params["acl"]; ok {
 				return bucket, key, "PutObjectAcl"
 			}
 			if _, ok := req.Params["tagging"]; ok {
@@ -367,7 +380,7 @@ func parseS3Operation(req *AWSRequest) (bucket, key, op string) {
 			}
 			return bucket, key, "PutObject"
 		case "GET":
-			if req.Params["acl"] == "1" {
+			if _, ok := req.Params["acl"]; ok {
 				return bucket, key, "GetObjectAcl"
 			}
 			if _, ok := req.Params["tagging"]; ok {

--- a/emulator/s3_subresource_routing_test.go
+++ b/emulator/s3_subresource_routing_test.go
@@ -1,0 +1,254 @@
+package emulator_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// These are #656's gates: every S3 subresource marker in the shape a real client
+// sends it, "?policy=" — a key with an empty value — rather than the bare "?policy"
+// the AWS documentation writes and substrate's own tests had always hand-built.
+//
+// Seven routing tests compared the marker against parser.go's bare-key sentinel
+// ("1"), which aws-sdk-go-v2 never produces, so every SDK bucket-policy and ACL call
+// fell through to its arm's default: PutBucketPolicy became CreateBucket,
+// GetBucketPolicy became a list, and DeleteBucketPolicy became **DeleteBucket** —
+// clearing a policy destroyed the bucket. Every unit test passed throughout, because
+// each set Params{"policy": "1"} itself and so asserted the one shape no client sends.
+//
+// The requests here go through Server.ServeHTTP so the parser produces the params,
+// which is the only level at which the two shapes differ at all.
+
+// s3SubresourceQueries is the marker shape captured from aws-sdk-go-v2
+// service/s3 v1.107.0 against an httptest server: PutBucketPolicy sends
+// RawQuery="policy=", GetBucketAcl sends "acl=", and so on. The bare form is kept
+// alongside it because the AWS documentation writes markers bare, some clients send
+// them that way, and both must route identically.
+var s3SubresourceQueries = []struct {
+	name  string
+	query string
+}{
+	{"empty value, as aws-sdk-go-v2 sends it", "="},
+	{"bare key, as the AWS docs write it", ""},
+}
+
+// TestS3_BucketPolicyRoundTripsThroughEverySubresourceShape asserts the whole
+// policy lifecycle, and that the bucket survives the delete.
+//
+// The survival assertion is the point: a DeleteBucketPolicy misrouted to DeleteBucket
+// answers 204 either way, so nothing in the response distinguishes the data-loss path
+// from the correct one. Only a later HeadBucket does.
+func TestS3_BucketPolicyRoundTripsThroughEverySubresourceShape(t *testing.T) {
+	const policy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"Service":"config.amazonaws.com"},"Action":"s3:PutObject",` +
+		`"Resource":"arn:aws:s3:::b/*"}]}`
+
+	for _, shape := range s3SubresourceQueries {
+		t.Run(shape.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			bucket := "policy-bucket"
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code)
+
+			marker := "/" + bucket + "?policy" + shape.query
+
+			put := s3Request(t, srv, http.MethodPut, marker, []byte(policy),
+				map[string]string{"Content-Type": "application/json"})
+			assert.Equal(t, http.StatusNoContent, put.Code,
+				"PutBucketPolicy: a 409 BucketAlreadyExists here means the request "+
+					"was routed as CreateBucket (#656): %s", put.Body.String())
+
+			get := s3Request(t, srv, http.MethodGet, marker, nil, nil)
+			require.Equal(t, http.StatusOK, get.Code, get.Body.String())
+			assert.JSONEq(t, policy, get.Body.String(),
+				"GetBucketPolicy must answer the stored policy, not an object listing")
+
+			del := s3Request(t, srv, http.MethodDelete, marker, nil, nil)
+			assert.Equal(t, http.StatusNoContent, del.Code, del.Body.String())
+
+			head := s3Request(t, srv, http.MethodHead, "/"+bucket, nil, nil)
+			assert.Equal(t, http.StatusOK, head.Code,
+				"the bucket must survive DeleteBucketPolicy — a 404 here is #656's "+
+					"data-loss path, where clearing a policy deleted the bucket")
+
+			gone := s3Request(t, srv, http.MethodGet, marker, nil, nil)
+			assert.Equal(t, http.StatusNotFound, gone.Code,
+				"and the policy is really gone: NoSuchBucketPolicy")
+		})
+	}
+}
+
+// TestS3_BucketACLRoutesThroughEverySubresourceShape covers the other pair of
+// misrouted markers. A misrouted PutBucketAcl reached CreateBucket, so it answered
+// 409 rather than storing anything.
+func TestS3_BucketACLRoutesThroughEverySubresourceShape(t *testing.T) {
+	for _, shape := range s3SubresourceQueries {
+		t.Run(shape.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			bucket := "acl-bucket"
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code)
+
+			marker := "/" + bucket + "?acl" + shape.query
+
+			put := s3Request(t, srv, http.MethodPut, marker, nil,
+				map[string]string{"X-Amz-Acl": "public-read"})
+			assert.Equal(t, http.StatusOK, put.Code,
+				"PutBucketAcl: a 409 here means the request was routed as CreateBucket "+
+					"(#656): %s", put.Body.String())
+
+			get := s3Request(t, srv, http.MethodGet, marker, nil, nil)
+			require.Equal(t, http.StatusOK, get.Code, get.Body.String())
+			assert.Contains(t, get.Body.String(), "AccessControlPolicy",
+				"GetBucketAcl must answer an ACL document, not an object listing")
+		})
+	}
+}
+
+// TestS3_ObjectACLRoutesThroughEverySubresourceShape covers the two object-level
+// markers, whose fall-throughs are quieter than the bucket ones: a misrouted
+// PutObjectAcl overwrites the object with the ACL request's body, and a misrouted
+// GetObjectAcl answers the object's own bytes.
+func TestS3_ObjectACLRoutesThroughEverySubresourceShape(t *testing.T) {
+	for _, shape := range s3SubresourceQueries {
+		t.Run(shape.name, func(t *testing.T) {
+			srv, _ := newS3TestServer(t)
+			bucket, key := "objacl-bucket", "obj.txt"
+			require.Equal(t, http.StatusOK,
+				s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code)
+			require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut,
+				"/"+bucket+"/"+key, []byte("payload"), nil).Code)
+
+			marker := "/" + bucket + "/" + key + "?acl" + shape.query
+
+			put := s3Request(t, srv, http.MethodPut, marker, nil,
+				map[string]string{"X-Amz-Acl": "public-read"})
+			assert.Equal(t, http.StatusOK, put.Code, put.Body.String())
+
+			get := s3Request(t, srv, http.MethodGet, marker, nil, nil)
+			require.Equal(t, http.StatusOK, get.Code, get.Body.String())
+			assert.Contains(t, get.Body.String(), "AccessControlPolicy",
+				"GetObjectAcl must answer an ACL document, not the object's bytes")
+
+			// The object itself is untouched: a misrouted PutObjectAcl is a PutObject,
+			// which would have replaced the payload with the ACL request's empty body.
+			body := s3Request(t, srv, http.MethodGet, "/"+bucket+"/"+key, nil, nil)
+			require.Equal(t, http.StatusOK, body.Code)
+			assert.Equal(t, "payload", body.Body.String(),
+				"the object's bytes must survive PutObjectAcl")
+		})
+	}
+}
+
+// TestS3_SubresourceMarkersAreNotValueSensitive is the guard against the class
+// rather than the instance: no subresource marker's *value* may change how a request
+// routes, whatever a client puts there. A test that only covered "=" and the bare
+// form would still pass if a future comparison were written against "" specifically.
+func TestS3_SubresourceMarkersAreNotValueSensitive(t *testing.T) {
+	markers := []string{"policy", "acl", "tagging", "versioning", "notification",
+		"lifecycle", "publicAccessBlock", "uploads", "versions"}
+	// Values a client has no reason to send, precisely so that anything reading them
+	// is caught. "1" is included because it was the sentinel the seven broken tests
+	// compared against, so a partially-reverted fix shows up here.
+	values := []string{"", "=", "=1", "=true", "=x"}
+
+	for _, marker := range markers {
+		srv, _ := newS3TestServer(t)
+		bucket := "marker-" + strings.ToLower(marker)
+		require.Equal(t, http.StatusOK,
+			s3Request(t, srv, http.MethodPut, "/"+bucket, nil, nil).Code)
+
+		codes := make(map[string]int, len(values))
+		for _, v := range values {
+			got := s3Request(t, srv, http.MethodGet, "/"+bucket+"?"+marker+v, nil, nil)
+			codes[v] = got.Code
+		}
+		for _, v := range values[1:] {
+			assert.Equal(t, codes[values[0]], codes[v],
+				"?%s%s routes differently from the bare ?%s (%d vs %d) — a marker's "+
+					"value must not affect routing", marker, v, marker,
+				codes[values[0]], codes[v])
+		}
+	}
+}
+
+// TestS3_ListTypeIsStillValueSensitive is the counter-case that keeps the rule above
+// honest. list-type is not a subresource marker but a real parameter whose value
+// selects the operation — "?list-type=2" is ListObjectsV2 and its absence is
+// ListObjects — so it is the one query key routing may read, and the fix must not
+// have flattened it.
+func TestS3_ListTypeIsStillValueSensitive(t *testing.T) {
+	srv, _ := newS3TestServer(t)
+	require.Equal(t, http.StatusOK,
+		s3Request(t, srv, http.MethodPut, "/list-bucket", nil, nil).Code)
+
+	v2 := s3Request(t, srv, http.MethodGet, "/list-bucket?list-type=2", nil, nil)
+	require.Equal(t, http.StatusOK, v2.Code)
+	assert.Contains(t, v2.Body.String(), "KeyCount",
+		"ListObjectsV2 carries KeyCount; ListObjects does not")
+
+	v1 := s3Request(t, srv, http.MethodGet, "/list-bucket", nil, nil)
+	require.Equal(t, http.StatusOK, v1.Code)
+	assert.NotContains(t, v1.Body.String(), "KeyCount",
+		"a request with no list-type is ListObjects")
+
+	// The case that actually separates a value test from a presence test: "2" is the
+	// only value the S3 API defines for list-type, so any other value is not
+	// ListObjectsV2. Without this, a presence test passes both assertions above —
+	// which is how a mutant flattening list-type to presence survived the first
+	// version of this test.
+	for _, other := range []string{"", "1", "3"} {
+		got := s3Request(t, srv, http.MethodGet, "/list-bucket?list-type="+other, nil, nil)
+		require.Equal(t, http.StatusOK, got.Code, got.Body.String())
+		assert.NotContains(t, got.Body.String(), "KeyCount",
+			"?list-type=%q is not ListObjectsV2: 2 is the only value the API defines, "+
+				"so this key is read by value where a subresource marker is read by "+
+				"presence", other)
+	}
+}
+
+// TestS3_BucketPolicyRoutesFromAnInProcessRequest keeps the in-process path working
+// too. A caller building an AWSRequest by hand — the CloudFormation deployer does,
+// and so does every plugin reading another service's state — sets the marker itself,
+// and both the sentinel it used to have to send and an empty value must route.
+func TestS3_BucketPolicyRoutesFromAnInProcessRequest(t *testing.T) {
+	for _, value := range []string{"1", ""} {
+		registry := emulator.NewPluginRegistry()
+		registry.Register(newS3PluginDirect(t))
+
+		reqCtx := &emulator.RequestContext{
+			RequestID: "inproc-request",
+			AccountID: "123456789012",
+			Region:    "us-east-1",
+			Timestamp: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+		}
+		_, err := registry.RouteRequest(reqCtx, &emulator.AWSRequest{
+			Service: "s3", Operation: http.MethodPut, Path: "/inproc-bucket",
+			Headers: map[string]string{}, Params: map[string]string{},
+		})
+		require.NoError(t, err)
+
+		_, err = registry.RouteRequest(reqCtx, &emulator.AWSRequest{
+			Service: "s3", Operation: http.MethodPut, Path: "/inproc-bucket",
+			Body:    []byte(`{"Version":"2012-10-17","Statement":[]}`),
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Params:  map[string]string{"policy": value},
+		})
+		require.NoError(t, err, "an in-process PutBucketPolicy with policy=%q", value)
+
+		resp, err := registry.RouteRequest(reqCtx, &emulator.AWSRequest{
+			Service: "s3", Operation: http.MethodGet, Path: "/inproc-bucket",
+			Headers: map[string]string{}, Params: map[string]string{"policy": value},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, string(resp.Body), "2012-10-17",
+			"the policy reads back with policy=%q", value)
+	}
+}

--- a/test/e2e/journey_s3_bucket_policy_test.go
+++ b/test/e2e/journey_s3_bucket_policy_test.go
@@ -1,0 +1,211 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestS3_BucketPolicyLifecycle is #656 at the tier that found it, and the only tier
+// that could have.
+//
+// The subresource markers S3 routes on arrive from aws-sdk-go-v2 as "?policy=" — a key
+// with an empty value — not as the bare "?policy" the AWS documentation writes.
+// Substrate's router compared them against the sentinel its own parser assigns to bare
+// keys, so every SDK bucket-policy call fell through its arm's default: PutBucketPolicy
+// was handled as CreateBucket, GetBucketPolicy as an object listing, and
+// DeleteBucketPolicy as **DeleteBucket** — clearing a policy destroyed the bucket and
+// its contents.
+//
+// Every S3 unit test passed throughout, because each hand-built the sentinel shape no
+// client sends. Only a real client produces the query string, which is why this belongs
+// here; #446, #561, #610 and #636 were all the same lesson.
+func TestS3_BucketPolicyLifecycle(t *testing.T) {
+	ctx := context.Background()
+	cfg := awsConfig(t)
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = true
+		o.BaseEndpoint = aws.String("http://s3.amazonaws.com")
+		// Retries off, so each assertion is about the first response.
+		o.RetryMaxAttempts = 1
+	})
+
+	const bucket = "e2e-policy-bucket"
+	const policy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Principal":{"Service":"config.amazonaws.com"},"Action":"s3:PutObject",` +
+		`"Resource":"arn:aws:s3:::e2e-policy-bucket/*"}]}`
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err, "CreateBucket")
+
+	// An object, so the delete path has something to lose: a bucket removed by a
+	// misrouted DeleteBucketPolicy takes its contents with it, and that is the part of
+	// the defect no status code shows.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("keepme"),
+		Body:   strings.NewReader("keep me"),
+	})
+	require.NoError(t, err, "PutObject")
+
+	// Put. A BucketAlreadyExists here is the misroute to CreateBucket.
+	_, err = client.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+		Bucket: aws.String(bucket),
+		Policy: aws.String(policy),
+	})
+	require.NoError(t, err,
+		"PutBucketPolicy: a BucketAlreadyExists means ?policy= was not routed (#656)")
+
+	// Get: the stored document, not an object listing.
+	got, err := client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
+		Bucket: aws.String(bucket),
+	})
+	require.NoError(t, err, "GetBucketPolicy")
+	assert.Contains(t, aws.ToString(got.Policy), "config.amazonaws.com",
+		"GetBucketPolicy must answer the stored policy, not an object listing")
+
+	// Delete, and the bucket survives it.
+	_, err = client.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{
+		Bucket: aws.String(bucket),
+	})
+	require.NoError(t, err, "DeleteBucketPolicy")
+
+	_, err = client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err, "HeadBucket after DeleteBucketPolicy: the bucket must "+
+		"survive — a NotFound here is #656's data-loss path, where clearing a policy "+
+		"deleted the bucket")
+
+	_, err = client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("keepme"),
+	})
+	require.NoError(t, err,
+		"HeadObject after DeleteBucketPolicy: the bucket's contents must survive too")
+
+	// And the policy really is gone rather than never having been stored.
+	_, err = client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
+		Bucket: aws.String(bucket),
+	})
+	require.Error(t, err, "GetBucketPolicy after the delete must be refused")
+	assert.Contains(t, err.Error(), "NoSuchBucketPolicy",
+		"the refusal names the missing policy, not a missing bucket")
+
+}
+
+// TestS3_DeleteBucketPolicyLeavesAnEmptyBucketStanding is the silent form of #656, and
+// it is a separate test because it has to be reached.
+//
+// In the lifecycle above the misrouted DeleteBucket met a bucket holding an object and
+// was refused with BucketNotEmpty, so the consumer at least saw an error and the test
+// stops there. With nothing in the bucket the misroute **succeeds** at 204 — byte for
+// byte what a correct DeleteBucketPolicy answers — and only a later HeadBucket shows
+// that the bucket is gone. That is the case a consumer would never notice, so it gets
+// its own path to the assertion.
+func TestS3_DeleteBucketPolicyLeavesAnEmptyBucketStanding(t *testing.T) {
+	ctx := context.Background()
+	cfg := awsConfig(t)
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = true
+		o.BaseEndpoint = aws.String("http://s3.amazonaws.com")
+		o.RetryMaxAttempts = 1
+	})
+
+	const bucket = "e2e-policy-empty-bucket"
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err, "CreateBucket")
+
+	_, err = client.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+		Bucket: aws.String(bucket),
+		Policy: aws.String(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+			`"Principal":{"Service":"config.amazonaws.com"},"Action":"s3:PutObject",` +
+			`"Resource":"arn:aws:s3:::e2e-policy-empty-bucket/*"}]}`),
+	})
+	require.NoError(t, err, "PutBucketPolicy")
+
+	_, err = client.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{
+		Bucket: aws.String(bucket),
+	})
+	require.NoError(t, err, "DeleteBucketPolicy")
+
+	_, err = client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err, "HeadBucket after DeleteBucketPolicy on an empty bucket: a "+
+		"NotFound here means the delete was routed as DeleteBucket and silently "+
+		"destroyed the bucket (#656)")
+}
+
+// TestS3_BucketACLLifecycle covers the other markers #656 broke: a misrouted
+// PutBucketAcl reached CreateBucket and stored nothing, and a misrouted GetBucketAcl
+// answered an object listing.
+func TestS3_BucketACLLifecycle(t *testing.T) {
+	ctx := context.Background()
+	cfg := awsConfig(t)
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = true
+		o.BaseEndpoint = aws.String("http://s3.amazonaws.com")
+		o.RetryMaxAttempts = 1
+	})
+
+	const bucket = "e2e-acl-bucket"
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err, "CreateBucket")
+
+	_, err = client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+		Bucket: aws.String(bucket),
+		ACL:    s3types.BucketCannedACLPublicRead,
+	})
+	require.NoError(t, err,
+		"PutBucketAcl: a BucketAlreadyExists means ?acl= was not routed (#656)")
+
+	acl, err := client.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err, "GetBucketAcl")
+	// An object listing deserialized in place of an AccessControlPolicy leaves both of
+	// these empty rather than erroring, so the assertion has to be on the contents.
+	require.NotNil(t, acl.Owner,
+		"GetBucketAcl returned no Owner — an object listing deserializes to exactly this")
+	assert.NotEmpty(t, aws.ToString(acl.Owner.ID), "the ACL's Owner.ID")
+	assert.NotEmpty(t, acl.Grants, "GetBucketAcl returned no Grants")
+
+	// The object-level pair, whose misroute is quieter: a PutObjectAcl handled as
+	// PutObject replaces the object with the ACL request's empty body.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("obj"),
+		Body:   strings.NewReader("payload"),
+	})
+	require.NoError(t, err, "PutObject")
+
+	_, err = client.PutObjectAcl(ctx, &s3.PutObjectAclInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("obj"),
+		ACL:    s3types.ObjectCannedACLPrivate,
+	})
+	require.NoError(t, err, "PutObjectAcl")
+
+	objACL, err := client.GetObjectAcl(ctx, &s3.GetObjectAclInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("obj"),
+	})
+	require.NoError(t, err, "GetObjectAcl")
+	require.NotNil(t, objACL.Owner,
+		"GetObjectAcl returned no Owner — the object's own bytes deserialize to exactly this")
+
+	// And the object still holds its bytes: a misrouted PutObjectAcl would have
+	// replaced them with the ACL request's body.
+	obj, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("obj"),
+	})
+	require.NoError(t, err, "GetObject")
+	defer obj.Body.Close()
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(obj.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", buf.String(), "the object's bytes must survive PutObjectAcl")
+}


### PR DESCRIPTION
Closes #656

## The defect

S3 routes bucket-policy and ACL operations on a query-string marker — `?policy`, `?acl` — and `emulator/s3_plugin.go` compared that marker against the `"1"` sentinel `parser.go` assigns to **bare** query keys. aws-sdk-go-v2 does not send a bare key. It sends `?policy=` — a key with an *empty value* — which the sentinel is never applied to.

Captured from aws-sdk-go-v2 `service/s3` v1.107.0 against an httptest server:

```
PUT    /b   RawQuery="policy="     <- PutBucketPolicy
GET    /b   RawQuery="policy="     <- GetBucketPolicy
DELETE /b   RawQuery="policy="     <- DeleteBucketPolicy
PUT    /b   RawQuery="acl="        <- PutBucketAcl
GET    /b   RawQuery="acl="        <- GetBucketAcl
```

So the comparison failed on every request a real client made, and seven operations fell through to their arm's default:

| Called | Actually handled as |
|---|---|
| `PutBucketPolicy` | `CreateBucket` → `409 BucketAlreadyExists` |
| `GetBucketPolicy` | `ListObjectsV2` |
| **`DeleteBucketPolicy`** | **`DeleteBucket`** |
| `PutBucketAcl` | `CreateBucket` → `409` |
| `GetBucketAcl` | `ListObjectsV2` |
| `PutObjectAcl` | `PutObject` — overwrites the object with the ACL request's empty body |
| `GetObjectAcl` | `GetObject` |

**`DeleteBucketPolicy` is data loss.** A consumer clearing a bucket policy destroyed the bucket. On a bucket holding objects the misroute at least surfaced as `BucketNotEmpty`; on an empty bucket it answered `204` — byte for byte what a correct `DeleteBucketPolicy` returns — so nothing in the response distinguished the two and only a later call revealed the bucket was gone.

## Why no test caught it

Every S3 unit test passed throughout. Each one hand-built `Params{"policy": "1"}`, so the suite asserted the routing worked for the one request shape no client sends. This is the #446 class and the #561/#610/#636 class at once: a path only a real client exercises cannot be pinned by a test that builds the request itself.

## The fix

All seven comparisons become presence tests, under a block comment stating the invariant: **a subresource marker is tested for presence, never for a value.** A marker carries no information beyond being there, and its wire shape is the client's choice, not substrate's. `list-type` is the sole exception and stays a value test, because `2` genuinely selects `ListObjectsV2`.

## Coverage, at the levels that can see the difference

`emulator/s3_subresource_routing_test.go` — through `Server.ServeHTTP`, so the parser produces the params:

- the policy lifecycle in **both** marker shapes, ending with a `HeadBucket` that asserts the bucket survived (a misrouted delete answers 204 either way, so only a later call distinguishes the data-loss path)
- the bucket-ACL and object-ACL pairs, the latter also asserting the object's bytes survive `PutObjectAcl`
- nine markers × five values, asserting a marker's *value* never changes routing — the guard against the class rather than the instance
- the `list-type` counter-case, asserting `""`, `"1"` and `"3"` are **not** `ListObjectsV2`
- the in-process path, where a caller (the CFN deployer, or any plugin reading another service) sets params by hand

`test/e2e/journey_s3_bucket_policy_test.go` — through the real SDK, the tier that found this. `TestS3_DeleteBucketPolicyLeavesAnEmptyBucketStanding` is separate on purpose: in the full lifecycle the misroute is stopped by `BucketNotEmpty` before the survival assertion is reached, so the silent case needs its own path to it.

## Verification

Full gate green: `gofmt`/`build`/`vet`/`golangci-lint` (0 issues), `make test` (race), `make coverage` (`emulator` 82.7%), docs targets, `npm --prefix docs run build`, `test/e2e`.

Each new test was confirmed to **fail** against the pre-fix code, including the silent path with only the DELETE-arm sentinel restored.

Live-server check with the real AWS CLI (`AWS_MAX_ATTEMPTS=1`): policy put/get/delete round trip, the `public-read` grant reflected in `GetBucketAcl`, the bucket standing after `DeleteBucketPolicy`, and `NoSuchBucketPolicy` on the follow-up read.

Mutation testing: **5 mutants, 5 CAUGHT, 0 survivors** — four sentinel restorations plus one flattening `list-type` to a presence test. The last survived the first version of `TestS3_ListTypeIsStillValueSensitive`, which only covered `=2` and absence; extending it to other values caught it.