### PR TITLE
fix(ec2): a launch materializes the volumes its block device mappings describe (#666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`RunInstances` accepted `BlockDeviceMapping.N.*` and discarded it, so a launch's storage
+  was unobservable** (#666). `runInstancesWithTags` read thirteen parameter groups and none of
+  them was a block device mapping: a request naming a 60 GiB `/dev/xvda` root volume
+  succeeded, and `DescribeVolumes` reported nothing for the instance. Substrate was silently
+  accepting a parameter it did not model — the shape #97 exists to remove.
+
+  The value was not merely hidden, it was unreachable. AWS's `EbsInstanceBlockDevice` — the
+  shape an instance renders per device — carries `volumeId`, `attachTime`,
+  `deleteOnTermination` and `status`, but **no size**, so `DescribeVolumes` is the only API
+  surface on which a launch-specified size can be observed at all. A launch now materializes
+  real volumes in the same store `CreateVolume` writes to, which is how real EC2 unifies
+  provisioned and launch-created volumes. `iops` and `throughput` reach the wire too; `iops`
+  was stored and never rendered, and `throughput` had nowhere to be stored.
+
+  `TerminateInstances` now settles those volumes, and that half is what made the parsing safe
+  to land: without it a volume would report `deleteOnTermination=true` while sitting `in-use`
+  on a terminated instance forever, a state real EC2 never reaches and a new inaccuracy in
+  place of the old silence. A volume whose attachment deletes on termination is removed; one
+  that does not becomes `available` with no attachment.
+
+  `DeleteOnTermination` defaults to **`true`** for every volume a launch creates, data volumes
+  included. That is counter-intuitive and is AWS's documented behaviour: its termination table
+  splits on how the volume was attached, not on what it is — a data volume attached at launch
+  through the console preserves, but through the API it is deleted, and an API emulator has no
+  console path. `AttachVolume` keeps the other default, `false`, since deleting a volume the
+  caller brought would destroy something the launch did not make.
+
+  A fleet reaches mappings through its **launch template**, which now carries them:
+  `CreateFleet` forwards the template reference rather than the caller's own parameters, so
+  the template path is the only one it has. `DescribeVolumes` also gained the filters the new
+  state makes worth asking about — `attachment.device`,
+  `attachment.delete-on-termination`, `volume-type`, `size`, `availability-zone` and
+  `snapshot-id` — alongside the three it had.
 - **An authorization denial on `pricing` reported the XML `AccessDenied`, which the Price
   List SDK cannot parse — and no test could see a plugin in that state** (#653). The generic
   gate derives its denial code from the service's wire protocol (#595), reading
@@ -29,6 +62,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assertion is now driven from the **plugin registry**: every plugin `RegisterDefaultPlugins`
   registers must have an entry, and a new plugin that lands without one fails with a message
   naming it and saying what to add.
+
+### Changed
+- **Every `RunInstances` now produces at least one EBS volume** (#666). A real instance always
+  has a root volume whether or not the request mentions one, and `DescribeImages` already
+  reported an 8 GiB `/dev/sda1` mapping for every AMI substrate serves, so a launch that
+  produced no volume left the two disagreeing about the same instance. A launch declaring no
+  mapping now gets a synthesized 8 GiB `gp2` volume at `/dev/sda1`; a mapping that names
+  `/dev/sda1` or `/dev/xvda` — the two spellings AWS's device-naming reference gives for the
+  HVM root — configures that root rather than adding a device beside it.
+
+  A test that listed **all** volumes and expected only what it created with `CreateVolume` now
+  sees a root volume per launched instance; filter by `volume-id` or
+  `attachment.instance-id` for the previous answer. A test that terminated an instance and
+  then read a volume attached at launch will find it gone unless it set
+  `DeleteOnTermination: false`. A volume attached *after* launch is untouched by termination.
 
 ## [v0.102.0] - 2026-08-16
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -2961,6 +2961,86 @@ Substrate's own choices, where the API model does not decide:
 - `InterfaceType` defaults to `interface`; `efa` and `efa-only` are recorded as
   given. `NetworkCardIndex` is recorded as given and defaults to 0.
 
+### Launch-time storage
+
+`RunInstances` and `CreateLaunchTemplate` parse every declared
+`BlockDeviceMapping.N.*`, contiguously from 1 and stopping at the first missing
+index, and a launch **materializes** the EBS volumes those mappings describe. They
+are real volumes in the same store `CreateVolume` writes to, so `DescribeVolumes`
+is the one place to observe an instance's storage, whether the volume was
+provisioned separately or created by the launch — which is how real EC2 unifies
+the two.
+
+`DescribeVolumes` is also the **only** place a launch-specified size is
+observable. AWS's `EbsInstanceBlockDevice` — the shape an instance renders per
+device — carries `volumeId`, `attachTime`, `deleteOnTermination` and `status`, but
+no size, so a caller that wants to know how large a launch made its root volume
+has nowhere else to ask.
+
+**Every launch produces at least one volume.** A real instance always has a root
+volume whether or not the request mentions one, and `DescribeImages` already
+reports an 8 GiB `/dev/sda1` mapping for every AMI substrate serves, so a launch
+that declares no mapping gets a synthesized 8 GiB `gp2` volume at `/dev/sda1`
+rather than none. A mapping that *does* name a root device configures that root
+volume instead of adding a device beside it, which is AWS's own rule for a mapping
+whose device name the AMI's mapping already uses.
+
+Root devices are recognized **by name**: `/dev/sda1` and `/dev/xvda`, the two
+spellings AWS's device-naming reference gives for the HVM root ("Differs by AMI").
+Substrate stores no per-AMI root device to compare against, so an AMI whose real
+root device is neither is out of reach here.
+
+`DeleteOnTermination` defaults to **`true`** for every volume a launch creates,
+data volumes included. That is counter-intuitive and is AWS's documented
+behaviour: its termination table splits on *how* the volume was attached, not on
+what it is — a data volume attached at launch through the console preserves, but
+through the API it is deleted, and an API emulator has no console path. A volume
+attached later with `AttachVolume` defaults to `false`, because deleting a volume
+the caller brought would destroy something the launch did not make. An explicit
+value wins over either default.
+
+`TerminateInstances` settles the volumes accordingly: one whose attachment deletes
+on termination is removed outright, and one that does not becomes `available` with
+no attachment, which is what a preserved volume looks like once its instance is
+gone.
+
+A fleet reaches mappings only through its **launch template** — `CreateFleet`
+forwards the template reference rather than the caller's own mappings — and the
+template merge is all-or-nothing, as it is for every other field: a request naming
+one mapping of its own does not inherit a second from the template.
+
+Modeled per mapping: `DeviceName`, `VirtualName`, `NoDevice`, and
+`Ebs.{SnapshotId, VolumeSize, VolumeType, Iops, Throughput, Encrypted,
+DeleteOnTermination}`. `NoDevice` suppresses the device outright, and a
+`VirtualName` with no `Ebs.*` members names an instance store device, which is not
+an EBS volume and has no presence in `DescribeVolumes` — either way the mapping is
+recorded intent that materializes nothing.
+
+`DescribeVolumes` renders `iops` and `throughput` on the volume and
+`deleteOnTermination` on each attachment, and filters on `volume-id`, `status`,
+`size`, `volume-type`, `availability-zone`, `snapshot-id`,
+`attachment.instance-id`, `attachment.device` and
+`attachment.delete-on-termination`.
+
+Substrate's own choices, where the API model does not decide:
+
+- `VolumeType` defaults to **`gp2`**. `EbsBlockDevice` documents no default at all;
+  `CreateVolume` documents `gp2`, and substrate uses it for both so there is one
+  default in one place rather than two that can drift. Real AMIs specify `gp3` in
+  their own mapping, which substrate's AMIs do not carry.
+- A volume takes the **instance's** Availability Zone, not the region's first: a
+  volume must be in the same zone as the instance it is attached to, so deriving it
+  any other way would produce an attachment real EC2 cannot have.
+- An unparseable number reads as zero rather than failing the launch, and the
+  mapping is still recorded.
+
+Not modeled: `Ebs.KmsKeyId` (left out rather than stored and hidden),
+`TagSpecification` scoped to `volume` (see the tag-specification note above),
+`InvalidBlockDeviceMapping` validation, and `blockDeviceMapping` on
+`DescribeInstances` or `DescribeInstanceAttribute` — the latter is still on the
+explicit-refusal list, since the shape it would render carries no size and so would
+not answer the question `DescribeVolumes` now does.
+
 ### Instance attributes
 
 `DescribeInstanceAttribute` reads one attribute off an instance. It is the only way
@@ -5361,7 +5441,7 @@ Account Management API calls are free.
 
 Service Quotas answers from a **built-in table of representative default quotas**,
 not from the plugins that enforce them. It covers eleven services rather than
-AWS's full catalog, which is why an unrecognised service code is an error rather
+AWS's full catalog, which is why an unrecognized service code is an error rather
 than an empty result — see below.
 
 ### Supported operations

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -1,0 +1,349 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Root device names. Substrate recognizes a mapping as configuring the root volume
+// by device name, because it has no per-AMI root device to compare against:
+// EC2Image records none, and DescribeImages fabricates /dev/sda1 for every AMI.
+//
+// Both spellings are AWS's own. Its device naming reference gives the HVM root
+// device as "Differs by AMI — /dev/sda1 or /dev/xvda" and the paravirtual one as
+// /dev/sda1, so a request naming either is naming the root. An AMI whose real root
+// device is neither is out of reach here; that is a documented limit rather than a
+// silent one.
+const (
+	ec2RootDeviceSDA1 = "/dev/sda1"
+	ec2RootDeviceXVDA = "/dev/xvda"
+)
+
+// ec2DefaultVolumeSizeGiB is the size of a volume whose mapping names none, and of
+// the implicit root volume a launch that declares no mapping still gets.
+//
+// It matches both the mapping DescribeImages fabricates for every AMI and
+// CreateVolume's own default, so a launch-created volume and a CreateVolume-created
+// one agree about what "unspecified" means.
+const ec2DefaultVolumeSizeGiB = 8
+
+// ec2DefaultVolumeType is the type of a volume whose mapping names none.
+//
+// AWS's EbsBlockDevice documents no default; CreateVolume documents gp2. Substrate
+// uses gp2 for both so there is one default in one place rather than two that can
+// drift. Real AMIs specify gp3 in their own block device mapping, but substrate's
+// AMIs carry no mapping to inherit one from.
+const ec2DefaultVolumeType = "gp2"
+
+// ec2ParseBlockDeviceMappings collects every BlockDeviceMapping.N specification
+// under prefix, contiguously from N=1 and stopping at the first index that names
+// nothing.
+//
+// prefix is "" for a RunInstances request and "LaunchTemplateData." for a
+// template's, so both paths parse the same shape by the same rules rather than by
+// two hand-rolled readers that can drift — the same argument
+// [ec2ParseNetworkInterfaces] takes, and for the same reason.
+//
+// Before #666 neither path parsed this at all. A request naming
+// BlockDeviceMapping.1.Ebs.VolumeSize=60 was accepted and the value discarded, so
+// DescribeVolumes reported nothing for the instance — and since AWS's
+// EbsInstanceBlockDevice carries no size member, DescribeVolumes is the *only* API
+// surface where a launch-specified volume size is observable at all.
+func ec2ParseBlockDeviceMappings(params map[string]string, prefix string) []EC2BlockDeviceMapping {
+	var out []EC2BlockDeviceMapping
+	for n := 1; ; n++ {
+		p := fmt.Sprintf("%sBlockDeviceMapping.%d.", prefix, n)
+		bdm, present := ec2ParseBlockDeviceMapping(params, p)
+		if !present {
+			return out
+		}
+		out = append(out, bdm)
+	}
+}
+
+// ec2ParseBlockDeviceMapping reads one mapping's members from the parameters under
+// p, reporting whether the index was present at all.
+//
+// An index is "present" when *any* of its members is, not when a particular one is.
+// A mapping naming only NoDevice is as real as one naming a device name and six Ebs
+// members, and requiring a chosen member would silently drop a mapping for spelling
+// reasons — [ec2ParseNetworkInterface]'s rule, applied here.
+func ec2ParseBlockDeviceMapping(params map[string]string, p string) (EC2BlockDeviceMapping, bool) {
+	// NoDevice is an empty-string member on the wire: AWS's model gives it a String
+	// type and the SDK sends NoDevice="" to mean "suppress this device", so its
+	// presence is the signal and its value is not. A hand-built request spelling it
+	// "true" is honored too.
+	noDeviceRaw, hasNoDevice := params[p+"NoDevice"]
+
+	bdm := EC2BlockDeviceMapping{
+		DeviceName:          params[p+"DeviceName"],
+		VirtualName:         params[p+"VirtualName"],
+		NoDevice:            hasNoDevice && !strings.EqualFold(noDeviceRaw, "false"),
+		SnapshotID:          params[p+"Ebs.SnapshotId"],
+		VolumeType:          params[p+"Ebs.VolumeType"],
+		Encrypted:           strings.EqualFold(params[p+"Ebs.Encrypted"], "true"),
+		DeleteOnTermination: params[p+"Ebs.DeleteOnTermination"],
+	}
+	if n, err := strconv.Atoi(strings.TrimSpace(params[p+"Ebs.VolumeSize"])); err == nil {
+		bdm.VolumeSize = n
+	}
+	if n, err := strconv.Atoi(strings.TrimSpace(params[p+"Ebs.Iops"])); err == nil {
+		bdm.IOPS = n
+	}
+	if n, err := strconv.Atoi(strings.TrimSpace(params[p+"Ebs.Throughput"])); err == nil {
+		bdm.Throughput = n
+	}
+
+	present := hasNoDevice || bdm.DeviceName != "" || bdm.VirtualName != "" ||
+		bdm.SnapshotID != "" || bdm.VolumeType != "" ||
+		params[p+"Ebs.VolumeSize"] != "" || params[p+"Ebs.Iops"] != "" ||
+		params[p+"Ebs.Throughput"] != "" || params[p+"Ebs.Encrypted"] != "" ||
+		params[p+"Ebs.DeleteOnTermination"] != ""
+	return bdm, present
+}
+
+// ec2IsRootDevice reports whether a device name names the root volume.
+func ec2IsRootDevice(device string) bool {
+	return device == ec2RootDeviceSDA1 || device == ec2RootDeviceXVDA
+}
+
+// ec2CreatesEBSVolume reports whether a mapping asks for an EBS volume.
+//
+// NoDevice suppresses the device outright, and a VirtualName with no Ebs.* members
+// names an instance store volume, which is not an EBS volume and has no presence in
+// DescribeVolumes. Either way the mapping is recorded intent that materializes
+// nothing.
+func ec2CreatesEBSVolume(bdm EC2BlockDeviceMapping) bool {
+	if bdm.NoDevice {
+		return false
+	}
+	if bdm.VirtualName != "" {
+		return bdm.SnapshotID != "" || bdm.VolumeSize > 0 || bdm.VolumeType != "" ||
+			bdm.IOPS > 0 || bdm.Throughput > 0 || bdm.Encrypted ||
+			bdm.DeleteOnTermination != ""
+	}
+	return true
+}
+
+// ec2LaunchVolumesFor resolves the EBS volumes a launch materializes for one
+// instance, each already attached to it.
+//
+// The volumes are real EC2Volume records written to the same "volume:" state
+// namespace CreateVolume writes to, so DescribeVolumes is the single source of truth
+// for provisioned and launch-created volumes alike — which is how real EC2 unifies
+// the two, and the reason #666's consumer had nowhere to look.
+//
+// **Every launch produces at least one volume.** A real instance always has a root
+// volume whether or not the request mentions one, so a launch that declares no
+// mapping gets a synthesized 8 GiB gp2 volume at /dev/sda1, matching what
+// DescribeImages already reports for every AMI. A mapping that *does* name a root
+// device configures that root volume rather than adding a device, which is AWS's own
+// rule for a mapping whose device name the AMI's mapping already uses: "the mapping
+// you specify replaces the AMI's".
+//
+// DeleteOnTermination defaults to **true** for every volume a launch creates, root
+// and data alike. That is counter-intuitive and is AWS's documented behavior: its
+// termination table splits on how the volume was attached, not on what it is — a
+// data volume attached at launch through the console preserves, but through the API
+// it is deleted, and substrate has no console. A volume attached after launch keeps
+// the other default; see attachVolume.
+func ec2LaunchVolumesFor(inst *EC2Instance, mappings []EC2BlockDeviceMapping, now string) []EC2Volume {
+	volumes := make([]EC2Volume, 0, len(mappings)+1)
+	rootDeclared := false
+
+	for _, bdm := range mappings {
+		if !ec2CreatesEBSVolume(bdm) {
+			continue
+		}
+		if ec2IsRootDevice(bdm.DeviceName) {
+			rootDeclared = true
+		}
+		volumes = append(volumes, ec2VolumeFromMapping(inst, bdm, now))
+	}
+
+	if !rootDeclared {
+		volumes = append(volumes, ec2VolumeFromMapping(inst, EC2BlockDeviceMapping{
+			DeviceName: ec2RootDeviceSDA1,
+		}, now))
+	}
+	return volumes
+}
+
+// ec2VolumeFromMapping builds one volume from one mapping, attached to inst.
+//
+// The zone comes from the instance rather than from the region's first zone: a
+// volume must be in the same Availability Zone as the instance it is attached to, so
+// deriving it any other way would let a launch into a non-default zone produce an
+// attachment real EC2 cannot have.
+func ec2VolumeFromMapping(inst *EC2Instance, bdm EC2BlockDeviceMapping, now string) EC2Volume {
+	size := bdm.VolumeSize
+	if size <= 0 {
+		size = ec2DefaultVolumeSizeGiB
+	}
+	volType := bdm.VolumeType
+	if volType == "" {
+		volType = ec2DefaultVolumeType
+	}
+	device := bdm.DeviceName
+	if device == "" {
+		device = ec2RootDeviceSDA1
+	}
+	// Absent means true here — the launch default — so only an explicit "false"
+	// preserves the volume. The raw string is what makes that distinguishable.
+	deleteOnTermination := true
+	if bdm.DeleteOnTermination != "" {
+		deleteOnTermination = strings.EqualFold(bdm.DeleteOnTermination, "true")
+	}
+
+	return EC2Volume{
+		VolumeID:         generateVolumeID(),
+		Size:             size,
+		VolumeType:       volType,
+		AvailabilityZone: inst.AvailabilityZone,
+		State:            "in-use",
+		SnapshotID:       bdm.SnapshotID,
+		Encrypted:        bdm.Encrypted,
+		IOPS:             bdm.IOPS,
+		Throughput:       bdm.Throughput,
+		Attachments: []EC2VolumeAttachment{{
+			InstanceID:          inst.InstanceID,
+			Device:              device,
+			State:               "attached",
+			AttachTime:          now,
+			DeleteOnTermination: deleteOnTermination,
+		}},
+		CreateTime: now,
+		AccountID:  inst.AccountID,
+		Region:     inst.Region,
+	}
+}
+
+// ec2CreateLaunchVolumes writes the volumes a launch materializes for one instance,
+// indexing each one the way CreateVolume does so DescribeVolumes and DeleteVolume
+// find them by the same paths.
+func (p *EC2Plugin) ec2CreateLaunchVolumes(
+	inst *EC2Instance,
+	mappings []EC2BlockDeviceMapping,
+	now string,
+) error {
+	for _, vol := range ec2LaunchVolumesFor(inst, mappings, now) {
+		data, err := json.Marshal(vol)
+		if err != nil {
+			return fmt.Errorf("ec2 runInstances volume marshal: %w", err)
+		}
+		key := ec2VolumeStateKey(vol.AccountID, vol.Region, vol.VolumeID)
+		if err := p.state.Put(context.Background(), ec2Namespace, key, data); err != nil {
+			return fmt.Errorf("ec2 runInstances volume state.Put: %w", err)
+		}
+		if err := p.appendToList(vol.AccountID+"/"+vol.Region, "volume_ids", vol.VolumeID); err != nil {
+			return fmt.Errorf("ec2 runInstances volume index: %w", err)
+		}
+	}
+	return nil
+}
+
+// ec2DeleteInstanceVolumes settles the volumes attached to a terminated instance.
+//
+// A volume whose attachment deletes on termination is removed outright; one that
+// does not becomes available with no attachment, which is what a preserved volume
+// looks like once its instance is gone. Doing neither would leave a volume reporting
+// in-use, attached to a terminated instance, forever — a new inaccuracy in place of
+// the old silence, and the reason the parsing in #666 could not land on its own.
+func (p *EC2Plugin) ec2DeleteInstanceVolumes(accountID, region, instanceID string) error {
+	ctx := context.Background()
+	keys, err := p.state.List(ctx, ec2Namespace, ec2VolumeStatePrefix(accountID, region))
+	if err != nil {
+		return fmt.Errorf("ec2 terminateInstances volume list: %w", err)
+	}
+	for _, key := range keys {
+		data, getErr := p.state.Get(ctx, ec2Namespace, key)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var vol EC2Volume
+		if json.Unmarshal(data, &vol) != nil {
+			continue
+		}
+		attached, deleteOnTermination := ec2VolumeAttachedTo(vol, instanceID)
+		if !attached {
+			continue
+		}
+		if deleteOnTermination {
+			if err := p.state.Delete(ctx, ec2Namespace, key); err != nil {
+				return fmt.Errorf("ec2 terminateInstances volume delete: %w", err)
+			}
+			removeFromStringIndex(ctx, p.state, ec2Namespace,
+				"volume_ids:"+accountID+"/"+region, vol.VolumeID)
+			continue
+		}
+		vol.State = "available"
+		vol.Attachments = nil
+		newData, marshalErr := json.Marshal(vol)
+		if marshalErr != nil {
+			return fmt.Errorf("ec2 terminateInstances volume marshal: %w", marshalErr)
+		}
+		if err := p.state.Put(ctx, ec2Namespace, key, newData); err != nil {
+			return fmt.Errorf("ec2 terminateInstances volume state.Put: %w", err)
+		}
+	}
+	return nil
+}
+
+// ec2VolumeMatchesAttachmentFilters reports whether a volume satisfies every
+// attachment-scoped DescribeVolumes filter that was supplied.
+//
+// Each filter is satisfied by *any* attachment, which is what a filter on a
+// list-valued member means, but the filters are ANDed with each other rather than
+// evaluated against one attachment at a time — AWS's filter semantics are per
+// filter, not per list element. An empty map means the filter was not supplied and
+// so constrains nothing.
+func ec2VolumeMatchesAttachmentFilters(
+	vol EC2Volume,
+	instanceIDs, devices, deleteOnTermination map[string]bool,
+) bool {
+	matches := func(want map[string]bool, got func(EC2VolumeAttachment) string) bool {
+		if len(want) == 0 {
+			return true
+		}
+		for _, att := range vol.Attachments {
+			if want[got(att)] {
+				return true
+			}
+		}
+		return false
+	}
+	return matches(instanceIDs, func(a EC2VolumeAttachment) string { return a.InstanceID }) &&
+		matches(devices, func(a EC2VolumeAttachment) string { return a.Device }) &&
+		matches(deleteOnTermination, func(a EC2VolumeAttachment) string {
+			return strconv.FormatBool(a.DeleteOnTermination)
+		})
+}
+
+// ec2VolumeStateKey is the state key one volume is stored under.
+//
+// Declared once rather than concatenated at each call site: a launch now writes
+// volumes that CreateVolume did not create, and a writer that spells the key
+// differently from the readers would produce volumes DescribeVolumes cannot see.
+func ec2VolumeStateKey(accountID, region, volumeID string) string {
+	return "volume:" + accountID + "/" + region + "/" + volumeID
+}
+
+// ec2VolumeStatePrefix is the key prefix every volume in one account and region
+// shares, for a List that has no particular volume in mind.
+func ec2VolumeStatePrefix(accountID, region string) string {
+	return "volume:" + accountID + "/" + region + "/"
+}
+
+// ec2VolumeAttachedTo reports whether a volume is attached to the named instance,
+// and whether that attachment deletes the volume when the instance terminates.
+func ec2VolumeAttachedTo(vol EC2Volume, instanceID string) (attached, deleteOnTermination bool) {
+	for _, att := range vol.Attachments {
+		if att.InstanceID == instanceID {
+			return true, att.DeleteOnTermination
+		}
+	}
+	return false, false
+}

--- a/emulator/ec2_block_devices_http_test.go
+++ b/emulator/ec2_block_devices_http_test.go
@@ -1,0 +1,449 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The launch-time block device mapping behavior #666 reports, asserted through HTTP
+// so what a caller actually receives is what is pinned.
+//
+// These assertions unmarshal the response rather than searching the body for "vol-".
+// The existing volume tests use strings.Index for that, which cannot tell two
+// volumes apart — and a launch now routinely produces two.
+
+// bdmVolume is one volumeSet>item of a DescribeVolumes response.
+type bdmVolume struct {
+	VolumeID         string `xml:"volumeId"`
+	Size             int    `xml:"size"`
+	VolumeType       string `xml:"volumeType"`
+	AvailabilityZone string `xml:"availabilityZone"`
+	Status           string `xml:"status"`
+	Encrypted        bool   `xml:"encrypted"`
+	SnapshotID       string `xml:"snapshotId"`
+	IOPS             int    `xml:"iops"`
+	Throughput       int    `xml:"throughput"`
+	Attachments      []struct {
+		VolumeID            string `xml:"volumeId"`
+		InstanceID          string `xml:"instanceId"`
+		Device              string `xml:"device"`
+		Status              string `xml:"status"`
+		AttachTime          string `xml:"attachTime"`
+		DeleteOnTermination bool   `xml:"deleteOnTermination"`
+	} `xml:"attachmentSet>item"`
+}
+
+// bdmDevice returns the volume's first attachment device, or "" when it has none.
+func (v bdmVolume) bdmDevice() string {
+	if len(v.Attachments) == 0 {
+		return ""
+	}
+	return v.Attachments[0].Device
+}
+
+// bdmDescribeVolumes calls DescribeVolumes with the given extra parameters and
+// returns the volumes it reports, sorted by attachment device so an assertion does
+// not depend on state-listing order.
+func bdmDescribeVolumes(t *testing.T, ts *httptest.Server, params map[string]string) []bdmVolume {
+	t.Helper()
+	all := map[string]string{"Action": "DescribeVolumes"}
+	for k, v := range params {
+		all[k] = v
+	}
+	resp := ec2Request(t, ts, all)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var parsed struct {
+		Items []bdmVolume `xml:"volumeSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), string(body))
+	sort.Slice(parsed.Items, func(i, j int) bool {
+		return parsed.Items[i].bdmDevice() < parsed.Items[j].bdmDevice()
+	})
+	return parsed.Items
+}
+
+// bdmRunInstances launches instances and returns their IDs in response order.
+func bdmRunInstances(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	all := map[string]string{
+		"Action":   "RunInstances",
+		"ImageId":  "ami-0abcdef1234567890",
+		"MinCount": "1",
+		"MaxCount": "1",
+	}
+	for k, v := range params {
+		all[k] = v
+	}
+	resp := ec2Request(t, ts, all)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var parsed struct {
+		Items []struct {
+			InstanceID string `xml:"instanceId"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), string(body))
+	ids := make([]string, 0, len(parsed.Items))
+	for _, item := range parsed.Items {
+		require.NotEmpty(t, item.InstanceID)
+		ids = append(ids, item.InstanceID)
+	}
+	return ids
+}
+
+// TestEC2_BlockDeviceMapping_ReportedRepro is #666's reproduction, verbatim: a
+// launch naming a 60 GiB /dev/xvda, then DescribeVolumes filtered on the instance.
+//
+// Before the fix this returned an empty volumeSet — the mapping was parsed nowhere,
+// so the size the caller asked for was not merely hidden but unreachable, AWS's
+// EbsInstanceBlockDevice carrying no size member of its own.
+//
+// One volume, not two. /dev/xvda is a root device name, so the mapping configures
+// the root rather than adding a device beside a synthesized one.
+func TestEC2_BlockDeviceMapping_ReportedRepro(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/xvda",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "60",
+	})
+	require.Len(t, ids, 1)
+
+	vols := bdmDescribeVolumes(t, ts, map[string]string{
+		"Filter.1.Name":    "attachment.instance-id",
+		"Filter.1.Value.1": ids[0],
+	})
+	require.Len(t, vols, 1)
+	assert.Equal(t, 60, vols[0].Size)
+	assert.Equal(t, "in-use", vols[0].Status)
+	assert.Equal(t, "/dev/xvda", vols[0].bdmDevice())
+	assert.Equal(t, ids[0], vols[0].Attachments[0].InstanceID)
+	assert.True(t, vols[0].Attachments[0].DeleteOnTermination,
+		"a volume a launch creates is deleted on termination")
+	assert.NotEmpty(t, vols[0].Attachments[0].AttachTime)
+}
+
+// TestEC2_BlockDeviceMapping_ImplicitRootVolume pins that a launch naming no mapping
+// still produces a volume. A real instance always has a root volume, and
+// DescribeImages already reports an 8 GiB /dev/sda1 mapping for every AMI substrate
+// serves, so producing none left the two disagreeing about one instance.
+func TestEC2_BlockDeviceMapping_ImplicitRootVolume(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, nil)
+
+	vols := bdmDescribeVolumes(t, ts, map[string]string{
+		"Filter.1.Name":    "attachment.instance-id",
+		"Filter.1.Value.1": ids[0],
+	})
+	require.Len(t, vols, 1)
+	assert.Equal(t, 8, vols[0].Size)
+	assert.Equal(t, "gp2", vols[0].VolumeType)
+	assert.Equal(t, "/dev/sda1", vols[0].bdmDevice())
+	// The volume shares the instance's zone, since an attachment across zones is a
+	// state real EC2 cannot reach.
+	assert.Equal(t, "us-east-1a", vols[0].AvailabilityZone)
+}
+
+// TestEC2_BlockDeviceMapping_DataVolumeAlongsideRoot covers a data volume and the
+// performance members that were stored and never rendered.
+func TestEC2_BlockDeviceMapping_DataVolumeAlongsideRoot(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "100",
+		"BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+		"BlockDeviceMapping.1.Ebs.Iops":       "4000",
+		"BlockDeviceMapping.1.Ebs.Throughput": "250",
+		"BlockDeviceMapping.1.Ebs.Encrypted":  "true",
+	})
+
+	vols := bdmDescribeVolumes(t, ts, map[string]string{
+		"Filter.1.Name":    "attachment.instance-id",
+		"Filter.1.Value.1": ids[0],
+	})
+	require.Len(t, vols, 2, "the data volume plus a synthesized root")
+
+	// Sorted by device: /dev/sda1 before /dev/sdf.
+	root, data := vols[0], vols[1]
+	assert.Equal(t, "/dev/sda1", root.bdmDevice())
+	assert.Equal(t, 8, root.Size)
+
+	assert.Equal(t, "/dev/sdf", data.bdmDevice())
+	assert.Equal(t, 100, data.Size)
+	assert.Equal(t, "gp3", data.VolumeType)
+	assert.Equal(t, 4000, data.IOPS, "iops was stored and never rendered")
+	assert.Equal(t, 250, data.Throughput, "throughput had nowhere to be stored at all")
+	assert.True(t, data.Encrypted)
+	assert.NotEqual(t, root.VolumeID, data.VolumeID)
+}
+
+// TestEC2_BlockDeviceMapping_TerminationHonorsDeleteOnTermination is the half that
+// makes the parsing safe to land.
+//
+// Without it a volume would report deleteOnTermination=true while sitting in-use on
+// a terminated instance forever — a state real EC2 never reaches, and a new
+// inaccuracy in place of the old silence.
+func TestEC2_BlockDeviceMapping_TerminationHonorsDeleteOnTermination(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		// The root deletes by default; the data volume explicitly preserves.
+		"BlockDeviceMapping.1.DeviceName":              "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.VolumeSize":          "30",
+		"BlockDeviceMapping.2.DeviceName":              "/dev/sdf",
+		"BlockDeviceMapping.2.Ebs.VolumeSize":          "40",
+		"BlockDeviceMapping.2.Ebs.DeleteOnTermination": "false",
+	})
+
+	before := bdmDescribeVolumes(t, ts, nil)
+	require.Len(t, before, 2)
+	assert.True(t, before[0].Attachments[0].DeleteOnTermination, "/dev/sda1")
+	assert.False(t, before[1].Attachments[0].DeleteOnTermination, "/dev/sdf")
+	preservedID := before[1].VolumeID
+
+	termResp := ec2Request(t, ts, map[string]string{
+		"Action":       "TerminateInstances",
+		"InstanceId.1": ids[0],
+	})
+	require.Equal(t, http.StatusOK, termResp.StatusCode)
+	require.NoError(t, termResp.Body.Close())
+
+	// An unfiltered DescribeVolumes must not report the deleted one: its record left
+	// the namespace DescribeVolumes lists, not merely its attachment.
+	after := bdmDescribeVolumes(t, ts, nil)
+	require.Len(t, after, 1)
+	assert.Equal(t, preservedID, after[0].VolumeID)
+	// A preserved volume is available with no attachment, which is what a volume
+	// whose instance is gone looks like.
+	assert.Equal(t, "available", after[0].Status)
+	assert.Empty(t, after[0].Attachments)
+	assert.Equal(t, 40, after[0].Size)
+}
+
+// TestEC2_BlockDeviceMapping_NoDeviceAndInstanceStore pins that neither a suppressed
+// device nor an instance store device becomes an EBS volume — while the root is still
+// synthesized, since neither entry was it.
+func TestEC2_BlockDeviceMapping_NoDeviceAndInstanceStore(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":  "/dev/sdb",
+		"BlockDeviceMapping.1.NoDevice":    "",
+		"BlockDeviceMapping.2.DeviceName":  "/dev/sdc",
+		"BlockDeviceMapping.2.VirtualName": "ephemeral0",
+	})
+
+	vols := bdmDescribeVolumes(t, ts, map[string]string{
+		"Filter.1.Name":    "attachment.instance-id",
+		"Filter.1.Value.1": ids[0],
+	})
+	require.Len(t, vols, 1)
+	assert.Equal(t, "/dev/sda1", vols[0].bdmDevice())
+}
+
+// TestEC2_BlockDeviceMapping_PerInstanceIsolation covers a multi-count launch. Two
+// instances cannot share one EBS volume, and terminating one must not touch the
+// other's.
+func TestEC2_BlockDeviceMapping_PerInstanceIsolation(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"MaxCount":                            "2",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/xvda",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "50",
+	})
+	require.Len(t, ids, 2)
+
+	first := bdmDescribeVolumes(t, ts, map[string]string{
+		"Filter.1.Name":    "attachment.instance-id",
+		"Filter.1.Value.1": ids[0],
+	})
+	second := bdmDescribeVolumes(t, ts, map[string]string{
+		"Filter.1.Name":    "attachment.instance-id",
+		"Filter.1.Value.1": ids[1],
+	})
+	require.Len(t, first, 1)
+	require.Len(t, second, 1)
+	assert.NotEqual(t, first[0].VolumeID, second[0].VolumeID)
+	assert.Equal(t, 50, first[0].Size)
+	assert.Equal(t, 50, second[0].Size)
+
+	termResp := ec2Request(t, ts, map[string]string{
+		"Action":       "TerminateInstances",
+		"InstanceId.1": ids[0],
+	})
+	require.Equal(t, http.StatusOK, termResp.StatusCode)
+	require.NoError(t, termResp.Body.Close())
+
+	remaining := bdmDescribeVolumes(t, ts, nil)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, second[0].VolumeID, remaining[0].VolumeID)
+}
+
+// TestEC2_BlockDeviceMapping_FromLaunchTemplate covers the template path, which is
+// the only route by which mappings reach a fleet launch: CreateFleet forwards the
+// template reference rather than the caller's own mappings.
+func TestEC2_BlockDeviceMapping_FromLaunchTemplate(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ltResp := ec2Request(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "with-storage",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/xvda",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize": "40",
+	})
+	require.Equal(t, http.StatusOK, ltResp.StatusCode)
+	require.NoError(t, ltResp.Body.Close())
+
+	t.Run("the template supplies the mappings", func(t *testing.T) {
+		ids := bdmRunInstances(t, ts, map[string]string{
+			"LaunchTemplate.LaunchTemplateName": "with-storage",
+		})
+		vols := bdmDescribeVolumes(t, ts, map[string]string{
+			"Filter.1.Name":    "attachment.instance-id",
+			"Filter.1.Value.1": ids[0],
+		})
+		require.Len(t, vols, 1)
+		assert.Equal(t, 40, vols[0].Size)
+		assert.Equal(t, "/dev/xvda", vols[0].bdmDevice())
+	})
+
+	t.Run("the request overrides the template wholesale", func(t *testing.T) {
+		// All-or-nothing, the rule every other template field follows: a request that
+		// names one mapping must not silently inherit a second.
+		ids := bdmRunInstances(t, ts, map[string]string{
+			"LaunchTemplate.LaunchTemplateName":   "with-storage",
+			"BlockDeviceMapping.1.DeviceName":     "/dev/xvda",
+			"BlockDeviceMapping.1.Ebs.VolumeSize": "90",
+		})
+		vols := bdmDescribeVolumes(t, ts, map[string]string{
+			"Filter.1.Name":    "attachment.instance-id",
+			"Filter.1.Value.1": ids[0],
+		})
+		require.Len(t, vols, 1)
+		assert.Equal(t, 90, vols[0].Size)
+	})
+}
+
+// TestEC2_BlockDeviceMapping_AttachVolumePreserves pins the other half of AWS's
+// termination rule: a volume attached *after* launch is preserved, because deleting
+// one the caller brought would destroy something the launch did not make.
+func TestEC2_BlockDeviceMapping_AttachVolumePreserves(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, nil)
+
+	cvResp := ec2Request(t, ts, map[string]string{
+		"Action":           "CreateVolume",
+		"AvailabilityZone": "us-east-1a",
+		"Size":             "15",
+	})
+	require.Equal(t, http.StatusOK, cvResp.StatusCode)
+	cvBody, err := io.ReadAll(cvResp.Body)
+	require.NoError(t, err)
+	require.NoError(t, cvResp.Body.Close())
+	var created struct {
+		VolumeID string `xml:"volumeId"`
+	}
+	require.NoError(t, xml.Unmarshal(cvBody, &created))
+	require.NotEmpty(t, created.VolumeID)
+
+	attResp := ec2Request(t, ts, map[string]string{
+		"Action":     "AttachVolume",
+		"VolumeId":   created.VolumeID,
+		"InstanceId": ids[0],
+		"Device":     "/dev/sdh",
+	})
+	require.Equal(t, http.StatusOK, attResp.StatusCode)
+	attBody, err := io.ReadAll(attResp.Body)
+	require.NoError(t, err)
+	require.NoError(t, attResp.Body.Close())
+	var attached struct {
+		DeleteOnTermination bool `xml:"deleteOnTermination"`
+	}
+	require.NoError(t, xml.Unmarshal(attBody, &attached))
+	assert.False(t, attached.DeleteOnTermination,
+		"AWS preserves a volume attached after launch")
+
+	termResp := ec2Request(t, ts, map[string]string{
+		"Action":       "TerminateInstances",
+		"InstanceId.1": ids[0],
+	})
+	require.Equal(t, http.StatusOK, termResp.StatusCode)
+	require.NoError(t, termResp.Body.Close())
+
+	// The brought volume survives; the launch's own root does not.
+	after := bdmDescribeVolumes(t, ts, nil)
+	require.Len(t, after, 1)
+	assert.Equal(t, created.VolumeID, after[0].VolumeID)
+	assert.Equal(t, "available", after[0].Status)
+}
+
+// TestEC2_BlockDeviceMapping_DescribeVolumesFilters covers each filter the new state
+// makes worth asking about, selecting and excluding.
+func TestEC2_BlockDeviceMapping_DescribeVolumesFilters(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":              "/dev/xvda",
+		"BlockDeviceMapping.1.Ebs.VolumeSize":          "30",
+		"BlockDeviceMapping.2.DeviceName":              "/dev/sdf",
+		"BlockDeviceMapping.2.Ebs.VolumeSize":          "40",
+		"BlockDeviceMapping.2.Ebs.VolumeType":          "gp3",
+		"BlockDeviceMapping.2.Ebs.DeleteOnTermination": "false",
+	})
+	require.Len(t, ids, 1)
+
+	tests := []struct {
+		name       string
+		filter     string
+		value      string
+		wantDevice []string
+	}{
+		{"attachment.device selects", "attachment.device", "/dev/sdf", []string{"/dev/sdf"}},
+		{"attachment.device excludes", "attachment.device", "/dev/sdz", nil},
+		{
+			"delete-on-termination selects the preserved one",
+			"attachment.delete-on-termination", "false", []string{"/dev/sdf"},
+		},
+		{
+			"delete-on-termination selects the deleted one",
+			"attachment.delete-on-termination", "true", []string{"/dev/xvda"},
+		},
+		{"volume-type selects", "volume-type", "gp3", []string{"/dev/sdf"}},
+		{"volume-type selects the default", "volume-type", "gp2", []string{"/dev/xvda"}},
+		{"volume-type excludes", "volume-type", "io2", nil},
+		{"size selects", "size", "30", []string{"/dev/xvda"}},
+		{"size excludes", "size", "999", nil},
+		{
+			"availability-zone selects both",
+			"availability-zone", "us-east-1a", []string{"/dev/sdf", "/dev/xvda"},
+		},
+		{"availability-zone excludes", "availability-zone", "eu-west-1a", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vols := bdmDescribeVolumes(t, ts, map[string]string{
+				"Filter.1.Name":    tt.filter,
+				"Filter.1.Value.1": tt.value,
+			})
+			devices := make([]string, 0, len(vols))
+			for _, v := range vols {
+				devices = append(devices, v.bdmDevice())
+			}
+			if tt.wantDevice == nil {
+				assert.Empty(t, devices)
+				return
+			}
+			assert.Equal(t, tt.wantDevice, devices)
+		})
+	}
+}

