### PR TITLE
fix(iam,ec2): the bundled policies' condition keys (#730)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   affected: every snapshot substrate writes is born `completed`, so an unseeded mapping behaves
   as before.
 
+- **A condition operator IAM does not recognize is refused when the document is submitted**
+  (#730). Substrate accepted any operator name, stored it, and discarded it at evaluation, so a
+  `{"NotAnOperator": {…}}` real IAM rejects outright was stored here and then silently ignored:
+  the policy looked attached, matched nothing, and the caller was never told why. All four
+  submitting paths — `CreateRole`, `UpdateAssumeRolePolicy`, `CreatePolicy` and the shared
+  handler behind `PutUserPolicy`/`PutRolePolicy`/`PutGroupPolicy` — now answer
+  `MalformedPolicyDocument` / 400 and name the offending operator, and nothing is written.
+
+  The vocabulary is not restated anywhere: the check asks the evaluator itself, so an operator
+  the evaluator learns is accepted at write time in the same commit. Three names are refused for
+  a documented reason rather than for being unknown — `NullIfExists`, because AWS permits the
+  suffix on "any condition operator name except the `Null` condition", and `ForAllValues:Null`
+  and `ForAnyValue:Null`, which AWS does not define. A set qualifier over any other recognized
+  operator is accepted, including the combinations AWS's operator page does not tabulate.
+  Operator names are matched case-sensitively; AWS's case-insensitivity covers condition *key*
+  names, not operator names.
+
+  Validation is on the submission paths only, never on the read path: `PolicyDocument` is
+  unmarshalled on every read from state, so validating there would make an already-stored
+  document permanently unloadable. A document already in state still evaluates exactly as
+  before — an unrecognized operator denies, which remains the only reading that cannot turn a
+  typo into a grant.
+
+  **Provenance.** `MalformedPolicyDocument` / 400 is AWS's published pair for every one of the
+  four operations, and their Errors sections say "The error message describes the specific
+  error" — which is what licenses substrate naming the operator. The message wording is
+  substrate's own.
+
+  **Compatibility.** A policy document carrying a misspelled operator was accepted and is now
+  refused. A test or fixture that submitted one and asserted success will fail; the policy it
+  created never granted anything, so nothing that depended on the grant changes.
+
 ### Fixed
 - **One server serves one account** (#734). `ParseAWSRequest` decided the account from the
   *shape of the access key*: a key beginning with `AKIA` was attributed to `123456789012`,
@@ -215,6 +247,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state keys with the account (`table:{account}/{name}`, `instance:{account}/{id}`), so
   **persisted SQLite state written under the old account is unreachable** after upgrading:
   re-seed it, or set `account.default: "000000000000"` to read it back.
+
+- **A grant written about `ec2:ResourceTag/<key>` no longer silently fails** (#730). Two of the
+  bundled AWS-authored managed policies scope an EC2 delete by tag under EC2's own prefix
+  rather than the global one — `ManagedCloudformationResourcesCleanupPolicy` allows
+  `ec2:DeleteInternetGateway`, `ec2:DeleteRoute`, `ec2:DeleteRouteTable` and
+  `ec2:DeleteSecurityGroup` where `ec2:ResourceTag/aws:cloudformation:stack-name` is like
+  `EC2ContainerService-*`, and `AmazonEKSClusterPolicyENIDelete` allows
+  `ec2:DeleteNetworkInterface` where `ec2:ResourceTag/eks:eni:owner` equals
+  `amazon-vpc-cni`. Substrate published a resource's tags under `aws:ResourceTag/` only, so
+  neither condition could be satisfied and neither statement ever granted anything. Both
+  prefixes now report the same tag, from the resource's one tag set, because a policy may
+  write the condition either way about the same tag and AWS answers both. A policy of your own
+  written against `ec2:ResourceTag/<key>` now evaluates end to end; the *bundled* cleanup
+  statement remains unsatisfiable for a second reason, recorded rather than papered over —
+  nothing in substrate produces the `aws:cloudformation:stack-name` tag it names, because
+  `CreateTags` refuses a caller-supplied `aws:` key exactly as AWS does and the CloudFormation
+  deployer does not tag what it creates (#746).
+
+  The prefix alone would have been inert. Authorization resolved an EC2 request to a real ARN,
+  and to that resource's tags, only when the request named `InstanceId` — every other EC2
+  operation was decided against a bare `*` with no tags, which is exactly the case the two
+  bundled statements govern. An operation naming one resource through `InstanceId`, `GroupId`,
+  `RouteTableId` or `InternetGatewayId` is now decided against that resource's ARN and that
+  resource's tags, resolved through a single lookup shared by the ARN builder and the tag
+  reader so the tags a condition is evaluated against always belong to the ARN the decision is
+  made about.
+
+  **Provenance.** The Service Authorization Reference page for EC2 was unreachable while this
+  was written; the citable evidence for `ec2:ResourceTag/${TagKey}` is EC2's own
+  service-specific condition-key list plus the two AWS-authored policies above, which use the
+  key and ship in substrate. `aws:ResourceTag/tag-key` is documented as global. Publishing a
+  `<service>:ResourceTag/` prefix is therefore **specific to EC2**, not general: reporting an
+  S3 bucket's tags under `s3:ResourceTag/` would invent a key AWS does not publish, and it
+  would diverge in the direction that grants.
+
+  **Compatibility.** An EC2 operation naming one of those four parameters is now authorized
+  against a real ARN instead of `*`. Because a statement's own `Resource` is the pattern, a
+  request resource of `*` matched only a statement whose `Resource` began with `*`, so
+  substituting the real ARN can narrow a grant but never widen one. A policy that allowed such
+  an operation through a wildcard `Resource` still allows it; one that allowed it through an
+  ARN pattern the named resource does not match no longer does. `DeleteNetworkInterface` stays
+  undecidable by tag — substrate stores no standalone taggable ENI record — so the EKS
+  statement remains unsatisfiable, and that is recorded rather than worked around.
 
 ## [v0.107.0] - 2026-08-21
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -1153,13 +1153,37 @@ epoch second 2020, the one place the two date notations collide; and Go's spelli
 infinity, NaN and hexadecimal floats are not numbers, so `"Inf"` cannot satisfy
 `NumericGreaterThan` against every number in existence.
 
-**An operator substrate does not recognize denies.** Real IAM validates operator names when
-the document is submitted, answering `MalformedPolicyDocument`; substrate does not, so a
-misspelled operator is stored and then discarded at evaluation. Denying is substrate's
-choice and the only one that cannot turn a typo into a grant — including under a set
-qualifier, where an unrecognized operator over an absent key used to be
-[vacuously true](#multivalued-condition-keys-forallvalues-and-foranyvalue) and *granted*
+**An operator substrate does not recognize is refused when the document is submitted**, with
+`MalformedPolicyDocument` and HTTP 400 — AWS's published pair for every one of the four
+submitting operations, whose Errors sections read "The request was rejected because the
+policy document was malformed. The error message describes the specific error." That last
+sentence is what licenses substrate naming the offending operator in the message, which is
+the only part of the refusal a caller can act on. The four doors are `CreateRole`,
+`UpdateAssumeRolePolicy`, `CreatePolicy` and the three inline-policy operations
+(`PutUserPolicy`, `PutRolePolicy`, `PutGroupPolicy`), which share one handler.
+
+Three names are refused for a documented reason rather than for being unknown:
+`NullIfExists`, because AWS allows the suffix on "any condition operator name except the
+`Null` condition"; `ForAllValues:Null` and `ForAnyValue:Null`, because AWS defines neither.
+A set qualifier over any other recognized operator is accepted, including the combinations
+AWS's condition-operator page does not tabulate — it lists the String, Bool and ARN forms,
+while its set-operator reference describes the qualifiers generally, so refusing
+`ForAllValues:NumericLessThan` would be substrate inventing a restriction. Operator names
+are matched **case-sensitively**: `stringequals` is refused, because AWS's
+case-insensitivity covers condition *key* names, not operator names.
+
+Validation runs on the submission paths only, never when a stored document is read back.
+`PolicyDocument` is unmarshalled on every read from state, so validating there would make
+an already-stored document — one written by an older substrate, or by a seed — permanently
+unloadable. **An operator that is already in state still denies**, which is the evaluator's
+own reading and unchanged: it is the only answer that cannot turn a typo into a grant,
+including under a set qualifier, where an unrecognized operator over an absent key used to
+be [vacuously true](#multivalued-condition-keys-forallvalues-and-foranyvalue) and *granted*
 the statement.
+
+Out of scope, and named because the asymmetry is visible: S3's `PutBucketPolicy` performs a
+shallower check and answers `MalformedPolicy`, and the SNS and SQS `Policy` attribute is
+stored opaquely and parsed by neither.
 
 #### Which keys have a producer
 
@@ -1170,6 +1194,7 @@ nothing else:
 |---|---|
 | `aws:RequestTag/<key>`, `aws:TagKeys` | The tags the request asks to apply |
 | `aws:ResourceTag/<key>` | The tags on each resource the request names |
+| `ec2:ResourceTag/<key>` | The same tags, under EC2's service-specific duplicate of the global key — see [both prefixes](#ec2-reports-a-resource-s-tags-under-both-prefixes) |
 | `aws:CurrentTime`, `aws:EpochTime` | The emulator's simulated clock |
 | `ec2:CreateAction` | [A tagged create's second authorization pass](#a-tagged-create-is-authorized-twice) |
 | `ec2:Subnet`, `ec2:Vpc` | [A launch's networking resources](#a-launch-s-networking-resources-carry-ec2-subnet-and-ec2-vpc) |
@@ -1205,18 +1230,44 @@ What has **no** producer, and therefore never matches on the enforcement path:
   every principal kind — it mints no unique ID, and a role session's user name is not the
   last component of its ARN — and a key guessed wrong is worse than one a policy can test
   for with `Null`.
-- Every key the bundled AWS managed policies condition on: `iam:PassedToService`,
-  `iam:AWSServiceName`, `aws:CalledViaLast`, `elasticloadbalancing:CreateAction`,
-  `devops-guru:ServiceNames`, and `ec2:ResourceTag/<key>` (substrate produces
-  `aws:ResourceTag/<key>`). Each is a false deny in the safe direction: all 32 condition
-  blocks in the bundled catalog sit on an `Allow`, so such a statement grants nothing
-  rather than a `Deny` going inert.
+- Six of the seven keys the bundled AWS managed policies condition on, each for its own
+  reason rather than as one omission:
 
-**Substrate performs no policy-variable substitution.** A `${aws:username}` in a resource
-ARN or a condition value is compared literally, so the `${aws:username}` in the bundled
-`IAMUserChangePassword` policy matches no user. AWS substitutes the value before
-evaluating; substrate does not, and a policy relying on it grants nothing rather than
-granting the wrong thing.
+  | Key | Blocks | Why it has no producer |
+  |---|---|---|
+  | `iam:AWSServiceName` | 11 | The most feasible of the six — it is a direct read of `CreateServiceLinkedRole`'s own parameter. Blocked only on that operation not existing |
+  | `iam:PassedToService` | 8 | No `PassRole` operation exists anywhere in substrate, and the value comes from the *calling* API's service principal, which substrate has no analogue for |
+  | `codestar-notifications:NotificationsForResource` | 6 | No CodeStar Notifications plugin |
+  | `aws:CalledViaLast` | 2 | `RequestContext` has no call-chain notion, and there is no service-to-service internal path to record one from |
+  | `devops-guru:ServiceNames` | 2 | No DevOps Guru plugin |
+  | `elasticloadbalancing:CreateAction` | 1 | The ELB plugin has no tagging at all — no `AddTags`, and a load balancer's tags are never read or written — so the action the statement conditions does not exist |
+
+  The seventh, `ec2:ResourceTag/<key>`, now has one; see [both
+  prefixes](#ec2-reports-a-resource-s-tags-under-both-prefixes).
+
+  Each remaining absence is a false deny in the safe direction: all 32 condition blocks in
+  the bundled catalog sit on an `Allow`, so such a statement grants nothing rather than a
+  `Deny` going inert.
+
+**Substrate performs no policy-variable substitution**, deliberately rather than by
+omission. A `${aws:username}` in a resource ARN or a condition value is compared literally.
+
+For the one bundled policy that uses a variable — the `${aws:username}` in
+`IAMUserChangePassword`, the only `${` across all 47 — that is not observable: AWS's rule is
+that an unresolved variable in `Resource` "will not match any resource", `aws:username` has
+no producer, and substrate's literal comparison reaches the same answer by a different
+route. The statement matches nothing either way.
+
+The divergence that **is** real is `NotResource` and the negated operators, where AWS says
+an unresolved variable *does* match — so the negation excludes everything on AWS and nothing
+here, and a policy written that way is more permissive under substrate. Nothing in the
+bundled catalog is written that way; a caller's own policy could be.
+
+Substitution cannot land before `aws:username` has an honest producer, and the two obvious
+candidates are both wrong: the ARN's last component is the *session* name for an assumed
+role, where AWS documents `aws:username` as absent altogether, and the value the caller ARN
+is built from is an access key ID. The honest producer is the resolved IAM user name, set
+where the credential lookup already has it in hand and currently discards it.
 
 ### Multivalued condition keys: `ForAllValues` and `ForAnyValue`
 
@@ -4284,7 +4335,8 @@ treats such an ID as a no-op, and AWS answers an unparseable tagging ID with `In
 ("The specified ID for the resource you are trying to tag is not valid") rather than
 `AccessDenied`. Skipping is also the only safe direction — widening it to `*` would hand
 the caller the one resource a broad `Allow` matches. A call naming *only* such IDs is
-decided against a single `*`, as every other EC2 operation is.
+decided against a single `*`, as an EC2 operation naming no resource substrate can resolve
+is.
 
 `aws:RequestTag/{key}` is populated from the tags a tagging call carries
 (`Tag.N.Key`/`Tag.N.Value`), so the "tag only with the keys and values we prescribe"
@@ -4302,6 +4354,64 @@ checks already have.
 evaluates. See [multivalued condition
 keys](#multivalued-condition-keys-forallvalues-and-foranyvalue) for the set-qualifier rules
 those examples depend on, including why AWS pairs them with `Null`.
+
+#### An operation naming one resource by ID is decided against that resource
+
+Four request parameters resolve to the resource they name, so the operations carrying them
+are authorized against a real ARN and against that resource's own tags rather than against
+the literal `*`:
+
+| Parameter | Resolves to | The bundled actions that need it |
+|---|---|---|
+| `InstanceId` | `instance/<id>` | — (it is the one parameter that already resolved) |
+| `GroupId` | `security-group/<id>` | `ec2:DeleteSecurityGroup` |
+| `RouteTableId` | `route-table/<id>` | `ec2:DeleteRouteTable`, `ec2:DeleteRoute` |
+| `InternetGatewayId` | `internet-gateway/<id>` | `ec2:DeleteInternetGateway` |
+
+The list is short for a reason: each entry is a parameter one of the two `ec2:ResourceTag`
+statements in the bundled AWS managed policies names its target with. `DeleteRoute` appears
+under `RouteTableId` because the route table is the resource AWS authorizes a route change
+against. The indexed and un-indexed spellings are the same request, matching what the
+handlers themselves accept.
+
+`aws:ResourceTag/<key>` and `ec2:ResourceTag/<key>` both report the resolved resource's
+tags. <a id="ec2-reports-a-resource-s-tags-under-both-prefixes"></a>**EC2 reports a
+resource's tags under both prefixes** because AWS publishes both — `aws:ResourceTag` as a
+global key and `ec2:ResourceTag` as EC2's own — and AWS's own bundled policies use the
+service-specific one. The two prefixes are not folded together: they are two keys, not one
+key compared case-insensitively, and only EC2 gets a second prefix. Reporting, say, an S3
+bucket's tags under an `s3:ResourceTag/` key AWS does not publish would honor a policy real
+AWS ignores, which is a divergence in the granting direction.
+
+One caveat on the bundled statement that motivated the prefix: it conditions on
+`ec2:ResourceTag/aws:cloudformation:stack-name`, and that tag is not one a caller can set —
+`CreateTags` refuses a key beginning with `aws:`, as AWS does, and substrate's CloudFormation
+deployer does not apply stack tags to the resources it creates. So the prefix and the
+resolution work, and a policy you write against `ec2:ResourceTag/<your key>` evaluates, but
+`ManagedCloudformationResourcesCleanupPolicy`'s own statement stays unsatisfiable until the
+deployer tags what it creates ([#746](https://github.com/scttfrdmn/substrate/issues/746)).
+
+What still resolves to `*`, each named because a policy written against it will not behave
+as AWS would:
+
+- **`NetworkInterfaceId`.** Substrate stores no standalone taggable ENI record, so there are
+  no tags to compare and `AmazonEKSClusterPolicy`'s `ec2:DeleteNetworkInterface` statement
+  stays inert. Fabricating an empty tag set would be worse: it would turn "substrate cannot
+  tell" into "the tag is absent", deciding the condition rather than admitting it cannot.
+- **`VpcId` and `SubnetId`.** Several creates carry one as the *container* the new resource
+  goes into rather than as the resource acted on, and authorizing a create against its
+  parent's ARN is not what AWS evaluates it against.
+- **The plural forms.** An operation naming several resources of one type is still decided
+  against the first ID alone — a `TerminateInstances` with three `InstanceId.N` is decided
+  against `InstanceId.1`. This is the shape [tagging](#tagging-is-authorized-against-every-resource-it-names)
+  already handles for `ResourceId.N` and it is tracked for the rest.
+
+An ID that resolves to no record, or whose prefix names no type substrate can tag, falls
+back to `*` rather than being refused — the handler owes that answer, as `NotFound`. The
+fallback is safe in one direction only, which is why it is the fallback: `*` as the
+*request* resource is not a wildcard, because `resourceMatches` uses the statement's own
+`Resource` as the pattern, so `*` matched only a statement whose `Resource` began with `*`.
+Replacing it with a concrete ARN can therefore narrow a grant but never widen one.
 
 #### A tagged create is authorized twice
 

--- a/emulator/authz.go
+++ b/emulator/authz.go
@@ -183,20 +183,31 @@ func (a *AuthController) CheckAccess(reqCtx *RequestContext, req *AWSRequest) er
 		requestMulti["aws:TagKeys"] = keys
 	}
 
+	// The prefixes this service reports a resource's tags under, resolved once: it is a
+	// property of the service, not of any one resource.
+	tagPrefixes := authzResourceTagPrefixes(req.Service)
+
 	// Every resource the request names must be allowed. A request naming several —
 	// organizations:MoveAccount and ec2:RunInstances — is denied unless the caller's
 	// policies admit all of them, which is how AWS evaluates a statement against
 	// "every resource that is required" for the action (#660, #662).
 	for _, res := range resources {
-		condCtx := make(map[string]string, len(requestTags)+len(res.Tags)+len(res.Context))
+		condCtx := make(map[string]string,
+			len(requestTags)+len(res.Tags)*len(tagPrefixes)+len(res.Context))
 		for k, v := range requestTags {
 			condCtx[k] = v
 		}
 		// The tags travel with the ARN they belong to: one merged map across several
 		// resources would let a tag on one satisfy a condition written about another,
 		// which is the false allow orgAuthzResourceID's comment exists to prevent.
+		//
+		// One tag is reported under every prefix the service publishes, because a policy
+		// may write the condition either way about the same tag and AWS answers both from
+		// the resource's single tag set.
 		for k, v := range res.Tags {
-			condCtx["aws:ResourceTag/"+k] = v
+			for _, prefix := range tagPrefixes {
+				condCtx[prefix+k] = v
+			}
 		}
 		// Keys that describe this resource, on the same reasoning: they are scoped to
 		// the resource the reference lists them on, so a condition written about a
@@ -781,10 +792,11 @@ func (a *AuthController) buildResourceARN(reqCtx *RequestContext, req *AWSReques
 		// RunInstances does not reach here: it names five resources and is resolved
 		// by [ec2AuthzRunInstancesResources] (#662). Nor does a CreateTags or
 		// DeleteTags naming any resource substrate can tag, resolved by
-		// [ec2AuthzTagResources] (#674). What is left is the operations that name an
-		// instance by ID — and everything else, which still resolves to "*".
-		if id := req.Params["InstanceId.1"]; id != "" {
-			return "arn:aws:ec2:" + region + ":" + acct + ":instance/" + id
+		// [ec2AuthzTagResources] (#674). What is left is the operations that name one
+		// resource by ID — an instance, a security group, a route table or an internet
+		// gateway (#730) — and everything else, which still resolves to "*".
+		if target, ok := ec2AuthzNamedResource(a.state, reqCtx, req); ok {
+			return target.arn(region, acct)
 		}
 		return "*"
 	case "lambda":
@@ -923,14 +935,40 @@ func buildS3ARN(req *AWSRequest) string {
 	return "arn:aws:s3:::" + path
 }
 
+// authzAWSResourceTagPrefix is the global condition-key prefix every service reports a
+// resource's tags under.
+const authzAWSResourceTagPrefix = "aws:ResourceTag/"
+
+// authzResourceTagPrefixes returns the condition-key prefixes a service reports a
+// resource's tags under, in the order they are written.
+//
+// AWS documents aws:ResourceTag/tag-key as global — "the tag attached to the resource
+// that you specify in the policy" — and some services additionally publish a
+// service-specific duplicate of it. EC2 is one: two of the AWS-authored managed policies
+// substrate bundles condition on ec2:ResourceTag/<key> rather than the global form
+// (ManagedCloudformationResourcesCleanupPolicy on aws:cloudformation:stack-name,
+// AmazonEKSClusterPolicy on eks:eni:owner), so a policy written the way AWS writes it
+// sees nothing unless the tags are reported under that prefix too.
+//
+// The list is per-service and deliberately not a blanket second prefix: reporting an S3
+// bucket's tags under s3:ResourceTag/ would invent a condition key AWS does not publish,
+// and a policy that happened to use it would then be honored here and ignored by AWS —
+// a divergence in the more dangerous direction, since it grants.
+func authzResourceTagPrefixes(service string) []string {
+	if service == "ec2" {
+		return []string{authzAWSResourceTagPrefix, "ec2:ResourceTag/"}
+	}
+	return []string{authzAWSResourceTagPrefix}
+}
+
 // resourceTagsFor loads the tags on the resource a request names, keyed by the
-// bare tag key. [AuthController.CheckAccess] adds the aws:ResourceTag/ prefix,
+// bare tag key. [AuthController.CheckAccess] adds the aws:ResourceTag/ prefix —
+// and any service-specific duplicate of it, see [authzResourceTagPrefixes] —
 // once per resource in the list, so an operation naming several resources cannot
 // mix one resource's tags into another's condition context.
 func (a *AuthController) resourceTagsFor(reqCtx *RequestContext, req *AWSRequest) map[string]string {
 	goCtx := context.Background()
 	acct := reqCtx.AccountID
-	region := reqCtx.Region
 	var tags map[string]string
 
 	switch req.Service {
@@ -1012,19 +1050,17 @@ func (a *AuthController) resourceTagsFor(reqCtx *RequestContext, req *AWSRequest
 		}
 
 	case "ec2":
-		id := req.Params["InstanceId.1"]
-		if id == "" {
+		// The same resolver [AuthController.buildResourceARN] uses, so the tags a
+		// condition is evaluated against always belong to the ARN the decision is made
+		// about. Reading them through [ec2AuthzTagsFor] is also what generalizes this
+		// arm past instances: it decodes the "tags" member every EC2 record spells the
+		// same way, which is how a security group's, route table's or internet gateway's
+		// tags become readable without a decoder per type (#730).
+		target, ok := ec2AuthzNamedResource(a.state, reqCtx, req)
+		if !ok {
 			return nil
 		}
-		raw, err := a.state.Get(goCtx, ec2Namespace, "instance:"+acct+"/"+region+"/"+id)
-		if err != nil || raw == nil {
-			return nil
-		}
-		var inst EC2Instance
-		if err := json.Unmarshal(raw, &inst); err != nil {
-			return nil
-		}
-		tags = ec2TagsToMap(inst.Tags)
+		tags = ec2AuthzTagsFor(a.state, target.stateKey)
 
 	case "dynamodb":
 		tbl := req.Params["TableName"]

--- a/emulator/ec2_authz.go
+++ b/emulator/ec2_authz.go
@@ -213,6 +213,70 @@ func ec2AuthzTagResources(state StateManager, reqCtx *RequestContext, req *AWSRe
 	return out
 }
 
+// ec2AuthzIDParams are the request parameters that name the resource an EC2 operation
+// acts on, in the order they are tried.
+//
+// Only four, and each is here because a bundled AWS managed policy conditions an action on
+// the tags of the resource that parameter names (#730). Substrate resolved a single EC2
+// resource from `InstanceId` alone, so every other operation was decided against the
+// literal "*" — and a tag condition about it could not be evaluated at all, because there
+// was no resource whose tags to read. That made both `ec2:ResourceTag/…` statements in
+// AWS's own `AmazonECSServiceRolePolicy`-shaped cleanup grants inert:
+// `DeleteInternetGateway`, `DeleteRoute`, `DeleteRouteTable` and `DeleteSecurityGroup` are
+// exactly the four actions they govern.
+//
+// Order is fixed so the decision is replay-stable, and it does not matter in practice:
+// no EC2 operation carries two of these four. `DeleteRoute` and `DeleteRouteTable` share
+// `RouteTableId`, which is the resource both act on.
+//
+// Deliberately absent, each for its own reason rather than by oversight:
+//
+//   - `NetworkInterfaceId`, which `AmazonEKSClusterPolicy` conditions
+//     `ec2:DeleteNetworkInterface` on. Substrate stores no standalone taggable ENI record —
+//     [ec2TaggableResource] has no `eni-` arm to read one through, as
+//     [ec2AuthzRunInstancesResources] already records — so there are no tags to compare and
+//     that statement stays inert. Fabricating an empty tag set would be worse than leaving
+//     it: it would turn "substrate cannot tell" into "the tag is absent", which decides the
+//     condition rather than admitting it cannot.
+//   - `VpcId` and `SubnetId`, which several *creates* carry (`CreateSubnet`, `CreateRoute`,
+//     `AttachInternetGateway`) as the container the new resource goes into rather than as
+//     the resource acted on. Resolving one there would authorize a create against its
+//     parent's ARN, which is not the ARN AWS evaluates it against.
+//   - The plural forms. An operation naming several resources of one type —
+//     `TerminateInstances` with three `InstanceId.N` — is still decided against the first
+//     alone, which is the #674-shaped gap [ec2AuthzTagResources] closed for tagging calls
+//     and #744 tracks for the rest.
+var ec2AuthzIDParams = []string{"InstanceId", "GroupId", "RouteTableId", "InternetGatewayId"}
+
+// ec2AuthzNamedResource resolves the resource an EC2 request names by ID, for the
+// operations that are not a launch and not a tagging call.
+//
+// It reads the parameter through [extractIndexedParams], so `GroupId` and `GroupId.1` are
+// the same request — which is the form the handlers themselves accept, and it is what
+// keeps the resource a policy is evaluated against the resource the handler will act on.
+//
+// ok=false means the request names no resource this can resolve, which sends the caller
+// back to the wildcard it used before. That is the only safe direction: "*" as the request
+// resource matches a statement whose own Resource starts with "*", so it can only ever
+// narrow a grant, never widen one.
+func ec2AuthzNamedResource(state StateManager, reqCtx *RequestContext, req *AWSRequest) (ec2Taggable, bool) {
+	for _, param := range ec2AuthzIDParams {
+		ids := extractIndexedParams(req.Params, param)
+		if len(ids) == 0 || ids[0] == "" {
+			continue
+		}
+		target, ok := ec2TaggableResource(state, reqCtx, ids[0])
+		if !ok || !target.resolved() {
+			// A prefix naming no taggable type, or a pg-/key- ID naming no record.
+			// Neither is a resource an ARN can be built for — see [ec2Taggable.resolved]
+			// — and neither is this function's to refuse: the handler owes that answer.
+			return ec2Taggable{}, false
+		}
+		return target, true
+	}
+	return ec2Taggable{}, false
+}
+
 // ec2CreateTagsAction is the action AWS authorizes a tag-carrying create against a
 // second time, in addition to the create itself.
 const ec2CreateTagsAction = "ec2:CreateTags"

--- a/emulator/ec2_resourcetag_authz_test.go
+++ b/emulator/ec2_resourcetag_authz_test.go
@@ -1,0 +1,308 @@
+package emulator_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// #730: the ec2:ResourceTag/<key> prefix, and the resolver that makes it observable.
+//
+// Two of the AWS-authored managed policies substrate bundles condition on
+// ec2:ResourceTag/<key> rather than the global aws:ResourceTag/<key>, and both were
+// inert: substrate wrote a resource's tags under the aws: prefix only, and resolved a
+// single EC2 resource from InstanceId alone, so DeleteSecurityGroup, DeleteRouteTable,
+// DeleteRoute and DeleteInternetGateway were all decided against the literal "*" with no
+// tags in the condition context at all. A grant scoped to a tag matched nothing, and a
+// Deny scoped to one was silently ignored.
+
+// ec2AuthzRouteTable and ec2AuthzIGW are the two IDs the delete tests name.
+const (
+	ec2AuthzRouteTable = "rtb-0eee66667777ffff8"
+	ec2AuthzIGW        = "igw-0fff88889999aaab0"
+)
+
+var (
+	ec2AuthzRouteTableARN = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":route-table/" + ec2AuthzRouteTable
+	ec2AuthzIGWARN        = "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":internet-gateway/" + ec2AuthzIGW
+)
+
+func (f *ec2AuthzFixture) putRouteTable(t *testing.T, id string, tags map[string]string) {
+	t.Helper()
+	f.put(t, "rtb:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+id, emulator.EC2RouteTable{
+		RouteTableID: id,
+		Tags:         ec2AuthzTags(tags),
+	})
+}
+
+func (f *ec2AuthzFixture) putInternetGateway(t *testing.T, id string, tags map[string]string) {
+	t.Helper()
+	f.put(t, "igw:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+id, emulator.EC2InternetGateway{
+		InternetGatewayID: id,
+		Tags:              ec2AuthzTags(tags),
+	})
+}
+
+// ec2AuthzTagCondition builds the condition shape both bundled policies use: one
+// operator, one ec2:ResourceTag key, one value.
+func ec2AuthzTagCondition(operator, key, value string) map[string]map[string]emulator.StringOrSlice {
+	return map[string]map[string]emulator.StringOrSlice{
+		operator: {key: emulator.StringOrSlice{value}},
+	}
+}
+
+// ec2AuthzConditionStatement allows one action on "*" if the condition holds, which is
+// exactly the shape of ManagedCloudformationResourcesCleanupPolicy: Resource "*", scoped
+// by a tag rather than by an ARN.
+func ec2AuthzConditionStatement(
+	action string,
+	condition map[string]map[string]emulator.StringOrSlice,
+) emulator.PolicyStatement {
+	return emulator.PolicyStatement{
+		Effect:    "Allow",
+		Action:    emulator.StringOrSlice{action},
+		Resource:  emulator.StringOrSlice{"*"},
+		Condition: condition,
+	}
+}
+
+// TestEC2Authz_ResourceTagPrefix_GrantsOnTheServicePrefix is the bundled cleanup policy's
+// own statement, run against a tagged and an untagged security group.
+//
+// AWS's ManagedCloudformationResourcesCleanupPolicy conditions ec2:DeleteSecurityGroup on
+// StringLike ec2:ResourceTag/aws:cloudformation:stack-name — so before the second prefix
+// existed, a caller carrying AWS's own policy could delete nothing.
+func TestEC2Authz_ResourceTagPrefix_GrantsOnTheServicePrefix(t *testing.T) {
+	t.Parallel()
+	f := newEC2AuthzFixture(t, "cfn-cleanup", emulator.PolicyDocument{})
+	f.setPolicy(t, ec2AuthzConditionStatement("ec2:DeleteSecurityGroup",
+		ec2AuthzTagCondition("StringLike", "ec2:ResourceTag/aws:cloudformation:stack-name",
+			"EC2ContainerService-*")))
+
+	f.putSecurityGroup(t, ec2AuthzSG, map[string]string{
+		"aws:cloudformation:stack-name": "EC2ContainerService-prod",
+	})
+	require.NoError(t, f.call(t, "DeleteSecurityGroup", map[string]string{"GroupId": ec2AuthzSG}),
+		"the tag matches the pattern AWS's own policy names")
+
+	// The same request against a group the pattern does not match is denied, which is
+	// what shows the grant is the tag's doing and not the prefix merely being present.
+	other := "sg-0999aaaabbbbcccc1"
+	f.putSecurityGroup(t, other, map[string]string{"aws:cloudformation:stack-name": "SomethingElse"})
+	err := f.call(t, "DeleteSecurityGroup", map[string]string{"GroupId": other})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ec2AuthzSGARNFor(other),
+		"and the refusal names the group's own ARN, not \"*\"")
+}
+
+// ec2AuthzSGARNFor is the ARN a security-group decision is made against.
+func ec2AuthzSGARNFor(id string) string {
+	return "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":security-group/" + id
+}
+
+// TestEC2Authz_ResourceTagPrefix_BothPrefixesReportTheSameTag pins that adding the
+// service prefix did not take the global one away.
+//
+// AWS documents aws:ResourceTag/tag-key as global — "the tag attached to the resource that
+// you specify in the policy" — so a policy written either way sees the same tag, and a
+// policy written both ways must see it under both keys. #704's case folding is not
+// involved: aws:ResourceTag/Env and ec2:ResourceTag/Env are two keys, not one compared
+// case-insensitively.
+func TestEC2Authz_ResourceTagPrefix_BothPrefixesReportTheSameTag(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []string{"aws:ResourceTag/Env", "ec2:ResourceTag/Env"} {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+			f := newEC2AuthzFixture(t, "tagged-delete", emulator.PolicyDocument{})
+			f.setPolicy(t, ec2AuthzConditionStatement("ec2:DeleteRouteTable",
+				ec2AuthzTagCondition("StringEquals", key, "dev")))
+
+			f.putRouteTable(t, ec2AuthzRouteTable, map[string]string{"Env": "dev"})
+			assert.NoError(t, f.call(t, "DeleteRouteTable",
+				map[string]string{"RouteTableId": ec2AuthzRouteTable}))
+
+			// And the tag is what decides it: retagged, the same policy denies.
+			f.putRouteTable(t, ec2AuthzRouteTable, map[string]string{"Env": "prod"})
+			assert.Error(t, f.call(t, "DeleteRouteTable",
+				map[string]string{"RouteTableId": ec2AuthzRouteTable}))
+		})
+	}
+}
+
+// TestEC2Authz_ResourceTagPrefix_IsPerService asserts the prefix is not blanket.
+//
+// A resource's tags are reported under a service prefix only where AWS publishes one. An
+// S3 bucket's tags under s3:ResourceTag/ would be a condition key AWS does not define, so
+// a policy using it would be honored here and ignored on AWS — a divergence that grants,
+// which is the worse direction.
+func TestEC2Authz_ResourceTagPrefix_IsPerService(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		condKey string
+		allowed bool
+	}{
+		"aws:ResourceTag/Env": {"aws:ResourceTag/Env", true},
+		"s3:ResourceTag/Env":  {"s3:ResourceTag/Env", false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			policyARN := "arn:aws:iam::" + ec2AuthzAccount + ":policy/S3Prefix"
+			state := newAuthTestState(t, "s3-prefix",
+				policyARN, newABACPolicy("Allow", "s3:PutObject", "*", tc.condKey, "prod"))
+			putS3BucketWithTags(t, state, "tagged-bucket", map[string]string{"Env": "prod"})
+
+			auth := emulator.NewAuthController(state, emulator.NewDefaultLogger(slog.LevelError, false))
+			err := auth.CheckAccess(
+				newAuthTestReqCtx("arn:aws:iam::"+ec2AuthzAccount+":user/s3-prefix"),
+				&emulator.AWSRequest{Service: "s3", Operation: "PutObject", Path: "/tagged-bucket/key"})
+
+			if tc.allowed {
+				assert.NoError(t, err, "the global key reports the bucket's tag")
+			} else {
+				assert.Error(t, err, "s3:ResourceTag/ is not a key AWS publishes")
+			}
+		})
+	}
+}
+
+// TestEC2Authz_NamedResource_ResolvesTheARN covers the resolver half on its own, with no
+// condition in play: an operation naming one resource by ID is decided against that
+// resource's ARN rather than against "*".
+//
+// Each of the four parameters is here because a bundled policy's action names its target
+// with it. DeleteRoute is the reason RouteTableId appears twice: the route table is the
+// resource AWS authorizes a route change against.
+func TestEC2Authz_NamedResource_ResolvesTheARN(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		operation string
+		params    map[string]string
+		arn       string
+	}{
+		{"DeleteSecurityGroup", map[string]string{"GroupId": ec2AuthzSG}, ec2AuthzSGARN},
+		{"DeleteRouteTable", map[string]string{"RouteTableId": ec2AuthzRouteTable}, ec2AuthzRouteTableARN},
+		{"DeleteRoute", map[string]string{
+			"RouteTableId": ec2AuthzRouteTable, "DestinationCidrBlock": "0.0.0.0/0",
+		}, ec2AuthzRouteTableARN},
+		{"DeleteInternetGateway", map[string]string{"InternetGatewayId": ec2AuthzIGW}, ec2AuthzIGWARN},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.operation, func(t *testing.T) {
+			t.Parallel()
+			f := newEC2AuthzFixture(t, "arn-scoped", emulator.PolicyDocument{})
+			f.putRouteTable(t, ec2AuthzRouteTable, nil)
+			f.putInternetGateway(t, ec2AuthzIGW, nil)
+
+			// An Allow naming the resource's own ARN grants the call, which it could
+			// not when every such operation resolved to "*": resourceMatches passes the
+			// statement's Resource to globMatch as the pattern, so a request resource of
+			// "*" matched only a statement whose Resource began with "*".
+			f.setPolicy(t, emulator.PolicyStatement{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice{"ec2:" + tc.operation},
+				Resource: emulator.StringOrSlice{tc.arn},
+			})
+			assert.NoError(t, f.call(t, tc.operation, tc.params))
+
+			// And an ARN-scoped Deny is no longer inert.
+			f.setPolicy(t,
+				emulator.PolicyStatement{
+					Effect:   "Allow",
+					Action:   emulator.StringOrSlice{"ec2:*"},
+					Resource: emulator.StringOrSlice{"*"},
+				},
+				emulator.PolicyStatement{
+					Effect:   "Deny",
+					Action:   emulator.StringOrSlice{"ec2:" + tc.operation},
+					Resource: emulator.StringOrSlice{tc.arn},
+				})
+			err := f.call(t, tc.operation, tc.params)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.arn)
+		})
+	}
+}
+
+// TestEC2Authz_NamedResource_UnresolvableFallsBackToWildcard pins the direction the
+// resolver is allowed to move a decision in.
+//
+// ok=false sends the caller back to the "*" it used before, and that is safe in one
+// direction only: "*" as the request resource matches a statement whose own Resource
+// starts with "*", so replacing it with a real ARN can narrow a grant but never widen
+// one. The three cases are the ones a live request produces — an ID naming no record, an
+// ID whose prefix names no taggable type, and no ID parameter at all.
+func TestEC2Authz_NamedResource_UnresolvableFallsBackToWildcard(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		operation string
+		params    map[string]string
+	}{
+		"absent record":     {"DeleteRouteTable", map[string]string{"RouteTableId": "rtb-0dddeeeeffff11112"}},
+		"untaggable prefix": {"DeleteVpcEndpoints", map[string]string{"GroupId": "vpce-0aaabbbbccccdddd3"}},
+		"no ID at all":      {"DescribeRouteTables", map[string]string{}},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			f := newEC2AuthzFixture(t, "wildcard-fallback", emulator.PolicyDocument{})
+
+			// A wildcard Allow still grants, so an unresolvable ID does not turn into a
+			// refusal this function has no standing to make — the handler owes that
+			// answer, as NotFound.
+			f.setPolicy(t, emulator.PolicyStatement{
+				Effect:   "Allow",
+				Action:   emulator.StringOrSlice{"ec2:*"},
+				Resource: emulator.StringOrSlice{"*"},
+			})
+			assert.NoError(t, f.call(t, tc.operation, tc.params))
+
+			// And with no tags to read, a tag condition is not satisfied — an absent
+			// record must not read as an empty tag set that happens to match.
+			f.setPolicy(t, ec2AuthzConditionStatement("ec2:"+tc.operation,
+				ec2AuthzTagCondition("StringEquals", "ec2:ResourceTag/Env", "dev")))
+			assert.Error(t, f.call(t, tc.operation, tc.params))
+		})
+	}
+}
+
+// TestEC2Authz_NamedResource_InstanceStillResolves is the regression guard on the one
+// parameter that already worked.
+//
+// InstanceId was the sole case resourceTagsFor and buildResourceARN handled, each with
+// its own EC2Instance decode. Both now go through the shared table, so the tags a
+// condition is evaluated against and the ARN the decision is made about come from one
+// place — but an instance must still resolve exactly as it did.
+func TestEC2Authz_NamedResource_InstanceStillResolves(t *testing.T) {
+	t.Parallel()
+	const instanceID = "i-0abc11112222dddd3"
+	instanceARN := "arn:aws:ec2:" + ec2AuthzRegion + ":" + ec2AuthzAccount + ":instance/" + instanceID
+
+	f := newEC2AuthzFixture(t, "instance-tagged", emulator.PolicyDocument{})
+	f.put(t, "instance:"+ec2AuthzAccount+"/"+ec2AuthzRegion+"/"+instanceID, emulator.EC2Instance{
+		InstanceID: instanceID,
+		Tags:       ec2AuthzTags(map[string]string{"Env": "dev"}),
+	})
+
+	f.setPolicy(t, ec2AuthzConditionStatement("ec2:TerminateInstances",
+		ec2AuthzTagCondition("StringEquals", "aws:ResourceTag/Env", "dev")))
+	assert.NoError(t, f.call(t, "TerminateInstances", map[string]string{"InstanceId.1": instanceID}))
+
+	f.setPolicy(t, emulator.PolicyStatement{
+		Effect:   "Allow",
+		Action:   emulator.StringOrSlice{"ec2:TerminateInstances"},
+		Resource: emulator.StringOrSlice{instanceARN},
+	})
+	assert.NoError(t, f.call(t, "TerminateInstances", map[string]string{"InstanceId.1": instanceID}))
+}

--- a/emulator/iam_plugin.go
+++ b/emulator/iam_plugin.go
@@ -457,6 +457,9 @@ func (p *IAMPlugin) createRole(ctx *RequestContext, req *AWSRequest) (*AWSRespon
 			return iamErrorResponse("MalformedPolicyDocument", //nolint:nilerr
 				"AssumeRolePolicyDocument is not valid JSON.", http.StatusBadRequest), nil
 		}
+		if err := iamValidateConditionOperators(trustPolicy); err != nil {
+			return nil, err
+		}
 	}
 
 	if params.Path == "" {
@@ -564,6 +567,9 @@ func (p *IAMPlugin) updateAssumeRolePolicy(ctx *RequestContext, req *AWSRequest)
 	if err := json.Unmarshal([]byte(params.PolicyDocument), &trustPolicy); err != nil {
 		return iamErrorResponse("MalformedPolicyDocument", //nolint:nilerr
 			"PolicyDocument is not valid JSON.", http.StatusBadRequest), nil
+	}
+	if err := iamValidateConditionOperators(trustPolicy); err != nil {
+		return nil, err
 	}
 	role.AssumeRolePolicyDocument = trustPolicy
 
@@ -1220,6 +1226,9 @@ func (p *IAMPlugin) createPolicy(ctx *RequestContext, req *AWSRequest) (*AWSResp
 			return iamErrorResponse("MalformedPolicyDocument", //nolint:nilerr
 				"PolicyDocument is not valid JSON.", http.StatusBadRequest), nil
 		}
+		if err := iamValidateConditionOperators(doc); err != nil {
+			return nil, err
+		}
 	}
 
 	now := p.now().UTC()
@@ -1761,6 +1770,9 @@ func (p *IAMPlugin) putInlinePolicy(ctx *RequestContext, req *AWSRequest, entity
 	if err := json.Unmarshal([]byte(params.PolicyDocument), &doc); err != nil {
 		return iamErrorResponse("MalformedPolicyDocument", //nolint:nilerr
 			"PolicyDocument is not valid JSON.", http.StatusBadRequest), nil
+	}
+	if err := iamValidateConditionOperators(doc); err != nil {
+		return nil, err
 	}
 
 	docRaw, err := json.Marshal(doc)

--- a/emulator/iam_policy_operators.go
+++ b/emulator/iam_policy_operators.go
@@ -1,0 +1,106 @@
+package emulator
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+)
+
+// iamValidateConditionOperators reports the first condition operator in doc that AWS
+// would refuse when the document is submitted.
+//
+// Substrate accepted any operator name at write time, stored it, and discarded it at
+// evaluation — [conditionKeyMatches] documents that reading and why it is the only safe
+// one: a typo must not become a grant. But it leaves a caller with no way to learn about
+// the typo. AWS validates the name when the document is submitted and answers
+// MalformedPolicyDocument / 400 — "The request was rejected because the policy document
+// was malformed. The error message describes the specific error" — so a `"NotAnOperator"`
+// that real IAM rejects outright was stored here and then silently ignored, and a policy
+// that looked attached did nothing (#730).
+//
+// The operator vocabulary is not restated here. It is [condOperatorRecognized], which
+// asks [condEvaluate] itself, so an operator the evaluator learns is accepted at write
+// time in the same commit — the drift a second list would introduce is the drift #714 was
+// filed about, in the other direction.
+//
+// The two rules beyond "the name is recognized" are the two the evaluator applies:
+//
+//   - `NullIfExists` is refused. AWS: "You can add IfExists to the end of any condition
+//     operator name except the Null condition." Null already answers the question
+//     IfExists asks.
+//   - A set-qualified `Null` — `ForAllValues:Null`, `ForAnyValue:Null` — is refused. AWS
+//     defines neither, and quantifying an existence test over the values whose existence
+//     it tests has no meaning.
+//
+// A set qualifier over any *other* recognized operator is accepted, including the
+// combinations AWS's condition-operator page does not tabulate (it lists the String,
+// Bool and ARN forms). Its set-operator reference describes the qualifiers generally
+// rather than as an enumerated set, so refusing `ForAllValues:NumericLessThan` would be
+// substrate inventing a restriction; the evaluator already treats it as recognized.
+//
+// Returns nil for a document with no conditions, which is most of them.
+func iamValidateConditionOperators(doc PolicyDocument) error {
+	for _, stmt := range doc.Statement {
+		if len(stmt.Condition) == 0 {
+			continue
+		}
+		// Sorted, because a Go map's iteration order is random and the message names
+		// one operator: two submissions of the same bad document must be refused with
+		// the same sentence, or a recorded run does not replay to the same response.
+		operators := make([]string, 0, len(stmt.Condition))
+		for operator := range stmt.Condition {
+			operators = append(operators, operator)
+		}
+		sort.Strings(operators)
+
+		for _, operator := range operators {
+			if err := iamValidateConditionOperator(operator); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// iamValidateConditionOperator reports whether one Condition key is an operator name AWS
+// accepts, naming the operator in the refusal so the caller can find the typo.
+func iamValidateConditionOperator(operator string) error {
+	qualifier, qualified := splitConditionOperator(operator)
+	if qualifier != "" && qualifier != condForAllValues && qualifier != condForAnyValue {
+		return &AWSError{
+			Code: "MalformedPolicyDocument",
+			Message: fmt.Sprintf(
+				"Condition operator %q is not valid: %q is not a set operator. The only set operators are %s and %s.",
+				operator, qualifier, condForAllValues, condForAnyValue),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+
+	base, ifExists := condSplitIfExists(qualified)
+	if base == "Null" && ifExists {
+		return &AWSError{
+			Code: "MalformedPolicyDocument",
+			Message: fmt.Sprintf(
+				"Condition operator %q is not valid: %s may be added to any condition operator except Null.",
+				operator, condIfExistsSuffix),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	if base == "Null" && qualifier != "" {
+		return &AWSError{
+			Code: "MalformedPolicyDocument",
+			Message: fmt.Sprintf(
+				"Condition operator %q is not valid: Null cannot be qualified by %s.",
+				operator, qualifier),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	if !condOperatorRecognized(base) {
+		return &AWSError{
+			Code:       "MalformedPolicyDocument",
+			Message:    fmt.Sprintf("Condition operator %q is not valid.", operator),
+			HTTPStatus: http.StatusBadRequest,
+		}
+	}
+	return nil
+}

--- a/emulator/iam_policy_operators_test.go
+++ b/emulator/iam_policy_operators_test.go
@@ -1,0 +1,309 @@
+package emulator_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scttfrdmn/substrate/emulator"
+)
+
+// #730: a condition operator AWS does not recognize is refused when the document is
+// submitted, rather than stored and then silently discarded at evaluation.
+//
+// The evaluator's reading does not change and is not in tension with this. A stored
+// document carrying an unknown operator still matches nothing — conditionKeyMatches
+// documents why that is the only safe answer, and #714 is what happens when it is not.
+// What changes is that a caller now learns about the typo instead of watching an attached
+// policy do nothing.
+
+// iamOperatorDoc is a policy document whose single statement carries one condition
+// operator, which is the only part these tests vary.
+func iamOperatorDoc(operator string) string {
+	return `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject",` +
+		`"Resource":"*","Condition":{"` + operator + `":{"aws:username":"alice"}}}]}`
+}
+
+// iamOperatorSubmission is one of the four paths a caller submits a policy document
+// through. Each is here because each unmarshalled the document and checked only that it
+// was JSON.
+type iamOperatorSubmission struct {
+	name      string
+	operation string
+	setup     func(t *testing.T, srv *emulator.Server)
+	body      func(document string) map[string]any
+}
+
+// iamOperatorSubmissions returns the four submission paths, each already carrying the
+// entity it needs.
+//
+// PutUserPolicy stands for all three inline-policy operations: PutRolePolicy and
+// PutGroupPolicy reach the same putInlinePolicy, so covering one covers the shared
+// validator rather than the parameter decoding around it.
+func iamOperatorSubmissions() []iamOperatorSubmission {
+	return []iamOperatorSubmission{
+		{
+			name:      "CreateRole",
+			operation: "CreateRole",
+			body: func(document string) map[string]any {
+				return map[string]any{"RoleName": "r1", "AssumeRolePolicyDocument": document}
+			},
+		},
+		{
+			name:      "UpdateAssumeRolePolicy",
+			operation: "UpdateAssumeRolePolicy",
+			setup: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				require.Equal(t, http.StatusOK,
+					iamRequest(t, srv, "CreateRole", map[string]any{"RoleName": "r1"}).StatusCode)
+			},
+			body: func(document string) map[string]any {
+				return map[string]any{"RoleName": "r1", "PolicyDocument": document}
+			},
+		},
+		{
+			name:      "CreatePolicy",
+			operation: "CreatePolicy",
+			body: func(document string) map[string]any {
+				return map[string]any{"PolicyName": "p1", "PolicyDocument": document}
+			},
+		},
+		{
+			name:      "PutUserPolicy",
+			operation: "PutUserPolicy",
+			setup: func(t *testing.T, srv *emulator.Server) {
+				t.Helper()
+				require.Equal(t, http.StatusOK,
+					iamRequest(t, srv, "CreateUser", map[string]any{"UserName": "u1"}).StatusCode)
+			},
+			body: func(document string) map[string]any {
+				return map[string]any{
+					"UserName": "u1", "PolicyName": "inline", "PolicyDocument": document,
+				}
+			},
+		},
+	}
+}
+
+// TestIAM_ConditionOperator_UnknownIsRefusedOnEverySubmissionPath is the issue's own
+// reproduction, run through all four doors.
+//
+// AWS publishes MalformedPolicyDocument / 400 for every one of them — "The request was
+// rejected because the policy document was malformed. The error message describes the
+// specific error" — which is what licenses substrate naming the operator in the message.
+func TestIAM_ConditionOperator_UnknownIsRefusedOnEverySubmissionPath(t *testing.T) {
+	t.Parallel()
+
+	for _, sub := range iamOperatorSubmissions() {
+		t.Run(sub.name, func(t *testing.T) {
+			t.Parallel()
+			srv := newIAMTestServer(t)
+			if sub.setup != nil {
+				sub.setup(t, srv)
+			}
+
+			resp := iamRequest(t, srv, sub.operation, sub.body(iamOperatorDoc("NotAnOperator")))
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, "MalformedPolicyDocument", result["__type"])
+			assert.Contains(t, result["message"], "NotAnOperator",
+				"the caller has to be told which operator, or the message does not find the typo")
+		})
+	}
+}
+
+// TestIAM_ConditionOperator_RefusalStoresNothing pins that the refusal runs before the
+// write.
+//
+// A stored document the caller was told was malformed is worse than no validation: a later
+// GetUserPolicy would report a policy AWS never accepted, and the run would not replay
+// against real IAM.
+func TestIAM_ConditionOperator_RefusalStoresNothing(t *testing.T) {
+	t.Parallel()
+	srv := newIAMTestServer(t)
+	require.Equal(t, http.StatusOK,
+		iamRequest(t, srv, "CreateUser", map[string]any{"UserName": "u1"}).StatusCode)
+
+	require.Equal(t, http.StatusBadRequest, iamRequest(t, srv, "PutUserPolicy", map[string]any{
+		"UserName": "u1", "PolicyName": "inline",
+		"PolicyDocument": iamOperatorDoc("NotAnOperator"),
+	}).StatusCode)
+
+	resp := iamRequest(t, srv, "GetUserPolicy", map[string]any{
+		"UserName": "u1", "PolicyName": "inline",
+	})
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	var result map[string]any
+	decodeIAMXML(t, resp, &result)
+	assert.Equal(t, "NoSuchEntity", result["__type"])
+
+	// And a valid document through the same path is stored, so the refusal is about the
+	// operator and not about the path.
+	require.Equal(t, http.StatusOK, iamRequest(t, srv, "PutUserPolicy", map[string]any{
+		"UserName": "u1", "PolicyName": "inline",
+		"PolicyDocument": iamOperatorDoc("StringEquals"),
+	}).StatusCode)
+	assert.Equal(t, http.StatusOK, iamRequest(t, srv, "GetUserPolicy", map[string]any{
+		"UserName": "u1", "PolicyName": "inline",
+	}).StatusCode)
+}
+
+// TestIAM_ConditionOperator_AcceptedForms walks the vocabulary AWS documents, so a policy a
+// consumer copies out of the AWS documentation submits.
+//
+// The suffix and qualifier cases are the ones a hand-written name list gets wrong:
+// StringLikeIfExists and ForAnyValue:StringEquals are two operators AWS spells as one JSON
+// key each, and both have to survive being split apart and recognized.
+func TestIAM_ConditionOperator_AcceptedForms(t *testing.T) {
+	t.Parallel()
+
+	operators := []string{
+		"StringEquals", "StringNotEquals", "StringEqualsIgnoreCase",
+		"StringNotEqualsIgnoreCase", "StringLike", "StringNotLike",
+		"NumericEquals", "NumericNotEquals", "NumericLessThan", "NumericLessThanEquals",
+		"NumericGreaterThan", "NumericGreaterThanEquals",
+		"DateEquals", "DateNotEquals", "DateLessThan", "DateLessThanEquals",
+		"DateGreaterThan", "DateGreaterThanEquals",
+		"Bool", "BinaryEquals", "IpAddress", "NotIpAddress",
+		"ArnEquals", "ArnLike", "ArnNotEquals", "ArnNotLike",
+		"Null",
+		// AWS: "You can add IfExists to the end of any condition operator name except
+		// the Null condition — for example, StringLikeIfExists."
+		"StringLikeIfExists", "ArnEqualsIfExists", "NumericLessThanIfExists",
+		// The set operators, over the operators AWS's own multivalued tables list and
+		// one it does not: its set-operator reference describes the qualifiers
+		// generally, so refusing the untabulated combinations would be substrate
+		// inventing a restriction.
+		"ForAllValues:StringEquals", "ForAnyValue:StringLike",
+		"ForAllValues:ArnNotLike", "ForAnyValue:Bool",
+		"ForAllValues:NumericLessThan",
+		// A qualifier and a suffix on one operator, which is the shape that has to
+		// survive both splits.
+		"ForAnyValue:StringEqualsIfExists",
+	}
+
+	for _, operator := range operators {
+		t.Run(operator, func(t *testing.T) {
+			t.Parallel()
+			srv := newIAMTestServer(t)
+			resp := iamRequest(t, srv, "CreatePolicy", map[string]any{
+				"PolicyName": "p1", "PolicyDocument": iamOperatorDoc(operator),
+			})
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}
+
+// TestIAM_ConditionOperator_RefusedForms covers the names AWS defines rules against, each
+// with the rule that refuses it.
+func TestIAM_ConditionOperator_RefusedForms(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		operator string
+		// wantMessage is a fragment naming the rule, so a refusal for the wrong reason
+		// fails rather than passing on the status code alone.
+		wantMessage string
+	}{
+		// AWS: IfExists may be added to any operator "except the Null condition".
+		"NullIfExists": {"NullIfExists", "except Null"},
+		// AWS defines no set-qualified Null, and quantifying an existence test over the
+		// values whose existence it tests has no meaning.
+		"ForAllValues:Null": {"ForAllValues:Null", "cannot be qualified"},
+		"ForAnyValue:Null":  {"ForAnyValue:Null", "cannot be qualified"},
+		// A qualifier that is not one of the two AWS defines.
+		"unknown qualifier": {"ForSomeValues:StringEquals", "not a set operator"},
+		// A recognized qualifier over an unrecognized operator: the qualifier must not
+		// carry the operator past the check, which is the #714 shape at write time.
+		"qualified unknown operator": {"ForAllValues:NotAnOperator", "not valid"},
+		// Case matters: AWS's case-insensitivity covers condition key *names*, not
+		// operator names (#704), and iam_set_qualifiers_test.go pins the same reading at
+		// evaluation.
+		"wrong case":     {"stringequals", "not valid"},
+		"bare IfExists":  {"IfExists", "not valid"},
+		"empty operator": {"", "not valid"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			srv := newIAMTestServer(t)
+			resp := iamRequest(t, srv, "CreatePolicy", map[string]any{
+				"PolicyName": "p1", "PolicyDocument": iamOperatorDoc(tc.operator),
+			})
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+			var result map[string]any
+			decodeIAMXML(t, resp, &result)
+			assert.Equal(t, "MalformedPolicyDocument", result["__type"])
+			assert.Contains(t, result["message"], tc.wantMessage)
+		})
+	}
+}
+
+// TestIAM_ConditionOperator_RefusalIsDeterministic pins the sort.
+//
+// A statement's Condition is a map, so its iteration order is random, and the message names
+// one operator. Without the sort a document with two bad operators would be refused with
+// either message, so a recorded run would not replay to the same response — which is the
+// property the whole event log rests on.
+func TestIAM_ConditionOperator_RefusalIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	document := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject",` +
+		`"Resource":"*","Condition":{` +
+		`"ZzzOperator":{"aws:username":"alice"},` +
+		`"AaaOperator":{"aws:username":"alice"},` +
+		`"MmmOperator":{"aws:username":"alice"}}}]}`
+
+	// Twenty submissions, because one pass over a three-key map has a good chance of
+	// starting at the same key by luck.
+	for range 20 {
+		srv := newIAMTestServer(t)
+		resp := iamRequest(t, srv, "CreatePolicy", map[string]any{
+			"PolicyName": "p1", "PolicyDocument": document,
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		var result map[string]any
+		decodeIAMXML(t, resp, &result)
+		require.Contains(t, result["message"], "AaaOperator",
+			"the lexicographically first bad operator, every time")
+	}
+}
+
+// TestIAM_ConditionOperator_ValidationIsNotOnTheReadPath is the placement decision, pinned.
+//
+// PolicyDocument is unmarshalled on every read from state, so validating in
+// UnmarshalJSON would make an already-stored document unloadable — a store written by an
+// older substrate, or by a seed, would stop answering. Validation is on the submission
+// paths only, and this asserts the consequence: a document that reached state before the
+// rule existed still loads, evaluates, and matches nothing.
+func TestIAM_ConditionOperator_ValidationIsNotOnTheReadPath(t *testing.T) {
+	t.Parallel()
+
+	doc := emulator.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []emulator.PolicyStatement{{
+			Effect:   "Allow",
+			Action:   emulator.StringOrSlice{"s3:GetObject"},
+			Resource: emulator.StringOrSlice{"*"},
+			Condition: map[string]map[string]emulator.StringOrSlice{
+				"NotAnOperator": {"aws:username": {"alice"}},
+			},
+		}},
+	}
+
+	result := emulator.Evaluate([]emulator.PolicyDocument{doc}, emulator.EvaluationRequest{
+		Principal: "arn:aws:iam::123456789012:user/alice",
+		Action:    "s3:GetObject",
+		Resource:  "arn:aws:s3:::bucket/key",
+		Context:   map[string]string{"aws:username": "alice"},
+	})
+	assert.NotEqual(t, emulator.DecisionAllow, result.Decision,
+		"an operator substrate cannot evaluate must not grant, whatever the key says")
+}


### PR DESCRIPTION
Closes #730.

Three parts, one PR, because they are one issue and the docs change once.

## `ec2:ResourceTag/<key>`, and making it observable

Two of the bundled AWS-authored managed policies scope an EC2 delete by tag under **EC2's own
prefix** rather than the global one: `ManagedCloudformationResourcesCleanupPolicy`
(`ec2:DeleteInternetGateway`, `ec2:DeleteRoute`, `ec2:DeleteRouteTable`,
`ec2:DeleteSecurityGroup`, `StringLike` on `ec2:ResourceTag/aws:cloudformation:stack-name`) and
`AmazonEKSClusterPolicyENIDelete` (`ec2:DeleteNetworkInterface`, `StringEquals` on
`ec2:ResourceTag/eks:eni:owner`). Substrate published a resource's tags under
`aws:ResourceTag/` only, so neither condition could be satisfied. Both prefixes now report the
same tag, from the resource's one tag set, because a policy may write the condition either way
and AWS answers both. The prefix is **specific to EC2**: reporting an S3 bucket's tags under an
`s3:ResourceTag/` key AWS does not publish would honor a policy real AWS ignores — a divergence
in the granting direction.

The prefix alone would have been inert, which is the issue's one wrong prediction. Authorization
resolved an EC2 request to a real ARN, and to that resource's tags, **only when the request
named `InstanceId`** — every operation the two statements govern names something else, and was
decided against a bare `*` with no tags. `ec2AuthzNamedResource` is now the single resolver for
`InstanceId`, `GroupId`, `RouteTableId` and `InternetGatewayId`, shared by `buildResourceARN`
and `resourceTagsFor` so the tags a condition is evaluated against always belong to the ARN the
decision is made about. `NetworkInterfaceId` (substrate stores no standalone taggable ENI
record), `VpcId`/`SubnetId` (a container, not the resource acted on) and the plural forms
(#744) stay at `*`, each with its reason in the docs.

Safe in one direction only, which is why the fallback is `*`: `resourceMatches` uses the
statement's own `Resource` as the pattern, so a request resource of `*` matched only a statement
whose `Resource` began with `*`. Substituting a concrete ARN can narrow a grant, never widen it.

## Write-time operator-name validation

All four IAM submission paths — `CreateRole`, `UpdateAssumeRolePolicy`, `CreatePolicy`,
`putInlinePolicy` — checked JSON syntax and nothing else, so `{"NotAnOperator": {…}}` was
stored and then discarded at evaluation, leaving a policy that looked attached and granted
nothing. They now answer `MalformedPolicyDocument` / 400, naming the operator.

The vocabulary is **not restated**: recognition goes through `condOperatorRecognized`, which
asks `condEvaluate` itself, so an operator the evaluator learns is accepted at write time in the
same commit — the drift #714 was filed about, in the other direction. Two further rules mirror
the evaluator's: `NullIfExists` is refused (AWS: "You can add `IfExists` to the end of any
condition operator name except the `Null` condition"), and a set-qualified `Null` is refused.
A set qualifier over any *other* recognized operator is accepted, including combinations AWS's
condition-operator page does not tabulate — its set-operator reference describes the qualifiers
generally, so refusing `ForAllValues:NumericLessThan` would be substrate inventing a
restriction.

Refusals are ordered deterministically. A statement's `Condition` is a Go map and the message
names one operator, so without sorting two submissions of the same bad document would be refused
with different sentences and a recorded run would not replay to the same response. Pinned with
20 iterations.

**Placement, stated explicitly:** validation is on the submission paths only, never in
`PolicyDocument.UnmarshalJSON`, which also runs on every *read* from state — validating there
would make a pre-existing stored document unloadable. `iam_set_qualifiers_test.go`'s
`"forallvalues:StringEquals"` assertion stays at evaluation and stays green: AWS's
case-insensitivity covers key *names*, not operator names. Predicted blast radius across the
whole suite was 0 test failures; observed 0.

## Policy variables: a recorded non-implementation

Documented as a deliberate choice with the divergence that remains — `NotResource` and negated
operators, where AWS says an unresolved variable *does* match — and the ordering constraint
that `aws:username` needs an honest producer first, which cannot be the ARN's last component
(that yields the *session* name for an assumed role, where AWS documents `aws:username` as
absent).

## Verification

Full gate green: `gofmt`, `go build`, `go vet`, `golangci-lint` (0 issues), `make test` (race),
`make coverage` (emulator 83.3%, total 82.7%), `make docs-reference-check`, `make docs-versions`,
the docs build plus an `href="#…"` vs `id="…"` diff over `dist/services.html` (dangling: none),
and `go vet`/`go test` in `test/e2e`. Both new functions and the new file are at 100% statement
coverage.

**Mutation testing, 8 mutations, all red then reverted:** drop the `ec2:ResourceTag/` prefix;
give every service a `<service>:ResourceTag/` prefix; revert `buildResourceARN` to `"*"`;
revert `resourceTagsFor` to instances-only; drop the refusal sort; disable each of the three
operator rules.

**Live SDK run** against a built binary. `PutUserPolicy` with `{"NotAnOperator": …}` →
`MalformedPolicyDocument`, "Condition operator \"NotAnOperator\" is not valid.", and
`GetUserPolicy` then answers `NoSuchEntity` — nothing was stored. `CreateRole` with
`NullIfExists` and `CreatePolicy` with the same bad operator refuse through their own doors;
`ForSomeValues:StringEquals` refuses naming the qualifier; `ForAllValues:StringLikeIfExists` is
accepted and readable back. On the EC2 half, a user whose only grant is a `StringLike` on
`ec2:ResourceTag/Stack` deletes the matching security group and route table and is denied on the
non-matching ones, and the same shape under `aws:ResourceTag/Env` allows the `Env=prod` internet
gateway and denies the `Env=dev` one — both prefixes answering from one tag set.

## Found while verifying, filed not fixed

The bundled cleanup statement stays unsatisfiable for a **second** reason: nothing in substrate
produces the `aws:cloudformation:stack-name` tag it names. `CreateTags` refuses a caller-supplied
`aws:` key exactly as AWS does, and substrate's CloudFormation deployer does not tag the
resources a stack creates. Recorded in `docs/services.md` and filed as #746 rather than papered
over. Also filed from #730's survey: #747 (`CreateServiceLinkedRole` for `iam:AWSServiceName`)
and #748 (ELB tagging for `elasticloadbalancing:CreateAction`).