### PR TITLE
fix(ec2): one place per Invalid*.NotFound (#713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documented gloss is "A value specified in a parameter is not valid, is unsupported, or
   cannot be used."
 
+### Changed
+- **Eighteen mutating EC2 operations answer their `Invalid*.NotFound` from the kind table, not
+  from a hand-written literal** (#713). `ec2_resourceid.go`'s `ec2IDKind` table has been the
+  single source of an ID family's prefix rule, `NotFound` code, `Malformed` code and message
+  since #391, but only the `Describe*` path went through it. Every mutation that named a
+  resource wrote its own `&AWSError{}`, so a wording, status or request-ID change had to land
+  in nineteen places and four of the copies had already drifted. `AuthorizeSecurityGroupIngress`,
+  `RevokeSecurityGroupEgress`, `Attach`/`DetachInternetGateway`, `AssociateRouteTable`,
+  `Create`/`Replace`/`DeleteRoute`, `ReplaceRouteTableAssociation`, `ModifySubnetAttribute`,
+  `CreateNatGateway`, `ModifyVpcAttribute`, `Associate`/`ReleaseAddress`, `DeleteNatGateway`
+  and `Delete`/`Attach`/`DetachVolume` now call `ec2RequireNamedResource`, and the kind table
+  says outright that a hand-written copy is a bug.
+
+  **Four wordings changed**, which is why this is a `Changed` and not only a `Fixed`. "Security
+  group not found", "Internet gateway not found" and "Route table not found" become the kind's
+  `The <noun> ID '<id>' does not exist`; the volume family's `The volume 'vol-…' does not
+  exist.` gains `" ID"` and loses its trailing period. AWS's own reference publishes the
+  latter form for every family, and pinning it in one place is the whole point — the
+  alternative, teaching the kind three bespoke strings, would have spread a trailing period
+  nothing else in the tree uses.
+
+  **A malformed ID on a mutation now answers `Malformed` rather than `NotFound`.** Fifteen of
+  the eighteen reported an absence for `GroupId=sg-not-an-id`, which is the wrong branch for a
+  consumer to land in: `Invalid*.NotFound` is retryable-after-create, `*.Malformed` never is.
+  The `Describe*` path has drawn this distinction since #391, so the two halves of the API now
+  agree. Note the casing AWS itself is inconsistent about and substrate spells verbatim:
+  `InvalidGroup.NotFound` pairs with `InvalidGroupId.Malformed`, `InvalidRouteTableID.NotFound`
+  with `InvalidRouteTableId.Malformed`, and `InvalidVolume.NotFound` with
+  `InvalidVolumeID.Malformed`.
+
+  **Eleven operations answer `MissingParameter` for an omitted ID**, where the empty string
+  previously fell through to a `Malformed` naming a parameter the caller never sent, or to a
+  hand-written `InvalidParameterValue` + "VolumeId is required". `AttachVolume` names its two
+  required IDs separately, so a caller who sent one of the two learns which is missing.
+
+  `DeleteNatGateway` answered `NatGatewayNotFound`; it now answers
+  `InvalidNatGatewayID.NotFound`, the spelling every other kind follows and the one
+  `DescribeNatGateways` has always published. See Provenance below. `cfnDeleteAbsentCodes`
+  keeps both, because an event log recorded by an older substrate replays the old code and a
+  stack mid-delete must still read it as an absence.
+
+  Out of scope and named in the kind table: `InvalidRoute.NotFound`,
+  `InvalidAssociationID.NotFound`, `InvalidLaunchTemplateId.NotFound` and
+  `InvalidLaunchTemplateName.NotFoundException` have no kind entry, so they stay hand-written.
+  The one deliberate exception to the convergence is `ec2CheckSecurityGroups`' membership
+  refusal, which reuses `InvalidGroup.NotFound` for a group that exists in the wrong VPC — a
+  different condition from absence, so it cannot share the kind's message.
+
+  Provenance: `NatGatewayMalformed` is AWS's, newly used — NAT gateways are the one family
+  whose malformed code sits outside the `Invalid*ID.Malformed` naming, published as "The
+  specified NAT gateway ID is not formed correctly. Ensure that you specify the NAT gateway ID
+  in the form nat-xxxxxxxxxxxxxxxxx." The choice **between** AWS's two absence codes is
+  substrate's: the reference publishes `NatGatewayNotFound` and `InvalidNatGatewayID.NotFound`
+  both, and no per-operation page settles which operation raises which —
+  `API_DeleteNatGateway.html`'s Errors section is empty, as EC2's pages generally are.
+
 ### Fixed
+- **A refused `ReplaceRouteTableAssociation` no longer destroys the association it was asked
+  to move** (#713). The handler removed the source association and committed it *before*
+  resolving the target route table, so a request naming a `RouteTableId` that was absent or
+  malformed deleted the caller's association and then reported a failure — the subnet was left
+  with no route table at all, and a retry with the ID corrected answered
+  `InvalidAssociationID.NotFound` for an association the first call had eaten. Every write now
+  happens after both IDs resolve, which is the same "a refusal must leave no state behind"
+  rule #673 established for `RunInstances`. Found by writing the convergence test above: its
+  own second assertion was reached by a state the first assertion had already corrupted.
+
+  Two more defects in the same handler, both reachable: replacing an association with one on
+  its own route table left **two** associations rather than one, because the target was read
+  before the detach and the append built on the pre-detach list; and two `json.Unmarshal` and
+  `state.Get` failures inside the search loop were swallowed by a bare `continue`, so a
+  storage error read as "this route table holds no such association".
+
+- **`ec2AllocationIDKind` no longer says "ID" twice** (#713). Its `Noun` was `"allocation ID"`
+  and `notFoundError` appends `" ID"` of its own, so `DescribeAddresses` on an absent
+  `eipalloc-` answered `The allocation ID ID 'eipalloc-…' does not exist`. Reachable since
+  #391 and pinned by nothing. Fixed at the noun, which is also what let `AssociateAddress` and
+  `ReleaseAddress` converge onto the kind rather than propagating the doubled word.
+
+- **Twelve EC2 handlers no longer report a storage failure as a missing resource** (#713).
+  They tested `if err != nil || data == nil`, collapsing a real `StateManager` error into the
+  resource's `NotFound` — so a caller was told their route table did not exist when the read
+  had failed, and the actual error was discarded, which the house rules forbid outright. Each
+  now wraps with `fmt.Errorf("…: %w", err)` and checks existence separately.
+
 - **EC2 filter values honour AWS's wildcards on every describe, not on the two that happened
   to have them** (#697). AWS states the rule once for the whole family — "An asterisk (\*)
   matches zero or more characters, and a question mark (?) matches zero or one character" —

--- a/docs/services.md
+++ b/docs/services.md
@@ -4150,17 +4150,57 @@ string, so substrate mirrors each pair exactly:
 | Snapshot | `InvalidSnapshot.NotFound` | `InvalidSnapshotID.Malformed` |
 | Volume | `InvalidVolume.NotFound` | `InvalidVolumeID.Malformed` |
 | Elastic IP allocation | `InvalidAllocationID.NotFound` | — |
-| NAT gateway | `InvalidNatGatewayID.NotFound` | — |
+| NAT gateway | `InvalidNatGatewayID.NotFound` | `NatGatewayMalformed` |
 
-EC2 publishes no `Malformed` variant for allocation IDs or NAT gateway IDs; a
-malformed ID for those surfaces as the `NotFound` code.
+EC2 publishes no `Malformed` variant for allocation IDs; a malformed allocation ID
+surfaces as `InvalidAllocationID.NotFound`. NAT gateways are the one family whose
+malformed code sits outside the `Invalid*ID.Malformed` naming entirely — the reference
+publishes it as `NatGatewayMalformed`, "The specified NAT gateway ID is not formed
+correctly. Ensure that you specify the NAT gateway ID in the form
+nat-xxxxxxxxxxxxxxxxx."
 
-The volume row covers `CreateSnapshot`, which is where it arrived. Three older volume
-operations — `DeleteVolume`, `AttachVolume` and `DetachVolume` — raise the same
-`InvalidVolume.NotFound` code with a message they spell themselves ("The volume
-'vol-…' does not exist.", with a trailing period and no "ID"). They are left as they
-are deliberately: rewording a published message is a change a consumer matching on it
-would notice, for no gain. Unifying them is a follow-up.
+AWS publishes two absence codes for NAT gateways — `NatGatewayNotFound` ("The
+specified NAT gateway does not exist.") and `InvalidNatGatewayID.NotFound` — and no
+per-operation page says which operation raises which; `DeleteNatGateway`'s `Errors`
+section is empty, as EC2's pages generally are. Substrate answers
+`InvalidNatGatewayID.NotFound` everywhere, because that is the spelling every other
+row above follows and the one `DescribeNatGateways` has always published.
+
+**Mutations answer from the same table.** Every operation that names a resource of one
+of these families — a `Describe*` reading `<Type>Id.N`, or a mutation reading a single
+`<Type>Id` — produces its code, message and status from the one entry, so the two
+halves of the API cannot drift apart:
+
+- An absent ID → the row's `NotFound`, with the message `The <noun> ID '<id>' does not
+  exist`.
+- A syntactically invalid ID → the row's `Malformed`, with the message
+  `Invalid id: "<id>"`. This is checked before existence on a mutation exactly as it is
+  on a describe, which matters because the two branches mean different things to a
+  caller: `Invalid*.NotFound` can be retried after creating the resource, and
+  `*.Malformed` never can.
+- An **omitted** single ID parameter → `MissingParameter`, "The request must contain the
+  parameter `<Name>`" — not a `Malformed` naming a parameter the caller never sent.
+  `AttachVolume` names its two required IDs separately, so a caller who sent one of the
+  two learns which is missing.
+
+Four codes are outside the table and stay hand-written, because AWS gives their ID
+families no prefix rule of the shape above: `InvalidRoute.NotFound`,
+`InvalidAssociationID.NotFound`, `InvalidLaunchTemplateId.NotFound` and
+`InvalidLaunchTemplateName.NotFoundException`.
+
+One refusal reuses a code above for a different condition. A `RunInstances` naming a
+security group that exists but lives in another VPC answers `InvalidGroup.NotFound`
+with `does not belong to VPC …` — AWS's own gloss for that code is "the specified
+security group does not exist", and from the target VPC's point of view it does not.
+That is membership rather than absence, so it does not share the table's message.
+
+**A refused mutation writes nothing.** An operation naming two resources resolves both
+before its first write. `ReplaceRouteTableAssociation` is the one that had this wrong: it
+removed the source association and committed it before resolving the target
+`RouteTableId`, so a request naming an absent or malformed route table deleted the
+association it was asked to move, left the subnet with no route table at all, and then
+reported a failure — and a retry with the ID corrected answered
+`InvalidAssociationID.NotFound` for the association the first call had eaten.
 
 An ID is well formed when it has the resource's prefix followed by at least one
 lowercase hex digit. Length is deliberately not checked: substrate's generators

--- a/emulator/cfn_delete.go
+++ b/emulator/cfn_delete.go
@@ -933,11 +933,16 @@ var cfnDeleteAbsentCodes = map[string]bool{
 	"InvalidInstanceID.NotFound":        true,
 	"InvalidInternetGatewayID.NotFound": true,
 	"InvalidLaunchTemplateId.NotFound":  true,
+	"InvalidNatGatewayID.NotFound":      true,
 	"InvalidRouteTableID.NotFound":      true,
 	"InvalidSubnetID.NotFound":          true,
 	"InvalidVpcID.NotFound":             true,
-	"NatGatewayNotFound":                true,
-	"NoSuchBucket":                      true,
+	// DeleteNatGateway's code before #713 routed it through ec2NatGatewayIDKind. The
+	// reference publishes both spellings, so this entry is not dead: an event log
+	// recorded by an older substrate replays the old code, and a stack mid-delete must
+	// still read it as an absence.
+	"NatGatewayNotFound": true,
+	"NoSuchBucket":       true,
 	// AWS Config's three not-found codes. Each is HTTP 400 rather than 404 — every
 	// Config exception is — so nothing but the code identifies them as an absence.
 	"NoSuchConfigRuleException":            true,

--- a/emulator/cfn_failure_test.go
+++ b/emulator/cfn_failure_test.go
@@ -64,13 +64,16 @@ func TestCFN_RefusedResourceIsRecordedAsAFailure(t *testing.T) {
 			// case is here so the fix cannot quietly break the path that worked.
 			name:       "EC2GroupNotFound",
 			convention: "*AWSError",
+			// The group ID is well-formed hex, so this is the absence path rather
+			// than the Malformed one — "sg-does-not-exist" was, and since #713 is
+			// answered as InvalidGroupId.Malformed.
 			tmpl: `{"Resources": {"I": {"Type": "AWS::EC2::SecurityGroupIngress", "Properties": {
-				"GroupId": "sg-does-not-exist",
+				"GroupId": "sg-0000000000000dead",
 				"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22,
 				"CidrIp": "0.0.0.0/0"}}}}`,
 			logicalID:   "I",
 			wantCode:    "InvalidGroup.NotFound",
-			wantMessage: "Security group not found",
+			wantMessage: "The security group ID 'sg-0000000000000dead' does not exist",
 		},
 	}
 

--- a/emulator/ec2_default_vpc_refusal_test.go
+++ b/emulator/ec2_default_vpc_refusal_test.go
@@ -36,8 +36,8 @@ func TestEC2_DefaultVPC_BadSecurityGroupRefusalWritesNothing(t *testing.T) {
 	})
 	require.Equal(t, http.StatusBadRequest, status)
 	require.Equal(t, "InvalidGroup.NotFound", code)
-	assert.Equal(t, "The security group 'sg-0000000000000dead' does not exist", msg,
-		"the message is unchanged; only when it is decided moved")
+	assert.Equal(t, "The security group ID 'sg-0000000000000dead' does not exist", msg,
+		"the kind's wording since #713 routed this refusal through ec2SecurityGroupIDKind")
 
 	// Nothing the launch would have created exists. DescribeSecurityGroups is included
 	// because ensureDefaultVPC's third write is the default group itself.

--- a/emulator/ec2_idkind_convergence_test.go
+++ b/emulator/ec2_idkind_convergence_test.go
@@ -1,0 +1,506 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #713: eighteen mutating EC2 handlers hand-wrote an Invalid*.NotFound whose ID family
+// already had an entry in ec2_resourceid.go's kind table. The code, message and status now
+// come from the kind, through ec2RequireNamedResource.
+//
+// The tables below are the guard on that. Every row names an operation, the parameter it
+// reads the ID from, and the exact code and message the kind produces — so a hand-written
+// copy reappearing anywhere, or a kind's wording changing without the table changing,
+// turns a row red. They pin the wire body rather than the internal call, because the wire
+// body is what an SDK consumer's error branch matches on.
+//
+// Four of the eighteen used a wording of their own that this replaced ("Security group not
+// found", "Internet gateway not found", "Route table not found", and the volume family's
+// trailing-period form). Those are behavior changes, recorded in the CHANGELOG.
+
+// ec2ErrorBody sends params and returns the status, code and message from the "ec2"
+// protocol's error document.
+func ec2ErrorBody(t *testing.T, ts *httptest.Server, params map[string]string) (int, string, string) {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var doc struct {
+		XMLName xml.Name `xml:"Response"`
+		Code    string   `xml:"Errors>Error>Code"`
+		Message string   `xml:"Errors>Error>Message"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &doc), string(body))
+	return resp.StatusCode, doc.Code, doc.Message
+}
+
+// ec2KindCase is one mutating operation reached with a bogus resource ID.
+type ec2KindCase struct {
+	// name is the subtest name, "<Action> <param>".
+	name string
+	// params are the request parameters with the ID left as a placeholder: the tests
+	// below fill idParam with the ID under test.
+	params map[string]string
+	// idParam is the parameter the handler reads the resource ID from.
+	idParam string
+	// notFound and malformed are the kind's two codes.
+	notFound, malformed string
+	// noun is the kind's noun, as it appears in the NotFound message.
+	noun string
+}
+
+// ec2KindCases covers every handler #713 converged, one row per (operation, ID family).
+//
+// ReplaceRouteTableAssociation is deliberately absent: it resolves the AssociationId
+// before the target route table, so a request carrying a bogus ID for both is answered by
+// InvalidAssociationID.NotFound — a code with no kind entry. Its route-table half is
+// covered by TestEC2_IDKind_ReplaceRouteTableAssociation below, which supplies a real
+// association first.
+func ec2KindCases() []ec2KindCase {
+	return []ec2KindCase{
+		{
+			name:    "AuthorizeSecurityGroupIngress GroupId",
+			params:  map[string]string{"Action": "AuthorizeSecurityGroupIngress", "IpProtocol": "tcp", "FromPort": "22", "ToPort": "22", "CidrIp": "0.0.0.0/0"},
+			idParam: "GroupId",
+			// AWS lowercases the "d" in the Malformed code but not in the NotFound one.
+			notFound: "InvalidGroup.NotFound", malformed: "InvalidGroupId.Malformed",
+			noun: "security group",
+		},
+		{
+			name:    "RevokeSecurityGroupEgress GroupId",
+			params:  map[string]string{"Action": "RevokeSecurityGroupEgress", "IpProtocol": "tcp", "FromPort": "22", "ToPort": "22", "CidrIp": "0.0.0.0/0"},
+			idParam: "GroupId",
+			// AWS lowercases the "d" in the Malformed code but not in the NotFound one.
+			notFound: "InvalidGroup.NotFound", malformed: "InvalidGroupId.Malformed",
+			noun: "security group",
+		},
+		{
+			name:     "AttachInternetGateway InternetGatewayId",
+			params:   map[string]string{"Action": "AttachInternetGateway", "VpcId": "vpc-0000000000000001"},
+			idParam:  "InternetGatewayId",
+			notFound: "InvalidInternetGatewayID.NotFound", malformed: "InvalidInternetGatewayId.Malformed",
+			noun: "internet gateway",
+		},
+		{
+			name:     "DetachInternetGateway InternetGatewayId",
+			params:   map[string]string{"Action": "DetachInternetGateway", "VpcId": "vpc-0000000000000001"},
+			idParam:  "InternetGatewayId",
+			notFound: "InvalidInternetGatewayID.NotFound", malformed: "InvalidInternetGatewayId.Malformed",
+			noun: "internet gateway",
+		},
+		{
+			name:     "AssociateRouteTable RouteTableId",
+			params:   map[string]string{"Action": "AssociateRouteTable", "SubnetId": "subnet-0000000000000001"},
+			idParam:  "RouteTableId",
+			notFound: "InvalidRouteTableID.NotFound", malformed: "InvalidRouteTableId.Malformed",
+			noun: "route table",
+		},
+		{
+			name:     "CreateRoute RouteTableId",
+			params:   map[string]string{"Action": "CreateRoute", "DestinationCidrBlock": "0.0.0.0/0", "GatewayId": "igw-0000000000000001"},
+			idParam:  "RouteTableId",
+			notFound: "InvalidRouteTableID.NotFound", malformed: "InvalidRouteTableId.Malformed",
+			noun: "route table",
+		},
+		{
+			name:     "ReplaceRoute RouteTableId",
+			params:   map[string]string{"Action": "ReplaceRoute", "DestinationCidrBlock": "0.0.0.0/0", "GatewayId": "igw-0000000000000001"},
+			idParam:  "RouteTableId",
+			notFound: "InvalidRouteTableID.NotFound", malformed: "InvalidRouteTableId.Malformed",
+			noun: "route table",
+		},
+		{
+			name:     "DeleteRoute RouteTableId",
+			params:   map[string]string{"Action": "DeleteRoute", "DestinationCidrBlock": "0.0.0.0/0"},
+			idParam:  "RouteTableId",
+			notFound: "InvalidRouteTableID.NotFound", malformed: "InvalidRouteTableId.Malformed",
+			noun: "route table",
+		},
+		{
+			name:     "ModifySubnetAttribute SubnetId",
+			params:   map[string]string{"Action": "ModifySubnetAttribute", "MapPublicIpOnLaunch.Value": "true"},
+			idParam:  "SubnetId",
+			notFound: "InvalidSubnetID.NotFound", malformed: "InvalidSubnetID.Malformed",
+			noun: "subnet",
+		},
+		{
+			name:     "CreateNatGateway SubnetId",
+			params:   map[string]string{"Action": "CreateNatGateway", "AllocationId": "eipalloc-0000000000000001"},
+			idParam:  "SubnetId",
+			notFound: "InvalidSubnetID.NotFound", malformed: "InvalidSubnetID.Malformed",
+			noun: "subnet",
+		},
+		{
+			name:     "ModifyVpcAttribute VpcId",
+			params:   map[string]string{"Action": "ModifyVpcAttribute", "EnableDnsSupport.Value": "true"},
+			idParam:  "VpcId",
+			notFound: "InvalidVpcID.NotFound", malformed: "InvalidVpcID.Malformed",
+			noun: "VPC",
+		},
+		{
+			name:    "AssociateAddress AllocationId",
+			params:  map[string]string{"Action": "AssociateAddress", "InstanceId": "i-0000000000000001"},
+			idParam: "AllocationId",
+			// EC2 publishes no InvalidAllocationID.Malformed, so the kind falls back.
+			notFound: "InvalidAllocationID.NotFound", malformed: "InvalidAllocationID.NotFound",
+			noun: "allocation",
+		},
+		{
+			name:     "ReleaseAddress AllocationId",
+			params:   map[string]string{"Action": "ReleaseAddress"},
+			idParam:  "AllocationId",
+			notFound: "InvalidAllocationID.NotFound", malformed: "InvalidAllocationID.NotFound",
+			noun: "allocation",
+		},
+		{
+			name:    "DeleteNatGateway NatGatewayId",
+			params:  map[string]string{"Action": "DeleteNatGateway"},
+			idParam: "NatGatewayId",
+			// The reference spells the malformed code NatGatewayMalformed, outside the
+			// Invalid*ID.Malformed family entirely. It also publishes a second absence
+			// code, NatGatewayNotFound, which this handler used before #713.
+			notFound: "InvalidNatGatewayID.NotFound", malformed: "NatGatewayMalformed",
+			noun: "NAT gateway",
+		},
+		{
+			name:     "DeleteVolume VolumeId",
+			params:   map[string]string{"Action": "DeleteVolume"},
+			idParam:  "VolumeId",
+			notFound: "InvalidVolume.NotFound", malformed: "InvalidVolumeID.Malformed",
+			noun: "volume",
+		},
+		{
+			name:     "AttachVolume VolumeId",
+			params:   map[string]string{"Action": "AttachVolume", "InstanceId": "i-0000000000000001", "Device": "/dev/xvdf"},
+			idParam:  "VolumeId",
+			notFound: "InvalidVolume.NotFound", malformed: "InvalidVolumeID.Malformed",
+			noun: "volume",
+		},
+		{
+			name:     "DetachVolume VolumeId",
+			params:   map[string]string{"Action": "DetachVolume"},
+			idParam:  "VolumeId",
+			notFound: "InvalidVolume.NotFound", malformed: "InvalidVolumeID.Malformed",
+			noun: "volume",
+		},
+	}
+}
+
+// ec2KindParams copies a case's parameters with the ID filled in, so the shared table can
+// be reused across the three tests without one mutating another's map.
+func ec2KindParams(c ec2KindCase, id string) map[string]string {
+	params := make(map[string]string, len(c.params)+1)
+	for k, v := range c.params {
+		params[k] = v
+	}
+	if id != "" {
+		params[c.idParam] = id
+	}
+	return params
+}
+
+// TestEC2_IDKind_MutateAbsentID pins the kind's NotFound code and its exact message on
+// every converged operation. The message is the kind's — "The <noun> ID '<id>' does not
+// exist", no trailing period — which is what four of these handlers did not say before.
+func TestEC2_IDKind_MutateAbsentID(t *testing.T) {
+	t.Parallel()
+	for _, c := range ec2KindCases() {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			// The prefix is derived from the case's own expectation rather than
+			// hardcoded per row: an ID's prefix is the kind's, and reading it off the
+			// parameter name would not survive AllocationId/eipalloc-.
+			id := ec2KindPrefixFor(t, c.idParam) + "0000000000000dead"
+			status, code, msg := ec2ErrorBody(t, ts, ec2KindParams(c, id))
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, c.notFound, code)
+			assert.Equal(t, "The "+c.noun+" ID '"+id+"' does not exist", msg)
+		})
+	}
+}
+
+// TestEC2_IDKind_MutateMalformedID pins the second half: syntax is checked before
+// existence, so a bogus prefix answers the kind's Malformed code — or its NotFound, for
+// the two families where AWS publishes no Malformed variant.
+//
+// Before #713 every one of these answered NotFound, telling a caller who typo'd an ID that
+// a well-formed resource was missing.
+func TestEC2_IDKind_MutateMalformedID(t *testing.T) {
+	t.Parallel()
+	for _, c := range ec2KindCases() {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			status, code, msg := ec2ErrorBody(t, ts, ec2KindParams(c, "not-an-id"))
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, c.malformed, code)
+			if c.malformed == c.notFound {
+				assert.Equal(t, "The "+c.noun+" ID 'not-an-id' does not exist", msg)
+				return
+			}
+			assert.Equal(t, `Invalid id: "not-an-id"`, msg)
+		})
+	}
+}
+
+// TestEC2_IDKind_MutateMissingID pins the third: an omitted ID is a MissingParameter
+// naming the parameter the caller left out, not a Malformed reporting an invalid value for
+// something never sent.
+//
+// Eleven of these handlers read the ID straight out of req.Params with no presence check
+// at all, so an omitted ID reached the state lookup as the empty string and came back as
+// the resource being absent.
+func TestEC2_IDKind_MutateMissingID(t *testing.T) {
+	t.Parallel()
+	for _, c := range ec2KindCases() {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			status, code, msg := ec2ErrorBody(t, ts, ec2KindParams(c, ""))
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "MissingParameter", code)
+			assert.Equal(t, "The request must contain the parameter "+c.idParam, msg)
+		})
+	}
+}
+
+// ec2KindPrefixFor maps a request parameter to the wire prefix of the IDs it carries.
+func ec2KindPrefixFor(t *testing.T, idParam string) string {
+	t.Helper()
+	prefixes := map[string]string{
+		"GroupId":           "sg-",
+		"InternetGatewayId": "igw-",
+		"RouteTableId":      "rtb-",
+		"SubnetId":          "subnet-",
+		"VpcId":             "vpc-",
+		"AllocationId":      "eipalloc-",
+		"NatGatewayId":      "nat-",
+		"VolumeId":          "vol-",
+	}
+	prefix, ok := prefixes[idParam]
+	require.True(t, ok, "no ID prefix known for parameter %q", idParam)
+	return prefix
+}
+
+// TestEC2_IDKind_ReplaceRouteTableAssociation covers the one converged site the shared
+// table cannot reach: ReplaceRouteTableAssociation resolves the AssociationId first, so
+// its route-table check needs a real association in front of it.
+func TestEC2_IDKind_ReplaceRouteTableAssociation(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	vpcID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateVpc", "CidrBlock": "10.9.0.0/16",
+	}, "vpcId")
+	subnetID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateSubnet", "VpcId": vpcID, "CidrBlock": "10.9.1.0/24",
+	}, "subnetId")
+	rtbID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateRouteTable", "VpcId": vpcID,
+	}, "routeTableId")
+	assocID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "AssociateRouteTable", "RouteTableId": rtbID, "SubnetId": subnetID,
+	}, "associationId")
+
+	absent := "rtb-0000000000000dead"
+	status, code, msg := ec2ErrorBody(t, ts, map[string]string{
+		"Action": "ReplaceRouteTableAssociation", "AssociationId": assocID, "RouteTableId": absent,
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidRouteTableID.NotFound", code)
+	assert.Equal(t, "The route table ID '"+absent+"' does not exist", msg)
+
+	status, code, msg = ec2ErrorBody(t, ts, map[string]string{
+		"Action": "ReplaceRouteTableAssociation", "AssociationId": assocID, "RouteTableId": "not-an-id",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidRouteTableId.Malformed", code)
+	assert.Equal(t, `Invalid id: "not-an-id"`, msg)
+
+	// Both refusals above must leave the association they were asked to move intact.
+	// Adding the target check found this: it used to sit after the source association had
+	// been removed and committed, so the two calls above destroyed the association and
+	// then reported a failure — and this test's own second call reached
+	// InvalidAssociationID.NotFound rather than the route-table refusal it was asserting.
+	assert.Equal(t, []string{assocID}, ec2RouteTableAssociationIDs(t, ts, rtbID),
+		"a refused ReplaceRouteTableAssociation writes nothing")
+
+	// The happy path still moves it, and to a second table rather than duplicating.
+	otherID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateRouteTable", "VpcId": vpcID,
+	}, "routeTableId")
+	moved := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "ReplaceRouteTableAssociation", "AssociationId": assocID, "RouteTableId": otherID,
+	}, "newAssociationId")
+	assert.Empty(t, ec2RouteTableAssociationIDs(t, ts, rtbID), "the source association is gone")
+	assert.Equal(t, []string{moved}, ec2RouteTableAssociationIDs(t, ts, otherID),
+		"and exactly one new one exists on the target")
+
+	// Replacing an association with one on its own route table replaces rather than
+	// duplicates: the target was read before the detach, so the append has to build on the
+	// post-detach list.
+	sameTable := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "ReplaceRouteTableAssociation", "AssociationId": moved, "RouteTableId": otherID,
+	}, "newAssociationId")
+	assert.Equal(t, []string{sameTable}, ec2RouteTableAssociationIDs(t, ts, otherID),
+		"a same-table replace leaves one association, not two")
+}
+
+// ec2RouteTableAssociationIDs returns the association IDs DescribeRouteTables reports for
+// one route table, sorted — state.List documents no ordering.
+func ec2RouteTableAssociationIDs(t *testing.T, ts *httptest.Server, rtbID string) []string {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{"Action": "DescribeRouteTables", "RouteTableId.1": rtbID})
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+	var doc struct {
+		Items []struct {
+			Associations []struct {
+				AssociationID string `xml:"routeTableAssociationId"`
+			} `xml:"associationSet>item"`
+		} `xml:"routeTableSet>item"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &doc), string(body))
+	ids := []string{}
+	for _, item := range doc.Items {
+		for _, a := range item.Associations {
+			ids = append(ids, a.AssociationID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// TestEC2_IDKind_ConvergedOperationsStillSucceed is the other half of the guard: routing a
+// refusal through the kind must not refuse a request that should work. Every operation the
+// table above reaches with a bogus ID is reached here with a real one.
+//
+// Without this, a kind check placed before the state lookup — or a wellFormed rule
+// tightened past what substrate's own 16-hex generators emit — would pass the tables above
+// while breaking every caller.
+func TestEC2_IDKind_ConvergedOperationsStillSucceed(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	vpcID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateVpc", "CidrBlock": "10.8.0.0/16",
+	}, "vpcId")
+	subnetID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateSubnet", "VpcId": vpcID, "CidrBlock": "10.8.1.0/24",
+	}, "subnetId")
+	sgID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateSecurityGroup", "GroupName": "kind-guard",
+		"GroupDescription": "converged operations", "VpcId": vpcID,
+	}, "groupId")
+	igwID := ec2CreateAndExtract(t, ts, map[string]string{"Action": "CreateInternetGateway"}, "internetGatewayId")
+	rtbID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateRouteTable", "VpcId": vpcID,
+	}, "routeTableId")
+	allocID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "AllocateAddress", "Domain": "vpc",
+	}, "allocationId")
+	instanceID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "RunInstances", "ImageId": "ami-0abcdef1234567890", "InstanceType": "t3.micro",
+		"MinCount": "1", "MaxCount": "1", "SubnetId": subnetID,
+	}, "instanceId")
+	volID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateVolume", "AvailabilityZone": "us-east-1a", "Size": "8",
+	}, "volumeId")
+	natID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "CreateNatGateway", "SubnetId": subnetID, "AllocationId": allocID,
+	}, "natGatewayId")
+
+	// AssociateAddress runs here rather than in the table below because the table is a
+	// literal: its parameters are evaluated before the first step runs, so the
+	// association ID DisassociateAddress needs would not exist yet.
+	eipAssocID := ec2CreateAndExtract(t, ts, map[string]string{
+		"Action": "AssociateAddress", "AllocationId": allocID, "InstanceId": instanceID,
+	}, "associationId")
+
+	// Ordered, because several of these depend on each other: the address must be
+	// associated before it can be released, and the volume attached before detached.
+	for _, step := range []struct {
+		name   string
+		params map[string]string
+	}{
+		{"AuthorizeSecurityGroupIngress", map[string]string{
+			"Action": "AuthorizeSecurityGroupIngress", "GroupId": sgID,
+			"IpProtocol": "tcp", "FromPort": "22", "ToPort": "22", "CidrIp": "0.0.0.0/0",
+		}},
+		{"RevokeSecurityGroupEgress", map[string]string{
+			"Action": "RevokeSecurityGroupEgress", "GroupId": sgID,
+			"IpProtocol": "tcp", "FromPort": "22", "ToPort": "22", "CidrIp": "0.0.0.0/0",
+		}},
+		{"AttachInternetGateway", map[string]string{
+			"Action": "AttachInternetGateway", "InternetGatewayId": igwID, "VpcId": vpcID,
+		}},
+		{"DetachInternetGateway", map[string]string{
+			"Action": "DetachInternetGateway", "InternetGatewayId": igwID, "VpcId": vpcID,
+		}},
+		{"CreateRoute", map[string]string{
+			"Action": "CreateRoute", "RouteTableId": rtbID,
+			"DestinationCidrBlock": "0.0.0.0/0", "GatewayId": igwID,
+		}},
+		{"ReplaceRoute", map[string]string{
+			"Action": "ReplaceRoute", "RouteTableId": rtbID,
+			"DestinationCidrBlock": "0.0.0.0/0", "GatewayId": igwID,
+		}},
+		{"DeleteRoute", map[string]string{
+			"Action": "DeleteRoute", "RouteTableId": rtbID, "DestinationCidrBlock": "0.0.0.0/0",
+		}},
+		{"AssociateRouteTable", map[string]string{
+			"Action": "AssociateRouteTable", "RouteTableId": rtbID, "SubnetId": subnetID,
+		}},
+		{"ModifySubnetAttribute", map[string]string{
+			"Action": "ModifySubnetAttribute", "SubnetId": subnetID, "MapPublicIpOnLaunch.Value": "true",
+		}},
+		{"ModifyVpcAttribute", map[string]string{
+			"Action": "ModifyVpcAttribute", "VpcId": vpcID, "EnableDnsSupport.Value": "true",
+		}},
+		// An associated address cannot be released — AWS answers
+		// InvalidIPAddress.InUse — so the disassociate is part of the sequence, not
+		// bookkeeping.
+		{"DisassociateAddress", map[string]string{
+			"Action": "DisassociateAddress", "AssociationId": eipAssocID,
+		}},
+		{"ReleaseAddress", map[string]string{"Action": "ReleaseAddress", "AllocationId": allocID}},
+		{"AttachVolume", map[string]string{
+			"Action": "AttachVolume", "VolumeId": volID, "InstanceId": instanceID, "Device": "/dev/xvdf",
+		}},
+		{"DetachVolume", map[string]string{"Action": "DetachVolume", "VolumeId": volID}},
+		{"DeleteVolume", map[string]string{"Action": "DeleteVolume", "VolumeId": volID}},
+		{"DeleteNatGateway", map[string]string{"Action": "DeleteNatGateway", "NatGatewayId": natID}},
+	} {
+		resp := ec2Request(t, ts, step.params)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "%s: %s", step.name, string(body))
+	}
+}
+
+// ec2CreateAndExtract sends a create and returns the named element of its response,
+// failing the test if the create was refused or the element is absent.
+func ec2CreateAndExtract(t *testing.T, ts *httptest.Server, params map[string]string, tag string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "%s: %s", params["Action"], string(body))
+	id := ec2ExtractXML(string(body), tag)
+	require.NotEmpty(t, id, "no <%s> in %s response: %s", tag, params["Action"], string(body))
+	return id
+}

--- a/emulator/ec2_notfound_test.go
+++ b/emulator/ec2_notfound_test.go
@@ -182,10 +182,12 @@ func TestEC2_DescribeByExplicitID_Malformed(t *testing.T) {
 			code:   "InvalidAllocationID.NotFound",
 		},
 		{
-			// Likewise for NAT gateways.
-			name:   "nat gateway wrong prefix falls back to NotFound",
+			// NAT gateways are the one family whose Malformed code sits outside the
+			// Invalid*ID.Malformed naming entirely: the reference publishes it as
+			// NatGatewayMalformed (#713).
+			name:   "nat gateway wrong prefix",
 			params: map[string]string{"Action": "DescribeNatGateways", "NatGatewayId.1": "not-an-id"},
-			code:   "InvalidNatGatewayID.NotFound",
+			code:   "NatGatewayMalformed",
 		},
 	}
 	for _, tt := range tests {

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -570,8 +570,8 @@ func (p *EC2Plugin) runInstancesWithTags(
 	// the next request in the same test sees state the refused one created. Reachable
 	// with no IAM configured, so this stands on its own regardless of the
 	// authorization change beside it.
-	if awsErr := p.ec2CheckSecurityGroups(reqCtx, securityGroupIDs, ""); awsErr != nil {
-		return nil, awsErr
+	if sgCheckErr := p.ec2CheckSecurityGroups(reqCtx, securityGroupIDs, ""); sgCheckErr != nil {
+		return nil, sgCheckErr
 	}
 
 	// Auto-create default VPC/subnet if none specified.
@@ -610,8 +610,8 @@ func (p *EC2Plugin) runInstancesWithTags(
 	// Validate security groups exist and belong to the target VPC. The existence half
 	// ran above, before the default VPC could be created; this pass adds the
 	// membership half and covers the default group the branch above may have supplied.
-	if awsErr := p.ec2CheckSecurityGroups(reqCtx, securityGroupIDs, targetVPCID); awsErr != nil {
-		return nil, awsErr
+	if sgCheckErr := p.ec2CheckSecurityGroups(reqCtx, securityGroupIDs, targetVPCID); sgCheckErr != nil {
+		return nil, sgCheckErr
 	}
 
 	reservationID := generateReservationID()
@@ -1778,8 +1778,11 @@ func (p *EC2Plugin) modifySGRules(reqCtx *RequestContext, req *AWSRequest, direc
 	sgID := req.Params["GroupId"]
 	key := "sg:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + sgID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidGroup.NotFound", Message: "Security group not found", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 modifySGRules get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2SecurityGroupIDKind, "GroupId", sgID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var sg EC2SecurityGroup
 	if unmarshalErr := json.Unmarshal(data, &sg); unmarshalErr != nil {
@@ -1903,8 +1906,11 @@ func (p *EC2Plugin) attachInternetGateway(reqCtx *RequestContext, req *AWSReques
 	vpcID := req.Params["VpcId"]
 	key := "igw:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + igwID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidInternetGatewayID.NotFound", Message: "Internet gateway not found", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 attachInternetGateway get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2InternetGatewayIDKind, "InternetGatewayId", igwID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var igw EC2InternetGateway
 	if unmarshalErr := json.Unmarshal(data, &igw); unmarshalErr != nil {
@@ -1926,8 +1932,11 @@ func (p *EC2Plugin) detachInternetGateway(reqCtx *RequestContext, req *AWSReques
 	vpcID := req.Params["VpcId"]
 	key := "igw:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + igwID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidInternetGatewayID.NotFound", Message: "Internet gateway not found", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 detachInternetGateway get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2InternetGatewayIDKind, "InternetGatewayId", igwID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var igw EC2InternetGateway
 	if unmarshalErr := json.Unmarshal(data, &igw); unmarshalErr != nil {
@@ -2116,8 +2125,11 @@ func (p *EC2Plugin) associateRouteTable(reqCtx *RequestContext, req *AWSRequest)
 	subnetID := req.Params["SubnetId"]
 	key := "rtb:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + rtbID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidRouteTableID.NotFound", Message: "Route table not found", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 associateRouteTable get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2RouteTableIDKind, "RouteTableId", rtbID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var rtb EC2RouteTable
 	if unmarshalErr := json.Unmarshal(data, &rtb); unmarshalErr != nil {
@@ -2180,8 +2192,11 @@ func (p *EC2Plugin) createRoute(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 	gwID := req.Params["GatewayId"]
 	key := "rtb:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + rtbID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidRouteTableID.NotFound", Message: "Route table not found", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 createRoute get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2RouteTableIDKind, "RouteTableId", rtbID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var rtb EC2RouteTable
 	if unmarshalErr := json.Unmarshal(data, &rtb); unmarshalErr != nil {
@@ -2217,8 +2232,11 @@ func (p *EC2Plugin) replaceRoute(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	gwID := routeTargetGateway(req.Params)
 	key := "rtb:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + rtbID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidRouteTableID.NotFound", Message: "Route table not found", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 replaceRoute get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2RouteTableIDKind, "RouteTableId", rtbID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var rtb EC2RouteTable
 	if unmarshalErr := json.Unmarshal(data, &rtb); unmarshalErr != nil {
@@ -2253,36 +2271,54 @@ func (p *EC2Plugin) replaceRouteTableAssociation(reqCtx *RequestContext, req *AW
 	assocID := req.Params["AssociationId"]
 	newRtbID := req.Params["RouteTableId"]
 
+	// Resolve the target route table first. Both refusals below used to sit after the
+	// source association had already been removed and committed, so a request naming a
+	// bogus RouteTableId destroyed the association it was asked to move and then reported
+	// a failure — the same "a refusal must leave no state behind" rule #673 established
+	// for RunInstances. Every write now happens after both IDs have resolved.
+	newKey := "rtb:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + newRtbID
+	data, getErr := p.state.Get(context.Background(), ec2Namespace, newKey)
+	if getErr != nil {
+		return nil, fmt.Errorf("ec2 replaceRouteTableAssociation get: %w", getErr)
+	}
+	if reqErr := ec2RequireNamedResource(ec2RouteTableIDKind, "RouteTableId", newRtbID, data != nil); reqErr != nil {
+		return nil, reqErr
+	}
+
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "rtb:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 replaceRouteTableAssociation list: %w", err)
 	}
 
-	// Locate and remove the existing association, capturing its subnet/main flag.
+	// Locate the existing association, capturing its subnet/main flag and the key of the
+	// route table holding it. Nothing is written until the association resolves too.
 	var moved EC2RTAssociation
+	var sourceKey string
+	var sourceAssocs []EC2RTAssociation
 	found := false
 	for _, k := range allKeys {
-		data, getErr := p.state.Get(context.Background(), ec2Namespace, k)
-		if getErr != nil || data == nil {
+		srcData, srcErr := p.state.Get(context.Background(), ec2Namespace, k)
+		if srcErr != nil {
+			return nil, fmt.Errorf("ec2 replaceRouteTableAssociation get %s: %w", k, srcErr)
+		}
+		if srcData == nil {
 			continue
 		}
 		var rtb EC2RouteTable
-		if json.Unmarshal(data, &rtb) != nil {
+		if json.Unmarshal(srcData, &rtb) != nil {
 			continue
 		}
-		newAssoc := rtb.Associations[:0]
+		remaining := make([]EC2RTAssociation, 0, len(rtb.Associations))
 		for _, a := range rtb.Associations {
 			if a.AssociationID == assocID {
 				moved = a
 				found = true
 			} else {
-				newAssoc = append(newAssoc, a)
+				remaining = append(remaining, a)
 			}
 		}
 		if found {
-			rtb.Associations = newAssoc
-			updated, _ := json.Marshal(rtb)
-			_ = p.state.Put(context.Background(), ec2Namespace, k, updated)
+			sourceKey, sourceAssocs = k, remaining
 			break
 		}
 	}
@@ -2290,20 +2326,47 @@ func (p *EC2Plugin) replaceRouteTableAssociation(reqCtx *RequestContext, req *AW
 		return nil, &AWSError{Code: "InvalidAssociationID.NotFound", Message: "association " + assocID + " not found", HTTPStatus: http.StatusBadRequest}
 	}
 
-	// Attach a fresh association to the target route table.
-	newKey := "rtb:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + newRtbID
-	data, getErr := p.state.Get(context.Background(), ec2Namespace, newKey)
-	if getErr != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidRouteTableID.NotFound", Message: "Route table not found", HTTPStatus: http.StatusBadRequest}
+	// Detach from the source. Re-read rather than reuse the loop's copy only if the source
+	// and target are the same table, which the append below would otherwise clobber.
+	if sourceKey != newKey {
+		var source EC2RouteTable
+		sourceData, srcErr := p.state.Get(context.Background(), ec2Namespace, sourceKey)
+		if srcErr != nil {
+			return nil, fmt.Errorf("ec2 replaceRouteTableAssociation reread source: %w", srcErr)
+		}
+		if unmarshalErr := json.Unmarshal(sourceData, &source); unmarshalErr != nil {
+			return nil, fmt.Errorf("ec2 replaceRouteTableAssociation unmarshal source: %w", unmarshalErr)
+		}
+		source.Associations = sourceAssocs
+		updated, marshalErr := json.Marshal(source)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("ec2 replaceRouteTableAssociation marshal source: %w", marshalErr)
+		}
+		if putErr := p.state.Put(context.Background(), ec2Namespace, sourceKey, updated); putErr != nil {
+			return nil, fmt.Errorf("ec2 replaceRouteTableAssociation put source: %w", putErr)
+		}
 	}
+
+	// Attach a fresh association to the target route table. data was read before the
+	// detach above, so when the caller replaced an association with one on the same route
+	// table it still carries the old entry; sourceAssocs is that read minus the moved
+	// association, which is what the append must build on.
 	var target EC2RouteTable
 	if unmarshalErr := json.Unmarshal(data, &target); unmarshalErr != nil {
 		return nil, fmt.Errorf("ec2 replaceRouteTableAssociation unmarshal: %w", unmarshalErr)
 	}
+	if sourceKey == newKey {
+		target.Associations = sourceAssocs
+	}
 	newAssocID := generateAssociationID()
 	target.Associations = append(target.Associations, EC2RTAssociation{AssociationID: newAssocID, SubnetID: moved.SubnetID, Main: moved.Main})
-	newData, _ := json.Marshal(target)
-	_ = p.state.Put(context.Background(), ec2Namespace, newKey, newData)
+	newData, marshalErr := json.Marshal(target)
+	if marshalErr != nil {
+		return nil, fmt.Errorf("ec2 replaceRouteTableAssociation marshal: %w", marshalErr)
+	}
+	if putErr := p.state.Put(context.Background(), ec2Namespace, newKey, newData); putErr != nil {
+		return nil, fmt.Errorf("ec2 replaceRouteTableAssociation put: %w", putErr)
+	}
 
 	type assocState struct {
 		State string `xml:"state"`
@@ -2326,8 +2389,11 @@ func (p *EC2Plugin) deleteRoute(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 	destCIDR := req.Params["DestinationCidrBlock"]
 	key := "rtb:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + rtbID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidRouteTableID.NotFound", Message: "Route table not found", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 deleteRoute get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2RouteTableIDKind, "RouteTableId", rtbID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var rtb EC2RouteTable
 	if unmarshalErr := json.Unmarshal(data, &rtb); unmarshalErr != nil {
@@ -3020,22 +3086,26 @@ func ec2LookupDefaultSecurityGroup(ctx context.Context, state StateManager, reqC
 // subnet may not exist yet, but existence needs nothing (#673). A group substrate's
 // own default-VPC branch supplied is checked by the second pass, where vpcID is
 // known.
-func (p *EC2Plugin) ec2CheckSecurityGroups(reqCtx *RequestContext, ids []string, vpcID string) *AWSError {
+func (p *EC2Plugin) ec2CheckSecurityGroups(reqCtx *RequestContext, ids []string, vpcID string) error {
 	for _, id := range ids {
 		key := "sg:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + id
 		sgData, sgErr := p.state.Get(context.Background(), ec2Namespace, key)
-		if sgErr != nil || sgData == nil {
-			return &AWSError{
-				Code:       "InvalidGroup.NotFound",
-				Message:    "The security group '" + id + "' does not exist",
-				HTTPStatus: http.StatusBadRequest,
-			}
+		if sgErr != nil {
+			return fmt.Errorf("ec2 ec2CheckSecurityGroups get %s: %w", id, sgErr)
+		}
+		if reqErr := ec2RequireResource(ec2SecurityGroupIDKind, id, sgData != nil); reqErr != nil {
+			return reqErr
 		}
 		if vpcID == "" {
 			continue
 		}
 		var sg EC2SecurityGroup
 		if json.Unmarshal(sgData, &sg) == nil && sg.VPCID != vpcID {
+			// Membership, not absence: the group resolved, so this cannot come from
+			// [ec2IDKind.notFoundError]. It reuses InvalidGroup.NotFound because that is
+			// what EC2 answers for a group in another VPC — the reference's own gloss is
+			// "the specified security group does not exist", and from the target VPC's
+			// point of view it does not.
 			return &AWSError{
 				Code:       "InvalidGroup.NotFound",
 				Message:    "The security group '" + id + "' does not belong to VPC '" + vpcID + "'",
@@ -3937,8 +4007,11 @@ func (p *EC2Plugin) modifySubnetAttribute(reqCtx *RequestContext, req *AWSReques
 	subnetID := req.Params["SubnetId"]
 	key := "subnet:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + subnetID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidSubnetID.NotFound", Message: "The subnet ID '" + subnetID + "' does not exist", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 modifySubnetAttribute get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2SubnetIDKind, "SubnetId", subnetID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var subnet EC2Subnet
 	if unmarshalErr := json.Unmarshal(data, &subnet); unmarshalErr != nil {
@@ -3963,8 +4036,11 @@ func (p *EC2Plugin) modifyVpcAttribute(reqCtx *RequestContext, req *AWSRequest) 
 	vpcID := req.Params["VpcId"]
 	key := "vpc:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + vpcID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidVpcID.NotFound", Message: "The vpc ID '" + vpcID + "' does not exist", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 modifyVpcAttribute get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2VPCIDKind, "VpcId", vpcID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var vpc EC2VPC
 	if unmarshalErr := json.Unmarshal(data, &vpc); unmarshalErr != nil {
@@ -4039,8 +4115,11 @@ func (p *EC2Plugin) associateAddress(reqCtx *RequestContext, req *AWSRequest) (*
 
 	key := "eip:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + allocationID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidAllocationID.NotFound", Message: "The allocation ID '" + allocationID + "' does not exist", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 associateAddress get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2AllocationIDKind, "AllocationId", allocationID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var eip EC2ElasticIP
 	if unmarshalErr := json.Unmarshal(data, &eip); unmarshalErr != nil {
@@ -4135,8 +4214,11 @@ func (p *EC2Plugin) releaseAddress(reqCtx *RequestContext, req *AWSRequest) (*AW
 	allocationID := req.Params["AllocationId"]
 	key := "eip:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + allocationID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "InvalidAllocationID.NotFound", Message: "The allocation ID '" + allocationID + "' does not exist", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 releaseAddress get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2AllocationIDKind, "AllocationId", allocationID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var eip EC2ElasticIP
 	if unmarshalErr := json.Unmarshal(data, &eip); unmarshalErr != nil {
@@ -4221,8 +4303,11 @@ func (p *EC2Plugin) createNatGateway(reqCtx *RequestContext, req *AWSRequest) (*
 	// Look up subnet to get VPCID.
 	subnetKey := "subnet:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + subnetID
 	subnetData, err := p.state.Get(context.Background(), ec2Namespace, subnetKey)
-	if err != nil || subnetData == nil {
-		return nil, &AWSError{Code: "InvalidSubnetID.NotFound", Message: "The subnet ID '" + subnetID + "' does not exist", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 createNatGateway get subnet: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2SubnetIDKind, "SubnetId", subnetID, subnetData != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var subnet EC2Subnet
 	if unmarshalErr := json.Unmarshal(subnetData, &subnet); unmarshalErr != nil {
@@ -4398,8 +4483,11 @@ func (p *EC2Plugin) deleteNatGateway(reqCtx *RequestContext, req *AWSRequest) (*
 	natID := req.Params["NatGatewayId"]
 	key := "nat:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + natID
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
-	if err != nil || data == nil {
-		return nil, &AWSError{Code: "NatGatewayNotFound", Message: "The nat gateway ID '" + natID + "' does not exist", HTTPStatus: http.StatusBadRequest}
+	if err != nil {
+		return nil, fmt.Errorf("ec2 deleteNatGateway get: %w", err)
+	}
+	if reqErr := ec2RequireNamedResource(ec2NatGatewayIDKind, "NatGatewayId", natID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var gw EC2NATGateway
 	if unmarshalErr := json.Unmarshal(data, &gw); unmarshalErr != nil {
@@ -5299,16 +5387,13 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 
 func (p *EC2Plugin) deleteVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	volID := req.Params["VolumeId"]
-	if volID == "" {
-		return nil, &AWSError{Code: "InvalidParameterValue", Message: "VolumeId is required", HTTPStatus: http.StatusBadRequest}
-	}
 	key := ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, volID)
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
 	if err != nil {
 		return nil, fmt.Errorf("ec2 deleteVolume get: %w", err)
 	}
-	if data == nil {
-		return nil, &AWSError{Code: "InvalidVolume.NotFound", Message: "The volume '" + volID + "' does not exist.", HTTPStatus: http.StatusBadRequest}
+	if reqErr := ec2RequireNamedResource(ec2VolumeIDKind, "VolumeId", volID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var vol EC2Volume
 	if err := json.Unmarshal(data, &vol); err != nil {
@@ -5334,8 +5419,12 @@ func (p *EC2Plugin) attachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	volID := req.Params["VolumeId"]
 	instanceID := req.Params["InstanceId"]
 	device := req.Params["Device"]
-	if volID == "" || instanceID == "" {
-		return nil, &AWSError{Code: "InvalidParameterValue", Message: "VolumeId and InstanceId are required", HTTPStatus: http.StatusBadRequest}
+	// AttachVolume names two required IDs, so each is reported by name rather than as a
+	// single refusal naming both: a caller who sent one of the two learns which. The
+	// volume is checked first, being the resource the operation is named for — an absent
+	// VolumeId falls to ec2RequireNamedResource below.
+	if volID != "" && instanceID == "" {
+		return nil, ec2MissingParameter("InstanceId")
 	}
 	if device == "" {
 		device = "/dev/xvdf"
@@ -5345,8 +5434,8 @@ func (p *EC2Plugin) attachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if err != nil {
 		return nil, fmt.Errorf("ec2 attachVolume get: %w", err)
 	}
-	if data == nil {
-		return nil, &AWSError{Code: "InvalidVolume.NotFound", Message: "The volume '" + volID + "' does not exist.", HTTPStatus: http.StatusBadRequest}
+	if reqErr := ec2RequireNamedResource(ec2VolumeIDKind, "VolumeId", volID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var vol EC2Volume
 	if err := json.Unmarshal(data, &vol); err != nil {
@@ -5400,16 +5489,13 @@ func (p *EC2Plugin) attachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 
 func (p *EC2Plugin) detachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	volID := req.Params["VolumeId"]
-	if volID == "" {
-		return nil, &AWSError{Code: "InvalidParameterValue", Message: "VolumeId is required", HTTPStatus: http.StatusBadRequest}
-	}
 	key := ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, volID)
 	data, err := p.state.Get(context.Background(), ec2Namespace, key)
 	if err != nil {
 		return nil, fmt.Errorf("ec2 detachVolume get: %w", err)
 	}
-	if data == nil {
-		return nil, &AWSError{Code: "InvalidVolume.NotFound", Message: "The volume '" + volID + "' does not exist.", HTTPStatus: http.StatusBadRequest}
+	if reqErr := ec2RequireNamedResource(ec2VolumeIDKind, "VolumeId", volID, data != nil); reqErr != nil {
+		return nil, reqErr
 	}
 	var vol EC2Volume
 	if err := json.Unmarshal(data, &vol); err != nil {

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -2988,8 +2988,25 @@ func TestEC2_RunInstances_InvalidSG(t *testing.T) {
 	body2 := readBody(t, resp2)
 	subnetID := ec2ExtractXML(body2, "subnetId")
 
-	// RunInstances with nonexistent SG → error.
+	// RunInstances with nonexistent SG → error. The ID is well-formed hex so this
+	// exercises the absence path; "sg-nonexistent" is a malformed ID and since #713
+	// answers InvalidGroupId.Malformed, which is a different assertion (below).
 	resp3 := ec2Request(t, ts, map[string]string{
+		"Action":            "RunInstances",
+		"ImageId":           "ami-12345678",
+		"InstanceType":      "t2.micro",
+		"SubnetId":          subnetID,
+		"SecurityGroupId.1": "sg-0000000000000dead",
+		"MinCount":          "1",
+		"MaxCount":          "1",
+	})
+	assert.Equal(t, http.StatusBadRequest, resp3.StatusCode)
+	body3 := readBody(t, resp3)
+	assert.Contains(t, body3, "InvalidGroup.NotFound")
+
+	// A syntactically invalid group ID is refused before the lookup, with the kind's
+	// Malformed code — the same ordering every other ID family follows (#713).
+	resp4 := ec2Request(t, ts, map[string]string{
 		"Action":            "RunInstances",
 		"ImageId":           "ami-12345678",
 		"InstanceType":      "t2.micro",
@@ -2998,9 +3015,8 @@ func TestEC2_RunInstances_InvalidSG(t *testing.T) {
 		"MinCount":          "1",
 		"MaxCount":          "1",
 	})
-	assert.Equal(t, http.StatusBadRequest, resp3.StatusCode)
-	body3 := readBody(t, resp3)
-	assert.Contains(t, body3, "InvalidGroup.NotFound")
+	assert.Equal(t, http.StatusBadRequest, resp4.StatusCode)
+	assert.Contains(t, readBody(t, resp4), "InvalidGroupId.Malformed")
 }
 
 // ec2ExtractXML extracts the text content of the first occurrence of an XML tag.

--- a/emulator/ec2_resourceid.go
+++ b/emulator/ec2_resourceid.go
@@ -30,6 +30,15 @@ type ec2IDKind struct {
 
 // EC2 resource-ID kinds, with error codes taken verbatim from
 // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html.
+//
+// Every operation that names a resource of one of these families answers through the kind
+// — via [ec2IDFilter] on a Describe*, or [ec2RequireResource] / [ec2RequireNamedResource]
+// on a mutation. A hand-written &AWSError carrying one of these codes is a bug: it is a
+// second place for a wording, status or request-ID change to have to land, and it is
+// invisible to anyone reading this table (#713). The one deliberate exception is
+// [EC2Plugin.ec2CheckSecurityGroups]' membership refusal, which reuses
+// InvalidGroup.NotFound for a group that exists in the wrong VPC — a different condition
+// from absence, so it cannot share the kind's message.
 var (
 	ec2InstanceIDKind = ec2IDKind{
 		Prefix: "i-", NotFound: "InvalidInstanceID.NotFound",
@@ -59,12 +68,6 @@ var (
 		Prefix: "snap-", NotFound: "InvalidSnapshot.NotFound",
 		Malformed: "InvalidSnapshotID.Malformed", Noun: "snapshot",
 	}
-	// The three volume operations that predate this kind — DeleteVolume, AttachVolume
-	// and DetachVolume — spell the NotFound message themselves, as "The volume 'vol-…'
-	// does not exist." with a trailing period and no "ID". They are left alone: this
-	// kind is for CreateSnapshot and CreateVolume, which had no volume check at all
-	// (#689), and rewording three published messages is a change a consumer matching on
-	// them would notice for no gain. Unifying them is a follow-up.
 	ec2VolumeIDKind = ec2IDKind{
 		Prefix: "vol-", NotFound: "InvalidVolume.NotFound",
 		Malformed: "InvalidVolumeID.Malformed", Noun: "volume",
@@ -72,11 +75,24 @@ var (
 	// EC2 publishes no InvalidAllocationID.Malformed; a malformed allocation ID
 	// comes back as InvalidAllocationID.NotFound.
 	ec2AllocationIDKind = ec2IDKind{
-		Prefix: "eipalloc-", NotFound: "InvalidAllocationID.NotFound", Noun: "allocation ID",
+		Prefix: "eipalloc-", NotFound: "InvalidAllocationID.NotFound", Noun: "allocation",
 	}
-	// Likewise EC2 publishes no InvalidNatGatewayID.Malformed.
+	// NAT gateways are the one family whose malformed code sits outside the
+	// Invalid*ID.Malformed naming: the reference publishes it as NatGatewayMalformed,
+	// "The specified NAT gateway ID is not formed correctly. Ensure that you specify the
+	// NAT gateway ID in the form nat-xxxxxxxxxxxxxxxxx." Pairing it with
+	// InvalidNatGatewayID.NotFound is the same cross-naming the kinds above already
+	// carry for snapshots and security groups (#713).
+	//
+	// The reference also publishes a second absence code, NatGatewayNotFound ("The
+	// specified NAT gateway does not exist."), and no per-operation page says which
+	// operation raises which — DeleteNatGateway's Errors section is empty, as EC2's are.
+	// Substrate answers InvalidNatGatewayID.NotFound everywhere, because that is the
+	// spelling every other kind here follows and the one DescribeNatGateways has always
+	// published; DeleteNatGateway's NatGatewayNotFound converged onto it.
 	ec2NatGatewayIDKind = ec2IDKind{
-		Prefix: "nat-", NotFound: "InvalidNatGatewayID.NotFound", Noun: "NAT gateway",
+		Prefix: "nat-", NotFound: "InvalidNatGatewayID.NotFound",
+		Malformed: "NatGatewayMalformed", Noun: "NAT gateway",
 	}
 )
 
@@ -203,18 +219,47 @@ func (f *ec2IDFilter) unresolved() error {
 	return nil
 }
 
+// requireResource returns the kind's Malformed error for a syntactically invalid id, its
+// NotFound error for a well-formed id that named nothing, or nil. found reports whether
+// the lookup succeeded.
+//
+// The typed *AWSError return is for the callers that thread one — returning it through an
+// error-typed variable would make a nil result a non-nil error interface holding a nil
+// pointer. [ec2RequireResource] is the error-typed form, and does the conversion once.
+func (k ec2IDKind) requireResource(id string, found bool) *AWSError {
+	switch {
+	case !k.wellFormed(id):
+		return k.malformedError(id)
+	case !found:
+		return k.notFoundError(id)
+	default:
+		return nil
+	}
+}
+
 // ec2RequireResource returns the kind's Malformed or NotFound error for an ID a
 // mutating operation named that substrate holds no state for. found reports
 // whether the lookup succeeded.
 func ec2RequireResource(kind ec2IDKind, id string, found bool) error {
-	switch {
-	case !kind.wellFormed(id):
-		return kind.malformedError(id)
-	case !found:
-		return kind.notFoundError(id)
-	default:
-		return nil
+	if err := kind.requireResource(id, found); err != nil {
+		return err
 	}
+	return nil
+}
+
+// ec2RequireNamedResource is [ec2RequireResource] for an ID read from a single named
+// request parameter, checking the three conditions in the order real EC2 reports them: an
+// omitted parameter is a MissingParameter, a syntactically invalid ID is the kind's
+// Malformed, and a well-formed ID that names nothing is the kind's NotFound.
+//
+// paramName is the wire parameter the ID came from, so the refusal names what the caller
+// left out. Without it an omitted ID reads as the empty string and falls through to
+// Malformed, reporting an invalid value for a parameter that was never sent.
+func ec2RequireNamedResource(kind ec2IDKind, paramName, id string, found bool) error {
+	if id == "" {
+		return ec2MissingParameter(paramName)
+	}
+	return ec2RequireResource(kind, id, found)
 }
 
 // ec2MissingParameter returns the error EC2 raises for a required-but-absent


### PR DESCRIPTION
`ec2_resourceid.go`'s `ec2IDKind` table has been the single source of an ID family's prefix rule, `NotFound` code, `Malformed` code and message since #391 — but only the `Describe*` path went through it. Every mutation that named a resource wrote its own `&AWSError{}`, so a wording, status or request-ID change had to land in nineteen places, and four of the copies had already drifted.

Eighteen handlers now answer through `ec2RequireNamedResource`: `AuthorizeSecurityGroupIngress`, `RevokeSecurityGroupEgress`, `Attach`/`DetachInternetGateway`, `AssociateRouteTable`, `Create`/`Replace`/`DeleteRoute`, `ReplaceRouteTableAssociation`, `ModifySubnetAttribute`, `CreateNatGateway`, `ModifyVpcAttribute`, `Associate`/`ReleaseAddress`, `DeleteNatGateway` and `Delete`/`Attach`/`DetachVolume`. The kind table's own comment now says outright that a hand-written copy is a bug.

## Criterion 2 is unsatisfiable, and this is what it does instead

The issue says the volume handlers "agree with the kind's message today". They do not, and `ec2_resourceid.go:62-67` already said so before this PR: the hand-written string is ``The volume 'vol-…' does not exist.`` and the kind emits ``The volume ID 'vol-…' does not exist`` — differing in `" ID"` and in the trailing period. So "no behaviour change to the message" cannot be met by any convergence.

Unified on the **machinery's** wording, rewriting the three published strings. Teaching the kind the hand-written form would have broken `ec2_snapshots_test.go:164` and spread a trailing period nothing else in the tree uses; AWS's own reference publishes the `" ID"` form for every family.

## Four behaviour changes

1. **Four wordings replaced.** "Security group not found", "Internet gateway not found" and "Route table not found" become `The <noun> ID '<id>' does not exist`; the volume family's form gains `" ID"` and loses its trailing period.
2. **A malformed ID on a mutation answers `Malformed`, not `NotFound`.** Fifteen of the eighteen reported an absence for `GroupId=sg-not-an-id` — the wrong branch for a consumer to land in, since `Invalid*.NotFound` is retryable-after-create and `*.Malformed` never is. The `Describe*` path has drawn the distinction since #391; the two halves of the API now agree.
3. **Eleven operations answer `MissingParameter` for an omitted ID**, where the empty string used to fall through to a `Malformed` naming a parameter the caller never sent, or to a hand-written `InvalidParameterValue` + "VolumeId is required". `AttachVolume` reports its two required IDs separately, so a caller who sent one of the two learns which.
4. **`DeleteNatGateway`'s `NatGatewayNotFound` becomes `InvalidNatGatewayID.NotFound`**, and `NatGatewayMalformed` is newly used. `cfnDeleteAbsentCodes` keeps both codes, because an event log recorded by an older substrate replays the old one and a stack mid-delete must still read it as an absence.

## Three bugs the sweep found

- **`ReplaceRouteTableAssociation` destroyed the association a refusal named.** It removed the source association and committed it *before* resolving the target `RouteTableId`, so a request naming an absent or malformed route table deleted the caller's association, left the subnet with no route table at all, and then reported a failure — and a retry with the ID corrected answered `InvalidAssociationID.NotFound` for an association the first call had eaten. Same "a refusal must leave no state behind" rule #673 established for `RunInstances`. Found by the new test, whose second assertion was being reached through state its first assertion had already corrupted.

  Two more in the same handler: replacing an association with one on *its own* route table left **two** associations, because the target was read before the detach and the append built on the pre-detach list; and two `state.Get`/`json.Unmarshal` failures inside the search loop were swallowed by a bare `continue`.

- **`ec2AllocationIDKind` said "ID" twice.** Its `Noun` was `"allocation ID"` and `notFoundError` appends `" ID"` of its own, so `DescribeAddresses` on an absent `eipalloc-` answered ``The allocation ID ID 'eipalloc-…' does not exist``. Reachable since #391, pinned by nothing. A naive sweep would have propagated the doubled word to two more sites.

- **Twelve handlers reported a storage failure as a missing resource.** They tested `if err != nil || data == nil`, collapsing a real `StateManager` error into the resource's `NotFound` and discarding the actual error. Each now wraps with `%w` and checks existence separately.

## Provenance

`NatGatewayMalformed` is AWS's, newly used: NAT gateways are the one family whose malformed code sits outside the `Invalid*ID.Malformed` naming, published as "The specified NAT gateway ID is not formed correctly. Ensure that you specify the NAT gateway ID in the form nat-xxxxxxxxxxxxxxxxx."

The choice **between** AWS's two absence codes is substrate's. The reference publishes `NatGatewayNotFound` ("The specified NAT gateway does not exist.") and `InvalidNatGatewayID.NotFound` both, and no per-operation page settles which operation raises which — `API_DeleteNatGateway.html`'s `Errors` section is empty, as EC2's pages generally are. Substrate answers the `Invalid*ID.NotFound` spelling, which is what every other kind follows and what `DescribeNatGateways` has always published.

## Scope

Out of scope and named in the kind table: `InvalidRoute.NotFound`, `InvalidAssociationID.NotFound`, `InvalidLaunchTemplateId.NotFound` and `InvalidLaunchTemplateName.NotFoundException` have no kind entry.

One deliberate exception to the convergence: `ec2CheckSecurityGroups`' membership refusal reuses `InvalidGroup.NotFound` for a group that exists in the wrong VPC. That is a different condition from absence, so it cannot share the kind's message — recorded in both the code and the docs.

## Tests

New `emulator/ec2_idkind_convergence_test.go`, pinning the **wire body** rather than the internal call, because the wire body is what an SDK consumer's error branch matches. A 17-row table × three tests covers absent / malformed / omitted for every converged site; `ReplaceRouteTableAssociation` gets its own test (it resolves `AssociationId` first, so it needs a real association in front of it) which also pins the no-partial-mutation and same-table-replace rules; and `TestEC2_IDKind_ConvergedOperationsStillSucceed` drives all eighteen through their happy paths so the sweep cannot have broken one silently.

Both new invariants were mutation-tested: deleting the same-table branch and moving the target check back below the detach each turn the test red, the second reproducing the original bug exactly (`actual: []string{}` — the association gone).

Four existing expectations changed, all of them because the tests used *malformed* IDs to reach a NotFound path: `cfn_failure_test.go` and `TestEC2_RunInstances_InvalidSG` (`sg-does-not-exist`, `sg-nonexistent` → now `InvalidGroupId.Malformed`, so both use a hex ID and the latter gains a Malformed assertion), `ec2_default_vpc_refusal_test.go`'s message, and the NAT malformed row.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `make test` (race), `make coverage` (82.3%), `make docs-reference docs-reference-check docs-versions`, `npm --prefix docs run build` with no dangling anchors, `go vet`/`go test -C test/e2e`.

Closes #713