### PR TITLE
fix(ec2): a block device mapping AWS refuses is refused, not materialized (#671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the volume ID breaking a tie, since `DescribeInstances` states its own order may vary
   but a deterministic emulator must not answer one request two ways.
 
+- **A block device mapping real EC2 refuses is now refused, with `InvalidBlockDeviceMapping`**
+  (#671). Every mapping substrate could parse was accepted and materialized, so a consumer
+  whose IaC carried an invalid mapping got a green test here and a failure on real AWS — the
+  same class of defect an empty `ImageId` used to have, and the worst kind for a tool whose
+  purpose is validating infrastructure code before it reaches AWS. Six refusals, each a 400:
+
+  - An `Ebs` structure naming neither `Ebs.VolumeSize` nor `Ebs.SnapshotId`. Documented
+    verbatim on `EbsBlockDevice.VolumeSize`: "You must specify either a snapshot ID or a
+    volume size."
+  - `Ebs.Throughput` on an explicitly named volume type other than `gp3`. Documented
+    verbatim: "This parameter is valid only for `gp3` volumes."
+  - `Ebs.Iops` on an explicitly named `standard`, `st1` or `sc1`.
+  - An unparseable numeric value for `Ebs.VolumeSize`, `Ebs.Iops` or `Ebs.Throughput`, which
+    previously read as zero — so `Ebs.VolumeSize=60GB` silently produced substrate's 8 GiB
+    default rather than failing the launch.
+  - Two mappings naming one `DeviceName`.
+  - A `VirtualName` beside any `Ebs.*` member, which asks for an instance store device and an
+    EBS volume at the same device at once.
+
+  **Both type-scoped rules key off the explicitly named `VolumeType`, never the resolved
+  one.** Substrate resolves an absent type to `gp2`, but on real EC2 it comes from the AMI's
+  own mapping — commonly `gp3` — so refusing `Throughput` on a mapping that named no type
+  would refuse a launch real EC2 accepts. For the same reason, the per-type numeric size and
+  IOPS ranges the reference lists are deliberately **not** encoded: they change, and a stale
+  range is a false deny a caller cannot work around. Nor is a `VolumeSize` compared against
+  the named snapshot's, since `EC2Snapshot.VolumeSize` is a constant at its single producer
+  and substrate has no `CreateSnapshot` — the comparison would test the constant.
+
+  A mapping carrying **no `Ebs` structure at all** — a bare `DeviceName` — is still accepted
+  and still takes the 8 GiB default: the size-or-snapshot requirement is documented on a
+  member *of* the `Ebs` structure, so with no structure it has no subject. `NoDevice` and a
+  `VirtualName`-only instance store mapping are likewise untouched, both being forms AWS
+  documents as legal.
+
+  **A refusal writes nothing.** The validator runs after the launch template merge, so a
+  mapping that reaches a launch through a template is refused at `RunInstances` time and one
+  validator covers requests, templates, template versions and fleet launches alike — a fleet
+  reaches mappings only through a template. And it runs before the default-VPC branch, which
+  commits a VPC, subnet, security group, internet gateway, route table and four index
+  mutations; a refusal past that point would leave state the next request in the same test
+  could see. `CreateLaunchTemplate` itself does not refuse: its response carries a documented
+  `warning` member of type `ValidationWarning` that exists for "parameters or parameter
+  combinations that are not valid", and its Errors section lists none.
+
+  Recording the refusal needs the raw request strings, so `EC2BlockDeviceMapping` gained
+  `VolumeSizeRaw`, `IOPSRaw` and `ThroughputRaw` — the parser previously discarded them, which
+  left an unparseable value indistinguishable from an absent one by validation time, and it is
+  also the only form that survives into a launch template, whose raw parameters are gone by
+  `RunInstances` time. Adding fields is replay-safe: an older event log unmarshals them empty.
+
+  **Provenance:** `InvalidBlockDeviceMapping` is documented in EC2's client-error table ("A
+  block device mapping parameter is not valid. The returned message indicates the incorrect
+  value."), but the HTTP status is a **class-level inference** — the table says only that
+  client errors are "accompanied by a 400-series HTTP response code" — and every per-case
+  message is substrate's own, since AWS publishes no wording. AWS documents no rule for a
+  duplicate `DeviceName` or a `VirtualName` beside `Ebs.*`; both are substrate's reading. The
+  `Ebs.Iops` refusal is a short **deny** list rather than AWS's `io1 | io2 | gp3` allow list,
+  because that "supported for … only" sentence appears on
+  `LaunchTemplateEbsBlockDeviceRequest.Iops` and not on the `EbsBlockDevice` shape
+  `RunInstances` accepts, whose same member describes what `Iops` means "for `gp2` volumes" —
+  AWS contradicts itself inside one member, so substrate refuses only the three types that
+  appear in neither list. That an invalid mapping belongs in `CreateLaunchTemplate`'s warning
+  rather than an error is substrate's reading too.
+
+  **Compatibility:** a `RunInstances`, `CreateLaunchTemplate` or fleet launch that v0.104.0
+  and earlier accepted may now fail with `InvalidBlockDeviceMapping`. The likeliest case by
+  far is a mapping naming a `VolumeType` and no size, which previously produced an 8 GiB
+  volume of that type.
+
 ### Fixed
 - **`RunInstances` omitted the `iamInstanceProfile` that `DescribeInstances` reported for the
   same instance** (#669). `runInstancesResponse` and `describeInstances` each declared their

--- a/docs/services.md
+++ b/docs/services.md
@@ -2619,7 +2619,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 
 | Operation | Notes |
 |-----------|-------|
-| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
+| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); [refuses an invalid block device mapping](#a-mapping-aws-refuses-is-refused-with-invalidblockdevicemapping); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time); `availability-zone` filter |
 | TerminateInstances | [Explicit resource IDs](#explicit-resource-ids); [honours termination protection, per Availability Zone](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
@@ -3054,12 +3054,78 @@ Substrate's own choices, where the API model does not decide:
 - A volume takes the **instance's** Availability Zone, not the region's first: a
   volume must be in the same zone as the instance it is attached to, so deriving it
   any other way would produce an attachment real EC2 cannot have.
-- An unparseable number reads as zero rather than failing the launch, and the
-  mapping is still recorded.
 
-Not modeled: `Ebs.KmsKeyId` (left out rather than stored and hidden),
-`TagSpecification` scoped to `volume` (see the tag-specification note above), and
-`InvalidBlockDeviceMapping` validation.
+Not modeled: `Ebs.KmsKeyId` (left out rather than stored and hidden), and
+`TagSpecification` scoped to `volume` (see the tag-specification note above).
+
+#### A mapping AWS refuses is refused, with `InvalidBlockDeviceMapping`
+
+A launch carrying a mapping real EC2 rejects fails here too, before anything is
+written. Through the versions that first parsed these mappings, every mapping
+substrate could parse was accepted and materialized, so a consumer whose IaC carried
+an invalid mapping got a green test and a failure on real AWS — the same class of
+defect an empty `ImageId` used to have.
+
+Six refusals:
+
+| Refused | Provenance |
+|---|---|
+| An `Ebs` structure naming neither `Ebs.VolumeSize` nor `Ebs.SnapshotId` | Documented verbatim on `EbsBlockDevice.VolumeSize`: "You must specify either a snapshot ID or a volume size." |
+| `Ebs.Throughput` on an explicitly named type that is not `gp3` | Documented verbatim: "This parameter is valid only for `gp3` volumes." |
+| `Ebs.Iops` on an explicitly named `standard`, `st1` or `sc1` | The sibling launch-template shape — substrate's reading, see below |
+| An unparseable numeric value for `Ebs.VolumeSize`, `Ebs.Iops` or `Ebs.Throughput` | Substrate's own |
+| Two mappings naming one `DeviceName` | Substrate's own — AWS documents no rule |
+| A `VirtualName` beside any `Ebs.*` member | Substrate's own — AWS documents no rule |
+
+The error code is documented — EC2's client-error table lists
+`InvalidBlockDeviceMapping` as "A block device mapping parameter is not valid. The
+returned message indicates the incorrect value." The `400` is a **class-level
+inference**: the table says only that client errors are "accompanied by a 400-series
+HTTP response code", and every message is substrate's own, since AWS publishes no
+wording. Each message names the offending device, because a request can carry many
+mappings and the code alone does not say which was refused.
+
+**The scope is only what the API model states.** Per-type size and IOPS ranges are
+deliberately *not* encoded even though the reference lists them: they change, and a
+stale range is a false deny — worse than the silence it replaces, because a caller
+cannot work around a refusal of a request AWS accepts. For the same reason both
+type-scoped rules key off the **explicitly named** `VolumeType`, never the resolved
+one. Substrate resolves an absent type to `gp2`, but on real EC2 it comes from the
+AMI's own mapping, commonly `gp3`, so refusing `Throughput` on a mapping that named
+no type would refuse a launch real EC2 accepts.
+
+Three reading calls worth stating outright:
+
+- The size-or-snapshot sentence lives on `EbsBlockDevice.VolumeSize`, a member *of*
+  the `Ebs` structure. A mapping carrying **no `Ebs` structure at all** — a bare
+  `DeviceName` — names no EBS block device for the requirement to have a subject, so
+  it is still accepted and still takes substrate's 8 GiB default.
+- `Ebs.Iops` is refused by a short **deny** list rather than AWS's `io1 | io2 | gp3`
+  allow list. The "supported for `io1`, `io2`, and `gp3` volumes only" sentence is on
+  `LaunchTemplateEbsBlockDeviceRequest.Iops`, not on the `EbsBlockDevice` shape
+  `RunInstances` accepts, and the very same member's own paragraph — on both shapes —
+  explains what `Iops` means "for `gp2` volumes". AWS contradicts itself inside one
+  member, so substrate refuses only the three types that appear in neither list and
+  takes the permissive reading of `gp2`.
+- A `VolumeSize` smaller than the named snapshot's is **not** checked.
+  `EC2Snapshot.VolumeSize` is a constant at its single producer and substrate has no
+  `CreateSnapshot`, so the comparison would test that constant rather than the
+  caller's request.
+
+**A refusal writes nothing.** The validator runs after a launch template has been
+merged in — so a mapping that reaches a launch through a template is refused at
+`RunInstances` time, and one validator covers requests, templates, template versions
+and fleet launches alike, since a fleet reaches mappings only through a template —
+and before the default-VPC branch, which commits a VPC, subnet, security group,
+internet gateway, route table and four index mutations. A refusal past that point
+would leave state the next request in the same test could see.
+
+**`CreateLaunchTemplate` does not refuse.** Its response carries a documented
+`warning` member of type `ValidationWarning` that exists precisely for "parameters or
+parameter combinations that are not valid", and its Errors section lists none — so a
+`400` there would be substrate's invention. That an invalid *block device mapping*
+belongs in that warning rather than in an error is substrate's reading; rendering the
+element is not yet modeled.
 
 #### An instance reports its own block devices
 

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -86,23 +87,209 @@ func ec2ParseBlockDeviceMapping(params map[string]string, p string) (EC2BlockDev
 		VolumeType:          params[p+"Ebs.VolumeType"],
 		Encrypted:           strings.EqualFold(params[p+"Ebs.Encrypted"], "true"),
 		DeleteOnTermination: params[p+"Ebs.DeleteOnTermination"],
+
+		// The raw strings are kept beside the parsed ints so a value that does not
+		// parse stays distinguishable from an absent one; see the field docs on
+		// [EC2BlockDeviceMapping] and [ec2CheckBlockDeviceMappings] (#671).
+		VolumeSizeRaw: params[p+"Ebs.VolumeSize"],
+		IOPSRaw:       params[p+"Ebs.Iops"],
+		ThroughputRaw: params[p+"Ebs.Throughput"],
 	}
-	if n, err := strconv.Atoi(strings.TrimSpace(params[p+"Ebs.VolumeSize"])); err == nil {
+	if n, err := strconv.Atoi(strings.TrimSpace(bdm.VolumeSizeRaw)); err == nil {
 		bdm.VolumeSize = n
 	}
-	if n, err := strconv.Atoi(strings.TrimSpace(params[p+"Ebs.Iops"])); err == nil {
+	if n, err := strconv.Atoi(strings.TrimSpace(bdm.IOPSRaw)); err == nil {
 		bdm.IOPS = n
 	}
-	if n, err := strconv.Atoi(strings.TrimSpace(params[p+"Ebs.Throughput"])); err == nil {
+	if n, err := strconv.Atoi(strings.TrimSpace(bdm.ThroughputRaw)); err == nil {
 		bdm.Throughput = n
 	}
 
 	present := hasNoDevice || bdm.DeviceName != "" || bdm.VirtualName != "" ||
 		bdm.SnapshotID != "" || bdm.VolumeType != "" ||
-		params[p+"Ebs.VolumeSize"] != "" || params[p+"Ebs.Iops"] != "" ||
-		params[p+"Ebs.Throughput"] != "" || params[p+"Ebs.Encrypted"] != "" ||
-		params[p+"Ebs.DeleteOnTermination"] != ""
+		bdm.VolumeSizeRaw != "" || bdm.IOPSRaw != "" ||
+		bdm.ThroughputRaw != "" || params[p+"Ebs.Encrypted"] != "" ||
+		bdm.DeleteOnTermination != ""
 	return bdm, present
+}
+
+// ec2NamesEbsMember reports whether a mapping carries any member of the Ebs
+// structure.
+//
+// It is what scopes the "you must specify either a snapshot ID or a volume size"
+// refusal. AWS's sentence lives on EbsBlockDevice.VolumeSize — a member *of* the Ebs
+// structure — so a mapping that carries no Ebs structure at all names no EBS block
+// device for the requirement to have a subject, and substrate keeps applying its 8 GiB
+// default to it. A mapping that names Ebs.VolumeType and nothing else is
+// unambiguously configuring a volume and has given neither of the two things one of
+// which is required.
+func ec2NamesEbsMember(bdm EC2BlockDeviceMapping) bool {
+	return bdm.SnapshotID != "" || bdm.VolumeType != "" || bdm.Encrypted ||
+		bdm.VolumeSizeRaw != "" || bdm.IOPSRaw != "" || bdm.ThroughputRaw != "" ||
+		bdm.DeleteOnTermination != ""
+}
+
+// ec2VolumeTypesWithoutIOPS names the volume types for which Ebs.Iops is meaningless.
+//
+// It is deliberately a refusal list rather than the allow list AWS's sentence implies.
+// The "supported for io1, io2, and gp3 volumes only" wording lives on
+// LaunchTemplateEbsBlockDeviceRequest.Iops, not on the EbsBlockDevice shape
+// RunInstances accepts, and the very same member's own paragraph — on both shapes —
+// explains what Iops means "for gp2 volumes". AWS contradicts itself within one
+// member, so substrate refuses only the three types that appear in neither the
+// supported-values list nor that paragraph, and takes the permissive reading of gp2.
+// See [ec2CheckBlockDeviceMappings] for why an *absent* type refuses nothing.
+var ec2VolumeTypesWithoutIOPS = map[string]bool{"standard": true, "st1": true, "sc1": true}
+
+// ec2CheckBlockDeviceMappings returns the error EC2 raises for a block device mapping
+// it will not accept, or nil.
+//
+// Through v0.104.0 substrate accepted every mapping it could parse and materialized a
+// volume from it, so a launch AWS refuses succeeded here — the same class of defect
+// #412 closed for an empty ImageId, and worse after #666, because the mapping now
+// produces state a consumer asserts against.
+//
+// # Scope
+//
+// Only what the API model states. Per-type size and IOPS ranges are deliberately not
+// encoded even though the reference lists them: they change, and a stale range is a
+// false deny — which is worse than the silence it replaces, because a caller cannot
+// work around a refusal of a request AWS accepts. For the same reason both type-scoped
+// rules key off the **explicitly named** VolumeType rather than the resolved one:
+// substrate resolves an absent type to gp2, but on real EC2 it comes from the AMI's own
+// mapping, commonly gp3.
+//
+// Also deliberately absent: a VolumeSize smaller than the named snapshot's.
+// EC2Snapshot.VolumeSize is the literal 8 at its single producer and substrate has no
+// CreateSnapshot, so the comparison would test a constant rather than the caller's
+// request. That is a follow-up, together with InvalidSnapshot.NotFound.
+//
+// # Provenance
+//
+// Two rules are documented verbatim — the size-or-snapshot requirement on
+// EbsBlockDevice.VolumeSize and "This parameter is valid only for gp3 volumes" on
+// Throughput. The Iops rule rests on the sibling launch-template shape; see
+// [ec2VolumeTypesWithoutIOPS]. Refusing a duplicate device name and a virtualName
+// beside an Ebs member rests on **substrate's own reading** — AWS documents no rule for
+// either, and neither is a thing real EC2 can act on, since one device cannot carry two
+// volumes and an instance store device is not an EBS volume. Refusing an unparseable
+// number is substrate's own too, and it is the reason the raw strings are recorded at
+// all.
+//
+// Every message is substrate's own; AWS publishes none. The code is documented — the
+// client-error table lists InvalidBlockDeviceMapping as "A block device mapping
+// parameter is not valid. The returned message indicates the incorrect value." The
+// status is a class-level inference: the table says only that client errors are
+// "accompanied by a 400-series HTTP response code", and substrate has no code-to-status
+// table to consult.
+//
+// # Placement
+//
+// Call it after a launch template has been merged in, so a mapping that reaches a
+// launch through a template is refused at RunInstances time, and before anything is
+// written, so a refusal leaves no state behind. CreateLaunchTemplate deliberately does
+// not call it: its response carries a documented `warning` member of type
+// ValidationWarning that exists for "parameters or parameter combinations that are not
+// valid", and its Errors section lists none — so a 400 there would be substrate's
+// invention. That an invalid block device mapping belongs in that warning is
+// substrate's reading; rendering the element is a follow-up.
+func ec2CheckBlockDeviceMappings(mappings []EC2BlockDeviceMapping) *AWSError {
+	seen := make(map[string]bool, len(mappings))
+	for _, bdm := range mappings {
+		if awsErr := ec2CheckBlockDeviceMapping(bdm); awsErr != nil {
+			return awsErr
+		}
+		// Only a mapping that materializes a volume can collide: NoDevice suppresses
+		// its device and a virtualName-only mapping names an instance store device, so
+		// neither occupies the device in a way a second mapping could contend for.
+		if !ec2CreatesEBSVolume(bdm) || bdm.DeviceName == "" {
+			continue
+		}
+		if seen[bdm.DeviceName] {
+			return ec2InvalidBlockDeviceMapping("",
+				"device "+bdm.DeviceName+" is named by more than one mapping")
+		}
+		seen[bdm.DeviceName] = true
+	}
+	return nil
+}
+
+// ec2CheckBlockDeviceMapping applies the rules that concern one mapping in isolation.
+//
+// The unparseable-number checks run first: a garbage size makes every judgement below
+// meaningless, and reporting the malformed value is more use to a caller than reporting
+// a consequence of it. The virtualName conflict runs before the size requirement, since
+// a mapping combining the two is wrong in a way that naming a size would not fix.
+func ec2CheckBlockDeviceMapping(bdm EC2BlockDeviceMapping) *AWSError {
+	device := bdm.DeviceName
+	for _, num := range []struct{ member, raw string }{
+		{"Ebs.VolumeSize", bdm.VolumeSizeRaw},
+		{"Ebs.Iops", bdm.IOPSRaw},
+		{"Ebs.Throughput", bdm.ThroughputRaw},
+	} {
+		if num.raw == "" {
+			continue
+		}
+		if _, err := strconv.Atoi(strings.TrimSpace(num.raw)); err != nil {
+			return ec2InvalidBlockDeviceMapping(device,
+				fmt.Sprintf("%s value %q is not an integer", num.member, num.raw))
+		}
+	}
+
+	if bdm.NoDevice {
+		// A suppressed device carries nothing to validate. AWS documents NoDevice
+		// beside the other members rather than as exclusive of them, so a mapping
+		// naming both is not refused — it suppresses the device, which is what
+		// ec2CreatesEBSVolume already decided.
+		return nil
+	}
+
+	if bdm.VirtualName != "" && ec2NamesEbsMember(bdm) {
+		return ec2InvalidBlockDeviceMapping(device,
+			"virtualName names an instance store device and cannot be combined with an Ebs member")
+	}
+
+	if ec2CreatesEBSVolume(bdm) && ec2NamesEbsMember(bdm) &&
+		bdm.VolumeSizeRaw == "" && bdm.SnapshotID == "" {
+		return ec2InvalidBlockDeviceMapping(device,
+			"you must specify either a snapshot ID or a volume size")
+	}
+
+	// Both type rules read the named type, never the resolved one; see
+	// [ec2CheckBlockDeviceMappings]. An absent type therefore refuses nothing.
+	volType := strings.ToLower(bdm.VolumeType)
+	if volType == "" {
+		return nil
+	}
+	if bdm.ThroughputRaw != "" && volType != "gp3" {
+		return ec2InvalidBlockDeviceMapping(device,
+			"Ebs.Throughput is valid only for gp3 volumes, not "+bdm.VolumeType)
+	}
+	if bdm.IOPSRaw != "" && ec2VolumeTypesWithoutIOPS[volType] {
+		return ec2InvalidBlockDeviceMapping(device,
+			"Ebs.Iops is not supported for "+bdm.VolumeType+" volumes")
+	}
+	return nil
+}
+
+// ec2InvalidBlockDeviceMapping returns EC2's InvalidBlockDeviceMapping error, naming
+// the offending device when the mapping has one.
+//
+// The device name is interpolated because a request can carry many mappings and the
+// code alone does not say which one was refused — the same reason
+// [ec2UnknownInstanceAttribute] interpolates its attribute. A mapping that names no
+// device gets the unqualified form rather than a stray "for ": the cross-mapping
+// duplicate check names its device in the detail instead.
+func ec2InvalidBlockDeviceMapping(device, detail string) *AWSError {
+	msg := "Invalid block device mapping: " + detail
+	if device != "" {
+		msg = "Invalid block device mapping for " + device + ": " + detail
+	}
+	return &AWSError{
+		Code:       "InvalidBlockDeviceMapping",
+		Message:    msg,
+		HTTPStatus: http.StatusBadRequest,
+	}
 }
 
 // ec2IsRootDevice reports whether a device name names the root volume.

--- a/emulator/ec2_block_devices_test.go
+++ b/emulator/ec2_block_devices_test.go
@@ -40,7 +40,7 @@ func TestEC2ParseBlockDeviceMappings(t *testing.T) {
 				"BlockDeviceMapping.1.Ebs.VolumeSize": "60",
 			},
 			want: []emulator.EC2BlockDeviceMapping{
-				{DeviceName: "/dev/xvda", VolumeSize: 60},
+				{DeviceName: "/dev/xvda", VolumeSize: 60, VolumeSizeRaw: "60"},
 			},
 		},
 		{
@@ -64,6 +64,9 @@ func TestEC2ParseBlockDeviceMappings(t *testing.T) {
 				Throughput:          250,
 				Encrypted:           true,
 				DeleteOnTermination: "false",
+				VolumeSizeRaw:       "100",
+				IOPSRaw:             "4000",
+				ThroughputRaw:       "250",
 			}},
 		},
 		{
@@ -79,9 +82,9 @@ func TestEC2ParseBlockDeviceMappings(t *testing.T) {
 				"BlockDeviceMapping.3.Ebs.VolumeSize": "50",
 			},
 			want: []emulator.EC2BlockDeviceMapping{
-				{DeviceName: "/dev/sda1", VolumeSize: 30},
-				{DeviceName: "/dev/sdf", VolumeSize: 40},
-				{DeviceName: "/dev/sdg", VolumeSize: 50},
+				{DeviceName: "/dev/sda1", VolumeSize: 30, VolumeSizeRaw: "30"},
+				{DeviceName: "/dev/sdf", VolumeSize: 40, VolumeSizeRaw: "40"},
+				{DeviceName: "/dev/sdg", VolumeSize: 50, VolumeSizeRaw: "50"},
 			},
 		},
 		{
@@ -101,7 +104,7 @@ func TestEC2ParseBlockDeviceMappings(t *testing.T) {
 			params: map[string]string{
 				"BlockDeviceMapping.1.Ebs.VolumeSize": "25",
 			},
-			want: []emulator.EC2BlockDeviceMapping{{VolumeSize: 25}},
+			want: []emulator.EC2BlockDeviceMapping{{VolumeSize: 25, VolumeSizeRaw: "25"}},
 		},
 		{
 			// NoDevice is an empty-string member on the wire, so its presence is the
@@ -137,19 +140,25 @@ func TestEC2ParseBlockDeviceMappings(t *testing.T) {
 				"BlockDeviceMapping.1.DeviceName": "/dev/sdz",
 			},
 			want: []emulator.EC2BlockDeviceMapping{
-				{DeviceName: "/dev/sda1", VolumeSize: 40},
+				{DeviceName: "/dev/sda1", VolumeSize: 40, VolumeSizeRaw: "40"},
 			},
 		},
 		{
-			// An unparseable number reads as zero rather than failing the launch, the
-			// same tolerance ec2ParseNetworkInterface gives DeviceIndex. The index is
-			// still present, so the mapping is not dropped.
+			// An unparseable number leaves the int at zero and keeps the raw string,
+			// which is what lets ec2CheckBlockDeviceMappings tell it from an absent
+			// value and refuse the launch (#671). The parser itself stays tolerant —
+			// the same tolerance ec2ParseNetworkInterface gives DeviceIndex — because
+			// the refusal is the validator's job and a template's mapping has to reach
+			// state before it can be judged at launch. This row is therefore no longer
+			// reachable through the API; it pins the parser's half of the contract.
 			name: "unparseable size",
 			params: map[string]string{
 				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
 				"BlockDeviceMapping.1.Ebs.VolumeSize": "not-a-number",
 			},
-			want: []emulator.EC2BlockDeviceMapping{{DeviceName: "/dev/sdf"}},
+			want: []emulator.EC2BlockDeviceMapping{
+				{DeviceName: "/dev/sdf", VolumeSizeRaw: "not-a-number"},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -264,9 +273,12 @@ func TestEC2LaunchVolumes(t *testing.T) {
 			want: []wantVol{{"/dev/sda1", 8, "gp2", true}},
 		},
 		{
-			// A VirtualName alongside real Ebs members is a contradictory mapping AWS
-			// would refuse; substrate honors the EBS half rather than silently dropping
-			// a volume the caller sized.
+			// A VirtualName alongside real Ebs members is refused at the API since #671,
+			// so this row is no longer reachable through RunInstances. It stays because
+			// the materializer must be total over whatever the parser produced: a
+			// mapping written straight into state by a replayed event log, or carried by
+			// a launch template stored before the refusal existed, still reaches here,
+			// and silently dropping a volume the caller sized would be the worse answer.
 			name: "virtual name with ebs members still creates",
 			mappings: []emulator.EC2BlockDeviceMapping{
 				{DeviceName: "/dev/sdb", VirtualName: "ephemeral0", VolumeSize: 12},

--- a/emulator/ec2_block_devices_validation_test.go
+++ b/emulator/ec2_block_devices_validation_test.go
@@ -1,0 +1,326 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #671's surface: a block device mapping real EC2 refuses is refused here too, before
+// anything is written.
+//
+// Every case below produced a volume through v0.104.0 — the mapping was parsed,
+// materialized and reported by DescribeVolumes, so a consumer whose IaC carried a
+// mapping AWS would reject got a green test and a failure on real AWS. That is the
+// same class of defect #412 closed for an empty ImageId.
+//
+// The error code is documented: EC2's client-error table lists
+// InvalidBlockDeviceMapping as "A block device mapping parameter is not valid. The
+// returned message indicates the incorrect value." Every message is substrate's own,
+// since AWS publishes no wording, and the 400 is a class-level inference — the table
+// says only that client errors are "accompanied by a 400-series HTTP response code".
+
+// ec2InvalidBDM sends a RunInstances carrying one or more mappings and returns the
+// error it is refused with.
+func ec2InvalidBDM(t *testing.T, ts *httptest.Server, extra map[string]string) (int, string, string) {
+	t.Helper()
+	params := map[string]string{
+		"Action":   "RunInstances",
+		"ImageId":  "ami-0abcdef1234567890",
+		"MinCount": "1",
+		"MaxCount": "1",
+	}
+	for k, v := range extra {
+		params[k] = v
+	}
+	return ec2ErrorDetail(t, ts, params)
+}
+
+func TestEC2_BlockDeviceMapping_Invalid(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		params map[string]string
+		msg    string
+	}{
+		{
+			// Documented verbatim on EbsBlockDevice.VolumeSize: "You must specify
+			// either a snapshot ID or a volume size."
+			name: "an Ebs structure naming neither a size nor a snapshot",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+			},
+			msg: "Invalid block device mapping for /dev/sdf: you must specify either a snapshot ID or a volume size",
+		},
+		{
+			name: "a duplicate device name",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+				"BlockDeviceMapping.2.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.2.Ebs.VolumeSize": "30",
+			},
+			msg: "Invalid block device mapping: device /dev/sdf is named by more than one mapping",
+		},
+		{
+			name: "a virtual name beside an Ebs member",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdb",
+				"BlockDeviceMapping.1.VirtualName":    "ephemeral0",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+			},
+			msg: "Invalid block device mapping for /dev/sdb: virtualName names an instance store device and cannot be combined with an Ebs member",
+		},
+		{
+			// Documented verbatim on EbsBlockDevice.Throughput: "This parameter is
+			// valid only for gp3 volumes."
+			name: "throughput on a volume type that is not gp3",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+				"BlockDeviceMapping.1.Ebs.VolumeType": "gp2",
+				"BlockDeviceMapping.1.Ebs.Throughput": "250",
+			},
+			msg: "Invalid block device mapping for /dev/sdf: Ebs.Throughput is valid only for gp3 volumes, not gp2",
+		},
+		{
+			name: "iops on a volume type that has none",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "500",
+				"BlockDeviceMapping.1.Ebs.VolumeType": "st1",
+				"BlockDeviceMapping.1.Ebs.Iops":       "3000",
+			},
+			msg: "Invalid block device mapping for /dev/sdf: Ebs.Iops is not supported for st1 volumes",
+		},
+		{
+			// The refusal #666 made necessary. Ebs.VolumeSize=60GB parsed as absent
+			// and silently produced an 8 GiB volume, which is the value a consumer
+			// then asserted against.
+			name: "an unparseable size",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "60GB",
+			},
+			msg: `Invalid block device mapping for /dev/sdf: Ebs.VolumeSize value "60GB" is not an integer`,
+		},
+		{
+			name: "an unparseable iops",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+				"BlockDeviceMapping.1.Ebs.Iops":       "lots",
+			},
+			msg: `Invalid block device mapping for /dev/sdf: Ebs.Iops value "lots" is not an integer`,
+		},
+		{
+			name: "an unparseable throughput",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+				"BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+				"BlockDeviceMapping.1.Ebs.Throughput": "125MiB",
+			},
+			msg: `Invalid block device mapping for /dev/sdf: Ebs.Throughput value "125MiB" is not an integer`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			status, code, msg := ec2InvalidBDM(t, ts, tc.params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidBlockDeviceMapping", code)
+			assert.Equal(t, tc.msg, msg)
+		})
+	}
+}
+
+// TestEC2_BlockDeviceMapping_ValidIsAccepted is the other half, and it is the half that
+// matters more: the settled scope for this change is "only what the API model states",
+// because a rule substrate invents is a false deny, and a false deny is worse than the
+// silence it replaces — the consumer cannot work around it.
+func TestEC2_BlockDeviceMapping_ValidIsAccepted(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		params map[string]string
+	}{
+		{
+			// AWS's sentence is on EbsBlockDevice.VolumeSize, a member of the Ebs
+			// structure. A mapping with no Ebs structure at all names no EBS block
+			// device for the requirement to apply to.
+			name:   "a device name with no Ebs structure",
+			params: map[string]string{"BlockDeviceMapping.1.DeviceName": "/dev/sdf"},
+		},
+		{
+			name: "a snapshot with no size",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.SnapshotId": "snap-0123456789abcdef0",
+			},
+		},
+		{
+			// Iops and Throughput with no VolumeType. Substrate resolves an absent
+			// type to gp2, but on real EC2 it comes from the AMI's own mapping, which
+			// is commonly gp3 — so keying either rule off the *resolved* type would
+			// refuse a request real EC2 accepts.
+			name: "iops and throughput with no volume type named",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+				"BlockDeviceMapping.1.Ebs.Iops":       "3000",
+				"BlockDeviceMapping.1.Ebs.Throughput": "125",
+			},
+		},
+		{
+			// The "only" sentence on the launch-template sibling shape excludes gp2,
+			// but the same member's own paragraph describes what Iops means for a gp2
+			// volume. Where AWS contradicts itself, substrate takes the permissive
+			// reading.
+			name: "iops on gp2",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+				"BlockDeviceMapping.1.Ebs.VolumeType": "gp2",
+				"BlockDeviceMapping.1.Ebs.Iops":       "100",
+			},
+		},
+		{
+			// Two documented-legal forms that rule 1 would refuse if it were not
+			// scoped to a mapping that asks for an EBS volume.
+			name: "a suppressed device and an instance store device",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":  "/dev/sdb",
+				"BlockDeviceMapping.1.NoDevice":    "",
+				"BlockDeviceMapping.2.DeviceName":  "/dev/sdc",
+				"BlockDeviceMapping.2.VirtualName": "ephemeral0",
+			},
+		},
+		{
+			// NoDevice and VirtualName are not device names for the duplicate rule:
+			// neither materializes a volume, so neither can collide with one.
+			name: "a suppressed device sharing a name with a volume",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+				"BlockDeviceMapping.2.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.2.NoDevice":       "",
+			},
+		},
+		{
+			// A size in the documented range for no type in particular. Per-type size
+			// and IOPS ranges are deliberately not encoded: they change, and a stale
+			// range is a false deny.
+			name: "a size outside the documented range for the resolved type",
+			params: map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "99999",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			params := map[string]string{
+				"Action":   "RunInstances",
+				"ImageId":  "ami-0abcdef1234567890",
+				"MinCount": "1",
+				"MaxCount": "1",
+			}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			resp := ec2Request(t, ts, params)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			assert.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+			assert.NotContains(t, string(body), "InvalidBlockDeviceMapping")
+		})
+	}
+}
+
+// TestEC2_BlockDeviceMapping_RefusalWritesNothing is #671's ordering criterion, and the
+// reason the validator sits where it does.
+//
+// runInstancesWithTags was validate-then-write in its error *returns* but not in its
+// writes: ensureDefaultVPC committed a VPC, subnet, security group, internet gateway,
+// route table and four index mutations before the security-group validation below it.
+// A refusal that leaves a VPC behind is worse than no validation, because the next
+// request in the same test sees state the refused one created.
+func TestEC2_BlockDeviceMapping_RefusalWritesNothing(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	_, code, _ := ec2InvalidBDM(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+	})
+	require.Equal(t, "InvalidBlockDeviceMapping", code)
+
+	assert.Empty(t, bdmDescribeVolumes(t, ts, nil), "a refused launch materializes no volume")
+
+	for _, action := range []string{"DescribeInstances", "DescribeVpcs", "DescribeSubnets"} {
+		resp := ec2Request(t, ts, map[string]string{"Action": action})
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+		var counted struct {
+			VPCs      []struct{} `xml:"vpcSet>item"`
+			Subnets   []struct{} `xml:"subnetSet>item"`
+			Instances []struct{} `xml:"reservationSet>item>instancesSet>item"`
+		}
+		require.NoError(t, xml.Unmarshal(body, &counted), string(body))
+		assert.Empty(t, counted.VPCs, "%s: a refused launch creates no default VPC", action)
+		assert.Empty(t, counted.Subnets, "%s: no default subnet either", action)
+		assert.Empty(t, counted.Instances, "%s: and no instance", action)
+	}
+}
+
+// TestEC2_BlockDeviceMapping_TemplateMappingRefusedAtLaunch pins that the validator sits
+// after the launch-template merge, so a mapping that reaches a launch through a template
+// is refused at RunInstances time rather than materialized.
+//
+// CreateLaunchTemplate deliberately does not refuse it. Its response carries a
+// documented `warning` member of type ValidationWarning, which exists precisely for
+// "parameters or parameter combinations that are not valid", and its Errors section
+// lists none — so a 400 there would be substrate's invention. That an invalid *block
+// device mapping* lands in the warning rather than in an error is substrate's reading,
+// and rendering the element is a follow-up.
+func TestEC2_BlockDeviceMapping_TemplateMappingRefusedAtLaunch(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "bad-mapping",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+	})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body),
+		"CreateLaunchTemplate does not refuse; the warning member is where AWS puts this")
+
+	status, code, msg := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                            "RunInstances",
+		"MinCount":                          "1",
+		"MaxCount":                          "1",
+		"LaunchTemplate.LaunchTemplateName": "bad-mapping",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidBlockDeviceMapping", code)
+	assert.Equal(t,
+		"Invalid block device mapping for /dev/sdf: you must specify either a snapshot ID or a volume size",
+		msg, "a template-carried mapping is refused at launch, where it materializes")
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -498,6 +498,19 @@ func (p *EC2Plugin) runInstancesWithTags(
 		return nil, ec2MissingParameter("ImageId")
 	}
 
