### PR TITLE
fix(ec2,iam): authorize a tagging call against every resource it names (#674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously succeeded with the tags dropped; the same is true at `CreateLaunchTemplate`.
 
 ### Fixed
+- **`ec2:CreateTags` and `ec2:DeleteTags` were decided against a single `*` no matter how many
+  resources they named, so an ARN-scoped guardrail on tagging was inert** (#674). Both
+  operations name their resources in `ResourceId.N` — up to 1000 of them, of mixed types — and
+  substrate built one ARN from `InstanceId.1`, a parameter neither operation carries, so every
+  tagging call resolved to the literal string `"*"`. This is #662's defect on the tagging pair,
+  and it broke in the same two directions: `resourceMatches` passes the *statement's* `Resource`
+  to `globMatch` as the pattern, so a `Deny` naming a VPC, volume or instance never matched
+  anything and a least-privilege `Allow` naming those ARNs denied every call. A policy written
+  to keep a shared or production resource out of reach of a pipeline that re-tags everything it
+  can see read as a boundary and was not one.
+
+  Each named resource is now resolved to its own ARN and paired with its own tags, so an
+  `aws:ResourceTag` condition written about one resource cannot be satisfied by a tag on
+  another, and the permission boundary is applied to every one of them. The denial names the
+  first resource the policies do not allow, in the request's own `ResourceId.N` order.
+
+  **The ARN resource type is stated, not derived.** For five of the nine taggable types
+  substrate's state key abbreviates where AWS's ARN does not — `sg`/`security-group`,
+  `igw`/`internet-gateway`, `rtb`/`route-table`, `eip`/`elastic-ip`, `nat`/`natgateway` — so
+  string-munging the state key would have produced `arn:…:sg/sg-…`, matching no ARN a caller can
+  write. One function now returns both spellings and the tagging handler's own resolver calls it,
+  so the list of taggable resources and the list of authorizable ones cannot drift apart.
+
+  **An ID whose prefix names no resource type substrate can tag is skipped, not denied.** AWS
+  answers an unparseable tagging ID with `InvalidID` rather than `AccessDenied`, and substrate's
+  handler treats it as a no-op — and skipping is the only safe direction, since widening to `*`
+  would hand the caller the one resource a broad `Allow` matches. A call naming only such IDs is
+  decided against a single `*`, exactly as before.
+
+  **`aws:RequestTag/{key}` is now populated for a direct tagging call**, which had to land with
+  the resource resolution rather than after it. `addRequestTags` read only
+  `TagSpecification.N.Tag.M.Key`/`.Value`; `CreateTags` and `DeleteTags` send
+  `Tag.N.Key`/`Tag.N.Value`, so the key was absent for every tagging call. On its own that was
+  inert — the statement never matched the resource anyway — but resolving the ARNs without it
+  would have converted the false allow into a false *deny*: AWS's documented "tag only with
+  these keys and values" policies would finally match the resource and then fail on the missing
+  condition key. The pre-existing `TagSpecification` walk is untouched, including its #468 rule
+  of not filtering by resource type. `DeleteTags` treats a tag's value as optional, so a request
+  naming only a key records the empty string — indistinguishable from an absent key to every
+  condition operator, including `Null`.
+
+  A refusal tags nothing at all, including the resources the policy would have allowed:
+  authorization runs before the handler, which extends the all-or-nothing shape `CreateTags`'
+  reserved-key and tag-limit checks already have.
+
+  **Provenance:** neither action has a required resource type — the Service Authorization
+  Reference marks **zero of the 105** it lists for either one. Authorizing against every
+  resource named is substrate's reading of AWS's general rule for an action naming several
+  resources, supported by AWS's own scoped tagging examples, which name a resource ARN as the
+  `Resource` of an `ec2:CreateTags` statement and would be pointless if only one resource of a
+  batch were evaluated. The nine ARN formats are the reference's own. Two things AWS does and
+  substrate does not are recorded in `docs/services.md` rather than left for a reader to
+  discover: `aws:TagKeys` is populated nowhere, so the `ForAllValues:StringEquals` form several
+  of AWS's `DeleteTags` examples use cannot be satisfied; and the second `ec2:CreateTags`
+  authorization pass AWS performs when a resource-creating action carries tags, keyed on
+  `ec2:CreateAction`, is not modelled.
+
+  **Compatibility:** a multi-resource `CreateTags` or `DeleteTags` that a broad `Allow` carried
+  in v0.104.0 and earlier may now be denied — by an ARN-scoped `Deny` that was previously inert,
+  by a permission boundary, or by an `aws:ResourceTag` condition now evaluated against each
+  resource's own tags. An `aws:RequestTag` condition on a tagging call now evaluates against keys
+  that were previously absent, which can change the decision in either direction. Callers whose
+  credentials resolve to no IAM entity are unaffected, as enforcement remains opt-in.
+
 - **`RunInstances` omitted the `iamInstanceProfile` that `DescribeInstances` reported for the
   same instance** (#669). `runInstancesResponse` and `describeInstances` each declared their
   own local `ec2InstanceItem`, and the copies had drifted a second time after #444: only

--- a/docs/services.md
+++ b/docs/services.md
@@ -2666,8 +2666,8 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances, [subject to termination protection](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
-| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); accepts a `vol-` ID like [any other taggable ID](#a-volume-carries-tags) |
-| DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) and [over-long keys](#tag-key-and-value-length-limits) |
+| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); accepts a `vol-` ID like [any other taggable ID](#a-volume-carries-tags); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
+| DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) and [over-long keys](#tag-key-and-value-length-limits); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
 
 ### RunInstances requires a resolvable AMI
 
@@ -3223,7 +3223,16 @@ Two substrate choices, where the API model does not decide:
   claim rests on this; a deterministic emulator answering one request two ways would
   break the guarantee the project exists for.
 
-### A launch is authorized against every resource it names
+### Every resource a request names is authorized
+
+Three EC2 operations name more than one resource, and each is decided against all of
+them: `RunInstances`, and the tagging pair `CreateTags`/`DeleteTags`. The rule is the
+service-agnostic one Organizations'
+[`MoveAccount` note](#a-request-naming-several-resources-is-authorized-against-every-one)
+states; these are EC2's instances of it. Every other EC2 operation still resolves to
+one ARN.
+
+#### A launch is authorized against every resource it names
 
 `RunInstances` is the EC2 action the Service Authorization Reference marks with the
 most required resource types — **`image`, `instance`, `network-interface`,
@@ -3286,6 +3295,69 @@ Not covered:
 - **The [fleet](#seeding-ec2-fleet-partial-fulfillment) path**, which launches
   instances internally without going through the API's authorization pipeline, so no
   policy applies to it.
+
+#### Tagging is authorized against every resource it names
+
+`CreateTags` and `DeleteTags` accept up to 1000 resource IDs in `ResourceId.N`, of
+mixed types, and the caller's policies are evaluated against every one of them. A
+`Deny` naming any single resource refuses the whole call, and the denial names that
+resource — so a policy written to keep a shared VPC or a production volume out of
+reach of a pipeline that re-tags everything it can see is a boundary. In the other
+direction, a least-privilege `Allow` listing the ARNs a call touches permits it; a
+policy missing one refuses the call and says which ARN to add. A permission boundary
+applies to every resource named, and each ARN is matched against the tags of the
+resource *it* names.
+
+Both actions have **no required resource type at all** — the Service Authorization
+Reference marks zero of the 105 it lists for either one. Authorizing against every
+resource named is therefore substrate's reading of AWS's general rule for an action
+naming several resources, supported by AWS's own scoped tagging examples, which write
+a resource ARN as the `Resource` of an `ec2:CreateTags` statement and would be
+pointless if only one resource of a batch were evaluated. The two actions resolve
+identically; they differ only in condition-key surface, and neither difference —
+`DeleteTags` carries no `ec2:CreateAction` — is modelled.
+
+The ARN a caller writes uses the resource type the reference documents, which for five
+of the nine taggable types is *not* the abbreviation substrate's own IDs suggest:
+
+| ID prefix | ARN resource type |
+|---|---|
+| `i-` | `instance` |
+| `vol-` | `volume` |
+| `vpc-` | `vpc` |
+| `subnet-` | `subnet` |
+| `sg-` | `security-group` |
+| `igw-` | `internet-gateway` |
+| `rtb-` | `route-table` |
+| `eipalloc-` | `elastic-ip` |
+| `nat-` | `natgateway` |
+
+An ID whose prefix names none of those is **skipped, not denied**: substrate's handler
+treats such an ID as a no-op, and AWS answers an unparseable tagging ID with `InvalidID`
+("The specified ID for the resource you are trying to tag is not valid") rather than
+`AccessDenied`. Skipping is also the only safe direction — widening it to `*` would hand
+the caller the one resource a broad `Allow` matches. A call naming *only* such IDs is
+decided against a single `*`, as every other EC2 operation is.
+
+`aws:RequestTag/{key}` is populated from the tags a tagging call carries
+(`Tag.N.Key`/`Tag.N.Value`), so the "tag only with the keys and values we prescribe"
+condition AWS's tagging guardrails are written around evaluates. `DeleteTags` treats a
+tag's value as optional, and a request naming only a key records the empty string —
+indistinguishable from an absent key to every condition operator, including `Null`.
+
+The refusal is whole: authorization runs before the handler, so a call that names one
+resource the policy denies tags **none** of them — the same all-or-nothing shape the
+[reserved-key](#reserved-tag-keys) and [tag-limit](#the-50-tag-per-resource-limit)
+checks already have.
+
+Not covered:
+
+- **`aws:TagKeys`**, which substrate populates nowhere, so the
+  `ForAllValues:StringEquals` form several of AWS's `DeleteTags` examples use cannot be
+  satisfied.
+- **The second authorization pass** AWS performs on `ec2:CreateTags` when a
+  resource-creating action carries tags, keyed on `ec2:CreateAction`. Tag-on-create is
+  authorized here as the creating action alone.
 
 ### Instance attributes
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -500,7 +500,7 @@ type authzResource struct {
 //
 // Almost every AWS operation names one resource, and for those this returns
 // exactly one pair — [buildResourceARN] plus the tags [AuthController.addResourceTags]
-// reads. Two operations are exceptions:
+// reads. Three operations are exceptions:
 //
 //   - `organizations:MoveAccount` names an account, a source parent and a
 //     destination parent, all three marked required by the Service Authorization
@@ -510,6 +510,9 @@ type authzResource struct {
 //     interfaces alongside the instance it creates — five required resource
 //     types, the most of any EC2 action — and was decided against a single ARN
 //     built from InstanceId.1, which a launch never carries (#662).
+//   - `ec2:CreateTags` and `ec2:DeleteTags` name up to 1000 resources of mixed
+//     types in ResourceId.N, and were decided against that same absent
+//     InstanceId.1 — so against "*" (#674).
 //
 // Each exception is gated on len(multi) > 0, which is what keeps every other
 // operation of those two services on the single-resource path below.
@@ -525,6 +528,9 @@ func (a *AuthController) buildResourceARNs(reqCtx *RequestContext, req *AWSReque
 	}
 	if req.Service == "ec2" {
 		if multi := ec2AuthzRunInstancesResources(a.state, reqCtx, req); len(multi) > 0 {
+			return multi
+		}
+		if multi := ec2AuthzTagResources(a.state, reqCtx, req); len(multi) > 0 {
 			return multi
 		}
 	}
@@ -553,9 +559,10 @@ func (a *AuthController) buildResourceARN(reqCtx *RequestContext, req *AWSReques
 		return "arn:aws:iam::" + acct + ":*"
 	case "ec2":
 		// RunInstances does not reach here: it names five resources and is resolved
-		// by [ec2AuthzRunInstancesResources] (#662). What is left is the operations
-		// that name an instance by ID — and everything else, including a CreateTags
-		// naming several ResourceId.N, which still resolves to "*".
+		// by [ec2AuthzRunInstancesResources] (#662). Nor does a CreateTags or
+		// DeleteTags naming any resource substrate can tag, resolved by
+		// [ec2AuthzTagResources] (#674). What is left is the operations that name an
+		// instance by ID — and everything else, which still resolves to "*".
 		if id := req.Params["InstanceId.1"]; id != "" {
 			return "arn:aws:ec2:" + region + ":" + acct + ":instance/" + id
 		}
@@ -872,6 +879,25 @@ func addRequestTags(condCtx map[string]string, req *AWSRequest) {
 			if !found {
 				break
 			}
+		}
+		// A direct CreateTags or DeleteTags carries no TagSpecification: its tags are
+		// Tag.N.Key / Tag.N.Value, the spelling [extractEC2Tags] reads. The walk above
+		// found none of them, so aws:RequestTag/* was empty for every tagging call, and
+		// AWS's own documented CreateTags policies — which condition on exactly that key
+		// — could not be satisfied. Resolving the resource ARNs those policies name
+		// (#674) without this would have turned their false allow into a false deny: the
+		// statement would finally match the resource and then fail on the missing key.
+		//
+		// DeleteTags treats a tag's value as optional, so a request that names only a key
+		// records an empty value here. That is not a new denial: [conditionMatches] reads
+		// an absent key as the empty string too, so the two are indistinguishable to
+		// every operator, including Null.
+		for i := 1; ; i++ {
+			k := req.Params[fmt.Sprintf("Tag.%d.Key", i)]
+			if k == "" {
+				break
+			}
+			condCtx["aws:RequestTag/"+k] = req.Params[fmt.Sprintf("Tag.%d.Value", i)]
 		}
 
 	case "lambda":

--- a/emulator/ec2_authz.go
+++ b/emulator/ec2_authz.go
@@ -90,6 +90,61 @@ func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, r
 	return out
 }
 
+// ec2AuthzTagResources returns every resource a CreateTags or DeleteTags request
+// names, each paired with its own tags. It returns nil for every other EC2
+// operation, which is what leaves them on buildResourceARNs' single-resource path.
+//
+// CreateTags accepts up to 1000 resource IDs of mixed types, and substrate decided
+// all of them against one ARN built from InstanceId.1 — a parameter neither
+// operation carries — so every tagging call was decided against the literal string
+// "*" (#674). A Deny scoped to one instance, subnet or security group was
+// therefore inert, and a least-privilege Allow naming those ARNs could not grant a
+// tagging call at all: resourceMatches passes the statement's Resource to
+// globMatch as the pattern, so "*" as the request resource matches only a
+// statement whose Resource itself starts with "*".
+//
+// Neither action has a *required* resource type — the Service Authorization
+// Reference marks zero of the 105 it lists for either one. Authorizing against
+// every named resource instead rests on AWS's general rule for an action naming
+// several resources, which its Organizations counterpart (#660) and RunInstances
+// (#662) already follow here, and on AWS's own scoped tagging examples, which
+// write instance/* as the Resource of an ec2:CreateTags statement and would be
+// pointless if only one resource of a batch were evaluated.
+//
+// Order is the request's own ResourceId.N order, which makes the denial message —
+// which names the first resource the policy does not allow — deterministic and
+// replay-stable.
+//
+// An ID whose prefix names no resource type substrate can tag is skipped, not
+// denied and not widened to "*". Skipping follows
+// [ec2AuthzRunInstancesResources]' rule for a resource the request does not name,
+// and it is the ID's own handler that owes the answer: AWS documents an
+// unparseable tagging ID as InvalidID — "The specified ID for the resource you are
+// trying to tag is not valid" — not AccessDenied, and substrate's handler treats
+// it as a no-op. A request naming only such IDs returns nil and is decided exactly
+// as it was before.
+func ec2AuthzTagResources(state StateManager, reqCtx *RequestContext, req *AWSRequest) []authzResource {
+	if req.Operation != "CreateTags" && req.Operation != "DeleteTags" {
+		return nil
+	}
+	acct := reqCtx.AccountID
+	region := reqCtx.Region
+	var out []authzResource
+	for _, id := range extractIndexedParams(req.Params, "ResourceId") {
+		stateKey, arnType, ok := ec2TaggableResource(reqCtx, id)
+		if !ok {
+			continue
+		}
+		out = append(out, authzResource{
+			ARN: "arn:aws:ec2:" + region + ":" + acct + ":" + arnType + "/" + id,
+			// The same state key the handler will read and write, so the tags a
+			// condition is evaluated against are the ones the call is about to change.
+			Tags: ec2AuthzTagsFor(state, stateKey),
+		})
+	}
+	return out
+}
+
 // ec2AuthzLaunchMembers is the set of resources one RunInstances request names.
 //
 // Network interfaces hold only the IDs of interfaces the request brings, not the

--- a/emulator/ec2_authz_test.go
+++ b/emulator/ec2_authz_test.go
@@ -691,10 +691,11 @@ func TestEC2_Authz_ImageARNCarriesNoAccountID(t *testing.T) {
 	assert.Equal(t, ec2AuthzImageARN, deniedResource(t, err))
 }
 
-// TestEC2_Authz_SingleResourceOperationsAreUnchanged pins that only RunInstances
-// takes the multi-resource path. Every other EC2 operation keeps the decision it
-// had before #662 — this change is about resolving a launch's resources, not
-// about tightening EC2 as a whole.
+// TestEC2_Authz_SingleResourceOperationsAreUnchanged pins which operations take the
+// multi-resource path: RunInstances (#662) and the two tagging operations (#674),
+// and nothing else. Every other EC2 operation keeps the decision it had before —
+// these changes are about resolving the resources a request names, not about
+// tightening EC2 as a whole.
 func TestEC2_Authz_SingleResourceOperationsAreUnchanged(t *testing.T) {
 	instanceARN := "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":instance/i-0abc"
 	tests := []struct {
@@ -716,11 +717,13 @@ func TestEC2_Authz_SingleResourceOperationsAreUnchanged(t *testing.T) {
 			instanceARN,
 		},
 		{
-			// CreateTags naming several resources still resolves to one ARN; that is
-			// the follow-up #662 scopes out, and this row records today's answer.
-			"CreateTags resolves to \"*\"",
+			// CreateTags with no ResourceId at all names nothing, so it stays on the
+			// single-resource path. The multi-resource form it used to take here — two
+			// ResourceId.N resolving to the one ARN "*" — was the follow-up #662 scoped
+			// out, and #674 closed it; see TestEC2_TagAuthz_ScopedDenyOnAnyNamedResourceBlocks.
+			"a CreateTags naming no resource resolves to \"*\"",
 			"CreateTags",
-			map[string]string{"ResourceId.1": ec2AuthzSubnet, "ResourceId.2": ec2AuthzSG},
+			map[string]string{"Tag.1.Key": "Env", "Tag.1.Value": "test"},
 			"*",
 		},
 		{

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -2472,6 +2472,57 @@ func (p *EC2Plugin) modifyInstanceAttribute(reqCtx *RequestContext, req *AWSRequ
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
 }
 
+// ec2TaggableResource resolves a taggable EC2 resource ID to the state key its record
+// lives under and the resource type its ARN names, reporting whether the ID's prefix
+// names a resource type substrate can tag at all.
+//
+// One switch answers both because for five of the nine prefixes the two spellings
+// differ: substrate's state keys abbreviate where the Service Authorization Reference's
+// ARN formats do not — sg/security-group, igw/internet-gateway, rtb/route-table,
+// eip/elastic-ip, nat/natgateway. Deriving one from the other by string-munging would
+// produce arn:aws:ec2:…:sg/sg-…, which matches no ARN a caller can write, so the
+// authorization decision (#674) needs the ARN type stated rather than inferred. Keeping
+// the pair in one place is what stops the tagging handler's list of taggable resources
+// and the authorizer's from drifting apart.
+//
+// The ARN type is a bare resource type, not a whole ARN: the caller supplies the
+// partition, region and account, and all nine of these ARN formats are
+// region-and-account qualified — none has the image ARN's deliberately empty account
+// field.
+func ec2TaggableResource(reqCtx *RequestContext, id string) (stateKey, arnType string, ok bool) {
+	scope := reqCtx.AccountID + "/" + reqCtx.Region
+	switch {
+	case strings.HasPrefix(id, "i-"):
+		return "instance:" + scope + "/" + id, "instance", true
+	case strings.HasPrefix(id, "vpc-"):
+		return "vpc:" + scope + "/" + id, "vpc", true
+	case strings.HasPrefix(id, "subnet-"):
+		return "subnet:" + scope + "/" + id, "subnet", true
+	case strings.HasPrefix(id, "sg-"):
+		return "sg:" + scope + "/" + id, "security-group", true
+	case strings.HasPrefix(id, "igw-"):
+		return "igw:" + scope + "/" + id, "internet-gateway", true
+	case strings.HasPrefix(id, "rtb-"):
+		return "rtb:" + scope + "/" + id, "route-table", true
+	case strings.HasPrefix(id, "eipalloc-"):
+		// elastic-ip, and the ARN carries the allocation ID — which is the ID CreateTags
+		// takes for an address, so no translation is needed here either.
+		return "eip:" + scope + "/" + id, "elastic-ip", true
+	case strings.HasPrefix(id, "nat-"):
+		// natgateway, unhyphenated, alone among the nine.
+		return "nat:" + scope + "/" + id, "natgateway", true
+	case strings.HasPrefix(id, "vol-"):
+		// Volumes were the one taggable resource with no arm here, so CreateTags on a
+		// vol- ID fell through to the default and answered <return>true</return> having
+		// written nothing (#670). Nothing else needed changing:
+		// [EC2Plugin.applyTagsToResource] is type-agnostic — it reads and writes the
+		// record's "tags" JSON member — and [EC2Volume.Tags] already serializes there.
+		return ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, id), "volume", true
+	default:
+		return "", "", false
+	}
+}
+
 // ec2TaggableStateKey returns the state key for a taggable resource ID, and whether
 // the ID's prefix names a resource type substrate can tag at all.
 //
@@ -2480,34 +2531,8 @@ func (p *EC2Plugin) modifyInstanceAttribute(reqCtx *RequestContext, req *AWSRequ
 // disagreed about which IDs resolve, CreateTags would either check a resource it does
 // not tag or tag one it did not check.
 func ec2TaggableStateKey(reqCtx *RequestContext, id string) (string, bool) {
-	scope := reqCtx.AccountID + "/" + reqCtx.Region
-	switch {
-	case strings.HasPrefix(id, "i-"):
-		return "instance:" + scope + "/" + id, true
-	case strings.HasPrefix(id, "vpc-"):
-		return "vpc:" + scope + "/" + id, true
-	case strings.HasPrefix(id, "subnet-"):
-		return "subnet:" + scope + "/" + id, true
-	case strings.HasPrefix(id, "sg-"):
-		return "sg:" + scope + "/" + id, true
-	case strings.HasPrefix(id, "igw-"):
-		return "igw:" + scope + "/" + id, true
-	case strings.HasPrefix(id, "rtb-"):
-		return "rtb:" + scope + "/" + id, true
-	case strings.HasPrefix(id, "eipalloc-"):
-		return "eip:" + scope + "/" + id, true
-	case strings.HasPrefix(id, "nat-"):
-		return "nat:" + scope + "/" + id, true
-	case strings.HasPrefix(id, "vol-"):
-		// Volumes were the one taggable resource with no arm here, so CreateTags on a
-		// vol- ID fell through to the default and answered <return>true</return> having
-		// written nothing (#670). Nothing else needed changing:
-		// [EC2Plugin.applyTagsToResource] is type-agnostic — it reads and writes the
-		// record's "tags" JSON member — and [EC2Volume.Tags] already serializes there.
-		return ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, id), true
-	default:
-		return "", false
-	}
+	stateKey, _, ok := ec2TaggableResource(reqCtx, id)
+	return stateKey, ok
 }
 
 // resourceTags returns the tags currently on the resource named by id, and whether the

--- a/emulator/ec2_tag_authz_test.go
+++ b/emulator/ec2_tag_authz_test.go
@@ -1,0 +1,474 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The authorization decision for ec2:CreateTags and ec2:DeleteTags (#674).
+//
+// Both operations name their resources in ResourceId.N — up to 1000 of them, of
+// mixed types — and substrate decided every one of them against a single ARN built
+// from InstanceId.1, which neither operation carries. So every tagging call was
+// decided against the literal string "*", with the same two-directional failure
+// #662 documented for RunInstances: an ARN-scoped Deny never matched and a
+// least-privilege Allow naming the ARNs denied every call.
+//
+// These tests use the #662 fixture, and they lean on one property of it: an
+// action-only Deny refuses whatever the decision resolves, and the denial message
+// names the first resource the policy does not allow — so the message is how a test
+// reads back which ARNs were built and in what order.
+
+const (
+	ec2TagAuthzInstance = "i-0aaa1111bbbb2222c"
+	ec2TagAuthzVolume   = "vol-0ddd3333eeee4444f"
+	ec2TagAuthzVPC      = "vpc-0eee5555ffff6666a"
+	ec2TagAuthzIGW      = "igw-0fff7777aaaa8888b"
+	ec2TagAuthzRTB      = "rtb-0aaa9999bbbb0000c"
+	ec2TagAuthzEIP      = "eipalloc-0bbb1111cccc2222d"
+	ec2TagAuthzNAT      = "nat-0ccc3333dddd4444e"
+)
+
+// ec2TagARN builds the ARN a tagging call is authorized against.
+//
+// Written out here rather than derived from the state key on purpose: for five of
+// the nine taggable prefixes substrate's state key abbreviates the resource type
+// the Service Authorization Reference's ARN uses, and a test that derived one from
+// the other would agree with a wrong answer.
+func ec2TagARN(arnType, id string) string {
+	return "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":" + arnType + "/" + id
+}
+
+// ec2TagAuthzResource is one taggable resource: the ID a caller passes as
+// ResourceId.N, the ARN the decision must build for it, and the record that has to
+// exist for its tags to be readable.
+type ec2TagAuthzResource struct {
+	id  string
+	arn string
+	put func(*ec2AuthzFixture, *testing.T, map[string]string)
+}
+
+// ec2TagAuthzAllTypes is every resource type substrate can tag, in the order these
+// tests name them in ResourceId.N — which is the order the decision evaluates.
+//
+// All nine, not a sample: the ARN resource type is a hand-written string per type,
+// so a wrong one is only caught by a case that names that type.
+func ec2TagAuthzAllTypes() []ec2TagAuthzResource {
+	return []ec2TagAuthzResource{
+		{ec2TagAuthzInstance, ec2TagARN("instance", ec2TagAuthzInstance), (*ec2AuthzFixture).putTagInstance},
+		{ec2AuthzSubnet, ec2TagARN("subnet", ec2AuthzSubnet), func(f *ec2AuthzFixture, t *testing.T, tags map[string]string) {
+			f.putSubnet(t, ec2AuthzSubnet, tags)
+		}},
+		{ec2AuthzSG, ec2TagARN("security-group", ec2AuthzSG), func(f *ec2AuthzFixture, t *testing.T, tags map[string]string) {
+			f.putSecurityGroup(t, ec2AuthzSG, tags)
+		}},
+		{ec2TagAuthzVolume, ec2TagARN("volume", ec2TagAuthzVolume), (*ec2AuthzFixture).putTagVolume},
+		{ec2TagAuthzVPC, ec2TagARN("vpc", ec2TagAuthzVPC), (*ec2AuthzFixture).putTagVPC},
+		{ec2TagAuthzIGW, ec2TagARN("internet-gateway", ec2TagAuthzIGW), (*ec2AuthzFixture).putTagInternetGateway},
+		{ec2TagAuthzRTB, ec2TagARN("route-table", ec2TagAuthzRTB), (*ec2AuthzFixture).putTagRouteTable},
+		{ec2TagAuthzEIP, ec2TagARN("elastic-ip", ec2TagAuthzEIP), (*ec2AuthzFixture).putTagElasticIP},
+		{ec2TagAuthzNAT, ec2TagARN("natgateway", ec2TagAuthzNAT), (*ec2AuthzFixture).putTagNATGateway},
+	}
+}
+
+// The records for the types the #662 fixture had no reason to write. Each uses the
+// real state key and the real struct, so a test proves the tags the decision reads
+// are the ones the resource actually stores under its "tags" member.
+func (f *ec2AuthzFixture) putTagInstance(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "instance:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzInstance,
+		emulator.EC2Instance{InstanceID: ec2TagAuthzInstance, Tags: ec2AuthzTags(tags)})
+}
+
+func (f *ec2AuthzFixture) putTagVolume(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "volume:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzVolume,
+		emulator.EC2Volume{VolumeID: ec2TagAuthzVolume, Tags: ec2AuthzTags(tags)})
+}
+
+func (f *ec2AuthzFixture) putTagVPC(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "vpc:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzVPC,
+		emulator.EC2VPC{VPCID: ec2TagAuthzVPC, Tags: ec2AuthzTags(tags)})
+}
+
+func (f *ec2AuthzFixture) putTagInternetGateway(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "igw:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzIGW,
+		emulator.EC2InternetGateway{InternetGatewayID: ec2TagAuthzIGW, Tags: ec2AuthzTags(tags)})
+}
+
+func (f *ec2AuthzFixture) putTagRouteTable(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "rtb:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzRTB,
+		emulator.EC2RouteTable{RouteTableID: ec2TagAuthzRTB, Tags: ec2AuthzTags(tags)})
+}
+
+func (f *ec2AuthzFixture) putTagElasticIP(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "eip:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzEIP,
+		emulator.EC2ElasticIP{AllocationID: ec2TagAuthzEIP, Tags: ec2AuthzTags(tags)})
+}
+
+func (f *ec2AuthzFixture) putTagNATGateway(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "nat:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzNAT,
+		emulator.EC2NATGateway{NatGatewayID: ec2TagAuthzNAT, Tags: ec2AuthzTags(tags)})
+}
+
+// ec2TagAuthzFixture is the #662 fixture with every taggable resource present and
+// untagged, which is the state a tagging call is decided against.
+func ec2TagAuthzFixture(t *testing.T, user string) *ec2AuthzFixture {
+	t.Helper()
+	f := newEC2AuthzFixture(t, user, emulator.PolicyDocument{})
+	for _, res := range ec2TagAuthzAllTypes() {
+		res.put(f, t, nil)
+	}
+	return f
+}
+
+// ec2TagAuthzParams names every taggable resource in one request, tagging them all
+// with one key — the shape a consumer's "tag everything this stack created" step
+// takes.
+func ec2TagAuthzParams() map[string]string {
+	params := map[string]string{"Tag.1.Key": "Env", "Tag.1.Value": "test"}
+	for i, res := range ec2TagAuthzAllTypes() {
+		params["ResourceId."+strconv.Itoa(i+1)] = res.id
+	}
+	return params
+}
+
+// ec2TagAuthzStatement builds one statement over a tagging action.
+func ec2TagAuthzStatement(effect, action string, resources ...string) emulator.PolicyStatement {
+	return emulator.PolicyStatement{
+		Effect:   effect,
+		Action:   emulator.StringOrSlice{action},
+		Resource: emulator.StringOrSlice(resources),
+	}
+}
+
+// TestEC2_TagAuthz_ScopedDenyOnAnyNamedResourceBlocks is the decisive test: the
+// false allow #674 reports, once per resource type.
+//
+// A policy allowing ec2:CreateTags broadly while denying it on one resource is the
+// guardrail shape — "tag anything except the shared VPC". It had no effect at all,
+// because the call resolved to the resource "*" and resourceMatches asks globMatch
+// whether the *statement's* ARN matches that "*", which it does not.
+//
+// Each subtest denies exactly one of the nine resources the request names, so it
+// fails unless the decision both reaches that resource and spells its ARN the way
+// the Service Authorization Reference does. Five of the nine are the interesting
+// ones — sg, igw, rtb, eip and nat abbreviate in the state key and do not in the
+// ARN — and a Deny on security-group/sg-… matching nothing is exactly what a
+// string-munged ARN would produce.
+func TestEC2_TagAuthz_ScopedDenyOnAnyNamedResourceBlocks(t *testing.T) {
+	for _, res := range ec2TagAuthzAllTypes() {
+		t.Run(res.arn, func(t *testing.T) {
+			f := ec2TagAuthzFixture(t, "iris")
+			f.setPolicy(t,
+				ec2TagAuthzStatement("Allow", "ec2:CreateTags", "*"),
+				ec2TagAuthzStatement("Deny", "ec2:CreateTags", res.arn),
+			)
+			err := f.call(t, "CreateTags", ec2TagAuthzParams())
+			if !ec2AuthzDenied(t, err) {
+				t.Fatalf("a Deny naming %s did not block a CreateTags that names it", res.arn)
+			}
+			assert.Equal(t, res.arn, deniedResource(t, err),
+				"the denial names the resource the Deny scoped to")
+		})
+	}
+}
+
+// TestEC2_TagAuthz_LeastPrivilegePolicyAllows is the other direction the single-ARN
+// resolution broke, and the one a consumer hits while writing a policy rather than
+// while testing one: a policy naming exactly the ARNs the call touches refused it.
+func TestEC2_TagAuthz_LeastPrivilegePolicyAllows(t *testing.T) {
+	all := ec2TagAuthzAllTypes()
+	arns := make([]string, 0, len(all))
+	for _, res := range all {
+		arns = append(arns, res.arn)
+	}
+
+	t.Run("naming every resource allows", func(t *testing.T) {
+		f := ec2TagAuthzFixture(t, "jonas")
+		f.setPolicy(t, ec2TagAuthzStatement("Allow", "ec2:CreateTags", arns...))
+		require.NoError(t, f.call(t, "CreateTags", ec2TagAuthzParams()))
+	})
+
+	// Dropping one ARN refuses the call and says which one, which is what makes a
+	// least-privilege tagging policy writable by iteration.
+	for i, omitted := range all {
+		t.Run("omitting "+omitted.arn+" denies", func(t *testing.T) {
+			f := ec2TagAuthzFixture(t, "jonas")
+			kept := make([]string, 0, len(arns)-1)
+			for j, arn := range arns {
+				if j != i {
+					kept = append(kept, arn)
+				}
+			}
+			f.setPolicy(t, ec2TagAuthzStatement("Allow", "ec2:CreateTags", kept...))
+			err := f.call(t, "CreateTags", ec2TagAuthzParams())
+			if !ec2AuthzDenied(t, err) {
+				t.Fatalf("a policy omitting %s allowed a CreateTags that names it", omitted.arn)
+			}
+			assert.Equal(t, omitted.arn, deniedResource(t, err))
+		})
+	}
+}
+
+// TestEC2_TagAuthz_DeleteTagsResolvesTheSameWay pins the second operation.
+//
+// DeleteTags names its resources identically and has the same (empty) set of
+// required resource types, so it resolves identically. The two differ only in
+// condition-key surface — DeleteTags carries no ec2:CreateAction — which substrate
+// does not model either way.
+func TestEC2_TagAuthz_DeleteTagsResolvesTheSameWay(t *testing.T) {
+	f := ec2TagAuthzFixture(t, "kira")
+	sgARN := ec2TagARN("security-group", ec2AuthzSG)
+	f.setPolicy(t,
+		ec2TagAuthzStatement("Allow", "ec2:DeleteTags", "*"),
+		ec2TagAuthzStatement("Deny", "ec2:DeleteTags", sgARN),
+	)
+	// DeleteTags names keys and treats the value as optional, so this request carries
+	// Tag.1.Key alone — the form that has to resolve too.
+	params := ec2TagAuthzParams()
+	delete(params, "Tag.1.Value")
+	err := f.call(t, "DeleteTags", params)
+	if !ec2AuthzDenied(t, err) {
+		t.Fatalf("a Deny naming %s did not block a DeleteTags that names it", sgARN)
+	}
+	assert.Equal(t, sgARN, deniedResource(t, err))
+}
+
+// TestEC2_TagAuthz_UnrecognizedIDIsSkipped pins that an ID whose prefix names no
+// taggable resource type is left out of the list rather than denied or widened.
+//
+// Denying would answer with a code AWS does not use for the condition: an
+// unparseable tagging ID earns InvalidID — "The specified ID for the resource you
+// are trying to tag is not valid" — and substrate's handler treats it as a no-op.
+// Widening to "*" would hand a caller the resource that matches a broad Allow,
+// which is the direction a privilege boundary must never fail in.
+func TestEC2_TagAuthz_UnrecognizedIDIsSkipped(t *testing.T) {
+	t.Run("a request naming only unknown IDs falls back unchanged", func(t *testing.T) {
+		f := ec2TagAuthzFixture(t, "liam")
+		params := map[string]string{
+			"ResourceId.1": "tgw-0abc1111", // a transit gateway: real AWS tags it, substrate does not model it
+			"ResourceId.2": "not-an-id",
+			"Tag.1.Key":    "Env",
+			"Tag.1.Value":  "test",
+		}
+		// Nothing resolved, so the single-resource path decides it exactly as before:
+		// the ec2 arm of buildResourceARN with no InstanceId.1, which is "*".
+		f.setPolicy(t, emulator.PolicyStatement{
+			Effect:   "Deny",
+			Action:   emulator.StringOrSlice{"ec2:CreateTags"},
+			Resource: emulator.StringOrSlice{"*"},
+		})
+		err := f.call(t, "CreateTags", params)
+		require.Error(t, err)
+		assert.Equal(t, "*", deniedResource(t, err))
+	})
+
+	t.Run("a known ID beside an unknown one still resolves", func(t *testing.T) {
+		f := ec2TagAuthzFixture(t, "liam")
+		vpcARN := ec2TagARN("vpc", ec2TagAuthzVPC)
+		// The policy names the VPC and nothing else. If the unknown ID widened the list
+		// to "*" this would be denied; if it were skipped from the *request* rather than
+		// from the list, there would be nothing left to allow.
+		f.setPolicy(t, ec2TagAuthzStatement("Allow", "ec2:CreateTags", vpcARN))
+		require.NoError(t, f.call(t, "CreateTags", map[string]string{
+			"ResourceId.1": "tgw-0abc1111",
+			"ResourceId.2": ec2TagAuthzVPC,
+			"Tag.1.Key":    "Env",
+			"Tag.1.Value":  "test",
+		}))
+	})
+}
+
+// TestEC2_TagAuthz_ResourceTagsPairWithTheirOwnResource is why each resolved
+// resource carries its own tags rather than one merged map: a condition is written
+// about the resource being evaluated, so a tag on the VPC must not satisfy a
+// condition checked against the security group.
+//
+// This is the tag-based access control AWS's own tagging examples are written
+// around, and it is only reachable now that the ARNs resolve — before this, the
+// resource was "*" and its tags were the instance's, read from an InstanceId.1
+// neither operation sends.
+func TestEC2_TagAuthz_ResourceTagsPairWithTheirOwnResource(t *testing.T) {
+	const good = "test"
+	const bad = "prod"
+	abac := func(f *ec2AuthzFixture, t *testing.T) {
+		t.Helper()
+		f.setPolicy(t, emulator.PolicyStatement{
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"ec2:CreateTags"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				"StringEquals": {"aws:ResourceTag/Env": {good}},
+			},
+		})
+	}
+
+	t.Run("every resource tagged is allowed", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "mira", emulator.PolicyDocument{})
+		for _, res := range ec2TagAuthzAllTypes() {
+			res.put(f, t, map[string]string{"Env": good})
+		}
+		abac(f, t)
+		require.NoError(t, f.call(t, "CreateTags", ec2TagAuthzParams()))
+	})
+
+	for _, mistagged := range ec2TagAuthzAllTypes() {
+		t.Run("mistagging "+mistagged.arn+" denies", func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "mira", emulator.PolicyDocument{})
+			for _, res := range ec2TagAuthzAllTypes() {
+				value := good
+				if res.id == mistagged.id {
+					value = bad
+				}
+				res.put(f, t, map[string]string{"Env": value})
+			}
+			abac(f, t)
+			err := f.call(t, "CreateTags", ec2TagAuthzParams())
+			if !ec2AuthzDenied(t, err) {
+				t.Fatalf("%s tagged Env=%s satisfied a condition requiring Env=%s",
+					mistagged.arn, bad, good)
+			}
+			assert.Equal(t, mistagged.arn, deniedResource(t, err))
+		})
+	}
+}
+
+// TestEC2_TagAuthz_RequestTagConditionEvaluates covers the half of #674 that had to
+// land with the resource resolution rather than after it.
+//
+// addRequestTags read only TagSpecification.N.Tag.M.Key/Value, and a direct
+// CreateTags sends Tag.N.Key/Tag.N.Value — so aws:RequestTag/* was empty for every
+// tagging call. On its own that was inert, because the statement never matched the
+// resource anyway. Resolving the ARNs without this would have converted the false
+// allow into a false deny: AWS's documented "may only tag with these keys" policies
+// would finally match the resource and then fail on the absent condition key.
+func TestEC2_TagAuthz_RequestTagConditionEvaluates(t *testing.T) {
+	scoped := func(f *ec2AuthzFixture, t *testing.T) {
+		t.Helper()
+		f.setPolicy(t, emulator.PolicyStatement{
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"ec2:CreateTags"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				"StringEquals": {"aws:RequestTag/Env": {"test"}},
+			},
+		})
+	}
+
+	t.Run("the tag the request carries satisfies the condition", func(t *testing.T) {
+		f := ec2TagAuthzFixture(t, "nadia")
+		scoped(f, t)
+		require.NoError(t, f.call(t, "CreateTags", map[string]string{
+			"ResourceId.1": ec2TagAuthzVPC,
+			"Tag.1.Key":    "Env",
+			"Tag.1.Value":  "test",
+		}))
+	})
+
+	t.Run("a different value denies", func(t *testing.T) {
+		f := ec2TagAuthzFixture(t, "nadia")
+		scoped(f, t)
+		err := f.call(t, "CreateTags", map[string]string{
+			"ResourceId.1": ec2TagAuthzVPC,
+			"Tag.1.Key":    "Env",
+			"Tag.1.Value":  "prod",
+		})
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a policy requiring Env=test allowed a request tagging Env=prod")
+		}
+	})
+
+	t.Run("a second tag beside it is read too", func(t *testing.T) {
+		// The walk stops at the first absent index, so a request whose conditioned key
+		// is not first has to be read past — Tag.1 here is unrelated.
+		f := ec2TagAuthzFixture(t, "nadia")
+		scoped(f, t)
+		require.NoError(t, f.call(t, "CreateTags", map[string]string{
+			"ResourceId.1": ec2TagAuthzVPC,
+			"Tag.1.Key":    "Owner",
+			"Tag.1.Value":  "platform",
+			"Tag.2.Key":    "Env",
+			"Tag.2.Value":  "test",
+		}))
+	})
+
+	t.Run("a launch's TagSpecification form still resolves", func(t *testing.T) {
+		// The pre-existing walk is untouched, so the shape RunInstances sends keeps
+		// populating the same condition key (#468).
+		f := ec2TagAuthzFixture(t, "nadia")
+		f.setPolicy(t, emulator.PolicyStatement{
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"ec2:RunInstances"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				"StringEquals": {"aws:RequestTag/Env": {"test"}},
+			},
+		})
+		params := nominalLaunch()
+		params["TagSpecification.1.ResourceType"] = "instance"
+		params["TagSpecification.1.Tag.1.Key"] = "Env"
+		params["TagSpecification.1.Tag.1.Value"] = "test"
+		require.NoError(t, f.launch(t, params))
+	})
+}
+
+// TestEC2_TagAuthz_PermissionBoundaryCoversEveryResource is the mutation-motivated
+// test: a boundary that refuses the *first* resource refuses the request whichever
+// loop the check sits in, so the boundary here allows the first resource and
+// refuses the second.
+func TestEC2_TagAuthz_PermissionBoundaryCoversEveryResource(t *testing.T) {
+	f := ec2TagAuthzFixture(t, "opal")
+	f.setPolicy(t, ec2TagAuthzStatement("Allow", "ec2:CreateTags", "*"))
+
+	boundaryARN := "arn:aws:iam::" + ec2AuthzAccount + ":policy/TagBoundary"
+	// The instance, which the request names first, and nothing else.
+	boundary := emulator.IAMPolicy{
+		PolicyName:       "TagBoundary",
+		PolicyID:         "ANPATAGB",
+		ARN:              boundaryARN,
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document: emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{
+				ec2TagAuthzStatement("Allow", "ec2:CreateTags", ec2TagARN("instance", ec2TagAuthzInstance)),
+			},
+		},
+	}
+	raw, err := json.Marshal(boundary)
+	require.NoError(t, err)
+	require.NoError(t, f.state.Put(context.Background(), "iam", "policy:"+boundaryARN, raw))
+
+	user := emulator.IAMUser{
+		UserName:            "opal",
+		UserID:              "AIDATEST",
+		ARN:                 "arn:aws:iam::" + ec2AuthzAccount + ":user/opal",
+		Path:                "/",
+		PermissionsBoundary: &emulator.IAMAttachedPolicy{PolicyARN: boundaryARN, PolicyName: "TagBoundary"},
+	}
+	userRaw, err := json.Marshal(user)
+	require.NoError(t, err)
+	require.NoError(t, f.state.Put(context.Background(), "iam", "user:opal", userRaw))
+
+	callErr := f.call(t, "CreateTags", ec2TagAuthzParams())
+	if !ec2AuthzDenied(t, callErr) {
+		t.Fatal("a boundary allowing only the first resource did not block a call naming nine")
+	}
+	var awsErr *emulator.AWSError
+	require.ErrorAs(t, callErr, &awsErr)
+	assert.Contains(t, awsErr.Message, "permission boundary")
+}

