### PR TITLE
feat(ec2,iam): ec2:Subnet and ec2:Vpc on a launch's networking resources (#692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documents them as case-insensitive — a pre-existing property of the evaluator, global to
   every key rather than new with this one, now tracked as #704.
 
+- **`ec2:Subnet` and `ec2:Vpc` are populated on a launch's networking resources** (#692), so
+  AWS's own recommended subnet guardrail works. v0.105.0's docs pointed a reader at that
+  guardrail — a `Deny` on `ec2:RunInstances` for `network-interface/*` with `ArnNotEquals`
+  against a subnet ARN, whose prose reads "denying permission to create a network interface,
+  except where subnet `subnet-12345678` is specified" — while noting substrate did not populate
+  the key. The consequence was worse than inert: because the key was absent, `ArnNotEquals`
+  compared the permitted ARN against the empty string, matched, and **denied every launch**,
+  including into the subnet the policy exists to permit. An `Allow` gated on either key denied
+  every launch for the mirror-image reason. Both directions are in the recorded fail-before.
+
+  **The values are full ARNs.** AWS states it for the VPC — "To specify a VPC for the
+  `ec2:Vpc` condition key, you must specify the full ARN of the VPC" — and its
+  machine-readable service reference (`servicereference.us-east-1.amazonaws.com/v1/ec2/ec2.json`)
+  declares the `Type` of both keys as `ARN`. Its two example policies nonetheless use
+  different operator families, `ArnNotEquals` for `ec2:Subnet` and `StringEquals` for
+  `ec2:Vpc`; both work, because a full ARN satisfies either, and both are tested.
+
+  **Each key is scoped to the resources the reference lists it on**, carried on the
+  `authzResource` it describes rather than merged into the request context — `ec2:Subnet` on
+  the launch's `network-interface` resources, and `ec2:Vpc` on those plus its `subnet` and each
+  `security-group`. That scoping is load-bearing rather than tidy: AWS's guardrail denies
+  `network-interface/*` unconditionally *unless* the key names the right subnet, so the
+  launch's other four resources must not carry the key at all, or the same `Deny` would fire on
+  the AMI and refuse everything. The reference's own columns are wider than
+  `network-interface` for `ec2:Vpc`, which is why the subnet and the groups carry it too.
+
+  **A security group reports its own VPC**, read from that group's record rather than from the
+  launch, because a group in another VPC is exactly the mismatch such a policy is written to
+  catch. The launch's VPC comes from the default-VPC lookup when no subnet was named, and
+  otherwise from the resolved subnet's own record — including one a launch template supplied,
+  under the same field-by-field precedence the rest of the decision uses. A launch that omits
+  `SubnetId` therefore reports the default subnet it will land in, so **both** spellings of the
+  guardrail — #673's resource ARN and AWS's condition key — hold for the launch shape every
+  getting-started example uses.
+
+  **A key with nothing to report is omitted, not `"*"`.** A launch with no subnet and no
+  default VPC is about to create both; a wildcard *value* would be an ARN-shaped string no
+  caller's `ArnEquals` could match. The consequences are AWS's documented behaviour, not
+  substrate quirks: an `Allow` gated on an absent key does not match, so such a launch is
+  refused — the safe direction — while a `Deny` with a positive operator does not fire, and a
+  `ForAllValues:` qualifier over it is vacuously true, which is why AWS says not to use set
+  operators on single-valued keys.
+
+  Substrate's first `ec2:`-prefixed keys after `ec2:CreateAction`, and they inherit its
+  case-sensitivity caveat (#704): the key **name** is matched case-sensitively here where AWS
+  documents it as case-insensitive.
+
 ### Changed
 - **A create carrying `TagSpecification` now additionally requires `ec2:CreateTags`** (#691).
   AWS performs a second authorization pass on a tag-carrying create: "If tags are specified in
@@ -338,6 +385,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can be a single rule.
 
 ### Fixed
+- **Three dead in-page links in `docs/services.md`** (#692). Two pointed at
+  `#finding-a-fleets-instances` where the rendered anchor is `#finding-a-fleet-s-instances`,
+  and one pointed the phrase "default VPC" at `#runinstances`, which is a row in an
+  operations table rather than a heading and so has no anchor at all. Found while adding the
+  cross-references for this issue; every in-page link in the built page now resolves.
+
 - **The `Null` operator no longer reads a multivalued condition key as null** (#690). It
   compares a single string, so a key carried only in the new `MultiContext` — which is where
   `aws:TagKeys` lives — read as absent. Without this, AWS's own recommended pairing of

--- a/docs/services.md
+++ b/docs/services.md
@@ -961,10 +961,13 @@ map iteration order could not replay from the event log.
 
 Everything else substrate populates is single-valued: `aws:RequestTag/<key>` and
 `aws:ResourceTag/<key>` on an authorized request, `ec2:CreateAction` on [a tagged create's
-second authorization pass](#a-tagged-create-is-authorized-twice), `sts:ExternalId` when a role
+second authorization pass](#a-tagged-create-is-authorized-twice),
+[`ec2:Subnet` and `ec2:Vpc`](#a-launch-s-networking-resources-carry-ec2-subnet-and-ec2-vpc) on a
+launch's networking resources, `sts:ExternalId` when a role
 is assumed, and `aws:PrincipalArn` / `aws:ResourceAccount` in a simulation. A set qualifier on one of
 those is evaluated over a one-element set — which is the thing AWS warns against writing,
-not something substrate refuses.
+not something substrate refuses. Over one that is **absent** it is vacuously true, which is
+the other half of the same warning.
 
 **One authorization path populates neither map**: `iam:` actions decided inside the IAM
 plugin. Nothing there reads the request for tags, so a condition on `aws:RequestTag` or
@@ -3484,10 +3487,11 @@ unknown resource would widen the policy the caller wrote instead of narrowing it
 
 ##### A launch that omits `SubnetId` is authorized against the default VPC's resources
 
-A launch that names no subnet does not run without one: substrate resolves the
-[default VPC](#runinstances)'s default subnet and its `default` security group,
-creating them when the account has none. Both are part of the decision, resolved from
-state *before* it is made:
+A launch that names no subnet does not run without one: substrate resolves the default
+VPC's default subnet and its `default` security group — the VPC being the
+`172.31.0.0/16` one substrate auto-creates on the first launch that needs it — creating
+them when the account has none. Both are part of the decision, resolved from state
+*before* it is made:
 
 | State when the launch arrives | Subnet in the decision | Security group in the decision |
 |---|---|---|
@@ -3507,14 +3511,79 @@ the request omits. A `Deny` on `subnet/*` therefore still matches, and a
 least-privilege `Allow` naming one specific subnet correctly refuses a launch that
 will mint a different one.
 
-**This is substrate's reading, not AWS parity.** The Service Authorization Reference's
-`RunInstances` scenario rows require `subnet*` only in the `EC2-VPC-EBS-Subnet` and
-`EC2-VPC-InstanceStore-Subnet` scenarios, so a launch that omits the subnet is, read
-straight, not authorized against one — and AWS's own recommended subnet guardrail is
-the `ec2:Subnet` condition key on `network-interface/*`, which substrate does not
-populate. Substrate diverges because a guardrail a caller defeats by omitting a
-parameter is useless for the purpose substrate exists for: a test that proves a policy
-keeps workloads out of a subnet has to fail when the launch lands in it.
+**The resource ARN is substrate's reading, not AWS parity.** The Service Authorization
+Reference's `RunInstances` scenario rows require `subnet*` only in the
+`EC2-VPC-EBS-Subnet` and `EC2-VPC-InstanceStore-Subnet` scenarios, so a launch that
+omits the subnet is, read straight, not authorized against one. Substrate diverges
+because a guardrail a caller defeats by omitting a parameter is useless for the purpose
+substrate exists for: a test that proves a policy keeps workloads out of a subnet has to
+fail when the launch lands in it.
+
+AWS's own recommended subnet guardrail is a condition key rather than a resource ARN —
+`ec2:Subnet` on `network-interface/*` — and substrate populates that too, from the same
+resolution, so **both** spellings of the guardrail hold for a launch that names no
+subnet. See [the condition keys a launch's networking resources
+carry](#a-launch-s-networking-resources-carry-ec2-subnet-and-ec2-vpc).
+
+##### A launch's networking resources carry `ec2:Subnet` and `ec2:Vpc`
+
+These are substrate's first `ec2:`-prefixed condition keys, and they are what AWS's own
+example policies reach for to fence a launch into one subnet or one VPC. The subnet
+example is a `Deny`: "you could create a policy that denies users permissions to launch
+an instance into any other subnet. The statement does this by denying permission to
+create a network interface, except where subnet `subnet-12345678` is specified."
+
+```json
+{
+  "Effect": "Deny",
+  "Action": "ec2:RunInstances",
+  "Resource": "arn:aws:ec2:us-east-1:111122223333:network-interface/*",
+  "Condition": {
+    "ArnNotEquals": {
+      "ec2:Subnet": "arn:aws:ec2:us-east-1:111122223333:subnet/subnet-12345678"
+    }
+  }
+}
+```
+
+Both keys' values are **full ARNs**. AWS says so outright for the VPC — "To specify a
+VPC for the `ec2:Vpc` condition key, you must specify the full ARN of the VPC" — and its
+machine-readable service reference declares the `Type` of both keys as `ARN`. Its two
+example policies nonetheless use different operator families, `ArnNotEquals` for
+`ec2:Subnet` and `StringEquals` for `ec2:Vpc`; both work here, because a full ARN
+satisfies either.
+
+Each key is scoped to the resources the reference lists it on, not merged into the
+request, so a condition written about the interface cannot be satisfied by the AMI:
+
+| Resource in the decision | `ec2:Subnet` | `ec2:Vpc` |
+|---|---|---|
+| `network-interface/*` or `network-interface/{id}` | the launch's subnet | the launch's VPC |
+| `subnet/{id}` or `subnet/*` | — | the launch's VPC |
+| `security-group/{id}` | — | **that group's own** VPC |
+| `image/{ami}`, `instance/*`, `security-group/*` | — | — |
+
+A security group reports the VPC from *its own* record rather than the launch's, because
+a group in another VPC is exactly the mismatch such a policy is written to catch. The
+VPC itself comes from the default-VPC lookup when the launch names no subnet, and
+otherwise from the resolved subnet's record — including a subnet a launch template
+supplied, on the same field-by-field precedence the rest of the decision uses.
+
+**A key with nothing to report is absent, not `"*"`.** A launch with no subnet and no
+default VPC is about to create both, so there is no subnet and no VPC to name; a
+wildcard *value* would be an ARN-shaped string no caller's `ArnEquals` could ever match.
+Two consequences, both AWS's documented behaviour rather than substrate quirks:
+
+- An `Allow` gated on an absent key does not match, so such a launch is **refused** —
+  which is the safe direction, and the reason the omitted-not-wildcarded choice is not a
+  loophole.
+- A `Deny` gated on one with a positive operator does not fire, and a set qualifier
+  (`ForAllValues:`) over it is **vacuously true** — which is why AWS says not to use set
+  operators on single-valued keys.
+
+Not covered: `ec2:Vpc` on any action other than `RunInstances` — the reference lists 28
+action×resource pairs carrying `ec2:Subnet` service-wide, and this covers the launch
+path only.
 
 ##### A fleet's launches are authorized, not exempted
 
@@ -3539,10 +3608,12 @@ Not covered:
   documented types.
 - **The launch-template ARN**, which the reference does not mark required for
   `RunInstances` — so requiring it would refuse the same policy.
-- **Most of the EC2 condition keys** (`ec2:InstanceType`, `ec2:Vpc`, `ec2:Subnet`,
+- **Most of the EC2 condition keys** (`ec2:InstanceType`,
   `ec2:IsLaunchTemplateResource` and the rest). Resource resolution is what this
-  covers; the condition keys substrate populates are the `aws:`-prefixed ones plus
-  [`ec2:CreateAction`](#a-tagged-create-is-authorized-twice) on the tagging pass.
+  covers; the condition keys substrate populates are the `aws:`-prefixed ones,
+  [`ec2:CreateAction`](#a-tagged-create-is-authorized-twice) on the tagging pass, and
+  [`ec2:Subnet`/`ec2:Vpc`](#a-launch-s-networking-resources-carry-ec2-subnet-and-ec2-vpc)
+  on a launch's networking resources.
 
 #### Tagging is authorized against every resource it names
 
@@ -4113,7 +4184,7 @@ caller.
 
 #### How substrate's own fleet tag is exempt
 
-Substrate stamps [`aws:ec2:fleet-id`](#finding-a-fleets-instances) on every fleet
+Substrate stamps [`aws:ec2:fleet-id`](#finding-a-fleet-s-instances) on every fleet
 instance, which is a reserved key on a tag-on-create path — the reason this check
 was previously left off that path entirely.
 
@@ -4162,7 +4233,7 @@ Two rules make this less arithmetic than it looks, and both are modelled.
 **Tags with the `aws:` prefix do not count.** The documentation says so directly:
 "Tags with the `aws:` prefix do not count against your tags per resource limit." This
 is load-bearing rather than pedantry, because substrate stamps
-[`aws:ec2:fleet-id`](#finding-a-fleets-instances) on every fleet instance — a counter
+[`aws:ec2:fleet-id`](#finding-a-fleet-s-instances) on every fleet instance — a counter
 that included reserved keys would refuse a fleet launch whose template names the full
 50 user tags, which real EC2 accepts. A fleet instance therefore holds 51 tags legally:
 50 of the caller's and one of substrate's.

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -103,7 +103,7 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 	// policies admit all of them, which is how AWS evaluates a statement against
 	// "every resource that is required" for the action (#660, #662).
 	for _, res := range resources {
-		condCtx := make(map[string]string, len(requestTags)+len(res.Tags))
+		condCtx := make(map[string]string, len(requestTags)+len(res.Tags)+len(res.Context))
 		for k, v := range requestTags {
 			condCtx[k] = v
 		}
@@ -112,6 +112,12 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		// which is the false allow orgAuthzResourceID's comment exists to prevent.
 		for k, v := range res.Tags {
 			condCtx["aws:ResourceTag/"+k] = v
+		}
+		// Keys that describe this resource, on the same reasoning: they are scoped to
+		// the resource the reference lists them on, so a condition written about a
+		// launch's network interface cannot be satisfied by its AMI or its instance.
+		for k, v := range res.Context {
+			condCtx[k] = v
 		}
 
 		result := Evaluate(docs, EvaluationRequest{
@@ -601,6 +607,19 @@ type authzResource struct {
 
 	// Tags are the tags on the resource ARN names, or nil when it carries none.
 	Tags map[string]string
+
+	// Context holds condition keys that describe this resource rather than the
+	// request — ec2:Subnet and ec2:Vpc on a launch's network interface, which the
+	// Service Authorization Reference lists on that resource and not on the action
+	// (#692). It is nil for a resource with none, which is every resource outside
+	// EC2's launch path.
+	//
+	// Per-resource rather than merged into the request context for the same reason
+	// Tags is: a key describing one resource must not satisfy a condition written
+	// about another. AWS's own subnet guardrail depends on that — it denies
+	// RunInstances on network-interface/* unless ec2:Subnet names one subnet, and
+	// the launch's other four resources must not carry the key at all.
+	Context map[string]string
 }
 
 // buildResourceARNs returns every resource the request names, each paired with

--- a/emulator/ec2_authz.go
+++ b/emulator/ec2_authz.go
@@ -43,6 +43,11 @@ import (
 // When there is no default VPC yet the launch is about to create both, so they are
 // the wildcards subnet/* and security-group/*, on the same reasoning instance/* and
 // network-interface/* already are.
+//
+// Three of the resources also carry condition keys of their own — ec2:Subnet on the
+// network interface, ec2:Vpc on the interface, the subnet and each security group —
+// which is the guardrail AWS itself documents for fencing off a subnet, and which
+// #673's docs pointed at while substrate had neither key (#692).
 func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, req *AWSRequest) []authzResource {
 	if req.Operation != "RunInstances" {
 		return nil
@@ -70,26 +75,50 @@ func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, r
 			Tags: ec2AuthzTagsFor(state, ec2ImageStateKey(acct, region, launch.imageID)),
 		})
 	}
+	// vpcID is the VPC this launch lands in, and it is what ec2:Vpc reports. The
+	// default-VPC path resolved it already; a named or template subnet carries it on
+	// the record read for that subnet's tags, so it costs no extra state read.
+	vpcID := launch.vpcID
 	switch {
 	case launch.subnetID != "":
+		tags, subnetVPC := ec2AuthzRecordFor(state, "subnet:"+acct+"/"+region+"/"+launch.subnetID)
+		if subnetVPC != "" {
+			vpcID = subnetVPC
+		}
 		out = append(out, authzResource{
 			ARN:  ec2SubnetARN(acct, region, launch.subnetID),
-			Tags: ec2AuthzTagsFor(state, "subnet:"+acct+"/"+region+"/"+launch.subnetID),
+			Tags: tags,
+			// The reference lists ec2:Vpc on RunInstances' subnet resource as well as
+			// on its network interface — a subnet belongs to exactly one VPC, so the
+			// key means the same thing here.
+			Context: ec2AuthzVpcContext(acct, region, vpcID),
 		})
 	case launch.subnetWildcard:
 		// The default subnet this launch is about to create. No tags: it does not
 		// exist, so an aws:ResourceTag condition about it cannot be satisfied — which
 		// is the honest answer, since the subnet substrate mints carries no tags
-		// either.
-		out = append(out, authzResource{ARN: "arn:aws:ec2:" + region + ":" + acct + ":subnet/*"})
+		// either. It does carry ec2:Vpc when the default VPC exists, because the
+		// subnet it mints will be in that VPC.
+		out = append(out, authzResource{
+			ARN:     "arn:aws:ec2:" + region + ":" + acct + ":subnet/*",
+			Context: ec2AuthzVpcContext(acct, region, vpcID),
+		})
 	}
 	for _, sgID := range launch.securityGroupIDs {
+		tags, sgVPC := ec2AuthzRecordFor(state, "sg:"+acct+"/"+region+"/"+sgID)
 		out = append(out, authzResource{
 			ARN:  "arn:aws:ec2:" + region + ":" + acct + ":security-group/" + sgID,
-			Tags: ec2AuthzTagsFor(state, "sg:"+acct+"/"+region+"/"+sgID),
+			Tags: tags,
+			// The group's *own* VPC, not the launch's: the reference lists ec2:Vpc on
+			// the security-group resource, where it means the VPC the group belongs
+			// to, and a group in another VPC is exactly the mismatch a policy scoped
+			// this way is written to catch.
+			Context: ec2AuthzVpcContext(acct, region, sgVPC),
 		})
 	}
 	if launch.securityGroupWildcard {
+		// No record to read, and this wildcard is set only when there is no default
+		// VPC at all — so there is no VPC to report either.
 		out = append(out, authzResource{ARN: "arn:aws:ec2:" + region + ":" + acct + ":security-group/*"})
 	}
 	// Every launch attaches an interface, so network-interface* is always evaluated.
@@ -97,11 +126,23 @@ func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, r
 	// request brings by ID is named, because a policy can meaningfully scope to it.
 	// Neither carries tags: substrate stores no standalone taggable ENI record, and
 	// ec2TaggableStateKey has no eni- arm to read one through.
+	//
+	// This is the resource AWS's own subnet guardrail is written against, so it is
+	// where ec2:Subnet and ec2:Vpc go — both of them, on every interface the launch
+	// touches, named or wildcard, since they describe where the interface lands
+	// rather than which interface it is.
+	eniContext := ec2AuthzInterfaceContext(acct, region, launch.subnetID, vpcID)
 	if len(launch.networkInterfaceIDs) == 0 {
-		out = append(out, authzResource{ARN: "arn:aws:ec2:" + region + ":" + acct + ":network-interface/*"})
+		out = append(out, authzResource{
+			ARN:     "arn:aws:ec2:" + region + ":" + acct + ":network-interface/*",
+			Context: eniContext,
+		})
 	}
 	for _, eniID := range launch.networkInterfaceIDs {
-		out = append(out, authzResource{ARN: "arn:aws:ec2:" + region + ":" + acct + ":network-interface/" + eniID})
+		out = append(out, authzResource{
+			ARN:     "arn:aws:ec2:" + region + ":" + acct + ":network-interface/" + eniID,
+			Context: eniContext,
+		})
 	}
 	// The instance does not exist yet, so its ARN is the wildcard AWS's own
 	// least-privilege RunInstances examples write. Including it is what makes a
@@ -334,6 +375,12 @@ type ec2AuthzLaunchMembers struct {
 	// kind of value that eventually reaches a state key (#656).
 	subnetWildcard        bool
 	securityGroupWildcard bool
+
+	// vpcID is the VPC the launch lands in, when the default-VPC lookup resolved one.
+	// A launch whose subnet came from the request or a template leaves it empty and
+	// the VPC is read off that subnet's own record instead, which is the one place
+	// that knows — including when the caller named a subnet outside the default VPC.
+	vpcID string
 }
 
 // ec2AuthzResolveLaunch resolves the resources a RunInstances request names,
@@ -469,6 +516,9 @@ func (m *ec2AuthzLaunchMembers) resolveDefaultVPC(state StateManager, reqCtx *Re
 		m.securityGroupWildcard = !namedGroups
 		return
 	}
+	// The VPC is known even when its default subnet is not, so ec2:Vpc is answerable
+	// for a launch that is about to mint the subnet.
+	m.vpcID = vpc.VPCID
 	if subnet != nil {
 		m.subnetID = subnet.SubnetID
 	} else {
@@ -508,15 +558,90 @@ func ec2AuthzInterfaceIDs(interfaces []EC2NetworkInterface) []string {
 // serves all three and the ARN a resource is authorized under cannot drift from
 // the tags it is matched against.
 func ec2AuthzTagsFor(state StateManager, key string) map[string]string {
+	tags, _ := ec2AuthzRecordFor(state, key)
+	return tags
+}
+
+// ec2AuthzRecordFor returns the tags and the VPC ID stored on the EC2 record at key,
+// each zero when the record cannot be read or does not carry it.
+//
+// Both come out of one read because both describe the same resource and are needed
+// together: a subnet contributes its tags to aws:ResourceTag/* and its VPC to
+// ec2:Vpc, and reading the record twice is how the two would come to describe
+// different versions of it. An image record has no vpc_id, so it yields "" — which
+// [ec2AuthzVpcContext] turns into an omitted key rather than an empty one.
+func ec2AuthzRecordFor(state StateManager, key string) (map[string]string, string) {
 	raw, err := state.Get(context.Background(), ec2Namespace, key)
 	if err != nil || raw == nil {
-		return nil
+		return nil, ""
 	}
 	var record struct {
 		Tags []EC2Tag `json:"tags"`
+		// Every EC2 record that belongs to a VPC spells the member this way — EC2Subnet
+		// and EC2SecurityGroup both do — so one decoder serves both, for the same
+		// reason one tag decoder serves all three record types.
+		VPCID string `json:"vpc_id"`
 	}
 	if json.Unmarshal(raw, &record) != nil {
+		return nil, ""
+	}
+	return ec2TagsToMap(record.Tags), record.VPCID
+}
+
+// ec2SubnetCondKey and ec2VpcCondKey are the two resource-level condition keys the
+// Service Authorization Reference lists on RunInstances' network-interface resource,
+// and the mechanism AWS's own documentation recommends for fencing a launch into one
+// subnet — over the resource-ARN scoping substrate already had (#673, #692).
+//
+// Both take a **full ARN**, not an ID. AWS says so for the VPC outright ("To specify
+// a VPC for the ec2:Vpc condition key, you must specify the full ARN of the VPC") and
+// shows it for the subnet in the policy its subnet guardrail is written as, which
+// compares ec2:Subnet against arn:aws:ec2:<region>:<account>:subnet/subnet-… . AWS's
+// machine-readable service reference declares the Type of both as ARN.
+//
+// The two example policies use *different* operator families against those ARNs —
+// ArnNotEquals for ec2:Subnet, StringEquals for ec2:Vpc — which both work here
+// because the value is the full ARN either way and substrate's Arn* and String*
+// operators compare the same string.
+const (
+	ec2SubnetCondKey = "ec2:Subnet"
+	ec2VpcCondKey    = "ec2:Vpc"
+)
+
+// ec2VpcARN returns the ARN of a VPC, the form ec2:Vpc is compared against.
+func ec2VpcARN(accountID, region, vpcID string) string {
+	return "arn:aws:ec2:" + region + ":" + accountID + ":vpc/" + vpcID
+}
+
+// ec2AuthzVpcContext returns the ec2:Vpc entry for vpcID, or nil when no VPC
+// resolved.
+//
+// **Omitted, not wildcarded.** A "*" value would be a string no caller's ArnEquals
+// could ever match and an ARN-shaped lie about a VPC that does not exist; an absent
+// key is what AWS's own evaluation rules already describe. The consequence is worth
+// knowing: a condition on an absent single-valued key does not match, so an Allow
+// gated on ec2:Vpc refuses such a launch and a Deny gated on it does not catch one —
+// and a set qualifier over an absent key is vacuously true, which is AWS's documented
+// behavior and the reason it says not to use one on a single-valued key.
+func ec2AuthzVpcContext(accountID, region, vpcID string) map[string]string {
+	if vpcID == "" {
 		return nil
 	}
-	return ec2TagsToMap(record.Tags)
+	return map[string]string{ec2VpcCondKey: ec2VpcARN(accountID, region, vpcID)}
+}
+
+// ec2AuthzInterfaceContext returns the condition keys AWS documents on a launch's
+// network-interface resource: ec2:Subnet for the subnet the interface lands in, and
+// ec2:Vpc for that subnet's VPC. Each is omitted when it did not resolve, per
+// [ec2AuthzVpcContext].
+func ec2AuthzInterfaceContext(accountID, region, subnetID, vpcID string) map[string]string {
+	out := ec2AuthzVpcContext(accountID, region, vpcID)
+	if subnetID == "" {
+		return out
+	}
+	if out == nil {
+		out = make(map[string]string, 1)
+	}
+	out[ec2SubnetCondKey] = ec2SubnetARN(accountID, region, subnetID)
+	return out
 }

--- a/emulator/ec2_network_condkeys_test.go
+++ b/emulator/ec2_network_condkeys_test.go
@@ -1,0 +1,515 @@
+package emulator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The ec2:Subnet and ec2:Vpc condition keys on a launch's networking resources
+// (#692).
+//
+// #673 made a launch that omits SubnetId authorized against the default VPC's subnet
+// ARN, and docs/services.md labeled that substrate's reading rather than AWS parity —
+// pointing instead at the mechanism AWS itself documents for fencing a launch into one
+// subnet, a condition key on the network-interface resource. Substrate had neither key,
+// so the policy AWS tells a consumer to write was worse than inert: an Allow gated on
+// ec2:Subnet could not be satisfied and denied every launch, and AWS's own Deny — which
+// is written with the negated ArnNotEquals — compared the permitted ARN against the
+// empty string, matched, and denied every launch too, the permitted subnet included.
+// Both halves of the recorded fail-before are that blanket deny.
+//
+// AWS's own subnet guardrail, quoted verbatim from the EC2 example policies, is the
+// Deny in [TestEC2_Authz_SubnetKeyFencesALaunchToOneSubnet]: "you could create a
+// policy that denies users permissions to launch an instance into any other subnet.
+// The statement does this by denying permission to create a network interface, except
+// where subnet subnet-12345678 is specified."
+//
+// Both keys take a full ARN. For the VPC AWS says so outright — "To specify a VPC for
+// the ec2:Vpc condition key, you must specify the full ARN of the VPC" — and its
+// machine-readable service reference declares the Type of both keys as ARN. Its two
+// example policies nonetheless reach for different operator families, ArnNotEquals for
+// ec2:Subnet and StringEquals for ec2:Vpc, so both are exercised below.
+
+const (
+	// ec2CondKeyVPCID is the VPC the fixture's own subnet and security group sit in.
+	ec2CondKeyVPCID = "vpc-0aaa22223333bbbb4"
+
+	// ec2CondKeyOtherSubnet and ec2CondKeyOtherVPCID are the subnet and VPC a
+	// guardrail is written to keep a launch out of.
+	ec2CondKeyOtherSubnet = "subnet-0bbb33334444cccc5"
+	ec2CondKeyOtherVPCID  = "vpc-0ccc44445555dddd6"
+)
+
+var (
+	ec2CondKeyVPCARN        = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":vpc/" + ec2CondKeyVPCID
+	ec2CondKeyOtherVPCARN   = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":vpc/" + ec2CondKeyOtherVPCID
+	ec2CondKeyDefaultVPCARN = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount +
+		":vpc/" + ec2AuthzDefaultVPCID
+)
+
+// putSubnetInVPC re-puts a subnet with the VPC it belongs to, which the shared
+// fixture's putSubnet leaves empty — the record's vpc_id is where ec2:Vpc comes from
+// for a launch whose subnet the request named.
+func (f *ec2AuthzFixture) putSubnetInVPC(t *testing.T, subnetID, vpcID string) {
+	t.Helper()
+	f.put(t, "subnet:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+subnetID, emulator.EC2Subnet{
+		SubnetID:  subnetID,
+		VPCID:     vpcID,
+		State:     "available",
+		AccountID: ec2AuthzAccount,
+		Region:    ec2AuthzRegion,
+	})
+}
+
+// putSGInVPC re-puts a security group with the VPC it belongs to. The reference lists
+// ec2:Vpc on RunInstances' security-group resource as well, where it means the group's
+// own VPC — not the launch's.
+func (f *ec2AuthzFixture) putSGInVPC(t *testing.T, sgID, vpcID string) {
+	t.Helper()
+	f.put(t, "sg:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+sgID, emulator.EC2SecurityGroup{
+		GroupID:   sgID,
+		VPCID:     vpcID,
+		AccountID: ec2AuthzAccount,
+		Region:    ec2AuthzRegion,
+	})
+}
+
+// ec2CondKeyStatement builds one RunInstances statement with a condition block, the
+// shape both of AWS's example policies take.
+func ec2CondKeyStatement(effect string, resources []string,
+	cond map[string]map[string]emulator.StringOrSlice) emulator.PolicyStatement {
+	return emulator.PolicyStatement{
+		Effect:    effect,
+		Action:    emulator.StringOrSlice{"ec2:RunInstances"},
+		Resource:  emulator.StringOrSlice(resources),
+		Condition: cond,
+	}
+}
+
+// ec2CondKeyAllowAll is the unconditional grant the guardrail Denies below sit beside,
+// so a refusal can only have come from the condition under test.
+func ec2CondKeyAllowAll() emulator.PolicyStatement {
+	return ec2AuthzStatement("Allow", "*")
+}
+
+// ec2CondKeyTemplateLaunch stores a launch template carrying subnetID and returns the
+// params of a launch that names it, which is how a caller reaches a subnet without
+// writing it in the request.
+func (f *ec2AuthzFixture) ec2CondKeyTemplateLaunch(t *testing.T, subnetID string) map[string]string {
+	t.Helper()
+	const ltID = "lt-0eee55556666ffff7"
+	const ltName = "subnet-from-template"
+	f.put(t, "lt:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ltID, emulator.EC2LaunchTemplate{
+		LaunchTemplateID:   ltID,
+		LaunchTemplateName: ltName,
+		DefaultVersionNum:  1,
+		LatestVersionNum:   1,
+		Versions: []emulator.EC2LaunchTemplateVersion{{
+			VersionNumber: 1,
+			Data: emulator.EC2LaunchTemplateData{
+				ImageID:                ec2AuthzAMI,
+				SubnetID:               subnetID,
+				NetworkInterfaceGroups: []string{ec2AuthzSG},
+			},
+		}},
+	})
+	if err := f.state.Put(context.Background(), "ec2", //nolint:contextcheck
+		"lt_by_name:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ltName, []byte(ltID)); err != nil {
+		t.Fatalf("store lt_by_name: %v", err)
+	}
+	return map[string]string{
+		"MinCount":                          "1",
+		"MaxCount":                          "1",
+		"LaunchTemplate.LaunchTemplateName": ltName,
+	}
+}
+
+// TestEC2_Authz_SubnetKeyFencesALaunchToOneSubnet is the decisive test: AWS's own
+// documented subnet guardrail, which had no effect before this change.
+//
+// The policy is AWS's, shape for shape — a Deny on network-interface/* with
+// ArnNotEquals over ec2:Subnet, whose prose reads "denying permission to create a
+// network interface, except where subnet subnet-12345678 is specified" — beside an
+// unconditional Allow, so the only thing that can refuse a launch is the key.
+func TestEC2_Authz_SubnetKeyFencesALaunchToOneSubnet(t *testing.T) {
+	guardrail := func(t *testing.T, f *ec2AuthzFixture) {
+		t.Helper()
+		f.setPolicy(t,
+			ec2CondKeyStatement("Deny", []string{ec2AuthzENIARN},
+				map[string]map[string]emulator.StringOrSlice{
+					"ArnNotEquals": {"ec2:Subnet": {ec2AuthzSubnetARN}},
+				}),
+			ec2CondKeyAllowAll(),
+		)
+	}
+
+	t.Run("a launch into the permitted subnet", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "amara", emulator.PolicyDocument{})
+		f.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyVPCID)
+		guardrail(t, f)
+		require.NoError(t, f.launch(t, nominalLaunch()))
+	})
+
+	t.Run("a launch into any other subnet", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "bao", emulator.PolicyDocument{})
+		f.putSubnetInVPC(t, ec2CondKeyOtherSubnet, ec2CondKeyOtherVPCID)
+		guardrail(t, f)
+		params := nominalLaunch()
+		params["SubnetId"] = ec2CondKeyOtherSubnet
+		err := f.launch(t, params)
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("AWS's documented subnet guardrail did not fence off another subnet")
+		}
+		// The Deny is written against the interface, so that is the resource named —
+		// which is also what tells a reader the key lives there and not on the subnet.
+		assert.Equal(t, ec2AuthzENIARN, deniedResource(t, err))
+	})
+
+	t.Run("a launch that omits SubnetId and lands in the default subnet", func(t *testing.T) {
+		// The gap #673 closed for resource ARNs, now closed for the key AWS's own
+		// documentation recommends instead: leaving the parameter out must not be a
+		// way around the guardrail.
+		f := newEC2AuthzFixture(t, "cato", emulator.PolicyDocument{})
+		f.putDefaultVPC(t, nil)
+		guardrail(t, f)
+		if !ec2AuthzDenied(t, f.launch(t, subnetlessLaunch())) {
+			t.Fatal("omitting SubnetId defeated an ec2:Subnet guardrail")
+		}
+	})
+
+	t.Run("a launch reaching the permitted subnet through a template", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "dilnoza", emulator.PolicyDocument{})
+		f.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyVPCID)
+		params := f.ec2CondKeyTemplateLaunch(t, ec2AuthzSubnet)
+		guardrail(t, f)
+		require.NoError(t, f.launch(t, params))
+	})
+
+	t.Run("a launch reaching another subnet through a template", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "emeka", emulator.PolicyDocument{})
+		f.putSubnetInVPC(t, ec2CondKeyOtherSubnet, ec2CondKeyOtherVPCID)
+		params := f.ec2CondKeyTemplateLaunch(t, ec2CondKeyOtherSubnet)
+		guardrail(t, f)
+		if !ec2AuthzDenied(t, f.launch(t, params)) {
+			t.Fatal("a template was a way around an ec2:Subnet guardrail")
+		}
+	})
+}
+
+// TestEC2_Authz_VpcKeyScopesALaunch pins ec2:Vpc, whose value AWS documents as a full
+// ARN: "To specify a VPC for the ec2:Vpc condition key, you must specify the full ARN
+// of the VPC."
+//
+// Both operator families are exercised. AWS's own ec2:Vpc example uses StringEquals
+// even though the reference declares the key's type as ARN, and its ec2:Subnet example
+// uses ArnNotEquals — a consumer will have copied whichever it found, and a full ARN
+// satisfies both.
+func TestEC2_Authz_VpcKeyScopesALaunch(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		operator string
+	}{
+		{"StringNotEquals, the operator AWS's own ec2:Vpc example uses", "StringNotEquals"},
+		{"ArnNotEquals, the family the reference's ARN type implies", "ArnNotEquals"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("a launch inside the permitted VPC", func(t *testing.T) {
+				f := newEC2AuthzFixture(t, "farida", emulator.PolicyDocument{})
+				f.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyVPCID)
+				f.putSGInVPC(t, ec2AuthzSG, ec2CondKeyVPCID)
+				f.setPolicy(t,
+					ec2CondKeyStatement("Deny", []string{ec2AuthzENIARN},
+						map[string]map[string]emulator.StringOrSlice{
+							tc.operator: {"ec2:Vpc": {ec2CondKeyVPCARN}},
+						}),
+					ec2CondKeyAllowAll(),
+				)
+				require.NoError(t, f.launch(t, nominalLaunch()))
+			})
+
+			t.Run("a launch in another VPC", func(t *testing.T) {
+				f := newEC2AuthzFixture(t, "gorou", emulator.PolicyDocument{})
+				f.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyOtherVPCID)
+				f.putSGInVPC(t, ec2AuthzSG, ec2CondKeyOtherVPCID)
+				f.setPolicy(t,
+					ec2CondKeyStatement("Deny", []string{ec2AuthzENIARN},
+						map[string]map[string]emulator.StringOrSlice{
+							tc.operator: {"ec2:Vpc": {ec2CondKeyVPCARN}},
+						}),
+					ec2CondKeyAllowAll(),
+				)
+				if !ec2AuthzDenied(t, f.launch(t, nominalLaunch())) {
+					t.Fatal("an ec2:Vpc guardrail did not fence off another VPC")
+				}
+			})
+		})
+	}
+}
+
+// TestEC2_Authz_TheKeysAreScopedToTheResourceTheyDescribe pins the reason Context
+// hangs off each resource rather than off the request: the reference lists ec2:Subnet
+// on RunInstances' network-interface resource only, and ec2:Vpc on the interface, the
+// subnet and each security group — not on the image and not on the instance.
+//
+// A merged request context would make all five carry both keys, so a Deny a consumer
+// scoped to instance/* would fire on a launch AWS permits.
+func TestEC2_Authz_TheKeysAreScopedToTheResourceTheyDescribe(t *testing.T) {
+	// Null:"false" matches when the key is *present*, which is the only way to ask
+	// "does this resource carry the key at all" without also asserting its value.
+	present := func(key string) map[string]map[string]emulator.StringOrSlice {
+		return map[string]map[string]emulator.StringOrSlice{
+			"Null": {key: {"false"}},
+		}
+	}
+
+	t.Run("ec2:Subnet is not on the instance resource", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "hana", emulator.PolicyDocument{})
+		f.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyVPCID)
+		f.setPolicy(t,
+			ec2CondKeyStatement("Deny", []string{ec2AuthzInstARN}, present("ec2:Subnet")),
+			ec2CondKeyAllowAll(),
+		)
+		require.NoError(t, f.launch(t, nominalLaunch()),
+			"the instance resource carried ec2:Subnet, which the reference does not list on it")
+	})
+
+	t.Run("ec2:Subnet is on the network-interface resource", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "ines", emulator.PolicyDocument{})
+		f.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyVPCID)
+		f.setPolicy(t,
+			ec2CondKeyStatement("Deny", []string{ec2AuthzENIARN}, present("ec2:Subnet")),
+			ec2CondKeyAllowAll(),
+		)
+		if !ec2AuthzDenied(t, f.launch(t, nominalLaunch())) {
+			t.Fatal("the network-interface resource did not carry ec2:Subnet")
+		}
+	})
+
+	t.Run("ec2:Vpc is on the subnet resource too", func(t *testing.T) {
+		f := newEC2AuthzFixture(t, "jomo", emulator.PolicyDocument{})
+		f.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyVPCID)
+		f.setPolicy(t,
+			ec2CondKeyStatement("Deny", []string{ec2AuthzSubnetARN},
+				map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {"ec2:Vpc": {ec2CondKeyVPCARN}},
+				}),
+			ec2CondKeyAllowAll(),
+		)
+		err := f.launch(t, nominalLaunch())
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("the subnet resource did not carry ec2:Vpc")
+		}
+		assert.Equal(t, ec2AuthzSubnetARN, deniedResource(t, err))
+	})
+
+	t.Run("a security group reports its own VPC, not the launch's", func(t *testing.T) {
+		// The group is in one VPC and the subnet in another — a real misconfiguration
+		// AWS refuses, and the case that shows whose VPC each resource reports.
+		f := newEC2AuthzFixture(t, "kwame", emulator.PolicyDocument{})
+		f.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyVPCID)
+		f.putSGInVPC(t, ec2AuthzSG, ec2CondKeyOtherVPCID)
+		denyGroupsInVPC := func(t *testing.T, f *ec2AuthzFixture, vpcARN string) {
+			t.Helper()
+			f.setPolicy(t,
+				ec2CondKeyStatement("Deny", []string{ec2AuthzSGARN},
+					map[string]map[string]emulator.StringOrSlice{
+						"StringEquals": {"ec2:Vpc": {vpcARN}},
+					}),
+				ec2CondKeyAllowAll(),
+			)
+		}
+
+		denyGroupsInVPC(t, f, ec2CondKeyOtherVPCARN)
+		err := f.launch(t, nominalLaunch())
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("the security-group resource did not report the group's own VPC")
+		}
+		assert.Equal(t, ec2AuthzSGARN, deniedResource(t, err))
+
+		// And the subnet's VPC does not match the group's resource, which is what
+		// makes the two independent rather than one value copied onto both.
+		g := newEC2AuthzFixture(t, "lior", emulator.PolicyDocument{})
+		g.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyVPCID)
+		g.putSGInVPC(t, ec2AuthzSG, ec2CondKeyOtherVPCID)
+		denyGroupsInVPC(t, g, ec2CondKeyVPCARN)
+		require.NoError(t, g.launch(t, nominalLaunch()))
+	})
+}
+
+// TestEC2_Authz_NetworkKeysAreOmittedWhenNothingResolved pins the absent-key rule the
+// issue asks for: "The keys are absent rather than empty when no subnet resolves, so a
+// condition on them denies rather than vacuously allowing."
+//
+// A launch with no subnet and no default VPC is about to create both, so there is no
+// subnet and no VPC to report. Writing "*" as the *value* would be an ARN-shaped lie
+// no caller's ArnEquals could match; omission is the honest answer, and it makes an
+// Allow gated on either key refuse such a launch.
+func TestEC2_Authz_NetworkKeysAreOmittedWhenNothingResolved(t *testing.T) {
+	for _, key := range []string{"ec2:Subnet", "ec2:Vpc"} {
+		t.Run(key+" is absent", func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "mira-"+key, emulator.PolicyDocument{})
+			f.setPolicy(t,
+				ec2CondKeyStatement("Deny", []string{ec2AuthzENIARN},
+					map[string]map[string]emulator.StringOrSlice{
+						"Null": {key: {"true"}},
+					}),
+				ec2CondKeyAllowAll(),
+			)
+			if !ec2AuthzDenied(t, f.launch(t, subnetlessLaunch())) {
+				t.Fatalf("%s was present on a launch that resolved neither", key)
+			}
+		})
+
+		t.Run("an Allow gated on "+key+" refuses it", func(t *testing.T) {
+			// Not vacuously allowed: the statement's condition is unsatisfiable, so
+			// the interface has no grant and the launch is refused, naming it.
+			f := newEC2AuthzFixture(t, "nadia-"+key, emulator.PolicyDocument{})
+			f.setPolicy(t,
+				ec2AuthzStatement("Allow", ec2AuthzImageARN, ec2AuthzSubnetWildcardARN,
+					ec2AuthzSGWildcardARN, ec2AuthzInstARN),
+				ec2CondKeyStatement("Allow", []string{ec2AuthzENIARN},
+					map[string]map[string]emulator.StringOrSlice{
+						"StringLike": {key: {"arn:aws:ec2:*"}},
+					}),
+			)
+			err := f.launch(t, subnetlessLaunch())
+			if !ec2AuthzDenied(t, err) {
+				t.Fatalf("an Allow gated on an absent %s permitted the launch", key)
+			}
+			assert.Equal(t, ec2AuthzENIARN, deniedResource(t, err))
+		})
+	}
+}
+
+// TestEC2_Authz_DefaultVPCLaunchReportsWhereItLands pins the other half of the
+// absent-key rule: a subnetless launch whose default VPC *does* exist reports both
+// keys, because substrate resolved where the instance will land before deciding.
+//
+// This is what makes AWS's guardrail hold for the launch shape every getting-started
+// example uses — the one #673 found defeating a subnet-scoped Deny by omission.
+func TestEC2_Authz_DefaultVPCLaunchReportsWhereItLands(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cond map[string]map[string]emulator.StringOrSlice
+	}{
+		{"the resolved default subnet", map[string]map[string]emulator.StringOrSlice{
+			"ArnEquals": {"ec2:Subnet": {ec2AuthzDefaultSubnetARN}},
+		}},
+		{"the default VPC", map[string]map[string]emulator.StringOrSlice{
+			"StringEquals": {"ec2:Vpc": {ec2CondKeyDefaultVPCARN}},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newEC2AuthzFixture(t, "omar", emulator.PolicyDocument{})
+			f.putDefaultVPC(t, nil)
+			f.setPolicy(t,
+				ec2CondKeyStatement("Deny", []string{ec2AuthzENIARN}, tc.cond),
+				ec2CondKeyAllowAll(),
+			)
+			if !ec2AuthzDenied(t, f.launch(t, subnetlessLaunch())) {
+				t.Fatal("a subnetless launch did not report where it lands")
+			}
+		})
+	}
+}
+
+// TestEC2_Authz_VpcIsAnswerableWithoutASubnet covers the one state a launch can be in
+// where the VPC is known and the subnet is not: a default VPC that has no default
+// subnet, so the launch is about to mint one.
+//
+// ec2:Vpc is answerable there and ec2:Subnet is not, which is why they are resolved
+// separately rather than both hanging off the subnet record.
+func TestEC2_Authz_VpcIsAnswerableWithoutASubnet(t *testing.T) {
+	// Only the VPC and a group inside it — putDefaultVPC's third record, the default
+	// subnet, is deliberately left out.
+	newFixture := func(t *testing.T, user string) *ec2AuthzFixture {
+		t.Helper()
+		f := newEC2AuthzFixture(t, user, emulator.PolicyDocument{})
+		f.put(t, "vpc:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2AuthzDefaultVPCID, emulator.EC2VPC{
+			VPCID:     ec2AuthzDefaultVPCID,
+			CIDRBlock: "172.31.0.0/16",
+			IsDefault: true,
+			State:     "available",
+			AccountID: ec2AuthzAccount,
+			Region:    ec2AuthzRegion,
+		})
+		f.putSGInVPC(t, ec2AuthzSG, ec2AuthzDefaultVPCID)
+		return f
+	}
+
+	t.Run("the subnet the launch will mint carries the VPC", func(t *testing.T) {
+		f := newFixture(t, "rafiq")
+		f.setPolicy(t,
+			ec2CondKeyStatement("Deny", []string{ec2AuthzSubnetWildcardARN},
+				map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {"ec2:Vpc": {ec2CondKeyDefaultVPCARN}},
+				}),
+			ec2CondKeyAllowAll(),
+		)
+		err := f.launch(t, subnetlessLaunch())
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("subnet/* did not carry the default VPC it will be minted in")
+		}
+		assert.Equal(t, ec2AuthzSubnetWildcardARN, deniedResource(t, err))
+	})
+
+	t.Run("the interface carries the VPC and not a subnet", func(t *testing.T) {
+		f := newFixture(t, "sanne")
+		f.setPolicy(t,
+			ec2CondKeyStatement("Deny", []string{ec2AuthzENIARN},
+				map[string]map[string]emulator.StringOrSlice{
+					"StringEquals": {"ec2:Vpc": {ec2CondKeyDefaultVPCARN}},
+					"Null":         {"ec2:Subnet": {"true"}},
+				}),
+			ec2CondKeyAllowAll(),
+		)
+		if !ec2AuthzDenied(t, f.launch(t, subnetlessLaunch())) {
+			t.Fatal("the interface reported no VPC, or reported a subnet that does not exist")
+		}
+	})
+}
+
+// TestEC2_Authz_NetworkKeysReachTheBoundary pins that the keys are part of the same
+// per-resource context both evaluations read, so a permission boundary written as
+// AWS's guardrail bounds a launch the identity policy would permit — and, in the
+// other direction, does not bound the launch it names.
+func TestEC2_Authz_NetworkKeysReachTheBoundary(t *testing.T) {
+	bounded := func(t *testing.T, user, subnetID string) error {
+		t.Helper()
+		f := newEC2AuthzFixture(t, user, emulator.PolicyDocument{})
+		f.putSubnetInVPC(t, ec2AuthzSubnet, ec2CondKeyVPCID)
+		f.setPolicy(t, ec2CondKeyAllowAll())
+		f.setBoundary(t, emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{
+				ec2CondKeyAllowAll(),
+				ec2CondKeyStatement("Deny", []string{ec2AuthzENIARN},
+					map[string]map[string]emulator.StringOrSlice{
+						"ArnNotEquals": {"ec2:Subnet": {"arn:aws:ec2:" + ec2AuthzRegion + ":" +
+							ec2AuthzAccount + ":subnet/" + subnetID}},
+					}),
+			},
+		})
+		return f.launch(t, nominalLaunch())
+	}
+
+	t.Run("a boundary naming another subnet bounds the launch", func(t *testing.T) {
+		err := bounded(t, "priya", ec2CondKeyOtherSubnet)
+		if !ec2AuthzDenied(t, err) {
+			t.Fatal("a boundary gated on ec2:Subnet did not bound the launch")
+		}
+		assert.Contains(t, err.Error(), "permission boundary")
+	})
+
+	t.Run("a boundary naming the launch's own subnet does not", func(t *testing.T) {
+		// The direction that distinguishes a working key from an absent one: before
+		// #692 the key was missing, so ArnNotEquals compared the allowed ARN against
+		// "" and matched, making AWS's guardrail a blanket deny rather than inert.
+		require.NoError(t, bounded(t, "quinn", ec2AuthzSubnet))
+	})
+}


