### PR TITLE
fix(ec2,iam): a launch is authorized against every resource it names (#662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`ec2:RunInstances` was authorized against one resource ARN a launch never carries, so an
+  ARN-scoped `Deny` had no effect** (#662). `buildResourceARN`'s `ec2` arm derived its ARN from
+  `InstanceId.1` — a parameter no launch request has — so every `RunInstances` was decided
+  against the literal string `"*"`. The Service Authorization Reference marks **five** required
+  resource types for the action (`image`, `instance`, `network-interface`, `security-group`,
+  `subnet`) and evaluates the caller's policies against every one of them.
+
+  Resolving to `"*"` broke the decision in both directions, because `resourceMatches` passes the
+  *statement's* `Resource` entry to `globMatch` as the pattern and the request's resource as the
+  value. A policy allowing the action on `"*"` beside a `Deny` scoped to one subnet, AMI or
+  security-group ARN matched the `Allow` and never the `Deny`: a guardrail written to keep
+  workloads out of a private or shared subnet read as a boundary and was not one. In the other
+  direction, a least-privilege policy naming exactly the five documented ARNs matched nothing,
+  so it refused every launch — the error a consumer would hit first, and the one that makes the
+  false allow look like the safe configuration.
+
+  A launch now resolves every resource it names — the AMI, the subnet, each security group, each
+  network interface it brings by ID, and the instance — and all of the caller's policies must
+  allow the action against all of them, with the permission boundary applied to each. Each ARN
+  is matched against the tags of the resource it names, so an `aws:ResourceTag` condition
+  written about the subnet cannot be satisfied by a tag on the AMI. The denial names the first
+  resource the policies do not allow, in a fixed order of image, subnet, security groups,
+  network interfaces, instance, which is the only place the missing ARN surfaces. The AMI's ARN
+  carries no account ID, the format the reference gives, because an AMI is shareable; the
+  instance and a launch-created interface are wildcards, since neither ID exists when the
+  decision is made. Resources a launch template supplies are authorized as if the request had
+  named them, under the same field-by-field precedence the launch itself uses — AWS states this
+  rule only in `CreateFleet`'s description — and a template that cannot be read contributes
+  nothing rather than turning a missing template into a denial. A resource the request omits is
+  skipped rather than resolved to `"*"`, which would widen the policy the caller wrote, and a
+  request naming none of them is decided exactly as it was before, as is every other EC2
+  operation.
+
+  **Compatibility:** a `RunInstances` request that an ARN-scoped `Deny` previously allowed is
+  now denied — that is the false allow being closed. A least-privilege policy naming the five
+  required ARNs previously denied every launch and now permits one. A policy allowing the action
+  on `"*"` with no `Deny` is unaffected, and callers whose credentials resolve to no IAM entity
+  remain unenforced. Not covered, and documented as such: `volume` and the launch-template ARN
+  (neither is marked required for the action), the EC2 condition keys, a launch whose subnet and
+  security group come from the default VPC — resolved after the decision — and the fleet path,
+  which never reaches the authorization pipeline.
+
 ## [v0.103.0] - 2026-08-20
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -3041,6 +3041,70 @@ Not modeled: `Ebs.KmsKeyId` (left out rather than stored and hidden),
 explicit-refusal list, since the shape it would render carries no size and so would
 not answer the question `DescribeVolumes` now does.
 
+### A launch is authorized against every resource it names
+
+`RunInstances` is the EC2 action the Service Authorization Reference marks with the
+most required resource types — **`image`, `instance`, `network-interface`,
+`security-group` and `subnet`** — and the caller's policies are evaluated against
+every one of them. A policy that allows `ec2:RunInstances` on the AMI and the
+instance but not the subnet cannot launch into that subnet, and, in the other
+direction, an ARN-scoped `Deny` on one subnet, AMI or security group fences off
+every launch that reaches it. That is what a policy written to keep workloads out of
+a shared or private subnet depends on.
+
+A permission boundary is applied to every one of those resources too, since a
+boundary checked against a subset is not a boundary. Each ARN is matched against the
+tags of the resource *it* names, so an `aws:ResourceTag` condition written about the
+subnet cannot be satisfied by a tag on the AMI. The denial names the first resource
+the policies do not allow — resolved in a fixed order of image, subnet, security
+groups, network interfaces, instance — which is the only place the missing ARN
+surfaces, and so the ARN a caller has to add.
+
+The AMI's ARN carries **no account ID** (`arn:aws:ec2:{region}::image/{ami}`),
+which is the format the Service Authorization Reference gives, because an AMI is
+shareable. The other four are `arn:aws:ec2:{region}:{account}:{type}/{id}`. Two of
+them name resources that do not exist when the decision is made, so they are
+wildcards: the instance is always `instance/*`, and an interface the launch creates
+is `network-interface/*`, while one the request brings by ID is named. The cost of
+that is a real limit — a policy scoped to `instance/i-*` matches on AWS and not
+here, because the statement is the pattern and `*` is the value it is matched
+against.
+
+Resources a [launch template](#a-launch-template-merges-with-the-request-field-by-field)
+supplies are authorized as if the request had named them, under the same
+field-by-field precedence the launch itself uses, so a policy scoped to one subnet
+fences off a launch that reaches another through a template. AWS states this only in
+`CreateFleet`'s description: "Resource-level permissions for this action do not
+include the resources specified in a launch template. To specify resource-level
+permissions for resources specified in a launch template, you must include the
+resources in the RunInstances action statement." A template that cannot be read
+contributes nothing to the resource list rather than failing the request, so a
+missing template still answers `InvalidLaunchTemplateId.NotFound` rather than a
+denial.
+
+A resource the request does not name is skipped, not resolved to `*` — `*` for an
+unknown resource would widen the policy the caller wrote instead of narrowing it.
+A request that names none of them at all is decided against a single `*`, as every
+other EC2 operation is.
+
+Not covered:
+
+- **`volume`.** Its asterisk appears only inside the reference's scenario rows,
+  never on the action's own resource list, and the ID does not exist until the
+  launch runs. Requiring it would refuse a policy naming exactly the five
+  documented types.
+- **The launch-template ARN**, which the reference does not mark required for
+  `RunInstances` — so requiring it would refuse the same policy.
+- **The EC2 condition keys** (`ec2:InstanceType`, `ec2:Vpc`,
+  `ec2:IsLaunchTemplateResource` and the rest). Resource resolution is what this
+  covers; the condition keys substrate does populate are the `aws:`-prefixed ones.
+- **A launch that names no subnet and no security group**, whose defaults are
+  resolved from the default VPC *after* the authorization decision. A policy scoped
+  to one subnet cannot fence off such a launch.
+- **The [fleet](#seeding-ec2-fleet-partial-fulfillment) path**, which launches
+  instances internally without going through the API's authorization pipeline, so no
+  policy applies to it.
+
 ### Instance attributes
 
 `DescribeInstanceAttribute` reads one attribute off an instance. It is the only way

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -84,9 +84,9 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	addRequestTags(requestTags, req)
 
 	// Every resource the request names must be allowed. A request naming several —
-	// organizations:MoveAccount is substrate's only one — is denied unless the
-	// caller's policies admit all of them, which is how AWS evaluates a statement
-	// against "every resource that is required" for the action (#660).
+	// organizations:MoveAccount and ec2:RunInstances — is denied unless the caller's
+	// policies admit all of them, which is how AWS evaluates a statement against
+	// "every resource that is required" for the action (#660, #662).
 	for _, res := range resources {
 		condCtx := make(map[string]string, len(requestTags)+len(res.Tags))
 		for k, v := range requestTags {
@@ -500,10 +500,19 @@ type authzResource struct {
 //
 // Almost every AWS operation names one resource, and for those this returns
 // exactly one pair — [buildResourceARN] plus the tags [AuthController.addResourceTags]
-// reads. `organizations:MoveAccount` is substrate's only exception: it names an
-// account, a source parent and a destination parent, all three marked required by
-// the Service Authorization Reference, and authorizing against one of them
-// over-permitted a policy scoped to the other two (#660).
+// reads. Two operations are exceptions:
+//
+//   - `organizations:MoveAccount` names an account, a source parent and a
+//     destination parent, all three marked required by the Service Authorization
+//     Reference, and authorizing against one of them over-permitted a policy
+//     scoped to the other two (#660).
+//   - `ec2:RunInstances` names an AMI, a subnet, security groups and network
+//     interfaces alongside the instance it creates — five required resource
+//     types, the most of any EC2 action — and was decided against a single ARN
+//     built from InstanceId.1, which a launch never carries (#662).
+//
+// Each exception is gated on len(multi) > 0, which is what keeps every other
+// operation of those two services on the single-resource path below.
 //
 // The list is never empty. An empty list would skip the decision loop entirely
 // and allow the request, which is the one direction a privilege boundary must
@@ -511,6 +520,11 @@ type authzResource struct {
 func (a *AuthController) buildResourceARNs(reqCtx *RequestContext, req *AWSRequest) []authzResource {
 	if req.Service == organizationsNamespace {
 		if multi := orgAuthzMoveAccountResources(a.state, reqCtx, req); len(multi) > 0 {
+			return multi
+		}
+	}
+	if req.Service == "ec2" {
+		if multi := ec2AuthzRunInstancesResources(a.state, reqCtx, req); len(multi) > 0 {
 			return multi
 		}
 	}
@@ -538,6 +552,10 @@ func (a *AuthController) buildResourceARN(reqCtx *RequestContext, req *AWSReques
 	case "iam":
 		return "arn:aws:iam::" + acct + ":*"
 	case "ec2":
+		// RunInstances does not reach here: it names five resources and is resolved
+		// by [ec2AuthzRunInstancesResources] (#662). What is left is the operations
+		// that name an instance by ID — and everything else, including a CreateTags
+		// naming several ResourceId.N, which still resolves to "*".
 		if id := req.Params["InstanceId.1"]; id != "" {
 			return "arn:aws:ec2:" + region + ":" + acct + ":instance/" + id
 		}

--- a/emulator/ec2_authz.go
+++ b/emulator/ec2_authz.go
@@ -1,0 +1,211 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ec2AuthzRunInstancesResources returns every resource a RunInstances request
+// names, each paired with its own tags. It returns nil for every other EC2
+// operation, which is what sends them down buildResourceARNs' single-resource
+// path.
+//
+// RunInstances is the EC2 action the Service Authorization Reference marks with
+// the most required resource types — image*, instance*, network-interface*,
+// security-group* and subnet* — and AWS evaluates the entire statement against
+// every one of them. Substrate authorized it against a single ARN derived from
+// InstanceId.1, a parameter a launch never carries, so every launch was decided
+// against the literal string "*" (#662).
+//
+// That broke in both directions. resourceMatches passes the statement's own
+// Resource entry to globMatch as the *pattern*, so "*" as the request resource
+// matches only a statement whose Resource begins with "*": a least-privilege
+// policy naming the five ARNs could not grant a launch at all, and a broad Allow
+// on "*" beside an ARN-scoped Deny ignored the Deny entirely — a guardrail
+// written to fence off a subnet, AMI or security group was silently inert.
+//
+// Order is fixed: image, subnet, security groups, network interfaces, instance.
+// The first resource a policy does not allow is the one the denial names, so a
+// fixed order makes that message deterministic and the decision replay-stable.
+// Request-named resources come first because those are the ARNs a caller can act
+// on; the two synthesized wildcards come last.
+//
+// A member the request omits is skipped rather than resolved to "*": "*" for an
+// absent ID would widen the policy the caller wrote instead of narrowing it. A
+// request naming none of them returns nil, so it is decided exactly as it was
+// before.
+func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, req *AWSRequest) []authzResource {
+	if req.Operation != "RunInstances" {
+		return nil
+	}
+	launch := ec2AuthzResolveLaunch(state, reqCtx, req)
+	if launch.empty() {
+		return nil
+	}
+
+	acct := reqCtx.AccountID
+	region := reqCtx.Region
+	var out []authzResource
+
+	if launch.imageID != "" {
+		out = append(out, authzResource{
+			// No account field. The Service Authorization Reference gives the image
+			// ARN as arn:${Partition}:ec2:${Region}::image/${ImageId}, and an AMI is
+			// shareable, so the field is empty rather than omitted by accident. It has
+			// to stay empty: arnAccountID reads an empty account as "no account", not
+			// as "this account", and a policy naming the ARN AWS documents would not
+			// match one carrying an account ID.
+			ARN:  "arn:aws:ec2:" + region + "::image/" + launch.imageID,
+			Tags: ec2AuthzTagsFor(state, ec2ImageStateKey(acct, region, launch.imageID)),
+		})
+	}
+	if launch.subnetID != "" {
+		out = append(out, authzResource{
+			ARN:  "arn:aws:ec2:" + region + ":" + acct + ":subnet/" + launch.subnetID,
+			Tags: ec2AuthzTagsFor(state, "subnet:"+acct+"/"+region+"/"+launch.subnetID),
+		})
+	}
+	for _, sgID := range launch.securityGroupIDs {
+		out = append(out, authzResource{
+			ARN:  "arn:aws:ec2:" + region + ":" + acct + ":security-group/" + sgID,
+			Tags: ec2AuthzTagsFor(state, "sg:"+acct+"/"+region+"/"+sgID),
+		})
+	}
+	// Every launch attaches an interface, so network-interface* is always evaluated.
+	// An interface the launch creates has no ID yet, so it is the wildcard; one the
+	// request brings by ID is named, because a policy can meaningfully scope to it.
+	// Neither carries tags: substrate stores no standalone taggable ENI record, and
+	// ec2TaggableStateKey has no eni- arm to read one through.
+	if len(launch.networkInterfaceIDs) == 0 {
+		out = append(out, authzResource{ARN: "arn:aws:ec2:" + region + ":" + acct + ":network-interface/*"})
+	}
+	for _, eniID := range launch.networkInterfaceIDs {
+		out = append(out, authzResource{ARN: "arn:aws:ec2:" + region + ":" + acct + ":network-interface/" + eniID})
+	}
+	// The instance does not exist yet, so its ARN is the wildcard AWS's own
+	// least-privilege RunInstances examples write. Including it is what makes a
+	// policy that omits instance* a denial, which is the answer real AWS gives.
+	out = append(out, authzResource{ARN: "arn:aws:ec2:" + region + ":" + acct + ":instance/*"})
+
+	return out
+}
+
+// ec2AuthzLaunchMembers is the set of resources one RunInstances request names.
+//
+// Network interfaces hold only the IDs of interfaces the request brings, not the
+// ones the launch creates: an interface with no ID is not a resource a policy can
+// name.
+type ec2AuthzLaunchMembers struct {
+	imageID             string
+	subnetID            string
+	securityGroupIDs    []string
+	networkInterfaceIDs []string
+}
+
+// empty reports whether the request named no resource at all, in which case
+// authorization falls back to the single-resource path unchanged.
+func (m ec2AuthzLaunchMembers) empty() bool {
+	return m.imageID == "" && m.subnetID == "" &&
+		len(m.securityGroupIDs) == 0 && len(m.networkInterfaceIDs) == 0
+}
+
+// ec2AuthzResolveLaunch resolves the resources a RunInstances request names,
+// reading them exactly as [EC2Plugin.runInstancesWithTags] does so the decision
+// and the handler cannot disagree about which resources a launch touches: the
+// same parameter spellings, the same primary-interface fallbacks, and the same
+// all-or-nothing launch-template precedence.
+//
+// The template has to be resolved here rather than inherited from the handler,
+// because CheckAccess runs before the handler does. AWS's CreateFleet reference
+// is the authority for consulting it at all: "Resource-level permissions for this
+// action do not include the resources specified in a launch template. To specify
+// resource-level permissions for resources specified in a launch template, you
+// must include the resources in the RunInstances action statement." So a
+// template-supplied subnet is part of a RunInstances decision, and a policy
+// scoped to one subnet must fence off a launch that reaches it through a
+// template.
+//
+// A template that cannot be read contributes nothing rather than failing the
+// request. The handler decides whether an unresolvable template is an error; this
+// is the resource list, and refusing here would answer a missing template with
+// AccessDenied instead of the InvalidLaunchTemplateId.NotFound it earns.
+func ec2AuthzResolveLaunch(state StateManager, reqCtx *RequestContext, req *AWSRequest) ec2AuthzLaunchMembers {
+	m := ec2AuthzLaunchMembers{
+		imageID:  req.Params["ImageId"],
+		subnetID: req.Params["SubnetId"],
+	}
+
+	interfaces := ec2ParseNetworkInterfaces(req.Params, "")
+	primary := ec2PrimaryInterface(interfaces)
+	if m.subnetID == "" && primary != nil {
+		m.subnetID = primary.SubnetID
+	}
+	m.securityGroupIDs = indexedParams(req.Params, "SecurityGroupId.%d", "SecurityGroupIds.%d")
+	if len(m.securityGroupIDs) == 0 && primary != nil {
+		m.securityGroupIDs = primary.SecurityGroupIDs
+	}
+	m.networkInterfaceIDs = ec2AuthzInterfaceIDs(interfaces)
+
+	lt := ec2LookupLaunchTemplate(context.Background(), state, reqCtx,
+		req.Params["LaunchTemplate.LaunchTemplateId"],
+		req.Params["LaunchTemplate.LaunchTemplateName"])
+	if lt == nil {
+		return m
+	}
+	version, awsErr := ec2ResolveTemplateVersion(lt, req.Params["LaunchTemplate.Version"])
+	if awsErr != nil || version == nil {
+		return m
+	}
+	data := version.Data
+	if m.imageID == "" {
+		m.imageID = data.ImageID
+	}
+	if m.subnetID == "" {
+		m.subnetID = data.SubnetID
+	}
+	if len(m.securityGroupIDs) == 0 {
+		m.securityGroupIDs = data.NetworkSecurityGroupIDs()
+	}
+	// All-or-nothing, matching the handler: the template's interfaces apply only
+	// when the request declared none, so a request naming one interface is not
+	// authorized against a second it will never attach.
+	if len(interfaces) == 0 {
+		m.networkInterfaceIDs = ec2AuthzInterfaceIDs(data.NetworkInterfaces)
+	}
+	return m
+}
+
+// ec2AuthzInterfaceIDs returns the IDs of the interfaces the launch attaches by
+// ID, dropping the ones it creates.
+func ec2AuthzInterfaceIDs(interfaces []EC2NetworkInterface) []string {
+	var out []string
+	for _, ifc := range interfaces {
+		if ifc.NetworkInterfaceID != "" {
+			out = append(out, ifc.NetworkInterfaceID)
+		}
+	}
+	return out
+}
+
+// ec2AuthzTagsFor returns the tags stored on the EC2 record at key, or nil when
+// it cannot be read.
+//
+// nil rather than a partial map on a failed read: an absent aws:ResourceTag key
+// denies a condition that requires it, whereas a fabricated one would let a
+// storage fault grant access. Every EC2 record this reads — image, subnet,
+// security group — carries its tags under the same "Tags" member, so one reader
+// serves all three and the ARN a resource is authorized under cannot drift from
+// the tags it is matched against.
+func ec2AuthzTagsFor(state StateManager, key string) map[string]string {
+	raw, err := state.Get(context.Background(), ec2Namespace, key)
+	if err != nil || raw == nil {
+		return nil
+	}
+	var record struct {
+		Tags []EC2Tag `json:"tags"`
+	}
+	if json.Unmarshal(raw, &record) != nil {
+		return nil
+	}
+	return ec2TagsToMap(record.Tags)
+}

--- a/emulator/ec2_authz_test.go
+++ b/emulator/ec2_authz_test.go
@@ -1,0 +1,756 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The authorization decision for ec2:RunInstances (#662).
+//
+// RunInstances names five required resource types — image*, instance*,
+// network-interface*, security-group* and subnet* — and was decided against a
+// single ARN built from InstanceId.1, a parameter a launch never carries. Every
+// launch therefore resolved to the literal string "*".
+//
+// These tests pin both directions that broke, because "*" as the *request*
+// resource is not a wildcard: resourceMatches passes the statement's Resource
+// entry to globMatch as the pattern, so "*" matched only a statement whose own
+// Resource begins with "*". An ARN-scoped Deny never matched and was silently
+// inert; a least-privilege Allow naming the five ARNs never matched either and
+// denied every launch.
+
+const (
+	ec2AuthzAccount = "123456789012"
+	ec2AuthzRegion  = "us-east-1"
+	ec2AuthzAMI     = "ami-0abcdef1234567890"
+	ec2AuthzSubnet  = "subnet-0aaa11112222bbbb3"
+	ec2AuthzSG      = "sg-0ccc44445555dddd6"
+)
+
+// ec2AuthzFixture is an EC2 state store plus an AuthController over the same
+// store, which is what makes a resource-tag condition testable: the tag has to
+// travel from the EC2 namespace into the condition context under the ARN it
+// belongs to.
+type ec2AuthzFixture struct {
+	state emulator.StateManager
+	auth  *emulator.AuthController
+	user  string
+}
+
+// the five ARNs a launch naming an AMI, a subnet and one security group is
+// authorized against, in the order the decision builds them.
+var (
+	ec2AuthzImageARN  = "arn:aws:ec2:" + ec2AuthzRegion + "::image/" + ec2AuthzAMI
+	ec2AuthzSubnetARN = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":subnet/" + ec2AuthzSubnet
+	ec2AuthzSGARN     = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":security-group/" + ec2AuthzSG
+	ec2AuthzENIARN    = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":network-interface/*"
+	ec2AuthzInstARN   = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":instance/*"
+)
+
+// ec2AuthzAllFive is every ARN a launch requires, which is what a least-privilege
+// RunInstances policy has to name.
+func ec2AuthzAllFive() []string {
+	return []string{ec2AuthzImageARN, ec2AuthzSubnetARN, ec2AuthzSGARN, ec2AuthzENIARN, ec2AuthzInstARN}
+}
+
+// newEC2AuthzFixture builds a user carrying one policy plus the AMI, subnet and
+// security group a launch names, each tagged as given.
+func newEC2AuthzFixture(t *testing.T, user string, doc emulator.PolicyDocument) *ec2AuthzFixture {
+	t.Helper()
+	policyARN := "arn:aws:iam::" + ec2AuthzAccount + ":policy/RunInstances-" + user
+	state := newAuthTestState(t, user, policyARN, doc)
+	f := &ec2AuthzFixture{
+		state: state,
+		auth:  emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false)),
+		user:  user,
+	}
+	f.putImage(t, ec2AuthzAMI, nil)
+	f.putSubnet(t, ec2AuthzSubnet, nil)
+	f.putSecurityGroup(t, ec2AuthzSG, nil)
+	return f
+}
+
+// put writes one EC2 record under key. Records are written directly rather than
+// through the plugin: the decision reads state, and a plugin call would drag a
+// launch's own authorization into the fixture for it.
+func (f *ec2AuthzFixture) put(t *testing.T, key string, record any) {
+	t.Helper()
+	raw, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", key, err)
+	}
+	if err := f.state.Put(context.Background(), "ec2", key, raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store %s: %v", key, err)
+	}
+}
+
+func (f *ec2AuthzFixture) putImage(t *testing.T, id string, tags map[string]string) {
+	t.Helper()
+	f.put(t, "image:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+id, emulator.EC2Image{
+		ImageID:   id,
+		AccountID: ec2AuthzAccount,
+		Region:    ec2AuthzRegion,
+		Tags:      ec2AuthzTags(tags),
+	})
+}
+
+func (f *ec2AuthzFixture) putSubnet(t *testing.T, id string, tags map[string]string) {
+	t.Helper()
+	f.put(t, "subnet:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+id, emulator.EC2Subnet{
+		SubnetID: id,
+		Tags:     ec2AuthzTags(tags),
+	})
+}
+
+func (f *ec2AuthzFixture) putSecurityGroup(t *testing.T, id string, tags map[string]string) {
+	t.Helper()
+	f.put(t, "sg:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+id, emulator.EC2SecurityGroup{
+		GroupID: id,
+		Tags:    ec2AuthzTags(tags),
+	})
+}
+
+// ec2AuthzTags converts a map to the []EC2Tag shape the records store, in no
+// particular order — a condition context is a map, so order cannot matter.
+func ec2AuthzTags(tags map[string]string) []emulator.EC2Tag {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]emulator.EC2Tag, 0, len(tags))
+	for k, v := range tags {
+		out = append(out, emulator.EC2Tag{Key: k, Value: v})
+	}
+	return out
+}
+
+// launch runs one RunInstances request through the authorization decision.
+//
+// Params, not Body: EC2 is a query-protocol service, so every resource a launch
+// names arrives as a form parameter.
+func (f *ec2AuthzFixture) launch(t *testing.T, params map[string]string) error {
+	t.Helper()
+	return f.call(t, "RunInstances", params)
+}
+
+// call runs one EC2 request through the authorization decision.
+func (f *ec2AuthzFixture) call(t *testing.T, operation string, params map[string]string) error {
+	t.Helper()
+	reqCtx := newAuthTestReqCtx("arn:aws:iam::" + ec2AuthzAccount + ":user/" + f.user)
+	return f.auth.CheckAccess(reqCtx, &emulator.AWSRequest{
+		Service:   "ec2",
+		Operation: operation,
+		Path:      "/",
+		Params:    params,
+	})
+}
+
+// nominalLaunch is a launch naming an AMI, a subnet and one security group — the
+// shape a consumer's RunInstances actually takes, and the one whose five ARNs the
+// tests below add to and subtract from.
+func nominalLaunch() map[string]string {
+	return map[string]string{
+		"ImageId":           ec2AuthzAMI,
+		"InstanceType":      "t3.micro",
+		"MinCount":          "1",
+		"MaxCount":          "1",
+		"SubnetId":          ec2AuthzSubnet,
+		"SecurityGroupId.1": ec2AuthzSG,
+	}
+}
+
+// setPolicy rewrites the user's single attached policy so its statements are
+// exactly those given, which is how a test scopes a decision to a list of ARNs
+// rather than to "*".
+func (f *ec2AuthzFixture) setPolicy(t *testing.T, statements ...emulator.PolicyStatement) {
+	t.Helper()
+	arn := "arn:aws:iam::" + ec2AuthzAccount + ":policy/RunInstances-" + f.user
+	pol := emulator.IAMPolicy{
+		PolicyName:       "runinstances",
+		PolicyID:         "ANPARUN",
+		ARN:              arn,
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document:         emulator.PolicyDocument{Version: "2012-10-17", Statement: statements},
+	}
+	raw, err := json.Marshal(pol)
+	if err != nil {
+		t.Fatalf("marshal policy: %v", err)
+	}
+	if err := f.state.Put(context.Background(), "iam", "policy:"+arn, raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store policy: %v", err)
+	}
+}
+
+// ec2AuthzStatement builds one statement over the RunInstances action.
+func ec2AuthzStatement(effect string, resources ...string) emulator.PolicyStatement {
+	return emulator.PolicyStatement{
+		Effect:   effect,
+		Action:   emulator.StringOrSlice{"ec2:RunInstances"},
+		Resource: emulator.StringOrSlice(resources),
+	}
+}
+
+// ec2AuthzDenied reports whether err is the denial an EC2 caller sees.
+//
+// EC2 speaks the query protocol with its own XML error shape, so the code is the
+// bare "AccessDenied" — not the "Exception"-suffixed spelling the JSON-RPC
+// services use. An SDK dispatches on that string, so it is the load-bearing half.
+func ec2AuthzDenied(t *testing.T, err error) bool {
+	t.Helper()
+	if err == nil {
+		return false
+	}
+	var awsErr *emulator.AWSError
+	if !errors.As(err, &awsErr) {
+		t.Fatalf("expected an *AWSError, got %T: %v", err, err)
+	}
+	if awsErr.Code != "AccessDenied" {
+		t.Errorf("expected AccessDenied, got %q", awsErr.Code)
+	}
+	if awsErr.HTTPStatus != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", awsErr.HTTPStatus)
+	}
+	return true
+}
+
+// TestEC2_Authz_RunInstancesScopedDenyBlocks is the decisive test: the false
+// allow #662 reports.
+//
+// A policy that allows ec2:RunInstances on "*" while denying it on one subnet is
+// the standard guardrail shape — "launch anywhere except the private subnet". It
+// had no effect at all. The launch resolved to the resource "*", the Deny's
+// Resource named a subnet ARN, and globMatch was asked whether the pattern
+// "arn:…:subnet/subnet-private" matches the value "*" — it does not, so the Deny
+// never applied and the guardrail was silently inert.
+func TestEC2_Authz_RunInstancesScopedDenyBlocks(t *testing.T) {
+	f := newEC2AuthzFixture(t, "ivan", emulator.PolicyDocument{})
+	f.setPolicy(t,
+		ec2AuthzStatement("Allow", "*"),
+		ec2AuthzStatement("Deny", ec2AuthzSubnetARN),
+	)
+
+	err := f.launch(t, nominalLaunch())
+	if !ec2AuthzDenied(t, err) {
+		t.Fatal("a Deny scoped to the launch's subnet ARN did not block the launch")
+	}
+	assert.Equal(t, ec2AuthzSubnetARN, deniedResource(t, err),
+		"the denial names the subnet the Deny scoped to")
+}
+
+// TestEC2_Authz_ScopedDenyOnEachResourceBlocks covers the same guardrail written
+// about each of the three resources a request names by ID. All three were inert.
+func TestEC2_Authz_ScopedDenyOnEachResourceBlocks(t *testing.T) {
+	for _, arn := range []string{ec2AuthzImageARN, ec2AuthzSubnetARN, ec2AuthzSGARN} {
+		t.Run(arn, func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "judy", emulator.PolicyDocument{})
+			f.setPolicy(t, ec2AuthzStatement("Allow", "*"), ec2AuthzStatement("Deny", arn))
+
+			err := f.launch(t, nominalLaunch())
+			if !ec2AuthzDenied(t, err) {
+				t.Fatalf("a Deny scoped to %s did not block the launch", arn)
+			}
+			assert.Equal(t, arn, deniedResource(t, err))
+		})
+	}
+}
+
+// TestEC2_Authz_LeastPrivilegePolicyAllows is the other direction the single-ARN
+// resolution broke: a policy naming exactly the five ARNs AWS requires denied
+// every launch, because "arn:…:image/ami-…" as a pattern does not match the value
+// "*" either. Writing the policy AWS's own documentation calls for made the
+// emulator refuse the call.
+func TestEC2_Authz_LeastPrivilegePolicyAllows(t *testing.T) {
+	f := newEC2AuthzFixture(t, "karl", emulator.PolicyDocument{})
+	f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzAllFive()...))
+
+	require.NoError(t, f.launch(t, nominalLaunch()),
+		"a policy naming every required ARN must permit the launch")
+}
+
+// TestEC2_Authz_OmittingAnyRequiredResourceDenies pins that all five must be
+// allowed, and that the denial names the one that was not — the message is the
+// only place the failing resource surfaces, so it is what tells a caller which
+// ARN to add.
+func TestEC2_Authz_OmittingAnyRequiredResourceDenies(t *testing.T) {
+	all := ec2AuthzAllFive()
+	for i, missing := range all {
+		t.Run(missing, func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "lena", emulator.PolicyDocument{})
+			kept := make([]string, 0, len(all)-1)
+			kept = append(kept, all[:i]...)
+			kept = append(kept, all[i+1:]...)
+			f.setPolicy(t, ec2AuthzStatement("Allow", kept...))
+
+			err := f.launch(t, nominalLaunch())
+			if !ec2AuthzDenied(t, err) {
+				t.Fatalf("a policy omitting %s allowed the launch", missing)
+			}
+			assert.Equal(t, missing, deniedResource(t, err),
+				"the denial names the ARN the policy omitted")
+		})
+	}
+}
+
+// TestEC2_Authz_ResourceTagsPairWithTheirOwnResource is why authzResource carries
+// tags per ARN rather than one merged map.
+//
+// The condition is written about the resource being evaluated, so a tag on the
+// AMI cannot satisfy a condition checked against the subnet. One merged map would
+// let any tagged resource in the request satisfy the condition for all of them —
+// a false allow, and the reason the decision loop builds a fresh condCtx per
+// resource.
+func TestEC2_Authz_ResourceTagsPairWithTheirOwnResource(t *testing.T) {
+	newFixture := func(t *testing.T) *ec2AuthzFixture {
+		t.Helper()
+		doc := newABACPolicy("Allow", "ec2:RunInstances", "*", "aws:ResourceTag/Env", "test")
+		return newEC2AuthzFixture(t, "mona", doc)
+	}
+	const good = "test"
+	const bad = "prod"
+
+	t.Run("every resource tagged is allowed", func(t *testing.T) {
+		f := newFixture(t)
+		f.putImage(t, ec2AuthzAMI, map[string]string{"Env": good})
+		f.putSubnet(t, ec2AuthzSubnet, map[string]string{"Env": good})
+		f.putSecurityGroup(t, ec2AuthzSG, map[string]string{"Env": good})
+		// The instance and network-interface ARNs carry no tags — they do not exist
+		// yet — so the condition cannot be met for them. The launch names its own
+		// resources, so a tag-gated policy has to allow those two unconditionally,
+		// which is what the second statement does.
+		f.setPolicy(t,
+			emulator.PolicyStatement{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice{"ec2:RunInstances"},
+				Resource: emulator.StringOrSlice{ec2AuthzImageARN, ec2AuthzSubnetARN, ec2AuthzSGARN},
+				Condition: map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {"aws:ResourceTag/Env": {good}},
+				},
+			},
+			ec2AuthzStatement("Allow", ec2AuthzENIARN, ec2AuthzInstARN),
+		)
+		require.NoError(t, f.launch(t, nominalLaunch()))
+	})
+
+	tagged := map[string]func(*ec2AuthzFixture, *testing.T, string){
+		ec2AuthzImageARN: func(f *ec2AuthzFixture, t *testing.T, v string) {
+			f.putImage(t, ec2AuthzAMI, map[string]string{"Env": v})
+		},
+		ec2AuthzSubnetARN: func(f *ec2AuthzFixture, t *testing.T, v string) {
+			f.putSubnet(t, ec2AuthzSubnet, map[string]string{"Env": v})
+		},
+		ec2AuthzSGARN: func(f *ec2AuthzFixture, t *testing.T, v string) {
+			f.putSecurityGroup(t, ec2AuthzSG, map[string]string{"Env": v})
+		},
+	}
+	for arn, mistag := range tagged {
+		t.Run("mistagging "+arn+" denies", func(t *testing.T) {
+			f := newFixture(t)
+			for other, tag := range tagged {
+				if other == arn {
+					continue
+				}
+				tag(f, t, good)
+			}
+			mistag(f, t, bad)
+			f.setPolicy(t,
+				emulator.PolicyStatement{
+					Effect:   "Allow",
+					Action:   emulator.StringOrSlice{"ec2:RunInstances"},
+					Resource: emulator.StringOrSlice{ec2AuthzImageARN, ec2AuthzSubnetARN, ec2AuthzSGARN},
+					Condition: map[string]map[string]emulator.StringOrSlice{
+						"StringEquals": {"aws:ResourceTag/Env": {good}},
+					},
+				},
+				ec2AuthzStatement("Allow", ec2AuthzENIARN, ec2AuthzInstARN),
+			)
+			err := f.launch(t, nominalLaunch())
+			if !ec2AuthzDenied(t, err) {
+				t.Fatalf("a %s tagged Env=%s satisfied a condition requiring Env=%s", arn, bad, good)
+			}
+			assert.Equal(t, arn, deniedResource(t, err))
+		})
+	}
+}
+
+// TestEC2_Authz_PermissionBoundaryCoversEveryResource pins the boundary against
+// every resource rather than only the first.
+//
+// This is the mutation #660's testing found surviving: moving the boundary check
+// out of the per-resource loop still passed every test that existed, because a
+// boundary that refuses the *first* resource refuses the request either way. The
+// boundary here allows the AMI and denies the subnet, so only a check that
+// reaches the second resource catches it.
+func TestEC2_Authz_PermissionBoundaryCoversEveryResource(t *testing.T) {
+	f := newEC2AuthzFixture(t, "nina", emulator.PolicyDocument{})
+	f.setPolicy(t, ec2AuthzStatement("Allow", "*"))
+
+	boundaryARN := "arn:aws:iam::" + ec2AuthzAccount + ":policy/LaunchBoundary"
+	boundary := emulator.IAMPolicy{
+		PolicyName:       "LaunchBoundary",
+		PolicyID:         "ANPABOUND",
+		ARN:              boundaryARN,
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document: emulator.PolicyDocument{
+			Version: "2012-10-17",
+			// Everything except the subnet, which is the second resource evaluated.
+			Statement: []emulator.PolicyStatement{
+				ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzSGARN, ec2AuthzENIARN, ec2AuthzInstARN),
+			},
+		},
+	}
+	raw, err := json.Marshal(boundary)
+	require.NoError(t, err)
+	require.NoError(t, f.state.Put(context.Background(), "iam", "policy:"+boundaryARN, raw))
+
+	user := emulator.IAMUser{
+		UserName:            "nina",
+		UserID:              "AIDATEST",
+		ARN:                 "arn:aws:iam::" + ec2AuthzAccount + ":user/nina",
+		Path:                "/",
+		PermissionsBoundary: &emulator.IAMAttachedPolicy{PolicyARN: boundaryARN, PolicyName: "LaunchBoundary"},
+	}
+	userRaw, err := json.Marshal(user)
+	require.NoError(t, err)
+	require.NoError(t, f.state.Put(context.Background(), "iam", "user:nina", userRaw))
+
+	launchErr := f.launch(t, nominalLaunch())
+	if !ec2AuthzDenied(t, launchErr) {
+		t.Fatal("a boundary refusing the launch's subnet did not block it")
+	}
+	var awsErr *emulator.AWSError
+	require.ErrorAs(t, launchErr, &awsErr)
+	assert.Contains(t, awsErr.Message, "permission boundary")
+}
+
+// TestEC2_Authz_AbsentMembersAreSkipped pins that a resource the request does not
+// name is left out rather than resolved to "*".
+//
+// "*" for an absent ID would widen the policy the caller wrote: a statement
+// naming only "*" would then satisfy a launch that named no subnet, which is the
+// direction a privilege boundary must never fail in.
+func TestEC2_Authz_AbsentMembersAreSkipped(t *testing.T) {
+	t.Run("an AMI-only launch names three resources", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "omar", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzENIARN, ec2AuthzInstARN))
+		require.NoError(t, f.launch(t, map[string]string{
+			"ImageId":  ec2AuthzAMI,
+			"MinCount": "1",
+			"MaxCount": "1",
+		}), "no subnet and no security group were named, so neither is required")
+	})
+
+	t.Run("the AMI is still required", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "omar", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzENIARN, ec2AuthzInstARN))
+		err := f.launch(t, map[string]string{"ImageId": ec2AuthzAMI, "MinCount": "1", "MaxCount": "1"})
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a policy omitting the AMI allowed a launch that named it")
+		}
+		assert.Equal(t, ec2AuthzImageARN, deniedResource(t, err))
+	})
+
+	t.Run("a launch naming nothing falls back unchanged", func(t *testing.T) {
+		// No resource at all, so there is nothing to authorize against and the
+		// single-resource path decides it exactly as it did before this change: the
+		// ec2 arm of buildResourceARN, with no InstanceId.1, resolves to "*".
+		f := newEC2AuthzFixture(t, "omar", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"))
+		require.NoError(t, f.launch(t, map[string]string{"MinCount": "1", "MaxCount": "1"}))
+
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzInstARN))
+		err := f.launch(t, map[string]string{"MinCount": "1", "MaxCount": "1"})
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a launch naming no resource is decided against \"*\", which an ARN-scoped policy does not match")
+		}
+		assert.Equal(t, "*", deniedResource(t, err))
+	})
+}
+
+// TestEC2_Authz_NestedNetworkInterfaceFormResolves covers the shape the AWS SDK
+// actually sends. Whenever a public-IP preference is set the SDK moves SubnetId
+// and the security groups inside NetworkInterface.1, so reading only the
+// top-level parameters would authorize such a launch against neither.
+func TestEC2_Authz_NestedNetworkInterfaceFormResolves(t *testing.T) {
+	nested := map[string]string{
+		"ImageId":                        ec2AuthzAMI,
+		"MinCount":                       "1",
+		"MaxCount":                       "1",
+		"NetworkInterface.1.DeviceIndex": "0",
+		"NetworkInterface.1.SubnetId":    ec2AuthzSubnet,
+		"NetworkInterface.1.Groups.1":    ec2AuthzSG,
+		"NetworkInterface.1.AssociatePublicIpAddress": "true",
+	}
+
+	t.Run("the nested subnet is required", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "pia", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"), ec2AuthzStatement("Deny", ec2AuthzSubnetARN))
+		err := f.launch(t, nested)
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a Deny on the subnet named inside NetworkInterface.1 did not block the launch")
+		}
+		assert.Equal(t, ec2AuthzSubnetARN, deniedResource(t, err))
+	})
+
+	t.Run("the five ARNs are the same as the top-level form", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "pia", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzAllFive()...))
+		require.NoError(t, f.launch(t, nested))
+	})
+
+	t.Run("an interface brought by ID is named, not wildcarded", func(t *testing.T) {
+		const eniID = "eni-0eee77778888ffff9"
+		byID := map[string]string{
+			"ImageId":                               ec2AuthzAMI,
+			"MinCount":                              "1",
+			"MaxCount":                              "1",
+			"NetworkInterface.1.DeviceIndex":        "0",
+			"NetworkInterface.1.NetworkInterfaceId": eniID,
+		}
+		eniARN := "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":network-interface/" + eniID
+
+		f := newEC2AuthzFixture(t, "pia", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"), ec2AuthzStatement("Deny", eniARN))
+		err := f.launch(t, byID)
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a Deny on the ENI the launch attaches did not block it")
+		}
+		assert.Equal(t, eniARN, deniedResource(t, err))
+
+		// And the wildcard is not also evaluated: a policy naming the specific ENI
+		// suffices, so an existing interface does not require network-interface/*.
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, eniARN, ec2AuthzInstARN))
+		require.NoError(t, f.launch(t, byID))
+	})
+}
+
+// TestEC2_Authz_LaunchTemplateResourcesAreAuthorized pins that a launch reaching
+// its subnet through a template is authorized against that subnet.
+//
+// AWS's CreateFleet reference is the authority: "Resource-level permissions for
+// this action do not include the resources specified in a launch template. To
+// specify resource-level permissions for resources specified in a launch
+// template, you must include the resources in the RunInstances action
+// statement." So the template's resources are part of a RunInstances decision,
+// and a guardrail scoped to one subnet has to fence off a template that reaches
+// it — otherwise a template is a way around the policy.
+func TestEC2_Authz_LaunchTemplateResourcesAreAuthorized(t *testing.T) {
+	const ltID = "lt-0aaa1111bbbb2222c"
+	const ltName = "launch-into-private"
+	newFixture := func(t *testing.T) *ec2AuthzFixture {
+		t.Helper()
+		f := newEC2AuthzFixture(t, "quinn", emulator.PolicyDocument{})
+		lt := emulator.EC2LaunchTemplate{
+			LaunchTemplateID:   ltID,
+			LaunchTemplateName: ltName,
+			DefaultVersionNum:  1,
+			LatestVersionNum:   1,
+			Versions: []emulator.EC2LaunchTemplateVersion{{
+				VersionNumber: 1,
+				Data: emulator.EC2LaunchTemplateData{
+					ImageID:                ec2AuthzAMI,
+					SubnetID:               ec2AuthzSubnet,
+					NetworkInterfaceGroups: []string{ec2AuthzSG},
+				},
+			}},
+		}
+		f.put(t, "lt:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ltID, lt)
+		if err := f.state.Put(context.Background(), "ec2", //nolint:contextcheck
+			"lt_by_name:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ltName, []byte(ltID)); err != nil {
+			t.Fatalf("store lt_by_name: %v", err)
+		}
+		return f
+	}
+	byName := map[string]string{
+		"MinCount":                          "1",
+		"MaxCount":                          "1",
+		"LaunchTemplate.LaunchTemplateName": ltName,
+	}
+
+	t.Run("by name, a Deny on the template's subnet blocks the launch", func(t *testing.T) {
+		f := newFixture(t)
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"), ec2AuthzStatement("Deny", ec2AuthzSubnetARN))
+		err := f.launch(t, byName)
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a template was a way around a subnet-scoped Deny")
+		}
+		assert.Equal(t, ec2AuthzSubnetARN, deniedResource(t, err))
+	})
+
+	t.Run("by ID, the same five ARNs are required", func(t *testing.T) {
+		f := newFixture(t)
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzAllFive()...))
+		require.NoError(t, f.launch(t, map[string]string{
+			"MinCount":                        "1",
+			"MaxCount":                        "1",
+			"LaunchTemplate.LaunchTemplateId": ltID,
+		}))
+	})
+
+	t.Run("the request's own AMI wins over the template's", func(t *testing.T) {
+		// AWS: "Any additional parameters that you specify for the new instance
+		// overwrite the corresponding parameters included in the launch template." So
+		// the decision has to be about the AMI the launch will actually use.
+		const ownAMI = "ami-00000000000000001"
+		f := newFixture(t)
+		f.putImage(t, ownAMI, nil)
+		ownARN := "arn:aws:ec2:" + ec2AuthzRegion + "::image/" + ownAMI
+		params := map[string]string{
+			"MinCount":                          "1",
+			"MaxCount":                          "1",
+			"ImageId":                           ownAMI,
+			"LaunchTemplate.LaunchTemplateName": ltName,
+		}
+
+		f.setPolicy(t, ec2AuthzStatement("Allow", ownARN, ec2AuthzSubnetARN, ec2AuthzSGARN, ec2AuthzENIARN, ec2AuthzInstARN))
+		require.NoError(t, f.launch(t, params))
+
+		// The template's AMI is not required, because the launch will not use it.
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"), ec2AuthzStatement("Deny", ec2AuthzImageARN))
+		require.NoError(t, f.launch(t, params),
+			"a Deny on the template's AMI must not block a launch that overrode it")
+	})
+
+	t.Run("an unresolvable template contributes nothing", func(t *testing.T) {
+		// The handler answers a missing template with InvalidLaunchTemplateId.NotFound.
+		// The decision must not turn that into AccessDenied, so an unreadable template
+		// adds no resources rather than failing the request.
+		f := newFixture(t)
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzENIARN, ec2AuthzInstARN))
+		require.NoError(t, f.launch(t, map[string]string{
+			"ImageId":                           ec2AuthzAMI,
+			"MinCount":                          "1",
+			"MaxCount":                          "1",
+			"LaunchTemplate.LaunchTemplateName": "no-such-template",
+		}))
+	})
+}
+
+// TestEC2_Authz_MultipleSecurityGroupsEachRequireAllowing pins that every group
+// is evaluated, not just the first. A policy allowing one group and not the other
+// must refuse the launch, or "may only use the approved security group" is not
+// expressible.
+func TestEC2_Authz_MultipleSecurityGroupsEachRequireAllowing(t *testing.T) {
+	const secondSG = "sg-0999888877776666a"
+	secondARN := "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":security-group/" + secondSG
+
+	f := newEC2AuthzFixture(t, "rita", emulator.PolicyDocument{})
+	f.putSecurityGroup(t, secondSG, nil)
+	params := nominalLaunch()
+	params["SecurityGroupId.2"] = secondSG
+
+	f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzAllFive()...))
+	err := f.launch(t, params)
+	if !ec2AuthzDenied(t, err) {
+		t.Fatal("a second security group the policy does not name allowed the launch")
+	}
+	assert.Equal(t, secondARN, deniedResource(t, err))
+
+	f.setPolicy(t, ec2AuthzStatement("Allow", append(ec2AuthzAllFive(), secondARN)...))
+	require.NoError(t, f.launch(t, params))
+}
+
+// TestEC2_Authz_ImageARNCarriesNoAccountID pins the one ARN whose account field
+// is empty.
+//
+// The Service Authorization Reference gives the image ARN as
+// arn:${Partition}:ec2:${Region}::image/${ImageId} — an AMI is shareable, so the
+// account field is empty by design rather than by omission. It has to stay empty:
+// arnAccountID reads an empty account as "no account" rather than as "this
+// account", and a policy naming the ARN AWS documents would not match one
+// carrying an account ID.
+func TestEC2_Authz_ImageARNCarriesNoAccountID(t *testing.T) {
+	f := newEC2AuthzFixture(t, "sami", emulator.PolicyDocument{})
+	f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzAllFive()...))
+	require.NoError(t, f.launch(t, nominalLaunch()))
+
+	assert.Equal(t, "arn:aws:ec2:us-east-1::image/"+ec2AuthzAMI, ec2AuthzImageARN,
+		"the ARN the decision builds has an empty account field")
+	assert.NotContains(t, strings.TrimPrefix(ec2AuthzImageARN, "arn:aws:ec2:us-east-1:"), ec2AuthzAccount)
+
+	// The account-scoped spelling must not be what the decision uses: a policy
+	// naming it does not grant the launch.
+	withAccount := "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":image/" + ec2AuthzAMI
+	f.setPolicy(t, ec2AuthzStatement("Allow", withAccount, ec2AuthzSubnetARN, ec2AuthzSGARN, ec2AuthzENIARN, ec2AuthzInstARN))
+	err := f.launch(t, nominalLaunch())
+	if !ec2AuthzDenied(t, err) {
+		t.Fatal("an account-scoped image ARN granted a launch, so the decision is not using AWS's format")
+	}
+	assert.Equal(t, ec2AuthzImageARN, deniedResource(t, err))
+}
+
+// TestEC2_Authz_SingleResourceOperationsAreUnchanged pins that only RunInstances
+// takes the multi-resource path. Every other EC2 operation keeps the decision it
+// had before #662 — this change is about resolving a launch's resources, not
+// about tightening EC2 as a whole.
+func TestEC2_Authz_SingleResourceOperationsAreUnchanged(t *testing.T) {
+	instanceARN := "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":instance/i-0abc"
+	tests := []struct {
+		name      string
+		operation string
+		params    map[string]string
+		resource  string
+	}{
+		{
+			"DescribeInstances by ID names the instance",
+			"DescribeInstances",
+			map[string]string{"InstanceId.1": "i-0abc"},
+			instanceARN,
+		},
+		{
+			"TerminateInstances by ID names the instance",
+			"TerminateInstances",
+			map[string]string{"InstanceId.1": "i-0abc"},
+			instanceARN,
+		},
+		{
+			// CreateTags naming several resources still resolves to one ARN; that is
+			// the follow-up #662 scopes out, and this row records today's answer.
+			"CreateTags resolves to \"*\"",
+			"CreateTags",
+			map[string]string{"ResourceId.1": ec2AuthzSubnet, "ResourceId.2": ec2AuthzSG},
+			"*",
+		},
+		{
+			"DescribeVolumes resolves to \"*\"",
+			"DescribeVolumes",
+			map[string]string{"VolumeId.1": "vol-0abc"},
+			"*",
+		},
+		{
+			// Not RunInstances, and it names an AMI — the gate is on the operation, so
+			// this must not pick up the launch resolver.
+			"CreateImage resolves to \"*\"",
+			"CreateImage",
+			map[string]string{"ImageId": ec2AuthzAMI, "Name": "snap"},
+			"*",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "toni", emulator.PolicyDocument{})
+			// An action-only Deny with no Resource scoping refuses whatever the
+			// decision resolves, so the message reports the single ARN it built.
+			f.setPolicy(t, emulator.PolicyStatement{
+				Effect:   "Deny",
+				Action:   emulator.StringOrSlice{"ec2:" + tt.operation},
+				Resource: emulator.StringOrSlice{"*"},
+			})
+			err := f.call(t, tt.operation, tt.params)
+			require.Error(t, err)
+			assert.Equal(t, tt.resource, deniedResource(t, err))
+		})
+	}
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -4385,20 +4385,33 @@ func (p *EC2Plugin) describeSpotPriceHistory(reqCtx *RequestContext, req *AWSReq
 // resolveLaunchTemplate looks up a launch template by ID or name and returns it,
 // or nil if not found.
 func (p *EC2Plugin) resolveLaunchTemplate(goCtx context.Context, ctx *RequestContext, ltID, ltName string) *EC2LaunchTemplate {
+	return ec2LookupLaunchTemplate(goCtx, p.state, ctx, ltID, ltName)
+}
+
+// ec2LookupLaunchTemplate reads a launch template by ID or name, or returns nil
+// when neither is given or the record cannot be read.
+//
+// A free function over the StateManager rather than a method, because the
+// authorization decision needs it too: CheckAccess runs before the handler, so
+// [ec2AuthzRunInstancesResources] has to resolve the template itself to know which
+// subnet and security groups a launch reaches through one (#662). Two readers of
+// the same two keys could drift about which template a request names, and then a
+// policy would be evaluated against resources the launch does not use.
+func ec2LookupLaunchTemplate(goCtx context.Context, state StateManager, ctx *RequestContext, ltID, ltName string) *EC2LaunchTemplate {
 	if ltID == "" && ltName == "" {
 		return nil
 	}
 	if ltID == "" {
 		// Look up ID by name.
 		nameKey := "lt_by_name:" + ctx.AccountID + "/" + ctx.Region + "/" + ltName
-		data, err := p.state.Get(goCtx, ec2Namespace, nameKey)
+		data, err := state.Get(goCtx, ec2Namespace, nameKey)
 		if err != nil || data == nil {
 			return nil
 		}
 		ltID = string(data)
 	}
 	key := "lt:" + ctx.AccountID + "/" + ctx.Region + "/" + ltID
-	data, err := p.state.Get(goCtx, ec2Namespace, key)
+	data, err := state.Get(goCtx, ec2Namespace, key)
 	if err != nil || data == nil {
 		return nil
 	}

--- a/test/e2e/journey_ec2_runinstances_authz_test.go
+++ b/test/e2e/journey_ec2_runinstances_authz_test.go
@@ -1,0 +1,227 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/smithy-go"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_EC2RunInstancesSubnetGuardrail is #662 at the tier the guardrail is
+// actually written at: a policy that allows ec2:RunInstances everywhere except one
+// subnet, which is how a consumer keeps workloads out of a private or shared
+// subnet.
+//
+// RunInstances names five required resource types — image*, instance*,
+// network-interface*, security-group* and subnet* — and substrate authorized it
+// against a single ARN built from InstanceId.1, a parameter a launch never
+// carries. Every launch was therefore decided against the literal string "*", and
+// because resourceMatches passes the *statement's* Resource entry to globMatch as
+// the pattern, an ARN-scoped Deny never matched anything. The guardrail read as a
+// boundary and was not one.
+//
+// Only this tier shows what the caller sees. EC2 models no exception shapes, so
+// the refusal arrives as a generic smithy.APIError whose ErrorCode a consumer
+// branches on, and its message has to name the ARN the policy is missing —
+// otherwise the fix is correct and undiagnosable.
+func TestJourney_EC2RunInstancesSubnetGuardrail(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	adminCfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	admin := ec2.NewFromConfig(adminCfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	iamClient := iam.NewFromConfig(adminCfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	// --- the network, built by the unenforced built-in caller ---
+	vpc, err := admin.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	newSubnet := func(cidr string) string {
+		t.Helper()
+		out, subnetErr := admin.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+			VpcId:     aws.String(vpcID),
+			CidrBlock: aws.String(cidr),
+		})
+		if subnetErr != nil {
+			t.Fatalf("CreateSubnet %s: %v", cidr, subnetErr)
+		}
+		return aws.ToString(out.Subnet.SubnetId)
+	}
+	privateSubnet := newSubnet("10.0.1.0/24")
+	publicSubnet := newSubnet("10.0.2.0/24")
+
+	sg, err := admin.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String("workload"),
+		Description: aws.String("journey"),
+		VpcId:       aws.String(vpcID),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+	sgID := aws.ToString(sg.GroupId)
+
+	// The ARNs a consumer writes into the policy. EC2's Describe responses carry no
+	// ARN member for a subnet, so these are built from the documented format — which
+	// is exactly what the caller has to do, and why the format has to match.
+	const region = "us-east-1"
+	const account = "123456789012"
+	privateSubnetARN := "arn:aws:ec2:" + region + ":" + account + ":subnet/" + privateSubnet
+
+	// --- the guarded launcher ---
+	//
+	// A real IAM user, because the built-in AKIA key resolves to no principal and an
+	// unenforced caller would make every assertion below pass regardless of policy.
+	user, err := iamClient.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("launcher")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	putPolicy := func(document string) {
+		t.Helper()
+		if _, policyErr := iamClient.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+			UserName:       user.User.UserName,
+			PolicyName:     aws.String("launch-guardrail"),
+			PolicyDocument: aws.String(document),
+		}); policyErr != nil {
+			t.Fatalf("PutUserPolicy: %v", policyErr)
+		}
+	}
+	// "Launch anywhere except the private subnet" — the whole point of the issue.
+	guardrail := `{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"ec2:*","Resource":"*"},` +
+		`{"Effect":"Deny","Action":"ec2:RunInstances","Resource":"` + privateSubnetARN + `"}]}`
+	putPolicy(guardrail)
+
+	key, err := iamClient.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{
+		UserName: user.User.UserName,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+	launcherCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+		config.WithBaseEndpoint(ts.URL),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			aws.ToString(key.AccessKey.AccessKeyId),
+			aws.ToString(key.AccessKey.SecretAccessKey), "")),
+		config.WithHTTPClient(&http.Client{}),
+	)
+	if err != nil {
+		t.Fatalf("launcher config: %v", err)
+	}
+	launcher := ec2.NewFromConfig(launcherCfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+
+	launch := func(client *ec2.Client, subnetID string) (*ec2.RunInstancesOutput, error) {
+		return client.RunInstances(ctx, &ec2.RunInstancesInput{
+			ImageId:          aws.String("ami-0abcdef1234567890"),
+			InstanceType:     ec2types.InstanceTypeT3Micro,
+			MinCount:         aws.Int32(1),
+			MaxCount:         aws.Int32(1),
+			SubnetId:         aws.String(subnetID),
+			SecurityGroupIds: []string{sgID},
+		})
+	}
+
+	// --- the launch into the fenced-off subnet, which the Deny names ---
+	//
+	// This is the request that was allowed. EC2 models no exception shapes, so the
+	// SDK surfaces a generic APIError rather than a typed one.
+	_, err = launch(launcher, privateSubnet)
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("launching into a subnet the policy denies: got %T (%v), want an API error", err, err)
+	}
+	if apiErr.ErrorCode() != "AccessDenied" {
+		t.Errorf("ErrorCode() = %q, want AccessDenied — EC2's XML protocol has no Exception suffix",
+			apiErr.ErrorCode())
+	}
+	// The message is the only place the refused resource surfaces, and it is what
+	// tells the caller which ARN the decision tripped on.
+	if msg := err.Error(); !strings.Contains(msg, privateSubnetARN) {
+		t.Errorf("the denial does not name the subnet ARN %s: %v", privateSubnetARN, msg)
+	}
+	// And the refusal really launched nothing: a denial that had already written
+	// state would be worse than the false allow it replaced.
+	if got := journeyEC2InstanceCount(t, ctx, admin); got != 0 {
+		t.Fatalf("after the refusal there are %d instances, want 0", got)
+	}
+
+	// --- the same launch into a subnet the Deny does not name ---
+	run, err := launch(launcher, publicSubnet)
+	if err != nil {
+		t.Fatalf("a launch into a subnet the guardrail permits must succeed: %v", err)
+	}
+	if len(run.Instances) != 1 {
+		t.Fatalf("RunInstances returned %d instances, want 1", len(run.Instances))
+	}
+	if got := aws.ToString(run.Instances[0].SubnetId); got != publicSubnet {
+		t.Errorf("the instance landed in subnet %q, want %s", got, publicSubnet)
+	}
+
+	// --- and a least-privilege policy naming every required ARN works ---
+	//
+	// The other direction the single-ARN resolution broke: a policy naming exactly
+	// the five ARNs AWS documents as required refused every launch, because
+	// "arn:…:image/ami-…" as a pattern does not match the value "*" either. Note the
+	// image ARN's empty account field, which is the format the Service Authorization
+	// Reference gives — an AMI is shareable.
+	leastPrivilege := `{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"ec2:RunInstances","Resource":[` +
+		`"arn:aws:ec2:` + region + `::image/ami-0abcdef1234567890",` +
+		`"arn:aws:ec2:` + region + `:` + account + `:subnet/` + publicSubnet + `",` +
+		`"arn:aws:ec2:` + region + `:` + account + `:security-group/` + sgID + `",` +
+		`"arn:aws:ec2:` + region + `:` + account + `:network-interface/*",` +
+		`"arn:aws:ec2:` + region + `:` + account + `:instance/*"]}]}`
+	putPolicy(leastPrivilege)
+
+	if _, err := launch(launcher, publicSubnet); err != nil {
+		t.Fatalf("a policy naming every required ARN must permit the launch: %v", err)
+	}
+
+	// Dropping one ARN from that policy refuses the launch and says which one, which
+	// is what makes a least-privilege policy writable by iteration rather than by
+	// guesswork.
+	withoutSubnet := strings.Replace(leastPrivilege,
+		`"arn:aws:ec2:`+region+`:`+account+`:subnet/`+publicSubnet+`",`, "", 1)
+	putPolicy(withoutSubnet)
+
+	_, err = launch(launcher, publicSubnet)
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("a policy omitting the subnet: got %T (%v), want an API error", err, err)
+	}
+	wantARN := "arn:aws:ec2:" + region + ":" + account + ":subnet/" + publicSubnet
+	if msg := err.Error(); !strings.Contains(msg, wantARN) {
+		t.Errorf("the denial does not name the omitted subnet ARN %s: %v", wantARN, msg)
+	}
+}
+
+// journeyEC2InstanceCount reports how many instances exist, read by the
+// unenforced admin so the count is not itself subject to the policy under test.
+func journeyEC2InstanceCount(t *testing.T, ctx context.Context, client *ec2.Client) int {
+	t.Helper()
+	out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+	n := 0
+	for _, r := range out.Reservations {
+		n += len(r.Instances)
+	}
+	return n
+}


