### PR TITLE
feat(ec2): CreateTags reaches every taggable resource type (#708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`CreateTags` and `DeleteTags` reach every taggable EC2 resource type** (#708). Five ID
+  prefixes were **silently ignored**: a request naming an `ami-`, `lt-`, `fleet-`, `pg-` or
+  `key-` ID answered `<return>true</return>` and wrote nothing. Each was well-formed and named
+  a resource substrate stores, so there was no way for a caller to tell — the answer is
+  identical to the one a successful call gives. `ec2TaggableResource` now resolves fifteen
+  prefixes, and `ec2TagScanTargets` reports the same fifteen, so `DescribeTags` and
+  `CreateTags` cover exactly the same set. They did not: three types could be read and not
+  written, and `placement-group` and `key-pair` could be neither.
+
+  **A launch template's own tags were settable by no path at all.** The `TagSpecification`
+  `CreateLaunchTemplate` read lives inside `LaunchTemplateData` and is AWS's "tags for the
+  resources that are created when an instance is launched" — a different parameter from the
+  top-level `TagSpecification.N`, "the tags to apply to the launch template on creation. To
+  tag the launch template, the resource type must be `launch-template`". Both are now read,
+  each on its own scope.
+
+  Also new: `EC2KeyPair` gained a `Tags` field (it had none), `CreateKeyPair`, `ImportKeyPair`
+  and `CreatePlacementGroup` honour `TagSpecification.N` and echo the result, and
+  `DescribeKeyPairs`/`DescribePlacementGroups` render `tagSet`.
+
+  Provenance: `InvalidID`'s code and description are AWS's, but from the EC2 client-error
+  table — `API_CreateTags.html` publishes no operation-specific error at all. Naming the
+  offending ID where AWS writes "The specified ID" is substrate's. Whether real `CreateTags`
+  takes a placement group **by ID or by name is not settled by AWS**: the ARN is by name and
+  `DescribePlacementGroups` publishes no `group-id` filter, but the client-error table
+  publishes `InvalidPlacementGroupId.Malformed` "in the form `pg-xxxxxxxxxxxxxxxxx`", which
+  only an ID-taking operation can raise. Substrate accepts the `pg-` form and translates.
+
 - **EC2's documented filter limits, enforced in one place** (#697). Using_Filtering publishes
   three: "You can specify up to 50 filters and up to 200 total filter values in a single
   request" and "Filter strings can be up to 255 characters in length." All three are now
@@ -25,6 +53,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot be used."
 
 ### Changed
+- **A tagging ID whose prefix names no taggable type is refused, not ignored** (#708).
+  `CreateTags`/`DeleteTags` answer `InvalidID` / HTTP 400 — "The ID '<id>' for the resource you
+  are trying to tag is not valid. Ensure that you provide the full resource ID; for example,
+  ami-2bb65342 for an AMI." The check runs over every `ResourceId.N` **before the first tag is
+  applied**, so a request naming a good ID first and a bad one second tags neither; refusing
+  inside the apply loop would leave a partially-tagged state real EC2 never produces. A
+  well-formed prefix naming *nothing* stays a no-op at HTTP 200 and is still not counted
+  against the 50-tag limit.
+
+- **Seven responses omit `tagSet` for an untagged resource** instead of rendering
+  `<tagSet></tagSet>` (#708): `CreateKeyPair`, `ImportKeyPair`, `DescribeKeyPairs`,
+  `CreatePlacementGroup`, `DescribePlacementGroups`, `CreateLaunchTemplate` and
+  `DescribeLaunchTemplates`. A wire change, and AWS's own examples are the reason —
+  `CreateLaunchTemplate`'s Example 1 and `CreatePlacementGroup`'s Example 2 each create an
+  untagged resource and neither response carries a `tagSet`, while `CreateKeyPair`'s tagged
+  example does. An SDK tells an absent list from an empty one. `xml:"tagSet>item,omitempty"`
+  cannot express the absence — encoding/xml writes the parent element of a nested path even
+  for a nil slice — so the four renderers converged on the pointer-to-wrapper shape #685 had
+  already written for `DescribeSubnets`, now shared as `ec2TagSetXML`. `DescribeFleets` keeps
+  the old shape deliberately: its reference page publishes no example response, so there is no
+  untagged sample to follow and changing it would be a guess. `DescribeSnapshots` keeps its
+  present-but-empty element because its own page shows it.
+
 - **Eighteen mutating EC2 operations answer their `Invalid*.NotFound` from the kind table, not
   from a hand-written literal** (#713). `ec2_resourceid.go`'s `ec2IDKind` table has been the
   single source of an ID family's prefix rule, `NotFound` code, `Malformed` code and message
@@ -126,6 +177,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a description of the condition, never a wire message.
 
 ### Fixed
+- **An `ami-` ID is authorized against the account-less ARN AWS documents** (#708).
+  `arn:${Partition}:ec2:${Region}::image/${ImageId}` has a deliberately empty account field,
+  as does a snapshot's, where the other thirteen taggable types carry `${Account}`. The
+  authorizer stamped the account on unconditionally, which makes an ARN-scoped `Deny` naming an
+  AMI inert and stops a least-privilege `Allow` from granting the call — the same
+  two-directional failure #674 fixed for tagging as a whole. #689's `snap-` arm shipped with
+  this defect and is fixed in the same pass; `ec2TaggableResource`'s own doc comment had
+  asserted no type here was account-less while `snapshot` already was.
+
 - **Three plugins answered a wrong code for an unimplemented operation** (#716), all corrected
   by routing through the shared refusal. DynamoDB returned `UnknownOperationException` — the
   right code — at HTTP **400**, where AWS's own DynamoDB Common Errors page publishes 404.

--- a/docs/services.md
+++ b/docs/services.md
@@ -2787,7 +2787,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids); ten filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); `Owner.N` and `RestorableBy.N` — see [A snapshot filters on its own members](#a-snapshot-filters-on-its-own-members-and-scopes-by-account) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
-| CreateLaunchTemplate | Creates version 1. Networking is read from every `NetworkInterface.N.*` — see [Launch template networking](#launch-template-networking) |
+| CreateLaunchTemplate | Creates version 1. Networking is read from every `NetworkInterface.N.*` — see [Launch template networking](#launch-template-networking). The top-level `TagSpecification.N` scoped to `launch-template` tags the template itself, separately from `LaunchTemplateData`'s, which tags what a launch creates |
 | DescribeLaunchTemplates | Summary only — no `launchTemplateData`, matching AWS. Use `DescribeLaunchTemplateVersions` to read a template's parameters |
 | DeleteLaunchTemplate | |
 | CreateLaunchTemplateVersion | `SourceVersion` inheritance — see [Launch template versions](#launch-template-versions) |
@@ -2797,9 +2797,9 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS; [filter names are checked](#one-rule-for-an-unrecognized-filter-name), and it documents **no tag filter** |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances, [subject to termination protection](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
-| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); accepts a `vol-` or `snap-` ID like [any other taggable ID](#a-volume-carries-tags); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
-| DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) and [over-long keys](#tag-key-and-value-length-limits); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
-| DescribeTags | Every tag in the region, across thirteen resource types. Five filters with **wildcards**, `MaxResults` 5–1000 and `NextToken`, and a deterministic order — see [Finding a resource by tag](#finding-a-resource-by-tag) |
+| CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); reaches [all fifteen taggable ID prefixes](#every-taggable-id-prefix-is-reachable) and refuses anything else with `InvalidID`; [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
+| DeleteTags | Rejects [reserved `aws:` keys](#reserved-tag-keys) and [over-long keys](#tag-key-and-value-length-limits); resolves [the same fifteen prefixes](#every-taggable-id-prefix-is-reachable); [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
+| DescribeTags | Every tag in the region, across [the same fifteen resource types `CreateTags` writes](#every-taggable-id-prefix-is-reachable). Five filters with **wildcards**, `MaxResults` 5–1000 and `NextToken`, and a deterministic order — see [Finding a resource by tag](#finding-a-resource-by-tag) |
 
 ### One rule for an unrecognized filter name
 
@@ -4623,6 +4623,92 @@ The rest of the `CreateSnapshot` family — `CreateSnapshots`, `CopySnapshot`,
 `ModifySnapshotAttribute`, `DescribeSnapshotAttribute` and `ResetSnapshotAttribute` — is
 still absent and answers `InvalidAction`.
 
+#### Every taggable ID prefix is reachable
+
+`CreateTags` resolved ten ID prefixes and **silently ignored the rest**: a request naming an
+`ami-`, `lt-`, `fleet-`, `pg-` or `key-` ID answered `<return>true</return>` and wrote
+nothing. Every one of the five was well-formed and named a resource substrate stores, so
+there was no way for a caller to tell — the answer a consumer's tag-everything step reads is
+the same answer it gets when the tags land.
+
+Fifteen prefixes now resolve, on `CreateTags` and `DeleteTags` alike:
+
+| Prefix | Resource type | Prefix | Resource type |
+|---|---|---|---|
+| `i-` | `instance` | `snap-` | `snapshot` |
+| `vpc-` | `vpc` | `ami-` | `image` |
+| `subnet-` | `subnet` | `lt-` | `launch-template` |
+| `sg-` | `security-group` | `fleet-` | `fleet` |
+| `igw-` | `internet-gateway` | `pg-` | `placement-group` |
+| `rtb-` | `route-table` | `key-` | `key-pair` |
+| `eipalloc-` | `elastic-ip` | `vol-` | `volume` |
+| `nat-` | `natgateway` | | |
+
+**A prefix naming no taggable type is now refused** rather than ignored, before anything is
+written:
+
+```
+InvalidID: The ID 'tgw-0abc11112222333d' for the resource you are trying to tag is not
+valid. Ensure that you provide the full resource ID; for example, ami-2bb65342 for an AMI.
+```
+
+The status is `400`, and the check runs over every `ResourceId.N` before the first tag is
+applied — so a request naming a good instance ID first and a bad ID second tags neither, the
+same all-or-nothing rule [the reserved-key check](#reserved-tag-keys) follows.
+
+A **well-formed prefix naming nothing** stays a no-op at HTTP 200, and is not counted against
+the [50-tag limit](#the-50-tag-per-resource-limit): there is nothing to apply the tags to, so
+refusing would reject a request real EC2 accepts.
+
+Two of the fifteen are keyed by **name** rather than by ID in substrate's state, and by name
+in AWS's ARN as well — `arn:aws:ec2:${Region}:${Account}:placement-group/${PlacementGroupName}`
+and `…:key-pair/${KeyPairName}`. `CreateTags` takes the `pg-`/`key-` form and translates by
+scanning the namespace for the ID inside each record; `DescribeTags` reports the `resourceId`
+member the record carries, not the name its key ends in, so what comes back is what a caller
+can pass in again.
+
+Whether real `CreateTags` takes a placement group by ID or by name **is not settled by AWS's
+documentation**: the ARN is by name and `DescribePlacementGroups` publishes no `group-id`
+filter, but the client-error table publishes `InvalidPlacementGroupId.Malformed` "in the form
+`pg-xxxxxxxxxxxxxxxxx`", which only an ID-taking operation can raise. Substrate accepts the
+`pg-` form.
+
+Three things had to change alongside the resolution:
+
+- **A launch template's own tags were settable by no path at all.** The `TagSpecification` in
+  `CreateLaunchTemplate`'s `LaunchTemplateData` is scoped to the resources a *launch* creates
+  — "for the resources that are created when an instance is launched" — which is a different
+  parameter from the top-level `TagSpecification.N`, "the tags to apply to the launch
+  template on creation. To tag the launch template, the resource type must be
+  `launch-template`". Substrate read only the inner one. It now reads both, each on its own
+  scope.
+- **`CreateKeyPair`, `ImportKeyPair` and `CreatePlacementGroup` honour `TagSpecification.N`**
+  and echo the result, and `DescribeKeyPairs`/`DescribePlacementGroups` render `tagSet`.
+  `EC2KeyPair` had no tags field to write to.
+- **An `image` and a `snapshot` ARN have an empty account field** —
+  `arn:${Partition}:ec2:${Region}::image/${ImageId}` — where the other thirteen carry
+  `${Account}`. The authorizer stamped the account on unconditionally, which makes an
+  ARN-scoped `Deny` naming an AMI inert and a least-privilege `Allow` unable to grant the
+  call. The `snap-` arm shipped with that defect in
+  [#689](https://github.com/scttfrdmn/substrate/issues/689) and is fixed here too.
+
+##### An untagged resource omits `tagSet`
+
+Seven renderers previously answered `<tagSet></tagSet>` for a resource with no tags and now
+omit the element: `CreateKeyPair`, `ImportKeyPair`, `DescribeKeyPairs`,
+`CreatePlacementGroup`, `DescribePlacementGroups`, `CreateLaunchTemplate` and
+`DescribeLaunchTemplates`. This is a **wire change**, and it follows AWS's own examples —
+`CreateLaunchTemplate`'s Example 1 and `CreatePlacementGroup`'s Example 2 each create an
+untagged resource and neither response carries a `tagSet` at all, while `CreateKeyPair`'s
+tagged example does. An SDK distinguishes an absent list from an empty one, which is the same
+distinction `DescribeTags` keeps `<value/>` present-but-empty for.
+
+`DescribeFleets` is the one place the old shape stays. Its API reference page publishes **no
+example response**, so there is no untagged sample to follow and changing it would be
+substrate guessing rather than substrate reading. `DescribeSnapshots` keeps its
+present-but-empty element for the opposite reason: its own page shows it. Each response
+answers to the page that documents it.
+
 #### Finding a resource by tag
 
 `DescribeTags` — the operation whose whole job is this question — did not exist until
@@ -4637,16 +4723,12 @@ It reports every tag stored in the request's account and region. Every EC2 recor
 `<namespace>:<account>/<region>/<id>`, so the scan is regional by construction, which is also
 real EC2's scope for this operation.
 
-**The scan is deliberately wider than what `CreateTags` can write.** `CreateTags` reaches
-ten resource types; `DescribeTags` reads thirteen, adding `image`, `launch-template` and
-`fleet` — types whose tags arrive through their own create call's `TagSpecification.N` and
-cannot be set through `CreateTags` at all
-([#695](https://github.com/scttfrdmn/substrate/issues/695) is the remaining three;
-`snapshot` was in this list until [#689](https://github.com/scttfrdmn/substrate/issues/689)
-gave `CreateTags` a `snap-` arm). Reporting only the
-writable types would hide tags a caller had successfully applied. `placement-group` is the one
-type carrying a `Tags` field that stays out: nothing writes it, and its records are keyed by
-group *name* where AWS's `TagDescription` reports an ID.
+**The scan and what `CreateTags` can write are now the same fifteen types.** They were not:
+`DescribeTags` read thirteen and `CreateTags` reached ten, so an `image`, `launch-template`
+or `fleet` tag could be *reported* and not *changed*, while a `placement-group` or `key-pair`
+tag could be neither — both were absent from the scan as well. See
+[every taggable ID prefix is reachable](#every-taggable-id-prefix-is-reachable) for the
+prefixes and for what a request naming something else now answers.
 
 | Behaviour | Answer |
 |---|---|

--- a/emulator/ec2_authz.go
+++ b/emulator/ec2_authz.go
@@ -125,7 +125,7 @@ func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, r
 	// An interface the launch creates has no ID yet, so it is the wildcard; one the
 	// request brings by ID is named, because a policy can meaningfully scope to it.
 	// Neither carries tags: substrate stores no standalone taggable ENI record, and
-	// ec2TaggableStateKey has no eni- arm to read one through.
+	// ec2TaggableResource has no eni- arm to read one through.
 	//
 	// This is the resource AWS's own subnet guardrail is written against, so it is
 	// where ec2:Subnet and ec2:Vpc go — both of them, on every interface the launch
@@ -182,9 +182,15 @@ func ec2AuthzRunInstancesResources(state StateManager, reqCtx *RequestContext, r
 // [ec2AuthzRunInstancesResources]' rule for a resource the request does not name,
 // and it is the ID's own handler that owes the answer: AWS documents an
 // unparseable tagging ID as InvalidID — "The specified ID for the resource you are
-// trying to tag is not valid" — not AccessDenied, and substrate's handler treats
-// it as a no-op. A request naming only such IDs returns nil and is decided exactly
-// as it was before.
+// trying to tag is not valid" — not AccessDenied, and substrate's handler answers
+// exactly that (#708). A request naming only such IDs returns nil and is refused by
+// the handler rather than by the policy.
+//
+// A well-formed pg- or key- ID that resolves to no record is skipped for a different
+// reason: AWS's ARN for a placement group and a key pair is by *name*, so with no
+// record there is no name to build one from. Inventing an ID-form ARN would decide the
+// call against a string AWS never emits; the handler treats an absent resource as a
+// no-op regardless, so nothing is authorized away.
 func ec2AuthzTagResources(state StateManager, reqCtx *RequestContext, req *AWSRequest) []authzResource {
 	if req.Operation != "CreateTags" && req.Operation != "DeleteTags" {
 		return nil
@@ -193,15 +199,15 @@ func ec2AuthzTagResources(state StateManager, reqCtx *RequestContext, req *AWSRe
 	region := reqCtx.Region
 	var out []authzResource
 	for _, id := range extractIndexedParams(req.Params, "ResourceId") {
-		stateKey, arnType, ok := ec2TaggableResource(reqCtx, id)
-		if !ok {
+		target, ok := ec2TaggableResource(state, reqCtx, id)
+		if !ok || !target.resolved() {
 			continue
 		}
 		out = append(out, authzResource{
-			ARN: "arn:aws:ec2:" + region + ":" + acct + ":" + arnType + "/" + id,
+			ARN: target.arn(region, acct),
 			// The same state key the handler will read and write, so the tags a
 			// condition is evaluated against are the ones the call is about to change.
-			Tags: ec2AuthzTagsFor(state, stateKey),
+			Tags: ec2AuthzTagsFor(state, target.stateKey),
 		})
 	}
 	return out

--- a/emulator/ec2_describetags.go
+++ b/emulator/ec2_describetags.go
@@ -35,12 +35,14 @@ func ec2StatePrefix(namespace, accountID, region string) string {
 	return namespace + ":" + accountID + "/" + region + "/"
 }
 
-// ec2TagResourceID returns the resource ID at the end of an EC2 state key.
+// ec2StateKeyTail returns the last path segment of an EC2 state key.
 //
-// Every namespace in [ec2TagScanTargets] keys its records by the resource's own ID in the
-// last path segment, so the tail is the ID a caller would pass to CreateTags — and the one
-// AWS's TagDescription reports.
-func ec2TagResourceID(key string) string {
+// For thirteen of the fifteen namespaces in [ec2TagScanTargets] that segment is the
+// resource's own ID, which is both what a caller passes to CreateTags and what AWS's
+// TagDescription reports. For the other two it is the resource's *name* — a placement group
+// and a key pair are keyed by name — which is why [ec2TagScanTarget.idMember] exists and why
+// this function is named for what it returns rather than for what it usually means.
+func ec2StateKeyTail(key string) string {
 	if i := strings.LastIndex(key, "/"); i >= 0 {
 		return key[i+1:]
 	}
@@ -59,39 +61,43 @@ type ec2TagScanTarget struct {
 	namespace string
 	// resourceType is AWS's TagSpecification spelling of the resource type.
 	resourceType string
+	// idMember is the record's JSON member holding the resource's ID, for a namespace
+	// keyed by name rather than by ID. Empty when [ec2StateKeyTail] is already the ID.
+	//
+	// AWS's TagDescription reports resourceId, so a name-keyed namespace has to read the
+	// ID out of the record: reporting the tail would name a placement group by its group
+	// name, which is not an ID a caller can pass back to CreateTags.
+	idMember string
 }
 
 // ec2TagScanTargets is every resource type DescribeTags reads tags from.
 //
-// This list is deliberately **wider** than [ec2TaggableResource]'s nine prefixes, which is
-// what CreateTags can write through. DescribeTags' job is to report every tag substrate
-// stores, however it was applied: an AMI, snapshot, launch template or fleet takes its tags
-// from its own create call's TagSpecification and cannot be tagged through CreateTags at
-// all (#689 adds the snapshot arm; the rest are #695's follow-up), so reporting only the
-// CreateTags-writable types would hide tags a caller had successfully applied.
-//
-// EC2PlacementGroup also carries a Tags field and is deliberately absent: no path writes
-// it, and its records are keyed by group *name* where AWS's TagDescription reports a
-// placement group's ID, so [ec2TagResourceID] would report the wrong identifier. It joins
-// the scan when something can tag a placement group.
+// The list is no longer wider than [ec2TaggableResource]'s prefixes: #708 closed the gap,
+// so every type here can also be tagged through CreateTags and every type CreateTags
+// accepts is reported here. Keeping the two aligned is the point — until #708 an AMI,
+// launch template, fleet, placement group or key pair could hold tags from its own create
+// call's TagSpecification that CreateTags had no way to change, and a placement group or
+// key pair held tags DescribeTags had no way to report.
 //
 // Order is alphabetical by type, which only sets the scan order — the response is sorted
 // by [ec2SortTagDescriptions] regardless.
 func ec2TagScanTargets() []ec2TagScanTarget {
 	return []ec2TagScanTarget{
-		{"eip", "elastic-ip"},
-		{"fleet", "fleet"},
-		{"image", "image"},
-		{"instance", "instance"},
-		{"igw", "internet-gateway"},
-		{"lt", "launch-template"},
-		{"nat", "natgateway"},
-		{"rtb", "route-table"},
-		{"sg", "security-group"},
-		{"snapshot", "snapshot"},
-		{"subnet", "subnet"},
-		{"volume", "volume"},
-		{"vpc", "vpc"},
+		{namespace: "eip", resourceType: "elastic-ip"},
+		{namespace: "fleet", resourceType: "fleet"},
+		{namespace: "image", resourceType: "image"},
+		{namespace: "instance", resourceType: "instance"},
+		{namespace: "igw", resourceType: "internet-gateway"},
+		{namespace: "keypair", resourceType: "key-pair", idMember: "keyPairId"},
+		{namespace: "lt", resourceType: "launch-template"},
+		{namespace: "nat", resourceType: "natgateway"},
+		{namespace: "placement_group", resourceType: "placement-group", idMember: "group_id"},
+		{namespace: "rtb", resourceType: "route-table"},
+		{namespace: "sg", resourceType: "security-group"},
+		{namespace: "snapshot", resourceType: "snapshot"},
+		{namespace: "subnet", resourceType: "subnet"},
+		{namespace: "volume", resourceType: "volume"},
+		{namespace: "vpc", resourceType: "vpc"},
 	}
 }
 
@@ -182,10 +188,10 @@ func (p *EC2Plugin) describeTags(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 // scanTags reads every stored tag in the account and region, keeping the ones the filters
 // accept.
 //
-// Each record is decoded into an anonymous struct carrying only "tags", the type-agnostic
-// shape [EC2Plugin.applyTagsToResource] writes and [ec2AuthzTagsFor] reads, so a new
-// resource type joins the scan by being listed in [ec2TagScanTargets] and needs no decoder
-// of its own.
+// Each record is decoded into a member map, so a new resource type joins the scan by being
+// listed in [ec2TagScanTargets] and needs no decoder of its own: "tags" is the
+// type-agnostic shape [EC2Plugin.applyTagsToResource] writes and [ec2AuthzTagsFor] reads,
+// and a name-keyed type's ID member is named by the target rather than by a Go type.
 //
 // A record that cannot be read or decoded is skipped rather than failing the request: a
 // partial answer names the resources it could read, where an error names none of them, and
@@ -204,15 +210,26 @@ func (p *EC2Plugin) scanTags(ctx context.Context, reqCtx *RequestContext, filter
 			if getErr != nil || data == nil {
 				continue
 			}
-			var record struct {
-				Tags []EC2Tag `json:"tags"`
-			}
+			var record map[string]json.RawMessage
 			if json.Unmarshal(data, &record) != nil {
 				continue
 			}
-			for _, tag := range record.Tags {
+			var tags []EC2Tag
+			if raw, ok := record["tags"]; ok && json.Unmarshal(raw, &tags) != nil {
+				continue
+			}
+			resourceID := ec2StateKeyTail(key)
+			if target.idMember != "" {
+				// A record that carries no ID member is skipped rather than reported under
+				// its name: a TagDescription naming a resource by something that is not its
+				// resourceId is worse than an omission, because a caller cannot tell.
+				if json.Unmarshal(record[target.idMember], &resourceID) != nil {
+					continue
+				}
+			}
+			for _, tag := range tags {
 				item := ec2TagDescription{
-					ResourceID:   ec2TagResourceID(key),
+					ResourceID:   resourceID,
 					ResourceType: target.resourceType,
 					Key:          tag.Key,
 					Value:        tag.Value,

--- a/emulator/ec2_fleet.go
+++ b/emulator/ec2_fleet.go
@@ -812,17 +812,25 @@ func (p *EC2Plugin) describeFleets(reqCtx *RequestContext, req *AWSRequest) (*AW
 		DefaultTargetCapacityType string `xml:"defaultTargetCapacityType,omitempty"`
 	}
 	type fleetItem struct {
-		FleetID                     string             `xml:"fleetId"`
-		FleetState                  string             `xml:"fleetState"`
-		ActivityStatus              string             `xml:"activityStatus,omitempty"`
-		Type                        string             `xml:"type"`
-		CreateTime                  string             `xml:"createTime"`
-		FulfilledCapacity           int                `xml:"fulfilledCapacity"`
-		FulfilledOnDemandCapacity   int                `xml:"fulfilledOnDemandCapacity"`
-		TargetCapacitySpecification targetCapacityXML  `xml:"targetCapacitySpecification"`
-		ClientToken                 string             `xml:"clientToken,omitempty"`
-		Tags                        []ec2TagItem       `xml:"tagSet>item,omitempty"`
-		Errors                      []fleetDescribeErr `xml:"errorSet>item,omitempty"`
+		FleetID                     string            `xml:"fleetId"`
+		FleetState                  string            `xml:"fleetState"`
+		ActivityStatus              string            `xml:"activityStatus,omitempty"`
+		Type                        string            `xml:"type"`
+		CreateTime                  string            `xml:"createTime"`
+		FulfilledCapacity           int               `xml:"fulfilledCapacity"`
+		FulfilledOnDemandCapacity   int               `xml:"fulfilledOnDemandCapacity"`
+		TargetCapacitySpecification targetCapacityXML `xml:"targetCapacitySpecification"`
+		ClientToken                 string            `xml:"clientToken,omitempty"`
+		// An untagged fleet answers <tagSet></tagSet> here, where the seven renderers
+		// #708 converted answer with no tagSet at all. Not an oversight and not
+		// inconsistency for its own sake: API_DescribeFleets.html publishes no example
+		// response — the page has no Examples section — so there is no untagged sample to
+		// follow, where CreateLaunchTemplate's Example 1 and CreatePlacementGroup's
+		// Example 2 each show the element absent. Each response answers to the page that
+		// documents it, and this page documents nothing about the shape. Changing it would
+		// be substrate guessing rather than substrate reading. See [ec2TagSetXML].
+		Tags   []ec2TagItem       `xml:"tagSet>item,omitempty"`
+		Errors []fleetDescribeErr `xml:"errorSet>item,omitempty"`
 	}
 	type response struct {
 		XMLName xml.Name    `xml:"DescribeFleetsResponse"`

--- a/emulator/ec2_launchtemplate_versions.go
+++ b/emulator/ec2_launchtemplate_versions.go
@@ -377,7 +377,7 @@ func (p *EC2Plugin) putLaunchTemplate(goCtx context.Context, lt *EC2LaunchTempla
 	if err != nil {
 		return fmt.Errorf("putLaunchTemplate: marshal: %w", err)
 	}
-	key := "lt:" + lt.AccountID + "/" + lt.Region + "/" + lt.LaunchTemplateID
+	key := ec2LaunchTemplateStateKey(lt.AccountID, lt.Region, lt.LaunchTemplateID)
 	if err := p.state.Put(goCtx, ec2Namespace, key, ltJSON); err != nil {
 		return fmt.Errorf("putLaunchTemplate: put: %w", err)
 	}
@@ -721,7 +721,7 @@ func (p *EC2Plugin) describeVersionsAccountWide(goCtx context.Context, ctx *Requ
 
 	var items []ec2LTVersionItem
 	for _, id := range ids {
-		key := "lt:" + ctx.AccountID + "/" + ctx.Region + "/" + id
+		key := ec2LaunchTemplateStateKey(ctx.AccountID, ctx.Region, id)
 		data, err := p.state.Get(goCtx, ec2Namespace, key)
 		if err != nil || data == nil {
 			continue

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -2453,15 +2453,18 @@ func (p *EC2Plugin) rebootInstances(_ *RequestContext, _ *AWSRequest) (*AWSRespo
 // Keys using the reserved "aws:" prefix are rejected before anything is applied, so a
 // mixed request leaves every named resource untouched (#452); a key or value over its
 // length limit likewise (#490); and every resource named is checked against the
-// per-resource tag limit before any of them is modified (#469). All three checks run
-// over the whole request for the same reason: CreateTags accepts up to 1000 resource
-// IDs, and a rejection partway through the apply loop would leave a partially-tagged
-// state real EC2 never produces.
+// per-resource tag limit before any of them is modified (#469); and an ID naming no
+// taggable resource type at all (#708). All four checks run over the whole request for the
+// same reason: CreateTags accepts up to 1000 resource IDs, and a rejection partway through
+// the apply loop would leave a partially-tagged state real EC2 never produces.
 func (p *EC2Plugin) createTags(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	resourceIDs := extractIndexedParams(req.Params, "ResourceId")
 	tags := extractEC2Tags(req.Params)
 	if err := ec2CheckTagRules(tags); err != nil {
 		return nil, err
+	}
+	if awsErr := ec2CheckTagResourceIDs(p.state, reqCtx, resourceIDs); awsErr != nil {
+		return nil, awsErr
 	}
 	for _, id := range resourceIDs {
 		existing, found, err := p.resourceTags(reqCtx, id)
@@ -2510,6 +2513,9 @@ func (p *EC2Plugin) deleteTags(reqCtx *RequestContext, req *AWSRequest) (*AWSRes
 	tags := extractEC2Tags(req.Params)
 	if err := ec2CheckTagRules(tags); err != nil {
 		return nil, err
+	}
+	if awsErr := ec2CheckTagResourceIDs(p.state, reqCtx, resourceIDs); awsErr != nil {
+		return nil, awsErr
 	}
 	for _, id := range resourceIDs {
 		if err := p.applyTagsToResource(reqCtx, id, tags, true); err != nil {
@@ -2583,74 +2589,235 @@ func (p *EC2Plugin) modifyInstanceAttribute(reqCtx *RequestContext, req *AWSRequ
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
 }
 
-// ec2TaggableResource resolves a taggable EC2 resource ID to the state key its record
-// lives under and the resource type its ARN names, reporting whether the ID's prefix
-// names a resource type substrate can tag at all.
+// ec2Taggable is what one taggable EC2 resource ID resolves to: where its record lives,
+// and how AWS spells its ARN.
 //
-// One switch answers both because for five of the nine prefixes the two spellings
-// differ: substrate's state keys abbreviate where the Service Authorization Reference's
-// ARN formats do not — sg/security-group, igw/internet-gateway, rtb/route-table,
-// eip/elastic-ip, nat/natgateway. Deriving one from the other by string-munging would
-// produce arn:aws:ec2:…:sg/sg-…, which matches no ARN a caller can write, so the
-// authorization decision (#674) needs the ARN type stated rather than inferred. Keeping
-// the pair in one place is what stops the tagging handler's list of taggable resources
-// and the authorizer's from drifting apart.
+// Four fields rather than the state key alone, because for each of three separate reasons
+// the ID a caller passes to CreateTags is not simply the tail of both strings:
 //
-// The ARN type is a bare resource type, not a whole ARN: the caller supplies the
-// partition, region and account, and all nine of these ARN formats are
-// region-and-account qualified — none has the image ARN's deliberately empty account
-// field.
-func ec2TaggableResource(reqCtx *RequestContext, id string) (stateKey, arnType string, ok bool) {
-	scope := reqCtx.AccountID + "/" + reqCtx.Region
+//   - substrate's state keys abbreviate where the Service Authorization Reference's ARN
+//     formats do not — sg/security-group, igw/internet-gateway, rtb/route-table,
+//     eip/elastic-ip, nat/natgateway. Deriving one from the other by string-munging would
+//     produce arn:aws:ec2:…:sg/sg-…, which matches no ARN a caller can write, so the
+//     authorization decision (#674) needs the ARN type stated rather than inferred.
+//   - A placement group's and a key pair's records are keyed by **name**, while CreateTags
+//     names both by ID — and AWS's ARN formats for both are by name as well
+//     (arn:${Partition}:ec2:${Region}:${Account}:placement-group/${PlacementGroupName},
+//     …:key-pair/${KeyPairName}). One state scan therefore answers both questions, which
+//     is why [ec2NameKeyedResource] runs inside the resolver rather than at either caller.
+//   - An image's and a snapshot's ARN formats have a **deliberately empty account field**
+//     (arn:${Partition}:ec2:${Region}::image/${ImageId}) where the other thirteen carry
+//     ${Account} — see [ec2Taggable.arn].
+//
+// Keeping all of it in one place is what stops the tagging handler's list of taggable
+// resources and the authorizer's from drifting apart.
+type ec2Taggable struct {
+	// stateKey is the key the resource's record lives under, or "" when the ID's prefix
+	// names a taggable type but no record answers to the ID — see [ec2Taggable.resolved].
+	stateKey string
+
+	// arnType is the bare resource type in AWS's ARN format for this resource, not a
+	// whole ARN: [ec2Taggable.arn] supplies the partition, region and account.
+	arnType string
+
+	// arnID is the identifier AWS's ARN format names the resource by, which is the
+	// request's own ID for every type except a placement group and a key pair.
+	arnID string
+
+	// accountLess reports that AWS's ARN format for this type has an empty account field.
+	accountLess bool
+}
+
+// resolved reports whether a record was found for the ID.
+//
+// False for a well-formed pg- or key- ID naming no placement group or key pair, which is
+// the one case a recognized prefix cannot be resolved: those two are looked up by scanning
+// for the ID inside the record, so an absent resource yields no state key at all where
+// every other type's key is computed from the ID and simply reads back nothing. Both
+// callers treat it as they treat an absent resource of any other type — a no-op, not a
+// refusal — and [ec2AuthzTagResources] skips it, having no name to build the ARN from.
+func (t ec2Taggable) resolved() bool { return t.stateKey != "" }
+
+// arn returns the resource's ARN, in AWS's documented format for its type.
+//
+// The account segment is empty for an image and a snapshot, which is not a substrate
+// simplification: AWS publishes arn:${Partition}:ec2:${Region}::image/${ImageId} and the
+// same shape for a snapshot, while every other type here carries ${Account}. Stamping the
+// account on produces an ARN matching no statement a caller wrote against AWS's template,
+// so a Deny naming an AMI would be inert and a least-privilege Allow could not grant the
+// call — the same defect #674 fixed for the batch as a whole. #689's snapshot arm had it:
+// this resolver's own doc comment claimed no type here was account-less while snapshot
+// already was.
+func (t ec2Taggable) arn(region, accountID string) string {
+	if t.accountLess {
+		accountID = ""
+	}
+	return "arn:aws:ec2:" + region + ":" + accountID + ":" + t.arnType + "/" + t.arnID
+}
+
+// ec2TaggableResource resolves a taggable EC2 resource ID, reporting whether the ID's
+// prefix names a resource type substrate can tag at all.
+//
+// ok=false is the caller's cue to refuse with [ec2InvalidTagResourceID]; ok=true with an
+// unresolved result is a no-op. See [ec2Taggable] for why the result carries four fields.
+func ec2TaggableResource(state StateManager, reqCtx *RequestContext, id string) (ec2Taggable, bool) {
+	acct, region := reqCtx.AccountID, reqCtx.Region
+	scope := acct + "/" + region
 	switch {
 	case strings.HasPrefix(id, "i-"):
-		return "instance:" + scope + "/" + id, "instance", true
+		return ec2Taggable{stateKey: "instance:" + scope + "/" + id, arnType: "instance", arnID: id}, true
 	case strings.HasPrefix(id, "vpc-"):
-		return "vpc:" + scope + "/" + id, "vpc", true
+		return ec2Taggable{stateKey: "vpc:" + scope + "/" + id, arnType: "vpc", arnID: id}, true
 	case strings.HasPrefix(id, "subnet-"):
-		return "subnet:" + scope + "/" + id, "subnet", true
+		return ec2Taggable{stateKey: "subnet:" + scope + "/" + id, arnType: "subnet", arnID: id}, true
 	case strings.HasPrefix(id, "sg-"):
-		return "sg:" + scope + "/" + id, "security-group", true
+		return ec2Taggable{stateKey: "sg:" + scope + "/" + id, arnType: "security-group", arnID: id}, true
 	case strings.HasPrefix(id, "igw-"):
-		return "igw:" + scope + "/" + id, "internet-gateway", true
+		return ec2Taggable{stateKey: "igw:" + scope + "/" + id, arnType: "internet-gateway", arnID: id}, true
 	case strings.HasPrefix(id, "rtb-"):
-		return "rtb:" + scope + "/" + id, "route-table", true
+		return ec2Taggable{stateKey: "rtb:" + scope + "/" + id, arnType: "route-table", arnID: id}, true
 	case strings.HasPrefix(id, "eipalloc-"):
 		// elastic-ip, and the ARN carries the allocation ID — which is the ID CreateTags
 		// takes for an address, so no translation is needed here either.
-		return "eip:" + scope + "/" + id, "elastic-ip", true
+		return ec2Taggable{stateKey: "eip:" + scope + "/" + id, arnType: "elastic-ip", arnID: id}, true
 	case strings.HasPrefix(id, "nat-"):
-		// natgateway, unhyphenated, alone among the nine.
-		return "nat:" + scope + "/" + id, "natgateway", true
+		// natgateway, unhyphenated, alone among the fifteen.
+		return ec2Taggable{stateKey: "nat:" + scope + "/" + id, arnType: "natgateway", arnID: id}, true
 	case strings.HasPrefix(id, "vol-"):
 		// Volumes were the one taggable resource with no arm here, so CreateTags on a
 		// vol- ID fell through to the default and answered <return>true</return> having
 		// written nothing (#670). Nothing else needed changing:
 		// [EC2Plugin.applyTagsToResource] is type-agnostic — it reads and writes the
 		// record's "tags" JSON member — and [EC2Volume.Tags] already serializes there.
-		return ec2VolumeStateKey(reqCtx.AccountID, reqCtx.Region, id), "volume", true
+		return ec2Taggable{stateKey: ec2VolumeStateKey(acct, region, id), arnType: "volume", arnID: id}, true
 	case strings.HasPrefix(id, "snap-"):
 		// Snapshots had the same silent no-op vol- did, and #689 made it reachable: a
 		// caller can now create a snapshot of their own, so tagging one after the fact is
 		// something they will do. DescribeTags already reported a snapshot's tags before
 		// this arm existed (#688) — its scan reads state directly — so until now
 		// DescribeTags could see tags CreateTags had no way to write.
-		return ec2SnapshotStateKey(reqCtx.AccountID, reqCtx.Region, id), "snapshot", true
+		return ec2Taggable{
+			stateKey: ec2SnapshotStateKey(acct, region, id), arnType: "snapshot", arnID: id,
+			accountLess: true,
+		}, true
+	case strings.HasPrefix(id, "ami-"):
+		return ec2Taggable{
+			stateKey: ec2ImageStateKey(acct, region, id), arnType: "image", arnID: id,
+			accountLess: true,
+		}, true
+	case strings.HasPrefix(id, "lt-"):
+		return ec2Taggable{
+			stateKey: ec2LaunchTemplateStateKey(acct, region, id),
+			arnType:  "launch-template", arnID: id,
+		}, true
+	case strings.HasPrefix(id, "fleet-"):
+		// A fleet ID carries four internal hyphens of its own
+		// ("fleet-12a34b56-7cd8-...") — see [generateFleetID] — so it is matched by
+		// prefix and used whole. Nothing here may split an ID on "-".
+		return ec2Taggable{stateKey: ec2FleetStateKey(acct, region, id), arnType: "fleet", arnID: id}, true
+	case strings.HasPrefix(id, "pg-"):
+		// AWS does not settle whether CreateTags takes a placement group by ID or by
+		// name: the ARN is by name and DescribePlacementGroups publishes no group-id
+		// filter, but the client-error table publishes InvalidPlacementGroupId.Malformed
+		// "in the form pg-xxxxxxxxxxxxxxxxx", which only an ID-taking operation can
+		// raise. Substrate takes the pg- form and translates.
+		name, found := ec2NameKeyedResource(state, ec2StatePrefix("placement_group", acct, region), "group_id", id)
+		if !found {
+			return ec2Taggable{arnType: "placement-group"}, true
+		}
+		return ec2Taggable{
+			stateKey: ec2PlacementGroupStateKey(acct, region, name),
+			arnType:  "placement-group", arnID: name,
+		}, true
+	case strings.HasPrefix(id, "key-"):
+		name, found := ec2NameKeyedResource(state, ec2StatePrefix("keypair", acct, region), "keyPairId", id)
+		if !found {
+			return ec2Taggable{arnType: "key-pair"}, true
+		}
+		return ec2Taggable{
+			stateKey: ec2KeyPairStateKey(acct, region, name),
+			arnType:  "key-pair", arnID: name,
+		}, true
 	default:
-		return "", "", false
+		return ec2Taggable{}, false
 	}
 }
 
-// ec2TaggableStateKey returns the state key for a taggable resource ID, and whether
-// the ID's prefix names a resource type substrate can tag at all.
+// ec2NameKeyedResource resolves a resource ID to the name its record is keyed by, for the
+// two taggable types substrate stores by name.
 //
-// Shared by [EC2Plugin.applyTagsToResource] and [EC2Plugin.resourceTags] so the tag
-// limit is counted against exactly the resources the apply step will modify: if the two
-// disagreed about which IDs resolve, CreateTags would either check a resource it does
-// not tag or tag one it did not check.
-func ec2TaggableStateKey(reqCtx *RequestContext, id string) (string, bool) {
-	stateKey, _, ok := ec2TaggableResource(reqCtx, id)
-	return stateKey, ok
+// A linear scan of the namespace, which is what a name-keyed record leaves available: the
+// ID lives inside the record, so there is no key to look it up by.
+// [EC2Plugin.deleteKeyPair] already does exactly this scan for a KeyPairId, and the cost
+// is bounded by the number of key pairs or placement groups in one account and region.
+// The state's own key order decides which of two records claiming the same ID wins, which
+// is deterministic because [StateManager.List] is; substrate mints both IDs uniquely, so
+// the tie cannot arise from anything substrate wrote.
+//
+// A read or decode failure yields found=false rather than an error, matching
+// [ec2AuthzRecordFor]: from here an unreadable record is indistinguishable from an absent
+// one, and both mean the ID names no resource this call can tag.
+func ec2NameKeyedResource(state StateManager, prefix, idMember, id string) (string, bool) {
+	keys, err := state.List(context.Background(), ec2Namespace, prefix)
+	if err != nil {
+		return "", false
+	}
+	for _, key := range keys {
+		raw, getErr := state.Get(context.Background(), ec2Namespace, key)
+		if getErr != nil || raw == nil {
+			continue
+		}
+		var record map[string]json.RawMessage
+		if json.Unmarshal(raw, &record) != nil {
+			continue
+		}
+		var got string
+		if json.Unmarshal(record[idMember], &got) != nil || got != id {
+			continue
+		}
+		return ec2StateKeyTail(key), true
+	}
+	return "", false
+}
+
+// ec2InvalidTagResourceID is the refusal for a ResourceId whose prefix names no resource
+// type substrate can tag.
+//
+// AWS publishes InvalidID for exactly this, in the EC2 client-error table rather than on
+// CreateTags itself — which publishes no operation-specific error at all: "The specified
+// ID for the resource you are trying to tag is not valid. Ensure that you provide the full
+// resource ID; for example, ami-2bb65342 for an AMI." Naming the offending ID in place of
+// AWS's "The specified ID" is substrate's; the guidance that follows is AWS's own words,
+// and is the one thing a caller who sent a truncated ID needs to read.
+//
+// Until #708 this path answered <return>true</return>: CreateTags reported success for an
+// ID it had silently ignored, which is the one answer a caller cannot detect. That
+// mattered most for the five types #708 adds — an ami-, lt-, fleet-, pg- or key- ID was
+// well-formed and named a real resource, and was dropped.
+func ec2InvalidTagResourceID(id string) *AWSError {
+	return &AWSError{
+		Code: "InvalidID",
+		Message: "The ID '" + id + "' for the resource you are trying to tag is not valid. " +
+			"Ensure that you provide the full resource ID; for example, ami-2bb65342 for an AMI.",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+// ec2CheckTagResourceIDs refuses the whole request when any ResourceId names a resource
+// type substrate cannot tag, before anything is written.
+//
+// Ordering, not redundancy: [EC2Plugin.applyTagsToResource] answers the same refusal from
+// the same constructor, but it answers it partway through the apply loop, which would
+// leave the resources named ahead of the bad ID tagged. That is the partially-tagged state
+// CreateTags' three other whole-request checks exist to prevent, and real EC2 never
+// produces.
+func ec2CheckTagResourceIDs(state StateManager, reqCtx *RequestContext, ids []string) *AWSError {
+	for _, id := range ids {
+		if _, ok := ec2TaggableResource(state, reqCtx, id); !ok {
+			return ec2InvalidTagResourceID(id)
+		}
+	}
+	return nil
 }
 
 // resourceTags returns the tags currently on the resource named by id, and whether the
@@ -2660,11 +2827,11 @@ func ec2TaggableStateKey(reqCtx *RequestContext, id string) (string, bool) {
 // [EC2Plugin.applyTagsToResource]: CreateTags on an absent resource is a no-op in
 // substrate rather than a rejection, so the tag-limit check has nothing to count.
 func (p *EC2Plugin) resourceTags(reqCtx *RequestContext, id string) ([]EC2Tag, bool, error) {
-	stateKey, ok := ec2TaggableStateKey(reqCtx, id)
-	if !ok {
+	target, ok := ec2TaggableResource(p.state, reqCtx, id)
+	if !ok || !target.resolved() {
 		return nil, false, nil
 	}
-	data, err := p.state.Get(context.Background(), ec2Namespace, stateKey)
+	data, err := p.state.Get(context.Background(), ec2Namespace, target.stateKey)
 	if err != nil || data == nil {
 		return nil, false, nil //nolint:nilerr // Absent resource — ignored, as by applyTagsToResource.
 	}
@@ -2682,12 +2849,25 @@ func (p *EC2Plugin) resourceTags(reqCtx *RequestContext, id string) ([]EC2Tag, b
 // applyTagsToResource loads the EC2 resource identified by id, merges or
 // removes the provided tags, and saves the updated resource back to state.
 // When remove is true, matching tag keys are deleted; otherwise tags are upserted.
+//
+// An ID whose prefix names no taggable type is refused with [ec2InvalidTagResourceID]
+// rather than silently ignored, which is what it was until #708 — the comment there read
+// "matches AWS behavior", and AWS's behavior is InvalidID. Both callers check every ID
+// through [ec2CheckTagResourceIDs] first, so the refusal here is reached only by a caller
+// that skipped that pass; it is kept so no future one can reintroduce the silent success.
+//
+// An ID that resolves to no record is still a no-op, deliberately: substrate does not
+// verify a taggable resource's existence, so a tag applied to an absent resource is
+// discarded rather than refused.
 func (p *EC2Plugin) applyTagsToResource(reqCtx *RequestContext, id string, tags []EC2Tag, remove bool) error {
-	stateKey, ok := ec2TaggableStateKey(reqCtx, id)
+	target, ok := ec2TaggableResource(p.state, reqCtx, id)
 	if !ok {
-		// Unknown resource type — silently ignore (matches AWS behavior).
+		return ec2InvalidTagResourceID(id)
+	}
+	if !target.resolved() {
 		return nil
 	}
+	stateKey := target.stateKey
 
 	data, err := p.state.Get(context.Background(), ec2Namespace, stateKey)
 	if err != nil || data == nil {
@@ -2759,14 +2939,36 @@ func extractEC2Tags(params map[string]string) []EC2Tag {
 
 // --- Key pair operations ---
 
+// ec2KeyPairTags reads the TagSpecification.N tags a key-pair create scopes to the key pair
+// and checks them, for CreateKeyPair and ImportKeyPair (#708).
+//
+// Both operations document TagSpecification.N and a tagSet in their responses — AWS's
+// CreateKeyPair Example 1 sends TagSpecification.1.ResourceType=key-pair and gets the tag
+// back — and until #708 neither read it: EC2KeyPair had no Tags field at all, so a key pair
+// created with tags reported none from anywhere.
+func ec2KeyPairTags(params map[string]string) ([]EC2Tag, *AWSError) {
+	tags := ec2TagSpecificationTags(params, "", "key-pair")
+	if awsErr := ec2CheckTagRules(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, tags); awsErr != nil {
+		return nil, awsErr
+	}
+	return tags, nil
+}
+
 func (p *EC2Plugin) createKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	name := req.Params["KeyName"]
 	if name == "" {
 		return nil, &AWSError{Code: "MissingParameter", Message: "KeyName is required", HTTPStatus: http.StatusBadRequest}
 	}
+	tags, awsErr := ec2KeyPairTags(req.Params)
+	if awsErr != nil {
+		return nil, awsErr
+	}
 
 	// Check for duplicate.
-	existing, _ := p.state.Get(context.Background(), ec2Namespace, "keypair:"+reqCtx.AccountID+"/"+reqCtx.Region+"/"+name)
+	existing, _ := p.state.Get(context.Background(), ec2Namespace, ec2KeyPairStateKey(reqCtx.AccountID, reqCtx.Region, name))
 	if existing != nil {
 		return nil, &AWSError{Code: "InvalidKeyPair.Duplicate", Message: "The keypair '" + name + "' already exists.", HTTPStatus: http.StatusBadRequest}
 	}
@@ -2799,11 +3001,15 @@ func (p *EC2Plugin) createKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWS
 		Fingerprint: fp,
 		KeyType:     keyType,
 		CreatedAt:   p.tc.Now().UTC().Format(time.RFC3339),
+		Tags:        tags,
 		AccountID:   reqCtx.AccountID,
 		Region:      reqCtx.Region,
 	}
-	data, _ := json.Marshal(kp)
-	if err := p.state.Put(context.Background(), ec2Namespace, "keypair:"+reqCtx.AccountID+"/"+reqCtx.Region+"/"+name, data); err != nil {
+	data, err := json.Marshal(kp)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 createKeyPair marshal: %w", err)
+	}
+	if err := p.state.Put(context.Background(), ec2Namespace, ec2KeyPairStateKey(reqCtx.AccountID, reqCtx.Region, name), data); err != nil {
 		return nil, fmt.Errorf("ec2 createKeyPair put: %w", err)
 	}
 	if err := p.appendToList(reqCtx.AccountID+"/"+reqCtx.Region, "keypair_names", name); err != nil {
@@ -2811,13 +3017,14 @@ func (p *EC2Plugin) createKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	}
 
 	type response struct {
-		XMLName        xml.Name `xml:"CreateKeyPairResponse"`
-		XMLNS          string   `xml:"xmlns,attr"`
-		KeyPairID      string   `xml:"keyPairId"`
-		KeyName        string   `xml:"keyName"`
-		KeyFingerprint string   `xml:"keyFingerprint"`
-		KeyType        string   `xml:"keyType"`
-		KeyMaterial    string   `xml:"keyMaterial"`
+		XMLName        xml.Name      `xml:"CreateKeyPairResponse"`
+		XMLNS          string        `xml:"xmlns,attr"`
+		KeyPairID      string        `xml:"keyPairId"`
+		KeyName        string        `xml:"keyName"`
+		KeyFingerprint string        `xml:"keyFingerprint"`
+		KeyType        string        `xml:"keyType"`
+		KeyMaterial    string        `xml:"keyMaterial"`
+		Tags           *ec2TagSetXML `xml:"tagSet,omitempty"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{
 		XMLNS:          "http://ec2.amazonaws.com/doc/2016-11-15/",
@@ -2826,23 +3033,25 @@ func (p *EC2Plugin) createKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWS
 		KeyFingerprint: kp.Fingerprint,
 		KeyType:        kp.KeyType,
 		KeyMaterial:    keyMaterial,
+		Tags:           ec2TagSet(kp.Tags),
 	})
 }
 
 func (p *EC2Plugin) describeKeyPairs(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	filterNames := extractIndexedParams(req.Params, "KeyName")
 
-	allKeys, err := p.state.List(context.Background(), ec2Namespace, "keypair:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+	allKeys, err := p.state.List(context.Background(), ec2Namespace, ec2StatePrefix("keypair", reqCtx.AccountID, reqCtx.Region))
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeKeyPairs list: %w", err)
 	}
 
 	type kpItem struct {
-		KeyPairID      string `xml:"keyPairId"`
-		KeyName        string `xml:"keyName"`
-		KeyFingerprint string `xml:"keyFingerprint"`
-		KeyType        string `xml:"keyType"`
-		CreateTime     string `xml:"createTime,omitempty"`
+		KeyPairID      string        `xml:"keyPairId"`
+		KeyName        string        `xml:"keyName"`
+		KeyFingerprint string        `xml:"keyFingerprint"`
+		KeyType        string        `xml:"keyType"`
+		CreateTime     string        `xml:"createTime,omitempty"`
+		Tags           *ec2TagSetXML `xml:"tagSet,omitempty"`
 	}
 	type response struct {
 		XMLName  xml.Name `xml:"DescribeKeyPairsResponse"`
@@ -2869,6 +3078,7 @@ func (p *EC2Plugin) describeKeyPairs(reqCtx *RequestContext, req *AWSRequest) (*
 			KeyFingerprint: kp.Fingerprint,
 			KeyType:        kp.KeyType,
 			CreateTime:     kp.CreatedAt,
+			Tags:           ec2TagSet(kp.Tags),
 		})
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
@@ -2884,9 +3094,9 @@ func (p *EC2Plugin) deleteKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	}
 
 	// Support lookup by KeyPairId: scan for matching pair.
-	stateKey := "keypair:" + reqCtx.AccountID + "/" + reqCtx.Region + "/" + name
+	stateKey := ec2KeyPairStateKey(reqCtx.AccountID, reqCtx.Region, name)
 	if strings.HasPrefix(name, "key-") {
-		allKeys, _ := p.state.List(context.Background(), ec2Namespace, "keypair:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+		allKeys, _ := p.state.List(context.Background(), ec2Namespace, ec2StatePrefix("keypair", reqCtx.AccountID, reqCtx.Region))
 		for _, k := range allKeys {
 			data, _ := p.state.Get(context.Background(), ec2Namespace, k)
 			if data == nil {
@@ -2921,9 +3131,13 @@ func (p *EC2Plugin) importKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	if pubKeyMaterial == "" {
 		return nil, &AWSError{Code: "MissingParameter", Message: "PublicKeyMaterial is required", HTTPStatus: http.StatusBadRequest}
 	}
+	tags, awsErr := ec2KeyPairTags(req.Params)
+	if awsErr != nil {
+		return nil, awsErr
+	}
 
 	// Check for duplicate.
-	existing, _ := p.state.Get(context.Background(), ec2Namespace, "keypair:"+reqCtx.AccountID+"/"+reqCtx.Region+"/"+name)
+	existing, _ := p.state.Get(context.Background(), ec2Namespace, ec2KeyPairStateKey(reqCtx.AccountID, reqCtx.Region, name))
 	if existing != nil {
 		return nil, &AWSError{Code: "InvalidKeyPair.Duplicate", Message: "The keypair '" + name + "' already exists.", HTTPStatus: http.StatusBadRequest}
 	}
@@ -2952,11 +3166,15 @@ func (p *EC2Plugin) importKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWS
 		Fingerprint: fp,
 		KeyType:     keyType,
 		CreatedAt:   p.tc.Now().UTC().Format(time.RFC3339),
+		Tags:        tags,
 		AccountID:   reqCtx.AccountID,
 		Region:      reqCtx.Region,
 	}
-	data, _ := json.Marshal(kp)
-	if err := p.state.Put(context.Background(), ec2Namespace, "keypair:"+reqCtx.AccountID+"/"+reqCtx.Region+"/"+name, data); err != nil {
+	data, err := json.Marshal(kp)
+	if err != nil {
+		return nil, fmt.Errorf("ec2 importKeyPair marshal: %w", err)
+	}
+	if err := p.state.Put(context.Background(), ec2Namespace, ec2KeyPairStateKey(reqCtx.AccountID, reqCtx.Region, name), data); err != nil {
 		return nil, fmt.Errorf("ec2 importKeyPair put: %w", err)
 	}
 	if err := p.appendToList(reqCtx.AccountID+"/"+reqCtx.Region, "keypair_names", name); err != nil {
@@ -2964,12 +3182,13 @@ func (p *EC2Plugin) importKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	}
 
 	type response struct {
-		XMLName        xml.Name `xml:"ImportKeyPairResponse"`
-		XMLNS          string   `xml:"xmlns,attr"`
-		KeyPairID      string   `xml:"keyPairId"`
-		KeyName        string   `xml:"keyName"`
-		KeyFingerprint string   `xml:"keyFingerprint"`
-		KeyType        string   `xml:"keyType"`
+		XMLName        xml.Name      `xml:"ImportKeyPairResponse"`
+		XMLNS          string        `xml:"xmlns,attr"`
+		KeyPairID      string        `xml:"keyPairId"`
+		KeyName        string        `xml:"keyName"`
+		KeyFingerprint string        `xml:"keyFingerprint"`
+		KeyType        string        `xml:"keyType"`
+		Tags           *ec2TagSetXML `xml:"tagSet,omitempty"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{
 		XMLNS:          "http://ec2.amazonaws.com/doc/2016-11-15/",
@@ -2977,6 +3196,7 @@ func (p *EC2Plugin) importKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWS
 		KeyName:        kp.KeyName,
 		KeyFingerprint: kp.Fingerprint,
 		KeyType:        kp.KeyType,
+		Tags:           ec2TagSet(kp.Tags),
 	})
 }
 
@@ -3863,8 +4083,38 @@ func (p *EC2Plugin) describeAvailabilityZones(reqCtx *RequestContext, _ *AWSRequ
 	return ec2XMLResponse(http.StatusOK, resp)
 }
 
+// ec2PlacementGroupXML is AWS's placementGroup element, shared by CreatePlacementGroup and
+// DescribePlacementGroups so the two cannot render a group differently.
+//
+// tagSet carries omitempty: AWS's own CreatePlacementGroup Example 2 — a group created with
+// no TagSpecification — renders no tagSet element at all, where Example 1 renders one.
+type ec2PlacementGroupXML struct {
+	GroupName string        `xml:"groupName"`
+	GroupID   string        `xml:"groupId"`
+	Strategy  string        `xml:"strategy"`
+	State     string        `xml:"state"`
+	Tags      *ec2TagSetXML `xml:"tagSet,omitempty"`
+}
+
+// ec2PlacementGroupSummary renders a placement group as AWS's placementGroup element.
+func ec2PlacementGroupSummary(pg EC2PlacementGroup) ec2PlacementGroupXML {
+	return ec2PlacementGroupXML{
+		GroupName: pg.GroupName,
+		GroupID:   pg.GroupID,
+		Strategy:  pg.Strategy,
+		State:     pg.State,
+		Tags:      ec2TagSet(pg.Tags),
+	}
+}
+
 // createPlacementGroup creates an EC2 placement group (#344). A repeat create of
 // an existing name returns InvalidPlacementGroup.Duplicate.
+//
+// TagSpecification.N with ResourceType=placement-group is read here (#708), which is the
+// only way a placement group's tags were settable at all until CreateTags grew a pg- arm:
+// EC2PlacementGroup has carried a Tags field since #344 and nothing ever wrote it, so
+// DescribePlacementGroups and DescribeTags reported a group as untagged however it was
+// created.
 func (p *EC2Plugin) createPlacementGroup(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	name := req.Params["GroupName"]
 	if name == "" {
@@ -3873,6 +4123,13 @@ func (p *EC2Plugin) createPlacementGroup(reqCtx *RequestContext, req *AWSRequest
 	strategy := req.Params["Strategy"]
 	if strategy == "" {
 		strategy = "cluster"
+	}
+	tags := ec2TagSpecificationTags(req.Params, "", "placement-group")
+	if awsErr := ec2CheckTagRules(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, tags); awsErr != nil {
+		return nil, awsErr
 	}
 
 	key := ec2PlacementGroupStateKey(reqCtx.AccountID, reqCtx.Region, name)
@@ -3885,6 +4142,7 @@ func (p *EC2Plugin) createPlacementGroup(reqCtx *RequestContext, req *AWSRequest
 		GroupID:   generatePlacementGroupID(),
 		Strategy:  strategy,
 		State:     "available",
+		Tags:      tags,
 		AccountID: reqCtx.AccountID,
 		Region:    reqCtx.Region,
 	}
@@ -3896,20 +4154,14 @@ func (p *EC2Plugin) createPlacementGroup(reqCtx *RequestContext, req *AWSRequest
 		return nil, fmt.Errorf("ec2 createPlacementGroup put: %w", err)
 	}
 
-	type pgItem struct {
-		GroupName string `xml:"groupName"`
-		GroupID   string `xml:"groupId"`
-		Strategy  string `xml:"strategy"`
-		State     string `xml:"state"`
-	}
 	type response struct {
-		XMLName        xml.Name `xml:"CreatePlacementGroupResponse"`
-		XMLNS          string   `xml:"xmlns,attr"`
-		PlacementGroup pgItem   `xml:"placementGroup"`
+		XMLName        xml.Name             `xml:"CreatePlacementGroupResponse"`
+		XMLNS          string               `xml:"xmlns,attr"`
+		PlacementGroup ec2PlacementGroupXML `xml:"placementGroup"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{
 		XMLNS:          "http://ec2.amazonaws.com/doc/2016-11-15/",
-		PlacementGroup: pgItem{GroupName: pg.GroupName, GroupID: pg.GroupID, Strategy: pg.Strategy, State: pg.State},
+		PlacementGroup: ec2PlacementGroupSummary(pg),
 	})
 }
 
@@ -3918,21 +4170,15 @@ func (p *EC2Plugin) createPlacementGroup(reqCtx *RequestContext, req *AWSRequest
 func (p *EC2Plugin) describePlacementGroups(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	names := extractIndexedParams(req.Params, "GroupName")
 	allKeys, err := p.state.List(context.Background(), ec2Namespace,
-		"placement_group:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+		ec2StatePrefix("placement_group", reqCtx.AccountID, reqCtx.Region))
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describePlacementGroups list: %w", err)
 	}
 
-	type pgItem struct {
-		GroupName string `xml:"groupName"`
-		GroupID   string `xml:"groupId"`
-		Strategy  string `xml:"strategy"`
-		State     string `xml:"state"`
-	}
 	type response struct {
-		XMLName xml.Name `xml:"DescribePlacementGroupsResponse"`
-		XMLNS   string   `xml:"xmlns,attr"`
-		Groups  []pgItem `xml:"placementGroupSet>item"`
+		XMLName xml.Name               `xml:"DescribePlacementGroupsResponse"`
+		XMLNS   string                 `xml:"xmlns,attr"`
+		Groups  []ec2PlacementGroupXML `xml:"placementGroupSet>item"`
 	}
 
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
@@ -3948,7 +4194,7 @@ func (p *EC2Plugin) describePlacementGroups(reqCtx *RequestContext, req *AWSRequ
 		if len(names) > 0 && !containsStr(names, pg.GroupName) {
 			continue
 		}
-		resp.Groups = append(resp.Groups, pgItem{GroupName: pg.GroupName, GroupID: pg.GroupID, Strategy: pg.Strategy, State: pg.State})
+		resp.Groups = append(resp.Groups, ec2PlacementGroupSummary(pg))
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -4806,7 +5052,7 @@ func ec2LookupLaunchTemplate(goCtx context.Context, state StateManager, ctx *Req
 		}
 		ltID = string(data)
 	}
-	key := "lt:" + ctx.AccountID + "/" + ctx.Region + "/" + ltID
+	key := ec2LaunchTemplateStateKey(ctx.AccountID, ctx.Region, ltID)
 	data, err := state.Get(goCtx, ec2Namespace, key)
 	if err != nil || data == nil {
 		return nil
@@ -4907,9 +5153,23 @@ func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 		return nil, awsErr
 	}
 
+	// The template's *own* tags, which are a different list from the two inside
+	// LaunchTemplateData: those scope to the instances and volumes a launch creates, and
+	// this one is on the template resource itself. Until #708 nothing read it, so
+	// EC2LaunchTemplate.Tags was never written by any path — ec2LaunchTemplateSummary has
+	// always rendered a tagSet from it, and the element was always empty.
+	ownTags := ec2TagSpecificationTags(req.Params, "", "launch-template")
+	if awsErr := ec2CheckTagRules(ownTags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, ownTags); awsErr != nil {
+		return nil, awsErr
+	}
+
 	lt := EC2LaunchTemplate{
 		LaunchTemplateID:   ltID,
 		LaunchTemplateName: name,
+		Tags:               ownTags,
 		DefaultVersionNum:  1,
 		LatestVersionNum:   1,
 		CreatedBy:          ctx.AccountID,
@@ -4932,7 +5192,7 @@ func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 	if err != nil {
 		return nil, fmt.Errorf("createLaunchTemplate: marshal: %w", err)
 	}
-	ltKey := "lt:" + ctx.AccountID + "/" + ctx.Region + "/" + ltID
+	ltKey := ec2LaunchTemplateStateKey(ctx.AccountID, ctx.Region, ltID)
 	if err := p.state.Put(goCtx, ec2Namespace, ltKey, ltJSON); err != nil {
 		return nil, fmt.Errorf("createLaunchTemplate: put lt: %w", err)
 	}
@@ -4969,13 +5229,13 @@ func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 // template's parameters back, which is why DescribeLaunchTemplateVersions exists and
 // why anything asserting on a template's contents has to call it.
 type ec2LaunchTemplateXML struct {
-	LaunchTemplateID   string       `xml:"launchTemplateId"`
-	LaunchTemplateName string       `xml:"launchTemplateName"`
-	CreateTime         string       `xml:"createTime"`
-	CreatedBy          string       `xml:"createdBy,omitempty"`
-	DefaultVersionNum  int64        `xml:"defaultVersionNumber"`
-	LatestVersionNum   int64        `xml:"latestVersionNumber"`
-	Tags               []ec2TagItem `xml:"tagSet>item,omitempty"`
+	LaunchTemplateID   string        `xml:"launchTemplateId"`
+	LaunchTemplateName string        `xml:"launchTemplateName"`
+	CreateTime         string        `xml:"createTime"`
+	CreatedBy          string        `xml:"createdBy,omitempty"`
+	DefaultVersionNum  int64         `xml:"defaultVersionNumber"`
+	LatestVersionNum   int64         `xml:"latestVersionNumber"`
+	Tags               *ec2TagSetXML `xml:"tagSet,omitempty"`
 }
 
 // ec2TagItem is a tagSet entry on the wire.
@@ -5005,20 +5265,48 @@ func ec2TagItems(tags []EC2Tag) []ec2TagItem {
 	return items
 }
 
+// ec2TagSetXML is a tagSet element that disappears when the resource carries no tags.
+//
+// A []ec2TagItem behind an `xml:"tagSet>item,omitempty"` path cannot express that:
+// omitempty suppresses the *items*, and encoding/xml still writes the parent, so an
+// untagged resource answers <tagSet></tagSet>. AWS's examples for the operations #708
+// gave tags to show the element absent instead — CreateLaunchTemplate Example 1 and
+// CreatePlacementGroup Example 2 each create an untagged resource and neither response
+// carries a tagSet, while CreateKeyPair's tagged example does — and an SDK tells an
+// absent list from an empty one, which is the same distinction [ec2TagDescription]'s
+// value member is kept present-but-empty for.
+//
+// #685 reached the same conclusion for DescribeSubnets and wrote the wrapper there; #708
+// needed it for four more renderers, so the type moved here beside [ec2TagItems] rather
+// than being written twice. Every *other* response's always-present tagSet is left alone:
+// describeSnapshots' present-but-empty element follows its own operation's samples, and
+// each response answers to the page that documents it.
+type ec2TagSetXML struct {
+	// Items are the tags, in stored order.
+	Items []ec2TagItem `xml:"item"`
+}
+
+// ec2TagSet renders tags as an omittable tagSet, returning nil when there are none so
+// that the element itself is left out.
+func ec2TagSet(tags []EC2Tag) *ec2TagSetXML {
+	items := ec2TagItems(tags)
+	if len(items) == 0 {
+		return nil
+	}
+	return &ec2TagSetXML{Items: items}
+}
+
 // ec2LaunchTemplateSummary renders a launch template as its summary element.
 func ec2LaunchTemplateSummary(lt *EC2LaunchTemplate) ec2LaunchTemplateXML {
-	out := ec2LaunchTemplateXML{
+	return ec2LaunchTemplateXML{
 		LaunchTemplateID:   lt.LaunchTemplateID,
 		LaunchTemplateName: lt.LaunchTemplateName,
 		CreateTime:         lt.CreateTime,
 		CreatedBy:          lt.CreatedBy,
 		DefaultVersionNum:  lt.DefaultVersionNum,
 		LatestVersionNum:   lt.LatestVersionNum,
+		Tags:               ec2TagSet(lt.Tags),
 	}
-	for _, t := range lt.Tags {
-		out.Tags = append(out.Tags, ec2TagItem(t))
-	}
-	return out
 }
 
 func (p *EC2Plugin) describeLaunchTemplates(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -5041,7 +5329,7 @@ func (p *EC2Plugin) describeLaunchTemplates(ctx *RequestContext, req *AWSRequest
 		idsKey := "lt_ids:" + ctx.AccountID + "/" + ctx.Region
 		ids, _ := loadStringIndex(goCtx, p.state, ec2Namespace, idsKey)
 		for _, id := range ids {
-			key := "lt:" + ctx.AccountID + "/" + ctx.Region + "/" + id
+			key := ec2LaunchTemplateStateKey(ctx.AccountID, ctx.Region, id)
 			data, err := p.state.Get(goCtx, ec2Namespace, key)
 			if err != nil || data == nil {
 				continue
@@ -5080,7 +5368,7 @@ func (p *EC2Plugin) deleteLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 		}
 	}
 
-	ltKey := "lt:" + ctx.AccountID + "/" + ctx.Region + "/" + lt.LaunchTemplateID
+	ltKey := ec2LaunchTemplateStateKey(ctx.AccountID, ctx.Region, lt.LaunchTemplateID)
 	nameKey := "lt_by_name:" + ctx.AccountID + "/" + ctx.Region + "/" + lt.LaunchTemplateName
 	idsKey := "lt_ids:" + ctx.AccountID + "/" + ctx.Region
 

--- a/emulator/ec2_subnet_filters.go
+++ b/emulator/ec2_subnet_filters.go
@@ -121,7 +121,9 @@ func ec2SubnetMatchesFilter(subnet EC2Subnet, name string, values []string) bool
 // encoding/xml emits the parent element of a nested path even for a nil slice, so the
 // omitempty form would render <tagSet></tagSet> on every untagged subnet — the very thing
 // the samples say is absent. A nil pointer is omitempty-empty, so it disappears. Callers
-// decoding tagSet>item see no difference between the two shapes.
+// decoding tagSet>item see no difference between the two shapes. The wrapper was this
+// operation's own until #708 needed it for four more; it now lives beside [ec2TagItems]
+// as [ec2TagSetXML].
 type ec2SubnetItem struct {
 	// SubnetID is the subnet's ID.
 	SubnetID string `xml:"subnetId"`
@@ -151,13 +153,7 @@ type ec2SubnetItem struct {
 	MapPublicIPOnLaunch bool `xml:"mapPublicIpOnLaunch"`
 
 	// Tags are the subnet's tags, absent when it has none.
-	Tags *ec2SubnetTagSet `xml:"tagSet,omitempty"`
-}
-
-// ec2SubnetTagSet wraps a subnet's tags so an untagged subnet can omit tagSet entirely.
-type ec2SubnetTagSet struct {
-	// Items are the tags themselves.
-	Items []ec2TagItem `xml:"item"`
+	Tags *ec2TagSetXML `xml:"tagSet,omitempty"`
 }
 
 // ec2SubnetXML renders one stored subnet as its response element.
@@ -173,8 +169,6 @@ func ec2SubnetXML(subnet EC2Subnet) ec2SubnetItem {
 		DefaultForAz:        subnet.IsDefault,
 		MapPublicIPOnLaunch: subnet.MapPublicIPOnLaunch,
 	}
-	if tags := ec2TagItems(subnet.Tags); len(tags) > 0 {
-		item.Tags = &ec2SubnetTagSet{Items: tags}
-	}
+	item.Tags = ec2TagSet(subnet.Tags)
 	return item
 }

--- a/emulator/ec2_tag_authz_test.go
+++ b/emulator/ec2_tag_authz_test.go
@@ -34,16 +34,43 @@ const (
 	ec2TagAuthzRTB      = "rtb-0aaa9999bbbb0000c"
 	ec2TagAuthzEIP      = "eipalloc-0bbb1111cccc2222d"
 	ec2TagAuthzNAT      = "nat-0ccc3333dddd4444e"
+
+	// The six types #708 added. A fleet ID carries four internal hyphens of its own,
+	// which is the shape that would break any prefix match that split on "-".
+	ec2TagAuthzSnapshot = "snap-0ddd5555eeee6666a"
+	ec2TagAuthzImage    = "ami-0eee7777ffff8888b"
+	ec2TagAuthzLT       = "lt-0fff9999aaaa0000c"
+	ec2TagAuthzFleet    = "fleet-12a34b56-7cd8-90ef-1a2b-3c4d5e6f7a8b"
+
+	// A placement group's and a key pair's ARNs name them by *name*, while CreateTags
+	// names them by ID, so each needs both spellings written out.
+	ec2TagAuthzPGID    = "pg-0aaa2222bbbb3333d"
+	ec2TagAuthzPGName  = "authz-placement-group"
+	ec2TagAuthzKeyID   = "key-0bbb4444cccc5555e"
+	ec2TagAuthzKeyName = "authz-key-pair"
 )
 
 // ec2TagARN builds the ARN a tagging call is authorized against.
 //
-// Written out here rather than derived from the state key on purpose: for five of
-// the nine taggable prefixes substrate's state key abbreviates the resource type
-// the Service Authorization Reference's ARN uses, and a test that derived one from
-// the other would agree with a wrong answer.
+// Written out here rather than derived from the state key on purpose: for seven of
+// the fifteen taggable prefixes substrate's state key abbreviates the resource type
+// the Service Authorization Reference's ARN uses, or names the resource by something
+// other than the ID the caller passed, and a test that derived one from the other
+// would agree with a wrong answer.
 func ec2TagARN(arnType, id string) string {
 	return "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":" + arnType + "/" + id
+}
+
+// ec2TagARNNoAccount builds the ARN for the two types whose account field AWS leaves
+// empty: arn:${Partition}:ec2:${Region}::image/${ImageId}, and the same shape for a
+// snapshot.
+//
+// A separate builder rather than a flag on [ec2TagARN], because the point is that these
+// two strings are not the shape the other thirteen have — an ARN with the account
+// stamped on matches no statement a caller wrote against AWS's template, so a Deny
+// naming an AMI would be inert. #689's snapshot arm shipped with exactly that defect.
+func ec2TagARNNoAccount(arnType, id string) string {
+	return "arn:aws:ec2:" + ec2AuthzRegion + "::" + arnType + "/" + id
 }
 
 // ec2TagAuthzResource is one taggable resource: the ID a caller passes as
@@ -58,8 +85,10 @@ type ec2TagAuthzResource struct {
 // ec2TagAuthzAllTypes is every resource type substrate can tag, in the order these
 // tests name them in ResourceId.N — which is the order the decision evaluates.
 //
-// All nine, not a sample: the ARN resource type is a hand-written string per type,
-// so a wrong one is only caught by a case that names that type.
+// All fifteen, not a sample: the ARN resource type is a hand-written string per type,
+// so a wrong one is only caught by a case that names that type. Six joined in #708, and
+// each of the three ways an ARN diverges from the state key is now represented — the
+// abbreviating five, the two with an empty account field, and the two named by name.
 func ec2TagAuthzAllTypes() []ec2TagAuthzResource {
 	return []ec2TagAuthzResource{
 		{ec2TagAuthzInstance, ec2TagARN("instance", ec2TagAuthzInstance), (*ec2AuthzFixture).putTagInstance},
@@ -75,6 +104,12 @@ func ec2TagAuthzAllTypes() []ec2TagAuthzResource {
 		{ec2TagAuthzRTB, ec2TagARN("route-table", ec2TagAuthzRTB), (*ec2AuthzFixture).putTagRouteTable},
 		{ec2TagAuthzEIP, ec2TagARN("elastic-ip", ec2TagAuthzEIP), (*ec2AuthzFixture).putTagElasticIP},
 		{ec2TagAuthzNAT, ec2TagARN("natgateway", ec2TagAuthzNAT), (*ec2AuthzFixture).putTagNATGateway},
+		{ec2TagAuthzSnapshot, ec2TagARNNoAccount("snapshot", ec2TagAuthzSnapshot), (*ec2AuthzFixture).putTagSnapshot},
+		{ec2TagAuthzImage, ec2TagARNNoAccount("image", ec2TagAuthzImage), (*ec2AuthzFixture).putTagImage},
+		{ec2TagAuthzLT, ec2TagARN("launch-template", ec2TagAuthzLT), (*ec2AuthzFixture).putTagLaunchTemplate},
+		{ec2TagAuthzFleet, ec2TagARN("fleet", ec2TagAuthzFleet), (*ec2AuthzFixture).putTagFleet},
+		{ec2TagAuthzPGID, ec2TagARN("placement-group", ec2TagAuthzPGName), (*ec2AuthzFixture).putTagPlacementGroup},
+		{ec2TagAuthzKeyID, ec2TagARN("key-pair", ec2TagAuthzKeyName), (*ec2AuthzFixture).putTagKeyPair},
 	}
 }
 
@@ -123,6 +158,50 @@ func (f *ec2AuthzFixture) putTagNATGateway(t *testing.T, tags map[string]string)
 		emulator.EC2NATGateway{NatGatewayID: ec2TagAuthzNAT, Tags: ec2AuthzTags(tags)})
 }
 
+func (f *ec2AuthzFixture) putTagSnapshot(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "snapshot:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzSnapshot,
+		emulator.EC2Snapshot{SnapshotID: ec2TagAuthzSnapshot, Tags: ec2AuthzTags(tags)})
+}
+
+func (f *ec2AuthzFixture) putTagImage(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "image:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzImage,
+		emulator.EC2Image{ImageID: ec2TagAuthzImage, Tags: ec2AuthzTags(tags)})
+}
+
+func (f *ec2AuthzFixture) putTagLaunchTemplate(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "lt:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzLT,
+		emulator.EC2LaunchTemplate{LaunchTemplateID: ec2TagAuthzLT, Tags: ec2AuthzTags(tags)})
+}
+
+func (f *ec2AuthzFixture) putTagFleet(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "fleet:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzFleet,
+		emulator.EC2Fleet{FleetID: ec2TagAuthzFleet, Tags: ec2AuthzTags(tags)})
+}
+
+// The last two are keyed by name, so the record has to carry the ID a caller passes as
+// well as the name the key and the ARN use — which is the whole point of the reverse scan
+// [ec2TagAuthzPGID] and [ec2TagAuthzKeyID] exercise. A record missing its ID member
+// resolves to nothing at all, and the resource drops silently out of the decision.
+func (f *ec2AuthzFixture) putTagPlacementGroup(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "placement_group:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzPGName,
+		emulator.EC2PlacementGroup{
+			GroupName: ec2TagAuthzPGName, GroupID: ec2TagAuthzPGID, Tags: ec2AuthzTags(tags),
+		})
+}
+
+func (f *ec2AuthzFixture) putTagKeyPair(t *testing.T, tags map[string]string) {
+	t.Helper()
+	f.put(t, "keypair:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+ec2TagAuthzKeyName,
+		emulator.EC2KeyPair{
+			KeyName: ec2TagAuthzKeyName, KeyPairID: ec2TagAuthzKeyID, Tags: ec2AuthzTags(tags),
+		})
+}
+
 // ec2TagAuthzFixture is the #662 fixture with every taggable resource present and
 // untagged, which is the state a tagging call is decided against.
 func ec2TagAuthzFixture(t *testing.T, user string) *ec2AuthzFixture {
@@ -162,12 +241,15 @@ func ec2TagAuthzStatement(effect, action string, resources ...string) emulator.P
 // because the call resolved to the resource "*" and resourceMatches asks globMatch
 // whether the *statement's* ARN matches that "*", which it does not.
 //
-// Each subtest denies exactly one of the nine resources the request names, so it
+// Each subtest denies exactly one of the fifteen resources the request names, so it
 // fails unless the decision both reaches that resource and spells its ARN the way
-// the Service Authorization Reference does. Five of the nine are the interesting
-// ones — sg, igw, rtb, eip and nat abbreviate in the state key and do not in the
-// ARN — and a Deny on security-group/sg-… matching nothing is exactly what a
-// string-munged ARN would produce.
+// the Service Authorization Reference does. Nine of the fifteen are the interesting
+// ones. Five abbreviate in the state key and do not in the ARN — sg, igw, rtb, eip
+// and nat — and a Deny on security-group/sg-… matching nothing is exactly what a
+// string-munged ARN would produce. Two have an empty account field, where stamping the
+// account on makes an ARN-scoped Deny inert (#689's snapshot arm did). Two are named by
+// name in the ARN and by ID in the request, so a Deny naming the ARN AWS documents only
+// matches if the decision translated.
 func TestEC2_TagAuthz_ScopedDenyOnAnyNamedResourceBlocks(t *testing.T) {
 	for _, res := range ec2TagAuthzAllTypes() {
 		t.Run(res.arn, func(t *testing.T) {
@@ -476,7 +558,7 @@ func TestEC2_TagAuthz_PermissionBoundaryCoversEveryResource(t *testing.T) {
 
 	callErr := f.call(t, "CreateTags", ec2TagAuthzParams())
 	if !ec2AuthzDenied(t, callErr) {
-		t.Fatal("a boundary allowing only the first resource did not block a call naming nine")
+		t.Fatal("a boundary allowing only the first resource did not block a call naming fifteen")
 	}
 	var awsErr *emulator.AWSError
 	require.ErrorAs(t, callErr, &awsErr)

--- a/emulator/ec2_tags_alltypes_test.go
+++ b/emulator/ec2_tags_alltypes_test.go
@@ -1,0 +1,510 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The five resource types CreateTags could not reach before #708 — an AMI, a launch
+// template, a fleet, a placement group and a key pair.
+//
+// Each was well-formed, named a real resource substrate stores, and was dropped:
+// ec2TaggableResource's switch had no arm for its prefix, so the request fell to the
+// default and answered <return>true</return> having written nothing. Two of the five were
+// worse than that — a placement group and a key pair were absent from DescribeTags' scan
+// as well, so tags applied by any route were unreportable, and a launch template's own
+// tags could not be set by *any* path, since the TagSpecification CreateLaunchTemplate
+// read lives inside LaunchTemplateData and is scoped to instance/volume.
+//
+// Every assertion here goes through HTTP for the reason #688's do: a hand-built plugin
+// call would not exercise the dispatcher, and silent success is exactly the failure a
+// caller cannot detect.
+
+// ec2TagAllTypesCase is one resource type CreateTags has to reach: how to create an
+// instance of it, and the resourceType DescribeTags reports it under.
+type ec2TagAllTypesCase struct {
+	name         string
+	resourceType string
+	// create returns the ID a caller passes as ResourceId.N, which for a placement group
+	// and a key pair is *not* the name its record is keyed by.
+	create func(t *testing.T, ts *httptest.Server) string
+}
+
+// ec2TagAllTypesCases is the five types #708 adds, and only those: the other ten already
+// had an arm, and [TestEC2_TagAuthz_ScopedDenyOnAnyNamedResourceBlocks] covers all
+// fifteen at the authorization layer.
+func ec2TagAllTypesCases() []ec2TagAllTypesCase {
+	return []ec2TagAllTypesCase{
+		{
+			name:         "an AMI",
+			resourceType: "image",
+			create: func(t *testing.T, ts *httptest.Server) string {
+				t.Helper()
+				return ec2CreateImageID(t, ts, map[string]string{
+					"Action":     "CreateImage",
+					"InstanceId": ec2TagTestInstance(t, ts),
+					"Name":       "tagme-ami",
+				})
+			},
+		},
+		{
+			name:         "a launch template",
+			resourceType: "launch-template",
+			create: func(t *testing.T, ts *httptest.Server) string {
+				t.Helper()
+				return newFleetLaunchTemplate(t, ts, "tagme-lt")
+			},
+		},
+		{
+			name:         "a fleet",
+			resourceType: "fleet",
+			create: func(t *testing.T, ts *httptest.Server) string {
+				t.Helper()
+				return ec2TagTestFleet(t, ts)
+			},
+		},
+		{
+			name:         "a placement group",
+			resourceType: "placement-group",
+			create: func(t *testing.T, ts *httptest.Server) string {
+				t.Helper()
+				id, _ := ec2TagTestPlacementGroup(t, ts, "tagme-pg", nil)
+				return id
+			},
+		},
+		{
+			name:         "a key pair",
+			resourceType: "key-pair",
+			create: func(t *testing.T, ts *httptest.Server) string {
+				t.Helper()
+				id, _ := ec2TagTestKeyPair(t, ts, "tagme-key", nil)
+				return id
+			},
+		},
+	}
+}
+
+// ec2TagTestFleet creates an instant fleet and returns its ID, which carries four
+// internal hyphens of its own — the shape nothing in the tagging path may split on "-".
+func ec2TagTestFleet(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	ltID := newFleetLaunchTemplate(t, ts, "tagme-fleet-lt")
+	var fleet struct {
+		FleetID string `xml:"fleetId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateFleet",
+		"Type":   "instant",
+		"LaunchTemplateConfigs.1.LaunchTemplateSpecification.LaunchTemplateId": ltID,
+		"TargetCapacitySpecification.TotalTargetCapacity":                      "1",
+	}, &fleet)
+	require.NotEmpty(t, fleet.FleetID)
+	require.Greater(t, strings.Count(fleet.FleetID, "-"), 1,
+		"a fleet ID carries internal hyphens; a one-hyphen fixture would not test the prefix match")
+	return fleet.FleetID
+}
+
+// ec2TagTestPlacementGroup creates a placement group and returns its ID and the tagSet
+// CreatePlacementGroup reported, which is how the tag-on-create half is read back.
+func ec2TagTestPlacementGroup(t *testing.T, ts *httptest.Server, name string,
+	extra map[string]string) (string, []describedTag) {
+	t.Helper()
+	params := map[string]string{"Action": "CreatePlacementGroup", "GroupName": name, "Strategy": "spread"}
+	for k, v := range extra {
+		params[k] = v
+	}
+	var pg struct {
+		GroupID string         `xml:"placementGroup>groupId"`
+		Tags    []describedTag `xml:"placementGroup>tagSet>item"`
+	}
+	ec2FleetXML(t, ts, params, &pg)
+	require.True(t, strings.HasPrefix(pg.GroupID, "pg-"), "got %q", pg.GroupID)
+	return pg.GroupID, pg.Tags
+}
+
+// ec2TagTestKeyPair creates a key pair and returns its ID and the tagSet CreateKeyPair
+// reported.
+func ec2TagTestKeyPair(t *testing.T, ts *httptest.Server, name string,
+	extra map[string]string) (string, []describedTag) {
+	t.Helper()
+	params := map[string]string{"Action": "CreateKeyPair", "KeyName": name}
+	for k, v := range extra {
+		params[k] = v
+	}
+	var kp struct {
+		KeyPairID string         `xml:"keyPairId"`
+		Tags      []describedTag `xml:"tagSet>item"`
+	}
+	ec2FleetXML(t, ts, params, &kp)
+	require.True(t, strings.HasPrefix(kp.KeyPairID, "key-"), "got %q", kp.KeyPairID)
+	return kp.KeyPairID, kp.Tags
+}
+
+// TestEC2_CreateTags_ReachesEveryTaggableType is the decisive test for #708: a tag
+// applied to each of the five new types is stored and reported.
+//
+// DescribeTags is the reader, for two reasons. It is type-agnostic — one scan over every
+// namespace — so a single assertion covers storage and reporting; and its resourceId is
+// where the two name-keyed types could go wrong silently. A placement group and a key pair
+// are keyed by *name* in state, so reporting the state key's tail would name the resource
+// by something a caller cannot pass back to CreateTags. The ID member each record carries
+// is what ec2TagScanTarget.idMember exists to read.
+func TestEC2_CreateTags_ReachesEveryTaggableType(t *testing.T) {
+	for _, tc := range ec2TagAllTypesCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			id := tc.create(t, ts)
+
+			status, code, message := ec2CreateTags(t, ts, id, map[string]string{
+				"Tag.1.Key":   "Env",
+				"Tag.1.Value": "prod",
+			})
+			require.Equal(t, http.StatusOK, status, "CreateTags on %s: %s %s", tc.name, code, message)
+
+			tags, _ := ec2DescribeTags(t, ts, map[string]string{
+				"Filter.1.Name":    "resource-id",
+				"Filter.1.Value.1": id,
+			})
+			require.Len(t, tags, 1, "DescribeTags must report the tag CreateTags wrote on %s", tc.name)
+			assert.Equal(t, id, tags[0].ResourceID,
+				"the tag is reported against the ID the caller tagged, not the name its record is keyed by")
+			assert.Equal(t, tc.resourceType, tags[0].ResourceType)
+			assert.Equal(t, "Env", tags[0].Key)
+			assert.Equal(t, "prod", tags[0].Value)
+		})
+	}
+}
+
+// TestEC2_DeleteTags_ReachesEveryTaggableType pins the symmetric path: the same five
+// types can have a tag removed again.
+//
+// Worth its own test rather than an assertion appended to the one above, because the two
+// operations resolve their IDs through the same function and could still diverge — until
+// #708 both fell to the same silent default, so a fix to one would look complete.
+func TestEC2_DeleteTags_ReachesEveryTaggableType(t *testing.T) {
+	for _, tc := range ec2TagAllTypesCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			id := tc.create(t, ts)
+			status, _, _ := ec2CreateTags(t, ts, id, map[string]string{
+				"Tag.1.Key":   "Env",
+				"Tag.1.Value": "prod",
+			})
+			require.Equal(t, http.StatusOK, status)
+
+			// DeleteTags names keys and treats the value as optional.
+			ec2FleetXML(t, ts, map[string]string{
+				"Action":       "DeleteTags",
+				"ResourceId.1": id,
+				"Tag.1.Key":    "Env",
+			}, nil)
+
+			tags, _ := ec2DescribeTags(t, ts, map[string]string{
+				"Filter.1.Name":    "resource-id",
+				"Filter.1.Value.1": id,
+			})
+			assert.Empty(t, tags, "DeleteTags left the tag on %s", tc.name)
+		})
+	}
+}
+
+// ec2InvalidTagIDMessage is the wording substrate emits for a ResourceId whose prefix
+// names no taggable type, pinned so it cannot drift silently.
+//
+// Provenance is split. The *code* InvalidID is AWS's, from EC2's client-error table —
+// CreateTags' own Errors section publishes nothing operation-specific, pointing only at
+// the common error types — and so is the sentence of guidance: "Ensure that you provide
+// the full resource ID; for example, ami-2bb65342 for an AMI." Naming the offending ID
+// where AWS writes "The specified ID" is substrate's, and is the half a caller who sent a
+// truncated ID actually needs.
+func ec2InvalidTagIDMessage(id string) string {
+	return "The ID '" + id + "' for the resource you are trying to tag is not valid. " +
+		"Ensure that you provide the full resource ID; for example, ami-2bb65342 for an AMI."
+}
+
+// TestEC2_Tags_UnknownResourceIDRefused covers the other half of #708: an ID whose prefix
+// names no taggable type is refused with InvalidID rather than reported as a success.
+//
+// Silent success is the one answer a caller cannot detect. It was substrate's answer for
+// every unrecognized prefix, under a comment claiming it matched AWS — AWS publishes
+// InvalidID for exactly this condition.
+func TestEC2_Tags_UnknownResourceIDRefused(t *testing.T) {
+	for _, id := range []string{
+		"tgw-0abc11112222333d", // a transit gateway: real EC2 tags it, substrate does not model it
+		"not-an-id",
+		"i", // a truncated prefix, which is the mistake AWS's guidance is written for
+	} {
+		for _, action := range []string{"CreateTags", "DeleteTags"} {
+			t.Run(action+" on "+id, func(t *testing.T) {
+				ts := newEC2TestServer(t)
+				status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+					"Action":       action,
+					"ResourceId.1": id,
+					"Tag.1.Key":    "Env",
+					"Tag.1.Value":  "prod",
+				})
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, "InvalidID", code)
+				assert.Equal(t, ec2InvalidTagIDMessage(id), message)
+			})
+		}
+	}
+}
+
+// TestEC2_CreateTags_RefusesBeforeTaggingAnything is why the ID check is a pre-pass over
+// the whole request rather than a refusal inside the apply loop.
+//
+// A request naming a good ID *before* a bad one would otherwise be refused partway
+// through, leaving the resources ahead of the bad ID tagged — the partially-applied state
+// CreateTags' three other whole-request checks (reserved keys, lengths, the 50-tag limit)
+// exist to prevent, and that real EC2 never produces. The instance is named first
+// deliberately: the test fails against an implementation that refuses in the loop.
+func TestEC2_CreateTags_RefusesBeforeTaggingAnything(t *testing.T) {
+	ts := newEC2TestServer(t)
+	instID := ec2TagTestInstance(t, ts)
+
+	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": instID,
+		"ResourceId.2": "tgw-0abc11112222333d",
+		"Tag.1.Key":    "Env",
+		"Tag.1.Value":  "prod",
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Equal(t, "InvalidID", code)
+
+	assert.Equal(t, 0, ec2InstanceTagCount(t, ts, instID),
+		"the instance named before the invalid ID was tagged by a refused request")
+}
+
+// TestEC2_Tags_WellFormedIDNamingNothingIsANoOp pins the third state an ID can be in,
+// which is neither of the two above.
+//
+// A pg- or key- ID is resolved by scanning the namespace for the ID inside each record,
+// so an absent placement group or key pair yields no state key at all — where every other
+// type's key is computed from the ID and simply reads back nothing. That difference must
+// not become a difference in behavior: substrate does not verify a taggable resource's
+// existence for any type, so an ID naming nothing is a no-op, and answering InvalidID
+// here would refuse a request real EC2 accepts.
+func TestEC2_Tags_WellFormedIDNamingNothingIsANoOp(t *testing.T) {
+	for _, id := range []string{
+		"pg-0abc11112222333d4",
+		"key-0abc11112222333d4",
+		"ami-0abc11112222333d4",
+		"lt-0abc11112222333d4",
+		"fleet-12a34b56-7cd8-90ef-1a2b-3c4d5e6f7a8b",
+	} {
+		t.Run(id, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			status, code, message := ec2CreateTags(t, ts, id, map[string]string{
+				"Tag.1.Key":   "Env",
+				"Tag.1.Value": "prod",
+			})
+			assert.Equal(t, http.StatusOK, status, "%s %s", code, message)
+
+			tags, _ := ec2DescribeTags(t, ts, nil)
+			assert.Empty(t, tags, "a no-op wrote a tag somewhere")
+		})
+	}
+}
+
+// ec2RawXML returns the response body for one EC2 request, which is what an assertion
+// about an *absent* element has to read: an unmarshalled struct cannot tell an omitted
+// tagSet from an empty one.
+func ec2RawXML(t *testing.T, ts *httptest.Server, params map[string]string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body = %s", body)
+	return string(body)
+}
+
+// TestEC2_TagOnCreate_KeyPairAndPlacementGroup covers the tag-on-create half of #708 for
+// the two types whose records gained tag storage.
+//
+// Both operations document TagSpecification.N and a tagSet in their responses, and
+// neither read it: EC2KeyPair had no Tags field at all, and nothing ever wrote
+// EC2PlacementGroup.Tags. ImportKeyPair is covered beside CreateKeyPair because the two
+// build the record independently — a fix to one leaves the other silent.
+func TestEC2_TagOnCreate_KeyPairAndPlacementGroup(t *testing.T) {
+	spec := map[string]string{
+		"TagSpecification.1.ResourceType": "", // filled per row
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	}
+
+	t.Run("CreateKeyPair", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		params := map[string]string{}
+		for k, v := range spec {
+			params[k] = v
+		}
+		params["TagSpecification.1.ResourceType"] = "key-pair"
+		id, tags := ec2TagTestKeyPair(t, ts, "tagged-key", params)
+		require.Len(t, tags, 1, "CreateKeyPair reported no tagSet")
+		assert.Equal(t, "Env", tags[0].Key)
+		assert.Equal(t, "prod", tags[0].Value)
+
+		// DescribeKeyPairs reads the stored record rather than the response it just
+		// built, so this is what proves the tag was persisted.
+		var desc struct {
+			KeyPairs []struct {
+				KeyPairID string         `xml:"keyPairId"`
+				Tags      []describedTag `xml:"tagSet>item"`
+			} `xml:"keySet>item"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "DescribeKeyPairs"}, &desc)
+		require.Len(t, desc.KeyPairs, 1)
+		assert.Equal(t, id, desc.KeyPairs[0].KeyPairID)
+		require.Len(t, desc.KeyPairs[0].Tags, 1, "DescribeKeyPairs reported no tagSet")
+		assert.Equal(t, "Env", desc.KeyPairs[0].Tags[0].Key)
+	})
+
+	t.Run("ImportKeyPair", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		var kp struct {
+			KeyPairID string         `xml:"keyPairId"`
+			Tags      []describedTag `xml:"tagSet>item"`
+		}
+		ec2FleetXML(t, ts, map[string]string{
+			"Action":                          "ImportKeyPair",
+			"KeyName":                         "imported-key",
+			"PublicKeyMaterial":               "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIexample",
+			"TagSpecification.1.ResourceType": "key-pair",
+			"TagSpecification.1.Tag.1.Key":    "Env",
+			"TagSpecification.1.Tag.1.Value":  "prod",
+		}, &kp)
+		require.NotEmpty(t, kp.KeyPairID)
+		require.Len(t, kp.Tags, 1, "ImportKeyPair reported no tagSet")
+		assert.Equal(t, "Env", kp.Tags[0].Key)
+	})
+
+	t.Run("CreatePlacementGroup", func(t *testing.T) {
+		ts := newEC2TestServer(t)
+		params := map[string]string{}
+		for k, v := range spec {
+			params[k] = v
+		}
+		params["TagSpecification.1.ResourceType"] = "placement-group"
+		id, tags := ec2TagTestPlacementGroup(t, ts, "tagged-pg", params)
+		require.Len(t, tags, 1, "CreatePlacementGroup reported no tagSet")
+		assert.Equal(t, "Env", tags[0].Key)
+
+		var desc struct {
+			Groups []struct {
+				GroupID string         `xml:"groupId"`
+				Tags    []describedTag `xml:"tagSet>item"`
+			} `xml:"placementGroupSet>item"`
+		}
+		ec2FleetXML(t, ts, map[string]string{"Action": "DescribePlacementGroups"}, &desc)
+		require.Len(t, desc.Groups, 1)
+		assert.Equal(t, id, desc.Groups[0].GroupID)
+		require.Len(t, desc.Groups[0].Tags, 1, "DescribePlacementGroups reported no tagSet")
+		assert.Equal(t, "prod", desc.Groups[0].Tags[0].Value)
+	})
+}
+
+// TestEC2_TagOnCreate_LaunchTemplateOwnTags covers the type whose own tags were settable
+// by no path at all.
+//
+// CreateLaunchTemplate reads a TagSpecification inside LaunchTemplateData, which AWS
+// scopes to the instances and volumes a *launch* from the template creates — a different
+// question from tagging the template. The template's own tags come from a top-level
+// TagSpecification with ResourceType=launch-template, which substrate did not read, while
+// ec2LaunchTemplateSummary had always rendered a tagSet from a field nothing wrote.
+func TestEC2_TagOnCreate_LaunchTemplateOwnTags(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	var created struct {
+		ID   string         `xml:"launchTemplate>launchTemplateId"`
+		Tags []describedTag `xml:"launchTemplate>tagSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":                          "CreateLaunchTemplate",
+		"LaunchTemplateName":              "tagged-lt",
+		"LaunchTemplateData.ImageId":      "ami-0lt00000000000001",
+		"LaunchTemplateData.InstanceType": "t3.micro",
+		"TagSpecification.1.ResourceType": "launch-template",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	}, &created)
+	require.NotEmpty(t, created.ID)
+	require.Len(t, created.Tags, 1, "CreateLaunchTemplate reported no tagSet for its own tags")
+	assert.Equal(t, "Env", created.Tags[0].Key)
+
+	// The tags scoped to a launch stay where they were: a specification naming instance
+	// belongs to LaunchTemplateData and must not become the template's own.
+	var scoped struct {
+		Tags []describedTag `xml:"launchTemplate>tagSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "instance-scoped-lt",
+		"LaunchTemplateData.ImageId": "ami-0lt00000000000002",
+		"LaunchTemplateData.TagSpecification.1.ResourceType": "instance",
+		"LaunchTemplateData.TagSpecification.1.Tag.1.Key":    "Env",
+		"LaunchTemplateData.TagSpecification.1.Tag.1.Value":  "prod",
+	}, &scoped)
+	assert.Empty(t, scoped.Tags,
+		"a TagSpecification scoped to instance tagged the template itself")
+}
+
+// TestEC2_TagOnCreate_NoTagSpecificationOmitsTheElement pins the shape of the answer when
+// no tags were asked for, which is not the same as an empty tagSet.
+//
+// AWS's CreatePlacementGroup Example 2 creates a group with no TagSpecification and its
+// response carries no tagSet element at all, where Example 1 renders one — so the member
+// is omitempty rather than always-present. An SDK tells an absent list from an empty one,
+// and a consumer asserting "this resource has no tags" reads the difference.
+func TestEC2_TagOnCreate_NoTagSpecificationOmitsTheElement(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		params map[string]string
+	}{
+		{
+			name: "CreatePlacementGroup",
+			params: map[string]string{
+				"Action": "CreatePlacementGroup", "GroupName": "bare-pg", "Strategy": "cluster",
+			},
+		},
+		{
+			name:   "CreateKeyPair",
+			params: map[string]string{"Action": "CreateKeyPair", "KeyName": "bare-key"},
+		},
+		{
+			name: "ImportKeyPair",
+			params: map[string]string{
+				"Action": "ImportKeyPair", "KeyName": "bare-import",
+				"PublicKeyMaterial": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIexample",
+			},
+		},
+		{
+			name: "CreateLaunchTemplate",
+			params: map[string]string{
+				"Action": "CreateLaunchTemplate", "LaunchTemplateName": "bare-lt",
+				"LaunchTemplateData.ImageId": "ami-0lt00000000000003",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := newEC2TestServer(t)
+			body := ec2RawXML(t, ts, tc.params)
+			assert.NotContains(t, body, "<tagSet>",
+				"a create carrying no TagSpecification rendered a tagSet element")
+			// And the document still parses, so the omission is an absent element rather
+			// than a malformed one.
+			var doc struct{ XMLName xml.Name }
+			require.NoError(t, xml.Unmarshal([]byte(body), &doc))
+			assert.NotEmpty(t, doc.XMLName.Local)
+		})
+	}
+}

--- a/emulator/ec2_tags_test.go
+++ b/emulator/ec2_tags_test.go
@@ -1093,28 +1093,50 @@ func TestEC2_CreateTags_TagLimitAppliesToEveryTaggableResource(t *testing.T) {
 // TestEC2_CreateTags_UncountedResourceIDs pins that an ID the apply step will not touch
 // is not counted against either.
 //
-// Substrate's CreateTags ignores an ID it cannot resolve rather than rejecting it, so
-// counting one would refuse a request real EC2 accepts as a no-op — turning a
-// silent-success infidelity into a spurious-rejection one. The two rows are the two
-// ways an ID goes unresolved: a prefix substrate does not tag, and a well-formed prefix
-// naming nothing.
+// Substrate's CreateTags ignores a well-formed ID that names nothing rather than
+// rejecting it, so counting one would refuse a request real EC2 accepts as a no-op —
+// turning a silent-success infidelity into a spurious-rejection one. Since #708 that is
+// the *only* way an ID goes unresolved: a prefix naming no taggable type is refused with
+// InvalidID, which the subtest below pins. Until then this test's first row read
+// "a prefix substrate does not tag", id: "ami-0notaggable000001" — a premise #708
+// inverted, since an ami- ID is now taggable, so the row passed for the wrong reason.
+//
+// The rows cover all four resolution shapes, because "names nothing" is reached
+// differently by each: a computed state key that reads back empty (i-, ami-), and the
+// reverse ID→name scan that finds no record at all (pg-, key-), which is the one case
+// [ec2Taggable.resolved] exists for.
 func TestEC2_CreateTags_UncountedResourceIDs(t *testing.T) {
 	tests := []struct {
 		name string
 		id   string
 	}{
-		{name: "a prefix substrate does not tag", id: "ami-0notaggable000001"},
-		{name: "a taggable prefix naming nothing", id: "i-0doesnotexist00001"},
+		{name: "an instance ID naming nothing", id: "i-0doesnotexist00001"},
+		{name: "an image ID naming nothing", id: "ami-0doesnotexist0001"},
+		{name: "a placement group ID naming nothing", id: "pg-0doesnotexist0001"},
+		{name: "a key pair ID naming nothing", id: "key-0doesnotexist001"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ts := newEC2TestServer(t)
-			status, _, _ := ec2CreateTags(t, ts, tc.id, ec2NumberedTags("key", ec2TagLimit+1))
+			status, code, message := ec2CreateTags(t, ts, tc.id, ec2NumberedTags("key", ec2TagLimit+1))
 			assert.Equal(t, http.StatusOK, status,
-				"an ID the apply step ignores must not be counted against")
+				"an ID the apply step ignores must not be counted against: %s %s", code, message)
 		})
 	}
+
+	t.Run("an untaggable prefix is refused before the count", func(t *testing.T) {
+		// A transit gateway: real EC2 tags one, substrate does not model it. The refusal
+		// names InvalidID rather than TagLimitExceeded even though the request carries one
+		// tag too many, which is the ordering [ec2CheckTagResourceIDs] documents — the
+		// whole request is refused before any per-resource count is read.
+		ts := newEC2TestServer(t)
+		status, code, message := ec2CreateTags(t, ts, "tgw-0abc11112222333d",
+			ec2NumberedTags("key", ec2TagLimit+1))
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidID", code)
+		assert.Equal(t, ec2InvalidTagIDMessage("tgw-0abc11112222333d"), message)
+	})
 }
 
 // The tag length limits, restated here because an external test package cannot see

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -200,6 +200,14 @@ type EC2KeyPair struct {
 	// CreatedAt is the RFC3339 timestamp when the key pair was created.
 	CreatedAt string `json:"createdAt,omitempty"`
 
+	// Tags holds key-value metadata tags.
+	//
+	// Spelled "tags" like every other EC2 record's, rather than following this struct's
+	// camelCase members: that is the member [EC2Plugin.applyTagsToResource] and
+	// [EC2Plugin.scanTags] read and write on every type, and a key pair spelling it
+	// differently would be tagged into a member nothing reports (#708).
+	Tags []EC2Tag `json:"tags,omitempty"`
+
 	// AccountID is the AWS account that owns the key pair.
 	AccountID string `json:"accountId"`
 
@@ -613,8 +621,34 @@ func generatePlacementGroupID() string {
 
 // ec2PlacementGroupStateKey returns the state key for a placement group (keyed
 // by name, which is unique per account/region).
+//
+// Keyed by name rather than by ID because that is what every placement-group operation
+// takes: CreatePlacementGroup, DeletePlacementGroup and DescribePlacementGroups all name
+// a GroupName and none accepts a group ID. AWS's ARN for the type is by name too. Only
+// CreateTags names a pg- ID, and it resolves through [ec2NameKeyedResource] rather than
+// changing the key — a rekey would orphan every record an earlier substrate wrote.
 func ec2PlacementGroupStateKey(accountID, region, groupName string) string {
 	return "placement_group:" + accountID + "/" + region + "/" + groupName
+}
+
+// ec2KeyPairStateKey returns the state key for a key pair (keyed by name, which is unique
+// per account/region).
+//
+// The same shape a placement group's key has, for the same reason: KeyName is what
+// CreateKeyPair, ImportKeyPair and DescribeKeyPairs take, and AWS's ARN for the type is
+// arn:${Partition}:ec2:${Region}:${Account}:key-pair/${KeyPairName}. DeleteKeyPair accepts
+// either, and scans for a KeyPairId.
+func ec2KeyPairStateKey(accountID, region, keyName string) string {
+	return "keypair:" + accountID + "/" + region + "/" + keyName
+}
+
+// ec2LaunchTemplateStateKey returns the state key for a launch template.
+//
+// Extracted from six inline copies by #708, which needed a seventh for CreateTags' lt-
+// arm. The name index is a separate key ("lt_by_name:…") holding the ID, so a template is
+// reachable by either and stored once.
+func ec2LaunchTemplateStateKey(accountID, region, launchTemplateID string) string {
+	return "lt:" + accountID + "/" + region + "/" + launchTemplateID
 }
 
 // EC2ElasticIP represents an Amazon EC2 Elastic IP address.


### PR DESCRIPTION
Closes #708

`CreateTags` resolved ten ID prefixes and **silently ignored the rest**. A request naming an `ami-`, `lt-`, `fleet-`, `pg-` or `key-` ID answered `<return>true</return>` and wrote nothing — every one of the five was well-formed and named a resource substrate stores, so the answer was indistinguishable from success. `ec2TaggableResource` now resolves fifteen prefixes, and `ec2TagScanTargets` reports the same fifteen, so `DescribeTags` and `CreateTags` cover exactly the same set. They did not: three types could be read and not written, and `placement-group` and `key-pair` could be neither — both were absent from the scan too.

### Corrections to the issue body

- **"every one names a record that already stores a `tags` member" — false for key-pair.** `EC2KeyPair` had no `Tags` field. Added, spelled `"tags"` like every other record so `applyTagsToResource` and `scanTags` find it.
- **"`DescribeTags` already reports tags on all of them" — false for placement-group and key-pair.** Neither was in `ec2TagScanTargets`, and both are keyed by *name*, so the scan needed `idMember` to read the ID out of the record rather than reporting the key's tail.
- **A launch template's own tags were settable by no path at all.** The `TagSpecification` `createLaunchTemplate` read lives inside `LaunchTemplateData` and is AWS's "tags for the resources that are created when an instance is launched" — a different parameter from the top-level `TagSpecification.N`, "the tags to apply to the launch template on creation. To tag the launch template, the resource type must be `launch-template`". Both are read now, each on its own scope.

### Two things the tests caught

**`xml:"tagSet>item,omitempty"` cannot omit an element.** encoding/xml writes the parent of a nested path even for a nil slice, so every untagged key pair, placement group and launch template answered `<tagSet></tagSet>`. AWS's `CreateLaunchTemplate` Example 1 and `CreatePlacementGroup` Example 2 each create an untagged resource and neither response carries a `tagSet` at all, while `CreateKeyPair`'s tagged example does. Fixed with a pointer-to-wrapper struct — which `ec2_subnet_filters.go` had already discovered for #685, so the two converged on one shared `ec2TagSetXML` rather than shipping the struct twice.

**Refusing inside the apply loop leaves a partially-tagged state.** `ec2CheckTagResourceIDs` runs over every `ResourceId.N` before the first tag is written, so a request naming a good instance ID first and a bad ID second tags neither. `TestEC2_CreateTags_RefusesBeforeTaggingAnything` fails against the refuse-in-the-loop shape.

### Behaviour changes

| Change | Justification |
|---|---|
| An untaggable prefix answers `InvalidID` / 400 instead of `<return>true</return>` | AWS publishes the code and description in the EC2 client-error table |
| Seven responses omit `tagSet` when a resource has no tags | AWS's own untagged examples for those operations |
| `ami-` and `snap-` authorize against an account-less ARN | `arn:${Partition}:ec2:${Region}::image/${ImageId}` is what AWS publishes |

`DescribeFleets` keeps the empty element deliberately: its API reference page publishes **no example response**, so there is no untagged sample to follow and changing it would be substrate guessing rather than reading. `DescribeSnapshots` keeps its present-but-empty element because its own page shows it. Each response answers to the page that documents it.

### Provenance

- `InvalidID`'s code and description are AWS's, but from the **client-error table** — `API_CreateTags.html` publishes no operation-specific error at all. Naming the offending ID where AWS writes "The specified ID" is substrate's.
- Whether real `CreateTags` takes a placement group **by ID or by name is not settled by AWS**. The ARN is by name and `DescribePlacementGroups` publishes no `group-id` filter, but the client-error table publishes `InvalidPlacementGroupId.Malformed` "in the form `pg-xxxxxxxxxxxxxxxxx`", which only an ID-taking operation can raise. Substrate accepts the `pg-` form and translates.

### Verification

`gofmt` / `go build` / `go vet` / `golangci-lint` clean; `make test` green with race; coverage 83.1% on `emulator` (82.4% total); `make docs-reference docs-reference-check docs-versions`; docs site builds with no missing anchors; `test/e2e` green.

The authz-layer suite went from nine resource types to all fifteen. Mutating the ARN builders — stamping the account onto `image`/`snapshot`, and naming the placement group by ID instead of by name — turns exactly those three subtests red, so the new rows bite.

A live AWS CLI run against a built binary confirms the wire shapes: tagged and untagged `CreateKeyPair`/`CreatePlacementGroup`/`CreateLaunchTemplate` (untagged decode to `Tags: null`, tagged to the tags), `CreateTags` over all five new types followed by `DescribeTags` reporting each under the right `resourceType` and the ID the caller passed, the `InvalidID` refusal, and `DeleteTags` clearing them again.