### PR TITLE
feat(iam): evaluate ForAllValues/ForAnyValue, and populate aws:TagKeys (#690)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`aws:TagKeys` is populated on every request that carries tags, and IAM's request context
+  can hold a multivalued key** (#690). `EvaluationRequest` gains
+  `MultiContext map[string][]string` beside `Context`, and `AuthController.CheckAccess` fills
+  `aws:TagKeys` with the tag keys the request asked for — the key AWS documents as defining
+  "what tag-keys are allowed in a request", and the one nearly every tag-scoped policy in the
+  wild is written against. It was populated nowhere before, so a policy naming it could not be
+  satisfied by any request.
+
+  It is **derived from the `aws:RequestTag/<key>` entries substrate already read out of the
+  request**, not gathered a second time per service. That is what keeps the two in step: the
+  keys of `aws:RequestTag/*` *are* the request's tag keys, so all seven service arms — EC2's
+  `TagSpecification.N.Tag.M.Key` and a direct `CreateTags`/`DeleteTags`' `Tag.N.Key`, IAM's
+  and Organizations' `Tags` lists, Lambda's `Tags` map, Config's `Tags`, and S3's
+  `x-amz-tagging` header — are covered at once, and an arm added later populates the key
+  without knowing it exists.
+
+  **The value is sorted.** Three of those arms iterate a Go map, whose order is randomized per
+  run, and a `ForAllValues` decision quantifies over this list — an unsorted value would make
+  a *denial* depend on map iteration order, which an event log that must replay identically
+  cannot tolerate.
+
+  Two maps rather than one `map[string][]string`: IAM itself draws the line between
+  single-valued and multivalued keys, documents that "multivalued context keys require a
+  condition set operator", and says outright not to use a set operator on a single-valued key.
+  Keeping them apart means every unqualified operator's lookup is byte-identical to what it
+  was before — so adding a multivalued key cannot change a decision that never named one.
+
+  The IAM control-plane authorization path (`iam:` actions decided inside the IAM plugin)
+  deliberately passes neither map, as it did before: nothing there reads the request for tags,
+  so a condition on `aws:RequestTag` or `aws:TagKeys` still cannot be satisfied through that
+  door. Worth knowing before writing one against an `iam:` action.
+
 - **`CreateLaunchTemplate` and `CreateLaunchTemplateVersion` report an invalid block device
   mapping through their documented `warning` member** (#693). v0.105.0 taught `RunInstances`
   to refuse a mapping real EC2 rejects and deliberately left both create operations
@@ -155,6 +187,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spelling callers were using for it by accident.
 
 ### Changed
+- **A policy statement using `ForAllValues:` or `ForAnyValue:` is now evaluated instead of
+  discarded** (#690). Neither qualifier was parsed anywhere in substrate, so
+  `"ForAllValues:StringEquals"` reached the operator switch whole, matched none of the nine
+  operators it knows, and fell through to its deny-by-default. The statement was thrown away
+  before its condition key was ever looked at.
+
+  **This is a behaviour change in both directions, and the issue that reported it had the
+  direction backwards.** It read as an unpopulated `aws:TagKeys` making such a statement
+  *allow*; the truth is worse. An `Allow` so written was a false **deny** — including AWS's own
+  documented `ec2:DeleteTags` example policies, none of which permitted anything — and a `Deny`
+  so written was silently **inert**, so a guardrail written the way AWS recommends refused
+  nothing at all. Both now behave as documented, which means a previously-ineffective `Deny`
+  will start firing and a previously-denied `Allow` may start permitting.
+
+  The semantics are AWS's, verbatim. `ForAllValues` "returns `true` if every context key value
+  in the request matches a context key value in the policy. It also returns `true` if there are
+  no context keys in the request" — so an absent or valueless key satisfies it, which is why
+  AWS's **Important** note says to always pair it with `"Null": {"<key>": "false"}`, and why all
+  four of its `aws:TagKeys` examples do. `ForAnyValue` "returns `true` if any one of the context
+  key values in the request matches any one of the context key values in the policy. For no
+  matching context key or if the key does not exist, the condition returns `false`."
+
+  An **unrecognized** qualifier still does not match — `ForSomeValues:StringEquals`, or a
+  lowercase `forallvalues:`, denies rather than being treated as unqualified. AWS defines
+  exactly two, so anything else is a policy substrate cannot evaluate, and refusing to guess is
+  the same deny-by-default an unknown operator already gets. **Provenance:** the absent-key
+  rules and the `Null: false` pairing are documented verbatim; treating an unrecognized
+  qualifier as a non-match is substrate's own choice, consistent with its existing rule.
+
+  Two bundled managed policies contain a real set-qualified statement —
+  `AmazonRDSFullAccess` and `AmazonRDSReadOnlyAccess` gate
+  `devops-guru:SearchInsights`/`ListAnomaliesForInsight` on
+  `ForAllValues:StringEquals` over `devops-guru:ServiceNames`, paired with `Null: false`. They
+  still withhold the grant from a request that names no service names, which is the `Null`
+  arm doing its job, and now make it when one names `RDS`. That is asserted, not assumed: a
+  fix that quietly widened two bundled policies would be the change escaping its own blast
+  radius.
+
 - **An unrecognized EC2 filter name is refused, on every operation that parses one** (#687).
   `Filter.N.Name` outside the set that operation's own API reference documents now answers
   `InvalidParameterValue` / `The filter "<name>" is not valid for this request`, HTTP 400.
@@ -202,6 +272,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can be a single rule.
 
 ### Fixed
+- **The `Null` operator no longer reads a multivalued condition key as null** (#690). It
+  compares a single string, so a key carried only in the new `MultiContext` — which is where
+  `aws:TagKeys` lives — read as absent. Without this, AWS's own recommended pairing of
+  `ForAllValues` with `"Null": {"aws:TagKeys": "false"}` would still have denied every request
+  it was written to allow, and the set-qualifier fix above would have looked like it worked
+  while changing nothing for a real policy. `Null` now falls back to the multivalued map, so a
+  request that carries the key is not null by either reading.
+
+- **The policy simulator keeps every value of a multivalued `ContextEntries` member** (#690).
+  `ContextKeyValues.member.N` is a value *list* by construction and
+  `SimulateCustomPolicy`/`SimulatePrincipalPolicy` kept only the first, so a caller simulating
+  `aws:TagKeys` was answered against a policy that had seen one of its values — an answer that
+  could differ from what enforcement would decide, which is the one thing a simulator must not
+  produce. All values are now evaluated, and a key supplied only as a multivalued entry is no
+  longer reported in `MissingContextValues`: naming a key that in fact decided the call would
+  make a simulation contradict the enforcement it exists to predict.
+
 - **A launch-template version derived with `SourceVersion` no longer silently drops its block
   device mappings and volume tags** (#693). `SourceVersion` is documented as the way to base a
   new version on an existing one — "The new version inherits the same launch parameters as the

--- a/docs/services.md
+++ b/docs/services.md
@@ -908,6 +908,68 @@ answer is worse than a missing one:
 A consumer whose preflight depends on an SCP boundary cannot get that answer here, and
 should not read an `allowed` as covering it.
 
+### Multivalued condition keys: `ForAllValues` and `ForAnyValue`
+
+A condition key is either **single-valued** — at most one value in the request context —
+or **multivalued**. AWS's rule is that a multivalued key "requires a condition set
+operator", written as a prefix on the operator itself, and that a set operator must *not*
+be used on a single-valued key. Substrate mirrors that split: the evaluator carries two
+context maps, and only the multivalued one is quantified over.
+
+| In the policy | Substrate's answer |
+|---|---|
+| `StringEquals` and the other eight operators, unqualified | Compares the single-valued context. Unchanged by anything in this section |
+| `ForAllValues:<operator>` | True when **every** value the request carries satisfies the operator — and **true when the key is absent or carries no values** |
+| `ForAnyValue:<operator>` | True when **at least one** value satisfies it; **false when the key is absent or carries no values** |
+| Anything else in that position | Does not match. `ForSomeValues:StringEquals`, or a lowercase `forallvalues:`, denies rather than being read as unqualified |
+
+Both absent-key rules are AWS's, quoted: `ForAllValues` "also returns `true` if there are no
+context keys in the request", and for `ForAnyValue`, "for no matching context key or if the
+key does not exist, the condition returns `false`".
+
+**Pair `ForAllValues` with `Null`.** The vacuous truth above means a `ForAllValues` `Allow`
+permits a request that names nothing at all, which is why AWS's own note says to "always
+include the `Null` condition operator in your policy with a `false` value", and why all four
+of its `aws:TagKeys` examples do:
+
+```json
+"Condition": {
+  "ForAllValues:StringEquals": {"aws:TagKeys": ["Department", "CostCenter"]},
+  "Null": {"aws:TagKeys": "false"}
+}
+```
+
+Seen from the `Deny` side the same vacuity bites the other way — a `ForAllValues` `Deny`
+fires on the request that carries no keys — so a guardrail is better written with
+`ForAnyValue`.
+
+Treating an unrecognized qualifier as a non-match is substrate's own choice, consistent with
+the deny-by-default it already applies to an unrecognized operator; everything else here is
+documented behaviour.
+
+#### Which keys are multivalued
+
+| Key | Populated from |
+|---|---|
+| `aws:TagKeys` | The tag keys the request asks to apply, on every service whose tags substrate reads: EC2's `TagSpecification.N.Tag.M.Key` and a direct `CreateTags`/`DeleteTags`' `Tag.N.Key`, IAM's and Organizations' `Tags` lists, Lambda's `Tags` map, Config's `Tags`, and S3's `x-amz-tagging` header |
+| Any key a simulation supplies | `ContextEntries.member.N.ContextKeyValues.member.M` — every value, not just the first |
+
+`aws:TagKeys` is derived from the `aws:RequestTag/<key>` entries substrate already read out
+of the request rather than gathered separately, so the two cannot disagree about what the
+request asked for, and its value is **sorted** — a `ForAllValues` denial that depended on Go
+map iteration order could not replay from the event log.
+
+Everything else substrate populates is single-valued: `aws:RequestTag/<key>` and
+`aws:ResourceTag/<key>` on an authorized request, `sts:ExternalId` when a role is assumed,
+and `aws:PrincipalArn` / `aws:ResourceAccount` in a simulation. A set qualifier on one of
+those is evaluated over a one-element set — which is the thing AWS warns against writing,
+not something substrate refuses.
+
+**One authorization path populates neither map**: `iam:` actions decided inside the IAM
+plugin. Nothing there reads the request for tags, so a condition on `aws:RequestTag` or
+`aws:TagKeys` cannot be satisfied through that door — worth knowing before writing one
+against an IAM action.
+
 ### AWS managed policies are a seeded catalog
 
 Substrate bundles **52** AWS managed policies, not the ~1,200 AWS publishes. Each carries
@@ -3534,11 +3596,14 @@ resource the policy denies tags **none** of them — the same all-or-nothing sha
 [reserved-key](#reserved-tag-keys) and [tag-limit](#the-50-tag-per-resource-limit)
 checks already have.
 
+`aws:TagKeys` is populated too — the sorted list of keys the request names — so the
+`ForAllValues:StringEquals` form several of AWS's `DeleteTags` examples are written in now
+evaluates. See [multivalued condition
+keys](#multivalued-condition-keys-forallvalues-and-foranyvalue) for the set-qualifier rules
+those examples depend on, including why AWS pairs them with `Null`.
+
 Not covered:
 
-- **`aws:TagKeys`**, which substrate populates nowhere, so the
-  `ForAllValues:StringEquals` form several of AWS's `DeleteTags` examples use cannot be
-  satisfied.
 - **The second authorization pass** AWS performs on `ec2:CreateTags` when a
   resource-creating action carries tags, keyed on `ec2:CreateAction`. Tag-on-create is
   authorized here as the creating action alone.

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 )
 
@@ -83,6 +84,20 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	requestTags := make(map[string]string)
 	addRequestTags(requestTags, req)
 
+	// aws:TagKeys is the same reading of the same request, so it is derived from the
+	// map above rather than gathered a second time per service. That is what keeps the
+	// two in step: every arm of addRequestTags records one aws:RequestTag/<key> entry
+	// per tag key in the request, so the keys *are* the request's tag keys, and a
+	// service arm added later populates both without knowing this key exists.
+	//
+	// It is request-level, like the tags it comes from, so one map serves every
+	// resource in the loop below — there is nothing per-resource in it to keep apart,
+	// which is the concern the per-resource condCtx exists for.
+	requestMulti := make(map[string][]string, 1)
+	if keys := requestTagKeys(requestTags); len(keys) > 0 {
+		requestMulti["aws:TagKeys"] = keys
+	}
+
 	// Every resource the request names must be allowed. A request naming several —
 	// organizations:MoveAccount and ec2:RunInstances — is denied unless the caller's
 	// policies admit all of them, which is how AWS evaluates a statement against
@@ -100,10 +115,11 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		}
 
 		result := Evaluate(docs, EvaluationRequest{
-			Principal: reqCtx.Principal.ARN,
-			Action:    action,
-			Resource:  res.ARN,
-			Context:   condCtx,
+			Principal:    reqCtx.Principal.ARN,
+			Action:       action,
+			Resource:     res.ARN,
+			Context:      condCtx,
+			MultiContext: requestMulti,
 		})
 		if result.Decision != DecisionAllow {
 			return &AWSError{
@@ -116,10 +132,11 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 
 		if boundary != nil {
 			boundaryResult := Evaluate([]PolicyDocument{*boundary}, EvaluationRequest{
-				Principal: reqCtx.Principal.ARN,
-				Action:    action,
-				Resource:  res.ARN,
-				Context:   condCtx,
+				Principal:    reqCtx.Principal.ARN,
+				Action:       action,
+				Resource:     res.ARN,
+				Context:      condCtx,
+				MultiContext: requestMulti,
 			})
 			if boundaryResult.Decision != DecisionAllow {
 				return &AWSError{
@@ -946,6 +963,34 @@ func addRequestTags(condCtx map[string]string, req *AWSRequest) {
 			}
 		}
 	}
+}
+
+// requestTagKeys returns the tag keys a request context carries, in sorted order —
+// the value of AWS's aws:TagKeys condition key.
+//
+// It reads the aws:RequestTag/ entries [addRequestTags] just produced rather than
+// re-walking the request, so the two can never disagree about what the request asked
+// for, and a service arm added to that function populates this key for free. AWS
+// documents the pair the same way: aws:RequestTag/${TagKey} is "the tag key-value pair
+// in a request" while aws:TagKeys "defines what tag-keys are allowed in a request but
+// does not include the tag-key values".
+//
+// **The sort is load-bearing.** Three of addRequestTags' arms iterate a Go map, whose
+// order is randomized per run, and a ForAllValues decision quantifies over this slice.
+// An unsorted value would make a *denial* depend on map iteration order — the one
+// thing an event log that must replay identically cannot tolerate. It also keeps the
+// recorded context byte-stable, so two runs of the same request produce the same
+// event.
+func requestTagKeys(condCtx map[string]string) []string {
+	const prefix = "aws:RequestTag/"
+	keys := make([]string, 0, len(condCtx))
+	for k := range condCtx {
+		if after, ok := strings.CutPrefix(k, prefix); ok && after != "" {
+			keys = append(keys, after)
+		}
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // iamTagsToMap converts []IAMTag to a map[string]string.

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -746,3 +746,23 @@ func LaunchVolumesForTest(instanceID, availabilityZone string, mappings []EC2Blo
 	}
 	return ec2LaunchVolumesFor(inst, mappings, nil, "2026-01-01T00:00:00Z")
 }
+
+// RequestTagKeysForTest wraps requestTagKeys for external tests.
+//
+// The sorted order it produces cannot be observed through any API surface: every
+// operator that reads aws:TagKeys is set-semantic, so reordering the slice changes no
+// decision. What it does change is whether the same request produces the same
+// recorded context twice, since three of addRequestTags' arms iterate a Go map — so
+// this is the only place the ordering can be asserted at all, the same reason
+// S3PersistedContentEncodingForTest exists (#690).
+func RequestTagKeysForTest(condCtx map[string]string) []string { return requestTagKeys(condCtx) }
+
+// AddRequestTagsForTest wraps addRequestTags, returning the aws:RequestTag entries it
+// reads out of a request together with the aws:TagKeys value derived from them. It
+// pairs the two halves the way CheckAccess does, so a test can assert that a service
+// arm feeds both without going through a whole authorized request.
+func AddRequestTagsForTest(req *AWSRequest) (map[string]string, []string) {
+	tags := make(map[string]string)
+	addRequestTags(tags, req)
+	return tags, requestTagKeys(tags)
+}

--- a/emulator/iam_eval.go
+++ b/emulator/iam_eval.go
@@ -119,7 +119,29 @@ type EvaluationRequest struct {
 	Resource string
 
 	// Context provides condition key values for condition evaluation.
+	//
+	// It holds AWS's *single-valued* keys: "Single-valued condition context keys have
+	// at most one value in the request context." Every operator without a set
+	// qualifier reads this map and nothing else.
 	Context map[string]string
+
+	// MultiContext provides the values of AWS's multivalued condition keys —
+	// aws:TagKeys and its kind, which "can have multiple values in the request
+	// context".
+	//
+	// It is deliberately a second map rather than a widening of Context to
+	// map[string][]string, because IAM itself draws the same line: a key is
+	// single-valued or multivalued by its nature, "Multivalued context keys require a
+	// condition set operator", and AWS says outright not to use a set operator on a
+	// single-valued key. Two maps make that distinction representable, and they keep
+	// every unqualified operator's lookup byte-identical to what it was before
+	// set qualifiers existed (#690) — so adding a multivalued key cannot change a
+	// decision that never named one.
+	//
+	// A key may appear in both maps; nothing here requires it not to. Lookups prefer
+	// MultiContext for a set-qualified operator and Context for an unqualified one,
+	// falling back to the other, so a producer that populates only one still works.
+	MultiContext map[string][]string
 }
 
 // Evaluate applies the AWS IAM policy evaluation algorithm across all provided
@@ -167,7 +189,7 @@ func EvaluateSourced(documents []SourcedPolicyDocument, req EvaluationRequest) E
 				// condition on an unset key is the reportable case: the answer would
 				// change given a value.
 				if actionResourcePrincipalMatch(stmt, req) {
-					for _, key := range unsetConditionKeys(stmt.Condition, req.Context) {
+					for _, key := range unsetConditionKeys(stmt.Condition, req.Context, req.MultiContext) {
 						missing[key] = struct{}{}
 					}
 				}
@@ -245,19 +267,32 @@ func actionResourcePrincipalMatch(stmt PolicyStatement, req EvaluationRequest) b
 		resourceMatches(stmt, req.Resource)
 }
 
-// unsetConditionKeys returns the condition keys stmt tests that ctx has no value
-// for.
+// unsetConditionKeys returns the condition keys stmt tests that the request context
+// has no value for.
 //
 // A key present with an empty value is *set*: the Null operator exists precisely to
 // test for absence, and treating "" as missing would report every Null condition as
 // an incomplete simulation.
-func unsetConditionKeys(conditions map[string]map[string]StringOrSlice, ctx map[string]string) []string {
+//
+// Both maps are consulted, for the same reason [condContextValue] consults both: a
+// multivalued key like aws:TagKeys lives in MultiContext, and reporting it as a
+// missing context value while the evaluator was in fact evaluating it would make a
+// simulation contradict the enforcement it exists to predict (#690).
+func unsetConditionKeys(
+	conditions map[string]map[string]StringOrSlice,
+	ctx map[string]string,
+	multiCtx map[string][]string,
+) []string {
 	var out []string
 	for _, keyValues := range conditions {
 		for condKey := range keyValues {
-			if _, ok := ctx[condKey]; !ok {
-				out = append(out, condKey)
+			if _, ok := ctx[condKey]; ok {
+				continue
 			}
+			if _, ok := multiCtx[condKey]; ok {
+				continue
+			}
+			out = append(out, condKey)
 		}
 	}
 	return out
@@ -275,7 +310,7 @@ func statementMatches(stmt PolicyStatement, req EvaluationRequest) bool {
 	if !resourceMatches(stmt, req.Resource) {
 		return false
 	}
-	if !conditionMatches(stmt.Condition, req.Context) {
+	if !conditionMatches(stmt.Condition, req.Context, req.MultiContext) {
 		return false
 	}
 	return true
@@ -424,19 +459,144 @@ func resourceMatches(stmt PolicyStatement, resource string) bool {
 	return false
 }
 
-// conditionMatches evaluates all condition operators against ctx.
-// Multiple operators use AND semantics. Multiple keys within one operator
-// use AND semantics. Multiple values for one key use OR semantics.
-func conditionMatches(conditions map[string]map[string]StringOrSlice, ctx map[string]string) bool {
+// Condition set qualifiers, the prefixes AWS puts in front of a condition operator
+// to compare a multivalued request key against the policy's value list.
+//
+// "To compare your condition context key against a request context key with multiple
+// values, you must use the ForAllValues or ForAnyValue set operators".
+const (
+	// condForAllValues requires every request value to match. AWS: "The condition
+	// returns true if every context key value in the request matches a context key
+	// value in the policy. It also returns true if there are no context keys in the
+	// request".
+	condForAllValues = "ForAllValues"
+
+	// condForAnyValue requires at least one request value to match. AWS: "The
+	// condition returns true if any one of the context key values in the request
+	// matches any one of the context key values in the policy. For no matching
+	// context key or if the key does not exist, the condition returns false".
+	condForAnyValue = "ForAnyValue"
+)
+
+// splitConditionOperator separates a set qualifier from the operator it qualifies.
+//
+// "ForAllValues:StringEquals" is one JSON key in the policy, so the qualifier is not
+// a separate element to read — it has to be parsed out of the operator name. An
+// operator with no colon has no qualifier, which is every operator substrate
+// evaluated before #690.
+func splitConditionOperator(operator string) (qualifier, base string) {
+	if idx := strings.Index(operator, ":"); idx >= 0 {
+		return operator[:idx], operator[idx+1:]
+	}
+	return "", operator
+}
+
+// conditionMatches evaluates all condition operators against the request context.
+//
+// Multiple operators use AND semantics. Multiple keys within one operator use AND
+// semantics. Multiple values for one key use OR semantics — except under a set
+// qualifier, where the request's own values are what is quantified over.
+//
+// An operator carrying an *unrecognized* qualifier does not match, which preserves
+// the deny-by-default [evaluateConditionKey] applies to an unknown operator. That is
+// the rule this function used to reach for ForAllValues and ForAnyValue themselves:
+// the whole operator name was unknown, so every statement using one was discarded
+// before its key was looked at, making an Allow a false deny and a Deny silently
+// inert (#690).
+func conditionMatches(
+	conditions map[string]map[string]StringOrSlice,
+	ctx map[string]string,
+	multiCtx map[string][]string,
+) bool {
 	for operator, keyValues := range conditions {
+		qualifier, base := splitConditionOperator(operator)
 		for condKey, condValues := range keyValues {
-			ctxVal := ctx[condKey]
-			if !evaluateConditionKey(operator, ctxVal, condValues) {
+			if !conditionKeyMatches(qualifier, base, condKey, condValues, ctx, multiCtx) {
 				return false
 			}
 		}
 	}
 	return true
+}
+
+// conditionKeyMatches evaluates one key of one operator, applying the set qualifier.
+func conditionKeyMatches(
+	qualifier, base, condKey string,
+	condValues StringOrSlice,
+	ctx map[string]string,
+	multiCtx map[string][]string,
+) bool {
+	switch qualifier {
+	case "":
+		return evaluateConditionKey(base, condContextValue(condKey, ctx, multiCtx), condValues)
+
+	case condForAllValues:
+		// Absent or empty is a match, per AWS — which is why AWS's own Important note
+		// says to pair ForAllValues with `"Null": {"key": "false"}` on an Allow, and why
+		// every one of its aws:TagKeys examples does.
+		for _, reqVal := range condRequestValues(condKey, ctx, multiCtx) {
+			if !evaluateConditionKey(base, reqVal, condValues) {
+				return false
+			}
+		}
+		return true
+
+	case condForAnyValue:
+		for _, reqVal := range condRequestValues(condKey, ctx, multiCtx) {
+			if evaluateConditionKey(base, reqVal, condValues) {
+				return true
+			}
+		}
+		// Absent, empty, or nothing matched: all three are false.
+		return false
+	}
+
+	return false
+}
+
+// condContextValue resolves the single value an unqualified operator compares
+// against.
+//
+// Context is consulted first, so a key both maps carry reads exactly as it did before
+// MultiContext existed. The MultiContext fallback is what makes the Null operator
+// honest about a multivalued key: without it a request carrying aws:TagKeys and no
+// aws:TagKeys entry in Context would read as null, and AWS's recommended
+// ForAllValues + `Null: false` pattern would deny every request it was written to
+// allow (#690).
+//
+// Only the first value can be reported — the caller compares a single string — which
+// is why AWS says not to use a single-valued operator on a multivalued key. Substrate
+// answers with the first value rather than with nothing, because for Null (the reason
+// this fallback exists) any value at all is the whole of what is being asked.
+func condContextValue(condKey string, ctx map[string]string, multiCtx map[string][]string) string {
+	if val, ok := ctx[condKey]; ok {
+		return val
+	}
+	if vals := multiCtx[condKey]; len(vals) > 0 {
+		return vals[0]
+	}
+	return ""
+}
+
+// condRequestValues resolves the set a set-qualified operator quantifies over.
+//
+// MultiContext is consulted first here, since a set qualifier is a statement that the
+// key is multivalued. A key present only in Context degrades to a one-element set
+// rather than to nothing: AWS's rule is about how many values the *request context*
+// holds, and a producer that recorded one value in the single-valued map has still
+// told substrate the request carried that value.
+//
+// An absent key yields no values, and the two qualifiers disagree about what that
+// means — true for ForAllValues, false for ForAnyValue — so the emptiness is returned
+// rather than resolved here.
+func condRequestValues(condKey string, ctx map[string]string, multiCtx map[string][]string) []string {
+	if vals, ok := multiCtx[condKey]; ok {
+		return vals
+	}
+	if val, ok := ctx[condKey]; ok {
+		return []string{val}
+	}
+	return nil
 }
 
 // evaluateConditionKey evaluates a single condition key against the context value.

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -1601,6 +1601,11 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 		}
 	}
 
+	// The context is deliberately empty, and MultiContext is left nil for the same
+	// reason: this path authorizes an IAM control-plane call, and nothing here reads the
+	// request for tags. A policy conditioned on aws:RequestTag or aws:TagKeys therefore
+	// cannot be satisfied through this door even though [CheckAccess] populates both —
+	// which is worth knowing before writing a condition against an iam: action (#690).
 	result := Evaluate(docs, EvaluationRequest{
 		Principal: reqCtx.Principal.ARN,
 		Action:    action,

--- a/emulator/iam_set_qualifiers_test.go
+++ b/emulator/iam_set_qualifiers_test.go
@@ -1,0 +1,729 @@
+package emulator_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The ForAllValues/ForAnyValue set qualifiers, the multivalued request context they
+// quantify over, and aws:TagKeys — the key every tag-scoped AWS policy in the wild is
+// written against (#690).
+//
+// The issue's premise was inverted, and the correction is what these tests pin. It
+// reported that an unpopulated aws:TagKeys made a ForAllValues:StringEquals statement
+// *allow*. In fact the qualifier was never parsed anywhere in the repo, so
+// "ForAllValues:StringEquals" reached evaluateConditionKey whole, matched none of its
+// nine operators, and fell through to its deny-by-default. Every statement carrying a
+// set qualifier was therefore discarded before its key was looked at — which cuts both
+// ways and is worse than the issue said: an Allow was a false *deny*, and a Deny was
+// silently *inert*. Populating aws:TagKeys alone would have changed nothing.
+//
+// The policies below are AWS's own, from the "Creating a condition with multiple keys
+// or values" and "Single-valued vs. multivalued condition keys" pages, so the expected
+// decisions are AWS's documented ones rather than substrate's inference.
+
+const (
+	// setQualDeleteTags is the action AWS's two example policies are written against.
+	setQualDeleteTags = "ec2:DeleteTags"
+
+	// setQualResource is a concrete ARN rather than "*", so resourceMatches is doing
+	// real work in every case below and no decision here can turn on the request
+	// resource being a literal star.
+	setQualResource = "arn:aws:ec2:us-east-1:123456789012:instance/i-0aaa1111bbbb2222c"
+)
+
+// setQualPolicy builds a one-statement policy testing aws:TagKeys under the given
+// operator, optionally paired with a Null condition.
+//
+// The value list — Department and CostCenter — is AWS's, so the five-row tables below
+// can be read straight off its documentation.
+func setQualPolicy(effect, operator string, nullValue string) []emulator.PolicyDocument {
+	cond := map[string]map[string]emulator.StringOrSlice{
+		operator: {"aws:TagKeys": {"Department", "CostCenter"}},
+	}
+	if nullValue != "" {
+		cond["Null"] = map[string]emulator.StringOrSlice{"aws:TagKeys": {nullValue}}
+	}
+	return []emulator.PolicyDocument{{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:    effect,
+			Action:    emulator.StringOrSlice{setQualDeleteTags},
+			Resource:  emulator.StringOrSlice{"*"},
+			Condition: cond,
+		}},
+	}}
+}
+
+// setQualDecide evaluates one request whose aws:TagKeys is the given set. A nil set is
+// a request that names no tag keys at all, which is the case the two qualifiers
+// disagree about.
+func setQualDecide(docs []emulator.PolicyDocument, tagKeys []string) emulator.EvaluationResult {
+	req := emulator.EvaluationRequest{
+		Action:   setQualDeleteTags,
+		Resource: setQualResource,
+	}
+	if tagKeys != nil {
+		req.MultiContext = map[string][]string{"aws:TagKeys": tagKeys}
+	}
+	return emulator.Evaluate(docs, req)
+}
+
+// TestIAMEval_ForAllValues_QuantifiesOverTheRequestValues walks AWS's own evaluation
+// table for its ec2:DeleteTags example: the statement allows the call only when *every*
+// tag key the request names is one the policy lists.
+//
+// The absent-key row is the one that matters most, and it is AWS's wording verbatim:
+// "It also returns true if there are no context keys in the request." That vacuous
+// truth is not substrate being lax — it is the documented behavior, and it is exactly
+// why the next test's Null pairing exists.
+func TestIAMEval_ForAllValues_QuantifiesOverTheRequestValues(t *testing.T) {
+	t.Parallel()
+	docs := setQualPolicy(emulator.IAMEffectAllow, "ForAllValues:StringEquals", "")
+
+	for _, tc := range []struct {
+		name    string
+		tagKeys []string
+		want    string
+	}{
+		{
+			name:    "one key from the policy's list",
+			tagKeys: []string{"Department"},
+			want:    emulator.DecisionAllow,
+		},
+		{
+			name:    "every key from the policy's list",
+			tagKeys: []string{"Department", "CostCenter"},
+			want:    emulator.DecisionAllow,
+		},
+		{
+			name:    "a listed key beside an unlisted one",
+			tagKeys: []string{"Department", "Environment"},
+			want:    emulator.DecisionImplicitDeny,
+		},
+		{
+			name:    "only an unlisted key",
+			tagKeys: []string{"Environment"},
+			want:    emulator.DecisionImplicitDeny,
+		},
+		{
+			name:    "the key is present with no values",
+			tagKeys: []string{},
+			want:    emulator.DecisionAllow,
+		},
+		{
+			name:    "the key is absent from the request",
+			tagKeys: nil,
+			want:    emulator.DecisionAllow,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, setQualDecide(docs, tc.tagKeys).Decision)
+		})
+	}
+}
+
+// TestIAMEval_ForAllValues_PairedWithNullFalse pins AWS's recommended form of the same
+// policy, and with it the second half of the fix.
+//
+// AWS's Important note: "You should always include the Null condition operator in your
+// policy with a false value" beside ForAllValues, and all four of its aws:TagKeys
+// examples do. Substrate's Null reads a single string, so before #690 a key carried
+// only in MultiContext read as null and the recommended pattern denied every request it
+// was written to allow — the fix would have looked like it worked while changing nothing
+// for a real policy.
+func TestIAMEval_ForAllValues_PairedWithNullFalse(t *testing.T) {
+	t.Parallel()
+	docs := setQualPolicy(emulator.IAMEffectAllow, "ForAllValues:StringEquals", "false")
+
+	for _, tc := range []struct {
+		name    string
+		tagKeys []string
+		want    string
+	}{
+		{
+			name:    "a listed key satisfies both operators",
+			tagKeys: []string{"Department"},
+			want:    emulator.DecisionAllow,
+		},
+		{
+			name:    "an unlisted key still fails ForAllValues",
+			tagKeys: []string{"Environment"},
+			want:    emulator.DecisionImplicitDeny,
+		},
+		{
+			name: "no tag keys at all is where the pairing earns its place: " +
+				"ForAllValues is vacuously true and Null:false is what refuses",
+			tagKeys: nil,
+			want:    emulator.DecisionImplicitDeny,
+		},
+		{
+			name:    "a present-but-valueless key is null too, having no value to report",
+			tagKeys: []string{},
+			want:    emulator.DecisionImplicitDeny,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, setQualDecide(docs, tc.tagKeys).Decision)
+		})
+	}
+}
+
+// TestIAMEval_ForAnyValue_NeedsOneMatch pins the qualifier whose absent-key answer is
+// the opposite one: "For no matching context key or if the key does not exist, the
+// condition returns false".
+func TestIAMEval_ForAnyValue_NeedsOneMatch(t *testing.T) {
+	t.Parallel()
+	docs := setQualPolicy(emulator.IAMEffectAllow, "ForAnyValue:StringEquals", "")
+
+	for _, tc := range []struct {
+		name    string
+		tagKeys []string
+		want    string
+	}{
+		{
+			name:    "one listed key",
+			tagKeys: []string{"Department"},
+			want:    emulator.DecisionAllow,
+		},
+		{
+			name: "a listed key beside an unlisted one — the row where the two " +
+				"qualifiers disagree",
+			tagKeys: []string{"Department", "Environment"},
+			want:    emulator.DecisionAllow,
+		},
+		{
+			name:    "no listed key",
+			tagKeys: []string{"Environment"},
+			want:    emulator.DecisionImplicitDeny,
+		},
+		{
+			name:    "the key is present with no values",
+			tagKeys: []string{},
+			want:    emulator.DecisionImplicitDeny,
+		},
+		{
+			name:    "the key is absent from the request",
+			tagKeys: nil,
+			want:    emulator.DecisionImplicitDeny,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, setQualDecide(docs, tc.tagKeys).Decision)
+		})
+	}
+}
+
+// TestIAMEval_UnrecognizedQualifierDoesNotMatch pins what is left of the old
+// behavior, deliberately.
+//
+// AWS defines exactly two set qualifiers. Anything else in that position is a policy
+// substrate cannot evaluate, and the safe answer is the one evaluateConditionKey
+// already gives an unknown operator: no match. An Allow so written does not allow —
+// which is what ForAllValues and ForAnyValue themselves used to get.
+func TestIAMEval_UnrecognizedQualifierDoesNotMatch(t *testing.T) {
+	t.Parallel()
+
+	for _, operator := range []string{
+		"ForSomeValues:StringEquals",
+		"forallvalues:StringEquals", // the qualifier is case-sensitive
+		"ForAllValues:ForAnyValue:StringEquals",
+	} {
+		t.Run(operator, func(t *testing.T) {
+			docs := setQualPolicy(emulator.IAMEffectAllow, operator, "")
+			assert.Equal(t, emulator.DecisionImplicitDeny,
+				setQualDecide(docs, []string{"Department"}).Decision,
+				"an unevaluable qualifier must not allow")
+		})
+	}
+}
+
+// TestIAMEval_Null_ConsultsMultiContext isolates the Null fix from the qualifier fix,
+// because the two are independently breakable: Null carries no qualifier at all, so it
+// reads the single-valued map, and a multivalued key lives in the other one.
+func TestIAMEval_Null_ConsultsMultiContext(t *testing.T) {
+	t.Parallel()
+
+	nullPolicy := func(value string) []emulator.PolicyDocument {
+		return []emulator.PolicyDocument{{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{{
+				Effect:   emulator.IAMEffectAllow,
+				Action:   emulator.StringOrSlice{setQualDeleteTags},
+				Resource: emulator.StringOrSlice{"*"},
+				Condition: map[string]map[string]emulator.StringOrSlice{
+					"Null": {"aws:TagKeys": {value}},
+				},
+			}},
+		}}
+	}
+
+	for _, tc := range []struct {
+		name      string
+		nullValue string
+		tagKeys   []string
+		want      string
+	}{
+		{
+			name:      "Null:false is satisfied by a key only MultiContext carries",
+			nullValue: "false",
+			tagKeys:   []string{"Department"},
+			want:      emulator.DecisionAllow,
+		},
+		{
+			name:      "Null:false still refuses a request that names no tag keys",
+			nullValue: "false",
+			tagKeys:   nil,
+			want:      emulator.DecisionImplicitDeny,
+		},
+		{
+			name:      "Null:true refuses a request that does carry them",
+			nullValue: "true",
+			tagKeys:   []string{"Department"},
+			want:      emulator.DecisionImplicitDeny,
+		},
+		{
+			name:      "Null:true is satisfied when the key is absent",
+			nullValue: "true",
+			tagKeys:   nil,
+			want:      emulator.DecisionAllow,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, setQualDecide(nullPolicy(tc.nullValue), tc.tagKeys).Decision)
+		})
+	}
+}
+
+// TestIAMEval_SetQualifiedDenyIsNoLongerInert pins the direction the issue did not
+// name, and the more dangerous of the two: a Deny that never matched refused nothing,
+// so a guardrail written with a set qualifier was decoration.
+//
+// The second case is the vacuous truth of ForAllValues seen from the Deny side, and it
+// is the reason AWS warns against combining the two: a request naming no tag keys
+// satisfies the qualifier, so the Deny fires on the request that asked for least. That
+// is AWS's documented semantics rather than a substrate quirk, and pinning it here is
+// what stops a later reading of "surely an empty set cannot match" from changing it.
+func TestIAMEval_SetQualifiedDenyIsNoLongerInert(t *testing.T) {
+	t.Parallel()
+
+	deny := func(operator string) []emulator.PolicyDocument {
+		docs := []emulator.PolicyDocument{{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{{
+				Effect:   emulator.IAMEffectAllow,
+				Action:   emulator.StringOrSlice{"ec2:*"},
+				Resource: emulator.StringOrSlice{"*"},
+			}},
+		}}
+		return append(docs, setQualPolicy(emulator.IAMEffectDeny, operator, "")...)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		operator string
+		tagKeys  []string
+		want     string
+	}{
+		{
+			name:     "ForAnyValue Deny fires on a key it names",
+			operator: "ForAnyValue:StringEquals",
+			tagKeys:  []string{"Environment", "Department"},
+			want:     emulator.DecisionDeny,
+		},
+		{
+			name:     "ForAnyValue Deny leaves a request naming no such key alone",
+			operator: "ForAnyValue:StringEquals",
+			tagKeys:  []string{"Environment"},
+			want:     emulator.DecisionAllow,
+		},
+		{
+			name:     "ForAllValues Deny fires on a request naming no tag keys at all",
+			operator: "ForAllValues:StringEquals",
+			tagKeys:  nil,
+			want:     emulator.DecisionDeny,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, setQualDecide(deny(tc.operator), tc.tagKeys).Decision)
+		})
+	}
+}
+
+// TestIAMEval_MultiContextKeyIsNotAMissingContextValue pins the simulator's half of the
+// same correction at the evaluator level: a key the evaluation *used* must not be
+// reported as one the request had no value for.
+//
+// MissingContextValues is how SimulatePrincipalPolicy tells a caller "your policy is
+// conditional on something I was not told", so naming a key that in fact decided the
+// call would make a simulation contradict the enforcement it exists to predict.
+func TestIAMEval_MultiContextKeyIsNotAMissingContextValue(t *testing.T) {
+	t.Parallel()
+
+	docs := []emulator.SourcedPolicyDocument{{
+		Document:   setQualPolicy(emulator.IAMEffectAllow, "ForAllValues:StringEquals", "false")[0],
+		SourceID:   "PolicyInputList.1",
+		SourceType: emulator.PolicySourceIAMPolicy,
+	}}
+
+	supplied := emulator.EvaluateSourced(docs, emulator.EvaluationRequest{
+		Action:       setQualDeleteTags,
+		Resource:     setQualResource,
+		MultiContext: map[string][]string{"aws:TagKeys": {"Department"}},
+	})
+	assert.Equal(t, emulator.DecisionAllow, supplied.Decision)
+	assert.Empty(t, supplied.MissingContextValues,
+		"the request carried the key, in the map a set qualifier reads")
+
+	// The case that actually exercises the computation, and the one a caller meets: a
+	// *refusal*. MissingContextValues is only gathered for a statement ruled out by its
+	// condition, so the allow above never reaches that code — and telling a caller "you
+	// gave me no value for aws:TagKeys" when the value it gave is precisely why the call
+	// was refused would send it looking for the wrong bug.
+	refused := emulator.EvaluateSourced(docs, emulator.EvaluationRequest{
+		Action:       setQualDeleteTags,
+		Resource:     setQualResource,
+		MultiContext: map[string][]string{"aws:TagKeys": {"Environment"}},
+	})
+	assert.Equal(t, emulator.DecisionImplicitDeny, refused.Decision)
+	assert.Empty(t, refused.MissingContextValues,
+		"the key was supplied and evaluated; the value is what failed")
+
+	// And the honest opposite: with neither map carrying it, it *is* missing.
+	absent := emulator.EvaluateSourced(docs, emulator.EvaluationRequest{
+		Action:   setQualDeleteTags,
+		Resource: setQualResource,
+	})
+	assert.Equal(t, emulator.DecisionImplicitDeny, absent.Decision)
+	assert.Equal(t, []string{"aws:TagKeys"}, absent.MissingContextValues)
+}
+
+// TestIAMManaged_RDSPoliciesStillWithholdDevOpsGuru is the regression the fix could
+// silently have widened.
+//
+// AmazonRDSFullAccess and AmazonRDSReadOnlyAccess each carry a real
+// ForAllValues:StringEquals on devops-guru:ServiceNames — paired, as AWS recommends,
+// with Null:false. Both statements were discarded before #690 and must *still* not
+// match a request that names no service names, because the Null arm refuses it. Two
+// bundled policies quietly granting devops-guru:SearchInsights would be the fix
+// escaping its own blast radius.
+func TestIAMManaged_RDSPoliciesStillWithholdDevOpsGuru(t *testing.T) {
+	t.Parallel()
+
+	for _, arn := range []string{
+		"arn:aws:iam::aws:policy/AmazonRDSFullAccess",
+		"arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess",
+	} {
+		t.Run(arn, func(t *testing.T) {
+			policy, ok := emulator.GetManagedPolicy(arn)
+			require.True(t, ok, "bundled policy %s", arn)
+			docs := []emulator.PolicyDocument{policy.Document}
+
+			decide := func(serviceNames []string) string {
+				req := emulator.EvaluationRequest{
+					Action:   "devops-guru:SearchInsights",
+					Resource: "*",
+				}
+				if serviceNames != nil {
+					req.MultiContext = map[string][]string{
+						"devops-guru:ServiceNames": serviceNames,
+					}
+				}
+				return emulator.Evaluate(docs, req).Decision
+			}
+
+			assert.Equal(t, emulator.DecisionImplicitDeny, decide(nil),
+				"the key is absent, so Null:false refuses — the statement must not "+
+					"start matching now that its qualifier is parsed")
+			assert.Equal(t, emulator.DecisionImplicitDeny, decide([]string{"EC2"}),
+				"a service name the policy does not list")
+			assert.Equal(t, emulator.DecisionAllow, decide([]string{"RDS"}),
+				"the grant the policy actually makes, reachable for the first time")
+		})
+	}
+}
+
+// TestRequestTagKeys_SortedAndDerivedFromRequestTag pins the shape of the derived key.
+//
+// aws:TagKeys is read out of the aws:RequestTag/ entries addRequestTags already
+// produced rather than gathered a second time per service, so the two cannot disagree
+// about what the request asked for. The sort is what makes the derivation replayable:
+// three of those arms iterate a Go map, whose order is randomized per run, and a
+// ForAllValues denial that depended on map order is the one thing an event log must
+// never record.
+func TestRequestTagKeys_SortedAndDerivedFromRequestTag(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"CostCenter", "Department", "Environment"},
+		emulator.RequestTagKeysForTest(map[string]string{
+			"aws:RequestTag/Environment": "prod",
+			"aws:RequestTag/Department":  "eng",
+			"aws:RequestTag/CostCenter":  "",
+			"aws:PrincipalArn":           "arn:aws:iam::123456789012:user/alice",
+			"aws:RequestTag/":            "a key with no name is not a tag key",
+		}),
+		"sorted, tag keys only, and an empty suffix is not a key")
+
+	assert.Empty(t, emulator.RequestTagKeysForTest(map[string]string{}),
+		"a request carrying no tags carries no tag keys")
+}
+
+// TestAddRequestTags_PopulatesTagKeysForEveryArm pins that the derivation covers every
+// service arm, which is the payoff of deriving it rather than threading a second map
+// through each of them: an arm added later populates aws:TagKeys without knowing the
+// key exists.
+func TestAddRequestTags_PopulatesTagKeysForEveryArm(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		req  emulator.AWSRequest
+		want []string
+	}{
+		{
+			name: "ec2 TagSpecification on a create",
+			req: emulator.AWSRequest{Service: "ec2", Operation: "RunInstances", Params: map[string]string{
+				"TagSpecification.1.ResourceType": "instance",
+				"TagSpecification.1.Tag.1.Key":    "Environment",
+				"TagSpecification.1.Tag.1.Value":  "prod",
+				"TagSpecification.2.ResourceType": "volume",
+				"TagSpecification.2.Tag.1.Key":    "CostCenter",
+				"TagSpecification.2.Tag.1.Value":  "1234",
+			}},
+			want: []string{"CostCenter", "Environment"},
+		},
+		{
+			name: "ec2 Tag.N on a direct CreateTags",
+			req: emulator.AWSRequest{Service: "ec2", Operation: "CreateTags", Params: map[string]string{
+				"ResourceId.1": "i-0aaa1111bbbb2222c",
+				"Tag.1.Key":    "Department",
+				"Tag.1.Value":  "eng",
+				"Tag.2.Key":    "Backup",
+				"Tag.2.Value":  "nightly",
+			}},
+			want: []string{"Backup", "Department"},
+		},
+		{
+			name: "ec2 DeleteTags, whose values are optional",
+			req: emulator.AWSRequest{Service: "ec2", Operation: "DeleteTags", Params: map[string]string{
+				"ResourceId.1": "i-0aaa1111bbbb2222c",
+				"Tag.1.Key":    "Department",
+			}},
+			want: []string{"Department"},
+		},
+		{
+			name: "an iam body's Tags list",
+			req: emulator.AWSRequest{Service: "iam", Operation: "CreateUser",
+				Body: []byte(`{"UserName":"bob","Tags":[{"Key":"Team","Value":"eng"},{"Key":"Cost","Value":"x"}]}`)},
+			want: []string{"Cost", "Team"},
+		},
+		{
+			name: "a lambda body's Tags map",
+			req: emulator.AWSRequest{Service: "lambda", Operation: "CreateFunction",
+				Body: []byte(`{"FunctionName":"f","Tags":{"Owner":"eng","Stage":"dev"}}`)},
+			want: []string{"Owner", "Stage"},
+		},
+		{
+			name: "an organizations body's Tags list",
+			req: emulator.AWSRequest{Service: "organizations", Operation: "TagResource",
+				Body: []byte(`{"ResourceId":"123456789012","Tags":[{"Key":"Zone","Value":"a"},{"Key":"Alpha","Value":"b"}]}`)},
+			want: []string{"Alpha", "Zone"},
+		},
+		{
+			name: "an s3 x-amz-tagging header",
+			req: emulator.AWSRequest{Service: "s3", Operation: "PutObject",
+				Headers: map[string]string{"x-amz-tagging": "Env=prod&Class=archive"}},
+			want: []string{"Class", "Env"},
+		},
+		{
+			name: "a request carrying no tags",
+			req: emulator.AWSRequest{Service: "ec2", Operation: "DescribeInstances",
+				Params: map[string]string{"InstanceId.1": "i-0aaa1111bbbb2222c"}},
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := tc.req
+			tags, keys := emulator.AddRequestTagsForTest(&req)
+			if tc.want == nil {
+				assert.Empty(t, keys)
+				return
+			}
+			assert.Equal(t, tc.want, keys)
+			for _, key := range tc.want {
+				assert.Contains(t, tags, "aws:RequestTag/"+key,
+					"the two halves read the same request")
+			}
+		})
+	}
+}
+
+// TestCheckAccess_TagKeysGatesATaggedRequest is the end-to-end: AWS's documented
+// tag-scoped policy, decided by CheckAccess against a real EC2 request.
+//
+// This is the case the issue was filed about and the one a consumer meets. Before #690
+// every row here denied — the statement was discarded whatever the request carried —
+// which made the policy a false deny rather than the false allow the issue predicted.
+func TestCheckAccess_TagKeysGatesATaggedRequest(t *testing.T) {
+	t.Parallel()
+
+	// The policy AWS writes for "may only apply approved tags": every tag key in the
+	// request must be listed, and the request must carry at least one.
+	doc := emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   emulator.IAMEffectAllow,
+			Action:   emulator.StringOrSlice{"ec2:*"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				"ForAllValues:StringEquals": {"aws:TagKeys": {"Department", "CostCenter"}},
+				"Null":                      {"aws:TagKeys": {"false"}},
+			},
+		}},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		operation string
+		params    map[string]string
+		allowed   bool
+	}{
+		{
+			name:      "a launch tagging with approved keys",
+			operation: "RunInstances",
+			params: map[string]string{
+				"TagSpecification.1.ResourceType": "instance",
+				"TagSpecification.1.Tag.1.Key":    "Department",
+				"TagSpecification.1.Tag.1.Value":  "eng",
+			},
+			allowed: true,
+		},
+		{
+			name:      "a launch tagging with an unapproved key",
+			operation: "RunInstances",
+			params: map[string]string{
+				"TagSpecification.1.ResourceType": "instance",
+				"TagSpecification.1.Tag.1.Key":    "Department",
+				"TagSpecification.1.Tag.1.Value":  "eng",
+				"TagSpecification.1.Tag.2.Key":    "Environment",
+				"TagSpecification.1.Tag.2.Value":  "prod",
+			},
+			allowed: false,
+		},
+		{
+			name:      "an untagged launch, which Null:false refuses",
+			operation: "RunInstances",
+			params:    map[string]string{},
+			allowed:   false,
+		},
+		{
+			name:      "a direct CreateTags naming approved keys",
+			operation: "CreateTags",
+			params: map[string]string{
+				"ResourceId.1": ec2TagAuthzInstance,
+				"Tag.1.Key":    "CostCenter",
+				"Tag.1.Value":  "1234",
+			},
+			allowed: true,
+		},
+		{
+			name:      "a direct CreateTags naming an unapproved key",
+			operation: "CreateTags",
+			params: map[string]string{
+				"ResourceId.1": ec2TagAuthzInstance,
+				"Tag.1.Key":    "Environment",
+				"Tag.1.Value":  "prod",
+			},
+			allowed: false,
+		},
+		{
+			name:      "a DeleteTags naming a key and no value",
+			operation: "DeleteTags",
+			params: map[string]string{
+				"ResourceId.1": ec2TagAuthzInstance,
+				"Tag.1.Key":    "Department",
+			},
+			allowed: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "tagkeys", doc)
+			f.putTagInstance(t, nil)
+
+			params := map[string]string{}
+			if tc.operation == "RunInstances" {
+				params = nominalLaunch()
+			}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+
+			err := f.call(t, tc.operation, params)
+			if tc.allowed {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not authorized")
+		})
+	}
+}
+
+// TestSimulate_ContextEntriesKeepEveryValue pins the third producer of a multivalued
+// context: the simulator, which used to keep only ContextKeyValues.member.1.
+//
+// A ContextEntry is a value *list* by construction, so discarding all but the first
+// meant a caller simulating aws:TagKeys was answered against a policy that had seen one
+// of its values. An answer that can differ from what enforcement would decide is the
+// one thing a simulator must not produce.
+func TestSimulate_ContextEntriesKeepEveryValue(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"ec2:DeleteTags","Resource":"*","Condition":{` +
+		`"ForAllValues:StringEquals":{"aws:TagKeys":["Department","CostCenter"]},` +
+		`"Null":{"aws:TagKeys":"false"}}}]}`
+
+	simulate := func(t *testing.T, values ...string) simulateXMLResult {
+		t.Helper()
+		params := map[string]string{
+			"ActionNames.member.1":                   "ec2:DeleteTags",
+			"PolicyInputList.member.1":               policy,
+			"ContextEntries.member.1.ContextKeyName": "aws:TagKeys",
+			"ContextEntries.member.1.ContextKeyType": "stringList",
+		}
+		for i, v := range values {
+			params["ContextEntries.member.1.ContextKeyValues.member."+strconv.Itoa(i+1)] = v
+		}
+		got := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulateCustomPolicy", params))
+		require.Len(t, got.results(), 1)
+		return got.results()[0]
+	}
+
+	t.Run("every supplied value satisfies the policy", func(t *testing.T) {
+		result := simulate(t, "Department", "CostCenter")
+		assert.Equal(t, "allowed", result.Decision)
+		assert.Empty(t, result.MissingContextValues,
+			"the caller supplied the key, so it is not missing")
+	})
+
+	t.Run("a second value the policy does not list refuses", func(t *testing.T) {
+		result := simulate(t, "Department", "Environment")
+		assert.Equal(t, "implicitDeny", result.Decision,
+			"the value after the first is evaluated, not discarded")
+	})
+
+	t.Run("a key named with no values is set but empty", func(t *testing.T) {
+		result := simulate(t)
+		assert.Equal(t, "implicitDeny", result.Decision,
+			"ForAllValues is vacuously true; Null:false is what refuses")
+		assert.Empty(t, result.MissingContextValues,
+			"a key named with no value was still supplied by the caller")
+	})
+}

--- a/emulator/iam_simulate.go
+++ b/emulator/iam_simulate.go
@@ -70,6 +70,12 @@ type iamSimulateRequest struct {
 	// request member, so it carries no JSON tag: only parseSimulateRequest fills it,
 	// from req.Params, because a nested member list has no JSON-body form at all.
 	context map[string]string
+
+	// contextMulti holds the same entries as context, keeping *every* value a caller
+	// supplied for a key rather than only the first. A ContextEntry is a list by
+	// construction (ContextKeyValues.member.N), so this is the map that matches the
+	// wire shape; context is the single-valued projection of it (#690).
+	contextMulti map[string][]string
 }
 
 // iamSimulationResult is one (action, resource) outcome, in the terms the response
@@ -224,7 +230,7 @@ func (p *IAMPlugin) parseSimulateRequest(req *AWSRequest) (*iamSimulateRequest, 
 		params.ResourceArns = []string{"*"}
 	}
 
-	params.context = simulationContextEntries(req.Params)
+	params.context, params.contextMulti = simulationContextEntries(req.Params)
 	return &params, nil
 }
 
@@ -242,18 +248,23 @@ func (p *IAMPlugin) parseSimulateRequest(req *AWSRequest) (*iamSimulateRequest, 
 // There is no JSON-body form of this at all, so unlike every other member it is read
 // only from req.Params.
 //
-// Only the first value of a multi-valued key is used, because substrate's condition
-// context is a map[string]string. A set-valued key needs ForAllValues/ForAnyValue,
-// which conditionMatches does not implement, so silently keeping one of several
-// values is the honest limit: the alternative is pretending to evaluate a
-// multi-valued condition. ContextKeyType is recorded by AWS but not consulted here —
-// every condition operator substrate implements compares strings.
-func simulationContextEntries(params map[string]string) map[string]string {
+// Every value is kept, in two shapes: the multi map holds the caller's whole list, so
+// a ForAllValues or ForAnyValue condition is evaluated over exactly what was supplied,
+// and the single map holds the first value, which is what an unqualified operator
+// compares. Until #690 only the first survived, so a caller simulating a multivalued
+// key was answered against a policy that had seen one of its values — an answer that
+// could differ from what enforcement would decide, which is the one thing a simulator
+// must not do.
+//
+// ContextKeyType is recorded by AWS but not consulted here — every condition operator
+// substrate implements compares strings.
+func simulationContextEntries(params map[string]string) (single map[string]string, multi map[string][]string) {
 	entries := iamMemberStructs(params, "ContextEntries")
 	if len(entries) == 0 {
-		return nil
+		return nil, nil
 	}
-	ctx := make(map[string]string, len(entries))
+	single = make(map[string]string, len(entries))
+	multi = make(map[string][]string, len(entries))
 	for _, entry := range entries {
 		name := entry["ContextKeyName"]
 		if name == "" {
@@ -263,13 +274,17 @@ func simulationContextEntries(params map[string]string) map[string]string {
 		if len(values) == 0 {
 			// A key named with no value is still *set* as far as the Null operator is
 			// concerned, and it must not be reported as a missing context value: the
-			// caller supplied it.
-			ctx[name] = ""
+			// caller supplied it. It is recorded in both maps for that reason — the
+			// multi entry is present and empty, which is what a ForAllValues condition
+			// reads as "no values in the request".
+			single[name] = ""
+			multi[name] = []string{}
 			continue
 		}
-		ctx[name] = values[0]
+		single[name] = values[0]
+		multi[name] = values
 	}
-	return ctx
+	return single, multi
 }
 
 // simulationPolicySet assembles the documents SimulatePrincipalPolicy evaluates:
@@ -506,10 +521,11 @@ func (p *IAMPlugin) simulateResponse(op string, params *iamSimulateRequest,
 	for _, action := range params.ActionNames {
 		for _, resource := range params.ResourceArns {
 			results = append(results, simulateOne(docs, boundaryDocs, EvaluationRequest{
-				Principal: callerArn,
-				Action:    action,
-				Resource:  resource,
-				Context:   condCtx,
+				Principal:    callerArn,
+				Action:       action,
+				Resource:     resource,
+				Context:      condCtx,
+				MultiContext: params.contextMulti,
 			}))
 		}
 	}


### PR DESCRIPTION
Closes #690

`ForAllValues:` and `ForAnyValue:` were never parsed anywhere in substrate. `"ForAllValues:StringEquals"` reached `evaluateConditionKey` whole, matched none of the nine operators it knows, and fell through to its `// Unknown operator — deny by default`. The statement was discarded before its condition key was ever looked at.