--- a/emulator/ec2_block_devices_test.go
+++ b/emulator/ec2_block_devices_test.go
@@ -1,0 +1,340 @@
+package emulator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// #666: RunInstances accepted BlockDeviceMapping.N.* and parsed none of it, so a
+// launch naming a 60 GiB root volume succeeded and DescribeVolumes reported nothing
+// for the instance. Since AWS's EbsInstanceBlockDevice carries no size member,
+// DescribeVolumes is the only API surface where a launch-specified size is
+// observable at all — the value was not merely hidden, it was unreachable.
+//
+// These tests cover the parser and the materializer in isolation; the launch,
+// termination and filter behavior they feed is covered through HTTP in
+// ec2_plugin_test.go.
+
+func TestEC2ParseBlockDeviceMappings(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		prefix string
+		params map[string]string
+		want   []emulator.EC2BlockDeviceMapping
+	}{
+		{
+			name:   "no mappings",
+			params: map[string]string{"ImageId": "ami-1"},
+			want:   nil,
+		},
+		{
+			// The issue's own repro.
+			name: "the reported repro",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/xvda",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "60",
+			},
+			want: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/xvda", VolumeSize: 60},
+			},
+		},
+		{
+			name: "every ebs member",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":              "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.SnapshotId":          "snap-abc",
+				"BlockDeviceMapping.1.Ebs.VolumeSize":          "100",
+				"BlockDeviceMapping.1.Ebs.VolumeType":          "gp3",
+				"BlockDeviceMapping.1.Ebs.Iops":                "4000",
+				"BlockDeviceMapping.1.Ebs.Throughput":          "250",
+				"BlockDeviceMapping.1.Ebs.Encrypted":           "true",
+				"BlockDeviceMapping.1.Ebs.DeleteOnTermination": "false",
+			},
+			want: []emulator.EC2BlockDeviceMapping{{
+				DeviceName:          "/dev/sdf",
+				SnapshotID:          "snap-abc",
+				VolumeSize:          100,
+				VolumeType:          "gp3",
+				IOPS:                4000,
+				Throughput:          250,
+				Encrypted:           true,
+				DeleteOnTermination: "false",
+			}},
+		},
+		{
+			// Every index is read, not just the first — [ec2ParseNetworkInterfaces]'
+			// own contiguous-from-1 rule, and the bug #455 fixed for interfaces.
+			name: "three contiguous mappings",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "30",
+				"BlockDeviceMapping.2.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.2.Ebs.VolumeSize": "40",
+				"BlockDeviceMapping.3.DeviceName":     "/dev/sdg",
+				"BlockDeviceMapping.3.Ebs.VolumeSize": "50",
+			},
+			want: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sda1", VolumeSize: 30},
+				{DeviceName: "/dev/sdf", VolumeSize: 40},
+				{DeviceName: "/dev/sdg", VolumeSize: 50},
+			},
+		},
+		{
+			// A gap terminates the scan, which is the convention every other indexed
+			// reader here follows.
+			name: "a gap stops the scan",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName": "/dev/sdf",
+				"BlockDeviceMapping.3.DeviceName": "/dev/sdh",
+			},
+			want: []emulator.EC2BlockDeviceMapping{{DeviceName: "/dev/sdf"}},
+		},
+		{
+			// An index naming only an Ebs member and no device name is still present:
+			// requiring a chosen member would drop a mapping for spelling reasons.
+			name: "size alone is present",
+			params: map[string]string{
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "25",
+			},
+			want: []emulator.EC2BlockDeviceMapping{{VolumeSize: 25}},
+		},
+		{
+			// NoDevice is an empty-string member on the wire, so its presence is the
+			// signal. An index naming only NoDevice must still be seen.
+			name: "no device with an empty value",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName": "/dev/sdb",
+				"BlockDeviceMapping.1.NoDevice":   "",
+			},
+			want: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sdb", NoDevice: true},
+			},
+		},
+		{
+			name: "instance store",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":  "/dev/sdb",
+				"BlockDeviceMapping.1.VirtualName": "ephemeral0",
+			},
+			want: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sdb", VirtualName: "ephemeral0"},
+			},
+		},
+		{
+			// The launch-template prefix, which is the whole reason the parser takes
+			// one: a template and a request parse the same shape by the same rules.
+			name:   "launch template prefix",
+			prefix: "LaunchTemplateData.",
+			params: map[string]string{
+				"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+				"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize": "40",
+				// A same-named parameter without the prefix must not leak in.
+				"BlockDeviceMapping.1.DeviceName": "/dev/sdz",
+			},
+			want: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sda1", VolumeSize: 40},
+			},
+		},
+		{
+			// An unparseable number reads as zero rather than failing the launch, the
+			// same tolerance ec2ParseNetworkInterface gives DeviceIndex. The index is
+			// still present, so the mapping is not dropped.
+			name: "unparseable size",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "not-a-number",
+			},
+			want: []emulator.EC2BlockDeviceMapping{{DeviceName: "/dev/sdf"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := emulator.ParseBlockDeviceMappingsForTest(tt.params, tt.prefix)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestEC2LaunchVolumes_AlwaysHasARoot pins the decision that every launch
+// materializes at least one volume.
+//
+// A real instance always has a root volume whether or not the request mentions one,
+// and DescribeImages already reports an 8 GiB /dev/sda1 mapping for every AMI
+// substrate serves. A launch that produced no volume at all would leave the two
+// disagreeing about the same instance.
+func TestEC2LaunchVolumes_AlwaysHasARoot(t *testing.T) {
+	t.Parallel()
+	vols := emulator.LaunchVolumesForTest("i-1", "us-west-2b", nil)
+	require.Len(t, vols, 1)
+	assert.Equal(t, 8, vols[0].Size)
+	assert.Equal(t, "gp2", vols[0].VolumeType)
+	assert.Equal(t, "in-use", vols[0].State)
+	// The zone is the instance's, not the region's first: a volume must be in the
+	// same zone as the instance it is attached to.
+	assert.Equal(t, "us-west-2b", vols[0].AvailabilityZone)
+	require.Len(t, vols[0].Attachments, 1)
+	assert.Equal(t, "/dev/sda1", vols[0].Attachments[0].Device)
+	assert.Equal(t, "i-1", vols[0].Attachments[0].InstanceID)
+	assert.True(t, vols[0].Attachments[0].DeleteOnTermination)
+}
+
+func TestEC2LaunchVolumes(t *testing.T) {
+	t.Parallel()
+	type wantVol struct {
+		device              string
+		size                int
+		volumeType          string
+		deleteOnTermination bool
+	}
+	tests := []struct {
+		name     string
+		mappings []emulator.EC2BlockDeviceMapping
+		want     []wantVol
+	}{
+		{
+			// Both root device names configure the root rather than adding a device.
+			// AWS's device-naming reference gives the HVM root as "Differs by AMI —
+			// /dev/sda1 or /dev/xvda", and the issue's repro uses /dev/xvda: a rule
+			// that recognized only /dev/sda1 would answer that repro with two volumes,
+			// a 60 GiB /dev/xvda alongside a spurious 8 GiB root.
+			name:     "xvda configures the root",
+			mappings: []emulator.EC2BlockDeviceMapping{{DeviceName: "/dev/xvda", VolumeSize: 60}},
+			want:     []wantVol{{"/dev/xvda", 60, "gp2", true}},
+		},
+		{
+			name:     "sda1 configures the root",
+			mappings: []emulator.EC2BlockDeviceMapping{{DeviceName: "/dev/sda1", VolumeSize: 30}},
+			want:     []wantVol{{"/dev/sda1", 30, "gp2", true}},
+		},
+		{
+			// A data volume does not suppress the root, so a launch naming only
+			// /dev/sdf gets two volumes.
+			name:     "a data volume gets a root alongside it",
+			mappings: []emulator.EC2BlockDeviceMapping{{DeviceName: "/dev/sdf", VolumeSize: 100, VolumeType: "gp3"}},
+			want: []wantVol{
+				{"/dev/sdf", 100, "gp3", true},
+				{"/dev/sda1", 8, "gp2", true},
+			},
+		},
+		{
+			// DeleteOnTermination defaults to true for a *data* volume too. Counter-
+			// intuitive, and AWS's own behavior: its termination table splits on how
+			// the volume was attached, not on what it is — a data volume attached at
+			// launch through the console preserves, but through the API it is deleted,
+			// and substrate has no console.
+			name: "an explicit false preserves",
+			mappings: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sdf", VolumeSize: 20, DeleteOnTermination: "false"},
+			},
+			want: []wantVol{
+				{"/dev/sdf", 20, "gp2", false},
+				{"/dev/sda1", 8, "gp2", true},
+			},
+		},
+		{
+			name: "an explicit true is honored",
+			mappings: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sda1", VolumeSize: 20, DeleteOnTermination: "true"},
+			},
+			want: []wantVol{{"/dev/sda1", 20, "gp2", true}},
+		},
+		{
+			// NoDevice suppresses the device outright, so nothing is created for it —
+			// and the root is still synthesized, since the suppressed entry was not it.
+			name: "no device creates nothing",
+			mappings: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sdb", NoDevice: true},
+			},
+			want: []wantVol{{"/dev/sda1", 8, "gp2", true}},
+		},
+		{
+			// An instance store device is not an EBS volume and has no presence in
+			// DescribeVolumes. Manufacturing one would be an observation nothing backs.
+			name: "instance store creates nothing",
+			mappings: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sdb", VirtualName: "ephemeral0"},
+			},
+			want: []wantVol{{"/dev/sda1", 8, "gp2", true}},
+		},
+		{
+			// A VirtualName alongside real Ebs members is a contradictory mapping AWS
+			// would refuse; substrate honors the EBS half rather than silently dropping
+			// a volume the caller sized.
+			name: "virtual name with ebs members still creates",
+			mappings: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sdb", VirtualName: "ephemeral0", VolumeSize: 12},
+			},
+			want: []wantVol{
+				{"/dev/sdb", 12, "gp2", true},
+				{"/dev/sda1", 8, "gp2", true},
+			},
+		},
+		{
+			// NoDevice wins over a size: it means "there is no such device".
+			name: "no device wins over a size",
+			mappings: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sda1", VolumeSize: 50, NoDevice: true},
+			},
+			want: []wantVol{{"/dev/sda1", 8, "gp2", true}},
+		},
+		{
+			name: "a root and two data volumes",
+			mappings: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/xvda", VolumeSize: 60},
+				{DeviceName: "/dev/sdf", VolumeSize: 100, VolumeType: "io2"},
+				{DeviceName: "/dev/sdg", VolumeSize: 200, DeleteOnTermination: "false"},
+			},
+			want: []wantVol{
+				{"/dev/xvda", 60, "gp2", true},
+				{"/dev/sdf", 100, "io2", true},
+				{"/dev/sdg", 200, "gp2", false},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			vols := emulator.LaunchVolumesForTest("i-abc", "us-east-1a", tt.mappings)
+			require.Len(t, vols, len(tt.want))
+			ids := map[string]bool{}
+			for i, want := range tt.want {
+				require.Len(t, vols[i].Attachments, 1, "volume %d", i)
+				assert.Equal(t, want.device, vols[i].Attachments[0].Device)
+				assert.Equal(t, want.size, vols[i].Size)
+				assert.Equal(t, want.volumeType, vols[i].VolumeType)
+				assert.Equal(t, want.deleteOnTermination, vols[i].Attachments[0].DeleteOnTermination)
+				// Every volume gets its own ID; two devices cannot be one volume.
+				assert.False(t, ids[vols[i].VolumeID], "duplicate volume ID")
+				ids[vols[i].VolumeID] = true
+			}
+		})
+	}
+}
+
+// TestEC2LaunchVolumes_CarriesPerformanceMembers pins that iops, throughput,
+// encryption and the snapshot reach the volume, which is the only place they are
+// observable — the attachment shape AWS renders on an instance carries none of them.
+func TestEC2LaunchVolumes_CarriesPerformanceMembers(t *testing.T) {
+	t.Parallel()
+	vols := emulator.LaunchVolumesForTest("i-1", "us-east-1a",
+		[]emulator.EC2BlockDeviceMapping{{
+			DeviceName: "/dev/sda1",
+			VolumeSize: 100,
+			VolumeType: "gp3",
+			IOPS:       4000,
+			Throughput: 250,
+			Encrypted:  true,
+			SnapshotID: "snap-abc",
+		}})
+	require.Len(t, vols, 1)
+	assert.Equal(t, 4000, vols[0].IOPS)
+	assert.Equal(t, 250, vols[0].Throughput)
+	assert.True(t, vols[0].Encrypted)
+	assert.Equal(t, "snap-abc", vols[0].SnapshotID)
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -351,6 +351,12 @@ func (p *EC2Plugin) runInstancesWithTags(
 	// for why that is the lowest device index rather than the first parameter index.
 	networkInterfaces := ec2ParseNetworkInterfaces(req.Params, "")
 	ec2SortInterfacesByDeviceIndex(networkInterfaces)
+
+	// Storage is specified the same way, and was likewise accepted and discarded
+	// until #666: a request naming BlockDeviceMapping.1.Ebs.VolumeSize succeeded and
+	// DescribeVolumes reported nothing for the instance. The mappings become real
+	// volumes in the launch loop below; see [ec2LaunchVolumesFor].
+	blockDeviceMappings := ec2ParseBlockDeviceMappings(req.Params, "")
 	primaryIfc := ec2PrimaryInterface(networkInterfaces)
 	if subnetID == "" && primaryIfc != nil {
 		subnetID = primaryIfc.SubnetID
@@ -431,6 +437,14 @@ func (p *EC2Plugin) runInstancesWithTags(
 		// would let a request that named one interface silently inherit a second.
 		if len(networkInterfaces) == 0 {
 			networkInterfaces = ltData.NetworkInterfaces
+		}
+		// Block device mappings follow the same all-or-nothing rule, for the same
+		// reason: merging per device name would let a request that named one volume
+		// silently inherit a second from the template. A template is also the only
+		// route by which mappings reach a fleet launch, since CreateFleet forwards
+		// the template reference rather than the caller's own mappings.
+		if len(blockDeviceMappings) == 0 {
+			blockDeviceMappings = ltData.BlockDeviceMappings
 		}
 		if sgID == "" && len(securityGroupIDs) > 0 {
 			sgID = securityGroupIDs[0]
@@ -618,6 +632,12 @@ func (p *EC2Plugin) runInstancesWithTags(
 		}
 		// Update instance_ids list.
 		if err := p.appendToList(reqCtx.AccountID+"/"+reqCtx.Region, "instance_ids", inst.InstanceID); err != nil {
+			return nil, err
+		}
+		// Materialize this instance's volumes, after the instance so they can carry
+		// its ID and its zone. Each instance of a multi-count launch gets its own
+		// volumes with their own IDs — two instances cannot share one EBS volume.
+		if err := p.ec2CreateLaunchVolumes(&inst, blockDeviceMappings, now); err != nil {
 			return nil, err
 		}
 		instances = append(instances, inst)
@@ -1086,6 +1106,12 @@ func (p *EC2Plugin) terminateInstances(reqCtx *RequestContext, req *AWSRequest) 
 		}
 		if err := p.state.Put(context.Background(), ec2Namespace, keys[i], newData); err != nil {
 			return nil, fmt.Errorf("ec2 terminateInstances state.Put: %w", err)
+		}
+		// Settle the instance's volumes: delete those whose attachment says to, and
+		// release the rest. A volume left in-use on a terminated instance would be a
+		// state real EC2 never reaches (#666).
+		if err := p.ec2DeleteInstanceVolumes(reqCtx.AccountID, reqCtx.Region, inst.InstanceID); err != nil {
+			return nil, err
 		}
 
 		sc := stateChange{InstanceID: inst.InstanceID}
@@ -4415,12 +4441,13 @@ func parseLaunchTemplateData(params map[string]string) EC2LaunchTemplateData {
 	ec2SortInterfacesByDeviceIndex(interfaces)
 
 	data := EC2LaunchTemplateData{
-		ImageID:           params[ltPrefix+"ImageId"],
-		InstanceType:      params[ltPrefix+"InstanceType"],
-		KeyName:           params[ltPrefix+"KeyName"],
-		UserData:          params[ltPrefix+"UserData"],
-		TagSpecifications: ec2TagSpecificationTags(params, ltPrefix, "instance"),
-		NetworkInterfaces: interfaces,
+		ImageID:             params[ltPrefix+"ImageId"],
+		InstanceType:        params[ltPrefix+"InstanceType"],
+		KeyName:             params[ltPrefix+"KeyName"],
+		UserData:            params[ltPrefix+"UserData"],
+		TagSpecifications:   ec2TagSpecificationTags(params, ltPrefix, "instance"),
+		NetworkInterfaces:   interfaces,
+		BlockDeviceMappings: ec2ParseBlockDeviceMappings(params, ltPrefix),
 	}
 	// The flat fields hold the primary interface's values; see
 	// [EC2LaunchTemplateData.NetworkInterfaces].
@@ -4681,7 +4708,7 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if err != nil {
 		return nil, fmt.Errorf("ec2 createVolume marshal: %w", err)
 	}
-	key := "volume:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + vol.VolumeID
+	key := ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, vol.VolumeID)
 	if err := p.state.Put(context.Background(), ec2Namespace, key, data); err != nil {
 		return nil, fmt.Errorf("ec2 createVolume state.Put: %w", err)
 	}
@@ -4732,10 +4759,21 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 		requestedIDs[id] = true
 	}
 
-	// Collect filter values (volume-id, status, attachment.instance-id).
+	// Collect filter values. The set grew with #666: a launch now materializes its
+	// own volumes, so "which volume is the root of this instance" and "which of
+	// these survive termination" became questions worth asking, and every filter
+	// name below is one AWS's DescribeVolumes reference documents. Names outside
+	// this set are still dropped rather than refused, which is the behavior every
+	// other EC2 filter site has.
 	filterVolumeIDs := map[string]bool{}
 	filterStatuses := map[string]bool{}
 	filterInstanceIDs := map[string]bool{}
+	filterDevices := map[string]bool{}
+	filterDeleteOnTerm := map[string]bool{}
+	filterVolumeTypes := map[string]bool{}
+	filterSizes := map[string]bool{}
+	filterZones := map[string]bool{}
+	filterSnapshotIDs := map[string]bool{}
 	for i := 1; ; i++ {
 		name := req.Params[fmt.Sprintf("Filter.%d.Name", i)]
 		if name == "" {
@@ -4753,11 +4791,23 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 				filterStatuses[val] = true
 			case "attachment.instance-id":
 				filterInstanceIDs[val] = true
+			case "attachment.device":
+				filterDevices[val] = true
+			case "attachment.delete-on-termination":
+				filterDeleteOnTerm[strings.ToLower(val)] = true
+			case "volume-type":
+				filterVolumeTypes[val] = true
+			case "size":
+				filterSizes[val] = true
+			case "availability-zone":
+				filterZones[val] = true
+			case "snapshot-id":
+				filterSnapshotIDs[val] = true
 			}
 		}
 	}
 
-	allKeys, err := p.state.List(context.Background(), ec2Namespace, "volume:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+	allKeys, err := p.state.List(context.Background(), ec2Namespace, ec2VolumeStatePrefix(reqCtx.AccountID, reqCtx.Region))
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeVolumes list: %w", err)
 	}
@@ -4768,17 +4818,24 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 		Device     string `xml:"device"`
 		Status     string `xml:"status"`
 		AttachTime string `xml:"attachTime"`
+		// deleteOnTermination lives here rather than on the volume item because that
+		// is where AWS's own DescribeVolumes response carries it.
+		DeleteOnTermination bool `xml:"deleteOnTermination"`
 	}
 	type volItem struct {
-		VolumeID         string       `xml:"volumeId"`
-		Size             int          `xml:"size"`
-		VolumeType       string       `xml:"volumeType"`
-		AvailabilityZone string       `xml:"availabilityZone"`
-		Status           string       `xml:"status"`
-		Encrypted        bool         `xml:"encrypted"`
-		CreateTime       string       `xml:"createTime"`
-		SnapshotID       string       `xml:"snapshotId"`
-		AttachmentSet    []attachItem `xml:"attachmentSet>item"`
+		VolumeID         string `xml:"volumeId"`
+		Size             int    `xml:"size"`
+		VolumeType       string `xml:"volumeType"`
+		AvailabilityZone string `xml:"availabilityZone"`
+		Status           string `xml:"status"`
+		Encrypted        bool   `xml:"encrypted"`
+		CreateTime       string `xml:"createTime"`
+		SnapshotID       string `xml:"snapshotId"`
+		// iops and throughput were stored and never rendered, so a volume created
+		// with provisioned performance read back as one without it.
+		IOPS          int          `xml:"iops,omitempty"`
+		Throughput    int          `xml:"throughput,omitempty"`
+		AttachmentSet []attachItem `xml:"attachmentSet>item"`
 	}
 	var volumes []volItem
 
@@ -4803,18 +4860,24 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 		if len(filterStatuses) > 0 && !filterStatuses[vol.State] {
 			continue
 		}
-		// Filter by attachment.instance-id.
-		if len(filterInstanceIDs) > 0 {
-			found := false
-			for _, att := range vol.Attachments {
-				if filterInstanceIDs[att.InstanceID] {
-					found = true
-					break
-				}
-			}
-			if !found {
-				continue
-			}
+		// Filter by volume-type, size and availability-zone, all volume-scoped.
+		if len(filterVolumeTypes) > 0 && !filterVolumeTypes[vol.VolumeType] {
+			continue
+		}
+		if len(filterSizes) > 0 && !filterSizes[strconv.Itoa(vol.Size)] {
+			continue
+		}
+		if len(filterZones) > 0 && !filterZones[vol.AvailabilityZone] {
+			continue
+		}
+		if len(filterSnapshotIDs) > 0 && !filterSnapshotIDs[vol.SnapshotID] {
+			continue
+		}
+		// The attachment-scoped filters match when *any* attachment satisfies them,
+		// which is what a filter on a list-valued member means: a volume matches
+		// attachment.device=/dev/sdf when it is attached at that device.
+		if !ec2VolumeMatchesAttachmentFilters(vol, filterInstanceIDs, filterDevices, filterDeleteOnTerm) {
+			continue
 		}
 		item := volItem{
 			VolumeID:         vol.VolumeID,
@@ -4825,14 +4888,17 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 			Encrypted:        vol.Encrypted,
 			CreateTime:       vol.CreateTime,
 			SnapshotID:       vol.SnapshotID,
+			IOPS:             vol.IOPS,
+			Throughput:       vol.Throughput,
 		}
 		for _, att := range vol.Attachments {
 			item.AttachmentSet = append(item.AttachmentSet, attachItem{
-				VolumeID:   vol.VolumeID,
-				InstanceID: att.InstanceID,
-				Device:     att.Device,
-				Status:     att.State,
-				AttachTime: att.AttachTime,
+				VolumeID:            vol.VolumeID,
+				InstanceID:          att.InstanceID,
+				Device:              att.Device,
+				Status:              att.State,
+				AttachTime:          att.AttachTime,
+				DeleteOnTermination: att.DeleteOnTermination,
 			})
 		}
 		volumes = append(volumes, item)
@@ -4859,7 +4925,7 @@ func (p *EC2Plugin) deleteVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if volID == "" {
 		return nil, &AWSError{Code: "InvalidParameterValue", Message: "VolumeId is required", HTTPStatus: http.StatusBadRequest}
 	}
-	key := "volume:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + volID
+	key := ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, volID)
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
 	if err != nil {
 		return nil, fmt.Errorf("ec2 deleteVolume get: %w", err)
@@ -4897,7 +4963,7 @@ func (p *EC2Plugin) attachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if device == "" {
 		device = "/dev/xvdf"
 	}
-	key := "volume:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + volID
+	key := ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, volID)
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
 	if err != nil {
 		return nil, fmt.Errorf("ec2 attachVolume get: %w", err)
@@ -4920,6 +4986,10 @@ func (p *EC2Plugin) attachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		Device:     device,
 		State:      "attached",
 		AttachTime: attachTime,
+		// AWS preserves a volume attached after launch: deleting one the caller
+		// brought would destroy something the launch did not make. Only a volume a
+		// launch creates defaults the other way; see [ec2LaunchVolumesFor].
+		DeleteOnTermination: false,
 	}}
 
 	newData, err := json.Marshal(vol)