+	// Block device mappings are validated here for two reasons that fix the position
+	// exactly (#671). It is after the template merge above, so a mapping that reaches
+	// this launch through a template is refused at RunInstances time rather than
+	// materialized — and one validator here covers requests, templates, template
+	// versions and fleet launches alike, since a fleet reaches mappings only through a
+	// template. And it is before the ensureDefaultVPC branch below, which commits a
+	// VPC, subnet, security group, internet gateway, route table and four index
+	// mutations: a refusal past that point leaves state behind, which is worse than no
+	// validation at all because the next request in the same test sees it.
+	if awsErr := ec2CheckBlockDeviceMappings(blockDeviceMappings); awsErr != nil {
+		return nil, awsErr
+	}
+
 	// Auto-create default VPC/subnet if none specified.
 	if subnetID == "" {
 		vpc, subnet, err := p.ensureDefaultVPC(context.Background(), reqCtx)

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -812,11 +812,32 @@ type EC2BlockDeviceMapping struct {
 
 	// DeleteOnTermination is the raw parameter value rather than a bool, because
 	// three states are observable and a bool collapses two of them: absent (take
-	// the launch default, which is true), "true", and "false". Storing a bool here
-	// would make a mapping that explicitly preserves its volume indistinguishable
-	// from one that said nothing — the same reason
-	// [EC2LaunchTemplateData.AssociatePublicIPAddress] keeps its string.
+	// the launch default, which splits by device role — see [ec2LaunchVolumesFor]),
+	// "true", and "false". Storing a bool here would make a mapping that explicitly
+	// preserves its volume indistinguishable from one that said nothing — the same
+	// reason [EC2LaunchTemplateData.AssociatePublicIPAddress] keeps its string.
 	DeleteOnTermination string `json:"delete_on_termination,omitempty"`
+
+	// VolumeSizeRaw, IOPSRaw and ThroughputRaw are the numeric members' parameter
+	// values exactly as they arrived, kept beside the parsed ints for two reasons
+	// that the ints alone cannot serve (#671).
+	//
+	// First, a value that does not parse is otherwise indistinguishable from an
+	// absent one: Ebs.VolumeSize=60GB left VolumeSize at 0, so the mapping silently
+	// produced substrate's 8 GiB default and a consumer asserted against a value the
+	// request never asked for. Second, an *absent* size is what
+	// EbsBlockDevice.VolumeSize's "You must specify either a snapshot ID or a volume
+	// size" is about, and a literal 0 is not the same thing.
+	//
+	// They are persisted rather than derived because a launch template carries its
+	// mappings into state, and by the time a RunInstances names that template the
+	// original parameters are long gone — so the refusal has to be reconstructable
+	// from the record. Adding a field to a persisted struct is replay-safe; an older
+	// event log simply unmarshals them empty, which reads as "nothing unparseable",
+	// and that is the behavior those logs already had.
+	VolumeSizeRaw string `json:"volume_size_raw,omitempty"`
+	IOPSRaw       string `json:"iops_raw,omitempty"`
+	ThroughputRaw string `json:"throughput_raw,omitempty"`
 }
 
 // NetworkSecurityGroupIDs returns the security groups a launch from this template

--- a/test/e2e/journey_ec2_block_devices_test.go
+++ b/test/e2e/journey_ec2_block_devices_test.go
@@ -2,11 +2,13 @@ package e2e_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 
 	emulator "github.com/scttfrdmn/substrate/emulator"
 )
