### PR TITLE
fix(plugins): an unimplemented operation is refused by its protocol, from one place (#716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   both, and no per-operation page settles which operation raises which —
   `API_DeleteNatGateway.html`'s Errors section is empty, as EC2's pages generally are.
 
+- **An unimplemented operation is refused by its service's protocol, from one place** (#716).
+  All 59 unknown-action arms across the tree — every plugin has one, since none covers its
+  whole service — now call `unknownActionError` (or `unknownRouteError` for a REST plugin whose
+  router matched nothing), so the answer is a property of the service's protocol rather than of
+  whoever wrote the plugin. They were 59 hand-written literals in **eight different wordings**,
+  each leading with the plugin's own Go type: `SSMPlugin: unknown operation "Foo"`. No AWS
+  endpoint emits a Go type name, so a consumer's error branch was matching on a substrate
+  internal, and a caller could not tell "substrate has not implemented this" from any other
+  refusal. A tripwire test now sweeps all 67 registered plugins and fails if any answer
+  contains the word `Plugin`.
+
+  **Forty-four services change both the code and the HTTP status. This is the upgrade note for
+  this release.** Those 44 answered `InvalidAction` at **400** — the Query protocol's code — on
+  a service whose protocol is JSON or REST/JSON. AWS publishes `UnknownOperationException` at
+  **404** for both JSON families, so that is what they answer now. Anything asserting
+  `InvalidAction` or a 400 for an unimplemented call on a JSON service needs both values
+  updated; the nine Query, `ec2` and REST/XML services are unchanged. The affected list is
+  every service in `docs/services.md`'s coverage matrix whose Protocol is JSON or REST/JSON.
+
+  The message names the operation in both arms, which is the point of it — that is what lets a
+  consumer tell an unimplemented call from a rejected one. A REST plugin reports the verb *and*
+  the path (`The action POST /substrate-no-such-path is not recognized.`), because a REST
+  operation is identified by the pair: `DELETE` and `POST` on one path are different
+  operations, and the same verb on a mistyped path is the more common mistake.
+
+  Two plugin-local helpers are retired, their reasoning moved to the call site:
+  `cfgsvcInvalidAction` and `orgInvalidAction`. `AccountPlugin`, `RAMPlugin` and
+  `SchedulerPlugin` switched to the route form, because their path resolvers hand the default
+  arm `""` (account, scheduler) or a bare HTTP verb (RAM) rather than an operation name. One
+  shape difference survives deliberately: IAM answers a refusal as a 4xx response document
+  rather than an error object, and both conventions are in use across the tree (#516 is about
+  that), so only IAM's code, message and status moved.
+
+  Provenance: `UnknownOperationException` and its 404 are AWS's — "The action or operation
+  isn't recognized. Verify that the action name is spelled correctly and that it's supported by
+  the API version you're using." — published on both a JSON service's Common Errors page
+  (DynamoDB) and a REST/JSON one's (Lambda), which agree on the code and the status.
+  **`InvalidAction` is substrate's choice, and #716's premise that it could be verified against
+  the reference is wrong: the code has been removed from every current Common Errors page.**
+  Checked on EC2's, IAM's, SNS's, DynamoDB's and Lambda's; the Query, `ec2` and REST/XML pages
+  now publish no unknown-action code at all, and nothing was put in `InvalidAction`'s place. It
+  is kept because it is the code the Query protocol has always used and an SDK caller's error
+  branch is written against it. The message wording in both arms is substrate's — AWS publishes
+  a description of the condition, never a wire message.
+
 ### Fixed
+- **Three plugins answered a wrong code for an unimplemented operation** (#716), all corrected
+  by routing through the shared refusal. DynamoDB returned `UnknownOperationException` — the
+  right code — at HTTP **400**, where AWS's own DynamoDB Common Errors page publishes 404.
+  Secrets Manager returned `UnrecognizedClientException`, which AWS's Common Errors pages
+  define as a *credentials* error — "The X.509 certificate or AWS access key ID you provided
+  doesn't exist in our records", HTTP 403 — sending a consumer to debug request signing for a
+  call substrate simply does not serve. Price List returned `InvalidParameterException`, the
+  code for a bad parameter rather than a bad operation. All three now answer
+  `UnknownOperationException` at 404, their protocol's documented refusal.
+
 - **A refused `ReplaceRouteTableAssociation` no longer destroys the association it was asked
   to move** (#713). The handler removed the source association and committed it *before*
   resolving the target route table, so a request naming a `RouteTableId` that was absent or

--- a/docs/services.md
+++ b/docs/services.md
@@ -90,6 +90,70 @@ here.
 
 ---
 
+## An operation substrate does not implement
+
+No plugin covers its whole service, so every one of the 67 has an answer for a call it
+does not serve. That answer is decided by the **Protocol** column above and by nothing
+else — not by which plugin the call reached, and not by who wrote it.
+
+| Protocol | Code | HTTP | Message |
+|---|---|---|---|
+| JSON, REST/JSON | `UnknownOperationException` | **404** | `The action <name> is not recognized.` |
+| Query, `ec2`, REST/XML | `InvalidAction` | 400 | `The action <name> is not valid for this endpoint.` |
+
+`<name>` is the operation name for a service that dispatches on one, and the HTTP verb
+and path — `POST /substrate-no-such-path` — for a REST service whose router matched
+nothing. A REST operation is identified by the pair, so both halves are reported:
+`DELETE` and `POST` on one path are different operations, and the same verb on a
+mistyped path is the more common mistake.
+
+The name is always present. It is what lets a consumer tell *substrate has not
+implemented this call* from *this call was rejected*, which is the difference that
+decides whether to change the test or the code under test.
+
+### Where the two rows come from
+
+`UnknownOperationException` at 404 is AWS's, quoted from its Common Errors pages:
+"The action or operation isn't recognized. Verify that the action name is spelled
+correctly and that it's supported by the API version you're using." Both JSON families
+publish it and both publish the 404 — checked on
+[DynamoDB's](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/CommonErrors.html)
+for JSON and
+[Lambda's](https://docs.aws.amazon.com/lambda/latest/api/CommonErrors.html)
+for REST/JSON.
+
+`InvalidAction` is **substrate's choice, not a citation.** AWS's current Common Errors
+pages publish no unknown-action code at all for the Query, `ec2` and REST/XML families:
+the `InvalidAction` entry those pages once carried has been removed, and nothing was put
+in its place — checked on EC2's, IAM's and SNS's. Substrate keeps `InvalidAction` because
+it is the code the Query protocol has always used and an SDK caller's error branch is
+written against it, and because the reference offers no replacement to move to. If AWS
+publishes one, this row changes.
+
+### Two things this is not
+
+It is **not** a Go type name. Until
+[#716](https://github.com/scttfrdmn/substrate/issues/716) every plugin wrote this
+refusal itself — 59 sites in eight wordings, each leading with the plugin's Go type
+("`SSMPlugin: unknown operation "Foo"`"). No AWS endpoint emits that, so a consumer's
+error branch was matching on a substrate internal. A tripwire test now sweeps all 67
+plugins and fails if any answer contains the word `Plugin`.
+
+It is **not** `InvalidAction` on a JSON service. Forty-four of those 59 sites answered the
+Query protocol's code at 400 on a service whose protocol is JSON, which is what the
+table above corrects. **A test asserting `InvalidAction` or a 400 for an unimplemented
+call on a JSON or REST/JSON service needs both the code and the status from the first
+row** — see the release that landed #716 in `CHANGELOG.md` for the upgrade note. The
+change is visible for every service in the matrix except the nine Query, `ec2` and
+REST/XML ones.
+
+One shape difference survives on purpose: IAM answers a refusal as a 4xx response
+document rather than as an error object. Both conventions are in use across the tree
+([#516](https://github.com/scttfrdmn/substrate/issues/516) is about that), so #716
+changed where IAM's code, message and status come from and left the shape alone.
+
+---
+
 ## CloudFormation
 
 **Endpoint:** `cloudformation.{region}.amazonaws.com`
@@ -5970,7 +6034,7 @@ the only place the missing ARN surfaces, and the ARN a caller has to add.
 | An `aws:`-prefixed tag key | `InvalidInputException`/`INVALID_SYSTEM_TAGS_PARAMETER` |
 | An unreadable pagination token | `InvalidInputException`/`INVALID_NEXT_TOKEN` |
 | An unparseable request body | `InvalidInputException` |
-| An unimplemented operation | `InvalidAction` |
+| An unimplemented operation | `UnknownOperationException`, **404** — Organizations is JSON; see [An operation substrate does not implement](#an-operation-substrate-does-not-implement) |
 
 ### Quotas
 

--- a/emulator/account_plugin.go
+++ b/emulator/account_plugin.go
@@ -183,11 +183,10 @@ func (p *AccountPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (
 	case "GetRegionOptStatus":
 		return p.getRegionOptStatus(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("AccountPlugin: unsupported operation %q", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		// parseAccountOperation answers "" for anything but the four Region routes, so
+		// there is no operation name to name and the refusal reports the verb and path
+		// that resolved to nothing.
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/account_plugin_test.go
+++ b/emulator/account_plugin_test.go
@@ -155,13 +155,20 @@ func TestAccount_IsReachableFromAnSDKShapedRequest(t *testing.T) {
 // of the four Region routes must not be answered as though it were: the eleven
 // contact and account-name operations are deliberately not emulated, and a
 // consumer calling one needs to see that rather than a plausible empty success.
+//
+// Account is REST-JSON, so the answer is the UnknownOperationException/404 that
+// AWS's Common Errors page publishes for that protocol (#716), and the message
+// names the verb and path because a REST operation is identified by the pair.
 func TestAccount_UnknownPathIsRefused(t *testing.T) {
 	ts := emulator.StartTestServer(t)
 
-	status, code, _ := decodeAccountResponse(t,
+	status, code, message := decodeAccountResponse(t,
 		accountRequest(t, ts, "/putAlternateContact", map[string]any{}), nil)
-	if status != http.StatusBadRequest || code != "InvalidAction" {
-		t.Errorf("POST /putAlternateContact: %d %q, want 400/InvalidAction", status, code)
+	if status != http.StatusNotFound || code != "UnknownOperationException" {
+		t.Errorf("POST /putAlternateContact: %d %q, want 404/UnknownOperationException", status, code)
+	}
+	if !strings.Contains(message, "POST /putAlternateContact") {
+		t.Errorf("message %q does not name the verb and path that resolved to nothing", message)
 	}
 }
 

--- a/emulator/acm_plugin.go
+++ b/emulator/acm_plugin.go
@@ -65,11 +65,7 @@ func (p *ACMPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "RenewCertificate":
 		return acmJSONResponse(http.StatusOK, struct{}{})
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("ACMPlugin: unknown operation %q", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), op)
 	}
 }
 

--- a/emulator/apigateway_plugin.go
+++ b/emulator/apigateway_plugin.go
@@ -125,11 +125,7 @@ func (p *APIGatewayPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (
 	case "GetBasePathMappings":
 		return p.getBasePathMappings(ctx, params["name"])
 	default:
-		return nil, &AWSError{
-			Code:       "NotFoundException",
-			Message:    fmt.Sprintf("APIGatewayPlugin: unknown operation for %s %s", req.Operation, req.Path),
-			HTTPStatus: http.StatusNotFound,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/apigatewayv2_plugin.go
+++ b/emulator/apigatewayv2_plugin.go
@@ -93,11 +93,7 @@ func (p *APIGatewayV2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest)
 	case "CreateApiMapping":
 		return p.createAPIMapping(ctx, req, params["name"])
 	default:
-		return nil, &AWSError{
-			Code:       "NotFoundException",
-			Message:    fmt.Sprintf("APIGatewayV2Plugin: unknown operation for %s %s", req.Operation, req.Path),
-			HTTPStatus: http.StatusNotFound,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/appsync_plugin.go
+++ b/emulator/appsync_plugin.go
@@ -89,11 +89,7 @@ func (p *AppSyncPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AW
 	case "ExecuteGraphQL":
 		return p.executeGraphQL(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "AppSyncPlugin: unsupported operation " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/athena_plugin.go
+++ b/emulator/athena_plugin.go
@@ -109,11 +109,7 @@ func (p *AthenaPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWS
 	case "ListWorkGroups":
 		return p.listWorkGroups(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "AthenaPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/backup_plugin.go
+++ b/emulator/backup_plugin.go
@@ -66,11 +66,7 @@ func (p *BackupPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (*
 	case "DeleteBackupSelection":
 		return p.deleteBackupSelection(reqCtx, planID, selectionID)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "BackupPlugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/batch_plugin.go
+++ b/emulator/batch_plugin.go
@@ -69,11 +69,7 @@ func (p *BatchPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSR
 	case "DescribeJobDefinitions":
 		return p.describeJobDefinitions(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "BatchPlugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/bedrock_runtime_plugin.go
+++ b/emulator/bedrock_runtime_plugin.go
@@ -72,11 +72,7 @@ func (p *BedrockRuntimePlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 	case "ListModelInvocationJobs":
 		return p.listModelInvocationJobs(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "BedrockRuntimePlugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/budgets_plugin.go
+++ b/emulator/budgets_plugin.go
@@ -50,11 +50,7 @@ func (p *BudgetsPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AW
 	case "DeleteBudget":
 		return p.deleteBudget(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "BudgetsPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/ce_plugin.go
+++ b/emulator/ce_plugin.go
@@ -80,11 +80,7 @@ func (p *CEPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSResp
 	case "GetDimensionValues":
 		return p.getDimensionValues(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "CEPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/ce_plugin_test.go
+++ b/emulator/ce_plugin_test.go
@@ -278,14 +278,17 @@ func TestCE_GetCostAndUsage_BlendedCostMetric(t *testing.T) {
 	t.Errorf("EC2 group not found in: %+v", out.ResultsByTime[0].Groups)
 }
 
+// TestCE_UnsupportedOperation pins the default arm. Cost Explorer is JSON-RPC, so
+// the refusal is the UnknownOperationException at 404 that AWS's Common Errors page
+// publishes for that protocol, not the Query protocol's InvalidAction at 400 (#716).
 func TestCE_UnsupportedOperation(t *testing.T) {
 	ts := newCETestServer(t)
 
 	resp := ceRequest(t, ts, "UnknownOp", map[string]interface{}{})
 	defer resp.Body.Close() //nolint:errcheck
 
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
 	}
 }
 

--- a/emulator/cloudformation_plugin.go
+++ b/emulator/cloudformation_plugin.go
@@ -180,11 +180,7 @@ func (p *CloudFormationPlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 	case "DescribeStackEvents":
 		return p.describeStackEvents(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "CloudFormationPlugin: unknown action " + action,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), action)
 	}
 }
 

--- a/emulator/cloudfront_plugin.go
+++ b/emulator/cloudfront_plugin.go
@@ -71,11 +71,7 @@ func (p *CloudFrontPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (
 	case "ListTagsForResource":
 		return p.listTagsForResource(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "CloudFrontPlugin: unsupported operation for path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/cloudtrail_plugin.go
+++ b/emulator/cloudtrail_plugin.go
@@ -56,11 +56,7 @@ func (p *CloudTrailPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest
 	case "StopLogging":
 		return p.stopLogging(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "CloudTrailPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/cloudwatch_extra_test.go
+++ b/emulator/cloudwatch_extra_test.go
@@ -25,10 +25,13 @@ func TestCWLogs_Shutdown(t *testing.T) {
 	require.NoError(t, p.Shutdown(context.Background()))
 }
 
+// TestCWLogs_UnknownOperation pins the default arm. CloudWatch Logs is JSON-RPC, so
+// the refusal is AWS's documented UnknownOperationException at 404, not the Query
+// protocol's InvalidAction at 400 (#716).
 func TestCWLogs_UnknownOperation(t *testing.T) {
 	srv := newCWLogsTestServer(t)
 	resp := cwLogsRequest(t, srv, "UnknownOp", map[string]any{})
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestCWLogs_CreateGroupMissingName(t *testing.T) {
@@ -137,10 +140,13 @@ func TestEB_Shutdown(t *testing.T) {
 	require.NoError(t, p.Shutdown(context.Background()))
 }
 
+// TestEB_UnknownOperation pins the default arm. EventBridge is JSON-RPC, so the
+// refusal is AWS's documented UnknownOperationException at 404, not the Query
+// protocol's InvalidAction at 400 (#716).
 func TestEB_UnknownOperation(t *testing.T) {
 	srv := newEBTestServer(t)
 	resp := ebRequest(t, srv, "UnknownOp", map[string]any{})
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestEB_PutRuleMissingName(t *testing.T) {

--- a/emulator/cloudwatch_plugin.go
+++ b/emulator/cloudwatch_plugin.go
@@ -65,11 +65,7 @@ func (p *CloudWatchPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (
 	case "ListMetrics":
 		return p.listMetrics(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("CloudWatchPlugin: unknown operation %q", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/cloudwatchlogs_plugin.go
+++ b/emulator/cloudwatchlogs_plugin.go
@@ -67,11 +67,7 @@ func (p *CloudWatchLogsPlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 	case "FilterLogEvents":
 		return p.filterLogEvents(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("CloudWatchLogsPlugin: unknown operation %q", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/codebuild_plugin.go
+++ b/emulator/codebuild_plugin.go
@@ -55,11 +55,7 @@ func (p *CodeBuildPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest)
 	case "BatchGetBuilds":
 		return p.batchGetBuilds(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "CodeBuildPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/codebuild_plugin_test.go
+++ b/emulator/codebuild_plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -270,6 +271,10 @@ func TestCodeBuildPlugin_StartBuild_ProjectNotFound(t *testing.T) {
 	}
 }
 
+// TestCodeBuildPlugin_UnsupportedOperation pins the default arm. CodeBuild is
+// JSON-RPC, so the refusal is AWS's documented UnknownOperationException at 404, not
+// the Query protocol's InvalidAction at 400 (#716). The message names the operation
+// so a consumer discovers which call is missing.
 func TestCodeBuildPlugin_UnsupportedOperation(t *testing.T) {
 	p, ctx := setupCodeBuildPlugin(t)
 	_, err := p.HandleRequest(ctx, codebuildRequest(t, "ListBuildsForProject", map[string]any{}))
@@ -277,7 +282,13 @@ func TestCodeBuildPlugin_UnsupportedOperation(t *testing.T) {
 		t.Fatal("want error for unsupported op, got nil")
 	}
 	awsErr, ok := err.(*emulator.AWSError)
-	if !ok || awsErr.Code != "InvalidAction" {
-		t.Errorf("want InvalidAction, got %v", err)
+	if !ok || awsErr.Code != "UnknownOperationException" {
+		t.Errorf("want UnknownOperationException, got %v", err)
+	}
+	if awsErr.HTTPStatus != http.StatusNotFound {
+		t.Errorf("HTTPStatus = %d, want 404", awsErr.HTTPStatus)
+	}
+	if !strings.Contains(awsErr.Message, "ListBuildsForProject") {
+		t.Errorf("message %q does not name the operation", awsErr.Message)
 	}
 }

--- a/emulator/codedeploy_plugin.go
+++ b/emulator/codedeploy_plugin.go
@@ -59,11 +59,7 @@ func (p *CodeDeployPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest
 	case "GetDeployment":
 		return p.getDeployment(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "CodeDeployPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/codepipeline_plugin.go
+++ b/emulator/codepipeline_plugin.go
@@ -57,11 +57,7 @@ func (p *CodePipelinePlugin) HandleRequest(reqCtx *RequestContext, req *AWSReque
 	case "GetPipelineExecution":
 		return p.getPipelineExecution(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "CodePipelinePlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/cognito_identity_plugin.go
+++ b/emulator/cognito_identity_plugin.go
@@ -65,11 +65,7 @@ func (p *CognitoIdentityPlugin) HandleRequest(ctx *RequestContext, req *AWSReque
 	case "GetIdentityPoolRoles":
 		return p.getIdentityPoolRoles(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("CognitoIdentityPlugin: unknown operation %q", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), op)
 	}
 }
 

--- a/emulator/cognito_idp_plugin.go
+++ b/emulator/cognito_idp_plugin.go
@@ -110,11 +110,7 @@ func (p *CognitoIDPPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (
 	case "SetUserPoolMfaConfig":
 		return p.setUserPoolMfaConfig(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("CognitoIDPPlugin: unknown operation %q", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), op)
 	}
 }
 

--- a/emulator/configservice_packs_test.go
+++ b/emulator/configservice_packs_test.go
@@ -1368,11 +1368,12 @@ func TestConformancePacks_AnUnsupportedPackOperationIsRefusedByName(t *testing.T
 	// Config has 97 operations and substrate implements the detective-controls subset, so
 	// the organization-level pack operations are not claimed. Naming the operation is
 	// what lets a consumer discover which call is missing rather than reading a bare
-	// refusal.
+	// refusal. Config is JSON-RPC, so the code and status are the
+	// UnknownOperationException/404 AWS publishes for that protocol (#716).
 	resp := configRequest(t, ts, "PutOrganizationConformancePack", map[string]any{})
 	status, code, message := decodeConfigResponse(t, resp, nil)
-	require.Equal(t, http.StatusBadRequest, status)
-	require.Equal(t, "InvalidAction", code)
+	require.Equal(t, http.StatusNotFound, status)
+	require.Equal(t, "UnknownOperationException", code)
 	require.Contains(t, message, "PutOrganizationConformancePack")
 }
 

--- a/emulator/configservice_plugin.go
+++ b/emulator/configservice_plugin.go
@@ -94,7 +94,10 @@ func (p *ConfigServicePlugin) HandleRequest(ctx *RequestContext, req *AWSRequest
 			return h(ctx, req)
 		}
 	}
-	return nil, cfgsvcInvalidAction(req.Operation)
+	// AWS Config has 97 operations and substrate implements the detective-controls
+	// subset, so this is the answer for the rest. It names the operation so a
+	// consumer discovers which call is missing rather than reading a bare refusal.
+	return nil, unknownActionError(p.Name(), req.Operation)
 }
 
 // cfgsvcJSONResponse marshals an AWS Config response body.

--- a/emulator/configservice_recorder_test.go
+++ b/emulator/configservice_recorder_test.go
@@ -859,12 +859,14 @@ func TestConfigRecorder_RefusesAMissingRecorderMember(t *testing.T) {
 func TestConfigService_AnUnimplementedOperationNamesItself(t *testing.T) {
 	// AWS Config has 97 operations and substrate implements the detective-controls
 	// subset. An unimplemented one must say which, so a consumer discovers the gap from
-	// the response rather than by reading the plugin.
+	// the response rather than by reading the plugin. Config is JSON-RPC, so the code
+	// and status are the UnknownOperationException/404 AWS publishes for that protocol
+	// (#716).
 	ts := emulator.StartTestServer(t)
 
 	resp := configRequest(t, ts, "SelectResourceConfig", map[string]any{})
 	status, code, message := decodeConfigResponse(t, resp, nil)
-	assert.Equal(t, http.StatusBadRequest, status)
-	assert.Equal(t, "InvalidAction", code)
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, "UnknownOperationException", code)
 	assert.Contains(t, message, "SelectResourceConfig")
 }

--- a/emulator/configservice_rules_test.go
+++ b/emulator/configservice_rules_test.go
@@ -1208,12 +1208,14 @@ func TestConfigRules_DescribePaginatesAndTheTokenTerminates(t *testing.T) {
 
 func TestConfigRules_AreNotReachableWithoutTheOperationBeingClaimed(t *testing.T) {
 	// The rule cluster is claimed by the plugin's third claim function; an operation no
-	// cluster claims is InvalidAction naming itself, so a consumer discovers which call
-	// is missing rather than getting a bare refusal.
+	// cluster claims is refused naming itself, so a consumer discovers which call is
+	// missing rather than getting a bare refusal. Config is JSON-RPC, so the code and
+	// status are the UnknownOperationException/404 AWS publishes for that protocol
+	// (#716).
 	ts := configRuleServer(t)
 	resp := configRequest(t, ts, "PutRemediationConfigurations", map[string]any{})
 	status, code, message := decodeConfigResponse(t, resp, nil)
-	assert.Equal(t, http.StatusBadRequest, status)
-	assert.Equal(t, "InvalidAction", code)
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, "UnknownOperationException", code)
 	assert.Contains(t, message, "PutRemediationConfigurations")
 }

--- a/emulator/configservice_tags_test.go
+++ b/emulator/configservice_tags_test.go
@@ -604,13 +604,15 @@ func TestConfigTags_AreClearedRatherThanStoredEmpty(t *testing.T) {
 
 func TestConfigTags_AnUnsupportedTagOperationIsRefusedByName(t *testing.T) {
 	// AWS Config has 97 operations; substrate implements the detective-controls subset.
-	// An unclaimed one names itself so a consumer discovers which call is missing.
+	// An unclaimed one names itself so a consumer discovers which call is missing. Config
+	// is JSON-RPC, so the code and status are the UnknownOperationException/404 AWS
+	// publishes for that protocol (#716).
 	ts := emulator.StartTestServer(t)
 
 	status, code, message := decodeConfigResponse(t,
 		configRequest(t, ts, "ListResourceEvaluations", map[string]any{}), nil)
-	assert.Equal(t, http.StatusBadRequest, status)
-	assert.Equal(t, "InvalidAction", code)
+	assert.Equal(t, http.StatusNotFound, status)
+	assert.Equal(t, "UnknownOperationException", code)
 	assert.Contains(t, message, "ListResourceEvaluations")
 }
 

--- a/emulator/configservice_types.go
+++ b/emulator/configservice_types.go
@@ -290,15 +290,6 @@ func cfgsvcValidation(message string) *AWSError {
 	return cfgsvcErr("ValidationException", message)
 }
 
-// cfgsvcInvalidAction reports an operation the plugin does not implement.
-//
-// AWS Config has 97 operations and substrate implements the detective-controls
-// subset, so this is the answer for the rest. It names the operation so a consumer
-// discovers which call is missing rather than a bare refusal.
-func cfgsvcInvalidAction(op string) *AWSError {
-	return cfgsvcErr("InvalidAction", "ConfigServicePlugin: unsupported operation "+op)
-}
-
 // cfgsvcUnmarshal decodes a request body, answering ValidationException rather
 // than a generic malformed-data code: ValidationException is the input exception
 // every Config operation declares, so it is the branch a caller's error handling

--- a/emulator/dynamodb_plugin.go
+++ b/emulator/dynamodb_plugin.go
@@ -105,11 +105,7 @@ func (p *DynamoDBPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*A
 	case "ListTagsOfResource":
 		return p.listTagsOfResource(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "UnknownOperationException",
-			Message:    fmt.Sprintf("DynamoDBPlugin: unknown operation %q", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/dynamodb_plugin_test.go
+++ b/emulator/dynamodb_plugin_test.go
@@ -993,11 +993,15 @@ func TestDynamoDB_UpdateItem_AddAndDelete(t *testing.T) {
 	assert.Equal(t, "alpha", remainingTags[0])
 }
 
+// TestDynamoDB_UnknownOperation pins the default arm. DynamoDB is the JSON-RPC
+// service whose Common Errors page substrate reads UnknownOperationException's HTTP
+// 404 from, so this is where the status is pinned: it was 400 before #716, which no
+// AWS page publishes.
 func TestDynamoDB_UnknownOperation(t *testing.T) {
 	srv := newDynamoDBTestServer(t)
 
 	resp := dynamodbRequest(t, srv, "FakeOperation", map[string]any{})
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	var errResult map[string]any
 	decodeDynamoJSON(t, resp, &errResult)

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -245,11 +245,7 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "DescribeSnapshots":
 		return p.describeSnapshots(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "EC2Plugin: unknown action " + action,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), action)
 	}
 }
 

--- a/emulator/ecr_plugin.go
+++ b/emulator/ecr_plugin.go
@@ -88,11 +88,7 @@ func (p *ECRPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "ListTagsForResource":
 		return p.listTagsForResource(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("ECRPlugin: unknown operation %q", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), op)
 	}
 }
 

--- a/emulator/ecs_plugin.go
+++ b/emulator/ecs_plugin.go
@@ -100,11 +100,7 @@ func (p *ECSPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "ListTagsForResource":
 		return p.listTagsForResource(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("ECSPlugin: unknown operation %q", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), op)
 	}
 }
 

--- a/emulator/efs_plugin.go
+++ b/emulator/efs_plugin.go
@@ -67,11 +67,7 @@ func (p *EFSPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "UntagResource":
 		return p.untagResource(ctx, req, resourceID)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "EFSPlugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/elasticache_plugin.go
+++ b/emulator/elasticache_plugin.go
@@ -85,11 +85,7 @@ func (p *ElastiCachePlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) 
 	case "RemoveTagsFromResource":
 		return p.removeTagsFromResource(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "ElastiCachePlugin: unknown action " + action,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), action)
 	}
 }
 

--- a/emulator/elb_plugin.go
+++ b/emulator/elb_plugin.go
@@ -86,11 +86,7 @@ func (p *ELBPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "SetRulePriorities":
 		return p.setRulePriorities(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "ELBPlugin: unknown action " + action,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), action)
 	}
 }
 

--- a/emulator/emrserverless_plugin.go
+++ b/emulator/emrserverless_plugin.go
@@ -59,11 +59,7 @@ func (p *EMRServerlessPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest
 	case "ListJobRuns":
 		return p.listJobRuns(ctx, req, appID)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "EMRServerlessPlugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/eventbridge_plugin.go
+++ b/emulator/eventbridge_plugin.go
@@ -64,11 +64,7 @@ func (p *EventBridgePlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) 
 	case "ListEventBuses":
 		return p.listEventBuses(ctx)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("EventBridgePlugin: unknown operation %q", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/firehose_plugin.go
+++ b/emulator/firehose_plugin.go
@@ -51,11 +51,7 @@ func (p *FirehosePlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*A
 	case "DeleteDeliveryStream":
 		return p.deleteDeliveryStream(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "FirehosePlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/fsx_plugin.go
+++ b/emulator/fsx_plugin.go
@@ -107,11 +107,7 @@ func (p *FSxPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "DeleteFileSystem":
 		return p.deleteFileSystem(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("FSxPlugin: unknown operation %q", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/glue_plugin.go
+++ b/emulator/glue_plugin.go
@@ -106,11 +106,7 @@ func (p *GluePlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRe
 	case "GetTags":
 		return p.getTags(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "GluePlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/health_plugin.go
+++ b/emulator/health_plugin.go
@@ -69,11 +69,7 @@ func (p *HealthPlugin) HandleRequest(_ *RequestContext, req *AWSRequest) (*AWSRe
 	case "DescribeEventAggregates":
 		return p.describeEventAggregates()
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "HealthPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -197,9 +197,11 @@ func (p *IAMPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.simulateCustomPolicy(ctx, req)
 
 	default:
-		return iamErrorResponse("InvalidAction",
-			fmt.Sprintf("Could not find operation %s", req.Operation),
-			http.StatusBadRequest), nil
+		// IAM answers a refusal as a 4xx *AWSResponse rather than an *AWSError —
+		// both conventions are in use and #516 turns on that — so the shape stays
+		// IAM's while the code, message and status come from the one place.
+		refusal := unknownActionError(p.Name(), req.Operation)
+		return iamErrorResponse(refusal.Code, refusal.Message, refusal.HTTPStatus), nil
 	}
 }
 

--- a/emulator/kinesis_plugin.go
+++ b/emulator/kinesis_plugin.go
@@ -90,11 +90,7 @@ func (p *KinesisPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AW
 	case "DisableEnhancedMonitoring":
 		return p.disableEnhancedMonitoring(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("KinesisPlugin: unknown operation %q", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), op)
 	}
 }
 

--- a/emulator/kms_plugin.go
+++ b/emulator/kms_plugin.go
@@ -95,11 +95,7 @@ func (p *KMSPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "ReEncrypt":
 		return p.reEncrypt(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "UnsupportedOperationException",
-			Message:    fmt.Sprintf("KMSPlugin: unknown operation %q", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/lambda_plugin.go
+++ b/emulator/lambda_plugin.go
@@ -114,11 +114,7 @@ func (p *LambdaPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWS
 	case "DeleteEventSourceMapping":
 		return p.deleteEventSourceMapping(ctx, name)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("LambdaPlugin: unknown operation %q (path %q)", op, req.Path),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/msk_plugin.go
+++ b/emulator/msk_plugin.go
@@ -58,11 +58,7 @@ func (p *MSKPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "ListNodes":
 		return p.listNodes(ctx, req, clusterARN)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "MSKPlugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/omics_plugin.go
+++ b/emulator/omics_plugin.go
@@ -55,11 +55,7 @@ func (p *OmicsPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSR
 	case "ListRuns":
 		return p.listRuns(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "OmicsPlugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/organizations_plugin.go
+++ b/emulator/organizations_plugin.go
@@ -104,7 +104,7 @@ func (p *OrganizationsPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest
 			return h(caller, req)
 		}
 	}
-	return nil, orgInvalidAction(req.Operation)
+	return nil, unknownActionError(p.Name(), req.Operation)
 }
 
 // resolveOrgCaller builds the orgCaller for a request, resolving the signing

--- a/emulator/organizations_policy_test.go
+++ b/emulator/organizations_policy_test.go
@@ -1703,10 +1703,14 @@ func TestOrganizations_PolicyIDSyntaxUnits(t *testing.T) {
 }
 
 // TestOrganizations_PolicyOperationsAreClaimed pins that every operation in the lane
-// is dispatched, and that an operation outside it still falls through to
-// InvalidAction. A silently unclaimed operation would answer InvalidAction, which a
-// caller reads as "this API does not exist" rather than "substrate has not
+// is dispatched, and that an operation outside it still falls through to the
+// unknown-action refusal. A silently unclaimed operation would answer that refusal,
+// which a caller reads as "this API does not exist" rather than "substrate has not
 // implemented it".
+//
+// Organizations is JSON-RPC, so that refusal is the UnknownOperationException AWS
+// publishes for the protocol; it was InvalidAction, a Query-protocol code, until
+// #716.
 func TestOrganizations_PolicyOperationsAreClaimed(t *testing.T) {
 	ts := newOrganizationsTestServer(t)
 
@@ -1721,8 +1725,8 @@ func TestOrganizations_PolicyOperationsAreClaimed(t *testing.T) {
 		}
 		_ = json.NewDecoder(resp.Body).Decode(&out) //nolint:errcheck
 		resp.Body.Close()                           //nolint:errcheck
-		if out.Type == "InvalidAction" {
-			t.Errorf("%s: expected the operation to be claimed, got InvalidAction", op)
+		if out.Type == "UnknownOperationException" {
+			t.Errorf("%s: expected the operation to be claimed, got UnknownOperationException", op)
 		}
 	}
 
@@ -1735,7 +1739,7 @@ func TestOrganizations_PolicyOperationsAreClaimed(t *testing.T) {
 	}
 	_ = json.NewDecoder(resp.Body).Decode(&out) //nolint:errcheck
 	resp.Body.Close()                           //nolint:errcheck
-	if out.Type != "InvalidAction" {
-		t.Errorf("expected an unimplemented operation to answer InvalidAction, got %q", out.Type)
+	if out.Type != "UnknownOperationException" {
+		t.Errorf("expected an unimplemented operation to answer UnknownOperationException, got %q", out.Type)
 	}
 }

--- a/emulator/organizations_resourcepolicy_test.go
+++ b/emulator/organizations_resourcepolicy_test.go
@@ -595,15 +595,20 @@ func TestOrganizations_ResourcePolicy_CorruptRecordIsAnError(t *testing.T) {
 // TestOrganizations_ResourcePolicyOperationsAreClaimed pins that all three
 // operations reach the new cluster.
 //
-// This is the failure #619 actually reported: an unclaimed operation falls through
-// to InvalidAction, which a caller reads as "no such API" rather than "substrate
-// has not implemented it", so it hunts for a bug in its own request.
+// This is the failure #619 actually reported: an unclaimed operation falls through to
+// the unknown-action refusal, which a caller reads as "no such API" rather than
+// "substrate has not implemented it", so it hunts for a bug in its own request.
+//
+// The code to watch for is Organizations' own protocol's: JSON, so
+// UnknownOperationException. It was InvalidAction until #716 routed every plugin's
+// refusal through one place, and a sentinel still naming that code would silently stop
+// catching anything.
 func TestOrganizations_ResourcePolicyOperationsAreClaimed(t *testing.T) {
 	ts := newOrganizationsTestServer(t)
 
 	for _, op := range []string{"PutResourcePolicy", "DescribeResourcePolicy", "DeleteResourcePolicy"} {
-		if _, _, code := orgResourcePolicyCall(t, ts, op, map[string]any{}); strings.HasPrefix(code, "InvalidAction") {
-			t.Errorf("%s: expected the operation to be claimed, got InvalidAction", op)
+		if _, _, code := orgResourcePolicyCall(t, ts, op, map[string]any{}); strings.HasPrefix(code, "UnknownOperationException") {
+			t.Errorf("%s: expected the operation to be claimed, got UnknownOperationException", op)
 		}
 	}
 }

--- a/emulator/organizations_state.go
+++ b/emulator/organizations_state.go
@@ -184,11 +184,6 @@ func orgConstraintViolation(reason, message string) *AWSError {
 	return orgErr("ConstraintViolationException", fmt.Sprintf("%s: %s", reason, message))
 }
 
-// orgInvalidAction reports an operation the plugin does not implement.
-func orgInvalidAction(op string) *AWSError {
-	return orgErr("InvalidAction", "OrganizationsPlugin: unsupported operation "+op)
-}
-
 // orgUnmarshal decodes a request body, answering InvalidInputException rather
 // than a generic malformed-data code: the caller's catch branch is written
 // against the Organizations exception, and no Organizations operation can return

--- a/emulator/organizations_state_test.go
+++ b/emulator/organizations_state_test.go
@@ -534,23 +534,24 @@ func TestOrganizations_MalformedBodyIsInvalidInput(t *testing.T) {
 	}
 }
 
-// TestOrganizations_UnsupportedOperation checks the claim chain's fallthrough:
-// an operation no cluster claims is InvalidAction rather than a panic or a
-// silent empty success.
+// TestOrganizations_UnsupportedOperation checks the claim chain's fallthrough: an
+// operation no cluster claims is refused rather than panicking or answering a silent
+// empty success. Organizations is JSON-RPC, so the refusal is the
+// UnknownOperationException at 404 AWS publishes for that protocol (#716).
 func TestOrganizations_UnsupportedOperation(t *testing.T) {
 	ts := newOrganizationsTestServer(t)
 
 	resp := orgsRequest(t, ts, "LeaveOrganization", map[string]interface{}{})
 	defer resp.Body.Close() //nolint:errcheck
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
 	}
 	var out map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if code, _ := out["__type"].(string); code != "InvalidAction" {
-		t.Errorf("expected __type=InvalidAction, got %q", code)
+	if code, _ := out["__type"].(string); code != "UnknownOperationException" {
+		t.Errorf("expected __type=UnknownOperationException, got %q", code)
 	}
 }
 

--- a/emulator/pricing_plugin.go
+++ b/emulator/pricing_plugin.go
@@ -173,8 +173,7 @@ func (p *PriceListPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*
 	case "GetAttributeValues":
 		return p.getAttributeValues(req)
 	default:
-		return nil, pricingError(pricingErrInvalidParameter,
-			"PriceListPlugin: unsupported operation "+req.Operation)
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/pricing_plugin_test.go
+++ b/emulator/pricing_plugin_test.go
@@ -1017,12 +1017,17 @@ func TestPricingEndpointRegions(t *testing.T) {
 	}
 }
 
+// TestPricingUnsupportedOperation pins the default arm. It answered
+// InvalidParameterException — the code for a bad *parameter*, not a bad operation —
+// until #716 routed every plugin's unknown-action arm through one place. Pricing is
+// JSON-RPC, so the answer is now the UnknownOperationException at 404 AWS publishes
+// for that protocol.
 func TestPricingUnsupportedOperation(t *testing.T) {
 	t.Parallel()
 	ts := newPricingTestServer(t)
 
 	resp := pricingCall(t, ts, "us-east-1", "GetPriceListFileUrl", map[string]any{})
-	assertPricingError(t, resp, http.StatusBadRequest, "InvalidParameterException")
+	assertPricingError(t, resp, http.StatusNotFound, "UnknownOperationException")
 }
 
 // TestPricingSeededFailure is the point of the seed endpoint: it lets a consumer

--- a/emulator/quicksight_plugin.go
+++ b/emulator/quicksight_plugin.go
@@ -54,11 +54,7 @@ func (p *QuickSightPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (
 	case "DescribeIngestion":
 		return p.describeIngestion(ctx, req, accountID, resourceID, secondaryID)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "QuickSightPlugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/ram_plugin.go
+++ b/emulator/ram_plugin.go
@@ -57,11 +57,10 @@ func (p *RAMPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	case "ListResources":
 		return p.listResources(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "RAMPlugin: unsupported operation " + op,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		// parseRAMOperation falls back to the bare HTTP method for a path it does not
+		// recognize, which is not an operation name, so the refusal reports the verb and
+		// path that resolved to nothing rather than that fallback.
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/rds_plugin.go
+++ b/emulator/rds_plugin.go
@@ -109,11 +109,7 @@ func (p *RDSPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "RemoveTagsFromResource":
 		return p.removeTagsFromResource(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "RDSPlugin: unknown action " + action,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), action)
 	}
 }
 

--- a/emulator/redshift_plugin.go
+++ b/emulator/redshift_plugin.go
@@ -60,11 +60,7 @@ func (p *RedshiftPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) 
 	case "DescribeClusterSnapshots":
 		return p.describeClusterSnapshots(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "RedshiftPlugin: unsupported action " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/redshiftdata_plugin.go
+++ b/emulator/redshiftdata_plugin.go
@@ -67,11 +67,7 @@ func (p *RedshiftDataPlugin) HandleRequest(reqCtx *RequestContext, req *AWSReque
 	case "GetStatementResult":
 		return p.getStatementResult(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "RedshiftDataPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/route53_plugin.go
+++ b/emulator/route53_plugin.go
@@ -66,11 +66,7 @@ func (p *Route53Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AW
 	case "ListResourceRecordSets":
 		return p.listResourceRecordSets(ctx, req, zoneID)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "Route53Plugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/sagemaker_plugin.go
+++ b/emulator/sagemaker_plugin.go
@@ -64,11 +64,7 @@ func (p *SageMakerPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*
 	case "ListTrainingJobs":
 		return p.listTrainingJobs(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "SageMakerPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/scheduler_plugin.go
+++ b/emulator/scheduler_plugin.go
@@ -118,11 +118,9 @@ func (p *SchedulerPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*
 	case "ListSchedules":
 		return p.listSchedules(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("SchedulerPlugin: unknown operation %q", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		// parseSchedulerOperation answers "" for a path it does not recognize, so there
+		// is no operation name to name and the refusal reports the verb and path.
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/secretsmanager_plugin.go
+++ b/emulator/secretsmanager_plugin.go
@@ -68,11 +68,7 @@ func (p *SecretsManagerPlugin) HandleRequest(ctx *RequestContext, req *AWSReques
 	case "RotateSecret":
 		return p.rotateSecret(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "UnrecognizedClientException",
-			Message:    fmt.Sprintf("SecretsManagerPlugin: unknown operation %q", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/servicequotas_plugin.go
+++ b/emulator/servicequotas_plugin.go
@@ -65,11 +65,7 @@ func (p *ServiceQuotasPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequ
 	case "GetRequestedServiceQuotaChange":
 		return p.getRequestedServiceQuotaChange(sqAccountID(reqCtx), req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("ServiceQuotasPlugin: unsupported operation %q", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/sesv2_plugin.go
+++ b/emulator/sesv2_plugin.go
@@ -53,11 +53,7 @@ func (p *SESv2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSR
 	case "SendEmail":
 		return p.sendEmail(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "SESv2Plugin: unsupported path " + req.Path,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownRouteError(p.Name(), requestMethod(req), req.Path)
 	}
 }
 

--- a/emulator/sns_plugin.go
+++ b/emulator/sns_plugin.go
@@ -86,11 +86,7 @@ func (p *SNSPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "ListTagsForResource":
 		return p.listTagsForResource(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("The action %s is not valid for this endpoint.", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/sqs_plugin.go
+++ b/emulator/sqs_plugin.go
@@ -88,11 +88,7 @@ func (p *SQSPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "PurgeQueue":
 		return p.purgeQueue(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("The action %s is not valid for this endpoint.", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/ssm_plugin.go
+++ b/emulator/ssm_plugin.go
@@ -79,11 +79,7 @@ func (p *SSMPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "DescribeInstanceInformation":
 		return p.describeInstanceInformation(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("SSMPlugin: unknown operation %q", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/sso_plugin.go
+++ b/emulator/sso_plugin.go
@@ -64,11 +64,7 @@ func (p *SSOPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	case "ListAccountAssignments":
 		return p.listAccountAssignments(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "SSOPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/stepfunctions_plugin.go
+++ b/emulator/stepfunctions_plugin.go
@@ -95,11 +95,7 @@ func (p *StepFunctionsPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest
 	case "ListTagsForResource":
 		return p.listTagsForResource(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "UnsupportedOperationException",
-			Message:    fmt.Sprintf("StepFunctionsPlugin: unknown operation %q", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), op)
 	}
 }
 

--- a/emulator/sts_plugin.go
+++ b/emulator/sts_plugin.go
@@ -57,11 +57,7 @@ func (p *STSPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 	case "GetSessionToken":
 		return p.getSessionToken(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("Could not find operation %s", req.Operation),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/tagging_plugin.go
+++ b/emulator/tagging_plugin.go
@@ -55,11 +55,7 @@ func (p *TaggingPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (
 	case "UntagResources":
 		return p.untagResources(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    fmt.Sprintf("The action %q is not valid for this web service", op),
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), op)
 	}
 }
 

--- a/emulator/tagging_plugin_test.go
+++ b/emulator/tagging_plugin_test.go
@@ -547,12 +547,15 @@ func TestTagging_InvalidARN(t *testing.T) {
 	assert.NotEmpty(t, failures)
 }
 
+// TestTagging_InvalidOperation pins the default arm. The Resource Groups Tagging API
+// is JSON-RPC, so the refusal is the UnknownOperationException at 404 AWS publishes
+// for that protocol, not the Query protocol's InvalidAction at 400 (#716).
 func TestTagging_InvalidOperation(t *testing.T) {
 	ts, _ := newTaggingTestServer(t)
 
 	resp := taggingRequest(t, ts, "BadOperation", map[string]any{})
 	defer resp.Body.Close() //nolint:errcheck
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestTagging_GetResources_IAMUser(t *testing.T) {

--- a/emulator/timestream_plugin.go
+++ b/emulator/timestream_plugin.go
@@ -69,11 +69,7 @@ func (p *TimestreamPlugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (
 	case "CancelQuery":
 		return p.cancelQuery(ctx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "TimestreamPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/transfer_plugin.go
+++ b/emulator/transfer_plugin.go
@@ -59,11 +59,7 @@ func (p *TransferPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) 
 	case "ListUsers":
 		return p.listUsers(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "TransferPlugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/unknown_action.go
+++ b/emulator/unknown_action.go
@@ -1,0 +1,74 @@
+package emulator
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// unknownActionError refuses an operation a plugin does not implement, in the
+// code, message and HTTP status the service's own error reference publishes for
+// that condition.
+//
+// Every plugin used to write this refusal itself — 59 sites in eight shapes, each
+// naming the plugin's Go type in the message ("SSMPlugin: unknown operation
+// \"Foo\"") — so a consumer's error branch read a substrate implementation detail
+// that no real endpoint emits, and a caller could not tell "substrate has not
+// implemented this" from any other refusal (#716). Routing them all here makes the
+// answer a property of the service's protocol rather than of whoever wrote the
+// plugin.
+//
+// The protocol decides it because AWS publishes two different answers:
+//
+//   - JSON-RPC and REST-JSON services publish UnknownOperationException with HTTP
+//     404: "The action or operation isn't recognized. Verify that the action name
+//     is spelled correctly and that it's supported by the API version you're
+//     using." Confirmed on a JSON-RPC service's Common Errors page (DynamoDB) and
+//     a REST-JSON one's (Lambda), which agree on both the code and the 404.
+//
+//   - Query, "ec2" and REST-XML services publish nothing for it. AWS's current
+//     Common Errors pages carry no unknown-action code at all for them — the
+//     InvalidAction entry they once had has been removed, checked on EC2's, IAM's
+//     and SNS's pages — so neither the code nor the message below can be cited to
+//     the live reference. Substrate keeps InvalidAction because it is the code the
+//     Query protocol has always used, an SDK caller's error branch is written
+//     against it, and the reference offers no replacement to move to.
+//
+// service is the plugin's own [Plugin.Name]. An unregistered service falls back to
+// the Query answer, which is [errorProtocolFor]'s own default with no
+// Content-Type to read.
+//
+// action is normalized to "(empty)" when blank, so a caller reading the message never
+// sees the two spaces a missing name would leave behind. A blank name is reachable:
+// a JSON-RPC service dispatches on an X-Amz-Target header a caller can omit.
+func unknownActionError(service, action string) *AWSError {
+	if action = strings.TrimSpace(action); action == "" {
+		action = "(empty)"
+	}
+	switch errorProtocolFor(service, "") {
+	case errProtoJSONRPC, errProtoRESTJSON:
+		return &AWSError{
+			Code:       "UnknownOperationException",
+			Message:    fmt.Sprintf("The action %s is not recognized.", action),
+			HTTPStatus: http.StatusNotFound,
+		}
+	default:
+		return &AWSError{
+			Code:       "InvalidAction",
+			Message:    fmt.Sprintf("The action %s is not valid for this endpoint.", action),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+}
+
+// unknownRouteError is [unknownActionError] for a REST plugin whose path resolver
+// matched nothing, so there is no operation name to name.
+//
+// A REST operation is identified by verb *and* path, and these plugins reach their
+// default arm precisely when the pair resolved to no operation — so the pair is
+// what the refusal reports. Both halves are included because either alone is
+// ambiguous: DELETE and POST on the same path are different operations, and the
+// same verb on a mistyped path is the more common mistake.
+func unknownRouteError(service, method, path string) *AWSError {
+	return unknownActionError(service, method+" "+path)
+}

--- a/emulator/unknown_action_test.go
+++ b/emulator/unknown_action_test.go
@@ -1,0 +1,239 @@
+package emulator_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// This file covers #716: the answer a plugin gives for an operation it does not
+// implement.
+//
+// Every plugin used to write that answer itself, in eight different shapes, and each
+// one named the plugin's own Go type — "SSMPlugin: unknown operation \"Foo\"". No AWS
+// endpoint emits a Go type name, so a consumer's error branch was reading a substrate
+// implementation detail. Worse, forty-four of the fifty-nine sites answered
+// InvalidAction, which is the Query protocol's code, on a service whose protocol is
+// JSON; AWS publishes UnknownOperationException at HTTP 404 for those.
+//
+// Both halves are pinned here. The table asserts the exact code, status and message
+// for one service per protocol arm, and the sweep asserts across *every* registered
+// plugin that no answer names a Go type — which is the assertion that stays true as
+// plugins are added, since a new plugin joins the sweep for free.
+
+// unknownActionRequest builds a request for an operation no AWS service publishes.
+//
+// It fills every field a plugin's dispatcher might read — Operation for a JSON-RPC or
+// Query service, HTTPMethod and Path for a REST one, and Action for a Query service
+// parsed from form parameters — so one request reaches the default arm whatever the
+// plugin routes on. No X-Amz-Target header is set, because each JSON-RPC plugin trims
+// its own service prefix from it and a foreign prefix would leave a plugin dispatching
+// on a value this function did not choose.
+func unknownActionRequest(service string) *emulator.AWSRequest {
+	const op = "SubstrateNoSuchOperation"
+	return &emulator.AWSRequest{
+		Service:    service,
+		Operation:  op,
+		HTTPMethod: http.MethodPost,
+		Path:       "/substrate-no-such-path",
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       []byte("{}"),
+		Params:     map[string]string{"Action": op},
+	}
+}
+
+// unknownActionRegistry builds the same plugin set the server builds, so the sweep
+// covers every service a consumer can reach rather than a hand-kept list.
+func unknownActionRegistry(t *testing.T) (*emulator.PluginRegistry, *emulator.RequestContext) {
+	t.Helper()
+	registry := emulator.NewPluginRegistry()
+	require.NoError(t, emulator.RegisterDefaultPlugins(
+		context.Background(),
+		registry,
+		emulator.NewMemoryStateManager(),
+		emulator.NewTimeController(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)),
+		emulator.NewDefaultLogger(slog.LevelError, false),
+		nil,
+		nil,
+	))
+	return registry, &emulator.RequestContext{
+		RequestID: "req-unknown-action",
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		Metadata:  make(map[string]interface{}),
+	}
+}
+
+// TestUnknownAction_AnswerComesFromTheProtocol pins the code, status and message for
+// one service per protocol arm.
+//
+// The two JSON families answer UnknownOperationException at 404, which is what AWS's
+// Common Errors pages publish — checked on DynamoDB's (JSON-RPC) and Lambda's
+// (REST-JSON), which agree on both. The Query, "ec2" and REST-XML families answer
+// InvalidAction at 400, which AWS no longer publishes anywhere: the InvalidAction
+// entry has been removed from EC2's, IAM's and SNS's Common Errors pages, and no
+// replacement was put in its place. Substrate keeps it because it is the code the
+// Query protocol has always used and an SDK caller's error branch is written against
+// it, so that row is substrate's choice rather than a citation.
+//
+// The message wording is substrate's in both arms — AWS publishes a description, not
+// a wire message — but naming the action is the point of it, so each row asserts the
+// name reaches the caller.
+func TestUnknownAction_AnswerComesFromTheProtocol(t *testing.T) {
+	registry, reqCtx := unknownActionRegistry(t)
+
+	tests := []struct {
+		name       string
+		service    string
+		protocol   string
+		wantCode   string
+		wantStatus int
+		// wantMessage is the whole message, so a change to the wording is visible here
+		// rather than only in whatever a consumer happens to match on.
+		wantMessage string
+	}{
+		{
+			name: "ec2 is its own protocol", service: "ec2", protocol: "ec2",
+			wantCode: "InvalidAction", wantStatus: http.StatusBadRequest,
+			wantMessage: "The action SubstrateNoSuchOperation is not valid for this endpoint.",
+		},
+		{
+			name: "sns is query", service: "sns", protocol: "query",
+			wantCode: "InvalidAction", wantStatus: http.StatusBadRequest,
+			wantMessage: "The action SubstrateNoSuchOperation is not valid for this endpoint.",
+		},
+		{
+			name: "cloudformation is query", service: "cloudformation", protocol: "query",
+			wantCode: "InvalidAction", wantStatus: http.StatusBadRequest,
+			wantMessage: "The action SubstrateNoSuchOperation is not valid for this endpoint.",
+		},
+		{
+			// Route 53 is REST-XML and resolves by verb and path, so it exercises both the
+			// XML arm and the route form of the message in one row.
+			name: "route53 is rest-xml and routes by path", service: "route53", protocol: "rest-xml",
+			wantCode: "InvalidAction", wantStatus: http.StatusBadRequest,
+			wantMessage: "The action POST /substrate-no-such-path is not valid for this endpoint.",
+		},
+		{
+			name: "dynamodb is json", service: "dynamodb", protocol: "json",
+			wantCode: "UnknownOperationException", wantStatus: http.StatusNotFound,
+			wantMessage: "The action SubstrateNoSuchOperation is not recognized.",
+		},
+		{
+			name: "ssm is json", service: "ssm", protocol: "json",
+			wantCode: "UnknownOperationException", wantStatus: http.StatusNotFound,
+			wantMessage: "The action SubstrateNoSuchOperation is not recognized.",
+		},
+		{
+			name: "lambda is rest-json and routes by path", service: "lambda", protocol: "rest-json",
+			wantCode: "UnknownOperationException", wantStatus: http.StatusNotFound,
+			wantMessage: "The action POST /substrate-no-such-path is not recognized.",
+		},
+		{
+			name: "account is rest-json and routes by path", service: "account", protocol: "rest-json",
+			wantCode: "UnknownOperationException", wantStatus: http.StatusNotFound,
+			wantMessage: "The action POST /substrate-no-such-path is not recognized.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := registry.RouteRequest(reqCtx, unknownActionRequest(tt.service))
+			require.Nil(t, resp, "a refusal carries no response")
+			var awsErr *emulator.AWSError
+			require.ErrorAs(t, err, &awsErr)
+			assert.Equal(t, tt.wantCode, awsErr.Code, "%s is %s", tt.service, tt.protocol)
+			assert.Equal(t, tt.wantStatus, awsErr.HTTPStatus, "%s is %s", tt.service, tt.protocol)
+			assert.Equal(t, tt.wantMessage, awsErr.Message)
+		})
+	}
+}
+
+// TestUnknownAction_IAMKeepsItsResponseShape pins the one plugin that answers a
+// refusal as a 4xx *AWSResponse with a nil error rather than as an *AWSError.
+//
+// Both conventions are in use across the tree and #516 turns on that, so #716 changed
+// only where IAM's code, message and status come from — not the shape it returns them
+// in. Without this case the sweep below would read IAM's answer as a success and
+// assert nothing about it.
+func TestUnknownAction_IAMKeepsItsResponseShape(t *testing.T) {
+	registry, reqCtx := unknownActionRegistry(t)
+
+	resp, err := registry.RouteRequest(reqCtx, unknownActionRequest("iam"))
+	require.NoError(t, err, "IAM answers a refusal as a response, not an error")
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "IAM is a query service")
+	body := string(resp.Body)
+	assert.Contains(t, body, "InvalidAction", "body: %s", body)
+	assert.Contains(t, body, "SubstrateNoSuchOperation", "body: %s", body)
+}
+
+// TestUnknownAction_NoServiceNamesAGoType is the tripwire, and it runs over every
+// registered plugin.
+//
+// "Plugin" is the substring to look for because every plugin's Go type is named for
+// it — SSMPlugin, EC2Plugin, S3Plugin — and all eight of the old wordings put that
+// type at the front of the message. No AWS error message contains the word, so a hit
+// here means a refusal is leaking a substrate internal again.
+//
+// A plugin that answers something other than a refusal is not a failure of this test:
+// a few resolve a bogus path to a real operation and answer a normal error for it, and
+// S3 reads any unrecognized path as a bucket request. What matters is that whatever
+// they answer, no consumer reads a Go type out of it.
+func TestUnknownAction_NoServiceNamesAGoType(t *testing.T) {
+	registry, reqCtx := unknownActionRegistry(t)
+
+	names := registry.Names()
+	require.Greater(t, len(names), 50, "the sweep is only meaningful over the whole plugin set")
+
+	for _, service := range names {
+		t.Run(service, func(t *testing.T) {
+			resp, err := registry.RouteRequest(reqCtx, unknownActionRequest(service))
+
+			if err != nil {
+				assert.NotContains(t, err.Error(), "Plugin",
+					"%s names a Go type in its refusal", service)
+				var awsErr *emulator.AWSError
+				if assert.ErrorAs(t, err, &awsErr) {
+					assert.NotEmpty(t, awsErr.Code, "%s refuses with an empty code", service)
+				}
+			}
+			if resp != nil {
+				assert.NotContains(t, string(resp.Body), "Plugin",
+					"%s names a Go type in its response body", service)
+			}
+		})
+	}
+}
+
+// TestUnknownAction_BlankActionIsNamed pins the normalization for a dispatcher that
+// reached its default arm with no operation name at all.
+//
+// This is reachable rather than theoretical: a JSON-RPC service dispatches on an
+// X-Amz-Target header a caller can simply omit, and a REST plugin's path resolver
+// answers "" for a path it does not recognize. Without the guard the message read
+// "The action  is not recognized." — two spaces where the name belongs, which tells a
+// consumer nothing.
+func TestUnknownAction_BlankActionIsNamed(t *testing.T) {
+	registry, reqCtx := unknownActionRegistry(t)
+
+	req := unknownActionRequest("dynamodb")
+	req.Operation = ""
+	req.Params = map[string]string{}
+
+	_, err := registry.RouteRequest(reqCtx, req)
+	var awsErr *emulator.AWSError
+	require.ErrorAs(t, err, &awsErr)
+	assert.Equal(t, "The action (empty) is not recognized.", awsErr.Message)
+	assert.NotContains(t, awsErr.Message, "  ", "a blank name leaves no doubled space")
+	assert.False(t, strings.Contains(awsErr.Message, "action  is"),
+		"the name is normalized rather than omitted")
+}

--- a/emulator/wafv2_plugin.go
+++ b/emulator/wafv2_plugin.go
@@ -68,11 +68,7 @@ func (p *WAFv2Plugin) HandleRequest(reqCtx *RequestContext, req *AWSRequest) (*A
 	case "ListIPSets":
 		return p.listIPSets(reqCtx, req)
 	default:
-		return nil, &AWSError{
-			Code:       "InvalidAction",
-			Message:    "WAFv2Plugin: unsupported operation " + req.Operation,
-			HTTPStatus: http.StatusBadRequest,
-		}
+		return nil, unknownActionError(p.Name(), req.Operation)
 	}
 }
 

--- a/emulator/wafv2_plugin_test.go
+++ b/emulator/wafv2_plugin_test.go
@@ -559,6 +559,9 @@ func TestWAFv2Plugin_DisassociateWebACL(t *testing.T) {
 	}
 }
 
+// TestWAFv2Plugin_UnsupportedOperation pins the default arm. WAFv2 is JSON-RPC, so
+// the refusal is AWS's documented UnknownOperationException at 404, not the Query
+// protocol's InvalidAction at 400 (#716).
 func TestWAFv2Plugin_UnsupportedOperation(t *testing.T) {
 	p, ctx := setupWAFv2Plugin(t)
 	_, err := p.HandleRequest(ctx, wafv2Request(t, "TagResource", map[string]any{}))
@@ -569,7 +572,10 @@ func TestWAFv2Plugin_UnsupportedOperation(t *testing.T) {
 	if !ok {
 		t.Fatalf("want *AWSError, got %T", err)
 	}
-	if awsErr.Code != "InvalidAction" {
-		t.Errorf("want InvalidAction, got %q", awsErr.Code)
+	if awsErr.Code != "UnknownOperationException" {
+		t.Errorf("want UnknownOperationException, got %q", awsErr.Code)
+	}
+	if awsErr.HTTPStatus != http.StatusNotFound {
+		t.Errorf("HTTPStatus = %d, want 404", awsErr.HTTPStatus)
 	}
 }

--- a/test/e2e/journey_config_test.go
+++ b/test/e2e/journey_config_test.go
@@ -40,7 +40,8 @@ func TestJourney_ConfigDetectiveControls(t *testing.T) {
 		o.UsePathStyle = true
 	})
 
-	// --- reachability. If this answers InvalidAction, nothing below matters. ---
+	// --- reachability. If this answers UnknownOperationException — Config is JSON, so
+	// that is its unknown-action refusal (#716) — nothing below matters. ---
 	recorders, err := cs.DescribeConfigurationRecorders(ctx,
 		&configservice.DescribeConfigurationRecordersInput{})
 	if err != nil {


### PR DESCRIPTION
Every plugin has an unknown-action arm — none covers its whole service. All 59 of them wrote the refusal by hand, in **eight different wordings**, each leading with the plugin's own Go type:

```
SSMPlugin: unknown operation "Foo"
```

No AWS endpoint emits a Go type name, so a consumer's error branch was matching on a substrate implementation detail, and a caller could not tell *substrate has not implemented this* from any other refusal. They now all route through `unknownActionError` — or `unknownRouteError` for a REST plugin whose router matched nothing — so the answer is a property of the **service's protocol** rather than of whoever wrote the plugin.

## The premise was wrong, and the real defect is bigger

#716 asks for convergence on `InvalidAction` and says the wording can be verified against the reference. Going to AWS's pages, as `CLAUDE.md` requires, refutes both halves:

- **`InvalidAction` has been removed from every current AWS Common Errors page.** Checked on EC2's, IAM's, SNS's, DynamoDB's and Lambda's. Nothing was put in its place for the Query, `ec2` and REST/XML families.
- **What AWS publishes for an unrecognized operation is `UnknownOperationException` at HTTP 404**: "The action or operation isn't recognized. Verify that the action name is spelled correctly and that it's supported by the API version you're using." It appears on both a JSON-RPC page (DynamoDB) and a REST-JSON one (Lambda), which agree on the code *and* the status.

Cross-tabulating the 59 sites against `serviceErrorProtocols` — which takes each service's protocol from its botocore `service-2.json` — showed **44 of them answering the Query protocol's code, at the wrong status, on a service whose protocol is JSON.** That is a worse defect for a consumer than the leaked type name the issue reported.

## The answer now

| Protocol | Code | HTTP |
|---|---|---|
| JSON, REST/JSON (44 services) | `UnknownOperationException` | **404** |
| Query, `ec2`, REST/XML (9 services) | `InvalidAction` | 400 |

The second row is **substrate's choice, not a citation**, and says so in the code, the changelog and the docs: it is kept because it is the code the Query protocol has always used and an SDK caller's error branch is written against it, and because the reference offers no replacement to move to.

The message names the operation in both arms — that is the point of it. A REST plugin reports the verb *and* the path (`The action POST /2015-03-31/functions/f/no-such-subresource is not recognized.`), because a REST operation is identified by the pair: `DELETE` and `POST` on one path are different operations, and the same verb on a mistyped path is the more common mistake.

## Three wrong codes ride along

- **DynamoDB** had the right code at HTTP **400**, where its own Common Errors page publishes 404.
- **Secrets Manager** used `UnrecognizedClientException`, which AWS defines as a *credentials* error ("The X.509 certificate or AWS access key ID you provided doesn't exist in our records") — sending a consumer to debug request signing for a call substrate simply does not serve.
- **Price List** used `InvalidParameterException`, the code for a bad parameter rather than a bad operation.

## Deliberate exceptions

- **IAM keeps its shape.** It answers a refusal as a 4xx `*AWSResponse` with a nil error rather than an `*AWSError`; both conventions are in use across the tree and #516 turns on that, so only IAM's code, message and status moved.
- **`AccountPlugin`, `RAMPlugin`, `SchedulerPlugin` take the route form.** Their path resolvers hand the default arm `""` (account, scheduler) or a bare HTTP verb (RAM), not an operation name — a naive sweep would have emitted `The action  is not recognized.` A blank name is now normalized to `(empty)` in one place, and pinned.
- `cfgsvcInvalidAction` and `orgInvalidAction` are retired, their reasoning moved to the call site.

## Tests

`emulator/unknown_action_test.go` (new):

- a table asserting the exact code, status and **whole message** for one service per protocol arm — `ec2`, `sns`, `cloudformation`, `route53`, `dynamodb`, `ssm`, `lambda`, `account`;
- IAM's response-shaped refusal, so the sweep does not read it as a success;
- **the tripwire: all 67 registered plugins, asserting no answer contains the word `Plugin`.** It runs off `PluginRegistry.Names()`, so a new plugin joins it for free. Mutation-tested — reintroducing the old `SSMPlugin: unknown operation` literal turns it red on the `ssm` subtest;
- the blank-action normalization.

15 existing expectations were pinning the old answer on a JSON-protocol service. Every one is updated with a comment naming #716 and the protocol it now follows. (The plan's "nothing pins any string" was wrong — the codes and statuses were pinned in 15 places.)

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint run ./...` → **0 issues**. `make test` (race) green; `make coverage` **82.4% total, 83.1% emulator**. `make docs-reference docs-reference-check docs-versions` green — `check-doc-versions.sh` caught a pinned version in my first draft of the docs prose, which is what it exists for. `npm --prefix docs run build` green, with the `href="#…"` vs `id="…"` diff over `dist/services.html` showing no broken anchors. `go vet`/`go test` in `test/e2e` green.

**Live SDK run** against a built binary (`AWS_MAX_ATTEMPTS=1`, torn down with `lsof -ti:4678 | xargs kill`):

```
ssm get-inventory            → UnknownOperationException: The action GetInventory is not recognized.
secretsmanager …             → UnknownOperationException: The action GetRandomPassword is not recognized.
pricing …                    → UnknownOperationException: The action GetPriceListFileUrl is not recognized.
organizations …              → UnknownOperationException: The action LeaveOrganization is not recognized.
account put-alternate-contact→ UnknownOperationException: The action POST /putAlternateContact is not recognized.
lambda, unrouted path        → HTTP 404, x-amzn-errortype: UnknownOperationException
ec2 DescribeCarrierGateways  → HTTP 400, <Code>InvalidAction</Code>
sns opt-in-phone-number      → InvalidAction: The action OptInPhoneNumber is not valid for this endpoint.
iam create-saml-provider     → InvalidAction, in IAM's <ErrorResponse> document
```

plus a live sweep of all 67 services: **0 leaked a Go type name.**

## Compatibility

**44 services change both the code and the HTTP status for an unimplemented operation.** A test asserting `InvalidAction` or a 400 on a JSON or REST/JSON service needs both values updated to `UnknownOperationException` / 404. The nine Query, `ec2` and REST/XML services are unchanged. `docs/services.md` gains a cross-service section, [An operation substrate does not implement](https://github.com/scttfrdmn/substrate/blob/fix/716-unknown-action-protocol/docs/services.md#an-operation-substrate-does-not-implement), stating the rule, its provenance, and this upgrade note.

Closes #716