@@ -4931,21 +5001,23 @@ func (p *EC2Plugin) attachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	}
 
 	type response struct {
-		XMLName    xml.Name `xml:"AttachVolumeResponse"`
-		XMLNS      string   `xml:"xmlns,attr"`
-		VolumeID   string   `xml:"volumeId"`
-		InstanceID string   `xml:"instanceId"`
-		Device     string   `xml:"device"`
-		Status     string   `xml:"status"`
-		AttachTime string   `xml:"attachTime"`
+		XMLName             xml.Name `xml:"AttachVolumeResponse"`
+		XMLNS               string   `xml:"xmlns,attr"`
+		VolumeID            string   `xml:"volumeId"`
+		InstanceID          string   `xml:"instanceId"`
+		Device              string   `xml:"device"`
+		Status              string   `xml:"status"`
+		AttachTime          string   `xml:"attachTime"`
+		DeleteOnTermination bool     `xml:"deleteOnTermination"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{
-		XMLNS:      "http://ec2.amazonaws.com/doc/2016-11-15/",
-		VolumeID:   volID,
-		InstanceID: instanceID,
-		Device:     device,
-		Status:     "attached",
-		AttachTime: attachTime,
+		XMLNS:               "http://ec2.amazonaws.com/doc/2016-11-15/",
+		VolumeID:            volID,
+		InstanceID:          instanceID,
+		Device:              device,
+		Status:              "attached",
+		AttachTime:          attachTime,
+		DeleteOnTermination: false,
 	})
 }
 
@@ -4954,7 +5026,7 @@ func (p *EC2Plugin) detachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if volID == "" {
 		return nil, &AWSError{Code: "InvalidParameterValue", Message: "VolumeId is required", HTTPStatus: http.StatusBadRequest}
 	}
-	key := "volume:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + volID
+	key := ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, volID)
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
 	if err != nil {
 		return nil, fmt.Errorf("ec2 detachVolume get: %w", err)

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -765,6 +765,58 @@ type EC2LaunchTemplateData struct {
 	// other, so the choice is substrate's, made for consistency with the call-level
 	// path rather than from the reference.
 	IamInstanceProfile string `json:"iamInstanceProfile,omitempty"`
+
+	// BlockDeviceMappings holds every BlockDeviceMapping.N the template declares.
+	//
+	// A template is the only way block device mappings reach a fleet launch:
+	// CreateFleet and RequestSpotFleet build their RunInstances parameters from the
+	// fleet request, forwarding the launch template reference rather than the
+	// caller's own mappings.
+	BlockDeviceMappings []EC2BlockDeviceMapping `json:"blockDeviceMappings,omitempty"`
+}
+
+// EC2BlockDeviceMapping is one BlockDeviceMapping.N entry of a launch request or a
+// launch template, as AWS's BlockDeviceMapping and EbsBlockDevice shapes define it.
+type EC2BlockDeviceMapping struct {
+	// DeviceName is the device the volume is exposed as (e.g. "/dev/sdh").
+	DeviceName string `json:"device_name,omitempty"`
+
+	// VirtualName names an instance store volume ("ephemeral0"…"ephemeral23"). No
+	// EBS volume is created for such an entry: an instance store device is not an
+	// EBS volume, and manufacturing one would be an observation nothing backs.
+	VirtualName string `json:"virtual_name,omitempty"`
+
+	// NoDevice suppresses a device the AMI's own mapping would otherwise include.
+	NoDevice bool `json:"no_device,omitempty"`
+
+	// SnapshotID is the snapshot the volume is restored from, if any.
+	SnapshotID string `json:"snapshot_id,omitempty"`
+
+	// VolumeSize is the size in GiB. AWS documents it as required unless a snapshot
+	// is named, in which case the snapshot's size is the default.
+	VolumeSize int `json:"volume_size,omitempty"`
+
+	// VolumeType is the EBS volume type. An absent value resolves to gp2 —
+	// substrate's own choice, matching CreateVolume's documented default;
+	// EbsBlockDevice documents none. See [ec2LaunchVolumesFor].
+	VolumeType string `json:"volume_type,omitempty"`
+
+	// IOPS is the provisioned IOPS, for io1/io2/gp3.
+	IOPS int `json:"iops,omitempty"`
+
+	// Throughput is the provisioned throughput in MiB/s, for gp3.
+	Throughput int `json:"throughput,omitempty"`
+
+	// Encrypted reports whether the volume is encrypted.
+	Encrypted bool `json:"encrypted,omitempty"`
+
+	// DeleteOnTermination is the raw parameter value rather than a bool, because
+	// three states are observable and a bool collapses two of them: absent (take
+	// the launch default, which is true), "true", and "false". Storing a bool here
+	// would make a mapping that explicitly preserves its volume indistinguishable
+	// from one that said nothing — the same reason
+	// [EC2LaunchTemplateData.AssociatePublicIPAddress] keeps its string.
+	DeleteOnTermination string `json:"delete_on_termination,omitempty"`
 }
 
 // NetworkSecurityGroupIDs returns the security groups a launch from this template
@@ -887,6 +939,21 @@ type EC2VolumeAttachment struct {
 
 	// AttachTime is the RFC3339 time the volume was attached.
 	AttachTime string `json:"attach_time"`
+
+	// DeleteOnTermination reports whether terminating the instance deletes the
+	// volume. It lives on the attachment rather than on the volume because that is
+	// where AWS renders it — DescribeVolumes' attachmentSet>item carries a
+	// deleteOnTermination member, and the volume item itself does not — and because
+	// the value describes this attachment: detaching and reattaching a volume
+	// resets it to the post-launch default.
+	//
+	// AWS's default depends on how the attachment came about, not on what the
+	// volume is. Anything attached after launch preserves on termination; a volume
+	// a launch creates is deleted, root and data volumes alike, when the launch
+	// came through the API rather than the console. Substrate is an API emulator,
+	// so a launch defaults this to true and AttachVolume defaults it to false. See
+	// [ec2LaunchVolumesFor].
+	DeleteOnTermination bool `json:"delete_on_termination"`
 }
 
 // EC2Volume represents an Amazon EBS volume.
@@ -914,6 +981,11 @@ type EC2Volume struct {
 
 	// IOPS is the provisioned IOPS (for io1/io2/gp3 volumes).
 	IOPS int `json:"iops,omitempty"`
+
+	// Throughput is the provisioned throughput in MiB/s. AWS supports it on gp3
+	// alone; substrate records whatever a request supplies rather than refusing it
+	// elsewhere, since no throughput validation is modeled.
+	Throughput int `json:"throughput,omitempty"`
 
 	// Attachments holds the current instance attachments.
 	Attachments []EC2VolumeAttachment `json:"attachments,omitempty"`

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -726,3 +726,23 @@ func (p IAMScalarParamsForTest) IAMScalarValuesForTest() (int, bool) {
 // body-decoding path — including the parameter-naming error message — is testable
 // from package emulator_test.
 func ParseIAMBodyForTest(body []byte, dst any) error { return parseIAMBody(body, dst) }
+
+// ParseBlockDeviceMappingsForTest wraps ec2ParseBlockDeviceMappings so the
+// BlockDeviceMapping.N reader is testable in isolation, including the prefix that
+// lets one parser serve both RunInstances and a launch template (#666).
+func ParseBlockDeviceMappingsForTest(params map[string]string, prefix string) []EC2BlockDeviceMapping {
+	return ec2ParseBlockDeviceMappings(params, prefix)
+}
+
+// LaunchVolumesForTest wraps ec2LaunchVolumesFor, taking the two instance fields the
+// resolution actually reads rather than a whole EC2Instance, so a test states only
+// what it is asserting about.
+func LaunchVolumesForTest(instanceID, availabilityZone string, mappings []EC2BlockDeviceMapping) []EC2Volume {
+	inst := &EC2Instance{
+		InstanceID:       instanceID,
+		AvailabilityZone: availabilityZone,
+		AccountID:        "123456789012",
+		Region:           "us-east-1",
+	}
+	return ec2LaunchVolumesFor(inst, mappings, "2026-01-01T00:00:00Z")
+}

--- a/test/e2e/journey_ec2_block_devices_test.go
+++ b/test/e2e/journey_ec2_block_devices_test.go
@@ -1,0 +1,114 @@
+package e2e_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_EC2LaunchBlockDeviceMappings is #666's journey, and it belongs at this
+// tier because this tier is where the issue was reported from: a consumer launching an
+// instance with a 60 GiB root volume, asking DescribeVolumes about it, and getting
+// nothing back. test/e2e had no EBS coverage at all, which is part of why.
+//
+// The SDK is the right reader for it. BlockDeviceMappings is a structured input the
+// SDK serializes into BlockDeviceMapping.1.Ebs.VolumeSize itself, so a hand-built form
+// body proves only that substrate parses the spelling this test's author chose. And
+// Volume.Size is where the value has to land: AWS's EbsInstanceBlockDevice — the shape
+// DescribeInstances renders per device — carries no size member, so DescribeVolumes is
+// the sole API surface on which a launch-specified size is observable.
+func TestJourney_EC2LaunchBlockDeviceMappings(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	client := ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	ctx := context.Background()
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-0abcdef1234567890"),
+		InstanceType: ec2types.InstanceTypeT3Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/xvda"),
+			Ebs:        &ec2types.EbsBlockDevice{VolumeSize: aws.Int32(60)},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	if len(run.Instances) != 1 {
+		t.Fatalf("RunInstances returned %d instances, want 1", len(run.Instances))
+	}
+	instanceID := aws.ToString(run.Instances[0].InstanceId)
+	if instanceID == "" {
+		t.Fatal("RunInstances returned an empty instance ID")
+	}
+
+	// Filtered on the instance rather than listing everything, so the assertion holds
+	// whatever else the emulator happens to hold.
+	byInstance := &ec2.DescribeVolumesInput{
+		Filters: []ec2types.Filter{{
+			Name:   aws.String("attachment.instance-id"),
+			Values: []string{instanceID},
+		}},
+	}
+	described, err := client.DescribeVolumes(ctx, byInstance)
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+	// One volume, not two: /dev/xvda is a root device name, so the mapping configures
+	// the root volume rather than adding a device beside a synthesized one.
+	if len(described.Volumes) != 1 {
+		t.Fatalf("DescribeVolumes returned %d volumes, want 1", len(described.Volumes))
+	}
+	vol := described.Volumes[0]
+	if got := aws.ToInt32(vol.Size); got != 60 {
+		t.Fatalf("Volume.Size = %d, want 60 — the size the launch asked for", got)
+	}
+	if vol.State != ec2types.VolumeStateInUse {
+		t.Fatalf("Volume.State = %q, want in-use", vol.State)
+	}
+	if len(vol.Attachments) != 1 {
+		t.Fatalf("Volume has %d attachments, want 1", len(vol.Attachments))
+	}
+	att := vol.Attachments[0]
+	if got := aws.ToString(att.Device); got != "/dev/xvda" {
+		t.Fatalf("attachment Device = %q, want /dev/xvda", got)
+	}
+	if got := aws.ToString(att.InstanceId); got != instanceID {
+		t.Fatalf("attachment InstanceId = %q, want %q", got, instanceID)
+	}
+	// True is AWS's launch default for a volume created through the API — its
+	// termination table splits on how the volume was attached, and the console path a
+	// consumer might expect Preserve from does not exist here.
+	if !aws.ToBool(att.DeleteOnTermination) {
+		t.Fatal("attachment DeleteOnTermination = false, want true for a launch-created volume")
+	}
+
+	if _, err := client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instanceID},
+	}); err != nil {
+		t.Fatalf("TerminateInstances: %v", err)
+	}
+
+	// Parsing the mapping without honoring termination would leave this volume
+	// reporting in-use on a terminated instance forever, which is a state real EC2
+	// never reaches.
+	after, err := client.DescribeVolumes(ctx, byInstance)
+	if err != nil {
+		t.Fatalf("DescribeVolumes after terminate: %v", err)
+	}
+	if len(after.Volumes) != 0 {
+		t.Fatalf("DescribeVolumes after terminate returned %d volumes, want 0",
+			len(after.Volumes))
+	}
+}


### PR DESCRIPTION
`RunInstances` accepted `BlockDeviceMapping.N.*` and parsed none of it.
`runInstancesWithTags` read thirteen parameter groups and no block device mapping was
among them, so a request naming a 60 GiB `/dev/xvda` root volume succeeded and
`DescribeVolumes` reported nothing for the instance — substrate silently accepting a
parameter it did not model, the shape #97 exists to remove.

The value was not merely hidden, it was **unreachable**. AWS's
`EbsInstanceBlockDevice` — the shape an instance renders per device — carries
`volumeId`, `attachTime`, `deleteOnTermination` and `status`, but no size. So
`DescribeVolumes` is the only API surface on which a launch-specified size can be
observed at all, which is why exposing `blockDeviceMapping` on `DescribeInstances`
would not have closed this.

## What changed

A launch now materializes real `EC2Volume` records in the same `volume:` namespace
`CreateVolume` writes to, each attached to the new instance, so `DescribeVolumes` is
the single source of truth for provisioned and launch-created volumes alike — how
real EC2 unifies the two.

- **`emulator/ec2_block_devices.go`** (new) — the parser and the materializer.
  `ec2ParseBlockDeviceMappings(params, prefix)` follows `ec2ParseNetworkInterfaces`'
  idiom exactly: 1-indexed, contiguous, terminating on a `present` bool that ORs
  every member, with the `prefix` argument that lets one parser serve `RunInstances`
  (`""`) and `CreateLaunchTemplate` (`"LaunchTemplateData."`).
- **Termination is honored.** `TerminateInstances` deletes a volume whose attachment
  deletes on termination and makes one that does not `available` with no attachment.
  This half is what made the parsing safe to land: without it a volume would report
  `deleteOnTermination=true` while sitting `in-use` on a terminated instance forever
  — a state real EC2 never reaches, a new inaccuracy in place of the old silence.
- **`iops` and `throughput` reach the wire.** `EC2Volume` already stored `IOPS` and
  never rendered it; `Throughput` had nowhere to be stored.
- **`DescribeVolumes` gained six filters** — `attachment.device`,
  `attachment.delete-on-termination`, `volume-type`, `size`, `availability-zone`,
  `snapshot-id` — beside the three it had. Each is one the reference documents, and
  each is a question the new state makes answerable.
- **`AttachVolume`** sets and renders `deleteOnTermination: false` explicitly.
- **A fleet** reaches mappings through its launch template, which now carries them;
  `ec2_fleet.go` needed no change because `CreateFleet` forwards the template
  reference rather than the caller's own parameters.

## The two decisions, and the evidence

**Every launch produces at least one volume.** A real instance always has a root
volume whether or not the request mentions one, and `DescribeImages` already reported
an 8 GiB `/dev/sda1` mapping for every AMI substrate serves, so producing none left
the two disagreeing about the same instance. Root devices are recognized by name:
`/dev/sda1` and `/dev/xvda`, the two spellings AWS's device-naming reference gives
for the HVM root ("Differs by AMI"). Recognizing only `/dev/sda1` would have answered
this issue's own `/dev/xvda` repro with **two** volumes — a 60 GiB one plus a spurious
8 GiB root.

**`DeleteOnTermination` defaults to `true` for data volumes too.** Counter-intuitive,
and AWS's documented behaviour: the `preserving-volumes-on-termination` table splits
on *how* the volume was attached, not on what it is — a data volume attached at
launch through the **console** preserves, but through the **CLI** it is deleted, and
an API emulator is the CLI path. `AttachVolume` keeps the other default, `false`.

Two things AWS does not settle, recorded rather than papered over: `EbsBlockDevice`
documents no `VolumeType` default (substrate uses `gp2`, matching `CreateVolume`, so
there is one default in one place — real AMIs specify `gp3` in a mapping substrate's
AMIs do not carry); and `EC2Image` stores no per-AMI root device, so an AMI whose
real root device is neither documented spelling is out of reach, which `docs/services.md`
now says.

## Deliberately out of scope

`blockDeviceMapping` on `DescribeInstances` / `DescribeInstanceAttribute` (the shape
carries no size, so it would not answer the question this does); `Ebs.KmsKeyId` (left
out rather than stored and hidden); volume tag specifications, which are a
`CreateVolume` parity gap; and `InvalidBlockDeviceMapping` validation, which needed
this state to exist first. Follow-ups filed against v0.104.0.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues),
`make test` (race), `make coverage` (82.1% total, `emulator` 82.7%),
`make docs-reference-check docs-versions`, `npm --prefix docs run build`,
`go vet -C test/e2e ./... && go test -C test/e2e ./...` — all green.

**New tests.** `emulator/ec2_block_devices_test.go` covers the parser and materializer
in isolation (25 cases). `emulator/ec2_block_devices_http_test.go` covers nine
scenarios through HTTP, unmarshalling the response into a struct rather than searching
the body for `vol-` — the existing volume tests' `strings.Index` idiom cannot tell two
volumes apart, and a launch now routinely produces two. `test/e2e/journey_ec2_block_devices_test.go`
is the tier this was reported from, and `test/e2e` had no EBS coverage at all; it goes
through the real SDK, because `BlockDeviceMappings` is a structured input the SDK
serializes itself, so a hand-built form body proves only that substrate parses the
spelling the test's author chose.

**Mutation pass**, nine targets, full-package `go test -race` per mutant with a
`gofmt`/`go vet` gate: **8 CAUGHT, 1 EQUIVALENT, 0 survivors that matter.**

| Mutant | Verdict |
|---|---|
| `ec2LaunchVolumesFor` returns nil (the bug itself) | CAUGHT (6 tests) |
| the implicit root volume is dropped | CAUGHT (6 tests) |
| `DeleteOnTermination` defaults to `false` | CAUGHT (6 tests) |
| the root-device check tests only `/dev/sda1` | CAUGHT (6 tests) |
| the volume's AZ comes from `region+"a"` | CAUGHT |
| `terminateInstances` deletes every attached volume regardless of the flag | CAUGHT (2 tests) |
| the parser stops at index 1 | CAUGHT (6 tests) |
| `"pricing"` maps to `errProtoQueryXML` (#653's guard) | CAUGHT (6 tests) |
| the `volume_ids` index is not cleaned on termination | **EQUIVALENT** |

The EQUIVALENT one, disclosed rather than glossed: `volume_ids` is a **write-only**
index. `createVolume` and the new launch path append to it and `deleteVolume` removes
from it, but nothing reads it — `describeVolumes` lists the `volume:` key prefix
directly. So no API observation can distinguish the mutant, and no test can catch it
without asserting on state rather than behaviour. The removal call stays because
`deleteVolume` makes it, and a stale entry would become wrong the moment something
does read it. (A test comment claiming the index was what the assertion proved has
been corrected to say what it actually proves: the record left the namespace
`DescribeVolumes` lists.)

**Live run** through the AWS CLI on `:4678`, the issue's repro verbatim:

```
$ aws ec2 run-instances --image-id ami-0abcdef1234567890 --instance-type t3.micro \
    --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":60}}]'
$ aws ec2 describe-volumes --filters Name=attachment.instance-id,Values=i-b54e18579dcf3cc8
    "VolumeType": "gp2", "Size": 60, "State": "in-use",
    "Attachments": [{"DeleteOnTermination": true, "Device": "/dev/xvda", "State": "attached"}]
$ aws ec2 terminate-instances --instance-ids i-b54e18579dcf3cc8   # terminated
$ aws ec2 describe-volumes --filters Name=attachment.instance-id,Values=i-b54e18579dcf3cc8
    {"Volumes": []}
```

And the data-volume path, showing the synthesized root beside it and the performance
members on the wire:

```
+-----------+--------+-------+-------+--------+--------+
|    Dev    |  DoT   | Iops  | Size  | Tput   | Type   |
+-----------+--------+-------+-------+--------+--------+
|  /dev/sdf |  False |  4000 |  100  |  250   |  gp3   |
|  /dev/sda1|  True  |  None |  8    |  None  |  gp2   |
+-----------+--------+-------+-------+--------+--------+
```

after terminate, the preserved one alone: `vol-45f7b9d0…  100  available  0 attachments`.

## Compatibility

**`DescribeVolumes` now returns volumes for launched instances.** A fixture that
listed all volumes and expected only what it created with `CreateVolume` will see a
root volume per instance — filter by `volume-id` or `attachment.instance-id` for the
old answer. `TerminateInstances` now deletes those volumes; a fixture that terminated
an instance and then read a volume attached at launch will find it gone unless it set
`DeleteOnTermination: false`. A volume attached **after** launch is untouched by
termination, per AWS.

Closes #666