@@ -224,5 +226,65 @@ func TestJourney_EC2LaunchDataVolumeSurvivesTermination(t *testing.T) {
 	if len(all.Volumes[0].Attachments) != 0 {
 		t.Fatalf("the preserved volume still reports %d attachments, want 0",
 			len(all.Volumes[0].Attachments))
+	}
+}
+
+// TestJourney_EC2InvalidBlockDeviceMappingRefused is #671 at the SDK tier, which is
+// where it matters: the point of refusing is that a consumer's IaC fails here for the
+// reason it would fail on real AWS, rather than passing here and failing there.
+//
+// The mapping names Ebs.VolumeType and no size, which AWS's EbsBlockDevice.VolumeSize
+// documents as invalid — "You must specify either a snapshot ID or a volume size."
+// Through v0.104.0 substrate accepted it and materialized an 8 GiB gp3 volume, so the
+// consumer's assertion passed against a size their request never asked for.
+func TestJourney_EC2InvalidBlockDeviceMappingRefused(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	client := ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	ctx := context.Background()
+
+	_, err = client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-0abcdef1234567890"),
+		InstanceType: ec2types.InstanceTypeT3Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/sdf"),
+			Ebs:        &ec2types.EbsBlockDevice{VolumeType: ec2types.VolumeTypeGp3},
+		}},
+	})
+	if err == nil {
+		t.Fatal("RunInstances succeeded; want InvalidBlockDeviceMapping")
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("RunInstances error is not an APIError: %v", err)
+	}
+	if apiErr.ErrorCode() != "InvalidBlockDeviceMapping" {
+		t.Fatalf("error code = %q, want InvalidBlockDeviceMapping (message %q)",
+			apiErr.ErrorCode(), apiErr.ErrorMessage())
+	}
+
+	// The refusal writes nothing. Without the validator's placement ahead of
+	// ensureDefaultVPC this launch left a VPC, subnet, security group, internet
+	// gateway and route table behind, which the next request in the same test would
+	// have seen.
+	vpcs, err := client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{})
+	if err != nil {
+		t.Fatalf("DescribeVpcs: %v", err)
+	}
+	if len(vpcs.Vpcs) != 0 {
+		t.Fatalf("a refused launch left %d VPCs behind, want 0", len(vpcs.Vpcs))
+	}
+	vols, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{})
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+	if len(vols.Volumes) != 0 {
+		t.Fatalf("a refused launch materialized %d volumes, want 0", len(vols.Volumes))
 	}
 }


