### PR TITLE
chore(release): v0.102.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.102.0] - 2026-08-16
+
 ### Fixed
 - **A confinement policy could not confine `MoveAccount`: only one of the three resources
   it names reached the authorization decision** (#660). `organizations:MoveAccount` names an
@@ -6957,7 +6959,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.101.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.102.0...HEAD
+[v0.102.0]: https://github.com/scttfrdmn/substrate/compare/v0.101.0...v0.102.0
 [v0.101.0]: https://github.com/scttfrdmn/substrate/compare/v0.100.0...v0.101.0
 [v0.100.0]: https://github.com/scttfrdmn/substrate/compare/v0.99.0...v0.100.0
 [v0.99.0]: https://github.com/scttfrdmn/substrate/compare/v0.98.0...v0.99.0


### PR DESCRIPTION
Dates the `## [v0.102.0]` CHANGELOG section and adds its comparison link, so the tag can be cut per CLAUDE.md.

v0.102.0 is #660 alone: `organizations:MoveAccount` names three required resources and only one reached the authorization decision, so a delegated-admin confinement policy did not confine and a parent-scoped `Deny` never matched. Shipped in #661.