**The issue's premise is inverted, and the truth is worse in both directions.** It reported that an unpopulated `aws:TagKeys` made such a statement *allow*. In fact an `Allow` so written was a false **deny** — including all three of AWS's documented `ec2:DeleteTags` example policies, none of which permitted anything — and a `Deny` so written was silently **inert**, so a guardrail written the way AWS recommends refused nothing at all. Populating `aws:TagKeys` alone would have changed nothing; the qualifier parse is the load-bearing half.

## What changed

- **`EvaluationRequest.MultiContext map[string][]string`**, beside `Context`. Two maps rather than one widened to `map[string][]string`, because IAM itself draws that line: a key is single- or multivalued by its nature, "multivalued context keys require a condition set operator", and AWS says outright not to use a set operator on a single-valued key. Keeping them apart leaves all nine existing operators' `ctx[key]` lookup byte-identical, so adding a multivalued key cannot change a decision that never named one.
- **The qualifier is split off the operator** and applied with AWS's rules verbatim: `ForAllValues` is true when every request value satisfies the base operator **and true when the key is absent or empty** ("It also returns `true` if there are no context keys in the request"); `ForAnyValue` needs one match and is **false when absent or empty** ("For no matching context key or if the key does not exist, the condition returns `false`"). An **unrecognized** qualifier — `ForSomeValues:`, a lowercase `forallvalues:` — still does not match, which is the deny-by-default an unknown operator already got.
- **`Null` consults both maps.** AWS's **Important** note says to always pair `ForAllValues` with `"Null": {"<key>": "false"}`, and all four of its `aws:TagKeys` examples do. Substrate's `Null` compares a single string, so a key carried only in `MultiContext` read as null — without this the recommended pattern would still deny every request it was written to allow, and the qualifier fix would have looked like it worked while changing nothing for a real policy.
- **`aws:TagKeys` is populated** in `CheckAccess`, sorted.
- **The simulator keeps every `ContextKeyValues.member.N` value** instead of the first, and `unsetConditionKeys` consults `MultiContext` so a key that *decided* the call is not also reported as missing.