### PR DESCRIPTION
Closes #671.

`RunInstances` accepted every block device mapping it could parse, so IaC carrying a mapping real EC2 rejects got a green test here and a failure on AWS — the same class of defect an empty `ImageId` used to have, and the worst kind for a tool that exists to validate infrastructure code before it reaches AWS. Six refusals now answer `InvalidBlockDeviceMapping` with a 400, before anything is written.

| Refused | Provenance |
|---|---|
| An `Ebs` structure naming neither `Ebs.VolumeSize` nor `Ebs.SnapshotId` | Documented verbatim on `EbsBlockDevice.VolumeSize`: "You must specify either a snapshot ID or a volume size." |
| `Ebs.Throughput` on an explicitly named type other than `gp3` | Documented verbatim: "This parameter is valid only for `gp3` volumes." |
| `Ebs.Iops` on an explicitly named `standard`, `st1` or `sc1` | The sibling launch-template shape — substrate's reading |
| An unparseable `Ebs.VolumeSize`, `Ebs.Iops` or `Ebs.Throughput` | Substrate's own |
| Two mappings naming one `DeviceName` | Substrate's own — AWS documents no rule |
| A `VirtualName` beside any `Ebs.*` member | Substrate's own — AWS documents no rule |

## Scope: only what the API model states

