### PR TITLE
fix(ec2): one rule for an unrecognized filter name — refuse it (#687)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value" — and it had to arrive in the same change as the fix below, which takes away the
   spelling callers were using for it by accident.
 
+### Changed
+- **An unrecognized EC2 filter name is refused, on every operation that parses one** (#687).
+  `Filter.N.Name` outside the set that operation's own API reference documents now answers
+  `InvalidParameterValue` / `The filter "<name>" is not valid for this request`, HTTP 400.
+  Substrate had three answers to the same mistake — dropped on volumes, snapshots, security
+  groups, route tables, NAT gateways, fleets and images; matched nothing on instances;
+  refused on instance-type offerings — so a typo returned everything, nothing, or an error
+  depending on which operation received it.
+
+  **This is a behaviour change, and the loudest in this release.** A misspelled filter name
+  previously came back inside a successful response, so a consumer's test could pass on a
+  filter that was never applied. It now fails, which is what real EC2 does.
+
+  Each operation's list is transcribed from its own reference page rather than shared between
+  them, because AWS documents different filters for each: `tag:<key>` is valid on
+  `DescribeInstances` and **refused on `DescribeFleets`**, which documents no tag filter at
+  all. The check runs before the state scan, so a refusal never depends on whether a resource
+  matched, and it walks `Filter.N` in request order rather than the extracted map, so two
+  undocumented names produce the same refusal on every replay.
+
+  Refusal reproduces AWS's *documented set*, not substrate's coverage: a name AWS documents
+  that substrate keeps no state to answer is accepted and **inert**, since refusing
+  `encrypted` or `ipv6-cidr-block-association.state` would deny a filter real EC2 accepts.
+  Those names are now listed per operation in `docs/services.md` rather than left to be
+  discovered.
+
+  **Provenance.** Refusal is real EC2's *observed* behaviour. Neither `Using_Filtering` nor
+  the `Filter` type's reference page says what happens to an unrecognized name — both are
+  silent — so nothing in AWS's documentation settles it. `InvalidParameterValue` is the
+  documented code; the message text is substrate's own, so dispatch on the code.
+
+  Deliberately unchanged, and now stated in the docs with an issue each: the fourteen EC2
+  describes that never parse `Filter.N` at all neither apply nor refuse one (#695), filter
+  *values* honour EC2's documented wildcards only on `DescribeInstanceTypeOfferings` (#697),
+  and an empty value list matches everything on `DescribeSecurityGroups` where it matches
+  nothing elsewhere (#696).
+
+- **A documented-but-unevaluated filter name is inert on `DescribeInstances` instead of
+  matching nothing** (#687). It used to return an empty set, which was defensible while an
+  unknown name landed in the same branch — better to return nothing than resources the
+  caller meant to exclude — but a refused typo answers that concern directly, and the old
+  rule left this one operation emptying a query where every sibling ignored it. An empty
+  answer is also the worse half of the choice: it cannot be told apart from "the resource
+  does not exist", so a consumer's wait loop polls forever, where over-matching fails once
+  and visibly. Neither answer is real EC2's, which would apply the filter; only one of them
+  can be a single rule.
+
 ### Fixed
 - **A `tag:<key>` filter with no value no longer matches any value on `DescribeImages`**
   (#686). `Filter.1.Name=tag:Env` with no `Filter.1.Value.1` matched every image carrying an

--- a/docs/services.md
+++ b/docs/services.md
@@ -2620,7 +2620,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | Operation | Notes |
 |-----------|-------|
 | RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); [refuses an invalid block device mapping](#a-mapping-aws-refuses-is-refused-with-invalidblockdevicemapping); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
-| DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time); `availability-zone` filter |
+| DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time); eleven filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | TerminateInstances | [Explicit resource IDs](#explicit-resource-ids); [honours termination protection, per Availability Zone](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StartInstances | [Explicit resource IDs](#explicit-resource-ids) |
@@ -2634,7 +2634,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeSubnets | [Explicit resource IDs](#explicit-resource-ids) |
 | DeleteSubnet | [Explicit resource IDs](#explicit-resource-ids) |
 | CreateSecurityGroup | |
-| DescribeSecurityGroups | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeSecurityGroups | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | DeleteSecurityGroup | [Explicit resource IDs](#explicit-resource-ids) |
 | AuthorizeSecurityGroupIngress | Supports source security groups (`IpPermissions.N.Groups.M.GroupId`), including self-referencing rules |
 | AuthorizeSecurityGroupEgress | Supports destination security groups |
@@ -2651,11 +2651,11 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeSpotPriceHistory | One stub price per catalog type per zone. `InstanceType.N` here is a *filter*, so an unknown type is an empty history — [see below](#instance-types-are-a-seeded-catalog) |
 | CreateRouteTable | |
 | AssociateRouteTable | |
-| DescribeRouteTables | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeRouteTables | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | DeleteRouteTable | [Explicit resource IDs](#explicit-resource-ids) |
-| DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
-| DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | CreateLaunchTemplate | Creates version 1. Networking is read from every `NetworkInterface.N.*` — see [Launch template networking](#launch-template-networking) |
 | DescribeLaunchTemplates | Summary only — no `launchTemplateData`, matching AWS. Use `DescribeLaunchTemplateVersions` to read a template's parameters |
 | DeleteLaunchTemplate | |
@@ -2664,10 +2664,107 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeLaunchTemplateVersions | Numbers, `$Latest`, `$Default`, `MinVersion`/`MaxVersion`, `MaxResults`/`NextToken`, and the account-wide form |
 | DeleteLaunchTemplateVersions | Reports per version at HTTP 200; the default version cannot be deleted |
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
-| DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS |
+| DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS; [filter names are checked](#one-rule-for-an-unrecognized-filter-name), and it documents **no tag filter** |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances, [subject to termination protection](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); accepts a `vol-` ID like [any other taggable ID](#a-volume-carries-tags); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
 | DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) and [over-long keys](#tag-key-and-value-length-limits); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
+
+### One rule for an unrecognized filter name
+
+**A `Filter.N.Name` the operation's own API reference does not list is refused**, with
+`InvalidParameterValue` / `The filter "<name>" is not valid for this request`, HTTP 400.
+The check runs **before** the state scan, so the refusal never depends on whether a
+resource happened to match: an empty account and a populated one answer a typo the same
+way.
+
+This replaced three different answers across substrate's nine filter-parsing EC2
+operations — dropped on volumes, snapshots, security groups, route tables, NAT gateways,
+fleets and images; matched nothing on instances; refused on instance-type offerings — with
+the one real EC2 gives.
+
+**This is a behaviour change, and the loudest one in the release that brought it.** A
+misspelled filter name previously came back as a successful response: dropped, so the query
+returned *everything*, or match-nothing, so it returned *nothing*. Either way a consumer's
+test could pass on a filter that was never applied. It now fails, which is what real EC2
+does.
+
+**Provenance.** Refusal is real EC2's *observed* behaviour, not its documented behaviour.
+Neither the
+[filtering guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html)
+nor the [`Filter` type](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html)
+says what happens to a name outside the documented set — both are silent. The code
+`InvalidParameterValue` is documented; the message text is substrate's own, so dispatch on
+the code.
+
+#### What is refused, and what is merely inert
+
+The refusal reproduces AWS's set rather than substrate's coverage, so a filter splits three
+ways:
+
+| The name | Answer |
+|---|---|
+| Documented **and** evaluated | Applied |
+| Documented, **not** evaluated — substrate keeps no state to answer it | **Inert**: it constrains nothing, so the operation returns every resource it would have returned without it |
+| Not documented for that operation | **Refused**, 400 |
+
+Refusing the middle row would deny filters real EC2 accepts —
+`ipv6-cidr-block-association.state` is a filter, not a typo — so it stays accepted, and it
+is listed by name below rather than left for a caller to discover. Inert is *also* a change
+for `DescribeInstances`, which used to match nothing for such a name: an empty answer is
+indistinguishable from "the resource does not exist", so a wait loop polls forever, where
+over-matching fails once and visibly.
+
+The lists live in `emulator/ec2_filters.go`, one per operation, each transcribed from that
+operation's own reference page. AWS documents different filters for each, so a name valid on
+one is refused on its neighbour — `tag:<key>` most conspicuously (see below).
+
+| Operation | Evaluated | Documented but inert |
+|---|---|---|
+| DescribeInstances | `availability-zone`, `image-id`, `instance-id`, `instance-state-code`, `instance-state-name`, `instance-type`, `key-name`, `subnet-id`, `tag-key`, `tag:<key>`, `vpc-id` | the other 125 — the `network-interface.*`, `block-device-mapping.*`, `metadata-options.*`, `capacity-reservation*`, `private-dns-name-options.*`, `iam-instance-profile.*` and `operator.*` families, plus `architecture`, `platform`, `tenancy`, `root-device-type`, `owner-id` and the rest |
+| DescribeImages | `block-device-mapping.snapshot-id`, `image-id`, `tag-key`, `tag:<key>` | the other 39 — the `block-device-mapping.*` (bar `snapshot-id`), `image-watermark.*`, `product-code*`, `source-image*` and `state-reason-*` families, plus `architecture`, `creation-date`, `description`, `is-public`, `name`, `owner-alias`, `owner-id`, `platform`, `root-device-name`, `root-device-type`, `state` and the rest |
+| DescribeVolumes | `attachment.delete-on-termination`, `attachment.device`, `attachment.instance-id`, `availability-zone`, `size`, `snapshot-id`, `status`, `tag-key`, `tag:<key>`, `volume-id`, `volume-type` | `attachment.attach-time`, `attachment.status`, `availability-zone-id`, `create-time`, `encrypted`, `fast-restored`, `multi-attach-enabled`, `operator.managed`, `operator.principal` |
+| DescribeSnapshots | `snapshot-id` | `description`, `encrypted`, `owner-alias`, `owner-id`, `progress`, `start-time`, `status`, `storage-tier`, `tag-key`, `tag:<key>`, `transfer-type`, `volume-id`, `volume-size` |
+| DescribeSecurityGroups | `group-id`, `group-name`, `vpc-id` | `description`, `owner-id`, `tag-key`, `tag:<key>`, and the twenty `ip-permission.*`/`egress.ip-permission.*` rule filters |
+| DescribeRouteTables | `association.route-table-id`, `association.subnet-id`, `vpc-id` | `association.gateway-id`, `association.main`, `association.route-table-association-id`, `owner-id`, `route-table-id`, `tag-key`, `tag:<key>`, and the eleven `route.*` filters |
+| DescribeNatGateways | `state`, `vpc-id` | `nat-gateway-id`, `subnet-id`, `tag-key`, `tag:<key>` |
+| DescribeFleets | `activity-status`, `fleet-state`, `type` | `excess-capacity-termination-policy`, `replace-unhealthy-instances` |
+| DescribeInstanceTypeOfferings | `instance-type`, `location` (both with [wildcards](#offerings-filters-and-wildcards)) | — |
+
+`tag:<key>` is refused on **`DescribeFleets` and `DescribeInstanceTypeOfferings`**, which
+document no tag filter at all — neither `tag:<key>` nor `tag-key` — even though a fleet
+carries tags and `DescribeFleets` renders them. That is AWS's set, not an omission here; to
+find a fleet by tag, use Resource Groups Tagging.
+
+Read the tag rows in the other direction and they are the surface's weakest point: only
+**`DescribeInstances`, `DescribeVolumes` and `DescribeImages`** actually filter on tags.
+On snapshots, security groups, route tables and NAT gateways a `tag:<key>` filter is
+accepted and inert, so "find the resources tagged `Env=prod`" answers with *all* of them.
+Real EC2 offers three routes to finding a resource by tag: the describe filters,
+`DescribeTags`, and Resource Groups Tagging. Substrate serves the third in full, the first
+on three operations, and does not implement `DescribeTags` at all.
+
+#### Filter semantics that apply everywhere
+
+- **Separate `Filter.N` entries AND**; **the values inside one filter OR**. Both are
+  documented.
+- **Repeated filter names OR their values.** Two `Filter.N` entries sharing a name are one
+  filter with the values of both. The second used to silently replace the first everywhere
+  except `DescribeImages`.
+- **Filter names and values are case-sensitive**, per the `Filter` type. `VPC-Id` is not
+  `vpc-id` and is refused.
+- **A `tag:<key>` filter with no value matches nothing.** AWS says only that a filter value
+  cannot be null; matching nothing is substrate's reading, and `tag-key` is the documented
+  way to ask the any-value question.
+
+**Two gaps, deliberately left standing**, because closing either would newly change
+requests that succeed today. Fourteen EC2 describes — including `DescribeVpcs`,
+`DescribeSubnets`, `DescribeInstanceTypes` and `DescribeAvailabilityZones` — never parse
+`Filter.N` at all, so they neither apply nor refuse one
+([#695](https://github.com/scttfrdmn/substrate/issues/695)). And filter *values* honour
+EC2's documented wildcards only on `DescribeInstanceTypeOfferings`; everywhere else
+matching is exact ([#697](https://github.com/scttfrdmn/substrate/issues/697)). A third,
+narrower one: an **empty** value list matches nothing here but matches everything on
+`DescribeSecurityGroups` ([#696](https://github.com/scttfrdmn/substrate/issues/696)).
 
 ### RunInstances requires a resolvable AMI
 
@@ -3105,17 +3202,15 @@ constraint, so there is nothing else to enforce.
 
 `DescribeVolumes` supports exactly the two tag filters AWS documents for it,
 `tag:<key>` and `tag-key`. There is no `tag-value`; AWS does not define one for this
-operation. Two behaviours here are substrate's own, because AWS's filtering guide
-settles neither:
+operation. A `tag:<key>` filter with **no value** matches nothing — substrate's reading,
+since the filtering guide says only that a filter value cannot be null and offers
+`tag-key` for the any-value question.
 
-- A `tag:<key>` filter with **no value** matches nothing, following
-  `DescribeInstances`. The guide says only that a filter value cannot be null, and
-  offers `tag-key` for the any-value question.
-- An **unrecognized filter name is dropped**, so the filter constrains nothing. That is
-  what this operation has always done, and it is kept rather than reconciled: real EC2
-  refuses an unknown name, and substrate has three different answers across its EC2
-  filter sites. Making them agree is its own change, and it is a behaviour change on
-  every one of them.
+An unrecognized filter name is **refused**, and one AWS documents that substrate cannot
+evaluate (`encrypted`, `create-time`, `fast-restored` and six others) is accepted and
+inert. Both follow the rule that now governs every EC2 describe — see
+[One rule for an unrecognized filter name](#one-rule-for-an-unrecognized-filter-name),
+which lists this operation's eleven evaluated names and nine inert ones.
 
 #### A mapping AWS refuses is refused, with `InvalidBlockDeviceMapping`
 
@@ -3682,9 +3777,11 @@ the same defect as an ignored filter. Tracked in
 #### Offerings filters and wildcards
 
 `DescribeInstanceTypeOfferings` accepts exactly the two filter names its reference
-documents — `instance-type` and `location`. **Any other name is refused** with
-`InvalidParameterValue` rather than ignored. Multiple `Filter.N.Value.M` values are
-an OR; separate `Filter.N` entries AND together.
+documents — `instance-type` and `location` — and there is nothing it accepts but cannot
+answer. **Any other name is refused** with `InvalidParameterValue`, which is now what
+[every EC2 describe does](#one-rule-for-an-unrecognized-filter-name); this operation is where
+that rule started. Multiple `Filter.N.Value.M` values are an OR; separate `Filter.N`
+entries AND together.
 
 Filter values honour EC2's documented wildcards, and are **case-sensitive**:
 
@@ -3979,8 +4076,9 @@ real EC2 puts them.
 #### `DescribeImages` filters
 
 Four filter names are applied: `image-id`, `block-device-mapping.snapshot-id`,
-`tag:<key>` and `tag-key`. An unrecognized name is dropped, as on every other EC2
-describe. AWS documents thirty-odd more; the rest need state substrate does not keep.
+`tag:<key>` and `tag-key`. AWS documents thirty-nine more, which need state substrate
+does not keep: those are accepted and inert, and anything outside AWS's list is refused —
+see [One rule for an unrecognized filter name](#one-rule-for-an-unrecognized-filter-name).
 
 Two behaviour changes came with `tag-key`, both of which bring this operation into line
 with `DescribeInstances` and `DescribeVolumes` rather than leaving it with its own rules:

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -531,10 +531,10 @@ func (p *EC2Plugin) ec2DeleteInstanceVolumes(accountID, region, instanceID strin
 // `tag-key`, out of 20 filters in total — there is no `tag-value` (#670).
 //
 // A `tag:<key>` filter with no values matches nothing. AWS documents no rule for
-// that shape (Using_Filtering says only that a filter value cannot be null, and
-// offers tag-key for the any-value question), and substrate's two existing
-// implementations disagree; this follows [ec2InstanceMatchesFilter], the closer
-// sibling, rather than describeImages, which treats it as tag-key.
+// that shape — Using_Filtering says only that a filter value cannot be null, and
+// offers tag-key for the any-value question — so this is substrate's reading, and
+// since #686 it is the reading everywhere: describeImages used to treat the shape as
+// tag-key and no longer does.
 func ec2VolumeMatchesFilters(vol EC2Volume, filters map[string][]string) bool {
 	for name, values := range filters {
 		if !ec2VolumeMatchesFilter(vol, name, values) {
@@ -546,12 +546,12 @@ func ec2VolumeMatchesFilters(vol EC2Volume, filters map[string][]string) bool {
 
 // ec2VolumeMatchesFilter evaluates a single DescribeVolumes filter against a volume.
 //
-// An unrecognized filter name is dropped — the volume matches — which is what this
-// operation has always done. That is not, as a comment here once claimed, what every
-// EC2 filter site does: three behaviors exist in this package (drop for volumes and
-// snapshots, match-nothing for [ec2InstanceMatchesFilter], and refuse for
-// describeInstanceTypeOfferings, which is what real EC2 does). Reconciling them is
-// its own change; this one keeps the observable answer it found.
+// A name this function does not handle is dropped — the volume matches — and since
+// #687 that can only be a name DescribeVolumes documents and substrate keeps no state
+// to answer, because [ec2VolumeFilterSpec] refuses anything outside AWS's set before
+// the scan begins. So the drop is now the *inert* case rather than the unknown one,
+// and it is deliberate: refusing `encrypted` would deny a filter real EC2 accepts.
+// docs/services.md lists the inert names per operation.
 func ec2VolumeMatchesFilter(vol EC2Volume, name string, values []string) bool {
 	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
 		for _, t := range vol.Tags {

--- a/emulator/ec2_filter_names_test.go
+++ b/emulator/ec2_filter_names_test.go
@@ -1,0 +1,227 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// One rule for a filter name EC2 does not document: refuse it (#687).
+//
+// Before this change the answer depended on which operation received the name — dropped
+// on volumes, snapshots, security groups, route tables, NAT gateways, fleets and images;
+// matched nothing on instances; refused on instance-type offerings. Real EC2 refuses. The
+// table below covers one operation per former behavior class, which is what the issue
+// asks for, plus the two cases the split into evaluated/accepted names creates: a
+// documented name substrate cannot answer must *not* be refused, and an operation that
+// documents no tag filter must refuse one.
+
+// ec2FilterRefusal sends a one-filter describe and returns its status, code and message.
+// No fixture is needed: the refusal is decided before the state scan, so it does not
+// depend on any resource existing.
+func ec2FilterRefusal(t *testing.T, action, name string) (int, string, string) {
+	t.Helper()
+	ts := newEC2TestServer(t)
+	return ec2ErrorDetail(t, ts, map[string]string{
+		"Action":           action,
+		"Filter.1.Name":    name,
+		"Filter.1.Value.1": "whatever",
+	})
+}
+
+// TestEC2_FilterNames_UndocumentedNameRefused is the behavior change, one operation per
+// former class.
+func TestEC2_FilterNames_UndocumentedNameRefused(t *testing.T) {
+	for _, tc := range []struct {
+		action string
+		filter string
+		was    string
+	}{
+		{"DescribeInstances", "some-unknown-filter", "matched nothing"},
+		{"DescribeVolumes", "not-a-filter", "dropped"},
+		{"DescribeSnapshots", "vloume-id", "dropped"},
+		{"DescribeImages", "ami-id", "dropped"},
+		{"DescribeSecurityGroups", "groupname", "dropped"},
+		{"DescribeRouteTables", "route.destination", "dropped"},
+		{"DescribeNatGateways", "natgateway-id", "dropped"},
+		// FleetId is a top-level parameter on this operation, never a filter name, so
+		// the plausible-looking spelling is exactly the mistake worth refusing.
+		{"DescribeFleets", "fleet-id", "dropped"},
+		{"DescribeInstanceTypeOfferings", "location-type", "refused"},
+	} {
+		t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
+			status, code, message := ec2FilterRefusal(t, tc.action, tc.filter)
+			assert.Equal(t, http.StatusBadRequest, status,
+				"%s previously %s this name", tc.action, tc.was)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Contains(t, message, tc.filter,
+				"the message must name the offending filter, which is the one thing a caller needs")
+		})
+	}
+}
+
+// TestEC2_FilterNames_CaseIsSignificant pins that a case variant of a real filter name is
+// refused.
+//
+// AWS's Filter type states "Filter names are case-sensitive", so `VPC-Id` is not `vpc-id`
+// and accepting it would be leniency past the model. This is also the most likely typo to
+// reach substrate from hand-written code, so it is worth its own case.
+func TestEC2_FilterNames_CaseIsSignificant(t *testing.T) {
+	for _, name := range []string{"VPC-Id", "Tag-Key", "Instance-Id"} {
+		t.Run(name, func(t *testing.T) {
+			status, code, _ := ec2FilterRefusal(t, "DescribeInstances", name)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+		})
+	}
+}
+
+// TestEC2_FilterNames_DocumentedButUnevaluatedIsAccepted is the other half of the rule,
+// and the reason the spec carries two lists.
+//
+// Every name below is on its operation's reference page and is one substrate keeps no
+// state to answer. Refusing them would be a false deny for filters real EC2 accepts, so
+// they are accepted and inert — the honest gap, listed per operation in docs/services.md
+// rather than left for a caller to discover.
+func TestEC2_FilterNames_DocumentedButUnevaluatedIsAccepted(t *testing.T) {
+	for _, tc := range []struct{ action, filter string }{
+		{"DescribeInstances", "platform"},
+		{"DescribeInstances", "network-interface.ipv6-addresses.is-primary-ipv6"},
+		{"DescribeImages", "creation-date"},
+		{"DescribeVolumes", "encrypted"},
+		{"DescribeSnapshots", "volume-size"},
+		{"DescribeSecurityGroups", "ip-permission.from-port"},
+		{"DescribeRouteTables", "route.state"},
+		{"DescribeNatGateways", "nat-gateway-id"},
+		{"DescribeFleets", "replace-unhealthy-instances"},
+	} {
+		t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
+			status, code, _ := ec2FilterRefusal(t, tc.action, tc.filter)
+			assert.Equal(t, http.StatusOK, status,
+				"%s documents %s, so refusing it would deny a filter real EC2 accepts",
+				tc.action, tc.filter)
+			assert.Empty(t, code)
+		})
+	}
+}
+
+// TestEC2_FilterNames_InertMeansEveryResource pins what "inert" answers, which the status
+// code alone cannot show: an empty result set is also HTTP 200.
+//
+// DescribeInstances used to answer a documented-but-unevaluated name by matching *nothing*
+// while DescribeVolumes matched *everything*, so the same filter emptied one operation and
+// constrained neither on the other. Both now ignore it. Neither answer is real EC2's — it
+// would apply the filter — but only one of them can be a single rule, and match-nothing is
+// the worse half of the choice: it is indistinguishable from "the resource does not exist",
+// so a consumer's wait loop polls forever instead of over-matching once.
+func TestEC2_FilterNames_InertMeansEveryResource(t *testing.T) {
+	ts := newEC2TestServer(t)
+	want := ec2TagTestInstance(t, ts)
+
+	for _, filter := range []string{"platform", "architecture", "root-device-type"} {
+		t.Run(filter, func(t *testing.T) {
+			resp := ec2Request(t, ts, map[string]string{
+				"Action":           "DescribeInstances",
+				"Filter.1.Name":    filter,
+				"Filter.1.Value.1": "no-instance-could-match-this",
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var doc struct {
+				XMLName xml.Name `xml:"DescribeInstancesResponse"`
+				IDs     []string `xml:"reservationSet>item>instancesSet>item>instanceId"`
+			}
+			require.NoError(t, xml.NewDecoder(resp.Body).Decode(&doc))
+			assert.Equal(t, []string{want}, doc.IDs,
+				"an inert filter constrains nothing, so every instance is still returned")
+		})
+	}
+}
+
+// TestEC2_FilterNames_TagFilterFollowsTheOperation pins that whether tag:<key> is accepted
+// is per operation, not a package-wide assumption.
+//
+// DescribeFleets and DescribeInstanceTypeOfferings document no tag filter at all — not
+// tag:<key> and not tag-key — even though a fleet carries tags and DescribeFleets renders
+// them. So the same filter name is a bad request on one operation and valid on its
+// neighbor, which is AWS's set rather than an omission in the transcription.
+func TestEC2_FilterNames_TagFilterFollowsTheOperation(t *testing.T) {
+	t.Run("refused where the operation documents no tag filter", func(t *testing.T) {
+		for _, tc := range []struct{ action, filter string }{
+			{"DescribeFleets", "tag:Env"},
+			{"DescribeFleets", "tag-key"},
+			{"DescribeInstanceTypeOfferings", "tag:Env"},
+			{"DescribeInstanceTypeOfferings", "tag-key"},
+		} {
+			t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
+				status, code, _ := ec2FilterRefusal(t, tc.action, tc.filter)
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "InvalidParameterValue", code)
+			})
+		}
+	})
+
+	t.Run("accepted where it is documented", func(t *testing.T) {
+		for _, tc := range []struct{ action, filter string }{
+			{"DescribeInstances", "tag:Env"},
+			{"DescribeVolumes", "tag:Env"},
+			{"DescribeImages", "tag-key"},
+			{"DescribeSnapshots", "tag:Env"},
+			{"DescribeRouteTables", "tag:Env"},
+			{"DescribeNatGateways", "tag-key"},
+		} {
+			t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
+				status, _, _ := ec2FilterRefusal(t, tc.action, tc.filter)
+				assert.Equal(t, http.StatusOK, status)
+			})
+		}
+	})
+}
+
+// TestEC2_FilterNames_RefusalIsDeterministic pins which of two undocumented names the
+// refusal reports.
+//
+// The check this replaced iterated the filter *map*, so it named whichever bad filter Go's
+// map order surfaced first — two replays of one recorded request could report different
+// refusals, which the event log must never allow. Walking Filter.N in request order names
+// the first offender instead. Repeating the request is what makes the test meaningful: a
+// map-order implementation passes it only by luck, and not twenty times running.
+func TestEC2_FilterNames_RefusalIsDeterministic(t *testing.T) {
+	ts := newEC2TestServer(t)
+	for i := 0; i < 20; i++ {
+		_, code, message := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":           "DescribeInstances",
+			"Filter.1.Name":    "aaa-not-a-filter",
+			"Filter.1.Value.1": "x",
+			"Filter.2.Name":    "zzz-not-a-filter",
+			"Filter.2.Value.1": "y",
+		})
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Contains(t, message, "aaa-not-a-filter",
+			"the first filter in request order is the one reported")
+		assert.NotContains(t, message, "zzz-not-a-filter")
+	}
+}
+
+// TestEC2_FilterNames_UndocumentedNameRefusedBeforeTheScan pins the ordering.
+//
+// A refusal must not depend on whether any resource matched, which is the rule
+// ec2IDFilter.unresolved states from the other side: a resource a filter excluded still
+// counts as resolved. An empty account and a populated one must answer the same way, or a
+// caller's first run would 400 and a later one would not.
+func TestEC2_FilterNames_UndocumentedNameRefusedBeforeTheScan(t *testing.T) {
+	ts := newEC2TestServer(t)
+	ec2TagTestInstance(t, ts) // one running instance, so the scan has something to find
+
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":           "DescribeInstances",
+		"Filter.1.Name":    "not-a-filter",
+		"Filter.1.Value.1": "x",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+}

--- a/emulator/ec2_filters.go
+++ b/emulator/ec2_filters.go
@@ -1,0 +1,328 @@
+package emulator
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ec2FilterSpec declares the Filter.N.Name values one EC2 describe operation accepts,
+// split by whether substrate can answer them.
+//
+// Before #687 an unrecognized filter name produced three different answers depending on
+// which operation received it: dropped (volumes, snapshots, security groups, route
+// tables, NAT gateways, fleets, images), matched nothing (instances), or refused
+// (instance-type offerings). Real EC2 refuses. A spec per operation makes the refusal one
+// shared rule, so a new operation cannot pick a fourth behavior.
+//
+// The split into two lists is what keeps the refusal from exceeding AWS's. Refusing every
+// name substrate does not *evaluate* would deny filters real EC2 accepts —
+// ipv6-cidr-block-association.state is a filter, not a typo — so a documented name
+// substrate cannot answer is accepted and left inert, and docs/services.md lists those
+// names per operation so the gap is visible rather than discovered. Only a name outside
+// AWS's documented set is refused.
+//
+// Each spec's list is transcribed from that operation's own API reference page, named in
+// the constructor's doc comment, rather than from a list shared between operations: AWS
+// documents different filters for each, and a shared list would refuse a name one
+// operation accepts because a sibling does not.
+type ec2FilterSpec struct {
+	// evaluated are the names substrate applies. A name here still has to be handled by
+	// the operation's match function; the spec governs refusal, not matching.
+	evaluated []string
+	// accepted are the names AWS documents that substrate keeps no state to answer.
+	accepted []string
+	// tagValueFilter records whether the operation documents the tag:<key> form. Two do
+	// not — DescribeFleets and DescribeInstanceTypeOfferings list no tag filter at all —
+	// so it cannot be assumed from the presence of tag-key.
+	tagValueFilter bool
+}
+
+// documents reports whether the operation's reference page lists name as a filter.
+//
+// tag:<key> is matched by prefix because its key is part of the name, which is why it
+// cannot live in either list. AWS's route-table, NAT-gateway and subnet pages render this
+// entry as a bare "tag" while the snapshot and security-group pages render it
+// "tag:<key>"; the body text is identical on all five and says to "use the tag key in the
+// filter name", so the prefix form is what is documented and no literal filter named
+// "tag" exists.
+func (s ec2FilterSpec) documents(name string) bool {
+	if strings.HasPrefix(name, "tag:") {
+		return s.tagValueFilter
+	}
+	return containsStr(s.evaluated, name) || containsStr(s.accepted, name)
+}
+
+// check refuses the first filter name, in request order, that the operation does not
+// document.
+//
+// It walks Filter.N itself rather than taking [extractEC2Filters]' map because a map has
+// no order: given two undocumented names the map form would name an arbitrary one, and
+// two replays of one recorded request could report different refusals. Naming the first
+// offending filter in request order is deterministic and is the reading a caller expects.
+//
+// An empty filter name is skipped rather than refused, because [extractEC2Filters] drops
+// it. Refusing here would make the checker and the extractor disagree about what the
+// request contains, which is the class of defect #686 fixed.
+//
+// Provenance: refusal is real EC2's *observed* behavior, not its documented behavior.
+// Neither Using_Filtering nor the Filter type's reference page says what happens to an
+// unrecognized name — both are silent — so nothing in AWS's documentation settles it, and
+// [ec2InvalidFilterError] carries the reasoning for the code and message.
+func (s ec2FilterSpec) check(params map[string]string) *AWSError {
+	for i := 1; ; i++ {
+		name, ok := params[fmt.Sprintf("Filter.%d.Name", i)]
+		if !ok {
+			return nil
+		}
+		if name == "" || s.documents(name) {
+			continue
+		}
+		return ec2InvalidFilterError(name)
+	}
+}
+
+// ec2InstanceFilterSpec is DescribeInstances' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html.
+//
+// The widest set of the nine, at 136 names. Substrate evaluates ten of them plus
+// tag:<key>; the rest describe instance members it does not model.
+func ec2InstanceFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated: []string{
+			"availability-zone", "image-id", "instance-id", "instance-state-code",
+			"instance-state-name", "instance-type", "key-name", "subnet-id", "tag-key",
+			"vpc-id",
+		},
+		accepted: []string{
+			"affinity", "architecture", "availability-zone-id",
+			"block-device-mapping.attach-time",
+			"block-device-mapping.delete-on-termination",
+			"block-device-mapping.device-name", "block-device-mapping.status",
+			"block-device-mapping.volume-id", "boot-mode", "capacity-reservation-id",
+			"capacity-reservation-specification.capacity-reservation-preference",
+			"capacity-reservation-specification.capacity-reservation-target.capacity-reservation-id",
+			"capacity-reservation-specification.capacity-reservation-target.capacity-reservation-resource-group-arn",
+			"client-token", "current-instance-boot-mode", "dns-name", "ebs-optimized",
+			"ena-support", "enclave-options.enabled", "hibernation-options.configured",
+			"host-id", "hypervisor", "iam-instance-profile.arn",
+			"iam-instance-profile.id", "instance-lifecycle", "instance.group-id",
+			"instance.group-name", "ip-address", "ipv6-address", "kernel-id",
+			"launch-index", "launch-time", "maintenance-options.auto-recovery",
+			"metadata-options.http-endpoint", "metadata-options.http-protocol-ipv4",
+			"metadata-options.http-protocol-ipv6",
+			"metadata-options.http-put-response-hop-limit",
+			"metadata-options.http-tokens", "metadata-options.instance-metadata-tags",
+			"metadata-options.state", "monitoring-state",
+			"network-interface.addresses.association.allocation-id",
+			"network-interface.addresses.association.association-id",
+			"network-interface.addresses.association.carrier-ip",
+			"network-interface.addresses.association.customer-owned-ip",
+			"network-interface.addresses.association.ip-owner-id",
+			"network-interface.addresses.association.public-dns-name",
+			"network-interface.addresses.association.public-ip",
+			"network-interface.addresses.primary",
+			"network-interface.addresses.private-dns-name",
+			"network-interface.addresses.private-ip-address",
+			"network-interface.association.allocation-id",
+			"network-interface.association.association-id",
+			"network-interface.association.carrier-ip",
+			"network-interface.association.customer-owned-ip",
+			"network-interface.association.ip-owner-id",
+			"network-interface.association.public-dns-name",
+			"network-interface.association.public-ip",
+			"network-interface.attachment.attach-time",
+			"network-interface.attachment.attachment-id",
+			"network-interface.attachment.delete-on-termination",
+			"network-interface.attachment.device-index",
+			"network-interface.attachment.instance-id",
+			"network-interface.attachment.instance-owner-id",
+			"network-interface.attachment.network-card-index",
+			"network-interface.attachment.status",
+			"network-interface.availability-zone",
+			"network-interface.deny-all-igw-traffic",
+			"network-interface.description", "network-interface.group-id",
+			"network-interface.group-name",
+			"network-interface.ipv4-prefixes.ipv4-prefix",
+			"network-interface.ipv6-address",
+			"network-interface.ipv6-addresses.ipv6-address",
+			"network-interface.ipv6-addresses.is-primary-ipv6",
+			"network-interface.ipv6-native",
+			"network-interface.ipv6-prefixes.ipv6-prefix",
+			"network-interface.mac-address", "network-interface.network-interface-id",
+			"network-interface.operator.managed", "network-interface.operator.principal",
+			"network-interface.outpost-arn", "network-interface.owner-id",
+			"network-interface.private-dns-name",
+			"network-interface.private-ip-address",
+			"network-interface.public-dns-name", "network-interface.requester-id",
+			"network-interface.requester-managed", "network-interface.source-dest-check",
+			"network-interface.status", "network-interface.subnet-id",
+			"network-interface.tag-key", "network-interface.tag-value",
+			"network-interface.vpc-id",
+			"network-performance-options.bandwidth-weighting", "operator.managed",
+			"operator.principal", "outpost-arn", "owner-id", "placement-group-name",
+			"placement-partition-number", "platform", "platform-details",
+			"private-dns-name",
+			"private-dns-name-options.enable-resource-name-dns-a-record",
+			"private-dns-name-options.enable-resource-name-dns-aaaa-record",
+			"private-dns-name-options.hostname-type", "private-ip-address",
+			"product-code", "product-code.type", "ramdisk-id", "reason", "requester-id",
+			"reservation-id", "root-device-name", "root-device-type",
+			"source-dest-check", "spot-instance-request-id", "state-reason-code",
+			"state-reason-message", "tenancy", "tpm-support", "usage-operation",
+			"usage-operation-update-time", "virtualization-type",
+		},
+	}
+}
+
+// ec2ImageFilterSpec is DescribeImages' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html.
+//
+// tag-key joined the evaluated list in #686, which also stopped a valueless tag:<key>
+// filter from standing in for it.
+func ec2ImageFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated: []string{
+			"block-device-mapping.snapshot-id", "image-id", "tag-key",
+		},
+		accepted: []string{
+			"architecture", "block-device-mapping.delete-on-termination",
+			"block-device-mapping.device-name", "block-device-mapping.encrypted",
+			"block-device-mapping.volume-size", "block-device-mapping.volume-type",
+			"creation-date", "description", "ena-support", "free-tier-eligible",
+			"hypervisor", "image-allowed", "image-type",
+			"image-watermark.source-image-creation-time",
+			"image-watermark.source-image-id", "image-watermark.source-image-region",
+			"image-watermark.watermark-creation-time", "image-watermark.watermark-key",
+			"is-public", "kernel-id", "manifest-location", "name", "owner-alias",
+			"owner-id", "platform", "product-code", "product-code.type",
+			"public-ssm-parameter-name", "ramdisk-id", "root-device-name",
+			"root-device-type", "source-image-id", "source-image-region",
+			"source-instance-id", "sriov-net-support", "state", "state-reason-code",
+			"state-reason-message", "virtualization-type",
+		},
+	}
+}
+
+// ec2VolumeFilterSpec is DescribeVolumes' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html.
+//
+// Eleven of AWS's twenty names are evaluated, which is the widest coverage of any
+// operation here — #670 filled it in.
+func ec2VolumeFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated: []string{
+			"attachment.delete-on-termination", "attachment.device",
+			"attachment.instance-id", "availability-zone", "size", "snapshot-id",
+			"status", "tag-key", "volume-id", "volume-type",
+		},
+		accepted: []string{
+			"attachment.attach-time", "attachment.status", "availability-zone-id",
+			"create-time", "encrypted", "fast-restored", "multi-attach-enabled",
+			"operator.managed", "operator.principal",
+		},
+	}
+}
+
+// ec2SnapshotFilterSpec is DescribeSnapshots' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshots.html.
+//
+// Only snapshot-id is evaluated. Widening that is #685.
+func ec2SnapshotFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated:      []string{"snapshot-id"},
+		accepted: []string{
+			"description", "encrypted", "owner-alias", "owner-id", "progress",
+			"start-time", "status", "storage-tier", "tag-key", "transfer-type",
+			"volume-id", "volume-size",
+		},
+	}
+}
+
+// ec2SecurityGroupFilterSpec is DescribeSecurityGroups' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html.
+//
+// The twenty rule-scoped filters are accepted and inert. AWS's own note on this
+// operation — "if using multiple filters for rules, the results include security groups
+// for which any combination of rules, not necessarily a single rule, match all filters" —
+// is a semantics substrate would have to implement deliberately rather than incidentally,
+// so answering those names is left to a change that can pin that rule.
+func ec2SecurityGroupFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated:      []string{"group-id", "group-name", "vpc-id"},
+		accepted: []string{
+			"description", "egress.ip-permission.cidr",
+			"egress.ip-permission.from-port", "egress.ip-permission.group-id",
+			"egress.ip-permission.group-name", "egress.ip-permission.ipv6-cidr",
+			"egress.ip-permission.prefix-list-id", "egress.ip-permission.protocol",
+			"egress.ip-permission.to-port", "egress.ip-permission.user-id",
+			"ip-permission.cidr", "ip-permission.from-port", "ip-permission.group-id",
+			"ip-permission.group-name", "ip-permission.ipv6-cidr",
+			"ip-permission.prefix-list-id", "ip-permission.protocol",
+			"ip-permission.to-port", "ip-permission.user-id", "owner-id", "tag-key",
+		},
+	}
+}
+
+// ec2RouteTableFilterSpec is DescribeRouteTables' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRouteTables.html.
+func ec2RouteTableFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated: []string{
+			"association.route-table-id", "association.subnet-id", "vpc-id",
+		},
+		accepted: []string{
+			"association.gateway-id", "association.main",
+			"association.route-table-association-id", "owner-id", "route-table-id",
+			"route.destination-cidr-block", "route.destination-ipv6-cidr-block",
+			"route.destination-prefix-list-id",
+			"route.egress-only-internet-gateway-id", "route.gateway-id",
+			"route.instance-id", "route.nat-gateway-id", "route.origin", "route.state",
+			"route.transit-gateway-id", "route.vpc-peering-connection-id", "tag-key",
+		},
+	}
+}
+
+// ec2NatGatewayFilterSpec is DescribeNatGateways' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNatGateways.html.
+//
+// AWS's narrowest tag-bearing set, at six names.
+func ec2NatGatewayFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated:      []string{"state", "vpc-id"},
+		accepted:       []string{"nat-gateway-id", "subnet-id", "tag-key"},
+	}
+}
+
+// ec2FleetFilterSpec is DescribeFleets' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeFleets.html.
+//
+// The reference documents five filters and **no tag filter at all** — neither tag:<key>
+// nor tag-key — even though a fleet carries tags and DescribeFleets renders them. So
+// tag:<key> is refused here while it is accepted on every neighboring describe, which is
+// AWS's set and not an omission: a caller looking for a fleet by tag uses Resource Groups
+// Tagging or DescribeTags.
+func ec2FleetFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		evaluated: []string{"activity-status", "fleet-state", "type"},
+		accepted: []string{
+			"excess-capacity-termination-policy", "replace-unhealthy-instances",
+		},
+	}
+}
+
+// ec2InstanceTypeOfferingFilterSpec is DescribeInstanceTypeOfferings' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html.
+//
+// Two names, both evaluated, and no tag filter — an instance type offering is not a
+// resource and carries no tags. This operation refused an undocumented name before #687
+// through a check of its own, and is where [ec2InvalidFilterError] came from.
+func ec2InstanceTypeOfferingFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{evaluated: []string{"instance-type", "location"}}
+}

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -795,6 +795,9 @@ func (p *EC2Plugin) createFleetResponse(fleet *EC2Fleet) (*AWSResponse, error) {
 func (p *EC2Plugin) describeFleets(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	ids := extractIndexedParams(req.Params, "FleetId")
+	if err := ec2FleetFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
 	filters := extractEC2Filters(req.Params)
 
 	keys, err := p.state.List(goCtx, ec2Namespace, "fleet:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -974,9 +974,12 @@ func (p *EC2Plugin) runInstancesResponse(instances []EC2Instance, reservationID 
 
 // ec2InstanceMatchesFilters reports whether an instance satisfies every supplied
 // DescribeInstances filter (filters are AND-combined; each filter's values are
-// OR-combined). Supported keys cover the filters real callers use; an unknown
-// key matches nothing (returns false) rather than being silently ignored, so a
-// filtered query never returns resources the caller meant to exclude.
+// OR-combined).
+//
+// An unrecognized filter name never reaches here: [ec2InstanceFilterSpec] refuses it
+// before the scan (#687). So the names this function does not handle are exactly the
+// ones DescribeInstances documents and substrate keeps no state to answer, and those
+// are inert — see [ec2InstanceMatchesFilter].
 func ec2InstanceMatchesFilters(inst EC2Instance, filters map[string][]string) bool {
 	for name, values := range filters {
 		if !ec2InstanceMatchesFilter(inst, name, values) {
@@ -987,6 +990,14 @@ func ec2InstanceMatchesFilters(inst EC2Instance, filters map[string][]string) bo
 }
 
 // ec2InstanceMatchesFilter evaluates a single filter against an instance.
+//
+// A name it does not handle is one of the 125 DescribeInstances documents over instance
+// members substrate does not model, and it is **inert** — the instance matches. Until
+// #687 it matched nothing, which was defensible while an unknown name landed here too
+// ("never return resources the caller meant to exclude"), but a refused typo is the
+// better answer to that concern and it left this operation returning empty where every
+// other describe returned everything. One answer for the inert case is the point of
+// #687, so this now agrees with [ec2VolumeMatchesFilter] rather than opposing it.
 func ec2InstanceMatchesFilter(inst EC2Instance, name string, values []string) bool {
 	// tag:<key> — instance has a tag with that key whose value is in values.
 	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
@@ -1029,14 +1040,21 @@ func ec2InstanceMatchesFilter(inst EC2Instance, name string, values []string) bo
 		}
 		return false
 	default:
-		// Unknown filter key: match nothing rather than silently passing.
-		return false
+		// A documented filter substrate cannot evaluate is inert; see the doc comment.
+		return true
 	}
 }
 
 func (p *EC2Plugin) describeInstances(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := newEC2IDFilter(extractIndexedParams(req.Params, "InstanceId"), ec2InstanceIDKind)
 	if err := ids.validate(); err != nil {
+		return nil, err
+	}
+	// The spec check runs before the scan, so a refusal cannot depend on whether any
+	// instance matched (#687). [ec2IDFilter.unresolved] already documents the same
+	// ordering rule from the other side: a resource a filter excluded still counts as
+	// resolved.
+	if err := ec2InstanceFilterSpec().check(req.Params); err != nil {
 		return nil, err
 	}
 	filters := extractEC2Filters(req.Params)
@@ -1609,6 +1627,9 @@ func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSReque
 	if err := ids.validate(); err != nil {
 		return nil, err
 	}
+	if err := ec2SecurityGroupFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
 	filters := extractEC2Filters(req.Params)
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "sg:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
@@ -1997,6 +2018,9 @@ func routeTableHasSubnet(rtb EC2RouteTable, subnetIDs []string) bool {
 func (p *EC2Plugin) describeRouteTables(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := newEC2IDFilter(extractIndexedParams(req.Params, "RouteTableId"), ec2RouteTableIDKind)
 	if err := ids.validate(); err != nil {
+		return nil, err
+	}
+	if err := ec2RouteTableFilterSpec().check(req.Params); err != nil {
 		return nil, err
 	}
 	filters := extractEC2Filters(req.Params)
@@ -3532,6 +3556,10 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 		return nil, fmt.Errorf("ec2 describeImages list: %w", err)
 	}
 
+	if err := ec2ImageFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+
 	// Filters come from the shared extractor rather than a walk of this function's own
 	// (#686). The hand-rolled version broke out of its value loop on the first empty
 	// string, which turned an explicitly empty filter value into the valueless form and
@@ -4223,6 +4251,9 @@ func (p *EC2Plugin) describeNatGateways(reqCtx *RequestContext, req *AWSRequest)
 	if err := filterIDs.validate(); err != nil {
 		return nil, err
 	}
+	if err := ec2NatGatewayFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
 	filters := extractEC2Filters(req.Params)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "nat:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
@@ -4456,12 +4487,13 @@ func (p *EC2Plugin) describeInstanceTypes(_ *RequestContext, req *AWSRequest) (*
 // InstanceType.N; see [ec2CheckInstanceTypesExist] for why, and #485 for the real-AWS
 // diff of both.
 func (p *EC2Plugin) describeInstanceTypeOfferings(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	filters := extractEC2Filters(req.Params)
-	for name := range filters {
-		if name != "instance-type" && name != "location" {
-			return nil, ec2InvalidFilterError(name)
-		}
+	// The bespoke check this replaced iterated the filter *map*, so with two undocumented
+	// names it reported whichever one Go's map order surfaced first (#687). The shared
+	// spec walks Filter.N in request order instead, which is deterministic.
+	if err := ec2InstanceTypeOfferingFilterSpec().check(req.Params); err != nil {
+		return nil, err
 	}
+	filters := extractEC2Filters(req.Params)
 
 	// LocationType is a top-level parameter, not a filter name, and it selects what the
 	// locations in the response *are*. Only availability-zone (the default per the
@@ -5025,6 +5057,10 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 }
 
 func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	if err := ec2VolumeFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+
 	// Collect requested volume IDs from repeated VolumeId.N params.
 	requestedIDs := map[string]bool{}
 	for i := 1; ; i++ {
@@ -5320,6 +5356,9 @@ func (p *EC2Plugin) deleteSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AW
 func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := newEC2IDFilter(extractIndexedParams(req.Params, "SnapshotId"), ec2SnapshotIDKind)
 	if err := ids.validate(); err != nil {
+		return nil, err
+	}
+	if err := ec2SnapshotFilterSpec().check(req.Params); err != nil {
 		return nil, err
 	}
 	filters := extractEC2Filters(req.Params)

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -3396,10 +3396,15 @@ func TestEC2_DescribeInstances_FilterOrderIndependent(t *testing.T) {
 	assert.Equal(t, 0, count(map[string]string{
 		"Filter.1.Name": "tag:k", "Filter.1.Value.1": "other",
 	}))
-	// Unknown filter key matches nothing (does not silently pass).
-	assert.Equal(t, 0, count(map[string]string{
+	// An undocumented filter name is refused (#687). It used to match nothing, which
+	// count() cannot tell apart from a refusal — an error document decodes to zero
+	// instances — so this asserts the status and code rather than the count.
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":        "DescribeInstances",
 		"Filter.1.Name": "some-unknown-filter", "Filter.1.Value.1": "x",
-	}))
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
 	_ = id
 }
 

--- a/emulator/ec2_volume_tags_test.go
+++ b/emulator/ec2_volume_tags_test.go
@@ -511,13 +511,14 @@ func TestEC2_DescribeVolumes_TagFilters(t *testing.T) {
 			want: []string{},
 		},
 		{
-			// Unchanged: this operation drops a name it does not know rather than
-			// refusing or matching nothing, and replacing the filter loop must not
-			// change that.
-			name: "an unknown filter name is still dropped",
+			// A documented filter substrate keeps no state to answer is inert rather
+			// than refused, so the answer is every volume (#687). Refusing it would
+			// deny a filter real EC2 accepts; the accepted-but-unevaluated names are
+			// listed per operation in docs/services.md.
+			name: "a documented filter substrate cannot evaluate is inert",
 			filters: map[string]string{
-				"Filter.1.Name":    "not-a-filter",
-				"Filter.1.Value.1": "x",
+				"Filter.1.Name":    "encrypted",
+				"Filter.1.Value.1": "false",
 			},
 			want: []string{dev.VolumeID, prod.VolumeID, untagged.VolumeID},
 		},


### PR DESCRIPTION
Closes #687

A `Filter.N.Name` outside the set an operation's own API reference documents now answers
`InvalidParameterValue` / `The filter "<name>" is not valid for this request`, HTTP 400, on
all nine EC2 describes that parse filters.

## The defect

Substrate had **three** answers to the same mistake, not the three the issue names in that
order — the issue says three behaviours exist and it is right about the count, but the
mapping is worth stating exactly:

| Former behaviour | Operations |
|---|---|
| Dropped — the filter constrained nothing, so the query returned **everything** | `DescribeVolumes`, `DescribeSnapshots`, `DescribeSecurityGroups`, `DescribeRouteTables`, `DescribeNatGateways`, `DescribeFleets`, `DescribeImages` |
| Matched nothing — the query returned **nothing** | `DescribeInstances` |
| Refused | `DescribeInstanceTypeOfferings` |

Two of the three came back inside a **successful response**, so a consumer's test could pass
on a filter that was never applied.

## The change

A new `emulator/ec2_filters.go` carries one `ec2FilterSpec` per operation:

```go
type ec2FilterSpec struct {
	evaluated      []string // substrate applies these
	accepted       []string // AWS documents them; substrate has no state to answer them
	tagValueFilter bool     // whether the operation documents tag:<key>
}
```

Three design points, each load-bearing:

- **Each list is transcribed from that operation's own reference page**, not shared between
  them. AWS documents different filters for each, so a shared list would refuse a name one
  operation accepts because a sibling does not. `tag:<key>` is the conspicuous case: valid on
  `DescribeInstances`, **refused on `DescribeFleets` and `DescribeInstanceTypeOfferings`**,
  which document no tag filter at all — even though a fleet carries tags and `DescribeFleets`
  renders them. That is AWS's set, not an omission in the transcription, so `tagValueFilter`
  is per spec and cannot be inferred from the presence of `tag-key`.
- **The check runs before the state scan.** `ec2IDFilter.unresolved` already documents the
  same ordering rule from the other side ("a resource that a filter excluded still counts as
  resolved"), so a refusal must not depend on whether any resource matched. An empty account
  and a populated one answer a typo identically.
- **`check` walks `Filter.N` in request order, not the extracted map.** A map has no order:
  given two undocumented names, the map form would name an arbitrary one and two replays of
  one recorded request could report different refusals. `describeInstanceTypeOfferings`' own
  bespoke check had exactly this defect and is deleted in favour of the spec.

### Refusal reproduces AWS's set, not substrate's coverage

The two lists are what keeps the refusal from *exceeding* real EC2's. A name AWS documents
that substrate keeps no state to answer stays **accepted and inert** — refusing `encrypted`
or `ipv6-cidr-block-association.state` would deny a filter real EC2 accepts. Those names are
now listed per operation in `docs/services.md` rather than left to be discovered.

`DescribeInstances`' inert case changes with them: `default: return false` becomes
`return true`. That branch was defensible while an unknown name landed there too ("never
return resources the caller meant to exclude"), but a refused typo answers that concern
directly, and match-nothing is the worse half of the remaining choice — an empty answer
cannot be told apart from "the resource does not exist", so a consumer's wait loop polls
forever where over-matching fails once and visibly. Neither answer is real EC2's, which
would apply the filter; only one of them can be a single rule.

## Provenance

**Refusal is real EC2's *observed* behaviour, not its documented behaviour.** Neither
[`Using_Filtering`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html)
nor the [`Filter` type](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html)
says what happens to a name outside the documented set — both are silent. Recorded in
`ec2FilterSpec.check`'s doc comment, the CHANGELOG and the docs, and it belongs in the
release's `## Provenance`.

`InvalidParameterValue` is the documented code; the message text is substrate's own
(`ec2InvalidFilterError`, unchanged and now with nine callers instead of one), so a consumer
should dispatch on the code.

What AWS *does* document, and this PR relies on: filter names and values are
**case-sensitive** (so `VPC-Id` is refused), filters AND, and values within one filter OR.

## Fail-before

Recorded by neutralizing the refusal (`return ec2InvalidFilterError(name)` → `continue`), by
file copy with restoration verified byte-identical — never `git stash`, and `gofmt -w` +
`go vet` first so a non-compiling mutant would be BROKEN rather than a result. Full-package
run, no `-run` filter:

```
--- FAIL: TestEC2_FilterNames_UndocumentedNameRefused              (all 9 subtests)
--- FAIL: TestEC2_FilterNames_CaseIsSignificant                    (all 3 subtests)
--- FAIL: TestEC2_FilterNames_TagFilterFollowsTheOperation/refused_where_the_operation_documents_no_tag_filter
--- FAIL: TestEC2_FilterNames_RefusalIsDeterministic
--- FAIL: TestEC2_FilterNames_UndocumentedNameRefusedBeforeTheScan
--- FAIL: TestEC2_DescribeInstanceTypeOfferings_UnknownFilterRefused (all 3 subtests)
--- FAIL: TestEC2_DescribeInstances_FilterOrderIndependent
RESTORED identical: True
```

The last two are pre-existing tests, which is the point: the offerings operation's refusal
still holds after its bespoke check was deleted.

A second mutation for the inert change (`return true` → `return false` in
`ec2InstanceMatchesFilter`'s default arm) fails `TestEC2_FilterNames_InertMeansEveryResource`
(all 3 subtests) and **nothing else** — no existing test depended on match-nothing.

## Tests

`emulator/ec2_filter_names_test.go`, new, six tests. The issue asks for "one operation per
former behaviour class"; the table covers all nine operations rather than three, since each
spec is transcribed separately and a fabricated or missing name would be a **false deny** —
the failure mode worth over-testing. Beyond the classes:

- `InertMeansEveryResource` asserts the returned instance IDs, not the status: an empty
  result set is also HTTP 200, so status alone cannot tell inert from match-nothing.
- `CaseIsSignificant` pins `VPC-Id`/`Tag-Key`/`Instance-Id` as refused, per the `Filter`
  type's "Filter names are case-sensitive".
- `RefusalIsDeterministic` sends two undocumented names 20 times and asserts the *first in
  request order* is the one reported — a map-order implementation passes once by luck, not
  twenty times.
- `TagFilterFollowsTheOperation` pins both directions of the `DescribeFleets` split.

Two existing assertions were rewritten rather than extended:

- `ec2_plugin_test.go`'s "Unknown filter key matches nothing" **passed for the wrong reason**
  — it used a `count` helper that decodes an error document to zero instances, so it would
  have kept passing after the refusal landed. It now asserts 400 + `InvalidParameterValue`
  through `ec2ErrorDetail`.
- `ec2_volume_tags_test.go`'s "an unknown filter name is still dropped" row now pins the
  *documented-but-unevaluated* case (`encrypted=false` → every volume), which is the
  behaviour that survives.

## Deliberately out of scope

Three gaps, each now filed and named in the docs rather than left implicit:

- **#695** — the fourteen EC2 describes that never parse `Filter.N` at all. Bringing them in
  would newly refuse filters callers pass harmlessly today, in a change whose point is
  consistency, and each needs its own reference page transcribed first.
- **#697** — filter *values* honour EC2's documented wildcards only on
  `DescribeInstanceTypeOfferings`; everywhere else matching is exact. AWS documents wildcards
  generally, so this is a real divergence, but it is orthogonal to filter *names*.
- **#696** — an empty value list matches everything on `DescribeSecurityGroups` and in
  `ec2FilterAccepts`, where it matches nothing elsewhere. Both sites carry a comment arguing
  for what they do; those arguments need answering, not deleting.

## Compatibility

**A filter name that was silently dropped — including a typo — now produces
`InvalidParameterValue`/400.** That is real EC2's behaviour and the reason the issue exists,
but it will break a caller who misspelled a filter and never noticed. A documented name
substrate cannot evaluate is *not* affected: it stays accepted.

`DescribeInstances` additionally changes what such an accepted-but-unevaluated name answers,
from an empty set to every instance.

## Docs

`docs/services.md` gains **One rule for an unrecognized filter name** — the rule, its
provenance, the three-way split (evaluated / inert / refused), a per-operation table of both
lists, the shared semantics (AND/OR, repeated names, case-sensitivity, valueless `tag:`), and
the three gaps above. The three sites that asserted the old three-behaviour split — the
`DescribeVolumes` tag-filter prose, the `DescribeImages` filter prose and the offerings
section — now point at it, as does `ec2_block_devices.go`'s comment that spelled the split
out. Six operations-table rows link to it.

The table also states the surface's weakest point in the other direction: only
`DescribeInstances`, `DescribeVolumes` and `DescribeImages` actually filter on tags, so on
snapshots, security groups, route tables and NAT gateways a `tag:<key>` filter is accepted
and inert. #685 and #688 close that.

## Verification

```
gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...   # 0 issues
make test                                                                 # race, green
make coverage                                                             # emulator 82.8%, total 82.1%
make docs-reference docs-reference-check docs-versions
npm --prefix docs run build
go vet -C test/e2e ./... && go test -C test/e2e ./...
```
