### PR TITLE
fix(ec2,iam): a tagged create is authorized twice, against ec2:CreateTags (#691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value" — and it had to arrive in the same change as the fix below, which takes away the
   spelling callers were using for it by accident.
 
+- **The `ec2:CreateAction` condition key** (#691). Substrate's first `ec2:`-prefixed condition
+  key, and the one that makes a tag-on-create grant scopable to the create that carries it.
+  Its value is the creating operation's name — `RunInstances`, `CreateVolume` — so AWS's
+  documented policy shape works as written:
+
+  ```json
+  {"Effect": "Allow", "Action": "ec2:CreateTags",
+   "Resource": "arn:aws:ec2:us-east-1:111122223333:instance/*",
+   "Condition": {"StringEquals": {"ec2:CreateAction": "RunInstances"}}}
+  ```
+
+  **The key is absent outside a create**, which is the whole point of that shape: a policy so
+  written permits tagging *during* a launch and not a standalone `CreateTags` on an existing
+  instance. AWS says so directly — "Users cannot tag existing resources". A statement wanting
+  to refuse only standalone tagging can therefore gate on `"Null": {"ec2:CreateAction":
+  "false"}`, the one construct that distinguishes an absent key from one present with another
+  value.
+
+  It is a *request*-level key, evaluated against every resource the tagging pass names, not a
+  per-resource one. Condition-key **names** are still matched case-sensitively here, where AWS
+  documents them as case-insensitive — a pre-existing property of the evaluator, global to
+  every key rather than new with this one, now tracked as #704.
+
 ### Changed
+- **A create carrying `TagSpecification` now additionally requires `ec2:CreateTags`** (#691).
+  AWS performs a second authorization pass on a tag-carrying create: "If tags are specified in
+  the resource-creating action, Amazon performs additional authorization on the
+  `ec2:CreateTags` action to verify if users have permissions to create tags. Therefore, users
+  must also have explicit permissions to use the `ec2:CreateTags` action." Substrate performed
+  only the first pass, so a policy granting `ec2:RunInstances` alone launched a *tagged*
+  instance that real EC2 refuses — and, worse in the other direction, a policy that deliberately
+  withheld `ec2:CreateTags` to stop callers writing tags did not stop them.
+
+  The pass runs **after** the primary decision succeeds, which is the order AWS describes, and
+  only when the request actually carries tags: "The `ec2:CreateTags` action is only evaluated if
+  tags are applied during the resource-creating action." An untagged create is unaffected, as is
+  a `TagSpecification` that names a resource type but no tags.
+
+  **It is a second decision, not a second resource.** Different action, different resources, and
+  a context key (`ec2:CreateAction`) the create's own decision must not see. The resources are
+  the ones the create will *make* — one `arn:aws:ec2:<region>:<account>:<type>/*` per distinct
+  `TagSpecification.N.ResourceType` — not the ones it reads. A launch reads an image, a subnet
+  and a security group; its tags land on an instance and a volume, and AWS's own example turns
+  precisely on that distinction, scoping the grant to `instance/*` with the prose "users cannot
+  tag volumes using the `RunInstances` request". So a launch that tags both its instance and its
+  volumes needs the grant on **both** types; one written for `instance/*` alone refuses the
+  volume half.
+
+  The `<type>/*` wildcard is **substrate's reading**, not a documented rule: the resources do not
+  exist when the decision is made, so no concrete ARN could be formed. It is the shape AWS's
+  four example policies for this key are written against (`*/*`, `instance/*`), which is the
+  evidence for choosing it. A `TagSpecification.N.ResourceType` value substrate does not
+  otherwise model is passed through rather than filtered out — filtering could only ever produce
+  a false *allow*.
+
+  **Tags supplied by a launch template count too**, per AWS: "The `ec2:CreateTags` action is also
+  evaluated if tags are provided in a launch template." The template's tags are resolved through
+  the same lookup the launch's *resource* authorization already uses, so the two halves of one
+  launch's decision cannot resolve different template versions. Per-scope precedence mirrors the
+  handler exactly: the template's instance tags apply only when the request named none of its
+  own, and likewise for volume tags — a request that overrides a scope authorizes its own tags
+  for it, not the template's.
+
+  `aws:RequestTag/*` and `aws:TagKeys` in the second pass are the first pass's values plus
+  whatever the template supplied, so the two readings of one request cannot disagree about what
+  it asked for.
+
 - **A policy statement using `ForAllValues:` or `ForAnyValue:` is now evaluated instead of
   discarded** (#690). Neither qualifier was parsed anywhere in substrate, so
   `"ForAllValues:StringEquals"` reached the operator switch whole, matched none of the nine

--- a/docs/services.md
+++ b/docs/services.md
@@ -960,8 +960,9 @@ request asked for, and its value is **sorted** — a `ForAllValues` denial that 
 map iteration order could not replay from the event log.
 
 Everything else substrate populates is single-valued: `aws:RequestTag/<key>` and
-`aws:ResourceTag/<key>` on an authorized request, `sts:ExternalId` when a role is assumed,
-and `aws:PrincipalArn` / `aws:ResourceAccount` in a simulation. A set qualifier on one of
+`aws:ResourceTag/<key>` on an authorized request, `ec2:CreateAction` on [a tagged create's
+second authorization pass](#a-tagged-create-is-authorized-twice), `sts:ExternalId` when a role
+is assumed, and `aws:PrincipalArn` / `aws:ResourceAccount` in a simulation. A set qualifier on one of
 those is evaluated over a one-element set — which is the thing AWS warns against writing,
 not something substrate refuses.
 
@@ -3538,9 +3539,10 @@ Not covered:
   documented types.
 - **The launch-template ARN**, which the reference does not mark required for
   `RunInstances` — so requiring it would refuse the same policy.
-- **The EC2 condition keys** (`ec2:InstanceType`, `ec2:Vpc`, `ec2:Subnet`,
+- **Most of the EC2 condition keys** (`ec2:InstanceType`, `ec2:Vpc`, `ec2:Subnet`,
   `ec2:IsLaunchTemplateResource` and the rest). Resource resolution is what this
-  covers; the condition keys substrate does populate are the `aws:`-prefixed ones.
+  covers; the condition keys substrate populates are the `aws:`-prefixed ones plus
+  [`ec2:CreateAction`](#a-tagged-create-is-authorized-twice) on the tagging pass.
 
 #### Tagging is authorized against every resource it names
 
@@ -3560,8 +3562,9 @@ resource named is therefore substrate's reading of AWS's general rule for an act
 naming several resources, supported by AWS's own scoped tagging examples, which write
 a resource ARN as the `Resource` of an `ec2:CreateTags` statement and would be
 pointless if only one resource of a batch were evaluated. The two actions resolve
-identically; they differ only in condition-key surface, and neither difference —
-`DeleteTags` carries no `ec2:CreateAction` — is modelled.
+identically. They differ in condition-key surface, and the difference that matters is
+modelled: **neither carries `ec2:CreateAction`**, because neither is a create. See [a
+tagged create is authorized twice](#a-tagged-create-is-authorized-twice).
 
 The ARN a caller writes uses the resource type the reference documents, which for five
 of the nine taggable types is *not* the abbreviation substrate's own IDs suggest:
@@ -3602,11 +3605,80 @@ evaluates. See [multivalued condition
 keys](#multivalued-condition-keys-forallvalues-and-foranyvalue) for the set-qualifier rules
 those examples depend on, including why AWS pairs them with `Null`.
 
-Not covered:
+#### A tagged create is authorized twice
 
-- **The second authorization pass** AWS performs on `ec2:CreateTags` when a
-  resource-creating action carries tags, keyed on `ec2:CreateAction`. Tag-on-create is
-  authorized here as the creating action alone.
+A create that carries tags is two authorization decisions, not one. AWS: "If tags are
+specified in the resource-creating action, Amazon performs additional authorization on the
+`ec2:CreateTags` action to verify if users have permissions to create tags. Therefore, users
+must also have explicit permissions to use the `ec2:CreateTags` action."
+
+So `ec2:RunInstances` alone launches an untagged instance and **refuses a tagged one** —
+which is what real EC2 does, and the point of the rule: a policy that withholds
+`ec2:CreateTags` is how AWS expects you to stop a caller writing tags at all.
+
+The second pass runs only when the request actually carries tags, per AWS: "The
+`ec2:CreateTags` action is only evaluated if tags are applied during the resource-creating
+action." An untagged create is decided exactly as before, as is a `TagSpecification.N` that
+names a `ResourceType` but no `Tag.M`. It also runs *after* the primary decision succeeds, so
+a caller missing both permissions is told about the create first.
+
+**What it is authorized against** is the resources the create will *make*, one wildcard per
+distinct `TagSpecification.N.ResourceType`:
+
+| Request | Second pass authorizes `ec2:CreateTags` on |
+|---|---|
+| `RunInstances` tagging `instance` | `arn:aws:ec2:<region>:<account>:instance/*` |
+| `RunInstances` tagging `instance` and `volume` | both `instance/*` and `volume/*` |
+| `CreateVolume` with `TagSpecification` | `arn:aws:ec2:<region>:<account>:volume/*` |
+| `CreateSubnet` with `TagSpecification` | `arn:aws:ec2:<region>:<account>:subnet/*` |
+
+Not the resources the create *reads*. A launch is authorized against its image, subnet and
+security group; its tags land on an instance and a volume, and AWS's own example turns on that
+distinction — it scopes the grant to `instance/*` and says "Users cannot tag existing
+resources, and users cannot tag volumes using the `RunInstances` request." A launch that tags
+both scopes therefore needs the grant on both types; one written for `instance/*` alone refuses
+the volume half, and the denial names `volume/*` so it is clear which ARN to add.
+
+The `<type>/*` wildcard is **substrate's reading**, not a documented rule — the resources have
+no IDs when the decision is made, so no concrete ARN exists to authorize against. It is the
+shape all four of AWS's example policies for this key are written against (`*/*`,
+`instance/*`), which is why it is the one chosen. A `ResourceType` substrate does not otherwise
+model is passed through as written rather than filtered out; filtering could only ever produce
+a false *allow*.
+
+**`ec2:CreateAction`** carries the creating operation's name — `RunInstances`, `CreateVolume` —
+so AWS's documented shape works verbatim:
+
+```json
+{"Effect": "Allow", "Action": "ec2:CreateTags",
+ "Resource": "arn:aws:ec2:us-east-1:111122223333:instance/*",
+ "Condition": {"StringEquals": {"ec2:CreateAction": "RunInstances"}}}
+```
+
+The key is **absent** on a direct `CreateTags` or `DeleteTags`, which is what makes that
+statement mean "tag during a launch, and not otherwise" — AWS's "Users cannot tag existing
+resources". A policy wanting to refuse only standalone tagging gates on `"Null":
+{"ec2:CreateAction": "false"}`, the one construct that tells an absent key apart from one
+present with a different value. The value is case-sensitive; the key *name* is matched
+case-sensitively too, where AWS documents key names as case-insensitive — a pre-existing
+property of substrate's evaluator, global to every condition key rather than specific to this
+one, tracked as [#704](https://github.com/scttfrdmn/substrate/issues/704).
+
+**Tags a launch template supplies are authorized the same way**, per AWS: "The
+`ec2:CreateTags` action is also evaluated if tags are provided in a launch template." The
+template is resolved through the same lookup the launch's *resource* authorization uses, so one
+launch's two decisions cannot read different template versions. Precedence is per scope and
+mirrors the handler: the template's instance tags apply only when the request named none of its
+own, and its volume tags only when the request named no volume tags — so a request that
+overrides a scope authorizes the tags it actually sends for that scope.
+
+`aws:RequestTag/{key}` and `aws:TagKeys` in the second pass are the first pass's values plus
+whatever the template contributed, so the two decisions cannot disagree about what the request
+asked for. No `aws:ResourceTag/*` is populated: the resources do not exist yet, so they have no
+tags to match.
+
+A permission boundary applies to the second pass as it does to the first — a boundary that
+omits `ec2:CreateTags` refuses a tagged create even when the identity policy permits it.
 
 ### Instance attributes
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -149,6 +149,97 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		}
 	}
 
+	// The create is allowed. If it also applies tags, AWS authorizes those separately
+	// against ec2:CreateTags, and the caller needs that permission too (#691).
+	return a.checkEC2TagOnCreate(reqCtx, req, docs, boundary, requestTags, deniedCode)
+}
+
+// checkEC2TagOnCreate runs the second authorization pass AWS performs on
+// ec2:CreateTags when an EC2 create applies tags, returning nil when the request
+// applies none or when the caller is permitted to apply them.
+//
+// AWS: "If tags are specified in the resource-creating action, Amazon performs
+// additional authorization on the ec2:CreateTags action to verify if users have
+// permissions to create tags. Therefore, users must also have explicit permissions to
+// use the ec2:CreateTags action." Substrate authorized a tagged create as the creating
+// action alone, so every policy AWS documents for tag-on-create — each of which
+// carries a separate ec2:CreateTags statement — permitted more than it says.
+//
+// It runs after the primary decision rather than beside it because it is a second
+// decision, not a second resource: the action is different, the resources are the ones
+// the create is about to *make* rather than the ones it reads, and the context carries
+// a key the create's own decision must not see. A caller who cannot perform the create
+// never reaches it, which is also the order AWS describes ("they must have permissions
+// to use the action that creates the resource … If tags are specified …").
+//
+// requestTags is the aws:RequestTag/* map the primary decision used, so the tags this
+// pass evaluates are the same reading of the same request, plus whatever a launch
+// template supplies.
+func (a *AuthController) checkEC2TagOnCreate(reqCtx *RequestContext, req *AWSRequest,
+	docs []PolicyDocument, boundary *PolicyDocument, requestTags map[string]string, deniedCode string) error {
+	if req.Service != "ec2" {
+		return nil
+	}
+	pass := ec2AuthzCreateTagsPass(a.state, reqCtx, req)
+	if pass == nil {
+		return nil
+	}
+
+	condCtx := make(map[string]string, len(requestTags)+len(pass.templateTags)+1)
+	for k, v := range requestTags {
+		condCtx[k] = v
+	}
+	// A template's tags are new information: they never appear in the request's params,
+	// so addRequestTags could not have read them, and AWS evaluates them all the same —
+	// "The ec2:CreateTags action is also evaluated if tags are provided in a launch
+	// template."
+	for k, v := range pass.templateTags {
+		condCtx["aws:RequestTag/"+k] = v
+	}
+	// The key that separates tagging during a create from standalone tagging. It is set
+	// only here, which is why a direct CreateTags cannot satisfy a statement conditioned
+	// on it — the behavior AWS's examples call "users cannot tag existing resources".
+	condCtx[ec2CreateActionCondKey] = req.Operation
+
+	// Derived from the merged map above rather than reused from the primary decision, so
+	// a template-supplied key is in aws:TagKeys too — AWS's combined example conditions
+	// the tagging grant on both keys at once.
+	tagKeysMulti := make(map[string][]string, 1)
+	if keys := requestTagKeys(condCtx); len(keys) > 0 {
+		tagKeysMulti["aws:TagKeys"] = keys
+	}
+
+	// No aws:ResourceTag/*: these resources do not exist yet, so a condition about
+	// tags already on them is unsatisfiable, and fabricating one would let the tags
+	// being applied stand in for tags already present.
+	for _, arn := range pass.resourceARNs(reqCtx) {
+		evalReq := EvaluationRequest{
+			Principal:    reqCtx.Principal.ARN,
+			Action:       ec2CreateTagsAction,
+			Resource:     arn,
+			Context:      condCtx,
+			MultiContext: tagKeysMulti,
+		}
+		if Evaluate(docs, evalReq).Decision != DecisionAllow {
+			return &AWSError{
+				Code: deniedCode,
+				Message: fmt.Sprintf("User: %s is not authorized to perform: %s on resource: %s",
+					reqCtx.Principal.ARN, ec2CreateTagsAction, arn),
+				HTTPStatus: http.StatusForbidden,
+			}
+		}
+		if boundary == nil {
+			continue
+		}
+		if Evaluate([]PolicyDocument{*boundary}, evalReq).Decision != DecisionAllow {
+			return &AWSError{
+				Code: deniedCode,
+				Message: fmt.Sprintf("User: %s is not authorized to perform: %s (blocked by permission boundary)",
+					reqCtx.Principal.ARN, ec2CreateTagsAction),
+				HTTPStatus: http.StatusForbidden,
+			}
+		}
+	}
 	return nil
 }
 

--- a/emulator/ec2_authz.go
+++ b/emulator/ec2_authz.go
@@ -3,6 +3,8 @@ package emulator
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"slices"
 )
 
 // ec2AuthzRunInstancesResources returns every resource a RunInstances request
@@ -164,6 +166,157 @@ func ec2AuthzTagResources(state StateManager, reqCtx *RequestContext, req *AWSRe
 	return out
 }
 
+// ec2CreateTagsAction is the action AWS authorizes a tag-carrying create against a
+// second time, in addition to the create itself.
+const ec2CreateTagsAction = "ec2:CreateTags"
+
+// ec2CreateActionCondKey is the condition key that tells an ec2:CreateTags statement
+// which creating operation the tags are being applied by.
+//
+// AWS: "In the IAM policy definition for the ec2:CreateTags action, use the Condition
+// element with the ec2:CreateAction condition key to give tagging permissions to the
+// action that creates the resource." It is a request-level key, so it lives in the
+// condition context beside aws:RequestTag/* rather than on a resource — and it is
+// **absent** from a direct CreateTags or DeleteTags, which is what makes AWS's own
+// examples ("users cannot tag existing resources") work.
+const ec2CreateActionCondKey = "ec2:CreateAction"
+
+// ec2CreateTagsPass is the extra ec2:CreateTags authorization a create that applies
+// tags requires, resolved from the request and any launch template it names.
+//
+// AWS: "If tags are specified in the resource-creating action, Amazon performs
+// additional authorization on the ec2:CreateTags action to verify if users have
+// permissions to create tags. Therefore, users must also have explicit permissions to
+// use the ec2:CreateTags action." And the converse, which is why this type is a
+// pointer that can be nil: "The ec2:CreateTags action is only evaluated if tags are
+// applied during the resource-creating action".
+type ec2CreateTagsPass struct {
+	// resourceTypes are the TagSpecification resource types the create actually
+	// applies tags to, in the order they were discovered — the request's own
+	// TagSpecification.N order, then any scope a launch template supplies. A fixed
+	// order makes the denial, which names the first type the policy does not allow,
+	// deterministic and replay-stable.
+	resourceTypes []string
+
+	// templateTags are the tags a launch template supplies to this create. They are
+	// held apart from the request's own because [addRequestTags] has already read
+	// those from the params: the second pass's context is that map plus these, so the
+	// two readings of the request cannot disagree.
+	templateTags map[string]string
+}
+
+// ec2AuthzCreateTagsPass returns the tagging pass a create requires, or nil when the
+// request applies no tags and therefore needs no ec2:CreateTags permission.
+//
+// It is deliberately not gated on a list of creating operation names. An operation
+// that does not accept TagSpecification.N never carries one, so the general rule costs
+// nothing — and a create added to substrate later is covered without anyone
+// remembering to extend a list, which is the only direction that cannot produce a
+// false allow. A direct CreateTags or DeleteTags carries its tags as Tag.N rather than
+// TagSpecification.N, so it resolves to nil here and is authorized once, as itself.
+//
+// A specification that declares a resource type and carries no tags applies no tags,
+// so it contributes nothing: that is AWS's "only evaluated if tags are applied" rule
+// read at the level of the individual scope.
+func ec2AuthzCreateTagsPass(state StateManager, reqCtx *RequestContext, req *AWSRequest) *ec2CreateTagsPass {
+	pass := &ec2CreateTagsPass{}
+	for n := 1; ; n++ {
+		// The absent-or-empty ResourceType ends the walk, which is how the query
+		// protocol terminates an indexed list and what ec2TagSpecificationTags does.
+		rt, ok := req.Params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
+		if !ok || rt == "" {
+			break
+		}
+		// The tags themselves are read through the single tag-on-create parser rather
+		// than a second walk of the same params, so a scope the handler will apply and
+		// a scope the decision authorizes cannot drift apart. It re-walks per type,
+		// which is fine: a request carries a handful of specifications, not a page of
+		// them.
+		pass.addScope(rt, ec2LaunchTagsForResource(req.Params, rt))
+	}
+
+	// AWS: "The ec2:CreateTags action is also evaluated if tags are provided in a
+	// launch template." Only RunInstances reads a template, and only the two scopes
+	// substrate stores — the same two the launch itself applies.
+	if req.Operation == "RunInstances" {
+		if data := ec2AuthzTemplateData(state, reqCtx, req); data != nil {
+			// Each scope is gated on whether the request named that scope itself,
+			// mirroring the launch's replace-rather-than-merge precedence: a template's
+			// tags are the ones the create applies only when the caller named none.
+			// ec2HasUserTags is that gate for the instance scope for the same reason the
+			// handler uses it — substrate's own fleet stamp is not the caller naming tags.
+			if !ec2HasUserTags(ec2LaunchTagsForResource(req.Params, "instance")) {
+				pass.addTemplateScope("instance", data.TagSpecifications)
+			}
+			if len(ec2LaunchTagsForResource(req.Params, "volume")) == 0 {
+				pass.addTemplateScope("volume", data.VolumeTagSpecifications)
+			}
+		}
+	}
+
+	if len(pass.resourceTypes) == 0 {
+		return nil
+	}
+	return pass
+}
+
+// addScope records that the create applies tags to resourceType, ignoring the tags
+// themselves.
+//
+// The tags are deliberately dropped here: a tag the request declared is already in the
+// aws:RequestTag/* map [addRequestTags] built from the same params, and reading it a
+// second time is how the two readings come to disagree. A scope carrying no tags
+// applies none, so it records nothing at all.
+func (p *ec2CreateTagsPass) addScope(resourceType string, tags []EC2Tag) {
+	if len(tags) == 0 {
+		return
+	}
+	if !slices.Contains(p.resourceTypes, resourceType) {
+		p.resourceTypes = append(p.resourceTypes, resourceType)
+	}
+}
+
+// addTemplateScope records a scope a launch template supplies, both its resource type
+// and its tags — the tags being new information, since the request's params do not
+// carry them.
+func (p *ec2CreateTagsPass) addTemplateScope(resourceType string, tags []EC2Tag) {
+	if len(tags) == 0 {
+		return
+	}
+	p.addScope(resourceType, tags)
+	if p.templateTags == nil {
+		p.templateTags = make(map[string]string, len(tags))
+	}
+	for _, t := range tags {
+		p.templateTags[t.Key] = t.Value
+	}
+}
+
+// resourceARNs returns the ARN the tagging pass is authorized against for each scope
+// the create applies tags to.
+//
+// The resources do not exist yet — that is the whole situation — so each is the
+// wildcard for its declared type: arn:aws:ec2:<region>:<account>:<type>/*. **That is
+// substrate's reading**, not a documented rule. It is the shape AWS's own examples
+// require: they write the Resource of an ec2:CreateTags statement as either */* or
+// instance/*, and the prose "users cannot tag volumes using the RunInstances request"
+// turns on instance/* not matching the volume scope of the very same launch. Resolving
+// the pass against one ARN, or against the resources the create *reads* (an AMI, a
+// subnet, a security group), would make both of those policies mean something else.
+//
+// The type is passed through as the request spells it. TagSpecification's ResourceType
+// values are the ARN resource types — "instance", "volume", "network-interface",
+// "natgateway" — so no mapping table is needed, and a type substrate does not model
+// still yields an ARN a policy naming that type matches. Filtering to a known set
+// would be the one direction that can produce a false allow.
+func (p *ec2CreateTagsPass) resourceARNs(reqCtx *RequestContext) []string {
+	out := make([]string, 0, len(p.resourceTypes))
+	for _, rt := range p.resourceTypes {
+		out = append(out, "arn:aws:ec2:"+reqCtx.Region+":"+reqCtx.AccountID+":"+rt+"/*")
+	}
+	return out
+}
+
 // ec2AuthzLaunchMembers is the set of resources one RunInstances request names.
 //
 // Network interfaces hold only the IDs of interfaces the request brings, not the
@@ -240,17 +393,11 @@ func ec2AuthzResolveLaunch(state StateManager, reqCtx *RequestContext, req *AWSR
 // A template that cannot be read or resolved contributes nothing, which is why both
 // failures return rather than refuse.
 func (m *ec2AuthzLaunchMembers) mergeTemplate(state StateManager, reqCtx *RequestContext, req *AWSRequest, takeInterfaces bool) {
-	lt := ec2LookupLaunchTemplate(context.Background(), state, reqCtx,
-		req.Params["LaunchTemplate.LaunchTemplateId"],
-		req.Params["LaunchTemplate.LaunchTemplateName"])
-	if lt == nil {
+	resolved := ec2AuthzTemplateData(state, reqCtx, req)
+	if resolved == nil {
 		return
 	}
-	version, awsErr := ec2ResolveTemplateVersion(lt, req.Params["LaunchTemplate.Version"])
-	if awsErr != nil || version == nil {
-		return
-	}
-	data := version.Data
+	data := *resolved
 	if m.imageID == "" {
 		m.imageID = data.ImageID
 	}
@@ -263,6 +410,32 @@ func (m *ec2AuthzLaunchMembers) mergeTemplate(state StateManager, reqCtx *Reques
 	if takeInterfaces {
 		m.networkInterfaceIDs = ec2AuthzInterfaceIDs(data.NetworkInterfaces)
 	}
+}
+
+// ec2AuthzTemplateData resolves the launch-template data a RunInstances request
+// names, or nil when it names none or names one that cannot be read.
+//
+// It is shared by the two halves of a launch's decision — the resources it names and
+// the tags it applies — so neither can resolve a different version of the template
+// than the other, and neither can resolve a different one than the handler.
+//
+// A template that cannot be read or whose version does not resolve contributes
+// nothing rather than failing the request: the handler owes that answer
+// (InvalidLaunchTemplateId.NotFound), and refusing here would turn it into
+// AccessDenied.
+func ec2AuthzTemplateData(state StateManager, reqCtx *RequestContext, req *AWSRequest) *EC2LaunchTemplateData {
+	lt := ec2LookupLaunchTemplate(context.Background(), state, reqCtx,
+		req.Params["LaunchTemplate.LaunchTemplateId"],
+		req.Params["LaunchTemplate.LaunchTemplateName"])
+	if lt == nil {
+		return nil
+	}
+	version, awsErr := ec2ResolveTemplateVersion(lt, req.Params["LaunchTemplate.Version"])
+	if awsErr != nil || version == nil {
+		return nil
+	}
+	data := version.Data
+	return &data
 }
 
 // resolveDefaultVPC fills in the subnet and security group a launch that named

--- a/emulator/ec2_createtags_authz_test.go
+++ b/emulator/ec2_createtags_authz_test.go
@@ -1,0 +1,577 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The second authorization pass AWS performs on ec2:CreateTags when a
+// resource-creating request applies tags (#691).
+//
+// AWS: "To enable users to tag resources on creation, they must have permissions
+// to use the action that creates the resource, such as ec2:RunInstances or
+// ec2:CreateVolume. If tags are specified in the resource-creating action, Amazon
+// performs additional authorization on the ec2:CreateTags action to verify if
+// users have permissions to create tags. Therefore, users must also have explicit
+// permissions to use the ec2:CreateTags action." And the converse: "The
+// ec2:CreateTags action is only evaluated if tags are applied during the
+// resource-creating action."
+//
+// Before this, a tagged create was authorized as the creating action alone, so
+// every policy AWS documents for tag-on-create — all of which scope a separate
+// ec2:CreateTags statement with ec2:CreateAction — permitted more than it says: a
+// caller holding only ec2:RunInstances could tag whatever the request named.
+
+// ec2CreateTagsVolumeARN and ec2CreateTagsAnyARN are the two other ARNs the second
+// pass names in these tests: the wildcard for a declared resource type that is not
+// instance, and the */* form AWS's own examples write as the Resource of an
+// ec2:CreateTags statement.
+var (
+	ec2CreateTagsVolumeARN = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":volume/*"
+	ec2CreateTagsAnyARN    = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":*/*"
+)
+
+// ec2CreateTagsStatement builds one statement over an arbitrary action, with an
+// optional condition block — the shape AWS's tag-on-create examples are written in,
+// which ec2AuthzStatement cannot express because it hardcodes ec2:RunInstances.
+func ec2CreateTagsStatement(effect, action string, resources []string,
+	cond map[string]map[string]emulator.StringOrSlice) emulator.PolicyStatement {
+	return emulator.PolicyStatement{
+		Effect:    effect,
+		Action:    emulator.StringOrSlice{action},
+		Resource:  emulator.StringOrSlice(resources),
+		Condition: cond,
+	}
+}
+
+// ec2CreateActionAllow is AWS's documented tagging grant: ec2:CreateTags on the
+// given resources, but only in the context of the named creating action.
+func ec2CreateActionAllow(createAction string, resources ...string) emulator.PolicyStatement {
+	return ec2CreateTagsStatement("Allow", "ec2:CreateTags", resources,
+		map[string]map[string]emulator.StringOrSlice{
+			"StringEquals": {"ec2:CreateAction": {createAction}},
+		})
+}
+
+// ec2CreateTagsParams merges extra params into a copy of base, so a table row can
+// add a tag specification to nominalLaunch without mutating it.
+func ec2CreateTagsParams(base map[string]string, extra ...map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+4)
+	for k, v := range base {
+		out[k] = v
+	}
+	for _, m := range extra {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// ec2TagSpecParams returns the TagSpecification.N params that scope kv pairs to
+// resourceType, in the wire spelling EC2's query protocol uses.
+func ec2TagSpecParams(n int, resourceType string, kv ...string) map[string]string {
+	spec := "TagSpecification." + strconv.Itoa(n)
+	out := map[string]string{spec + ".ResourceType": resourceType}
+	for i := 0; i+1 < len(kv); i += 2 {
+		tag := spec + ".Tag." + strconv.Itoa(i/2+1)
+		out[tag+".Key"] = kv[i]
+		out[tag+".Value"] = kv[i+1]
+	}
+	return out
+}
+
+// deniedActionNamed reports the action a denial names, which is what tells a caller
+// the tagging pass refused rather than the create itself.
+func deniedActionNamed(t *testing.T, err error) string {
+	t.Helper()
+	var awsErr *emulator.AWSError
+	if !errors.As(err, &awsErr) {
+		t.Fatalf("expected an *AWSError, got %T: %v", err, err)
+	}
+	const marker = "to perform: "
+	idx := strings.Index(awsErr.Message, marker)
+	if idx < 0 {
+		t.Fatalf("denial names no action: %q", awsErr.Message)
+	}
+	rest := awsErr.Message[idx+len(marker):]
+	if end := strings.Index(rest, " "); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}
+
+// setBoundary attaches a permission boundary to the fixture's user, which is how a
+// boundary reaches CheckAccess: it is read off the IAM entity, not from the
+// attached-policy list.
+func (f *ec2AuthzFixture) setBoundary(t *testing.T, doc emulator.PolicyDocument) {
+	t.Helper()
+	arn := "arn:aws:iam::" + ec2AuthzAccount + ":policy/Boundary-" + f.user
+	pol := emulator.IAMPolicy{
+		PolicyName:       "boundary",
+		PolicyID:         "ANPABOUND",
+		ARN:              arn,
+		Path:             "/",
+		DefaultVersionID: "v1",
+		IsAttachable:     true,
+		Document:         doc,
+	}
+	raw, err := json.Marshal(pol)
+	if err != nil {
+		t.Fatalf("marshal boundary: %v", err)
+	}
+	if err := f.state.Put(context.Background(), "iam", "policy:"+arn, raw); err != nil { //nolint:contextcheck
+		t.Fatalf("store boundary: %v", err)
+	}
+	user := emulator.IAMUser{
+		UserName:            f.user,
+		UserID:              "AIDATEST",
+		ARN:                 "arn:aws:iam::" + ec2AuthzAccount + ":user/" + f.user,
+		Path:                "/",
+		PermissionsBoundary: &emulator.IAMAttachedPolicy{PolicyARN: arn, PolicyName: "boundary"},
+	}
+	userRaw, err := json.Marshal(user)
+	if err != nil {
+		t.Fatalf("marshal user: %v", err)
+	}
+	if err := f.state.Put(context.Background(), "iam", "user:"+f.user, userRaw); err != nil { //nolint:contextcheck
+		t.Fatalf("store user: %v", err)
+	}
+}
+
+// TestEC2_Authz_TaggedCreateRequiresCreateTags is the decisive test: a caller
+// holding the creating action alone cannot tag on create.
+//
+// AWS: "users must also have explicit permissions to use the ec2:CreateTags
+// action." The policy here is the one a least-privilege consumer writes for a
+// tagging launch and, before #691, it permitted the tagging too.
+func TestEC2_Authz_TaggedCreateRequiresCreateTags(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		operation string
+		params    map[string]string
+		wantARN   string // "" means the request must be allowed
+	}{
+		{
+			name:      "a launch tagging its instance",
+			operation: "RunInstances",
+			params:    ec2TagSpecParams(1, "instance", "Env", "prod"),
+			wantARN:   ec2AuthzInstARN,
+		},
+		{
+			name:      "a launch tagging its volumes",
+			operation: "RunInstances",
+			params:    ec2TagSpecParams(1, "volume", "Env", "prod"),
+			wantARN:   ec2CreateTagsVolumeARN,
+		},
+		{
+			name:      "a volume created with tags",
+			operation: "CreateVolume",
+			params:    ec2TagSpecParams(1, "volume", "Env", "prod"),
+			wantARN:   ec2CreateTagsVolumeARN,
+		},
+		{
+			// AWS: "a user that has permissions to create a resource … does not
+			// require permissions to use the ec2:CreateTags action if no tags are
+			// specified in the request."
+			name:      "an untagged launch",
+			operation: "RunInstances",
+		},
+		{
+			name:      "an untagged volume",
+			operation: "CreateVolume",
+		},
+		{
+			// A specification that declares a type and applies no tag applies no
+			// tags, so there is nothing for the tagging pass to authorize.
+			name:      "a tag specification carrying no tags",
+			operation: "RunInstances",
+			params:    ec2TagSpecParams(1, "instance"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "tori", emulator.PolicyDocument{})
+			f.setPolicy(t,
+				ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+				ec2CreateTagsStatement("Allow", "ec2:CreateVolume", []string{"*"}, nil),
+			)
+
+			base := map[string]string{}
+			if tc.operation == "RunInstances" {
+				base = nominalLaunch()
+			}
+			err := f.call(t, tc.operation, ec2CreateTagsParams(base, tc.params))
+
+			if tc.wantARN == "" {
+				require.NoError(t, err, "a create applying no tags needs no ec2:CreateTags")
+				return
+			}
+			if !ec2AuthzDenied(t, err) {
+				t.Fatalf("a %s applying tags was allowed without ec2:CreateTags", tc.operation)
+			}
+			assert.Equal(t, "ec2:CreateTags", deniedActionNamed(t, err),
+				"the denial names the action that was missing, not the create")
+			assert.Equal(t, tc.wantARN, deniedResource(t, err),
+				"the tagging pass is authorized against the declared resource type's wildcard")
+		})
+	}
+}
+
+// TestEC2_Authz_CreateActionScopesTheTaggingGrant runs AWS's own documented
+// tag-on-create policy, which is the reason ec2:CreateAction exists.
+//
+// AWS: "The second statement uses the ec2:CreateAction condition key to allow
+// users to create tags only in the context of RunInstances, and only for
+// instances. Users cannot tag existing resources, and users cannot tag volumes
+// using the RunInstances request".
+func TestEC2_Authz_CreateActionScopesTheTaggingGrant(t *testing.T) {
+	statements := []emulator.PolicyStatement{
+		ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+		ec2CreateActionAllow("RunInstances", ec2AuthzInstARN),
+	}
+
+	t.Run("tagging the instance during the launch is allowed", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "ulla", emulator.PolicyDocument{})
+		f.setPolicy(t, statements...)
+		require.NoError(t, f.call(t, "RunInstances",
+			ec2CreateTagsParams(nominalLaunch(), ec2TagSpecParams(1, "instance", "Env", "prod"))))
+	})
+
+	t.Run("tagging the volumes in the same launch is not", func(t *testing.T) {
+		// The prose above is explicit, and it turns on the resource: the grant names
+		// instance/*, so the volume scope of the same request has no statement.
+		f := newEC2AuthzFixture(t, "ulla", emulator.PolicyDocument{})
+		f.setPolicy(t, statements...)
+		err := f.call(t, "RunInstances", ec2CreateTagsParams(nominalLaunch(),
+			ec2TagSpecParams(1, "instance", "Env", "prod"),
+			ec2TagSpecParams(2, "volume", "Env", "prod")))
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a grant scoped to instance/* permitted tagging volumes")
+		}
+		assert.Equal(t, ec2CreateTagsVolumeARN, deniedResource(t, err))
+	})
+
+	t.Run("tagging an existing instance is not", func(t *testing.T) {
+		// The whole point of the key: a direct CreateTags carries no ec2:CreateAction,
+		// so a grant conditioned on it cannot be satisfied outside a create.
+		f := newEC2AuthzFixture(t, "ulla", emulator.PolicyDocument{})
+		f.putTagInstance(t, nil)
+		f.setPolicy(t, statements...)
+		err := f.call(t, "CreateTags", map[string]string{
+			"ResourceId.1": ec2TagAuthzInstance,
+			"Tag.1.Key":    "Env",
+			"Tag.1.Value":  "prod",
+		})
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a grant conditioned on ec2:CreateAction permitted standalone tagging")
+		}
+	})
+
+	t.Run("the value is the creating operation and is case-sensitive", func(t *testing.T) {
+		// AWS: "the condition key is not case-sensitive and the condition value is
+		// case-sensitive." A grant written for CreateVolume must not admit a launch.
+		f := newEC2AuthzFixture(t, "ulla", emulator.PolicyDocument{})
+		f.setPolicy(t,
+			ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+			ec2CreateActionAllow("CreateVolume", ec2CreateTagsAnyARN),
+		)
+		err := f.call(t, "RunInstances",
+			ec2CreateTagsParams(nominalLaunch(), ec2TagSpecParams(1, "instance", "Env", "prod")))
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a grant written for CreateVolume admitted a RunInstances")
+		}
+	})
+
+	// The key is spelled exactly "ec2:CreateAction". AWS matches a condition key's
+	// name case-insensitively — substrate matches every condition key's name
+	// case-sensitively, which predates this pass and applies to all of them, so a
+	// policy writing "ec2:createaction" is not evaluated here (#704).
+}
+
+// TestEC2_Authz_CreateActionIsAbsentOutsideACreate pins the key's absence, which
+// is the half AWS's examples depend on and which no positive test can show.
+//
+// A Deny gated on Null:false fires only when the key is present, so it separates
+// "absent" from "present with some other value" — the distinction a StringEquals
+// cannot make.
+func TestEC2_Authz_CreateActionIsAbsentOutsideACreate(t *testing.T) {
+	statements := []emulator.PolicyStatement{
+		ec2CreateTagsStatement("Allow", "ec2:*", []string{"*"}, nil),
+		ec2CreateTagsStatement("Deny", "ec2:CreateTags", []string{"*"},
+			map[string]map[string]emulator.StringOrSlice{
+				"Null": {"ec2:CreateAction": {"false"}},
+			}),
+	}
+
+	t.Run("a direct CreateTags", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "vera", emulator.PolicyDocument{})
+		f.putTagInstance(t, nil)
+		f.setPolicy(t, statements...)
+		require.NoError(t, f.call(t, "CreateTags", map[string]string{
+			"ResourceId.1": ec2TagAuthzInstance,
+			"Tag.1.Key":    "Env",
+			"Tag.1.Value":  "prod",
+		}), "a standalone tagging call must carry no ec2:CreateAction")
+	})
+
+	t.Run("a direct DeleteTags", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "vera", emulator.PolicyDocument{})
+		f.putTagInstance(t, nil)
+		f.setPolicy(t, statements...)
+		require.NoError(t, f.call(t, "DeleteTags", map[string]string{
+			"ResourceId.1": ec2TagAuthzInstance,
+			"Tag.1.Key":    "Env",
+		}))
+	})
+
+	t.Run("a tagged launch", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "vera", emulator.PolicyDocument{})
+		f.setPolicy(t, statements...)
+		err := f.call(t, "RunInstances",
+			ec2CreateTagsParams(nominalLaunch(), ec2TagSpecParams(1, "instance", "Env", "prod")))
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("the tagging pass of a tagged create carried no ec2:CreateAction")
+		}
+		assert.Equal(t, "ec2:CreateTags", deniedActionNamed(t, err))
+	})
+}
+
+// TestEC2_Authz_TaggingPassSeesTheRequestTags runs AWS's "if instances are tagged
+// on creation, they must be tagged with a specific tag" policy, which conditions
+// the tagging grant on aws:RequestTag and aws:TagKeys rather than on the resource.
+//
+// AWS: "users do not have to specify tags in the request, but if they do, the tag
+// must be purpose=test. No other tags are allowed".
+func TestEC2_Authz_TaggingPassSeesTheRequestTags(t *testing.T) {
+	statements := []emulator.PolicyStatement{
+		ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+		ec2CreateTagsStatement("Allow", "ec2:CreateTags", []string{ec2CreateTagsAnyARN},
+			map[string]map[string]emulator.StringOrSlice{
+				"StringEquals": {
+					"aws:RequestTag/purpose": {"test"},
+					"ec2:CreateAction":       {"RunInstances"},
+				},
+				"ForAllValues:StringEquals": {"aws:TagKeys": {"purpose"}},
+			}),
+	}
+
+	for _, tc := range []struct {
+		name    string
+		params  map[string]string
+		allowed bool
+	}{
+		{
+			name:    "the prescribed tag",
+			params:  ec2TagSpecParams(1, "instance", "purpose", "test"),
+			allowed: true,
+		},
+		{
+			name:   "the prescribed key with another value",
+			params: ec2TagSpecParams(1, "instance", "purpose", "prod"),
+		},
+		{
+			name:   "the prescribed tag plus one more",
+			params: ec2TagSpecParams(1, "instance", "purpose", "test", "Env", "prod"),
+		},
+		{
+			name:    "no tags at all",
+			allowed: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "wanda", emulator.PolicyDocument{})
+			f.setPolicy(t, statements...)
+			err := f.call(t, "RunInstances", ec2CreateTagsParams(nominalLaunch(), tc.params))
+			if tc.allowed {
+				require.NoError(t, err)
+				return
+			}
+			if !ec2AuthzDenied(t, err) {
+				t.Fatal("the tagging pass ignored the tags the request applies")
+			}
+		})
+	}
+}
+
+// TestEC2_Authz_TemplateSuppliedTagsAreAuthorized pins AWS's other half: "The
+// ec2:CreateTags action is also evaluated if tags are provided in a launch
+// template."
+//
+// The template is resolved for the decision exactly as it is for the launch, under
+// the same replace-rather-than-merge precedence, so the tags authorized are the
+// ones the launch will actually apply.
+func TestEC2_Authz_TemplateSuppliedTagsAreAuthorized(t *testing.T) {
+	const ltID = "lt-0ddd3333eeee4444f"
+	const ltName = "tags-from-template"
+
+	newFixture := func(t *testing.T, data emulator.EC2LaunchTemplateData) *ec2AuthzFixture {
+		t.Helper()
+		f := newEC2AuthzFixture(t, "xena", emulator.PolicyDocument{})
+		data.ImageID = ec2AuthzAMI
+		data.SubnetID = ec2AuthzSubnet
+		data.NetworkInterfaceGroups = []string{ec2AuthzSG}
+		f.put(t, "lt:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ltID, emulator.EC2LaunchTemplate{
+			LaunchTemplateID:   ltID,
+			LaunchTemplateName: ltName,
+			DefaultVersionNum:  1,
+			LatestVersionNum:   1,
+			Versions: []emulator.EC2LaunchTemplateVersion{{
+				VersionNumber: 1,
+				Data:          data,
+			}},
+		})
+		if err := f.state.Put(context.Background(), "ec2", //nolint:contextcheck
+			"lt_by_name:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ltName, []byte(ltID)); err != nil {
+			t.Fatalf("store lt_by_name: %v", err)
+		}
+		return f
+	}
+	byName := map[string]string{
+		"MinCount":                          "1",
+		"MaxCount":                          "1",
+		"LaunchTemplate.LaunchTemplateName": ltName,
+	}
+	instanceTags := emulator.EC2LaunchTemplateData{
+		TagSpecifications: []emulator.EC2Tag{{Key: "Env", Value: "tmpl"}},
+	}
+
+	t.Run("a template's instance tags require ec2:CreateTags", func(t *testing.T) {
+		f := newFixture(t, instanceTags)
+		f.setPolicy(t, ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil))
+		err := f.launch(t, byName)
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a template was a way to tag on create without ec2:CreateTags")
+		}
+		assert.Equal(t, "ec2:CreateTags", deniedActionNamed(t, err))
+		assert.Equal(t, ec2AuthzInstARN, deniedResource(t, err))
+	})
+
+	t.Run("the grant AWS documents for a tagging template permits it", func(t *testing.T) {
+		// AWS's launch-template example: "The second part of the statement allows
+		// users to tag instances on creation—this part of the statement is necessary
+		// if tags are specified for the instance in the launch template."
+		f := newFixture(t, instanceTags)
+		f.setPolicy(t,
+			ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+			ec2CreateActionAllow("RunInstances", ec2AuthzInstARN),
+		)
+		require.NoError(t, f.launch(t, byName))
+	})
+
+	t.Run("a template's volume tags name the volume wildcard", func(t *testing.T) {
+		f := newFixture(t, emulator.EC2LaunchTemplateData{
+			VolumeTagSpecifications: []emulator.EC2Tag{{Key: "Env", Value: "tmpl"}},
+		})
+		f.setPolicy(t,
+			ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+			ec2CreateActionAllow("RunInstances", ec2AuthzInstARN),
+		)
+		err := f.launch(t, byName)
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a template's volume tags were authorized as instance tags")
+		}
+		assert.Equal(t, ec2CreateTagsVolumeARN, deniedResource(t, err))
+	})
+
+	t.Run("the request's own tags replace the template's", func(t *testing.T) {
+		// The handler applies a template's tag scope only when the request named
+		// none, so the decision must too: a launch naming Env=req applies Env=req,
+		// and a grant that admits only that value has to permit it.
+		f := newFixture(t, instanceTags)
+		f.setPolicy(t,
+			ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+			ec2CreateTagsStatement("Allow", "ec2:CreateTags", []string{ec2CreateTagsAnyARN},
+				map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {"aws:RequestTag/Env": {"req"}},
+				}),
+		)
+		require.NoError(t, f.launch(t,
+			ec2CreateTagsParams(byName, ec2TagSpecParams(1, "instance", "Env", "req"))))
+
+		// And the same policy refuses the template's own value, which is what shows
+		// the tags in the decision came from the template when the request named none.
+		g := newFixture(t, instanceTags)
+		g.setPolicy(t,
+			ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+			ec2CreateTagsStatement("Allow", "ec2:CreateTags", []string{ec2CreateTagsAnyARN},
+				map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {"aws:RequestTag/Env": {"req"}},
+				}),
+		)
+		if !ec2AuthzDenied(t, g.launch(t, byName)) {
+			t.Fatal("the template's Env=tmpl was not in the tagging decision")
+		}
+	})
+
+	t.Run("a template's own values are what the tagging pass evaluates", func(t *testing.T) {
+		// The mirror of the case above, and the one that shows the template's tags
+		// reach aws:RequestTag/* rather than merely making the pass happen: a grant
+		// admitting only Env=tmpl has to permit a launch whose Env=tmpl comes from
+		// the template alone.
+		f := newFixture(t, instanceTags)
+		f.setPolicy(t,
+			ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+			ec2CreateTagsStatement("Allow", "ec2:CreateTags", []string{ec2CreateTagsAnyARN},
+				map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {"aws:RequestTag/Env": {"tmpl"}},
+				}),
+		)
+		require.NoError(t, f.launch(t, byName))
+	})
+
+	t.Run("a request's volume tags keep the template's out of the decision", func(t *testing.T) {
+		// Precedence is per scope, and the scope the request overrode must not
+		// contribute the template's keys: AWS's own approved-keys guardrail would
+		// otherwise refuse a launch over a tag the launch never applies.
+		f := newFixture(t, emulator.EC2LaunchTemplateData{
+			VolumeTagSpecifications: []emulator.EC2Tag{{Key: "Team", Value: "tmpl"}},
+		})
+		f.setPolicy(t,
+			ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+			ec2CreateTagsStatement("Allow", "ec2:CreateTags", []string{ec2CreateTagsAnyARN},
+				map[string]map[string]emulator.StringOrSlice{
+					"ForAllValues:StringEquals": {"aws:TagKeys": {"Name"}},
+					"Null":                      {"aws:TagKeys": {"false"}},
+				}),
+		)
+		require.NoError(t, f.launch(t,
+			ec2CreateTagsParams(byName, ec2TagSpecParams(1, "volume", "Name", "data"))))
+	})
+
+	t.Run("an untagged template needs no ec2:CreateTags", func(t *testing.T) {
+		f := newFixture(t, emulator.EC2LaunchTemplateData{})
+		f.setPolicy(t, ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil))
+		require.NoError(t, f.launch(t, byName))
+	})
+}
+
+// TestEC2_Authz_BoundaryAppliesToTheTaggingPass pins that the second pass is a
+// full decision, not an identity-policy-only shortcut: a permission boundary that
+// withholds ec2:CreateTags blocks a tagged create just as it blocks the create.
+func TestEC2_Authz_BoundaryAppliesToTheTaggingPass(t *testing.T) {
+	f := newEC2AuthzFixture(t, "yuri", emulator.PolicyDocument{})
+	f.setPolicy(t, ec2CreateTagsStatement("Allow", "ec2:*", []string{"*"}, nil))
+	f.setBoundary(t, emulator.PolicyDocument{
+		Version:   "2012-10-17",
+		Statement: []emulator.PolicyStatement{ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil)},
+	})
+
+	require.NoError(t, f.launch(t, nominalLaunch()),
+		"the boundary allows the launch itself")
+
+	err := f.call(t, "RunInstances",
+		ec2CreateTagsParams(nominalLaunch(), ec2TagSpecParams(1, "instance", "Env", "prod")))
+	if !ec2AuthzDenied(t, err) {
+		t.Fatal("a boundary withholding ec2:CreateTags permitted a tagged launch")
+	}
+	assert.Contains(t, err.Error(), "permission boundary")
+}

--- a/emulator/ec2_tag_authz_test.go
+++ b/emulator/ec2_tag_authz_test.go
@@ -409,13 +409,23 @@ func TestEC2_TagAuthz_RequestTagConditionEvaluates(t *testing.T) {
 		// The pre-existing walk is untouched, so the shape RunInstances sends keeps
 		// populating the same condition key (#468).
 		f := ec2TagAuthzFixture(t, "nadia")
+		condition := map[string]map[string]emulator.StringOrSlice{
+			"StringEquals": {"aws:RequestTag/Env": {"test"}},
+		}
 		f.setPolicy(t, emulator.PolicyStatement{
-			Effect:   "Allow",
-			Action:   emulator.StringOrSlice{"ec2:RunInstances"},
-			Resource: emulator.StringOrSlice{"*"},
-			Condition: map[string]map[string]emulator.StringOrSlice{
-				"StringEquals": {"aws:RequestTag/Env": {"test"}},
-			},
+			Effect:    "Allow",
+			Action:    emulator.StringOrSlice{"ec2:RunInstances"},
+			Resource:  emulator.StringOrSlice{"*"},
+			Condition: condition,
+		}, emulator.PolicyStatement{
+			// A launch that applies tags needs ec2:CreateTags as well (#691), so the
+			// policy that grants this launch is now two statements. The same condition
+			// on both is what a real tag-scoped policy does, and it holds in the
+			// tagging pass for the same reason it holds in the launch's own.
+			Effect:    "Allow",
+			Action:    emulator.StringOrSlice{"ec2:CreateTags"},
+			Resource:  emulator.StringOrSlice{"*"},
+			Condition: condition,
 		})
 		params := nominalLaunch()
 		params["TagSpecification.1.ResourceType"] = "instance"


### PR DESCRIPTION
Closes #691

AWS performs **two** authorization decisions on a create that carries tags:

> If tags are specified in the resource-creating action, Amazon performs additional authorization on the `ec2:CreateTags` action to verify if users have permissions to create tags. Therefore, users must also have explicit permissions to use the `ec2:CreateTags` action.

Substrate performed only the first. So a policy granting `ec2:RunInstances` alone launched a *tagged* instance that real EC2 refuses — and, in the direction that actually matters for a guardrail, a policy that deliberately withheld `ec2:CreateTags` to stop callers writing tags did not stop them.

## It is a second decision, not a second resource

Different action, different resources, and a context key the create's own decision must not see. That is why it is a separate pass rather than extra ARNs on the primary loop:

- **The resources are the ones the create will *make***, not the ones it reads. A launch is authorized against an AMI, a subnet and a security group; its tags land on an instance and a volume. AWS's own example turns on exactly that: it scopes the tagging grant to `instance/*` and says "Users cannot tag existing resources, and users cannot tag volumes using the `RunInstances` request."
- **`ec2:CreateAction` is set only here**, which is what makes AWS's documented policy mean "tag during a create, and not otherwise".
- **It runs after the primary decision succeeds**, the order AWS describes — a caller who cannot perform the create hears about the create first.

## What changed

- **`ec2AuthzCreateTagsPass`** (`ec2_authz.go`) walks `TagSpecification.N`, and for `RunInstances` the launch template's two tag scopes, returning the scopes a create actually applies tags to — or `nil`, which is AWS's "The `ec2:CreateTags` action is only evaluated if tags are applied during the resource-creating action." An untagged create is decided exactly as before, as is a specification naming a `ResourceType` with no `Tag.M`.
- **`AuthController.checkEC2TagOnCreate`** (`authz.go`) evaluates `ec2:CreateTags` against one `arn:aws:ec2:<region>:<account>:<type>/*` per distinct declared resource type, through the identity policies and then the boundary.
- **`ec2AuthzTemplateData`** extracted out of `mergeTemplate`, so the resource half and the tag half of one launch's decision cannot resolve different template versions.

**The pass is deliberately not gated on a list of creating operation names.** An operation that does not accept `TagSpecification.N` never carries one, so the general rule costs nothing — and a create added to substrate later is covered without anyone remembering to extend a list, which is the only direction that cannot produce a false allow. A direct `CreateTags`/`DeleteTags` carries `Tag.N`, not `TagSpecification.N`, so it resolves to `nil` and is authorized once, as itself.

## `<type>/*` is substrate's reading

The resources have no IDs when the decision is made — that is the whole situation — so no concrete ARN exists to authorize against. The wildcard-per-declared-type shape is what all four of AWS's example policies for this key are written against (`*/*`, `instance/*`), and it is the only shape under which its prose about volumes is true: a launch tagging both scopes needs the grant on **both** types, and one written for `instance/*` alone refuses the volume half, naming `volume/*` so the caller knows which ARN to add.

`TagSpecification` `ResourceType` values *are* ARN resource types (`instance`, `volume`, `network-interface`, `natgateway`), so there is no mapping table, and a type substrate does not otherwise model is passed through as written. Filtering to a known set would be the one direction that can produce a false allow.

## Precedence mirrors the handler, per scope

AWS: "The `ec2:CreateTags` action is also evaluated if tags are provided in a launch template." The template's instance tags are the ones the launch applies only when the request named none of its own (`ec2HasUserTags`, the same gate the handler uses, so substrate's fleet stamp does not count as the caller naming tags); likewise for volume tags. A request that overrides a scope authorizes the tags it actually sends for that scope — otherwise AWS's approved-keys guardrail would refuse a launch over a tag the launch never applies.

`aws:RequestTag/*` and `aws:TagKeys` in the second pass are the first pass's map plus whatever the template contributed, so the two decisions cannot disagree about what the request asked for. No `aws:ResourceTag/*` is populated: the resources do not exist yet, so a condition about tags already on them is unsatisfiable, and fabricating one would let the tags being applied stand in for tags already present.

## Fail-before

The new tests use only pre-existing exported API (`CheckAccess`), so they compile and run at `main`. 13 failing leaf subtests, **every one in the "was allowed" direction**:

```
--- FAIL: TestEC2_Authz_TaggedCreateRequiresCreateTags
    --- FAIL: .../a_launch_tagging_its_instance
    --- FAIL: .../a_launch_tagging_its_volumes
    --- FAIL: .../a_volume_created_with_tags
    --- PASS: .../an_untagged_launch
    --- PASS: .../an_untagged_volume
    --- PASS: .../a_tag_specification_carrying_no_tags
--- FAIL: TestEC2_Authz_CreateActionScopesTheTaggingGrant
    --- FAIL: .../tagging_the_volumes_in_the_same_launch_is_not
    --- FAIL: .../the_value_is_the_creating_operation_and_is_case-sensitive
--- FAIL: TestEC2_Authz_CreateActionIsAbsentOutsideACreate/a_tagged_launch
--- FAIL: TestEC2_Authz_TaggingPassSeesTheRequestTags
    --- FAIL: .../the_prescribed_key_with_another_value
    --- FAIL: .../the_prescribed_tag_plus_one_more
--- FAIL: TestEC2_Authz_TemplateSuppliedTagsAreAuthorized
    --- FAIL: .../a_template's_instance_tags_require_ec2:CreateTags
    --- FAIL: .../a_template's_volume_tags_name_the_volume_wildcard
    --- FAIL: .../the_request's_own_tags_replace_the_template's
--- FAIL: TestEC2_Authz_BoundaryAppliesToTheTaggingPass
```

The rows that "passed" are the untagged ones, which must keep passing — the gate on tags being present is half the rule.

## One pre-existing test changed, legitimately

`TestEC2_TagAuthz_RequestTagConditionEvaluates/"a launch's TagSpecification form still resolves"` granted only `ec2:RunInstances` and now needs the `ec2:CreateTags` statement too. That is the behaviour change, asserted: the policy it used is one real EC2 refuses.

## Live run

`substrate server --address :4678` from a scratch directory, real AWS CLI, `AWS_MAX_ATTEMPTS=1`, torn down with `lsof -ti:4678 | xargs kill`.

| Policy | Call | Result |
|---|---|---|
| `ec2:RunInstances` only | untagged launch | `i-4a2f3c3eea828d66` |
| the same | **tagged** launch | `AccessDenied` — `ec2:CreateTags` on `…:instance/*` |
| AWS's documented grant on `instance/*` + `ec2:CreateAction=RunInstances` | tagged launch | `i-4eb37757e43a1c2d`, `Name=web` applied |
| the same | launch tagging instance **and volume** | `AccessDenied` on `…:volume/*` |
| the same | standalone `create-tags` | `AccessDenied` on `…:instance/i-4eb3…` — the key is absent |
| grant conditioned on `ec2:CreateAction=CreateVolume` | tagged launch | `AccessDenied` |
| the same | tagged `create-volume` | `vol-dc46668522f44c04` |
| `Deny` gated on `Null:{"ec2:CreateAction":"false"}` | tagged launch | `AccessDenied` |
| the same | standalone `create-tags` | tagged |
| `ec2:RunInstances` only | launch from a **tagging template** | `AccessDenied` on `…:instance/*` |
| + the documented grant | the same launch | `i-e9908b5b4fc4efcd`, `FromTemplate=yes` applied |
| grant conditioned on `aws:RequestTag/purpose=test` | launch tagging `purpose=test` | `i-28ac3c03cbe1958c` |
| the same | launch tagging `purpose=prod` | `AccessDenied` |
| boundary omitting `ec2:CreateTags` | untagged launch | `i-bb4c127da6321b4f` |
| the same | tagged launch | `AccessDenied … (blocked by permission boundary)` |

## Mutation testing

Twelve mutants, anchor count asserted `== 1` over the whole file, `gofmt -w && go vet` so a non-compiling mutant is BROKEN rather than a result, full-package `go test -race -count=1 ./emulator/` **plus** `go test -C test/e2e ./...` with no `-run` filter, restore verified byte-for-byte.

| Mutant | Verdict |
|---|---|
| the second pass is skipped entirely | KILLED |
| the pass runs on every ec2 request, so `ec2:CreateAction` is set for a direct `CreateTags` | KILLED |
| the template's scopes are ignored | KILLED |
| the instance scope's precedence gate is dropped | KILLED |
| the **volume** scope's precedence gate is dropped | **SURVIVED**, then killed |
| an empty tag scope still records its resource type | KILLED |
| `templateTags` are not merged into the tagging context | **SURVIVED**, then killed |
| `ec2:CreateAction` is never set | KILLED |
| `ec2:CreateAction` carries `ec2:RunInstances` rather than `RunInstances` | KILLED |
| `aws:TagKeys` is not populated in the tagging pass | KILLED |
| the boundary is not consulted in the tagging pass | KILLED |
| one `*/*` for every scope instead of one ARN per resource type | KILLED |

**Both survivors were holes in the tests, and both were about a template contributing tags nobody asserted the *values* of.** Every template assertion I had written turned on the pass *happening* (a denial naming `instance/*` or `volume/*`), and a denial is reached identically whether the template's tags are in the context or absent from it. Two subtests were added in the **allow** direction, where the difference is observable: a grant admitting only `Env=tmpl` must permit a launch whose `Env=tmpl` comes from the template alone; and AWS's `ForAllValues:StringEquals` over `aws:TagKeys ["Name"]` must permit a launch whose own volume tag is `Name`, which it does only if the overridden scope keeps the template's `Team` key out of the context. Both mutants re-run: KILLED.

## Follow-up filed

#704 — substrate matches condition-key **names** case-sensitively where AWS documents them as case-insensitive. Found here (`ec2:createaction` does not match) but global to the evaluator, not specific to this key, and it cuts both ways: a differently-cased `Deny` is inert, a differently-cased `Allow` is a false refusal. The caveat is recorded at `ec2_createtags_authz_test.go` and in the docs rather than pinned as intended behaviour.

## Compatibility

**A policy granting only the create action will start failing on a tagged create.** That is what real AWS requires, and it is the reason the issue exists, but it is visible to any consumer whose IaC tags what it creates — which CDK and Terraform both do by default. The fix is the statement AWS documents:

```json
{"Effect": "Allow", "Action": "ec2:CreateTags",
 "Resource": "arn:aws:ec2:us-east-1:111122223333:instance/*",
 "Condition": {"StringEquals": {"ec2:CreateAction": "RunInstances"}}}
```

An untagged create is unaffected, and so is any caller whose policy already grants `ec2:*` or `ec2:CreateTags` broadly.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `make test` (race), `make coverage` (82.2% total), `make docs-reference-check`, `make docs-versions`, `npm --prefix docs run build`, `go vet -C test/e2e ./...` and `go test -C test/e2e ./...` all green.

## Docs

A new `#### A tagged create is authorized twice` section in the EC2 authorization chapter: the two-decisions framing, the per-request-type ARN table, why it is the created resources and not the read ones, `ec2:CreateAction`'s value and its absence outside a create (with the `Null` construct that detects that), the template half and its per-scope precedence, what is in the pass's context and what deliberately is not, and the boundary. The `Not covered` block that named this pass is gone; the `DeleteTags` sentence that said the `ec2:CreateAction` difference was unmodelled now says it is, and points here. The multivalued-keys chapter lists `ec2:CreateAction` among the single-valued keys substrate populates.