Both type-scoped rules key off the **explicitly named** `VolumeType`, never the resolved one. Substrate resolves an absent type to `gp2`, but on real EC2 it comes from the AMI's own mapping — commonly `gp3` — so refusing `Throughput` on a mapping that named no type would refuse a launch real EC2 accepts. For the same reason the per-type numeric size and IOPS ranges the reference lists are **not** encoded: they change, and a stale range is a false deny a caller cannot work around. And a `VolumeSize` is not compared against the named snapshot's, because `EC2Snapshot.VolumeSize` is a constant at its single producer and there is no `CreateSnapshot` — the comparison would test the constant. Follow-up filed for that one.

A mapping carrying **no `Ebs` structure at all** — a bare `DeviceName` — is still accepted and still takes the 8 GiB default: the size-or-snapshot requirement is documented on a member *of* the `Ebs` structure, so with no structure it has no subject. `NoDevice` and a `VirtualName`-only instance store mapping are untouched.

`Ebs.Iops` uses a short **deny** list rather than AWS's `io1 | io2 | gp3` allow list. The "supported for `io1`, `io2`, and `gp3` volumes only" sentence is on `LaunchTemplateEbsBlockDeviceRequest.Iops`, not on the `EbsBlockDevice` shape `RunInstances` accepts, and that same member's own paragraph — on both shapes — explains what `Iops` means "for `gp2` volumes". AWS contradicts itself inside one member, so substrate refuses only the three types that appear in neither list.