### PR DESCRIPTION
`ec2:Subnet` and `ec2:Vpc` are substrate's first `ec2:`-prefixed condition keys after
`ec2:CreateAction`, and they are what makes **AWS's own recommended subnet guardrail**
work. v0.105.0's docs pointed a reader at that guardrail while noting substrate did not
populate the key.

Closes #692.

## The defect was worse than "inert"

AWS's example is a `Deny` written with a *negated* operator:

```json
{"Effect": "Deny", "Action": "ec2:RunInstances",
 "Resource": "arn:aws:ec2:us-east-1:111122223333:network-interface/*",
 "Condition": {"ArnNotEquals": {
   "ec2:Subnet": "arn:aws:ec2:us-east-1:111122223333:subnet/subnet-12345678"}}}
```

With the key absent, `ArnNotEquals` compared the permitted ARN against `""`, matched, and
**denied every launch — including into the subnet the policy exists to permit.** An
`Allow` gated on either key denied everything for the mirror-image reason. Both
directions are in the fail-before below.

## Fail-before, recorded at `main` (`b77f1aa`) in a throwaway worktree

12 of 27 subtests fail; the ones that pass do so as absence pins, not as coverage.

```
--- FAIL: …SubnetKeyFencesALaunchToOneSubnet/a_launch_into_the_permitted_subnet
--- FAIL: …SubnetKeyFencesALaunchToOneSubnet/a_launch_reaching_the_permitted_subnet_through_a_template
--- FAIL: …VpcKeyScopesALaunch/StringNotEquals…/a_launch_inside_the_permitted_VPC
--- FAIL: …VpcKeyScopesALaunch/ArnNotEquals…/a_launch_inside_the_permitted_VPC
--- FAIL: …TheKeysAreScopedToTheResourceTheyDescribe/ec2:Subnet_is_on_the_network-interface_resource
--- FAIL: …TheKeysAreScopedToTheResourceTheyDescribe/ec2:Vpc_is_on_the_subnet_resource_too
--- FAIL: …TheKeysAreScopedToTheResourceTheyDescribe/a_security_group_reports_its_own_VPC,_not_the_launch's
--- FAIL: …DefaultVPCLaunchReportsWhereItLands/the_resolved_default_subnet
--- FAIL: …DefaultVPCLaunchReportsWhereItLands/the_default_VPC
--- FAIL: …NetworkKeysReachTheBoundary/a_boundary_naming_the_launch's_own_subnet_does_not
--- FAIL: …VpcIsAnswerableWithoutASubnet/the_subnet_the_launch_will_mint_carries_the_VPC   (new file, both subtests)
```

