### PR TITLE
feat(ec2): a filter spec per never-parsed describe (#695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   publishes `InvalidPlacementGroupId.Malformed` "in the form `pg-xxxxxxxxxxxxxxxxx`", which
   only an ID-taking operation can raise. Substrate accepts the `pg-` form and translates.
 
+- **Twelve more EC2 describes read `Filter.N`, so twenty-three of twenty-four now do** (#695).
+  Each of the twelve declared a `Filters` parameter on its reference page and never parsed one:
+  `DescribeInstanceStatus`, `DescribeVpcs`, `DescribeInternetGateways`, `DescribeKeyPairs`,
+  `DescribeAvailabilityZones`, `DescribePlacementGroups`, `DescribeAddresses`,
+  `DescribeRegions`, `DescribeInstanceTypes`, `DescribeSpotPriceHistory`,
+  `DescribeLaunchTemplates` and `DescribeLaunchTemplateVersions`. A filter reached the handler
+  and was discarded, so a request for one VPC by `cidr` got every VPC in the account — the
+  silent-widening half of the failure #685 and #688 fixed for subnets and tags. That is now
+  every EC2 describe substrate serves but one: `DescribeInstanceAttribute`, whose page
+  documents no `Filters` parameter at all.
+
+  Three of the twelve evaluate **every** name their page documents —
+  `DescribeInternetGateways` (6 of 6), `DescribeRegions` (3 of 3) and `DescribeLaunchTemplates`
+  (4 of 4). The rest evaluate what substrate's records can answer and accept the remainder as
+  inert, each inert name listed per operation in `docs/services.md` rather than left for a
+  caller to find by getting a wrong answer. An **undocumented** name is refused with
+  `InvalidParameterValue`, the rule #687 established. That evaluated/inert split is what closed
+  `TODO(#495)` on `DescribeInstanceTypes`: the objection to applying five of fifty-seven
+  filters was never the five, it was that dropping the fifty-two *silently* is
+  indistinguishable from applying them.
+
+  Eight of the twelve document no tag filter, which is why the choice is per operation and not
+  a package-wide assumption — `DescribeLaunchTemplates` documents both `tag:<key>` and
+  `tag-key` while `DescribeLaunchTemplateVersions`, on the same page family, documents neither.
+
+  Provenance: **AWS documents no rule for a paired identity list**, and five operations take
+  one — `KeyName.N`/`KeyPairId.N`, `ZoneName.N`/`ZoneId.N`, `GroupName.N`/`GroupId.N`,
+  `AllocationId.N`/`PublicIp.N` and `LaunchTemplateId.N`/`LaunchTemplateName.N`. Substrate
+  reads them as a **union**, not an intersection: naming one key by name and a second by ID
+  returns both. The reading comes from what AWS does document — an unresolvable name or ID
+  answers `NotFound` rather than an empty set, which only makes sense if every identifier named
+  is expected to appear in the response, and an intersection would answer nothing for two
+  identifiers that each resolve.
+
 - **EC2's documented filter limits, enforced in one place** (#697). Using_Filtering publishes
   three: "You can specify up to 50 filters and up to 200 total filter values in a single
   request" and "Filter strings can be up to 255 characters in length." All three are now
@@ -75,6 +109,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the old shape deliberately: its reference page publishes no example response, so there is no
   untagged sample to follow and changing it would be a guess. `DescribeSnapshots` keeps its
   present-but-empty element because its own page shows it.
+
+- **`DescribeVpcs` and `CreateVpc` name the VPC's state element `state`, not `vpcState`**
+  (#695). A wire fix: both of AWS's sample responses render `<state>available</state>`, and
+  substrate had emitted `<vpcState>` since the operation was written. A consumer reading the
+  element by name — a raw XML or CloudFormation-style parser, not an SDK, which maps by the
+  model — saw an empty state. The two renderers also converged: `CreateVpc` and `DescribeVpcs`
+  had separate structs that had drifted, and `CreateInternetGateway`/`DescribeInternetGateways`
+  had the same split, so each pair now emits one shape by construction. Found by writing the
+  filter matcher, which had to select on a field the create path did not publish.
+
+- **Seven EC2 response members appear where they were absent** (#695), each because a filter
+  now selects on it and a caller who cannot read the value cannot check the filter's answer:
+  `ownerId` and `tagSet` on a VPC, `ownerId`, `attachmentSet` and `tagSet` on an internet
+  gateway, `groupArn` on a placement group, `tagSet` on an address, and `availabilityZone` on
+  an instance status. Additive — nothing is renamed or removed apart from the `vpcState` fix
+  above — but a consumer asserting on an exact response body will see the new elements.
+
+  The empty-value convention **follows each operation's own page rather than a house style**:
+  an unattached, untagged internet gateway renders `<attachmentSet/>` and `<tagSet/>` because
+  its reference sample does, while an untagged VPC or address omits `tagSet` entirely because
+  theirs do. That is deliberately inconsistent across operations and consistent with AWS.
+
+- **`DescribeLaunchTemplateVersions` filters before it paginates** (#695), so a page carries
+  `MaxResults` *matching* versions rather than `MaxResults` versions of which some match.
+  Paginating first is the defect that makes a filtered query look empty while `nextToken` is
+  still set — the same ordering every other paginated EC2 describe uses.
 
 - **Eighteen mutating EC2 operations answer their `Invalid*.NotFound` from the kind table, not
   from a hand-written literal** (#713). `ec2_resourceid.go`'s `ec2IDKind` table has been the
@@ -223,6 +283,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resource's `NotFound` — so a caller was told their route table did not exist when the read
   had failed, and the actual error was discarded, which the house rules forbid outright. Each
   now wraps with `fmt.Errorf("…: %w", err)` and checks existence separately.
+
+- **Three indexed EC2 list parameters were read at index 1 only** (#695).
+  `DescribeLaunchTemplates` consulted `LaunchTemplateId.1` and `LaunchTemplateName.1`, and
+  `DescribeSpotPriceHistory` consulted `ProductDescription.1`, so a caller naming three
+  templates was answered about one and every later element was dropped without a word. Each now
+  walks every index, and the union rule above governs the two launch-template lists. This is the
+  same defect class as the `Filter.N` walks themselves: a parameter accepted, partly read, and
+  answered as though it had been honoured.
 
 - **EC2 filter values honour AWS's wildcards on every describe, not on the two that happened
   to have them** (#697). AWS states the rule once for the whole family — "An asterisk (\*)

--- a/docs/services.md
+++ b/docs/services.md
@@ -2754,11 +2754,11 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | TerminateInstances | [Explicit resource IDs](#explicit-resource-ids); [honours termination protection, per Availability Zone](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
 | StartInstances | [Explicit resource IDs](#explicit-resource-ids) |
-| DescribeInstanceStatus | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeInstanceStatus | [Explicit resource IDs](#explicit-resource-ids); three of eighteen filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); reports `availabilityZone` |
 | DescribeInstanceAttribute | Five attributes, scalars `<value>`-wrapped — see [Instance attributes](#instance-attributes) |
 | ModifyInstanceAttribute | `InstanceType.Value`, `UserData.Value`, `DisableApiTermination.Value`; the first two [require a stopped instance](#instance-attributes) |
-| CreateVpc | |
-| DescribeVpcs | [Explicit resource IDs](#explicit-resource-ids) |
+| CreateVpc | Renders the same VPC `DescribeVpcs` does, `ownerId` and `tagSet` included — see [Twelve describes gained filters](#twelve-describes-gained-filters) |
+| DescribeVpcs | [Explicit resource IDs](#explicit-resource-ids); six of fifteen filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); reports `state`, `ownerId` and `tagSet` |
 | DeleteVpc | [Explicit resource IDs](#explicit-resource-ids) |
 | CreateSubnet | `TagSpecification.N` scoped to `subnet`, and it renders the same subnet `DescribeSubnets` does — see [A subnet reports its tags, and filters on them](#a-subnet-reports-its-tags-and-filters-on-them) |
 | DescribeSubnets | [Explicit resource IDs](#explicit-resource-ids); fourteen filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); [reports `tagSet`, `subnetArn`, `ownerId` and `defaultForAz`](#a-subnet-reports-its-tags-and-filters-on-them) |
@@ -2770,29 +2770,29 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | AuthorizeSecurityGroupEgress | Supports destination security groups |
 | RevokeSecurityGroupIngress | Matches on protocol, ports, **and** source |
 | RevokeSecurityGroupEgress | |
-| CreateInternetGateway | |
+| CreateInternetGateway | Renders the same gateway `DescribeInternetGateways` does — see [Twelve describes gained filters](#twelve-describes-gained-filters) |
 | AttachInternetGateway | |
-| DescribeInternetGateways | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeInternetGateways | [Explicit resource IDs](#explicit-resource-ids); **all six** filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); reports `ownerId`, `attachmentSet` and `tagSet` |
 | DeleteInternetGateway | [Explicit resource IDs](#explicit-resource-ids) |
-| DescribeAvailabilityZones | Three zones per region, from the same list the offerings and spot-price operations use — see [Instance types are a seeded catalog](#instance-types-are-a-seeded-catalog) |
-| DescribeRegions | |
-| DescribeInstanceTypes | Answers from a [seeded catalog](#instance-types-are-a-seeded-catalog). `InstanceType.N` is an assertion: a type outside the catalog is refused with `InvalidInstanceType`. `Filter.N` is not applied |
+| DescribeAvailabilityZones | Three zones per region, from the same list the offerings and spot-price operations use — see [Instance types are a seeded catalog](#instance-types-are-a-seeded-catalog). `ZoneName.N`, `ZoneId.N`, and four of eleven filters |
+| DescribeRegions | **All three** filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name). `AllRegions` is accepted and inert — every seeded region is `opt-in-not-required`, so it is already in the answer |
+| DescribeInstanceTypes | Answers from a [seeded catalog](#instance-types-are-a-seeded-catalog). `InstanceType.N` is an assertion: a type outside the catalog is refused with `InvalidInstanceType`. Five of fifty-seven filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | DescribeInstanceTypeOfferings | `instance-type` and `location` filters (both with [wildcards](#wildcards-in-filter-values)) and the `LocationType` parameter; an unmatched filter is an empty answer, not an error |
-| DescribeSpotPriceHistory | One stub price per catalog type per zone. `InstanceType.N` here is a *filter*, so an unknown type is an empty history — [see below](#instance-types-are-a-seeded-catalog) |
+| DescribeSpotPriceHistory | One stub price per catalog type per zone. `InstanceType.N` here is a *filter*, so an unknown type is an empty history — [see below](#instance-types-are-a-seeded-catalog). `ProductDescription.N` is read at every index, and five of six filters |
 | CreateRouteTable | |
 | AssociateRouteTable | |
 | DescribeRouteTables | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | DeleteRouteTable | [Explicit resource IDs](#explicit-resource-ids) |
 | CreateSnapshot | `VolumeId` is required and checked; `volumeSize` and `encrypted` come from the source volume, and `status` is `completed` at once — see [A snapshot has a real size](#a-snapshot-has-a-real-size) |
 | DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids); ten filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); `Owner.N` and `RestorableBy.N` — see [A snapshot filters on its own members](#a-snapshot-filters-on-its-own-members-and-scopes-by-account) |
-| DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids) |
+| DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids); `AllocationId.N` and `PublicIp.N` [union](#twelve-describes-gained-filters); eight of ten filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); reports `tagSet` |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | CreateLaunchTemplate | Creates version 1. Networking is read from every `NetworkInterface.N.*` — see [Launch template networking](#launch-template-networking). The top-level `TagSpecification.N` scoped to `launch-template` tags the template itself, separately from `LaunchTemplateData`'s, which tags what a launch creates |
-| DescribeLaunchTemplates | Summary only — no `launchTemplateData`, matching AWS. Use `DescribeLaunchTemplateVersions` to read a template's parameters |
+| DescribeLaunchTemplates | Summary only — no `launchTemplateData`, matching AWS. Use `DescribeLaunchTemplateVersions` to read a template's parameters. **All four** filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); `LaunchTemplateId.N` and `LaunchTemplateName.N` are read at every index and [union](#twelve-describes-gained-filters) |
 | DeleteLaunchTemplate | |
 | CreateLaunchTemplateVersion | `SourceVersion` inheritance — see [Launch template versions](#launch-template-versions) |
 | ModifyLaunchTemplate | `SetDefaultVersion` only, which is AWS's only modifiable attribute |
-| DescribeLaunchTemplateVersions | Numbers, `$Latest`, `$Default`, `MinVersion`/`MaxVersion`, `MaxResults`/`NextToken`, and the account-wide form |
+| DescribeLaunchTemplateVersions | Numbers, `$Latest`, `$Default`, `MinVersion`/`MaxVersion`, `MaxResults`/`NextToken`, and the account-wide form. Four of fourteen filters, applied **before** pagination, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name) before the template is resolved |
 | DeleteLaunchTemplateVersions | Reports per version at HTTP 200; the default version cannot be deleted |
 | CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS; [filter names are checked](#one-rule-for-an-unrecognized-filter-name), and it documents **no tag filter** |
@@ -2812,9 +2812,17 @@ way.
 This replaced three different answers across substrate's filter-parsing EC2 operations —
 dropped on volumes, snapshots, security groups, route tables, NAT gateways, fleets and
 images; matched nothing on instances; refused on instance-type offerings — with the one
-real EC2 gives. `DescribeSubnets` and `DescribeTags` are the tenth and eleventh operations
-the rule covers, and the only two that arrived with both halves at once: the first parsed no
+real EC2 gives. `DescribeSubnets` and `DescribeTags` were the tenth and eleventh operations
+the rule covered, and the only two that arrived with both halves at once: the first parsed no
 `Filter.N` at all before it gained the filters below, and the second did not exist.
+
+[#695](https://github.com/scttfrdmn/substrate/issues/695) then brought **twelve more the same
+way** — every EC2 describe that had never parsed `Filter.N` at all — so the rule now covers
+**twenty-three operations**. That is every EC2 describe substrate serves but one:
+`DescribeInstanceAttribute`, whose reference page documents no `Filters` parameter, so there is
+no set to check a name against. See
+[Twelve describes gained filters](#twelve-describes-gained-filters) for what changed besides
+the filters.
 
 **This is a behaviour change, and the loudest one in the release that brought it.** A
 misspelled filter name previously came back as a successful response: dropped, so the query
@@ -2865,23 +2873,44 @@ one is refused on its neighbour — `tag:<key>` most conspicuously (see below).
 | DescribeFleets | `activity-status`, `fleet-state`, `type` | `excess-capacity-termination-policy`, `replace-unhealthy-instances` |
 | DescribeInstanceTypeOfferings | `instance-type`, `location` (both with [wildcards](#wildcards-in-filter-values)) | — |
 | DescribeTags | `key`, `resource-id`, `resource-type`, `value`, `tag:<key>` — all five AWS documents, all with [wildcards](#wildcards-in-filter-values) | — |
+| DescribeInstanceStatus | `availability-zone`, `instance-state-code`, `instance-state-name` | the other fifteen — the `event.*`, `system-status.*`, `instance-status.*` and `operator.*` families, plus `application-status.status`, `attached-ebs-status.status` and `availability-zone-id` |
+| DescribeVpcs | `cidr`, `is-default`, `owner-id`, `state`, `tag-key`, `tag:<key>` | `dhcp-options-id`, and the eight `cidr-block-association.*`/`ipv6-cidr-block-association.*` filters |
+| DescribeInternetGateways | `attachment.state`, `attachment.vpc-id`, `internet-gateway-id`, `owner-id`, `tag-key`, `tag:<key>` — **all six** | — |
+| DescribeKeyPairs | `fingerprint`, `key-name`, `key-pair-id`, `tag-key`, `tag:<key>` — **all five** | — |
+| DescribeAvailabilityZones | `region-name`, `state`, `zone-id`, `zone-name` | `group-long-name`, `group-name`, `message`, `opt-in-status`, `parent-zone-id`, `parent-zone-name`, `zone-type` |
+| DescribePlacementGroups | `group-arn`, `group-name`, `state`, `strategy`, `tag-key`, `tag:<key>` | `spread-level` |
+| DescribeAddresses | `allocation-id`, `association-id`, `instance-id`, `network-interface-id`, `private-ip-address`, `public-ip`, `tag-key`, `tag:<key>` | `network-border-group`, `network-interface-owner-id` |
+| DescribeRegions | `endpoint`, `opt-in-status`, `region-name` — **all three** | — |
+| DescribeInstanceTypes | `instance-type`, `memory-info.size-in-mib`, `processor-info.supported-architecture`, `supported-usage-class`, `vcpu-info.default-vcpus` | the other fifty-two — the `ebs-info.*`, `network-info.*`, `instance-storage-info.*`, `nitro-tpm-info.*`, `vcpu-info.*` (bar `default-vcpus`) and `processor-info.*` (bar `supported-architecture`) families, plus `auto-recovery-supported`, `bare-metal`, `burstable-performance-supported`, `current-generation`, `dedicated-hosts-supported`, `free-tier-eligible`, `hibernation-supported`, `hypervisor`, `instance-storage-supported`, `nitro-enclaves-support`, `nitro-tpm-support`, `reboot-migration-support`, `supported-boot-mode`, `supported-root-device-type` and `supported-virtualization-type` |
+| DescribeSpotPriceHistory | `availability-zone`, `instance-type`, `product-description`, `spot-price`, `timestamp` | `availability-zone-id` |
+| DescribeLaunchTemplates | `create-time`, `launch-template-name`, `tag-key`, `tag:<key>` — **all four** | — |
+| DescribeLaunchTemplateVersions | `create-time`, `image-id`, `instance-type`, `is-default-version` | `host-resource-group-arn`, `iam-instance-profile`, `kernel-id`, `license-configuration-arn`, `network-card-index`, `ram-disk-id`, and the four `ebs-optimized`/`http-*` metadata filters |
 
-`tag:<key>` is refused on **`DescribeFleets` and `DescribeInstanceTypeOfferings`**, which
-document no tag filter at all — neither `tag:<key>` nor `tag-key` — even though a fleet
-carries tags and `DescribeFleets` renders them. That is AWS's set, not an omission here; to
-find a fleet by tag, use `DescribeTags` or Resource Groups Tagging.
+`tag:<key>` is refused on **eight operations that document no tag filter at all** — neither
+`tag:<key>` nor `tag-key`: `DescribeFleets`, `DescribeInstanceTypeOfferings`,
+`DescribeInstanceStatus`, `DescribeAvailabilityZones`, `DescribeRegions`,
+`DescribeInstanceTypes`, `DescribeSpotPriceHistory` and `DescribeLaunchTemplateVersions`. Some
+of those describe resources that plainly carry tags — a fleet carries tags and
+`DescribeFleets` renders them, and `DescribeLaunchTemplates` documents both tag filters while
+`DescribeLaunchTemplateVersions`, next to it in the same family, documents neither. That is
+AWS's set, not an omission here; to find such a resource by tag, use `DescribeTags` or Resource
+Groups Tagging.
 
 `tag-key` runs the other way: every tag-bearing describe documents it **except
 `DescribeTags`**, which has no such filter because its `key` filter already asks that
 question. So `tag-key` is refused there and accepted on its neighbours — again AWS's set.
 
-Read the tag rows in the other direction and the describe filters remain the narrowest of
-the three routes: **`DescribeInstances`, `DescribeVolumes`, `DescribeImages`,
-`DescribeSnapshots` and `DescribeSubnets`** filter on tags; on security groups, route tables
-and NAT gateways a `tag:<key>` filter is accepted and inert, so "find the security groups
-tagged `Env=prod`" answers with *all* of them. Real EC2 offers three routes to finding a
-resource by tag: the describe filters, `DescribeTags`, and Resource Groups Tagging.
-Substrate now serves all three — the first on five operations, and the other two in full.
+Read the tag rows in the other direction and **ten** describes filter on tags:
+`DescribeInstances`, `DescribeVolumes`, `DescribeImages`, `DescribeSnapshots`,
+`DescribeSubnets`, `DescribeVpcs`, `DescribeInternetGateways`, `DescribeKeyPairs`,
+`DescribePlacementGroups` and `DescribeAddresses` — the last five since
+[#695](https://github.com/scttfrdmn/substrate/issues/695), and the two of those
+[#708](https://github.com/scttfrdmn/substrate/issues/708) had to give tag storage to first.
+On security groups, route tables and NAT gateways a `tag:<key>` filter is accepted and inert,
+so "find the security groups tagged `Env=prod`" answers with *all* of them. Real EC2 offers
+three routes to finding a resource by tag: the describe filters, `DescribeTags`, and Resource
+Groups Tagging. Substrate serves all three — the first on ten operations, and the other two in
+full.
 
 #### Filter semantics that apply everywhere
 
@@ -2941,10 +2970,11 @@ way: `?ebserver` finding `webserver` or `Webserver` is consistent with both read
 the string a zero-or-one `?` would additionally match is not in AWS's data set.
 
 Two comparisons deliberately stay exact, because they are not filter values. **Identifier
-parameters** — `KeyName.N`, `GroupName.N`, `FleetId.N`, `RegionName.N`, `InstanceType.N` —
-assert the resource exists and answer `Invalid*.NotFound` when it does not, so globbing them
-would turn a NotFound contract into a match. And **filter names**, which are one of a fixed
-documented set.
+parameters** — `KeyName.N`, `KeyPairId.N`, `GroupName.N`, `GroupId.N`, `ZoneName.N`, `ZoneId.N`,
+`AllocationId.N`, `PublicIp.N`, `LaunchTemplateId.N`, `LaunchTemplateName.N`, `FleetId.N`,
+`RegionName.N`, `InstanceType.N` — assert the resource exists and answer `Invalid*.NotFound`
+when it does not, so globbing them would turn a NotFound contract into a match. And **filter
+names**, which are one of a fixed documented set.
 
 A filter whose *values* happen to be identifiers is still a filter: `DescribeRouteTables`'
 `association.subnet-id`, `DescribeSubnets`' `vpc-id`, `DescribeSnapshots`' `volume-id` and the
@@ -2955,11 +2985,101 @@ One case-*insensitive* comparison was removed:
 `attachment.delete-on-termination` on `DescribeVolumes` accepted `True` for `true`, which AWS's
 "Filter values are case sensitive" does not, and which no sibling boolean filter did.
 
-**One gap, deliberately left standing**, because closing it would newly change requests that
-succeed today: twelve EC2 describes — including `DescribeVpcs`, `DescribeAddresses`,
-`DescribeInstanceTypes` and `DescribeAvailabilityZones` — never parse `Filter.N` at all, so
-they neither apply nor refuse one
-([#695](https://github.com/scttfrdmn/substrate/issues/695)).
+#### Twelve describes gained filters
+
+Until [#695](https://github.com/scttfrdmn/substrate/issues/695), twelve EC2 describes never
+parsed `Filter.N` at all: the parameter reached the handler and was discarded, so a filtered
+request was answered with **every resource in the region** and nothing in the response said the
+filter had been dropped. That was the same defect
+[#685](https://github.com/scttfrdmn/substrate/issues/685) fixed for `DescribeSubnets`, twelve
+times over, and it is the most consequential kind of silence in an emulator: a consumer's test
+asserting "the query returns only the tagged VPC" passed while the query was never applied.
+
+All twelve now carry a filter spec, so each one applies what it can answer, accepts the
+documented names it cannot, and refuses the rest — see the table above for the split per
+operation. What follows is everything else that had to change to make those filters *readable*,
+plus the gaps left standing.
+
+**Response members were added, because a filter you cannot read back is not usable.** Filtering
+on a value the response never renders leaves a caller unable to tell a correct answer from a
+wrong one. Six members are new:
+
+| Operation | New in the response |
+|---|---|
+| `DescribeVpcs`, `CreateVpc` | `ownerId`, `tagSet`, and `state` **renamed** from `vpcState` |
+| `DescribeInternetGateways`, `CreateInternetGateway` | `ownerId`, `attachmentSet`, `tagSet` |
+| `DescribePlacementGroups` | `groupArn` |
+| `DescribeAddresses` | `tagSet` |
+| `DescribeInstanceStatus` | `availabilityZone` |
+
+The `vpcState` → `state` rename is a **wire fix**: AWS's own samples for both `CreateVpc` and
+`DescribeVpcs` render `<state>available</state>`, so an SDK caller decoded an empty `State` from
+a VPC that was in fact available — and could not distinguish that from a VPC whose state
+substrate had failed to set. Nothing in substrate pinned the old spelling.
+
+`CreateVpc` and `CreateInternetGateway` now render through the same code as their describes, so
+the two responses cannot drift — the reason `DescribeSubnets` shares a renderer with
+`CreateSubnet`.
+
+**An empty `tagSet` follows the operation's own page, not a house rule.**
+`DescribeInternetGateways` renders a present-but-empty `<tagSet/>` and `<attachmentSet/>` on an
+unattached, untagged gateway, because its AWS sample does. `DescribeVpcs` and
+`DescribeAddresses` **omit** an empty `tagSet`, because theirs do. The inconsistency is AWS's,
+and reproducing it per page is the point: a sweep "for consistency" would break one of them
+against its own reference.
+
+**Paired identity parameters union rather than intersect.** Five operations take two lists that
+name the same resource two ways — `KeyName.N`+`KeyPairId.N`, `ZoneName.N`+`ZoneId.N`,
+`GroupName.N`+`GroupId.N`, `AllocationId.N`+`PublicIp.N`, and
+`LaunchTemplateId.N`+`LaunchTemplateName.N`. A request carrying both is answered with the
+resources named by **either**:
+
+```
+DescribeKeyPairs&KeyPairId.1=key-0abc…&KeyName.1=deploy   → both key pairs
+```
+
+*This reading is substrate's* — AWS documents no rule for the combination. It follows from what
+AWS *does* document: an unresolvable name or ID in either list is a `NotFound` error, which only
+makes sense if every resource named is expected in the answer. Intersecting would answer empty
+while reporting both lists resolved.
+
+Two of those lists were also **read only at index 1** before #695 —
+`DescribeLaunchTemplates`' `LaunchTemplateId`/`LaunchTemplateName`, and
+`DescribeSpotPriceHistory`' `ProductDescription` — so a caller naming three templates was
+answered about one, indistinguishable from the other two not existing. All indices are read now.
+Naming one resource in both lists still returns it once.
+
+**Filters apply before pagination** on `DescribeLaunchTemplateVersions`, the only one of the
+twelve that paginates. A page holds `MaxResults` *matching* versions; filtering after paging
+would answer `MaxResults=1` with an empty page and a `nextToken`, which reads as "nothing
+matches" to a caller that does not follow the token. Its filter names are also checked **before**
+the template is resolved, so a typo answers `InvalidParameterValue` rather than
+`InvalidLaunchTemplateId.NotFound`.
+
+**Gaps left standing**, each deliberate:
+
+- **No pagination was added.** `DescribeAddresses`, `DescribeKeyPairs`,
+  `DescribeAvailabilityZones` and `DescribePlacementGroups` document **no** `MaxResults` or
+  `NextToken` at all, so there is nothing to add. `DescribeInstanceStatus`, `DescribeVpcs`,
+  `DescribeInternetGateways`, `DescribeInstanceTypes`, `DescribeSpotPriceHistory` and
+  `DescribeLaunchTemplates` document both and still answer in one page.
+- **`IncludeAllInstances` is not read** on `DescribeInstanceStatus`. AWS defaults it to `false`,
+  meaning "running instances only"; substrate reports every instance whatever its state, so a
+  caller relying on the default to exclude stopped instances gets them. Filter on
+  `instance-state-name` instead, which is evaluated.
+- **`AllRegions` is inert** on `DescribeRegions`, and harmlessly so: every seeded region is
+  `opt-in-not-required`, so the opt-in filtering the parameter controls has nothing to exclude.
+- **`IncludeUnsupportedInRegion` is not read** on `DescribeInstanceTypes`; the seeded catalog is
+  the same in every region.
+- **Six of the new selectors answer an empty set where AWS answers `NotFound`.** `KeyName.N` and
+  `KeyPairId.N` (AWS: `InvalidKeyPair.NotFound`), `GroupName.N` and `GroupId.N` on
+  `DescribePlacementGroups` (`InvalidPlacementGroup.Unknown`), `ZoneName.N`/`ZoneId.N`, and
+  `PublicIp.N` all select by membership rather than through an
+  [ID assertion](#explicit-resource-ids), because no `ec2IDKind` is registered for those
+  resources — so naming one that does not exist narrows the answer to nothing instead of
+  failing. Within the twelve, `InstanceId.N`, `VpcId.N`, `InternetGatewayId.N`,
+  `AllocationId.N` and `DescribeLaunchTemplateVersions`' template selector **do** assert
+  existence, as does `DescribeInstanceTypes`' `InstanceType.N` (`InvalidInstanceType`).
 
 ### RunInstances requires a resolvable AMI
 
@@ -4141,11 +4261,20 @@ One bad type fails the whole request; the known types are not returned. The
 message is verbatim from a real `us-east-1` capture for the single-type case; the
 `", "` separator for a list is substrate's choice, so dispatch on the code.
 
-`DescribeInstanceTypes` ignores `Filter.N` entirely. The operation documents some
-60 filter names, nearly all over response fields the seeded catalog does not carry,
-and applying the handful that are answerable while silently dropping the rest is
-the same defect as an ignored filter. Tracked in
-[#495](https://github.com/scttfrdmn/substrate/issues/495).
+`DescribeInstanceTypes` applies **five** of the fifty-seven filter names its reference
+documents — `instance-type`, `memory-info.size-in-mib`,
+`processor-info.supported-architecture`, `supported-usage-class` and
+`vcpu-info.default-vcpus`. The other fifty-two are over response fields the seeded catalog does
+not carry, so they are accepted and inert, and an undocumented name is refused. That split is
+what closed [#495](https://github.com/scttfrdmn/substrate/issues/495)'s filter half: the concern
+was never that the answerable handful should go unapplied, but that dropping the rest
+*silently* is indistinguishable from applying them — which the
+[evaluated/inert table](#what-is-refused-and-what-is-merely-inert) resolves by naming every
+inert one.
+
+The numeric filters compare as **strings**, because AWS supports no
+greater-than or less-than in a filter value: `memory-info.size-in-mib=4096` selects the types
+with exactly that much memory, and `4097` selects none rather than "more than 4096".
 
 #### Offerings filters and wildcards
 

--- a/emulator/ec2_describe_filters.go
+++ b/emulator/ec2_describe_filters.go
@@ -1,0 +1,556 @@
+package emulator
+
+import (
+	"strconv"
+	"strings"
+)
+
+// The filter matchers for the twelve describes that parsed no Filter.N before #695.
+//
+// Each answers one operation, and each is reached only after that operation's
+// [ec2FilterSpec] has refused every name AWS does not document — so a name arriving here is
+// either evaluated below or documented-but-inert, and the `default: return true` arm is the
+// second of those two cases rather than a hole. That split is [ec2FilterSpec]'s whole
+// purpose; see [ec2SubnetMatchesFilter] for the precedent this batch follows.
+//
+// Filters AND with each other and each one's values OR, AWS's documented rule, and every
+// value comparison goes through [ec2FilterAccepts] so wildcards work everywhere (#697).
+
+// ec2TagFilterMatch evaluates the two tag filter forms — tag:<key> and tag-key — against a
+// resource's tags, reporting in its second result whether name was one of them.
+//
+// Comma-ok shaped so a matcher writes one guard above its own switch instead of two cases
+// inside it, which is what the six tag-bearing operations in this batch would otherwise
+// repeat twelve times between them. The five matchers that predate #695 inline the same two
+// blocks; they are left alone here because converting them would be a behavior-neutral edit
+// to working code in a change that already touches twelve operations.
+//
+// A tag: filter compares the *key* exactly and the *value* through [ec2FilterAccepts]: the
+// key is part of the filter name, and a filter name is never a pattern — AWS's wildcard rule
+// is about values. tag-key compares the key through [ec2FilterAccepts] because there the key
+// *is* the value.
+func ec2TagFilterMatch(tags []EC2Tag, name string, values []string) (bool, bool) {
+	if key, ok := strings.CutPrefix(name, "tag:"); ok {
+		for _, t := range tags {
+			if t.Key == key && ec2FilterAccepts(values, t.Value) {
+				return true, true
+			}
+		}
+		return false, true
+	}
+	if name != "tag-key" {
+		return false, false
+	}
+	for _, t := range tags {
+		if ec2FilterAccepts(values, t.Key) {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+// ec2SelectedByEither reports whether a resource is named by two identity selectors, given
+// each selector's requested list and this resource's value for it. With neither list supplied
+// every resource is selected.
+//
+// The two lists are **unioned**, not intersected, because they are two spellings of the same
+// question — DescribeKeyPairs' KeyName.N and KeyPairId.N, DescribeAvailabilityZones' ZoneName.N
+// and ZoneId.N, DescribePlacementGroups' GroupName.N and GroupId.N. AWS answers NotFound for a
+// name or ID it cannot resolve, which only makes sense if every one a request names is expected
+// in the response; intersecting would answer with the empty set while both named resources
+// exist. AWS documents no rule for the combination, so this is substrate's reading, recorded
+// here.
+//
+// Membership is exact, never a glob: these are identity lists, and #697 deliberately left them
+// out of the wildcard change so that a mistyped ID stays a mistyped ID rather than becoming a
+// pattern that matches nothing silently.
+func ec2SelectedByEither(listA []string, valueA string, listB []string, valueB string) bool {
+	if len(listA) == 0 && len(listB) == 0 {
+		return true
+	}
+	return (len(listA) > 0 && containsStr(listA, valueA)) || (len(listB) > 0 && containsStr(listB, valueB))
+}
+
+// ec2VPCMatchesFilters reports whether a VPC satisfies every supplied DescribeVpcs filter.
+func ec2VPCMatchesFilters(vpc EC2VPC, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2VPCMatchesFilter(vpc, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2VPCMatchesFilter evaluates a single DescribeVpcs filter against a VPC.
+//
+// See [ec2VPCFilterSpec] for which of AWS's fifteen names are inert and why.
+func ec2VPCMatchesFilter(vpc EC2VPC, name string, values []string) bool {
+	if matched, isTag := ec2TagFilterMatch(vpc.Tags, name, values); isTag {
+		return matched
+	}
+	switch name {
+	case "cidr":
+		// AWS: "The primary IPv4 CIDR block of the VPC. The CIDR block you specify must
+		// exactly match the VPC's CIDR block for information to be returned for the VPC."
+		// Equality against the primary block, not containment — the same reading
+		// [ec2SubnetMatchesFilter] records for the subnet cidr filter, and the reason the
+		// cidr-block-association family is a separate set of names rather than an alias.
+		return ec2FilterAccepts(values, vpc.CIDRBlock)
+	case "is-default":
+		return ec2FilterAccepts(values, strconv.FormatBool(vpc.IsDefault))
+	case "owner-id":
+		return ec2FilterAccepts(values, vpc.AccountID)
+	case "state":
+		return ec2FilterAccepts(values, vpc.State)
+	case "vpc-id":
+		return ec2FilterAccepts(values, vpc.VPCID)
+	default:
+		return true
+	}
+}
+
+// ec2InternetGatewayMatchesFilters reports whether an internet gateway satisfies every
+// supplied DescribeInternetGateways filter.
+func ec2InternetGatewayMatchesFilters(igw EC2InternetGateway, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2InternetGatewayMatchesFilter(igw, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2InternetGatewayMatchesFilter evaluates a single DescribeInternetGateways filter.
+//
+// There is no inert arm to explain: all six documented names are evaluated. The default arm
+// is unreachable through the plugin — [ec2InternetGatewayFilterSpec] refuses everything
+// else — and returns true rather than false so that a future name added to the spec's
+// accepted list behaves as the rest of the family does.
+//
+// Both attachment filters walk the attachment set, so a gateway attached to no VPC matches
+// neither, which follows AWS's own gloss on attachment.state — "Present only if a VPC is
+// attached".
+func ec2InternetGatewayMatchesFilter(igw EC2InternetGateway, name string, values []string) bool {
+	if matched, isTag := ec2TagFilterMatch(igw.Tags, name, values); isTag {
+		return matched
+	}
+	switch name {
+	case "attachment.state":
+		for _, a := range igw.Attachments {
+			if ec2FilterAccepts(values, a.State) {
+				return true
+			}
+		}
+		return false
+	case "attachment.vpc-id":
+		for _, a := range igw.Attachments {
+			if ec2FilterAccepts(values, a.VPCID) {
+				return true
+			}
+		}
+		return false
+	case "internet-gateway-id":
+		return ec2FilterAccepts(values, igw.InternetGatewayID)
+	case "owner-id":
+		return ec2FilterAccepts(values, igw.AccountID)
+	default:
+		return true
+	}
+}
+
+// ec2KeyPairMatchesFilters reports whether a key pair satisfies every supplied
+// DescribeKeyPairs filter.
+func ec2KeyPairMatchesFilters(kp EC2KeyPair, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2KeyPairMatchesFilter(kp, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2KeyPairMatchesFilter evaluates a single DescribeKeyPairs filter against a key pair.
+//
+// All five documented names are evaluated. AWS's own Example 2 on this page filters with a
+// wildcard — `Filter.1.Name=key-name&Filter.1.Value.1=*Dave*` — which is the shape #697 made
+// work for every filter value in the tree.
+func ec2KeyPairMatchesFilter(kp EC2KeyPair, name string, values []string) bool {
+	if matched, isTag := ec2TagFilterMatch(kp.Tags, name, values); isTag {
+		return matched
+	}
+	switch name {
+	case "fingerprint":
+		return ec2FilterAccepts(values, kp.Fingerprint)
+	case "key-name":
+		return ec2FilterAccepts(values, kp.KeyName)
+	case "key-pair-id":
+		return ec2FilterAccepts(values, kp.KeyPairID)
+	default:
+		return true
+	}
+}
+
+// ec2PlacementGroupARN returns the ARN of a placement group.
+//
+// AWS's template is arn:${Partition}:ec2:${Region}:${Account}:placement-group/${PlacementGroupName} —
+// by *name*, not by ID, which is why this takes the name and why CreateTags has to translate a
+// pg- ID into one (#708).
+//
+// One spelling for the two readers that compare it as a string: the group-arn filter here and
+// a caller's ArnEquals condition, which reaches the same string through
+// [ec2Taggable.arn]. [TestEC2_PlacementGroupARN_MatchesTheTaggableResolver] pins that the two
+// agree, because a filter and an authorization decision disagreeing about a resource's ARN is
+// exactly the defect #674 was.
+func ec2PlacementGroupARN(accountID, region, groupName string) string {
+	return "arn:aws:ec2:" + region + ":" + accountID + ":placement-group/" + groupName
+}
+
+// ec2PlacementGroupMatchesFilters reports whether a placement group satisfies every supplied
+// DescribePlacementGroups filter.
+func ec2PlacementGroupMatchesFilters(pg EC2PlacementGroup, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2PlacementGroupMatchesFilter(pg, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2PlacementGroupMatchesFilter evaluates a single DescribePlacementGroups filter.
+//
+// Six of seven evaluated; spread-level is inert, per [ec2PlacementGroupFilterSpec].
+func ec2PlacementGroupMatchesFilter(pg EC2PlacementGroup, name string, values []string) bool {
+	if matched, isTag := ec2TagFilterMatch(pg.Tags, name, values); isTag {
+		return matched
+	}
+	switch name {
+	case "group-arn":
+		return ec2FilterAccepts(values, ec2PlacementGroupARN(pg.AccountID, pg.Region, pg.GroupName))
+	case "group-name":
+		return ec2FilterAccepts(values, pg.GroupName)
+	case "state":
+		return ec2FilterAccepts(values, pg.State)
+	case "strategy":
+		return ec2FilterAccepts(values, pg.Strategy)
+	default:
+		return true
+	}
+}
+
+// ec2AddressMatchesFilters reports whether an Elastic IP satisfies every supplied
+// DescribeAddresses filter.
+func ec2AddressMatchesFilters(eip EC2ElasticIP, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2AddressMatchesFilter(eip, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2AddressMatchesFilter evaluates a single DescribeAddresses filter against an Elastic IP.
+//
+// The five association-shaped names — association-id, instance-id, network-interface-id,
+// private-ip-address and public-ip — are compared against the members substrate records,
+// which are empty on an unassociated address. So `instance-id=i-x` selects nothing among
+// unassociated addresses rather than everything, which is the answer a caller looking for
+// "the address on this instance" wants.
+//
+// The page documents no `domain` filter, so the one member substrate renders that is not
+// filterable is the one a caller is most likely to reach for. That is AWS's set: `domain`
+// distinguishes EC2-Classic from VPC addresses, and EC2-Classic is retired.
+func ec2AddressMatchesFilter(eip EC2ElasticIP, name string, values []string) bool {
+	if matched, isTag := ec2TagFilterMatch(eip.Tags, name, values); isTag {
+		return matched
+	}
+	switch name {
+	case "allocation-id":
+		return ec2FilterAccepts(values, eip.AllocationID)
+	case "association-id":
+		return ec2FilterAccepts(values, eip.AssociationID)
+	case "instance-id":
+		return ec2FilterAccepts(values, eip.InstanceID)
+	case "network-interface-id":
+		return ec2FilterAccepts(values, eip.NetworkInterfaceID)
+	case "private-ip-address":
+		return ec2FilterAccepts(values, eip.PrivateIPAddress)
+	case "public-ip":
+		return ec2FilterAccepts(values, eip.PublicIP)
+	default:
+		return true
+	}
+}
+
+// ec2AvailabilityZoneItem is one availabilityZoneInfo entry in AWS's
+// DescribeAvailabilityZones response.
+//
+// Promoted out of the handler's function body in #695 so the filter matcher and the renderer
+// compare and emit the same four values. The members are the four substrate can state without
+// inventing: AWS's sample also carries optInStatus, groupName, groupLongName, messageSet,
+// networkBorderGroup, geographySet and subGeographySet, and substrate models no zone grouping
+// or geography — see [ec2AvailabilityZoneFilterSpec] for what that costs the filter set.
+//
+// The state element is `zoneState`, which is AWS's spelling in its own sample response and
+// not the `state` the filter is named after.
+type ec2AvailabilityZoneItem struct {
+	// ZoneName is the zone's name, e.g. "us-east-1a".
+	ZoneName string `xml:"zoneName"`
+
+	// State is the zone's state. Substrate reports every seeded zone available.
+	State string `xml:"zoneState"`
+
+	// RegionName is the region the zone belongs to.
+	RegionName string `xml:"regionName"`
+
+	// ZoneID is the zone's ID, e.g. "use1-az1".
+	ZoneID string `xml:"zoneId"`
+}
+
+// ec2AvailabilityZoneMatchesFilters reports whether a zone satisfies every supplied
+// DescribeAvailabilityZones filter.
+func ec2AvailabilityZoneMatchesFilters(az ec2AvailabilityZoneItem, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2AvailabilityZoneMatchesFilter(az, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2AvailabilityZoneMatchesFilter evaluates a single DescribeAvailabilityZones filter.
+//
+// The filter is named `state` and the response element `zoneState`; both read the same value.
+func ec2AvailabilityZoneMatchesFilter(az ec2AvailabilityZoneItem, name string, values []string) bool {
+	switch name {
+	case "region-name":
+		return ec2FilterAccepts(values, az.RegionName)
+	case "state":
+		return ec2FilterAccepts(values, az.State)
+	case "zone-id":
+		return ec2FilterAccepts(values, az.ZoneID)
+	case "zone-name":
+		return ec2FilterAccepts(values, az.ZoneName)
+	default:
+		return true
+	}
+}
+
+// ec2RegionItem is one regionInfo entry in AWS's DescribeRegions response.
+//
+// Promoted to package level in #695 for the same reason as [ec2AvailabilityZoneItem]: the
+// three filters this operation documents are over exactly these three members, so the matcher
+// and the renderer read one struct.
+type ec2RegionItem struct {
+	// RegionName is the region's name, e.g. "us-east-1".
+	RegionName string `xml:"regionName"`
+
+	// RegionEndpoint is the region's EC2 endpoint, the value the endpoint filter compares.
+	RegionEndpoint string `xml:"regionEndpoint"`
+
+	// OptInStatus is the region's opt-in status. Every seeded region is
+	// opt-in-not-required, so a caller filtering for opted-in or not-opted-in selects
+	// nothing — which is the honest answer for an emulator with no disabled regions.
+	OptInStatus string `xml:"optInStatus"`
+}
+
+// ec2RegionMatchesFilters reports whether a region satisfies every supplied DescribeRegions
+// filter. All three documented names are evaluated.
+func ec2RegionMatchesFilters(r ec2RegionItem, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2RegionMatchesFilter(r, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2RegionMatchesFilter evaluates a single DescribeRegions filter against a region.
+func ec2RegionMatchesFilter(r ec2RegionItem, name string, values []string) bool {
+	switch name {
+	case "endpoint":
+		return ec2FilterAccepts(values, r.RegionEndpoint)
+	case "opt-in-status":
+		return ec2FilterAccepts(values, r.OptInStatus)
+	case "region-name":
+		return ec2FilterAccepts(values, r.RegionName)
+	default:
+		return true
+	}
+}
+
+// ec2InstanceTypeMatchesFilters reports whether a catalog entry satisfies every supplied
+// DescribeInstanceTypes filter.
+func ec2InstanceTypeMatchesFilters(info ec2InstanceTypeInfo, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2InstanceTypeMatchesFilter(info, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2InstanceTypeMatchesFilter evaluates a single DescribeInstanceTypes filter against a
+// catalog entry.
+//
+// Five of fifty-seven, which retires the filter half of TODO(#495). The two numeric filters
+// compare the decimal rendering of the stored integer: AWS documents no comparison operators
+// for filters — "greater than or less than comparison is not supported", as the spot-price
+// filter says outright — so `memory-info.size-in-mib=1024` is a string match against 1024 and
+// a wildcard is the only way to ask a range-ish question.
+//
+// The two list-valued filters match if any element matches, which is the same any-of rule
+// [ec2InternetGatewayMatchesFilter] applies to the attachment set.
+func ec2InstanceTypeMatchesFilter(info ec2InstanceTypeInfo, name string, values []string) bool {
+	switch name {
+	case "instance-type":
+		// AWS documents a wildcard here in the filter's own description — "for example
+		// c5.2xlarge or c5*" — which is the only place in EC2's filter documentation
+		// where a wildcard appears beside a specific filter rather than in the general
+		// rule.
+		return ec2FilterAccepts(values, info.InstanceType)
+	case "memory-info.size-in-mib":
+		return ec2FilterAccepts(values, strconv.Itoa(info.MemoryMiB))
+	case "processor-info.supported-architecture":
+		for _, arch := range info.SupportedArchs {
+			if ec2FilterAccepts(values, arch) {
+				return true
+			}
+		}
+		return false
+	case "supported-usage-class":
+		for _, class := range info.SupportedUsageClasses {
+			if ec2FilterAccepts(values, class) {
+				return true
+			}
+		}
+		return false
+	case "vcpu-info.default-vcpus":
+		return ec2FilterAccepts(values, strconv.Itoa(info.VCpus))
+	default:
+		return true
+	}
+}
+
+// ec2SpotPriceItem is one spotPriceHistorySet entry in AWS's DescribeSpotPriceHistory
+// response.
+//
+// Promoted to package level in #695 so the matcher compares what the response renders. That
+// matters most for `timestamp`: substrate renders RFC3339, and AWS's filter description gives
+// its example in a different format ("ddd MMM dd HH:mm:ss UTC YYYY") from the one its own
+// sample response emits (2016-11-01T20:56:05.000Z). Comparing against the rendered value is
+// the only reading that lets a caller filter on something it can read back — a value in the
+// description's format matches nothing here, and would match nothing against AWS's own sample
+// either.
+type ec2SpotPriceItem struct {
+	// InstanceType is the instance type the price is for.
+	InstanceType string `xml:"instanceType"`
+
+	// ProductDescription is the platform, always Linux/UNIX in substrate's catalog.
+	ProductDescription string `xml:"productDescription"`
+
+	// SpotPrice is the price in USD per hour, as a decimal string.
+	SpotPrice string `xml:"spotPrice"`
+
+	// Timestamp is when the price was observed, in RFC3339.
+	Timestamp string `xml:"timestamp"`
+
+	// AvailabilityZone is the zone the price applies to.
+	AvailabilityZone string `xml:"availabilityZone"`
+}
+
+// ec2SpotPriceMatchesFilters reports whether a price observation satisfies every supplied
+// DescribeSpotPriceHistory filter.
+func ec2SpotPriceMatchesFilters(item ec2SpotPriceItem, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2SpotPriceMatchesFilter(item, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2SpotPriceMatchesFilter evaluates a single DescribeSpotPriceHistory filter.
+//
+// Five of six; availability-zone-id is inert, per [ec2SpotPriceFilterSpec].
+func ec2SpotPriceMatchesFilter(item ec2SpotPriceItem, name string, values []string) bool {
+	switch name {
+	case "availability-zone":
+		return ec2FilterAccepts(values, item.AvailabilityZone)
+	case "instance-type":
+		return ec2FilterAccepts(values, item.InstanceType)
+	case "product-description":
+		return ec2FilterAccepts(values, item.ProductDescription)
+	case "spot-price":
+		// AWS: "The value must match exactly (or use wildcards; greater than or less
+		// than comparison is not supported)."
+		return ec2FilterAccepts(values, item.SpotPrice)
+	case "timestamp":
+		return ec2FilterAccepts(values, item.Timestamp)
+	default:
+		return true
+	}
+}
+
+// ec2LaunchTemplateMatchesFilters reports whether a launch template satisfies every supplied
+// DescribeLaunchTemplates filter.
+func ec2LaunchTemplateMatchesFilters(lt EC2LaunchTemplate, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2LaunchTemplateMatchesFilter(lt, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2LaunchTemplateMatchesFilter evaluates a single DescribeLaunchTemplates filter.
+//
+// All four documented names are evaluated. There is deliberately no launch-template-id arm:
+// the page documents no such filter, and [ec2LaunchTemplateFilterSpec] refuses the name rather
+// than answering a question AWS's API does not offer.
+func ec2LaunchTemplateMatchesFilter(lt EC2LaunchTemplate, name string, values []string) bool {
+	if matched, isTag := ec2TagFilterMatch(lt.Tags, name, values); isTag {
+		return matched
+	}
+	switch name {
+	case "create-time":
+		return ec2FilterAccepts(values, lt.CreateTime)
+	case "launch-template-name":
+		return ec2FilterAccepts(values, lt.LaunchTemplateName)
+	default:
+		return true
+	}
+}
+
+// ec2LTVersionMatchesFilters reports whether a launch template version satisfies every
+// supplied DescribeLaunchTemplateVersions filter.
+//
+// Takes the rendered [ec2LTVersionItem] rather than the stored version, because two of the
+// four evaluated filters read through it: is-default-version is derived from the parent
+// template's default version number, and image-id and instance-type live inside the version's
+// data. Filtering the rendered item keeps the answer and the filter over one value.
+func ec2LTVersionMatchesFilters(item ec2LTVersionItem, filters map[string][]string) bool {
+	for name, values := range filters {
+		if !ec2LTVersionMatchesFilter(item, name, values) {
+			return false
+		}
+	}
+	return true
+}
+
+// ec2LTVersionMatchesFilter evaluates a single DescribeLaunchTemplateVersions filter.
+//
+// Four of fourteen; see [ec2LaunchTemplateVersionFilterSpec] for the ten that are inert.
+func ec2LTVersionMatchesFilter(item ec2LTVersionItem, name string, values []string) bool {
+	switch name {
+	case "create-time":
+		return ec2FilterAccepts(values, item.CreateTime)
+	case "image-id":
+		return ec2FilterAccepts(values, item.LaunchTemplateData.ImageID)
+	case "instance-type":
+		return ec2FilterAccepts(values, item.LaunchTemplateData.InstanceType)
+	case "is-default-version":
+		return ec2FilterAccepts(values, strconv.FormatBool(item.DefaultVersion))
+	default:
+		return true
+	}
+}

--- a/emulator/ec2_describe_filters_test.go
+++ b/emulator/ec2_describe_filters_test.go
@@ -1,0 +1,1255 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The twelve describes that parsed no Filter.N at all before #695.
+//
+// Each accepted a Filter.N on the wire, read none of it, and answered with every resource
+// in the region — the failure #685 fixed for subnets, twelve times over. These tests are
+// written per operation rather than as one table because what each filter *means* is
+// per operation: the same name reads a different member, and the split between the names
+// substrate can evaluate and the documented ones it cannot is different on every page.
+//
+// Every assertion goes through HTTP, so the spec check, the Filter.N walk, the matcher and
+// the renderer are all in the path. A matcher tested directly would pass while the handler
+// still ignored the parameter, which is precisely the bug being fixed.
+
+// ec2DescribeXML sends a describe and decodes its body into v, failing on any non-200.
+func ec2DescribeXML(t *testing.T, ts *httptest.Server, params map[string]string, v any) {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(v))
+}
+
+// ec2DescribeBody sends a describe and returns its raw body, which is the only way to tell
+// an absent element from an empty one — a decoder reports both as a zero value.
+func ec2DescribeBody(t *testing.T, ts *httptest.Server, params map[string]string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(raw)
+}
+
+// ec2OneFilter is the params for a describe carrying exactly one filter, which is the shape
+// almost every case below needs.
+func ec2OneFilter(action, name, value string) map[string]string {
+	return map[string]string{
+		"Action":           action,
+		"Filter.1.Name":    name,
+		"Filter.1.Value.1": value,
+	}
+}
+
+// --- DescribeVpcs ---
+
+// ec2TestVPC is a vpcSet item as a caller decodes it.
+type ec2TestVPC struct {
+	VpcID     string         `xml:"vpcId"`
+	State     string         `xml:"state"`
+	CIDRBlock string         `xml:"cidrBlock"`
+	OwnerID   string         `xml:"ownerId"`
+	IsDefault bool           `xml:"isDefault"`
+	Tags      []describedTag `xml:"tagSet>item"`
+}
+
+func ec2DescribeVPCs(t *testing.T, ts *httptest.Server, params map[string]string) []ec2TestVPC {
+	t.Helper()
+	var doc struct {
+		XMLName xml.Name     `xml:"DescribeVpcsResponse"`
+		Items   []ec2TestVPC `xml:"vpcSet>item"`
+	}
+	ec2DescribeXML(t, ts, params, &doc)
+	return doc.Items
+}
+
+func ec2CreateVPC(t *testing.T, ts *httptest.Server, cidr string) string {
+	t.Helper()
+	var doc struct {
+		XMLName xml.Name `xml:"CreateVpcResponse"`
+		VpcID   string   `xml:"vpc>vpcId"`
+	}
+	ec2DescribeXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": cidr}, &doc)
+	require.NotEmpty(t, doc.VpcID)
+	return doc.VpcID
+}
+
+// ec2TagResource applies one tag through CreateTags, which is how every fixture here that
+// needs a tagged resource gets one.
+func ec2TagResource(t *testing.T, ts *httptest.Server, id, key, value string) {
+	t.Helper()
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":       "CreateTags",
+		"ResourceId.1": id,
+		"Tag.1.Key":    key,
+		"Tag.1.Value":  value,
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestEC2_VPCFilters_EvaluatedNamesSelect pins the six filters DescribeVpcs can answer.
+//
+// Before #695 every row here returned both VPCs: a caller asking for "the VPC with CIDR
+// 10.9.0.0/16" was handed its neighbors too, with nothing in the response to say the filter
+// had been dropped.
+func TestEC2_VPCFilters_EvaluatedNamesSelect(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	wanted := ec2CreateVPC(t, ts, "10.9.0.0/16")
+	ec2CreateVPC(t, ts, "10.8.0.0/16")
+	ec2TagResource(t, ts, wanted, "Env", "prod")
+
+	owner := ec2DescribeVPCs(t, ts, map[string]string{"Action": "DescribeVpcs", "VpcId.1": wanted})[0].OwnerID
+	require.NotEmpty(t, owner, "ownerId must be rendered for the owner-id filter to be readable")
+
+	// state and owner-id are the same on both VPCs, so they pin that a *matching* filter
+	// does not exclude — the complement of the single-selection rows below.
+	assert.Len(t, ec2DescribeVPCs(t, ts, ec2OneFilter("DescribeVpcs", "state", "available")), 2)
+	assert.Len(t, ec2DescribeVPCs(t, ts, ec2OneFilter("DescribeVpcs", "owner-id", owner)), 2)
+
+	for _, tc := range []struct{ name, filter, value string }{
+		{"cidr", "cidr", "10.9.0.0/16"},
+		{"cidr wildcards", "cidr", "10.9.*"},
+		{"vpc-id", "vpc-id", wanted},
+		{"tag by key and value", "tag:Env", "prod"},
+		{"tag-key", "tag-key", "Env"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items := ec2DescribeVPCs(t, ts, ec2OneFilter("DescribeVpcs", tc.filter, tc.value))
+			ids := make([]string, 0, len(items))
+			for _, v := range items {
+				ids = append(ids, v.VpcID)
+			}
+			assert.Equal(t, []string{wanted}, ids,
+				"%s=%s must select only the VPC it names", tc.filter, tc.value)
+		})
+	}
+}
+
+// TestEC2_VPCFilters_IsDefaultAndNonMatchingValues pins the two answers a caller most needs
+// to be able to trust: a filter that matches nothing returns nothing, and is-default reads
+// the stored flag rather than defaulting to true.
+func TestEC2_VPCFilters_IsDefaultAndNonMatchingValues(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	ec2CreateVPC(t, ts, "10.9.0.0/16")
+
+	assert.Empty(t, ec2DescribeVPCs(t, ts, ec2OneFilter("DescribeVpcs", "cidr", "192.168.0.0/16")),
+		"a filter no VPC matches selects nothing, not everything")
+	assert.Empty(t, ec2DescribeVPCs(t, ts, ec2OneFilter("DescribeVpcs", "owner-id", "000000000001")),
+		"another account owns no VPC here")
+	assert.Empty(t, ec2DescribeVPCs(t, ts, ec2OneFilter("DescribeVpcs", "is-default", "true")),
+		"a created VPC is not the default one")
+	assert.Len(t, ec2DescribeVPCs(t, ts, ec2OneFilter("DescribeVpcs", "is-default", "false")), 1)
+}
+
+// TestEC2_VPCFilters_InertNameSelectsEverything pins that a documented name substrate cannot
+// answer constrains nothing — the same rule [TestEC2_FilterNames_InertMeansEveryResource]
+// pins for instances, on the operation whose inert list is longest.
+func TestEC2_VPCFilters_InertNameSelectsEverything(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	ec2CreateVPC(t, ts, "10.9.0.0/16")
+
+	for _, filter := range []string{"dhcp-options-id", "cidr-block-association.cidr-block", "ipv6-cidr-block-association.state"} {
+		t.Run(filter, func(t *testing.T) {
+			items := ec2DescribeVPCs(t, ts, ec2OneFilter("DescribeVpcs", filter, "nothing-matches-this"))
+			assert.Len(t, items, 1, "an inert filter is accepted and constrains nothing")
+		})
+	}
+}
+
+// TestEC2_DescribeVpcs_StateElementIsState pins the wire fix.
+//
+// Both CreateVpc and DescribeVpcs rendered the state as <vpcState>, where AWS's own samples
+// for both operations render <state>. Nothing in the suite or the docs pinned it, so an SDK
+// caller decoded State: "" from a VPC that was in fact available — and could not tell that
+// from a VPC whose state substrate had failed to set.
+func TestEC2_DescribeVpcs_StateElementIsState(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	vpcID := ec2CreateVPC(t, ts, "10.9.0.0/16")
+
+	items := ec2DescribeVPCs(t, ts, map[string]string{"Action": "DescribeVpcs", "VpcId.1": vpcID})
+	require.Len(t, items, 1)
+	assert.Equal(t, "available", items[0].State,
+		"AWS's DescribeVpcs sample renders <state>available</state>")
+
+	body := ec2DescribeBody(t, ts, map[string]string{"Action": "DescribeVpcs", "VpcId.1": vpcID})
+	assert.NotContains(t, body, "vpcState", "the old spelling is gone, not rendered alongside")
+}
+
+// TestEC2_CreateVpc_AgreesWithDescribe pins that the two operations render one VPC.
+//
+// They rendered different member subsets before #695 — neither carried an owner or a tagSet,
+// and both misspelled the state element — which is the drift one shared renderer prevents,
+// the reason #685 gave for [ec2SubnetItem].
+func TestEC2_CreateVpc_AgreesWithDescribe(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	var created struct {
+		XMLName xml.Name   `xml:"CreateVpcResponse"`
+		Vpc     ec2TestVPC `xml:"vpc"`
+	}
+	ec2DescribeXML(t, ts, map[string]string{"Action": "CreateVpc", "CidrBlock": "10.7.0.0/16"}, &created)
+
+	// Asserted before the comparison, because equality alone is satisfied by both
+	// responses being equally blank — which is what the two renderers did before #695.
+	require.NotEmpty(t, created.Vpc.VpcID)
+	require.Equal(t, "available", created.Vpc.State)
+	require.Equal(t, "10.7.0.0/16", created.Vpc.CIDRBlock)
+	require.NotEmpty(t, created.Vpc.OwnerID)
+
+	described := ec2DescribeVPCs(t, ts, map[string]string{"Action": "DescribeVpcs", "VpcId.1": created.Vpc.VpcID})
+	require.Len(t, described, 1)
+	assert.Equal(t, created.Vpc, described[0],
+		"the create response and the describe must describe the same VPC")
+}
+
+// TestEC2_DescribeVpcs_TagSetIsAbsentWhenUntagged pins this page's own convention.
+//
+// AWS's DescribeVpcs sample omits tagSet on an untagged VPC, so substrate omits it —
+// unlike DescribeInternetGateways, whose sample publishes a present-but-empty <tagSet/> and
+// which [TestEC2_DescribeInternetGateways_EmptySetsArePresent] pins the other way. Each
+// response answers to the page that documents it (#708).
+func TestEC2_DescribeVpcs_TagSetIsAbsentWhenUntagged(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	untagged := ec2CreateVPC(t, ts, "10.9.0.0/16")
+	tagged := ec2CreateVPC(t, ts, "10.10.0.0/16")
+	ec2TagResource(t, ts, tagged, "Env", "prod")
+
+	assert.NotContains(t, ec2DescribeBody(t, ts, map[string]string{"Action": "DescribeVpcs", "VpcId.1": untagged}),
+		"tagSet", "an untagged VPC omits the element, as AWS's sample does")
+	assert.Contains(t, ec2DescribeBody(t, ts, map[string]string{"Action": "DescribeVpcs", "VpcId.1": tagged}),
+		"<tagSet>", "a tagged VPC renders it")
+}
+
+// --- DescribeInternetGateways ---
+
+// ec2TestIGW is an internetGatewaySet item as a caller decodes it.
+type ec2TestIGW struct {
+	InternetGatewayID string `xml:"internetGatewayId"`
+	OwnerID           string `xml:"ownerId"`
+	Attachments       []struct {
+		State string `xml:"state"`
+		VpcID string `xml:"vpcId"`
+	} `xml:"attachmentSet>item"`
+	Tags []describedTag `xml:"tagSet>item"`
+}
+
+func ec2DescribeIGWs(t *testing.T, ts *httptest.Server, params map[string]string) []ec2TestIGW {
+	t.Helper()
+	var doc struct {
+		XMLName xml.Name     `xml:"DescribeInternetGatewaysResponse"`
+		Items   []ec2TestIGW `xml:"internetGatewaySet>item"`
+	}
+	ec2DescribeXML(t, ts, params, &doc)
+	return doc.Items
+}
+
+func ec2CreateIGW(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	var doc struct {
+		XMLName xml.Name `xml:"CreateInternetGatewayResponse"`
+		ID      string   `xml:"internetGateway>internetGatewayId"`
+	}
+	ec2DescribeXML(t, ts, map[string]string{"Action": "CreateInternetGateway"}, &doc)
+	require.NotEmpty(t, doc.ID)
+	return doc.ID
+}
+
+// TestEC2_InternetGatewayFilters_AllSixEvaluated pins the one operation in this batch whose
+// documented filter set substrate can answer completely.
+//
+// The response carried nothing but internetGatewayId before #695, so both halves of every
+// row here are new: the filter, and the member it selects on being readable at all.
+func TestEC2_InternetGatewayFilters_AllSixEvaluated(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	vpcID := ec2CreateVPC(t, ts, "10.9.0.0/16")
+	attached := ec2CreateIGW(t, ts)
+	detached := ec2CreateIGW(t, ts)
+	ec2TagResource(t, ts, attached, "Env", "prod")
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "AttachInternetGateway", "InternetGatewayId": attached, "VpcId": vpcID,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	owner := ec2DescribeIGWs(t, ts, map[string]string{"Action": "DescribeInternetGateways"})[0].OwnerID
+	require.NotEmpty(t, owner)
+
+	for _, tc := range []struct{ name, filter, value string }{
+		{"attachment.state", "attachment.state", "available"},
+		{"attachment.vpc-id", "attachment.vpc-id", vpcID},
+		{"internet-gateway-id", "internet-gateway-id", attached},
+		{"tag by key and value", "tag:Env", "prod"},
+		{"tag-key", "tag-key", "Env"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items := ec2DescribeIGWs(t, ts, ec2OneFilter("DescribeInternetGateways", tc.filter, tc.value))
+			require.Len(t, items, 1, "%s=%s selected %d gateways", tc.filter, tc.value, len(items))
+			assert.Equal(t, attached, items[0].InternetGatewayID)
+		})
+	}
+
+	t.Run("owner-id selects both", func(t *testing.T) {
+		items := ec2DescribeIGWs(t, ts, ec2OneFilter("DescribeInternetGateways", "owner-id", owner))
+		assert.Len(t, items, 2, "both gateways belong to the requesting account")
+	})
+
+	t.Run("an unattached gateway matches no attachment filter", func(t *testing.T) {
+		// AWS: attachment.state is "Present only if a VPC is attached", so a gateway
+		// with no attachment is not a match for any value of it — including the state
+		// its future attachment would have.
+		items := ec2DescribeIGWs(t, ts, ec2OneFilter("DescribeInternetGateways", "attachment.state", "available"))
+		for _, igw := range items {
+			assert.NotEqual(t, detached, igw.InternetGatewayID)
+		}
+	})
+}
+
+// TestEC2_DescribeInternetGateways_EmptySetsArePresent pins this page's convention, which is
+// the opposite of DescribeVpcs'.
+//
+// AWS's DescribeInternetGateways sample renders <attachmentSet/> and <tagSet/> on an
+// unattached, untagged gateway — present and empty, not absent. Substrate follows the page in
+// front of it rather than a house rule, which is why the two operations differ here on
+// purpose; a future sweep "for consistency" would break one of them against its own
+// reference.
+func TestEC2_DescribeInternetGateways_EmptySetsArePresent(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	igwID := ec2CreateIGW(t, ts)
+
+	body := ec2DescribeBody(t, ts, map[string]string{
+		"Action": "DescribeInternetGateways", "InternetGatewayId.1": igwID,
+	})
+	assert.Contains(t, body, "attachmentSet", "AWS's sample carries the element even when empty")
+	assert.Contains(t, body, "tagSet", "as it does for tagSet")
+}
+
+// TestEC2_CreateInternetGateway_AgreesWithDescribe pins that the two render one gateway.
+func TestEC2_CreateInternetGateway_AgreesWithDescribe(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	var created struct {
+		XMLName xml.Name   `xml:"CreateInternetGatewayResponse"`
+		IGW     ec2TestIGW `xml:"internetGateway"`
+	}
+	ec2DescribeXML(t, ts, map[string]string{"Action": "CreateInternetGateway"}, &created)
+
+	// As in [TestEC2_CreateVpc_AgreesWithDescribe], the members are asserted present
+	// first: two responses that both render nothing but the ID are trivially equal.
+	require.NotEmpty(t, created.IGW.InternetGatewayID)
+	require.NotEmpty(t, created.IGW.OwnerID)
+
+	described := ec2DescribeIGWs(t, ts, map[string]string{
+		"Action": "DescribeInternetGateways", "InternetGatewayId.1": created.IGW.InternetGatewayID,
+	})
+	require.Len(t, described, 1)
+	assert.Equal(t, created.IGW, described[0])
+}
+
+// --- DescribeKeyPairs ---
+
+// ec2TestKeyPair is a keySet item as a caller decodes it.
+type ec2TestKeyPair struct {
+	KeyPairID      string         `xml:"keyPairId"`
+	KeyName        string         `xml:"keyName"`
+	KeyFingerprint string         `xml:"keyFingerprint"`
+	Tags           []describedTag `xml:"tagSet>item"`
+}
+
+func ec2DescribeKeyPairs(t *testing.T, ts *httptest.Server, params map[string]string) []ec2TestKeyPair {
+	t.Helper()
+	var doc struct {
+		XMLName xml.Name         `xml:"DescribeKeyPairsResponse"`
+		Items   []ec2TestKeyPair `xml:"keySet>item"`
+	}
+	ec2DescribeXML(t, ts, params, &doc)
+	return doc.Items
+}
+
+// TestEC2_KeyPairFilters_AllFiveEvaluated pins the five filters this page documents, all of
+// which substrate can answer since #708 gave EC2KeyPair a Tags field.
+func TestEC2_KeyPairFilters_AllFiveEvaluated(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	wantedID, _ := ec2TagTestKeyPair(t, ts, "filter-wanted", map[string]string{
+		"TagSpecification.1.ResourceType": "key-pair",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	})
+	ec2TagTestKeyPair(t, ts, "filter-other", nil)
+
+	fingerprint := ec2DescribeKeyPairs(t, ts, map[string]string{
+		"Action": "DescribeKeyPairs", "KeyPairId.1": wantedID,
+	})[0].KeyFingerprint
+	require.NotEmpty(t, fingerprint)
+
+	for _, tc := range []struct{ name, filter, value string }{
+		{"key-name", "key-name", "filter-wanted"},
+		{"key-name wildcards", "key-name", "*wanted"},
+		{"key-pair-id", "key-pair-id", wantedID},
+		{"fingerprint", "fingerprint", fingerprint},
+		{"tag by key and value", "tag:Env", "prod"},
+		{"tag-key", "tag-key", "Env"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items := ec2DescribeKeyPairs(t, ts, ec2OneFilter("DescribeKeyPairs", tc.filter, tc.value))
+			require.Len(t, items, 1, "%s=%s selected %d key pairs", tc.filter, tc.value, len(items))
+			assert.Equal(t, "filter-wanted", items[0].KeyName)
+		})
+	}
+}
+
+// TestEC2_KeyPairs_IdentitySelectorsUnion pins KeyPairId.N, which was read by nothing before
+// #695, and the reading of a request that carries both identity lists.
+//
+// AWS documents no rule for the combination. Substrate unions them: a request naming a key
+// pair by name and another by ID is answered with both, because AWS answers NotFound for a
+// name or ID it cannot resolve — which only makes sense if each is expected in the response.
+func TestEC2_KeyPairs_IdentitySelectorsUnion(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	byIDTarget, _ := ec2TagTestKeyPair(t, ts, "union-by-id", nil)
+	ec2TagTestKeyPair(t, ts, "union-by-name", nil)
+	ec2TagTestKeyPair(t, ts, "union-neither", nil)
+
+	t.Run("KeyPairId.N alone selects", func(t *testing.T) {
+		items := ec2DescribeKeyPairs(t, ts, map[string]string{
+			"Action": "DescribeKeyPairs", "KeyPairId.1": byIDTarget,
+		})
+		require.Len(t, items, 1, "KeyPairId.N was ignored before #695, answering with every key pair")
+		assert.Equal(t, "union-by-id", items[0].KeyName)
+	})
+
+	t.Run("both lists union", func(t *testing.T) {
+		items := ec2DescribeKeyPairs(t, ts, map[string]string{
+			"Action": "DescribeKeyPairs", "KeyPairId.1": byIDTarget, "KeyName.1": "union-by-name",
+		})
+		names := make([]string, 0, len(items))
+		for _, kp := range items {
+			names = append(names, kp.KeyName)
+		}
+		assert.ElementsMatch(t, []string{"union-by-id", "union-by-name"}, names)
+	})
+}
+
+// --- DescribeAvailabilityZones ---
+
+// ec2TestAZ is an availabilityZoneInfo item as a caller decodes it.
+type ec2TestAZ struct {
+	ZoneName   string `xml:"zoneName"`
+	State      string `xml:"zoneState"`
+	RegionName string `xml:"regionName"`
+	ZoneID     string `xml:"zoneId"`
+}
+
+func ec2DescribeAZs(t *testing.T, ts *httptest.Server, params map[string]string) []ec2TestAZ {
+	t.Helper()
+	var doc struct {
+		XMLName xml.Name    `xml:"DescribeAvailabilityZonesResponse"`
+		Items   []ec2TestAZ `xml:"availabilityZoneInfo>item"`
+	}
+	ec2DescribeXML(t, ts, params, &doc)
+	return doc.Items
+}
+
+// TestEC2_AvailabilityZoneSelectors pins every selector this operation documents and
+// substrate can answer. The handler discarded the request entirely before #695 — its
+// signature took `_ *AWSRequest` — so ZoneName.N, ZoneId.N and Filter.N were all ignored.
+func TestEC2_AvailabilityZoneSelectors(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	all := ec2DescribeAZs(t, ts, map[string]string{"Action": "DescribeAvailabilityZones"})
+	require.Greater(t, len(all), 1, "the fixture needs more than one zone for a filter to be visible")
+	first := all[0]
+
+	for _, tc := range []struct {
+		name   string
+		params map[string]string
+	}{
+		{"ZoneName.N", map[string]string{"Action": "DescribeAvailabilityZones", "ZoneName.1": first.ZoneName}},
+		{"ZoneId.N", map[string]string{"Action": "DescribeAvailabilityZones", "ZoneId.1": first.ZoneID}},
+		{"zone-name filter", ec2OneFilter("DescribeAvailabilityZones", "zone-name", first.ZoneName)},
+		{"zone-id filter", ec2OneFilter("DescribeAvailabilityZones", "zone-id", first.ZoneID)},
+		{"zone-name wildcards", ec2OneFilter("DescribeAvailabilityZones", "zone-name", "*"+first.ZoneName[len(first.ZoneName)-2:])},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items := ec2DescribeAZs(t, ts, tc.params)
+			require.Len(t, items, 1, "%s selected %d zones of %d", tc.name, len(items), len(all))
+			assert.Equal(t, first, items[0])
+		})
+	}
+
+	t.Run("region-name and state select every zone", func(t *testing.T) {
+		byRegion := ec2DescribeAZs(t, ts, ec2OneFilter("DescribeAvailabilityZones", "region-name", first.RegionName))
+		assert.Len(t, byRegion, len(all))
+		byState := ec2DescribeAZs(t, ts, ec2OneFilter("DescribeAvailabilityZones", "state", "available"))
+		assert.Len(t, byState, len(all), "substrate reports every seeded zone available")
+	})
+
+	t.Run("a non-matching value selects nothing", func(t *testing.T) {
+		assert.Empty(t, ec2DescribeAZs(t, ts, ec2OneFilter("DescribeAvailabilityZones", "zone-name", "eu-west-9z")))
+		assert.Empty(t, ec2DescribeAZs(t, ts, map[string]string{
+			"Action": "DescribeAvailabilityZones", "ZoneId.1": "usw2-az9",
+		}))
+	})
+
+	t.Run("an inert name selects everything", func(t *testing.T) {
+		// substrate models no zone grouping or opt-in, so these are accepted and inert.
+		for _, filter := range []string{"zone-type", "opt-in-status", "parent-zone-id", "group-name"} {
+			items := ec2DescribeAZs(t, ts, ec2OneFilter("DescribeAvailabilityZones", filter, "no-zone-matches"))
+			assert.Len(t, items, len(all), "%s is documented but inert", filter)
+		}
+	})
+}
+
+// --- DescribePlacementGroups ---
+
+// ec2TestPlacementGroup is a placementGroupSet item as a caller decodes it.
+type ec2TestPlacementGroup struct {
+	GroupName string         `xml:"groupName"`
+	GroupID   string         `xml:"groupId"`
+	GroupARN  string         `xml:"groupArn"`
+	Strategy  string         `xml:"strategy"`
+	State     string         `xml:"state"`
+	Tags      []describedTag `xml:"tagSet>item"`
+}
+
+func ec2DescribePlacementGroups(t *testing.T, ts *httptest.Server, params map[string]string) []ec2TestPlacementGroup {
+	t.Helper()
+	var doc struct {
+		XMLName xml.Name                `xml:"DescribePlacementGroupsResponse"`
+		Items   []ec2TestPlacementGroup `xml:"placementGroupSet>item"`
+	}
+	ec2DescribeXML(t, ts, params, &doc)
+	return doc.Items
+}
+
+// TestEC2_PlacementGroupFilters_SixOfSevenEvaluated pins the filters this page documents,
+// including group-arn — which needs the ARN to be rendered before a caller can use it.
+func TestEC2_PlacementGroupFilters_SixOfSevenEvaluated(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	wantedID, _ := ec2TagTestPlacementGroup(t, ts, "filter-wanted-pg", map[string]string{
+		"TagSpecification.1.ResourceType": "placement-group",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	})
+	ec2TagTestPlacementGroup(t, ts, "filter-other-pg", nil)
+
+	wanted := ec2DescribePlacementGroups(t, ts, map[string]string{
+		"Action": "DescribePlacementGroups", "GroupName.1": "filter-wanted-pg",
+	})
+	require.Len(t, wanted, 1)
+	require.NotEmpty(t, wanted[0].GroupARN, "group-arn cannot be filtered on if it is never rendered")
+
+	for _, tc := range []struct{ name, filter, value string }{
+		{"group-name", "group-name", "filter-wanted-pg"},
+		{"group-name wildcards", "group-name", "filter-wanted*"},
+		{"group-arn", "group-arn", wanted[0].GroupARN},
+		{"tag by key and value", "tag:Env", "prod"},
+		{"tag-key", "tag-key", "Env"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items := ec2DescribePlacementGroups(t, ts, ec2OneFilter("DescribePlacementGroups", tc.filter, tc.value))
+			require.Len(t, items, 1, "%s=%s selected %d groups", tc.filter, tc.value, len(items))
+			assert.Equal(t, "filter-wanted-pg", items[0].GroupName)
+		})
+	}
+
+	t.Run("GroupId.N selects", func(t *testing.T) {
+		items := ec2DescribePlacementGroups(t, ts, map[string]string{
+			"Action": "DescribePlacementGroups", "GroupId.1": wantedID,
+		})
+		require.Len(t, items, 1, "GroupId.N was documented and read by nothing before #695")
+		assert.Equal(t, "filter-wanted-pg", items[0].GroupName)
+	})
+
+	t.Run("state and strategy select both", func(t *testing.T) {
+		assert.Len(t, ec2DescribePlacementGroups(t, ts,
+			ec2OneFilter("DescribePlacementGroups", "state", "available")), 2)
+		assert.Len(t, ec2DescribePlacementGroups(t, ts,
+			ec2OneFilter("DescribePlacementGroups", "strategy", "spread")), 2)
+	})
+
+	t.Run("spread-level is inert", func(t *testing.T) {
+		items := ec2DescribePlacementGroups(t, ts,
+			ec2OneFilter("DescribePlacementGroups", "spread-level", "host"))
+		assert.Len(t, items, 2, "substrate records no spread level, so the filter constrains nothing")
+	})
+}
+
+// TestEC2_PlacementGroupARN_MatchesTheTaggableResolver pins that the group-arn filter and an
+// IAM ArnEquals condition compare the same string.
+//
+// A placement group's ARN is by *name*, not by ID —
+// arn:${Partition}:ec2:${Region}:${Account}:placement-group/${PlacementGroupName} — and two
+// readers compose it: the filter, through ec2PlacementGroupARN, and the authorization
+// resolver, through ec2Taggable.arn. #674 was exactly the defect of a filter and an
+// authorization decision disagreeing about a resource's identity, so the spellings are pinned
+// against each other here. ec2TagARN is the formula the authz suite asserts against, in
+// [TestEC2_TagAuthz_ScopedDenyOnAnyNamedResourceBlocks].
+func TestEC2_PlacementGroupARN_MatchesTheTaggableResolver(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	ec2TagTestPlacementGroup(t, ts, "arn-shape-pg", nil)
+
+	groups := ec2DescribePlacementGroups(t, ts, map[string]string{
+		"Action": "DescribePlacementGroups", "GroupName.1": "arn-shape-pg",
+	})
+	require.Len(t, groups, 1)
+
+	// The account is read back from the response rather than hardcoded, because the test
+	// server takes it from the request's credentials.
+	vpcOwner := ec2DescribeVPCs(t, ts, map[string]string{
+		"Action": "DescribeVpcs", "VpcId.1": ec2CreateVPC(t, ts, "10.31.0.0/16"),
+	})[0].OwnerID
+	require.NotEmpty(t, vpcOwner)
+
+	assert.Equal(t, "arn:aws:ec2:us-east-1:"+vpcOwner+":placement-group/arn-shape-pg", groups[0].GroupARN,
+		"the ARN is by name and matches the template ec2Taggable.arn composes")
+}
+
+// --- DescribeAddresses ---
+
+// ec2TestAddress is an addressesSet item as a caller decodes it.
+type ec2TestAddress struct {
+	AllocationID string         `xml:"allocationId"`
+	PublicIP     string         `xml:"publicIp"`
+	InstanceID   string         `xml:"instanceId"`
+	Domain       string         `xml:"domain"`
+	Tags         []describedTag `xml:"tagSet>item"`
+}
+
+func ec2DescribeAddresses(t *testing.T, ts *httptest.Server, params map[string]string) []ec2TestAddress {
+	t.Helper()
+	var doc struct {
+		XMLName xml.Name         `xml:"DescribeAddressesResponse"`
+		Items   []ec2TestAddress `xml:"addressesSet>item"`
+	}
+	ec2DescribeXML(t, ts, params, &doc)
+	return doc.Items
+}
+
+func ec2AllocateAddress(t *testing.T, ts *httptest.Server) (allocationID, publicIP string) {
+	t.Helper()
+	var doc struct {
+		XMLName      xml.Name `xml:"AllocateAddressResponse"`
+		AllocationID string   `xml:"allocationId"`
+		PublicIP     string   `xml:"publicIp"`
+	}
+	ec2DescribeXML(t, ts, map[string]string{"Action": "AllocateAddress", "Domain": "vpc"}, &doc)
+	require.NotEmpty(t, doc.AllocationID)
+	require.NotEmpty(t, doc.PublicIP)
+	return doc.AllocationID, doc.PublicIP
+}
+
+// TestEC2_AddressFilters_EvaluatedNamesSelect pins the filters DescribeAddresses can answer,
+// and PublicIp.N, which was documented and read by nothing.
+func TestEC2_AddressFilters_EvaluatedNamesSelect(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instanceID := ec2TagTestInstance(t, ts)
+	wantedAlloc, wantedIP := ec2AllocateAddress(t, ts)
+	otherAlloc, otherIP := ec2AllocateAddress(t, ts)
+	ec2TagResource(t, ts, wantedAlloc, "Env", "prod")
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action": "AssociateAddress", "AllocationId": wantedAlloc, "InstanceId": instanceID,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	for _, tc := range []struct{ name, filter, value string }{
+		{"public-ip", "public-ip", wantedIP},
+		{"allocation-id", "allocation-id", wantedAlloc},
+		{"instance-id", "instance-id", instanceID},
+		{"tag by key and value", "tag:Env", "prod"},
+		{"tag-key", "tag-key", "Env"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items := ec2DescribeAddresses(t, ts, ec2OneFilter("DescribeAddresses", tc.filter, tc.value))
+			require.Len(t, items, 1, "%s=%s selected %d addresses", tc.filter, tc.value, len(items))
+			assert.Equal(t, wantedAlloc, items[0].AllocationID)
+		})
+	}
+
+	t.Run("an unassociated address matches no association filter", func(t *testing.T) {
+		items := ec2DescribeAddresses(t, ts, ec2OneFilter("DescribeAddresses", "instance-id", instanceID))
+		for _, a := range items {
+			assert.NotEqual(t, otherAlloc, a.AllocationID,
+				"instance-id compares the recorded instance, which is empty on an unassociated address")
+		}
+	})
+
+	t.Run("PublicIp.N selects", func(t *testing.T) {
+		items := ec2DescribeAddresses(t, ts, map[string]string{
+			"Action": "DescribeAddresses", "PublicIp.1": otherIP,
+		})
+		require.Len(t, items, 1, "PublicIp.N answered with every address before #695")
+		assert.Equal(t, otherAlloc, items[0].AllocationID)
+	})
+
+	t.Run("AllocationId.N and PublicIp.N union", func(t *testing.T) {
+		items := ec2DescribeAddresses(t, ts, map[string]string{
+			"Action": "DescribeAddresses", "AllocationId.1": wantedAlloc, "PublicIp.1": otherIP,
+		})
+		ids := make([]string, 0, len(items))
+		for _, a := range items {
+			ids = append(ids, a.AllocationID)
+		}
+		assert.ElementsMatch(t, []string{wantedAlloc, otherAlloc}, ids,
+			"a request naming one address by allocation and another by IP is answered with both")
+	})
+
+	t.Run("an address named by IP does not make its own allocation ID unresolved", func(t *testing.T) {
+		// The regression this guards: ec2IDFilter.match records that a requested
+		// allocation ID resolved. If the union short-circuited past it, an address
+		// selected by PublicIp.N would leave its allocation ID looking unseen and the
+		// response would be InvalidAllocationID.NotFound instead of the address.
+		items := ec2DescribeAddresses(t, ts, map[string]string{
+			"Action": "DescribeAddresses", "AllocationId.1": wantedAlloc, "PublicIp.1": wantedIP,
+		})
+		require.Len(t, items, 1, "both selectors name the same address")
+		assert.Equal(t, wantedAlloc, items[0].AllocationID)
+	})
+
+	t.Run("tagSet is rendered when the address is tagged", func(t *testing.T) {
+		items := ec2DescribeAddresses(t, ts, map[string]string{
+			"Action": "DescribeAddresses", "AllocationId.1": wantedAlloc,
+		})
+		require.Len(t, items, 1)
+		require.Len(t, items[0].Tags, 1, "a tag:<key> filter is unreadable if tagSet is never rendered")
+		assert.Equal(t, "Env", items[0].Tags[0].Key)
+
+		untagged := ec2DescribeBody(t, ts, map[string]string{
+			"Action": "DescribeAddresses", "AllocationId.1": otherAlloc,
+		})
+		assert.NotContains(t, untagged, "tagSet",
+			"no sample on this page shows a tagSet on an untagged address")
+	})
+}
+
+// --- DescribeRegions ---
+
+// TestEC2_RegionFilters_AllThreeEvaluated pins the three filters this page documents.
+func TestEC2_RegionFilters_AllThreeEvaluated(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	type region struct {
+		RegionName     string `xml:"regionName"`
+		RegionEndpoint string `xml:"regionEndpoint"`
+		OptInStatus    string `xml:"optInStatus"`
+	}
+	describe := func(params map[string]string) []region {
+		var doc struct {
+			XMLName xml.Name `xml:"DescribeRegionsResponse"`
+			Items   []region `xml:"regionInfo>item"`
+		}
+		ec2DescribeXML(t, ts, params, &doc)
+		return doc.Items
+	}
+
+	all := describe(map[string]string{"Action": "DescribeRegions"})
+	require.Greater(t, len(all), 1)
+	first := all[0]
+
+	t.Run("region-name", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeRegions", "region-name", first.RegionName))
+		require.Len(t, items, 1)
+		assert.Equal(t, first, items[0])
+	})
+
+	t.Run("endpoint", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeRegions", "endpoint", first.RegionEndpoint))
+		require.Len(t, items, 1)
+		assert.Equal(t, first, items[0])
+	})
+
+	t.Run("opt-in-status", func(t *testing.T) {
+		assert.Len(t, describe(ec2OneFilter("DescribeRegions", "opt-in-status", "opt-in-not-required")), len(all))
+		assert.Empty(t, describe(ec2OneFilter("DescribeRegions", "opt-in-status", "opted-in")),
+			"every seeded region is opt-in-not-required, so asking for an opted-in one selects nothing")
+	})
+
+	t.Run("wildcards", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeRegions", "region-name", "us-*"))
+		assert.NotEmpty(t, items)
+		for _, r := range items {
+			assert.Contains(t, r.RegionName, "us-")
+		}
+	})
+}
+
+// --- DescribeInstanceTypes ---
+
+// TestEC2_InstanceTypeFilters_FiveOfFiftySeven pins the filters the catalog can answer, which
+// retires the filter half of TODO(#495).
+func TestEC2_InstanceTypeFilters_FiveOfFiftySeven(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	type itype struct {
+		InstanceType string   `xml:"instanceType"`
+		VCpus        int      `xml:"vCpuInfo>defaultVCpus"`
+		MemoryMiB    int      `xml:"memoryInfo>sizeInMiB"`
+		Archs        []string `xml:"processorInfo>supportedArchitectures>item"`
+		UsageClasses []string `xml:"supportedUsageClasses>item"`
+	}
+	describe := func(params map[string]string) []itype {
+		var doc struct {
+			XMLName xml.Name `xml:"DescribeInstanceTypesResponse"`
+			Items   []itype  `xml:"instanceTypeSet>item"`
+		}
+		ec2DescribeXML(t, ts, params, &doc)
+		return doc.Items
+	}
+
+	all := describe(map[string]string{"Action": "DescribeInstanceTypes"})
+	require.Greater(t, len(all), 5)
+	one := all[0]
+
+	t.Run("instance-type", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeInstanceTypes", "instance-type", one.InstanceType))
+		require.Len(t, items, 1)
+		assert.Equal(t, one.InstanceType, items[0].InstanceType)
+	})
+
+	t.Run("instance-type wildcards", func(t *testing.T) {
+		// AWS documents the wildcard on this filter itself: "for example c5.2xlarge or
+		// c5*", the one place a wildcard appears beside a specific filter rather than in
+		// the general rule.
+		items := describe(ec2OneFilter("DescribeInstanceTypes", "instance-type", "c5*"))
+		require.NotEmpty(t, items)
+		for _, it := range items {
+			assert.Contains(t, it.InstanceType, "c5")
+		}
+	})
+
+	t.Run("vcpu-info.default-vcpus", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeInstanceTypes", "vcpu-info.default-vcpus", "2"))
+		require.NotEmpty(t, items)
+		for _, it := range items {
+			assert.Equal(t, 2, it.VCpus)
+		}
+	})
+
+	t.Run("memory-info.size-in-mib", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeInstanceTypes", "memory-info.size-in-mib", "4096"))
+		require.NotEmpty(t, items)
+		for _, it := range items {
+			assert.Equal(t, 4096, it.MemoryMiB)
+		}
+	})
+
+	t.Run("processor-info.supported-architecture", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeInstanceTypes", "processor-info.supported-architecture", "x86_64"))
+		require.NotEmpty(t, items)
+		for _, it := range items {
+			assert.Contains(t, it.Archs, "x86_64")
+		}
+	})
+
+	t.Run("supported-usage-class", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeInstanceTypes", "supported-usage-class", "spot"))
+		require.NotEmpty(t, items)
+		for _, it := range items {
+			assert.Contains(t, it.UsageClasses, "spot")
+		}
+	})
+
+	t.Run("no comparison operators", func(t *testing.T) {
+		// AWS supports no greater-than/less-than on filters, so a numeric filter is a
+		// string match: "4097" selects nothing rather than "more than 4096".
+		assert.Empty(t, describe(ec2OneFilter("DescribeInstanceTypes", "memory-info.size-in-mib", "4097")))
+	})
+
+	t.Run("an inert name selects everything", func(t *testing.T) {
+		for _, filter := range []string{"bare-metal", "hypervisor", "network-info.ipv6-supported"} {
+			items := describe(ec2OneFilter("DescribeInstanceTypes", filter, "no-type-matches"))
+			assert.Len(t, items, len(all), "%s is documented but inert", filter)
+		}
+	})
+}
+
+// --- DescribeSpotPriceHistory ---
+
+// TestEC2_SpotPriceFilters_FiveOfSix pins the filters this page documents, and the
+// ProductDescription.N index fix that rode along.
+func TestEC2_SpotPriceFilters_FiveOfSix(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	type price struct {
+		InstanceType       string `xml:"instanceType"`
+		ProductDescription string `xml:"productDescription"`
+		SpotPrice          string `xml:"spotPrice"`
+		Timestamp          string `xml:"timestamp"`
+		AvailabilityZone   string `xml:"availabilityZone"`
+	}
+	describe := func(params map[string]string) []price {
+		var doc struct {
+			XMLName xml.Name `xml:"DescribeSpotPriceHistoryResponse"`
+			Items   []price  `xml:"spotPriceHistorySet>item"`
+		}
+		ec2DescribeXML(t, ts, params, &doc)
+		return doc.Items
+	}
+
+	all := describe(map[string]string{"Action": "DescribeSpotPriceHistory"})
+	require.Greater(t, len(all), 1)
+	one := all[0]
+
+	t.Run("availability-zone", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeSpotPriceHistory", "availability-zone", one.AvailabilityZone))
+		require.NotEmpty(t, items)
+		for _, p := range items {
+			assert.Equal(t, one.AvailabilityZone, p.AvailabilityZone)
+		}
+		assert.Less(t, len(items), len(all), "one zone's prices are a subset of every zone's")
+	})
+
+	t.Run("instance-type", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeSpotPriceHistory", "instance-type", one.InstanceType))
+		require.NotEmpty(t, items)
+		for _, p := range items {
+			assert.Equal(t, one.InstanceType, p.InstanceType)
+		}
+	})
+
+	t.Run("product-description", func(t *testing.T) {
+		assert.Len(t, describe(ec2OneFilter("DescribeSpotPriceHistory", "product-description", "Linux/UNIX")), len(all))
+		assert.Empty(t, describe(ec2OneFilter("DescribeSpotPriceHistory", "product-description", "Windows")),
+			"substrate's catalog prices Linux/UNIX only")
+	})
+
+	t.Run("spot-price", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeSpotPriceHistory", "spot-price", one.SpotPrice))
+		require.NotEmpty(t, items)
+		for _, p := range items {
+			assert.Equal(t, one.SpotPrice, p.SpotPrice)
+		}
+	})
+
+	t.Run("timestamp matches the rendered value", func(t *testing.T) {
+		// The filter compares what the response renders, which is RFC3339. AWS's own
+		// description gives its example in a third format; comparing against the
+		// rendered value is the only reading that lets a caller filter on something it
+		// can read back.
+		assert.Len(t, describe(ec2OneFilter("DescribeSpotPriceHistory", "timestamp", one.Timestamp)), len(all))
+	})
+
+	t.Run("availability-zone-id is inert", func(t *testing.T) {
+		items := describe(ec2OneFilter("DescribeSpotPriceHistory", "availability-zone-id", "use1-az1"))
+		assert.Len(t, items, len(all), "substrate records no zone ID against a price")
+	})
+
+	t.Run("ProductDescription.N is read at every index", func(t *testing.T) {
+		// Only ProductDescription.1 was consulted before #695, so a caller asking for
+		// two platforms was answered as if it had asked for the first.
+		items := describe(map[string]string{
+			"Action":                 "DescribeSpotPriceHistory",
+			"ProductDescription.1":   "Windows",
+			"ProductDescription.2":   "Linux/UNIX",
+			"MaxResults":             "0",
+			"AvailabilityZone":       one.AvailabilityZone,
+			"InstanceType.1":         one.InstanceType,
+			"ProductDescription.foo": "ignored",
+		})
+		assert.NotEmpty(t, items,
+			"Linux/UNIX at index 2 must be read; before #695 only index 1 was")
+	})
+}
+
+// --- DescribeLaunchTemplates ---
+
+// TestEC2_LaunchTemplateFilters_AllFourEvaluated pins the four filters this page documents
+// and the multi-index selector fix.
+func TestEC2_LaunchTemplateFilters_AllFourEvaluated(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	wantedID := newFleetLaunchTemplate(t, ts, "filter-wanted-lt")
+	otherID := newFleetLaunchTemplate(t, ts, "filter-other-lt")
+	thirdID := newFleetLaunchTemplate(t, ts, "filter-third-lt")
+	ec2TagResource(t, ts, wantedID, "Env", "prod")
+
+	type template struct {
+		LaunchTemplateID   string         `xml:"launchTemplateId"`
+		LaunchTemplateName string         `xml:"launchTemplateName"`
+		CreateTime         string         `xml:"createTime"`
+		Tags               []describedTag `xml:"tagSet>item"`
+	}
+	describe := func(params map[string]string) []template {
+		var doc struct {
+			XMLName xml.Name   `xml:"DescribeLaunchTemplatesResponse"`
+			Items   []template `xml:"launchTemplates>item"`
+		}
+		ec2DescribeXML(t, ts, params, &doc)
+		return doc.Items
+	}
+
+	all := describe(map[string]string{"Action": "DescribeLaunchTemplates"})
+	require.Len(t, all, 3)
+	createTime := all[0].CreateTime
+	require.NotEmpty(t, createTime)
+
+	for _, tc := range []struct{ name, filter, value string }{
+		{"launch-template-name", "launch-template-name", "filter-wanted-lt"},
+		{"launch-template-name wildcards", "launch-template-name", "*wanted*"},
+		{"tag by key and value", "tag:Env", "prod"},
+		{"tag-key", "tag-key", "Env"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items := describe(ec2OneFilter("DescribeLaunchTemplates", tc.filter, tc.value))
+			require.Len(t, items, 1, "%s=%s selected %d templates", tc.filter, tc.value, len(items))
+			assert.Equal(t, "filter-wanted-lt", items[0].LaunchTemplateName)
+		})
+	}
+
+	t.Run("create-time selects every template", func(t *testing.T) {
+		assert.Len(t, describe(ec2OneFilter("DescribeLaunchTemplates", "create-time", createTime)), 3,
+			"all three were created at the same simulated instant")
+	})
+
+	t.Run("every index of both identity lists is read", func(t *testing.T) {
+		// Only LaunchTemplateId.1 and LaunchTemplateName.1 were consulted before #695,
+		// so a caller naming three templates was answered about one — indistinguishable
+		// from the other two not existing.
+		items := describe(map[string]string{
+			"Action":                 "DescribeLaunchTemplates",
+			"LaunchTemplateId.1":     wantedID,
+			"LaunchTemplateId.2":     otherID,
+			"LaunchTemplateName.1":   "filter-third-lt",
+			"LaunchTemplateName.foo": "ignored",
+		})
+		ids := make([]string, 0, len(items))
+		for _, lt := range items {
+			ids = append(ids, lt.LaunchTemplateID)
+		}
+		assert.ElementsMatch(t, []string{wantedID, otherID, thirdID}, ids)
+	})
+
+	t.Run("naming a template twice returns it once", func(t *testing.T) {
+		items := describe(map[string]string{
+			"Action":               "DescribeLaunchTemplates",
+			"LaunchTemplateId.1":   wantedID,
+			"LaunchTemplateName.1": "filter-wanted-lt",
+		})
+		assert.Len(t, items, 1, "the two spellings name one template, and AWS never doubles it")
+	})
+
+	t.Run("a filter still applies to a named template", func(t *testing.T) {
+		items := describe(map[string]string{
+			"Action":             "DescribeLaunchTemplates",
+			"LaunchTemplateId.1": wantedID,
+			"Filter.1.Name":      "tag-key",
+			"Filter.1.Value.1":   "NotATagOnThis",
+		})
+		assert.Empty(t, items, "an ID list and a non-matching filter intersect, as on every other describe")
+	})
+}
+
+// --- DescribeLaunchTemplateVersions ---
+
+// TestEC2_LaunchTemplateVersionFilters_FourOfFourteen pins the filters this page documents
+// that a version's stored data can answer, and that filtering happens before pagination.
+func TestEC2_LaunchTemplateVersionFilters_FourOfFourteen(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	ltID := newFleetLaunchTemplate(t, ts, "version-filters-lt")
+
+	// A second version differing in both filterable data members, so each filter has
+	// something to exclude.
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":                            "CreateLaunchTemplateVersion",
+		"LaunchTemplateId":                  ltID,
+		"LaunchTemplateData.ImageId":        "ami-0000000000000beef",
+		"LaunchTemplateData.InstanceType":   "m5.4xlarge",
+		"LaunchTemplateData.KeyName":        "irrelevant",
+		"LaunchTemplateData.EbsOptimized":   "false",
+		"LaunchTemplateData.DisableApiStop": "false",
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	type version struct {
+		VersionNumber  int64  `xml:"versionNumber"`
+		DefaultVersion bool   `xml:"defaultVersion"`
+		CreateTime     string `xml:"createTime"`
+		ImageID        string `xml:"launchTemplateData>imageId"`
+		InstanceType   string `xml:"launchTemplateData>instanceType"`
+	}
+	describe := func(params map[string]string) []version {
+		var doc struct {
+			XMLName xml.Name  `xml:"DescribeLaunchTemplateVersionsResponse"`
+			Items   []version `xml:"launchTemplateVersionSet>item"`
+		}
+		ec2DescribeXML(t, ts, params, &doc)
+		return doc.Items
+	}
+
+	all := describe(map[string]string{"Action": "DescribeLaunchTemplateVersions", "LaunchTemplateId": ltID})
+	require.Len(t, all, 2)
+	first := all[0]
+
+	t.Run("image-id", func(t *testing.T) {
+		items := describe(map[string]string{
+			"Action": "DescribeLaunchTemplateVersions", "LaunchTemplateId": ltID,
+			"Filter.1.Name": "image-id", "Filter.1.Value.1": "ami-0000000000000beef",
+		})
+		require.Len(t, items, 1)
+		assert.Equal(t, "ami-0000000000000beef", items[0].ImageID)
+	})
+
+	t.Run("instance-type", func(t *testing.T) {
+		items := describe(map[string]string{
+			"Action": "DescribeLaunchTemplateVersions", "LaunchTemplateId": ltID,
+			"Filter.1.Name": "instance-type", "Filter.1.Value.1": "m5.4xlarge",
+		})
+		require.Len(t, items, 1)
+		assert.Equal(t, "m5.4xlarge", items[0].InstanceType)
+	})
+
+	t.Run("is-default-version", func(t *testing.T) {
+		items := describe(map[string]string{
+			"Action": "DescribeLaunchTemplateVersions", "LaunchTemplateId": ltID,
+			"Filter.1.Name": "is-default-version", "Filter.1.Value.1": "true",
+		})
+		require.Len(t, items, 1, "exactly one version is the default")
+		assert.True(t, items[0].DefaultVersion)
+	})
+
+	t.Run("create-time", func(t *testing.T) {
+		items := describe(map[string]string{
+			"Action": "DescribeLaunchTemplateVersions", "LaunchTemplateId": ltID,
+			"Filter.1.Name": "create-time", "Filter.1.Value.1": first.CreateTime,
+		})
+		assert.NotEmpty(t, items)
+	})
+
+	t.Run("an inert name selects every version", func(t *testing.T) {
+		for _, filter := range []string{"ram-disk-id", "kernel-id", "iam-instance-profile"} {
+			items := describe(map[string]string{
+				"Action": "DescribeLaunchTemplateVersions", "LaunchTemplateId": ltID,
+				"Filter.1.Name": filter, "Filter.1.Value.1": "no-version-matches",
+			})
+			assert.Len(t, items, 2, "%s is documented but inert", filter)
+		}
+	})
+
+	t.Run("filters apply before pagination", func(t *testing.T) {
+		// A page must hold MaxResults *matching* versions. Filtering after paging would
+		// answer a MaxResults=1 request with an empty page and a next token, which reads
+		// as "no version matches" to a caller that does not follow the token.
+		var doc struct {
+			XMLName   xml.Name  `xml:"DescribeLaunchTemplateVersionsResponse"`
+			Items     []version `xml:"launchTemplateVersionSet>item"`
+			NextToken string    `xml:"nextToken"`
+		}
+		ec2DescribeXML(t, ts, map[string]string{
+			"Action": "DescribeLaunchTemplateVersions", "LaunchTemplateId": ltID,
+			"MaxResults":    "1",
+			"Filter.1.Name": "instance-type", "Filter.1.Value.1": "m5.4xlarge",
+		}, &doc)
+		require.Len(t, doc.Items, 1)
+		assert.Equal(t, "m5.4xlarge", doc.Items[0].InstanceType)
+		assert.Empty(t, doc.NextToken, "one version matches, so the page is the whole answer")
+	})
+
+	t.Run("an undocumented name is refused before the template is resolved", func(t *testing.T) {
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action":           "DescribeLaunchTemplateVersions",
+			"LaunchTemplateId": "lt-0000000000000dead",
+			"Filter.1.Name":    "not-a-filter",
+			"Filter.1.Value.1": "x",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code,
+			"the filter name is refused rather than the missing template being reported first")
+	})
+}
+
+// --- DescribeInstanceStatus ---
+
+// TestEC2_InstanceStatusFilters_ThreeOfEighteen pins the three filters this operation can
+// answer, which it reads through DescribeInstances' matcher.
+func TestEC2_InstanceStatusFilters_ThreeOfEighteen(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instanceID := ec2TagTestInstance(t, ts)
+
+	type status struct {
+		InstanceID       string `xml:"instanceId"`
+		AvailabilityZone string `xml:"availabilityZone"`
+		StateName        string `xml:"instanceState>name"`
+		StateCode        int    `xml:"instanceState>code"`
+	}
+	describe := func(params map[string]string) []status {
+		var doc struct {
+			XMLName xml.Name `xml:"DescribeInstanceStatusResponse"`
+			Items   []status `xml:"instanceStatusSet>item"`
+		}
+		ec2DescribeXML(t, ts, params, &doc)
+		return doc.Items
+	}
+
+	all := describe(map[string]string{"Action": "DescribeInstanceStatus"})
+	require.Len(t, all, 1)
+	require.NotEmpty(t, all[0].AvailabilityZone,
+		"the availability-zone filter is unreadable if the zone is never rendered")
+
+	for _, tc := range []struct{ name, filter, value string }{
+		{"instance-state-name", "instance-state-name", all[0].StateName},
+		{"instance-state-code", "instance-state-code", "16"},
+		{"availability-zone", "availability-zone", all[0].AvailabilityZone},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items := describe(ec2OneFilter("DescribeInstanceStatus", tc.filter, tc.value))
+			require.Len(t, items, 1)
+			assert.Equal(t, instanceID, items[0].InstanceID)
+		})
+	}
+
+	t.Run("a non-matching value selects nothing", func(t *testing.T) {
+		assert.Empty(t, describe(ec2OneFilter("DescribeInstanceStatus", "instance-state-name", "terminated")))
+		assert.Empty(t, describe(ec2OneFilter("DescribeInstanceStatus", "availability-zone", "eu-west-9z")))
+	})
+
+	t.Run("the health and event families are inert", func(t *testing.T) {
+		// Substrate models no status check, scheduled event or operator, so each of
+		// these is accepted and constrains nothing. Promoting any of them to an
+		// evaluated case on DescribeInstances would silently change this operation too,
+		// which is the hazard describeInstanceStatus' doc comment records.
+		for _, filter := range []string{
+			"system-status.status", "instance-status.status", "event.code", "operator.managed",
+			"availability-zone-id",
+		} {
+			items := describe(ec2OneFilter("DescribeInstanceStatus", filter, "nothing-matches"))
+			assert.Len(t, items, 1, "%s is documented but inert", filter)
+		}
+	})
+}

--- a/emulator/ec2_filter_names_test.go
+++ b/emulator/ec2_filter_names_test.go
@@ -55,6 +55,29 @@ func TestEC2_FilterNames_UndocumentedNameRefused(t *testing.T) {
 		// DescribeSubnets parsed no Filter.N at all before #685, so this name — and every
 		// other — was neither applied nor refused. It is the tenth spec's first case.
 		{"DescribeSubnets", "vpc", "ignored the parameter entirely"},
+
+		// The twelve #695 gave a spec to. Every one is the same former class as
+		// DescribeSubnets — the parameter reached the handler and was never read — so
+		// the rows are not twelve variations on a behavior but twelve operations that
+		// had no filter contract at all. Each name below is a plausible near-miss for a
+		// real one on that page, which is the mistake a refusal is worth having.
+		{"DescribeInstanceStatus", "instance-status", "ignored the parameter entirely"},
+		{"DescribeVpcs", "vpc", "ignored the parameter entirely"},
+		{"DescribeInternetGateways", "internet-gateway", "ignored the parameter entirely"},
+		{"DescribeKeyPairs", "key-pair-name", "ignored the parameter entirely"},
+		{"DescribeAvailabilityZones", "availability-zone", "ignored the parameter entirely"},
+		{"DescribePlacementGroups", "placement-group-name", "ignored the parameter entirely"},
+		// AWS documents no domain filter here, only a domain response element, so the
+		// spelling a caller would most reasonably guess from the response is refused.
+		{"DescribeAddresses", "domain", "ignored the parameter entirely"},
+		{"DescribeRegions", "region", "ignored the parameter entirely"},
+		// vcpu-info.default-cores *is* documented (and inert); vcpu-count is not.
+		{"DescribeInstanceTypes", "vcpu-count", "ignored the parameter entirely"},
+		{"DescribeSpotPriceHistory", "spot-price-history", "ignored the parameter entirely"},
+		// No launch-template-id filter exists on either launch-template page, even
+		// though both take the ID as a parameter — the asymmetry placement groups have.
+		{"DescribeLaunchTemplates", "launch-template-id", "ignored the parameter entirely"},
+		{"DescribeLaunchTemplateVersions", "launch-template-id", "ignored the parameter entirely"},
 	} {
 		t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
 			status, code, message := ec2FilterRefusal(t, tc.action, tc.filter)
@@ -103,6 +126,31 @@ func TestEC2_FilterNames_DocumentedButUnevaluatedIsAccepted(t *testing.T) {
 		{"DescribeFleets", "replace-unhealthy-instances"},
 		{"DescribeSubnets", "ipv6-cidr-block-association.state"},
 		{"DescribeSubnets", "outpost-arn"},
+
+		// #695's nine specs that have an inert name. The three that do not —
+		// DescribeInternetGateways (6/6), DescribeRegions (3/3) and
+		// DescribeLaunchTemplates (4/4) — evaluate every name their page documents, so
+		// they have no row here and any name they accept must be evaluated.
+		{"DescribeInstanceStatus", "system-status.status"},
+		{"DescribeInstanceStatus", "event.code"},
+		{"DescribeInstanceStatus", "availability-zone-id"},
+		{"DescribeVpcs", "dhcp-options-id"},
+		{"DescribeVpcs", "cidr-block-association.cidr-block"},
+		{"DescribeAvailabilityZones", "zone-type"},
+		{"DescribeAvailabilityZones", "parent-zone-id"},
+		{"DescribePlacementGroups", "spread-level"},
+		{"DescribeAddresses", "network-border-group"},
+		{"DescribeAddresses", "network-interface-owner-id"},
+		{"DescribeInstanceTypes", "bare-metal"},
+		{"DescribeInstanceTypes", "hypervisor"},
+		{"DescribeSpotPriceHistory", "availability-zone-id"},
+		// DescribeLaunchTemplateVersions has inert names too, but it cannot appear here:
+		// it answers InvalidLaunchTemplateId.NotFound without a template that exists, and
+		// this table's whole point is that no fixture is needed. Its inert names are
+		// pinned against a real template in
+		// TestEC2_LaunchTemplateVersionFilters_FourOfFourteen, whose last subtest also
+		// pins the ordering — a *refused* name is reported before the missing template,
+		// so the refusal still needs no fixture.
 	} {
 		t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
 			status, code, _ := ec2FilterRefusal(t, tc.action, tc.filter)
@@ -155,6 +203,12 @@ func TestEC2_FilterNames_InertMeansEveryResource(t *testing.T) {
 // tag:<key> and not tag-key — even though a fleet carries tags and DescribeFleets renders
 // them. So the same filter name is a bad request on one operation and valid on its
 // neighbor, which is AWS's set rather than an omission in the transcription.
+//
+// #695 added eight more operations on the refusing side, which is what makes the split worth
+// a test of its own: over half the describes in EC2's family document no tag filter, and a
+// package-wide "tags are always filterable" assumption would be wrong more often than right.
+// DescribeLaunchTemplateVersions is the sharpest case — DescribeLaunchTemplates, the
+// operation next to it on the same page family, documents both tag filters.
 func TestEC2_FilterNames_TagFilterFollowsTheOperation(t *testing.T) {
 	t.Run("refused where the operation documents no tag filter", func(t *testing.T) {
 		for _, tc := range []struct{ action, filter string }{
@@ -162,6 +216,18 @@ func TestEC2_FilterNames_TagFilterFollowsTheOperation(t *testing.T) {
 			{"DescribeFleets", "tag-key"},
 			{"DescribeInstanceTypeOfferings", "tag:Env"},
 			{"DescribeInstanceTypeOfferings", "tag-key"},
+			{"DescribeInstanceStatus", "tag:Env"},
+			{"DescribeInstanceStatus", "tag-key"},
+			{"DescribeAvailabilityZones", "tag:Env"},
+			{"DescribeAvailabilityZones", "tag-key"},
+			{"DescribeRegions", "tag:Env"},
+			{"DescribeRegions", "tag-key"},
+			{"DescribeInstanceTypes", "tag:Env"},
+			{"DescribeInstanceTypes", "tag-key"},
+			{"DescribeSpotPriceHistory", "tag:Env"},
+			{"DescribeSpotPriceHistory", "tag-key"},
+			{"DescribeLaunchTemplateVersions", "tag:Env"},
+			{"DescribeLaunchTemplateVersions", "tag-key"},
 		} {
 			t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
 				status, code, _ := ec2FilterRefusal(t, tc.action, tc.filter)
@@ -181,6 +247,18 @@ func TestEC2_FilterNames_TagFilterFollowsTheOperation(t *testing.T) {
 			{"DescribeNatGateways", "tag-key"},
 			{"DescribeSubnets", "tag:Env"},
 			{"DescribeSubnets", "tag-key"},
+			{"DescribeVpcs", "tag:Env"},
+			{"DescribeVpcs", "tag-key"},
+			{"DescribeInternetGateways", "tag:Env"},
+			{"DescribeInternetGateways", "tag-key"},
+			{"DescribeKeyPairs", "tag:Env"},
+			{"DescribeKeyPairs", "tag-key"},
+			{"DescribePlacementGroups", "tag:Env"},
+			{"DescribePlacementGroups", "tag-key"},
+			{"DescribeAddresses", "tag:Env"},
+			{"DescribeAddresses", "tag-key"},
+			{"DescribeLaunchTemplates", "tag:Env"},
+			{"DescribeLaunchTemplates", "tag-key"},
 		} {
 			t.Run(tc.action+"/"+tc.filter, func(t *testing.T) {
 				status, _, _ := ec2FilterRefusal(t, tc.action, tc.filter)

--- a/emulator/ec2_filters.go
+++ b/emulator/ec2_filters.go
@@ -427,3 +427,286 @@ func ec2FleetFilterSpec() ec2FilterSpec {
 func ec2InstanceTypeOfferingFilterSpec() ec2FilterSpec {
 	return ec2FilterSpec{evaluated: []string{"instance-type", "location"}}
 }
+
+// The twelve specs below are #695's: every remaining EC2 describe that read no Filter.N at
+// all. Until this change each of them accepted a Filter.N on the wire, parsed none of it and
+// answered with every resource in the region — the failure #685 fixed for subnets, twelve
+// times over. An "instance statuses in us-east-1b" question answered with every zone's, and
+// nothing in the response said so.
+//
+// Each spec's names are transcribed from that operation's own reference page, and **none of
+// the twelve pages documents an alias spelling** — no "You can also use" sentence appears on
+// any of them, unlike the subnet page's five. So unlike [ec2SubnetFilterSpec] these carry one
+// spelling per filter.
+
+// ec2InstanceStatusFilterSpec is DescribeInstanceStatus' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html.
+//
+// Eighteen names and **no tag filter** — neither tag:<key> nor tag-key, which is AWS's set
+// even though the operation is over instances and DescribeInstances documents both. An
+// instance status is not the instance.
+//
+// Three are evaluated. The other fifteen name the health model substrate does not keep:
+// there is no reachability check, no scheduled event, and no managed-instance operator, so
+// system-status.status has nothing to compare a value against. That gap is why the response
+// renders instanceState and nothing else.
+func ec2InstanceStatusFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		evaluated: []string{
+			"availability-zone", "instance-state-code", "instance-state-name",
+		},
+		accepted: []string{
+			"application-status.status", "attached-ebs-status.status",
+			"availability-zone-id", "event.code", "event.description",
+			"event.instance-event-id", "event.not-after", "event.not-before",
+			"event.not-before-deadline", "instance-status.reachability",
+			"instance-status.status", "operator.managed", "operator.principal",
+			"system-status.reachability", "system-status.status",
+		},
+	}
+}
+
+// ec2VPCFilterSpec is DescribeVpcs' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcs.html.
+//
+// Six of fifteen evaluated. The nine that are not all name a CIDR *association* — the
+// cidr-block-association and ipv6-cidr-block-association families — or the DHCP option set,
+// and substrate models neither: [EC2VPC] carries one primary CIDR block and no association
+// records, so the association filters have nothing to walk. dhcp-options-id is inert for the
+// same reason the response renders no dhcpOptionsId.
+func ec2VPCFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated: []string{
+			"cidr", "is-default", "owner-id", "state", "tag-key", "vpc-id",
+		},
+		accepted: []string{
+			"cidr-block-association.association-id",
+			"cidr-block-association.cidr-block", "cidr-block-association.state",
+			"dhcp-options-id", "ipv6-cidr-block-association.association-id",
+			"ipv6-cidr-block-association.ipv6-cidr-block",
+			"ipv6-cidr-block-association.ipv6-pool",
+			"ipv6-cidr-block-association.state",
+		},
+	}
+}
+
+// ec2InternetGatewayFilterSpec is DescribeInternetGateways' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInternetGateways.html.
+//
+// Six names, **all six evaluated** — one of three operations in this batch with no inert
+// filter at all, and the only one of those three over a stored resource. [EC2InternetGateway]
+// happens to carry every member the page documents a filter over.
+func ec2InternetGatewayFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated: []string{
+			"attachment.state", "attachment.vpc-id", "internet-gateway-id", "owner-id",
+			"tag-key",
+		},
+	}
+}
+
+// ec2KeyPairFilterSpec is DescribeKeyPairs' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeKeyPairs.html.
+//
+// Five names, all evaluated. Two of them only became answerable in #708, which gave
+// [EC2KeyPair] a Tags field: before it a key pair could hold no tags at all, so tag:<key> and
+// tag-key would have had to be accepted and inert. Landing the two changes in this order is
+// what keeps a claim from being written and then retracted.
+func ec2KeyPairFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated:      []string{"fingerprint", "key-name", "key-pair-id", "tag-key"},
+	}
+}
+
+// ec2AvailabilityZoneFilterSpec is DescribeAvailabilityZones' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html.
+//
+// Eleven names, four evaluated — the four the synthesized zone actually carries. No tag
+// filter: a zone is not a taggable resource.
+//
+// The seven inert ones are inert for a reason worth stating, because it differs from every
+// other spec here: substrate could *invent* a value for most of them. It renders no
+// optInStatus, groupName, groupLongName or messageSet, and a Local Zone or Wavelength Zone
+// has no representation at all — so parent-zone-id, parent-zone-name and zone-type describe
+// a distinction substrate does not draw. Answering them would mean fabricating the answer
+// rather than reading it, which is the line [ec2SubnetItem] draws about
+// availableIpAddressCount.
+func ec2AvailabilityZoneFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		evaluated: []string{"region-name", "state", "zone-id", "zone-name"},
+		accepted: []string{
+			"group-long-name", "group-name", "message", "opt-in-status",
+			"parent-zone-id", "parent-zone-name", "zone-type",
+		},
+	}
+}
+
+// ec2PlacementGroupFilterSpec is DescribePlacementGroups' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePlacementGroups.html.
+//
+// Seven names, six evaluated. Only spread-level is inert — substrate records a strategy but
+// not the host-or-rack level a spread group can be created at.
+//
+// The page documents **no group-id filter** even though GroupId.N is a request parameter, so
+// selection by ID is by parameter and never by filter. That asymmetry is AWS's, and it is the
+// same one DescribeLaunchTemplates has.
+func ec2PlacementGroupFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated: []string{
+			"group-arn", "group-name", "state", "strategy", "tag-key",
+		},
+		accepted: []string{"spread-level"},
+	}
+}
+
+// ec2AddressFilterSpec is DescribeAddresses' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAddresses.html.
+//
+// Ten names, eight evaluated. network-border-group names a zone grouping substrate does not
+// model, and network-interface-owner-id names the *interface's* owner rather than the
+// address's: substrate records an attached interface ID but nothing about who owns it, and
+// answering it with the requesting account would be an invention rather than a read.
+func ec2AddressFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated: []string{
+			"allocation-id", "association-id", "instance-id", "network-interface-id",
+			"private-ip-address", "public-ip", "tag-key",
+		},
+		accepted: []string{"network-border-group", "network-interface-owner-id"},
+	}
+}
+
+// ec2RegionFilterSpec is DescribeRegions' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html.
+//
+// Three names, all evaluated, and no tag filter — the narrowest complete set in EC2's
+// describe family, and the only spec here where "everything AWS documents" and "everything
+// substrate answers" are the same three strings.
+func ec2RegionFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		evaluated: []string{"endpoint", "opt-in-status", "region-name"},
+	}
+}
+
+// ec2InstanceTypeFilterSpec is DescribeInstanceTypes' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html.
+//
+// Fifty-seven names, the widest set in EC2 after DescribeInstances', of which the seeded
+// catalog answers five. That ratio is the whole reason this operation went unfiltered
+// through v0.106.0: TODO(#495) recorded that applying the modellable handful and dropping
+// the rest would repeat #485's silent narrowing. It is no longer a silent drop — the five are
+// applied, and the fifty-two are accepted and listed, which is the distinction
+// [ec2FilterSpec] exists to draw.
+//
+// Every inert name describes an instance-type property [ec2InstanceTypeInfo] does not carry:
+// EBS optimization, NVMe support, ENA and EFA, hypervisor, boot mode, disk layout. The
+// catalog is deliberately small (#495) and this list is what that costs.
+func ec2InstanceTypeFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		evaluated: []string{
+			"instance-type", "memory-info.size-in-mib",
+			"processor-info.supported-architecture", "supported-usage-class",
+			"vcpu-info.default-vcpus",
+		},
+		accepted: []string{
+			"auto-recovery-supported", "bare-metal", "burstable-performance-supported",
+			"current-generation", "dedicated-hosts-supported",
+			"ebs-info.attachment-limit-type",
+			"ebs-info.ebs-optimized-info.baseline-bandwidth-in-mbps",
+			"ebs-info.ebs-optimized-info.baseline-iops",
+			"ebs-info.ebs-optimized-info.baseline-throughput-in-mbps",
+			"ebs-info.ebs-optimized-info.maximum-bandwidth-in-mbps",
+			"ebs-info.ebs-optimized-info.maximum-iops",
+			"ebs-info.ebs-optimized-info.maximum-throughput-in-mbps",
+			"ebs-info.ebs-optimized-support", "ebs-info.encryption-support",
+			"ebs-info.maximum-ebs-attachments", "ebs-info.nvme-support",
+			"free-tier-eligible", "hibernation-supported", "hypervisor",
+			"instance-storage-info.disk.count", "instance-storage-info.disk.size-in-gb",
+			"instance-storage-info.disk.type",
+			"instance-storage-info.encryption-support",
+			"instance-storage-info.nvme-support",
+			"instance-storage-info.total-size-in-gb", "instance-storage-supported",
+			"network-info.bandwidth-weightings",
+			"network-info.efa-info.maximum-efa-interfaces",
+			"network-info.efa-supported", "network-info.ena-support",
+			"network-info.encryption-in-transit-supported",
+			"network-info.flexible-ena-queues-support",
+			"network-info.ipv4-addresses-per-interface",
+			"network-info.ipv6-addresses-per-interface",
+			"network-info.ipv6-supported", "network-info.maximum-network-cards",
+			"network-info.maximum-network-interfaces",
+			"network-info.network-performance", "nitro-enclaves-support",
+			"nitro-tpm-info.supported-versions", "nitro-tpm-support",
+			"processor-info.supported-features",
+			"processor-info.sustained-clock-speed-in-ghz",
+			"reboot-migration-support", "supported-boot-mode",
+			"supported-root-device-type", "supported-virtualization-type",
+			"vcpu-info.default-cores", "vcpu-info.default-threads-per-core",
+			"vcpu-info.valid-cores", "vcpu-info.valid-threads-per-core",
+		},
+	}
+}
+
+// ec2SpotPriceFilterSpec is DescribeSpotPriceHistory' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotPriceHistory.html.
+//
+// Six names, five evaluated. Only availability-zone-id is inert: substrate derives a zone ID
+// for DescribeAvailabilityZones but records none against a price observation, and deriving it
+// here would make the two operations disagree about a zone whose name is not one of the
+// seeded suffixes.
+func ec2SpotPriceFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		evaluated: []string{
+			"availability-zone", "instance-type", "product-description", "spot-price",
+			"timestamp",
+		},
+		accepted: []string{"availability-zone-id"},
+	}
+}
+
+// ec2LaunchTemplateFilterSpec is DescribeLaunchTemplates' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html.
+//
+// Four names, all evaluated. Note what is *not* here: the page documents no
+// launch-template-id filter, so an ID selects only through LaunchTemplateId.N. A caller
+// reaching for `Filter.1.Name=launch-template-id` is refused, which is AWS's set and the most
+// likely wrong guess on this operation.
+//
+// The two tag filters, like DescribeKeyPairs', became answerable in #708 — which was also the
+// first change that let a launch template's own tags be set at all.
+func ec2LaunchTemplateFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		tagValueFilter: true,
+		evaluated:      []string{"create-time", "launch-template-name", "tag-key"},
+	}
+}
+
+// ec2LaunchTemplateVersionFilterSpec is DescribeLaunchTemplateVersions' filter set, from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplateVersions.html.
+//
+// Fourteen names, four evaluated, and **no tag filter** — a version is not separately
+// taggable, so the operation documents neither form even though its parent template's
+// describe documents both.
+//
+// The ten inert names are the launch-template data members substrate does not store: metadata
+// options (http-endpoint, http-protocol-ipv4, http-tokens), the kernel and RAM disk, EBS
+// optimization, and the three ARNs. [EC2LaunchTemplateData] carries the image, instance type,
+// key name, subnet, security groups, user data and block device mappings, and only the first
+// two of those have a documented filter.
+func ec2LaunchTemplateVersionFilterSpec() ec2FilterSpec {
+	return ec2FilterSpec{
+		evaluated: []string{
+			"create-time", "image-id", "instance-type", "is-default-version",
+		},
+		accepted: []string{
+			"ebs-optimized", "host-resource-group-arn", "http-endpoint",
+			"http-protocol-ipv4", "http-tokens", "iam-instance-profile", "kernel-id",
+			"license-configuration-arn", "network-card-index", "ram-disk-id",
+		},
+	}
+}

--- a/emulator/ec2_launchtemplate_versions.go
+++ b/emulator/ec2_launchtemplate_versions.go
@@ -541,8 +541,22 @@ func (p *EC2Plugin) modifyLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 }
 
 // describeLaunchTemplateVersions handles the DescribeLaunchTemplateVersions action.
+//
+// Filter.N was accepted and ignored before #695; four of AWS's fourteen names are evaluated
+// now, per [ec2LaunchTemplateVersionFilterSpec]. The filter names are checked before anything
+// is resolved, so an undocumented name is refused rather than answered after a NotFound for
+// the template — the ordering #687 established and [TestEC2_FilterNames_UndocumentedNameRefusedBeforeTheScan]
+// pins.
+//
+// Filters apply before pagination, so a page holds MaxResults *matching* versions rather than
+// MaxResults versions of which some match.
 func (p *EC2Plugin) describeLaunchTemplateVersions(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
+
+	if err := ec2LaunchTemplateVersionFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 
 	maxResults := ec2MaxLaunchTemplateVersionResults
 	if raw := req.Params["MaxResults"]; raw != "" {
@@ -581,6 +595,16 @@ func (p *EC2Plugin) describeLaunchTemplateVersions(ctx *RequestContext, req *AWS
 		if awsErr != nil {
 			return nil, awsErr
 		}
+	}
+
+	if len(filters) > 0 {
+		kept := make([]ec2LTVersionItem, 0, len(items))
+		for _, item := range items {
+			if ec2LTVersionMatchesFilters(item, filters) {
+				kept = append(kept, item)
+			}
+		}
+		items = kept
 	}
 
 	// Pagination is offset-based over a stable ordering, matching the other EC2

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -1313,14 +1313,41 @@ func (p *EC2Plugin) startInstances(reqCtx *RequestContext, req *AWSRequest) (*AW
 	return ec2XMLResponse(http.StatusOK, resp)
 }
 
+// describeInstanceStatus reports each instance's state.
+//
+// The three filters substrate can evaluate here — availability-zone, instance-state-code and
+// instance-state-name — are spelled identically on DescribeInstances' page and read the same
+// members, so this delegates to [ec2InstanceMatchesFilters] rather than growing a fourteenth
+// matcher that would duplicate three arms.
+//
+// That reuse is safe *because* [ec2InstanceStatusFilterSpec] gates which names arrive: none of
+// the fifteen names it accepts-but-leaves-inert (the health, event and operator families, plus
+// availability-zone-id) appears as a case in [ec2InstanceMatchesFilter], so each falls to its
+// default arm and stays inert. The hazard to know about: promoting one of those names to an
+// evaluated case on DescribeInstances would silently start evaluating it here too, against
+// whatever DescribeInstances means by it. Add an arm to the spec's own matcher instead if the
+// two operations ever need to read one name differently.
+//
+// IncludeAllInstances is not implemented: AWS returns only running instances by default, and
+// substrate returns every instance regardless. Stated in docs/services.md rather than guessed
+// at, because narrowing it would change what a caller with no filters sees.
 func (p *EC2Plugin) describeInstanceStatus(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := newEC2IDFilter(extractIndexedParams(req.Params, "InstanceId"), ec2InstanceIDKind)
 	if err := ids.validate(); err != nil {
 		return nil, err
 	}
+	if err := ec2InstanceStatusFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 	type statusItem struct {
-		InstanceID    string `xml:"instanceId"`
-		InstanceState struct {
+		InstanceID string `xml:"instanceId"`
+		// AvailabilityZone is rendered because the availability-zone filter selects on
+		// it: a caller narrowing to one zone could not otherwise read back which zone
+		// it got, which is the same unreadable-answer defect the filters themselves
+		// were (#695). AWS's own instanceStatusSet item carries it.
+		AvailabilityZone string `xml:"availabilityZone,omitempty"`
+		InstanceState    struct {
 			Code int    `xml:"code"`
 			Name string `xml:"name"`
 		} `xml:"instanceState"`
@@ -1348,7 +1375,10 @@ func (p *EC2Plugin) describeInstanceStatus(reqCtx *RequestContext, req *AWSReque
 		if !ids.match(inst.InstanceID) {
 			continue
 		}
-		si := statusItem{InstanceID: inst.InstanceID}
+		if !ec2InstanceMatchesFilters(inst, filters) {
+			continue
+		}
+		si := statusItem{InstanceID: inst.InstanceID, AvailabilityZone: inst.AvailabilityZone}
 		si.InstanceState.Code = inst.State.Code
 		si.InstanceState.Name = inst.State.Name
 		resp.Items = append(resp.Items, si)
@@ -1392,21 +1422,71 @@ func (p *EC2Plugin) createVPC(reqCtx *RequestContext, req *AWSRequest) (*AWSResp
 		p.logger.Warn("ec2: failed to create default route table", "err", err)
 	}
 
-	type vpcItem struct {
-		VpcID     string `xml:"vpcId"`
-		CIDRBlock string `xml:"cidrBlock"`
-		IsDefault bool   `xml:"isDefault"`
-		State     string `xml:"vpcState"`
-	}
 	type response struct {
-		XMLName xml.Name `xml:"CreateVpcResponse"`
-		XMLNS   string   `xml:"xmlns,attr"`
-		Vpc     vpcItem  `xml:"vpc"`
+		XMLName xml.Name   `xml:"CreateVpcResponse"`
+		XMLNS   string     `xml:"xmlns,attr"`
+		Vpc     ec2VPCItem `xml:"vpc"`
 	}
 	return ec2XMLResponse(http.StatusOK, response{
 		XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/",
-		Vpc:   vpcItem{VpcID: vpcID, CIDRBlock: cidr, State: "available"},
+		Vpc:   ec2VPCXML(vpc),
 	})
+}
+
+// ec2VPCItem renders a VPC as AWS's Vpc element.
+//
+// Shared by CreateVpc and DescribeVpcs for the reason [ec2SubnetItem]'s doc comment gives:
+// AWS documents one Vpc type for both, and two hand-rolled copies drift. These two had
+// already drifted from AWS itself in the same way — both spelled the state element
+// `vpcState`, where AWS's own DescribeVpcs and CreateVpc samples render `<state>available</state>`.
+// Nothing pinned it, so an SDK caller read `State: ""` from both. Fixed here (#695); it is a
+// wire change, and the release notes say so.
+//
+// ownerId is new in #695 because the owner-id filter selects on it, and tagSet because the
+// tag:<key> and tag-key filters do — a filter over a member the response never showed would
+// be unreadable even when it worked.
+//
+// Six members AWS's samples carry are deliberately absent: dhcpOptionsId,
+// instanceTenancy, ipv6CidrBlockAssociationSet, cidrBlockAssociationSet, isDefault's
+// blockPublicAccessStates sibling and encryptionControl. Nothing in [EC2VPC] backs them,
+// which is exactly why [ec2VPCFilterSpec] leaves the CIDR-association and dhcp-options-id
+// filters inert.
+//
+// tagSet is omitted entirely when the VPC has no tags, which is what AWS's DescribeVpcs
+// sample shows for an untagged VPC. DescribeInternetGateways' page shows the opposite — a
+// present-but-empty <tagSet/> — and [ec2InternetGatewayItem] follows it; each response follows
+// its own page, the rule #708 recorded. See [ec2SubnetItem] for why omission needs the
+// pointer-to-wrapper shape rather than `omitempty` on a nested path.
+type ec2VPCItem struct {
+	// VpcID is the VPC's ID.
+	VpcID string `xml:"vpcId"`
+
+	// State is pending or available. Substrate mints VPCs available.
+	State string `xml:"state"`
+
+	// CIDRBlock is the VPC's primary IPv4 CIDR block.
+	CIDRBlock string `xml:"cidrBlock"`
+
+	// OwnerID is the account that owns the VPC.
+	OwnerID string `xml:"ownerId"`
+
+	// IsDefault reports whether this is the account's default VPC for the region.
+	IsDefault bool `xml:"isDefault"`
+
+	// Tags are the VPC's tags, absent when it has none.
+	Tags *ec2TagSetXML `xml:"tagSet,omitempty"`
+}
+
+// ec2VPCXML renders one stored VPC as its response element.
+func ec2VPCXML(vpc EC2VPC) ec2VPCItem {
+	return ec2VPCItem{
+		VpcID:     vpc.VPCID,
+		State:     vpc.State,
+		CIDRBlock: vpc.CIDRBlock,
+		OwnerID:   vpc.AccountID,
+		IsDefault: vpc.IsDefault,
+		Tags:      ec2TagSet(vpc.Tags),
+	}
 }
 
 func (p *EC2Plugin) describeVPCs(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -1414,20 +1494,18 @@ func (p *EC2Plugin) describeVPCs(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	if err := ids.validate(); err != nil {
 		return nil, err
 	}
+	if err := ec2VPCFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "vpc:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeVpcs: %w", err)
 	}
-	type vpcItem struct {
-		VpcID     string `xml:"vpcId"`
-		CIDRBlock string `xml:"cidrBlock"`
-		IsDefault bool   `xml:"isDefault"`
-		State     string `xml:"vpcState"`
-	}
 	type response struct {
-		XMLName xml.Name  `xml:"DescribeVpcsResponse"`
-		XMLNS   string    `xml:"xmlns,attr"`
-		Vpcs    []vpcItem `xml:"vpcSet>item"`
+		XMLName xml.Name     `xml:"DescribeVpcsResponse"`
+		XMLNS   string       `xml:"xmlns,attr"`
+		Vpcs    []ec2VPCItem `xml:"vpcSet>item"`
 	}
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 	for _, k := range allKeys {
@@ -1442,7 +1520,10 @@ func (p *EC2Plugin) describeVPCs(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		if !ids.match(vpc.VPCID) {
 			continue
 		}
-		resp.Vpcs = append(resp.Vpcs, vpcItem{VpcID: vpc.VPCID, CIDRBlock: vpc.CIDRBlock, IsDefault: vpc.IsDefault, State: vpc.State})
+		if !ec2VPCMatchesFilters(vpc, filters) {
+			continue
+		}
+		resp.Vpcs = append(resp.Vpcs, ec2VPCXML(vpc))
 	}
 	if err := ids.unresolved(); err != nil {
 		return nil, err
@@ -1848,15 +1929,64 @@ func (p *EC2Plugin) createInternetGateway(reqCtx *RequestContext, _ *AWSRequest)
 	if err := p.appendToList(reqCtx.AccountID+"/"+reqCtx.Region, "igw_ids", igwID); err != nil {
 		return nil, err
 	}
-	type igwItem struct {
-		InternetGatewayID string `xml:"internetGatewayId"`
-	}
 	type response struct {
-		XMLName xml.Name `xml:"CreateInternetGatewayResponse"`
-		XMLNS   string   `xml:"xmlns,attr"`
-		IGW     igwItem  `xml:"internetGateway"`
+		XMLName xml.Name               `xml:"CreateInternetGatewayResponse"`
+		XMLNS   string                 `xml:"xmlns,attr"`
+		IGW     ec2InternetGatewayItem `xml:"internetGateway"`
 	}
-	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", IGW: igwItem{igwID}})
+	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", IGW: ec2InternetGatewayXML(igw)})
+}
+
+// ec2InternetGatewayAttachmentItem renders one attachment in an internet gateway's
+// attachmentSet.
+type ec2InternetGatewayAttachmentItem struct {
+	// State is the attachment state; AWS documents attaching, attached, detaching,
+	// detached, and substrate mints an attachment available — see [attachInternetGateway].
+	State string `xml:"state"`
+
+	// VpcID is the attached VPC.
+	VpcID string `xml:"vpcId"`
+}
+
+// ec2InternetGatewayItem renders an internet gateway as AWS's InternetGateway element.
+//
+// Shared by CreateInternetGateway and DescribeInternetGateways, which AWS documents with one
+// type; before #695 both rendered internetGatewayId and nothing else, so a caller could not
+// read which VPC a gateway was attached to, who owned it, or what it was tagged with — while
+// DescribeInternetGateways answered every filter over exactly those three things by returning
+// every gateway in the region.
+//
+// Both attachmentSet and tagSet are **present but empty** on an unattached, untagged gateway,
+// because that is what this page's own sample response shows (`<attachmentSet/>`,
+// `<tagSet/>`). That is the opposite of [ec2VPCItem]'s and [ec2SubnetItem]'s convention, whose
+// pages omit an empty tagSet. Each response follows its own page rather than a house style, the
+// rule #708 recorded; the non-pointer nested-path form here renders the empty parent, which is
+// exactly the shape [ec2SubnetItem] needs a pointer to avoid.
+type ec2InternetGatewayItem struct {
+	// Attachments are the VPCs the gateway is attached to, at most one in substrate.
+	Attachments []ec2InternetGatewayAttachmentItem `xml:"attachmentSet>item"`
+
+	// InternetGatewayID is the gateway's ID.
+	InternetGatewayID string `xml:"internetGatewayId"`
+
+	// OwnerID is the account that owns the gateway.
+	OwnerID string `xml:"ownerId"`
+
+	// Tags are the gateway's tags, present and empty when it has none.
+	Tags []ec2TagItem `xml:"tagSet>item"`
+}
+
+// ec2InternetGatewayXML renders one stored internet gateway as its response element.
+func ec2InternetGatewayXML(igw EC2InternetGateway) ec2InternetGatewayItem {
+	item := ec2InternetGatewayItem{
+		InternetGatewayID: igw.InternetGatewayID,
+		OwnerID:           igw.AccountID,
+		Tags:              ec2TagItems(igw.Tags),
+	}
+	for _, a := range igw.Attachments {
+		item.Attachments = append(item.Attachments, ec2InternetGatewayAttachmentItem{State: a.State, VpcID: a.VPCID})
+	}
+	return item
 }
 
 func (p *EC2Plugin) describeInternetGateways(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
@@ -1864,17 +1994,18 @@ func (p *EC2Plugin) describeInternetGateways(reqCtx *RequestContext, req *AWSReq
 	if err := ids.validate(); err != nil {
 		return nil, err
 	}
+	if err := ec2InternetGatewayFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "igw:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeInternetGateways: %w", err)
 	}
-	type igwItem struct {
-		InternetGatewayID string `xml:"internetGatewayId"`
-	}
 	type response struct {
-		XMLName xml.Name  `xml:"DescribeInternetGatewaysResponse"`
-		XMLNS   string    `xml:"xmlns,attr"`
-		IGWs    []igwItem `xml:"internetGatewaySet>item"`
+		XMLName xml.Name                 `xml:"DescribeInternetGatewaysResponse"`
+		XMLNS   string                   `xml:"xmlns,attr"`
+		IGWs    []ec2InternetGatewayItem `xml:"internetGatewaySet>item"`
 	}
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 	for _, k := range allKeys {
@@ -1889,7 +2020,10 @@ func (p *EC2Plugin) describeInternetGateways(reqCtx *RequestContext, req *AWSReq
 		if !ids.match(igw.InternetGatewayID) {
 			continue
 		}
-		resp.IGWs = append(resp.IGWs, igwItem{igw.InternetGatewayID})
+		if !ec2InternetGatewayMatchesFilters(igw, filters) {
+			continue
+		}
+		resp.IGWs = append(resp.IGWs, ec2InternetGatewayXML(igw))
 	}
 	if err := ids.unresolved(); err != nil {
 		return nil, err
@@ -3037,8 +3171,23 @@ func (p *EC2Plugin) createKeyPair(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	})
 }
 
+// describeKeyPairs reports the region's key pairs.
+//
+// Selects on KeyName.N, KeyPairId.N and Filter.N. KeyPairId.N was read by nothing before #695
+// — a caller narrowing by ID got every key pair in the account — and it is matched by
+// membership rather than through [newEC2IDFilter] because no [ec2IDKind] describes a key-pair
+// ID, so there is no malformed-form or NotFound wording to inherit.
+//
+// Neither selector refuses an unknown name or ID. AWS answers InvalidKeyPair.NotFound there;
+// substrate answers an empty set, which docs/services.md states as the gap it is rather than
+// substrate inventing the error's wording.
 func (p *EC2Plugin) describeKeyPairs(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	filterNames := extractIndexedParams(req.Params, "KeyName")
+	filterIDs := extractIndexedParams(req.Params, "KeyPairId")
+	if err := ec2KeyPairFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, ec2StatePrefix("keypair", reqCtx.AccountID, reqCtx.Region))
 	if err != nil {
@@ -3069,7 +3218,10 @@ func (p *EC2Plugin) describeKeyPairs(reqCtx *RequestContext, req *AWSRequest) (*
 		if json.Unmarshal(data, &kp) != nil {
 			continue
 		}
-		if len(filterNames) > 0 && !containsStr(filterNames, kp.KeyName) {
+		if !ec2SelectedByEither(filterNames, kp.KeyName, filterIDs, kp.KeyPairID) {
+			continue
+		}
+		if !ec2KeyPairMatchesFilters(kp, filters) {
 			continue
 		}
 		resp.KeyPairs = append(resp.KeyPairs, kpItem{
@@ -4056,29 +4208,45 @@ func (p *EC2Plugin) deregisterImage(reqCtx *RequestContext, req *AWSRequest) (*A
 
 // --- Availability Zone operations ---
 
-func (p *EC2Plugin) describeAvailabilityZones(reqCtx *RequestContext, _ *AWSRequest) (*AWSResponse, error) {
+// describeAvailabilityZones reports the region's seeded zones.
+//
+// The signature took the request and discarded it before #695, so every documented selector
+// was ignored: ZoneName.N, ZoneId.N and Filter.N alike. A caller asking for one zone got all
+// of them.
+//
+// AllRegions stays unread, and is inert rather than unimplemented: it asks for zones in
+// regions the account has *not* opted into, and every region substrate seeds is
+// opt-in-not-required, so the flag cannot change the answer. Stated in docs/services.md.
+func (p *EC2Plugin) describeAvailabilityZones(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	names := extractIndexedParams(req.Params, "ZoneName")
+	zoneIDs := extractIndexedParams(req.Params, "ZoneId")
+	if err := ec2AvailabilityZoneFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 	region := reqCtx.Region
 	// Derive abbreviated region for zoneId (e.g. "use1" from "us-east-1").
 	abbrev := azRegionAbbrev(region)
-	type azItem struct {
-		ZoneName   string `xml:"zoneName"`
-		State      string `xml:"zoneState"`
-		RegionName string `xml:"regionName"`
-		ZoneID     string `xml:"zoneId"`
-	}
 	type response struct {
-		XMLName           xml.Name `xml:"DescribeAvailabilityZonesResponse"`
-		XMLNS             string   `xml:"xmlns,attr"`
-		AvailabilityZones []azItem `xml:"availabilityZoneInfo>item"`
+		XMLName           xml.Name                  `xml:"DescribeAvailabilityZonesResponse"`
+		XMLNS             string                    `xml:"xmlns,attr"`
+		AvailabilityZones []ec2AvailabilityZoneItem `xml:"availabilityZoneInfo>item"`
 	}
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 	for i, suffix := range ec2SeededAZSuffixes {
-		resp.AvailabilityZones = append(resp.AvailabilityZones, azItem{
+		az := ec2AvailabilityZoneItem{
 			ZoneName:   region + suffix,
 			State:      "available",
 			RegionName: region,
 			ZoneID:     abbrev + "-az" + strconv.Itoa(i+1),
-		})
+		}
+		if !ec2SelectedByEither(names, az.ZoneName, zoneIDs, az.ZoneID) {
+			continue
+		}
+		if !ec2AvailabilityZoneMatchesFilters(az, filters) {
+			continue
+		}
+		resp.AvailabilityZones = append(resp.AvailabilityZones, az)
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -4091,16 +4259,22 @@ func (p *EC2Plugin) describeAvailabilityZones(reqCtx *RequestContext, _ *AWSRequ
 type ec2PlacementGroupXML struct {
 	GroupName string        `xml:"groupName"`
 	GroupID   string        `xml:"groupId"`
+	GroupARN  string        `xml:"groupArn"`
 	Strategy  string        `xml:"strategy"`
 	State     string        `xml:"state"`
 	Tags      *ec2TagSetXML `xml:"tagSet,omitempty"`
 }
 
 // ec2PlacementGroupSummary renders a placement group as AWS's placementGroup element.
+//
+// groupArn is rendered as of #695, when the group-arn filter started selecting on it: a filter
+// over a value the response never showed would leave a caller unable to read back what it
+// matched. The string comes from [ec2PlacementGroupARN], the one spelling the filter also uses.
 func ec2PlacementGroupSummary(pg EC2PlacementGroup) ec2PlacementGroupXML {
 	return ec2PlacementGroupXML{
 		GroupName: pg.GroupName,
 		GroupID:   pg.GroupID,
+		GroupARN:  ec2PlacementGroupARN(pg.AccountID, pg.Region, pg.GroupName),
 		Strategy:  pg.Strategy,
 		State:     pg.State,
 		Tags:      ec2TagSet(pg.Tags),
@@ -4167,8 +4341,20 @@ func (p *EC2Plugin) createPlacementGroup(reqCtx *RequestContext, req *AWSRequest
 
 // describePlacementGroups lists placement groups, optionally filtered by
 // GroupName.N parameters (#344).
+// describePlacementGroups reports the region's placement groups.
+//
+// Selects on GroupName.N, GroupId.N and Filter.N. GroupId.N is documented and was read by
+// nothing before #695; it is matched by membership rather than through [newEC2IDFilter]
+// because #708 left the ID-vs-name question this operation raises deliberately open — the ARN
+// is by name, and no group-id filter exists — so refusing a malformed pg- form here would
+// settle by accident what that PR recorded as underdetermined.
 func (p *EC2Plugin) describePlacementGroups(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	names := extractIndexedParams(req.Params, "GroupName")
+	groupIDs := extractIndexedParams(req.Params, "GroupId")
+	if err := ec2PlacementGroupFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 	allKeys, err := p.state.List(context.Background(), ec2Namespace,
 		ec2StatePrefix("placement_group", reqCtx.AccountID, reqCtx.Region))
 	if err != nil {
@@ -4191,7 +4377,10 @@ func (p *EC2Plugin) describePlacementGroups(reqCtx *RequestContext, req *AWSRequ
 		if json.Unmarshal(data, &pg) != nil {
 			continue
 		}
-		if len(names) > 0 && !containsStr(names, pg.GroupName) {
+		if !ec2SelectedByEither(names, pg.GroupName, groupIDs, pg.GroupID) {
+			continue
+		}
+		if !ec2PlacementGroupMatchesFilters(pg, filters) {
 			continue
 		}
 		resp.Groups = append(resp.Groups, ec2PlacementGroupSummary(pg))
@@ -4480,23 +4669,40 @@ func (p *EC2Plugin) releaseAddress(reqCtx *RequestContext, req *AWSRequest) (*AW
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
 }
 
+// describeAddresses reports the region's Elastic IPs.
+//
+// Selects on AllocationId.N, PublicIp.N and Filter.N. PublicIp.N is documented and was read by
+// nothing before #695; unlike AllocationId.N it goes through plain membership, because an
+// address is not an EC2 ID and there is no InvalidAddress.Malformed form to check against.
+//
+// No pagination: this operation publishes no MaxResults or NextToken, so there is none to add.
 func (p *EC2Plugin) describeAddresses(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	filterIDs := newEC2IDFilter(extractIndexedParams(req.Params, "AllocationId"), ec2AllocationIDKind)
+	allocationIDs := extractIndexedParams(req.Params, "AllocationId")
+	filterIDs := newEC2IDFilter(allocationIDs, ec2AllocationIDKind)
 	if err := filterIDs.validate(); err != nil {
 		return nil, err
 	}
+	publicIPs := extractIndexedParams(req.Params, "PublicIp")
+	if err := ec2AddressFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 	allKeys, err := p.state.List(context.Background(), ec2Namespace, "eip:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
 	if err != nil {
 		return nil, fmt.Errorf("ec2 describeAddresses list: %w", err)
 	}
+	// tagSet is omitted when the address carries none, following this page's samples —
+	// none of which shows a tagSet on an untagged address. See [ec2TagSetXML] for why
+	// omission needs the wrapper.
 	type addressItem struct {
-		AllocationID       string `xml:"allocationId"`
-		PublicIP           string `xml:"publicIp"`
-		AssociationID      string `xml:"associationId,omitempty"`
-		InstanceID         string `xml:"instanceId,omitempty"`
-		NetworkInterfaceID string `xml:"networkInterfaceId,omitempty"`
-		PrivateIPAddress   string `xml:"privateIpAddress,omitempty"`
-		Domain             string `xml:"domain"`
+		AllocationID       string        `xml:"allocationId"`
+		PublicIP           string        `xml:"publicIp"`
+		AssociationID      string        `xml:"associationId,omitempty"`
+		InstanceID         string        `xml:"instanceId,omitempty"`
+		NetworkInterfaceID string        `xml:"networkInterfaceId,omitempty"`
+		PrivateIPAddress   string        `xml:"privateIpAddress,omitempty"`
+		Domain             string        `xml:"domain"`
+		Tags               *ec2TagSetXML `xml:"tagSet,omitempty"`
 	}
 	type response struct {
 		XMLName   xml.Name      `xml:"DescribeAddressesResponse"`
@@ -4513,7 +4719,18 @@ func (p *EC2Plugin) describeAddresses(reqCtx *RequestContext, req *AWSRequest) (
 		if json.Unmarshal(data, &eip) != nil {
 			continue
 		}
-		if !filterIDs.match(eip.AllocationID) {
+		// AllocationId.N and PublicIp.N union, for the reason [ec2SelectedByEither]
+		// records — written out here rather than delegating because
+		// [ec2IDFilter.match] must be called for every address whatever selects it: it
+		// is what records that a requested allocation ID resolved, and skipping it
+		// would turn an address selected by its public IP into a NotFound for its own
+		// allocation ID.
+		selectedByID := len(allocationIDs) > 0 && filterIDs.match(eip.AllocationID)
+		selectedByIP := len(publicIPs) > 0 && containsStr(publicIPs, eip.PublicIP)
+		if (len(allocationIDs) > 0 || len(publicIPs) > 0) && !selectedByID && !selectedByIP {
+			continue
+		}
+		if !ec2AddressMatchesFilters(eip, filters) {
 			continue
 		}
 		resp.Addresses = append(resp.Addresses, addressItem{
@@ -4524,6 +4741,7 @@ func (p *EC2Plugin) describeAddresses(reqCtx *RequestContext, req *AWSRequest) (
 			NetworkInterfaceID: eip.NetworkInterfaceID,
 			PrivateIPAddress:   eip.PrivateIPAddress,
 			Domain:             eip.Domain,
+			Tags:               ec2TagSet(eip.Tags),
 		})
 	}
 	if err := filterIDs.unresolved(); err != nil {
@@ -4765,6 +4983,15 @@ var ec2SeededRegions = []struct {
 	{"eu-west-1", "ec2.eu-west-1.amazonaws.com"},
 }
 
+// describeRegions reports the seeded regions.
+//
+// All three filters this operation documents — endpoint, opt-in-status and region-name — are
+// evaluated as of #695; before it, Filter.N was accepted and ignored.
+//
+// AllRegions is not read, and cannot change the answer: it asks for regions the account has
+// not opted into, and every seeded region is opt-in-not-required. By the same token an
+// opt-in-status filter naming opted-in or not-opted-in selects nothing, which is the honest
+// answer rather than a gap.
 func (p *EC2Plugin) describeRegions(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	// Build optional RegionName.N filter.
 	wanted := map[string]bool{}
@@ -4776,15 +5003,15 @@ func (p *EC2Plugin) describeRegions(_ *RequestContext, req *AWSRequest) (*AWSRes
 		wanted[v] = true
 	}
 
-	type regionItem struct {
-		RegionName     string `xml:"regionName"`
-		RegionEndpoint string `xml:"regionEndpoint"`
-		OptInStatus    string `xml:"optInStatus"`
+	if err := ec2RegionFilterSpec().check(req.Params); err != nil {
+		return nil, err
 	}
+	filters := extractEC2Filters(req.Params)
+
 	type response struct {
-		XMLName    xml.Name     `xml:"DescribeRegionsResponse"`
-		XMLNS      string       `xml:"xmlns,attr"`
-		RegionInfo []regionItem `xml:"regionInfo>item"`
+		XMLName    xml.Name        `xml:"DescribeRegionsResponse"`
+		XMLNS      string          `xml:"xmlns,attr"`
+		RegionInfo []ec2RegionItem `xml:"regionInfo>item"`
 	}
 
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
@@ -4792,11 +5019,15 @@ func (p *EC2Plugin) describeRegions(_ *RequestContext, req *AWSRequest) (*AWSRes
 		if len(wanted) > 0 && !wanted[r.Name] {
 			continue
 		}
-		resp.RegionInfo = append(resp.RegionInfo, regionItem{
+		item := ec2RegionItem{
 			RegionName:     r.Name,
 			RegionEndpoint: r.Endpoint,
 			OptInStatus:    "opt-in-not-required",
-		})
+		}
+		if !ec2RegionMatchesFilters(item, filters) {
+			continue
+		}
+		resp.RegionInfo = append(resp.RegionInfo, item)
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -4805,12 +5036,17 @@ func (p *EC2Plugin) describeRegions(_ *RequestContext, req *AWSRequest) (*AWSRes
 
 // describeInstanceTypes answers from the seeded [ec2InstanceTypeCatalog].
 //
-// Filter.N is not applied. The operation documents some 60 filter names, nearly all over
-// response fields the seeded catalog does not carry, so applying the handful that are
-// modellable and ignoring the rest would be the same silent-narrowing defect #485
-// reported on the offerings operation (TODO(#495): apply the filters the catalog can
-// answer and refuse the rest). InstanceType.N is honored, and unlike a filter it is an
-// assertion that the types exist.
+// Filter.N is applied through [ec2InstanceTypeFilterSpec] and
+// [ec2InstanceTypeMatchesFilters]: five of the fifty-seven documented names are evaluated,
+// the other fifty-two are accepted and inert, and an undocumented one is refused. That is
+// what #695 settled and what retires TODO(#495)'s filter half — the concern it recorded was
+// that applying the modellable handful and *silently dropping* the rest would repeat the
+// narrowing defect #485 found on the offerings operation, and the evaluated/accepted split is
+// the answer to it: an inert name constrains nothing and is listed as inert in
+// docs/services.md, rather than looking applied.
+//
+// InstanceType.N is honored, and unlike a filter it is an assertion that the types exist.
+// IncludeUnsupportedInRegion is not read; the catalog is the same in every region.
 func (p *EC2Plugin) describeInstanceTypes(_ *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	requested := indexedParams(req.Params, "InstanceType.%d")
 	if err := ec2CheckInstanceTypesExist(requested); err != nil {
@@ -4820,6 +5056,10 @@ func (p *EC2Plugin) describeInstanceTypes(_ *RequestContext, req *AWSRequest) (*
 	for _, t := range requested {
 		wanted[t] = true
 	}
+	if err := ec2InstanceTypeFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 
 	type gpuInfoItem struct {
 		Count int `xml:"gpus>item>count"`
@@ -4854,6 +5094,9 @@ func (p *EC2Plugin) describeInstanceTypes(_ *RequestContext, req *AWSRequest) (*
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 	for _, info := range ec2InstanceTypeCatalog {
 		if len(wanted) > 0 && !wanted[info.InstanceType] {
+			continue
+		}
+		if !ec2InstanceTypeMatchesFilters(info, filters) {
 			continue
 		}
 		item := instanceTypeItem{
@@ -4974,26 +5217,25 @@ func (p *EC2Plugin) describeSpotPriceHistory(reqCtx *RequestContext, req *AWSReq
 	for _, t := range indexedParams(req.Params, "InstanceType.%d") {
 		wantedTypes[t] = true
 	}
-	// AZ filter.
+	// AZ filter — a scalar on this operation, not indexed, per AWS's parameter list.
 	azFilter := req.Params["AvailabilityZone"]
-	// ProductDescription filter (e.g. "Linux/UNIX").
-	pdFilter := req.Params["ProductDescription.1"]
+	// ProductDescription.N filter (e.g. "Linux/UNIX"). Read at every index as of #695;
+	// before it only ProductDescription.1 was consulted, so a caller asking for two
+	// platforms was answered as if it had asked for the first.
+	pdFilter := indexedParams(req.Params, "ProductDescription.%d")
+	if err := ec2SpotPriceFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
 
 	region := reqCtx.Region
 	// Stub timestamp: use time controller's current time.
 	ts := p.tc.Now().UTC().Format(time.RFC3339)
 
-	type spotPriceItem struct {
-		InstanceType       string `xml:"instanceType"`
-		ProductDescription string `xml:"productDescription"`
-		SpotPrice          string `xml:"spotPrice"`
-		Timestamp          string `xml:"timestamp"`
-		AvailabilityZone   string `xml:"availabilityZone"`
-	}
 	type response struct {
-		XMLName          xml.Name        `xml:"DescribeSpotPriceHistoryResponse"`
-		XMLNS            string          `xml:"xmlns,attr"`
-		SpotPriceHistory []spotPriceItem `xml:"spotPriceHistorySet>item"`
+		XMLName          xml.Name           `xml:"DescribeSpotPriceHistoryResponse"`
+		XMLNS            string             `xml:"xmlns,attr"`
+		SpotPriceHistory []ec2SpotPriceItem `xml:"spotPriceHistorySet>item"`
 	}
 
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
@@ -5002,7 +5244,7 @@ func (p *EC2Plugin) describeSpotPriceHistory(reqCtx *RequestContext, req *AWSReq
 			continue
 		}
 		desc := "Linux/UNIX"
-		if pdFilter != "" && pdFilter != desc {
+		if len(pdFilter) > 0 && !containsStr(pdFilter, desc) {
 			continue
 		}
 		for _, suffix := range ec2SeededAZSuffixes {
@@ -5010,13 +5252,17 @@ func (p *EC2Plugin) describeSpotPriceHistory(reqCtx *RequestContext, req *AWSReq
 			if azFilter != "" && azFilter != az {
 				continue
 			}
-			resp.SpotPriceHistory = append(resp.SpotPriceHistory, spotPriceItem{
+			item := ec2SpotPriceItem{
 				InstanceType:       info.InstanceType,
 				ProductDescription: desc,
 				SpotPrice:          info.SpotPrice,
 				Timestamp:          ts,
 				AvailabilityZone:   az,
-			})
+			}
+			if !ec2SpotPriceMatchesFilters(item, filters) {
+				continue
+			}
+			resp.SpotPriceHistory = append(resp.SpotPriceHistory, item)
 		}
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
@@ -5309,20 +5555,52 @@ func ec2LaunchTemplateSummary(lt *EC2LaunchTemplate) ec2LaunchTemplateXML {
 	}
 }
 
+// describeLaunchTemplates reports the region's launch templates.
+//
+// Two defects fixed in #695. Filter.N was accepted and ignored, so "the templates tagged
+// Env=prod" answered with every template in the region. And only LaunchTemplateId.1 and
+// LaunchTemplateName.1 were read, so a caller naming three templates was answered about one
+// — silently, since a one-element answer to a three-element question looks like two of them
+// not existing.
+//
+// The two identity lists union, per [ec2SelectedByEither]. Each named template is resolved
+// through [EC2Plugin.resolveLaunchTemplate] rather than scanned for, because that is the
+// lookup CreateLaunchTemplateVersion and RunInstances use, and a describe that resolved names
+// differently from the operations that consume them would disagree with itself.
+//
+// An unknown ID or name still yields an empty set rather than
+// InvalidLaunchTemplateId.NotFound, which AWS publishes: that code has no [ec2IDKind] entry,
+// and #713 recorded inventing one as out of its scope. docs/services.md states the gap.
 func (p *EC2Plugin) describeLaunchTemplates(ctx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	goCtx := context.Background()
 	var lts []EC2LaunchTemplate
 
-	filterID := req.Params["LaunchTemplateId.1"]
-	filterName := req.Params["LaunchTemplateName.1"]
+	if err := ec2LaunchTemplateFilterSpec().check(req.Params); err != nil {
+		return nil, err
+	}
+	filters := extractEC2Filters(req.Params)
+	filterIDs := extractIndexedParams(req.Params, "LaunchTemplateId")
+	filterNames := extractIndexedParams(req.Params, "LaunchTemplateName")
 
 	switch {
-	case filterID != "":
-		if lt := p.resolveLaunchTemplate(goCtx, ctx, filterID, ""); lt != nil {
+	case len(filterIDs) > 0 || len(filterNames) > 0:
+		// Dedup by ID: a request may name the same template by both spellings, and
+		// answering with it twice would be a shape AWS never produces.
+		seen := map[string]bool{}
+		for _, id := range filterIDs {
+			lt := p.resolveLaunchTemplate(goCtx, ctx, id, "")
+			if lt == nil || seen[lt.LaunchTemplateID] {
+				continue
+			}
+			seen[lt.LaunchTemplateID] = true
 			lts = append(lts, *lt)
 		}
-	case filterName != "":
-		if lt := p.resolveLaunchTemplate(goCtx, ctx, "", filterName); lt != nil {
+		for _, name := range filterNames {
+			lt := p.resolveLaunchTemplate(goCtx, ctx, "", name)
+			if lt == nil || seen[lt.LaunchTemplateID] {
+				continue
+			}
+			seen[lt.LaunchTemplateID] = true
 			lts = append(lts, *lt)
 		}
 	default:
@@ -5349,6 +5627,9 @@ func (p *EC2Plugin) describeLaunchTemplates(ctx *RequestContext, req *AWSRequest
 
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
 	for i := range lts {
+		if !ec2LaunchTemplateMatchesFilters(lts[i], filters) {
+			continue
+		}
 		resp.LaunchTemplates = append(resp.LaunchTemplates, ec2LaunchTemplateSummary(&lts[i]))
 	}
 	return ec2XMLResponse(http.StatusOK, resp)


### PR DESCRIPTION
Closes #695

Twelve EC2 describes declared a `Filters` parameter on their reference page and never parsed
one: `DescribeInstanceStatus`, `DescribeVpcs`, `DescribeInternetGateways`, `DescribeKeyPairs`,
`DescribeAvailabilityZones`, `DescribePlacementGroups`, `DescribeAddresses`, `DescribeRegions`,
`DescribeInstanceTypes`, `DescribeSpotPriceHistory`, `DescribeLaunchTemplates` and
`DescribeLaunchTemplateVersions`. A filter reached the handler and was discarded, so a request
for one VPC by `cidr` answered with every VPC in the account.

With this, **twenty-three of the twenty-four EC2 describes substrate serves parse `Filter.N`**.
The exception is `DescribeInstanceAttribute`, whose page documents no `Filters` parameter at all.

## Correction to the issue

#695 says *fourteen* describes never parse `Filter.N`. It is **twelve**: `DescribeSubnets`
landed in #685 and `DescribeTags` in #688, and `DescribeInstanceAttribute` documents no
`Filters` parameter and is excluded rather than fixed.

## Evaluated, or accepted and inert

Three of the twelve evaluate **every** name their page documents — `DescribeInternetGateways`
(6/6), `DescribeRegions` (3/3), `DescribeLaunchTemplates` (4/4). The rest evaluate what
substrate's records can answer and accept the remainder as inert, each inert name listed per
operation in `docs/services.md`. An **undocumented** name is refused with
`InvalidParameterValue`, per #687.

That split is what closes `TODO(#495)` on `DescribeInstanceTypes`. #495's objection to applying
five of fifty-seven filters was never the five — it was that dropping the fifty-two *silently*
is indistinguishable from applying them. Naming every inert one resolves that; the code no
longer contradicts its own doc comment, which claimed `Filter.N` was unapplied directly above a
line applying it.

Eight of the twelve document no tag filter, which is why the choice is per operation.
`DescribeLaunchTemplates` documents both `tag:<key>` and `tag-key` while
`DescribeLaunchTemplateVersions`, on the same page family, documents neither.

## Wire changes a consumer should know about

- `DescribeVpcs`/`CreateVpc` name the state element **`state`**, not `vpcState` — both of AWS's
  samples render `<state>available</state>`.
- **Seven response members appear** where they were absent, each because a filter now selects on
  it: `ownerId` and `tagSet` on a VPC; `ownerId`, `attachmentSet` and `tagSet` on an internet
  gateway; `groupArn` on a placement group; `tagSet` on an address; `availabilityZone` on an
  instance status.
- The empty-value convention **follows each page rather than a house style**: an internet gateway
  renders `<attachmentSet/>` and `<tagSet/>` when empty because its sample does; a VPC and an
  address omit `tagSet` because theirs do.
- `DescribeLaunchTemplateVersions` filters **before** it paginates.
- Fixed: `LaunchTemplateId.N`, `LaunchTemplateName.N` and `ProductDescription.N` were read at
  **index 1 only**, so a caller naming three templates was answered about one.

The `CreateVpc`/`DescribeVpcs` and `CreateInternetGateway`/`DescribeInternetGateways` renderers
were separate structs that had drifted; each pair now emits one shape by construction. Two tests
pin that, and both were vacuous until they asserted the members *present* — equality alone was
satisfied by the two responses being equally blank, which is exactly what they were before.

## Provenance

- **A paired identity list is a union, not an intersection**, and AWS documents no rule. Five
  operations take one: `KeyName.N`/`KeyPairId.N`, `ZoneName.N`/`ZoneId.N`,
  `GroupName.N`/`GroupId.N`, `AllocationId.N`/`PublicIp.N`,
  `LaunchTemplateId.N`/`LaunchTemplateName.N`. The reading comes from what AWS *does* document:
  an unresolvable name or ID answers `NotFound` rather than an empty set, which only makes sense
  if every identifier named is expected in the response — and an intersection would answer
  nothing for two identifiers that each resolve.
- **Six new selectors answer an empty set where AWS answers `NotFound`** — `KeyName.N`,
  `KeyPairId.N`, `GroupName.N`/`GroupId.N` on placement groups, `ZoneName.N`/`ZoneId.N`,
  `PublicIp.N`. Stated as a gap in the docs rather than papered over.
- Refusing an undocumented filter name is **observed, not documented** — the carried-forward
  provenance of #687.
- No pagination was added. Four of the twelve (`DescribeAddresses`, `DescribeKeyPairs`,
  `DescribeAvailabilityZones`, `DescribePlacementGroups`) publish no `MaxResults`/`NextToken`.
- Also left standing, and named in the docs: `IncludeAllInstances` and
  `IncludeUnsupportedInRegion` are unread, and `AllRegions` is inert.

## Verification

22 new tests in `emulator/ec2_describe_filters_test.go`; **20 of 21 fail at the base commit**
(verified in a throwaway worktree, not asserted). The one that passes,
`_InertNameSelectsEverything`, pins an invariant by design. The three tripwire tables in
`ec2_filter_names_test.go` gained 12, 13 and 14 rows.

\`\`\`
gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...   # clean
make test                                                                 # race on, green
make coverage                                                             # emulator 83.2%, total 82.5%
make docs-reference docs-reference-check docs-versions                    # up to date
npm --prefix docs run build                                               # + href/id diff: no dangling anchors
go vet -C test/e2e ./... && go test -C test/e2e ./...                     # green
\`\`\`