## Placement

The validator sits between the `ImageId` check and the `ensureDefaultVPC` branch, and both sides of that position are load-bearing:

- **After the launch template merge**, so a mapping that reaches a launch through a template is refused at `RunInstances` time rather than materialized — and one validator covers requests, templates, template versions and fleet launches alike, since a fleet reaches mappings only through a template.
- **Before `ensureDefaultVPC`**, which commits a VPC, subnet, security group, internet gateway, route table and four index mutations. A refusal past that point leaves state the next request in the same test sees, which is worse than no validation at all.

`CreateLaunchTemplate` deliberately does **not** refuse: its response carries a documented `warning` member of type `ValidationWarning` that exists precisely for "parameters or parameter combinations that are not valid", and its Errors section lists none — so a 400 there would be substrate's invention. Rendering that element is a follow-up.

## Recording the raw values

`EC2BlockDeviceMapping` gains `VolumeSizeRaw`, `IOPSRaw` and `ThroughputRaw`. The parser discarded them, so by validation time `Ebs.VolumeSize=60GB` was indistinguishable from an absent size — and a literal `0` is not the same thing as absent, which is exactly what the size-or-snapshot rule is about. They are persisted rather than derived because a launch template carries its mappings into state and the original parameters are gone by the time a `RunInstances` names it. Adding fields to a persisted struct is replay-safe: an older event log unmarshals them empty, which reads as "nothing unparseable" — the behavior those logs already had.

