### PR TITLE
fix(ec2): wildcards in every filter value, and AWS's documented filter limits (#697)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **EC2's documented filter limits, enforced in one place** (#697). Using_Filtering publishes
+  three: "You can specify up to 50 filters and up to 200 total filter values in a single
+  request" and "Filter strings can be up to 255 characters in length." All three are now
+  checked in `ec2FilterSpec.check`, so every one of the eleven operations that has a filter
+  spec inherits them, and the count is tested before a filter name is validated — a 51st
+  filter is refused for being the 51st, not for whatever it happens to be called. The
+  `Filter` type's own reference page publishes none of the three, which is why they are cited
+  from the filtering guide.
+
+  Provenance: the limits are AWS's, the error code is substrate's reading. No EC2 error code
+  exists for a filter limit — every `*LimitExceeded` in the client-error table names a
+  resource quota (`KeyPairLimitExceeded`, `NatGatewayLimitExceeded`,
+  `TrafficMirrorFilterLimitExceeded`, …) — so substrate answers `InvalidParameterValue`, whose
+  documented gloss is "A value specified in a parameter is not valid, is unsupported, or
+  cannot be used."
+
 ### Fixed
+- **EC2 filter values honour AWS's wildcards on every describe, not on the two that happened
+  to have them** (#697). AWS states the rule once for the whole family — "An asterisk (\*)
+  matches zero or more characters, and a question mark (?) matches zero or one character" —
+  but nine of substrate's eleven filter-value matchers compared with `containsStr`, so
+  `instance-type=t3.*` selected nothing at all. That is the silent-narrowing failure of an
+  ignored filter: a consumer sees a legitimate-looking empty set rather than an error.
+  `DescribeInstanceTypeOfferings` and `DescribeTags` already matched through
+  `ec2FilterValueMatches`, which is what made the split a defect — one documented value meant
+  two different things depending on the operation. 55 comparisons across `DescribeInstances`,
+  `DescribeVolumes`, `DescribeImages`, `DescribeSnapshots`, `DescribeSubnets`,
+  `DescribeSecurityGroups`, `DescribeRouteTables`, `DescribeNatGateways` and `DescribeFleets`
+  now route through the one matcher, escaping (`\*`, `\?`, `\\`) and all.
+
+  **`?` matches zero or one character, and AWS's own page disagrees with itself about that.**
+  #697 reported the contradiction; this is its resolution. Using_Filtering's normative
+  "Filtering considerations" list says "zero or one", and the console's wildcard section says
+  the same and works it through: "if you have a data set with the values prod, prods, and
+  production, a search of `prod*` matches all values, whereas `prod?` matches only prod and
+  prods". One later sentence in the CLI examples says "The ? wildcard matches exactly 1
+  character" and is refuted by its own next example, which returns descriptions that are
+  "'database' or 'database' followed by one character", and by `database????` returning
+  "database" followed by **up to** four characters. Two normative statements and three worked
+  examples against one self-refuting sentence, so substrate's existing zero-or-one stands and
+  was **not** narrowed.
+
+- **`attachment.delete-on-termination` is case-sensitive, like every other EC2 filter value**
+  (#697). It was the tree's only case-*insensitive* value comparison, inherited from a
+  hand-rolled loop that lowercased the request value so `True` selected a
+  delete-on-termination attachment. AWS documents the opposite twice — Using_Filtering's
+  "Filter values are case sensitive" and the `Filter` type's "Filter values are
+  case-sensitive" — so `True` now selects nothing. The lowercase form AWS's own examples use
+  is unaffected, and `*e` reaches both booleans.
+
+- **`DescribeRouteTables`' `association.subnet-id` is a filter value, not an identifier**
+  (#697). `routeTableHasSubnet` compared it exactly, which was the right rule for the wrong
+  reason: its doc comment classified it alongside `sgSourcesMatch` as a record-to-record
+  comparison, when it is a request value matched against a stored association. It globs now,
+  where the same string in `SubnetId.N` would still be a malformed ID.
+
 - **A filter naming no values matches nothing on every EC2 describe, not just on most of
   them** (#696). Three operations answered a valueless `Filter.N` with *every* resource:
   `DescribeSecurityGroups`, whose `group-name`, `vpc-id` and `group-id` arms each carried a

--- a/docs/services.md
+++ b/docs/services.md
@@ -2713,7 +2713,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeAvailabilityZones | Three zones per region, from the same list the offerings and spot-price operations use — see [Instance types are a seeded catalog](#instance-types-are-a-seeded-catalog) |
 | DescribeRegions | |
 | DescribeInstanceTypes | Answers from a [seeded catalog](#instance-types-are-a-seeded-catalog). `InstanceType.N` is an assertion: a type outside the catalog is refused with `InvalidInstanceType`. `Filter.N` is not applied |
-| DescribeInstanceTypeOfferings | `instance-type` and `location` filters (both with [wildcards](#instance-types-are-a-seeded-catalog)) and the `LocationType` parameter; an unmatched filter is an empty answer, not an error |
+| DescribeInstanceTypeOfferings | `instance-type` and `location` filters (both with [wildcards](#wildcards-in-filter-values)) and the `LocationType` parameter; an unmatched filter is an empty answer, not an error |
 | DescribeSpotPriceHistory | One stub price per catalog type per zone. `InstanceType.N` here is a *filter*, so an unknown type is an empty history — [see below](#instance-types-are-a-seeded-catalog) |
 | CreateRouteTable | |
 | AssociateRouteTable | |
@@ -2799,8 +2799,8 @@ one is refused on its neighbour — `tag:<key>` most conspicuously (see below).
 | DescribeRouteTables | `association.route-table-id`, `association.subnet-id`, `vpc-id` | `association.gateway-id`, `association.main`, `association.route-table-association-id`, `owner-id`, `route-table-id`, `tag-key`, `tag:<key>`, and the eleven `route.*` filters |
 | DescribeNatGateways | `state`, `vpc-id` | `nat-gateway-id`, `subnet-id`, `tag-key`, `tag:<key>` |
 | DescribeFleets | `activity-status`, `fleet-state`, `type` | `excess-capacity-termination-policy`, `replace-unhealthy-instances` |
-| DescribeInstanceTypeOfferings | `instance-type`, `location` (both with [wildcards](#offerings-filters-and-wildcards)) | — |
-| DescribeTags | `key`, `resource-id`, `resource-type`, `value`, `tag:<key>` — all five AWS documents, all with [wildcards](#finding-a-resource-by-tag) | — |
+| DescribeInstanceTypeOfferings | `instance-type`, `location` (both with [wildcards](#wildcards-in-filter-values)) | — |
+| DescribeTags | `key`, `resource-id`, `resource-type`, `value`, `tag:<key>` — all five AWS documents, all with [wildcards](#wildcards-in-filter-values) | — |
 
 `tag:<key>` is refused on **`DescribeFleets` and `DescribeInstanceTypeOfferings`**, which
 document no tag filter at all — neither `tag:<key>` nor `tag-key` — even though a fleet
@@ -2839,15 +2839,63 @@ Substrate now serves all three — the first on five operations, and the other t
   absent filter. An unfiltered answer to a request that asked for a subset is the more
   dangerous silence of the two: a caller cannot tell it from a genuine match on everything.
   An **absent** filter still constrains nothing, as it always has.
+- **Wildcards work in every filter value**, on every operation — see below.
+- **The documented request limits are enforced**: at most **50 filters** and **200 total
+  filter values** per request, and at most **255 characters** per filter value. Exceeding any
+  of them is `InvalidParameterValue`, HTTP 400. The limits are AWS's, from Using_Filtering's
+  "Filtering considerations"; the error code is substrate's reading, because EC2's error tables
+  publish no filter-limit code — every `*LimitExceeded` code there names a resource quota, not
+  a request-shape limit. The 255 applies to values, not names: every documented name is a short
+  fixed literal, so a length rule on names could only fire after the refusal already had.
 
-**Two gaps, deliberately left standing**, because closing either would newly change
-requests that succeed today. Twelve EC2 describes — including `DescribeVpcs`,
-`DescribeAddresses`, `DescribeInstanceTypes` and `DescribeAvailabilityZones` — never parse
-`Filter.N` at all, so they neither apply nor refuse one
-([#695](https://github.com/scttfrdmn/substrate/issues/695)). And filter *values* honour
-EC2's documented wildcards only on `DescribeInstanceTypeOfferings` and `DescribeTags` — the
-two operations whose reference pages state them outright; everywhere else matching is exact
-([#697](https://github.com/scttfrdmn/substrate/issues/697)).
+#### Wildcards in filter values
+
+Since [#697](https://github.com/scttfrdmn/substrate/issues/697), one matcher backs every EC2
+describe filter, so these rules hold for all of them — previously only
+`DescribeInstanceTypeOfferings` and `DescribeTags` honoured wildcards, the two operations whose
+reference pages state them outright, and the other nine compared exactly.
+
+| Value | Matches |
+|---|---|
+| `c5.2xlarge` | that value exactly |
+| `c5.*` | the eight `c5` sizes — `*` matches zero or more characters |
+| `c5*` | `c5` **and** `c5a`, since `*` also matches the `a` |
+| `t3?.micro` | `t3.micro` and `t3a.micro` — `?` matches zero **or one** character |
+| `m5.larg\*` | the literal string `m5.larg*`; a backslash escapes a wildcard |
+| `M5.XLarge` | nothing — values are case-sensitive |
+
+**`?` matches zero or one character, and AWS's page disagrees with itself about that.** The
+resolution is substrate's, and it is the reading two normative statements and three worked
+examples support: Using_Filtering's "Filtering considerations" list — the one that governs the
+API rather than the console — says "a question mark (?) matches zero or one character", and the
+console's wildcard section says the same and works it through (`prod?` matches `prod` and
+`prods`, not `production`). One sentence in the CLI examples says "The ? wildcard matches
+exactly 1 character" and is refuted by its own example in the next breath, which returns
+descriptions that are `"database"` *or* `"database"` plus one character, and by `database????`
+returning `"database"` plus **up to** four. `DescribeTags`' Example 4 settles nothing either
+way: `?ebserver` finding `webserver` or `Webserver` is consistent with both readings, because
+the string a zero-or-one `?` would additionally match is not in AWS's data set.
+
+Two comparisons deliberately stay exact, because they are not filter values. **Identifier
+parameters** — `KeyName.N`, `GroupName.N`, `FleetId.N`, `RegionName.N`, `InstanceType.N` —
+assert the resource exists and answer `Invalid*.NotFound` when it does not, so globbing them
+would turn a NotFound contract into a match. And **filter names**, which are one of a fixed
+documented set.
+
+A filter whose *values* happen to be identifiers is still a filter: `DescribeRouteTables`'
+`association.subnet-id`, `DescribeSubnets`' `vpc-id`, `DescribeSnapshots`' `volume-id` and the
+rest all glob. So `association.subnet-id=subnet-*` narrows the answer to the route tables
+associated with any subnet at all, where the same string in `SubnetId.N` is a malformed ID.
+
+One case-*insensitive* comparison was removed:
+`attachment.delete-on-termination` on `DescribeVolumes` accepted `True` for `true`, which AWS's
+"Filter values are case sensitive" does not, and which no sibling boolean filter did.
+
+**One gap, deliberately left standing**, because closing it would newly change requests that
+succeed today: twelve EC2 describes — including `DescribeVpcs`, `DescribeAddresses`,
+`DescribeInstanceTypes` and `DescribeAvailabilityZones` — never parse `Filter.N` at all, so
+they neither apply nor refuse one
+([#695](https://github.com/scttfrdmn/substrate/issues/695)).
 
 ### RunInstances requires a resolvable AMI
 
@@ -4044,16 +4092,9 @@ answer. **Any other name is refused** with `InvalidParameterValue`, which is now
 that rule started. Multiple `Filter.N.Value.M` values are an OR; separate `Filter.N`
 entries AND together.
 
-Filter values honour EC2's documented wildcards, and are **case-sensitive**:
-
-| Value | Matches |
-|---|---|
-| `c5.2xlarge` | that type |
-| `c5.*` | the eight `c5` sizes |
-| `c5*` | `c5` **and** `c5a` — `*` matches zero or more characters, including the `a` |
-| `t3?.micro` | `t3.micro` and `t3a.micro` — `?` matches zero **or one** character |
-| `m5.larg\*` | nothing; a backslash escapes a literal wildcard |
-| `M5.XLarge` | nothing |
+Filter values honour EC2's documented wildcards and are case-sensitive, per
+[the rules that apply to every EC2 filter](#wildcards-in-filter-values). This operation is
+where that matcher started, which is why the examples there use instance types.
 
 `LocationType` is a top-level **parameter**, not a filter name (`location-type` is
 refused as a filter). `availability-zone` is the default and `region` returns one
@@ -4507,7 +4548,7 @@ group *name* where AWS's `TagDescription` reports an ID.
 |---|---|
 | Filters | `key`, `resource-id`, `resource-type`, `value`, `tag:<key>` — every name AWS documents, all evaluated, none inert |
 | `tag-key` | **Refused.** This operation documents no such filter, alone in the describe family, because `key` already matches a key whatever its value |
-| Wildcards | `*` and `?` work in every filter value, which AWS's Example 4 states outright ("specify the value as `?ebserver` to find tags with the key `webserver` or `Webserver`") |
+| Wildcards | `*` and `?` work in every filter value, which AWS's Example 4 states outright ("specify the value as `?ebserver` to find tags with the key `webserver` or `Webserver`"). Since #697 that is true of [every EC2 filter](#wildcards-in-filter-values), not just this one |
 | An empty value | A tag whose value is the empty string renders `<value/>` and is matched by `Filter.N.Value.1=` — AWS's Example 1 and Example 6 respectively |
 | `MaxResults` | 5–1000. A value outside the range is **refused** with `InvalidParameterValue`, not clamped: a caller who asked for 2000 asked for something the operation cannot do |
 | `NextToken` | A decimal offset. A malformed token is refused; an offset past the end is clamped to an empty last page, so resuming after a tag was deleted is not an error |

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -693,7 +693,7 @@ func ec2VolumeMatchesFilters(vol EC2Volume, filters map[string][]string) bool {
 func ec2VolumeMatchesFilter(vol EC2Volume, name string, values []string) bool {
 	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
 		for _, t := range vol.Tags {
-			if t.Key == tagKey && containsStr(values, t.Value) {
+			if t.Key == tagKey && ec2FilterAccepts(values, t.Value) {
 				return true
 			}
 		}
@@ -706,7 +706,7 @@ func ec2VolumeMatchesFilter(vol EC2Volume, name string, values []string) bool {
 	// are per filter, not per list element.
 	anyAttachment := func(got func(EC2VolumeAttachment) string) bool {
 		for _, att := range vol.Attachments {
-			if containsStr(values, got(att)) {
+			if ec2FilterAccepts(values, got(att)) {
 				return true
 			}
 		}
@@ -715,20 +715,20 @@ func ec2VolumeMatchesFilter(vol EC2Volume, name string, values []string) bool {
 
 	switch name {
 	case "volume-id":
-		return containsStr(values, vol.VolumeID)
+		return ec2FilterAccepts(values, vol.VolumeID)
 	case "status":
-		return containsStr(values, vol.State)
+		return ec2FilterAccepts(values, vol.State)
 	case "volume-type":
-		return containsStr(values, vol.VolumeType)
+		return ec2FilterAccepts(values, vol.VolumeType)
 	case "size":
-		return containsStr(values, strconv.Itoa(vol.Size))
+		return ec2FilterAccepts(values, strconv.Itoa(vol.Size))
 	case "availability-zone":
-		return containsStr(values, vol.AvailabilityZone)
+		return ec2FilterAccepts(values, vol.AvailabilityZone)
 	case "snapshot-id":
-		return containsStr(values, vol.SnapshotID)
+		return ec2FilterAccepts(values, vol.SnapshotID)
 	case "tag-key":
 		for _, t := range vol.Tags {
-			if containsStr(values, t.Key) {
+			if ec2FilterAccepts(values, t.Key) {
 				return true
 			}
 		}
@@ -738,15 +738,17 @@ func ec2VolumeMatchesFilter(vol EC2Volume, name string, values []string) bool {
 	case "attachment.device":
 		return anyAttachment(func(a EC2VolumeAttachment) string { return a.Device })
 	case "attachment.delete-on-termination":
-		// The hand-rolled loop lowercased the value before comparing, so "True"
-		// matched a true attachment; EqualFold keeps that leniency without mutating
-		// the caller's value slice.
+		// This was the tree's only case-*insensitive* filter-value comparison, inherited
+		// from a hand-rolled loop that lowercased the value so "True" matched a true
+		// attachment. AWS documents the opposite twice — Using_Filtering's "Filter values
+		// are case sensitive" and the Filter type's own "Filter values are case-sensitive" —
+		// and every sibling boolean filter (`encrypted`, `default-for-az`,
+		// `map-public-ip-on-launch`) already compared exactly, so #697 makes this one agree
+		// rather than keeping a leniency real EC2 does not offer. A caller sending "True"
+		// now selects nothing, which is what AWS answers.
 		for _, att := range vol.Attachments {
-			want := strconv.FormatBool(att.DeleteOnTermination)
-			for _, v := range values {
-				if strings.EqualFold(v, want) {
-					return true
-				}
+			if ec2FilterAccepts(values, strconv.FormatBool(att.DeleteOnTermination)) {
+				return true
 			}
 		}
 		return false

--- a/emulator/ec2_describetags.go
+++ b/emulator/ec2_describetags.go
@@ -241,9 +241,10 @@ func ec2TagMatchesFilters(item ec2TagDescription, filters map[string][]string) b
 //
 // Values are matched with [ec2FilterAccepts], so **wildcards work** — AWS's Example 4 says
 // so for this operation in as many words: "You can use wildcards with filters, so you could
-// specify the value as ?ebserver to find tags with the key webserver or Webserver." This is
-// the first site outside DescribeInstanceTypeOfferings to match a filter value that way;
-// every other EC2 describe compares exactly, which is #697.
+// specify the value as ?ebserver to find tags with the key webserver or Webserver." Since #697
+// every EC2 describe matches its filter values that way, so this is no longer one of two
+// operations that does; see [ec2FilterValueMatches] for the rules and for what AWS's own page
+// contradicts itself about.
 //
 // An explicitly empty value is a value, not an absent one: AWS's Example 6 filters on
 // `value` with `Filter.3.Value.1=` to find tags whose value is the empty string, and

--- a/emulator/ec2_filter_wildcards_test.go
+++ b/emulator/ec2_filter_wildcards_test.go
@@ -1,0 +1,539 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file pins #697: EC2's documented filter-value wildcards work on every describe, not
+// on the two operations that happened to have them.
+//
+// AWS states the rule once, for the whole family: "An asterisk (*) matches zero or more
+// characters, and a question mark (?) matches zero or one character." Before #697 nine of
+// substrate's eleven matchers compared with containsStr, so `t3.*` selected nothing at all —
+// the silent-narrowing shape of an ignored filter, where a consumer sees a legitimate-looking
+// empty set instead of an error. DescribeInstanceTypeOfferings and DescribeTags matched
+// through ec2FilterValueMatches and so already worked, which is what made the split a defect:
+// one documented value meant two different things depending on the operation.
+//
+// Three things are deliberately *not* globbed, and the last test here pins each: identifier
+// parameter lists (KeyName.N, GroupName.N, FleetId.N, InstanceType.N), which assert a resource
+// exists rather than narrowing a set, and filter *names*, which are one of a fixed documented
+// set. See containsStr's doc comment for the whole surviving list.
+
+// ec2WildcardSubnetNames returns the Name tags of the subnets a tag:Name filter selected,
+// sorted, so a case asserts on the names it seeded rather than on generated IDs.
+func ec2WildcardSubnetNames(t *testing.T, ts *httptest.Server, value string) []string {
+	t.Helper()
+	names := make([]string, 0, 4)
+	for _, s := range ec2DescribeSubnets(t, ts, ec2Filter("tag:Name", value)) {
+		for _, tag := range s.Tags {
+			if tag.Key == "Name" {
+				names = append(names, tag.Value)
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestEC2_FilterWildcards_ValueSemantics walks AWS's own worked example through a real
+// request.
+//
+// EC2's "Wildcard search" section works the rule through on exactly this data set: "if you
+// have a data set with the values prod, prods, and production, a search of prod* matches all
+// values, whereas prod? matches only prod and prods". So the fixture is prod / prods /
+// production plus a fourth subnet whose Name is the literal string `prod*`, which is what
+// makes the escape rule assertable — `prod\*` must select that one and only that one.
+//
+// The prod? row is the one that matters most, because AWS's page contradicts itself about it.
+// Two normative statements and three worked examples say '?' matches zero **or one**
+// character; one sentence in the CLI examples says "exactly 1" and is refuted by its own next
+// example. Substrate follows the majority reading, so `prod?` selects prod — with the '?'
+// matching nothing — and that is asserted here rather than left to ec2globMatch's internals.
+func TestEC2_FilterWildcards_ValueSemantics(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	var vpc struct {
+		VPCID string `xml:"vpc>vpcId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.7.0.0/16"}, &vpc)
+	require.NotEmpty(t, vpc.VPCID)
+
+	for i, name := range []string{"prod", "prods", "production", `prod*`} {
+		ec2CreateTaggedSubnet(t, ts, vpc.VPCID,
+			"10.7."+strconv.Itoa(i+1)+".0/24", "us-east-1a",
+			map[string]string{"Name": name})
+	}
+
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{"no wildcard is still exact", "prod", []string{"prod"}},
+		{"'*' matches zero or more", "prod*", []string{"prod", `prod*`, "prods", "production"}},
+		{"'*' matches zero characters", "production*", []string{"production"}},
+		{"'*' matches in the middle", "*duct*", []string{"production"}},
+		{"leading '*'", "*s", []string{"prods"}},
+		{"'?' matches zero or one", "prod?", []string{"prod", `prod*`, "prods"}},
+		{"'?' matches exactly the one it needs", "pro?", []string{"prod"}},
+		{"'?' does not match two", "prod??", []string{"prod", `prod*`, "prods"}},
+		{"an escaped '*' is a literal", `prod\*`, []string{`prod*`}},
+		{"values are case sensitive", "PROD*", []string{}},
+		{"a wildcard matching nothing is an empty answer", "stag*", []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ec2WildcardSubnetNames(t, ts, tt.value))
+		})
+	}
+}
+
+// TestEC2_FilterWildcards_EveryOperation is #697's headline: one wildcard case per matcher
+// that compared exactly before it.
+//
+// Each case selects with a pattern that is not a legal exact value, so an exact comparison
+// answers with the empty set — the fixture always holds a resource that must be excluded, so
+// a matcher that wrongly matched everything fails too. Together they cover all nine
+// previously-exact matchers: instances, volumes, images, snapshots, subnets, security groups,
+// route tables, NAT gateways and fleets.
+func TestEC2_FilterWildcards_EveryOperation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DescribeInstances", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		wanted := bdmRunInstances(t, ts, map[string]string{"InstanceType": "t3.micro"})
+		bdmRunInstances(t, ts, map[string]string{"InstanceType": "m5.large"})
+		require.Len(t, wanted, 1)
+
+		var desc describedInstances
+		ec2FleetXML(t, ts, ec2WithAction("DescribeInstances",
+			ec2Filter("instance-type", "t3.*")), &desc)
+		require.Len(t, desc.Instances, 1, "t3.* should select only the t3 instance")
+		assert.Equal(t, wanted[0], desc.Instances[0].InstanceID)
+	})
+
+	t.Run("DescribeVolumes", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		gp3 := volCreate(t, ts, map[string]string{"VolumeType": "gp3"})
+		volCreate(t, ts, map[string]string{"VolumeType": "io1", "Iops": "100"})
+
+		assert.Equal(t, []string{gp3.VolumeID},
+			volIDs(volDescribe(t, ts, ec2Filter("volume-type", "gp?"))),
+			"gp? should select gp3 and not io1")
+	})
+
+	t.Run("DescribeImages", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		tagged, untagged := ec2ImageFilterFixture(t, ts)
+
+		got := ec2FilteredImageIDs(t, ts, ec2Filter("tag:Env", "pro*"))
+		assert.Equal(t, []string{tagged}, got)
+		assert.NotContains(t, got, untagged)
+	})
+
+	t.Run("DescribeSnapshots", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		snaps := ec2SeedTaggedSnapshots(t, ts, "alpha", "beta")
+
+		assert.Equal(t, []string{snaps["alpha"]},
+			ec2SnapshotIDsFor(t, ts, ec2Filter("tag:Scope", "alph?")))
+	})
+
+	t.Run("DescribeSubnets", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		f := newSubnetFixture(t, ts)
+
+		assert.Equal(t, []string{f.alpha},
+			ec2SubnetIDsFor(t, ts, ec2Filter("tag:Scope", "*pha")))
+	})
+
+	t.Run("DescribeSecurityGroups", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		var vpc struct {
+			VPCID string `xml:"vpc>vpcId"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.8.0.0/16"}, &vpc)
+		for _, name := range []string{"web-tier", "db-tier"} {
+			ec2FleetXML(t, ts, map[string]string{
+				"Action": "CreateSecurityGroup", "GroupName": name,
+				"GroupDescription": name, "VpcId": vpc.VPCID,
+			}, nil)
+		}
+
+		assert.Equal(t, []string{"web-tier"},
+			ec2SecurityGroupNames(t, ts, ec2Filter("group-name", "web-*")))
+	})
+
+	t.Run("DescribeRouteTables", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		// newSubnetFixture's launch mints the default VPC, whose own route table is
+		// associated with a subnet — so both filters below have a route table to exclude.
+		f := newSubnetFixture(t, ts)
+		rtbID := ec2CreateRouteTableID(t, ts, f.vpcID)
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "AssociateRouteTable", "RouteTableId": rtbID, "SubnetId": f.alpha,
+		}, nil)
+
+		// association.subnet-id is a filter value, so it globs — where the same string in
+		// SubnetId.N would be a malformed ID (see routeTableHasSubnet).
+		assert.Equal(t, []string{rtbID},
+			ec2RouteTableIDsFor(t, ts, ec2Filter("association.subnet-id", f.alpha+"*")))
+
+		// vpc-id is asserted against the exact filter's own answer rather than a literal
+		// list, because CreateVpc mints a main route table alongside the one created
+		// above. The property under test is that a wildcard answers what the exact value
+		// answers, and that it is still narrower than no filter at all.
+		exact := ec2RouteTableIDsFor(t, ts, ec2Filter("vpc-id", f.vpcID))
+		require.NotEmpty(t, exact)
+		require.Less(t, len(exact), len(ec2RouteTableIDsFor(t, ts, nil)),
+			"the default VPC's route table is what the filter must exclude")
+		assert.Equal(t, exact, ec2RouteTableIDsFor(t, ts, ec2Filter("vpc-id", f.vpcID+"*")))
+	})
+
+	t.Run("DescribeNatGateways", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		natID := ec2CreateNatGatewayID(t, ts)
+
+		assert.Equal(t, []string{natID}, ec2NatGatewayIDsFor(t, ts, ec2Filter("state", "avail*")))
+		assert.Empty(t, ec2NatGatewayIDsFor(t, ts, ec2Filter("state", "pend*")))
+	})
+
+	t.Run("DescribeFleets", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		ltID := newFleetLaunchTemplate(t, ts, "fleet-wildcards")
+		var maintain createFleetResp
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CreateFleet",
+			"Type":   "maintain",
+			"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+			"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+		}, &maintain)
+
+		var got describeFleetsResp
+		ec2FleetXML(t, ts, ec2WithAction("DescribeFleets", ec2Filter("type", "main*")), &got)
+		require.Len(t, got.Fleets, 1)
+		assert.Equal(t, maintain.FleetID, got.Fleets[0].FleetID)
+
+		var none describeFleetsResp
+		ec2FleetXML(t, ts, ec2WithAction("DescribeFleets", ec2Filter("type", "spot*")), &none)
+		assert.Empty(t, none.Fleets)
+	})
+}
+
+// TestEC2_DescribeVolumes_DeleteOnTerminationIsCaseSensitive pins the one behavior change
+// #697 makes to an answer a caller could already have been getting.
+//
+// attachment.delete-on-termination was the tree's only case-*insensitive* filter-value
+// comparison: a hand-rolled loop lowercased the request value, so "True" selected a
+// delete-on-termination attachment. AWS documents the opposite twice — Using_Filtering's
+// "Filter values are case sensitive" and the Filter type's "Filter values are
+// case-sensitive" — so it now selects nothing, and the lowercase form that AWS's own
+// examples use still works.
+func TestEC2_DescribeVolumes_DeleteOnTerminationIsCaseSensitive(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	ids := bdmRunInstances(t, ts, map[string]string{
+		"BlockDeviceMapping.1.DeviceName":              "/dev/xvda",
+		"BlockDeviceMapping.1.Ebs.VolumeSize":          "30",
+		"BlockDeviceMapping.2.DeviceName":              "/dev/sdf",
+		"BlockDeviceMapping.2.Ebs.VolumeSize":          "40",
+		"BlockDeviceMapping.2.Ebs.DeleteOnTermination": "false",
+	})
+	require.Len(t, ids, 1)
+
+	deleted := bdmDescribeVolumes(t, ts, ec2Filter("attachment.delete-on-termination", "true"))
+	require.Len(t, deleted, 1, "the lowercase form AWS's examples use still selects")
+	assert.Equal(t, "/dev/xvda", deleted[0].bdmDevice())
+
+	assert.Empty(t, bdmDescribeVolumes(t, ts,
+		ec2Filter("attachment.delete-on-termination", "True")),
+		`"True" is not "true"; AWS documents filter values as case-sensitive`)
+
+	// A wildcard still reaches both, which is what makes the case rule a rule about the
+	// comparison rather than about the boolean rendering.
+	assert.Len(t, bdmDescribeVolumes(t, ts,
+		ec2Filter("attachment.delete-on-termination", "*e")), 2)
+}
+
+// TestEC2_FilterWildcards_IdentifierParametersStayExact pins what #697 must not reach.
+//
+// AWS documents wildcards for Filter.N.Value.N only. An identifier parameter list asserts
+// that the resources it names exist, so globbing one would let `i-*` stand in for an ID and
+// quietly turn an Invalid*.NotFound contract into a match. Filter *names* are excluded for a
+// different reason: they are one of a fixed documented set, and the Filter type says "Filter
+// names are case-sensitive", so a name is either in the set or refused.
+func TestEC2_FilterWildcards_IdentifierParametersStayExact(t *testing.T) {
+	t.Parallel()
+
+	t.Run("KeyName.N on DescribeKeyPairs", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		ec2FleetXML(t, ts, map[string]string{"Action": "CreateKeyPair", "KeyName": "alpha-key"}, nil)
+
+		require.Equal(t, []string{"alpha-key"}, ec2KeyPairNamesFor(t, ts, "alpha-key"))
+		assert.Empty(t, ec2KeyPairNamesFor(t, ts, "alpha-*"),
+			"KeyName.N names a key pair; it is not a pattern")
+	})
+
+	t.Run("GroupName.N on DescribePlacementGroups", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CreatePlacementGroup", "GroupName": "alpha-pg", "Strategy": "cluster",
+		}, nil)
+
+		require.Equal(t, []string{"alpha-pg"}, ec2PlacementGroupNamesFor(t, ts, "alpha-pg"))
+		assert.Empty(t, ec2PlacementGroupNamesFor(t, ts, "alpha-*"))
+	})
+
+	t.Run("FleetId.N on DescribeFleets", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		ltID := newFleetLaunchTemplate(t, ts, "fleet-ids-exact")
+		var fleet createFleetResp
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CreateFleet",
+			"Type":   "maintain",
+			"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+			"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+		}, &fleet)
+
+		var got describeFleetsResp
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "DescribeFleets", "FleetId.1": fleet.FleetID + "*",
+		}, &got)
+		assert.Empty(t, got.Fleets)
+	})
+
+	t.Run("InstanceType.N on DescribeInstanceTypes", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		status, code := ec2ErrorCode(t, ts, map[string]string{
+			"Action": "DescribeInstanceTypes", "InstanceType.1": "t3.*",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidInstanceType", code,
+			"InstanceType.N asserts the type exists, so a pattern is a bad request")
+	})
+
+	t.Run("the filter name itself", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		status, code := ec2ErrorCode(t, ts, map[string]string{
+			"Action":           "DescribeSnapshots",
+			"Filter.1.Name":    "tag-ke?",
+			"Filter.1.Value.1": "Scope",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+	})
+}
+
+// TestEC2_Filter_RequestLimits covers the three limits AWS publishes for Filter.N, enforced
+// in ec2FilterSpec.check so that every operation with a spec inherits them.
+//
+// Using_Filtering states all three: "You can specify up to 50 filters and up to 200 total
+// filter values in a single request" and "Filter strings can be up to 255 characters in
+// length." The Filter type's own reference page publishes none of them, which is why the
+// numbers are cited from the filtering guide.
+//
+// Provenance: no EC2 error code exists for a filter limit. Every *LimitExceeded in the
+// client-error table names a resource quota — KeyPairLimitExceeded, NatGatewayLimitExceeded
+// and so on — so substrate answers InvalidParameterValue, whose documented gloss is "A value
+// specified in a parameter is not valid, is unsupported, or cannot be used." The code is
+// substrate's reading; the limits are AWS's.
+func TestEC2_Filter_RequestLimits(t *testing.T) {
+	t.Parallel()
+
+	// Two operations, to show the limits come from the shared check rather than a handler.
+	for _, op := range []struct{ action, filter string }{
+		{"DescribeSnapshots", "tag-key"},
+		{"DescribeTags", "key"},
+	} {
+		t.Run(op.action, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+
+			tests := []struct {
+				name     string
+				params   map[string]string
+				wantCode string
+			}{
+				{"50 filters is accepted", ec2RepeatedFilters(op.filter, 50), ""},
+				{"51 filters is refused", ec2RepeatedFilters(op.filter, 51), "InvalidParameterValue"},
+				{"200 values is accepted", ec2FilterWithValues(op.filter, 200), ""},
+				{"201 values is refused", ec2FilterWithValues(op.filter, 201), "InvalidParameterValue"},
+				{
+					"a 255-character value is accepted",
+					ec2Filter(op.filter, ec2RepeatChar('a', 255)), "",
+				},
+				{
+					"a 256-character value is refused",
+					ec2Filter(op.filter, ec2RepeatChar('a', 256)), "InvalidParameterValue",
+				},
+			}
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					status, code := ec2ErrorCode(t, ts, ec2WithAction(op.action, tt.params))
+					assert.Equal(t, tt.wantCode, code)
+					if tt.wantCode == "" {
+						assert.Equal(t, http.StatusOK, status)
+					} else {
+						assert.Equal(t, http.StatusBadRequest, status)
+					}
+				})
+			}
+		})
+	}
+}
+
+// ec2WithAction returns params with Action set, leaving the caller's map untouched — several
+// helpers here take a filter map built by ec2Filter and must not mutate it.
+func ec2WithAction(action string, params map[string]string) map[string]string {
+	full := map[string]string{"Action": action}
+	for k, v := range params {
+		full[k] = v
+	}
+	return full
+}
+
+// ec2RepeatedFilters builds n Filter.N entries all naming the same filter, each with one
+// value. Repeating one documented name is what isolates the count limit: ec2FilterSpec.check
+// tests the count before it validates the name, so an undocumented name would be refused for
+// the wrong reason.
+func ec2RepeatedFilters(name string, n int) map[string]string {
+	params := make(map[string]string, n*2)
+	for i := 1; i <= n; i++ {
+		params["Filter."+strconv.Itoa(i)+".Name"] = name
+		params["Filter."+strconv.Itoa(i)+".Value.1"] = "v" + strconv.Itoa(i)
+	}
+	return params
+}
+
+// ec2FilterWithValues builds one filter carrying n values, for the total-values limit.
+func ec2FilterWithValues(name string, n int) map[string]string {
+	params := map[string]string{"Filter.1.Name": name}
+	for i := 1; i <= n; i++ {
+		params["Filter.1.Value."+strconv.Itoa(i)] = "v" + strconv.Itoa(i)
+	}
+	return params
+}
+
+// ec2RepeatChar returns a string of n copies of c, for the value-length limit.
+func ec2RepeatChar(c byte, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = c
+	}
+	return string(b)
+}
+
+// ec2CreateRouteTableID creates a route table in vpcID and returns its ID.
+func ec2CreateRouteTableID(t *testing.T, ts *httptest.Server, vpcID string) string {
+	t.Helper()
+	var res struct {
+		RouteTableID string `xml:"routeTable>routeTableId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateRouteTable", "VpcId": vpcID}, &res)
+	require.NotEmpty(t, res.RouteTableID)
+	return res.RouteTableID
+}
+
+// ec2RouteTableIDsFor returns the route table IDs DescribeRouteTables reports for params,
+// sorted.
+//
+// Sorted here rather than asserted in response order because describeRouteTables walks
+// StateManager.List, which documents no ordering — unlike describeTags, which sorts its own
+// answer for the reason ec2SortTagDescriptions records. What these cases assert is which
+// route tables a filter selected, not the sequence they arrived in.
+func ec2RouteTableIDsFor(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	var res struct {
+		IDs []string `xml:"routeTableSet>item>routeTableId"`
+	}
+	ec2FleetXML(t, ts, ec2WithAction("DescribeRouteTables", params), &res)
+	sort.Strings(res.IDs)
+	return res.IDs
+}
+
+// ec2CreateNatGatewayID builds the subnet and elastic IP a NAT gateway needs and returns the
+// gateway's ID.
+func ec2CreateNatGatewayID(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	var vpc struct {
+		VPCID string `xml:"vpc>vpcId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.6.0.0/16"}, &vpc)
+	var subnet struct {
+		SubnetID string `xml:"subnet>subnetId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateSubnet", "VpcId": vpc.VPCID, "CidrBlock": "10.6.1.0/24",
+	}, &subnet)
+	var addr struct {
+		AllocationID string `xml:"allocationId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "AllocateAddress", "Domain": "vpc"}, &addr)
+
+	var nat struct {
+		NatGatewayID string `xml:"natGateway>natGatewayId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateNatGateway", "SubnetId": subnet.SubnetID, "AllocationId": addr.AllocationID,
+	}, &nat)
+	require.NotEmpty(t, nat.NatGatewayID)
+	return nat.NatGatewayID
+}
+
+// ec2NatGatewayIDsFor returns the gateway IDs DescribeNatGateways reports for params,
+// sorted for the reason [ec2RouteTableIDsFor] gives.
+func ec2NatGatewayIDsFor(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	var res struct {
+		IDs []string `xml:"natGatewaySet>item>natGatewayId"`
+	}
+	ec2FleetXML(t, ts, ec2WithAction("DescribeNatGateways", params), &res)
+	sort.Strings(res.IDs)
+	return res.IDs
+}
+
+// ec2KeyPairNamesFor returns the key-pair names DescribeKeyPairs reports for one KeyName.1.
+func ec2KeyPairNamesFor(t *testing.T, ts *httptest.Server, keyName string) []string {
+	t.Helper()
+	var res struct {
+		Names []string `xml:"keySet>item>keyName"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeKeyPairs", "KeyName.1": keyName}, &res)
+	return res.Names
+}
+
+// ec2PlacementGroupNamesFor returns the names DescribePlacementGroups reports for one
+// GroupName.1.
+func ec2PlacementGroupNamesFor(t *testing.T, ts *httptest.Server, groupName string) []string {
+	t.Helper()
+	var res struct {
+		Names []string `xml:"placementGroupSet>item>groupName"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "DescribePlacementGroups", "GroupName.1": groupName,
+	}, &res)
+	return res.Names
+}

--- a/emulator/ec2_filters.go
+++ b/emulator/ec2_filters.go
@@ -2,6 +2,7 @@ package emulator
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -64,20 +65,87 @@ func (s ec2FilterSpec) documents(name string) bool {
 // it. Refusing here would make the checker and the extractor disagree about what the
 // request contains, which is the class of defect #686 fixed.
 //
+// The three request limits are enforced here too, for the same reason the refusal is: one
+// place, inherited by every operation that has a spec. See [ec2FilterLimitError].
+//
 // Provenance: refusal is real EC2's *observed* behavior, not its documented behavior.
 // Neither Using_Filtering nor the Filter type's reference page says what happens to an
 // unrecognized name — both are silent — so nothing in AWS's documentation settles it, and
-// [ec2InvalidFilterError] carries the reasoning for the code and message.
+// [ec2InvalidFilterError] carries the reasoning for the code and message. The *limits*, by
+// contrast, are documented; only the error they raise is substrate's choice.
 func (s ec2FilterSpec) check(params map[string]string) *AWSError {
+	totalValues := 0
 	for i := 1; ; i++ {
 		name, ok := params[fmt.Sprintf("Filter.%d.Name", i)]
 		if !ok {
 			return nil
 		}
+		if i > ec2MaxFiltersPerRequest {
+			return ec2FilterLimitError(fmt.Sprintf(
+				"a request may specify at most %d filters", ec2MaxFiltersPerRequest))
+		}
+		// Values are counted for every filter, including one whose name is skipped below:
+		// AWS's limit is on the request, and an empty name still carries its values on the
+		// wire.
+		for j := 1; ; j++ {
+			v, ok := params[fmt.Sprintf("Filter.%d.Value.%d", i, j)]
+			if !ok {
+				break
+			}
+			totalValues++
+			if totalValues > ec2MaxFilterValuesPerRequest {
+				return ec2FilterLimitError(fmt.Sprintf(
+					"a request may specify at most %d filter values in total",
+					ec2MaxFilterValuesPerRequest))
+			}
+			if len(v) > ec2MaxFilterValueLength {
+				return ec2FilterLimitError(fmt.Sprintf(
+					"a filter value may be at most %d characters", ec2MaxFilterValueLength))
+			}
+		}
 		if name == "" || s.documents(name) {
 			continue
 		}
 		return ec2InvalidFilterError(name)
+	}
+}
+
+// The request limits EC2 documents for filters, from the "Filtering considerations" list in
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html: "You can specify
+// up to 50 filters and up to 200 total filter values in a single request" and "Filter strings
+// can be up to 255 characters in length".
+//
+// The 255 is applied to filter *values*, not names. "Filter strings" is not defined on that
+// page, but a name is bounded far below 255 by [ec2FilterSpec.documents] — every documented
+// name is a fixed short literal — so a length rule on names could only ever fire after the
+// refusal already had, and pretending otherwise would advertise a check that cannot be
+// reached. The one name that is not a fixed literal, tag:<key>, is bounded by AWS's own
+// 128-character tag-key limit.
+//
+// Length is measured in bytes rather than runes. AWS does not say which it means, and the two
+// differ only for a non-ASCII value; bytes is what the wire carries.
+const (
+	ec2MaxFiltersPerRequest      = 50
+	ec2MaxFilterValuesPerRequest = 200
+	ec2MaxFilterValueLength      = 255
+)
+
+// ec2FilterLimitError returns the error substrate raises when a request exceeds one of the
+// documented filter limits. detail states which limit and its value.
+//
+// Provenance is split, the opposite way round from [ec2InvalidFilterError]: the *limits* are
+// documented and the *error* is not. EC2's client-error tables publish no filter-limit code —
+// every `*LimitExceeded` code there names a resource quota (KeyPairLimitExceeded,
+// NatGatewayLimitExceeded, TrafficMirrorFilterLimitExceeded and so on), none of them a
+// request-shape limit — so InvalidParameterValue is the only candidate whose published gloss
+// covers this: "A value specified in a parameter is not valid, is unsupported, or cannot be
+// used… The returned message provides an explanation of the error value." A consumer must
+// dispatch on the code and not on this message.
+func ec2FilterLimitError(detail string) *AWSError {
+	return &AWSError{
+		Code:       "InvalidParameterValue",
+		Message:    detail,
+		HTTPStatus: http.StatusBadRequest,
 	}
 }
 

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -847,13 +847,13 @@ func (p *EC2Plugin) describeFleets(reqCtx *RequestContext, req *AWSRequest) (*AW
 		if len(ids) == 0 && fleet.Type == "instant" {
 			continue
 		}
-		if vals, ok := filters["fleet-state"]; ok && !containsStr(vals, fleet.FleetState) {
+		if vals, ok := filters["fleet-state"]; ok && !ec2FilterAccepts(vals, fleet.FleetState) {
 			continue
 		}
-		if vals, ok := filters["type"]; ok && !containsStr(vals, fleet.Type) {
+		if vals, ok := filters["type"]; ok && !ec2FilterAccepts(vals, fleet.Type) {
 			continue
 		}
-		if vals, ok := filters["activity-status"]; ok && !containsStr(vals, fleet.ActivityStatus) {
+		if vals, ok := filters["activity-status"]; ok && !ec2FilterAccepts(vals, fleet.ActivityStatus) {
 			continue
 		}
 

--- a/emulator/ec2_instancetypes.go
+++ b/emulator/ec2_instancetypes.go
@@ -302,12 +302,31 @@ func ec2UnmodelledLocationTypeError(value string) *AWSError {
 
 // ec2FilterValueMatches reports whether value satisfies one EC2 filter value.
 //
-// EC2's resource-filtering documentation gives the rules for API filters: "An asterisk
-// (*) matches zero or more characters, and a question mark (?) matches zero or one
-// character", a literal wildcard is escaped with a preceding backslash, and filter values
-// are case-sensitive — so the comparison here is too. DescribeInstanceTypes' reference
-// documents the form explicitly for this filter: "instance-type - The instance type (for
-// example c5.2xlarge or c5*)".
+// Since #697 this is the comparison behind *every* EC2 describe filter, so the rules below
+// are the whole family's, not one operation's. EC2's resource-filtering documentation gives
+// them for API filters: "An asterisk (*) matches zero or more characters, and a question mark
+// (?) matches zero or one character", "Your search can include the literal values of the
+// wildcard characters; you just need to escape them with a backslash before the character.
+// For example, a value of `\*amazon\?\\` searches for the literal string `*amazon?\`", and
+// "Filter values are case sensitive" — which the Filter type's own reference page repeats, so
+// the comparison here is case-sensitive too.
+//
+// **'?' matches zero or one character, and AWS's own page disagrees with itself about that.**
+// #697 reports the contradiction and this is its resolution. Using_Filtering's normative
+// "Filtering considerations" list — the one that governs the API rather than the console —
+// says "zero or one", and the console's wildcard section says "zero or one" and works it
+// through: "if you have a data set with the values prod, prods, and production, a search of
+// prod* matches all values, whereas prod? matches only prod and prods". One later sentence in
+// the CLI examples says "The ? wildcard matches exactly 1 character" — and is contradicted by
+// its own example in the next breath, which returns "the snapshots whose description is
+// 'database' or 'database' followed by one character", and by `database????` returning
+// descriptions with "database" followed by **up to** four characters. Two normative statements
+// and three worked examples say zero-or-one; one sentence says otherwise and refutes itself.
+// So zero-or-one stands, and substrate is not narrowing to the outlier sentence.
+//
+// DescribeTags' Example 4 does not settle it either way: `?ebserver` finding "webserver or
+// Webserver" is consistent with both readings, because the third string a zero-or-one '?'
+// would also match — "ebserver" — is simply not in AWS's data set.
 //
 // path.Match is not used because its '?' matches exactly one character where EC2's
 // matches zero or one, and because it treats '/' specially.

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -1012,7 +1012,7 @@ func ec2InstanceMatchesFilter(inst EC2Instance, name string, values []string) bo
 	// tag:<key> — instance has a tag with that key whose value is in values.
 	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
 		for _, t := range inst.Tags {
-			if t.Key == tagKey && containsStr(values, t.Value) {
+			if t.Key == tagKey && ec2FilterAccepts(values, t.Value) {
 				return true
 			}
 		}
@@ -1021,30 +1021,30 @@ func ec2InstanceMatchesFilter(inst EC2Instance, name string, values []string) bo
 
 	switch name {
 	case "instance-state-name":
-		return containsStr(values, inst.State.Name)
+		return ec2FilterAccepts(values, inst.State.Name)
 	case "instance-state-code":
-		return containsStr(values, strconv.Itoa(inst.State.Code))
+		return ec2FilterAccepts(values, strconv.Itoa(inst.State.Code))
 	case "instance-id":
-		return containsStr(values, inst.InstanceID)
+		return ec2FilterAccepts(values, inst.InstanceID)
 	case "instance-type":
-		return containsStr(values, inst.InstanceType)
+		return ec2FilterAccepts(values, inst.InstanceType)
 	case "image-id":
-		return containsStr(values, inst.ImageID)
+		return ec2FilterAccepts(values, inst.ImageID)
 	case "vpc-id":
-		return containsStr(values, inst.VPCID)
+		return ec2FilterAccepts(values, inst.VPCID)
 	case "subnet-id":
-		return containsStr(values, inst.SubnetID)
+		return ec2FilterAccepts(values, inst.SubnetID)
 	case "key-name":
-		return containsStr(values, inst.KeyName)
+		return ec2FilterAccepts(values, inst.KeyName)
 	case "availability-zone":
 		// The reference names this filter "availability-zone", not
 		// "placement.availability-zone" — the placement family's filters are
 		// spelled out individually in DescribeInstances' filter list.
-		return containsStr(values, inst.AvailabilityZone)
+		return ec2FilterAccepts(values, inst.AvailabilityZone)
 	case "tag-key":
 		// Instance has a tag with any of the requested keys (any value).
 		for _, t := range inst.Tags {
-			if containsStr(values, t.Key) {
+			if ec2FilterAccepts(values, t.Key) {
 				return true
 			}
 		}
@@ -1695,13 +1695,13 @@ func (p *EC2Plugin) describeSecurityGroups(reqCtx *RequestContext, req *AWSReque
 		// A filter naming no values matches nothing, as it does everywhere else: these
 		// three arms used to carry an `ok && len(vals) > 0 &&` guard, which returned every
 		// security group for a request that had asked for a subset (#696).
-		if vals, ok := filters["group-name"]; ok && !containsStr(vals, sg.GroupName) {
+		if vals, ok := filters["group-name"]; ok && !ec2FilterAccepts(vals, sg.GroupName) {
 			continue
 		}
-		if vals, ok := filters["vpc-id"]; ok && !containsStr(vals, sg.VPCID) {
+		if vals, ok := filters["vpc-id"]; ok && !ec2FilterAccepts(vals, sg.VPCID) {
 			continue
 		}
-		if vals, ok := filters["group-id"]; ok && !containsStr(vals, sg.GroupID) {
+		if vals, ok := filters["group-id"]; ok && !ec2FilterAccepts(vals, sg.GroupID) {
 			continue
 		}
 		renderPerm := func(rule EC2IPPermission) permItem {
@@ -2022,11 +2022,18 @@ func (p *EC2Plugin) createRouteTableForVPC(reqCtx *RequestContext, vpcID, localC
 	return rtbID, nil
 }
 
-// routeTableHasSubnet reports whether the route table has an association with
-// any of the given subnet IDs.
+// routeTableHasSubnet reports whether the route table has an association with any of the
+// given subnet IDs, which are the values of DescribeRouteTables' association.subnet-id
+// filter.
+//
+// They are filter values rather than an identifier list, so they match through
+// [ec2FilterAccepts] and honor EC2's wildcards like every other filter value (#697). The
+// distinction is the one [containsStr] documents: an association.subnet-id of `subnet-*`
+// narrows the answer to the route tables that are associated with any subnet at all, where
+// the same string in `SubnetId.N` would be a malformed ID.
 func routeTableHasSubnet(rtb EC2RouteTable, subnetIDs []string) bool {
 	for _, a := range rtb.Associations {
-		if a.SubnetID != "" && containsStr(subnetIDs, a.SubnetID) {
+		if a.SubnetID != "" && ec2FilterAccepts(subnetIDs, a.SubnetID) {
 			return true
 		}
 	}
@@ -2080,10 +2087,10 @@ func (p *EC2Plugin) describeRouteTables(reqCtx *RequestContext, req *AWSRequest)
 		if !ids.match(rtb.RouteTableID) {
 			continue
 		}
-		if vals, ok := filters["vpc-id"]; ok && !containsStr(vals, rtb.VPCID) {
+		if vals, ok := filters["vpc-id"]; ok && !ec2FilterAccepts(vals, rtb.VPCID) {
 			continue
 		}
-		if vals, ok := filters["association.route-table-id"]; ok && !containsStr(vals, rtb.RouteTableID) {
+		if vals, ok := filters["association.route-table-id"]; ok && !ec2FilterAccepts(vals, rtb.RouteTableID) {
 			continue
 		}
 		if vals, ok := filters["association.subnet-id"]; ok && !routeTableHasSubnet(rtb, vals) {
@@ -3258,7 +3265,25 @@ func extractEC2Filters(params map[string]string) map[string][]string {
 	return filters
 }
 
-// containsStr reports whether s is in the slice.
+// containsStr reports whether s is in the slice, comparing exactly.
+//
+// Since #697 this is **not** how a filter value is compared — [ec2FilterAccepts] is, and it
+// honors EC2's documented wildcards. What is left here is every membership test that is not
+// a filter, and each one must stay exact:
+//
+//   - The `KeyName.N`, `GroupName.N`, `FleetId.N`, `RegionName.N` and `InstanceType.N`
+//     parameter lists on DescribeKeyPairs, DescribePlacementGroups, DescribeFleets,
+//     DescribeRegions and DescribeInstanceTypes. These are *identifiers*, not filter values:
+//     AWS documents wildcards for `Filter.N.Value.N` only, and each of these parameters
+//     asserts the resource exists — an unmatched entry raises Invalid*.NotFound rather than
+//     narrowing a result set. Globbing them would let `i-*` stand in for an ID and quietly
+//     turn a NotFound contract into a match.
+//   - [ec2FilterSpec.documents]' name lookup. AWS's wildcards are for values; a filter *name*
+//     is one of a fixed documented set and "Filter names are case-sensitive" per the Filter
+//     type, so a name is either in the set or refused.
+//   - [sgSourcesMatch], which compares two stored permissions to each other rather than a
+//     request value to a record. It backs RevokeSecurityGroupIngress/Egress, where the
+//     source a caller names is the rule being removed, not a pattern selecting rules.
 func containsStr(slice []string, s string) bool {
 	for _, v := range slice {
 		if v == s {
@@ -3696,22 +3721,22 @@ func ec2ImageMatchesFilters(img EC2Image, filters map[string][]string) bool {
 		case strings.HasPrefix(name, "tag:"):
 			key := strings.TrimPrefix(name, "tag:")
 			for _, t := range img.Tags {
-				if t.Key == key && containsStr(vals, t.Value) {
+				if t.Key == key && ec2FilterAccepts(vals, t.Value) {
 					matched = true
 					break
 				}
 			}
 		case name == "tag-key":
 			for _, t := range img.Tags {
-				if containsStr(vals, t.Key) {
+				if ec2FilterAccepts(vals, t.Key) {
 					matched = true
 					break
 				}
 			}
 		case name == "block-device-mapping.snapshot-id":
-			matched = img.SnapshotID != "" && containsStr(vals, img.SnapshotID)
+			matched = img.SnapshotID != "" && ec2FilterAccepts(vals, img.SnapshotID)
 		case name == "image-id":
-			matched = containsStr(vals, img.ImageID)
+			matched = ec2FilterAccepts(vals, img.ImageID)
 		default:
 			continue
 		}
@@ -4343,10 +4368,10 @@ func (p *EC2Plugin) describeNatGateways(reqCtx *RequestContext, req *AWSRequest)
 			continue
 		}
 		// Apply filters.
-		if stateVals, ok := filters["state"]; ok && !containsStr(stateVals, gw.State) {
+		if stateVals, ok := filters["state"]; ok && !ec2FilterAccepts(stateVals, gw.State) {
 			continue
 		}
-		if vpcVals, ok := filters["vpc-id"]; ok && !containsStr(vpcVals, gw.VPCID) {
+		if vpcVals, ok := filters["vpc-id"]; ok && !ec2FilterAccepts(vpcVals, gw.VPCID) {
 			continue
 		}
 		resp.NatGateways = append(resp.NatGateways, natItem{

--- a/emulator/ec2_snapshot_filters.go
+++ b/emulator/ec2_snapshot_filters.go
@@ -32,7 +32,7 @@ func ec2SnapshotMatchesFilters(snap EC2Snapshot, filters map[string][]string) bo
 func ec2SnapshotMatchesFilter(snap EC2Snapshot, name string, values []string) bool {
 	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
 		for _, t := range snap.Tags {
-			if t.Key == tagKey && containsStr(values, t.Value) {
+			if t.Key == tagKey && ec2FilterAccepts(values, t.Value) {
 				return true
 			}
 		}
@@ -41,37 +41,40 @@ func ec2SnapshotMatchesFilter(snap EC2Snapshot, name string, values []string) bo
 
 	switch name {
 	case "description":
-		return containsStr(values, snap.Description)
+		return ec2FilterAccepts(values, snap.Description)
 	case "encrypted":
-		return containsStr(values, strconv.FormatBool(snap.Encrypted))
+		return ec2FilterAccepts(values, strconv.FormatBool(snap.Encrypted))
 	case "owner-id":
 		// The account that owns the snapshot, which is always the requesting account:
 		// substrate is single-account, so this filter either matches everything or
 		// nothing. It is still evaluated rather than inert, because a caller who names
 		// another account is asking a question whose honest answer is "none".
-		return containsStr(values, snap.AccountID)
+		return ec2FilterAccepts(values, snap.AccountID)
 	case "snapshot-id":
-		return containsStr(values, snap.SnapshotID)
+		return ec2FilterAccepts(values, snap.SnapshotID)
 	case "start-time":
 		// Compared as the string substrate renders in startTime. AWS documents this
 		// filter with no matching semantics of its own, and its values are timestamps, so
-		// a caller wanting a range needs the wildcards tracked in #697 rather than this.
-		return containsStr(values, snap.StartTime)
+		// a caller wanting a range asks for it with a wildcard — `2026-08-*` selects a
+		// month, which is as close to a range as EC2's filters get (#697). AWS's own
+		// Using_Filtering answer to the range question is client-side `--query` with
+		// JMESPath, not a filter.
+		return ec2FilterAccepts(values, snap.StartTime)
 	case "status":
 		// AWS names the filter "status" and the response element "status" while the API
 		// model calls the member State; EC2Snapshot follows the model.
-		return containsStr(values, snap.State)
+		return ec2FilterAccepts(values, snap.State)
 	case "tag-key":
 		for _, t := range snap.Tags {
-			if containsStr(values, t.Key) {
+			if ec2FilterAccepts(values, t.Key) {
 				return true
 			}
 		}
 		return false
 	case "volume-id":
-		return containsStr(values, snap.VolumeID)
+		return ec2FilterAccepts(values, snap.VolumeID)
 	case "volume-size":
-		return containsStr(values, strconv.FormatInt(snap.VolumeSize, 10))
+		return ec2FilterAccepts(values, strconv.FormatInt(snap.VolumeSize, 10))
 	default:
 		// A documented filter substrate cannot evaluate is inert; see the doc comment.
 		return true

--- a/emulator/ec2_subnet_filters.go
+++ b/emulator/ec2_subnet_filters.go
@@ -47,7 +47,7 @@ func ec2SubnetMatchesFilters(subnet EC2Subnet, filters map[string][]string) bool
 func ec2SubnetMatchesFilter(subnet EC2Subnet, name string, values []string) bool {
 	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
 		for _, t := range subnet.Tags {
-			if t.Key == tagKey && containsStr(values, t.Value) {
+			if t.Key == tagKey && ec2FilterAccepts(values, t.Value) {
 				return true
 			}
 		}
@@ -56,31 +56,37 @@ func ec2SubnetMatchesFilter(subnet EC2Subnet, name string, values []string) bool
 
 	switch name {
 	case "availability-zone", "availabilityZone":
-		return containsStr(values, subnet.AvailabilityZone)
+		return ec2FilterAccepts(values, subnet.AvailabilityZone)
 	case "cidr-block", "cidr", "cidrBlock":
 		// AWS: "The CIDR block you specify must exactly match the subnet's CIDR block
 		// for information to be returned for the subnet." So this is equality, not
 		// containment — a caller asking for 10.0.0.0/16 does not get 10.0.1.0/24.
-		return containsStr(values, subnet.CIDRBlock)
+		//
+		// "Exactly match" is about *containment*, not about wildcards: it rules out a
+		// prefix-containment reading of the filter, not the pattern matching AWS documents
+		// for every filter value. `10.0.*` is still a legal value here (#697), and it still
+		// does not select 10.0.1.0/24 under a 10.0.0.0/16 subnet, because a value matches a
+		// subnet's CIDR string or it does not.
+		return ec2FilterAccepts(values, subnet.CIDRBlock)
 	case "default-for-az", "defaultForAz":
-		return containsStr(values, strconv.FormatBool(subnet.IsDefault))
+		return ec2FilterAccepts(values, strconv.FormatBool(subnet.IsDefault))
 	case "map-public-ip-on-launch":
-		return containsStr(values, strconv.FormatBool(subnet.MapPublicIPOnLaunch))
+		return ec2FilterAccepts(values, strconv.FormatBool(subnet.MapPublicIPOnLaunch))
 	case "owner-id":
 		// Always the requesting account: substrate is single-account, so a caller
 		// naming another account is asking a question whose honest answer is "none".
-		return containsStr(values, subnet.AccountID)
+		return ec2FilterAccepts(values, subnet.AccountID)
 	case "state":
-		return containsStr(values, subnet.State)
+		return ec2FilterAccepts(values, subnet.State)
 	case "subnet-arn":
-		return containsStr(values, ec2SubnetARN(subnet.AccountID, subnet.Region, subnet.SubnetID))
+		return ec2FilterAccepts(values, ec2SubnetARN(subnet.AccountID, subnet.Region, subnet.SubnetID))
 	case "subnet-id":
-		return containsStr(values, subnet.SubnetID)
+		return ec2FilterAccepts(values, subnet.SubnetID)
 	case "vpc-id":
-		return containsStr(values, subnet.VPCID)
+		return ec2FilterAccepts(values, subnet.VPCID)
 	case "tag-key":
 		for _, t := range subnet.Tags {
-			if containsStr(values, t.Key) {
+			if ec2FilterAccepts(values, t.Key) {
 				return true
 			}
 		}


### PR DESCRIPTION
AWS states EC2's filter-value wildcard rule once, for the whole family: "An asterisk (*)
matches zero or more characters, and a question mark (?) matches zero or one character." Nine
of substrate's eleven filter-value matchers compared with `containsStr`, so
`instance-type=t3.*` selected nothing at all — the silent-narrowing failure of an ignored
filter, where a consumer sees a legitimate-looking empty set rather than an error.
`DescribeInstanceTypeOfferings` and `DescribeTags` already matched through
`ec2FilterValueMatches`, which is what made the split a defect: one documented value meant two
different things depending on which operation received it.

55 comparisons now route through the one matcher, across `DescribeInstances`,
`DescribeVolumes`, `DescribeImages`, `DescribeSnapshots`, `DescribeSubnets`,
`DescribeSecurityGroups`, `DescribeRouteTables`, `DescribeNatGateways` and `DescribeFleets`.
Escaping (`\*`, `\?`, `\\`) and case sensitivity come with it.

## Two corrections to the plan, both from AWS's own pages

**`?` was not narrowed to exactly one character, because AWS's documentation refutes the
narrowing.** #697's headline claim — that AWS's page self-contradicts on `?` — is *correct*, and
the resolution goes the other way from what the plan assumed. Zero-or-one is stated twice
normatively (Using_Filtering's "Filtering considerations" list, the one that governs the API,
and the console "Wildcard search" section) and worked through three times: "if you have a data
set with the values prod, prods, and production, a search of `prod*` matches all values,
whereas `prod?` matches only prod and prods". The "exactly 1 character" sentence appears once,
in the CLI examples, and is refuted by its own next sentence ("description is 'database' or
'database' followed by one character") and by `database????` returning "up to four" characters.
Two normative statements and three worked examples against one self-refuting sentence, so
substrate's existing zero-or-one stands and `ec2globMatch` is untouched.

**The filter limits are 50 / 200 / 255, not 200 / 200 / 256.** Using_Filtering: "You can
specify up to 50 filters and up to 200 total filter values in a single request" and "Filter
strings can be up to 255 characters in length." `API_Filter.html` publishes no limits at all.
All three are enforced in `ec2FilterSpec.check`, so every operation with a filter spec
inherits them, and the count is checked before a name is validated — a 51st filter is refused
for being the 51st, not for whatever it is called.

## A third correction, found during the sweep

`routeTableHasSubnet` compared `DescribeRouteTables`' `association.subnet-id` exactly, and its
doc comment classified it alongside `sgSourcesMatch` as a record-to-record comparison. It is
not: it matches a request filter value against a stored association, so it globs now.
`association.subnet-id=subnet-*` narrows to the route tables associated with any subnet at
all, where the same string in `SubnetId.N` is still a malformed ID.

## Behaviour changes

- **`attachment.delete-on-termination` is case-sensitive.** It was the tree's only
  case-*insensitive* value comparison, inherited from a hand-rolled loop that lowercased the
  request value so `True` selected a delete-on-termination attachment. AWS documents the
  opposite twice. `True` now selects nothing; the lowercase form AWS's own examples use is
  unaffected.
- A filter value exceeding any of the three limits is now `InvalidParameterValue`, HTTP 400,
  where it was previously accepted.
- Nine operations answer more than they used to for any value containing `*` or `?`. Nothing
  that succeeds today starts failing.

## Provenance

The limits are AWS's; the **error code is substrate's reading**. No EC2 error code exists for
a filter limit — every `*LimitExceeded` in the client-error table names a resource quota
(`KeyPairLimitExceeded`, `NatGatewayLimitExceeded`, `TrafficMirrorFilterLimitExceeded`, …) — so
`InvalidParameterValue` is the only candidate, glossed as "A value specified in a parameter is
not valid, is unsupported, or cannot be used."

## Deliberately still exact

Identifier parameter lists (`KeyName.N`, `GroupName.N`, `FleetId.N`, `RegionName.N`,
`InstanceType.N`) assert their resources exist and answer `Invalid*.NotFound`, so globbing them
would turn a NotFound contract into a match. Filter *names* are one of a fixed documented set.
`sgSourcesMatch` compares two stored permissions, not a request value to a record.
`containsStr`'s doc comment enumerates all six surviving call sites and why each stays exact.

## Tests

New `emulator/ec2_filter_wildcards_test.go`:

- `TestEC2_FilterWildcards_ValueSemantics` runs AWS's own prod/prods/production data set
  through a real `tag:Name` filter, plus a fourth subnet named the literal `prod*` so the
  escape rule is assertable. Eleven rows: `*` at every position, `?` matching zero and one,
  `prod\*`, case sensitivity.
- `TestEC2_FilterWildcards_EveryOperation` — one case per previously-exact matcher, each
  selecting with a pattern that is not a legal exact value, against a fixture that always
  holds a resource which must be excluded.
- `TestEC2_DescribeVolumes_DeleteOnTerminationIsCaseSensitive`.
- `TestEC2_FilterWildcards_IdentifierParametersStayExact` — `KeyName.N`, `GroupName.N`,
  `FleetId.N`, `InstanceType.N` and the filter name.
- `TestEC2_Filter_RequestLimits` — both boundaries of all three limits, on two operations, to
  show they come from the shared check rather than a handler.

Fail-before verified by mutation: reducing `ec2FilterValueMatches` to `pattern == value` and
raising the three constants turns every wildcard, limit and case-sensitivity case red;
restoring them turns all green. Full gate green — `gofmt`, `go build`, `go vet`,
`golangci-lint`, `make test` (race), `make coverage` (82.3%), `make docs-reference-check`,
`docs-versions`, the VitePress build with an anchor-vs-id diff over `dist/services.html`, and
`test/e2e`.

Closes #697
