### PR TITLE
fix(parser,config): one server serves one account (#734)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`account.default` in `substrate.yaml` sets the account every request is attributed to**
+  (#734). It defaults to `123456789012`, AWS's documented example account, and `Validate`
+  refuses a value that is not 12 digits rather than letting a typo through to every ARN the
+  server mints. `substrate.yaml.example` documents it beside `region:`, which it parallels.
+
+### Fixed
+- **One server serves one account** (#734). `ParseAWSRequest` decided the account from the
+  *shape of the access key*: a key beginning with `AKIA` was attributed to `123456789012`,
+  and everything else — substrate's own documented `test`/`test`, an unsigned request, an
+  `ASIA` session key — to `000000000000`. So one substrate process served two accounts,
+  chosen by which of two documented credentials the client happened to pick, and **nothing on
+  the wire told a caller which one they had.** A consumer who created an IAM user with one
+  credential and made a denied EC2 call with another saw the denial name an account their user
+  was not in.
+
+  The issue diagnosed this as the IAM plugin and the authorization path disagreeing about a
+  constant. That is refuted: both read `RequestContext.AccountID` and always have. The split
+  was upstream of both, in the parser, which is why it reached every service at once.
+
+  The account now comes from one place, in one order, each step knowing more than the last:
+  the built-in default, then `account.default`, then a `CredentialRegistry` entry, then an STS
+  session record — the last being the only thing that can know the account a cross-account
+  `AssumeRole` landed in, since a temporary credential's account is recorded when the session
+  is minted and appears nowhere on the wire. `extractAccount` and `fallbackAccountID` are gone,
+  along with the duplicate `seedSSMAccountID`.
+
+  A test parses every non-test Go file and fails on any string literal carrying an
+  account-shaped run of twelve digits, exempting only the declaration of the default itself —
+  a stronger rule than "no `000000000000`", because a second literal `123456789012` would be
+  just as wrong. It catches the one offender that survived: `ListEventBuses` returned
+  `arn:aws:events:us-east-1:000000000000:event-bus/default`, ignoring **both** of its request
+  context's fields, so a caller's own default event bus was reported in an account and a Region
+  that were not theirs. A second test asks three services who the caller is — `GetCallerIdentity`,
+  the CloudFormation deployer's stack ARN, and a DynamoDB table reached through the Resource
+  Groups Tagging API's account-prefixed state key — and compares the answers, for two accounts,
+  because a producer that returns a constant agrees with itself.
+
+  Deliberately not covered, each documented in `docs/services.md` and filed: IAM's state keys
+  stay account-blind, so an entity still resolves by name across accounts (#737);
+  `substrate.yaml`'s `credentials:` and `auth:` sections are still not read by `Config` (#736);
+  and the registry is still not wired into `cmd/substrate/main.go`, because wiring one also
+  switches SigV4 enforcement on and would 403 substrate's own documented credentials — the
+  decoupling is #630.
+
+- **EventBridge is reachable from a real SDK** (#734). Found while verifying the above with the
+  `aws` CLI: **every** EventBridge call answered `ServiceNotAvailable: service not emulated:
+  awsevents`. The target prefix in EventBridge's model is `AWSEvents`, not `AmazonEventBridge`,
+  and only the host alias (`events.*` → `eventbridge`) was registered. That is enough on a real
+  endpoint and useless on the one way substrate is actually reached: with `--endpoint-url` the
+  host is `localhost` and `X-Amz-Target` is the only signal. The plugin was registered, green,
+  and unreachable — the #561/#580 failure mode — so `ListEventBuses` returning the wrong account
+  had never been observable in the first place. A test now pins all three resolution paths, as
+  Config's does.
+
+  **Compatibility.** Every ARN returned to an unsigned or non-`AKIA` caller changes account, so
+  a fixture asserting on `000000000000` now sees `123456789012`. Several plugins prefix their
+  state keys with the account (`table:{account}/{name}`, `instance:{account}/{id}`), so
+  **persisted SQLite state written under the old account is unreachable** after upgrading:
+  re-seed it, or set `account.default: "000000000000"` to read it back.
+
 ## [v0.107.0] - 2026-08-21
 
 ### Added

--- a/docs/services.md
+++ b/docs/services.md
@@ -154,6 +154,72 @@ changed where IAM's code, message and status come from and left the shape alone.
 
 ---
 
+## Which account a request is attributed to
+
+Most plugins scope a resource to the account of the request that created it, and
+every ARN substrate mints names one, so "which account is this?" is a question with a
+single answer. Substrate resolves it in one place and in this order:
+
+| Source | When it applies |
+|---|---|
+| `123456789012` | Always, as the starting point. AWS's documented example account. |
+| `account.default` in `substrate.yaml` | Whenever it is set and 12 digits. Set it to whatever your fixtures assert on. |
+| A `CredentialRegistry` entry | When the request is signed with an access key the registry holds. |
+| An STS session record | When the request is signed with credentials `AssumeRole` minted. |
+
+Later rows win. The order is what it is because each row knows strictly more than the
+one above it: a config file knows the deployment, a registry knows which key belongs
+to which account, and only the session record knows the account a cross-account
+`AssumeRole` landed in — a temporary credential's account is recorded when the session
+is minted and appears nowhere on the wire.
+
+An **unsigned** request is attributed to the resolved default. That is deliberate:
+`VerifySigV4` passes a request carrying no `Authorization` header, so an unsigned
+caller reaches its plugin as the default account even against a server with a
+credential registry wired.
+
+### There is no second account for free
+
+Until [#734](https://github.com/scttfrdmn/substrate/issues/734), the account came
+from the *shape of the access key*: a key beginning with `AKIA` was attributed to
+`123456789012`, and everything else — substrate's own documented `test`/`test`, an
+unsigned request, an `ASIA` session key — to `000000000000`. One server served two
+accounts, chosen by which of two documented credentials the client happened to pick,
+and nothing on the wire told a caller which one they had.
+
+`000000000000` no longer exists anywhere in substrate. A test asserts it: every
+non-test Go file is parsed and any string literal carrying an account-shaped run of
+twelve digits fails the build, with one exemption for the declaration of the default
+itself. A run bounded by anything other than `:`, `/` or the end of the string is not
+an account — which is what keeps `shardId-000000000000` and the like out of it.
+
+**If a fixture asserts on `000000000000`, it now sees `123456789012`.** Two things
+follow. Every ARN returned to an unsigned or non-`AKIA` caller changes account. And
+because several plugins prefix their state keys with the account —
+`table:{account}/{name}`, `instance:{account}/{id}` — **persisted SQLite state written
+under the old account is unreachable** after upgrading. Re-seed it, or set
+`account.default: "000000000000"` to read it back.
+
+### What is deliberately not covered
+
+- **IAM's state keys are account-blind.** A user is stored under `user:{name}` with no
+  account in the key, so `resolveIAMEntity` resolves a principal by name across
+  accounts and two accounts cannot both hold a role of the same name. Filed as
+  [#737](https://github.com/scttfrdmn/substrate/issues/737); it is reachable only with
+  a credential registry, which is in-process only today.
+- **`substrate.yaml`'s `credentials:` and `auth:` sections are not read.** `Config` has
+  no fields for them, so the shipped `substrate server` discards both. Both subsystems
+  are real and reachable in-process through `ServerOptions`. Filed as
+  [#736](https://github.com/scttfrdmn/substrate/issues/736).
+- **Wiring a registry also switches SigV4 enforcement on**, because `Server` verifies
+  signatures exactly when `ServerOptions.Credentials` is non-nil. That coupling is why
+  the registry cannot simply be wired into the binary: substrate's documented
+  `test`/`test` credentials are in no registry and would start answering
+  `InvalidClientTokenId` 403. Decoupling the two is
+  [#630](https://github.com/scttfrdmn/substrate/issues/630).
+
+---
+
 ## CloudFormation
 
 **Endpoint:** `cloudformation.{region}.amazonaws.com`
@@ -250,7 +316,7 @@ caller that created the stack, so they are visible to that caller's reads and no
 one else's:
 
 ```
-# unsigned, so the caller is 000000000000
+# unsigned, so the caller is the default account — 123456789012
 aws --endpoint-url http://localhost:4566 cloudformation create-stack \
   --stack-name acct --template-body '{"Resources":{"I":{"Type":"AWS::EC2::Instance",
                      "Properties":{"ImageId":"ami-12345678","InstanceType":"t3.micro"}}}}'
@@ -265,7 +331,11 @@ built from either agrees with the stack ARN.
 The in-process `emulator.Client` deploys into substrate's default partition
 (`123456789012` / `us-east-1`). Its callers never sign a request, so there is no
 caller identity to take; an in-process caller that needs another partition can set
-one on the deployer with `emulator.WithDeployerIdentity`.
+one on the deployer with `emulator.WithDeployerIdentity`. An unsigned wire caller
+lands in the same partition — see
+[Which account a request is attributed to](#which-account-a-request-is-attributed-to)
+— so a stack deployed in process and one deployed over the wire are visible to each
+other without either side configuring anything.
 
 ### A stack's resource calls are authorized
 

--- a/emulator/account_plugin.go
+++ b/emulator/account_plugin.go
@@ -605,7 +605,7 @@ func (p *AccountPlugin) regionInput(req *AWSRequest) (*accountRegionRequest, err
 // must be the management account itself; a member naming another member is
 // refused.
 func (p *AccountPlugin) targetAccount(reqCtx *RequestContext, accountID string) (string, error) {
-	caller := fallbackAccountID
+	caller := defaultAccountID
 	if reqCtx != nil && reqCtx.AccountID != "" {
 		caller = reqCtx.AccountID
 	}

--- a/emulator/account_plugin_test.go
+++ b/emulator/account_plugin_test.go
@@ -690,7 +690,7 @@ func TestAccount_AccountIDTargetsAMemberAccount(t *testing.T) {
 //
 // The rest-json path is part of the canonical request, so the signature covers it;
 // signing "/" here would produce a header the server refuses before any plugin
-// runs, which is why sigV4Header takes the path.
+// runs, which is why signAs signs the request's own path.
 func accountSignedRequest(t *testing.T, ts *emulator.TestServer, account, path string, body any) *http.Response {
 	t.Helper()
 
@@ -703,19 +703,14 @@ func accountSignedRequest(t *testing.T, ts *emulator.TestServer, account, path s
 		t.Fatalf("marshal %s: %v", path, err)
 	}
 
-	const (
-		host     = "account.us-east-1.amazonaws.com"
-		dateTime = "20260101T120000Z"
-	)
+	const host = "account.us-east-1.amazonaws.com"
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+path, bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("build %s request: %v", path, err)
 	}
 	req.Host = host
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Amz-Date", dateTime)
-	req.Header.Set("Authorization", sigV4Header(path, host, "account", dateTime, data,
-		creds.AccessKeyID, creds.SecretAccessKey))
+	signAs(req, creds, "account", "us-east-1", data)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/emulator/account_single_test.go
+++ b/emulator/account_single_test.go
@@ -1,0 +1,324 @@
+package emulator_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// The tests in this file are #734's gate, and between them they state the whole
+// contract: there is one account, it is resolved in one place, and every service
+// that names an account names that one.
+//
+// The defect was not two services disagreeing about a constant — it was substrate
+// handing out a *second* account for free. ParseAWSRequest branched on the shape of
+// the access key: a key beginning with "AKIA" resolved to 123456789012, and
+// anything else — substrate's own documented test/test, an unsigned request, an
+// ASIA session key — resolved to 000000000000. One server, two accounts, chosen by
+// which of two documented credentials the client happened to pick, and nothing on
+// the wire to tell a caller which one they got.
+//
+// So the fix has two halves that need pinning separately. The first is that the
+// account comes from one place, which is what the tripwire below asserts
+// structurally. The second is that every producer reads it from that place, which is
+// what the agreement test asserts observably.
+
+// TestSingleAccount_NoSecondHardcodedAccountInProduction is the tripwire.
+//
+// It parses every non-test Go file in the repository and refuses any string literal
+// carrying an account-shaped run of digits, with exactly one exemption: the
+// declaration of defaultAccountID itself. That is a stronger rule than "no
+// 000000000000" — a second literal 123456789012 would be just as wrong, because the
+// property #734 buys is that the account is resolved in one place and overridable
+// from configuration. A literal anywhere else is a service that cannot be moved.
+//
+// It catches the offender the live run found: listEventBuses returned
+// arn:aws:events:us-east-1:000000000000:event-bus/default, ignoring both of its
+// request context's fields, so a caller's own default event bus was reported in an
+// account and a Region that were not theirs.
+func TestSingleAccount_NoSecondHardcodedAccountInProduction(t *testing.T) {
+	root, err := filepath.Abs("..")
+	require.NoError(t, err)
+
+	type finding struct {
+		file    string
+		line    int
+		account string
+		inside  string
+	}
+	var found []finding
+
+	fset := token.NewFileSet()
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// test/ is the e2e suite and testdata/ is fixtures; neither ships.
+			// examples/ is consumer code, and a consumer filling in AccountID on a
+			// RequestContext it builds itself is the documented way to choose an
+			// account — the opposite of the defect. The rest are not Go at all and
+			// walking them only costs time.
+			switch d.Name() {
+			case ".git", "node_modules", "docs", "examples", "test", "testdata":
+				if path != root {
+					return fs.SkipDir
+				}
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		f, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		// The one exemption, identified structurally rather than by file name: the
+		// value of the const named defaultAccountID.
+		exempt := map[ast.Expr]bool{}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			if spec, ok := n.(*ast.ValueSpec); ok {
+				for _, name := range spec.Names {
+					if name.Name == "defaultAccountID" {
+						for _, v := range spec.Values {
+							exempt[v] = true
+						}
+					}
+				}
+				return true
+			}
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING || exempt[lit] {
+				return true
+			}
+			text, unquoteErr := strconv.Unquote(lit.Value)
+			if unquoteErr != nil {
+				return true
+			}
+			for _, account := range accountShapedRuns(text) {
+				found = append(found, finding{
+					file:    rel,
+					line:    fset.Position(lit.Pos()).Line,
+					account: account,
+					inside:  text,
+				})
+			}
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, walkErr)
+
+	for _, f := range found {
+		t.Errorf("%s:%d hardcodes account %s in %q; read it from RequestContext.AccountID, "+
+			"or from defaultAccountID when there is genuinely no request in hand",
+			f.file, f.line, f.account, f.inside)
+	}
+}
+
+// accountShapedRuns returns the account IDs a string literal contains.
+//
+// An AWS account ID is twelve digits, and the bounding rule is what keeps this from
+// firing on identifiers that merely contain twelve zeroes: an account ID appears in
+// an ARN between colons, or after one and before a slash, so a run bounded by
+// anything else is part of a longer token rather than an account. That excludes
+// Kinesis's "shardId-000000000000" and DynamoDB's stream shard IDs, both preceded by
+// a hyphen, and MSK's "-0001-0001-0001-000000000001" for the same reason. Requiring
+// the run to be maximal excludes the twenty-digit shard sequence and the
+// fourteen-digit pricing offer version, which are not twelve digits long even though
+// they contain twelve consecutive ones.
+func accountShapedRuns(s string) []string {
+	const accountIDLen = 12
+	var out []string
+	for i := 0; i < len(s); {
+		if s[i] < '0' || s[i] > '9' {
+			i++
+			continue
+		}
+		j := i
+		for j < len(s) && s[j] >= '0' && s[j] <= '9' {
+			j++
+		}
+		if j-i == accountIDLen && accountIDBoundary(s, i-1) && accountIDBoundary(s, j) {
+			out = append(out, s[i:j])
+		}
+		i = j
+	}
+	return out
+}
+
+// accountIDBoundary reports whether index i can bound an account ID: either it is
+// off the end of the string, or it holds one of the two characters an ARN uses to
+// separate an account from what surrounds it.
+func accountIDBoundary(s string, i int) bool {
+	if i < 0 || i >= len(s) {
+		return true
+	}
+	return s[i] == ':' || s[i] == '/'
+}
+
+// singleAccountQuery posts a query-protocol request to a service in us-east-1,
+// signed as account.
+//
+// An empty account leaves the request unsigned, which still reaches its plugin —
+// [emulator.VerifySigV4] passes a request carrying no Authorization header — and
+// resolves to the server's default account.
+func singleAccountQuery(t *testing.T, ts *emulator.TestServer, service, account string,
+	params map[string]string,
+) (int, string) {
+	t.Helper()
+
+	var creds emulator.CredentialEntry
+	if account != "" {
+		var ok bool
+		creds, ok = ts.CredentialsFor(account)
+		require.True(t, ok, "no credential registered for account %s", account)
+	}
+
+	form := url.Values{}
+	for k, v := range params {
+		form.Set(k, v)
+	}
+	body := form.Encode()
+	host := service + ".us-east-1.amazonaws.com"
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Host = host
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	signAs(req, creds, service, "us-east-1", []byte(body))
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(raw)
+}
+
+// TestSingleAccount_ServicesAgreeOnTheAccount is the observable half, and it is the
+// test that would have caught #734 the way the live run did: by asking three
+// different services who the caller is and comparing the answers.
+//
+// The three are not arbitrary. sts:GetCallerIdentity is the only operation whose
+// entire purpose is to answer the question, and it puts the account in all three of
+// its members. The CloudFormation deployer mints a stack ARN from an identity it
+// carries separately, which is the split #517 was filed for. And the Resource Groups
+// Tagging API reaches a resource through an account-prefixed state key, so its
+// answer proves the account the write used and the account the read used are the
+// same string — which is the failure mode that leaves a resource created and then
+// invisible.
+//
+// It runs for two accounts, because a producer that returns a constant agrees with
+// itself. The second account is reachable only by signing, so a disagreement shows
+// up as a resource in the wrong account rather than as a resource that is missing.
+func TestSingleAccount_ServicesAgreeOnTheAccount(t *testing.T) {
+	const secondAccount = "777788889999"
+	ts := emulator.StartTestServerWithAccounts(t, secondAccount)
+
+	for _, account := range []string{"123456789012", secondAccount} {
+		t.Run("account "+account, func(t *testing.T) {
+			// 1. The operation whose whole job is to answer the question. Both
+			// members that carry an account carry this one: Arn names it in its
+			// fifth field, and a caller comparing the two must see them agree.
+			code, body := singleAccountQuery(t, ts, "sts", account, map[string]string{
+				"Action": "GetCallerIdentity", "Version": "2011-06-15",
+			})
+			require.Equal(t, http.StatusOK, code, "GetCallerIdentity: body was %s", body)
+			assert.Equal(t, account, cfnXMLValue(t, body, "Account"))
+			assert.True(t, strings.HasPrefix(cfnXMLValue(t, body, "Arn"), "arn:aws:iam::"+account+":"),
+				"Arn was %s", cfnXMLValue(t, body, "Arn"))
+
+			// 2. The CloudFormation deployer's own identity, which reaches a caller
+			// only as the StackId it mints. The stack name carries the account
+			// because a stack record is not partitioned by one — that is #517's
+			// other half, and it is not what this test is about.
+			stack := "agreement-" + account
+			code, body = singleAccountQuery(t, ts, "cloudformation", account, map[string]string{
+				"Action": "CreateStack", "Version": "2010-05-15",
+				"StackName": stack, "TemplateBody": cfnEmptyTemplate,
+			})
+			require.Equal(t, http.StatusOK, code, "CreateStack: body was %s", body)
+			assert.Contains(t, cfnXMLValue(t, body, "StackId"),
+				":cloudformation:us-east-1:"+account+":stack/"+stack+"/")
+
+			// 3. An account-prefixed state key, written by one service and read by
+			// another. A DynamoDB table is written under "table:{account}/{name}";
+			// the tagging API lists that prefix and reports the ARN the table
+			// carries. Both halves have to agree with the account above, or the
+			// table is created and then unreachable.
+			resp := signedRequest(t, ts, signedRequestTarget{
+				host:        "dynamodb.us-east-1.amazonaws.com",
+				target:      "DynamoDB_20120810",
+				signingName: "dynamodb",
+			}, account, "CreateTable", map[string]any{
+				"TableName":            "agreement",
+				"KeySchema":            []map[string]string{{"AttributeName": "id", "KeyType": "HASH"}},
+				"AttributeDefinitions": []map[string]string{{"AttributeName": "id", "AttributeType": "S"}},
+				"Tags":                 []map[string]string{{"Key": "Owner", "Value": "agreement"}},
+			})
+			status, errCode := decodeAWSResponse(t, resp, nil)
+			require.Equal(t, http.StatusOK, status, "CreateTable: %s", errCode)
+
+			var listed struct {
+				ResourceTagMappingList []struct {
+					ResourceARN string `json:"ResourceARN"`
+					Tags        []struct {
+						Key   string `json:"Key"`
+						Value string `json:"Value"`
+					} `json:"Tags"`
+				} `json:"ResourceTagMappingList"`
+			}
+			resp = signedRequest(t, ts, signedRequestTarget{
+				host:        "tagging.us-east-1.amazonaws.com",
+				target:      "ResourceGroupsTaggingAPI_20170126",
+				signingName: "tagging",
+			}, account, "GetResources", map[string]any{
+				"ResourceTypeFilters": []string{"dynamodb:table"},
+			})
+			status, errCode = decodeAWSResponse(t, resp, &listed)
+			require.Equal(t, http.StatusOK, status, "GetResources: %s", errCode)
+
+			require.Len(t, listed.ResourceTagMappingList, 1,
+				"a caller sees its own table and only its own")
+			assert.Equal(t, "arn:aws:dynamodb:us-east-1:"+account+":table/agreement",
+				listed.ResourceTagMappingList[0].ResourceARN)
+			require.Len(t, listed.ResourceTagMappingList[0].Tags, 1)
+			assert.Equal(t, "Owner", listed.ResourceTagMappingList[0].Tags[0].Key)
+		})
+	}
+
+	// The unsigned caller is the case #734 was really about, and it is also the one
+	// path on which all three of GetCallerIdentity's members come from the account
+	// rather than from a principal. Substrate's own documented credentials, an
+	// unsigned request and an ASIA session key used to resolve to 000000000000
+	// while AKIAIOSFODNN7EXAMPLE resolved to 123456789012; now there is one answer.
+	code, body := singleAccountQuery(t, ts, "sts", "", map[string]string{
+		"Action": "GetCallerIdentity", "Version": "2011-06-15",
+	})
+	require.Equal(t, http.StatusOK, code, "unsigned GetCallerIdentity: body was %s", body)
+	assert.Equal(t, "123456789012", cfnXMLValue(t, body, "Account"))
+	assert.Equal(t, "123456789012", cfnXMLValue(t, body, "UserId"))
+	assert.Equal(t, "arn:aws:iam::123456789012:root", cfnXMLValue(t, body, "Arn"))
+}

--- a/emulator/apigateway_proxy_test.go
+++ b/emulator/apigateway_proxy_test.go
@@ -232,7 +232,7 @@ func TestAPIGatewayProxy_LambdaNotFound(t *testing.T) {
 	proxyPutMethod(t, ts, apiID, resourceID, "GET")
 
 	// Put integration pointing to a non-existent Lambda function.
-	ghostARN := "arn:aws:lambda:us-east-1:000000000000:function:ghost-fn"
+	ghostARN := "arn:aws:lambda:us-east-1:123456789012:function:ghost-fn"
 	uri := fmt.Sprintf("arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/%s/invocations", ghostARN)
 	proxyCreateIntegration(t, ts, apiID, resourceID, "GET", uri)
 
@@ -268,7 +268,7 @@ func TestAPIGatewayProxy_EndToEnd(t *testing.T) {
 
 	// Put GET method + AWS_PROXY integration pointing at the Lambda function.
 	proxyPutMethod(t, ts, apiID, resourceID, "GET")
-	acct := "000000000000"
+	acct := "123456789012"
 	lambdaARN := fmt.Sprintf("arn:aws:lambda:us-east-1:%s:function:%s", acct, fnName)
 	uri := fmt.Sprintf("arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/%s/invocations", lambdaARN)
 	proxyCreateIntegration(t, ts, apiID, resourceID, "GET", uri)
@@ -321,7 +321,7 @@ func TestAPIGatewayProxy_V2EndToEnd(t *testing.T) {
 	fnName := fmt.Sprintf("proxy-v2-fn-%d", time.Now().UnixNano())
 	proxyCreateLambdaFunction(t, ts, fnName)
 
-	acct := "000000000000"
+	acct := "123456789012"
 	lambdaARN := fmt.Sprintf("arn:aws:lambda:us-east-1:%s:function:%s", acct, fnName)
 	lambdaURI := fmt.Sprintf("arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/%s/invocations", lambdaARN)
 
@@ -424,7 +424,7 @@ func proxyCreateLambdaFunction(t *testing.T, ts *emulator.TestServer, name strin
 	payload, _ := json.Marshal(map[string]interface{}{
 		"FunctionName": name,
 		"Runtime":      "python3.12",
-		"Role":         "arn:aws:iam::000000000000:role/test",
+		"Role":         "arn:aws:iam::123456789012:role/test",
 		"Handler":      "index.handler",
 	})
 	resp := proxyDoRequest(t, ts, http.MethodPost, "/2015-03-31/functions",

--- a/emulator/batch_describe_test.go
+++ b/emulator/batch_describe_test.go
@@ -41,12 +41,17 @@ func batchPost(t *testing.T, ts *httptest.Server, path string, body interface{})
 	return resp.StatusCode, string(batchBody(t, resp))
 }
 
+// batchOtherAccount is an account other than the one substrate attributes an
+// unsigned request to, so a test here can be two callers. Reaching it means signing
+// as it: nothing else on the wire names an account (#734).
+const batchOtherAccount = "888899990000"
+
 // batchIdentityRequest posts to a Batch path as a particular caller: the Region comes
-// from the host the request is addressed to and the account from the Authorization
-// header, which is how the server resolves both. An empty authHeader is an unsigned
-// caller.
+// from the host the request is addressed to and the account from the signature, which
+// is how the server resolves both. An empty account is an unsigned caller, which
+// resolves to substrate's default account.
 func batchIdentityRequest(
-	t *testing.T, ts *httptest.Server, region, authHeader, path string, body interface{},
+	t *testing.T, ts *httptest.Server, region, account, path string, body interface{},
 ) (int, string) {
 	t.Helper()
 	data, err := json.Marshal(body)
@@ -55,8 +60,8 @@ func batchIdentityRequest(
 	require.NoError(t, err)
 	req.Host = "batch." + region + ".amazonaws.com"
 	req.Header.Set("Content-Type", "application/json")
-	if authHeader != "" {
-		req.Header.Set("Authorization", authHeader)
+	if account != "" {
+		signAs(req, testCredentialsFor(account), "batch", region, data)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -437,43 +442,44 @@ func TestBatchDescribe_Pagination(t *testing.T) {
 func TestBatchDescribe_ScopedToTheCaller(t *testing.T) {
 	ts := newBatchTestServer(t)
 
-	// Unsigned resolves to 000000000000; an AKIA-signed request to 123456789012.
-	const unsigned = ""
-	signed := signedAuthHeader("batch", "us-east-1")
-	signedWest := signedAuthHeader("batch", "eu-west-1")
+	// Two accounts: an unsigned request resolves to substrate's default, and one
+	// signed as batchOtherAccount to that one. The second account also appears in
+	// eu-west-1, so the Region half of the scope is exercised independently.
+	const defaultCaller = ""
+	const otherCaller = batchOtherAccount
 
-	create := func(auth, region, name string) string {
+	create := func(account, region, name string) string {
 		t.Helper()
-		code, body := batchIdentityRequest(t, ts, region, auth, "/v1/createcomputeenvironment",
+		code, body := batchIdentityRequest(t, ts, region, account, "/v1/createcomputeenvironment",
 			map[string]interface{}{"computeEnvironmentName": name, "type": "MANAGED"})
 		require.Equal(t, http.StatusOK, code, "body was %s", body)
 		return body
 	}
 
-	zero := create(unsigned, "us-east-1", "zero-owned")
-	test := create(signed, "us-east-1", "test-owned")
-	west := create(signedWest, "eu-west-1", "west-owned")
+	own := create(defaultCaller, "us-east-1", "default-owned")
+	other := create(otherCaller, "us-east-1", "other-owned")
+	west := create(otherCaller, "eu-west-1", "west-owned")
 
-	assert.Contains(t, zero, `"computeEnvironmentArn":"arn:aws:batch:us-east-1:000000000000:compute-environment/zero-owned"`)
-	assert.Contains(t, test, `:123456789012:compute-environment/test-owned"`,
-		"the ARN carries the caller's account, not a hardcoded 000000000000")
+	assert.Contains(t, own, `"computeEnvironmentArn":"arn:aws:batch:us-east-1:123456789012:compute-environment/default-owned"`)
+	assert.Contains(t, other, `:`+batchOtherAccount+`:compute-environment/other-owned"`,
+		"the ARN carries the caller's account, not a hardcoded one")
 	assert.Contains(t, west, `"computeEnvironmentArn":"arn:aws:batch:eu-west-1:`,
 		"the ARN carries the caller's Region, not a hardcoded us-east-1")
 
 	// Each caller's unfiltered describe reports its own environment and no other's.
 	cases := []struct {
-		auth    string
+		account string
 		region  string
 		want    string
 		notWant []string
 	}{
-		{unsigned, "us-east-1", "zero-owned", []string{"test-owned", "west-owned"}},
-		{signed, "us-east-1", "test-owned", []string{"zero-owned", "west-owned"}},
-		{signedWest, "eu-west-1", "west-owned", []string{"zero-owned", "test-owned"}},
+		{defaultCaller, "us-east-1", "default-owned", []string{"other-owned", "west-owned"}},
+		{otherCaller, "us-east-1", "other-owned", []string{"default-owned", "west-owned"}},
+		{otherCaller, "eu-west-1", "west-owned", []string{"default-owned", "other-owned"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.want, func(t *testing.T) {
-			code, body := batchIdentityRequest(t, ts, tc.region, tc.auth,
+			code, body := batchIdentityRequest(t, ts, tc.region, tc.account,
 				"/v1/describecomputeenvironments", map[string]interface{}{})
 			require.Equal(t, http.StatusOK, code, "body was %s", body)
 			assert.Contains(t, body, `"computeEnvironmentName":"`+tc.want+`"`)
@@ -484,7 +490,7 @@ func TestBatchDescribe_ScopedToTheCaller(t *testing.T) {
 			// And a name filter cannot cross the scope either: naming another
 			// caller's environment reports nothing, not that caller's record.
 			for _, other := range tc.notWant {
-				code, body := batchIdentityRequest(t, ts, tc.region, tc.auth,
+				code, body := batchIdentityRequest(t, ts, tc.region, tc.account,
 					"/v1/describecomputeenvironments",
 					map[string]interface{}{"computeEnvironments": []string{other}})
 				require.Equal(t, http.StatusOK, code, "body was %s", body)
@@ -496,8 +502,8 @@ func TestBatchDescribe_ScopedToTheCaller(t *testing.T) {
 
 	// A job definition's revision counter is scoped the same way: two callers each
 	// registering one definition of the same name both get revision 1.
-	for _, auth := range []string{unsigned, signed} {
-		code, body := batchIdentityRequest(t, ts, "us-east-1", auth, "/v1/registerjobdefinition",
+	for _, account := range []string{defaultCaller, otherCaller} {
+		code, body := batchIdentityRequest(t, ts, "us-east-1", account, "/v1/registerjobdefinition",
 			map[string]interface{}{"jobDefinitionName": "shared", "type": "container"})
 		require.Equal(t, http.StatusOK, code, "body was %s", body)
 		assert.Contains(t, body, `"revision":1`,
@@ -513,7 +519,7 @@ func TestBatchDescribe_ScopedToTheCaller(t *testing.T) {
 	// caller's names consume this caller's page and the count and token come out
 	// wrong. The result would be a caller paging forever through pages that are
 	// mysteriously short.
-	code, body := batchIdentityRequest(t, ts, "us-east-1", signed,
+	code, body := batchIdentityRequest(t, ts, "us-east-1", otherCaller,
 		"/v1/describecomputeenvironments", map[string]interface{}{"maxResults": 1})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	assert.Len(t, batchMembers(t, body, "computeEnvironments"), 1,

--- a/emulator/batch_plugin_test.go
+++ b/emulator/batch_plugin_test.go
@@ -32,7 +32,14 @@ func newBatchTestServer(t *testing.T) *httptest.Server {
 	registry.Register(p)
 
 	cfg := emulator.DefaultConfig()
-	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger)
+	// A credential registry holding batchOtherAccount, so TestBatchDescribe_ScopedToTheCaller
+	// can be two accounts. Unsigned requests — every other test in these files — are
+	// unaffected: VerifySigV4 passes a request with no Authorization header, which
+	// resolves to the configured default account.
+	creds := emulator.NewCredentialRegistry()
+	creds.Register(testCredentialsFor(batchOtherAccount))
+	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger,
+		emulator.ServerOptions{Credentials: creds})
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 	return ts
@@ -80,8 +87,8 @@ func TestBatchPlugin_SubmitDescribeTerminateJob(t *testing.T) {
 	// SubmitJob
 	resp := batchRequest(t, ts, http.MethodPost, "/v1/submitjob", map[string]string{
 		"jobName":       "test-job",
-		"jobQueue":      "arn:aws:batch:us-east-1:000000000000:job-queue/q1",
-		"jobDefinition": "arn:aws:batch:us-east-1:000000000000:job-definition/jd1:1",
+		"jobQueue":      "arn:aws:batch:us-east-1:123456789012:job-queue/q1",
+		"jobDefinition": "arn:aws:batch:us-east-1:123456789012:job-definition/jd1:1",
 	})
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("submitJob: expected 200, got %d; body: %s", resp.StatusCode, batchBody(t, resp))

--- a/emulator/bedrock_runtime_plugin_test.go
+++ b/emulator/bedrock_runtime_plugin_test.go
@@ -136,7 +136,7 @@ func TestBedrockRuntimePlugin_BlocklistIntervened(t *testing.T) {
 	setup := newBedrockRuntimeTestServer(t)
 
 	// Seed the blocklist with "forbidden" term.
-	blocklistKey := "guardrail:000000000000/guardrail-block/blocklist"
+	blocklistKey := "guardrail:123456789012/guardrail-block/blocklist"
 	blocklist, _ := json.Marshal([]string{"forbidden"})
 	if err := setup.state.Put(context.Background(), "bedrock-runtime", blocklistKey, blocklist); err != nil {
 		t.Fatalf("seed blocklist: %v", err)
@@ -162,7 +162,7 @@ func TestBedrockRuntimePlugin_BlocklistNonMatching(t *testing.T) {
 	setup := newBedrockRuntimeTestServer(t)
 
 	// Seed blocklist with term that won't match.
-	blocklistKey := "guardrail:000000000000/guardrail-nm/blocklist"
+	blocklistKey := "guardrail:123456789012/guardrail-nm/blocklist"
 	blocklist, _ := json.Marshal([]string{"badword"})
 	if err := setup.state.Put(context.Background(), "bedrock-runtime", blocklistKey, blocklist); err != nil {
 		t.Fatalf("seed blocklist: %v", err)

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -1021,7 +1021,7 @@ func NewStackDeployer(registry *PluginRegistry, store *EventStore, state StateMa
 		tc:       tc,
 		logger:   logger,
 		costs:    costs,
-		identity: cfnIdentity{accountID: testAccountID, region: defaultRegion},
+		identity: cfnIdentity{accountID: defaultAccountID, region: defaultRegion},
 	}
 	for _, opt := range opts {
 		opt(d)

--- a/emulator/cfn_physical_name_test.go
+++ b/emulator/cfn_physical_name_test.go
@@ -179,7 +179,7 @@ func TestCFNGeneratedName_UpdateDoesNotMoveAPhysicalID(t *testing.T) {
 // over-long name would fail for some types and silently pass for others.
 func TestCFNGeneratedName_Constraints(t *testing.T) {
 	const (
-		acct   = "000000000000"
+		acct   = "123456789012"
 		region = "us-east-1"
 		long40 = "abcdefghijabcdefghijabcdefghijabcdefghij"
 	)
@@ -229,17 +229,17 @@ func TestCFNGeneratedName_Constraints(t *testing.T) {
 // account or Region makes two same-named stacks in different Regions collide —
 // which sameScope already treats as different stacks.
 func TestCFNGeneratedName_ScopeChangesTheName(t *testing.T) {
-	base := emulator.CFNGeneratedNameForTest("000000000000", "us-east-1", "stk",
+	base := emulator.CFNGeneratedNameForTest("123456789012", "us-east-1", "stk",
 		"AWS::IAM::Role", "MyRole")
 
 	tests := []struct {
 		name                           string
 		acct, region, stack, logicalID string
 	}{
-		{"a different stack", "000000000000", "us-east-1", "other", "MyRole"},
-		{"a different Region", "000000000000", "eu-west-1", "stk", "MyRole"},
+		{"a different stack", "123456789012", "us-east-1", "other", "MyRole"},
+		{"a different Region", "123456789012", "eu-west-1", "stk", "MyRole"},
 		{"a different account", "111111111111", "us-east-1", "stk", "MyRole"},
-		{"a different logical ID", "000000000000", "us-east-1", "stk", "OtherRole"},
+		{"a different logical ID", "123456789012", "us-east-1", "stk", "OtherRole"},
 	}
 
 	for _, tt := range tests {
@@ -262,7 +262,7 @@ func TestCFNGeneratedName_UntabledTypeKeepsItsLogicalID(t *testing.T) {
 		"AWS::SecretsManager::Secret",
 		"AWS::Unknown::Thing",
 	} {
-		assert.Equal(t, "Widget", emulator.CFNGeneratedNameForTest("000000000000",
+		assert.Equal(t, "Widget", emulator.CFNGeneratedNameForTest("123456789012",
 			"us-east-1", "stk", resType, "Widget"),
 			"%s is not in the generated-name table and must keep its logical ID", resType)
 	}
@@ -276,7 +276,7 @@ func TestCFNGeneratedName_UntabledTypeKeepsItsLogicalID(t *testing.T) {
 // Measured: dropping stackName from cfnNameSuffix passes every other test here.
 func TestCFNGeneratedName_LongStackNamesStillDiffer(t *testing.T) {
 	const (
-		acct   = "000000000000"
+		acct   = "123456789012"
 		region = "us-east-1"
 		prefix = "a-very-long-stack-name-that-will-be-truncated"
 	)

--- a/emulator/cfn_stack_arn_test.go
+++ b/emulator/cfn_stack_arn_test.go
@@ -27,10 +27,11 @@ import (
 // A caller could not tell: no error to catch, no status to poll. The next
 // CreateStack answering AlreadyExists was the only symptom.
 
-// cfnTestAccount and cfnTestRegion are the identity cfnRequest's signed
-// Authorization header resolves to. The ARN assertions below are built from them
-// rather than from a pasted string, so a change to either shows up as a failure
-// here rather than as a test that no longer exercises the scope check.
+// cfnTestAccount and cfnTestRegion are the identity cfnRequest resolves to: it
+// signs nothing and addresses us-east-1, so it is the server's default account in
+// its default Region. The ARN assertions below are built from them rather than from
+// a pasted string, so a change to either shows up as a failure here rather than as a
+// test that no longer exercises the scope check.
 const (
 	cfnTestAccount = "123456789012"
 	cfnTestRegion  = "us-east-1"
@@ -332,14 +333,14 @@ func TestCFNStackARN_EveryOperationRefusesAnOutOfScopeARN(t *testing.T) {
 func TestCFNStackARN_AnotherCallersARNIsRefused(t *testing.T) {
 	ts := newCFNIdentityTestServer(t)
 
-	// Two callers on one server: unsigned resolves to 000000000000, an AKIA-signed
-	// request to 123456789012.
-	const unsigned = ""
-	signed := signedAuthHeader("cloudformation", cfnTestRegion)
+	// Two callers on one server: an unsigned request resolves to the default account,
+	// and a request signed as cfnOtherAccount to that one.
+	const defaultCaller = ""
+	const otherCaller = cfnOtherAccount
 
-	create := func(auth, region, name string) string {
+	create := func(account, region, name string) string {
 		t.Helper()
-		code, body := cfnIdentityRequest(t, ts, "cloudformation", region, auth, map[string]string{
+		code, body := cfnIdentityRequest(t, ts, "cloudformation", region, account, map[string]string{
 			"Action":       "CreateStack",
 			"Version":      "2010-05-15",
 			"StackName":    name,
@@ -349,47 +350,47 @@ func TestCFNStackARN_AnotherCallersARNIsRefused(t *testing.T) {
 		return cfnXMLValue(t, body, "StackId")
 	}
 
-	zeroARN := create(unsigned, cfnTestRegion, "zero-owned")
-	testARN := create(signed, cfnTestRegion, "test-owned")
-	westARN := create(signed, "eu-west-1", "west-owned")
+	defaultARN := create(defaultCaller, cfnTestRegion, "default-owned")
+	otherARN := create(otherCaller, cfnTestRegion, "other-owned")
+	westARN := create(otherCaller, "eu-west-1", "west-owned")
 
-	require.Contains(t, zeroARN, ":000000000000:stack/zero-owned/")
-	require.Contains(t, testARN, ":"+cfnTestAccount+":stack/test-owned/")
+	require.Contains(t, defaultARN, ":"+cfnTestAccount+":stack/default-owned/")
+	require.Contains(t, otherARN, ":"+cfnOtherAccount+":stack/other-owned/")
 	require.Contains(t, westARN, ":eu-west-1:")
 
 	cases := []struct {
-		name   string
-		auth   string
-		region string
-		arn    string
+		name    string
+		account string
+		region  string
+		arn     string
 	}{
 		{
-			name: "the unsigned caller's own ARN, offered by the signed caller",
-			auth: signed, region: cfnTestRegion, arn: zeroARN,
+			name:    "the default account's own ARN, offered by the other account",
+			account: otherCaller, region: cfnTestRegion, arn: defaultARN,
 		},
 		{
-			name: "the signed caller's own ARN, offered by the unsigned caller",
-			auth: unsigned, region: cfnTestRegion, arn: testARN,
+			name:    "the other account's own ARN, offered by the default account",
+			account: defaultCaller, region: cfnTestRegion, arn: otherARN,
 		},
 		{
-			name: "a us-east-1 ARN offered to the eu-west-1 endpoint",
-			auth: signedAuthHeader("cloudformation", "eu-west-1"), region: "eu-west-1", arn: testARN,
+			name:    "a us-east-1 ARN offered to the eu-west-1 endpoint",
+			account: otherCaller, region: "eu-west-1", arn: otherARN,
 		},
 		{
-			name: "an eu-west-1 ARN offered to the us-east-1 endpoint",
-			auth: signed, region: cfnTestRegion, arn: westARN,
+			name:    "an eu-west-1 ARN offered to the us-east-1 endpoint",
+			account: otherCaller, region: cfnTestRegion, arn: westARN,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			code, body := cfnIdentityRequest(t, ts, "cloudformation", tc.region, tc.auth,
+			code, body := cfnIdentityRequest(t, ts, "cloudformation", tc.region, tc.account,
 				map[string]string{
 					"Action": "DescribeStacks", "Version": "2010-05-15", "StackName": tc.arn,
 				})
 			require.Equal(t, http.StatusBadRequest, code, "body was %s", body)
 			assert.Contains(t, body, "<Code>ValidationError</Code>")
 
-			code, body = cfnIdentityRequest(t, ts, "cloudformation", tc.region, tc.auth,
+			code, body = cfnIdentityRequest(t, ts, "cloudformation", tc.region, tc.account,
 				map[string]string{
 					"Action": "DeleteStack", "Version": "2010-05-15", "StackName": tc.arn,
 				})
@@ -401,13 +402,13 @@ func TestCFNStackARN_AnotherCallersARNIsRefused(t *testing.T) {
 	// Each owner still reaches its own stack by its own ARN, which is what keeps the
 	// refusals above from being a blanket "no ARNs across identities".
 	for _, own := range []struct {
-		auth, region, arn, name string
+		account, region, arn, name string
 	}{
-		{unsigned, cfnTestRegion, zeroARN, "zero-owned"},
-		{signed, cfnTestRegion, testARN, "test-owned"},
-		{signedAuthHeader("cloudformation", "eu-west-1"), "eu-west-1", westARN, "west-owned"},
+		{defaultCaller, cfnTestRegion, defaultARN, "default-owned"},
+		{otherCaller, cfnTestRegion, otherARN, "other-owned"},
+		{otherCaller, "eu-west-1", westARN, "west-owned"},
 	} {
-		code, body := cfnIdentityRequest(t, ts, "cloudformation", own.region, own.auth,
+		code, body := cfnIdentityRequest(t, ts, "cloudformation", own.region, own.account,
 			map[string]string{
 				"Action": "DescribeStacks", "Version": "2010-05-15", "StackName": own.arn,
 			})

--- a/emulator/cloudformation_exports_test.go
+++ b/emulator/cloudformation_exports_test.go
@@ -232,9 +232,9 @@ func TestCFNPlugin_ExportsAreScopedToTheCallersPartition(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 
-	// An unsigned request resolves to the fallback account 000000000000, so the
-	// export is out of scope and invisible.
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	// A request signed as another account is out of the export's scope, so the export
+	// is invisible to it.
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "ListExports", "Version": "2010-05-15",
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
@@ -244,13 +244,13 @@ func TestCFNPlugin_ExportsAreScopedToTheCallersPartition(t *testing.T) {
 
 	// And an import from that account fails the resource rather than resolving
 	// against an export it is not entitled to see.
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "CreateStack", "Version": "2010-05-15",
 		"StackName": "otheracct", "TemplateBody": cfnWireImportTemplate,
 	})
 	require.Equal(t, http.StatusOK, code, "the resource fails; the operation does not: %s", body)
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "DescribeStackResources", "Version": "2010-05-15",
 		"StackName": "otheracct",
 	})
@@ -259,7 +259,7 @@ func TestCFNPlugin_ExportsAreScopedToTheCallersPartition(t *testing.T) {
 	assert.Contains(t, body, "no exported output named")
 
 	// The refusal to delete is scoped the same way: the other account's stack
-	// imports nothing this account can see, so the exporting stack in the signed
+	// imports nothing this account can see, so the exporting stack in the default
 	// account is still deletable.
 	code, body = cfnAction(t, ts, "DeleteStack", map[string]string{"StackName": "wirenet"})
 	assert.Equal(t, http.StatusOK, code,
@@ -275,18 +275,19 @@ func TestCFNPlugin_ExportsAreScopedToTheCallersPartition(t *testing.T) {
 // consult the wrong namespace — and the direction that matters is this one: a
 // non-default caller's own import is invisible from the default namespace, so a
 // delete that must be refused would be allowed, quietly removing an export another
-// of that caller's stacks is holding. The signed-caller case cannot catch it,
-// because a signed caller's identity *is* the default.
+// of that caller's stacks is holding. A caller in the default account cannot catch
+// it, because its identity *is* the default — which is why both stacks here are
+// created by a caller signing as another account.
 func TestCFNPlugin_DeleteRefusalUsesTheCallersOwnNamespace(t *testing.T) {
 	ts := newCFNTestServer(t)
 
-	// Both stacks unsigned, so both live in the fallback account 000000000000 —
-	// not the default 123456789012 the plugin's own deployer would consult.
+	// Both stacks signed as cfnOtherAccount, so both live outside the default account
+	// the plugin's own deployer would consult.
 	for _, s := range []struct{ name, tmpl string }{
 		{"wirenet", cfnWireExportTemplate},
 		{"wireapp", cfnWireImportTemplate},
 	} {
-		code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+		code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 			"Action": "CreateStack", "Version": "2010-05-15",
 			"StackName": s.name, "TemplateBody": s.tmpl,
 		})
@@ -295,7 +296,7 @@ func TestCFNPlugin_DeleteRefusalUsesTheCallersOwnNamespace(t *testing.T) {
 
 	// The import resolved, which is what makes the refusal below meaningful: an
 	// unresolved import would leave nothing recorded and the delete would be legal.
-	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "DescribeStackResources", "Version": "2010-05-15",
 		"StackName": "wireapp",
 	})
@@ -303,7 +304,7 @@ func TestCFNPlugin_DeleteRefusalUsesTheCallersOwnNamespace(t *testing.T) {
 	require.Contains(t, body, "CREATE_COMPLETE")
 	require.NotContains(t, body, "CREATE_FAILED")
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "DeleteStack", "Version": "2010-05-15", "StackName": "wirenet",
 	})
 	assert.Equal(t, http.StatusBadRequest, code, "body was %s", body)

--- a/emulator/cloudformation_identity_test.go
+++ b/emulator/cloudformation_identity_test.go
@@ -33,10 +33,21 @@ import (
 // some of them the region — in their state keys. Those are the only honest
 // subjects for this fix, so every case below uses one.
 
+// cfnOtherAccount is an account other than the one substrate attributes an
+// unsigned request to. Being it requires signing as it, which is the only way a
+// caller names an account: nothing else on the wire does (#734).
+const cfnOtherAccount = "555566667777"
+
 // newCFNIdentityTestServer builds a server with CloudFormation registered
 // alongside the *partitioned* plugins: EC2, ECS, CloudWatch Logs, DynamoDB, SQS
 // and SNS. S3 and IAM are deliberately absent — a stack whose resources are all
 // unpartitioned cannot distinguish a threaded identity from a hardcoded one.
+//
+// A [emulator.CredentialRegistry] holding [cfnOtherAccount] is wired, so a test
+// here can be two callers. That also switches SigV4 verification on, which is why
+// cfnIdentityRequest signs for real; an unsigned request still reaches its plugin,
+// as the default account, because [emulator.VerifySigV4] passes a request carrying
+// no Authorization header.
 func newCFNIdentityTestServer(t *testing.T) *cfnTestServer {
 	t.Helper()
 	cfg := emulator.DefaultConfig()
@@ -83,32 +94,39 @@ func newCFNIdentityTestServer(t *testing.T) *cfnTestServer {
 	}))
 	registry.Register(cfnp)
 
+	creds := emulator.NewCredentialRegistry()
+	creds.Register(testCredentialsFor(cfnOtherAccount))
+
 	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger,
-		emulator.ServerOptions{Costs: emulator.NewCostController(emulator.CostConfig{Enabled: true})})
+		emulator.ServerOptions{
+			Costs:       emulator.NewCostController(emulator.CostConfig{Enabled: true}),
+			Credentials: creds,
+		})
 
 	return &cfnTestServer{srv: srv, state: state, registry: registry, tc: tc}
 }
 
-// cfnIdentityRequest posts a query-protocol request to any service, optionally
-// signed and optionally to a non-default region, so a test can vary exactly the
-// two things #517 is about.
+// cfnIdentityRequest posts a query-protocol request to any service, as a chosen
+// account and to a chosen region, so a test can vary exactly the two things #517 is
+// about.
 //
-// An empty authHeader means an unsigned request, which resolves to the fallback
-// account 000000000000 — the identity #517's reporter had, since their client
-// signed nothing.
-func cfnIdentityRequest(t *testing.T, ts *cfnTestServer, service, region, authHeader string, params map[string]string) (int, string) {
+// An empty account means an unsigned request, which resolves to substrate's default
+// account — the identity #517's reporter had, since their client signed nothing.
+// Any other account must be one newCFNIdentityTestServer registered, and the request
+// is signed as it; an unregistered key is InvalidClientTokenId 403 before any plugin
+// sees it.
+func cfnIdentityRequest(t *testing.T, ts *cfnTestServer, service, region, account string, params map[string]string) (int, string) {
 	t.Helper()
 	form := url.Values{}
 	for k, v := range params {
 		form.Set(k, v)
 	}
+	body := form.Encode()
 	host := service + "." + region + ".amazonaws.com"
-	r := httptest.NewRequest(http.MethodPost, "http://"+host+"/", strings.NewReader(form.Encode()))
+	r := httptest.NewRequest(http.MethodPost, "http://"+host+"/", strings.NewReader(body))
 	r.Host = host
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	if authHeader != "" {
-		r.Header.Set("Authorization", authHeader)
-	}
+	cfnSignAs(r, account, service, region, []byte(body))
 	w := httptest.NewRecorder()
 	ts.srv.ServeHTTP(w, r)
 	return w.Code, w.Body.String()
@@ -116,26 +134,25 @@ func cfnIdentityRequest(t *testing.T, ts *cfnTestServer, service, region, authHe
 
 // cfnJSONRequest posts a JSON-protocol request, for the services that use one
 // (ECS and CloudWatch Logs).
-func cfnJSONRequest(t *testing.T, ts *cfnTestServer, service, region, target, authHeader, body string) (int, string) {
+func cfnJSONRequest(t *testing.T, ts *cfnTestServer, service, region, target, account, body string) (int, string) {
 	t.Helper()
 	host := service + "." + region + ".amazonaws.com"
 	r := httptest.NewRequest(http.MethodPost, "http://"+host+"/", strings.NewReader(body))
 	r.Host = host
 	r.Header.Set("Content-Type", "application/x-amz-json-1.1")
 	r.Header.Set("X-Amz-Target", target)
-	if authHeader != "" {
-		r.Header.Set("Authorization", authHeader)
-	}
+	cfnSignAs(r, account, service, region, []byte(body))
 	w := httptest.NewRecorder()
 	ts.srv.ServeHTTP(w, r)
 	return w.Code, w.Body.String()
 }
 
-// signedAuthHeader builds an AKIA-signed Authorization header, which resolves to
-// the well-known test account 123456789012.
-func signedAuthHeader(service, region string) string {
-	return "AWS4-HMAC-SHA256 Credential=AKIATEST1234567890/20260101/" +
-		region + "/" + service + "/aws4_request, SignedHeaders=host, Signature=fake"
+// cfnSignAs signs r as account, or leaves it unsigned when account is empty.
+func cfnSignAs(r *http.Request, account, signingName, region string, body []byte) {
+	if account == "" {
+		return
+	}
+	signAs(r, testCredentialsFor(account), signingName, region, body)
 }
 
 // cfnXMLValue extracts the text of the first tag element in an XML body. Enough
@@ -162,47 +179,47 @@ func cfnPhysicalID(t *testing.T, body string) string {
 const cfnInstanceTemplate = `{"Resources":{"I":{"Type":"AWS::EC2::Instance",` +
 	`"Properties":{"ImageId":"ami-12345678","InstanceType":"t3.micro"}}}}`
 
-// TestCFNIdentity_UnsignedCallerFindsItsOwnInstance is #517's reproduction, and
-// it fails before the fix.
+// TestCFNIdentity_CallerFindsItsOwnInstance is #517's reproduction, and it fails
+// before the fix.
 //
-// An unsigned request resolves to account 000000000000. The stack ARN named that
-// account, but the deployer dispatched RunInstances under substrate's default
-// 123456789012, and the EC2 plugin keys an instance by account and region — so
-// DescribeInstances, correctly scoped to the caller, reported nothing. The
-// reporter read that as EC2 support being stubbed out; it was a partition split.
-func TestCFNIdentity_UnsignedCallerFindsItsOwnInstance(t *testing.T) {
+// The caller here is not substrate's default account, which is what #517's reporter
+// was: the stack ARN named their account, but the deployer dispatched RunInstances
+// under substrate's default, and the EC2 plugin keys an instance by account and
+// region — so DescribeInstances, correctly scoped to the caller, reported nothing.
+// The reporter read that as EC2 support being stubbed out; it was a partition split.
+func TestCFNIdentity_CallerFindsItsOwnInstance(t *testing.T) {
 	ts := newCFNIdentityTestServer(t)
 
-	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action":       "CreateStack",
 		"Version":      "2010-05-15",
-		"StackName":    "unsigned",
+		"StackName":    "other",
 		"TemplateBody": cfnInstanceTemplate,
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
-	assert.Contains(t, body, ":000000000000:stack/unsigned",
-		"the stack ARN should name the unsigned caller's account")
+	assert.Contains(t, body, ":"+cfnOtherAccount+":stack/other",
+		"the stack ARN should name the signing caller's account")
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action":    "DescribeStackResources",
 		"Version":   "2010-05-15",
-		"StackName": "unsigned",
+		"StackName": "other",
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	instanceID := cfnPhysicalID(t, body)
 	require.True(t, strings.HasPrefix(instanceID, "i-"), "physical ID was %q", instanceID)
 
 	// The gate: the same caller that created the stack must see the instance.
-	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action":  "DescribeInstances",
 		"Version": "2016-11-15",
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	assert.Contains(t, body, instanceID,
-		"the unsigned caller's DescribeInstances must find the instance its own stack created")
+		"the caller's DescribeInstances must find the instance its own stack created")
 
 	// And by ID, which is the lookup that answered InvalidInstanceID.NotFound.
-	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action":       "DescribeInstances",
 		"Version":      "2016-11-15",
 		"InstanceId.1": instanceID,
@@ -229,7 +246,7 @@ func TestCFNIdentity_PartitionedServices(t *testing.T) {
 			wantID: "identity-cluster",
 			readBack: func(t *testing.T, ts *cfnTestServer) (int, string) {
 				return cfnJSONRequest(t, ts, "ecs", "us-east-1",
-					"AmazonEC2ContainerServiceV20141113.ListClusters", "", `{}`)
+					"AmazonEC2ContainerServiceV20141113.ListClusters", cfnOtherAccount, `{}`)
 			},
 		},
 		{
@@ -239,7 +256,7 @@ func TestCFNIdentity_PartitionedServices(t *testing.T) {
 			wantID: "/identity/group",
 			readBack: func(t *testing.T, ts *cfnTestServer) (int, string) {
 				return cfnJSONRequest(t, ts, "logs", "us-east-1",
-					"Logs_20140328.DescribeLogGroups", "", `{}`)
+					"Logs_20140328.DescribeLogGroups", cfnOtherAccount, `{}`)
 			},
 		},
 		{
@@ -249,7 +266,7 @@ func TestCFNIdentity_PartitionedServices(t *testing.T) {
 				`"LaunchTemplateData":{"ImageId":"ami-12345678","InstanceType":"t3.micro"}}}}}`,
 			wantID: "identity-lt",
 			readBack: func(t *testing.T, ts *cfnTestServer) (int, string) {
-				return cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+				return cfnIdentityRequest(t, ts, "ec2", "us-east-1", cfnOtherAccount, map[string]string{
 					"Action":  "DescribeLaunchTemplates",
 					"Version": "2016-11-15",
 				})
@@ -261,7 +278,7 @@ func TestCFNIdentity_PartitionedServices(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ts := newCFNIdentityTestServer(t)
 
-			code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+			code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 				"Action":       "CreateStack",
 				"Version":      "2010-05-15",
 				"StackName":    "partitioned",
@@ -272,7 +289,7 @@ func TestCFNIdentity_PartitionedServices(t *testing.T) {
 			code, body = tc.readBack(t, ts)
 			require.Equal(t, http.StatusOK, code, "body was %s", body)
 			assert.Contains(t, body, tc.wantID,
-				"the unsigned caller must see the resource its own stack created")
+				"the caller must see the resource its own stack created")
 		})
 	}
 }
@@ -285,59 +302,59 @@ func TestCFNIdentity_PartitionedServices(t *testing.T) {
 func TestCFNIdentity_NonDefaultRegion(t *testing.T) {
 	ts := newCFNIdentityTestServer(t)
 
-	code, body := cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1",
-		signedAuthHeader("cloudformation", "eu-west-1"), map[string]string{
-			"Action":       "CreateStack",
-			"Version":      "2010-05-15",
-			"StackName":    "euwest",
-			"TemplateBody": cfnInstanceTemplate,
-		})
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1", "", map[string]string{
+		"Action":       "CreateStack",
+		"Version":      "2010-05-15",
+		"StackName":    "euwest",
+		"TemplateBody": cfnInstanceTemplate,
+	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	assert.Contains(t, body, "arn:aws:cloudformation:eu-west-1:")
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1",
-		signedAuthHeader("cloudformation", "eu-west-1"), map[string]string{
-			"Action":    "DescribeStackResources",
-			"Version":   "2010-05-15",
-			"StackName": "euwest",
-		})
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1", "", map[string]string{
+		"Action":    "DescribeStackResources",
+		"Version":   "2010-05-15",
+		"StackName": "euwest",
+	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	instanceID := cfnPhysicalID(t, body)
 
-	code, body = cfnIdentityRequest(t, ts, "ec2", "eu-west-1",
-		signedAuthHeader("ec2", "eu-west-1"), map[string]string{
-			"Action": "DescribeInstances", "Version": "2016-11-15",
-		})
+	code, body = cfnIdentityRequest(t, ts, "ec2", "eu-west-1", "", map[string]string{
+		"Action": "DescribeInstances", "Version": "2016-11-15",
+	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	assert.Contains(t, body, instanceID, "the instance belongs to eu-west-1")
 
 	// Absent from another region, which is the half that proves partitioning still
 	// holds rather than having been widened away.
-	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1",
-		signedAuthHeader("ec2", "us-east-1"), map[string]string{
-			"Action": "DescribeInstances", "Version": "2016-11-15",
-		})
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+		"Action": "DescribeInstances", "Version": "2016-11-15",
+	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	assert.NotContains(t, body, instanceID,
 		"a eu-west-1 instance must not be visible in us-east-1")
 }
 
-// TestCFNIdentity_SignedAndUnsignedAreIsolated pins that the fix threads identity
-// rather than widening a lookup. The same template deployed by a signed caller
-// (123456789012) and an unsigned one (000000000000) yields two instances, each
-// visible only to the caller that created it.
-func TestCFNIdentity_SignedAndUnsignedAreIsolated(t *testing.T) {
+// TestCFNIdentity_TwoAccountsAreIsolated pins that the fix threads identity rather
+// than widening a lookup. The same template deployed by two accounts yields two
+// instances, each visible only to the account that created it.
+//
+// This is the test that says what #734 changed and what it did not. It used to read
+// "signed and unsigned are isolated", because substrate handed out a second account
+// to any request whose access key did not begin with "AKIA" — so its two callers
+// were the same client with two credentials. They now differ by the only thing that
+// can name an account, a signature, and the isolation they assert is unchanged.
+func TestCFNIdentity_TwoAccountsAreIsolated(t *testing.T) {
 	ts := newCFNIdentityTestServer(t)
-	signed := signedAuthHeader("cloudformation", "us-east-1")
 
-	create := func(auth, stackName string) string {
-		code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", auth,
+	create := func(account, stackName string) string {
+		code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", account,
 			map[string]string{
 				"Action": "CreateStack", "Version": "2010-05-15",
 				"StackName": stackName, "TemplateBody": cfnInstanceTemplate,
 			})
 		require.Equal(t, http.StatusOK, code, "body was %s", body)
-		code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", auth,
+		code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", account,
 			map[string]string{
 				"Action": "DescribeStackResources", "Version": "2010-05-15",
 				"StackName": stackName,
@@ -346,26 +363,26 @@ func TestCFNIdentity_SignedAndUnsignedAreIsolated(t *testing.T) {
 		return cfnPhysicalID(t, body)
 	}
 
-	signedID := create(signed, "by-signed")
-	unsignedID := create("", "by-unsigned")
-	require.NotEqual(t, signedID, unsignedID, "two stacks, two instances")
+	otherID := create(cfnOtherAccount, "by-other")
+	defaultID := create("", "by-default")
+	require.NotEqual(t, otherID, defaultID, "two stacks, two instances")
 
-	describe := func(auth string) string {
-		code, body := cfnIdentityRequest(t, ts, "ec2", "us-east-1", auth,
+	describe := func(account string) string {
+		code, body := cfnIdentityRequest(t, ts, "ec2", "us-east-1", account,
 			map[string]string{"Action": "DescribeInstances", "Version": "2016-11-15"})
 		require.Equal(t, http.StatusOK, code, "body was %s", body)
 		return body
 	}
 
-	signedView := describe(signedAuthHeader("ec2", "us-east-1"))
-	assert.Contains(t, signedView, signedID)
-	assert.NotContains(t, signedView, unsignedID,
-		"the signed caller must not see the unsigned caller's instance")
+	otherView := describe(cfnOtherAccount)
+	assert.Contains(t, otherView, otherID)
+	assert.NotContains(t, otherView, defaultID,
+		"the signing caller must not see the default account's instance")
 
-	unsignedView := describe("")
-	assert.Contains(t, unsignedView, unsignedID)
-	assert.NotContains(t, unsignedView, signedID,
-		"the unsigned caller must not see the signed caller's instance")
+	defaultView := describe("")
+	assert.Contains(t, defaultView, defaultID)
+	assert.NotContains(t, defaultView, otherID,
+		"the default account must not see the signing caller's instance")
 }
 
 // TestCFNIdentity_PseudoParametersMatchTheStackARN is the buildCFNContext half of
@@ -381,20 +398,20 @@ func TestCFNIdentity_PseudoParametersMatchTheStackARN(t *testing.T) {
 	tmpl := `{"Resources":{"G":{"Type":"AWS::Logs::LogGroup","Properties":{
 		"LogGroupName":{"Fn::Sub":"/g-${AWS::AccountId}-${AWS::Region}"}}}}}`
 
-	code, body := cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1", "", map[string]string{
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1", cfnOtherAccount, map[string]string{
 		"Action": "CreateStack", "Version": "2010-05-15",
 		"StackName": "pseudo", "TemplateBody": tmpl,
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
-	require.Contains(t, body, "arn:aws:cloudformation:eu-west-1:000000000000:stack/pseudo",
+	require.Contains(t, body, "arn:aws:cloudformation:eu-west-1:"+cfnOtherAccount+":stack/pseudo",
 		"the stack ARN names the caller")
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "eu-west-1", cfnOtherAccount, map[string]string{
 		"Action": "DescribeStackResources", "Version": "2010-05-15",
 		"StackName": "pseudo",
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
-	assert.Equal(t, "/g-000000000000-eu-west-1", cfnPhysicalID(t, body),
+	assert.Equal(t, "/g-"+cfnOtherAccount+"-eu-west-1", cfnPhysicalID(t, body),
 		"the pseudo-parameters must resolve to the caller's identity, not substrate's defaults")
 }
 
@@ -421,7 +438,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 	cases := []struct {
 		name string
 		tmpl string
-		// namespace and key locate the resource in the *unsigned* caller's
+		// namespace and key locate the resource in the *signing* caller's
 		// partition, which is where it must be for drift to have any chance.
 		namespace string
 		key       string
@@ -437,7 +454,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 				"KeySchema":[{"AttributeName":"pk","KeyType":"HASH"}],
 				"AttributeDefinitions":[{"AttributeName":"pk","AttributeType":"S"}]}}}}`,
 			namespace: "dynamodb",
-			key:       "table:000000000000/drift-table",
+			key:       "table:" + cfnOtherAccount + "/drift-table",
 			mutate: func(m map[string]any) {
 				m["BillingModeSummary"] = map[string]any{"BillingMode": "PROVISIONED"}
 			},
@@ -448,7 +465,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 			tmpl: `{"Resources":{"Q":{"Type":"AWS::SQS::Queue","Properties":{
 				"QueueName":"drift-queue","VisibilityTimeout":45}}}}`,
 			namespace: "sqs",
-			key:       "queue:000000000000/drift-queue",
+			key:       "queue:" + cfnOtherAccount + "/drift-queue",
 			mutate: func(m map[string]any) {
 				attrs, _ := m["Attributes"].(map[string]any)
 				if attrs == nil {
@@ -468,7 +485,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 			// of the template, through a context built separately from the deploy
 			// path's — a third identity read, and the only place either
 			// pseudo-parameter is resolved twice. Deploy stamps
-			// "000000000000 in eu-west-1"; a comparator resolving against the
+			// "555566667777 in eu-west-1"; a comparator resolving against the
 			// defaults expects "123456789012 in us-east-1" and reports MODIFIED on a
 			// topic nobody touched. A false drift report is the failure mode, so the
 			// IN_SYNC half of this case is what pins it.
@@ -477,7 +494,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 				"TopicName":"drift-topic",
 				"DisplayName":{"Fn::Sub":"${AWS::AccountId} in ${AWS::Region}"}}}}}`,
 			namespace: "sns",
-			key:       "topic:000000000000/" + region + "/drift-topic",
+			key:       "topic:" + cfnOtherAccount + "/" + region + "/drift-topic",
 			mutate: func(m map[string]any) {
 				m["Attributes"] = map[string]any{"DisplayName": "Renamed"}
 			},
@@ -489,7 +506,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ts := newCFNIdentityTestServer(t)
 
-			code, body := cfnIdentityRequest(t, ts, "cloudformation", region, "",
+			code, body := cfnIdentityRequest(t, ts, "cloudformation", region, cfnOtherAccount,
 				map[string]string{
 					"Action": "CreateStack", "Version": "2010-05-15",
 					"StackName": "drift", "TemplateBody": tc.tmpl,
@@ -497,7 +514,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 			require.Equal(t, http.StatusOK, code, "body was %s", body)
 
 			drifts := func() string {
-				code, body := cfnIdentityRequest(t, ts, "cloudformation", region, "",
+				code, body := cfnIdentityRequest(t, ts, "cloudformation", region, cfnOtherAccount,
 					map[string]string{
 						"Action": "DescribeStackResourceDrifts", "Version": "2010-05-15",
 						"StackName": "drift",
@@ -516,7 +533,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 			// It reports no per-resource statuses, only a count and a stack-level
 			// verdict, so its own assertion is the count: on the wrong identity
 			// every resource reads as DELETED and the stack comes back DRIFTED.
-			code, body = cfnIdentityRequest(t, ts, "cloudformation", region, "",
+			code, body = cfnIdentityRequest(t, ts, "cloudformation", region, cfnOtherAccount,
 				map[string]string{
 					"Action": "DetectStackDrift", "Version": "2010-05-15",
 					"StackName": "drift",
@@ -524,7 +541,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 			require.Equal(t, http.StatusOK, code, "body was %s", body)
 			detectionID := cfnXMLValue(t, body, "StackDriftDetectionId")
 
-			code, body = cfnIdentityRequest(t, ts, "cloudformation", region, "",
+			code, body = cfnIdentityRequest(t, ts, "cloudformation", region, cfnOtherAccount,
 				map[string]string{
 					"Action": "DescribeStackDriftDetectionStatus", "Version": "2010-05-15",
 					"StackDriftDetectionId": detectionID,
@@ -537,7 +554,7 @@ func TestCFNIdentity_DriftFindsTheCallersResources(t *testing.T) {
 
 			raw, err := ts.state.Get(context.Background(), tc.namespace, tc.key)
 			require.NoError(t, err)
-			require.NotNil(t, raw, "the resource must be in the unsigned caller's partition")
+			require.NotNil(t, raw, "the resource must be in the signing caller's partition")
 			var live map[string]any
 			require.NoError(t, json.Unmarshal(raw, &live))
 			tc.mutate(live)
@@ -562,32 +579,32 @@ func TestCFNIdentity_ExecuteChangeSetUsesTheExecutingCaller(t *testing.T) {
 
 	// A stack to change: created empty so the change set is what deploys the
 	// instance.
-	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "CreateStack", "Version": "2010-05-15",
 		"StackName": "cs", "TemplateBody": `{"Resources":{}}`,
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "CreateChangeSet", "Version": "2010-05-15",
 		"StackName": "cs", "ChangeSetName": "add-instance",
 		"TemplateBody": cfnInstanceTemplate,
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "ExecuteChangeSet", "Version": "2010-05-15",
 		"StackName": "cs", "ChangeSetName": "add-instance",
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "DescribeStackResources", "Version": "2010-05-15", "StackName": "cs",
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	instanceID := cfnPhysicalID(t, body)
 
-	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "DescribeInstances", "Version": "2016-11-15",
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
@@ -606,26 +623,26 @@ func TestCFNIdentity_ExecuteChangeSetUsesTheExecutingCaller(t *testing.T) {
 func TestCFNIdentity_UpdateStackUsesTheUpdatingCaller(t *testing.T) {
 	ts := newCFNIdentityTestServer(t)
 
-	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body := cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "CreateStack", "Version": "2010-05-15",
 		"StackName": "upd", "TemplateBody": `{"Resources":{}}`,
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "UpdateStack", "Version": "2010-05-15",
 		"StackName": "upd", "TemplateBody": cfnInstanceTemplate,
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 
-	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "cloudformation", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "DescribeStackResources", "Version": "2010-05-15", "StackName": "upd",
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	instanceID := cfnPhysicalID(t, body)
 	require.True(t, strings.HasPrefix(instanceID, "i-"), "physical ID was %q", instanceID)
 
-	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+	code, body = cfnIdentityRequest(t, ts, "ec2", "us-east-1", cfnOtherAccount, map[string]string{
 		"Action": "DescribeInstances", "Version": "2016-11-15",
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
@@ -646,11 +663,12 @@ func TestCFNIdentity_UnpartitionedServicesStillWork(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 
-	// Read back as an *unsigned* caller, which is a different account from the
-	// signed one that created the stack. An unpartitioned key is found anyway,
-	// which is the pre-existing behavior this fix must not change.
+	// Read back as a different account from the one that created the stack, which
+	// created it unsigned and so as the default. An unpartitioned key is found
+	// anyway, which is the pre-existing behavior this fix must not change.
 	head := httptest.NewRequest(http.MethodHead, "http://s3.amazonaws.com/cfn-shared-bucket", nil)
 	head.Host = "s3.amazonaws.com"
+	signAs(head, testCredentialsFor(cfnOtherAccount), "s3", "us-east-1", nil)
 	hw := httptest.NewRecorder()
 	ts.srv.ServeHTTP(hw, head)
 	assert.Equal(t, http.StatusOK, hw.Code,
@@ -679,11 +697,10 @@ func TestCFNIdentity_InProcessDeployerDefaultsToSubstratesOwn(t *testing.T) {
 	require.Empty(t, result.Resources[0].Error)
 	instanceID := result.Resources[0].PhysicalID
 
-	// Visible to a default-partition read: signed (123456789012) in us-east-1.
-	code, body := cfnIdentityRequest(t, ts, "ec2", "us-east-1",
-		signedAuthHeader("ec2", "us-east-1"), map[string]string{
-			"Action": "DescribeInstances", "Version": "2016-11-15",
-		})
+	// Visible to a default-partition read: the default account in us-east-1.
+	code, body := cfnIdentityRequest(t, ts, "ec2", "us-east-1", "", map[string]string{
+		"Action": "DescribeInstances", "Version": "2016-11-15",
+	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	assert.Contains(t, body, instanceID,
 		"an in-process deploy lands in substrate's default partition")
@@ -712,7 +729,7 @@ func TestCFNIdentity_ExplicitIdentityOverridesTheDefault(t *testing.T) {
 
 	// And the log group is in that partition, not the default one.
 	code, body := cfnJSONRequest(t, ts, "logs", "us-east-1",
-		"Logs_20140328.DescribeLogGroups", signedAuthHeader("logs", "us-east-1"), `{}`)
+		"Logs_20140328.DescribeLogGroups", "", `{}`)
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	assert.NotContains(t, body, "/g-999988887777-ap-southeast-2",
 		"a default-partition read must not see it")

--- a/emulator/cloudformation_plugin_test.go
+++ b/emulator/cloudformation_plugin_test.go
@@ -78,19 +78,29 @@ func newCFNTestServer(t *testing.T) *cfnTestServer {
 	}))
 	registry.Register(cfnp)
 
+	// A credential registry holding cfnOtherAccount, so a test here can be a caller
+	// other than the default one. It costs the unsigned requests below nothing:
+	// VerifySigV4 passes a request with no Authorization header, which resolves to
+	// the configured default account.
+	creds := emulator.NewCredentialRegistry()
+	creds.Register(testCredentialsFor(cfnOtherAccount))
+
 	srv := emulator.NewServer(*cfg, registry, store, state, tc, logger,
-		emulator.ServerOptions{Costs: emulator.NewCostController(emulator.CostConfig{Enabled: true})})
+		emulator.ServerOptions{
+			Costs:       emulator.NewCostController(emulator.CostConfig{Enabled: true}),
+			Credentials: creds,
+		})
 
 	return &cfnTestServer{srv: srv, state: state, registry: registry, tc: tc}
 }
 
-// cfnAuthHeader is a SigV4 Authorization header carrying a fake AKIA access
-// key, which extractAccount maps to the well-known test account 123456789012.
-const cfnAuthHeader = "AWS4-HMAC-SHA256 Credential=AKIATEST1234567890/20260101/" +
-	"us-east-1/cloudformation/aws4_request, SignedHeaders=host, Signature=fake"
-
 // cfnRequest posts a CloudFormation query-protocol request and returns the
 // status code and body.
+//
+// The request is unsigned, so it resolves to substrate's default account — which is
+// every account substrate has unless a caller signs as another one (#734). This used
+// to carry a fake AKIA-keyed Authorization header, because the account came from the
+// shape of the access key rather than from a signature that had to verify.
 func cfnRequest(t *testing.T, ts *cfnTestServer, params map[string]string) (int, string) {
 	t.Helper()
 	form := url.Values{}
@@ -101,10 +111,6 @@ func cfnRequest(t *testing.T, ts *cfnTestServer, params map[string]string) (int,
 		strings.NewReader(form.Encode()))
 	r.Host = "cloudformation.us-east-1.amazonaws.com"
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	// Signing with an AKIA key resolves the request to the well-known test
-	// account, which is what a signed CLI or SDK request carries; without it the
-	// stack ARNs would name the zero account.
-	r.Header.Set("Authorization", cfnAuthHeader)
 	w := httptest.NewRecorder()
 	ts.srv.ServeHTTP(w, r)
 	body, err := io.ReadAll(w.Body)

--- a/emulator/config.go
+++ b/emulator/config.go
@@ -49,6 +49,9 @@ type Config struct {
 	// Region controls multi-region routing and resource isolation.
 	Region RegionCfg `mapstructure:"region"`
 
+	// Account controls the AWS account requests are attributed to.
+	Account AccountCfg `mapstructure:"account"`
+
 	// Lambda controls Lambda Docker execution behavior.
 	Lambda LambdaCfg `mapstructure:"lambda"`
 
@@ -429,6 +432,19 @@ type RegionCfg struct {
 	Allowed []string `mapstructure:"allowed"`
 }
 
+// AccountCfg controls the AWS account a request is attributed to.
+type AccountCfg struct {
+	// Default is the account ID every caller resolves to. Default "123456789012",
+	// AWS's documented example account.
+	//
+	// It is the *default*, not the answer: a wired [CredentialRegistry] names the
+	// account per access key and an STS session record names the account it was
+	// issued for, and both take precedence. Set this when a test needs the whole
+	// server to sit in a particular account without signing for it — a fixture
+	// asserting on ARNs captured from a real account, for one.
+	Default string `mapstructure:"default"`
+}
+
 // LambdaCfg controls Lambda Docker execution behavior.
 type LambdaCfg struct {
 	// DockerEnabled gates the Docker-based Lambda execution engine. Default false.
@@ -519,6 +535,9 @@ func DefaultConfig() *Config {
 		Region: RegionCfg{
 			Default: "us-east-1",
 		},
+		Account: AccountCfg{
+			Default: defaultAccountID,
+		},
 		Lambda: LambdaCfg{
 			DockerEnabled: false,
 			ReplayMode:    "live",
@@ -575,6 +594,7 @@ func LoadConfig(path string) (*Config, error) {
 	v.SetDefault("fault.enabled", defaults.Fault.Enabled)
 	v.SetDefault("fault.seed", defaults.Fault.Seed)
 	v.SetDefault("region.default", defaults.Region.Default)
+	v.SetDefault("account.default", defaults.Account.Default)
 	v.SetDefault("lambda.docker_enabled", defaults.Lambda.DockerEnabled)
 	v.SetDefault("lambda.replay_mode", defaults.Lambda.ReplayMode)
 	v.SetDefault("lambda.warm_pool_ttl", defaults.Lambda.WarmPoolTTL)
@@ -672,6 +692,13 @@ func Validate(cfg *Config) error {
 		if _, err := time.ParseDuration(cfg.Lambda.WarmPoolTTL); err != nil {
 			return fmt.Errorf("lambda.warm_pool_ttl %q is not a valid duration: %w", cfg.Lambda.WarmPoolTTL, err)
 		}
+	}
+
+	// An empty value keeps the built-in default; anything else must be a real
+	// account ID, because it lands in every ARN the server hands back and a
+	// malformed one is a fixture that cannot be compared against AWS.
+	if cfg.Account.Default != "" && !isAccountIDPattern(cfg.Account.Default) {
+		return fmt.Errorf("account.default %q is not valid; an AWS account ID is 12 digits", cfg.Account.Default)
 	}
 
 	validRDSEngines := map[string]bool{"stub": true, "container": true}

--- a/emulator/credentials.go
+++ b/emulator/credentials.go
@@ -49,7 +49,7 @@ func NewCredentialRegistry() *CredentialRegistry {
 	r.store[defaultTestAccessKeyID] = CredentialEntry{
 		AccessKeyID:     defaultTestAccessKeyID,
 		SecretAccessKey: defaultTestSecretKey,
-		AccountID:       testAccountID,
+		AccountID:       defaultAccountID,
 	}
 	return r
 }
@@ -123,12 +123,10 @@ func buildCallerARN(accountID, accessKeyID string) string {
 // the principal, so a caller who never touched IAM is unaffected.
 //
 // The second return is an account ID to adopt, or "" to keep the one already
-// resolved. Only an STS session supplies one: extractAccount recognizes AKIA as
-// substrate's test account and maps everything else — ASIA session keys
-// included — to the fallback account, so a caller using AssumeRole credentials
-// was placed in a different partition from the resources it went on to create.
-// The session record names the account it was issued for, which is the one the
-// role's caller was in.
+// resolved. Only an STS session supplies one, and it is the only thing that can:
+// a temporary credential's account is recorded when the session is minted and
+// appears nowhere on the wire, so a cross-account AssumeRole would otherwise
+// leave the caller in the server's own account rather than the role's.
 func resolvePrincipal(ctx context.Context, state StateManager, accountID, accessKeyID string) (*Principal, string) {
 	if state == nil || accessKeyID == "" {
 		return nil, ""

--- a/emulator/debug_ui_test.go
+++ b/emulator/debug_ui_test.go
@@ -243,7 +243,7 @@ func TestDebugExport(t *testing.T) {
 		Sequence:  0,
 		Service:   "sqs",
 		Operation: "CreateQueue",
-		AccountID: "000000000000",
+		AccountID: "123456789012",
 		Region:    "us-east-1",
 		StreamID:  "export-stream",
 		Request: &emulator.AWSRequest{

--- a/emulator/ec2_instanceattribute_test.go
+++ b/emulator/ec2_instanceattribute_test.go
@@ -587,13 +587,13 @@ func TestEC2_InstanceAttribute_EmptyGroupSetIsStillPresent(t *testing.T) {
 		"instance_type": "t3.micro",
 		"image_id":      "ami-1",
 		"state":         map[string]any{"code": 16, "name": "running"},
-		"account_id":    "000000000000",
+		"account_id":    "123456789012",
 		"region":        "us-east-1",
 	}
 	raw, err := json.Marshal(inst)
 	require.NoError(t, err)
 	require.NoError(t, state.Put(context.Background(), "ec2",
-		"instance:000000000000/us-east-1/"+instID, raw))
+		"instance:123456789012/us-east-1/"+instID, raw))
 
 	resp := ec2Request(t, ts, map[string]string{
 		"Action": "DescribeInstanceAttribute", "InstanceId": instID, "Attribute": "groupSet",

--- a/emulator/ec2_launchtemplate_test.go
+++ b/emulator/ec2_launchtemplate_test.go
@@ -765,8 +765,8 @@ func TestEC2_LaunchTemplate_RoundTripsTagsAndProfile(t *testing.T) {
 		{
 			name:         "Arn form",
 			profileParam: "LaunchTemplateData.IamInstanceProfile.Arn",
-			profile:      "arn:aws:iam::000000000000:instance-profile/tmpl-profile",
-			wantARN:      "arn:aws:iam::000000000000:instance-profile/tmpl-profile",
+			profile:      "arn:aws:iam::123456789012:instance-profile/tmpl-profile",
+			wantARN:      "arn:aws:iam::123456789012:instance-profile/tmpl-profile",
 		},
 	}
 	for _, tt := range tests {
@@ -835,7 +835,7 @@ func TestEC2_LaunchTemplate_TagsReachTheInstance(t *testing.T) {
 // response shape has no name member — so a bare template name is surfaced as the
 // ARN it implies, matching what a call-level IamInstanceProfile.Name already did.
 func TestEC2_LaunchTemplate_ProfileReachesTheInstance(t *testing.T) {
-	const arn = "arn:aws:iam::000000000000:instance-profile/tmpl-profile"
+	const arn = "arn:aws:iam::123456789012:instance-profile/tmpl-profile"
 	tests := []struct {
 		name  string
 		param string
@@ -879,8 +879,8 @@ func TestEC2_LaunchTemplate_ProfileReachesTheInstance(t *testing.T) {
 // general "overwrite the corresponding parameters" rule, so replacement is that rule
 // applied — a request naming Env=req does not also inherit the template's Team=x.
 func TestEC2_LaunchTemplate_TagAndProfilePrecedence(t *testing.T) {
-	const reqARN = "arn:aws:iam::000000000000:instance-profile/p-req"
-	const tmplARN = "arn:aws:iam::000000000000:instance-profile/p-tmpl"
+	const reqARN = "arn:aws:iam::123456789012:instance-profile/p-req"
+	const tmplARN = "arn:aws:iam::123456789012:instance-profile/p-tmpl"
 
 	tests := []struct {
 		name          string
@@ -1107,7 +1107,7 @@ func storeTemplateWithTags(t *testing.T, name, ltID string, tags []map[string]st
 	ts := httptest.NewServer(emulator.NewServer(*emulator.DefaultConfig(), registry, store, state, tc, logger))
 	t.Cleanup(ts.Close)
 
-	const acct, region = "000000000000", "us-east-1"
+	const acct, region = "123456789012", "us-east-1"
 	raw, err := json.Marshal(map[string]any{
 		"launchTemplateId":     ltID,
 		"launchTemplateName":   name,

--- a/emulator/ec2_launchtemplate_versions_test.go
+++ b/emulator/ec2_launchtemplate_versions_test.go
@@ -718,7 +718,7 @@ func TestEC2_LaunchTemplate_PreVersioningStateStillWorks(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	// Exactly the shape createLaunchTemplate wrote before #456: no "versions" key.
-	const acct, region, ltID = "000000000000", "us-east-1", "lt-0legacy00000001"
+	const acct, region, ltID = "123456789012", "us-east-1", "lt-0legacy00000001"
 	legacy := map[string]any{
 		"launchTemplateId":     ltID,
 		"launchTemplateName":   "legacy",

--- a/emulator/ec2_network_interfaces_test.go
+++ b/emulator/ec2_network_interfaces_test.go
@@ -605,7 +605,7 @@ func TestEC2NetworkInterfaces_PreSliceTemplateStateStillWorks(t *testing.T) {
 
 	// The shape createLaunchTemplate wrote before #455: subnetId,
 	// associatePublicIpAddress and networkInterfaceGroups, no networkInterfaces key.
-	const acct, region, ltID = "000000000000", "us-east-1", "lt-0preslice00001"
+	const acct, region, ltID = "123456789012", "us-east-1", "lt-0preslice00001"
 	stored := map[string]any{
 		"launchTemplateId":     ltID,
 		"launchTemplateName":   "preslice",

--- a/emulator/ec2_registerimage_test.go
+++ b/emulator/ec2_registerimage_test.go
@@ -409,12 +409,12 @@ func TestEC2_DescribeImages_PhantomSnapshotReportsTheDefaultSize(t *testing.T) {
 			Name:       "pre-711",
 			State:      "available",
 			SnapshotID: "snap-0123456789abcdef0",
-			AccountID:  "000000000000",
+			AccountID:  "123456789012",
 			Region:     "us-east-1",
 		})
 		require.NoError(t, err)
 		require.NoError(t, state.Put(context.Background(), "ec2",
-			"image:000000000000/us-east-1/ami-0123456789abcdef0", record))
+			"image:123456789012/us-east-1/ami-0123456789abcdef0", record))
 
 		got := ec2ImageMappings(t, ts, "ami-0123456789abcdef0")
 		require.Len(t, got, 1, "the root device entry substrate fabricates for such a record")

--- a/emulator/elasticache_plugin_test.go
+++ b/emulator/elasticache_plugin_test.go
@@ -350,7 +350,7 @@ func TestElastiCachePlugin_Tagging(t *testing.T) {
 		t.Fatalf("CreateCacheCluster status %d, body: %s", resp.StatusCode, body)
 	}
 
-	arn := "arn:aws:elasticache:us-east-1:000000000000:cluster:tag-cluster"
+	arn := "arn:aws:elasticache:us-east-1:123456789012:cluster:tag-cluster"
 
 	// AddTagsToResource
 	resp = ecRequest(t, ts, map[string]string{
@@ -513,7 +513,7 @@ func TestElastiCachePlugin_ReplicationGroupTagging(t *testing.T) {
 	}
 
 	// Tagging via replicationgroup ARN type.
-	arn := "arn:aws:elasticache:us-east-1:000000000000:replicationgroup:tag-rg"
+	arn := "arn:aws:elasticache:us-east-1:123456789012:replicationgroup:tag-rg"
 
 	resp = ecRequest(t, ts, map[string]string{
 		"Action":              "AddTagsToResource",
@@ -662,7 +662,7 @@ func TestElastiCachePlugin_ReplicationGroupTaggingARN(t *testing.T) {
 		t.Fatalf("CreateReplicationGroup status %d", resp.StatusCode)
 	}
 
-	rgARN := "arn:aws:elasticache:us-east-1:000000000000:replicationgroup:rg-tag-test"
+	rgARN := "arn:aws:elasticache:us-east-1:123456789012:replicationgroup:rg-tag-test"
 
 	resp = ecRequest(t, ts, map[string]string{
 		"Action":              "AddTagsToResource",

--- a/emulator/eventbridge_plugin.go
+++ b/emulator/eventbridge_plugin.go
@@ -504,7 +504,7 @@ func (p *EventBridgePlugin) putEvents(ctx *RequestContext, req *AWSRequest) (*AW
 	return ebJSONResponse(http.StatusOK, response{FailedEntryCount: failedCount, Entries: results})
 }
 
-func (p *EventBridgePlugin) listEventBuses(_ *RequestContext) (*AWSResponse, error) {
+func (p *EventBridgePlugin) listEventBuses(reqCtx *RequestContext) (*AWSResponse, error) {
 	type eventBus struct {
 		Name   string `json:"Name"`
 		ARN    string `json:"Arn"`
@@ -513,9 +513,14 @@ func (p *EventBridgePlugin) listEventBuses(_ *RequestContext) (*AWSResponse, err
 	type response struct {
 		EventBuses []eventBus `json:"EventBuses"`
 	}
+	// The default bus exists in every account and Region, so its ARN is the
+	// caller's — not the us-east-1/000000000000 literal this returned before
+	// (#734), which named a bus in neither the account nor the Region the caller
+	// was addressing and so matched no ARN-scoped policy and no rule this plugin
+	// went on to store.
 	return ebJSONResponse(http.StatusOK, response{
 		EventBuses: []eventBus{
-			{Name: "default", ARN: "arn:aws:events:us-east-1:000000000000:event-bus/default"},
+			{Name: "default", ARN: ebEventBusARN(reqCtx, "default")},
 		},
 	})
 }

--- a/emulator/eventbridge_types.go
+++ b/emulator/eventbridge_types.go
@@ -64,3 +64,19 @@ type EBEvent struct {
 func ebRuleARN(region, accountID, ruleName string) string {
 	return "arn:aws:events:" + region + ":" + accountID + ":rule/" + ruleName
 }
+
+// ebEventBusARN constructs the ARN for an event bus in the caller's account and
+// Region. A nil context yields the parser's defaults, so a plugin driven directly
+// by a unit test gets the same ARN an HTTP caller would.
+func ebEventBusARN(reqCtx *RequestContext, busName string) string {
+	region, accountID := defaultRegion, defaultAccountID
+	if reqCtx != nil {
+		if reqCtx.Region != "" {
+			region = reqCtx.Region
+		}
+		if reqCtx.AccountID != "" {
+			accountID = reqCtx.AccountID
+		}
+	}
+	return "arn:aws:events:" + region + ":" + accountID + ":event-bus/" + busName
+}

--- a/emulator/export_test.go
+++ b/emulator/export_test.go
@@ -463,7 +463,7 @@ func CFNResolveWithMappingsForTest(
 		evaluating: map[string]bool{},
 		mappings:   mappings,
 		region:     region,
-		accountID:  testAccountID,
+		accountID:  defaultAccountID,
 		stackName:  "teststack",
 	}
 	return resolveValue(v, cctx), cctx.takeFailures()
@@ -486,7 +486,7 @@ func CFNResolveListWithMappingsForTest(
 		evaluating: map[string]bool{},
 		mappings:   mappings,
 		region:     region,
-		accountID:  testAccountID,
+		accountID:  defaultAccountID,
 		stackName:  "teststack",
 	}
 	return resolveValueList(v, cctx), cctx.takeFailures()
@@ -516,7 +516,7 @@ func CFNResolveNestedWithMappingsForTest(
 		evaluating: map[string]bool{},
 		mappings:   mappings,
 		region:     region,
-		accountID:  testAccountID,
+		accountID:  defaultAccountID,
 		stackName:  "teststack",
 	}
 	return resolveNested(v, cctx), cctx.takeFailures()
@@ -545,7 +545,7 @@ func CFNResolveImportForTest(
 		imports:    map[string]bool{},
 		exports:    exports,
 		region:     defaultRegion,
-		accountID:  testAccountID,
+		accountID:  defaultAccountID,
 		stackName:  "teststack",
 	}
 	value = resolveValue(v, cctx)

--- a/emulator/glue_plugin_test.go
+++ b/emulator/glue_plugin_test.go
@@ -616,7 +616,7 @@ func TestGluePlugin_TaggingOperations(t *testing.T) {
 		t.Fatalf("CreateJob: %d: %s", r.StatusCode, glueBody(t, r))
 	}
 	_ = glueBody(t, r)
-	jobARN := "arn:aws:glue:us-east-1:000000000000:job/tag-job"
+	jobARN := "arn:aws:glue:us-east-1:123456789012:job/tag-job"
 
 	// GetTags.
 	r2 := glueRequest(t, ts, "GetTags", map[string]interface{}{

--- a/emulator/iam_plugin_test.go
+++ b/emulator/iam_plugin_test.go
@@ -766,7 +766,7 @@ func TestIAMPlugin_CreatePolicy_Duplicate(t *testing.T) {
 func TestIAMPlugin_DeletePolicy_NotFound(t *testing.T) {
 	srv := newIAMTestServer(t)
 	resp := iamRequest(t, srv, "DeletePolicy", map[string]any{
-		"PolicyArn": "arn:aws:iam::000000000000:policy/nonexistent",
+		"PolicyArn": "arn:aws:iam::123456789012:policy/nonexistent",
 	})
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/emulator/lambda_esm_exec_test.go
+++ b/emulator/lambda_esm_exec_test.go
@@ -21,7 +21,7 @@ func TestPollAndInvoke(t *testing.T) {
 	// Create SQS queue.
 	queueName := fmt.Sprintf("esm-test-%d", time.Now().UnixNano())
 	esmCreateSQSQueue(t, ts, queueName)
-	acct := "000000000000" // fallbackAccountID used without auth
+	acct := "123456789012" // fallbackAccountID used without auth
 	queueURL := fmt.Sprintf("http://sqs.us-east-1.amazonaws.com/%s/%s", acct, queueName)
 
 	// Send two messages.
@@ -57,7 +57,7 @@ func TestESMPollerLifecycle(t *testing.T) {
 	ts := emulator.StartTestServer(t)
 
 	queueName := fmt.Sprintf("esm-lifecycle-%d", time.Now().UnixNano())
-	acct := "000000000000"
+	acct := "123456789012"
 	region := "us-east-1"
 	sqsARN := fmt.Sprintf("arn:aws:sqs:%s:%s:%s", region, acct, queueName)
 
@@ -75,7 +75,7 @@ func TestESMShutdown_StopsAll(t *testing.T) {
 	// Does not use t.Parallel() because we need to stop the server mid-test.
 	ts := emulator.StartTestServer(t)
 
-	acct := "000000000000"
+	acct := "123456789012"
 	region := "us-east-1"
 
 	for i := 0; i < 3; i++ {
@@ -136,7 +136,7 @@ func esmCreateLambdaFunction(t *testing.T, ts *emulator.TestServer, name string)
 	payload, _ := json.Marshal(map[string]interface{}{
 		"FunctionName": name,
 		"Runtime":      "python3.12",
-		"Role":         "arn:aws:iam::000000000000:role/test",
+		"Role":         "arn:aws:iam::123456789012:role/test",
 		"Handler":      "index.handler",
 	})
 	resp := esmDoRequest(t, ts, http.MethodPost, "/2015-03-31/functions",

--- a/emulator/lambda_exec_docker_test.go
+++ b/emulator/lambda_exec_docker_test.go
@@ -28,7 +28,7 @@ func TestLambdaExecutor_GracefulDegradation_WithDocker(t *testing.T) {
 	// "docker run" fails immediately without pulling anything.
 	fn := emulator.LambdaFunction{
 		FunctionName: "docker-fail-fn",
-		FunctionArn:  "arn:aws:lambda:us-east-1:000000000000:function:docker-fail-fn",
+		FunctionArn:  "arn:aws:lambda:us-east-1:123456789012:function:docker-fail-fn",
 		Runtime:      "python3.12",
 		Handler:      "index.handler",
 		PackageType:  "Image",
@@ -66,7 +66,7 @@ func TestLambdaExecutor_StopAll_WithPool(t *testing.T) {
 		WarmPoolTTL: 5 * time.Minute,
 	}, logger, false)
 	// Inject a fake pool entry to exercise the stop-container path.
-	emulator.InjectPoolEntryForTest(exec, "arn:aws:lambda:us-east-1:000000000000:function:f",
+	emulator.InjectPoolEntryForTest(exec, "arn:aws:lambda:us-east-1:123456789012:function:f",
 		"nonexistent-container-id-xyz")
 	// StopAll logs the error but must not panic.
 	exec.StopAll()

--- a/emulator/omics_plugin_test.go
+++ b/emulator/omics_plugin_test.go
@@ -82,7 +82,7 @@ func TestOmicsPlugin_StartGetCancelRun(t *testing.T) {
 		"workflowId":   "wf-12345",
 		"workflowType": "PRIVATE",
 		"name":         "my-run",
-		"roleArn":      "arn:aws:iam::000000000000:role/OmicsRole",
+		"roleArn":      "arn:aws:iam::123456789012:role/OmicsRole",
 	})
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("startRun: expected 201, got %d; body: %s", resp.StatusCode, omicsBody(t, resp))
@@ -148,7 +148,7 @@ func TestOmicsPlugin_ListRuns(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		r := omicsRequest(t, ts, http.MethodPost, "/run", map[string]string{
 			"workflowId": "wf-1",
-			"roleArn":    "arn:aws:iam::000000000000:role/R",
+			"roleArn":    "arn:aws:iam::123456789012:role/R",
 		})
 		omicsBody(t, r)
 	}

--- a/emulator/organizations_state_test.go
+++ b/emulator/organizations_state_test.go
@@ -21,7 +21,7 @@ func newOrganizationsStateFixture(t *testing.T) *emulator.OrganizationsPlugin {
 	return emulator.NewOrganizationsPluginForTest(state, tc)
 }
 
-const orgTestAccount = "000000000000"
+const orgTestAccount = "123456789012"
 
 // newOrgBadBody returns a body no JSON decoder can parse.
 func newOrgBadBody() io.Reader { return strings.NewReader(`{"AccountId":`) }

--- a/emulator/parser.go
+++ b/emulator/parser.go
@@ -8,18 +8,32 @@ import (
 	"time"
 )
 
-// testAccountID is the well-known AWS account ID used for test access keys.
-const testAccountID = "123456789012"
-
-// fallbackAccountID is used when no account can be determined.
-const fallbackAccountID = "000000000000"
+// defaultAccountID is the AWS account every request is attributed to unless the
+// server is told otherwise. It is AWS's documented example account ID.
+//
+// There is deliberately only one. Substrate used to run two: a request signed
+// with an "AKIA"-prefixed access key was filed under this account and everything
+// else — the documented test/test pair, an unsigned request, an "ASIA" session
+// key — under a zero fallback, so one server served two accounts depending on
+// which credential the client happened to pick and resources created under one
+// were invisible to the other (#734). Nothing about a request off the wire
+// carries an account, so inventing a second one from the shape of an access key
+// was a guess; the account now comes from configuration
+// ([AccountCfg.Default]), from a wired [CredentialRegistry], or from an STS
+// session record — each of which actually knows.
+const defaultAccountID = "123456789012"
 
 // defaultRegion is used when no region can be extracted from the request.
 const defaultRegion = "us-east-1"
 
-// ParseAWSRequest extracts service, operation, region, and account from r and
-// returns a populated [AWSRequest] and [RequestContext]. It is a pure function
-// that does not perform SigV4 signature verification (deferred to a later release).
+// ParseAWSRequest extracts service, operation and region from r and returns a
+// populated [AWSRequest] and [RequestContext]. It is a pure function that does
+// not perform SigV4 signature verification (deferred to a later release).
+//
+// The account is [defaultAccountID] for every request: nothing on the wire names
+// one, and this function has no configuration to consult. A server overrides it
+// from [AccountCfg.Default], from a wired [CredentialRegistry] and from an STS
+// session record, in that order.
 func ParseAWSRequest(r *http.Request) (*AWSRequest, *RequestContext, error) {
 	if r == nil {
 		return nil, nil, fmt.Errorf("request must not be nil")
@@ -108,7 +122,6 @@ func ParseAWSRequest(r *http.Request) (*AWSRequest, *RequestContext, error) {
 
 	operation := extractOperation(target, params, r.Method, r.URL.Path)
 	region := extractRegion(host, authHeader)
-	account := extractAccount(authHeader)
 
 	req := &AWSRequest{
 		Service:    service,
@@ -134,7 +147,7 @@ func ParseAWSRequest(r *http.Request) (*AWSRequest, *RequestContext, error) {
 
 	reqCtx := &RequestContext{
 		RequestID: generateRequestID(),
-		AccountID: account,
+		AccountID: defaultAccountID,
 		Region:    region,
 		Timestamp: time.Now(),
 		Metadata:  make(map[string]interface{}),
@@ -232,6 +245,12 @@ var targetServiceAliases = map[string]string{
 	// "AmazonEventBridge" → strip "Amazon" → "eventbridge" (already correct), but
 	// the host "events.*" produces "events" which must alias to "eventbridge".
 	"events": "eventbridge",
+	// "AWSEvents" → no strip → "awsevents", which is what every SDK actually sends:
+	// the EventBridge model's target prefix is AWSEvents, not AmazonEventBridge. Host
+	// routing hid this until a live run pointed the CLI at --endpoint-url, where the
+	// host is localhost and the target is the only signal — so every EventBridge call
+	// answered ServiceNotAvailable (#734).
+	"awsevents": "eventbridge",
 	// "CertificateManager" is the ACM target namespace prefix.
 	"certificatemanager": "acm",
 	// "AmazonEC2ContainerServiceV20141113" → strip "Amazon" → "ec2containerservicev20141113"
@@ -735,25 +754,6 @@ func extractServiceFromAuth(authHeader string) string {
 		return canonical
 	}
 	return svc
-}
-
-// extractAccount determines the AWS account ID from the Authorization header.
-// Fake test access keys (starting with "AKIA") map to the well-known test
-// account ID; everything else falls back to the zero account.
-func extractAccount(authHeader string) string {
-	const credPrefix = "Credential="
-	idx := strings.Index(authHeader, credPrefix)
-	if idx < 0 {
-		return fallbackAccountID
-	}
-	cred := authHeader[idx+len(credPrefix):]
-	if end := strings.IndexAny(cred, "/, "); end > 0 {
-		accessKey := cred[:end]
-		if strings.HasPrefix(accessKey, "AKIA") {
-			return testAccountID
-		}
-	}
-	return fallbackAccountID
 }
 
 // generateRequestID produces a unique request ID string.

--- a/emulator/parser_test.go
+++ b/emulator/parser_test.go
@@ -419,25 +419,40 @@ func TestExtractService_PriceListTarget(t *testing.T) {
 	assert.Equal(t, "GetProducts", req.Operation)
 }
 
+// TestParseAWSRequest_Account pins the convergence #734 asked for: every
+// credential shape resolves to the same account.
+//
+// This table used to assert the opposite. An "AKIA"-prefixed key was filed under
+// 123456789012 and everything else — the documented test/test pair, an unsigned
+// request, an "ASIA" session key — under 000000000000, so one server served two
+// accounts depending on which credential the client happened to pick, and a
+// resource created under one was invisible to the other. Nothing on the wire names
+// an account, so the prefix was never evidence of one; the cases below are kept
+// (rather than collapsed into a single assertion) precisely because each of them
+// used to answer differently.
 func TestParseAWSRequest_Account(t *testing.T) {
 	tests := []struct {
-		name        string
-		authHeader  string
-		wantAccount string
+		name       string
+		authHeader string
 	}{
 		{
-			name:        "test AKIA key",
-			authHeader:  "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request",
-			wantAccount: "123456789012",
+			name:       "the documented AKIA example key",
+			authHeader: "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request",
 		},
 		{
-			name:        "no auth → fallback",
-			wantAccount: "000000000000",
+			name: "no Authorization header at all",
 		},
 		{
-			name:        "non-AKIA key → fallback",
-			authHeader:  "AWS4-HMAC-SHA256 Credential=ASIAXYZ/20130524/us-east-1/s3/aws4_request",
-			wantAccount: "000000000000",
+			name:       "an ASIA session key",
+			authHeader: "AWS4-HMAC-SHA256 Credential=ASIAXYZ/20130524/us-east-1/s3/aws4_request",
+		},
+		{
+			name:       "the documented test/test pair",
+			authHeader: "AWS4-HMAC-SHA256 Credential=test/20130524/us-east-1/s3/aws4_request",
+		},
+		{
+			name:       "a credential scope with no access key",
+			authHeader: "AWS4-HMAC-SHA256 Credential=/20130524/us-east-1/s3/aws4_request",
 		},
 	}
 
@@ -450,7 +465,8 @@ func TestParseAWSRequest_Account(t *testing.T) {
 
 			_, reqCtx, err := emulator.ParseAWSRequest(r)
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantAccount, reqCtx.AccountID)
+			assert.Equal(t, "123456789012", reqCtx.AccountID,
+				"every credential shape resolves to the one account (#734)")
 		})
 	}
 }
@@ -914,6 +930,64 @@ func TestParseAWSRequest_ConfigResolvesByEveryPath(t *testing.T) {
 		req, _, err := emulator.ParseAWSRequest(r)
 		require.NoError(t, err)
 		assert.Equal(t, "config", req.Service)
+	})
+}
+
+// TestParseAWSRequest_EventBridgeResolvesByEveryPath is the same gate for
+// EventBridge, and it fails before the alias this file adds.
+//
+// The target prefix in EventBridge's model is **AWSEvents**, not AmazonEventBridge:
+// every SDK sends `X-Amz-Target: AWSEvents.ListEventBuses`. Only the host alias
+// ("events.*" → eventbridge) was registered, which is enough on a real endpoint and
+// useless on the one way substrate is actually reached — `--endpoint-url`, where the
+// host is localhost and the target is the only signal. So every EventBridge call from
+// a real client answered ServiceNotAvailable, and a live run for #734 is how that
+// surfaced: the plugin was registered, green, and unreachable, which is the #561/#580
+// failure mode again.
+func TestParseAWSRequest_EventBridgeResolvesByEveryPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("target prefix", func(t *testing.T) {
+		t.Parallel()
+		for _, target := range []string{
+			"AWSEvents.ListEventBuses",
+			"AWSEvents.PutRule",
+			"AWSEvents.PutEvents",
+		} {
+			t.Run(target, func(t *testing.T) {
+				t.Parallel()
+				r := httptest.NewRequest(http.MethodPost, "http://localhost:4566/", nil)
+				r.Host = "localhost:4566"
+				r.Header.Set("X-Amz-Target", target)
+
+				req, _, err := emulator.ParseAWSRequest(r)
+				require.NoError(t, err)
+				assert.Equal(t, "eventbridge", req.Service)
+			})
+		}
+	})
+
+	t.Run("host", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequest(http.MethodPost, "http://events.us-east-1.amazonaws.com/", nil)
+		r.Host = "events.us-east-1.amazonaws.com"
+
+		req, _, err := emulator.ParseAWSRequest(r)
+		require.NoError(t, err)
+		assert.Equal(t, "eventbridge", req.Service)
+	})
+
+	t.Run("sigv4 signing name", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequest(http.MethodPost, "http://localhost:4566/", nil)
+		r.Host = "localhost:4566"
+		r.Header.Set("Authorization",
+			"AWS4-HMAC-SHA256 Credential=AKIATEST12345678901/20260101/us-east-1/events/aws4_request, "+
+				"SignedHeaders=host, Signature=fake")
+
+		req, _, err := emulator.ParseAWSRequest(r)
+		require.NoError(t, err)
+		assert.Equal(t, "eventbridge", req.Service)
 	})
 }
 

--- a/emulator/rds_plugin_test.go
+++ b/emulator/rds_plugin_test.go
@@ -330,7 +330,7 @@ func TestRDSPlugin_Tagging(t *testing.T) {
 		t.Fatalf("CreateDBInstance status %d, body: %s", resp.StatusCode, body)
 	}
 
-	arn := "arn:aws:rds:us-east-1:000000000000:db:tagdb"
+	arn := "arn:aws:rds:us-east-1:123456789012:db:tagdb"
 
 	// AddTagsToResource
 	resp = rdsRequest(t, ts, map[string]string{
@@ -744,7 +744,7 @@ func TestRDSPlugin_SnapshotTagging(t *testing.T) {
 		t.Fatalf("CreateDBSnapshot status %d", resp.StatusCode)
 	}
 
-	snapARN := "arn:aws:rds:us-east-1:000000000000:snapshot:snap-tag"
+	snapARN := "arn:aws:rds:us-east-1:123456789012:snapshot:snap-tag"
 
 	// AddTagsToResource on snapshot.
 	resp = rdsRequest(t, ts, map[string]string{

--- a/emulator/s3_acl_test.go
+++ b/emulator/s3_acl_test.go
@@ -620,7 +620,7 @@ func TestS3_ACL_CreateBucketClearsAStaleACL(t *testing.T) {
 // canonicalize them on the way in.
 func TestS3_ACL_NonCanonicalHeaderNames(t *testing.T) {
 	p := newS3PluginDirect(t)
-	rctx := &emulator.RequestContext{AccountID: "000000000000", Region: "us-east-1"}
+	rctx := &emulator.RequestContext{AccountID: "123456789012", Region: "us-east-1"}
 
 	// Operation carries the HTTP verb on entry; the plugin resolves the semantic
 	// operation from it and the path, exactly as the server pipeline does.

--- a/emulator/s3_notification_wire_test.go
+++ b/emulator/s3_notification_wire_test.go
@@ -261,8 +261,8 @@ func TestS3Notification_FiresSQSFromRealS3Body(t *testing.T) {
 		"Action":    "CreateQueue",
 		"QueueName": "wire-notify-queue",
 	})
-	const queueARN = "arn:aws:sqs:us-east-1:000000000000:wire-notify-queue"
-	const queueURL = "http://sqs.us-east-1.localhost/000000000000/wire-notify-queue"
+	const queueARN = "arn:aws:sqs:us-east-1:123456789012:wire-notify-queue"
+	const queueURL = "http://sqs.us-east-1.localhost/123456789012/wire-notify-queue"
 
 	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/fire-wire", nil, nil).Code)
 	require.Equal(t, http.StatusOK, putNotification(t, srv, "fire-wire", notificationXML(queueARN)).Code)
@@ -293,8 +293,8 @@ func TestS3Notification_KeyFilterAppliesOnDispatch(t *testing.T) {
 		"Action":    "CreateQueue",
 		"QueueName": "filtered-queue",
 	})
-	const queueARN = "arn:aws:sqs:us-east-1:000000000000:filtered-queue"
-	const queueURL = "http://sqs.us-east-1.localhost/000000000000/filtered-queue"
+	const queueARN = "arn:aws:sqs:us-east-1:123456789012:filtered-queue"
+	const queueURL = "http://sqs.us-east-1.localhost/123456789012/filtered-queue"
 
 	require.Equal(t, http.StatusOK, s3Request(t, srv, http.MethodPut, "/filter-fire", nil, nil).Code)
 	cfg := `<NotificationConfiguration><QueueConfiguration>` +

--- a/emulator/s3_plugin_test.go
+++ b/emulator/s3_plugin_test.go
@@ -484,7 +484,7 @@ func TestS3_PutObject_CostTracked(t *testing.T) {
 	s3Request(t, srv, http.MethodPut, "/cost-bucket/obj.txt", []byte("hello"), nil)
 
 	// Retrieve cost summary.
-	summary, err := store.GetCostSummary(context.Background(), "000000000000", time.Time{}, time.Time{})
+	summary, err := store.GetCostSummary(context.Background(), "123456789012", time.Time{}, time.Time{})
 	require.NoError(t, err)
 	// PutObject costs $0.000005.
 	assert.InDelta(t, 0.000005, summary.ByOperation["s3/PutObject"], 1e-9)
@@ -712,8 +712,8 @@ func TestS3Plugin_BucketNotification_FireSQS(t *testing.T) {
 		"Action":    "CreateQueue",
 		"QueueName": "s3-notify-queue",
 	})
-	queueARN := "arn:aws:sqs:us-east-1:000000000000:s3-notify-queue"
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/s3-notify-queue"
+	queueARN := "arn:aws:sqs:us-east-1:123456789012:s3-notify-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/s3-notify-queue"
 
 	// Create S3 bucket.
 	s3Request(t, srv, http.MethodPut, "/fire-notif-bucket", nil, nil)

--- a/emulator/s3_sse_test.go
+++ b/emulator/s3_sse_test.go
@@ -295,7 +295,7 @@ func TestS3_SSE_StoredAbsentOnUnencryptedObject(t *testing.T) {
 // canonicalize them on the way in.
 func TestS3_SSE_NonCanonicalHeaderNames(t *testing.T) {
 	p := newS3PluginDirect(t)
-	rctx := &emulator.RequestContext{AccountID: "000000000000", Region: "us-east-1"}
+	rctx := &emulator.RequestContext{AccountID: "123456789012", Region: "us-east-1"}
 
 	// Operation carries the HTTP verb on entry; the plugin resolves the semantic
 	// operation from it and the path, exactly as the server pipeline does.

--- a/emulator/s3_system_metadata_test.go
+++ b/emulator/s3_system_metadata_test.go
@@ -191,7 +191,7 @@ func TestS3_SystemMetadata_ExpiresStoredVerbatim(t *testing.T) {
 // through the server would arrive canonical and the test would prove nothing.
 func TestS3_SystemMetadata_HeaderCaseInsensitive(t *testing.T) {
 	p := newS3PluginDirect(t)
-	rctx := &emulator.RequestContext{AccountID: "000000000000", Region: "us-east-1"}
+	rctx := &emulator.RequestContext{AccountID: "123456789012", Region: "us-east-1"}
 
 	// Operation carries the HTTP verb on entry; the plugin resolves the semantic
 	// operation from it and the path, exactly as the server pipeline does.

--- a/emulator/scheduler_plugin_test.go
+++ b/emulator/scheduler_plugin_test.go
@@ -77,7 +77,7 @@ func TestScheduler_CreateGetDelete(t *testing.T) {
 	createBody := `{
 		"ScheduleExpression": "rate(5 minutes)",
 		"State": "ENABLED",
-		"Target": {"Arn": "arn:aws:lambda:us-east-1:000000000000:function:my-fn", "RoleArn": "arn:aws:iam::000000000000:role/my-role"},
+		"Target": {"Arn": "arn:aws:lambda:us-east-1:123456789012:function:my-fn", "RoleArn": "arn:aws:iam::123456789012:role/my-role"},
 		"FlexibleTimeWindow": {"Mode": "OFF"}
 	}`
 	resp := schedulerRequest(t, ts, http.MethodPost, "/schedules/my-schedule", createBody)
@@ -124,7 +124,7 @@ func TestScheduler_UpdateSchedule(t *testing.T) {
 	createBody := `{
 		"ScheduleExpression": "rate(5 minutes)",
 		"State": "ENABLED",
-		"Target": {"Arn": "arn:aws:lambda:us-east-1:000000000000:function:my-fn", "RoleArn": "arn:aws:iam::000000000000:role/my-role"},
+		"Target": {"Arn": "arn:aws:lambda:us-east-1:123456789012:function:my-fn", "RoleArn": "arn:aws:iam::123456789012:role/my-role"},
 		"FlexibleTimeWindow": {"Mode": "OFF"}
 	}`
 	resp := schedulerRequest(t, ts, http.MethodPost, "/schedules/update-test", createBody)
@@ -159,7 +159,7 @@ func TestScheduler_CreateDuplicate(t *testing.T) {
 
 	createBody := `{
 		"ScheduleExpression": "rate(1 hour)",
-		"Target": {"Arn": "arn:aws:sqs:us-east-1:000000000000:my-queue", "RoleArn": "arn:aws:iam::000000000000:role/my-role"},
+		"Target": {"Arn": "arn:aws:sqs:us-east-1:123456789012:my-queue", "RoleArn": "arn:aws:iam::123456789012:role/my-role"},
 		"FlexibleTimeWindow": {"Mode": "OFF"}
 	}`
 
@@ -177,7 +177,7 @@ func TestScheduler_ListSchedules(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 
-	target := `{"Arn": "arn:aws:lambda:us-east-1:000000000000:function:fn", "RoleArn": "arn:aws:iam::000000000000:role/role"}`
+	target := `{"Arn": "arn:aws:lambda:us-east-1:123456789012:function:fn", "RoleArn": "arn:aws:iam::123456789012:role/role"}`
 	ftw := `{"Mode": "OFF"}`
 
 	// Create 3 schedules: alpha-1, alpha-2, beta-1.
@@ -219,7 +219,7 @@ func TestScheduler_ListPagination(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 
-	target := `{"Arn": "arn:aws:lambda:us-east-1:000000000000:function:fn", "RoleArn": "arn:aws:iam::000000000000:role/role"}`
+	target := `{"Arn": "arn:aws:lambda:us-east-1:123456789012:function:fn", "RoleArn": "arn:aws:iam::123456789012:role/role"}`
 	ftw := `{"Mode": "OFF"}`
 
 	// Create 5 schedules.
@@ -282,7 +282,7 @@ func TestScheduler_TimestampFormat(t *testing.T) {
 
 	createBody := `{
 		"ScheduleExpression": "rate(1 hour)",
-		"Target": {"Arn": "arn:aws:lambda:us-east-1:000000000000:function:fn", "RoleArn": "arn:aws:iam::000000000000:role/r"},
+		"Target": {"Arn": "arn:aws:lambda:us-east-1:123456789012:function:fn", "RoleArn": "arn:aws:iam::123456789012:role/r"},
 		"FlexibleTimeWindow": {"Mode": "OFF"}
 	}`
 	resp := schedulerRequest(t, ts, http.MethodPost, "/schedules/ts-test", createBody)

--- a/emulator/server.go
+++ b/emulator/server.go
@@ -598,6 +598,14 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// [ParseAWSRequest] is pure and has no configuration to read, so it fills in
+	// [defaultAccountID]; the configured account, if any, is the server's answer.
+	// Step 1.5 below may still override it from a credential registry or an STS
+	// session, both of which know more than a config file does.
+	if s.config.Account.Default != "" {
+		reqCtx.AccountID = s.config.Account.Default
+	}
+
 	// Assign body. For S3 and other REST-protocol services rawBody holds the
 	// full binary payload. For query-protocol services (IAM, STS) ParseAWSRequest
 	// consumes the form body; we rebuild req.Body as JSON from the parsed params.
@@ -659,10 +667,10 @@ func (s *Server) handleAWSRequest(w http.ResponseWriter, r *http.Request) {
 		if principal, sessionAccount := resolvePrincipal(ctx, s.state, reqCtx.AccountID, accessKey); principal != nil {
 			reqCtx.Principal = principal
 			// An STS session names the account it was issued for. Adopt it unless
-			// the registry already spoke: parser.extractAccount recognizes only an
-			// AKIA prefix as substrate's test account, so an ASIA session key was
-			// otherwise filed under the fallback account — a different partition
-			// from the resources the role's caller had just created.
+			// the registry already spoke: the session record is the only thing that
+			// knows which account a temporary credential belongs to, and it may
+			// differ from the configured default — an AssumeRole across accounts is
+			// the case that matters.
 			if sessionAccount != "" && !registryHit {
 				reqCtx.AccountID = sessionAccount
 			}

--- a/emulator/servicequotas_plugin.go
+++ b/emulator/servicequotas_plugin.go
@@ -71,14 +71,14 @@ func (p *ServiceQuotasPlugin) HandleRequest(reqCtx *RequestContext, req *AWSRequ
 
 // sqAccountID returns the account a quota-increase record belongs to.
 //
-// A nil context, or one carrying no account, falls back to the same placeholder
-// every increase used to be filed under (#624). That is not a guess about the
-// caller: it is the account substrate's own parser assigns a request it cannot
-// attribute, so a plugin driven directly by a unit test keeps landing where it
-// always did rather than under "".
+// A nil context, or one carrying no account, falls back to the account substrate
+// attributes an unconfigured request to (#624). That is not a guess about the
+// caller: it is what every request off the wire resolves to, so a plugin driven
+// directly by a unit test files its increase where an HTTP caller would rather
+// than under "".
 func sqAccountID(reqCtx *RequestContext) string {
 	if reqCtx == nil || reqCtx.AccountID == "" {
-		return fallbackAccountID
+		return defaultAccountID
 	}
 	return reqCtx.AccountID
 }

--- a/emulator/signed_request_test.go
+++ b/emulator/signed_request_test.go
@@ -17,16 +17,28 @@ import (
 
 // This file holds the shared machinery for a test that needs to be *a particular
 // account*. It exists because most of substrate's tests cannot be: they send no
-// Authorization header, and extractAccount answers 000000000000 for a request
-// without one and 123456789012 for any AKIA-prefixed key. So every caller in them
-// is the same caller, which is why both #623 and #624 — two different services
-// answering as if there were only ever one account — survived a green suite.
+// Authorization header, and a request that names no credential the server knows
+// resolves to the one default account (#734). So every caller in them is the same
+// caller, which is why both #623 and #624 — two different services answering as if
+// there were only ever one account — survived a green suite.
+//
+// Substrate used to hand out a second account for free, to any request whose access
+// key did not start with "AKIA", and a handful of tests used that as their way of
+// being two callers. It was never a second account in any sense a consumer could
+// rely on — nothing on the wire names an account — so those tests now sign, like
+// these ones.
 //
 // Reaching a second identity means a CredentialRegistry, and a registry is also
 // what switches SigV4 verification on, so these requests carry real signatures.
 // The signing algorithm is reimplemented here rather than called into the
 // emulator, so a mistake in substrate's own signing cannot make a test pass by
 // agreeing with it.
+
+// sigV4TestDateTime is the instant every signature in the suite is computed at. It
+// is fixed rather than time.Now because the signature covers the date, and a test
+// that depends on the wall clock is exactly what CLAUDE.md forbids. Substrate does
+// not check a signature's age, so an instant in the past signs as well as any.
+const sigV4TestDateTime = "20260101T120000Z"
 
 // signedRequestTarget names the wire details of one service's JSON-target
 // endpoint, so a signed request can be built for it.
@@ -65,10 +77,6 @@ func signedRequest(t *testing.T, ts *emulator.TestServer, tgt signedRequestTarge
 		t.Fatalf("marshal %s: %v", op, err)
 	}
 
-	// A fixed instant rather than time.Now: the signature covers the date, and a
-	// test that depends on the wall clock is exactly what CLAUDE.md forbids.
-	const dateTime = "20260101T120000Z"
-
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/", bytes.NewReader(data))
 	if err != nil {
 		t.Fatalf("build %s request: %v", op, err)
@@ -76,9 +84,10 @@ func signedRequest(t *testing.T, ts *emulator.TestServer, tgt signedRequestTarge
 	req.Host = tgt.host
 	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
 	req.Header.Set("X-Amz-Target", tgt.target+"."+op)
-	req.Header.Set("X-Amz-Date", dateTime)
+	req.Header.Set("X-Amz-Date", sigV4TestDateTime)
 	req.Header.Set("Authorization", sigV4Header(
-		"/", tgt.host, tgt.signingName, dateTime, data, creds.AccessKeyID, creds.SecretAccessKey))
+		http.MethodPost, "/", tgt.host, tgt.signingName, "us-east-1", sigV4TestDateTime, data,
+		creds.AccessKeyID, creds.SecretAccessKey))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -87,23 +96,25 @@ func signedRequest(t *testing.T, ts *emulator.TestServer, tgt signedRequestTarge
 	return resp
 }
 
-// sigV4Header computes a valid SigV4 Authorization header for a POST to path with
-// the host and x-amz-date headers signed.
+// sigV4Header computes a valid SigV4 Authorization header for a request to path
+// with the host and x-amz-date headers signed.
 //
-// path is a parameter because a rest-json service carries its operation in the URL
-// — the account service posts to /listRegions and the like — and the canonical
-// request covers the path, so signing "/" for a request sent elsewhere produces a
-// signature the server correctly refuses.
-func sigV4Header(path, host, signingName, dateTime string, body []byte, accessKey, secretKey string) string {
-	const (
-		region        = "us-east-1"
-		signedHeaders = "host;x-amz-date"
-	)
+// method and path are parameters because both are covered by the canonical request:
+// a rest-json service carries its operation in the URL — the account service posts
+// to /listRegions and the like — and S3 addresses a bucket with a HEAD. Signing "/"
+// or POST for a request sent otherwise produces a signature the server correctly
+// refuses.
+//
+// region is a parameter for the same reason it is part of the credential scope: the
+// parser reads the Region off the scope, so a test asserting on a Region other than
+// us-east-1 has to sign for it.
+func sigV4Header(method, path, host, signingName, region, dateTime string, body []byte, accessKey, secretKey string) string {
+	const signedHeaders = "host;x-amz-date"
 	date := dateTime[:8]
 
 	bodyHash := sha256.Sum256(body)
 	canonicalReq := strings.Join([]string{
-		http.MethodPost,
+		method,
 		path,
 		"",
 		"host:" + host + "\n" + "x-amz-date:" + dateTime + "\n",
@@ -126,6 +137,38 @@ func sigV4Header(path, host, signingName, dateTime string, body []byte, accessKe
 
 	return fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
 		accessKey, credScope, signedHeaders, hex.EncodeToString(mac(signing, []byte(stringToSign))))
+}
+
+// signAs sets the Authorization and X-Amz-Date headers on req so the server
+// attributes it to creds' account, for a test that builds its own request rather
+// than going through [signedRequest].
+//
+// A zero creds leaves req unsigned, which is how a test asks to be the server's
+// default account: [emulator.VerifySigV4] passes a request carrying no
+// Authorization header, so an unsigned request reaches its plugin even against a
+// server with a credential registry wired.
+func signAs(req *http.Request, creds emulator.CredentialEntry, signingName, region string, body []byte) {
+	if creds.AccessKeyID == "" {
+		return
+	}
+	req.Header.Set("X-Amz-Date", sigV4TestDateTime)
+	req.Header.Set("Authorization", sigV4Header(req.Method, req.URL.Path, req.Host, signingName,
+		region, sigV4TestDateTime, body, creds.AccessKeyID, creds.SecretAccessKey))
+}
+
+// testCredentialsFor derives a signing credential for an account the same way
+// [emulator.TestServer.RegisterAccount] does, for a test that builds its own server
+// and registry rather than using [emulator.StartTestServerWithAccounts].
+//
+// The derivation is duplicated rather than exported because it is a convention, not
+// a contract: what matters is that the key is 20 uppercase alphanumerics, which is
+// what an AWS access key ID is and what resolvePrincipal will accept.
+func testCredentialsFor(accountID string) emulator.CredentialEntry {
+	return emulator.CredentialEntry{
+		AccessKeyID:     "AKIA" + accountID + "TEST",
+		SecretAccessKey: "substrate-secret-" + accountID,
+		AccountID:       accountID,
+	}
 }
 
 // decodeAWSResponse decodes a JSON-protocol response into out, returning the

--- a/emulator/sns_plugin_test.go
+++ b/emulator/sns_plugin_test.go
@@ -78,7 +78,7 @@ func TestSNSPlugin_CreateTopic(t *testing.T) {
 	})
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body := readSNSBody(t, resp)
-	assert.Contains(t, body, "arn:aws:sns:us-east-1:000000000000:my-topic")
+	assert.Contains(t, body, "arn:aws:sns:us-east-1:123456789012:my-topic")
 
 	// Idempotent create — same ARN returned.
 	resp2 := snsRequest(t, srv, map[string]string{
@@ -87,7 +87,7 @@ func TestSNSPlugin_CreateTopic(t *testing.T) {
 	})
 	assert.Equal(t, http.StatusOK, resp2.StatusCode)
 	body2 := readSNSBody(t, resp2)
-	assert.Contains(t, body2, "arn:aws:sns:us-east-1:000000000000:my-topic")
+	assert.Contains(t, body2, "arn:aws:sns:us-east-1:123456789012:my-topic")
 }
 
 func TestSNSPlugin_DeleteTopic(t *testing.T) {
@@ -103,7 +103,7 @@ func TestSNSPlugin_DeleteTopic(t *testing.T) {
 	// Delete topic.
 	resp2 := snsRequest(t, srv, map[string]string{
 		"Action":   "DeleteTopic",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:delete-me",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:delete-me",
 	})
 	assert.Equal(t, http.StatusOK, resp2.StatusCode)
 
@@ -127,9 +127,9 @@ func TestSNSPlugin_Subscribe(t *testing.T) {
 	// Subscribe with SQS protocol.
 	resp := snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:sub-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:sub-topic",
 		"Protocol": "sqs",
-		"Endpoint": "https://sqs.us-east-1.amazonaws.com/000000000000/my-queue",
+		"Endpoint": "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
 	})
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body := readSNSBody(t, resp)
@@ -147,9 +147,9 @@ func TestSNSPlugin_Unsubscribe(t *testing.T) {
 
 	subResp := snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:unsub-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:unsub-topic",
 		"Protocol": "sqs",
-		"Endpoint": "https://sqs.us-east-1.amazonaws.com/000000000000/my-queue",
+		"Endpoint": "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
 	})
 	assert.Equal(t, http.StatusOK, subResp.StatusCode)
 	subBody := readSNSBody(t, subResp)
@@ -197,15 +197,15 @@ func TestSNSPlugin_ListSubscriptions(t *testing.T) {
 	})
 	snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:list-sub-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:list-sub-topic",
 		"Protocol": "sqs",
-		"Endpoint": "https://sqs.us-east-1.amazonaws.com/000000000000/q1",
+		"Endpoint": "https://sqs.us-east-1.amazonaws.com/123456789012/q1",
 	})
 	snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:list-sub-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:list-sub-topic",
 		"Protocol": "sqs",
-		"Endpoint": "https://sqs.us-east-1.amazonaws.com/000000000000/q2",
+		"Endpoint": "https://sqs.us-east-1.amazonaws.com/123456789012/q2",
 	})
 
 	resp := snsRequest(t, srv, map[string]string{
@@ -227,7 +227,7 @@ func TestSNSPlugin_Publish(t *testing.T) {
 	// Publish without subscribers — should succeed.
 	resp := snsRequest(t, srv, map[string]string{
 		"Action":   "Publish",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:publish-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:publish-topic",
 		"Message":  "hello world",
 	})
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -246,7 +246,7 @@ func TestSNSPlugin_TagResource_ListTagsForResource(t *testing.T) {
 	// Tag the topic.
 	resp := snsRequest(t, srv, map[string]string{
 		"Action":              "TagResource",
-		"ResourceArn":         "arn:aws:sns:us-east-1:000000000000:tagged-topic",
+		"ResourceArn":         "arn:aws:sns:us-east-1:123456789012:tagged-topic",
 		"Tags.member.1.Key":   "Env",
 		"Tags.member.1.Value": "test",
 	})
@@ -255,7 +255,7 @@ func TestSNSPlugin_TagResource_ListTagsForResource(t *testing.T) {
 	// List tags.
 	resp2 := snsRequest(t, srv, map[string]string{
 		"Action":      "ListTagsForResource",
-		"ResourceArn": "arn:aws:sns:us-east-1:000000000000:tagged-topic",
+		"ResourceArn": "arn:aws:sns:us-east-1:123456789012:tagged-topic",
 	})
 	assert.Equal(t, http.StatusOK, resp2.StatusCode)
 	body2 := readSNSBody(t, resp2)
@@ -297,12 +297,12 @@ func TestSNS_Publish_SQSEnvelope(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, resp2.StatusCode)
 
-	queueURL := "http://sqs.us-east-1.amazonaws.com/000000000000/envelope-queue"
+	queueURL := "http://sqs.us-east-1.amazonaws.com/123456789012/envelope-queue"
 
 	// Subscribe SQS to topic.
 	resp3 := snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:envelope-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:envelope-topic",
 		"Protocol": "sqs",
 		"Endpoint": queueURL,
 	})
@@ -311,7 +311,7 @@ func TestSNS_Publish_SQSEnvelope(t *testing.T) {
 	// Publish message.
 	resp4 := snsRequest(t, srv, map[string]string{
 		"Action":   "Publish",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:envelope-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:envelope-topic",
 		"Message":  "hello from sns",
 		"Subject":  "Test Subject",
 	})
@@ -373,7 +373,7 @@ func TestSNS_Publish_HTTPEndpoint(t *testing.T) {
 	// Subscribe HTTP endpoint.
 	resp2 := snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:http-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:http-topic",
 		"Protocol": "http",
 		"Endpoint": endpoint.URL,
 	})
@@ -382,7 +382,7 @@ func TestSNS_Publish_HTTPEndpoint(t *testing.T) {
 	// Publish message.
 	resp3 := snsRequest(t, srv, map[string]string{
 		"Action":   "Publish",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:http-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:http-topic",
 		"Message":  "hello http",
 		"Subject":  "HTTP Test",
 	})
@@ -436,40 +436,40 @@ func TestSNS_Publish_FilterPolicy(t *testing.T) {
 	resp2 := sqsRequestViaSNSServer(t, srv, map[string]string{"Action": "CreateQueue", "QueueName": "filter-queue"})
 	require.Equal(t, http.StatusOK, resp2.StatusCode)
 
-	queueURL := "http://sqs.us-east-1.amazonaws.com/000000000000/filter-queue"
+	queueURL := "http://sqs.us-east-1.amazonaws.com/123456789012/filter-queue"
 
 	// Subscribe with filter policy. We need to seed the filter policy directly
 	// into state since SetSubscriptionAttributes is not yet integrated.
 	resp3 := snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:filter-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:filter-topic",
 		"Protocol": "sqs",
 		"Endpoint": queueURL,
 	})
 	require.Equal(t, http.StatusOK, resp3.StatusCode)
 
 	// Seed filter policy directly into state on the subscription.
-	subKeys, _ := state.List(context.Background(), "sns", "sub_ids:000000000000/us-east-1/filter-topic")
+	subKeys, _ := state.List(context.Background(), "sns", "sub_ids:123456789012/us-east-1/filter-topic")
 	require.NotEmpty(t, subKeys)
 
 	// Load subscription IDs.
-	subIDsData, _ := state.Get(context.Background(), "sns", "sub_ids:000000000000/us-east-1/filter-topic")
+	subIDsData, _ := state.Get(context.Background(), "sns", "sub_ids:123456789012/us-east-1/filter-topic")
 	var subIDs []string
 	require.NoError(t, json.Unmarshal(subIDsData, &subIDs))
 	require.Len(t, subIDs, 1)
 
 	// Load subscription, add filter policy, save.
-	subData, _ := state.Get(context.Background(), "sns", "subscription:000000000000/us-east-1/"+subIDs[0])
+	subData, _ := state.Get(context.Background(), "sns", "subscription:123456789012/us-east-1/"+subIDs[0])
 	var sub emulator.SNSSubscription
 	require.NoError(t, json.Unmarshal(subData, &sub))
 	sub.FilterPolicy = map[string]interface{}{"color": []interface{}{"red", "blue"}}
 	updated, _ := json.Marshal(sub)
-	require.NoError(t, state.Put(context.Background(), "sns", "subscription:000000000000/us-east-1/"+subIDs[0], updated))
+	require.NoError(t, state.Put(context.Background(), "sns", "subscription:123456789012/us-east-1/"+subIDs[0], updated))
 
 	// Publish matching message (color=red) → should be delivered.
 	resp4 := snsRequest(t, srv, map[string]string{
 		"Action":                         "Publish",
-		"TopicArn":                       "arn:aws:sns:us-east-1:000000000000:filter-topic",
+		"TopicArn":                       "arn:aws:sns:us-east-1:123456789012:filter-topic",
 		"Message":                        "red message",
 		"MessageAttributes.entry.1.Name": "color",
 		"MessageAttributes.entry.1.Value.DataType":    "String",
@@ -480,7 +480,7 @@ func TestSNS_Publish_FilterPolicy(t *testing.T) {
 	// Publish non-matching message (color=green) → should NOT be delivered.
 	resp5 := snsRequest(t, srv, map[string]string{
 		"Action":                         "Publish",
-		"TopicArn":                       "arn:aws:sns:us-east-1:000000000000:filter-topic",
+		"TopicArn":                       "arn:aws:sns:us-east-1:123456789012:filter-topic",
 		"Message":                        "green message",
 		"MessageAttributes.entry.1.Name": "color",
 		"MessageAttributes.entry.1.Value.DataType":    "String",

--- a/emulator/sqs_consistency_test.go
+++ b/emulator/sqs_consistency_test.go
@@ -51,7 +51,7 @@ func createSQSQueue(t *testing.T, srv *emulator.Server, name string) string {
 	resp := sqsRequest(t, srv, map[string]string{"Action": "CreateQueue", "QueueName": name})
 	defer resp.Body.Close() //nolint:errcheck
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	return "http://sqs.us-east-1.localhost/000000000000/" + name
+	return "http://sqs.us-east-1.localhost/123456789012/" + name
 }
 
 // sqsErrorCode returns the response status and the error code from an SQS error
@@ -667,8 +667,8 @@ func TestSQS_QueueNameFromURL(t *testing.T) {
 		url  string
 		want string
 	}{
-		{"standard", "http://sqs.us-east-1.localhost/000000000000/my-q", "my-q"},
-		{"trailing slash", "http://sqs.us-east-1.localhost/000000000000/my-q/", "my-q"},
+		{"standard", "http://sqs.us-east-1.localhost/123456789012/my-q", "my-q"},
+		{"trailing slash", "http://sqs.us-east-1.localhost/123456789012/my-q/", "my-q"},
 		{"bare name, no separator", "my-q", "my-q"},
 		{"empty", "", ""},
 	}

--- a/emulator/sqs_createqueue_test.go
+++ b/emulator/sqs_createqueue_test.go
@@ -457,7 +457,7 @@ func TestSQS_CreateQueue_DeletedRecentlyCounterIsIndependent(t *testing.T) {
 	assert.Equal(t, http.StatusOK, status, "an unseeded lookup must not consume the create budget")
 
 	// ...and the create budget is still intact once the name is free.
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/indep-create-q"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/indep-create-q"
 	resp := sqsRequest(t, srv, map[string]string{"Action": "DeleteQueue", "QueueUrl": queueURL})
 	resp.Body.Close() //nolint:errcheck
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -513,7 +513,7 @@ func TestSQS_CreateQueue_DeletedRecentlyStateFailure(t *testing.T) {
 // presence.
 func sqsQueueAttribute(t *testing.T, srv *emulator.Server, name, attr string, jsonProto bool) string {
 	t.Helper()
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/" + name
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/" + name
 	if jsonProto {
 		resp := sqsJSONRequest(t, srv, "GetQueueAttributes", map[string]interface{}{
 			"QueueUrl":       queueURL,

--- a/emulator/sqs_messageattributes_test.go
+++ b/emulator/sqs_messageattributes_test.go
@@ -209,7 +209,7 @@ func createAttrQueue(t *testing.T, srv *emulator.Server, name string) string {
 	t.Helper()
 	status, code := createQueueWithAttrs(t, srv, name, nil, false)
 	require.Equal(t, http.StatusOK, status, "create failed: %s", code)
-	return "http://sqs.us-east-1.localhost/000000000000/" + name
+	return "http://sqs.us-east-1.localhost/123456789012/" + name
 }
 
 // TestSQS_MessageAttributes_KnownGoodDigests is #461's "verified against a known-good
@@ -662,7 +662,7 @@ func TestSQS_MessageAttributes_FifoDedupReportsThisRequestsDigest(t *testing.T) 
 	status, code := createQueueWithAttrs(t, srv, "attr-dedup.fifo",
 		map[string]string{"FifoQueue": "true"}, false)
 	require.Equal(t, http.StatusOK, status, "create failed: %s", code)
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/attr-dedup.fifo"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/attr-dedup.fifo"
 
 	send := func(attrs []sqsMessageAttr) string {
 		t.Helper()

--- a/emulator/sqs_messageattrrules_test.go
+++ b/emulator/sqs_messageattrrules_test.go
@@ -578,7 +578,7 @@ func TestSQS_MessageAttributes_FifoRejectionPrecedesDedup(t *testing.T) {
 	status, code := createQueueWithAttrs(t, srv, "attr-rules.fifo",
 		map[string]string{"FifoQueue": "true"}, false)
 	require.Equal(t, http.StatusOK, status, "create failed: %s", code)
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/attr-rules.fifo"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/attr-rules.fifo"
 
 	send := func(attrName string) *http.Response {
 		t.Helper()
@@ -787,7 +787,7 @@ func storeIllegalAttributes(t *testing.T, state emulator.StateManager, queueName
 ) string {
 	t.Helper()
 	ctx := context.Background()
-	urlKey := "000000000000/" + queueName
+	urlKey := "123456789012/" + queueName
 
 	idsRaw, err := state.Get(ctx, "sqs", "msg_ids:"+urlKey)
 	require.NoError(t, err)

--- a/emulator/sqs_messagesize_test.go
+++ b/emulator/sqs_messagesize_test.go
@@ -139,7 +139,7 @@ func createSizedQueue(t *testing.T, srv *emulator.Server, name, maxSize string) 
 	status, code := createQueueWithAttrs(t, srv, name,
 		map[string]string{"MaximumMessageSize": maxSize}, false)
 	require.Equal(t, http.StatusOK, status, "create failed: %s", code)
-	return "http://sqs.us-east-1.localhost/000000000000/" + name
+	return "http://sqs.us-east-1.localhost/123456789012/" + name
 }
 
 // TestSQS_SendMessage_EnforcesMaximumMessageSize is #454. No length check existed
@@ -418,7 +418,7 @@ func TestSQS_SendMessage_FifoQueueEnforcesBeforeDedup(t *testing.T) {
 		"FifoQueue": "true", "MaximumMessageSize": "1024",
 	}, false)
 	require.Equal(t, http.StatusOK, status, code)
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/size-q.fifo"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/size-q.fifo"
 
 	send := func(body string) (int, string) {
 		return sqsErrorCode(t, sqsRequest(t, srv, map[string]string{

--- a/emulator/sqs_plugin_test.go
+++ b/emulator/sqs_plugin_test.go
@@ -90,8 +90,8 @@ func TestSQSPlugin_CreateGetDelete(t *testing.T) {
 	body2 := readBody(t, resp2)
 	assert.Contains(t, body2, "test-queue")
 
-	// Delete queue (account "000000000000" = fallback when no auth header).
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/test-queue"
+	// Delete queue (account "123456789012" = fallback when no auth header).
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/test-queue"
 	resp3 := sqsRequest(t, srv, map[string]string{
 		"Action":   "DeleteQueue",
 		"QueueUrl": queueURL,
@@ -109,7 +109,7 @@ func TestSQSPlugin_CreateGetDelete(t *testing.T) {
 func TestSQSPlugin_SendReceiveDelete(t *testing.T) {
 	srv, _ := newSQSTestServer(t)
 
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/msg-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/msg-queue"
 
 	// Create queue.
 	sqsRequest(t, srv, map[string]string{
@@ -174,7 +174,7 @@ func TestSQSPlugin_SendReceiveDelete(t *testing.T) {
 func TestSQSPlugin_VisibilityTimeout(t *testing.T) {
 	srv, tc := newSQSTestServer(t)
 
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/vis-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/vis-queue"
 
 	sqsRequest(t, srv, map[string]string{
 		"Action":    "CreateQueue",
@@ -222,7 +222,7 @@ func TestSQSPlugin_VisibilityTimeout(t *testing.T) {
 func TestSQSPlugin_ReceiveMessage_DelaySeconds(t *testing.T) {
 	srv, tc := newSQSTestServer(t)
 
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/delay-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/delay-queue"
 
 	sqsRequest(t, srv, map[string]string{
 		"Action":    "CreateQueue",
@@ -292,7 +292,7 @@ func TestSQSPlugin_ListQueues(t *testing.T) {
 func TestSQSPlugin_SendMessageBatch(t *testing.T) {
 	srv, _ := newSQSTestServer(t)
 
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/batch-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/batch-queue"
 
 	sqsRequest(t, srv, map[string]string{
 		"Action":    "CreateQueue",
@@ -327,7 +327,7 @@ func TestSQSPlugin_SendMessageBatch(t *testing.T) {
 func TestSQSPlugin_PurgeQueue(t *testing.T) {
 	srv, _ := newSQSTestServer(t)
 
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/purge-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/purge-queue"
 
 	sqsRequest(t, srv, map[string]string{
 		"Action":    "CreateQueue",
@@ -369,7 +369,7 @@ func TestSQSPlugin_GetQueueAttributes(t *testing.T) {
 		"QueueName": "attrs-queue",
 	})
 
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/attrs-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/attrs-queue"
 	resp := sqsRequest(t, srv, map[string]string{
 		"Action":   "GetQueueAttributes",
 		"QueueUrl": queueURL,
@@ -383,7 +383,7 @@ func TestSQSPlugin_GetQueueAttributes(t *testing.T) {
 func TestSQSPlugin_ChangeMessageVisibility(t *testing.T) {
 	srv, _ := newSQSTestServer(t)
 
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/cmv-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/cmv-queue"
 	sqsRequest(t, srv, map[string]string{
 		"Action":    "CreateQueue",
 		"QueueName": "cmv-queue",
@@ -439,7 +439,7 @@ func TestSQSPlugin_TagUntagListTags(t *testing.T) {
 		"Action":    "CreateQueue",
 		"QueueName": "tag-queue",
 	})
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/tag-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/tag-queue"
 
 	// Tag the queue.
 	sqsRequest(t, srv, map[string]string{
@@ -478,7 +478,7 @@ func TestSQSPlugin_TagUntagListTags(t *testing.T) {
 func TestSQSPlugin_DeleteMessageBatch(t *testing.T) {
 	srv, _ := newSQSTestServer(t)
 
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/dmbatch-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/dmbatch-queue"
 	sqsRequest(t, srv, map[string]string{
 		"Action":    "CreateQueue",
 		"QueueName": "dmbatch-queue",
@@ -534,7 +534,7 @@ func TestSQSPlugin_SetQueueAttributes(t *testing.T) {
 		"Action":    "CreateQueue",
 		"QueueName": "setattr-queue",
 	})
-	queueURL := "http://sqs.us-east-1.localhost/000000000000/setattr-queue"
+	queueURL := "http://sqs.us-east-1.localhost/123456789012/setattr-queue"
 
 	// Set VisibilityTimeout to 60.
 	resp := sqsRequest(t, srv, map[string]string{
@@ -628,7 +628,7 @@ func TestSQSPlugin_JSON_GetQueueAttributes(t *testing.T) {
 	sqsJSONRequest(t, srv, "CreateQueue", map[string]interface{}{
 		"QueueName": "attrs-json-queue",
 	})
-	qURL := "http://sqs.us-east-1.localhost/000000000000/attrs-json-queue"
+	qURL := "http://sqs.us-east-1.localhost/123456789012/attrs-json-queue"
 
 	resp := sqsJSONRequest(t, srv, "GetQueueAttributes", map[string]interface{}{
 		"QueueUrl":       qURL,
@@ -648,7 +648,7 @@ func TestSQSPlugin_JSON_SetQueueAttributes(t *testing.T) {
 	sqsJSONRequest(t, srv, "CreateQueue", map[string]interface{}{
 		"QueueName": "setattr-json-queue",
 	})
-	qURL := "http://sqs.us-east-1.localhost/000000000000/setattr-json-queue"
+	qURL := "http://sqs.us-east-1.localhost/123456789012/setattr-json-queue"
 
 	resp := sqsJSONRequest(t, srv, "SetQueueAttributes", map[string]interface{}{
 		"QueueUrl":   qURL,
@@ -670,7 +670,7 @@ func TestSQSPlugin_JSON_SendReceiveDeleteMessage(t *testing.T) {
 	sqsJSONRequest(t, srv, "CreateQueue", map[string]interface{}{
 		"QueueName": "msg-json-queue",
 	})
-	qURL := "http://sqs.us-east-1.localhost/000000000000/msg-json-queue"
+	qURL := "http://sqs.us-east-1.localhost/123456789012/msg-json-queue"
 
 	// Send message.
 	resp := sqsJSONRequest(t, srv, "SendMessage", map[string]interface{}{
@@ -718,7 +718,7 @@ func TestSQSPlugin_JSON_ReceiveMessage_Empty(t *testing.T) {
 	sqsJSONRequest(t, srv, "CreateQueue", map[string]interface{}{
 		"QueueName": "empty-json-queue",
 	})
-	qURL := "http://sqs.us-east-1.localhost/000000000000/empty-json-queue"
+	qURL := "http://sqs.us-east-1.localhost/123456789012/empty-json-queue"
 
 	resp := sqsJSONRequest(t, srv, "ReceiveMessage", map[string]interface{}{
 		"QueueUrl":            qURL,
@@ -768,7 +768,7 @@ func TestSQSPlugin_JSON_PurgeQueue(t *testing.T) {
 	sqsJSONRequest(t, srv, "CreateQueue", map[string]interface{}{
 		"QueueName": "purge-json-queue",
 	})
-	qURL := "http://sqs.us-east-1.localhost/000000000000/purge-json-queue"
+	qURL := "http://sqs.us-east-1.localhost/123456789012/purge-json-queue"
 
 	for i := 0; i < 3; i++ {
 		sqsJSONRequest(t, srv, "SendMessage", map[string]interface{}{
@@ -796,7 +796,7 @@ func TestSQSPlugin_JSON_SendMessageBatch(t *testing.T) {
 	sqsJSONRequest(t, srv, "CreateQueue", map[string]interface{}{
 		"QueueName": "batch-json-queue",
 	})
-	qURL := "http://sqs.us-east-1.localhost/000000000000/batch-json-queue"
+	qURL := "http://sqs.us-east-1.localhost/123456789012/batch-json-queue"
 
 	resp := sqsJSONRequest(t, srv, "SendMessageBatch", map[string]interface{}{
 		"QueueUrl": qURL,
@@ -825,7 +825,7 @@ func TestSQSPlugin_JSON_TagUntagListQueueTags(t *testing.T) {
 	sqsJSONRequest(t, srv, "CreateQueue", map[string]interface{}{
 		"QueueName": "tag-json-queue",
 	})
-	qURL := "http://sqs.us-east-1.localhost/000000000000/tag-json-queue"
+	qURL := "http://sqs.us-east-1.localhost/123456789012/tag-json-queue"
 
 	// Tag the queue.
 	resp := sqsJSONRequest(t, srv, "TagQueue", map[string]interface{}{
@@ -866,7 +866,7 @@ func TestSQSPlugin_JSON_ChangeMessageVisibility(t *testing.T) {
 	sqsJSONRequest(t, srv, "CreateQueue", map[string]interface{}{
 		"QueueName": "cmv-json-queue",
 	})
-	qURL := "http://sqs.us-east-1.localhost/000000000000/cmv-json-queue"
+	qURL := "http://sqs.us-east-1.localhost/123456789012/cmv-json-queue"
 
 	sqsJSONRequest(t, srv, "SendMessage", map[string]interface{}{
 		"QueueUrl":    qURL,
@@ -907,7 +907,7 @@ func TestSQSPlugin_JSON_Error_NonExistentQueue(t *testing.T) {
 	srv, _ := newSQSTestServer(t)
 
 	resp := sqsJSONRequest(t, srv, "SendMessage", map[string]interface{}{
-		"QueueUrl":    "http://sqs.us-east-1.localhost/000000000000/no-such-queue",
+		"QueueUrl":    "http://sqs.us-east-1.localhost/123456789012/no-such-queue",
 		"MessageBody": "test",
 	})
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
@@ -937,7 +937,7 @@ func TestSQSPlugin_JSON_Error_NonExistentQueue(t *testing.T) {
 // registered as errProtoJSONRPC. Both protocol rows therefore assert the same JSON
 // shape; that is deliberate, not an oversight.
 func TestSQS_QueueDoesNotExist_AllOperations(t *testing.T) {
-	const missingURL = "http://sqs.us-east-1.localhost/000000000000/no-such-queue"
+	const missingURL = "http://sqs.us-east-1.localhost/123456789012/no-such-queue"
 
 	// Each case names an operation and the minimum extra parameters it needs to
 	// reach the queue lookup.
@@ -996,7 +996,7 @@ func TestSQSPlugin_CrossProtocol(t *testing.T) {
 		"QueueName": "cross-queue",
 	})
 	require.Equal(t, http.StatusOK, respCreate.StatusCode)
-	qURL := "http://sqs.us-east-1.localhost/000000000000/cross-queue"
+	qURL := "http://sqs.us-east-1.localhost/123456789012/cross-queue"
 
 	// Send via query protocol.
 	sqsRequest(t, srv, map[string]string{

--- a/emulator/sts_plugin_test.go
+++ b/emulator/sts_plugin_test.go
@@ -148,7 +148,7 @@ func TestSTSPlugin_AssumeRole_Success(t *testing.T) {
 
 	now := tc.Now()
 	resp := stsRequest(t, srv, "AssumeRole", map[string]string{
-		"RoleArn":         "arn:aws:iam::000000000000:role/myrole",
+		"RoleArn":         "arn:aws:iam::123456789012:role/myrole",
 		"RoleSessionName": "test-session",
 		"DurationSeconds": "3600",
 	})
@@ -168,7 +168,7 @@ func TestSTSPlugin_AssumeRole_Success(t *testing.T) {
 func TestSTSPlugin_AssumeRole_RoleNotFound(t *testing.T) {
 	srv, _, _ := newSTSTestServer(t)
 	resp := stsRequest(t, srv, "AssumeRole", map[string]string{
-		"RoleArn":         "arn:aws:iam::000000000000:role/nonexistent",
+		"RoleArn":         "arn:aws:iam::123456789012:role/nonexistent",
 		"RoleSessionName": "session",
 	})
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -192,7 +192,7 @@ func TestSTSPlugin_AssumeRole_DurationTooShort(t *testing.T) {
 	srv.ServeHTTP(iamW, iamReq)
 
 	resp := stsRequest(t, srv, "AssumeRole", map[string]string{
-		"RoleArn":         "arn:aws:iam::000000000000:role/r",
+		"RoleArn":         "arn:aws:iam::123456789012:role/r",
 		"RoleSessionName": "session",
 		"DurationSeconds": "100", // < 900
 	})
@@ -208,7 +208,7 @@ func TestSTSPlugin_AssumeRole_DurationTooLong(t *testing.T) {
 	srv.ServeHTTP(iamW, iamReq)
 
 	resp := stsRequest(t, srv, "AssumeRole", map[string]string{
-		"RoleArn":         "arn:aws:iam::000000000000:role/r",
+		"RoleArn":         "arn:aws:iam::123456789012:role/r",
 		"RoleSessionName": "session",
 		"DurationSeconds": "99999", // > 43200
 	})

--- a/emulator/tagging_plugin_test.go
+++ b/emulator/tagging_plugin_test.go
@@ -333,7 +333,7 @@ func putTestSQSQueue(t *testing.T, state emulator.StateManager, name string, tag
 
 // taggingTestAccountID is the account ID used in tagging tests. Since the test
 // server has no auth configured, ParseAWSRequest resolves to fallbackAccountID.
-const taggingTestAccountID = "000000000000"
+const taggingTestAccountID = "123456789012"
 
 // putTestDynamoDBTable pre-populates state with a DynamoDB table.
 func putTestDynamoDBTable(t *testing.T, state emulator.StateManager, name string, tags map[string]string) {

--- a/emulator/testing.go
+++ b/emulator/testing.go
@@ -50,8 +50,8 @@ func (ts *TestServer) Registry() *PluginRegistry { return ts.registry }
 // returns.
 //
 // No [CredentialRegistry] is wired, so SigV4 signatures are not verified and any
-// access key is accepted: an AKIA-prefixed one resolves to account 123456789012
-// and everything else to 000000000000. Use [StartTestServerWithAccounts] when a
+// access key is accepted — every one of them, and an unsigned request too,
+// resolving to account 123456789012. Use [StartTestServerWithAccounts] when a
 // test needs to call as more than one account.
 func StartTestServer(t *testing.T) *TestServer {
 	t.Helper()
@@ -191,8 +191,8 @@ func startTestServer(t testing.TB, creds *CredentialRegistry) *TestServer {
 // The access key and secret are derived from the account ID rather than generated,
 // so a recorded run replays with the same credentials in it. AWS access key IDs are
 // 20 characters of uppercase alphanumerics; a 12-digit account ID padded after
-// "AKIA" fits exactly, which keeps the key one that resolvePrincipal and
-// extractAccount both recognize.
+// "AKIA" fits exactly, which keeps the key one that [VerifySigV4] and
+// resolvePrincipal both accept.
 func (ts *TestServer) RegisterAccount(t testing.TB, accountID string) CredentialEntry {
 	t.Helper()
 	if ts.creds == nil {
@@ -256,10 +256,6 @@ func (ts *TestServer) SetScale(scale float64) {
 	ts.tc.SetScale(scale)
 }
 
-// seedSSMAccountID is the AWS account ID used for seeded SSM parameters.
-// It matches the account that the built-in test key AKIATEST12345678901 maps to.
-const seedSSMAccountID = "123456789012"
-
 // seedSSMRegion is the default AWS region used for seeded SSM parameters.
 const seedSSMRegion = "us-east-1"
 
@@ -289,19 +285,19 @@ func (ts *TestServer) SeedSSMParameter(name, value string) {
 		Value:            value,
 		Version:          1,
 		LastModifiedDate: ts.tc.Now(),
-		AccountID:        seedSSMAccountID,
+		AccountID:        defaultAccountID,
 		Region:           seedSSMRegion,
-		ARN:              ssmParameterARN(seedSSMRegion, seedSSMAccountID, name),
+		ARN:              ssmParameterARN(seedSSMRegion, defaultAccountID, name),
 	}
 	data, err := json.Marshal(param)
 	if err != nil {
 		return
 	}
-	stateKey := "parameter:" + seedSSMAccountID + "/" + seedSSMRegion + "/" + name
+	stateKey := "parameter:" + defaultAccountID + "/" + seedSSMRegion + "/" + name
 	_ = ts.state.Put(ctx, ssmNamespace, stateKey, data)
 
 	// Update the paths index.
-	pathsKey := "parameter_paths:" + seedSSMAccountID + "/" + seedSSMRegion
+	pathsKey := "parameter_paths:" + defaultAccountID + "/" + seedSSMRegion
 	existing, _ := ts.state.Get(ctx, ssmNamespace, pathsKey)
 	var paths []string
 	if existing != nil {

--- a/emulator/v016_extra_test.go
+++ b/emulator/v016_extra_test.go
@@ -232,7 +232,7 @@ func TestCFN_SNSSubscription(t *testing.T) {
 				"Properties": {
 					"TopicArn": {"Fn::GetAtt": ["MyTopic", "TopicArn"]},
 					"Protocol": "sqs",
-					"Endpoint": "https://sqs.us-east-1.amazonaws.com/000000000000/sub-cfn-queue"
+					"Endpoint": "https://sqs.us-east-1.amazonaws.com/123456789012/sub-cfn-queue"
 				}
 			}
 		}
@@ -327,7 +327,7 @@ func TestCFN_KMSReplicaKey(t *testing.T) {
 			"MyReplicaKey": {
 				"Type": "AWS::KMS::ReplicaKey",
 				"Properties": {
-					"PrimaryKeyArn": "arn:aws:kms:us-east-1:000000000000:key/stub",
+					"PrimaryKeyArn": "arn:aws:kms:us-east-1:123456789012:key/stub",
 					"Description": "Replica key"
 				}
 			}
@@ -607,7 +607,7 @@ func TestSNSPlugin_PublishBatch(t *testing.T) {
 		"Action": "CreateTopic",
 		"Name":   "batch-topic",
 	})
-	topicARN := "arn:aws:sns:us-east-1:000000000000:batch-topic"
+	topicARN := "arn:aws:sns:us-east-1:123456789012:batch-topic"
 
 	resp := snsRequest(t, srv, map[string]string{
 		"Action":                                 "PublishBatch",
@@ -663,14 +663,14 @@ func TestSNSPlugin_DispatchToSubscriber(t *testing.T) {
 		"Action": "CreateTopic",
 		"Name":   "fanout-topic",
 	})
-	topicARN := "arn:aws:sns:us-east-1:000000000000:fanout-topic"
+	topicARN := "arn:aws:sns:us-east-1:123456789012:fanout-topic"
 
 	// Subscribe SQS endpoint.
 	snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
 		"TopicArn": topicARN,
 		"Protocol": "sqs",
-		"Endpoint": "https://sqs.us-east-1.amazonaws.com/000000000000/fanout-queue",
+		"Endpoint": "https://sqs.us-east-1.amazonaws.com/123456789012/fanout-queue",
 	})
 
 	// Publish — triggers dispatchToSubscriber → SQS SendMessage.
@@ -704,7 +704,7 @@ func TestSNSPlugin_TagResourceReplaceKey(t *testing.T) {
 		"Action": "CreateTopic",
 		"Name":   "replace-tag-topic",
 	})
-	topicARN := "arn:aws:sns:us-east-1:000000000000:replace-tag-topic"
+	topicARN := "arn:aws:sns:us-east-1:123456789012:replace-tag-topic"
 
 	// Tag once.
 	snsRequest(t, srv, map[string]string{
@@ -1412,7 +1412,7 @@ func TestSNSPlugin_GetAndSetTopicAttributes(t *testing.T) {
 		"Action": "CreateTopic",
 		"Name":   "attr-topic",
 	})
-	topicARN := "arn:aws:sns:us-east-1:000000000000:attr-topic"
+	topicARN := "arn:aws:sns:us-east-1:123456789012:attr-topic"
 
 	// GetTopicAttributes.
 	resp := snsRequest(t, srv, map[string]string{
@@ -1438,7 +1438,7 @@ func TestSNSPlugin_ListSubscriptionsByTopic(t *testing.T) {
 		"Action": "CreateTopic",
 		"Name":   "subs-topic",
 	})
-	topicARN := "arn:aws:sns:us-east-1:000000000000:subs-topic"
+	topicARN := "arn:aws:sns:us-east-1:123456789012:subs-topic"
 
 	// Subscribe.
 	snsRequest(t, srv, map[string]string{
@@ -1466,7 +1466,7 @@ func TestSNSPlugin_GetSubscriptionAttributes(t *testing.T) {
 	})
 	subResp := snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:gsa-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:gsa-topic",
 		"Protocol": "https",
 		"Endpoint": "https://example.com/sns",
 	})
@@ -1492,7 +1492,7 @@ func TestSNSPlugin_SetSubscriptionAttributes(t *testing.T) {
 	})
 	subResp := snsRequest(t, srv, map[string]string{
 		"Action":   "Subscribe",
-		"TopicArn": "arn:aws:sns:us-east-1:000000000000:ssa-topic",
+		"TopicArn": "arn:aws:sns:us-east-1:123456789012:ssa-topic",
 		"Protocol": "https",
 		"Endpoint": "https://example.com/sns",
 	})
@@ -1518,7 +1518,7 @@ func TestSNSPlugin_AddRemovePermission(t *testing.T) {
 		"Action": "CreateTopic",
 		"Name":   "perm-topic",
 	})
-	topicARN := "arn:aws:sns:us-east-1:000000000000:perm-topic"
+	topicARN := "arn:aws:sns:us-east-1:123456789012:perm-topic"
 
 	resp := snsRequest(t, srv, map[string]string{
 		"Action":                "AddPermission",
@@ -1612,7 +1612,7 @@ func TestSNSPlugin_UntagResource(t *testing.T) {
 		"Action": "CreateTopic",
 		"Name":   "untag-topic",
 	})
-	topicARN := "arn:aws:sns:us-east-1:000000000000:untag-topic"
+	topicARN := "arn:aws:sns:us-east-1:123456789012:untag-topic"
 
 	// Tag.
 	snsRequest(t, srv, map[string]string{

--- a/substrate.yaml.example
+++ b/substrate.yaml.example
@@ -65,6 +65,12 @@ consistency:
 # When enabled, every incoming request must carry a valid AWS4-HMAC-SHA256 Authorization
 # header signed with a key registered here. Omitting this section disables both credential
 # resolution and signature verification (all requests are accepted, backward-compatible default).
+#
+# NOT YET READ FROM THIS FILE (#736). Config has no field for this section, so the
+# shipped `substrate server` discards it and starts with verification off. The
+# registry itself is real — reach it in-process through ServerOptions.Credentials.
+# Wiring it here waits on #630, because a registry also switches SigV4 enforcement
+# on, which would 403 substrate's own documented test/test credentials.
 credentials:
   # Set to true to enable SigV4 signature verification.
   # enabled: true
@@ -78,6 +84,10 @@ credentials:
 # When enabled, every request whose caller principal has been resolved via the credential
 # registry is checked against that principal's attached managed policies, inline policies,
 # and permission boundary before the request reaches the plugin layer.
+#
+# NOT YET READ FROM THIS FILE (#736), for the same reason as credentials: above.
+# AuthController is reachable in-process through ServerOptions.Auth, which is how
+# StartTestServer wires it.
 auth:
   # Set to true to enable cross-service IAM enforcement.
   # enabled: true
@@ -140,3 +150,11 @@ region:
   # allowed:
   #   - "us-east-1"
   #   - "us-west-2"
+
+# The AWS account requests are attributed to.
+# Every ARN substrate mints, and every state key it partitions by account, names
+# this one — unless the request identifies another account, which only a
+# credentials entry (above) or an STS session can do. AWS's documented example
+# account is the default; change it to match whatever your fixtures assert on.
+account:
+  default: "123456789012"


### PR DESCRIPTION
Closes #734

## The defect

`ParseAWSRequest` decided the account from the **shape of the access key**. `extractAccount` returned `123456789012` iff the key began with `AKIA`, and `000000000000` otherwise — so substrate's own documented `test`/`test`, an unsigned request, and an `ASIA` session key all landed in a different account from `AKIAIOSFODNN7EXAMPLE`. One process served two accounts, chosen by which of two documented credentials the client happened to pick, and **nothing on the wire told a caller which one they had.**

The reporter hit it by using two credentials in one live run.

## A correction to the issue body

The issue diagnoses this as "the IAM plugin mints ARNs under `000000000000`; the authorization path builds ARNs under `123456789012`". That is **refuted**: both read `RequestContext.AccountID` and always have — IAM through `iamUserARN` and friends, authorization at `authz.go`. The split was upstream of both, in the parser, which is why it reached every service at once and why fixing either plugin would have fixed nothing.

The issue also cites `ec2AuthzAccount` as evidence that "the rest of the emulator uses `123456789012`". That is a test constant, not production code. The conclusion was right for the wrong reason.

## The fix

One account, resolved in one place, in one order — each step knowing strictly more than the one above it:

| Source | When it applies |
|---|---|
| `123456789012` | Always, as the starting point |
| `account.default` in `substrate.yaml` | Whenever set and 12 digits |
| A `CredentialRegistry` entry | When signed with a key the registry holds |
| An STS session record | When signed with credentials `AssumeRole` minted |

The session record is last because it is the only thing that *can* know the account a cross-account `AssumeRole` landed in: a temporary credential's account is recorded when the session is minted and appears nowhere on the wire.

`extractAccount` and `fallbackAccountID` are deleted, along with the duplicate `seedSSMAccountID`. `Config.Validate` refuses an `account.default` that is not 12 digits rather than letting a typo through to every ARN the server mints.

## Two tests, doing different jobs

**The tripwire** parses every non-test Go file and fails on any string literal carrying an account-shaped run of twelve digits, with exactly one exemption: the declaration of `defaultAccountID` itself. That is stronger than "no `000000000000`" — a second literal `123456789012` would be just as wrong, because the property this buys is that the account is resolved in one place and overridable. A digit run bounded by anything other than `:`, `/` or the end of the string is not an account, which keeps `shardId-000000000000` and MSK's UUID fragments out of it.

It catches the one genuine offender: `ListEventBuses` returned `arn:aws:events:us-east-1:000000000000:event-bus/default`, ignoring **both** of its request context's fields.

**The agreement test** asks three services who the caller is and compares the answers, for two accounts — because a producer that returns a constant agrees with itself. The three are not arbitrary: `sts:GetCallerIdentity` is the only operation whose whole purpose is to answer the question, the CloudFormation deployer mints a stack ARN from an identity it carries separately (#517's split), and the Resource Groups Tagging API reaches a DynamoDB table through an account-prefixed state key — so its answer proves the account the write used and the account the read used are the same string, which is the failure mode that leaves a resource created and then invisible.

## A second defect the live run found

Verifying the above with the `aws` CLI, **every EventBridge call answered `ServiceNotAvailable: service not emulated: awsevents`.** The target prefix in EventBridge's model is `AWSEvents`, not `AmazonEventBridge`, and only the host alias (`events.*` → `eventbridge`) was registered. That is enough on a real endpoint and useless on the one way substrate is actually reached: with `--endpoint-url` the host is `localhost` and `X-Amz-Target` is the only signal.

So the plugin was registered, green, and unreachable — the #561/#580 failure mode — which means `ListEventBuses` returning the wrong account had never been observable in the first place. Aliased, with a three-path test mirroring Config's. A systematic sweep of the other 66 plugins is filed as #739.

## Live verification

Against a built binary, `substrate server --address :4678`:

- `sts get-caller-identity` under `AKIAIOSFODNN7EXAMPLE` and under `test`/`test` → both `123456789012`, `arn:aws:iam::123456789012:root`
- `dynamodb create-table` as `test`/`test`, then `list-tables` and `describe-table` as `AKIAIOSFODNN7EXAMPLE` → the table is there (two accounts before)
- `resourcegroupstaggingapi get-resources` → `arn:aws:dynamodb:us-east-1:123456789012:table/probe`
- `events list-event-buses` in `us-east-1` and `eu-west-1` → `arn:aws:events:{region}:123456789012:event-bus/default`, both fields the caller's
- `iam create-user` as one credential, `get-user` as the other → the same `arn:aws:iam::123456789012:user/probe-user`
- restarted with `account.default: "555566667777"` → STS, EventBridge, IAM, the tagging API and a CloudFormation `StackId` all move together
- `account.default: "12345"` → `substrate: load config: account.default "12345" is not valid; an AWS account ID is 12 digits`

Mutation check: reintroducing the `000000000000` literal in `listEventBuses` turns the tripwire red at the exact line, and reverting it green.

## A deviation from the approved plan, stated plainly

The plan's PR 1 specified wiring `ServerOptions.Credentials` in `cmd/substrate/main.go`, as half of #630. **I did not**, and I think the plan was wrong here.

Wiring a registry also switches SigV4 **enforcement** on: `server.go`'s step 1.5 (registry account lookup) and step 1.6 (signature verification) both gate on `s.opts.Credentials != nil`. So the shipped `substrate server` would start answering `InvalidClientTokenId` 403 to the `test`/`test` credentials substrate documents — a regression far larger than the gap it closes. And the plan's justification for the wiring was that the binary is "permanently stuck on the sniff", which stops being true the moment the account comes from config, as it now does.

#630 stays open and is commented rather than closed; the decoupling is the real work. `substrate.yaml.example`'s `credentials:` and `auth:` sections are marked as not-yet-read rather than left reading as though they work (#736).

## Deliberately out of scope, each documented and filed

- **IAM's state keys stay account-blind** (`user:{name}`, no account), so `resolveIAMEntity` still resolves an entity by name across accounts — the "works by accident" the issue correctly identifies. #737.
- **`substrate.yaml`'s `credentials:` and `auth:` sections are still not parsed** by `Config`. #736.
- `DynamoDBTable.TableARN` serializes under the wrong wire name (`TableArn` on AWS), found while writing the live script. #738.

## Compatibility

Every ARN returned to an unsigned or non-`AKIA` caller changes account, so a fixture asserting on `000000000000` now sees `123456789012`. Several plugins prefix their state keys with the account (`table:{account}/{name}`, `instance:{account}/{id}`), so **persisted SQLite state written under the old account is unreachable** after upgrading: re-seed it, or set `account.default: "000000000000"` to read it back.

## Verification

```
gofmt -l .                          clean
go build ./... && go vet ./...      clean
golangci-lint run ./...             0 issues
make test                           ok (race)
make coverage                       emulator 83.3%, total 82.6%
make docs-reference{,-check} docs-versions   clean
npm --prefix docs run build         clean; no dangling in-page anchors
go vet -C test/e2e ./... && go test -C test/e2e ./...   ok
```

Roughly 268 occurrences across 62 test files moved to the single account. A dozen asserted the split *as the contract* and were rewritten rather than replaced: four test files that used the `AKIA` sniff as their way of being two callers now wire a real `CredentialRegistry` and sign genuine SigV4 signatures as an explicitly named second account, leaving the other caller unsigned — which still reaches its plugin as the default account, because `VerifySigV4` passes a request with no `Authorization` header.