## Deviation from the plan: `aws:TagKeys` is derived, not gathered

The plan had `addRequestTags` gain the multi map as a parameter and each of its seven service arms populate it. It is instead **derived from the `aws:RequestTag/<key>` entries that function already produces**: the keys of `aws:RequestTag/*` *are* the request's tag keys, so one reading of the request covers all seven arms — EC2's `TagSpecification.N.Tag.M.Key` and a direct `CreateTags`/`DeleteTags`' `Tag.N.Key`, IAM's and Organizations' `Tags` lists, Lambda's `Tags` map, Config's `Tags`, S3's `x-amz-tagging` — an arm added later is covered for free, and the two cannot drift into disagreeing about what the request asked for.

**The sort is load-bearing but unobservable through any API surface.** Three of those arms iterate a Go map, whose order is randomized per run, and a `ForAllValues` decision quantifies over the slice — an unsorted value would make a *denial* depend on map iteration order, which an event log that must replay identically cannot tolerate. But every operator that reads the key is set-semantic, so reordering changes no decision, and no request can observe it. It is therefore asserted through `RequestTagKeysForTest` in `export_test.go`, following the `S3PersistedContentEncodingForTest` precedent, rather than through a test that pretends an API observes it.

## Fail-before

Recorded at `main` (`75fbf6d`) in a throwaway worktree, with only the new test file copied in. Two of the new tests cannot be recorded there at all — they exercise `requestTagKeys`, which this PR introduces — and the unit-level ones do not compile against a `EvaluationRequest` with no `MultiContext`, so what ran is the two tests that use only pre-existing API:

```
--- FAIL: TestCheckAccess_TagKeysGatesATaggedRequest
    --- FAIL: .../a_launch_tagging_with_approved_keys
    --- PASS: .../a_launch_tagging_with_an_unapproved_key
    --- PASS: .../an_untagged_launch,_which_Null:false_refuses
    --- FAIL: .../a_direct_CreateTags_naming_approved_keys
    --- PASS: .../a_direct_CreateTags_naming_an_unapproved_key
    --- FAIL: .../a_DeleteTags_naming_a_key_and_no_value
--- FAIL: TestSimulate_ContextEntriesKeepEveryValue
    --- FAIL: .../every_supplied_value_satisfies_the_policy
    --- PASS: .../a_second_value_the_policy_does_not_list_refuses
    --- PASS: .../a_key_named_with_no_values_is_set_but_empty
```

The shape is the inverted premise itself: every row AWS's policy *permits* fails, and every refusal "passes" because everything was refused.

```
AccessDenied: User: arn:aws:iam::123456789012:user/tagkeys is not authorized to perform:
ec2:RunInstances on resource: arn:aws:ec2:us-east-1::image/ami-0abcdef1234567890
```

## Regression pinned explicitly

`AmazonRDSFullAccess` and `AmazonRDSReadOnlyAccess` each carry a real `ForAllValues:StringEquals` over `devops-guru:ServiceNames`, paired with `Null: false`. Both statements were discarded before this PR. `TestIAMManaged_RDSPoliciesStillWithholdDevOpsGuru` asserts they **still** withhold the grant from a request naming no service names (the `Null` arm refuses it) and now make it when one names `RDS` — two bundled policies quietly widening would be the fix escaping its own blast radius.

