### PR TITLE
feat(ec2): RegisterImage records the whole block device mapping (#711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot be used."
 
 ### Changed
+- **`RegisterImage` records the whole block device mapping it is sent** (#711). It read exactly
+  one thing out of it — the first `BlockDeviceMapping.N.Ebs.SnapshotId`, found by a hand walk of
+  indexes 1 to 32 — and discarded the rest of every entry: device names, sizes, volume types,
+  and every mapping after the first that named a snapshot. AWS's own third example for this
+  operation registers three volumes (two distinct snapshots and an empty 100 GiB volume), so a
+  caller sending AWS's documented request got one volume back, rendered on a `/dev/sda1` the
+  request need never have mentioned. `EC2Image` gained a mappings field, `DescribeImages`
+  renders every entry in request order, and each entry naming a snapshot is validated by the
+  same checker the launch path uses — so a malformed or absent snapshot ID is
+  `InvalidSnapshotID.Malformed` / `InvalidSnapshot.NotFound` before anything is written,
+  instead of being stored and later rendered as a plausible volume of substrate's default size.
+
+  Three rules the operation had no reader for at all. `RootDeviceName` now decides which mapping
+  is the root device's, falling back to the first that names a snapshot — which matters beyond
+  bookkeeping, because that is the snapshot `DeleteSnapshot`'s in-use rule protects.
+  `TagSpecification.N` scoped to `image` now tags the AMI, where the tags previously went
+  nowhere; any other `ResourceType` is refused, per AWS's "If you specify another value for
+  `ResourceType`, the request fails". And a mapping that names a size and no snapshot — AWS's
+  third example volume — is registered rather than being ignored for naming no snapshot.
+
+  Two changes a caller can notice from the shared parser replacing the hand walk: it is
+  **unbounded**, so a request with more than 32 mappings no longer loses the remainder, and it
+  **stops at the first absent index** rather than tolerating a gap. AWS's query protocol indexes
+  contiguously and every other indexed walk in substrate assumes it, so a sparse request is not
+  one an SDK produces — but a hand-built request that skipped an index used to have its later
+  mappings read. Also widened: `block-device-mapping.snapshot-id` matches on every snapshot an
+  AMI's mapping names, not only the root device's, because consulting the root alone meant a
+  filter naming a volume `DescribeImages` had just rendered found no AMI.
+
+  #711's premises were both wrong and are corrected here. `DescribeImages` did **not** report
+  "a size of zero rather than the old constant 8" — it falls back to `ec2DefaultVolumeSizeGiB`
+  and documents why; what it lacked was a test, which it now has on both records that reach the
+  fallback. And the hand walk was not "a different convention from `extractEC2Filters`' and
+  `ec2CheckBlockDeviceMappings`' own walks": neither of those walks `BlockDeviceMapping.N` at
+  all. There was one convention, `ec2ParseBlockDeviceMappings`, and this path is now its third
+  caller rather than a fourth convention.
+
+  Deliberately **not** included: the rest of the shared mapping validator (duplicate device
+  names, `virtualName` spellings, gp3-only `Throughput`). None of it is a rule AWS states for
+  this operation, and bringing six unrelated refusals onto a published path unannounced is how
+  a consumer's working request starts failing. `Name`'s documented character constraints stay
+  unenforced too; only an empty `Name` is refused.
+
+  Provenance: `API_RegisterImage.html`'s Errors section is empty, so no code here comes from the
+  operation's own page. The snapshot codes come from EC2's client-error table and predate this
+  change. The `ResourceType` refusal's code is **substrate's reading** — AWS says only that "the
+  request fails" — chosen because `InvalidParameterValue`'s documented gloss is "A value
+  specified in a parameter is not valid, is unsupported, or cannot be used".
+
 - **`DeleteSnapshot` validates the ID it is given, and refuses one a registered AMI still
   references** (#710). The operation deleted the record correctly — it has since #325, whatever
   the doc comment saying "Substratefs does not persist snapshots; the operation succeeds" claimed
@@ -107,10 +156,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   AMI referencing a snapshot that no longer existed — a state real EC2 cannot be put into, and
   the reason `DescribeImages` needed a fallback to render a volume size at all.
 
-  Substrate's images record exactly one snapshot and it is by construction the root device's, so
-  AWS's narrower scoping (the *root* device specifically) happens not to bite; that is stated
-  rather than glossed, because an image that could reference a non-root snapshot would need the
-  check narrowed. Where two AMIs share one snapshot — reachable since #328 — the refusal names
+  AWS's scoping — the *root* device specifically — is followed rather than widened, and #711 in
+  this same release makes that load-bearing: an AMI now records the whole mapping it was
+  registered with, so a snapshot it names on a non-root device is **not** protected. Deleting one
+  succeeds and leaves the mapping dangling, which `DescribeImages` renders at the 8 GiB default.
+  That is what AWS's sentence says. Where two AMIs share one snapshot — reachable since #328 — the refusal names
   the **lowest** image ID, so identical inputs produce an identical body on replay instead of one
   that follows Go's map iteration order.
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -4684,6 +4684,59 @@ tags on the AMI instead. A caller asserting on `DescribeImages` tags that were
 actually snapshot-scoped will now see them on `DescribeSnapshots`, which is where
 real EC2 puts them.
 
+#### `RegisterImage` records the whole block device mapping
+
+`RegisterImage` read exactly one thing out of the mapping it was sent — the first
+`BlockDeviceMapping.N.Ebs.SnapshotId`, found by a hand walk of indexes 1 to 32 — and
+discarded the rest of every entry: device names, sizes, volume types, and every mapping
+after the first that named a snapshot. AWS's own third example for this operation registers
+three volumes (two snapshots and an empty 100 GiB volume), so a caller sending AWS's
+documented request got one volume back, on a `/dev/sda1` the request need never have
+mentioned.
+
+| Request | Answer |
+|---|---|
+| Every `BlockDeviceMapping.N` entry | Stored as sent and rendered back by `DescribeImages` in request order |
+| A mapping naming a snapshot that is malformed or names nothing | `InvalidSnapshotID.Malformed` / `InvalidSnapshot.NotFound`, before anything is written |
+| `Ebs.VolumeSize` below the snapshot's size | `InvalidBlockDeviceMapping`, naming the device |
+| A mapping with a size and **no** snapshot | Registered — AWS's third example volume is exactly that |
+| A mapping absent a size but naming a snapshot | The snapshot's size, per `EbsBlockDevice.VolumeSize`: "If you specify a snapshot, the default is the snapshot size" |
+| `RootDeviceName` | Read, to decide which mapping is the root device's; absent, the first mapping naming a snapshot is |
+| `TagSpecification.N` with `ResourceType=image` | Tags the AMI, through the same walk and the same [tag rules](#reserved-tag-keys) as every other tag-on-create |
+| `TagSpecification.N` with any other `ResourceType` | `InvalidParameterValue`. AWS: "If you specify another value for `ResourceType`, the request fails" |
+| `Name` | Still the only required parameter, as AWS marks it |
+
+The mapping is now read by the same parser `RunInstances` and a launch template use, which
+brings two changes a caller can notice beyond getting its volumes back. The walk is
+**unbounded**, so a request with more than 32 mappings no longer has the remainder dropped;
+and it **stops at the first absent index** instead of tolerating a gap. AWS's query protocol
+indexes contiguously and every other indexed walk in substrate assumes it, so a sparse
+request is not one an SDK produces — but a hand-built request that skipped an index used to
+have its later mappings read, and no longer does.
+
+Three mapping shapes render differently, because they are different things: an EBS volume
+gets an `ebs` element, an instance store device gets a `virtualName` and **no** `ebs`, and a
+suppressed device gets a `noDevice` element whose value is empty. Giving every mapping an
+`ebs` element would report a phantom 0 GiB volume for the latter two.
+
+`block-device-mapping.snapshot-id` widened with this: it matches on **every** snapshot the
+AMI's mapping names, not only the root device's. Consulting the root alone meant a filter
+naming a volume `DescribeImages` had just rendered found no AMI — two operations
+contradicting each other about one record.
+
+Two things this does **not** do. It applies only the snapshot rule from the shared mapping
+validator, not the rest of it (duplicate device names, `virtualName` spellings, gp3-only
+`Throughput`): none of those is a rule AWS states for this operation, and arriving on a
+published path unannounced is how a consumer's working request starts failing. And
+`Name`'s documented character constraints ("3-128 alphanumeric characters, parentheses…")
+stay unenforced — only an empty `Name` is refused.
+
+Provenance: `API_RegisterImage.html`'s Errors section is empty, so no code here is quoted
+from the operation's own page. The snapshot codes come from EC2's client-error table and
+predate this change. The `ResourceType` code is **substrate's reading** — AWS says only that
+"the request fails" — chosen because `InvalidParameterValue` is EC2's gloss for "A value
+specified in a parameter is not valid, is unsupported, or cannot be used".
+
 #### `DescribeImages` filters
 
 Four filter names are applied: `image-id`, `block-device-mapping.snapshot-id`,
@@ -4814,8 +4867,11 @@ size and its ID — so an AMI made from a 40 GiB root volume reports 40 GiB thro
 `DescribeSnapshots` *and* through `DescribeImages`, which reads the snapshot record rather
 than rendering its own constant. An AMI whose snapshot is missing falls back to the 8 GiB
 default rather than reporting `0`, since a caller sizing a volume off that member can act on
-the default. `DeleteSnapshot` no longer produces that state — see below — so it is reached
-only by `RegisterImage` naming a snapshot that does not exist, or by a record written
+the default. Two things reach that state, and `RegisterImage` naming a snapshot that does not
+exist is no longer one of them — that request is refused, see
+[`RegisterImage` records the whole block device mapping](#registerimage-records-the-whole-block-device-mapping).
+What remains is deleting the snapshot a **non-root** mapping names, which `DeleteSnapshot`
+permits because AWS scopes its refusal to the root device (below), and an AMI record written
 directly into state.
 
 The rest of the `CreateSnapshot` family — `CreateSnapshots`, `CopySnapshot`,
@@ -4836,14 +4892,19 @@ it had removed a snapshot.
 | `SnapshotId` omitted | `MissingParameter` — AWS marks it `Required: Yes` |
 | Not a snapshot ID (`vol-…`, `ami-…`, no prefix, non-hex, uppercase) | `InvalidSnapshotID.Malformed` |
 | Well-formed, names nothing — **including a second delete of the same ID** | `InvalidSnapshot.NotFound` |
-| Named by a registered AMI's block device mapping | `InvalidSnapshot.InUse`, naming both the snapshot and the AMI |
+| A registered AMI's **root device** snapshot | `InvalidSnapshot.InUse`, naming both the snapshot and the AMI |
 | Anything else | Deleted; a subsequent `DescribeSnapshots` does not report it |
 
 The in-use rule is AWS's: "You cannot delete a snapshot of the root device of an EBS volume
 used by a registered AMI. You must first deregister the AMI before you can delete the
-snapshot." Substrate's images record exactly one snapshot and it is by construction the root
-device's, so AWS's narrower scoping — the *root* device specifically — happens not to bite;
-every snapshot an image references here is a root-device snapshot.
+snapshot." Its scoping — the *root* device specifically — is load-bearing, not incidental. An
+AMI records the whole mapping it was registered with, so it can reference snapshots that are
+not its root device's, and **those are not protected**: deleting one succeeds and leaves the
+mapping pointing at a snapshot that no longer exists, which `DescribeImages` then renders at
+the 8 GiB default. That is what AWS's sentence says, and following the API model rather than a
+wider guess is the standing rule here. Which mapping is the root device's is decided by the
+request's `RootDeviceName`, falling back to the first mapping that names a snapshot; a
+`CreateImage`-minted AMI has one snapshot and it is the instance's root volume's.
 
 Two consequences worth planning for:
 

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -3994,38 +3994,79 @@ func (p *EC2Plugin) createImage(reqCtx *RequestContext, req *AWSRequest) (*AWSRe
 	})
 }
 
-// registerImage registers an AMI, optionally pointing its root device at an
-// existing EBS snapshot supplied via BlockDeviceMapping.N.Ebs.SnapshotId. Unlike
-// CreateImage (which always materializes a fresh snapshot), RegisterImage lets a
-// caller register multiple AMIs that *share* one snapshot — the AWS-faithful way
-// to model snapshot sharing, so retain-shared-snapshot logic is testable (#328).
+// registerImage registers an AMI from the block device mapping the caller sends, storing
+// every entry of it. Unlike CreateImage (which always materializes a fresh snapshot),
+// RegisterImage lets a caller register multiple AMIs that *share* one snapshot — the
+// AWS-faithful way to model snapshot sharing, so retain-shared-snapshot logic is testable
+// (#328).
+//
+// # The mappings
+//
+// They are read by [ec2ParseBlockDeviceMappings], the walk RunInstances and a launch
+// template already share, rather than by the bounded 1..32 scan this had through v0.106.0
+// that kept only the first snapshot it found and discarded the rest of every mapping (#711).
+// AWS's own Example 3 registers three volumes — two distinct snapshots and an empty 100 GiB
+// volume — so keeping one snapshot was losing most of the request.
+//
+// Two changes a caller can observe, beyond getting its mappings back: the walk is unbounded,
+// and it stops at the first absent index rather than tolerating a sparse one. AWS's query
+// protocol indexes contiguously and every other indexed walk in this plugin assumes it, so
+// this is alignment with the rest of substrate — but a request that skipped an index used to
+// have its later mappings read and now does not.
+//
+// Each mapping that names a snapshot is checked by [ec2CheckMappingSnapshot], so an ID that
+// is malformed or names nothing is refused instead of being stored and rendered as a
+// dangling reference. That rule alone, deliberately, and not the whole of
+// [ec2CheckBlockDeviceMappings]: the rest of it (duplicate device names, virtualName
+// spellings, gp3-only Throughput, size-or-snapshot) would arrive on a published path
+// unannounced, and none of it is a rule AWS states for this operation.
+//
+// A mapping naming no snapshot is stored as sent — AWS's third Example volume is exactly
+// that, and refusing it would refuse AWS's own documented request.
 func (p *EC2Plugin) registerImage(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	name := req.Params["Name"]
 	if name == "" {
 		return nil, &AWSError{Code: "InvalidParameterValue", Message: "Name is required", HTTPStatus: http.StatusBadRequest}
 	}
 
-	// Find the first block device mapping that names an EBS snapshot. EC2 sends
-	// these as BlockDeviceMapping.N.Ebs.SnapshotId (1-indexed); scan a bounded
-	// range so a sparse index doesn't cause an early stop.
-	snapshotID := ""
-	for i := 1; i <= 32; i++ {
-		if v := req.Params[fmt.Sprintf("BlockDeviceMapping.%d.Ebs.SnapshotId", i)]; v != "" {
-			snapshotID = v
-			break
+	// AWS: "To tag the AMI, the value for ResourceType must be image. If you specify
+	// another value for ResourceType, the request fails." Checked before anything is
+	// written, so a refused request registers nothing — [ec2CheckReservedTagKeys]'s
+	// rollback rule.
+	if awsErr := ec2CheckTagSpecificationTypes(req.Params, "image"); awsErr != nil {
+		return nil, awsErr
+	}
+	tags := ec2LaunchTagsForResource(req.Params, "image")
+	if awsErr := ec2CheckTagRules(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, tags); awsErr != nil {
+		return nil, awsErr
+	}
+
+	mappings := ec2ParseBlockDeviceMappings(req.Params, "")
+	resolveSnapshot := p.ec2SnapshotResolver(reqCtx)
+	for _, bdm := range mappings {
+		if bdm.SnapshotID == "" {
+			continue
+		}
+		if awsErr := ec2CheckMappingSnapshot(bdm, resolveSnapshot); awsErr != nil {
+			return nil, awsErr
 		}
 	}
 
 	imageID := generateImageID()
 	img := EC2Image{
-		ImageID:      imageID,
-		Name:         name,
-		Description:  req.Params["Description"],
-		State:        "available",
-		CreationDate: p.tc.Now().UTC().Format(time.RFC3339),
-		SnapshotID:   snapshotID,
-		AccountID:    reqCtx.AccountID,
-		Region:       reqCtx.Region,
+		ImageID:             imageID,
+		Name:                name,
+		Description:         req.Params["Description"],
+		State:               "available",
+		CreationDate:        p.tc.Now().UTC().Format(time.RFC3339),
+		SnapshotID:          ec2RootMappingSnapshot(mappings, req.Params["RootDeviceName"]),
+		BlockDeviceMappings: mappings,
+		Tags:                tags,
+		AccountID:           reqCtx.AccountID,
+		Region:              reqCtx.Region,
 	}
 	data, err := json.Marshal(img)
 	if err != nil {
@@ -4064,13 +4105,24 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 	// gave this operation a tag: rule no other describe had.
 	filters := extractEC2Filters(req.Params)
 
+	// snapshotId is omitempty because AWS's third RegisterImage example registers a
+	// mapping with a size and no snapshot; rendering an empty element for it would report
+	// a snapshot the AMI does not have.
 	type ebsBlockDevice struct {
-		SnapshotID string `xml:"snapshotId"`
+		SnapshotID string `xml:"snapshotId,omitempty"`
 		VolumeSize int64  `xml:"volumeSize"`
 	}
+	// ebs is a pointer and noDevice a pointer to a string so the three mapping shapes stay
+	// distinguishable: an EBS volume has an ebs element, an instance store device has a
+	// virtualName and no ebs, and a suppressed device has a noDevice element whose value is
+	// empty — present-but-empty is not the same as omitted, the distinction
+	// [ec2UnknownInstanceAttribute]'s neighbors in ec2_instanceattribute.go keep for the
+	// same reason. A value type here would give a suppressed device a phantom 0 GiB volume.
 	type blockDeviceItem struct {
-		DeviceName string         `xml:"deviceName"`
-		EBS        ebsBlockDevice `xml:"ebs"`
+		DeviceName  string          `xml:"deviceName,omitempty"`
+		VirtualName string          `xml:"virtualName,omitempty"`
+		NoDevice    *string         `xml:"noDevice,omitempty"`
+		EBS         *ebsBlockDevice `xml:"ebs,omitempty"`
 	}
 	type imageItem struct {
 		ImageID             string            `xml:"imageId"`
@@ -4121,17 +4173,50 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 			OwnerID:      img.AccountID,
 			CreationDate: img.CreationDate,
 		}
-		if img.SnapshotID != "" {
-			// An AMI whose snapshot record is gone — DeleteSnapshot removes it and leaves
-			// the AMI standing — falls back to the default rather than reporting 0, which
-			// is what a caller sizing a volume off this member can act on.
+		// A RegisterImage AMI renders the mapping the caller sent, entry for entry, in
+		// request order (#711). ec2ResolveSnapshotSizes fills in a size the mapping left to
+		// its snapshot, which is the rule AWS states on EbsBlockDevice.VolumeSize ("If you
+		// specify a snapshot, the default is the snapshot size") and the same pass the
+		// launch path uses — so an AMI's reported volume size and the volume a launch from
+		// it produces cannot disagree.
+		for _, bdm := range ec2ResolveSnapshotSizes(img.BlockDeviceMappings, resolveSnapshot) {
+			bdi := blockDeviceItem{DeviceName: bdm.DeviceName, VirtualName: bdm.VirtualName}
+			switch {
+			case bdm.NoDevice:
+				empty := ""
+				bdi.NoDevice = &empty
+			case bdm.VirtualName != "":
+				// An instance store device is not an EBS volume; manufacturing an ebs
+				// element for it would be an observation nothing backs, the rule
+				// [EC2BlockDeviceMapping.VirtualName] already states for volumes.
+			default:
+				size := int64(bdm.VolumeSize)
+				if size <= 0 {
+					size = ec2DefaultVolumeSizeGiB
+				}
+				bdi.EBS = &ebsBlockDevice{SnapshotID: bdm.SnapshotID, VolumeSize: size}
+			}
+			item.BlockDeviceMappings = append(item.BlockDeviceMappings, bdi)
+		}
+		if len(img.BlockDeviceMappings) == 0 && img.SnapshotID != "" {
+			// Every CreateImage-minted AMI, and any AMI registered before #711, has a root
+			// snapshot and no recorded mapping — so substrate fabricates the root device
+			// entry for it. /dev/sda1 rather than a stored name because that path has none
+			// to store: it images an instance, and EC2Image records no root device.
+			//
+			// An AMI whose snapshot record is gone falls back to the default rather than
+			// reporting 0, which is what a caller sizing a volume off this member can act
+			// on. That state is reachable: DeleteSnapshot refuses only a *root* snapshot
+			// (#710, following AWS's scoping), so deleting the snapshot a non-root mapping
+			// names leaves the AMI standing and the mapping dangling — and lands in the
+			// size <= 0 branch above rather than in this one.
 			size := int64(ec2DefaultVolumeSizeGiB)
 			if snap, found := resolveSnapshot(img.SnapshotID); found && snap.VolumeSize > 0 {
 				size = snap.VolumeSize
 			}
 			item.BlockDeviceMappings = []blockDeviceItem{{
-				DeviceName: "/dev/sda1",
-				EBS:        ebsBlockDevice{SnapshotID: img.SnapshotID, VolumeSize: size},
+				DeviceName: ec2RootDeviceSDA1,
+				EBS:        &ebsBlockDevice{SnapshotID: img.SnapshotID, VolumeSize: size},
 			}}
 		}
 		item.Tags = ec2TagItems(img.Tags)
@@ -4173,7 +4258,17 @@ func ec2ImageMatchesFilters(img EC2Image, filters map[string][]string) bool {
 				}
 			}
 		case name == "block-device-mapping.snapshot-id":
-			matched = img.SnapshotID != "" && ec2FilterAccepts(vals, img.SnapshotID)
+			// Every snapshot the mapping names, not just the root device's. An AMI
+			// registered from AWS's Example 3 renders two snapshots, and a filter that
+			// consulted only the first would report no AMI for a snapshot DescribeImages
+			// had just rendered — a contradiction between two answers about one record
+			// (#711).
+			for _, id := range ec2ImageSnapshotIDs(img) {
+				if ec2FilterAccepts(vals, id) {
+					matched = true
+					break
+				}
+			}
 		case name == "image-id":
 			matched = ec2FilterAccepts(vals, img.ImageID)
 		default:
@@ -4184,6 +4279,61 @@ func ec2ImageMatchesFilters(img EC2Image, filters map[string][]string) bool {
 		}
 	}
 	return true
+}
+
+// ec2RootMappingSnapshot returns the snapshot backing the root device among mappings, or ""
+// if none of them names one.
+//
+// rootDevice is the request's RootDeviceName, which AWS's own RegisterImage examples send
+// beside the mapping that implements it ("&RootDeviceName=/dev/sda1
+// &BlockDeviceMapping.1.DeviceName=/dev/sda1"). When it names one of the mappings, that
+// mapping's snapshot is the answer; otherwise the first mapping naming a snapshot is, which
+// is what AWS's examples put first and what this operation recorded through v0.106.0.
+//
+// RootDeviceName is read rather than [ec2IsRootDevice] guessed at, because this is the one
+// place a caller states which device is root, and guessing would give the wrong answer for
+// an AMI whose root device is neither /dev/sda1 nor /dev/xvda — the limit
+// ec2_block_devices.go's device-name constants already document for paths that have nothing
+// to read.
+//
+// Which mapping wins is load-bearing, not bookkeeping: [EC2Image.SnapshotID] is what
+// DeleteSnapshot's in-use rule consults, and AWS scopes that rule to "a snapshot of the root
+// device of an EBS volume used by a registered AMI" (#710). Picking the wrong mapping would
+// protect the wrong snapshot and leave the root device's deletable.
+func ec2RootMappingSnapshot(mappings []EC2BlockDeviceMapping, rootDevice string) string {
+	if rootDevice != "" {
+		for _, bdm := range mappings {
+			if bdm.DeviceName == rootDevice && bdm.SnapshotID != "" {
+				return bdm.SnapshotID
+			}
+		}
+	}
+	for _, bdm := range mappings {
+		if bdm.SnapshotID != "" {
+			return bdm.SnapshotID
+		}
+	}
+	return ""
+}
+
+// ec2ImageSnapshotIDs returns every snapshot the AMI references, the root device's first.
+//
+// Both members are read because they answer different questions and an AMI can have either:
+// [EC2Image.SnapshotID] is the only one a pre-#711 record or a CreateImage-minted AMI has,
+// and [EC2Image.BlockDeviceMappings] is the only one that has an AMI's non-root volumes.
+// The root snapshot is skipped when a mapping repeats it, so the common case — one mapping,
+// which is the root — yields one ID rather than the same ID twice.
+func ec2ImageSnapshotIDs(img EC2Image) []string {
+	var out []string
+	if img.SnapshotID != "" {
+		out = append(out, img.SnapshotID)
+	}
+	for _, bdm := range img.BlockDeviceMappings {
+		if bdm.SnapshotID != "" && bdm.SnapshotID != img.SnapshotID {
+			out = append(out, bdm.SnapshotID)
+		}
+	}
+	return out
 }
 
 // deregisterImage removes an AMI from state.
@@ -4207,7 +4357,9 @@ func (p *EC2Plugin) deregisterImage(reqCtx *RequestContext, req *AWSRequest) (*A
 	})
 }
 
-// ec2ImageUsingSnapshot reports the AMI that references snapshotID, or "" if none does.
+// ec2ImageUsingSnapshot reports the AMI whose *root device* snapshot is snapshotID, or "" if
+// no AMI has one. An AMI that names it in some other mapping entry is not reported, for the
+// reason [EC2Plugin.deleteSnapshot] gives — AWS scopes the refusal to the root device.
 //
 // The answer must be stable, because it reaches the caller inside a refusal message:
 // [StateManager.List] returns keys in map order, and an AMI registered against an existing
@@ -6293,10 +6445,16 @@ func (p *EC2Plugin) detachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 // AWS: "You cannot delete a snapshot of the root device of an EBS volume used by a
 // registered AMI. You must first deregister the AMI before you can delete the snapshot."
 // [EC2Image.SnapshotID] is by construction the root device's snapshot — createImage writes
-// it from the instance's root volume and registerImage from the caller's mapping — so
-// AWS's narrower scoping (the *root* device specifically) happens not to bite here; every
-// snapshot an image references is a root-device snapshot. A future change that lets an
-// image reference a non-root snapshot has to narrow this check to keep matching AWS.
+// it from the instance's root volume and registerImage from the mapping RootDeviceName names
+// (see [ec2RootMappingSnapshot]) — so consulting that member alone *is* AWS's scoping rather
+// than an approximation of it.
+//
+// Since #711 an AMI can also reference non-root snapshots, through the rest of its recorded
+// mapping, and this rule deliberately does not protect those: AWS's sentence names the root
+// device specifically, and #671 settled that substrate models what the API model states. The
+// consequence is observable and is the one API-reachable route to an AMI whose mapping names
+// a snapshot that no longer exists — DescribeImages renders such a mapping at
+// [ec2DefaultVolumeSizeGiB], which is what that fallback is for.
 //
 // Order matters and follows real EC2: the ID is validated, then existence, then the in-use
 // rule. Reporting InUse for a malformed ID would tell a caller an AMI holds something that

--- a/emulator/ec2_registerimage_test.go
+++ b/emulator/ec2_registerimage_test.go
@@ -1,0 +1,426 @@
+package emulator_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/scttfrdmn/substrate/emulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// What RegisterImage does with the block device mapping it is sent (#711).
+//
+// Through v0.106.0 it read one thing out of the mapping — the first
+// BlockDeviceMapping.N.Ebs.SnapshotId, found by a hand walk of indexes 1..32 — and discarded
+// everything else: device names, sizes, volume types, and every mapping after the first that
+// named a snapshot. AWS's own third example registers three volumes, so a caller sending
+// AWS's documented request got back one, and DescribeImages rendered a /dev/sda1 the request
+// may never have mentioned.
+//
+// The mapping is now parsed by the walk RunInstances and launch templates share, validated
+// for the snapshots it names, stored entry for entry, and rendered back in request order.
+//
+// Provenance: API_RegisterImage.html's Errors section is empty, so no refusal below is
+// quoted from the operation's own page. The snapshot refusals come from EC2's client-error
+// table via ec2SnapshotIDKind, which predates this change; the ResourceType refusal is
+// substrate's code for AWS's "If you specify another value for ResourceType, the request
+// fails", which names no code.
+
+// ec2ImageMappingEBS is the ebs element of a rendered block device mapping. It is a pointer
+// in [ec2ImageMapping] so that "no ebs element" and "an ebs element reporting 0 GiB" stay
+// distinguishable, which is the whole subject of the instance-store and NoDevice tests.
+type ec2ImageMappingEBS struct {
+	SnapshotID string `xml:"snapshotId"`
+	VolumeSize int64  `xml:"volumeSize"`
+}
+
+// ec2ImageMapping is one item of a DescribeImages blockDeviceMapping.
+type ec2ImageMapping struct {
+	DeviceName  string              `xml:"deviceName"`
+	VirtualName string              `xml:"virtualName"`
+	NoDevice    *string             `xml:"noDevice"`
+	EBS         *ec2ImageMappingEBS `xml:"ebs"`
+}
+
+// ec2ImageMappings returns the block device mapping DescribeImages renders for imageID.
+func ec2ImageMappings(t *testing.T, ts *httptest.Server, imageID string) []ec2ImageMapping {
+	t.Helper()
+	var doc struct {
+		Images []struct {
+			Mappings []ec2ImageMapping `xml:"blockDeviceMapping>item"`
+		} `xml:"imagesSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeImages", "ImageId.1": imageID}, &doc)
+	require.Len(t, doc.Images, 1)
+	return doc.Images[0].Mappings
+}
+
+// ec2RegisterImage sends a RegisterImage with params on top of Action and Name.
+func ec2RegisterImage(t *testing.T, ts *httptest.Server, name string, params map[string]string) map[string]string {
+	t.Helper()
+	req := map[string]string{"Action": "RegisterImage", "Name": name}
+	for k, v := range params {
+		req[k] = v
+	}
+	return req
+}
+
+// TestEC2_RegisterImage_StoresEveryMappingAWSSends registers AWS's Example 3 verbatim in
+// shape: two volumes from two distinct snapshots and a third that is an empty 100 GiB volume.
+//
+// This is the operation's fail-before. Before #711 the response to this request described a
+// single /dev/sda1 volume, so two of the three volumes the caller registered were
+// unobservable through any API call — and the one that survived reported a device name that
+// happened to match only because AWS's example uses /dev/sda1 for the root.
+//
+// The two snapshots have different sizes on purpose: a renderer that resolved every mapping
+// against the same snapshot, or against the AMI's root, would report one size twice.
+func TestEC2_RegisterImage_StoresEveryMappingAWSSends(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, rootSnap := ec2SnapshotOfSize(t, ts, 30)
+	_, dataSnap := ec2SnapshotOfSize(t, ts, 50)
+
+	imageID := ec2CreateImageID(t, ts, ec2RegisterImage(t, ts, "MyImage", map[string]string{
+		"RootDeviceName":                      "/dev/sda1",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": rootSnap,
+		"BlockDeviceMapping.2.DeviceName":     "/dev/sdb",
+		"BlockDeviceMapping.2.Ebs.SnapshotId": dataSnap,
+		"BlockDeviceMapping.3.DeviceName":     "/dev/sdc",
+		"BlockDeviceMapping.3.Ebs.VolumeSize": "100",
+	}))
+
+	got := ec2ImageMappings(t, ts, imageID)
+	require.Len(t, got, 3, "all three of AWS's example volumes, in request order")
+
+	assert.Equal(t, "/dev/sda1", got[0].DeviceName)
+	require.NotNil(t, got[0].EBS)
+	assert.Equal(t, rootSnap, got[0].EBS.SnapshotID)
+	assert.Equal(t, int64(30), got[0].EBS.VolumeSize, "the root snapshot's own size")
+
+	assert.Equal(t, "/dev/sdb", got[1].DeviceName)
+	require.NotNil(t, got[1].EBS)
+	assert.Equal(t, dataSnap, got[1].EBS.SnapshotID)
+	assert.Equal(t, int64(50), got[1].EBS.VolumeSize, "the second snapshot's, not the root's")
+
+	// AWS: "The third volume is an empty 100 GiB Amazon EBS volume." A mapping naming a
+	// size and no snapshot is a request AWS documents, so registering it must succeed and
+	// it must render no snapshotId at all.
+	assert.Equal(t, "/dev/sdc", got[2].DeviceName)
+	require.NotNil(t, got[2].EBS)
+	assert.Empty(t, got[2].EBS.SnapshotID)
+	assert.Equal(t, int64(100), got[2].EBS.VolumeSize)
+}
+
+// TestEC2_RegisterImage_RefusesASnapshotItCannotResolve pins the one validation rule this
+// path borrows, on a mapping that is not the first — the index the old walk stopped at.
+//
+// A stored dangling reference is worse than a refusal here, because DescribeImages renders it
+// as a real volume of substrate's default size: the caller reads a plausible answer about a
+// snapshot that does not exist. Nothing is registered either way, so a refused request leaves
+// no half-built AMI.
+func TestEC2_RegisterImage_RefusesASnapshotItCannotResolve(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, rootSnap := ec2SnapshotOfSize(t, ts, 20)
+
+	for name, tc := range map[string]struct {
+		snapshotID string
+		wantCode   string
+	}{
+		"absent":       {"snap-0123456789abcdef0", "InvalidSnapshot.NotFound"},
+		"wrong prefix": {"vol-0123456789abcdef0", "InvalidSnapshotID.Malformed"},
+		"no prefix":    {"0123456789abcdef0", "InvalidSnapshotID.Malformed"},
+		"non-hex body": {"snap-0123456789abcdefg", "InvalidSnapshotID.Malformed"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := ec2FilteredImageIDs(t, ts, map[string]string{})
+			status, code, _ := ec2ErrorDetail(t, ts, ec2RegisterImage(t, ts, "refused-"+name,
+				map[string]string{
+					"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+					"BlockDeviceMapping.1.Ebs.SnapshotId": rootSnap,
+					"BlockDeviceMapping.2.DeviceName":     "/dev/sdb",
+					"BlockDeviceMapping.2.Ebs.SnapshotId": tc.snapshotID,
+				}))
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tc.wantCode, code)
+			assert.Len(t, ec2FilteredImageIDs(t, ts, map[string]string{}), len(before),
+				"a refused request registers no AMI")
+		})
+	}
+}
+
+// TestEC2_RegisterImage_RefusesASizeBelowTheSnapshot is the other half of the borrowed rule,
+// and the reason it is worth borrowing rather than writing: the two refusals carry different
+// codes because they are different mistakes, and the shared checker already knows that.
+func TestEC2_RegisterImage_RefusesASizeBelowTheSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapID := ec2SnapshotOfSize(t, ts, 40)
+
+	status, code, message := ec2ErrorDetail(t, ts, ec2RegisterImage(t, ts, "too-small",
+		map[string]string{
+			"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+			"BlockDeviceMapping.1.Ebs.SnapshotId": snapID,
+			"BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+		}))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidBlockDeviceMapping", code)
+	assert.Contains(t, message, "/dev/sda1", "the message must name the offending device")
+	assert.Contains(t, message, snapID)
+}
+
+// TestEC2_RegisterImage_WalksPastIndexThirtyTwoAndStopsAtAGap pins both halves of the parser
+// change, in the two directions a caller can notice.
+//
+// Unbounded: the old walk read indexes 1..32, so a request with more mappings than that had
+// the rest silently dropped. Contiguous: the old walk tolerated a gap, and the shared parser
+// stops at the first absent index. AWS's query protocol indexes contiguously and every other
+// indexed walk in the plugin assumes it, so a sparse request is not one an SDK produces — but
+// a hand-built request that skipped an index used to have its later mappings read, and no
+// longer does.
+func TestEC2_RegisterImage_WalksPastIndexThirtyTwoAndStopsAtAGap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("index 33 is read", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		params := map[string]string{}
+		for i := 1; i <= 33; i++ {
+			params[fmt.Sprintf("BlockDeviceMapping.%d.DeviceName", i)] = fmt.Sprintf("/dev/sd%d", i)
+			params[fmt.Sprintf("BlockDeviceMapping.%d.Ebs.VolumeSize", i)] = "10"
+		}
+		imageID := ec2CreateImageID(t, ts, ec2RegisterImage(t, ts, "thirty-three", params))
+		assert.Len(t, ec2ImageMappings(t, ts, imageID), 33,
+			"the walk no longer stops at 32")
+	})
+
+	t.Run("a gap ends the list", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		imageID := ec2CreateImageID(t, ts, ec2RegisterImage(t, ts, "sparse", map[string]string{
+			"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+			"BlockDeviceMapping.1.Ebs.VolumeSize": "10",
+			"BlockDeviceMapping.3.DeviceName":     "/dev/sdc",
+			"BlockDeviceMapping.3.Ebs.VolumeSize": "20",
+		}))
+		got := ec2ImageMappings(t, ts, imageID)
+		require.Len(t, got, 1, "index 2 is absent, so index 3 is not read")
+		assert.Equal(t, "/dev/sda1", got[0].DeviceName)
+	})
+}
+
+// TestEC2_RegisterImage_RootDeviceNameChoosesTheProtectedSnapshot pins which of several
+// snapshots becomes the AMI's root — through the one behavior that depends on the answer.
+//
+// [EC2Image.SnapshotID] is not directly observable, so asserting on it would mean reading
+// state. DeleteSnapshot's in-use rule is observable and is scoped to the root device
+// specifically (#710, following AWS's "You cannot delete a snapshot of the root device of an
+// EBS volume used by a registered AMI"), so the root snapshot is the one that cannot be
+// deleted and every other one can. The mapping order here is deliberately the reverse of
+// AWS's example: the root device is the *second* mapping, so an implementation taking the
+// first would protect the data volume's snapshot and leave the root's deletable.
+func TestEC2_RegisterImage_RootDeviceNameChoosesTheProtectedSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, dataSnap := ec2SnapshotOfSize(t, ts, 25)
+	_, rootSnap := ec2SnapshotOfSize(t, ts, 35)
+
+	imageID := ec2CreateImageID(t, ts, ec2RegisterImage(t, ts, "root-is-second", map[string]string{
+		"RootDeviceName":                      "/dev/xvda",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdb",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": dataSnap,
+		"BlockDeviceMapping.2.DeviceName":     "/dev/xvda",
+		"BlockDeviceMapping.2.Ebs.SnapshotId": rootSnap,
+	}))
+
+	status, code, message := ec2DeleteSnapshot(t, ts, rootSnap)
+	require.Equal(t, http.StatusBadRequest, status, "the root snapshot is protected")
+	assert.Equal(t, "InvalidSnapshot.InUse", code)
+	assert.Contains(t, message, imageID)
+
+	// And the non-root one is not: AWS's sentence names the root device, and #671 settled
+	// that substrate models what the API model states rather than a wider guess.
+	status, code, _ = ec2DeleteSnapshot(t, ts, dataSnap)
+	require.Equal(t, http.StatusOK, status, "code=%s", code)
+}
+
+// TestEC2_RegisterImage_FilterFindsANonRootSnapshot keeps two answers about one AMI
+// consistent.
+//
+// The block-device-mapping.snapshot-id filter read only the root snapshot, so an AMI whose
+// second volume DescribeImages had just rendered was invisible to a filter naming that
+// volume's snapshot — one operation contradicting the other about the same record.
+func TestEC2_RegisterImage_FilterFindsANonRootSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, rootSnap := ec2SnapshotOfSize(t, ts, 15)
+	_, dataSnap := ec2SnapshotOfSize(t, ts, 45)
+
+	imageID := ec2CreateImageID(t, ts, ec2RegisterImage(t, ts, "two-volumes", map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": rootSnap,
+		"BlockDeviceMapping.2.DeviceName":     "/dev/sdb",
+		"BlockDeviceMapping.2.Ebs.SnapshotId": dataSnap,
+	}))
+
+	for _, snapID := range []string{rootSnap, dataSnap} {
+		assert.Equal(t, []string{imageID}, ec2FilteredImageIDs(t, ts, map[string]string{
+			"Filter.1.Name": "block-device-mapping.snapshot-id", "Filter.1.Value.1": snapID,
+		}), "the AMI must match on every snapshot its mapping names")
+	}
+}
+
+// TestEC2_RegisterImage_TagsTheAMIAndRefusesAnotherResourceType covers the parameter this
+// operation never read at all: a caller could tag an AMI at registration and the tags went
+// nowhere, which DescribeTags and every tag-based filter then agreed about.
+//
+// AWS: "To tag the AMI, the value for ResourceType must be image. If you specify another
+// value for ResourceType, the request fails." Both halves are asserted, because the silent
+// skip the shared collector performs would satisfy the first alone while dropping the tags of
+// a caller who spelled the type wrong.
+func TestEC2_RegisterImage_TagsTheAMIAndRefusesAnotherResourceType(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapID := ec2SnapshotOfSize(t, ts, 10)
+	mapping := map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": snapID,
+	}
+
+	tagged := map[string]string{
+		"TagSpecification.1.ResourceType": "image",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	}
+	for k, v := range mapping {
+		tagged[k] = v
+	}
+	imageID := ec2CreateImageID(t, ts, ec2RegisterImage(t, ts, "tagged", tagged))
+	assert.Equal(t, []string{imageID}, ec2FilteredImageIDs(t, ts, map[string]string{
+		"Filter.1.Name": "tag:Env", "Filter.1.Value.1": "prod",
+	}), "the tag must be on the AMI, not dropped")
+
+	refused := map[string]string{
+		"TagSpecification.1.ResourceType": "volume",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	}
+	for k, v := range mapping {
+		refused[k] = v
+	}
+	before := ec2FilteredImageIDs(t, ts, map[string]string{})
+	status, code, message := ec2ErrorDetail(t, ts, ec2RegisterImage(t, ts, "wrong-type", refused))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+	assert.Contains(t, message, "volume", "the message must name the type that was refused")
+	assert.Len(t, ec2FilteredImageIDs(t, ts, map[string]string{}), len(before),
+		"a refused request registers no AMI")
+}
+
+// TestEC2_DescribeImages_RendersInstanceStoreAndSuppressedDevices pins the two mapping shapes
+// that are not EBS volumes.
+//
+// An instance store device has a virtualName and no ebs element, and a suppressed one has a
+// noDevice element whose value is empty. Both were unreachable before #711 — the operation
+// stored neither — and both would be reported as EBS volumes of substrate's default size by a
+// renderer that gave every mapping an ebs element, which is an observation nothing backs.
+func TestEC2_DescribeImages_RendersInstanceStoreAndSuppressedDevices(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapID := ec2SnapshotOfSize(t, ts, 12)
+
+	imageID := ec2CreateImageID(t, ts, ec2RegisterImage(t, ts, "mixed", map[string]string{
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": snapID,
+		"BlockDeviceMapping.2.VirtualName":    "ephemeral0",
+		"BlockDeviceMapping.2.DeviceName":     "/dev/sdb",
+		"BlockDeviceMapping.3.DeviceName":     "/dev/sdc",
+		"BlockDeviceMapping.3.NoDevice":       "",
+	}))
+
+	got := ec2ImageMappings(t, ts, imageID)
+	require.Len(t, got, 3)
+
+	require.NotNil(t, got[0].EBS, "an EBS mapping has an ebs element")
+	assert.Equal(t, int64(12), got[0].EBS.VolumeSize)
+
+	assert.Equal(t, "ephemeral0", got[1].VirtualName)
+	assert.Nil(t, got[1].EBS, "an instance store device is not an EBS volume")
+
+	assert.Nil(t, got[2].EBS, "a suppressed device has no volume at all")
+	require.NotNil(t, got[2].NoDevice, "noDevice is rendered as a present, empty element")
+	assert.Empty(t, *got[2].NoDevice)
+}
+
+// TestEC2_DescribeImages_PhantomSnapshotReportsTheDefaultSize is the test the fallback at
+// ec2DefaultVolumeSizeGiB has never had, on both records that can reach it.
+//
+// It exists so a caller sizing a volume off this member reads something it can act on rather
+// than 0. Registering a phantom snapshot is no longer a way in — the mapping is validated now
+// — so the two remaining routes are asserted directly: a non-root mapping whose snapshot was
+// deleted afterwards (which DeleteSnapshot permits, since AWS scopes its refusal to the root
+// device), and an AMI record written before #711, which has a root snapshot, no stored
+// mapping, and nothing in state to resolve it against.
+func TestEC2_DescribeImages_PhantomSnapshotReportsTheDefaultSize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a non-root snapshot deleted after registration", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		_, rootSnap := ec2SnapshotOfSize(t, ts, 60)
+		_, dataSnap := ec2SnapshotOfSize(t, ts, 70)
+		imageID := ec2CreateImageID(t, ts, ec2RegisterImage(t, ts, "loses-a-volume",
+			map[string]string{
+				"RootDeviceName":                      "/dev/sda1",
+				"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+				"BlockDeviceMapping.1.Ebs.SnapshotId": rootSnap,
+				"BlockDeviceMapping.2.DeviceName":     "/dev/sdb",
+				"BlockDeviceMapping.2.Ebs.SnapshotId": dataSnap,
+			}))
+
+		status, code, _ := ec2DeleteSnapshot(t, ts, dataSnap)
+		require.Equal(t, http.StatusOK, status, "code=%s", code)
+
+		got := ec2ImageMappings(t, ts, imageID)
+		require.Len(t, got, 2, "the mapping still describes two volumes")
+		require.NotNil(t, got[0].EBS)
+		assert.Equal(t, int64(60), got[0].EBS.VolumeSize, "the root volume is unaffected")
+		require.NotNil(t, got[1].EBS)
+		assert.Equal(t, dataSnap, got[1].EBS.SnapshotID, "the reference is kept, as AWS keeps it")
+		assert.Equal(t, int64(8), got[1].EBS.VolumeSize, "not 0, which a caller cannot size from")
+	})
+
+	t.Run("an AMI record that predates the mappings field", func(t *testing.T) {
+		t.Parallel()
+		state := emulator.NewMemoryStateManager()
+		ts := newEC2TestServerWithState(t, state)
+		// The shape RegisterImage wrote through v0.106.0: a root snapshot and no mapping.
+		// Written directly because no request produces it any more, which is the reason
+		// newEC2TestServerWithState exists.
+		record, err := json.Marshal(emulator.EC2Image{
+			ImageID:    "ami-0123456789abcdef0",
+			Name:       "pre-711",
+			State:      "available",
+			SnapshotID: "snap-0123456789abcdef0",
+			AccountID:  "000000000000",
+			Region:     "us-east-1",
+		})
+		require.NoError(t, err)
+		require.NoError(t, state.Put(context.Background(), "ec2",
+			"image:000000000000/us-east-1/ami-0123456789abcdef0", record))
+
+		got := ec2ImageMappings(t, ts, "ami-0123456789abcdef0")
+		require.Len(t, got, 1, "the root device entry substrate fabricates for such a record")
+		assert.Equal(t, "/dev/sda1", got[0].DeviceName)
+		require.NotNil(t, got[0].EBS)
+		assert.Equal(t, "snap-0123456789abcdef0", got[0].EBS.SnapshotID)
+		assert.Equal(t, int64(8), got[0].EBS.VolumeSize)
+	})
+}

--- a/emulator/ec2_tags.go
+++ b/emulator/ec2_tags.go
@@ -204,6 +204,42 @@ func ec2LaunchTagsForResource(params map[string]string, resourceType string) []E
 	return ec2TagSpecificationTags(params, "", resourceType)
 }
 
+// ec2CheckTagSpecificationTypes returns an error if any TagSpecification.N names a
+// ResourceType other than want, or nil.
+//
+// AWS states the rule on RegisterImage: "To tag the AMI, the value for ResourceType must be
+// image. If you specify another value for ResourceType, the request fails." That is a
+// refusal, and [ec2TagSpecificationTags] performs a silent skip instead — correct for an
+// operation that accepts several scopes, since CreateImage tags an AMI and its snapshots and
+// a snapshot-scoped specification is not a mistake there, and wrong for one that accepts a
+// single scope, where the skip drops the caller's tags and reports success.
+//
+// The walk ends on the first absent or empty ResourceType, matching
+// [ec2TagSpecificationTags] exactly: if the two disagreed about which specifications exist,
+// this check could pass a list whose tags that one then read, or refuse one it would ignore.
+//
+// Provenance: the code is substrate's reading. RegisterImage's Errors section is empty and
+// AWS says only that "the request fails", so nothing publishes one. InvalidParameterValue is
+// EC2's gloss for "A value specified in a parameter is not valid, is unsupported, or cannot
+// be used", which is what a resource type the operation does not accept is.
+func ec2CheckTagSpecificationTypes(params map[string]string, want string) *AWSError {
+	for n := 1; ; n++ {
+		rt, ok := params[fmt.Sprintf("TagSpecification.%d.ResourceType", n)]
+		if !ok || rt == "" {
+			return nil
+		}
+		if rt != want {
+			return &AWSError{
+				Code: "InvalidParameterValue",
+				Message: fmt.Sprintf(
+					"'%s' is not a valid resource type for this request; the value for ResourceType must be %s",
+					rt, want),
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
+	}
+}
+
 // ec2TagSpecificationTags collects the tags a TagSpecification.N list scopes to
 // resourceType, under an optional param-name prefix.
 //

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -515,8 +515,26 @@ type EC2Image struct {
 	CreationDate string `json:"creation_date,omitempty"`
 
 	// SnapshotID is the EBS snapshot backing the root device of this AMI, if any.
-	// CreateImage materializes one so snapshot-retention logic can be tested.
+	// CreateImage materializes one so snapshot-retention logic can be tested;
+	// RegisterImage takes it from the mapping RootDeviceName names, or from the first
+	// mapping naming a snapshot when it names none — see [ec2RootMappingSnapshot].
+	//
+	// It stays a scalar beside BlockDeviceMappings rather than being derived from them
+	// on every read because DeleteSnapshot's in-use rule is scoped to the *root*
+	// device's snapshot (#710), so the distinction is load-bearing rather than
+	// bookkeeping, and because it is the only snapshot member an AMI recorded before
+	// #711 has.
 	SnapshotID string `json:"snapshot_id,omitempty"`
+
+	// BlockDeviceMappings holds the mapping entries a RegisterImage request sent, in
+	// request order, so DescribeImages can render what the caller asked for rather than
+	// the single fabricated /dev/sda1 item it rendered through v0.106.0 (#711).
+	//
+	// It is empty for every CreateImage-minted AMI — that path materializes one root
+	// snapshot and has no caller mapping to record — and for any AMI registered before
+	// #711. DescribeImages renders those from SnapshotID, which is why both members
+	// exist; see [EC2Plugin.describeImages].
+	BlockDeviceMappings []EC2BlockDeviceMapping `json:"block_device_mappings,omitempty"`
 
 	// Tags holds key-value metadata tags.
 	Tags []EC2Tag `json:"tags,omitempty"`


### PR DESCRIPTION
Closes #711

`RegisterImage` read exactly one thing out of the mapping it was sent — the first
`BlockDeviceMapping.N.Ebs.SnapshotId`, found by a hand walk of indexes 1 to 32 — and
discarded the rest of every entry: device names, sizes, volume types, and every mapping
after the first that named a snapshot. AWS's own third example for this operation registers
three volumes (two distinct snapshots and an empty 100 GiB volume), so a caller sending
AWS's documented request got one volume back, rendered on a `/dev/sda1` the request need
never have mentioned.

## What changed

| Request | Answer |
|---|---|
| Every `BlockDeviceMapping.N` entry | Stored and rendered by `DescribeImages` in request order |
| A mapping naming a malformed or absent snapshot | `InvalidSnapshotID.Malformed` / `InvalidSnapshot.NotFound`, before anything is written |
| `Ebs.VolumeSize` below the snapshot's | `InvalidBlockDeviceMapping`, naming the device |
| A mapping with a size and no snapshot | Registered — AWS's third example volume is exactly that |
| A mapping absent a size but naming a snapshot | The snapshot's size, per `EbsBlockDevice.VolumeSize` |
| `RootDeviceName` | Read, to decide which mapping is the root device's |
| `TagSpecification.N` `ResourceType=image` | Tags the AMI; any other type is `InvalidParameterValue` |

Three of those had no reader at all before. `RootDeviceName` matters beyond bookkeeping: the
mapping it names supplies `EC2Image.SnapshotID`, which is the snapshot `DeleteSnapshot`'s
in-use rule protects (#710), so picking the wrong mapping would protect the wrong snapshot.

## Two consequences of the shared parser

The hand walk is replaced by `ec2ParseBlockDeviceMappings`, the walk `RunInstances` and a
launch template already share — its third caller, not a fourth convention. It is
**unbounded**, so a request with more than 32 mappings no longer loses the remainder, and it
**stops at the first absent index** instead of tolerating a gap. AWS's query protocol indexes
contiguously and every other indexed walk in the plugin assumes it, so a sparse request is
not one an SDK produces — but a hand-built request that skipped an index used to have its
later mappings read, and no longer does. Both directions are pinned.

`block-device-mapping.snapshot-id` widened with this: it matches every snapshot an AMI's
mapping names, not only the root's. Consulting the root alone meant a filter naming a volume
`DescribeImages` had just rendered found no AMI — two operations contradicting each other
about one record.

## The issue's premises, corrected

Both of #711's factual claims are wrong, and the PR says so rather than fixing what they
describe:

- "reports a size of zero rather than the old constant 8" — **false**. `describeImages` falls
  back to `ec2DefaultVolumeSizeGiB` and documents why. What it lacked was a test, which it now
  has on both records that reach the fallback.
- "a different convention from `extractEC2Filters`' and `ec2CheckBlockDeviceMappings`' own
  walks" — neither of those walks `BlockDeviceMapping.N` at all. There was one convention.

## What the fallback is now reachable through

Registering a phantom snapshot is no longer a route — the mapping is validated. `DeleteSnapshot`
refuses only a **root device** snapshot, following AWS's sentence exactly ("a snapshot of the
root device of an EBS volume used by a registered AMI"), so deleting the snapshot a non-root
mapping names succeeds and leaves the mapping dangling. That, and an AMI record written before
this change, are the two routes, and both are tested. #710's doc comment anticipated needing to
narrow this check; it turns out the check was already narrow, and the narrowness is now
load-bearing rather than incidental.

## Deliberately not included

Only the snapshot rule from the shared mapping validator, not the rest of it (duplicate device
names, `virtualName` spellings, gp3-only `Throughput`, size-or-snapshot). None of those is a
rule AWS states for this operation, and six unrelated refusals arriving on a published path
unannounced is how a consumer's working request starts failing. `Name`'s documented character
constraints stay unenforced too; only an empty `Name` is refused. Both are stated in the docs.

## Provenance

`API_RegisterImage.html`'s Errors section is **empty**, so no code here comes from the
operation's own page. The snapshot codes come from EC2's client-error table and predate this
change. The `ResourceType` refusal's code is **substrate's reading** — AWS says only that "the
request fails" — chosen because `InvalidParameterValue`'s documented gloss is "A value
specified in a parameter is not valid, is unsupported, or cannot be used".

## Verification

Nine new tests (`emulator/ec2_registerimage_test.go`). All but one fail at `b3861d1`,
established in a throwaway worktree; the exception is the pre-#711-record case, the negative
control the old path already answers correctly.

- `gofmt`/`go build`/`go vet`/`golangci-lint run ./...` — 0 issues
- `make test` green with the race detector
- `make coverage` — 83.2% `emulator`, 82.5% total
- `make docs-reference docs-reference-check docs-versions` — up to date
- `npm --prefix docs run build`, 319 anchors against 328 ids, none dangling
- `go vet -C test/e2e ./... && go test -C test/e2e ./...` green