### PR TITLE
feat(ec2): the rest of the snapshot family (#709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documented gloss is "A value specified in a parameter is not valid, is unsupported, or
   cannot be used."
 
+- **The rest of the EC2 snapshot family: `CreateSnapshots`, `CopySnapshot` and the three
+  attribute operations** (#709). All five reached the dispatcher's unknown-action arm and
+  answered `InvalidAction` — the answer a caller reads as "this endpoint does not speak EC2",
+  not "substrate has not got to it yet". `CreateSnapshot` was the whole of substrate's snapshot
+  creation, so IaC that snapshots an instance rather than a volume, or copies a snapshot before
+  sharing it, had nowhere to land.
+
+  `CreateSnapshots` snapshots every attached volume of one instance, ordered by device name —
+  state keys come back in Go map order, so an unsorted `snapshotSet` would answer differently
+  on each run and `snapshotSet[0]` would be a coin toss. `ExcludeBootVolume` and
+  `ExcludeDataVolumeId.N` (singular member, indexed, capped at AWS's 40) each drop what they
+  name, and naming the root volume in `ExcludeDataVolumeId.N` is refused with a message naming
+  `ExcludeBootVolume`, per AWS's "If you specify the ID of the root volume, the request fails."
+  `CopyTagsFromSource=volume` gives each snapshot **its own** source volume's tags. Its response
+  item is `SnapshotInfo`, which names the state member **`state`** where `CreateSnapshot` and
+  `DescribeSnapshots` name the same thing `status` — so a caller unmarshalling it reads `State`,
+  and substrate could not reuse `CreateSnapshot`'s response struct.
+
+  `CopySnapshot` copies within the region, which AWS's text makes coherent for a single-region
+  emulator twice over: "if the source snapshot is in a Region, you can copy it within that
+  Region" (its Example 1 is one), and `DestinationRegion` is a `PresignedUrl`-signing artifact
+  rather than routing — "the snapshot copy is sent to the regional endpoint that you sent the
+  HTTP request to". A cross-region source is `SnapshotCopyUnsupported.InterRegion`. The copy
+  records an arbitrary volume ID that resolves to nothing, which is what AWS produces:
+  "snapshots copies have an arbitrary source volume ID. Do not use this volume ID for any
+  purpose" — rendering the source's would hand a caller a reference that resolves, inviting
+  exactly the use that sentence forbids.
+
+  `DescribeSnapshotAttribute`, `ModifySnapshotAttribute` and `ResetSnapshotAttribute` record and
+  report a snapshot's create-volume permissions. `ModifySnapshotAttribute` reads **both** wire
+  forms, because an SDK picks between them: structured `CreateVolumePermission.Add.N.{UserId,
+  Group}` and flat `OperationType` + `UserId.N` + **`UserGroup.N`** — the wire member, where the
+  CLI spells the same thing `--group-names` and an SDK spells it `GroupNames`. Sharing an
+  encrypted snapshot publicly is refused ("you can share only unencrypted snapshots publicly");
+  sharing one with a named account is not. Substrate is single-account, so a permission grants
+  nothing — it is recorded intent a caller can read back, which is the observable half of
+  sharing.
+
+  **#709's "you cannot both add and remove in a single operation" is scoped to account IDs, and
+  the issue's unscoped reading would have refused AWS's own example.** AWS's sentence is "you
+  may add or remove specified AWS account **IDs** … but you cannot do both in a single
+  operation", and its Example 2 adds the group `all` while removing the account `111122223333`
+  in one request. Substrate refuses only add-account-and-remove-account.
+
+  Provenance: **none of the five operations publishes an operation-specific error** — every
+  Errors section points only at the common types, and `CreateSnapshots` has no Examples section
+  at all. So each refusal is either a code from EC2's client-error table, which describes a
+  condition rather than quoting a wire message (`SnapshotCopyUnsupported.InterRegion`,
+  `InvalidSnapshot.NotFound`), or substrate's reading of a prose rule AWS states without naming
+  a code (the root-volume exclusion, `Encrypted=false`, `KmsKeyId` without encryption, a group
+  other than `all`, the public-sharing rule, the 500-modification cap). The
+  `InvalidParameterValue` message shape is the one captured EC2 example of that code; the
+  trailing sentence in each is AWS's own prose, because that rule is the only thing telling a
+  caller what to send instead. `productCodes` is answered on the describe rather than refused —
+  as a **present but empty** element — because nothing in substrate assigns a product code, so
+  "none" is a fact about every snapshot it can produce rather than an invented default. Three
+  `SnapshotInfo` members are deliberately not rendered: `progress` (substrate stores none),
+  `availabilityZone` (the Local-Zone placement member — the singular `CreateSnapshot` response
+  has no such member — so rendering the volume's AZ would claim a local snapshot), and
+  `outpostArn`/`sseType` (not modelled; inventing `sse-ebs` would be indistinguishable from an
+  observation).
+
 ### Changed
 - **`RegisterImage` records the whole block device mapping it is sent** (#711). It read exactly
   one thing out of it — the first `BlockDeviceMapping.N.Ebs.SnapshotId`, found by a hand walk of

--- a/docs/services.md
+++ b/docs/services.md
@@ -4874,9 +4874,95 @@ What remains is deleting the snapshot a **non-root** mapping names, which `Delet
 permits because AWS scopes its refusal to the root device (below), and an AMI record written
 directly into state.
 
-The rest of the `CreateSnapshot` family — `CreateSnapshots`, `CopySnapshot`,
-`ModifySnapshotAttribute`, `DescribeSnapshotAttribute` and `ResetSnapshotAttribute` — is
-still absent and answers `InvalidAction`.
+#### The rest of the snapshot family
+
+`CreateSnapshots`, `CopySnapshot` and the three attribute operations answered `InvalidAction`
+until [#709](https://github.com/scttfrdmn/substrate/issues/709) — the answer that tells a
+caller the endpoint does not speak EC2, rather than that substrate has a gap. All five are
+implemented. None of the five publishes an operation-specific error: every Errors section
+points only at the common types, and `CreateSnapshots` has no Examples section at all. So each
+refusal below is either a code from EC2's client-error table (which describes a condition
+rather than quoting a wire message) or substrate's reading of a rule AWS states in prose; the
+table says which.
+
+**`CreateSnapshots`** snapshots every EBS volume attached to one instance in a single call.
+
+| Behaviour | Answer |
+|---|---|
+| `InstanceSpecification.InstanceId` | Required; absent is `MissingParameter`. Resolved against state, so an absent instance is `InvalidInstanceID.NotFound` rather than an empty `snapshotSet` — an empty set is the true answer for an instance with nothing left to snapshot, and a consumer's wait loop turns on the difference |
+| Order | `snapshotSet` is ordered by device name. State keys come back in map order, so anything else would answer differently on each run and `snapshotSet[0]` would be a coin toss |
+| `ExcludeBootVolume` | Drops the volume attached at a root device name |
+| `ExcludeDataVolumeId.N` | Singular member, indexed — not a plural. Up to 40 per request, per AWS; a 41st is `InvalidParameterValue`. An ID that is not attached excludes nothing, which is what the parameter asks for |
+| The root volume named in `ExcludeDataVolumeId.N` | Refused, naming `ExcludeBootVolume`. AWS: "If you specify the ID of the root volume, the request fails. To exclude the root volume, use `ExcludeBootVolume`." The code is substrate's; AWS says only that the request fails |
+| `CopyTagsFromSource` | Valid value `volume`, and any other value is refused rather than treated as "do not copy". Each snapshot inherits **its own** source volume's tags |
+| `Description`, `TagSpecification.N` | Applied to every snapshot the call creates. Where a request tag collides with a copied volume tag, the request wins — AWS settles neither the precedence nor the ordering, so both are substrate's |
+| `state` | `completed` at once, for the reason `CreateSnapshot`'s `status` is |
+| `Location`, `OutpostArn` | Not read, as on `CreateSnapshot` |
+
+The response element is `snapshotSet` of `SnapshotInfo`, which names the state member
+**`state`** where `CreateSnapshot` and `DescribeSnapshots` both name the same thing `status`.
+A caller unmarshalling `SnapshotInfo` reads `State`. `progress`, `availabilityZone`,
+`outpostArn` and `sseType` are not rendered: substrate stores no progress, `availabilityZone` is
+the Local-Zone placement member — the singular `CreateSnapshot` response has no such member —
+so rendering the volume's AZ would claim a local snapshot, and neither Outposts nor a specific
+server-side encryption type is modelled.
+
+A refused request writes nothing: every snapshot is built and its tags checked before the
+first write, so a five-volume instance whose fourth volume carries a reserved tag key does not
+leave three snapshots behind.
+
+**`CopySnapshot`** copies a snapshot within the region, which AWS's own text makes coherent
+for a single-region emulator twice over. "If the source snapshot is in a Region, you can copy
+it within that Region" makes a same-region copy legal rather than degenerate, and AWS's Example
+1 is one. And `DestinationRegion` is not routing — "this parameter is only valid for specifying
+the destination Region in a `PresignedUrl` parameter … the snapshot copy is sent to the
+regional endpoint that you sent the HTTP request to" — so the destination is the endpoint, and
+the endpoint is the one region substrate serves.
+
+| Behaviour | Answer |
+|---|---|
+| `SourceRegion`, `SourceSnapshotId` | Both required; absent is `MissingParameter`. A malformed source is `InvalidSnapshotID.Malformed`, one naming nothing `InvalidSnapshot.NotFound` |
+| A `SourceRegion` that is not the request's region | `SnapshotCopyUnsupported.InterRegion`, whose published description — "inter-region snapshot copy is not supported for this AWS Region" — is precisely substrate's situation. The code is AWS's; the message is substrate's |
+| `Encrypted` | Accepted only as `true`. A copy of an encrypted snapshot is encrypted whatever the request says; `Encrypted=false` is refused rather than silently honoured or silently dropped |
+| `KmsKeyId` | Validated, not stored: "if `KmsKeyId` is specified, the encrypted state must be true", so naming a key for a copy that will not be encrypted is refused. Substrate models no KMS key on a snapshot, so the rule is observable only as that refusal |
+| `Description` | The request's, empty when absent. AWS documents nothing for an omitted one, so substrate invents no "Copied from …" string a consumer might assert on |
+| `TagSpecification.N` | The only source of the copy's tags. `CopySnapshot` has no `CopyTagsFromSource` — that is `CreateSnapshots`' parameter — so the source's tags are deliberately not carried over |
+| `volumeId` | A freshly generated ID that names no volume, which is what AWS produces: "snapshots copies have an arbitrary source volume ID. Do not use this volume ID for any purpose." Rendering the source's would hand a caller a reference that resolves, inviting exactly that use |
+| `CompletionDurationMinutes`, `DestinationAvailabilityZone`, `DestinationOutpostArn`, `DestinationRegion`, `PresignedUrl` | Not read. A time-based copy has nothing to slow down here, the next two place the copy somewhere substrate does not model, and the last two are artifacts of signing a cross-region request |
+
+The response carries `snapshotId` and `tagSet` and nothing else — no status, no size — so a
+caller polls `DescribeSnapshots` for the rest.
+
+**The attribute trio** — `DescribeSnapshotAttribute`, `ModifySnapshotAttribute` and
+`ResetSnapshotAttribute` — follows
+[Instance attributes](#instance-attributes) in four respects:
+the attribute name is validated *before* the snapshot is resolved (a bad name is a defect no
+retry fixes; an absent snapshot may be one the caller is still waiting on), exactly one
+attribute element marshals, a present-but-empty element is not the same observation as an
+omitted one, and an attribute substrate will not answer is refused rather than answered with an
+invented default.
+
+| Behaviour | Answer |
+|---|---|
+| `Attribute` | `Required: Yes` on the describe and the reset — "you can specify only one attribute at a time" — and `Required: No` on the modify, where the wire form carries the selection. Valid values `createVolumePermission` and `productCodes`; anything else is `InvalidParameterValue` |
+| `productCodes` on the describe | Answered, as a **present but empty** element. Nothing in substrate assigns a product code, so "none" is a fact about every snapshot it can produce rather than an invented default — and an SDK reads a present-but-empty element as an empty list where it reads an omitted one as `nil` |
+| `productCodes` on the modify | Refused: "only volume creation permissions can be modified" |
+| `productCodes` on the reset | Refused: "only the attribute for permission to create volumes can be reset" |
+| `createVolumePermission` on a fresh or copied snapshot | Present and empty. AWS describes a reset snapshot as "a private snapshot that can only be used by the account that created it", which is what a created one already is |
+| The two wire forms of a modification | Both read. Structured is `CreateVolumePermission.Add.N.{UserId,Group}` and `…Remove.N.…`, which is what AWS's own examples send; flat is `OperationType` (`add`/`remove`) with `UserId.N` and **`UserGroup.N`** — the wire member, where the CLI spells the same thing `--group-names` and an SDK spells it `GroupNames`. A request using both simply concatenates; AWS documents no precedence |
+| `Group` | Only `all`. Any other group is refused rather than stored, since a stored group nothing can grant is a permission a caller reads back and cannot act on |
+| Adding *and* removing an **account ID** in one request | Refused. AWS: "You may add or remove specified AWS account IDs … but you cannot do both in a single operation" |
+| Adding a group while removing an account | **Allowed** — that is AWS's own Example 2, which adds `all` while removing `111122223333`. The sentence above is scoped to account IDs, so the refusal is too; read as a blanket rule it would reject AWS's example |
+| Sharing an **encrypted** snapshot publicly | Refused: "you can share only unencrypted snapshots publicly". Sharing an encrypted snapshot with a named account is not refused — the rule is about the group. The companion rule, that a snapshot carrying a Marketplace product code cannot be made public, is unreachable rather than unmodelled: substrate assigns no product codes |
+| More than 500 modifications | Refused: "you can make up to 500 modifications to a snapshot in a single operation" |
+| A flat `UserId.N`/`UserGroup.N` with no `OperationType` | `MissingParameter`. The values name no list to join, and accepting the request would silently discard the permission |
+| A modify naming no modification at all | Succeeds and changes nothing. Every parameter but `SnapshotId` is optional and AWS publishes no error for the empty case |
+| Adding a permission already present, or removing one that is not | Neither is an error, and neither duplicates. AWS documents no refusal for either, and both are idempotent in the direction a cleanup loop needs |
+| The reset | Clears the list rather than restoring a remembered default, since an empty list is what a snapshot is created with |
+
+Substrate is single-account, so a permission recorded here grants nothing. It is recorded
+intent a caller can read back, which is the observable half of sharing — and the observable
+half is the whole of what substrate models.
 
 #### Deleting a snapshot refuses what AWS refuses
 

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -245,6 +245,16 @@ func (p *EC2Plugin) HandleRequest(ctx *RequestContext, req *AWSRequest) (*AWSRes
 		return p.deleteSnapshot(ctx, req)
 	case "DescribeSnapshots":
 		return p.describeSnapshots(ctx, req)
+	case "CreateSnapshots":
+		return p.createSnapshots(ctx, req)
+	case "CopySnapshot":
+		return p.copySnapshot(ctx, req)
+	case "DescribeSnapshotAttribute":
+		return p.describeSnapshotAttribute(ctx, req)
+	case "ModifySnapshotAttribute":
+		return p.modifySnapshotAttribute(ctx, req)
+	case "ResetSnapshotAttribute":
+		return p.resetSnapshotAttribute(ctx, req)
 	default:
 		return nil, unknownActionError(p.Name(), action)
 	}

--- a/emulator/ec2_snapshot_attributes.go
+++ b/emulator/ec2_snapshot_attributes.go
@@ -1,0 +1,420 @@
+package emulator
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+)
+
+// A snapshot's attributes: describing, modifying and resetting the list of accounts and
+// groups that may create volumes from it (#709).
+//
+// The three operations are modeled on [EC2Plugin.describeInstanceAttribute] and its
+// siblings, whose file records why each of these shapes is the way it is. Four of those
+// decisions are load-bearing here and are repeated in the places they apply: the attribute
+// name is validated before the snapshot is resolved; the wrapper fields are pointers so
+// exactly one attribute element marshals; a present-but-empty element is not the same
+// observation as an omitted one; and an attribute substrate will not answer is refused
+// rather than answered with an invented default.
+//
+// Provenance: none of the three pages publishes an operation-specific error, so every
+// refusal below is substrate's reading of a rule AWS states in prose. Each names the
+// sentence it comes from. The message *shape* follows the one captured EC2 rejection of this
+// kind (see [ec2UnknownInstanceAttribute]); the text is not itself a capture, and the
+// stronger claim that comment makes for the instance wording is deliberately not extended to
+// these.
+
+// The snapshot attributes, per DescribeSnapshotAttribute's Valid Values.
+//
+// Both are answerable, which is why neither is refused on the describe path — and the reason
+// differs between them. createVolumePermission is state substrate now holds. productCodes is
+// state substrate holds *none of*, and that is a fact about every snapshot it can produce
+// rather than a value it would have to invent: nothing in substrate assigns a product code to
+// a snapshot, so "no product codes" is true rather than a plausible-looking default. That is
+// the distinction [ec2AttributeSupported] draws for instances, where reporting
+// sourceDestCheck as false would have been an invention.
+const (
+	ec2SnapAttrCreateVolumePermission = "createVolumePermission"
+	ec2SnapAttrProductCodes           = "productCodes"
+)
+
+// ec2MaxSnapshotAttributeModifications is the number of permission changes one
+// ModifySnapshotAttribute request may carry: "You can make up to 500 modifications to a
+// snapshot in a single operation", from the operation's own description.
+const ec2MaxSnapshotAttributeModifications = 500
+
+// ec2CreateVolumePermissionItem is one rendered createVolumePermission entry.
+//
+// Both members carry omitempty because AWS's CreateVolumePermission has exactly one of them
+// set per entry — a permission names either an account or the group "all" — and its own
+// Example 1 renders a group-only item as <item><group>all</group></item> with no userId
+// element at all.
+type ec2CreateVolumePermissionItem struct {
+	UserID string `xml:"userId,omitempty"`
+	Group  string `xml:"group,omitempty"`
+}
+
+// ec2CreateVolumePermissionSetXML wraps the createVolumePermission items so the element can
+// be omitted entirely.
+//
+// A plain []ec2CreateVolumePermissionItem with an `xml:"createVolumePermission>item"` path
+// would emit the parent element even when the slice is empty, so a caller who asked for
+// productCodes would additionally be told the snapshot has no volume permissions — an
+// observation about an attribute they did not ask about, which real AWS does not make. This
+// is #669's rule, recorded on [ec2InstanceAttributeXML].
+type ec2CreateVolumePermissionSetXML struct {
+	Items []ec2CreateVolumePermissionItem `xml:"item"`
+}
+
+// ec2ProductCodeSetXML wraps the productCodes items, a pointer for the same reason
+// [ec2CreateVolumePermissionSetXML] is.
+//
+// Items is always empty in substrate, and the element is nonetheless *present* when
+// productCodes is the attribute asked for: an SDK maps a present-but-empty element to an
+// empty slice and an omitted one to nil, so omitting it would report "unknown" where the
+// honest answer is "none".
+type ec2ProductCodeSetXML struct {
+	Items []ec2ProductCodeItem `xml:"item"`
+}
+
+// ec2ProductCodeItem is one rendered productCodes entry, per AWS's ProductCode.
+//
+// It is declared even though substrate renders none, so the element's shape is fixed by the
+// reference rather than by whatever a future writer happens to emit.
+type ec2ProductCodeItem struct {
+	ProductCodeID   string `xml:"productCode,omitempty"`
+	ProductCodeType string `xml:"type,omitempty"`
+}
+
+// describeSnapshotAttribute handles DescribeSnapshotAttribute.
+//
+// Attribute and SnapshotId are both Required: Yes, and "You can specify only one attribute at
+// a time" — so unlike ModifySnapshotAttribute there is no wire form that carries the
+// selection implicitly and an absent Attribute is a MissingParameter.
+//
+// The attribute name is checked before the snapshot is resolved, for the reason
+// [EC2Plugin.describeInstanceAttribute] records: a snapshot ID that names nothing may be one
+// a caller is still waiting on, while an attribute name the operation does not accept is a
+// defect in the request that no retry fixes.
+func (p *EC2Plugin) describeSnapshotAttribute(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	attr := req.Params["Attribute"]
+	if attr == "" {
+		return nil, ec2MissingParameter("Attribute")
+	}
+	if attr != ec2SnapAttrCreateVolumePermission && attr != ec2SnapAttrProductCodes {
+		return nil, ec2UnknownSnapshotAttribute(attr)
+	}
+	snapshotID := req.Params["SnapshotId"]
+	if snapshotID == "" {
+		return nil, ec2MissingParameter("SnapshotId")
+	}
+	snap, found := p.ec2SnapshotResolver(reqCtx)(snapshotID)
+	if awsErr := ec2RequireResource(ec2SnapshotIDKind, snapshotID, found); awsErr != nil {
+		return nil, awsErr
+	}
+
+	type response struct {
+		XMLName    xml.Name `xml:"DescribeSnapshotAttributeResponse"`
+		XMLNS      string   `xml:"xmlns,attr"`
+		SnapshotID string   `xml:"snapshotId"`
+
+		CreateVolumePermission *ec2CreateVolumePermissionSetXML `xml:"createVolumePermission,omitempty"`
+		ProductCodes           *ec2ProductCodeSetXML            `xml:"productCodes,omitempty"`
+	}
+	resp := response{
+		XMLNS:      "http://ec2.amazonaws.com/doc/2016-11-15/",
+		SnapshotID: snap.SnapshotID,
+	}
+	switch attr {
+	case ec2SnapAttrCreateVolumePermission:
+		items := make([]ec2CreateVolumePermissionItem, 0, len(snap.CreateVolumePermissions))
+		for _, perm := range snap.CreateVolumePermissions {
+			// The conversion, rather than a field-by-field literal, is what the linter asks
+			// for — and it fails to compile if either type gains a member the other lacks,
+			// which is the right moment to notice that the wire shape and the record have
+			// diverged.
+			items = append(items, ec2CreateVolumePermissionItem(perm))
+		}
+		resp.CreateVolumePermission = &ec2CreateVolumePermissionSetXML{Items: items}
+	case ec2SnapAttrProductCodes:
+		resp.ProductCodes = &ec2ProductCodeSetXML{}
+	}
+	return ec2XMLResponse(http.StatusOK, resp)
+}
+
+// modifySnapshotAttribute handles ModifySnapshotAttribute.
+//
+// # The two wire forms
+//
+// AWS accepts the same modification two ways, and an SDK picks between them, so both are
+// read. The structured form is CreateVolumePermission.Add.N.{UserId,Group} and
+// CreateVolumePermission.Remove.N.{UserId,Group}, which is what AWS's own two examples send.
+// The flat form is OperationType (add|remove) together with UserId.N and UserGroup.N — note
+// **UserGroup.N**, which is the wire member even though the CLI spells the same thing
+// --group-names and an SDK spells it GroupNames. A request may use either; when it uses both,
+// the two lists are simply concatenated, since AWS documents no precedence and neither form
+// is a modifier of the other.
+//
+// # The rules
+//
+// Attribute is Required: No here, because the wire form carries the selection — the split
+// [EC2Plugin.describeInstanceAttribute] documents for instances. When it is present it must
+// name a valid attribute, and productCodes is refused: "Only volume creation permissions can
+// be modified."
+//
+// "You may add or remove specified AWS account IDs from a snapshot's list of create volume
+// permissions, but you cannot do both in a single operation." That sentence is scoped to
+// **account IDs**, and AWS's own Example 2 proves the scope is not wider: it adds the group
+// "all" while removing the account 111122223333 in one request. So the refusal fires only
+// when a request both adds and removes a UserId; a group added alongside an account removed
+// is a request AWS documents as legal, and refusing it would reject AWS's example.
+//
+// Group's only valid value is "all", so any other group is refused rather than stored — a
+// stored group nothing can grant would be a permission a caller reads back and cannot act on.
+//
+// "You can share only unencrypted snapshots publicly", so adding the group "all" to an
+// encrypted snapshot is refused. This is reachable because [EC2Plugin.createSnapshot] already
+// records Encrypted from the source volume. The companion rule — "Snapshots ... with AWS
+// Marketplace product codes cannot be made public" — is unreachable rather than unmodeled:
+// substrate assigns no product codes, as [ec2SnapAttrProductCodes] records.
+//
+// A request that names no modification at all succeeds and changes nothing. Every parameter
+// but SnapshotId is optional, and AWS documents no refusal for the empty case.
+func (p *EC2Plugin) modifySnapshotAttribute(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	if attr := req.Params["Attribute"]; attr != "" {
+		switch attr {
+		case ec2SnapAttrCreateVolumePermission:
+		case ec2SnapAttrProductCodes:
+			return nil, ec2InvalidParameterValue("Attribute", attr,
+				"Only volume creation permissions can be modified.")
+		default:
+			return nil, ec2UnknownSnapshotAttribute(attr)
+		}
+	}
+	snapshotID := req.Params["SnapshotId"]
+	if snapshotID == "" {
+		return nil, ec2MissingParameter("SnapshotId")
+	}
+
+	adds, removes, parseErr := ec2ParseVolumePermissionChanges(req.Params)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	if n := len(adds) + len(removes); n > ec2MaxSnapshotAttributeModifications {
+		return nil, ec2InvalidParameterValue("CreateVolumePermission", fmt.Sprint(n),
+			fmt.Sprintf("You can make up to %d modifications to a snapshot in a single operation.",
+				ec2MaxSnapshotAttributeModifications))
+	}
+	if ec2PermissionsNameAUser(adds) && ec2PermissionsNameAUser(removes) {
+		return nil, ec2InvalidParameterValue("OperationType", "add and remove",
+			"You cannot both add and remove account IDs in a single operation.")
+	}
+
+	snap, found := p.ec2SnapshotResolver(reqCtx)(snapshotID)
+	if awsErr := ec2RequireResource(ec2SnapshotIDKind, snapshotID, found); awsErr != nil {
+		return nil, awsErr
+	}
+	if snap.Encrypted {
+		for _, perm := range adds {
+			if perm.Group != "" {
+				return nil, ec2InvalidParameterValue("Group", perm.Group,
+					"You can share only unencrypted snapshots publicly.")
+			}
+		}
+	}
+
+	snap.CreateVolumePermissions = ec2ApplyVolumePermissions(snap.CreateVolumePermissions, adds, removes)
+	if err := p.ec2PutSnapshot(reqCtx, snap); err != nil {
+		return nil, err
+	}
+	return ec2SnapshotAttributeReturn("ModifySnapshotAttributeResponse")
+}
+
+// resetSnapshotAttribute handles ResetSnapshotAttribute.
+//
+// Attribute is Required: Yes and takes the same two valid values as the describe, but "only
+// the attribute for permission to create volumes can be reset" — so productCodes is accepted
+// as a name and refused as a target, exactly as it is on the modify.
+//
+// Resetting clears the list rather than restoring a remembered default: AWS describes the
+// result as "making it a private snapshot that can only be used by the account that created
+// it", and an empty list is what a snapshot is created with.
+func (p *EC2Plugin) resetSnapshotAttribute(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	attr := req.Params["Attribute"]
+	if attr == "" {
+		return nil, ec2MissingParameter("Attribute")
+	}
+	switch attr {
+	case ec2SnapAttrCreateVolumePermission:
+	case ec2SnapAttrProductCodes:
+		return nil, ec2InvalidParameterValue("Attribute", attr,
+			"Only the attribute for permission to create volumes can be reset.")
+	default:
+		return nil, ec2UnknownSnapshotAttribute(attr)
+	}
+	snapshotID := req.Params["SnapshotId"]
+	if snapshotID == "" {
+		return nil, ec2MissingParameter("SnapshotId")
+	}
+	snap, found := p.ec2SnapshotResolver(reqCtx)(snapshotID)
+	if awsErr := ec2RequireResource(ec2SnapshotIDKind, snapshotID, found); awsErr != nil {
+		return nil, awsErr
+	}
+
+	snap.CreateVolumePermissions = nil
+	if err := p.ec2PutSnapshot(reqCtx, snap); err != nil {
+		return nil, err
+	}
+	return ec2SnapshotAttributeReturn("ResetSnapshotAttributeResponse")
+}
+
+// ec2SnapshotAttributeReturn renders the <return>true</return> body the two mutating
+// attribute operations share, under the element name root.
+//
+// Both publish exactly requestId and return, and "return" is documented as "true if the
+// request succeeds, and an error otherwise" — so there is no false case to render.
+func ec2SnapshotAttributeReturn(root string) (*AWSResponse, error) {
+	type response struct {
+		XMLName xml.Name
+		XMLNS   string `xml:"xmlns,attr"`
+		Return  bool   `xml:"return"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLName: xml.Name{Local: root},
+		XMLNS:   "http://ec2.amazonaws.com/doc/2016-11-15/",
+		Return:  true,
+	})
+}
+
+// ec2ParseVolumePermissionChanges reads both wire forms of a create-volume-permission
+// modification, returning the entries to add and to remove.
+//
+// The structured lists are walked contiguously from index 1 and stop at the first index with
+// neither a UserId nor a Group, which is how the query protocol terminates an indexed list
+// and what every other indexed walk in the plugin does — see [ec2ParseBlockDeviceMappings].
+//
+// A Group other than "all" is refused here rather than at the call site, so the flat and
+// structured forms cannot disagree about it.
+func ec2ParseVolumePermissionChanges(params map[string]string) (adds, removes []EC2CreateVolumePermission, err error) {
+	for _, form := range []struct {
+		prefix string
+		target *[]EC2CreateVolumePermission
+	}{
+		{"CreateVolumePermission.Add", &adds},
+		{"CreateVolumePermission.Remove", &removes},
+	} {
+		for n := 1; ; n++ {
+			userID := params[fmt.Sprintf("%s.%d.UserId", form.prefix, n)]
+			group := params[fmt.Sprintf("%s.%d.Group", form.prefix, n)]
+			if userID == "" && group == "" {
+				break
+			}
+			if group != "" && group != "all" {
+				return nil, nil, ec2InvalidParameterValue("Group", group,
+					"The only supported value is all.")
+			}
+			*form.target = append(*form.target, EC2CreateVolumePermission{UserID: userID, Group: group})
+		}
+	}
+
+	// The flat form. OperationType decides which list the UserId.N and UserGroup.N values
+	// join; it is validated even when neither list is present, since a misspelled operation
+	// type is a defect in the request whether or not it would have changed anything.
+	opType, hasOpType := params["OperationType"]
+	if hasOpType && opType != "add" && opType != "remove" {
+		return nil, nil, ec2InvalidParameterValue("OperationType", opType,
+			"The supported values are add and remove.")
+	}
+	var flat []EC2CreateVolumePermission
+	for _, userID := range extractIndexedParams(params, "UserId") {
+		flat = append(flat, EC2CreateVolumePermission{UserID: userID})
+	}
+	for _, group := range extractIndexedParams(params, "UserGroup") {
+		if group != "all" {
+			return nil, nil, ec2InvalidParameterValue("UserGroup", group,
+				"The only supported value is all.")
+		}
+		flat = append(flat, EC2CreateVolumePermission{Group: group})
+	}
+	if len(flat) > 0 {
+		if !hasOpType {
+			return nil, nil, ec2MissingParameter("OperationType")
+		}
+		if opType == "add" {
+			adds = append(adds, flat...)
+		} else {
+			removes = append(removes, flat...)
+		}
+	}
+	return adds, removes, nil
+}
+
+// ec2PermissionsNameAUser reports whether any entry names an account ID.
+//
+// It is what scopes the "cannot both add and remove in a single operation" refusal to account
+// IDs, which is the scope AWS's sentence and its Example 2 together establish — see
+// [EC2Plugin.modifySnapshotAttribute].
+func ec2PermissionsNameAUser(perms []EC2CreateVolumePermission) bool {
+	for _, perm := range perms {
+		if perm.UserID != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// ec2ApplyVolumePermissions returns existing with adds merged in and removes taken out.
+//
+// An add that is already present changes nothing rather than duplicating, and a remove that
+// names nothing present is not an error — AWS documents neither as a refusal, and both are
+// idempotent in the direction a caller's cleanup loop needs.
+//
+// Order is existing's, with anything new appended in request order, so the list
+// DescribeSnapshotAttribute renders is the same on every run.
+func ec2ApplyVolumePermissions(existing, adds, removes []EC2CreateVolumePermission) []EC2CreateVolumePermission {
+	out := make([]EC2CreateVolumePermission, 0, len(existing)+len(adds))
+	for _, perm := range existing {
+		dropped := false
+		for _, rm := range removes {
+			if rm == perm {
+				dropped = true
+				break
+			}
+		}
+		if !dropped {
+			out = append(out, perm)
+		}
+	}
+	for _, add := range adds {
+		present := false
+		for _, perm := range out {
+			if perm == add {
+				present = true
+				break
+			}
+		}
+		if !present {
+			out = append(out, add)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// ec2UnknownSnapshotAttribute returns the error EC2 raises for a snapshot attribute name it
+// will not answer.
+//
+// The wording mirrors [ec2UnknownInstanceAttribute] so the two refusals read alike, but the
+// capture that comment cites is for describe-instance-attribute and **is not claimed for
+// this**: no capture of a snapshot-attribute rejection was found, and the three snapshot
+// pages' Errors sections are empty. The code and status are the analogy; the message is
+// substrate's.
+func ec2UnknownSnapshotAttribute(attr string) *AWSError {
+	return &AWSError{
+		Code:       "InvalidParameterValue",
+		Message:    "Value (" + attr + ") for parameter attribute is invalid. Unknown attribute.",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/emulator/ec2_snapshot_attributes_test.go
+++ b/emulator/ec2_snapshot_attributes_test.go
@@ -1,0 +1,488 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// DescribeSnapshotAttribute, ModifySnapshotAttribute and ResetSnapshotAttribute (#709).
+//
+// All three reached the dispatcher's default arm through v0.106.0, so every case here is a
+// fail-before answering InvalidAction. None of the three pages publishes an operation-specific
+// error, so each refusal below is substrate's reading of a prose rule; the test names say which
+// rule, and the handler's comments say where it comes from.
+
+// snapshotAttributeDoc is a DescribeSnapshotAttribute response.
+//
+// The two wrapper fields are pointers so the test can tell an *omitted* element from a
+// present-but-empty one — the distinction #669 established and the whole reason the handler's
+// own fields are pointers. A plain slice here would read both as an empty slice and the
+// assertions below would pass against a handler that always emitted both elements.
+type snapshotAttributeDoc struct {
+	SnapshotID             string `xml:"snapshotId"`
+	CreateVolumePermission *struct {
+		Items []struct {
+			UserID string `xml:"userId"`
+			Group  string `xml:"group"`
+		} `xml:"item"`
+	} `xml:"createVolumePermission"`
+	ProductCodes *struct {
+		Items []struct {
+			ProductCode string `xml:"productCode"`
+			Type        string `xml:"type"`
+		} `xml:"item"`
+	} `xml:"productCodes"`
+}
+
+// ec2SnapshotAttribute sends DescribeSnapshotAttribute for one attribute and returns both the
+// parsed document and the raw body.
+//
+// The raw body is returned because two of the assertions below are about an element that must
+// *not* be there, and an absent element is invisible in a struct that does not declare it.
+func ec2SnapshotAttribute(t *testing.T, ts *httptest.Server, snapshotID, attr string) (snapshotAttributeDoc, string) {
+	t.Helper()
+	body := ec2RawPost(t, ts, map[string]string{
+		"Action":     "DescribeSnapshotAttribute",
+		"SnapshotId": snapshotID,
+		"Attribute":  attr,
+	})
+	var doc snapshotAttributeDoc
+	require.NoError(t, xml.Unmarshal([]byte(body), &doc), "body: %s", body)
+	return doc, body
+}
+
+// ec2RawPost sends an EC2 request through [ec2Request] and returns the body, requiring HTTP
+// 200.
+//
+// It goes through ec2Request rather than posting directly so the Host header — which is what
+// resolves the region — is the one every other EC2 test sends.
+func ec2RawPost(t *testing.T, ts *httptest.Server, params map[string]string) string {
+	t.Helper()
+	resp := ec2Request(t, ts, params)
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
+	return string(raw)
+}
+
+// ec2ModifySnapshotAttribute sends ModifySnapshotAttribute and requires it to succeed.
+func ec2ModifySnapshotAttribute(t *testing.T, ts *httptest.Server, params map[string]string) {
+	t.Helper()
+	full := map[string]string{"Action": "ModifySnapshotAttribute"}
+	for k, v := range params {
+		full[k] = v
+	}
+	var doc struct {
+		Return bool `xml:"return"`
+	}
+	ec2FleetXML(t, ts, full, &doc)
+	assert.True(t, doc.Return, "return is documented as true on success")
+}
+
+// ec2VolumePermissions reduces the describe to the permissions it reports, in order.
+func ec2VolumePermissions(t *testing.T, ts *httptest.Server, snapshotID string) []string {
+	t.Helper()
+	doc, body := ec2SnapshotAttribute(t, ts, snapshotID, "createVolumePermission")
+	require.NotNil(t, doc.CreateVolumePermission, "the element must be present: %s", body)
+	out := make([]string, 0, len(doc.CreateVolumePermission.Items))
+	for _, item := range doc.CreateVolumePermission.Items {
+		out = append(out, item.UserID+item.Group)
+	}
+	return out
+}
+
+// TestEC2_DescribeSnapshotAttribute_AnswersBothAttributes is the describe's fail-before, and
+// pins the one thing a struct-only assertion cannot see: exactly one attribute element
+// marshals.
+//
+// A fresh snapshot's createVolumePermission is present and empty, not omitted. AWS describes a
+// reset snapshot as "a private snapshot that can only be used by the account that created it",
+// which is what a newly created one is — so "no permissions" is the true answer, and an SDK
+// reads a present-but-empty element as an empty list where it reads an omitted one as nil.
+func TestEC2_DescribeSnapshotAttribute_AnswersBothAttributes(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapshotID := ec2SnapshotOfSize(t, ts, 12)
+
+	perms, body := ec2SnapshotAttribute(t, ts, snapshotID, "createVolumePermission")
+	assert.Equal(t, snapshotID, perms.SnapshotID)
+	require.NotNil(t, perms.CreateVolumePermission, "present, so a caller reads an empty list")
+	assert.Empty(t, perms.CreateVolumePermission.Items)
+	assert.Nil(t, perms.ProductCodes, "an attribute the caller did not ask about")
+	assert.NotContains(t, body, "productCodes",
+		"a wrapper that is not a pointer would emit this element too")
+
+	// productCodes is answered rather than refused, and the reason differs from
+	// createVolumePermission's: nothing in substrate assigns a product code to a snapshot, so
+	// "none" is a fact about every snapshot it can produce rather than an invented default.
+	codes, body := ec2SnapshotAttribute(t, ts, snapshotID, "productCodes")
+	assert.Equal(t, snapshotID, codes.SnapshotID)
+	require.NotNil(t, codes.ProductCodes)
+	assert.Empty(t, codes.ProductCodes.Items)
+	assert.Nil(t, codes.CreateVolumePermission)
+	assert.NotContains(t, body, "createVolumePermission")
+}
+
+// TestEC2_ModifySnapshotAttribute_BothWireForms pins that the structured and flat forms are the
+// same request, because an SDK picks between them and a caller cannot tell which they got.
+func TestEC2_ModifySnapshotAttribute_BothWireForms(t *testing.T) {
+	t.Parallel()
+
+	for name, params := range map[string]map[string]string{
+		// The form AWS's own two examples send.
+		"structured": {
+			"CreateVolumePermission.Add.1.UserId": "123456789012",
+		},
+		// OperationType + UserId.N. The Attribute parameter is Required: No here, so its
+		// absence must not be a refusal — the wire form carries the selection.
+		"flat": {
+			"OperationType": "add",
+			"UserId.1":      "123456789012",
+		},
+		// The same, with the attribute named explicitly.
+		"flat with Attribute": {
+			"Attribute":     "createVolumePermission",
+			"OperationType": "add",
+			"UserId.1":      "123456789012",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			_, snapshotID := ec2SnapshotOfSize(t, ts, 12)
+
+			full := map[string]string{"SnapshotId": snapshotID}
+			for k, v := range params {
+				full[k] = v
+			}
+			ec2ModifySnapshotAttribute(t, ts, full)
+			assert.Equal(t, []string{"123456789012"}, ec2VolumePermissions(t, ts, snapshotID))
+		})
+	}
+}
+
+// TestEC2_ModifySnapshotAttribute_UserGroupIsTheWireMember guards the member name the CLI and
+// the SDKs disguise: the wire member of the flat form is **UserGroup.N**, where the CLI spells
+// the same thing --group-names and an SDK spells it GroupNames. A handler reading GroupNames.N
+// would silently accept the request and share nothing.
+func TestEC2_ModifySnapshotAttribute_UserGroupIsTheWireMember(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapshotID := ec2SnapshotOfSize(t, ts, 12)
+
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{
+		"SnapshotId":    snapshotID,
+		"OperationType": "add",
+		"UserGroup.1":   "all",
+	})
+	assert.Equal(t, []string{"all"}, ec2VolumePermissions(t, ts, snapshotID))
+}
+
+// TestEC2_ModifySnapshotAttribute_AddsAndRemoves walks the lifecycle a sharing consumer walks,
+// and pins the two idempotence choices AWS leaves unstated.
+func TestEC2_ModifySnapshotAttribute_AddsAndRemoves(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapshotID := ec2SnapshotOfSize(t, ts, 12)
+
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{
+		"SnapshotId":                          snapshotID,
+		"CreateVolumePermission.Add.1.UserId": "111122223333",
+		"CreateVolumePermission.Add.2.UserId": "444455556666",
+	})
+	assert.Equal(t, []string{"111122223333", "444455556666"},
+		ec2VolumePermissions(t, ts, snapshotID), "the list keeps request order")
+
+	// Adding one already present changes nothing rather than duplicating.
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{
+		"SnapshotId":                          snapshotID,
+		"CreateVolumePermission.Add.1.UserId": "111122223333",
+	})
+	assert.Equal(t, []string{"111122223333", "444455556666"},
+		ec2VolumePermissions(t, ts, snapshotID))
+
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{
+		"SnapshotId":                             snapshotID,
+		"CreateVolumePermission.Remove.1.UserId": "111122223333",
+	})
+	assert.Equal(t, []string{"444455556666"}, ec2VolumePermissions(t, ts, snapshotID))
+
+	// Removing one that is not there is not an error — AWS documents none, and a cleanup loop
+	// that runs twice needs the second run to succeed.
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{
+		"SnapshotId":                             snapshotID,
+		"CreateVolumePermission.Remove.1.UserId": "111122223333",
+	})
+	assert.Equal(t, []string{"444455556666"}, ec2VolumePermissions(t, ts, snapshotID))
+
+	// A request naming no modification at all is not a refusal: every parameter but SnapshotId
+	// is optional and AWS publishes no error for the empty case.
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{"SnapshotId": snapshotID})
+	assert.Equal(t, []string{"444455556666"}, ec2VolumePermissions(t, ts, snapshotID))
+}
+
+// TestEC2_ModifySnapshotAttribute_AWSExample2Succeeds is the test that keeps substrate from
+// refusing a request AWS documents as valid.
+//
+// AWS: "You may add or remove specified AWS account IDs from a snapshot's list of create
+// volume permissions, but you cannot do both in a single operation." Read as a blanket rule
+// that sentence would refuse AWS's own Example 2, which adds the group "all" while removing
+// the account 111122223333 in one request. The sentence is scoped to account IDs, so the
+// refusal is too.
+func TestEC2_ModifySnapshotAttribute_AWSExample2Succeeds(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapshotID := ec2SnapshotOfSize(t, ts, 12)
+
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{
+		"SnapshotId":                          snapshotID,
+		"CreateVolumePermission.Add.1.UserId": "111122223333",
+	})
+
+	// AWS's Example 2, verbatim in shape.
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{
+		"SnapshotId":                             snapshotID,
+		"CreateVolumePermission.Add.1.Group":     "all",
+		"CreateVolumePermission.Remove.1.UserId": "111122223333",
+	})
+	assert.Equal(t, []string{"all"}, ec2VolumePermissions(t, ts, snapshotID))
+}
+
+// TestEC2_ModifySnapshotAttribute_RefusesABadRequest is the refusal table.
+//
+// Every row is substrate's reading of a prose rule, since the operation publishes no error;
+// the comment on each names the sentence.
+func TestEC2_ModifySnapshotAttribute_RefusesABadRequest(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapshotID := ec2SnapshotOfSize(t, ts, 12)
+
+	tooMany := map[string]string{"SnapshotId": snapshotID}
+	for i := 1; i <= 501; i++ {
+		tooMany["CreateVolumePermission.Add."+strconv.Itoa(i)+".UserId"] =
+			strconv.FormatInt(int64(100000000000+i), 10)
+	}
+
+	for name, tc := range map[string]struct {
+		params   map[string]string
+		wantCode string
+	}{
+		"no snapshot": {
+			map[string]string{"CreateVolumePermission.Add.1.UserId": "123456789012"},
+			"MissingParameter",
+		},
+		"malformed snapshot": {
+			map[string]string{"SnapshotId": "snapshot-1"}, "InvalidSnapshotID.Malformed",
+		},
+		"absent snapshot": {
+			map[string]string{"SnapshotId": "snap-0123456789abcdef0"}, "InvalidSnapshot.NotFound",
+		},
+		// "Only volume creation permissions can be modified."
+		"productCodes": {
+			map[string]string{"SnapshotId": snapshotID, "Attribute": "productCodes"},
+			"InvalidParameterValue",
+		},
+		"unknown attribute": {
+			map[string]string{"SnapshotId": snapshotID, "Attribute": "launchPermission"},
+			"InvalidParameterValue",
+		},
+		// Group's only valid value is "all"; a group nothing can grant would be a permission
+		// a caller reads back and cannot act on.
+		"another group, structured": {
+			map[string]string{
+				"SnapshotId":                         snapshotID,
+				"CreateVolumePermission.Add.1.Group": "everyone",
+			},
+			"InvalidParameterValue",
+		},
+		"another group, flat": {
+			map[string]string{
+				"SnapshotId": snapshotID, "OperationType": "add", "UserGroup.1": "everyone",
+			},
+			"InvalidParameterValue",
+		},
+		// The account IDs half of "you cannot do both in a single operation".
+		"add and remove an account": {
+			map[string]string{
+				"SnapshotId":                             snapshotID,
+				"CreateVolumePermission.Add.1.UserId":    "111122223333",
+				"CreateVolumePermission.Remove.1.UserId": "444455556666",
+			},
+			"InvalidParameterValue",
+		},
+		// "You can make up to 500 modifications to a snapshot in a single operation."
+		"five hundred and one modifications": {tooMany, "InvalidParameterValue"},
+		"unknown OperationType": {
+			map[string]string{
+				"SnapshotId": snapshotID, "OperationType": "share", "UserId.1": "111122223333",
+			},
+			"InvalidParameterValue",
+		},
+		// A flat value with no OperationType names no list to join, so there is nothing to do
+		// with it but refuse — accepting it would silently discard the permission.
+		"flat values with no OperationType": {
+			map[string]string{"SnapshotId": snapshotID, "UserId.1": "111122223333"},
+			"MissingParameter",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			params := map[string]string{"Action": "ModifySnapshotAttribute"}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			status, code, _ := ec2ErrorDetail(t, ts, params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tc.wantCode, code)
+		})
+	}
+
+	// None of the above wrote anything: the snapshot is still private.
+	assert.Empty(t, ec2VolumePermissions(t, ts, snapshotID))
+}
+
+// TestEC2_ModifySnapshotAttribute_EncryptedSnapshotCannotBeMadePublic pins the EBS user guide's
+// rule — "You can share only unencrypted snapshots publicly" — and its scope: the refusal is
+// about the group, so sharing an encrypted snapshot with a *named account* still works.
+//
+// The companion rule AWS states in the same breath, that a snapshot with a Marketplace product
+// code cannot be made public, is unreachable rather than unmodeled: substrate assigns no
+// product codes at all.
+func TestEC2_ModifySnapshotAttribute_EncryptedSnapshotCannotBeMadePublic(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volID := ec2CreateSizedVolume(t, ts, 12, map[string]string{"Encrypted": "true"})
+	snap := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volID})
+	require.True(t, snap.Encrypted, "the snapshot inherits the volume's encryption")
+
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                             "ModifySnapshotAttribute",
+		"SnapshotId":                         snap.SnapshotID,
+		"CreateVolumePermission.Add.1.Group": "all",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+	assert.Contains(t, strings.ToLower(message), "unencrypted")
+	assert.Empty(t, ec2VolumePermissions(t, ts, snap.SnapshotID))
+
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{
+		"SnapshotId":                          snap.SnapshotID,
+		"CreateVolumePermission.Add.1.UserId": "111122223333",
+	})
+	assert.Equal(t, []string{"111122223333"},
+		ec2VolumePermissions(t, ts, snap.SnapshotID), "sharing with an account is not sharing publicly")
+}
+
+// TestEC2_ResetSnapshotAttribute_ClearsThePermissions is the reset's fail-before.
+//
+// Resetting clears the list rather than restoring a remembered default, because AWS describes
+// the result as "making it a private snapshot that can only be used by the account that
+// created it" — which is what a created snapshot already is.
+func TestEC2_ResetSnapshotAttribute_ClearsThePermissions(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapshotID := ec2SnapshotOfSize(t, ts, 12)
+
+	ec2ModifySnapshotAttribute(t, ts, map[string]string{
+		"SnapshotId":                          snapshotID,
+		"CreateVolumePermission.Add.1.UserId": "111122223333",
+		"CreateVolumePermission.Add.2.Group":  "all",
+	})
+	require.Len(t, ec2VolumePermissions(t, ts, snapshotID), 2)
+
+	var doc struct {
+		Return bool `xml:"return"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":     "ResetSnapshotAttribute",
+		"SnapshotId": snapshotID,
+		"Attribute":  "createVolumePermission",
+	}, &doc)
+	assert.True(t, doc.Return)
+
+	// Present and empty, not omitted: the snapshot still exists and still has the attribute.
+	after, body := ec2SnapshotAttribute(t, ts, snapshotID, "createVolumePermission")
+	require.NotNil(t, after.CreateVolumePermission, "body: %s", body)
+	assert.Empty(t, after.CreateVolumePermission.Items)
+
+	// And the snapshot itself is untouched.
+	described := ec2DescribeSnapshots(t, ts, map[string]string{"SnapshotId.1": snapshotID})
+	require.Len(t, described, 1)
+	assert.Equal(t, int64(12), described[0].VolumeSize)
+}
+
+// TestEC2_SnapshotAttribute_ValidatesTheAttributeBeforeTheSnapshot pins the ordering
+// [EC2Plugin.describeInstanceAttribute] established: an attribute name the operation does not
+// accept is a defect in the request that no retry fixes, while a snapshot ID naming nothing may
+// be one the caller is still waiting on. Reporting the wrong one first sends a consumer's
+// retry loop after a request that will never succeed.
+func TestEC2_SnapshotAttribute_ValidatesTheAttributeBeforeTheSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	for _, action := range []string{
+		"DescribeSnapshotAttribute", "ModifySnapshotAttribute", "ResetSnapshotAttribute",
+	} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+				"Action":     action,
+				"Attribute":  "nonsense",
+				"SnapshotId": "snap-0123456789abcdef0",
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "InvalidParameterValue", code,
+				"the attribute name is refused before the snapshot is resolved")
+		})
+	}
+}
+
+// TestEC2_SnapshotAttribute_RequiresTheAttributeWhereAWSDoes pins the split between the three
+// operations: Attribute is Required: Yes on the describe and the reset — "You can specify only
+// one attribute at a time" — and Required: No on the modify, where the wire form carries the
+// selection. A handler that required it everywhere would refuse the flat modify form; one that
+// defaulted it everywhere would answer an attribute the caller never named.
+func TestEC2_SnapshotAttribute_RequiresTheAttributeWhereAWSDoes(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, snapshotID := ec2SnapshotOfSize(t, ts, 12)
+
+	for _, action := range []string{"DescribeSnapshotAttribute", "ResetSnapshotAttribute"} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+				"Action": action, "SnapshotId": snapshotID,
+			})
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "MissingParameter", code)
+		})
+	}
+
+	t.Run("ResetSnapshotAttribute refuses productCodes", func(t *testing.T) {
+		t.Parallel()
+		// "Only the attribute for permission to create volumes can be reset."
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action": "ResetSnapshotAttribute", "SnapshotId": snapshotID,
+			"Attribute": "productCodes",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+	})
+
+	t.Run("DescribeSnapshotAttribute requires a snapshot", func(t *testing.T) {
+		t.Parallel()
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action": "DescribeSnapshotAttribute", "Attribute": "createVolumePermission",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "MissingParameter", code)
+	})
+}

--- a/emulator/ec2_snapshot_ops.go
+++ b/emulator/ec2_snapshot_ops.go
@@ -1,0 +1,454 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// The two snapshot-creating operations beyond CreateSnapshot (#709).
+//
+// Through v0.106.0 CreateSnapshot was the whole of substrate's snapshot creation, so a
+// consumer whose IaC snapshots an instance rather than a volume, or copies a snapshot before
+// sharing it, reached the dispatcher's default arm and read InvalidAction — an answer that
+// tells a caller the endpoint does not speak EC2 rather than that substrate has a gap.
+//
+// Provenance, which is the same for both operations: neither API_CreateSnapshots.html nor
+// API_CopySnapshot.html publishes a single operation-specific error — both Errors sections
+// point only at the common types — and CreateSnapshots has no Examples section at all. So
+// every refusal below is either a code from EC2's client-error table (which describes the
+// condition rather than quoting a wire message) or substrate's own reading of a documented
+// rule AWS states in prose without naming a code. Each says which it is.
+
+// ec2MaxExcludedDataVolumes is the number of volume IDs one CreateSnapshots request may
+// exclude: "You can specify up to 40 volume IDs per request", from InstanceSpecification's own
+// text.
+const ec2MaxExcludedDataVolumes = 40
+
+// ec2AttachedVolume pairs a volume with the device name it is attached at, which
+// CreateSnapshots needs together: the device decides whether the volume is the instance's
+// boot volume, and the volume carries the size and encryption the snapshot inherits.
+type ec2AttachedVolume struct {
+	volume EC2Volume
+	device string
+}
+
+// ec2InstanceAttachedVolumes returns every volume attached to instanceID, ordered by device
+// name.
+//
+// The ordering is not cosmetic. [StateManager.List] returns keys in Go map order, so the
+// snapshotSet of a CreateSnapshots call over a multi-volume instance would otherwise come
+// back in a different order on every run — and a test asserting on the first item, or a
+// consumer reading snapshotSet[0], would pass or fail by iteration order. A device name is
+// unique per instance, so sorting on it is a total order.
+//
+// A record that cannot be read or unmarshalled is skipped rather than failing the request,
+// matching [EC2Plugin.ec2InstanceRootVolume]'s treatment of the same scan: one corrupt
+// volume record should not make an instance unsnapshottable.
+func (p *EC2Plugin) ec2InstanceAttachedVolumes(reqCtx *RequestContext, instanceID string) ([]ec2AttachedVolume, error) {
+	ctx := context.Background()
+	keys, err := p.state.List(ctx, ec2Namespace, ec2VolumeStatePrefix(reqCtx.AccountID, reqCtx.Region))
+	if err != nil {
+		return nil, fmt.Errorf("ec2 instance volumes list: %w", err)
+	}
+	var out []ec2AttachedVolume
+	for _, key := range keys {
+		data, getErr := p.state.Get(ctx, ec2Namespace, key)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var vol EC2Volume
+		if json.Unmarshal(data, &vol) != nil {
+			continue
+		}
+		for _, att := range vol.Attachments {
+			if att.InstanceID == instanceID {
+				out = append(out, ec2AttachedVolume{volume: vol, device: att.Device})
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].device < out[j].device })
+	return out, nil
+}
+
+// ec2SnapshotInfoItem is one member of a CreateSnapshots snapshotSet.
+//
+// It is a separate type from the item [EC2Plugin.describeSnapshots] renders, and cannot
+// reuse [EC2Plugin.createSnapshot]'s response struct either, for one reason: AWS's
+// SnapshotInfo names the state member **state**, where CreateSnapshot's and
+// DescribeSnapshots' responses both name it **status**. A caller unmarshalling
+// SnapshotInfo reads State; sharing a struct would hand them an empty string.
+//
+// The members substrate does not render are omissions with reasons rather than oversights:
+//
+//   - progress — substrate stores none, the same reason DescribeSnapshots and CreateSnapshot
+//     render none. It arrives with the seedable progression in #715.
+//   - availabilityZone — documented as "The Availability Zone or Local Zone of the
+//     snapshots", and the singular CreateSnapshot response has no such member at all, so it
+//     reads as the placement member for a Location=local snapshot. Substrate models only
+//     regional snapshots, so rendering the source volume's AZ here would claim a local
+//     snapshot that does not exist.
+//   - outpostArn and sseType — neither Outposts nor a specific server-side encryption type is
+//     modeled, and inventing "sse-ebs" would be indistinguishable to a caller from an
+//     observation.
+type ec2SnapshotInfoItem struct {
+	SnapshotID  string       `xml:"snapshotId"`
+	VolumeID    string       `xml:"volumeId,omitempty"`
+	VolumeSize  int64        `xml:"volumeSize"`
+	State       string       `xml:"state"`
+	StartTime   string       `xml:"startTime"`
+	OwnerID     string       `xml:"ownerId"`
+	Description string       `xml:"description,omitempty"`
+	Encrypted   bool         `xml:"encrypted"`
+	Tags        []ec2TagItem `xml:"tagSet>item"`
+}
+
+// createSnapshots snapshots every EBS volume attached to one instance in a single call.
+//
+// # What is read
+//
+// InstanceSpecification is the one required parameter, and its InstanceId is required in
+// turn. The instance is resolved against state, so an absent one answers
+// InvalidInstanceID.NotFound rather than an empty snapshotSet — an empty set is what an
+// instance with no volumes gets, and the two must not be confused.
+//
+// ExcludeBootVolume drops the volume attached at a root device name (see [ec2IsRootDevice]).
+// ExcludeDataVolumeId.N — singular member, indexed, not a plural — drops named volumes, up
+// to [ec2MaxExcludedDataVolumes] of them. Naming the root volume there is refused, because
+// AWS refuses it: "If you specify the ID of the root volume, the request fails. To exclude
+// the root volume, use ExcludeBootVolume." A volume ID that is not attached to the instance
+// is *not* refused: it excludes nothing, which is what the parameter asks for.
+//
+// CopyTagsFromSource has the single valid value "volume", and any other value is refused
+// rather than ignored. When it is set, each snapshot inherits its own source volume's tags —
+// its own, not the instance's, since AWS scopes the copy to the source of that snapshot.
+//
+// Description and TagSpecification.N apply to every snapshot the call creates. Where a
+// TagSpecification key collides with a copied volume tag the request's value wins, since a
+// tag the caller wrote in this request is the more specific instruction; AWS settles neither
+// the precedence nor the ordering, so both are substrate's and are stated here.
+//
+// Location and OutpostArn are not read, for the reason [EC2Plugin.createSnapshot] does not
+// read them: both are documented as supported only for a Local Zone or an Outpost, and
+// neither is modeled, so honoring them would place the snapshots somewhere substrate
+// cannot describe them from. Location's own default is "regional", which is what substrate
+// produces — but a request asking for "local" gets a regional snapshot rather than a
+// refusal, exactly as the sibling operation behaves.
+//
+// # The state it reports
+//
+// state is "completed" at once, as CreateSnapshot's status is, and for the same reason:
+// substrate advances no snapshot asynchronously, so a waiter succeeds on its first poll
+// instead of depending on wall-clock time.
+func (p *EC2Plugin) createSnapshots(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	instanceID := req.Params["InstanceSpecification.InstanceId"]
+	if instanceID == "" {
+		return nil, ec2MissingParameter("InstanceSpecification.InstanceId")
+	}
+
+	copyTags := req.Params["CopyTagsFromSource"]
+	if copyTags != "" && copyTags != "volume" {
+		return nil, ec2InvalidParameterValue("CopyTagsFromSource", copyTags,
+			"The only supported value is volume.")
+	}
+
+	excluded := extractIndexedParams(req.Params, "InstanceSpecification.ExcludeDataVolumeId")
+	if len(excluded) > ec2MaxExcludedDataVolumes {
+		return nil, ec2InvalidParameterValue("InstanceSpecification.ExcludeDataVolumeId",
+			strconv.Itoa(len(excluded)),
+			fmt.Sprintf("You can specify up to %d volume IDs per request.", ec2MaxExcludedDataVolumes))
+	}
+
+	inst, awsErr, err := p.loadInstance(reqCtx, instanceID, "createSnapshots")
+	if err != nil || awsErr != nil {
+		return nil, errOrAWS(err, awsErr)
+	}
+
+	attached, err := p.ec2InstanceAttachedVolumes(reqCtx, inst.InstanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	requestTags := ec2LaunchTagsForResource(req.Params, "snapshot")
+	excludeBoot := req.Params["InstanceSpecification.ExcludeBootVolume"] == "true"
+
+	// The root volume's ID is needed before anything is written, because naming it in
+	// ExcludeDataVolumeId.N is a refusal and the rollback rule in [ec2CheckReservedTagKeys]
+	// applies to every tag-on-create path: a refused request must leave no snapshot behind.
+	rootVolumeID := ""
+	for _, av := range attached {
+		if ec2IsRootDevice(av.device) {
+			rootVolumeID = av.volume.VolumeID
+			break
+		}
+	}
+	excludedIDs := make(map[string]struct{}, len(excluded))
+	for _, id := range excluded {
+		if rootVolumeID != "" && id == rootVolumeID {
+			return nil, ec2InvalidParameterValue("InstanceSpecification.ExcludeDataVolumeId", id,
+				"The root volume cannot be excluded by ID; use ExcludeBootVolume.")
+		}
+		excludedIDs[id] = struct{}{}
+	}
+
+	// Every snapshot is built and its tags checked before the first Put, for the rollback
+	// rule above: a five-volume instance whose fourth volume carries a reserved tag key must
+	// not leave three snapshots behind.
+	now := p.tc.Now().UTC().Format(time.RFC3339)
+	var snapshots []EC2Snapshot
+	for _, av := range attached {
+		if _, skip := excludedIDs[av.volume.VolumeID]; skip {
+			continue
+		}
+		if excludeBoot && ec2IsRootDevice(av.device) {
+			continue
+		}
+		tags := requestTags
+		if copyTags == "volume" {
+			tags = ec2MergeTags(av.volume.Tags, requestTags)
+		}
+		if tagErr := ec2CheckTagRules(tags); tagErr != nil {
+			return nil, tagErr
+		}
+		if tagErr := ec2CheckTagLimit(nil, tags); tagErr != nil {
+			return nil, tagErr
+		}
+		snapshots = append(snapshots, EC2Snapshot{
+			SnapshotID:  generateEBSSnapshotID(),
+			VolumeID:    av.volume.VolumeID,
+			VolumeSize:  int64(av.volume.Size),
+			State:       "completed",
+			StartTime:   now,
+			Encrypted:   av.volume.Encrypted,
+			Description: req.Params["Description"],
+			Tags:        tags,
+			AccountID:   reqCtx.AccountID,
+			Region:      reqCtx.Region,
+		})
+	}
+
+	items := make([]ec2SnapshotInfoItem, 0, len(snapshots))
+	for _, snap := range snapshots {
+		if err := p.ec2PutSnapshot(reqCtx, snap); err != nil {
+			return nil, err
+		}
+		items = append(items, ec2SnapshotInfoItem{
+			SnapshotID:  snap.SnapshotID,
+			VolumeID:    snap.VolumeID,
+			VolumeSize:  snap.VolumeSize,
+			State:       snap.State,
+			StartTime:   snap.StartTime,
+			OwnerID:     snap.AccountID,
+			Description: snap.Description,
+			Encrypted:   snap.Encrypted,
+			Tags:        ec2TagItems(snap.Tags),
+		})
+	}
+
+	// snapshotSet carries no omitempty: an instance with no volumes left to snapshot is
+	// "none", and an SDK reads an omitted element as nil rather than as an empty slice.
+	type response struct {
+		XMLName   xml.Name              `xml:"CreateSnapshotsResponse"`
+		XMLNS     string                `xml:"xmlns,attr"`
+		Snapshots []ec2SnapshotInfoItem `xml:"snapshotSet>item"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:     "http://ec2.amazonaws.com/doc/2016-11-15/",
+		Snapshots: items,
+	})
+}
+
+// ec2MergeTags returns base with each of override's tags applied, replacing a tag of the
+// same key in place rather than appending a duplicate.
+//
+// Order is base's, then any key override introduces, so the result is the same on every run
+// for the same request — which a map-based merge would not be.
+func ec2MergeTags(base, override []EC2Tag) []EC2Tag {
+	out := make([]EC2Tag, len(base))
+	copy(out, base)
+	for _, t := range override {
+		replaced := false
+		for i := range out {
+			if out[i].Key == t.Key {
+				out[i].Value = t.Value
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// ec2PutSnapshot writes one snapshot record to state.
+//
+// It exists because four operations now write snapshots — CreateSnapshot, CreateSnapshots,
+// CopySnapshot and the two attribute mutators — and a writer that spelled the key
+// differently from [ec2SnapshotStateKey] would produce a snapshot DescribeSnapshots cannot
+// see, which is the failure mode [ec2SnapshotStatePrefix]'s own doc comment records.
+func (p *EC2Plugin) ec2PutSnapshot(reqCtx *RequestContext, snap EC2Snapshot) error {
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Errorf("ec2 snapshot marshal %s: %w", snap.SnapshotID, err)
+	}
+	key := ec2SnapshotStateKey(reqCtx.AccountID, reqCtx.Region, snap.SnapshotID)
+	if err := p.state.Put(context.Background(), ec2Namespace, key, data); err != nil {
+		return fmt.Errorf("ec2 snapshot state.Put %s: %w", snap.SnapshotID, err)
+	}
+	return nil
+}
+
+// copySnapshot copies an existing snapshot within the region.
+//
+// # Why a single-region emulator can implement a copy at all
+//
+// AWS's own description settles it twice. "If the source snapshot is in a Region, you can
+// copy it within that Region" makes a same-region copy legal rather than a degenerate case,
+// and its Example 1 is exactly that. And DestinationRegion is not routing: "This parameter is
+// only valid for specifying the destination Region in a PresignedUrl parameter, where it is
+// required … The snapshot copy is sent to the regional endpoint that you sent the HTTP
+// request to." So the destination of a copy is the endpoint it was sent to, which is the one
+// region substrate serves.
+//
+// A SourceRegion naming any other region is refused with
+// SnapshotCopyUnsupported.InterRegion, whose published description — "Inter-region snapshot
+// copy is not supported for this AWS Region" — is precisely substrate's situation. That is a
+// code from the client-error table rather than a captured message; the wording below is
+// substrate's.
+//
+// # What is read
+//
+// SourceRegion and SourceSnapshotId are both required. The source is resolved against state,
+// so a malformed ID answers InvalidSnapshotID.Malformed and an absent one
+// InvalidSnapshot.NotFound.
+//
+// Encrypted is accepted only as true. AWS: "Copies of encrypted snapshots are encrypted,
+// even if you omit this parameter … You cannot set this parameter to false." A copy of an
+// encrypted snapshot is therefore encrypted whatever the request says, and an explicit
+// Encrypted=false is refused rather than silently honored or silently dropped — substrate's
+// reading of that sentence, since AWS names no code for it.
+//
+// KmsKeyId is validated but not stored: "If KmsKeyId is specified, the encrypted state must
+// be true", so naming a key for an unencrypted copy is refused. Substrate models no KMS key
+// on a snapshot, so there is nothing for a caller to read back, and the rule is observable
+// only as that refusal.
+//
+// Description is the request's, empty when absent. AWS does not document what an omitted
+// description produces, so substrate stores nothing rather than inventing a "Copied from …"
+// string a consumer might assert on.
+//
+// Tags are the request's TagSpecification.N alone. CopySnapshot has no CopyTagsFromSource —
+// that parameter is CreateSnapshots' — so the source's tags are deliberately not carried
+// over.
+//
+// CompletionDurationMinutes, DestinationAvailabilityZone, DestinationOutpostArn,
+// DestinationRegion and PresignedUrl are not read. The first is a time-based copy, which has
+// nothing to slow down here; the next two place the copy somewhere substrate does not model;
+// and the last two are artifacts of signing a cross-region request, which cannot arise.
+//
+// # The volume ID
+//
+// The copy records a freshly generated volume ID that names no volume, which is what AWS
+// produces: "Snapshots copies have an arbitrary source volume ID. Do not use this volume ID
+// for any purpose." Rendering the *source's* volume ID would hand a caller a reference that
+// resolves, inviting exactly the use AWS warns against; omitting the member entirely would
+// drop an element AWS always sends. An arbitrary ID keeps the shape and makes the warning
+// self-enforcing — any operation a caller passes it to answers InvalidVolume.NotFound.
+func (p *EC2Plugin) copySnapshot(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
+	sourceRegion := req.Params["SourceRegion"]
+	if sourceRegion == "" {
+		return nil, ec2MissingParameter("SourceRegion")
+	}
+	sourceID := req.Params["SourceSnapshotId"]
+	if sourceID == "" {
+		return nil, ec2MissingParameter("SourceSnapshotId")
+	}
+	if sourceRegion != reqCtx.Region {
+		return nil, &AWSError{
+			Code: "SnapshotCopyUnsupported.InterRegion",
+			Message: fmt.Sprintf(
+				"Inter-region snapshot copy is not supported: the source region %s is not %s.",
+				sourceRegion, reqCtx.Region),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	if encrypted, ok := req.Params["Encrypted"]; ok && encrypted != "true" {
+		return nil, ec2InvalidParameterValue("Encrypted", encrypted,
+			"You cannot set this parameter to false.")
+	}
+	requestedEncryption := req.Params["Encrypted"] == "true"
+
+	source, found := p.ec2SnapshotResolver(reqCtx)(sourceID)
+	if awsErr := ec2RequireResource(ec2SnapshotIDKind, sourceID, found); awsErr != nil {
+		return nil, awsErr
+	}
+
+	encrypted := source.Encrypted || requestedEncryption
+	if kms := req.Params["KmsKeyId"]; kms != "" && !encrypted {
+		return nil, ec2InvalidParameterValue("KmsKeyId", kms,
+			"If KmsKeyId is specified, the encrypted state must be true.")
+	}
+
+	tags := ec2LaunchTagsForResource(req.Params, "snapshot")
+	if awsErr := ec2CheckTagRules(tags); awsErr != nil {
+		return nil, awsErr
+	}
+	if awsErr := ec2CheckTagLimit(nil, tags); awsErr != nil {
+		return nil, awsErr
+	}
+
+	snap := EC2Snapshot{
+		SnapshotID:  generateEBSSnapshotID(),
+		VolumeID:    generateVolumeID(),
+		VolumeSize:  source.VolumeSize,
+		State:       "completed",
+		StartTime:   p.tc.Now().UTC().Format(time.RFC3339),
+		Encrypted:   encrypted,
+		Description: req.Params["Description"],
+		Tags:        tags,
+		AccountID:   reqCtx.AccountID,
+		Region:      reqCtx.Region,
+	}
+	if err := p.ec2PutSnapshot(reqCtx, snap); err != nil {
+		return nil, err
+	}
+
+	// snapshotId and tagSet are the whole of the documented response beyond requestId — no
+	// status, no volumeSize — so a caller polls DescribeSnapshots for the rest.
+	type response struct {
+		XMLName    xml.Name     `xml:"CopySnapshotResponse"`
+		XMLNS      string       `xml:"xmlns,attr"`
+		SnapshotID string       `xml:"snapshotId"`
+		Tags       []ec2TagItem `xml:"tagSet>item"`
+	}
+	return ec2XMLResponse(http.StatusOK, response{
+		XMLNS:      "http://ec2.amazonaws.com/doc/2016-11-15/",
+		SnapshotID: snap.SnapshotID,
+		Tags:       ec2TagItems(snap.Tags),
+	})
+}
+
+// ec2InvalidParameterValue returns EC2's InvalidParameterValue for a parameter whose value
+// the operation will not accept, in the shape the one captured EC2 example of this code uses
+// — "Value (x) for parameter y is invalid." — with a sentence saying why appended.
+//
+// The captured half is the prefix, from the capture [ec2UnknownInstanceAttribute] records.
+// The trailing sentence is substrate's, and in every caller below it is AWS's own prose rule
+// quoted or paraphrased, because that rule is the only thing that tells a caller what to
+// send instead and none of these refusals is published with a message.
+func ec2InvalidParameterValue(param, value, why string) *AWSError {
+	return &AWSError{
+		Code:       "InvalidParameterValue",
+		Message:    fmt.Sprintf("Value (%s) for parameter %s is invalid. %s", value, param, why),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}

--- a/emulator/ec2_snapshot_ops_test.go
+++ b/emulator/ec2_snapshot_ops_test.go
@@ -1,0 +1,559 @@
+package emulator_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateSnapshots and CopySnapshot (#709).
+//
+// Both reached the dispatcher's default arm through v0.106.0, so every assertion in this file
+// is a fail-before: the request answered InvalidAction / HTTP 400, which is the answer a
+// consumer reads as "this endpoint does not speak EC2" rather than "substrate has not
+// implemented this yet".
+//
+// Provenance: neither operation publishes an operation-specific error — both Errors sections
+// point only at the common types, and CreateSnapshots has no Examples section at all — so
+// every refused row below is either a code from EC2's client-error table
+// (SnapshotCopyUnsupported.InterRegion, InvalidSnapshot.NotFound) or substrate's reading of a
+// prose rule AWS states without naming a code. The code comments say which for each.
+
+// snapshotInfo is the CreateSnapshots snapshotSet item as a caller receives it.
+//
+// The state member is read from `state`, **not** `status`: AWS's SnapshotInfo — which is what
+// CreateSnapshots returns — names it `state`, while CreateSnapshot's and DescribeSnapshots'
+// own responses name the same thing `status`. A test reading `status` here would pass against
+// a handler that had reused CreateSnapshot's struct and reported nothing at all.
+type snapshotInfo struct {
+	SnapshotID  string `xml:"snapshotId"`
+	VolumeID    string `xml:"volumeId"`
+	VolumeSize  int64  `xml:"volumeSize"`
+	State       string `xml:"state"`
+	Status      string `xml:"status"`
+	StartTime   string `xml:"startTime"`
+	OwnerID     string `xml:"ownerId"`
+	Description string `xml:"description"`
+	Encrypted   bool   `xml:"encrypted"`
+	Tags        []struct {
+		Key   string `xml:"key"`
+		Value string `xml:"value"`
+	} `xml:"tagSet>item"`
+}
+
+// ec2CreateSnapshots sends CreateSnapshots and returns the snapshotSet it answers.
+func ec2CreateSnapshots(t *testing.T, ts *httptest.Server, params map[string]string) []snapshotInfo {
+	t.Helper()
+	full := map[string]string{"Action": "CreateSnapshots"}
+	for k, v := range params {
+		full[k] = v
+	}
+	var doc struct {
+		Snapshots []snapshotInfo `xml:"snapshotSet>item"`
+	}
+	ec2FleetXML(t, ts, full, &doc)
+	return doc.Snapshots
+}
+
+// ec2InstanceWithDataVolume launches an instance and attaches a data volume of dataGiB at
+// /dev/sdb, returning the instance ID, the root volume's ID and the data volume's.
+//
+// The volume is created and attached explicitly rather than declared in the launch's block
+// device mapping, so the test knows the data volume's ID without having to find it. The root
+// volume's ID is read back from DescribeVolumes, since the launch mints it.
+//
+// The two sizes are deliberately different from each other and from
+// ec2DefaultVolumeSizeGiB where the caller passes anything but 8: a snapshotSet in which
+// every volumeSize agreed would not distinguish a handler that snapshotted each volume from
+// one that snapshotted the root twice.
+func ec2InstanceWithDataVolume(t *testing.T, ts *httptest.Server, dataGiB int) (instanceID, rootVolumeID, dataVolumeID string) {
+	t.Helper()
+	instanceID = ec2RunInstanceIDs(t, ts, map[string]string{
+		"Action":   "RunInstances",
+		"ImageId":  "ami-0123456789abcdef0",
+		"MinCount": "1",
+		"MaxCount": "1",
+	})[0]
+
+	dataVolumeID = ec2CreateSizedVolume(t, ts, dataGiB, nil)
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":     "AttachVolume",
+		"VolumeId":   dataVolumeID,
+		"InstanceId": instanceID,
+		"Device":     "/dev/sdb",
+	}, nil)
+
+	for device, volumeID := range ec2InstanceVolumesByDevice(t, ts, instanceID) {
+		if device == "/dev/sda1" {
+			rootVolumeID = volumeID
+		}
+	}
+	require.NotEmpty(t, rootVolumeID, "the launch must have materialized a root volume")
+	return instanceID, rootVolumeID, dataVolumeID
+}
+
+// ec2InstanceVolumesByDevice maps each device name on instanceID to the volume attached at
+// it, as DescribeVolumes reports them.
+func ec2InstanceVolumesByDevice(t *testing.T, ts *httptest.Server, instanceID string) map[string]string {
+	t.Helper()
+	var doc struct {
+		Volumes []struct {
+			VolumeID    string `xml:"volumeId"`
+			Attachments []struct {
+				InstanceID string `xml:"instanceId"`
+				Device     string `xml:"device"`
+			} `xml:"attachmentSet>item"`
+		} `xml:"volumeSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{"Action": "DescribeVolumes"}, &doc)
+	byDevice := map[string]string{}
+	for _, vol := range doc.Volumes {
+		for _, att := range vol.Attachments {
+			if att.InstanceID == instanceID {
+				byDevice[att.Device] = vol.VolumeID
+			}
+		}
+	}
+	return byDevice
+}
+
+// TestEC2_CreateSnapshots_SnapshotsEveryAttachedVolume is the operation's fail-before, and
+// pins the member name that makes it impossible to reuse CreateSnapshot's response.
+//
+// The order is asserted, not just the membership. RunInstances appends the root volume to
+// state *after* any declared mapping (see ec2LaunchVolumesFor), and StateManager.List returns
+// keys in Go map order, so a handler that rendered the scan's order would answer differently
+// on different runs and a consumer reading snapshotSet[0] would pass or fail by iteration
+// order. Sorting on the device name is what makes the answer a fact about the request.
+func TestEC2_CreateSnapshots_SnapshotsEveryAttachedVolume(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instanceID, rootVolumeID, dataVolumeID := ec2InstanceWithDataVolume(t, ts, 20)
+
+	got := ec2CreateSnapshots(t, ts, map[string]string{
+		"InstanceSpecification.InstanceId": instanceID,
+		"Description":                      "nightly",
+	})
+	require.Len(t, got, 2, "one snapshot per attached volume")
+
+	assert.Equal(t, rootVolumeID, got[0].VolumeID, "/dev/sda1 sorts before /dev/sdb")
+	assert.Equal(t, int64(8), got[0].VolumeSize, "the root volume's own size")
+	assert.Equal(t, dataVolumeID, got[1].VolumeID)
+	assert.Equal(t, int64(20), got[1].VolumeSize, "the data volume's, not the root's")
+
+	for i, snap := range got {
+		assert.Contains(t, snap.SnapshotID, "snap-", "item %d", i)
+		assert.Equal(t, "completed", snap.State,
+			"SnapshotInfo names the state member `state`, not `status`")
+		assert.Empty(t, snap.Status, "a `status` element here would be the wrong member name")
+		assert.NotEmpty(t, snap.StartTime, "item %d", i)
+		assert.NotEmpty(t, snap.OwnerID, "item %d", i)
+		assert.Equal(t, "nightly", snap.Description, "the description applies to every snapshot")
+	}
+
+	// And DescribeSnapshots reports both, so the two operations cannot drift about what was
+	// written — which is the whole point of writing through one state key helper.
+	described := ec2DescribeSnapshots(t, ts, map[string]string{
+		"SnapshotId.1": got[0].SnapshotID, "SnapshotId.2": got[1].SnapshotID,
+	})
+	require.Len(t, described, 2)
+	for _, snap := range described {
+		assert.Equal(t, "completed", snap.State, "DescribeSnapshots names it `status`")
+	}
+}
+
+// TestEC2_CreateSnapshots_ExcludesWhatTheRequestExcludes covers the two exclusion parameters
+// separately, because they are not interchangeable: AWS refuses excluding the root volume by
+// ID and directs a caller to ExcludeBootVolume instead, so a handler that treated them as one
+// list would accept a request AWS rejects.
+func TestEC2_CreateSnapshots_ExcludesWhatTheRequestExcludes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ExcludeBootVolume leaves the data volume", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		instanceID, _, dataVolumeID := ec2InstanceWithDataVolume(t, ts, 30)
+
+		got := ec2CreateSnapshots(t, ts, map[string]string{
+			"InstanceSpecification.InstanceId":        instanceID,
+			"InstanceSpecification.ExcludeBootVolume": "true",
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, dataVolumeID, got[0].VolumeID)
+		assert.Equal(t, int64(30), got[0].VolumeSize)
+	})
+
+	t.Run("ExcludeDataVolumeId leaves the root volume", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		instanceID, rootVolumeID, dataVolumeID := ec2InstanceWithDataVolume(t, ts, 30)
+
+		got := ec2CreateSnapshots(t, ts, map[string]string{
+			"InstanceSpecification.InstanceId":            instanceID,
+			"InstanceSpecification.ExcludeDataVolumeId.1": dataVolumeID,
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, rootVolumeID, got[0].VolumeID)
+	})
+
+	t.Run("a volume ID that is not attached excludes nothing", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		instanceID, _, _ := ec2InstanceWithDataVolume(t, ts, 30)
+
+		// Not a refusal: the parameter asks for volumes to be left out, and a volume that
+		// was never in is left out. AWS documents no error for it, and refusing would
+		// break a caller excluding a volume they had already detached.
+		got := ec2CreateSnapshots(t, ts, map[string]string{
+			"InstanceSpecification.InstanceId":            instanceID,
+			"InstanceSpecification.ExcludeDataVolumeId.1": "vol-0123456789abcdef0",
+		})
+		assert.Len(t, got, 2)
+	})
+}
+
+// TestEC2_CreateSnapshots_RefusesTheRootVolumeByID pins AWS's one explicit refusal on this
+// operation: "If you specify the ID of the root volume, the request fails. To exclude the
+// root volume, use ExcludeBootVolume."
+//
+// The message names ExcludeBootVolume for the same reason AWS's sentence does — it is the
+// only thing that tells the caller what to send instead. The code is substrate's; AWS says
+// only that the request fails.
+func TestEC2_CreateSnapshots_RefusesTheRootVolumeByID(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instanceID, rootVolumeID, _ := ec2InstanceWithDataVolume(t, ts, 30)
+
+	before := ec2DescribeSnapshots(t, ts, map[string]string{})
+	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action":                           "CreateSnapshots",
+		"InstanceSpecification.InstanceId": instanceID,
+		"InstanceSpecification.ExcludeDataVolumeId.1": rootVolumeID,
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidParameterValue", code)
+	assert.Contains(t, message, rootVolumeID)
+	assert.Contains(t, message, "ExcludeBootVolume", "the message must name the parameter to use")
+	assert.Len(t, ec2DescribeSnapshots(t, ts, map[string]string{}), len(before),
+		"a refused request snapshots nothing")
+}
+
+// TestEC2_CreateSnapshots_RefusesABadRequest is the parameter table.
+//
+// The instance is resolved against state rather than assumed, so an absent one is
+// InvalidInstanceID.NotFound and not an empty snapshotSet — the distinction matters because
+// an empty set is a real answer for an instance with no volumes left to snapshot, and a
+// consumer's wait loop turns on "not yet" versus "never".
+func TestEC2_CreateSnapshots_RefusesABadRequest(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instanceID, _, _ := ec2InstanceWithDataVolume(t, ts, 30)
+
+	manyExclusions := map[string]string{"InstanceSpecification.InstanceId": instanceID}
+	for i := 1; i <= 41; i++ {
+		manyExclusions[fmt.Sprintf("InstanceSpecification.ExcludeDataVolumeId.%d", i)] =
+			fmt.Sprintf("vol-%017d", i)
+	}
+
+	for name, tc := range map[string]struct {
+		params   map[string]string
+		wantCode string
+	}{
+		"no instance": {
+			map[string]string{}, "MissingParameter",
+		},
+		"malformed instance": {
+			map[string]string{"InstanceSpecification.InstanceId": "not-an-instance"},
+			"InvalidInstanceID.Malformed",
+		},
+		"absent instance": {
+			map[string]string{"InstanceSpecification.InstanceId": "i-0123456789abcdef0"},
+			"InvalidInstanceID.NotFound",
+		},
+		// AWS lists exactly one valid value for CopyTagsFromSource, so a request naming
+		// another is refused rather than treated as "do not copy": a caller who meant to
+		// copy tags and misspelled the source would otherwise get a silent no-op.
+		"unknown CopyTagsFromSource": {
+			map[string]string{
+				"InstanceSpecification.InstanceId": instanceID,
+				"CopyTagsFromSource":               "instance",
+			},
+			"InvalidParameterValue",
+		},
+		// "You can specify up to 40 volume IDs per request."
+		"forty-one exclusions": {manyExclusions, "InvalidParameterValue"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			params := map[string]string{"Action": "CreateSnapshots"}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			status, code, _ := ec2ErrorDetail(t, ts, params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tc.wantCode, code)
+		})
+	}
+}
+
+// TestEC2_CreateSnapshots_CopyTagsFromSourceCopiesEachVolumesOwnTags pins the scope of the
+// copy: each snapshot inherits *its own* source volume's tags, not the union of every
+// volume's, which a handler collecting tags once before the loop would produce.
+//
+// The colliding key is the other half. AWS settles neither precedence nor ordering when a
+// TagSpecification names a key a copied volume tag already carries, so substrate's choice —
+// the request wins, and the result is ordered volume-tags-then-new-keys — is pinned here
+// rather than left to whichever the implementation happened to do.
+func TestEC2_CreateSnapshots_CopyTagsFromSourceCopiesEachVolumesOwnTags(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	instanceID, rootVolumeID, dataVolumeID := ec2InstanceWithDataVolume(t, ts, 40)
+
+	for volumeID, role := range map[string]string{rootVolumeID: "root", dataVolumeID: "data"} {
+		ec2FleetXML(t, ts, map[string]string{
+			"Action":       "CreateTags",
+			"ResourceId.1": volumeID,
+			"Tag.1.Key":    "Role",
+			"Tag.1.Value":  role,
+			"Tag.2.Key":    "Keep",
+			"Tag.2.Value":  "yes",
+		}, nil)
+	}
+
+	got := ec2CreateSnapshots(t, ts, map[string]string{
+		"InstanceSpecification.InstanceId": instanceID,
+		"CopyTagsFromSource":               "volume",
+		// Collides with the volumes' own Keep tag, and introduces one they do not have.
+		"TagSpecification.1.ResourceType": "snapshot",
+		"TagSpecification.1.Tag.1.Key":    "Keep",
+		"TagSpecification.1.Tag.1.Value":  "no",
+		"TagSpecification.1.Tag.2.Key":    "Batch",
+		"TagSpecification.1.Tag.2.Value":  "b1",
+	})
+	require.Len(t, got, 2)
+
+	byRole := map[string]map[string]string{}
+	for _, snap := range got {
+		tags := map[string]string{}
+		for _, tag := range snap.Tags {
+			tags[tag.Key] = tag.Value
+		}
+		require.Contains(t, tags, "Role", "each snapshot carries its own volume's Role tag")
+		byRole[tags["Role"]] = tags
+	}
+	require.Len(t, byRole, 2, "the two snapshots must not share one Role value")
+	for role, tags := range byRole {
+		assert.Equal(t, "no", tags["Keep"], "the request's value wins the collision (%s)", role)
+		assert.Equal(t, "b1", tags["Batch"], "a key only the request names is added (%s)", role)
+		assert.Len(t, tags, 3, "no duplicate Keep entry (%s)", role)
+	}
+}
+
+// TestEC2_CopySnapshot_CopiesWithinTheRegion is CopySnapshot's fail-before, and pins the
+// three answers a caller can only get from a real copy.
+//
+// A same-region copy is the case AWS's Example 1 documents — "you can copy it within that
+// Region" — and it is the only case a single-region emulator can serve, which is what makes
+// the operation coherent here rather than a stub.
+func TestEC2_CopySnapshot_CopiesWithinTheRegion(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	sourceVolume, sourceSnap := ec2SnapshotOfSize(t, ts, 55)
+
+	var copied struct {
+		SnapshotID string `xml:"snapshotId"`
+		Tags       []struct {
+			Key   string `xml:"key"`
+			Value string `xml:"value"`
+		} `xml:"tagSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action":                          "CopySnapshot",
+		"SourceRegion":                    "us-east-1",
+		"SourceSnapshotId":                sourceSnap,
+		"Description":                     "My_snapshot",
+		"TagSpecification.1.ResourceType": "snapshot",
+		"TagSpecification.1.Tag.1.Key":    "Origin",
+		"TagSpecification.1.Tag.1.Value":  "copy",
+	}, &copied)
+
+	require.Contains(t, copied.SnapshotID, "snap-")
+	assert.NotEqual(t, sourceSnap, copied.SnapshotID, "a copy is a new snapshot")
+	require.Len(t, copied.Tags, 1, "tagSet is one of the three documented response elements")
+	assert.Equal(t, "Origin", copied.Tags[0].Key)
+
+	described := ec2DescribeSnapshots(t, ts, map[string]string{"SnapshotId.1": copied.SnapshotID})
+	require.Len(t, described, 1)
+	assert.Equal(t, int64(55), described[0].VolumeSize, "the copy is the source's size")
+	assert.Equal(t, "completed", described[0].State)
+	assert.Equal(t, "My_snapshot", described[0].Description)
+
+	// AWS: "Snapshots copies have an arbitrary source volume ID. Do not use this volume ID
+	// for any purpose." So the copy must not point at the source's volume — a caller given a
+	// reference that resolves would be invited to do exactly what that sentence forbids.
+	assert.NotEqual(t, sourceVolume, described[0].VolumeID,
+		"the copy's volumeId is arbitrary, not the source's")
+	assert.NotEmpty(t, described[0].VolumeID, "AWS always renders the member")
+
+	// And it names no volume, which is what makes AWS's warning self-enforcing.
+	//
+	// The assertion is an empty volumeSet rather than InvalidVolume.NotFound because
+	// substrate's DescribeVolumes selects by ID without resolving one — an unknown VolumeId.N
+	// narrows the answer to nothing instead of being refused. That is a separate gap from
+	// #709 and is left standing rather than widened into this PR; it is recorded so a future
+	// reader does not mistake the weaker assertion for the stronger claim.
+	var volumes struct {
+		Volumes []struct {
+			VolumeID string `xml:"volumeId"`
+		} `xml:"volumeSet>item"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "DescribeVolumes", "VolumeId.1": described[0].VolumeID,
+	}, &volumes)
+	assert.Empty(t, volumes.Volumes, "the copy's arbitrary volume ID resolves to nothing")
+}
+
+// TestEC2_CopySnapshot_EncryptionFollowsTheDocumentedRules covers the three sentences AWS
+// writes about encryption on this operation, none of which is published with an error code.
+func TestEC2_CopySnapshot_EncryptionFollowsTheDocumentedRules(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a copy of an encrypted snapshot is encrypted", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		volID := ec2CreateSizedVolume(t, ts, 25, map[string]string{"Encrypted": "true"})
+		source := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volID})
+		require.True(t, source.Encrypted)
+
+		// "Copies of encrypted snapshots are encrypted, even if you omit this parameter."
+		var copied struct {
+			SnapshotID string `xml:"snapshotId"`
+		}
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CopySnapshot", "SourceRegion": "us-east-1",
+			"SourceSnapshotId": source.SnapshotID,
+		}, &copied)
+		described := ec2DescribeSnapshots(t, ts,
+			map[string]string{"SnapshotId.1": copied.SnapshotID})
+		require.Len(t, described, 1)
+		assert.True(t, described[0].Encrypted)
+	})
+
+	t.Run("Encrypted=true encrypts a copy of an unencrypted snapshot", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		_, source := ec2SnapshotOfSize(t, ts, 25)
+
+		var copied struct {
+			SnapshotID string `xml:"snapshotId"`
+		}
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CopySnapshot", "SourceRegion": "us-east-1",
+			"SourceSnapshotId": source, "Encrypted": "true",
+		}, &copied)
+		described := ec2DescribeSnapshots(t, ts,
+			map[string]string{"SnapshotId.1": copied.SnapshotID})
+		require.Len(t, described, 1)
+		assert.True(t, described[0].Encrypted, "the parameter is what encrypts it")
+	})
+
+	t.Run("Encrypted=false is refused", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		_, source := ec2SnapshotOfSize(t, ts, 25)
+
+		// "You cannot set this parameter to false." Refusing rather than ignoring is
+		// substrate's reading: a caller who wrote false meant an unencrypted copy, and
+		// silently producing an encrypted one would be an observation they did not ask for.
+		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
+			"Action": "CopySnapshot", "SourceRegion": "us-east-1",
+			"SourceSnapshotId": source, "Encrypted": "false",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+	})
+
+	t.Run("KmsKeyId without encryption is refused", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		_, source := ec2SnapshotOfSize(t, ts, 25)
+
+		// "If KmsKeyId is specified, the encrypted state must be true."
+		status, code, message := ec2ErrorDetail(t, ts, map[string]string{
+			"Action": "CopySnapshot", "SourceRegion": "us-east-1",
+			"SourceSnapshotId": source,
+			"KmsKeyId":         "alias/ExampleAlias",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidParameterValue", code)
+		assert.Contains(t, message, "KmsKeyId")
+	})
+
+	t.Run("KmsKeyId with an encrypted source is accepted", func(t *testing.T) {
+		t.Parallel()
+		ts := newEC2TestServer(t)
+		volID := ec2CreateSizedVolume(t, ts, 25, map[string]string{"Encrypted": "true"})
+		source := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volID})
+
+		// The source's own encryption satisfies "the encrypted state must be true", so this
+		// must not be refused — the rule is about the resulting state, not the parameter.
+		ec2FleetXML(t, ts, map[string]string{
+			"Action": "CopySnapshot", "SourceRegion": "us-east-1",
+			"SourceSnapshotId": source.SnapshotID,
+			"KmsKeyId":         "alias/ExampleAlias",
+		}, nil)
+	})
+}
+
+// TestEC2_CopySnapshot_RefusesABadRequest is the parameter table.
+//
+// The cross-region row is the one that decides what kind of emulator this is.
+// SnapshotCopyUnsupported.InterRegion is a documented code whose published description —
+// "Inter-region snapshot copy is not supported for this AWS Region" — is exactly substrate's
+// position, so a consumer whose IaC copies across regions reads a refusal real EC2 also
+// issues in regions where the feature is unavailable, rather than a fabricated success.
+func TestEC2_CopySnapshot_RefusesABadRequest(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	_, source := ec2SnapshotOfSize(t, ts, 25)
+
+	for name, tc := range map[string]struct {
+		params   map[string]string
+		wantCode string
+	}{
+		"no source region": {
+			map[string]string{"SourceSnapshotId": source}, "MissingParameter",
+		},
+		"no source snapshot": {
+			map[string]string{"SourceRegion": "us-east-1"}, "MissingParameter",
+		},
+		"another region": {
+			map[string]string{"SourceRegion": "us-west-2", "SourceSnapshotId": source},
+			"SnapshotCopyUnsupported.InterRegion",
+		},
+		"malformed source": {
+			map[string]string{"SourceRegion": "us-east-1", "SourceSnapshotId": "vol-0123456789abcdef0"},
+			"InvalidSnapshotID.Malformed",
+		},
+		"absent source": {
+			map[string]string{"SourceRegion": "us-east-1", "SourceSnapshotId": "snap-0123456789abcdef0"},
+			"InvalidSnapshot.NotFound",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			params := map[string]string{"Action": "CopySnapshot"}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			before := ec2DescribeSnapshots(t, ts, map[string]string{})
+			status, code, _ := ec2ErrorDetail(t, ts, params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tc.wantCode, code)
+			assert.Len(t, ec2DescribeSnapshots(t, ts, map[string]string{}), len(before),
+				"a refused copy writes no snapshot")
+		})
+	}
+}

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -572,11 +572,37 @@ type EC2Snapshot struct {
 	// Tags holds key-value metadata tags.
 	Tags []EC2Tag `json:"tags,omitempty"`
 
+	// CreateVolumePermissions is the list of accounts and groups that may create volumes
+	// from this snapshot, as ModifySnapshotAttribute sets it and
+	// DescribeSnapshotAttribute reports it (#709).
+	//
+	// It is empty for a newly created or copied snapshot, which is what AWS describes a
+	// reset snapshot as being — "a private snapshot that can only be used by the account
+	// that created it". Substrate is single-account, so a permission here grants nothing;
+	// it is recorded intent that a caller can read back, which is the observable half of
+	// sharing.
+	CreateVolumePermissions []EC2CreateVolumePermission `json:"create_volume_permissions,omitempty"`
+
 	// AccountID is the AWS account that owns the snapshot.
 	AccountID string `json:"account_id"`
 
 	// Region is the AWS region in which the snapshot resides.
 	Region string `json:"region"`
+}
+
+// EC2CreateVolumePermission is one entry in a snapshot's create-volume permission list.
+//
+// Exactly one member is set per entry, per AWS's CreateVolumePermission: a permission names
+// either an account or the group "all". The type is comparable so that adding a permission
+// already present, or removing one that is not, needs no key function — see
+// [ec2ApplyVolumePermissions].
+type EC2CreateVolumePermission struct {
+	// UserID is the AWS account the permission is granted to.
+	UserID string `json:"user_id,omitempty"`
+
+	// Group is the group the permission is granted to. AWS's only valid value is "all",
+	// which makes the snapshot public.
+	Group string `json:"group,omitempty"`
 }
 
 // generateImageID generates a random AMI ID in the format "ami-" followed


### PR DESCRIPTION
Closes #709.

Five EC2 operations answered `InvalidAction` — the answer a caller reads as "this endpoint does not speak EC2", not "substrate has not got to it yet". `CreateSnapshot` was the whole of substrate's snapshot creation, so IaC that snapshots an instance rather than a volume, or copies a snapshot before sharing it, had nowhere to land.

## `CreateSnapshots`

Snapshots every attached volume of one instance, **ordered by device name**. That ordering is not cosmetic: `StateManager.List` returns keys in Go map order and `ec2LaunchVolumesFor` appends the root volume *last*, so an unsorted `snapshotSet` would come back differently on each run and `snapshotSet[0]` would be a coin toss. A device name is unique per instance, so sorting on it is a total order.

`ExcludeBootVolume` and `ExcludeDataVolumeId.N` (singular member, indexed, capped at AWS's 40) each drop what they name; naming the root volume in `ExcludeDataVolumeId.N` is refused with a message naming `ExcludeBootVolume`, per AWS's "If you specify the ID of the root volume, the request fails." A volume ID that is *not* attached excludes nothing rather than being refused — that is what the parameter asks for, and refusing would break a caller excluding a volume they had already detached. `CopyTagsFromSource=volume` gives each snapshot **its own** source volume's tags, and every snapshot is built and its tags checked before the first write, so a refused request leaves nothing behind.

The response item is `SnapshotInfo`, which names the state member **`state`** where `CreateSnapshot` and `DescribeSnapshots` name the same thing `status`. `createSnapshot`'s response struct could not be reused, and the test asserts the element by name so it cannot silently become `status` again.

## `CopySnapshot`

AWS's own text makes a copy coherent for a single-region emulator twice over: "if the source snapshot is in a Region, you can copy it within that Region" (its Example 1 is one), and `DestinationRegion` is a `PresignedUrl`-signing artifact rather than routing — "the snapshot copy is sent to the regional endpoint that you sent the HTTP request to". The live run confirms it: with `--source-region`, botocore adds both `PresignedUrl` and `DestinationRegion` to the body on its own, and substrate ignores both. A cross-region source is `SnapshotCopyUnsupported.InterRegion`.

The copy records a freshly generated volume ID that resolves to nothing, which is what AWS produces: "snapshots copies have an arbitrary source volume ID. Do not use this volume ID for any purpose." Rendering the source's would hand a caller a reference that resolves, inviting exactly the use that sentence forbids; omitting the member would drop an element AWS always sends.

## The attribute trio

`ModifySnapshotAttribute` reads **both** wire forms, because an SDK picks between them: structured `CreateVolumePermission.Add.N.{UserId,Group}` and flat `OperationType` + `UserId.N` + **`UserGroup.N`** — the wire member, where the CLI spells the same thing `--group-names` and an SDK spells it `GroupNames`. Sharing an encrypted snapshot publicly is refused ("you can share only unencrypted snapshots publicly"); sharing one with a named account is not. Substrate is single-account, so a permission grants nothing — it is recorded intent a caller can read back, which is the observable half of sharing.

The trio follows `ec2_instanceattribute.go` in four respects: the attribute name is validated **before** the snapshot is resolved (a bad name is a defect no retry fixes; an absent snapshot may be one the caller is still waiting on), the wrapper fields are **pointers** so exactly one attribute element marshals, present-but-empty ≠ omitted, and an attribute substrate will not answer is refused rather than answered with an invented default. `productCodes` is *answered* on the describe rather than refused — as a present but empty element — because nothing in substrate assigns a product code, so "none" is a fact about every snapshot it can produce.

## The plan correction this PR lands

**#709's "you cannot both add and remove in a single operation" is scoped to account IDs, and the issue's unscoped reading would have refused AWS's own example.** AWS's sentence is "you may add or remove specified AWS account **IDs** … but you cannot do both in a single operation", and its Example 2 adds the group `all` while removing the account `111122223333` in one request. Substrate refuses only add-account-and-remove-account, and `TestEC2_ModifySnapshotAttribute_AWSExample2Succeeds` is the test that keeps it that way.

## Provenance

**None of the five operations publishes an operation-specific error** — every Errors section points only at the common types, and `CreateSnapshots` has no Examples section at all. So each refusal is either a code from EC2's client-error table, which describes a condition rather than quoting a wire message (`SnapshotCopyUnsupported.InterRegion`, `InvalidSnapshot.NotFound`), or substrate's reading of a prose rule AWS states without naming a code: the root-volume exclusion, `Encrypted=false`, `KmsKeyId` without encryption, a group other than `all`, the public-sharing rule (from the EBS user guide), and the 500-modification cap. The `InvalidParameterValue` message *shape* is the one captured EC2 example of that code; the trailing sentence in each is AWS's own prose, because that rule is the only thing telling a caller what to send instead. `ec2UnknownSnapshotAttribute` mirrors `ec2UnknownInstanceAttribute`'s wording but explicitly does **not** claim its capture.

Three `SnapshotInfo` members are deliberately not rendered, each recorded in the code: `progress` (substrate stores none), `availabilityZone` (the Local-Zone placement member — the singular `CreateSnapshot` response has no such member — so rendering the volume's AZ would claim a local snapshot), and `outpostArn`/`sseType` (not modelled; inventing `sse-ebs` would be indistinguishable from an observation).

## Verification

Fail-before established in a throwaway worktree at the parent commit: all 18 new tests fail there, e.g. `InvalidAction` / `The action CopySnapshot is not valid for this endpoint.`

- `gofmt -l . && go build ./... && go vet ./... && golangci-lint run ./...` — clean, 0 issues
- `make test` (race) — ok; `make coverage` — emulator 83.2%, total 82.6%
- `make docs-reference docs-reference-check docs-versions` — clean
- `npm --prefix docs run build` plus an `href="#…"` vs `id="…"` diff over `dist/services.html` — no broken anchors
- `go vet -C test/e2e ./... && go test -C test/e2e ./...` — ok
- **Live AWS CLI run** against a built binary on `:4678` covering all five operations: `create-snapshots` in device order with `--copy-tags-from-source volume`, `ExcludeBootVolume`, the root-volume-by-ID refusal, a same-region `copy-snapshot` whose volume ID resolves to nothing, the cross-region and encryption refusals, both modify wire forms (`--user-ids` and `--group-names`), AWS's Example 2, the add-and-remove refusal, the encrypted-public refusal, and the reset. The CLI parses every response shape, including `State` off `SnapshotInfo`.

## One observation left standing

`DescribeVolumes` selects by `VolumeId.N` without resolving one, so an unknown ID narrows the answer to an empty set instead of answering `InvalidVolume.NotFound`. That is outside #709 and is not widened into this PR; the test comment says so, so the weaker assertion is not mistaken for the stronger claim. Worth a follow-up issue.