## A research correction the plan called out as unverified

The plan recorded that **the Service Authorization Reference's declared `Type` for these
two keys could not be fetched** (the SAR HTML page is JS-rendered and returns nothing to a
fetch), so it hedged: accept both the `Arn*` and `String*` operator families because AWS's
two example policies use different ones.

AWS's **machine-readable** service reference is fetchable where the HTML page is not:
`https://servicereference.us-east-1.amazonaws.com/v1/ec2/ec2.json`. It gives

- `ec2:Subnet` → `{"Types":["ARN"]}`, `ec2:Vpc` → `{"Types":["ARN"]}` — so the type column
  **is** verified, and the release notes must not ship the "unverified" sentence;
- and a **wider** scoping than the plan assumed. On `RunInstances`, `ec2:Vpc` is listed on
  the `security-group` and `subnet` resources as well as `network-interface`, not on
  `network-interface` alone. The implementation follows the reference rather than the plan.

Both operator families still work, now for a stated reason rather than as a hedge: the
value is a full ARN either way. Both are tested.

## What lands where

| Resource in the decision | `ec2:Subnet` | `ec2:Vpc` |
|---|---|---|
| `network-interface/*` or `network-interface/{id}` | the launch's subnet | the launch's VPC |
| `subnet/{id}` or `subnet/*` | — | the launch's VPC |
| `security-group/{id}` | — | **that group's own** VPC |
| `image/{ami}`, `instance/*`, `security-group/*` | — | — |

