### PR TITLE
fix(ec2): a block device mapping can only name a completed snapshot (#732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returned an empty set. Two of substrate's own tests asserted the empty set as the contract —
   one of them with a comment naming this gap — and both now assert the refusal.
 
+- **A block device mapping naming a snapshot that is not usable yet is refused** (#732).
+  `CreateVolume` refused such a snapshot from #715 onward, but a launch declaring the *same*
+  snapshot in a `BlockDeviceMapping` materialized a volume from it and reported success. So one
+  rule had two doors that disagreed: `create-volume --snapshot-id` failed while `run-instances
+  --block-device-mappings` naming the same snapshot succeeded, and a consumer restoring through
+  a launch — which is what CDK's and Terraform's snapshot-backed volumes do — never reached the
+  error branch it had written. `RegisterImage`, whose own second AWS example registers an AMI
+  from a root-device snapshot, had the same hole.
+
+  Both now answer `IncorrectState` / 400, naming the snapshot and the state it is in so a caller
+  can decide to wait, from the single validator the launch path and `RegisterImage` already
+  share. Everything except `completed` is refused: AWS's snapshot-states table says a `pending`
+  or `error` snapshot "can't be used", a `recoverable` one "must first [be recovered] from the
+  Recycle Bin", and a `recovering` one is "ready for use" only once it reaches `completed`.
+
+  The state is read through the peeking accessor, never the observing one, and a test pins that
+  by asserting a seeded one-observation budget survives two three-mapping launch attempts. It
+  has to: the countdown advances in exactly one place, so an observing read would spend one
+  observation *per mapping per request* and `pendingObservations: 2` would mean a different
+  number of polls depending on how many volumes a launch declared — while a consumer's wait
+  loop, which alternates a launch attempt and a describe, raced its own budget.
+
+  `CreateLaunchTemplate` and `CreateLaunchTemplateVersion` are exempt, deliberately: a template
+  records a mapping rather than consuming one, both report mapping problems through AWS's
+  `warning` member and refuse nothing (#693), and a snapshot `pending` when a template is
+  written may legitimately be `completed` when the template is used — refusing at write time
+  would forbid an ordering AWS permits. A launch *from* such a template is refused, so the rule
+  is not escapable by routing a mapping through one.
+
+  **Provenance.** Substrate's reading. `RegisterImage`'s Errors section is empty and its page
+  says nothing about a snapshot's required state; the rule is AWS's snapshot-states rule and
+  `IncorrectState` is substrate's choice from EC2's client-error table, the same shape
+  `CreateVolume` carries. `DeleteSnapshot` is **not** analogous and still refuses nothing — AWS
+  permits deleting a snapshot that is still in progress. The issue's premise that #715 had
+  already settled `DeleteSnapshot` is inverted; #715 records the opposite.
+
+  **Compatibility.** A launch or a `RegisterImage` whose mapping names a snapshot under a seeded
+  progression now fails until that snapshot reports `completed`. Only a seeded snapshot is
+  affected: every snapshot substrate writes is born `completed`, so an unseeded mapping behaves
+  as before.
+
 ### Fixed
 - **One server serves one account** (#734). `ParseAWSRequest` decided the account from the
   *shape of the access key*: a key beginning with `AKIA` was attributed to `123456789012`,

--- a/docs/services.md
+++ b/docs/services.md
@@ -5643,13 +5643,33 @@ below it for a failure: AWS's one observable data point says so, its
 `"State": "recovering"`. So progress measures how far the progression ran, not whether it
 succeeded.
 
-Two operations read the state without consuming an observation, since neither is a poll:
+Several operations read the state without consuming an observation, since none of them is a
+poll:
 
 - **`CreateVolume`** refuses a snapshot that is not `completed` with `IncorrectState`. The rule
   is AWS's — its snapshot-states table says "a snapshot can't be used while it is in the
   `pending` state" and "a snapshot can't be used if it is in the `error` state" — though
   `CreateVolume`'s own page publishes no error for it, so the code is substrate's choice from
   EC2's client-error table, the one it already answers with for a volume in the wrong state.
+- **A block device mapping** naming such a snapshot is refused the same way, with the same code,
+  wherever the mapping is *consumed*: on the launch path (`RunInstances`, and `CreateFleet`
+  through it) and in `RegisterImage`. One rule, one place, two doors — because a launch that
+  restores a volume from a snapshot is doing what `CreateVolume` does, and the two disagreeing
+  meant a consumer restoring through a launch never reached its own error branch
+  ([#732](https://github.com/scttfrdmn/substrate/issues/732)). AWS's snapshot-states table covers
+  all four non-`completed` states: a `recoverable` snapshot "must first [be recovered] from the
+  Recycle Bin", and a `recovering` one is "ready for use" only once it reaches `completed`. So
+  the rule is `completed`-or-refused, not pending-and-error-only. `RegisterImage` publishes no
+  error for it either — its Errors section is empty — so again the code is substrate's choice.
+  This is the one of these reads a single request can make more than once, one mapping each, so
+  spending an observation on it would make `pendingObservations: 2` mean something different
+  depending on how many volumes a launch declared.
+- **The two `CreateLaunchTemplate` operations are exempt, deliberately.** A template *records* a
+  mapping rather than consuming one, both report mapping problems through AWS's documented
+  `warning` member and refuse nothing, and a snapshot that is `pending` when a template is
+  written may legitimately be `completed` by the time the template is used — so refusing at
+  write time would forbid an ordering AWS permits. A launch *from* such a template is refused,
+  which is where the mapping is used.
 - **`DeleteSnapshot`** does *not* refuse one, because AWS permits it in so many words:
   "although you can delete a snapshot that is still in progress, the snapshot must complete
   before the deletion takes effect." The deferred-effect half is not modelled — AWS publishes

--- a/emulator/ec2_block_devices.go
+++ b/emulator/ec2_block_devices.go
@@ -166,17 +166,35 @@ var ec2VolumeTypesWithoutIOPS = map[string]bool{"standard": true, "st1": true, "
 //
 // # The snapshot rules
 //
-// Two of them, both added by #689 once a snapshot had a real size to compare against:
-// a SnapshotId that is malformed or names nothing is refused, and a VolumeSize smaller
-// than the named snapshot's is refused. v0.105.0 deferred the second for the reason
-// #689 removes — EC2Snapshot.VolumeSize was the literal 8 at its single producer, so
-// the comparison would have tested a constant rather than the caller's request.
+// Three of them. Two were added by #689 once a snapshot had a real size to compare
+// against: a SnapshotId that is malformed or names nothing is refused, and a VolumeSize
+// smaller than the named snapshot's is refused. v0.105.0 deferred the second for the
+// reason #689 removes — EC2Snapshot.VolumeSize was the literal 8 at its single producer,
+// so the comparison would have tested a constant rather than the caller's request. The
+// third, added by #732, refuses a snapshot that is not `completed`, which is the same
+// refusal CreateVolume already makes from the same rule.
 //
-// resolveSnapshot is how both reach state: a lookup rather than a [StateManager], so
-// this stays a pure function over its arguments and a unit test can supply three
-// snapshots without a state fixture. It is required, not optional — a nil-means-skip
-// escape would silently disable a refusal, which is the failure mode #689 exists to
-// close. [EC2Plugin.ec2SnapshotResolver] builds the production one.
+// resolveSnapshot is how the first two reach state: a lookup rather than a
+// [StateManager], so this stays a pure function over its arguments and a unit test can
+// supply three snapshots without a state fixture. It is required, not optional — a
+// nil-means-skip escape would silently disable a refusal, which is the failure mode #689
+// exists to close. [EC2Plugin.ec2SnapshotResolver] builds the production one.
+//
+// observeSnapshot is how the third reaches it, and it is separate because the state a
+// snapshot *reports* is not the state its record carries: EC2Snapshot.State is
+// "completed" for every snapshot substrate writes, so a rule reading the record would be
+// dead code, and the observable state lives behind a seed. It must be
+// [EC2Plugin.peekSnapshotStatus] and never [EC2Plugin.observeSnapshotStatus] — the
+// countdown advances in one place, so an observing read here would burn one observation
+// *per mapping per request* and make "pendingObservations: 2" mean a different number of
+// polls depending on how many volumes a launch declared.
+//
+// Unlike resolveSnapshot, a nil observeSnapshot skips the state rule, and the two
+// CreateLaunchTemplate paths pass nil deliberately: a template is not a launch, they
+// report mapping problems through `warning` rather than refusing at all, and a snapshot
+// that is pending when a template is written may legitimately be complete when the
+// template is used. The rule still lives in one place — here — so the launch path and
+// RegisterImage cannot drift apart on it.
 //
 // # Provenance
 //
@@ -184,7 +202,9 @@ var ec2VolumeTypesWithoutIOPS = map[string]bool{"standard": true, "st1": true, "
 // EbsBlockDevice.VolumeSize, "You can specify a volume size that is equal to or larger
 // than the snapshot size" on the same member, InvalidSnapshot.NotFound in the
 // client-error table, and "This parameter is valid only for gp3 volumes" on
-// Throughput. The Iops rule rests on the sibling launch-template shape; see
+// Throughput. The snapshot-state rule is AWS's too, from the snapshot-states table
+// rather than from either operation's page; only its code is substrate's, as
+// [ec2CheckMappingSnapshot] records. The Iops rule rests on the sibling launch-template shape; see
 // [ec2VolumeTypesWithoutIOPS]. Refusing a duplicate device name and a virtualName
 // beside an Ebs member rests on **substrate's own reading** — AWS documents no rule for
 // either, and neither is a thing real EC2 can act on, since one device cannot carry two
@@ -212,8 +232,9 @@ var ec2VolumeTypesWithoutIOPS = map[string]bool{"standard": true, "st1": true, "
 func ec2CheckBlockDeviceMappings(
 	mappings []EC2BlockDeviceMapping,
 	resolveSnapshot func(string) (EC2Snapshot, bool),
+	observeSnapshot func(EC2Snapshot) (ec2SnapshotObservation, error),
 ) *AWSError {
-	if problems := ec2CollectBlockDeviceMappings(mappings, resolveSnapshot); len(problems) > 0 {
+	if problems := ec2CollectBlockDeviceMappings(mappings, resolveSnapshot, observeSnapshot); len(problems) > 0 {
 		return problems[0]
 	}
 	return nil
@@ -237,11 +258,12 @@ func ec2CheckBlockDeviceMappings(
 func ec2CollectBlockDeviceMappings(
 	mappings []EC2BlockDeviceMapping,
 	resolveSnapshot func(string) (EC2Snapshot, bool),
+	observeSnapshot func(EC2Snapshot) (ec2SnapshotObservation, error),
 ) []*AWSError {
 	var problems []*AWSError
 	seen := make(map[string]bool, len(mappings))
 	for _, bdm := range mappings {
-		problems = append(problems, ec2CollectBlockDeviceMapping(bdm, resolveSnapshot)...)
+		problems = append(problems, ec2CollectBlockDeviceMapping(bdm, resolveSnapshot, observeSnapshot)...)
 		// Only a mapping that materializes a volume can collide: NoDevice suppresses
 		// its device and a virtualName-only mapping names an instance store device, so
 		// neither occupies the device in a way a second mapping could contend for.
@@ -277,6 +299,7 @@ func ec2CollectBlockDeviceMappings(
 func ec2CollectBlockDeviceMapping(
 	bdm EC2BlockDeviceMapping,
 	resolveSnapshot func(string) (EC2Snapshot, bool),
+	observeSnapshot func(EC2Snapshot) (ec2SnapshotObservation, error),
 ) []*AWSError {
 	var problems []*AWSError
 	device := bdm.DeviceName
@@ -317,7 +340,7 @@ func ec2CollectBlockDeviceMapping(
 	}
 
 	if bdm.SnapshotID != "" {
-		if awsErr := ec2CheckMappingSnapshot(bdm, resolveSnapshot); awsErr != nil {
+		if awsErr := ec2CheckMappingSnapshot(bdm, resolveSnapshot, observeSnapshot); awsErr != nil {
 			problems = append(problems, awsErr)
 		}
 	}
@@ -339,23 +362,49 @@ func ec2CollectBlockDeviceMapping(
 	return problems
 }
 
-// ec2CheckMappingSnapshot applies the two rules that concern the snapshot a mapping
+// ec2CheckMappingSnapshot applies the three rules that concern the snapshot a mapping
 // names. The caller has already established that it names one.
 //
-// The two refusals carry different codes on purpose, because they are different
-// mistakes: a snapshot substrate cannot find is an InvalidSnapshot.NotFound (or
+// The refusals carry different codes on purpose, because they are different mistakes: a
+// snapshot substrate cannot find is an InvalidSnapshot.NotFound (or
 // InvalidSnapshotID.Malformed) about the *ID*, which is what a caller naming a snapshot
 // from another account or a stale run has done, while a size below the snapshot's is an
 // InvalidBlockDeviceMapping about the *mapping*, which is what the rest of this
 // validator reports. Collapsing them into one code would tell a caller to look in the
-// wrong place.
+// wrong place. The state rule is a third thing again — nothing about the request is wrong,
+// the snapshot is simply not usable yet — so it answers IncorrectState, the code
+// CreateVolume already gives for the same condition.
+//
+// # Order
+//
+// Existence, then state, then size, each refusal being more fundamental than the next: a
+// caller told "size 8 is smaller than the snapshot" would fix the size and be refused
+// again for the state. This is CreateVolume's order too, deliberately.
 //
 // The size comparison reads the parsed VolumeSize and gates on it being positive, so a
 // mapping that names no size inherits the snapshot's rather than being refused for
 // naming 0 — see [ec2ResolveSnapshotSizes], which does the inheriting.
+//
+// # Provenance of the state rule
+//
+// AWS's snapshot-states table is the rule: "A snapshot can't be used while it is in the
+// pending state", "A snapshot can't be used if it is in the error state", a recoverable
+// one "must first [be recovered] from the Recycle Bin", and a recovering one becomes
+// "ready for use" only once it reaches completed. So every state but completed is refused,
+// and the four reasons are AWS's own. Neither operation's page states it —
+// API_RegisterImage.html's Errors section is empty and API_RunInstances.html publishes no
+// snapshot error — so IncorrectState is substrate's choice from EC2's client-error table,
+// the same provenance shape CreateVolume's copy of this rule carries (#715, #732).
+//
+// An unreadable seed answers InternalError/500 rather than being read as completed. This
+// is the opposite of [EC2Plugin.ec2SnapshotResolver]'s rule for an unreadable *record*,
+// and for the reason that one gives: reporting "absent" for an unreadable record is the
+// same answer a caller gets for one never written, whereas reading an unreadable seed as
+// "completed" would silently disable a refusal.
 func ec2CheckMappingSnapshot(
 	bdm EC2BlockDeviceMapping,
 	resolveSnapshot func(string) (EC2Snapshot, bool),
+	observeSnapshot func(EC2Snapshot) (ec2SnapshotObservation, error),
 ) *AWSError {
 	if !ec2SnapshotIDKind.wellFormed(bdm.SnapshotID) {
 		return ec2SnapshotIDKind.malformedError(bdm.SnapshotID)
@@ -363,6 +412,25 @@ func ec2CheckMappingSnapshot(
 	snap, found := resolveSnapshot(bdm.SnapshotID)
 	if !found {
 		return ec2SnapshotIDKind.notFoundError(bdm.SnapshotID)
+	}
+	if observeSnapshot != nil {
+		observed, err := observeSnapshot(snap)
+		if err != nil {
+			return &AWSError{
+				Code:       "InternalError",
+				Message:    "Failed to read the state of snapshot " + snap.SnapshotID,
+				HTTPStatus: http.StatusInternalServerError,
+			}
+		}
+		if observed.State != "completed" {
+			return &AWSError{
+				Code: "IncorrectState",
+				Message: fmt.Sprintf(
+					"Snapshot %s is in %s state; a block device mapping can only name a completed snapshot",
+					snap.SnapshotID, observed.State),
+				HTTPStatus: http.StatusBadRequest,
+			}
+		}
 	}
 	if bdm.VolumeSize > 0 && int64(bdm.VolumeSize) < snap.VolumeSize {
 		return ec2InvalidBlockDeviceMapping(bdm.DeviceName, fmt.Sprintf(

--- a/emulator/ec2_launchtemplate_versions.go
+++ b/emulator/ec2_launchtemplate_versions.go
@@ -451,8 +451,10 @@ func (p *EC2Plugin) createLaunchTemplateVersion(ctx *RequestContext, req *AWSReq
 		Version: ec2LTVersionItemFor(lt, newVersion),
 		// Collected after the overlay, for the reason the tag check runs there: a
 		// version inheriting a mapping from its source version is warned about it too.
+		// The nil observer skips the snapshot-state rule for the reason
+		// CreateLaunchTemplate's does; see [ec2CheckMappingSnapshot].
 		Warning: ec2ValidationWarningFor(
-			ec2CollectBlockDeviceMappings(data.BlockDeviceMappings, p.ec2SnapshotResolver(ctx))),
+			ec2CollectBlockDeviceMappings(data.BlockDeviceMappings, p.ec2SnapshotResolver(ctx), nil)),
 	})
 }
 

--- a/emulator/ec2_mapping_snapshot_state_test.go
+++ b/emulator/ec2_mapping_snapshot_state_test.go
@@ -1,0 +1,244 @@
+package emulator_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #732: a block device mapping naming a snapshot that is not usable yet is refused, on the
+// two paths that consume a mapping rather than record one.
+//
+// CreateVolume already refused such a snapshot (#715) while a launch declaring the same
+// snapshot as a mapping materialized a volume from it, so the two doors onto one rule
+// disagreed: `aws ec2 create-volume --snapshot-id` failed and
+// `aws ec2 run-instances --block-device-mappings` naming the same snapshot succeeded. A
+// consumer restoring through a launch — which is what CDK's and Terraform's snapshot-backed
+// volumes do — never reached its own error branch.
+
+// ec2SnapshotMappingLaunch is a launch declaring one mapping restored from a snapshot.
+func ec2SnapshotMappingLaunch(snapshotID string) map[string]string {
+	return map[string]string{
+		"Action": "RunInstances", "ImageId": ec2TestImage, "MinCount": "1", "MaxCount": "1",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": snapshotID,
+	}
+}
+
+// ec2SnapshotMappingRegisterImage registers an AMI whose root device restores from a snapshot,
+// which is AWS's own second RegisterImage example.
+func ec2SnapshotMappingRegisterImage(name, snapshotID string) map[string]string {
+	return map[string]string{
+		"Action": "RegisterImage", "Name": name, "RootDeviceName": "/dev/sda1",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sda1",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": snapshotID,
+	}
+}
+
+// ec2PendingSnapshot creates a snapshot and seeds it so every observation reports state.
+//
+// The order matters: the snapshot is created *before* the seed, so the create itself is not
+// the thing under test — a snapshot born under a seed is born in the seeded state, which
+// TestEC2_SnapshotProgression_PollsToCompleted covers.
+func ec2PendingSnapshot(t *testing.T, ts *httptest.Server, state string) string {
+	t.Helper()
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+	switch state {
+	case "pending":
+		ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":9}`)
+	default:
+		ec2SeedSnapshotStatus(t, ts,
+			`{"snapshotId":"*","pendingObservations":0,"finalState":"`+state+`"}`)
+	}
+	return snapshotID
+}
+
+// TestEC2_MappingSnapshot_LaunchRefusesAnUnusableSnapshot covers AWS's snapshot-states rule on
+// the launch path, for all four states that are not `completed`.
+//
+// Every one of the four has AWS's own sentence behind it: pending and error say "a snapshot
+// can't be used" outright, a recoverable snapshot "must first [be recovered] from the Recycle
+// Bin", and a recovering one becomes "ready for use" only once it reaches completed. So the
+// rule is "completed or refused", not "pending or error are refused".
+func TestEC2_MappingSnapshot_LaunchRefusesAnUnusableSnapshot(t *testing.T) {
+	t.Parallel()
+
+	for _, state := range []string{"pending", "error", "recoverable", "recovering"} {
+		t.Run(state, func(t *testing.T) {
+			t.Parallel()
+			ts := newEC2TestServer(t)
+			volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+			snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+			launch := ec2SnapshotMappingLaunch(snapshotID)
+
+			// Unseeded the launch succeeds, which is what makes the refusal below a
+			// consequence of the state and not of anything else in the request.
+			require.Len(t, runInstancesLaunched(t, ts, launch), 1)
+
+			if state == "pending" {
+				ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":9}`)
+			} else {
+				ec2SeedSnapshotStatus(t, ts,
+					`{"snapshotId":"*","pendingObservations":0,"finalState":"`+state+`"}`)
+			}
+
+			status, code, message := ec2ErrorDetail(t, ts, launch)
+			assert.Equal(t, http.StatusBadRequest, status)
+			assert.Equal(t, "IncorrectState", code,
+				"the same code CreateVolume answers with for the same condition")
+			assert.Contains(t, message, state, "the caller is told which state, so it can decide to wait")
+			assert.Contains(t, message, snapshotID)
+		})
+	}
+}
+
+// TestEC2_MappingSnapshot_RegisterImageRefusesAnUnusableSnapshot covers the second door onto
+// the rule. Registering an AMI from a snapshot of a root device volume is what AWS's own
+// second RegisterImage example does, and an AMI recorded against a snapshot that never
+// completed is one every later launch fails on.
+func TestEC2_MappingSnapshot_RegisterImageRefusesAnUnusableSnapshot(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	snapshotID := ec2PendingSnapshot(t, ts, "pending")
+
+	status, code, message := ec2ErrorDetail(t, ts,
+		ec2SnapshotMappingRegisterImage("from-pending", snapshotID))
+	assert.Equal(t, http.StatusBadRequest, status)
+	assert.Equal(t, "IncorrectState", code)
+	assert.Contains(t, message, "pending")
+	assert.Contains(t, message, snapshotID)
+
+	// Nothing was registered: the check runs before the write, so a refused request leaves
+	// no AMI naming a snapshot the caller was told it could not use.
+	assert.Empty(t, ec2DescribedImageIDs(t, ts, nil))
+
+	// Once the snapshot is usable, the same request is accepted — the refusal is about the
+	// state and nothing else.
+	ec2ClearSnapshotStatus(t, ts, "")
+	var registered struct {
+		ImageID string `xml:"imageId"`
+	}
+	ec2FleetXML(t, ts, ec2SnapshotMappingRegisterImage("from-completed", snapshotID), &registered)
+	assert.NotEmpty(t, registered.ImageID)
+}
+
+// TestEC2_MappingSnapshot_RefusalWritesNothing pins the ordering the rest of the launch
+// validator already honors: the refusal runs before ensureDefaultVPC, which commits a VPC,
+// subnet, security group, gateway, route table and four index mutations.
+//
+// State left behind by a refused launch is worse than no rule at all, because the next request
+// in the same test sees it.
+func TestEC2_MappingSnapshot_RefusalWritesNothing(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	snapshotID := ec2PendingSnapshot(t, ts, "pending")
+
+	_, code, _ := ec2ErrorDetail(t, ts, ec2SnapshotMappingLaunch(snapshotID))
+	require.Equal(t, "IncorrectState", code)
+
+	assert.Empty(t, ec2InstanceIDs(t, ts), "no instance")
+	assert.Len(t, ec2DescribedVolumeIDs(t, ts, nil), 1,
+		"only the volume the snapshot was taken from, so the mapping materialized nothing")
+}
+
+// TestEC2_MappingSnapshot_DoesNotSpendAPoll is what pins peekSnapshotStatus over
+// observeSnapshotStatus, and it is the reason the observer is injected rather than read from
+// the record.
+//
+// The countdown advances in exactly one place, so an observing read here would burn one
+// observation *per mapping per request*: "pendingObservations: 3" would mean three polls in a
+// test that only describes, one in a test that also tries a three-mapping launch, and
+// something else again after a retry. A consumer's wait loop alternates a launch attempt and a
+// describe, so it would race its own budget.
+func TestEC2_MappingSnapshot_DoesNotSpendAPoll(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+
+	ec2SeedSnapshotStatus(t, ts, `{"snapshotId":"*","pendingObservations":1}`)
+
+	// Three mappings naming the same snapshot, attempted twice: six observations, if the
+	// rule consumed them.
+	launch := map[string]string{
+		"Action": "RunInstances", "ImageId": ec2TestImage, "MinCount": "1", "MaxCount": "1",
+		"BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"BlockDeviceMapping.1.Ebs.SnapshotId": snapshotID,
+		"BlockDeviceMapping.2.DeviceName":     "/dev/sdg",
+		"BlockDeviceMapping.2.Ebs.SnapshotId": snapshotID,
+		"BlockDeviceMapping.3.DeviceName":     "/dev/sdh",
+		"BlockDeviceMapping.3.Ebs.SnapshotId": snapshotID,
+	}
+	for range 2 {
+		_, code, _ := ec2ErrorDetail(t, ts, launch)
+		require.Equal(t, "IncorrectState", code, "six mappings must not exhaust a one-poll budget")
+	}
+
+	assert.Equal(t, "pending", ec2DescribeOneSnapshot(t, ts, snapshotID).State,
+		"the single budgeted observation is still unspent")
+	assert.Equal(t, "completed", ec2DescribeOneSnapshot(t, ts, snapshotID).State)
+
+	// And the launch the consumer was waiting to make now succeeds, all three volumes
+	// materialized from the snapshot's size.
+	launched := runInstancesLaunched(t, ts, launch)
+	require.Len(t, launched, 1)
+	assert.Len(t, ec2DescribedVolumeIDs(t, ts, map[string]string{
+		"Filter.1.Name": "snapshot-id", "Filter.1.Value.1": snapshotID,
+	}), 3)
+}
+
+// TestEC2_MappingSnapshot_LaunchTemplatesStayPermissive pins the exemption, which is a
+// decision rather than an oversight.
+//
+// A template is not a launch: both create operations report mapping problems through AWS's
+// documented `warning` member and refuse nothing (#693), so a 400 here would be substrate's
+// invention. And a snapshot pending when a template is written may legitimately be completed
+// by the time the template is used — refusing at write time would forbid the ordering AWS
+// permits. The rule applies where the mapping is consumed, which the launch below shows.
+func TestEC2_MappingSnapshot_LaunchTemplatesStayPermissive(t *testing.T) {
+	t.Parallel()
+	ts := newEC2TestServer(t)
+	snapshotID := ec2PendingSnapshot(t, ts, "pending")
+
+	created, body := ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplate",
+		"LaunchTemplateName":         "pending-snapshot",
+		"LaunchTemplateData.ImageId": ec2TestImage,
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdf",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.SnapshotId": snapshotID,
+	})
+	require.NotEmpty(t, created.LaunchTemplateID, "the template is created")
+	assert.Nil(t, created.Warning,
+		"and not even warned about: the mapping is valid, only the snapshot is not ready: %s", body)
+
+	version, versionBody := ltWarningRequest(t, ts, map[string]string{
+		"Action":                     "CreateLaunchTemplateVersion",
+		"LaunchTemplateName":         "pending-snapshot",
+		"LaunchTemplateData.ImageId": ec2TestImage,
+		"LaunchTemplateData.BlockDeviceMapping.1.DeviceName":     "/dev/sdg",
+		"LaunchTemplateData.BlockDeviceMapping.1.Ebs.SnapshotId": snapshotID,
+	})
+	assert.Equal(t, int64(2), version.VersionNumber)
+	assert.Nil(t, version.Warning, versionBody)
+
+	// The launch from that template is where the state is read, so the rule is not escapable
+	// by routing a mapping through a template.
+	_, code, message := ec2ErrorDetail(t, ts, map[string]string{
+		"Action": "RunInstances", "MinCount": "1", "MaxCount": "1",
+		"LaunchTemplate.LaunchTemplateName": "pending-snapshot",
+	})
+	assert.Equal(t, "IncorrectState", code)
+	assert.Contains(t, message, snapshotID)
+
+	// And the same template launches once the snapshot is usable, which is the ordering the
+	// exemption exists to allow.
+	ec2ClearSnapshotStatus(t, ts, "")
+	require.Len(t, runInstancesLaunched(t, ts, map[string]string{
+		"Action": "RunInstances", "MinCount": "1", "MaxCount": "1",
+		"LaunchTemplate.LaunchTemplateName": "pending-snapshot",
+	}), 1)
+}

--- a/emulator/ec2_mapping_snapshot_state_test.go
+++ b/emulator/ec2_mapping_snapshot_state_test.go
@@ -1,10 +1,13 @@
 package emulator_test
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/scttfrdmn/substrate/emulator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -189,6 +192,67 @@ func TestEC2_MappingSnapshot_DoesNotSpendAPoll(t *testing.T) {
 	assert.Len(t, ec2DescribedVolumeIDs(t, ts, map[string]string{
 		"Filter.1.Name": "snapshot-id", "Filter.1.Value.1": snapshotID,
 	}), 3)
+}
+
+// seedBlindStateManager passes every call through until it is armed, after which a Get against
+// the snapshot control-plane namespace fails.
+//
+// Failing only that namespace is what makes the test specific: a store that failed every Get
+// would never get past resolving the snapshot record, and the refusal a test then saw would be
+// InvalidSnapshot.NotFound — the very collapse the assertion below exists to rule out.
+type seedBlindStateManager struct {
+	inner emulator.StateManager
+	armed bool
+}
+
+// ec2SnapCtrlNamespace is the namespace the snapshot progression seeds live in. It is
+// unexported, so the literal is repeated here; a rename that missed it would disarm this test
+// rather than break it, which is why the assertion below also pins the status code.
+const ec2SnapCtrlNamespaceLiteral = "ec2-snap-ctrl"
+
+func (m *seedBlindStateManager) Get(ctx context.Context, namespace, key string) ([]byte, error) {
+	if m.armed && namespace == ec2SnapCtrlNamespaceLiteral {
+		return nil, errors.New("state store unavailable")
+	}
+	return m.inner.Get(ctx, namespace, key)
+}
+
+func (m *seedBlindStateManager) Put(ctx context.Context, namespace, key string, value []byte) error {
+	return m.inner.Put(ctx, namespace, key, value)
+}
+
+func (m *seedBlindStateManager) Delete(ctx context.Context, namespace, key string) error {
+	return m.inner.Delete(ctx, namespace, key)
+}
+
+func (m *seedBlindStateManager) List(ctx context.Context, namespace, prefix string) ([]string, error) {
+	return m.inner.List(ctx, namespace, prefix)
+}
+
+// TestEC2_MappingSnapshot_UnreadableStateIsNotPermission asserts that a state read the rule
+// cannot complete answers InternalError / 500 rather than letting the mapping through.
+//
+// This is deliberately the opposite of the resolver's absent-on-error rule beside it, and the
+// two are not in tension: an unresolvable snapshot is indistinguishable from an absent one, so
+// reporting NotFound is honest, whereas an unreadable *state* is not evidence the snapshot is
+// usable. Permitting the mapping would make the rule's absence indistinguishable from its
+// satisfaction — the caller would see a launch succeed and could not tell whether it was
+// checked. A 500 is also the only answer that tells an SDK to retry, which is the correct
+// behavior for a transient store failure.
+func TestEC2_MappingSnapshot_UnreadableStateIsNotPermission(t *testing.T) {
+	t.Parallel()
+	state := &seedBlindStateManager{inner: emulator.NewMemoryStateManager()}
+	ts := newEC2TestServerWithState(t, state)
+
+	volumeID := ec2CreateSizedVolume(t, ts, 8, nil)
+	snapshotID := ec2CreateSnapshot(t, ts, map[string]string{"VolumeId": volumeID}).SnapshotID
+	state.armed = true
+
+	status, code, _ := ec2ErrorDetail(t, ts, ec2SnapshotMappingLaunch(snapshotID))
+	assert.Equal(t, http.StatusInternalServerError, status)
+	assert.Equal(t, "InternalError", code)
+
+	assert.Empty(t, ec2InstanceIDs(t, ts), "and the launch wrote nothing")
 }
 
 // TestEC2_MappingSnapshot_LaunchTemplatesStayPermissive pins the exemption, which is a

--- a/emulator/ec2_plugin.go
+++ b/emulator/ec2_plugin.go
@@ -575,8 +575,12 @@ func (p *EC2Plugin) runInstancesWithTags(
 	// VPC, subnet, security group, internet gateway, route table and four index
 	// mutations: a refusal past that point leaves state behind, which is worse than no
 	// validation at all because the next request in the same test sees it.
+	//
+	// peekSnapshotStatus, not observeSnapshotStatus: a launch is not a poll, and the
+	// countdown advances in one place, so observing here would spend one of a test's
+	// seeded observations per mapping — see [ec2CheckMappingSnapshot].
 	resolveSnapshot := p.ec2SnapshotResolver(reqCtx)
-	if awsErr := ec2CheckBlockDeviceMappings(blockDeviceMappings, resolveSnapshot); awsErr != nil {
+	if awsErr := ec2CheckBlockDeviceMappings(blockDeviceMappings, resolveSnapshot, p.peekSnapshotStatus); awsErr != nil {
 		return nil, awsErr
 	}
 
@@ -4126,7 +4130,7 @@ func (p *EC2Plugin) registerImage(reqCtx *RequestContext, req *AWSRequest) (*AWS
 		if bdm.SnapshotID == "" {
 			continue
 		}
-		if awsErr := ec2CheckMappingSnapshot(bdm, resolveSnapshot); awsErr != nil {
+		if awsErr := ec2CheckMappingSnapshot(bdm, resolveSnapshot, p.peekSnapshotStatus); awsErr != nil {
 			return nil, awsErr
 		}
 	}
@@ -5846,8 +5850,12 @@ func (p *EC2Plugin) createLaunchTemplate(ctx *RequestContext, req *AWSRequest) (
 		// Reported rather than refused: the template is created either way, because
 		// AWS's Errors section lists nothing for an invalid one and its `warning`
 		// member exists for exactly this. See [ec2CollectBlockDeviceMappings].
+		//
+		// The nil observer skips the snapshot-state rule, deliberately: a template is
+		// not a launch, and a snapshot pending now may be complete when the template is
+		// used — see [ec2CheckMappingSnapshot].
 		Warning: ec2ValidationWarningFor(
-			ec2CollectBlockDeviceMappings(ltData.BlockDeviceMappings, p.ec2SnapshotResolver(ctx))),
+			ec2CollectBlockDeviceMappings(ltData.BlockDeviceMappings, p.ec2SnapshotResolver(ctx), nil)),
 	})
 }
 

--- a/emulator/ec2_snapshot_control.go
+++ b/emulator/ec2_snapshot_control.go
@@ -159,11 +159,14 @@ func (p *EC2Plugin) resolveSnapshotProgression(snapshotID string) (*ec2SnapshotP
 // peekSnapshotStatus reports what the snapshot would observe right now, without advancing its
 // countdown.
 //
-// Three callers need the state without consuming an observation, because none of them is a
-// poll: CreateSnapshot and CreateSnapshots, which report the state a snapshot is born in, and
-// CreateVolume, which refuses a snapshot that is not usable yet. Counting those against a
-// budget the caller meant to spend on polling would make "pendingObservations: 2" mean two
-// polls in one test and one in another.
+// Its callers need the state without consuming an observation, because none of them is a
+// poll: CreateSnapshot and CreateSnapshots, which report the state a snapshot is born in;
+// CreateVolume, which refuses a snapshot that is not usable yet; and the block-device-mapping
+// rule that refuses the same snapshot in a launch or a RegisterImage (#732), which is also the
+// one caller that can reach here more than once per request — one mapping each. Counting any
+// of those against a budget the caller meant to spend on polling would make
+// "pendingObservations: 2" mean two polls in one test and one in another, and in the mapping
+// case would make it depend on how many volumes the launch declared.
 //
 // DeleteSnapshot needs neither peek nor observation: AWS permits deleting a snapshot in
 // progress, so its answer does not depend on the state at all — see [EC2Plugin.deleteSnapshot].


### PR DESCRIPTION
Closes #732

`CreateVolume` has refused a snapshot that is not usable yet since #715. A launch declaring the
**same** snapshot in a `BlockDeviceMapping` materialized a volume from it and reported success.
So one rule had two doors that disagreed:

```
$ aws ec2 create-volume --snapshot-id snap-… --availability-zone us-east-1a
IncorrectState: … a volume can only be created from a completed snapshot
$ aws ec2 run-instances --block-device-mappings 'DeviceName=/dev/sdf,Ebs={SnapshotId=snap-…}'
i-41f8cd8460402cbf
```

A consumer restoring through a launch — which is what CDK's and Terraform's snapshot-backed
volumes do — never reached the error branch it had written. `RegisterImage`, whose own second
AWS example registers an AMI from a root-device snapshot, had the same hole, and an AMI recorded
against a snapshot that never completes is one every later launch fails on.

## The change

The rule goes into `ec2CheckMappingSnapshot`, so the launch path (and `CreateFleet` through it)
and `RegisterImage` inherit it from one place: `IncorrectState` / 400, naming the snapshot and
the state it is in so a caller can decide to wait. Ordering inside the validator is existence →
state → size, which is `CreateVolume`'s order.

**Everything except `completed` is refused**, not just `pending` and `error`. AWS's
snapshot-states table covers all four in its own words: a `pending` snapshot "can't be used
while it is in the `pending` state", an `error` one "can't be used", a `recoverable` one "must
first [be recovered] from the Recycle Bin", and a `recovering` one becomes "ready for use" only
after it reaches `completed`.

**The state comes from an observation, not the record.** `EC2Snapshot.State` is `"completed"` for
every snapshot substrate writes, so `if snap.State != "completed"` would be dead code — the
observable state lives only behind the seed accessors.

**And it peeks rather than observes.** The countdown advances in exactly one place, so an
observing read would spend one observation *per mapping per request*: `pendingObservations: 2`
would mean two polls in a test that only describes and fewer in one that also attempts a
three-mapping launch, and a consumer's wait loop — which alternates a launch attempt and a
describe — would race its own budget. A test pins this by asserting a seeded one-observation
budget survives two three-mapping launch attempts; swapping `peek` for `observe` reddens exactly
that test and nothing else.

`ec2CheckMappingSnapshot` is deliberately pure — its doc comment records that it takes a
resolver and no `StateManager`. That is preserved by injecting a second
`func(EC2Snapshot) (ec2SnapshotObservation, error)` rather than promoting the function to a
method. A **nil observer skips the state rule**, which is how the exemption below is expressed.

## The launch-template exemption

`CreateLaunchTemplate` and `CreateLaunchTemplateVersion` pass nil, with the reason recorded at
both call sites: a template *records* a mapping rather than consuming one, both report mapping
problems through AWS's documented `warning` member and refuse nothing (#693), and a snapshot
`pending` when a template is written may legitimately be `completed` by the time the template is
used — so refusing at write time would forbid an ordering AWS permits. A launch *from* such a
template **is** refused, so the rule is not escapable by routing a mapping through one; a test
asserts both halves.

## Provenance

Substrate's reading. `API_RegisterImage.html`'s Errors section contains only the pointer to the
errors common to all actions — it is empty — and the page says nothing about a snapshot's
required state. The *rule* is AWS's snapshot-states rule, quoted above; the *code* is
substrate's choice from EC2's client-error table, the one `CreateVolume` already answers with,
which is the same provenance shape that carries.

**`DeleteSnapshot` is not analogous**, and the issue's premise that #715 settled it is inverted:
#715 records the opposite, that AWS permits deleting a snapshot still in progress. It still
refuses nothing on state grounds — the live run below shows a seeded `pending` snapshot refused
only with `InvalidSnapshot.InUse`, because an AMI referenced it, a rule that has nothing to do
with the state.

A dedicated test covers the unreadable-state branch with a state double that fails Gets only in
the control-plane namespace, which is what keeps the refusal from collapsing into
`InvalidSnapshot.NotFound`.

An unreadable seed answers `InternalError` / 500 rather than treating the snapshot as usable,
which is deliberately the opposite of `ec2SnapshotResolver`'s absent-on-error rule and is
documented as such: silently permitting a mapping because the seed could not be read would make
the rule's absence indistinguishable from its satisfaction.

## Verification

Full gate green: `gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues), `make test` (race),
`make coverage` (emulator 83.3%, total 82.6%), `make docs-reference{,-check}`, `make
docs-versions`, `npm --prefix docs run build` with no dangling anchors, and `go vet`/`go test`
in `test/e2e`.

Fail-before: nulling the injected observer at both call sites reddens all seven new tests.
Mutation: swapping `peekSnapshotStatus` for `observeSnapshotStatus` reddens only the poll-budget
test.

Live SDK run against a built binary, which is how the issue was found, all twelve parts
verified — the AMI resolved through the SSM parameter generated IaC uses, the unseeded launch
and `RegisterImage` succeeding, both refused once seeded with the identical message,
`CreateVolume` agreeing on the code, three mappings plus a `RegisterImage` plus a `CreateVolume`
leaving the seeded three-poll budget exactly intact (`pending 0% → 33% → 66% → completed 100%`),
both template operations accepting the pending mapping while a launch from the template is
refused, and the same template launching both volumes once the seed is cleared.

## Compatibility

A launch or a `RegisterImage` whose mapping names a snapshot under a seeded progression now
fails until that snapshot reports `completed`. Only a seeded snapshot is affected: every snapshot
substrate writes is born `completed`, so an unseeded mapping behaves exactly as before.

