### PR TITLE
feat(ec2): a snapshot's progression is seedable, so a poll loop has something to poll (#715)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,12 +141,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trailing sentence in each is AWS's own prose, because that rule is the only thing telling a
   caller what to send instead. `productCodes` is answered on the describe rather than refused —
   as a **present but empty** element — because nothing in substrate assigns a product code, so
-  "none" is a fact about every snapshot it can produce rather than an invented default. Three
-  `SnapshotInfo` members are deliberately not rendered: `progress` (substrate stores none),
-  `availabilityZone` (the Local-Zone placement member — the singular `CreateSnapshot` response
-  has no such member — so rendering the volume's AZ would claim a local snapshot), and
-  `outpostArn`/`sseType` (not modelled; inventing `sse-ebs` would be indistinguishable from an
-  observation).
+  "none" is a fact about every snapshot it can produce rather than an invented default. Two
+  `SnapshotInfo` members are deliberately not rendered: `availabilityZone` (the Local-Zone
+  placement member — the singular `CreateSnapshot` response has no such member — so rendering
+  the volume's AZ would claim a local snapshot), and `outpostArn`/`sseType` (not modelled;
+  inventing `sse-ebs` would be indistinguishable from an observation). `progress` was a third
+  until the seedable progression below gave substrate one to render.
+
+- **A snapshot's `pending → completed` progression is seedable, so a poll loop has something to
+  poll** (#715). Every snapshot substrate writes is born `completed`, so the one loop callers
+  actually write around this API — poll `DescribeSnapshots` until `status` is `completed`, which
+  is what CDK's custom resources, Terraform's `aws_ebs_snapshot` and
+  `aws ec2 wait snapshot-completed` all do — exited on its first iteration. The retry, timeout
+  and error branches such a loop carries were never taken, so a consumer whose polling is broken,
+  or which treats `error` as retryable forever, passed against substrate and failed against AWS.
+
+  `POST /v1/ec2/snapshot-status` seeds how many observations report a non-terminal state before
+  the snapshot reaches its final one, keyed by snapshot ID or `*`;
+  `DELETE /v1/ec2/snapshot-status[?snapshotId=…]` clears one seed or all. `state` defaults to
+  `pending`, `finalState` to `completed`, and both accept only the five values AWS publishes for
+  the member (`pending | completed | error | recoverable | recovering`) — a sixth is refused
+  rather than stored, because it is one no SDK can map and no consumer can branch on, so the seed
+  would look accepted and produce a response the caller's own model rejects.
+
+  **The progression is counted in observations, not measured as a duration.** `TimeController.Now`
+  advances with wall time from its baseline, so a duration seed would expire partway through a
+  test and make every "still pending" assertion depend on how long the rest of the test took —
+  the reasoning `sqs_control.go` already records. It is also the more useful unit: "the next two
+  polls see pending" is what a test of a poll loop wants to say. This is the first seed in the
+  repo that models a multi-step progression at all; #715 cited Bedrock's and SageMaker's job
+  status as precedent, but both say "without simulated time" explicitly and both are a single
+  flat value.
+
+  The **count is per snapshot** even under a `"*"` seed, which is the hazard #582 recorded for
+  the SQS seed met by separating the specification (shared, read-only) from the position through
+  it (per snapshot). Without that split, one `DescribeSnapshots` over five snapshots would burn
+  five observations off a single shared countdown and the snapshot a test was watching would
+  complete early. `EC2Plugin` gained the one `seedMu sync.Mutex` — not one per key — that
+  `SQSPlugin` and `S3Plugin` already carry, since advancing the count is a read-modify-write and
+  `StateManager` offers no compare-and-swap.
+
+  A seed governs what an **observation** reports and never rewrites the snapshot record, whose
+  `state` stays `completed`. So clearing a seed, or `POST /v1/state/reset`, makes every snapshot
+  read `completed` again, and a snapshot with no seed against it is untouched — which is how the
+  default is unchanged rather than merely believed to be. Seeds live in the state manager, so
+  they replay like any other state.
+
+  Riding along: `CreateSnapshot` and `CreateSnapshots` now render the `progress` member AWS
+  documents on the types they return, `DescribeSnapshots` renders `progress` and `statusMessage`,
+  and the `progress` filter moved out of the inert list — eleven of the operation's fourteen
+  documented filter names are now evaluated. `status` and `progress` compare against what *this*
+  request reports rather than the stored record: filtering on the record would make
+  `status=pending` select nothing at the very moment the caller is told the snapshot is pending.
+  And the observation is consumed **before** the filters run, so a snapshot a filter excludes has
+  still advanced its countdown — required, because the CLI's own waiter polls
+  `--filters Name=status,Values=completed` and would otherwise never terminate.
+
+  Provenance: the *progress schedule* is substrate's. AWS documents the member only as "the
+  progress of the snapshot, as a percentage"; the ramp (`0%`, `25%`, `50%`, `75%`, `100%` for a
+  four-observation seed) is chosen because a consumer's poll loop often logs or asserts on a
+  rising percentage. A consumer must no more assert on an exact intermediate value than it may
+  against AWS, whose own `CreateSnapshot` sample response implausibly shows a freshly created
+  snapshot at `60%`. Progress reaches `100%` for **every** terminal state rather than freezing
+  below it for a failure, on the strength of AWS's one observable data point: its
+  `restore-snapshot-from-recycle-bin` example shows `"Progress": "100%"` beside
+  `"State": "recovering"`. Two of the five seedable states, `recoverable` and `recovering`, are
+  not otherwise reachable — they mean the snapshot is in the Recycle Bin, which real
+  `DescribeSnapshots` does not return — and exist here only as something a seed can make a
+  consumer's branch see; the member's five-value enumeration is followed over the filter's
+  three-value one, per #671.
 
 ### Changed
 - **`RegisterImage` records the whole block device mapping it is sent** (#711). It read exactly
@@ -420,6 +483,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is kept because it is the code the Query protocol has always used and an SDK caller's error
   branch is written against it. The message wording in both arms is substrate's — AWS publishes
   a description of the condition, never a wire message.
+
+- **`CreateVolume` refuses a snapshot that is not usable yet** (#715). AWS's snapshot-states
+  table is a documented rule — "a snapshot can't be used while it is in the `pending` state",
+  "a snapshot can't be used if it is in the `error` state" — and substrate applied neither, so
+  a restore from a snapshot in any state succeeded. It answers `IncorrectState`/400 now,
+  checked before the size rules, since a caller told "size 8 is smaller than the snapshot" would
+  fix the size and be refused again. **This is reachable only under a seeded progression**: every
+  snapshot substrate writes is `completed`, so nothing that succeeds today starts failing.
+
+  `DeleteSnapshot` deliberately does *not* acquire the matching rule, because AWS permits it in
+  so many words: "although you can delete a snapshot that is still in progress, the snapshot must
+  complete before the deletion takes effect." #715 framed both as an open decision to be settled
+  against AWS's documentation; the documentation settles them in opposite directions. The
+  deferred-effect half of that sentence is not modelled — AWS publishes nothing observable about
+  the interval, since a caller cannot see the snapshot after the request returns either way, so
+  a delay would be a resource-internal detail rather than an API observation.
+
+  Provenance: `IncorrectState` is substrate's choice from EC2's client-error table — the code it
+  already answers with for "Volume … is not in available state" — because `CreateVolume`'s own
+  page publishes no error for the condition. The rule is AWS's; only the code and the message
+  are substrate's.
 
 ### Fixed
 - **A zone ID takes the shape AWS publishes** (#712). The derivation produced `ue11-az1` for

--- a/docs/services.md
+++ b/docs/services.md
@@ -2866,7 +2866,7 @@ one is refused on its neighbour — `tag:<key>` most conspicuously (see below).
 | DescribeInstances | `availability-zone`, `image-id`, `instance-id`, `instance-state-code`, `instance-state-name`, `instance-type`, `key-name`, `subnet-id`, `tag-key`, `tag:<key>`, `vpc-id` | the other 125 — the `network-interface.*`, `block-device-mapping.*`, `metadata-options.*`, `capacity-reservation*`, `private-dns-name-options.*`, `iam-instance-profile.*` and `operator.*` families, plus `architecture`, `platform`, `tenancy`, `root-device-type`, `owner-id` and the rest |
 | DescribeImages | `block-device-mapping.snapshot-id`, `image-id`, `tag-key`, `tag:<key>` | the other 39 — the `block-device-mapping.*` (bar `snapshot-id`), `image-watermark.*`, `product-code*`, `source-image*` and `state-reason-*` families, plus `architecture`, `creation-date`, `description`, `is-public`, `name`, `owner-alias`, `owner-id`, `platform`, `root-device-name`, `root-device-type`, `state` and the rest |
 | DescribeVolumes | `attachment.delete-on-termination`, `attachment.device`, `attachment.instance-id`, `availability-zone`, `size`, `snapshot-id`, `status`, `tag-key`, `tag:<key>`, `volume-id`, `volume-type` | `attachment.attach-time`, `attachment.status`, `availability-zone-id`, `create-time`, `encrypted`, `fast-restored`, `multi-attach-enabled`, `operator.managed`, `operator.principal` |
-| DescribeSnapshots | `description`, `encrypted`, `owner-id`, `snapshot-id`, `start-time`, `status`, `tag-key`, `tag:<key>`, `volume-id`, `volume-size` | `owner-alias`, `progress`, `storage-tier`, `transfer-type` |
+| DescribeSnapshots | `description`, `encrypted`, `owner-id`, `progress`, `snapshot-id`, `start-time`, `status`, `tag-key`, `tag:<key>`, `volume-id`, `volume-size` | `owner-alias`, `storage-tier`, `transfer-type` |
 | DescribeSubnets | `availability-zone`, `cidr-block`, `default-for-az`, `map-public-ip-on-launch`, `owner-id`, `state`, `subnet-arn`, `subnet-id`, `tag-key`, `tag:<key>`, `vpc-id`, plus AWS's four alias spellings `availabilityZone`, `cidr`, `cidrBlock` and `defaultForAz` | `availability-zone-id`/`availabilityZoneId`, `available-ip-address-count`, `customer-owned-ipv4-pool`, `enable-dns64`, `enable-lni-at-device-index`, `ipv6-native`, `map-customer-owned-ip-on-launch`, `outpost-arn`, and the three `ipv6-cidr-block-association.*` and three `private-dns-name-options-on-launch.*` filters |
 | DescribeSecurityGroups | `group-id`, `group-name`, `vpc-id` | `description`, `owner-id`, `tag-key`, `tag:<key>`, and the twenty `ip-permission.*`/`egress.ip-permission.*` rule filters |
 | DescribeRouteTables | `association.route-table-id`, `association.subnet-id`, `vpc-id` | `association.gateway-id`, `association.main`, `association.route-table-association-id`, `owner-id`, `route-table-id`, `tag-key`, `tag:<key>`, and the eleven `route.*` filters |
@@ -4816,11 +4816,24 @@ subnet's CIDR block for information to be returned for the subnet." A caller ask
 
 `DescribeSnapshots` evaluated exactly one filter — `snapshot-id` — and silently dropped the
 other thirteen, so `status=pending` or `tag:Env=prod` returned every snapshot in the
-account. Ten are now applied: `description`, `encrypted`, `owner-id`, `snapshot-id`,
-`start-time`, `status`, `tag-key`, `tag:<key>`, `volume-id` and `volume-size`. The remaining
-four — `owner-alias`, `progress`, `storage-tier` and `transfer-type` — name members
+account. Eleven are now applied: `description`, `encrypted`, `owner-id`, `progress`,
+`snapshot-id`, `start-time`, `status`, `tag-key`, `tag:<key>`, `volume-id` and `volume-size`.
+The remaining three — `owner-alias`, `storage-tier` and `transfer-type` — name members
 substrate does not render, so there is nothing to compare a value against; they are
 accepted and inert.
+
+`progress` was the fourth inert name until substrate had a progress to render (see
+[Seeding a snapshot progression](#seeding-a-snapshot-progression)). It compares against the
+percent-suffixed string the response carries, which is the form AWS's own filter text shows
+("for example, `80%`"): a caller filters on `100%`, not on `100`.
+
+**`status` and `progress` compare against what *this* request reports, not against the stored
+record.** The two differ only under a seeded progression, and that is the one case a poll loop
+cares about — filtering on the record would make `status=pending` select nothing at the very
+moment the caller is being told the snapshot is pending. It also means the CLI's own
+`aws ec2 wait snapshot-completed`, which polls
+`--filters Name=status,Values=completed`, terminates: an observation is taken before the
+filters run, so a snapshot the filter excludes has still advanced its countdown.
 
 **`Owner.N` and `RestorableBy.N`** were read by neither the ID selection nor the filters,
 and are now honoured. Both sit outside `Filter.N` and both accept `self`, an account ID, or
@@ -4851,16 +4864,17 @@ knew a real size.
 | `VolumeId` | Required, and checked against state. Absent is `MissingParameter`; a syntactically invalid ID is `InvalidVolumeID.Malformed`; one that names nothing is `InvalidVolume.NotFound` — so a snapshot cannot exist for a volume that does not |
 | `volumeSize` | The source volume's size, which is what AWS documents the member as: "the size of the volume, in GiB" |
 | `encrypted` | The source volume's. "Snapshots that are taken from encrypted volumes are automatically encrypted" |
-| `status` | `completed` at once, **not** the `pending` AWS's own sample response shows |
-| `progress` | Not rendered, for the same reason `DescribeSnapshots` renders none: substrate stores none, and `status` already says the whole of what a completed snapshot's progress would say |
+| `status` | `completed` at once by default, **not** the `pending` AWS's own sample response shows — unless a [progression is seeded](#seeding-a-snapshot-progression), in which case the snapshot is born in the seeded state |
+| `progress` | Rendered, since AWS documents it as a member of the `Snapshot` that `CreateSnapshot` returns. `100%` for an unseeded snapshot; the ramp's current position under a seed |
+| `statusMessage` | Not rendered, because AWS scopes it: "this parameter is only returned by `DescribeSnapshots`" — where an SDK reads the same element as `StateMessage`, the third of these name splits after `status`/`State` and `state`/`State` |
 | `Description`, `TagSpecification.N` | Read; the tags go through the same walk and the same [tag rules](#reserved-tag-keys) as every other tag-on-create, checked before anything is written |
 | `Location`, `OutpostArn` | Not read. Both are documented as supported only for a Local Zone or an Outpost, neither of which substrate models, so honouring them would place the snapshot somewhere substrate cannot describe it from |
 
 `status` being `completed` immediately is the deliberate divergence. Substrate advances no
 snapshot asynchronously, so a caller's waiter succeeds on its first poll rather than
-depending on wall-clock time — which is the point of a deterministic emulator. A
-**seedable** `pending → completed` progression is the shape that would let a test exercise
-the waiting path, and it is a follow-up rather than something this operation should invent.
+depending on wall-clock time — which is the point of a deterministic emulator. The waiting
+path is exercised instead by seeding it: see
+[Seeding a snapshot progression](#seeding-a-snapshot-progression).
 
 `CreateImage`'s own snapshot now reads the instance's root volume too, recording both its
 size and its ID — so an AMI made from a 40 GiB root volume reports 40 GiB through
@@ -4896,16 +4910,18 @@ table says which.
 | The root volume named in `ExcludeDataVolumeId.N` | Refused, naming `ExcludeBootVolume`. AWS: "If you specify the ID of the root volume, the request fails. To exclude the root volume, use `ExcludeBootVolume`." The code is substrate's; AWS says only that the request fails |
 | `CopyTagsFromSource` | Valid value `volume`, and any other value is refused rather than treated as "do not copy". Each snapshot inherits **its own** source volume's tags |
 | `Description`, `TagSpecification.N` | Applied to every snapshot the call creates. Where a request tag collides with a copied volume tag, the request wins — AWS settles neither the precedence nor the ordering, so both are substrate's |
-| `state` | `completed` at once, for the reason `CreateSnapshot`'s `status` is |
+| `state` | `completed` at once, for the reason `CreateSnapshot`'s `status` is — and seedable the same way. A `"*"` seed governs every snapshot in the set, each with its own countdown, so snapshotting five volumes under a two-poll seed leaves each of the five with its own two polls |
+| `progress` | Rendered, as `CreateSnapshot`'s is |
 | `Location`, `OutpostArn` | Not read, as on `CreateSnapshot` |
 
 The response element is `snapshotSet` of `SnapshotInfo`, which names the state member
 **`state`** where `CreateSnapshot` and `DescribeSnapshots` both name the same thing `status`.
-A caller unmarshalling `SnapshotInfo` reads `State`. `progress`, `availabilityZone`,
-`outpostArn` and `sseType` are not rendered: substrate stores no progress, `availabilityZone` is
-the Local-Zone placement member — the singular `CreateSnapshot` response has no such member —
-so rendering the volume's AZ would claim a local snapshot, and neither Outposts nor a specific
-server-side encryption type is modelled.
+A caller unmarshalling `SnapshotInfo` reads `State`. `availabilityZone`, `outpostArn` and
+`sseType` are not rendered: `availabilityZone` is the Local-Zone placement member — the
+singular `CreateSnapshot` response has no such member — so rendering the volume's AZ would
+claim a local snapshot, and neither Outposts nor a specific server-side encryption type is
+modelled. `SnapshotInfo` has no `statusMessage` member at all; AWS publishes that one on
+`Snapshot` alone.
 
 A refused request writes nothing: every snapshot is built and its tags checked before the
 first write, so a five-volume instance whose fourth volume carries a reserved tag key does not
@@ -5161,6 +5177,89 @@ curl -X DELETE http://localhost:4566/v1/ec2/fleet-shortfall
 any. The shortfall is spread across the request's capacity pools, so `errorSet`
 reports one item per pool that came up short, and `DescribeFleets` reports the
 result in `fulfilledCapacity`.
+
+### Seeding a snapshot progression
+
+Every snapshot substrate writes is born `completed`, so the one loop callers actually write
+around this API — poll `DescribeSnapshots` until `status` is `completed`, which is what CDK's
+custom resources, Terraform's `aws_ebs_snapshot` and `aws ec2 wait snapshot-completed` all do —
+exits on its first iteration. The retry, timeout and error branches such a loop carries are
+never taken, so a consumer whose polling is broken, or which treats `error` as retryable
+forever, passes against substrate and fails against AWS.
+
+```bash
+# The next four observations report pending; the fifth reports completed.
+curl -X POST http://localhost:4566/v1/ec2/snapshot-status \
+  -d '{"snapshotId":"*","pendingObservations":4}'
+
+# Fail immediately, with the diagnostic AWS publishes for a failed copy. DescribeSnapshots
+# renders it as `statusMessage`, which an SDK reads as `StateMessage`.
+curl -X POST http://localhost:4566/v1/ec2/snapshot-status \
+  -d '{"snapshotId":"snap-0abc123","pendingObservations":0,
+       "finalState":"error","stateMessage":"Given key ID is not accessible"}'
+
+# Clear one seed, or all of them.
+curl -X DELETE 'http://localhost:4566/v1/ec2/snapshot-status?snapshotId=snap-0abc123'
+curl -X DELETE http://localhost:4566/v1/ec2/snapshot-status
+```
+
+A seeded `error` is what makes the CLI waiter's own failure path reachable: botocore defines
+`SnapshotCompleted` with a `pathAny Snapshots[].State == error` acceptor alongside the success
+one — a fact the CLI's own documentation page omits — so `aws ec2 wait snapshot-completed`
+exits 255 with "encountered a terminal failure state" rather than retrying for ten minutes.
+That is the branch a consumer's error handling exists for, and it was unreachable before.
+
+`snapshotId` matches one snapshot ID or `*` (the default) for any; an ID-scoped seed wins over
+the wildcard. `state` defaults to `pending` and `finalState` to `completed`, and both accept any
+of the five values AWS publishes for the member — `pending`, `completed`, `error`,
+`recoverable`, `recovering`. A value outside those five is refused rather than stored: it is one
+no SDK can map and no consumer can branch on, so the seed would look accepted and produce a
+response the caller's own model rejects. Seeding again restarts the countdown, so a test that
+seeds twice gets two full progressions rather than the remainder of the first.
+
+**The progression is counted in observations, not measured as a duration.** The simulated clock
+advances with wall time from its baseline, so a duration seed would expire partway through a
+test and make every "still pending" assertion depend on how long the rest of the test took —
+which no test here may be. This follows the reasoning the SQS consistency seed records. A count
+is also the more useful unit: "the next two polls see pending" is what a test of a poll loop
+wants to say.
+
+The count is **per snapshot** even under a `"*"` seed. Without that, one `DescribeSnapshots`
+over five snapshots would burn five observations off a single shared countdown, and the
+snapshot a test was actually watching would complete early.
+
+`progress` is the fraction of the countdown already spent, so a four-observation seed reports
+`0%`, `25%`, `50%`, `75%` and then `100%`. AWS documents the member only as "the progress of the
+snapshot, as a percentage", so the *schedule* is substrate's; it is deterministic, which is the
+property that matters, and a consumer must no more assert on an exact intermediate value than it
+may against AWS — whose own `CreateSnapshot` sample response implausibly shows a freshly created
+snapshot at `60%`. Progress reaches `100%` whatever the terminal state, rather than freezing
+below it for a failure: AWS's one observable data point says so, its
+`restore-snapshot-from-recycle-bin` example showing `"Progress": "100%"` beside
+`"State": "recovering"`. So progress measures how far the progression ran, not whether it
+succeeded.
+
+Two operations read the state without consuming an observation, since neither is a poll:
+
+- **`CreateVolume`** refuses a snapshot that is not `completed` with `IncorrectState`. The rule
+  is AWS's — its snapshot-states table says "a snapshot can't be used while it is in the
+  `pending` state" and "a snapshot can't be used if it is in the `error` state" — though
+  `CreateVolume`'s own page publishes no error for it, so the code is substrate's choice from
+  EC2's client-error table, the one it already answers with for a volume in the wrong state.
+- **`DeleteSnapshot`** does *not* refuse one, because AWS permits it in so many words:
+  "although you can delete a snapshot that is still in progress, the snapshot must complete
+  before the deletion takes effect." The deferred-effect half is not modelled — AWS publishes
+  nothing observable about the interval, since a caller cannot see the snapshot after the
+  request returns either way.
+
+A seed governs what an *observation* reports and never rewrites the snapshot record, whose
+`state` stays `completed`. So clearing a seed — or `POST /v1/state/reset`, which clears the
+whole namespace — makes every snapshot read `completed` again, and a snapshot with no seed
+against it is untouched. Seeds live in the state manager, so they replay like any other state.
+
+There is no Python helper for this endpoint: `pytest_substrate`'s seeding helpers are hardcoded
+to the Athena, Redshift Data and Timestream result endpoints, so drive this one with raw HTTP,
+as the fleet seed above is driven.
 
 ### CloudFormation resource types
 

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -34,6 +35,11 @@ type EC2Plugin struct {
 	// registry built without [WithPluginAuth], in which case a fleet launches exactly
 	// as it did before (#673).
 	auth *AuthController
+
+	// seedMu serializes advancing a seeded snapshot progression. It is one lock rather
+	// than one per snapshot for the reason [EC2Plugin.observeSnapshotStatus] records, the
+	// same shape [SQSPlugin.consumeQueueMiss] carries (#582).
+	seedMu sync.Mutex
 }
 
 // Name returns the service name "ec2".
@@ -6074,6 +6080,30 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 		if awsErr := ec2RequireResource(ec2SnapshotIDKind, snapshotID, found); awsErr != nil {
 			return nil, awsErr
 		}
+		// A snapshot that is not completed cannot be cloned (#715). AWS's snapshot-states
+		// table is the rule — "a snapshot can't be used while it is in the pending state" and
+		// "a snapshot can't be used if it is in the error state" — and it is a documented rule
+		// rather than an inference, though CreateVolume's own page publishes no error for it.
+		// IncorrectState is substrate's choice from EC2's client-error table, the code it
+		// already answers with for "Volume … is not in available state"; per #671 the rule is
+		// AWS's and only the code is substrate's.
+		//
+		// This is checked before the size rules because it is the more fundamental refusal: a
+		// caller told "size 8 is smaller than the snapshot" would fix the size and be refused
+		// again. And it reads the observation, not the record, so an unseeded snapshot — every
+		// snapshot substrate writes — is unaffected and nothing that succeeds today fails.
+		observed, obsErr := p.peekSnapshotStatus(snap)
+		if obsErr != nil {
+			return nil, obsErr
+		}
+		if observed.State != "completed" {
+			return nil, &AWSError{
+				Code: "IncorrectState",
+				Message: fmt.Sprintf("Snapshot %s is in %s state; a volume can only be created from a completed snapshot",
+					snapshotID, observed.State),
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
 		switch {
 		case sizeStr == "":
 			size = int(snap.VolumeSize)
@@ -6470,6 +6500,20 @@ func (p *EC2Plugin) detachVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 // rule. Reporting InUse for a malformed ID would tell a caller an AMI holds something that
 // cannot be a snapshot ID at all.
 //
+// # Why the snapshot's state is not consulted
+//
+// A seeded pending snapshot (#715) is deleted here as readily as a completed one, and neither
+// the peek nor the observation is taken — unlike [EC2Plugin.createVolume], which refuses one.
+// AWS documents the difference explicitly: "although you can delete a snapshot that is still in
+// progress, the snapshot must complete before the deletion takes effect." So deletion is
+// permitted, and there is no error code for the case.
+//
+// The deferred-effect half of that sentence is not modeled. AWS publishes nothing observable
+// about the interval — a caller cannot see the snapshot after the DeleteSnapshot returns
+// either way, since real DescribeSnapshots stops reporting it — so a delay here would be a
+// resource-internal detail rather than an API observation, which is the boundary CLAUDE.md
+// draws.
+//
 // Provenance: InvalidSnapshot.InUse is not on API_DeleteSnapshot.html — that page's Errors
 // section is empty. It comes from EC2's client-error table, whose entry describes the
 // condition ("The snapshot that you are trying to delete is in use by one or more AMIs")
@@ -6505,13 +6549,20 @@ func (p *EC2Plugin) deleteSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AW
 }
 
 // describeSnapshots lists EBS snapshots owned by the account, honoring an optional list of
-// SnapshotId.N parameters, Owner.N and RestorableBy.N, and the ten Filter.N names
+// SnapshotId.N parameters, Owner.N and RestorableBy.N, and the eleven Filter.N names
 // [ec2SnapshotMatchesFilter] evaluates.
 //
 // The three selectors compose as AWS documents: a snapshot must satisfy the ID list, both
 // account scopes and every filter. ids.match runs first so that a snapshot excluded by a
 // filter still counts as resolved for [ec2IDFilter.unresolved] — a named ID that exists is
-// not "not found" merely because a filter rejected it.
+// not "not found" merely because a filter rejected it. It also runs first so that a request
+// naming one snapshot does not advance the seeded progression of every *other* snapshot in the
+// region, which would spend a countdown a test meant for the snapshot it was polling.
+//
+// This is the operation a consumer's wait loop polls, so it is the operation a seeded
+// progression counts (#715): status and progress come from [EC2Plugin.observeSnapshotStatus]
+// rather than from the record, and with no seed in place they are the record's own state at
+// 100%.
 func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	ids := newEC2IDFilter(extractIndexedParams(req.Params, "SnapshotId"), ec2SnapshotIDKind)
 	if err := ids.validate(); err != nil {
@@ -6530,16 +6581,24 @@ func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (
 		return nil, fmt.Errorf("ec2 describeSnapshots list: %w", err)
 	}
 
+	// progress is rendered unconditionally — "the progress of the snapshot, as a percentage",
+	// which AWS's own DescribeSnapshots example shows as 100% for a completed snapshot — while
+	// statusMessage carries omitempty, because AWS documents it as populated only when a copy
+	// fails ("this field displays error state details to help you diagnose why the error
+	// occurred"). A statusMessage on every snapshot would claim a diagnostic exists for one
+	// that succeeded.
 	type snapshotItem struct {
-		SnapshotID  string       `xml:"snapshotId"`
-		VolumeID    string       `xml:"volumeId,omitempty"`
-		VolumeSize  int64        `xml:"volumeSize"`
-		State       string       `xml:"status"`
-		StartTime   string       `xml:"startTime"`
-		Encrypted   bool         `xml:"encrypted"`
-		Description string       `xml:"description,omitempty"`
-		OwnerID     string       `xml:"ownerId"`
-		Tags        []ec2TagItem `xml:"tagSet>item"`
+		SnapshotID    string       `xml:"snapshotId"`
+		VolumeID      string       `xml:"volumeId,omitempty"`
+		VolumeSize    int64        `xml:"volumeSize"`
+		State         string       `xml:"status"`
+		StatusMessage string       `xml:"statusMessage,omitempty"`
+		StartTime     string       `xml:"startTime"`
+		Progress      string       `xml:"progress"`
+		Encrypted     bool         `xml:"encrypted"`
+		Description   string       `xml:"description,omitempty"`
+		OwnerID       string       `xml:"ownerId"`
+		Tags          []ec2TagItem `xml:"tagSet>item"`
 	}
 	type response struct {
 		XMLName   xml.Name       `xml:"DescribeSnapshotsResponse"`
@@ -6563,19 +6622,31 @@ func (p *EC2Plugin) describeSnapshots(reqCtx *RequestContext, req *AWSRequest) (
 		if !owners.match(snap) || !restorableBy.match(snap) {
 			continue
 		}
-		if !ec2SnapshotMatchesFilters(snap, filters) {
+		// The observation is taken — and a seeded countdown advanced — before the filters
+		// run, so a snapshot a filter then excludes has still been observed. That is
+		// deliberate: the AWS CLI's own snapshot-completed waiter polls
+		// `DescribeSnapshots --filters Name=status,Values=completed` and waits for a
+		// non-empty answer, so a loop written that way would never advance a countdown that
+		// only counted the snapshots it selected.
+		observed, obsErr := p.observeSnapshotStatus(snap)
+		if obsErr != nil {
+			return nil, obsErr
+		}
+		if !ec2SnapshotMatchesFilters(snap, observed, filters) {
 			continue
 		}
 		resp.Snapshots = append(resp.Snapshots, snapshotItem{
-			SnapshotID:  snap.SnapshotID,
-			VolumeID:    snap.VolumeID,
-			VolumeSize:  snap.VolumeSize,
-			State:       snap.State,
-			StartTime:   snap.StartTime,
-			Encrypted:   snap.Encrypted,
-			Description: snap.Description,
-			OwnerID:     snap.AccountID,
-			Tags:        ec2TagItems(snap.Tags),
+			SnapshotID:    snap.SnapshotID,
+			VolumeID:      snap.VolumeID,
+			VolumeSize:    snap.VolumeSize,
+			State:         observed.State,
+			StatusMessage: observed.StateMessage,
+			StartTime:     snap.StartTime,
+			Progress:      observed.Progress,
+			Encrypted:     snap.Encrypted,
+			Description:   snap.Description,
+			OwnerID:       snap.AccountID,
+			Tags:          ec2TagItems(snap.Tags),
 		})
 	}
 	if err := ids.unresolved(); err != nil {

--- a/emulator/ec2_snapshot_control.go
+++ b/emulator/ec2_snapshot_control.go
@@ -1,0 +1,391 @@
+package emulator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+)
+
+// ec2SnapCtrlNamespace is the state namespace for EC2 snapshot control-plane (seed) data.
+const ec2SnapCtrlNamespace = "ec2-snap-ctrl"
+
+// ec2SnapshotProgression is a seeded pending → terminal snapshot progression (#715).
+//
+// A snapshot in substrate is born completed, so the one loop callers actually write around
+// this API — poll DescribeSnapshots until status is completed, which is what CDK's custom
+// resources, Terraform's aws_ebs_snapshot and the CLI's own snapshot-completed waiter all do —
+// exits on its first iteration and never exercises the path it exists for. A consumer whose
+// polling is broken, or which treats error as retryable forever, passes against substrate and
+// fails against AWS. Seeding is what makes the transition observable.
+//
+// # Why the progression is counted in observations rather than measured as a duration
+//
+// [TimeController.Now] advances with wall time from its baseline, so a duration seed would
+// expire partway through a test and make every "still pending" assertion depend on how long
+// the rest of the test took — which no test here may be. A count of observations is exactly
+// reproducible, and it is the same choice [sqsConsistencySeed] records for the same reason.
+// It is also the more useful unit: "the next two polls see pending" is what a test of a poll
+// loop actually wants to say.
+//
+// # What a seed governs
+//
+// A seed governs what an observation *reports*; it never rewrites the snapshot record. So
+// clearing the seed — or POST /v1/state/reset, which clears the whole namespace — makes every
+// snapshot read completed again, and an unseeded snapshot is untouched.
+type ec2SnapshotProgression struct {
+	// SnapshotID is the snapshot the seed applies to, or "*" for any snapshot.
+	//
+	// A snapshot created *after* a "*" seed is in place is born in State, which is what
+	// makes the create → poll → completed sequence testable end to end. An ID-scoped seed
+	// necessarily names a snapshot that already exists, since the ID does not exist before
+	// the create.
+	SnapshotID string `json:"snapshotId"`
+
+	// PendingObservations is the number of DescribeSnapshots observations that report State
+	// before the snapshot reaches FinalState. Zero means the snapshot is in FinalState from
+	// the start, which is how error is seeded as an immediate terminal outcome.
+	PendingObservations int `json:"pendingObservations"`
+
+	// State is what the snapshot reports while the countdown runs. Defaults to "pending".
+	State string `json:"state"`
+
+	// FinalState is what it reports once the countdown is exhausted. Defaults to
+	// "completed".
+	FinalState string `json:"finalState"`
+
+	// StateMessage is the statusMessage rendered alongside a terminal state other than
+	// completed.
+	//
+	// It is optional and has no default, because AWS's own member is narrow: "if a snapshot
+	// copy operation fails (for example, if the proper AWS KMS permissions are not obtained)
+	// this field displays error state details to help you diagnose why the error occurred",
+	// and "this parameter is only returned by DescribeSnapshots". So substrate renders it
+	// only where AWS does, and only when a seed supplies the text — inventing a diagnostic
+	// would be indistinguishable to a caller from an observation.
+	StateMessage string `json:"stateMessage"`
+}
+
+// ec2SnapshotStates is the snapshot-state enumeration, which AWS publishes identically as the
+// Valid Values of Snapshot.status and of SnapshotInfo.state.
+//
+// A seed naming anything else is refused at the endpoint rather than stored, because a state
+// outside the enumeration is one no SDK can map and no consumer can branch on — the seed would
+// look accepted and produce a response the caller's own model rejects.
+//
+// Two of the five are seedable but not otherwise reachable, and that is deliberate. AWS's
+// DescribeSnapshots *filter* documents only three values ("status - The status of the snapshot
+// (pending | completed | error)") where the member documents five, because recoverable means
+// the snapshot is in the Recycle Bin — which real DescribeSnapshots does not return at all,
+// ListSnapshotsInRecycleBin does. Substrate models neither the Recycle Bin nor that operation,
+// so the two states exist here only as something a seed can make a consumer's branch see. The
+// member's enumeration is the one followed, per #671: what the API model states.
+var ec2SnapshotStates = []string{"pending", "completed", "error", "recoverable", "recovering"}
+
+// ec2SnapCtrlKeyPrefix is the key prefix for every progression seed, used to clear all.
+const ec2SnapCtrlKeyPrefix = "status:"
+
+// ec2SnapObservedPrefix is the key prefix for the per-snapshot observation counters.
+const ec2SnapObservedPrefix = "observed:"
+
+// ec2SnapCtrlKey returns the state key for a progression seed. Snapshot-scoped seeds use
+// "status:{id}"; the wildcard uses "status:*".
+func ec2SnapCtrlKey(snapshotID string) string {
+	if snapshotID == "" {
+		snapshotID = "*"
+	}
+	return ec2SnapCtrlKeyPrefix + snapshotID
+}
+
+// ec2SnapObservedKey returns the state key holding how many observations one snapshot has
+// already had.
+//
+// The count is keyed by snapshot ID even when the seed that governs it is the "*" wildcard,
+// which is what keeps one DescribeSnapshots call over five snapshots from burning five
+// observations off a single shared countdown. That is the hazard #582 records for the SQS
+// seed, met here by separating the specification (shared, read-only) from the progress
+// through it (per snapshot).
+func ec2SnapObservedKey(snapshotID string) string {
+	return ec2SnapObservedPrefix + snapshotID
+}
+
+// ec2SnapshotObserved is the per-snapshot countdown position.
+type ec2SnapshotObserved struct {
+	// Observations is how many observations the snapshot has already had.
+	Observations int `json:"observations"`
+}
+
+// ec2SnapshotObservation is what one observation of a snapshot reports: the state and
+// progress to render, and a statusMessage when the seed supplies one for a terminal state
+// other than completed.
+type ec2SnapshotObservation struct {
+	State        string
+	Progress     string
+	StateMessage string
+}
+
+// ec2UnseededObservation is what a snapshot with no seed against it reports: the record's own
+// state — "completed", for every snapshot substrate writes — at 100%.
+//
+// It is the default the whole of the existing suite pins, and keeping it a named function is
+// what makes "no seed changes nothing" checkable in one place rather than inferred from two
+// early returns.
+func ec2UnseededObservation(snap EC2Snapshot) ec2SnapshotObservation {
+	return ec2SnapshotObservation{State: snap.State, Progress: "100%"}
+}
+
+// resolveSnapshotProgression returns the seeded progression for one snapshot, matching the
+// exact ID first and then the "*" wildcard, or (nil, nil) when none applies.
+func (p *EC2Plugin) resolveSnapshotProgression(snapshotID string) (*ec2SnapshotProgression, error) {
+	goCtx := context.Background()
+	for _, key := range []string{ec2SnapCtrlKey(snapshotID), ec2SnapCtrlKey("*")} {
+		data, err := p.state.Get(goCtx, ec2SnapCtrlNamespace, key)
+		if err != nil {
+			return nil, fmt.Errorf("ec2 resolveSnapshotProgression get: %w", err)
+		}
+		if data == nil {
+			continue
+		}
+		var seed ec2SnapshotProgression
+		if err := json.Unmarshal(data, &seed); err != nil {
+			return nil, fmt.Errorf("ec2 resolveSnapshotProgression unmarshal: %w", err)
+		}
+		return &seed, nil
+	}
+	return nil, nil //nolint:nilnil // (nil, nil) = "no seed applies", handled by caller.
+}
+
+// peekSnapshotStatus reports what the snapshot would observe right now, without advancing its
+// countdown.
+//
+// Three callers need the state without consuming an observation, because none of them is a
+// poll: CreateSnapshot and CreateSnapshots, which report the state a snapshot is born in, and
+// CreateVolume, which refuses a snapshot that is not usable yet. Counting those against a
+// budget the caller meant to spend on polling would make "pendingObservations: 2" mean two
+// polls in one test and one in another.
+//
+// DeleteSnapshot needs neither peek nor observation: AWS permits deleting a snapshot in
+// progress, so its answer does not depend on the state at all — see [EC2Plugin.deleteSnapshot].
+func (p *EC2Plugin) peekSnapshotStatus(snap EC2Snapshot) (ec2SnapshotObservation, error) {
+	seed, err := p.resolveSnapshotProgression(snap.SnapshotID)
+	if err != nil {
+		return ec2SnapshotObservation{}, err
+	}
+	if seed == nil {
+		return ec2UnseededObservation(snap), nil
+	}
+	seen, err := p.snapshotObservations(snap.SnapshotID)
+	if err != nil {
+		return ec2SnapshotObservation{}, err
+	}
+	return seed.observation(seen), nil
+}
+
+// observeSnapshotStatus reports what this observation of the snapshot sees and advances its
+// countdown by one.
+//
+// It takes one dedicated mutex rather than one per snapshot ID. Advancing the counter is a
+// read-modify-write and [StateManager] offers no compare-and-swap — Get/Put/Delete/List only,
+// with [MemoryStateManager] last-write-wins — so two concurrent describes of the same snapshot
+// could both read a count of 1, both write 2, and consume one observation twice, making a test
+// that asserts "the third poll completes" flake. One lock means there is no lock order to get
+// wrong, and seed consumption is a harness-frequency operation, so it costs nothing.
+// [SQSPlugin.consumeQueueMiss] and [S3Plugin.consumeConditionalConflict] hold the same shape.
+//
+// The guarantee is bounded the way those are: it is process-local, which covers substrate's
+// single-process topology and would not hold across two emulator processes sharing one state
+// backend.
+func (p *EC2Plugin) observeSnapshotStatus(snap EC2Snapshot) (ec2SnapshotObservation, error) {
+	p.seedMu.Lock()
+	defer p.seedMu.Unlock()
+
+	seed, err := p.resolveSnapshotProgression(snap.SnapshotID)
+	if err != nil {
+		return ec2SnapshotObservation{}, err
+	}
+	if seed == nil {
+		return ec2UnseededObservation(snap), nil
+	}
+	seen, err := p.snapshotObservations(snap.SnapshotID)
+	if err != nil {
+		return ec2SnapshotObservation{}, err
+	}
+	observation := seed.observation(seen)
+
+	// The counter is advanced only while it can still change an answer. Past the end of the
+	// countdown the snapshot is terminal, so a further Put would rewrite state on every
+	// describe of a completed snapshot for no observable difference — and every one of those
+	// writes lands in the event log a replay has to walk.
+	if seen < seed.PendingObservations {
+		data, marshalErr := json.Marshal(ec2SnapshotObserved{Observations: seen + 1})
+		if marshalErr != nil {
+			return ec2SnapshotObservation{}, fmt.Errorf("ec2 observeSnapshotStatus marshal: %w", marshalErr)
+		}
+		if putErr := p.state.Put(context.Background(), ec2SnapCtrlNamespace,
+			ec2SnapObservedKey(snap.SnapshotID), data); putErr != nil {
+			return ec2SnapshotObservation{}, fmt.Errorf("ec2 observeSnapshotStatus put: %w", putErr)
+		}
+	}
+	return observation, nil
+}
+
+// snapshotObservations returns how many observations one snapshot has already had, zero when
+// it has had none.
+func (p *EC2Plugin) snapshotObservations(snapshotID string) (int, error) {
+	data, err := p.state.Get(context.Background(), ec2SnapCtrlNamespace, ec2SnapObservedKey(snapshotID))
+	if err != nil {
+		return 0, fmt.Errorf("ec2 snapshotObservations get: %w", err)
+	}
+	if data == nil {
+		return 0, nil
+	}
+	var observed ec2SnapshotObserved
+	if err := json.Unmarshal(data, &observed); err != nil {
+		return 0, fmt.Errorf("ec2 snapshotObservations unmarshal: %w", err)
+	}
+	return observed.Observations, nil
+}
+
+// observation returns what the seen-th observation of a seeded snapshot reports, counting from
+// zero.
+//
+// # The progress ramp
+//
+// progress is the fraction of the countdown already spent, so a seed of four pending
+// observations reports 0%, 25%, 50% and 75% and then 100%. A single value held for the whole
+// pending phase would satisfy "below 100%", but a caller's poll loop very often logs or asserts
+// on a rising percentage, and a ramp is what lets that be tested.
+//
+// AWS documents the member only as "the progress of the snapshot, as a percentage", and the
+// trailing % comes from its filter text ("for example, 80%") and from its own examples rather
+// than from the member's description. So the *schedule* is substrate's. It is deterministic,
+// which is the property that matters here; a consumer must no more assert on an exact
+// intermediate value than it may against AWS, whose CreateSnapshot sample response implausibly
+// shows a freshly created snapshot at 60%.
+//
+// progress reaches 100% when the countdown is exhausted **whatever the terminal state is**,
+// rather than freezing below it for a state other than completed. AWS's one observable
+// data point says so: its restore-snapshot-from-recycle-bin example shows "Progress": "100%"
+// beside "State": "recovering". Progress therefore measures how far the progression ran, not
+// whether it succeeded — which is exactly the distinction a consumer that polls progress
+// instead of status gets wrong, and now a test can catch that.
+func (seed ec2SnapshotProgression) observation(seen int) ec2SnapshotObservation {
+	pendingState := seed.State
+	if pendingState == "" {
+		pendingState = "pending"
+	}
+	finalState := seed.FinalState
+	if finalState == "" {
+		finalState = "completed"
+	}
+
+	if total := seed.PendingObservations; seen < total {
+		return ec2SnapshotObservation{
+			State:    pendingState,
+			Progress: fmt.Sprintf("%d%%", seen*100/total),
+		}
+	}
+	return ec2SnapshotObservation{
+		State:        finalState,
+		Progress:     "100%",
+		StateMessage: seed.StateMessage,
+	}
+}
+
+// handleEC2SeedSnapshotStatus handles POST /v1/ec2/snapshot-status. It seeds how many
+// DescribeSnapshots observations report a non-terminal state before the snapshot reaches its
+// final one, for snapshots matching the given ID (default "*"). Body:
+// {"snapshotId","pendingObservations","state","finalState","stateMessage"}.
+//
+// Seeding resets the countdown for every snapshot the seed governs, so a test that seeds twice
+// gets two full progressions rather than the remainder of the first.
+func (s *Server) handleEC2SeedSnapshotStatus(w http.ResponseWriter, r *http.Request) {
+	var seed ec2SnapshotProgression
+	if err := json.NewDecoder(r.Body).Decode(&seed); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+	if seed.PendingObservations < 0 {
+		http.Error(w, `{"error":"pendingObservations must be >= 0"}`, http.StatusBadRequest)
+		return
+	}
+	for _, state := range []string{seed.State, seed.FinalState} {
+		if state != "" && !slices.Contains(ec2SnapshotStates, state) {
+			http.Error(w, fmt.Sprintf(`{"error":"unknown snapshot state %q, want one of %v"}`,
+				state, ec2SnapshotStates), http.StatusBadRequest)
+			return
+		}
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.state.Put(r.Context(), ec2SnapCtrlNamespace, ec2SnapCtrlKey(seed.SnapshotID), data); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if err := s.clearSnapshotObservations(r, seed.SnapshotID); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true, "snapshotId": ec2SnapCtrlKey(seed.SnapshotID)})
+}
+
+// handleEC2ClearSnapshotStatus handles DELETE /v1/ec2/snapshot-status. With ?snapshotId=... it
+// removes that seed; without it removes all. Either way it also clears the countdown position
+// of the snapshots the seed governed, so a later seed starts from the beginning.
+func (s *Server) handleEC2ClearSnapshotStatus(w http.ResponseWriter, r *http.Request) {
+	if id := r.URL.Query().Get("snapshotId"); id != "" {
+		if err := s.state.Delete(r.Context(), ec2SnapCtrlNamespace, ec2SnapCtrlKey(id)); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		if err := s.clearSnapshotObservations(r, id); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+		return
+	}
+	for _, prefix := range []string{ec2SnapCtrlKeyPrefix, ec2SnapObservedPrefix} {
+		keys, err := s.state.List(r.Context(), ec2SnapCtrlNamespace, prefix)
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+		for _, k := range keys {
+			if err := s.state.Delete(r.Context(), ec2SnapCtrlNamespace, k); err != nil {
+				http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+	writeJSONDebug(w, s.logger, map[string]any{"ok": true})
+}
+
+// clearSnapshotObservations resets the countdown position of the snapshots a seed governs: one
+// snapshot for an ID-scoped seed, every snapshot for the "*" wildcard.
+//
+// The wildcard case has to sweep the prefix rather than delete one key, because the counters
+// are per snapshot by design — see [ec2SnapObservedKey] — so there is no single key holding a
+// wildcard seed's progress.
+func (s *Server) clearSnapshotObservations(r *http.Request, snapshotID string) error {
+	if snapshotID != "" && snapshotID != "*" {
+		if err := s.state.Delete(r.Context(), ec2SnapCtrlNamespace, ec2SnapObservedKey(snapshotID)); err != nil {
+			return fmt.Errorf("ec2 clear snapshot observations %s: %w", snapshotID, err)
+		}
+		return nil
+	}
+	keys, err := s.state.List(r.Context(), ec2SnapCtrlNamespace, ec2SnapObservedPrefix)
+	if err != nil {
+		return fmt.Errorf("ec2 list snapshot observations: %w", err)
+	}
+	for _, k := range keys {
+		if err := s.state.Delete(r.Context(), ec2SnapCtrlNamespace, k); err != nil {
+			return fmt.Errorf("ec2 clear snapshot observations %s: %w", k, err)
+		}
+	}
+	return nil
+}

--- a/emulator/ec2_snapshot_control_test.go
+++ b/emulator/ec2_snapshot_control_test.go
@@ -1,0 +1,467 @@
+package emulator_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #715's surface: a snapshot's status and progress can be seeded so that a consumer's
+// poll-until-completed loop has something to poll.
+//
+// Every assertion is at HTTP level, because the whole of the defect was observable only
+// through a response: a snapshot in substrate is born completed, so `aws ec2 wait
+// snapshot-completed` — and CDK's, Terraform's and every hand-written equivalent — exits on
+// its first iteration and the retry, timeout and error branches it carries are never taken.
+// A consumer whose polling is broken passed against substrate and failed against AWS.
+
+// ec2SeedSnapshotStatus POSTs a snapshot-progression seed to the control plane.
+func ec2SeedSnapshotStatus(t *testing.T, ts *httptest.Server, body string) {
+	t.Helper()
+	resp, err := http.Post(ts.URL+"/v1/ec2/snapshot-status", "application/json", strings.NewReader(body))
+	require.NoError(t, err, "seed snapshot status")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		got, _ := io.ReadAll(resp.Body)
+		t.Fatalf("seed snapshot status = %d: %s", resp.StatusCode, got)
+	}
+}
+
+// ec2ClearSnapshotStatus DELETEs a progression seed; an empty snapshotID clears every seed.
+func ec2ClearSnapshotStatus(t *testing.T, ts *httptest.Server, snapshotID string) {
+	t.Helper()
+	u := ts.URL + "/v1/ec2/snapshot-status"
+	if snapshotID != "" {
+		u += "?snapshotId=" + snapshotID
+	}
+	req, err := http.NewRequest(http.MethodDelete, u, nil)
+	require.NoError(t, err, "build clear request")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "clear snapshot status")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		got, _ := io.ReadAll(resp.Body)
+		t.Fatalf("clear snapshot status = %d: %s", resp.StatusCode, got)
+	}
+}
+
+// ec2DescribeOneSnapshot describes exactly one snapshot by ID, which is what a poll loop does.
+//
+// Naming the ID matters and is not just narrowing: describeSnapshots advances the countdown of
+// every snapshot it observes, so describing the whole region would spend an observation on
+// snapshots the test was not polling.
+func ec2DescribeOneSnapshot(t *testing.T, ts *httptest.Server, snapshotID string) describedSnapshot {
+	t.Helper()
+	got := ec2DescribeSnapshots(t, ts, map[string]string{"SnapshotId.1": snapshotID})
+	require.Len(t, got, 1)
+	return got[0]
+}
+
+// TestEC2_SnapshotProgression_PollsToCompleted is the operation's fail-before: without a seed
+// the first observation is already "completed", so this whole sequence collapses to one line.
+//
+// The progress ramp is asserted value by value rather than only "not 100%", because a rising
+// percentage is what a consumer that logs or asserts on progress reads — and because a
+// single frozen value would satisfy a laxer assertion while being useless to such a consumer.
+func TestEC2_SnapshotProgression_PollsToCompleted(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 20, nil)
+
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":4}`)
+
+	// The create is born pending at 0% — and does not consume an observation, so all four
+	// polls below are still available.
+	created := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID})
+	assert.Equal(t, "pending", created.Status,
+		"a snapshot created under a seed is born in the seeded state, so create → poll is testable")
+	assert.Equal(t, "0%", created.Progress)
+
+	for i, want := range []string{"0%", "25%", "50%", "75%"} {
+		got := ec2DescribeOneSnapshot(t, ts, created.SnapshotID)
+		assert.Equal(t, "pending", got.State, "poll %d", i+1)
+		assert.Equal(t, want, got.Progress, "poll %d", i+1)
+	}
+
+	// The fifth poll is the one the countdown was budgeted for.
+	done := ec2DescribeOneSnapshot(t, ts, created.SnapshotID)
+	assert.Equal(t, "completed", done.State, "the fifth poll exhausts a four-observation countdown")
+	assert.Equal(t, "100%", done.Progress)
+
+	// And it stays completed: the countdown does not restart, so a consumer that polls once
+	// more after success is not told the snapshot went back to pending.
+	again := ec2DescribeOneSnapshot(t, ts, created.SnapshotID)
+	assert.Equal(t, "completed", again.State)
+	assert.Equal(t, "100%", again.Progress)
+}
+
+// TestEC2_SnapshotProgression_LeavesTheRecordAlone pins the rule the whole design rests on: a
+// seed governs what an observation reports and never rewrites the snapshot.
+//
+// It is what makes the seed safe to leave in place — and what makes "the default is unchanged"
+// a fact about one overlay rather than a claim about every write path.
+func TestEC2_SnapshotProgression_LeavesTheRecordAlone(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":10}`)
+	assert.Equal(t, "pending", ec2DescribeOneSnapshot(t, ts, snapshotID).State)
+
+	ec2ClearSnapshotStatus(t, ts, "")
+	got := ec2DescribeOneSnapshot(t, ts, snapshotID)
+	assert.Equal(t, "completed", got.State,
+		"clearing the seed reveals the record, which was never anything but completed")
+	assert.Equal(t, "100%", got.Progress)
+
+	// Re-seeding restarts the countdown rather than resuming the six observations left over
+	// from the first seed, so a test that seeds twice gets two full progressions.
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":1}`)
+	first := ec2DescribeOneSnapshot(t, ts, snapshotID)
+	assert.Equal(t, "pending", first.State, "a fresh seed starts from the beginning")
+	assert.Equal(t, "completed", ec2DescribeOneSnapshot(t, ts, snapshotID).State)
+}
+
+// TestEC2_SnapshotProgression_CountsPerSnapshot pins the hazard #582 recorded for the SQS
+// seed, met here by keying the countdown position per snapshot even under a "*" seed.
+//
+// Without that split, one DescribeSnapshots over three snapshots would burn three
+// observations off a single shared countdown — so a test seeding two polls would see the
+// snapshot it was actually watching complete on its first one.
+func TestEC2_SnapshotProgression_CountsPerSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":2}`)
+
+	ids := make([]string, 0, 3)
+	for range 3 {
+		ids = append(ids, ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID)
+	}
+
+	// Two unfiltered describes observe all three snapshots twice, which is exactly the budget.
+	for range 2 {
+		for _, got := range ec2DescribeSnapshots(t, ts, nil) {
+			assert.Equal(t, "pending", got.State, "%s is still within its own countdown", got.SnapshotID)
+		}
+	}
+	for _, got := range ec2DescribeSnapshots(t, ts, nil) {
+		assert.Equal(t, "completed", got.State,
+			"%s spent its own two observations, not a third of a shared budget", got.SnapshotID)
+	}
+	assert.Len(t, ids, 3)
+}
+
+// TestEC2_SnapshotProgression_ObservedBeforeFiltering pins the ordering describeSnapshots
+// documents: the observation is taken, and the countdown advanced, before the filters run.
+//
+// The CLI's own waiter polls `--filters Name=status,Values=completed`, so a snapshot the
+// filter excludes has still been observed. Consuming after the filter instead would leave
+// that loop polling a countdown that never advances — a hang rather than a wrong answer.
+func TestEC2_SnapshotProgression_ObservedBeforeFiltering(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":2}`)
+
+	completedOnly := map[string]string{
+		"SnapshotId.1":  snapshotID,
+		"Filter.1.Name": "status", "Filter.1.Value.1": "completed",
+	}
+	for i := range 2 {
+		assert.Empty(t, ec2SnapshotIDsFor(t, ts, completedOnly),
+			"poll %d sees a pending snapshot, which the filter excludes", i+1)
+	}
+	assert.Equal(t, []string{snapshotID}, ec2SnapshotIDsFor(t, ts, completedOnly),
+		"the two excluded polls still advanced the countdown, so the waiter terminates")
+}
+
+// TestEC2_SnapshotProgression_FiltersReadTheObservation pins that status and progress compare
+// against what this request reports, not against the stored record.
+//
+// Filtering on the record would make `status=pending` select nothing at the very moment the
+// caller is being told the snapshot is pending — the one case where the two disagree, and the
+// only case a poll loop cares about.
+func TestEC2_SnapshotProgression_FiltersReadTheObservation(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":4}`)
+
+	assert.Equal(t, []string{snapshotID}, ec2SnapshotIDsFor(t, ts, ec2Filter("status", "pending")),
+		"status=pending selects a snapshot whose observation is pending, though its record is not")
+	assert.Equal(t, []string{snapshotID}, ec2SnapshotIDsFor(t, ts, ec2Filter("progress", "25%")),
+		"progress compares against the ramp this request rendered")
+	assert.Empty(t, ec2SnapshotIDsFor(t, ts, ec2Filter("progress", "100%")),
+		"a snapshot mid-countdown is not at 100%")
+}
+
+// TestEC2_SnapshotProgression_TerminalStates covers a seed whose final state is not completed,
+// which is the outcome a consumer's error branch exists for and the one AWS's own waiter fails
+// fast on (botocore's snapshot-completed defines an `error` acceptor).
+//
+// progress reaches 100% for every terminal state, not only completed: AWS's
+// restore-snapshot-from-recycle-bin example shows "Progress": "100%" beside "State":
+// "recovering", so progress measures how far the progression ran rather than whether it
+// succeeded. A consumer that polls progress instead of status gets that wrong, and this is
+// where such a consumer's test catches it.
+func TestEC2_SnapshotProgression_TerminalStates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		seed        string
+		wantState   string
+		wantMessage string
+	}{
+		{
+			name:      "error immediately",
+			seed:      `{"snapshotId":"*","pendingObservations":0,"finalState":"error"}`,
+			wantState: "error",
+		},
+		{
+			name: "error with a diagnostic",
+			seed: `{"snapshotId":"*","pendingObservations":0,"finalState":"error",` +
+				`"stateMessage":"Given key ID is not accessible"}`,
+			wantState:   "error",
+			wantMessage: "Given key ID is not accessible",
+		},
+		{
+			name:      "recovering from the recycle bin",
+			seed:      `{"snapshotId":"*","pendingObservations":0,"finalState":"recovering"}`,
+			wantState: "recovering",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+			ec2SeedSnapshotStatus(t, ts, tc.seed)
+			snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+
+			got := ec2DescribeOneSnapshot(t, ts, snapshotID)
+			assert.Equal(t, tc.wantState, got.State,
+				"a zero-observation seed is terminal from the first look")
+			assert.Equal(t, "100%", got.Progress,
+				"progress records how far the progression ran, not whether it succeeded")
+			assert.Equal(t, tc.wantMessage, got.StatusMsg)
+		})
+	}
+}
+
+// TestEC2_SnapshotProgression_StatusMessageOnlyOnDescribe pins AWS's own scoping of the
+// member: "this parameter is only returned by DescribeSnapshots."
+func TestEC2_SnapshotProgression_StatusMessageOnlyOnDescribe(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	ec2SeedSnapshotStatus(t, ts,
+		`{"snapshotId":"*","pendingObservations":0,"finalState":"error","stateMessage":"KMS key unavailable"}`)
+
+	resp := ec2Request(t, ts, map[string]string{"Action": "CreateSnapshot", "VolumeId": volumeID})
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(body), "<status>error</status>", "the seed governs what the create reports")
+	assert.NotContains(t, string(body), "statusMessage",
+		"CreateSnapshot renders no statusMessage, because AWS returns it only from DescribeSnapshots")
+
+	described := ec2DescribeSnapshots(t, ts, nil)
+	require.Len(t, described, 1)
+	assert.Equal(t, "KMS key unavailable", described[0].StatusMsg,
+		"DescribeSnapshots is where the diagnostic is published")
+}
+
+// TestEC2_SnapshotProgression_ScopedSeedBeatsTheWildcard pins the resolution order every seed
+// in the repo uses: the exact ID first, then "*".
+func TestEC2_SnapshotProgression_ScopedSeedBeatsTheWildcard(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	scoped := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+	other := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":0,"finalState":"error"}`)
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"`+scoped+`","pendingObservations":1}`)
+
+	assert.Equal(t, "pending", ec2DescribeOneSnapshot(t, ts, scoped).State,
+		"the ID-scoped seed governs, not the wildcard")
+	assert.Equal(t, "completed", ec2DescribeOneSnapshot(t, ts, scoped).State)
+	assert.Equal(t, "error", ec2DescribeOneSnapshot(t, ts, other).State,
+		"a snapshot with no seed of its own falls to the wildcard")
+
+	// Clearing the scoped seed hands that snapshot back to the wildcard.
+	ec2ClearSnapshotStatus(t, ts, scoped)
+	assert.Equal(t, "error", ec2DescribeOneSnapshot(t, ts, scoped).State)
+}
+
+// TestEC2_SnapshotProgression_CreateVolumeRefusesAnUnusableSnapshot covers the rule AWS states
+// in its snapshot-states table — "a snapshot can't be used while it is in the pending state",
+// "a snapshot can't be used if it is in the error state" — with the IncorrectState code
+// substrate already answers with for a volume in the wrong state.
+func TestEC2_SnapshotProgression_CreateVolumeRefusesAnUnusableSnapshot(t *testing.T) {
+	t.Parallel()
+
+	for _, state := range []string{"pending", "error"} {
+		t.Run(state, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			volumeID := ec2CreateSizedVolume(t, ts, 20, nil)
+			snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+
+			restore := map[string]string{
+				"Action": "CreateVolume", "AvailabilityZone": "us-east-1a", "SnapshotId": snapshotID,
+			}
+
+			// Unseeded, the restore succeeds — which is what makes the refusal below a
+			// consequence of the seed rather than of anything else in the request.
+			var ok struct {
+				VolumeID string `xml:"volumeId"`
+			}
+			ec2FleetXML(t, ts, restore, &ok)
+			require.NotEmpty(t, ok.VolumeID)
+
+			if state == "pending" {
+				ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":5}`)
+			} else {
+				ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":0,"finalState":"error"}`)
+			}
+
+			status, code, message := ec2ErrorDetail(t, ts, restore)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "IncorrectState", code)
+			assert.Contains(t, message, state)
+			assert.Contains(t, message, snapshotID)
+		})
+	}
+}
+
+// TestEC2_SnapshotProgression_CreateVolumeDoesNotSpendAPoll pins that the refusal above reads
+// the state without consuming an observation.
+//
+// Otherwise "pendingObservations: 2" would mean two polls in a test that only describes and
+// one in a test that also tries a restore — and a consumer's retry loop, which alternates
+// CreateVolume and DescribeSnapshots, would race its own budget.
+func TestEC2_SnapshotProgression_CreateVolumeDoesNotSpendAPoll(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 20, nil)
+	snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":1}`)
+
+	restore := map[string]string{
+		"Action": "CreateVolume", "AvailabilityZone": "us-east-1a", "SnapshotId": snapshotID,
+	}
+	for range 3 {
+		_, code, _ := ec2ErrorDetail(t, ts, restore)
+		require.Equal(t, "IncorrectState", code, "three refusals must not exhaust a one-poll budget")
+	}
+
+	assert.Equal(t, "pending", ec2DescribeOneSnapshot(t, ts, snapshotID).State,
+		"the single budgeted observation is still unspent")
+	assert.Equal(t, "completed", ec2DescribeOneSnapshot(t, ts, snapshotID).State)
+
+	var ok struct {
+		VolumeID string `xml:"volumeId"`
+		Size     int    `xml:"size"`
+	}
+	ec2FleetXML(t, ts, restore, &ok)
+	assert.NotEmpty(t, ok.VolumeID, "a completed snapshot restores")
+	assert.Equal(t, 20, ok.Size, "and still sizes from the snapshot")
+}
+
+// TestEC2_SnapshotProgression_DeleteSnapshotIgnoresTheState pins AWS's explicit permission:
+// "although you can delete a snapshot that is still in progress, the snapshot must complete
+// before the deletion takes effect." There is no error code for the case, so there is no
+// refusal — and the deferred-effect half is not modeled, for the reason deleteSnapshot records.
+func TestEC2_SnapshotProgression_DeleteSnapshotIgnoresTheState(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":9}`)
+	require.Equal(t, "pending", ec2DescribeOneSnapshot(t, ts, snapshotID).State)
+
+	resp := ec2Request(t, ts, map[string]string{"Action": "DeleteSnapshot", "SnapshotId": snapshotID})
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"a snapshot still in progress is deletable, which AWS documents in so many words")
+
+	assert.Empty(t, ec2DescribeSnapshots(t, ts, nil), "and it is gone at once, not after the countdown")
+}
+
+// TestEC2_SeedSnapshotStatus_Validation covers the endpoint's own refusals.
+//
+// An unknown state is refused rather than stored because it is one no SDK can map and no
+// consumer can branch on: the seed would look accepted and produce a response the caller's own
+// model rejects. Both members are checked, since a seed is as easily wrong about where a
+// progression ends as about where it starts.
+func TestEC2_SeedSnapshotStatus_Validation(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{"wildcard default", `{"pendingObservations":2}`, http.StatusOK},
+		{"every documented state is seedable", `{"state":"recoverable","finalState":"recovering"}`, http.StatusOK},
+		{"zero observations", `{"pendingObservations":0}`, http.StatusOK},
+		{"negative observations", `{"pendingObservations":-1}`, http.StatusBadRequest},
+		{"unknown pending state", `{"state":"creating"}`, http.StatusBadRequest},
+		{"unknown final state", `{"finalState":"done"}`, http.StatusBadRequest},
+		{"state casing is not folded", `{"state":"Pending"}`, http.StatusBadRequest},
+		{"malformed json", `{`, http.StatusBadRequest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Post(ts.URL+"/v1/ec2/snapshot-status",
+				"application/json", strings.NewReader(tc.body))
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+			assert.Equal(t, tc.wantStatus, resp.StatusCode)
+		})
+	}
+
+	// An ID-scoped clear leaves the wildcard alone, and a bare clear sweeps both.
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"snap-0123456789abcdef0","pendingObservations":1}`)
+	ec2ClearSnapshotStatus(t, ts, "snap-0123456789abcdef0")
+	ec2ClearSnapshotStatus(t, ts, "")
+}
+
+// TestEC2_SnapshotProgression_UnseededIsUnchanged is the criterion "default behavior
+// unchanged", checked in one place rather than inferred from the rest of the suite staying
+// green: with no seed ever posted, every snapshot-reporting operation says completed at 100%.
+func TestEC2_SnapshotProgression_UnseededIsUnchanged(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+
+	created := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID})
+	assert.Equal(t, "completed", created.Status)
+	assert.Equal(t, "100%", created.Progress)
+
+	// Repeated describes cannot drift, because an exhausted countdown writes nothing.
+	for range 3 {
+		got := ec2DescribeOneSnapshot(t, ts, created.SnapshotID)
+		assert.Equal(t, "completed", got.State)
+		assert.Equal(t, "100%", got.Progress)
+		assert.Empty(t, got.StatusMsg, "an unseeded snapshot has no diagnostic to publish")
+	}
+}

--- a/emulator/ec2_snapshot_filters.go
+++ b/emulator/ec2_snapshot_filters.go
@@ -13,9 +13,15 @@ import (
 // snapshot-id — and silently ignored the other thirteen, so "the snapshots of volume
 // vol-x" answered with every snapshot in the region. That is the failure mode an ignored
 // filter always has: a caller cannot tell an unfiltered answer from a filtered one.
-func ec2SnapshotMatchesFilters(snap EC2Snapshot, filters map[string][]string) bool {
+//
+// observed carries the state and progress *this* request reports for the snapshot, which is
+// what the status and progress filters compare against. They must not read the record: a
+// seeded snapshot's record still says completed while the observation says pending (#715), so
+// filtering on the record would make `status=pending` select nothing at the very moment a
+// caller's poll loop is being told the snapshot is pending.
+func ec2SnapshotMatchesFilters(snap EC2Snapshot, observed ec2SnapshotObservation, filters map[string][]string) bool {
 	for name, values := range filters {
-		if !ec2SnapshotMatchesFilter(snap, name, values) {
+		if !ec2SnapshotMatchesFilter(snap, observed, name, values) {
 			return false
 		}
 	}
@@ -24,12 +30,12 @@ func ec2SnapshotMatchesFilters(snap EC2Snapshot, filters map[string][]string) bo
 
 // ec2SnapshotMatchesFilter evaluates a single DescribeSnapshots filter against a snapshot.
 //
-// Ten of AWS's fourteen names are answerable from [EC2Snapshot]. The four that are not —
-// owner-alias, progress, storage-tier and transfer-type — are inert, per the rule
-// [ec2FilterSpec] states: substrate renders none of those members either, so a filter over
-// them has nothing to compare against. A name outside all fourteen never arrives, because
-// [ec2SnapshotFilterSpec] refuses it before the scan (#687).
-func ec2SnapshotMatchesFilter(snap EC2Snapshot, name string, values []string) bool {
+// Eleven of AWS's fourteen names are answerable from [EC2Snapshot] and the observation
+// alongside it. The three that are not — owner-alias, storage-tier and transfer-type — are
+// inert, per the rule [ec2FilterSpec] states: substrate renders none of those members either,
+// so a filter over them has nothing to compare against. A name outside all fourteen never
+// arrives, because [ec2SnapshotFilterSpec] refuses it before the scan (#687).
+func ec2SnapshotMatchesFilter(snap EC2Snapshot, observed ec2SnapshotObservation, name string, values []string) bool {
 	if tagKey, ok := strings.CutPrefix(name, "tag:"); ok {
 		for _, t := range snap.Tags {
 			if t.Key == tagKey && ec2FilterAccepts(values, t.Value) {
@@ -50,6 +56,12 @@ func ec2SnapshotMatchesFilter(snap EC2Snapshot, name string, values []string) bo
 		// nothing. It is still evaluated rather than inert, because a caller who names
 		// another account is asking a question whose honest answer is "none".
 		return ec2FilterAccepts(values, snap.AccountID)
+	case "progress":
+		// "The progress of the snapshot, as a percentage (for example, 80%)" — compared as
+		// the string startTime's sibling element renders, so a caller filters on `100%`
+		// rather than on `100`. Answerable only since #715 gave substrate a progress to
+		// render at all; before that this name was one of four inert ones.
+		return ec2FilterAccepts(values, observed.Progress)
 	case "snapshot-id":
 		return ec2FilterAccepts(values, snap.SnapshotID)
 	case "start-time":
@@ -63,7 +75,13 @@ func ec2SnapshotMatchesFilter(snap EC2Snapshot, name string, values []string) bo
 	case "status":
 		// AWS names the filter "status" and the response element "status" while the API
 		// model calls the member State; EC2Snapshot follows the model.
-		return ec2FilterAccepts(values, snap.State)
+		//
+		// AWS's filter documents three valid values ("pending | completed | error") where
+		// its member documents five, adding recoverable and recovering. Nothing is
+		// validated here either way — a value outside both lists simply matches nothing,
+		// which is what a filter comparing strings does — but the divergence is real and
+		// [ec2SnapshotStates] records which of the two substrate follows.
+		return ec2FilterAccepts(values, observed.State)
 	case "tag-key":
 		for _, t := range snap.Tags {
 			if ec2FilterAccepts(values, t.Key) {

--- a/emulator/ec2_snapshot_filters_test.go
+++ b/emulator/ec2_snapshot_filters_test.go
@@ -16,7 +16,9 @@ type describedSnapshot struct {
 	VolumeID    string `xml:"volumeId"`
 	VolumeSize  int64  `xml:"volumeSize"`
 	State       string `xml:"status"`
+	StatusMsg   string `xml:"statusMessage"`
 	StartTime   string `xml:"startTime"`
+	Progress    string `xml:"progress"`
 	Encrypted   bool   `xml:"encrypted"`
 	Description string `xml:"description"`
 	OwnerID     string `xml:"ownerId"`
@@ -97,11 +99,12 @@ func ec2SeedTaggedSnapshots(t *testing.T, ts *httptest.Server, names ...string) 
 	return out
 }
 
-// TestEC2_DescribeSnapshots_EvaluatedFiltersNarrowTheAnswer covers the ten filter names
-// #685 taught describeSnapshots to evaluate. Before it, snapshot-id was the only one that
-// did anything and the other thirteen were silently ignored — so every case below whose
-// want is narrower than "both" returned both snapshots, and a caller had no way to tell an
-// unfiltered answer from a filtered one.
+// TestEC2_DescribeSnapshots_EvaluatedFiltersNarrowTheAnswer covers the eleven filter names
+// describeSnapshots evaluates — the ten #685 taught it, plus progress, which became answerable
+// once #715 gave substrate a progress to render. Before #685, snapshot-id was the only one that
+// did anything and the other thirteen were silently ignored — so every case below whose want is
+// narrower than "both" returned both snapshots, and a caller had no way to tell an unfiltered
+// answer from a filtered one.
 func TestEC2_DescribeSnapshots_EvaluatedFiltersNarrowTheAnswer(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
@@ -128,6 +131,12 @@ func TestEC2_DescribeSnapshots_EvaluatedFiltersNarrowTheAnswer(t *testing.T) {
 		{"encrypted true", ec2Filter("encrypted", "true"), nil},
 		{"owner-id self", ec2Filter("owner-id", owner), []string{alpha, beta}},
 		{"owner-id another account", ec2Filter("owner-id", "999999999999"), nil},
+		// An unseeded snapshot is complete, so progress compares against the percent-suffixed
+		// "100%" AWS's own examples show — not against a bare "100", which is the mistake the
+		// miss row below pins.
+		{"progress complete", ec2Filter("progress", "100%"), []string{alpha, beta}},
+		{"progress without the percent sign", ec2Filter("progress", "100"), nil},
+		{"progress partial", ec2Filter("progress", "50%"), nil},
 		{"snapshot-id selects one", ec2Filter("snapshot-id", alpha), []string{alpha}},
 		{"start-time miss", ec2Filter("start-time", "2000-01-01T00:00:00Z"), nil},
 		{"status completed", ec2Filter("status", "completed"), []string{alpha, beta}},
@@ -188,11 +197,13 @@ func TestEC2_DescribeSnapshots_FiltersAND(t *testing.T) {
 		"two filters AND, so a snapshot satisfying only one is excluded")
 }
 
-// TestEC2_DescribeSnapshots_InertFiltersReturnEverything pins the four names AWS documents
+// TestEC2_DescribeSnapshots_InertFiltersReturnEverything pins the three names AWS documents
 // that substrate accepts and cannot answer. They constrain nothing rather than being
 // refused, because refusing a filter real EC2 accepts would be a false deny — and rather
 // than matching nothing, because an empty answer is indistinguishable from "no such
 // snapshot" and would hang a caller's wait loop. docs/services.md lists them by name.
+//
+// It was four until #715: progress is evaluated now, and its rows live in the table above.
 func TestEC2_DescribeSnapshots_InertFiltersReturnEverything(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
@@ -201,7 +212,6 @@ func TestEC2_DescribeSnapshots_InertFiltersReturnEverything(t *testing.T) {
 
 	for name, value := range map[string]string{
 		"owner-alias":   "amazon",
-		"progress":      "100%",
 		"storage-tier":  "standard",
 		"transfer-type": "standard",
 	} {

--- a/emulator/ec2_snapshot_ops.go
+++ b/emulator/ec2_snapshot_ops.go
@@ -85,10 +85,15 @@ func (p *EC2Plugin) ec2InstanceAttachedVolumes(reqCtx *RequestContext, instanceI
 // DescribeSnapshots' responses both name it **status**. A caller unmarshalling
 // SnapshotInfo reads State; sharing a struct would hand them an empty string.
 //
+// progress arrived with the seedable progression (#715). AWS describes SnapshotInfo's member
+// as "progress this snapshot has made towards completing", where the Snapshot type's is "the
+// progress of the snapshot, as a percentage" — the same value, described twice; both render the
+// percent-suffixed form AWS's examples and its progress filter show.
+//
 // The members substrate does not render are omissions with reasons rather than oversights:
 //
-//   - progress — substrate stores none, the same reason DescribeSnapshots and CreateSnapshot
-//     render none. It arrives with the seedable progression in #715.
+//   - statusMessage — SnapshotInfo has no such member. AWS publishes it on Snapshot alone, and
+//     scopes it further still: "this parameter is only returned by DescribeSnapshots."
 //   - availabilityZone — documented as "The Availability Zone or Local Zone of the
 //     snapshots", and the singular CreateSnapshot response has no such member at all, so it
 //     reads as the placement member for a Location=local snapshot. Substrate models only
@@ -103,6 +108,7 @@ type ec2SnapshotInfoItem struct {
 	VolumeSize  int64        `xml:"volumeSize"`
 	State       string       `xml:"state"`
 	StartTime   string       `xml:"startTime"`
+	Progress    string       `xml:"progress"`
 	OwnerID     string       `xml:"ownerId"`
 	Description string       `xml:"description,omitempty"`
 	Encrypted   bool         `xml:"encrypted"`
@@ -145,7 +151,10 @@ type ec2SnapshotInfoItem struct {
 //
 // state is "completed" at once, as CreateSnapshot's status is, and for the same reason:
 // substrate advances no snapshot asynchronously, so a waiter succeeds on its first poll
-// instead of depending on wall-clock time.
+// instead of depending on wall-clock time. A "*" seed changes what every snapshot in the set
+// reports (#715), through the same non-consuming [EC2Plugin.peekSnapshotStatus] the singular
+// operation uses — so snapshotting a five-volume instance under a two-poll seed leaves each of
+// the five with its own full two polls, rather than spending the budget five times over.
 func (p *EC2Plugin) createSnapshots(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	instanceID := req.Params["InstanceSpecification.InstanceId"]
 	if instanceID == "" {
@@ -238,12 +247,17 @@ func (p *EC2Plugin) createSnapshots(reqCtx *RequestContext, req *AWSRequest) (*A
 		if err := p.ec2PutSnapshot(reqCtx, snap); err != nil {
 			return nil, err
 		}
+		observed, obsErr := p.peekSnapshotStatus(snap)
+		if obsErr != nil {
+			return nil, obsErr
+		}
 		items = append(items, ec2SnapshotInfoItem{
 			SnapshotID:  snap.SnapshotID,
 			VolumeID:    snap.VolumeID,
 			VolumeSize:  snap.VolumeSize,
-			State:       snap.State,
+			State:       observed.State,
 			StartTime:   snap.StartTime,
+			Progress:    observed.Progress,
 			OwnerID:     snap.AccountID,
 			Description: snap.Description,
 			Encrypted:   snap.Encrypted,

--- a/emulator/ec2_snapshot_ops_test.go
+++ b/emulator/ec2_snapshot_ops_test.go
@@ -36,6 +36,7 @@ type snapshotInfo struct {
 	State       string `xml:"state"`
 	Status      string `xml:"status"`
 	StartTime   string `xml:"startTime"`
+	Progress    string `xml:"progress"`
 	OwnerID     string `xml:"ownerId"`
 	Description string `xml:"description"`
 	Encrypted   bool   `xml:"encrypted"`
@@ -150,6 +151,7 @@ func TestEC2_CreateSnapshots_SnapshotsEveryAttachedVolume(t *testing.T) {
 		assert.Equal(t, "completed", snap.State,
 			"SnapshotInfo names the state member `state`, not `status`")
 		assert.Empty(t, snap.Status, "a `status` element here would be the wrong member name")
+		assert.Equal(t, "100%", snap.Progress, "item %d is complete, so progress says so (#715)", i)
 		assert.NotEmpty(t, snap.StartTime, "item %d", i)
 		assert.NotEmpty(t, snap.OwnerID, "item %d", i)
 		assert.Equal(t, "nightly", snap.Description, "the description applies to every snapshot")

--- a/emulator/ec2_snapshots.go
+++ b/emulator/ec2_snapshots.go
@@ -66,16 +66,22 @@ func (p *EC2Plugin) ec2SnapshotResolver(reqCtx *RequestContext) func(string) (EC
 //
 // # The state it reports
 //
-// status is "completed" immediately, not the "pending" AWS's own sample response shows.
-// Substrate advances no snapshot asynchronously — CreateImage's snapshots have always
-// been born completed — so a caller's waiter succeeds on its first poll rather than
-// depending on wall-clock time. A seedable pending → completed progression is the shape
-// that would let a test exercise the waiting path, and it is a follow-up rather than
-// something this operation should invent.
+// status is "completed" immediately by default, not the "pending" AWS's own sample response
+// shows: substrate advances no snapshot asynchronously — CreateImage's snapshots have always
+// been born completed — so a caller's waiter succeeds on its first poll rather than depending
+// on wall-clock time.
 //
-// progress is not rendered, for the reason describeSnapshots does not render it either:
-// substrate stores none, and status already carries the whole of what a completed
-// snapshot's progress would say.
+// A "*" seed in place changes what this reports (#715), which is what makes the whole
+// create → poll → completed sequence testable rather than only its tail: a snapshot created
+// under a seed is born in the seeded pending state at 0%, so a consumer's waiter has something
+// to wait for. The record is still written as "completed" — a seed governs observations, never
+// state — and [EC2Plugin.peekSnapshotStatus] is deliberately the non-consuming read, so
+// creating a snapshot does not spend one of the polls the seed budgeted.
+//
+// progress is rendered here where it was not before #715, because CreateSnapshot returns a
+// Snapshot and AWS documents progress as one of its members — its own sample response shows
+// `<progress>60%</progress>`. statusMessage is not rendered, because AWS scopes it: "this
+// parameter is only returned by DescribeSnapshots".
 func (p *EC2Plugin) createSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
 	volumeID := req.Params["VolumeId"]
 	if volumeID == "" {
@@ -119,11 +125,18 @@ func (p *EC2Plugin) createSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AW
 		return nil, fmt.Errorf("ec2 createSnapshot state.Put: %w", err)
 	}
 
+	observed, err := p.peekSnapshotStatus(snap)
+	if err != nil {
+		return nil, err
+	}
+
 	// Member order follows AWS's own sample response — snapshotId, volumeId, status,
-	// startTime, ownerId, volumeSize, description — with the two documented elements it
-	// does not show appended. tagSet carries no omitempty for the reason CreateVolume's
-	// does not: an SDK maps a present-but-empty element to an empty slice where it maps an
-	// omitted one to nil, so omitting it would report "unknown" where AWS reports "none".
+	// startTime, progress, ownerId, volumeSize, description — with the one documented element
+	// it does not show appended. progress carries no omitempty because it is always rendered:
+	// AWS's sample shows it beside a pending status, and an unseeded snapshot is complete.
+	// tagSet carries none either, for the reason CreateVolume's does not: an SDK maps a
+	// present-but-empty element to an empty slice where it maps an omitted one to nil, so
+	// omitting it would report "unknown" where AWS reports "none".
 	type response struct {
 		XMLName     xml.Name     `xml:"CreateSnapshotResponse"`
 		XMLNS       string       `xml:"xmlns,attr"`
@@ -131,6 +144,7 @@ func (p *EC2Plugin) createSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AW
 		VolumeID    string       `xml:"volumeId"`
 		Status      string       `xml:"status"`
 		StartTime   string       `xml:"startTime"`
+		Progress    string       `xml:"progress"`
 		OwnerID     string       `xml:"ownerId"`
 		VolumeSize  int64        `xml:"volumeSize"`
 		Description string       `xml:"description,omitempty"`
@@ -141,8 +155,9 @@ func (p *EC2Plugin) createSnapshot(reqCtx *RequestContext, req *AWSRequest) (*AW
 		XMLNS:       "http://ec2.amazonaws.com/doc/2016-11-15/",
 		SnapshotID:  snap.SnapshotID,
 		VolumeID:    snap.VolumeID,
-		Status:      snap.State,
+		Status:      observed.State,
 		StartTime:   snap.StartTime,
+		Progress:    observed.Progress,
 		OwnerID:     snap.AccountID,
 		VolumeSize:  snap.VolumeSize,
 		Description: snap.Description,

--- a/emulator/ec2_snapshots_test.go
+++ b/emulator/ec2_snapshots_test.go
@@ -25,6 +25,7 @@ type createdSnapshot struct {
 	VolumeID    string `xml:"volumeId"`
 	Status      string `xml:"status"`
 	StartTime   string `xml:"startTime"`
+	Progress    string `xml:"progress"`
 	OwnerID     string `xml:"ownerId"`
 	VolumeSize  int64  `xml:"volumeSize"`
 	Description string `xml:"description"`
@@ -105,6 +106,8 @@ func TestEC2_CreateSnapshot_ReportsTheSourceVolume(t *testing.T) {
 	assert.Equal(t, volID, snap.VolumeID)
 	assert.Equal(t, int64(100), snap.VolumeSize, "the size is the source volume's, not 8")
 	assert.Equal(t, "completed", snap.Status)
+	assert.Equal(t, "100%", snap.Progress,
+		"with no seed in place a snapshot is born complete, and progress says so (#715)")
 	assert.NotEmpty(t, snap.StartTime)
 	assert.NotEmpty(t, snap.OwnerID)
 	assert.Equal(t, "Daily Backup", snap.Description)

--- a/emulator/ec2_types.go
+++ b/emulator/ec2_types.go
@@ -557,7 +557,14 @@ type EC2Snapshot struct {
 	// VolumeSize is the size of the volume, in GiB.
 	VolumeSize int64 `json:"volume_size"`
 
-	// State is the snapshot state: always "completed" in Substrate.
+	// State is the snapshot state, one of [ec2SnapshotStates]. Every snapshot Substrate
+	// writes is "completed": nothing advances a snapshot asynchronously, so there is no
+	// transition for the record to hold.
+	//
+	// A seeded progression (#715) does not change that. It overlays what an *observation*
+	// reports — see [EC2Plugin.observeSnapshotStatus] — leaving this member "completed", so
+	// clearing the seed makes the snapshot read completed again and a snapshot with no seed
+	// against it is untouched.
 	State string `json:"state"`
 
 	// StartTime is the RFC3339 timestamp when the snapshot was started.

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -369,6 +369,10 @@ func (s *Server) buildRouter() *chi.Mux {
 	r.Post("/v1/ec2/fleet-shortfall", s.handleEC2SeedFleetShortfall)
 	r.Delete("/v1/ec2/fleet-shortfall", s.handleEC2ClearFleetShortfall)
 
+	// EC2 snapshot progression control-plane endpoints (#715).
+	r.Post("/v1/ec2/snapshot-status", s.handleEC2SeedSnapshotStatus)
+	r.Delete("/v1/ec2/snapshot-status", s.handleEC2ClearSnapshotStatus)
+
 	// spore.host spawn task-completion control-plane endpoints (#360).
 	r.Post("/v1/spawn/task-completion", s.handleSpawnSeedTaskCompletion)
 	r.Delete("/v1/spawn/task-completion", s.handleSpawnClearTaskCompletion)


### PR DESCRIPTION
## The gap

Every snapshot substrate writes is born `completed`. So the one loop callers actually write
around this API — poll `DescribeSnapshots` until `status` is `completed`, which is what CDK's
custom resources, Terraform's `aws_ebs_snapshot` and `aws ec2 wait snapshot-completed` all do —
exited on its first iteration. The retry, timeout and error branches such a loop carries were
never taken, so a consumer whose polling is broken, or which treats `error` as retryable
forever, passed against substrate and failed against AWS.

## What lands

`POST /v1/ec2/snapshot-status` seeds how many observations report a non-terminal state before
the snapshot reaches its final one, keyed by snapshot ID or `*`;
`DELETE /v1/ec2/snapshot-status[?snapshotId=…]` clears one or all.

```bash
curl -X POST http://localhost:4566/v1/ec2/snapshot-status \
  -d '{"snapshotId":"*","pendingObservations":4}'
