### PR TITLE
docs(config): the Config service reference, and an SDK journey that proves reachability (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expressible at creation time. A tag store that will not decode leaves the condition key
   absent, which denies; an absent key is the safe direction.
 
+  **An end-to-end journey drives the whole surface through the real SDK**, and for Config
+  that tier is not optional. Config's `X-Amz-Target` prefix is `StarlingDoveService` — an
+  internal code name bearing no resemblance to the `config` endpoint prefix — and every
+  aws-sdk-go-v2, boto3 and CLI call routes by that target. A plugin registered without the
+  alias is fully unit-tested and unreachable from every SDK, which is what #561, #610 and
+  #636 each turned out to be; a unit test driving a hand-built request never touches the
+  alias. The journey walks the detective-controls baseline a consumer actually performs:
+  reachability on an empty account, both ordering refusals, a recorder reporting
+  `recording: false`, the two-segment ARN, all three S3 refusals in the order the operation
+  documents them, `Start`, `recording: true`, a rule reporting `INSUFFICIENT_DATA`, a seed,
+  `NON_COMPLIANT`, and the teardown-and-rebuild sequence. `docs/services.md` gains the
+  Config section: the target-prefix warning, the supported-operation table, `curl` examples
+  for all five seed families, and prose stating plainly that compliance is seeded and never
+  computed, what the delivery-policy matcher checks and why it is permissive, and the
+  `ListTagsForResource` `Limit` contradiction with the bound substrate takes.
+
 ### Fixed
 - **`DeleteBucketPolicy` deleted the bucket, and every other S3 subresource call from a real
   SDK was misrouted** (#656). S3 routes bucket-policy and ACL operations on a query-string

--- a/docs/services.md
+++ b/docs/services.md
@@ -4950,6 +4950,265 @@ Organizations API calls are free.
 
 ---
 
+## Config
+
+**Endpoint:** `config.{region}.amazonaws.com`
+**Protocol:** JSON (`X-Amz-Target: StarlingDoveService.{Op}`)
+
+Note the target prefix. AWS Config's `targetPrefix` is `StarlingDoveService`, an
+internal code name bearing no resemblance to the `config` endpoint prefix — and
+every aws-sdk-go-v2, boto3 and CLI Config call routes by that target. A plugin
+registered without the alias would be fully unit-tested and unreachable from every
+SDK, which is what issues #561, #610 and #636 each turned out to be. The end-to-end
+journey exists to keep that from recurring.
+
+**Every Config exception is HTTP 400.** Every exception shape in the API model
+carries `exception: True` with no `error` member, and every operation's reference
+page states "HTTP Status Code: 400" — `NoSuchBucketException` and
+`NoSuchConfigRuleException` included. A consumer branching on the status rather than
+the code takes a path AWS never sends it down.
+
+**One recorder and one delivery channel per account per Region.** Both `Put`s are
+idempotent per the reference: a second call with the same name updates the role and
+recording group but does **not** replace creation-time tags. A second *distinct* name
+is `MaxNumberOf{ConfigurationRecorders,DeliveryChannels}ExceededException`. Both
+names default to `default`, and changing either requires a delete followed by a put.
+Every state key carries the Region, so a recorder put in `us-east-1` is absent in
+`eu-west-1` — "recording in one Region only" being a misconfiguration that looks
+like success from the Region you check.
+
+### Supported operations
+
+| Operation | Notes |
+|-----------|-------|
+| PutConfigurationRecorder | Idempotent; leaves `recording: false`; empty `roleARN` is `InvalidRoleException` |
+| DescribeConfigurationRecorders | Reports the recorder whether or not it is recording — see below |
+| DescribeConfigurationRecorderStatus | The only operation that answers "is it recording?"; `ValidationException` on more than one name |
+| StartConfigurationRecorder | `NoAvailableDeliveryChannelException` with no channel; a no-op at 200 when already recording |
+| StopConfigurationRecorder | A no-op at 200 when already stopped |
+| DeleteConfigurationRecorder | `NoSuchConfigurationRecorderException`; no ordering precondition is documented |
+| PutDeliveryChannel | `NoAvailableConfigurationRecorderException` **before** the bucket is looked at; then `NoSuchBucketException`, then `InsufficientDeliveryPolicyException` |
+| DescribeDeliveryChannels | |
+| DescribeDeliveryChannelStatus | `Not_Applicable` until the recorder first starts, then `Success`; seedable to `Failure` |
+| DeleteDeliveryChannel | `LastDeliveryChannelDeleteFailedException` while the recorder records |
+| PutConfigRule | Mints `ConfigRuleId`/`ConfigRuleArn` and refuses a *create* supplying either; an update may name the rule by Name, Id or Arn; 1000 rules per Region |
+| DescribeConfigRules | Paginated, cap 100; honours the `EvaluationMode` filter; `ConfigRuleNames` 0–25 |
+| DeleteConfigRule | Removes the rule's compliance seed and recorded evaluations with it |
+| DescribeComplianceByConfigRule | `INSUFFICIENT_DATA` unless seeded — never computed |
+| GetComplianceDetailsByConfigRule | Cap 100; `ComplianceTypes` 0–3; recorded `PutEvaluations` results outrank the seed |
+| PutEvaluations | `ResultToken` required; `TestMode` stores nothing; `Evaluations` 0–100 and optional |
+| PutConformancePack | Exactly one of `TemplateS3Uri`/`TemplateBody`/`TemplateSSMDocumentDetails`; 60 input parameters; 50 packs per Region |
+| DescribeConformancePacks | Page size cap 20 |
+| DescribeConformancePackStatus | `CREATE_IN_PROGRESS` → `CREATE_COMPLETE` on first observation; cap 20 |
+| DescribeConformancePackCompliance | Cap 1000; seeded per rule |
+| GetConformancePackComplianceSummary | Cap 20; `ConformancePackNames` 1–5 |
+| DeleteConformancePack | `ResourceInUseException` while a create or delete is in flight |
+| TagResource | Recorders, rules and packs; 50 tags; an `aws:`-prefixed key is refused |
+| UntagResource | An absent key is a no-op, not a refusal |
+| ListTagsForResource | Paginated; `Limit` capped at **100** — see Provenance below |
+
+### A recorder that exists is not a recorder that records
+
+This is the behaviour the release exists for. `DescribeConfigurationRecorders`
+reporting a recorder says **nothing** about whether anything is being recorded; that
+is `DescribeConfigurationRecorderStatus.recording`. A recorder created and never
+started is the single most common real Config misconfiguration, and a consumer that
+checks only the first call reports an account as covered while nothing is recorded.
+
+So `PutConfigurationRecorder` leaves `recording: false` and only
+`StartConfigurationRecorder` flips it. The two states are indistinguishable through
+the operation most consumers reach for first, which is precisely why substrate
+models them separately.
+
+The ordering refusals are the other half, and they make a consumer's sequencing bug
+observable instead of silently tolerated:
+
+```
+StartConfigurationRecorder, no channel   → NoAvailableDeliveryChannelException
+PutDeliveryChannel, no recorder          → NoAvailableConfigurationRecorderException
+PutConfigRule, no recorder               → NoAvailableConfigurationRecorderException
+DeleteDeliveryChannel, recorder running  → LastDeliveryChannelDeleteFailedException
+```
+
+The last one is what makes a teardown-and-rebuild fixture — the same test run twice
+— express an ordering requirement rather than pass on a sequence AWS rejects:
+
+```
+Put recorder → Put channel → Start → Delete channel   LastDeliveryChannelDeleteFailed
+Stop → Delete channel → Delete recorder → Put recorder → Put channel → Start   all 200
+```
+
+### The delivery-policy check reads real S3 state, permissively
+
+`PutDeliveryChannel` is the one Config operation whose success depends on another
+service. A missing bucket is `NoSuchBucketException`; a bucket with **no policy at
+all** is `InsufficientDeliveryPolicyException`, which is certain rather than a guess
+about a policy's contents.
+
+Where a policy does exist, the matcher passes if **any** `Allow` statement's
+principal covers `config.amazonaws.com` or `*` and its action covers `s3:PutObject`
+— including `s3:Put*`, `s3:*` and `*`. The resource ARN is **not** matched, and a
+policy shape substrate's parser cannot decode **passes**, because refusing there
+would be substrate blaming the consumer for its own limitation.
+
+That asymmetry is deliberate. The two failure directions are not equivalent: always
+accepting would make a bucket-policy bug invisible here and fatal at AWS, while
+demanding the exact documented policy would refuse policies AWS accepts — and a
+wrong refusal breaks working code, which is the worse failure. The seed below exists
+for both edges of that choice.
+
+### Compliance is seeded, never computed
+
+Substrate does not evaluate Config rules, and will not. Evaluating a rule against
+resource state is workload-internal rather than an API observation, so it falls
+outside what substrate models. Computing it would mean reimplementing hundreds of
+AWS-managed rules, and — worse — would make a consumer's compliance assertion
+silently change meaning as unrelated plugins gained fidelity.
+
+An unevaluated rule therefore reports **`INSUFFICIENT_DATA`**, which is what AWS
+reports for a rule that has not evaluated. A default of `COMPLIANT` would make every
+consumer's compliance assertion pass for free, which is worse than no answer.
+Anything else comes from a seed.
+
+`PutEvaluations` is the exception that proves the rule: a custom rule reporting its
+own result *is* an API observation, so what a caller submits is recorded — and where
+a rule has recorded evaluations, `GetComplianceDetailsByConfigRule` reports those in
+preference to the seed. A custom rule's own report outranks a fixture default.
+
+### Control plane
+
+```bash
+# A recorder reporting a failure. lastStatus must be a RecorderStatus member;
+# lastErrorCode/lastErrorMessage apply only to Failure.
+curl -X POST localhost:8080/v1/config/recorder-status \
+  -d '{"lastStatus":"Failure","lastErrorCode":"InsufficientDeliveryPolicy",
+       "lastErrorMessage":"Cannot write to the bucket"}'
+curl -X DELETE localhost:8080/v1/config/recorder-status        # ?accountId=&region= to narrow
+
+# A delivery stream that cannot write. Note Not_Applicable carries an underscore —
+# the DeliveryStatus enum spells it differently from RecorderStatus's NotApplicable.
+curl -X POST localhost:8080/v1/config/delivery-status \
+  -d '{"status":"Failure","lastErrorCode":"AccessDenied"}'
+curl -X DELETE localhost:8080/v1/config/delivery-status
+
+# Force or suppress the bucket-policy refusal regardless of real S3 state:
+# "insufficient" for a consumer with no S3 fixture, "ok" for one whose valid policy
+# substrate's permissive matcher still cannot read.
+curl -X POST localhost:8080/v1/config/delivery-policy \
+  -d '{"bucket":"cfg-logs","outcome":"insufficient"}'
+curl -X DELETE 'localhost:8080/v1/config/delivery-policy?bucket=cfg-logs'
+
+# A rule's verdict. A {name} of "*" seeds every rule.
+curl -X POST localhost:8080/v1/config/rule-compliance/s3-encrypted \
+  -d '{"complianceType":"NON_COMPLIANT","annotation":"Bucket b1 is unencrypted",
+       "resources":[{"resourceType":"AWS::S3::Bucket","resourceId":"b1"}]}'
+curl -X DELETE localhost:8080/v1/config/rule-compliance/s3-encrypted
+
+# A conformance pack's state, and its per-rule verdicts.
+curl -X POST localhost:8080/v1/config/pack-status/ops -d '{"state":"CREATE_FAILED",
+       "statusReason":"The template could not be read"}'
+curl -X POST localhost:8080/v1/config/pack-compliance/ops \
+  -d '{"rules":[{"configRuleName":"iam-password-policy",
+       "complianceType":"NON_COMPLIANT","controls":["CIS 1.5"]}]}'
+curl -X DELETE localhost:8080/v1/config/pack-status/ops
+curl -X DELETE localhost:8080/v1/config/pack-compliance/ops
+```
+
+Every seed is applied at **read** time rather than written into the resource, so
+clearing one restores the real state instead of leaving the seeded value behind.
+Seeds live in their own `config-ctrl` namespace so a seeded status is never mistaken
+for a real one in a state dump or during replay.
+
+A seed that would be **silently ignored is refused**, which is the rule the whole
+family follows: a `lastErrorCode` on a non-`Failure` status, a `statusReason` on a
+pack state that is not one of the two failures, `resources` alongside
+`INSUFFICIENT_DATA` (which the `EvaluationResult` shape does not support), a body
+naming a different rule than the path, the same rule name twice in one
+pack-compliance seed, and any value outside its enum are all a 400. In particular
+`NOT_APPLICABLE` is refused for both a rule's verdict and a pack's: it is in the
+rule-level `ComplianceType` enum but not in the `Compliance` shape's subset, and
+`ConformancePackComplianceType` has no such member at all. Storing one would make
+substrate report a value no SDK enum member matches, so a consumer's `switch` would
+fall through to its default while the test passed asserting nothing.
+
+### Conformance pack status advances on observation
+
+`PutConformancePack` returns `CREATE_IN_PROGRESS`, and the first
+`DescribeConformancePackStatus` resolves it to `CREATE_COMPLETE` and **persists**
+that, so every later observation reports the same state and the same timestamp. A
+waiter converges in one poll with no wall-clock dependence, and a status that
+re-resolved on each read would make a poll-comparing waiter loop forever. A seeded
+state does not advance — that is the point of seeding it.
+
+`ConformancePackStatusDetail` carries all six required members, including a
+synthesized `StackArn` of the form
+`arn:aws:cloudformation:{region}:{account}:stack/awsconfigconforms-{name}-{id}/{uuid}`,
+matching the `awsconfigconforms` stack-name convention Config uses for the
+CloudFormation stack it deploys a pack through.
+
+### CloudFormation
+
+`AWS::Config::ConfigurationRecorder`, `AWS::Config::ConfigRule` and
+`AWS::Config::DeliveryChannel` dispatch the real API operations. Earlier releases had
+all three reporting `CREATE_COMPLETE` while creating nothing.
+
+A template carrying both a recorder and a channel ends with `recording: true`, per
+"AWS CloudFormation starts the recorder as soon as the delivery channel is
+available", and it does so no matter which order the two are declared in — ordering
+is carried by the deployer's type priority rather than by `DependsOn`. A template
+carrying only a recorder leaves it stopped, which is what a consumer's stack actually
+depends on.
+
+`Ref` on the recorder and the channel returns the **name** (`default`, in the CFN
+page's own example); neither exposes any `Fn::GetAtt` attribute, because that section
+of each page is empty and exposing one would be an invention. `AWS::Config::ConfigRule`
+does expose `Arn`, `ConfigRuleId` and `Compliance.Type`, which its page documents.
+
+CloudFormation marks `RoleARN` *Required: Yes* while the API model says No, so that
+refusal lives at the CloudFormation layer. Note also that CloudFormation spells the
+recorder's and channel's nested members UpperCamel where the API spells them
+lowerCamel (`RecordingGroup.AllSupported` vs. `recordingGroup.allSupported`); the
+deployer translates them, because real Config is case-sensitive and would silently
+ignore the UpperCamel form.
+
+`AWS::Config::ConformancePack` remains unsupported in CloudFormation even though its
+API operations exist.
+
+### Provenance
+
+- **`ListTagsForResource`'s `Limit` is documented two ways.** The prose says "The
+  limit maximum is 50. You cannot specify a number greater than 50"; the Valid Range
+  says 0–100. Substrate takes **100**, the API model's bound, so it never refuses a
+  request the model permits.
+- **The ARN templates come from the Service Authorization Reference**, which the API
+  reference does not give: `config-rule/${ConfigRuleId}`,
+  `conformance-pack/${Name}/${Id}`, `delivery-channel/${Name}`. The recorder's is
+  two-segment — `configuration-recorder/{name}/{id}` — which corrected substrate's own
+  pre-existing CloudFormation stub, that had minted `recorder/{name}`.
+- **`roleARN` is required though the model does not say so**: "While the API model
+  does not require this field, the server will reject a request without a defined
+  `roleARN`." The exception is a **null-or-empty check**, not an assumability check,
+  so a role that was never created is accepted — as AWS accepts it. Verifying
+  assumability would refuse requests AWS accepts.
+- **Three documented members are absent from the vendored botocore model** —
+  `ConfigurationRecorder.connectorArn`, `ConfigurationRecorder.scopeConfiguration` and
+  `ConfigRule.RuleEvaluationVisibility`. Substrate models the vendored shape and does
+  not emit them.
+- **Recorder and delivery-channel maxima are not on the service-limits page.** The
+  "one per account per Region" note on each operation is what makes
+  `MaxNumberOf…ExceededException` reachable at a count of two.
+- **There is no delivery-channel resource type in the Service Authorization
+  Reference's list of Config resource types**, so `TagResource` accepts recorders,
+  rules and packs only.
+
+### Cost
+
+Config API calls are free. Substrate does not model Config's per-configuration-item
+or per-rule-evaluation charges, because it records no configuration items and
+evaluates no rules.
+
+---
+
 ## Account Management
 
 **Endpoint:** `account.{region}.amazonaws.com`

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.34
 	github.com/aws/aws-sdk-go-v2/service/account v1.35.6
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1
+	github.com/aws/aws-sdk-go-v2/service/configservice v1.68.6
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.58.1
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.53.5

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -18,6 +18,8 @@ github.com/aws/aws-sdk-go-v2/service/account v1.35.6 h1:mObt+amlHneRU0jyyCIRb6vy
 github.com/aws/aws-sdk-go-v2/service/account v1.35.6/go.mod h1:N2v9jPq9iN8zqp2/IzP44Y6hShrwn8Q7IJGiBHCc184=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1 h1:UDQGJ9AuLcf4yiDKyHPGN4EirOLo/E8+Zfoii8FhyZs=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1/go.mod h1:tCsJEKr4HMFIZSnXLx6rU2HlptPtLhWWfw2V2j9p7lE=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.68.6 h1:8xf8QK6jZ5K/qvmHYUyRYuPVwMPR0FfGXMbtfn5hQqA=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.68.6/go.mod h1:z2ZuTbi9wofbMt8Fy6y2De9+4xoghaKeV2XDyYoKIVs=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0 h1:XxzwotCCRk2Un1OWcJujk4vAC2OZkGh5l816W1w+Fd8=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.0/go.mod h1:Gi5mEHpABbT34fHwafgyxqrIte9oHUEHscusPBYEdHA=
 github.com/aws/aws-sdk-go-v2/service/iam v1.58.1 h1:zfcqlttrsc7l4bPHtnPlOGripqUsq7gH7hK7IOy4Mks=

--- a/test/e2e/journey_config_test.go
+++ b/test/e2e/journey_config_test.go
@@ -1,0 +1,337 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/configservice"
+	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_ConfigDetectiveControls is #580 at the SDK level: the detective-controls
+// baseline a consumer walks after its stacks deploy.
+//
+// This tier is the one that matters most for AWS Config, because Config's
+// X-Amz-Target prefix is StarlingDoveService — an internal code name bearing no
+// resemblance to the config endpoint prefix. Every aws-sdk-go-v2 and boto3 Config call
+// takes the target path, so the plugin could be registered, fully unit-tested, and
+// unreachable from every SDK. That is exactly what #561, #610 and #636 were: a unit
+// test driving a hand-built request never touches the alias.
+func TestJourney_ConfigDetectiveControls(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	// Retries off, so each assertion is about the first response rather than whatever
+	// the retry loop settled on.
+	cs := configservice.NewFromConfig(cfg, func(o *configservice.Options) { o.RetryMaxAttempts = 1 })
+	s3c := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.RetryMaxAttempts = 1
+		o.UsePathStyle = true
+	})
+
+	// --- reachability. If this answers InvalidAction, nothing below matters. ---
+	recorders, err := cs.DescribeConfigurationRecorders(ctx,
+		&configservice.DescribeConfigurationRecordersInput{})
+	if err != nil {
+		t.Fatalf("DescribeConfigurationRecorders on an empty account: %v — a routing failure surfaces here and nowhere else", err)
+	}
+	if len(recorders.ConfigurationRecorders) != 0 {
+		t.Fatalf("a fresh account reported %d recorders, want none", len(recorders.ConfigurationRecorders))
+	}
+
+	// --- the two ordering refusals, in the order the operations document them ---
+	// PutDeliveryChannel checks for a recorder before it looks at the bucket, so this
+	// refusal is reachable with no S3 fixture at all.
+	var noRecorder *configtypes.NoAvailableConfigurationRecorderException
+	_, err = cs.PutDeliveryChannel(ctx, &configservice.PutDeliveryChannelInput{
+		DeliveryChannel: &configtypes.DeliveryChannel{
+			Name:         aws.String("default"),
+			S3BucketName: aws.String("cfg-logs"),
+		},
+	})
+	if !errors.As(err, &noRecorder) {
+		t.Fatalf("PutDeliveryChannel with no recorder answered %v, want *NoAvailableConfigurationRecorderException", err)
+	}
+
+	// --- the recorder ---
+	if _, err := cs.PutConfigurationRecorder(ctx, &configservice.PutConfigurationRecorderInput{
+		ConfigurationRecorder: &configtypes.ConfigurationRecorder{
+			Name:    aws.String("default"),
+			RoleARN: aws.String("arn:aws:iam::123456789012:role/config"),
+			RecordingGroup: &configtypes.RecordingGroup{
+				AllSupported: true,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("PutConfigurationRecorder: %v", err)
+	}
+
+	// The headline of the release: a recorder that exists is not a recorder that
+	// records. DescribeConfigurationRecorders reports it either way, and the two states
+	// are told apart only by the status operation — which is the real misconfiguration
+	// an account carries silently.
+	recorders, err = cs.DescribeConfigurationRecorders(ctx,
+		&configservice.DescribeConfigurationRecordersInput{})
+	if err != nil {
+		t.Fatalf("DescribeConfigurationRecorders: %v", err)
+	}
+	if len(recorders.ConfigurationRecorders) != 1 {
+		t.Fatalf("got %d recorders, want 1", len(recorders.ConfigurationRecorders))
+	}
+	// The ARN is the Service Authorization Reference's two-segment form. A one-segment
+	// ARN matches no policy written against the real template, and Config now
+	// authorizes against its own ARN.
+	if arn := aws.ToString(recorders.ConfigurationRecorders[0].Arn); !strings.Contains(arn,
+		":configuration-recorder/default/") {
+		t.Errorf("the recorder ARN is %q, want configuration-recorder/<name>/<id>", arn)
+	}
+
+	status, err := cs.DescribeConfigurationRecorderStatus(ctx,
+		&configservice.DescribeConfigurationRecorderStatusInput{})
+	if err != nil {
+		t.Fatalf("DescribeConfigurationRecorderStatus: %v", err)
+	}
+	if len(status.ConfigurationRecordersStatus) != 1 {
+		t.Fatalf("got %d statuses, want 1", len(status.ConfigurationRecordersStatus))
+	}
+	if status.ConfigurationRecordersStatus[0].Recording {
+		t.Error("a recorder reports recording: true immediately after the Put — it must be false until Start, which is the whole point of #580 behavior #1")
+	}
+
+	// Start is refused without a delivery channel: "You must have created a delivery
+	// channel to successfully start the configuration recorder."
+	var noChannel *configtypes.NoAvailableDeliveryChannelException
+	_, err = cs.StartConfigurationRecorder(ctx, &configservice.StartConfigurationRecorderInput{
+		ConfigurationRecorderName: aws.String("default"),
+	})
+	if !errors.As(err, &noChannel) {
+		t.Fatalf("StartConfigurationRecorder with no channel answered %v, want *NoAvailableDeliveryChannelException", err)
+	}
+
+	// --- the delivery channel, and the S3 checks that read real bucket state ---
+	var noBucket *configtypes.NoSuchBucketException
+	_, err = cs.PutDeliveryChannel(ctx, &configservice.PutDeliveryChannelInput{
+		DeliveryChannel: &configtypes.DeliveryChannel{
+			Name:         aws.String("default"),
+			S3BucketName: aws.String("cfg-logs"),
+		},
+	})
+	if !errors.As(err, &noBucket) {
+		t.Fatalf("PutDeliveryChannel naming an absent bucket answered %v, want *NoSuchBucketException", err)
+	}
+
+	if _, err := s3c.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String("cfg-logs"),
+	}); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	// A bucket with no policy at all cannot admit Config, so the refusal is certain
+	// rather than a guess about a policy's contents.
+	var insufficient *configtypes.InsufficientDeliveryPolicyException
+	_, err = cs.PutDeliveryChannel(ctx, &configservice.PutDeliveryChannelInput{
+		DeliveryChannel: &configtypes.DeliveryChannel{
+			Name:         aws.String("default"),
+			S3BucketName: aws.String("cfg-logs"),
+		},
+	})
+	if !errors.As(err, &insufficient) {
+		t.Fatalf("PutDeliveryChannel on a policy-less bucket answered %v, want *InsufficientDeliveryPolicyException", err)
+	}
+
+	if _, err := s3c.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+		Bucket: aws.String("cfg-logs"),
+		Policy: aws.String(`{"Version":"2012-10-17","Statement":[{` +
+			`"Effect":"Allow","Principal":{"Service":"config.amazonaws.com"},` +
+			`"Action":"s3:PutObject","Resource":"arn:aws:s3:::cfg-logs/*"}]}`),
+	}); err != nil {
+		t.Fatalf("PutBucketPolicy: %v", err)
+	}
+
+	if _, err := cs.PutDeliveryChannel(ctx, &configservice.PutDeliveryChannelInput{
+		DeliveryChannel: &configtypes.DeliveryChannel{
+			Name:         aws.String("default"),
+			S3BucketName: aws.String("cfg-logs"),
+			S3KeyPrefix:  aws.String("config"),
+		},
+	}); err != nil {
+		t.Fatalf("PutDeliveryChannel with a Config-admitting policy: %v — the matcher is meant to be permissive, and a wrong refusal breaks working code", err)
+	}
+
+	// --- and now the recorder starts ---
+	if _, err := cs.StartConfigurationRecorder(ctx,
+		&configservice.StartConfigurationRecorderInput{
+			ConfigurationRecorderName: aws.String("default"),
+		}); err != nil {
+		t.Fatalf("StartConfigurationRecorder: %v", err)
+	}
+	status, err = cs.DescribeConfigurationRecorderStatus(ctx,
+		&configservice.DescribeConfigurationRecorderStatusInput{})
+	if err != nil {
+		t.Fatalf("DescribeConfigurationRecorderStatus after Start: %v", err)
+	}
+	if !status.ConfigurationRecordersStatus[0].Recording {
+		t.Error("the recorder is not recording after Start")
+	}
+
+	// --- rules, and compliance that is seeded rather than computed ---
+	if _, err := cs.PutConfigRule(ctx, &configservice.PutConfigRuleInput{
+		ConfigRule: &configtypes.ConfigRule{
+			ConfigRuleName: aws.String("s3-encrypted"),
+			Source: &configtypes.Source{
+				Owner:            configtypes.OwnerAws,
+				SourceIdentifier: aws.String("S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"),
+			},
+		},
+	}); err != nil {
+		t.Fatalf("PutConfigRule: %v", err)
+	}
+
+	// An unevaluated rule is INSUFFICIENT_DATA, not a fabricated COMPLIANT. A default
+	// of COMPLIANT would make every consumer's compliance assertion pass for free,
+	// which is worse than no answer.
+	compliance, err := cs.DescribeComplianceByConfigRule(ctx,
+		&configservice.DescribeComplianceByConfigRuleInput{
+			ConfigRuleNames: []string{"s3-encrypted"},
+		})
+	if err != nil {
+		t.Fatalf("DescribeComplianceByConfigRule: %v", err)
+	}
+	if len(compliance.ComplianceByConfigRules) != 1 {
+		t.Fatalf("got %d compliance results, want 1", len(compliance.ComplianceByConfigRules))
+	}
+	if got := compliance.ComplianceByConfigRules[0].Compliance.ComplianceType; got !=
+		configtypes.ComplianceTypeInsufficientData {
+		t.Errorf("an unevaluated rule reports %q, want INSUFFICIENT_DATA", got)
+	}
+
+	// The seed is what makes a NON_COMPLIANT branch testable at all: evaluating a rule
+	// against resource state is workload-internal, so per CLAUDE.md's scope boundary
+	// compliance is a seeded observation.
+	seedConfigRuleCompliance(t, ts, "s3-encrypted", `{"complianceType":"NON_COMPLIANT"}`)
+
+	compliance, err = cs.DescribeComplianceByConfigRule(ctx,
+		&configservice.DescribeComplianceByConfigRuleInput{
+			ConfigRuleNames: []string{"s3-encrypted"},
+		})
+	if err != nil {
+		t.Fatalf("DescribeComplianceByConfigRule after the seed: %v", err)
+	}
+	if got := compliance.ComplianceByConfigRules[0].Compliance.ComplianceType; got !=
+		configtypes.ComplianceTypeNonCompliant {
+		t.Errorf("the seeded rule reports %q, want NON_COMPLIANT", got)
+	}
+
+	// --- the teardown ordering story, which is what a repeated test run performs ---
+	var lastChannel *configtypes.LastDeliveryChannelDeleteFailedException
+	_, err = cs.DeleteDeliveryChannel(ctx, &configservice.DeleteDeliveryChannelInput{
+		DeliveryChannelName: aws.String("default"),
+	})
+	if !errors.As(err, &lastChannel) {
+		t.Fatalf("DeleteDeliveryChannel while the recorder records answered %v, want *LastDeliveryChannelDeleteFailedException", err)
+	}
+
+	if _, err := cs.StopConfigurationRecorder(ctx,
+		&configservice.StopConfigurationRecorderInput{
+			ConfigurationRecorderName: aws.String("default"),
+		}); err != nil {
+		t.Fatalf("StopConfigurationRecorder: %v", err)
+	}
+	if _, err := cs.DeleteDeliveryChannel(ctx, &configservice.DeleteDeliveryChannelInput{
+		DeliveryChannelName: aws.String("default"),
+	}); err != nil {
+		t.Fatalf("DeleteDeliveryChannel after Stop: %v", err)
+	}
+	if _, err := cs.DeleteConfigurationRecorder(ctx,
+		&configservice.DeleteConfigurationRecorderInput{
+			ConfigurationRecorderName: aws.String("default"),
+		}); err != nil {
+		t.Fatalf("DeleteConfigurationRecorder: %v", err)
+	}
+
+	// And the rebuild: the account is back to a state a second run of the same fixture
+	// can start from, which is what the deletes are in scope for.
+	if _, err := cs.PutConfigurationRecorder(ctx, &configservice.PutConfigurationRecorderInput{
+		ConfigurationRecorder: &configtypes.ConfigurationRecorder{
+			Name:           aws.String("default"),
+			RoleARN:        aws.String("arn:aws:iam::123456789012:role/config"),
+			RecordingGroup: &configtypes.RecordingGroup{AllSupported: true},
+		},
+	}); err != nil {
+		t.Fatalf("re-creating the recorder after the teardown: %v — a fixture must be re-runnable", err)
+	}
+}
+
+// TestJourney_ConfigInvalidRole covers the refusal a consumer's own template most
+// often trips, through the SDK's error type.
+//
+// The API model does not mark roleARN required; the reference states plainly that
+// "the server will reject a request without a defined roleARN", and the exception is a
+// null-or-empty check rather than an assumability check. Verifying assumability would
+// refuse requests AWS accepts, which is the worse failure.
+func TestJourney_ConfigInvalidRole(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	cs := configservice.NewFromConfig(cfg, func(o *configservice.Options) { o.RetryMaxAttempts = 1 })
+
+	var invalidRole *configtypes.InvalidRoleException
+	_, err = cs.PutConfigurationRecorder(ctx, &configservice.PutConfigurationRecorderInput{
+		ConfigurationRecorder: &configtypes.ConfigurationRecorder{
+			Name:    aws.String("default"),
+			RoleARN: aws.String(""),
+		},
+	})
+	if !errors.As(err, &invalidRole) {
+		t.Fatalf("PutConfigurationRecorder with an empty roleARN answered %v, want *InvalidRoleException", err)
+	}
+
+	// A rule cannot be put without a recorder either, and the refusal names the
+	// operation that fixes it.
+	var noRecorder *configtypes.NoAvailableConfigurationRecorderException
+	_, err = cs.PutConfigRule(ctx, &configservice.PutConfigRuleInput{
+		ConfigRule: &configtypes.ConfigRule{
+			ConfigRuleName: aws.String("s3-encrypted"),
+			Source: &configtypes.Source{
+				Owner:            configtypes.OwnerAws,
+				SourceIdentifier: aws.String("S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"),
+			},
+		},
+	})
+	if !errors.As(err, &noRecorder) {
+		t.Fatalf("PutConfigRule with no recorder answered %v, want *NoAvailableConfigurationRecorderException", err)
+	}
+}
+
+// seedConfigRuleCompliance posts a rule-compliance seed to the control plane.
+func seedConfigRuleCompliance(t *testing.T, ts *emulator.TestServer, rule, body string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		ts.URL+"/v1/config/rule-compliance/"+rule, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build seed request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("seed %s: %v", body, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("seed %s: %d", body, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Closes #580

The last PR of the v0.101.0 milestone. PRs 1–6 built the plugin, its five seed families, the authz hook and the CloudFormation dispatches; this one documents the surface and proves it is reachable from a real client.

## Why the e2e tier is not optional here

Config's `X-Amz-Target` prefix is **`StarlingDoveService`** — an internal code name bearing no resemblance to the `config` endpoint prefix — and every aws-sdk-go-v2, boto3 and CLI Config call routes by that target. A plugin registered without the alias is fully unit-tested and **unreachable from every SDK**. That is what #561, #610 and #636 each turned out to be: a unit test driving a hand-built request never touches the alias, so no amount of unit coverage can see the gap.

`test/e2e/journey_config_test.go` walks the detective-controls baseline a consumer actually performs:

- reachability on an empty account — if this answered `InvalidAction`, nothing else would matter
- `PutDeliveryChannel` with no recorder → `NoAvailableConfigurationRecorderException`
- the recorder, then `DescribeConfigurationRecorders` (present) vs. `DescribeConfigurationRecorderStatus` (**`recording: false`**) — the release's headline
- the two-segment `configuration-recorder/<name>/<id>` ARN
- `StartConfigurationRecorder` with no channel → `NoAvailableDeliveryChannelException`
- all three S3 refusals in the order the operation documents them: `NoSuchBucketException`, `InsufficientDeliveryPolicyException`, then 200 once a Config-admitting policy exists
- `Start` → `recording: true`
- a rule reporting `INSUFFICIENT_DATA`, a compliance seed over HTTP, then `NON_COMPLIANT`
- `DeleteDeliveryChannel` while recording → `LastDeliveryChannelDeleteFailedException`, then `Stop` → deletes → **rebuild**, because a fixture must be re-runnable

A second test covers `InvalidRoleException` and the rule's missing-recorder refusal through the SDK's own error types.

## Docs

`docs/services.md` gains the `## Config` section on the Organizations template: the target-prefix warning, the 25-operation table, `curl` examples for all five seed families, and prose on the points a reader would otherwise have to infer from the code — compliance is **seeded, never computed** and why; what the delivery-policy matcher checks and why it is deliberately permissive (a wrong refusal breaks working code, which is the worse failure direction); one recorder and one channel per account per Region; that a seed which would be silently ignored is refused; and how the conformance-pack status advances on observation.

A `### Provenance` subsection records the six findings that came from somewhere other than the API reference — chiefly the `ListTagsForResource` `Limit` contradiction (prose says max 50, Valid Range says 0–100; substrate takes 100, the model's bound, so it never refuses a request the model permits) and the ARN templates, which only the Service Authorization Reference gives.

## Verification

Full gate green: `gofmt`/`build`/`vet`/`golangci-lint` (0 issues), `make test` (race), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `test/e2e`.

`check-doc-versions.sh` earned its keep, rejecting a pinned `v0.101.0` in the new prose.

Verified live against the real AWS CLI (`AWS_MAX_ATTEMPTS=1`) across every lane: the three S3 refusals in order; `recording` false then true; regional isolation (`eu-west-1` empty); `InvalidRoleException`; `INSUFFICIENT_DATA` → seed → `NON_COMPLIANT`; `PutEvaluations` outranking the seed via a `ResultToken` constructed from its documented format; `CREATE_IN_PROGRESS` → `CREATE_COMPLETE` staying put; the `aws:` tag refusal; the full teardown ordering story; and a CloudFormation stack whose recorder deploys for real, with its recording group translated to lowerCamel (`allSupported`/`includeGlobalResourceTypes` both `true`) and `recording: true` because a channel is present, `Ref` = the name, `GetAtt ConfigRuleId` = the minted ID.

One doc correction came out of that run: the synthesized pack `StackArn` is `awsconfigconforms-{name}-{id}/{uuid}`, not the `{name}/{id}` form the plan had written.