### PR TITLE
feat(iam): every condition operator AWS documents, and a producer for the keys they need (#714)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consumer's branch see; the member's five-value enumeration is followed over the filter's
   three-value one, per #671.
 
+- **Every condition operator AWS documents is evaluated, and `aws:CurrentTime` /
+  `aws:EpochTime` have a producer** (#714). Nine operators were implemented out of AWS's
+  twenty-six; the numeric family, the date family, the IP family, `BinaryEquals`,
+  `StringEqualsIgnoreCase`/`StringNotEqualsIgnoreCase` (which AWS uses in its own
+  `ec2:CreateTags` example) and the `...IfExists` suffix were all absent, and every one of them
+  fell to a deny — so a policy real IAM accepts and evaluates was, at best, a false refusal
+  here. The operator layer now lives in one place, `emulator/iam_condition_operators.go`, and
+  `docs/services.md` gained the operator reference it never had.
+
+  A date operator needs a clock, so `AuthController` gained an optional `TimeController`
+  (`WithAuthTimeController`) and both `aws:CurrentTime` and `aws:EpochTime` are populated from
+  it — read once per request, so every resource in one request is decided against one instant.
+  It is deliberately **not** `reqCtx.Timestamp`, which is `time.Now()` on the HTTP path: a date
+  condition sourced from the wall clock would decide differently on replay, and `replay.go`
+  calls `SetTime(event.Timestamp)` before dispatch precisely so it does not have to. An
+  `AuthController` built without a clock leaves both keys **absent** rather than falling back to
+  wall time — a documented false deny, in exchange for a replayable one. The simulator populates
+  the same pair from the IAM plugin's clock, because a simulation reporting a date condition as a
+  missing context value while the gate evaluated it would contradict the enforcement it exists to
+  predict.
+
+  **`aws:PrincipalArn` now has a producer on the enforcement path**, at all four gates that
+  build a condition context: the identity-policy and permission-boundary decision, the
+  tag-on-create pass, the IAM control-plane door and a role's trust policy. It was populated in
+  the simulator alone, from `CallerArn` — a divergence in the worst direction, since a caller
+  could simulate a policy conditioned on the key, watch it evaluate, and have the gate the
+  simulation exists to predict decide it differently. Writing it at every gate rather than only
+  where a condition on it is expected is what keeps a request that passes two gates from getting
+  two answers. It also could not have stayed simulator-only alongside the absent-key polarity
+  rule below: with the key missing, `"ArnNotEquals": {"aws:PrincipalArn": "…:user/carol"}` — the
+  shape of an exemption — is satisfied by every caller, so as a `Deny` it fires on carol herself
+  and as an `Allow` it grants everyone. That inversion was caught by a live SDK run against this
+  release's own operator work, before either shipped. `aws:PrincipalAccount`, `aws:userid` and `aws:username` are still absent: each
+  needs a derivation substrate cannot make honestly for every principal kind, and a key guessed
+  wrong is worse than one a policy can test for with `Null`.
+
+  Two rules substrate never had, both AWS's: **an absent key follows the operator's polarity**
+  ("If the policy condition requires that the key is *not* matched, such as `StringNotLike` or
+  `ArnNotLike`, and the right key is not present, the condition is `true`") — the old code passed
+  an empty string into the operator, which coincided with the right answer for the string family
+  and would have mis-answered the numeric and date ones; and **a key present with an empty value
+  counts as absent** ("resolves to a null dataset, such as an empty string"), everywhere except
+  `Null`, whose whole job is to see it.
+
+  Provenance: several readings are substrate's, because AWS documents no answer. A value that
+  cannot be parsed as the operator's type is **skipped** in the policy and **fails a positive
+  operator / satisfies a negated one** in the request context. `"2020"` is a legal W3C year and a
+  legal epoch second; the year wins. A bare IPv6 address is a `/128` — AWS's "IAM uses the
+  default prefix value of /32" is written for IPv4, and taking it literally would turn one
+  address into 2^96 of them. Go's spellings of infinity, NaN and hexadecimal floats are refused
+  as numbers, so `"Inf"` cannot satisfy `NumericGreaterThan` against every number in existence.
+  `ForAnyValue:<operator>IfExists` is the one place AWS's own two rules conflict — the qualifier
+  says an absent key is false, the suffix says it is true — and substrate reads the suffix as the
+  more specific annotation, on the strength of AWS's gloss that other elements "can still result
+  in a nonmatch, but not a missing key when checked with `...IfExists`". A **set-qualified
+  `Null`** does not match at all: AWS defines neither `ForAllValues:Null` nor `ForAnyValue:Null`,
+  and quantifying an existence test over the values whose existence it is testing has no meaning.
+  Nothing validates an operator *name* at write time, where real IAM answers
+  `MalformedPolicyDocument`, so a misspelled operator is stored and discarded at evaluation.
+
+
 ### Changed
 - **`RegisterImage` records the whole block device mapping it is sent** (#711). It read exactly
   one thing out of it — the first `BlockDeviceMapping.N.Ebs.SnapshotId`, found by a hand walk of
@@ -692,6 +753,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keep telling the two apart: a bare `filters[name]` index yields the same nil slice for
   "absent" and "present with no values", which under the new rule would have emptied the
   catalog for an unfiltered query.
+
+- **A set-qualified condition granted the statement it should have denied** (#714). Under
+  `ForAllValues:<operator>` or `ForAnyValue:<operator>`, an absent condition key answered `true`
+  **without consulting the operator at all** — so an `Allow` conditioned on
+  `ForAllValues:NumericLessThan`, or on a misspelled operator name, was *granted*. Given how few
+  condition keys substrate populates, the absent key was the common case, and #714 recorded the
+  opposite ("falls to the closing deny-by-default"), as did `docs/services.md`. The vacuous truth
+  is itself AWS's rule — "The `ForAllValues` qualifier returns true if there are no context keys
+  in the request" — and it stays, but only for an operator substrate actually evaluates; an
+  unrecognized one, and a qualified `Null`, now deny. Recognition and the answer come from one
+  function so the two cannot drift: a second list of operator names would have re-opened the hole
+  the first time an operator was added to only one of them.
+
+- **An ARN condition's wildcards no longer match across a colon** (#714). AWS: "Each of the six
+  colon-delimited components of the ARN is checked separately and each can include multi-character
+  match wildcards (`*`) or single-character match wildcards (`?`)." Substrate ran one glob over
+  the whole string, so `arn:aws:sns:*:TOPIC-ID` — five components — matched
+  `arn:aws:sns:us-east-1:123456789012:TOPIC-ID`, authorizing a resource in an account the pattern
+  never mentioned. The resource component may legitimately contain colons (an SNS subscription
+  ARN), so the split is bounded at six and the remainder stays in the last component, where AWS's
+  own wildcard examples put it. A pattern naming fewer than six components has the missing
+  trailing ones filled with `*`; AWS states that rule for a `Resource` element and not for a
+  condition, so it is substrate's reading, chosen because refusing to match a short pattern would
+  silently narrow a `Deny` — the direction that cannot be recovered from.
+
+- **`ArnNotEquals` and `ArnNotLike` honour wildcards** (#714). They compared with `==`, so no
+  real ARN was ever equal to a pattern containing a `*` and the negation was **always
+  satisfied**. `"ArnNotEquals": {"aws:PrincipalArn": "arn:aws:iam::123456789012:role/*"}` on a
+  `Deny` therefore fired against every principal, including the roles the pattern existed to
+  exempt; on an `Allow` — "grant anyone who is not one of these" — it granted every principal,
+  including the ones it named to exclude. #714 described the effect as an inert `Deny`; it is the
+  opposite, and the `Allow` direction is the dangerous one. Both operators are now the negation of
+  their positive pair, which is AWS's rule and not an approximation: "The `ArnNotEquals` and
+  `ArnNotLike` condition operators behave identically." #714's related claim — that aliasing
+  `ArnLike` to `ArnEquals` is wrong — is **refuted** by the same page's "The `ArnEquals` and
+  `ArnLike` condition operators behave identically"; the alias was correct.
+
+- **A policy that writes a number or a Boolean unquoted is no longer `MalformedPolicyDocument`**
+  (#714). The IAM grammar: "Values are enclosed in quotation marks. **Quotation marks are
+  optional for numeric and Boolean values.**" `{"Bool": {"aws:SecureTransport": false}}` and
+  `{"NumericLessThanEquals": {"s3:max-keys": 10}}` are both legal IAM and both were rejected
+  outright, which is a live `Bool` bug independent of the numeric family and was a prerequisite
+  for it. A number keeps the spelling the document used, through `json.Number`: routing it
+  through a float would render `10` as `1e+01` and round a value too large for a `float64` before
+  the comparison ever saw it. The tolerance reaches `Action` and `Resource`, which share the type,
+  and is left there because the effect is bounded and safe — an `"Action": 5` becomes the action
+  name `"5"`, which matches nothing.
 
 ## [v0.106.0] - 2026-08-21
 

--- a/cmd/substrate/main.go
+++ b/cmd/substrate/main.go
@@ -134,7 +134,8 @@ configured address will have their requests emulated and recorded.`,
 			// resource calls are dispatched in process rather than through the server,
 			// so they are authorized by the controller the plugin holds rather than by
 			// the one ServerOptions.Auth names. It is the same controller either way.
-			authCtrl := substrate.NewAuthController(state, logger)
+			authCtrl := substrate.NewAuthController(state, logger,
+				substrate.WithAuthTimeController(tc))
 
 			if err := substrate.RegisterDefaultPlugins(initCtx, registry, state, tc, logger, store, cfg,
 				substrate.WithPluginAuth(authCtrl)); err != nil {

--- a/docs/services.md
+++ b/docs/services.md
@@ -1023,6 +1023,131 @@ by case are one key, and the later one wins, under the earlier one's spelling. A
 `ContextEntry` also overrides a derived `aws:PrincipalArn` or `aws:ResourceAccount`
 however it is cased.
 
+### Which condition operators substrate evaluates
+
+Every operator AWS documents, in all five families, plus the `...IfExists` suffix on each
+of them.
+
+| Family | Operators | Comparison |
+|---|---|---|
+| String | `StringEquals`, `StringNotEquals`, `StringEqualsIgnoreCase`, `StringNotEqualsIgnoreCase`, `StringLike`, `StringNotLike` | Exact, case-folded, or globbed with `*` and `?` |
+| Numeric | `NumericEquals`, `NumericNotEquals`, `NumericLessThan`, `NumericLessThanEquals`, `NumericGreaterThan`, `NumericGreaterThanEquals` | Both sides read as decimals |
+| Date | `DateEquals`, `DateNotEquals`, `DateLessThan`, `DateLessThanEquals`, `DateGreaterThan`, `DateGreaterThanEquals` | W3C ISO 8601 (`2020-01-01T00:00:00Z` down to `2020`) or epoch seconds, on either side |
+| Boolean | `Bool` | `true` / `false` |
+| Binary | `BinaryEquals` | Base64 text, compared as AWS's own example table does |
+| IP | `IpAddress`, `NotIpAddress` | CIDR containment, IPv4 and IPv6 |
+| ARN | `ArnEquals`, `ArnLike`, `ArnNotEquals`, `ArnNotLike` | Six components, each globbed separately |
+| Existence | `Null` | `true` matches an absent key, `false` a present one |
+
+Three details of the comparisons are worth stating, because they are the ones a policy
+written against real IAM depends on:
+
+- **An ARN's six components are compared one at a time**, per AWS: "Each of the six
+  colon-delimited components of the ARN is checked separately and each can include
+  multi-character match wildcards (`*`) or single-character match wildcards (`?`)." So
+  `arn:aws:sns:*:TOPIC-ID` does **not** match
+  `arn:aws:sns:us-east-1:123456789012:TOPIC-ID` — a `*` cannot cross a colon. A pattern
+  naming fewer than six components has the missing trailing ones filled with `*`.
+  `ArnEquals`/`ArnLike` are one operator and `ArnNotEquals`/`ArnNotLike` are its negation,
+  which is AWS's rule, not an approximation: "The `ArnEquals` and `ArnLike` condition
+  operators behave identically."
+- **A bare IP address is a host route** — `/32` for IPv4, as AWS says, and `/128` for
+  IPv6, which AWS's IPv4-written sentence does not cover.
+- **Unquoted numbers and Booleans are accepted**, per the grammar: "Values are enclosed in
+  quotation marks. Quotation marks are optional for numeric and Boolean values." So
+  `{"Bool": {"aws:SecureTransport": false}}` and
+  `{"NumericLessThanEquals": {"s3:max-keys": 10}}` are read as written, and a number keeps
+  the spelling the document used.
+
+**A key the request context does not carry follows the operator's polarity**, which is
+AWS's rule: "If the key that you specify in a policy condition is not present in the
+request context, the values do not match and the condition is `false`. If the policy
+condition requires that the key is **not** matched, such as `StringNotLike` or
+`ArnNotLike`, and the right key is not present, the condition is `true`." A key present
+with an empty value counts as absent — AWS's own phrase is a value that "resolves to a
+null dataset, such as an empty string" — except to `Null`, which is the operator whose
+whole job is to see it.
+
+**`...IfExists` on any operator but `Null`.** AWS excludes `Null` explicitly ("any
+condition operator name except the `Null` condition"), so `NullIfExists` does not match;
+`Null` already answers the question the suffix asks. On a `Deny`, a negated `IfExists`
+still fires on an absent key, which is AWS's documented behaviour and the reason the
+suffix is safe to write in a guardrail.
+
+**A value substrate cannot parse as the operator's type** is substrate's own choice, since
+AWS documents neither side. In the *policy*, such a value is skipped, so one unparseable
+element of a list does not decide the answer. In the *request context*, it fails a positive
+operator and satisfies a negated one, on the reasoning that a comparison that cannot be
+made has not been satisfied. Two consequences: `"2020"` is read as a year rather than as
+epoch second 2020, the one place the two date notations collide; and Go's spellings of
+infinity, NaN and hexadecimal floats are not numbers, so `"Inf"` cannot satisfy
+`NumericGreaterThan` against every number in existence.
+
+**An operator substrate does not recognize denies.** Real IAM validates operator names when
+the document is submitted, answering `MalformedPolicyDocument`; substrate does not, so a
+misspelled operator is stored and then discarded at evaluation. Denying is substrate's
+choice and the only one that cannot turn a typo into a grant — including under a set
+qualifier, where an unrecognized operator over an absent key used to be
+[vacuously true](#multivalued-condition-keys-forallvalues-and-foranyvalue) and *granted*
+the statement.
+
+#### Which keys have a producer
+
+An operator is only as useful as the keys it can compare. Substrate populates these, and
+nothing else:
+
+| Key | Where it comes from |
+|---|---|
+| `aws:RequestTag/<key>`, `aws:TagKeys` | The tags the request asks to apply |
+| `aws:ResourceTag/<key>` | The tags on each resource the request names |
+| `aws:CurrentTime`, `aws:EpochTime` | The emulator's simulated clock |
+| `ec2:CreateAction` | [A tagged create's second authorization pass](#a-tagged-create-is-authorized-twice) |
+| `ec2:Subnet`, `ec2:Vpc` | [A launch's networking resources](#a-launch-s-networking-resources-carry-ec2-subnet-and-ec2-vpc) |
+| `sts:ExternalId` | An `AssumeRole` that supplied one |
+| `aws:PrincipalArn` | The caller, at every gate — identity policy, permission boundary, [tag-on-create](#a-tagged-create-is-authorized-twice), the IAM control plane and a role's trust policy |
+| `aws:ResourceAccount` | A **simulation** only, from `ResourceOwner` |
+| Anything at all | A simulation's `ContextEntries` |
+
+The time pair comes from the emulator's `TimeController`, not the wall clock, so a
+recorded request replays to the same decision. An `AuthController` constructed without one
+leaves both keys **absent** rather than falling back to `time.Now()`: a date condition then
+reports a missing key and denies, which is a false refusal, but a replayable one.
+
+`aws:PrincipalArn` is written at every gate rather than only where a condition on it is
+expected, because a request that passes two gates must get one answer from both. It is also
+why the key could not stay simulator-only once the negated operators arrived: AWS answers
+*true* for a negated operator over an absent key, so
+`"ArnNotEquals": {"aws:PrincipalArn": "arn:aws:iam::*:user/carol"}` — an exemption — was
+satisfied by every caller. As a `Deny` it fired on carol herself; as an `Allow` it granted
+everyone.
+
+What has **no** producer, and therefore never matches on the enforcement path:
+
+- `aws:SecureTransport`, `aws:username`, `aws:userid`, `aws:MultiFactorAuthPresent`,
+  `aws:MultiFactorAuthAge`, `aws:SourceIp`, `aws:SourceVpc`, `aws:PrincipalOrgID` and
+  every other key not in the table above. The IP family is therefore correct but
+  satisfiable only through a simulation's `ContextEntries`. (S3's
+  [public-access analysis](#block-public-access) reads an `aws:SourceIp` condition out of a
+  *bucket policy* to judge how broad it is, which is a different question from evaluating
+  one against a request.)
+- `aws:PrincipalAccount`, `aws:userid` and `aws:username`, even though `aws:PrincipalArn`
+  is populated beside them. Each needs a derivation substrate cannot make honestly for
+  every principal kind — it mints no unique ID, and a role session's user name is not the
+  last component of its ARN — and a key guessed wrong is worse than one a policy can test
+  for with `Null`.
+- Every key the bundled AWS managed policies condition on: `iam:PassedToService`,
+  `iam:AWSServiceName`, `aws:CalledViaLast`, `elasticloadbalancing:CreateAction`,
+  `devops-guru:ServiceNames`, and `ec2:ResourceTag/<key>` (substrate produces
+  `aws:ResourceTag/<key>`). Each is a false deny in the safe direction: all 32 condition
+  blocks in the bundled catalog sit on an `Allow`, so such a statement grants nothing
+  rather than a `Deny` going inert.
+
+**Substrate performs no policy-variable substitution.** A `${aws:username}` in a resource
+ARN or a condition value is compared literally, so the `${aws:username}` in the bundled
+`IAMUserChangePassword` policy matches no user. AWS substitutes the value before
+evaluating; substrate does not, and a policy relying on it grants nothing rather than
+granting the wrong thing.
+
 ### Multivalued condition keys: `ForAllValues` and `ForAnyValue`
 
 A condition key is either **single-valued** — at most one value in the request context —
@@ -1036,6 +1161,8 @@ context maps, and only the multivalued one is quantified over.
 | `StringEquals` and the other eight operators, unqualified | Compares the single-valued context. Unchanged by anything in this section |
 | `ForAllValues:<operator>` | True when **every** value the request carries satisfies the operator — and **true when the key is absent or carries no values** |
 | `ForAnyValue:<operator>` | True when **at least one** value satisfies it; **false when the key is absent or carries no values** |
+| Either qualifier on an operator substrate does not [recognize](#which-condition-operators-substrate-evaluates) | Does not match, absent key or not |
+| Either qualifier on `Null` | Does not match. AWS defines no set-qualified `Null`, and quantifying an existence test over the values whose existence it is testing has no meaning |
 | Anything else in that position | Does not match. `ForSomeValues:StringEquals`, or a lowercase `forallvalues:`, denies rather than being read as unqualified |
 
 Both absent-key rules are AWS's, quoted: `ForAllValues` "also returns `true` if there are no
@@ -1058,9 +1185,15 @@ Seen from the `Deny` side the same vacuity bites the other way — a `ForAllValu
 fires on the request that carries no keys — so a guardrail is better written with
 `ForAnyValue`.
 
-Treating an unrecognized qualifier as a non-match is substrate's own choice, consistent with
-the deny-by-default it already applies to an unrecognized operator; everything else here is
-documented behaviour.
+The two absent-key rules are AWS's, but they are also what used to make the qualifiers
+dangerous: substrate answered `true` for `ForAllValues:<anything>` over an absent key
+**without consulting the operator at all**, so an `Allow` written with an operator it could
+not evaluate — or with a misspelled one, which nothing rejects at write time — was granted.
+The vacuous truth now applies only to an operator substrate
+[actually evaluates](#which-condition-operators-substrate-evaluates); an unrecognized one,
+and a qualified `Null`, deny. Treating an unrecognized qualifier or operator as a non-match
+is substrate's own choice — real IAM refuses the document instead — and it is the only choice
+that cannot turn a typo into a grant. Everything else here is documented behaviour.
 
 #### Which keys are multivalued
 
@@ -1075,11 +1208,12 @@ request asked for, and its value is **sorted** — a `ForAllValues` denial that 
 map iteration order could not replay from the event log.
 
 Everything else substrate populates is single-valued: `aws:RequestTag/<key>` and
-`aws:ResourceTag/<key>` on an authorized request, `ec2:CreateAction` on [a tagged create's
+`aws:ResourceTag/<key>` on an authorized request, `aws:CurrentTime` and `aws:EpochTime`
+from the simulated clock, `ec2:CreateAction` on [a tagged create's
 second authorization pass](#a-tagged-create-is-authorized-twice),
 [`ec2:Subnet` and `ec2:Vpc`](#a-launch-s-networking-resources-carry-ec2-subnet-and-ec2-vpc) on a
 launch's networking resources, `sts:ExternalId` when a role
-is assumed, and `aws:PrincipalArn` / `aws:ResourceAccount` in a simulation. A set qualifier on one of
+is assumed, `aws:PrincipalArn` at every gate, and `aws:ResourceAccount` in a simulation. A set qualifier on one of
 those is evaluated over a one-element set — which is the thing AWS warns against writing,
 not something substrate refuses. Over one that is **absent** it is vacuously true, which is
 the other half of the same warning.

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // AuthController enforces IAM policy decisions for all AWS service requests.
@@ -17,11 +19,93 @@ import (
 type AuthController struct {
 	state  StateManager
 	logger Logger
+	tc     *TimeController
+}
+
+// AuthControllerOption configures an [AuthController].
+type AuthControllerOption func(*AuthController)
+
+// WithAuthTimeController gives the controller the simulated clock, which is what makes
+// aws:CurrentTime and aws:EpochTime available to a policy condition.
+//
+// Without it those two keys are absent from every request context, so a condition
+// naming either is a false deny rather than a wall-clock answer. That is deliberate:
+// substrate's guarantee is that a recorded run replays identically, and a date
+// condition evaluated against time.Now() would decide differently on replay. A caller
+// wiring authorization into a server has a TimeController already — the server reads
+// it one line above the authorization call — so the honest default is to say the keys
+// are unavailable rather than to reach for the wall clock (#714).
+func WithAuthTimeController(tc *TimeController) AuthControllerOption {
+	return func(a *AuthController) {
+		a.tc = tc
+	}
 }
 
 // NewAuthController creates an AuthController backed by state and logger.
-func NewAuthController(state StateManager, logger Logger) *AuthController {
-	return &AuthController{state: state, logger: logger}
+//
+// The options are variadic so that adding the clock did not change the signature
+// every caller and every test already uses.
+func NewAuthController(state StateManager, logger Logger, opts ...AuthControllerOption) *AuthController {
+	a := &AuthController{state: state, logger: logger}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+// authzTimeContext writes the two clock-derived condition keys into ctx, if the
+// controller was given a clock.
+//
+// AWS documents the pair as the keys its date operators are used with:
+// aws:CurrentTime is "the date and time of the request" in ISO 8601 / RFC 3339 form,
+// aws:EpochTime the same instant "in Unix time" — so they are one reading of one clock
+// rendered two ways, and a policy testing them against each other cannot disagree.
+//
+// The instant is read once per request rather than once per resource, so a request
+// naming several resources is evaluated at one time. reqCtx.Timestamp is deliberately
+// not the source: it is time.Now() on the HTTP path, so a condition sourced from it
+// would be unreplayable for every real SDK request.
+func (a *AuthController) authzTimeContext(ctx map[string]string, now time.Time, ok bool) {
+	if !ok {
+		return
+	}
+	ctx["aws:CurrentTime"] = now.UTC().Format(time.RFC3339)
+	ctx["aws:EpochTime"] = strconv.FormatInt(now.Unix(), 10)
+}
+
+// authzPrincipalContext writes the condition key that names the caller.
+//
+// AWS documents aws:PrincipalArn as "the ARN of the principal that made the request",
+// present in the context of every request a principal signs. Substrate knows it with
+// certainty — it is the ARN the evaluation below is run for, and the one the denial
+// message names — so leaving it out reported as missing a key the request itself carries.
+// The simulator has always derived it from CallerArn ([simulationConditionContext]), so
+// the two paths disagreed about the one key a simulation is most often written about.
+//
+// Omitting it stopped being merely a false deny once the negated operators arrived
+// (#714). AWS's rule is that a negated operator over an absent key is *true*, so with the
+// key missing, `"ArnNotEquals": {"aws:PrincipalArn": "arn:aws:iam::*:user/carol"}` — the
+// shape of an exemption — was satisfied by every caller: as a Deny it fired against carol
+// herself, and as an Allow it granted everyone. The absence turned an exemption into its
+// opposite, which is why the producer lands with the operators rather than after them.
+//
+// aws:PrincipalAccount, aws:userid and aws:username are deliberately still absent: each
+// needs a derivation this function cannot do honestly for every principal kind — a unique
+// ID substrate does not mint, a name that is not the last ARN component for a role
+// session — and a key guessed wrong is worse than one a policy can test for with Null.
+func authzPrincipalContext(ctx map[string]string, principalARN string) {
+	if principalARN == "" {
+		return
+	}
+	ctx["aws:PrincipalArn"] = principalARN
+}
+
+// now reports the controlled time, and whether there is a clock to read it from.
+func (a *AuthController) now() (time.Time, bool) {
+	if a.tc == nil {
+		return time.Time{}, false
+	}
+	return a.tc.Now(), true
 }
 
 // CheckAccess returns nil when the caller is allowed or when reqCtx.Principal
@@ -38,6 +122,7 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		return nil
 	}
 	resources := a.buildResourceARNs(reqCtx, req)
+	now, haveClock := a.now()
 
 	goCtx := context.Background()
 	entity, exists, err := resolveIAMEntity(goCtx, a.state, reqCtx.Principal.ARN)
@@ -119,6 +204,8 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		for k, v := range res.Context {
 			condCtx[k] = v
 		}
+		a.authzTimeContext(condCtx, now, haveClock)
+		authzPrincipalContext(condCtx, reqCtx.Principal.ARN)
 
 		result := Evaluate(docs, EvaluationRequest{
 			Principal:    reqCtx.Principal.ARN,
@@ -157,7 +244,7 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 
 	// The create is allowed. If it also applies tags, AWS authorizes those separately
 	// against ec2:CreateTags, and the caller needs that permission too (#691).
-	return a.checkEC2TagOnCreate(reqCtx, req, docs, boundary, requestTags, deniedCode)
+	return a.checkEC2TagOnCreate(reqCtx, req, docs, boundary, requestTags, deniedCode, now, haveClock)
 }
 
 // checkEC2TagOnCreate runs the second authorization pass AWS performs on
@@ -182,7 +269,8 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 // pass evaluates are the same reading of the same request, plus whatever a launch
 // template supplies.
 func (a *AuthController) checkEC2TagOnCreate(reqCtx *RequestContext, req *AWSRequest,
-	docs []PolicyDocument, boundary *PolicyDocument, requestTags map[string]string, deniedCode string) error {
+	docs []PolicyDocument, boundary *PolicyDocument, requestTags map[string]string, deniedCode string,
+	now time.Time, haveClock bool) error {
 	if req.Service != "ec2" {
 		return nil
 	}
@@ -206,6 +294,11 @@ func (a *AuthController) checkEC2TagOnCreate(reqCtx *RequestContext, req *AWSReq
 	// only here, which is why a direct CreateTags cannot satisfy a statement conditioned
 	// on it — the behavior AWS's examples call "users cannot tag existing resources".
 	condCtx[ec2CreateActionCondKey] = req.Operation
+	a.authzTimeContext(condCtx, now, haveClock)
+	// The same caller signed the same request, so this gate must name the same principal
+	// as the primary decision — a request authorized twice against two different answers
+	// for aws:PrincipalArn would deny on one door and allow on the other (#714).
+	authzPrincipalContext(condCtx, reqCtx.Principal.ARN)
 
 	// Derived from the merged map above rather than reused from the primary decision, so
 	// a template-supplied key is in aws:TagKeys too — AWS's combined example conditions

--- a/emulator/iam_condition_clock_test.go
+++ b/emulator/iam_condition_clock_test.go
@@ -1,0 +1,168 @@
+package emulator_test
+
+import (
+	"log/slog"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// aws:CurrentTime and aws:EpochTime come from the simulated clock (#714).
+//
+// The date operators are useless without a producer for the keys AWS's own examples
+// condition on, and there was none: every date condition read a missing key. The clock
+// is the emulator's TimeController rather than time.Now(), so a replayed request decides
+// the same way it did when it was recorded — replay.go calls SetTime(event.Timestamp)
+// before dispatch, and a decision sourced from the wall clock would ignore it.
+
+// iamClockTestTime is the instant these tests seed the controller with. It is far from
+// any boundary they assert against, so the sub-second advance TimeController.Now()
+// applies cannot flip a comparison.
+func iamClockTestTime() time.Time {
+	return time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+}
+
+// iamClockCheckAccess authorizes one s3:GetObject through an AuthController carrying the
+// inline policy doc, with the clock plumbed in or left out.
+func iamClockCheckAccess(t *testing.T, doc *emulator.PolicyDocument, withClock bool) error {
+	t.Helper()
+	state := newAuthzGroupState(t, "jill", "devs", authzGroupState{UserInline: doc})
+	logger := emulator.NewDefaultLogger(slog.LevelError, false)
+	opts := []emulator.AuthControllerOption{}
+	if withClock {
+		opts = append(opts, emulator.WithAuthTimeController(emulator.NewTimeController(iamClockTestTime())))
+	}
+	auth := emulator.NewAuthController(state, logger, opts...)
+	return auth.CheckAccess(
+		newAuthTestReqCtx("arn:aws:iam::123456789012:user/jill"),
+		&emulator.AWSRequest{Service: "s3", Operation: "GetObject", Path: "/bucket/key"})
+}
+
+// iamClockPolicy is a one-condition Allow for s3:GetObject.
+func iamClockPolicy(operator, condKey, condValue string) *emulator.PolicyDocument {
+	return &emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   emulator.IAMEffectAllow,
+			Action:   emulator.StringOrSlice{"s3:GetObject"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				operator: {condKey: emulator.StringOrSlice{condValue}},
+			},
+		}},
+	}
+}
+
+// TestAuthController_ClockPopulatesTheTimeKeys walks a date and a numeric condition
+// against the seeded instant, in both directions.
+//
+// The Null rows are the load-bearing ones: they assert the key is *populated* without
+// reference to its value, so they hold whatever the clock says. The comparison rows then
+// assert the rendering is one the date and numeric operators can actually read — a key
+// present but written in some form condParseTime rejects would pass the Null rows and
+// fail these.
+func TestAuthController_ClockPopulatesTheTimeKeys(t *testing.T) {
+	t.Parallel()
+
+	now := iamClockTestTime()
+	cases := []struct {
+		name      string
+		operator  string
+		condKey   string
+		condValue string
+		allowed   bool
+	}{
+		{"CurrentTime exists", "Null", "aws:CurrentTime", "false", true},
+		{"EpochTime exists", "Null", "aws:EpochTime", "false", true},
+		{"after the seeded instant", "DateGreaterThan", "aws:CurrentTime", "2026-03-04T05:00:00Z", true},
+		{"before the seeded instant", "DateLessThan", "aws:CurrentTime", "2026-03-04T05:00:00Z", false},
+		{"before a later instant", "DateLessThan", "aws:CurrentTime", "2026-03-04T06:00:00Z", true},
+		{"epoch is a number", "NumericGreaterThan", "aws:EpochTime", strconv.FormatInt(now.Add(-time.Hour).Unix(), 10), true},
+		{"epoch orders correctly", "NumericGreaterThan", "aws:EpochTime", strconv.FormatInt(now.Add(time.Hour).Unix(), 10), false},
+		// The two spellings must name the same instant, which a test comparing each
+		// against its own literal would not catch.
+		{"epoch read as a date", "DateGreaterThan", "aws:EpochTime", "2026-03-04T05:00:00Z", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := iamClockCheckAccess(t, iamClockPolicy(tc.operator, tc.condKey, tc.condValue), true)
+			if tc.allowed {
+				assert.NoError(t, err, "%s %s %s", tc.operator, tc.condKey, tc.condValue)
+				return
+			}
+			require.Error(t, err)
+			var awsErr *emulator.AWSError
+			require.ErrorAs(t, err, &awsErr)
+			assert.Equal(t, "AccessDenied", awsErr.Code)
+		})
+	}
+}
+
+// TestAuthController_WithoutAClockTheTimeKeysAreAbsent pins the documented false deny.
+//
+// An AuthController built without a TimeController leaves both keys out of the request
+// context rather than falling back to time.Now(). A date condition then reports a
+// missing key and denies, which is wrong but safe and replay-stable; sourcing the value
+// from the wall clock would make a replayed decision disagree with the recorded one.
+func TestAuthController_WithoutAClockTheTimeKeysAreAbsent(t *testing.T) {
+	t.Parallel()
+
+	for _, condKey := range []string{"aws:CurrentTime", "aws:EpochTime"} {
+		t.Run(condKey, func(t *testing.T) {
+			t.Parallel()
+			// Null:true is satisfied only by an absent key, so this row asserts absence
+			// directly rather than inferring it from a denial that any bug would produce.
+			assert.NoError(t, iamClockCheckAccess(t, iamClockPolicy("Null", condKey, "true"), false),
+				"%s must be absent without a clock", condKey)
+			assert.Error(t, iamClockCheckAccess(t, iamClockPolicy("Null", condKey, "false"), false))
+		})
+	}
+}
+
+// TestSimulate_ClockPopulatesTheTimeKeys is the same pair on the simulation path.
+//
+// A simulation reporting aws:CurrentTime in MissingContextValues while the enforcement
+// gate evaluated it would contradict the enforcement it exists to predict — and the
+// simulator is the only place a consumer can see that a key is missing, so the
+// disagreement would be visible and misleading.
+//
+// The assertions are on existence rather than on the instant, because the test server's
+// controller is seeded from time.Now(); the enforcement tests above own the rendering.
+func TestSimulate_ClockPopulatesTheTimeKeys(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+
+	for _, condKey := range []string{"aws:CurrentTime", "aws:EpochTime"} {
+		t.Run(condKey, func(t *testing.T) {
+			policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+				`"Action":"s3:GetObject","Resource":"*",` +
+				`"Condition":{"Null":{"` + condKey + `":"false"}}}]}`
+			got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+				"ActionNames":     []string{"s3:GetObject"},
+				"PolicyInputList": []string{policy},
+			})
+			require.Len(t, got.results(), 1)
+			assert.Equal(t, "allowed", got.results()[0].Decision,
+				"%s must be populated in a simulation too", condKey)
+		})
+
+		t.Run(condKey+"/not reported missing", func(t *testing.T) {
+			policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+				`"Action":"s3:GetObject","Resource":"*",` +
+				`"Condition":{"DateGreaterThan":{"` + condKey + `":"2000-01-01T00:00:00Z"}}}]}`
+			got := iamSimulate(t, srv, "SimulateCustomPolicy", map[string]any{
+				"ActionNames":     []string{"s3:GetObject"},
+				"PolicyInputList": []string{policy},
+			})
+			require.Len(t, got.results(), 1)
+			assert.Empty(t, got.results()[0].MissingContextValues,
+				"the simulator supplies %s itself, so it is not missing", condKey)
+		})
+	}
+}

--- a/emulator/iam_condition_operators.go
+++ b/emulator/iam_condition_operators.go
@@ -1,0 +1,419 @@
+package emulator
+
+import (
+	"encoding/base64"
+	"math"
+	"net/netip"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// condEvaluate reports whether one request-context value satisfies base, and whether
+// base is an operator substrate recognizes at all.
+//
+// The two answers come from one function on purpose. Three callers need to know
+// "recognized" *before* they can use "matched": a set qualifier over an absent key
+// returns true vacuously, an `...IfExists` over an absent key returns true by
+// definition, and a negated operator over an absent key returns true per AWS's rule
+// below — so all three would grant an Allow written with an operator substrate cannot
+// evaluate. A second list of operator names would drift from this switch the first
+// time one was added to only one of them; [condOperatorRecognized] is derived from
+// this function instead.
+//
+// AWS: "If the key that you specify in a policy condition is not present in the
+// request context, the values do not match and the condition is *false*. If the
+// policy condition requires that the key is *not* matched, such as StringNotLike or
+// ArnNotLike, and the right key is not present, the condition is *true*." That rule
+// is applied by [conditionKeyMatches], which is where presence is known; base is
+// evaluated here against whatever value was found.
+//
+// Multiple values for the same key use OR semantics for a positive operator and AND
+// semantics for a negated one — the same list read either way round, which is why a
+// negated arm returns false on the first match rather than true.
+//
+// A policy value substrate cannot parse as the operator's type — "ten" under
+// NumericEquals, "not-a-date" under DateLessThan — is skipped rather than failing the
+// whole condition, so one unparseable element of a list does not decide the answer.
+// A *context* value substrate cannot parse fails a positive operator and satisfies a
+// negated one, on the reasoning that a comparison that cannot be made has not been
+// satisfied. AWS documents neither case, on the policy side or the request side; both
+// are substrate's recorded choices (#714).
+func condEvaluate(base, ctxVal string, condValues StringOrSlice) (matched, recognized bool) {
+	switch base {
+	case "StringEquals":
+		return condAnyValue(condValues, func(v string) bool { return ctxVal == v }), true
+	case "StringNotEquals":
+		return !condAnyValue(condValues, func(v string) bool { return ctxVal == v }), true
+	case "StringEqualsIgnoreCase":
+		return condAnyValue(condValues, func(v string) bool { return strings.EqualFold(ctxVal, v) }), true
+	case "StringNotEqualsIgnoreCase":
+		return !condAnyValue(condValues, func(v string) bool { return strings.EqualFold(ctxVal, v) }), true
+	case "StringLike":
+		return condAnyValue(condValues, func(v string) bool { return globMatch(v, ctxVal) }), true
+	case "StringNotLike":
+		return !condAnyValue(condValues, func(v string) bool { return globMatch(v, ctxVal) }), true
+
+	case "ArnEquals", "ArnLike":
+		return condAnyValue(condValues, func(v string) bool { return condARNMatches(v, ctxVal) }), true
+	case "ArnNotEquals", "ArnNotLike":
+		return !condAnyValue(condValues, func(v string) bool { return condARNMatches(v, ctxVal) }), true
+
+	case "NumericEquals", "NumericNotEquals", "NumericLessThan", "NumericLessThanEquals",
+		"NumericGreaterThan", "NumericGreaterThanEquals":
+		return condNumericMatches(base, ctxVal, condValues), true
+
+	case "DateEquals", "DateNotEquals", "DateLessThan", "DateLessThanEquals",
+		"DateGreaterThan", "DateGreaterThanEquals":
+		return condDateMatches(base, ctxVal, condValues), true
+
+	case "IpAddress":
+		return condAnyValue(condValues, func(v string) bool { return condIPMatches(v, ctxVal) }), true
+	case "NotIpAddress":
+		return !condAnyValue(condValues, func(v string) bool { return condIPMatches(v, ctxVal) }), true
+
+	case "Bool":
+		// AWS publishes only the lowercase forms, and substrate's own producers write
+		// them, so the fold buys only a policy that spelled the value "True". It is
+		// there because an unquoted JSON `true` and the string "TRUE" are the same
+		// assertion by a caller, and [StringOrSlice.UnmarshalJSON] renders the first
+		// as "true" — the two forms must not disagree.
+		return condAnyValue(condValues, func(v string) bool { return strings.EqualFold(ctxVal, v) }), true
+
+	case "BinaryEquals":
+		// AWS: BinaryEquals "compares the value of the specified key byte for byte
+		// against a base-64 encoded representation of the binary value in the policy",
+		// and its own example table compares two base64 strings. So the comparison is
+		// on the encoded text, and a policy value that is not valid base64 encodes no
+		// binary value and cannot match. No substrate producer writes a binary context
+		// key, so this operator is reachable only through a simulation's ContextEntries.
+		return condAnyValue(condValues, func(v string) bool {
+			_, err := base64.StdEncoding.DecodeString(v)
+			return err == nil && ctxVal == v
+		}), true
+
+	case "Null":
+		// Null is the one operator that must see an absent key rather than being told
+		// about it, which is why [conditionKeyMatches] routes it past the presence
+		// check. AWS: "use either true (the key doesn't exist — it is null) or false
+		// (the key exists and its value is not null)" — so a key present with an empty
+		// value is null, the reading substrate has always had here.
+		isNull := ctxVal == ""
+		return condAnyValue(condValues, func(v string) bool {
+			return (strings.ToLower(v) == "true") == isNull
+		}), true
+	}
+
+	return false, false
+}
+
+// condAnyValue reports whether any of the policy's values satisfies match.
+//
+// Every operator is expressed through it, including the negated ones — a negated
+// operator is the same scan with the answer inverted, which is what makes AWS's "the
+// ArnNotEquals and ArnNotLike condition operators behave identically" to the negation
+// of their positive pair true by construction rather than by two parallel loops.
+func condAnyValue(condValues StringOrSlice, match func(string) bool) bool {
+	for _, v := range condValues {
+		if match(v) {
+			return true
+		}
+	}
+	return false
+}
+
+// condOperatorRecognized reports whether base is an operator [condEvaluate] evaluates.
+//
+// It asks condEvaluate itself, with no value and no policy values, rather than
+// carrying a second list of names: a list would answer "no" for an operator added to
+// the switch and forgotten here, and that answer is what turns a vacuous set-qualifier
+// truth into a grant. See [condEvaluate].
+func condOperatorRecognized(base string) bool {
+	_, recognized := condEvaluate(base, "", nil)
+	return recognized
+}
+
+// condOperatorNegated reports whether base is one of AWS's negated operators — the
+// ones whose answer is true when the key it names is absent.
+//
+// AWS: "If the policy condition requires that the key is *not* matched, such as
+// StringNotLike or ArnNotLike, and the right key is not present, the condition is
+// *true*."
+//
+// Bool is not in this set even though "false" reads like a negation: it is a positive
+// comparison against the value false, and AWS's own table answers "No match" for an
+// absent aws:SecureTransport under `"Bool": {"aws:SecureTransport": "false"}`.
+// TestEvaluate_ConditionNegatedOperatorsAreTheNotNames pins this list against
+// [condEvaluate]'s switch.
+func condOperatorNegated(base string) bool {
+	switch base {
+	case "StringNotEquals", "StringNotEqualsIgnoreCase", "StringNotLike",
+		"ArnNotEquals", "ArnNotLike", "NumericNotEquals", "DateNotEquals", "NotIpAddress":
+		return true
+	}
+	return false
+}
+
+// condARNComponents is the number of colon-delimited components in an ARN:
+// arn:partition:service:region:account-id:resource.
+const condARNComponents = 6
+
+// condARNMatches reports whether an ARN condition value matches an ARN from the
+// request context.
+//
+// AWS: "Each of the six colon-delimited components of the ARN is checked separately
+// and each can include multi-character match wildcards (*) or single-character match
+// wildcards (?)." Substrate ran one [globMatch] over the whole string, so a `*` in one
+// component could match across a colon into the next: `arn:aws:sns:*:topic` matched
+// `arn:aws:sns:us-east-1:123456789012:topic`, letting a pattern that names five
+// components authorize a resource whose account it never mentioned (#714).
+//
+// The resource component may itself contain colons — an SNS subscription ARN is
+// arn:aws:sns:region:account:topic:sub-id — so the split is bounded at six and the
+// remainder stays in the last component, where AWS's own wildcard examples put it.
+//
+// A pattern naming fewer than six components has the missing trailing ones filled with
+// `*`. That is substrate's reading, not a documented rule for conditions: AWS states it
+// for a Resource element ("When you specify an incomplete ARN … AWS automatically
+// completes the ARN by adding wildcard characters (*) to all missing fields") and says
+// nothing about an incomplete ARN in a condition. Refusing to match one instead would
+// narrow both an Allow and a *Deny* written as `arn:aws:ec2:us-east-1:*`, and silently
+// narrowing a Deny is the direction that cannot be recovered from. A *context* value
+// with fewer than six components is not padded — it is the request's own ARN, and a
+// short one is malformed rather than abbreviated.
+func condARNMatches(pattern, value string) bool {
+	valueParts := strings.SplitN(value, ":", condARNComponents)
+	patternParts := strings.SplitN(pattern, ":", condARNComponents)
+	for len(patternParts) < len(valueParts) {
+		patternParts = append(patternParts, "*")
+	}
+	if len(patternParts) != len(valueParts) {
+		return false
+	}
+	for i := range patternParts {
+		if !globMatch(patternParts[i], valueParts[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// condNumericMatches evaluates the six numeric operators.
+//
+// AWS: numeric operators "restrict access based on comparing a key to an integer or
+// decimal value". Both sides are read as decimals, so a policy that quotes its number
+// and one that does not — legal IAM either way, see [StringOrSlice.UnmarshalJSON] —
+// compare identically.
+func condNumericMatches(base, ctxVal string, condValues StringOrSlice) bool {
+	ctxNum, ok := condParseNumber(ctxVal)
+	if !ok {
+		return condOperatorNegated(base)
+	}
+	return condCompare(base, condValues, func(v string) (int, bool) {
+		n, ok := condParseNumber(v)
+		if !ok {
+			return 0, false
+		}
+		switch {
+		case ctxNum < n:
+			return -1, true
+		case ctxNum > n:
+			return 1, true
+		default:
+			return 0, true
+		}
+	})
+}
+
+// condDateMatches evaluates the six date operators.
+//
+// AWS: "You must specify date/time values with one of the W3C implementations of the
+// ISO 8601 date formats or in epoch (UNIX) time." Either notation is accepted on either
+// side, so the two can be compared against each other; see [condParseTime].
+func condDateMatches(base, ctxVal string, condValues StringOrSlice) bool {
+	ctxTime, ok := condParseTime(ctxVal)
+	if !ok {
+		return condOperatorNegated(base)
+	}
+	return condCompare(base, condValues, func(v string) (int, bool) {
+		t, ok := condParseTime(v)
+		if !ok {
+			return 0, false
+		}
+		return ctxTime.Compare(t), true
+	})
+}
+
+// condCompare applies one of the six ordered comparisons to every policy value.
+//
+// cmp reports how the context value orders against one policy value (-1, 0, 1) and
+// whether that value could be parsed at all. It is shared by the numeric and date
+// families because the six operator suffixes mean the same thing in both, and writing
+// them twice would let the two families disagree about, say, whether LessThanEquals
+// includes equality.
+func condCompare(base string, condValues StringOrSlice, cmp func(string) (int, bool)) bool {
+	// A negated operator is satisfied unless some value matches, so its scan cannot
+	// short-circuit on the first parse failure the way a positive one does.
+	if strings.HasSuffix(base, "NotEquals") {
+		for _, v := range condValues {
+			if c, ok := cmp(v); ok && c == 0 {
+				return false
+			}
+		}
+		return true
+	}
+	for _, v := range condValues {
+		c, ok := cmp(v)
+		if !ok {
+			continue
+		}
+		switch {
+		case strings.HasSuffix(base, "LessThanEquals"):
+			if c <= 0 {
+				return true
+			}
+		case strings.HasSuffix(base, "GreaterThanEquals"):
+			if c >= 0 {
+				return true
+			}
+		case strings.HasSuffix(base, "LessThan"):
+			if c < 0 {
+				return true
+			}
+		case strings.HasSuffix(base, "GreaterThan"):
+			if c > 0 {
+				return true
+			}
+		default: // Equals
+			if c == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// condParseNumber parses one side of a numeric comparison.
+//
+// [strconv.ParseFloat] accepts three spellings that are not "an integer or decimal
+// value": "NaN", "Inf" (so a policy value of "Inf" would satisfy NumericGreaterThan
+// against every number in existence) and Go's hexadecimal float syntax, where "0x1p4"
+// would compare equal to 16. The first two are caught by the IsInf/IsNaN checks below;
+// the character filter is what catches the third, since a hex float parses to a perfectly
+// finite number.
+func condParseNumber(s string) (float64, bool) {
+	if strings.ContainsAny(s, "xXpPnNiI") {
+		return 0, false
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil || math.IsInf(n, 0) || math.IsNaN(n) {
+		return 0, false
+	}
+	return n, true
+}
+
+// condTimeLayouts are the W3C ISO 8601 profile's date and date-time forms, longest
+// first.
+//
+// The profile's complete forms carry a timezone designator; the two without one are a
+// tolerance, read as UTC, because a policy author writing a bare local timestamp means
+// a time rather than nothing at all.
+var condTimeLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04Z07:00",
+	"2006-01-02T15:04:05",
+	"2006-01-02T15:04",
+	"2006-01-02",
+	"2006-01",
+	"2006",
+}
+
+// condParseTime parses a W3C ISO 8601 date/time or an epoch (UNIX) timestamp.
+//
+// ISO forms are tried first, which is what settles the one ambiguity between the two
+// notations: "2020" is a legal W3C year and a legal epoch second, and reading it as the
+// year is the reading a policy author writing a date means. An epoch value large enough
+// to be a real timestamp matches no ISO layout, so nothing else is affected. AWS
+// documents both notations and no rule for choosing between them; this is substrate's
+// recorded choice (#714).
+//
+// Epoch values may be fractional — aws:EpochTime is documented as seconds since
+// 1970-01-01, and a sub-second value is still a time.
+func condParseTime(s string) (time.Time, bool) {
+	for _, layout := range condTimeLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	if secs, ok := condParseNumber(s); ok {
+		whole, frac := math.Modf(secs)
+		return time.Unix(int64(whole), int64(frac*float64(time.Second))).UTC(), true
+	}
+	return time.Time{}, false
+}
+
+// condIPMatches reports whether an IP from the request context lies in the range a
+// policy value names.
+//
+// AWS: "The value must be in the standard CIDR format (for example, 203.0.113.0/24 or
+// 2001:DB8:1234:5678::/64). If you specify an IP address without the associated routing
+// prefix, IAM uses the default prefix value of /32."
+//
+// A bare address is read as a single host — /32 for IPv4, as AWS says, and /128 for
+// IPv6, which AWS's sentence does not cover. Taking "/32" literally for an IPv6
+// address would turn one address into 2^96 of them, so the host route is read as the
+// address family's own full width. That is substrate's reading of a sentence written
+// for IPv4.
+//
+// A malformed policy value matches nothing, and a context value that is not an address
+// matches nothing. Neither case is documented by AWS; the reasoning is the one
+// [s3SourceIPValuePinsAccess] records — a value that is not an address pins no range —
+// and it keeps NotIpAddress from being satisfied by a typo.
+func condIPMatches(pattern, value string) bool {
+	addr, err := netip.ParseAddr(value)
+	if err != nil {
+		return false
+	}
+	prefix, err := netip.ParsePrefix(pattern)
+	if err != nil {
+		host, hostErr := netip.ParseAddr(pattern)
+		if hostErr != nil {
+			return false
+		}
+		prefix = netip.PrefixFrom(host, host.BitLen())
+	}
+	return prefix.Contains(addr)
+}
+
+// condIfExistsSuffix is the suffix AWS allows on every operator but Null.
+const condIfExistsSuffix = "IfExists"
+
+// condSplitIfExists separates an ...IfExists suffix from the operator it modifies.
+//
+// AWS: "You can add IfExists to the end of any condition operator name except the Null
+// condition — for example, StringLikeIfExists." The exception is enforced by the
+// caller: "NullIfExists" splits here and is then refused, because Null already tests
+// for the absence IfExists would excuse.
+func condSplitIfExists(operator string) (base string, ifExists bool) {
+	return strings.CutSuffix(operator, condIfExistsSuffix)
+}
+
+// condAbsentMatches reports whether an operator is satisfied by a key the request
+// context does not carry.
+//
+// Three rules meet here, and an unrecognized operator must not benefit from any of
+// them — an Allow conditioned on an operator substrate cannot evaluate must not be
+// granted merely because the key it names is missing, which is the shape of the hole
+// #714 was filed about.
+//
+//   - ...IfExists: "If the key is not present, evaluate the condition element as true."
+//   - A negated operator: "If the policy condition requires that the key is not
+//     matched … and the right key is not present, the condition is true."
+//   - Anything else: "the values do not match and the condition is false."
+func condAbsentMatches(base string, ifExists bool) bool {
+	if !condOperatorRecognized(base) {
+		return false
+	}
+	return ifExists || condOperatorNegated(base)
+}

--- a/emulator/iam_condition_operators_test.go
+++ b/emulator/iam_condition_operators_test.go
@@ -1,0 +1,632 @@
+package emulator_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// iamOperatorPolicy builds a one-statement Allow conditioned on a single operator and
+// key, which is the shape every operator-family case below needs.
+func iamOperatorPolicy(operator, condKey string, condValues ...string) emulator.PolicyDocument {
+	return emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   emulator.IAMEffectAllow,
+			Action:   emulator.StringOrSlice{"*"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				operator: {condKey: emulator.StringOrSlice(condValues)},
+			},
+		}},
+	}
+}
+
+// iamOperatorAllows reports whether a one-key Allow conditioned on operator is granted
+// for a request context carrying ctxVal — or carrying nothing, when ctxVal is absent.
+func iamOperatorAllows(t *testing.T, operator string, condValues []string, ctxVal ...string) bool {
+	t.Helper()
+	const condKey = "test:Key"
+	req := emulator.EvaluationRequest{Action: "s3:GetObject", Resource: "*"}
+	if len(ctxVal) > 0 {
+		req.Context = map[string]string{condKey: ctxVal[0]}
+	}
+	doc := iamOperatorPolicy(operator, condKey, condValues...)
+	return emulator.Evaluate([]emulator.PolicyDocument{doc}, req).Decision == emulator.DecisionAllow
+}
+
+// TestEvaluate_UnrecognizedOperatorDeniesUnderASetQualifier pins the hole #714 was
+// filed about: a set qualifier over an absent key returned true without ever consulting
+// the operator, so an Allow written with an operator substrate cannot evaluate was
+// granted.
+//
+// The vacuous truth itself is AWS's rule and stays for a recognized operator: "The
+// ForAllValues qualifier returns true if there are no context keys in the request".
+// What changed is that an operator name substrate does not evaluate no longer collects
+// it. Real IAM rejects an unknown operator when the document is submitted, so a policy
+// reaching this arm is one AWS would never have stored.
+func TestEvaluate_UnrecognizedOperatorDeniesUnderASetQualifier(t *testing.T) {
+	cases := []struct {
+		operator string
+		allowed  bool
+		why      string
+	}{
+		{"ForAllValues:StringEquals", true, "recognized: AWS's vacuous truth applies"},
+		{"ForAllValues:NumericLessThan", true, "recognized as of #714, so the same rule applies"},
+		{"ForAllValues:NotAnOperator", false, "unrecognized: must not be granted vacuously"},
+		{"ForAllValues:stringequals", false, "an operator's own name is case-sensitive"},
+		{"ForAllValues:Null", false, "AWS defines no set-qualified Null"},
+		{"ForAnyValue:Null", false, "nor a ForAnyValue one"},
+		{"ForAnyValue:NotAnOperator", false, "ForAnyValue denies on an absent key regardless"},
+		{"NotAnOperator", false, "unqualified, unrecognized: unchanged"},
+		// IfExists is where the qualified unrecognized operator becomes a grant if the
+		// operator is not checked: the suffix answers true on an absent key before the
+		// value loop that would otherwise have found nothing to match.
+		{"ForAnyValue:NotAnOperatorIfExists", false, "the suffix must not rescue an unevaluable operator"},
+		{"ForAllValues:NotAnOperatorIfExists", false, "nor under the other qualifier"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operator, func(t *testing.T) {
+			doc := iamOperatorPolicy(tc.operator, "aws:TagKeys", "Env")
+			result := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+				Action: "s3:GetObject", Resource: "*",
+			})
+			if tc.allowed {
+				assert.Equal(t, emulator.DecisionAllow, result.Decision, tc.why)
+				return
+			}
+			assert.Equal(t, emulator.DecisionImplicitDeny, result.Decision, tc.why)
+		})
+	}
+}
+
+// TestEvaluate_ConditionAbsentKeyFollowsTheOperator pins AWS's Important note: an
+// absent key is false for a positive operator and *true* for a negated one.
+//
+// AWS: "If the key that you specify in a policy condition is not present in the request
+// context, the values do not match and the condition is false. If the policy condition
+// requires that the key is not matched, such as StringNotLike or ArnNotLike, and the
+// right key is not present, the condition is true." The rows below walk that sentence
+// operator by operator, since the polarity is the only thing deciding each answer.
+func TestEvaluate_ConditionAbsentKeyFollowsTheOperator(t *testing.T) {
+	positive := []string{
+		"StringEquals", "StringEqualsIgnoreCase", "StringLike", "ArnEquals", "ArnLike",
+		"NumericEquals", "NumericLessThan", "NumericGreaterThanEquals",
+		"DateEquals", "DateLessThan", "IpAddress", "Bool", "BinaryEquals",
+	}
+	negated := []string{
+		"StringNotEquals", "StringNotEqualsIgnoreCase", "StringNotLike",
+		"ArnNotEquals", "ArnNotLike", "NumericNotEquals", "DateNotEquals", "NotIpAddress",
+	}
+	for _, op := range positive {
+		t.Run(op+"/absent is false", func(t *testing.T) {
+			assert.False(t, iamOperatorAllows(t, op, []string{"anything"}),
+				"%s on an absent key must not match", op)
+		})
+	}
+	for _, op := range negated {
+		t.Run(op+"/absent is true", func(t *testing.T) {
+			assert.True(t, iamOperatorAllows(t, op, []string{"anything"}),
+				"%s on an absent key must match, per AWS", op)
+		})
+	}
+}
+
+// TestEvaluate_ConditionNegatedOperatorsAreTheNotNames is the drift tripwire between
+// the negated-operator list and the operator switch itself: every operator AWS names
+// with "Not" must be treated as negated, and nothing else may be.
+//
+// It works by observation rather than by reading either list — an operator is negated
+// exactly when an absent key satisfies it — so a new operator added to only one of the
+// two places fails here.
+func TestEvaluate_ConditionNegatedOperatorsAreTheNotNames(t *testing.T) {
+	all := []string{
+		"StringEquals", "StringNotEquals", "StringEqualsIgnoreCase", "StringNotEqualsIgnoreCase",
+		"StringLike", "StringNotLike", "ArnEquals", "ArnLike", "ArnNotEquals", "ArnNotLike",
+		"NumericEquals", "NumericNotEquals", "NumericLessThan", "NumericLessThanEquals",
+		"NumericGreaterThan", "NumericGreaterThanEquals",
+		"DateEquals", "DateNotEquals", "DateLessThan", "DateLessThanEquals",
+		"DateGreaterThan", "DateGreaterThanEquals",
+		"Bool", "BinaryEquals", "IpAddress", "NotIpAddress",
+	}
+	for _, op := range all {
+		t.Run(op, func(t *testing.T) {
+			assert.Equal(t, strings.Contains(op, "Not"), iamOperatorAllows(t, op, []string{"x"}),
+				"%q: an absent key matches exactly the operators AWS names with Not", op)
+		})
+	}
+}
+
+// TestEvaluate_ConditionStringIgnoreCase covers the two operators AWS uses in its own
+// ec2:CreateTags example and substrate did not implement.
+//
+// AWS: "When you append IgnoreCase to the operator, you allow any existing tag value
+// capitalization, such as preprod, Preprod, and PreProd, to resolve to true." The
+// case-sensitive rows are here too, since the pair is only useful if it is a pair.
+func TestEvaluate_ConditionStringIgnoreCase(t *testing.T) {
+	cases := []struct {
+		operator string
+		ctxVal   string
+		want     bool
+	}{
+		{"StringEqualsIgnoreCase", "preprod", true},
+		{"StringEqualsIgnoreCase", "PreProd", true},
+		{"StringEqualsIgnoreCase", "PREPROD", true},
+		{"StringEqualsIgnoreCase", "storage", true},
+		{"StringEqualsIgnoreCase", "prod", false},
+		{"StringNotEqualsIgnoreCase", "PreProd", false},
+		{"StringNotEqualsIgnoreCase", "prod", true},
+		// The case-sensitive operator is unaffected, which is the whole point of the pair.
+		{"StringEquals", "PreProd", false},
+		{"StringEquals", "preprod", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operator+"/"+tc.ctxVal, func(t *testing.T) {
+			assert.Equal(t, tc.want,
+				iamOperatorAllows(t, tc.operator, []string{"preprod", "storage"}, tc.ctxVal))
+		})
+	}
+}
+
+// TestEvaluate_ConditionNumericFamily covers the six numeric operators.
+//
+// AWS: numeric operators compare "a key to an integer or decimal value". The quoted
+// and unquoted spellings of a number are the same value, so "10" is used throughout and
+// TestPolicyDocument_UnquotedNumbersAndBooleans pins the other spelling.
+func TestEvaluate_ConditionNumericFamily(t *testing.T) {
+	cases := []struct {
+		operator string
+		ctxVal   string
+		values   []string
+		want     bool
+	}{
+		{"NumericEquals", "10", []string{"10"}, true},
+		{"NumericEquals", "10.0", []string{"10"}, true},
+		{"NumericEquals", "11", []string{"10"}, false},
+		{"NumericEquals", "11", []string{"10", "11"}, true},
+		{"NumericNotEquals", "11", []string{"10"}, true},
+		{"NumericNotEquals", "10", []string{"10"}, false},
+		{"NumericLessThan", "9", []string{"10"}, true},
+		{"NumericLessThan", "10", []string{"10"}, false},
+		{"NumericLessThanEquals", "10", []string{"10"}, true},
+		{"NumericGreaterThan", "11", []string{"10"}, true},
+		{"NumericGreaterThan", "10", []string{"10"}, false},
+		{"NumericGreaterThanEquals", "10", []string{"10"}, true},
+		{"NumericLessThanEquals", "2.5", []string{"2.75"}, true},
+		// A context value that is not a number cannot be compared: the positive
+		// operators are unsatisfied, the negated one is satisfied.
+		{"NumericLessThan", "ten", []string{"10"}, false},
+		{"NumericEquals", "", []string{"10"}, false},
+		{"NumericNotEquals", "ten", []string{"10"}, true},
+		// An unparseable *policy* value is skipped rather than deciding the condition.
+		{"NumericEquals", "10", []string{"ten", "10"}, true},
+		{"NumericNotEquals", "10", []string{"ten"}, true},
+		// None of NaN, an infinity, or Go's hexadecimal float syntax is an integer or a
+		// decimal value: "Inf" must not satisfy NumericLessThan against every number
+		// there is, and "0x1p4" must not compare equal to 16.
+		{"NumericLessThan", "10", []string{"Inf"}, false},
+		{"NumericGreaterThan", "Inf", []string{"10"}, false},
+		{"NumericEquals", "NaN", []string{"NaN"}, false},
+		{"NumericEquals", "0x10", []string{"16"}, false},
+		{"NumericEquals", "0x1p4", []string{"16"}, false},
+		{"NumericEquals", "16", []string{"0x1p4"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operator+"/"+tc.ctxVal, func(t *testing.T) {
+			assert.Equal(t, tc.want, iamOperatorAllows(t, tc.operator, tc.values, tc.ctxVal))
+		})
+	}
+}
+
+// TestEvaluate_ConditionDateFamily covers the six date operators.
+//
+// AWS: "You must specify date/time values with one of the W3C implementations of the
+// ISO 8601 date formats or in epoch (UNIX) time." Both notations appear below, on both
+// sides of the comparison and against each other.
+func TestEvaluate_ConditionDateFamily(t *testing.T) {
+	cases := []struct {
+		name     string
+		operator string
+		ctxVal   string
+		values   []string
+		want     bool
+	}{
+		{"after", "DateGreaterThan", "2020-06-01T00:00:00Z", []string{"2020-01-01T00:00:01Z"}, true},
+		{"before", "DateGreaterThan", "2019-06-01T00:00:00Z", []string{"2020-01-01T00:00:01Z"}, false},
+		{"less than", "DateLessThan", "2019-06-01T00:00:00Z", []string{"2020-01-01T00:00:01Z"}, true},
+		{"equal", "DateEquals", "2020-01-01T00:00:01Z", []string{"2020-01-01T00:00:01Z"}, true},
+		{"equal at or before", "DateLessThanEquals", "2020-01-01T00:00:01Z", []string{"2020-01-01T00:00:01Z"}, true},
+		{"equal at or after", "DateGreaterThanEquals", "2020-01-01T00:00:01Z", []string{"2020-01-01T00:00:01Z"}, true},
+		{"not equals", "DateNotEquals", "2020-06-01T00:00:00Z", []string{"2020-01-01T00:00:01Z"}, true},
+		// An offset is a W3C timezone designator, not just "Z".
+		{"offset", "DateEquals", "2020-01-01T00:00:00Z", []string{"2019-12-31T19:00:00-05:00"}, true},
+		// The shorter W3C forms.
+		{"date only", "DateLessThan", "2019-12-31T23:59:59Z", []string{"2020-01-01"}, true},
+		{"month only", "DateGreaterThan", "2020-02-01T00:00:00Z", []string{"2020-01"}, true},
+		{"year only", "DateGreaterThan", "2020-06-01T00:00:00Z", []string{"2020"}, true},
+		// Epoch on either side, and the two notations compared against each other.
+		{"epoch policy value", "DateGreaterThan", "2020-06-01T00:00:00Z", []string{"1577836800"}, true},
+		{"epoch context value", "DateLessThan", "1577836800", []string{"2020-06-01T00:00:00Z"}, true},
+		{"fractional epoch", "DateGreaterThan", "1577836800.5", []string{"1577836800"}, true},
+		// A four-digit value is read as a W3C year rather than as an epoch second, which
+		// is the one place the two notations collide. Read as epoch, "2020" would be
+		// 1970-01-01T00:33:40Z and this would answer false.
+		{"four digits are a year", "DateGreaterThan", "2019-01-01T00:00:00Z", []string{"2020"}, false},
+		// Unparseable values, in both directions.
+		{"bad context value", "DateLessThan", "not-a-date", []string{"2020-01-01"}, false},
+		{"bad context value negated", "DateNotEquals", "not-a-date", []string{"2020-01-01"}, true},
+		{"bad policy value skipped", "DateEquals", "2020-01-01", []string{"nope", "2020-01-01"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operator+"/"+tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, iamOperatorAllows(t, tc.operator, tc.values, tc.ctxVal))
+		})
+	}
+}
+
+// TestEvaluate_ConditionIPFamily covers IpAddress and NotIpAddress.
+//
+// AWS: "The value must be in the standard CIDR format (for example, 203.0.113.0/24 or
+// 2001:DB8:1234:5678::/64). If you specify an IP address without the associated routing
+// prefix, IAM uses the default prefix value of /32." Both address families are covered,
+// including the IPv6 host route that sentence does not describe.
+func TestEvaluate_ConditionIPFamily(t *testing.T) {
+	cases := []struct {
+		name     string
+		operator string
+		ctxVal   string
+		values   []string
+		want     bool
+	}{
+		{"in range", "IpAddress", "203.0.113.1", []string{"203.0.113.0/24"}, true},
+		{"out of range", "IpAddress", "198.51.100.1", []string{"203.0.113.0/24"}, false},
+		{"second value", "IpAddress", "198.51.100.1", []string{"203.0.113.0/24", "198.51.100.0/24"}, true},
+		{"not in range", "NotIpAddress", "198.51.100.1", []string{"203.0.113.0/24"}, true},
+		{"not, but in range", "NotIpAddress", "203.0.113.1", []string{"203.0.113.0/24"}, false},
+		// A bare address is a host route: itself and nothing else.
+		{"bare address matches itself", "IpAddress", "203.0.113.1", []string{"203.0.113.1"}, true},
+		{"bare address matches nothing else", "IpAddress", "203.0.113.2", []string{"203.0.113.1"}, false},
+		// IPv6, including the mixed list AWS recommends writing.
+		{"v6 in range", "IpAddress", "2001:db8:1234:5678::1", []string{"2001:db8:1234:5678::/64"}, true},
+		{"v6 out of range", "IpAddress", "2001:db8:1234:9999::1", []string{"2001:db8:1234:5678::/64"}, false},
+		{"mixed list", "IpAddress", "2001:db8:1234:5678::1", []string{"203.0.113.0/24", "2001:db8:1234:5678::/64"}, true},
+		// A bare IPv6 address is its own /128. Taking AWS's "/32" literally would make
+		// this one address stand for 2^96 of them, and the second row would pass.
+		{"bare v6 matches itself", "IpAddress", "2001:db8::1", []string{"2001:db8::1"}, true},
+		{"bare v6 is not a /32", "IpAddress", "2001:db8:ffff::1", []string{"2001:db8::1"}, false},
+		// Families do not cross.
+		{"v4 against a v6 prefix", "IpAddress", "203.0.113.1", []string{"2001:db8::/32"}, false},
+		// A malformed value on either side matches nothing, so a typo cannot satisfy
+		// NotIpAddress either.
+		{"malformed policy value", "IpAddress", "203.0.113.1", []string{"203.0.113.0/33"}, false},
+		{"malformed context value", "IpAddress", "not-an-ip", []string{"203.0.113.0/24"}, false},
+		{"malformed policy value, negated", "NotIpAddress", "203.0.113.1", []string{"not-a-cidr"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operator+"/"+tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, iamOperatorAllows(t, tc.operator, tc.values, tc.ctxVal))
+		})
+	}
+}
+
+// TestEvaluate_ConditionBinaryEquals covers the base64 comparison.
+//
+// AWS: BinaryEquals "compares the value of the specified key byte for byte against a
+// base-64 encoded representation of the binary value in the policy", and its own
+// example table compares two base64 strings.
+func TestEvaluate_ConditionBinaryEquals(t *testing.T) {
+	const encoded = "QmluYXJ5VmFsdWVJbkJhc2U2NA=="
+	assert.True(t, iamOperatorAllows(t, "BinaryEquals", []string{encoded}, encoded))
+	assert.False(t, iamOperatorAllows(t, "BinaryEquals", []string{encoded}, "ASIAIOSFODNN7EXAMPLE"),
+		"AWS's own no-match row")
+	assert.False(t, iamOperatorAllows(t, "BinaryEquals", []string{"not base64!!"}, "not base64!!"),
+		"a policy value that is not base64 encodes no binary value")
+}
+
+// TestEvaluate_ConditionARNComponentsAreCompared pins AWS's component rule: "Each of
+// the six colon-delimited components of the ARN is checked separately."
+//
+// Substrate ran one glob over the whole string, so a `*` in one component matched
+// across a colon into the next — the row named below granted a pattern that never
+// mentioned the account it authorized (#714).
+func TestEvaluate_ConditionARNComponentsAreCompared(t *testing.T) {
+	const topic = "arn:aws:sns:us-east-1:123456789012:TOPIC-ID"
+	cases := []struct {
+		name    string
+		pattern string
+		want    bool
+	}{
+		{"exact", topic, true},
+		{"account differs", "arn:aws:sns:us-east-1:777788889999:TOPIC-ID", false},
+		{"wildcard in one component", "arn:aws:sns:us-east-1:*:TOPIC-ID", true},
+		{"single-character wildcard", "arn:aws:sns:us-east-?:123456789012:TOPIC-ID", true},
+		{"wildcard resource", "arn:aws:sns:us-east-1:123456789012:*", true},
+		// The bug: five components, whose trailing `*` used to eat the colon between
+		// the account and the resource.
+		{"a star must not cross a colon", "arn:aws:sns:*:TOPIC-ID", false},
+		{"nor may a leading one", "arn:aws:*:TOPIC-ID", false},
+		// A pattern naming fewer components has the missing trailing ones filled with
+		// `*`, so a deliberately broad pattern keeps working — and a Deny written that
+		// way is not silently narrowed.
+		{"incomplete pattern is completed", "arn:aws:sns:us-east-1", true},
+		{"incomplete pattern still checks what it names", "arn:aws:sqs:us-east-1", false},
+		{"partition only", "arn:aws", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, op := range []string{"ArnEquals", "ArnLike"} {
+				assert.Equal(t, tc.want, iamOperatorAllows(t, op, []string{tc.pattern}, topic),
+					"%s %q: AWS documents ArnEquals and ArnLike as behaving identically", op, tc.pattern)
+			}
+			for _, op := range []string{"ArnNotEquals", "ArnNotLike"} {
+				assert.Equal(t, !tc.want, iamOperatorAllows(t, op, []string{tc.pattern}, topic),
+					"%s %q must be the negation of its positive pair", op, tc.pattern)
+			}
+		})
+	}
+
+	t.Run("a context value with too few components matches no full pattern", func(t *testing.T) {
+		assert.False(t, iamOperatorAllows(t, "ArnEquals",
+			[]string{"arn:aws:sns:us-east-1:123456789012:TOPIC-ID"}, "arn:aws:sns"))
+	})
+}
+
+// TestEvaluate_ConditionArnNotEqualsHonoursWildcards is the second ARN bug: the negated
+// operator compared with == , so a Deny written with a wildcard was inert.
+//
+// AWS: "The ArnNotEquals and ArnNotLike condition operators behave identically" —
+// negated matching, wildcards and all.
+func TestEvaluate_ConditionArnNotEqualsHonoursWildcards(t *testing.T) {
+	doc := emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{
+			{Effect: emulator.IAMEffectAllow, Action: emulator.StringOrSlice{"*"}, Resource: emulator.StringOrSlice{"*"}},
+			{
+				Effect:   emulator.IAMEffectDeny,
+				Action:   emulator.StringOrSlice{"*"},
+				Resource: emulator.StringOrSlice{"*"},
+				Condition: map[string]map[string]emulator.StringOrSlice{
+					"ArnNotEquals": {"aws:PrincipalArn": emulator.StringOrSlice{"arn:aws:iam::123456789012:role/*"}},
+				},
+			},
+		},
+	}
+	decide := func(principalArn string) string {
+		return emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+			Action: "s3:GetObject", Resource: "*",
+			Context: map[string]string{"aws:PrincipalArn": principalArn},
+		}).Decision
+	}
+	assert.Equal(t, emulator.DecisionAllow, decide("arn:aws:iam::123456789012:role/admin"),
+		"the wildcard must match, so the Deny does not fire")
+	assert.Equal(t, emulator.DecisionDeny, decide("arn:aws:iam::123456789012:user/eve"),
+		"a principal outside the pattern must still be denied")
+	assert.Equal(t, emulator.DecisionDeny, decide("arn:aws:iam::777788889999:role/admin"),
+		"a role in another account is outside the pattern")
+}
+
+// TestEvaluate_ConditionIfExists covers the suffix AWS allows on every operator but
+// Null.
+//
+// AWS: "If the condition key is present in the context of the request, process the key
+// as specified in the policy. If the key is not present, evaluate the condition element
+// as true." Both halves are asserted: a suffix that ignored a present key would pass a
+// test written only about absence.
+func TestEvaluate_ConditionIfExists(t *testing.T) {
+	t.Run("absent key is a match", func(t *testing.T) {
+		assert.True(t, iamOperatorAllows(t, "StringLikeIfExists", []string{"t1.*", "t2.*"}))
+	})
+	t.Run("present key is still evaluated", func(t *testing.T) {
+		assert.True(t, iamOperatorAllows(t, "StringLikeIfExists", []string{"t1.*", "t2.*"}, "t1.micro"),
+			"AWS's own match row")
+		assert.False(t, iamOperatorAllows(t, "StringLikeIfExists", []string{"t1.*", "t2.*"}, "m2.micro"),
+			"AWS's own no-match row")
+	})
+	t.Run("every family takes the suffix", func(t *testing.T) {
+		for _, op := range []string{
+			"StringEqualsIfExists", "StringNotEqualsIfExists", "StringEqualsIgnoreCaseIfExists",
+			"ArnEqualsIfExists", "ArnNotLikeIfExists", "NumericLessThanIfExists",
+			"DateGreaterThanIfExists", "IpAddressIfExists", "NotIpAddressIfExists",
+			"BoolIfExists", "BinaryEqualsIfExists",
+		} {
+			assert.True(t, iamOperatorAllows(t, op, []string{"anything"}),
+				"%s on an absent key must match", op)
+		}
+	})
+	t.Run("Null takes no suffix", func(t *testing.T) {
+		// AWS: IfExists may be added to "any condition operator name except the Null
+		// condition". Both spellings of the intent must fail, since either would
+		// otherwise be a grant.
+		assert.False(t, iamOperatorAllows(t, "NullIfExists", []string{"true"}))
+		assert.False(t, iamOperatorAllows(t, "NullIfExists", []string{"false"}))
+		assert.False(t, iamOperatorAllows(t, "NullIfExists", []string{"true"}, "present"))
+	})
+	t.Run("an unrecognized operator gains nothing from the suffix", func(t *testing.T) {
+		assert.False(t, iamOperatorAllows(t, "NotAnOperatorIfExists", []string{"x"}))
+	})
+	t.Run("a Deny with a negated IfExists still fires on an absent key", func(t *testing.T) {
+		// AWS: "If you are using an "Effect": "Deny" element with a negated condition
+		// operator like StringNotEqualsIfExists, the request is still denied even if the
+		// condition key is not present."
+		doc := emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{
+				{Effect: emulator.IAMEffectAllow, Action: emulator.StringOrSlice{"*"}, Resource: emulator.StringOrSlice{"*"}},
+				{
+					Effect:   emulator.IAMEffectDeny,
+					Action:   emulator.StringOrSlice{"*"},
+					Resource: emulator.StringOrSlice{"*"},
+					Condition: map[string]map[string]emulator.StringOrSlice{
+						"StringNotEqualsIfExists": {"test:Key": emulator.StringOrSlice{"expected"}},
+					},
+				},
+			},
+		}
+		result := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+			Action: "s3:GetObject", Resource: "*",
+		})
+		assert.Equal(t, emulator.DecisionDeny, result.Decision)
+	})
+}
+
+// TestEvaluate_ConditionIfExistsUnderASetQualifier records the one resolution AWS does
+// not publish.
+//
+// ForAnyValue says an absent key is false; IfExists says an absent key is true. AWS
+// documents no answer, so substrate reads IfExists as the more specific annotation —
+// the author wrote it about exactly this case, and AWS's gloss is emphatic that other
+// elements "can still result in a nonmatch, but not a missing key when checked with
+// ...IfExists".
+func TestEvaluate_ConditionIfExistsUnderASetQualifier(t *testing.T) {
+	absent := func(operator string) bool {
+		doc := iamOperatorPolicy(operator, "aws:TagKeys", "Env")
+		return emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+			Action: "s3:GetObject", Resource: "*",
+		}).Decision == emulator.DecisionAllow
+	}
+	assert.False(t, absent("ForAnyValue:StringEquals"),
+		"without the suffix, ForAnyValue's own rule holds")
+	assert.True(t, absent("ForAnyValue:StringEqualsIfExists"),
+		"with it, the more specific annotation wins")
+	assert.True(t, absent("ForAllValues:StringEqualsIfExists"),
+		"ForAllValues already answers true, so the suffix changes nothing")
+
+	// A present key is evaluated either way — the suffix speaks only to absence.
+	present := func(operator string, values ...string) bool {
+		doc := iamOperatorPolicy(operator, "aws:TagKeys", values...)
+		return emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+			Action: "s3:GetObject", Resource: "*",
+			MultiContext: map[string][]string{"aws:TagKeys": {"Env", "Owner"}},
+		}).Decision == emulator.DecisionAllow
+	}
+	assert.True(t, present("ForAnyValue:StringEqualsIfExists", "Env"))
+	assert.False(t, present("ForAnyValue:StringEqualsIfExists", "Nope"))
+	assert.False(t, present("ForAllValues:StringEqualsIfExists", "Env"),
+		"Owner is not in the policy's list")
+
+	// A set-qualified Null is refused whether or not the key is there. Quantifying an
+	// existence test over the values whose existence it is testing has no meaning, and
+	// AWS defines neither form — but `ForAnyValue:Null` with "false" would *match* a
+	// present key if the qualifier arms evaluated Null like any other operator, which is
+	// a grant nobody wrote.
+	assert.False(t, present("ForAnyValue:Null", "false"))
+	assert.False(t, present("ForAllValues:Null", "false"))
+	assert.False(t, present("ForAnyValue:Null", "true"))
+}
+
+// TestEvaluate_ConditionPresentButEmptyIsAbsent pins the reading a key with an empty
+// value gets.
+//
+// AWS speaks of a value that "resolves to a null dataset, such as an empty string", and
+// Null's own wording is "the key exists and its value is not null". So an empty value is
+// null, which is the reading substrate's Null operator has always had — and now the one
+// the rest of the operators use.
+func TestEvaluate_ConditionPresentButEmptyIsAbsent(t *testing.T) {
+	assert.False(t, iamOperatorAllows(t, "StringEquals", []string{"prod"}, ""))
+	assert.True(t, iamOperatorAllows(t, "StringNotEquals", []string{"prod"}, ""))
+	assert.True(t, iamOperatorAllows(t, "StringEqualsIfExists", []string{"prod"}, ""))
+	assert.True(t, iamOperatorAllows(t, "Null", []string{"true"}, ""),
+		"Null must still see the empty value rather than being told the key is absent")
+	assert.False(t, iamOperatorAllows(t, "Null", []string{"false"}, ""))
+	assert.True(t, iamOperatorAllows(t, "Null", []string{"false"}, "prod"))
+}
+
+// TestPolicyDocument_UnquotedNumbersAndBooleans pins the IAM grammar's rule that
+// substrate rejected outright: "Values are enclosed in quotation marks. Quotation marks
+// are optional for numeric and Boolean values." Each document below is one real IAM
+// accepts and substrate answered MalformedPolicyDocument for.
+func TestPolicyDocument_UnquotedNumbersAndBooleans(t *testing.T) {
+	cases := []struct {
+		name   string
+		policy string
+		ctxVal string
+		want   string
+	}{
+		{
+			name: "unquoted Boolean",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*",` +
+				`"Condition":{"Bool":{"test:Key":false}}}]}`,
+			ctxVal: "false",
+			want:   emulator.DecisionAllow,
+		},
+		{
+			name: "unquoted Boolean, no match",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*",` +
+				`"Condition":{"Bool":{"test:Key":false}}}]}`,
+			ctxVal: "true",
+			want:   emulator.DecisionImplicitDeny,
+		},
+		{
+			name: "unquoted number",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*",` +
+				`"Condition":{"NumericLessThanEquals":{"test:Key":10}}}]}`,
+			ctxVal: "10",
+			want:   emulator.DecisionAllow,
+		},
+		{
+			name: "unquoted number, no match",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*",` +
+				`"Condition":{"NumericLessThanEquals":{"test:Key":10}}}]}`,
+			ctxVal: "11",
+			want:   emulator.DecisionImplicitDeny,
+		},
+		{
+			name: "a mixed list",
+			policy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*",` +
+				`"Condition":{"NumericEquals":{"test:Key":[10,"11",12]}}}]}`,
+			ctxVal: "11",
+			want:   emulator.DecisionAllow,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var doc emulator.PolicyDocument
+			require.NoError(t, json.Unmarshal([]byte(tc.policy), &doc),
+				"the IAM grammar declares this document legal")
+			result := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+				Action: "s3:GetObject", Resource: "*",
+				Context: map[string]string{"test:Key": tc.ctxVal},
+			})
+			assert.Equal(t, tc.want, result.Decision)
+		})
+	}
+}
+
+// TestStringOrSlice_UnmarshalKeepsTheNumbersSpelling pins that a number reaches the
+// comparison as the document spelled it. Routing it through a float64 would render 10
+// as "1e+01" and a large integer as a rounded approximation.
+func TestStringOrSlice_UnmarshalKeepsTheNumbersSpelling(t *testing.T) {
+	cases := []struct {
+		json string
+		want emulator.StringOrSlice
+	}{
+		{`10`, emulator.StringOrSlice{"10"}},
+		{`10.5`, emulator.StringOrSlice{"10.5"}},
+		{`-3`, emulator.StringOrSlice{"-3"}},
+		{`123456789012345678901234567890`, emulator.StringOrSlice{"123456789012345678901234567890"}},
+		{`true`, emulator.StringOrSlice{"true"}},
+		{`false`, emulator.StringOrSlice{"false"}},
+		{`"already a string"`, emulator.StringOrSlice{"already a string"}},
+		{`["a",1,true]`, emulator.StringOrSlice{"a", "1", "true"}},
+		{`[]`, emulator.StringOrSlice{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.json, func(t *testing.T) {
+			var got emulator.StringOrSlice
+			require.NoError(t, json.Unmarshal([]byte(tc.json), &got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("null, an object and a nested array are still refused", func(t *testing.T) {
+		for _, bad := range []string{`null`, `{"k":"v"}`, `[["a"]]`, `[{"k":"v"}]`, `[null]`} {
+			var got emulator.StringOrSlice
+			assert.Error(t, json.Unmarshal([]byte(bad), &got), "%s is not a policy value", bad)
+		}
+	})
+}

--- a/emulator/iam_condition_principal_test.go
+++ b/emulator/iam_condition_principal_test.go
@@ -1,0 +1,292 @@
+package emulator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// aws:PrincipalArn has a producer on every enforcement door (#714).
+//
+// It had one only in the simulator, which is a divergence in the direction that matters:
+// a caller could simulate a policy conditioned on the key, watch it evaluate, and then
+// have the same policy decided differently by the gate the simulation exists to predict.
+//
+// The tests below are in two halves. The first asserts the key is populated and readable
+// by the operators written about it. The second is the regression #714's own absent-key
+// rule created: AWS answers *true* for a negated operator over an absent key, so with no
+// producer, `ArnNotEquals` over aws:PrincipalArn was satisfied by every caller — a Deny
+// so written fired against the principal its wildcard exempted, and an Allow so written
+// granted everyone.
+
+// iamPrincipalARN is the caller every case here authorizes as, matching the ARN
+// newAuthTestReqCtx is given below.
+const iamPrincipalARN = "arn:aws:iam::123456789012:user/jill"
+
+// iamPrincipalPolicy is a one-condition Allow for s3:GetObject over aws:PrincipalArn.
+func iamPrincipalPolicy(operator, condValue string) *emulator.PolicyDocument {
+	return iamClockPolicy(operator, "aws:PrincipalArn", condValue)
+}
+
+// TestAuthController_PrincipalArnHasAProducer reads the key with each family of operator
+// AWS documents for it.
+//
+// The Null rows assert population without reference to the value; the rest assert the ARN
+// written is the caller's own, which a Null row alone would not catch — a producer writing
+// the *role*'s ARN, or a truncated one, would pass Null and fail these.
+func TestAuthController_PrincipalArnHasAProducer(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		operator  string
+		condValue string
+		allowed   bool
+	}{
+		{"the key exists", "Null", "false", true},
+		{"the key is not absent", "Null", "true", false},
+		{"ArnEquals on the caller's own ARN", "ArnEquals", iamPrincipalARN, true},
+		{"ArnEquals on another ARN", "ArnEquals", "arn:aws:iam::123456789012:user/jack", false},
+		{"ArnLike over the user path", "ArnLike", "arn:aws:iam::123456789012:user/*", true},
+		{"ArnLike over the role path", "ArnLike", "arn:aws:iam::123456789012:role/*", false},
+		// AWS: aws:PrincipalArn is "always present" and its value is a string, so the
+		// String operators read it too — which is how a policy conditioned with
+		// StringLike rather than ArnLike behaves the same way.
+		{"StringLike over the user path", "StringLike", "arn:aws:iam::*:user/jill", true},
+		{"StringEquals on the caller's own ARN", "StringEquals", iamPrincipalARN, true},
+		// The negated form, read against a present key: it is the absence that used to
+		// make these vacuous, so both directions are pinned.
+		{"ArnNotEquals on another ARN", "ArnNotEquals", "arn:aws:iam::123456789012:user/jack", true},
+		{"ArnNotEquals on the caller's own ARN", "ArnNotEquals", iamPrincipalARN, false},
+		{"ArnNotEquals over a matching wildcard", "ArnNotEquals", "arn:aws:iam::123456789012:user/*", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := iamClockCheckAccess(t, iamPrincipalPolicy(tc.operator, tc.condValue), false)
+			if tc.allowed {
+				assert.NoError(t, err, "%s %s", tc.operator, tc.condValue)
+				return
+			}
+			require.Error(t, err, "%s %s", tc.operator, tc.condValue)
+			var awsErr *emulator.AWSError
+			require.ErrorAs(t, err, &awsErr)
+			assert.Equal(t, "AccessDenied", awsErr.Code)
+		})
+	}
+}
+
+// TestAuthController_ArnNotEqualsDenyExemptsTheNamedPrincipal is the regression, written
+// as the policy that expresses it: a broad Allow with a Deny that carves out one caller.
+//
+// This is the shape a guardrail takes — "deny this action to everyone who is not the
+// break-glass principal" — and it inverted completely without a producer for the key it
+// names. The second case is the control: the same Deny must still fire on a principal the
+// wildcard does not cover, or the test would pass on a Deny that had simply gone inert.
+func TestAuthController_ArnNotEqualsDenyExemptsTheNamedPrincipal(t *testing.T) {
+	t.Parallel()
+
+	denyUnless := func(pattern string) *emulator.PolicyDocument {
+		return &emulator.PolicyDocument{
+			Version: "2012-10-17",
+			Statement: []emulator.PolicyStatement{
+				{
+					Effect:   emulator.IAMEffectAllow,
+					Action:   emulator.StringOrSlice{"s3:*"},
+					Resource: emulator.StringOrSlice{"*"},
+				},
+				{
+					Effect:   emulator.IAMEffectDeny,
+					Action:   emulator.StringOrSlice{"s3:GetObject"},
+					Resource: emulator.StringOrSlice{"*"},
+					Condition: map[string]map[string]emulator.StringOrSlice{
+						"ArnNotEquals": {"aws:PrincipalArn": emulator.StringOrSlice{pattern}},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("the exempted principal is allowed", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, iamClockCheckAccess(t, denyUnless("arn:aws:iam::*:user/jill"), false),
+			"the wildcard names jill, so the Deny must not fire on her")
+	})
+
+	t.Run("everyone else is denied", func(t *testing.T) {
+		t.Parallel()
+		assert.Error(t, iamClockCheckAccess(t, denyUnless("arn:aws:iam::*:user/jack"), false),
+			"the wildcard does not name jill, so the Deny must fire")
+	})
+}
+
+// TestEC2_TagOnCreate_ReadsPrincipalArn covers the second door a tagged create passes.
+//
+// The tag-on-create gate builds its own condition context, so the key had to be written
+// there too; a request authorized twice against two different answers for the same key
+// would allow at one door and deny at the other. Both statements below carry the
+// condition, so a missing producer fails whichever gate lost it.
+func TestEC2_TagOnCreate_ReadsPrincipalArn(t *testing.T) {
+	t.Parallel()
+
+	principal := "arn:aws:iam::" + ec2AuthzAccount + ":user/tagger"
+	onlyTagger := map[string]map[string]emulator.StringOrSlice{
+		"ArnEquals": {"aws:PrincipalArn": emulator.StringOrSlice{principal}},
+	}
+	f := newEC2AuthzFixture(t, "tagger", emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{
+			ec2CreateTagsStatement("Allow", "ec2:RunInstances", ec2AuthzAllFive(), onlyTagger),
+			ec2CreateTagsStatement("Allow", "ec2:CreateTags", []string{ec2CreateTagsAnyARN}, onlyTagger),
+		},
+	})
+
+	err := f.launch(t, map[string]string{
+		"ImageId":                         ec2AuthzAMI,
+		"SubnetId":                        ec2AuthzSubnet,
+		"SecurityGroupId.1":               ec2AuthzSG,
+		"TagSpecification.1.ResourceType": "instance",
+		"TagSpecification.1.Tag.1.Key":    "Env",
+		"TagSpecification.1.Tag.1.Value":  "prod",
+	})
+	assert.NoError(t, err, "both gates condition on aws:PrincipalArn, so both must read it")
+}
+
+// TestIAMPlugin_ControlPlaneDoorReadsPrincipalArn covers the fourth door.
+//
+// The IAM plugin authorizes its own control-plane calls rather than going through
+// [emulator.AuthController], and its context was empty by design — nothing there reads the
+// request for tags. aws:PrincipalArn is the exception, because it is not read from the
+// request at all: it is who signed it, and this door knows that as surely as the others.
+// While it was missing, a condition on the key held vacuously here and failed at the main
+// gate, so one policy got two answers depending on which service the call went to.
+func TestIAMPlugin_ControlPlaneDoorReadsPrincipalArn(t *testing.T) {
+	const danaARN = "arn:aws:iam::123456789012:user/dana"
+
+	// The call under test creates a second user, which is as good as any: it is
+	// authorized as iam:CreateUser and needs no prior state.
+	call := func(t *testing.T, srv *emulator.Server, keyID, userName string) int {
+		t.Helper()
+		raw, err := json.Marshal(map[string]any{"UserName": userName})
+		require.NoError(t, err)
+		r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+		r.Host = "iam.amazonaws.com"
+		r.Header.Set("X-Amz-Target", "AmazonIdentityManagementService.CreateUser")
+		r.Header.Set("Content-Type", "application/x-amz-json-1.1")
+		r.Header.Set("Authorization", trustAuthHeader(keyID, "iam"))
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, r)
+		resp := w.Result()
+		require.NoError(t, resp.Body.Close())
+		return resp.StatusCode
+	}
+
+	cases := []struct {
+		name       string
+		condARN    string
+		wantStatus int
+	}{
+		{"ArnEquals on the caller is allowed", danaARN, http.StatusOK},
+		{"ArnEquals on another principal is refused",
+			"arn:aws:iam::123456789012:user/eve", http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTrustPolicyTestServer(t)
+			require.Equal(t, http.StatusOK,
+				trustIAMCall(t, srv, "CreateUser", map[string]any{"UserName": "dana"}).StatusCode)
+			require.Equal(t, http.StatusOK, trustIAMCall(t, srv, "PutUserPolicy", map[string]any{
+				"UserName":   "dana",
+				"PolicyName": "iam-as-dana",
+				"PolicyDocument": `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+					`"Action":"iam:*","Resource":"*",` +
+					`"Condition":{"ArnEquals":{"aws:PrincipalArn":"` + tc.condARN + `"}}}]}`,
+			}).StatusCode)
+
+			resp := trustIAMCall(t, srv, "CreateAccessKey", map[string]any{"UserName": "dana"})
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			var parsed struct {
+				AccessKeyID string `xml:"CreateAccessKeyResult>AccessKey>AccessKeyId"`
+			}
+			require.NoError(t, xml.Unmarshal(body, &parsed))
+			require.NotEmpty(t, parsed.AccessKeyID)
+
+			assert.Equal(t, tc.wantStatus, call(t, srv, parsed.AccessKeyID, "made-by-dana"))
+		})
+	}
+}
+
+// TestSTSAssumeRole_TrustPolicyReadsPrincipalArn covers the trust-policy door.
+//
+// A trust policy is where AWS's own guidance puts a condition on aws:PrincipalArn — it is
+// how a Principal naming a whole account is narrowed to particular callers — so the key
+// being absent there made the narrowing either inert or inverted. The Deny case is the
+// same exemption shape as the identity-policy test above, on the door where it is most
+// often written.
+func TestSTSAssumeRole_TrustPolicyReadsPrincipalArn(t *testing.T) {
+	const aliceARN = "arn:aws:iam::123456789012:user/alice"
+
+	cases := []struct {
+		name        string
+		trustPolicy string
+		wantStatus  int
+	}{
+		{
+			name: "ArnEquals on the caller is admitted",
+			trustPolicy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+				`"Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole",` +
+				`"Condition":{"ArnEquals":{"aws:PrincipalArn":"` + aliceARN + `"}}}]}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "ArnEquals on another principal is refused",
+			trustPolicy: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow",` +
+				`"Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole",` +
+				`"Condition":{"ArnEquals":{"aws:PrincipalArn":"arn:aws:iam::123456789012:user/bob"}}}]}`,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			// The exemption shape: everyone in the account may assume the role except
+			// the principals the wildcard does not name. Without a producer the Deny
+			// fired on alice too, and the role was assumable by nobody.
+			name: "a Deny with ArnNotEquals exempts the named principal",
+			trustPolicy: `{"Version":"2012-10-17","Statement":[` +
+				`{"Effect":"Allow","Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole"},` +
+				`{"Effect":"Deny","Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole",` +
+				`"Condition":{"ArnNotEquals":{"aws:PrincipalArn":"arn:aws:iam::*:user/alice"}}}]}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "the same Deny fires on a principal it does not name",
+			trustPolicy: `{"Version":"2012-10-17","Statement":[` +
+				`{"Effect":"Allow","Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole"},` +
+				`{"Effect":"Deny","Principal":{"AWS":"123456789012"},"Action":"sts:AssumeRole",` +
+				`"Condition":{"ArnNotEquals":{"aws:PrincipalArn":"arn:aws:iam::*:user/bob"}}}]}`,
+			wantStatus: http.StatusForbidden,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTrustPolicyTestServer(t)
+			keyID := trustSetupCaller(t, srv, "alice")
+			trustCreateRole(t, srv, "target", tc.trustPolicy)
+
+			resp := trustAssumeRole(t, srv, keyID,
+				"arn:aws:iam::123456789012:role/target", "sess", "")
+			assert.Equal(t, tc.wantStatus, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+		})
+	}
+}

--- a/emulator/iam_eval.go
+++ b/emulator/iam_eval.go
@@ -525,31 +525,85 @@ func conditionMatches(
 	return true
 }
 
-// conditionKeyMatches evaluates one key of one operator, applying the set qualifier.
+// conditionKeyMatches evaluates one key of one operator, applying the set qualifier
+// and the ...IfExists suffix.
+//
+// The operator is decided before the key is read, and an operator substrate does not
+// recognize matches nothing whatever the qualifier. It used to match *everything* under
+// a set qualifier over an absent key: the loop below ran zero times and returned true
+// without the operator ever being consulted, so `ForAllValues:NumericLessThan` on a key
+// substrate does not populate granted an Allow (#714). For a *recognized* operator that
+// vacuous truth is AWS's own rule, quoted below, and it stays — the two cases are only
+// distinguishable because [condEvaluate] reports recognition alongside its answer.
+//
+// Substrate accepts an unknown operator at write time, stores it, and discards it here.
+// Real IAM validates the name when the document is submitted, so a document reaching
+// this deny-by-default is one AWS would have refused with MalformedPolicyDocument;
+// treating it as a non-match rather than as AWS's absent-key match is substrate's
+// choice, and it is the only one that cannot turn a typo into a grant.
+//
+// Null is routed past the presence check because it is the operator that tests for
+// absence: telling it the key is missing instead of letting it see the empty value
+// would invert it. A *set-qualified* Null does not match at all — AWS defines no
+// ForAllValues:Null or ForAnyValue:Null, and quantifying an existence test over the
+// values whose existence it is testing has no meaning. That too was a vacuous grant
+// before #714.
 func conditionKeyMatches(
-	qualifier, base, condKey string,
+	qualifier, operator, condKey string,
 	condValues StringOrSlice,
 	ctx map[string]string,
 	multiCtx map[string][]string,
 ) bool {
+	base, ifExists := condSplitIfExists(operator)
+	if base == "Null" && ifExists {
+		// AWS: IfExists may be added to "any condition operator name except the Null
+		// condition". Null already answers the question IfExists asks.
+		return false
+	}
+
 	switch qualifier {
 	case "":
-		return evaluateConditionKey(base, condContextValue(condKey, ctx, multiCtx), condValues)
+		if base == "Null" {
+			matched, _ := condEvaluate(base, condContextValue(condKey, ctx, multiCtx), condValues)
+			return matched
+		}
+		if !condKeyPresent(condKey, ctx, multiCtx) {
+			return condAbsentMatches(base, ifExists)
+		}
+		matched, recognized := condEvaluate(base, condContextValue(condKey, ctx, multiCtx), condValues)
+		return recognized && matched
 
 	case condForAllValues:
-		// Absent or empty is a match, per AWS — which is why AWS's own Important note
-		// says to pair ForAllValues with `"Null": {"key": "false"}` on an Allow, and why
-		// every one of its aws:TagKeys examples does.
+		if base == "Null" || !condOperatorRecognized(base) {
+			return false
+		}
+		// Absent or empty is a match, per AWS — "The ForAllValues qualifier returns true
+		// if there are no context keys in the request or if the context key value
+		// resolves to a null dataset" — which is why AWS's own Important note says to
+		// pair ForAllValues with `"Null": {"key": "false"}` on an Allow, and why every
+		// one of its aws:TagKeys examples does.
 		for _, reqVal := range condRequestValues(condKey, ctx, multiCtx) {
-			if !evaluateConditionKey(base, reqVal, condValues) {
+			if matched, _ := condEvaluate(base, reqVal, condValues); !matched {
 				return false
 			}
 		}
 		return true
 
 	case condForAnyValue:
+		if base == "Null" || !condOperatorRecognized(base) {
+			return false
+		}
+		// The one place AWS's two rules genuinely conflict: ForAnyValue says an absent
+		// key is false, IfExists says an absent key is true. AWS resolves it nowhere, so
+		// substrate reads IfExists as the more specific annotation — the author wrote it
+		// about exactly this case, and AWS's own gloss is emphatic that "other condition
+		// elements in the statement can still result in a nonmatch, but *not a missing
+		// key* when checked with ...IfExists". Recorded as substrate's choice (#714).
+		if ifExists && !condKeyPresent(condKey, ctx, multiCtx) {
+			return true
+		}
 		for _, reqVal := range condRequestValues(condKey, ctx, multiCtx) {
-			if evaluateConditionKey(base, reqVal, condValues) {
+			if matched, _ := condEvaluate(base, reqVal, condValues); matched {
 				return true
 			}
 		}
@@ -557,6 +611,27 @@ func conditionKeyMatches(
 		return false
 	}
 
+	return false
+}
+
+// condKeyPresent reports whether the request context carries a usable value for the
+// name a policy spells.
+//
+// A key present with an empty value counts as absent, which is the reading Null has
+// always had here ("the key exists and its value is not null") and the one AWS's
+// ForAllValues note uses when it speaks of a value that "resolves to a null dataset,
+// such as an empty string".
+//
+// This is a different question from the one [unsetConditionKeys] answers. That one
+// reports what a *simulation* was not given, so a caller who supplied a key with an
+// empty value is not told it was missing; this one asks whether there is a value to
+// compare, and there is not.
+func condKeyPresent(condKey string, ctx map[string]string, multiCtx map[string][]string) bool {
+	for _, v := range condRequestValues(condKey, ctx, multiCtx) {
+		if v != "" {
+			return true
+		}
+	}
 	return false
 }
 
@@ -656,81 +731,6 @@ func condRequestValues(condKey string, ctx map[string]string, multiCtx map[strin
 		return []string{ctx[name]}
 	}
 	return nil
-}
-
-// evaluateConditionKey evaluates a single condition key against the context value.
-// Multiple values for the same key use OR semantics.
-func evaluateConditionKey(operator, ctxVal string, condValues StringOrSlice) bool {
-	switch operator {
-	case "StringEquals":
-		for _, v := range condValues {
-			if ctxVal == v {
-				return true
-			}
-		}
-		return false
-
-	case "StringNotEquals":
-		for _, v := range condValues {
-			if ctxVal == v {
-				return false
-			}
-		}
-		return true
-
-	case "StringLike":
-		for _, v := range condValues {
-			if globMatch(v, ctxVal) {
-				return true
-			}
-		}
-		return false
-
-	case "StringNotLike":
-		for _, v := range condValues {
-			if globMatch(v, ctxVal) {
-				return false
-			}
-		}
-		return true
-
-	case "ArnEquals", "ArnLike":
-		for _, v := range condValues {
-			if globMatch(v, ctxVal) {
-				return true
-			}
-		}
-		return false
-
-	case "ArnNotEquals":
-		for _, v := range condValues {
-			if ctxVal == v {
-				return false
-			}
-		}
-		return true
-
-	case "Bool":
-		for _, v := range condValues {
-			if ctxVal == v {
-				return true
-			}
-		}
-		return false
-
-	case "Null":
-		isNull := ctxVal == ""
-		for _, v := range condValues {
-			want := strings.ToLower(v) == "true"
-			if want == isNull {
-				return true
-			}
-		}
-		return false
-	}
-
-	// Unknown operator — deny by default (safe).
-	return false
 }
 
 // globMatch returns true if pattern matches value using AWS glob rules:

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -1603,16 +1603,24 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 		}
 	}
 
-	// The context is deliberately empty, and MultiContext is left nil for the same
-	// reason: this path authorizes an IAM control-plane call, and nothing here reads the
-	// request for tags. A policy conditioned on aws:RequestTag or aws:TagKeys therefore
-	// cannot be satisfied through this door even though [CheckAccess] populates both —
-	// which is worth knowing before writing a condition against an iam: action (#690).
+	// The context carries the caller and nothing else, and MultiContext is left nil: this
+	// path authorizes an IAM control-plane call, and nothing here reads the request for
+	// tags. A policy conditioned on aws:RequestTag or aws:TagKeys therefore cannot be
+	// satisfied through this door even though [CheckAccess] populates both — which is
+	// worth knowing before writing a condition against an iam: action (#690).
+	//
+	// aws:PrincipalArn is the exception, for [authzPrincipalContext]'s reason: it is not
+	// read from the request at all, it is who signed it, and this door knows that as
+	// surely as the other three. Leaving it out let a negated operator over it hold
+	// vacuously here while failing at the main gate (#714).
+	condCtx := make(map[string]string, 1)
+	authzPrincipalContext(condCtx, reqCtx.Principal.ARN)
+
 	result := Evaluate(docs, EvaluationRequest{
 		Principal: reqCtx.Principal.ARN,
 		Action:    action,
 		Resource:  resource,
-		Context:   make(map[string]string),
+		Context:   condCtx,
 	})
 
 	if result.Decision != DecisionAllow {
@@ -1639,7 +1647,7 @@ func (p *IAMPlugin) authorize(goCtx context.Context, reqCtx *RequestContext, act
 					Principal: reqCtx.Principal.ARN,
 					Action:    action,
 					Resource:  resource,
-					Context:   make(map[string]string),
+					Context:   condCtx,
 				})
 				if boundaryResult.Decision != DecisionAllow {
 					return &AWSError{

--- a/emulator/iam_simulate.go
+++ b/emulator/iam_simulate.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // The IAM policy simulator: SimulatePrincipalPolicy and SimulateCustomPolicy.
@@ -526,7 +527,7 @@ func parseSimulationPolicyInputs(inputs []string, prefix string) ([]SourcedPolic
 func (p *IAMPlugin) simulateResponse(op string, params *iamSimulateRequest,
 	docs, boundaryDocs []SourcedPolicyDocument, callerArn string,
 ) (*AWSResponse, error) {
-	condCtx := simulationConditionContext(params, callerArn)
+	condCtx := simulationConditionContext(params, callerArn, p.now())
 
 	results := make([]iamSimulationResult, 0, len(params.ActionNames)*len(params.ResourceArns))
 	for _, action := range params.ActionNames {
@@ -617,20 +618,27 @@ func simulationDecision(decision string) string {
 // would otherwise report the key as a missing context value when the caller had in
 // fact told substrate what it is, through a differently-named parameter.
 //
+// aws:CurrentTime and aws:EpochTime come from the plugin's clock, for the same reason
+// and with the same rendering the enforcement path uses ([AuthController.authzTimeContext]):
+// a simulation that reported a date condition as a missing context value while the
+// request gate evaluated it would contradict the enforcement it exists to predict.
+//
 // An explicit ContextEntry wins over both, whatever case it is spelled in. A caller
 // who names a key is stating what to simulate with, and overriding that with a derived
 // value would make the parameter unusable — which is what a plain assignment would do
 // for AWS:PrincipalArn before #704, since it left the derived aws:PrincipalArn in the
 // map beside it and the evaluator would then resolve to whichever sorted first.
 // Deleting the folded-equal name is what makes the caller's entry win.
-func simulationConditionContext(params *iamSimulateRequest, callerArn string) map[string]string {
-	ctx := make(map[string]string, len(params.context)+2)
+func simulationConditionContext(params *iamSimulateRequest, callerArn string, now time.Time) map[string]string {
+	ctx := make(map[string]string, len(params.context)+4)
 	if callerArn != "" {
 		ctx["aws:PrincipalArn"] = callerArn
 	}
 	if params.ResourceOwner != "" {
 		ctx["aws:ResourceAccount"] = params.ResourceOwner
 	}
+	ctx["aws:CurrentTime"] = now.UTC().Format(time.RFC3339)
+	ctx["aws:EpochTime"] = strconv.FormatInt(now.Unix(), 10)
 	for key, value := range params.context {
 		if derived, ok := condResolveKey(key, ctx); ok && derived != key {
 			delete(ctx, derived)

--- a/emulator/iam_types.go
+++ b/emulator/iam_types.go
@@ -1,9 +1,11 @@
 package emulator
 
 import (
+	"bytes"
 	cryptorand "crypto/rand"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -174,22 +176,69 @@ func (p *PolicyPrincipal) MarshalJSON() ([]byte, error) {
 }
 
 // StringOrSlice unmarshals either a JSON string or an array of strings.
-// AWS policy fields Action, Resource, NotAction, and NotResource accept both forms.
+// AWS policy fields Action, Resource, NotAction, and NotResource accept both forms,
+// as does a condition value list.
 type StringOrSlice []string
 
 // UnmarshalJSON implements json.Unmarshaler for StringOrSlice.
+//
+// Numbers and Booleans are read as their text. The IAM grammar says so of every value
+// in a policy — "Values are enclosed in quotation marks. Quotation marks are optional
+// for numeric and Boolean values" — and a document substrate refused for writing them
+// unquoted is one real IAM accepts: `{"Bool": {"aws:SecureTransport": false}}` and
+// `{"NumericLessThanEquals": {"s3:max-keys": 10}}` are both legal, and both answered
+// MalformedPolicyDocument here before #714.
+//
+// A number keeps the spelling the document used, through [json.Number], rather than
+// being routed through a float: 10 must not become "1e+01" on its way to a comparison,
+// and a value too large for a float64 must not be silently rounded before
+// [condParseNumber] ever sees it.
+//
+// The tolerance reaches Action and Resource too, since they share this type, and there
+// a number is nonsense rather than shorthand. It is left in rather than scoped to
+// condition values because the effect is bounded and lies in the safe direction: an
+// `"Action": 5` becomes the action name "5", which matches no action, so the statement
+// grants nothing instead of being rejected.
 func (s *StringOrSlice) UnmarshalJSON(data []byte) error {
-	var str string
-	if err := json.Unmarshal(data, &str); err == nil {
-		*s = StringOrSlice{str}
-		return nil
-	}
-	var arr []string
-	if err := json.Unmarshal(data, &arr); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var raw any
+	if err := dec.Decode(&raw); err != nil {
 		return fmt.Errorf("unmarshal StringOrSlice: %w", err)
 	}
-	*s = StringOrSlice(arr)
+	if list, ok := raw.([]any); ok {
+		out := make(StringOrSlice, 0, len(list))
+		for _, elem := range list {
+			text, ok := jsonScalarText(elem)
+			if !ok {
+				return fmt.Errorf("unmarshal StringOrSlice: element %v is not a string, number or boolean", elem)
+			}
+			out = append(out, text)
+		}
+		*s = out
+		return nil
+	}
+	text, ok := jsonScalarText(raw)
+	if !ok {
+		return fmt.Errorf("unmarshal StringOrSlice: %v is not a string, number or boolean", raw)
+	}
+	*s = StringOrSlice{text}
 	return nil
+}
+
+// jsonScalarText renders a decoded JSON scalar as the text a policy comparison uses,
+// reporting false for null, an object, or a nested array — none of which the grammar
+// admits where a string, a number or a Boolean is allowed.
+func jsonScalarText(value any) (string, bool) {
+	switch v := value.(type) {
+	case string:
+		return v, true
+	case json.Number:
+		return v.String(), true
+	case bool:
+		return strconv.FormatBool(v), true
+	}
+	return "", false
 }
 
 // MarshalJSON implements json.Marshaler for StringOrSlice.

--- a/emulator/sts_plugin.go
+++ b/emulator/sts_plugin.go
@@ -287,10 +287,16 @@ func (p *STSPlugin) checkTrustPolicy(ctx *RequestContext, role IAMRole, roleARN,
 	// A condition key absent from the context is not the same as one set to "":
 	// conditionMatches reads a missing key as the empty string, so a policy
 	// requiring StringEquals sts:ExternalId correctly fails when none was sent.
-	condCtx := make(map[string]string, 1)
+	condCtx := make(map[string]string, 2)
 	if externalID != "" {
 		condCtx["sts:ExternalId"] = externalID
 	}
+	// The principal asking to assume the role. A trust policy is the likeliest place in
+	// AWS for a condition on aws:PrincipalArn — it is how an account-wide Principal is
+	// narrowed to particular callers — and with the key absent, a negated operator over it
+	// was satisfied by every caller, exempting nobody and, on an Allow, admitting all
+	// (#714). See [authzPrincipalContext].
+	authzPrincipalContext(condCtx, ctx.Principal.ARN)
 
 	// Resource is empty because a trust policy carries no Resource element — the
 	// role it is attached to *is* the resource. resourceMatches treats an empty

--- a/emulator/testing.go
+++ b/emulator/testing.go
@@ -115,7 +115,7 @@ func startTestServer(t testing.TB, creds *CredentialRegistry) *TestServer {
 	// Enforcement keys off whether the caller resolves to an IAM entity present in
 	// state, so an unsigned request, substrate's documented credentials, and any
 	// key that was never minted here are all unenforced.
-	auth := NewAuthController(state, logger)
+	auth := NewAuthController(state, logger, WithAuthTimeController(tc))
 
 	ctx := context.Background()
 	if err := RegisterDefaultPlugins(ctx, registry, state, tc, logger, store, nil,


### PR DESCRIPTION
Nine of AWS's twenty-six condition operators were implemented. The numeric family, the date
family, the IP family, `BinaryEquals`, `StringEqualsIgnoreCase`/`StringNotEqualsIgnoreCase`
(which AWS uses in its own `ec2:CreateTags` example) and the `...IfExists` suffix all fell
through to a deny, so a policy real IAM accepts and evaluates was at best a false refusal
here. The operator layer now lives in one place, `emulator/iam_condition_operators.go`, and
`docs/services.md` gained the operator reference it never had.

## Four bugs in the operators that were already there

- **A set qualifier over an absent key granted the statement.** `ForAllValues:`/`ForAnyValue:`
  returned `true` without consulting the operator at all, so an `Allow` written with an
  operator substrate cannot evaluate — or a misspelled one, which nothing rejects at write
  time — was granted. #714 called this "safe"; it is the opposite, and given how few keys
  have producers it was the common case.
- **`ArnNotEquals` compared with `==`.** No real ARN is byte-equal to a pattern containing
  `*`, so the negation was always satisfied: a `Deny` so written fired against the very
  principals its wildcard exempted, and an `Allow` so written granted everyone.
- **An ARN wildcard crossed a colon.** One `globMatch` ran over the whole string, so
  `arn:aws:sns:*:topic` matched a five-component ARN whose account it never named. AWS: "Each
  of the six colon-delimited components of the ARN is checked separately."
- **Unquoted numbers and Booleans were refused.** The IAM grammar declares them legal
  ("Quotation marks are optional for numeric and Boolean values"), so
  `{"Bool": {"aws:SecureTransport": false}}` got `MalformedPolicyDocument`.

Two rules substrate never had, both AWS's: **an absent key follows the operator's polarity**
(negated operators answer `true`), and **a key present with an empty value counts as absent**,
everywhere except `Null`, whose whole job is to see it.

## Producers

An operator is only as useful as the keys it can compare.

`AuthController` gained an optional `TimeController` (`WithAuthTimeController`), so
`aws:CurrentTime`/`aws:EpochTime` are real and replay-safe — read once per request, and
deliberately **not** `reqCtx.Timestamp`, which is `time.Now()` on the HTTP path. Without a
clock both keys stay absent rather than falling back to wall time: a documented false deny in
exchange for a replayable one.

`aws:PrincipalArn` is now written at all four enforcement gates, not in the simulator alone.
That divergence was found by the live SDK run below, and it was not merely cosmetic: with the
key absent, *this PR's own* absent-key polarity rule made
`"ArnNotEquals": {"aws:PrincipalArn": "arn:aws:iam::*:user/carol"}` — an exemption — satisfied
by every caller, so the `Deny` fired on carol herself. `aws:PrincipalAccount`, `aws:userid` and
`aws:username` stay absent: each needs a derivation substrate cannot make honestly for every
principal kind.

## Corrections to the issue

- "an unimplemented operator falls to the closing deny-by-default (safe)" — **false in the
  dangerous direction**, per the first bug above.
- "`ArnLike` is aliased to `ArnEquals`, which AWS documents as distinct" — **refuted.** AWS:
  "The `ArnEquals` and `ArnLike` condition operators behave identically." The alias is correct;
  the `==` is the bug.
- The operator list omitted `StringEqualsIgnoreCase`/`StringNotEqualsIgnoreCase` and the
  unquoted-value grammar.
- `ForAllValues` over an absent key is a **match** per AWS ("returns true if there are no
  context keys in the request"), so the fix distinguishes *recognized* from *unrecognized*
  operators rather than making every qualified operator consult its base.

## Provenance

AWS documents no answer for these; each is substrate's recorded reading. An unparseable policy
value is **skipped**; an unparseable *context* value fails a positive operator and satisfies a
negated one. `"2020"` is both a legal W3C year and a legal epoch second — the year wins. A bare
IPv6 address is a `/128` (AWS's "/32" sentence is written for IPv4; taking it literally would
turn one address into 2^96). Go's spellings of infinity, NaN and hexadecimal floats are not
numbers. `ForAnyValue:<operator>IfExists` is where AWS's two rules conflict and the suffix wins,
on the strength of "Other condition elements … can still result in a nonmatch, but not a
missing key when checked with `...IfExists`". A set-qualified `Null` does not match at all. An
operator substrate does not recognize denies — real IAM answers `MalformedPolicyDocument` at
write time and substrate does not validate operator names at all.

## Verification

- `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → 0 issues
- `make test` (race, `-count=1`) green; `make coverage` 82.6% total, `emulator` 83.3%
- `make docs-reference docs-reference-check docs-versions`; `npm --prefix docs run build` plus
  an `href="#…"` vs `id="…"` diff over `dist/services.html` — no dangling anchors
- `go vet -C test/e2e ./... && go test -C test/e2e ./...` green
- **Mutation testing**: 26 mutations, one decision each, all caught. Two survivors along the
  way each exposed a real gap — the hex-float guard's actual job, and `ForAnyValue`'s operator
  check being load-bearing only for a present-key `Null` — and both are now pinned.
- **Live SDK run** against a built binary (`aws` CLI, `AWS_MAX_ATTEMPTS=1`): 31 probes over all
  seven areas, including the `aws:PrincipalArn` inversion this PR then fixed.

Closes #714
