### PR TITLE
fix(iam): a condition key's name is matched case-insensitively (#704)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,6 +422,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a description of the condition, never a wire message.
 
 ### Fixed
+- **Condition key *names* are matched case-insensitively** (#704). AWS: "Context key **names**
+  are not case-sensitive. For example, including the `aws:SourceIP` context key is equivalent to
+  testing for `AWS:SourceIp`. Case-sensitivity of context key **values** depends on the
+  condition operator that you use." Substrate matched the name byte-for-byte, so a policy
+  spelling a key `ec2:createaction`, `AWS:RequestTag/Env` or `aws:tagkeys` — every one of which
+  real IAM evaluates — was silently unmatched. It failed in **both** directions: an `Allow`
+  written that way was an implicit deny, a false refusal a policy author sees immediately; a
+  `Deny` written that way was **inert**, allowing what AWS refuses, which a policy author does
+  not see at all. It was global to the evaluator rather than specific to any key, and was found
+  while implementing the second `ec2:CreateTags` pass (#691).
+
+  The fold is a **read-time** resolution in the three functions that already take both context
+  maps — `condContextValue`, `condRequestValues` and `unsetConditionKeys` — so no operator arm
+  changes and `Null` is fixed with them. An exact hit is still answered by a single map read, so
+  every canonically-spelled key (which is every key any substrate producer writes) costs nothing
+  and behaves byte-identically. Write-time canonicalization was rejected: `requestTagKeys` does a
+  case-sensitive `CutPrefix` on `aws:RequestTag/`, so lowercasing the stored name would empty
+  `aws:TagKeys` and flip every `ForAllValues:StringEquals` + `Null: false` policy — AWS's own
+  recommended pattern.
+
+  **The tag suffix folds too**, which is the opposite of what #704 asked for. AWS states it in
+  the same breath as the key–value form: "Key names are not case-sensitive. This means that if
+  you specify `"aws:ResourceTag/TagKey1": "Value1"` in the condition element of your policy, then
+  the condition matches a resource tag key named either `TagKey1` or `tagkey1`, but not both."
+  The case-sensitive rule #704 remembers governs a tag key used as a condition *value* —
+  `aws:TagKeys` — which is a different thing; both halves are now pinned so the distinction
+  cannot be collapsed. AWS's "but not both" leaves unstated which spelling wins, and AWS names
+  the resulting hazard rather than resolving it ("the key name matches both tags, but only one
+  value matches. This can result in unexpected condition failures"), so substrate answers with
+  the **first in sorted order** — never with whichever key Go's randomized map iteration reached,
+  which a decision that must replay identically from the event log cannot depend on.
+
+  What deliberately does **not** fold: the condition *value* (per each operator's own
+  definition, which is why `StringEqualsIgnoreCase` exists as a separate operator), and the
+  operator and its set qualifier — `stringequals` and `forallvalues:StringEquals` still deny,
+  since AWS's sentence is about key names. A simulation's caller-supplied `ContextEntries` is
+  the only way two spellings of one key can enter substrate at all, so two such entries are now
+  collapsed to one, the later winning under the earlier's spelling, and a `ContextEntry`
+  overrides a derived `aws:PrincipalArn`/`aws:ResourceAccount` whatever its case — previously
+  both survived side by side and which one decided was a matter of sort order.
+  `MissingContextValues` still reports the **policy's** spelling, because that string reaches
+  the wire and a caller compares it against the document they submitted; a key the evaluator
+  resolved by folding is no longer reported there at all.
+
 - **A zone ID takes the shape AWS publishes** (#712). The derivation produced `ue11-az1` for
   `us-east-1` — the wrong prefix and a doubled digit — where AWS publishes `use1-az1`, and the
   code's own comment claimed `use1`. Nothing caught it because a zone ID was only ever

--- a/docs/services.md
+++ b/docs/services.md
@@ -972,6 +972,57 @@ answer is worse than a missing one:
 A consumer whose preflight depends on an SCP boundary cannot get that answer here, and
 should not read an `allowed` as covering it.
 
+### Condition key *names* are matched case-insensitively
+
+AWS: "Context key **names** are not case-sensitive. For example, including the
+`aws:SourceIP` context key is equivalent to testing for `AWS:SourceIp`.
+Case-sensitivity of context key **values** depends on the condition operator that you
+use."
+
+Substrate follows both halves. A policy naming `ec2:createaction`, `AWS:RequestTag/Env`
+or `aws:tagkeys` is evaluated identically to its canonical spelling, in `Allow` and
+`Deny` position alike — and every operator still compares its *value* exactly as its own
+definition says, which is why `StringEquals` and `StringEqualsIgnoreCase` remain
+different operators.
+
+The name was previously matched byte-for-byte, which failed in both directions: an
+`Allow` written with a differently-cased name was an implicit deny — a false refusal —
+and a `Deny` written that way was **inert**, allowing what AWS refuses.
+
+| Folded | Not folded |
+|---|---|
+| The whole key name, including the tag suffix of `aws:RequestTag/<key>` and `aws:ResourceTag/<key>` | The condition **value**, per the operator's own definition |
+| The `aws:` / `ec2:` / `sts:` service prefix | A tag key carried as a value, in `aws:TagKeys` — and substrate's own tag rules, which AWS documents as case-sensitive |
+| Names supplied through a simulation's `ContextEntries` | The **operator** and its set qualifier: `stringequals` and `forallvalues:StringEquals` are not operators substrate evaluates, and [deny rather than being read as their canonical spellings](#multivalued-condition-keys-forallvalues-and-foranyvalue) |
+
+**The tag suffix folds too**, which is AWS's rule stated in the same breath as the
+key–value form: "Key names are not case-sensitive. This means that if you specify
+`"aws:ResourceTag/TagKey1": "Value1"` in the condition element of your policy, then the
+condition matches a resource tag key named either `TagKey1` or `tagkey1`, **but not
+both**." A tag key compared as a *value* is a different thing and stays case-sensitive.
+
+**When both spellings exist, substrate answers with the first in sorted order.** AWS
+names this hazard without resolving it — "you might tag an Amazon EC2 instance with
+`ec2=test1` and `EC2=test2` … the key name matches both tags, but only one value matches.
+This can result in unexpected condition failures" — so substrate makes the choice
+explicit rather than leaving it to Go's randomized map iteration, which a decision that
+must replay identically from the event log cannot depend on. An **exact** hit always wins
+over a folded one, whatever the folded one sorts as.
+
+Two notes for a caller reading a simulation:
+
+- A key the evaluator resolved by folding case is **not** reported in
+  `MissingContextValues`. Reporting it would make the simulation contradict the
+  enforcement it exists to predict.
+- A key that genuinely is absent is reported **as the policy spelled it**, not
+  canonicalized — that string is compared against the document the caller submitted.
+
+Only `ContextEntries` can introduce two spellings of one key on the way in; every
+producer inside substrate writes a canonical literal. Two entries whose names differ only
+by case are one key, and the later one wins, under the earlier one's spelling. A
+`ContextEntry` also overrides a derived `aws:PrincipalArn` or `aws:ResourceAccount`
+however it is cased.
+
 ### Multivalued condition keys: `ForAllValues` and `ForAnyValue`
 
 A condition key is either **single-valued** — at most one value in the request context —
@@ -4011,10 +4062,12 @@ The key is **absent** on a direct `CreateTags` or `DeleteTags`, which is what ma
 statement mean "tag during a launch, and not otherwise" — AWS's "Users cannot tag existing
 resources". A policy wanting to refuse only standalone tagging gates on `"Null":
 {"ec2:CreateAction": "false"}`, the one construct that tells an absent key apart from one
-present with a different value. The value is case-sensitive; the key *name* is matched
-case-sensitively too, where AWS documents key names as case-insensitive — a pre-existing
-property of substrate's evaluator, global to every condition key rather than specific to this
-one, tracked as [#704](https://github.com/scttfrdmn/substrate/issues/704).
+present with a different value. The value is case-sensitive, so a grant written for
+`CreateVolume` does not admit a `RunInstances`; the key *name* is not, so a policy writing
+`ec2:createaction` is evaluated exactly as one writing `ec2:CreateAction` — see [condition
+key names are matched
+case-insensitively](#condition-key-names-are-matched-case-insensitively), which is global
+to the evaluator rather than specific to this key.
 
 **Tags a launch template supplies are authorized the same way**, per AWS: "The
 `ec2:CreateTags` action is also evaluated if tags are provided in a launch template." The

--- a/emulator/ec2_createtags_authz_test.go
+++ b/emulator/ec2_createtags_authz_test.go
@@ -291,10 +291,31 @@ func TestEC2_Authz_CreateActionScopesTheTaggingGrant(t *testing.T) {
 		}
 	})
 
-	// The key is spelled exactly "ec2:CreateAction". AWS matches a condition key's
-	// name case-insensitively — substrate matches every condition key's name
-	// case-sensitively, which predates this pass and applies to all of them, so a
-	// policy writing "ec2:createaction" is not evaluated here (#704).
+	t.Run("the key's own name is not case-sensitive", func(t *testing.T) {
+		// AWS: "Context key *names* are not case-sensitive. For example, including the
+		// aws:SourceIP context key is equivalent to testing for AWS:SourceIp."
+		//
+		// This ran on the enforcement path rather than through Evaluate directly,
+		// because that is where the gap was found (#691) and where it mattered: a real
+		// policy naming "ec2:createaction" was silently unmatched, so AWS's own
+		// tag-on-create grant was a false refusal and the same grant written as a Deny
+		// was inert. #704 closed it; this subtest replaces the comment that recorded it.
+		for _, spelling := range []string{"ec2:createaction", "EC2:CreateAction"} {
+			t.Run(spelling, func(t *testing.T) {
+				f := newEC2AuthzFixture(t, "ulla", emulator.PolicyDocument{})
+				f.setPolicy(t,
+					ec2CreateTagsStatement("Allow", "ec2:RunInstances", []string{"*"}, nil),
+					ec2CreateTagsStatement("Allow", "ec2:CreateTags", []string{ec2AuthzInstARN},
+						map[string]map[string]emulator.StringOrSlice{
+							"StringEquals": {spelling: {"RunInstances"}},
+						}),
+				)
+				require.NoError(t, f.call(t, "RunInstances",
+					ec2CreateTagsParams(nominalLaunch(), ec2TagSpecParams(1, "instance", "Env", "prod"))),
+					"a grant naming the key as %q must be evaluated", spelling)
+			})
+		}
+	})
 }
 
 // TestEC2_Authz_CreateActionIsAbsentOutsideACreate pins the key's absence, which

--- a/emulator/iam_condition_case_test.go
+++ b/emulator/iam_condition_case_test.go
@@ -1,0 +1,495 @@
+package emulator_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// Condition-key names are matched case-insensitively (#704).
+//
+// AWS, in *IAM JSON policy elements: Condition*: "Context key *names* are not
+// case-sensitive. For example, including the aws:SourceIP context key is equivalent to
+// testing for AWS:SourceIp. Case-sensitivity of context key *values* depends on the
+// condition operator that you use."
+//
+// Substrate matched names byte-for-byte before this pass, which failed in both
+// directions: an Allow written with a differently-cased name was an implicit deny — a
+// false refusal — and a Deny written that way was inert, allowing what AWS refuses. The
+// second is the dangerous one, and it is what these tests exist to keep closed.
+
+// iamCaseFoldPolicy builds the one-statement document these tests evaluate: a single
+// operator testing a single key, against every resource and action, so the only thing
+// that can decide the result is the condition.
+func iamCaseFoldPolicy(effect, operator, condKey string, condValues ...string) emulator.PolicyDocument {
+	return emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   effect,
+			Action:   emulator.StringOrSlice{"*"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				operator: {condKey: emulator.StringOrSlice(condValues)},
+			},
+		}},
+	}
+}
+
+// TestEvaluate_ConditionKeyNameFoldsCase walks the spellings of one key against one
+// request, in both effect positions.
+//
+// The Allow rows assert the false refusal is gone; the Deny rows assert the inert Deny
+// is gone. Both are needed: an implementation that folded only on the way to an Allow
+// would leave every case-variant Deny unenforced, which is the failure a policy author
+// cannot see from a successful test run.
+func TestEvaluate_ConditionKeyNameFoldsCase(t *testing.T) {
+	t.Parallel()
+
+	const canonical = "ec2:CreateAction"
+	spellings := []string{
+		canonical,
+		"ec2:createaction",
+		"EC2:CREATEACTION",
+		"Ec2:CreateAction",
+	}
+
+	for _, spelling := range spellings {
+		t.Run("allow/"+spelling, func(t *testing.T) {
+			t.Parallel()
+			doc := iamCaseFoldPolicy(emulator.IAMEffectAllow, "StringEquals", spelling, "RunInstances")
+			result := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+				Action:   "ec2:CreateTags",
+				Resource: "*",
+				Context:  map[string]string{canonical: "RunInstances"},
+			})
+			assert.Equal(t, emulator.DecisionAllow, result.Decision,
+				"a grant naming the key as %q must read the value the producer wrote under %q", spelling, canonical)
+		})
+
+		t.Run("deny/"+spelling, func(t *testing.T) {
+			t.Parallel()
+			docs := []emulator.PolicyDocument{
+				{
+					Version: "2012-10-17",
+					Statement: []emulator.PolicyStatement{{
+						Effect:   emulator.IAMEffectAllow,
+						Action:   emulator.StringOrSlice{"*"},
+						Resource: emulator.StringOrSlice{"*"},
+					}},
+				},
+				iamCaseFoldPolicy(emulator.IAMEffectDeny, "StringEquals", spelling, "RunInstances"),
+			}
+			result := emulator.Evaluate(docs, emulator.EvaluationRequest{
+				Action:   "ec2:CreateTags",
+				Resource: "*",
+				Context:  map[string]string{canonical: "RunInstances"},
+			})
+			assert.Equal(t, emulator.DecisionDeny, result.Decision,
+				"a Deny naming the key as %q must not be inert", spelling)
+		})
+	}
+}
+
+// TestEvaluate_ConditionValueStaysCaseSensitive is the other half of AWS's sentence,
+// and the reason the fold lives in the lookup rather than in the operator arms.
+//
+// StringEquals is defined as an exact match, so folding the name must not fold what the
+// name resolves to. AWS supplies StringEqualsIgnoreCase for callers who want the value
+// folded too; a StringEquals that quietly behaved like it would make that operator
+// meaningless and would allow requests a policy was written to exclude.
+func TestEvaluate_ConditionValueStaysCaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	doc := iamCaseFoldPolicy(emulator.IAMEffectAllow, "StringEquals", "AWS:RequestTag/Env", "prod")
+
+	matching := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		Context: map[string]string{"aws:RequestTag/Env": "prod"},
+	})
+	assert.Equal(t, emulator.DecisionAllow, matching.Decision, "the name folds")
+
+	cased := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		Context: map[string]string{"aws:RequestTag/Env": "PROD"},
+	})
+	assert.Equal(t, emulator.DecisionImplicitDeny, cased.Decision,
+		"the value does not: StringEquals is an exact match, which is why StringEqualsIgnoreCase exists")
+}
+
+// TestEvaluate_ConditionKeyTagSuffixFoldsToo pins the half of #704 that its own scope
+// section got backwards.
+//
+// #704 asked that the tag-key suffix of aws:RequestTag/ and aws:ResourceTag/ stay
+// case-sensitive. AWS documents the opposite, in the same breath as the key–value form
+// itself: "Key names are not case-sensitive. This means that if you specify
+// "aws:ResourceTag/TagKey1": "Value1" in the condition element of your policy, then the
+// condition matches a resource tag key named either TagKey1 or tagkey1, but not both."
+//
+// The case-sensitive rule #704 remembers is real, but it governs a tag key used as a
+// condition *value* — aws:TagKeys, and substrate's own tag rules — which is a different
+// thing from a key name. Both halves are asserted here so the distinction cannot be
+// collapsed by a later change to either.
+func TestEvaluate_ConditionKeyTagSuffixFoldsToo(t *testing.T) {
+	t.Parallel()
+
+	suffixFolded := iamCaseFoldPolicy(emulator.IAMEffectAllow, "StringEquals", "aws:ResourceTag/tagkey1", "Value1")
+	result := emulator.Evaluate([]emulator.PolicyDocument{suffixFolded}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		Context: map[string]string{"aws:ResourceTag/TagKey1": "Value1"},
+	})
+	assert.Equal(t, emulator.DecisionAllow, result.Decision,
+		`AWS: the condition "matches a resource tag key named either TagKey1 or tagkey1"`)
+
+	// aws:TagKeys carries tag keys as *values*, so the same string is compared exactly.
+	// A policy listing "Env" does not admit a request tagging "env".
+	asValue := iamCaseFoldPolicy(emulator.IAMEffectAllow, "ForAllValues:StringEquals", "aws:TagKeys", "Env")
+	admitted := emulator.Evaluate([]emulator.PolicyDocument{asValue}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		MultiContext: map[string][]string{"aws:TagKeys": {"Env"}},
+	})
+	assert.Equal(t, emulator.DecisionAllow, admitted.Decision)
+
+	refused := emulator.Evaluate([]emulator.PolicyDocument{asValue}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		MultiContext: map[string][]string{"aws:TagKeys": {"env"}},
+	})
+	assert.Equal(t, emulator.DecisionImplicitDeny, refused.Decision,
+		"a tag key compared as a condition value stays case-sensitive")
+}
+
+// TestEvaluate_ConditionKeyFoldIsDeterministic pins the tie-break AWS leaves unstated.
+//
+// AWS says the condition matches either spelling "but not both", and names the hazard
+// without resolving it: "you might tag an Amazon EC2 instance with ec2=test1 and
+// EC2=test2 … the key name matches both tags, but only one value matches. This can
+// result in unexpected condition failures." Substrate has to answer with one of them,
+// so it answers with the first in sorted order.
+//
+// The loop is what makes this a test rather than a coincidence: a fold that returned
+// whichever key Go's randomized map iteration reached first would pass a single run
+// about half the time, and would put a *decision* at the mercy of map order — which an
+// event log that must replay identically cannot tolerate.
+func TestEvaluate_ConditionKeyFoldIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// "EC2" sorts before "ec2" (upper case is lower in ASCII), so the sorted-first rule
+	// answers with test2 and the StringEquals on test1 does not match.
+	doc := iamCaseFoldPolicy(emulator.IAMEffectAllow, "StringEquals", "aws:ResourceTag/Ec2", "test1")
+	req := emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		Context: map[string]string{
+			"aws:ResourceTag/ec2": "test1",
+			"aws:ResourceTag/EC2": "test2",
+		},
+	}
+
+	for range 200 {
+		result := emulator.Evaluate([]emulator.PolicyDocument{doc}, req)
+		require.Equal(t, emulator.DecisionImplicitDeny, result.Decision,
+			"the fold must resolve to the sorted-first name on every run, never to whichever key map iteration reached")
+	}
+
+	// The mirror image: asking for the value the sorted-first name holds always matches.
+	wins := iamCaseFoldPolicy(emulator.IAMEffectAllow, "StringEquals", "aws:ResourceTag/Ec2", "test2")
+	for range 200 {
+		result := emulator.Evaluate([]emulator.PolicyDocument{wins}, req)
+		require.Equal(t, emulator.DecisionAllow, result.Decision)
+	}
+}
+
+// TestEvaluate_ConditionOperatorStaysCaseSensitive pins the boundary of the fold.
+//
+// AWS's sentence is about context key *names*. Nothing documents an operator name as
+// case-insensitive, and an implementation that folded the whole Condition map key —
+// which is where the operator and its set qualifier live — would fold both. An
+// unrecognized operator denies, which is the safe direction and the one substrate
+// already took for a bare unknown operator.
+func TestEvaluate_ConditionOperatorStaysCaseSensitive(t *testing.T) {
+	t.Parallel()
+
+	for _, operator := range []string{"stringequals", "STRINGEQUALS", "forallvalues:StringEquals"} {
+		t.Run(operator, func(t *testing.T) {
+			t.Parallel()
+			doc := iamCaseFoldPolicy(emulator.IAMEffectAllow, operator, "ec2:CreateAction", "RunInstances")
+			result := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+				Action: "ec2:CreateTags", Resource: "*",
+				Context: map[string]string{"ec2:CreateAction": "RunInstances"},
+			})
+			assert.Equal(t, emulator.DecisionImplicitDeny, result.Decision,
+				"%q is not an operator substrate evaluates, and the key-name fold must not make it one", operator)
+		})
+	}
+}
+
+// TestEvaluate_NullResolvesTheSameWay covers the operator whose whole job is to tell an
+// absent key from a present one.
+//
+// Null is where a lookup that missed on case would be worst: it does not compare a
+// value, so a name that failed to resolve reads as a definite "this key is absent"
+// rather than as a mismatch. AWS's recommended ForAllValues + `"Null": "false"` pairing
+// is built on that answer, so a differently-cased name would flip the guard the pattern
+// exists to provide.
+func TestEvaluate_NullResolvesTheSameWay(t *testing.T) {
+	t.Parallel()
+
+	present := iamCaseFoldPolicy(emulator.IAMEffectAllow, "Null", "EC2:CreateAction", "false")
+	result := emulator.Evaluate([]emulator.PolicyDocument{present}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		Context: map[string]string{"ec2:CreateAction": "RunInstances"},
+	})
+	assert.Equal(t, emulator.DecisionAllow, result.Decision,
+		"the key is present, so Null:false is true however the policy spells the name")
+
+	absent := emulator.Evaluate([]emulator.PolicyDocument{present}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+	})
+	assert.Equal(t, emulator.DecisionImplicitDeny, absent.Decision,
+		"a key nothing in the request folds to is still absent")
+
+	// Null:true is the same question inverted, and reaches through MultiContext, which
+	// is the map condContextValue falls back to.
+	nullTrue := iamCaseFoldPolicy(emulator.IAMEffectAllow, "Null", "AWS:TagKeys", "true")
+	multi := emulator.Evaluate([]emulator.PolicyDocument{nullTrue}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		MultiContext: map[string][]string{"aws:TagKeys": {"Env"}},
+	})
+	assert.Equal(t, emulator.DecisionImplicitDeny, multi.Decision,
+		"the multivalued key resolves through the fold too, so Null:true is false")
+}
+
+// TestEvaluate_SetQualifiersResolveTheSameWay covers the pair whose disagreement about
+// an absent key makes an unresolved name dangerous in *both* directions at once.
+//
+// ForAllValues on an absent key is true — AWS: "It also returns true if there are no
+// context keys in the request" — so a name that failed to fold would grant a
+// ForAllValues Allow outright. ForAnyValue on an absent key is false, so the same
+// failure would make a ForAnyValue Allow a false deny. One lookup fixes both.
+func TestEvaluate_SetQualifiersResolveTheSameWay(t *testing.T) {
+	t.Parallel()
+
+	req := emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		MultiContext: map[string][]string{"aws:TagKeys": {"Env", "Owner"}},
+	}
+
+	// Owner is not in the policy's list, so ForAllValues is false — which is only
+	// reachable if the differently-cased name resolved to the request's two values.
+	forAll := iamCaseFoldPolicy(emulator.IAMEffectAllow, "ForAllValues:StringEquals", "aws:tagkeys", "Env")
+	assert.Equal(t, emulator.DecisionImplicitDeny,
+		emulator.Evaluate([]emulator.PolicyDocument{forAll}, req).Decision,
+		"an unresolved name would have read as no values in the request, which ForAllValues calls true")
+
+	forAllBoth := iamCaseFoldPolicy(emulator.IAMEffectAllow, "ForAllValues:StringEquals", "aws:tagkeys", "Env", "Owner")
+	assert.Equal(t, emulator.DecisionAllow,
+		emulator.Evaluate([]emulator.PolicyDocument{forAllBoth}, req).Decision)
+
+	forAny := iamCaseFoldPolicy(emulator.IAMEffectAllow, "ForAnyValue:StringEquals", "AWS:TAGKEYS", "Owner")
+	assert.Equal(t, emulator.DecisionAllow,
+		emulator.Evaluate([]emulator.PolicyDocument{forAny}, req).Decision,
+		"an unresolved name would have read as no values, which ForAnyValue calls false")
+
+	// A set qualifier over a key the request carries only in the *single-valued* map
+	// degrades to a one-element set — AWS's rule is about how many values the request
+	// context holds, and a producer that recorded one has still said the request carried
+	// it. That fallback needs the fold too: every key substrate populates on the
+	// enforcement path except aws:TagKeys is single-valued, so this is the shape a real
+	// ForAnyValue policy on aws:RequestTag/<key> actually meets.
+	single := emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		Context: map[string]string{"aws:RequestTag/Env": "prod"},
+	}
+	anyOnSingle := iamCaseFoldPolicy(emulator.IAMEffectAllow, "ForAnyValue:StringEquals",
+		"AWS:REQUESTTAG/ENV", "prod")
+	assert.Equal(t, emulator.DecisionAllow,
+		emulator.Evaluate([]emulator.PolicyDocument{anyOnSingle}, single).Decision,
+		"the single-valued fallback resolves the name as well")
+
+	allOnSingle := iamCaseFoldPolicy(emulator.IAMEffectAllow, "ForAllValues:StringEquals",
+		"AWS:REQUESTTAG/ENV", "staging")
+	assert.Equal(t, emulator.DecisionImplicitDeny,
+		emulator.Evaluate([]emulator.PolicyDocument{allOnSingle}, single).Decision,
+		"an unresolved name would have read as no values at all, which ForAllValues calls true")
+}
+
+// TestSimulate_MissingContextValuesFoldsTheName is the simulator's half of the same
+// rule, and the one a caller sees.
+//
+// A key the evaluator found by folding case must not also be reported as missing: the
+// simulation would then contradict the enforcement it exists to predict — an allowed
+// decision alongside a claim that the answer depends on a value the request supplied.
+// When the key genuinely is absent, the reported string is the **policy's** spelling,
+// because that is what the caller submitted and what they will compare against.
+func TestSimulate_MissingContextValuesFoldsTheName(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	// The policy spells the derived key in a different case from the one the simulation
+	// fills in from CallerArn.
+	folded := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"s3:GetObject","Resource":"*","Condition":{"ArnEquals":` +
+		`{"AWS:PRINCIPALARN":"arn:aws:iam::123456789012:user/alice"}}}]}`
+
+	got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{folded},
+		"CallerArn":       "arn:aws:iam::123456789012:user/alice",
+	})
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "allowed", got.results()[0].Decision)
+	assert.Empty(t, got.results()[0].MissingContextValues,
+		"the evaluator resolved the name, so nothing about this simulation is incomplete")
+
+	// The decisive case, because MissingContextValues is only *gathered* for a statement
+	// ruled out by its condition: the name resolves, and the value it resolves to does
+	// not match. The refusal is real and complete — supplying the key would change
+	// nothing, since the request already carries it — so the key must not be listed. A
+	// lookup that missed on case here would answer implicitDeny *and* claim the key was
+	// never supplied, which is the two-way contradiction a preflight must never produce.
+	mismatched := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"s3:GetObject","Resource":"*","Condition":{"ArnEquals":` +
+		`{"AWS:PRINCIPALARN":"arn:aws:iam::123456789012:user/bob"}}}]}`
+	refused := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{mismatched},
+		"CallerArn":       "arn:aws:iam::123456789012:user/alice",
+	})
+	require.Len(t, refused.results(), 1)
+	assert.Equal(t, "implicitDeny", refused.results()[0].Decision)
+	assert.Empty(t, refused.results()[0].MissingContextValues,
+		"the request supplied the key under another spelling, so the refusal is not for want of a value")
+
+	// A key nothing folds to is missing, and is reported exactly as the policy spelled
+	// it — that string reaches the wire, and canonicalizing it would answer a caller
+	// with a name they never wrote.
+	unknown := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"s3:GetObject","Resource":"*","Condition":{"Bool":` +
+		`{"AWS:MultiFactorAuthPresent":"true"}}}]}`
+	absent := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+		"ActionNames":     []string{"s3:GetObject"},
+		"PolicyInputList": []string{unknown},
+	})
+	require.Len(t, absent.results(), 1)
+	assert.Equal(t, "implicitDeny", absent.results()[0].Decision)
+	assert.Equal(t, []string{"AWS:MultiFactorAuthPresent"}, absent.results()[0].MissingContextValues,
+		"MissingContextValues echoes the submitted document, not substrate's preferred casing")
+}
+
+// TestSimulate_ContextEntriesFoldAgainstEachOther covers the one place a case-variant
+// duplicate can enter substrate at all: the caller supplies these names.
+//
+// Every internal producer writes a canonical literal, so two spellings of one key can
+// only arrive through ContextEntries. Letting both survive would leave the decision to
+// condResolveKey's sorted tie-break rather than to what the caller last said, so the
+// later entry overwrites the earlier under the earlier's spelling. Entries arrive in
+// wire-index order, which is the caller's own ordering.
+//
+// **Each call is repeated**, because collapsing here is what makes the answer a function
+// of the request at all. With both spellings in the map, the derived-key override in
+// simulationConditionContext iterates them in Go map order and deletes whichever folded
+// sibling it happens to meet first, so the surviving value — and the decision — differs
+// run to run. A single round trip would pass about half the time.
+func TestSimulate_ContextEntriesFoldAgainstEachOther(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	onProd := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"s3:GetObject","Resource":"*","Condition":{"StringEquals":` +
+		`{"aws:RequestTag/Env":"prod"}}}]}`
+
+	for range 40 {
+		got := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulateCustomPolicy", map[string]string{
+			"ActionNames.member.1":                              "s3:GetObject",
+			"PolicyInputList.member.1":                          onProd,
+			"ContextEntries.member.1.ContextKeyName":            "AWS:RequestTag/Env",
+			"ContextEntries.member.1.ContextKeyValues.member.1": "staging",
+			"ContextEntries.member.2.ContextKeyName":            "aws:requesttag/env",
+			"ContextEntries.member.2.ContextKeyValues.member.1": "prod",
+		}))
+		require.Len(t, got.results(), 1)
+		require.Equal(t, "allowed", got.results()[0].Decision,
+			"the last entry the caller sent is the value simulated with, on every run")
+	}
+
+	// Reversing the order reverses the answer, which is what "the caller's ordering
+	// decides" means.
+	for range 40 {
+		reversed := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulateCustomPolicy", map[string]string{
+			"ActionNames.member.1":                              "s3:GetObject",
+			"PolicyInputList.member.1":                          onProd,
+			"ContextEntries.member.1.ContextKeyName":            "aws:requesttag/env",
+			"ContextEntries.member.1.ContextKeyValues.member.1": "prod",
+			"ContextEntries.member.2.ContextKeyName":            "AWS:RequestTag/Env",
+			"ContextEntries.member.2.ContextKeyValues.member.1": "staging",
+		}))
+		require.Len(t, reversed.results(), 1)
+		require.Equal(t, "implicitDeny", reversed.results()[0].Decision)
+	}
+}
+
+// TestSimulate_ContextEntryOverridesADerivedKeyWhateverItsCase pins the rule
+// simulationConditionContext exists for, against a differently-cased entry.
+//
+// aws:PrincipalArn is derived from CallerArn because the simulation knows it. A caller
+// who names the key is stating what to simulate with instead — and before #704 a
+// differently-cased entry left the derived value in the map beside it, so which one the
+// evaluator read was decided by a sort rather than by the caller.
+//
+// The entry is spelled `aws:principalarn` deliberately: it sorts *after* the derived
+// `aws:PrincipalArn` (upper case is lower in ASCII), so an implementation that left both
+// in the map would answer with alice and deny. A spelling that sorted first would pass
+// this test whether or not the derived key was removed, and so would pin nothing.
+func TestSimulate_ContextEntryOverridesADerivedKeyWhateverItsCase(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	onBob := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+		`"Action":"s3:GetObject","Resource":"*","Condition":{"ArnEquals":` +
+		`{"aws:PrincipalArn":"arn:aws:iam::123456789012:user/bob"}}}]}`
+
+	got := iamDecodeSimulation(t, iamFormRequest(t, srv, "SimulateCustomPolicy", map[string]string{
+		"ActionNames.member.1":                              "s3:GetObject",
+		"PolicyInputList.member.1":                          onBob,
+		"CallerArn":                                         "arn:aws:iam::123456789012:user/alice",
+		"ContextEntries.member.1.ContextKeyName":            "aws:principalarn",
+		"ContextEntries.member.1.ContextKeyValues.member.1": "arn:aws:iam::123456789012:user/bob",
+	}))
+	require.Len(t, got.results(), 1)
+	assert.Equal(t, "allowed", got.results()[0].Decision,
+		"the caller's entry replaces the derived key rather than sitting beside it")
+}
+
+// TestEvaluate_ConditionKeyExactMatchIsUnaffected is the regression guard for the fast
+// path.
+//
+// Every policy substrate ships and every key any of its producers writes is spelled
+// canonically, so the overwhelming majority of lookups must still be the single map
+// read they were before #704 — and must still return the exact entry even when a
+// folded-equal sibling exists and sorts earlier.
+func TestEvaluate_ConditionKeyExactMatchIsUnaffected(t *testing.T) {
+	t.Parallel()
+
+	doc := iamCaseFoldPolicy(emulator.IAMEffectAllow, "StringEquals", "aws:ResourceTag/env", "exact")
+	result := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		Context: map[string]string{
+			"aws:ResourceTag/ENV": "sorts-first",
+			"aws:ResourceTag/env": "exact",
+		},
+	})
+	assert.Equal(t, emulator.DecisionAllow, result.Decision,
+		"an exact hit wins over a folded one, however the folded one sorts")
+
+	// And the canonical spelling of a key present only once behaves as it always did,
+	// which is the case the whole evaluator runs on.
+	assert.False(t, strings.EqualFold("aws:ResourceTag/env", "aws:ResourceTag/other"),
+		"guard against a fold so wide it matches unrelated names")
+	unrelated := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+		Action: "ec2:CreateTags", Resource: "*",
+		Context: map[string]string{"aws:ResourceTag/other": "exact"},
+	})
+	assert.Equal(t, emulator.DecisionImplicitDeny, unrelated.Decision)
+}

--- a/emulator/iam_eval.go
+++ b/emulator/iam_eval.go
@@ -278,6 +278,12 @@ func actionResourcePrincipalMatch(stmt PolicyStatement, req EvaluationRequest) b
 // multivalued key like aws:TagKeys lives in MultiContext, and reporting it as a
 // missing context value while the evaluator was in fact evaluating it would make a
 // simulation contradict the enforcement it exists to predict (#690).
+//
+// Resolution goes through [condResolveKey] for that same reason: a key the evaluator
+// found by folding case must not be reported as missing (#704). What is appended is
+// the **policy's** spelling, not the producer's — that string reaches the wire as
+// MissingContextValues, and a caller comparing it against the document it submitted
+// would not recognize a canonicalized name.
 func unsetConditionKeys(
 	conditions map[string]map[string]StringOrSlice,
 	ctx map[string]string,
@@ -286,10 +292,10 @@ func unsetConditionKeys(
 	var out []string
 	for _, keyValues := range conditions {
 		for condKey := range keyValues {
-			if _, ok := ctx[condKey]; ok {
+			if _, ok := condResolveKey(condKey, ctx); ok {
 				continue
 			}
-			if _, ok := multiCtx[condKey]; ok {
+			if _, ok := condResolveKey(condKey, multiCtx); ok {
 				continue
 			}
 			out = append(out, condKey)
@@ -554,6 +560,52 @@ func conditionKeyMatches(
 	return false
 }
 
+// condResolveKey resolves the name a policy spells against the names the request
+// context carries, matching case-insensitively, and reports the name to read under.
+//
+// AWS, in *IAM JSON policy elements: Condition*: "Context key *names* are not
+// case-sensitive. For example, including the aws:SourceIP context key is equivalent
+// to testing for AWS:SourceIp. Case-sensitivity of context key *values* depends on
+// the condition operator that you use." Only the name folds here; every operator in
+// [evaluateConditionKey] still compares values exactly as its own definition says,
+// which is why the fold lives in the lookup and not in the operator arms.
+//
+// The **whole** name folds, tag suffix included, on AWS's own statement about the
+// key–value form: "Key names are not case-sensitive. This means that if you specify
+// "aws:ResourceTag/TagKey1": "Value1" in the condition element of your policy, then
+// the condition matches a resource tag key named either TagKey1 or tagkey1, but not
+// both." That is the opposite of what #704 assumed. The case-sensitive rule #704
+// remembers governs a tag key used as a condition *value* — aws:TagKeys, and the tag
+// rules in [ec2_tags.go] — which is a different thing from a key name.
+//
+// "But not both" leaves unstated which of the two wins, and AWS names the resulting
+// hazard rather than resolving it: "you might tag an Amazon EC2 instance with
+// ec2=test1 and EC2=test2 … the key name matches both tags, but only one value
+// matches. This can result in unexpected condition failures." Substrate has to pick
+// one, so it picks the first in sorted order — a property of the request, never of Go
+// map iteration order, which an event log that must replay identically cannot depend
+// on. The minimum is selected in one pass rather than by sorting, which is the same
+// answer without the allocation.
+//
+// The exact match is answered first, so a policy spelling a key canonically — which
+// is every policy substrate itself ships, and every key any of its producers writes —
+// reads byte-identically to how it read before #704, and pays nothing for the fold.
+func condResolveKey[V any](condKey string, ctx map[string]V) (string, bool) {
+	if _, ok := ctx[condKey]; ok {
+		return condKey, true
+	}
+	name, found := "", false
+	for candidate := range ctx {
+		if !strings.EqualFold(candidate, condKey) {
+			continue
+		}
+		if !found || candidate < name {
+			name, found = candidate, true
+		}
+	}
+	return name, found
+}
+
 // condContextValue resolves the single value an unqualified operator compares
 // against.
 //
@@ -564,16 +616,21 @@ func conditionKeyMatches(
 // ForAllValues + `Null: false` pattern would deny every request it was written to
 // allow (#690).
 //
+// Both lookups go through [condResolveKey], so the policy's spelling of the name need
+// not be the producer's (#704).
+//
 // Only the first value can be reported — the caller compares a single string — which
 // is why AWS says not to use a single-valued operator on a multivalued key. Substrate
 // answers with the first value rather than with nothing, because for Null (the reason
 // this fallback exists) any value at all is the whole of what is being asked.
 func condContextValue(condKey string, ctx map[string]string, multiCtx map[string][]string) string {
-	if val, ok := ctx[condKey]; ok {
-		return val
+	if name, ok := condResolveKey(condKey, ctx); ok {
+		return ctx[name]
 	}
-	if vals := multiCtx[condKey]; len(vals) > 0 {
-		return vals[0]
+	if name, ok := condResolveKey(condKey, multiCtx); ok {
+		if vals := multiCtx[name]; len(vals) > 0 {
+			return vals[0]
+		}
 	}
 	return ""
 }
@@ -588,13 +645,15 @@ func condContextValue(condKey string, ctx map[string]string, multiCtx map[string
 //
 // An absent key yields no values, and the two qualifiers disagree about what that
 // means — true for ForAllValues, false for ForAnyValue — so the emptiness is returned
-// rather than resolved here.
+// rather than resolved here. That disagreement is why the name must fold here too: a
+// differently-cased key would read as absent, silently granting every
+// ForAllValues Allow and making every ForAnyValue Allow a false deny (#704).
 func condRequestValues(condKey string, ctx map[string]string, multiCtx map[string][]string) []string {
-	if vals, ok := multiCtx[condKey]; ok {
-		return vals
+	if name, ok := condResolveKey(condKey, multiCtx); ok {
+		return multiCtx[name]
 	}
-	if val, ok := ctx[condKey]; ok {
-		return []string{val}
+	if name, ok := condResolveKey(condKey, ctx); ok {
+		return []string{ctx[name]}
 	}
 	return nil
 }

--- a/emulator/iam_simulate.go
+++ b/emulator/iam_simulate.go
@@ -258,6 +258,14 @@ func (p *IAMPlugin) parseSimulateRequest(req *AWSRequest) (*iamSimulateRequest, 
 //
 // ContextKeyType is recorded by AWS but not consulted here — every condition operator
 // substrate implements compares strings.
+//
+// Two entries whose names differ only by case are one key, since that is how the
+// evaluator resolves a name (#704) — so the later entry overwrites the earlier, under
+// the spelling the earlier used. Letting both survive would leave the answer to
+// [condResolveKey]'s sorted tie-break, making a caller who sent AWS:PrincipalArn and
+// aws:PrincipalArn simulated against whichever sorts first rather than against what
+// they last said. Entries arrive in wire-index order, so "later" is the caller's own
+// ordering and not Go's.
 func simulationContextEntries(params map[string]string) (single map[string]string, multi map[string][]string) {
 	entries := iamMemberStructs(params, "ContextEntries")
 	if len(entries) == 0 {
@@ -269,6 +277,9 @@ func simulationContextEntries(params map[string]string) (single map[string]strin
 		name := entry["ContextKeyName"]
 		if name == "" {
 			continue
+		}
+		if existing, ok := condResolveKey(name, single); ok {
+			name = existing
 		}
 		values := iamMemberList(entry, "ContextKeyValues")
 		if len(values) == 0 {
@@ -606,9 +617,12 @@ func simulationDecision(decision string) string {
 // would otherwise report the key as a missing context value when the caller had in
 // fact told substrate what it is, through a differently-named parameter.
 //
-// An explicit ContextEntry wins over both. A caller who names a key is stating what
-// to simulate with, and overriding that with a derived value would make the
-// parameter unusable.
+// An explicit ContextEntry wins over both, whatever case it is spelled in. A caller
+// who names a key is stating what to simulate with, and overriding that with a derived
+// value would make the parameter unusable — which is what a plain assignment would do
+// for AWS:PrincipalArn before #704, since it left the derived aws:PrincipalArn in the
+// map beside it and the evaluator would then resolve to whichever sorted first.
+// Deleting the folded-equal name is what makes the caller's entry win.
 func simulationConditionContext(params *iamSimulateRequest, callerArn string) map[string]string {
 	ctx := make(map[string]string, len(params.context)+2)
 	if callerArn != "" {
@@ -618,6 +632,9 @@ func simulationConditionContext(params *iamSimulateRequest, callerArn string) ma
 		ctx["aws:ResourceAccount"] = params.ResourceOwner
 	}
 	for key, value := range params.context {
+		if derived, ok := condResolveKey(key, ctx); ok && derived != key {
+			delete(ctx, derived)
+		}
 		ctx[key] = value
 	}
 	return ctx


### PR DESCRIPTION
## The gap

AWS, in *IAM JSON policy elements: Condition*:

> Context key **names** are not case-sensitive. For example, including the `aws:SourceIP` context key is equivalent to testing for `AWS:SourceIp`. Case-sensitivity of context key **values** depends on the condition operator that you use.

Substrate matched the name byte-for-byte, so a policy spelling a key `ec2:createaction`, `AWS:RequestTag/Env` or `aws:tagkeys` — every one of which real IAM evaluates — was silently unmatched. It failed in **both** directions:

- an `Allow` written that way was an implicit deny: a false refusal, which a policy author sees immediately;
- a `Deny` written that way was **inert**, allowing what AWS refuses — which a policy author does not see at all.

Global to the evaluator rather than specific to any key. Found while implementing the second `ec2:CreateTags` pass (#691), which left a bare comment pointing here; this PR replaces that comment with a real subtest.

## What lands

**Read-time resolution** in the three functions that already take both context maps — `condContextValue`, `condRequestValues`, `unsetConditionKeys` — through one new helper, `condResolveKey`. No operator arm changes, so `Null` is fixed with them and `evaluateConditionKey` is untouched. An exact hit is still a single map read, so every canonically-spelled key (which is every key any substrate producer writes) behaves byte-identically and pays nothing.

**Write-time canonicalization was rejected**, and the code says why: `requestTagKeys` does a case-sensitive `CutPrefix` on `aws:RequestTag/`, so lowercasing the stored name would empty `aws:TagKeys` and flip every `ForAllValues:StringEquals` + `Null: false` policy — AWS's own recommended pattern, pinned in `iam_set_qualifiers_test.go`.

**Simulator.** `ContextEntries` is the only way two spellings of one key can enter substrate, so two such entries are collapsed to one — the later winning, under the earlier's spelling, in wire-index order — and a `ContextEntry` now overrides a derived `aws:PrincipalArn`/`aws:ResourceAccount` whatever its case. `MissingContextValues` still reports the **policy's** spelling (that string reaches the wire and the caller compares it against what they submitted), and a key the evaluator resolved by folding is no longer reported there at all.

### What deliberately does not fold

| Folded | Not folded |
|---|---|
| The whole key name, tag suffix included | The condition **value**, per each operator's own definition — which is why `StringEqualsIgnoreCase` is a separate operator |
| The service prefix (`aws:`, `ec2:`, `sts:`) | A tag key carried as a value, in `aws:TagKeys` |
| Names supplied through `ContextEntries` | The **operator** and its set qualifier: `stringequals` and `forallvalues:StringEquals` still deny |

## Two corrections to the issue

**1. The tag suffix folds — the opposite of what #704's scope section asked for.** AWS states it in the same breath as the key–value form:

> **Key names are not case-sensitive.** This means that if you specify `"aws:ResourceTag/TagKey1": "Value1"` in the condition element of your policy, then the condition matches a resource tag key named either `TagKey1` or `tagkey1`, **but not both**.

The case-sensitive rule the issue remembers is real, but it governs a tag key used as a condition **value** (`aws:TagKeys`, and substrate's own tag rules), which is a different thing from a key name. Both halves are pinned so the distinction cannot be collapsed later. Acceptance criterion 2 is therefore met in the opposite direction from the one it names, deliberately.

**2. The "two producers" hazard does not exist as described.** #704 asks that two producers writing the same key in different cases must not both survive. Every internal producer writes a canonical literal, so that cannot happen; the real entry point is caller-supplied `ContextEntries`, which is what this PR collapses.

## Provenance

The tie-break is substrate's. AWS's "but not both" does not say which spelling wins, and AWS names the resulting hazard rather than resolving it:

> AWS services that support these attributes might allow you to create multiple key names that differ only by case. For example, you might tag an Amazon EC2 instance with `ec2=test1` and `EC2=test2`. When you use a condition such as `"aws:ResourceTag/EC2": "test1"` to allow access to that resource, the key name matches both tags, but only one value matches. This can result in unexpected condition failures.

Substrate answers with the **first in sorted order** — a property of the request, never of Go's randomized map iteration, which a decision that must replay identically from the event log cannot depend on. An exact hit always wins over a folded one. Documented as substrate's explicit choice rather than presented as AWS's.

Also worth recording: the sentence #704 quotes ("the condition key is not case-sensitive and the condition value is case-sensitive") has been superseded on the live page. The key-name half is unchanged; the value half now reads "Case-sensitivity of context key values depends on the condition operator that you use" — which is exactly why `StringEqualsIgnoreCase` exists.

## Verification

`gofmt` / `go build` / `go vet` clean; `golangci-lint run ./...` **0 issues**; `make test` green with the race detector; `make coverage` **83.2% emulator / 82.6% total**; `make docs-reference docs-reference-check docs-versions` clean; VitePress build succeeded with **no broken anchors**; `go vet -C test/e2e ./... && go test -C test/e2e ./...` green.

**Fail-before:** with the fold reverted to an exact-only lookup, all 12 new tests go red.

**Mutation testing** — eleven mutations, each caught:

| Mutation | Result |
|---|---|
| M1 drop the exact-match fast path | caught |
| M2 take the sorted-**last** folded match | caught |
| M3 compare names exactly instead of folding | caught (17 tests) |
| M4 `condContextValue`: single map exact only | caught (14 tests) |
| M5 `condContextValue`: multi map exact only | caught |
| M6 `condRequestValues`: multi map exact only | caught |
| M7 `condRequestValues`: single map exact only | caught |
| M8 `unsetConditionKeys`: single map exact only | caught |
| M9 `unsetConditionKeys`: report the folded name, not the policy's | caught (4 tests) |
| M10 `simulationContextEntries`: let both spellings survive | caught |
| M11 `simulationConditionContext`: leave the derived key beside the caller's | caught |

M7, M8 and M10 survived the first pass and drove three test additions. M10 is the interesting one: without the entry-level collapse, the derived-key override iterates a map holding both spellings and deletes whichever folded sibling it meets first, so the **decision** differs run to run. A single round trip passed about half the time; the assertion is now looped, as the sorted-tie-break test already was.

**Live run** against the real AWS CLI v2 and a signed user access key — eleven sections, all as designed: a lowercase-keyed `Allow` now launches (`i-b1ea05b6…`) where it was refused; an `EC2:CREATEACTION` `Deny` is enforced rather than inert; `StringEquals` on the *value* still refuses `runinstances` for `RunInstances`; `AWS:REQUESTTAG/env` matches a request tagging `Env`; `aws:TagKeys` listing `env` still refuses a request tagging `Env`; a folded name is `allowed` with an empty `MissingContextValues`, while a genuinely absent `AWS:MultiFactorAuthPresent` is echoed back in the policy's own casing; case-variant `ContextEntries` resolved to the later entry on six consecutive runs; a lowercase `stringequals` still denies.

Closes #704