```

`state` defaults to `pending` and `finalState` to `completed`; both accept only the five values
AWS publishes for the member (`pending | completed | error | recoverable | recovering`). A sixth
is refused rather than stored — it is one no SDK can map and no consumer can branch on, so the
seed would look accepted and produce a response the caller's own model rejects.

**Counted in observations, not measured as a duration.** `TimeController.Now` advances with wall
time from its baseline, so a duration seed would expire partway through a test and make every
"still pending" assertion depend on how long the rest of the test took. That is the reasoning
`sqs_control.go:21-25` already records. It is also the more useful unit: "the next two polls see
pending" is what a test of a poll loop wants to say.

**The count is per snapshot even under a `"*"` seed.** This is the hazard #582 recorded for the
SQS seed, met by separating the specification (shared, read-only) from the position through it
(per snapshot). Without the split, one `DescribeSnapshots` over five snapshots would burn five
observations off a single shared countdown, and the snapshot a test was watching would complete
early. `EC2Plugin` gained the one `seedMu sync.Mutex` — not one per key — that `SQSPlugin` and
`S3Plugin` already carry, since advancing the count is a read-modify-write and `StateManager`
offers no compare-and-swap.

**A seed governs what an observation reports and never rewrites the record**, whose `state` stays
`completed`. Clearing a seed, or `POST /v1/state/reset`, makes every snapshot read `completed`
again, and a snapshot with no seed against it is untouched — which is how "the default is
unchanged" is a fact about one overlay rather than a claim about every write path.

Riding along: `CreateSnapshot` and `CreateSnapshots` render the `progress` member AWS documents
on the types they return, `DescribeSnapshots` renders `progress` and `statusMessage`, and the
`progress` filter moved out of the inert list — eleven of the operation's fourteen documented
names are evaluated now. `status` and `progress` compare against what *this* request reports,
not the record: filtering on the record would make `status=pending` select nothing at the very
moment the caller is told the snapshot is pending. And the observation is consumed **before** the
filters run, so a snapshot a filter excludes has still advanced its countdown — required,
because the CLI's own waiter polls `--filters Name=status,Values=completed` and would otherwise
never terminate.

## Two corrections to the issue

**#715's cited precedent is wrong.** It names Bedrock's and SageMaker's job status as "the
established pattern" for a progression. Both say "without simulated time" explicitly
(`bedrock_runtime_ctrl.go:67-68`, `sagemaker_control.go:20-22`) and both are a single flat value.
No seed in the repo modelled a multi-step progression; this is the first.

**#715 framed `DeleteSnapshot` and `CreateVolume` against a non-`completed` snapshot as one open
decision to settle. AWS settles them in opposite directions.**

- `DeleteSnapshot` **succeeds**, and AWS says so in so many words: "although you can delete a
  snapshot that is still in progress, the snapshot must complete before the deletion takes
  effect." There is no error code for the case. The deferred-effect half is not modelled — AWS
  publishes nothing observable about the interval, since a caller cannot see the snapshot after
  the request returns either way, so a delay would be a resource-internal detail rather than an
  API observation.
- `CreateVolume` is **refused** with `IncorrectState`/400, on the strength of AWS's
  snapshot-states table: "a snapshot can't be used while it is in the `pending` state", "a
  snapshot can't be used if it is in the `error` state". Reachable only under a seed, so nothing
  that succeeds today starts failing.

## Provenance

The **progress schedule is substrate's**. AWS documents the member only as "the progress of the
snapshot, as a percentage"; the ramp (`0%`, `25%`, `50%`, `75%`, `100%` for a four-observation
seed) is chosen because a consumer's poll loop often logs or asserts on a rising percentage. A
consumer must no more assert on an exact intermediate value than it may against AWS, whose own
`CreateSnapshot` sample response implausibly shows a freshly created snapshot at `60%`.

Progress reaches `100%` for **every** terminal state rather than freezing below it for a failure,
on AWS's one observable data point: its `restore-snapshot-from-recycle-bin` example shows
`"Progress": "100%"` beside `"State": "recovering"`. So progress measures how far the progression
ran, not whether it succeeded.

Two of the five seedable states, `recoverable` and `recovering`, are not otherwise reachable —
they mean the snapshot is in the Recycle Bin, which real `DescribeSnapshots` does not return
(`ListSnapshotsInRecycleBin` does) — and exist here only as something a seed can make a
consumer's branch see. That is also why the filter documents three values where the member
documents five; the member's enumeration is followed, per #671.

`IncorrectState` is substrate's choice from EC2's client-error table — the code it already
answers with for "Volume … is not in available state" — because `CreateVolume`'s own page
publishes no error for the condition. The rule is AWS's; only the code and message are
substrate's.

## Verification

Full gate green: `gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues), `make test` (race),
`make coverage` at **82.6%**, `make docs-reference-check`, `docs-versions`, the VitePress build
with no broken anchors, and `test/e2e`.

