### PR TITLE
chore(release): v0.106.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.106.0] - 2026-08-21
+
 ### Added
 - **`aws:TagKeys` is populated on every request that carries tags, and IAM's request context
   can hold a multivalued key** (#690). `EvaluationRequest` gains
@@ -7963,7 +7965,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.105.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.106.0...HEAD
+[v0.106.0]: https://github.com/scttfrdmn/substrate/compare/v0.105.0...v0.106.0
 [v0.105.0]: https://github.com/scttfrdmn/substrate/compare/v0.104.0...v0.105.0
 [v0.104.0]: https://github.com/scttfrdmn/substrate/compare/v0.103.0...v0.104.0
 [v0.103.0]: https://github.com/scttfrdmn/substrate/compare/v0.102.0...v0.103.0


### PR DESCRIPTION
Cuts the `## [Unreleased]` section for milestone 91 as `## [v0.106.0] - 2026-08-21` and adds its
comparison link, per CLAUDE.md's release steps. No code changes.

The nine issues the release resolves — #685, #686, #687, #688, #689, #690, #691, #692, #693 — are
already closed by their own PRs (#694, #698, #699, #700, #701, #702, #703, #705, #706). The signed
tag goes on this PR's merge commit once it lands.