### PR TITLE
feat(ec2): a volume can be tagged, reports its tags, and is filterable by them (#670)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   far is a mapping naming a `VolumeType` and no size, which previously produced an 8 GiB
   volume of that type.
 
+- **A volume can be tagged, reports its tags, and is findable by them** (#670). A volume was
+  the one taggable EC2 resource with no working tagging path at all, and every call on it
+  answered success: `CreateVolume` accepted `TagSpecification.N` and stored nothing,
+  `CreateTags` on a `vol-` ID answered `<return>true</return>` and wrote nothing,
+  `DescribeVolumes` rendered no `tagSet` and matched no tag filter, and `EC2Volume.Tags`
+  existed with nothing ever writing to it. So an IaC consumer's tag-everything convention
+  appeared to hold and nothing could observe that it had not — the same store-and-hide shape
+  #471 closed for a launch template's tags. Four paths are now real:
+
+  - `CreateVolume` applies its `volume`-scoped `TagSpecification.N` and echoes the result in a
+    `tagSet`.
+  - `RunInstances` applies its `volume`-scoped tags to **every** volume the launch
+    materializes, including the root volume substrate synthesizes when no mapping declares
+    one. AWS's structure has no way to tag one mapping's volume differently from another's.
+  - A launch template's `volume`-scoped tags reach the launch on their own merge gate, so the
+    two scopes resolve independently: a request naming volume tags still inherits the
+    template's instance tags, and each scope replaces rather than merges within itself.
+  - `CreateTags` and `DeleteTags` accept a `vol-` ID like any other taggable ID.
+
+  Both tag rules apply on all of them — the reserved `aws:` prefix and the 50-tag limit, since
+  AWS documents no volume-specific tag constraint — and on a launch the check runs **before
+  the launch loop**, because a volume is written after its own instance and a refusal inside
+  the loop would leave the first instance of a multi-count launch behind. A launch template's
+  volume scope is checked at `CreateLaunchTemplate` and `CreateLaunchTemplateVersion` too, and
+  each scope counts against the 50-tag limit on its own: the limit is per resource, and an
+  instance and its volumes are different resources.
+
+  `DescribeVolumes` now filters on `tag:<key>` and `tag-key`, which are exactly the two tag
+  filters AWS documents for the operation out of 20 — there is no `tag-value`. Its
+  hand-rolled `Filter.N` loop, whose nine `map[string]bool` sets could not express a filter
+  whose key is part of its name, is replaced by the shared `extractEC2Filters` walk plus a
+  match function. Three consequences worth naming rather than leaving to be found: an empty
+  filter value is now recorded as a value where the old loop truncated the list at it; a
+  filter whose value list is empty is now a filter that matches nothing rather than one that
+  was never seen; and the nine names the loop already supported are covered by a regression
+  test that passed before this change and after it.
+
+  `CreateVolume` also stopped discarding `Iops` and `Throughput`, which `EC2Volume` stored and
+  `DescribeVolumes` rendered — so a provisioned volume created through `CreateVolume` read
+  back as an unprovisioned one, while the same values given through a launch mapping did not.
+  `Ebs.KmsKeyId` stays deliberately absent.
+
+  The launch template's volume scope is stored in a **new** `VolumeTagSpecifications` field
+  rather than by widening the existing instance-scoped one with a resource-type
+  discriminator. Widening it would unmarshal every template already in an event log without
+  error, into an element with an empty resource type and no tags, so every stored template
+  would silently start launching untagged instances — a change that breaks deterministic
+  replay while compiling. This follows the split `EC2LaunchTemplateData.NetworkInterfaces`
+  already uses for the same reason.
+
+  **Provenance:** the `tagSet` element carries no `omitempty` because AWS's second
+  `CreateVolume` example renders `<tagSet/>` for an untagged volume, and an SDK tells a
+  present-but-empty element ("no tags") from an omitted one ("unknown"). Two answers are
+  substrate's own, because AWS's filtering guide settles neither: a `tag:<key>` filter with no
+  value matches nothing, following `DescribeInstances` rather than `describeImages`, which
+  treats it as `tag-key`; and an unrecognized filter name is still **dropped**, which is what
+  this operation has always done — real EC2 refuses one, and substrate has three different
+  answers across its EC2 filter sites, so reconciling them is its own change on all of them.
+  A comment claiming that dropping was universal in the package is corrected rather than
+  carried.
+
+  **Compatibility:** `CreateVolume` and `DescribeVolumes` responses gain `tagSet`, `iops` and
+  `throughput`, which a byte-exact response assertion will see. A `RunInstances` naming a
+  reserved key or more than 50 tags in a `volume`-scoped `TagSpecification` now fails where it
+  previously succeeded with the tags dropped; the same is true at `CreateLaunchTemplate`.
+
 ### Fixed
 - **`RunInstances` omitted the `iamInstanceProfile` that `DescribeInstances` reported for the
   same instance** (#669). `runInstancesResponse` and `describeInstances` each declared their

--- a/docs/services.md
+++ b/docs/services.md
@@ -2666,7 +2666,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances, [subject to termination protection](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
-| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit) |
+| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); accepts a `vol-` ID like [any other taggable ID](#a-volume-carries-tags) |
 | DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) and [over-long keys](#tag-key-and-value-length-limits) |
 
 ### RunInstances requires a resolvable AMI
@@ -2711,6 +2711,7 @@ corresponding parameters included in the launch template."
 | `KeyName` | `k-request` | `k-template` | `k-request` |
 | `TagSpecification` (instance-scoped) | `Env=req` | `Env=tmpl,Team=x` | `Env=req` alone — replace, not merge |
 | `TagSpecification` (instance-scoped) | absent | `Env=tmpl` | `Env=tmpl` |
+| `TagSpecification` (volume-scoped) | absent | `Env=tmpl` | `Env=tmpl` on every volume the launch makes |
 | `IamInstanceProfile` | `p-request` | `p-template` | `p-request` |
 | `IamInstanceProfile` | absent | `p-template` | `p-template` |
 | `SubnetId`, security groups, `AssociatePublicIpAddress` | see [Launch template networking](#launch-template-networking) | | |
@@ -2758,13 +2759,29 @@ Both now participate in the merge, with two things worth stating:
   otherwise a fleet launched from a tagging template would silently lose the
   template's tags. See [Reserved tag keys](#reserved-tag-keys).
 
-**Only the instance scope is modelled.** A template may also scope tags to `volume`,
-`network-interface` or `spot-instances-request`. Substrate models none of those
-resources, so those specifications are recorded nowhere rather than misapplied to the
-instance: they neither reach the launch nor read back from
-`DescribeLaunchTemplateVersions`. Note that a template's instance-scoped tags land on
-the *instance*, not on the template — the reference is explicit that "these tags are
-not applied to the launch template."
+**The `instance` and `volume` scopes are modelled, and they resolve
+independently.** Each is stored in its own field, so a request naming volume tags
+alone still inherits the template's instance tags and vice versa, and each replaces
+rather than merges within its own scope. The volume scope applies to every volume the
+launch materializes, including the root volume substrate synthesizes when no mapping
+declares one — AWS's structure has no way to tag one mapping's volume differently
+from another's.
+
+Keeping the two in separate fields is deliberate rather than incidental. Widening the
+existing instance field to carry a `ResourceType` discriminator would unmarshal every
+template already in an event log without error — into an element with an empty
+resource type and no tags — so every stored template would silently start launching
+untagged instances. A change that breaks replay while compiling is exactly the shape
+this project's persisted structures are grown to avoid.
+
+A template may also scope tags to `network-interface` or `spot-instances-request`.
+Those are still recorded nowhere rather than misapplied: they neither reach the launch
+nor read back from `DescribeLaunchTemplateVersions`, because a recorded tag no read
+surfaces is indistinguishable from a discarded one.
+
+Note that a template's instance-scoped tags land on the *instance*, not on the
+template — the reference is explicit that "these tags are not applied to the launch
+template."
 
 A template's tags are subject to both tag rules, so a template is not a second
 unrestricted tagging path: a `TagSpecifications` naming an `aws:`-prefixed key or
@@ -3039,11 +3056,11 @@ DeleteOnTermination}`. `NoDevice` suppresses the device outright, and a
 an EBS volume and has no presence in `DescribeVolumes` — either way the mapping is
 recorded intent that materializes nothing.
 
-`DescribeVolumes` renders `iops` and `throughput` on the volume and
-`deleteOnTermination` on each attachment, and filters on `volume-id`, `status`,
-`size`, `volume-type`, `availability-zone`, `snapshot-id`,
-`attachment.instance-id`, `attachment.device` and
-`attachment.delete-on-termination`.
+`DescribeVolumes` renders `iops` and `throughput` on the volume,
+`deleteOnTermination` on each attachment, and a `tagSet` — and filters on
+`volume-id`, `status`, `size`, `volume-type`, `availability-zone`, `snapshot-id`,
+`attachment.instance-id`, `attachment.device`,
+`attachment.delete-on-termination`, `tag:<key>` and `tag-key`.
 
 Substrate's own choices, where the API model does not decide:
 
@@ -3055,8 +3072,50 @@ Substrate's own choices, where the API model does not decide:
   volume must be in the same zone as the instance it is attached to, so deriving it
   any other way would produce an attachment real EC2 cannot have.
 
-Not modeled: `Ebs.KmsKeyId` (left out rather than stored and hidden), and
-`TagSpecification` scoped to `volume` (see the tag-specification note above).
+Not modeled: `Ebs.KmsKeyId`, left out rather than stored and hidden.
+
+#### A volume carries tags
+
+A volume is taggable on every path the other EC2 resources are. Until this landed it
+was the one taggable EC2 resource with no working path at all: `CreateVolume`
+accepted `TagSpecification.N` and stored nothing, `CreateTags` on a `vol-` ID answered
+`<return>true</return>` and wrote nothing, and `DescribeVolumes` rendered no `tagSet`
+and matched no tag filter. Every call returned success, so an IaC consumer's
+tag-everything convention appeared to hold and nothing could observe that it had not.
+
+Four paths, all of them now real:
+
+- **`CreateVolume`** applies `TagSpecification.N` scoped to `volume` and echoes the
+  result in a `tagSet`. The element carries no `omitempty`: AWS's own second
+  `CreateVolume` example renders `<tagSet/>` for an untagged volume, and an SDK tells a
+  present-but-empty element ("no tags") from an omitted one ("unknown").
+- **`RunInstances`** applies its volume-scoped `TagSpecification.N` to every volume the
+  launch materializes, the synthesized root volume included. The instance scope is
+  unaffected: a request naming both gets each on its own resource.
+- **A launch template**'s volume-scoped tags reach the launch the same way, on their own
+  merge gate; see
+  [A launch template merges with the request, field by field](#a-launch-template-merges-with-the-request-field-by-field).
+- **`CreateTags`/`DeleteTags`** accept a `vol-` ID like any other taggable ID.
+
+Both tag rules apply on every one of them — the reserved `aws:` prefix and the 50-tag
+limit — and on a launch the check runs **before the launch loop**, because a volume is
+written after its own instance and a refusal inside the loop would leave the first
+instance of a multi-count launch behind. AWS documents no volume-specific tag
+constraint, so there is nothing else to enforce.
+
+`DescribeVolumes` supports exactly the two tag filters AWS documents for it,
+`tag:<key>` and `tag-key`. There is no `tag-value`; AWS does not define one for this
+operation. Two behaviours here are substrate's own, because AWS's filtering guide
+settles neither:
+
+- A `tag:<key>` filter with **no value** matches nothing, following
+  `DescribeInstances`. The guide says only that a filter value cannot be null, and
+  offers `tag-key` for the any-value question.
+- An **unrecognized filter name is dropped**, so the filter constrains nothing. That is
+  what this operation has always done, and it is kept rather than reconciled: real EC2
+  refuses an unknown name, and substrate has three different answers across its EC2
+  filter sites. Making them agree is its own change, and it is a behaviour change on
+  every one of them.
 
 #### A mapping AWS refuses is refused, with `InvalidBlockDeviceMapping`
 
@@ -3668,15 +3727,19 @@ instance- and fleet-scoped alike — while the fleet's own stamp is still applie
 both coexist with the caller's legal tags on the same instance.
 
 One limit of the current scope, stated rather than implied: only tags scoped to a
-resource substrate models are checked. A `TagSpecification` naming `volume` or
-`network-interface` on `RunInstances`, or inside a launch template's
+resource substrate tags are checked. A `TagSpecification` naming `network-interface`
+or `spot-instances-request` on `RunInstances`, or inside a launch template's
 `LaunchTemplateData`, is skipped, because substrate does not tag those resources at
-all; real EC2 would reject a reserved key there too.
+all; real EC2 would reject a reserved key there too. The `volume` scope used to be
+skipped for the same reason and no longer is: now that a launch tags its volumes, a
+reserved key there refuses the launch, and the refusal happens before the launch loop
+so no instance is left behind by it.
 
-A launch template's own instance-scoped tags *are* checked, at
+A launch template's own tags *are* checked, on both modelled scopes, at
 `CreateLaunchTemplate` and `CreateLaunchTemplateVersion` as well as at every launch
 that names the template — so a template cannot serve as an unchecked second path to a
-reserved key. See
+reserved key. Each scope is counted against the 50-tag limit on its own, because the
+limit is per resource and an instance and its volumes are different resources. See
 [A launch template merges with the request, field by field](#a-launch-template-merges-with-the-request-field-by-field).
 
 ### The 50-tag-per-resource limit

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -353,7 +353,16 @@ func ec2CreatesEBSVolume(bdm EC2BlockDeviceMapping) bool {
 //
 // A volume attached after launch keeps the other default; see attachVolume, where
 // the two pages agree and nothing here changes it.
-func ec2LaunchVolumesFor(inst *EC2Instance, mappings []EC2BlockDeviceMapping, now string) []EC2Volume {
+// tags are the launch's volume-scoped TagSpecification tags, applied to every volume
+// the launch materializes — including the root volume synthesized when no mapping
+// declares one. AWS's rule is per resource type, not per mapping: the request has no
+// way to tag one mapping's volume differently from another's (#670).
+func ec2LaunchVolumesFor(
+	inst *EC2Instance,
+	mappings []EC2BlockDeviceMapping,
+	tags []EC2Tag,
+	now string,
+) []EC2Volume {
 	volumes := make([]EC2Volume, 0, len(mappings)+1)
 	rootDeclared := false
 
@@ -364,13 +373,13 @@ func ec2LaunchVolumesFor(inst *EC2Instance, mappings []EC2BlockDeviceMapping, no
 		if ec2IsRootDevice(bdm.DeviceName) {
 			rootDeclared = true
 		}
-		volumes = append(volumes, ec2VolumeFromMapping(inst, bdm, now))
+		volumes = append(volumes, ec2VolumeFromMapping(inst, bdm, tags, now))
 	}
 
 	if !rootDeclared {
 		volumes = append(volumes, ec2VolumeFromMapping(inst, EC2BlockDeviceMapping{
 			DeviceName: ec2RootDeviceSDA1,
-		}, now))
+		}, tags, now))
 	}
 	return volumes
 }
@@ -381,7 +390,12 @@ func ec2LaunchVolumesFor(inst *EC2Instance, mappings []EC2BlockDeviceMapping, no
 // volume must be in the same Availability Zone as the instance it is attached to, so
 // deriving it any other way would let a launch into a non-default zone produce an
 // attachment real EC2 cannot have.
-func ec2VolumeFromMapping(inst *EC2Instance, bdm EC2BlockDeviceMapping, now string) EC2Volume {
+func ec2VolumeFromMapping(
+	inst *EC2Instance,
+	bdm EC2BlockDeviceMapping,
+	tags []EC2Tag,
+	now string,
+) EC2Volume {
 	size := bdm.VolumeSize
 	if size <= 0 {
 		size = ec2DefaultVolumeSizeGiB
@@ -406,9 +420,17 @@ func ec2VolumeFromMapping(inst *EC2Instance, bdm EC2BlockDeviceMapping, now stri
 		deleteOnTermination = strings.EqualFold(bdm.DeleteOnTermination, "true")
 	}
 
+	// Each volume gets its own copy, so a later CreateTags on one of them cannot be
+	// seen through another's slice while both are still in memory.
+	var volTags []EC2Tag
+	if len(tags) > 0 {
+		volTags = append(volTags, tags...)
+	}
+
 	return EC2Volume{
 		VolumeID:         generateVolumeID(),
 		Size:             size,
+		Tags:             volTags,
 		VolumeType:       volType,
 		AvailabilityZone: inst.AvailabilityZone,
 		State:            "in-use",
@@ -435,9 +457,10 @@ func ec2VolumeFromMapping(inst *EC2Instance, bdm EC2BlockDeviceMapping, now stri
 func (p *EC2Plugin) ec2CreateLaunchVolumes(
 	inst *EC2Instance,
 	mappings []EC2BlockDeviceMapping,
+	tags []EC2Tag,
 	now string,
 ) error {
-	for _, vol := range ec2LaunchVolumesFor(inst, mappings, now) {
+	for _, vol := range ec2LaunchVolumesFor(inst, mappings, tags, now) {
 		data, err := json.Marshal(vol)
 		if err != nil {
 			return fmt.Errorf("ec2 runInstances volume marshal: %w", err)
@@ -500,34 +523,98 @@ func (p *EC2Plugin) ec2DeleteInstanceVolumes(accountID, region, instanceID strin
 	return nil
 }
 
-// ec2VolumeMatchesAttachmentFilters reports whether a volume satisfies every
-// attachment-scoped DescribeVolumes filter that was supplied.
+// ec2VolumeMatchesFilters reports whether a volume satisfies every DescribeVolumes
+// filter that was supplied. Filters are ANDed with each other and each one's values
+// are ORed, which is AWS's documented rule for all of them.
 //
-// Each filter is satisfied by *any* attachment, which is what a filter on a
-// list-valued member means, but the filters are ANDed with each other rather than
-// evaluated against one attachment at a time — AWS's filter semantics are per
-// filter, not per list element. An empty map means the filter was not supplied and
-// so constrains nothing.
-func ec2VolumeMatchesAttachmentFilters(
-	vol EC2Volume,
-	instanceIDs, devices, deleteOnTermination map[string]bool,
-) bool {
-	matches := func(want map[string]bool, got func(EC2VolumeAttachment) string) bool {
-		if len(want) == 0 {
-			return true
+// AWS documents exactly two tag filters for this operation, `tag:<key>` and
+// `tag-key`, out of 20 filters in total — there is no `tag-value` (#670).
+//
+// A `tag:<key>` filter with no values matches nothing. AWS documents no rule for
+// that shape (Using_Filtering says only that a filter value cannot be null, and
+// offers tag-key for the any-value question), and substrate's two existing
+// implementations disagree; this follows [ec2InstanceMatchesFilter], the closer
+// sibling, rather than describeImages, which treats it as tag-key.
+func ec2VolumeMatchesFilters(vol EC2Volume, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2VolumeMatchesFilter(vol, name, values) {
+			return false
 		}
-		for _, att := range vol.Attachments {
-			if want[got(att)] {
+	}
+	return true
+}
+
+// ec2VolumeMatchesFilter evaluates a single DescribeVolumes filter against a volume.
+//
+// An unrecognized filter name is dropped — the volume matches — which is what this
+// operation has always done. That is not, as a comment here once claimed, what every
+// EC2 filter site does: three behaviors exist in this package (drop for volumes and
+// snapshots, match-nothing for [ec2InstanceMatchesFilter], and refuse for
+// describeInstanceTypeOfferings, which is what real EC2 does). Reconciling them is
+// its own change; this one keeps the observable answer it found.
+func ec2VolumeMatchesFilter(vol EC2Volume, name string, values []string) bool {
+	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
+		for _, t := range vol.Tags {
+			if t.Key == tagKey && containsStr(values, t.Value) {
 				return true
 			}
 		}
 		return false
 	}
-	return matches(instanceIDs, func(a EC2VolumeAttachment) string { return a.InstanceID }) &&
-		matches(devices, func(a EC2VolumeAttachment) string { return a.Device }) &&
-		matches(deleteOnTermination, func(a EC2VolumeAttachment) string {
-			return strconv.FormatBool(a.DeleteOnTermination)
-		})
+
+	// An attachment-scoped filter is satisfied by *any* attachment, which is what a
+	// filter on a list-valued member means. The filters are still ANDed with each
+	// other rather than evaluated against one attachment at a time — AWS's semantics
+	// are per filter, not per list element.
+	anyAttachment := func(got func(EC2VolumeAttachment) string) bool {
+		for _, att := range vol.Attachments {
+			if containsStr(values, got(att)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch name {
+	case "volume-id":
+		return containsStr(values, vol.VolumeID)
+	case "status":
+		return containsStr(values, vol.State)
+	case "volume-type":
+		return containsStr(values, vol.VolumeType)
+	case "size":
+		return containsStr(values, strconv.Itoa(vol.Size))
+	case "availability-zone":
+		return containsStr(values, vol.AvailabilityZone)
+	case "snapshot-id":
+		return containsStr(values, vol.SnapshotID)
+	case "tag-key":
+		for _, t := range vol.Tags {
+			if containsStr(values, t.Key) {
+				return true
+			}
+		}
+		return false
+	case "attachment.instance-id":
+		return anyAttachment(func(a EC2VolumeAttachment) string { return a.InstanceID })
+	case "attachment.device":
+		return anyAttachment(func(a EC2VolumeAttachment) string { return a.Device })
+	case "attachment.delete-on-termination":
+		// The hand-rolled loop lowercased the value before comparing, so "True"
+		// matched a true attachment; EqualFold keeps that leniency without mutating
+		// the caller's value slice.
+		for _, att := range vol.Attachments {
+			want := strconv.FormatBool(att.DeleteOnTermination)
+			for _, v := range values {
+				if strings.EqualFold(v, want) {
+					return true
+				}
+			}
+		}
+		return false
+	default:
+		return true
+	}
 }
 
 // ec2VolumeStateKey is the state key one volume is stored under.

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -357,6 +357,13 @@ func (p *EC2Plugin) runInstancesWithTags(
 	// DescribeVolumes reported nothing for the instance. The mappings become real
 	// volumes in the launch loop below; see [ec2LaunchVolumesFor].
 	blockDeviceMappings := ec2ParseBlockDeviceMappings(req.Params, "")
+	// A launch tags its volumes through the same TagSpecification.N structure that
+	// tags the instance, scoped to "volume" — and those tags were accepted and
+	// discarded until #670. They are parsed here rather than in
+	// [EC2Plugin.runInstances] because a template can also supply them, and because
+	// substrate's fleet stamp is an instance tag with no volume-scoped counterpart, so
+	// there is nothing for the caller-named-tags rule to distinguish.
+	volumeTags := ec2LaunchTagsForResource(req.Params, "volume")
 	primaryIfc := ec2PrimaryInterface(networkInterfaces)
 	if subnetID == "" && primaryIfc != nil {
 		subnetID = primaryIfc.SubnetID
@@ -477,6 +484,15 @@ func (p *EC2Plugin) runInstancesWithTags(
 			}
 			tags = append(append([]EC2Tag{}, ltData.TagSpecifications...), tags...)
 		}
+		// The volume scope follows the same replace-rather-than-merge rule, on its own
+		// gate: a request naming volume tags and a template naming others yields the
+		// request's alone, and the two scopes resolve independently, so a template can
+		// supply volume tags for a request that named only instance tags. There is no
+		// reserved-key exclusion to make here — the fleet stamp is instance-scoped —
+		// so the plain emptiness test is the whole rule (#670).
+		if len(volumeTags) == 0 {
+			volumeTags = ltData.VolumeTagSpecifications
+		}
 	}
 
 	// The instance-type default is resolved last, so it applies only when neither the
@@ -508,6 +524,21 @@ func (p *EC2Plugin) runInstancesWithTags(
 	// mutations: a refusal past that point leaves state behind, which is worse than no
 	// validation at all because the next request in the same test sees it.
 	if awsErr := ec2CheckBlockDeviceMappings(blockDeviceMappings); awsErr != nil {
+		return nil, awsErr
+	}
+
+	// The volume tags are checked here for the same ordering reason, and it is not the
+	// same as the instance tags' position: a volume is written inside the launch loop
+	// *after* its instance's own Put, so a refusal there would leave instance 1 behind
+	// on a MaxCount=2 launch. Both tag rules apply, whether the tags came from the
+	// request or from a template — the template check is not redundant, since a
+	// template stored before these checks existed, or one written straight into state
+	// by a replayed event log, can still carry a reserved key or more than the limit.
+	// A new volume starts with no tags, so the resolved set is the whole count (#670).
+	if awsErr := ec2CheckTagRules(volumeTags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, volumeTags); awsErr != nil {
 		return nil, awsErr
 	}
 
@@ -650,7 +681,7 @@ func (p *EC2Plugin) runInstancesWithTags(
 		// Materialize this instance's volumes, after the instance so they can carry
 		// its ID and its zone. Each instance of a multi-count launch gets its own
 		// volumes with their own IDs — two instances cannot share one EBS volume.
-		if err := p.ec2CreateLaunchVolumes(&inst, blockDeviceMappings, now); err != nil {
+		if err := p.ec2CreateLaunchVolumes(&inst, blockDeviceMappings, volumeTags, now); err != nil {
 			return nil, err
 		}
 		instances = append(instances, inst)
@@ -2467,6 +2498,13 @@ func ec2TaggableStateKey(reqCtx *RequestContext, id string) (string, bool) {
 		return "eip:" + scope + "/" + id, true
 	case strings.HasPrefix(id, "nat-"):
 		return "nat:" + scope + "/" + id, true
+	case strings.HasPrefix(id, "vol-"):
+		// Volumes were the one taggable resource with no arm here, so CreateTags on a
+		// vol- ID fell through to the default and answered <return>true</return> having
+		// written nothing (#670). Nothing else needed changing:
+		// [EC2Plugin.applyTagsToResource] is type-agnostic — it reads and writes the
+		// record's "tags" JSON member — and [EC2Volume.Tags] already serializes there.
+		return ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, id), true
 	default:
 		return "", false
 	}
@@ -4487,13 +4525,17 @@ func parseLaunchTemplateData(params map[string]string) EC2LaunchTemplateData {
 	ec2SortInterfacesByDeviceIndex(interfaces)
 
 	data := EC2LaunchTemplateData{
-		ImageID:             params[ltPrefix+"ImageId"],
-		InstanceType:        params[ltPrefix+"InstanceType"],
-		KeyName:             params[ltPrefix+"KeyName"],
-		UserData:            params[ltPrefix+"UserData"],
-		TagSpecifications:   ec2TagSpecificationTags(params, ltPrefix, "instance"),
-		NetworkInterfaces:   interfaces,
-		BlockDeviceMappings: ec2ParseBlockDeviceMappings(params, ltPrefix),
+		ImageID:      params[ltPrefix+"ImageId"],
+		InstanceType: params[ltPrefix+"InstanceType"],
+		KeyName:      params[ltPrefix+"KeyName"],
+		UserData:     params[ltPrefix+"UserData"],
+		// One parse per scope, into a field per scope. The instance scope keeps the
+		// original field because widening it would break replay; see
+		// [EC2LaunchTemplateData.TagSpecifications] (#670).
+		TagSpecifications:       ec2TagSpecificationTags(params, ltPrefix, "instance"),
+		VolumeTagSpecifications: ec2TagSpecificationTags(params, ltPrefix, "volume"),
+		NetworkInterfaces:       interfaces,
+		BlockDeviceMappings:     ec2ParseBlockDeviceMappings(params, ltPrefix),
 	}
 	// The flat fields hold the primary interface's values; see
 	// [EC2LaunchTemplateData.NetworkInterfaces].
@@ -4611,6 +4653,24 @@ type ec2TagItem struct {
 	Value string `xml:"value"`
 }
 
+// ec2TagItems renders a stored tag list as tagSet entries, in slice order.
+//
+// [EC2Tag] and [ec2TagItem] have identical field sets, so the conversion is a cast per
+// element rather than a copy — the same cast the five hand-rolled loops that predate
+// this helper each perform. It returns nil for an empty list, which a caller renders as
+// a present-but-empty element or omits by its own struct tag; the choice belongs to the
+// response shape, not here.
+func ec2TagItems(tags []EC2Tag) []ec2TagItem {
+	if len(tags) == 0 {
+		return nil
+	}
+	items := make([]ec2TagItem, 0, len(tags))
+	for _, t := range tags {
+		items = append(items, ec2TagItem(t))
+	}
+	return items
+}
+
 // ec2LaunchTemplateSummary renders a launch template as its summary element.
 func ec2LaunchTemplateSummary(lt *EC2LaunchTemplate) ec2LaunchTemplateXML {
 	out := ec2LaunchTemplateXML{
@@ -4718,7 +4778,30 @@ func (p *EC2Plugin) deleteLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 
 // --- EBS volume operations ---
 
+// createVolume creates an EBS volume, tagging it from TagSpecification.N.
+//
+// The tags come from [ec2LaunchTagsForResource] scoped to "volume", which is the same
+// walk RunInstances, CreateFleet, CreateImage and CreateNatGateway already use: AWS's
+// wire shape here is byte-identical to theirs, so a second parser would only be a
+// second thing to drift (#670). They are checked before the volume is written, per the
+// rollback rule in [ec2CheckReservedTagKeys] — a refusal that had already stored the
+// volume would leave an untagged one behind for the next request to see.
+//
+// Iops and Throughput are read here for the same reason the tags are: [EC2Volume]
+// carried both and DescribeVolumes rendered both, but this parser ignored them, so
+// CreateVolume(Iops=…) and RunInstances(…Ebs.Iops=…) disagreed about the same field. No
+// per-type validation is applied — see [ec2CheckBlockDeviceMappings] for why substrate
+// does not encode the documented numeric ranges.
 func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	tags := ec2LaunchTagsForResource(req.Params, "volume")
+	if awsErr := ec2CheckTagRules(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	// A new volume starts with no tags, so the request's own tags are the whole count.
+	if awsErr := ec2CheckTagLimit(nil, tags); awsErr != nil {
+		return nil, awsErr
+	}
+
 	az := req.Params["AvailabilityZone"]
 	if az == "" {
 		az = reqCtx.Region + "a"
@@ -4736,6 +4819,11 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	}
 	snapshotID := req.Params["SnapshotId"]
 	encrypted := strings.ToLower(req.Params["Encrypted"]) == "true"
+	// Recorded as given, with the same tolerance Size above has: a value that does not
+	// parse leaves the field at zero and the field is then omitted from the response,
+	// which is what a volume with no provisioned performance looks like.
+	iops, _ := strconv.Atoi(req.Params["Iops"])
+	throughput, _ := strconv.Atoi(req.Params["Throughput"])
 
 	vol := EC2Volume{
 		VolumeID:         generateVolumeID(),
@@ -4745,6 +4833,9 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		State:            "available",
 		SnapshotID:       snapshotID,
 		Encrypted:        encrypted,
+		IOPS:             iops,
+		Throughput:       throughput,
+		Tags:             tags,
 		CreateTime:       p.tc.Now().UTC().Format(time.RFC3339),
 		AccountID:        reqCtx.AccountID,
 		Region:           reqCtx.Region,
@@ -4769,19 +4860,26 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		Status     string `xml:"status"`
 	}
 	type response struct {
-		XMLName          xml.Name         `xml:"CreateVolumeResponse"`
-		XMLNS            string           `xml:"xmlns,attr"`
-		VolumeID         string           `xml:"volumeId"`
-		Size             int              `xml:"size"`
-		VolumeType       string           `xml:"volumeType"`
-		AvailabilityZone string           `xml:"availabilityZone"`
-		Status           string           `xml:"status"`
-		Encrypted        bool             `xml:"encrypted"`
-		CreateTime       string           `xml:"createTime"`
-		SnapshotID       string           `xml:"snapshotId"`
-		AttachmentSet    []attachmentItem `xml:"attachmentSet>item"`
+		XMLName          xml.Name `xml:"CreateVolumeResponse"`
+		XMLNS            string   `xml:"xmlns,attr"`
+		VolumeID         string   `xml:"volumeId"`
+		Size             int      `xml:"size"`
+		VolumeType       string   `xml:"volumeType"`
+		AvailabilityZone string   `xml:"availabilityZone"`
+		Status           string   `xml:"status"`
+		Encrypted        bool     `xml:"encrypted"`
+		CreateTime       string   `xml:"createTime"`
+		SnapshotID       string   `xml:"snapshotId"`
+		IOPS             int      `xml:"iops,omitempty"`
+		Throughput       int      `xml:"throughput,omitempty"`
+		// tagSet carries no omitempty, deliberately: AWS's Example 2 emits <tagSet/>
+		// for a volume created with no tags, and an SDK maps a present-but-empty
+		// element to an empty slice where it maps an omitted one to nil. Omitting it
+		// would report "unknown" where AWS reports "none".
+		Tags          []ec2TagItem     `xml:"tagSet>item"`
+		AttachmentSet []attachmentItem `xml:"attachmentSet>item"`
 	}
-	return ec2XMLResponse(http.StatusOK, response{
+	resp := response{
 		XMLNS:            "http://ec2.amazonaws.com/doc/2016-11-15/",
 		VolumeID:         vol.VolumeID,
 		Size:             vol.Size,
@@ -4791,7 +4889,11 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		Encrypted:        vol.Encrypted,
 		CreateTime:       vol.CreateTime,
 		SnapshotID:       vol.SnapshotID,
-	})
+		IOPS:             vol.IOPS,
+		Throughput:       vol.Throughput,
+		Tags:             ec2TagItems(vol.Tags),
+	}
+	return ec2XMLResponse(http.StatusOK, resp)
 }
 
 func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -4805,53 +4907,17 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 		requestedIDs[id] = true
 	}
 
-	// Collect filter values. The set grew with #666: a launch now materializes its
-	// own volumes, so "which volume is the root of this instance" and "which of
-	// these survive termination" became questions worth asking, and every filter
-	// name below is one AWS's DescribeVolumes reference documents. Names outside
-	// this set are still dropped rather than refused, which is the behavior every
-	// other EC2 filter site has.
-	filterVolumeIDs := map[string]bool{}
-	filterStatuses := map[string]bool{}
-	filterInstanceIDs := map[string]bool{}
-	filterDevices := map[string]bool{}
-	filterDeleteOnTerm := map[string]bool{}
-	filterVolumeTypes := map[string]bool{}
-	filterSizes := map[string]bool{}
-	filterZones := map[string]bool{}
-	filterSnapshotIDs := map[string]bool{}
-	for i := 1; ; i++ {
-		name := req.Params[fmt.Sprintf("Filter.%d.Name", i)]
-		if name == "" {
-			break
-		}
-		for j := 1; ; j++ {
-			val := req.Params[fmt.Sprintf("Filter.%d.Value.%d", i, j)]
-			if val == "" {
-				break
-			}
-			switch name {
-			case "volume-id":
-				filterVolumeIDs[val] = true
-			case "status":
-				filterStatuses[val] = true
-			case "attachment.instance-id":
-				filterInstanceIDs[val] = true
-			case "attachment.device":
-				filterDevices[val] = true
-			case "attachment.delete-on-termination":
-				filterDeleteOnTerm[strings.ToLower(val)] = true
-			case "volume-type":
-				filterVolumeTypes[val] = true
-			case "size":
-				filterSizes[val] = true
-			case "availability-zone":
-				filterZones[val] = true
-			case "snapshot-id":
-				filterSnapshotIDs[val] = true
-			}
-		}
-	}
+	// Filters come from the shared [extractEC2Filters] walk rather than a hand-rolled
+	// one. The hand-rolled loop this replaces switched on the filter name *inside* the
+	// value loop, into nine map[string]bool sets — a shape that cannot express
+	// tag:<key>, since the key is part of the name (#670).
+	//
+	// Two behavior changes come with the shared walk, both fidelity improvements worth
+	// naming rather than leaving to be discovered. It records an empty filter value as a
+	// value, where the old loop's `if val == "" { break }` truncated the list at it. And
+	// it keeps a filter whose value list is empty, so `tag:Env` with no value is a filter
+	// that matches nothing rather than one that was never seen.
+	filters := extractEC2Filters(req.Params)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, ec2VolumeStatePrefix(reqCtx.AccountID, reqCtx.Region))
 	if err != nil {
@@ -4879,8 +4945,12 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 		SnapshotID       string `xml:"snapshotId"`
 		// iops and throughput were stored and never rendered, so a volume created
 		// with provisioned performance read back as one without it.
-		IOPS          int          `xml:"iops,omitempty"`
-		Throughput    int          `xml:"throughput,omitempty"`
+		IOPS       int `xml:"iops,omitempty"`
+		Throughput int `xml:"throughput,omitempty"`
+		// tagSet carries no omitempty, for the reason CreateVolume's does not: AWS
+		// renders the element for an untagged volume, and an SDK tells a
+		// present-but-empty element from an omitted one.
+		Tags          []ec2TagItem `xml:"tagSet>item"`
 		AttachmentSet []attachItem `xml:"attachmentSet>item"`
 	}
 	var volumes []volItem
@@ -4898,31 +4968,7 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 		if len(requestedIDs) > 0 && !requestedIDs[vol.VolumeID] {
 			continue
 		}
-		// Filter by volume-id filter.
-		if len(filterVolumeIDs) > 0 && !filterVolumeIDs[vol.VolumeID] {
-			continue
-		}
-		// Filter by status.
-		if len(filterStatuses) > 0 && !filterStatuses[vol.State] {
-			continue
-		}
-		// Filter by volume-type, size and availability-zone, all volume-scoped.
-		if len(filterVolumeTypes) > 0 && !filterVolumeTypes[vol.VolumeType] {
-			continue
-		}
-		if len(filterSizes) > 0 && !filterSizes[strconv.Itoa(vol.Size)] {
-			continue
-		}
-		if len(filterZones) > 0 && !filterZones[vol.AvailabilityZone] {
-			continue
-		}
-		if len(filterSnapshotIDs) > 0 && !filterSnapshotIDs[vol.SnapshotID] {
-			continue
-		}
-		// The attachment-scoped filters match when *any* attachment satisfies them,
-		// which is what a filter on a list-valued member means: a volume matches
-		// attachment.device=/dev/sdf when it is attached at that device.
-		if !ec2VolumeMatchesAttachmentFilters(vol, filterInstanceIDs, filterDevices, filterDeleteOnTerm) {
+		if !ec2VolumeMatchesFilters(vol, filters) {
 			continue
 		}
 		item := volItem{
@@ -4936,6 +4982,7 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 			SnapshotID:       vol.SnapshotID,
 			IOPS:             vol.IOPS,
 			Throughput:       vol.Throughput,
+			Tags:             ec2TagItems(vol.Tags),
 		}
 		for _, att := range vol.Attachments {
 			item.AttachmentSet = append(item.AttachmentSet, attachItem{

--- a/emulator/ec2_tags.go
+++ b/emulator/ec2_tags.go
@@ -240,21 +240,30 @@ func ec2TagSpecificationTags(params map[string]string, prefix, resourceType stri
 	return tags
 }
 
-// ec2CheckTemplateTags returns an error if a launch template's instance-scoped tags
-// break any tag rule, or nil.
+// ec2CheckTemplateTags returns an error if a launch template's tags break any tag
+// rule, or nil.
 //
 // Run when a template or a version of one is created, so a template carrying a
 // reserved key, an over-long key or value, or more than [ec2MaxTagsPerResource] is
 // refused up front rather than at every launch that names it. Real EC2 rejects at
 // creation too: every rule is on the tag and the count, not on the operation.
 //
+// Every scope the template records is checked, and each is counted against the limit
+// on its own: the limit is per resource, and the instance and its volumes are
+// different resources (#670).
+//
 // The launch path checks again, deliberately — see the fallback in
 // [EC2Plugin.runInstancesWithTags] for why a stored template can still carry one.
 func ec2CheckTemplateTags(d EC2LaunchTemplateData) *AWSError {
-	if awsErr := ec2CheckTagRules(d.TagSpecifications); awsErr != nil {
-		return awsErr
+	for _, scope := range [][]EC2Tag{d.TagSpecifications, d.VolumeTagSpecifications} {
+		if awsErr := ec2CheckTagRules(scope); awsErr != nil {
+			return awsErr
+		}
+		if awsErr := ec2CheckTagLimit(nil, scope); awsErr != nil {
+			return awsErr
+		}
 	}
-	return ec2CheckTagLimit(nil, d.TagSpecifications)
+	return nil
 }
 
 // ec2HasUserTags reports whether tags holds any key that is not reserved.

--- a/emulator/ec2_tags_test.go
+++ b/emulator/ec2_tags_test.go
@@ -388,10 +388,14 @@ func TestEC2_RunInstances_ReservedTagRejectionCreatesNothing(t *testing.T) {
 	require.Equal(t, "InvalidParameterValue", code)
 	assert.Zero(t, ec2InstanceCount(t, ts))
 
-	// A volume-scoped reserved key does not fail an instance launch: substrate models
-	// instance tags on this path, and a specification for a resource it does not tag is
-	// skipped rather than checked. Stated as a deliberate limit, not an oversight.
-	ids := ec2RunInstanceIDs(t, ts, map[string]string{
+	// A volume-scoped reserved key now fails the launch too, and this row is inverted
+	// from what it asserted through v0.104.0: the volume scope was parsed nowhere, so a
+	// specification substrate did not apply was a specification it did not check, and
+	// the launch succeeded with the reserved key silently dropped. Now that the scope
+	// tags real volumes (#670) it is checked on the same terms as the instance scope,
+	// and the refusal still leaves no instance behind — the check runs before the
+	// launch loop, where the instance is written one iteration ahead of its volumes.
+	status, code, _ = ec2ErrorDetail(t, ts, map[string]string{
 		"Action":                          "RunInstances",
 		"ImageId":                         "ami-0rollback00000003",
 		"MinCount":                        "1",
@@ -400,7 +404,9 @@ func TestEC2_RunInstances_ReservedTagRejectionCreatesNothing(t *testing.T) {
 		"TagSpecification.1.Tag.1.Key":    "aws:volume",
 		"TagSpecification.1.Tag.1.Value":  "x",
 	})
-	assert.Len(t, ids, 1)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidParameterValue", code)
+	assert.Zero(t, ec2InstanceCount(t, ts), "a volume-tag refusal leaves no instance either")
 }
 
 // TestEC2_CreateImage_RejectsReservedTagKeys covers CreateImage's two tag scopes.

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -747,13 +747,27 @@ type EC2LaunchTemplateData struct {
 	// TagSpecifications is the template's instance-scoped tag-on-create tags, from
 	// LaunchTemplateData.TagSpecification.N with ResourceType=instance.
 	//
-	// Instance-scoped only. A template may also scope tags to volume,
-	// network-interface or spot-instances-request; substrate models none of those
-	// resources, so those scopes are recorded nowhere rather than misapplied to the
-	// instance. Note that these tags land on the *instance*, not on the template
-	// itself — the reference is explicit: "These tags are not applied to the launch
-	// template."
+	// Instance-scoped only, and deliberately still so. Widening this field to carry a
+	// resource-type discriminator would unmarshal every template already in an event
+	// log without error into an element with an empty ResourceType and no tags, so
+	// every stored template would silently start launching untagged instances — the
+	// replay guarantee broken by a change that compiles. Other scopes get their own
+	// field instead; see VolumeTagSpecifications and the same split at
+	// NetworkInterfaces above.
+	//
+	// Note that these tags land on the *instance*, not on the template itself — the
+	// reference is explicit: "These tags are not applied to the launch template."
 	TagSpecifications []EC2Tag `json:"tagSpecifications,omitempty"`
+
+	// VolumeTagSpecifications is the template's volume-scoped tag-on-create tags, from
+	// LaunchTemplateData.TagSpecification.N with ResourceType=volume (#670). They land
+	// on every volume the launch materializes, including the root volume substrate
+	// synthesizes when no mapping declares one.
+	//
+	// AWS's LaunchTemplateTagSpecificationRequest also allows network-interface and
+	// spot-instances-request; those scopes are still recorded nowhere, because a
+	// recorded tag that no read surfaces is indistinguishable from a discarded one.
+	VolumeTagSpecifications []EC2Tag `json:"volumeTagSpecifications,omitempty"`
 
 	// IamInstanceProfile is the instance profile the template names, stored as
 	// whichever of Name or Arn the request supplied — the same single-string shape

--- a/emulator/ec2_volume_tags_test.go
+++ b/emulator/ec2_volume_tags_test.go
@@ -1,0 +1,741 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #670's surface: a volume can be tagged at creation, reports its tags, and is
+// findable by them.
+//
+// Through v0.104.0 an EBS volume was the one taggable EC2 resource with no tagging
+// path at all. CreateVolume accepted TagSpecification.N and stored nothing;
+// CreateTags on a vol- ID answered <return>true</return> and wrote nothing, because
+// ec2TaggableStateKey had no vol- arm; DescribeVolumes rendered no tagSet and
+// supported no tag filter. EC2Volume.Tags existed the whole time and nothing ever
+// wrote to it — the store-and-hide shape, except that even the store was missing.
+//
+// Every assertion here goes through HTTP, because the defect was entirely on the
+// wire: state carried a field the API could neither fill nor read.
+
+// volTag is one tagSet>item entry.
+type volTag struct {
+	Key   string `xml:"key"`
+	Value string `xml:"value"`
+}
+
+// volTagMap collapses a tagSet to a map for order-independent comparison. AWS states
+// outright that response element order may vary, so a test must not pin it.
+func volTagMap(tags []volTag) map[string]string {
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[t.Key] = t.Value
+	}
+	return out
+}
+
+// volCreateResult is a CreateVolume response, parsed.
+//
+// TagSet is a pointer so the test can tell an absent element from a present-but-empty
+// one: AWS's Example 2 emits <tagSet/> for a volume created with no tags, so absent is
+// the wrong answer and only a pointer distinguishes the two.
+type volCreateResult struct {
+	VolumeID   string    `xml:"volumeId"`
+	Size       int       `xml:"size"`
+	VolumeType string    `xml:"volumeType"`
+	IOPS       int       `xml:"iops"`
+	Throughput int       `xml:"throughput"`
+	TagSet     *struct { //nolint:govet // Shape mirrors the wire, not field alignment.
+		Items []volTag `xml:"item"`
+	} `xml:"tagSet"`
+}
+
+// volCreate calls CreateVolume and returns the parsed response.
+func volCreate(t *testing.T, ts *httptest.Server, params map[string]string) volCreateResult {
+	t.Helper()
+	all := map[string]string{
+		"Action":           "CreateVolume",
+		"AvailabilityZone": "us-east-1a",
+		"Size":             "20",
+	}
+	for k, v := range params {
+		all[k] = v
+	}
+	resp := ec2Request(t, ts, all)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var parsed volCreateResult
+	require.NoError(t, xml.Unmarshal(body, &parsed), string(body))
+	require.NotEmpty(t, parsed.VolumeID)
+	return parsed
+}
+
+// volDescribe calls DescribeVolumes and returns each volume's ID with its tags,
+// sorted by volume ID so an assertion does not depend on state-listing order.
+func volDescribe(t *testing.T, ts *httptest.Server, params map[string]string) []struct {
+	ID   string
+	Tags map[string]string
+} {
+	t.Helper()
+	all := map[string]string{"Action": "DescribeVolumes"}
+	for k, v := range params {
+		all[k] = v
+	}
+	resp := ec2Request(t, ts, all)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var parsed struct {
+		Items []struct {
+			VolumeID string   `xml:"volumeId"`
+			Tags     []volTag `xml:"tagSet>item"`
+		} `xml:"volumeSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), string(body))
+	out := make([]struct {
+		ID   string
+		Tags map[string]string
+	}, 0, len(parsed.Items))
+	for _, item := range parsed.Items {
+		out = append(out, struct {
+			ID   string
+			Tags map[string]string
+		}{ID: item.VolumeID, Tags: volTagMap(item.Tags)})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// volIDs returns just the volume IDs volDescribe reported.
+func volIDs(described []struct {
+	ID   string
+	Tags map[string]string
+}) []string {
+	ids := make([]string, 0, len(described))
+	for _, v := range described {
+		ids = append(ids, v.ID)
+	}
+	return ids
+}
+
+// ec2InstanceTagMap returns the tags DescribeInstances reports for one instance, so a
+// volume-scoped assertion can also prove the instance scope was not affected.
+func ec2InstanceTagMap(t *testing.T, ts *httptest.Server, instanceID string) map[string]string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":       "DescribeInstances",
+		"InstanceId.1": instanceID,
+	})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var parsed struct {
+		Instances []struct {
+			Tags []volTag `xml:"tagSet>item"`
+		} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), string(body))
+	require.Len(t, parsed.Instances, 1)
+	return volTagMap(parsed.Instances[0].Tags)
+}
+
+// ec2InstanceIDs returns every instance DescribeInstances reports, which is how a
+// refusal is shown to have written nothing.
+func ec2InstanceIDs(t *testing.T, ts *httptest.Server) []string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{"Action": "DescribeInstances"})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var parsed struct {
+		IDs []string `xml:"reservationSet>item>instancesSet>item>instanceId"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &parsed), string(body))
+	return parsed.IDs
+}
+
+// TestEC2_CreateVolume_TagOnCreate is the wire shape AWS's own Example 3 documents:
+// TagSpecification.1.ResourceType=volume with Tag.1.Key/Value, answered with a
+// populated tagSet.
+//
+// The parser is the one ec2LaunchTagsForResource already uses for RunInstances,
+// CreateFleet, CreateImage and CreateNatGateway, called with one different argument —
+// the wire shape is byte-identical, so a second walk would only be a second thing to
+// drift.
+func TestEC2_CreateVolume_TagOnCreate(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	created := volCreate(t, ts, map[string]string{
+		"TagSpecification.1.ResourceType": "volume",
+		"TagSpecification.1.Tag.1.Key":    "stack",
+		"TagSpecification.1.Tag.1.Value":  "production",
+		"TagSpecification.1.Tag.2.Key":    "Name",
+		"TagSpecification.1.Tag.2.Value":  "data",
+	})
+	require.NotNil(t, created.TagSet, "CreateVolume rendered no tagSet element at all")
+	assert.Equal(t, map[string]string{"stack": "production", "Name": "data"},
+		volTagMap(created.TagSet.Items))
+
+	// And they are stored, not merely echoed.
+	described := volDescribe(t, ts, map[string]string{"VolumeId.1": created.VolumeID})
+	require.Len(t, described, 1)
+	assert.Equal(t, map[string]string{"stack": "production", "Name": "data"}, described[0].Tags)
+}
+
+// TestEC2_CreateVolume_ScopeIsHonored pins that the resource-type scope is read
+// rather than ignored. A specification scoped to something else contributes nothing,
+// and one scoped to volume that follows it still applies — which is the skip-don't-stop
+// rule ec2TagSpecificationTags already implements and this is the volume-side proof of.
+func TestEC2_CreateVolume_ScopeIsHonored(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	created := volCreate(t, ts, map[string]string{
+		"TagSpecification.1.ResourceType": "instance",
+		"TagSpecification.1.Tag.1.Key":    "wrong",
+		"TagSpecification.1.Tag.1.Value":  "scope",
+		"TagSpecification.2.ResourceType": "volume",
+		"TagSpecification.2.Tag.1.Key":    "right",
+		"TagSpecification.2.Tag.1.Value":  "scope",
+	})
+	require.NotNil(t, created.TagSet)
+	assert.Equal(t, map[string]string{"right": "scope"}, volTagMap(created.TagSet.Items))
+}
+
+// TestEC2_CreateVolume_EmptyTagSetIsPresent pins the present-but-empty element, which
+// AWS's Example 2 shows verbatim for a volume created with no tags: <tagSet/>. An SDK
+// maps a present-but-empty element to an empty slice and an omitted one to nil, so
+// omitempty here would report "unknown" where AWS reports "none".
+func TestEC2_CreateVolume_EmptyTagSetIsPresent(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	created := volCreate(t, ts, nil)
+	require.NotNil(t, created.TagSet, "an untagged volume must still render <tagSet/>")
+	assert.Empty(t, created.TagSet.Items)
+
+	described := volDescribe(t, ts, map[string]string{"VolumeId.1": created.VolumeID})
+	require.Len(t, described, 1)
+	assert.Empty(t, described[0].Tags)
+}
+
+// TestEC2_CreateVolume_IopsAndThroughput closes a store-and-hide gap found in the same
+// parser: EC2Volume carries IOPS and Throughput and DescribeVolumes renders both, but
+// createVolume never read either parameter — so CreateVolume(Iops=…) and
+// RunInstances(…Ebs.Iops=…) disagreed about the same field.
+func TestEC2_CreateVolume_IopsAndThroughput(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	created := volCreate(t, ts, map[string]string{
+		"VolumeType": "gp3",
+		"Iops":       "4000",
+		"Throughput": "250",
+	})
+	assert.Equal(t, 4000, created.IOPS)
+	assert.Equal(t, 250, created.Throughput)
+
+	vols := bdmDescribeVolumes(t, ts, map[string]string{"VolumeId.1": created.VolumeID})
+	require.Len(t, vols, 1)
+	assert.Equal(t, 4000, vols[0].IOPS)
+	assert.Equal(t, 250, vols[0].Throughput)
+}
+
+// TestEC2_CreateVolume_TagRulesRefused pins that tag-on-create here goes through the
+// same restrictions every other tag-on-create path does, rather than being a second
+// unrestricted door. AWS documents no volume-specific tag constraint, so the rules are
+// exactly the resource-independent ones.
+//
+// The volume must not exist afterwards. A refusal that had already written the volume
+// would leave an untagged volume behind for the next request in the same test to see,
+// which is the rollback rule every other tag-on-create path follows.
+func TestEC2_CreateVolume_TagRulesRefused(t *testing.T) {
+	t.Parallel()
+	manyTags := func(n int) map[string]string {
+		params := map[string]string{"TagSpecification.1.ResourceType": "volume"}
+		for i := 1; i <= n; i++ {
+			params["TagSpecification.1.Tag."+strconv.Itoa(i)+".Key"] = "k" + strconv.Itoa(i)
+			params["TagSpecification.1.Tag."+strconv.Itoa(i)+".Value"] = "v"
+		}
+		return params
+	}
+	for _, tc := range []struct {
+		name   string
+		params map[string]string
+		code   string
+	}{
+		{
+			name: "a reserved key",
+			params: map[string]string{
+				"TagSpecification.1.ResourceType": "volume",
+				"TagSpecification.1.Tag.1.Key":    "aws:cloudformation:stack-name",
+				"TagSpecification.1.Tag.1.Value":  "mine",
+			},
+			code: "InvalidParameterValue",
+		},
+		{
+			name: "an over-long key",
+			params: map[string]string{
+				"TagSpecification.1.ResourceType": "volume",
+				"TagSpecification.1.Tag.1.Key":    strings.Repeat("k", 129),
+				"TagSpecification.1.Tag.1.Value":  "v",
+			},
+			code: "InvalidParameterValue",
+		},
+		{
+			name:   "more tags than the per-resource limit",
+			params: manyTags(51),
+			code:   "TagLimitExceeded",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			all := map[string]string{
+				"Action":           "CreateVolume",
+				"AvailabilityZone": "us-east-1a",
+				"Size":             "20",
+			}
+			for k, v := range tc.params {
+				all[k] = v
+			}
+			status, code, msg := ec2ErrorDetail(t, ts, all)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tc.code, code, "message: %s", msg)
+
+			assert.Empty(t, volIDs(volDescribe(t, ts, nil)),
+				"a refused CreateVolume left a volume behind")
+		})
+	}
+}
+
+// TestEC2_CreateVolume_TagLimitAllowsExactly50 is the boundary the limit check must not
+// be off by one on: 50 user tags is legal.
+func TestEC2_CreateVolume_TagLimitAllowsExactly50(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	params := map[string]string{"TagSpecification.1.ResourceType": "volume"}
+	for i := 1; i <= 50; i++ {
+		params["TagSpecification.1.Tag."+strconv.Itoa(i)+".Key"] = "k" + strconv.Itoa(i)
+		params["TagSpecification.1.Tag."+strconv.Itoa(i)+".Value"] = "v"
+	}
+	created := volCreate(t, ts, params)
+	require.NotNil(t, created.TagSet)
+	assert.Len(t, created.TagSet.Items, 50)
+}
+
+// TestEC2_CreateTags_OnVolume is the plainest form of #670's report, and the one that
+// answered 200 while writing nothing: ec2TaggableStateKey had arms for instances, VPCs,
+// subnets, security groups, internet gateways, route tables, elastic IPs and NAT
+// gateways, and none for a volume — so the ID fell through to the default and both
+// applyTagsToResource and resourceTags treated it as an untaggable type.
+//
+// Nothing else needed changing for this: applyTagsToResource is type-agnostic, reading
+// and writing the record's "tags" JSON member, and EC2Volume.Tags already serialized
+// there. This test is what verifies that rather than asserting it.
+func TestEC2_CreateTags_OnVolume(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	created := volCreate(t, ts, nil)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": created.VolumeID,
+		"Tag.1.Key":    "Env",
+		"Tag.1.Value":  "prod",
+		"Tag.2.Key":    "Owner",
+		"Tag.2.Value":  "team-a",
+	})
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	described := volDescribe(t, ts, map[string]string{"VolumeId.1": created.VolumeID})
+	require.Len(t, described, 1)
+	assert.Equal(t, map[string]string{"Env": "prod", "Owner": "team-a"}, described[0].Tags)
+
+	// DeleteTags reaches it through the same resolver, so it must too.
+	del := ec2Request(t, ts, map[string]string{
+		"Action":       "DeleteTags",
+		"ResourceId.1": created.VolumeID,
+		"Tag.1.Key":    "Env",
+	})
+	require.NoError(t, del.Body.Close())
+	require.Equal(t, http.StatusOK, del.StatusCode)
+
+	after := volDescribe(t, ts, map[string]string{"VolumeId.1": created.VolumeID})
+	require.Len(t, after, 1)
+	assert.Equal(t, map[string]string{"Owner": "team-a"}, after[0].Tags)
+}
+
+// TestEC2_CreateTags_OnVolumeChecksTheLimit pins that a volume joined the *checked* set
+// and not merely the written one: the tag limit is counted against the resource's
+// existing tags, which requires resourceTags to resolve the same key
+// applyTagsToResource writes to.
+func TestEC2_CreateTags_OnVolumeChecksTheLimit(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	params := map[string]string{"TagSpecification.1.ResourceType": "volume"}
+	for i := 1; i <= 50; i++ {
+		params["TagSpecification.1.Tag."+strconv.Itoa(i)+".Key"] = "k" + strconv.Itoa(i)
+		params["TagSpecification.1.Tag."+strconv.Itoa(i)+".Value"] = "v"
+	}
+	created := volCreate(t, ts, params)
+
+	// A 51st distinct key does not fit.
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": created.VolumeID,
+		"Tag.1.Key":    "one-too-many",
+		"Tag.1.Value":  "v",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "TagLimitExceeded", code)
+
+	// Overwriting a key already on the volume adds nothing to the count, so it fits —
+	// the post-merge count ec2CheckTagLimit documents, now reachable for a volume.
+	ok := ec2Request(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": created.VolumeID,
+		"Tag.1.Key":    "k1",
+		"Tag.1.Value":  "overwritten",
+	})
+	require.NoError(t, ok.Body.Close())
+	require.Equal(t, http.StatusOK, ok.StatusCode)
+
+	described := volDescribe(t, ts, map[string]string{"VolumeId.1": created.VolumeID})
+	require.Len(t, described, 1)
+	assert.Equal(t, "overwritten", described[0].Tags["k1"])
+}
+
+// TestEC2_DescribeVolumes_TagFilters pins the two tag filters AWS's DescribeVolumes
+// reference documents, and only those two: tag:<key> and tag-key. There is no
+// tag-value filter on this operation — of its twenty documented filters those are the
+// only two in the tag family — so an unknown name keeps falling through to the drop
+// this operation has always done.
+func TestEC2_DescribeVolumes_TagFilters(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	prod := volCreate(t, ts, map[string]string{
+		"TagSpecification.1.ResourceType": "volume",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	})
+	dev := volCreate(t, ts, map[string]string{
+		"TagSpecification.1.ResourceType": "volume",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "dev",
+	})
+	untagged := volCreate(t, ts, nil)
+
+	for _, tc := range []struct {
+		name    string
+		filters map[string]string
+		want    []string
+	}{
+		{
+			name: "tag:Env=prod matches the one volume",
+			filters: map[string]string{
+				"Filter.1.Name":    "tag:Env",
+				"Filter.1.Value.1": "prod",
+			},
+			want: []string{prod.VolumeID},
+		},
+		{
+			name: "a tag: filter's values are OR-combined",
+			filters: map[string]string{
+				"Filter.1.Name":    "tag:Env",
+				"Filter.1.Value.1": "prod",
+				"Filter.1.Value.2": "dev",
+			},
+			want: []string{dev.VolumeID, prod.VolumeID},
+		},
+		{
+			name: "tag-key matches any value",
+			filters: map[string]string{
+				"Filter.1.Name":    "tag-key",
+				"Filter.1.Value.1": "Env",
+			},
+			want: []string{dev.VolumeID, prod.VolumeID},
+		},
+		{
+			name: "tag-key on a key nothing carries matches nothing",
+			filters: map[string]string{
+				"Filter.1.Name":    "tag-key",
+				"Filter.1.Value.1": "Absent",
+			},
+			want: []string{},
+		},
+		{
+			// Two filters are AND-combined, which is the rule that makes a tag filter
+			// usable beside the volume-scoped ones this operation already had.
+			name: "a tag filter combines with a volume-scoped one",
+			filters: map[string]string{
+				"Filter.1.Name":    "tag-key",
+				"Filter.1.Value.1": "Env",
+				"Filter.2.Name":    "volume-id",
+				"Filter.2.Value.1": prod.VolumeID,
+			},
+			want: []string{prod.VolumeID},
+		},
+		{
+			// Substrate's answer where AWS documents none: "You can't specify a filter
+			// value of null" is all Using_Filtering says, and tag-key exists for the
+			// any-value question. Matching nothing follows DescribeInstances.
+			name: "a tag: filter with no value matches nothing",
+			filters: map[string]string{
+				"Filter.1.Name": "tag:Env",
+			},
+			want: []string{},
+		},
+		{
+			// Unchanged: this operation drops a name it does not know rather than
+			// refusing or matching nothing, and replacing the filter loop must not
+			// change that.
+			name: "an unknown filter name is still dropped",
+			filters: map[string]string{
+				"Filter.1.Name":    "not-a-filter",
+				"Filter.1.Value.1": "x",
+			},
+			want: []string{dev.VolumeID, prod.VolumeID, untagged.VolumeID},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := volIDs(volDescribe(t, ts, tc.filters))
+			sort.Strings(tc.want)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestEC2_DescribeVolumes_ExistingFiltersStillWork guards the replacement of
+// describeVolumes' hand-rolled filter loop with the shared extractEC2Filters walk. All
+// nine names it already supported must keep matching exactly what they did, since a
+// silent regression here would be invisible to the tag tests above.
+func TestEC2_DescribeVolumes_ExistingFiltersStillWork(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":              "/dev/xvda",
+		"BlockDeviceMapping.1.Ebs.VolumeSize":          "30",
+		"BlockDeviceMapping.2.DeviceName":              "/dev/sdf",
+		"BlockDeviceMapping.2.Ebs.VolumeSize":          "40",
+		"BlockDeviceMapping.2.Ebs.VolumeType":          "gp3",
+		"BlockDeviceMapping.2.Ebs.DeleteOnTermination": "true",
+	})
+	require.Len(t, ids, 1)
+
+	for _, tc := range []struct {
+		name    string
+		filters map[string]string
+		want    int
+	}{
+		{"attachment.instance-id", map[string]string{
+			"Filter.1.Name": "attachment.instance-id", "Filter.1.Value.1": ids[0]}, 2},
+		{"attachment.device", map[string]string{
+			"Filter.1.Name": "attachment.device", "Filter.1.Value.1": "/dev/sdf"}, 1},
+		{"attachment.delete-on-termination", map[string]string{
+			"Filter.1.Name": "attachment.delete-on-termination", "Filter.1.Value.1": "true"}, 2},
+		{"status", map[string]string{
+			"Filter.1.Name": "status", "Filter.1.Value.1": "in-use"}, 2},
+		{"size", map[string]string{
+			"Filter.1.Name": "size", "Filter.1.Value.1": "40"}, 1},
+		{"volume-type", map[string]string{
+			"Filter.1.Name": "volume-type", "Filter.1.Value.1": "gp3"}, 1},
+		{"availability-zone", map[string]string{
+			"Filter.1.Name": "availability-zone", "Filter.1.Value.1": "us-east-1a"}, 2},
+		{"snapshot-id matches the empty snapshot nothing came from", map[string]string{
+			"Filter.1.Name": "snapshot-id", "Filter.1.Value.1": "snap-absent"}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Len(t, volDescribe(t, ts, tc.filters), tc.want)
+		})
+	}
+}
+
+// TestEC2_RunInstances_VolumeTagSpecifications is the launch-time half: a
+// TagSpecification scoped to volume tags every volume the launch materializes, and
+// nothing else.
+//
+// The two scopes are independent, which the assertion pins from both directions: the
+// instance does not pick up the volume's tags and the volumes do not pick up the
+// instance's. A launch's implicit root volume is tagged too — it is a volume the launch
+// created, and AWS's own wording is "the tags to apply to the resources that are
+// created during instance launch".
+func TestEC2_RunInstances_VolumeTagSpecifications(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "40",
+		"TagSpecification.1.ResourceType":     "instance",
+		"TagSpecification.1.Tag.1.Key":        "Name",
+		"TagSpecification.1.Tag.1.Value":      "web",
+		"TagSpecification.2.ResourceType":     "volume",
+		"TagSpecification.2.Tag.1.Key":        "Backup",
+		"TagSpecification.2.Tag.1.Value":      "daily",
+	})
+	require.Len(t, ids, 1)
+
+	// Both volumes — the declared /dev/sdf and the synthesized root — carry the
+	// volume-scoped tag and only it.
+	described := volDescribe(t, ts, map[string]string{
+		"Filter.1.Name": "attachment.instance-id", "Filter.1.Value.1": ids[0],
+	})
+	require.Len(t, described, 2)
+	for _, vol := range described {
+		assert.Equal(t, map[string]string{"Backup": "daily"}, vol.Tags,
+			"volume %s", vol.ID)
+	}
+
+	// And the volume tag did not land on the instance.
+	instTags := ec2InstanceTagMap(t, ts, ids[0])
+	assert.Equal(t, map[string]string{"Name": "web"}, instTags)
+}
+
+// TestEC2_RunInstances_VolumeTagsAreFilterable is the round trip the issue is really
+// about: tag at launch, then find the volume by that tag without knowing its ID.
+func TestEC2_RunInstances_VolumeTagsAreFilterable(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	bdmRunInstances(t, ts, map[string]string{
+		"TagSpecification.1.ResourceType": "volume",
+		"TagSpecification.1.Tag.1.Key":    "Role",
+		"TagSpecification.1.Tag.1.Value":  "root",
+	})
+	found := volDescribe(t, ts, map[string]string{
+		"Filter.1.Name": "tag:Role", "Filter.1.Value.1": "root",
+	})
+	require.Len(t, found, 1)
+	assert.Equal(t, map[string]string{"Role": "root"}, found[0].Tags)
+}
+
+// TestEC2_RunInstances_VolumeTagRulesRefused pins that the volume scope is checked
+// before the launch writes anything. The tags reach state through
+// ec2VolumeFromMapping, inside the launch loop and after the instance's own Put, so a
+// check made there would leave the instance — and on a multi-count launch, some of its
+// siblings — behind.
+func TestEC2_RunInstances_VolumeTagRulesRefused(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	status, code, msg := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                          "RunInstances",
+		"ImageId":                         "ami-0abcdef1234567890",
+		"MinCount":                        "1",
+		"MaxCount":                        "1",
+		"TagSpecification.1.ResourceType": "volume",
+		"TagSpecification.1.Tag.1.Key":    "aws:reserved",
+		"TagSpecification.1.Tag.1.Value":  "no",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code, "message: %s", msg)
+
+	assert.Empty(t, volIDs(volDescribe(t, ts, nil)),
+		"a refused launch materialized a volume")
+	assert.Empty(t, ec2InstanceIDs(t, ts), "a refused launch left an instance behind")
+}
+
+// TestEC2_LaunchTemplate_VolumeTagSpecifications pins the template route, which is the
+// only route by which a fleet launch can tag its volumes.
+//
+// The template's volume scope is a separately-named field rather than a widening of the
+// existing flat instance-scoped one. Widening the persisted field would unmarshal every
+// stored template into an element with an empty resource type and no tags, silently
+// untagging the instances they already tag — the replay guarantee the emulator exists
+// for. It is the same mitigation EC2LaunchTemplateData.NetworkInterfaces uses.
+func TestEC2_LaunchTemplate_VolumeTagSpecifications(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "tagged-volumes",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.TagSpecification.1.ResourceType": "instance",
+		"LaunchTemplateData.TagSpecification.1.Tag.1.Key":    "Name",
+		"LaunchTemplateData.TagSpecification.1.Tag.1.Value":  "from-template",
+		"LaunchTemplateData.TagSpecification.2.ResourceType": "volume",
+		"LaunchTemplateData.TagSpecification.2.Tag.1.Key":    "Backup",
+		"LaunchTemplateData.TagSpecification.2.Tag.1.Value":  "weekly",
+	})
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateName": "tagged-volumes",
+	})
+	require.Len(t, ids, 1)
+
+	described := volDescribe(t, ts, map[string]string{
+		"Filter.1.Name": "attachment.instance-id", "Filter.1.Value.1": ids[0],
+	})
+	require.Len(t, described, 1)
+	assert.Equal(t, map[string]string{"Backup": "weekly"}, described[0].Tags)
+	assert.Equal(t, map[string]string{"Name": "from-template"},
+		ec2InstanceTagMap(t, ts, ids[0]))
+}
+
+// TestEC2_LaunchTemplate_VolumeTagsAreReplacedNotMerged pins the same all-or-nothing
+// merge rule every other launch-template field follows: the request's own volume tags
+// win outright rather than merging with the template's. AWS states only the general
+// rule — "any additional parameters that you specify for the new instance overwrite the
+// corresponding parameters included in the launch template" — and this is that rule
+// applied to the volume scope, exactly as the instance scope already applies it.
+func TestEC2_LaunchTemplate_VolumeTagsAreReplacedNotMerged(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "merge-check",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.TagSpecification.1.ResourceType": "volume",
+		"LaunchTemplateData.TagSpecification.1.Tag.1.Key":    "Backup",
+		"LaunchTemplateData.TagSpecification.1.Tag.1.Value":  "weekly",
+		"LaunchTemplateData.TagSpecification.1.Tag.2.Key":    "Team",
+		"LaunchTemplateData.TagSpecification.1.Tag.2.Value":  "infra",
+	})
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateName": "merge-check",
+		"TagSpecification.1.ResourceType":   "volume",
+		"TagSpecification.1.Tag.1.Key":      "Backup",
+		"TagSpecification.1.Tag.1.Value":    "hourly",
+	})
+	require.Len(t, ids, 1)
+
+	described := volDescribe(t, ts, map[string]string{
+		"Filter.1.Name": "attachment.instance-id", "Filter.1.Value.1": ids[0],
+	})
+	require.Len(t, described, 1)
+	assert.Equal(t, map[string]string{"Backup": "hourly"}, described[0].Tags,
+		"the request's volume tags replace the template's rather than merging")
+}

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -744,5 +744,5 @@ func LaunchVolumesForTest(instanceID, availabilityZone string, mappings []EC2Blo
 		AccountID:        "123456789012",
 		Region:           "us-east-1",
 	}
-	return ec2LaunchVolumesFor(inst, mappings, "2026-01-01T00:00:00Z")
+	return ec2LaunchVolumesFor(inst, mappings, nil, "2026-01-01T00:00:00Z")
 }

--- a/test/e2e/journey_ec2_block_devices_test.go
+++ b/test/e2e/journey_ec2_block_devices_test.go
@@ -288,3 +288,195 @@ func TestJourney_EC2InvalidBlockDeviceMappingRefused(t *testing.T) {
 		t.Fatalf("a refused launch materialized %d volumes, want 0", len(vols.Volumes))
 	}
 }
+
+// TestJourney_EC2VolumeTags is #670 at the tier the defect was invisible from: every
+// call below returned HTTP 200 through v0.104.0 and every tag went nowhere. CreateVolume
+// accepted TagSpecification and stored nothing, CreateTags on a vol- ID answered
+// return=true and wrote nothing, and DescribeVolumes rendered no tagSet and matched no
+// tag filter — so an IaC consumer's "tag every volume" convention appeared to work and
+// nothing could observe that it had not.
+//
+// The SDK is the right reader again: TagSpecifications and Filters are structured inputs
+// it serializes itself, and Volume.Tags is where an SDK-shaped assertion lands.
+func TestJourney_EC2VolumeTags(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	client := ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	ctx := context.Background()
+
+	created, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(20),
+		VolumeType:       ec2types.VolumeTypeGp3,
+		Iops:             aws.Int32(3000),
+		Throughput:       aws.Int32(125),
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeVolume,
+			Tags: []ec2types.Tag{
+				{Key: aws.String("Name"), Value: aws.String("data")},
+				{Key: aws.String("Env"), Value: aws.String("prod")},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+	standaloneID := aws.ToString(created.VolumeId)
+	if got := journeyTagMap(created.Tags); got["Name"] != "data" || got["Env"] != "prod" {
+		t.Fatalf("CreateVolume returned tags %v, want Name=data and Env=prod", got)
+	}
+	// Iops and Throughput were stored and never rendered, so a provisioned volume read
+	// back as an unprovisioned one.
+	if got := aws.ToInt32(created.Iops); got != 3000 {
+		t.Errorf("CreateVolume returned Iops = %d, want 3000", got)
+	}
+	if got := aws.ToInt32(created.Throughput); got != 125 {
+		t.Errorf("CreateVolume returned Throughput = %d, want 125", got)
+	}
+
+	// A launch tags its own volumes through the same structure, scoped to volume — and
+	// the instance scope must stay separate, which is what the second specification
+	// here proves.
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-0abcdef1234567890"),
+		InstanceType: ec2types.InstanceTypeT3Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/sdf"),
+			Ebs:        &ec2types.EbsBlockDevice{VolumeSize: aws.Int32(40)},
+		}},
+		TagSpecifications: []ec2types.TagSpecification{
+			{
+				ResourceType: ec2types.ResourceTypeVolume,
+				Tags:         []ec2types.Tag{{Key: aws.String("Env"), Value: aws.String("prod")}},
+			},
+			{
+				ResourceType: ec2types.ResourceTypeInstance,
+				Tags:         []ec2types.Tag{{Key: aws.String("Role"), Value: aws.String("web")}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instanceID := aws.ToString(run.Instances[0].InstanceId)
+	if got := journeyTagMap(run.Instances[0].Tags); got["Role"] != "web" || got["Env"] != "" {
+		t.Fatalf("the instance carries tags %v, want Role=web alone", got)
+	}
+
+	// The launch produced two volumes — the declared /dev/sdf and the synthesized root —
+	// and the volume-scoped tags apply to both, which is what makes the filter below
+	// return three volumes rather than one.
+	byEnv, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("tag:Env"), Values: []string{"prod"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVolumes by tag: %v", err)
+	}
+	if len(byEnv.Volumes) != 3 {
+		t.Fatalf("tag:Env=prod matched %d volumes, want 3 — the standalone one and both of the launch's",
+			len(byEnv.Volumes))
+	}
+	for _, vol := range byEnv.Volumes {
+		if got := journeyTagMap(vol.Tags); got["Env"] != "prod" {
+			t.Errorf("volume %s reports tags %v, want Env=prod",
+				aws.ToString(vol.VolumeId), got)
+		}
+	}
+
+	// A tag filter AND-combines with the attachment-scoped filter this operation already
+	// had, which is what makes it usable for "the volumes of this instance that carry
+	// this tag" — the question a consumer's cleanup step asks.
+	byEnvAndInstance, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("tag:Env"), Values: []string{"prod"}},
+			{Name: aws.String("attachment.instance-id"), Values: []string{instanceID}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVolumes by tag and instance: %v", err)
+	}
+	if len(byEnvAndInstance.Volumes) != 2 {
+		t.Fatalf("tag:Env=prod on instance %s matched %d volumes, want 2",
+			instanceID, len(byEnvAndInstance.Volumes))
+	}
+
+	// CreateTags and DeleteTags on a vol- ID, the pair that silently no-opped.
+	if _, err := client.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{standaloneID},
+		Tags:      []ec2types.Tag{{Key: aws.String("Owner"), Value: aws.String("platform")}},
+	}); err != nil {
+		t.Fatalf("CreateTags: %v", err)
+	}
+	byOwner, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("tag-key"), Values: []string{"Owner"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVolumes by tag-key: %v", err)
+	}
+	if len(byOwner.Volumes) != 1 || aws.ToString(byOwner.Volumes[0].VolumeId) != standaloneID {
+		t.Fatalf("tag-key=Owner matched %d volumes, want only %s", len(byOwner.Volumes), standaloneID)
+	}
+
+	if _, err := client.DeleteTags(ctx, &ec2.DeleteTagsInput{
+		Resources: []string{standaloneID},
+		Tags:      []ec2types.Tag{{Key: aws.String("Owner")}},
+	}); err != nil {
+		t.Fatalf("DeleteTags: %v", err)
+	}
+	afterDelete, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		VolumeIds: []string{standaloneID},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVolumes after DeleteTags: %v", err)
+	}
+	if got := journeyTagMap(afterDelete.Volumes[0].Tags); got["Owner"] != "" {
+		t.Fatalf("the volume still carries Owner=%q after DeleteTags", got["Owner"])
+	}
+	if got := journeyTagMap(afterDelete.Volumes[0].Tags); got["Name"] != "data" {
+		t.Fatal("DeleteTags removed a tag it was not asked to remove")
+	}
+
+	// A reserved key is refused on the volume scope on the same terms as the instance
+	// scope, and the refusal is whole: no instance, no volume.
+	_, err = client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-0abcdef1234567890"),
+		InstanceType: ec2types.InstanceTypeT3Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeVolume,
+			Tags:         []ec2types.Tag{{Key: aws.String("aws:reserved"), Value: aws.String("x")}},
+		}},
+	})
+	var apiErr2 smithy.APIError
+	if !errors.As(err, &apiErr2) || apiErr2.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("a reserved volume tag key gave %v, want InvalidParameterValue", err)
+	}
+	instances, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+	var count int
+	for _, res := range instances.Reservations {
+		count += len(res.Instances)
+	}
+	if count != 1 {
+		t.Fatalf("after the refusal there are %d instances, want 1 — only the successful launch's", count)
+	}
+}
+
+// journeyTagMap turns an SDK tag list into a map, so an assertion names the tag it cares
+// about rather than an index.
+func journeyTagMap(tags []ec2types.Tag) map[string]string {
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[aws.ToString(t.Key)] = aws.ToString(t.Value)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #670.

A volume was the one taggable EC2 resource with **no working tagging path at all**, and
every call on it answered success:

- `CreateVolume` accepted `TagSpecification.N` and stored nothing.
- `CreateTags` on a `vol-` ID answered `<return>true</return>` and wrote nothing —
  the issue's "may already work" premise, traced end to end and false.
- `DescribeVolumes` rendered no `tagSet` and supported no tag filter.
- `EC2Volume.Tags` existed, with nothing ever writing to it.

So an IaC consumer's tag-everything convention appeared to hold and nothing could
observe that it had not — the same store-and-hide shape #471 closed for a launch
template's tags.

## What changed

Four paths, all now real:

| Path | Behaviour |
|---|---|
| `CreateVolume` | applies its `volume`-scoped `TagSpecification.N`, echoes a `tagSet` |
| `RunInstances` | applies its `volume`-scoped tags to **every** volume the launch makes, synthesized root included |
| A launch template | volume-scoped tags reach the launch on their own merge gate, independent of the instance scope |
| `CreateTags`/`DeleteTags` | accept a `vol-` ID like any other taggable ID |

Both tag rules apply on all four — reserved `aws:` prefix and the 50-tag limit, since
AWS documents no volume-specific constraint. On a launch the check runs **before the
launch loop**: a volume is written after its own instance, so a refusal inside the loop
would leave instance 1 of a `MaxCount=2` launch behind.

`DescribeVolumes` gains `tag:<key>` and `tag-key` — exactly the two tag filters AWS
documents for the operation, out of 20; there is **no** `tag-value`. Its hand-rolled
`Filter.N` loop, whose nine `map[string]bool` sets could not express a filter whose key
is part of its name, is replaced by the shared `extractEC2Filters` walk plus a match
function, per the issue's "rather than a second hand-rolled implementation".

`CreateVolume` also stopped discarding `Iops` and `Throughput`, which `EC2Volume` stored
and `DescribeVolumes` rendered — so a provisioned volume created that way read back as an
unprovisioned one, while the same values through a launch mapping did not.

## The one risky piece, and the mitigation

The template's volume scope is a **new** `VolumeTagSpecifications` field, not a widened
`TagSpecifications`. Adding a `ResourceType` discriminator to the existing persisted
field would unmarshal every template already in an event log *without error* — into an
element with an empty resource type and no tags — so every stored template would
silently start launching untagged instances. That is deterministic replay broken by a
change that compiles. `EC2LaunchTemplateData.NetworkInterfaces` already uses this split
for the same reason.

## Fail-before proof

`go test ./emulator/ -run 'TestEC2_(CreateVolume|CreateTags_OnVolume|DescribeVolumes|RunInstances_Volume|LaunchTemplate_Volume)'`, on `main` at e111039 with the new test file added and no other change:

```
--- FAIL: TestEC2_CreateVolume_TagOnCreate
--- FAIL: TestEC2_CreateVolume_ScopeIsHonored
--- FAIL: TestEC2_CreateVolume_EmptyTagSetIsPresent
--- FAIL: TestEC2_CreateVolume_IopsAndThroughput
--- FAIL: TestEC2_CreateVolume_TagRulesRefused (all 3 subtests)
--- FAIL: TestEC2_CreateVolume_TagLimitAllowsExactly50
--- FAIL: TestEC2_CreateTags_OnVolume
--- FAIL: TestEC2_CreateTags_OnVolumeChecksTheLimit
--- FAIL: TestEC2_DescribeVolumes_TagFilters (5 of 7 subtests)
--- FAIL: TestEC2_RunInstances_VolumeTagSpecifications
--- FAIL: TestEC2_RunInstances_VolumeTagsAreFilterable
--- FAIL: TestEC2_RunInstances_VolumeTagRulesRefused
--- FAIL: TestEC2_LaunchTemplate_VolumeTagSpecifications
--- FAIL: TestEC2_LaunchTemplate_VolumeTagsAreReplacedNotMerged
```

Illustrative: the reserved-key and over-long-key `CreateVolume` rows returned **200** and
left `vol-52fb17a02eac01a2` / `vol-55e237ecad5b242a` behind; `_IopsAndThroughput` got 0
for both; `_VolumeTagsAreFilterable` got `map[string]string{}`.
`TestEC2_DescribeVolumes_ExistingFiltersStillWork` **passed** before and after, which is
what a regression guard for the filter-loop replacement is for.

## One existing assertion inverted

`TestEC2_RunInstances_ReservedTagRejectionCreatesNothing`'s last case asserted the old
deliberate limit — a volume-scoped reserved key did **not** fail an instance launch,
because the scope was parsed nowhere and an unapplied specification was an unchecked one.
It now fails the launch, and the row asserts the refusal leaves no instance behind.

## Provenance

- The `tagSet` element carries no `omitempty` because AWS's second `CreateVolume` example
  renders `<tagSet/>` for an untagged volume, and an SDK tells present-but-empty ("no
  tags") from omitted ("unknown").
- A `tag:<key>` filter with **no value matches nothing** — substrate's answer where AWS
  documents none (`Using_Filtering` says only that a filter value cannot be null, and
  offers `tag-key` for the any-value question). This follows `DescribeInstances`;
  `describeImages`, which treats it as `tag-key`, is deliberately left alone and filed as
  a follow-up rather than changed in this PR.
- An **unrecognized filter name is still dropped**. The comment claiming that was "the
  behavior every other EC2 filter site has" is corrected: three behaviours exist in the
  package — drop (volumes, snapshots), match-nothing (`ec2InstanceMatchesFilter`), and
  refuse (`describeInstanceTypeOfferings`, which is what real EC2 does).

## Compatibility

`CreateVolume` and `DescribeVolumes` responses gain `tagSet`, `iops` and `throughput` — a
byte-exact response assertion will see them. A `RunInstances` or `CreateLaunchTemplate`
naming a reserved key or more than 50 tags in a `volume`-scoped `TagSpecification` now
fails where it previously succeeded with those tags dropped.

## Verification

```
gofmt -l . ; go build ./... ; go vet ./... ; golangci-lint run ./...   # clean, 0 issues
make test                                                             # race, all green
make coverage                                                         # emulator 82.8%
make docs-reference docs-reference-check docs-versions                 # clean
npm --prefix docs run build                                            # build complete
go vet -C test/e2e ./... && go test -C test/e2e ./...                  # ok
```

The SDK-tier journey is `TestJourney_EC2VolumeTags`: `CreateVolume` with tags and
provisioned performance, a launch tagging both scopes, `tag:Env` alone and AND-combined
with `attachment.instance-id`, a `CreateTags`/`DeleteTags` round trip on the volume, and
a reserved-key refusal that leaves no instance behind.