### PR DESCRIPTION
`buildResourceARN`'s `ec2` arm derived its resource ARN from `req.Params["InstanceId.1"]`, a parameter no `RunInstances` request carries, so **every launch was authorized against the literal string `"*"`**. The Service Authorization Reference marks five required resource types for the action — `image`, `instance`, `network-interface`, `security-group`, `subnet` — and evaluates the caller's policies against all of them.

## The mechanism, corrected

#662 states the resource resolves to `"*"` "and `resourceMatches` lets `"*"` satisfy any statement". It does not. `resourceMatches` (`emulator/iam_eval.go:407-425`) short-circuits only on `resource == ""`, and calls `globMatch(stmtEntry, requestResource)` — the **statement** is the pattern and the request's resource is the value (`iam_eval.go:519-560`). So `"*"` as a request resource matches only a statement whose own `Resource` begins with `*`.

That makes the defect two-sided, and it is the *false allow* that decides the severity:

- **A broad `Allow` on `"*"` beside an ARN-scoped `Deny` ignored the `Deny` entirely.** A policy written to keep workloads out of a private or shared subnet — allow `ec2:RunInstances` on `*`, deny it on `subnet/subnet-private` — read as a privilege boundary and was inert. This is the same class as #660, which shipped alone as v0.102.0.
- **A least-privilege `Allow` naming the five documented ARNs denied every launch**, because none of those patterns matches the value `*`. This is the error a consumer hits first, and it is what makes the broad-`Allow` policy look like the safe configuration.