## Live run

`substrate server --address :4678` from a scratch directory, real AWS CLI, `AWS_MAX_ATTEMPTS=1`, torn down with `lsof -ti:4678 | xargs kill`. AWS's "may only apply approved tags" policy (`ForAllValues:StringEquals` over `aws:TagKeys` + `Null: false`):

| Call | Result |
|---|---|
| `run-instances` tagging `Department` | launched `i-045a59b0fa812e9f` — a false deny before this PR |
| the same launch adding `Environment` | `AccessDenied` on `ec2:RunInstances` |
| an untagged launch | `AccessDenied` — the `Null: false` arm, per AWS's note |
| `create-tags Key=CostCenter` | tagged |
| `create-tags Key=Environment` | `AccessDenied` on `ec2:CreateTags` |
| `delete-tags Key=CostCenter` (no value) | untagged |
| a `ForAnyValue` **Deny** on `Secret`, then tagging `Secret` | `AccessDenied` — the inert guardrail now fires |
| the same Deny, tagging `Department` | tagged — the Deny does not overreach |
| `simulate-custom-policy`, `ContextKeyValues=Department,CostCenter` | `allowed`, no missing context values |
| the same with `Department,Environment` | `implicitDeny` — the second value is evaluated, not discarded |

## Mutation testing

