### PR TITLE
feat(ec2): CreateLaunchTemplate reports an invalid mapping through its warning (#693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`CreateLaunchTemplate` and `CreateLaunchTemplateVersion` report an invalid block device
+  mapping through their documented `warning` member** (#693). v0.105.0 taught `RunInstances`
+  to refuse a mapping real EC2 rejects and deliberately left both create operations
+  accepting one, because neither documents an error for it — so the mapping was swallowed in
+  silence and the caller learned about it only at launch, from a template it had already
+  shipped to every consumer of that template. The response now carries AWS's
+  `ValidationWarning` (`warning` — singular; `errorSet>item` of `{code, message}`), which the
+  reference describes as being for exactly this: "parameters or parameter combinations that
+  are not valid".
+
+  **The warning and the refusal are the same diagnosis, by construction.** Both are produced
+  by one collector over the mappings; the refusal is a thin wrapper that returns its first
+  problem. So the code and message a caller reads from `CreateLaunchTemplate` are
+  byte-identical to what `RunInstances` would have refused with — the two cannot drift into
+  describing the same mapping differently, which is the failure mode two independently
+  written message strings would have.
+
+  Where the warning is *not* the same, it is wider: it reports **every** problem, not the
+  first, because `ValidationWarning` holds a list and AWS documents one entry "for each issue
+  that's found". A template naming two bad mappings is warned about both.
+
+  A valid template's response carries **no `warning` element at all**, rather than an empty
+  one — the member is a pointer, since `encoding/xml` ignores `omitempty` on a struct value
+  and would otherwise emit `<warning></warning>` on every successful create.
+
+  **Provenance.** That an invalid *block device mapping* is what lands in `warning`, rather
+  than in a 400, is substrate's reading: AWS documents the member's purpose but never says
+  which validations use it, and neither operation's Errors section lists anything about block
+  device mappings. Dispatch on the code, not the message — the codes
+  (`InvalidBlockDeviceMapping`, `InvalidSnapshot.NotFound`) are documented and the messages
+  are substrate's own.
+
+- **A launch template's block device mappings read back through
+  `DescribeLaunchTemplateVersions`** (#693). v0.104.0 taught the template to parse and store
+  `LaunchTemplateData.BlockDeviceMapping.N` and nothing ever rendered it, and that operation
+  is the only one that returns a template's data at all — so the round trip was silently
+  lossy in the one direction a caller could check it, and a warned caller could not read back
+  the mapping the warning was about. `blockDeviceMappingSet>item` now carries `deviceName`,
+  `virtualName`, `noDevice` and the full `ebs` structure (`volumeSize`, `volumeType`, `iops`,
+  `throughput`, `snapshotId`, `encrypted`, `deleteOnTermination`). `noDevice` renders as the
+  present-and-empty element AWS documents ("To omit the device from the block device mapping,
+  specify an empty string"), and `deleteOnTermination` keeps its three states — absent, true,
+  false — rather than collapsing an unstated value to `false`.
+
 - **`CreateSnapshot`, and a snapshot with a real size** (#689). Substrate had no
   `CreateSnapshot` at all — it answered `InvalidAction` / HTTP 400 — so the only snapshots it
   held were the ones `CreateImage` mints for an AMI's root device, and every one of them
@@ -158,6 +202,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can be a single rule.
 
 ### Fixed
+- **A launch-template version derived with `SourceVersion` no longer silently drops its block
+  device mappings and volume tags** (#693). `SourceVersion` is documented as the way to base a
+  new version on an existing one — "The new version inherits the same launch parameters as the
+  source version, except for parameters that you explicitly specify" — and substrate's overlay
+  copied every member *except* `BlockDeviceMappings` and `VolumeTagSpecifications`. A version
+  that specified nothing about either lost both, so a launch from the derived version came up
+  with the AMI's default 8 GiB root device and untagged volumes while the source version's
+  launched exactly as written. Nothing rendered either member, so the loss was invisible until
+  an instance was launched and its volumes inspected — which is how a consumer would find it
+  in a deployed template, not in a test.
+
+  A version that names no `SourceVersion` still inherits nothing, which is the asymmetry the
+  fix had to preserve: the overlay applies only where a source version was asked for.
+
 - **A block device mapping naming a snapshot that does not exist is refused** (#689). It was
   accepted and materialized an 8 GiB volume, so a launch real EC2 rejects succeeded here and
   produced state a consumer then asserted against — the same class of defect #671 closed for

--- a/docs/services.md
+++ b/docs/services.md
@@ -2933,7 +2933,11 @@ would launch instances from parameters the caller never asked for.
 `CreateLaunchTemplateVersion`'s `SourceVersion` is the asymmetry to know:
 
 - **With `SourceVersion`**, the new version inherits that version's parameters and
-  the request's values overwrite the ones they name.
+  the request's values overwrite the ones they name. Every parameter substrate stores
+  is inherited, including block device mappings and volume tag specifications —
+  those two were silently dropped until #693, so a version derived from a template
+  with a 25 GiB mapping launched an 8 GiB default root device instead, and nothing in
+  the response revealed the loss.
 - **Without it**, the new version holds *only* what the request names. Nothing is
   inherited — not from version 1, not from the latest.
 
@@ -3295,12 +3299,35 @@ and before the default-VPC branch, which commits a VPC, subnet, security group,
 internet gateway, route table and four index mutations. A refusal past that point
 would leave state the next request in the same test could see.
 
-**`CreateLaunchTemplate` does not refuse.** Its response carries a documented
-`warning` member of type `ValidationWarning` that exists precisely for "parameters or
-parameter combinations that are not valid", and its Errors section lists none — so a
-`400` there would be substrate's invention. That an invalid *block device mapping*
-belongs in that warning rather than in an error is substrate's reading; rendering the
-element is not yet modeled.
+**`CreateLaunchTemplate` does not refuse — it warns.** Its response carries a
+documented `warning` member of type `ValidationWarning` that exists precisely for
+"parameters or parameter combinations that are not valid", and its Errors section
+lists none — so a `400` there would be substrate's invention. That an invalid *block
+device mapping* belongs in that warning rather than in an error is substrate's
+reading; AWS documents the member's purpose but never says which validations use it.
+
+Since #693 both `CreateLaunchTemplate` and `CreateLaunchTemplateVersion` render it:
+`warning` (singular) holding `errorSet>item` of `{code, message}`. The warning and
+the refusal are the same diagnosis by construction — one collector produces the
+problems and the refusal is a thin wrapper returning its first — so the code and
+message a caller reads at create time are byte-identical to what the launch would
+have refused with. The warning is wider in one respect: it reports **every** problem
+rather than the first, because AWS documents one entry "for each issue that's found".
+A valid template's response carries no `warning` element at all.
+
+| Operation | On an invalid mapping |
+|---|---|
+| `CreateLaunchTemplate` | `200` + `warning`; the template is created |
+| `CreateLaunchTemplateVersion` | `200` + `warning`; the version is created, including for a mapping inherited through `SourceVersion` |
+| `RunInstances` | `400` `InvalidBlockDeviceMapping` (or `InvalidSnapshot.NotFound`); nothing is written |
+| `CreateFleet` | as `RunInstances`, since a fleet reaches mappings only through a template |
+
+The mapping a warning is about reads back through
+`DescribeLaunchTemplateVersions`, which renders `blockDeviceMappingSet>item` —
+`deviceName`, `virtualName`, `noDevice` and the full `ebs` structure. `noDevice` is
+the present-and-empty element AWS documents, and `deleteOnTermination` keeps its
+three states rather than collapsing an unstated value to `false`. Nothing rendered
+the member before #693, so a template's mappings were write-only.
 
 #### An instance reports its own block devices
 

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -199,20 +199,44 @@ var ec2VolumeTypesWithoutIOPS = map[string]bool{"standard": true, "st1": true, "
 // Call it after a launch template has been merged in, so a mapping that reaches a
 // launch through a template is refused at RunInstances time, and before anything is
 // written, so a refusal leaves no state behind. CreateLaunchTemplate deliberately does
-// not call it: its response carries a documented `warning` member of type
+// not refuse: its response carries a documented `warning` member of type
 // ValidationWarning that exists for "parameters or parameter combinations that are not
 // valid", and its Errors section lists none — so a 400 there would be substrate's
-// invention. That an invalid block device mapping belongs in that warning is
-// substrate's reading; rendering the element is a follow-up.
+// invention. It reports the same problems through that member instead, which is what
+// [ec2CollectBlockDeviceMappings] is for.
 func ec2CheckBlockDeviceMappings(
 	mappings []EC2BlockDeviceMapping,
 	resolveSnapshot func(string) (EC2Snapshot, bool),
 ) *AWSError {
+	if problems := ec2CollectBlockDeviceMappings(mappings, resolveSnapshot); len(problems) > 0 {
+		return problems[0]
+	}
+	return nil
+}
+
+// ec2CollectBlockDeviceMappings returns every problem the mapping rules find, in the
+// order [ec2CheckBlockDeviceMappings] would have hit them, so its first element is
+// exactly what that function refuses with.
+//
+// The list exists because CreateLaunchTemplate's `warning` member holds one — AWS's
+// ValidationWarning is "an error code and an error message […] for each issue that's
+// found", plural — while RunInstances refuses with a single error. Collecting is the
+// primitive and refusing is the thin wrapper, rather than the other way round: a
+// first-error function cannot be widened into a list without losing every problem after
+// the first, which is the whole of what a caller wants from a warning (#693).
+//
+// The elements are [AWSError] values rather than a warning-shaped type so that both
+// doors report byte-identical codes and messages by construction — a mapping refused at
+// RunInstances and the same mapping warned about at CreateLaunchTemplate cannot drift.
+// [ec2ValidationWarningFor] converts them at the wire boundary.
+func ec2CollectBlockDeviceMappings(
+	mappings []EC2BlockDeviceMapping,
+	resolveSnapshot func(string) (EC2Snapshot, bool),
+) []*AWSError {
+	var problems []*AWSError
 	seen := make(map[string]bool, len(mappings))
 	for _, bdm := range mappings {
-		if awsErr := ec2CheckBlockDeviceMapping(bdm, resolveSnapshot); awsErr != nil {
-			return awsErr
-		}
+		problems = append(problems, ec2CollectBlockDeviceMapping(bdm, resolveSnapshot)...)
 		// Only a mapping that materializes a volume can collide: NoDevice suppresses
 		// its device and a virtualName-only mapping names an instance store device, so
 		// neither occupies the device in a way a second mapping could contend for.
@@ -220,28 +244,36 @@ func ec2CheckBlockDeviceMappings(
 			continue
 		}
 		if seen[bdm.DeviceName] {
-			return ec2InvalidBlockDeviceMapping("",
-				"device "+bdm.DeviceName+" is named by more than one mapping")
+			problems = append(problems, ec2InvalidBlockDeviceMapping("",
+				"device "+bdm.DeviceName+" is named by more than one mapping"))
+			continue
 		}
 		seen[bdm.DeviceName] = true
 	}
-	return nil
+	return problems
 }
 
-// ec2CheckBlockDeviceMapping applies the rules that concern one mapping in isolation.
+// ec2CollectBlockDeviceMapping applies the rules that concern one mapping in isolation
+// and returns every problem it finds.
 //
 // The unparseable-number checks run first: a garbage size makes every judgement below
 // meaningless, and reporting the malformed value is more use to a caller than reporting
-// a consequence of it. The virtualName conflict runs before the size requirement, since
-// a mapping combining the two is wrong in a way that naming a size would not fix. The
-// snapshot checks follow the size requirement, because a mapping that names neither a
-// size nor a snapshot has no snapshot to look up; they precede the type rules so that a
-// nonexistent snapshot is still reported for a mapping that names no volume type, which
-// is where the type rules return early.
-func ec2CheckBlockDeviceMapping(
+// a consequence of it. That is also why an unparseable number is the one problem that
+// stops the walk — every rule after it reads a parsed int, so continuing would report
+// consequences of the value rather than facts about the request. All three numeric
+// members are reported, though, not just the first: they are independent mistakes.
+//
+// The virtualName conflict runs before the size requirement, since a mapping combining
+// the two is wrong in a way that naming a size would not fix. The snapshot checks follow
+// the size requirement, because a mapping that names neither a size nor a snapshot has
+// no snapshot to look up; they precede the type rules so that a nonexistent snapshot is
+// still reported for a mapping that names no volume type, which is where the type rules
+// stop.
+func ec2CollectBlockDeviceMapping(
 	bdm EC2BlockDeviceMapping,
 	resolveSnapshot func(string) (EC2Snapshot, bool),
-) *AWSError {
+) []*AWSError {
+	var problems []*AWSError
 	device := bdm.DeviceName
 	for _, num := range []struct{ member, raw string }{
 		{"Ebs.VolumeSize", bdm.VolumeSizeRaw},
@@ -252,9 +284,12 @@ func ec2CheckBlockDeviceMapping(
 			continue
 		}
 		if _, err := strconv.Atoi(strings.TrimSpace(num.raw)); err != nil {
-			return ec2InvalidBlockDeviceMapping(device,
-				fmt.Sprintf("%s value %q is not an integer", num.member, num.raw))
+			problems = append(problems, ec2InvalidBlockDeviceMapping(device,
+				fmt.Sprintf("%s value %q is not an integer", num.member, num.raw)))
 		}
+	}
+	if len(problems) > 0 {
+		return problems
 	}
 
 	if bdm.NoDevice {
@@ -266,19 +301,19 @@ func ec2CheckBlockDeviceMapping(
 	}
 
 	if bdm.VirtualName != "" && ec2NamesEbsMember(bdm) {
-		return ec2InvalidBlockDeviceMapping(device,
-			"virtualName names an instance store device and cannot be combined with an Ebs member")
+		problems = append(problems, ec2InvalidBlockDeviceMapping(device,
+			"virtualName names an instance store device and cannot be combined with an Ebs member"))
 	}
 
 	if ec2CreatesEBSVolume(bdm) && ec2NamesEbsMember(bdm) &&
 		bdm.VolumeSizeRaw == "" && bdm.SnapshotID == "" {
-		return ec2InvalidBlockDeviceMapping(device,
-			"you must specify either a snapshot ID or a volume size")
+		problems = append(problems, ec2InvalidBlockDeviceMapping(device,
+			"you must specify either a snapshot ID or a volume size"))
 	}
 
 	if bdm.SnapshotID != "" {
 		if awsErr := ec2CheckMappingSnapshot(bdm, resolveSnapshot); awsErr != nil {
-			return awsErr
+			problems = append(problems, awsErr)
 		}
 	}
 
@@ -286,17 +321,17 @@ func ec2CheckBlockDeviceMapping(
 	// [ec2CheckBlockDeviceMappings]. An absent type therefore refuses nothing.
 	volType := strings.ToLower(bdm.VolumeType)
 	if volType == "" {
-		return nil
+		return problems
 	}
 	if bdm.ThroughputRaw != "" && volType != "gp3" {
-		return ec2InvalidBlockDeviceMapping(device,
-			"Ebs.Throughput is valid only for gp3 volumes, not "+bdm.VolumeType)
+		problems = append(problems, ec2InvalidBlockDeviceMapping(device,
+			"Ebs.Throughput is valid only for gp3 volumes, not "+bdm.VolumeType))
 	}
 	if bdm.IOPSRaw != "" && ec2VolumeTypesWithoutIOPS[volType] {
-		return ec2InvalidBlockDeviceMapping(device,
-			"Ebs.Iops is not supported for "+bdm.VolumeType+" volumes")
+		problems = append(problems, ec2InvalidBlockDeviceMapping(device,
+			"Ebs.Iops is not supported for "+bdm.VolumeType+" volumes"))
 	}
-	return nil
+	return problems
 }
 
 // ec2CheckMappingSnapshot applies the two rules that concern the snapshot a mapping
@@ -350,7 +385,7 @@ func ec2CheckMappingSnapshot(
 //
 // VolumeSizeRaw is the test for absence rather than a zero VolumeSize, for the reason it
 // exists at all: "Ebs.VolumeSize=0" is a value a caller supplied, and an unparseable one
-// has already been refused by [ec2CheckBlockDeviceMapping].
+// has already been refused by [ec2CollectBlockDeviceMapping].
 //
 // A snapshot that does not resolve is left alone rather than defaulted, because
 // [ec2CheckMappingSnapshot] has already refused it — this pass runs after validation and

--- a/emulator/ec2_block_devices_validation_test.go
+++ b/emulator/ec2_block_devices_validation_test.go
@@ -312,8 +312,11 @@ func TestEC2_BlockDeviceMapping_RefusalWritesNothing(t *testing.T) {
 // documented `warning` member of type ValidationWarning, which exists precisely for
 // "parameters or parameter combinations that are not valid", and its Errors section
 // lists none — so a 400 there would be substrate's invention. That an invalid *block
-// device mapping* lands in the warning rather than in an error is substrate's reading,
-// and rendering the element is a follow-up.
+// device mapping* lands in the warning rather than in an error is substrate's reading;
+// #693 renders the element, so the diagnosis now reaches the caller at create time as
+// well as at launch. What is pinned here is that the warning does not become a refusal:
+// the template is still created and the launch is still the operation that fails.
+// TestEC2_CreateLaunchTemplate_WarnsAboutAnInvalidMapping pins the warning itself.
 func TestEC2_BlockDeviceMapping_TemplateMappingRefusedAtLaunch(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)

--- a/emulator/ec2_launchtemplate_versions.go
+++ b/emulator/ec2_launchtemplate_versions.go
@@ -113,6 +113,51 @@ type ec2LTVersionItem struct {
 	VersionNumber      int64               `xml:"versionNumber"`
 }
 
+// ec2ValidationWarningXML is AWS's ValidationWarning: the `warning` member
+// CreateLaunchTemplate and CreateLaunchTemplateVersion return for "parameters or
+// parameter combinations that are not valid".
+//
+// Both operations document the member and neither documents an error for an invalid
+// launch template, so a template carrying a mapping RunInstances refuses is *created*
+// and warned about rather than refused — see [ec2CollectBlockDeviceMappings]. Substrate
+// swallowed those mappings silently until #693.
+//
+// It is always rendered through a pointer field, never a value: encoding/xml ignores
+// omitempty on a struct, so a value field would emit an empty `<warning></warning>` on
+// every valid template and a caller checking for the element's presence would read every
+// template as warned about.
+type ec2ValidationWarningXML struct {
+	// Errors is ValidationWarning's sole member, ErrorSet.N. It carries no omitempty:
+	// a warning with no errors is a shape substrate never builds, since the pointer is
+	// nil when there is nothing to report.
+	Errors []ec2ValidationErrorXML `xml:"errorSet>item"`
+}
+
+// ec2ValidationErrorXML is one ValidationError within a warning — AWS's two members are
+// code and message, both documented as pointing at the same error-code table the
+// equivalent refusal draws its code from.
+type ec2ValidationErrorXML struct {
+	Code    string `xml:"code"`
+	Message string `xml:"message"`
+}
+
+// ec2ValidationWarningFor renders a collected problem list as the `warning` member, or
+// nil when there is nothing to warn about.
+//
+// Returning nil for an empty list is what keeps the element absent from a valid
+// template's response; see [ec2ValidationWarningXML] for why that cannot be a struct
+// tag's job.
+func ec2ValidationWarningFor(problems []*AWSError) *ec2ValidationWarningXML {
+	if len(problems) == 0 {
+		return nil
+	}
+	errs := make([]ec2ValidationErrorXML, 0, len(problems))
+	for _, p := range problems {
+		errs = append(errs, ec2ValidationErrorXML{Code: p.Code, Message: p.Message})
+	}
+	return &ec2ValidationWarningXML{Errors: errs}
+}
+
 // ec2LTVersionDataXML renders a version's stored parameters as AWS's
 // ResponseLaunchTemplateData.
 //
@@ -126,14 +171,51 @@ type ec2LTVersionItem struct {
 // RequestLaunchTemplateData spell it differently, so a round-trip test has to use
 // both names.
 type ec2LTVersionDataXML struct {
-	IamInstanceProfile *ec2LTVersionProfileXML  `xml:"iamInstanceProfile,omitempty"`
-	ImageID            string                   `xml:"imageId,omitempty"`
-	InstanceType       string                   `xml:"instanceType,omitempty"`
-	KeyName            string                   `xml:"keyName,omitempty"`
-	UserData           string                   `xml:"userData,omitempty"`
-	SecurityGroupIDs   []string                 `xml:"securityGroupIdSet>item,omitempty"`
-	NetworkInterfaces  []ec2LTVersionNetIfcXML  `xml:"networkInterfaceSet>item,omitempty"`
-	TagSpecifications  []ec2LTVersionTagSpecXML `xml:"tagSpecificationSet>item,omitempty"`
+	BlockDeviceMappings []ec2LTVersionBDMXML     `xml:"blockDeviceMappingSet>item,omitempty"`
+	IamInstanceProfile  *ec2LTVersionProfileXML  `xml:"iamInstanceProfile,omitempty"`
+	ImageID             string                   `xml:"imageId,omitempty"`
+	InstanceType        string                   `xml:"instanceType,omitempty"`
+	KeyName             string                   `xml:"keyName,omitempty"`
+	UserData            string                   `xml:"userData,omitempty"`
+	SecurityGroupIDs    []string                 `xml:"securityGroupIdSet>item,omitempty"`
+	NetworkInterfaces   []ec2LTVersionNetIfcXML  `xml:"networkInterfaceSet>item,omitempty"`
+	TagSpecifications   []ec2LTVersionTagSpecXML `xml:"tagSpecificationSet>item,omitempty"`
+}
+
+// ec2LTVersionBDMXML is one LaunchTemplateBlockDeviceMapping within a version's data.
+//
+// A template's mappings were stored and unreadable until #693: parsing them landed in
+// v0.104.0 and this member did not, so a caller could not read back the mapping a
+// `warning` is about — nor see what a SourceVersion-derived version inherited.
+//
+// noDevice is a string on the wire, not a bool: AWS documents it as "To omit the device
+// from the block device mapping, specify an empty string", so its presence is the signal
+// and its value carries nothing. Substrate stores a bool and renders the empty string
+// through a pointer, which is the only way encoding/xml can emit `<noDevice></noDevice>`
+// for a suppressed device and nothing at all for every other mapping.
+type ec2LTVersionBDMXML struct {
+	DeviceName  string                 `xml:"deviceName,omitempty"`
+	VirtualName string                 `xml:"virtualName,omitempty"`
+	NoDevice    *string                `xml:"noDevice"`
+	Ebs         *ec2LTVersionEbsBDMXML `xml:"ebs,omitempty"`
+}
+
+// ec2LTVersionEbsBDMXML is a mapping's LaunchTemplateEbsBlockDevice.
+//
+// Every member is a pointer or omitempty for the same reason the raw strings exist on
+// [EC2BlockDeviceMapping]: a mapping that named no size is a different request from one
+// that named zero, and rendering a 0 for the first would report a value the caller never
+// sent. deleteOnTermination is a *bool because the stored field keeps three states —
+// absent, true, false — and AWS's own member is a Boolean that a template can leave
+// unset.
+type ec2LTVersionEbsBDMXML struct {
+	DeleteOnTermination *bool  `xml:"deleteOnTermination,omitempty"`
+	Encrypted           *bool  `xml:"encrypted,omitempty"`
+	Iops                int    `xml:"iops,omitempty"`
+	SnapshotID          string `xml:"snapshotId,omitempty"`
+	Throughput          int    `xml:"throughput,omitempty"`
+	VolumeSize          int    `xml:"volumeSize,omitempty"`
+	VolumeType          string `xml:"volumeType,omitempty"`
 }
 
 // ec2LTVersionNetIfcXML is one network interface within a version's data.
@@ -185,6 +267,7 @@ func ec2LTVersionData(d EC2LaunchTemplateData) ec2LTVersionDataXML {
 			out.IamInstanceProfile = &ec2LTVersionProfileXML{Name: d.IamInstanceProfile}
 		}
 	}
+	out.BlockDeviceMappings = ec2LTVersionBDMs(d.BlockDeviceMappings)
 	// Only the instance scope is stored, so only the instance scope reads back; see
 	// [EC2LaunchTemplateData.TagSpecifications].
 	if len(d.TagSpecifications) > 0 {
@@ -224,6 +307,52 @@ func ec2LTVersionData(d EC2LaunchTemplateData) ec2LTVersionDataXML {
 			Groups:                   d.NetworkInterfaceGroups,
 			DeleteOnTermination:      true,
 		}}
+	}
+	return out
+}
+
+// ec2LTVersionBDMs renders a version's stored block device mappings for the wire.
+//
+// A mapping is emitted whether or not it would materialize a volume — a virtualName-only
+// entry and a NoDevice suppression are both parameters the template carries, and the
+// point of reading them back is to see what the template says rather than what a launch
+// from it would do.
+//
+// The ebs member is omitted entirely for a mapping that names none, so an instance-store
+// or suppressed device does not read back with an empty `<ebs/>` that a caller could
+// mistake for an EBS volume with defaults.
+func ec2LTVersionBDMs(mappings []EC2BlockDeviceMapping) []ec2LTVersionBDMXML {
+	if len(mappings) == 0 {
+		return nil
+	}
+	empty := ""
+	out := make([]ec2LTVersionBDMXML, 0, len(mappings))
+	for _, bdm := range mappings {
+		item := ec2LTVersionBDMXML{DeviceName: bdm.DeviceName, VirtualName: bdm.VirtualName}
+		if bdm.NoDevice {
+			item.NoDevice = &empty
+		}
+		if ec2NamesEbsMember(bdm) {
+			ebs := &ec2LTVersionEbsBDMXML{
+				Iops:       bdm.IOPS,
+				SnapshotID: bdm.SnapshotID,
+				Throughput: bdm.Throughput,
+				VolumeSize: bdm.VolumeSize,
+				VolumeType: bdm.VolumeType,
+			}
+			if bdm.Encrypted {
+				encrypted := true
+				ebs.Encrypted = &encrypted
+			}
+			// The stored value is the raw parameter, so "" is absent rather than false;
+			// see [EC2BlockDeviceMapping.DeleteOnTermination].
+			if bdm.DeleteOnTermination != "" {
+				dot := bdm.DeleteOnTermination == "true"
+				ebs.DeleteOnTermination = &dot
+			}
+			item.Ebs = ebs
+		}
+		out = append(out, item)
 	}
 	return out
 }
@@ -308,14 +437,22 @@ func (p *EC2Plugin) createLaunchTemplateVersion(ctx *RequestContext, req *AWSReq
 		return nil, err
 	}
 
+	// The warning goes on this outer struct rather than on ec2LTVersionItem, which
+	// DescribeLaunchTemplateVersions shares: only the two create operations document
+	// the member, and a describe reporting one would invent it.
 	type response struct {
-		XMLName xml.Name         `xml:"CreateLaunchTemplateVersionResponse"`
-		XMLNS   string           `xml:"xmlns,attr"`
-		Version ec2LTVersionItem `xml:"launchTemplateVersion"`
+		XMLName xml.Name                 `xml:"CreateLaunchTemplateVersionResponse"`
+		XMLNS   string                   `xml:"xmlns,attr"`
+		Version ec2LTVersionItem         `xml:"launchTemplateVersion"`
+		Warning *ec2ValidationWarningXML `xml:"warning,omitempty"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{
 		XMLNS:   "http://ec2.amazonaws.com/doc/2016-11-15/",
 		Version: ec2LTVersionItemFor(lt, newVersion),
+		// Collected after the overlay, for the reason the tag check runs there: a
+		// version inheriting a mapping from its source version is warned about it too.
+		Warning: ec2ValidationWarningFor(
+			ec2CollectBlockDeviceMappings(data.BlockDeviceMappings, p.ec2SnapshotResolver(ctx))),
 	})
 }
 
@@ -352,6 +489,17 @@ func ec2OverlayTemplateData(src, overlay EC2LaunchTemplateData) EC2LaunchTemplat
 	}
 	if len(overlay.TagSpecifications) > 0 {
 		out.TagSpecifications = overlay.TagSpecifications
+	}
+	// Both scopes are overlaid, not just the instance one: a source version's volume
+	// tags survived into the new version and its block device mappings did not, so a
+	// SourceVersion-derived version silently launched instances with no mappings while
+	// reporting the same template data (#693). The omission was invisible because
+	// nothing rendered either member.
+	if len(overlay.VolumeTagSpecifications) > 0 {
+		out.VolumeTagSpecifications = overlay.VolumeTagSpecifications
+	}
+	if len(overlay.BlockDeviceMappings) > 0 {
+		out.BlockDeviceMappings = overlay.BlockDeviceMappings
 	}
 	if overlay.IamInstanceProfile != "" {
 		out.IamInstanceProfile = overlay.IamInstanceProfile

--- a/emulator/ec2_launchtemplate_warning_test.go
+++ b/emulator/ec2_launchtemplate_warning_test.go
@@ -1,0 +1,448 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #693: CreateLaunchTemplate and CreateLaunchTemplateVersion render the `warning`
+// member AWS documents for "parameters or parameter combinations that are not valid".
+//
+// v0.105.0 taught RunInstances to refuse an invalid block device mapping and left both
+// create operations accepting one, because neither documents an error for it — so the
+// mapping was swallowed in silence and a caller learned about it only at launch, from a
+// template it had already shipped. These tests pin that the same diagnosis now arrives
+// through both doors, and that a valid template's response carries no warning element at
+// all.
+
+// ltWarningError is one ValidationError within a warning.
+type ltWarningError struct {
+	Code    string `xml:"code"`
+	Message string `xml:"message"`
+}
+
+// ltWarningResponse decodes just enough of either create operation's response to read
+// the template it made and the warning it attached.
+//
+// The warning is a pointer so an absent element is distinguishable from a present-but-
+// empty one — which is the whole of what the pointer field on the response struct is
+// for, and would be untestable through a value here.
+type ltWarningResponse struct {
+	LaunchTemplateID string `xml:"launchTemplate>launchTemplateId"`
+	VersionNumber    int64  `xml:"launchTemplateVersion>versionNumber"`
+	Warning          *struct {
+		Errors []ltWarningError `xml:"errorSet>item"`
+	} `xml:"warning"`
+}
+
+// ltWarningRequest sends one launch-template request and returns the decoded response
+// beside the raw body, which is what an assertion about an *absent* element has to read.
+func ltWarningRequest(t *testing.T, ts *httptest.Server, params map[string]string) (ltWarningResponse, string) {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var out ltWarningResponse
+	require.NoError(t, xml.Unmarshal(body, &out), string(body))
+	return out, string(body)
+}
+
+// TestEC2_CreateLaunchTemplate_WarnsAboutAnInvalidMapping pins that a template carrying
+// a mapping RunInstances refuses is created and reported through `warning`, with the
+// same code and message the refusal carries.
+//
+// The message equality is the point of the assertion, not decoration: the warning and
+// the refusal are built by the same collector, so a caller diagnosing a template through
+// CreateLaunchTemplate reads exactly what it would have read from the launch. Two
+// independent message strings would drift the moment one of them was reworded.
+func TestEC2_CreateLaunchTemplate_WarnsAboutAnInvalidMapping(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	out, body := ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "warned",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+	})
+	require.NotEmpty(t, out.LaunchTemplateID, "the template is created, not refused")
+	require.NotNil(t, out.Warning, "an invalid mapping is reported through warning: %s", body)
+	require.Len(t, out.Warning.Errors, 1)
+	assert.Equal(t, "InvalidBlockDeviceMapping", out.Warning.Errors[0].Code)
+
+	// The same mapping, reached through a launch, produces the identical diagnosis.
+	_, code, msg := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                            "RunInstances",
+		"MinCount":                          "1",
+		"MaxCount":                          "1",
+		"LaunchTemplate.LaunchTemplateName": "warned",
+	})
+	assert.Equal(t, code, out.Warning.Errors[0].Code)
+	assert.Equal(t, msg, out.Warning.Errors[0].Message,
+		"the warning and the refusal are the same diagnosis")
+}
+
+// TestEC2_CreateLaunchTemplate_WarnsAboutEveryProblem pins that the warning reports
+// every problem rather than the first.
+//
+// This is why the collector had to become the primitive and the first-error function its
+// wrapper: ValidationWarning is documented as carrying "an error code and an error
+// message […] for each issue that's found", and a list built by calling a first-error
+// function once can only ever hold one entry.
+func TestEC2_CreateLaunchTemplate_WarnsAboutEveryProblem(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	out, body := ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "two-problems",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		// Names an Ebs member and neither a size nor a snapshot.
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+		// Iops on a type that does not support it.
+		"LaunchTemplateData.BlockDeviceMapping.2.DeviceName":     "/dev/sdg",
+		"LaunchTemplateData.BlockDeviceMapping.2.Ebs.VolumeSize": "10",
+		"LaunchTemplateData.BlockDeviceMapping.2.Ebs.VolumeType": "standard",
+		"LaunchTemplateData.BlockDeviceMapping.2.Ebs.Iops":       "100",
+	})
+	require.NotNil(t, out.Warning, body)
+	require.Len(t, out.Warning.Errors, 2, "both mappings are reported: %s", body)
+	assert.Contains(t, out.Warning.Errors[0].Message, "/dev/sdf")
+	assert.Contains(t, out.Warning.Errors[0].Message, "you must specify either a snapshot ID or a volume size")
+	assert.Contains(t, out.Warning.Errors[1].Message, "/dev/sdg")
+	assert.Contains(t, out.Warning.Errors[1].Message, "Ebs.Iops is not supported for standard volumes")
+}
+
+// TestEC2_CreateLaunchTemplate_ValidTemplateCarriesNoWarning pins the absence of the
+// element, which is what makes its presence meaningful.
+//
+// It reads the raw body because that is the only place the distinction survives: a
+// non-pointer struct field would emit `<warning></warning>` on every response —
+// encoding/xml ignores omitempty on a struct — and every decoded assertion about a
+// present-but-empty warning would still pass.
+func TestEC2_CreateLaunchTemplate_ValidTemplateCarriesNoWarning(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	for _, tc := range []struct {
+		name   string
+		params map[string]string
+	}{
+		{
+			name: "a valid mapping",
+			params: map[string]string{
+				"LaunchTemplateName": "clean-mapping",
+				"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+				"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+			},
+		},
+		{
+			name:   "no mapping at all",
+			params: map[string]string{"LaunchTemplateName": "no-mapping"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]string{
+				"Action":                     "CreateLaunchTemplate",
+				"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+			}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			out, body := ltWarningRequest(t, ts, params)
+			assert.Nil(t, out.Warning)
+			assert.NotContains(t, body, "<warning",
+				"a valid template's response carries no warning element")
+		})
+	}
+}
+
+// TestEC2_CreateLaunchTemplateVersion_WarnsAboutAnInvalidMapping pins that the second
+// door reports too — and that a version inheriting a mapping from its source version is
+// warned about it, which is the case a caller cannot see any other way.
+//
+// The inherited case is also what makes the overlay fix observable: before #693,
+// SourceVersion dropped BlockDeviceMappings entirely, so version 2 below carried no
+// mapping to warn about and launched an instance with none.
+func TestEC2_CreateLaunchTemplateVersion_WarnsAboutAnInvalidMapping(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	v1, _ := ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "versioned",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+	})
+	require.NotNil(t, v1.Warning, "version 1 carries the mapping and the warning")
+
+	for _, tc := range []struct {
+		name   string
+		params map[string]string
+	}{
+		{
+			name: "the version names the mapping itself",
+			params: map[string]string{
+				"LaunchTemplateData.ImageId":                             "ami-0abcdef1234567890",
+				"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdg",
+				"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+			},
+		},
+		{
+			name: "the version inherits it from SourceVersion",
+			params: map[string]string{
+				"SourceVersion":              "1",
+				"LaunchTemplateData.ImageId": "ami-11112222333344445",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]string{
+				"Action":             "CreateLaunchTemplateVersion",
+				"LaunchTemplateName": "versioned",
+			}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			out, body := ltWarningRequest(t, ts, params)
+			require.NotZero(t, out.VersionNumber, "the version is created, not refused")
+			require.NotNil(t, out.Warning, body)
+			require.Len(t, out.Warning.Errors, 1)
+			assert.Equal(t, "InvalidBlockDeviceMapping", out.Warning.Errors[0].Code)
+			assert.Contains(t, out.Warning.Errors[0].Message,
+				"you must specify either a snapshot ID or a volume size")
+		})
+	}
+}
+
+// TestEC2_CreateLaunchTemplate_WarnsAboutAnUnknownSnapshot pins that the warning reports
+// the snapshot rules #689 added, not just the shape rules — the two arrived one PR apart
+// and share one collector, so the second door has to see both.
+func TestEC2_CreateLaunchTemplate_WarnsAboutAnUnknownSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	out, body := ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "unknown-snapshot",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.SnapshotId": "snap-0123456789abcdef0",
+	})
+	require.NotNil(t, out.Warning, body)
+	require.Len(t, out.Warning.Errors, 1)
+	assert.Equal(t, "InvalidSnapshot.NotFound", out.Warning.Errors[0].Code)
+	assert.Equal(t, "The snapshot ID 'snap-0123456789abcdef0' does not exist",
+		out.Warning.Errors[0].Message)
+}
+
+// ltDataMapping is one blockDeviceMappingSet>item of a version's launchTemplateData.
+type ltDataMapping struct {
+	DeviceName  string  `xml:"deviceName"`
+	VirtualName string  `xml:"virtualName"`
+	NoDevice    *string `xml:"noDevice"`
+	Ebs         *struct {
+		SnapshotID          string `xml:"snapshotId"`
+		VolumeSize          int    `xml:"volumeSize"`
+		VolumeType          string `xml:"volumeType"`
+		IOPS                int    `xml:"iops"`
+		Throughput          int    `xml:"throughput"`
+		Encrypted           *bool  `xml:"encrypted"`
+		DeleteOnTermination *bool  `xml:"deleteOnTermination"`
+	} `xml:"ebs"`
+}
+
+// ltDescribeMappings returns the mappings one version of a template reads back.
+func ltDescribeMappings(t *testing.T, ts *httptest.Server, name, version string) ([]ltDataMapping, string) {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                  "DescribeLaunchTemplateVersions",
+		"LaunchTemplateName":      name,
+		"LaunchTemplateVersion.1": version,
+	})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var out struct {
+		Versions []struct {
+			Mappings []ltDataMapping `xml:"launchTemplateData>blockDeviceMappingSet>item"`
+		} `xml:"launchTemplateVersionSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &out), string(body))
+	require.Len(t, out.Versions, 1, string(body))
+	return out.Versions[0].Mappings, string(body)
+}
+
+// TestEC2_LaunchTemplateVersion_ReadsBackItsBlockDeviceMappings pins the
+// blockDeviceMappingSet member, without which a warned caller cannot read back the
+// mapping the warning is about.
+//
+// DescribeLaunchTemplateVersions is the only operation that returns a template's data at
+// all, so an unrendered member is an unreadable parameter: v0.104.0 taught the template
+// to parse and store mappings and nothing rendered them, which made the round trip
+// silently lossy.
+func TestEC2_LaunchTemplateVersion_ReadsBackItsBlockDeviceMappings(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	_, snapID := ec2SnapshotOfSize(t, ts, 30)
+	_, body := ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "readback",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		// A fully specified EBS mapping.
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":              "/dev/sdf",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize":          "40",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType":          "gp3",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.Iops":                "4000",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.Throughput":          "200",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.Encrypted":           "true",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.DeleteOnTermination": "false",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.SnapshotId":          snapID,
+		// An instance store device.
+		"LaunchTemplateData.BlockDeviceMapping.2.DeviceName":  "/dev/sdb",
+		"LaunchTemplateData.BlockDeviceMapping.2.VirtualName": "ephemeral0",
+		// A suppression.
+		"LaunchTemplateData.BlockDeviceMapping.3.DeviceName": "/dev/sdc",
+		"LaunchTemplateData.BlockDeviceMapping.3.NoDevice":   "",
+	})
+	require.NotContains(t, body, "<warning", "every mapping above is valid")
+
+	mappings, describeBody := ltDescribeMappings(t, ts, "readback", "1")
+	require.Len(t, mappings, 3, describeBody)
+
+	ebs := mappings[0]
+	assert.Equal(t, "/dev/sdf", ebs.DeviceName)
+	require.NotNil(t, ebs.Ebs, describeBody)
+	assert.Equal(t, snapID, ebs.Ebs.SnapshotID)
+	assert.Equal(t, 40, ebs.Ebs.VolumeSize)
+	assert.Equal(t, "gp3", ebs.Ebs.VolumeType)
+	assert.Equal(t, 4000, ebs.Ebs.IOPS)
+	assert.Equal(t, 200, ebs.Ebs.Throughput)
+	require.NotNil(t, ebs.Ebs.Encrypted)
+	assert.True(t, *ebs.Ebs.Encrypted)
+	// The three-state DeleteOnTermination reads back as the false it was given, rather
+	// than as absent — which is the distinction the stored raw string exists for.
+	require.NotNil(t, ebs.Ebs.DeleteOnTermination)
+	assert.False(t, *ebs.Ebs.DeleteOnTermination)
+
+	store := mappings[1]
+	assert.Equal(t, "ephemeral0", store.VirtualName)
+	assert.Nil(t, store.Ebs, "an instance store device carries no ebs member")
+	assert.Nil(t, store.NoDevice)
+
+	suppressed := mappings[2]
+	require.NotNil(t, suppressed.NoDevice, "noDevice is present-and-empty, per AWS")
+	assert.Empty(t, *suppressed.NoDevice)
+	assert.Nil(t, suppressed.Ebs)
+}
+
+// TestEC2_LaunchTemplateVersion_SourceVersionCarriesMappingsAndVolumeTags pins the two
+// members SourceVersion inheritance silently dropped.
+//
+// The drop was invisible in both directions: nothing rendered blockDeviceMappingSet, and
+// nothing renders volume tag specifications at all — so the only way to see either was
+// to launch from the derived version and look at the volumes it made. That is what this
+// test does, which is also the observation a consumer would make.
+func TestEC2_LaunchTemplateVersion_SourceVersionCarriesMappingsAndVolumeTags(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	_, body := ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "inheriting",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize": "25",
+		"LaunchTemplateData.TagSpecification.1.ResourceType":     "volume",
+		"LaunchTemplateData.TagSpecification.1.Tag.1.Key":        "Backup",
+		"LaunchTemplateData.TagSpecification.1.Tag.1.Value":      "nightly",
+	})
+	require.NotContains(t, body, "<warning", body)
+
+	v2, _ := ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplateVersion",
+		"LaunchTemplateName":         "inheriting",
+		"SourceVersion":              "1",
+		"LaunchTemplateData.ImageId": "ami-11112222333344445",
+	})
+	require.Equal(t, int64(2), v2.VersionNumber)
+
+	mappings, describeBody := ltDescribeMappings(t, ts, "inheriting", "2")
+	require.Len(t, mappings, 1, "version 2 inherits version 1's mapping: %s", describeBody)
+	require.NotNil(t, mappings[0].Ebs, describeBody)
+	assert.Equal(t, 25, mappings[0].Ebs.VolumeSize)
+
+	// And a launch from version 2 materializes that volume, carrying the inherited
+	// volume tags — the only surface either member is otherwise observable through.
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"LaunchTemplate.LaunchTemplateName": "inheriting",
+		"LaunchTemplate.Version":            "2",
+	})
+	require.Len(t, ids, 1)
+
+	volumes := bdmDescribeVolumes(t, ts, map[string]string{
+		"Filter.1.Name":    "attachment.instance-id",
+		"Filter.1.Value.1": ids[0],
+		"Filter.2.Name":    "attachment.device",
+		"Filter.2.Value.1": "/dev/sdf",
+	})
+	require.Len(t, volumes, 1)
+	assert.Equal(t, 25, volumes[0].Size, "the inherited mapping's size, not the 8 GiB default")
+
+	tagged := bdmDescribeVolumes(t, ts, map[string]string{
+		"Filter.1.Name":    "attachment.instance-id",
+		"Filter.1.Value.1": ids[0],
+		"Filter.2.Name":    "tag:Backup",
+		"Filter.2.Value.1": "nightly",
+	})
+	require.NotEmpty(t, tagged, "the inherited volume tag specification is applied")
+	for _, v := range tagged {
+		assert.NotEqual(t, "", v.VolumeID)
+	}
+}
+
+// TestEC2_LaunchTemplateVersion_NoSourceVersionInheritsNothing guards the asymmetry the
+// overlay fix could have broken: an omitted SourceVersion inherits nothing, so adding
+// mappings to the overlay must not make version 2 pick up version 1's.
+func TestEC2_LaunchTemplateVersion_NoSourceVersionInheritsNothing(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	_, _ = ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "no-inherit",
+		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize": "25",
+	})
+	_, _ = ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplateVersion",
+		"LaunchTemplateName":         "no-inherit",
+		"LaunchTemplateData.ImageId": "ami-11112222333344445",
+	})
+
+	mappings, body := ltDescribeMappings(t, ts, "no-inherit", "2")
+	assert.Empty(t, mappings,
+		"a version naming no SourceVersion holds only what its own request said: %s", body)
+	// The container element itself is still emitted, empty — encoding/xml writes the
+	// parent of an `a>b` path unconditionally, so omitempty on the slice cannot suppress
+	// it. That is what securityGroupIdSet, networkInterfaceSet and tagSpecificationSet
+	// have always done in this same struct, so the new member matches its siblings rather
+	// than being the one that disappears.
+	assert.Contains(t, body, "<blockDeviceMappingSet></blockDeviceMappingSet>")
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -4823,14 +4823,23 @@ func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 	idsKey := "lt_ids:" + ctx.AccountID + "/" + ctx.Region
 	updateStringIndex(goCtx, p.state, ec2Namespace, idsKey, ltID)
 