## Provenance

`InvalidBlockDeviceMapping` is documented in EC2's client-error table ("A block device mapping parameter is not valid. The returned message indicates the incorrect value."). The **HTTP status is a class-level inference** — the table says only that client errors are "accompanied by a 400-series HTTP response code" — and **every per-case message is substrate's own**, since AWS publishes no wording. Each message names the offending device, because a request can carry many mappings and the code alone does not say which was refused.

## Fail-before

All 8 refusal subtests plus both ordering tests fail on the pre-fix tree:

```
--- FAIL: TestEC2_BlockDeviceMapping_Invalid/an_unparseable_size
    expected: 400 / actual: 200
    expected: "InvalidBlockDeviceMapping" / actual: ""
    expected: "Invalid block device mapping for /dev/sdf: Ebs.VolumeSize value \"60GB\" is not an integer" / actual: ""
--- FAIL: TestEC2_BlockDeviceMapping_RefusalWritesNothing
    expected: "InvalidBlockDeviceMapping" / actual: ""
```

## Tests

- `TestEC2_BlockDeviceMapping_Invalid` — 8 rows, one per refusal, asserting 400 + code + exact message.
- `TestEC2_BlockDeviceMapping_ValidIsAccepted` — 7 rows pinning the *non*-refusals, so the scope decision is a test rather than a comment: a bare device name; a snapshot with no size; `Iops`/`Throughput` with no `VolumeType`; `Iops` on `gp2`; `NoDevice` beside an instance store mapping; a suppressed device sharing a name with a volume; a size outside the documented range.
- `TestEC2_BlockDeviceMapping_RefusalWritesNothing` — no volume, VPC, subnet or instance after a refusal.
- `TestEC2_BlockDeviceMapping_TemplateMappingRefusedAtLaunch` — `CreateLaunchTemplate` returns 200; the `RunInstances` naming it is refused.
- `TestJourney_EC2InvalidBlockDeviceMappingRefused` — SDK tier, `smithy.APIError` with the code, then zero VPCs and zero volumes.

Two existing parser rows are re-labelled as API-unreachable rather than deleted: the unparseable-size row still pins the parser's half of the contract, and the `virtualName`-beside-`Ebs` row still pins the materializer's totality over replayed or pre-existing state.

## Compatibility

A `RunInstances` or fleet launch that v0.104.0 and earlier accepted may now fail with `InvalidBlockDeviceMapping`. The likeliest case by far is a mapping naming a `VolumeType` and no size, which previously produced an 8 GiB volume of that type. No CloudFormation, CDK or Terraform fixture in the repo carries a block device mapping.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race, all packages), `go run ./cmd/gen-service-reference -check`, `bash scripts/check-doc-versions.sh`, `go test -C test/e2e ./...`, `npm --prefix docs run build` — all clean.
