### PR TITLE
fix(pricing,authz): classify pricing's error protocol, and assert over the registry (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **An authorization denial on `pricing` reported the XML `AccessDenied`, which the Price
+  List SDK cannot parse — and no test could see a plugin in that state** (#653). The generic
+  gate derives its denial code from the service's wire protocol (#595), reading
+  `serviceErrorProtocols`. It is called with no Content-Type, so a service absent from that
+  map cannot be rescued by the Content-Type sniff either and takes the final XML default.
+  `pricing` was absent. Its own plugin already reported `AccessDeniedException` for the
+  refusals it raises itself, so substrate emitted **two codes for one outcome on one
+  service** — the drift #595 exists to prevent, one level down.
+
+  `pricing` is now classified as JSON RPC, which its model states (`"protocol": "json"`,
+  jsonVersion 1.1, targetPrefix `AWSPriceListService`) and its own `AccessDeniedException`
+  shape corroborates. The shape is declared on `GetPriceListFileUrl` and `ListPriceLists`
+  but not on `GetProducts`, the operation the report names, so for `GetProducts` neither
+  spelling is modeled and the protocol rule alone decides it.
+
+  The second half is why this survived at all. The property test guarding the mapping
+  iterated `serviceErrorProtocols` itself, so a service missing from the map had no entry to
+  iterate and was invisible to it — `config` sat in the same blind spot until #580. The
+  assertion is now driven from the **plugin registry**: every plugin `RegisterDefaultPlugins`
+  registers must have an entry, and a new plugin that lands without one fails with a message
+  naming it and saying what to add.
+
 ## [v0.102.0] - 2026-08-16
 
 ### Fixed

--- a/emulator/access_denied_code_test.go
+++ b/emulator/access_denied_code_test.go
@@ -1,10 +1,13 @@
 package emulator_test
 
 import (
+	"context"
 	"encoding/xml"
 	"io"
+	"log/slog"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,6 +68,11 @@ func TestAccessDeniedCodeFor_TracksTheWireProtocol(t *testing.T) {
 		// match. Config was in exactly that state when its plugin landed (#580).
 		{"config is json rpc", "config", "", "AccessDeniedException"},
 		{"config is json rpc with a body", "config", "application/x-amz-json-1.1", "AccessDeniedException"},
+
+		// Pricing, which was in that same state until #653: its plugin reported
+		// AccessDeniedException for its own refusals while the generic gate, called
+		// with no Content-Type, refused the same caller with the bare XML code.
+		{"pricing is json rpc", "pricing", "", "AccessDeniedException"},
 		{"lambda is rest json", "lambda", "application/json", "AccessDeniedException"},
 		{"apigateway is rest json", "apigateway", "application/json", "AccessDeniedException"},
 
@@ -113,6 +121,63 @@ func TestAccessDenied_IAMPluginAgreesWithTheGenericGate(t *testing.T) {
 	assert.Equal(t, emulator.AccessDeniedCodeForTest("iam", ""),
 		emulator.IAMAccessDeniedCodeForTest,
 		"the IAM plugin's denial code must be the one its protocol implies")
+}
+
+// TestAccessDenied_PricingPluginAgreesWithTheGenericGate is the IAM assertion
+// above, for the service #653 reports. The Price List plugin builds its own
+// denials from pricingErrAccessDenied, so a service missing from
+// serviceErrorProtocols left substrate reporting two codes for one outcome on one
+// service — #595's complaint restated, and the exact shape the IAM test exists to
+// prevent.
+func TestAccessDenied_PricingPluginAgreesWithTheGenericGate(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, emulator.AccessDeniedCodeForTest("pricing", ""),
+		emulator.PricingAccessDeniedCodeForTest,
+		"the Price List plugin's denial code must be the one its protocol implies")
+}
+
+// TestAccessDenied_EveryRegisteredPluginHasAnErrorProtocol is the test that could
+// have seen #653 coming, and the reason neither #580 nor #653 was caught by the
+// coverage already here.
+//
+// TestAccessDeniedCode_MatchesTheServiceErrorProtocol asserts a property over
+// serviceErrorProtocols by iterating *that map*, so a service absent from it is
+// invisible to the test: there is no entry to iterate. Both config (#580) and
+// pricing (#653) sat in exactly that blind spot, taking errorProtocolFor's final
+// errProtoQueryXML default and refusing a JSON caller with a code its SDK cannot
+// match — AuthController.CheckAccess calls accessDeniedCodeFor(service, "") with
+// no Content-Type, so the Content-Type sniff cannot rescue them either.
+//
+// The fix is to drive the assertion from the *plugin registry* instead. A plugin
+// that lands without an entry now fails here, whatever its name.
+func TestAccessDenied_EveryRegisteredPluginHasAnErrorProtocol(t *testing.T) {
+	t.Parallel()
+
+	state := emulator.NewMemoryStateManager()
+	tc := emulator.NewTimeController(time.Now())
+	registry := emulator.NewPluginRegistry()
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	store := emulator.NewEventStore(
+		emulator.DefaultConfig().EventStore.ToEventStoreConfig(),
+		emulator.WithTimeController(tc))
+	require.NoError(t, emulator.RegisterDefaultPlugins(
+		context.Background(), registry, state, tc, logger, store, nil))
+
+	classified := make(map[string]bool)
+	for _, svc := range emulator.RegisteredErrorProtocolServicesForTest() {
+		classified[svc] = true
+	}
+
+	names := registry.Names()
+	require.NotEmpty(t, names, "the registry must hold plugins for this to assert anything")
+	for _, name := range names {
+		assert.True(t, classified[name],
+			"plugin %q has no serviceErrorProtocols entry, so its authorization "+
+				"denials fall back to the XML AccessDenied regardless of the "+
+				"protocol it actually speaks; add %q to serviceErrorProtocols in "+
+				"emulator/error_protocol.go, classified by the \"protocol\" field "+
+				"of its botocore service model", name, name)
+	}
 }
 
 // TestAccessDenied_BothGatesAgree is the test #595 asks for by name: an identity

--- a/emulator/error_protocol.go
+++ b/emulator/error_protocol.go
@@ -141,17 +141,25 @@ var serviceErrorProtocols = map[string]awsErrorProtocol{
 	"kms":              errProtoJSONRPC,
 	"logs":             errProtoJSONRPC,
 	"organizations":    errProtoJSONRPC,
-	"redshift-data":    errProtoJSONRPC,
-	"sagemaker":        errProtoJSONRPC,
-	"secretsmanager":   errProtoJSONRPC,
-	"servicequotas":    errProtoJSONRPC,
-	"sqs":              errProtoJSONRPC,
-	"ssm":              errProtoJSONRPC,
-	"states":           errProtoJSONRPC,
-	"tagging":          errProtoJSONRPC,
-	"timestream":       errProtoJSONRPC,
-	"transfer":         errProtoJSONRPC,
-	"wafv2":            errProtoJSONRPC,
+	// pricing is "protocol": "json" with jsonVersion 1.1 and the targetPrefix
+	// AWSPriceListService, and its model declares an AccessDeniedException shape
+	// carrying "exception": true — the suffixed spelling this arm produces. That
+	// shape is declared on GetPriceListFileUrl and ListPriceLists but *not* on
+	// GetProducts, the operation #653 reports, so for GetProducts neither code is
+	// modeled and the protocol rule alone decides it; the shape corroborates the
+	// spelling rather than supplying it.
+	"pricing":        errProtoJSONRPC,
+	"redshift-data":  errProtoJSONRPC,
+	"sagemaker":      errProtoJSONRPC,
+	"secretsmanager": errProtoJSONRPC,
+	"servicequotas":  errProtoJSONRPC,
+	"sqs":            errProtoJSONRPC,
+	"ssm":            errProtoJSONRPC,
+	"states":         errProtoJSONRPC,
+	"tagging":        errProtoJSONRPC,
+	"timestream":     errProtoJSONRPC,
+	"transfer":       errProtoJSONRPC,
+	"wafv2":          errProtoJSONRPC,
 
 	// REST-JSON.
 	"account":         errProtoRESTJSON,

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -308,6 +308,12 @@ func RegisteredErrorProtocolServicesForTest() []string {
 // instead of restating the literal.
 const IAMAccessDeniedCodeForTest = iamAccessDeniedCode
 
+// PricingAccessDeniedCodeForTest is the code the Price List plugin's own gate
+// reports, exposed for the same reason IAMAccessDeniedCodeForTest is: so a test
+// asserts the plugin and the generic gate agree rather than restating either
+// literal.
+const PricingAccessDeniedCodeForTest = pricingErrAccessDenied
+
 // MarshalAWSErrorForTest wraps marshalAWSError, selecting the protocol by one of
 // the ErrProto*ForTest names. status is the HTTP status the error carries, which
 // the S3 arm needs because it builds a whole response rather than a body alone.


### PR DESCRIPTION
Closes #653.

## The gap

`AuthController.CheckAccess` derives its denial code from the service's wire protocol (#595) by reading `serviceErrorProtocols`. It calls `accessDeniedCodeFor(req.Service, "")` with **no Content-Type**, so a service absent from that map cannot be rescued by `errorProtocolFor`'s Content-Type sniff either — it takes the final `errProtoQueryXML` default and is refused with the bare XML `AccessDenied`.

`pricing` was absent. Its plugin already reports `AccessDeniedException` for the refusals it raises itself (`pricing_plugin.go:46`), so substrate emitted **two codes for one outcome on one service** — the drift `TestAccessDenied_IAMPluginAgreesWithTheGenericGate` exists to prevent, one level down.

## Why no test saw it

`TestAccessDeniedCode_MatchesTheServiceErrorProtocol` asserts the protocol→code property over every registered service — by iterating **`serviceErrorProtocols` itself**. A service missing from the map has no entry to iterate, so it is invisible to the test that exists to cover it. `config` sat in exactly that blind spot until #580; `pricing` was next.

The new `TestAccessDenied_EveryRegisteredPluginHasAnErrorProtocol` drives the assertion from the **plugin registry**: it builds a real registry via `RegisterDefaultPlugins` and asserts every `registry.Names()` entry has a mapping. A plugin that lands without one now fails with a message naming it and saying what to add.

## Provenance

`pricing` is classified from its botocore model: `"protocol": "json"`, `jsonVersion 1.1`, `targetPrefix AWSPriceListService`. Its own `AccessDeniedException` shape (`"exception": true`, "General authentication failure.") corroborates the suffixed spelling — but note it is declared on `GetPriceListFileUrl` and `ListPriceLists` and **not** on `GetProducts`, the operation the issue reports. So for `GetProducts` neither spelling is modeled and the protocol rule from #595 alone decides it; the shape confirms rather than supplies it.

## Verification

Both new tests and the new table row were confirmed to fail with the map entry removed:

```
--- FAIL: TestAccessDenied_PricingPluginAgreesWithTheGenericGate
--- FAIL: TestAccessDeniedCodeFor_TracksTheWireProtocol/pricing_is_json_rpc
        expected: "AccessDeniedException"  actual: "AccessDenied"
--- FAIL: TestAccessDenied_EveryRegisteredPluginHasAnErrorProtocol
        plugin "pricing" has no serviceErrorProtocols entry, so its authorization
        denials fall back to the XML AccessDenied regardless of the protocol it
        actually speaks; add "pricing" to serviceErrorProtocols ...
```

`gofmt`, `go build`, `go vet`, `golangci-lint run` (0 issues), `make test` (race) all green.

## Compatibility

A `pricing` authorization denial changes code from `AccessDenied` to `AccessDeniedException`. A fixture matching the old string must be updated — it was never a code the Price List SDK could parse.
