### PR TITLE
chore(release): v0.104.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.104.0] - 2026-08-20
 
 ### Fixed
 - **`ec2:RunInstances` was authorized against one resource ARN a launch never carries, so an
@@ -7076,6 +7076,7 @@ all changes onto the v0.44.x line.
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
 [Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.103.0...HEAD
+[v0.104.0]: https://github.com/scttfrdmn/substrate/compare/v0.103.0...v0.104.0
 [v0.103.0]: https://github.com/scttfrdmn/substrate/compare/v0.102.0...v0.103.0
 [v0.102.0]: https://github.com/scttfrdmn/substrate/compare/v0.101.0...v0.102.0
 [v0.101.0]: https://github.com/scttfrdmn/substrate/compare/v0.100.0...v0.101.0


### PR DESCRIPTION
Dates the `## [Unreleased]` section as `## [v0.104.0] - 2026-08-20` and adds its comparison link.

v0.104.0 ships **#662 alone**: `ec2:RunInstances` was authorized against a single resource ARN derived from `InstanceId.1`, a parameter no launch carries, so an ARN-scoped `Deny` written to fence off a subnet, AMI or security group had no effect. That is a false allow in a privilege boundary — the same class as #660, which shipped by itself as v0.102.0 — and `SECURITY.md` promises a fix released as soon as practical, prioritised by severity. #669, #670 and #671 are on the v0.105.0 milestone.

No code changes.