### PR TITLE
chore(release): v0.107.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.107.0] - 2026-08-21
+
 ### Added
 - **`CreateTags` and `DeleteTags` reach every taggable EC2 resource type** (#708). Five ID
   prefixes were **silently ignored**: a request naming an `ami-`, `lt-`, `fleet-`, `pg-` or
@@ -800,6 +802,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the comparison ever saw it. The tolerance reaches `Action` and `Resource`, which share the type,
   and is left there because the effect is bounded and safe — an `"Action": 5` becomes the action
   name `"5"`, which matches nothing.
+
+- **`CLAUDE.md`'s scope section no longer cites a progression substrate does not model.** It
+  offered an SSM command invocation going `Pending → InProgress → Success` as an example of a
+  state transition in scope; `ssm_control.go`'s seed is a single flat `Status` written once, and
+  the string `InProgress` appears nowhere in the plugin. The example is replaced with the
+  snapshot progression this release actually added (#715), and the sentence no longer claims
+  every progression is clock-driven — #715's is a countdown of observations, deliberately, so
+  that an assertion about it cannot depend on wall-clock time.
 
 ## [v0.106.0] - 2026-08-21
 
@@ -8759,7 +8769,8 @@ all changes onto the v0.44.x line.
 [v0.58.2]: https://github.com/scttfrdmn/substrate/compare/v0.58.1...v0.58.2
 [v0.58.1]: https://github.com/scttfrdmn/substrate/compare/v0.58.0...v0.58.1
 [v0.58.0]: https://github.com/scttfrdmn/substrate/compare/v0.57.0...v0.58.0
-[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.106.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/substrate/compare/v0.107.0...HEAD
+[v0.107.0]: https://github.com/scttfrdmn/substrate/compare/v0.106.0...v0.107.0
 [v0.106.0]: https://github.com/scttfrdmn/substrate/compare/v0.105.0...v0.106.0
 [v0.105.0]: https://github.com/scttfrdmn/substrate/compare/v0.104.0...v0.105.0
 [v0.104.0]: https://github.com/scttfrdmn/substrate/compare/v0.103.0...v0.104.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,13 @@ caller can make accurate, seedable, and time-ordered — never to execute the
 workload behind the API.
 
 - In scope: request/response shapes, error codes, resource state and its
-  transitions over the simulated clock (e.g. an instance moving
-  `pending → running`, a job reporting `Failed` with a seeded reason, a command
-  invocation going `Pending → InProgress → Success`), and seedable outcomes that
-  let a consumer's poll/retry/wait loop be tested.
+  transitions (e.g. an instance moving `pending → running`, a job reporting
+  `Failed` with a seeded reason, a snapshot reported `pending` for a seeded
+  number of observations before it reaches `completed`), and seedable outcomes
+  that let a consumer's poll/retry/wait loop be tested. A progression is driven
+  by the simulated clock or by a countdown of observations, whichever the
+  operation's own reference behaviour makes assertable without wall-clock
+  dependence.
 - Out of scope: actually running the work — executing user-data or cloud-init,
   running a Lambda's code, performing an inference, running a training job,
   bootstrapping a node. Capture such inputs as recorded intent and expose a


### PR DESCRIPTION
Rolls `## [Unreleased]` into `## [v0.107.0] - 2026-08-21` and adds the comparison link. No
code changes; the thirteen issues on milestone 92 all landed in their own PRs.

Also in this PR, as the plan called for: **`CLAUDE.md`'s scope section cited a progression
substrate does not model.** It offered "a command invocation going `Pending → InProgress →
Success`" as an in-scope example. `emulator/ssm_control.go`'s seed is a single flat
`Status string` written once, and `InProgress` appears nowhere in the SSM plugin — so the
one example a contributor would reach for as precedent was the one that had no
implementation behind it. It is replaced with the snapshot progression #715 actually added,
and the sentence no longer claims a progression is always clock-driven: #715's is a
countdown of observations, chosen precisely so an assertion about it cannot depend on
wall-clock time, which the old wording ruled out by definition.

Verified on this branch: `gofmt`/`go build`/`go vet` clean, `golangci-lint run ./...` →
0 issues, `make test` (race, `-count=1`) green, `make coverage` 82.6%, `make docs-reference
docs-reference-check docs-versions` clean, `npm --prefix docs run build` clean, `go vet -C
test/e2e ./... && go test -C test/e2e ./...` green.
