### PR TITLE
fix(ec2): CreateVolume invents neither a size nor a zone (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot be used."
 
 ### Changed
+- **`CreateVolume` invents neither a size nor an Availability Zone** (#712). AWS puts two
+  combination rules on the operation and marks every member involved `Required: No`, because
+  each requirement is on a *pair*: "You must specify either a snapshot ID or a volume size" and,
+  said once on each member, "Either `AvailabilityZone` or `AvailabilityZoneId` must be specified,
+  but not both." Substrate read neither. A request naming no size got a silent 8 GiB volume, one
+  naming `Size=-1` or `Size=eight` got the same — the parse was
+  `if n, err := strconv.Atoi(s); err == nil && n > 0` with no `else`, discarding both the error
+  and the out-of-range value — and one naming no zone got `<region>a`. Each returned HTTP 200
+  with a volume ID, so the volume was real, at a size and in a zone the caller never asked for,
+  and the first visible symptom was an attach failing later with nothing to point at. Both rules
+  are enforced now: `InvalidParameterCombination` for either broken pair (including a zone named
+  **both** ways, since AWS says "not both"), and `InvalidParameterValue` for a `Size` that is not
+  a positive integer. All three refusals land before the state write, so a refused call leaves
+  no volume.
+
+  **`AvailabilityZoneId` is read for the first time** — it was ignored outright, so a request
+  naming a zone by ID created a volume in zone `a`. It resolves through the same derivation
+  `DescribeAvailabilityZones` renders from, so a zone ID read out of one operation is one the
+  other accepts. Two asymmetries are deliberate: a zone *name* is recorded as given and not
+  checked against the seeded zones, because unlike an ID it needs no translation to be stored;
+  and an unresolvable zone ID answers `InvalidParameterValue` rather than the combination code.
+
+  #712's own premise is corrected in passing: it quotes AWS as documenting "Size is required
+  unless SnapshotId is specified" and `AvailabilityZone` as required. Neither sentence exists.
+  Both members are `Required: No` and the rules are the combination ones above.
+
+  Provenance: **the codes are substrate's reading.** `CreateVolume`'s Errors section is empty —
+  it publishes no operation-specific error at all — and `InvalidParameterCombination`'s EC2
+  client-error gloss is the only one whose shape fits: "The request includes an incorrect
+  combination of parameters, **or a missing parameter**." Left standing and stated in the docs:
+  AWS's per-type size ranges (`gp2` 1–16384, `io1` 4–16384, `st1`/`sc1` 125–16384, …) are still
+  unenforced, and `Iops`/`Throughput` keep their tolerance for an unparseable value. `Size` and
+  `Iops` differ because their absences differ — a volume must have a size, while omitting `Iops`
+  is the ordinary case for the five volume types that do not take one.
+
 - **A tagging ID whose prefix names no taggable type is refused, not ignored** (#708).
   `CreateTags`/`DeleteTags` answer `InvalidID` / HTTP 400 — "The ID '<id>' for the resource you
   are trying to tag is not valid. Ensure that you provide the full resource ID; for example,
@@ -237,6 +272,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a description of the condition, never a wire message.
 
 ### Fixed
+- **A zone ID takes the shape AWS publishes** (#712). The derivation produced `ue11-az1` for
+  `us-east-1` — the wrong prefix and a doubled digit — where AWS publishes `use1-az1`, and the
+  code's own comment claimed `use1`. Nothing caught it because a zone ID was only ever
+  *emitted*: a test that read one out of `DescribeAvailabilityZones` and filtered on it was
+  self-consistent whatever the string said. `CreateVolume` now accepts one as **input**, so a
+  fixture carrying the real `use1-az1` would have been refused. The prefix is AWS's published
+  table, which refutes AWS's own summarising sentence ("the first three letters of the Region
+  code, followed by the number at the end"): that rule gives `aps2` for `ap-southeast-2`, and
+  the table says `apse2`. The real shape is the first segment verbatim, one letter per compass
+  word, then the trailing number — pinned against 18 rows copied from the table.
+
+  Two limits are stated rather than left to be found: substrate always maps zone `a` to `-az1`,
+  where AWS says "we independently map Availability Zones to codes for each AWS account", so
+  substrate will agree with an assumption real AWS breaks; and a zone *name* is still not
+  validated against the seeded zones.
+
+- **A flaky filter test no longer depends on the wall clock** (#712). `DescribeSpotPriceHistory`
+  renders its timestamp from the time controller at scale 1.0, so the RFC3339 value changes at
+  every second boundary. #695's timestamp subtest read the value out of one response and
+  filtered on it in the next, which failed whenever a second elapsed between the two — roughly
+  one run in sixty, on `main`. It runs against a frozen clock now (scale zero, reachable only
+  in-process, since `POST /v1/control/scale` refuses a non-positive scale).
+
 - **An `ami-` ID is authorized against the account-less ARN AWS documents** (#708).
   `arn:${Partition}:ec2:${Region}::image/${ImageId}` has a deliberately empty account field,
   as does a snapshot's, where the other thirteen taggable types carry `${Account}`. The

--- a/docs/services.md
+++ b/docs/services.md
@@ -2774,7 +2774,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | AttachInternetGateway | |
 | DescribeInternetGateways | [Explicit resource IDs](#explicit-resource-ids); **all six** filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); reports `ownerId`, `attachmentSet` and `tagSet` |
 | DeleteInternetGateway | [Explicit resource IDs](#explicit-resource-ids) |
-| DescribeAvailabilityZones | Three zones per region, from the same list the offerings and spot-price operations use — see [Instance types are a seeded catalog](#instance-types-are-a-seeded-catalog). `ZoneName.N`, `ZoneId.N`, and four of eleven filters |
+| DescribeAvailabilityZones | Three zones per region, from the same list the offerings and spot-price operations use — see [Instance types are a seeded catalog](#instance-types-are-a-seeded-catalog). `ZoneName.N`, `ZoneId.N`, and four of eleven filters. `zoneId` takes AWS's published shape (`use1-az1`) and always maps zone `a` to `-az1` — see [Zone IDs](#zone-ids-take-aws-s-published-shape-and-always-map-zone-a-to-az1) |
 | DescribeRegions | **All three** filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name). `AllRegions` is accepted and inert — every seeded region is `opt-in-not-required`, so it is already in the answer |
 | DescribeInstanceTypes | Answers from a [seeded catalog](#instance-types-are-a-seeded-catalog). `InstanceType.N` is an assertion: a type outside the catalog is refused with `InvalidInstanceType`. Five of fifty-seven filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | DescribeInstanceTypeOfferings | `instance-type` and `location` filters (both with [wildcards](#wildcards-in-filter-values)) and the `LocationType` parameter; an unmatched filter is an empty answer, not an error |
@@ -3530,6 +3530,49 @@ evaluate (`encrypted`, `create-time`, `fast-restored` and six others) is accepte
 inert. Both follow the rule that now governs every EC2 describe — see
 [One rule for an unrecognized filter name](#one-rule-for-an-unrecognized-filter-name),
 which lists this operation's eleven evaluated names and nine inert ones.
+
+#### `CreateVolume` invents neither a size nor a zone
+
+AWS puts two combination rules on this operation and marks every member involved
+`Required: No`, because in each case the requirement is on a *pair*:
+
+| Rule | AWS's words | Substrate's answer when it is broken |
+|---|---|---|
+| Size or snapshot | "You must specify either a snapshot ID or a volume size." | `InvalidParameterCombination`, 400 |
+| Zone name or zone ID | "Either `AvailabilityZone` or `AvailabilityZoneId` must be specified, but not both." | `InvalidParameterCombination`, 400 — for **neither** and for **both** |
+| A `Size` that is not a positive integer | — | `InvalidParameterValue`, 400 |
+
+Substrate read neither rule before this. A request naming no size got a silent 8 GiB
+volume, one naming `Size=-1` or `Size=eight` got the same, and one naming no zone got
+`<region>a` — including a request that named the zone *by ID*, since
+`AvailabilityZoneId` was ignored outright. Every one of those returned `200` with a
+volume ID, which is the failure a refusal exists to prevent: the volume was real, at a
+size and in a zone the caller never asked for, and the first visible symptom was an
+attach failing later with nothing to point at.
+
+`AvailabilityZoneId` now resolves to the zone's name, through the **same derivation**
+`DescribeAvailabilityZones` renders — a zone ID read out of one operation is one the
+other accepts. Two deliberate asymmetries:
+
+- A zone **name** is recorded as given and is *not* checked against the three seeded
+  zones; a zone **ID** must resolve, because it has to be translated before it can be
+  stored at all. Validating names would be a wider change than the pair rule, and one
+  substrate makes on no zone-taking operation.
+- An unresolvable zone ID answers `InvalidParameterValue`, not `InvalidParameterCombination`.
+
+The refusal **codes are substrate's reading**: `CreateVolume`'s Errors section is empty,
+so it publishes no operation-specific error, and `InvalidParameterCombination`'s
+client-error gloss is the only one whose shape fits — "The request includes an incorrect
+combination of parameters, **or a missing parameter**."
+
+Still not enforced, and stated here rather than left to be found: AWS's per-type size
+ranges (`gp2` 1–16384, `io1` 4–16384, `st1`/`sc1` 125–16384, `standard` 1–1024, …).
+`Iops` and `Throughput` also keep their tolerance — an unparseable value leaves the
+field at zero and omits it from the response. That differs from `Size` because the
+absences differ: a volume must have a size, so an unusable `Size` has no defensible
+reading, while omitting `Iops` is the ordinary case for the five volume types that do
+not take one. The 8 GiB `ec2DefaultVolumeSizeGiB` still backs the **launch** path, where
+a mapping that omits a size is legal and AWS does document a default.
 
 #### A mapping AWS refuses is refused, with `InvalidBlockDeviceMapping`
 
@@ -4300,6 +4343,30 @@ matching the two would silently mis-read.
 The three zones `DescribeAvailabilityZones` reports are the same three the
 offerings and spot-price operations use, so filtering an offerings query by a zone
 you just enumerated always returns an answer.
+
+##### Zone IDs take AWS's published shape, and always map zone `a` to `-az1`
+
+`zoneId` is derived from the region: `us-east-1a` is `use1-az1`, `eu-west-1b` is
+`euw1-az2`, `ap-southeast-2c` is `apse2-az3`. Every prefix reproduces a row of AWS's
+[Availability Zones reference](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-availability-zones.html).
+Substrate emitted a different shape entirely until this release — `us-east-1` produced
+`ue11`, with a doubled digit — which nothing caught because zone IDs were only ever
+*emitted*: a test that read one out of a response and filtered on it was self-consistent
+whatever the string was. `CreateVolume`'s `AvailabilityZoneId` made it an input, and a
+consumer's fixture carrying the real `use1-az1` would have been refused.
+
+The derivation is **one letter per compass word**, not AWS's own summarising sentence
+("the first three letters of the Region code, followed by the number at the end"). That
+sentence is refuted by the table it introduces: `ap-southeast-2` is `apse2`, not `aps2`,
+and `ap-northeast-1` is `apne1`. The published table wins.
+
+What substrate does **not** model is the per-account shuffle. AWS: "we independently map
+Availability Zones to codes for each AWS account", so a real `us-east-1a` is `use1-az1`
+in one account and `use1-az3` in another — which is the whole reason AZ IDs exist.
+Substrate maps zone `a` to `-az1` in every account, because a deterministic emulator
+cannot hold a per-account secret and a test asserting the pairing has to be able to pass.
+Do not use substrate to verify that code correctly treats the name→ID mapping as
+account-specific; it will agree with an assumption real AWS breaks.
 
 #### Spot prices are stubs
 

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -26,9 +26,14 @@ const (
 // ec2DefaultVolumeSizeGiB is the size of a volume whose mapping names none, and of
 // the implicit root volume a launch that declares no mapping still gets.
 //
-// It matches both the mapping DescribeImages fabricates for every AMI and
-// CreateVolume's own default, so a launch-created volume and a CreateVolume-created
-// one agree about what "unspecified" means.
+// It matches the mapping DescribeImages fabricates for every AMI, so an AMI's reported
+// root size and the volume a launch from it produces agree.
+//
+// It no longer backs CreateVolume, which refuses a request naming neither Size nor
+// SnapshotId as of #712: AWS documents a default only on the launch path, where a mapping
+// that omits a size is legal, and never on the operation whose whole purpose is to be told
+// one. A launch-created volume and a CreateVolume-created one therefore no longer agree
+// about what "unspecified" means — because on CreateVolume it is not a request AWS accepts.
 const ec2DefaultVolumeSizeGiB = 8
 
 // ec2DefaultVolumeType is the type of a volume whose mapping names none.

--- a/emulator/ec2_createvolume_params_test.go
+++ b/emulator/ec2_createvolume_params_test.go
@@ -1,0 +1,308 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateVolume's two combination rules, and the size it will no longer invent (#712).
+//
+// AWS states both rules in its request parameters and neither with a Required: Yes. On Size:
+// "You must specify either a snapshot ID or a volume size." On the zone pair, said twice, once
+// on each member: "Either AvailabilityZone or AvailabilityZoneId must be specified, but not
+// both." Substrate read neither, and the two silent defaults it used instead — 8 GiB and
+// region+"a" — are the failure mode a refusal exists to prevent: the call reported success, so
+// a volume appeared in a zone the caller never named, at a size they never asked for, and the
+// first visible symptom was an attach failing later for no stated cause.
+//
+// The refusal code is substrate's reading and the tests assert it as such. CreateVolume's own
+// Errors section is empty — it publishes no operation-specific error — so the only candidate is
+// EC2's client-error table, where InvalidParameterCombination's gloss is the one that covers
+// this shape: "The request includes an incorrect combination of parameters, or a missing
+// parameter."
+
+// ec2CreateVolumeParams builds a CreateVolume request, letting a caller drop a parameter the
+// default request carries by naming it with an empty value.
+func ec2CreateVolumeParams(extra map[string]string) map[string]string {
+	params := map[string]string{
+		"Action":           "CreateVolume",
+		"AvailabilityZone": "us-east-1a",
+		"Size":             "8",
+	}
+	for k, v := range extra {
+		if v == "" {
+			delete(params, k)
+			continue
+		}
+		params[k] = v
+	}
+	return params
+}
+
+// ec2CreatedVolume is the part of a CreateVolume response these tests read.
+type ec2CreatedVolume struct {
+	VolumeID         string `xml:"volumeId"`
+	Size             int    `xml:"size"`
+	AvailabilityZone string `xml:"availabilityZone"`
+}
+
+// ec2CreateVolumeOK sends a CreateVolume expected to succeed.
+func ec2CreateVolumeOK(t *testing.T, ts *httptest.Server, extra map[string]string) ec2CreatedVolume {
+	t.Helper()
+	var doc ec2CreatedVolume
+	ec2FleetXML(t, ts, ec2CreateVolumeParams(extra), &doc)
+	require.NotEmpty(t, doc.VolumeID)
+	return doc
+}
+
+// TestEC2_CreateVolume_SizeOrSnapshotIsRequired pins the first combination rule.
+func TestEC2_CreateVolume_SizeOrSnapshotIsRequired(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	t.Run("neither is refused", func(t *testing.T) {
+		status, code, message := ec2ErrorDetail(t, ts,
+			ec2CreateVolumeParams(map[string]string{"Size": ""}))
+		assert.Equal(t, http.StatusBadRequest, status,
+			"a request naming neither Size nor SnapshotId got a silent 8 GiB volume before #712")
+		assert.Equal(t, "InvalidParameterCombination", code)
+		assert.Contains(t, message, "snapshot",
+			"the message must name what the caller could supply instead of a size")
+	})
+
+	t.Run("a size alone is enough", func(t *testing.T) {
+		vol := ec2CreateVolumeOK(t, ts, map[string]string{"Size": "20"})
+		assert.Equal(t, 20, vol.Size)
+	})
+
+	t.Run("a snapshot alone is enough", func(t *testing.T) {
+		_, snapID := ec2SnapshotOfSize(t, ts, 30)
+		vol := ec2CreateVolumeOK(t, ts, map[string]string{"Size": "", "SnapshotId": snapID})
+		assert.Equal(t, 30, vol.Size,
+			"the snapshot supplies the size, which is the whole reason Size is optional")
+	})
+}
+
+// TestEC2_CreateVolume_SizeMustBeAPositiveInteger pins that an unusable Size is refused rather
+// than replaced.
+//
+// Every row below produced an 8 GiB volume before #712, because the parse was
+// `if n, err := strconv.Atoi(sizeStr); err == nil && n > 0` with no else — a discarded error
+// and a discarded out-of-range value, which is exactly the shape the house rules forbid. `-1`
+// is the sharpest case: a caller who meant to compute a size and got a negative number was
+// told the volume was created.
+func TestEC2_CreateVolume_SizeMustBeAPositiveInteger(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	for _, size := range []string{"0", "-1", "8.5", "eight", "8 GiB", " 8", "0x8"} {
+		t.Run(size, func(t *testing.T) {
+			status, code, message := ec2ErrorDetail(t, ts,
+				ec2CreateVolumeParams(map[string]string{"Size": size}))
+			assert.Equal(t, http.StatusBadRequest, status,
+				"Size=%q silently became %d GiB before #712", size, 8)
+			assert.Equal(t, "InvalidParameterValue", code)
+			assert.Contains(t, message, size,
+				"the message must quote the offending value back")
+		})
+	}
+
+	// The boundary: 1 GiB is the smallest size any documented volume type accepts, and it is
+	// accepted. Substrate does not enforce the per-type ranges (gp2 1-16384, io1 4-16384, …),
+	// which is stated in the docs rather than left to be discovered.
+	t.Run("1 GiB is accepted", func(t *testing.T) {
+		vol := ec2CreateVolumeOK(t, ts, map[string]string{"Size": "1"})
+		assert.Equal(t, 1, vol.Size)
+	})
+}
+
+// TestEC2_CreateVolume_ZonePairIsExclusiveAndRequired pins the second combination rule, whose
+// two halves fail in opposite directions.
+func TestEC2_CreateVolume_ZonePairIsExclusiveAndRequired(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	t.Run("neither is refused", func(t *testing.T) {
+		status, code, message := ec2ErrorDetail(t, ts,
+			ec2CreateVolumeParams(map[string]string{"AvailabilityZone": ""}))
+		assert.Equal(t, http.StatusBadRequest, status,
+			"an absent zone silently became region+\"a\" before #712")
+		assert.Equal(t, "InvalidParameterCombination", code)
+		assert.Contains(t, message, "AvailabilityZoneId",
+			"a caller who omitted both needs to be told both spellings exist")
+	})
+
+	t.Run("both is refused", func(t *testing.T) {
+		status, code, _ := ec2ErrorDetail(t, ts, ec2CreateVolumeParams(map[string]string{
+			"AvailabilityZone":   "us-east-1a",
+			"AvailabilityZoneId": "use1-az1",
+		}))
+		assert.Equal(t, http.StatusBadRequest, status,
+			"AWS says \"but not both\", and agreeing values are still both")
+		assert.Equal(t, "InvalidParameterCombination", code)
+	})
+
+	t.Run("a zone name alone", func(t *testing.T) {
+		vol := ec2CreateVolumeOK(t, ts, map[string]string{"AvailabilityZone": "us-east-1c"})
+		assert.Equal(t, "us-east-1c", vol.AvailabilityZone)
+	})
+}
+
+// TestEC2_CreateVolume_ZoneIDResolvesThroughDescribeAvailabilityZones pins that the zone ID
+// substrate accepts is the one it publishes.
+//
+// AvailabilityZoneId was ignored outright before #712, so a request naming a zone by ID
+// created a volume in zone a. It resolves now, and it resolves through the same derivation
+// DescribeAvailabilityZones renders from — which is the point of the test: a caller who reads
+// a zone ID out of one operation and hands it to the other must not be told it does not exist.
+func TestEC2_CreateVolume_ZoneIDResolvesThroughDescribeAvailabilityZones(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	zones := ec2DescribeAZs(t, ts, map[string]string{"Action": "DescribeAvailabilityZones"})
+	require.Len(t, zones, 3)
+
+	for _, zone := range zones {
+		t.Run(zone.ZoneID, func(t *testing.T) {
+			require.NotEmpty(t, zone.ZoneID)
+			vol := ec2CreateVolumeOK(t, ts, map[string]string{
+				"AvailabilityZone":   "",
+				"AvailabilityZoneId": zone.ZoneID,
+			})
+			assert.Equal(t, zone.ZoneName, vol.AvailabilityZone,
+				"the record and the response carry the zone *name*, translated from the ID")
+		})
+	}
+
+	// A zone ID naming nothing is refused rather than resolved to zone a, because unlike a
+	// zone name it cannot be recorded as given — it has to be translated to be stored at all.
+	t.Run("an unknown zone ID is refused", func(t *testing.T) {
+		status, code, message := ec2ErrorDetail(t, ts, ec2CreateVolumeParams(map[string]string{
+			"AvailabilityZone":   "",
+			"AvailabilityZoneId": "use1-az9",
+		}))
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Contains(t, message, "use1-az9")
+	})
+
+	// The asymmetry, pinned so it is a decision and not an oversight: a zone *name* naming
+	// nothing is recorded as given. Validating names is a wider change than the pair rule and
+	// one substrate has never made on any zone-taking operation.
+	t.Run("an unknown zone name is recorded as given", func(t *testing.T) {
+		vol := ec2CreateVolumeOK(t, ts, map[string]string{"AvailabilityZone": "us-east-1z"})
+		assert.Equal(t, "us-east-1z", vol.AvailabilityZone)
+	})
+}
+
+// ec2ZoneIDsInRegion asks DescribeAvailabilityZones for one region's zone IDs, addressing the
+// server by that region's host so the request context carries it.
+func ec2ZoneIDsInRegion(t *testing.T, ts *httptest.Server, region string) []string {
+	t.Helper()
+	form := url.Values{"Action": []string{"DescribeAvailabilityZones"}}
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Host = "ec2." + region + ".amazonaws.com"
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var doc struct {
+		XMLName xml.Name `xml:"DescribeAvailabilityZonesResponse"`
+		Items   []struct {
+			ZoneID string `xml:"zoneId"`
+		} `xml:"availabilityZoneInfo>item"`
+	}
+	require.NoError(t, xml.NewDecoder(resp.Body).Decode(&doc))
+	ids := make([]string, 0, len(doc.Items))
+	for _, item := range doc.Items {
+		ids = append(ids, item.ZoneID)
+	}
+	return ids
+}
+
+// TestEC2_ZoneIDPrefixMatchesAWSPublishedTable pins the AZ-ID derivation against AWS's own
+// table, which #712 is the first change to make load-bearing on the request side.
+//
+// Every row is copied from the AWS Availability Zones reference. Before #712 the derivation
+// produced "ue11" for us-east-1 — a doubled digit and the wrong shape, refuted by AWS's table
+// and by the code's own comment, which claimed "use1". Nothing pinned it because zone IDs were
+// only ever *emitted*: a test that read one out of DescribeAvailabilityZones and filtered on
+// it was self-consistent whatever the string was. CreateVolume now accepts one as an input,
+// so a consumer's fixture carrying the real "use1-az1" would have been refused.
+//
+// ap-southeast-2 and ap-northeast-1 are the rows that matter most: they refute AWS's own
+// summarizing sentence ("the first three letters of the Region code"), which would give "aps2"
+// and "apn1". The published table wins over the sentence describing it.
+func TestEC2_ZoneIDPrefixMatchesAWSPublishedTable(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	for region, prefix := range map[string]string{
+		"us-east-1":      "use1",
+		"us-east-2":      "use2",
+		"us-west-1":      "usw1",
+		"us-west-2":      "usw2",
+		"ca-central-1":   "cac1",
+		"mx-central-1":   "mxc1",
+		"af-south-1":     "afs1",
+		"ap-east-1":      "ape1",
+		"ap-south-1":     "aps1",
+		"ap-southeast-2": "apse2",
+		"ap-northeast-1": "apne1",
+		"eu-central-1":   "euc1",
+		"eu-north-1":     "eun1",
+		"eu-west-1":      "euw1",
+		"eu-west-3":      "euw3",
+		"il-central-1":   "ilc1",
+		"me-south-1":     "mes1",
+		"sa-east-1":      "sae1",
+	} {
+		t.Run(region, func(t *testing.T) {
+			assert.Equal(t,
+				[]string{prefix + "-az1", prefix + "-az2", prefix + "-az3"},
+				ec2ZoneIDsInRegion(t, ts, region),
+				"AWS publishes %s-az1 and friends for %s", prefix, region)
+		})
+	}
+}
+
+// TestEC2_CreateVolume_RefusalWritesNothing pins that a refused CreateVolume leaves no volume
+// behind, which is the rule #673 established for RunInstances and #713 re-established for
+// ReplaceRouteTableAssociation.
+//
+// The three refusals land before the state write, but that is an ordering a later change could
+// break silently: a refusal that had already stored the volume would leave one at a size or in
+// a zone the caller was told was invalid, and DescribeVolumes would report it.
+func TestEC2_CreateVolume_RefusalWritesNothing(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	for name, extra := range map[string]map[string]string{
+		"no size, no snapshot": {"Size": ""},
+		"negative size":        {"Size": "-1"},
+		"no zone":              {"AvailabilityZone": ""},
+		"both zones":           {"AvailabilityZoneId": "use1-az1"},
+		"unknown zone ID":      {"AvailabilityZone": "", "AvailabilityZoneId": "use1-az9"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			status, _, _ := ec2ErrorDetail(t, ts, ec2CreateVolumeParams(extra))
+			require.Equal(t, http.StatusBadRequest, status)
+		})
+	}
+
+	var doc struct {
+		VolumeIDs []string `xml:"volumeSet>item>volumeId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeVolumes"}, &doc)
+	assert.Empty(t, doc.VolumeIDs, "five refused requests must have created no volume")
+}

--- a/emulator/ec2_describe_filters_test.go
+++ b/emulator/ec2_describe_filters_test.go
@@ -900,9 +900,13 @@ func TestEC2_InstanceTypeFilters_FiveOfFiftySeven(t *testing.T) {
 
 // TestEC2_SpotPriceFilters_FiveOfSix pins the filters this page documents, and the
 // ProductDescription.N index fix that rode along.
+//
+// The clock is frozen because the timestamp subtest below filters on a value read out of
+// an earlier response, and the rendered value changes at every second boundary — see
+// [newEC2TestServerFrozenClock].
 func TestEC2_SpotPriceFilters_FiveOfSix(t *testing.T) {
 	t.Parallel()
-	ts := newEC2TestServer(t)
+	ts := newEC2TestServerFrozenClock(t)
 
 	type price struct {
 		InstanceType       string `xml:"instanceType"`

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -4208,6 +4208,28 @@ func (p *EC2Plugin) deregisterImage(reqCtx *RequestContext, req *AWSRequest) (*A
 
 // --- Availability Zone operations ---
 
+// ec2SeededZones reports the region's zones, name and ID both, in a stable order.
+//
+// One derivation, because two would drift: DescribeAvailabilityZones renders these and
+// CreateVolume resolves an AvailabilityZoneId through them, so a zone ID a caller read out
+// of one operation is a zone ID the other accepts. The ID follows AWS's shape —
+// "use1-az1" for us-east-1a — from [azRegionAbbrev] and the zone's position in
+// [ec2SeededAZSuffixes]. Real zone IDs are per-account shuffled and substrate's are not;
+// docs/services.md says so.
+func ec2SeededZones(region string) []ec2AvailabilityZoneItem {
+	abbrev := azRegionAbbrev(region)
+	zones := make([]ec2AvailabilityZoneItem, 0, len(ec2SeededAZSuffixes))
+	for i, suffix := range ec2SeededAZSuffixes {
+		zones = append(zones, ec2AvailabilityZoneItem{
+			ZoneName:   region + suffix,
+			State:      "available",
+			RegionName: region,
+			ZoneID:     abbrev + "-az" + strconv.Itoa(i+1),
+		})
+	}
+	return zones
+}
+
 // describeAvailabilityZones reports the region's seeded zones.
 //
 // The signature took the request and discarded it before #695, so every documented selector
@@ -4224,22 +4246,13 @@ func (p *EC2Plugin) describeAvailabilityZones(reqCtx *RequestContext, req *AWSRe
 		return nil, err
 	}
 	filters := extractEC2Filters(req.Params)
-	region := reqCtx.Region
-	// Derive abbreviated region for zoneId (e.g. "use1" from "us-east-1").
-	abbrev := azRegionAbbrev(region)
 	type response struct {
 		XMLName           xml.Name                  `xml:"DescribeAvailabilityZonesResponse"`
 		XMLNS             string                    `xml:"xmlns,attr"`
 		AvailabilityZones []ec2AvailabilityZoneItem `xml:"availabilityZoneInfo>item"`
 	}
 	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
-	for i, suffix := range ec2SeededAZSuffixes {
-		az := ec2AvailabilityZoneItem{
-			ZoneName:   region + suffix,
-			State:      "available",
-			RegionName: region,
-			ZoneID:     abbrev + "-az" + strconv.Itoa(i+1),
-		}
+	for _, az := range ec2SeededZones(reqCtx.Region) {
 		if !ec2SelectedByEither(names, az.ZoneName, zoneIDs, az.ZoneID) {
 			continue
 		}
@@ -4411,24 +4424,71 @@ func (p *EC2Plugin) deletePlacementGroup(reqCtx *RequestContext, req *AWSRequest
 	return ec2XMLResponse(http.StatusOK, response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/", Return: true})
 }
 
-// azRegionAbbrev returns a short abbreviation for a region name used in zone IDs
-// (e.g. "us-east-1" → "use1", "eu-west-2" → "euw2").
+// azCompassWords are the direction words an AWS region code's middle segment is built from.
+//
+// Only the simple words are listed, deliberately: a compound like "southeast" is *two* words
+// and contributes two letters, so it must decompose rather than match whole. That is what
+// AWS's table shows — ap-southeast-2 is apse2 and ap-northeast-1 is apne1, where matching
+// "southeast" as one word would give apse2's neighbor aps2. None of the five is a prefix of
+// another, so a greedy left-to-right walk is unambiguous.
+var azCompassWords = []string{"north", "south", "east", "west", "central"}
+
+// azRegionAbbrev returns the AZ-ID prefix for a region: "us-east-1" → "use1",
+// "eu-west-2" → "euw2", "ap-southeast-2" → "apse2".
+//
+// This produced "ue11" for us-east-1 before #712 — the wrong shape *and* a doubled digit,
+// since the old walk took the first byte of every hyphenated segment and then appended a
+// trailing digit that, for the numeric segment, was the byte it had just written. Every
+// zoneId DescribeAvailabilityZones has ever reported was therefore a form no real account
+// returns, and #712 is where that starts to bite: CreateVolume now accepts an
+// AvailabilityZoneId, so a consumer whose fixture carries the real "use1-az1" would have been
+// refused for naming the zone correctly.
+//
+// AWS states the rule in the AZ-ID reference — "An AZ ID consists of the first three letters
+// of the Region code, followed by the number at the end of the Region code, followed by -az,
+// followed by a number" — but its own table refutes the "three letters" part for the compound
+// directions: ap-southeast-2 is apse2, not aps2, and ap-northeast-1 is apne1. The published
+// table is authoritative over the sentence summarizing it, so the derivation here is one
+// letter per compass word, which reproduces every row of that table.
+//
+// What substrate does *not* model is the mapping's per-account shuffle. AWS: "we
+// independently map Availability Zones to codes for each AWS account", so real us-east-1a is
+// use1-az1 in one account and use1-az3 in another. Substrate maps zone a to -az1 always,
+// because a deterministic emulator cannot have a per-account secret and a test asserting a
+// pairing must be able to pass. docs/services.md says so.
 func azRegionAbbrev(region string) string {
-	// Remove hyphens and digits, keep first letters of each segment plus trailing digit.
-	parts := strings.Split(region, "-")
+	parts := strings.SplitN(region, "-", 2)
 	if len(parts) < 2 {
 		return region
 	}
+	middle, number := parts[1], ""
+	if i := strings.LastIndex(middle, "-"); i >= 0 {
+		middle, number = middle[:i], middle[i+1:]
+	}
 	var sb strings.Builder
-	for _, p := range parts {
-		if len(p) > 0 {
-			sb.WriteByte(p[0])
-			// Append trailing digit if present.
-			if last := p[len(p)-1]; last >= '0' && last <= '9' {
-				sb.WriteByte(last)
+	sb.WriteString(parts[0])
+	for middle != "" {
+		word := ""
+		for _, w := range azCompassWords {
+			if strings.HasPrefix(middle, w) {
+				word = w
+				break
 			}
 		}
+		if word == "" {
+			// An unrecognized middle segment contributes its first letter, which is what
+			// AWS's three-letter sentence would give and the best available guess. A
+			// non-letter contributes nothing, so a Local Zone code substrate does not seed
+			// (us-west-2-lax-1) yields "usw1" rather than "usw-1".
+			if c := middle[0]; (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+				sb.WriteByte(c)
+			}
+			break
+		}
+		sb.WriteByte(word[0])
+		middle = middle[len(word):]
 	}
+	sb.WriteString(number)
 	return sb.String()
 }
 
@@ -5681,7 +5741,70 @@ func (p *EC2Plugin) deleteLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 
 // --- EBS volume operations ---
 
+// ec2VolumeZone resolves CreateVolume's zone from AvailabilityZone or AvailabilityZoneId.
+//
+// AWS states the rule on both members: "Either AvailabilityZone or AvailabilityZoneId must be
+// specified, but not both." Each is Required: No on its own, which is why neither can be
+// checked with [ec2MissingParameter] — the requirement is on the pair. Before #712 substrate
+// read neither alternative: AvailabilityZoneId was ignored outright, and an absent
+// AvailabilityZone silently became region+"a", so a request that AWS refuses produced a volume
+// in a zone the caller never named and a request naming a zone *by ID* produced one in zone a.
+// Both failures are worse than a refusal for the same reason: the call reported success, so a
+// test asserting the volume landed where it was asked for could only fail later, when an
+// attach to an instance in another zone failed for no visible cause.
+//
+// A zone *name* is recorded as given and not checked against [ec2SeededZones]; a zone *ID*
+// must resolve, because it has to be translated into the name the record and every response
+// carry. That asymmetry is deliberate and stated in docs/services.md — validating names would
+// be a wider change than the pair rule, and one substrate has never made on any zone-taking
+// operation.
+//
+// The refusal code is substrate's reading. CreateVolume publishes no operation-specific error
+// at all — its Errors section is empty — and InvalidParameterCombination is the only code in
+// EC2's client-error table whose gloss covers this shape: "an incorrect combination of
+// parameters, or a missing parameter" names both halves of the rule.
+func ec2VolumeZone(region string, params map[string]string) (string, *AWSError) {
+	name, id := params["AvailabilityZone"], params["AvailabilityZoneId"]
+	switch {
+	case name != "" && id != "":
+		return "", &AWSError{
+			Code: "InvalidParameterCombination",
+			Message: "Either AvailabilityZone or AvailabilityZoneId may be specified, " +
+				"but not both",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	case name == "" && id == "":
+		return "", &AWSError{
+			Code:       "InvalidParameterCombination",
+			Message:    "Either AvailabilityZone or AvailabilityZoneId must be specified",
+			HTTPStatus: http.StatusBadRequest,
+		}
+	case name != "":
+		return name, nil
+	}
+	for _, zone := range ec2SeededZones(region) {
+		if zone.ZoneID == id {
+			return zone.ZoneName, nil
+		}
+	}
+	return "", &AWSError{
+		Code: "InvalidParameterValue",
+		Message: fmt.Sprintf(
+			"Invalid value '%s' for AvailabilityZoneId. No such Availability Zone in %s.",
+			id, region),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
 // createVolume creates an EBS volume, tagging it from TagSpecification.N.
+//
+// Size and the zone follow AWS's two combination rules as of #712 — see [ec2VolumeZone] for
+// the zone pair, and "You must specify either a snapshot ID or a volume size" for the other.
+// A request naming neither Size nor SnapshotId used to get a silent 8 GiB volume, and one
+// naming an unparseable, zero or negative Size got the same, so `Size=-1` and `Size=huge`
+// both produced 8 GiB. [ec2DefaultVolumeSizeGiB] no longer backs this operation; it still
+// backs the launch path, where a mapping that names no size is legal and AWS does supply a
+// default.
 //
 // The tags come from [ec2LaunchTagsForResource] scoped to "volume", which is the same
 // walk RunInstances, CreateFleet, CreateImage and CreateNatGateway already use: AWS's
@@ -5705,16 +5828,33 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		return nil, awsErr
 	}
 
-	az := req.Params["AvailabilityZone"]
-	if az == "" {
-		az = reqCtx.Region + "a"
+	az, awsErr := ec2VolumeZone(reqCtx.Region, req.Params)
+	if awsErr != nil {
+		return nil, awsErr
 	}
 	sizeStr := req.Params["Size"]
-	size := ec2DefaultVolumeSizeGiB
-	if sizeStr != "" {
-		if n, err := strconv.Atoi(sizeStr); err == nil && n > 0 {
-			size = n
+	snapshotID := req.Params["SnapshotId"]
+	if sizeStr == "" && snapshotID == "" {
+		return nil, &AWSError{
+			Code: "InvalidParameterCombination",
+			Message: "Either the volume size or the snapshot ID must be specified, " +
+				"but not neither",
+			HTTPStatus: http.StatusBadRequest,
 		}
+	}
+	size := 0
+	if sizeStr != "" {
+		n, err := strconv.Atoi(sizeStr)
+		if err != nil || n <= 0 {
+			return nil, &AWSError{
+				Code: "InvalidParameterValue",
+				Message: fmt.Sprintf(
+					"Invalid value '%s' for size. Size must be a positive integer number of GiB.",
+					sizeStr),
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+		size = n
 	}
 	volType := req.Params["VolumeType"]
 	if volType == "" {
@@ -5729,10 +5869,8 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	// the default is the snapshot size" and "You can specify a volume size that is equal
 	// to or larger than the snapshot size."
 	//
-	// A request naming neither Size nor SnapshotId still gets the 8 GiB default rather
-	// than the refusal AWS documents ("Size is required unless SnapshotId is specified").
-	// That is a wider change than this one and a follow-up.
-	snapshotID := req.Params["SnapshotId"]
+	// Both are refused above when neither is given (#712), so by here the size is either a
+	// positive integer from the request or zero with a snapshot to take it from.
 	if snapshotID != "" {
 		snap, found := p.ec2SnapshotResolver(reqCtx)(snapshotID)
 		if awsErr := ec2RequireResource(ec2SnapshotIDKind, snapshotID, found); awsErr != nil {
@@ -5752,9 +5890,12 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		}
 	}
 	encrypted := strings.ToLower(req.Params["Encrypted"]) == "true"
-	// Recorded as given, with the same tolerance Size above has: a value that does not
-	// parse leaves the field at zero and the field is then omitted from the response,
-	// which is what a volume with no provisioned performance looks like.
+	// Recorded as given, and tolerant where Size is now strict (#712): a value that does not
+	// parse leaves the field at zero and the field is then omitted from the response, which
+	// is what a volume with no provisioned performance looks like. The two differ because
+	// their absences differ — a volume must have a size, so an unusable Size has no
+	// defensible reading, while omitting Iops entirely is the ordinary case for the five
+	// volume types that do not take one.
 	iops, _ := strconv.Atoi(req.Params["Iops"])
 	throughput, _ := strconv.Atoi(req.Params["Throughput"])
 

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -24,14 +24,36 @@ func newEC2TestServer(t *testing.T) *httptest.Server {
 	return newEC2TestServerWithState(t, emulator.NewMemoryStateManager())
 }
 
+// newEC2TestServerFrozenClock is [newEC2TestServer] with a clock that does not advance,
+// for a test whose subject is a rendered timestamp.
+//
+// The default controller runs at scale 1.0, so a value rendered as RFC3339 changes at
+// every second boundary. Any test that reads a timestamp out of one response and hands
+// it back in the next request is therefore wall-clock dependent, which the house rules
+// forbid — and TestEC2_SpotPriceFilters_FiveOfSix was, failing roughly once per sixty
+// runs until #712. Scale zero is the freeze: Now() is simBaseline + elapsed*scale, so
+// every read returns the same instant. It is reachable only in-process — POST
+// /v1/control/scale refuses a non-positive scale — which is why this is a constructor
+// rather than a request the test could send.
+func newEC2TestServerFrozenClock(t *testing.T) *httptest.Server {
+	t.Helper()
+	return newEC2TestServerWithState(t, emulator.NewMemoryStateManager(), func(tc *emulator.TimeController) {
+		tc.SetScale(0)
+	})
+}
+
 // newEC2TestServerWithState is [newEC2TestServer] with the caller's StateManager, so
 // a test can write a stored shape no request produces — a pre-migration record, or an
-// instance with no security groups — and read it back through the API.
-func newEC2TestServerWithState(t *testing.T, state emulator.StateManager) *httptest.Server {
+// instance with no security groups — and read it back through the API. Each opt is
+// applied to the server's TimeController before the first request reaches it.
+func newEC2TestServerWithState(t *testing.T, state emulator.StateManager, opts ...func(*emulator.TimeController)) *httptest.Server {
 	t.Helper()
 	registry := emulator.NewPluginRegistry()
 	store := emulator.NewEventStore(emulator.EventStoreConfig{Enabled: true, Backend: "memory"})
 	tc := emulator.NewTimeController(time.Now())
+	for _, opt := range opts {
+		opt(tc)
+	}
 	logger := emulator.NewDefaultLogger(0, false)
 
 	p := &emulator.EC2Plugin{}


### PR DESCRIPTION
Closes #712

## What AWS documents, and what #712 got wrong

`CreateVolume` puts two combination rules on its parameters and marks **every member involved `Required: No`**, because each requirement is on a *pair*:

- `Size` — "You must specify either a snapshot ID or a volume size."
- `AvailabilityZone` / `AvailabilityZoneId` — said once on each member: "Either `AvailabilityZone` or `AvailabilityZoneId` must be specified, but not both."

#712's premise is corrected in passing: it quotes AWS as documenting "Size is required unless SnapshotId is specified" and `AvailabilityZone` as required. Neither sentence exists. The rules are the combination ones above, which is why both members read `Required: No`.

## What substrate did

It read neither rule, and answered HTTP 200 in every broken case:

| request | before | now |
|---|---|---|
| no `Size`, no `SnapshotId` | 8 GiB volume | `InvalidParameterCombination`, 400 |
| `Size=-1`, `Size=eight`, `Size=8.5` | 8 GiB volume | `InvalidParameterValue`, 400, quoting the value |
| no zone at all | zone `<region>a` | `InvalidParameterCombination`, 400 |
| both zone spellings | zone name wins, ID ignored | `InvalidParameterCombination`, 400 |
| `AvailabilityZoneId` alone | ignored → zone `a` | resolved to the zone's name |

The size parse was `if n, err := strconv.Atoi(s); err == nil && n > 0` with no `else` — a discarded error *and* a discarded out-of-range value. Each of these reported success, so the volume was real, at a size and in a zone the caller never asked for, and the first visible symptom was an attach failing later with nothing to point at. All three refusals land before the state write; `TestEC2_CreateVolume_RefusalWritesNothing` pins that five refused calls leave `DescribeVolumes` empty.

## `AvailabilityZoneId`, and the zone-ID bug it exposed

The ID resolves through the same derivation `DescribeAvailabilityZones` renders from, so a zone ID read out of one operation is one the other accepts — pinned by round-tripping all three zones.

Making a zone ID an *input* for the first time exposed the derivation: it produced **`ue11-az1`** for `us-east-1` — wrong prefix, doubled digit — where AWS publishes `use1-az1`, and the code's own comment claimed `use1`. Nothing caught it because zone IDs were only ever emitted, and a test that read one back and filtered on it was self-consistent whatever the string said. A consumer fixture carrying the real `use1-az1` would have been refused.

AWS's *table* refutes AWS's own summarising sentence ("the first three letters of the Region code, followed by the number at the end"): that rule gives `aps2` for `ap-southeast-2`, and the table says `apse2`. The real shape is the first segment verbatim, one letter per compass word, then the trailing number. `TestEC2_ZoneIDPrefixMatchesAWSPublishedTable` pins 18 rows copied from the table, with `ap-southeast-2` and `ap-northeast-1` as the rows that settle it.

Two deliberate asymmetries, documented rather than left to be discovered:

- A zone **name** is recorded as given and not validated; a zone **ID** must resolve, because it has to be translated into the name the record and every response carry. Validating names is a wider change than the pair rule and one substrate has never made on any zone-taking operation.
- An unresolvable zone ID answers `InvalidParameterValue`, not the combination code — the pair is well-formed, the value is not.

## Provenance

**Both refusal codes are substrate's reading.** `CreateVolume`'s Errors section is *empty* — it publishes no operation-specific error at all — so #712's acceptance criterion "verify the code against the reference" cannot be met as written. `InvalidParameterCombination`'s EC2 client-error gloss is the only candidate whose shape fits: "The request includes an incorrect combination of parameters, **or a missing parameter**."

The zone-ID prefix comes from AWS's published table, chosen over AWS's prose describing it. AWS also states "we independently map Availability Zones to codes for each AWS account", so the real name→ID pairing is per-account; substrate always maps zone `a` to `-az1`, and the docs say plainly not to use substrate to verify that code treats the mapping as account-specific.

## Also fixed: a wall-clock-dependent test

`DescribeSpotPriceHistory` renders its timestamp from the time controller at scale 1.0, so the RFC3339 value changes at every second boundary. #695's timestamp subtest read the value out of one response and filtered on it in the next, failing whenever a second elapsed between them — about one run in sixty, on `main`. It runs against a frozen clock now (scale zero; reachable only in-process, since `POST /v1/control/scale` refuses a non-positive scale).

## Out of scope, stated in the docs

AWS's per-volume-type size ranges (`gp2` 1–16384, `io1` 4–16384, `st1`/`sc1` 125–16384, `standard` 1–1024) are still unenforced, and `Iops`/`Throughput` keep their existing tolerance for an unparseable value — `Size` differs because its absence differs: a volume must have a size, while omitting `Iops` is the ordinary case for the five types that do not take one. The launch path keeps `ec2DefaultVolumeSizeGiB`, where a mapping omitting a size is legal; its doc comment now says it no longer backs `CreateVolume`.

## Verification

Fail-before established empirically in a throwaway worktree at `6f0f579`: all five new `CreateVolume` tests failed, 22 subtests — and the failing subtest *names* (`ue11-az2`, `ue11-az3`) are what exposed the zone-ID bug.

```
gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...   # 0 issues
make test                                                                 # green, race on
make coverage                                                             # 83.2% emulator
make docs-reference docs-reference-check docs-versions                     # up to date
npm --prefix docs run build                                               # 317 hrefs / 326 ids, none dangling
go vet -C test/e2e ./... && go test -C test/e2e ./...                     # green
```