### PR TITLE
fix(ec2): a valueless `tag:` filter on DescribeImages matches nothing (#686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`tag-key` on `DescribeImages`** (#686). AWS documents it for this operation and
+  substrate did not support it, so the name was silently dropped and the filter constrained
+  nothing. It is the any-value question — "images carrying an `Env` tag, whatever its
+  value" — and it had to arrive in the same change as the fix below, which takes away the
+  spelling callers were using for it by accident.
+
+### Fixed
+- **A `tag:<key>` filter with no value no longer matches any value on `DescribeImages`**
+  (#686). `Filter.1.Name=tag:Env` with no `Filter.1.Value.1` matched every image carrying an
+  `Env` tag, which is `tag-key`'s job — so this one operation answered a filter differently
+  from `DescribeInstances` and `DescribeVolumes`, which both match nothing. AWS settles
+  neither reading: `Using_Filtering` says only that "You can't specify a filter value of
+  null". Matching nothing is substrate's, and it is now substrate's answer everywhere rather
+  than at two of three sites.
+
+  **This is a behaviour change.** A caller relying on the valueless form to mean any-value
+  must switch to `tag-key`, which the same release adds.
+
+- **An explicitly empty filter value is a value on `DescribeImages`** (#686).
+  `Filter.1.Value.1=` asks for an image whose tag is the empty string, which is a different
+  request from naming no values at all. `describeImages` parsed `Filter.N` itself rather than
+  through the shared extractor, and its walk broke out of the value loop on the first empty
+  string — so the two requests arrived identical and the empty one inherited the
+  any-value rule above. Adopting `extractEC2Filters` fixes both defects at once and leaves
+  one filter parser in the plugin instead of two that disagreed.
+
+- **Two `Filter.N` entries sharing a name OR their values instead of the first being
+  discarded** (#686). `extractEC2Filters` keyed a map by filter name and overwrote, so a
+  caller who sent the same name twice got only the last one applied and no indication the
+  first had been dropped. AWS documents that filters are ANDed and the values within a
+  filter ORed, and says nothing about a repeated name; merging the value lists answers it as
+  an OR, which is substrate's reading. Overwriting was not a reading of anything.
+
+  This affects **every** EC2 describe that parses filters, not only `DescribeImages`.
+  Differently-named filters are ANDed, as documented, and are unchanged — a regression test
+  pins that, since adopting the shared extractor for `DescribeImages` is what put it at
+  risk.
+
+- **`DescribeImages` renders its tags through the package-level renderer** (#686), deleting
+  one of the EC2 plugin's three identical function-local `tagItem` copies. Nothing
+  observable changes — the shapes matched — but a fix to that shape now has one place to
+  land. `DescribeFleets` and `DescribeSnapshots` still carry theirs.
+
 ## [v0.105.0] - 2026-08-20
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -3976,6 +3976,33 @@ tags on the AMI instead. A caller asserting on `DescribeImages` tags that were
 actually snapshot-scoped will now see them on `DescribeSnapshots`, which is where
 real EC2 puts them.
 
+#### `DescribeImages` filters
+
+Four filter names are applied: `image-id`, `block-device-mapping.snapshot-id`,
+`tag:<key>` and `tag-key`. An unrecognized name is dropped, as on every other EC2
+describe. AWS documents thirty-odd more; the rest need state substrate does not keep.
+
+Two behaviour changes came with `tag-key`, both of which bring this operation into line
+with `DescribeInstances` and `DescribeVolumes` rather than leaving it with its own rules:
+
+- A **`tag:<key>` filter with no value now matches nothing**, where it previously matched
+  any value. That any-value question is what `tag-key` spells, which is why the filter had
+  to arrive in the same change — otherwise the correction would have removed the only way
+  to ask it. AWS settles neither shape: its filtering guide says only that a filter value
+  cannot be null, so matching nothing is substrate's reading, and it is now the same
+  reading everywhere.
+- An **explicitly empty filter value is a value**. `Filter.1.Value.1=` asks for an image
+  whose tag is the empty string; it previously arrived indistinguishable from naming no
+  values at all, because this operation parsed `Filter.N` itself and stopped at the first
+  empty string.
+
+Repeated filter names changed for **every** EC2 describe, not only this one: two
+`Filter.N` entries sharing a name now **OR their values** instead of the second silently
+replacing the first. AWS documents that filters are ANDed and the values within a filter
+ORed, and says nothing about a name appearing twice, so the merge is substrate's reading.
+What it replaces was not a reading of anything — the earlier entry was discarded with no
+indication. Differently-named filters are ANDed, as documented, and always were.
+
 ### Seeding EC2 Fleet partial fulfillment
 
 `CreateFleet` fulfills its whole `TotalTargetCapacity` by default. Partial

--- a/emulator/ec2_image_filters_test.go
+++ b/emulator/ec2_image_filters_test.go
@@ -1,0 +1,219 @@
+package emulator_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// DescribeImages' tag filters (#686).
+//
+// describeImages parsed Filter.N itself rather than through extractEC2Filters, and the
+// two disagreed in three ways that compounded:
+//
+//   - a tag: filter with no values matched any value, which is tag-key's job — and
+//     tag-key itself was unsupported, so the operation had the wrong spelling of the
+//     any-value question and not the right one;
+//   - the hand-rolled walk stopped at the first empty Filter.N.Value.M, so an
+//     explicitly empty filter value arrived as *no* values and silently became the
+//     any-value form; and
+//   - extractEC2Filters, which every other describe uses, overwrote a repeated filter
+//     name instead of accumulating its values, so a caller who sent the same name twice
+//     got only the last one applied and no indication the first was dropped.
+//
+// These tests pin all three, because the fix for the first is to adopt extractEC2Filters
+// and the other two are what adopting it would otherwise change or carry over.
+
+// ec2ImageFilterFixture registers two AMIs — one tagged Env=prod, one untagged — and
+// returns their IDs. Both are needed for every case: a filter that wrongly matches
+// everything and one that wrongly matches nothing are only distinguishable when the
+// fixture holds an image that should be excluded.
+func ec2ImageFilterFixture(t *testing.T, ts *httptest.Server) (tagged, untagged string) {
+	t.Helper()
+	instID := ec2TagTestInstance(t, ts)
+
+	tagged = ec2CreateImageID(t, ts, map[string]string{
+		"Action":                          "CreateImage",
+		"InstanceId":                      instID,
+		"Name":                            "tagged-ami",
+		"TagSpecification.1.ResourceType": "image",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	})
+	untagged = ec2CreateImageID(t, ts, map[string]string{
+		"Action":     "CreateImage",
+		"InstanceId": instID,
+		"Name":       "untagged-ami",
+	})
+	return tagged, untagged
+}
+
+// ec2CreateImageID sends a CreateImage request and returns the AMI ID it reports.
+func ec2CreateImageID(t *testing.T, ts *httptest.Server, params map[string]string) string {
+	t.Helper()
+	var res struct {
+		ImageID string `xml:"imageId"`
+	}
+	ec2FleetXML(t, ts, params, &res)
+	require.NotEmpty(t, res.ImageID)
+	return res.ImageID
+}
+
+// ec2FilteredImageIDs returns the image IDs DescribeImages reports for params.
+func ec2FilteredImageIDs(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	params["Action"] = "DescribeImages"
+	var res struct {
+		Images []struct {
+			ImageID string `xml:"imageId"`
+		} `xml:"imagesSet>item"`
+	}
+	ec2FleetXML(t, ts, params, &res)
+	ids := make([]string, 0, len(res.Images))
+	for _, im := range res.Images {
+		ids = append(ids, im.ImageID)
+	}
+	return ids
+}
+
+// TestEC2_DescribeImages_ValuelessTagFilterMatchesNothing is the defect #686 reports.
+//
+// AWS documents no rule for a filter with no values — Using_Filtering says only that
+// "You can't specify a filter value of null" — so matching nothing is substrate's
+// reading, taken from ec2InstanceMatchesFilter and describeVolumes, which both already
+// answer that way. What made this a defect is not the answer but the disagreement: the
+// same filter meant two different things depending on which operation received it.
+func TestEC2_DescribeImages_ValuelessTagFilterMatchesNothing(t *testing.T) {
+	ts := newEC2TestServer(t)
+	tagged, untagged := ec2ImageFilterFixture(t, ts)
+
+	got := ec2FilteredImageIDs(t, ts, map[string]string{"Filter.1.Name": "tag:Env"})
+	assert.Empty(t, got,
+		"a tag: filter with no values matched any value, which is tag-key's job")
+	assert.NotContains(t, got, tagged)
+	assert.NotContains(t, got, untagged)
+}
+
+// TestEC2_DescribeImages_ExplicitEmptyTagValue pins the difference the hand-rolled walk
+// erased: an empty filter value is a value, and it is not the same request as no value.
+//
+// tag:Env with Value.1 set to the empty string asks for an image whose Env tag is
+// empty. The old walk broke out of its value loop on the first empty string, so the
+// request arrived indistinguishable from the valueless form above and matched Env=prod.
+func TestEC2_DescribeImages_ExplicitEmptyTagValue(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ec2ImageFilterFixture(t, ts)
+
+	got := ec2FilteredImageIDs(t, ts, map[string]string{
+		"Filter.1.Name": "tag:Env", "Filter.1.Value.1": "",
+	})
+	assert.Empty(t, got, "tag:Env= asks for an empty Env value, and no image has one")
+}
+
+// TestEC2_DescribeImages_TagKeyFilter pins tag-key, which DescribeImages documents and
+// substrate did not support.
+//
+// This is the filter the valueless-tag: form was standing in for, so it has to work
+// before that form can stop working — otherwise the fix takes away the only way to ask
+// the any-value question. An unsupported name was silently dropped, which made the
+// filter a no-op and returned the untagged AMI too.
+func TestEC2_DescribeImages_TagKeyFilter(t *testing.T) {
+	ts := newEC2TestServer(t)
+	tagged, untagged := ec2ImageFilterFixture(t, ts)
+
+	got := ec2FilteredImageIDs(t, ts, map[string]string{
+		"Filter.1.Name": "tag-key", "Filter.1.Value.1": "Env",
+	})
+	assert.Equal(t, []string{tagged}, got,
+		"tag-key=Env selects the images carrying an Env tag whatever its value")
+	assert.NotContains(t, got, untagged)
+}
+
+// ec2TwoTagImages registers one AMI tagged Env=prod,Team=core and one tagged Env=prod
+// alone, which is the pair every multi-filter case below needs: one image satisfying both
+// requirements and one satisfying only the first.
+func ec2TwoTagImages(t *testing.T, ts *httptest.Server) (both, envOnly string) {
+	t.Helper()
+	instID := ec2TagTestInstance(t, ts)
+
+	both = ec2CreateImageID(t, ts, map[string]string{
+		"Action": "CreateImage", "InstanceId": instID, "Name": "both-tags",
+		"TagSpecification.1.ResourceType": "image",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+		"TagSpecification.1.Tag.2.Key":    "Team",
+		"TagSpecification.1.Tag.2.Value":  "core",
+	})
+	envOnly = ec2CreateImageID(t, ts, map[string]string{
+		"Action": "CreateImage", "InstanceId": instID, "Name": "env-only",
+		"TagSpecification.1.ResourceType": "image",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	})
+	return both, envOnly
+}
+
+// TestEC2_DescribeImages_DistinctFilterNamesAreANDed guards the property adopting
+// extractEC2Filters could have taken away.
+//
+// Using_Filtering is explicit that filters are ANDed and the values within one ORed, so
+// two differently-named tag: filters state two requirements. describeImages' own walk got
+// this right by appending each Filter.N to a slice; extractEC2Filters keys a map by name,
+// which preserves it only because these two names differ. This test is the regression
+// guard on that, and it passes both before and after the switch to the shared extractor —
+// which is the point.
+func TestEC2_DescribeImages_DistinctFilterNamesAreANDed(t *testing.T) {
+	ts := newEC2TestServer(t)
+	both, envOnly := ec2TwoTagImages(t, ts)
+
+	got := ec2FilteredImageIDs(t, ts, map[string]string{
+		"Filter.1.Name": "tag:Env", "Filter.1.Value.1": "prod",
+		"Filter.2.Name": "tag:Team", "Filter.2.Value.1": "core",
+	})
+	assert.Equal(t, []string{both}, got, "both tag filters must apply, not only the last")
+	assert.NotContains(t, got, envOnly,
+		"an image satisfying one of two ANDed filters must not match")
+}
+
+// TestEC2_DescribeImages_RepeatedFilterNameORsItsValues pins the one case where the map
+// keyed by name actually collides: the same name sent twice.
+//
+// AWS documents that filters are ANDed and values ORed, and says nothing about a name
+// appearing twice, so merging the two value lists into one OR is substrate's reading.
+// What it replaces was not a reading of anything — extractEC2Filters overwrote the
+// earlier entry, so a caller who sent two got the last one applied and no indication the
+// first had been dropped. Every operation using the shared extractor inherits this fix,
+// which is why it is pinned here rather than left implicit in the ANDing case above.
+func TestEC2_DescribeImages_RepeatedFilterNameORsItsValues(t *testing.T) {
+	ts := newEC2TestServer(t)
+	instID := ec2TagTestInstance(t, ts)
+
+	prod := ec2CreateImageID(t, ts, map[string]string{
+		"Action": "CreateImage", "InstanceId": instID, "Name": "prod-ami",
+		"TagSpecification.1.ResourceType": "image",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	})
+	staging := ec2CreateImageID(t, ts, map[string]string{
+		"Action": "CreateImage", "InstanceId": instID, "Name": "staging-ami",
+		"TagSpecification.1.ResourceType": "image",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "staging",
+	})
+	dev := ec2CreateImageID(t, ts, map[string]string{
+		"Action": "CreateImage", "InstanceId": instID, "Name": "dev-ami",
+		"TagSpecification.1.ResourceType": "image",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "dev",
+	})
+
+	got := ec2FilteredImageIDs(t, ts, map[string]string{
+		"Filter.1.Name": "tag:Env", "Filter.1.Value.1": "prod",
+		"Filter.2.Name": "tag:Env", "Filter.2.Value.1": "staging",
+	})
+	assert.ElementsMatch(t, []string{prod, staging}, got,
+		"a repeated filter name keeps both values instead of discarding the first")
+	assert.NotContains(t, got, dev)
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -3175,6 +3175,18 @@ func extractIndexedParams(params map[string]string, prefix string) []string {
 
 // extractEC2Filters parses EC2 query-protocol Filter.N.Name / Filter.N.Value.M
 // parameters into a map of filter-name → allowed values.
+//
+// Presence rather than emptiness terminates both loops, so an explicitly empty filter
+// value is recorded as a value: Filter.1.Value.1= asks for the empty string, which is a
+// different request from naming no values at all, and every caller of this function
+// distinguishes the two.
+//
+// A repeated filter name accumulates into one value list rather than overwriting the
+// previous one (#686). AWS documents that filters are ANDed and the values within a
+// filter ORed, and says nothing about the same name appearing twice; merging the values
+// answers it as an OR, which is substrate's reading. Overwriting was not a reading of
+// anything — it silently discarded the earlier filter, so a caller who sent two got the
+// last one applied and no indication the first was dropped.
 func extractEC2Filters(params map[string]string) map[string][]string {
 	filters := make(map[string][]string)
 	for i := 1; ; i++ {
@@ -3191,7 +3203,7 @@ func extractEC2Filters(params map[string]string) map[string][]string {
 			vals = append(vals, v)
 		}
 		if name != "" {
-			filters[name] = vals
+			filters[name] = append(filters[name], vals...)
 		}
 	}
 	return filters
@@ -3520,32 +3532,12 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 		return nil, fmt.Errorf("ec2 describeImages list: %w", err)
 	}
 
-	// Collect all Filter.N.Name / Filter.N.Value.M pairs.
-	type filterEntry struct {
-		name   string
-		values []string
-	}
-	var filters []filterEntry
-	for i := 1; ; i++ {
-		fn := req.Params["Filter."+strconv.Itoa(i)+".Name"]
-		if fn == "" {
-			break
-		}
-		var vals []string
-		for j := 1; ; j++ {
-			fv := req.Params["Filter."+strconv.Itoa(i)+".Value."+strconv.Itoa(j)]
-			if fv == "" {
-				break
-			}
-			vals = append(vals, fv)
-		}
-		filters = append(filters, filterEntry{name: fn, values: vals})
-	}
+	// Filters come from the shared extractor rather than a walk of this function's own
+	// (#686). The hand-rolled version broke out of its value loop on the first empty
+	// string, which turned an explicitly empty filter value into the valueless form and
+	// gave this operation a tag: rule no other describe had.
+	filters := extractEC2Filters(req.Params)
 
-	type tagItem struct {
-		Key   string `xml:"key"`
-		Value string `xml:"value"`
-	}
 	type ebsBlockDevice struct {
 		SnapshotID string `xml:"snapshotId"`
 		VolumeSize int64  `xml:"volumeSize"`
@@ -3562,7 +3554,7 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 		OwnerID             string            `xml:"imageOwnerId"`
 		CreationDate        string            `xml:"creationDate,omitempty"`
 		BlockDeviceMappings []blockDeviceItem `xml:"blockDeviceMapping>item,omitempty"`
-		Tags                []tagItem         `xml:"tagSet>item"`
+		Tags                []ec2TagItem      `xml:"tagSet>item"`
 	}
 	type response struct {
 		XMLName xml.Name    `xml:"DescribeImagesResponse"`
@@ -3581,36 +3573,9 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 			continue
 		}
 
-		// Apply filters.
-		skip := false
-		for _, f := range filters {
-			switch {
-			case strings.HasPrefix(f.name, "tag:"):
-				tagKey := f.name[4:]
-				found := false
-				for _, t := range img.Tags {
-					if t.Key == tagKey && (len(f.values) == 0 || containsStr(f.values, t.Value)) {
-						found = true
-						break
-					}
-				}
-				if !found {
-					skip = true
-				}
-			case f.name == "block-device-mapping.snapshot-id":
-				if img.SnapshotID == "" || !containsStr(f.values, img.SnapshotID) {
-					skip = true
-				}
-			case f.name == "image-id":
-				if !containsStr(f.values, img.ImageID) {
-					skip = true
-				}
-			}
-			if skip {
-				break
-			}
-		}
-		if skip {
+		// Apply filters. Every named filter must match — AWS ANDs filters and ORs the
+		// values within one — so the map's iteration order does not affect the outcome.
+		if !ec2ImageMatchesFilters(img, filters) {
 			continue
 		}
 
@@ -3628,12 +3593,56 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 				EBS:        ebsBlockDevice{SnapshotID: img.SnapshotID, VolumeSize: 8},
 			}}
 		}
-		for _, t := range img.Tags {
-			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck
-		}
+		item.Tags = ec2TagItems(img.Tags)
 		resp.Images = append(resp.Images, item)
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
+}
+
+// ec2ImageMatchesFilters reports whether img satisfies every filter the caller named.
+//
+// Filters are ANDed and the values within one ORed, which is what Using_Filtering
+// documents, so the map's iteration order cannot affect the answer. A name substrate does
+// not evaluate is ignored rather than refused; one rule for an unrecognized filter name
+// is #687's subject, not this function's.
+//
+// A filter naming no values matches nothing (#686). AWS documents no rule for that shape
+// — Using_Filtering says only "You can't specify a filter value of null" — so this is
+// substrate's reading, taken from ec2InstanceMatchesFilter and describeVolumes, which
+// both already answer that way. describeImages previously read it as the any-value
+// question instead, which is what tag-key spells and what this function now answers under
+// that name.
+func ec2ImageMatchesFilters(img EC2Image, filters map[string][]string) bool {
+	for name, vals := range filters {
+		matched := false
+		switch {
+		case strings.HasPrefix(name, "tag:"):
+			key := strings.TrimPrefix(name, "tag:")
+			for _, t := range img.Tags {
+				if t.Key == key && containsStr(vals, t.Value) {
+					matched = true
+					break
+				}
+			}
+		case name == "tag-key":
+			for _, t := range img.Tags {
+				if containsStr(vals, t.Key) {
+					matched = true
+					break
+				}
+			}
+		case name == "block-device-mapping.snapshot-id":
+			matched = img.SnapshotID != "" && containsStr(vals, img.SnapshotID)
+		case name == "image-id":
+			matched = containsStr(vals, img.ImageID)
+		default:
+			continue
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
 }
 
 // deregisterImage removes an AMI from state.


### PR DESCRIPTION
`describeImages` parsed `Filter.N` itself instead of calling `extractEC2Filters`, and the
two parsers disagreed in three ways that compounded into one wrong answer.

**The defect #686 reports.** A `tag:<key>` filter with no value matched *any* value:

```go
if t.Key == tagKey && (len(f.values) == 0 || containsStr(f.values, t.Value)) {
```

That is `tag-key`'s question, and `tag-key` was unsupported — so this operation had the
wrong spelling of the any-value question and not the right one. `DescribeInstances`
(`default: return false`) and `DescribeVolumes` both match nothing for the valueless form.
AWS settles neither reading: `Using_Filtering` says only "You can't specify a filter value
of null". Matching nothing is substrate's reading, and it is now substrate's answer at all
three sites rather than two of three.

**What the hand-rolled walk added.** `if fv == "" { break }` truncated the value list, so
`Filter.1.Value.1=` arrived as *no values* and inherited the rule above. An empty filter
value is a value — it asks for a tag whose value is the empty string — and every other
caller of `extractEC2Filters` distinguishes the two. Adopting the shared extractor fixes
this and the first defect together, and leaves one filter parser in the plugin instead of
two that disagreed.

**What adopting it would have broken, so it is fixed here too.** `extractEC2Filters` keyed
a map by name and overwrote, so a repeated filter name kept only the last. The old walk
appended each `Filter.N` to a slice and ANDed them, which is right for *distinct* names —
and `extractEC2Filters` gets those right too, since they are separate map keys. The
collision is the *same* name twice, where overwriting silently discarded the first entry
with no indication. AWS documents filters ANDed and values within a filter ORed, and says
nothing about a repeated name; merging the value lists answers it as an OR, which is
substrate's reading. Overwriting was not a reading of anything. **This affects every EC2
describe that parses filters**, which is why it is pinned by its own test.

`tag-key` arrives in the same PR because the first fix takes away the spelling callers were
using for it. Without it the change would be a pure removal.

## Fail-before

The issue's acceptance criterion asks that the test pinning the old rule be *updated*. No
such test existed — only three tests in the repo pin any unknown/empty filter behaviour and
none covers `DescribeImages` — so `emulator/ec2_image_filters_test.go` is written here as
the fail-before. Recorded against unfixed code:

| Test | Before |
|---|---|
| `ValuelessTagFilterMatchesNothing` | FAIL — `tag:Env` with no value returned the `Env=prod` AMI |
| `ExplicitEmptyTagValue` | FAIL — `tag:Env=` returned the `Env=prod` AMI |
| `TagKeyFilter` | FAIL — the name was dropped, so both AMIs came back |
| `DistinctFilterNamesAreANDed` | PASS — the regression guard; it must not start failing |
| `RepeatedFilterNameORsItsValues` | FAIL — verified separately by reverting the `append` to `filters[name] = vals`, which returned only `staging` |

## Verification

`gofmt -l` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues),
`go test -race -count=1 ./emulator/` (full package, no `-run` filter),
`go test -C test/e2e ./...`, `make docs-reference-check`, `scripts/check-doc-versions.sh`,
`npm --prefix docs run build` — all pass.

Nothing else needed changing: no test asserts a `DescribeImages` response byte-exactly, and
no golden-XML fixture exists in the repo.

## Compatibility

Three behaviour changes, all named in `CHANGELOG.md` and `docs/services.md`: the valueless
`tag:` form now matches nothing (use `tag-key`), an explicitly empty filter value is now
honoured as the empty string, and a repeated filter name now ORs rather than dropping the
earlier entry — the last on every EC2 describe, not only this one.

Closes #686
