### PR TITLE
fix(ec2): a launch-declared data volume is preserved on termination (#675)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **A launch-declared *data* volume is now preserved on termination rather than deleted, and
+  the ambiguity behind that value is recorded** (#675). Two current AWS pages disagree about
+  `DeleteOnTermination`'s default for a volume a launch creates.
+  `block-device-mapping-concepts` states the default is "`true` for the root volume and `false`
+  for attached volumes"; `preserving-volumes-on-termination` carries a console-vs-CLI table
+  that lists a launch-created data volume as Delete when the launch came through the CLI. #666
+  followed the second page and applied `true` to every launch-created volume, root and data
+  alike, and both the code comment and `docs/services.md` presented that as simply AWS's
+  documented behaviour.
+
+  The API reference itself documents no default for `EbsBlockDevice.DeleteOnTermination` at
+  all, and its only pointer on the subject is a link that no longer resolves to the content it
+  cites. Both guide pages agree that the real launch default comes from the **AMI's own block
+  device mapping**, which substrate's AMIs do not carry — so the value is substrate's choice
+  either way. Given a genuine ambiguity, the non-destructive side wins: a volume wrongly
+  preserved is visible and correctable, while one wrongly deleted is gone and the caller learns
+  of it by its absence rather than by an error. A consumer reading the page that describes the
+  mapping shape they are writing would otherwise find substrate wrong rather than opinionated.
+
+  The root volume still defaults to `true`, which both pages agree on, and the default keys off
+  the *resolved* device name so a mapping naming no device — which lands on `/dev/sda1` — is
+  treated as the root it became. `AttachVolume`'s `false` is unchanged and unaffected; the two
+  pages agree about a volume attached after launch. An explicit value still wins over either
+  default. `docs/services.md` now names both pages and states which wins and why, rather than
+  only the behaviour.
+
+  **Compatibility:** a data volume that a launch created and `TerminateInstances` deleted in
+  v0.103.0 and v0.104.0 now survives as `available` with no attachment, and
+  `DescribeVolumes` reports `deleteOnTermination=false` on its attachment where it previously
+  reported `true`. A mapping that names `DeleteOnTermination` explicitly is unaffected, as is
+  every root-device mapping.
+
 ## [v0.104.0] - 2026-08-20
 
 ### Fixed

--- a/docs/services.md
+++ b/docs/services.md
@@ -2990,14 +2990,37 @@ spellings AWS's device-naming reference gives for the HVM root ("Differs by AMI"
 Substrate stores no per-AMI root device to compare against, so an AMI whose real
 root device is neither is out of reach here.
 
-`DeleteOnTermination` defaults to **`true`** for every volume a launch creates,
-data volumes included. That is counter-intuitive and is AWS's documented
-behaviour: its termination table splits on *how* the volume was attached, not on
-what it is — a data volume attached at launch through the console preserves, but
-through the API it is deleted, and an API emulator has no console path. A volume
-attached later with `AttachVolume` defaults to `false`, because deleting a volume
-the caller brought would destroy something the launch did not make. An explicit
-value wins over either default.
+`DeleteOnTermination` defaults to **`true` for the root volume and `false` for a
+data volume**, and that split is substrate's resolution of a conflict between two
+current AWS pages rather than a value either one simply states.
+
+The API reference documents no default for `EbsBlockDevice.DeleteOnTermination` at
+all — its only pointer on the subject is a link that no longer resolves to the
+content it cites. Two guide pages do, and they disagree:
+
+- [`block-device-mapping-concepts`][bdm-concepts] gives exactly this split: the
+  default is "`true` for the root volume and `false` for attached volumes".
+- [`preserving-volumes-on-termination`][preserve-volumes] carries a console-vs-CLI
+  table that lists a data volume created at launch **via the CLI** as Delete.
+
+Substrate previously followed the second page and applied `true` to every
+launch-created volume. The split wins now for two reasons. Both pages agree that the real
+launch default comes from the **AMI's own block device mapping**, and substrate's
+AMIs carry none to inherit — so the value is substrate's choice either way, and the
+non-destructive side of a genuine ambiguity is the one a test emulator should take:
+a volume wrongly preserved is visible and correctable, while one wrongly deleted is
+gone and the caller learns of it by its absence rather than by an error. And a
+consumer reading `block-device-mapping-concepts` — the page that describes the
+mapping shape they are writing — would find substrate wrong rather than
+opinionated.
+
+A volume attached later with `AttachVolume` defaults to `false`, because deleting a
+volume the caller brought would destroy something the launch did not make. Both
+pages agree about that one, so nothing here changes it. An explicit value wins over
+either default.
+
+[bdm-concepts]: https://docs.aws.amazon.com/ebs/latest/userguide/block-device-mapping-concepts.html
+[preserve-volumes]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/preserving-volumes-on-termination.html
 
 `TerminateInstances` settles the volumes accordingly: one whose attachment deletes
 on termination is removed outright, and one that does not becomes `available` with

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -144,12 +144,28 @@ func ec2CreatesEBSVolume(bdm EC2BlockDeviceMapping) bool {
 // rule for a mapping whose device name the AMI's mapping already uses: "the mapping
 // you specify replaces the AMI's".
 //
-// DeleteOnTermination defaults to **true** for every volume a launch creates, root
-// and data alike. That is counter-intuitive and is AWS's documented behavior: its
-// termination table splits on how the volume was attached, not on what it is — a
-// data volume attached at launch through the console preserves, but through the API
-// it is deleted, and substrate has no console. A volume attached after launch keeps
-// the other default; see attachVolume.
+// DeleteOnTermination defaults to **true for the root volume and false for a data
+// volume**, and that split is substrate's resolution of a conflict between two
+// current AWS pages rather than a value either one simply states (#675).
+//
+// The API reference documents no default for EbsBlockDevice.DeleteOnTermination at
+// all. Of the two guide pages that do, block-device-mapping-concepts gives exactly
+// this split — "true for the root volume and false for attached volumes" — while
+// preserving-volumes-on-termination carries a console-vs-CLI table listing a
+// launch-created data volume as Delete when the launch came through the CLI. #666
+// followed the second and applied true to everything.
+//
+// The split wins for two reasons. Both pages agree that the real launch default
+// comes from the *AMI's* own block device mapping, and substrate's AMIs carry none
+// to inherit — so this is substrate's choice either way, and the non-destructive
+// side of a genuine ambiguity is the one a test emulator should take: a volume
+// wrongly preserved is visible and correctable, one wrongly deleted is gone. And a
+// consumer reading block-device-mapping-concepts, the page that describes the
+// mapping shape they are writing, would find substrate wrong rather than
+// opinionated.
+//
+// A volume attached after launch keeps the other default; see attachVolume, where
+// the two pages agree and nothing here changes it.
 func ec2LaunchVolumesFor(inst *EC2Instance, mappings []EC2BlockDeviceMapping, now string) []EC2Volume {
 	volumes := make([]EC2Volume, 0, len(mappings)+1)
 	rootDeclared := false
@@ -191,9 +207,14 @@ func ec2VolumeFromMapping(inst *EC2Instance, bdm EC2BlockDeviceMapping, now stri
 	if device == "" {
 		device = ec2RootDeviceSDA1
 	}
-	// Absent means true here — the launch default — so only an explicit "false"
-	// preserves the volume. The raw string is what makes that distinguishable.
-	deleteOnTermination := true
+	// The default splits on whether this is the root device; see
+	// [ec2LaunchVolumesFor] for why. It keys off the *resolved* device name, so a
+	// mapping naming no device at all — which lands on /dev/sda1 above — is treated
+	// as the root it became rather than as a data volume.
+	//
+	// The raw string is what makes an explicit value distinguishable from an absent
+	// one, and an explicit value wins over either default.
+	deleteOnTermination := ec2IsRootDevice(device)
 	if bdm.DeleteOnTermination != "" {
 		deleteOnTermination = strings.EqualFold(bdm.DeleteOnTermination, "true")
 	}

--- a/emulator/ec2_block_devices_http_test.go
+++ b/emulator/ec2_block_devices_http_test.go
@@ -131,8 +131,11 @@ func TestEC2_BlockDeviceMapping_ReportedRepro(t *testing.T) {
 	assert.Equal(t, "in-use", vols[0].Status)
 	assert.Equal(t, "/dev/xvda", vols[0].bdmDevice())
 	assert.Equal(t, ids[0], vols[0].Attachments[0].InstanceID)
+	// /dev/xvda is a root device, and both AWS pages agree the root volume is deleted
+	// on termination. Only the data-volume default was ever in doubt (#675), and it
+	// is pinned by TestEC2_BlockDeviceMapping_DataVolumeDefaultPreserves.
 	assert.True(t, vols[0].Attachments[0].DeleteOnTermination,
-		"a volume a launch creates is deleted on termination")
+		"the root volume a launch creates is deleted on termination")
 	assert.NotEmpty(t, vols[0].Attachments[0].AttachTime)
 }
 
@@ -199,7 +202,9 @@ func TestEC2_BlockDeviceMapping_DataVolumeAlongsideRoot(t *testing.T) {
 func TestEC2_BlockDeviceMapping_TerminationHonorsDeleteOnTermination(t *testing.T) {
 	ts := newEC2TestServer(t)
 	ids := bdmRunInstances(t, ts, map[string]string{
-		// The root deletes by default; the data volume explicitly preserves.
+		// The root deletes by default; the data volume preserves explicitly, which
+		// since #675 is also its default — this case is about honoring the explicit
+		// value, so it keeps stating it.
 		"BlockDeviceMapping.1.DeviceName":              "/dev/sda1",
 		"BlockDeviceMapping.1.Ebs.VolumeSize":          "30",
 		"BlockDeviceMapping.2.DeviceName":              "/dev/sdf",
@@ -227,6 +232,53 @@ func TestEC2_BlockDeviceMapping_TerminationHonorsDeleteOnTermination(t *testing.
 	assert.Equal(t, preservedID, after[0].VolumeID)
 	// A preserved volume is available with no attachment, which is what a volume
 	// whose instance is gone looks like.
+	assert.Equal(t, "available", after[0].Status)
+	assert.Empty(t, after[0].Attachments)
+	assert.Equal(t, 40, after[0].Size)
+}
+
+// TestEC2_BlockDeviceMapping_DataVolumeDefaultPreserves pins the default #675 is
+// about, at the tier a consumer meets it: a launch-declared *data* volume that names
+// no DeleteOnTermination survives its instance, while the root volume beside it does
+// not.
+//
+// The default was untested through HTTP before this — every existing case either
+// names a root device or sets the value explicitly — so the behavior #675 disputed
+// was reachable only through the unit tier. It is the destructive direction that
+// needs the assertion: a volume wrongly deleted is gone, and the caller finds out by
+// its absence rather than by an error.
+func TestEC2_BlockDeviceMapping_DataVolumeDefaultPreserves(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		// No DeleteOnTermination on either mapping: both take the default, and the
+		// two defaults differ.
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "30",
+		"BlockDeviceMapping.2.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.2.Ebs.VolumeSize": "40",
+	})
+	require.Len(t, ids, 1)
+
+	before := bdmDescribeVolumes(t, ts, nil)
+	require.Len(t, before, 2)
+	assert.True(t, before[0].Attachments[0].DeleteOnTermination,
+		"the root volume is deleted on termination — both AWS pages agree")
+	assert.False(t, before[1].Attachments[0].DeleteOnTermination,
+		"a data volume with no explicit value is preserved (#675)")
+	dataVolumeID := before[1].VolumeID
+
+	termResp := ec2Request(t, ts, map[string]string{
+		"Action":       "TerminateInstances",
+		"InstanceId.1": ids[0],
+	})
+	require.Equal(t, http.StatusOK, termResp.StatusCode)
+	require.NoError(t, termResp.Body.Close())
+
+	// The rendered flag and what termination actually does have to agree; a volume
+	// reporting false and then vanishing would be worse than either answer.
+	after := bdmDescribeVolumes(t, ts, nil)
+	require.Len(t, after, 1, "the root is deleted and the data volume is not")
+	assert.Equal(t, dataVolumeID, after[0].VolumeID)
 	assert.Equal(t, "available", after[0].Status)
 	assert.Empty(t, after[0].Attachments)
 	assert.Equal(t, 40, after[0].Size)

--- a/emulator/ec2_block_devices_test.go
+++ b/emulator/ec2_block_devices_test.go
@@ -214,20 +214,21 @@ func TestEC2LaunchVolumes(t *testing.T) {
 		},
 		{
 			// A data volume does not suppress the root, so a launch naming only
-			// /dev/sdf gets two volumes.
+			// /dev/sdf gets two volumes — and the two take *different*
+			// DeleteOnTermination defaults, true for the root and false for the data
+			// volume, which is substrate's resolution of a conflict between two
+			// current AWS pages (#675).
 			name:     "a data volume gets a root alongside it",
 			mappings: []emulator.EC2BlockDeviceMapping{{DeviceName: "/dev/sdf", VolumeSize: 100, VolumeType: "gp3"}},
 			want: []wantVol{
-				{"/dev/sdf", 100, "gp3", true},
+				{"/dev/sdf", 100, "gp3", false},
 				{"/dev/sda1", 8, "gp2", true},
 			},
 		},
 		{
-			// DeleteOnTermination defaults to true for a *data* volume too. Counter-
-			// intuitive, and AWS's own behavior: its termination table splits on how
-			// the volume was attached, not on what it is — a data volume attached at
-			// launch through the console preserves, but through the API it is deleted,
-			// and substrate has no console.
+			// An explicit value wins over either default, which is what makes the
+			// default distinguishable at all: the raw string is retained precisely so
+			// "false" and absent are not the same input.
 			name: "an explicit false preserves",
 			mappings: []emulator.EC2BlockDeviceMapping{
 				{DeviceName: "/dev/sdf", VolumeSize: 20, DeleteOnTermination: "false"},
@@ -271,7 +272,7 @@ func TestEC2LaunchVolumes(t *testing.T) {
 				{DeviceName: "/dev/sdb", VirtualName: "ephemeral0", VolumeSize: 12},
 			},
 			want: []wantVol{
-				{"/dev/sdb", 12, "gp2", true},
+				{"/dev/sdb", 12, "gp2", false},
 				{"/dev/sda1", 8, "gp2", true},
 			},
 		},
@@ -284,6 +285,8 @@ func TestEC2LaunchVolumes(t *testing.T) {
 			want: []wantVol{{"/dev/sda1", 8, "gp2", true}},
 		},
 		{
+			// The root deletes and both data volumes are preserved, one by default and
+			// one explicitly — the same answer by two routes.
 			name: "a root and two data volumes",
 			mappings: []emulator.EC2BlockDeviceMapping{
 				{DeviceName: "/dev/xvda", VolumeSize: 60},
@@ -292,7 +295,7 @@ func TestEC2LaunchVolumes(t *testing.T) {
 			},
 			want: []wantVol{
 				{"/dev/xvda", 60, "gp2", true},
-				{"/dev/sdf", 100, "io2", true},
+				{"/dev/sdf", 100, "io2", false},
 				{"/dev/sdg", 200, "gp2", false},
 			},
 		},

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -947,12 +947,12 @@ type EC2VolumeAttachment struct {
 	// the value describes this attachment: detaching and reattaching a volume
 	// resets it to the post-launch default.
 	//
-	// AWS's default depends on how the attachment came about, not on what the
-	// volume is. Anything attached after launch preserves on termination; a volume
-	// a launch creates is deleted, root and data volumes alike, when the launch
-	// came through the API rather than the console. Substrate is an API emulator,
-	// so a launch defaults this to true and AttachVolume defaults it to false. See
-	// [ec2LaunchVolumesFor].
+	// Anything attached after launch preserves on termination, which both AWS pages
+	// that document a default agree on, so AttachVolume defaults this to false. For
+	// a volume a launch creates the two pages disagree, and substrate resolves the
+	// conflict by device role: true for the root volume, false for a data volume
+	// (#675). See [ec2LaunchVolumesFor] for which pages say what and why the split
+	// wins.
 	DeleteOnTermination bool `json:"delete_on_termination"`
 }
 

--- a/test/e2e/journey_ec2_block_devices_test.go
+++ b/test/e2e/journey_ec2_block_devices_test.go
@@ -87,11 +87,11 @@ func TestJourney_EC2LaunchBlockDeviceMappings(t *testing.T) {
 	if got := aws.ToString(att.InstanceId); got != instanceID {
 		t.Fatalf("attachment InstanceId = %q, want %q", got, instanceID)
 	}
-	// True is AWS's launch default for a volume created through the API — its
-	// termination table splits on how the volume was attached, and the console path a
-	// consumer might expect Preserve from does not exist here.
+	// True for the *root* volume, which is what /dev/xvda is. Both AWS pages that
+	// document a launch default agree about the root; they disagree about a data
+	// volume, and substrate preserves that one (#675).
 	if !aws.ToBool(att.DeleteOnTermination) {
-		t.Fatal("attachment DeleteOnTermination = false, want true for a launch-created volume")
+		t.Fatal("attachment DeleteOnTermination = false, want true for a launch-created root volume")
 	}
 
 	if _, err := client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
@@ -110,5 +110,119 @@ func TestJourney_EC2LaunchBlockDeviceMappings(t *testing.T) {
 	if len(after.Volumes) != 0 {
 		t.Fatalf("DescribeVolumes after terminate returned %d volumes, want 0",
 			len(after.Volumes))
+	}
+}
+
+// TestJourney_EC2LaunchDataVolumeSurvivesTermination is #675 at the tier that made it
+// worth deciding: a consumer whose IaC attaches a data volume at launch and expects to
+// still have it afterwards.
+//
+// Through v0.104.0 substrate deleted it, following the one AWS page whose console-vs-CLI
+// table says so. The page that describes the mapping shape a consumer is actually
+// writing says the opposite, both pages agree the real default comes from an AMI mapping
+// substrate does not carry, and a volume wrongly deleted is gone — so the split default
+// wins, and this is the direction that needs an SDK-tier assertion.
+func TestJourney_EC2LaunchDataVolumeSurvivesTermination(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	client := ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	ctx := context.Background()
+
+	// Neither mapping names DeleteOnTermination, so both take a default and the two
+	// defaults differ.
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-0abcdef1234567890"),
+		InstanceType: ec2types.InstanceTypeT3Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{
+			{
+				DeviceName: aws.String("/dev/xvda"),
+				Ebs:        &ec2types.EbsBlockDevice{VolumeSize: aws.Int32(30)},
+			},
+			{
+				DeviceName: aws.String("/dev/sdf"),
+				Ebs:        &ec2types.EbsBlockDevice{VolumeSize: aws.Int32(40)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	if len(run.Instances) != 1 {
+		t.Fatalf("RunInstances returned %d instances, want 1", len(run.Instances))
+	}
+	instanceID := aws.ToString(run.Instances[0].InstanceId)
+
+	byInstance := &ec2.DescribeVolumesInput{
+		Filters: []ec2types.Filter{{
+			Name:   aws.String("attachment.instance-id"),
+			Values: []string{instanceID},
+		}},
+	}
+	described, err := client.DescribeVolumes(ctx, byInstance)
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+	if len(described.Volumes) != 2 {
+		t.Fatalf("DescribeVolumes returned %d volumes, want 2", len(described.Volumes))
+	}
+	var dataVolumeID string
+	for _, vol := range described.Volumes {
+		if len(vol.Attachments) != 1 {
+			t.Fatalf("volume %s has %d attachments, want 1",
+				aws.ToString(vol.VolumeId), len(vol.Attachments))
+		}
+		att := vol.Attachments[0]
+		device := aws.ToString(att.Device)
+		deleteOnTermination := aws.ToBool(att.DeleteOnTermination)
+		switch device {
+		case "/dev/xvda":
+			if !deleteOnTermination {
+				t.Error("the root volume reports DeleteOnTermination=false, want true")
+			}
+		case "/dev/sdf":
+			if deleteOnTermination {
+				t.Error("the data volume reports DeleteOnTermination=true, want false (#675)")
+			}
+			dataVolumeID = aws.ToString(vol.VolumeId)
+		default:
+			t.Errorf("unexpected device %q", device)
+		}
+	}
+	if dataVolumeID == "" {
+		t.Fatal("the launch produced no /dev/sdf volume")
+	}
+
+	if _, err := client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instanceID},
+	}); err != nil {
+		t.Fatalf("TerminateInstances: %v", err)
+	}
+
+	// What the flag reports and what termination does have to agree. Listing
+	// everything rather than filtering on the instance: a preserved volume has no
+	// attachment left to filter on, which is itself the observation.
+	all, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{})
+	if err != nil {
+		t.Fatalf("DescribeVolumes after terminate: %v", err)
+	}
+	if len(all.Volumes) != 1 {
+		t.Fatalf("after terminate there are %d volumes, want 1 — the preserved data volume",
+			len(all.Volumes))
+	}
+	if got := aws.ToString(all.Volumes[0].VolumeId); got != dataVolumeID {
+		t.Fatalf("the surviving volume is %s, want the data volume %s", got, dataVolumeID)
+	}
+	if all.Volumes[0].State != ec2types.VolumeStateAvailable {
+		t.Fatalf("the preserved volume is %q, want available", all.Volumes[0].State)
+	}
+	if len(all.Volumes[0].Attachments) != 0 {
+		t.Fatalf("the preserved volume still reports %d attachments, want 0",
+			len(all.Volumes[0].Attachments))
 	}
 }


### PR DESCRIPTION
Closes #675.

## The conflict

Two current AWS pages disagree about `DeleteOnTermination`'s default for a volume a launch creates:

- `block-device-mapping-concepts` states the default is "`true` for the root volume and `false` for attached volumes".
- `preserving-volumes-on-termination` carries a console-vs-CLI table listing a launch-created data volume as **Delete** when the launch came through the CLI.

#666 followed the second page and applied `true` to every launch-created volume, root and data alike. The code comment argued it well — "its termination table splits on how the volume was attached, not on what it is … and substrate has no console" — but presented the answer as simply AWS's documented behavior, with no note that another current page says the opposite.

## Why the split wins

The API reference itself documents **no default** for `EbsBlockDevice.DeleteOnTermination`, and its only pointer on the subject is a link that no longer resolves to the content it cites. Both guide pages agree the real launch default comes from the **AMI's own block device mapping** — which substrate's AMIs do not carry. So the value is substrate's choice either way, and given a genuine ambiguity the non-destructive side is the one a test emulator should take: a volume wrongly preserved is visible and correctable, while one wrongly deleted is gone and the caller learns of it by its absence rather than by an error. A consumer reading the page that describes the mapping shape they are writing would otherwise find substrate wrong rather than opinionated.

## What changed

- `ec2VolumeFromMapping` defaults `DeleteOnTermination` to `ec2IsRootDevice(device)` rather than unconditional `true`. It keys off the **resolved** device name, so a mapping naming no device — which lands on `/dev/sda1` — is treated as the root it became rather than as a data volume. An explicit value still wins.
- `AttachVolume`'s `false` is untouched and unaffected; both pages agree about a volume attached after launch, and its comment needed no root-device special case.
- Three comments asserted the old rationale and all three now name the conflict: `ec2_block_devices.go`'s `ec2LaunchVolumesFor`, `EC2VolumeAttachment.DeleteOnTermination`'s field doc, and `docs/services.md`. The docs paragraph names **both** pages and states which wins and why, per the house provenance rule.

## Fail-before proof

The contested default had no HTTP-tier coverage at all — every existing case either names a root device or sets the value explicitly. `TestEC2_BlockDeviceMapping_DataVolumeDefaultPreserves` was written first and run against `main`:

```
--- FAIL: TestEC2_BlockDeviceMapping_DataVolumeDefaultPreserves (0.00s)
    ec2_block_devices_http_test.go:261: Should be false
        Messages: a data volume with no explicit value is preserved (#675)
    ec2_block_devices_http_test.go:275: "[]" should have 1 item(s), but has 0
        Messages: the root is deleted and the data volume is not
```

The second failure is the one that matters: the volume was not merely mislabelled, it was destroyed.

## Tests

- **Added** `TestEC2_BlockDeviceMapping_DataVolumeDefaultPreserves` (HTTP) — root and data volume in one launch, neither naming the value, asserting the two differ *and* that termination honors the difference. The rendered flag and what termination does have to agree.
- **Added** `TestJourney_EC2LaunchDataVolumeSurvivesTermination` (SDK) — the tier the change is consumer-visible at.
- **Inverted** three `TestEC2LaunchVolumes` rows that pinned `true` for a data volume, and rewrote the case comment that argued for it. (The plan for this release recorded the default as untested; it was in fact pinned in three unit rows, which is where the fail-before evidence for the unit tier came from.)
- **Reaffirmed with a `#675` note** the two assertions the issue names — `journey_ec2_block_devices_test.go` and `ec2_block_devices_http_test.go`'s repro — both of which are on a **root** device and so keep `true`.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run` clean; `make test` (race) green; `go test -C test/e2e ./...` green; `go run ./cmd/gen-service-reference -check` and `scripts/check-doc-versions.sh` clean.

## Compatibility

A data volume that a launch created and `TerminateInstances` deleted in v0.103.0/v0.104.0 now survives as `available` with no attachment, and `DescribeVolumes` reports `deleteOnTermination=false` on its attachment where it previously reported `true`. A mapping naming `DeleteOnTermination` explicitly is unaffected, as is every root-device mapping and every volume attached after launch.