### PR TITLE
fix(ec2): a volume or AMI ID that names nothing is an error (#731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coherent. Substrate's own suite needed roughly 300 such edits across 40 test files, and not one
   of them had been launching an AMI that existed.
 
+- **A `VolumeId.N` or `ImageId.N` that names nothing is an error, not an empty answer** (#731).
+  Both operations answered 200 and an empty set for an ID that resolved to nothing, so a
+  consumer's `InvalidVolume.NotFound` branch was unreachable and a poll loop waiting for a
+  volume to appear could not tell "not yet" from "never". `DescribeVolumes` and `DescribeImages`
+  now route their ID lists through the same `ec2IDFilter` the other ten ID-asserting describes
+  use, so they answer `InvalidVolume.NotFound`/`InvalidVolumeID.Malformed` and
+  `InvalidAMIID.NotFound`/`InvalidAMIID.Malformed` from the one table, syntax before absence,
+  and one present plus one absent ID fails the whole call. An ID a `Filter` excluded still
+  counts as resolved — only absence is an error. Twelve EC2 describes now assert existence,
+  which is every one whose ID family has a published code and a registered kind.
+
+  Validating the ID list moved **ahead** of the filter-name check on `DescribeVolumes`, where it
+  ran second, matching the other handlers; the ordering is now pinned rather than incidental.
+
+  A bundled public AMI (#733) is nameable here even though it is not enumerated: a describe
+  that called an AMI absent while a launch accepted it would contradict itself, and resolving
+  an AMI through SSM and then reading its members is the workflow generated IaC produces.
+
+  **Compatibility.** A describe naming a volume or an AMI that does not exist now fails where it
+  returned an empty set. Two of substrate's own tests asserted the empty set as the contract —
+  one of them with a comment naming this gap — and both now assert the refusal.
+
 ### Fixed
 - **One server serves one account** (#734). `ParseAWSRequest` decided the account from the
   *shape of the access key*: a key beginning with `AKIA` was attributed to `123456789012`,
@@ -119,6 +141,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and unreachable — the #561/#580 failure mode — so `ListEventBuses` returning the wrong account
   had never been observable in the first place. A test now pins all three resolution paths, as
   Config's does.
+
+- **`DescribeImages` read no `ImageId.N` at all** (#731). Found while surveying for the above:
+  a caller naming one AMI was answered with **every** AMI the account owned. This is the worse
+  half of the issue, because a superset is invisible where an error is not — "the query returns
+  only my AMI" passed with two AMIs in the answer and one in the assertion's blind spot, and a
+  CDK or Terraform run that describes an AMI to read its members read the wrong image's.
+
+  Two more silent widenings on `DescribeVolumes`' hand-rolled ID loop, both fixed by moving to
+  the shared helper: it read only the indexed `VolumeId.N`, so the un-indexed `VolumeId` a
+  hand-built request or an older SDK shape sends was ignored and the answer covered every
+  volume; and it stopped at the first empty **value** rather than the first missing **key**, so
+  an explicitly empty `VolumeId.1` discarded `VolumeId.2` and everything after it. An empty
+  value is an ID the caller sent, so it is now reported as `Malformed`.
+
+  `DescribeImages` still does not read `Owner.N` or `ExecutableBy.N`, and `docs/services.md`
+  now says so and why: substrate stores only images the account owns, so `self` is the answer
+  to every describe and AWS's other three `Owner` values select sets substrate does not model.
+  Reading the parameter would let a caller believe a narrowing happened.
+
+- **Two documentation claims that were wrong** (#731). `containsStr`'s doc comment said
+  `KeyName.N`, `GroupName.N`, `FleetId.N` and `RegionName.N` each raise an `Invalid*.NotFound`
+  on an unmatched entry; only `InstanceType.N` does, and the other four narrow the answer to
+  nothing. `docs/services.md` counted "six of the new selectors" that answer an empty set where
+  AWS answers `NotFound` and named four families; there are seven, and each now carries its own
+  reason — `DescribeFleets`' `FleetId.N` and `DescribeRegions`' `RegionName.N` are permanent
+  declines (AWS publishes no `InvalidFleetId.NotFound`, and `RegionName.N` explicitly permits
+  naming any Region), while the other five are unimplemented rather than declined.
 
   **Compatibility.** Every ARN returned to an unsigned or non-`AKIA` caller changes account, so
   a fixture asserting on `000000000000` now sees `123456789012`. Several plugins prefix their

--- a/docs/services.md
+++ b/docs/services.md
@@ -3327,15 +3327,20 @@ the template is resolved, so a typo answers `InvalidParameterValue` rather than
   `opt-in-not-required`, so the opt-in filtering the parameter controls has nothing to exclude.
 - **`IncludeUnsupportedInRegion` is not read** on `DescribeInstanceTypes`; the seeded catalog is
   the same in every region.
-- **Six of the new selectors answer an empty set where AWS answers `NotFound`.** `KeyName.N` and
-  `KeyPairId.N` (AWS: `InvalidKeyPair.NotFound`), `GroupName.N` and `GroupId.N` on
-  `DescribePlacementGroups` (`InvalidPlacementGroup.Unknown`), `ZoneName.N`/`ZoneId.N`, and
-  `PublicIp.N` all select by membership rather than through an
-  [ID assertion](#explicit-resource-ids), because no `ec2IDKind` is registered for those
-  resources — so naming one that does not exist narrows the answer to nothing instead of
-  failing. Within the twelve, `InstanceId.N`, `VpcId.N`, `InternetGatewayId.N`,
-  `AllocationId.N` and `DescribeLaunchTemplateVersions`' template selector **do** assert
-  existence, as does `DescribeInstanceTypes`' `InstanceType.N` (`InvalidInstanceType`).
+- **Seven selector families answer an empty set where AWS answers `NotFound`.** `KeyName.N`
+  and `KeyPairId.N` (AWS: `InvalidKeyPair.NotFound`), `GroupName.N` and `GroupId.N` on
+  `DescribePlacementGroups` (`InvalidPlacementGroup.Unknown`), `ZoneName.N`/`ZoneId.N`,
+  `PublicIp.N`, `DescribeLaunchTemplates`' selectors, `DescribeFleets`' `FleetId.N` and
+  `DescribeRegions`' `RegionName.N` all select by membership rather than through an
+  [ID assertion](#explicit-resource-ids) — so naming one that does not exist narrows the
+  answer to nothing instead of failing. This read "six of the new selectors" and named
+  four families until #731, which added `DescribeLaunchTemplates` and the two whose
+  reasons are permanent rather than pending, and recorded a reason for each; see
+  [Which selectors assert existence](#which-selectors-assert-existence), where the two whose
+  reasons are permanent are separated from the five that are merely unimplemented. Within
+  the twelve, `InstanceId.N`, `VpcId.N`, `InternetGatewayId.N`, `AllocationId.N` and
+  `DescribeLaunchTemplateVersions`' template selector **do** assert existence, as does
+  `DescribeInstanceTypes`' `InstanceType.N` (`InvalidInstanceType`).
 
 ### RunInstances requires a resolvable AMI
 
@@ -3429,7 +3434,10 @@ Two things follow from bundled images living outside state.
   public AWS-owned AMI is not that, so an unqualified `DescribeImages` does not
   return them. This is substrate's reading, not AWS's behaviour — real AWS would
   return every public image, tens of thousands of them. A bundled AMI is
-  resolvable and nameable; it is not inventory.
+  resolvable and nameable; it is not inventory. Naming one in `ImageId.N` does
+  answer with it, because a describe and a launch must agree about which AMIs
+  exist — see [Explicit resource IDs](#explicit-resource-ids), whose rules
+  `DescribeImages` follows for every other ID.
 - **They are not the caller's.** A bundled image reports no owner, so it is not
   taggable and an `Owners=self` describe does not match it. Register your own AMI
   when the test is about owning one.
@@ -3738,7 +3746,10 @@ index, and a launch **materializes** the EBS volumes those mappings describe. Th
 are real volumes in the same store `CreateVolume` writes to, so `DescribeVolumes`
 is the one place to observe an instance's storage, whether the volume was
 provisioned separately or created by the launch — which is how real EC2 unifies
-the two.
+the two. Naming a `VolumeId.N` there is an
+[assertion that the volume exists](#explicit-resource-ids), so a mapping whose
+volume a test expects is confirmed by an error rather than by a silently empty
+answer.
 
 `DescribeVolumes` is also the **only** place a launch-specified size is
 observable. AWS's `EbsInstanceBlockDevice` — the shape an instance renders per
@@ -4812,6 +4823,54 @@ An ID is well formed when it has the resource's prefix followed by at least one
 lowercase hex digit. Length is deliberately not checked: substrate's generators
 emit 16 hex characters where AWS emits 8 or 17, and AWS itself still accepts the
 legacy 8-character form for several resources.
+
+#### Which selectors assert existence
+
+Every `Describe*` whose ID family has a row above resolves the IDs a caller names.
+Twelve do: `DescribeInstances`, `DescribeInstanceStatus`, `DescribeVpcs`,
+`DescribeSubnets`, `DescribeSecurityGroups`, `DescribeInternetGateways`,
+`DescribeRouteTables`, `DescribeSnapshots`, `DescribeAddresses`,
+`DescribeNatGateways`, `DescribeVolumes` and `DescribeImages`. The last two joined with
+[#731](https://github.com/scttfrdmn/substrate/issues/731); before that each answered a
+superset rather than an error, and
+`DescribeImages` did not read `ImageId.N` **at all** — a caller naming one AMI was
+answered with every AMI the account owned. A superset is the worse failure of the two,
+because an error is visible and a superset reads as a successful narrowing.
+
+`DescribeInstanceTypes`' `InstanceType.N` also asserts existence, answering
+`InvalidInstanceType`.
+
+**Seven selector families deliberately do not**, and answer an empty set where AWS
+answers `NotFound`. Two have reasons that would not change if a kind were registered
+for them:
+
+| Selector | Why not |
+|---|---|
+| `DescribeFleets`' `FleetId.N` | AWS publishes **no** `InvalidFleetId.NotFound`. The only fleet-ID absence code in the reference is `InvalidSpotFleetRequestId.*`, which is a `sfr-` request, not a `fleet-` fleet. |
+| `DescribeRegions`' `RegionName.N` | The parameter explicitly permits naming any Region, enabled for the account or not, so "this Region is not in your answer" is not absence. |
+
+Five more have a published code but no registered `ec2IDKind`, so the assertion is
+unimplemented rather than declined: `DescribeKeyPairs`' `KeyName.N`/`KeyPairId.N`
+(`InvalidKeyPair.NotFound`), `DescribePlacementGroups`' `GroupName.N`/`GroupId.N`
+(`InvalidPlacementGroup.Unknown`), `DescribeAvailabilityZones`' `ZoneName.N`/`ZoneId.N`,
+`DescribeAddresses`' `PublicIp.N` (its `AllocationId.N` **does** assert), and
+`DescribeLaunchTemplates`, whose `InvalidLaunchTemplateId.NotFound` is one of the four
+hand-written codes above.
+
+`DescribeSecurityGroups` documents a `GroupName.N` alongside `GroupId.N` and substrate
+**does not read it**: only the ID list selects. A caller naming a group by name is
+answered about every group, so filter on `group-name` instead, which is evaluated.
+
+`DescribeImages` also does not read `Owner.N` or `ExecutableBy.N`. Substrate stores only
+images the account owns, so `self` is the answer to every describe and AWS's other three
+`Owner` values — `amazon`, `aws-marketplace`, another account ID — select sets substrate
+does not model. Reading the parameter would let a caller believe a narrowing happened. A
+bundled public AMI is reachable by naming its ID, which is the case generated IaC
+actually produces; see [Which AMIs resolve](#which-amis-resolve).
+
+Both ID lists are read in every form AWS accepts — `VolumeId.1`, `VolumeId.2`, … and the
+un-indexed `VolumeId` — and an explicitly empty value is an ID the caller sent, so it is
+reported as `Malformed` rather than truncating the list.
 
 ### Finding a fleet's instances
 

--- a/emulator/ec2_describe_ids_test.go
+++ b/emulator/ec2_describe_ids_test.go
@@ -1,0 +1,243 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// ec2CreateVolume creates a volume and returns its ID.
+func ec2CreateVolume(t *testing.T, ts *httptest.Server, size string) string {
+	t.Helper()
+	var created struct {
+		VolumeID string `xml:"volumeId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "CreateVolume", "AvailabilityZone": "us-east-1a", "Size": size,
+	}, &created)
+	require.NotEmpty(t, created.VolumeID)
+	return created.VolumeID
+}
+
+// ec2RegisterImageID registers an AMI and returns its ID.
+func ec2RegisterImageID(t *testing.T, ts *httptest.Server, name string) string {
+	t.Helper()
+	var created struct {
+		ImageID string `xml:"imageId"`
+	}
+	ec2FleetXML(t, ts, map[string]string{
+		"Action": "RegisterImage", "Name": name, "RootDeviceName": "/dev/sda1",
+	}, &created)
+	require.NotEmpty(t, created.ImageID)
+	return created.ImageID
+}
+
+// ec2DescribedVolumeIDs returns the volume IDs a DescribeVolumes call answered with.
+func ec2DescribedVolumeIDs(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	var described struct {
+		Volumes []struct {
+			VolumeID string `xml:"volumeId"`
+		} `xml:"volumeSet>item"`
+	}
+	full := map[string]string{"Action": "DescribeVolumes"}
+	for k, v := range params {
+		full[k] = v
+	}
+	ec2FleetXML(t, ts, full, &described)
+	ids := make([]string, 0, len(described.Volumes))
+	for _, v := range described.Volumes {
+		ids = append(ids, v.VolumeID)
+	}
+	return ids
+}
+
+// ec2DescribedImageIDs returns the AMI IDs a DescribeImages call answered with.
+func ec2DescribedImageIDs(t *testing.T, ts *httptest.Server, params map[string]string) []string {
+	t.Helper()
+	var described struct {
+		Images []struct {
+			ImageID string `xml:"imageId"`
+		} `xml:"imagesSet>item"`
+	}
+	full := map[string]string{"Action": "DescribeImages"}
+	for k, v := range params {
+		full[k] = v
+	}
+	ec2FleetXML(t, ts, full, &described)
+	ids := make([]string, 0, len(described.Images))
+	for _, img := range described.Images {
+		ids = append(ids, img.ImageID)
+	}
+	return ids
+}
+
+// TestEC2_DescribeImages_NamedIDNarrowsTheAnswer covers the defect #731's survey turned up,
+// which is worse than the one it was filed for: DescribeImages read no ImageId.N at all, so
+// a caller naming one AMI was answered with every AMI the account owned.
+//
+// A superset is worse than an error. An error is visible; a superset looks like a successful
+// narrowing, so a consumer's "the query returns only my AMI" assertion passed with two AMIs
+// in the answer and one in the assertion's blind spot.
+func TestEC2_DescribeImages_NamedIDNarrowsTheAnswer(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	first := ec2RegisterImageID(t, ts, "first-ami")
+	second := ec2RegisterImageID(t, ts, "second-ami")
+	require.NotEqual(t, first, second)
+
+	assert.ElementsMatch(t, []string{first}, ec2DescribedImageIDs(t, ts, map[string]string{"ImageId.1": first}))
+	assert.ElementsMatch(t, []string{second}, ec2DescribedImageIDs(t, ts, map[string]string{"ImageId.1": second}))
+	assert.ElementsMatch(t, []string{first, second},
+		ec2DescribedImageIDs(t, ts, map[string]string{"ImageId.1": first, "ImageId.2": second}))
+
+	// With no ID named, both — which is the answer the ID list was silently giving before.
+	assert.ElementsMatch(t, []string{first, second}, ec2DescribedImageIDs(t, ts, nil))
+
+	// One present and one absent fails the whole call: EC2 does not return the partial set.
+	status, code := ec2ErrorCode(t, ts, map[string]string{
+		"Action": "DescribeImages", "ImageId.1": first, "ImageId.2": "ami-0000000000000dead",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidAMIID.NotFound", code)
+}
+
+// TestEC2_DescribeImages_BundledAMIIsNameableButNotEnumerated pins both halves of
+// substrate's reading of the bundled catalog (#733), now that this operation resolves an
+// explicit ID rather than ignoring it.
+//
+// Nameable, because a launch accepts a bundled AMI and a describe that called the same AMI
+// absent would contradict it — a consumer who resolves an AMI through SSM, describes it to
+// read its members, and launches it must get one consistent answer. Not enumerated, because
+// DescribeImages lists what an account owns and a public AWS-owned image is not that; real
+// AWS would answer an unqualified describe with tens of thousands of public images.
+func TestEC2_DescribeImages_BundledAMIIsNameableButNotEnumerated(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	own := ec2RegisterImageID(t, ts, "my-own-ami")
+
+	// Named explicitly, the bundled AMI is answered.
+	assert.ElementsMatch(t, []string{ec2TestImage},
+		ec2DescribedImageIDs(t, ts, map[string]string{"ImageId.1": ec2TestImage}))
+
+	// Named alongside the account's own AMI, both are answered.
+	assert.ElementsMatch(t, []string{own, ec2TestImage},
+		ec2DescribedImageIDs(t, ts, map[string]string{"ImageId.1": own, "ImageId.2": ec2TestImage}))
+
+	// Unqualified, only the account's own.
+	assert.ElementsMatch(t, []string{own}, ec2DescribedImageIDs(t, ts, nil))
+
+	// And the ID is Region-scoped, as on AWS: the same parameter's eu-west-1 image does not
+	// resolve against a us-east-1 request.
+	status, code := ec2ErrorCode(t, ts, map[string]string{
+		"Action":    "DescribeImages",
+		"ImageId.1": emulator.BundledImageID("eu-west-1", ec2BundledParameters[0]),
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidAMIID.NotFound", code)
+}
+
+// TestEC2_DescribeImages_IDPlusNonMatchingFilterIsEmpty guards the distinction the ID
+// assertion turns on: an AMI a *filter* excluded resolved, so the answer is an empty set,
+// not NotFound. Only absence is an error.
+func TestEC2_DescribeImages_IDPlusNonMatchingFilterIsEmpty(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	own := ec2RegisterImageID(t, ts, "filtered-ami")
+
+	assert.Empty(t, ec2DescribedImageIDs(t, ts, map[string]string{
+		"ImageId.1":        own,
+		"Filter.1.Name":    "image-id",
+		"Filter.1.Value.1": "ami-0000000000000dead",
+	}))
+
+	// The same holds for a bundled AMI reached through the catalog rather than state, so
+	// the two passes cannot disagree about what "resolved" means.
+	assert.Empty(t, ec2DescribedImageIDs(t, ts, map[string]string{
+		"ImageId.1":        ec2TestImage,
+		"Filter.1.Name":    "image-id",
+		"Filter.1.Value.1": "ami-0000000000000dead",
+	}))
+}
+
+// TestEC2_DescribeVolumes_ExplicitIDAssertsExistence is #731's own subject: naming a volume
+// ID asserts the volume exists, so an ID that resolves to nothing is refused rather than
+// narrowing the answer to an empty set.
+//
+// The empty set was the silent shape — a consumer's error branch was unreachable, and the
+// test that covered it passed while asserting the opposite of AWS's behavior.
+func TestEC2_DescribeVolumes_ExplicitIDAssertsExistence(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	first := ec2CreateVolume(t, ts, "8")
+	second := ec2CreateVolume(t, ts, "16")
+
+	assert.ElementsMatch(t, []string{first}, ec2DescribedVolumeIDs(t, ts, map[string]string{"VolumeId.1": first}))
+	assert.ElementsMatch(t, []string{first, second}, ec2DescribedVolumeIDs(t, ts, nil))
+
+	status, code := ec2ErrorCode(t, ts, map[string]string{
+		"Action": "DescribeVolumes", "VolumeId.1": first, "VolumeId.2": "vol-0000000000000dead",
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidVolume.NotFound", code)
+
+	// A filter that excludes a volume the ID named is still a resolution, so an empty set.
+	assert.Empty(t, ec2DescribedVolumeIDs(t, ts, map[string]string{
+		"VolumeId.1":       first,
+		"Filter.1.Name":    "size",
+		"Filter.1.Value.1": "99",
+	}))
+}
+
+// TestEC2_DescribeVolumes_ReadsEveryIDForm covers the two silent bugs in the hand-rolled ID
+// loop #731 replaced, neither of which was the one the issue was filed for.
+//
+// It read only the indexed form, so the un-indexed VolumeId that hand-built requests and
+// some older SDK shapes send was ignored — a request naming one volume was answered about
+// every volume. And it broke on the first empty *value* rather than the first missing *key*,
+// so an explicitly empty VolumeId.1 discarded VolumeId.2 and everything after it, again
+// widening the answer instead of failing.
+func TestEC2_DescribeVolumes_ReadsEveryIDForm(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+
+	first := ec2CreateVolume(t, ts, "8")
+	second := ec2CreateVolume(t, ts, "16")
+
+	t.Run("the un-indexed form narrows", func(t *testing.T) {
+		assert.ElementsMatch(t, []string{first}, ec2DescribedVolumeIDs(t, ts, map[string]string{"VolumeId": first}))
+	})
+
+	t.Run("the un-indexed form asserts existence too", func(t *testing.T) {
+		status, code := ec2ErrorCode(t, ts, map[string]string{
+			"Action": "DescribeVolumes", "VolumeId": "vol-0000000000000dead",
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidVolume.NotFound", code)
+	})
+
+	t.Run("an empty value does not truncate the list", func(t *testing.T) {
+		// The empty string is now a malformed volume ID — an ID the caller sent and
+		// substrate reports on. Truncating instead answered about every volume, which is
+		// the failure mode a caller cannot see.
+		status, code := ec2ErrorCode(t, ts, map[string]string{
+			"Action": "DescribeVolumes", "VolumeId.1": "", "VolumeId.2": second,
+		})
+		assert.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "InvalidVolumeID.Malformed", code)
+	})
+
+	t.Run("the same ID twice resolves once", func(t *testing.T) {
+		assert.ElementsMatch(t, []string{first},
+			ec2DescribedVolumeIDs(t, ts, map[string]string{"VolumeId.1": first, "VolumeId.2": first}))
+	})
+}

--- a/emulator/ec2_notfound_test.go
+++ b/emulator/ec2_notfound_test.go
@@ -104,6 +104,19 @@ func TestEC2_DescribeByExplicitID_NotFound(t *testing.T) {
 			params: map[string]string{"Action": "DescribeNatGateways", "NatGatewayId.1": "nat-0000000000000dead"},
 			code:   "InvalidNatGatewayID.NotFound",
 		},
+		{
+			name:   "volumes",
+			params: map[string]string{"Action": "DescribeVolumes", "VolumeId.1": "vol-0000000000000dead"},
+			code:   "InvalidVolume.NotFound",
+		},
+		{
+			// The AMI family's absence code names no ID at all, and the AMI that
+			// names nothing here is deliberately not a bundled one — a bundled ID
+			// resolves by name (#733), so using one would assert the opposite.
+			name:   "images",
+			params: map[string]string{"Action": "DescribeImages", "ImageId.1": "ami-0000000000000dead"},
+			code:   "InvalidAMIID.NotFound",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -189,6 +202,25 @@ func TestEC2_DescribeByExplicitID_Malformed(t *testing.T) {
 			params: map[string]string{"Action": "DescribeNatGateways", "NatGatewayId.1": "not-an-id"},
 			code:   "NatGatewayMalformed",
 		},
+		{
+			// AWS spells this one InvalidVolumeID.Malformed against
+			// InvalidVolume.NotFound, the same cross-naming security groups carry.
+			name:   "volume wrong prefix",
+			params: map[string]string{"Action": "DescribeVolumes", "VolumeId.1": "not-an-id"},
+			code:   "InvalidVolumeID.Malformed",
+		},
+		{
+			name:   "image wrong prefix",
+			params: map[string]string{"Action": "DescribeImages", "ImageId.1": "not-an-id"},
+			code:   "InvalidAMIID.Malformed",
+		},
+		{
+			// The placeholder shape generated IaC produces, which is malformed
+			// rather than absent because uppercase is not hex.
+			name:   "image non-hex suffix",
+			params: map[string]string{"Action": "DescribeImages", "ImageId.1": "ami-EXAMPLE"},
+			code:   "InvalidAMIID.Malformed",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -217,6 +249,49 @@ func TestEC2_MalformedBeatsNotFound(t *testing.T) {
 	assert.Equal(t, "InvalidVpcID.Malformed", code)
 }
 
+// TestEC2_IDListValidatesBeforeFilterNames pins the *other* ordering the ID filter
+// depends on, which nothing asserted before #731: the ID list is validated before the
+// filter spec, so a request carrying both a malformed ID and an unknown filter name
+// reports the ID.
+//
+// It matters because the two are separately reachable and a caller branches on the code.
+// DescribeVolumes checked its filter names first until #731 and would have answered
+// InvalidParameterValue here, contradicting the eleven other ID-asserting describes.
+func TestEC2_IDListValidatesBeforeFilterNames(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		params map[string]string
+		code   string
+	}{
+		{
+			name: "volumes",
+			params: map[string]string{
+				"Action": "DescribeVolumes", "VolumeId.1": "bogus",
+				"Filter.1.Name": "not-a-filter", "Filter.1.Value.1": "x",
+			},
+			code: "InvalidVolumeID.Malformed",
+		},
+		{
+			name: "images",
+			params: map[string]string{
+				"Action": "DescribeImages", "ImageId.1": "bogus",
+				"Filter.1.Name": "not-a-filter", "Filter.1.Value.1": "x",
+			},
+			code: "InvalidAMIID.Malformed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			status, code := ec2ErrorCode(t, ts, tt.params)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, tt.code, code)
+		})
+	}
+}
+
 // TestEC2_DescribeWithNoIDs_ReturnsEmpty guards the "absent vs. filtered"
 // distinction #391 turns on: with no explicit ID, an empty account legitimately
 // describes to 200 and an empty set. Only an explicit ID is an existence
@@ -227,6 +302,7 @@ func TestEC2_DescribeWithNoIDs_ReturnsEmpty(t *testing.T) {
 		"DescribeInstances", "DescribeInstanceStatus", "DescribeVpcs", "DescribeSubnets",
 		"DescribeSecurityGroups", "DescribeInternetGateways", "DescribeRouteTables",
 		"DescribeSnapshots", "DescribeAddresses", "DescribeNatGateways",
+		"DescribeVolumes", "DescribeImages",
 	} {
 		t.Run(action, func(t *testing.T) {
 			t.Parallel()
@@ -451,6 +527,15 @@ func TestEC2_SubstrateMintedIDsAreWellFormed(t *testing.T) {
 	natID := create(map[string]string{
 		"Action": "CreateNatGateway", "SubnetId": subnetID, "AllocationId": allocID,
 	}, "natGatewayId")
+	volumeID := create(map[string]string{
+		"Action": "CreateVolume", "AvailabilityZone": "us-east-1a", "Size": "8",
+	}, "volumeId")
+	// generateImageID mints 16 hex characters where AWS mints 8 or 17, which is exactly
+	// the shape a length-checking Malformed rule would reject. RegisterImage rather than a
+	// bundled ID, because the point is substrate's own generator.
+	imageID := create(map[string]string{
+		"Action": "RegisterImage", "Name": "minted-ami", "RootDeviceName": "/dev/sda1",
+	}, "imageId")
 
 	for _, tc := range []struct{ action, param, id string }{
 		{"DescribeVpcs", "VpcId.1", vpcID},
@@ -462,6 +547,8 @@ func TestEC2_SubstrateMintedIDsAreWellFormed(t *testing.T) {
 		{"DescribeInstanceStatus", "InstanceId.1", instanceID},
 		{"DescribeAddresses", "AllocationId.1", allocID},
 		{"DescribeNatGateways", "NatGatewayId.1", natID},
+		{"DescribeVolumes", "VolumeId.1", volumeID},
+		{"DescribeImages", "ImageId.1", imageID},
 	} {
 		t.Run(tc.action, func(t *testing.T) {
 			resp := ec2Request(t, ts, map[string]string{"Action": tc.action, tc.param: tc.id})

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -3756,10 +3756,12 @@ func extractEC2Filters(params map[string]string) map[string][]string {
 //   - The `KeyName.N`, `GroupName.N`, `FleetId.N`, `RegionName.N` and `InstanceType.N`
 //     parameter lists on DescribeKeyPairs, DescribePlacementGroups, DescribeFleets,
 //     DescribeRegions and DescribeInstanceTypes. These are *identifiers*, not filter values:
-//     AWS documents wildcards for `Filter.N.Value.N` only, and each of these parameters
-//     asserts the resource exists — an unmatched entry raises Invalid*.NotFound rather than
-//     narrowing a result set. Globbing them would let `i-*` stand in for an ID and quietly
-//     turn a NotFound contract into a match.
+//     AWS documents wildcards for `Filter.N.Value.N` only, so globbing them would let `i-*`
+//     stand in for an ID. Of the five, only `InstanceType.N` asserts the resource exists
+//     (`InvalidInstanceType`); the other four narrow the answer to nothing when an entry
+//     matches nothing, each for a reason recorded in docs/services.md's "Explicit resource
+//     IDs" section. This comment claimed all five asserted existence until #731; the claim
+//     was wrong, and it mattered because it read as an already-honored contract.
 //   - [ec2FilterSpec.documents]' name lookup. AWS's wildcards are for values; a filter *name*
 //     is one of a fixed documented set and "Filter names are case-sensitive" per the Filter
 //     type, so a name is either in the set or refused.
@@ -4161,16 +4163,36 @@ func (p *EC2Plugin) registerImage(reqCtx *RequestContext, req *AWSRequest) (*AWS
 	})
 }
 
-// describeImages lists AMIs owned by the account, with optional tag filters.
-// Supports Owners=["self"] and tag:<key>=<value> Filter entries.
+// describeImages lists the AMIs the account owns in the request's Region, narrowed by an
+// explicit ImageId.N list and by the filters [ec2ImageFilterSpec] evaluates.
+//
+// `Owner.N` and `ExecutableBy.N` are not read, deliberately and visibly: substrate stores
+// only images the account owns, so `self` is the answer to every describe and the other
+// three values AWS documents — `amazon`, `aws-marketplace`, another account ID — select
+// sets substrate does not model. Reading the parameter would let a caller believe a
+// narrowing happened. A bundled public AMI is reachable by naming it, which is the case
+// generated IaC actually produces.
 func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	allKeys, err := p.state.List(context.Background(), ec2Namespace, "image:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
-	if err != nil {
-		return nil, fmt.Errorf("ec2 describeImages list: %w", err)
+	// Before v0.108.0 this read no ImageId.N at all, so a caller naming one AMI was
+	// answered with every AMI the account owned — a superset, which is worse than an
+	// error because it looks like a successful narrowing (#731). AWS is explicit that
+	// naming an image that does not exist "will eventually return an error indicating
+	// that the AMI ID cannot be found".
+	//
+	// The ID list is validated before the filter spec, matching the eleven other
+	// ID-asserting describes.
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "ImageId"), ec2ImageIDKind)
+	if err := ids.validate(); err != nil {
+		return nil, err
 	}
 
 	if err := ec2ImageFilterSpec().check(req.Params); err != nil {
 		return nil, err
+	}
+
+	allKeys, err := p.state.List(context.Background(), ec2Namespace, "image:"+reqCtx.AccountID+"/"+reqCtx.Region+"/")
+	if err != nil {
+		return nil, fmt.Errorf("ec2 describeImages list: %w", err)
 	}
 
 	// Filters come from the shared extractor rather than a walk of this function's own
@@ -4222,23 +4244,13 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 	// cannot disagree about the same snapshot.
 	resolveSnapshot := p.ec2SnapshotResolver(reqCtx)
 
-	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
-	for _, k := range allKeys {
-		data, getErr := p.state.Get(context.Background(), ec2Namespace, k)
-		if getErr != nil || data == nil {
-			continue
-		}
-		var img EC2Image
-		if json.Unmarshal(data, &img) != nil {
-			continue
-		}
-
-		// Apply filters. Every named filter must match — AWS ANDs filters and ORs the
-		// values within one — so the map's iteration order does not affect the outcome.
-		if !ec2ImageMatchesFilters(img, filters) {
-			continue
-		}
-
+	// renderImage builds one response item. It is a closure rather than a method because
+	// imageItem and the types it holds are local to this function, and it is factored out
+	// because two passes render an image: the walk of the account's own AMIs below, and
+	// the bundled-catalog lookup for an ID that walk did not resolve. Rendering them
+	// through one function is what keeps a named bundled AMI reporting the same members as
+	// a registered one.
+	renderImage := func(img EC2Image) imageItem {
 		item := imageItem{
 			ImageID:      img.ImageID,
 			Name:         img.Name,
@@ -4294,7 +4306,56 @@ func (p *EC2Plugin) describeImages(reqCtx *RequestContext, req *AWSRequest) (*AW
 			}}
 		}
 		item.Tags = ec2TagItems(img.Tags)
-		resp.Images = append(resp.Images, item)
+		return item
+	}
+
+	resp := response{XMLNS: "http://ec2.amazonaws.com/doc/2016-11-15/"}
+	for _, k := range allKeys {
+		data, getErr := p.state.Get(context.Background(), ec2Namespace, k)
+		if getErr != nil || data == nil {
+			continue
+		}
+		var img EC2Image
+		if json.Unmarshal(data, &img) != nil {
+			continue
+		}
+
+		if !ids.match(img.ImageID) {
+			continue
+		}
+
+		// Apply filters. Every named filter must match — AWS ANDs filters and ORs the
+		// values within one — so the map's iteration order does not affect the outcome.
+		if !ec2ImageMatchesFilters(img, filters) {
+			continue
+		}
+		resp.Images = append(resp.Images, renderImage(img))
+	}
+
+	// An ID the account's own images did not answer may still name a bundled public AMI.
+	// Those are deliberately absent from state (#733), so they are reachable by name but
+	// are not part of an unqualified describe's answer — substrate's reading, and the one
+	// that keeps this operation reporting what the account owns while a launch and a
+	// describe still agree about the AMI a consumer resolved through SSM.
+	for _, id := range ids.pending() {
+		img, found := p.resolveImage(reqCtx, id)
+		if !found {
+			continue
+		}
+		// Records the resolution, so unresolved below does not report an AMI that exists.
+		// It cannot return false: the ID came from the request's own list.
+		_ = ids.match(id)
+		if !ec2ImageMatchesFilters(img, filters) {
+			continue
+		}
+		resp.Images = append(resp.Images, renderImage(img))
+	}
+
+	// After both passes, because an image a *filter* excluded still counts as resolved:
+	// EC2 answers an existing ID plus a non-matching filter with an empty set, not
+	// NotFound.
+	if err := ids.unresolved(); err != nil {
+		return nil, err
 	}
 	return ec2XMLResponse(http.StatusOK, resp)
 }
@@ -6257,18 +6318,26 @@ func (p *EC2Plugin) createVolume(reqCtx *RequestContext, req *AWSRequest) (*AWSR
 }
 
 func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*AWSResponse, error) {
-	if err := ec2VolumeFilterSpec().check(req.Params); err != nil {
+	// The ID list is validated before the filter spec, which is the order the other
+	// eleven ID-asserting describes use and the order EC2 reports in: a request naming
+	// both a malformed volume ID and an unknown filter name answers
+	// InvalidVolumeID.Malformed. TestEC2_MalformedBeatsNotFound pins it.
+	//
+	// The hand-rolled loop this replaces (#731) did three things wrong, all of them
+	// silent. It never refused: an ID naming no volume narrowed the answer to nothing
+	// instead of raising InvalidVolume.NotFound, so a consumer's error branch was
+	// unreachable and a test asserting it passed while verifying the opposite. It broke
+	// on the first empty *value* rather than the first missing *key*, so an explicitly
+	// empty VolumeId.1 discarded VolumeId.2 and everything after it. And it read only
+	// the indexed form, so the un-indexed VolumeId some hand-built requests send was
+	// ignored entirely — a request naming one volume was answered about every volume.
+	ids := newEC2IDFilter(extractIndexedParams(req.Params, "VolumeId"), ec2VolumeIDKind)
+	if err := ids.validate(); err != nil {
 		return nil, err
 	}
 
-	// Collect requested volume IDs from repeated VolumeId.N params.
-	requestedIDs := map[string]bool{}
-	for i := 1; ; i++ {
-		id := req.Params[fmt.Sprintf("VolumeId.%d", i)]
-		if id == "" {
-			break
-		}
-		requestedIDs[id] = true
+	if err := ec2VolumeFilterSpec().check(req.Params); err != nil {
+		return nil, err
 	}
 
 	// Filters come from the shared [extractEC2Filters] walk rather than a hand-rolled
@@ -6328,8 +6397,7 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 		if err := json.Unmarshal(data, &vol); err != nil {
 			continue
 		}
-		// Filter by requested IDs.
-		if len(requestedIDs) > 0 && !requestedIDs[vol.VolumeID] {
+		if !ids.match(vol.VolumeID) {
 			continue
 		}
 		if !ec2VolumeMatchesFilters(vol, filters) {
@@ -6359,6 +6427,14 @@ func (p *EC2Plugin) describeVolumes(reqCtx *RequestContext, req *AWSRequest) (*A
 			})
 		}
 		volumes = append(volumes, item)
+	}
+
+	// After the loop, because a volume a *filter* excluded still counts as resolved —
+	// EC2 answers an existing ID plus a non-matching filter with an empty set, not
+	// NotFound. [ec2IDFilter.match] records the resolution before the filter runs, which
+	// is what makes that distinction hold here.
+	if err := ids.unresolved(); err != nil {
+		return nil, err
 	}
 
 	type volumeSet struct {

--- a/emulator/ec2_plugin_test.go
+++ b/emulator/ec2_plugin_test.go
@@ -2904,14 +2904,24 @@ func TestEC2_EBS_CreateDescribeDeleteVolume(t *testing.T) {
 	})
 	assert.Equal(t, http.StatusOK, resp3.StatusCode)
 
-	// DescribeVolumes should now return empty.
-	resp4 := ec2Request(t, ts, map[string]string{
+	// Describing the deleted volume by ID is now a refusal, not an empty set (#731):
+	// naming an ID explicitly asserts it exists, and a caller who deleted a volume and
+	// then described it should be told it is gone rather than handed a 200 that reads
+	// identically to "the filter excluded it".
+	status, code := ec2ErrorCode(t, ts, map[string]string{
 		"Action":     "DescribeVolumes",
 		"VolumeId.1": volID,
 	})
-	assert.Equal(t, http.StatusOK, resp4.StatusCode)
-	body4, _ := io.ReadAll(resp4.Body)
-	assert.NotContains(t, string(body4), volID)
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidVolume.NotFound", code)
+
+	// With no ID named there is no assertion to fail, so the account describes to an
+	// empty set — the "absent vs. filtered" distinction the ID list turns on.
+	resp5 := ec2Request(t, ts, map[string]string{"Action": "DescribeVolumes"})
+	defer resp5.Body.Close() //nolint:errcheck
+	assert.Equal(t, http.StatusOK, resp5.StatusCode)
+	body5, _ := io.ReadAll(resp5.Body)
+	assert.NotContains(t, string(body5), volID)
 }
 
 func TestEC2_EBS_AttachDetachVolume(t *testing.T) {

--- a/emulator/ec2_resourceid.go
+++ b/emulator/ec2_resourceid.go
@@ -233,6 +233,27 @@ func (f *ec2IDFilter) unresolved() error {
 	return nil
 }
 
+// pending returns the requested IDs that match has not seen yet, in request order.
+//
+// It exists for a describe whose resources do not all live in the store it walks:
+// DescribeImages walks the account's own AMIs, and a bundled public AMI is deliberately
+// not among them (#733), so a caller naming one would reach [ec2IDFilter.unresolved] and
+// be told it does not exist. Resolving what is still pending after the walk, and calling
+// match on each one that resolves, keeps "named explicitly" working without making the
+// bundled catalog part of an unqualified describe's answer.
+//
+// It returns nothing when no IDs were requested, so a caller cannot mistake "describe
+// everything" for "everything is missing".
+func (f *ec2IDFilter) pending() []string {
+	var out []string
+	for _, id := range f.order {
+		if !f.want[id] {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
 // requireResource returns the kind's Malformed error for a syntactically invalid id, its
 // NotFound error for a well-formed id that named nothing, or nil. found reports whether
 // the lookup succeeded.

--- a/emulator/ec2_snapshot_ops_test.go
+++ b/emulator/ec2_snapshot_ops_test.go
@@ -400,22 +400,18 @@ func TestEC2_CopySnapshot_CopiesWithinTheRegion(t *testing.T) {
 		"the copy's volumeId is arbitrary, not the source's")
 	assert.NotEmpty(t, described[0].VolumeID, "AWS always renders the member")
 
-	// And it names no volume, which is what makes AWS's warning self-enforcing.
-	//
-	// The assertion is an empty volumeSet rather than InvalidVolume.NotFound because
-	// substrate's DescribeVolumes selects by ID without resolving one — an unknown VolumeId.N
-	// narrows the answer to nothing instead of being refused. That is a separate gap from
-	// #709 and is left standing rather than widened into this PR; it is recorded so a future
-	// reader does not mistake the weaker assertion for the stronger claim.
-	var volumes struct {
-		Volumes []struct {
-			VolumeID string `xml:"volumeId"`
-		} `xml:"volumeSet>item"`
-	}
-	ec2FleetXML(t, ts, map[string]string{
+	// And it names no volume, which is what makes AWS's warning self-enforcing. The
+	// assertion is InvalidVolume.NotFound as of #731: DescribeVolumes resolves an explicit
+	// VolumeId.N rather than merely selecting on it, so the arbitrary ID is refused rather
+	// than narrowing the answer to nothing. That is the stronger claim, and the one a
+	// caller who tried to use the ID would actually see. The comment here previously
+	// recorded the weaker assertion as a gap left standing; this is that gap closed.
+	status, code := ec2ErrorCode(t, ts, map[string]string{
 		"Action": "DescribeVolumes", "VolumeId.1": described[0].VolumeID,
-	}, &volumes)
-	assert.Empty(t, volumes.Volumes, "the copy's arbitrary volume ID resolves to nothing")
+	})
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "InvalidVolume.NotFound", code,
+		"the copy's arbitrary volume ID resolves to nothing")
 }
 
 // TestEC2_CopySnapshot_EncryptionFollowsTheDocumentedRules covers the three sentences AWS


### PR DESCRIPTION
Closes #731.

`DescribeVolumes` and `DescribeImages` answered 200 and an empty set for an ID that
resolved to nothing. Both now route their ID lists through `ec2IDFilter`, the helper the
other ten ID-asserting describes already share, so they answer
`InvalidVolume.NotFound`/`InvalidVolumeID.Malformed` and
`InvalidAMIID.NotFound`/`InvalidAMIID.Malformed` from the one kind table — syntax before
absence, one present plus one absent failing the whole call, and an ID a `Filter` excluded
still counting as resolved. Twelve EC2 describes now assert existence.

## What the survey found beyond the issue

- **`DescribeImages` read no `ImageId.N` at all** — a caller naming one AMI was answered
  with every AMI the account owned. This is the worse half: an error is visible, a superset
  reads as a successful narrowing, so "the query returns only my AMI" passed with the other
  AMI in the assertion's blind spot.
- **`DescribeVolumes`' hand-rolled loop had two more silent widenings.** It read only the
  indexed `VolumeId.N`, ignoring the un-indexed `VolumeId` a hand-built request or an older
  SDK shape sends; and it stopped at the first empty *value* rather than the first missing
  *key*, so an explicitly empty `VolumeId.1` discarded `VolumeId.2` and everything after
  it. `extractIndexedParams` fixes both, and an empty value is now `Malformed` — it is an
  ID the caller sent.
- **`validate()` moved ahead of the filter-name check** on `DescribeVolumes`, where it ran
  second, matching all ten existing handlers. `TestEC2_IDListValidatesBeforeFilterNames`
  pins the ordering, which nothing did.

The `DescribeImages` half inherits `ec2ImageIDKind` from #733 (PR #741) rather than adding
a kind — same table, same wording, same ordering as the volume half.

## Two decisions recorded rather than implemented

**A bundled public AMI is nameable here, though still not enumerated.** A describe that
called an AMI absent while a launch accepted it would contradict itself, and resolving an
AMI through SSM and then reading its members is the workflow generated IaC produces. So a
named bundled ID resolves through a second pass over `resolveImage` and renders the same
members a registered AMI does, while an unqualified `DescribeImages` still lists only what
the account owns.

**`Owner.N` and `ExecutableBy.N` stay unread**, now stated in the docs with the reason:
substrate stores only images the account owns, so `self` is the answer to every describe
and AWS's other three `Owner` values select sets substrate does not model. Reading the
parameter would let a caller believe a narrowing happened.

## Corrections in passing

`containsStr`'s doc comment claimed `KeyName.N`, `GroupName.N`, `FleetId.N` and
`RegionName.N` each raise an `Invalid*.NotFound` on an unmatched entry; only
`InstanceType.N` does. `docs/services.md` counted "six of the new selectors" answering an
empty set where AWS answers `NotFound` and named four families; there are seven, and the
new **Which selectors assert existence** subsection gives each its reason — separating
`DescribeFleets`' `FleetId.N` and `DescribeRegions`' `RegionName.N`, which are permanent
declines, from the five that are merely unimplemented.

## Compatibility

A describe naming a volume or an AMI that does not exist now fails where it returned an
empty set. Two of substrate's own tests asserted the empty set as the contract — one with a
comment naming this exact gap — and both now assert the refusal.

## Verification

`gofmt`/`go build`/`go vet`/`golangci-lint` clean; `make test` (race) green; emulator
coverage 83.3%, total 82.6%; `make docs-reference-check docs-versions` clean; VitePress
build clean with no dangling anchors; `go vet`/`go test` clean in `test/e2e`.

Thirteen live `aws` CLI checks against a built binary on `:4678`, including the issue's own
command:

```
$ aws ec2 describe-volumes --volume-ids vol-0aaaaaaaaaaaaaaaa
InvalidVolume.NotFound: The volume ID 'vol-0aaaaaaaaaaaaaaaa' does not exist
$ aws ec2 describe-volumes --volume-ids vol-0000000000000dead nope
InvalidVolumeID.Malformed: Invalid id: "nope"
$ aws ec2 describe-images --image-ids ami-EXAMPLE
InvalidAMIID.Malformed: Invalid id: "ami-EXAMPLE"
```

and the round trip the two halves have to agree on: `ssm get-parameter` resolves
`ami-d4c4e839d3f47ba84`, `describe-images --image-ids` answers with it, an unqualified
`describe-images` does not list it, and `run-instances` launches it.
