### PR TITLE
fix(ec2,iam): resolve the default VPC before the decision, and authorize a fleet's launches (#673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously succeeded with the tags dropped; the same is true at `CreateLaunchTemplate`.
 
 ### Fixed
+- **A `RunInstances` that omitted `SubnetId` was decided before its subnet existed, so a
+  subnet-scoped guardrail was defeated by leaving the parameter out** (#673). Such a launch does
+  not run without a subnet: substrate resolves the default VPC's default subnet and its
+  `default` security group, creating them when the account has none — and that happened *after*
+  `CheckAccess`, so the decision named neither. A policy allowing `ec2:RunInstances` on exactly
+  one subnet permitted a launch into a subnet it never mentioned, and a `Deny` on the default
+  subnet was inert. This is the shape every getting-started example and most CDK-generated
+  launches take, so the guardrail that read as a boundary was not one for the most common launch
+  of all.
+
+  Both resources are now resolved from state **before** the decision, through a read-only lookup
+  rather than the create-if-absent path — calling the latter from the authorizer would let a
+  request the policy is about to refuse create a VPC. An existing default subnet is named by its
+  own ARN; an account that has none yet is decided against `subnet/*`, and one with no default
+  VPC at all also against `security-group/*`, because those are resources the launch is about to
+  **create**. That is the same reasoning `instance/*` and `network-interface/*` already rest on,
+  and it is not the skip-don't-widen rule, which is about a resource the request *omits*: a
+  `Deny` on `subnet/*` still matches, and a least-privilege `Allow` naming one specific subnet
+  correctly refuses a launch that will mint a different one. Substrate's fixtures all start from
+  empty state, so this is the common case rather than a corner.
+
+  The default subnet applies only when nothing else supplied one — a request parameter, a nested
+  `NetworkInterface.N.SubnetId` and a launch template all take precedence, in the order the
+  launch itself applies them — and a launch naming its own security groups is not additionally
+  authorized against the default group, because it does not attach it. The resolved subnet
+  arrives with its own tags, so an `aws:ResourceTag` condition about it is evaluated rather than
+  silently unsatisfiable. The default-group lookup is now one function shared with the launch
+  handler, so the group a launch attaches and the group its policy was evaluated against cannot
+  differ.
+
+  **A fleet's launches are authorized rather than exempted.** `CreateFleet` launches through the
+  same `RunInstances` path a direct call takes, which the API's authorization pipeline never
+  sees — the pipeline decides the `CreateFleet` request, not the launches it synthesizes — so a
+  caller denied `ec2:RunInstances` on a subnet reached it by asking for a fleet instead. Each
+  pool is now decided against the resources that pool resolves to, using the same request
+  builder the launch itself uses so the decision cannot be about a different request, and every
+  pool is decided before the first one launches: a refused fleet leaves no instances and no
+  fleet record behind. The `AuthController` reaches the EC2 plugin the way it already reaches
+  CloudFormation's stack deployer, and a caller carrying no IAM principal is unenforced exactly
+  as before.
+
+  One consequence worth stating: `RunInstances` is no longer decided against the literal `"*"`
+  under any circumstances. Every launch now names at least `instance/*`, and the fallback branch
+  a parameterless launch used to take was removed rather than left as a branch nothing can
+  reach.
+
+  **Provenance:** this is substrate's reading, not AWS parity, and `docs/services.md` says so.
+  The Service Authorization Reference's `RunInstances` scenario rows require `subnet*` only in
+  the `EC2-VPC-EBS-Subnet` and `EC2-VPC-InstanceStore-Subnet` scenarios, so a launch that omits
+  the subnet is, read straight, not authorized against one; AWS's own recommended subnet
+  guardrail is the `ec2:Subnet` condition key on `network-interface/*`, which substrate does not
+  populate. Substrate diverges because a guardrail a caller defeats by omitting a parameter is
+  useless for the purpose substrate exists for. The fleet half is not a divergence: AWS's
+  `CreateFleet` reference states that resource-level permissions for the action do not cover a
+  launch template's resources and that those must be named in the `RunInstances` statement.
+
+  **Compatibility:** a `RunInstances` omitting `SubnetId` that a subnet-scoped policy allowed in
+  v0.104.0 and earlier may now be denied, and a `CreateFleet` may now be denied unless the
+  policy also permits `ec2:RunInstances` on the launch's resources. Callers whose credentials
+  resolve to no IAM entity are unaffected, as enforcement remains opt-in.
+
+- **A launch refused for a nonexistent security group left a default VPC behind** (#673).
+  `runInstancesWithTags` validated security-group membership, which needs the target subnet's
+  VPC, so the check sat below the default-VPC branch — and a launch that omitted `SubnetId`
+  committed a VPC, a subnet, a security group, an internet gateway, a route table and four index
+  mutations before being refused, two of those writes swallowing their own errors. The next
+  request in the same test then saw state a refused one had created. Existence is now checked
+  before the first write, where it needs nothing; membership keeps its place, where the subnet's
+  VPC is known. Both error messages are unchanged. This is reachable with no IAM configured at
+  all, so it is independent of the authorization change above.
+
 - **`ec2:CreateTags` and `ec2:DeleteTags` were decided against a single `*` no matter how many
   resources they named, so an ARN-scoped guardrail on tagging was inert** (#674). Both
   operations name their resources in `ResourceId.N` — up to 1000 of them, of mixed types — and

--- a/docs/services.md
+++ b/docs/services.md
@@ -3275,8 +3275,55 @@ denial.
 
 A resource the request does not name is skipped, not resolved to `*` — `*` for an
 unknown resource would widen the policy the caller wrote instead of narrowing it.
-A request that names none of them at all is decided against a single `*`, as every
-other EC2 operation is.
+
+##### A launch that omits `SubnetId` is authorized against the default VPC's resources
+
+A launch that names no subnet does not run without one: substrate resolves the
+[default VPC](#runinstances)'s default subnet and its `default` security group,
+creating them when the account has none. Both are part of the decision, resolved from
+state *before* it is made:
+
+| State when the launch arrives | Subnet in the decision | Security group in the decision |
+|---|---|---|
+| A default VPC with a default subnet | that subnet's ARN | the default VPC's group, if the request named none |
+| A default VPC with no default subnet | `subnet/*` | the default VPC's group, if the request named none |
+| No default VPC | `subnet/*` | `security-group/*` |
+
+A launch that names its own security groups is authorized against those and not
+additionally against the default one, because that is what it attaches. The default
+subnet applies only when nothing else supplied one — a request parameter, a nested
+`NetworkInterface.N.SubnetId` and a launch template all take precedence, in the same
+order the launch itself applies them.
+
+The two wildcards are resources the launch is about to **create**, which is why they
+are wildcards rather than skipped: the skip-don't-widen rule above is about a resource
+the request omits. A `Deny` on `subnet/*` therefore still matches, and a
+least-privilege `Allow` naming one specific subnet correctly refuses a launch that
+will mint a different one.
+
+**This is substrate's reading, not AWS parity.** The Service Authorization Reference's
+`RunInstances` scenario rows require `subnet*` only in the `EC2-VPC-EBS-Subnet` and
+`EC2-VPC-InstanceStore-Subnet` scenarios, so a launch that omits the subnet is, read
+straight, not authorized against one — and AWS's own recommended subnet guardrail is
+the `ec2:Subnet` condition key on `network-interface/*`, which substrate does not
+populate. Substrate diverges because a guardrail a caller defeats by omitting a
+parameter is useless for the purpose substrate exists for: a test that proves a policy
+keeps workloads out of a subnet has to fail when the launch lands in it.
+
+##### A fleet's launches are authorized, not exempted
+
+`CreateFleet` launches its instances internally, through the same `RunInstances` path a
+direct call takes, so the API's authorization pipeline sees only the `CreateFleet`
+request. Each pool's launch is therefore authorized separately, against the resources
+that pool resolves to — its launch template's AMI, the override's subnet, and the
+instance and interface wildcards. A caller needs `ec2:RunInstances` on those resources
+in addition to `ec2:CreateFleet`, which is what AWS requires too: "Resource-level
+permissions for this action do not include the resources specified in a launch
+template. To specify resource-level permissions for resources specified in a launch
+template, you must include the resources in the RunInstances action statement."
+
+Every pool is decided before the first one launches, so a refused fleet leaves no
+instances and no fleet record behind.
 
 Not covered:
 
@@ -3286,15 +3333,9 @@ Not covered:
   documented types.
 - **The launch-template ARN**, which the reference does not mark required for
   `RunInstances` — so requiring it would refuse the same policy.
-- **The EC2 condition keys** (`ec2:InstanceType`, `ec2:Vpc`,
+- **The EC2 condition keys** (`ec2:InstanceType`, `ec2:Vpc`, `ec2:Subnet`,
   `ec2:IsLaunchTemplateResource` and the rest). Resource resolution is what this
   covers; the condition keys substrate does populate are the `aws:`-prefixed ones.
-- **A launch that names no subnet and no security group**, whose defaults are
-  resolved from the default VPC *after* the authorization decision. A policy scoped
-  to one subnet cannot fence off such a launch.
-- **The [fleet](#seeding-ec2-fleet-partial-fulfillment) path**, which launches
-  instances internally without going through the API's authorization pipeline, so no
-  policy applies to it.
 
 #### Tagging is authorized against every resource it names
 

--- a/emulator/ec2_authz.go
+++ b/emulator/ec2_authz.go
@@ -31,17 +31,26 @@ import (
 // on; the two synthesized wildcards come last.
 //
 // A member the request omits is skipped rather than resolved to "*": "*" for an
-// absent ID would widen the policy the caller wrote instead of narrowing it. A
-// request naming none of them returns nil, so it is decided exactly as it was
-// before.
+// absent ID would widen the policy the caller wrote instead of narrowing it.
+//
+// The exception is a launch that omits SubnetId, whose subnet and security group are
+// substrate's default-VPC defaults. Those are resources the launch *will land in*,
+// not resources it fails to name, so they are resolved before the decision rather
+// than skipped — otherwise a caller defeats a subnet-scoped guardrail by leaving the
+// parameter out, which is the one thing such a guardrail exists to prevent (#673).
+// When there is no default VPC yet the launch is about to create both, so they are
+// the wildcards subnet/* and security-group/*, on the same reasoning instance/* and
+// network-interface/* already are.
 func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, req *AWSRequest) []authzResource {
 	if req.Operation != "RunInstances" {
 		return nil
 	}
+	// No emptiness guard: every launch names at least instance/*, and one that named
+	// nothing else still resolves its subnet from the default VPC, so RunInstances is
+	// never decided against the literal "*" any more. The guard that used to send a
+	// parameterless launch down buildResourceARNs' single-resource path was removed
+	// with #673 rather than left as a branch nothing can reach.
 	launch := ec2AuthzResolveLaunch(state, reqCtx, req)
-	if launch.empty() {
-		return nil
-	}
 
 	acct := reqCtx.AccountID
 	region := reqCtx.Region
@@ -59,17 +68,27 @@ func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, r
 			Tags: ec2AuthzTagsFor(state, ec2ImageStateKey(acct, region, launch.imageID)),
 		})
 	}
-	if launch.subnetID != "" {
+	switch {
+	case launch.subnetID != "":
 		out = append(out, authzResource{
 			ARN:  "arn:aws:ec2:" + region + ":" + acct + ":subnet/" + launch.subnetID,
 			Tags: ec2AuthzTagsFor(state, "subnet:"+acct+"/"+region+"/"+launch.subnetID),
 		})
+	case launch.subnetWildcard:
+		// The default subnet this launch is about to create. No tags: it does not
+		// exist, so an aws:ResourceTag condition about it cannot be satisfied — which
+		// is the honest answer, since the subnet substrate mints carries no tags
+		// either.
+		out = append(out, authzResource{ARN: "arn:aws:ec2:" + region + ":" + acct + ":subnet/*"})
 	}
 	for _, sgID := range launch.securityGroupIDs {
 		out = append(out, authzResource{
 			ARN:  "arn:aws:ec2:" + region + ":" + acct + ":security-group/" + sgID,
 			Tags: ec2AuthzTagsFor(state, "sg:"+acct+"/"+region+"/"+sgID),
 		})
+	}
+	if launch.securityGroupWildcard {
+		out = append(out, authzResource{ARN: "arn:aws:ec2:" + region + ":" + acct + ":security-group/*"})
 	}
 	// Every launch attaches an interface, so network-interface* is always evaluated.
 	// An interface the launch creates has no ID yet, so it is the wildcard; one the
@@ -155,13 +174,13 @@ type ec2AuthzLaunchMembers struct {
 	subnetID            string
 	securityGroupIDs    []string
 	networkInterfaceIDs []string
-}
-
-// empty reports whether the request named no resource at all, in which case
-// authorization falls back to the single-resource path unchanged.
-func (m ec2AuthzLaunchMembers) empty() bool {
-	return m.imageID == "" && m.subnetID == "" &&
-		len(m.securityGroupIDs) == 0 && len(m.networkInterfaceIDs) == 0
+	// subnetWildcard and securityGroupWildcard mark the two default-VPC resources
+	// this launch will create rather than find: no ID exists to name, so the decision
+	// is made against subnet/* and security-group/*. They are a separate field rather
+	// than a "*" written into subnetID because a sentinel that reads as an ID is the
+	// kind of value that eventually reaches a state key (#656).
+	subnetWildcard        bool
+	securityGroupWildcard bool
 }
 
 // ec2AuthzResolveLaunch resolves the resources a RunInstances request names,
@@ -201,15 +220,35 @@ func ec2AuthzResolveLaunch(state StateManager, reqCtx *RequestContext, req *AWSR
 	}
 	m.networkInterfaceIDs = ec2AuthzInterfaceIDs(interfaces)
 
+	m.mergeTemplate(state, reqCtx, req, len(interfaces) == 0)
+	// Last, so it applies only to a launch nothing else gave a subnet — including a
+	// template. A return from the template merge above must not skip this: a plain
+	// request naming no template is exactly the launch whose subnet comes from the
+	// default VPC (#673).
+	m.resolveDefaultVPC(state, reqCtx)
+	return m
+}
+
+// mergeTemplate folds in the resources a named launch template supplies, under the
+// same field-by-field precedence the handler applies: a value the request already
+// resolved wins.
+//
+// takeInterfaces carries the handler's all-or-nothing interface rule from the caller,
+// which knows whether the *request* declared any — a request naming one interface is
+// not authorized against a second it will never attach.
+//
+// A template that cannot be read or resolved contributes nothing, which is why both
+// failures return rather than refuse.
+func (m *ec2AuthzLaunchMembers) mergeTemplate(state StateManager, reqCtx *RequestContext, req *AWSRequest, takeInterfaces bool) {
 	lt := ec2LookupLaunchTemplate(context.Background(), state, reqCtx,
 		req.Params["LaunchTemplate.LaunchTemplateId"],
 		req.Params["LaunchTemplate.LaunchTemplateName"])
 	if lt == nil {
-		return m
+		return
 	}
 	version, awsErr := ec2ResolveTemplateVersion(lt, req.Params["LaunchTemplate.Version"])
 	if awsErr != nil || version == nil {
-		return m
+		return
 	}
 	data := version.Data
 	if m.imageID == "" {
@@ -221,13 +260,57 @@ func ec2AuthzResolveLaunch(state StateManager, reqCtx *RequestContext, req *AWSR
 	if len(m.securityGroupIDs) == 0 {
 		m.securityGroupIDs = data.NetworkSecurityGroupIDs()
 	}
-	// All-or-nothing, matching the handler: the template's interfaces apply only
-	// when the request declared none, so a request naming one interface is not
-	// authorized against a second it will never attach.
-	if len(interfaces) == 0 {
+	if takeInterfaces {
 		m.networkInterfaceIDs = ec2AuthzInterfaceIDs(data.NetworkInterfaces)
 	}
-	return m
+}
+
+// resolveDefaultVPC fills in the subnet and security group a launch that named
+// neither takes from the default VPC, reading state without creating anything.
+//
+// It runs last, after the template merge, because the default VPC applies only when
+// nothing else supplied a subnet — the same precedence the handler uses, which is
+// what keeps the decision and the launch from disagreeing about where an instance
+// lands.
+//
+// The read is [ec2LookupDefaultVPC] rather than ensureDefaultVPC: the latter creates
+// nine records, and calling it here would let a request the policy is about to refuse
+// create a VPC.
+//
+// A launch whose default VPC does not exist yet is authorized against subnet/* and
+// security-group/*, because it is about to create both. A Deny on subnet/* still
+// matches, and a least-privilege Allow naming one specific subnet correctly refuses a
+// launch that will mint a different one. Substrate's fixtures all start from empty
+// state, so that is the common case rather than a corner.
+func (m *ec2AuthzLaunchMembers) resolveDefaultVPC(state StateManager, reqCtx *RequestContext) {
+	if m.subnetID != "" {
+		return
+	}
+	namedGroups := len(m.securityGroupIDs) > 0
+	vpc, subnet, err := ec2LookupDefaultVPC(context.Background(), state, reqCtx)
+	if err != nil || vpc == nil {
+		// No default VPC, or state cannot say: this launch creates both. A failed read
+		// resolves to the wildcards rather than to nothing, so a storage fault cannot
+		// turn a guarded launch into an unguarded one.
+		m.subnetWildcard = true
+		m.securityGroupWildcard = !namedGroups
+		return
+	}
+	if subnet != nil {
+		m.subnetID = subnet.SubnetID
+	} else {
+		// The default VPC exists but has no default subnet, so the launch mints one.
+		m.subnetWildcard = true
+	}
+	if namedGroups {
+		return
+	}
+	// The default group already exists alongside the VPC, so it is named rather than
+	// wildcarded. When it does not resolve, the launch attaches no group at all and
+	// the decision names none either — the same rule the handler follows.
+	if sgID := ec2LookupDefaultSecurityGroup(context.Background(), state, reqCtx, vpc.VPCID); sgID != "" {
+		m.securityGroupIDs = []string{sgID}
+	}
 }
 
 // ec2AuthzInterfaceIDs returns the IDs of the interfaces the launch attaches by

--- a/emulator/ec2_authz_defaultvpc_test.go
+++ b/emulator/ec2_authz_defaultvpc_test.go
@@ -1,0 +1,410 @@
+package emulator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The authorization decision for a RunInstances that omits SubnetId (#673).
+//
+// Such a launch does not run without a subnet: substrate resolves the default VPC's
+// default subnet and default security group, creating them if the account has none.
+// Until #673 that happened *after* CheckAccess, so the decision named neither — a
+// subnet-scoped guardrail was defeated by leaving the parameter out, which is the one
+// thing such a guardrail exists to prevent.
+//
+// These tests pin the resolved resources both ways: an existing default subnet is
+// named by its own ID, and an account that has none yet is decided against subnet/*
+// and security-group/*, because those are resources the launch is about to create —
+// the same reasoning instance/* and network-interface/* already rest on.
+
+const (
+	ec2AuthzDefaultVPCID    = "vpc-0ddd88889999eeee0"
+	ec2AuthzDefaultSubnetID = "subnet-0fff00001111aaaa2"
+)
+
+var ec2AuthzDefaultSubnetARN = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount +
+	":subnet/" + ec2AuthzDefaultSubnetID
+
+// putDefaultVPC gives the fixture's account a default VPC, its default subnet, and a
+// default security group inside it — the three records ensureDefaultVPC would create.
+//
+// The security group is the fixture's own ec2AuthzSG re-put with the VPC's ID rather
+// than a second group, because ec2LookupDefaultSecurityGroup takes the *first*
+// security-group key in the account and only if it belongs to the VPC. Adding a
+// second group would make which one resolves depend on key ordering, which is not
+// what these tests are about.
+//
+// subnetTags are the resolved subnet's own tags, which is what an aws:ResourceTag
+// condition about it is evaluated against.
+func (f *ec2AuthzFixture) putDefaultVPC(t *testing.T, subnetTags map[string]string) {
+	t.Helper()
+	f.put(t, "vpc:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2AuthzDefaultVPCID, emulator.EC2VPC{
+		VPCID:     ec2AuthzDefaultVPCID,
+		CIDRBlock: "172.31.0.0/16",
+		IsDefault: true,
+		State:     "available",
+		AccountID: ec2AuthzAccount,
+		Region:    ec2AuthzRegion,
+	})
+	f.put(t, "subnet:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2AuthzDefaultSubnetID, emulator.EC2Subnet{
+		SubnetID:  ec2AuthzDefaultSubnetID,
+		VPCID:     ec2AuthzDefaultVPCID,
+		CIDRBlock: "172.31.0.0/20",
+		IsDefault: true,
+		State:     "available",
+		Tags:      ec2AuthzTags(subnetTags),
+		AccountID: ec2AuthzAccount,
+		Region:    ec2AuthzRegion,
+	})
+	f.put(t, "sg:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2AuthzSG, emulator.EC2SecurityGroup{
+		GroupID: ec2AuthzSG,
+		VPCID:   ec2AuthzDefaultVPCID,
+	})
+}
+
+// subnetlessLaunch is a launch naming an AMI and nothing else — the shape every
+// getting-started example and most CDK-generated launches take.
+func subnetlessLaunch() map[string]string {
+	return map[string]string{
+		"ImageId":      ec2AuthzAMI,
+		"InstanceType": "t3.micro",
+		"MinCount":     "1",
+		"MaxCount":     "1",
+	}
+}
+
+// TestEC2_Authz_DefaultSubnetDenyBlocksSubnetlessLaunch is the decisive test: the
+// false allow #673 reports.
+//
+// "Launch anywhere except the default subnet" is the guardrail, and omitting SubnetId
+// was the way around it — the launch landed in the very subnet the Deny named,
+// because the decision was made before the subnet was resolved.
+func TestEC2_Authz_DefaultSubnetDenyBlocksSubnetlessLaunch(t *testing.T) {
+	f := newEC2AuthzFixture(t, "tariq", emulator.PolicyDocument{})
+	f.putDefaultVPC(t, nil)
+	f.setPolicy(t,
+		ec2AuthzStatement("Allow", "*"),
+		ec2AuthzStatement("Deny", ec2AuthzDefaultSubnetARN),
+	)
+
+	err := f.launch(t, subnetlessLaunch())
+	if !ec2AuthzDenied(t, err) {
+		t.Fatal("omitting SubnetId was a way around a Deny on the subnet the launch lands in")
+	}
+	assert.Equal(t, ec2AuthzDefaultSubnetARN, deniedResource(t, err),
+		"the denial names the default subnet, resolved from state before the decision")
+}
+
+// TestEC2_Authz_DefaultVPCLeastPrivilegeAllows is the other direction: a policy
+// naming the resolved default subnet and security group has to permit the launch, or
+// the fix would make the ordinary subnet-less launch unrunnable under least
+// privilege.
+func TestEC2_Authz_DefaultVPCLeastPrivilegeAllows(t *testing.T) {
+	f := newEC2AuthzFixture(t, "ursula", emulator.PolicyDocument{})
+	f.putDefaultVPC(t, nil)
+	f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzDefaultSubnetARN,
+		ec2AuthzSGARN, ec2AuthzENIARN, ec2AuthzInstARN))
+
+	require.NoError(t, f.launch(t, subnetlessLaunch()),
+		"a policy naming the resolved default subnet and group must permit the launch")
+}
+
+// TestEC2_Authz_DefaultSecurityGroupIsNamed pins that the group the launch will
+// attach is part of the decision too, not only the subnet.
+//
+// The handler attaches the default VPC's security group to a launch that named none,
+// so a policy that fences off that group has to refuse the launch. Naming the subnet
+// and omitting the group is exactly the mistake a least-privilege policy makes, and
+// the denial has to say which ARN is missing.
+func TestEC2_Authz_DefaultSecurityGroupIsNamed(t *testing.T) {
+	f := newEC2AuthzFixture(t, "vera", emulator.PolicyDocument{})
+	f.putDefaultVPC(t, nil)
+	f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzDefaultSubnetARN,
+		ec2AuthzENIARN, ec2AuthzInstARN))
+
+	err := f.launch(t, subnetlessLaunch())
+	if !ec2AuthzDenied(t, err) {
+		t.Fatal("a policy omitting the default security group allowed a launch that attaches it")
+	}
+	assert.Equal(t, ec2AuthzSGARN, deniedResource(t, err))
+}
+
+// TestEC2_Authz_NamedGroupsSuppressTheDefaultGroup pins that a launch naming its own
+// security groups is not additionally authorized against the default one.
+//
+// The handler attaches what the request named and nothing else, so a decision that
+// also demanded the default group would require an ARN the launch never touches.
+func TestEC2_Authz_NamedGroupsSuppressTheDefaultGroup(t *testing.T) {
+	const ownSG = "sg-0111222233334444a"
+	ownARN := "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":security-group/" + ownSG
+
+	f := newEC2AuthzFixture(t, "walid", emulator.PolicyDocument{})
+	f.putDefaultVPC(t, nil)
+	f.putSecurityGroup(t, ownSG, nil)
+	params := subnetlessLaunch()
+	params["SecurityGroupId.1"] = ownSG
+
+	f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzDefaultSubnetARN,
+		ownARN, ec2AuthzENIARN, ec2AuthzInstARN))
+	require.NoError(t, f.launch(t, params),
+		"the group the request named is the only one required")
+
+	// And a Deny on the group the launch does *not* attach must not block it.
+	f.setPolicy(t, ec2AuthzStatement("Allow", "*"), ec2AuthzStatement("Deny", ec2AuthzSGARN))
+	require.NoError(t, f.launch(t, params),
+		"a Deny on the default group must not block a launch that named its own")
+}
+
+// TestEC2_Authz_FreshAccountResolvesToWildcards covers the case substrate's fixtures
+// all start in: no default VPC exists, so the launch will create one.
+//
+// This is not the skip-don't-widen case. That rule is about a resource the request
+// omits; this is a resource the request *creates*, which is why instance/* and
+// network-interface/* are already wildcards. Without it the first launch in a fresh
+// account escapes the guardrail every later launch is subject to.
+func TestEC2_Authz_FreshAccountResolvesToWildcards(t *testing.T) {
+	t.Run("a Deny on subnet/* blocks the launch", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "xena", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"),
+			ec2AuthzStatement("Deny", ec2AuthzSubnetWildcardARN))
+
+		err := f.launch(t, subnetlessLaunch())
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a Deny on subnet/* did not block a launch that will create a default subnet")
+		}
+		assert.Equal(t, ec2AuthzSubnetWildcardARN, deniedResource(t, err))
+	})
+
+	t.Run("a Deny on security-group/* blocks the launch", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "xena", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"),
+			ec2AuthzStatement("Deny", ec2AuthzSGWildcardARN))
+
+		err := f.launch(t, subnetlessLaunch())
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a Deny on security-group/* did not block a launch that will create one")
+		}
+		assert.Equal(t, ec2AuthzSGWildcardARN, deniedResource(t, err))
+	})
+
+	t.Run("a policy scoped to one subnet does not permit it", func(t *testing.T) {
+		// The fail-before this issue turns on. A policy allowing exactly one subnet
+		// permitted a subnet-less launch, because the launch resolved to "*" and "*"
+		// as a request resource matches only a statement whose own Resource starts
+		// with "*". Now it is decided against subnet/*, which the specific ARN does
+		// not match — the honest answer, since the launch will mint a different subnet.
+		f := newEC2AuthzFixture(t, "yusuf", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzAllFive()...))
+
+		err := f.launch(t, subnetlessLaunch())
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a policy allowing only one subnet permitted a launch that omits SubnetId")
+		}
+		assert.Equal(t, ec2AuthzSubnetWildcardARN, deniedResource(t, err))
+	})
+
+	t.Run("a launch naming its own groups is not decided against security-group/*", func(t *testing.T) {
+		// The fresh-account mirror of TestEC2_Authz_NamedGroupsSuppressTheDefaultGroup.
+		// A launch that named its own groups attaches those and no others, so no default
+		// group is created and the decision must not demand one.
+		//
+		// A least-privilege Allow is what shows this, not a Deny on security-group/*: that
+		// pattern matches the named group's own ARN too, so it would refuse the launch
+		// either way. Naming the group and not the wildcard distinguishes them, because a
+		// specific ARN in a statement does not match a request resource of
+		// security-group/*.
+		const ownSG = "sg-0555666677778888b"
+		ownARN := "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":security-group/" + ownSG
+		f := newEC2AuthzFixture(t, "xena", emulator.PolicyDocument{})
+		f.putSecurityGroup(t, ownSG, nil)
+		params := subnetlessLaunch()
+		params["SecurityGroupId.1"] = ownSG
+
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzSubnetWildcardARN,
+			ownARN, ec2AuthzENIARN, ec2AuthzInstARN))
+		require.NoError(t, f.launch(t, params),
+			"the group the request named is the only one required, default VPC or not")
+	})
+
+	t.Run("naming both wildcards permits it", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "yusuf", emulator.PolicyDocument{})
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzSubnetWildcardARN,
+			ec2AuthzSGWildcardARN, ec2AuthzENIARN, ec2AuthzInstARN))
+		require.NoError(t, f.launch(t, subnetlessLaunch()))
+	})
+}
+
+// TestEC2_Authz_DefaultVPCWithoutADefaultSubnet covers the state ensureDefaultVPC can
+// leave behind: the VPC exists but its default subnet does not, so the launch mints
+// the subnet and keeps the VPC.
+//
+// The subnet is therefore the wildcard while the security group — which does exist
+// alongside the VPC — is named. Resolving both to wildcards would let a Deny on the
+// existing group go unmatched.
+func TestEC2_Authz_DefaultVPCWithoutADefaultSubnet(t *testing.T) {
+	newFixture := func(t *testing.T) *ec2AuthzFixture {
+		t.Helper()
+		f := newEC2AuthzFixture(t, "zora", emulator.PolicyDocument{})
+		f.put(t, "vpc:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2AuthzDefaultVPCID, emulator.EC2VPC{
+			VPCID:     ec2AuthzDefaultVPCID,
+			IsDefault: true,
+			State:     "available",
+			AccountID: ec2AuthzAccount,
+			Region:    ec2AuthzRegion,
+		})
+		f.put(t, "sg:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2AuthzSG, emulator.EC2SecurityGroup{
+			GroupID: ec2AuthzSG,
+			VPCID:   ec2AuthzDefaultVPCID,
+		})
+		return f
+	}
+
+	t.Run("the subnet is the wildcard and the group is named", func(t *testing.T) {
+		f := newFixture(t)
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzSubnetWildcardARN,
+			ec2AuthzSGARN, ec2AuthzENIARN, ec2AuthzInstARN))
+		require.NoError(t, f.launch(t, subnetlessLaunch()))
+	})
+
+	t.Run("a Deny on the existing default group still matches", func(t *testing.T) {
+		f := newFixture(t)
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"), ec2AuthzStatement("Deny", ec2AuthzSGARN))
+		err := f.launch(t, subnetlessLaunch())
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a Deny on the default VPC's security group did not block the launch")
+		}
+		assert.Equal(t, ec2AuthzSGARN, deniedResource(t, err))
+	})
+}
+
+// TestEC2_Authz_DefaultVPCYieldsToEverySubnetSource pins the precedence: the default
+// VPC applies only to a launch nothing else gave a subnet.
+//
+// resolveDefaultVPC runs last for exactly this reason, and the handler applies the
+// same order — a decision made about the default subnet for a launch that lands in a
+// template's would be a false denial in one direction and a false allow in the other.
+func TestEC2_Authz_DefaultVPCYieldsToEverySubnetSource(t *testing.T) {
+	// The default subnet exists, so if precedence were wrong the decision would name
+	// it rather than the subnet each launch actually uses.
+	t.Run("a request-named subnet wins", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "abel", emulator.PolicyDocument{})
+		f.putDefaultVPC(t, nil)
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"),
+			ec2AuthzStatement("Deny", ec2AuthzDefaultSubnetARN))
+		require.NoError(t, f.launch(t, nominalLaunch()),
+			"a Deny on the default subnet must not block a launch that named another")
+	})
+
+	t.Run("a nested interface's subnet wins", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "abel", emulator.PolicyDocument{})
+		f.putDefaultVPC(t, nil)
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"),
+			ec2AuthzStatement("Deny", ec2AuthzDefaultSubnetARN))
+		require.NoError(t, f.launch(t, map[string]string{
+			"ImageId":                        ec2AuthzAMI,
+			"MinCount":                       "1",
+			"MaxCount":                       "1",
+			"NetworkInterface.1.DeviceIndex": "0",
+			"NetworkInterface.1.SubnetId":    ec2AuthzSubnet,
+			"NetworkInterface.1.Groups.1":    ec2AuthzSG,
+		}), "a Deny on the default subnet must not block a launch whose interface named another")
+	})
+
+	t.Run("a launch template's subnet wins", func(t *testing.T) {
+		// The regression this guards against is structural: the template merge used to
+		// return early, and putting the default-VPC lookup inside it would have skipped
+		// the lookup for a template-less launch. Splitting the two made this case and
+		// the wildcard cases above both reachable.
+		const ltID = "lt-0eee3333ffff4444d"
+		f := newEC2AuthzFixture(t, "abel", emulator.PolicyDocument{})
+		f.putDefaultVPC(t, nil)
+		f.put(t, "lt:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ltID, emulator.EC2LaunchTemplate{
+			LaunchTemplateID:   ltID,
+			LaunchTemplateName: "into-a-named-subnet",
+			DefaultVersionNum:  1,
+			LatestVersionNum:   1,
+			Versions: []emulator.EC2LaunchTemplateVersion{{
+				VersionNumber: 1,
+				Data: emulator.EC2LaunchTemplateData{
+					ImageID:                ec2AuthzAMI,
+					SubnetID:               ec2AuthzSubnet,
+					NetworkInterfaceGroups: []string{ec2AuthzSG},
+				},
+			}},
+		})
+		params := map[string]string{
+			"MinCount":                        "1",
+			"MaxCount":                        "1",
+			"LaunchTemplate.LaunchTemplateId": ltID,
+		}
+
+		f.setPolicy(t, ec2AuthzStatement("Allow", "*"),
+			ec2AuthzStatement("Deny", ec2AuthzDefaultSubnetARN))
+		require.NoError(t, f.launch(t, params),
+			"a Deny on the default subnet must not block a launch whose template named another")
+
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzAllFive()...))
+		require.NoError(t, f.launch(t, params),
+			"the template's own subnet is the one the decision names")
+	})
+}
+
+// TestEC2_Authz_DefaultSubnetTagsAreItsOwn pins that the resolved subnet arrives with
+// its tags, not bare.
+//
+// Resolving the ARN without the tags would leave aws:ResourceTag/* absent for it, so
+// an ABAC policy would deny every subnet-less launch — the false deny that is the
+// mirror image of #673's false allow.
+func TestEC2_Authz_DefaultSubnetTagsAreItsOwn(t *testing.T) {
+	doc := newABACPolicy("Allow", "ec2:RunInstances", "*", "aws:ResourceTag/Env", "test")
+
+	t.Run("a matching tag on the resolved subnet allows", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "bianca", doc)
+		f.putDefaultVPC(t, map[string]string{"Env": "test"})
+		f.putImage(t, ec2AuthzAMI, map[string]string{"Env": "test"})
+		f.put(t, "sg:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2AuthzSG, emulator.EC2SecurityGroup{
+			GroupID: ec2AuthzSG,
+			VPCID:   ec2AuthzDefaultVPCID,
+			Tags:    ec2AuthzTags(map[string]string{"Env": "test"}),
+		})
+		f.setPolicy(t,
+			emulator.PolicyStatement{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice{"ec2:RunInstances"},
+				Resource: emulator.StringOrSlice{ec2AuthzImageARN, ec2AuthzDefaultSubnetARN, ec2AuthzSGARN},
+				Condition: map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {"aws:ResourceTag/Env": {"test"}},
+				},
+			},
+			ec2AuthzStatement("Allow", ec2AuthzENIARN, ec2AuthzInstARN),
+		)
+		require.NoError(t, f.launch(t, subnetlessLaunch()))
+	})
+
+	t.Run("a mismatched tag on the resolved subnet denies", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "bianca", doc)
+		f.putDefaultVPC(t, map[string]string{"Env": "prod"})
+		f.putImage(t, ec2AuthzAMI, map[string]string{"Env": "test"})
+		f.setPolicy(t,
+			emulator.PolicyStatement{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice{"ec2:RunInstances"},
+				Resource: emulator.StringOrSlice{ec2AuthzImageARN, ec2AuthzDefaultSubnetARN, ec2AuthzSGARN},
+				Condition: map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {"aws:ResourceTag/Env": {"test"}},
+				},
+			},
+			ec2AuthzStatement("Allow", ec2AuthzENIARN, ec2AuthzInstARN),
+		)
+		err := f.launch(t, subnetlessLaunch())
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a default subnet tagged Env=prod satisfied a condition requiring Env=test")
+		}
+		assert.Equal(t, ec2AuthzDefaultSubnetARN, deniedResource(t, err))
+	})
+}

--- a/emulator/ec2_authz_test.go
+++ b/emulator/ec2_authz_test.go
@@ -55,6 +55,11 @@ var (
 	ec2AuthzSGARN     = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":security-group/" + ec2AuthzSG
 	ec2AuthzENIARN    = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":network-interface/*"
 	ec2AuthzInstARN   = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":instance/*"
+
+	// The two default-VPC resources a launch that names no subnet is about to create,
+	// which is why they are wildcards rather than IDs (#673).
+	ec2AuthzSubnetWildcardARN = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":subnet/*"
+	ec2AuthzSGWildcardARN     = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":security-group/*"
 )
 
 // ec2AuthzAllFive is every ARN a launch requires, which is what a least-privilege
@@ -441,15 +446,37 @@ func TestEC2_Authz_PermissionBoundaryCoversEveryResource(t *testing.T) {
 // "*" for an absent ID would widen the policy the caller wrote: a statement
 // naming only "*" would then satisfy a launch that named no subnet, which is the
 // direction a privilege boundary must never fail in.
+//
+// The subnet and security group are the exception, and not to this rule: a launch that
+// names neither takes both from the default VPC, creating them if the account has none,
+// so they are resolved rather than absent — by ID when they exist and as subnet/* and
+// security-group/* when the launch is about to mint them, the same footing instance/*
+// and network-interface/* are already on. That is a resource the request *creates*, not
+// one it omits (#673); see TestEC2_Authz_FreshAccountResolvesToWildcards. Every other
+// member below is genuinely absent, which is why the subtests here assert the two are
+// named while the rest are not.
 func TestEC2_Authz_AbsentMembersAreSkipped(t *testing.T) {
-	t.Run("an AMI-only launch names three resources", func(t *testing.T) {
+	t.Run("an AMI-only launch names the default-VPC wildcards too", func(t *testing.T) {
+		// Before #673 this launch named three resources and the policy below sufficed.
+		// A launch that omits SubnetId does not omit a subnet — it takes the default
+		// VPC's, and in an empty fixture it is about to create one — so subnet/* and
+		// security-group/* are part of the decision. Skip-don't-widen still governs a
+		// resource the request truly leaves out; it does not cover one the launch
+		// creates.
 		f := newEC2AuthzFixture(t, "omar", emulator.PolicyDocument{})
+		params := map[string]string{"ImageId": ec2AuthzAMI, "MinCount": "1", "MaxCount": "1"}
+
 		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzENIARN, ec2AuthzInstARN))
-		require.NoError(t, f.launch(t, map[string]string{
-			"ImageId":  ec2AuthzAMI,
-			"MinCount": "1",
-			"MaxCount": "1",
-		}), "no subnet and no security group were named, so neither is required")
+		err := f.launch(t, params)
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a policy omitting subnet/* allowed a launch that will create a default subnet")
+		}
+		assert.Equal(t, ec2AuthzSubnetWildcardARN, deniedResource(t, err))
+
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN,
+			ec2AuthzSubnetWildcardARN, ec2AuthzSGWildcardARN, ec2AuthzENIARN, ec2AuthzInstARN))
+		require.NoError(t, f.launch(t, params),
+			"naming the two wildcards the launch will create permits it")
 	})
 
 	t.Run("the AMI is still required", func(t *testing.T) {
@@ -462,20 +489,30 @@ func TestEC2_Authz_AbsentMembersAreSkipped(t *testing.T) {
 		assert.Equal(t, ec2AuthzImageARN, deniedResource(t, err))
 	})
 
-	t.Run("a launch naming nothing falls back unchanged", func(t *testing.T) {
-		// No resource at all, so there is nothing to authorize against and the
-		// single-resource path decides it exactly as it did before this change: the
-		// ec2 arm of buildResourceARN, with no InstanceId.1, resolves to "*".
+	t.Run("a launch naming nothing is still decided against ARNs", func(t *testing.T) {
+		// Before #673 this fell back to buildResourceARN's single-resource path and
+		// resolved to the literal "*". It no longer can: the launch will create a
+		// default subnet, a default security group, an interface and an instance, so
+		// four ARNs are named and none of them is "*". That closes the last route by
+		// which a RunInstances escaped its own resource list.
 		f := newEC2AuthzFixture(t, "omar", emulator.PolicyDocument{})
+		params := map[string]string{"MinCount": "1", "MaxCount": "1"}
+
 		f.setPolicy(t, ec2AuthzStatement("Allow", "*"))
-		require.NoError(t, f.launch(t, map[string]string{"MinCount": "1", "MaxCount": "1"}))
+		require.NoError(t, f.launch(t, params))
 
 		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzInstARN))
-		err := f.launch(t, map[string]string{"MinCount": "1", "MaxCount": "1"})
+		err := f.launch(t, params)
 		if !ec2AuthzDenied(t, err) {
-			t.Fatal("a launch naming no resource is decided against \"*\", which an ARN-scoped policy does not match")
+			t.Fatal("a policy naming only instance/* allowed a launch that also creates a subnet")
 		}
-		assert.Equal(t, "*", deniedResource(t, err))
+		assert.Equal(t, ec2AuthzSubnetWildcardARN, deniedResource(t, err),
+			"the denial names the default subnet the launch would create, not \"*\"")
+
+		f.setPolicy(t, ec2AuthzStatement("Allow",
+			ec2AuthzSubnetWildcardARN, ec2AuthzSGWildcardARN, ec2AuthzENIARN, ec2AuthzInstARN))
+		require.NoError(t, f.launch(t, params),
+			"a launch naming no AMI requires no image ARN, so these four suffice")
 	})
 }
 
@@ -531,7 +568,10 @@ func TestEC2_Authz_NestedNetworkInterfaceFormResolves(t *testing.T) {
 
 		// And the wildcard is not also evaluated: a policy naming the specific ENI
 		// suffices, so an existing interface does not require network-interface/*.
-		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, eniARN, ec2AuthzInstARN))
+		// The two default-VPC wildcards join it, because the interface carries no
+		// subnet and the launch has none of its own (#673).
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, eniARN, ec2AuthzInstARN,
+			ec2AuthzSubnetWildcardARN, ec2AuthzSGWildcardARN))
 		require.NoError(t, f.launch(t, byID))
 	})
 }
@@ -628,7 +668,10 @@ func TestEC2_Authz_LaunchTemplateResourcesAreAuthorized(t *testing.T) {
 		// The decision must not turn that into AccessDenied, so an unreadable template
 		// adds no resources rather than failing the request.
 		f := newFixture(t)
-		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzENIARN, ec2AuthzInstARN))
+		// Contributing nothing leaves the launch with no subnet of its own, so the
+		// default-VPC wildcards apply as they would to any subnet-less launch (#673).
+		f.setPolicy(t, ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzENIARN, ec2AuthzInstARN,
+			ec2AuthzSubnetWildcardARN, ec2AuthzSGWildcardARN))
 		require.NoError(t, f.launch(t, map[string]string{
 			"ImageId":                           ec2AuthzAMI,
 			"MinCount":                          "1",

--- a/emulator/ec2_default_vpc_refusal_test.go
+++ b/emulator/ec2_default_vpc_refusal_test.go
@@ -1,0 +1,140 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #673's second half: a launch refused for a bad security group leaves no default VPC
+// behind.
+//
+// runInstancesWithTags validated security-group *membership*, which needs the target
+// subnet's VPC — so the check sat below the ensureDefaultVPC branch, and a launch that
+// omitted SubnetId committed a VPC, a subnet, a security group, an internet gateway, a
+// route table and four index mutations before being refused. Two of those writes
+// swallow their own errors, so the state a refused request left behind was not even
+// guaranteed to be complete.
+//
+// The fix splits the check in two: existence needs nothing and runs before the first
+// write, membership keeps its place. This is reachable with no IAM configured at all,
+// so it stands on its own regardless of the authorization change beside it.
+func TestEC2_DefaultVPC_BadSecurityGroupRefusalWritesNothing(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	status, code, msg := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":            "RunInstances",
+		"ImageId":           "ami-0abcdef1234567890",
+		"MinCount":          "1",
+		"MaxCount":          "1",
+		"SecurityGroupId.1": "sg-0000000000000dead",
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidGroup.NotFound", code)
+	assert.Equal(t, "The security group 'sg-0000000000000dead' does not exist", msg,
+		"the message is unchanged; only when it is decided moved")
+
+	// Nothing the launch would have created exists. DescribeSecurityGroups is included
+	// because ensureDefaultVPC's third write is the default group itself.
+	resp := ec2Request(t, ts, map[string]string{"Action": "DescribeVpcs"})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var vpcs struct {
+		Items []struct{} `xml:"vpcSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &vpcs), string(body))
+	assert.Empty(t, vpcs.Items, "a refused launch creates no default VPC")
+
+	resp = ec2Request(t, ts, map[string]string{"Action": "DescribeSubnets"})
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var subnets struct {
+		Items []struct{} `xml:"subnetSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &subnets), string(body))
+	assert.Empty(t, subnets.Items, "and no default subnet")
+
+	resp = ec2Request(t, ts, map[string]string{"Action": "DescribeSecurityGroups"})
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var groups struct {
+		Items []struct{} `xml:"securityGroupInfo>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &groups), string(body))
+	assert.Empty(t, groups.Items, "and no default security group")
+
+	resp = ec2Request(t, ts, map[string]string{"Action": "DescribeInstances"})
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var instances struct {
+		Items []struct{} `xml:"reservationSet>item>instancesSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &instances), string(body))
+	assert.Empty(t, instances.Items, "and no instance")
+}
+
+// TestEC2_DefaultVPC_MembershipStillRefusedAfterResolution pins the half of the check
+// that could not move: a group that exists but lives in another VPC.
+//
+// Membership needs the target subnet's VPC, so it can only be decided once the subnet
+// is known. Splitting existence out must not weaken it — a launch into the default VPC
+// naming a group from a VPC of the caller's own is still refused, just later, and by
+// then the default VPC legitimately exists because the launch was going to use it.
+func TestEC2_DefaultVPC_MembershipStillRefusedAfterResolution(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	// A VPC of the caller's own, with a group inside it. This is not the default VPC:
+	// CreateVpc does not set isDefault.
+	resp := ec2Request(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.0.0.0/16"})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var created struct {
+		VPCID string `xml:"vpc>vpcId"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &created), string(body))
+	require.NotEmpty(t, created.VPCID)
+
+	resp = ec2Request(t, ts, map[string]string{
+		"Action":      "CreateSecurityGroup",
+		"GroupName":   "elsewhere",
+		"Description": "a group in a VPC no launch below uses",
+		"VpcId":       created.VPCID,
+	})
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var group struct {
+		GroupID string `xml:"groupId"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &group), string(body))
+	require.NotEmpty(t, group.GroupID)
+
+	_, code, msg := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":            "RunInstances",
+		"ImageId":           "ami-0abcdef1234567890",
+		"MinCount":          "1",
+		"MaxCount":          "1",
+		"SecurityGroupId.1": group.GroupID,
+	})
+	assert.Equal(t, "InvalidGroup.NotFound", code)
+	assert.Contains(t, msg, group.GroupID)
+	assert.Contains(t, msg, "does not belong to VPC",
+		"the membership message is the second one, unchanged by the split")
+}

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -293,6 +293,12 @@ func (p *EC2Plugin) createFleet(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 		return nil, awsErr
 	}
 
+	// Every pool is authorized before the first one launches, so a fleet the policy
+	// refuses leaves no instances behind (#673).
+	if err := p.authorizeFleetLaunches(reqCtx, pools, gotPerPool); err != nil {
+		return nil, err
+	}
+
 	fleet := EC2Fleet{
 		FleetID:                   generateFleetID(),
 		FleetState:                "active",
@@ -437,20 +443,50 @@ func distributeAcrossPools(n, pools int) []int {
 	return out
 }
 
-// launchFleetPool launches count instances for one pool by dispatching through
-// runInstances, and returns the resulting instance IDs. Going through
-// runInstances (rather than writing instance state directly) is what makes fleet
-// instances indistinguishable from directly-launched ones to DescribeInstances.
+// authorizeFleetLaunches checks the caller's permission to run each pool's
+// instances, before any of them launch.
 //
-// fleetID is stamped on every instance as [ec2FleetIDTagKey], which is what lets a
-// caller get from a fleet back to its instances at all (#443).
-func (p *EC2Plugin) launchFleetPool(
-	reqCtx *RequestContext,
-	pool fleetPool,
-	count int,
-	instanceTags []EC2Tag,
-	fleetID string,
-) ([]string, error) {
+// CreateFleet launches through [EC2Plugin.runInstancesWithTags], which the server's
+// authorization pipeline never sees: the pipeline decides the CreateFleet request
+// the caller sent, not the RunInstances requests the fleet synthesizes. Without this
+// a caller denied ec2:RunInstances on a subnet reached it by asking for a fleet
+// instead, which is not what real AWS answers — its CreateFleet reference requires
+// permission for the launch's own resources (#673). The in-repo precedent is
+// [StackDeployer.dispatch], which authorizes the requests a stack synthesizes for
+// the same reason.
+//
+// Every pool is decided before the first launch, so a refusal writes nothing at all
+// rather than leaving the pools ahead of it behind.
+//
+// The request handed to CheckAccess is [ec2FleetLaunchRequest], the same builder the
+// launch itself uses, so the decision cannot be made about a request other than the
+// one that runs.
+//
+// A nil controller or a nil principal is not enforced, matching CloudFormation: the
+// controller is absent unless [WithPluginAuth] wired one, and substrate's own
+// internal callers carry no principal.
+func (p *EC2Plugin) authorizeFleetLaunches(reqCtx *RequestContext, pools []fleetPool, gotPerPool []int) error {
+	if p.auth == nil || reqCtx.Principal == nil {
+		return nil
+	}
+	for i, pool := range pools {
+		if gotPerPool[i] <= 0 {
+			continue
+		}
+		if err := p.auth.CheckAccess(reqCtx, ec2FleetLaunchRequest(pool, gotPerPool[i])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ec2FleetLaunchRequest is the RunInstances request one fleet pool launches.
+//
+// It is built here rather than inline so the authorization decision and the launch
+// are made from the same request. CreateFleet authorizes every pool before launching
+// any of them, and a second construction site would eventually be authorized as one
+// launch and executed as another (#673).
+func ec2FleetLaunchRequest(pool fleetPool, count int) *AWSRequest {
 	params := map[string]string{
 		"Action":   "RunInstances",
 		"MinCount": strconv.Itoa(count),
@@ -489,6 +525,32 @@ func (p *EC2Plugin) launchFleetPool(
 	if pool.override.AvailabilityZone != "" {
 		params["Placement.AvailabilityZone"] = pool.override.AvailabilityZone
 	}
+	return &AWSRequest{
+		Service:   "ec2",
+		Operation: "RunInstances",
+		Params:    params,
+		Headers:   map[string]string{},
+	}
+}
+
+// launchFleetPool launches count instances for one pool by dispatching through
+// runInstances, and returns the resulting instance IDs. Going through
+// runInstances (rather than writing instance state directly) is what makes fleet
+// instances indistinguishable from directly-launched ones to DescribeInstances.
+//
+// fleetID is stamped on every instance as [ec2FleetIDTagKey], which is what lets a
+// caller get from a fleet back to its instances at all (#443).
+//
+// The launch is not authorized here. [EC2Plugin.authorizeFleetLaunches] does it for
+// every pool before the first one launches, so a refused fleet leaves no instances
+// behind.
+func (p *EC2Plugin) launchFleetPool(
+	reqCtx *RequestContext,
+	pool fleetPool,
+	count int,
+	instanceTags []EC2Tag,
+	fleetID string,
+) ([]string, error) {
 	// The caller's tags travel as already-parsed values rather than as re-emitted
 	// TagSpecification.N params, so the fleet-ID tag can be appended without hunting
 	// for a free index — and, more to the point, without riding the request-tag path
@@ -502,12 +564,7 @@ func (p *EC2Plugin) launchFleetPool(
 		})
 	}
 
-	resp, err := p.runInstancesWithTags(reqCtx, &AWSRequest{
-		Service:   "ec2",
-		Operation: "RunInstances",
-		Params:    params,
-		Headers:   map[string]string{},
-	}, tags)
+	resp, err := p.runInstancesWithTags(reqCtx, ec2FleetLaunchRequest(pool, count), tags)
 	if err != nil {
 		return nil, err
 	}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -28,6 +28,11 @@ type EC2Plugin struct {
 	state  StateManager
 	logger Logger
 	tc     *TimeController
+	// auth authorizes the launches CreateFleet dispatches through the plugin's own
+	// RunInstances path, which never passes through the server's check. nil for a
+	// registry built without [WithPluginAuth], in which case a fleet launches exactly
+	// as it did before (#673).
+	auth *AuthController
 }
 
 // Name returns the service name "ec2".
@@ -41,6 +46,9 @@ func (p *EC2Plugin) Initialize(_ context.Context, cfg PluginConfig) error {
 		p.tc = tc
 	} else {
 		p.tc = NewTimeController(time.Now())
+	}
+	if auth, ok := cfg.Options["auth_controller"].(*AuthController); ok {
+		p.auth = auth
 	}
 	return nil
 }
@@ -542,6 +550,20 @@ func (p *EC2Plugin) runInstancesWithTags(
 		return nil, awsErr
 	}
 
+	// The groups the request or its template named are checked for existence here,
+	// before the ensureDefaultVPC branch below writes anything (#673). The membership
+	// check has to wait for the subnet's VPC, but existence does not, and a launch
+	// naming a group that does not exist was previously refused *after* nine records
+	// had been committed — a VPC, subnet, security group, internet gateway, route
+	// table and four index mutations, two of them swallowing their own failures. A
+	// refusal that leaves a default VPC behind is worse than no check at all, because
+	// the next request in the same test sees state the refused one created. Reachable
+	// with no IAM configured, so this stands on its own regardless of the
+	// authorization change beside it.
+	if awsErr := p.ec2CheckSecurityGroups(reqCtx, securityGroupIDs, ""); awsErr != nil {
+		return nil, awsErr
+	}
+
 	// Auto-create default VPC/subnet if none specified.
 	if subnetID == "" {
 		vpc, subnet, err := p.ensureDefaultVPC(context.Background(), reqCtx)
@@ -550,17 +572,10 @@ func (p *EC2Plugin) runInstancesWithTags(
 		}
 		subnetID = subnet.SubnetID
 		if sgID == "" {
-			// Use the default security group.
-			sgIDs, listErr := p.state.List(context.Background(), ec2Namespace, "sg:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
-			if listErr == nil && len(sgIDs) > 0 {
-				data, getErr := p.state.Get(context.Background(), ec2Namespace, sgIDs[0])
-				if getErr == nil && data != nil {
-					var sg EC2SecurityGroup
-					if json.Unmarshal(data, &sg) == nil && sg.VPCID == vpc.VPCID {
-						sgID = sg.GroupID
-					}
-				}
-			}
+			// Use the default security group — the same lookup the authorization
+			// decision makes, so the group this launch attaches is the group its
+			// policy was evaluated against (#673).
+			sgID = ec2LookupDefaultSecurityGroup(context.Background(), p.state, reqCtx, vpc.VPCID)
 		}
 	}
 
@@ -582,26 +597,11 @@ func (p *EC2Plugin) runInstancesWithTags(
 		}
 	}
 
-	// Validate security groups exist and belong to the target VPC.
-	for _, id := range securityGroupIDs {
-		sgData, sgErr := p.state.Get(context.Background(), ec2Namespace, "sg:"+reqCtx.AccountID+"/"+reqCtx.Region+"/"+id)
-		if sgErr != nil || sgData == nil {
-			return nil, &AWSError{
-				Code:       "InvalidGroup.NotFound",
-				Message:    "The security group '" + id + "' does not exist",
-				HTTPStatus: http.StatusBadRequest,
-			}
-		}
-		if targetVPCID != "" {
-			var sg EC2SecurityGroup
-			if json.Unmarshal(sgData, &sg) == nil && sg.VPCID != targetVPCID {
-				return nil, &AWSError{
-					Code:       "InvalidGroup.NotFound",
-					Message:    "The security group '" + id + "' does not belong to VPC '" + targetVPCID + "'",
-					HTTPStatus: http.StatusBadRequest,
-				}
-			}
-		}
+	// Validate security groups exist and belong to the target VPC. The existence half
+	// ran above, before the default VPC could be created; this pass adds the
+	// membership half and covers the default group the branch above may have supplied.
+	if awsErr := p.ec2CheckSecurityGroups(reqCtx, securityGroupIDs, targetVPCID); awsErr != nil {
+		return nil, awsErr
 	}
 
 	reservationID := generateReservationID()
@@ -2876,48 +2876,142 @@ func ec2KeyFingerprint(derBytes []byte) string {
 
 // --- Helper functions ---
 
-// ensureDefaultVPC creates the default VPC and subnet if they don't already
-// exist for the given account/region.
-func (p *EC2Plugin) ensureDefaultVPC(ctx context.Context, reqCtx *RequestContext) (*EC2VPC, *EC2Subnet, error) {
-	// Check for existing default VPC.
-	vpcKeys, err := p.state.List(ctx, ec2Namespace, "vpc:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+// ec2LookupDefaultVPC returns the account and region's default VPC and that VPC's
+// default subnet, reading state without writing any of it.
+//
+// It is a free function taking a [StateManager] for the same reason
+// [ec2LookupLaunchTemplate] is one: the authorization decision needs it, and
+// CheckAccess runs before the handler and has no plugin to call a method on. A
+// launch that omits SubnetId is authorized against the subnet it will actually land
+// in, which is only knowable by reading the default VPC first (#673).
+//
+// The read is split out from [EC2Plugin.ensureDefaultVPC] rather than shared with
+// it, because that one *creates* what it does not find — nine records, two of them
+// swallowing their own failures. Calling it from the authorizer would let an
+// unauthorized request create a VPC, which is the opposite of what authorizing
+// early is for.
+//
+// A nil subnet with a non-nil VPC means the default VPC exists but has no default
+// subnet: the caller decides whether to create one (the handler) or treat the
+// subnet as one this launch will mint (the authorizer). Both nil means there is no
+// default VPC yet. A state error is returned rather than reported as "no default
+// VPC", so the handler still fails instead of creating a second one.
+func ec2LookupDefaultVPC(ctx context.Context, state StateManager, reqCtx *RequestContext) (*EC2VPC, *EC2Subnet, error) {
+	vpcKeys, err := state.List(ctx, ec2Namespace, "vpc:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
-		return nil, nil, fmt.Errorf("ec2 ensureDefaultVPC list vpcs: %w", err)
+		return nil, nil, fmt.Errorf("ec2 lookupDefaultVPC list vpcs: %w", err)
 	}
 	for _, k := range vpcKeys {
-		data, getErr := p.state.Get(ctx, ec2Namespace, k)
+		data, getErr := state.Get(ctx, ec2Namespace, k)
 		if getErr != nil || data == nil {
 			continue
 		}
 		var vpc EC2VPC
-		if json.Unmarshal(data, &vpc) == nil && vpc.IsDefault {
-			// Found existing default VPC. Find its default subnet.
-			subnetKeys, listErr := p.state.List(ctx, ec2Namespace, "subnet:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
-			if listErr != nil {
-				return nil, nil, fmt.Errorf("ec2 ensureDefaultVPC list subnets: %w", listErr)
-			}
-			for _, sk := range subnetKeys {
-				sdata, sErr := p.state.Get(ctx, ec2Namespace, sk)
-				if sErr != nil || sdata == nil {
-					continue
-				}
-				var subnet EC2Subnet
-				if json.Unmarshal(sdata, &subnet) == nil && subnet.VPCID == vpc.VPCID && subnet.IsDefault {
-					return &vpc, &subnet, nil
-				}
-			}
-			// No default subnet found; create one.
-			subnet, createErr := p.createDefaultSubnet(ctx, reqCtx, &vpc)
-			if createErr != nil {
-				return nil, nil, createErr
-			}
-			return &vpc, subnet, nil
+		if json.Unmarshal(data, &vpc) != nil || !vpc.IsDefault {
+			continue
 		}
+		subnetKeys, listErr := state.List(ctx, ec2Namespace, "subnet:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+		if listErr != nil {
+			return nil, nil, fmt.Errorf("ec2 lookupDefaultVPC list subnets: %w", listErr)
+		}
+		for _, sk := range subnetKeys {
+			sdata, sErr := state.Get(ctx, ec2Namespace, sk)
+			if sErr != nil || sdata == nil {
+				continue
+			}
+			var subnet EC2Subnet
+			if json.Unmarshal(sdata, &subnet) == nil && subnet.VPCID == vpc.VPCID && subnet.IsDefault {
+				return &vpc, &subnet, nil
+			}
+		}
+		return &vpc, nil, nil
+	}
+	return nil, nil, nil
+}
+
+// ec2LookupDefaultSecurityGroup returns the ID of the security group a launch that
+// named none falls back to, or "" when none resolves.
+//
+// Shared between the launch handler and the authorization decision so the group the
+// launch attaches and the group its policy is evaluated against cannot differ. The
+// rule is deliberately the handler's own, unchanged: the first security-group key in
+// the account and region, and only if it belongs to vpcID. That is narrower than
+// "the group named default" — a launch in an account whose lexicographically first
+// group lives in another VPC attaches no group at all — but widening it would change
+// what a launch attaches, which is a separate question from what it is authorized
+// against.
+func ec2LookupDefaultSecurityGroup(ctx context.Context, state StateManager, reqCtx *RequestContext, vpcID string) string {
+	sgKeys, err := state.List(ctx, ec2Namespace, "sg:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+	if err != nil || len(sgKeys) == 0 {
+		return ""
+	}
+	data, getErr := state.Get(ctx, ec2Namespace, sgKeys[0])
+	if getErr != nil || data == nil {
+		return ""
+	}
+	var sg EC2SecurityGroup
+	if json.Unmarshal(data, &sg) != nil || sg.VPCID != vpcID {
+		return ""
+	}
+	return sg.GroupID
+}
+
+// ec2CheckSecurityGroups refuses a launch naming a security group that does not
+// exist, or one that exists in a VPC other than vpcID.
+//
+// vpcID is "" for an existence-only pass, which is what lets a launch be refused
+// before the default VPC is created: membership needs the subnet's VPC and the
+// subnet may not exist yet, but existence needs nothing (#673). A group substrate's
+// own default-VPC branch supplied is checked by the second pass, where vpcID is
+// known.
+func (p *EC2Plugin) ec2CheckSecurityGroups(reqCtx *RequestContext, ids []string, vpcID string) *AWSError {
+	for _, id := range ids {
+		key := "sg:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + id
+		sgData, sgErr := p.state.Get(context.Background(), ec2Namespace, key)
+		if sgErr != nil || sgData == nil {
+			return &AWSError{
+				Code:       "InvalidGroup.NotFound",
+				Message:    "The security group '" + id + "' does not exist",
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+		if vpcID == "" {
+			continue
+		}
+		var sg EC2SecurityGroup
+		if json.Unmarshal(sgData, &sg) == nil && sg.VPCID != vpcID {
+			return &AWSError{
+				Code:       "InvalidGroup.NotFound",
+				Message:    "The security group '" + id + "' does not belong to VPC '" + vpcID + "'",
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+	}
+	return nil
+}
+
+// ensureDefaultVPC creates the default VPC and subnet if they don't already
+// exist for the given account/region.
+func (p *EC2Plugin) ensureDefaultVPC(ctx context.Context, reqCtx *RequestContext) (*EC2VPC, *EC2Subnet, error) {
+	vpc, subnet, err := ec2LookupDefaultVPC(ctx, p.state, reqCtx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if vpc != nil {
+		if subnet != nil {
+			return vpc, subnet, nil
+		}
+		// The default VPC exists but has no default subnet; create one.
+		created, createErr := p.createDefaultSubnet(ctx, reqCtx, vpc)
+		if createErr != nil {
+			return nil, nil, createErr
+		}
+		return vpc, created, nil
 	}
 
 	// Create default VPC.
 	vpcID := generateVPCID()
-	vpc := EC2VPC{
+	created := EC2VPC{
 		VPCID:              vpcID,
 		CIDRBlock:          "172.31.0.0/16",
 		IsDefault:          true,
@@ -2927,7 +3021,7 @@ func (p *EC2Plugin) ensureDefaultVPC(ctx context.Context, reqCtx *RequestContext
 		AccountID:          reqCtx.AccountID,
 		Region:             reqCtx.Region,
 	}
-	vpcData, _ := json.Marshal(vpc)
+	vpcData, _ := json.Marshal(created)
 	vpcKey := "vpc:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + vpcID
 	if err := p.state.Put(ctx, ec2Namespace, vpcKey, vpcData); err != nil {
 		return nil, nil, fmt.Errorf("ec2 ensureDefaultVPC create vpc: %w", err)
@@ -2977,11 +3071,11 @@ func (p *EC2Plugin) ensureDefaultVPC(ctx context.Context, reqCtx *RequestContext
 		p.logger.Warn("ec2: failed to create default route table", "err", rtErr)
 	}
 
-	subnet, err := p.createDefaultSubnet(ctx, reqCtx, &vpc)
+	subnet, err = p.createDefaultSubnet(ctx, reqCtx, &created)
 	if err != nil {
 		return nil, nil, err
 	}
-	return &vpc, subnet, nil
+	return &created, subnet, nil
 }
 
 func (p *EC2Plugin) createDefaultSubnet(ctx context.Context, reqCtx *RequestContext, vpc *EC2VPC) (*EC2Subnet, error) {

--- a/emulator/plugins.go
+++ b/emulator/plugins.go
@@ -21,14 +21,19 @@ type registerPluginsSettings struct {
 	auth *AuthController
 }
 
-// WithPluginAuth gives the CloudFormation plugin the controller that authorizes the
-// resource calls a stack deployment makes.
+// WithPluginAuth gives a plugin that dispatches requests of its own the controller
+// that authorizes them.
 //
-// Only CloudFormation takes it, and only because it is the one plugin that
-// dispatches requests of its own: every other plugin's calls arrive through the
-// server, which authorizes them before routing. Without this a stack's resource
-// calls are dispatched unauthorized, which is what they always were — the gap that
-// made a template asking for a permission it did not have deploy cleanly.
+// Two plugins take it, and both for the same reason: their calls do not arrive
+// through the server, which is where every other request is authorized before
+// routing. CloudFormation dispatches a stack's resource calls, and without this a
+// template asking for a permission it did not have deployed cleanly. EC2's
+// CreateFleet launches instances by calling its own RunInstances path, and without
+// this a fleet launched resources no policy was consulted about — the guardrail a
+// caller wrote for RunInstances was bypassed by asking for a fleet instead (#673).
+//
+// A plugin holding the controller still authorizes only requests carrying a
+// principal, so substrate's own unenforced built-in caller is unaffected.
 func WithPluginAuth(auth *AuthController) RegisterPluginsOption {
 	return func(s *registerPluginsSettings) {
 		s.auth = auth
@@ -134,10 +139,16 @@ func RegisterDefaultPlugins(
 	registry.Register(dynamodbPlugin)
 
 	ec2Plugin := &EC2Plugin{}
+	ec2Opts := map[string]any{"time_controller": tc}
+	if settings.auth != nil {
+		// CreateFleet launches through EC2's own RunInstances path rather than through
+		// the server, so the fleet's launches are authorized by the plugin itself.
+		ec2Opts["auth_controller"] = settings.auth
+	}
 	if err := ec2Plugin.Initialize(ctx, PluginConfig{
 		State:   state,
 		Logger:  logger,
-		Options: map[string]any{"time_controller": tc},
+		Options: ec2Opts,
 	}); err != nil {
 		return fmt.Errorf("initialize ec2 plugin: %w", err)
 	}

--- a/test/e2e/journey_ec2_default_vpc_authz_test.go
+++ b/test/e2e/journey_ec2_default_vpc_authz_test.go
@@ -1,0 +1,399 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/smithy-go"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+const (
+	journeyDefaultVPCRegion  = "us-east-1"
+	journeyDefaultVPCAccount = "123456789012"
+	journeyDefaultVPCAMI     = "ami-0abcdef1234567890"
+)
+
+// journeyGuardedEC2 creates an IAM user with an access key and returns an EC2 client
+// signing as it, plus a function that rewrites its inline policy.
+//
+// A real IAM user is what makes any of this meaningful: the built-in AKIA key resolves
+// to no principal, and an unenforced caller would make every assertion below pass
+// regardless of policy.
+func journeyGuardedEC2(
+	t *testing.T,
+	ctx context.Context,
+	ts *emulator.TestServer,
+	iamClient *iam.Client,
+	userName string,
+) (*ec2.Client, func(document string)) {
+	t.Helper()
+	user, err := iamClient.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String(userName)})
+	if err != nil {
+		t.Fatalf("CreateUser %s: %v", userName, err)
+	}
+	putPolicy := func(document string) {
+		t.Helper()
+		if _, policyErr := iamClient.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+			UserName:       user.User.UserName,
+			PolicyName:     aws.String("guardrail"),
+			PolicyDocument: aws.String(document),
+		}); policyErr != nil {
+			t.Fatalf("PutUserPolicy: %v", policyErr)
+		}
+	}
+	key, err := iamClient.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{UserName: user.User.UserName})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(journeyDefaultVPCRegion),
+		config.WithBaseEndpoint(ts.URL),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			aws.ToString(key.AccessKey.AccessKeyId),
+			aws.ToString(key.AccessKey.SecretAccessKey), "")),
+		config.WithHTTPClient(&http.Client{}),
+	)
+	if err != nil {
+		t.Fatalf("%s config: %v", userName, err)
+	}
+	return ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 }), putPolicy
+}
+
+// journeyDeniedResource returns the ARN an EC2 AccessDenied names, failing the test if
+// err is not one.
+//
+// EC2 models no exception shapes, so the refusal arrives as a generic smithy.APIError
+// whose ErrorCode a consumer branches on. The message is the only place the refused
+// resource surfaces, which is what makes a least-privilege policy writable by
+// iteration rather than by guesswork.
+func journeyDeniedResource(t *testing.T, err error) string {
+	t.Helper()
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("got %T (%v), want an API error", err, err)
+	}
+	if apiErr.ErrorCode() != "AccessDenied" {
+		t.Fatalf("ErrorCode() = %q, want AccessDenied", apiErr.ErrorCode())
+	}
+	msg := apiErr.ErrorMessage()
+	const marker = "on resource: "
+	i := strings.Index(msg, marker)
+	if i < 0 {
+		t.Fatalf("the denial does not name a resource: %s", msg)
+	}
+	return strings.TrimSpace(msg[i+len(marker):])
+}
+
+// TestJourney_EC2DefaultVPCSubnetGuardrail is #673 at the tier the guardrail is
+// written at: a launch that omits SubnetId.
+//
+// Substrate resolves such a launch's subnet and security group from the default VPC,
+// creating them if the account has none — and until #673 that happened *after* the
+// authorization decision, so the decision named neither. A policy scoped to one subnet
+// therefore permitted a launch into a subnet it never mentioned, which is precisely
+// what a subnet guardrail exists to prevent. Every getting-started example and most
+// CDK-generated launches take exactly this shape.
+//
+// AWS's own Service Authorization Reference points the other way — its RunInstances
+// scenario rows require subnet* only in the -Subnet scenarios, and its recommended
+// subnet guardrail is the ec2:Subnet condition key on network-interface/* — so this is
+// substrate's reading, made because a guardrail a caller defeats by omitting a
+// parameter is useless for the purpose substrate exists for.
+func TestJourney_EC2DefaultVPCSubnetGuardrail(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	adminCfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	admin := ec2.NewFromConfig(adminCfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	iamClient := iam.NewFromConfig(adminCfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	// A subnet of the caller's own, in a VPC CreateVpc does not mark as default. No
+	// security group is created: once the default VPC exists, its own group is then the
+	// only one in the account, which is what makes the default-group lookup below
+	// resolve to a known ID rather than to whichever group sorts first.
+	vpc, err := admin.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+	approved, err := admin.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     vpc.Vpc.VpcId,
+		CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+	approvedSubnet := aws.ToString(approved.Subnet.SubnetId)
+
+	arn := func(format string) string {
+		return "arn:aws:ec2:" + journeyDefaultVPCRegion + ":" + journeyDefaultVPCAccount + ":" + format
+	}
+	imageARN := "arn:aws:ec2:" + journeyDefaultVPCRegion + "::image/" + journeyDefaultVPCAMI
+	allow := func(resources ...string) string {
+		return `{"Version":"2012-10-17","Statement":[` +
+			`{"Effect":"Allow","Action":"ec2:RunInstances","Resource":["` +
+			strings.Join(resources, `","`) + `"]}]}`
+	}
+
+	launcher, putPolicy := journeyGuardedEC2(t, ctx, ts, iamClient, "subnetless-launcher")
+	launch := func(client *ec2.Client) (*ec2.RunInstancesOutput, error) {
+		return client.RunInstances(ctx, &ec2.RunInstancesInput{
+			ImageId:      aws.String(journeyDefaultVPCAMI),
+			InstanceType: ec2types.InstanceTypeT3Micro,
+			MinCount:     aws.Int32(1),
+			MaxCount:     aws.Int32(1),
+		})
+	}
+
+	// --- the fail-before: a policy allowing exactly one subnet ---
+	//
+	// Generous about security groups and strict about subnets, so the only thing the
+	// policy withholds is a subnet other than the approved one. This launch used to
+	// succeed: it resolved to the literal "*", which matches only a statement whose own
+	// Resource starts with "*", so no ARN in this policy was ever compared against it.
+	putPolicy(allow(imageARN, arn("subnet/"+approvedSubnet), arn("security-group/*"),
+		arn("network-interface/*"), arn("instance/*")))
+
+	_, err = launch(launcher)
+	if got := journeyDeniedResource(t, err); got != arn("subnet/*") {
+		t.Errorf("the denial names %q, want the default subnet the launch would create, %q",
+			got, arn("subnet/*"))
+	}
+	if got := journeyEC2InstanceCount(t, ctx, admin); got != 0 {
+		t.Fatalf("after the refusal there are %d instances, want 0", got)
+	}
+	// And no default VPC was created on the way to the refusal, which authorization
+	// running before the handler is what guarantees.
+	vpcs, err := admin.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{})
+	if err != nil {
+		t.Fatalf("DescribeVpcs: %v", err)
+	}
+	if len(vpcs.Vpcs) != 1 {
+		t.Fatalf("after the refusal there are %d VPCs, want only the caller's own", len(vpcs.Vpcs))
+	}
+
+	// --- naming the two wildcards permits it, and it creates the default VPC ---
+	//
+	// subnet/* and security-group/* are resources this launch will *create*, which is
+	// why they are wildcards on the same reasoning instance/* and network-interface/*
+	// already are.
+	putPolicy(allow(imageARN, arn("subnet/*"), arn("security-group/*"),
+		arn("network-interface/*"), arn("instance/*")))
+
+	if _, err = launch(launcher); err != nil {
+		t.Fatalf("a policy naming the wildcards the launch will create must permit it: %v", err)
+	}
+
+	// The default subnet and group the launch resolved, read back through the API
+	// rather than assumed — these are the ARNs a consumer would have to write.
+	described, err := admin.DescribeInstances(ctx, &ec2.DescribeInstancesInput{})
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+	if len(described.Reservations) != 1 || len(described.Reservations[0].Instances) != 1 {
+		t.Fatalf("want exactly one instance, got %+v", described.Reservations)
+	}
+	instance := described.Reservations[0].Instances[0]
+	defaultSubnet := aws.ToString(instance.SubnetId)
+	if defaultSubnet == "" || defaultSubnet == approvedSubnet {
+		t.Fatalf("the launch landed in %q, want a freshly created default subnet", defaultSubnet)
+	}
+	if len(instance.SecurityGroups) != 1 {
+		t.Fatalf("the instance carries %d security groups, want the default VPC's one",
+			len(instance.SecurityGroups))
+	}
+	defaultSG := aws.ToString(instance.SecurityGroups[0].GroupId)
+
+	// --- the guardrail: a Deny on the resolved default subnet ---
+	//
+	// "Launch anywhere except the default subnet", which omitting SubnetId used to be
+	// the way around.
+	defaultSubnetARN := arn("subnet/" + defaultSubnet)
+	putPolicy(`{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"ec2:*","Resource":"*"},` +
+		`{"Effect":"Deny","Action":"ec2:RunInstances","Resource":"` + defaultSubnetARN + `"}]}`)
+
+	_, err = launch(launcher)
+	if got := journeyDeniedResource(t, err); got != defaultSubnetARN {
+		t.Errorf("the denial names %q, want the default subnet %q", got, defaultSubnetARN)
+	}
+	if got := journeyEC2InstanceCount(t, ctx, admin); got != 1 {
+		t.Fatalf("the refused launch changed the instance count to %d, want 1", got)
+	}
+
+	// --- and a least-privilege policy naming what the launch resolves to works ---
+	//
+	// The other direction the fix has to hold in: making the ordinary subnet-less
+	// launch unrunnable under least privilege would be its own defect.
+	putPolicy(allow(imageARN, defaultSubnetARN, arn("security-group/"+defaultSG),
+		arn("network-interface/*"), arn("instance/*")))
+
+	run, err := launch(launcher)
+	if err != nil {
+		t.Fatalf("a policy naming the resolved default subnet and group must permit the launch: %v", err)
+	}
+	if got := aws.ToString(run.Instances[0].SubnetId); got != defaultSubnet {
+		t.Errorf("the instance landed in %q, want the default subnet %q", got, defaultSubnet)
+	}
+
+	// Dropping the security group from that policy refuses the launch and says so,
+	// which is what tells a caller the default group is part of the decision at all.
+	putPolicy(allow(imageARN, defaultSubnetARN, arn("network-interface/*"), arn("instance/*")))
+	_, err = launch(launcher)
+	if got := journeyDeniedResource(t, err); got != arn("security-group/"+defaultSG) {
+		t.Errorf("the denial names %q, want the default security group %q",
+			got, arn("security-group/"+defaultSG))
+	}
+}
+
+// TestJourney_EC2CreateFleetAuthorizesItsLaunches pins #673's second gap: the fleet
+// path.
+//
+// CreateFleet launches its instances internally, through runInstances rather than
+// through the API, so the server's authorization pipeline decided the CreateFleet
+// request and never the launches it produced. A caller denied ec2:RunInstances on a
+// subnet reached it by asking for a fleet instead. Real AWS does not answer that way —
+// its CreateFleet reference requires permission for the launch's own resources — so
+// the fleet path is authorized rather than exempted, using the same request builder the
+// launch itself uses so the decision cannot be about a different request.
+func TestJourney_EC2CreateFleetAuthorizesItsLaunches(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	adminCfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	admin := ec2.NewFromConfig(adminCfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	iamClient := iam.NewFromConfig(adminCfg, func(o *iam.Options) { o.RetryMaxAttempts = 1 })
+
+	vpc, err := admin.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+	subnet, err := admin.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     vpc.Vpc.VpcId,
+		CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+	subnetID := aws.ToString(subnet.Subnet.SubnetId)
+
+	lt, err := admin.CreateLaunchTemplate(ctx, &ec2.CreateLaunchTemplateInput{
+		LaunchTemplateName: aws.String("fleet-pool"),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
+			ImageId: aws.String(journeyDefaultVPCAMI),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateLaunchTemplate: %v", err)
+	}
+	ltID := aws.ToString(lt.LaunchTemplate.LaunchTemplateId)
+
+	arn := func(format string) string {
+		return "arn:aws:ec2:" + journeyDefaultVPCRegion + ":" + journeyDefaultVPCAccount + ":" + format
+	}
+	imageARN := "arn:aws:ec2:" + journeyDefaultVPCRegion + "::image/" + journeyDefaultVPCAMI
+
+	fleeter, putPolicy := journeyGuardedEC2(t, ctx, ts, iamClient, "fleeter")
+	createFleet := func() (*ec2.CreateFleetOutput, error) {
+		return fleeter.CreateFleet(ctx, &ec2.CreateFleetInput{
+			Type: ec2types.FleetTypeInstant,
+			LaunchTemplateConfigs: []ec2types.FleetLaunchTemplateConfigRequest{{
+				LaunchTemplateSpecification: &ec2types.FleetLaunchTemplateSpecificationRequest{
+					LaunchTemplateId: aws.String(ltID),
+					Version:          aws.String("1"),
+				},
+				Overrides: []ec2types.FleetLaunchTemplateOverridesRequest{{
+					InstanceType: ec2types.InstanceTypeT3Micro,
+					SubnetId:     aws.String(subnetID),
+				}},
+			}},
+			TargetCapacitySpecification: &ec2types.TargetCapacitySpecificationRequest{
+				TotalTargetCapacity:       aws.Int32(2),
+				DefaultTargetCapacityType: ec2types.DefaultTargetCapacityTypeOnDemand,
+			},
+		})
+	}
+
+	// --- ec2:CreateFleet alone is not enough ---
+	//
+	// This is the request that used to launch two instances. The denial names the
+	// launch's own first resource, the launch template's AMI, because that is what the
+	// synthesized RunInstances is decided against.
+	putPolicy(`{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"ec2:CreateFleet","Resource":"*"}]}`)
+
+	_, err = createFleet()
+	if got := journeyDeniedResource(t, err); got != imageARN {
+		t.Errorf("the denial names %q, want the launch's AMI %q", got, imageARN)
+	}
+	if got := journeyEC2InstanceCount(t, ctx, admin); got != 0 {
+		t.Fatalf("a refused fleet launched %d instances, want 0", got)
+	}
+	// And no fleet record either: every pool is decided before the first launch, so a
+	// refusal writes nothing at all.
+	fleets, err := admin.DescribeFleets(ctx, &ec2.DescribeFleetsInput{})
+	if err != nil {
+		t.Fatalf("DescribeFleets: %v", err)
+	}
+	if len(fleets.Fleets) != 0 {
+		t.Errorf("a refused fleet left %d fleet records behind, want 0", len(fleets.Fleets))
+	}
+
+	// --- a Deny scoped to the pool's subnet blocks the fleet ---
+	//
+	// The guardrail a consumer actually writes, now reachable through the fleet path.
+	subnetARN := arn("subnet/" + subnetID)
+	putPolicy(`{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"ec2:*","Resource":"*"},` +
+		`{"Effect":"Deny","Action":"ec2:RunInstances","Resource":"` + subnetARN + `"}]}`)
+
+	_, err = createFleet()
+	if got := journeyDeniedResource(t, err); got != subnetARN {
+		t.Errorf("the denial names %q, want the pool's subnet %q", got, subnetARN)
+	}
+	if got := journeyEC2InstanceCount(t, ctx, admin); got != 0 {
+		t.Fatalf("a refused fleet launched %d instances, want 0", got)
+	}
+
+	// --- permitting ec2:RunInstances on the launch's resources lets the fleet run ---
+	//
+	// Which is what real AWS requires, and the reason authorizing the path rather than
+	// exempting it is the right answer: the policy a consumer writes against AWS is the
+	// policy that works here.
+	putPolicy(`{"Version":"2012-10-17","Statement":[` +
+		`{"Effect":"Allow","Action":"ec2:CreateFleet","Resource":"*"},` +
+		`{"Effect":"Allow","Action":"ec2:RunInstances","Resource":["` +
+		strings.Join([]string{imageARN, subnetARN, arn("network-interface/*"), arn("instance/*")},
+			`","`) + `"]}]}`)
+
+	out, err := createFleet()
+	if err != nil {
+		t.Fatalf("a policy permitting the launch's resources must permit the fleet: %v", err)
+	}
+	launched := 0
+	for _, group := range out.Instances {
+		launched += len(group.InstanceIds)
+	}
+	if launched != 2 {
+		t.Errorf("the fleet launched %d instances, want 2", launched)
+	}
+	if got := journeyEC2InstanceCount(t, ctx, admin); got != 2 {
+		t.Errorf("DescribeInstances reports %d instances, want 2", got)
+	}
+}


### PR DESCRIPTION
Closes #673

A `RunInstances` that omits `SubnetId` does not run without a subnet — substrate resolves the default VPC's default subnet and default security group, creating them if the account has none. Until now that happened *after* `CheckAccess`, so the decision named neither: the launch resolved to the literal `"*"`, and `"*"` as a **request** resource matches only a statement whose own `Resource` starts with `"*"`, so no specific ARN in the policy was ever compared against it. A policy scoped to one subnet permitted a launch into a subnet it never mentioned, and "launch anywhere except the default subnet" was defeated by leaving the parameter out. That is the shape every getting-started example and most CDK-generated launches take.

### Resolve before authorizing

`ec2AuthzResolveLaunch` already makes this move for launch templates, and its comment records why: `CheckAccess` runs before the handler, so the authorizer resolves through a free function made free for exactly that reason. `ensureDefaultVPC` cannot be that function — it is a create-if-absent committing nine records, and calling it from the authorizer would let a request the policy is about to refuse create a VPC. So it is split into a read-only `ec2LookupDefaultVPC` and the create, with `ec2LookupDefaultSecurityGroup` beside it; the handler calls the same two, so the decision and the launch cannot disagree about where an instance lands.

Precedence: the default VPC applies only to a launch that nothing else gave a subnet. `resolveDefaultVPC` runs last, after the template merge, and yields to a request-named subnet, a nested interface's subnet and a template's subnet alike.

**A launch whose default VPC does not exist yet is decided against `subnet/*` and `security-group/*`.** This is not the skip-don't-widen case: that rule is about a resource the request *omits*, whereas this is a resource the request will **create** — which is precisely why `instance/*` and `network-interface/*` are already wildcards in the same file. A `Deny` on `subnet/*` still matches, and a least-privilege `Allow` naming one subnet correctly refuses a launch that will mint a different one. Substrate's fixtures all start from empty state, so this is the common case rather than a corner. A failed state read also resolves to the wildcards, so a storage fault cannot turn a guarded launch into an unguarded one.

One consequence worth stating: **`RunInstances` is no longer ever decided against the literal `"*"`.** Every launch names at least `instance/*`, and one that named nothing else still resolves its subnet, so `ec2AuthzLaunchMembers.empty()` became structurally unreachable. It is deleted rather than left as a branch nothing can reach, with a comment where the guard was.

### The fleet path is authorized, not exempted

`CreateFleet` launches through `runInstancesWithTags`, which the server's authorization pipeline never sees: the pipeline decides the `CreateFleet` request the caller sent, not the `RunInstances` requests the fleet synthesizes. A caller denied `ec2:RunInstances` on a subnet reached it by asking for a fleet instead. Real AWS does not answer that way — its `CreateFleet` reference requires permission for the launch's own resources — so `EC2Plugin` now holds the `*AuthController` (threaded through `WithPluginAuth`, whose doc comment asserting only CloudFormation takes one is rewritten) and authorizes **every pool before the first one launches**, so a refusal writes nothing at all rather than leaving the pools ahead of it behind. The request handed to `CheckAccess` is built by `ec2FleetLaunchRequest`, the same builder the launch itself uses. The in-repo precedent is `StackDeployer.dispatch`, which holds a controller for the same reason; like it, this is a no-op when no controller is wired or the principal is nil, so substrate's own internal callers are unaffected.

### The partial-write fix, which stands on its own

A launch that omitted `SubnetId` and named a nonexistent `SecurityGroupId` committed a VPC, a default security group, an internet gateway, a route table, a subnet and four index mutations before being refused — and two of those writes swallow their own errors, so the state a refused request left behind was not even guaranteed to be complete. Reachable with no IAM configured at all. Group **existence** needs nothing and now runs before the first write; **membership**, which needs the target subnet's VPC, keeps its place. Its own `### Fixed` line.

## Provenance

Authorizing a subnet-less launch against its default subnet is **substrate's reading, not AWS parity**, and `docs/services.md` says so: the Service Authorization Reference's `RunInstances` scenario rows require `subnet*` only in `EC2-VPC-EBS-Subnet` and `EC2-VPC-InstanceStore-Subnet`, and AWS's own recommended subnet guardrail is the `ec2:Subnet` condition key on `network-interface/*` (filed as a follow-up — it needs the same lookup this PR adds and would be substrate's first `ec2:`-prefixed condition key). The reading is made because a guardrail a caller defeats by omitting a parameter is useless for the purpose substrate exists for. The fleet half is the opposite: AWS's `CreateFleet` reference states the requirement outright.

## Verification

**Fail-before, at the tier each defect lives at** (mutate → run → restore, by file copy):

| Removed | Result |
|---|---|
| `m.resolveDefaultVPC(state, reqCtx)` | 5 unit test functions fail (9 subtest failures); the e2e journey fails at `journey_ec2_default_vpc_authz_test.go:171` with `got <nil> (<nil>), want an API error` |
| the fleet `CheckAccess` (`\|\| true` on its guard) | the fleet journey fails at `:342` with `got <nil>` |
| the security-group existence pre-check | the partial-write test fails on VPC, subnet **and** security group all non-empty |

**Mutation testing** — 7 mutants, green baseline, anchor count asserted over the whole file, `gofmt -w && go vet` so a non-compiling mutant is BROKEN rather than a result, full-package `go test -race -count=1 ./emulator/` plus the e2e module with no `-run` filter, restored and re-run green:

| # | Mutant | Verdict |
|---|---|---|
| M1 | `ec2LookupDefaultVPC` never recognizes a default VPC | KILLED (11) |
| M2 | the default subnet is never found, so the subnet stays a wildcard | KILLED (8) |
| M3 | the security-group existence pre-check never refuses | KILLED (1) |
| M4 | the fleet's launches are not authorized | KILLED (1, e2e only) |
| M5 | the default group is wildcarded even when the request named groups | KILLED (1) |
| M6 | the default group overwrites the groups the request named | KILLED (1) |
| M7 | the default VPC overrides a subnet the request or template supplied | KILLED (5) |

**M5 survived the first pass** and the test added to kill it is the interesting one. The obvious test — a `Deny` on `security-group/*` must not block a launch that named its own group — asserts nothing, because that pattern matches the named group's own ARN too and refuses the launch either way. The discriminator is a least-privilege `Allow` naming the group and **not** the wildcard: a specific ARN in a statement does not match a request resource of `security-group/*`.

**Live run** through the AWS CLI against `substrate server --address :4678` (`AWS_MAX_ATTEMPTS=1`, torn down with `lsof -ti:4678 | xargs kill`), which also confirms `main.go` already wires `WithPluginAuth`, so the fleet fix is live in the real server:

1. policy allowing one subnet → `AccessDenied … on resource: …:subnet/*`; 0 instances; still only the caller's 1 VPC
2. naming `subnet/*` + `security-group/*` → launches, creating `subnet-b347…` / `sg-3b44…`
3. `Deny` on the resolved default subnet → `AccessDenied … subnet/subnet-b347…`; instance count unchanged
4. least privilege naming both → launches, and lands in `subnet-b347…`
5. dropping the group → `AccessDenied … security-group/sg-3b44…`
6. `ec2:CreateFleet` alone → `AccessDenied … on resource: arn:aws:ec2:us-east-1::image/ami-0abcdef1234567890`; 0 new instances; **0 fleet records**
7. `Deny` on the pool's subnet → `AccessDenied … subnet/subnet-c74d…`; 0 new instances
8. adding `ec2:RunInstances` on the launch's resources → the fleet launches 2, both in the pool's subnet

**Gate**: `gofmt -l .` clean; `go build ./...`; `go vet ./...`; `golangci-lint run ./...` → 0 issues; `make test` (race) ok; `make coverage` total **82.1%** (emulator 82.8%); `make docs-reference-check docs-versions`; `go test -C test/e2e ./...` ok; `npm --prefix docs run build`.

## Compatibility

A `RunInstances` that omits `SubnetId` and was permitted by a subnet-scoped policy may now be denied — including the first launch in a fresh account, which is decided against `subnet/*`. A `CreateFleet` may now be denied unless the policy also permits `ec2:RunInstances` on the launch's own resources, which is what real AWS requires. Neither affects a caller with no IAM configured, or one whose policy allows `ec2:RunInstances` on `"*"`.
