### PR TITLE
fix(ec2): a subnet reports its tags and filters on them; a snapshot honours its own (#685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **A subnet reports its tags, and `DescribeSubnets` filters on them** (#685). `EC2Subnet`
+  has carried a `Tags` field for as long as it has existed and `CreateTags` on a `subnet-` ID
+  has always written to it — only the reader was missing, so every tag a caller applied to a
+  subnet was stored and invisible. `DescribeSubnets` now renders `tagSet`, and evaluates
+  eleven filter names plus the four alias spellings AWS documents inline
+  (`availabilityZone`, `cidr`, `cidrBlock`, `defaultForAz`), which are separate names on the
+  wire and so are answered individually rather than normalized away.
+
+  It also gains **`subnetArn`, `ownerId` and `defaultForAz`**. The first two are what the
+  `subnet-arn` and `owner-id` filters compare against, so rendering them is what lets a
+  caller round-trip a value it read; a single `ec2SubnetARN` builds the ARN for the filter,
+  the response and the authorization resolver, because two spellings would break the
+  round-trip silently.
+
+  `tagSet` is **absent** on an untagged subnet rather than present-and-empty, following both
+  of AWS's `DescribeSubnets` samples. That deliberately differs from `DescribeSnapshots`,
+  whose own page shows the empty element: each operation follows its own samples rather than
+  a house rule. Five members those samples carry stay absent —
+  `availableIpAddressCount`, `availabilityZoneId`, `assignIpv6AddressOnCreation`,
+  `ipv6CidrBlockAssociationSet` and the
+  `blockPublicAccessStates`/`privateDnsNameOptionsOnLaunch` structures — because nothing in
+  state backs them and deriving an address count from the CIDR would be fabrication.
+
+- **`TagSpecification.N` on `CreateSubnet`** (#685), scoped to `subnet`, under the same two
+  rules every other tag path enforces — the reserved `aws:` prefix and the 50-tag limit —
+  with a refused request creating no subnet. This is how CDK and Terraform set tags, so
+  without it the filters above had nothing to find on a subnet the caller had just made.
+
+- **`Owner.N` and `RestorableBy.N` on `DescribeSnapshots`** (#685). Both sit outside
+  `Filter.N` and both were read by nothing, so a request scoped to one account answered with
+  every snapshot. Substrate is single-account: `self` and the requesting account's ID match
+  everything, and anything else — **including `amazon`** — matches nothing, because
+  answering "snapshots owned by `amazon`" with the account's own snapshots would claim they
+  were public. Values within either parameter OR; the two AND with each other, with the
+  filters, and with `SnapshotId.N`.
+
 - **`tag-key` on `DescribeImages`** (#686). AWS documents it for this operation and
   substrate did not support it, so the name was silently dropped and the filter constrained
   nothing. It is the any-value question — "images carrying an `Env` tag, whatever its
@@ -62,6 +98,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can be a single rule.
 
 ### Fixed
+- **`DescribeSubnets` applies the filters a request sends** (#685). It parsed no `Filter.N`
+  at all, so "the subnets of `vpc-x`" answered with every subnet in the region and the
+  response carried nothing to say the filter had been ignored — the worst shape of this
+  defect, because a consumer walking a VPC's subnets silently got its neighbours' too. Its
+  `SubnetId.N` selection is unchanged, and the filter match runs after it so that a subnet a
+  filter excluded still counts as *resolved*: naming an existing subnet and filtering it out
+  is an empty HTTP 200, not `InvalidSubnetID.NotFound`.
+
+  `cidr-block` is **exact**, per AWS — "The CIDR block you specify must exactly match the
+  subnet's CIDR block for information to be returned for the subnet" — so a caller asking
+  for `10.0.0.0/16` does not get `10.0.1.0/24`.
+
+- **`DescribeSnapshots` applies ten filters instead of one** (#685). `snapshot-id` was the
+  only name it evaluated; the other thirteen were silently dropped, so `status=pending` or
+  `tag:Env=prod` returned every snapshot in the account. Now applied: `description`,
+  `encrypted`, `owner-id`, `snapshot-id`, `start-time`, `status`, `tag-key`, `tag:<key>`,
+  `volume-id` and `volume-size`. The remaining four — `owner-alias`, `progress`,
+  `storage-tier` and `transfer-type` — name members substrate does not render, so there is
+  nothing to compare a value against and they are accepted and inert.
+
+  **These two are a behaviour change.** A request that previously returned everything now
+  returns the subset that actually matches. A consumer's test asserting on a count it got
+  from an unapplied filter will see a different number — which is the point: the number it
+  saw was never the answer to the question it asked.
+
+- **`CreateSubnet` and `DescribeSubnets` render one `Subnet` element** (#685), which is what
+  AWS documents. The two rendered different subsets of it — `CreateSubnet` omitted
+  `mapPublicIpOnLaunch`, and neither carried tags, an ARN, an owner or `defaultForAz` — so a
+  caller reading the create response saw a different subnet from the one it could then
+  describe. A test asserts the two are equal, so they cannot drift apart again.
+
+- **The EC2 plugin's last two function-local tag renderers are gone** (#685).
+  `DescribeSnapshots` and `DescribeFleets` each carried their own `tagItem` copy; both now
+  use the package-level `ec2TagItems`, as `DescribeImages` began doing in #686. Nothing
+  observable changes — all four shapes matched — but a fix to the shape has one place to
+  land instead of four.
+
 - **A `tag:<key>` filter with no value no longer matches any value on `DescribeImages`**
   (#686). `Filter.1.Name=tag:Env` with no `Filter.1.Value.1` matched every image carrying an
   `Env` tag, which is `tag-key`'s job — so this one operation answered a filter differently
@@ -96,7 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`DescribeImages` renders its tags through the package-level renderer** (#686), deleting
   one of the EC2 plugin's three identical function-local `tagItem` copies. Nothing
   observable changes — the shapes matched — but a fix to that shape now has one place to
-  land. `DescribeFleets` and `DescribeSnapshots` still carry theirs.
+  land. #685 below deletes the last two, on `DescribeSnapshots` and `DescribeFleets`.
 
 ## [v0.105.0] - 2026-08-20
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -2630,8 +2630,8 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | CreateVpc | |
 | DescribeVpcs | [Explicit resource IDs](#explicit-resource-ids) |
 | DeleteVpc | [Explicit resource IDs](#explicit-resource-ids) |
-| CreateSubnet | |
-| DescribeSubnets | [Explicit resource IDs](#explicit-resource-ids) |
+| CreateSubnet | `TagSpecification.N` scoped to `subnet`, and it renders the same subnet `DescribeSubnets` does — see [A subnet reports its tags, and filters on them](#a-subnet-reports-its-tags-and-filters-on-them) |
+| DescribeSubnets | [Explicit resource IDs](#explicit-resource-ids); fourteen filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); [reports `tagSet`, `subnetArn`, `ownerId` and `defaultForAz`](#a-subnet-reports-its-tags-and-filters-on-them) |
 | DeleteSubnet | [Explicit resource IDs](#explicit-resource-ids) |
 | CreateSecurityGroup | |
 | DescribeSecurityGroups | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
@@ -2653,7 +2653,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | AssociateRouteTable | |
 | DescribeRouteTables | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | DeleteRouteTable | [Explicit resource IDs](#explicit-resource-ids) |
-| DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
+| DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids); ten filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); `Owner.N` and `RestorableBy.N` — see [A snapshot filters on its own members](#a-snapshot-filters-on-its-own-members-and-scopes-by-account) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | CreateLaunchTemplate | Creates version 1. Networking is read from every `NetworkInterface.N.*` — see [Launch template networking](#launch-template-networking) |
@@ -2677,10 +2677,12 @@ The check runs **before** the state scan, so the refusal never depends on whethe
 resource happened to match: an empty account and a populated one answer a typo the same
 way.
 
-This replaced three different answers across substrate's nine filter-parsing EC2
-operations — dropped on volumes, snapshots, security groups, route tables, NAT gateways,
-fleets and images; matched nothing on instances; refused on instance-type offerings — with
-the one real EC2 gives.
+This replaced three different answers across substrate's filter-parsing EC2 operations —
+dropped on volumes, snapshots, security groups, route tables, NAT gateways, fleets and
+images; matched nothing on instances; refused on instance-type offerings — with the one
+real EC2 gives. `DescribeSubnets` is the tenth operation the rule covers, and the only one
+that arrived with both halves at once: it parsed no `Filter.N` at all before it gained the
+filters below.
 
 **This is a behaviour change, and the loudest one in the release that brought it.** A
 misspelled filter name previously came back as a successful response: dropped, so the query
@@ -2723,7 +2725,8 @@ one is refused on its neighbour — `tag:<key>` most conspicuously (see below).
 | DescribeInstances | `availability-zone`, `image-id`, `instance-id`, `instance-state-code`, `instance-state-name`, `instance-type`, `key-name`, `subnet-id`, `tag-key`, `tag:<key>`, `vpc-id` | the other 125 — the `network-interface.*`, `block-device-mapping.*`, `metadata-options.*`, `capacity-reservation*`, `private-dns-name-options.*`, `iam-instance-profile.*` and `operator.*` families, plus `architecture`, `platform`, `tenancy`, `root-device-type`, `owner-id` and the rest |
 | DescribeImages | `block-device-mapping.snapshot-id`, `image-id`, `tag-key`, `tag:<key>` | the other 39 — the `block-device-mapping.*` (bar `snapshot-id`), `image-watermark.*`, `product-code*`, `source-image*` and `state-reason-*` families, plus `architecture`, `creation-date`, `description`, `is-public`, `name`, `owner-alias`, `owner-id`, `platform`, `root-device-name`, `root-device-type`, `state` and the rest |
 | DescribeVolumes | `attachment.delete-on-termination`, `attachment.device`, `attachment.instance-id`, `availability-zone`, `size`, `snapshot-id`, `status`, `tag-key`, `tag:<key>`, `volume-id`, `volume-type` | `attachment.attach-time`, `attachment.status`, `availability-zone-id`, `create-time`, `encrypted`, `fast-restored`, `multi-attach-enabled`, `operator.managed`, `operator.principal` |
-| DescribeSnapshots | `snapshot-id` | `description`, `encrypted`, `owner-alias`, `owner-id`, `progress`, `start-time`, `status`, `storage-tier`, `tag-key`, `tag:<key>`, `transfer-type`, `volume-id`, `volume-size` |
+| DescribeSnapshots | `description`, `encrypted`, `owner-id`, `snapshot-id`, `start-time`, `status`, `tag-key`, `tag:<key>`, `volume-id`, `volume-size` | `owner-alias`, `progress`, `storage-tier`, `transfer-type` |
+| DescribeSubnets | `availability-zone`, `cidr-block`, `default-for-az`, `map-public-ip-on-launch`, `owner-id`, `state`, `subnet-arn`, `subnet-id`, `tag-key`, `tag:<key>`, `vpc-id`, plus AWS's four alias spellings `availabilityZone`, `cidr`, `cidrBlock` and `defaultForAz` | `availability-zone-id`/`availabilityZoneId`, `available-ip-address-count`, `customer-owned-ipv4-pool`, `enable-dns64`, `enable-lni-at-device-index`, `ipv6-native`, `map-customer-owned-ip-on-launch`, `outpost-arn`, and the three `ipv6-cidr-block-association.*` and three `private-dns-name-options-on-launch.*` filters |
 | DescribeSecurityGroups | `group-id`, `group-name`, `vpc-id` | `description`, `owner-id`, `tag-key`, `tag:<key>`, and the twenty `ip-permission.*`/`egress.ip-permission.*` rule filters |
 | DescribeRouteTables | `association.route-table-id`, `association.subnet-id`, `vpc-id` | `association.gateway-id`, `association.main`, `association.route-table-association-id`, `owner-id`, `route-table-id`, `tag-key`, `tag:<key>`, and the eleven `route.*` filters |
 | DescribeNatGateways | `state`, `vpc-id` | `nat-gateway-id`, `subnet-id`, `tag-key`, `tag:<key>` |
@@ -2735,13 +2738,13 @@ document no tag filter at all — neither `tag:<key>` nor `tag-key` — even tho
 carries tags and `DescribeFleets` renders them. That is AWS's set, not an omission here; to
 find a fleet by tag, use Resource Groups Tagging.
 
-Read the tag rows in the other direction and they are the surface's weakest point: only
-**`DescribeInstances`, `DescribeVolumes` and `DescribeImages`** actually filter on tags.
-On snapshots, security groups, route tables and NAT gateways a `tag:<key>` filter is
-accepted and inert, so "find the resources tagged `Env=prod`" answers with *all* of them.
-Real EC2 offers three routes to finding a resource by tag: the describe filters,
-`DescribeTags`, and Resource Groups Tagging. Substrate serves the third in full, the first
-on three operations, and does not implement `DescribeTags` at all.
+Read the tag rows in the other direction and they remain the surface's weakest point:
+**`DescribeInstances`, `DescribeVolumes`, `DescribeImages`, `DescribeSnapshots` and
+`DescribeSubnets`** filter on tags; on security groups, route tables and NAT gateways a
+`tag:<key>` filter is accepted and inert, so "find the resources tagged `Env=prod`"
+answers with *all* of them. Real EC2 offers three routes to finding a resource by tag: the
+describe filters, `DescribeTags`, and Resource Groups Tagging. Substrate serves the third
+in full, the first on five operations, and does not implement `DescribeTags` at all.
 
 #### Filter semantics that apply everywhere
 
@@ -2757,8 +2760,8 @@ on three operations, and does not implement `DescribeTags` at all.
   way to ask the any-value question.
 
 **Two gaps, deliberately left standing**, because closing either would newly change
-requests that succeed today. Fourteen EC2 describes — including `DescribeVpcs`,
-`DescribeSubnets`, `DescribeInstanceTypes` and `DescribeAvailabilityZones` — never parse
+requests that succeed today. Thirteen EC2 describes — including `DescribeVpcs`,
+`DescribeAddresses`, `DescribeInstanceTypes` and `DescribeAvailabilityZones` — never parse
 `Filter.N` at all, so they neither apply nor refuse one
 ([#695](https://github.com/scttfrdmn/substrate/issues/695)). And filter *values* honour
 EC2's documented wildcards only on `DescribeInstanceTypeOfferings`; everywhere else
@@ -4100,6 +4103,75 @@ replacing the first. AWS documents that filters are ANDed and the values within 
 ORed, and says nothing about a name appearing twice, so the merge is substrate's reading.
 What it replaces was not a reading of anything — the earlier entry was discarded with no
 indication. Differently-named filters are ANDed, as documented, and always were.
+
+#### A subnet reports its tags, and filters on them
+
+`EC2Subnet` has carried a `Tags` field since it existed, and `CreateTags` on a `subnet-` ID
+has always written to it. Only the reader was missing: `DescribeSubnets` rendered six
+members and no `tagSet`, and it parsed **no `Filter.N` at all** — so a request for "the
+subnets of `vpc-x`" answered with every subnet in the region, with nothing in the response
+to say the filter had not been applied. That is the worst shape of an ignored filter: a
+consumer walking a VPC's subnets silently got its neighbours' as well.
+
+Three things changed together, because each is useless without the others:
+
+- **`CreateSubnet` honours `TagSpecification.N`** scoped to `subnet`, under the same two
+  rules every other tag path enforces — the reserved `aws:` prefix and the 50-tag limit —
+  and a refused request creates no subnet. This is how CDK and Terraform set the tags a
+  caller then filters on, so without it the filters below had nothing to find.
+- **`CreateSubnet` and `DescribeSubnets` render one `Subnet` element**, which is what AWS
+  documents. The two previously rendered different subsets of it: `CreateSubnet` omitted
+  `mapPublicIpOnLaunch`, so a caller reading the create response saw a different subnet from
+  the one it could then describe. A regression test asserts the two are equal.
+- **The element gained `tagSet`, `subnetArn`, `ownerId` and `defaultForAz`.** The ARN and
+  the owner are what the `subnet-arn` and `owner-id` filters compare against, so rendering
+  them is what lets a caller round-trip a value it read.
+
+`tagSet` is **absent** on an untagged subnet rather than present-and-empty, which is what
+both of AWS's `DescribeSubnets` samples show. That deliberately differs from
+`DescribeSnapshots`, whose own page shows the empty element — each follows its own
+operation's samples rather than one house rule. No sample on either page shows a *tagged*
+subnet, so `tagSet`'s position last in the element is substrate's choice.
+
+Five members AWS's samples carry stay absent: `availableIpAddressCount`,
+`availabilityZoneId`, `assignIpv6AddressOnCreation`, `ipv6CidrBlockAssociationSet` and the
+`blockPublicAccessStates`/`privateDnsNameOptionsOnLaunch` structures. Nothing in state backs
+them, and deriving an address count from the CIDR would be fabrication — the real count
+depends on how many addresses AWS reserves and on every interface in the subnet.
+
+Eleven filter names are applied, plus the four alias spellings the reference documents
+inline ("You can also use `availabilityZone` as the filter name"); the aliases are separate
+names on the wire, so each is answered beside its canonical form rather than normalized
+away. The fourteen names AWS documents that substrate keeps no state for are accepted and
+inert, and anything outside the twenty-five is refused —
+[the same rule as everywhere else](#one-rule-for-an-unrecognized-filter-name), which lists
+both sets.
+
+`cidr-block` is **exact**, per AWS: "The CIDR block you specify must exactly match the
+subnet's CIDR block for information to be returned for the subnet." A caller asking for
+`10.0.0.0/16` does not get `10.0.1.0/24`.
+
+#### A snapshot filters on its own members, and scopes by account
+
+`DescribeSnapshots` evaluated exactly one filter — `snapshot-id` — and silently dropped the
+other thirteen, so `status=pending` or `tag:Env=prod` returned every snapshot in the
+account. Ten are now applied: `description`, `encrypted`, `owner-id`, `snapshot-id`,
+`start-time`, `status`, `tag-key`, `tag:<key>`, `volume-id` and `volume-size`. The remaining
+four — `owner-alias`, `progress`, `storage-tier` and `transfer-type` — name members
+substrate does not render, so there is nothing to compare a value against; they are
+accepted and inert.
+
+**`Owner.N` and `RestorableBy.N`** were read by neither the ID selection nor the filters,
+and are now honoured. Both sit outside `Filter.N` and both accept `self`, an account ID, or
+one of AWS's aliases. Substrate is single-account, so `self` and the requesting account's ID
+match everything, and **anything else — including `amazon` — matches nothing**: answering
+"snapshots owned by `amazon`" with the account's own snapshots would claim they were public.
+Values within either parameter OR, and the two AND with the filters and with the ID list.
+
+A snapshot a *filter* excluded still counts as resolved, so naming an existing snapshot and
+filtering it out is an empty HTTP 200 rather than `InvalidSnapshot.NotFound` — the rule
+[Explicit resource IDs](#explicit-resource-ids) states, and the distinction between "not
+yet" and "never" that a consumer's wait loop turns on. `DescribeSubnets` follows it too.
 
 ### Seeding EC2 Fleet partial fulfillment
 

--- a/emulator/ec2_authz.go
+++ b/emulator/ec2_authz.go
@@ -71,7 +71,7 @@ func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, r
 	switch {
 	case launch.subnetID != "":
 		out = append(out, authzResource{
-			ARN:  "arn:aws:ec2:" + region + ":" + acct + ":subnet/" + launch.subnetID,
+			ARN:  ec2SubnetARN(acct, region, launch.subnetID),
 			Tags: ec2AuthzTagsFor(state, "subnet:"+acct+"/"+region+"/"+launch.subnetID),
 		})
 	case launch.subnetWildcard:

--- a/emulator/ec2_filter_names_test.go
+++ b/emulator/ec2_filter_names_test.go
@@ -13,7 +13,8 @@ import (
 //
 // Before this change the answer depended on which operation received the name — dropped
 // on volumes, snapshots, security groups, route tables, NAT gateways, fleets and images;
-// matched nothing on instances; refused on instance-type offerings. Real EC2 refuses. The
+// matched nothing on instances; refused on instance-type offerings; and, on subnets, never
+// parsed at all until #685 gave that operation filters. Real EC2 refuses. The
 // table below covers one operation per former behavior class, which is what the issue
 // asks for, plus the two cases the split into evaluated/accepted names creates: a
 // documented name substrate cannot answer must *not* be refused, and an operation that
@@ -51,6 +52,9 @@ func TestEC2_FilterNames_UndocumentedNameRefused(t *testing.T) {
 		// the plausible-looking spelling is exactly the mistake worth refusing.
 		{"DescribeFleets", "fleet-id", "dropped"},
 		{"DescribeInstanceTypeOfferings", "location-type", "refused"},
+		// DescribeSubnets parsed no Filter.N at all before #685, so this name — and every
+		// other — was neither applied nor refused. It is the tenth spec's first case.
+		{"DescribeSubnets", "vpc", "ignored the parameter entirely"},
 	} {
 		t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
 			status, code, message := ec2FilterRefusal(t, tc.action, tc.filter)
@@ -97,6 +101,8 @@ func TestEC2_FilterNames_DocumentedButUnevaluatedIsAccepted(t *testing.T) {
 		{"DescribeRouteTables", "route.state"},
 		{"DescribeNatGateways", "nat-gateway-id"},
 		{"DescribeFleets", "replace-unhealthy-instances"},
+		{"DescribeSubnets", "ipv6-cidr-block-association.state"},
+		{"DescribeSubnets", "outpost-arn"},
 	} {
 		t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
 			status, code, _ := ec2FilterRefusal(t, tc.action, tc.filter)
@@ -173,6 +179,8 @@ func TestEC2_FilterNames_TagFilterFollowsTheOperation(t *testing.T) {
 			{"DescribeSnapshots", "tag:Env"},
 			{"DescribeRouteTables", "tag:Env"},
 			{"DescribeNatGateways", "tag-key"},
+			{"DescribeSubnets", "tag:Env"},
+			{"DescribeSubnets", "tag-key"},
 		} {
 			t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
 				status, _, _ := ec2FilterRefusal(t, tc.action, tc.filter)

--- a/emulator/ec2_filters.go
+++ b/emulator/ec2_filters.go
@@ -84,7 +84,7 @@ func (s ec2FilterSpec) check(params map[string]string) *AWSError {
 // ec2InstanceFilterSpec is DescribeInstances' filter set, from
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html.
 //
-// The widest set of the nine, at 136 names. Substrate evaluates ten of them plus
+// The widest set of the ten, at 136 names. Substrate evaluates ten of them plus
 // tag:<key>; the rest describe instance members it does not model.
 func ec2InstanceFilterSpec() ec2FilterSpec {
 	return ec2FilterSpec{
@@ -229,15 +229,48 @@ func ec2VolumeFilterSpec() ec2FilterSpec {
 // ec2SnapshotFilterSpec is DescribeSnapshots' filter set, from
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshots.html.
 //
-// Only snapshot-id is evaluated. Widening that is #685.
+// Ten of AWS's fourteen names are evaluated as of #685 — the nine below plus tag:<key>. The
+// four that are not name snapshot members substrate does not render, so there is nothing to
+// compare a value against.
 func ec2SnapshotFilterSpec() ec2FilterSpec {
 	return ec2FilterSpec{
 		tagValueFilter: true,
-		evaluated:      []string{"snapshot-id"},
+		evaluated: []string{
+			"description", "encrypted", "owner-id", "snapshot-id", "start-time",
+			"status", "tag-key", "volume-id", "volume-size",
+		},
+		accepted: []string{"owner-alias", "progress", "storage-tier", "transfer-type"},
+	}
+}
+
+// ec2SubnetFilterSpec is DescribeSubnets' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html.
+//
+// Twenty-five names plus five alias spellings the page documents inline, of which #685
+// evaluates eleven and four aliases. The aliases are listed individually rather than
+// normalized: they are distinct names on the wire, and folding them would make the spec
+// disagree with [ec2SubnetMatchesFilter] about what it accepts.
+//
+// This operation parsed no Filter.N at all before #685, so unlike its siblings it gains
+// both halves at once — the refusal from #687 and the matching.
+func ec2SubnetFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated: []string{
+			"availability-zone", "availabilityZone", "cidr", "cidr-block", "cidrBlock",
+			"default-for-az", "defaultForAz", "map-public-ip-on-launch", "owner-id",
+			"state", "subnet-arn", "subnet-id", "tag-key", "vpc-id",
+		},
 		accepted: []string{
-			"description", "encrypted", "owner-alias", "owner-id", "progress",
-			"start-time", "status", "storage-tier", "tag-key", "transfer-type",
-			"volume-id", "volume-size",
+			"availability-zone-id", "availabilityZoneId", "available-ip-address-count",
+			"customer-owned-ipv4-pool", "enable-dns64", "enable-lni-at-device-index",
+			"ipv6-cidr-block-association.association-id",
+			"ipv6-cidr-block-association.ipv6-cidr-block",
+			"ipv6-cidr-block-association.state", "ipv6-native",
+			"map-customer-owned-ip-on-launch", "outpost-arn",
+			"private-dns-name-options-on-launch.enable-resource-name-dns-a-record",
+			"private-dns-name-options-on-launch.enable-resource-name-dns-aaaa-record",
+			"private-dns-name-options-on-launch.hostname-type",
 		},
 	}
 }

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -811,10 +811,6 @@ func (p *EC2Plugin) describeFleets(reqCtx *RequestContext, req *AWSRequest) (*AW
 		SpotTargetCapacity        int    `xml:"spotTargetCapacity"`
 		DefaultTargetCapacityType string `xml:"defaultTargetCapacityType,omitempty"`
 	}
-	type tagItem struct {
-		Key   string `xml:"key"`
-		Value string `xml:"value"`
-	}
 	type fleetItem struct {
 		FleetID                     string             `xml:"fleetId"`
 		FleetState                  string             `xml:"fleetState"`
@@ -825,7 +821,7 @@ func (p *EC2Plugin) describeFleets(reqCtx *RequestContext, req *AWSRequest) (*AW
 		FulfilledOnDemandCapacity   int                `xml:"fulfilledOnDemandCapacity"`
 		TargetCapacitySpecification targetCapacityXML  `xml:"targetCapacitySpecification"`
 		ClientToken                 string             `xml:"clientToken,omitempty"`
-		Tags                        []tagItem          `xml:"tagSet>item,omitempty"`
+		Tags                        []ec2TagItem       `xml:"tagSet>item,omitempty"`
 		Errors                      []fleetDescribeErr `xml:"errorSet>item,omitempty"`
 	}
 	type response struct {
@@ -879,9 +875,7 @@ func (p *EC2Plugin) describeFleets(reqCtx *RequestContext, req *AWSRequest) (*AW
 		if fleet.DefaultTargetCapacityType != "spot" {
 			item.FulfilledOnDemandCapacity = fleet.FulfilledCapacity
 		}
-		for _, t := range fleet.Tags {
-			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck // XML tags differ from EC2Tag's JSON tags.
-		}
+		item.Tags = ec2TagItems(fleet.Tags)
 		for _, e := range fleet.Errors {
 			item.Errors = append(item.Errors, fleetDescribeErr{
 				LaunchTemplateAndOverrides: fleetLTAndOverrides(e.LaunchTemplateID, e.LaunchTemplateName, "", e.Override),

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -1468,12 +1468,25 @@ func (p *EC2Plugin) deleteVPC(reqCtx *RequestContext, req *AWSRequest) (*AWSResp
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
 }
 
+// createSubnet creates a subnet in a VPC, optionally tagging it on creation.
+//
+// TagSpecification.N arrived with #685 for the same reason it did for CreateVolume in #670:
+// CDK and Terraform tag at create time, so without it the tags a caller can then filter on
+// could never be set. The tag rules are checked before the record is written, so a rejected
+// request creates no subnet.
 func (p *EC2Plugin) createSubnet(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	vpcID := req.Params["VpcId"]
 	cidr := req.Params["CidrBlock"]
 	az := req.Params["AvailabilityZone"]
 	if az == "" {
 		az = reqCtx.Region + "a"
+	}
+	tags := ec2TagSpecificationTags(req.Params, "", "subnet")
+	if awsErr := ec2CheckTagRules(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, tags); awsErr != nil {
+		return nil, awsErr
 	}
 	subnetID := generateSubnetID()
 	subnet := EC2Subnet{
@@ -1482,6 +1495,7 @@ func (p *EC2Plugin) createSubnet(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		CIDRBlock:        cidr,
 		AvailabilityZone: az,
 		State:            "available",
+		Tags:             tags,
 		AccountID:        reqCtx.AccountID,
 		Region:           reqCtx.Region,
 	}
@@ -1496,45 +1510,40 @@ func (p *EC2Plugin) createSubnet(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if err := p.appendToList(reqCtx.AccountID+"/"+reqCtx.Region, "subnet_ids", subnetID); err != nil {
 		return nil, err
 	}
-	type subnetItem struct {
-		SubnetID         string `xml:"subnetId"`
-		VpcID            string `xml:"vpcId"`
-		CIDRBlock        string `xml:"cidrBlock"`
-		AvailabilityZone string `xml:"availabilityZone"`
-		State            string `xml:"state"`
-	}
 	type response struct {
-		XMLName xml.Name   `xml:"CreateSubnetResponse"`
-		XMLNS   string     `xml:"xmlns,attr"`
-		Subnet  subnetItem `xml:"subnet"`
+		XMLName xml.Name      `xml:"CreateSubnetResponse"`
+		XMLNS   string        `xml:"xmlns,attr"`
+		Subnet  ec2SubnetItem `xml:"subnet"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{
 		XMLNS:  "http://ec2.amazonaws.com/doc/2016-11-15/",
-		Subnet: subnetItem{SubnetID: subnetID, VpcID: vpcID, CIDRBlock: cidr, AvailabilityZone: az, State: "available"},
+		Subnet: ec2SubnetXML(subnet),
 	})
 }
 
+// describeSubnets lists the account's subnets, honoring an optional list of SubnetId.N
+// parameters and the eleven Filter.N names [ec2SubnetMatchesFilter] evaluates.
+//
+// Filter.N was parsed nowhere here before #685. The spec check runs before the scan so a
+// refusal cannot depend on whether any subnet matched, and ids.match runs before the filters
+// so a subnet a filter excluded still counts as resolved for [ec2IDFilter.unresolved].
 func (p *EC2Plugin) describeSubnets(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := newEC2IDFilter(extractIndexedParams(req.Params, "SubnetId"), ec2SubnetIDKind)
 	if err := ids.validate(); err != nil {
 		return nil, err
 	}
+	if err := ec2SubnetFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "subnet:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeSubnets: %w", err)
 	}
-	type subnetItem struct {
-		SubnetID            string `xml:"subnetId"`
-		VpcID               string `xml:"vpcId"`
-		CIDRBlock           string `xml:"cidrBlock"`
-		AvailabilityZone    string `xml:"availabilityZone"`
-		State               string `xml:"state"`
-		MapPublicIPOnLaunch bool   `xml:"mapPublicIpOnLaunch"`
-	}
 	type response struct {
-		XMLName xml.Name     `xml:"DescribeSubnetsResponse"`
-		XMLNS   string       `xml:"xmlns,attr"`
-		Subnets []subnetItem `xml:"subnetSet>item"`
+		XMLName xml.Name        `xml:"DescribeSubnetsResponse"`
+		XMLNS   string          `xml:"xmlns,attr"`
+		Subnets []ec2SubnetItem `xml:"subnetSet>item"`
 	}
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 	for _, k := range allKeys {
@@ -1549,14 +1558,10 @@ func (p *EC2Plugin) describeSubnets(reqCtx *RequestContext, req *AWSRequest) (*A
 		if !ids.match(subnet.SubnetID) {
 			continue
 		}
-		resp.Subnets = append(resp.Subnets, subnetItem{
-			SubnetID:            subnet.SubnetID,
-			VpcID:               subnet.VPCID,
-			CIDRBlock:           subnet.CIDRBlock,
-			AvailabilityZone:    subnet.AvailabilityZone,
-			State:               subnet.State,
-			MapPublicIPOnLaunch: subnet.MapPublicIPOnLaunch,
-		})
+		if !ec2SubnetMatchesFilters(subnet, filters) {
+			continue
+		}
+		resp.Subnets = append(resp.Subnets, ec2SubnetXML(subnet))
 	}
 	if err := ids.unresolved(); err != nil {
 		return nil, err
@@ -5351,8 +5356,14 @@ func (p *EC2Plugin) deleteSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AW
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
 }
 
-// describeSnapshots lists EBS snapshots owned by the account, honoring an
-// optional list of SnapshotId.N parameters and the snapshot-id Filter.
+// describeSnapshots lists EBS snapshots owned by the account, honoring an optional list of
+// SnapshotId.N parameters, Owner.N and RestorableBy.N, and the ten Filter.N names
+// [ec2SnapshotMatchesFilter] evaluates.
+//
+// The three selectors compose as AWS documents: a snapshot must satisfy the ID list, both
+// account scopes and every filter. ids.match runs first so that a snapshot excluded by a
+// filter still counts as resolved for [ec2IDFilter.unresolved] — a named ID that exists is
+// not "not found" merely because a filter rejected it.
 func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := newEC2IDFilter(extractIndexedParams(req.Params, "SnapshotId"), ec2SnapshotIDKind)
 	if err := ids.validate(); err != nil {
@@ -5362,6 +5373,8 @@ func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (
 		return nil, err
 	}
 	filters := extractEC2Filters(req.Params)
+	owners := newEC2SnapshotOwners(req.Params, reqCtx.AccountID)
+	restorableBy := newEC2SnapshotRestorableBy(req.Params, reqCtx.AccountID)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace,
 		"snapshot:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
@@ -5369,20 +5382,16 @@ func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (
 		return nil, fmt.Errorf("ec2 describeSnapshots list: %w", err)
 	}
 
-	type tagItem struct {
-		Key   string `xml:"key"`
-		Value string `xml:"value"`
-	}
 	type snapshotItem struct {
-		SnapshotID  string    `xml:"snapshotId"`
-		VolumeID    string    `xml:"volumeId,omitempty"`
-		VolumeSize  int64     `xml:"volumeSize"`
-		State       string    `xml:"status"`
-		StartTime   string    `xml:"startTime"`
-		Encrypted   bool      `xml:"encrypted"`
-		Description string    `xml:"description,omitempty"`
-		OwnerID     string    `xml:"ownerId"`
-		Tags        []tagItem `xml:"tagSet>item"`
+		SnapshotID  string       `xml:"snapshotId"`
+		VolumeID    string       `xml:"volumeId,omitempty"`
+		VolumeSize  int64        `xml:"volumeSize"`
+		State       string       `xml:"status"`
+		StartTime   string       `xml:"startTime"`
+		Encrypted   bool         `xml:"encrypted"`
+		Description string       `xml:"description,omitempty"`
+		OwnerID     string       `xml:"ownerId"`
+		Tags        []ec2TagItem `xml:"tagSet>item"`
 	}
 	type response struct {
 		XMLName   xml.Name       `xml:"DescribeSnapshotsResponse"`
@@ -5403,10 +5412,13 @@ func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (
 		if !ids.match(snap.SnapshotID) {
 			continue
 		}
-		if vals, ok := filters["snapshot-id"]; ok && !containsStr(vals, snap.SnapshotID) {
+		if !owners.match(snap) || !restorableBy.match(snap) {
 			continue
 		}
-		item := snapshotItem{
+		if !ec2SnapshotMatchesFilters(snap, filters) {
+			continue
+		}
+		resp.Snapshots = append(resp.Snapshots, snapshotItem{
 			SnapshotID:  snap.SnapshotID,
 			VolumeID:    snap.VolumeID,
 			VolumeSize:  snap.VolumeSize,
@@ -5415,11 +5427,8 @@ func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (
 			Encrypted:   snap.Encrypted,
 			Description: snap.Description,
 			OwnerID:     snap.AccountID,
-		}
-		for _, t := range snap.Tags {
-			item.Tags = append(item.Tags, tagItem{Key: t.Key, Value: t.Value}) //nolint:staticcheck
-		}
-		resp.Snapshots = append(resp.Snapshots, item)
+			Tags:        ec2TagItems(snap.Tags),
+		})
 	}
 	if err := ids.unresolved(); err != nil {
 		return nil, err

--- a/emulator/ec2_snapshot_filters.go
+++ b/emulator/ec2_snapshot_filters.go
@@ -1,0 +1,130 @@
+package emulator
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ec2SnapshotMatchesFilters reports whether a snapshot satisfies every supplied
+// DescribeSnapshots filter. Filters AND with each other and each one's values OR, which is
+// AWS's documented rule for all of them.
+//
+// Until #685 this operation honored one of the fourteen names its reference documents —
+// snapshot-id — and silently ignored the other thirteen, so "the snapshots of volume
+// vol-x" answered with every snapshot in the region. That is the failure mode an ignored
+// filter always has: a caller cannot tell an unfiltered answer from a filtered one.
+func ec2SnapshotMatchesFilters(snap EC2Snapshot, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2SnapshotMatchesFilter(snap, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2SnapshotMatchesFilter evaluates a single DescribeSnapshots filter against a snapshot.
+//
+// Ten of AWS's fourteen names are answerable from [EC2Snapshot]. The four that are not —
+// owner-alias, progress, storage-tier and transfer-type — are inert, per the rule
+// [ec2FilterSpec] states: substrate renders none of those members either, so a filter over
+// them has nothing to compare against. A name outside all fourteen never arrives, because
+// [ec2SnapshotFilterSpec] refuses it before the scan (#687).
+func ec2SnapshotMatchesFilter(snap EC2Snapshot, name string, values []string) bool {
+	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
+		for _, t := range snap.Tags {
+			if t.Key == tagKey && containsStr(values, t.Value) {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch name {
+	case "description":
+		return containsStr(values, snap.Description)
+	case "encrypted":
+		return containsStr(values, strconv.FormatBool(snap.Encrypted))
+	case "owner-id":
+		// The account that owns the snapshot, which is always the requesting account:
+		// substrate is single-account, so this filter either matches everything or
+		// nothing. It is still evaluated rather than inert, because a caller who names
+		// another account is asking a question whose honest answer is "none".
+		return containsStr(values, snap.AccountID)
+	case "snapshot-id":
+		return containsStr(values, snap.SnapshotID)
+	case "start-time":
+		// Compared as the string substrate renders in startTime. AWS documents this
+		// filter with no matching semantics of its own, and its values are timestamps, so
+		// a caller wanting a range needs the wildcards tracked in #697 rather than this.
+		return containsStr(values, snap.StartTime)
+	case "status":
+		// AWS names the filter "status" and the response element "status" while the API
+		// model calls the member State; EC2Snapshot follows the model.
+		return containsStr(values, snap.State)
+	case "tag-key":
+		for _, t := range snap.Tags {
+			if containsStr(values, t.Key) {
+				return true
+			}
+		}
+		return false
+	case "volume-id":
+		return containsStr(values, snap.VolumeID)
+	case "volume-size":
+		return containsStr(values, strconv.FormatInt(snap.VolumeSize, 10))
+	default:
+		// A documented filter substrate cannot evaluate is inert; see the doc comment.
+		return true
+	}
+}
+
+// ec2SnapshotAccountScope filters DescribeSnapshots by an account-valued parameter list —
+// Owner.N or RestorableBy.N — both of which sit outside Filter.N and outside the ID list.
+//
+// The two collapse to one type because substrate is single-account, so they cannot disagree:
+// every stored snapshot is owned by the requesting account, and its owner can always create
+// a volume from it. "self" and the caller's own account ID therefore match everything, and
+// any other value — another account ID, or the "amazon" alias Owner.N documents — matches
+// nothing, because substrate models neither cross-account snapshots nor
+// createVolumePermission. Matching nothing is the honest answer to "snapshots owned by
+// amazon" in an emulator that has none; answering with the account's own snapshots would
+// claim they are public.
+type ec2SnapshotAccountScope struct {
+	requested []string
+	accountID string
+}
+
+// newEC2SnapshotOwners reads Owner.N, which AWS documents as "a combination of AWS account
+// IDs, self, and amazon".
+func newEC2SnapshotOwners(params map[string]string, accountID string) ec2SnapshotAccountScope {
+	return ec2SnapshotAccountScope{
+		requested: extractIndexedParams(params, "Owner"),
+		accountID: accountID,
+	}
+}
+
+// newEC2SnapshotRestorableBy reads RestorableBy.N, "the IDs of the AWS accounts that can
+// create volumes from the snapshot".
+func newEC2SnapshotRestorableBy(params map[string]string, accountID string) ec2SnapshotAccountScope {
+	return ec2SnapshotAccountScope{
+		requested: extractIndexedParams(params, "RestorableBy"),
+		accountID: accountID,
+	}
+}
+
+// match reports whether snap is in scope. A scope the caller did not send matches
+// everything, which is how both parameters are documented to behave when absent.
+func (s ec2SnapshotAccountScope) match(snap EC2Snapshot) bool {
+	if len(s.requested) == 0 {
+		return true
+	}
+	for _, want := range s.requested {
+		if want == "self" && snap.AccountID == s.accountID {
+			return true
+		}
+		if want == snap.AccountID {
+			return true
+		}
+	}
+	return false
+}

--- a/emulator/ec2_snapshot_filters_test.go
+++ b/emulator/ec2_snapshot_filters_test.go
@@ -1,0 +1,271 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// describedSnapshot is the subset of a DescribeSnapshots item these tests read.
+type describedSnapshot struct {
+	SnapshotID  string `xml:"snapshotId"`
+	VolumeID    string `xml:"volumeId"`
+	VolumeSize  int64  `xml:"volumeSize"`
+	State       string `xml:"status"`
+	StartTime   string `xml:"startTime"`
+	Encrypted   bool   `xml:"encrypted"`
+	Description string `xml:"description"`
+	OwnerID     string `xml:"ownerId"`
+	Tags        []struct {
+		Key   string `xml:"key"`
+		Value string `xml:"value"`
+	} `xml:"tagSet>item"`
+}
+
+// ec2DescribeSnapshots sends DescribeSnapshots with params and returns the snapshots.
+func ec2DescribeSnapshots(t *testing.T, ts *httptest.Server, params map[string]string) []describedSnapshot {
+	t.Helper()
+	full := map[string]string{"Action": "DescribeSnapshots"}
+	for k, v := range params {
+		full[k] = v
+	}
+	var doc struct {
+		Snapshots []describedSnapshot `xml:"snapshotSet>item"`
+	}
+	ec2FleetXML(t, ts, full, &doc)
+	return doc.Snapshots
+}
+
+// ec2SnapshotIDsFor is [ec2DescribeSnapshots] reduced to the IDs, which is what a filter
+// test asserts on: the identity of the answer, not its contents.
+func ec2SnapshotIDsFor(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	snaps := ec2DescribeSnapshots(t, ts, params)
+	ids := make([]string, 0, len(snaps))
+	for _, s := range snaps {
+		ids = append(ids, s.SnapshotID)
+	}
+	return ids
+}
+
+// ec2Filter builds the Filter.1 parameters for one name and its values.
+func ec2Filter(name string, values ...string) map[string]string {
+	params := map[string]string{"Filter.1.Name": name}
+	for i, v := range values {
+		params["Filter.1.Value."+strconv.Itoa(i+1)] = v
+	}
+	return params
+}
+
+// ec2SeedTaggedSnapshots creates one AMI per name — each of which materializes a backing
+// EBS snapshot, tagged Scope=<name> and described "Created by CreateImage for <name>" — and
+// returns the snapshot IDs keyed by name.
+//
+// CreateImage is the only path that writes a snapshot record today; CreateSnapshot is #689.
+// The snapshots it mints therefore carry no source volume, which is why volume-id below is
+// asserted to match nothing rather than to select one.
+func ec2SeedTaggedSnapshots(t *testing.T, ts *httptest.Server, names ...string) map[string]string {
+	t.Helper()
+	instID := ec2TagTestInstance(t, ts)
+	for _, n := range names {
+		resp := ec2Request(t, ts, map[string]string{
+			"Action":                          "CreateImage",
+			"InstanceId":                      instID,
+			"Name":                            n,
+			"TagSpecification.1.ResourceType": "snapshot",
+			"TagSpecification.1.Tag.1.Key":    "Scope",
+			"TagSpecification.1.Tag.1.Value":  n,
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close() //nolint:errcheck
+	}
+	out := make(map[string]string, len(names))
+	for _, s := range ec2DescribeSnapshots(t, ts, nil) {
+		for _, tag := range s.Tags {
+			if tag.Key == "Scope" {
+				out[tag.Value] = s.SnapshotID
+			}
+		}
+	}
+	require.Len(t, out, len(names), "each CreateImage should leave one tagged snapshot")
+	return out
+}
+
+// TestEC2_DescribeSnapshots_EvaluatedFiltersNarrowTheAnswer covers the ten filter names
+// #685 taught describeSnapshots to evaluate. Before it, snapshot-id was the only one that
+// did anything and the other thirteen were silently ignored — so every case below whose
+// want is narrower than "both" returned both snapshots, and a caller had no way to tell an
+// unfiltered answer from a filtered one.
+func TestEC2_DescribeSnapshots_EvaluatedFiltersNarrowTheAnswer(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	snaps := ec2SeedTaggedSnapshots(t, ts, "alpha", "beta")
+	alpha, beta := snaps["alpha"], snaps["beta"]
+
+	all := ec2DescribeSnapshots(t, ts, nil)
+	require.Len(t, all, 2)
+	owner := all[0].OwnerID
+	require.NotEmpty(t, owner, "ownerId is what the owner-id filter compares against")
+
+	tests := []struct {
+		name   string
+		filter map[string]string
+		want   []string
+	}{
+		{"description selects one", ec2Filter("description", "Created by CreateImage for alpha"), []string{alpha}},
+		{"description values OR", ec2Filter("description",
+			"Created by CreateImage for alpha", "Created by CreateImage for beta"), []string{alpha, beta}},
+		{"description miss", ec2Filter("description", "no such description"), nil},
+		{"encrypted false", ec2Filter("encrypted", "false"), []string{alpha, beta}},
+		{"encrypted true", ec2Filter("encrypted", "true"), nil},
+		{"owner-id self", ec2Filter("owner-id", owner), []string{alpha, beta}},
+		{"owner-id another account", ec2Filter("owner-id", "999999999999"), nil},
+		{"snapshot-id selects one", ec2Filter("snapshot-id", alpha), []string{alpha}},
+		{"start-time miss", ec2Filter("start-time", "2000-01-01T00:00:00Z"), nil},
+		{"status completed", ec2Filter("status", "completed"), []string{alpha, beta}},
+		{"status pending", ec2Filter("status", "pending"), nil},
+		{"tag-key present", ec2Filter("tag-key", "Scope"), []string{alpha, beta}},
+		{"tag-key absent", ec2Filter("tag-key", "Absent"), nil},
+		{"tag value selects one", ec2Filter("tag:Scope", "alpha"), []string{alpha}},
+		{"tag values OR", ec2Filter("tag:Scope", "alpha", "beta"), []string{alpha, beta}},
+		{"tag key absent", ec2Filter("tag:Absent", "alpha"), nil},
+		{"volume-size matches", ec2Filter("volume-size", "8"), []string{alpha, beta}},
+		{"volume-size miss", ec2Filter("volume-size", "100"), nil},
+		{"volume-id matches nothing without a source volume",
+			ec2Filter("volume-id", "vol-0123456789abcdef0"), nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tc.want, ec2SnapshotIDsFor(t, ts, tc.filter))
+		})
+	}
+}
+
+// TestEC2_DescribeSnapshots_StartTimeMatchesItsOwnSnapshot pins the start-time filter
+// against a value taken from the response, since the timestamp is minted by the simulated
+// clock and cannot be written into a table. The negative case lives in the table above.
+func TestEC2_DescribeSnapshots_StartTimeMatchesItsOwnSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	ec2SeedTaggedSnapshots(t, ts, "alpha")
+
+	all := ec2DescribeSnapshots(t, ts, nil)
+	require.Len(t, all, 1)
+	require.NotEmpty(t, all[0].StartTime)
+
+	assert.Equal(t, []string{all[0].SnapshotID},
+		ec2SnapshotIDsFor(t, ts, ec2Filter("start-time", all[0].StartTime)),
+		"a snapshot must match the startTime the same response reported")
+}
+
+// TestEC2_DescribeSnapshots_FiltersAND pins AWS's documented composition rule: separate
+// filters AND while values within one OR.
+func TestEC2_DescribeSnapshots_FiltersAND(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	snaps := ec2SeedTaggedSnapshots(t, ts, "alpha", "beta")
+
+	both := map[string]string{
+		"Filter.1.Name": "tag:Scope", "Filter.1.Value.1": "alpha",
+		"Filter.2.Name": "status", "Filter.2.Value.1": "completed",
+	}
+	assert.Equal(t, []string{snaps["alpha"]}, ec2SnapshotIDsFor(t, ts, both))
+
+	conflicting := map[string]string{
+		"Filter.1.Name": "tag:Scope", "Filter.1.Value.1": "alpha",
+		"Filter.2.Name": "status", "Filter.2.Value.1": "pending",
+	}
+	assert.Empty(t, ec2SnapshotIDsFor(t, ts, conflicting),
+		"two filters AND, so a snapshot satisfying only one is excluded")
+}
+
+// TestEC2_DescribeSnapshots_InertFiltersReturnEverything pins the four names AWS documents
+// that substrate accepts and cannot answer. They constrain nothing rather than being
+// refused, because refusing a filter real EC2 accepts would be a false deny — and rather
+// than matching nothing, because an empty answer is indistinguishable from "no such
+// snapshot" and would hang a caller's wait loop. docs/services.md lists them by name.
+func TestEC2_DescribeSnapshots_InertFiltersReturnEverything(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	snaps := ec2SeedTaggedSnapshots(t, ts, "alpha", "beta")
+	want := []string{snaps["alpha"], snaps["beta"]}
+
+	for name, value := range map[string]string{
+		"owner-alias":   "amazon",
+		"progress":      "100%",
+		"storage-tier":  "standard",
+		"transfer-type": "standard",
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.ElementsMatch(t, want, ec2SnapshotIDsFor(t, ts, ec2Filter(name, value)),
+				"an inert filter constrains nothing, so every snapshot is still returned")
+		})
+	}
+}
+
+// TestEC2_DescribeSnapshots_AccountScopes covers Owner.N and RestorableBy.N, which sit
+// outside Filter.N and outside the ID list and were both ignored before #685.
+//
+// Substrate is single-account, so the honest answer to "snapshots owned by amazon" is none:
+// answering with the account's own snapshots would claim they are public.
+func TestEC2_DescribeSnapshots_AccountScopes(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	snaps := ec2SeedTaggedSnapshots(t, ts, "alpha", "beta")
+	both := []string{snaps["alpha"], snaps["beta"]}
+
+	all := ec2DescribeSnapshots(t, ts, nil)
+	require.Len(t, all, 2)
+	owner := all[0].OwnerID
+
+	for _, param := range []string{"Owner", "RestorableBy"} {
+		t.Run(param, func(t *testing.T) {
+			tests := []struct {
+				name   string
+				params map[string]string
+				want   []string
+			}{
+				{"absent matches everything", nil, both},
+				{"self", map[string]string{param + ".1": "self"}, both},
+				{"own account ID", map[string]string{param + ".1": owner}, both},
+				{"another account", map[string]string{param + ".1": "999999999999"}, nil},
+				{"amazon", map[string]string{param + ".1": "amazon"}, nil},
+				{"values OR", map[string]string{param + ".1": "amazon", param + ".2": "self"}, both},
+			}
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					assert.ElementsMatch(t, tc.want, ec2SnapshotIDsFor(t, ts, tc.params))
+				})
+			}
+		})
+	}
+}
+
+// TestEC2_DescribeSnapshots_AFilterDoesNotUnresolveANamedID pins the ordering
+// [ec2IDFilter.unresolved] documents: a snapshot excluded by a filter still counts as
+// resolved, so naming an existing snapshot and filtering it out is an empty 200 rather than
+// InvalidSnapshot.NotFound. The two are very different answers to a consumer — one means
+// "not yet", the other means "never".
+func TestEC2_DescribeSnapshots_AFilterDoesNotUnresolveANamedID(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	snaps := ec2SeedTaggedSnapshots(t, ts, "alpha")
+
+	assert.Empty(t, ec2SnapshotIDsFor(t, ts, map[string]string{
+		"SnapshotId.1":  snaps["alpha"],
+		"Filter.1.Name": "status", "Filter.1.Value.1": "pending",
+	}), "an existing snapshot a filter excluded is an empty answer, not a not-found error")
+
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":        "DescribeSnapshots",
+		"SnapshotId.1":  "snap-0000000000000dead",
+		"Filter.1.Name": "status", "Filter.1.Value.1": "completed",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidSnapshot.NotFound", code,
+		"a snapshot that does not exist is still not found, filter or no filter")
+}

--- a/emulator/ec2_subnet_filters.go
+++ b/emulator/ec2_subnet_filters.go
@@ -1,0 +1,174 @@
+package emulator
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ec2SubnetARN returns the ARN of a subnet.
+//
+// One spelling, shared by the two describe paths and by the authorization resolver, for the
+// reason [ec2VolumeStateKey]'s doc comment gives about state keys: a writer that spells a
+// resource's identity differently from its readers produces a resource the readers cannot
+// find. Here the readers are a caller's ArnEquals condition and the subnet-arn filter, and
+// both compare the string literally.
+func ec2SubnetARN(accountID, region, subnetID string) string {
+	return "arn:aws:ec2:" + region + ":" + accountID + ":subnet/" + subnetID
+}
+
+// ec2SubnetMatchesFilters reports whether a subnet satisfies every supplied DescribeSubnets
+// filter. Filters AND with each other and each one's values OR, AWS's documented rule.
+//
+// Until #685 DescribeSubnets parsed no Filter.N at all: it selected on SubnetId.N and
+// nothing else, so "the subnets of vpc-x" answered with every subnet in the region. That is
+// the worst shape of the ignored-filter failure — a consumer walking a VPC's subnets got
+// its neighbors' too, with nothing in the response to say so.
+func ec2SubnetMatchesFilters(subnet EC2Subnet, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2SubnetMatchesFilter(subnet, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2SubnetMatchesFilter evaluates a single DescribeSubnets filter against a subnet.
+//
+// Eleven of AWS's twenty-five names are answerable from [EC2Subnet], and four of them have
+// an alias spelling the reference documents inline ("You can also use availabilityZone as
+// the filter name") — the aliases are separate names on the wire, so each is handled here
+// beside its canonical form rather than normalized away, which would leave the canonical
+// name working and the documented alias silently inert.
+//
+// The other fourteen are inert, per the rule [ec2FilterSpec] states: substrate models no
+// IPv6 association, Outpost, customer-owned pool or private-DNS-on-launch option, so a
+// filter over one has nothing to compare against. A name outside all twenty-five never
+// arrives — [ec2SubnetFilterSpec] refuses it before the scan (#687).
+func ec2SubnetMatchesFilter(subnet EC2Subnet, name string, values []string) bool {
+	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
+		for _, t := range subnet.Tags {
+			if t.Key == tagKey && containsStr(values, t.Value) {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch name {
+	case "availability-zone", "availabilityZone":
+		return containsStr(values, subnet.AvailabilityZone)
+	case "cidr-block", "cidr", "cidrBlock":
+		// AWS: "The CIDR block you specify must exactly match the subnet's CIDR block
+		// for information to be returned for the subnet." So this is equality, not
+		// containment — a caller asking for 10.0.0.0/16 does not get 10.0.1.0/24.
+		return containsStr(values, subnet.CIDRBlock)
+	case "default-for-az", "defaultForAz":
+		return containsStr(values, strconv.FormatBool(subnet.IsDefault))
+	case "map-public-ip-on-launch":
+		return containsStr(values, strconv.FormatBool(subnet.MapPublicIPOnLaunch))
+	case "owner-id":
+		// Always the requesting account: substrate is single-account, so a caller
+		// naming another account is asking a question whose honest answer is "none".
+		return containsStr(values, subnet.AccountID)
+	case "state":
+		return containsStr(values, subnet.State)
+	case "subnet-arn":
+		return containsStr(values, ec2SubnetARN(subnet.AccountID, subnet.Region, subnet.SubnetID))
+	case "subnet-id":
+		return containsStr(values, subnet.SubnetID)
+	case "vpc-id":
+		return containsStr(values, subnet.VPCID)
+	case "tag-key":
+		for _, t := range subnet.Tags {
+			if containsStr(values, t.Key) {
+				return true
+			}
+		}
+		return false
+	default:
+		// A documented filter substrate cannot evaluate is inert; see the doc comment.
+		return true
+	}
+}
+
+// ec2SubnetItem renders a subnet as AWS's Subnet element.
+//
+// Shared by CreateSubnet and DescribeSubnets because AWS documents one Subnet type for
+// both, and before #685 the two rendered different subsets of it — CreateSubnet omitted
+// mapPublicIpOnLaunch, so a caller reading the create response saw a different subnet from
+// the one the describe reported.
+//
+// Member order follows AWS's sample responses, which are identical across both operations.
+// Five members those samples carry are deliberately absent: availableIpAddressCount,
+// availabilityZoneId, assignIpv6AddressOnCreation, ipv6CidrBlockAssociationSet and the
+// blockPublicAccessStates/privateDnsNameOptionsOnLaunch structures. Nothing in state backs
+// them, and deriving an available-address count from the CIDR would be fabrication — the
+// count depends on how many addresses AWS reserves and on every interface in the subnet.
+//
+// tagSet is omitted entirely when the subnet has no tags, which is what both DescribeSubnets
+// samples show for an untagged subnet. That deliberately differs from describeSnapshots'
+// present-but-empty tagSet: each follows its own operation's samples. No sample on either
+// page shows a *tagged* subnet, so the element's position — last, after the members the
+// samples do order — is substrate's choice.
+//
+// Omission needs the pointer-to-wrapper shape rather than `xml:"tagSet>item,omitempty"`:
+// encoding/xml emits the parent element of a nested path even for a nil slice, so the
+// omitempty form would render <tagSet></tagSet> on every untagged subnet — the very thing
+// the samples say is absent. A nil pointer is omitempty-empty, so it disappears. Callers
+// decoding tagSet>item see no difference between the two shapes.
+type ec2SubnetItem struct {
+	// SubnetID is the subnet's ID.
+	SubnetID string `xml:"subnetId"`
+
+	// SubnetARN is the subnet's ARN, the value the subnet-arn filter compares against.
+	SubnetARN string `xml:"subnetArn"`
+
+	// State is pending or available. Substrate mints subnets available.
+	State string `xml:"state"`
+
+	// OwnerID is the account that owns the subnet.
+	OwnerID string `xml:"ownerId"`
+
+	// VpcID is the VPC the subnet belongs to.
+	VpcID string `xml:"vpcId"`
+
+	// CIDRBlock is the subnet's IPv4 CIDR block.
+	CIDRBlock string `xml:"cidrBlock"`
+
+	// AvailabilityZone is the zone the subnet was created in.
+	AvailabilityZone string `xml:"availabilityZone"`
+
+	// DefaultForAz reports whether this is the zone's default subnet.
+	DefaultForAz bool `xml:"defaultForAz"`
+
+	// MapPublicIPOnLaunch reports whether a launch in this subnet gets a public IPv4.
+	MapPublicIPOnLaunch bool `xml:"mapPublicIpOnLaunch"`
+
+	// Tags are the subnet's tags, absent when it has none.
+	Tags *ec2SubnetTagSet `xml:"tagSet,omitempty"`
+}
+
+// ec2SubnetTagSet wraps a subnet's tags so an untagged subnet can omit tagSet entirely.
+type ec2SubnetTagSet struct {
+	// Items are the tags themselves.
+	Items []ec2TagItem `xml:"item"`
+}
+
+// ec2SubnetXML renders one stored subnet as its response element.
+func ec2SubnetXML(subnet EC2Subnet) ec2SubnetItem {
+	item := ec2SubnetItem{
+		SubnetID:            subnet.SubnetID,
+		SubnetARN:           ec2SubnetARN(subnet.AccountID, subnet.Region, subnet.SubnetID),
+		State:               subnet.State,
+		OwnerID:             subnet.AccountID,
+		VpcID:               subnet.VPCID,
+		CIDRBlock:           subnet.CIDRBlock,
+		AvailabilityZone:    subnet.AvailabilityZone,
+		DefaultForAz:        subnet.IsDefault,
+		MapPublicIPOnLaunch: subnet.MapPublicIPOnLaunch,
+	}
+	if tags := ec2TagItems(subnet.Tags); len(tags) > 0 {
+		item.Tags = &ec2SubnetTagSet{Items: tags}
+	}
+	return item
+}

--- a/emulator/ec2_subnet_filters_test.go
+++ b/emulator/ec2_subnet_filters_test.go
@@ -1,0 +1,360 @@
+package emulator_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// describedSubnet is the subset of a DescribeSubnets item these tests read. Every member
+// below arrived with #685 except subnetId, vpcId, cidrBlock, availabilityZone, state and
+// mapPublicIpOnLaunch.
+type describedSubnet struct {
+	SubnetID            string `xml:"subnetId"`
+	SubnetARN           string `xml:"subnetArn"`
+	State               string `xml:"state"`
+	OwnerID             string `xml:"ownerId"`
+	VpcID               string `xml:"vpcId"`
+	CIDRBlock           string `xml:"cidrBlock"`
+	AvailabilityZone    string `xml:"availabilityZone"`
+	DefaultForAz        bool   `xml:"defaultForAz"`
+	MapPublicIPOnLaunch bool   `xml:"mapPublicIpOnLaunch"`
+	Tags                []struct {
+		Key   string `xml:"key"`
+		Value string `xml:"value"`
+	} `xml:"tagSet>item"`
+}
+
+// ec2DescribeSubnets sends DescribeSubnets with params and returns the subnets.
+func ec2DescribeSubnets(t *testing.T, ts *httptest.Server, params map[string]string) []describedSubnet {
+	t.Helper()
+	full := map[string]string{"Action": "DescribeSubnets"}
+	for k, v := range params {
+		full[k] = v
+	}
+	var doc struct {
+		Subnets []describedSubnet `xml:"subnetSet>item"`
+	}
+	ec2FleetXML(t, ts, full, &doc)
+	return doc.Subnets
+}
+
+// ec2SubnetIDsFor is [ec2DescribeSubnets] reduced to the IDs a filter selected.
+func ec2SubnetIDsFor(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	subnets := ec2DescribeSubnets(t, ts, params)
+	ids := make([]string, 0, len(subnets))
+	for _, s := range subnets {
+		ids = append(ids, s.SubnetID)
+	}
+	return ids
+}
+
+// ec2CreateTaggedSubnet creates one subnet, tagging it on creation through
+// TagSpecification.N — the parameter #685 added to CreateSubnet, and the only way CDK or
+// Terraform sets the tags a caller then filters on.
+func ec2CreateTaggedSubnet(t *testing.T, ts *httptest.Server, vpcID, cidr, az string, tags map[string]string) string {
+	t.Helper()
+	params := map[string]string{
+		"Action":                          "CreateSubnet",
+		"VpcId":                           vpcID,
+		"CidrBlock":                       cidr,
+		"AvailabilityZone":                az,
+		"TagSpecification.1.ResourceType": "subnet",
+	}
+	i := 1
+	for k, v := range tags {
+		params["TagSpecification.1.Tag."+strconv.Itoa(i)+".Key"] = k
+		params["TagSpecification.1.Tag."+strconv.Itoa(i)+".Value"] = v
+		i++
+	}
+	var created struct {
+		Subnet describedSubnet `xml:"subnet"`
+	}
+	ec2FleetXML(t, ts, params, &created)
+	require.NotEmpty(t, created.Subnet.SubnetID)
+	return created.Subnet.SubnetID
+}
+
+// subnetFixture is the three-subnet fixture the filter tests share: the account's default
+// subnet, which a launch with no SubnetId mints, plus two tagged subnets in a VPC of their
+// own. The default subnet is what makes default-for-az and map-public-ip-on-launch
+// testable in both directions — nothing else in substrate sets either to true.
+type subnetFixture struct {
+	vpcID          string
+	defaultSubnet  string
+	alpha, beta    string
+	owner          string
+	defaultSubnetV string
+}
+
+// newSubnetFixture builds [subnetFixture].
+func newSubnetFixture(t *testing.T, ts *httptest.Server) subnetFixture {
+	t.Helper()
+	ec2TagTestInstance(t, ts) // no SubnetId, so this mints the default VPC and subnet
+
+	var vpc struct {
+		VPCID string `xml:"vpc>vpcId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.9.0.0/16"}, &vpc)
+	require.NotEmpty(t, vpc.VPCID)
+
+	f := subnetFixture{
+		vpcID: vpc.VPCID,
+		alpha: ec2CreateTaggedSubnet(t, ts, vpc.VPCID, "10.9.1.0/24", "us-east-1b",
+			map[string]string{"Scope": "alpha", "Tier": "web"}),
+		beta: ec2CreateTaggedSubnet(t, ts, vpc.VPCID, "10.9.2.0/24", "us-east-1c",
+			map[string]string{"Scope": "beta"}),
+	}
+	for _, s := range ec2DescribeSubnets(t, ts, nil) {
+		f.owner = s.OwnerID
+		if s.DefaultForAz {
+			f.defaultSubnet = s.SubnetID
+			f.defaultSubnetV = s.VpcID
+		}
+	}
+	require.NotEmpty(t, f.defaultSubnet, "the launch should have left a default subnet")
+	require.NotEmpty(t, f.owner, "ownerId is what the owner-id filter compares against")
+	return f
+}
+
+// TestEC2_DescribeSubnets_FiltersNarrowTheAnswer covers the eleven filter names #685 taught
+// describeSubnets to evaluate, and the four alias spellings AWS documents inline.
+//
+// This operation parsed no Filter.N at all before #685: it selected on SubnetId.N and
+// nothing else, so every case below returned all three subnets. "The subnets of vpc-x"
+// answering with a neighbor's subnets is the worst shape of the ignored-filter failure,
+// because the response carries nothing that says the filter was not applied.
+func TestEC2_DescribeSubnets_FiltersNarrowTheAnswer(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	f := newSubnetFixture(t, ts)
+	all := []string{f.defaultSubnet, f.alpha, f.beta}
+	created := []string{f.alpha, f.beta}
+
+	tests := []struct {
+		name   string
+		filter map[string]string
+		want   []string
+	}{
+		{"vpc-id selects one VPC's subnets", ec2Filter("vpc-id", f.vpcID), created},
+		{"vpc-id values OR", ec2Filter("vpc-id", f.vpcID, f.defaultSubnetV), all},
+		{"vpc-id miss", ec2Filter("vpc-id", "vpc-0000000000000dead"), nil},
+		{"availability-zone", ec2Filter("availability-zone", "us-east-1b"), []string{f.alpha}},
+		{"availabilityZone alias", ec2Filter("availabilityZone", "us-east-1b"), []string{f.alpha}},
+		{"cidr-block is exact", ec2Filter("cidr-block", "10.9.1.0/24"), []string{f.alpha}},
+		{"cidr alias", ec2Filter("cidr", "10.9.2.0/24"), []string{f.beta}},
+		{"cidrBlock alias", ec2Filter("cidrBlock", "10.9.2.0/24"), []string{f.beta}},
+		{"cidr-block does not match a containing block",
+			ec2Filter("cidr-block", "10.9.0.0/16"), nil},
+		{"default-for-az true", ec2Filter("default-for-az", "true"), []string{f.defaultSubnet}},
+		{"default-for-az false", ec2Filter("default-for-az", "false"), created},
+		{"defaultForAz alias", ec2Filter("defaultForAz", "true"), []string{f.defaultSubnet}},
+		{"map-public-ip-on-launch true",
+			ec2Filter("map-public-ip-on-launch", "true"), []string{f.defaultSubnet}},
+		{"map-public-ip-on-launch false", ec2Filter("map-public-ip-on-launch", "false"), created},
+		{"owner-id self", ec2Filter("owner-id", f.owner), all},
+		{"owner-id another account", ec2Filter("owner-id", "999999999999"), nil},
+		{"state available", ec2Filter("state", "available"), all},
+		{"state pending", ec2Filter("state", "pending"), nil},
+		{"subnet-id", ec2Filter("subnet-id", f.alpha), []string{f.alpha}},
+		{"tag-key shared by two", ec2Filter("tag-key", "Scope"), created},
+		{"tag-key on one", ec2Filter("tag-key", "Tier"), []string{f.alpha}},
+		{"tag-key absent", ec2Filter("tag-key", "Absent"), nil},
+		{"tag value selects one", ec2Filter("tag:Scope", "alpha"), []string{f.alpha}},
+		{"tag values OR", ec2Filter("tag:Scope", "alpha", "beta"), created},
+		{"tag key absent", ec2Filter("tag:Absent", "alpha"), nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tc.want, ec2SubnetIDsFor(t, ts, tc.filter))
+		})
+	}
+}
+
+// TestEC2_DescribeSubnets_SubnetArnFilterMatchesTheRenderedARN pins the two halves of
+// subnet-arn against each other: the filter compares the same string the response renders,
+// so a caller can round-trip what it read. Two spellings of the ARN would break that
+// silently, which is why [ec2SubnetARN] is the only one.
+func TestEC2_DescribeSubnets_SubnetArnFilterMatchesTheRenderedARN(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	f := newSubnetFixture(t, ts)
+
+	one := ec2DescribeSubnets(t, ts, map[string]string{"SubnetId.1": f.alpha})
+	require.Len(t, one, 1)
+	require.Equal(t, "arn:aws:ec2:us-east-1:"+f.owner+":subnet/"+f.alpha, one[0].SubnetARN)
+
+	assert.Equal(t, []string{f.alpha},
+		ec2SubnetIDsFor(t, ts, ec2Filter("subnet-arn", one[0].SubnetARN)))
+	assert.Empty(t, ec2SubnetIDsFor(t, ts,
+		ec2Filter("subnet-arn", "arn:aws:ec2:us-east-1:"+f.owner+":subnet/subnet-0000000000000dead")))
+}
+
+// TestEC2_DescribeSubnets_FiltersAND pins AWS's composition rule on this operation:
+// separate filters AND, values within one OR.
+func TestEC2_DescribeSubnets_FiltersAND(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	f := newSubnetFixture(t, ts)
+
+	assert.Equal(t, []string{f.alpha}, ec2SubnetIDsFor(t, ts, map[string]string{
+		"Filter.1.Name": "vpc-id", "Filter.1.Value.1": f.vpcID,
+		"Filter.2.Name": "tag:Scope", "Filter.2.Value.1": "alpha",
+	}))
+	assert.Empty(t, ec2SubnetIDsFor(t, ts, map[string]string{
+		"Filter.1.Name": "vpc-id", "Filter.1.Value.1": f.vpcID,
+		"Filter.2.Name": "default-for-az", "Filter.2.Value.1": "true",
+	}), "no subnet in the created VPC is a default subnet, so the AND is empty")
+}
+
+// TestEC2_DescribeSubnets_InertFiltersReturnEverything pins the fourteen names AWS
+// documents that substrate accepts and cannot answer — sampled here, listed in full in
+// docs/services.md. They constrain nothing rather than being refused, because refusing a
+// filter real EC2 accepts would be a false deny.
+func TestEC2_DescribeSubnets_InertFiltersReturnEverything(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	f := newSubnetFixture(t, ts)
+	want := []string{f.defaultSubnet, f.alpha, f.beta}
+
+	for name, value := range map[string]string{
+		"availability-zone-id":       "use1-az1",
+		"available-ip-address-count": "251",
+		"ipv6-native":                "false",
+		"outpost-arn":                "arn:aws:outposts:us-east-1:1:outpost/op-1",
+		"private-dns-name-options-on-launch.hostname-type": "ip-name",
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.ElementsMatch(t, want, ec2SubnetIDsFor(t, ts, ec2Filter(name, value)),
+				"an inert filter constrains nothing, so every subnet is still returned")
+		})
+	}
+}
+
+// TestEC2_DescribeSubnets_AFilterDoesNotUnresolveANamedID pins the same ordering rule
+// describeSnapshots follows: a subnet a filter excluded still counts as resolved, so naming
+// an existing subnet and filtering it out is an empty 200 rather than a not-found error.
+func TestEC2_DescribeSubnets_AFilterDoesNotUnresolveANamedID(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	f := newSubnetFixture(t, ts)
+
+	assert.Empty(t, ec2SubnetIDsFor(t, ts, map[string]string{
+		"SubnetId.1":    f.alpha,
+		"Filter.1.Name": "state", "Filter.1.Value.1": "pending",
+	}), "an existing subnet a filter excluded is an empty answer, not a not-found error")
+
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":        "DescribeSubnets",
+		"SubnetId.1":    "subnet-0000000000000dead",
+		"Filter.1.Name": "state", "Filter.1.Value.1": "available",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidSubnetID.NotFound", code)
+}
+
+// TestEC2_DescribeSubnets_TagSetIsAbsentWhenUntagged pins the decision that an untagged
+// subnet omits tagSet entirely rather than rendering it empty.
+//
+// Both of AWS's DescribeSubnets samples omit the element on an untagged subnet, which is
+// per-operation evidence — describeSnapshots' present-but-empty tagSet is left as it is,
+// because its own page shows that shape. Asserting on the raw body is the only way to see
+// the difference: a decoder reports an absent element and an empty one identically.
+func TestEC2_DescribeSubnets_TagSetIsAbsentWhenUntagged(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	f := newSubnetFixture(t, ts)
+
+	body := func(subnetID string) string {
+		resp := ec2Request(t, ts, map[string]string{
+			"Action": "DescribeSubnets", "SubnetId.1": subnetID,
+		})
+		defer resp.Body.Close() //nolint:errcheck
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		raw, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return string(raw)
+	}
+
+	assert.NotContains(t, body(f.defaultSubnet), "tagSet",
+		"an untagged subnet omits tagSet, as both of AWS's samples do")
+	assert.Contains(t, body(f.alpha), "<tagSet>",
+		"a tagged subnet renders it")
+}
+
+// TestEC2_CreateSubnet_TagsOnCreateAndAgreesWithDescribe pins both halves of the create
+// path: TagSpecification.N is honored, and the create response describes the same subnet
+// the describe does.
+//
+// The two rendered different member subsets before #685 — CreateSubnet omitted
+// mapPublicIpOnLaunch, and neither carried tags, an ARN, an owner or defaultForAz — so a
+// caller reading the create response saw a different subnet from the one it could then
+// filter on. One shared renderer is what keeps them from drifting again.
+func TestEC2_CreateSubnet_TagsOnCreateAndAgreesWithDescribe(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	var vpc struct {
+		VPCID string `xml:"vpc>vpcId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.9.0.0/16"}, &vpc)
+
+	var created struct {
+		Subnet describedSubnet `xml:"subnet"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":                          "CreateSubnet",
+		"VpcId":                           vpc.VPCID,
+		"CidrBlock":                       "10.9.1.0/24",
+		"AvailabilityZone":                "us-east-1b",
+		"TagSpecification.1.ResourceType": "subnet",
+		"TagSpecification.1.Tag.1.Key":    "Scope",
+		"TagSpecification.1.Tag.1.Value":  "alpha",
+	}, &created)
+	require.NotEmpty(t, created.Subnet.SubnetID)
+	require.Len(t, created.Subnet.Tags, 1, "TagSpecification.N must be honored on create")
+	assert.Equal(t, "Scope", created.Subnet.Tags[0].Key)
+	assert.Equal(t, "alpha", created.Subnet.Tags[0].Value)
+
+	described := ec2DescribeSubnets(t, ts, map[string]string{"SubnetId.1": created.Subnet.SubnetID})
+	require.Len(t, described, 1)
+	assert.Equal(t, created.Subnet, described[0],
+		"CreateSubnet and DescribeSubnets render one Subnet type, so the two must agree")
+
+	assert.Equal(t, []string{created.Subnet.SubnetID},
+		ec2SubnetIDsFor(t, ts, ec2Filter("tag:Scope", "alpha")),
+		"a tag set at create time is immediately filterable, which is the point of the parameter")
+}
+
+// TestEC2_CreateSubnet_RejectsReservedTagKeys pins that the shared tag rules apply to this
+// new tag-on-create path too, and that a rejected request leaves no subnet behind.
+func TestEC2_CreateSubnet_RejectsReservedTagKeys(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	var vpc struct {
+		VPCID string `xml:"vpc>vpcId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.9.0.0/16"}, &vpc)
+
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                          "CreateSubnet",
+		"VpcId":                           vpc.VPCID,
+		"CidrBlock":                       "10.9.1.0/24",
+		"TagSpecification.1.ResourceType": "subnet",
+		"TagSpecification.1.Tag.1.Key":    "aws:foo",
+		"TagSpecification.1.Tag.1.Value":  "v",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+	assert.Equal(t, ec2ReservedTagMessage, message)
+
+	assert.Empty(t, ec2DescribeSubnets(t, ts, nil),
+		"a rejected CreateSubnet must not create a subnet")
+}


### PR DESCRIPTION
Closes #685.

`DescribeSubnets` parsed **no `Filter.N` at all** and rendered no `tagSet`, so a request for
"the subnets of `vpc-x`" answered with every subnet in the region — with nothing in the
response to say the filter had been ignored — and every tag a caller applied to a subnet was
stored and invisible. `DescribeSnapshots` evaluated one of the fourteen filter names its
reference documents and read neither `Owner.N` nor `RestorableBy.N`.

## Subnets

- **`CreateSubnet` honours `TagSpecification.N`** scoped to `subnet`, under the same two rules
  every other tag path enforces (reserved `aws:` prefix, 50-tag limit); a refused request
  creates no subnet. Without it the filters below have nothing to find on a subnet the caller
  just made, which is how CDK and Terraform set tags.
- **One shared `Subnet` element** for `CreateSubnet` and `DescribeSubnets`, which is what AWS
  documents. They rendered different subsets before — create omitted `mapPublicIpOnLaunch`, and
  neither carried tags, an ARN, an owner or `defaultForAz` — so a caller reading the create
  response saw a different subnet from the one it could describe. A test asserts the two are
  equal.
- **New members**: `tagSet`, `subnetArn`, `ownerId`, `defaultForAz`. The ARN and owner are what
  `subnet-arn` and `owner-id` compare against, so rendering them is what lets a caller
  round-trip a value it read. `ec2SubnetARN` is now the one spelling, shared by the filter, the
  response and `ec2_authz.go`'s launch resolver.
- **Eleven filters plus AWS's four inline aliases** (`availabilityZone`, `cidr`, `cidrBlock`,
  `defaultForAz`), each answered beside its canonical name rather than normalized away — they
  are distinct names on the wire, and folding them would leave the documented alias silently
  inert. `cidr-block` is exact, per AWS's own sentence about it. The fourteen documented names
  substrate keeps no state for are accepted and inert; anything outside the twenty-five is
  refused by #687's spec, which this PR gives the operation.
- **`tagSet` is absent on an untagged subnet**, not present-and-empty: both of AWS's
  `DescribeSubnets` samples omit it. `DescribeSnapshots`' present-but-empty `tagSet` is left
  alone because its own page shows that shape — per-operation evidence, not a house rule.

  Worth recording for the next person: `xml:"tagSet>item,omitempty"` **does not** omit the
  parent element — `encoding/xml` emits `<tagSet></tagSet>` for a nil slice on a nested path.
  Omission needs a pointer-to-wrapper struct, verified empirically both ways (it decodes
  identically through `tagSet>item`). PR 6 (#693) needs the same shape for its `warning` member.

## Snapshots

- **Ten of fourteen filters applied**: `description`, `encrypted`, `owner-id`, `snapshot-id`,
  `start-time`, `status`, `tag-key`, `tag:<key>`, `volume-id`, `volume-size`. The other four
  (`owner-alias`, `progress`, `storage-tier`, `transfer-type`) name members substrate does not
  render, so there is nothing to compare against — accepted and inert.
- **`Owner.N` and `RestorableBy.N` honoured**, with single-account semantics: `self` and the
  requesting account's ID match everything; anything else, **`amazon` included**, matches
  nothing, because answering "snapshots owned by `amazon`" with the account's own snapshots
  would claim they were public.
- **Ordering**: `ids.match` runs before the filter match on both operations, so a resource a
  *filter* excluded still counts as resolved — naming an existing ID and filtering it out is an
  empty 200, not a `NotFound`. That is the rule `ec2IDFilter.unresolved` documents, and the
  difference between "not yet" and "never" to a consumer's wait loop.

## Also in the same neighbourhood

The EC2 plugin's **last two function-local `tagItem` copies** (`describeSnapshots`,
`describeFleets`) are deleted in favour of the package-level `ec2TagItems`, finishing what #686
started. All four shapes matched, so nothing observable changes.

## Fail-before proof

Recorded before the fix, with the anchor count asserted `== 1` over the whole file, the file
copied to a `.orig` and restored in a `finally` with byte-identity checked by sha256, and
`gofmt -w` + `go vet` so a non-compiling mutant is BROKEN rather than a result. Full-package
runs, no `-run` filter.

**Snapshots** — the pre-#685 handler body (`snapshot-id` only, `Owner.N`/`RestorableBy.N`
unread): **15 subtests plus 4 parent tests fail**. `_StartTimeMatchesItsOwnSnapshot` and
`_InertFiltersReturnEverything` correctly still pass — the first because its assertion is
positive, the second because inert is what the old code did to everything.

**Subnets**, two mutations:

| Mutation | Result |
|---|---|
| `describeSubnets` applies no filters (`_ = filters`) | exit 1, **26 tests fail** |
| `createSubnet` ignores `TagSpecification.N` (`Tags: nil`) | exit 1, **8 tests fail** — including the four `tag*` filter subtests, `_TagSetIsAbsentWhenUntagged` and `_TagsOnCreateAndAgreesWithDescribe` |

Restore verified byte-identical after every mutation.

The first attempt at the second mutation printed `ANCHOR COUNT 2 - skipped` rather than
mutating: `Tags:             tags,` appears in both `createSubnet` and `createVolume`. The
anchor was widened to include the neighbouring `State:` line rather than mutating blindly.

## Tests

Two new files, 40-plus subtests. The fixture worth explaining: `default-for-az` and
`map-public-ip-on-launch` are only testable in both directions because a launch with no
`SubnetId` mints a default subnet with both `true` — `createDefaultSubnet` is the sole writer of
either. `_TagSetIsAbsentWhenUntagged` asserts on the **raw body**, since a decoder reports an
absent element and an empty one identically.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues),
`make test` (race), `make coverage` (**82.2%** total, emulator 82.8%),
`make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build`,
`go vet -C test/e2e ./... && go test -C test/e2e ./...` — all clean.

## Docs

`docs/services.md` gains two subsections (a subnet's tags and filters; a snapshot's filters and
account scopes), a `DescribeSubnets` row and a corrected `DescribeSnapshots` row in #687's
per-operation Evaluated/Inert table, and three corrections the change makes necessary: five
operations now filter on tags rather than three, `DescribeSubnets` is the tenth operation the
refusal rule covers, and #695's never-parse list drops from fourteen operations to **thirteen**
(verified by enumerating the dispatch arms, not by subtraction).
