### PR TITLE
fix(ec2): DeleteSnapshot validates its ID and refuses one an AMI uses (#710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot be used."
 
 ### Changed
+- **`DeleteSnapshot` validates the ID it is given, and refuses one a registered AMI still
+  references** (#710). The operation deleted the record correctly — it has since #325, whatever
+  the doc comment saying "Substratefs does not persist snapshots; the operation succeeds" claimed
+  — and validated nothing at all. **Every** well-formed ID answered HTTP 200 and
+  `<return>true</return>`, so a cleanup loop deleting a typoed ID, an ID from another region, or
+  the same ID twice was told each time that it had removed a snapshot. Four answers now:
+  `MissingParameter` for an omitted `SnapshotId` (AWS marks it `Required: Yes`),
+  `InvalidSnapshotID.Malformed` for anything that is not a snapshot ID,
+  `InvalidSnapshot.NotFound` for a well-formed ID naming nothing, and `InvalidSnapshot.InUse`
+  when an AMI's block device mapping names it — AWS: "You cannot delete a snapshot of the root
+  device of an EBS volume used by a registered AMI. You must first deregister the AMI before you
+  can delete the snapshot."
+
+  Two things a consumer must plan for. **The operation is not idempotent** — a second delete of
+  the same ID is `InvalidSnapshot.NotFound`, which is what AWS answers; substrate's 200 was
+  hiding a requirement a re-runnable teardown has to meet anyway. And **order matters**:
+  deregister the AMI, then delete its snapshot. The reverse order used to succeed and leave an
+  AMI referencing a snapshot that no longer existed — a state real EC2 cannot be put into, and
+  the reason `DescribeImages` needed a fallback to render a volume size at all.
+
+  Substrate's images record exactly one snapshot and it is by construction the root device's, so
+  AWS's narrower scoping (the *root* device specifically) happens not to bite; that is stated
+  rather than glossed, because an image that could reference a non-root snapshot would need the
+  check narrowed. Where two AMIs share one snapshot — reachable since #328 — the refusal names
+  the **lowest** image ID, so identical inputs produce an identical body on replay instead of one
+  that follows Go's map iteration order.
+
+  #710's premise is corrected in passing: its headline claim is that "a snapshot survives its own
+  `DeleteSnapshot`". It does not, and has not since #325 — two doc comments and a test already
+  said so. The defect was the validation, not the deletion.
+
+  Provenance: **none of the codes is on `API_DeleteSnapshot.html`**, whose Errors section is
+  empty. All three come from EC2's client-error table, where the `InvalidSnapshot.InUse` entry
+  describes the condition ("The snapshot that you are trying to delete is in use by one or more
+  AMIs") rather than quoting a wire message — so the message is substrate's wording of AWS's
+  description, the same caveat `ec2_instanceattribute.go` records for `IncorrectInstanceState`.
+  Match on the code, not the string.
+
 - **`CreateVolume` invents neither a size nor an Availability Zone** (#712). AWS puts two
   combination rules on the operation and marks every member involved `Required: No`, because
   each requirement is on a *pair*: "You must specify either a snapshot ID or a volume size" and,

--- a/docs/services.md
+++ b/docs/services.md
@@ -2785,6 +2785,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DeleteRouteTable | [Explicit resource IDs](#explicit-resource-ids) |
 | CreateSnapshot | `VolumeId` is required and checked; `volumeSize` and `encrypted` come from the source volume, and `status` is `completed` at once — see [A snapshot has a real size](#a-snapshot-has-a-real-size) |
 | DescribeSnapshots | [Explicit resource IDs](#explicit-resource-ids); ten filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); `Owner.N` and `RestorableBy.N` — see [A snapshot filters on its own members](#a-snapshot-filters-on-its-own-members-and-scopes-by-account) |
+| DeleteSnapshot | `SnapshotId` is required and checked; refuses one a registered AMI still references with `InvalidSnapshot.InUse`, and is **not** idempotent — see [Deleting a snapshot](#deleting-a-snapshot-refuses-what-aws-refuses) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids); `AllocationId.N` and `PublicIp.N` [union](#twelve-describes-gained-filters); eight of ten filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); reports `tagSet` |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | CreateLaunchTemplate | Creates version 1. Networking is read from every `NetworkInterface.N.*` — see [Launch template networking](#launch-template-networking). The top-level `TagSpecification.N` scoped to `launch-template` tags the template itself, separately from `LaunchTemplateData`'s, which tags what a launch creates |
@@ -4811,13 +4812,59 @@ the waiting path, and it is a follow-up rather than something this operation sho
 `CreateImage`'s own snapshot now reads the instance's root volume too, recording both its
 size and its ID — so an AMI made from a 40 GiB root volume reports 40 GiB through
 `DescribeSnapshots` *and* through `DescribeImages`, which reads the snapshot record rather
-than rendering its own constant. An AMI whose snapshot was later deleted falls back to the
-8 GiB default rather than reporting `0`, since a caller sizing a volume off that member can
-act on the default.
+than rendering its own constant. An AMI whose snapshot is missing falls back to the 8 GiB
+default rather than reporting `0`, since a caller sizing a volume off that member can act on
+the default. `DeleteSnapshot` no longer produces that state — see below — so it is reached
+only by `RegisterImage` naming a snapshot that does not exist, or by a record written
+directly into state.
 
 The rest of the `CreateSnapshot` family — `CreateSnapshots`, `CopySnapshot`,
 `ModifySnapshotAttribute`, `DescribeSnapshotAttribute` and `ResetSnapshotAttribute` — is
 still absent and answers `InvalidAction`.
+
+#### Deleting a snapshot refuses what AWS refuses
+
+`DeleteSnapshot` did delete the record — it has since
+[#325](https://github.com/scttfrdmn/substrate/issues/325), whatever its doc comment claimed —
+and validated nothing whatever. **Every** well-formed ID answered HTTP 200 and
+`<return>true</return>`, which is the answer a caller reads as "deleted": a cleanup loop
+deleting a typoed ID, an ID from another region, or the same ID twice was told each time that
+it had removed a snapshot.
+
+| Request | Answer |
+|---|---|
+| `SnapshotId` omitted | `MissingParameter` — AWS marks it `Required: Yes` |
+| Not a snapshot ID (`vol-…`, `ami-…`, no prefix, non-hex, uppercase) | `InvalidSnapshotID.Malformed` |
+| Well-formed, names nothing — **including a second delete of the same ID** | `InvalidSnapshot.NotFound` |
+| Named by a registered AMI's block device mapping | `InvalidSnapshot.InUse`, naming both the snapshot and the AMI |
+| Anything else | Deleted; a subsequent `DescribeSnapshots` does not report it |
+
+The in-use rule is AWS's: "You cannot delete a snapshot of the root device of an EBS volume
+used by a registered AMI. You must first deregister the AMI before you can delete the
+snapshot." Substrate's images record exactly one snapshot and it is by construction the root
+device's, so AWS's narrower scoping — the *root* device specifically — happens not to bite;
+every snapshot an image references here is a root-device snapshot.
+
+Two consequences worth planning for:
+
+- **The operation is not idempotent**, and against AWS it never was. A consumer whose teardown
+  is written to be re-runnable has to tolerate `InvalidSnapshot.NotFound`, which is what it has
+  to tolerate against AWS. Substrate answering 200 was hiding that requirement.
+- **Order matters**: deregister the AMI, then delete its snapshot. Substrate previously let the
+  reverse order succeed, leaving an AMI pointing at a snapshot that no longer existed — a state
+  real EC2 cannot be put into.
+
+When two AMIs reference one snapshot — reachable since
+[#328](https://github.com/scttfrdmn/substrate/issues/328), because `RegisterImage` against an
+existing snapshot shares it — the refusal names the **lowest** image ID. That tie-break exists
+so identical inputs produce an identical response body on replay; without it the message would
+follow Go's map iteration order.
+
+Provenance: none of these codes is on `API_DeleteSnapshot.html`, whose Errors section is
+empty. All three come from EC2's client-error table, and its `InvalidSnapshot.InUse` entry
+*describes* the condition ("The snapshot that you are trying to delete is in use by one or
+more AMIs") rather than quoting a wire message, so the message substrate returns is its own
+wording of AWS's description — match on the code, not the string.
 
 #### Every taggable ID prefix is reachable
 

--- a/emulator/ec2_deletesnapshot_test.go
+++ b/emulator/ec2_deletesnapshot_test.go
@@ -1,0 +1,212 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// What DeleteSnapshot refuses, now that it refuses anything (#710).
+//
+// The operation deleted the record correctly — it has since #325, whatever the doc comment
+// #710 quotes said — and validated nothing at all. A well-formed ID naming no snapshot got
+// HTTP 200 and `return true`, which is the answer a caller reads as "deleted": a cleanup
+// loop deleting a typoed ID, or the same ID twice, or an ID from another region was told
+// each time that it had removed a snapshot.
+//
+// Three refusals now, in the order real EC2 reports them — malformed, absent, in use.
+// The order is what makes the in-use message trustworthy: reporting InUse for a string that
+// cannot be a snapshot ID would claim an AMI holds something no AMI could hold.
+//
+// Provenance: API_DeleteSnapshot.html's Errors section is empty, so none of the three codes
+// comes from the operation's own page. InvalidSnapshotID.Malformed and
+// InvalidSnapshot.NotFound come from EC2's client-error table via [ec2SnapshotIDKind], which
+// predates this change; InvalidSnapshot.InUse comes from the same table, where the entry
+// describes the condition ("The snapshot that you are trying to delete is in use by one or
+// more AMIs") rather than quoting a wire message. The assertions below check the code, the
+// status and that the message names the two resources — not AWS's exact wording, which AWS
+// does not publish.
+
+// ec2DeleteSnapshot sends a DeleteSnapshot and reports (status, code, message).
+func ec2DeleteSnapshot(t *testing.T, ts *httptest.Server, snapshotID string) (int, string, string) {
+	t.Helper()
+	params := map[string]string{"Action": "DeleteSnapshot"}
+	if snapshotID != "" {
+		params["SnapshotId"] = snapshotID
+	}
+	return ec2ErrorDetail(t, ts, params)
+}
+
+// ec2ImageWithSnapshot creates an AMI from an instance and returns it with the snapshot it
+// references, read from the AMI's own block device mapping rather than from DescribeSnapshots
+// — the in-use rule is about that reference, so the test has to assert on the same link.
+func ec2ImageWithSnapshot(t *testing.T, ts *httptest.Server) (imageID, snapshotID string) {
+	t.Helper()
+	imageID = ec2CreateImageID(t, ts, map[string]string{
+		"Action":     "CreateImage",
+		"InstanceId": ec2TagTestInstance(t, ts),
+		"Name":       "in-use-ami",
+	})
+	var doc struct {
+		Snapshots []string `xml:"imagesSet>item>blockDeviceMapping>item>ebs>snapshotId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "DescribeImages", "ImageId.1": imageID,
+	}, &doc)
+	require.Len(t, doc.Snapshots, 1)
+	require.NotEmpty(t, doc.Snapshots[0])
+	return imageID, doc.Snapshots[0]
+}
+
+// ec2SnapshotExists reports whether DescribeSnapshots still lists snapshotID.
+func ec2SnapshotExists(t *testing.T, ts *httptest.Server, snapshotID string) bool {
+	t.Helper()
+	var doc struct {
+		IDs []string `xml:"snapshotSet>item>snapshotId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeSnapshots"}, &doc)
+	for _, id := range doc.IDs {
+		if id == snapshotID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEC2_DeleteSnapshot_DeletesAndIsNotIdempotent pins the happy path and the one that
+// used to share it.
+//
+// A second delete of the same ID is a refusal, not a second success. That is the whole
+// behavioral change for a consumer whose cleanup is written to be re-runnable: it has to
+// tolerate InvalidSnapshot.NotFound now, which is what it has to tolerate against AWS.
+func TestEC2_DeleteSnapshot_DeletesAndIsNotIdempotent(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapID := ec2SnapshotOfSize(t, ts, 20)
+	require.True(t, ec2SnapshotExists(t, ts, snapID))
+
+	status, code, _ := ec2DeleteSnapshot(t, ts, snapID)
+	require.Equal(t, http.StatusOK, status, "code=%s", code)
+	assert.False(t, ec2SnapshotExists(t, ts, snapID), "the record is gone from DescribeSnapshots")
+
+	status, code, _ = ec2DeleteSnapshot(t, ts, snapID)
+	assert.Equal(t, http.StatusBadRequest, status, "the second delete answered 200 before #710")
+	assert.Equal(t, "InvalidSnapshot.NotFound", code)
+}
+
+// TestEC2_DeleteSnapshot_RefusesAnIDItCannotResolve covers the two ID failures, plus the
+// omitted parameter AWS marks Required: Yes.
+func TestEC2_DeleteSnapshot_RefusesAnIDItCannotResolve(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	for name, tc := range map[string]struct {
+		snapshotID string
+		wantCode   string
+	}{
+		// Well-formed and names nothing — the case the stub answered 200 for.
+		"absent":                 {"snap-0123456789abcdef0", "InvalidSnapshot.NotFound"},
+		"wrong prefix":           {"vol-0123456789abcdef0", "InvalidSnapshotID.Malformed"},
+		"no prefix":              {"0123456789abcdef0", "InvalidSnapshotID.Malformed"},
+		"prefix only":            {"snap-", "InvalidSnapshotID.Malformed"},
+		"non-hex body":           {"snap-0123456789abcdefg", "InvalidSnapshotID.Malformed"},
+		"omitted altogether":     {"", "MissingParameter"},
+		"an AMI ID, not a snap":  {"ami-0123456789abcdef0", "InvalidSnapshotID.Malformed"},
+		"uppercase is malformed": {"snap-0123456789ABCDEF0", "InvalidSnapshotID.Malformed"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			status, code, _ := ec2DeleteSnapshot(t, ts, tc.snapshotID)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tc.wantCode, code)
+		})
+	}
+}
+
+// TestEC2_DeleteSnapshot_RefusesOneAnAMIStillUses pins AWS's documented sequence: deregister
+// the AMI, then delete the snapshot.
+//
+// Before #710 the delete succeeded and left the AMI referencing a snapshot that no longer
+// existed — a state real EC2 cannot be put into, and one substrate had to grow a fallback
+// for in describeImages to keep rendering a volume size at all.
+func TestEC2_DeleteSnapshot_RefusesOneAnAMIStillUses(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	imageID, snapID := ec2ImageWithSnapshot(t, ts)
+
+	status, code, message := ec2DeleteSnapshot(t, ts, snapID)
+	require.Equal(t, http.StatusBadRequest, status, "this answered 200 before #710")
+	assert.Equal(t, "InvalidSnapshot.InUse", code)
+	assert.Contains(t, message, snapID, "the message must name the snapshot")
+	assert.Contains(t, message, imageID,
+		"and the AMI, since deregistering it is the caller's next step")
+	assert.True(t, ec2SnapshotExists(t, ts, snapID), "a refused delete removes nothing")
+
+	// AWS: "You must first deregister the AMI before you can delete the snapshot."
+	dereg := ec2Request(t, ts, map[string]string{"Action": "DeregisterImage", "ImageId": imageID})
+	require.Equal(t, http.StatusOK, dereg.StatusCode)
+	dereg.Body.Close() //nolint:errcheck
+
+	status, code, _ = ec2DeleteSnapshot(t, ts, snapID)
+	require.Equal(t, http.StatusOK, status, "code=%s", code)
+	assert.False(t, ec2SnapshotExists(t, ts, snapID))
+}
+
+// TestEC2_DeleteSnapshot_SharedSnapshotNamesTheSameAMIEveryTime pins the tie-break when two
+// AMIs reference one snapshot, which #328 made reachable: RegisterImage against an existing
+// snapshot shares it with the AMI that minted it.
+//
+// The refusal message names an image, and [StateManager.List] returns keys in Go map order,
+// so without a tie-break the message would vary run to run for identical inputs — the one
+// thing an event-sourced emulator cannot do, since replay would produce a different body
+// from the recorded one. The rule is the lowest image ID, and this asserts the property
+// rather than a fixed string, because the IDs are freshly generated.
+//
+// Ten deletes rather than one: a map with two entries yields either order often enough that
+// a single call would pass a broken implementation about half the time.
+func TestEC2_DeleteSnapshot_SharedSnapshotNamesTheSameAMIEveryTime(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	amiA, snapID := ec2ImageWithSnapshot(t, ts)
+	amiB := ec2CreateImageID(t, ts, map[string]string{
+		"Action": "RegisterImage", "Name": "shares-the-snapshot",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": snapID,
+	})
+	require.NotEqual(t, amiA, amiB)
+	// Not the min builtin: apigateway_proxy_test.go:144 declares a package-level min(int,
+	// int) that shadows it for the whole test package.
+	want := amiA
+	if amiB < want {
+		want = amiB
+	}
+
+	for range 10 {
+		status, code, message := ec2DeleteSnapshot(t, ts, snapID)
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Equal(t, "InvalidSnapshot.InUse", code)
+		require.Contains(t, message, want,
+			"the lowest image ID, so the same inputs give the same body on replay")
+	}
+}
+
+// TestEC2_DeleteSnapshot_AnUnrelatedAMIDoesNotBlockIt is the negative half of the in-use
+// rule: the check must match on the snapshot, not on the existence of any AMI.
+//
+// Two AMIs exist here and each has its own backing snapshot, so a check that answered
+// "some image exists" rather than "this image names this snapshot" would refuse both
+// deletions and pass every assertion in the test above.
+func TestEC2_DeleteSnapshot_AnUnrelatedAMIDoesNotBlockIt(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, otherSnap := ec2ImageWithSnapshot(t, ts)
+	_, freeSnap := ec2SnapshotOfSize(t, ts, 10)
+	require.NotEqual(t, otherSnap, freeSnap)
+
+	status, code, _ := ec2DeleteSnapshot(t, ts, freeSnap)
+	require.Equal(t, http.StatusOK, status, "code=%s", code)
+	assert.False(t, ec2SnapshotExists(t, ts, freeSnap))
+	assert.True(t, ec2SnapshotExists(t, ts, otherSnap), "the AMI's own snapshot is untouched")
+}

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -4206,6 +4207,41 @@ func (p *EC2Plugin) deregisterImage(reqCtx *RequestContext, req *AWSRequest) (*A
 	})
 }
 
+// ec2ImageUsingSnapshot reports the AMI that references snapshotID, or "" if none does.
+//
+// The answer must be stable, because it reaches the caller inside a refusal message:
+// [StateManager.List] returns keys in map order, and an AMI registered against an existing
+// snapshot shares it with the AMI that minted it (#328), so two images can name the same
+// snapshot. Sorting the keys and reporting the first makes the message the same on every
+// run and on replay, rather than whichever image the map happened to yield.
+//
+// A record that will not read is skipped for the reason [EC2Plugin.ec2SnapshotResolver]
+// gives — but note the direction of the consequence here: a skipped image is one this
+// function does not report, so an unreadable record permits a deletion rather than
+// refusing one.
+func (p *EC2Plugin) ec2ImageUsingSnapshot(reqCtx *RequestContext, snapshotID string) (string, error) {
+	keys, err := p.state.List(context.Background(), ec2Namespace,
+		"image:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+	if err != nil {
+		return "", fmt.Errorf("ec2 deleteSnapshot list images: %w", err)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		data, getErr := p.state.Get(context.Background(), ec2Namespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var img EC2Image
+		if json.Unmarshal(data, &img) != nil {
+			continue
+		}
+		if img.SnapshotID == snapshotID {
+			return img.ImageID, nil
+		}
+	}
+	return "", nil
+}
+
 // --- Availability Zone operations ---
 
 // ec2SeededZones reports the region's zones, name and ID both, in a stable order.
@@ -6241,17 +6277,54 @@ func (p *EC2Plugin) detachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 	})
 }
 
-// deleteSnapshot is a stub that accepts DeleteSnapshot requests without error.
-// Substratefs does not persist snapshots; the operation succeeds to allow
-// AMI deregistration cleanup workflows to proceed.
+// deleteSnapshot deletes the snapshot SnapshotId names, refusing an ID that names nothing
+// and one an AMI still references.
+//
+// The record has been deleted since #325 — the doc comment this replaces claimed otherwise
+// ("Substratefs does not persist snapshots; the operation succeeds"), which was false for
+// long enough that #710 was filed to fix a deletion that already worked. What did not work
+// was the validation. A well-formed ID naming no snapshot answered 200 and `return true`,
+// so a consumer's cleanup could delete the wrong ID, or the same ID twice, or an ID it had
+// typoed, and be told each time that a snapshot had been deleted. AWS documents
+// InvalidSnapshot.NotFound: "The specified snapshot does not exist."
+//
+// # The in-use rule
+//
+// AWS: "You cannot delete a snapshot of the root device of an EBS volume used by a
+// registered AMI. You must first deregister the AMI before you can delete the snapshot."
+// [EC2Image.SnapshotID] is by construction the root device's snapshot — createImage writes
+// it from the instance's root volume and registerImage from the caller's mapping — so
+// AWS's narrower scoping (the *root* device specifically) happens not to bite here; every
+// snapshot an image references is a root-device snapshot. A future change that lets an
+// image reference a non-root snapshot has to narrow this check to keep matching AWS.
+//
+// Order matters and follows real EC2: the ID is validated, then existence, then the in-use
+// rule. Reporting InUse for a malformed ID would tell a caller an AMI holds something that
+// cannot be a snapshot ID at all.
+//
+// Provenance: InvalidSnapshot.InUse is not on API_DeleteSnapshot.html — that page's Errors
+// section is empty. It comes from EC2's client-error table, whose entry describes the
+// condition ("The snapshot that you are trying to delete is in use by one or more AMIs")
+// rather than quoting a wire message, so the message here is substrate's wording of AWS's
+// description — the same caveat [ec2UnknownInstanceAttribute] records for IncorrectState.
 func (p *EC2Plugin) deleteSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	snapshotID := req.Params["SnapshotId"]
-	if snapshotID == "" {
-		return nil, &AWSError{Code: "InvalidParameterValue", Message: "SnapshotId is required", HTTPStatus: http.StatusBadRequest}
+	_, found := p.ec2SnapshotResolver(reqCtx)(snapshotID)
+	if err := ec2RequireNamedResource(ec2SnapshotIDKind, "SnapshotId", snapshotID, found); err != nil {
+		return nil, err
 	}
-	// Remove the snapshot from state so a subsequent DescribeSnapshots reflects
-	// the deletion (enables shared-snapshot retain-vs-delete testing). Delete is
-	// idempotent — a missing snapshot still returns success.
+	imageID, err := p.ec2ImageUsingSnapshot(reqCtx, snapshotID)
+	if err != nil {
+		return nil, err
+	}
+	if imageID != "" {
+		return nil, &AWSError{
+			Code: "InvalidSnapshot.InUse",
+			Message: fmt.Sprintf("The snapshot %s is currently in use by %s",
+				snapshotID, imageID),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
 	if err := p.state.Delete(context.Background(), ec2Namespace, ec2SnapshotStateKey(reqCtx.AccountID, reqCtx.Region, snapshotID)); err != nil {
 		return nil, fmt.Errorf("ec2 deleteSnapshot delete: %w", err)
 	}

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -2976,14 +2976,10 @@ func TestEC2_EBS_AttachDetachVolume(t *testing.T) {
 	assert.Contains(t, string(descBody2), "available")
 }
 
-func TestEC2_DeleteSnapshot_Stub(t *testing.T) {
-	ts := newEC2TestServer(t)
-	resp := ec2Request(t, ts, map[string]string{
-		"Action":     "DeleteSnapshot",
-		"SnapshotId": "snap-0123456789abcdef0",
-	})
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
+// TestEC2_DeleteSnapshot_Stub used to assert 200 for a well-formed ID naming no snapshot —
+// the stub's whole behavior. #710 made that case InvalidSnapshot.NotFound, so the test
+// moved to ec2_deletesnapshot_test.go with the rest of the operation's rules and the name
+// went with it: nothing about DeleteSnapshot is a stub now.
 
 func TestEC2_RunInstances_InvalidSG(t *testing.T) {
 	ts := newEC2TestServer(t)
@@ -3565,6 +3561,16 @@ func TestEC2_CreateImage_SnapshotsAndFilter(t *testing.T) {
 	require.Contains(t, filtered, amiA)
 
 	// Deleting a snapshot removes it from DescribeSnapshots (retention path).
+	//
+	// The deregister is AWS's documented sequence, and required as of #710: "You cannot
+	// delete a snapshot of the root device of an EBS volume used by a registered AMI. You
+	// must first deregister the AMI before you can delete the snapshot." Before #710 this
+	// deleted amiB's backing snapshot out from under a registered AMI and was told it had
+	// succeeded — which is why the AMI-whose-snapshot-is-gone fallback in describeImages
+	// exists at all.
+	dereg := ec2Request(t, ts, map[string]string{"Action": "DeregisterImage", "ImageId": amiB})
+	require.Equal(t, http.StatusOK, dereg.StatusCode)
+	dereg.Body.Close() //nolint:errcheck
 	del := ec2Request(t, ts, map[string]string{"Action": "DeleteSnapshot", "SnapshotId": snapB})
 	assert.Equal(t, http.StatusOK, del.StatusCode)
 	del.Body.Close() //nolint:errcheck


### PR DESCRIPTION
Closes #710

## Correcting the issue first

#710's headline is that "`DeleteSnapshot` deletes nothing; a snapshot survives its own `DeleteSnapshot`". **It does not, and has not since #325** — `deleteSnapshot` calls `state.Delete`, two doc comments say so, and `TestEC2_CreateImage_SnapshotsAndFilter` already asserted the record disappears. Acceptance criterion 2 was met before this PR started.

What was actually broken is the validation. **Every** well-formed ID answered HTTP 200 and `<return>true</return>` — the answer a caller reads as "deleted". A cleanup loop deleting a typoed ID, an ID from another region, or the same ID twice was told each time that it had removed a snapshot.

The doc comment was the other half of the report, and it was false in both sentences:

> deleteSnapshot is a stub that accepts DeleteSnapshot requests without error.
> Substratefs does not persist snapshots; the operation succeeds to allow AMI deregistration cleanup workflows to proceed.

## What it answers now

| Request | Answer |
|---|---|
| `SnapshotId` omitted | `MissingParameter` — AWS marks it `Required: Yes` |
| `vol-…`, `ami-…`, no prefix, non-hex, uppercase, `snap-` alone | `InvalidSnapshotID.Malformed` |
| Well-formed, names nothing — **including a second delete of the same ID** | `InvalidSnapshot.NotFound` |
| Named by a registered AMI's block device mapping | `InvalidSnapshot.InUse`, naming both the snapshot and the AMI |
| Anything else | Deleted; `DescribeSnapshots` no longer reports it |

Validation order is real EC2's — malformed, then absent, then in use — through `ec2RequireNamedResource(ec2SnapshotIDKind, …)`, so this operation gets the same three answers every other ID-validated one does rather than a fourth hand-written variant. Reporting `InUse` for a malformed ID would claim an AMI holds something no AMI could hold.

## The in-use rule

AWS: "You cannot delete a snapshot of the root device of an EBS volume used by a registered AMI. You must first deregister the AMI before you can delete the snapshot."

`EC2Image.SnapshotID` is by construction the root device's snapshot — `createImage` writes it from the instance's root volume, `registerImage` from the caller's mapping — so AWS's narrower scoping (the *root* device specifically) happens not to bite: every snapshot an image references here is a root-device snapshot. That is stated in the doc comment rather than glossed, because an image that could reference a non-root snapshot would need the check narrowed to keep matching AWS. #711 adds a mappings list to `EC2Image` and will have to extend this check to it.

**The refusal names the lowest image ID** when two AMIs share one snapshot, which #328 made reachable (`RegisterImage` against an existing snapshot shares it with the AMI that minted it). `StateManager.List` returns keys in Go map order, so without a tie-break the message would vary run to run for identical inputs — the one thing an event-sourced emulator cannot do, since replay would produce a different body from the recorded one.

## Two consequences for consumers

- **The operation is not idempotent**, and against AWS it never was. A teardown written to be re-runnable has to tolerate `InvalidSnapshot.NotFound`; substrate's 200 was hiding a requirement it has to meet anyway.
- **Order matters**: deregister the AMI, then delete its snapshot. The reverse used to succeed and leave an AMI referencing a snapshot that no longer existed — a state real EC2 cannot be put into, and the reason `describeImages` needed its missing-snapshot fallback. That fallback stays (it is still reachable via `RegisterImage` naming a nonexistent snapshot, and by a record written directly into state), and the docs now say so instead of attributing it to deletion.

## Provenance

**None of the three codes is on `API_DeleteSnapshot.html` — that page's Errors section is empty.** All come from EC2's client-error table. `InvalidSnapshotID.Malformed` and `InvalidSnapshot.NotFound` were already wired through `ec2SnapshotIDKind` and predate this change. `InvalidSnapshot.InUse`'s entry *describes* the condition — "The snapshot that you are trying to delete is in use by one or more AMIs" — rather than quoting a wire message, so the message substrate returns is its own wording of AWS's description, the same caveat `ec2_instanceattribute.go` records for `IncorrectInstanceState`. The tests match on the code and on the two resource IDs, not on AWS's wording.

One documentation oddity, deliberately not honoured: AWS's own sample request on that page sends `SnapshotId.1=snap-…`, an indexed form for a parameter its normative parameter list declares scalar. The parameter list wins; substrate reads `SnapshotId`, as it did before.

## Tests

Existing tests that had to change, both predicted:

- `TestEC2_DeleteSnapshot_Stub` asserted 200 for a well-formed ID naming nothing — the stub's whole behaviour. Removed, with a pointer to where its subject now lives; `_Stub` is a misnomer now.
- `TestEC2_CreateImage_SnapshotsAndFilter` deleted an AMI's backing snapshot with no `DeregisterImage` first. The deregister is inserted, which makes it exercise AWS's documented sequence.

New, in `ec2_deletesnapshot_test.go`: delete-then-describe plus the non-idempotent second delete, an eight-row table over the ID failures, the in-use refusal followed by deregister-then-delete, the unrelated-AMI negative control, and the shared-snapshot tie-break.

**Fail-before**, in a throwaway worktree at `1318a51`: 3 of 4 tests fail, 11 subtests. The fourth is the negative control, which the old code satisfies trivially — as it should.

**Mutation testing**, one condition at a time, reverted after each:

| Mutation | Killed by |
|---|---|
| `img.SnapshotID == snapshotID` → `img.SnapshotID != ""` (any AMI blocks any delete) | `_AnUnrelatedAMIDoesNotBlockIt` |
| the `InUse` refusal dropped, check still run | `_RefusesOneAnAMIStillUses` |
| `sort.Strings(keys)` removed | `_SharedSnapshotNamesTheSameAMIEveryTime` |

The third mutation is why that last test exists: the first pass at this PR had the sort with nothing pinning it.

## Verification

```
gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...   # 0 issues
make test                                                                 # green, race on
make coverage                                                             # 83.2% emulator
make docs-reference docs-reference-check docs-versions                     # up to date
npm --prefix docs run build                                               # 318 hrefs / 327 ids, none dangling
go vet -C test/e2e ./... && go test -C test/e2e ./...                     # green
```