### PR TITLE
fix(organizations,iam): authorize every resource a request names (#660)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A confinement policy could not confine `MoveAccount`: only one of the three resources
+  it names reached the authorization decision** (#660). `organizations:MoveAccount` names an
+  account, a source parent and a destination parent, and the Service Authorization Reference
+  marks all three required. Substrate resolved a request to a single resource by walking a
+  fixed list of body members and taking the first non-empty one — a list that contains
+  `ParentId`, which a MoveAccount body does not carry, and neither `SourceParentId` nor
+  `DestinationParentId`, which it does. Every MoveAccount therefore authorized against the
+  account alone and the two parent ARNs never entered the decision.
+
+  Two things followed, both false allows. A delegated-admin policy naming the account and
+  the OU it may manage — but not the root — **allowed** a move out of the root and into it,
+  so the boundary read as a confinement and was not one. And an explicit `Deny` scoped to a
+  parent ARN, which is how an SCP-shaped guardrail is written at the identity level, never
+  matched: "this account may never leave the sandbox OU" was a statement that silently did
+  nothing.
+
+  The authorization decision now evaluates **every** resource a request names, and denies
+  unless all of them are allowed — which is how AWS documents a statement being evaluated
+  against "every resource that is required" for an action. The permission boundary is
+  applied to each of them too, since a boundary checked against a subset is not a boundary.
+  Each ARN is matched against the tags of the resource *it* names rather than one merged tag
+  map, so a condition on `aws:ResourceTag` written about the destination cannot be satisfied
+  by a tag on the account — the false allow substrate's existing `AttachPolicy` handling
+  already avoided, in a new place. The denial names the first resource the policies do not
+  allow, in a fixed order of account, source parent, destination parent, because that ARN is
+  the one the caller has to add and the message is the only place it surfaces.
+
+  The machinery is general — a request now resolves to a list of (ARN, tags) pairs — but
+  MoveAccount is its only caller. It is the only one of the 63 Organizations actions the
+  reference marks with more than one required resource type; `AttachPolicy` and
+  `DetachPolicy` mark only the policy required, so authorizing them against their target too
+  would turn AWS's own single-ARN example into a denial. Every other operation resolves to
+  exactly one pair and decides exactly as it did before.
+
 ## [v0.101.0] - 2026-08-15
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -4837,6 +4837,26 @@ condition. An invalid tag fails the whole create and leaves nothing behind, and
 request is malformed, so there is nothing to vend. Deleting an OU or a policy
 deletes its tags, so an entity that reused the ID cannot inherit them.
 
+### A request naming several resources is authorized against every one
+
+`MoveAccount` names three resources — the account, the source parent and the
+destination parent — and the Service Authorization Reference marks all three
+required. It is the only Organizations operation that does; every other one names
+a single resource, and `AttachPolicy`/`DetachPolicy` mark only the policy
+required, so those authorize against the policy alone.
+
+The caller's policies must therefore allow the action against all three ARNs. A
+policy that names the account and one OU but not the root cannot move that account
+out of the root or into it, which is what a delegated-admin confinement policy is
+written to guarantee. A permission boundary is applied to every one of the three
+as well, since a boundary checked against a subset is not a boundary.
+
+Each ARN is matched against the tags of the resource *it* names, so a condition on
+`aws:ResourceTag` written about the destination cannot be satisfied by a tag on
+the account. The denial names the first resource the policies do not allow —
+resolved in a fixed order of account, source parent, destination parent — which is
+the only place the missing ARN surfaces, and the ARN a caller has to add.
+
 ### Refusals
 
 | Condition | Answer |

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -36,7 +36,7 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	if authzNoPermissionsRequired[action] {
 		return nil
 	}
-	resource := a.buildResourceARN(reqCtx, req)
+	resources := a.buildResourceARNs(reqCtx, req)
 
 	goCtx := context.Background()
 	entity, exists, err := resolveIAMEntity(goCtx, a.state, reqCtx.Principal.ARN)
@@ -65,47 +65,69 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		return nil
 	}
 
-	condCtx := a.buildConditionContext(reqCtx, req)
-
-	result := Evaluate(docs, EvaluationRequest{
-		Principal: reqCtx.Principal.ARN,
-		Action:    action,
-		Resource:  resource,
-		Context:   condCtx,
-	})
-
 	// Both denial arms take their code from the same helper, so an identity-policy
 	// refusal and a boundary refusal cannot drift apart — and neither can drift from
 	// the trust-policy gate #593 added, which resolves the same way for STS.
 	deniedCode := accessDeniedCodeFor(req.Service, "")
 
-	if result.Decision != DecisionAllow {
-		return &AWSError{
-			Code: deniedCode,
-			Message: fmt.Sprintf("User: %s is not authorized to perform: %s on resource: %s",
-				reqCtx.Principal.ARN, action, resource),
-			HTTPStatus: http.StatusForbidden,
-		}
-	}
-
-	// If a permission boundary is set it must also allow the action.
+	// If a permission boundary is set it must also allow the action, against every
+	// resource the request names — loaded once, outside the loop, because it is a
+	// property of the principal rather than of a resource.
 	boundary, err := a.loadPermissionBoundary(entity)
 	if err != nil {
 		a.logger.Warn("authz: failed to load permission boundary", "principal", reqCtx.Principal.ARN, "err", err)
 	}
-	if boundary != nil {
-		boundaryResult := Evaluate([]PolicyDocument{*boundary}, EvaluationRequest{
+
+	// The request tags describe the request, not any one resource, so they are read
+	// once and merged under each resource's own tags below.
+	requestTags := make(map[string]string)
+	addRequestTags(requestTags, req)
+
+	// Every resource the request names must be allowed. A request naming several —
+	// organizations:MoveAccount is substrate's only one — is denied unless the
+	// caller's policies admit all of them, which is how AWS evaluates a statement
+	// against "every resource that is required" for the action (#660).
+	for _, res := range resources {
+		condCtx := make(map[string]string, len(requestTags)+len(res.Tags))
+		for k, v := range requestTags {
+			condCtx[k] = v
+		}
+		// The tags travel with the ARN they belong to: one merged map across several
+		// resources would let a tag on one satisfy a condition written about another,
+		// which is the false allow orgAuthzResourceID's comment exists to prevent.
+		for k, v := range res.Tags {
+			condCtx["aws:ResourceTag/"+k] = v
+		}
+
+		result := Evaluate(docs, EvaluationRequest{
 			Principal: reqCtx.Principal.ARN,
 			Action:    action,
-			Resource:  resource,
+			Resource:  res.ARN,
 			Context:   condCtx,
 		})
-		if boundaryResult.Decision != DecisionAllow {
+		if result.Decision != DecisionAllow {
 			return &AWSError{
 				Code: deniedCode,
-				Message: fmt.Sprintf("User: %s is not authorized to perform: %s (blocked by permission boundary)",
-					reqCtx.Principal.ARN, action),
+				Message: fmt.Sprintf("User: %s is not authorized to perform: %s on resource: %s",
+					reqCtx.Principal.ARN, action, res.ARN),
 				HTTPStatus: http.StatusForbidden,
+			}
+		}
+
+		if boundary != nil {
+			boundaryResult := Evaluate([]PolicyDocument{*boundary}, EvaluationRequest{
+				Principal: reqCtx.Principal.ARN,
+				Action:    action,
+				Resource:  res.ARN,
+				Context:   condCtx,
+			})
+			if boundaryResult.Decision != DecisionAllow {
+				return &AWSError{
+					Code: deniedCode,
+					Message: fmt.Sprintf("User: %s is not authorized to perform: %s (blocked by permission boundary)",
+						reqCtx.Principal.ARN, action),
+					HTTPStatus: http.StatusForbidden,
+				}
 			}
 		}
 	}
@@ -458,11 +480,55 @@ func serviceToAction(req *AWSRequest, service, operation string) string {
 	return action
 }
 
+// authzResource is one resource a request names, paired with its own tags.
+//
+// The pairing is the point: the tags belong to the resource the ARN names, so a
+// condition written about one resource cannot be satisfied by a tag on another.
+// Tags are the raw key-value pairs, not yet prefixed with aws:ResourceTag/.
+type authzResource struct {
+	// ARN is the resource ARN a policy statement's Resource element is matched
+	// against. It is never "" — resourceMatches treats the empty string as
+	// matching every statement, so an unresolvable resource is "*".
+	ARN string
+
+	// Tags are the tags on the resource ARN names, or nil when it carries none.
+	Tags map[string]string
+}
+
+// buildResourceARNs returns every resource the request names, each paired with
+// its own tags. All of them must be allowed for the request to be allowed.
+//
+// Almost every AWS operation names one resource, and for those this returns
+// exactly one pair — [buildResourceARN] plus the tags [AuthController.addResourceTags]
+// reads. `organizations:MoveAccount` is substrate's only exception: it names an
+// account, a source parent and a destination parent, all three marked required by
+// the Service Authorization Reference, and authorizing against one of them
+// over-permitted a policy scoped to the other two (#660).
+//
+// The list is never empty. An empty list would skip the decision loop entirely
+// and allow the request, which is the one direction a privilege boundary must
+// never fail in.
+func (a *AuthController) buildResourceARNs(reqCtx *RequestContext, req *AWSRequest) []authzResource {
+	if req.Service == organizationsNamespace {
+		if multi := orgAuthzMoveAccountResources(a.state, reqCtx, req); len(multi) > 0 {
+			return multi
+		}
+	}
+	return []authzResource{{
+		ARN:  a.buildResourceARN(reqCtx, req),
+		Tags: a.resourceTagsFor(reqCtx, req),
+	}}
+}
+
 // buildResourceARN constructs a best-effort IAM resource ARN for the request.
 //
 // It is a method rather than a free function because some services cannot name
 // their resources without reading them: an Organizations ARN embeds the
 // organization's own ID, which only the stored record knows.
+//
+// It answers for one resource. An operation that names several is resolved by
+// [AuthController.buildResourceARNs], which calls this for the single-resource
+// case every other operation falls into.
 func (a *AuthController) buildResourceARN(reqCtx *RequestContext, req *AWSRequest) string {
 	acct := reqCtx.AccountID
 	region := reqCtx.Region
@@ -612,18 +678,11 @@ func buildS3ARN(req *AWSRequest) string {
 	return "arn:aws:s3:::" + path
 }
 
-// buildConditionContext assembles the IAM condition context map for a request,
-// populating aws:ResourceTag/* and aws:RequestTag/* keys.
-func (a *AuthController) buildConditionContext(reqCtx *RequestContext, req *AWSRequest) map[string]string {
-	ctx := make(map[string]string)
-	a.addResourceTags(ctx, reqCtx, req)
-	addRequestTags(ctx, req)
-	return ctx
-}
-
-// addResourceTags loads existing resource tags from state and injects them as
-// aws:ResourceTag/{Key} entries into condCtx.
-func (a *AuthController) addResourceTags(condCtx map[string]string, reqCtx *RequestContext, req *AWSRequest) {
+// resourceTagsFor loads the tags on the resource a request names, keyed by the
+// bare tag key. [AuthController.CheckAccess] adds the aws:ResourceTag/ prefix,
+// once per resource in the list, so an operation naming several resources cannot
+// mix one resource's tags into another's condition context.
+func (a *AuthController) resourceTagsFor(reqCtx *RequestContext, req *AWSRequest) map[string]string {
 	goCtx := context.Background()
 	acct := reqCtx.AccountID
 	region := reqCtx.Region
@@ -633,50 +692,50 @@ func (a *AuthController) addResourceTags(condCtx map[string]string, reqCtx *Requ
 	case "s3":
 		bucket := bucketFromPath(req.Path)
 		if bucket == "" {
-			return
+			return nil
 		}
 		raw, err := a.state.Get(goCtx, s3Namespace, "bucket:"+bucket)
 		if err != nil || raw == nil {
-			return
+			return nil
 		}
 		var b S3Bucket
 		if err := json.Unmarshal(raw, &b); err != nil {
-			return
+			return nil
 		}
 		tags = b.Tags
 
 	case "lambda":
 		name := lambdaNameFromPath(req.Path)
 		if name == "" {
-			return
+			return nil
 		}
 		raw, err := a.state.Get(goCtx, lambdaNamespace, "function:"+name)
 		if err != nil || raw == nil {
-			return
+			return nil
 		}
 		var fn LambdaFunction
 		if err := json.Unmarshal(raw, &fn); err != nil {
-			return
+			return nil
 		}
 		tags = fn.Tags
 
 	case "sqs":
 		qurl := strings.TrimRight(req.Params["QueueUrl"], "/")
 		if qurl == "" {
-			return
+			return nil
 		}
 		parts := strings.Split(qurl, "/")
 		name := parts[len(parts)-1]
 		if name == "" {
-			return
+			return nil
 		}
 		raw, err := a.state.Get(goCtx, sqsNamespace, "queue:"+name)
 		if err != nil || raw == nil {
-			return
+			return nil
 		}
 		var q SQSQueue
 		if err := json.Unmarshal(raw, &q); err != nil {
-			return
+			return nil
 		}
 		tags = q.Tags
 
@@ -686,54 +745,54 @@ func (a *AuthController) addResourceTags(condCtx map[string]string, reqCtx *Requ
 		case "user":
 			raw, err := a.state.Get(goCtx, iamNamespace, "user:"+entityName)
 			if err != nil || raw == nil {
-				return
+				return nil
 			}
 			var u IAMUser
 			if err := json.Unmarshal(raw, &u); err != nil {
-				return
+				return nil
 			}
 			tags = iamTagsToMap(u.Tags)
 		case "role":
 			raw, err := a.state.Get(goCtx, iamNamespace, "role:"+entityName)
 			if err != nil || raw == nil {
-				return
+				return nil
 			}
 			var r IAMRole
 			if err := json.Unmarshal(raw, &r); err != nil {
-				return
+				return nil
 			}
 			tags = iamTagsToMap(r.Tags)
 		default:
-			return
+			return nil
 		}
 
 	case "ec2":
 		id := req.Params["InstanceId.1"]
 		if id == "" {
-			return
+			return nil
 		}
 		raw, err := a.state.Get(goCtx, ec2Namespace, "instance:"+acct+"/"+region+"/"+id)
 		if err != nil || raw == nil {
-			return
+			return nil
 		}
 		var inst EC2Instance
 		if err := json.Unmarshal(raw, &inst); err != nil {
-			return
+			return nil
 		}
 		tags = ec2TagsToMap(inst.Tags)
 
 	case "dynamodb":
 		tbl := req.Params["TableName"]
 		if tbl == "" {
-			return
+			return nil
 		}
 		raw, err := a.state.Get(goCtx, dynamodbNamespace, "table:"+acct+"/"+tbl)
 		if err != nil || raw == nil {
-			return
+			return nil
 		}
 		var t DynamoDBTable
 		if err := json.Unmarshal(raw, &t); err != nil {
-			return
+			return nil
 		}
 		tags = t.Tags
 
@@ -751,12 +810,10 @@ func (a *AuthController) addResourceTags(condCtx map[string]string, reqCtx *Requ
 		tags = cfgsvcAuthzResourceTags(a.state, reqCtx, req)
 
 	default:
-		return
+		return nil
 	}
 
-	for k, v := range tags {
-		condCtx["aws:ResourceTag/"+k] = v
-	}
+	return tags
 }
 
 // addRequestTags parses tags being set on the resource in this request and

--- a/emulator/organizations_tags.go
+++ b/emulator/organizations_tags.go
@@ -482,11 +482,11 @@ func orgTagsFromKeys(keys []string, byKey map[string]string) []OrgTag {
 
 // --- authorization support ---
 //
-// These three feed the organizations arms of buildResourceARN, addResourceTags
+// These feed the organizations arms of buildResourceARNs, resourceTagsFor
 // and addRequestTags in authz.go. They read through the raw StateManager rather
 // than through the plugin because authorization runs before dispatch, so no
 // plugin instance is in hand — and they run on every request, so each reads at
-// most the one resource the request names.
+// most the resources the request names.
 
 // orgAuthzResourceID returns the ID of the Organizations resource a request
 // names, or "" when it names none.
@@ -496,6 +496,12 @@ func orgTagsFromKeys(keys []string, byKey map[string]string) []OrgTag {
 // satisfy a condition written about the target — a false allow, which is the
 // failure a tag-gated boundary exists to prevent. The order below prefers the
 // member that names the operation's own subject.
+//
+// MoveAccount is the operation that outgrew this contract: it names three
+// resources AWS marks required, and no single-resource answer can authorize it.
+// It is resolved by orgAuthzMoveAccountResources instead, so do not add
+// SourceParentId or DestinationParentId to the list below — a function whose
+// contract is "one resource" cannot report three (#660).
 func orgAuthzResourceID(req *AWSRequest) string {
 	var body struct {
 		ResourceID           string `json:"ResourceId"`
@@ -534,7 +540,13 @@ func orgAuthzResourceID(req *AWSRequest) string {
 // "matches every statement", so an unreadable record would widen a
 // resource-scoped policy instead of narrowing it.
 func orgAuthzResourceARN(state StateManager, reqCtx *RequestContext, req *AWSRequest) string {
-	id := orgAuthzResourceID(req)
+	return orgAuthzResourceARNForID(state, reqCtx, orgAuthzResourceID(req))
+}
+
+// orgAuthzResourceARNForID resolves one Organizations resource ID to the ARN the
+// API reports for it, answering "*" for an empty or unknown ID. It is separate
+// from orgAuthzResourceARN because MoveAccount resolves three IDs from one body.
+func orgAuthzResourceARNForID(state StateManager, reqCtx *RequestContext, id string) string {
 	if id == "" {
 		return "*"
 	}
@@ -585,7 +597,12 @@ func orgAuthzResourceARN(state StateManager, reqCtx *RequestContext, req *AWSReq
 // orgAuthzResourceTags returns the tags on the Organizations resource a request
 // names, as an aws:ResourceTag-shaped map.
 func orgAuthzResourceTags(state StateManager, req *AWSRequest) map[string]string {
-	id := orgAuthzResourceID(req)
+	return orgAuthzResourceTagsForID(state, orgAuthzResourceID(req))
+}
+
+// orgAuthzResourceTagsForID returns the tags stored against one Organizations
+// resource ID, or nil when the ID is empty or carries none.
+func orgAuthzResourceTagsForID(state StateManager, id string) map[string]string {
 	if id == "" {
 		return nil
 	}
@@ -594,6 +611,51 @@ func orgAuthzResourceTags(state StateManager, req *AWSRequest) map[string]string
 		return nil
 	}
 	return orgTagsToMap(tags)
+}
+
+// orgAuthzMoveAccountResources returns the three resources a MoveAccount request
+// names — the account, the source parent and the destination parent — each paired
+// with its own tags. It returns nil for every other operation, which is what
+// sends them down buildResourceARNs' single-resource path.
+//
+// MoveAccount is the only Organizations action the Service Authorization
+// Reference marks with more than one required resource type: account*,
+// organizationalunit* and root*. Authorizing against the account alone let a
+// policy naming the account and one OU move that account to a parent it never
+// named — the delegated-admin confinement policy shape, and a false allow — while
+// a policy scoped only to the parents could not grant the move at all (#660).
+//
+// Order is fixed: account, source parent, destination parent. The first resource
+// a policy does not allow is the one the denial names, so a fixed order makes
+// that message deterministic and the decision replay-stable.
+//
+// A member the body omits is skipped rather than resolved to "*": "*" for an
+// absent ID would widen the policy the caller wrote instead of narrowing it. A
+// body naming none of the three returns nil, so the request is decided exactly as
+// it was before.
+func orgAuthzMoveAccountResources(state StateManager, reqCtx *RequestContext, req *AWSRequest) []authzResource {
+	if req.Operation != "MoveAccount" {
+		return nil
+	}
+	var body struct {
+		AccountID           string `json:"AccountId"`
+		SourceParentID      string `json:"SourceParentId"`
+		DestinationParentID string `json:"DestinationParentId"`
+	}
+	if err := json.Unmarshal(req.Body, &body); err != nil {
+		return nil
+	}
+	var out []authzResource
+	for _, id := range []string{body.AccountID, body.SourceParentID, body.DestinationParentID} {
+		if id == "" {
+			continue
+		}
+		out = append(out, authzResource{
+			ARN:  orgAuthzResourceARNForID(state, reqCtx, id),
+			Tags: orgAuthzResourceTagsForID(state, id),
+		})
+	}
+	return out
 }
 
 // orgAuthzRequestTags returns the tags a request asks to set, as an

--- a/emulator/organizations_tags_test.go
+++ b/emulator/organizations_tags_test.go
@@ -1029,6 +1029,54 @@ func (f *orgAuthzFixture) check(t *testing.T, user, operation string, body map[s
 	})
 }
 
+// setResourcePolicy rewrites the user's single attached policy so its Resource
+// element names exactly resources, which is how a test scopes a statement to a
+// list of ARNs rather than to "*".
+func (f *orgAuthzFixture) setResourcePolicy(t *testing.T, user, action string, resources ...string) {
+	t.Helper()
+	pol := emulator.IAMPolicy{
+		PolicyName:       "moveaccount",
+		PolicyID:         "ANPAMOVE",
+		ARN:              "arn:aws:iam::123456789012:policy/OrgTagGate-" + user,
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document: emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice{action},
+				Resource: emulator.StringOrSlice(resources),
+			}},
+		},
+	}
+	raw, err := json.Marshal(pol)
+	if err != nil {
+		t.Fatalf("marshal policy: %v", err)
+	}
+	if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store policy: %v", err)
+	}
+}
+
+// deniedResource returns the resource ARN a denial names, which is the resource
+// the caller has to add to its policy. The message is the only place the failing
+// resource surfaces, so a test asserting *which* of several resources was refused
+// has to read it.
+func deniedResource(t *testing.T, err error) string {
+	t.Helper()
+	var awsErr *emulator.AWSError
+	if !errors.As(err, &awsErr) {
+		t.Fatalf("expected an *AWSError, got %T: %v", err, err)
+	}
+	const marker = "on resource: "
+	idx := strings.Index(awsErr.Message, marker)
+	if idx < 0 {
+		t.Fatalf("denial names no resource: %q", awsErr.Message)
+	}
+	return awsErr.Message[idx+len(marker):]
+}
+
 // orgAuthzDenied reports whether err is the denial an Organizations caller sees.
 // Organizations speaks JSON-RPC, so the code carries the "Exception" suffix.
 func orgAuthzDenied(t *testing.T, err error) bool {
@@ -1394,5 +1442,418 @@ func TestOrganizations_Authz_NonOrganizationsRequestsAreUnaffected(t *testing.T)
 	}
 	if awsErr.Code != "AccessDenied" {
 		t.Errorf("expected AccessDenied for an S3 request, got %q", awsErr.Code)
+	}
+}
+
+// --- MoveAccount names three resources, and all three must authorize (#660) ---
+
+// orgMoveFixture is an authorization fixture plus the ARNs of the three resources
+// a MoveAccount request names, since a test scoping a policy to them has to paste
+// the same ARNs the decision builds.
+type orgMoveFixture struct {
+	*orgAuthzFixture
+	accountID  string
+	accountArn string
+	rootID     string
+	rootArn    string
+	ouID       string
+	ouArn      string
+}
+
+// newOrgMoveFixture builds an organization holding one OU, and reports every ARN
+// a MoveAccount between the root and that OU touches.
+func newOrgMoveFixture(t *testing.T, user string) *orgMoveFixture {
+	t.Helper()
+	f := newOrgAuthzFixture(t, user, emulator.PolicyDocument{})
+	ctx := t.Context()
+
+	root, err := f.plugin.LoadRootForTest(ctx, "123456789012")
+	if err != nil {
+		t.Fatalf("load root: %v", err)
+	}
+	account, err := f.plugin.LoadAccountForTest(ctx, "123456789012")
+	if err != nil || account == nil {
+		t.Fatalf("load management account: %v", err)
+	}
+	ouID := "ou-" + root.ID[2:] + "-move1111"
+	ouArn := "arn:aws:organizations::123456789012:ou/o-move/" + ouID
+	if err := f.plugin.SaveOUForTest(ctx, "123456789012", emulator.OrgOrganizationalUnit{
+		ID: ouID, Arn: ouArn, Name: "confined",
+	}); err != nil {
+		t.Fatalf("save OU: %v", err)
+	}
+	return &orgMoveFixture{
+		orgAuthzFixture: f,
+		accountID:       account.ID,
+		accountArn:      account.Arn,
+		rootID:          root.ID,
+		rootArn:         root.Arn,
+		ouID:            ouID,
+		ouArn:           ouArn,
+	}
+}
+
+// move runs one MoveAccount through the authorization decision.
+func (f *orgMoveFixture) move(t *testing.T, user, from, to string) error {
+	t.Helper()
+	return f.check(t, user, "MoveAccount", map[string]any{
+		"AccountId":           f.accountID,
+		"SourceParentId":      from,
+		"DestinationParentId": to,
+	})
+}
+
+// TestOrganizations_Authz_MoveAccountAuthorizesEveryParent is #660: MoveAccount
+// names an account, a source parent and a destination parent, and the Service
+// Authorization Reference marks all three required. Authorizing against the
+// account alone let a confinement policy naming the account and one OU move that
+// account into the root, which the policy never named — a false allow, and the one
+// direction a privilege boundary must never fail in.
+func TestOrganizations_Authz_MoveAccountAuthorizesEveryParent(t *testing.T) {
+	f := newOrgMoveFixture(t, "orgmover")
+	// The delegated-admin shape: the account and the confined OU, deliberately not
+	// the root.
+	f.setResourcePolicy(t, "orgmover", "organizations:MoveAccount", f.accountArn, f.ouArn)
+
+	if err := f.move(t, "orgmover", f.rootID, f.ouID); !orgAuthzDenied(t, err) {
+		t.Error("a policy that does not name the root cannot authorize a move out of it")
+	} else if got := deniedResource(t, err); got != f.rootArn {
+		t.Errorf("the denial names %q, want the root ARN %q — the caller has to be told which resource to add", got, f.rootArn)
+	}
+
+	// And the mirror direction: moving *into* the root is refused for the same
+	// reason, which is the failure #660 reported.
+	if err := f.move(t, "orgmover", f.ouID, f.rootID); !orgAuthzDenied(t, err) {
+		t.Error("a policy that does not name the root cannot authorize a move into it")
+	} else if got := deniedResource(t, err); got != f.rootArn {
+		t.Errorf("the denial names %q, want the root ARN %q", got, f.rootArn)
+	}
+
+	// Naming all three allows it, so the fix is not a blanket refusal.
+	f.setResourcePolicy(t, "orgmover", "organizations:MoveAccount",
+		f.accountArn, f.ouArn, f.rootArn)
+	if err := f.move(t, "orgmover", f.rootID, f.ouID); err != nil {
+		t.Errorf("a policy naming all three resources must allow the move: %v", err)
+	}
+}
+
+// TestOrganizations_Authz_MoveAccountParentScopedDenyBlocks is #660's second
+// false-allow direction, and the one that survives a fix written only for the
+// first: an explicit Deny scoped to a parent ARN never matched, because the parent
+// ARNs were not built, so "this account may never leave the sandbox OU" was a
+// statement that silently did nothing.
+//
+// Denying by ARN is how an SCP-shaped guardrail is written at the identity level,
+// and a Deny that quietly fails to apply is worse than one that was never written:
+// the policy reads as a boundary and is not one.
+func TestOrganizations_Authz_MoveAccountParentScopedDenyBlocks(t *testing.T) {
+	f := newOrgMoveFixture(t, "orgparentdeny")
+	// Allow the move broadly, then carve out the root by ARN.
+	pol := emulator.IAMPolicy{
+		PolicyName:       "sandbox",
+		PolicyID:         "ANPASANDBOX",
+		ARN:              "arn:aws:iam::123456789012:policy/OrgTagGate-orgparentdeny",
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document: emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{
+				{
+					Effect:   "Allow",
+					Action:   emulator.StringOrSlice{"organizations:MoveAccount"},
+					Resource: emulator.StringOrSlice{"*"},
+				},
+				{
+					Effect:   "Deny",
+					Action:   emulator.StringOrSlice{"organizations:MoveAccount"},
+					Resource: emulator.StringOrSlice{f.rootArn},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(pol)
+	if err != nil {
+		t.Fatalf("marshal policy: %v", err)
+	}
+	if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store policy: %v", err)
+	}
+
+	// The root is the source: the Deny names it, so the move is blocked.
+	if err := f.move(t, "orgparentdeny", f.rootID, f.ouID); !orgAuthzDenied(t, err) {
+		t.Error("a Deny naming the source parent must block the move — before #660 the source ARN never entered the decision")
+	} else if got := deniedResource(t, err); got != f.rootArn {
+		t.Errorf("the denial names %q, want the root ARN %q", got, f.rootArn)
+	}
+
+	// The root is the destination: same Deny, same refusal, which is what pins the
+	// destination parent as its own resource rather than a duplicate of the source.
+	if err := f.move(t, "orgparentdeny", f.ouID, f.rootID); !orgAuthzDenied(t, err) {
+		t.Error("a Deny naming the destination parent must block the move")
+	} else if got := deniedResource(t, err); got != f.rootArn {
+		t.Errorf("the denial names %q, want the root ARN %q", got, f.rootArn)
+	}
+
+	// And a move the Deny does not name is still allowed, so the guardrail narrows
+	// rather than blocking everything.
+	otherOU := "ou-" + f.rootID[2:] + "-move2222"
+	otherArn := "arn:aws:organizations::123456789012:ou/o-move/" + otherOU
+	if err := f.plugin.SaveOUForTest(t.Context(), "123456789012", emulator.OrgOrganizationalUnit{
+		ID: otherOU, Arn: otherArn, Name: "other",
+	}); err != nil {
+		t.Fatalf("save second OU: %v", err)
+	}
+	if err := f.move(t, "orgparentdeny", f.ouID, otherOU); err != nil {
+		t.Errorf("a move between two OUs the Deny does not name must be allowed: %v", err)
+	}
+}
+
+// TestOrganizations_Authz_MoveAccountTagsPairWithTheirOwnResource is the
+// regression the fix itself could introduce. Each of the three ARNs is matched
+// against the tags of the resource *it* names; one merged tag map across all three
+// would let a tag on the OU satisfy a condition written about the account, which
+// is the false allow orgAuthzResourceID's comment exists to prevent.
+func TestOrganizations_Authz_MoveAccountTagsPairWithTheirOwnResource(t *testing.T) {
+	doc := newABACPolicy("Allow", "organizations:MoveAccount", "*",
+		"aws:ResourceTag/Owner", "platform")
+	f := newOrgMoveFixture(t, "orgmovetags")
+	// Rewrite the policy to the tag-gated one; newOrgMoveFixture starts from an
+	// empty document so the condition has to be installed here.
+	pol := emulator.IAMPolicy{
+		PolicyName:       "movetags",
+		PolicyID:         "ANPAMOVETAG",
+		ARN:              "arn:aws:iam::123456789012:policy/OrgTagGate-orgmovetags",
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document:         doc,
+	}
+	raw, err := json.Marshal(pol)
+	if err != nil {
+		t.Fatalf("marshal policy: %v", err)
+	}
+	if err := f.state.Put(context.Background(), "iam", "policy:"+pol.ARN, raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store policy: %v", err)
+	}
+
+	ctx := t.Context()
+	tag := func(id, owner string) {
+		if err := f.plugin.SaveTagsForTest(ctx, id,
+			[]emulator.OrgTag{{Key: "Owner", Value: owner}}); err != nil {
+			t.Fatalf("tag %s: %v", id, err)
+		}
+	}
+
+	// Every resource carries the tag the condition wants: allowed.
+	tag(f.accountID, "platform")
+	tag(f.rootID, "platform")
+	tag(f.ouID, "platform")
+	if err := f.move(t, "orgmovetags", f.rootID, f.ouID); err != nil {
+		t.Fatalf("all three resources tagged Owner=platform must be allowed: %v", err)
+	}
+
+	// Now each resource in turn carries the wrong owner. Every case must deny: a
+	// merged tag map would let the two remaining "platform" tags satisfy the
+	// condition for the resource that does not carry it.
+	for _, c := range []struct{ name, id string }{
+		{"account", f.accountID},
+		{"source parent", f.rootID},
+		{"destination parent", f.ouID},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			tag(c.id, "security")
+			defer tag(c.id, "platform")
+			if err := f.move(t, "orgmovetags", f.rootID, f.ouID); !orgAuthzDenied(t, err) {
+				t.Errorf("a tag on another resource must not satisfy a condition about the %s", c.name)
+			}
+		})
+	}
+}
+
+// TestOrganizations_Authz_MoveAccountWithNoParentsFallsBack asserts a body naming
+// no parent decides exactly as it did before. An absent member resolved to "*"
+// would widen the policy the caller wrote — the opposite of what the multi-resource
+// path is for.
+func TestOrganizations_Authz_MoveAccountWithNoParentsFallsBack(t *testing.T) {
+	f := newOrgMoveFixture(t, "orgnoparent")
+	f.setResourcePolicy(t, "orgnoparent", "organizations:MoveAccount", f.accountArn)
+
+	// Only the account: one resource, and the policy naming it allows the request.
+	if err := f.check(t, "orgnoparent", "MoveAccount", map[string]any{
+		"AccountId": f.accountID,
+	}); err != nil {
+		t.Errorf("a body naming only the account is one resource, and the policy names it: %v", err)
+	}
+
+	// A body naming nothing at all resolves to "*", which the account-scoped policy
+	// does not match — the same answer it gave before, and not a silent grant.
+	if err := f.check(t, "orgnoparent", "MoveAccount", map[string]any{}); !orgAuthzDenied(t, err) {
+		t.Error("a body naming no resource must not be granted by an account-scoped policy")
+	}
+
+	// And an undecodable body: no resource is named, so nothing widens.
+	reqCtx := newAuthTestReqCtx("arn:aws:iam::123456789012:user/orgnoparent")
+	if err := f.auth.CheckAccess(reqCtx, &emulator.AWSRequest{
+		Service: "organizations", Operation: "MoveAccount", Path: "/",
+		Body: []byte(`{"AccountId":`),
+	}); !orgAuthzDenied(t, err) {
+		t.Error("an unparseable MoveAccount body must not be granted by a resource-scoped policy")
+	}
+}
+
+// TestOrganizations_Authz_SingleResourceOperationsAreUnchanged asserts the
+// multi-resource path is scoped to MoveAccount. Every other operation still
+// authorizes against the one resource orgAuthzResourceID names — AttachPolicy
+// above all, where the Service Authorization Reference marks only the policy
+// required, so authorizing against the target too would turn AWS's own single-ARN
+// example into a denial.
+func TestOrganizations_Authz_SingleResourceOperationsAreUnchanged(t *testing.T) {
+	f := newOrgMoveFixture(t, "orgsingle")
+	ctx := t.Context()
+
+	policyID := "p-single01"
+	policyArn := "arn:aws:organizations::123456789012:policy/o-move/service_control_policy/" + policyID
+	if err := f.plugin.SavePolicyForTest(ctx, "123456789012", emulator.OrgPolicy{
+		PolicySummary: emulator.OrgPolicySummary{
+			ID: policyID, Arn: policyArn, Name: "deny", Type: emulator.OrgPolicyTypeSCPForTest,
+		},
+		Content: `{"Version":"2012-10-17"}`,
+	}); err != nil {
+		t.Fatalf("save policy: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		operation string
+		body      map[string]any
+		// resource is the one ARN the decision must be made against; a statement
+		// naming it alone has to allow the request.
+		resource string
+	}{
+		{"TagResource", "TagResource",
+			map[string]any{"ResourceId": f.ouID}, f.ouArn},
+		{"AttachPolicy names the policy, not the target", "AttachPolicy",
+			map[string]any{"PolicyId": policyID, "TargetId": f.ouID}, policyArn},
+		{"DetachPolicy names the policy, not the target", "DetachPolicy",
+			map[string]any{"PolicyId": policyID, "TargetId": f.ouID}, policyArn},
+		{"CreateOrganizationalUnit names the parent", "CreateOrganizationalUnit",
+			map[string]any{"ParentId": f.rootID, "Name": "new"}, f.rootArn},
+		{"DescribeAccount names the account", "DescribeAccount",
+			map[string]any{"AccountId": f.accountID}, f.accountArn},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f.setResourcePolicy(t, "orgsingle", "organizations:"+c.operation, c.resource)
+			if err := f.check(t, "orgsingle", c.operation, c.body); err != nil {
+				t.Errorf("a statement naming %s must allow %s: %v", c.resource, c.operation, err)
+			}
+			// And nothing else: a statement naming a different resource must not.
+			f.setResourcePolicy(t, "orgsingle", "organizations:"+c.operation, f.rootArn+"/nonexistent")
+			if err := f.check(t, "orgsingle", c.operation, c.body); !orgAuthzDenied(t, err) {
+				t.Errorf("%s must be denied by a statement naming another resource", c.operation)
+			}
+		})
+	}
+}
+
+// TestOrganizations_Authz_MoveAccountBoundaryCoversEveryResource pins that a
+// permission boundary is applied to every resource a MoveAccount names, not only
+// to the first.
+//
+// A boundary is the outer limit of what a principal may ever do, so checking it
+// against one of three resources is the same false allow as checking the identity
+// policy against one: a boundary confining a delegated admin to a sandbox OU would
+// let it move an account into the root, which is exactly what the boundary was set
+// to prevent. Mutation testing found this uncovered — the identity-policy tests
+// above pass with the boundary check hoisted out of the loop.
+func TestOrganizations_Authz_MoveAccountBoundaryCoversEveryResource(t *testing.T) {
+	f := newOrgMoveFixture(t, "orgbounded")
+
+	// The identity policy allows the move against every resource, so only the
+	// boundary can refuse it.
+	f.setResourcePolicy(t, "orgbounded", "organizations:MoveAccount", "*")
+
+	// The boundary names the account and the OU — not the root.
+	boundaryARN := "arn:aws:iam::123456789012:policy/MoveAccountBoundary"
+	boundary := emulator.IAMPolicy{
+		PolicyName:       "MoveAccountBoundary",
+		PolicyID:         "ANPABOUNDMOVE",
+		ARN:              boundaryARN,
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document: emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice{"organizations:MoveAccount"},
+				Resource: emulator.StringOrSlice{f.accountArn, f.ouArn},
+			}},
+		},
+	}
+	boundaryRaw, err := json.Marshal(boundary)
+	if err != nil {
+		t.Fatalf("marshal boundary: %v", err)
+	}
+	ctx := context.Background()
+	if err := f.state.Put(ctx, "iam", "policy:"+boundaryARN, boundaryRaw); err != nil { //nolint:contextcheck
+		t.Fatalf("store boundary: %v", err)
+	}
+	// Attach it to the user, which is what makes CheckAccess load it.
+	user := emulator.IAMUser{
+		UserName: "orgbounded",
+		UserID:   "AIDATEST",
+		ARN:      "arn:aws:iam::123456789012:user/orgbounded",
+		Path:     "/",
+		PermissionsBoundary: &emulator.IAMAttachedPolicy{
+			PolicyARN: boundaryARN, PolicyName: "MoveAccountBoundary",
+		},
+	}
+	userRaw, err := json.Marshal(user)
+	if err != nil {
+		t.Fatalf("marshal user: %v", err)
+	}
+	if err := f.state.Put(ctx, "iam", "user:orgbounded", userRaw); err != nil { //nolint:contextcheck
+		t.Fatalf("store user: %v", err)
+	}
+
+	// The account is the first resource and the boundary allows it, so a boundary
+	// checked only against the first resource would let this through.
+	err = f.move(t, "orgbounded", f.rootID, f.ouID)
+	if !orgAuthzDenied(t, err) {
+		t.Fatal("the boundary does not name the root, so a move out of it must be blocked")
+	}
+	var awsErr *emulator.AWSError
+	if !errors.As(err, &awsErr) {
+		t.Fatalf("expected an *AWSError, got %T: %v", err, err)
+	}
+	if !strings.Contains(awsErr.Message, "permission boundary") {
+		t.Errorf("the denial does not name the boundary as the cause: %q", awsErr.Message)
+	}
+
+	// And a move the boundary does name is allowed, so it narrows rather than
+	// blocking every MoveAccount.
+	otherOU := "ou-" + f.rootID[2:] + "-move3333"
+	otherArn := "arn:aws:organizations::123456789012:ou/o-move/" + otherOU
+	if err := f.plugin.SaveOUForTest(t.Context(), "123456789012", emulator.OrgOrganizationalUnit{
+		ID: otherOU, Arn: otherArn, Name: "other",
+	}); err != nil {
+		t.Fatalf("save second OU: %v", err)
+	}
+	// Widen the boundary by that OU only, then move OU -> otherOU: every resource
+	// the request names is now inside the boundary.
+	boundary.Document.Statement[0].Resource = emulator.StringOrSlice{
+		f.accountArn, f.ouArn, otherArn,
+	}
+	boundaryRaw, err = json.Marshal(boundary)
+	if err != nil {
+		t.Fatalf("re-marshal boundary: %v", err)
+	}
+	if err := f.state.Put(ctx, "iam", "policy:"+boundaryARN, boundaryRaw); err != nil { //nolint:contextcheck
+		t.Fatalf("re-store boundary: %v", err)
+	}
+	if err := f.move(t, "orgbounded", f.ouID, otherOU); err != nil {
+		t.Errorf("a move whose every resource the boundary names must be allowed: %v", err)
 	}
 }

--- a/test/e2e/journey_organizations_moveaccount_authz_test.go
+++ b/test/e2e/journey_organizations_moveaccount_authz_test.go
@@ -1,0 +1,202 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_OrganizationsMoveAccountConfinement is #660 at the tier a consumer's
+// own confinement fixture occupies: a delegated administrator holding a policy that
+// names the account it may move and the OU it may move that account into, and
+// nothing else.
+//
+// MoveAccount names three resources — the account, the source parent and the
+// destination parent — and the Service Authorization Reference marks all three
+// required. Substrate authorized against the account alone, so a policy that never
+// named the root allowed a move into the root: the boundary read as a confinement
+// and was not one.
+//
+// Only this tier shows what the caller sees. The refusal has to arrive as the
+// typed *AccessDeniedException a consumer's error handling branches on, and its
+// message has to name the resource the policy is missing — otherwise the fix is
+// correct and undiagnosable.
+func TestJourney_OrganizationsMoveAccountConfinement(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	adminCfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	admin := organizations.NewFromConfig(adminCfg,
+		func(o *organizations.Options) { o.RetryMaxAttempts = 1 })
+	iamClient := iam.NewFromConfig(adminCfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	// --- the hierarchy, built by the unenforced built-in caller ---
+	roots, err := admin.ListRoots(ctx, &organizations.ListRootsInput{})
+	if err != nil {
+		t.Fatalf("ListRoots: %v", err)
+	}
+	if len(roots.Roots) != 1 {
+		t.Fatalf("ListRoots returned %d roots, want 1", len(roots.Roots))
+	}
+	rootID := aws.ToString(roots.Roots[0].Id)
+	rootARN := aws.ToString(roots.Roots[0].Arn)
+
+	ou, err := admin.CreateOrganizationalUnit(ctx, &organizations.CreateOrganizationalUnitInput{
+		ParentId: aws.String(rootID),
+		Name:     aws.String("confined"),
+	})
+	if err != nil {
+		t.Fatalf("CreateOrganizationalUnit: %v", err)
+	}
+	ouID := aws.ToString(ou.OrganizationalUnit.Id)
+	ouARN := aws.ToString(ou.OrganizationalUnit.Arn)
+
+	created, err := admin.CreateAccount(ctx, &organizations.CreateAccountInput{
+		AccountName: aws.String("workload"),
+		Email:       aws.String("workload@example.com"),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccount: %v", err)
+	}
+	status, err := admin.DescribeCreateAccountStatus(ctx,
+		&organizations.DescribeCreateAccountStatusInput{
+			CreateAccountRequestId: created.CreateAccountStatus.Id,
+		})
+	if err != nil {
+		t.Fatalf("DescribeCreateAccountStatus: %v", err)
+	}
+	accountID := aws.ToString(status.CreateAccountStatus.AccountId)
+	if accountID == "" {
+		t.Fatal("a SUCCEEDED create-account status carried no AccountId")
+	}
+	account, err := admin.DescribeAccount(ctx, &organizations.DescribeAccountInput{
+		AccountId: aws.String(accountID),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAccount: %v", err)
+	}
+	accountARN := aws.ToString(account.Account.Arn)
+
+	// --- the confined mover ---
+	//
+	// A real IAM user, because the built-in AKIA key resolves to no principal and an
+	// unenforced caller would make every assertion below pass regardless of policy.
+	// The policy names the account and the destination OU — the ARNs a consumer
+	// pastes out of the Describe responses above — and deliberately not the root.
+	user, err := iamClient.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("mover")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if _, err := iamClient.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:   user.User.UserName,
+		PolicyName: aws.String("confine"),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[{` +
+			`"Effect":"Allow","Action":"organizations:MoveAccount","Resource":[` +
+			`"` + accountARN + `","` + ouARN + `"]}]}`),
+	}); err != nil {
+		t.Fatalf("PutUserPolicy: %v", err)
+	}
+	key, err := iamClient.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{
+		UserName: user.User.UserName,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+	moverCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+		config.WithBaseEndpoint(ts.URL),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			aws.ToString(key.AccessKey.AccessKeyId),
+			aws.ToString(key.AccessKey.SecretAccessKey), "")),
+		config.WithHTTPClient(&http.Client{}),
+	)
+	if err != nil {
+		t.Fatalf("mover config: %v", err)
+	}
+	mover := organizations.NewFromConfig(moverCfg,
+		func(o *organizations.Options) { o.RetryMaxAttempts = 1 })
+
+	// --- the move out of the root, which the policy does not name ---
+	//
+	// This is the request that was allowed. The source parent is the root, so the
+	// policy has to name it and does not.
+	var denied *orgtypes.AccessDeniedException
+	_, err = mover.MoveAccount(ctx, &organizations.MoveAccountInput{
+		AccountId:           aws.String(accountID),
+		SourceParentId:      aws.String(rootID),
+		DestinationParentId: aws.String(ouID),
+	})
+	if !errors.As(err, &denied) {
+		t.Fatalf("moving out of a root the policy does not name: got %T (%v), want *AccessDeniedException", err, err)
+	}
+	// The message is the only place the missing resource surfaces, and it is what
+	// tells the caller which ARN to add.
+	if msg := err.Error(); !strings.Contains(msg, rootARN) {
+		t.Errorf("the denial does not name the root ARN %s: %v", rootARN, msg)
+	}
+	// And the move really did not happen: a refusal that had already written state
+	// would be worse than the false allow it replaced.
+	if parents := journeyOrgParents(t, ctx, admin, accountID); len(parents) != 1 || parents[0] != rootID {
+		t.Fatalf("after the refusal the account's parents = %v, want just the root %s", parents, rootID)
+	}
+
+	// --- widening the policy by exactly the resource the denial named ---
+	if _, err := iamClient.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:   user.User.UserName,
+		PolicyName: aws.String("confine"),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[{` +
+			`"Effect":"Allow","Action":"organizations:MoveAccount","Resource":[` +
+			`"` + accountARN + `","` + ouARN + `","` + rootARN + `"]}]}`),
+	}); err != nil {
+		t.Fatalf("PutUserPolicy widening to the root: %v", err)
+	}
+	if _, err := mover.MoveAccount(ctx, &organizations.MoveAccountInput{
+		AccountId:           aws.String(accountID),
+		SourceParentId:      aws.String(rootID),
+		DestinationParentId: aws.String(ouID),
+	}); err != nil {
+		t.Fatalf("the move must be allowed once the policy names every resource it touches: %v", err)
+	}
+	if parents := journeyOrgParents(t, ctx, admin, accountID); len(parents) != 1 || parents[0] != ouID {
+		t.Fatalf("after the move, parents = %v, want just the OU %s", parents, ouID)
+	}
+
+	// --- and the confinement holds in the other direction ---
+	//
+	// Narrowing back to account + OU must stop the account from leaving the OU,
+	// which is what a delegated-admin boundary is written to guarantee.
+	if _, err := iamClient.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:   user.User.UserName,
+		PolicyName: aws.String("confine"),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[{` +
+			`"Effect":"Allow","Action":"organizations:MoveAccount","Resource":[` +
+			`"` + accountARN + `","` + ouARN + `"]}]}`),
+	}); err != nil {
+		t.Fatalf("PutUserPolicy narrowing back: %v", err)
+	}
+	_, err = mover.MoveAccount(ctx, &organizations.MoveAccountInput{
+		AccountId:           aws.String(accountID),
+		SourceParentId:      aws.String(ouID),
+		DestinationParentId: aws.String(rootID),
+	})
+	if !errors.As(err, &denied) {
+		t.Fatalf("moving into a root the policy does not name: got %T (%v), want *AccessDeniedException", err, err)
+	}
+	if parents := journeyOrgParents(t, ctx, admin, accountID); len(parents) != 1 || parents[0] != ouID {
+		t.Fatalf("the confined account left the OU: parents = %v, want just %s", parents, ouID)
+	}
+}


### PR DESCRIPTION
Closes #660

## The defect

`organizations:MoveAccount` names **three** resources in one request body —
`AccountId`, `SourceParentId`, `DestinationParentId` — and substrate authorized
against **one** of them. `orgAuthzResourceID` decodes a fixed member list
(`ResourceId`, `PolicyId`, `TargetId`, `AccountId`, `OrganizationalUnitId`,
`RootId`, `ParentId`) and returns the first non-empty. A MoveAccount body has no
`ParentId` — it has `SourceParentId`/`DestinationParentId`, which that struct does
not decode at all — so the function fell through to `AccountId` and the two parent
ARNs never entered the decision.

Two false-allow directions, both reproduced and both now pinned by tests that fail
before this change:

1. A delegated-admin confinement policy naming `[accountArn, ouArn]` and
   deliberately *not* the root allowed a move **out of** and **into** the root. The
   policy read as a confinement and was not one.
2. An explicit **`Deny`** scoped to a parent ARN never matched, so "this account may
   never leave the sandbox OU" silently did nothing.

A correction to the issue's framing, and to my own first pass: there is **no
false-deny mirror**. A policy naming only `[rootArn, ouArn]` is denied both before
and after, because the account is also a required resource. The new decision is
strictly stricter, never more permissive.

## The change

`CheckAccess` resolves `[]authzResource` — (ARN, tags) pairs — and requires **every**
one to allow, identity policies and permission boundary alike. Each ARN is matched
against **its own** tags: one merged tag map across three resources would let a tag
on the OU satisfy a condition written about the account, which is the exact false
allow `orgAuthzResourceID`'s doc comment already exists to prevent.

Every service except Organizations MoveAccount returns exactly one pair, so all
other decisions are byte-for-byte what they were. `addResourceTags` became
`resourceTagsFor`, returning bare-keyed tags so the `aws:ResourceTag/` prefix is
applied once per resource rather than into a shared map; `buildConditionContext`
had no remaining callers and is gone.

Ordering is fixed — account, source parent, destination parent — so the denial is
deterministic and replay-stable, and it names the resource that failed, which is
the whole diagnostic value: a caller reading `on resource: arn:…:root/o-…/r-82e5`
learns which ARN to add.

## Why this is narrow

All 63 Organizations action blocks in the SAR markdown source were parsed:
MoveAccount is the **only** action with more than one asterisked (required) resource
type — 28 have exactly one, 34 have none. `AttachPolicy`/`DetachPolicy` asterisk only
`policy`; their target types are optional, and they are deliberately **unchanged** —
widening them would turn AWS's own single-ARN OU example into a denial.

`ec2:RunInstances` has the same shape (five asterisked types, only the instance ARN
built). Out of scope here; filed as a follow-up so the general machinery has a named
next caller.

## Verification

`gofmt -l`, `go build`, `go vet`, `golangci-lint run` (0 issues), `make test` (race),
`make coverage` (emulator 82.7%), `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e`, `go test -C
test/e2e`.

Plus a **live** `aws` CLI run against `substrate server --address :4678`, which
reproduced the denial naming
`arn:aws:organizations::123456789012:root/o-4r8l3hgqx4/r-82e5`, the allow after
widening the policy by exactly that ARN, and the confinement holding in reverse.

**Mutation testing**: 7 mutants, **one genuine survivor** — the permission boundary
check hoisted outside the loop, so it saw only the first resource, was invisible to
every existing test. Closed by
`TestOrganizations_Authz_MoveAccountBoundaryCoversEveryResource`; final tally 7/7
caught. (An eighth attempt was discarded as BROKEN, not a result: it left
`unreachable code` that `go vet` rejected.)

## Provenance

The required-resource asterisks are recoverable only from the SAR **markdown**
source — the rendered page is JS-only and the machine-readable
`servicereference.us-east-1.amazonaws.com` JSON omits the required flag entirely.
The "the entire statement is evaluated against every resource that is required"
rule is documented for `ec2:RunInstances` and never for Organizations. AWS
publishes **no** MoveAccount policy example, and its nearest OU example
(`"organizations:*"` on a single OU ARN) would not authorize a three-resource
MoveAccount. Whether `SourceParentId` is authorized at all is settled by observed
real-AWS behaviour — #660's `iam simulate-custom-policy` run against a live
organization — not by any AWS document.