## What changed

`emulator/ec2_authz.go` (new) resolves every resource a launch names and returns them as `[]authzResource`, reusing the multi-resource machinery #660 built: all-must-allow, a fresh condition context per resource, the permission boundary evaluated **inside** the loop, and the first failure naming the ARN. `buildResourceARNs` gained one gated arm beside the Organizations one; `len(multi) > 0` is what keeps every other EC2 operation on the single-resource path.

Fixed order — image, subnet, security groups, network interfaces, instance — so the denial message is deterministic and replay-stable, with request-named resources first because those are the ARNs a caller can act on.

- **The AMI's ARN carries no account field** (`arn:aws:ec2:{region}::image/{ami}`), the format the reference gives, because an AMI is shareable. It has to stay empty: `arnAccountID` reads an empty account as "no account", not "this account", so an account-scoped ARN would not match the policy AWS documents.
- **`instance/*` and `network-interface/*`** for the resources whose IDs do not exist at decision time — the shape AWS's own least-privilege examples write. Including `instance/*` is what makes a policy omitting `instance` a denial, the answer real AWS gives. An interface the request brings by ID is named instead. The cost is a documented limit: a policy scoped to `instance/i-*` matches on AWS and not here.
- **Each ARN carries only its own tags**, read through one reader over the shared `tags` member, so an `aws:ResourceTag` condition written about the subnet cannot be satisfied by a tag on the AMI. An unreadable record yields *no* tags, never a partial map — an absent condition key denies, whereas a fabricated one would let a storage fault grant access.
- **Launch-template resources are authorized as if the request had named them**, under the same field-by-field, all-or-nothing precedence the handler uses, resolved independently because `CheckAccess` runs before the handler (`server.go:695`). `resolveLaunchTemplate` was extracted to the free function `ec2LookupLaunchTemplate` so the decision and the handler cannot drift. AWS states this rule only in `CreateFleet`'s description: *"Resource-level permissions for this action do not include the resources specified in a launch template. To specify resource-level permissions for resources specified in a launch template, you must include the resources in the RunInstances action statement."* A template that cannot be read contributes nothing rather than answering a missing template with `AccessDenied` instead of the `InvalidLaunchTemplateId.NotFound` it earns.
- **An omitted resource is skipped, not resolved to `"*"`**, which would widen the policy the caller wrote. A request naming none of them returns `nil` and is decided exactly as before.