**Mutation testing on the countdown**, one condition at a time, each reverted:

| Mutation | Subtests red |
|---|---|
| off-by-one, `seen <= total` | 9 |
| progress frozen at `0%` instead of a ramp | 2 |
| `status` filter reads the record, not the observation | 2 |
| `progress` filter reads a bare number | 2 |
| countdown keyed globally, not per snapshot (the #582 hazard) | 1 |
| observation consumed *after* filtering | 1 |
| `CreateSnapshot` consumes a poll (`peek` → `observe`) | 2 |
| `CreateVolume` consumes a poll | 5 |

**Live run** against a built binary and the real AWS CLI v2:

```
=== 1. seed four pending observations, then poll the ramp ===
  poll 1: pending  0%      poll 4: pending  75%
  poll 2: pending  25%     poll 5: completed  100%
  poll 3: pending  50%     poll 6: completed  100%

=== 2. the CLI's own waiter terminates ===
  real 0m45.299s  (3 polls x the waiter's own 15s delay)
  waiter exit: 0

=== 3. the waiter fails fast on a seeded error ===
  aws: [ERROR]: Waiter SnapshotCompleted failed: Waiter encountered a terminal
  failure state: For expression "Snapshots[].State" we matched expected path:
  "error" at least once
  waiter exit: 255

=== 5. CreateVolume refuses a pending snapshot; DeleteSnapshot does not ===
  An error occurred (IncorrectState) ... Snapshot snap-… is in pending state
  delete of a pending snapshot: OK (AWS permits it)
```

Section 3 is the branch a consumer's error handling exists for, and it was unreachable before:
botocore defines `SnapshotCompleted` with a `pathAny Snapshots[].State == error` acceptor
alongside the success one — a fact the CLI's own documentation page omits.

Sections 4, 6, 7 and 8 confirmed that the filters read the observation, that `CreateSnapshots`
gives each snapshot in the set its own countdown, that clearing the seed reveals the record, and
that the endpoint refuses an unmappable state (400) and a negative count (400).

One live-run finding worth recording: the wire element is `statusMessage`, which an SDK reads as
**`StateMessage`** — the third of these name splits after `status`/`State` and `state`/`State`.
Noted in `docs/services.md`.

Closes #715
