### PR TITLE
chore(release): v0.105.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.105.0] - 2026-08-20
+
 ### Added
 - **An instance reports its own block devices, on all three surfaces that render them**
   (#669). `DescribeInstances`, `RunInstances` and `DescribeInstanceAttribute` now emit a
@@ -7433,7 +7435,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.103.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.105.0...HEAD
+[v0.105.0]: https://github.com/scttfrdmn/substrate/compare/v0.104.0...v0.105.0
 [v0.104.0]: https://github.com/scttfrdmn/substrate/compare/v0.103.0...v0.104.0
 [v0.103.0]: https://github.com/scttfrdmn/substrate/compare/v0.102.0...v0.103.0
 [v0.102.0]: https://github.com/scttfrdmn/substrate/compare/v0.101.0...v0.102.0


### PR DESCRIPTION
Dates the `## [v0.105.0]` section and adds its comparison link, per the release
procedure in CLAUDE.md. No behaviour change.

The `[Unreleased]` link was still pointing at `v0.103.0...HEAD`; it now points at
`v0.105.0...HEAD`.

v0.105.0 closes all six issues on milestone 90 — the EC2 launch-and-tag surface:
#669, #670, #671, #673, #674, #675.