`authzResource` gains `Context map[string]string`, merged in `CheckAccess` right where that
resource's tags already are — so both the identity and the boundary evaluation pick it up
with no further wiring. **Per-resource, not request-level**, and that is load-bearing:
AWS's guardrail denies `network-interface/*` unless the key names the right subnet, so the
launch's other four resources must not carry the key at all, or the same `Deny` would fire
on the AMI and refuse everything.

A security group reports the VPC from **its own record**, because a group in another VPC is
exactly the mismatch such a policy catches. The launch's VPC comes from the default-VPC
lookup when no subnet was named, and otherwise from the resolved subnet's own record — one
extra decoded field on a `state.Get` the tag read already performed, no new read.

**A key with nothing to report is omitted, not `"*"`** — a wildcard *value* would be an
ARN-shaped string no `ArnEquals` could match. Consequences, all AWS's documented behaviour:
an `Allow` gated on an absent key refuses the launch (the safe direction), a positive `Deny`
does not fire, and a `ForAllValues:` over it is vacuously true.

## Live run

`substrate server --address :4678` from a scratch state directory, `AWS_MAX_ATTEMPTS=1`,
real AWS CLI, torn down with `lsof -ti:4678 | xargs kill`. Two VPCs, a subnet and a
security group in each.

| # | Scenario | Result |
|---|---|---|
| 1 | AWS's guardrail, launch into the permitted subnet A | allowed — `i-aee7be3fb34d578a` |
| 2 | same guardrail, launch into subnet B | denied on `network-interface/*` |
| 2b | same guardrail, **before any default VPC exists** (key absent) | denied — the omitted-not-wildcarded rule |
| 3 | same guardrail, launch omitting `SubnetId`, default subnet resolved | denied — omission is not a way around it |
| 4 | guardrail naming the default subnet instead | the subnetless launch is allowed — `i-34997c292f935652` |
| 5 | `ec2:Vpc` with `StringNotEquals`, AWS's own family | subnet A allowed, subnet B denied |
| 6 | the same `Deny` written about `instance/*` | never fires — allowed, the key is scoped |
| 7 | group B (VPC B) on a subnet-A launch | denied on `security-group/sg-e8d6…`; group A allowed |
| 8 | least-privilege **`Allow`** gated on `ArnEquals` `ec2:Subnet` | subnet A allowed, subnet B denied |
| 9 | the guardrail as a **permission boundary** | subnet A `(blocked by permission boundary)`; subnet B allowed |

