### PR TITLE
feat(ec2): DescribeTags, the operation whose whole job is finding resources by tag (#688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`DescribeTags`** (#688) — the EC2 operation whose whole job is finding resources by tag,
+  which reached the dispatcher's default arm and answered `InvalidAction` / HTTP 400 while
+  four bundled managed policies *granted* `ec2:DescribeTags`: `AmazonVPCFullAccess` and
+  `AmazonVPCReadOnlyAccess` name it outright, and `AmazonEC2FullAccess` and
+  `AmazonEC2ReadOnlyAccess` reach it through `ec2:*` and `ec2:Describe*`. A policy permitted
+  an operation nothing served. Real EC2 offers three routes to a resource's tags — this
+  operation, a `tag:<key>` filter on each describe, and Resource Groups Tagging — and
+  substrate served the third in full and the second on five operations.
+
+  It reports every tag stored in the request's account and region as AWS's `TagDescription`
+  (`resourceId`, `resourceType`, `key`, `value`), with `MaxResults` 5–1000 and `NextToken`.
+  All five documented filters are evaluated — `key`, `resource-id`, `resource-type`, `value`
+  and `tag:<key>` — with **wildcards in their values**, which this operation's reference
+  states outright and which no other EC2 describe in substrate honours. **There is no
+  `tag-key` filter**, alone in the describe family: `key` already asks that question, so
+  `tag-key` is refused here while it is accepted on every neighbouring operation. That is
+  AWS's set, not an omission.
+
+  **The scan is deliberately wider than what `CreateTags` can write.** `CreateTags` reaches
+  nine resource types; the scan reads thirteen, adding `image`, `snapshot`, `launch-template`
+  and `fleet` — types whose tags arrive through their own create call's `TagSpecification.N`
+  and cannot be set through `CreateTags` at all (#689 adds the snapshot arm, #695 the rest).
+  Reporting only the writable types would hide tags a caller had successfully applied.
+  `placement-group` is the one type with a `Tags` field left out: nothing writes it, and its
+  records are keyed by group *name* where AWS's `TagDescription` reports an ID.
+
+  The answer is **sorted by `resourceId`, then `resourceType`, then `key`**, which is
+  stricter than AWS — it states its own order "might vary". `StateManager.List` promises no
+  ordering either, so an offset token over an unordered list could skip or repeat a tag
+  between pages, and two replays of one recorded request could answer differently.
+
 - **A subnet reports its tags, and `DescribeSubnets` filters on them** (#685). `EC2Subnet`
   has carried a `Tags` field for as long as it has existed and `CreateTags` on a `subnet-` ID
   has always written to it — only the reader was missing, so every tag a caller applied to a

--- a/docs/services.md
+++ b/docs/services.md
@@ -2668,6 +2668,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances, [subject to termination protection](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); accepts a `vol-` ID like [any other taggable ID](#a-volume-carries-tags); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
 | DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) and [over-long keys](#tag-key-and-value-length-limits); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
+| DescribeTags | Every tag in the region, across thirteen resource types. Five filters with **wildcards**, `MaxResults` 5–1000 and `NextToken`, and a deterministic order — see [Finding a resource by tag](#finding-a-resource-by-tag) |
 
 ### One rule for an unrecognized filter name
 
@@ -2680,9 +2681,9 @@ way.
 This replaced three different answers across substrate's filter-parsing EC2 operations —
 dropped on volumes, snapshots, security groups, route tables, NAT gateways, fleets and
 images; matched nothing on instances; refused on instance-type offerings — with the one
-real EC2 gives. `DescribeSubnets` is the tenth operation the rule covers, and the only one
-that arrived with both halves at once: it parsed no `Filter.N` at all before it gained the
-filters below.
+real EC2 gives. `DescribeSubnets` and `DescribeTags` are the tenth and eleventh operations
+the rule covers, and the only two that arrived with both halves at once: the first parsed no
+`Filter.N` at all before it gained the filters below, and the second did not exist.
 
 **This is a behaviour change, and the loudest one in the release that brought it.** A
 misspelled filter name previously came back as a successful response: dropped, so the query
@@ -2732,19 +2733,24 @@ one is refused on its neighbour — `tag:<key>` most conspicuously (see below).
 | DescribeNatGateways | `state`, `vpc-id` | `nat-gateway-id`, `subnet-id`, `tag-key`, `tag:<key>` |
 | DescribeFleets | `activity-status`, `fleet-state`, `type` | `excess-capacity-termination-policy`, `replace-unhealthy-instances` |
 | DescribeInstanceTypeOfferings | `instance-type`, `location` (both with [wildcards](#offerings-filters-and-wildcards)) | — |
+| DescribeTags | `key`, `resource-id`, `resource-type`, `value`, `tag:<key>` — all five AWS documents, all with [wildcards](#finding-a-resource-by-tag) | — |
 
 `tag:<key>` is refused on **`DescribeFleets` and `DescribeInstanceTypeOfferings`**, which
 document no tag filter at all — neither `tag:<key>` nor `tag-key` — even though a fleet
 carries tags and `DescribeFleets` renders them. That is AWS's set, not an omission here; to
-find a fleet by tag, use Resource Groups Tagging.
+find a fleet by tag, use `DescribeTags` or Resource Groups Tagging.
 
-Read the tag rows in the other direction and they remain the surface's weakest point:
-**`DescribeInstances`, `DescribeVolumes`, `DescribeImages`, `DescribeSnapshots` and
-`DescribeSubnets`** filter on tags; on security groups, route tables and NAT gateways a
-`tag:<key>` filter is accepted and inert, so "find the resources tagged `Env=prod`"
-answers with *all* of them. Real EC2 offers three routes to finding a resource by tag: the
-describe filters, `DescribeTags`, and Resource Groups Tagging. Substrate serves the third
-in full, the first on five operations, and does not implement `DescribeTags` at all.
+`tag-key` runs the other way: every tag-bearing describe documents it **except
+`DescribeTags`**, which has no such filter because its `key` filter already asks that
+question. So `tag-key` is refused there and accepted on its neighbours — again AWS's set.
+
+Read the tag rows in the other direction and the describe filters remain the narrowest of
+the three routes: **`DescribeInstances`, `DescribeVolumes`, `DescribeImages`,
+`DescribeSnapshots` and `DescribeSubnets`** filter on tags; on security groups, route tables
+and NAT gateways a `tag:<key>` filter is accepted and inert, so "find the security groups
+tagged `Env=prod`" answers with *all* of them. Real EC2 offers three routes to finding a
+resource by tag: the describe filters, `DescribeTags`, and Resource Groups Tagging.
+Substrate now serves all three — the first on five operations, and the other two in full.
 
 #### Filter semantics that apply everywhere
 
@@ -2764,10 +2770,12 @@ requests that succeed today. Thirteen EC2 describes — including `DescribeVpcs`
 `DescribeAddresses`, `DescribeInstanceTypes` and `DescribeAvailabilityZones` — never parse
 `Filter.N` at all, so they neither apply nor refuse one
 ([#695](https://github.com/scttfrdmn/substrate/issues/695)). And filter *values* honour
-EC2's documented wildcards only on `DescribeInstanceTypeOfferings`; everywhere else
-matching is exact ([#697](https://github.com/scttfrdmn/substrate/issues/697)). A third,
-narrower one: an **empty** value list matches nothing here but matches everything on
-`DescribeSecurityGroups` ([#696](https://github.com/scttfrdmn/substrate/issues/696)).
+EC2's documented wildcards only on `DescribeInstanceTypeOfferings` and `DescribeTags` — the
+two operations whose reference pages state them outright; everywhere else matching is exact
+([#697](https://github.com/scttfrdmn/substrate/issues/697)). A third, narrower one: an
+**empty** value list matches nothing on most operations but matches everything on
+`DescribeSecurityGroups` and `DescribeTags`, both of which route through the same shared
+matcher ([#696](https://github.com/scttfrdmn/substrate/issues/696)).
 
 ### RunInstances requires a resolvable AMI
 
@@ -4172,6 +4180,49 @@ A snapshot a *filter* excluded still counts as resolved, so naming an existing s
 filtering it out is an empty HTTP 200 rather than `InvalidSnapshot.NotFound` — the rule
 [Explicit resource IDs](#explicit-resource-ids) states, and the distinction between "not
 yet" and "never" that a consumer's wait loop turns on. `DescribeSubnets` follows it too.
+
+#### Finding a resource by tag
+
+`DescribeTags` — the operation whose whole job is this question — did not exist until
+[#688](https://github.com/scttfrdmn/substrate/issues/688), and answered
+`InvalidAction` / HTTP 400, while four of substrate's bundled managed policies *granted*
+`ec2:DescribeTags`: `AmazonVPCFullAccess` and `AmazonVPCReadOnlyAccess` name it outright, and
+`AmazonEC2FullAccess` and `AmazonEC2ReadOnlyAccess` reach it through `ec2:*` and
+`ec2:Describe*`. A policy permitted an operation nothing served, and the only routes left were
+the per-operation `tag:<key>` filters (five operations) and Resource Groups Tagging.
+
+It reports every tag stored in the request's account and region. Every EC2 record key is
+`<namespace>:<account>/<region>/<id>`, so the scan is regional by construction, which is also
+real EC2's scope for this operation.
+
+**The scan is deliberately wider than what `CreateTags` can write.** `CreateTags` reaches
+nine resource types; `DescribeTags` reads thirteen, adding `image`, `snapshot`,
+`launch-template` and `fleet` — types whose tags arrive through their own create call's
+`TagSpecification.N` and cannot be set through `CreateTags` at all
+([#689](https://github.com/scttfrdmn/substrate/issues/689) adds the snapshot arm;
+[#695](https://github.com/scttfrdmn/substrate/issues/695) the rest). Reporting only the
+writable types would hide tags a caller had successfully applied. `placement-group` is the one
+type carrying a `Tags` field that stays out: nothing writes it, and its records are keyed by
+group *name* where AWS's `TagDescription` reports an ID.
+
+| Behaviour | Answer |
+|---|---|
+| Filters | `key`, `resource-id`, `resource-type`, `value`, `tag:<key>` — every name AWS documents, all evaluated, none inert |
+| `tag-key` | **Refused.** This operation documents no such filter, alone in the describe family, because `key` already matches a key whatever its value |
+| Wildcards | `*` and `?` work in every filter value, which AWS's Example 4 states outright ("specify the value as `?ebserver` to find tags with the key `webserver` or `Webserver`") |
+| An empty value | A tag whose value is the empty string renders `<value/>` and is matched by `Filter.N.Value.1=` — AWS's Example 1 and Example 6 respectively |
+| `MaxResults` | 5–1000. A value outside the range is **refused** with `InvalidParameterValue`, not clamped: a caller who asked for 2000 asked for something the operation cannot do |
+| `NextToken` | A decimal offset. A malformed token is refused; an offset past the end is clamped to an empty last page, so resuming after a tag was deleted is not an error |
+| Order | **Sorted by `resourceId`, then `resourceType`, then `key`** |
+
+The sort is *stricter than AWS*, which says its own order "might vary" and that applications
+should not rely on it. Substrate must be stricter: `StateManager.List` promises no ordering
+either, so an offset-based token over an unordered list could skip or repeat a tag between
+pages, and two replays of one recorded request could answer differently. A deterministic
+emulator cannot answer one request two ways.
+
+Authorization needs nothing special: the Service Authorization Reference gives
+`DescribeTags` resource type "—", and substrate authorizes it against `*`.
 
 ### Seeding EC2 Fleet partial fulfillment
 

--- a/emulator/ec2_describetags.go
+++ b/emulator/ec2_describetags.go
@@ -1,0 +1,353 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ec2MaxTagResults is the largest MaxResults DescribeTags accepts, and the page size a
+// request naming none receives.
+const ec2MaxTagResults = 1000
+
+// ec2MinTagResults is the smallest MaxResults DescribeTags accepts.
+//
+// AWS documents this operation's range as "between 5 and 1000", where
+// DescribeLaunchTemplateVersions' is 1 to 200 — the floor is per-operation, so it cannot be
+// shared with [ec2MaxLaunchTemplateVersionResults]' check even though the two read alike.
+const ec2MinTagResults = 5
+
+// ec2StatePrefix is the key prefix every EC2 record of one namespace in one account and
+// region shares.
+//
+// Every EC2 state key is "<namespace>:<account>/<region>/<id>", so one builder for the
+// prefix half is what lets [ec2TagScanTargets] name a namespace once instead of
+// concatenating it, for the reason [ec2VolumeStateKey]'s doc comment gives: a reader that
+// spells a key differently from the writer sees no records at all. The scan is naturally
+// regional because the scope is inside the prefix, which is also real EC2's scope for this
+// operation.
+func ec2StatePrefix(namespace, accountID, region string) string {
+	return namespace + ":" + accountID + "/" + region + "/"
+}
+
+// ec2TagResourceID returns the resource ID at the end of an EC2 state key.
+//
+// Every namespace in [ec2TagScanTargets] keys its records by the resource's own ID in the
+// last path segment, so the tail is the ID a caller would pass to CreateTags — and the one
+// AWS's TagDescription reports.
+func ec2TagResourceID(key string) string {
+	if i := strings.LastIndex(key, "/"); i >= 0 {
+		return key[i+1:]
+	}
+	return key
+}
+
+// ec2TagScanTarget is one resource type DescribeTags reads: the namespace its records live
+// under, and AWS's TagSpecification spelling of the type.
+//
+// The spelling matters twice over — it is the value the resource-type filter is documented
+// against and the value the resourceType response member carries — which is why it is
+// written here beside the namespace rather than derived from it: "sg" is "security-group"
+// and "nat" is "natgateway", unhyphenated, and neither could be computed.
+type ec2TagScanTarget struct {
+	// namespace is the state-key namespace, the half before the colon.
+	namespace string
+	// resourceType is AWS's TagSpecification spelling of the resource type.
+	resourceType string
+}
+
+// ec2TagScanTargets is every resource type DescribeTags reads tags from.
+//
+// This list is deliberately **wider** than [ec2TaggableResource]'s nine prefixes, which is
+// what CreateTags can write through. DescribeTags' job is to report every tag substrate
+// stores, however it was applied: an AMI, snapshot, launch template or fleet takes its tags
+// from its own create call's TagSpecification and cannot be tagged through CreateTags at
+// all (#689 adds the snapshot arm; the rest are #695's follow-up), so reporting only the
+// CreateTags-writable types would hide tags a caller had successfully applied.
+//
+// EC2PlacementGroup also carries a Tags field and is deliberately absent: no path writes
+// it, and its records are keyed by group *name* where AWS's TagDescription reports a
+// placement group's ID, so [ec2TagResourceID] would report the wrong identifier. It joins
+// the scan when something can tag a placement group.
+//
+// Order is alphabetical by type, which only sets the scan order — the response is sorted
+// by [ec2SortTagDescriptions] regardless.
+func ec2TagScanTargets() []ec2TagScanTarget {
+	return []ec2TagScanTarget{
+		{"eip", "elastic-ip"},
+		{"fleet", "fleet"},
+		{"image", "image"},
+		{"instance", "instance"},
+		{"igw", "internet-gateway"},
+		{"lt", "launch-template"},
+		{"nat", "natgateway"},
+		{"rtb", "route-table"},
+		{"sg", "security-group"},
+		{"snapshot", "snapshot"},
+		{"subnet", "subnet"},
+		{"volume", "volume"},
+		{"vpc", "vpc"},
+	}
+}
+
+// ec2TagFilterSpec is DescribeTags' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTags.html.
+//
+// Five names, all evaluated, and **no tag-key** — the one operation in EC2's describe family
+// that documents none, which is worth stating rather than leaving to look like an omission
+// here. Its `key` filter is that question: `key` matches a tag key whatever its value, which
+// is what tag-key spells elsewhere.
+func ec2TagFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated:      []string{"key", "resource-id", "resource-type", "value"},
+	}
+}
+
+// ec2TagDescription renders one tag on one resource as AWS's TagDescription element.
+//
+// Its own type rather than [ec2TagItem]: a TagDescription carries the resource it is on,
+// which a Tag does not, so the two are different shapes for different questions.
+//
+// No omitempty on value. AWS's Example 1 renders `<value/>` for a tag whose value is empty,
+// and an SDK tells a present-but-empty element ("the tag's value is the empty string") from
+// an absent one ("unknown") — the same reasoning CreateVolume's tagSet follows.
+type ec2TagDescription struct {
+	// ResourceID is the ID of the resource the tag is on.
+	ResourceID string `xml:"resourceId"`
+
+	// ResourceType is AWS's TagSpecification spelling of the resource's type.
+	ResourceType string `xml:"resourceType"`
+
+	// Key is the tag key.
+	Key string `xml:"key"`
+
+	// Value is the tag value, which may be empty.
+	Value string `xml:"value"`
+}
+
+// describeTags handles the DescribeTags action, the operation whose whole job is finding
+// resources by tag.
+//
+// Until #688 it reached the dispatcher's default arm and answered InvalidAction / HTTP 400,
+// while four of [ListManagedPolicies]' bundles granted ec2:DescribeTags — AmazonVPCFullAccess
+// and AmazonVPCReadOnlyAccess name it outright, AmazonEC2FullAccess and
+// AmazonEC2ReadOnlyAccess reach it through ec2:* and ec2:Describe* — so a policy permitted an
+// operation nothing served. Real EC2 offers three routes to a resource's tags: this
+// operation, a tag:<key> filter on each describe, and Resource Groups Tagging. Substrate
+// served the third in full and the second on five operations.
+//
+// The answer is assembled in four steps, in this order: refuse an undocumented filter name,
+// validate MaxResults, scan and filter, then sort and page. Refusal comes first so that it
+// never depends on how many resources happen to be tagged, which is the ordering
+// [ec2FilterSpec.check] documents.
+func (p *EC2Plugin) describeTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	if awsErr := ec2TagFilterSpec().check(req.Params); awsErr != nil {
+		return nil, awsErr
+	}
+	maxResults, awsErr := ec2TagMaxResults(req.Params)
+	if awsErr != nil {
+		return nil, awsErr
+	}
+
+	items, err := p.scanTags(context.Background(), reqCtx, extractEC2Filters(req.Params))
+	if err != nil {
+		return nil, fmt.Errorf("ec2 describeTags: %w", err)
+	}
+	ec2SortTagDescriptions(items)
+
+	page, nextToken, awsErr := ec2PageTagDescriptions(items, req.Params["NextToken"], maxResults)
+	if awsErr != nil {
+		return nil, awsErr
+	}
+
+	type response struct {
+		XMLName   xml.Name            `xml:"DescribeTagsResponse"`
+		XMLNS     string              `xml:"xmlns,attr"`
+		Tags      []ec2TagDescription `xml:"tagSet>item"`
+		NextToken string              `xml:"nextToken,omitempty"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:     "http://ec2.amazonaws.com/doc/2016-11-15/",
+		Tags:      page,
+		NextToken: nextToken,
+	})
+}
+
+// scanTags reads every stored tag in the account and region, keeping the ones the filters
+// accept.
+//
+// Each record is decoded into an anonymous struct carrying only "tags", the type-agnostic
+// shape [EC2Plugin.applyTagsToResource] writes and [ec2AuthzTagsFor] reads, so a new
+// resource type joins the scan by being listed in [ec2TagScanTargets] and needs no decoder
+// of its own.
+//
+// A record that cannot be read or decoded is skipped rather than failing the request: a
+// partial answer names the resources it could read, where an error names none of them, and
+// a single unparseable record would otherwise make DescribeTags unusable. A failed List is
+// different — that is the whole namespace, so it is returned as an error.
+func (p *EC2Plugin) scanTags(ctx context.Context, reqCtx *RequestContext, filters map[string][]string) ([]ec2TagDescription, error) {
+	var out []ec2TagDescription
+	for _, target := range ec2TagScanTargets() {
+		keys, err := p.state.List(ctx, ec2Namespace,
+			ec2StatePrefix(target.namespace, reqCtx.AccountID, reqCtx.Region))
+		if err != nil {
+			return nil, fmt.Errorf("list %s: %w", target.namespace, err)
+		}
+		for _, key := range keys {
+			data, getErr := p.state.Get(ctx, ec2Namespace, key)
+			if getErr != nil || data == nil {
+				continue
+			}
+			var record struct {
+				Tags []EC2Tag `json:"tags"`
+			}
+			if json.Unmarshal(data, &record) != nil {
+				continue
+			}
+			for _, tag := range record.Tags {
+				item := ec2TagDescription{
+					ResourceID:   ec2TagResourceID(key),
+					ResourceType: target.resourceType,
+					Key:          tag.Key,
+					Value:        tag.Value,
+				}
+				if ec2TagMatchesFilters(item, filters) {
+					out = append(out, item)
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+// ec2TagMatchesFilters reports whether one tag satisfies every supplied filter. Filters AND
+// with each other and each one's values OR, AWS's documented rule.
+func ec2TagMatchesFilters(item ec2TagDescription, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2TagMatchesFilter(item, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2TagMatchesFilter evaluates a single DescribeTags filter against one tag.
+//
+// Values are matched with [ec2FilterAccepts], so **wildcards work** — AWS's Example 4 says
+// so for this operation in as many words: "You can use wildcards with filters, so you could
+// specify the value as ?ebserver to find tags with the key webserver or Webserver." This is
+// the first site outside DescribeInstanceTypeOfferings to match a filter value that way;
+// every other EC2 describe compares exactly, which is #697.
+//
+// An explicitly empty value is a value, not an absent one: AWS's Example 6 filters on
+// `value` with `Filter.3.Value.1=` to find tags whose value is the empty string, and
+// [extractEC2Filters] preserves that as a one-element list. A filter carrying *no* Value.N
+// at all is a different request, and [ec2FilterAccepts] answers it by matching everything —
+// this operation inherits that rule rather than choosing it, and reconciling it with the
+// match-nothing reading its siblings take is #696.
+//
+// There is no default arm returning true. Every name that reaches here is one of the five
+// AWS documents, because [ec2TagFilterSpec] refuses the rest before the scan and its
+// evaluated list is the whole documented set — this operation is the only one in the family
+// with nothing inert.
+func ec2TagMatchesFilter(item ec2TagDescription, name string, values []string) bool {
+	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
+		return item.Key == tagKey && ec2FilterAccepts(values, item.Value)
+	}
+	switch name {
+	case "key":
+		return ec2FilterAccepts(values, item.Key)
+	case "resource-id":
+		return ec2FilterAccepts(values, item.ResourceID)
+	case "resource-type":
+		return ec2FilterAccepts(values, item.ResourceType)
+	case "value":
+		return ec2FilterAccepts(values, item.Value)
+	default:
+		return false
+	}
+}
+
+// ec2SortTagDescriptions orders the answer by resource ID, then type, then key.
+//
+// AWS says its own order "might vary" and that applications should not rely on it.
+// Substrate is stricter deliberately: [StateManager.List] documents no ordering either, so
+// an offset-based NextToken over an unordered list could skip or repeat a tag between
+// pages, and two replays of one recorded request could answer differently. A deterministic
+// emulator must not answer one request two ways.
+//
+// The key breaks the tie within a resource, and the type breaks it between two resources of
+// different types sharing an ID — which substrate's generated IDs make impossible, but the
+// comparison is total rather than nearly so.
+func ec2SortTagDescriptions(items []ec2TagDescription) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].ResourceID != items[j].ResourceID {
+			return items[i].ResourceID < items[j].ResourceID
+		}
+		if items[i].ResourceType != items[j].ResourceType {
+			return items[i].ResourceType < items[j].ResourceType
+		}
+		return items[i].Key < items[j].Key
+	})
+}
+
+// ec2TagMaxResults reads DescribeTags' MaxResults, defaulting to [ec2MaxTagResults].
+//
+// A value outside 5–1000 is refused rather than clamped, which is what
+// DescribeLaunchTemplateVersions does with its own range: a caller who asked for 2000 items
+// asked for something the operation cannot do, and silently giving 1000 hides that.
+func ec2TagMaxResults(params map[string]string) (int, *AWSError) {
+	raw := params["MaxResults"]
+	if raw == "" {
+		return ec2MaxTagResults, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < ec2MinTagResults || n > ec2MaxTagResults {
+		return 0, &AWSError{
+			Code: "InvalidParameterValue",
+			Message: "MaxResults must be between " + strconv.Itoa(ec2MinTagResults) +
+				" and " + strconv.Itoa(ec2MaxTagResults),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	return n, nil
+}
+
+// ec2PageTagDescriptions returns the page of items starting at token, and the token for the
+// page after it.
+//
+// The wire shape is DescribeLaunchTemplateVersions': a plain decimal offset, an
+// InvalidParameterValue for a token that is not one, an out-of-range offset clamped to the
+// end rather than refused — a caller resuming after a tag was deleted gets an empty last
+// page, not an error — and an omitted nextToken on the last page, since AWS documents the
+// member as null when there are no more items.
+//
+// The offset is only stable because [ec2SortTagDescriptions] ran first.
+func ec2PageTagDescriptions(items []ec2TagDescription, token string, maxResults int) ([]ec2TagDescription, string, *AWSError) {
+	start := 0
+	if token != "" {
+		n, err := strconv.Atoi(token)
+		if err != nil || n < 0 {
+			return nil, "", &AWSError{
+				Code:       "InvalidParameterValue",
+				Message:    "The token '" + token + "' is invalid",
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+		start = n
+	}
+	if start > len(items) {
+		start = len(items)
+	}
+	page := items[start:]
+	if len(page) > maxResults {
+		return page[:maxResults], strconv.Itoa(start + maxResults), nil
+	}
+	return page, "", nil
+}

--- a/emulator/ec2_describetags_test.go
+++ b/emulator/ec2_describetags_test.go
@@ -1,0 +1,352 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #688's surface: DescribeTags, the operation whose whole job is finding resources by tag.
+//
+// Before this it reached the dispatcher's default arm and answered InvalidAction / HTTP 400
+// while four bundled managed policies granted ec2:DescribeTags — a policy permitted an
+// operation nothing served. Every assertion here goes through HTTP, because that is where the whole
+// defect lived.
+
+// describedTag is one DescribeTags tagSet>item.
+type describedTag struct {
+	ResourceID   string `xml:"resourceId"`
+	ResourceType string `xml:"resourceType"`
+	Key          string `xml:"key"`
+	Value        string `xml:"value"`
+}
+
+// ec2DescribeTags sends DescribeTags with params and returns the tags and the next token.
+func ec2DescribeTags(t *testing.T, ts *httptest.Server, params map[string]string) ([]describedTag, string) {
+	t.Helper()
+	full := map[string]string{"Action": "DescribeTags"}
+	for k, v := range params {
+		full[k] = v
+	}
+	var doc struct {
+		Tags      []describedTag `xml:"tagSet>item"`
+		NextToken string         `xml:"nextToken"`
+	}
+	ec2FleetXML(t, ts, full, &doc)
+	return doc.Tags, doc.NextToken
+}
+
+// ec2TagKeysFor reduces the answer to "<resourceId>/<key>=<value>" strings, which is what a
+// filter test asserts on: the identity of each tag, not the element order AWS says may vary.
+func ec2TagKeysFor(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	tags, _ := ec2DescribeTags(t, ts, params)
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		out = append(out, tag.ResourceID+"/"+tag.Key+"="+tag.Value)
+	}
+	return out
+}
+
+// ec2SeedTaggedResources tags one instance and one VPC through CreateTags and returns their
+// IDs. Two resource types, so a resource-type filter has something to exclude.
+func ec2SeedTaggedResources(t *testing.T, ts *httptest.Server) (instID, vpcID string) {
+	t.Helper()
+	instID = ec2TagTestInstance(t, ts)
+
+	var vpc struct {
+		VPCID string `xml:"vpc>vpcId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.7.0.0/16"}, &vpc)
+	vpcID = vpc.VPCID
+	require.NotEmpty(t, vpcID)
+
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": instID,
+		"Tag.1.Key":    "Name",
+		"Tag.1.Value":  "webserver",
+		"Tag.2.Key":    "Env",
+		"Tag.2.Value":  "prod",
+	}, nil)
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": vpcID,
+		"Tag.1.Key":    "Env",
+		"Tag.1.Value":  "staging",
+		"Tag.2.Key":    "Empty",
+		"Tag.2.Value":  "",
+	}, nil)
+	return instID, vpcID
+}
+
+// TestEC2_DescribeTags_ReportsEveryStoredTag is the fail-before: this request answered
+// InvalidAction / 400 before #688, so nothing below could be asserted at all.
+//
+// It also pins the four members of AWS's TagDescription together, since resourceId and
+// resourceType are the whole difference between this operation and reading a tagSet off each
+// describe — a caller asks DescribeTags precisely because it does not know which resource
+// carries the tag.
+func TestEC2_DescribeTags_ReportsEveryStoredTag(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instID, vpcID := ec2SeedTaggedResources(t, ts)
+
+	tags, next := ec2DescribeTags(t, ts, nil)
+	assert.Empty(t, next, "four tags is one page, so the last page carries no token")
+
+	byID := map[string][]describedTag{}
+	for _, tag := range tags {
+		byID[tag.ResourceID] = append(byID[tag.ResourceID], tag)
+	}
+	require.Len(t, byID[instID], 2, "both instance tags are reported")
+	require.Len(t, byID[vpcID], 2, "both VPC tags are reported")
+
+	for _, tag := range byID[instID] {
+		assert.Equal(t, "instance", tag.ResourceType,
+			"resourceType is AWS's TagSpecification spelling of the type")
+	}
+	for _, tag := range byID[vpcID] {
+		assert.Equal(t, "vpc", tag.ResourceType)
+	}
+	assert.Contains(t, ec2TagKeysFor(t, ts, nil), vpcID+"/Empty=",
+		"a tag whose value is the empty string is reported as one, not dropped")
+}
+
+// TestEC2_DescribeTags_FiltersNarrowTheAnswer walks each of the five filter names AWS
+// documents, in both the exact and the wildcard form its Example 4 shows.
+func TestEC2_DescribeTags_FiltersNarrowTheAnswer(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instID, vpcID := ec2SeedTaggedResources(t, ts)
+
+	tests := []struct {
+		name   string
+		filter map[string]string
+		want   []string
+	}{
+		{"key selects a key whatever its value", ec2Filter("key", "Env"),
+			[]string{instID + "/Env=prod", vpcID + "/Env=staging"}},
+		{"key values OR", ec2Filter("key", "Name", "Empty"),
+			[]string{instID + "/Name=webserver", vpcID + "/Empty="}},
+		{"resource-id selects one resource", ec2Filter("resource-id", vpcID),
+			[]string{vpcID + "/Empty=", vpcID + "/Env=staging"}},
+		{"resource-type excludes the other type", ec2Filter("resource-type", "vpc"),
+			[]string{vpcID + "/Empty=", vpcID + "/Env=staging"}},
+		{"resource-type matches nothing for an unstored type",
+			ec2Filter("resource-type", "volume"), []string{}},
+		{"value selects by value alone", ec2Filter("value", "staging"),
+			[]string{vpcID + "/Env=staging"}},
+		{"value matches an explicitly empty value", ec2Filter("value", ""),
+			[]string{vpcID + "/Empty="}},
+		{"tag:<key> needs the key and the value", ec2Filter("tag:Env", "prod"),
+			[]string{instID + "/Env=prod"}},
+		{"tag:<key> with a non-matching value selects nothing",
+			ec2Filter("tag:Env", "absent"), []string{}},
+		// AWS's Example 4, verbatim: "You can use wildcards with filters, so you could
+		// specify the value as ?ebserver to find tags with the key webserver or Webserver."
+		{"a ? wildcard matches one character", ec2Filter("value", "?ebserver"),
+			[]string{instID + "/Name=webserver"}},
+		{"a * wildcard matches a run", ec2Filter("value", "*ing"),
+			[]string{vpcID + "/Env=staging"}},
+		{"a wildcard applies to key too", ec2Filter("key", "E*"),
+			[]string{instID + "/Env=prod", vpcID + "/Empty=", vpcID + "/Env=staging"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// ElementsMatch, not Equal: this table asserts which tags the filter
+			// selects, and the deterministic order is pinned by the pagination test
+			// instead — the one place the order is load-bearing.
+			assert.ElementsMatch(t, tc.want, ec2TagKeysFor(t, ts, tc.filter))
+		})
+	}
+}
+
+// TestEC2_DescribeTags_FiltersAnd pins the AND-across-names, OR-within-values rule on the
+// operation whose reference states it, using AWS's Example 5 shape: several filters, one of
+// them multi-valued.
+func TestEC2_DescribeTags_FiltersAnd(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instID, vpcID := ec2SeedTaggedResources(t, ts)
+
+	assert.Equal(t, []string{instID + "/Env=prod"}, ec2TagKeysFor(t, ts, map[string]string{
+		"Filter.1.Name":    "key",
+		"Filter.1.Value.1": "Env",
+		"Filter.2.Name":    "value",
+		"Filter.2.Value.1": "prod",
+		"Filter.2.Value.2": "dev",
+	}), "key=Env AND value in (prod, dev) selects the instance tag alone")
+
+	assert.Empty(t, ec2TagKeysFor(t, ts, map[string]string{
+		"Filter.1.Name":    "resource-id",
+		"Filter.1.Value.1": vpcID,
+		"Filter.2.Name":    "value",
+		"Filter.2.Value.1": "prod",
+	}), "two filters that no single tag satisfies select nothing, rather than the union")
+}
+
+// TestEC2_DescribeTags_RefusesUndocumentedFilterNames pins #687's rule on this operation,
+// and with it the distinction worth stating out loud: DescribeTags documents **no tag-key
+// filter**, alone in the describe family, because its `key` filter already asks that
+// question. So a caller reaching for the neighboring spelling is refused rather than
+// silently given everything.
+func TestEC2_DescribeTags_RefusesUndocumentedFilterNames(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	ec2SeedTaggedResources(t, ts)
+
+	for _, name := range []string{"tag-key", "resource-typ", "tag", "instance-id"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			params := ec2Filter(name, "Env")
+			params["Action"] = "DescribeTags"
+			status, code, _ := ec2ErrorDetail(t, ts, params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code)
+		})
+	}
+}
+
+// TestEC2_DescribeTags_Pagination covers the MaxResults range and the offset token.
+//
+// The ordering assertion is the load-bearing one: StateManager.List documents no ordering,
+// so an offset token over an unordered list could skip or repeat a tag between pages, and
+// two replays of one recorded request could answer differently.
+func TestEC2_DescribeTags_Pagination(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instID := ec2TagTestInstance(t, ts)
+
+	// Twelve tags on one instance, created in an order that is not the sorted order.
+	params := map[string]string{"Action": "CreateTags", "ResourceId.1": instID}
+	for i := 12; i >= 1; i-- {
+		n := strconv.Itoa(i)
+		params["Tag."+n+".Key"] = "k" + string(rune('a'+i-1))
+		params["Tag."+n+".Value"] = "v" + n
+	}
+	ec2FleetXML(t, ts, params, nil)
+
+	all, next := ec2DescribeTags(t, ts, nil)
+	require.Len(t, all, 12)
+	assert.Empty(t, next)
+	keys := make([]string, 0, len(all))
+	for _, tag := range all {
+		keys = append(keys, tag.Key)
+	}
+	assert.Equal(t, []string{"ka", "kb", "kc", "kd", "ke", "kf", "kg", "kh", "ki", "kj", "kk", "kl"},
+		keys, "one resource's tags come back sorted by key, whatever order they were written in")
+
+	// Paged at AWS's minimum of five, the three pages concatenate to the same list.
+	var paged []describedTag
+	token := ""
+	for page := 0; page < 3; page++ {
+		req := map[string]string{"MaxResults": "5"}
+		if token != "" {
+			req["NextToken"] = token
+		}
+		var items []describedTag
+		items, token = ec2DescribeTags(t, ts, req)
+		paged = append(paged, items...)
+		if page < 2 {
+			assert.Len(t, items, 5)
+			assert.NotEmpty(t, token, "a full page must carry a token")
+		}
+	}
+	assert.Empty(t, token, "the last page carries no token, since AWS documents it as null")
+	assert.Equal(t, all, paged, "the pages concatenate to the unpaged answer, in order")
+}
+
+// TestEC2_DescribeTags_RefusesBadPagination pins the two refusals, both of which are
+// InvalidParameterValue: a MaxResults outside 5–1000, and a token that is not an offset.
+//
+// A value outside the range is refused rather than clamped — a caller who asked for 2000
+// items asked for something the operation cannot do, and silently giving 1000 hides that.
+func TestEC2_DescribeTags_RefusesBadPagination(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	ec2SeedTaggedResources(t, ts)
+
+	tests := []struct {
+		name   string
+		params map[string]string
+		want   bool
+	}{
+		{"MaxResults below AWS's minimum of 5", map[string]string{"MaxResults": "4"}, true},
+		{"MaxResults above AWS's maximum of 1000", map[string]string{"MaxResults": "1001"}, true},
+		{"MaxResults not a number", map[string]string{"MaxResults": "many"}, true},
+		{"MaxResults at the minimum", map[string]string{"MaxResults": "5"}, false},
+		{"MaxResults at the maximum", map[string]string{"MaxResults": "1000"}, false},
+		{"a token that is not an offset", map[string]string{"NextToken": "abc"}, true},
+		{"a negative offset", map[string]string{"NextToken": "-1"}, true},
+		// Clamped, not refused: a caller resuming after a tag was deleted gets an empty
+		// last page rather than an error.
+		{"an offset past the end", map[string]string{"NextToken": "9999"}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			params := map[string]string{"Action": "DescribeTags"}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			status, code, _ := ec2ErrorDetail(t, ts, params)
+			if tc.want {
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "InvalidParameterValue", code)
+				return
+			}
+			assert.Equal(t, http.StatusOK, status)
+			assert.Empty(t, code)
+		})
+	}
+}
+
+// TestEC2_DescribeTags_ScanIsWiderThanCreateTags pins the asymmetry deliberately: a
+// snapshot's tags are reported even though CreateTags cannot write them.
+//
+// ec2TaggableResource covers nine prefixes, and a snap- ID is not one of them (#689 adds the
+// arm) — but CreateImage's TagSpecification writes a snapshot's tags anyway, so a
+// DescribeTags that reported only the CreateTags-writable types would hide tags a caller had
+// successfully applied. Reporting every tag substrate stores, however it was applied, is the
+// operation's job.
+func TestEC2_DescribeTags_ScanIsWiderThanCreateTags(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	snaps := ec2SeedTaggedSnapshots(t, ts, "alpha")
+
+	assert.Equal(t, []string{snaps["alpha"] + "/Scope=alpha"},
+		ec2TagKeysFor(t, ts, ec2Filter("resource-type", "snapshot")),
+		"a snapshot tagged through CreateImage's TagSpecification is still reported")
+
+	// And CreateTags on that same snapshot still writes nothing, so the two halves of the
+	// asymmetry are pinned together and #689 has a test to change.
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": snaps["alpha"],
+		"Tag.1.Key":    "Added",
+		"Tag.1.Value":  "later",
+	}, nil)
+	assert.NotContains(t, ec2TagKeysFor(t, ts, ec2Filter("resource-type", "snapshot")),
+		snaps["alpha"]+"/Added=later",
+		"CreateTags has no snap- arm yet, so it silently writes nothing — #689")
+}
+
+// TestEC2_DescribeTags_EmptyWhenNothingIsTagged pins that an account with no tags answers an
+// empty tagSet and a 200, not an error and not the untagged resources themselves.
+func TestEC2_DescribeTags_EmptyWhenNothingIsTagged(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	ec2TagTestInstance(t, ts)
+
+	tags, next := ec2DescribeTags(t, ts, nil)
+	assert.Empty(t, tags, "an untagged instance contributes no tags")
+	assert.Empty(t, next)
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -138,6 +138,8 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.createTags(ctx, req)
 	case "DeleteTags":
 		return p.deleteTags(ctx, req)
+	case "DescribeTags":
+		return p.describeTags(ctx, req)
 	case "ModifyInstanceAttribute":
 		return p.modifyInstanceAttribute(ctx, req)
 	case "DescribeInstanceAttribute":

--- a/test/e2e/journey_ec2_describetags_test.go
+++ b/test/e2e/journey_ec2_describetags_test.go
@@ -1,0 +1,135 @@
+package e2e_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_EC2DescribeTags is #688 at the tier that proves the operation is reachable:
+// through a typed SDK client, whose DescribeTagsPaginator is how a consumer actually walks
+// a region's tags.
+//
+// The unit tests build the form parameters by hand. This one cannot — the SDK decides how
+// Filters and MaxResults serialize and how the tagSet decodes into []types.TagDescription,
+// so it is the only tier that shows a real client's shape agreeing with substrate's. Before
+// #688 every call below failed with InvalidAction, which the SDK surfaces as an API error
+// rather than an empty result: a consumer could not have written this loop at all.
+func TestJourney_EC2DescribeTags(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	ctx := context.Background()
+	client := ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+
+	// Two resources of different types, so resourceType has something to distinguish.
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-0abcdef1234567890"),
+		InstanceType: ec2types.InstanceTypeT3Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instanceID := aws.ToString(run.Instances[0].InstanceId)
+
+	vpc, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.42.0.0/16")})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	tag := func(id, key, value string) {
+		t.Helper()
+		if _, err := client.CreateTags(ctx, &ec2.CreateTagsInput{
+			Resources: []string{id},
+			Tags:      []ec2types.Tag{{Key: aws.String(key), Value: aws.String(value)}},
+		}); err != nil {
+			t.Fatalf("CreateTags %s %s: %v", id, key, err)
+		}
+	}
+	tag(instanceID, "Name", "webserver")
+	tag(instanceID, "Env", "prod")
+	tag(vpcID, "Env", "staging")
+
+	// --- the whole region, through the paginator ---
+	//
+	// MaxResults 5 with three tags is one page; the point is that the SDK's own loop
+	// terminates, which it does only because the last page carries no NextToken.
+	var described []ec2types.TagDescription
+	pages := ec2.NewDescribeTagsPaginator(client, &ec2.DescribeTagsInput{MaxResults: aws.Int32(5)})
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("DescribeTags page: %v", err)
+		}
+		described = append(described, page.Tags...)
+	}
+	if len(described) != 3 {
+		t.Fatalf("DescribeTags returned %d tags, want 3: %+v", len(described), described)
+	}
+
+	got := make([]string, 0, len(described))
+	for _, d := range described {
+		got = append(got, aws.ToString(d.ResourceId)+" "+string(d.ResourceType)+" "+
+			aws.ToString(d.Key)+"="+aws.ToString(d.Value))
+	}
+	sort.Strings(got)
+	want := []string{
+		instanceID + " instance Env=prod",
+		instanceID + " instance Name=webserver",
+		vpcID + " vpc Env=staging",
+	}
+	sort.Strings(want)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("tag %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// ResourceType decodes into the SDK's own enum, so a spelling substrate invented
+	// would arrive as an unknown value rather than failing loudly. Assert against the
+	// enum constants to catch that.
+	for _, d := range described {
+		switch d.ResourceType {
+		case ec2types.ResourceTypeInstance, ec2types.ResourceTypeVpc:
+		default:
+			t.Fatalf("resourceType %q is not one of the SDK's own values", d.ResourceType)
+		}
+	}
+
+	// --- a filter the SDK serializes, and a wildcard AWS documents for this operation ---
+	byValue, err := client.DescribeTags(ctx, &ec2.DescribeTagsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("value"), Values: []string{"?ebserver"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeTags filtered: %v", err)
+	}
+	if len(byValue.Tags) != 1 || aws.ToString(byValue.Tags[0].Key) != "Name" {
+		t.Fatalf("value=?ebserver returned %+v, want the one Name tag", byValue.Tags)
+	}
+
+	// Two filters AND, so a combination no single tag satisfies is an empty answer and
+	// not the union — the shape a consumer's "is this resource tagged X" check turns on.
+	none, err := client.DescribeTags(ctx, &ec2.DescribeTagsInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("resource-id"), Values: []string{vpcID}},
+			{Name: aws.String("value"), Values: []string{"prod"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DescribeTags ANDed: %v", err)
+	}
+	if len(none.Tags) != 0 {
+		t.Fatalf("two ANDed filters returned %+v, want none", none.Tags)
+	}
+}


### PR DESCRIPTION
Closes #688.

`DescribeTags` — the EC2 operation whose whole job is finding resources by tag — reached the
dispatcher's `default:` arm and answered `InvalidAction` / HTTP 400, while **four bundled
managed policies granted `ec2:DescribeTags`**: `AmazonVPCFullAccess` and
`AmazonVPCReadOnlyAccess` name it outright (`emulator/iam_managed.go:785`, `:878`), and
`AmazonEC2FullAccess` and `AmazonEC2ReadOnlyAccess` reach it through `ec2:*` and
`ec2:Describe*`. A policy permitted an operation nothing served.

Real EC2 offers three routes to a resource's tags: this operation, a `tag:<key>` filter on
each describe, and Resource Groups Tagging. Substrate served the third in full and the second
on five operations (#685/#686/#687, earlier in this milestone). This is the first.

## What it does

New `emulator/ec2_describetags.go` plus one dispatch arm beside `CreateTags`/`DeleteTags`.

- **Response**: AWS's `TagDescription` — `resourceId`, `resourceType`, `key`, `value` — under
  `tagSet>item`, plus `nextToken,omitempty`. Its own struct rather than `ec2TagItem`, which
  carries no resource. **No `omitempty` on `value`**: AWS's Example 1 renders `<value/>` for a
  tag whose value is empty, and an SDK tells a present-but-empty element from an absent one.
- **Filters — exactly five**, all evaluated, none inert: `key`, `resource-id`,
  `resource-type`, `value`, `tag:<key>`. This is the only operation in the family with an
  empty `accepted` list.
- **No `tag-key`.** Alone in the describe family, this operation documents none — its `key`
  filter already matches a key whatever its value. So `tag-key` is **refused** here while it
  is accepted on every neighbour. That is AWS's set, not an omission, and it has a test and a
  comment saying so, because it reads like one.
- **Wildcards work in filter values**, matched through the existing `ec2FilterAccepts`.
  AWS's Example 4 states it outright for this operation: "You can use wildcards with filters,
  so you could specify the value as `?ebserver` to find tags with the key `webserver` or
  `Webserver`." This is the first site outside `DescribeInstanceTypeOfferings` to honour them
  (#697 is the rest).
- **Pagination**: `MaxResults` 5–1000 — AWS's range for *this* operation, where
  `DescribeLaunchTemplateVersions`' floor is 1, so the constant cannot be shared. A value
  outside the range is **refused**, not clamped. The token is `DescribeLaunchTemplateVersions`'
  wire shape: a decimal offset, `InvalidParameterValue` on a malformed one, an out-of-range
  offset clamped to an empty last page, and no token on the last page.
- **Deterministic order**: sorted by `(resourceId, resourceType, key)` before paging.

## Two decisions worth reading

**The scan is deliberately wider than what `CreateTags` can write.** `ec2TaggableResource`
covers nine prefixes; the scan reads thirteen, adding `image`, `snapshot`, `launch-template`
and `fleet` — types whose tags arrive through their own create call's `TagSpecification.N` and
cannot be set through `CreateTags` at all (#689 adds the snapshot arm, #695 the rest).
Reporting only the writable types would hide tags a caller had *successfully applied*.
`TestEC2_DescribeTags_ScanIsWiderThanCreateTags` pins both halves of the asymmetry together,
so #689 has a test to change rather than a surprise to find.

`placement-group` is the one type carrying a `Tags` field left out: nothing writes it, and its
records are keyed by group **name** where AWS's `TagDescription` reports an ID, so the shared
key-tail helper would report the wrong identifier. (This corrects the plan's own note, which
also listed `keypair` — `EC2KeyPair` has no `Tags` field at all.)

**The sort is stricter than AWS**, which says its order "might vary" and that applications
should not rely on it. `StateManager.List` promises no ordering either
(`emulator/types.go:123-124`), so an offset token over an unordered list could skip or repeat
a tag between pages, and two replays of one recorded request could answer differently. A
deterministic emulator cannot answer one request two ways.

One helper rather than thirteen: `ec2StatePrefix(namespace, accountID, region)` plus a
`{namespace, resourceType}` table, since every EC2 key is `<ns>:<account>/<region>/<id>`. The
`resourceType` spelling is written beside each namespace rather than derived — `sg` is
`security-group` and `nat` is `natgateway`, and neither could be computed.

## Fail-before

Recorded before the fix, by deleting the dispatch arm and `emulator/ec2_describetags.go` — i.e.
the pre-#688 tree — with the harness asserting the arm appeared exactly once, `go vet`ing the
result so a non-compiling tree would be BROKEN rather than a result, and restoring by file copy
with sha256 byte-identity printed for both files.

```
=== FAIL-BEFORE: pre-#688 tree (no dispatch arm, no implementation) ===
--- FAIL: TestEC2_DescribeTags_EmptyWhenNothingIsTagged
--- FAIL: TestEC2_DescribeTags_Pagination
--- FAIL: TestEC2_DescribeTags_ScanIsWiderThanCreateTags
--- FAIL: TestEC2_DescribeTags_FiltersAnd
--- FAIL: TestEC2_DescribeTags_FiltersNarrowTheAnswer          (12 subtests)
--- FAIL: TestEC2_DescribeTags_ReportsEveryStoredTag
--- FAIL: TestEC2_DescribeTags_RefusesUndocumentedFilterNames  (4 subtests)
--- FAIL: TestEC2_DescribeTags_RefusesBadPagination            (8 subtests)
=== 8 top-level, 24 leaf failures ===
RESTORE plugin: 5146a888… == 5146a888…
RESTORE impl:   d2c59e02… == d2c59e02…
```

Every one failed the same way: `InvalidAction` / `EC2Plugin: unknown action DescribeTags`,
HTTP 400 (`emulator/ec2_plugin.go:245-250`).

## Tests

Eight unit tests through HTTP, because the whole defect was on the wire, plus an **SDK
journey** (`test/e2e/journey_ec2_describetags_test.go`) — the only tier that shows a real
client's shape agreeing with substrate's, since the SDK decides how `Filters` serialize and
how `tagSet` decodes into `[]types.TagDescription`. It walks the region with
`ec2.NewDescribeTagsPaginator`, whose loop terminates only because the last page carries no
token, and asserts `ResourceType` against the SDK's own enum constants — a spelling substrate
invented would otherwise arrive as an unknown enum value rather than failing loudly.

## Docs

`docs/services.md` gains a `DescribeTags` row, a row in the per-operation evaluated/inert
table, and a **Finding a resource by tag** subsection carrying the wider-than-`CreateTags`
scan, the no-`tag-key` rule, and the stricter-than-AWS ordering with its reason. Three
existing statements are now reconciled rather than left standing:

- "Substrate serves the third in full, the first on five operations, and **does not implement
  `DescribeTags` at all**" → all three routes now served.
- The wildcard gap (#697) named only `DescribeInstanceTypeOfferings`; it is now the two
  operations whose reference pages state wildcards outright.
- The empty-value-list divergence (#696) named only `DescribeSecurityGroups`; `DescribeTags`
  routes through the same shared matcher, so it inherits the rule rather than choosing it —
  said so in both the docs and the code comment.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues),
`make test` (race, ok), `make coverage`, `make docs-reference docs-reference-check
docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...` and
`go test -C test/e2e ./...` all clean. `docs-versions` caught a pinned `v0.106.0` in the new
prose on the first pass; it now links the issue instead.