+	// The warning goes on this outer struct rather than on ec2LaunchTemplateXML, which
+	// ModifyLaunchTemplate and DescribeLaunchTemplates share: neither documents the
+	// member, and AWS's own order is launchTemplate then warning.
 	type response struct {
-		XMLName        xml.Name             `xml:"CreateLaunchTemplateResponse"`
-		XMLNS          string               `xml:"xmlns,attr"`
-		LaunchTemplate ec2LaunchTemplateXML `xml:"launchTemplate"`
+		XMLName        xml.Name                 `xml:"CreateLaunchTemplateResponse"`
+		XMLNS          string                   `xml:"xmlns,attr"`
+		LaunchTemplate ec2LaunchTemplateXML     `xml:"launchTemplate"`
+		Warning        *ec2ValidationWarningXML `xml:"warning,omitempty"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{
 		XMLNS:          "http://ec2.amazonaws.com/doc/2016-11-15/",
 		LaunchTemplate: ec2LaunchTemplateSummary(&lt),
+		// Reported rather than refused: the template is created either way, because
+		// AWS's Errors section lists nothing for an invalid one and its `warning`
+		// member exists for exactly this. See [ec2CollectBlockDeviceMappings].
+		Warning: ec2ValidationWarningFor(
+			ec2CollectBlockDeviceMappings(ltData.BlockDeviceMappings, p.ec2SnapshotResolver(ctx))),
 	})
 }
 


### PR DESCRIPTION
Closes #693.

v0.105.0 taught `RunInstances` to refuse a block device mapping real EC2 rejects and deliberately left `CreateLaunchTemplate` accepting one, because the reference documents a `warning` member of type `ValidationWarning` "for parameters or parameter combinations that are not valid" and lists no errors for the case. Rendering that member is what makes the decision honest rather than a silent swallow: until now the mapping vanished, and the caller learned about it only at launch — from a template it had already shipped to every consumer of that template.

## What changed

**Both create operations render `warning`.** Singular, per the reference (`validationWarnings` appears nowhere in AWS's model or in this repo), holding `errorSet>item` of `{code, message}`. It goes on each operation's function-local response struct rather than on the shared `ec2LaunchTemplateXML`, which `ModifyLaunchTemplate` and `DescribeLaunchTemplates` also render and which must not grow a member they never emit. It is a **pointer** field: `encoding/xml` ignores `omitempty` on a struct value, so a value field would emit `<warning></warning>` on every valid template.

**The warning and the refusal are the same diagnosis, by construction.** `ec2CollectBlockDeviceMappings` is now the primitive and `ec2CheckBlockDeviceMappings` is a three-line wrapper returning `problems[0]`. Traversal order is unchanged, so the refusal refuses with exactly what it refused with before — and the code and message a caller reads from `CreateLaunchTemplate` are byte-identical to what `RunInstances` would have refused with. `TestEC2_CreateLaunchTemplate_WarnsAboutAnInvalidMapping` asserts that equality against the live refusal rather than against a literal, so the two cannot drift.

Where the warning differs it is wider: it reports **every** problem, because AWS documents one entry "for each issue that's found". A first-error function called once can only ever produce one entry, which is why the collector had to be the primitive and not the wrapper.

**Two adjacent bugs the feature is hollow without**, each its own `### Fixed` line:

- Nothing rendered a template's block device mappings. `DescribeLaunchTemplateVersions` is the only operation that returns a template's data at all, so v0.104.0's parse-and-store was write-only and a warned caller could not read back the mapping the warning was about. `blockDeviceMappingSet>item` now carries `deviceName`, `virtualName`, `noDevice` and the full `ebs` structure. `noDevice` is a `*string` so it renders as the present-and-empty element AWS documents ("specify an empty string"), and `deleteOnTermination`/`encrypted` are `*bool` so an unstated value stays absent instead of becoming `false`.
- `ec2OverlayTemplateData` copied every member except `BlockDeviceMappings` and `VolumeTagSpecifications`, so a `SourceVersion`-derived version silently lost both. With nothing rendering either, the only way to see the loss was to launch from the derived version and inspect its volumes — which is how a consumer would find it in a deployed template, not in a test.

## Deviation from the plan, deliberate

The plan said to restructure the per-mapping validator to return `[]ec2ValidationError`. It returns **`[]*AWSError`** instead, converted to the wire shape by `ec2ValidationWarningFor` at the response boundary. The reason is the equality above: with one problem type there is exactly one place codes and messages are written, and the refusal and the warning cannot describe the same mapping differently. A second warning-shaped type would have to be kept in step with the first by hand, and nothing would fail if it drifted.

## Fail-before, recorded at `main` (`ae23038`)

The two test files copied into a throwaway worktree at `main`, so this is the fix's absence and nothing else:

```
--- FAIL: TestEC2_CreateLaunchTemplate_WarnsAboutAnInvalidMapping (0.00s)
        Error:      Expected value not to be nil.
        Messages:   an invalid mapping is reported through warning: <?xml version="1.0" ...
                    <CreateLaunchTemplateResponse ...><launchTemplate><launchTemplateId>lt-28f0072db7ad455e</launchTemplateId><launchTemplateName>warned</launchTemplateName>...<tagSet></tagSet></launchTemplate></CreateLaunchTemplateResponse>
--- FAIL: TestEC2_CreateLaunchTemplate_WarnsAboutEveryProblem (0.00s)
        Error:      Expected value not to be nil.
--- FAIL: TestEC2_CreateLaunchTemplate_WarnsAboutAnUnknownSnapshot (0.00s)
        Error:      Expected value not to be nil.
--- FAIL: TestEC2_CreateLaunchTemplateVersion_WarnsAboutAnInvalidMapping (0.00s)
        Error:      Expected value not to be nil.
        Messages:   version 1 carries the mapping and the warning
--- FAIL: TestEC2_LaunchTemplateVersion_ReadsBackItsBlockDeviceMappings (0.00s)
        Error:      "[]" should have 3 item(s), but has 0
--- FAIL: TestEC2_LaunchTemplateVersion_SourceVersionCarriesMappingsAndVolumeTags (0.00s)
        Error:      "[]" should have 1 item(s), but has 0
        Messages:   version 2 inherits version 1's mapping: ...<launchTemplateData><imageId>ami-11112222333344445</imageId><securityGroupIdSet></securityGroupIdSet><networkInterfaceSet></networkInterfaceSet><tagSpecificationSet></tagSpecificationSet></launchTemplateData>...
--- FAIL: TestEC2_LaunchTemplateVersion_NoSourceVersionInheritsNothing (0.00s)
        Error:      ... does not contain "<blockDeviceMappingSet></blockDeviceMappingSet>"
```

Note the sixth failure's body: version 2 carries **no** mapping element and no tag specification, which is the silent drop rather than an unrendered member.

One assertion in the new file was written wrong and corrected rather than driven into the code: an empty `blockDeviceMappingSet` still emits its container element, because `encoding/xml` writes the parent of an `a>b` path unconditionally and `omitempty` on the slice cannot suppress it. Its three siblings in the same struct (`securityGroupIdSet`, `networkInterfaceSet`, `tagSpecificationSet`) have always done the same, so matching them is right and being the one member that disappears would not be.

## Tests

New `emulator/ec2_launchtemplate_warning_test.go`: the warning on both operations; the code and message equal to the live `RunInstances` refusal; two problems producing two `errorSet>item`s; a snapshot rule (#689's `InvalidSnapshot.NotFound`) reported through the same member, since the two rule sets arrived a PR apart and share one collector; a valid template and a template with no mapping at all carrying **no `<warning`** anywhere in the raw body; a `SourceVersion`-inherited mapping warned about; the full `ebs` round trip including the three-state `deleteOnTermination`, an instance store device and a suppression; the inherited mapping and volume tags observed through a launch from the derived version; and the preserved asymmetry that a version naming no `SourceVersion` inherits nothing.

`TestEC2_BlockDeviceMapping_TemplateMappingRefusedAtLaunch`'s doc comment said rendering the element was a follow-up. It now states what that test still pins — that the warning did not become a refusal: the template is created and the launch is still the operation that fails.

## Provenance

That an invalid *block device mapping* lands in `warning` rather than in a 400 is substrate's reading. AWS documents the member's purpose but never says which validations use it, and neither operation's Errors section lists anything about block device mappings — so a 400 there would be substrate's invention in the other direction. `warning`/`ValidationWarning`/`ValidationError`, `ErrorSet.N` as ValidationWarning's sole member, `BlockDeviceMappingSet.N` → `blockDeviceMappingSet>item`, `noDevice` being a String ("specify an empty string") and `LaunchTemplateEbsBlockDevice`'s ten members were each verified against the API reference. The codes are documented; the messages are substrate's own, so dispatch on the code.

## Verification

`gofmt -l` clean, `go build`, `go vet`, `golangci-lint run ./...` → `0 issues`, `make test` (race) green, `make docs-reference docs-reference-check docs-versions` clean, `npm --prefix docs run build` green, `go vet -C test/e2e ./... && go test -C test/e2e ./...` green.