Scenario 4 required an admin subnetless launch first to mint the default VPC — otherwise
its refusal would have been 2b's absent-key path, not the resolved-subnet one. The first
draft of scenarios 8 and 9 was wrong (a stray `"*"` in a `Resource` list, and a leftover
identity-policy `Deny` in the boundary case); both were corrected and re-run from a clean
state directory. That is why the instance IDs above are all from the second run.

## Mutation testing — 13 mutants, 13 killed

Green baseline, anchor count asserted `== 1` over the whole file, `.orig` restored in a
`finally`, `gofmt -w && go vet` so a non-compiling mutant is BROKEN rather than a result,
full-package `go test -race -count=1 ./emulator/` **plus** `go test -C test/e2e ./...` with
no `-run` filter, restore verified byte-for-byte.

| # | Mutation | Verdict |
|---|---|---|
| M1 | the per-resource `Context` merge is dropped | KILLED |
| M2 | `ec2:Subnet` is wildcarded rather than omitted | KILLED |
| M3 | `ec2:Vpc` is wildcarded rather than omitted | KILLED |
| M4 | a security group reports the launch's VPC rather than its own | KILLED |
| M5 | the named subnet's own VPC is ignored | KILLED |
| M6 | `resolveDefaultVPC` does not record the VPC it resolved | KILLED |
| M7 | `ec2:Subnet` is left off the interface | KILLED |
| M8 | the wildcard interface carries no context | KILLED |
| M9 | the subnet resource does not carry `ec2:Vpc` | KILLED |
| M10 | the subnet **wildcard** does not carry `ec2:Vpc` | KILLED |
| M11 | `ec2:Vpc` carries the bare VPC ID rather than the full ARN | KILLED |
| M12 | the record's `vpc_id` is never decoded | KILLED |
| M13 | the keys land on every resource, `instance/*` included | KILLED |

