### PR TITLE
fix(ec2): a filter naming no values matches nothing, everywhere (#696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A filter naming no values matches nothing on every EC2 describe, not just on most of
+  them** (#696). Three operations answered a valueless `Filter.N` with *every* resource:
+  `DescribeSecurityGroups`, whose `group-name`, `vpc-id` and `group-id` arms each carried a
+  hand-written `len(vals) > 0` guard, and `DescribeTags` and
+  `DescribeInstanceTypeOfferings`, which share `ec2FilterAccepts`. The other nine matchers
+  already selected nothing, by calling `containsStr` with no guard at all.
+
+  AWS documents no rule here — Using_Filtering says only that "You can't specify a filter
+  value of null" — so both answers were readings, and the defect was the disagreement: the
+  same request meant two different things depending on which operation received it. The two
+  permissive sites converge on the nine strict ones. The argument for the old behaviour was
+  that dropping every result turns a malformed request into a silently empty answer, but the
+  unfiltered answer is silent in exactly the same way and wrong in the more dangerous
+  direction — a caller who asked for a subset and got everything cannot tell that from a
+  genuine match on every resource. #686 had already settled the same question for `tag:<key>`
+  on `DescribeImages`, so this extends a rule rather than inventing one.
+
+  A quiet change: an over-broad answer becomes an empty one, and nothing that succeeds today
+  starts failing. Two distinctions are unaffected. A filter carrying one *empty* value
+  (`Filter.1.Value.1=`) asks for the empty string and is a value like any other — which is
+  what `DescribeTags`' own Example 6 does. An **absent** filter still constrains nothing, and
+  `describeInstanceTypeOfferings` now looks its two filters up with the two-value map form to
+  keep telling the two apart: a bare `filters[name]` index yields the same nil slice for
+  "absent" and "present with no values", which under the new rule would have emptied the
+  catalog for an unfiltered query.
+
 ## [v0.106.0] - 2026-08-21
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -2828,21 +2828,26 @@ Substrate now serves all three — the first on five operations, and the other t
   except `DescribeImages`.
 - **Filter names and values are case-sensitive**, per the `Filter` type. `VPC-Id` is not
   `vpc-id` and is refused.
-- **A `tag:<key>` filter with no value matches nothing.** AWS says only that a filter value
-  cannot be null; matching nothing is substrate's reading, and `tag-key` is the documented
-  way to ask the any-value question.
+- **A filter naming no values at all matches nothing** — on every operation and every filter
+  name, `tag:<key>` included. AWS says only that a filter value cannot be null, so matching
+  nothing is substrate's reading; `tag-key` is the documented way to ask the any-value
+  question. Note the distinction from a filter carrying one *empty* value: `Filter.1.Value.1=`
+  asks for the empty string, which `DescribeTags`' own Example 6 does, and that is a value like
+  any other. Until [#696](https://github.com/scttfrdmn/substrate/issues/696),
+  `DescribeSecurityGroups`, `DescribeTags` and `DescribeInstanceTypeOfferings` answered a
+  valueless filter with *every* resource, because they shared a matcher that read it as an
+  absent filter. An unfiltered answer to a request that asked for a subset is the more
+  dangerous silence of the two: a caller cannot tell it from a genuine match on everything.
+  An **absent** filter still constrains nothing, as it always has.
 
 **Two gaps, deliberately left standing**, because closing either would newly change
-requests that succeed today. Thirteen EC2 describes — including `DescribeVpcs`,
+requests that succeed today. Twelve EC2 describes — including `DescribeVpcs`,
 `DescribeAddresses`, `DescribeInstanceTypes` and `DescribeAvailabilityZones` — never parse
 `Filter.N` at all, so they neither apply nor refuse one
 ([#695](https://github.com/scttfrdmn/substrate/issues/695)). And filter *values* honour
 EC2's documented wildcards only on `DescribeInstanceTypeOfferings` and `DescribeTags` — the
 two operations whose reference pages state them outright; everywhere else matching is exact
-([#697](https://github.com/scttfrdmn/substrate/issues/697)). A third, narrower one: an
-**empty** value list matches nothing on most operations but matches everything on
-`DescribeSecurityGroups` and `DescribeTags`, both of which route through the same shared
-matcher ([#696](https://github.com/scttfrdmn/substrate/issues/696)).
+([#697](https://github.com/scttfrdmn/substrate/issues/697)).
 
 ### RunInstances requires a resolvable AMI
 

--- a/emulator/ec2_describetags.go
+++ b/emulator/ec2_describetags.go
@@ -248,9 +248,11 @@ func ec2TagMatchesFilters(item ec2TagDescription, filters map[string][]string) b
 // An explicitly empty value is a value, not an absent one: AWS's Example 6 filters on
 // `value` with `Filter.3.Value.1=` to find tags whose value is the empty string, and
 // [extractEC2Filters] preserves that as a one-element list. A filter carrying *no* Value.N
-// at all is a different request, and [ec2FilterAccepts] answers it by matching everything —
-// this operation inherits that rule rather than choosing it, and reconciling it with the
-// match-nothing reading its siblings take is #696.
+// at all is a different request, and it now matches nothing, which is what every other EC2
+// describe already answered — #696 converged the two permissive sites on the nine strict ones
+// rather than the other way round. This operation still inherits the rule from
+// [ec2FilterAccepts] rather than choosing it. Only names present in the filter map reach here,
+// so an absent filter never arrives as an empty list.
 //
 // There is no default arm returning true. Every name that reaches here is one of the five
 // AWS documents, because [ec2TagFilterSpec] refuses the rest before the scan and its

--- a/emulator/ec2_instancetypes.go
+++ b/emulator/ec2_instancetypes.go
@@ -356,13 +356,20 @@ func ec2globMatch(pattern, value []rune) bool {
 // ec2FilterAccepts reports whether value satisfies a filter's value list, which EC2
 // joins with OR.
 //
-// A filter carrying no values at all is treated as absent rather than as matching
-// nothing: [extractEC2Filters] records such a filter with an empty list, and dropping
-// every result for it would turn a malformed request into a silently empty answer.
+// A filter carrying no values at all matches nothing, so an empty list drops every
+// result. This function used to treat such a filter as absent, on the argument that
+// dropping everything turns a malformed request into a silently empty answer — but the
+// unfiltered answer that argument produces is silent in the same way and wrong in the
+// more dangerous direction, since a caller cannot tell it from a genuine match on every
+// resource. #686 had already settled the shape for `tag:<key>`, and nine of substrate's
+// eleven matchers reached the same answer by calling [containsStr] with no guard, so this
+// is the majority rule rather than a new one (#696).
+//
+// A caller must therefore not pass a bare map index: an *absent* filter constrains nothing
+// and an empty value list matches nothing, and `filters[name]` yields the same nil slice for
+// both. Look the name up with the two-value form and only call this when it is present, as
+// [extractEC2Filters] records a valueless filter as a present key.
 func ec2FilterAccepts(values []string, value string) bool {
-	if len(values) == 0 {
-		return true
-	}
 	for _, v := range values {
 		if ec2FilterValueMatches(v, value) {
 			return true

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -1692,13 +1692,16 @@ func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSReque
 		if !ids.match(sg.GroupID) {
 			continue
 		}
-		if vals, ok := filters["group-name"]; ok && len(vals) > 0 && !containsStr(vals, sg.GroupName) {
+		// A filter naming no values matches nothing, as it does everywhere else: these
+		// three arms used to carry an `ok && len(vals) > 0 &&` guard, which returned every
+		// security group for a request that had asked for a subset (#696).
+		if vals, ok := filters["group-name"]; ok && !containsStr(vals, sg.GroupName) {
 			continue
 		}
-		if vals, ok := filters["vpc-id"]; ok && len(vals) > 0 && !containsStr(vals, sg.VPCID) {
+		if vals, ok := filters["vpc-id"]; ok && !containsStr(vals, sg.VPCID) {
 			continue
 		}
-		if vals, ok := filters["group-id"]; ok && len(vals) > 0 && !containsStr(vals, sg.GroupID) {
+		if vals, ok := filters["group-id"]; ok && !containsStr(vals, sg.GroupID) {
 			continue
 		}
 		renderPerm := func(rule EC2IPPermission) permItem {
@@ -4576,13 +4579,20 @@ func (p *EC2Plugin) describeInstanceTypeOfferings(reqCtx *RequestContext, req *A
 		InstanceTypeOfferings []offeringItem `xml:"instanceTypeOfferingSet>item"`
 	}
 
+	// Both filters are looked up with the two-value form because an absent filter and a
+	// filter naming no values are different requests and now get different answers: absent
+	// constrains nothing, while an empty value list matches nothing (#696). Indexing the map
+	// directly would conflate them and drop the whole catalog for an unfiltered query.
+	wantTypes, filterByType := filters["instance-type"]
+	wantLocations, filterByLocation := filters["location"]
+
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 	for _, info := range ec2InstanceTypeCatalog {
-		if !ec2FilterAccepts(filters["instance-type"], info.InstanceType) {
+		if filterByType && !ec2FilterAccepts(wantTypes, info.InstanceType) {
 			continue
 		}
 		for _, loc := range locations {
-			if !ec2FilterAccepts(filters["location"], loc) {
+			if filterByLocation && !ec2FilterAccepts(wantLocations, loc) {
 				continue
 			}
 			resp.InstanceTypeOfferings = append(resp.InstanceTypeOfferings, offeringItem{

--- a/emulator/ec2_valueless_filter_test.go
+++ b/emulator/ec2_valueless_filter_test.go
@@ -1,0 +1,182 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file pins #696: a Filter.N entry naming no Value.N at all matches nothing, on every
+// operation.
+//
+// Nine of substrate's eleven filter-value matchers already answered that way, by calling
+// containsStr with no guard on the value list. Two did not — ec2FilterAccepts and the three
+// hand-written DescribeSecurityGroups arms — and returned *every* resource instead, reading a
+// valueless filter as an absent one. Three operations diverged, because DescribeTags shares
+// ec2FilterAccepts: DescribeSecurityGroups, DescribeTags and DescribeInstanceTypeOfferings.
+//
+// AWS documents no rule here — Using_Filtering says only that "You can't specify a filter
+// value of null" — so both answers were readings. What made the split a defect is that the
+// same request meant two different things depending on which operation received it, and the
+// permissive reading is the more dangerous silence of the two: a caller who asked for a
+// subset and got everything cannot tell that answer from a genuine match on every resource.
+// #686 had already settled it for tag:<key> on DescribeImages; this converges the rest.
+//
+// Throughout, note what is *not* being asserted. A filter carrying one empty value
+// (Filter.1.Value.1=) asks for the empty string and is a value like any other — DescribeTags'
+// own Example 6 does exactly that, and TestEC2_DescribeTags_FiltersNarrowTheAnswer pins it.
+// An *absent* filter still constrains nothing.
+
+// ec2SecurityGroupNames returns the group names DescribeSecurityGroups reports for params.
+func ec2SecurityGroupNames(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	full := map[string]string{"Action": "DescribeSecurityGroups"}
+	for k, v := range params {
+		full[k] = v
+	}
+	resp := ec2Request(t, ts, full)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var doc struct {
+		Groups []struct {
+			GroupName string `xml:"groupName"`
+		} `xml:"securityGroupInfo>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&doc))
+	names := make([]string, 0, len(doc.Groups))
+	for _, g := range doc.Groups {
+		names = append(names, g.GroupName)
+	}
+	return names
+}
+
+// TestEC2_DescribeSecurityGroups_ValuelessFilterMatchesNothing is the first of #696's two
+// permissive sites: the three hand-written arms carried an `ok && len(vals) > 0 &&` guard, so
+// a caller who named a filter and no values got every security group in the account.
+//
+// Every evaluated name is exercised, because the guard was written out three times rather
+// than shared — dropping it from two of the three would have left the divergence in place on
+// the third.
+func TestEC2_DescribeSecurityGroups_ValuelessFilterMatchesNothing(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	var vpc struct {
+		VPCID string `xml:"vpc>vpcId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.9.0.0/16"}, &vpc)
+	require.NotEmpty(t, vpc.VPCID)
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":           "CreateSecurityGroup",
+		"GroupName":        "valueless-fixture",
+		"GroupDescription": "valueless-fixture",
+		"VpcId":            vpc.VPCID,
+	}, nil)
+
+	// The fixture is only meaningful if the unfiltered answer is non-empty, which is also
+	// the assertion that an absent filter still constrains nothing.
+	all := ec2SecurityGroupNames(t, ts, nil)
+	require.Contains(t, all, "valueless-fixture",
+		"fixture setup: the group must be visible without a filter")
+
+	for _, name := range []string{"group-name", "vpc-id", "group-id"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := ec2SecurityGroupNames(t, ts, map[string]string{"Filter.1.Name": name})
+			assert.Empty(t, got,
+				"a valueless %s filter returned groups; it must select none of them", name)
+		})
+	}
+}
+
+// TestEC2_DescribeTags_ValuelessFilterMatchesNothing covers the site that inherited the
+// permissive rule rather than choosing it: ec2TagMatchesFilter routes every value comparison
+// through ec2FilterAccepts, so all five of AWS's documented names changed together.
+//
+// tag:<key> is included even though #686 settled that spelling on DescribeImages, because
+// DescribeTags reached it through the other matcher and so answered the opposite way — the
+// two spellings of the same question are now one answer.
+func TestEC2_DescribeTags_ValuelessFilterMatchesNothing(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instID, _ := ec2SeedTaggedResources(t, ts)
+
+	require.Contains(t, ec2TagKeysFor(t, ts, nil), instID+"/Env=prod",
+		"fixture setup: the tag must be visible without a filter")
+
+	for _, name := range []string{"key", "value", "resource-id", "resource-type", "tag:Env"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := ec2TagKeysFor(t, ts, map[string]string{"Filter.1.Name": name})
+			assert.Empty(t, got,
+				"a valueless %s filter returned tags; it must select none of them", name)
+		})
+	}
+}
+
+// TestEC2_DescribeInstanceTypeOfferings_ValuelessFilterMatchesNothing covers the operation
+// ec2FilterAccepts was written for.
+//
+// Its two call sites index the filter map, so they need the two-value lookup form to keep
+// telling an absent filter from a valueless one — with a bare index both arrive as the same
+// nil slice, and the whole catalog would disappear from an unfiltered query. The no-filter
+// case in TestEC2_DescribeInstanceTypeOfferings_InstanceTypeFilter is the other half of that
+// guard; this asserts the two answers differ.
+func TestEC2_DescribeInstanceTypeOfferings_ValuelessFilterMatchesNothing(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	require.NotEmpty(t, ec2Offerings(t, ts, map[string]string{}),
+		"fixture setup: the catalog must be non-empty without a filter")
+
+	for _, name := range []string{"instance-type", "location"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := ec2Offerings(t, ts, map[string]string{"Filter.1.Name": name})
+			assert.Empty(t, got,
+				"a valueless %s filter returned offerings; it must select none of them", name)
+		})
+	}
+}
+
+// TestEC2_ValuelessFilter_MajorityOperationsUnchanged is the other direction of #696: the nine
+// matchers that already answered "nothing" still do.
+//
+// The convergence went towards these, so a regression here would mean the fix had been
+// applied backwards — and because the two permissive sites are the ones that moved, nothing in
+// this test needed to change to make it pass.
+func TestEC2_ValuelessFilter_MajorityOperationsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DescribeSnapshots", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		ec2SeedTaggedSnapshots(t, ts, "majority-unchanged")
+		require.NotEmpty(t, ec2SnapshotIDsFor(t, ts, map[string]string{}))
+		assert.Empty(t, ec2SnapshotIDsFor(t, ts, map[string]string{"Filter.1.Name": "status"}))
+	})
+
+	t.Run("DescribeImages", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		ec2ImageFilterFixture(t, ts)
+		require.NotEmpty(t, ec2FilteredImageIDs(t, ts, map[string]string{}))
+		assert.Empty(t, ec2FilteredImageIDs(t, ts, map[string]string{"Filter.1.Name": "image-id"}))
+	})
+
+	t.Run("DescribeSubnets", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		var vpc struct {
+			VPCID string `xml:"vpc>vpcId"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.11.0.0/16"}, &vpc)
+		ec2CreateTaggedSubnet(t, ts, vpc.VPCID, "10.11.1.0/24", "us-east-1a", nil)
+		require.NotEmpty(t, ec2SubnetIDsFor(t, ts, map[string]string{}))
+		assert.Empty(t, ec2SubnetIDsFor(t, ts, map[string]string{"Filter.1.Name": "state"}))
+	})
+}


### PR DESCRIPTION
Three EC2 describes answered a `Filter.N` entry naming no `Value.N` with **every** resource, where the other nine answered with none.

The permissive three were `DescribeSecurityGroups` — whose `group-name`, `vpc-id` and `group-id` arms each carried a hand-written `ok && len(vals) > 0 &&` guard — and `DescribeTags` and `DescribeInstanceTypeOfferings`, which both route their value comparisons through `ec2FilterAccepts`. The nine strict ones got there by calling `containsStr` with no guard at all, which is why the split was never deliberate on their side.

### Corrections to the issue body

- **"Each existing comment argues for the behaviour it has" is half false.** Only `ec2FilterAccepts` carried a rationale; the three `describeSecurityGroups` arms carried no comment whatsoever.
- **Two operations undercounts it.** Three diverged — `DescribeTags` inherits the permissive rule through the shared matcher, which #688 recorded at the time as something to reconcile here.

### The decision

An empty value list **matches nothing, on every operation**. AWS documents no rule — Using_Filtering says only that "You can't specify a filter value of null" — so both answers were readings, and what made this a defect is the disagreement rather than either answer. #686 had already settled the same question for `tag:<key>` on `DescribeImages`, so the two permissive sites converge on the nine strict ones rather than the other way round.

The old rationale was that dropping every result turns a malformed request into a silently empty answer. The unfiltered answer is silent in exactly the same way and wrong in the more dangerous direction: a caller who asked for a subset and got everything back cannot distinguish that from a genuine match on every resource. `ec2FilterAccepts`' comment is rewritten to record the reversal rather than deleted, per the issue's own criterion, and `ec2TagMatchesFilter`'s now-false sentence ("`ec2FilterAccepts` answers it by matching everything") is corrected.

### The nil-slice trap

`describeInstanceTypeOfferings` passed `filters["instance-type"]` straight into the matcher. A bare map index yields the same nil slice for *absent* and for *present with no values*, so under the new rule an unfiltered query would have returned an empty catalog. Both lookups move to the two-value form; `extractEC2Filters` records a valueless filter as a present key with a nil value, so `ok` distinguishes them. `ec2FilterAccepts`' doc comment now states that contract for future callers. The pre-existing "no filter returns the whole catalog" row in `TestEC2_DescribeInstanceTypeOfferings_InstanceTypeFilter` is the other half of that guard.

### Blast radius

Quiet. An over-broad answer becomes an empty one; nothing that succeeds today starts failing. Two distinctions are untouched:

- A filter carrying one **empty** value (`Filter.1.Value.1=`) asks for the empty string and is a value like any other — `DescribeTags`' own Example 6 does this, and `ec2_describetags_test.go:144` pins it.
- An **absent** filter still constrains nothing.

### Tests

New `emulator/ec2_valueless_filter_test.go`. All three operations, every evaluated filter name on each — the SG guard was written out three times, so fixing two of three would have left the divergence standing on the third. Plus `TestEC2_ValuelessFilter_MajorityOperationsUnchanged`, which asserts the convergence went in the right direction on `DescribeSnapshots`, `DescribeImages` and `DescribeSubnets`.

Fail-before verified by restoring the three source files and re-running: all twelve subtests fail, and the majority-unchanged test is green both before and after — nothing in it had to change to make the fix pass.

### Docs

`docs/services.md`' "Filter semantics that apply everywhere" gains the general rule, replacing the `tag:<key>`-only bullet, and states the absent-vs-valueless-vs-empty-value distinction. The "**Two gaps, deliberately left standing**" paragraph loses its third gap, and its `#695` count is corrected from thirteen describes to twelve — `DescribeSubnets` (#685) and `DescribeTags` (#688) have both landed since it was written.

```
gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...   # 0 issues
make test                                                                # race, green
make coverage                                                            # 82.3% total
make docs-reference docs-reference-check docs-versions                    # up to date
npm --prefix docs run build && go test -C test/e2e ./...                  # green
```

Closes #696
