### PR TITLE
feat(ec2): an instance reports its own block devices (#669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **An instance reports its own block devices, on all three surfaces that render them**
+  (#669). `DescribeInstances`, `RunInstances` and `DescribeInstanceAttribute` now emit a
+  `blockDeviceMapping` set. #666 made a launch materialize its EBS volumes, but the only way
+  to learn which volume sat on which device was `DescribeVolumes` filtered on
+  `attachment.instance-id` — a question real EC2 answers from the instance, and one CDK and
+  Terraform consumers ask while asserting on a launch they just made.
+  `DescribeInstanceAttribute` refused `blockDeviceMapping` outright.
+
+  The set is **derived from the volume records**, not from the mappings the launch recorded,
+  which is what makes it track reality rather than intent: a volume attached with
+  `AttachVolume` after launch appears, a detached one stops appearing, and an instance store
+  device never appears because it never became a volume. `EC2Instance` carries no
+  block-device field, so the volumes are also the only available source. Each item is AWS's
+  `InstanceBlockDeviceMapping` — `deviceName` plus `ebs` — and the `ebs` element carries the
+  four members AWS's own sample shows (`volumeId`, `status`, `attachTime`,
+  `deleteOnTermination`), each read straight off a stored attachment. The other four
+  `EbsInstanceBlockDevice` members are omitted rather than defaulted, since substrate records
+  nothing behind them and a fabricated `volumeOwnerId` would be indistinguishable from a real
+  one.
+
+  `EbsInstanceBlockDevice` carries **no size**, so this does not replace `DescribeVolumes`
+  for the question #666 made it answer — `docs/services.md` continues to say that
+  `DescribeVolumes` is the only surface a launch-specified size is observable on.
+  `status` uses AWS's four-value `AttachmentStatus` enum, not the five-value volume-side enum
+  `DescribeVolumes` renders, so the two are deliberately not rendered through one helper.
+
+  On `DescribeInstanceAttribute` the set follows the shape `groupSet` already established: no
+  `<value>` wrapper (it is one of the `InstanceAttribute` members that is not an
+  `AttributeValue`), present-but-empty for an instance with no EBS volumes, and absent
+  entirely from any other attribute's response. AWS publishes no `blockDeviceMapping` example
+  for the operation, so the present-but-empty choice rests on that in-file reasoning rather
+  than on the reference.
+
+  Two substrate choices are labelled as such: `RunInstances` renders the set **populated**,
+  diverging from the reference's only sample response — which emits `<blockDeviceMapping />`
+  empty, on a `pending` instance whose request declared no mappings at all — on the same
+  ground `networkInterfaceSet` already uses, that substrate's instances are running and their
+  volumes exist by the time `RunInstances` answers; and the set is **ordered by device name**
+  with the volume ID breaking a tie, since `DescribeInstances` states its own order may vary
+  but a deterministic emulator must not answer one request two ways.
+
+### Fixed
+- **`RunInstances` omitted the `iamInstanceProfile` that `DescribeInstances` reported for the
+  same instance** (#669). `runInstancesResponse` and `describeInstances` each declared their
+  own local `ec2InstanceItem`, and the copies had drifted a second time after #444: only
+  `describeInstances`' carried `iamInstanceProfile`, they used different Go types for the
+  instance-state element, and their `placement`/`instanceState` order was swapped. A consumer
+  that read the profile off the launch response got nothing back and had to describe the
+  instance to see the value it had just set. `ec2InstanceItem` and its four sub-items are now
+  declared once at package level and built by one function, following the precedent
+  `ec2GroupItem` and `ec2NetworkInterfaceItem` set for exactly this bug.
+
 ### Changed
 - **A launch-declared *data* volume is now preserved on termination rather than deleted, and
   the ambiguity behind that value is recorded** (#675). Two current AWS pages disagree about

--- a/docs/services.md
+++ b/docs/services.md
@@ -2619,13 +2619,13 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 
 | Operation | Notes |
 |-----------|-------|
-| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); reports [`groupSet`](#security-groups-on-an-instance) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
-| DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time); `availability-zone` filter |
+| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
+| DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time); `availability-zone` filter |
 | TerminateInstances | [Explicit resource IDs](#explicit-resource-ids); [honours termination protection, per Availability Zone](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StartInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeInstanceStatus | [Explicit resource IDs](#explicit-resource-ids) |
-| DescribeInstanceAttribute | Four attributes, `<value>`-wrapped — see [Instance attributes](#instance-attributes) |
+| DescribeInstanceAttribute | Five attributes, scalars `<value>`-wrapped — see [Instance attributes](#instance-attributes) |
 | ModifyInstanceAttribute | `InstanceType.Value`, `UserData.Value`, `DisableApiTermination.Value`; the first two [require a stopped instance](#instance-attributes) |
 | CreateVpc | |
 | DescribeVpcs | [Explicit resource IDs](#explicit-resource-ids) |
@@ -3058,11 +3058,45 @@ Substrate's own choices, where the API model does not decide:
   mapping is still recorded.
 
 Not modeled: `Ebs.KmsKeyId` (left out rather than stored and hidden),
-`TagSpecification` scoped to `volume` (see the tag-specification note above),
-`InvalidBlockDeviceMapping` validation, and `blockDeviceMapping` on
-`DescribeInstances` or `DescribeInstanceAttribute` — the latter is still on the
-explicit-refusal list, since the shape it would render carries no size and so would
-not answer the question `DescribeVolumes` now does.
+`TagSpecification` scoped to `volume` (see the tag-specification note above), and
+`InvalidBlockDeviceMapping` validation.
+
+#### An instance reports its own block devices
+
+`DescribeInstances`, `RunInstances` and `DescribeInstanceAttribute` each render a
+`blockDeviceMapping` set for an instance, so a caller no longer has to go to
+`DescribeVolumes` and filter on `attachment.instance-id` to learn which volume is on
+which device.
+
+The set is **derived from the volume records**, not from the mappings the launch
+recorded. That is what makes it track reality rather than intent: a volume attached
+with `AttachVolume` after launch appears, one detached stops appearing, and an
+instance store device never appears because it never became a volume. `EC2Instance`
+carries no block-device field of its own, so the volumes are also the only available
+source.
+
+Each item is AWS's `InstanceBlockDeviceMapping` — `deviceName` plus an `ebs`
+sub-element — and the `ebs` element carries the four members AWS's own sample shows:
+`volumeId`, `status`, `attachTime` and `deleteOnTermination`. AWS's
+`EbsInstanceBlockDevice` has eight members and **no size**, which is why this set does
+not replace `DescribeVolumes` for the question above: the other four
+(`associatedResource`, `ebsCardIndex`, `operator`, `volumeOwnerId`) are omitted rather
+than defaulted, since substrate records nothing behind them and a fabricated
+`volumeOwnerId` would be indistinguishable from a real one. `status` uses AWS's
+four-value `AttachmentStatus` enum, which is not the five-value volume-side enum
+`DescribeVolumes` renders.
+
+Two substrate choices, where the API model does not decide:
+
+- **`RunInstances` renders the set populated.** The reference's only `RunInstances`
+  sample response emits `<blockDeviceMapping />` empty, on a `pending` instance whose
+  request declared no mappings at all. Substrate's instances are running by the time
+  `RunInstances` answers and their volumes already exist — the same ground
+  `networkInterfaceSet` is rendered on.
+- **The set is ordered by device name**, with the volume ID breaking a tie.
+  `DescribeInstances` states outright that its own order may vary, so no fidelity
+  claim rests on this; a deterministic emulator answering one request two ways would
+  break the guarantee the project exists for.
 
 ### A launch is authorized against every resource it names
 
@@ -3136,7 +3170,7 @@ nothing could observe it, so a consumer could not assert that the user data thei
 intended reached the instance — including the value a
 [launch template supplied](#a-launch-template-merges-with-the-request-field-by-field).
 
-Four attributes are readable, being the ones that correspond to state substrate holds:
+Five attributes are readable, being the ones that correspond to state substrate holds:
 
 | `Attribute` | Reports |
 |---|---|
@@ -3144,6 +3178,7 @@ Four attributes are readable, being the ones that correspond to state substrate 
 | `instanceType` | |
 | `disableApiTermination` | `true` or `false`; recorded at launch and by `ModifyInstanceAttribute` |
 | `groupSet` | `groupSet>item` with `groupId`/`groupName`, the same shape [`DescribeInstances` reports](#security-groups-on-an-instance) |
+| `blockDeviceMapping` | `blockDeviceMapping>item`, the same set [an instance reports](#an-instance-reports-its-own-block-devices) |
 
 Scalar values are **wrapped in a `<value>` element**, which all three of the
 reference's worked examples show and which matches the `AttributeValue` type the
@@ -3156,8 +3191,11 @@ response elements carry:
 </DescribeInstanceAttributeResponse>
 ```
 
-Exactly one attribute appears per response — the one asked for. `groupSet` is the
-exception to the wrapper: it is an array of `GroupIdentifier`, not an `AttributeValue`.
+Exactly one attribute appears per response — the one asked for. `groupSet` and
+`blockDeviceMapping` are the exceptions to the wrapper: they are arrays, not
+`AttributeValue`s. Both are rendered as a **present-but-empty** element when the
+instance has none, rather than an omitted one, because an SDK maps a present-but-empty
+element to an empty slice and an omitted one to nil.
 
 `Attribute` is **Required: Yes**, so an absent one fails with `MissingParameter`
 (`The request must contain the parameter Attribute`). An unknown instance ID fails
@@ -3167,8 +3205,8 @@ as [everywhere else](#explicit-resource-ids).
 #### Unmodelled attributes are refused, not defaulted
 
 Every other name in the documented valid-values list — `kernel`, `ramdisk`,
-`sourceDestCheck`, `blockDeviceMapping`, `productCodes`, `ebsOptimized`,
-`rootDeviceName`, `sriovNetSupport`, `enaSupport`, `enclaveOptions`,
+`sourceDestCheck`, `productCodes`, `ebsOptimized`, `rootDeviceName`,
+`sriovNetSupport`, `enaSupport`, `enclaveOptions`,
 `instanceInitiatedShutdownBehavior`, `disableApiStop` — is rejected:
 
 ```

--- a/emulator/ec2_instance_blockdevices.go
+++ b/emulator/ec2_instance_blockdevices.go
@@ -1,0 +1,135 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// ec2BlockDeviceMappingItem is one blockDeviceMapping>item as an *instance* renders
+// it, mirroring AWS's InstanceBlockDeviceMapping.
+//
+// The shape is exactly deviceName plus an ebs sub-element. It is not the shape
+// RunInstances and CreateLaunchTemplate *accept* — AWS's request-side
+// BlockDeviceMapping carries virtualName, noDevice and a sized EbsBlockDevice, none
+// of which appear here — so the two are deliberately separate types rather than one
+// reused in both directions.
+//
+// Declared once at package level for the reason [ec2GroupItem] is: three surfaces
+// render this set, and three private copies is exactly how the instance items drifted
+// apart before (#444).
+type ec2BlockDeviceMappingItem struct {
+	// DeviceName is the device the volume is attached at, taken from the attachment
+	// rather than from the recorded request.
+	DeviceName string `xml:"deviceName"`
+
+	// Ebs is the attached volume. AWS's InstanceBlockDeviceMapping has no other
+	// member, so there is nothing to omit beside it.
+	Ebs ec2EbsInstanceBlockDeviceItem `xml:"ebs"`
+}
+
+// ec2EbsInstanceBlockDeviceItem is AWS's EbsInstanceBlockDevice.
+//
+// AWS's shape carries eight members — associatedResource, attachTime,
+// deleteOnTermination, ebsCardIndex, operator, status, volumeId and volumeOwnerId —
+// and notably **no size**, which is why rendering this set does not answer the
+// question #666 made DescribeVolumes answer. The four rendered here are the four
+// AWS's own sample response shows, in its order, and each one is read straight off a
+// stored attachment. The other four are omitted rather than defaulted: substrate
+// records nothing behind them, and a fabricated volumeOwnerId is indistinguishable to
+// a caller from a real one.
+type ec2EbsInstanceBlockDeviceItem struct {
+	VolumeID string `xml:"volumeId"`
+
+	// Status is the attachment's state, which uses the four-value AttachmentStatus
+	// enum — attaching, attached, detaching, detached. DescribeVolumes' volume-side
+	// status is a *five*-value enum that adds busy, so the two must not be rendered
+	// through one shared helper.
+	Status string `xml:"status"`
+
+	AttachTime          string `xml:"attachTime"`
+	DeleteOnTermination bool   `xml:"deleteOnTermination"`
+}
+
+// ec2BlockDeviceMappingSetXML wraps the mapping items so
+// DescribeInstanceAttribute can omit the element entirely.
+//
+// It exists for the reason [ec2GroupSetXML] does: encoding/xml emits the parent
+// element of a `blockDeviceMapping>item` path even when the slice is empty, so a
+// caller asking for userData would be told the instance has no block devices. A nil
+// pointer is skipped outright.
+type ec2BlockDeviceMappingSetXML struct {
+	Items []ec2BlockDeviceMappingItem `xml:"item"`
+}
+
+// ec2BlockDeviceMappingsByInstance returns every instance's block device mappings in
+// one account and region, keyed by instance ID.
+//
+// The set is derived from the **volume records**, not from the mappings a launch
+// recorded, which is what makes it track reality: a volume attached after launch
+// appears, a detached one stops appearing, and an instance store device never appears
+// because it never became a volume (#666's rule for DescribeVolumes, inherited here
+// for free). EC2Instance carries no block-device field at all, so the volumes are
+// also the only available source.
+//
+// The whole set is read once and bucketed rather than listed per instance:
+// DescribeInstances already does one List plus a Get per security group per instance,
+// and a per-instance List would compound that into an instances × volumes scan.
+//
+// Each instance's items are ordered by device name. AWS states outright that its own
+// order may vary, so no fidelity claim rests on this — but state-listing order is not
+// a promise substrate makes, and a deterministic emulator answering one request two
+// ways would break the guarantee the project exists for.
+func (p *EC2Plugin) ec2BlockDeviceMappingsByInstance(
+	accountID, region string,
+) (map[string][]ec2BlockDeviceMappingItem, error) {
+	ctx := context.Background()
+	keys, err := p.state.List(ctx, ec2Namespace, ec2VolumeStatePrefix(accountID, region))
+	if err != nil {
+		return nil, fmt.Errorf("ec2 block device mapping volume list: %w", err)
+	}
+
+	byInstance := make(map[string][]ec2BlockDeviceMappingItem)
+	for _, key := range keys {
+		data, getErr := p.state.Get(ctx, ec2Namespace, key)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var vol EC2Volume
+		if json.Unmarshal(data, &vol) != nil {
+			continue
+		}
+		// One volume can carry several attachments in the record's shape, so each is
+		// mapped independently rather than only the first: a volume attached to two
+		// instances must appear on both, and skipping past the first would silently
+		// hide the second.
+		for _, att := range vol.Attachments {
+			if att.InstanceID == "" {
+				continue
+			}
+			byInstance[att.InstanceID] = append(byInstance[att.InstanceID],
+				ec2BlockDeviceMappingItem{
+					DeviceName: att.Device,
+					Ebs: ec2EbsInstanceBlockDeviceItem{
+						VolumeID:            vol.VolumeID,
+						Status:              att.State,
+						AttachTime:          att.AttachTime,
+						DeleteOnTermination: att.DeleteOnTermination,
+					},
+				})
+		}
+	}
+	for _, items := range byInstance {
+		sort.Slice(items, func(i, j int) bool {
+			// Volume ID breaks a device-name tie, so two volumes claiming one device
+			// — which state can hold even though real EC2 cannot — still order
+			// stably rather than by whichever the listing reached first.
+			if items[i].DeviceName != items[j].DeviceName {
+				return items[i].DeviceName < items[j].DeviceName
+			}
+			return items[i].Ebs.VolumeID < items[j].Ebs.VolumeID
+		})
+	}
+	return byInstance, nil
+}

--- a/emulator/ec2_instance_blockdevices_test.go
+++ b/emulator/ec2_instance_blockdevices_test.go
@@ -1,0 +1,365 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #669's surfaces: the instance's own view of its block devices, on the three
+// operations that render one.
+//
+// The set is derived from the volume records rather than from the recorded request,
+// which is what makes a detached volume stop appearing and an attached one start —
+// and it is also why there is nothing to fabricate: every member AWS's
+// EbsInstanceBlockDevice shows is already a field on the attachment.
+
+// instanceBDM is one blockDeviceMapping>item as an instance renders it.
+type instanceBDM struct {
+	DeviceName string `xml:"deviceName"`
+	Ebs        struct {
+		VolumeID            string `xml:"volumeId"`
+		Status              string `xml:"status"`
+		AttachTime          string `xml:"attachTime"`
+		DeleteOnTermination bool   `xml:"deleteOnTermination"`
+	} `xml:"ebs"`
+}
+
+// instanceBDMDescribeInstances returns the mappings DescribeInstances reports for one
+// instance, in response order.
+func instanceBDMDescribeInstances(t *testing.T, ts *httptest.Server, instanceID string) []instanceBDM {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":       "DescribeInstances",
+		"InstanceId.1": instanceID,
+	})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var parsed struct {
+		Instances []struct {
+			InstanceID string        `xml:"instanceId"`
+			Mappings   []instanceBDM `xml:"blockDeviceMapping>item"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), string(body))
+	require.Len(t, parsed.Instances, 1)
+	require.Equal(t, instanceID, parsed.Instances[0].InstanceID)
+	return parsed.Instances[0].Mappings
+}
+
+// instanceBDMDevices reduces a mapping set to its device names, for the assertions
+// that are about which devices appear rather than about their contents.
+func instanceBDMDevices(mappings []instanceBDM) []string {
+	devices := make([]string, 0, len(mappings))
+	for _, m := range mappings {
+		devices = append(devices, m.DeviceName)
+	}
+	return devices
+}
+
+// TestEC2_InstanceBlockDeviceMapping_DescribeInstances is #669's first surface. A
+// caller had to go to DescribeVolumes and filter on attachment.instance-id to learn a
+// device's volume ID; real EC2 answers it from the instance.
+func TestEC2_InstanceBlockDeviceMapping_DescribeInstances(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/xvda",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "30",
+		"BlockDeviceMapping.2.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.2.Ebs.VolumeSize": "40",
+	})
+	require.Len(t, ids, 1)
+
+	mappings := instanceBDMDescribeInstances(t, ts, ids[0])
+	require.Len(t, mappings, 2)
+	assert.Equal(t, []string{"/dev/sdf", "/dev/xvda"}, instanceBDMDevices(mappings),
+		"/dev/xvda configures the root rather than adding a device beside a synthesized "+
+			"one, and it keeps the name the request gave it")
+
+	// The volume IDs must be the ones DescribeVolumes reports for the same instance:
+	// two surfaces disagreeing about which volume is on a device would be worse than
+	// one of them being silent.
+	vols := bdmDescribeVolumes(t, ts, map[string]string{
+		"Filter.1.Name":    "attachment.instance-id",
+		"Filter.1.Value.1": ids[0],
+	})
+	require.Len(t, vols, 2)
+	byDevice := map[string]string{}
+	for _, v := range vols {
+		byDevice[v.bdmDevice()] = v.VolumeID
+	}
+	for _, m := range mappings {
+		assert.Equal(t, byDevice[m.DeviceName], m.Ebs.VolumeID,
+			"device %s", m.DeviceName)
+		assert.Equal(t, "attached", m.Ebs.Status,
+			"EbsInstanceBlockDevice.status uses the four-value AttachmentStatus enum")
+		assert.NotEmpty(t, m.Ebs.AttachTime)
+	}
+
+	// The two DeleteOnTermination defaults differ (#675), and this surface is where a
+	// caller most naturally reads them.
+	assert.False(t, mappings[0].Ebs.DeleteOnTermination, "/dev/sdf is a data volume")
+	assert.True(t, mappings[1].Ebs.DeleteOnTermination, "/dev/xvda is the root")
+}
+
+// TestEC2_InstanceBlockDeviceMapping_RunInstances covers the same set on the launch
+// response.
+//
+// This one is a deliberate divergence from AWS's only RunInstances sample response,
+// which emits <blockDeviceMapping /> empty on a pending instance whose request
+// declared no mappings at all. Substrate's instances are running by the time
+// RunInstances answers and their volumes already exist — the same argument
+// networkInterfaceSet is rendered on.
+func TestEC2_InstanceBlockDeviceMapping_RunInstances(t *testing.T) {
+	ts := newEC2TestServer(t)
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                              "RunInstances",
+		"ImageId":                             "ami-0abcdef1234567890",
+		"MinCount":                            "1",
+		"MaxCount":                            "1",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "40",
+	})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var parsed struct {
+		Instances []struct {
+			InstanceID string        `xml:"instanceId"`
+			Mappings   []instanceBDM `xml:"blockDeviceMapping>item"`
+		} `xml:"instancesSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), string(body))
+	require.Len(t, parsed.Instances, 1)
+
+	mappings := parsed.Instances[0].Mappings
+	require.Len(t, mappings, 2, "the data volume plus the synthesized root")
+	assert.Equal(t, []string{"/dev/sda1", "/dev/sdf"}, instanceBDMDevices(mappings))
+	for _, m := range mappings {
+		assert.NotEmpty(t, m.Ebs.VolumeID, "device %s", m.DeviceName)
+	}
+
+	// And the launch response agrees with the describe that follows it, which is the
+	// drift #444 was about.
+	described := instanceBDMDescribeInstances(t, ts, parsed.Instances[0].InstanceID)
+	assert.Equal(t, mappings, described,
+		"RunInstances and DescribeInstances must report one instance the same way")
+}
+
+// TestEC2_InstanceBlockDeviceMapping_Attribute covers the third surface, which used to
+// refuse the question outright.
+func TestEC2_InstanceBlockDeviceMapping_Attribute(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "40",
+	})
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":     "DescribeInstanceAttribute",
+		"InstanceId": ids[0],
+		"Attribute":  "blockDeviceMapping",
+	})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var parsed struct {
+		InstanceID string        `xml:"instanceId"`
+		Mappings   []instanceBDM `xml:"blockDeviceMapping>item"`
+		// The other attributes must be absent: AWS returns one attribute per call.
+		UserData     *struct{} `xml:"userData"`
+		InstanceType *struct{} `xml:"instanceType"`
+		Groups       *struct{} `xml:"groupSet"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), string(body))
+	assert.Equal(t, ids[0], parsed.InstanceID)
+	require.Len(t, parsed.Mappings, 2)
+	assert.Equal(t, []string{"/dev/sda1", "/dev/sdf"}, instanceBDMDevices(parsed.Mappings))
+	assert.Nil(t, parsed.UserData, "userData must not appear in a blockDeviceMapping response")
+	assert.Nil(t, parsed.InstanceType)
+	assert.Nil(t, parsed.Groups, "groupSet's element must stay absent")
+
+	// A blockDeviceMapping response does not carry a <value> wrapper: it is one of the
+	// InstanceAttribute members that is not an AttributeValue.
+	assert.NotContains(t, string(body), "<value>")
+}
+
+// TestEC2_InstanceBlockDeviceMapping_InstanceStoreAndNoDevice pins that neither a
+// suppressed device nor an instance store device appears, matching what #666 decided
+// for DescribeVolumes. Deriving the set from the volumes is what makes that automatic:
+// neither ever became a volume.
+func TestEC2_InstanceBlockDeviceMapping_InstanceStoreAndNoDevice(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":  "/dev/sdb",
+		"BlockDeviceMapping.1.NoDevice":    "",
+		"BlockDeviceMapping.2.DeviceName":  "/dev/sdc",
+		"BlockDeviceMapping.2.VirtualName": "ephemeral0",
+	})
+
+	mappings := instanceBDMDescribeInstances(t, ts, ids[0])
+	assert.Equal(t, []string{"/dev/sda1"}, instanceBDMDevices(mappings),
+		"only the synthesized root is an EBS volume")
+}
+
+// TestEC2_InstanceBlockDeviceMapping_TracksAttachments is the criterion that decides
+// the whole design: the set comes from the volumes, not from the launch request. So a
+// volume attached after launch appears and one detached stops appearing, neither of
+// which the recorded mappings could ever express.
+func TestEC2_InstanceBlockDeviceMapping_TracksAttachments(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, nil)
+
+	cvResp := ec2Request(t, ts, map[string]string{
+		"Action":           "CreateVolume",
+		"AvailabilityZone": "us-east-1a",
+		"Size":             "15",
+	})
+	cvBody, err := io.ReadAll(cvResp.Body)
+	require.NoError(t, err)
+	require.NoError(t, cvResp.Body.Close())
+	require.Equal(t, http.StatusOK, cvResp.StatusCode, string(cvBody))
+	var created struct {
+		VolumeID string `xml:"volumeId"`
+	}
+	require.NoError(t, xml.Unmarshal(cvBody, &created))
+	require.NotEmpty(t, created.VolumeID)
+
+	assert.Equal(t, []string{"/dev/sda1"},
+		instanceBDMDevices(instanceBDMDescribeInstances(t, ts, ids[0])),
+		"a volume that exists but is not attached is not the instance's device")
+
+	attResp := ec2Request(t, ts, map[string]string{
+		"Action":     "AttachVolume",
+		"VolumeId":   created.VolumeID,
+		"InstanceId": ids[0],
+		"Device":     "/dev/sdh",
+	})
+	require.Equal(t, http.StatusOK, attResp.StatusCode)
+	require.NoError(t, attResp.Body.Close())
+
+	afterAttach := instanceBDMDescribeInstances(t, ts, ids[0])
+	require.Len(t, afterAttach, 2)
+	assert.Equal(t, []string{"/dev/sda1", "/dev/sdh"}, instanceBDMDevices(afterAttach))
+	var attachedItem instanceBDM
+	for _, m := range afterAttach {
+		if m.DeviceName == "/dev/sdh" {
+			attachedItem = m
+		}
+	}
+	assert.Equal(t, created.VolumeID, attachedItem.Ebs.VolumeID)
+	assert.False(t, attachedItem.Ebs.DeleteOnTermination,
+		"a volume attached after launch is preserved, and the instance reports that")
+
+	detResp := ec2Request(t, ts, map[string]string{
+		"Action":   "DetachVolume",
+		"VolumeId": created.VolumeID,
+	})
+	require.Equal(t, http.StatusOK, detResp.StatusCode)
+	require.NoError(t, detResp.Body.Close())
+
+	assert.Equal(t, []string{"/dev/sda1"},
+		instanceBDMDevices(instanceBDMDescribeInstances(t, ts, ids[0])),
+		"a detached volume stops appearing")
+}
+
+// TestEC2_InstanceBlockDeviceMapping_PerInstance pins that a multi-count launch does
+// not let one instance report another's devices — the bucketing bug a per-instance
+// filter would hide, since each instance's volumes are read out of one list.
+func TestEC2_InstanceBlockDeviceMapping_PerInstance(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"MaxCount":                            "2",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/xvda",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "50",
+	})
+	require.Len(t, ids, 2)
+
+	seen := map[string]bool{}
+	for _, id := range ids {
+		mappings := instanceBDMDescribeInstances(t, ts, id)
+		require.Len(t, mappings, 1, "instance %s", id)
+		assert.Equal(t, "/dev/xvda", mappings[0].DeviceName)
+		assert.False(t, seen[mappings[0].Ebs.VolumeID],
+			"two instances cannot report the same volume")
+		seen[mappings[0].Ebs.VolumeID] = true
+	}
+}
+
+// TestEC2_InstanceBlockDeviceMapping_EmptySetIsAbsent covers the shape of an instance
+// with no EBS volume at all. Every launch produces a root volume, so the only way to
+// reach it is to terminate — and a terminated instance's mappings are gone with its
+// volumes.
+func TestEC2_InstanceBlockDeviceMapping_EmptySetIsAbsent(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, nil)
+
+	termResp := ec2Request(t, ts, map[string]string{
+		"Action":       "TerminateInstances",
+		"InstanceId.1": ids[0],
+	})
+	require.Equal(t, http.StatusOK, termResp.StatusCode)
+	require.NoError(t, termResp.Body.Close())
+
+	assert.Empty(t, instanceBDMDescribeInstances(t, ts, ids[0]),
+		"the root volume was deleted with the instance, so it reports no devices")
+
+	// The attribute surface answers the same instance with a present-but-empty
+	// element, which is the shape groupSet and userData already use for "nothing to
+	// report": an SDK maps a present-but-empty element to an empty slice and an
+	// omitted one to nil.
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":     "DescribeInstanceAttribute",
+		"InstanceId": ids[0],
+		"Attribute":  "blockDeviceMapping",
+	})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	assert.Contains(t, string(body), "<blockDeviceMapping>",
+		"the element is present even with no devices to list")
+}
+
+// TestEC2_InstanceBlockDeviceMapping_DeterministicOrder pins that the set comes back
+// in a stable order.
+//
+// AWS states outright that its order may vary, so no fidelity claim rests on this —
+// but a deterministic emulator answering one request two ways would break the
+// guarantee the project exists for, and a consumer indexing the set would flake.
+func TestEC2_InstanceBlockDeviceMapping_DeterministicOrder(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdz",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "10",
+		"BlockDeviceMapping.2.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.2.Ebs.VolumeSize": "20",
+		"BlockDeviceMapping.3.DeviceName":     "/dev/xvda",
+		"BlockDeviceMapping.3.Ebs.VolumeSize": "30",
+	})
+
+	first := instanceBDMDevices(instanceBDMDescribeInstances(t, ts, ids[0]))
+	require.Len(t, first, 3)
+	sorted := append([]string(nil), first...)
+	sort.Strings(sorted)
+	assert.Equal(t, sorted, first, "the set is ordered by device name")
+
+	for range 3 {
+		assert.Equal(t, first,
+			instanceBDMDevices(instanceBDMDescribeInstances(t, ts, ids[0])),
+			"the same request must answer the same way")
+	}
+}

--- a/emulator/ec2_instanceattribute.go
+++ b/emulator/ec2_instanceattribute.go
@@ -16,7 +16,7 @@ import (
 //	productCodes | sourceDestCheck | groupSet | ebsOptimized | sriovNetSupport |
 //	enaSupport | enclaveOptions | disableApiStop
 //
-// Substrate reads the four that correspond to state it actually holds. The rest are
+// Substrate reads the five that correspond to state it actually holds. The rest are
 // deliberately rejected rather than answered with a default: reporting
 // sourceDestCheck as false, say, would be indistinguishable from a real instance
 // that has it disabled, and a consumer asserting on it would get a green test built
@@ -32,6 +32,7 @@ const (
 	ec2AttrInstanceType          = "instanceType"
 	ec2AttrGroupSet              = "groupSet"
 	ec2AttrDisableAPITermination = "disableApiTermination"
+	ec2AttrBlockDeviceMapping    = "blockDeviceMapping"
 )
 
 // ec2InstanceAttributeXML is one DescribeInstanceAttribute response.
@@ -68,6 +69,13 @@ type ec2InstanceAttributeXML struct {
 	// <groupSet></groupSet>, and a caller asking for userData would be told the
 	// instance has no security groups. A nil pointer is skipped outright.
 	Groups *ec2GroupSetXML `xml:"groupSet,omitempty"`
+
+	// BlockDeviceMappings is the other non-AttributeValue attribute substrate answers,
+	// and it is a pointer for the same reason Groups is (#669). AWS publishes no
+	// blockDeviceMapping example on this operation, so the present-but-empty shape for
+	// an instance with no EBS volumes rests on the groupSet and userData reasoning in
+	// this file rather than on anything the reference settles.
+	BlockDeviceMappings *ec2BlockDeviceMappingSetXML `xml:"blockDeviceMapping,omitempty"`
 }
 
 // ec2GroupSetXML wraps the groupSet items so the element can be omitted entirely.
@@ -150,6 +158,18 @@ func (p *EC2Plugin) describeInstanceAttribute(reqCtx *RequestContext, req *AWSRe
 		// same reason an unset userData is present: an SDK distinguishes an empty
 		// array from a nil one.
 		resp.Groups = &ec2GroupSetXML{Items: p.ec2GroupItems(reqCtx, inst.SecurityGroupIDs)}
+	case ec2AttrBlockDeviceMapping:
+		// Derived from the volume records rather than from the launch's recorded
+		// mappings, so the answer tracks attachments made and broken after launch; see
+		// [EC2Plugin.ec2BlockDeviceMappingsByInstance]. Present-but-empty for an
+		// instance with no EBS volumes, as groupSet is.
+		mappings, mapErr := p.ec2BlockDeviceMappingsByInstance(reqCtx.AccountID, reqCtx.Region)
+		if mapErr != nil {
+			return nil, mapErr
+		}
+		resp.BlockDeviceMappings = &ec2BlockDeviceMappingSetXML{
+			Items: mappings[inst.InstanceID],
+		}
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -157,7 +177,8 @@ func (p *EC2Plugin) describeInstanceAttribute(reqCtx *RequestContext, req *AWSRe
 // ec2AttributeSupported reports whether substrate can read attr off stored state.
 func ec2AttributeSupported(attr string) bool {
 	switch attr {
-	case ec2AttrUserData, ec2AttrInstanceType, ec2AttrGroupSet, ec2AttrDisableAPITermination:
+	case ec2AttrUserData, ec2AttrInstanceType, ec2AttrGroupSet, ec2AttrDisableAPITermination,
+		ec2AttrBlockDeviceMapping:
 		return true
 	default:
 		return false

--- a/emulator/ec2_instanceattribute_test.go
+++ b/emulator/ec2_instanceattribute_test.go
@@ -246,6 +246,13 @@ func TestEC2_InstanceAttribute_DisableAPITerminationDefaultsFalse(t *testing.T) 
 // is not supported." — #4273 captures real AWS rejecting exactly it. Substrate
 // refusing a value AWS's own docs list is fidelity, not a gap, and a reader who
 // checks only the valid-values list would "fix" this into a regression.
+//
+// blockDeviceMapping used to be a row here and deliberately is not one now: #669 gave
+// substrate the state to answer it, so it moved to the supported list rather than
+// staying refused. The remaining five still cover all four refusal classes — listed and
+// rejected by AWS, not an attribute at all, listed and unmodelled, and right name in the
+// wrong case — so the list shrank without losing a class.
+// See TestEC2_InstanceBlockDeviceMapping_Attribute for the answer it gives instead.
 func TestEC2_InstanceAttribute_UnknownAttribute(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
@@ -256,7 +263,6 @@ func TestEC2_InstanceAttribute_UnknownAttribute(t *testing.T) {
 		"abc",        // not an attribute at all
 		"kernel",     // listed, and unmodelled by substrate
 		"sourceDestCheck",
-		"blockDeviceMapping",
 		"InstanceType", // valid name in the wrong case — the values are case-sensitive
 	} {
 		t.Run(attr, func(t *testing.T) {

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -662,6 +662,122 @@ type ec2GroupItem struct {
 	GroupName string `xml:"groupName,omitempty"`
 }
 
+// ec2InstanceStateItem is an instance's instanceState element.
+type ec2InstanceStateItem struct {
+	// Code is AWS's numeric state code (0 pending, 16 running, 48 terminated).
+	Code int `xml:"code"`
+
+	// Name is the state name the code corresponds to.
+	Name string `xml:"name"`
+}
+
+// ec2PlacementItem is an instance's placement element.
+//
+// Only availabilityZone is emitted: it is the one member substrate records, and it
+// must be readable for a caller to reason about TerminateInstances' zone-scoped
+// protection rule (#489).
+type ec2PlacementItem struct {
+	// AvailabilityZone is the zone the instance was placed in.
+	AvailabilityZone string `xml:"availabilityZone"`
+}
+
+// ec2IAMInstanceProfileItem is an instance's iamInstanceProfile element.
+type ec2IAMInstanceProfileItem struct {
+	// ARN is the profile's ARN, derived from the stored name when the launch gave a
+	// bare name.
+	ARN string `xml:"arn"`
+
+	// ID is the profile's AWS-side identifier.
+	ID string `xml:"id"`
+}
+
+// ec2InstanceItem is one instancesSet>item, the shape both RunInstances and
+// DescribeInstances report an instance in.
+//
+// Declared once at package level because the two responses each carried their own
+// copy and those copies had already drifted twice. #444 was the first round —
+// neither emitted a groupSet, so security groups accepted on a launch were invisible
+// to every read. By #669 they had drifted again: DescribeInstances' copy grew an
+// iamInstanceProfile that RunInstances' did not, they used different Go types for the
+// state element, and their placement and instanceState members were in opposite
+// orders. So a launch that attached an instance profile answered without it while the
+// describe that followed reported it. One shared type and one builder
+// ([EC2Plugin.ec2InstanceItemFor]) mean the two responses cannot disagree about an
+// instance again.
+type ec2InstanceItem struct {
+	InstanceID         string                     `xml:"instanceId"`
+	ImageID            string                     `xml:"imageId"`
+	InstanceType       string                     `xml:"instanceType"`
+	LaunchTime         string                     `xml:"launchTime"`
+	PrivateIPAddress   string                     `xml:"privateIpAddress"`
+	PublicIPAddress    string                     `xml:"publicIpAddress,omitempty"`
+	PublicDNSName      string                     `xml:"dnsName,omitempty"`
+	PrivateDNSName     string                     `xml:"privateDnsName,omitempty"`
+	SubnetID           string                     `xml:"subnetId"`
+	VpcID              string                     `xml:"vpcId"`
+	KeyName            string                     `xml:"keyName,omitempty"`
+	IamInstanceProfile *ec2IAMInstanceProfileItem `xml:"iamInstanceProfile,omitempty"`
+	State              ec2InstanceStateItem       `xml:"instanceState"`
+	Placement          ec2PlacementItem           `xml:"placement"`
+	Groups             []ec2GroupItem             `xml:"groupSet>item"`
+	Tags               []ec2TagItem               `xml:"tagSet>item"`
+
+	// BlockDeviceMappings is the instance's view of its EBS volumes, derived from the
+	// volume records rather than from the mappings the launch recorded (#669). It is
+	// omitted when the instance has none, which is the shape AWS's own DescribeInstances
+	// sample shows for an instance-store-backed instance.
+	BlockDeviceMappings []ec2BlockDeviceMappingItem `xml:"blockDeviceMapping>item,omitempty"`
+
+	NetworkInterfaces []ec2NetworkInterfaceItem `xml:"networkInterfaceSet>item,omitempty"`
+}
+
+// ec2InstanceItemFor builds one instance's response item, shared by RunInstances and
+// DescribeInstances so neither can report an instance differently from the other.
+//
+// mappings is the instance's block device set, resolved by the caller: both callers
+// read every volume in the account and region once and bucket by instance, because a
+// per-instance read would turn one List into an instances × volumes scan.
+func (p *EC2Plugin) ec2InstanceItemFor(
+	reqCtx *RequestContext,
+	inst EC2Instance,
+	mappings []ec2BlockDeviceMappingItem,
+) ec2InstanceItem {
+	item := ec2InstanceItem{
+		InstanceID:          inst.InstanceID,
+		ImageID:             inst.ImageID,
+		InstanceType:        inst.InstanceType,
+		LaunchTime:          inst.LaunchTime,
+		PrivateIPAddress:    inst.PrivateIPAddress,
+		PublicIPAddress:     inst.PublicIPAddress,
+		PublicDNSName:       inst.PublicDNSName,
+		PrivateDNSName:      inst.PrivateDNSName,
+		SubnetID:            inst.SubnetID,
+		VpcID:               inst.VPCID,
+		KeyName:             inst.KeyName,
+		State:               ec2InstanceStateItem{Code: inst.State.Code, Name: inst.State.Name},
+		Placement:           ec2PlacementItem{AvailabilityZone: inst.AvailabilityZone},
+		Groups:              p.ec2GroupItems(reqCtx, inst.SecurityGroupIDs),
+		BlockDeviceMappings: mappings,
+		NetworkInterfaces:   p.ec2NetworkInterfaceItems(reqCtx, inst),
+	}
+	// Echo the IAM instance profile set at launch (#331). The stored value is the name
+	// or ARN supplied; surface it as the ARN and derive an id so a caller can read back
+	// the profile it attached.
+	if inst.IamInstanceProfile != "" {
+		arn := inst.IamInstanceProfile
+		if !strings.HasPrefix(arn, "arn:") {
+			arn = "arn:aws:iam::" + reqCtx.AccountID + ":instance-profile/" + inst.IamInstanceProfile
+		}
+		item.IamInstanceProfile = &ec2IAMInstanceProfileItem{ARN: arn, ID: "AIPA" + randomHex(8)}
+	}
+	// Echo launch-time tags (from TagSpecifications) — real EC2 populates tagSet in
+	// the RunInstances response, not just DescribeInstances (#351).
+	for _, t := range inst.Tags {
+		item.Tags = append(item.Tags, ec2TagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck // XML tags differ from EC2Tag's JSON tags.
+	}
+	return item
+}
+
 // ec2NetworkInterfaceItem is one networkInterfaceSet>item, the shape both
 // RunInstances and DescribeInstances report an instance's interfaces in.
 //
@@ -770,38 +886,22 @@ func (p *EC2Plugin) ec2GroupItems(reqCtx *RequestContext, groupIDs []string) []e
 	return items
 }
 
+// runInstancesResponse renders a launch's instances.
+//
+// It reports the same members DescribeInstances does, through the one shared
+// [ec2InstanceItem]: networkInterfaceSet, whose presence AWS's own sample response
+// carries (#455); tagSet, which real EC2 populates on a launch (#351);
+// iamInstanceProfile, which DescribeInstances reported and this response silently
+// omitted until #669; and blockDeviceMapping.
+//
+// blockDeviceMapping is a deliberate divergence. AWS's only RunInstances sample
+// response emits <blockDeviceMapping /> empty, on a pending instance whose request
+// declared no mappings at all — so the reference neither shows nor forbids a populated
+// set here. Substrate renders one on the grounds networkInterfaceSet already uses: its
+// instances are running by the time RunInstances answers and their volumes already
+// exist, so reporting the instance as having no block devices would contradict the
+// state beside it.
 func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID string, reqCtx *RequestContext) (*AWSResponse, error) {
-	type tagItem struct {
-		Key   string `xml:"key"`
-		Value string `xml:"value"`
-	}
-	// See [EC2Plugin.describeInstances]'s placement item: RunInstances reports the
-	// zone too, so a caller launching into two zones can read back which is which
-	// without a follow-up describe.
-	type placementItem struct {
-		AvailabilityZone string `xml:"availabilityZone"`
-	}
-	type ec2InstanceItem struct {
-		InstanceID       string        `xml:"instanceId"`
-		ImageID          string        `xml:"imageId"`
-		InstanceType     string        `xml:"instanceType"`
-		LaunchTime       string        `xml:"launchTime"`
-		PrivateIPAddress string        `xml:"privateIpAddress"`
-		PublicIPAddress  string        `xml:"publicIpAddress,omitempty"`
-		PublicDNSName    string        `xml:"dnsName,omitempty"`
-		PrivateDNSName   string        `xml:"privateDnsName,omitempty"`
-		SubnetID         string        `xml:"subnetId"`
-		VpcID            string        `xml:"vpcId"`
-		KeyName          string        `xml:"keyName,omitempty"`
-		Placement        placementItem `xml:"placement"`
-		State            struct {
-			Code int    `xml:"code"`
-			Name string `xml:"name"`
-		} `xml:"instanceState"`
-		Groups            []ec2GroupItem            `xml:"groupSet>item"`
-		Tags              []tagItem                 `xml:"tagSet>item"`
-		NetworkInterfaces []ec2NetworkInterfaceItem `xml:"networkInterfaceSet>item,omitempty"`
-	}
 	type response struct {
 		XMLName       xml.Name          `xml:"RunInstancesResponse"`
 		XMLNS         string            `xml:"xmlns,attr"`
@@ -810,39 +910,19 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 		Instances     []ec2InstanceItem `xml:"instancesSet>item"`
 	}
 
+	mappings, err := p.ec2BlockDeviceMappingsByInstance(reqCtx.AccountID, reqCtx.Region)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := response{
 		XMLNS:         "http://ec2.amazonaws.com/doc/2016-11-15/",
 		ReservationID: reservationID,
 		OwnerID:       reqCtx.AccountID,
 	}
 	for _, inst := range instances {
-		item := ec2InstanceItem{
-			InstanceID:       inst.InstanceID,
-			ImageID:          inst.ImageID,
-			InstanceType:     inst.InstanceType,
-			LaunchTime:       inst.LaunchTime,
-			PrivateIPAddress: inst.PrivateIPAddress,
-			PublicIPAddress:  inst.PublicIPAddress,
-			PublicDNSName:    inst.PublicDNSName,
-			PrivateDNSName:   inst.PrivateDNSName,
-			SubnetID:         inst.SubnetID,
-			VpcID:            inst.VPCID,
-			KeyName:          inst.KeyName,
-			Placement:        placementItem{AvailabilityZone: inst.AvailabilityZone},
-		}
-		item.State.Code = inst.State.Code
-		item.State.Name = inst.State.Name
-		item.Groups = p.ec2GroupItems(reqCtx, inst.SecurityGroupIDs)
-		// RunInstances reports networkInterfaceSet, not only DescribeInstances — the
-		// reference's own sample response carries it — so a caller can read back the
-		// interfaces it declared without a follow-up describe (#455).
-		item.NetworkInterfaces = p.ec2NetworkInterfaceItems(reqCtx, inst)
-		// Echo launch-time tags (from TagSpecifications) — real EC2 populates
-		// tagSet in the RunInstances response, not just DescribeInstances (#351).
-		for _, t := range inst.Tags {
-			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck // XML tags differ from EC2Tag's JSON tags.
-		}
-		resp.Instances = append(resp.Instances, item)
+		resp.Instances = append(resp.Instances,
+			p.ec2InstanceItemFor(reqCtx, inst, mappings[inst.InstanceID]))
 	}
 
 	return ec2XMLResponse(http.StatusOK, resp)
@@ -922,44 +1002,6 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		return nil, fmt.Errorf("ec2 describeInstances list: %w", err)
 	}
 
-	type ec2StateItem struct {
-		Code int    `xml:"code"`
-		Name string `xml:"name"`
-	}
-	type tagItem struct {
-		Key   string `xml:"key"`
-		Value string `xml:"value"`
-	}
-	type iamProfileItem struct {
-		ARN string `xml:"arn"`
-		ID  string `xml:"id"`
-	}
-	// placementItem is the instance's placement structure. Only availabilityZone is
-	// emitted: it is the one member substrate records, and it must be readable for a
-	// caller to reason about TerminateInstances' zone-scoped protection rule (#489).
-	type placementItem struct {
-		AvailabilityZone string `xml:"availabilityZone"`
-	}
-	type ec2InstanceItem struct {
-		InstanceID         string          `xml:"instanceId"`
-		ImageID            string          `xml:"imageId"`
-		InstanceType       string          `xml:"instanceType"`
-		LaunchTime         string          `xml:"launchTime"`
-		PrivateIPAddress   string          `xml:"privateIpAddress"`
-		PublicIPAddress    string          `xml:"publicIpAddress,omitempty"`
-		PublicDNSName      string          `xml:"dnsName,omitempty"`
-		PrivateDNSName     string          `xml:"privateDnsName,omitempty"`
-		SubnetID           string          `xml:"subnetId"`
-		VpcID              string          `xml:"vpcId"`
-		KeyName            string          `xml:"keyName,omitempty"`
-		IamInstanceProfile *iamProfileItem `xml:"iamInstanceProfile,omitempty"`
-		State              ec2StateItem    `xml:"instanceState"`
-		Placement          placementItem   `xml:"placement"`
-		Groups             []ec2GroupItem  `xml:"groupSet>item"`
-		Tags               []tagItem       `xml:"tagSet>item"`
-
-		NetworkInterfaces []ec2NetworkInterfaceItem `xml:"networkInterfaceSet>item,omitempty"`
-	}
 	type reservationItem struct {
 		ReservationID string            `xml:"reservationId"`
 		OwnerID       string            `xml:"ownerId"`
@@ -969,6 +1011,14 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 		XMLName      xml.Name          `xml:"DescribeInstancesResponse"`
 		XMLNS        string            `xml:"xmlns,attr"`
 		Reservations []reservationItem `xml:"reservationSet>item"`
+	}
+
+	// Every volume in the account and region, read once and bucketed by instance:
+	// this loop already does a Get per instance and a Get per security group, so a
+	// per-instance volume List would compound into an instances × volumes scan.
+	mappings, err := p.ec2BlockDeviceMappingsByInstance(reqCtx.AccountID, reqCtx.Region)
+	if err != nil {
+		return nil, err
 	}
 
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
@@ -992,37 +1042,7 @@ func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (
 			continue
 		}
 
-		item := ec2InstanceItem{
-			InstanceID:       inst.InstanceID,
-			ImageID:          inst.ImageID,
-			InstanceType:     inst.InstanceType,
-			LaunchTime:       inst.LaunchTime,
-			PrivateIPAddress: inst.PrivateIPAddress,
-			PublicIPAddress:  inst.PublicIPAddress,
-			PublicDNSName:    inst.PublicDNSName,
-			PrivateDNSName:   inst.PrivateDNSName,
-			SubnetID:         inst.SubnetID,
-			VpcID:            inst.VPCID,
-			KeyName:          inst.KeyName,
-			Placement:        placementItem{AvailabilityZone: inst.AvailabilityZone},
-		}
-		item.State.Code = inst.State.Code
-		item.State.Name = inst.State.Name
-		item.Groups = p.ec2GroupItems(reqCtx, inst.SecurityGroupIDs)
-		item.NetworkInterfaces = p.ec2NetworkInterfaceItems(reqCtx, inst)
-		// Echo the IAM instance profile set at launch (#331). The stored value is
-		// the name or ARN supplied; surface it as the ARN and derive an id so a
-		// caller can read back the profile it attached.
-		if inst.IamInstanceProfile != "" {
-			arn := inst.IamInstanceProfile
-			if !strings.HasPrefix(arn, "arn:") {
-				arn = "arn:aws:iam::" + reqCtx.AccountID + ":instance-profile/" + inst.IamInstanceProfile
-			}
-			item.IamInstanceProfile = &iamProfileItem{ARN: arn, ID: "AIPA" + randomHex(8)}
-		}
-		for _, t := range inst.Tags {
-			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck
-		}
+		item := p.ec2InstanceItemFor(reqCtx, inst, mappings[inst.InstanceID])
 
 		if _, ok := resMap[inst.ReservationID]; !ok {
 			resMap[inst.ReservationID] = &reservationItem{


### PR DESCRIPTION
## What

`DescribeInstances`, `RunInstances` and `DescribeInstanceAttribute` now render a
`blockDeviceMapping` set for an instance.

#666 made a launch materialize its EBS volumes, but the only way to learn which volume sat
on which device was `DescribeVolumes` filtered on `attachment.instance-id` — a question real
EC2 answers from the instance. `DescribeInstanceAttribute` refused `blockDeviceMapping`
outright, which was right when there was nothing to render.

## The set is derived from the volumes, not from the request

That is the design decision the whole change rests on, and it is what satisfies the
detached-later-stops-appearing criterion for free:

- a volume attached with `AttachVolume` after launch **appears**,
- a detached one **stops appearing**,
- an instance store device **never appears**, because `ec2CreatesEBSVolume` excluded it in
  #666 and it therefore never became an `EC2Volume`.

`EC2Instance` carries no block-device field, so the volumes are also the only available
source. The mapping from state to AWS's shape is one-to-one and total — `deviceName` ←
`att.Device`, `volumeId` ← `vol.VolumeID`, `status` ← `att.State`, `attachTime` ←
`att.AttachTime`, `deleteOnTermination` ← `att.DeleteOnTermination` — so nothing is
fabricated.

The volume list is read **once per request and bucketed by instance ID**.
`describeInstances` already does one `List` plus a `Get` per security group per instance, so
a per-instance `List` would compound into an instances × volumes scan.

## Shape

`InstanceBlockDeviceMapping` is exactly `deviceName` + `ebs`. `EbsInstanceBlockDevice` has
eight members and **no size**; the four AWS's own sample shows are rendered, in its order.
The other four (`associatedResource`, `ebsCardIndex`, `operator`, `volumeOwnerId`) are
omitted rather than defaulted — substrate records nothing behind them, and a fabricated
`volumeOwnerId` is indistinguishable to a caller from a real one.

Because there is no size member, **this does not close #666's gap**: `docs/services.md`
still says `DescribeVolumes` is the only surface a launch-specified size is observable on,
and that sentence is deliberately kept true.

`EbsInstanceBlockDevice.status` uses the four-value `AttachmentStatus` enum, while
`DescribeVolumes`' volume-side status is a five-value enum that adds `busy` — so the two are
deliberately not rendered through one shared helper, and the type comment says why.

On `DescribeInstanceAttribute` the response needs **both** halves of the existing `groupSet`
pattern: a `*ec2BlockDeviceMappingSetXML` pointer field, so the element is absent from a
`userData` response (`encoding/xml` emits the parent of a `foo>item` path even when the
slice is empty), and an unconditional non-nil assignment in its own `case`, so an instance
with no EBS volumes renders present-but-empty. No `<value>` wrapper — it is one of the
`InstanceAttribute` members that is not an `AttributeValue`.

## Two divergences from the issue's premises, corrected rather than implemented

**The issue says `RunInstances`' response should render the set "since the reference shows it
there too". It does not.** The reference's only `RunInstances` sample response emits
`<blockDeviceMapping />`, empty, on a `pending` instance whose request declared no mappings
at all. Rendering it populated is a **deliberate divergence**, argued on substrate's own
grounds — the same ones `ec2_plugin.go` already records for `networkInterfaceSet`: substrate's
instances are running and their volumes exist by the time `RunInstances` answers. The code
comment and the release's `## Provenance` say so rather than claiming AWS settles it.

**The issue calls the two `ec2InstanceItem` structs duplicates; they had already drifted
again.** `describeInstances`' copy carried `iamInstanceProfile` and `runInstancesResponse`'
did not, they used different Go types for the state element, and their
`placement`/`instanceState` order was swapped. So `RunInstances` silently omitted the
instance profile `DescribeInstances` reported for the same instance — a live #444-class
defect, fixed as a side effect of the hoist and given its own `### Fixed` CHANGELOG line
rather than landing quietly. `ec2InstanceItem` and its four sub-items are now package-level
with one builder, following the `ec2GroupItem` / `ec2NetworkInterfaceItem` precedents whose
comments record the original #444 bug.

## Ordering

Sorted by device name, volume ID breaking a tie. `DescribeInstances` states outright that
its own order may vary, so **no fidelity claim rests on this** — but state-listing order is
not a promise substrate makes, and a deterministic emulator answering one request two ways
would break the guarantee the project exists for. No test asserts *element* order within an
item.

## Fail-before proof

All eight new tests fail on the pre-fix tree. `DescribeInstances` and `RunInstances` return
zero mappings, and the attribute surface refuses:

```
InvalidParameterValue: Value (blockDeviceMapping) for parameter attribute is invalid. Unknown attribute.
```

## Tests

Eight HTTP-tier tests in `emulator/ec2_instance_blockdevices_test.go`, reusing #666's
`bdmRunInstances` / `bdmDescribeVolumes` helpers: the three surfaces; that `RunInstances` and
`DescribeInstances` agree byte-for-byte on the set (the drift above); that the volume IDs
agree with what `DescribeVolumes` reports for the same instance; instance-store and
`NoDevice`; attach-then-detach tracking; per-instance bucketing on a two-count launch;
present-but-empty on the attribute surface after termination; and stable order across four
identical requests.

`ec2AttributeSupported` is an allow-list with a catch-all `default: return false`, so the
change is "the allow-list grew" and the `"blockDeviceMapping"` row in
`TestEC2_InstanceAttribute_UnknownAttribute` is deleted. Its doc comment now records that
the row left deliberately and that the remaining five still cover all four refusal classes —
listed-and-rejected-by-AWS, not-an-attribute, listed-and-unmodelled, and right-name-wrong-case.

## Verification

`gofmt -l` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues),
`make test` (race, all packages), `go vet -C test/e2e ./...` + `go test -C test/e2e ./...`,
`gen-service-reference -check`, `scripts/check-doc-versions.sh`, `npm --prefix docs run
build`.

## Docs

Two sites, not the one the issue names: the launch-time-storage "not modeled" paragraph
loses both `blockDeviceMapping` clauses and gains a new **"An instance reports its own block
devices"** subsection, and the instance-attributes section's unmodelled-attributes list
drops the name while its table grows a fifth row. The two operation-table rows and the
`DescribeInstanceAttribute` row are updated too.

Closes #669