M4 and M10 each exposed a real gap on the first pass. M4 as first written did not compile
(`sgVPC` unused), so it was rewritten to assign over it. M10 needs a default VPC that has
**no** default subnet — the one state where the VPC is known and the subnet is not — which
nothing covered; `TestEC2_Authz_VpcIsAnswerableWithoutASubnet` was added for it rather than
letting the mutant be recorded as equivalent.

## Follow-up

Inherits #704: condition-key **names** are matched case-sensitively where AWS documents them
as case-insensitive. Global to the evaluator, not new here.

## Docs

New `##### A launch's networking resources carry ec2:Subnet and ec2:Vpc` section with AWS's
example policy, the per-resource table and the absent-key consequences. The #673 paragraph
saying AWS's recommended guardrail is a key "which substrate does not populate" is
rewritten — both spellings of the guardrail now hold. The `Not covered` bullet listing these
keys as absent, and the single-valued-keys sentence, are updated.

Drive-by: **three dead in-page links** in `docs/services.md`, found while adding the
cross-references — `#finding-a-fleets-instances` (×2) where the rendered anchor is
`#finding-a-fleet-s-instances`, and `"default VPC" → #runinstances`, a table row with no
anchor. Every in-page link in the built page now resolves; the VitePress build does not
fail on a dead anchor, so this was checked by diffing every `href="#…"` against every
`id="…"` in the rendered HTML.

## Verification

`gofmt -l .` clean · `go build ./...` · `go vet ./...` · `golangci-lint run ./...` 0 issues ·
`make test` (race) green · `go test -C test/e2e ./...` green · coverage **82.3%** ·
`make docs-reference docs-reference-check docs-versions` clean · `npm --prefix docs run build`
clean.

## Compatibility

Additive as a mechanism — no existing decision changes unless a policy already names one of
these keys. For a policy that **does**, the change is loud and in the safe direction: such a
statement was previously evaluated against an absent key, which made a negated `Deny` refuse
every launch and a positive `Allow` refuse every launch. Both now decide on the launch's
actual subnet and VPC. A consumer who wrote AWS's guardrail and worked around it by removing
the statement should put it back.