## Deliberately not covered (stated in `docs/services.md`, not left to be discovered)

`volume` (asterisked only inside the reference's scenario rows, never on the action's own resource list — requiring it would refuse a policy naming exactly the five documented types); the launch-template ARN (not marked required for `RunInstances`, same reasoning); the EC2 condition keys; a launch whose subnet and security group come from the default VPC, resolved *after* the decision (#673); and the fleet path, which never reaches `CheckAccess` at all (`ec2_fleet.go:505-510`).

## Verification

- `emulator/ec2_authz_test.go` — 12 tests. Every behavioural one **confirmed to fail before the change** (probe injected after the operation gate); the two that passed before are exactly the ones pinning unchanged behaviour, which is correct by design.
- `test/e2e/journey_ec2_runinstances_authz_test.go` — a real IAM user via `PutUserPolicy` + `CreateAccessKey` and a static-credentials config, because the built-in `AKIA…` key resolves to no principal and an unenforced caller would make every assertion pass regardless of policy. Asserts the generic `smithy.APIError` with `ErrorCode() == "AccessDenied"` (EC2's XML protocol has no `Exception` suffix), that the message names the missing ARN, and that **the refusal launched nothing**. Before the fix it failed with `got <nil>` — the guardrail was inert.
- `make test` (race) and `make coverage`: emulator **82.8%**, total **82.1%**. `gofmt -l`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`, `go test -C test/e2e ./...` — all clean.
- **Live run** against a built binary on `:4678` as the IAM user's own access key: with `Allow ec2:*` on `*` plus a `Deny` on one subnet, the launch into that subnet is refused naming `arn:aws:ec2:us-east-1:123456789012:subnet/subnet-6239…`, a launch into another succeeds, and `describe-instances` shows exactly one instance — the refusal wrote nothing. A policy naming the five required ARNs launches; the same policy minus the security-group ARN is refused naming that ARN.

## Mutation testing — 9 mutants, **9 killed, 0 survivors**

Resolver returns `nil` (the bug itself, 11 tests); AMI dropped (5); absent subnet resolved to `subnet/*` (3); tag maps merged into a union (the false-allow — killed by the mistagging subtests); `break` after the first resource (9 EC2 + 4 Organizations tests); boundary evaluated against only the first resource (**#660's own mutation survivor, now killed twice over**); image ARN gains the account field (5); template fallback skipped; operation gate deleted.

Three kill margins worth recording rather than reporting clean:

- The tag-union mutant — the most dangerous of the set — is killed by exactly one test, `TestEC2_Authz_ResourceTagsPairWithTheirOwnResource`. A union map still yields the right five ARNs and differs only when a condition names a tag a *different* resource carries, so that test's per-resource mistagging subtests are the only oracle for it.
- The gate-deleted mutant is killed only by the `CreateImage` subtest of `SingleResourceOperationsAreUnchanged`, i.e. only because one non-`RunInstances` EC2 operation happens to carry an `ImageId`. Sufficient, but resting on one subtest's parameter choice.
- Two mutants had to be re-expressed as `|| true` on the preceding early-return condition, because `go vet`'s `unreachable` analyzer rejects an inserted `return`. Behaviourally the same early return.

Closes #662