Nine mutants, anchor count asserted `== 1` over the whole file, `gofmt -w && go vet` so a non-compiling mutant is BROKEN rather than a result, full-package `go test -race -count=1 ./emulator/` **plus** `go test -C test/e2e ./...` with no `-run` filter, restore verified byte-for-byte.

| Mutant | Verdict |
|---|---|
| the qualifier split falls through to the unqualified path | KILLED |
| `ForAllValues` is false on an absent or empty key | KILLED |
| `ForAnyValue` is true on an absent or empty key | KILLED |
| an unrecognized qualifier matches instead of denying | KILLED |
| `Null` ignores `MultiContext` | KILLED |
| `unsetConditionKeys` ignores `MultiContext` | **SURVIVED**, then killed |
| the `aws:TagKeys` sort is dropped | KILLED |
| `CheckAccess` does not populate `aws:TagKeys` | KILLED |
| the simulator keeps only the first `ContextKeyValues` value | KILLED |

**The survivor is disclosed because it found a real hole in the test, not in the code.** `MissingContextValues` is gathered only for a statement ruled out *by its condition*, so the assertion I had written — on an **allowed** request — never reached that code at all. The case a caller actually meets is a **refusal**: a policy that lists `Department` and a request naming `Environment` is denied, and reporting `aws:TagKeys` as a missing context value there would send the caller looking for the wrong bug when the value it supplied is precisely why the call failed. That assertion was added and the mutant re-run: KILLED.

## Compatibility

**A previously-inert `Deny` will start firing, and a previously-denied `Allow` may start permitting.** Both are visible to any consumer using AWS's documented tag-scoped policies. Two bundled managed policies newly grant `devops-guru:SearchInsights` to a request naming `ServiceNames=RDS` — which is what their real documents say.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race), `make coverage` (82.9% on `emulator`), `make docs-reference-check`, `make docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...` and `go test -C test/e2e ./...` all green.

## Docs

A new `### Multivalued condition keys: ForAllValues and ForAnyValue` section in the IAM chapter: the per-qualifier table including both absent-key rules, AWS's `Null` pairing with the JSON it recommends, the note that the same vacuity bites a `Deny` the other way, which keys are multivalued and where each is populated from, why the value is sorted, and the one authorization path (`iam:` actions inside the IAM plugin) that populates neither map. The EC2 authorization chapter's "Not covered — `aws:TagKeys`" bullet is replaced by a pointer to it; the second `ec2:CreateTags` pass stays listed as not covered, since that is #691.