--- a/test/e2e/journey_ec2_tag_authz_test.go
+++ b/test/e2e/journey_ec2_tag_authz_test.go
@@ -1,0 +1,253 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/smithy-go"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_EC2CreateTagsGuardrail is #674 at the tier the guardrail is written
+// at: a policy that allows tagging everywhere except one resource, which is how a
+// consumer keeps a shared or production resource out of reach of a pipeline that
+// re-tags everything it can see.
+//
+// CreateTags and DeleteTags name their resources in ResourceId.N, and substrate
+// decided them against a single ARN built from InstanceId.1 — a parameter neither
+// operation carries — so every tagging call was decided against the literal string
+// "*". Because resourceMatches passes the statement's own Resource to globMatch as
+// the pattern, an ARN-scoped Deny never matched: the guardrail read as a boundary
+// and was not one, and a least-privilege Allow naming the ARNs denied every call.
+//
+// This tier is where the two halves of the fix meet. The SDK serializes Tags as
+// Tag.1.Key/Tag.1.Value, which is the form addRequestTags did not read, so an
+// aws:RequestTag condition is only testable through a real client — and it has to
+// be tested, because resolving the ARNs without that fix would have turned this
+// policy shape from a false allow into a false deny.
+func TestJourney_EC2CreateTagsGuardrail(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	adminCfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	admin := ec2.NewFromConfig(adminCfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	iamClient := iam.NewFromConfig(adminCfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	// --- the resources, created by the unenforced built-in caller ---
+	//
+	// An instance and a volume, because those are the two taggable types whose tags
+	// are readable back through a Describe: this journey has to see that a denial
+	// wrote nothing, not just that it answered 403.
+	run, err := admin.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-0abcdef1234567890"),
+		InstanceType: ec2types.InstanceTypeT3Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instanceID := aws.ToString(run.Instances[0].InstanceId)
+
+	vol, err := admin.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(20),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+	volumeID := aws.ToString(vol.VolumeId)
+
+	// The ARNs a consumer writes into the policy, built from the documented formats —
+	// no EC2 response carries an ARN member for either type, so this is what the
+	// caller has to do, and it is why the resource-type spelling has to match. The
+	// volume's would read "vol/vol-…" if it were derived from substrate's own state
+	// key, and would then match nothing.
+	const region = "us-east-1"
+	const account = "123456789012"
+	instanceARN := "arn:aws:ec2:" + region + ":" + account + ":instance/" + instanceID
+	volumeARN := "arn:aws:ec2:" + region + ":" + account + ":volume/" + volumeID
+
+	// --- the guarded tagger ---
+	//
+	// A real IAM user: the built-in AKIA key resolves to no principal, and an
+	// unenforced caller would make every assertion below pass regardless of policy.
+	user, err := iamClient.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("tagger")})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	putPolicy := func(document string) {
+		t.Helper()
+		if _, policyErr := iamClient.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+			UserName:       user.User.UserName,
+			PolicyName:     aws.String("tag-guardrail"),
+			PolicyDocument: aws.String(document),
+		}); policyErr != nil {
+			t.Fatalf("PutUserPolicy: %v", policyErr)
+		}
+	}
+	// "Tag anything except that volume" — the whole point of the issue.
+	putPolicy(`{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"ec2:*","Resource":"*"},` +
+		`{"Effect":"Deny","Action":"ec2:CreateTags","Resource":"` + volumeARN + `"}]}`)
+
+	key, err := iamClient.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{UserName: user.User.UserName})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+	taggerCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+		config.WithBaseEndpoint(ts.URL),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			aws.ToString(key.AccessKey.AccessKeyId),
+			aws.ToString(key.AccessKey.SecretAccessKey), "")),
+		config.WithHTTPClient(&http.Client{}),
+	)
+	if err != nil {
+		t.Fatalf("tagger config: %v", err)
+	}
+	tagger := ec2.NewFromConfig(taggerCfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+
+	tag := func(client *ec2.Client, value string, resources ...string) error {
+		_, tagErr := client.CreateTags(ctx, &ec2.CreateTagsInput{
+			Resources: resources,
+			Tags:      []ec2types.Tag{{Key: aws.String("Env"), Value: aws.String(value)}},
+		})
+		return tagErr
+	}
+
+	// --- the call that names the fenced-off volume alongside a resource it may tag ---
+	//
+	// This is the request that was allowed. The instance comes first, so a decision
+	// that stopped at the first resource would also allow it.
+	err = tag(tagger, "test", instanceID, volumeID)
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("tagging a volume the policy denies: got %T (%v), want an API error", err, err)
+	}
+	if apiErr.ErrorCode() != "AccessDenied" {
+		t.Errorf("ErrorCode() = %q, want AccessDenied — EC2's XML protocol has no Exception suffix",
+			apiErr.ErrorCode())
+	}
+	if msg := err.Error(); !strings.Contains(msg, volumeARN) {
+		t.Errorf("the denial does not name the volume ARN %s: %v", volumeARN, msg)
+	}
+	// And the refusal tagged nothing at all — not even the instance the policy
+	// permits. Authorization runs before the handler, so a mixed request is refused
+	// whole, which is the same all-or-nothing shape CreateTags' own reserved-key and
+	// tag-limit checks already have.
+	if got := journeyInstanceTags(t, ctx, admin, instanceID)["Env"]; got != "" {
+		t.Errorf("a refused CreateTags tagged the instance anyway: Env=%q", got)
+	}
+
+	// --- the same call without the resource the Deny names ---
+	if err := tag(tagger, "test", instanceID); err != nil {
+		t.Fatalf("tagging a resource the guardrail permits must succeed: %v", err)
+	}
+	if got := journeyInstanceTags(t, ctx, admin, instanceID)["Env"]; got != "test" {
+		t.Errorf("the instance carries Env=%q, want test", got)
+	}
+
+	// --- a least-privilege policy naming both ARNs works ---
+	//
+	// The other direction the single-ARN resolution broke, and the one a consumer hits
+	// while writing the policy rather than while testing it.
+	leastPrivilege := `{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"ec2:CreateTags","Resource":[` +
+		`"` + instanceARN + `","` + volumeARN + `"]}]}`
+	putPolicy(leastPrivilege)
+	if err := tag(tagger, "prod", instanceID, volumeID); err != nil {
+		t.Fatalf("a policy naming both ARNs must permit the call: %v", err)
+	}
+	if got := journeyVolumeTags(t, ctx, admin, volumeID)["Env"]; got != "prod" {
+		t.Errorf("the volume carries Env=%q, want prod", got)
+	}
+
+	// Dropping one ARN refuses the call and says which one, which is what makes a
+	// least-privilege tagging policy writable by iteration rather than by guesswork.
+	putPolicy(strings.Replace(leastPrivilege, `,"`+volumeARN+`"`, "", 1))
+	err = tag(tagger, "test", instanceID, volumeID)
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("a policy omitting the volume: got %T (%v), want an API error", err, err)
+	}
+	if msg := err.Error(); !strings.Contains(msg, volumeARN) {
+		t.Errorf("the denial does not name the omitted volume ARN %s: %v", volumeARN, msg)
+	}
+
+	// --- the tag the request carries decides the call ---
+	//
+	// AWS's own tagging guardrails are written this way: tag with the keys and values
+	// we prescribe, or not at all. aws:RequestTag was empty for every direct tagging
+	// call, so this policy could not be satisfied — and once the ARNs resolved, it
+	// would have denied every call instead of allowing none.
+	putPolicy(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"ec2:CreateTags","Resource":"*",` +
+		`"Condition":{"StringEquals":{"aws:RequestTag/Env":"test"}}}]}`)
+	if err := tag(tagger, "test", instanceID); err != nil {
+		t.Fatalf("a request tagging Env=test must satisfy a policy requiring it: %v", err)
+	}
+	if err := tag(tagger, "staging", instanceID); !errors.As(err, &apiErr) {
+		t.Fatalf("a request tagging Env=staging: got %T (%v), want an API error", err, err)
+	}
+
+	// --- DeleteTags resolves the same way ---
+	//
+	// Same resources, same ARNs, and the value is optional: this request names the key
+	// alone, which is the form a consumer's cleanup step sends.
+	putPolicy(`{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"ec2:*","Resource":"*"},` +
+		`{"Effect":"Deny","Action":"ec2:DeleteTags","Resource":"` + volumeARN + `"}]}`)
+	_, err = tagger.DeleteTags(ctx, &ec2.DeleteTagsInput{
+		Resources: []string{volumeID},
+		Tags:      []ec2types.Tag{{Key: aws.String("Env")}},
+	})
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("deleting a tag the policy denies: got %T (%v), want an API error", err, err)
+	}
+	if msg := err.Error(); !strings.Contains(msg, volumeARN) {
+		t.Errorf("the denial does not name the volume ARN %s: %v", volumeARN, msg)
+	}
+	if got := journeyVolumeTags(t, ctx, admin, volumeID)["Env"]; got != "prod" {
+		t.Errorf("a refused DeleteTags removed the tag anyway: Env=%q, want prod", got)
+	}
+}
+
+// journeyInstanceTags reads one instance's tags through the unenforced admin, so the
+// verification is not itself subject to the policy under test.
+func journeyInstanceTags(t *testing.T, ctx context.Context, client *ec2.Client, id string) map[string]string {
+	t.Helper()
+	out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{id}})
+	if err != nil {
+		t.Fatalf("DescribeInstances %s: %v", id, err)
+	}
+	if len(out.Reservations) != 1 || len(out.Reservations[0].Instances) != 1 {
+		t.Fatalf("DescribeInstances %s returned no instance", id)
+	}
+	return journeyTagMap(out.Reservations[0].Instances[0].Tags)
+}
+
+// journeyVolumeTags reads one volume's tags through the unenforced admin.
+func journeyVolumeTags(t *testing.T, ctx context.Context, client *ec2.Client, id string) map[string]string {
+	t.Helper()
+	out, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{VolumeIds: []string{id}})
+	if err != nil {
+		t.Fatalf("DescribeVolumes %s: %v", id, err)
+	}
+	if len(out.Volumes) != 1 {
+		t.Fatalf("DescribeVolumes %s returned %d volumes, want 1", id, len(out.Volumes))
+	}
+	return journeyTagMap(out.Volumes[0].Tags)
+}


### PR DESCRIPTION
`CreateTags` and `DeleteTags` accept up to 1000 resource IDs of mixed types, and substrate decided all of them against a single ARN built from `InstanceId.1` — a parameter neither operation carries. Every tagging call was therefore decided against the literal string `"*"`.

That broke in **both** directions, and the reason is `resourceMatches`: it passes the *statement's* own `Resource` to `globMatch` as the **pattern**, so `"*"` as the *request* resource matches only a statement whose `Resource` itself begins with `"*"`.

- A `Deny` scoped to one instance, subnet, volume or security group was **inert**. A guardrail fencing a shared or production resource off from a pipeline that re-tags everything it can see read as a boundary and was not one.
- A least-privilege `Allow` naming those ARNs could not grant a tagging call **at all**.

Each named resource now resolves to its own ARN paired with its own tags, so `aws:ResourceTag` conditions and the permission boundary are evaluated per resource, and the denial names the first resource the policy does not allow.

### The ARN resource type is stated, not derived

Five of the nine taggable ID prefixes have a state-key abbreviation that differs from the ARN resource type: `sg`→`security-group`, `igw`→`internet-gateway`, `rtb`→`route-table`, `eip`→`elastic-ip`, `nat`→`natgateway`. String-munging the state key would produce `arn:…:sg/sg-…`, which matches nothing a caller writes. `ec2TaggableResource` now returns `(stateKey, arnType, ok)` and `ec2TaggableStateKey` calls it, so the two lists cannot drift.

### An unrecognized ID prefix is skipped, not denied and not widened

AWS answers a tagging ID it cannot parse with `InvalidID` — "The specified ID for the resource you are trying to tag is not valid" — not `AccessDenied`, and it is the handler's answer to owe. Widening to `"*"` would match a broad `Allow` and quietly grant more than the caller wrote. So the ID is omitted from the resource list, following `ec2AuthzRunInstancesResources`' rule for a resource the request does not name; a request naming only such IDs returns `nil` and is decided exactly as before.

### The `aws:RequestTag` fix is coupled and mandatory

`addRequestTags`' ec2 arm read only `TagSpecification.N.Tag.M.Key/Value`. A direct `CreateTags`/`DeleteTags` sends `Tag.N.Key`/`Tag.N.Value`, so `aws:RequestTag/*` was **empty for every direct tagging call**. Resolving the ARNs without this would have turned AWS's own documented `CreateTags` policies from a false allow into a false **deny**. The `TagSpecification` walk is untouched, including its #468 comment about deliberately not filtering by resource type. `DeleteTags`' optional tag value records as `""`, which `conditionMatches` cannot distinguish from an absent key for any operator including `Null` — so no new denial arises from it.

### Atomicity comes free

`CheckAccess` runs entirely before the handler, so a refused mixed-resource call writes nothing — not even to the resources the policy permits. That is the same all-or-nothing shape `createTags`' own reserved-key and tag-limit checks already have, and the e2e journey asserts it.

## Fail-before evidence

**Unit tier**, with the source reverted and the new tests in place: **38 failing cases across the 6 new tests** — every scoped-`Deny` and least-privilege subtest resolving to `"*"` instead of the expected ARN, and the `aws:RequestTag` subtests denied with `not authorized … on resource: *`.

**SDK tier**, `test/e2e/journey_ec2_tag_authz_test.go` against the unfixed emulator:

```
journey_ec2_tag_authz_test.go:139: tagging a volume the policy denies: got <nil> (<nil>), want an API error
```

**Honest caveat:** `TestEC2_TagAuthz_PermissionBoundaryCoversEveryResource` passes both before and after. The boundary check is already inside the decision loop, so that criterion is satisfied by construction — the test is a regression guard, not a fail-before proof.

## Mutation testing

Green baseline; anchor counts asserted over the whole file; `gofmt -w && go vet` so a non-compiling mutant is BROKEN rather than a result; full-package `go test -race -count=1 ./emulator/` with no `-run` filter. **All four targets killed, no survivors:**

| Mutant | Result |
|---|---|
| the tag resolver never resolves anything | KILLED by 5 tests |
| only the first `ResourceId` is evaluated | KILLED by 6 tests |
| the ARN type falls back to the state-key abbreviation (`sg`) | KILLED by 4 tests |
| the `aws:RequestTag` walk over `Tag.N` is dropped | KILLED by 1 test |

## Live run

`substrate server --address :4678` from a scratch directory, real AWS CLI, `AWS_MAX_ATTEMPTS=1`, a real IAM user with an access key (the built-in key resolves to no principal and is unenforced):

1. `create-tags --resources <instance> <volume>` under `Allow ec2:*` + `Deny ec2:CreateTags` on the volume ARN → `AccessDenied`, naming the volume ARN — and **both** resources came back with `[]` tags.
2. The same call without the denied resource → succeeds, instance carries `Env=test`.
3. A least-privilege `Allow` naming both ARNs → succeeds, volume carries `Env=prod`.
4. Dropping the volume ARN from that policy → `AccessDenied`, naming the volume ARN.
5. `Condition: StringEquals aws:RequestTag/Env=test` → `Env=test` succeeds; `Env=staging` denied.
6. `delete-tags` under a `Deny` on the volume ARN → `AccessDenied`, and `Env=prod` survives.
7. `create-tags --resources tgw-…` under a broad `Allow` → 200, no `AccessDenied`.

## Provenance

Neither action has a **required** resource type — the Service Authorization Reference marks zero of the 105 resource types it lists for either one. Authorizing against every named resource instead rests on AWS's general rule for an action naming several resources, which the Organizations counterpart (#660) and `RunInstances` (#662) already follow here, and on AWS's own scoped tagging examples, which write `instance/*` as the `Resource` of an `ec2:CreateTags` statement and would be pointless if only one resource of a batch were evaluated. The nine ARN formats come from the SAR's resource-types table: `arn:${Partition}:ec2:${Region}:${Account}:{type}/{id}` for all nine — none has the `image` ARN's deliberately empty account field.

Two AWS behaviours are **not** modelled and are named in the docs as such: `aws:TagKeys` is populated nowhere in the emulator, so the `ForAllValues:StringEquals` form three of AWS's `DeleteTags` examples use cannot be satisfied; and the second authorization pass AWS performs on `ec2:CreateTags` when a resource-creating action carries tags, keyed on `ec2:CreateAction`, which substrate does not model at all. `DeleteTags` does not carry `ec2:CreateAction`, so the two actions are identical in resource resolution and differ only in condition-key surface.

## Compatibility

A multi-resource `CreateTags`/`DeleteTags` that a broad-allow-plus-scoped-deny policy previously carried **may now be denied** — that is the defect, and the denial is the correct answer. An `aws:RequestTag` condition on a direct tagging call now evaluates against keys that were previously absent, so a policy requiring one now grants the calls that satisfy it and denies the ones that do not; previously it could grant neither. Callers with no principal (the built-in unenforced key) are unaffected.

## Verification

```
gofmt -l .                              clean
go build ./... && go vet ./...          ok
golangci-lint run ./...                 0 issues
make test                               ok (race)
make coverage                           emulator 82.8%, total 82.1%
make docs-reference docs-reference-check docs-versions   clean (67 plugins)
npm --prefix docs run build             build complete
go vet -C test/e2e ./... && go test -C test/e2e -count=1 ./...   ok
```

Closes #674
