### PR TITLE
fix(ec2): RunInstances refuses an AMI that is malformed or names nothing (#733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **A bundled catalog of public AMIs, so an AMI discovered through SSM is an AMI that
+  launches** (#733). Substrate bundled no AMIs at all: the only way an `EC2Image` came into
+  existence was `CreateImage` or `RegisterImage`, and nothing seeded one. Nine AWS public
+  parameter names now resolve to a real image — Amazon Linux 2023 (full and minimal, x86_64 and
+  arm64), Windows Server 2022 Full Base, the ECS-optimized AL2023 and AL2 images, and Canonical
+  Ubuntu 24.04 and 22.04 — with every path taken verbatim from the AWS page that publishes it.
+  Any other AMI-shaped `/aws/service/…` path resolves to its family's entry, because substrate
+  has answered every such path since it gained `GetParameter` and an unlisted one must still
+  resolve to something launchable.
+
+  The ID is derived, `sha256(region + ":" + parameter)` rendered as `ami-` + 17 hex characters,
+  and it is the *same* computation `GetParameter` answers with — one table, so the AMI substrate
+  hands out cannot be an AMI it then refuses. Being derived rather than seeded, it needs no
+  startup write, works in every Region, and is stable across runs, processes and replays;
+  being Region-scoped, an ID resolves in exactly one Region, as on AWS. `emulator.BundledImageID(region, parameterName)`
+  returns it, and `TestServer.SeedEC2Image` registers a caller-owned one for a test that needs
+  a specific record in state.
+
+  Deliberately **not** bundled: `ami-0abcdef1234567890` and `ami-1234567890abcdef0`, the example
+  IDs AWS's own reference pages use and generated IaC copies. IaC that hardcodes one fails on
+  real AWS, so it has to fail here; a test pins their absence.
+
 - **`account.default` in `substrate.yaml` sets the account every request is attributed to**
   (#734). It defaults to `123456789012`, AWS's documented example account, and `Validate`
   refuses a value that is not 12 digits rather than letting a typo through to every ARN the
   server mints. `substrate.yaml.example` documents it beside `region:`, which it parallels.
+
+### Changed
+- **`RunInstances` refuses an AMI that is malformed or names nothing** (#733). Substrate
+  accepted **any** non-empty `ImageId` — `ami-test`, `not-an-ami`, `ami-EXAMPLE`,
+  `ami-0abcdef1234567890` — and launched an instance reporting it. The check that existed only
+  asked whether a value was present at all. So the one mistake generated infrastructure code
+  makes most often, naming an AMI that does not exist in the target Region, was invisible until
+  the same template reached real AWS, which is the opposite of what substrate is for.
+
+  A launch now answers `InvalidAMIID.Malformed` / 400 for an ID that is not `ami-` followed by a
+  run of lowercase hex, and `InvalidAMIID.NotFound` / 400 for a well-formed ID naming no image,
+  syntax before absence. Both codes come from a new `ec2ImageIDKind` in the same table the other
+  ten EC2 ID families answer through, so the wording, status and ordering are shared rather than
+  hand-written. `CreateFleet` inherits the rule through the launch path it already shares.
+
+  `InvalidAMIID.Unavailable` is deliberately not raised: substrate models no
+  deregistered-but-extant image — `DeregisterImage` deletes the record — so an unavailable AMI
+  reads as absent, which is what a caller polling for one observes.
+
+  `CreateLaunchTemplate` and `CreateLaunchTemplateVersion` stay permissive, also deliberately.
+  AWS reports mapping problems on those operations through the response's `warning` member
+  rather than refusing, so an AMI rule there would be a refusal AWS does not make; a template
+  may carry an AMI that no longer resolves, and the launch from it is where that surfaces.
+
+  Bundled AMIs are resolvable and nameable but **not enumerated** — substrate's reading, not
+  AWS's behaviour. `DescribeImages` lists what an account owns, and a public AWS-owned image is
+  not that; real AWS would answer an unqualified describe with tens of thousands of public
+  images. A bundled image also reports no owner, so it is not taggable and an `Owners=self`
+  describe does not match it.
+
+  **Compatibility.** A launch naming an AMI that does not exist now fails where it used to
+  succeed. A fixture carrying a placeholder or a Region-specific literal must name a bundled AMI
+  (`emulator.BundledImageID`), register one with `CreateImage`/`RegisterImage`, or resolve one
+  through the SSM public parameter it would use on AWS — which is the workflow this makes
+  coherent. Substrate's own suite needed roughly 300 such edits across 40 test files, and not one
+  of them had been launching an AMI that existed.
 
 ### Fixed
 - **One server serves one account** (#734). `ParseAWSRequest` decided the account from the

--- a/docs/services.md
+++ b/docs/services.md
@@ -3004,7 +3004,7 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 
 | Operation | Notes |
 |-----------|-------|
-| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires a resolvable AMI](#runinstances-requires-a-resolvable-ami); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); [refuses an invalid block device mapping](#a-mapping-aws-refuses-is-refused-with-invalidblockdevicemapping); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
+| RunInstances | Auto-creates default VPC (172.31.0.0/16); [requires an AMI that resolves](#runinstances-requires-a-resolvable-ami), from the caller's own images or the [bundled catalog](#which-amis-resolve); [merges a named launch template field by field](#a-launch-template-merges-with-the-request-field-by-field); [validates MinCount/MaxCount](#mincount-and-maxcount); [refuses an invalid block device mapping](#a-mapping-aws-refuses-is-refused-with-invalidblockdevicemapping); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | DescribeInstances | [Explicit resource IDs](#explicit-resource-ids); reports [`groupSet`](#security-groups-on-an-instance), [`blockDeviceMapping`](#an-instance-reports-its-own-block-devices) and [`placement`](#termination-protection-is-honoured-one-availability-zone-at-a-time); eleven filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
 | TerminateInstances | [Explicit resource IDs](#explicit-resource-ids); [honours termination protection, per Availability Zone](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | StopInstances | [Explicit resource IDs](#explicit-resource-ids) |
@@ -3043,14 +3043,14 @@ DynamoDB write operations: $0.00000125 per WCU. Read operations: $0.00000025 per
 | DeleteSnapshot | `SnapshotId` is required and checked; refuses one a registered AMI still references with `InvalidSnapshot.InUse`, and is **not** idempotent — see [Deleting a snapshot](#deleting-a-snapshot-refuses-what-aws-refuses) |
 | DescribeAddresses | [Explicit resource IDs](#explicit-resource-ids); `AllocationId.N` and `PublicIp.N` [union](#twelve-describes-gained-filters); eight of ten filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); reports `tagSet` |
 | DescribeNatGateways | [Explicit resource IDs](#explicit-resource-ids); [filter names are checked](#one-rule-for-an-unrecognized-filter-name) |
-| CreateLaunchTemplate | Creates version 1. Networking is read from every `NetworkInterface.N.*` — see [Launch template networking](#launch-template-networking). The top-level `TagSpecification.N` scoped to `launch-template` tags the template itself, separately from `LaunchTemplateData`'s, which tags what a launch creates |
+| CreateLaunchTemplate | Creates version 1. [Does not validate the AMI](#runinstances-requires-a-resolvable-ami), matching AWS, which reports mapping problems here through `warning`. Networking is read from every `NetworkInterface.N.*` — see [Launch template networking](#launch-template-networking). The top-level `TagSpecification.N` scoped to `launch-template` tags the template itself, separately from `LaunchTemplateData`'s, which tags what a launch creates |
 | DescribeLaunchTemplates | Summary only — no `launchTemplateData`, matching AWS. Use `DescribeLaunchTemplateVersions` to read a template's parameters. **All four** filters, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name); `LaunchTemplateId.N` and `LaunchTemplateName.N` are read at every index and [union](#twelve-describes-gained-filters) |
 | DeleteLaunchTemplate | |
 | CreateLaunchTemplateVersion | `SourceVersion` inheritance — see [Launch template versions](#launch-template-versions) |
 | ModifyLaunchTemplate | `SetDefaultVersion` only, which is AWS's only modifiable attribute |
 | DescribeLaunchTemplateVersions | Numbers, `$Latest`, `$Default`, `MinVersion`/`MaxVersion`, `MaxResults`/`NextToken`, and the account-wide form. Four of fourteen filters, applied **before** pagination, and [filter names are checked](#one-rule-for-an-unrecognized-filter-name) before the template is resolved |
 | DeleteLaunchTemplateVersions | Reports per version at HTTP 200; the default version cannot be deleted |
-| CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
+| CreateFleet | Instances launch through the `RunInstances` path, so they are visible to `DescribeInstances`, [need an AMI that resolves](#runinstances-requires-a-resolvable-ami), and carry the reserved `aws:ec2:fleet-id` tag. Partial fulfillment is seedable — see below |
 | DescribeFleets | An `instant` fleet is returned only when its ID is named explicitly, matching AWS; [filter names are checked](#one-rule-for-an-unrecognized-filter-name), and it documents **no tag filter** |
 | DeleteFleets | `TerminateInstances=true` (and any `instant` fleet) terminates the fleet's instances, [subject to termination protection](#termination-protection-is-honoured-one-availability-zone-at-a-time) |
 | CreateTags | Rejects [reserved `aws:` keys](#reserved-tag-keys), [over-long keys and values](#tag-key-and-value-length-limits), and more than [50 tags per resource](#the-50-tag-per-resource-limit); reaches [all fifteen taggable ID prefixes](#every-taggable-id-prefix-is-reachable) and refuses anything else with `InvalidID`; [authorized against every resource named](#tagging-is-authorized-against-every-resource-it-names) |
@@ -3357,8 +3357,88 @@ at all.
 Note that `ImageId` is an optional `*string` in the typed SDKs, so
 `aws.String("")` serializes as **absent from the wire**: an empty AMI reaches the
 service rather than being caught client-side. That is the shape this check exists
-for. The AMI value itself is not format-validated — substrate accepts any
-non-empty string, so fixtures like `ami-test` work.
+for.
+
+**The AMI must also exist.** Once a value is in hand, substrate answers the way
+EC2 does:
+
+| The value | Answer |
+|---|---|
+| `ami-` + a run of lowercase hex naming an AMI substrate can resolve | the launch proceeds |
+| `ami-` + a run of lowercase hex naming nothing | `InvalidAMIID.NotFound` / "The image ID '…' does not exist", HTTP 400 |
+| anything else — `not-an-ami`, `ami-EXAMPLE`, `ami-zzzzzzzz`, a bare `ami-` | `InvalidAMIID.Malformed` / `Invalid id: "…"`, HTTP 400 |
+
+Syntax is reported before absence, as everywhere else substrate names an EC2
+resource — see [Explicit resource IDs](#explicit-resource-ids), whose table this
+AMI pair now joins. Length is deliberately not part of the syntax rule: AWS itself
+accepts both the legacy 8-character and the current 17-character form.
+
+Substrate raises `InvalidAMIID.Unavailable` nowhere. AWS publishes it for an AMI
+"deregistered and no longer available", and substrate models no such state —
+`DeregisterImage` deletes the record — so an unavailable AMI reads as absent,
+which is what a caller polling for one observes anyway.
+
+`CreateFleet` inherits the rule, because its instances launch through the same
+path. `CreateLaunchTemplate` and `CreateLaunchTemplateVersion` deliberately do
+**not**: AWS reports mapping problems on those operations through the response's
+`warning` member rather than by refusing, so an AMI rule there would be a refusal
+AWS does not make. A template may therefore carry an AMI that no longer resolves;
+the launch from it is where that surfaces.
+
+### Which AMIs resolve
+
+Three kinds of AMI resolve, and nothing else does.
+
+1. **One the caller made** — through `CreateImage` or `RegisterImage`, in the
+   caller's own account and region.
+2. **A bundled public AMI**, keyed by the SSM public parameter a consumer
+   discovers it through. Substrate answers nine parameter names with a real image:
+
+   | Parameter | Image |
+   |---|---|
+   | `/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64` | Amazon Linux 2023, x86_64 |
+   | `/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64` | Amazon Linux 2023, arm64 |
+   | `/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64` | Amazon Linux 2023 minimal, x86_64 |
+   | `/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64` | Amazon Linux 2023 minimal, arm64 |
+   | `/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base` | Windows Server 2022 Full Base |
+   | `/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id` | ECS-optimized Amazon Linux 2023 |
+   | `/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id` | ECS-optimized Amazon Linux 2 |
+   | `/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id` | Ubuntu Server 24.04 LTS, amd64 |
+   | `/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id` | Ubuntu Server 22.04 LTS, amd64 |
+
+3. **Any other `/aws/service/…` AMI parameter path**, which resolves to its
+   family's entry above — a Windows path to the Windows image, an Ubuntu path to
+   Ubuntu 24.04, an ECS path to ECS-on-AL2023, anything else to Amazon Linux 2023
+   on x86_64. Substrate has answered every AMI-shaped `/aws/service/` path since
+   it gained `GetParameter`, and this is why: an unlisted path must still resolve
+   to something launchable, or `GetParameter` would hand out an AMI that
+   `RunInstances` then refuses. The cost is that two unlisted paths in one family
+   share an image.
+
+The AMI ID a bundled image gets is **derived** — `sha256(region + ":" +
+parameter)`, rendered as `ami-` + 17 hex characters — not random and not written
+into state at startup. So it is the same across runs, processes and replays, and
+it differs per region exactly as on AWS, where an AMI ID names an image in one
+region and nothing in any other. The Go helper `emulator.BundledImageID(region,
+parameterName)` returns it, which is what a fixture should name rather than
+inventing a literal.
+
+Two things follow from bundled images living outside state.
+
+- **They are not enumerated.** `DescribeImages` lists what the account owns, and a
+  public AWS-owned AMI is not that, so an unqualified `DescribeImages` does not
+  return them. This is substrate's reading, not AWS's behaviour — real AWS would
+  return every public image, tens of thousands of them. A bundled AMI is
+  resolvable and nameable; it is not inventory.
+- **They are not the caller's.** A bundled image reports no owner, so it is not
+  taggable and an `Owners=self` describe does not match it. Register your own AMI
+  when the test is about owning one.
+
+Deliberately **not** bundled: the example IDs AWS's own reference pages use,
+`ami-0abcdef1234567890` and `ami-1234567890abcdef0`. Generated IaC copies them,
+and it fails on real AWS when it does. Making them launch here would recreate the
+exact divergence this check removes, so substrate refuses them like any other AMI
+that names nothing.
 
 ### A launch template merges with the request, field by field
 
@@ -4667,8 +4747,16 @@ string, so substrate mirrors each pair exactly:
 | Route table | `InvalidRouteTableID.NotFound` | `InvalidRouteTableId.Malformed` |
 | Snapshot | `InvalidSnapshot.NotFound` | `InvalidSnapshotID.Malformed` |
 | Volume | `InvalidVolume.NotFound` | `InvalidVolumeID.Malformed` |
+| Image (AMI) | `InvalidAMIID.NotFound` | `InvalidAMIID.Malformed` |
 | Elastic IP allocation | `InvalidAllocationID.NotFound` | — |
 | NAT gateway | `InvalidNatGatewayID.NotFound` | `NatGatewayMalformed` |
+
+AMIs are the one family whose absence code names no ID — `InvalidAMIID.NotFound` is
+"The specified AMI doesn't exist" — the mirror image of the cross-naming snapshots
+carry. Which AMIs an ID can resolve to is
+[its own question](#which-amis-resolve); AWS's third AMI code,
+`InvalidAMIID.Unavailable`, is raised nowhere, because substrate models no
+deregistered-but-extant image.
 
 EC2 publishes no `Malformed` variant for allocation IDs; a malformed allocation ID
 surfaces as `InvalidAllocationID.NotFound`. NAT gateways are the one family whose
@@ -5707,6 +5795,19 @@ Secrets Manager API calls: $0.05 per 10,000 API calls.
 | GetParametersByPath | Recursive path traversal |
 | DeleteParameter | |
 | DescribeParameters | |
+
+### AWS's public AMI parameters are answered
+
+A `/aws/service/…` path whose shape says "AMI" is answered without anyone having
+put it there, because that is how AWS documents AMI discovery — a template or a
+script reads `/aws/service/ami-amazon-linux-latest/…` rather than hardcoding an ID.
+The value is the AMI ID substrate resolves for that parameter in the request's
+region, and it is the *same* ID `RunInstances` accepts: the two answers come from
+one table, so `GetParameter` cannot hand out an AMI the launch then refuses. See
+[Which AMIs resolve](#which-amis-resolve) for the paths and the derivation.
+
+A parameter the caller wrote wins over a managed one at the same path, so
+`PutParameter` can override any of these.
 
 ### CloudFormation resource types
 

--- a/emulator/ce_plugin_test.go
+++ b/emulator/ce_plugin_test.go
@@ -215,7 +215,7 @@ func TestCE_GetCostAndUsage_BlendedCostMetric(t *testing.T) {
 	// Run an instance so there is non-zero cost.
 	runResp := ec2QueryRequest(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "m7i.large",
 		"MinCount":     "1",
 		"MaxCount":     "1",
@@ -302,7 +302,7 @@ func TestCE_EC2UsageCost_RunningInstance(t *testing.T) {
 	// Launch an m7i.large instance.
 	runResp := ec2QueryRequest(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "m7i.large",
 		"MinCount":     "1",
 		"MaxCount":     "1",
@@ -375,7 +375,7 @@ func TestCE_EC2UsageCost_TerminatedInstance(t *testing.T) {
 	// Launch an instance.
 	runResp := ec2QueryRequest(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "m7i.large",
 		"MinCount":     "1",
 		"MaxCount":     "1",
@@ -484,7 +484,7 @@ func TestCE_GetCostAndUsage_GroupByTag(t *testing.T) {
 	// Launch an m7i.large with Name=cost-tag-test.
 	runResp := ec2QueryRequest(t, ts, map[string]string{
 		"Action":                          "RunInstances",
-		"ImageId":                         "ami-12345678",
+		"ImageId":                         ec2TestImage,
 		"InstanceType":                    "m7i.large",
 		"MinCount":                        "1",
 		"MaxCount":                        "1",
@@ -568,7 +568,7 @@ func TestCE_GetCostAndUsage_GroupByTag_NoServiceFilter(t *testing.T) {
 	// Launch instance with no Name tag.
 	runResp := ec2QueryRequest(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "t3.micro",
 		"MinCount":     "1",
 		"MaxCount":     "1",
@@ -625,7 +625,7 @@ func TestCE_GetCostAndUsage_GroupByTag_NoEventStoreLeakage(t *testing.T) {
 	// Generate EventStore records for several services by making API calls.
 	ec2QueryRequest(t, ts, map[string]string{
 		"Action":                          "RunInstances",
-		"ImageId":                         "ami-12345678",
+		"ImageId":                         ec2TestImage,
 		"InstanceType":                    "t3.micro",
 		"MinCount":                        "1",
 		"MaxCount":                        "1",
@@ -705,7 +705,7 @@ func TestCE_GetCostAndUsage_DailyGranularity(t *testing.T) {
 	// Launch a t3.micro on day 1 (Jan 5).
 	ec2QueryRequest(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "t3.micro",
 		"MinCount":     "1",
 		"MaxCount":     "1",
@@ -782,7 +782,7 @@ func TestCE_GetCostAndUsage_CreateTagsAfterLaunch(t *testing.T) {
 	// Launch an m7i.large with NO tags.
 	runResp := ec2QueryRequest(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "m7i.large",
 		"MinCount":     "1",
 		"MaxCount":     "1",

--- a/emulator/cfn_deployer.go
+++ b/emulator/cfn_deployer.go
@@ -3286,7 +3286,14 @@ func (d *StackDeployer) deployEC2Instance(
 	streamID string,
 	cctx *cfnContext,
 ) (DeployedResource, float64, error) {
-	imageID := resolveStringProp(props, "ImageId", "ami-00000000", cctx)
+	// The default is a bundled AMI for the stack's Region rather than the literal
+	// "ami-00000000" this used through v0.107.0. That literal existed only because
+	// nothing checked an AMI's existence; now that RunInstances refuses one that names
+	// nothing (#733), a template omitting ImageId would have failed to deploy on
+	// substrate's own default. Falling back to the image a caller would have discovered
+	// through /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+	// keeps that deployment working and keeps the AMI one substrate can resolve.
+	imageID := resolveStringProp(props, "ImageId", BundledImageID(cctx.region, bundledImageDefaultParameter), cctx)
 	instanceType := resolveStringProp(props, "InstanceType", "t3.micro", cctx)
 	subnetID := resolveStringProp(props, "SubnetId", "", cctx)
 	params := map[string]string{

--- a/emulator/cfn_deployer_test.go
+++ b/emulator/cfn_deployer_test.go
@@ -825,7 +825,7 @@ func TestCFN_EC2Instance(t *testing.T) {
 			"MyInstance": {
 				"Type": "AWS::EC2::Instance",
 				"Properties": {
-					"ImageId": "ami-cfntest",
+					"ImageId": "` + ec2TestImage + `",
 					"InstanceType": "t3.micro"
 				}
 			}

--- a/emulator/cfn_fnsplit_test.go
+++ b/emulator/cfn_fnsplit_test.go
@@ -123,7 +123,7 @@ func TestCFN_FnSplit_ListValuedProperty(t *testing.T) {
 			"Node": {
 				"Type": "AWS::EC2::Instance",
 				"Properties": {
-					"ImageId": "ami-0abc1234",
+					"ImageId": "` + ec2TestImage + `",
 					"InstanceType": "c5.large",
 					"SubnetId": {"Ref": "Subnet"},
 					"SecurityGroupIds": {"Fn::Split": [",", {"Ref": "Groups"}]}
@@ -163,7 +163,7 @@ func TestCFN_FnIf_ListBranch(t *testing.T) {
 			"Node": {
 				"Type": "AWS::EC2::Instance",
 				"Properties": {
-					"ImageId": "ami-0abc1234",
+					"ImageId": "` + ec2TestImage + `",
 					"InstanceType": "c5.large",
 					"SubnetId": {"Ref": "Subnet"},
 					"SecurityGroupIds": {"Fn::If": [
@@ -225,7 +225,7 @@ func TestCFN_Ref_CommaDelimitedListParameter(t *testing.T) {
 			"Node": {
 				"Type": "AWS::EC2::Instance",
 				"Properties": {
-					"ImageId": "ami-0abc1234",
+					"ImageId": "` + ec2TestImage + `",
 					"InstanceType": "c5.large",
 					"SubnetId": {"Ref": "Subnet"},
 					"SecurityGroupIds": {"Ref": "Groups"}

--- a/emulator/cfn_mappings_test.go
+++ b/emulator/cfn_mappings_test.go
@@ -500,17 +500,22 @@ func TestCFN_FindInMap_UnknownKeyFailsTheResource(t *testing.T) {
 
 	deployer, _ := newFullTestDeployerWithRegistry(t)
 
-	const template = `
+	// The mapped AMI is a bundled one in the deployer's own region, because Good is
+	// launched rather than merely resolved: RunInstances refuses an AMI it cannot
+	// resolve (#733), and a lookup that resolved to a fabricated ID would fail the
+	// resource for the wrong reason and make "a resolvable lookup must deploy"
+	// unfalsifiable.
+	template := `
 AWSTemplateFormatVersion: '2010-09-09'
 Mappings:
   RegionMap:
-    eu-west-1:
-      AMI: ami-0eu1
+    us-east-1:
+      AMI: ` + ec2TestImage + `
 Resources:
   Good:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: !FindInMap [RegionMap, eu-west-1, AMI]
+      ImageId: !FindInMap [RegionMap, us-east-1, AMI]
       InstanceType: t3.micro
   Bad:
     Type: AWS::EC2::Instance

--- a/emulator/cfn_resources_v77_test.go
+++ b/emulator/cfn_resources_v77_test.go
@@ -149,7 +149,7 @@ func TestCFN_IAMInstanceProfile(t *testing.T) {
 			"Node": {
 				"Type": "AWS::EC2::Instance",
 				"Properties": {
-					"ImageId": "ami-0abc1234",
+					"ImageId": "` + ec2TestImage + `",
 					"InstanceType": "c5.large",
 					"IamInstanceProfile": {"Ref": "NodeProfile"}
 				}
@@ -390,7 +390,7 @@ func TestCFN_LaunchTemplateFeedsCreateFleet(t *testing.T) {
 				"Type": "AWS::EC2::LaunchTemplate",
 				"Properties": {
 					"LaunchTemplateName": "fleet-nodes",
-					"LaunchTemplateData": {"ImageId": "ami-0abc1234", "InstanceType": "c5.large"}
+					"LaunchTemplateData": {"ImageId": "` + ec2TestImage + `", "InstanceType": "c5.large"}
 				}
 			}
 		}

--- a/emulator/cloudformation_identity_test.go
+++ b/emulator/cloudformation_identity_test.go
@@ -176,8 +176,22 @@ func cfnPhysicalID(t *testing.T, body string) string {
 	return cfnXMLValue(t, body, "PhysicalResourceId")
 }
 
-const cfnInstanceTemplate = `{"Resources":{"I":{"Type":"AWS::EC2::Instance",` +
-	`"Properties":{"ImageId":"ami-12345678","InstanceType":"t3.micro"}}}}`
+// cfnInstanceTemplateIn returns the one-instance stack these tests deploy, naming an AMI
+// that resolves in region.
+//
+// RunInstances refuses an AMI it cannot resolve (#733) and an AMI ID names an image in
+// exactly one Region, so a stack deployed outside [ec2TestRegion] has to carry that
+// Region's ID — otherwise the deploy fails for a reason none of these tests is about.
+func cfnInstanceTemplateIn(region string) string {
+	imageID := emulator.BundledImageID(region,
+		"/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64")
+	return `{"Resources":{"I":{"Type":"AWS::EC2::Instance",` +
+		`"Properties":{"ImageId":"` + imageID + `","InstanceType":"t3.micro"}}}}`
+}
+
+// cfnInstanceTemplate is that stack in the Region every test here but
+// TestCFNIdentity_NonDefaultRegion addresses.
+var cfnInstanceTemplate = cfnInstanceTemplateIn(ec2TestRegion)
 
 // TestCFNIdentity_CallerFindsItsOwnInstance is #517's reproduction, and it fails
 // before the fix.
@@ -306,7 +320,7 @@ func TestCFNIdentity_NonDefaultRegion(t *testing.T) {
 		"Action":       "CreateStack",
 		"Version":      "2010-05-15",
 		"StackName":    "euwest",
-		"TemplateBody": cfnInstanceTemplate,
+		"TemplateBody": cfnInstanceTemplateIn("eu-west-1"),
 	})
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
 	assert.Contains(t, body, "arn:aws:cloudformation:eu-west-1:")

--- a/emulator/ec2_authz_test.go
+++ b/emulator/ec2_authz_test.go
@@ -32,10 +32,15 @@ import (
 const (
 	ec2AuthzAccount = "123456789012"
 	ec2AuthzRegion  = "us-east-1"
-	ec2AuthzAMI     = "ami-0abcdef1234567890"
 	ec2AuthzSubnet  = "subnet-0aaa11112222bbbb3"
 	ec2AuthzSG      = "sg-0ccc44445555dddd6"
 )
+
+// ec2AuthzAMI is the AMI the nominal launch names. It is a bundled image rather than a
+// fabricated literal so the fixture names an AMI a real RunInstances would also accept
+// (#733) — these tests reach only the authorization decision, but a reader copying the
+// fixture into a launch should not be handed an ID substrate refuses.
+var ec2AuthzAMI = ec2TestImage
 
 // ec2AuthzFixture is an EC2 state store plus an AuthController over the same
 // store, which is what makes a resource-tag condition testable: the tag has to
@@ -643,7 +648,9 @@ func TestEC2_Authz_LaunchTemplateResourcesAreAuthorized(t *testing.T) {
 		// AWS: "Any additional parameters that you specify for the new instance
 		// overwrite the corresponding parameters included in the launch template." So
 		// the decision has to be about the AMI the launch will actually use.
-		const ownAMI = "ami-00000000000000001"
+		// A second bundled image, distinct from the template's, so "the request's AMI
+		// won" is falsifiable.
+		ownAMI := ec2TestImageArm
 		f := newFixture(t)
 		f.putImage(t, ownAMI, nil)
 		ownARN := "arn:aws:ec2:" + ec2AuthzRegion + "::image/" + ownAMI

--- a/emulator/ec2_block_devices_http_test.go
+++ b/emulator/ec2_block_devices_http_test.go
@@ -78,7 +78,7 @@ func bdmRunInstances(t *testing.T, ts *httptest.Server, params map[string]string
 	t.Helper()
 	all := map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-0abcdef1234567890",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1",
 		"MaxCount": "1",
 	}
@@ -350,7 +350,7 @@ func TestEC2_BlockDeviceMapping_FromLaunchTemplate(t *testing.T) {
 	ltResp := ec2Request(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "with-storage",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/xvda",
 		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize": "40",
 	})

--- a/emulator/ec2_block_devices_validation_test.go
+++ b/emulator/ec2_block_devices_validation_test.go
@@ -31,7 +31,7 @@ func ec2InvalidBDM(t *testing.T, ts *httptest.Server, extra map[string]string) (
 	t.Helper()
 	params := map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-0abcdef1234567890",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1",
 		"MaxCount": "1",
 	}
@@ -244,7 +244,7 @@ func TestEC2_BlockDeviceMapping_ValidIsAccepted(t *testing.T) {
 			ts := newEC2TestServer(t)
 			params := map[string]string{
 				"Action":   "RunInstances",
-				"ImageId":  "ami-0abcdef1234567890",
+				"ImageId":  ec2TestImage,
 				"MinCount": "1",
 				"MaxCount": "1",
 			}
@@ -324,7 +324,7 @@ func TestEC2_BlockDeviceMapping_TemplateMappingRefusedAtLaunch(t *testing.T) {
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "bad-mapping",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
 		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
 	})

--- a/emulator/ec2_bundled_images.go
+++ b/emulator/ec2_bundled_images.go
@@ -1,0 +1,227 @@
+package emulator
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// bundledImage is an AMI substrate resolves without anyone having registered one, so a
+// launch that discovers its AMI the way AWS documents — through an SSM public parameter —
+// finds an image at the other end (#733).
+//
+// Every entry is an AWS-published public parameter, and that is the whole membership rule.
+// Substrate deliberately bundles no AMI a caller could not also resolve on real AWS: the
+// point of refusing an unknown AMI is that a launch which works here works there, and an
+// ID that resolves only in substrate would reintroduce exactly that divergence. In
+// particular the example IDs AWS's own reference pages use — ami-0abcdef1234567890 and
+// ami-1234567890abcdef0 — are *not* bundled, because IaC that hardcodes one fails on real
+// AWS and must fail here too.
+type bundledImage struct {
+	// Parameter is the SSM public parameter name a caller discovers the image through,
+	// and the sole input (with the region) to its derived ID.
+	Parameter string
+
+	// Name is the AMI's name member. It is the parameter's leaf rather than a
+	// version-stamped image name ("al2023-ami-2023.6.20260101.0-kernel-6.1-x86_64"),
+	// because a stamped literal here would be a date that goes stale silently and that
+	// no caller can act on.
+	Name string
+
+	// Description is the human-readable description AWS renders for the image family.
+	Description string
+}
+
+// bundledImages is the catalog, with every parameter name taken verbatim from AWS's own
+// documentation:
+//
+//   - /aws/service/ami-amazon-linux-latest/* from
+//     https://docs.aws.amazon.com/linux/al2023/ug/ec2.html
+//   - /aws/service/ami-windows-latest/* from
+//     https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami-parameter-store.html
+//   - /aws/service/ecs/optimized-ami/* from
+//     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/retrieve-ecs-optimized_AMI.html
+//
+// The Canonical Ubuntu paths are Canonical's rather than AWS's — they are published at
+// https://cloud-images.ubuntu.com/locator/ec2/, which AWS's own "find an AMI" page links
+// to as the Ubuntu reference — and substrate has answered them since #267.
+//
+// The list is not AWS's whole public-parameter set, and it does not have to be:
+// [bundledImageForParameter] falls back to the family an unlisted AMI path names, so a
+// parameter substrate has never heard of still resolves to a launchable image rather than
+// to an ID nothing backs.
+var bundledImages = []bundledImage{
+	{
+		Parameter:   "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+		Name:        "al2023-ami-kernel-default-x86_64",
+		Description: "Amazon Linux 2023 AMI, kernel default, x86_64",
+	},
+	{
+		Parameter:   "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64",
+		Name:        "al2023-ami-kernel-default-arm64",
+		Description: "Amazon Linux 2023 AMI, kernel default, arm64",
+	},
+	{
+		Parameter:   "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64",
+		Name:        "al2023-ami-minimal-kernel-default-x86_64",
+		Description: "Amazon Linux 2023 minimal AMI, kernel default, x86_64",
+	},
+	{
+		Parameter:   "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64",
+		Name:        "al2023-ami-minimal-kernel-default-arm64",
+		Description: "Amazon Linux 2023 minimal AMI, kernel default, arm64",
+	},
+	{
+		Parameter:   "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
+		Name:        "Windows_Server-2022-English-Full-Base",
+		Description: "Microsoft Windows Server 2022 Full Locale English AMI",
+	},
+	{
+		Parameter:   "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id",
+		Name:        "amazon-linux-2023-ecs-optimized",
+		Description: "Amazon ECS-optimized Amazon Linux 2023 AMI",
+	},
+	{
+		Parameter:   "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
+		Name:        "amazon-linux-2-ecs-optimized",
+		Description: "Amazon ECS-optimized Amazon Linux 2 AMI",
+	},
+	{
+		Parameter:   "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id",
+		Name:        "ubuntu-noble-24.04-amd64-server",
+		Description: "Canonical Ubuntu Server 24.04 LTS, amd64",
+	},
+	{
+		Parameter:   "/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id",
+		Name:        "ubuntu-jammy-22.04-amd64-server",
+		Description: "Canonical Ubuntu Server 22.04 LTS, amd64",
+	},
+}
+
+// bundledImageDefaultParameter is the parameter substrate resolves when something needs an
+// AMI and nothing named one — the CloudFormation deployer's AWS::EC2::Instance default, and
+// the family fallback for an unlisted Linux AMI path. Amazon Linux 2023 on x86_64 is the
+// choice because it is the AMI AWS's own launch examples reach for.
+const bundledImageDefaultParameter = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+
+// bundledImageFamilyDefaults maps a substring of an AMI parameter path to the catalog
+// parameter substrate answers an *unlisted* path in that family with.
+//
+// The substrings are the same four the SSM resolver has recognized since #267, so the set
+// of names that resolve does not change — only what they resolve to. Order matters, and is
+// the order of this slice rather than a map's, because "/optimized-ami/" and "-latest" can
+// both appear in one path.
+var bundledImageFamilyDefaults = []struct {
+	Match     string
+	Parameter string
+}{
+	{"/ami-windows-latest/", "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base"},
+	{"/ubuntu/", "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id"},
+	{"/optimized-ami/", "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"},
+	{"", bundledImageDefaultParameter},
+}
+
+// BundledImageID returns the AMI ID substrate resolves for an SSM public parameter in one
+// region, or "" if parameterName is not an AMI parameter path.
+//
+// It is the identifier a test fixture or a generated template should name when it needs an
+// AMI that exists: substrate refuses a launch from an AMI it cannot resolve (#733), and
+// this is the same value [SSMPlugin] answers GetParameter with, so a fixture that names it
+// and a consumer that discovers it through SSM agree.
+//
+// The ID is region-dependent, exactly as on AWS — an AMI ID names an image in one region
+// and nothing in any other — and it is derived rather than random, so it is stable across
+// runs, processes and replays.
+func BundledImageID(region, parameterName string) string {
+	img, ok := bundledImageForParameter(parameterName)
+	if !ok {
+		return ""
+	}
+	return img.idIn(region)
+}
+
+// idIn returns the image's ID in one region.
+//
+// The derivation is sha256(region + ":" + parameter), truncated to 17 hex characters —
+// AWS's current AMI-ID length. It is shared with [resolveManagedParameter] rather than
+// spelled twice so the ID a GetParameter hands out and the ID a launch resolves cannot
+// drift apart; that drift is the whole failure mode the shared helper exists to prevent.
+func (b bundledImage) idIn(region string) string {
+	sum := sha256.Sum256([]byte(region + ":" + b.Parameter))
+	return "ami-" + hex.EncodeToString(sum[:])[:17]
+}
+
+// image renders the bundled descriptor as the record the rest of the plugin reads.
+//
+// AccountID is deliberately empty. A public AWS-owned AMI is not owned by the caller, and
+// substrate holds no account for the "amazon" owner alias — so attributing it to the
+// requesting account would be a claim nothing backs and would make an Owners=self
+// DescribeImages match an image the caller does not own. Nothing renders the member for a
+// bundled image yet; DescribeImages lists state, which holds no record for these.
+func (b bundledImage) image(region string) EC2Image {
+	return EC2Image{
+		ImageID:     b.idIn(region),
+		Name:        b.Name,
+		Description: b.Description,
+		State:       "available",
+		Region:      region,
+	}
+}
+
+// bundledImageForParameter returns the bundled image an SSM parameter name resolves to.
+//
+// An exact catalog match wins. Any other /aws/service/ path whose shape says "AMI" —
+// the four substrings [bundledImageFamilyDefaults] lists, unchanged from #267's resolver —
+// falls back to its family's entry rather than to a hash of its own name. That fallback is
+// substrate's reading, and it is load-bearing: hashing the unlisted name would mint an ID
+// no catalog entry backs, so GetParameter would hand out an AMI that RunInstances then
+// refuses — a self-contradiction between two of substrate's own answers. The cost is that
+// two unlisted paths in one family resolve to the same image, which is visible only to a
+// caller comparing IDs across paths substrate does not bundle.
+func bundledImageForParameter(name string) (bundledImage, bool) {
+	if !strings.HasPrefix(name, "/aws/service/") {
+		return bundledImage{}, false
+	}
+	for _, img := range bundledImages {
+		if img.Parameter == name {
+			return img, true
+		}
+	}
+	isAMI := strings.Contains(name, "ami-") ||
+		strings.Contains(name, "/optimized-ami/") ||
+		strings.Contains(name, "/ubuntu/") ||
+		strings.Contains(name, "-latest")
+	if !isAMI {
+		return bundledImage{}, false
+	}
+	for _, fam := range bundledImageFamilyDefaults {
+		if fam.Match != "" && !strings.Contains(name, fam.Match) {
+			continue
+		}
+		for _, img := range bundledImages {
+			if img.Parameter == fam.Parameter {
+				return img, true
+			}
+		}
+	}
+	return bundledImage{}, false
+}
+
+// bundledImageByID returns the bundled image with the given ID in one region.
+//
+// The lookup is a scan and a hash per entry rather than a precomputed map, because the map
+// would have to be keyed by (region, ID) and substrate serves every AWS region — building
+// it would mean enumerating regions, which is the reason the IDs are derived rather than
+// written into state at startup in the first place. The catalog is small and the scan runs
+// once per launch.
+func bundledImageByID(region, imageID string) (bundledImage, bool) {
+	if !strings.HasPrefix(imageID, "ami-") {
+		return bundledImage{}, false
+	}
+	for _, img := range bundledImages {
+		if img.idIn(region) == imageID {
+			return img, true
+		}
+	}
+	return bundledImage{}, false
+}

--- a/emulator/ec2_bundled_images_test.go
+++ b/emulator/ec2_bundled_images_test.go
@@ -1,0 +1,258 @@
+package emulator_test
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// ec2TestRegion is the Region every request in this package's EC2 tests is addressed to —
+// [ec2Request] sets Host to ec2.us-east-1.amazonaws.com — and therefore the Region the
+// bundled AMI IDs below are derived for. An AMI ID names an image in exactly one Region on
+// AWS, and substrate's derived IDs are Region-scoped for the same reason, so a test that
+// addresses another Region must derive its own.
+const ec2TestRegion = "us-east-1"
+
+// The bundled AMIs this package's launches name.
+//
+// RunInstances refuses an AMI that names nothing (#733), so a test that launches has to
+// name one that exists. Almost none of them are *about* the AMI, and for those any of
+// these will do; the several that assert one AMI beat another — a request's over a
+// template's, a fleet override's over both — need two or more that differ, which is why
+// there is a set rather than one constant.
+//
+// Each is derived from an SSM public parameter, so a test naming one of these names exactly
+// what a consumer discovers through GetParameter. Deliberately absent: AWS's own example
+// IDs, ami-0abcdef1234567890 and ami-1234567890abcdef0. Substrate refuses those, real AWS
+// refuses those, and TestEC2_BundledImages_DocumentationExamplesAreNotBundled pins it.
+var (
+	ec2TestImage           = emulator.BundledImageID(ec2TestRegion, "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64")
+	ec2TestImageArm        = emulator.BundledImageID(ec2TestRegion, "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64")
+	ec2TestImageMinimal    = emulator.BundledImageID(ec2TestRegion, "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64")
+	ec2TestImageMinimalArm = emulator.BundledImageID(ec2TestRegion, "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64")
+	ec2TestImageWindows    = emulator.BundledImageID(ec2TestRegion, "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base")
+	ec2TestImageECS        = emulator.BundledImageID(ec2TestRegion, "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id")
+	ec2TestImageECS2       = emulator.BundledImageID(ec2TestRegion, "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id")
+	ec2TestImageUbuntu     = emulator.BundledImageID(ec2TestRegion, "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id")
+	ec2TestImageUbuntu22   = emulator.BundledImageID(ec2TestRegion, "/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id")
+)
+
+// ec2BundledParameters is every parameter the vars above name, in the same order, so a test
+// can assert a property of the whole catalog without restating the paths.
+var ec2BundledParameters = []string{
+	"/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+	"/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64",
+	"/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64",
+	"/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-arm64",
+	"/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
+	"/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id",
+	"/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
+	"/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id",
+	"/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id",
+}
+
+// TestEC2_BundledImages_IDsAreWellFormedAndDistinct pins the two properties every other
+// test in this file leans on: a bundled ID passes substrate's own AMI-ID syntax rule, and
+// no two catalog entries collide.
+//
+// A collision would be silent and would make a precedence test pass for the wrong reason —
+// "the request's AMI won" is unfalsifiable when both AMIs are the same string.
+func TestEC2_BundledImages_IDsAreWellFormedAndDistinct(t *testing.T) {
+	seen := map[string]string{}
+	for _, param := range ec2BundledParameters {
+		id := emulator.BundledImageID(ec2TestRegion, param)
+		require.NotEmpty(t, id, "no bundled image for %s", param)
+		assert.True(t, strings.HasPrefix(id, "ami-"), "%s: %q has no ami- prefix", param, id)
+		assert.Len(t, id, len("ami-")+17, "%s: %q is not AWS's 17-hex-character form", param, id)
+		for i := len("ami-"); i < len(id); i++ {
+			c := id[i]
+			require.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+				"%s: %q is not lowercase hex at index %d", param, id, i)
+		}
+		if other, dup := seen[id]; dup {
+			t.Errorf("%s and %s both derive %s", param, other, id)
+		}
+		seen[id] = param
+	}
+}
+
+// TestEC2_BundledImages_RegionScoped asserts an AMI ID means one Region, as on AWS, and
+// that it is stable across calls.
+//
+// Stability is what lets a fixture hardcode the value a previous run printed; Region
+// scoping is what stops a template that launches in eu-west-1 from succeeding with an ID
+// substrate resolves only in us-east-1, which is the divergence #733 exists to remove.
+func TestEC2_BundledImages_RegionScoped(t *testing.T) {
+	const param = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+
+	east := emulator.BundledImageID("us-east-1", param)
+	west := emulator.BundledImageID("eu-west-1", param)
+	require.NotEmpty(t, east)
+	require.NotEmpty(t, west)
+	assert.NotEqual(t, east, west, "one AMI ID cannot name an image in two Regions")
+	assert.Equal(t, east, emulator.BundledImageID("us-east-1", param), "resolution is not stable")
+}
+
+// TestEC2_BundledImages_UnlistedPathResolvesToItsFamily covers the fallback that keeps
+// GetParameter and RunInstances from contradicting each other.
+//
+// Substrate answers every /aws/service/ path that looks like an AMI, and always has, so a
+// path the catalog does not list must still resolve to an image that launches — otherwise
+// substrate hands out an AMI and then refuses it. A path that is not an AMI path at all
+// resolves to nothing, which is what makes this a fallback rather than a catch-all.
+func TestEC2_BundledImages_UnlistedPathResolvesToItsFamily(t *testing.T) {
+	tests := []struct {
+		name  string
+		param string
+		want  string
+	}{
+		{"an unlisted Windows release", "/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base", ec2TestImageWindows},
+		{"an unlisted Ubuntu release", "/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id", ec2TestImageUbuntu},
+		{"an unlisted ECS variant", "/aws/service/ecs/optimized-ami/amazon-linux-2023/gpu/recommended/image_id", ec2TestImageECS},
+		{"an unlisted Amazon Linux kernel", "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64", ec2TestImage},
+		{"a listed path is itself, not its family's default", "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64", ec2TestImageArm},
+		{"a listed release is itself, not its family's newest", "/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id", ec2TestImageUbuntu22},
+		{"not an AMI path", "/aws/service/datasync/agent", ""},
+		{"not a managed path at all", "/my/own/parameter", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, emulator.BundledImageID(ec2TestRegion, tc.param))
+		})
+	}
+}
+
+// TestEC2_BundledImages_LaunchAndRefusal is the operation #733 was filed against.
+//
+// A bundled AMI launches; a well-formed AMI ID that names nothing is InvalidAMIID.NotFound;
+// something that is not an AMI ID is InvalidAMIID.Malformed, and syntax is reported before
+// absence. All four codes and the order come from
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html.
+func TestEC2_BundledImages_LaunchAndRefusal(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	tests := []struct {
+		name     string
+		imageID  string
+		wantCode string
+	}{
+		{"a bundled AMI launches", ec2TestImage, ""},
+		{"a bundled AMI from another family launches", ec2TestImageWindows, ""},
+		{"a well-formed AMI that names nothing", "ami-0dddddddddddddddd", "InvalidAMIID.NotFound"},
+		{"an AMI ID from another Region", emulator.BundledImageID("eu-west-1", ec2BundledParameters[0]), "InvalidAMIID.NotFound"},
+		{"not an AMI ID at all", "not-an-ami", "InvalidAMIID.Malformed"},
+		{"the right prefix, the wrong alphabet", "ami-zzzzzzzz", "InvalidAMIID.Malformed"},
+		{"a placeholder an AI left behind", "ami-EXAMPLE", "InvalidAMIID.Malformed"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := ec2Request(t, ts, map[string]string{
+				"Action":  "RunInstances",
+				"ImageId": tc.imageID,
+			})
+			defer resp.Body.Close() //nolint:errcheck
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			if tc.wantCode == "" {
+				assert.Equal(t, http.StatusOK, resp.StatusCode, "body was %s", body)
+				return
+			}
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "body was %s", body)
+			assert.Contains(t, string(body), tc.wantCode)
+		})
+	}
+}
+
+// TestEC2_BundledImages_MalformedBeatsNotFound pins the ordering separately, because both
+// refusals are 400s and a test that only checked the status would not notice the two codes
+// swapping.
+func TestEC2_BundledImages_MalformedBeatsNotFound(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	resp := ec2Request(t, ts, map[string]string{
+		"Action":  "RunInstances",
+		"ImageId": "ami-nope",
+	})
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "InvalidAMIID.Malformed")
+	assert.NotContains(t, string(body), "InvalidAMIID.NotFound")
+}
+
+// TestEC2_BundledImages_DocumentationExamplesAreNotBundled is the membership tripwire.
+//
+// AWS's reference pages use ami-0abcdef1234567890 and ami-1234567890abcdef0 as example IDs,
+// and generated IaC copies them. Both must be refused: the reason to refuse an unknown AMI
+// at all is that a launch which works in substrate should work on real AWS, and bundling a
+// doc example — however convenient for the fixtures in this package — would reintroduce
+// exactly the divergence #733 was filed to remove.
+func TestEC2_BundledImages_DocumentationExamplesAreNotBundled(t *testing.T) {
+	ts := newEC2TestServer(t)
+
+	for _, imageID := range []string{"ami-0abcdef1234567890", "ami-1234567890abcdef0"} {
+		t.Run(imageID, func(t *testing.T) {
+			resp := ec2Request(t, ts, map[string]string{"Action": "RunInstances", "ImageId": imageID})
+			defer resp.Body.Close() //nolint:errcheck
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "body was %s", body)
+			assert.Contains(t, string(body), "InvalidAMIID.NotFound")
+		})
+	}
+}
+
+// TestEC2_BundledImages_SSMDiscoveryThenLaunch is the coherence check between two plugins:
+// the AMI GetParameter hands out is the AMI RunInstances accepts.
+//
+// Those were independent computations through v0.107.0 — the SSM resolver hashed the
+// parameter name, and nothing on the EC2 side had any notion of an AMI existing — so nothing
+// could have caught them diverging. Once one refuses, the other's answer has to be
+// resolvable, and this asserts that over the whole catalog rather than trusting the shared
+// helper both now call. Both servers are addressed to [ec2TestRegion], which is what makes
+// the two IDs comparable at all.
+func TestEC2_BundledImages_SSMDiscoveryThenLaunch(t *testing.T) {
+	ssm := newSSMTestServer(t)
+	ec2 := newEC2TestServer(t)
+
+	for _, param := range ec2BundledParameters {
+		t.Run(param, func(t *testing.T) {
+			resp := ssmRequest(t, ssm, "GetParameter", map[string]interface{}{"Name": param})
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			parameter, ok := readSSMBody(t, resp)["Parameter"].(map[string]interface{})
+			require.True(t, ok, "GetParameter %s returned no Parameter member", param)
+
+			imageID, ok := parameter["Value"].(string)
+			require.True(t, ok, "GetParameter %s returned no Value", param)
+			assert.Equal(t, emulator.BundledImageID(ec2TestRegion, param), imageID,
+				"GetParameter and BundledImageID disagree about %s", param)
+
+			launch := ec2Request(t, ec2, map[string]string{
+				"Action":  "RunInstances",
+				"ImageId": imageID,
+			})
+			defer launch.Body.Close() //nolint:errcheck
+			body, err := io.ReadAll(launch.Body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, launch.StatusCode,
+				"RunInstances from the discovered AMI: %s", body)
+
+			var launched struct {
+				Instances []struct {
+					ImageID string `xml:"imageId"`
+				} `xml:"instancesSet>item"`
+			}
+			require.NoError(t, xml.Unmarshal(body, &launched))
+			require.Len(t, launched.Instances, 1)
+			assert.Equal(t, imageID, launched.Instances[0].ImageID)
+		})
+	}
+}

--- a/emulator/ec2_default_vpc_refusal_test.go
+++ b/emulator/ec2_default_vpc_refusal_test.go
@@ -29,7 +29,7 @@ func TestEC2_DefaultVPC_BadSecurityGroupRefusalWritesNothing(t *testing.T) {
 
 	status, code, msg := ec2ErrorDetail(t, ts, map[string]string{
 		"Action":            "RunInstances",
-		"ImageId":           "ami-0abcdef1234567890",
+		"ImageId":           ec2TestImage,
 		"MinCount":          "1",
 		"MaxCount":          "1",
 		"SecurityGroupId.1": "sg-0000000000000dead",
@@ -128,7 +128,7 @@ func TestEC2_DefaultVPC_MembershipStillRefusedAfterResolution(t *testing.T) {
 
 	_, code, msg := ec2ErrorDetail(t, ts, map[string]string{
 		"Action":            "RunInstances",
-		"ImageId":           "ami-0abcdef1234567890",
+		"ImageId":           ec2TestImage,
 		"MinCount":          "1",
 		"MaxCount":          "1",
 		"SecurityGroupId.1": group.GroupID,

--- a/emulator/ec2_describe_filters_test.go
+++ b/emulator/ec2_describe_filters_test.go
@@ -1091,7 +1091,7 @@ func TestEC2_LaunchTemplateVersionFilters_FourOfFourteen(t *testing.T) {
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                            "CreateLaunchTemplateVersion",
 		"LaunchTemplateId":                  ltID,
-		"LaunchTemplateData.ImageId":        "ami-0000000000000beef",
+		"LaunchTemplateData.ImageId":        ec2TestImageArm,
 		"LaunchTemplateData.InstanceType":   "m5.4xlarge",
 		"LaunchTemplateData.KeyName":        "irrelevant",
 		"LaunchTemplateData.EbsOptimized":   "false",
@@ -1123,10 +1123,10 @@ func TestEC2_LaunchTemplateVersionFilters_FourOfFourteen(t *testing.T) {
 	t.Run("image-id", func(t *testing.T) {
 		items := describe(map[string]string{
 			"Action": "DescribeLaunchTemplateVersions", "LaunchTemplateId": ltID,
-			"Filter.1.Name": "image-id", "Filter.1.Value.1": "ami-0000000000000beef",
+			"Filter.1.Name": "image-id", "Filter.1.Value.1": ec2TestImageArm,
 		})
 		require.Len(t, items, 1)
-		assert.Equal(t, "ami-0000000000000beef", items[0].ImageID)
+		assert.Equal(t, ec2TestImageArm, items[0].ImageID)
 	})
 
 	t.Run("instance-type", func(t *testing.T) {

--- a/emulator/ec2_fleet_test.go
+++ b/emulator/ec2_fleet_test.go
@@ -98,7 +98,7 @@ func newFleetLaunchTemplate(t *testing.T, ts *httptest.Server, name string) stri
 	ec2FleetXML(t, ts, map[string]string{
 		"Action":                          "CreateLaunchTemplate",
 		"LaunchTemplateName":              name,
-		"LaunchTemplateData.ImageId":      "ami-0fleet0000000001",
+		"LaunchTemplateData.ImageId":      ec2TestImage,
 		"LaunchTemplateData.InstanceType": "t3.micro",
 	}, &lt)
 	if lt.LaunchTemplateID == "" {

--- a/emulator/ec2_idkind_convergence_test.go
+++ b/emulator/ec2_idkind_convergence_test.go
@@ -412,7 +412,7 @@ func TestEC2_IDKind_ConvergedOperationsStillSucceed(t *testing.T) {
 		"Action": "AllocateAddress", "Domain": "vpc",
 	}, "allocationId")
 	instanceID := ec2CreateAndExtract(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-0abcdef1234567890", "InstanceType": "t3.micro",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"MinCount": "1", "MaxCount": "1", "SubnetId": subnetID,
 	}, "instanceId")
 	volID := ec2CreateAndExtract(t, ts, map[string]string{

--- a/emulator/ec2_instance_blockdevices_test.go
+++ b/emulator/ec2_instance_blockdevices_test.go
@@ -123,7 +123,7 @@ func TestEC2_InstanceBlockDeviceMapping_RunInstances(t *testing.T) {
 	ts := newEC2TestServer(t)
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                              "RunInstances",
-		"ImageId":                             "ami-0abcdef1234567890",
+		"ImageId":                             ec2TestImage,
 		"MinCount":                            "1",
 		"MaxCount":                            "1",
 		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",

--- a/emulator/ec2_instanceattribute_test.go
+++ b/emulator/ec2_instanceattribute_test.go
@@ -93,7 +93,7 @@ func TestEC2_InstanceAttribute_UserData(t *testing.T) {
 
 	encoded := base64.StdEncoding.EncodeToString([]byte("#!/bin/bash\necho hello\n"))
 	id := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro", "UserData": encoded,
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro", "UserData": encoded,
 	})
 
 	got := describeInstanceAttribute(t, ts, id, "userData")
@@ -120,7 +120,7 @@ func TestEC2_InstanceAttribute_UserDataFromLaunchTemplate(t *testing.T) {
 
 	encoded := base64.StdEncoding.EncodeToString([]byte("from-the-template"))
 	ltID := createLaunchTemplate(t, ts, "lt-userdata", map[string]string{
-		"LaunchTemplateData.ImageId":      "ami-tmpl",
+		"LaunchTemplateData.ImageId":      ec2TestImage,
 		"LaunchTemplateData.InstanceType": "t3.small",
 		"LaunchTemplateData.UserData":     encoded,
 	})
@@ -147,7 +147,7 @@ func TestEC2_InstanceAttribute_RequestBeatsTemplate(t *testing.T) {
 	tmpl := base64.StdEncoding.EncodeToString([]byte("template"))
 	req := base64.StdEncoding.EncodeToString([]byte("request"))
 	ltID := createLaunchTemplate(t, ts, "lt-userdata-override", map[string]string{
-		"LaunchTemplateData.ImageId":  "ami-tmpl",
+		"LaunchTemplateData.ImageId":  ec2TestImage,
 		"LaunchTemplateData.UserData": tmpl,
 	})
 
@@ -175,7 +175,7 @@ func TestEC2_InstanceAttribute_UnsetIsPresentButEmpty(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	id := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 	})
 
 	got := describeInstanceAttribute(t, ts, id, "userData")
@@ -195,7 +195,7 @@ func TestEC2_InstanceAttribute_SupportedAttributes(t *testing.T) {
 	subnetID := createSubnet(t, ts, vpcID, "10.9.1.0/24")
 
 	id := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.large",
+		"ImageId": ec2TestImage, "InstanceType": "t3.large",
 		"SubnetId": subnetID, "SecurityGroupId.1": sgID,
 		"DisableApiTermination": "true",
 	})
@@ -229,7 +229,7 @@ func TestEC2_InstanceAttribute_DisableAPITerminationDefaultsFalse(t *testing.T) 
 	t.Parallel()
 	ts := newEC2TestServer(t)
 
-	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	id := runInstance(t, ts, map[string]string{"ImageId": ec2TestImage, "InstanceType": "t3.micro"})
 
 	got := describeInstanceAttribute(t, ts, id, "disableApiTermination")
 	require.NotNil(t, got.DisableAPI)
@@ -256,7 +256,7 @@ func TestEC2_InstanceAttribute_DisableAPITerminationDefaultsFalse(t *testing.T) 
 func TestEC2_InstanceAttribute_UnknownAttribute(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
-	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	id := runInstance(t, ts, map[string]string{"ImageId": ec2TestImage, "InstanceType": "t3.micro"})
 
 	for _, attr := range []string{
 		"enaSupport", // listed by AWS, rejected by AWS
@@ -309,7 +309,7 @@ func TestEC2_InstanceAttribute_AttributeCheckedBeforeInstance(t *testing.T) {
 func TestEC2_InstanceAttribute_RequiredParameters(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
-	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	id := runInstance(t, ts, map[string]string{"ImageId": ec2TestImage, "InstanceType": "t3.micro"})
 
 	tests := []struct {
 		name   string
@@ -365,7 +365,7 @@ func TestEC2_InstanceAttribute_ModifyUserData(t *testing.T) {
 	first := base64.StdEncoding.EncodeToString([]byte("first"))
 	second := base64.StdEncoding.EncodeToString([]byte("second"))
 	id := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro", "UserData": first,
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro", "UserData": first,
 	})
 	stopInstance(t, ts, id)
 
@@ -391,7 +391,7 @@ func TestEC2_InstanceAttribute_ModifyUserDataCanClear(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	id := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"UserData": base64.StdEncoding.EncodeToString([]byte("to-be-cleared")),
 	})
 	stopInstance(t, ts, id)
@@ -439,7 +439,7 @@ func TestEC2_InstanceAttribute_ModifyRequiresStopped(t *testing.T) {
 
 			original := base64.StdEncoding.EncodeToString([]byte("original"))
 			id := runInstance(t, ts, map[string]string{
-				"ImageId": "ami-1", "InstanceType": "t3.micro", "UserData": original,
+				"ImageId": ec2TestImage, "InstanceType": "t3.micro", "UserData": original,
 			})
 
 			status, code, msg := ec2ErrorDetail(t, ts, map[string]string{
@@ -483,7 +483,7 @@ func TestEC2_InstanceAttribute_TerminationProtectionNotGated(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
 
-	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	id := runInstance(t, ts, map[string]string{"ImageId": ec2TestImage, "InstanceType": "t3.micro"})
 
 	// Still running.
 	status := modifyInstanceAttribute(t, ts, map[string]string{
@@ -541,7 +541,7 @@ func TestEC2_InstanceAttribute_ModifyUnknownInstance(t *testing.T) {
 func TestEC2_InstanceAttribute_ResponseWrapsTheValue(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
-	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	id := runInstance(t, ts, map[string]string{"ImageId": ec2TestImage, "InstanceType": "t3.micro"})
 
 	resp := ec2Request(t, ts, map[string]string{
 		"Action": "DescribeInstanceAttribute", "InstanceId": id, "Attribute": "instanceType",
@@ -585,7 +585,7 @@ func TestEC2_InstanceAttribute_EmptyGroupSetIsStillPresent(t *testing.T) {
 	inst := map[string]any{
 		"instance_id":   instID,
 		"instance_type": "t3.micro",
-		"image_id":      "ami-1",
+		"image_id":      ec2TestImage,
 		"state":         map[string]any{"code": 16, "name": "running"},
 		"account_id":    "123456789012",
 		"region":        "us-east-1",
@@ -690,7 +690,7 @@ func TestEC2_TerminateInstances_ProtectionRefused(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	id := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"DisableApiTermination": "true",
 	})
 
@@ -712,7 +712,7 @@ func TestEC2_TerminateInstances_ProtectionClearedThenTerminates(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	id := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"DisableApiTermination": "true",
 	})
 	require.Equal(t, http.StatusOK, modifyInstanceAttribute(t, ts, map[string]string{
@@ -731,8 +731,8 @@ func TestEC2_TerminateInstances_UnprotectedUnaffected(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
 
-	a := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
-	b := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	a := runInstance(t, ts, map[string]string{"ImageId": ec2TestImage, "InstanceType": "t3.micro"})
+	b := runInstance(t, ts, map[string]string{"ImageId": ec2TestImage, "InstanceType": "t3.micro"})
 
 	code, body := terminateInstances(t, ts, a, b)
 	require.Equal(t, http.StatusOK, code, "body was %s", body)
@@ -758,7 +758,7 @@ func TestEC2_TerminateInstances_ProtectionIsZoneScoped(t *testing.T) {
 
 	launch := func(az string, protected bool) string {
 		params := map[string]string{
-			"ImageId": "ami-1", "InstanceType": "t3.micro",
+			"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 			"Placement.AvailabilityZone": az,
 		}
 		if protected {
@@ -792,12 +792,12 @@ func TestEC2_TerminateInstances_ProtectedAloneInItsZone(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	protected := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"Placement.AvailabilityZone": "us-east-1a",
 		"DisableApiTermination":      "true",
 	})
 	other := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"Placement.AvailabilityZone": "us-east-1b",
 	})
 
@@ -817,7 +817,7 @@ func TestEC2_TerminateInstances_BadIDTerminatesNothing(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
 
-	good := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	good := runInstance(t, ts, map[string]string{"ImageId": ec2TestImage, "InstanceType": "t3.micro"})
 
 	code, _ := terminateInstances(t, ts, good, "i-0deadbeefdeadbeef")
 	assert.Equal(t, http.StatusBadRequest, code)
@@ -832,7 +832,7 @@ func TestEC2_TerminateInstances_Idempotent(t *testing.T) {
 	t.Parallel()
 	ts := newEC2TestServer(t)
 
-	id := runInstance(t, ts, map[string]string{"ImageId": "ami-1", "InstanceType": "t3.micro"})
+	id := runInstance(t, ts, map[string]string{"ImageId": ec2TestImage, "InstanceType": "t3.micro"})
 	code, _ := terminateInstances(t, ts, id)
 	require.Equal(t, http.StatusOK, code)
 	code, body := terminateInstances(t, ts, id)
@@ -856,14 +856,14 @@ func TestEC2_TerminateInstances_ZoneFromSubnet(t *testing.T) {
 	subnetB := createSubnetInAZ(t, ts, vpcID, "10.0.2.0/24", "us-east-1b")
 
 	protected := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"SubnetId": subnetA, "DisableApiTermination": "true",
 	})
 	sameZone := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro", "SubnetId": subnetA,
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro", "SubnetId": subnetA,
 	})
 	otherZone := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro", "SubnetId": subnetB,
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro", "SubnetId": subnetB,
 	})
 
 	code, _ := terminateInstances(t, ts, protected, sameZone, otherZone)
@@ -885,7 +885,7 @@ func TestEC2_Instance_ReportsAvailabilityZone(t *testing.T) {
 	// RunInstances reports it directly, so no follow-up describe is needed.
 	resp := ec2Request(t, ts, map[string]string{
 		"Action": "RunInstances", "MinCount": "1", "MaxCount": "1",
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"Placement.AvailabilityZone": "us-west-2c",
 	})
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -923,11 +923,11 @@ func TestEC2_DescribeInstances_AvailabilityZoneFilter(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	inA := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"Placement.AvailabilityZone": "eu-west-1a",
 	})
 	inB := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"Placement.AvailabilityZone": "eu-west-1b",
 	})
 
@@ -958,7 +958,7 @@ func TestEC2_Instance_AlwaysCarriesAZone(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	id := runInstance(t, ts, map[string]string{
-		"ImageId": "ami-1", "InstanceType": "t3.micro",
+		"ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"SubnetId": "subnet-0000000000000dead",
 	})
 

--- a/emulator/ec2_launchtemplate_test.go
+++ b/emulator/ec2_launchtemplate_test.go
@@ -143,7 +143,7 @@ func TestEC2_LaunchTemplate_SubnetSources(t *testing.T) {
 		ts := newEC2TestServer(t)
 		net := newLTNetwork(t, ts, "10.1.0.0/16", "lt-case-a")
 		ltID := createLaunchTemplate(t, ts, "case-a", map[string]string{
-			"LaunchTemplateData.ImageId":                        "ami-0case00000000001",
+			"LaunchTemplateData.ImageId":                        ec2TestImage,
 			"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
 			"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
 		})
@@ -159,7 +159,7 @@ func TestEC2_LaunchTemplate_SubnetSources(t *testing.T) {
 		ts := newEC2TestServer(t)
 		net := newLTNetwork(t, ts, "10.2.0.0/16", "lt-case-b")
 		ltID := createLaunchTemplate(t, ts, "case-b", map[string]string{
-			"LaunchTemplateData.ImageId": "ami-0case00000000002",
+			"LaunchTemplateData.ImageId": ec2TestImageArm,
 		})
 
 		id := runInstance(t, ts, map[string]string{
@@ -175,7 +175,7 @@ func TestEC2_LaunchTemplate_SubnetSources(t *testing.T) {
 		ts := newEC2TestServer(t)
 		net := newLTNetwork(t, ts, "10.3.0.0/16", "lt-case-c")
 		ltID := createLaunchTemplate(t, ts, "case-c", map[string]string{
-			"LaunchTemplateData.ImageId": "ami-0case00000000003",
+			"LaunchTemplateData.ImageId": ec2TestImageMinimal,
 		})
 
 		var fleet createFleetResp
@@ -200,7 +200,7 @@ func TestEC2_LaunchTemplate_SubnetSources(t *testing.T) {
 		ts := newEC2TestServer(t)
 		net := newLTNetwork(t, ts, "10.4.0.0/16", "lt-case-d")
 		ltID := createLaunchTemplate(t, ts, "case-d", map[string]string{
-			"LaunchTemplateData.ImageId":                        "ami-0case00000000004",
+			"LaunchTemplateData.ImageId":                        ec2TestImageMinimalArm,
 			"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
 			"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
 		})
@@ -235,7 +235,7 @@ func TestEC2_LaunchTemplate_SubnetPrecedence(t *testing.T) {
 	overrideNet := newLTNetwork(t, ts, "10.7.0.0/16", "lt-prec-override")
 
 	ltID := createLaunchTemplate(t, ts, "precedence", map[string]string{
-		"LaunchTemplateData.ImageId":                        "ami-0prec00000000001",
+		"LaunchTemplateData.ImageId":                        ec2TestImage,
 		"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
 		"LaunchTemplateData.NetworkInterface.1.SubnetId":    templateNet.subnetID,
 	})
@@ -310,7 +310,7 @@ func TestEC2_LaunchTemplate_SecurityGroups(t *testing.T) {
 
 			// A group from the template's own VPC launches.
 			sameVPC := createLaunchTemplate(t, ts, "sg-same-"+tt.param, map[string]string{
-				"LaunchTemplateData.ImageId":                        "ami-0sg000000000001",
+				"LaunchTemplateData.ImageId":                        ec2TestImage,
 				"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
 				"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
 				tt.param: net.sgID,
@@ -327,7 +327,7 @@ func TestEC2_LaunchTemplate_SecurityGroups(t *testing.T) {
 			// A group from a different VPC than the template's subnet must be
 			// rejected — which proves the list was read rather than ignored.
 			crossVPC := createLaunchTemplate(t, ts, "sg-cross-"+tt.param, map[string]string{
-				"LaunchTemplateData.ImageId":                        "ami-0sg000000000002",
+				"LaunchTemplateData.ImageId":                        ec2TestImageArm,
 				"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
 				"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
 				tt.param: other.sgID,
@@ -381,7 +381,7 @@ func TestEC2_LaunchTemplate_AssociatePublicIPAddress(t *testing.T) {
 			ts := newEC2TestServer(t)
 			net := newLTNetwork(t, ts, "10.9.0.0/16", "lt-public-ip")
 			data := map[string]string{
-				"LaunchTemplateData.ImageId":                        "ami-0pub00000000001",
+				"LaunchTemplateData.ImageId":                        ec2TestImage,
 				"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
 				"LaunchTemplateData.NetworkInterface.1.SubnetId":    net.subnetID,
 			}
@@ -406,7 +406,7 @@ func TestEC2_LaunchTemplate_AssociatePublicIPAddress(t *testing.T) {
 func TestEC2_LaunchTemplate_NoNetworkInterface(t *testing.T) {
 	ts := newEC2TestServer(t)
 	ltID := createLaunchTemplate(t, ts, "no-ni", map[string]string{
-		"LaunchTemplateData.ImageId":      "ami-0noni0000000001",
+		"LaunchTemplateData.ImageId":      ec2TestImage,
 		"LaunchTemplateData.InstanceType": "t3.small",
 	})
 
@@ -442,7 +442,7 @@ func TestEC2_LaunchTemplate_MergesWithRequestParams(t *testing.T) {
 	ts := newEC2TestServer(t)
 	net := newLTNetwork(t, ts, "10.20.0.0/16", "lt-merge")
 	ltID := createLaunchTemplate(t, ts, "merge", map[string]string{
-		"LaunchTemplateData.ImageId":                                     "ami-0template000001",
+		"LaunchTemplateData.ImageId":                                     ec2TestImage,
 		"LaunchTemplateData.InstanceType":                                "c5.xlarge",
 		"LaunchTemplateData.KeyName":                                     "template-key",
 		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
@@ -455,11 +455,11 @@ func TestEC2_LaunchTemplate_MergesWithRequestParams(t *testing.T) {
 		"LaunchTemplate.LaunchTemplateId": ltID,
 		// The only field the request names. Before #453 its presence alone was
 		// enough to discard everything else above.
-		"ImageId": "ami-0request0000001",
+		"ImageId": ec2TestImageArm,
 	})
 	got := describeInstance(t, ts, id)
 
-	if got.ImageID != "ami-0request0000001" {
+	if got.ImageID != ec2TestImageArm {
 		t.Errorf("imageId = %q, want the request's AMI", got.ImageID)
 	}
 	if got.InstanceType != "c5.xlarge" {
@@ -565,10 +565,10 @@ func TestEC2_LaunchTemplate_FieldPrecedence(t *testing.T) {
 		},
 		{
 			name:          "the template fills an absent ImageId",
-			templateData:  map[string]string{"LaunchTemplateData.ImageId": "ami-0template000002"},
+			templateData:  map[string]string{"LaunchTemplateData.ImageId": ec2TestImageArm},
 			requestParams: map[string]string{},
 			check: func(t *testing.T, got launchedInstance) {
-				if got.ImageID != "ami-0template000002" {
+				if got.ImageID != ec2TestImageArm {
 					t.Errorf("imageId = %q, want the template's", got.ImageID)
 				}
 			},
@@ -582,7 +582,7 @@ func TestEC2_LaunchTemplate_FieldPrecedence(t *testing.T) {
 			// Every template carries an AMI so the #412 check is satisfied even in
 			// the cases whose request names one; a case asserting on the AMI
 			// overrides it explicitly.
-			data := map[string]string{"LaunchTemplateData.ImageId": "ami-0template000001"}
+			data := map[string]string{"LaunchTemplateData.ImageId": ec2TestImage}
 			for k, v := range tt.templateData {
 				data[k] = v
 			}
@@ -611,7 +611,7 @@ func TestEC2_LaunchTemplate_NetworkingPrecedenceWithRequestImageID(t *testing.T)
 	reqNet := newLTNetwork(t, ts, "10.31.0.0/16", "lt-net-req")
 
 	ltID := createLaunchTemplate(t, ts, "net-precedence", map[string]string{
-		"LaunchTemplateData.ImageId":                                     "ami-0template000003",
+		"LaunchTemplateData.ImageId":                                     ec2TestImage,
 		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
 		"LaunchTemplateData.NetworkInterface.1.SubnetId":                 tmplNet.subnetID,
 		"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1":        tmplNet.sgID,
@@ -620,7 +620,7 @@ func TestEC2_LaunchTemplate_NetworkingPrecedenceWithRequestImageID(t *testing.T)
 
 	got := describeInstance(t, ts, runInstance(t, ts, map[string]string{
 		"LaunchTemplate.LaunchTemplateId": ltID,
-		"ImageId":                         "ami-0request0000002",
+		"ImageId":                         ec2TestImageArm,
 		"SubnetId":                        reqNet.subnetID,
 		"SecurityGroupId.1":               reqNet.sgID,
 	}))
@@ -649,7 +649,7 @@ func TestEC2_LaunchTemplate_RequestFalseBeatsTemplateTrue(t *testing.T) {
 	ts := newEC2TestServer(t)
 	net := newLTNetwork(t, ts, "10.40.0.0/16", "lt-public-false")
 	ltID := createLaunchTemplate(t, ts, "public-false", map[string]string{
-		"LaunchTemplateData.ImageId":                                     "ami-0template000004",
+		"LaunchTemplateData.ImageId":                                     ec2TestImage,
 		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
 		"LaunchTemplateData.NetworkInterface.1.SubnetId":                 net.subnetID,
 		"LaunchTemplateData.NetworkInterface.1.AssociatePublicIpAddress": "true",
@@ -657,7 +657,7 @@ func TestEC2_LaunchTemplate_RequestFalseBeatsTemplateTrue(t *testing.T) {
 
 	got := describeInstance(t, ts, runInstance(t, ts, map[string]string{
 		"LaunchTemplate.LaunchTemplateId": ltID,
-		"ImageId":                         "ami-0request0000003",
+		"ImageId":                         ec2TestImageArm,
 		"NetworkInterface.1.AssociatePublicIpAddress": "false",
 		"NetworkInterface.1.SubnetId":                 net.subnetID,
 	}))
@@ -773,7 +773,7 @@ func TestEC2_LaunchTemplate_RoundTripsTagsAndProfile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := newEC2TestServer(t)
 			data := map[string]string{
-				"LaunchTemplateData.ImageId": "ami-0roundtrip000001",
+				"LaunchTemplateData.ImageId": ec2TestImage,
 				tt.profileParam:              tt.profile,
 			}
 			for k, v := range ltTagParams([2]string{"Env", "prod"}, [2]string{"Team", "core"}) {
@@ -811,7 +811,7 @@ func TestEC2_LaunchTemplate_RoundTripsTagsAndProfile(t *testing.T) {
 // created, and it can fail even when the tagSet is right.
 func TestEC2_LaunchTemplate_TagsReachTheInstance(t *testing.T) {
 	ts := newEC2TestServer(t)
-	data := map[string]string{"LaunchTemplateData.ImageId": "ami-0tagsreach00001"}
+	data := map[string]string{"LaunchTemplateData.ImageId": ec2TestImage}
 	for k, v := range ltTagParams([2]string{"Env", "prod"}, [2]string{"Team", "core"}) {
 		data[k] = v
 	}
@@ -856,7 +856,7 @@ func TestEC2_LaunchTemplate_ProfileReachesTheInstance(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := newEC2TestServer(t)
 			ltID := createLaunchTemplate(t, ts, "profile-"+tt.param, map[string]string{
-				"LaunchTemplateData.ImageId": "ami-0profile0000001",
+				"LaunchTemplateData.ImageId": ec2TestImage,
 				tt.param:                     tt.value,
 			})
 			instID := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
@@ -938,7 +938,7 @@ func TestEC2_LaunchTemplate_TagAndProfilePrecedence(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := newEC2TestServer(t)
-			data := map[string]string{"LaunchTemplateData.ImageId": "ami-0precedence0001"}
+			data := map[string]string{"LaunchTemplateData.ImageId": ec2TestImage}
 			for k, v := range tt.templateData {
 				data[k] = v
 			}
@@ -974,7 +974,7 @@ func TestEC2_LaunchTemplate_TagsAreSubjectToTheTagRules(t *testing.T) {
 		params := map[string]string{
 			"Action":                     "CreateLaunchTemplate",
 			"LaunchTemplateName":         "reserved-tag",
-			"LaunchTemplateData.ImageId": "ami-0reserved00001",
+			"LaunchTemplateData.ImageId": ec2TestImage,
 		}
 		for k, v := range ltTagParams([2]string{"Name", "ok"}, [2]string{"aws:foo", "v"}) {
 			params[k] = v
@@ -986,13 +986,13 @@ func TestEC2_LaunchTemplate_TagsAreSubjectToTheTagRules(t *testing.T) {
 
 		// Nothing is created, so the name is still free.
 		_ = createLaunchTemplate(t, ts, "reserved-tag", map[string]string{
-			"LaunchTemplateData.ImageId": "ami-0reserved00002",
+			"LaunchTemplateData.ImageId": ec2TestImageArm,
 		})
 	})
 
 	t.Run("SourceVersion inheritance does not outrank the new version's tags", func(t *testing.T) {
 		ts := newEC2TestServer(t)
-		v1 := map[string]string{"LaunchTemplateData.ImageId": "ami-0overlay00000001"}
+		v1 := map[string]string{"LaunchTemplateData.ImageId": ec2TestImageMinimal}
 		for k, v := range ltTagParams([2]string{"Env", "one"}) {
 			v1[k] = v
 		}
@@ -1029,12 +1029,12 @@ func TestEC2_LaunchTemplate_TagsAreSubjectToTheTagRules(t *testing.T) {
 	t.Run("a new version carrying a reserved key is rejected", func(t *testing.T) {
 		ts := newEC2TestServer(t)
 		ltID := createLaunchTemplate(t, ts, "reserved-version", map[string]string{
-			"LaunchTemplateData.ImageId": "ami-0reserved00003",
+			"LaunchTemplateData.ImageId": ec2TestImageMinimalArm,
 		})
 		params := map[string]string{
 			"Action":                     "CreateLaunchTemplateVersion",
 			"LaunchTemplateId":           ltID,
-			"LaunchTemplateData.ImageId": "ami-0reserved00004",
+			"LaunchTemplateData.ImageId": ec2TestImageWindows,
 		}
 		for k, v := range ltTagParams([2]string{"aws:foo", "v"}) {
 			params[k] = v
@@ -1055,7 +1055,7 @@ func TestEC2_LaunchTemplate_TagsAreSubjectToTheTagRules(t *testing.T) {
 		params := map[string]string{
 			"Action":                     "CreateLaunchTemplate",
 			"LaunchTemplateName":         "too-many-tags",
-			"LaunchTemplateData.ImageId": "ami-0toomany000001",
+			"LaunchTemplateData.ImageId": ec2TestImageECS,
 		}
 		for k, v := range ltTagParams(tags...) {
 			params[k] = v
@@ -1072,7 +1072,7 @@ func TestEC2_LaunchTemplate_TagsAreSubjectToTheTagRules(t *testing.T) {
 		for i := 1; i <= ec2TagLimit; i++ {
 			tags = append(tags, [2]string{fmt.Sprintf("key%d", i), "v"})
 		}
-		data := map[string]string{"LaunchTemplateData.ImageId": "ami-0atlimit0000001"}
+		data := map[string]string{"LaunchTemplateData.ImageId": ec2TestImageECS2}
 		for k, v := range ltTagParams(tags...) {
 			data[k] = v
 		}
@@ -1116,7 +1116,7 @@ func storeTemplateWithTags(t *testing.T, name, ltID string, tags []map[string]st
 		"createdBy":            acct,
 		"createTime":           "2026-01-01T00:00:00Z",
 		"latestData": map[string]any{
-			"imageId":           "ami-0stored00000001",
+			"imageId":           ec2TestImage,
 			"tagSpecifications": tags,
 		},
 		"accountID": acct,
@@ -1190,7 +1190,7 @@ func storedNumberedTags(count int) []map[string]string {
 // exactly the path #443 added.
 func TestEC2_Fleet_TemplateTagsReachFleetInstances(t *testing.T) {
 	ts := newEC2TestServer(t)
-	data := map[string]string{"LaunchTemplateData.ImageId": "ami-0fleettags00001"}
+	data := map[string]string{"LaunchTemplateData.ImageId": ec2TestImage}
 	for k, v := range ltTagParams([2]string{"Env", "prod"}) {
 		data[k] = v
 	}
@@ -1219,7 +1219,7 @@ func TestEC2_LaunchTemplate_DescribeEchoesNetworking(t *testing.T) {
 	ts := newEC2TestServer(t)
 	net := newLTNetwork(t, ts, "10.10.0.0/16", "lt-echo")
 	ltID := createLaunchTemplate(t, ts, "echo", map[string]string{
-		"LaunchTemplateData.ImageId":                                     "ami-0echo0000000001",
+		"LaunchTemplateData.ImageId":                                     ec2TestImage,
 		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
 		"LaunchTemplateData.NetworkInterface.1.SubnetId":                 net.subnetID,
 		"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1":        net.sgID,

--- a/emulator/ec2_launchtemplate_versions_test.go
+++ b/emulator/ec2_launchtemplate_versions_test.go
@@ -114,7 +114,7 @@ func describeLT(t *testing.T, ts *httptest.Server, ltID string) ltSummary {
 func TestEC2_CreateLaunchTemplate_MakesVersionOne(t *testing.T) {
 	ts := newEC2TestServer(t)
 	ltID := createLaunchTemplate(t, ts, "v1-only", map[string]string{
-		"LaunchTemplateData.ImageId":      "ami-0000000000000001",
+		"LaunchTemplateData.ImageId":      ec2TestImage,
 		"LaunchTemplateData.InstanceType": "t3.small",
 		"VersionDescription":              "initial",
 	})
@@ -128,7 +128,7 @@ func TestEC2_CreateLaunchTemplate_MakesVersionOne(t *testing.T) {
 	assert.Equal(t, int64(1), versions[0].VersionNumber)
 	assert.True(t, versions[0].DefaultVersion)
 	assert.Equal(t, "initial", versions[0].VersionDescription)
-	assert.Equal(t, "ami-0000000000000001", versions[0].Data.ImageID)
+	assert.Equal(t, ec2TestImage, versions[0].Data.ImageID)
 	assert.Equal(t, "t3.small", versions[0].Data.InstanceType)
 }
 
@@ -139,20 +139,20 @@ func TestEC2_CreateLaunchTemplate_MakesVersionOne(t *testing.T) {
 func TestEC2_CreateLaunchTemplateVersion_AppendsWithoutChangingDefault(t *testing.T) {
 	ts := newEC2TestServer(t)
 	ltID := createLaunchTemplate(t, ts, "appends", map[string]string{
-		"LaunchTemplateData.ImageId":      "ami-0000000000000001",
+		"LaunchTemplateData.ImageId":      ec2TestImage,
 		"LaunchTemplateData.InstanceType": "t3.small",
 	})
 
 	second := createLTVersion(t, ts, map[string]string{
 		"LaunchTemplateId":           ltID,
-		"LaunchTemplateData.ImageId": "ami-0000000000000002",
+		"LaunchTemplateData.ImageId": ec2TestImageArm,
 	})
 	assert.Equal(t, int64(2), second.VersionNumber)
 	assert.False(t, second.DefaultVersion, "a new version must not become the default")
 
 	third := createLTVersion(t, ts, map[string]string{
 		"LaunchTemplateId":           ltID,
-		"LaunchTemplateData.ImageId": "ami-0000000000000003",
+		"LaunchTemplateData.ImageId": ec2TestImageMinimal,
 	})
 	assert.Equal(t, int64(3), third.VersionNumber)
 
@@ -173,7 +173,7 @@ func TestEC2_CreateLaunchTemplateVersion_SourceVersion(t *testing.T) {
 	t.Run("SourceVersion inherits, request overwrites", func(t *testing.T) {
 		ts := newEC2TestServer(t)
 		ltID := createLaunchTemplate(t, ts, "inherits", map[string]string{
-			"LaunchTemplateData.ImageId":      "ami-0000000000000001",
+			"LaunchTemplateData.ImageId":      ec2TestImage,
 			"LaunchTemplateData.InstanceType": "t3.small",
 			"LaunchTemplateData.KeyName":      "inherited-key",
 		})
@@ -181,9 +181,9 @@ func TestEC2_CreateLaunchTemplateVersion_SourceVersion(t *testing.T) {
 		v2 := createLTVersion(t, ts, map[string]string{
 			"LaunchTemplateId":           ltID,
 			"SourceVersion":              "1",
-			"LaunchTemplateData.ImageId": "ami-0000000000000002",
+			"LaunchTemplateData.ImageId": ec2TestImageArm,
 		})
-		assert.Equal(t, "ami-0000000000000002", v2.Data.ImageID, "the request's AMI wins")
+		assert.Equal(t, ec2TestImageArm, v2.Data.ImageID, "the request's AMI wins")
 		assert.Equal(t, "t3.small", v2.Data.InstanceType, "inherited from version 1")
 		assert.Equal(t, "inherited-key", v2.Data.KeyName, "inherited from version 1")
 	})
@@ -191,16 +191,16 @@ func TestEC2_CreateLaunchTemplateVersion_SourceVersion(t *testing.T) {
 	t.Run("no SourceVersion inherits nothing", func(t *testing.T) {
 		ts := newEC2TestServer(t)
 		ltID := createLaunchTemplate(t, ts, "no-inherit", map[string]string{
-			"LaunchTemplateData.ImageId":      "ami-0000000000000001",
+			"LaunchTemplateData.ImageId":      ec2TestImage,
 			"LaunchTemplateData.InstanceType": "t3.small",
 			"LaunchTemplateData.KeyName":      "dropped-key",
 		})
 
 		v2 := createLTVersion(t, ts, map[string]string{
 			"LaunchTemplateId":           ltID,
-			"LaunchTemplateData.ImageId": "ami-0000000000000002",
+			"LaunchTemplateData.ImageId": ec2TestImageArm,
 		})
-		assert.Equal(t, "ami-0000000000000002", v2.Data.ImageID)
+		assert.Equal(t, ec2TestImageArm, v2.Data.ImageID)
 		assert.Empty(t, v2.Data.InstanceType, "an omitted SourceVersion inherits nothing")
 		assert.Empty(t, v2.Data.KeyName, "an omitted SourceVersion inherits nothing")
 	})
@@ -208,11 +208,11 @@ func TestEC2_CreateLaunchTemplateVersion_SourceVersion(t *testing.T) {
 	t.Run("$Latest as the source", func(t *testing.T) {
 		ts := newEC2TestServer(t)
 		ltID := createLaunchTemplate(t, ts, "latest-source", map[string]string{
-			"LaunchTemplateData.ImageId": "ami-0000000000000001",
+			"LaunchTemplateData.ImageId": ec2TestImage,
 		})
 		createLTVersion(t, ts, map[string]string{
 			"LaunchTemplateId":                ltID,
-			"LaunchTemplateData.ImageId":      "ami-0000000000000002",
+			"LaunchTemplateData.ImageId":      ec2TestImageArm,
 			"LaunchTemplateData.InstanceType": "t3.large",
 		})
 		v3 := createLTVersion(t, ts, map[string]string{
@@ -220,20 +220,20 @@ func TestEC2_CreateLaunchTemplateVersion_SourceVersion(t *testing.T) {
 			"SourceVersion":              "$Latest",
 			"LaunchTemplateData.KeyName": "k",
 		})
-		assert.Equal(t, "ami-0000000000000002", v3.Data.ImageID, "inherited from version 2")
+		assert.Equal(t, ec2TestImageArm, v3.Data.ImageID, "inherited from version 2")
 		assert.Equal(t, "t3.large", v3.Data.InstanceType)
 	})
 
 	t.Run("a nonexistent SourceVersion is an error", func(t *testing.T) {
 		ts := newEC2TestServer(t)
 		ltID := createLaunchTemplate(t, ts, "bad-source", map[string]string{
-			"LaunchTemplateData.ImageId": "ami-0000000000000001",
+			"LaunchTemplateData.ImageId": ec2TestImage,
 		})
 		status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
 			"Action":                     "CreateLaunchTemplateVersion",
 			"LaunchTemplateId":           ltID,
 			"SourceVersion":              "7",
-			"LaunchTemplateData.ImageId": "ami-0000000000000002",
+			"LaunchTemplateData.ImageId": ec2TestImageArm,
 		})
 		assert.Equal(t, http.StatusBadRequest, status)
 		assert.Equal(t, "InvalidLaunchTemplateId.VersionNotFound", code)
@@ -252,20 +252,20 @@ func TestEC2_CreateLaunchTemplateVersion_SourceVersion(t *testing.T) {
 func TestEC2_RunInstances_AbsentVersionMeansDefault(t *testing.T) {
 	ts := newEC2TestServer(t)
 	ltID := createLaunchTemplate(t, ts, "default-vs-latest", map[string]string{
-		"LaunchTemplateData.ImageId": "ami-0000000000000001",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 	})
 	createLTVersion(t, ts, map[string]string{
 		"LaunchTemplateId":           ltID,
-		"LaunchTemplateData.ImageId": "ami-0000000000000002",
+		"LaunchTemplateData.ImageId": ec2TestImageArm,
 	})
 	createLTVersion(t, ts, map[string]string{
 		"LaunchTemplateId":           ltID,
-		"LaunchTemplateData.ImageId": "ami-0000000000000003",
+		"LaunchTemplateData.ImageId": ec2TestImageMinimal,
 	})
 
 	// Before any Modify, the default is version 1 while the latest is 3.
 	instID := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
-	assert.Equal(t, "ami-0000000000000001", describeInstance(t, ts, instID).ImageID,
+	assert.Equal(t, ec2TestImage, describeInstance(t, ts, instID).ImageID,
 		"an absent version must resolve to the default (1), not the latest (3)")
 
 	// Pin the default to 2; the latest is still 3.
@@ -284,7 +284,7 @@ func TestEC2_RunInstances_AbsentVersionMeansDefault(t *testing.T) {
 	assert.Equal(t, int64(3), modified.LaunchTemplate.LatestVersionNum)
 
 	instID = runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
-	assert.Equal(t, "ami-0000000000000002", describeInstance(t, ts, instID).ImageID,
+	assert.Equal(t, ec2TestImageArm, describeInstance(t, ts, instID).ImageID,
 		"an absent version must follow the new default (2), not the latest (3)")
 }
 
@@ -297,21 +297,21 @@ func TestEC2_RunInstances_VersionSpecifiers(t *testing.T) {
 		version string
 		wantAMI string
 	}{
-		{name: "absent means the default", version: "", wantAMI: "ami-0000000000000002"},
-		{name: "$Default", version: "$Default", wantAMI: "ami-0000000000000002"},
-		{name: "$Latest", version: "$Latest", wantAMI: "ami-0000000000000003"},
-		{name: "lowercase $latest", version: "$latest", wantAMI: "ami-0000000000000003"},
-		{name: "an explicit number", version: "1", wantAMI: "ami-0000000000000001"},
-		{name: "the default's own number", version: "2", wantAMI: "ami-0000000000000002"},
+		{name: "absent means the default", version: "", wantAMI: ec2TestImageArm},
+		{name: "$Default", version: "$Default", wantAMI: ec2TestImageArm},
+		{name: "$Latest", version: "$Latest", wantAMI: ec2TestImageMinimal},
+		{name: "lowercase $latest", version: "$latest", wantAMI: ec2TestImageMinimal},
+		{name: "an explicit number", version: "1", wantAMI: ec2TestImage},
+		{name: "the default's own number", version: "2", wantAMI: ec2TestImageArm},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := newEC2TestServer(t)
 			ltID := createLaunchTemplate(t, ts, "specifiers", map[string]string{
-				"LaunchTemplateData.ImageId": "ami-0000000000000001",
+				"LaunchTemplateData.ImageId": ec2TestImage,
 			})
-			for _, ami := range []string{"ami-0000000000000002", "ami-0000000000000003"} {
+			for _, ami := range []string{ec2TestImageArm, ec2TestImageMinimal} {
 				createLTVersion(t, ts, map[string]string{
 					"LaunchTemplateId":           ltID,
 					"LaunchTemplateData.ImageId": ami,
@@ -342,7 +342,7 @@ func TestEC2_RunInstances_VersionSpecifiers(t *testing.T) {
 func TestEC2_RunInstances_NonexistentVersionIsRejected(t *testing.T) {
 	ts := newEC2TestServer(t)
 	ltID := createLaunchTemplate(t, ts, "bad-version", map[string]string{
-		"LaunchTemplateData.ImageId": "ami-0000000000000001",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 	})
 
 	status, code, message := ec2ErrorDetail(t, ts, map[string]string{
@@ -372,7 +372,7 @@ func TestEC2_RunInstances_NonexistentVersionIsRejected(t *testing.T) {
 func TestEC2_ModifyLaunchTemplate_RejectsUnknownVersion(t *testing.T) {
 	ts := newEC2TestServer(t)
 	ltID := createLaunchTemplate(t, ts, "modify-bad", map[string]string{
-		"LaunchTemplateData.ImageId": "ami-0000000000000001",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 	})
 
 	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
@@ -392,10 +392,10 @@ func TestEC2_DescribeLaunchTemplateVersions_Selection(t *testing.T) {
 		t.Helper()
 		ts := newEC2TestServer(t)
 		ltID := createLaunchTemplate(t, ts, "selection", map[string]string{
-			"LaunchTemplateData.ImageId": "ami-0000000000000001",
+			"LaunchTemplateData.ImageId": ec2TestImage,
 		})
 		for _, ami := range []string{
-			"ami-0000000000000002", "ami-0000000000000003", "ami-0000000000000004",
+			ec2TestImageArm, ec2TestImageMinimal, ec2TestImageMinimalArm,
 		} {
 			createLTVersion(t, ts, map[string]string{
 				"LaunchTemplateId":           ltID,
@@ -492,13 +492,19 @@ func TestEC2_DescribeLaunchTemplateVersions_AccountWide(t *testing.T) {
 	setup := func(t *testing.T) *httptest.Server {
 		t.Helper()
 		ts := newEC2TestServer(t)
+		// One AMI per template per version, all four distinct, so no assertion below
+		// can pass because two templates happened to hold the same image.
+		images := [][2]string{
+			{ec2TestImage, ec2TestImageArm},
+			{ec2TestImageMinimal, ec2TestImageMinimalArm},
+		}
 		for i, name := range []string{"acct-a", "acct-b"} {
 			ltID := createLaunchTemplate(t, ts, name, map[string]string{
-				"LaunchTemplateData.ImageId": "ami-000000000000000" + string(rune('1'+i*2)),
+				"LaunchTemplateData.ImageId": images[i][0],
 			})
 			createLTVersion(t, ts, map[string]string{
 				"LaunchTemplateId":           ltID,
-				"LaunchTemplateData.ImageId": "ami-000000000000000" + string(rune('2'+i*2)),
+				"LaunchTemplateData.ImageId": images[i][1],
 			})
 		}
 		return ts
@@ -583,9 +589,9 @@ func TestEC2_DeleteLaunchTemplateVersions(t *testing.T) {
 		t.Helper()
 		ts := newEC2TestServer(t)
 		ltID := createLaunchTemplate(t, ts, "deletes", map[string]string{
-			"LaunchTemplateData.ImageId": "ami-0000000000000001",
+			"LaunchTemplateData.ImageId": ec2TestImage,
 		})
-		for _, ami := range []string{"ami-0000000000000002", "ami-0000000000000003"} {
+		for _, ami := range []string{ec2TestImageArm, ec2TestImageMinimal} {
 			createLTVersion(t, ts, map[string]string{
 				"LaunchTemplateId":           ltID,
 				"LaunchTemplateData.ImageId": ami,
@@ -676,7 +682,7 @@ func TestEC2_DeleteLaunchTemplateVersions(t *testing.T) {
 		// "You cannot replace the version number after you delete it."
 		next := createLTVersion(t, ts, map[string]string{
 			"LaunchTemplateId":           ltID,
-			"LaunchTemplateData.ImageId": "ami-0000000000000004",
+			"LaunchTemplateData.ImageId": ec2TestImageMinimalArm,
 		})
 		assert.Equal(t, int64(4), next.VersionNumber, "a deleted version number must not be reused")
 	})
@@ -727,7 +733,7 @@ func TestEC2_LaunchTemplate_PreVersioningStateStillWorks(t *testing.T) {
 		"createdBy":            acct,
 		"createTime":           "2026-01-01T00:00:00Z",
 		"latestData": map[string]any{
-			"imageId":      "ami-0legacy000000001",
+			"imageId":      ec2TestImage,
 			"instanceType": "t3.small",
 			"keyName":      "legacy-key",
 		},
@@ -746,7 +752,7 @@ func TestEC2_LaunchTemplate_PreVersioningStateStillWorks(t *testing.T) {
 	t.Run("it still launches", func(t *testing.T) {
 		instID := runInstance(t, ts, map[string]string{"LaunchTemplate.LaunchTemplateId": ltID})
 		inst := describeInstance(t, ts, instID)
-		assert.Equal(t, "ami-0legacy000000001", inst.ImageID)
+		assert.Equal(t, ec2TestImage, inst.ImageID)
 		assert.Equal(t, "t3.small", inst.InstanceType)
 		assert.Equal(t, "legacy-key", inst.KeyName)
 	})
@@ -756,7 +762,7 @@ func TestEC2_LaunchTemplate_PreVersioningStateStillWorks(t *testing.T) {
 		require.Len(t, versions, 1)
 		assert.Equal(t, int64(1), versions[0].VersionNumber)
 		assert.True(t, versions[0].DefaultVersion)
-		assert.Equal(t, "ami-0legacy000000001", versions[0].Data.ImageID)
+		assert.Equal(t, ec2TestImage, versions[0].Data.ImageID)
 	})
 
 	t.Run("$Latest and $Default both resolve to it", func(t *testing.T) {
@@ -765,7 +771,7 @@ func TestEC2_LaunchTemplate_PreVersioningStateStillWorks(t *testing.T) {
 				"LaunchTemplate.LaunchTemplateId": ltID,
 				"LaunchTemplate.Version":          spec,
 			})
-			assert.Equal(t, "ami-0legacy000000001", describeInstance(t, ts, instID).ImageID, "version %q", spec)
+			assert.Equal(t, ec2TestImage, describeInstance(t, ts, instID).ImageID, "version %q", spec)
 		}
 	})
 
@@ -773,7 +779,7 @@ func TestEC2_LaunchTemplate_PreVersioningStateStillWorks(t *testing.T) {
 		v2 := createLTVersion(t, ts, map[string]string{
 			"LaunchTemplateId":           ltID,
 			"SourceVersion":              "1",
-			"LaunchTemplateData.ImageId": "ami-0legacy000000002",
+			"LaunchTemplateData.ImageId": ec2TestImageArm,
 		})
 		assert.Equal(t, int64(2), v2.VersionNumber)
 		assert.Equal(t, "t3.small", v2.Data.InstanceType, "inherited from the synthesized version 1")
@@ -788,7 +794,7 @@ func TestEC2_DescribeLaunchTemplateVersions_RoundTripsNetworking(t *testing.T) {
 	ts := newEC2TestServer(t)
 	net := newLTNetwork(t, ts, "10.9.0.0/16", "lt-versions-net")
 	ltID := createLaunchTemplate(t, ts, "networking", map[string]string{
-		"LaunchTemplateData.ImageId":                                     "ami-0000000000000001",
+		"LaunchTemplateData.ImageId":                                     ec2TestImage,
 		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":              "0",
 		"LaunchTemplateData.NetworkInterface.1.SubnetId":                 net.subnetID,
 		"LaunchTemplateData.NetworkInterface.1.Groups.1":                 net.sgID,
@@ -811,12 +817,12 @@ func TestEC2_DescribeLaunchTemplateVersions_RoundTripsNetworking(t *testing.T) {
 func TestEC2_Fleet_HonorsLaunchTemplateVersion(t *testing.T) {
 	ts := newEC2TestServer(t)
 	ltID := createLaunchTemplate(t, ts, "fleet-versions", map[string]string{
-		"LaunchTemplateData.ImageId":      "ami-0fleet0000000001",
+		"LaunchTemplateData.ImageId":      ec2TestImage,
 		"LaunchTemplateData.InstanceType": "t3.small",
 	})
 	createLTVersion(t, ts, map[string]string{
 		"LaunchTemplateId":                ltID,
-		"LaunchTemplateData.ImageId":      "ami-0fleet0000000002",
+		"LaunchTemplateData.ImageId":      ec2TestImageArm,
 		"LaunchTemplateData.InstanceType": "t3.small",
 	})
 
@@ -825,12 +831,12 @@ func TestEC2_Fleet_HonorsLaunchTemplateVersion(t *testing.T) {
 		version string
 		wantAMI string
 	}{
-		{name: "pinned to version 1", version: "1", wantAMI: "ami-0fleet0000000001"},
-		{name: "pinned to version 2", version: "2", wantAMI: "ami-0fleet0000000002"},
-		{name: "$Latest", version: "$Latest", wantAMI: "ami-0fleet0000000002"},
+		{name: "pinned to version 1", version: "1", wantAMI: ec2TestImage},
+		{name: "pinned to version 2", version: "2", wantAMI: ec2TestImageArm},
+		{name: "$Latest", version: "$Latest", wantAMI: ec2TestImageArm},
 		// An absent version follows the default, which is still 1 even though
 		// version 2 exists.
-		{name: "absent means the default", version: "", wantAMI: "ami-0fleet0000000001"},
+		{name: "absent means the default", version: "", wantAMI: ec2TestImage},
 	}
 
 	for _, tt := range tests {

--- a/emulator/ec2_launchtemplate_warning_test.go
+++ b/emulator/ec2_launchtemplate_warning_test.go
@@ -71,7 +71,7 @@ func TestEC2_CreateLaunchTemplate_WarnsAboutAnInvalidMapping(t *testing.T) {
 	out, body := ltWarningRequest(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "warned",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
 		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
 	})
@@ -106,7 +106,7 @@ func TestEC2_CreateLaunchTemplate_WarnsAboutEveryProblem(t *testing.T) {
 	out, body := ltWarningRequest(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "two-problems",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		// Names an Ebs member and neither a size nor a snapshot.
 		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
 		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
@@ -155,7 +155,7 @@ func TestEC2_CreateLaunchTemplate_ValidTemplateCarriesNoWarning(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			params := map[string]string{
 				"Action":                     "CreateLaunchTemplate",
-				"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+				"LaunchTemplateData.ImageId": ec2TestImage,
 			}
 			for k, v := range tc.params {
 				params[k] = v
@@ -182,7 +182,7 @@ func TestEC2_CreateLaunchTemplateVersion_WarnsAboutAnInvalidMapping(t *testing.T
 	v1, _ := ltWarningRequest(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "versioned",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
 		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
 	})
@@ -195,7 +195,7 @@ func TestEC2_CreateLaunchTemplateVersion_WarnsAboutAnInvalidMapping(t *testing.T
 		{
 			name: "the version names the mapping itself",
 			params: map[string]string{
-				"LaunchTemplateData.ImageId":                             "ami-0abcdef1234567890",
+				"LaunchTemplateData.ImageId":                             ec2TestImage,
 				"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdg",
 				"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
 			},
@@ -204,7 +204,7 @@ func TestEC2_CreateLaunchTemplateVersion_WarnsAboutAnInvalidMapping(t *testing.T
 			name: "the version inherits it from SourceVersion",
 			params: map[string]string{
 				"SourceVersion":              "1",
-				"LaunchTemplateData.ImageId": "ami-11112222333344445",
+				"LaunchTemplateData.ImageId": ec2TestImageArm,
 			},
 		},
 	} {
@@ -237,7 +237,7 @@ func TestEC2_CreateLaunchTemplate_WarnsAboutAnUnknownSnapshot(t *testing.T) {
 	out, body := ltWarningRequest(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "unknown-snapshot",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
 		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.SnapshotId": "snap-0123456789abcdef0",
 	})
@@ -303,7 +303,7 @@ func TestEC2_LaunchTemplateVersion_ReadsBackItsBlockDeviceMappings(t *testing.T)
 	_, body := ltWarningRequest(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "readback",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		// A fully specified EBS mapping.
 		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":              "/dev/sdf",
 		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize":          "40",
@@ -365,7 +365,7 @@ func TestEC2_LaunchTemplateVersion_SourceVersionCarriesMappingsAndVolumeTags(t *
 	_, body := ltWarningRequest(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "inheriting",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
 		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize": "25",
 		"LaunchTemplateData.TagSpecification.1.ResourceType":     "volume",
@@ -378,7 +378,7 @@ func TestEC2_LaunchTemplateVersion_SourceVersionCarriesMappingsAndVolumeTags(t *
 		"Action":                     "CreateLaunchTemplateVersion",
 		"LaunchTemplateName":         "inheriting",
 		"SourceVersion":              "1",
-		"LaunchTemplateData.ImageId": "ami-11112222333344445",
+		"LaunchTemplateData.ImageId": ec2TestImageArm,
 	})
 	require.Equal(t, int64(2), v2.VersionNumber)
 
@@ -426,14 +426,14 @@ func TestEC2_LaunchTemplateVersion_NoSourceVersionInheritsNothing(t *testing.T) 
 	_, _ = ltWarningRequest(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "no-inherit",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
 		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.VolumeSize": "25",
 	})
 	_, _ = ltWarningRequest(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplateVersion",
 		"LaunchTemplateName":         "no-inherit",
-		"LaunchTemplateData.ImageId": "ami-11112222333344445",
+		"LaunchTemplateData.ImageId": ec2TestImageArm,
 	})
 
 	mappings, body := ltDescribeMappings(t, ts, "no-inherit", "2")

--- a/emulator/ec2_network_interfaces_test.go
+++ b/emulator/ec2_network_interfaces_test.go
@@ -64,7 +64,7 @@ func niRun(t *testing.T, ts *httptest.Server, params map[string]string) []niInst
 	t.Helper()
 	full := map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-12345678",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1",
 		"MaxCount": "1",
 	}
@@ -496,7 +496,7 @@ func TestEC2NetworkInterfaces_LaunchTemplateAllInterfaces(t *testing.T) {
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "two-nics",
-		"LaunchTemplateData.ImageId": "ami-12345678",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.NetworkInterface.1.DeviceIndex":       "0",
 		"LaunchTemplateData.NetworkInterface.1.SubnetId":          subnetA,
 		"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1": groupA,
@@ -541,7 +541,7 @@ func TestEC2NetworkInterfaces_RequestInterfacesBeatTemplate(t *testing.T) {
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "tmpl-two",
-		"LaunchTemplateData.ImageId": "ami-12345678",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.NetworkInterface.1.DeviceIndex": "0",
 		"LaunchTemplateData.NetworkInterface.1.SubnetId":    subnetB,
 		"LaunchTemplateData.NetworkInterface.2.DeviceIndex": "1",
@@ -571,7 +571,7 @@ func TestEC2NetworkInterfaces_TemplateFlatFieldsStillLaunch(t *testing.T) {
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "flat",
-		"LaunchTemplateData.ImageId": "ami-12345678",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.NetworkInterface.1.SubnetId":          subnetA,
 		"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1": groupA,
 	})
@@ -614,7 +614,7 @@ func TestEC2NetworkInterfaces_PreSliceTemplateStateStillWorks(t *testing.T) {
 		"createdBy":            acct,
 		"createTime":           "2026-01-01T00:00:00Z",
 		"latestData": map[string]any{
-			"imageId":                  "ami-12345678",
+			"imageId":                  ec2TestImage,
 			"instanceType":             "t3.small",
 			"subnetId":                 subnetA,
 			"associatePublicIpAddress": "true",

--- a/emulator/ec2_networkinterface_test.go
+++ b/emulator/ec2_networkinterface_test.go
@@ -23,7 +23,7 @@ func TestEC2_RunInstances_NetworkInterface(t *testing.T) {
 
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "t3.small",
 		"MinCount":     "1",
 		"MaxCount":     "1",

--- a/emulator/ec2_notfound_test.go
+++ b/emulator/ec2_notfound_test.go
@@ -444,7 +444,7 @@ func TestEC2_SubstrateMintedIDsAreWellFormed(t *testing.T) {
 	igwID := create(map[string]string{"Action": "CreateInternetGateway"}, "internetGatewayId")
 	rtbID := create(map[string]string{"Action": "CreateRouteTable", "VpcId": vpcID}, "routeTableId")
 	instanceID := create(map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-12345678", "InstanceType": "t3.micro",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"MinCount": "1", "MaxCount": "1",
 	}, "instanceId")
 	allocID := create(map[string]string{"Action": "AllocateAddress", "Domain": "vpc"}, "allocationId")

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -539,6 +539,33 @@ func (p *EC2Plugin) runInstancesWithTags(
 		return nil, ec2MissingParameter("ImageId")
 	}
 
+	// And it must be an AMI that exists. Through v0.107.0 substrate launched from any
+	// string beginning "ami-", and from several that did not, so a template naming a
+	// region-specific literal, a placeholder an AI left in, or an AMI that had never
+	// existed all launched here and failed on real AWS — the divergence #733 was filed
+	// for, found by a live run.
+	//
+	// Both codes come from the kind, so a caller distinguishes "that is not an AMI ID"
+	// from "that AMI is not here" the way EC2 does: ec2ImageIDKind.requireResource
+	// checks syntax before existence, which is the order EC2 reports them in.
+	//
+	// The check sits here, beside the emptiness refusal and after the launch-template
+	// merge, for the same two reasons that position exists at all. An AMI that reaches
+	// this launch through a template is refused at RunInstances time rather than
+	// materialized, and CreateFleet inherits the rule for free by going through
+	// runInstancesWithTags. And it is ahead of the ensureDefaultVPC branch below, which
+	// commits a VPC, subnet, security group, gateway and route table: refusing past
+	// that point would leave state behind for the next request in the same test to see.
+	//
+	// CreateLaunchTemplate deliberately does not carry this rule. It reports mapping
+	// problems through AWS's documented warning member rather than refusing, and an AMI
+	// named in a template is not yet a launch — so a refusal there would be one AWS
+	// does not make. The template's AMI is checked here, when it is used.
+	_, imageFound := p.resolveImage(reqCtx, imageID)
+	if awsErr := ec2ImageIDKind.requireResource(imageID, imageFound); awsErr != nil {
+		return nil, awsErr
+	}
+
 	// Block device mappings are validated here for two reasons that fix the position
 	// exactly (#671). It is after the template merge above, so a mapping that reaches
 	// this launch through a template is refused at RunInstances time rather than
@@ -3912,6 +3939,37 @@ func sgOwnerOrDefault(owner, accountID string) string {
 // ec2ImageStateKey returns the state key for an AMI.
 func ec2ImageStateKey(accountID, region, imageID string) string {
 	return "image:" + accountID + "/" + region + "/" + imageID
+}
+
+// resolveImage returns the AMI an ID names in one account and region, from state first and
+// then from the bundled catalog.
+//
+// It is the single answer to "does this AMI exist", so a launch, an authorization decision
+// and a describe cannot disagree about one ID. Registered images win over bundled ones:
+// a caller who registers an AMI whose ID collides with a derived one — reachable only by
+// naming the derived ID deliberately, since RegisterImage mints its own — sees their own
+// record, on the same precedence [SSMPlugin] gives a user-created parameter over a managed
+// one.
+//
+// A read error reports the image as absent rather than propagating, matching
+// [EC2Plugin.ec2SnapshotResolver]: substrate's state backends fail only for reasons a
+// caller cannot act on, and "no such AMI" is the same answer they would get for a record
+// that was never written.
+func (p *EC2Plugin) resolveImage(reqCtx *RequestContext, imageID string) (EC2Image, bool) {
+	if imageID == "" {
+		return EC2Image{}, false
+	}
+	key := ec2ImageStateKey(reqCtx.AccountID, reqCtx.Region, imageID)
+	if data, err := p.state.Get(context.Background(), ec2Namespace, key); err == nil && data != nil {
+		var img EC2Image
+		if json.Unmarshal(data, &img) == nil {
+			return img, true
+		}
+	}
+	if bundled, ok := bundledImageByID(reqCtx.Region, imageID); ok {
+		return bundled.image(reqCtx.Region), true
+	}
+	return EC2Image{}, false
 }
 
 // createImage creates an AMI from a running or stopped instance.

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -99,7 +99,7 @@ func TestEC2_RunDescribeTerminate(t *testing.T) {
 	// RunInstances.
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "t3.micro",
 		"MinCount":     "1",
 		"MaxCount":     "1",
@@ -153,7 +153,7 @@ func TestEC2_StopStartInstances(t *testing.T) {
 	// Launch instance.
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-00000001",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1",
 		"MaxCount": "1",
 	})
@@ -482,7 +482,7 @@ func TestEC2_DefaultVPCAutoCreate(t *testing.T) {
 	// Launch without specifying a subnet — should auto-create default VPC/subnet.
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-auto",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1",
 		"MaxCount": "1",
 	})
@@ -528,9 +528,9 @@ func TestEC2_DescribeInstances_Filter(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	// Launch 2 instances.
-	r1 := ec2Request(t, ts, map[string]string{"Action": "RunInstances", "ImageId": "ami-1", "MinCount": "1", "MaxCount": "1"})
+	r1 := ec2Request(t, ts, map[string]string{"Action": "RunInstances", "ImageId": ec2TestImage, "MinCount": "1", "MaxCount": "1"})
 	r1.Body.Close() //nolint:errcheck
-	r2 := ec2Request(t, ts, map[string]string{"Action": "RunInstances", "ImageId": "ami-2", "MinCount": "1", "MaxCount": "1"})
+	r2 := ec2Request(t, ts, map[string]string{"Action": "RunInstances", "ImageId": ec2TestImageArm, "MinCount": "1", "MaxCount": "1"})
 	r2.Body.Close() //nolint:errcheck
 
 	// Describe all — should get at least 2.
@@ -556,7 +556,7 @@ func TestEC2_DescribeInstanceStatus(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	resp := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-status", "MinCount": "1", "MaxCount": "1",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "MinCount": "1", "MaxCount": "1",
 	})
 	resp.Body.Close() //nolint:errcheck
 
@@ -897,7 +897,7 @@ func TestEC2_KeyPair_CreateDescribeDelete(t *testing.T) {
 	// RunInstances referencing the key pair records KeyName on the instance.
 	runResp := ec2Request(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "t3.micro",
 		"MinCount":     "1",
 		"MaxCount":     "1",
@@ -993,7 +993,7 @@ func TestEC2_RebootInstances(t *testing.T) {
 
 	// Launch an instance first.
 	runResp := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-1", "MinCount": "1", "MaxCount": "1",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "MinCount": "1", "MaxCount": "1",
 	})
 	var runResult struct {
 		Instances []struct {
@@ -1019,7 +1019,7 @@ func TestEC2_CreateDeleteTags(t *testing.T) {
 
 	// Launch an instance.
 	runResp := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-1", "MinCount": "1", "MaxCount": "1",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "MinCount": "1", "MaxCount": "1",
 	})
 	var runResult struct {
 		Instances []struct {
@@ -1097,7 +1097,7 @@ func TestEC2_ModifyInstanceAttribute(t *testing.T) {
 
 	// Launch a t3.micro instance.
 	runResp := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-1",
+		"Action": "RunInstances", "ImageId": ec2TestImage,
 		"InstanceType": "t3.micro", "MinCount": "1", "MaxCount": "1",
 	})
 	var runResult struct {
@@ -1164,7 +1164,7 @@ func TestEC2_AMI_CreateDescribeDeregister(t *testing.T) {
 
 	// Launch an instance so we have a valid source instance ID.
 	runResp := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-base",
+		"Action": "RunInstances", "ImageId": ec2TestImage,
 		"InstanceType": "t3.micro", "MinCount": "1", "MaxCount": "1",
 	})
 	var runResult struct {
@@ -1399,7 +1399,7 @@ func TestEC2_Image_CreationDate(t *testing.T) {
 
 	// Launch an instance so we have a valid source instance ID.
 	runResp := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-base",
+		"Action": "RunInstances", "ImageId": ec2TestImage,
 		"InstanceType": "t3.micro", "MinCount": "1", "MaxCount": "1",
 	})
 	var runResult struct {
@@ -1457,7 +1457,7 @@ func TestEC2_RunInstances_TagSpecifications(t *testing.T) {
 	// Launch with TagSpecifications for ResourceType=instance.
 	runResp := ec2Request(t, ts, map[string]string{
 		"Action":                          "RunInstances",
-		"ImageId":                         "ami-1",
+		"ImageId":                         ec2TestImage,
 		"InstanceType":                    "t3.micro",
 		"MinCount":                        "1",
 		"MaxCount":                        "1",
@@ -1670,7 +1670,7 @@ func TestEC2_PublicIP(t *testing.T) {
 	// RunInstances into the default VPC/subnet (no SubnetId specified).
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "t3.micro",
 		"MinCount":     "1",
 		"MaxCount":     "1",
@@ -1795,7 +1795,7 @@ func TestEC2_NoPublicIP_NonDefaultSubnet(t *testing.T) {
 	// RunInstances into the non-default subnet.
 	runResp := ec2Request(t, ts, map[string]string{
 		"Action":       "RunInstances",
-		"ImageId":      "ami-12345678",
+		"ImageId":      ec2TestImage,
 		"InstanceType": "t3.micro",
 		"MinCount":     "1",
 		"MaxCount":     "1",
@@ -2024,7 +2024,7 @@ func TestEC2_ElasticIP_AssociateDisassociate(t *testing.T) {
 	_ = xml.NewDecoder(allocResp.Body).Decode(&allocResult)
 
 	// Launch instance.
-	runResp := ec2Request(t, ts, map[string]string{"Action": "RunInstances", "ImageId": "ami-test", "MinCount": "1", "MaxCount": "1"})
+	runResp := ec2Request(t, ts, map[string]string{"Action": "RunInstances", "ImageId": ec2TestImage, "MinCount": "1", "MaxCount": "1"})
 	defer runResp.Body.Close() //nolint:errcheck
 	var runResult struct {
 		Instances []struct {
@@ -2116,7 +2116,7 @@ func TestEC2_ElasticIP_ReleaseWhileAssociated(t *testing.T) {
 	_ = xml.NewDecoder(allocResp.Body).Decode(&allocResult)
 
 	// Launch and associate.
-	runResp := ec2Request(t, ts, map[string]string{"Action": "RunInstances", "ImageId": "ami-test", "MinCount": "1", "MaxCount": "1"})
+	runResp := ec2Request(t, ts, map[string]string{"Action": "RunInstances", "ImageId": ec2TestImage, "MinCount": "1", "MaxCount": "1"})
 	defer runResp.Body.Close() //nolint:errcheck
 	var runResult struct {
 		Instances []struct {
@@ -2670,7 +2670,7 @@ func TestEC2Plugin_CreateDescribeDeleteLaunchTemplate(t *testing.T) {
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                               "CreateLaunchTemplate",
 		"LaunchTemplateName":                   "my-template",
-		"LaunchTemplateData.ImageId":           "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId":           ec2TestImage,
 		"LaunchTemplateData.InstanceType":      "t3.small",
 		"LaunchTemplateData.KeyName":           "my-key",
 		"LaunchTemplateData.SecurityGroupId.1": "sg-12345678",
@@ -2780,7 +2780,7 @@ func TestEC2Plugin_RunInstances_ViaLaunchTemplate(t *testing.T) {
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                          "CreateLaunchTemplate",
 		"LaunchTemplateName":              "run-tmpl",
-		"LaunchTemplateData.ImageId":      "ami-launch-template-test",
+		"LaunchTemplateData.ImageId":      ec2TestImage,
 		"LaunchTemplateData.InstanceType": "m5.large",
 	})
 	defer resp.Body.Close() //nolint:errcheck
@@ -2822,8 +2822,8 @@ func TestEC2Plugin_RunInstances_ViaLaunchTemplate(t *testing.T) {
 	if len(runResult.Instances) != 1 {
 		t.Fatalf("expected 1 instance, got %d", len(runResult.Instances))
 	}
-	if runResult.Instances[0].ImageID != "ami-launch-template-test" {
-		t.Errorf("expected ami-launch-template-test, got %q", runResult.Instances[0].ImageID)
+	if runResult.Instances[0].ImageID != ec2TestImage {
+		t.Errorf("expected %q, got %q", ec2TestImage, runResult.Instances[0].ImageID)
 	}
 	if runResult.Instances[0].InstanceType != "m5.large" {
 		t.Errorf("expected m5.large, got %q", runResult.Instances[0].InstanceType)
@@ -2920,7 +2920,7 @@ func TestEC2_EBS_AttachDetachVolume(t *testing.T) {
 	// Launch an instance to attach to.
 	runResp := ec2Request(t, ts, map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-test",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1",
 		"MaxCount": "1",
 	})
@@ -3011,7 +3011,7 @@ func TestEC2_RunInstances_InvalidSG(t *testing.T) {
 	// answers InvalidGroupId.Malformed, which is a different assertion (below).
 	resp3 := ec2Request(t, ts, map[string]string{
 		"Action":            "RunInstances",
-		"ImageId":           "ami-12345678",
+		"ImageId":           ec2TestImage,
 		"InstanceType":      "t2.micro",
 		"SubnetId":          subnetID,
 		"SecurityGroupId.1": "sg-0000000000000dead",
@@ -3026,7 +3026,7 @@ func TestEC2_RunInstances_InvalidSG(t *testing.T) {
 	// Malformed code — the same ordering every other ID family follows (#713).
 	resp4 := ec2Request(t, ts, map[string]string{
 		"Action":            "RunInstances",
-		"ImageId":           "ami-12345678",
+		"ImageId":           ec2TestImage,
 		"InstanceType":      "t2.micro",
 		"SubnetId":          subnetID,
 		"SecurityGroupId.1": "sg-nonexistent",
@@ -3313,7 +3313,7 @@ func TestEC2_DefaultVPC_IGWRoute(t *testing.T) {
 
 	// RunInstances with no SubnetId triggers ensureDefaultVPC.
 	run := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-12345678", "InstanceType": "t3.micro",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"MinCount": "1", "MaxCount": "1",
 	})
 	assert.Equal(t, http.StatusOK, run.StatusCode)
@@ -3333,7 +3333,7 @@ func TestEC2_DescribeInstances_MultiFilter(t *testing.T) {
 
 	// Launch a tagged instance.
 	resp := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-12345678", "InstanceType": "t3.micro",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"MinCount": "1", "MaxCount": "1",
 		"TagSpecification.1.ResourceType": "instance",
 		"TagSpecification.1.Tag.1.Key":    "spawn:managed",
@@ -3389,7 +3389,7 @@ func TestEC2_DescribeInstances_MultiFilter(t *testing.T) {
 func TestEC2_DescribeInstances_FilterOrderIndependent(t *testing.T) {
 	ts := newEC2TestServer(t)
 	run := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-1", "InstanceType": "t3.micro",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "InstanceType": "t3.micro",
 		"MinCount": "1", "MaxCount": "1",
 		"TagSpecification.1.ResourceType": "instance",
 		"TagSpecification.1.Tag.1.Key":    "k", "TagSpecification.1.Tag.1.Value": "v",
@@ -3451,7 +3451,7 @@ func TestEC2_CreateImage_SnapshotsAndFilter(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	run := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-base",
+		"Action": "RunInstances", "ImageId": ec2TestImage,
 		"InstanceType": "t3.micro", "MinCount": "1", "MaxCount": "1",
 	})
 	var runResult struct {
@@ -3588,7 +3588,7 @@ func TestEC2_RegisterImage_SharedSnapshot(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	run := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-base",
+		"Action": "RunInstances", "ImageId": ec2TestImage,
 		"InstanceType": "t3.micro", "MinCount": "1", "MaxCount": "1",
 	})
 	var runResult struct {
@@ -3699,7 +3699,7 @@ func newEC2SSMTestServer(t *testing.T) *httptest.Server {
 func runInstanceWithProfile(t *testing.T, ts *httptest.Server, profile string) string {
 	t.Helper()
 	params := map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-base",
+		"Action": "RunInstances", "ImageId": ec2TestImage,
 		"InstanceType": "m7i.xlarge", "MinCount": "1", "MaxCount": "1",
 	}
 	if profile != "" {
@@ -3844,7 +3844,7 @@ func TestEC2_PlacementGroups(t *testing.T) {
 
 	// RunInstances into the known group → success.
 	ok := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-base", "InstanceType": "c7i.xlarge",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "InstanceType": "c7i.xlarge",
 		"MinCount": "1", "MaxCount": "1", "Placement.GroupName": "mpi-pg",
 	})
 	assert.Equal(t, http.StatusOK, ok.StatusCode)
@@ -3852,7 +3852,7 @@ func TestEC2_PlacementGroups(t *testing.T) {
 
 	// RunInstances into an unknown group → InvalidPlacementGroup.Unknown (400).
 	bad := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-base", "InstanceType": "c7i.xlarge",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "InstanceType": "c7i.xlarge",
 		"MinCount": "1", "MaxCount": "1", "Placement.GroupName": "does-not-exist",
 	})
 	assert.Equal(t, http.StatusBadRequest, bad.StatusCode)
@@ -3886,7 +3886,7 @@ func TestEC2_RunInstances_ReturnsTagSet(t *testing.T) {
 	ts := newEC2TestServer(t)
 
 	run := ec2Request(t, ts, map[string]string{
-		"Action": "RunInstances", "ImageId": "ami-12345678", "InstanceType": "c6a.xlarge",
+		"Action": "RunInstances", "ImageId": ec2TestImage, "InstanceType": "c6a.xlarge",
 		"MinCount": "1", "MaxCount": "1",
 		"TagSpecification.1.ResourceType": "instance",
 		"TagSpecification.1.Tag.1.Key":    "Name",
@@ -4027,7 +4027,7 @@ func TestEC2_RunInstances_MissingImageId(t *testing.T) {
 		{
 			name: "explicit ImageId still launches",
 			params: func(*testing.T, *httptest.Server) map[string]string {
-				return map[string]string{"MinCount": "1", "MaxCount": "1", "ImageId": "ami-regression-guard"}
+				return map[string]string{"MinCount": "1", "MaxCount": "1", "ImageId": ec2TestImage}
 			},
 			wantStatus: http.StatusOK,
 		},
@@ -4036,7 +4036,7 @@ func TestEC2_RunInstances_MissingImageId(t *testing.T) {
 			// the top of runInstances.
 			name: "launch template supplies the ImageId",
 			params: func(t *testing.T, ts *httptest.Server) map[string]string {
-				ltID := createTemplate(t, ts, "ami-tmpl", "ami-from-template")
+				ltID := createTemplate(t, ts, "ami-tmpl", ec2TestImage)
 				return map[string]string{
 					"MinCount": "1", "MaxCount": "1",
 					"LaunchTemplate.LaunchTemplateId": ltID,
@@ -4188,7 +4188,7 @@ func TestEC2_RunInstances_InstanceCounts(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				ts := newEC2TestServer(t)
-				params := map[string]string{"Action": "RunInstances", "ImageId": "ami-counts"}
+				params := map[string]string{"Action": "RunInstances", "ImageId": ec2TestImage}
 				for k, v := range tt.params {
 					params[k] = v
 				}
@@ -4254,7 +4254,7 @@ func TestEC2_RunInstances_InstanceCounts(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				ts := newEC2TestServer(t)
-				params := map[string]string{"Action": "RunInstances", "ImageId": "ami-counts"}
+				params := map[string]string{"Action": "RunInstances", "ImageId": ec2TestImage}
 				for k, v := range tt.params {
 					params[k] = v
 				}
@@ -4352,7 +4352,7 @@ func TestEC2_Instances_GroupSet(t *testing.T) {
 		net := newLTNetwork(t, ts, "10.20.0.0/16", "gs-call")
 
 		for _, v := range bothViews(t, ts, map[string]string{
-			"ImageId":           "ami-0gs000000000001",
+			"ImageId":           ec2TestImage,
 			"SubnetId":          net.subnetID,
 			"SecurityGroupId.1": net.sgID,
 		}) {
@@ -4366,7 +4366,7 @@ func TestEC2_Instances_GroupSet(t *testing.T) {
 		second := createSecurityGroup(t, ts, net.vpcID, "gs-multi-b")
 
 		for _, v := range bothViews(t, ts, map[string]string{
-			"ImageId":           "ami-0gs000000000002",
+			"ImageId":           ec2TestImage,
 			"SubnetId":          net.subnetID,
 			"SecurityGroupId.1": net.sgID,
 			"SecurityGroupId.2": second,
@@ -4381,7 +4381,7 @@ func TestEC2_Instances_GroupSet(t *testing.T) {
 		// No SubnetId and no group: the launch falls through to the auto-created
 		// default VPC and resolves its "default" group. That resolution happened
 		// before this fix too — it was simply invisible.
-		for _, v := range bothViews(t, ts, map[string]string{"ImageId": "ami-0gs000000000003"}) {
+		for _, v := range bothViews(t, ts, map[string]string{"ImageId": ec2TestImage}) {
 			if len(v.inst.Groups) != 1 {
 				t.Fatalf("%s: groupSet has %d items, want the default VPC group", v.from, len(v.inst.Groups))
 			}
@@ -4398,7 +4398,7 @@ func TestEC2_Instances_GroupSet(t *testing.T) {
 		ts := newEC2TestServer(t)
 		net := newLTNetwork(t, ts, "10.22.0.0/16", "gs-template")
 		ltID := createLaunchTemplate(t, ts, "gs-template", map[string]string{
-			"LaunchTemplateData.ImageId":                              "ami-0gs000000000004",
+			"LaunchTemplateData.ImageId":                              ec2TestImage,
 			"LaunchTemplateData.NetworkInterface.1.DeviceIndex":       "0",
 			"LaunchTemplateData.NetworkInterface.1.SubnetId":          net.subnetID,
 			"LaunchTemplateData.NetworkInterface.1.SecurityGroupId.1": net.sgID,
@@ -4414,7 +4414,7 @@ func TestEC2_Instances_GroupSet(t *testing.T) {
 		net := newLTNetwork(t, ts, "10.23.0.0/16", "gs-deleted")
 
 		launched := runInstancesLaunched(t, ts, map[string]string{
-			"ImageId":           "ami-0gs000000000005",
+			"ImageId":           ec2TestImage,
 			"SubnetId":          net.subnetID,
 			"SecurityGroupId.1": net.sgID,
 		})

--- a/emulator/ec2_resourceid.go
+++ b/emulator/ec2_resourceid.go
@@ -72,6 +72,20 @@ var (
 		Prefix: "vol-", NotFound: "InvalidVolume.NotFound",
 		Malformed: "InvalidVolumeID.Malformed", Noun: "volume",
 	}
+	// AMIs are the one family whose absence code names no ID at all —
+	// InvalidAMIID.NotFound, "The specified AMI doesn't exist" — which is the
+	// cross-naming snapshots already carry the other way round.
+	//
+	// The reference publishes a third code, InvalidAMIID.Unavailable, for an AMI
+	// "deregistered and no longer available, or ... not in a state from which you can
+	// launch an instance". Substrate raises it nowhere: it models no
+	// deregistered-but-extant image, since DeregisterImage deletes the record, and
+	// every AMI it holds is "available". An unavailable AMI is therefore reported as
+	// absent, which is what a caller polling for one observes anyway.
+	ec2ImageIDKind = ec2IDKind{
+		Prefix: "ami-", NotFound: "InvalidAMIID.NotFound",
+		Malformed: "InvalidAMIID.Malformed", Noun: "image",
+	}
 	// EC2 publishes no InvalidAllocationID.Malformed; a malformed allocation ID
 	// comes back as InvalidAllocationID.NotFound.
 	ec2AllocationIDKind = ec2IDKind{

--- a/emulator/ec2_snapshot_ops_test.go
+++ b/emulator/ec2_snapshot_ops_test.go
@@ -75,7 +75,7 @@ func ec2InstanceWithDataVolume(t *testing.T, ts *httptest.Server, dataGiB int) (
 	t.Helper()
 	instanceID = ec2RunInstanceIDs(t, ts, map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-0123456789abcdef0",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1",
 		"MaxCount": "1",
 	})[0]

--- a/emulator/ec2_snapshots_test.go
+++ b/emulator/ec2_snapshots_test.go
@@ -258,7 +258,7 @@ func TestEC2_BlockDeviceMapping_InheritsTheSnapshotSize(t *testing.T) {
 
 	ec2FleetXML(t, ts, map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-0abcdef1234567890",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1", "MaxCount": "1",
 		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
 		"BlockDeviceMapping.1.Ebs.SnapshotId": snapID,
@@ -371,7 +371,7 @@ func TestEC2_CreateImage_SnapshotSizeIsTheRootVolume(t *testing.T) {
 	}
 	ec2FleetXML(t, ts, map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-0abcdef1234567890",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1", "MaxCount": "1",
 		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
 		"BlockDeviceMapping.1.Ebs.VolumeSize": "40",

--- a/emulator/ec2_tags_test.go
+++ b/emulator/ec2_tags_test.go
@@ -23,7 +23,7 @@ func ec2TagTestInstance(t *testing.T, ts *httptest.Server) string {
 	t.Helper()
 	ids := ec2RunInstanceIDs(t, ts, map[string]string{
 		"Action":   "RunInstances",
-		"ImageId":  "ami-0tagtest00000001",
+		"ImageId":  ec2TestImage,
 		"MinCount": "1",
 		"MaxCount": "1",
 	})
@@ -314,7 +314,7 @@ func TestEC2_RunInstances_RejectsReservedTagKeys(t *testing.T) {
 			ts := newEC2TestServer(t)
 			params := map[string]string{
 				"Action":                          "RunInstances",
-				"ImageId":                         "ami-0reserved00000001",
+				"ImageId":                         ec2TestImage,
 				"MinCount":                        "1",
 				"MaxCount":                        "1",
 				"TagSpecification.1.ResourceType": "instance",
@@ -356,7 +356,7 @@ func TestEC2_RunInstances_ReservedTagRejectionCreatesNothing(t *testing.T) {
 	// legal tag is not applied to anything either.
 	status, code, _ := ec2ErrorDetail(t, ts, map[string]string{
 		"Action":                          "RunInstances",
-		"ImageId":                         "ami-0rollback00000001",
+		"ImageId":                         ec2TestImage,
 		"MinCount":                        "3",
 		"MaxCount":                        "3",
 		"TagSpecification.1.ResourceType": "instance",
@@ -374,7 +374,7 @@ func TestEC2_RunInstances_ReservedTagRejectionCreatesNothing(t *testing.T) {
 	// tag, not just the first block's.
 	status, code, _ = ec2ErrorDetail(t, ts, map[string]string{
 		"Action":                          "RunInstances",
-		"ImageId":                         "ami-0rollback00000002",
+		"ImageId":                         ec2TestImage,
 		"MinCount":                        "1",
 		"MaxCount":                        "1",
 		"TagSpecification.1.ResourceType": "instance",
@@ -397,7 +397,7 @@ func TestEC2_RunInstances_ReservedTagRejectionCreatesNothing(t *testing.T) {
 	// launch loop, where the instance is written one iteration ahead of its volumes.
 	status, code, _ = ec2ErrorDetail(t, ts, map[string]string{
 		"Action":                          "RunInstances",
-		"ImageId":                         "ami-0rollback00000003",
+		"ImageId":                         ec2TestImage,
 		"MinCount":                        "1",
 		"MaxCount":                        "1",
 		"TagSpecification.1.ResourceType": "volume",
@@ -842,7 +842,7 @@ func TestEC2_TagOnCreate_EnforcesTagLimit(t *testing.T) {
 		ts := newEC2TestServer(t)
 		params := map[string]string{
 			"Action":   "RunInstances",
-			"ImageId":  "ami-0taglimit0000001",
+			"ImageId":  ec2TestImage,
 			"MinCount": "1",
 			"MaxCount": "1",
 		}
@@ -858,7 +858,7 @@ func TestEC2_TagOnCreate_EnforcesTagLimit(t *testing.T) {
 		ts := newEC2TestServer(t)
 		params := map[string]string{
 			"Action":   "RunInstances",
-			"ImageId":  "ami-0taglimit0000002",
+			"ImageId":  ec2TestImage,
 			"MinCount": "1",
 			"MaxCount": "1",
 		}
@@ -1463,7 +1463,7 @@ func TestEC2_TagOnCreate_EnforcesLengthLimits(t *testing.T) {
 		ts := newEC2TestServer(t)
 		status, code, message := ec2ErrorDetail(t, ts, map[string]string{
 			"Action":                          "RunInstances",
-			"ImageId":                         "ami-0taglength00000001",
+			"ImageId":                         ec2TestImage,
 			"MinCount":                        "2",
 			"MaxCount":                        "2",
 			"TagSpecification.1.ResourceType": "instance",
@@ -1640,7 +1640,7 @@ func TestEC2_LaunchTemplate_EnforcesTagLengthAtCreation(t *testing.T) {
 		// case without refusing the ordinary one, which is what a mis-scoped comparison
 		// would do.
 		ts := newEC2TestServer(t)
-		data := map[string]string{"LaunchTemplateData.ImageId": "ami-0lttaglength00004"}
+		data := map[string]string{"LaunchTemplateData.ImageId": ec2TestImage}
 		for k, v := range ltTagParams([2]string{
 			strings.Repeat("k", ec2TagKeyLimit),
 			strings.Repeat("v", ec2TagValueLimit),

--- a/emulator/ec2_volume_tags_test.go
+++ b/emulator/ec2_volume_tags_test.go
@@ -647,7 +647,7 @@ func TestEC2_RunInstances_VolumeTagRulesRefused(t *testing.T) {
 
 	status, code, msg := ec2ErrorDetail(t, ts, map[string]string{
 		"Action":                          "RunInstances",
-		"ImageId":                         "ami-0abcdef1234567890",
+		"ImageId":                         ec2TestImage,
 		"MinCount":                        "1",
 		"MaxCount":                        "1",
 		"TagSpecification.1.ResourceType": "volume",
@@ -677,7 +677,7 @@ func TestEC2_LaunchTemplate_VolumeTagSpecifications(t *testing.T) {
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "tagged-volumes",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.TagSpecification.1.ResourceType": "instance",
 		"LaunchTemplateData.TagSpecification.1.Tag.1.Key":    "Name",
 		"LaunchTemplateData.TagSpecification.1.Tag.1.Value":  "from-template",
@@ -715,7 +715,7 @@ func TestEC2_LaunchTemplate_VolumeTagsAreReplacedNotMerged(t *testing.T) {
 	resp := ec2Request(t, ts, map[string]string{
 		"Action":                     "CreateLaunchTemplate",
 		"LaunchTemplateName":         "merge-check",
-		"LaunchTemplateData.ImageId": "ami-0abcdef1234567890",
+		"LaunchTemplateData.ImageId": ec2TestImage,
 		"LaunchTemplateData.TagSpecification.1.ResourceType": "volume",
 		"LaunchTemplateData.TagSpecification.1.Tag.1.Key":    "Backup",
 		"LaunchTemplateData.TagSpecification.1.Tag.1.Value":  "weekly",

--- a/emulator/ssm_managed_ami_test.go
+++ b/emulator/ssm_managed_ami_test.go
@@ -7,12 +7,21 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
 )
 
 // TestSSMPlugin_ManagedAMIParameter verifies that GetParameter resolves the
 // AWS-managed public AMI parameters under /aws/service/* (which are not
-// user-created) to a deterministic synthetic AMI id, rather than 404. Tools
-// like spawn auto-detect their AMI via these parameters.
+// user-created) to a deterministic AMI id, rather than 404. Tools like spawn
+// auto-detect their AMI via these parameters.
+//
+// The id is the bundled catalog's answer for (region, parameter) rather than a
+// hash taken in the resolver: since #733 RunInstances refuses an AMI it cannot
+// resolve, so the value here has to be one a launch accepts. That is why the
+// assertion compares against [emulator.BundledImageID] instead of merely
+// checking the ami- prefix — a resolver that minted an id of its own would still
+// pass a prefix check while handing out an AMI substrate then refuses.
 func TestSSMPlugin_ManagedAMIParameter(t *testing.T) {
 	srv := newSSMTestServer(t)
 
@@ -26,6 +35,8 @@ func TestSSMPlugin_ManagedAMIParameter(t *testing.T) {
 
 	val, _ := param["Value"].(string)
 	assert.True(t, strings.HasPrefix(val, "ami-"), "managed AMI param should resolve to an ami- value, got %q", val)
+	assert.Equal(t, emulator.BundledImageID(ec2TestRegion, name), val,
+		"the value must be the bundled catalog's AMI for this parameter, which is the one a launch resolves")
 	assert.Equal(t, name, param["Name"])
 
 	// Deterministic: a second lookup returns the same value.

--- a/emulator/ssm_plugin.go
+++ b/emulator/ssm_plugin.go
@@ -3,9 +3,7 @@ package emulator
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -277,20 +275,21 @@ func (p *SSMPlugin) getParameter(ctx *RequestContext, req *AWSRequest) (*AWSResp
 // /aws/service/canonical/ubuntu/*, /aws/service/ecs/optimized-ami/*). The AMI id
 // is deterministic per (name, region) so repeated lookups are stable. Returns
 // nil for non-managed names.
+//
+// The id comes from the bundled image catalog rather than from a hash of the name
+// taken here, so that the AMI this hands a caller is one [EC2Plugin.resolveImage]
+// can also resolve. Those were independent computations through v0.107.0, which
+// was survivable only while nothing checked an AMI's existence: once RunInstances
+// began refusing an AMI that names nothing (#733), a GetParameter answer no
+// catalog entry backed would have been an AMI substrate itself handed out and
+// then refused to launch. See [bundledImageForParameter] for what an unlisted
+// path in a known family resolves to.
 func resolveManagedParameter(name, region string) map[string]interface{} {
-	if !strings.HasPrefix(name, "/aws/service/") {
+	img, ok := bundledImageForParameter(name)
+	if !ok {
 		return nil
 	}
-	isAMI := strings.Contains(name, "ami-") ||
-		strings.Contains(name, "/optimized-ami/") ||
-		strings.Contains(name, "/ubuntu/") ||
-		strings.Contains(name, "-latest")
-	if !isAMI {
-		return nil
-	}
-	// Deterministic 17-hex-char AMI id derived from name+region.
-	sum := sha256.Sum256([]byte(region + ":" + name))
-	amiID := "ami-" + hex.EncodeToString(sum[:])[:17]
+	amiID := img.idIn(region)
 	return map[string]interface{}{
 		"Name":             name,
 		"Type":             "String",

--- a/emulator/testing.go
+++ b/emulator/testing.go
@@ -328,3 +328,37 @@ func (ts *TestServer) SeedSSMParameters(params map[string]string) {
 		ts.SeedSSMParameter(name, value)
 	}
 }
+
+// SeedEC2Image registers an AMI owned by the seeding account, bypassing the HTTP layer, so a
+// test can launch from an image ID it chose.
+//
+// RunInstances refuses an AMI it cannot resolve (#733), which leaves a test that needs a
+// specific ID three options: name a bundled AMI through [BundledImageID], call RegisterImage,
+// or call this. It exists for the third case — a caller-owned image, or an ID a fixture
+// already hardcodes — and writes the same record RegisterImage would, in state, so
+// DescribeImages lists it and an Owners=self describe matches it. A bundled AMI is *not* in
+// state, which is the difference between the two.
+//
+// The image is stored under account 123456789012 and the region the built-in test credentials
+// use, in state "available". Call [TestServer.ResetState] between cases to clear it.
+func (ts *TestServer) SeedEC2Image(imageID, name string) {
+	if ts.state == nil {
+		return
+	}
+
+	img := EC2Image{
+		ImageID:      imageID,
+		Name:         name,
+		Description:  name,
+		State:        "available",
+		CreationDate: ts.tc.Now().UTC().Format(time.RFC3339),
+		AccountID:    defaultAccountID,
+		Region:       seedSSMRegion,
+	}
+	data, err := json.Marshal(img)
+	if err != nil {
+		return
+	}
+	_ = ts.state.Put(context.Background(), ec2Namespace,
+		ec2ImageStateKey(defaultAccountID, seedSSMRegion, imageID), data)
+}

--- a/emulator/testing_test.go
+++ b/emulator/testing_test.go
@@ -248,6 +248,73 @@ func TestTestServer_SeedSSMParameter(t *testing.T) {
 	}
 }
 
+// TestTestServer_SeedEC2Image covers the helper a test reaches for when it needs to launch
+// from an AMI ID of its own choosing.
+//
+// RunInstances refuses an AMI it cannot resolve (#733), so an ID a fixture invents no longer
+// launches by itself. Seeding is what makes it resolvable, and the unseeded half of this test
+// is what proves the seeding — rather than a permissive handler — is doing the work.
+func TestTestServer_SeedEC2Image(t *testing.T) {
+	ts := emulator.StartTestServer(t)
+
+	const seeded = "ami-0f00dbaadf00d0001"
+	const unseeded = "ami-0e11e11e11e11e11e"
+
+	ts.SeedEC2Image(seeded, "fixture-image")
+
+	runInstances := func(imageID string) (int, string) {
+		form := "Action=RunInstances&Version=2016-11-15&MinCount=1&MaxCount=1&ImageId=" + imageID
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader(form)) //nolint:noctx
+		req.Host = "ec2.us-east-1.amazonaws.com"
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIATEST12345678901/20260101/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-date, Signature=fakesig")
+		req.Header.Set("X-Amz-Date", "20260101T000000Z")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("RunInstances %s: %v", imageID, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return resp.StatusCode, string(body)
+	}
+
+	status, body := runInstances(seeded)
+	if status != http.StatusOK {
+		t.Fatalf("RunInstances from a seeded AMI: status %d body %s", status, body)
+	}
+	if !strings.Contains(body, seeded) {
+		t.Errorf("the launched instance does not report the seeded AMI: %s", body)
+	}
+
+	status, body = runInstances(unseeded)
+	if status != http.StatusBadRequest {
+		t.Fatalf("RunInstances from an unseeded AMI: status %d body %s", status, body)
+	}
+	if !strings.Contains(body, "InvalidAMIID.NotFound") {
+		t.Errorf("want InvalidAMIID.NotFound for an unseeded AMI, got %s", body)
+	}
+
+	// The record is a real image record, so DescribeImages lists it.
+	form := "Action=DescribeImages&Version=2016-11-15&ImageId.1=" + seeded
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/", strings.NewReader(form)) //nolint:noctx
+	req.Host = "ec2.us-east-1.amazonaws.com"
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIATEST12345678901/20260101/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-date, Signature=fakesig")
+	req.Header.Set("X-Amz-Date", "20260101T000000Z")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+	described, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DescribeImages: status %d body %s", resp.StatusCode, described)
+	}
+	if !strings.Contains(string(described), "fixture-image") {
+		t.Errorf("DescribeImages does not name the seeded image: %s", described)
+	}
+}
+
 func TestTestServer_Accessors(t *testing.T) {
 	ts := emulator.StartTestServer(t)
 

--- a/test/e2e/journey_ec2_block_devices_test.go
+++ b/test/e2e/journey_ec2_block_devices_test.go
@@ -35,7 +35,7 @@ func TestJourney_EC2LaunchBlockDeviceMappings(t *testing.T) {
 	ctx := context.Background()
 
 	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-0abcdef1234567890"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: ec2types.InstanceTypeT3Micro,
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),
@@ -137,7 +137,7 @@ func TestJourney_EC2LaunchDataVolumeSurvivesTermination(t *testing.T) {
 	// Neither mapping names DeleteOnTermination, so both take a default and the two
 	// defaults differ.
 	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-0abcdef1234567890"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: ec2types.InstanceTypeT3Micro,
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),
@@ -248,7 +248,7 @@ func TestJourney_EC2InvalidBlockDeviceMappingRefused(t *testing.T) {
 	ctx := context.Background()
 
 	_, err = client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-0abcdef1234567890"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: ec2types.InstanceTypeT3Micro,
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),
@@ -342,7 +342,7 @@ func TestJourney_EC2VolumeTags(t *testing.T) {
 	// the instance scope must stay separate, which is what the second specification
 	// here proves.
 	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-0abcdef1234567890"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: ec2types.InstanceTypeT3Micro,
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),
@@ -445,7 +445,7 @@ func TestJourney_EC2VolumeTags(t *testing.T) {
 	// A reserved key is refused on the volume scope on the same terms as the instance
 	// scope, and the refusal is whole: no instance, no volume.
 	_, err = client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-0abcdef1234567890"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: ec2types.InstanceTypeT3Micro,
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),

--- a/test/e2e/journey_ec2_default_vpc_authz_test.go
+++ b/test/e2e/journey_ec2_default_vpc_authz_test.go
@@ -18,10 +18,12 @@ import (
 	emulator "github.com/scttfrdmn/substrate/emulator"
 )
 
+// journeyDefaultVPCRegion has to be the region [journeyImage] resolves in: these journeys
+// launch from that AMI and also name it in a policy ARN, and an AMI ID is valid in exactly
+// one region (#733).
 const (
 	journeyDefaultVPCRegion  = "us-east-1"
 	journeyDefaultVPCAccount = "123456789012"
-	journeyDefaultVPCAMI     = "ami-0abcdef1234567890"
 )
 
 // journeyGuardedEC2 creates an IAM user with an access key and returns an EC2 client
@@ -141,7 +143,7 @@ func TestJourney_EC2DefaultVPCSubnetGuardrail(t *testing.T) {
 	arn := func(format string) string {
 		return "arn:aws:ec2:" + journeyDefaultVPCRegion + ":" + journeyDefaultVPCAccount + ":" + format
 	}
-	imageARN := "arn:aws:ec2:" + journeyDefaultVPCRegion + "::image/" + journeyDefaultVPCAMI
+	imageARN := "arn:aws:ec2:" + journeyDefaultVPCRegion + "::image/" + journeyImage
 	allow := func(resources ...string) string {
 		return `{"Version":"2012-10-17","Statement":[` +
 			`{"Effect":"Allow","Action":"ec2:RunInstances","Resource":["` +
@@ -151,7 +153,7 @@ func TestJourney_EC2DefaultVPCSubnetGuardrail(t *testing.T) {
 	launcher, putPolicy := journeyGuardedEC2(t, ctx, ts, iamClient, "subnetless-launcher")
 	launch := func(client *ec2.Client) (*ec2.RunInstancesOutput, error) {
 		return client.RunInstances(ctx, &ec2.RunInstancesInput{
-			ImageId:      aws.String(journeyDefaultVPCAMI),
+			ImageId:      aws.String(journeyImage),
 			InstanceType: ec2types.InstanceTypeT3Micro,
 			MinCount:     aws.Int32(1),
 			MaxCount:     aws.Int32(1),
@@ -296,7 +298,7 @@ func TestJourney_EC2CreateFleetAuthorizesItsLaunches(t *testing.T) {
 	lt, err := admin.CreateLaunchTemplate(ctx, &ec2.CreateLaunchTemplateInput{
 		LaunchTemplateName: aws.String("fleet-pool"),
 		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
-			ImageId: aws.String(journeyDefaultVPCAMI),
+			ImageId: aws.String(journeyImage),
 		},
 	})
 	if err != nil {
@@ -307,7 +309,7 @@ func TestJourney_EC2CreateFleetAuthorizesItsLaunches(t *testing.T) {
 	arn := func(format string) string {
 		return "arn:aws:ec2:" + journeyDefaultVPCRegion + ":" + journeyDefaultVPCAccount + ":" + format
 	}
-	imageARN := "arn:aws:ec2:" + journeyDefaultVPCRegion + "::image/" + journeyDefaultVPCAMI
+	imageARN := "arn:aws:ec2:" + journeyDefaultVPCRegion + "::image/" + journeyImage
 
 	fleeter, putPolicy := journeyGuardedEC2(t, ctx, ts, iamClient, "fleeter")
 	createFleet := func() (*ec2.CreateFleetOutput, error) {

--- a/test/e2e/journey_ec2_describetags_test.go
+++ b/test/e2e/journey_ec2_describetags_test.go
@@ -32,7 +32,7 @@ func TestJourney_EC2DescribeTags(t *testing.T) {
 
 	// Two resources of different types, so resourceType has something to distinguish.
 	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-0abcdef1234567890"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: ec2types.InstanceTypeT3Micro,
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),

--- a/test/e2e/journey_ec2_errors_test.go
+++ b/test/e2e/journey_ec2_errors_test.go
@@ -78,7 +78,7 @@ func TestJourney_EC2ErrorCodesReachTheSDK(t *testing.T) {
 	})
 
 	_, err = client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-12345678"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: "t3.micro",
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),
@@ -106,9 +106,12 @@ func TestJourney_EC2ErrorCodesReachTheSDK(t *testing.T) {
 
 	// Clearing the fault restores the nominal path, which proves the assertion above
 	// was reading the seeded error rather than a launch that would have failed anyway.
+	// That argument only holds if the launch is otherwise valid, which is why both calls
+	// name the bundled journeyImage rather than a fabricated ID RunInstances would refuse
+	// with InvalidAMIID.NotFound (#733).
 	clearFaultRules(t, ts)
 	if _, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-12345678"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: "t3.micro",
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),

--- a/test/e2e/journey_ec2_runinstances_authz_test.go
+++ b/test/e2e/journey_ec2_runinstances_authz_test.go
@@ -18,6 +18,22 @@ import (
 	emulator "github.com/scttfrdmn/substrate/emulator"
 )
 
+// journeyImage is the AMI the EC2 journeys launch from — the ID substrate resolves for
+// AWS's Amazon Linux 2023 x86_64 SSM public parameter, which is what a consumer's IaC
+// discovers an AMI through.
+//
+// It is derived from the bundled catalog rather than written as a literal because
+// RunInstances refuses an ImageId it cannot resolve (#733). The fabricated
+// "ami-0abcdef1234567890" these journeys used to name is one of the example IDs from AWS's
+// own reference pages, and substrate deliberately does not bundle those: IaC hardcoding one
+// fails on real AWS, so it has to fail here too.
+//
+// The region is the one every journey's client addresses (see journeyConfig), and it is
+// load-bearing — an AMI ID names an image in exactly one region and nothing in any other,
+// so this value is launchable only through a us-east-1 client.
+var journeyImage = emulator.BundledImageID("us-east-1",
+	"/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64")
+
 // TestJourney_EC2RunInstancesSubnetGuardrail is #662 at the tier the guardrail is
 // actually written at: a policy that allows ec2:RunInstances everywhere except one
 // subnet, which is how a consumer keeps workloads out of a private or shared
@@ -129,7 +145,7 @@ func TestJourney_EC2RunInstancesSubnetGuardrail(t *testing.T) {
 
 	launch := func(client *ec2.Client, subnetID string) (*ec2.RunInstancesOutput, error) {
 		return client.RunInstances(ctx, &ec2.RunInstancesInput{
-			ImageId:          aws.String("ami-0abcdef1234567890"),
+			ImageId:          aws.String(journeyImage),
 			InstanceType:     ec2types.InstanceTypeT3Micro,
 			MinCount:         aws.Int32(1),
 			MaxCount:         aws.Int32(1),
@@ -183,7 +199,7 @@ func TestJourney_EC2RunInstancesSubnetGuardrail(t *testing.T) {
 	// Reference gives — an AMI is shareable.
 	leastPrivilege := `{"Version":"2012-10-17","Statement":[` +
 		`{"Effect":"Allow","Action":"ec2:RunInstances","Resource":[` +
-		`"arn:aws:ec2:` + region + `::image/ami-0abcdef1234567890",` +
+		`"arn:aws:ec2:` + region + `::image/` + journeyImage + `",` +
 		`"arn:aws:ec2:` + region + `:` + account + `:subnet/` + publicSubnet + `",` +
 		`"arn:aws:ec2:` + region + `:` + account + `:security-group/` + sgID + `",` +
 		`"arn:aws:ec2:` + region + `:` + account + `:network-interface/*",` +

--- a/test/e2e/journey_ec2_snapshots_test.go
+++ b/test/e2e/journey_ec2_snapshots_test.go
@@ -104,7 +104,7 @@ func TestJourney_EC2SnapshotRestore(t *testing.T) {
 	// observable only through DescribeVolumes — AWS's EbsInstanceBlockDevice, the shape
 	// DescribeInstances renders per device, carries no size member.
 	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-0abcdef1234567890"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: ec2types.InstanceTypeT3Micro,
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),
@@ -166,7 +166,7 @@ func TestJourney_EC2SnapshotRefusals(t *testing.T) {
 
 	launch := func(bdm ec2types.BlockDeviceMapping) error {
 		_, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
-			ImageId:             aws.String("ami-0abcdef1234567890"),
+			ImageId:             aws.String(journeyImage),
 			InstanceType:        ec2types.InstanceTypeT3Micro,
 			MinCount:            aws.Int32(1),
 			MaxCount:            aws.Int32(1),

--- a/test/e2e/journey_ec2_tag_authz_test.go
+++ b/test/e2e/journey_ec2_tag_authz_test.go
@@ -52,7 +52,7 @@ func TestJourney_EC2CreateTagsGuardrail(t *testing.T) {
 	// are readable back through a Describe: this journey has to see that a denial
 	// wrote nothing, not just that it answered 403.
 	run, err := admin.RunInstances(ctx, &ec2.RunInstancesInput{
-		ImageId:      aws.String("ami-0abcdef1234567890"),
+		ImageId:      aws.String(journeyImage),
 		InstanceType: ec2types.InstanceTypeT3Micro,
 		MinCount:     aws.Int32(1),
 		MaxCount:     aws.Int32(1),


### PR DESCRIPTION
Substrate accepted **any** non-empty `ImageId` and launched an instance reporting it — `ami-test`,
`not-an-ami`, `ami-EXAMPLE`, `ami-0abcdef1234567890`. The only check asked whether a value was
present. So the mistake generated infrastructure code makes most often, naming an AMI that does
not exist in the target Region, was invisible until the same template reached real AWS — the
opposite of what substrate is for. Found by a live SDK run against a built binary.

## What lands

**A bundled AMI catalog** (`emulator/ec2_bundled_images.go`, new). Nine AWS public SSM parameter
names resolve to a real image — Amazon Linux 2023 (full and minimal, x86_64 and arm64), Windows
Server 2022 Full Base, ECS-optimized AL2023 and AL2, Ubuntu 24.04 and 22.04 — each path taken
verbatim from the AWS page that publishes it. Any other AMI-shaped `/aws/service/…` path resolves
to its family's entry, because substrate has answered every such path since #267 and an unlisted
one must still resolve to something launchable.

The ID is **derived**, `sha256(region + ":" + parameter)` as `ami-` + 17 hex, and it is the *same*
computation `GetParameter` answers with — `resolveManagedParameter` now delegates to the catalog
instead of hashing the name itself. One table means the AMI substrate hands out cannot be an AMI
it then refuses. Derived rather than seeded: no startup write, every Region, stable across runs,
processes and replays. `emulator.BundledImageID(region, parameter)` exposes it;
`TestServer.SeedEC2Image` registers a caller-owned record for a test that needs a specific ID.

Deliberately **not** bundled: `ami-0abcdef1234567890` and `ami-1234567890abcdef0`, the example IDs
AWS's own reference pages use and generated IaC copies. IaC that hardcodes one fails on real AWS,
so it must fail here. `TestEC2_BundledImages_DocumentationExamplesAreNotBundled` pins it.

**One resolver.** `EC2Plugin.resolveImage` checks `ec2ImageStateKey` first, then the catalog for
the request's Region, so a registered image wins over a derived one.

**The kind and the refusal.** `ec2ImageIDKind` joins the ten existing families in
`ec2_resourceid.go`, carrying AWS's published pair `InvalidAMIID.NotFound` /
`InvalidAMIID.Malformed`. A single insertion in `runInstancesWithTags`, beside the emptiness
refusal and after the launch-template merge, answers syntax before absence. That position matters
twice: an AMI reaching a launch through a template is refused at `RunInstances` time, and the check
sits ahead of `ensureDefaultVPC`, which would otherwise commit a VPC, subnet, security group,
gateway and route table before refusing. `CreateFleet` inherits the rule through the launch path
it already shares.

**`CreateLaunchTemplate` / `CreateLaunchTemplateVersion` stay permissive**, deliberately: AWS
reports mapping problems there through the response's `warning` member rather than refusing, so an
AMI rule would be a refusal AWS does not make. The template's AMI is checked when it is used.

**The CFN deployer's default** was the literal `"ami-00000000"` — a value that existed only because
nothing checked existence. It is now `BundledImageID(region, …al2023-ami-kernel-default-x86_64)`,
so a template omitting `ImageId` still deploys, against an AMI substrate can resolve.

## Narrowed from the plan

Three things the plan called for that implementation changed, recorded here because the release
notes come from the CHANGELOG, not the plan:

1. **No region-independent literal fixture entry.** The plan wanted one catalog entry with a fixed
   ID for `cfn_deployer.go:3289`'s default. A literal entry would be an AMI resolving in every
   Region, which is exactly the property #733 removes. The default became Region-derived instead.
2. **Descriptors omit architecture, platform and root device.** `EC2Image` has no fields for them,
   and adding three is a `DescribeImages` rendering change that belongs with #731's half of that
   operation. Filed as a follow-up.
3. **`describeImages` is untouched here.** A bundled AMI is resolvable and nameable but not yet
   *nameable through `DescribeImages`* — that operation ignores `ImageId.N` entirely today, which
   is #731's worse defect. Until PR 3 lands, a bundled AMI describes as absent.

Bundled AMIs are resolvable but **not enumerated** by an unqualified describe — substrate's
reading, recorded in `docs/services.md`. `DescribeImages` lists what an account owns; a public
AWS-owned image is not that, and real AWS would answer tens of thousands of images.
`InvalidAMIID.Unavailable` is out of scope: substrate models no deregistered-but-extant image.

## The sweep

Roughly 300 edits across 40 test files in two packages. **Not one test was launching an AMI that
existed** — a quarter of the distinct literals were non-hex (`ami-base`, `ami-tmpl`,
`ami-0legacy000000001`) and would now trip Malformed, so seeding could not have rescued them; the
literals themselves changed. Shared fixtures did most of the work: one edit to `ec2_tags_test.go`'s
`ec2TagTestInstance` cleared seven top-level failures, and one to `newFleetLaunchTemplate` cleared
seventeen.

Four orderings the sweep exposed, each a case where the new check preempted the refusal a test was
about: `runInstancesWithTags` checks the AMI before `ec2CheckBlockDeviceMappings`, before the
volume-scoped tag check, and before `ensureDefaultVPC`'s `InvalidGroup.NotFound`; and
`cfn_mappings_test.go`'s good mapping key had to move to `us-east-1` because the deployer's default
Region is what resolves the AMI. `cloudformation_identity_test.go`'s shared template const became
`cfnInstanceTemplateIn(region)` for the one test that deploys into eu-west-1.
`TestEC2_RunInstances_MissingImageId` stays green — an absent `ImageId` is still
`MissingParameter`, not `Malformed`.

## Verification

```
gofmt -l . · go build ./... · go vet ./... · golangci-lint run ./...   clean
make test (race)                                                      pass
make coverage                                                         emulator 83.3%, total 82.6%
make docs-reference docs-reference-check docs-versions                 clean
npm --prefix docs run build + href/id anchor diff over dist            no dangling anchors
go vet -C test/e2e ./... && go test -C test/e2e ./...                  pass
```

Live SDK run against a built binary on `:4678`, nine parts — the issue's own two commands, AWS's
doc-example ID, SSM discovery then launch, the Windows and Ubuntu parameters, a eu-west-1 ID
refused in us-east-1, `RegisterImage` then launch, `CreateFleet` refusing a template's
unresolvable AMI while `CreateLaunchTemplate` accepted it, and a CFN stack with no `ImageId`
reaching `CREATE_COMPLETE` on the bundled default:

```
1. run-instances --image-id ami-00000000000000000
   InvalidAMIID.NotFound: The image ID 'ami-00000000000000000' does not exist
2. run-instances --image-id not-an-ami
   InvalidAMIID.Malformed: Invalid id: "not-an-ami"
3. run-instances --image-id ami-0abcdef1234567890
   InvalidAMIID.NotFound
4. GetParameter -> ami-d4c4e839d3f47ba84;  i-6cedd00fc53f2c27  ami-d4c4e839d3f47ba84  running
6. eu-west-1 -> ami-e70f32506019b1b47 (us-east-1 was ami-d4c4e839d3f47ba84)
   InvalidAMIID.NotFound in us-east-1
8. CreateLaunchTemplate accepted lt-cd8450278a83a138; CreateFleet -> InvalidAMIID.NotFound
9. Box  CREATE_COMPLETE  i-8c4645df6741803c
```

Closes #733
