### PR TITLE
feat(ec2): a snapshot has a real size, and a nonexistent one is refused (#689)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`CreateSnapshot`, and a snapshot with a real size** (#689). Substrate had no
+  `CreateSnapshot` at all — it answered `InvalidAction` / HTTP 400 — so the only snapshots it
+  held were the ones `CreateImage` mints for an AMI's root device, and every one of them
+  recorded `volumeSize` as **the literal `8`**. A consumer could neither create a snapshot of
+  a known size nor observe one, which made every size-dependent rule a comparison against a
+  constant: the `volume-size` filter #685 added in this release, and the block-device-mapping
+  rule that a size must not be smaller than its snapshot's, which v0.105.0 deferred *for
+  exactly this reason*.
+
+  `VolumeId` is required and checked against state — absent is `MissingParameter`, a
+  syntactically invalid ID is `InvalidVolumeID.Malformed`, one that names nothing is
+  `InvalidVolume.NotFound` — so a snapshot cannot exist for a volume that does not.
+  `volumeSize` and `encrypted` come from the source volume rather than from the request,
+  which is what AWS documents ("the size of the volume, in GiB"; "snapshots that are taken
+  from encrypted volumes are automatically encrypted"). `Description` and
+  `TagSpecification.N` are read, the tags through the same walk and the same tag rules as
+  every other tag-on-create and checked before anything is written.
+
+  `status` is **`completed` at once**, not the `pending` AWS's own sample response shows.
+  Substrate advances no snapshot asynchronously, so a caller's waiter succeeds on its first
+  poll rather than depending on wall-clock time. A *seedable* `pending → completed`
+  progression is the shape that would let a test exercise the waiting path and is a
+  follow-up. `progress` is not rendered, for the reason `DescribeSnapshots` renders none:
+  substrate stores none, and `status` already carries the whole of what a completed
+  snapshot's progress would say. `Location` and `OutpostArn` are not read — both are
+  documented as supported only for a Local Zone or an Outpost, neither of which substrate
+  models.
+
 - **`DescribeTags`** (#688) — the EC2 operation whose whole job is finding resources by tag,
   which reached the dispatcher's default arm and answered `InvalidAction` / HTTP 400 while
   four bundled managed policies *granted* `ec2:DescribeTags`: `AmazonVPCFullAccess` and
@@ -27,9 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   AWS's set, not an omission.
 
   **The scan is deliberately wider than what `CreateTags` can write.** `CreateTags` reaches
-  nine resource types; the scan reads thirteen, adding `image`, `snapshot`, `launch-template`
-  and `fleet` — types whose tags arrive through their own create call's `TagSpecification.N`
-  and cannot be set through `CreateTags` at all (#689 adds the snapshot arm, #695 the rest).
+  ten resource types; the scan reads thirteen, adding `image`, `launch-template` and `fleet` —
+  types whose tags arrive through their own create call's `TagSpecification.N` and cannot be
+  set through `CreateTags` at all (#695 is the remaining three; `snapshot` was a fourth until
+  #689 in this release gave `CreateTags` a `snap-` arm).
   Reporting only the writable types would hide tags a caller had successfully applied.
   `placement-group` is the one type with a `Tags` field left out: nothing writes it, and its
   records are keyed by group *name* where AWS's `TagDescription` reports an ID.
@@ -129,6 +158,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can be a single rule.
 
 ### Fixed
+- **A block device mapping naming a snapshot that does not exist is refused** (#689). It was
+  accepted and materialized an 8 GiB volume, so a launch real EC2 rejects succeeded here and
+  produced state a consumer then asserted against — the same class of defect #671 closed for
+  the six mapping rules it added. A malformed ID is `InvalidSnapshotID.Malformed` and one that
+  names nothing is `InvalidSnapshot.NotFound`, both documented codes, and the refusal leaves
+  no state behind because the check sits where #671 put the validator: after the launch
+  template merge, before the default-VPC branch.
+
+  **A size below the snapshot's is refused too**, with `InvalidBlockDeviceMapping` — the
+  refusal v0.105.0 deferred, now that there is a real size to compare against. The two carry
+  different codes on purpose: a snapshot substrate cannot find is a mistake about the *ID*,
+  which is what naming a snapshot from a previous run looks like, while a size below it is a
+  mistake about the *mapping*. AWS documents the rule verbatim on
+  `EbsBlockDevice.VolumeSize`: "You can specify a volume size that is equal to or larger than
+  the snapshot size."
+
+- **A mapping naming a snapshot and no size takes the snapshot's size** (#689), where it took
+  substrate's 8 GiB default. `EC2BlockDeviceMapping.VolumeSize`'s own field doc already stated
+  the correct rule, so the doc was ahead of the code, and AWS states it on the same member it
+  states the refusal on: "If you specify a snapshot, the default is the snapshot size."
+  `CreateVolume` had the identical gap independently — a restore from a 30 GiB snapshot
+  produced an 8 GiB volume there too, and one naming a snapshot no account holds succeeded
+  outright — and now applies both rules through the same comparison.
+
+- **`CreateImage`'s snapshot records the instance's root volume, and `DescribeImages` reads
+  it** (#689). `createImage` wrote `volumeSize: 8` as a literal, and `describeImages` rendered
+  a *second*, independent literal `8` for the same snapshot in its own `ebs` member — two
+  constants that agreed only for as long as neither knew a real size. Both now read the volume
+  record, so an AMI made from a 40 GiB root volume reports 40 GiB through `DescribeSnapshots`
+  *and* through `DescribeImages`, and the snapshot also records the source volume's ID, which
+  gives `DescribeSnapshots`' `volume-id` filter something to select on for the only snapshots
+  substrate could previously produce. An AMI whose snapshot was since deleted falls back to
+  the 8 GiB default rather than reporting `0`.
+
+- **`CreateTags` and `DeleteTags` reach a snapshot** (#689). A `snap-` ID had no arm in
+  `ec2TaggableResource`, so `CreateTags` on a snapshot answered `<return>true</return>` having
+  written nothing — the same silent no-op #670 fixed for `vol-`, and immediately relevant now
+  that `CreateSnapshot`'s `TagSpecification` gives a caller a snapshot of their own. Until this
+  release `DescribeTags` could report a snapshot's tags that `CreateTags` had no way to write.
+
 - **`DescribeSubnets` applies the filters a request sends** (#685). It parsed no `Filter.N`
   at all, so "the subnets of `vpc-x`" answered with every subnet in the region and the
   response carried nothing to say the filter had been ignored — the worst shape of this

--- a/docs/services.md
+++ b/docs/services.md
@@ -2653,6 +2653,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | AssociateRouteTable | |
 | DescribeRouteTables | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | DeleteRouteTable | [Explicit resource IDs](#explicit-resource-ids) |
+| CreateSnapshot | `VolumeId` is required and checked; `volumeSize` and `encrypted` come from the source volume, and `status` is `completed` at once — see [A snapshot has a real size](#a-snapshot-has-a-real-size) |
 | DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids); ten filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); `Owner.N` and `RestorableBy.N` — see [A snapshot filters on its own members](#a-snapshot-filters-on-its-own-members-and-scopes-by-account) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
@@ -2666,7 +2667,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS; [filter names are checked](#one-rule-for-an-unrecognized-filter-name), and it documents **no tag filter** |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances, [subject to termination protection](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
-| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); accepts a `vol-` ID like [any other taggable ID](#a-volume-carries-tags); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
+| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); accepts a `vol-` or `snap-` ID like [any other taggable ID](#a-volume-carries-tags); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
 | DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) and [over-long keys](#tag-key-and-value-length-limits); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
 | DescribeTags | Every tag in the region, across thirteen resource types. Five filters with **wildcards**, `MaxResults` 5–1000 and `NextToken`, and a deterministic order — see [Finding a resource by tag](#finding-a-resource-by-tag) |
 
@@ -3231,16 +3232,24 @@ substrate could parse was accepted and materialized, so a consumer whose IaC car
 an invalid mapping got a green test and a failure on real AWS — the same class of
 defect an empty `ImageId` used to have.
 
-Six refusals:
+Eight refusals:
 
 | Refused | Provenance |
 |---|---|
 | An `Ebs` structure naming neither `Ebs.VolumeSize` nor `Ebs.SnapshotId` | Documented verbatim on `EbsBlockDevice.VolumeSize`: "You must specify either a snapshot ID or a volume size." |
+| `Ebs.SnapshotId` naming a snapshot the account does not hold | `InvalidSnapshot.NotFound` (or `InvalidSnapshotID.Malformed` for the syntax) — both codes documented in EC2's client-error table |
+| `Ebs.VolumeSize` smaller than the named snapshot's | Documented verbatim on `EbsBlockDevice.VolumeSize`: "You can specify a volume size that is equal to or larger than the snapshot size." |
 | `Ebs.Throughput` on an explicitly named type that is not `gp3` | Documented verbatim: "This parameter is valid only for `gp3` volumes." |
 | `Ebs.Iops` on an explicitly named `standard`, `st1` or `sc1` | The sibling launch-template shape — substrate's reading, see below |
 | An unparseable numeric value for `Ebs.VolumeSize`, `Ebs.Iops` or `Ebs.Throughput` | Substrate's own |
 | Two mappings naming one `DeviceName` | Substrate's own — AWS documents no rule |
 | A `VirtualName` beside any `Ebs.*` member | Substrate's own — AWS documents no rule |
+
+The two snapshot refusals carry different codes on purpose. A snapshot substrate cannot
+find is an `InvalidSnapshot.NotFound` about the *ID* — which is what a caller naming a
+snapshot from another account or a previous run has done — while a size below the
+snapshot's is an `InvalidBlockDeviceMapping` about the *mapping*, like every other row
+above.
 
 The error code is documented — EC2's client-error table lists
 `InvalidBlockDeviceMapping` as "A block device mapping parameter is not valid. The
@@ -3272,10 +3281,11 @@ Three reading calls worth stating outright:
   explains what `Iops` means "for `gp2` volumes". AWS contradicts itself inside one
   member, so substrate refuses only the three types that appear in neither list and
   takes the permissive reading of `gp2`.
-- A `VolumeSize` smaller than the named snapshot's is **not** checked.
-  `EC2Snapshot.VolumeSize` is a constant at its single producer and substrate has no
-  `CreateSnapshot`, so the comparison would test that constant rather than the
-  caller's request.
+- A mapping naming a snapshot and **no size** takes the snapshot's size, which AWS
+  documents on the same member: "If you specify a snapshot, the default is the snapshot
+  size." It took substrate's 8 GiB default instead until #689, so a restore from a
+  30 GiB snapshot produced an 8 GiB volume. `CreateVolume` had the identical gap
+  independently and applies the same two rules through the same comparison.
 
 **A refusal writes nothing.** The validator runs after a launch template has been
 merged in — so a mapping that reaches a launch through a template is refused at
@@ -3857,11 +3867,19 @@ string, so substrate mirrors each pair exactly:
 | Internet gateway | `InvalidInternetGatewayID.NotFound` | `InvalidInternetGatewayId.Malformed` |
 | Route table | `InvalidRouteTableID.NotFound` | `InvalidRouteTableId.Malformed` |
 | Snapshot | `InvalidSnapshot.NotFound` | `InvalidSnapshotID.Malformed` |
+| Volume | `InvalidVolume.NotFound` | `InvalidVolumeID.Malformed` |
 | Elastic IP allocation | `InvalidAllocationID.NotFound` | — |
 | NAT gateway | `InvalidNatGatewayID.NotFound` | — |
 
 EC2 publishes no `Malformed` variant for allocation IDs or NAT gateway IDs; a
 malformed ID for those surfaces as the `NotFound` code.
+
+The volume row covers `CreateSnapshot`, which is where it arrived. Three older volume
+operations — `DeleteVolume`, `AttachVolume` and `DetachVolume` — raise the same
+`InvalidVolume.NotFound` code with a message they spell themselves ("The volume
+'vol-…' does not exist.", with a trailing period and no "ID"). They are left as they
+are deliberately: rewording a published message is a change a consumer matching on it
+would notice, for no gain. Unifying them is a follow-up.
 
 An ID is well formed when it has the resource's prefix followed by at least one
 lowercase hex digit. Length is deliberately not checked: substrate's generators
@@ -4181,6 +4199,45 @@ filtering it out is an empty HTTP 200 rather than `InvalidSnapshot.NotFound` —
 [Explicit resource IDs](#explicit-resource-ids) states, and the distinction between "not
 yet" and "never" that a consumer's wait loop turns on. `DescribeSubnets` follows it too.
 
+#### A snapshot has a real size
+
+Until [#689](https://github.com/scttfrdmn/substrate/issues/689) every snapshot in substrate
+reported `volumeSize` as the literal `8`,
+because `CreateImage` was the only thing that wrote one and it wrote the constant. So the
+`volume-size` filter above compared against a constant, the mapping rule "a size must not be
+smaller than its snapshot's" had nothing to test, and `DescribeImages` rendered a *second*,
+independent `8` for the same snapshot — two constants that agreed only for as long as neither
+knew a real size.
+
+`CreateSnapshot` closes it at the source:
+
+| Behaviour | Answer |
+|---|---|
+| `VolumeId` | Required, and checked against state. Absent is `MissingParameter`; a syntactically invalid ID is `InvalidVolumeID.Malformed`; one that names nothing is `InvalidVolume.NotFound` — so a snapshot cannot exist for a volume that does not |
+| `volumeSize` | The source volume's size, which is what AWS documents the member as: "the size of the volume, in GiB" |
+| `encrypted` | The source volume's. "Snapshots that are taken from encrypted volumes are automatically encrypted" |
+| `status` | `completed` at once, **not** the `pending` AWS's own sample response shows |
+| `progress` | Not rendered, for the same reason `DescribeSnapshots` renders none: substrate stores none, and `status` already says the whole of what a completed snapshot's progress would say |
+| `Description`, `TagSpecification.N` | Read; the tags go through the same walk and the same [tag rules](#reserved-tag-keys) as every other tag-on-create, checked before anything is written |
+| `Location`, `OutpostArn` | Not read. Both are documented as supported only for a Local Zone or an Outpost, neither of which substrate models, so honouring them would place the snapshot somewhere substrate cannot describe it from |
+
+`status` being `completed` immediately is the deliberate divergence. Substrate advances no
+snapshot asynchronously, so a caller's waiter succeeds on its first poll rather than
+depending on wall-clock time — which is the point of a deterministic emulator. A
+**seedable** `pending → completed` progression is the shape that would let a test exercise
+the waiting path, and it is a follow-up rather than something this operation should invent.
+
+`CreateImage`'s own snapshot now reads the instance's root volume too, recording both its
+size and its ID — so an AMI made from a 40 GiB root volume reports 40 GiB through
+`DescribeSnapshots` *and* through `DescribeImages`, which reads the snapshot record rather
+than rendering its own constant. An AMI whose snapshot was later deleted falls back to the
+8 GiB default rather than reporting `0`, since a caller sizing a volume off that member can
+act on the default.
+
+The rest of the `CreateSnapshot` family — `CreateSnapshots`, `CopySnapshot`,
+`ModifySnapshotAttribute`, `DescribeSnapshotAttribute` and `ResetSnapshotAttribute` — is
+still absent and answers `InvalidAction`.
+
 #### Finding a resource by tag
 
 `DescribeTags` — the operation whose whole job is this question — did not exist until
@@ -4196,11 +4253,12 @@ It reports every tag stored in the request's account and region. Every EC2 recor
 real EC2's scope for this operation.
 
 **The scan is deliberately wider than what `CreateTags` can write.** `CreateTags` reaches
-nine resource types; `DescribeTags` reads thirteen, adding `image`, `snapshot`,
-`launch-template` and `fleet` — types whose tags arrive through their own create call's
-`TagSpecification.N` and cannot be set through `CreateTags` at all
-([#689](https://github.com/scttfrdmn/substrate/issues/689) adds the snapshot arm;
-[#695](https://github.com/scttfrdmn/substrate/issues/695) the rest). Reporting only the
+ten resource types; `DescribeTags` reads thirteen, adding `image`, `launch-template` and
+`fleet` — types whose tags arrive through their own create call's `TagSpecification.N` and
+cannot be set through `CreateTags` at all
+([#695](https://github.com/scttfrdmn/substrate/issues/695) is the remaining three;
+`snapshot` was in this list until [#689](https://github.com/scttfrdmn/substrate/issues/689)
+gave `CreateTags` a `snap-` arm). Reporting only the
 writable types would hide tags a caller had successfully applied. `placement-group` is the one
 type carrying a `Tags` field that stays out: nothing writes it, and its records are keyed by
 group *name* where AWS's `TagDescription` reports an ID.

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -159,15 +159,26 @@ var ec2VolumeTypesWithoutIOPS = map[string]bool{"standard": true, "st1": true, "
 // substrate resolves an absent type to gp2, but on real EC2 it comes from the AMI's own
 // mapping, commonly gp3.
 //
-// Also deliberately absent: a VolumeSize smaller than the named snapshot's.
-// EC2Snapshot.VolumeSize is the literal 8 at its single producer and substrate has no
-// CreateSnapshot, so the comparison would test a constant rather than the caller's
-// request. That is a follow-up, together with InvalidSnapshot.NotFound.
+// # The snapshot rules
+//
+// Two of them, both added by #689 once a snapshot had a real size to compare against:
+// a SnapshotId that is malformed or names nothing is refused, and a VolumeSize smaller
+// than the named snapshot's is refused. v0.105.0 deferred the second for the reason
+// #689 removes — EC2Snapshot.VolumeSize was the literal 8 at its single producer, so
+// the comparison would have tested a constant rather than the caller's request.
+//
+// resolveSnapshot is how both reach state: a lookup rather than a [StateManager], so
+// this stays a pure function over its arguments and a unit test can supply three
+// snapshots without a state fixture. It is required, not optional — a nil-means-skip
+// escape would silently disable a refusal, which is the failure mode #689 exists to
+// close. [EC2Plugin.ec2SnapshotResolver] builds the production one.
 //
 // # Provenance
 //
-// Two rules are documented verbatim — the size-or-snapshot requirement on
-// EbsBlockDevice.VolumeSize and "This parameter is valid only for gp3 volumes" on
+// Four rules are documented verbatim — the size-or-snapshot requirement on
+// EbsBlockDevice.VolumeSize, "You can specify a volume size that is equal to or larger
+// than the snapshot size" on the same member, InvalidSnapshot.NotFound in the
+// client-error table, and "This parameter is valid only for gp3 volumes" on
 // Throughput. The Iops rule rests on the sibling launch-template shape; see
 // [ec2VolumeTypesWithoutIOPS]. Refusing a duplicate device name and a virtualName
 // beside an Ebs member rests on **substrate's own reading** — AWS documents no rule for
@@ -193,10 +204,13 @@ var ec2VolumeTypesWithoutIOPS = map[string]bool{"standard": true, "st1": true, "
 // valid", and its Errors section lists none — so a 400 there would be substrate's
 // invention. That an invalid block device mapping belongs in that warning is
 // substrate's reading; rendering the element is a follow-up.
-func ec2CheckBlockDeviceMappings(mappings []EC2BlockDeviceMapping) *AWSError {
+func ec2CheckBlockDeviceMappings(
+	mappings []EC2BlockDeviceMapping,
+	resolveSnapshot func(string) (EC2Snapshot, bool),
+) *AWSError {
 	seen := make(map[string]bool, len(mappings))
 	for _, bdm := range mappings {
-		if awsErr := ec2CheckBlockDeviceMapping(bdm); awsErr != nil {
+		if awsErr := ec2CheckBlockDeviceMapping(bdm, resolveSnapshot); awsErr != nil {
 			return awsErr
 		}
 		// Only a mapping that materializes a volume can collide: NoDevice suppresses
@@ -219,8 +233,15 @@ func ec2CheckBlockDeviceMappings(mappings []EC2BlockDeviceMapping) *AWSError {
 // The unparseable-number checks run first: a garbage size makes every judgement below
 // meaningless, and reporting the malformed value is more use to a caller than reporting
 // a consequence of it. The virtualName conflict runs before the size requirement, since
-// a mapping combining the two is wrong in a way that naming a size would not fix.
-func ec2CheckBlockDeviceMapping(bdm EC2BlockDeviceMapping) *AWSError {
+// a mapping combining the two is wrong in a way that naming a size would not fix. The
+// snapshot checks follow the size requirement, because a mapping that names neither a
+// size nor a snapshot has no snapshot to look up; they precede the type rules so that a
+// nonexistent snapshot is still reported for a mapping that names no volume type, which
+// is where the type rules return early.
+func ec2CheckBlockDeviceMapping(
+	bdm EC2BlockDeviceMapping,
+	resolveSnapshot func(string) (EC2Snapshot, bool),
+) *AWSError {
 	device := bdm.DeviceName
 	for _, num := range []struct{ member, raw string }{
 		{"Ebs.VolumeSize", bdm.VolumeSizeRaw},
@@ -255,6 +276,12 @@ func ec2CheckBlockDeviceMapping(bdm EC2BlockDeviceMapping) *AWSError {
 			"you must specify either a snapshot ID or a volume size")
 	}
 
+	if bdm.SnapshotID != "" {
+		if awsErr := ec2CheckMappingSnapshot(bdm, resolveSnapshot); awsErr != nil {
+			return awsErr
+		}
+	}
+
 	// Both type rules read the named type, never the resolved one; see
 	// [ec2CheckBlockDeviceMappings]. An absent type therefore refuses nothing.
 	volType := strings.ToLower(bdm.VolumeType)
@@ -270,6 +297,82 @@ func ec2CheckBlockDeviceMapping(bdm EC2BlockDeviceMapping) *AWSError {
 			"Ebs.Iops is not supported for "+bdm.VolumeType+" volumes")
 	}
 	return nil
+}
+
+// ec2CheckMappingSnapshot applies the two rules that concern the snapshot a mapping
+// names. The caller has already established that it names one.
+//
+// The two refusals carry different codes on purpose, because they are different
+// mistakes: a snapshot substrate cannot find is an InvalidSnapshot.NotFound (or
+// InvalidSnapshotID.Malformed) about the *ID*, which is what a caller naming a snapshot
+// from another account or a stale run has done, while a size below the snapshot's is an
+// InvalidBlockDeviceMapping about the *mapping*, which is what the rest of this
+// validator reports. Collapsing them into one code would tell a caller to look in the
+// wrong place.
+//
+// The size comparison reads the parsed VolumeSize and gates on it being positive, so a
+// mapping that names no size inherits the snapshot's rather than being refused for
+// naming 0 — see [ec2ResolveSnapshotSizes], which does the inheriting.
+func ec2CheckMappingSnapshot(
+	bdm EC2BlockDeviceMapping,
+	resolveSnapshot func(string) (EC2Snapshot, bool),
+) *AWSError {
+	if !ec2SnapshotIDKind.wellFormed(bdm.SnapshotID) {
+		return ec2SnapshotIDKind.malformedError(bdm.SnapshotID)
+	}
+	snap, found := resolveSnapshot(bdm.SnapshotID)
+	if !found {
+		return ec2SnapshotIDKind.notFoundError(bdm.SnapshotID)
+	}
+	if bdm.VolumeSize > 0 && int64(bdm.VolumeSize) < snap.VolumeSize {
+		return ec2InvalidBlockDeviceMapping(bdm.DeviceName, fmt.Sprintf(
+			"Ebs.VolumeSize %d is smaller than the size of snapshot %s (%d GiB)",
+			bdm.VolumeSize, snap.SnapshotID, snap.VolumeSize))
+	}
+	return nil
+}
+
+// ec2ResolveSnapshotSizes returns mappings with every absent VolumeSize filled in from
+// the snapshot that mapping names, leaving everything else untouched.
+//
+// Without it a mapping naming a snapshot and no size fell through to
+// [ec2DefaultVolumeSizeGiB], so a 30 GiB snapshot produced an 8 GiB volume —
+// [EC2BlockDeviceMapping.VolumeSize]'s own field doc already stated the correct rule, so
+// the doc was ahead of the code (#689). AWS states it too, on EbsBlockDevice.VolumeSize:
+// "If you specify a snapshot, the default is the snapshot size."
+//
+// It is a separate pass over the mappings rather than a lookup inside
+// [ec2VolumeFromMapping] so that function stays pure — it is what
+// [ec2LaunchVolumesFor] is built out of, and threading state through it would put a
+// state read inside the volume-building loop. The returned slice is fresh, so a caller's
+// parsed mappings keep reporting what the request actually said, which is what the
+// launch template merge and the recorded-intent members read.
+//
+// VolumeSizeRaw is the test for absence rather than a zero VolumeSize, for the reason it
+// exists at all: "Ebs.VolumeSize=0" is a value a caller supplied, and an unparseable one
+// has already been refused by [ec2CheckBlockDeviceMapping].
+//
+// A snapshot that does not resolve is left alone rather than defaulted, because
+// [ec2CheckMappingSnapshot] has already refused it — this pass runs after validation and
+// never decides anything a caller can observe as an error.
+func ec2ResolveSnapshotSizes(
+	mappings []EC2BlockDeviceMapping,
+	resolveSnapshot func(string) (EC2Snapshot, bool),
+) []EC2BlockDeviceMapping {
+	if len(mappings) == 0 {
+		return mappings
+	}
+	out := make([]EC2BlockDeviceMapping, len(mappings))
+	copy(out, mappings)
+	for i := range out {
+		if out[i].SnapshotID == "" || out[i].VolumeSizeRaw != "" {
+			continue
+		}
+		if snap, found := resolveSnapshot(out[i].SnapshotID); found && snap.VolumeSize > 0 {
+			out[i].VolumeSize = int(snap.VolumeSize)
+		}
+	}
+	return out
 }
 
 // ec2InvalidBlockDeviceMapping returns EC2's InvalidBlockDeviceMapping error, naming

--- a/emulator/ec2_block_devices_validation_test.go
+++ b/emulator/ec2_block_devices_validation_test.go
@@ -150,6 +150,11 @@ func TestEC2_BlockDeviceMapping_ValidIsAccepted(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		params map[string]string
+		// snapshotGiB, when set, creates a snapshot of that size first and puts its ID in
+		// BlockDeviceMapping.1.Ebs.SnapshotId. Before #689 a row could name any
+		// well-formed snap- ID and be accepted; now the ID must resolve, so a row about
+		// snapshots has to have one.
+		snapshotGiB int
 	}{
 		{
 			// AWS's sentence is on EbsBlockDevice.VolumeSize, a member of the Ebs
@@ -159,11 +164,21 @@ func TestEC2_BlockDeviceMapping_ValidIsAccepted(t *testing.T) {
 			params: map[string]string{"BlockDeviceMapping.1.DeviceName": "/dev/sdf"},
 		},
 		{
-			name: "a snapshot with no size",
+			// A snapshot and no size is legal and inherits the snapshot's; see
+			// TestEC2_BlockDeviceMapping_InheritsTheSnapshotSize for the value.
+			name:        "a snapshot with no size",
+			params:      map[string]string{"BlockDeviceMapping.1.DeviceName": "/dev/sdf"},
+			snapshotGiB: 30,
+		},
+		{
+			// The size rule is "equal to or larger", so equal is accepted — the boundary
+			// the refusal table's own row stops one below.
+			name: "a size equal to the snapshot's",
 			params: map[string]string{
 				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
-				"BlockDeviceMapping.1.Ebs.SnapshotId": "snap-0123456789abcdef0",
+				"BlockDeviceMapping.1.Ebs.VolumeSize": "30",
 			},
+			snapshotGiB: 30,
 		},
 		{
 			// Iops and Throughput with no VolumeType. Substrate resolves an absent
@@ -235,6 +250,10 @@ func TestEC2_BlockDeviceMapping_ValidIsAccepted(t *testing.T) {
 			}
 			for k, v := range tc.params {
 				params[k] = v
+			}
+			if tc.snapshotGiB > 0 {
+				_, snapID := ec2SnapshotOfSize(t, ts, tc.snapshotGiB)
+				params["BlockDeviceMapping.1.Ebs.SnapshotId"] = snapID
 			}
 			resp := ec2Request(t, ts, params)
 			body, err := io.ReadAll(resp.Body)

--- a/emulator/ec2_describetags_test.go
+++ b/emulator/ec2_describetags_test.go
@@ -309,14 +309,20 @@ func TestEC2_DescribeTags_RefusesBadPagination(t *testing.T) {
 	}
 }
 
-// TestEC2_DescribeTags_ScanIsWiderThanCreateTags pins the asymmetry deliberately: a
-// snapshot's tags are reported even though CreateTags cannot write them.
+// TestEC2_DescribeTags_ScanIsWiderThanCreateTags pins the asymmetry deliberately: a tag
+// applied by something other than CreateTags is still reported.
 //
-// ec2TaggableResource covers nine prefixes, and a snap- ID is not one of them (#689 adds the
-// arm) — but CreateImage's TagSpecification writes a snapshot's tags anyway, so a
-// DescribeTags that reported only the CreateTags-writable types would hide tags a caller had
-// successfully applied. Reporting every tag substrate stores, however it was applied, is the
-// operation's job.
+// ec2TaggableResource covers the prefixes CreateTags can write, and several types store tags
+// without being among them — image, launch-template, fleet — but their TagSpecification
+// writes those tags anyway, so a DescribeTags that reported only the CreateTags-writable
+// types would hide tags a caller had successfully applied. Reporting every tag substrate
+// stores, however it was applied, is the operation's job.
+//
+// Snapshots were the example this test was written against, and #689 closed that half: a
+// snap- arm now exists, so the tag CreateTags writes below is reported too. The
+// CreateImage-applied tag being reported is the assertion that survives, and it is the one
+// the asymmetry is actually about — see TestEC2_CreateTags_TagsASnapshot for the writable
+// half.
 func TestEC2_DescribeTags_ScanIsWiderThanCreateTags(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
@@ -326,17 +332,18 @@ func TestEC2_DescribeTags_ScanIsWiderThanCreateTags(t *testing.T) {
 		ec2TagKeysFor(t, ts, ec2Filter("resource-type", "snapshot")),
 		"a snapshot tagged through CreateImage's TagSpecification is still reported")
 
-	// And CreateTags on that same snapshot still writes nothing, so the two halves of the
-	// asymmetry are pinned together and #689 has a test to change.
+	// Since #689 CreateTags reaches a snapshot too, so both routes onto the same record
+	// land in the same tagSet rather than one of them writing nothing.
 	ec2FleetXML(t, ts, map[string]string{
 		"Action":       "CreateTags",
 		"ResourceId.1": snaps["alpha"],
 		"Tag.1.Key":    "Added",
 		"Tag.1.Value":  "later",
 	}, nil)
-	assert.NotContains(t, ec2TagKeysFor(t, ts, ec2Filter("resource-type", "snapshot")),
-		snaps["alpha"]+"/Added=later",
-		"CreateTags has no snap- arm yet, so it silently writes nothing — #689")
+	assert.ElementsMatch(t,
+		[]string{snaps["alpha"] + "/Scope=alpha", snaps["alpha"] + "/Added=later"},
+		ec2TagKeysFor(t, ts, ec2Filter("resource-type", "snapshot")),
+		"a CreateTags-applied tag joins the CreateImage-applied one")
 }
 
 // TestEC2_DescribeTags_EmptyWhenNothingIsTagged pins that an account with no tags answers an

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -238,6 +238,8 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.attachVolume(ctx, req)
 	case "DetachVolume":
 		return p.detachVolume(ctx, req)
+	case "CreateSnapshot":
+		return p.createSnapshot(ctx, req)
 	case "DeleteSnapshot":
 		return p.deleteSnapshot(ctx, req)
 	case "DescribeSnapshots":
@@ -533,9 +535,15 @@ func (p *EC2Plugin) runInstancesWithTags(
 	// VPC, subnet, security group, internet gateway, route table and four index
 	// mutations: a refusal past that point leaves state behind, which is worse than no
 	// validation at all because the next request in the same test sees it.
-	if awsErr := ec2CheckBlockDeviceMappings(blockDeviceMappings); awsErr != nil {
+	resolveSnapshot := p.ec2SnapshotResolver(reqCtx)
+	if awsErr := ec2CheckBlockDeviceMappings(blockDeviceMappings, resolveSnapshot); awsErr != nil {
 		return nil, awsErr
 	}
+
+	// A mapping that names a snapshot and no size takes the snapshot's, which the
+	// validation above has just established exists. It happens here rather than inside
+	// ec2VolumeFromMapping so that function stays pure; see [ec2ResolveSnapshotSizes].
+	blockDeviceMappings = ec2ResolveSnapshotSizes(blockDeviceMappings, resolveSnapshot)
 
 	// The volume tags are checked here for the same ordering reason, and it is not the
 	// same as the instance tags' position: a volume is written inside the launch loop
@@ -2549,6 +2557,13 @@ func ec2TaggableResource(reqCtx *RequestContext, id string) (stateKey, arnType s
 		// [EC2Plugin.applyTagsToResource] is type-agnostic — it reads and writes the
 		// record's "tags" JSON member — and [EC2Volume.Tags] already serializes there.
 		return ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, id), "volume", true
+	case strings.HasPrefix(id, "snap-"):
+		// Snapshots had the same silent no-op vol- did, and #689 made it reachable: a
+		// caller can now create a snapshot of their own, so tagging one after the fact is
+		// something they will do. DescribeTags already reported a snapshot's tags before
+		// this arm existed (#688) — its scan reads state directly — so until now
+		// DescribeTags could see tags CreateTags had no way to write.
+		return ec2SnapshotStateKey(reqCtx.AccountID, reqCtx.Region, id), "snapshot", true
 	default:
 		return "", "", false
 	}
@@ -3452,10 +3467,19 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 	// Materialize a backing EBS snapshot for the AMI's root device, so that
 	// DescribeSnapshots and the block-device-mapping.snapshot-id filter on
 	// DescribeImages can model snapshot-retention logic (#322).
+	//
+	// The size and the source volume are read from the instance's own root volume rather
+	// than being the literal 8 this recorded through v0.105.0; see
+	// [EC2Plugin.ec2InstanceRootVolume] for what that constant cost a caller (#689).
+	rootVolumeID, rootVolumeSize, err := p.ec2InstanceRootVolume(reqCtx, instanceID)
+	if err != nil {
+		return nil, err
+	}
 	snapshotID := generateEBSSnapshotID()
 	snap := EC2Snapshot{
 		SnapshotID:  snapshotID,
-		VolumeSize:  8,
+		VolumeID:    rootVolumeID,
+		VolumeSize:  rootVolumeSize,
 		State:       "completed",
 		StartTime:   p.tc.Now().UTC().Format(time.RFC3339),
 		Description: "Created by CreateImage for " + name,
@@ -3597,6 +3621,14 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 		Images  []imageItem `xml:"imagesSet>item"`
 	}
 
+	// The mapping's volumeSize is read from the backing snapshot rather than rendered as
+	// the literal 8 this used through v0.105.0. That constant was a second, independent
+	// copy of createImage's — so the two agreed only for as long as neither knew a real
+	// size, and #689 gave createImage one. Reading the snapshot means there is one source
+	// of truth for an AMI's root volume size, and DescribeImages and DescribeSnapshots
+	// cannot disagree about the same snapshot.
+	resolveSnapshot := p.ec2SnapshotResolver(reqCtx)
+
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 	for _, k := range allKeys {
 		data, getErr := p.state.Get(context.Background(), ec2Namespace, k)
@@ -3623,9 +3655,16 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 			CreationDate: img.CreationDate,
 		}
 		if img.SnapshotID != "" {
+			// An AMI whose snapshot record is gone — DeleteSnapshot removes it and leaves
+			// the AMI standing — falls back to the default rather than reporting 0, which
+			// is what a caller sizing a volume off this member can act on.
+			size := int64(ec2DefaultVolumeSizeGiB)
+			if snap, found := resolveSnapshot(img.SnapshotID); found && snap.VolumeSize > 0 {
+				size = snap.VolumeSize
+			}
 			item.BlockDeviceMappings = []blockDeviceItem{{
 				DeviceName: "/dev/sda1",
-				EBS:        ebsBlockDevice{SnapshotID: img.SnapshotID, VolumeSize: 8},
+				EBS:        ebsBlockDevice{SnapshotID: img.SnapshotID, VolumeSize: size},
 			}}
 		}
 		item.Tags = ec2TagItems(img.Tags)
@@ -4974,7 +5013,7 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		az = reqCtx.Region + "a"
 	}
 	sizeStr := req.Params["Size"]
-	size := 8
+	size := ec2DefaultVolumeSizeGiB
 	if sizeStr != "" {
 		if n, err := strconv.Atoi(sizeStr); err == nil && n > 0 {
 			size = n
@@ -4984,7 +5023,37 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if volType == "" {
 		volType = "gp2"
 	}
+
+	// A named snapshot is checked and its size honored, the same two rules the launch
+	// path applies through [ec2CheckMappingSnapshot] — CreateVolume had an independent
+	// copy of the gap, so a restore from a 30 GiB snapshot produced an 8 GiB volume here
+	// too, and one naming a snapshot no account holds succeeded outright (#689). Both
+	// AWS sentences are on CreateVolume's own Size member: "If you specify a snapshot,
+	// the default is the snapshot size" and "You can specify a volume size that is equal
+	// to or larger than the snapshot size."
+	//
+	// A request naming neither Size nor SnapshotId still gets the 8 GiB default rather
+	// than the refusal AWS documents ("Size is required unless SnapshotId is specified").
+	// That is a wider change than this one and a follow-up.
 	snapshotID := req.Params["SnapshotId"]
+	if snapshotID != "" {
+		snap, found := p.ec2SnapshotResolver(reqCtx)(snapshotID)
+		if awsErr := ec2RequireResource(ec2SnapshotIDKind, snapshotID, found); awsErr != nil {
+			return nil, awsErr
+		}
+		switch {
+		case sizeStr == "":
+			size = int(snap.VolumeSize)
+		case int64(size) < snap.VolumeSize:
+			return nil, &AWSError{
+				Code: "InvalidParameterValue",
+				Message: fmt.Sprintf(
+					"Size %d is smaller than the size of snapshot %s (%d GiB)",
+					size, snapshotID, snap.VolumeSize),
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+	}
 	encrypted := strings.ToLower(req.Params["Encrypted"]) == "true"
 	// Recorded as given, with the same tolerance Size above has: a value that does not
 	// parse leaves the field at zero and the field is then omitted from the response,
@@ -5379,7 +5448,7 @@ func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (
 	restorableBy := newEC2SnapshotRestorableBy(req.Params, reqCtx.AccountID)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace,
-		"snapshot:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+		ec2SnapshotStatePrefix(reqCtx.AccountID, reqCtx.Region))
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeSnapshots list: %w", err)
 	}

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -3513,6 +3513,10 @@ func TestEC2_CreateImage_SnapshotsAndFilter(t *testing.T) {
 	require.Contains(t, snaps, snapA)
 	require.Contains(t, snaps, snapB)
 	assert.Equal(t, "completed", snaps[snapA].State)
+	// 8 GiB is the launch's own root volume size, read from the volume record since #689
+	// rather than being the literal createImage used to write. The value is the same, so
+	// this assertion is unchanged — it now holds for the right reason, and
+	// TestEC2_CreateImage_SnapshotSizeIsTheRootVolume is where a non-default size proves it.
 	assert.Equal(t, int64(8), snaps[snapA].Size)
 
 	// DescribeImages filtered by snapshot-id finds only the owning AMI.

--- a/emulator/ec2_resourceid.go
+++ b/emulator/ec2_resourceid.go
@@ -59,6 +59,16 @@ var (
 		Prefix: "snap-", NotFound: "InvalidSnapshot.NotFound",
 		Malformed: "InvalidSnapshotID.Malformed", Noun: "snapshot",
 	}
+	// The three volume operations that predate this kind — DeleteVolume, AttachVolume
+	// and DetachVolume — spell the NotFound message themselves, as "The volume 'vol-…'
+	// does not exist." with a trailing period and no "ID". They are left alone: this
+	// kind is for CreateSnapshot and CreateVolume, which had no volume check at all
+	// (#689), and rewording three published messages is a change a consumer matching on
+	// them would notice for no gain. Unifying them is a follow-up.
+	ec2VolumeIDKind = ec2IDKind{
+		Prefix: "vol-", NotFound: "InvalidVolume.NotFound",
+		Malformed: "InvalidVolumeID.Malformed", Noun: "volume",
+	}
 	// EC2 publishes no InvalidAllocationID.Malformed; a malformed allocation ID
 	// comes back as InvalidAllocationID.NotFound.
 	ec2AllocationIDKind = ec2IDKind{

--- a/emulator/ec2_snapshot_filters_test.go
+++ b/emulator/ec2_snapshot_filters_test.go
@@ -65,9 +65,11 @@ func ec2Filter(name string, values ...string) map[string]string {
 // EBS snapshot, tagged Scope=<name> and described "Created by CreateImage for <name>" — and
 // returns the snapshot IDs keyed by name.
 //
-// CreateImage is the only path that writes a snapshot record today; CreateSnapshot is #689.
-// The snapshots it mints therefore carry no source volume, which is why volume-id below is
-// asserted to match nothing rather than to select one.
+// Both snapshots come from one instance's root volume, so both report that volume's ID and
+// its 8 GiB size — since #689 those are read from the volume record rather than being the
+// literal 8 CreateImage used to write. The volume-id and volume-size rows below therefore
+// select on a real value; TestEC2_CreateSnapshot_ReportsTheSourceVolume is where a size
+// other than the default is asserted, so neither passes by coinciding with a constant.
 func ec2SeedTaggedSnapshots(t *testing.T, ts *httptest.Server, names ...string) map[string]string {
 	t.Helper()
 	instID := ec2TagTestInstance(t, ts)
@@ -110,6 +112,8 @@ func TestEC2_DescribeSnapshots_EvaluatedFiltersNarrowTheAnswer(t *testing.T) {
 	require.Len(t, all, 2)
 	owner := all[0].OwnerID
 	require.NotEmpty(t, owner, "ownerId is what the owner-id filter compares against")
+	require.NotEmpty(t, all[0].VolumeID,
+		"since #689 a CreateImage snapshot records the root volume it was taken from")
 
 	tests := []struct {
 		name   string
@@ -135,8 +139,9 @@ func TestEC2_DescribeSnapshots_EvaluatedFiltersNarrowTheAnswer(t *testing.T) {
 		{"tag key absent", ec2Filter("tag:Absent", "alpha"), nil},
 		{"volume-size matches", ec2Filter("volume-size", "8"), []string{alpha, beta}},
 		{"volume-size miss", ec2Filter("volume-size", "100"), nil},
-		{"volume-id matches nothing without a source volume",
-			ec2Filter("volume-id", "vol-0123456789abcdef0"), nil},
+		{"volume-id selects the shared source volume",
+			ec2Filter("volume-id", all[0].VolumeID), []string{alpha, beta}},
+		{"volume-id another volume", ec2Filter("volume-id", "vol-0123456789abcdef0"), nil},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/emulator/ec2_snapshots.go
+++ b/emulator/ec2_snapshots.go
@@ -1,0 +1,213 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// ec2SnapshotResolver returns a lookup from snapshot ID to the stored snapshot, for the
+// account and region of one request.
+//
+// It exists so the block-device-mapping validator can check a snapshot's existence and
+// size while staying a pure function over its mappings: it takes this lookup rather than
+// a [StateManager], which keeps it unit-testable with no state fixture and lets a caller
+// that has already resolved the snapshots supply them directly.
+//
+// A read error reports the snapshot as absent rather than propagating, matching
+// [EC2Plugin.ec2CheckSecurityGroups] and [EC2Plugin.resourceTags]: substrate's state
+// backends fail only for reasons a caller cannot act on, and reporting "not found" for an
+// unreadable record is the same answer a caller gets for one that was never written.
+func (p *EC2Plugin) ec2SnapshotResolver(reqCtx *RequestContext) func(string) (EC2Snapshot, bool) {
+	return func(snapshotID string) (EC2Snapshot, bool) {
+		if snapshotID == "" {
+			return EC2Snapshot{}, false
+		}
+		key := ec2SnapshotStateKey(reqCtx.AccountID, reqCtx.Region, snapshotID)
+		data, err := p.state.Get(context.Background(), ec2Namespace, key)
+		if err != nil || data == nil {
+			return EC2Snapshot{}, false
+		}
+		var snap EC2Snapshot
+		if json.Unmarshal(data, &snap) != nil {
+			return EC2Snapshot{}, false
+		}
+		return snap, true
+	}
+}
+
+// createSnapshot creates an EBS snapshot of a volume the account holds.
+//
+// Before #689 substrate had no CreateSnapshot at all: the only snapshots it held were the
+// ones CreateImage mints for an AMI's root device, every one of them recording
+// [EC2Snapshot.VolumeSize] as the literal 8. So a consumer could neither create a
+// snapshot of a known size nor observe one, which made every size-dependent rule — the
+// filter on volume-size, the mapping whose size must not be smaller than its snapshot's —
+// a comparison against a constant.
+//
+// # What is read
+//
+// VolumeId is the one required parameter and is checked against state, so a snapshot
+// cannot exist for a volume that does not. Description and TagSpecification.N are read;
+// the tags come through [ec2LaunchTagsForResource] scoped to "snapshot", the same walk
+// CreateImage already uses for the snapshots it mints, and they are checked before
+// anything is written, per the rollback rule in [ec2CheckReservedTagKeys].
+//
+// VolumeSize and Encrypted come from the source volume rather than from the request,
+// which is what AWS documents: volumeSize is "the size of the volume, in GiB", and
+// "snapshots that are taken from encrypted volumes are automatically encrypted".
+//
+// Location and OutpostArn are not read. Both are documented as supported only for volumes
+// in a Local Zone or on an Outpost, neither of which substrate models, so honoring them
+// would place the snapshot somewhere substrate cannot describe it from.
+//
+// # The state it reports
+//
+// status is "completed" immediately, not the "pending" AWS's own sample response shows.
+// Substrate advances no snapshot asynchronously — CreateImage's snapshots have always
+// been born completed — so a caller's waiter succeeds on its first poll rather than
+// depending on wall-clock time. A seedable pending → completed progression is the shape
+// that would let a test exercise the waiting path, and it is a follow-up rather than
+// something this operation should invent.
+//
+// progress is not rendered, for the reason describeSnapshots does not render it either:
+// substrate stores none, and status already carries the whole of what a completed
+// snapshot's progress would say.
+func (p *EC2Plugin) createSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	volumeID := req.Params["VolumeId"]
+	if volumeID == "" {
+		return nil, ec2MissingParameter("VolumeId")
+	}
+
+	vol, found, err := p.ec2Volume(reqCtx, volumeID)
+	if err != nil {
+		return nil, err
+	}
+	if awsErr := ec2RequireResource(ec2VolumeIDKind, volumeID, found); awsErr != nil {
+		return nil, awsErr
+	}
+
+	tags := ec2LaunchTagsForResource(req.Params, "snapshot")
+	if awsErr := ec2CheckTagRules(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, tags); awsErr != nil {
+		return nil, awsErr
+	}
+
+	snap := EC2Snapshot{
+		SnapshotID:  generateEBSSnapshotID(),
+		VolumeID:    vol.VolumeID,
+		VolumeSize:  int64(vol.Size),
+		State:       "completed",
+		StartTime:   p.tc.Now().UTC().Format(time.RFC3339),
+		Encrypted:   vol.Encrypted,
+		Description: req.Params["Description"],
+		Tags:        tags,
+		AccountID:   reqCtx.AccountID,
+		Region:      reqCtx.Region,
+	}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 createSnapshot marshal: %w", err)
+	}
+	key := ec2SnapshotStateKey(reqCtx.AccountID, reqCtx.Region, snap.SnapshotID)
+	if err := p.state.Put(context.Background(), ec2Namespace, key, data); err != nil {
+		return nil, fmt.Errorf("ec2 createSnapshot state.Put: %w", err)
+	}
+
+	// Member order follows AWS's own sample response — snapshotId, volumeId, status,
+	// startTime, ownerId, volumeSize, description — with the two documented elements it
+	// does not show appended. tagSet carries no omitempty for the reason CreateVolume's
+	// does not: an SDK maps a present-but-empty element to an empty slice where it maps an
+	// omitted one to nil, so omitting it would report "unknown" where AWS reports "none".
+	type response struct {
+		XMLName     xml.Name     `xml:"CreateSnapshotResponse"`
+		XMLNS       string       `xml:"xmlns,attr"`
+		SnapshotID  string       `xml:"snapshotId"`
+		VolumeID    string       `xml:"volumeId"`
+		Status      string       `xml:"status"`
+		StartTime   string       `xml:"startTime"`
+		OwnerID     string       `xml:"ownerId"`
+		VolumeSize  int64        `xml:"volumeSize"`
+		Description string       `xml:"description,omitempty"`
+		Encrypted   bool         `xml:"encrypted"`
+		Tags        []ec2TagItem `xml:"tagSet>item"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:       "http://ec2.amazonaws.com/doc/2016-11-15/",
+		SnapshotID:  snap.SnapshotID,
+		VolumeID:    snap.VolumeID,
+		Status:      snap.State,
+		StartTime:   snap.StartTime,
+		OwnerID:     snap.AccountID,
+		VolumeSize:  snap.VolumeSize,
+		Description: snap.Description,
+		Encrypted:   snap.Encrypted,
+		Tags:        ec2TagItems(snap.Tags),
+	})
+}
+
+// ec2Volume loads one volume by ID, reporting whether it exists.
+//
+// A read error is returned rather than swallowed, unlike [EC2Plugin.ec2SnapshotResolver]'s
+// treatment of the same failure: this is the source of a snapshot a caller asked for by
+// ID, so answering "no such volume" for a volume that is there would report a state
+// failure as the caller's mistake.
+func (p *EC2Plugin) ec2Volume(reqCtx *RequestContext, volumeID string) (EC2Volume, bool, error) {
+	key := ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, volumeID)
+	data, err := p.state.Get(context.Background(), ec2Namespace, key)
+	if err != nil {
+		return EC2Volume{}, false, fmt.Errorf("ec2 volume get %s: %w", volumeID, err)
+	}
+	if data == nil {
+		return EC2Volume{}, false, nil
+	}
+	var vol EC2Volume
+	if err := json.Unmarshal(data, &vol); err != nil {
+		return EC2Volume{}, false, fmt.Errorf("ec2 volume unmarshal %s: %w", volumeID, err)
+	}
+	return vol, true, nil
+}
+
+// ec2InstanceRootVolume is the ID and size in GiB of the volume attached to instanceID at
+// a root device name. It reports an empty ID and [ec2DefaultVolumeSizeGiB] when the
+// instance has no root volume in state.
+//
+// CreateImage needs both, because the snapshot it mints backs the AMI's root device: its
+// size was the literal 8 through v0.105.0 — so an AMI made from an instance whose root
+// volume was 40 GiB reported 8, and a consumer restoring from that AMI sized their volume
+// off a constant — and it recorded no source volume at all, which left the volume-id
+// filter #685 added with nothing to select on for the only snapshots substrate could
+// produce.
+//
+// The fallback is not defensive padding: an instance written straight into state by a test
+// has no volumes at all, and every launch since #666 materializes a root volume, so the
+// fallback is reached only where there is nothing better to read. It is the same constant
+// DescribeImages fabricates a mapping for, so the two still agree in that case.
+func (p *EC2Plugin) ec2InstanceRootVolume(reqCtx *RequestContext, instanceID string) (volumeID string, sizeGiB int64, err error) {
+	ctx := context.Background()
+	keys, err := p.state.List(ctx, ec2Namespace, ec2VolumeStatePrefix(reqCtx.AccountID, reqCtx.Region))
+	if err != nil {
+		return "", 0, fmt.Errorf("ec2 root volume list: %w", err)
+	}
+	for _, key := range keys {
+		data, getErr := p.state.Get(ctx, ec2Namespace, key)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var vol EC2Volume
+		if json.Unmarshal(data, &vol) != nil {
+			continue
+		}
+		for _, att := range vol.Attachments {
+			if att.InstanceID == instanceID && ec2IsRootDevice(att.Device) {
+				return vol.VolumeID, int64(vol.Size), nil
+			}
+		}
+	}
+	return "", ec2DefaultVolumeSizeGiB, nil
+}

--- a/emulator/ec2_snapshots_test.go
+++ b/emulator/ec2_snapshots_test.go
@@ -1,0 +1,407 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #689's surface: a snapshot's size is the source volume's rather than the literal 8, and a
+// block device mapping naming a snapshot that does not exist is refused.
+//
+// Every assertion below is at HTTP level, because both halves of the defect were observable
+// only through a response: EC2Snapshot.VolumeSize was 8 at its single producer, so
+// DescribeSnapshots reported 8 for a snapshot of a 100 GiB volume, and a mapping naming
+// snap-0123456789abcdef0 — a snapshot no account holds — produced an 8 GiB volume a consumer
+// then asserted against.
+
+// createdSnapshot is the CreateSnapshot response as a caller receives it.
+type createdSnapshot struct {
+	SnapshotID  string `xml:"snapshotId"`
+	VolumeID    string `xml:"volumeId"`
+	Status      string `xml:"status"`
+	StartTime   string `xml:"startTime"`
+	OwnerID     string `xml:"ownerId"`
+	VolumeSize  int64  `xml:"volumeSize"`
+	Description string `xml:"description"`
+	Encrypted   bool   `xml:"encrypted"`
+	Tags        []struct {
+		Key   string `xml:"key"`
+		Value string `xml:"value"`
+	} `xml:"tagSet>item"`
+}
+
+// ec2CreateSizedVolume creates a volume of sizeGiB and returns its ID.
+func ec2CreateSizedVolume(t *testing.T, ts *httptest.Server, sizeGiB int, extra map[string]string) string {
+	t.Helper()
+	params := map[string]string{
+		"Action":           "CreateVolume",
+		"AvailabilityZone": "us-east-1a",
+		"Size":             strconv.Itoa(sizeGiB),
+	}
+	for k, v := range extra {
+		params[k] = v
+	}
+	var doc struct {
+		VolumeID string `xml:"volumeId"`
+		Size     int    `xml:"size"`
+	}
+	ec2FleetXML(t, ts, params, &doc)
+	require.NotEmpty(t, doc.VolumeID)
+	require.Equal(t, sizeGiB, doc.Size)
+	return doc.VolumeID
+}
+
+// ec2CreateSnapshot sends CreateSnapshot and returns the response it answers.
+func ec2CreateSnapshot(t *testing.T, ts *httptest.Server, params map[string]string) createdSnapshot {
+	t.Helper()
+	full := map[string]string{"Action": "CreateSnapshot"}
+	for k, v := range params {
+		full[k] = v
+	}
+	var snap createdSnapshot
+	ec2FleetXML(t, ts, full, &snap)
+	return snap
+}
+
+// ec2SnapshotOfSize creates a volume of sizeGiB, snapshots it, and returns both IDs.
+//
+// It is what every mapping test below needs: a snapshot whose size is *not* 8, so that a
+// volume reported as 8 GiB is a failure rather than a coincidence.
+func ec2SnapshotOfSize(t *testing.T, ts *httptest.Server, sizeGiB int) (volumeID, snapshotID string) {
+	t.Helper()
+	volumeID = ec2CreateSizedVolume(t, ts, sizeGiB, nil)
+	snap := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID})
+	require.Equal(t, int64(sizeGiB), snap.VolumeSize)
+	return volumeID, snap.SnapshotID
+}
+
+// TestEC2_CreateSnapshot_ReportsTheSourceVolume is the operation's own fail-before: before
+// #689 CreateSnapshot reached the dispatcher's default arm and answered InvalidAction/400,
+// so the only snapshots substrate held were CreateImage's, all of them 8 GiB.
+//
+// The response members are asserted individually rather than as a body substring, because
+// the one that matters is volumeSize and 8 appears in an unrelated element of a launch
+// response. Element names come from the CreateSnapshot reference: the state member is
+// `status`, not `state`.
+func TestEC2_CreateSnapshot_ReportsTheSourceVolume(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volID := ec2CreateSizedVolume(t, ts, 100, map[string]string{"Encrypted": "true"})
+
+	snap := ec2CreateSnapshot(t, ts, map[string]string{
+		"VolumeId":                        volID,
+		"Description":                     "Daily Backup",
+		"TagSpecification.1.ResourceType": "snapshot",
+		"TagSpecification.1.Tag.1.Key":    "Name",
+		"TagSpecification.1.Tag.1.Value":  "nightly",
+	})
+
+	assert.Contains(t, snap.SnapshotID, "snap-")
+	assert.Equal(t, volID, snap.VolumeID)
+	assert.Equal(t, int64(100), snap.VolumeSize, "the size is the source volume's, not 8")
+	assert.Equal(t, "completed", snap.Status)
+	assert.NotEmpty(t, snap.StartTime)
+	assert.NotEmpty(t, snap.OwnerID)
+	assert.Equal(t, "Daily Backup", snap.Description)
+	assert.True(t, snap.Encrypted, "a snapshot of an encrypted volume is encrypted")
+	require.Len(t, snap.Tags, 1)
+	assert.Equal(t, "Name", snap.Tags[0].Key)
+	assert.Equal(t, "nightly", snap.Tags[0].Value)
+
+	// And DescribeSnapshots reports the same record, so the two operations cannot drift.
+	described := ec2DescribeSnapshots(t, ts, map[string]string{"SnapshotId.1": snap.SnapshotID})
+	require.Len(t, described, 1)
+	assert.Equal(t, snap.VolumeID, described[0].VolumeID)
+	assert.Equal(t, int64(100), described[0].VolumeSize)
+	assert.Equal(t, "Daily Backup", described[0].Description)
+	assert.True(t, described[0].Encrypted)
+	require.Len(t, described[0].Tags, 1)
+	assert.Equal(t, "nightly", described[0].Tags[0].Value)
+
+	// The volume-size filter #685 added now has something other than 8 to select on.
+	assert.Equal(t, []string{snap.SnapshotID},
+		ec2SnapshotIDsFor(t, ts, ec2Filter("volume-size", "100")))
+	assert.Equal(t, []string{snap.SnapshotID},
+		ec2SnapshotIDsFor(t, ts, ec2Filter("volume-id", volID)))
+}
+
+// TestEC2_CreateSnapshot_RefusesAVolumeItCannotFind pins that VolumeId is required and
+// checked against state, which is what makes the mapping-level check below coherent: a
+// snapshot cannot exist for a volume that does not.
+//
+// Both codes are documented. EC2's client-error table gives InvalidVolume.NotFound as "The
+// specified volume does not exist" and InvalidVolumeID.Malformed as "The specified volume ID
+// is not valid"; the messages are substrate's own, from the shared [ec2IDKind] machinery, and
+// MissingParameter is the code substrate already raises for an absent required parameter.
+func TestEC2_CreateSnapshot_RefusesAVolumeItCannotFind(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		volumeID string
+		code     string
+		msg      string
+	}{
+		{
+			name: "absent",
+			code: "MissingParameter",
+			msg:  "The request must contain the parameter VolumeId",
+		},
+		{
+			name:     "malformed",
+			volumeID: "vol-not-hex",
+			code:     "InvalidVolumeID.Malformed",
+			msg:      `Invalid id: "vol-not-hex"`,
+		},
+		{
+			name:     "well-formed but unknown",
+			volumeID: "vol-0123456789abcdef0",
+			code:     "InvalidVolume.NotFound",
+			msg:      "The volume ID 'vol-0123456789abcdef0' does not exist",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			params := map[string]string{"Action": "CreateSnapshot"}
+			if tc.volumeID != "" {
+				params["VolumeId"] = tc.volumeID
+			}
+			status, code, msg := ec2ErrorDetail(t, ts, params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tc.code, code)
+			assert.Equal(t, tc.msg, msg)
+			assert.Empty(t, ec2DescribeSnapshots(t, ts, nil), "a refused request writes no snapshot")
+		})
+	}
+}
+
+// TestEC2_CreateTags_TagsASnapshot is the other half of #688's
+// TestEC2_DescribeTags_ScanIsWiderThanCreateTags: a snap- ID had no arm in
+// ec2TaggableResource, so CreateTags on a snapshot answered <return>true</return> having
+// written nothing — the same shape #670 fixed for vol-, and immediately relevant now that
+// CreateSnapshot's TagSpecification gives a caller a snapshot of their own to tag.
+func TestEC2_CreateTags_TagsASnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapID := ec2SnapshotOfSize(t, ts, 30)
+
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": snapID,
+		"Tag.1.Key":    "Added",
+		"Tag.1.Value":  "later",
+	}, nil)
+
+	described := ec2DescribeSnapshots(t, ts, map[string]string{"SnapshotId.1": snapID})
+	require.Len(t, described, 1)
+	require.Len(t, described[0].Tags, 1)
+	assert.Equal(t, "Added", described[0].Tags[0].Key)
+	assert.Equal(t, "later", described[0].Tags[0].Value)
+
+	assert.Contains(t, ec2TagKeysFor(t, ts, ec2Filter("resource-type", "snapshot")),
+		snapID+"/Added=later", "DescribeTags reports a tag CreateTags wrote to a snapshot")
+
+	// DeleteTags reaches it too — both directions go through the same arm.
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":       "DeleteTags",
+		"ResourceId.1": snapID,
+		"Tag.1.Key":    "Added",
+	}, nil)
+	assert.Empty(t, ec2DescribeSnapshots(t, ts,
+		map[string]string{"SnapshotId.1": snapID})[0].Tags)
+}
+
+// TestEC2_BlockDeviceMapping_RefusesAnUnknownSnapshot is #689's launch-side fail-before: a
+// mapping naming a snapshot no account holds was accepted and materialized an 8 GiB volume.
+//
+// InvalidSnapshot.NotFound is documented — "The specified snapshot does not exist" — and the
+// refusal leaves no state behind, for the ordering reason
+// TestEC2_BlockDeviceMapping_RefusalWritesNothing pins.
+func TestEC2_BlockDeviceMapping_RefusesAnUnknownSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	status, code, msg := ec2InvalidBDM(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": "snap-0123456789abcdef0",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidSnapshot.NotFound", code)
+	assert.Equal(t, "The snapshot ID 'snap-0123456789abcdef0' does not exist", msg)
+
+	assert.Empty(t, bdmDescribeVolumes(t, ts, nil), "a refused launch materializes no volume")
+
+	// A malformed snapshot ID is refused too, with the code EC2 publishes for the syntax.
+	_, code, _ = ec2InvalidBDM(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": "snap-NOTHEX",
+	})
+	assert.Equal(t, "InvalidSnapshotID.Malformed", code)
+}
+
+// TestEC2_BlockDeviceMapping_InheritsTheSnapshotSize covers the mirror of the same defect:
+// ec2VolumeFromMapping took nothing from the snapshot, so a mapping naming a snapshot and no
+// size fell through to the 8 GiB default. EC2BlockDeviceMapping.VolumeSize's own field doc
+// already stated the correct rule — the doc was ahead of the code.
+func TestEC2_BlockDeviceMapping_InheritsTheSnapshotSize(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapID := ec2SnapshotOfSize(t, ts, 30)
+
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":   "RunInstances",
+		"ImageId":  "ami-0abcdef1234567890",
+		"MinCount": "1", "MaxCount": "1",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": snapID,
+	}, nil)
+
+	var found bool
+	for _, vol := range bdmDescribeVolumes(t, ts, nil) {
+		if vol.SnapshotID != snapID {
+			continue
+		}
+		found = true
+		assert.Equal(t, 30, vol.Size, "the volume is the snapshot's size, not the 8 GiB default")
+		assert.Equal(t, "/dev/sdf", vol.bdmDevice())
+	}
+	assert.True(t, found, "the launch materialized a volume from the snapshot")
+}
+
+// TestEC2_BlockDeviceMapping_SizeBelowTheSnapshotIsRefused is the refusal v0.105.0 deferred
+// for exactly the reason #689 removes: with EC2Snapshot.VolumeSize a literal 8 at its single
+// producer, the comparison would have tested a constant rather than the caller's request.
+//
+// Equal and larger are accepted, which is what makes this a rule about the snapshot rather
+// than about the size: AWS's sentence on EbsBlockDevice.VolumeSize is "must be equal to or
+// larger than the snapshot size".
+func TestEC2_BlockDeviceMapping_SizeBelowTheSnapshotIsRefused(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		size    string
+		refused bool
+	}{
+		{name: "smaller", size: "10", refused: true},
+		{name: "equal", size: "30"},
+		{name: "larger", size: "60"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			_, snapID := ec2SnapshotOfSize(t, ts, 30)
+
+			status, code, msg := ec2InvalidBDM(t, ts, map[string]string{
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"BlockDeviceMapping.1.Ebs.SnapshotId": snapID,
+				"BlockDeviceMapping.1.Ebs.VolumeSize": tc.size,
+			})
+			if !tc.refused {
+				assert.Equal(t, http.StatusOK, status)
+				assert.Empty(t, code)
+				return
+			}
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidBlockDeviceMapping", code)
+			assert.Equal(t,
+				"Invalid block device mapping for /dev/sdf: Ebs.VolumeSize 10 is smaller than "+
+					"the size of snapshot "+snapID+" (30 GiB)", msg)
+		})
+	}
+}
+
+// TestEC2_CreateVolume_InheritsTheSnapshotSize covers CreateVolume's independent copy of the
+// same gap: Size absent with SnapshotId present resolved to 8 there too, so the two doors
+// onto the same defect are closed in one change.
+func TestEC2_CreateVolume_InheritsTheSnapshotSize(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapID := ec2SnapshotOfSize(t, ts, 30)
+
+	var doc struct {
+		VolumeID string `xml:"volumeId"`
+		Size     int    `xml:"size"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "CreateVolume",
+		"AvailabilityZone": "us-east-1a",
+		"SnapshotId":       snapID,
+	}, &doc)
+	assert.Equal(t, 30, doc.Size, "a volume restored from a snapshot is at least its size")
+
+	// An explicit size still wins, and one below the snapshot's is refused — the same rule
+	// the mapping path applies, through the same comparison.
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "CreateVolume",
+		"AvailabilityZone": "us-east-1a",
+		"SnapshotId":       snapID,
+		"Size":             "60",
+	}, &doc)
+	assert.Equal(t, 60, doc.Size)
+
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":           "CreateVolume",
+		"AvailabilityZone": "us-east-1a",
+		"SnapshotId":       snapID,
+		"Size":             "10",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+}
+
+// TestEC2_CreateImage_SnapshotSizeIsTheRootVolume pins the second half of the literal 8:
+// CreateImage minted a backing snapshot whose size was the constant, and DescribeImages
+// rendered the constant again in its own ebs member — so an AMI made from a 40 GiB root
+// volume reported 8 GiB twice, through two different operations, and the two would have
+// disagreed the moment either one learned a real size.
+func TestEC2_CreateImage_SnapshotSizeIsTheRootVolume(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	var run struct {
+		InstanceID string `xml:"instancesSet>item>instanceId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":   "RunInstances",
+		"ImageId":  "ami-0abcdef1234567890",
+		"MinCount": "1", "MaxCount": "1",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.VolumeSize": "40",
+	}, &run)
+	require.NotEmpty(t, run.InstanceID)
+
+	var img struct {
+		ImageID string `xml:"imageId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateImage", "InstanceId": run.InstanceID, "Name": "forty",
+	}, &img)
+	require.NotEmpty(t, img.ImageID)
+
+	snaps := ec2DescribeSnapshots(t, ts, nil)
+	require.Len(t, snaps, 1)
+	assert.Equal(t, int64(40), snaps[0].VolumeSize, "the AMI's snapshot is the root volume's size")
+
+	var described struct {
+		Images []struct {
+			ImageID string `xml:"imageId"`
+			BDM     []struct {
+				EBS struct {
+					SnapshotID string `xml:"snapshotId"`
+					VolumeSize int64  `xml:"volumeSize"`
+				} `xml:"ebs"`
+			} `xml:"blockDeviceMapping>item"`
+		} `xml:"imagesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeImages"}, &described)
+	require.Len(t, described.Images, 1)
+	require.Len(t, described.Images[0].BDM, 1)
+	assert.Equal(t, snaps[0].SnapshotID, described.Images[0].BDM[0].EBS.SnapshotID)
+	assert.Equal(t, int64(40), described.Images[0].BDM[0].EBS.VolumeSize,
+		"DescribeImages reads the snapshot's size rather than rendering its own constant")
+}

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -570,6 +570,17 @@ func ec2SnapshotStateKey(accountID, region, snapshotID string) string {
 	return "snapshot:" + accountID + "/" + region + "/" + snapshotID
 }
 
+// ec2SnapshotStatePrefix is the key prefix every snapshot in one account and region
+// shares, for a List that has no particular snapshot in mind.
+//
+// Declared beside the key for the reason [ec2VolumeStateKey]'s own doc comment gives:
+// CreateSnapshot now writes records CreateImage did not, and a writer that spells the
+// prefix differently from the readers would produce snapshots DescribeSnapshots cannot
+// see.
+func ec2SnapshotStatePrefix(accountID, region string) string {
+	return "snapshot:" + accountID + "/" + region + "/"
+}
+
 // EC2PlacementGroup represents an Amazon EC2 placement group.
 type EC2PlacementGroup struct {
 	// GroupName is the user-supplied placement group name.

--- a/test/e2e/journey_ec2_snapshots_test.go
+++ b/test/e2e/journey_ec2_snapshots_test.go
@@ -1,0 +1,231 @@
+package e2e_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
+
+	emulator "github.com/scttfrdmn/substrate/emulator"
+)
+
+// TestJourney_EC2SnapshotRestore is #689's journey: create a volume, snapshot it, restore
+// from the snapshot both ways a caller can, and read the size back.
+//
+// It belongs at this tier because the size is the whole point and the size is what a real
+// SDK client reads. Snapshot.VolumeSize was the literal 8 at substrate's only producer, so
+// every route a consumer had to "how big is this snapshot?" answered with a constant — and
+// a restore from it produced an 8 GiB volume whatever the snapshot said. The HTTP-level
+// tests pin the wire; this pins that a client's own types carry the value through.
+func TestJourney_EC2SnapshotRestore(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	client := ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	ctx := context.Background()
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(40),
+		Encrypted:        aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+	volumeID := aws.ToString(vol.VolumeId)
+
+	// TagSpecifications is a structured input the SDK serializes itself, so this proves
+	// substrate reads the spelling the SDK sends rather than one chosen by hand.
+	snap, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{
+		VolumeId:    aws.String(volumeID),
+		Description: aws.String("nightly"),
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeSnapshot,
+			Tags:         []ec2types.Tag{{Key: aws.String("Scope"), Value: aws.String("nightly")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	snapshotID := aws.ToString(snap.SnapshotId)
+	if snapshotID == "" {
+		t.Fatal("CreateSnapshot returned an empty snapshot ID")
+	}
+	if got := aws.ToInt32(snap.VolumeSize); got != 40 {
+		t.Errorf("CreateSnapshot VolumeSize = %d, want the source volume's 40", got)
+	}
+	if got := aws.ToString(snap.VolumeId); got != volumeID {
+		t.Errorf("CreateSnapshot VolumeId = %q, want %q", got, volumeID)
+	}
+	// State is the SDK's name for the wire's `status` member. completed at once is
+	// deliberate: substrate advances no snapshot asynchronously, so a waiter succeeds on
+	// its first poll instead of depending on wall-clock time.
+	if snap.State != ec2types.SnapshotStateCompleted {
+		t.Errorf("CreateSnapshot State = %q, want completed", snap.State)
+	}
+	if !aws.ToBool(snap.Encrypted) {
+		t.Error("a snapshot of an encrypted volume should be encrypted")
+	}
+
+	// DescribeSnapshots agrees, and the volume-size filter selects on the real value.
+	described, err := client.DescribeSnapshots(ctx, &ec2.DescribeSnapshotsInput{
+		Filters: []ec2types.Filter{{Name: aws.String("volume-size"), Values: []string{"40"}}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots: %v", err)
+	}
+	if len(described.Snapshots) != 1 || aws.ToString(described.Snapshots[0].SnapshotId) != snapshotID {
+		t.Fatalf("volume-size=40 selected %d snapshots, want just %s", len(described.Snapshots), snapshotID)
+	}
+	if got := aws.ToString(described.Snapshots[0].Description); got != "nightly" {
+		t.Errorf("Description = %q, want %q", got, "nightly")
+	}
+
+	// Route one: CreateVolume with no Size takes the snapshot's.
+	restored, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		SnapshotId:       aws.String(snapshotID),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume from snapshot: %v", err)
+	}
+	if got := aws.ToInt32(restored.Size); got != 40 {
+		t.Errorf("restored volume Size = %d, want the snapshot's 40", got)
+	}
+
+	// Route two: a launch's block device mapping with no size takes it too. The value is
+	// observable only through DescribeVolumes — AWS's EbsInstanceBlockDevice, the shape
+	// DescribeInstances renders per device, carries no size member.
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-0abcdef1234567890"),
+		InstanceType: ec2types.InstanceTypeT3Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/sdf"),
+			Ebs:        &ec2types.EbsBlockDevice{SnapshotId: aws.String(snapshotID)},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("RunInstances: %v", err)
+	}
+	instanceID := aws.ToString(run.Instances[0].InstanceId)
+
+	launched, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("attachment.instance-id"), Values: []string{instanceID}},
+			{Name: aws.String("attachment.device"), Values: []string{"/dev/sdf"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DescribeVolumes: %v", err)
+	}
+	if len(launched.Volumes) != 1 {
+		t.Fatalf("DescribeVolumes returned %d volumes for /dev/sdf, want 1", len(launched.Volumes))
+	}
+	if got := aws.ToInt32(launched.Volumes[0].Size); got != 40 {
+		t.Errorf("launch-created volume Size = %d, want the snapshot's 40", got)
+	}
+}
+
+// TestJourney_EC2SnapshotRefusals is the other half: the two mistakes a consumer's retry
+// loop has to tell apart, each read through the SDK's own error shape.
+//
+// A snapshot that does not exist is an InvalidSnapshot.NotFound about the ID — which is
+// what naming a snapshot from a previous run looks like — while a size below the
+// snapshot's is an InvalidBlockDeviceMapping about the mapping. Before #689 both
+// succeeded and produced an 8 GiB volume.
+func TestJourney_EC2SnapshotRefusals(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	cfg, err := journeyConfig(ts)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	client := ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.RetryMaxAttempts = 1 })
+	ctx := context.Background()
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(30),
+	})
+	if err != nil {
+		t.Fatalf("CreateVolume: %v", err)
+	}
+	snap, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{VolumeId: vol.VolumeId})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	launch := func(bdm ec2types.BlockDeviceMapping) error {
+		_, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+			ImageId:             aws.String("ami-0abcdef1234567890"),
+			InstanceType:        ec2types.InstanceTypeT3Micro,
+			MinCount:            aws.Int32(1),
+			MaxCount:            aws.Int32(1),
+			BlockDeviceMappings: []ec2types.BlockDeviceMapping{bdm},
+		})
+		return err
+	}
+
+	for _, tc := range []struct {
+		name string
+		bdm  ec2types.BlockDeviceMapping
+		code string
+	}{
+		{
+			name: "a snapshot no account holds",
+			bdm: ec2types.BlockDeviceMapping{
+				DeviceName: aws.String("/dev/sdf"),
+				Ebs:        &ec2types.EbsBlockDevice{SnapshotId: aws.String("snap-0123456789abcdef0")},
+			},
+			code: "InvalidSnapshot.NotFound",
+		},
+		{
+			name: "a size below the snapshot's",
+			bdm: ec2types.BlockDeviceMapping{
+				DeviceName: aws.String("/dev/sdf"),
+				Ebs: &ec2types.EbsBlockDevice{
+					SnapshotId: snap.SnapshotId,
+					VolumeSize: aws.Int32(10),
+				},
+			},
+			code: "InvalidBlockDeviceMapping",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := launch(tc.bdm)
+			if err == nil {
+				t.Fatalf("RunInstances succeeded, want %s", tc.code)
+			}
+			var apiErr smithy.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("error is not an APIError: %v", err)
+			}
+			if apiErr.ErrorCode() != tc.code {
+				t.Errorf("code = %q, want %q (message %q)",
+					apiErr.ErrorCode(), tc.code, apiErr.ErrorMessage())
+			}
+		})
+	}
+
+	// And CreateSnapshot itself refuses a volume it cannot find, so a snapshot cannot
+	// exist for a volume that does not.
+	_, err = client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{
+		VolumeId: aws.String("vol-0123456789abcdef0"),
+	})
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("CreateSnapshot on an unknown volume: error is not an APIError: %v", err)
+	}
+	if apiErr.ErrorCode() != "InvalidVolume.NotFound" {
+		t.Errorf("code = %q, want InvalidVolume.NotFound", apiErr.ErrorCode())
+	}
+}


### PR DESCRIPTION
Closes #689.

`EC2Snapshot.VolumeSize` was **the literal `8`**, and substrate had no `CreateSnapshot` at all
(`InvalidAction` / HTTP 400) — so the only snapshots it held were the ones `CreateImage` mints for
an AMI's root device, all of them 8 GiB whatever the instance's root volume was. Every
size-dependent rule was therefore a comparison against a constant, which is precisely why v0.105.0
deferred the block-device-mapping rule that a size must not be smaller than its snapshot's, and why
#685's `volume-size` filter had a single value to select on.

Four changes, one theme: **the constant `8` becomes a real value, and a snapshot ID gets checked.**

### `CreateSnapshot`

`VolumeId` is required and resolved against state through the existing `ec2VolumeIDKind` machinery:
absent is `MissingParameter`, a syntactically invalid ID is `InvalidVolumeID.Malformed`, one that
names nothing is `InvalidVolume.NotFound` — so a snapshot cannot exist for a volume that does not.
`volumeSize` and `encrypted` come from the source volume rather than the request, which is what AWS
documents ("the size of the volume, in GiB"; "snapshots that are taken from encrypted volumes are
automatically encrypted"). `Description` and `TagSpecification.N` are read, the tags through the
same walk and the same two rules as every other tag-on-create, checked **before** anything is
written.

The response element is **`status`**, not `state` — verified against the `CreateSnapshot` reference,
whose documented values are `pending | completed | error | recoverable | recovering`. It is
`completed` at once, not the `pending` AWS's own sample shows: substrate advances no snapshot
asynchronously, so a caller's waiter succeeds on its first poll rather than depending on wall-clock
time. A *seedable* `pending → completed` progression is the shape that would let a test exercise the
waiting path, and is a follow-up rather than nondeterministic behaviour. `Location` and `OutpostArn`
are not read — both are documented as supported only for a Local Zone or an Outpost, neither of
which substrate models.

### The two literal `8`s

`createImage` wrote `volumeSize: 8`, and `describeImages` rendered a *second*, independent literal
`8` for the same snapshot in its own `ebs` member (the one this issue does not mention). Two
constants that agreed only for as long as neither knew a real size. Both now read the volume
record — `ec2InstanceRootVolume` scans for the volume attached at a device passing
`ec2IsRootDevice` — so an AMI made from a 40 GiB root volume reports 40 GiB through
`DescribeSnapshots` **and** through `DescribeImages`. The snapshot also records the source volume's
ID, which finally gives `DescribeSnapshots`' `volume-id` filter something to select on for the only
snapshots substrate could previously produce. An AMI whose snapshot was since deleted falls back to
the 8 GiB default rather than reporting `0`.

### The snapshot checks on a block device mapping

A mapping naming a snapshot was accepted unconditionally and materialized an 8 GiB volume, so a
launch real EC2 rejects succeeded here and left state a consumer then asserted against — the same
class of defect #671 closed for the six mapping rules it added.

- **Malformed ID** → `InvalidSnapshotID.Malformed`; **names nothing** → `InvalidSnapshot.NotFound`.
  Both come from `ec2SnapshotIDKind`, which already produced the exact code, message and status.
- **`Ebs.VolumeSize` below the snapshot's** → `InvalidBlockDeviceMapping`, the refusal v0.105.0
  deferred. AWS documents the rule verbatim on `EbsBlockDevice.VolumeSize`: "You can specify a
  volume size that is equal to or larger than the snapshot size."

The two carry different codes on purpose: a snapshot substrate cannot find is a mistake about the
*ID* — which is what naming a snapshot from a previous run looks like — while a size below it is a
mistake about the *mapping*. A refusal leaves no state behind, because the check sits where #671 put
the validator: after the launch-template merge, before the default-VPC branch.

`ec2CheckBlockDeviceMappings` was pure and snapshot existence needs state, so it takes a
`resolveSnapshot func(string) (EC2Snapshot, bool)` rather than a `*StateManager` — the validator
stays unit-testable with a two-line closure, and #693's collecting variant can wrap the same
signature. **Rule order is load-bearing and the doc comment states both halves**: the snapshot
checks run *after* the size-or-snapshot requirement (a mapping naming neither has no snapshot to
look up) and *before* the Throughput/Iops rules, which `return nil` early on an absent `VolumeType`
and would otherwise skip the snapshot check entirely.

### And the mirror of the same defect

A mapping with a present `SnapshotId` and **absent** `VolumeSize` yielded `ec2DefaultVolumeSizeGiB`
= 8, because `ec2VolumeFromMapping` took nothing from the snapshot. `EC2BlockDeviceMapping`'s own
field doc already stated the correct rule — the doc was ahead of the code — and AWS states it on the
same member it states the refusal on: "If you specify a snapshot, the default is the snapshot size."
`ec2ResolveSnapshotSizes` fills it in a pre-resolution step before `ec2CreateLaunchVolumes`, which
keeps both pure functions pure and fixes `DescribeVolumes`' reported `size` for free. It keys off
`VolumeSizeRaw == ""`, which is what makes an absent value distinguishable from an unparseable one.

`createVolume` had the identical gap independently — a restore from a 30 GiB snapshot produced an
8 GiB volume there too, and one naming a snapshot no account holds succeeded outright — and now
applies both rules through the same comparison.

### `CreateTags` reaches a snapshot

A `snap-` ID had no arm in `ec2TaggableResource`, so `CreateTags` on a snapshot answered
`<return>true</return>` having written nothing — the same silent no-op #670 fixed for `vol-`, and
immediately relevant now that `CreateSnapshot`'s `TagSpecification` gives a caller a snapshot of
their own. Until this change `DescribeTags` (#688, this release) could report a snapshot's tags that
`CreateTags` had no way to write. The `image`/`lt`/`fleet` arms each need their own ARN-format
verification and stay in #695.

## Provenance

`status` and its five values, `VolumeId`'s Required: Yes, the size-inheritance default and the
equal-or-larger refusal are all from the `CreateSnapshot` and `EbsBlockDevice` references, fetched
this session — both "If you specify a snapshot, the default is the snapshot size" and "You can
specify a volume size that is equal to or larger than the snapshot size" appear verbatim on
`CreateVolume.Size` *and* `EbsBlockDevice.VolumeSize`, so the same rule is applied through both
doors. Neither operation's Errors section lists anything beyond the common errors, so the specific
codes come from EC2's errors-overview page (`InvalidSnapshot.NotFound`,
`InvalidSnapshotID.Malformed`, `InvalidVolume.NotFound`, `InvalidVolumeID.Malformed` are all
documented there) rather than from the per-operation pages. **`completed` at once is substrate's**,
not AWS's sample; so is which code applies to which of the two mapping mistakes.

## Fail-before

`emulator/ec2_snapshots_test.go` and `test/e2e/journey_ec2_snapshots_test.go` run against `main`
(85a01b4), all seven tests and thirteen subtests failing:

```
--- FAIL: TestEC2_CreateSnapshot_ReportsTheSourceVolume (0.00s)
    status = 400, want 200; body = <Response><Errors><Error><Code>InvalidAction</Code>
    <Message>EC2Plugin: unknown action CreateSnapshot</Message></Error></Errors>...
--- FAIL: TestEC2_BlockDeviceMapping_RefusesAnUnknownSnapshot (0.00s)
    Error: Not equal: expected: "InvalidSnapshot.NotFound"  actual: ""
    Error: Should be empty, but was [{vol-9db4f82f… 8 gp2 …} {vol-ec5e5c7b… 8 gp2 us-east-1a
      in-use false snap-0123456789abcdef0 …}]
    Messages: a refused launch materializes no volume
    Error: Not equal: expected: "InvalidSnapshotID.Malformed"  actual: ""
--- FAIL: TestEC2_CreateImage_SnapshotSizeIsTheRootVolume (0.00s)
    Error: Not equal: expected: 40  actual: 8
    Messages: the AMI's snapshot is the root volume's size
    Error: Not equal: expected: 40  actual: 8
    Messages: DescribeImages reads the snapshot's size rather than rendering its own constant
--- FAIL: TestEC2_CreateVolume_InheritsTheSnapshotSize
--- FAIL: TestEC2_BlockDeviceMapping_InheritsTheSnapshotSize
--- FAIL: TestEC2_CreateTags_TagsASnapshot
--- FAIL: TestEC2_CreateSnapshot_RefusesAVolumeItCannotFind/absent
```

The nonexistent-snapshot case is the one worth reading twice: not only was the launch accepted, it
**materialized a volume carrying `snap-0123456789abcdef0`** — a snapshot no account holds — at the
8 GiB default.

And at the SDK tier:

```
--- FAIL: TestJourney_EC2SnapshotRestore (0.01s)
    CreateSnapshot: operation error EC2: CreateSnapshot, https response error StatusCode: 400,
    api error InvalidAction: EC2Plugin: unknown action CreateSnapshot
--- FAIL: TestJourney_EC2SnapshotRefusals (0.00s)
    (same)
```

## Two tests rewritten rather than extended

- `TestEC2_BlockDeviceMapping_ValidIsAccepted/a_snapshot_with_no_size` asserted that a mapping
  naming `snap-0123456789abcdef0` is **accepted**. Under the existence check it is refused, so the
  row now seeds a real 30 GiB snapshot — and a sibling row asserts a size *equal* to the snapshot's
  is accepted, since the rule is equal-or-larger.
- `TestEC2_DescribeTags_ScanIsWiderThanCreateTags` asserted "`CreateTags` has no `snap-` arm yet".
  That is now false; it asserts both the `CreateTags`-written and `TagSpecification`-written tags
  come back.

Two assertions I expected to break **still pass, and now for the right reason**: the `int64(8)` in
`ec2_plugin_test.go` and the `volume-size "8"` filter row. The seeded instances genuinely have 8 GiB
root volumes, so `8` went from a constant to a real value. Both got a comment saying so, plus a
`require.NotEmpty` on the newly-recorded `VolumeID` and a real `volume-id` selection row, so nothing
passes by coinciding with a constant.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test`
(race, all packages), `make docs-reference-check`, `make docs-versions`, and
`go vet -C test/e2e ./... && go test -C test/e2e ./...` all clean. Coverage unchanged in shape: the
new file arrives with the seven tests above plus the journey.
